### PR TITLE
Fix pcbnew crash when closing the dialog during a Claude run

### DIFF
--- a/kicad_routing_plugin/claude_gui.py
+++ b/kicad_routing_plugin/claude_gui.py
@@ -333,9 +333,13 @@ class ClaudeSkillDialog(wx.Dialog):
         self._runner.run(prompt, allowed_tools=allowed_tools, model=model, effort=effort)
 
     def _append(self, text):
+        if not self:  # dialog destroyed while the run streamed
+            return
         self.output_ctrl.AppendText(text)
 
     def _on_done(self, result_text, error):
+        if not self:
+            return
         self._done = True
         self._elapsed_timer.Stop()
         self.gauge.SetValue(0)
@@ -364,6 +368,8 @@ class ClaudeSkillDialog(wx.Dialog):
         self.EndModal(wx.ID_CANCEL)
 
     def _on_elapsed_tick(self, event):
+        if not self:
+            return
         self._elapsed_seconds += 1
         mins, secs = divmod(self._elapsed_seconds, 60)
         self.elapsed_label.SetLabel(f"{mins}m {secs:02d}s" if mins else f"{secs}s")
@@ -390,6 +396,24 @@ class ClaudeTab(wx.Panel):
             self._runner = ClaudeSkillRunner(
                 self._claude_path, self._append_transcript, self._on_done)
         self._create_ui()
+        # The runner streams via wx.CallAfter from a background thread; if the
+        # dialog is destroyed mid-run those callbacks would land on dead
+        # widgets (crashing pcbnew). Shut the run down with the window.
+        self.Bind(wx.EVT_WINDOW_DESTROY, self._on_destroy)
+
+    def _on_destroy(self, event):
+        if event.GetEventObject() is self:
+            self.shutdown()
+        event.Skip()
+
+    def shutdown(self):
+        """Stop background work before the dialog goes away: cancel the
+        claude subprocess, stop the plan executor and the elapsed timer."""
+        if self._runner is not None:
+            self._runner.cancel()
+        if self._plan_executor is not None:
+            self._plan_executor.stop()
+        self._elapsed_timer.Stop()
 
     def _create_ui(self):
         sizer = wx.BoxSizer(wx.VERTICAL)
@@ -676,9 +700,13 @@ class ClaudeTab(wx.Panel):
                         "(board analysis + datasheet lookups; typically several minutes)")
 
     def _append_transcript(self, text):
+        if not self:  # dialog destroyed while the run streamed
+            return
         self.output_ctrl.AppendText(text)
 
     def _on_done(self, result_text, error):
+        if not self:  # dialog destroyed while the run finished
+            return
         self._elapsed_timer.Stop()
         self.gauge.SetValue(0)
         self.plan_btn.Enable(self.routing_dialog is not None)
@@ -775,6 +803,8 @@ class ClaudeTab(wx.Panel):
             self._log("Claude plan: stop requested (after current step)")
 
     def _on_plan_step_status(self, index, status):
+        if not self:
+            return
         from .claude_plan import step_label
         mark = {"running": "> ", "done": "[ok] ", "failed": "[FAIL] "}[status]
         self.plan_list.SetString(index, mark + step_label(index + 1, self._plan_steps[index]))
@@ -783,6 +813,8 @@ class ClaudeTab(wx.Panel):
 
     def _on_plan_finished(self, completed, aborted_reason):
         self._plan_executor = None
+        if not self:  # dialog destroyed while a step was running
+            return
         self.stop_plan_btn.Disable()
         self.run_plan_btn.Enable(bool(self._plan_steps))
         self.plan_btn.Enable()
@@ -802,6 +834,8 @@ class ClaudeTab(wx.Panel):
         self._log("Claude: cancel requested")
 
     def _on_elapsed_tick(self, event):
+        if not self:
+            return
         self._elapsed_seconds += 1
         mins, secs = divmod(self._elapsed_seconds, 60)
         self.elapsed_label.SetLabel(f"{mins}m {secs:02d}s" if mins else f"{secs}s")


### PR DESCRIPTION
Closing the routing dialog while a Claude run was streaming (e.g. **Review Routed Board**) crashed pcbnew: `ClaudeSkillRunner` delivers transcript events from a background thread via `wx.CallAfter`, and after `Destroy()` those queued callbacks landed on dead C++ widgets. The `claude` subprocess also kept running as an orphan.

Fix, two layers:
- **`ClaudeTab.shutdown()`** bound to `EVT_WINDOW_DESTROY` (covers every close path — X button, Close button, EndModal): terminates the subprocess, stops a running plan executor, stops the elapsed timer.
- **Liveness guards** (`if not self: return` — wx proxies are falsy once the C++ object dies) on every main-thread callback in `ClaudeTab` and `ClaudeSkillDialog`, so callbacks already queued at destruction become no-ops.

Headless-tested with dead-proxy mocks whose widgets raise on any access — all callbacks no-op, shutdown cancels subprocess/executor/timer, alive instances unaffected.

To verify in pcbnew: start Review Routed Board, close the dialog mid-run, then quit pcbnew — previously crashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)