### PR TITLE
Eliminate Python-side routing bottlenecks: bitmap dedupe + vectorized blocking analysis

### DIFF
--- a/blocking_analysis.py
+++ b/blocking_analysis.py
@@ -23,12 +23,30 @@ Usage:
 
 from typing import List, Tuple, Dict, Set, Optional
 from dataclasses import dataclass
-from collections import defaultdict
+
+import numpy as np
 
 from kicad_parser import PCBData, Segment, Via
 from routing_config import GridRouteConfig, GridCoord
-from routing_utils import build_layer_map
+from routing_utils import build_layer_map, square_offsets, circle_offsets
 from bresenham_utils import walk_line
+
+_PACK_OFFSET = 1 << 20  # grid coords stay well within +/-2^20 at any allowed grid step
+_COORD_MASK = (1 << 21) - 1
+
+
+def _pack_cells(gxy: "np.ndarray", layer) -> "np.ndarray":
+    """Pack (N,2) grid coords + layer (scalar or (N,) array) into int64 keys."""
+    key = ((gxy[:, 0].astype(np.int64) + _PACK_OFFSET) << 21) | \
+          (gxy[:, 1].astype(np.int64) + _PACK_OFFSET)
+    return (key << 8) | layer
+
+
+def _unpack_xy(keys: "np.ndarray") -> Tuple["np.ndarray", "np.ndarray"]:
+    """Recover (gx, gy) arrays from packed int64 cell keys."""
+    gx = (keys >> 29) - _PACK_OFFSET
+    gy = ((keys >> 8) & _COORD_MASK) - _PACK_OFFSET
+    return gx, gy
 
 
 def invalidate_obstacle_cache(cache: Dict, net_id: int) -> None:
@@ -62,11 +80,12 @@ def compute_net_obstacle_cells(
     path: Optional[List[Tuple[int, int, int]]],
     config: GridRouteConfig,
     extra_clearance: float = 0.0,
-) -> Tuple[Set[Tuple[int, int, int]], Set[Tuple[int, int, int]]]:
+) -> Tuple["np.ndarray", "np.ndarray"]:
     """
     Compute all obstacle cells for a net (tracks and vias).
 
-    Returns (track_cells, via_cells) where each cell is (gx, gy, layer).
+    Returns (track_keys, via_keys): sorted unique int64 arrays of packed
+    (gx, gy, layer) cell keys (see _pack_cells).
     """
     coord = GridCoord(config.grid_step)
     layer_map = build_layer_map(config.layers)
@@ -79,28 +98,28 @@ def compute_net_obstacle_cells(
     via_expansion_grid = max(1, coord.to_grid_dist(
         config.via_size / 2 + config.track_width / 2 + config.clearance + extra_clearance))
 
-    track_cells = set()
-    via_cells = set()
+    track_offs = square_offsets(expansion_grid)
+    via_offs = circle_offsets(via_expansion_grid, via_expansion_grid * via_expansion_grid)
+    all_layers = np.arange(num_layers, dtype=np.int64)
+
+    track_parts: List["np.ndarray"] = []
+    via_parts: List["np.ndarray"] = []
+    via_centers: List[Tuple[int, int]] = []
+
+    def add_track_line(gx1, gy1, gx2, gy2, layer_idx):
+        line = np.array(list(walk_line(gx1, gy1, gx2, gy2)), dtype=np.int32)
+        cells = (line[:, None, :] + track_offs[None, :, :]).reshape(-1, 2)
+        track_parts.append(_pack_cells(cells, layer_idx))
 
     # Add cells from routed path
     if path:
         for i in range(len(path) - 1):
             gx1, gy1, layer1 = path[i]
             gx2, gy2, layer2 = path[i + 1]
-
             if layer1 != layer2:
-                # Via - blocks all layers
-                for ex in range(-via_expansion_grid, via_expansion_grid + 1):
-                    for ey in range(-via_expansion_grid, via_expansion_grid + 1):
-                        if ex*ex + ey*ey <= via_expansion_grid * via_expansion_grid:
-                            for layer_idx in range(num_layers):
-                                via_cells.add((gx1 + ex, gy1 + ey, layer_idx))
+                via_centers.append((gx1, gy1))  # via blocks all layers
             else:
-                # Track segment
-                for gx, gy in walk_line(gx1, gy1, gx2, gy2):
-                    for ex in range(-expansion_grid, expansion_grid + 1):
-                        for ey in range(-expansion_grid, expansion_grid + 1):
-                            track_cells.add((gx + ex, gy + ey, layer1))
+                add_track_line(gx1, gy1, gx2, gy2, layer1)
 
     # Add cells from original stubs
     for seg in pcb_data.segments:
@@ -109,27 +128,25 @@ def compute_net_obstacle_cells(
         layer_idx = layer_map.get(seg.layer)
         if layer_idx is None:
             continue
-
         gx1, gy1 = coord.to_grid(seg.start_x, seg.start_y)
         gx2, gy2 = coord.to_grid(seg.end_x, seg.end_y)
+        add_track_line(gx1, gy1, gx2, gy2, layer_idx)
 
-        for gx, gy in walk_line(gx1, gy1, gx2, gy2):
-            for ex in range(-expansion_grid, expansion_grid + 1):
-                for ey in range(-expansion_grid, expansion_grid + 1):
-                    track_cells.add((gx + ex, gy + ey, layer_idx))
-
-    # Add cells from existing vias
+    # Add cells from existing vias (block all layers)
     for via in pcb_data.vias:
         if via.net_id != net_id:
             continue
-        gx, gy = coord.to_grid(via.x, via.y)
-        for ex in range(-via_expansion_grid, via_expansion_grid + 1):
-            for ey in range(-via_expansion_grid, via_expansion_grid + 1):
-                if ex*ex + ey*ey <= via_expansion_grid * via_expansion_grid:
-                    for layer_idx in range(num_layers):
-                        via_cells.add((gx + ex, gy + ey, layer_idx))
+        via_centers.append(coord.to_grid(via.x, via.y))
 
-    return track_cells, via_cells
+    if via_centers:
+        centers = np.array(via_centers, dtype=np.int32)
+        cells = (centers[:, None, :] + via_offs[None, :, :]).reshape(-1, 2)
+        layerless = _pack_cells(cells, 0)
+        via_parts.append((layerless[:, None] | all_layers[None, :]).ravel())
+
+    track_keys = np.unique(np.concatenate(track_parts)) if track_parts else np.empty(0, dtype=np.int64)
+    via_keys = np.unique(np.concatenate(via_parts)) if via_parts else np.empty(0, dtype=np.int64)
+    return track_keys, via_keys
 
 
 def analyze_frontier_blocking(
@@ -166,7 +183,8 @@ def analyze_frontier_blocking(
         return []
 
     exclude_net_ids = exclude_net_ids or set()
-    blocked_set = set(blocked_cells)
+    blocked_arr = np.asarray(list(blocked_cells), dtype=np.int64)
+    blocked_keys = np.unique(_pack_cells(blocked_arr[:, :2], blocked_arr[:, 2]))
 
     # Compute source/target grid coords and proximity threshold
     coord = GridCoord(config.grid_step)
@@ -179,9 +197,9 @@ def analyze_frontier_blocking(
     if source_xy is not None:
         source_gx, source_gy = coord.to_grid(source_xy[0], source_xy[1])
 
-    # First pass: compute obstacle cells for each net and track which nets block each cell
-    cell_to_blockers: Dict[Tuple[int, int, int], Set[int]] = defaultdict(set)
-    net_blocking_data = {}  # net_id -> (track_cells, via_cells, blocking_track, blocking_via, blocking_total)
+    # First pass: compute obstacle cells for each net and intersect with the
+    # blocked frontier (all arrays are sorted unique packed keys)
+    net_blocking_data = {}  # net_id -> (blocking_track, blocking_via, blocking_total)
 
     # Use provided cache or create local one
     local_cache = obstacle_cache if obstacle_cache is not None else {}
@@ -194,48 +212,49 @@ def analyze_frontier_blocking(
         # Cache key includes extra_clearance since it affects expansion radius
         cache_key = (net_id, extra_clearance)
         if cache_key in local_cache:
-            track_cells, via_cells = local_cache[cache_key]
+            track_keys, via_keys = local_cache[cache_key]
         else:
-            track_cells, via_cells = compute_net_obstacle_cells(
+            track_keys, via_keys = compute_net_obstacle_cells(
                 pcb_data, net_id, path, config, extra_clearance
             )
             # Store in cache for future calls
-            local_cache[cache_key] = (track_cells, via_cells)
-
-        all_cells = track_cells | via_cells
+            local_cache[cache_key] = (track_keys, via_keys)
 
         # Count how many blocked frontier cells this net is responsible for
-        blocking_track = blocked_set & track_cells
-        blocking_via = blocked_set & via_cells
-        blocking_total = blocked_set & all_cells
+        blocking_track = np.intersect1d(blocked_keys, track_keys, assume_unique=True)
+        blocking_via = np.intersect1d(blocked_keys, via_keys, assume_unique=True)
+        blocking_total = np.union1d(blocking_track, blocking_via)
 
         if len(blocking_total) > 0:
-            net_blocking_data[net_id] = (track_cells, via_cells, blocking_track, blocking_via, blocking_total)
-            # Track which nets block each cell
-            for cell in blocking_total:
-                cell_to_blockers[cell].add(net_id)
+            net_blocking_data[net_id] = (blocking_track, blocking_via, blocking_total)
+
+    # Cells blocked by exactly one net (each net contributes each cell once)
+    if net_blocking_data:
+        all_blocking = np.concatenate([d[2] for d in net_blocking_data.values()])
+        cells, counts = np.unique(all_blocking, return_counts=True)
+        solo_cells = cells[counts == 1]
+    else:
+        solo_cells = np.empty(0, dtype=np.int64)
 
     # Second pass: count unique blocking and near-source/target blocking
     results = []
-    for net_id, (track_cells, via_cells, blocking_track, blocking_via, blocking_total) in net_blocking_data.items():
+    for net_id, (blocking_track, blocking_via, blocking_total) in net_blocking_data.items():
         net = pcb_data.nets.get(net_id)
         net_name = net.name if net else f"Net {net_id}"
 
         # Count cells where this net is the ONLY blocker
-        unique_count = sum(1 for cell in blocking_total if len(cell_to_blockers[cell]) == 1)
+        unique_count = int(np.isin(blocking_total, solo_cells, assume_unique=True).sum())
 
         # Count cells near target and source
         near_target_count = 0
         near_source_count = 0
-        for gx, gy, _ in blocking_total:
-            if target_gx is not None:
-                dist_sq = (gx - target_gx) ** 2 + (gy - target_gy) ** 2
-                if dist_sq <= near_radius_grid ** 2:
-                    near_target_count += 1
-            if source_gx is not None:
-                dist_sq = (gx - source_gx) ** 2 + (gy - source_gy) ** 2
-                if dist_sq <= near_radius_grid ** 2:
-                    near_source_count += 1
+        gx, gy = _unpack_xy(blocking_total)
+        if target_gx is not None:
+            near_target_count = int(((gx - target_gx) ** 2 + (gy - target_gy) ** 2
+                                     <= near_radius_grid ** 2).sum())
+        if source_gx is not None:
+            near_source_count = int(((gx - source_gx) ** 2 + (gy - source_gy) ** 2
+                                     <= near_radius_grid ** 2).sum())
 
         details = f"{len(blocking_track)} track, {len(blocking_via)} via cells on frontier"
         results.append(BlockingInfo(

--- a/obstacle_cache.py
+++ b/obstacle_cache.py
@@ -27,6 +27,43 @@ except ImportError:
     GridObstacleMap = None
 
 
+_PACK_OFFSET = 1 << 20  # grid coords stay well within +/-2^20 at any allowed grid step
+
+# Bitmap dedupe allocates one bool per cell in the rows' bounding box; cap the
+# allocation (200M bools = 200MB) and fall back to sorting for outliers.
+_BITMAP_DEDUPE_MAX_CELLS = 200_000_000
+
+
+def _unique_rows(arr: np.ndarray) -> np.ndarray:
+    """Row-deduplicate an int32 (N,2) or (N,3) cell array.
+
+    Equivalent to np.unique(arr, axis=0) except for row order, which callers
+    must not rely on (these are unordered cell sets). np.unique(axis=0) sorts
+    rows as void records, which dominated routing time at fine grid steps;
+    marking cells in a bounding-box bitmap dedupes without sorting at all.
+    """
+    mins = arr.min(axis=0)
+    rel = arr - mins  # stays int32; ravel_multi_index widens internally
+    dims = (rel.max(axis=0) + 1).astype(np.int64)
+    total = int(np.prod(dims))
+    if total > _BITMAP_DEDUPE_MAX_CELLS:
+        # Sparse outlier (huge extent): pack rows into scalar int64 keys so
+        # np.unique sorts scalars instead of void records.
+        a = arr.astype(np.int64)
+        key = ((a[:, 0] + _PACK_OFFSET) << 21) | (a[:, 1] + _PACK_OFFSET)
+        if a.shape[1] == 3:
+            key = (key << 8) | a[:, 2]
+        _, idx = np.unique(key, return_index=True)
+        return arr[idx]
+    seen = np.zeros(total, dtype=bool)
+    seen[np.ravel_multi_index(rel.T, dims)] = True
+    uniq = np.flatnonzero(seen)
+    out = np.empty((len(uniq), arr.shape[1]), dtype=arr.dtype)
+    for i, col in enumerate(np.unravel_index(uniq, dims)):
+        out[:, i] = col + mins[i]
+    return out
+
+
 @dataclass
 class NetObstacleData:
     """Cached obstacle data for a single net.
@@ -112,12 +149,12 @@ def precompute_net_obstacles(pcb_data: PCBData, net_id: int, config: GridRouteCo
     # Concatenate and deduplicate (the Rust map refcounts batch adds, so
     # each cell must appear once per net - same as the old set semantics)
     if blocked_cells_set:
-        blocked_cells_arr = np.unique(np.concatenate(blocked_cells_set), axis=0)
+        blocked_cells_arr = _unique_rows(np.concatenate(blocked_cells_set))
     else:
         blocked_cells_arr = np.empty((0, 3), dtype=np.int32)
 
     if blocked_vias_set:
-        blocked_vias_arr = np.unique(np.concatenate(blocked_vias_set), axis=0)
+        blocked_vias_arr = _unique_rows(np.concatenate(blocked_vias_set))
     else:
         blocked_vias_arr = np.empty((0, 2), dtype=np.int32)
 


### PR DESCRIPTION
## Summary

Profiling for #36 showed Rust A* is a minority of routing wall time (~6% on uncongested boards, ~30% on congested ones); the dominant costs were two Python-side hotspots that scale with (1/grid_step)². This PR removes both:

1. **Bitmap dedupe in `obstacle_cache.py`** — `np.unique(axis=0)` sorts rows as void records and accounted for ~55% of wall time at the default 0.1mm grid (~70% at 0.05mm). `_unique_rows` now marks cells in a bounding-box bitmap (no sorting), with a packed-int64 scalar-sort fallback for outlier extents.
2. **Vectorized blocking analysis in `blocking_analysis.py`** — `compute_net_obstacle_cells` expanded every routed net's cells in nested Python loops (141M `set.add` calls on interf_u at 0.05mm). It now builds sorted unique packed-int64 cell keys from the existing vectorized offset tables, and `analyze_frontier_blocking` uses `np.intersect1d`/`np.unique`/boolean masks for frontier intersections, unique-blocker counts, and near-endpoint counts.

## Benchmarks

End-to-end `route.py` wall time (M-series Mac):

| Board / grid step | Before | After | Speedup |
|---|---|---|---|
| interf_u (116×108mm, 2 layers, 174 nets) @ 0.1mm | 19.0s | 6.0s | 3.2× |
| interf_u @ 0.05mm | 125s | 18.5s | 6.8× |
| kit coldfire (4 layers, 204 nets, rip-ups) @ 0.1mm | 47.9s | 25.4s | 1.9× |
| kit coldfire @ 0.05mm | 372s | 164s | 2.3× |

## Verification

- **Routing output is bit-identical** on all four benchmark configurations: same `total_iterations` (e.g. kit 0.1mm: 26,841,617), same via counts, same success/failure sets — including the kit board's full rip-up + blocking-analysis + phase-3 path.
- Isolated equivalence test of the new cell computation vs the legacy set-based loops on real kit-board nets: exact cell-set match (track + via, with and without routed paths).
- `tests/test_diff_pair_route.py` passes 3/3 after each commit.

No Rust changes; the Rust router and its version are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)