### PR TITLE
Make routing cost knobs mm-based, independent of grid step

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,7 +741,8 @@ python route.py kicad_files/input.kicad_pcb [output.kicad_pcb] [OPTIONS]
 
 # Algorithm
 --grid-step 0.1         # Grid resolution (mm)
---via-cost 50           # Via penalty (grid steps)
+--via-cost 50           # Via penalty in 0.1mm grid steps (50 = 5mm of path; all cost knobs
+                        # are mm-calibrated, so behavior is independent of --grid-step)
 --max-iterations 200000      # A* iteration limit
 --max-probe-iterations 5000  # Quick probe per direction to detect stuck routes
 --heuristic-weight 1.9       # A* greediness (>1 = faster)

--- a/diff_pair_routing.py
+++ b/diff_pair_routing.py
@@ -1433,12 +1433,12 @@ def _try_route_direction(src, tgt, pcb_data, config, obstacles, base_obstacles,
 
     # Calculate vertical attraction parameters
     attraction_radius_grid = coord.to_grid_dist(config.vertical_attraction_radius) if config.vertical_attraction_radius > 0 else 0
-    attraction_bonus = int(config.vertical_attraction_cost * 1000 / config.grid_step) if config.vertical_attraction_cost > 0 else 0
+    attraction_bonus = config.cell_cost(config.vertical_attraction_cost) if config.vertical_attraction_cost > 0 else 0
 
     # prox_h_cost is now passed as a parameter (checked before endpoint exemptions are set)
 
     pose_router = PoseRouter(
-        via_cost=config.via_cost * 1000 * 2,
+        via_cost=config.via_cost_units() * 2,
         h_weight=config.heuristic_weight,
         turn_cost=turn_cost,
         min_radius_grid=min_radius_grid,

--- a/obstacle_costs.py
+++ b/obstacle_costs.py
@@ -68,7 +68,7 @@ def add_stub_proximity_costs(obstacles: GridObstacleMap, unrouted_stubs: List[Tu
 
     coord = GridCoord(config.grid_step)
     stub_radius_grid = coord.to_grid_dist(config.stub_proximity_radius)
-    stub_cost_grid = int(config.stub_proximity_cost * 1000 / config.grid_step)
+    stub_cost_grid = config.cell_cost(config.stub_proximity_cost)
     block_vias = (config.via_proximity_cost == 0)
 
     # Convert stub positions to grid coordinates
@@ -95,7 +95,7 @@ def add_bga_proximity_costs(obstacles: GridObstacleMap, config: GridRouteConfig)
 
     coord = GridCoord(config.grid_step)
     radius_grid = coord.to_grid_dist(config.bga_proximity_radius)
-    cost_grid = int(config.bga_proximity_cost * 1000 / config.grid_step)
+    cost_grid = config.cell_cost(config.bga_proximity_cost)
 
     for zone in config.bga_exclusion_zones:
         min_x, min_y, max_x, max_y = zone[:4]
@@ -145,7 +145,7 @@ def compute_track_proximity_for_net(pcb_data: PCBData, net_id: int, config: Grid
 
     coord = GridCoord(config.grid_step)
     radius_grid = coord.to_grid_dist(config.track_proximity_distance)
-    cost_grid = int(config.track_proximity_cost * 1000 / config.grid_step)
+    cost_grid = config.cell_cost(config.track_proximity_cost)
 
     # Get pre-computed offset table (cached)
     offsets = _get_proximity_offsets(radius_grid, cost_grid)
@@ -341,7 +341,7 @@ def compute_ripped_route_costs(saved_result: dict, config: GridRouteConfig,
 
     coord = GridCoord(config.grid_step)
     radius_grid = coord.to_grid_dist(config.ripped_route_avoidance_radius)
-    cost_grid = int(config.ripped_route_avoidance_cost * 1000 / config.grid_step)
+    cost_grid = config.cell_cost(config.ripped_route_avoidance_cost)
 
     # Get pre-computed offset table (cached)
     offsets = _get_proximity_offsets(radius_grid, cost_grid)

--- a/plane_region_connector.py
+++ b/plane_region_connector.py
@@ -919,7 +919,7 @@ def route_disconnected_regions(
 
     # Create a single reusable router for all MST edges
     plane_router = GridRouter(
-        via_cost=config.via_cost * 1000,
+        via_cost=config.via_cost_units(),
         h_weight=config.heuristic_weight,
         turn_cost=config.turn_cost,
         via_proximity_cost=0,
@@ -1106,7 +1106,7 @@ def build_base_obstacles(
 
     # Add proximity costs around other nets' vias (on all layers)
     proximity_radius_grid = coord.to_grid_dist(proximity_radius)
-    proximity_cost_grid = int(proximity_cost * 1000 / config.grid_step)
+    proximity_cost_grid = config.cell_cost(proximity_cost)
 
     all_other_vias = []
     for via in pcb_data.vias:
@@ -1356,7 +1356,7 @@ def route_plane_connection_wide(
     # Create router if not provided
     if router is None:
         router = GridRouter(
-            via_cost=config.via_cost * 1000,
+            via_cost=config.via_cost_units(),
             h_weight=config.heuristic_weight,
             turn_cost=config.turn_cost,
             via_proximity_cost=0,

--- a/route.py
+++ b/route.py
@@ -190,7 +190,7 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
         via_size: Via outer diameter in mm (default: 0.3)
         via_drill: Via drill size in mm (default: 0.2)
         grid_step: Grid resolution in mm (default: 0.1)
-        via_cost: Penalty for placing a via in grid steps (default: 50)
+        via_cost: Penalty for placing a via in 0.1mm grid steps (default: 50 = 5mm; mm-equivalent at any grid_step)
         max_iterations: Max A* iterations before giving up (default: 200000)
         heuristic_weight: A* heuristic weight, higher=faster but less optimal (default: 1.9)
         stub_proximity_radius: Radius around stubs to penalize in mm (default: 2.0)
@@ -885,7 +885,7 @@ For differential pair routing, use route_diff.py:
     parser.add_argument("--grid-step", type=float, default=defaults.GRID_STEP,
                         help=f"Grid resolution in mm (default: {defaults.GRID_STEP})")
     parser.add_argument("--via-cost", type=int, default=defaults.VIA_COST,
-                        help=f"Penalty for placing a via in grid steps (default: {defaults.VIA_COST})")
+                        help=f"Penalty for placing a via, in 0.1mm grid steps (default: {defaults.VIA_COST} = 5mm of path; mm-equivalent at any --grid-step)")
     parser.add_argument("--via-proximity-cost", type=int, default=defaults.VIA_PROXIMITY_COST,
                         help=f"Via cost multiplier in stub/BGA proximity zones (default: {defaults.VIA_PROXIMITY_COST}, 0=block vias)")
     parser.add_argument("--max-iterations", type=int, default=defaults.MAX_ITERATIONS,

--- a/route_diff.py
+++ b/route_diff.py
@@ -840,7 +840,7 @@ Examples:
     parser.add_argument("--grid-step", type=float, default=0.1,
                         help="Grid resolution in mm (default: 0.1)")
     parser.add_argument("--via-cost", type=int, default=50,
-                        help="Penalty for placing a via in grid steps (default: 50, doubled for diff pairs)")
+                        help="Penalty for placing a via, in 0.1mm grid steps (default: 50 = 5mm of path, doubled for diff pairs; mm-equivalent at any --grid-step)")
     parser.add_argument("--via-proximity-cost", type=int, default=10,
                         help="Via cost multiplier in stub/BGA proximity zones (default: 10, 0=block vias)")
     parser.add_argument("--max-iterations", type=int, default=200000,

--- a/route_planes.py
+++ b/route_planes.py
@@ -419,7 +419,7 @@ def route_via_to_pad(
     # Create or reuse router
     if router is None:
         router = GridRouter(
-            via_cost=config.via_cost * 1000,
+            via_cost=config.via_cost_units(),
             h_weight=config.heuristic_weight,
             turn_cost=config.turn_cost,
             via_proximity_cost=0,
@@ -605,7 +605,7 @@ def build_plane_base_obstacles(
 
     # Add proximity costs around other nets' vias
     proximity_radius_grid = coord.to_grid_dist(proximity_radius)
-    proximity_cost_grid = int(proximity_cost * 1000 / config.grid_step)
+    proximity_cost_grid = config.cell_cost(proximity_cost)
 
     all_other_vias_grid = []
     for via_positions in other_nets_vias.values():
@@ -712,7 +712,7 @@ def route_plane_connection(
     # Create or reuse router
     if router is None:
         router = GridRouter(
-            via_cost=config.via_cost * 1000,
+            via_cost=config.via_cost_units(),
             h_weight=config.heuristic_weight,
             turn_cost=config.turn_cost,
             via_proximity_cost=0,
@@ -896,7 +896,7 @@ def _generate_multinet_layer_zones(
 
         # Create router once per MST iteration (reused across all nets/edges)
         plane_router = GridRouter(
-            via_cost=config.via_cost * 1000,
+            via_cost=config.via_cost_units(),
             h_weight=config.heuristic_weight,
             turn_cost=config.turn_cost,
             via_proximity_cost=0,
@@ -1371,7 +1371,7 @@ def create_plane(
 
     # Create reusable router for via-to-pad routing
     via_pad_router = GridRouter(
-        via_cost=config.via_cost * 1000,
+        via_cost=config.via_cost_units(),
         h_weight=config.heuristic_weight,
         turn_cost=config.turn_cost,
         via_proximity_cost=0,

--- a/routing_config.py
+++ b/routing_config.py
@@ -6,6 +6,12 @@ import math
 from typing import List, Optional, Tuple, Dict
 from dataclasses import dataclass, field
 
+# Cost knobs (proximity costs, via_cost, attraction bonuses) are calibrated at
+# this grid step: GridRouteConfig.cell_cost / via_cost_units scale them so the
+# cost per mm of path is the same at any --grid-step, and identical to
+# historical behavior at 0.1mm.
+REFERENCE_GRID_STEP = 0.1  # mm
+
 
 @dataclass
 class DiffPairNet:
@@ -182,6 +188,31 @@ class GridRouteConfig:
             prefs.append(i % 2)
         return prefs
 
+    def cell_cost(self, cost_mm: float) -> int:
+        """Per-cell cost units for costs that accumulate per visited cell
+        (proximity penalties, attraction bonuses).
+
+        Cost knobs are calibrated at REFERENCE_GRID_STEP: the per-cell value
+        scales with grid_step so the accumulated cost per mm of path is
+        independent of --grid-step (a finer grid visits proportionally more
+        cells). At 0.1mm this reproduces the historical values exactly.
+        """
+        return int(cost_mm * 1000 / REFERENCE_GRID_STEP * (self.grid_step / REFERENCE_GRID_STEP))
+
+    def scaled_cell_units(self, units: float) -> int:
+        """Grid-invariant scaling for per-cell cost knobs given in raw cost
+        units calibrated at REFERENCE_GRID_STEP (e.g. bus_attraction_bonus)."""
+        return int(units * (self.grid_step / REFERENCE_GRID_STEP))
+
+    def via_cost_units(self) -> int:
+        """Per-via penalty in cost units.
+
+        The via_cost knob is in grid steps at REFERENCE_GRID_STEP (default 50
+        = 5mm of path); the value scales with 1/grid_step so a via costs the
+        same mm-equivalent detour at any --grid-step.
+        """
+        return int(self.via_cost * 1000 * (REFERENCE_GRID_STEP / self.grid_step))
+
     def get_proximity_heuristic_cost(self) -> int:
         """Get the maximum proximity heuristic cost for the Rust router.
 
@@ -205,7 +236,7 @@ class GridRouteConfig:
             # Default factor 0.02 is conservative to avoid overestimating for paths
             # that don't go through proximity zones. Tuned for ~5mm typical radius.
             estimated_cost = total_weight * self.proximity_heuristic_factor
-            return int(estimated_cost * 1000 / self.grid_step)
+            return self.cell_cost(estimated_cost)
         return 0
 
     def get_proximity_heuristic_for_zones(self, src_in_stub: bool, src_in_bga: bool,
@@ -239,7 +270,7 @@ class GridRouteConfig:
 
         if total_weight > 0:
             estimated_cost = total_weight * self.proximity_heuristic_factor
-            return int(estimated_cost * 1000 / self.grid_step)
+            return self.cell_cost(estimated_cost)
         return 0
 
 

--- a/routing_context.py
+++ b/routing_context.py
@@ -72,7 +72,7 @@ def merge_ripped_route_costs(obstacles, ripped_route_layer_costs: Dict[int, np.n
     if ripped_route_via_positions:
         coord = GridCoord(config.grid_step)
         radius_grid = coord.to_grid_dist(config.ripped_route_avoidance_radius)
-        cost_grid = int(config.ripped_route_avoidance_cost * 1000 / config.grid_step)
+        cost_grid = config.cell_cost(config.ripped_route_avoidance_cost)
 
         all_via_positions = []
         for via_list in ripped_route_via_positions.values():

--- a/single_ended_routing.py
+++ b/single_ended_routing.py
@@ -532,7 +532,7 @@ def route_net(pcb_data: PCBData, net_id: int, config: GridRouteConfig,
 
     # Calculate vertical attraction parameters
     attraction_radius_grid = coord.to_grid_dist(config.vertical_attraction_radius) if config.vertical_attraction_radius > 0 else 0
-    attraction_bonus = int(config.vertical_attraction_cost * 1000 / config.grid_step) if config.vertical_attraction_cost > 0 else 0
+    attraction_bonus = config.cell_cost(config.vertical_attraction_cost) if config.vertical_attraction_cost > 0 else 0
 
     # Check which proximity zones the stub free ends are in for precise heuristic estimate
     src_in_stub = any(obstacles.get_stub_proximity_cost(gx, gy) > 0 for gx, gy, _ in prox_check_sources)
@@ -548,7 +548,7 @@ def route_net(pcb_data: PCBData, net_id: int, config: GridRouteConfig,
         if tgt_in_bga: zones.append("tgt:bga")
         print(f"  proximity_heuristic_cost={prox_h_cost} zones=[{', '.join(zones) if zones else 'none'}]")
 
-    router = GridRouter(via_cost=config.via_cost * 1000, h_weight=config.heuristic_weight,
+    router = GridRouter(via_cost=config.via_cost_units(), h_weight=config.heuristic_weight,
                         turn_cost=config.turn_cost, via_proximity_cost=int(config.via_proximity_cost),
                         vertical_attraction_radius=attraction_radius_grid,
                         vertical_attraction_bonus=attraction_bonus,
@@ -804,7 +804,7 @@ def route_net_with_obstacles(pcb_data: PCBData, net_id: int, config: GridRouteCo
 
     # Calculate vertical attraction parameters
     attraction_radius_grid = coord.to_grid_dist(config.vertical_attraction_radius) if config.vertical_attraction_radius > 0 else 0
-    attraction_bonus = int(config.vertical_attraction_cost * 1000 / config.grid_step) if config.vertical_attraction_cost > 0 else 0
+    attraction_bonus = config.cell_cost(config.vertical_attraction_cost) if config.vertical_attraction_cost > 0 else 0
 
     # Check which proximity zones the stub free ends are in for precise heuristic estimate
     src_in_stub = any(obstacles.get_stub_proximity_cost(gx, gy) > 0 for gx, gy, _ in prox_check_sources)
@@ -822,9 +822,9 @@ def route_net_with_obstacles(pcb_data: PCBData, net_id: int, config: GridRouteCo
 
     # Calculate bus attraction parameters
     bus_attraction_radius_grid = coord.to_grid_dist(config.bus_attraction_radius) if config.bus_attraction_radius > 0 else 0
-    bus_attraction_bonus = int(config.bus_attraction_bonus) if config.bus_attraction_bonus > 0 else 0
+    bus_attraction_bonus = config.scaled_cell_units(config.bus_attraction_bonus) if config.bus_attraction_bonus > 0 else 0
 
-    router = GridRouter(via_cost=config.via_cost * 1000, h_weight=config.heuristic_weight,
+    router = GridRouter(via_cost=config.via_cost_units(), h_weight=config.heuristic_weight,
                         turn_cost=config.turn_cost, via_proximity_cost=int(config.via_proximity_cost),
                         vertical_attraction_radius=attraction_radius_grid,
                         vertical_attraction_bonus=attraction_bonus,
@@ -1367,7 +1367,7 @@ def route_net_with_visualization(pcb_data: PCBData, net_id: int, config: GridRou
 
     # Calculate vertical attraction parameters
     attraction_radius_grid = coord.to_grid_dist(config.vertical_attraction_radius) if config.vertical_attraction_radius > 0 else 0
-    attraction_bonus = int(config.vertical_attraction_cost * 1000 / config.grid_step) if config.vertical_attraction_cost > 0 else 0
+    attraction_bonus = config.cell_cost(config.vertical_attraction_cost) if config.vertical_attraction_cost > 0 else 0
 
     # Determine direction order (always deterministic)
     if config.direction_order in ("backwards", "backward"):
@@ -1385,7 +1385,7 @@ def route_net_with_visualization(pcb_data: PCBData, net_id: int, config: GridRou
         first_label, second_label = "forward", "backward"
 
     # Create visual router
-    router = VisualRouter(via_cost=config.via_cost * 1000, h_weight=config.heuristic_weight,
+    router = VisualRouter(via_cost=config.via_cost_units(), h_weight=config.heuristic_weight,
                           turn_cost=config.turn_cost, via_proximity_cost=int(config.via_proximity_cost),
                           vertical_attraction_radius=attraction_radius_grid,
                           vertical_attraction_bonus=attraction_bonus,
@@ -1427,7 +1427,7 @@ def route_net_with_visualization(pcb_data: PCBData, net_id: int, config: GridRou
         print(f"No route found after {total_iterations} iterations ({first_label}), trying {second_label}...")
 
         # Try second direction
-        router = VisualRouter(via_cost=config.via_cost * 1000, h_weight=config.heuristic_weight,
+        router = VisualRouter(via_cost=config.via_cost_units(), h_weight=config.heuristic_weight,
                           turn_cost=config.turn_cost, via_proximity_cost=int(config.via_proximity_cost),
                           vertical_attraction_radius=attraction_radius_grid,
                           vertical_attraction_bonus=attraction_bonus,
@@ -1726,7 +1726,7 @@ def route_multipoint_main(
 
     # Calculate vertical attraction parameters
     attraction_radius_grid = coord.to_grid_dist(config.vertical_attraction_radius) if config.vertical_attraction_radius > 0 else 0
-    attraction_bonus = int(config.vertical_attraction_cost * 1000 / config.grid_step) if config.vertical_attraction_cost > 0 else 0
+    attraction_bonus = config.cell_cost(config.vertical_attraction_cost) if config.vertical_attraction_cost > 0 else 0
 
     # Check which proximity zones the stub free ends are in for precise heuristic estimate
     src_in_stub = any(obstacles.get_stub_proximity_cost(gx, gy) > 0 for gx, gy, _ in prox_check_sources)
@@ -1743,7 +1743,7 @@ def route_multipoint_main(
         print(f"  proximity_heuristic_cost={prox_h_cost} zones=[{', '.join(zones) if zones else 'none'}]")
 
     # Route farthest pair with probe routing (same as single-ended)
-    router = GridRouter(via_cost=config.via_cost * 1000, h_weight=config.heuristic_weight,
+    router = GridRouter(via_cost=config.via_cost_units(), h_weight=config.heuristic_weight,
                         turn_cost=config.turn_cost, via_proximity_cost=int(config.via_proximity_cost),
                         vertical_attraction_radius=attraction_radius_grid,
                         vertical_attraction_bonus=attraction_bonus,
@@ -1946,9 +1946,9 @@ def route_multipoint_taps(
 
     # Calculate vertical attraction parameters
     attraction_radius_grid = coord.to_grid_dist(config.vertical_attraction_radius) if config.vertical_attraction_radius > 0 else 0
-    attraction_bonus = int(config.vertical_attraction_cost * 1000 / config.grid_step) if config.vertical_attraction_cost > 0 else 0
+    attraction_bonus = config.cell_cost(config.vertical_attraction_cost) if config.vertical_attraction_cost > 0 else 0
 
-    router = GridRouter(via_cost=config.via_cost * 1000, h_weight=config.heuristic_weight,
+    router = GridRouter(via_cost=config.via_cost_units(), h_weight=config.heuristic_weight,
                         turn_cost=config.turn_cost, via_proximity_cost=int(config.via_proximity_cost),
                         vertical_attraction_radius=attraction_radius_grid,
                         vertical_attraction_bonus=attraction_bonus,


### PR DESCRIPTION
## Summary

Routing cost knobs silently changed meaning with `--grid-step`:

- **Per-cell costs** (stub/BGA/track proximity, ripped-route avoidance, vertical attraction, bus attraction, plane-connector proximity) were scaled `1/grid_step` per cell, so traversing the same physical zone cost 2× more per mm at 0.05mm than at 0.1mm.
- **`via_cost`** was a fixed step count, so a via cost half the mm-equivalent detour at 0.05mm.

All cost knobs now go through three `GridRouteConfig` helpers (`cell_cost`, `scaled_cell_units`, `via_cost_units`) calibrated at `REFERENCE_GRID_STEP = 0.1mm`: the cost per mm of path is the same at any grid step, and 0.1mm behavior is exactly unchanged. ~25 sites across 7 files; CLI help and README updated.

## Verification

- **Bit-identical at 0.1mm** on both benchmark boards (same `total_iterations`, vias, success/fail sets): interf_u 2,294,234 iterations / 136 vias; kit coldfire 26,841,617 / 345.
- `tests/test_diff_pair_route.py` passes 3/3.

## Fine-grid behavior (intentional change)

The distorted landscape was making fine-grid A* over-explore and buy too many vias. kit board at 0.05mm (on top of the #68 optimizations):

| | before | after |
|---|---|---|
| A* iterations | 170.6M | 65.4M |
| Wall time | 164s | 74s |
| Vias | 481 | 279 (vs 345 at 0.1mm) |
| Pad-clearance DRC violations | 207 | 67 |
| Failed nets | 0 | 0 |

interf_u at 0.05mm: 150 → 117 vias.

Known behavior note: 2 marginal multipoint power-tap edges on the kit board (U102, 0.5mm pitch) connected under the old 0.05mm landscape and now fail their tap edge; they fail in nearly every other configuration tested (including the old landscape with single knobs adjusted), and tap-edge failures being silent/unretried is a pre-existing gap worth its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)