### PR TITLE
Add four Claude skills; update plan-pcb-routing to orchestrate them

### DIFF
--- a/.claude/skills/diagnose-routing-failures/SKILL.md
+++ b/.claude/skills/diagnose-routing-failures/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: diagnose-routing-failures
+description: Root-causes failed routes from a routing run's logs and the board file. Parses the JSON summary, failed-net histories, and blocking reports, correlates failures spatially with board regions and components, classifies the failure mode, and outputs a ready-to-run retry command. Use after route.py/route_diff.py runs report failed nets.
+---
+
+# Diagnose Routing Failures
+
+When this skill is invoked with a board file and routing log file(s), root-cause the failures and produce a targeted retry command. Routing runs should always be captured with `2>&1 | tee /tmp/<step>.txt` so the logs are available.
+
+## Step 1: Parse the Structured Outputs
+
+### JSON summary
+
+```bash
+grep "JSON_SUMMARY" /tmp/route_output.txt | sed 's/.*JSON_SUMMARY: //' | python3 -m json.tool
+```
+
+Key fields:
+- `failed_single`: failed single-ended net names
+- `failed_multipoint`: nets with unconnected pads, including pad coordinates
+- `multipoint_pads_connected` vs `multipoint_pads_total`: connection success rate
+
+### Failed net histories
+
+```bash
+grep -A 30 "FAILED NET HISTORIES" /tmp/route_output.txt
+```
+
+Each failed net's history records its route attempts, which nets ripped it up (`ripped_by`, with escalation level N), and reroute outcomes. A net that was ripped and never successfully rerouted points at the net that ripped it as much as at the failed net itself.
+
+### Blocking reports
+
+Look for blocking analysis lines:
+
+```bash
+grep -B2 -A8 -i "blocked by\|no rippable blockers\|Route stuck" /tmp/route_output.txt
+```
+
+These name the previously-routed nets occupying the failed route's frontier and where the search got stuck (position + layer).
+
+## Step 2: Correlate Failures Spatially
+
+Load the board and map failures to regions and components:
+
+```python
+from kicad_parser import parse_kicad_pcb
+pcb = parse_kicad_pcb('board.kicad_pcb')
+
+# For each failed net: where are its pads, and what is nearby?
+for net in pcb.nets.values():
+    if net.name in failed_names:
+        for pad in net.pads:
+            print(net.name, pad.component_ref, pad.global_x, pad.global_y, pad.layers)
+```
+
+Check whether failures cluster:
+- Near one component (especially a BGA/PGA — its auto-detected exclusion zone may be walling off paths)
+- In one board region (a congested corridor every failed net needs to cross)
+- On one layer (layer costs or direction preference starving that layer)
+
+Report the spatial pattern explicitly, e.g. "all 6 failures have an endpoint within 3mm of U9's southeast corner."
+
+## Step 3: Classify and Recommend
+
+Work through the failure modes most-targeted-first. Do not jump straight to global parameter increases — they are the last resort, not the first.
+
+| Evidence | Failure mode | Fix |
+|----------|--------------|-----|
+| "no rippable blockers found" near a BGA/PGA | Blocked by the BGA exclusion zone or pre-existing copper | `--no-bga-zone <ref>` for that component |
+| Stuck positions cluster in one corridor; blockers are routed nets that themselves had few alternatives | Corridor congestion | Suggest the user **draw a guide corridor**: a polyline on `User.1` through a less congested region, then re-route the failed nets with `--guide-corridor`. Describe in words where the corridor should go (e.g. "south of J3, between the mounting hole and C14"). **Do not draw the geometry yourself** — guide drawing is the user's decision |
+| Failed nets have source and target stubs on conflicting layers; rip-up histories show repeated mutual ripping | Same-layer crossing conflicts | `--mps-layer-swap`, or revisit `--layer-costs` |
+| "Re-route FAILED: no path found" for ripped nets | Retry budget exhausted | Increase `--max-iterations` (e.g. 1000000) |
+| Many multipoint pads failed on the same fine-pitch component | Grid too coarse for the pad geometry | `--grid-step 0.05`, and check `--track-width`/`--clearance` against the pad pitch |
+| Failures spread across the board, blockers vary | Genuine capacity problem | Escalate in order: `--max-ripup 10` → reduce `--clearance`/`--track-width` toward fab minimums → add routing layers |
+
+## Step 4: Output the Retry Command
+
+Produce one command that retries **only the failed nets** with the targeted fixes, and explain each parameter change in one line:
+
+```bash
+python -X utf8 route.py board_routed.kicad_pcb board_retry.kicad_pcb \
+    --nets "SDA" "Net-(U1-Pad8)" \
+    --no-bga-zone U9 \
+    --max-ripup 10 \
+    2>&1 | tee /tmp/route_retry.txt
+```
+
+Routing only the failed nets preserves the successful routes (already in the input file) and is much faster than a full re-run. After the retry, re-check with `check_connected.py`, and if nets still fail, repeat the diagnosis on the new log — the failure mode often changes after the first fix.

--- a/.claude/skills/identify-diff-pairs/SKILL.md
+++ b/.claude/skills/identify-diff-pairs/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: identify-diff-pairs
+description: Identifies differential pairs on a KiCad PCB by pin function via datasheet lookup, catching pairs whose net names don't follow P/N conventions. Recommends per-interface routing parameters (differential impedance, gap, intra-pair matching) and outputs ready-to-use route_diff.py commands.
+---
+
+# Identify Differential Pairs
+
+When this skill is invoked with a KiCad PCB file, find all differential pairs — including ones name-based detection misses — and recommend routing parameters per interface.
+
+## Step 1: Baseline Name-Based Detection
+
+```bash
+python3 list_nets.py path/to/file.kicad_pcb --diff-pairs
+```
+
+This catches pairs following P/N naming conventions. Record the result as the baseline.
+
+## Step 2: Datasheet-Based Detection by Pin Function
+
+For each IC likely to have differential interfaces (footprint/value keywords: FPGA, PHY, SERDES, USB, ETH, HDMI, LVDS, MIPI, SATA, PCIE, DDR, transceiver, redriver):
+
+1. Check pad metadata first — KiCad symbols often carry it:
+
+```python
+from kicad_parser import parse_kicad_pcb
+pcb = parse_kicad_pcb('path/to/file.kicad_pcb')
+fp = pcb.footprints['U3']
+for pad in fp.pads:
+    print(pad.pad_number, pad.pinfunction, pad.net_name)
+```
+
+Differential pin functions usually pair as `..._P`/`..._N`, `TX+`/`TX-`, `D+`/`D-`.
+
+2. Where `pinfunction` is missing or generic, **WebSearch the part's datasheet pinout** and map differential pin pairs to pad numbers, then to nets via the pads.
+
+3. **Trace through series passives**: if a differential pin connects to a 2-pad R/C/L, follow to the net on the component's other pad — the pair often gets its "real" net name on the far side of AC coupling caps or series resistors.
+
+A pair is **confirmed** when both nets trace back to a documented differential pin pair. Nets that look paired only by name or topology are **suspected** — list them separately for the user to confirm.
+
+## Step 3: Recommend Parameters per Interface
+
+| Interface | Differential impedance | Notes |
+|-----------|------------------------|-------|
+| USB 2.0 / 3.x | 90 Ω | Intra-pair matching matters from USB 2.0 HS up |
+| LVDS | 100 Ω | |
+| Ethernet (MDI) | 100 Ω | |
+| HDMI / TMDS | 100 Ω | |
+| PCIe | 85 Ω | AC coupling caps in-line on TX |
+| SATA | 90 Ω | |
+| MIPI D-PHY | 100 Ω | |
+| DDR (DQS, CK) | 100 Ω typical | Check the memory datasheet |
+| CAN | 120 Ω | Low speed; tolerances relaxed |
+
+From the impedance, derive the routing flags:
+
+- `--impedance <Z>` computes per-layer widths and gap from the stackup (preferred when the stackup is realistic — see `/recommend-stackup`), or set `--track-width`/`--diff-pair-gap` explicitly.
+- `--diff-pair-intra-match` for interfaces fast enough that P/N skew matters (USB HS+, PCIe, SATA, HDMI, LVDS at high rates).
+- Note which pairs allow polarity swapping at the receiver (PCIe, most SerDes are polarity-tolerant; USB is not) — relevant to whether `--no-fix-polarity` is safe to relax.
+
+## Step 4: Output
+
+1. **Confirmed pairs**, grouped by interface, each group with a ready-to-run command:
+
+```bash
+python -X utf8 route_diff.py board.kicad_pcb board_usb.kicad_pcb \
+    --nets "USB_DP" "USB_DM" \
+    --impedance 90 --diff-pair-intra-match \
+    2>&1 | tee /tmp/route_usb.txt
+```
+
+2. **Suspected pairs** with the evidence (matching pin functions but unverified part, name-only pairing), asking the user to confirm before routing them as pairs.
+
+3. A note of any pairs found by Step 1 but *not* corroborated by pin function — possible false positives of name matching (e.g. unrelated nets that happen to end in P/N).

--- a/.claude/skills/plan-pcb-routing/SKILL.md
+++ b/.claude/skills/plan-pcb-routing/SKILL.md
@@ -36,6 +36,14 @@ Report to user:
 - Available copper layers (F.Cu, B.Cu, In1.Cu, In2.Cu, etc.)
 - Whether it's a 2-layer, 4-layer, or multi-layer board
 
+### Stackup Sanity Check
+
+If the board has impedance-relevant signals (see the speed detection in Step 4) and you plan
+to recommend `--impedance` or `--time-matching`, check the stackup first: an untouched KiCad
+default stackup (no stackup section, or uniform dielectric thickness/ε_r) makes those
+calculations wrong for the user's fab. In that case recommend running `/recommend-stackup`
+before routing, and take plane-layer assignments from its output when available.
+
 ## Step 3: Check for Components Needing Fanout
 
 Identify BGA, QFN, QFP, PGA, and other array packages that benefit from escape routing:
@@ -128,6 +136,15 @@ If differential pairs are found:
 - List each P/N pair
 - Note that `route_diff.py` should be used for these
 - Explain that diff pairs maintain consistent spacing and length matching
+
+> **Tip:** Name-based detection misses pairs with unconventional names. For boards with
+> high-speed ICs (PHYs, SerDes, USB, FPGA transceivers), or when detection finds suspiciously
+> few pairs, run `/identify-diff-pairs` for datasheet-based detection by pin function and
+> per-interface gap/impedance recommendations.
+
+Also note: `route_diff.py` resolves P/N polarity mismatches automatically, which can swap
+target pad net assignments. Swaps are reported in the output — when they happen, the
+schematic sync step below applies (see "Schematic Synchronization After Swaps").
 
 ### Check for DDR/High-Speed Memory Signals
 
@@ -335,8 +352,9 @@ python -X utf8 route_disconnected_planes.py board_step4.kicad_pcb board_step5.ki
     2>&1 | tee /tmp/step5_plane_repair.txt
 
 ### Step 6: Verify Results
-Check for DRC violations, unrouted nets, and orphan stubs.
-Save outputs to /tmp for analysis if issues are found.
+Invoke `/review-routed-board board_step5.kicad_pcb` for the full review (DRC,
+connectivity, orphan stubs, length-match tolerances, GND return via coverage,
+diff pair checks). If that skill is unavailable, run the raw checks:
 
 python -X utf8 check_drc.py board_step5.kicad_pcb --clearance 0.25 2>&1 | tee /tmp/step6_drc.txt
 python -X utf8 check_connected.py board_step5.kicad_pcb 2>&1 | tee /tmp/step6_connectivity.txt
@@ -510,6 +528,49 @@ This updates the `.kicad_sch` files with any pad swaps made during routing.
 Schematic sync is **disabled by default** to avoid unexpected changes. Only enable
 when the user confirms they want schematic updates.
 
+### Guide Corridors (user-drawn preferred routes)
+
+When specific nets keep taking bad paths (or the user wants control over where a bundle
+runs), the user can draw a polyline on `User.1` in KiCad and re-route those nets with:
+
+```bash
+python3 route.py board.kicad_pcb --nets "SPI*" --guide-corridor --output board_routed.kicad_pcb
+```
+
+The route follows the line as waypoints, strictly best-effort — a guide never makes a route
+fail or adds vias. See `docs/configuration.md` "Guide Corridor Options" for details.
+
+**Scope rule: do NOT draw guide corridor geometry yourself.** Suggest *in words* where a
+corridor would help ("a line on User.1 south of J3, between the mounting hole and C14") and
+let the user draw it; then incorporate `--guide-corridor` into the plan.
+
+### Keepout Zones (RF / analog exclusions)
+
+Check the board for components that warrant routing exclusions: antennas (footprint/value
+keywords ANT, ANTENNA, chip antenna parts), RF modules, and sensitive analog front-ends. If
+found, recommend the user draw closed polygon(s) on `User.2` around those regions and add
+`--keepout` to every routing step (`route.py`, `route_diff.py`) so tracks and vias stay out
+on all copper layers. Same scope rule as guide corridors: describe where the keepout should
+go; the user draws it.
+
+### MPS Layer Swap (crossing conflicts)
+
+When MPS ordering reports crossing conflicts (nets in Round 2+), or failures show pairs of
+nets repeatedly ripping each other up, add `--mps-layer-swap` to attempt layer swaps that
+eliminate same-layer crossings before routing begins.
+
+### Vertical Track Alignment
+
+On 4+ layer boards where through-hole components need via space, `--vertical-attraction-radius`
+/ `--vertical-attraction-cost` attract tracks on different layers to stack vertically,
+consolidating routing corridors.
+
+### Plane Via Placement Options (route_planes.py)
+
+- Multiple nets can share one plane layer (Voronoi partitioning): `--nets GND VCC --plane-layers In2.Cu In2.Cu`
+- `--same-net-pad-clearance <mm>` forces plane vias outside same-net pads with that edge-to-edge clearance (default places at pad center when possible)
+- `--rip-blocker-nets` rips up interfering routed nets to maximize via placement, then re-routes them
+
 ### Net Ordering Strategies
 
 | Strategy | Flag | Best For |
@@ -602,6 +663,8 @@ python3 route.py board.kicad_pcb --nets "*" \
     - Reduces routing congestion (power pins don't consume escape channels)
     - Provides lower impedance power connections
 15. **Aggressive parameters for 2-layer BGA/PGA boards** - Use `--max-ripup 10 --max-iterations 1000000` from the start for boards with dense components. These parameters help resolve routing conflicts that would otherwise fail.
+16. **Guide corridors and keepouts are user-drawn** - Never draw `User.1` guide polylines or `User.2` keepout polygons yourself; suggest in words where they should go and let the user draw them, then add `--guide-corridor` / `--keepout` to the plan.
+17. **Companion skills** - Defer to `/identify-diff-pairs` (datasheet-based pair detection), `/recommend-stackup` (before impedance/time-matching work), `/diagnose-routing-failures` (after failures), and `/review-routed-board` (final verification) rather than duplicating their logic inline.
 
 ## Presenting the Plan
 
@@ -654,7 +717,10 @@ The JSON_SUMMARY line contains structured data including:
 
 After running routing commands:
 1. Report how many nets were routed successfully
-2. **If routes failed**, parse the logs to understand why, then retry with appropriate parameters:
+2. **If routes failed**, invoke `/diagnose-routing-failures <board> <log files>` — it parses
+   the JSON summary, failed-net histories, and blocking reports, correlates failures
+   spatially, and outputs a targeted retry command. Apply its recommendation. If that skill
+   is unavailable, fall back to this table:
 
 | Failure Pattern | Likely Cause | Solution |
 |-----------------|--------------|----------|
@@ -683,7 +749,7 @@ python -X utf8 route.py board_prev.kicad_pcb board_routed.kicad_pcb \
    - Ask if they want to sync the schematic
    - If yes, ask for the KiCad project directory path
    - Re-run the routing command with `--schematic-dir` added
-4. Run verification (DRC and connectivity checks)
+4. Run verification: invoke `/review-routed-board` (falls back to the raw DRC and connectivity checks)
 5. Summarize the final state of the board
 6. **Offer to clean up intermediate files**:
    - List the intermediate `.kicad_pcb` files created (e.g., `board_step1.kicad_pcb`, `board_step2.kicad_pcb`, etc.)

--- a/.claude/skills/recommend-stackup/SKILL.md
+++ b/.claude/skills/recommend-stackup/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: recommend-stackup
+description: Reviews a KiCad board's stackup and recommends a fab-realistic one. Flags untouched default stackups, validates that target impedances are achievable with manufacturable widths using the project's own IPC-2141 formulas, and outputs the routing arguments (--impedance, plane layers) that follow. Use before impedance-controlled routing or time matching.
+---
+
+# Recommend Stackup
+
+When this skill is invoked with a KiCad PCB file, review the stackup and recommend one suited to the board's impedance and plane requirements. The router's `--impedance` widths and `--time-matching` delays are computed *from the stackup* — a default stackup silently skews both.
+
+## Step 1: Read the Current Stackup
+
+```python
+from kicad_parser import parse_kicad_pcb
+pcb = parse_kicad_pcb('path/to/file.kicad_pcb')
+for layer in pcb.stackup:
+    print(layer.name, layer.thickness, layer.epsilon_r)
+```
+
+Judge whether it looks deliberate or default:
+- No stackup section at all, or all dielectric layers with identical thickness and ε_r ≈ 4.5, suggests KiCad's untouched default.
+- Real fab stackups have distinct core/prepreg thicknesses (e.g. JLCPCB 4-layer: ~0.21mm prepreg, ~1.0mm core).
+
+Report the verdict explicitly: "stackup appears to be KiCad's default — impedance calculations will not match your fab" vs. "stackup looks deliberate."
+
+## Step 2: Gather Requirements
+
+- **Layer count and roles**: copper layers from the board; which should be planes (GND/power) vs signal.
+- **Impedance targets**: from `/identify-diff-pairs` and `/find-high-speed-nets` results if available; otherwise infer from net names (USB 90Ω, LVDS/Ethernet/HDMI 100Ω, PCIe 85Ω, 50Ω single-ended for RF/clocks).
+- **The fab**: ask the user. If they name one (JLCPCB, PCBWay, OSH Park, Eurocircuits…), WebSearch its standard multilayer stackup and impedance-control offerings rather than inventing thicknesses.
+
+## Step 3: Recommend and Validate
+
+Propose: layer assignment (e.g. 4-layer: F.Cu signal / In1.Cu GND plane / In2.Cu power plane / B.Cu signal), dielectric thicknesses and ε_r per the fab's standard stackup, and copper weights.
+
+Validate with the project's own formulas so the recommendation matches what the router will compute:
+
+```python
+from impedance import calculate_width_for_impedance, calculate_impedance_for_layer
+
+# After (hypothetically) applying the proposed stackup values:
+w = calculate_width_for_impedance(pcb, 'F.Cu', target_z0=50.0)
+```
+
+Warn when a target is unachievable with manufacturable geometry (e.g. 50Ω microstrip needing a wider trace than the design's clearances allow, or a width below the fab's minimum) and propose the nearest workable option (thinner prepreg, different layer, relaxed target).
+
+## Step 4: Output
+
+1. The recommended stackup as a table (layer, type, thickness, ε_r) with the resulting trace widths per impedance target per layer.
+2. The routing arguments that follow:
+   ```
+   --layers F.Cu In1.Cu In2.Cu B.Cu
+   --impedance 50                      # route.py, single-ended
+   --impedance 100                     # route_diff.py, differential
+   route_planes.py --nets GND --plane-layers In1.Cu
+   ```
+3. Optionally, the KiCad `(stackup ...)` s-expression block for the user to apply via Board Setup → Physical Stackup. **Do not modify the board file directly** — stackup is a fab-facing decision the user must own.
+4. If the stackup was changed, remind the user to re-run any impedance-based routing, since previously computed widths are now stale.

--- a/.claude/skills/review-routed-board/SKILL.md
+++ b/.claude/skills/review-routed-board/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: review-routed-board
+description: Post-route QA on a KiCad board. Runs the DRC, connectivity, and orphan-stub checkers, verifies length/time-match groups landed within tolerance, checks GND return via coverage on high-speed nets, and reviews differential pairs. Produces a pass/fail sign-off report with concrete next actions. Works on boards routed by this tool, by hand, or by other tools.
+---
+
+# Review Routed Board
+
+When this skill is invoked with a board file, run a full post-route review and present a sign-off report.
+
+## Step 1: Mechanical Checks
+
+Run all three checkers, capturing output:
+
+```bash
+python -X utf8 check_drc.py board.kicad_pcb 2>&1 | tee /tmp/review_drc.txt
+python -X utf8 check_connected.py board.kicad_pcb 2>&1 | tee /tmp/review_connectivity.txt
+python -X utf8 check_orphan_stubs.py board.kicad_pcb 2>&1 | tee /tmp/review_orphans.txt
+```
+
+Pass `--clearance` to `check_drc.py` matching the value used for routing if known.
+
+**Important caveat to include in the report:** `check_drc.py` does not check zone copper, minimum trace width, or netclass compliance. If the board has copper zones/planes, recommend the authoritative check:
+
+```bash
+kicad-cli pcb drc board.kicad_pcb --refill-zones
+```
+
+## Step 2: Length/Time Match Verification
+
+If the board has length-matched groups (DDR byte lanes, matched buses — detect DQ/DQS patterns or ask the user for the groups and tolerance):
+
+```python
+from kicad_parser import parse_kicad_pcb
+from net_queries import calculate_route_length
+
+pcb = parse_kicad_pcb('board.kicad_pcb')
+for group_name, net_names in groups.items():
+    lengths = {}
+    for net in pcb.nets.values():
+        if net.name in net_names:
+            lengths[net.name] = calculate_route_length(pcb, net.net_id)
+    spread = max(lengths.values()) - min(lengths.values())
+    # PASS if spread <= tolerance (default 0.1 mm); report worst offender otherwise
+```
+
+For time-matched groups use `calculate_route_propagation_time_ps()` from `impedance.py` instead, and compare against the ps tolerance. Lengths include via barrels from the stackup, matching KiCad's measurement.
+
+Report per group: the spread, the tolerance, and the worst offender net.
+
+## Step 3: GND Return Via Coverage
+
+For high-speed nets (use `/find-high-speed-nets` results if available, else the name-pattern tiers from `/plan-pcb-routing`), check each signal via has a GND via nearby:
+
+```python
+gnd_ids = {n.net_id for n in pcb.nets.values() if n.name and 'GND' in n.name.upper()}
+gnd_vias = [v for v in pcb.vias if v.net_id in gnd_ids]
+# Through-hole GND pads also count as return paths
+for via in pcb.vias:
+    if via.net_id in high_speed_net_ids:
+        nearest = min(((v.x-via.x)**2 + (v.y-via.y)**2)**0.5 for v in gnd_vias)
+        # Flag if nearest > recommended distance for the net's speed tier
+        # (ultra-high: 2.0mm, high: 3.0mm, medium: 5.0mm)
+```
+
+## Step 4: Differential Pair Review
+
+For each differential pair (from `list_nets.py --diff-pairs`):
+
+- **Gap consistency**: sample parallel P/N segment pairs on the same layer and confirm the spacing matches the design gap.
+- **Intra-pair skew**: compare P and N lengths; flag pairs differing by more than ~0.5mm if intra-pair matching was expected.
+- **Polarity swaps**: if the routing logs (or the user) indicate pad swaps were applied, remind that the schematic may be out of sync and `--schematic-dir` can update it.
+
+## Step 5: The Sign-Off Report
+
+Present a compact report — one pass/fail line per category, details only for failures, ending with next actions:
+
+```
+## Board Review: board.kicad_pcb
+
+| Check | Result |
+|-------|--------|
+| DRC (check_drc.py)        | PASS (0 violations) |
+| Zone DRC (kicad-cli)      | NOT RUN - board has 2 zones, recommend running |
+| Connectivity              | FAIL - 2 nets with disconnected pads |
+| Orphan stubs              | PASS |
+| Length match (byte_lane_0)| PASS (spread 0.06mm, tol 0.1mm) |
+| GND return vias           | WARN - 3 high-tier signal vias lack GND via within 3mm |
+| Diff pairs                | PASS (4 pairs, gap consistent) |
+
+### Failures
+- SDA: pad (151.25, 109.06) on F.Cu [U1] disconnected ...
+
+### Next actions
+1. Run /diagnose-routing-failures with the routing logs for the 2 disconnected nets
+2. Re-run route_planes.py --add-gnd-vias for the 3 uncovered signal vias
+```
+
+When connectivity or routing failures are found, recommend `/diagnose-routing-failures` as the follow-up rather than diagnosing inline here.

--- a/README.md
+++ b/README.md
@@ -137,8 +137,12 @@ Claude will:
 
 Other useful skills:
 ```
-> /find-high-speed-nets kicad_files/my_board.kicad_pcb   # Identify high-speed nets via datasheet lookup
-> /analyze-power-nets kicad_files/my_board.kicad_pcb     # Identify power nets and track widths
+> /find-high-speed-nets kicad_files/my_board.kicad_pcb       # Identify high-speed nets via datasheet lookup
+> /analyze-power-nets kicad_files/my_board.kicad_pcb         # Identify power nets and track widths
+> /identify-diff-pairs kicad_files/my_board.kicad_pcb        # Find diff pairs by pin function, recommend gap/impedance
+> /recommend-stackup kicad_files/my_board.kicad_pcb          # Stackup advice for impedance/time-matching accuracy
+> /diagnose-routing-failures my_board.kicad_pcb /tmp/route_output.txt  # Root-cause failed routes, get a retry command
+> /review-routed-board my_board_routed.kicad_pcb             # Post-route QA: DRC, connectivity, length match, GND vias
 ```
 
 **Option C: Manual Command Line (For scripting and automation)**
@@ -590,7 +594,11 @@ KiCadRoutingTools/
 └── .claude/skills/           # Claude Code skills
     ├── analyze-power-nets/   # AI-powered power net analysis skill
     ├── find-high-speed-nets/ # AI-powered high-speed net identification skill
-    └── plan-pcb-routing/     # AI-powered routing plan generation skill
+    ├── plan-pcb-routing/     # AI-powered routing plan generation skill (orchestrates the others)
+    ├── identify-diff-pairs/  # Datasheet-based diff pair detection skill
+    ├── recommend-stackup/    # Stackup review/recommendation skill
+    ├── diagnose-routing-failures/  # Failure root-cause and retry skill
+    └── review-routed-board/  # Post-route QA and sign-off skill
 ```
 
 ## Module Overview


### PR DESCRIPTION
## Summary

Follow-up to #41 (this commit was pushed to the branch just after #41 merged, so it needs its own PR). Implements the four new Claude skills and brings `/plan-pcb-routing` up to date as their orchestrator.

### New skills

- **`/diagnose-routing-failures`** (`.claude/skills/diagnose-routing-failures/`) — parses the `JSON_SUMMARY`, `FAILED NET HISTORIES`, and blocking reports from routing logs, correlates failures spatially with board regions and components via `kicad_parser`, classifies the failure mode most-targeted-first, and outputs a ready-to-run retry command for just the failed nets.
- **`/review-routed-board`** (`.claude/skills/review-routed-board/`) — post-route QA: runs the DRC/connectivity/orphan-stub checkers (flagging `check_drc.py`'s zone-copper blind spot and recommending `kicad-cli pcb drc`), verifies length/time-match groups against tolerance, checks GND return via coverage by speed tier, reviews diff-pair gaps and polarity, and emits a pass/fail sign-off report.
- **`/identify-diff-pairs`** (`.claude/skills/identify-diff-pairs/`) — datasheet-based pair detection by pin function (catches unconventional names and pairs behind series passives), with per-interface impedance/gap recommendations and ready-to-use `route_diff.py` commands.
- **`/recommend-stackup`** (`.claude/skills/recommend-stackup/`) — flags untouched default stackups, recommends fab-realistic ones validated with the project's own `impedance.py` formulas, and outputs the routing arguments that follow; never modifies the board file.

### /plan-pcb-routing updates

- Defers to the new skills (failure diagnosis, verification, pair detection, stackup sanity check) instead of inlining their logic, following the existing `/find-high-speed-nets` cross-skill pattern.
- Covers previously missing router features: user-drawn guide corridors and keepout zones — with an explicit scope rule that the AI suggests placement **in words** but never draws the geometry itself — plus `--mps-layer-swap`, vertical track alignment, diff-pair polarity-swap reporting, and the plane via placement options (`--same-net-pad-clearance`, `--rip-blocker-nets`, multi-net Voronoi plane layers).

### README

The new skills are listed in Quick Start Option B and the project structure tree.

Closes #42
Closes #43
Closes #44
Closes #45
Closes #46

https://claude.ai/code/session_01Lu8Vp93mn44vX3pdicr4g8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lu8Vp93mn44vX3pdicr4g8)_