### PR TITLE
Don't print a Claude run's error twice in the transcript

### DIFF
--- a/kicad_routing_plugin/claude_gui.py
+++ b/kicad_routing_plugin/claude_gui.py
@@ -356,7 +356,12 @@ class ClaudeSkillDialog(wx.Dialog):
         self.gauge.SetValue(0)
         self.action_btn.SetLabel("Close")
         if error:
-            self.output_ctrl.AppendText(f"\n{error}{auth_error_hint(error)}\n")
+            if self.output_ctrl.GetValue().rstrip().endswith(error.strip()):
+                appended = auth_error_hint(error)
+            else:
+                appended = f"\n{error}{auth_error_hint(error)}"
+            if appended:
+                self.output_ctrl.AppendText(appended + "\n")
             return
         self.result_text = result_text
         self.result_value = extract_result_line(result_text)
@@ -728,7 +733,15 @@ class ClaudeTab(wx.Panel):
         kind, self._pending_kind = self._pending_kind, None
 
         if error:
-            self.output_ctrl.AppendText(f"\n{error}{auth_error_hint(error)}\n")
+            # The CLI often streams the failure text (e.g. 'Not logged in')
+            # as an assistant message before the error result repeats it -
+            # don't print the same line twice.
+            if self.output_ctrl.GetValue().rstrip().endswith(error.strip()):
+                appended = auth_error_hint(error)
+            else:
+                appended = f"\n{error}{auth_error_hint(error)}"
+            if appended:
+                self.output_ctrl.AppendText(appended + "\n")
             self._log(f"Claude: {error}")
             return
 


### PR DESCRIPTION
Field report: the unauthenticated-CLI failure showed 'Not logged in · Please run /login' twice — once streamed as an assistant message, once re-appended by the error path. When the transcript already ends with the error text, only the login hint is appended; unstreamed errors are unchanged. Four cases tested (streamed/unstreamed × auth/non-auth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)