### PR TITLE
Add --skip-existing-zones flag to route_planes

### DIFF
--- a/docs/route-plane.md
+++ b/docs/route-plane.md
@@ -65,6 +65,7 @@ When specifying multiple nets, each net is paired with its corresponding plane l
 |--------|---------|-------------|
 | `--zone-clearance` | 0.2 | Zone clearance from other copper in mm |
 | `--min-thickness` | 0.1 | Minimum zone copper thickness in mm |
+| `--skip-existing-zones` | off | Keep an existing same-net zone on the target layer instead of replacing it (place stitching vias only), and tolerate other-net zones on the same layer (e.g. a GND island under an RF feed). When off (the CLI default), an existing same-net zone on the target layer is replaced |
 
 ### Algorithm Options
 

--- a/route_planes.py
+++ b/route_planes.py
@@ -2085,6 +2085,9 @@ Examples:
 
     # Debug options
     parser.add_argument("--dry-run", action="store_true", help="Analyze without writing output")
+    parser.add_argument("--skip-existing-zones", action="store_true",
+                        help="Keep an existing same-net zone (don't recreate) and only place stitching vias; "
+                             "tolerate other-net zones on the same layer (e.g. a GND island under an RF feed)")
     parser.add_argument("--verbose", "-v", action="store_true", help="Print detailed DEBUG messages")
     parser.add_argument("--debug-lines", action="store_true", help="Output MST routes on User.1, User.2, etc. per net")
     parser.add_argument("--add-teardrops", action="store_true", help="Add teardrop settings to all pads in output file")
@@ -2183,6 +2186,7 @@ Examples:
         power_nets_widths=args.power_nets_widths,
         add_teardrops=args.add_teardrops,
         same_net_pad_clearance=args.same_net_pad_clearance,
+        skip_existing_zones=args.skip_existing_zones,
     )
 
     # Add GND return vias if requested


### PR DESCRIPTION
## What

Expose the existing `skip_existing_zones` plane option on the `route_planes` command line. The parameter and its logic already exist in the function (`route_planes.py:1211,1289`); this only adds the argparse wiring so it's reachable from the CLI.

## Behavior

With `--skip-existing-zones`: keep an existing same-net zone (don't recreate it, place stitching vias only) and tolerate other-net zones on the same layer — e.g. a GND island under an RF feed.

## Changes

- **`route_planes.py`** — add the `--skip-existing-zones` argparse flag and thread `args.skip_existing_zones` into the plane-generation call. +4 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)