### PR TITLE
Fix #121: diff-pair launch onto open layers (bare-pad fan, peel far terminals, relocate blocked terminals)

### DIFF
--- a/.claude/skills/plan-pcb-routing/SKILL.md
+++ b/.claude/skills/plan-pcb-routing/SKILL.md
@@ -239,6 +239,19 @@ Also note: `route_diff.py` resolves P/N polarity mismatches automatically, which
 target pad net assignments. Swaps are reported in the output — when they happen, the
 schematic sync step below applies (see "Schematic Synchronization After Swaps").
 
+**Far-apart terminal pads → single-ended follow-up (issue #121).** A "diff pair"
+sometimes has pads that aren't a coupled connection — e.g. a P and an N test point
+several mm apart, or a logical pair daisy-chained through spread-out parts. If the
+coupled chain can't be routed, `route_diff.py` peels those far-apart pads off the
+chain (routing the genuinely-coupled terminals as a pair) and lists the affected
+nets under `single_ended_followup_nets` in its `JSON_SUMMARY` (and a "route them
+single-ended next" block on stdout). Those pads are **not** dropped — the **Signal
+Routing** step (`route.py "*" "!GND" "!VCC"`) connects them P→P / N→N along with
+every other unrouted net, since they remain unrouted after the diff-pair step. So:
+**do not exclude the diff-pair nets from the signal-routing step's net selection** —
+that step is what finishes the peeled pads. If you scope the signal step to specific
+nets instead of `"*"`, add any `single_ended_followup_nets` to it explicitly.
+
 ### Check for DDR/High-Speed Memory Signals
 
 Look for DDR signal patterns in the net list that may need length matching:
@@ -298,11 +311,14 @@ Based on the analysis, generate a step-by-step plan. The general order is:
 1. **Fanout** (if needed) - Escape routing first, while the board is empty. Exclude
    nets that planes will handle (`"*" "!GND" "!VCC"`).
 2. **Differential Pairs** - The most constrained routes claim their channels before
-   anything else can block them (if present).
+   anything else can block them (if present). May peel far-apart "terminal" pads
+   (e.g. spread-out test points) off the coupled chain and leave them for the
+   signal-routing step (reported as `single_ended_followup_nets`, issue #121).
 3. **Signal Routing** - All remaining nets, **excluding the plane nets**
    (`--nets "*" "!GND" "!VCC"`). Routing them as tracks now would defeat the
    planes step - the exclusions are mandatory whenever a later step gives those
-   nets planes.
+   nets planes. This step also finishes any diff-pair pads peeled off in step 2,
+   so keep the diff-pair nets in its selection (the `"*"` covers them).
 4. **Power Planes** - Create GND and VCC planes together. Stitching vias adapt
    around the routed signals; the reverse is not true - a stitching via placed
    early can block the only clean channel for a diff pair (issue #56). If signal

--- a/diff_pair_loop.py
+++ b/diff_pair_loop.py
@@ -112,10 +112,15 @@ def route_diff_pairs(
         # legs - a pair cannot tap mid-track without P/N crossing
         terminals = get_diff_pair_terminals(pcb_data, pair.p_net_id, pair.n_net_id)
         if len(terminals) > 2:
-            leg_results, merged = route_multipoint_diff_pair(state, pair, pair_name, terminals)
+            leg_results, merged, peeled = route_multipoint_diff_pair(state, pair, pair_name, terminals)
             elapsed = time.time() - start_time
             total_time += elapsed
             results.extend(leg_results)
+            if peeled:
+                # Far-apart terminal pads were dropped from the coupled chain;
+                # connect them single-ended afterward (issue #121).
+                state.diff_pair_single_ended_nets[pair.p_net_id] = pair.p_net_name
+                state.diff_pair_single_ended_nets[pair.n_net_id] = pair.n_net_name
             if merged is not None:
                 total_segs = len(merged['new_segments'])
                 total_legs = len(leg_results)

--- a/diff_pair_multipoint.py
+++ b/diff_pair_multipoint.py
@@ -25,7 +25,8 @@ from routing_config import GridRouteConfig, GridCoord, DiffPairNet
 from diff_pair_routing import (
     route_diff_pair_with_obstacles, get_pair_end_direction, _pn_tracks_cross
 )
-from layer_swap_fallback import add_own_stubs_as_obstacles_for_diff_pair
+from layer_swap_fallback import add_own_stubs_as_obstacles_for_diff_pair, rank_fallback_layers
+from stub_layer_switching import apply_bare_pad_target_via
 from pcb_modification import add_route_to_pcb_data, remove_route_from_pcb_data
 from polarity_swap import apply_polarity_swap, undo_polarity_swap
 from routing_context import build_diff_pair_obstacles
@@ -132,6 +133,121 @@ def classify_terminals(terminals: List[Tuple[Pad, Pad]], config: GridRouteConfig
     for t in terminals:
         (coupled if terminal_separation(t) <= threshold else uncoupled).append(t)
     return coupled, uncoupled
+
+
+def _blocked_fraction(config, obstacles, cx, cy, layer_idx, radius_mm=1.5):
+    """Fraction of a disk around (cx, cy) that is blocked on layer_idx."""
+    coord = GridCoord(config.grid_step)
+    r = max(1, int(radius_mm / config.grid_step))
+    total = blocked = 0
+    for dx in range(-r, r + 1):
+        for dy in range(-r, r + 1):
+            if dx * dx + dy * dy > r * r:
+                continue
+            gx, gy = coord.to_grid(cx + dx * config.grid_step, cy + dy * config.grid_step)
+            total += 1
+            if obstacles.is_blocked(gx, gy, layer_idx):
+                blocked += 1
+    return blocked / total if total else 1.0
+
+
+def _fake_pad(ref_pad: Pad, x: float, y: float, layer: str) -> Pad:
+    """A stand-in pad at (x, y) on `layer` carrying ref_pad's net, used as a leg
+    launch point after a terminal is relocated to an open layer (issue #121)."""
+    return Pad(
+        component_ref=ref_pad.component_ref, pad_number=ref_pad.pad_number,
+        global_x=x, global_y=y, local_x=x, local_y=y,
+        size_x=ref_pad.size_x, size_y=ref_pad.size_y, shape=ref_pad.shape,
+        layers=[layer], net_id=ref_pad.net_id, net_name=ref_pad.net_name)
+
+
+def _candidate_relocation_layers(state, terminals, obstacles, max_layers=3):
+    """Rank shared target layers for relocating blocked terminals: a layer is a
+    candidate if it is clearly more open than at least one terminal's own layer.
+    Non-plane (signal) layers first, then by worst-case openness across the
+    blocked terminals; planes last (routing them slots the reference). (#121)"""
+    config = state.config
+    pcb_data = state.pcb_data
+    centers = [_terminal_center(t) for t in terminals]
+    own_fracs = [_blocked_fraction(config, obstacles, cx, cy,
+                                   config.layers.index(_pad_layer(t[0], config)))
+                 for t, (cx, cy) in zip(terminals, centers)]
+    if not any(f >= 0.45 for f in own_fracs):
+        return []  # nothing is meaningfully blocked
+    ranked = []
+    for li, layer in enumerate(config.layers):
+        fracs = [_blocked_fraction(config, obstacles, cx, cy, li) for cx, cy in centers]
+        worst = max(fracs)
+        # Useful only if it actually unblocks a blocked terminal.
+        helps = any(own >= 0.45 and fracs[k] < own - 0.15 and fracs[k] < 0.4
+                    for k, own in enumerate(own_fracs))
+        if not helps:
+            continue
+        is_plane = any(_layer_is_plane_for(pcb_data, layer, cx, cy) for cx, cy in centers)
+        ranked.append((is_plane, worst, layer))
+    ranked.sort(key=lambda t: (t[0], t[1]))
+    return [layer for _, _, layer in ranked[:max_layers]]
+
+
+def _layer_is_plane_for(pcb_data, layer_name, x, y):
+    from layer_swap_fallback import _layer_is_plane_at
+    return _layer_is_plane_at(pcb_data, layer_name, x, y)
+
+
+def _relocate_blocked_terminals(state, pair: DiffPairNet, terminals, obstacles, target_layer):
+    """Relocate every terminal whose own (pad) layer is too blocked to launch a
+    coupled pair onto `target_layer` (when target_layer is open there): drop a
+    via on each pad to switch layers and grow a short stub (apply_bare_pad_target_via);
+    the leg launches from the stub's free end. Reuses the layer-switch endpoint
+    mechanism (issue #121, the user's "drop a via, call the stub an endpoint").
+
+    Returns (new_terminals, fans): new_terminals has relocated terminals replaced
+    by stub-end stand-in pads; fans is a list of (via, stub) added to pcb_data
+    (attach to the route on success, remove on failure)."""
+    config = state.config
+    pcb_data = state.pcb_data
+    centers = [_terminal_center(t) for t in terminals]
+    tgt_idx = config.layers.index(target_layer)
+    new_terminals = list(terminals)
+    fans = []
+    for i, (pp, nn) in enumerate(terminals):
+        cx, cy = centers[i]
+        pad_layer = _pad_layer(pp, config)
+        if pad_layer == target_layer:
+            continue
+        frac = _blocked_fraction(config, obstacles, cx, cy, config.layers.index(pad_layer))
+        tgt_frac = _blocked_fraction(config, obstacles, cx, cy, tgt_idx)
+        # Only relocate a genuinely-blocked terminal onto a clearly-open target.
+        if frac < 0.45 or tgt_frac > frac - 0.15 or tgt_frac > 0.4:
+            continue
+        # Aim the new stubs toward the rest of the chain (away from this part).
+        others = [centers[j] for j in range(len(centers)) if j != i] or [(cx, cy)]
+        ax = sum(c[0] for c in others) / len(others)
+        ay = sum(c[1] for c in others) / len(others)
+        via_p, stub_p = apply_bare_pad_target_via(pcb_data, pp.net_id, pp.global_x, pp.global_y, target_layer, ax, ay, config)
+        via_n, stub_n = apply_bare_pad_target_via(pcb_data, nn.net_id, nn.global_x, nn.global_y, target_layer, ax, ay, config)
+        fans += [(via_p, stub_p), (via_n, stub_n)]
+        new_terminals[i] = (_fake_pad(pp, stub_p.end_x, stub_p.end_y, target_layer),
+                            _fake_pad(nn, stub_n.end_x, stub_n.end_y, target_layer))
+        print(f"    Relocated terminal {pp.component_ref}:{pp.pad_number}/{nn.pad_number} "
+              f"{pad_layer}({frac*100:.0f}%) -> {target_layer}({tgt_frac*100:.0f}%)")
+    return new_terminals, fans
+
+
+def _attach_fans(merged, fans):
+    """Record relocation fan copper (via + stub per pad) on the merged route so
+    sync_pcb_data_segments writes it to the output."""
+    merged['new_segments'] = list(merged.get('new_segments', [])) + [s for _, s in fans]
+    merged['new_vias'] = list(merged.get('new_vias', [])) + [v for v, _ in fans]
+
+
+def _cleanup_fans(pcb_data, fans):
+    """Remove relocation fan copper from pcb_data (failed attempt)."""
+    for via, stub in fans:
+        if via in pcb_data.vias:
+            pcb_data.vias.remove(via)
+        if stub in pcb_data.segments:
+            pcb_data.segments.remove(stub)
 
 
 def candidate_terminal_chains(terminals: List[Tuple[Pad, Pad]],
@@ -288,6 +404,8 @@ def route_multipoint_diff_pair(state, pair: DiffPairNet, pair_name: str,
     failure (failed attempts' legs are ripped back out).
     """
     config = state.config
+    pcb_data = state.pcb_data
+    obstacles = state.diff_pair_base_obstacles
 
     print(f"  Multi-point pair: {len(terminals)} terminals, {len(terminals) - 1} legs")
     # Try the full coupled chain first - a pair that routes fine through a
@@ -297,7 +415,29 @@ def route_multipoint_diff_pair(state, pair: DiffPairNet, pair_name: str,
     if merged is not None:
         return leg_results, merged, []
 
-    # Full chain failed. If some terminals are too far apart to be a coupled
+    # The chain couldn't launch on the terminals' own layers (jammed outer
+    # layers). Relocate the blocked terminals onto an open layer (drop a via,
+    # launch from the stub) and retry - trying candidate target layers in turn
+    # (non-plane first, then planes, which the router treats as open).
+    def _try_relocated(term_set):
+        for layer in _candidate_relocation_layers(state, term_set, obstacles):
+            reloc, fans = _relocate_blocked_terminals(state, pair, term_set, obstacles, layer)
+            if not fans:
+                continue
+            print(f"  Retrying chain with {len(fans)//2} terminal(s) relocated to {layer}...")
+            legs, m = _route_terminal_set(state, pair, pair_name, reloc)
+            if m is not None:
+                _attach_fans(m, fans)
+                return legs, m
+            _cleanup_fans(pcb_data, fans)
+        return [], None
+
+    if obstacles is not None:
+        leg_results, merged = _try_relocated(terminals)
+        if merged is not None:
+            return leg_results, merged, []
+
+    # Still stuck. If some terminals are too far apart to be a coupled
     # differential connection, peel them off and route only the coupled
     # terminals as a pair; the peeled pads are connected single-ended afterward.
     coupled, uncoupled = classify_terminals(terminals, config)
@@ -309,6 +449,10 @@ def route_multipoint_diff_pair(state, pair: DiffPairNet, pair_name: str,
         leg_results, merged = _route_terminal_set(state, pair, pair_name, coupled)
         if merged is not None:
             return leg_results, merged, uncoupled
+        if obstacles is not None:
+            leg_results, merged = _try_relocated(coupled)
+            if merged is not None:
+                return leg_results, merged, uncoupled
     return [], None, []
 
 

--- a/diff_pair_multipoint.py
+++ b/diff_pair_multipoint.py
@@ -113,6 +113,27 @@ def _terminal_center(terminal: Tuple[Pad, Pad]) -> Tuple[float, float]:
     return ((pp.global_x + nn.global_x) / 2, (pp.global_y + nn.global_y) / 2)
 
 
+def terminal_separation(terminal: Tuple[Pad, Pad]) -> float:
+    """P-to-N pad distance (mm) of a terminal."""
+    pp, nn = terminal
+    return math.hypot(pp.global_x - nn.global_x, pp.global_y - nn.global_y)
+
+
+def classify_terminals(terminals: List[Tuple[Pad, Pad]], config: GridRouteConfig
+                       ) -> Tuple[List[Tuple[Pad, Pad]], List[Tuple[Pad, Pad]]]:
+    """Split terminals into (coupled, uncoupled).
+
+    A terminal is coupled when its P and N pads are close enough to launch a real
+    differential pair; uncoupled when they are too far apart to be a coupled
+    connection (e.g. test points on opposite sides of a part). Threshold =
+    diff_pair_uncouple_factor * (track_width + diff_pair_gap) (issue #121)."""
+    threshold = config.diff_pair_uncouple_factor * (config.track_width + config.diff_pair_gap)
+    coupled, uncoupled = [], []
+    for t in terminals:
+        (coupled if terminal_separation(t) <= threshold else uncoupled).append(t)
+    return coupled, uncoupled
+
+
 def candidate_terminal_chains(terminals: List[Tuple[Pad, Pad]],
                               max_candidates: int = 4) -> List[List[Tuple[Pad, Pad]]]:
     """Rank terminal orderings for an open chain (each terminal has only two
@@ -266,11 +287,38 @@ def route_multipoint_diff_pair(state, pair: DiffPairNet, pair_name: str,
     Returns (leg_results, merged_result) on full success, ([], None) on
     failure (failed attempts' legs are ripped back out).
     """
-    pcb_data = state.pcb_data
     config = state.config
 
-    chains = candidate_terminal_chains(terminals)
     print(f"  Multi-point pair: {len(terminals)} terminals, {len(terminals) - 1} legs")
+    # Try the full coupled chain first - a pair that routes fine through a
+    # widely-spaced terminal (e.g. a test point reached as a chain end) must not
+    # be broken up needlessly (issue #121).
+    leg_results, merged = _route_terminal_set(state, pair, pair_name, terminals)
+    if merged is not None:
+        return leg_results, merged, []
+
+    # Full chain failed. If some terminals are too far apart to be a coupled
+    # differential connection, peel them off and route only the coupled
+    # terminals as a pair; the peeled pads are connected single-ended afterward.
+    coupled, uncoupled = classify_terminals(terminals, config)
+    if uncoupled and len(coupled) >= 2:
+        far = min(terminal_separation(t) for t in uncoupled)
+        print(f"  Coupled chain failed; peeling {len(uncoupled)} far-apart terminal(s) "
+              f"(P/N >= {far:.1f}mm apart) to route single-ended, retrying "
+              f"coupled {len(coupled)}-terminal chain...")
+        leg_results, merged = _route_terminal_set(state, pair, pair_name, coupled)
+        if merged is not None:
+            return leg_results, merged, uncoupled
+    return [], None, []
+
+
+def _route_terminal_set(state, pair: DiffPairNet, pair_name: str,
+                        terminals: List[Tuple[Pad, Pad]]):
+    """Route a fixed set of terminals as a coupled chain, trying alternative
+    chain orderings. Returns (leg_results, merged) or ([], None)."""
+    if len(terminals) < 2:
+        return [], None
+    chains = candidate_terminal_chains(terminals)
     for attempt, chain in enumerate(chains):
         if attempt > 0:
             print(f"  Trying alternative chain order ({attempt + 1}/{len(chains)})...")

--- a/layer_swap_fallback.py
+++ b/layer_swap_fallback.py
@@ -109,6 +109,73 @@ def add_own_pads_as_obstacles_for_diff_pair(obstacles, pcb_data, p_net_id: int, 
     )
 
 
+def _point_in_polygon(x: float, y: float, poly) -> bool:
+    """Ray-cast point-in-polygon test for a list of (x, y) vertices."""
+    inside = False
+    n = len(poly)
+    if n < 3:
+        return False
+    j = n - 1
+    for i in range(n):
+        xi, yi = poly[i][0], poly[i][1]
+        xj, yj = poly[j][0], poly[j][1]
+        if ((yi > y) != (yj > y)) and \
+           (x < (xj - xi) * (y - yi) / (yj - yi + 1e-12) + xi):
+            inside = not inside
+        j = i
+    return inside
+
+
+def _layer_is_plane_at(pcb_data, layer_name: str, x: float, y: float) -> bool:
+    """True if a filled copper zone (power/GND plane) on layer_name covers (x, y).
+
+    Routing on a plane layer is allowed (the zone re-pours with a void around the
+    new trace), but it slots the reference plane, so the launch-layer fallback
+    prefers non-plane layers first (issue #121)."""
+    for zone in getattr(pcb_data, 'zones', []) or []:
+        zlayers = zone.layers if getattr(zone, 'layers', None) else [getattr(zone, 'layer', None)]
+        if layer_name not in zlayers:
+            continue
+        poly = getattr(zone, 'polygon', None)
+        if poly and _point_in_polygon(x, y, poly):
+            return True
+    return False
+
+
+def rank_fallback_layers(config, pcb_data, obstacles, center_x: float, center_y: float,
+                         current_layer: str, probe_radius_mm: float = 1.5) -> list:
+    """Order candidate launch layers for the layer-swap fallback, best first.
+
+    A terminal whose own layer is fully blocked can launch by via-ing the pair
+    down to another layer; pick the layer that is most open around the terminal,
+    preferring non-plane (signal) layers over plane layers (issue #121). Returns
+    layer names excluding current_layer.
+    """
+    from routing_config import GridCoord
+    coord = GridCoord(config.grid_step)
+    r = max(1, int(probe_radius_mm / config.grid_step))
+    ranked = []
+    for li, layer_name in enumerate(config.layers):
+        if layer_name == current_layer:
+            continue
+        total = blocked = 0
+        for dx in range(-r, r + 1):
+            for dy in range(-r, r + 1):
+                if dx * dx + dy * dy > r * r:
+                    continue
+                gx, gy = coord.to_grid(center_x + dx * config.grid_step,
+                                       center_y + dy * config.grid_step)
+                total += 1
+                if obstacles.is_blocked(gx, gy, li):
+                    blocked += 1
+        frac = blocked / total if total else 1.0
+        is_plane = _layer_is_plane_at(pcb_data, layer_name, center_x, center_y)
+        ranked.append((is_plane, frac, layer_name))
+    # Non-plane first, then most-open (lowest blocked fraction)
+    ranked.sort(key=lambda t: (t[0], t[1]))
+    return [name for _, _, name in ranked]
+
+
 def try_fallback_layer_swap(pcb_data, pair, pair_name: str, config,
                             fwd_cells: list, bwd_cells: list,
                             diff_pair_base_obstacles, base_obstacles,
@@ -192,8 +259,16 @@ def try_fallback_layer_swap(pcb_data, pair, pair_name: str, config,
                         lookup_n_net_id = ppair.n_net_id
                         break
 
-        # Try each candidate layer
-        for candidate_layer in config.layers:
+        # Try candidate layers ordered by how open they are around this terminal,
+        # preferring non-plane (signal) layers over plane layers (issue #121).
+        # The terminal's own layer may be fully blocked (dense pad row, congested
+        # outer layer) while an inner layer is wide open - via the pair P/N down
+        # there instead of failing to launch.
+        term_cx = (endpoints[0][5] + endpoints[0][7]) / 2
+        term_cy = (endpoints[0][6] + endpoints[0][8]) / 2
+        candidate_layers = rank_fallback_layers(
+            config, pcb_data, diff_pair_base_obstacles, term_cx, term_cy, current_layer)
+        for candidate_layer in candidate_layers:
             if candidate_layer == current_layer:
                 continue
 

--- a/layer_swap_optimization.py
+++ b/layer_swap_optimization.py
@@ -134,7 +134,8 @@ def apply_diff_pair_layer_swaps(
     all_segment_modifications: List,
     all_swap_vias: List,
     verbose: bool = False,
-    all_swap_segments: Optional[List] = None
+    all_swap_segments: Optional[List] = None,
+    probe_obstacles=None
 ) -> Tuple[int, Dict, Dict]:
     """
     Apply upfront layer swap optimization for diff pairs.
@@ -627,29 +628,44 @@ def apply_diff_pair_layer_swaps(
                 # right way for the launcher.
                 src_cx = (sources[0][5] + sources[0][7]) / 2
                 src_cy = (sources[0][6] + sources[0][8]) / 2
+                # Fan onto the most-open layer around the target (non-plane first)
+                # rather than blindly src_layer, which can be fully blocked by a
+                # connector pad wall while inner layers are open (issue #121).
+                fan_layer = src_layer
+                if probe_obstacles is not None:
+                    from layer_swap_fallback import rank_fallback_layers
+                    tgt_cx = (p_tgt_x + n_tgt_x) / 2
+                    tgt_cy = (p_tgt_y + n_tgt_y) / 2
+                    ranked = rank_fallback_layers(
+                        config, pcb_data, probe_obstacles, tgt_cx, tgt_cy, tgt_layer)
+                    if ranked:
+                        fan_layer = ranked[0]
+                        if fan_layer != src_layer:
+                            print(f"    Bare-pad target launch layer: {fan_layer} "
+                                  f"(most open; src is {src_layer})")
                 via_p, stub_p = apply_bare_pad_target_via(
-                    pcb_data, pair.p_net_id, p_tgt_x, p_tgt_y, src_layer,
+                    pcb_data, pair.p_net_id, p_tgt_x, p_tgt_y, fan_layer,
                     src_cx, src_cy, config)
                 via_n, stub_n = apply_bare_pad_target_via(
-                    pcb_data, pair.n_net_id, n_tgt_x, n_tgt_y, src_layer,
+                    pcb_data, pair.n_net_id, n_tgt_x, n_tgt_y, fan_layer,
                     src_cx, src_cy, config)
                 all_swap_vias.extend([via_p, via_n])
                 all_swap_segments.extend([stub_p, stub_n])
 
-                # Register the new inner-layer stubs so later swap validation sees them.
-                if src_layer not in all_stubs_by_layer:
-                    all_stubs_by_layer[src_layer] = []
-                all_stubs_by_layer[src_layer].append((pair_name, [stub_p, stub_n]))
-                if src_layer not in stub_endpoints_by_layer:
-                    stub_endpoints_by_layer[src_layer] = []
-                stub_endpoints_by_layer[src_layer].append(
+                # Register the new stubs (on fan_layer) so later swap validation sees them.
+                if fan_layer not in all_stubs_by_layer:
+                    all_stubs_by_layer[fan_layer] = []
+                all_stubs_by_layer[fan_layer].append((pair_name, [stub_p, stub_n]))
+                if fan_layer not in stub_endpoints_by_layer:
+                    stub_endpoints_by_layer[fan_layer] = []
+                stub_endpoints_by_layer[fan_layer].append(
                     (pair_name, [(stub_p.end_x, stub_p.end_y), (stub_n.end_x, stub_n.end_y)])
                 )
 
                 applied_swaps.add(pair_name)
                 solo_switch_count += 1
                 total_layer_swaps += 1
-                print(f"  Bare-pad target swap: {pair_name} ({tgt_layer} pad -> {src_layer} stub), added 2 pad via(s)")
+                print(f"  Bare-pad target swap: {pair_name} ({tgt_layer} pad -> {fan_layer} stub), added 2 pad via(s)")
                 continue
 
             missing = []

--- a/route_diff.py
+++ b/route_diff.py
@@ -398,10 +398,17 @@ def batch_route_diff_pairs(input_file: str, output_file: str, net_names: List[st
     all_stubs_by_layer = {}
     stub_endpoints_by_layer = {}
     if enable_layer_switch and diff_pair_ids_to_route_set:
+        # Probe obstacle map so a bare-pad target swap can fan onto an OPEN
+        # launch layer rather than blindly the source layer (issue #121: lpddr4
+        # DQ_S0's target was fanned to B.Cu, which is 100% blocked by a connector
+        # pad wall, while the inner layers right there were empty).
+        _swap_probe_clearance = (config.track_width + config.diff_pair_gap) / 2
+        swap_probe_obstacles = build_base_obstacle_map(
+            pcb_data, config, [nid for _, nid in net_ids], _swap_probe_clearance)
         total_layer_swaps, all_stubs_by_layer, stub_endpoints_by_layer = apply_diff_pair_layer_swaps(
             pcb_data, config, diff_pair_ids_to_route_set, diff_pairs,
             can_swap_to_top_layer, all_segment_modifications, all_swap_vias,
-            all_swap_segments=all_swap_segments
+            all_swap_segments=all_swap_segments, probe_obstacles=swap_probe_obstacles
         )
 
     # Add stub swap vias to pcb_data so routing and length matching see them as obstacles

--- a/route_diff.py
+++ b/route_diff.py
@@ -620,6 +620,24 @@ def batch_route_diff_pairs(input_file: str, output_file: str, net_names: List[st
     total_time += dp_time
     total_iterations += dp_iterations
 
+    # Report nets whose far-apart (uncoupled) terminal pads were peeled off the
+    # coupled chain (issue #121). Those pads are not a coupled differential
+    # connection (e.g. spread-out test points), so they are left for a separate
+    # single-ended pass (route.py); the plan-pcb-routing workflow sequences that
+    # after this step. Surfaced here and in JSON_SUMMARY so the follow-up knows
+    # which nets still need P->P / N->N routing.
+    single_ended_followup = sorted(state.diff_pair_single_ended_nets.values())
+    if single_ended_followup:
+        print("\n" + "=" * 60)
+        print(f"{len(single_ended_followup)} net(s) have far-apart terminal pads "
+              f"peeled from the coupled chain - route them single-ended next:")
+        for nm in single_ended_followup:
+            print(f"  {nm}")
+        print("  e.g.  route.py <this_output> <out2> --nets " +
+              " ".join(f"'{n}'" for n in single_ended_followup[:3]) +
+              (" ..." if len(single_ended_followup) > 3 else ""))
+        print("=" * 60)
+
     # Run reroute loop for nets that were ripped during diff pair routing
     rq_successful, rq_failed, rq_time, rq_iterations, route_index = run_reroute_loop(
         state, route_index_start=route_index,
@@ -702,6 +720,7 @@ def batch_route_diff_pairs(input_file: str, output_file: str, net_names: List[st
         'ripup_success_pairs': sorted(ripup_success_pairs),
         'rerouted_pairs': sorted(rerouted_pairs),
         'polarity_swapped_pairs': sorted(polarity_swapped_pairs),
+        'single_ended_followup_nets': sorted(state.diff_pair_single_ended_nets.values()),
         'target_swaps': [{'pair1': k, 'pair2': v} for k, v in target_swaps.items() if k < v],
         'layer_swaps': total_layer_swaps,
         'successful': successful,

--- a/routing_config.py
+++ b/routing_config.py
@@ -172,10 +172,11 @@ class GridRouteConfig:
         Returns costs scaled by 1000 (1000 = 1.0x, 1500 = 1.5x penalty).
         If layer_costs is empty or shorter than layers list, uses 1000 (1.0x) for missing layers.
         """
+        layer_costs = self.layer_costs or []  # may be None when set explicitly
         costs = []
         for i in range(len(self.layers)):
-            if i < len(self.layer_costs):
-                costs.append(int(self.layer_costs[i] * 1000))
+            if i < len(layer_costs):
+                costs.append(int(layer_costs[i] * 1000))
             else:
                 costs.append(1000)  # Default 1.0x
         return costs

--- a/routing_config.py
+++ b/routing_config.py
@@ -53,6 +53,12 @@ class GridRouteConfig:
     # Differential pair routing parameters
     diff_pair_gap: float = 0.101  # mm - gap between P and N traces (center-to-center = track_width + gap)
     diff_pair_centerline_setback: float = None  # mm - distance in front of stubs to start centerline route (None = 2 * spacing)
+    # In a multi-point pair, a "terminal" whose P and N pads are farther apart
+    # than diff_pair_uncouple_factor * (track_width + diff_pair_gap) is not a
+    # coupled differential connection (e.g. spread-out test points). If the full
+    # coupled chain can't be routed, such terminals are peeled off and their pads
+    # routed single-ended (P->P, N->N) instead (issue #121).
+    diff_pair_uncouple_factor: float = 6.0  # multiples of pair spacing (track+gap)
     min_turning_radius: float = 0.2  # mm - minimum turning radius for pose-based routing
     fix_polarity: bool = True  # Swap target pad nets if polarity swap needed
     debug_lines: bool = False  # Output debug geometry on User.2/3/8/9 layers

--- a/routing_state.py
+++ b/routing_state.py
@@ -57,6 +57,10 @@ class RoutingState:
     rip_and_retry_history: Set[Tuple] = field(default_factory=set)
     ripup_success_pairs: Set[str] = field(default_factory=set)
     rerouted_pairs: Set[str] = field(default_factory=set)
+    # Diff-pair nets whose far-apart (uncoupled) terminal pads were peeled off the
+    # coupled chain and must be connected single-ended afterward (issue #121).
+    # net_id -> net_name.
+    diff_pair_single_ended_nets: Dict[int, str] = field(default_factory=dict)
 
     # Environment
     all_unrouted_net_ids: Set[int] = field(default_factory=set)


### PR DESCRIPTION
Fixes the "no valid position at any setback/direction" (0-iteration) diff-pair launch failures in #121, where a pair's terminal sits on a fully-blocked layer while open layers are right there. The router doesn't model copper plane pours as obstacles, so inner/plane layers are routable (zones re-pour around traces) — the launch search just never tried them.

## Part 1 — bare-pad target fans onto the most-open layer (`2e905c7`)
The upfront "bare-pad target swap" fanned a connector-pin target onto the *source* layer, which on lpddr4 was B.Cu — **100% blocked** behind a 130-pad connector wall — while In1 was **5% open**. It now probes a base obstacle map and fans onto the most-open layer (non-plane first; planes are routable but slot the reference). The pair stays coupled, vias between layers as needed.

- **lpddr4 DQ_S0 now routes fully connected** (the reported failure).
- Lives in the shared `batch_route_diff_pairs`, so the GUI inherits it.
- Drive-by: `get_layer_costs()` tolerates `layer_costs=None` (latent crash).

## Part 2 — peel far-apart multipoint terminals → single-ended (`d1123b0`)
`route_multipoint_diff_pair` tries the **full coupled chain first** (so a pair that routes fine through a widely-spaced terminal, e.g. RS‑485 through an 8.5mm test point, is never broken up), and only on failure peels terminals whose P/N are farther than `diff_pair_uncouple_factor × (track+gap)` (default 6×) apart. Peeled nets are reported via stdout and `JSON_SUMMARY.single_ended_followup_nets`; the normal single-ended `route.py` pass connects them P→P / N→N. `plan-pcb-routing` documents the sequencing.

## Part 3 — relocate blocked multipoint terminals onto open layers (`68de3b0`)
When a coupled chain can't launch on jammed layers, it vias the blocked terminals onto an open layer (best-first, planes last) and launches the leg from the resulting stub — the "drop a via, call the stub an endpoint" layer-switch mechanism. Fan copper is attached to the route on success, removed on failure.

**Honest caveat:** part 3 is a non-regressing mechanism that extends coupled-routing reach, but it does **not** yet convert a specific real failure (e.g. lumenpnp USB_D) to a *coupled* success — even relocated to a clean plane, the coupled launch conflicts with the fresh fan via/stub. Such pairs (which the human routed as compact single tracks) fall through to the downstream single-ended pass, which is the correct outcome. A future single-ended fallback for short/uncoupleable pairs is the planned follow-up.

## Testing
`tests/test_diff_pair_route.py` 5/5, `tests/test_multipoint_diff_route.py` 7/7, `tests/test_fanout_and_route.py` and `tests/test_interf_u.py` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
