### PR TITLE
Batch obstacle-map rasterization: 6.4x faster base map builds

### DIFF
--- a/obstacle_cache.py
+++ b/obstacle_cache.py
@@ -11,7 +11,8 @@ import numpy as np
 
 from kicad_parser import PCBData
 from routing_config import GridRouteConfig, GridCoord
-from routing_utils import build_layer_map, iter_pad_blocked_cells
+from routing_utils import build_layer_map, iter_pad_blocked_cells, \
+    pad_blocked_cells_array, square_offsets, circle_offsets
 from bresenham_utils import walk_line, is_diagonal_segment, get_diagonal_via_blocking_params
 from net_queries import expand_pad_layers
 
@@ -61,9 +62,10 @@ def precompute_net_obstacles(pcb_data: PCBData, net_id: int, config: GridRouteCo
     num_layers = len(config.layers)
     layer_map = build_layer_map(config.layers)
 
-    # Collect cells/vias into sets to deduplicate
-    blocked_cells_set: Set[Tuple[int, int, int]] = set()
-    blocked_vias_set: Set[Tuple[int, int]] = set()
+    # Collect cell arrays; deduplicated with np.unique at the end (same
+    # unique-cell semantics as the per-cell sets this replaces)
+    blocked_cells_set: List["np.ndarray"] = []
+    blocked_vias_set: List["np.ndarray"] = []
 
     # Precompute per-layer expansion values for impedance-controlled and power net routing
     # Use to_grid_dist_safe for via-related clearances to avoid grid quantization DRC errors
@@ -107,14 +109,15 @@ def precompute_net_obstacles(pcb_data: PCBData, net_id: int, config: GridRouteCo
         _collect_pad_obstacles(pad, coord, layer_map, config, extra_clearance,
                                 blocked_cells_set, blocked_vias_set)
 
-    # Convert sets to numpy arrays for memory efficiency
+    # Concatenate and deduplicate (the Rust map refcounts batch adds, so
+    # each cell must appear once per net - same as the old set semantics)
     if blocked_cells_set:
-        blocked_cells_arr = np.array(list(blocked_cells_set), dtype=np.int32)
+        blocked_cells_arr = np.unique(np.concatenate(blocked_cells_set), axis=0)
     else:
         blocked_cells_arr = np.empty((0, 3), dtype=np.int32)
 
     if blocked_vias_set:
-        blocked_vias_arr = np.array(list(blocked_vias_set), dtype=np.int32)
+        blocked_vias_arr = np.unique(np.concatenate(blocked_vias_set), axis=0)
     else:
         blocked_vias_arr = np.empty((0, 2), dtype=np.int32)
 
@@ -126,8 +129,8 @@ def precompute_net_obstacles(pcb_data: PCBData, net_id: int, config: GridRouteCo
 
 def _collect_segment_obstacles(seg, coord: GridCoord, layer_idx: int,
                                 expansion_grid: int, via_block_grid: int,
-                                blocked_cells: Set[Tuple[int, int, int]],
-                                blocked_vias: Set[Tuple[int, int]]):
+                                blocked_cells: List["np.ndarray"],
+                                blocked_vias: List["np.ndarray"]):
     """Collect segment obstacle cells into sets (no obstacle map modification)."""
     gx1, gy1 = coord.to_grid(seg.start_x, seg.start_y)
     gx2, gy2 = coord.to_grid(seg.end_x, seg.end_y)
@@ -135,59 +138,64 @@ def _collect_segment_obstacles(seg, coord: GridCoord, layer_idx: int,
     is_diagonal = is_diagonal_segment(gx1, gy1, gx2, gy2)
     effective_via_block_sq, via_block_range = get_diagonal_via_blocking_params(via_block_grid, is_diagonal)
 
-    for gx, gy in walk_line(gx1, gy1, gx2, gy2):
-        for ex in range(-expansion_grid, expansion_grid + 1):
-            for ey in range(-expansion_grid, expansion_grid + 1):
-                blocked_cells.add((gx + ex, gy + ey, layer_idx))
-        for ex in range(-via_block_range, via_block_range + 1):
-            for ey in range(-via_block_range, via_block_range + 1):
-                if ex*ex + ey*ey <= effective_via_block_sq:
-                    blocked_vias.add((gx + ex, gy + ey))
+    # Batched rasterization (issue #35): collect cell arrays; the caller
+    # deduplicates with np.unique, matching the old per-cell set semantics.
+    line = np.array(list(walk_line(gx1, gy1, gx2, gy2)), dtype=np.int32)
+
+    track_offs = square_offsets(expansion_grid)
+    cells = (line[:, None, :] + track_offs[None, :, :]).reshape(-1, 2)
+    rows = np.empty((len(cells), 3), dtype=np.int32)
+    rows[:, :2] = cells
+    rows[:, 2] = layer_idx
+    blocked_cells.append(rows)
+
+    via_offs = circle_offsets(via_block_range, effective_via_block_sq)
+    blocked_vias.append((line[:, None, :] + via_offs[None, :, :]).reshape(-1, 2))
 
 
 def _collect_via_obstacles(via, coord: GridCoord, num_layers: int,
                             via_track_expansion_grid, via_via_expansion_grid: int,
                             diagonal_margin: float,
-                            blocked_cells: Set[Tuple[int, int, int]],
-                            blocked_vias: Set[Tuple[int, int]]):
+                            blocked_cells: List["np.ndarray"],
+                            blocked_vias: List["np.ndarray"]):
     """Collect via obstacle cells into sets (no obstacle map modification).
 
     Args:
         via_track_expansion_grid: Either a single int or list of ints (per-layer) for impedance control
     """
     gx, gy = coord.to_grid(via.x, via.y)
+    center = np.array([gx, gy], dtype=np.int32)
+
+    def add_layer_cells(offs, layer_idx):
+        cells = center + offs
+        rows = np.empty((len(cells), 3), dtype=np.int32)
+        rows[:, :2] = cells
+        rows[:, 2] = layer_idx
+        blocked_cells.append(rows)
 
     # Support per-layer expansion for impedance-controlled routing
     if isinstance(via_track_expansion_grid, list):
-        # Per-layer blocking
         for layer_idx in range(num_layers):
             layer_expansion = via_track_expansion_grid[layer_idx]
             effective_track_block_sq = (layer_expansion + diagonal_margin) ** 2
             track_block_range = layer_expansion + 1
-            for ex in range(-track_block_range, track_block_range + 1):
-                for ey in range(-track_block_range, track_block_range + 1):
-                    if ex*ex + ey*ey <= effective_track_block_sq:
-                        blocked_cells.add((gx + ex, gy + ey, layer_idx))
+            add_layer_cells(circle_offsets(track_block_range, effective_track_block_sq), layer_idx)
     else:
-        # Single value for all layers (legacy behavior)
         effective_track_block_sq = (via_track_expansion_grid + diagonal_margin) ** 2
         track_block_range = via_track_expansion_grid + 1
-        for ex in range(-track_block_range, track_block_range + 1):
-            for ey in range(-track_block_range, track_block_range + 1):
-                if ex*ex + ey*ey <= effective_track_block_sq:
-                    for layer_idx in range(num_layers):
-                        blocked_cells.add((gx + ex, gy + ey, layer_idx))
+        offs = circle_offsets(track_block_range, effective_track_block_sq)
+        for layer_idx in range(num_layers):
+            add_layer_cells(offs, layer_idx)
 
-    for ex in range(-via_via_expansion_grid, via_via_expansion_grid + 1):
-        for ey in range(-via_via_expansion_grid, via_via_expansion_grid + 1):
-            if ex*ex + ey*ey <= via_via_expansion_grid * via_via_expansion_grid:
-                blocked_vias.add((gx + ex, gy + ey))
+    via_offs = circle_offsets(via_via_expansion_grid,
+                              via_via_expansion_grid * via_via_expansion_grid)
+    blocked_vias.append(center + via_offs)
 
 
 def _collect_pad_obstacles(pad, coord: GridCoord, layer_map: Dict[str, int],
                             config: GridRouteConfig, extra_clearance: float,
-                            blocked_cells: Set[Tuple[int, int, int]],
-                            blocked_vias: Set[Tuple[int, int]]):
+                            blocked_cells: List["np.ndarray"],
+                            blocked_vias: List["np.ndarray"]):
     """Collect pad obstacle cells into sets (no obstacle map modification).
 
     Uses rectangular-with-rounded-corners pattern matching other pad blocking functions.
@@ -206,19 +214,24 @@ def _collect_pad_obstacles(pad, coord: GridCoord, layer_map: Dict[str, int],
 
     expanded_layers = expand_pad_layers(pad.layers, config.layers)
 
-    # Use shared utility for consistent pad blocking
-    for cell_gx, cell_gy in iter_pad_blocked_cells(gx, gy, half_width, half_height, margin, config.grid_step, corner_radius):
-        for layer in expanded_layers:
-            layer_idx = layer_map.get(layer)
-            if layer_idx is not None:
-                blocked_cells.add((cell_gx, cell_gy, layer_idx))
+    # Batched rasterization (issue #35): same cell sets as the generator
+    # (pad_blocked_cells_array is bit-identical to iter_pad_blocked_cells)
+    cells = pad_blocked_cells_array(gx, gy, half_width, half_height, margin,
+                                    config.grid_step, corner_radius)
+    for layer in expanded_layers:
+        layer_idx = layer_map.get(layer)
+        if layer_idx is not None:
+            rows = np.empty((len(cells), 3), dtype=np.int32)
+            rows[:, :2] = cells
+            rows[:, 2] = layer_idx
+            blocked_cells.append(rows)
 
     # Via blocking around pads
     if any(layer.endswith('.Cu') for layer in expanded_layers):
         # Add half grid step buffer to account for grid quantization errors
         via_margin = config.via_size / 2 + config.clearance + config.grid_step / 2
-        for cell_gx, cell_gy in iter_pad_blocked_cells(gx, gy, half_width, half_height, via_margin, config.grid_step, corner_radius):
-            blocked_vias.add((cell_gx, cell_gy))
+        blocked_vias.append(pad_blocked_cells_array(gx, gy, half_width, half_height,
+                                                    via_margin, config.grid_step, corner_radius))
 
 
 def precompute_all_net_obstacles(pcb_data: PCBData, net_ids: List[int], config: GridRouteConfig,

--- a/obstacle_map.py
+++ b/obstacle_map.py
@@ -12,7 +12,8 @@ import math
 
 from kicad_parser import PCBData, Segment, Via, Pad
 from routing_config import GridRouteConfig, GridCoord
-from routing_utils import build_layer_map, iter_pad_blocked_cells, pad_blocked_cells_array
+from routing_utils import build_layer_map, iter_pad_blocked_cells, pad_blocked_cells_array, \
+    square_offsets, circle_offsets
 from bresenham_utils import walk_line, is_diagonal_segment, get_diagonal_via_blocking_params
 from net_queries import expand_pad_layers
 from obstacle_costs import add_bga_proximity_costs
@@ -1157,38 +1158,6 @@ def get_same_net_through_hole_positions(pcb_data: PCBData, net_id: int,
     return positions
 
 
-# Offset-pattern caches for batched rasterization. The patterns are tiny
-# (a few hundred cells) and reused for every segment/via on the board.
-_SQUARE_OFFSETS_CACHE: Dict[int, "np.ndarray"] = {}
-_CIRCLE_OFFSETS_CACHE: Dict[Tuple[int, float], "np.ndarray"] = {}
-
-
-def _square_offsets(expansion: int) -> "np.ndarray":
-    """(K, 2) int32 offsets covering the full square [-e, e] x [-e, e],
-    in the same (ex outer, ey inner) order as the legacy loops."""
-    offs = _SQUARE_OFFSETS_CACHE.get(expansion)
-    if offs is None:
-        r = np.arange(-expansion, expansion + 1, dtype=np.int32)
-        exg, eyg = np.meshgrid(r, r, indexing="ij")
-        offs = np.column_stack([exg.ravel(), eyg.ravel()]).astype(np.int32)
-        _SQUARE_OFFSETS_CACHE[expansion] = offs
-    return offs
-
-
-def _circle_offsets(block_range: int, effective_sq: float) -> "np.ndarray":
-    """(K, 2) int32 offsets with ex^2 + ey^2 <= effective_sq, matching the
-    legacy loops' integer-vs-float comparison and iteration order."""
-    key = (block_range, float(effective_sq))
-    offs = _CIRCLE_OFFSETS_CACHE.get(key)
-    if offs is None:
-        r = np.arange(-block_range, block_range + 1, dtype=np.int32)
-        exg, eyg = np.meshgrid(r, r, indexing="ij")
-        mask = (exg.astype(np.int64) ** 2 + eyg.astype(np.int64) ** 2) <= effective_sq
-        offs = np.column_stack([exg[mask], eyg[mask]]).astype(np.int32)
-        _CIRCLE_OFFSETS_CACHE[key] = offs
-    return offs
-
-
 def _batch_cells_one_layer(obstacles, cells_xy: "np.ndarray", layer_idx: int,
                            blocked_cells=None):
     """Block an (N, 2) array of cells on one layer via the batch API."""
@@ -1240,11 +1209,11 @@ def _add_segment_obstacle(obstacles: GridObstacleMap, seg, coord: GridCoord,
     # therefore later removals during rip-up) are unchanged.
     line = np.array(list(walk_line(gx1, gy1, gx2, gy2)), dtype=np.int32)
 
-    track_offs = _square_offsets(expansion_grid)
+    track_offs = square_offsets(expansion_grid)
     cells = (line[:, None, :] + track_offs[None, :, :]).reshape(-1, 2)
     _batch_cells_one_layer(obstacles, cells, layer_idx, blocked_cells)
 
-    via_offs = _circle_offsets(via_block_range, effective_via_block_sq)
+    via_offs = circle_offsets(via_block_range, effective_via_block_sq)
     vias = (line[:, None, :] + via_offs[None, :, :]).reshape(-1, 2)
     _batch_vias(obstacles, vias, blocked_vias)
 
@@ -1275,19 +1244,19 @@ def _add_via_obstacle(obstacles: GridObstacleMap, via, coord: GridCoord,
             layer_expansion = via_track_expansion_grid[layer_idx]
             effective_track_block_sq = (layer_expansion + diagonal_margin) ** 2
             track_block_range = layer_expansion + 1
-            offs = _circle_offsets(track_block_range, effective_track_block_sq)
+            offs = circle_offsets(track_block_range, effective_track_block_sq)
             _batch_cells_one_layer(obstacles, center + offs, layer_idx, blocked_cells)
     else:
         # Single value for all layers (legacy behavior)
         effective_track_block_sq = (via_track_expansion_grid + diagonal_margin) ** 2
         track_block_range = via_track_expansion_grid + 1
-        offs = _circle_offsets(track_block_range, effective_track_block_sq)
+        offs = circle_offsets(track_block_range, effective_track_block_sq)
         cells = center + offs
         for layer_idx in range(num_layers):
             _batch_cells_one_layer(obstacles, cells, layer_idx, blocked_cells)
 
     # Block cells for via placement
-    via_offs = _circle_offsets(via_via_expansion_grid,
+    via_offs = circle_offsets(via_via_expansion_grid,
                                via_via_expansion_grid * via_via_expansion_grid)
     _batch_vias(obstacles, center + via_offs, blocked_vias)
 

--- a/obstacle_map.py
+++ b/obstacle_map.py
@@ -12,7 +12,7 @@ import math
 
 from kicad_parser import PCBData, Segment, Via, Pad
 from routing_config import GridRouteConfig, GridCoord
-from routing_utils import build_layer_map, iter_pad_blocked_cells
+from routing_utils import build_layer_map, iter_pad_blocked_cells, pad_blocked_cells_array
 from bresenham_utils import walk_line, is_diagonal_segment, get_diagonal_via_blocking_params
 from net_queries import expand_pad_layers
 from obstacle_costs import add_bga_proximity_costs
@@ -1157,6 +1157,60 @@ def get_same_net_through_hole_positions(pcb_data: PCBData, net_id: int,
     return positions
 
 
+# Offset-pattern caches for batched rasterization. The patterns are tiny
+# (a few hundred cells) and reused for every segment/via on the board.
+_SQUARE_OFFSETS_CACHE: Dict[int, "np.ndarray"] = {}
+_CIRCLE_OFFSETS_CACHE: Dict[Tuple[int, float], "np.ndarray"] = {}
+
+
+def _square_offsets(expansion: int) -> "np.ndarray":
+    """(K, 2) int32 offsets covering the full square [-e, e] x [-e, e],
+    in the same (ex outer, ey inner) order as the legacy loops."""
+    offs = _SQUARE_OFFSETS_CACHE.get(expansion)
+    if offs is None:
+        r = np.arange(-expansion, expansion + 1, dtype=np.int32)
+        exg, eyg = np.meshgrid(r, r, indexing="ij")
+        offs = np.column_stack([exg.ravel(), eyg.ravel()]).astype(np.int32)
+        _SQUARE_OFFSETS_CACHE[expansion] = offs
+    return offs
+
+
+def _circle_offsets(block_range: int, effective_sq: float) -> "np.ndarray":
+    """(K, 2) int32 offsets with ex^2 + ey^2 <= effective_sq, matching the
+    legacy loops' integer-vs-float comparison and iteration order."""
+    key = (block_range, float(effective_sq))
+    offs = _CIRCLE_OFFSETS_CACHE.get(key)
+    if offs is None:
+        r = np.arange(-block_range, block_range + 1, dtype=np.int32)
+        exg, eyg = np.meshgrid(r, r, indexing="ij")
+        mask = (exg.astype(np.int64) ** 2 + eyg.astype(np.int64) ** 2) <= effective_sq
+        offs = np.column_stack([exg[mask], eyg[mask]]).astype(np.int32)
+        _CIRCLE_OFFSETS_CACHE[key] = offs
+    return offs
+
+
+def _batch_cells_one_layer(obstacles, cells_xy: "np.ndarray", layer_idx: int,
+                           blocked_cells=None):
+    """Block an (N, 2) array of cells on one layer via the batch API."""
+    if len(cells_xy) == 0:
+        return
+    rows = np.empty((len(cells_xy), 3), dtype=np.int32)
+    rows[:, :2] = cells_xy
+    rows[:, 2] = layer_idx
+    obstacles.add_blocked_cells_batch(np.ascontiguousarray(rows))
+    if blocked_cells is not None:
+        blocked_cells[layer_idx].update(map(tuple, cells_xy.tolist()))
+
+
+def _batch_vias(obstacles, vias_xy: "np.ndarray", blocked_vias=None):
+    """Block an (N, 2) array of via positions via the batch API."""
+    if len(vias_xy) == 0:
+        return
+    obstacles.add_blocked_vias_batch(np.ascontiguousarray(vias_xy.astype(np.int32)))
+    if blocked_vias is not None:
+        blocked_vias.update(map(tuple, vias_xy.tolist()))
+
+
 def _add_segment_obstacle(obstacles: GridObstacleMap, seg, coord: GridCoord,
                           layer_idx: int, expansion_grid: int, via_block_grid: int,
                           blocked_cells: List[Set[Tuple[int, int]]] = None,
@@ -1179,18 +1233,20 @@ def _add_segment_obstacle(obstacles: GridObstacleMap, seg, coord: GridCoord,
     is_diagonal = is_diagonal_segment(gx1, gy1, gx2, gy2)
     effective_via_block_sq, via_block_range = get_diagonal_via_blocking_params(via_block_grid, is_diagonal)
 
-    for gx, gy in walk_line(gx1, gy1, gx2, gy2):
-        for ex in range(-expansion_grid, expansion_grid + 1):
-            for ey in range(-expansion_grid, expansion_grid + 1):
-                obstacles.add_blocked_cell(gx + ex, gy + ey, layer_idx)
-                if blocked_cells is not None:
-                    blocked_cells[layer_idx].add((gx + ex, gy + ey))
-        for ex in range(-via_block_range, via_block_range + 1):
-            for ey in range(-via_block_range, via_block_range + 1):
-                if ex*ex + ey*ey <= effective_via_block_sq:
-                    obstacles.add_blocked_via(gx + ex, gy + ey)
-                    if blocked_vias is not None:
-                        blocked_vias.add((gx + ex, gy + ey))
+    # Batched rasterization (issue #35): every line step contributes its full
+    # offset pattern, so the emitted (cell, layer) MULTISET - including the
+    # duplicates where patterns of adjacent steps overlap - is identical to
+    # the per-cell loops this replaces. Reference counts in the Rust map (and
+    # therefore later removals during rip-up) are unchanged.
+    line = np.array(list(walk_line(gx1, gy1, gx2, gy2)), dtype=np.int32)
+
+    track_offs = _square_offsets(expansion_grid)
+    cells = (line[:, None, :] + track_offs[None, :, :]).reshape(-1, 2)
+    _batch_cells_one_layer(obstacles, cells, layer_idx, blocked_cells)
+
+    via_offs = _circle_offsets(via_block_range, effective_via_block_sq)
+    vias = (line[:, None, :] + via_offs[None, :, :]).reshape(-1, 2)
+    _batch_vias(obstacles, vias, blocked_vias)
 
 
 def _add_via_obstacle(obstacles: GridObstacleMap, via, coord: GridCoord,
@@ -1209,39 +1265,31 @@ def _add_via_obstacle(obstacles: GridObstacleMap, via, coord: GridCoord,
         blocked_vias: Optional set to collect blocked via positions for visualization
     """
     gx, gy = coord.to_grid(via.x, via.y)
+    center = np.array([gx, gy], dtype=np.int32)
 
-    # Support per-layer expansion for impedance-controlled routing
+    # Batched rasterization (issue #35) - emits the same cell multiset as the
+    # per-cell loops it replaces (each layer gets the full circle pattern).
     if isinstance(via_track_expansion_grid, list):
-        # Per-layer blocking
+        # Per-layer blocking (impedance-controlled routing)
         for layer_idx in range(num_layers):
             layer_expansion = via_track_expansion_grid[layer_idx]
             effective_track_block_sq = (layer_expansion + diagonal_margin) ** 2
             track_block_range = layer_expansion + 1
-            for ex in range(-track_block_range, track_block_range + 1):
-                for ey in range(-track_block_range, track_block_range + 1):
-                    if ex*ex + ey*ey <= effective_track_block_sq:
-                        obstacles.add_blocked_cell(gx + ex, gy + ey, layer_idx)
-                        if blocked_cells is not None:
-                            blocked_cells[layer_idx].add((gx + ex, gy + ey))
+            offs = _circle_offsets(track_block_range, effective_track_block_sq)
+            _batch_cells_one_layer(obstacles, center + offs, layer_idx, blocked_cells)
     else:
         # Single value for all layers (legacy behavior)
         effective_track_block_sq = (via_track_expansion_grid + diagonal_margin) ** 2
         track_block_range = via_track_expansion_grid + 1
-        for ex in range(-track_block_range, track_block_range + 1):
-            for ey in range(-track_block_range, track_block_range + 1):
-                if ex*ex + ey*ey <= effective_track_block_sq:
-                    for layer_idx in range(num_layers):
-                        obstacles.add_blocked_cell(gx + ex, gy + ey, layer_idx)
-                        if blocked_cells is not None:
-                            blocked_cells[layer_idx].add((gx + ex, gy + ey))
+        offs = _circle_offsets(track_block_range, effective_track_block_sq)
+        cells = center + offs
+        for layer_idx in range(num_layers):
+            _batch_cells_one_layer(obstacles, cells, layer_idx, blocked_cells)
 
     # Block cells for via placement
-    for ex in range(-via_via_expansion_grid, via_via_expansion_grid + 1):
-        for ey in range(-via_via_expansion_grid, via_via_expansion_grid + 1):
-            if ex*ex + ey*ey <= via_via_expansion_grid * via_via_expansion_grid:
-                obstacles.add_blocked_via(gx + ex, gy + ey)
-                if blocked_vias is not None:
-                    blocked_vias.add((gx + ex, gy + ey))
+    via_offs = _circle_offsets(via_via_expansion_grid,
+                               via_via_expansion_grid * via_via_expansion_grid)
+    _batch_vias(obstacles, center + via_offs, blocked_vias)
 
 
 def _add_pad_obstacle(obstacles: GridObstacleMap, pad, coord: GridCoord,
@@ -1293,28 +1341,30 @@ def _add_pad_obstacle(obstacles: GridObstacleMap, pad, coord: GridCoord,
     # passes by round pads cannot shave below the clearance
     corner_buffer = config.grid_step * 0.75 if extra_clearance > 0 else None
 
-    # Use shared utility for consistent pad blocking
-    for cell_gx, cell_gy in iter_pad_blocked_cells(gx, gy, half_width, half_height, margin,
-                                                   config.grid_step, corner_radius, corner_buffer):
-        if skip_cell is not None and skip_cell(cell_gx, cell_gy):
-            continue
-        for layer in expanded_layers:
-            layer_idx = layer_map.get(layer)
-            if layer_idx is not None:
-                obstacles.add_blocked_cell(cell_gx, cell_gy, layer_idx)
-                if blocked_cells is not None:
-                    blocked_cells[layer_idx].add((cell_gx, cell_gy))
+    # Batched rasterization (issue #35): pad_blocked_cells_array produces the
+    # exact cell set of iter_pad_blocked_cells (verified bit-identical). The
+    # rare skip_cell path (per-cell Python predicate, used for connector
+    # exemptions) filters the array with the same predicate.
+    layer_idxs = [layer_map[layer] for layer in expanded_layers if layer in layer_map]
+    cells = pad_blocked_cells_array(gx, gy, half_width, half_height, margin,
+                                    config.grid_step, corner_radius, corner_buffer)
+    if skip_cell is not None and len(cells):
+        keep = np.fromiter((not skip_cell(int(cx), int(cy)) for cx, cy in cells),
+                           dtype=bool, count=len(cells))
+        cells = cells[keep]
+    for layer_idx in layer_idxs:
+        _batch_cells_one_layer(obstacles, cells, layer_idx, blocked_cells)
 
     # Via blocking near pads - block vias if pad is on any copper layer
     if any(layer.endswith('.Cu') for layer in expanded_layers):
         via_margin = config.via_size / 2 + clearance + extra_clearance
-        for cell_gx, cell_gy in iter_pad_blocked_cells(gx, gy, half_width, half_height, via_margin,
-                                                       config.grid_step, corner_radius, corner_buffer):
-            if skip_cell is not None and skip_cell(cell_gx, cell_gy):
-                continue
-            obstacles.add_blocked_via(cell_gx, cell_gy)
-            if blocked_vias is not None:
-                blocked_vias.add((cell_gx, cell_gy))
+        via_cells = pad_blocked_cells_array(gx, gy, half_width, half_height, via_margin,
+                                            config.grid_step, corner_radius, corner_buffer)
+        if skip_cell is not None and len(via_cells):
+            keep = np.fromiter((not skip_cell(int(cx), int(cy)) for cx, cy in via_cells),
+                               dtype=bool, count=len(via_cells))
+            via_cells = via_cells[keep]
+        _batch_vias(obstacles, via_cells, blocked_vias)
 
 
 def add_routed_path_obstacles(obstacles: GridObstacleMap, path: List[Tuple[int, int, int]],

--- a/routing_utils.py
+++ b/routing_utils.py
@@ -208,3 +208,35 @@ def pad_blocked_cells_array(
     cells[:, 0] = (exg[mask] + pad_gx).astype(np.int32)
     cells[:, 1] = (eyg[mask] + pad_gy).astype(np.int32)
     return cells
+
+
+# Offset-pattern caches for batched rasterization. The patterns are tiny
+# (a few hundred cells) and reused for every segment/via on the board.
+_SQUARE_OFFSETS_CACHE: Dict[int, "np.ndarray"] = {}
+_CIRCLE_OFFSETS_CACHE: Dict[Tuple[int, float], "np.ndarray"] = {}
+
+
+def square_offsets(expansion: int) -> "np.ndarray":
+    """(K, 2) int32 offsets covering the full square [-e, e] x [-e, e],
+    in the same (ex outer, ey inner) order as the legacy loops."""
+    offs = _SQUARE_OFFSETS_CACHE.get(expansion)
+    if offs is None:
+        r = np.arange(-expansion, expansion + 1, dtype=np.int32)
+        exg, eyg = np.meshgrid(r, r, indexing="ij")
+        offs = np.column_stack([exg.ravel(), eyg.ravel()]).astype(np.int32)
+        _SQUARE_OFFSETS_CACHE[expansion] = offs
+    return offs
+
+
+def circle_offsets(block_range: int, effective_sq: float) -> "np.ndarray":
+    """(K, 2) int32 offsets with ex^2 + ey^2 <= effective_sq, matching the
+    legacy loops' integer-vs-float comparison and iteration order."""
+    key = (block_range, float(effective_sq))
+    offs = _CIRCLE_OFFSETS_CACHE.get(key)
+    if offs is None:
+        r = np.arange(-block_range, block_range + 1, dtype=np.int32)
+        exg, eyg = np.meshgrid(r, r, indexing="ij")
+        mask = (exg.astype(np.int64) ** 2 + eyg.astype(np.int64) ** 2) <= effective_sq
+        offs = np.column_stack([exg[mask], eyg[mask]]).astype(np.int32)
+        _CIRCLE_OFFSETS_CACHE[key] = offs
+    return offs

--- a/routing_utils.py
+++ b/routing_utils.py
@@ -11,6 +11,8 @@ The bulk of routing functionality has been split into:
 import math
 from typing import Dict, List, Tuple
 
+import numpy as np
+
 from kicad_parser import Segment, POSITION_DECIMALS
 
 
@@ -142,3 +144,67 @@ def iter_pad_blocked_cells(
             dist_sq = dist_sq_to_rounded_rect(cell_x, cell_y, half_width, half_height, corner_radius)
             if dist_sq < effective_margin_sq:
                 yield (pad_gx + ex, pad_gy + ey)
+
+
+def pad_blocked_cells_array(
+    pad_gx: int, pad_gy: int,
+    half_width: float, half_height: float,
+    margin: float,
+    grid_step: float,
+    corner_radius: float = 0.0,
+    corner_buffer: float = None,
+):
+    """Vectorized twin of iter_pad_blocked_cells: returns an (N, 2) int32
+    array of blocked (gx, gy) cells, in the same row-major (ex, ey) order
+    and with bit-identical float comparisons (same IEEE operations on the
+    same values), so the produced cell set matches the generator exactly.
+    """
+    if corner_buffer is None:
+        corner_buffer = grid_step / 2
+    expand_x = int(math.ceil((half_width + margin + corner_buffer) / grid_step))
+    expand_y = int(math.ceil((half_height + margin + corner_buffer) / grid_step))
+    margin_sq = margin * margin
+    buffered_margin_sq = (margin + corner_buffer) * (margin + corner_buffer)
+
+    corner_threshold = grid_step / 2 if corner_radius == 0 else 0
+    inner_half_w = half_width - corner_radius - corner_threshold
+    inner_half_h = half_height - corner_radius - corner_threshold
+
+    ex = np.arange(-expand_x, expand_x + 1, dtype=np.int64)
+    ey = np.arange(-expand_y, expand_y + 1, dtype=np.int64)
+    # Match the generator's loop order: ex outer, ey inner
+    exg, eyg = np.meshgrid(ex, ey, indexing="ij")
+    cell_x = exg.astype(np.float64) * grid_step
+    cell_y = eyg.astype(np.float64) * grid_step
+    abs_x = np.abs(cell_x)
+    abs_y = np.abs(cell_y)
+
+    in_corner = (abs_x > inner_half_w) & (abs_y > inner_half_h)
+    effective_margin_sq = np.where(in_corner, buffered_margin_sq, margin_sq)
+
+    # dist_sq_to_rounded_rect, vectorized with the same operations
+    if corner_radius > 0:
+        cr_inner_w = half_width - corner_radius
+        cr_inner_h = half_height - corner_radius
+        corner_region = (abs_x > cr_inner_w) & (abs_y > cr_inner_h)
+        dxc = abs_x - cr_inner_w
+        dyc = abs_y - cr_inner_h
+        dist = np.sqrt(dxc * dxc + dyc * dyc) - corner_radius
+        corner_dist_sq = np.where(dist > 0, dist * dist, 0.0)
+    else:
+        corner_region = np.zeros_like(abs_x, dtype=bool)
+        corner_dist_sq = np.zeros_like(abs_x)
+
+    closest_x = np.maximum(-half_width, np.minimum(cell_x, half_width))
+    closest_y = np.maximum(-half_height, np.minimum(cell_y, half_height))
+    dx = cell_x - closest_x
+    dy = cell_y - closest_y
+    rect_dist_sq = dx * dx + dy * dy
+
+    dist_sq = np.where(corner_region, corner_dist_sq, rect_dist_sq)
+    mask = dist_sq < effective_margin_sq
+
+    cells = np.empty((int(mask.sum()), 2), dtype=np.int32)
+    cells[:, 0] = (exg[mask] + pad_gx).astype(np.int32)
+    cells[:, 1] = (eyg[mask] + pad_gy).astype(np.int32)
+    return cells


### PR DESCRIPTION
Addresses issue #35 point 2 — with a finding that redirects it: profiling showed the base obstacle map cost is **not in Rust at all**. The hot functions ran triple-nested Python loops calling `add_blocked_cell()` once per cell — **13.1M Python→Rust FFI crossings** per build on a dense board. Rayon in `obstacle_map.rs` would have parallelized nothing.

## Changes (pure Python — no Rust rebuild or version bump)

- `routing_utils.pad_blocked_cells_array`: vectorized twin of `iter_pad_blocked_cells`, same IEEE operations — fuzz-tested **bit-identical (content and order)** over 3000 random pad geometries
- `_add_segment_obstacle` / `_add_via_obstacle` / `_add_pad_obstacle`: numpy batches into the existing `add_blocked_cells_batch` APIs, with cached square/circle offset patterns. Segments emit per-line-step pattern blocks so the emitted (cell, layer) **multiset — including overlap duplicates — is exactly what the loops emitted**; Rust refcounts and rip-up removals are unchanged. Vis collectors and the `skip_cell` exemption preserved.
- `obstacle_cache` collectors batched the same way (`np.unique` preserves the one-refcount-per-net set semantics); shared offset helpers moved to `routing_utils`.

## Equivalence (vs the legacy implementation loaded from main)

- Exact emission-multiset equality: 13.1M emissions on kit-out, plus lvds_gnd and 4-layer interf_u
- Identical Rust map `get_stats` and visualization-collector sets
- Per-net cache cell/via sets identical for all **451 nets** across two boards
- **Bit-identical full kit-board route**: 104/105 nets, 1,390,741 iterations, before and after
- Full test suite passes; every internal FAILED/'Command failed' line was verified **pre-existing on main** (identical counts in side-by-side worktree runs)

## Performance (kit-dev-coldfire, 5973-segment routed board)

| | before | after |
|---|---|---|
| Base obstacle map build | 1.72s | **0.27s (6.4×)** |
| Net obstacle cache (278 nets) | 0.49s | **0.34s (1.45×)** |

The remaining rayon candidates from #35 (parallel fwd/rev probes, rip-up candidate evaluation) touch actual Rust A* compute and stay open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)