### PR TITLE
CI: move release workflow actions to Node 24 majors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
             extra_rustflags: ''
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -64,7 +64,7 @@ jobs:
           targets: ${{ matrix.cargo_target }}
 
       - name: Cache cargo registry and target
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -91,7 +91,7 @@ jobs:
         run: cp "${{ matrix.artifact_src }}" "${{ matrix.artifact_dst }}"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact_dst }}
           path: ${{ matrix.artifact_dst }}
@@ -105,10 +105,10 @@ jobs:
     # can produce a downloadable zip for inspection. metadata.json is only
     # committed/PR'd on tag pushes (see the release job below).
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download all built binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true
@@ -129,7 +129,7 @@ jobs:
         run: ls -la dist
 
       - name: Upload PCM zips + metadata
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pcm-package
           path: |
@@ -147,7 +147,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - name: Download all built binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true
@@ -156,7 +156,7 @@ jobs:
         run: ls -la artifacts
 
       - name: Create or update GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           # Attach: raw binaries, PCM zips, and the patched metadata.json
           # (so a maintainer can grab the exact metadata.json that matches


### PR DESCRIPTION
GitHub forces Node 24 for JavaScript actions on **June 16, 2026** (Node 20 removed from runners September 16). Bumps every Node-20 action to its Node-24 major (verified against each repo's releases): checkout v4→v6, cache v4→v5, upload-artifact v4→v7, download-artifact v4→v8, softprops/action-gh-release v2→v3. `dtolnay/rust-toolchain` is composite (no Node runtime).

Validated with a `workflow_dispatch` dry run on this branch: [all 4 platform builds + PCM packaging green](https://github.com/drandyhaas/KiCadRoutingTools/actions/runs/27311547200), zero deprecation warnings. The tag-gated `action-gh-release@v3` publish step exercises on the next release tag (inputs unchanged v2→v3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)