### PR TITLE
Count multipoint nets with unconnected tap pads as failed

### DIFF
--- a/route.py
+++ b/route.py
@@ -682,6 +682,12 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
                     'net_id': net_id,
                     'failed_pads': failed_pads_info
                 })
+    # A multipoint net with unconnected tap pads is not fully routed: count
+    # it as failed, not successful (its first connection routed, so it was
+    # counted successful when the main loop completed)
+    successful -= len(failed_multipoint)
+    failed += len(failed_multipoint)
+
     # Count total vias from results
     total_vias = sum(len(r.get('new_vias', [])) for r in results)
 


### PR DESCRIPTION
## Summary

A multipoint net was counted `successful` as soon as its first two-pad connection routed. If Phase 3 tap routing then failed to connect some pads, that showed up only in `multipoint_edges_failed` / `failed_multipoint` and a warning line — `"failed": 0` could be reported on a board with unconnected pads. Nets with failed tap pads now count as failed (and not successful) in both the JSON summary and the return value.

For the record (investigated for #36): tap edges were **already retried** with progressive rip-up (`try_phase3_ripup` — blocking analysis, escalating N, re-route of ripped nets). The retry machinery is fine; only the accounting was missing.

## Verification

- Routing output unchanged: bit-identical `total_iterations` (26,841,617) and vias (345) on the kit board at 0.1mm.
- `tests/test_diff_pair_route.py` passes (route_diff.py has no multipoint taps; unaffected).
- The fix immediately surfaces real, previously-silent failures on the kit benchmark: at the **default 0.1mm grid** the summary now reports `failed: 3` (was 1) — GNDA and /VCCA tap pads at the 0.5mm-pitch U102 never connected (`check_connected` confirms). At 0.05mm: `failed: 2` (was 0).

Note: anything gating on `"failed": 0` will now correctly fail on boards with unconnected tap pads — on the kit board that's a true positive. The underlying tap failures there are 0.3mm-wide power taps walled in at the 0.5mm-pitch QFP after /VCCA routes first; a possible future improvement is retrying failed power taps at default track width (neck-down).

🤖 Generated with [Claude Code](https://claude.com/claude-code)