### PR TITLE
feat(layer-costs): -1 = forbidden layer (obstacle-only, no routed copper); fixes #206

### DIFF
--- a/route.py
+++ b/route.py
@@ -86,7 +86,7 @@ from routing_common import (
 import routing_defaults as defaults
 import re
 from terminal_colors import RED, RESET
-from routing_constants import DEFAULT_4_LAYER_STACK, POWER_NET_EXCLUSION_PATTERNS
+from routing_constants import DEFAULT_4_LAYER_STACK, POWER_NET_EXCLUSION_PATTERNS, FORBIDDEN_LAYER_COST
 
 # Import Rust router (startup_checks ensures it's available and up-to-date)
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'rust_router'))
@@ -270,12 +270,14 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
         else:
             layer_costs = [1.0 if layer == 'F.Cu' else 3.0 for layer in layers]
 
-    # Validate layer costs are in range [1.0, 1000]
+    # Validate layer costs: -1 = forbidden (no copper placed; still an obstacle),
+    # otherwise a multiplier in [1.0, 1000].
     for i, cost in enumerate(layer_costs):
-        if cost < 1.0 or cost > 1000:
+        if cost != FORBIDDEN_LAYER_COST and (cost < 1.0 or cost > 1000):
             layer_name = layers[i] if i < len(layers) else f"layer {i}"
             from routing_exceptions import ConfigurationError
-            raise ConfigurationError(f"Layer cost for {layer_name} must be between 1.0 and 1000, got {cost}")
+            raise ConfigurationError(f"Layer cost for {layer_name} must be -1 (forbidden) or "
+                                     f"between 1.0 and 1000, got {cost}")
 
     costs_str = ', '.join(f"{layers[i]}={layer_costs[i]}x" for i in range(min(len(layers), len(layer_costs))))
     print(f"  Layer costs: {costs_str}")
@@ -1331,8 +1333,11 @@ For differential pair routing, use route_diff.py:
 
     # Layer preference options
     parser.add_argument("--layer-costs", nargs="+", type=float, default=[],
-                        help="Per-layer cost multipliers (1.0-1000, default: F.Cu=1.0, others=3.0). "
-                             "Order matches --layers. Example: --layer-costs 1.0 5.0")
+                        help="Per-layer cost multipliers (1.0-1000, default: F.Cu=1.0, others=3.0), "
+                             "or -1 = FORBIDDEN: the layer stays an obstacle (its copper blocks vias) "
+                             "and through-vias may span it, but NO track copper is placed on it. "
+                             "Order matches --layers. Example (route only F.Cu/B.Cu, In1/In2 obstacle-"
+                             "only): --layers F.Cu In1.Cu In2.Cu B.Cu --layer-costs 1.0 -1 -1 3.0")
 
     # Debug options
     parser.add_argument("--debug-lines", action="store_true",

--- a/route_diff.py
+++ b/route_diff.py
@@ -220,11 +220,13 @@ def batch_route_diff_pairs(input_file: str, output_file: str, net_names: List[st
     # --layer-costs is given; unlike route.py there is no 2-layer F.Cu/B.Cu default.
     if not layer_costs:
         layer_costs = [1.0] * len(layers)
+    from routing_constants import FORBIDDEN_LAYER_COST
     for i, cost in enumerate(layer_costs):
-        if cost < 1.0 or cost > 1000:
+        if cost != FORBIDDEN_LAYER_COST and (cost < 1.0 or cost > 1000):
             from routing_exceptions import ConfigurationError
             layer_name = layers[i] if i < len(layers) else f"layer {i}"
-            raise ConfigurationError(f"Layer cost for {layer_name} must be between 1.0 and 1000, got {cost}")
+            raise ConfigurationError(f"Layer cost for {layer_name} must be -1 (forbidden) or "
+                                     f"between 1.0 and 1000, got {cost}")
     if any(c != 1.0 for c in layer_costs):
         costs_str = ', '.join(f"{layers[i]}={layer_costs[i]}x" for i in range(min(len(layers), len(layer_costs))))
         print(f"  Layer costs: {costs_str}")
@@ -970,8 +972,9 @@ Examples:
                         default=['F.Cu', 'B.Cu'],
                         help="Routing layers to use (default: F.Cu B.Cu)")
     parser.add_argument("--layer-costs", nargs="+", type=float, default=None,
-                        help="Per-layer cost multipliers (1.0-1000), one per --layers entry, "
-                             "to bias which layer(s) coupled diff pairs prefer (e.g. '1 1 1 3' "
+                        help="Per-layer cost multipliers (1.0-1000, or -1 = forbidden: the layer is "
+                             "an obstacle / via span but carries no routed copper), one per --layers "
+                             "entry, to bias which layer(s) coupled diff pairs prefer (e.g. '1 1 1 3' "
                              "to discourage the 4th layer). Default: 1.0 on every layer "
                              "(behavior unchanged). Matches route.py / route_planes.")
 

--- a/route_planes.py
+++ b/route_planes.py
@@ -1772,11 +1772,14 @@ def create_plane(
         else:
             layer_costs = [1.0 if layer == 'F.Cu' else 3.0 for layer in all_layers]
 
-    # Validate layer costs are in range [1.0, 1000]
+    # Validate layer costs: -1 = forbidden (no copper placed; still an obstacle),
+    # otherwise a multiplier in [1.0, 1000].
+    from routing_constants import FORBIDDEN_LAYER_COST
     for i, cost in enumerate(layer_costs):
-        if cost < 1.0 or cost > 1000:
+        if cost != FORBIDDEN_LAYER_COST and (cost < 1.0 or cost > 1000):
             layer_name = all_layers[i] if i < len(all_layers) else f"layer {i}"
-            print(f"ERROR: Layer cost for {layer_name} must be between 1.0 and 1000, got {cost}")
+            print(f"ERROR: Layer cost for {layer_name} must be -1 (forbidden) or "
+                  f"between 1.0 and 1000, got {cost}")
             return (0, 0, 0)
 
     costs_str = ', '.join(f"{all_layers[i]}={layer_costs[i]}x" for i in range(min(len(all_layers), len(layer_costs))))
@@ -2575,8 +2578,9 @@ Examples:
     parser.add_argument("--layers", "-l", nargs="+", default=None,
                         help="All copper layers for routing and via span (default: F.Cu + plane-layers + B.Cu)")
     parser.add_argument("--layer-costs", nargs="+", type=float, default=[],
-                        help="Per-layer routing cost multipliers (1.0-1000). "
-                             "Order matches --layers. Example: --layer-costs 1.0 3.0 3.0 3.0")
+                        help="Per-layer routing cost multipliers (1.0-1000, or -1 = forbidden: "
+                             "the layer stays an obstacle / via span but gets no routed copper). "
+                             "Order matches --layers. Example: --layer-costs 1.0 -1 -1 3.0")
 
     # Blocker rip-up options
     parser.add_argument("--rip-blocker-nets", action="store_true",

--- a/routing_config.py
+++ b/routing_config.py
@@ -6,6 +6,8 @@ import math
 from typing import List, Optional, Tuple, Dict
 from dataclasses import dataclass, field
 
+from routing_constants import FORBIDDEN_LAYER_COST
+
 # Cost knobs (proximity costs, via_cost, attraction bonuses) are calibrated at
 # this grid step: GridRouteConfig.cell_cost / via_cost_units scale them so the
 # cost per mm of path is the same at any --grid-step, and identical to
@@ -181,12 +183,21 @@ class GridRouteConfig:
 
         Returns costs scaled by 1000 (1000 = 1.0x, 1500 = 1.5x penalty).
         If layer_costs is empty or shorter than layers list, uses 1000 (1.0x) for missing layers.
+        A cost of -1 (FORBIDDEN_LAYER_COST) is emitted VERBATIM (not scaled): the Rust
+        router skips track placement on any layer whose cost is negative, while the layer
+        stays an obstacle and through-vias may span it.
         """
         layer_costs = self.layer_costs or []  # may be None when set explicitly
         costs = []
         for i in range(len(self.layers)):
             if i < len(layer_costs):
-                costs.append(int(layer_costs[i] * 1000))
+                cost = layer_costs[i]
+                if cost == FORBIDDEN_LAYER_COST:
+                    # Forbidden: pass the sentinel through UNSCALED (do NOT do
+                    # int(-1 * 1000) -> -1000, which Rust would read as a discount).
+                    costs.append(FORBIDDEN_LAYER_COST)
+                else:
+                    costs.append(int(cost * 1000))
             else:
                 costs.append(1000)  # Default 1.0x
         return costs

--- a/routing_constants.py
+++ b/routing_constants.py
@@ -7,6 +7,13 @@ Centralizes magic numbers and default values for consistency.
 # Default layer stack for 4-layer boards
 DEFAULT_4_LAYER_STACK = ['F.Cu', 'In1.Cu', 'In2.Cu', 'B.Cu']
 
+# --layer-costs sentinel: the layer is included in --layers (full obstacle
+# awareness; foreign copper on it blocks via barrels, and through-vias may span
+# it) but the router places NO track copper on it. Emitted verbatim into the
+# i32 layer_costs vector; the Rust router treats any negative layer cost as
+# "forbidden" (canonical value -1). NOT scaled by 1000.
+FORBIDDEN_LAYER_COST = -1
+
 # Power net detection patterns (used for auto-exclusion from component routing)
 POWER_NET_EXCLUSION_PATTERNS = [
     '*GND*', '*VCC*', '*VDD*', '+*V', '-*V', 'unconnected-*', ''

--- a/rust_router/src/pose_router.rs
+++ b/rust_router/src/pose_router.rs
@@ -166,12 +166,12 @@ impl PoseRouter {
             let nx = current.gx + dx;
             let ny = current.gy + dy;
 
-            if !obstacles.is_blocked(nx, ny, current.layer as usize) {
+            if !self.layer_forbidden(current.layer as usize) && !obstacles.is_blocked(nx, ny, current.layer as usize) {  // G2: no track on a forbidden source layer
                 let neighbor = PoseState::new(nx, ny, current.theta_idx, current.layer);
                 let neighbor_key = neighbor.as_key();
 
                 if !closed.contains(&neighbor_key) {
-                    let move_cost = ((if dx != 0 && dy != 0 { DIAG_COST } else { ORTHO_COST }) as i64 * self.layer_costs.get(current.layer as usize).copied().unwrap_or(1000) as i64 / 1000) as i32;  // layer-cost scaled (issue #193; default 1.0x)
+                    let move_cost = ((if dx != 0 && dy != 0 { DIAG_COST } else { ORTHO_COST }) as i64 * self.layer_cost_or_default(current.layer as usize) as i64 / 1000) as i32;  // layer-cost scaled (issue #193; default 1.0x)
                     let proximity_cost = obstacles.get_stub_proximity_cost(nx, ny)
                         + obstacles.get_layer_proximity_cost(nx, ny, current.layer as usize);
                     let attraction_bonus = obstacles.get_cross_layer_attraction(
@@ -211,7 +211,7 @@ impl PoseRouter {
             // - First move from start must be straight in src_theta direction
             // - After a via, must go straight for 2 steps (no turns)
             // - For diff pairs, limit cumulative turn to prevent loops
-            if current_key != start_key && current_straight_remaining <= 0 {
+            if !self.layer_forbidden(current.layer as usize) && current_key != start_key && current_straight_remaining <= 0 {  // G2: no turns on a forbidden source layer
                 for delta in [-1i8, 1i8] {
                     let new_steps = current_steps + 1;
                     // Calculate new turn values, resetting at respective intervals
@@ -228,13 +228,13 @@ impl PoseRouter {
                     let nx = current.gx + dx;
                     let ny = current.gy + dy;
 
-                    if !obstacles.is_blocked(nx, ny, current.layer as usize) {
+                    if !self.layer_forbidden(current.layer as usize) && !obstacles.is_blocked(nx, ny, current.layer as usize) {  // G2: no track on a forbidden source layer
                         let neighbor = PoseState::new(nx, ny, new_theta, current.layer);
                         let neighbor_key = neighbor.as_key();
 
                         if !closed.contains(&neighbor_key) {
                             // Cost = movement + turn arc cost
-                            let move_cost = ((if dx != 0 && dy != 0 { DIAG_COST } else { ORTHO_COST }) as i64 * self.layer_costs.get(current.layer as usize).copied().unwrap_or(1000) as i64 / 1000) as i32;  // layer-cost scaled (issue #193; default 1.0x)
+                            let move_cost = ((if dx != 0 && dy != 0 { DIAG_COST } else { ORTHO_COST }) as i64 * self.layer_cost_or_default(current.layer as usize) as i64 / 1000) as i32;  // layer-cost scaled (issue #193; default 1.0x)
                             let proximity_cost = obstacles.get_stub_proximity_cost(nx, ny)
                                 + obstacles.get_layer_proximity_cost(nx, ny, current.layer as usize);
                             let attraction_bonus = obstacles.get_cross_layer_attraction(
@@ -357,6 +357,9 @@ impl PoseRouter {
                     if layer == current.layer {
                         continue;
                     }
+                    if self.layer_forbidden(layer as usize) {
+                        continue;  // FORBIDDEN LAYER: never end a via here
+                    }
 
                     if obstacles.is_blocked(current.gx, current.gy, layer as usize) {
                         continue;
@@ -373,8 +376,8 @@ impl PoseRouter {
                             self.via_cost
                         };
                         // Layer transition: penalize a via INTO a costlier layer, discount into a cheaper one (issue #193)
-                        let layer_transition = self.layer_costs.get(layer as usize).copied().unwrap_or(1000)
-                            - self.layer_costs.get(current.layer as usize).copied().unwrap_or(1000);
+                        let layer_transition = self.layer_cost_or_default(layer as usize)
+                            - self.layer_cost_or_default(current.layer as usize);
                         let new_g = g + (via_cost + layer_transition).max(0);
 
                         let existing_g = g_costs.get(&neighbor_key).copied().unwrap_or(i32::MAX);
@@ -478,14 +481,14 @@ impl PoseRouter {
             let nx = current.gx + dx;
             let ny = current.gy + dy;
 
-            if obstacles.is_blocked(nx, ny, current.layer as usize) {
+            if self.layer_forbidden(current.layer as usize) || obstacles.is_blocked(nx, ny, current.layer as usize) {  // G2: no track on a forbidden source layer
                 tracker.track(nx, ny, current.layer);
             } else {
                 let neighbor = PoseState::new(nx, ny, current.theta_idx, current.layer);
                 let neighbor_key = neighbor.as_key();
 
                 if !closed.contains(&neighbor_key) {
-                    let move_cost = ((if dx != 0 && dy != 0 { DIAG_COST } else { ORTHO_COST }) as i64 * self.layer_costs.get(current.layer as usize).copied().unwrap_or(1000) as i64 / 1000) as i32;  // layer-cost scaled (issue #193; default 1.0x)
+                    let move_cost = ((if dx != 0 && dy != 0 { DIAG_COST } else { ORTHO_COST }) as i64 * self.layer_cost_or_default(current.layer as usize) as i64 / 1000) as i32;  // layer-cost scaled (issue #193; default 1.0x)
                     let proximity_cost = obstacles.get_stub_proximity_cost(nx, ny)
                         + obstacles.get_layer_proximity_cost(nx, ny, current.layer as usize);
                     let attraction_bonus = obstacles.get_cross_layer_attraction(
@@ -513,7 +516,7 @@ impl PoseRouter {
             }
 
             // 2. Move + turn by ±45°
-            if current_key != start_key && current_straight_remaining <= 0 {
+            if !self.layer_forbidden(current.layer as usize) && current_key != start_key && current_straight_remaining <= 0 {  // G2: no turns on a forbidden source layer
                 for delta in [-1i8, 1i8] {
                     let new_steps = current_steps + 1;
                     let new_turn_1 = if new_steps % 100 == 0 { delta as i32 } else { current_turn_1 + delta as i32 };
@@ -529,7 +532,7 @@ impl PoseRouter {
                     let nx = current.gx + dx;
                     let ny = current.gy + dy;
 
-                    if obstacles.is_blocked(nx, ny, current.layer as usize) {
+                    if self.layer_forbidden(current.layer as usize) || obstacles.is_blocked(nx, ny, current.layer as usize) {  // G2: no track on a forbidden source layer
                         tracker.track(nx, ny, current.layer);
                         continue;
                     }
@@ -538,7 +541,7 @@ impl PoseRouter {
                     let neighbor_key = neighbor.as_key();
 
                     if !closed.contains(&neighbor_key) {
-                        let move_cost = ((if dx != 0 && dy != 0 { DIAG_COST } else { ORTHO_COST }) as i64 * self.layer_costs.get(current.layer as usize).copied().unwrap_or(1000) as i64 / 1000) as i32;  // layer-cost scaled (issue #193; default 1.0x)
+                        let move_cost = ((if dx != 0 && dy != 0 { DIAG_COST } else { ORTHO_COST }) as i64 * self.layer_cost_or_default(current.layer as usize) as i64 / 1000) as i32;  // layer-cost scaled (issue #193; default 1.0x)
                         let proximity_cost = obstacles.get_stub_proximity_cost(nx, ny)
                             + obstacles.get_layer_proximity_cost(nx, ny, current.layer as usize);
                         let attraction_bonus = obstacles.get_cross_layer_attraction(
@@ -660,6 +663,7 @@ impl PoseRouter {
             if can_place_via && via_positions_clear {
                 for layer in 0..obstacles.num_layers as u8 {
                     if layer == current.layer { continue; }
+                    if self.layer_forbidden(layer as usize) { continue; }  // FORBIDDEN LAYER: never end a via here
 
                     if obstacles.is_blocked(current.gx, current.gy, layer as usize) {
                         tracker.track(current.gx, current.gy, layer);
@@ -677,8 +681,8 @@ impl PoseRouter {
                             self.via_cost
                         };
                         // Layer transition: penalize a via INTO a costlier layer, discount into a cheaper one (issue #193)
-                        let layer_transition = self.layer_costs.get(layer as usize).copied().unwrap_or(1000)
-                            - self.layer_costs.get(current.layer as usize).copied().unwrap_or(1000);
+                        let layer_transition = self.layer_cost_or_default(layer as usize)
+                            - self.layer_cost_or_default(current.layer as usize);
                         let new_g = g + (via_cost + layer_transition).max(0);
 
                         let existing_g = g_costs.get(&neighbor_key).copied().unwrap_or(i32::MAX);
@@ -701,6 +705,24 @@ impl PoseRouter {
 }
 
 impl PoseRouter {
+    /// FORBIDDEN LAYER (`--layer-costs -1` => a negative entry in `layer_costs`):
+    /// the router never places a track on, nor ends a via on, such a layer. It
+    /// still acts as an obstacle and through-vias may SPAN it.
+    #[inline]
+    fn layer_forbidden(&self, layer: usize) -> bool {
+        self.layer_costs.get(layer).map_or(false, |&c| c < 0)
+    }
+
+    /// Cost for arithmetic; forbidden/missing folds to neutral 1.0x (1000) so the
+    /// sentinel can never leak into a subtraction.
+    #[inline]
+    fn layer_cost_or_default(&self, layer: usize) -> i32 {
+        match self.layer_costs.get(layer).copied() {
+            Some(c) if c >= 0 => c,
+            _ => 1000,
+        }
+    }
+
     /// Dubins heuristic: estimate shortest path considering orientation
     fn dubins_heuristic(&self, dubins: &DubinsCalculator, state: &PoseState, goal: &PoseState) -> i32 {
         let theta1 = state.theta_radians();

--- a/rust_router/src/router.rs
+++ b/rust_router/src/router.rs
@@ -246,14 +246,16 @@ impl GridRouter {
 
 
         // Find minimum layer cost for initial g penalty
-        let min_layer_cost = self.layer_costs.iter().copied().min().unwrap_or(1000);
+        // A1: exclude FORBIDDEN sentinels (< 0) — else min() returns the sentinel
+        // and pollutes the start penalty + the admissibility-scaled heuristic.
+        let min_layer_cost = self.layer_costs.iter().copied().filter(|&c| c >= 0).min().unwrap_or(1000);
         let mut best_initial_h = i32::MAX;
 
         for (gx, gy, layer) in sources {
             let state = GridState::new(gx, gy, layer);
             let key = state.as_key();
             // Penalize starting on expensive layers
-            let layer_cost = self.layer_costs.get(layer as usize).copied().unwrap_or(1000);
+            let layer_cost = self.layer_cost_or_default(layer as usize);
             let initial_g = layer_cost - min_layer_cost;
             let h = self.heuristic_to_targets(&state, &target_states);
             best_initial_h = best_initial_h.min(h);
@@ -378,6 +380,7 @@ impl GridRouter {
 
             // Expand neighbors - 8 directions
             for (dx, dy) in DIRECTIONS {
+                if self.layer_forbidden(current.layer as usize) { break; }  // G2: no track on a forbidden source layer
                 // If we have a required exact direction (just came through via), only allow that direction
                 if let Some((req_dx, req_dy)) = required_direction {
                     if dx != req_dx || dy != req_dy {
@@ -421,7 +424,7 @@ impl GridRouter {
 
                 let base_move_cost = if dx != 0 && dy != 0 { DIAG_COST } else { ORTHO_COST };
                 // Apply layer cost multiplier (1000 = 1.0x, 1500 = 1.5x, etc.)
-                let layer_multiplier = self.layer_costs.get(current.layer as usize).copied().unwrap_or(1000);
+                let layer_multiplier = self.layer_cost_or_default(current.layer as usize);
                 let move_cost = (base_move_cost as i64 * layer_multiplier as i64 / 1000) as i32;
                 // Add turn cost if direction changes (encourages straighter paths)
                 let turn_cost = match prev_direction {
@@ -546,6 +549,9 @@ impl GridRouter {
                     if layer == current.layer {
                         continue;
                     }
+                    if self.layer_forbidden(layer as usize) {
+                        continue;  // FORBIDDEN LAYER: never end a via here
+                    }
 
                     // Check if destination layer is blocked at this position
                     if obstacles.segment_blocked(current.gx, current.gy, current.gx, current.gy, layer as usize, track_margin as f64) {
@@ -566,8 +572,8 @@ impl GridRouter {
                         + obstacles.get_layer_proximity_cost(current.gx, current.gy, layer as usize))
                         * self.via_proximity_cost;
                     // Layer transition cost: penalize switching TO expensive layers, discount switching to cheaper
-                    let current_layer_cost = self.layer_costs.get(current.layer as usize).copied().unwrap_or(1000);
-                    let dest_layer_cost = self.layer_costs.get(layer as usize).copied().unwrap_or(1000);
+                    let current_layer_cost = self.layer_cost_or_default(current.layer as usize);
+                    let dest_layer_cost = self.layer_cost_or_default(layer as usize);
                     let layer_transition_cost = dest_layer_cost - current_layer_cost;
                     // Combined via cost can be as low as 0 when switching to a much cheaper layer
                     let combined_via_cost = (via_cost + layer_transition_cost).max(0);
@@ -689,13 +695,15 @@ impl GridRouter {
         };
 
         // Find minimum layer cost for initial g penalty
-        let min_layer_cost = self.layer_costs.iter().copied().min().unwrap_or(1000);
+        // A1: exclude FORBIDDEN sentinels (< 0) — else min() returns the sentinel
+        // and pollutes the start penalty + the admissibility-scaled heuristic.
+        let min_layer_cost = self.layer_costs.iter().copied().filter(|&c| c >= 0).min().unwrap_or(1000);
 
         for (gx, gy, layer) in sources {
             let state = GridState::new(gx, gy, layer);
             let key = state.as_key();
             // Penalize starting on expensive layers
-            let layer_cost = self.layer_costs.get(layer as usize).copied().unwrap_or(1000);
+            let layer_cost = self.layer_cost_or_default(layer as usize);
             let initial_g = layer_cost - min_layer_cost;
             let h = self.heuristic_to_targets(&state, &target_states);
             open_set.push(OpenEntry { f_score: initial_g + h, g_score: initial_g, state, counter });
@@ -759,6 +767,7 @@ impl GridRouter {
             });
 
             for (dx, dy) in DIRECTIONS {
+                if self.layer_forbidden(current.layer as usize) { break; }  // G2: no track on a forbidden source layer
                 if let Some((req_dx, req_dy)) = required_direction {
                     if dx != req_dx || dy != req_dy { continue; }
                 } else if let Some((base_dx, base_dy)) = allowed_45deg_from {
@@ -790,7 +799,7 @@ impl GridRouter {
 
                 let base_move_cost = if dx != 0 && dy != 0 { DIAG_COST } else { ORTHO_COST };
                 // Apply layer cost multiplier (1000 = 1.0x, 1500 = 1.5x, etc.)
-                let layer_multiplier = self.layer_costs.get(current.layer as usize).copied().unwrap_or(1000);
+                let layer_multiplier = self.layer_cost_or_default(current.layer as usize);
                 let move_cost = (base_move_cost as i64 * layer_multiplier as i64 / 1000) as i32;
                 let turn_cost = match prev_direction {
                     Some((pdx, pdy)) if pdx != 0 || pdy != 0 => {
@@ -872,6 +881,7 @@ impl GridRouter {
                 && (!obstacles.is_via_blocked(current.gx, current.gy) || free_here) {
                 for layer in 0..obstacles.num_layers as u8 {
                     if layer == current.layer { continue; }
+                    if self.layer_forbidden(layer as usize) { continue; }  // FORBIDDEN LAYER: never end a via here
 
                     if obstacles.segment_blocked(current.gx, current.gy, current.gx, current.gy, layer as usize, track_margin as f64) {
                         tracker.track(current.gx, current.gy, layer);
@@ -890,8 +900,8 @@ impl GridRouter {
                         + obstacles.get_layer_proximity_cost(current.gx, current.gy, layer as usize))
                         * self.via_proximity_cost;
                     // Layer transition cost: penalize switching TO expensive layers, discount switching to cheaper
-                    let current_layer_cost = self.layer_costs.get(current.layer as usize).copied().unwrap_or(1000);
-                    let dest_layer_cost = self.layer_costs.get(layer as usize).copied().unwrap_or(1000);
+                    let current_layer_cost = self.layer_cost_or_default(current.layer as usize);
+                    let dest_layer_cost = self.layer_cost_or_default(layer as usize);
                     let layer_transition_cost = dest_layer_cost - current_layer_cost;
                     // Combined via cost can be as low as 0 when switching to a much cheaper layer
                     let combined_via_cost = (via_cost + layer_transition_cost).max(0);
@@ -925,12 +935,33 @@ impl GridRouter {
 }
 
 impl GridRouter {
+    /// FORBIDDEN LAYER (`--layer-costs -1` => a negative entry in `layer_costs`):
+    /// the router never places a track on, nor ends a via on, such a layer. It
+    /// still acts as an obstacle (its copper blocks via barrels) and through-vias
+    /// may SPAN it (a via is one direct edge to its target layer).
+    #[inline]
+    fn layer_forbidden(&self, layer: usize) -> bool {
+        self.layer_costs.get(layer).map_or(false, |&c| c < 0)
+    }
+
+    /// Cost to use in arithmetic; a forbidden/missing layer folds to the neutral
+    /// 1.0x (1000) so the sentinel can never leak into a subtraction/multiply.
+    #[inline]
+    fn layer_cost_or_default(&self, layer: usize) -> i32 {
+        match self.layer_costs.get(layer).copied() {
+            Some(c) if c >= 0 => c,
+            _ => 1000,
+        }
+    }
+
     /// Octile distance heuristic to nearest target
     /// Uses minimum layer cost to remain admissible (never overestimate)
     #[inline]
     fn heuristic_to_targets(&self, state: &GridState, targets: &[GridState]) -> i32 {
         // Use minimum layer cost for admissibility
-        let min_layer_cost = self.layer_costs.iter().copied().min().unwrap_or(1000);
+        // A1: exclude FORBIDDEN sentinels (< 0) — else min() returns the sentinel
+        // and pollutes the start penalty + the admissibility-scaled heuristic.
+        let min_layer_cost = self.layer_costs.iter().copied().filter(|&c| c >= 0).min().unwrap_or(1000);
 
         let mut min_h = i32::MAX;
         for target in targets {

--- a/tests/test_forbidden_layer_grid.py
+++ b/tests/test_forbidden_layer_grid.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""GridRouter FORBIDDEN LAYER (`--layer-costs -1` => a negative entry in the i32
+layer_costs vector). The router must never place a track on, nor end a via on, a
+forbidden layer; the layer still acts as an obstacle and through-vias may SPAN it.
+
+  - BAN: with the source layer made costly, the route would normally via onto the
+    cheaper layer; forbidding that layer keeps the route on the costly source layer
+    (control proves the bias WOULD have used it). A high cost alone is only a soft
+    avoid -- the ban must be hard.
+  - SPAN: a source on layer 0 / target on layer 2 routes via a single 0->2
+    through-via that SPANS the forbidden middle layer 1 (no node ever on layer 1) --
+    identical to the non-forbidden case, because a via is one direct edge.
+  - CLEAN FAIL: a target ON a forbidden layer is unreachable (no via may land there)
+    and the router returns no path rather than silently ending on it.
+
+    python3 tests/test_forbidden_layer_grid.py        # needs the built grid_router
+"""
+import os
+import sys
+from collections import Counter
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "rust_router"))
+import grid_router  # noqa: E402
+
+FORBIDDEN = -1
+
+
+def _route(layer_costs, n_layers, src, tgt):
+    obs = grid_router.GridObstacleMap(n_layers)  # fully open
+    r = grid_router.GridRouter(via_cost=500, h_weight=1.0, turn_cost=10, layer_costs=layer_costs)
+    path, _iters, _stats = r.route_multi(obs, [src], [tgt], 2_000_000, False, 0, None, None, 0, 0)
+    return path
+
+
+def run():
+    fails = []
+
+    # CONTROL: layer 0 costly, layer 1 cheap+ALLOWED -> the route SHOULD via to layer 1.
+    ctrl = _route([50000, 1000], 2, (2, 2, 0), (60, 2, 0))
+    ctrl_layers = Counter(p[2] for p in ctrl) if ctrl else {}
+    if not ctrl or ctrl_layers.get(1, 0) <= 0:
+        fails.append(f"control: costly layer 0 should via to the cheaper layer 1, got {dict(ctrl_layers)}")
+
+    # BAN: same bias, but layer 1 FORBIDDEN -> the route must stay on layer 0 (hard ban,
+    # not just discouraged). Zero nodes on layer 1.
+    banned = _route([50000, FORBIDDEN], 2, (2, 2, 0), (60, 2, 0))
+    if not banned:
+        fails.append("ban: route failed (should complete on the costly-but-allowed layer 0)")
+    else:
+        layers = Counter(p[2] for p in banned)
+        if 1 in layers:
+            fails.append(f"ban: forbidden layer 1 carries {layers[1]} node(s) (must be 0): {dict(layers)}")
+
+    # SPAN: source layer 0, target layer 2, middle layer 1 FORBIDDEN -> one 0->2 through-via
+    # spans layer 1. Must match the non-forbidden route exactly (the via never touches layer 1).
+    span = _route([1000, FORBIDDEN, 1000], 3, (2, 2, 0), (60, 2, 2))
+    span_ref = _route([1000, 1000, 1000], 3, (2, 2, 0), (60, 2, 2))
+    if not span:
+        fails.append("span: route 0->2 failed across a forbidden middle layer")
+    else:
+        layers = set(p[2] for p in span)
+        if 1 in layers:
+            fails.append(f"span: forbidden middle layer 1 was used: {sorted(layers)}")
+        if 2 not in layers:
+            fails.append(f"span: route never reached the layer-2 target: {sorted(layers)}")
+        if span_ref and Counter(p[2] for p in span) != Counter(p[2] for p in span_ref):
+            fails.append("span: forbidding the (unused) middle layer changed the route")
+
+    # CLEAN FAIL: target ON a forbidden layer -> unreachable (no via lands on it) -> no path.
+    stuck = _route([1000, FORBIDDEN], 2, (2, 2, 0), (60, 2, 1))
+    if stuck:
+        fails.append(f"clean-fail: a route ended on the forbidden target layer: {Counter(p[2] for p in stuck)}")
+
+    if fails:
+        print("FAIL:")
+        for f in fails:
+            print("  -", f)
+        return False
+    print("PASS: hard ban (zero copper on the forbidden layer), through-via spans it, "
+          "forbidden target is unreachable")
+    return True
+
+
+if __name__ == "__main__":
+    sys.exit(0 if run() else 1)

--- a/tests/test_forbidden_layer_pose.py
+++ b/tests/test_forbidden_layer_pose.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""PoseRouter FORBIDDEN LAYER (`--layer-costs -1` => a negative entry in the i32
+layer_costs vector). The router must never place a track on, nor end a via on, a
+forbidden layer; the layer still acts as an obstacle and through-vias may SPAN it.
+
+  - BAN: with the cheaper escape layer forbidden, the route stays on the costly
+    source layer rather than v-ing onto the forbidden one (control proves the bias
+    WOULD have used it).
+  - CLEAN FAIL: a source placed on a forbidden layer cannot lay track (G2) and
+    returns no path rather than silently routing on it.
+
+(The through-via SPAN over a forbidden middle layer is covered by
+ test_forbidden_layer_grid.py -- the PoseRouter does not route a goal two layers
+ away in an open map, so a 0->2 span is not exercisable here.)
+
+    python3 tests/test_forbidden_layer_pose.py        # needs the built grid_router
+"""
+import os
+import sys
+from collections import Counter
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "rust_router"))
+import grid_router  # noqa: E402
+
+FORBIDDEN = -1
+
+
+def _pr(layer_costs):
+    return grid_router.PoseRouter(
+        via_cost=500, h_weight=1.0, turn_cost=10, min_radius_grid=2.0,
+        via_proximity_cost=10, diff_pair_spacing=0, max_turn_units=4,
+        layer_costs=layer_costs,
+    )
+
+
+def _route(layer_costs, n_layers, start_layer, goal_layer):
+    obs = grid_router.GridObstacleMap(n_layers)  # fully open
+    pr = _pr(layer_costs)
+    path, _i, _b, _g = pr.route_pose_with_frontier(
+        obs, 2, 2, 0, start_layer, 60, 2, 0, goal_layer, 2_000_000, None)
+    return path
+
+
+def run():
+    fails = []
+
+    # CONTROL: layer 0 costly, layer 1 cheap+ALLOWED -> the route SHOULD via to layer 1.
+    ctrl = _route([50000, 1000], 2, 0, 0)
+    ctrl_layers = Counter(p[3] for p in ctrl) if ctrl else {}
+    if not ctrl or ctrl_layers.get(1, 0) <= 0:
+        fails.append(f"control: costly layer 0 should via to the cheaper layer 1, got {dict(ctrl_layers)}")
+
+    # BAN: same bias, but layer 1 FORBIDDEN -> the route must stay on layer 0.
+    banned = _route([50000, FORBIDDEN], 2, 0, 0)
+    if not banned:
+        fails.append("ban: route failed (should complete on the costly-but-allowed layer 0)")
+    else:
+        layers = Counter(p[3] for p in banned)
+        if 1 in layers:
+            fails.append(f"ban: forbidden layer 1 carries {layers[1]} node(s) (must be 0): {dict(layers)}")
+
+    # CLEAN FAIL: source ON a forbidden layer (1) -> PoseRouter cannot lay track (G2) and
+    # cannot gather the straight steps to via off -> returns no path (no copper on layer 1).
+    stuck = _route([1000, FORBIDDEN, 1000], 3, 1, 0)
+    if stuck and any(p[3] == 1 for p in stuck):
+        fails.append(f"clean-fail: a forbidden source laid track on layer 1: {Counter(p[3] for p in stuck)}")
+
+    if fails:
+        print("FAIL:")
+        for f in fails:
+            print("  -", f)
+        return False
+    print("PASS: forbidden layer carries no track, and a forbidden source lays no copper")
+    return True
+
+
+if __name__ == "__main__":
+    sys.exit(0 if run() else 1)


### PR DESCRIPTION
## What

Adds a forbidden-layer mode to `--layer-costs`: a value of **`-1`** for a layer means *"keep this layer in the obstacle map (its copper blocks via barrels, and through-vias may span it) but place **no routed track copper** on it."* Any other value keeps the existing `[1.0, 1000]` cost-multiplier meaning.

This re-scopes the PR to the approach you suggested on #206 (thanks for the steer). Intended usage — pass **all** board copper layers in `--layers` for full obstacle awareness, and forbid the inner ones via cost:

```
--layers F.Cu In1.Cu In2.Cu B.Cu --layer-costs 1.0 -1 -1 3.0
```

Tracks route only on F.Cu/B.Cu; In1/In2 stay obstacles and via spans.

## Why this supersedes the original obstacle-map patch

The first version of this PR added `add_intermediate_copper_via_obstacles` to make a **subset**-layer route safe. As you noted, passing **every** layer in `--layers` already makes `build_base_obstacle_map` rasterize all copper (including the global via keep-out), so a through-via barrel can't short an inner trace — the same #206 protection, natively. The special-case becomes redundant (its `inter = copper_layers - layers` set is empty when all layers are passed), so this PR drops it and solves #206 through the layer-cost mechanism instead.

## Why a Rust change, not just a high cost

The move-cost path is unclamped, so a large *positive* cost is only a **soft** avoid — A* still routes onto the layer when cornered. A hard "never place copper here" needs the successor skipped:

- **`rust_router/router.rs` + `pose_router.rs`** — skip any A* successor that would end a via on (G1) or lateral-move/turn on (G2) a layer whose cost `< 0`. A via is one direct edge to its target layer, so through-vias keep **spanning** a forbidden middle layer for free.
- Sanitize the sentinel out of `min_layer_cost` (start penalty + admissibility heuristic) and the via layer-transition delta, so a negative cost can never underflow the cost math. Applied across `route_multi`/`route_with_frontier` and `route_pose`/`route_pose_with_frontier`.

## Python

- `routing_constants.FORBIDDEN_LAYER_COST = -1`.
- `routing_config.get_layer_costs()` emits `-1` **verbatim** (not `int(-1*1000) = -1000`, which the engine would read as a *discount*).
- `route.py` / `route_diff.py` / `route_planes.py`: `--layer-costs` validation accepts `-1`; `--help` updated.

## Tests

`tests/test_forbidden_layer_grid.py` + `tests/test_forbidden_layer_pose.py`: a hard ban (zero copper on the forbidden layer, where a control proves the cost bias *would* have used it), a through-via that spans the forbidden middle layer, and a forbidden target/source that is unreachable / lays no copper. Built from source (`build_router.py --from-source`) and run green; the existing `test_pose_layer_costs.py` (#193 biasing) still passes.

Verified end-to-end on a real barrel-vs-inner-copper repro (a F.Cu→B.Cu net whose via must clear a foreign trace on an inner layer): with `--layers F.Cu In1.Cu In2.Cu B.Cu --layer-costs 1.0 -1 -1 1.0` the via detours exactly to the clearance edge of the inner copper and no track lands on In1/In2; the old subset route drops the via straight onto the inner trace.

Fixes #206.
