### PR TITLE
Reject multipoint diff-pair legs that cross earlier legs

### DIFF
--- a/diff_pair_multipoint.py
+++ b/diff_pair_multipoint.py
@@ -31,6 +31,47 @@ from polarity_swap import apply_polarity_swap, undo_polarity_swap
 from routing_context import build_diff_pair_obstacles
 
 
+def _segments_properly_cross(a, b, eps: float = 1e-6) -> bool:
+    """True if segments a and b cross at an interior point.
+
+    Shared endpoints and endpoint touches do NOT count: chain legs meet at
+    the same terminal pads, so they legitimately touch there - only a real
+    crossing (the loop-around failure mode of issue #56) is an error.
+    """
+    for (x, y) in ((a.start_x, a.start_y), (a.end_x, a.end_y)):
+        for (u, v) in ((b.start_x, b.start_y), (b.end_x, b.end_y)):
+            if abs(x - u) < eps and abs(y - v) < eps:
+                return False
+
+    def cross(px, py, qx, qy, rx, ry):
+        return (qx - px) * (ry - py) - (qy - py) * (rx - px)
+
+    d1 = cross(b.start_x, b.start_y, b.end_x, b.end_y, a.start_x, a.start_y)
+    d2 = cross(b.start_x, b.start_y, b.end_x, b.end_y, a.end_x, a.end_y)
+    d3 = cross(a.start_x, a.start_y, a.end_x, a.end_y, b.start_x, b.start_y)
+    d4 = cross(a.start_x, a.start_y, a.end_x, a.end_y, b.end_x, b.end_y)
+    return ((d1 > eps) != (d2 > eps)) and ((d3 > eps) != (d4 > eps)) and \
+        min(abs(d1), abs(d2), abs(d3), abs(d4)) > eps
+
+
+def _crosses_committed_legs(new_segments, committed_segments) -> bool:
+    """True if any new-leg segment properly crosses a previously committed
+    leg's segment on the same layer.
+
+    The obstacle map alone cannot prevent this: corridor exemptions at a
+    shared terminal deliberately unblock the previous leg's tracks there so
+    the opposite-side setback can leave, which also lets a wrap-around leg
+    cross them (issue #56 - shorts and self-crossing loops around a
+    termination resistor when an obstacle forces a detour).
+    """
+    for new_seg in new_segments:
+        for old_seg in committed_segments:
+            if new_seg.layer == old_seg.layer and \
+                    _segments_properly_cross(new_seg, old_seg):
+                return True
+    return False
+
+
 def _oriented(terminal: Tuple[Pad, Pad], pair: DiffPairNet) -> Tuple[Pad, Pad]:
     """Return the terminal as (current P pad, current N pad). A polarity pad
     swap flips the pads' net assignments, so the original ordering can be
@@ -260,6 +301,7 @@ def _route_chain_attempt(state, pair: DiffPairNet, pair_name: str,
 
     centers = [_terminal_center(t) for t in chain]
     leg_results = []
+    committed_segments = []  # all committed legs' segments, for crossing checks
     applied_swaps = []  # polarity pad swaps applied by this attempt's legs
     forced_dir_next = None  # forced source direction for the next leg (opposite
                             # side of the previous leg at the shared terminal)
@@ -334,6 +376,10 @@ def _route_chain_attempt(state, pair: DiffPairNet, pair_name: str,
         elif _pn_tracks_cross(result.get('new_segments', []), pair.p_net_id, pair.n_net_id):
             # Wrapping legs can fold back on themselves - never commit a crossing leg
             failed_reason = "crosses itself"
+        elif _crosses_committed_legs(result.get('new_segments', []), committed_segments):
+            # A wrap-around leg can cross an earlier leg's tracks inside the
+            # shared terminal's corridor exemption (issue #56)
+            failed_reason = "crosses an earlier leg"
         elif result.get('target_base_dir') is None:
             failed_reason = "missing target direction"
 
@@ -358,6 +404,7 @@ def _route_chain_attempt(state, pair: DiffPairNet, pair_name: str,
         # Commit this leg so the next leg sees it (as obstacle and topology)
         add_route_to_pcb_data(pcb_data, result, debug_lines=config.debug_lines)
         leg_results.append(result)
+        committed_segments.extend(result.get('new_segments', []))
 
         # Next leg must leave the shared terminal on the opposite side
         used_dir = result['target_base_dir']


### PR DESCRIPTION
Closes #56.

## Root cause

Multipoint diff pairs route as a chain of legs. Each leg validated only its **own** P/N crossing — crossings against **previously committed legs** relied on the obstacle map, which deliberately exempts corridor capsules at shared terminals (the opposite-side setback must be able to leave). When an obstacle (the GND stitching via at (97.7, 61.5) next to R3) blocked the natural channel, the forced wrap-around leg crossed the earlier legs' tracks inside that exemption — committing **real P/N shorts** plus same-net loops (7 DRC violations, +15mm on the CLK pair).

## Fix

`_crosses_committed_legs()": after each leg routes, check its segments for proper interior crossings (endpoint touches at shared terminal pads are legitimate and excluded) against all committed legs' segments. A crossing fails the leg with `crosses an earlier leg`, the attempt rips, and the existing alternative-chain-ordering retry takes over.

## Verification on `lvds_converter_dualclk_gnd.kicad_pcb`

- **Before**: 4 segment crossings (2 cross-net = shorts), 7 DRC violations, CLK ~45mm
- **After (fix-polarity on, the CLI default)**: routes first try, 0 crossings, CLK ~30mm, only the input board's pre-existing via-via violation remains
- **After (--no-fix-polarity, which is also the GUI's default - the GUI keeps pad swaps off so the schematic stays in sync)**: all 4 chain orderings rejected → the CLK pair **fails honestly** instead of shorting (with this obstacle, the only clean topology needs a pad swap). GUI users hitting this see the failure and can either remove the blocking via, or enable 'Fix polarity swaps' and sync the schematic
- Regressions: `tests/test_multipoint_diff_route.py` 5/5 (both polarity modes), `tests/test_diff_pair_route.py` 3/3

Pure-Python change (no Rust router rebuild needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
