### PR TITLE
feat(#196): end-to-end length matching for AC-coupled differential pairs

### DIFF
--- a/diff_xnet.py
+++ b/diff_xnet.py
@@ -1,0 +1,145 @@
+"""
+AC-coupled differential-pair (XNet) detection -- issue #196.
+
+A high-speed differential pair (PCIe / USB3 / SATA / ...) is commonly split into
+two separately-named pairs by series DC-blocking capacitors:
+
+    DPA_P --[C1]-- DPB_P        (the full P conductor: driver -> caps -> receiver)
+    DPA_N --[C2]-- DPB_N        (the full N conductor)
+
+``route_diff`` sees ``DPA_*`` and ``DPB_*`` as two independent pairs and
+length-matches each side's P/N on its own, so the end-to-end skew the receiver
+actually sees (the whole P path vs the whole N path) is never matched. This
+module detects that topology -- the industry "extended net" / XNet -- so the
+matcher can treat the concatenated P and N conductors as one length budget.
+
+Detection is a pure, side-effect-free read of the parsed board.
+"""
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple
+
+from kicad_parser import PCBData
+from routing_config import DiffPairNet
+
+
+@dataclass
+class AcCoupledXNet:
+    """A differential signal whose P and N conductors are each split across one
+    or more series 2-pad parts (DC-blocking caps), joining 2+ ``DiffPairNet``s
+    into one end-to-end pair.
+
+    Attributes:
+        members: the per-segment pairs that make up the chain (2 or more).
+        bridge_refs: component references of the series parts joining them.
+    """
+    members: List[DiffPairNet]
+    bridge_refs: List[str] = field(default_factory=list)
+
+    @property
+    def p_net_ids(self) -> List[int]:
+        return [m.p_net_id for m in self.members]
+
+    @property
+    def n_net_ids(self) -> List[int]:
+        return [m.n_net_id for m in self.members]
+
+    @property
+    def base_names(self) -> List[str]:
+        return [m.base_name for m in self.members]
+
+
+def find_ac_coupled_xnets(
+    pcb_data: PCBData,
+    diff_pairs: Dict[str, DiffPairNet],
+) -> Tuple[List[AcCoupledXNet], List[str]]:
+    """Detect AC-coupling XNets among already-detected ``diff_pairs``.
+
+    A junction between two pairs A and B is recognized only when BOTH polarities
+    are bridged by a distinct 2-pad, non-DNP part (``A.P<->B.P`` AND
+    ``A.N<->B.N``) -- the conservative, symmetric case that unambiguously
+    identifies one electrical signal split by series DC-blocking caps. A 2-pad
+    part with a pad on GND/power (a decoupling cap) is ignored automatically
+    because that pad's net is not a differential-pair member, and a no-pop (DNP)
+    part is ignored because it is an open circuit. Single-sided / asymmetric
+    junctions are skipped and reported as warnings, so the caller keeps today's
+    per-side behavior for them.
+
+    ``diff_pairs`` is the dict returned by ``find_differential_pairs``; its keys
+    are used as stable pair identifiers.
+
+    Returns ``(xnets, warnings)``. Pure read of ``pcb_data``; mutates nothing.
+    """
+    # Map every complete diff-pair member net -> (pair_key, 'P'|'N').
+    net_to_member: Dict[int, Tuple[str, str]] = {}
+    for pair_key, pair in diff_pairs.items():
+        if not pair.is_complete:
+            continue
+        net_to_member[pair.p_net_id] = (pair_key, 'P')
+        net_to_member[pair.n_net_id] = (pair_key, 'N')
+
+    # Per unordered pair-of-pairs, record which polarities are bridged by a 2-pad
+    # part: junctions[(keyX, keyY)] -> {'P': ref, 'N': ref}.
+    junctions: Dict[Tuple[str, str], Dict[str, str]] = {}
+    for ref, fp in pcb_data.footprints.items():
+        if fp.dnp or len(fp.pads) != 2:
+            continue
+        n1, n2 = fp.pads[0].net_id, fp.pads[1].net_id
+        if not n1 or not n2 or n1 == n2:
+            continue
+        m1, m2 = net_to_member.get(n1), net_to_member.get(n2)
+        if m1 is None or m2 is None:
+            continue  # a side is not a diff-pair net (e.g. GND/VCC decoupling cap)
+        (key1, pol1), (key2, pol2) = m1, m2
+        if key1 == key2 or pol1 != pol2:
+            continue  # within one pair, or a cross-polarity (swapped) bridge
+        jkey = (key1, key2) if key1 < key2 else (key2, key1)
+        junctions.setdefault(jkey, {})[pol1] = ref
+
+    # A coupling edge requires BOTH polarities bridged (symmetric); warn otherwise.
+    edges: List[Tuple[str, str, List[str]]] = []
+    warnings: List[str] = []
+    for (kx, ky), pols in junctions.items():
+        if 'P' in pols and 'N' in pols:
+            edges.append((kx, ky, [pols['P'], pols['N']]))
+        else:
+            only = next(iter(pols))
+            warnings.append(
+                f"AC-couple: pairs '{kx}' and '{ky}' are bridged on the {only} side "
+                f"only (via {pols[only]}); not treating as one signal "
+                f"(asymmetric coupling -- per-side matching kept)."
+            )
+
+    if not edges:
+        return [], warnings
+
+    # Union-find over pair keys connected by coupling edges -> XNet groups
+    # (handles chains of 2+ caps, e.g. A--B--C, as one group).
+    parent: Dict[str, str] = {}
+
+    def find(x: str) -> str:
+        parent.setdefault(x, x)
+        root = x
+        while parent[root] != root:
+            root = parent[root]
+        while parent[x] != root:
+            parent[x], x = root, parent[x]
+        return root
+
+    for kx, ky, _refs in edges:
+        parent[find(kx)] = find(ky)
+
+    group_keys: Dict[str, List[str]] = {}
+    group_refs: Dict[str, List[str]] = {}
+    for key in {k for e in edges for k in e[:2]}:
+        group_keys.setdefault(find(key), []).append(key)
+    for kx, ky, refs in edges:
+        group_refs.setdefault(find(kx), []).extend(refs)
+
+    xnets: List[AcCoupledXNet] = []
+    for root, keys in group_keys.items():
+        members = [diff_pairs[k] for k in sorted(keys) if k in diff_pairs]
+        if len(members) < 2:
+            continue
+        refs = sorted(set(group_refs.get(root, [])))
+        xnets.append(AcCoupledXNet(members=members, bridge_refs=refs))
+    return xnets, warnings

--- a/docs/api-routing-config.md
+++ b/docs/api-routing-config.md
@@ -96,6 +96,7 @@ automatically at other grid steps (see [cost scaling](#cost-scaling)).
 | `fix_polarity` | `True` | Allow P/N pad swap when polarity is crossed |
 | `gnd_via_enabled` | `True` | Place GND return vias next to diff-pair signal vias |
 | `diff_pair_intra_match` | `False` | Meander the shorter of P/N to match lengths within the pair |
+| `ac_couple_match` | `False` | End-to-end length-match AC-coupled pairs split by series caps: concatenated P vs N path (#196) |
 | `diff_chamfer_extra` | `1.5` | Meander chamfer multiplier for pairs (avoids P/N crossings) |
 
 ### Length / time matching

--- a/docs/length-matching.md
+++ b/docs/length-matching.md
@@ -24,6 +24,7 @@ For multi-point nets this happens between Phase 1 and Phase 3 of the MST-based a
 | `--time-matching` | false | Match propagation delay instead of physical length |
 | `--time-match-tolerance` | 1.0 | Acceptable delay variance within a group (ps) |
 | `--diff-pair-intra-match` | false | (`route_diff.py`) Match P and N lengths *within* each differential pair |
+| `--ac-couple-match` | false | (`route_diff.py`) End-to-end length-match AC-coupled pairs split by series DC-blocking caps (#196): match the concatenated P path vs N path across the caps |
 
 Examples:
 
@@ -102,6 +103,7 @@ Two forms of matching exist for differential pairs (`route_diff.py`):
 
 - **Group matching** — multiple pairs in a `--length-match-group` are matched pair-to-pair by meandering each pair's *centerline*; both P and N are regenerated from the modified centerline so the pair stays symmetric.
 - **Intra-pair matching** (`--diff-pair-intra-match`) — within one pair, meanders are added to the shorter of P/N to equalize them (`apply_intra_pair_length_matching()`). Bumps here are smaller (minimum amplitude 0.1mm) since they must fit between the pair and its surroundings; stub barrel lengths and polarity swaps are accounted for.
+- **End-to-end AC-coupled matching** (`--ac-couple-match`) — a pair split into two base-named pairs by series DC-blocking caps (the common PCIe/USB3/SATA TX case) is auto-detected as one *extended net* / XNet: a 2-pad cap bridging `A_P↔B_P` plus another bridging `A_N↔B_N`. Its concatenated P path (`A_P+B_P`) is matched against the concatenated N path (`A_N+B_N`) — the skew the receiver actually sees — with the compensating meander placed on whichever segment has room (`apply_ac_coupled_length_matching()`, sharing the meander engine with intra-pair via `_lengthen_net_with_meanders()`). This **supersedes** per-side intra-pair matching for the member pairs, reports the end-to-end skew in the JSON summary (`ac_coupled_xnets`), and is off by default. No-pop (DNP) caps are open circuits and are not stitched; only symmetric cap pairs (both polarities bridged) are joined. Detection requires the pair halves to be found first (so it inherits the `_P`/`_N` naming rules above).
 
 ## Time Matching
 

--- a/kicad_files/cap_chain.kicad_pcb
+++ b/kicad_files/cap_chain.kicad_pcb
@@ -1,0 +1,877 @@
+(kicad_pcb
+	(version 20260206)
+	(generator "pcbnew")
+	(generator_version "10.0")
+	(general
+		(thickness 1.6)
+		(legacy_teardrops no)
+	)
+	(paper "A4")
+	(layers
+		(0 "F.Cu" signal)
+		(2 "B.Cu" signal)
+		(9 "F.Adhes" user "F.Adhesive")
+		(11 "B.Adhes" user "B.Adhesive")
+		(13 "F.Paste" user)
+		(15 "B.Paste" user)
+		(5 "F.SilkS" user "F.Silkscreen")
+		(7 "B.SilkS" user "B.Silkscreen")
+		(1 "F.Mask" user)
+		(3 "B.Mask" user)
+		(17 "Dwgs.User" user "User.Drawings")
+		(19 "Cmts.User" user "User.Comments")
+		(21 "Eco1.User" user "User.Eco1")
+		(23 "Eco2.User" user "User.Eco2")
+		(25 "Edge.Cuts" user)
+		(27 "Margin" user)
+		(31 "F.CrtYd" user "F.Courtyard")
+		(29 "B.CrtYd" user "B.Courtyard")
+		(35 "F.Fab" user)
+		(33 "B.Fab" user)
+		(39 "User.1" user)
+		(41 "User.2" user)
+		(43 "User.3" user)
+		(45 "User.4" user)
+	)
+	(setup
+		(pad_to_mask_clearance 0)
+		(allow_soldermask_bridges_in_footprints no)
+		(tenting
+			(front yes)
+			(back yes)
+		)
+		(covering
+			(front no)
+			(back no)
+		)
+		(plugging
+			(front no)
+			(back no)
+		)
+		(capping no)
+		(filling no)
+		(pcbplotparams
+			(layerselection 0x00000000_00000000_55555555_5755f5ff)
+			(plot_on_all_layers_selection 0x00000000_00000000_00000000_00000000)
+			(disableapertmacros no)
+			(usegerberextensions no)
+			(usegerberattributes yes)
+			(usegerberadvancedattributes yes)
+			(creategerberjobfile yes)
+			(dashed_line_dash_ratio 12)
+			(dashed_line_gap_ratio 3)
+			(svgprecision 4)
+			(plotframeref no)
+			(mode 1)
+			(useauxorigin no)
+			(pdf_front_fp_property_popups yes)
+			(pdf_back_fp_property_popups yes)
+			(pdf_metadata yes)
+			(pdf_single_document no)
+			(dxfpolygonmode yes)
+			(dxfimperialunits yes)
+			(dxfusepcbnewfont yes)
+			(psnegative no)
+			(psa4output no)
+			(plot_black_and_white yes)
+			(sketchpadsonfab no)
+			(plotpadnumbers no)
+			(hidednponfab no)
+			(sketchdnponfab yes)
+			(crossoutdnponfab yes)
+			(subtractmaskfromsilk no)
+			(outputformat 1)
+			(mirror no)
+			(drillshape 1)
+			(scaleselection 1)
+			(outputdirectory "")
+		)
+	)
+	(footprint "C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "56260132-166f-4368-a7f9-3576f58df969")
+		(at 18 13)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC-7351 nominal, (Body size source: IPC-SM-782 page 76, https://www.pcb-3d.com/wordpress/wp-content/uploads/ipc-sm-782a_amendment_1_and_2.pdf)")
+		(tags "capacitor")
+		(property "Reference" "C1"
+			(at 0 -1.16 0)
+			(layer "F.SilkS")
+			(uuid "5d5fd84d-99c8-48ff-a63e-62d31c89402a")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "C_0402_1005Metric"
+			(at 0 1.16 0)
+			(layer "F.Fab")
+			(uuid "8ea3a845-0a0e-4a21-8f4b-162a67d5af11")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "178ffffc-4d0d-4953-a1c3-4b55256f57b6")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "8cec3911-d4cb-4945-af29-e7597d39d260")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "KiLib_Generator" "SMD_2terminal_chip_molded"
+			(at 0 0 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "6742cb15-9406-4fa0-949c-9f4d44299dce")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.107836 -0.36)
+			(end 0.107836 -0.36)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "49fa5cce-af2f-4359-ad06-9245024b9170")
+		)
+		(fp_line
+			(start -0.107836 0.36)
+			(end 0.107836 0.36)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "dac57eae-a73c-4442-9ee9-38ad961a5d43")
+		)
+		(fp_rect
+			(start -0.91 -0.46)
+			(end 0.91 0.46)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+			(uuid "87aa1968-f4de-4176-9e41-9de1bdd0b20e")
+		)
+		(fp_rect
+			(start -0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.Fab")
+			(uuid "a5c25ae0-cf6c-47e4-af83-09fe3cff8117")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "8eee0d28-07f6-4dc0-b47d-cdd45d46370a")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.48 0)
+			(size 0.56 0.62)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "DPA_P")
+			(uuid "c982a5a0-e064-4341-95fd-a161a4b62b42")
+		)
+		(pad "2" smd roundrect
+			(at 0.48 0)
+			(size 0.56 0.62)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "DPB_P")
+			(uuid "ce9ccee6-5687-405d-9f8d-dfc1bfdc1186")
+		)
+		(embedded_fonts no)
+		(model "${KICAD10_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0402_1005Metric.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "56260132-166f-4368-a7f9-3576f58df969")
+		(at 18 17)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC-7351 nominal, (Body size source: IPC-SM-782 page 76, https://www.pcb-3d.com/wordpress/wp-content/uploads/ipc-sm-782a_amendment_1_and_2.pdf)")
+		(tags "capacitor")
+		(property "Reference" "C2"
+			(at 0 -1.16 0)
+			(layer "F.SilkS")
+			(uuid "18631c6d-0df8-40c7-92d3-5af7aee5110e")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "C_0402_1005Metric"
+			(at 0 1.16 0)
+			(layer "F.Fab")
+			(uuid "9d3c6940-f46f-4197-88ca-cb9bab20aaab")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "ea8f3908-2ac5-4b76-8bff-fd72562acce1")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "a0e38d51-5f8a-456a-bbf9-5a2f9afc08d7")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "KiLib_Generator" "SMD_2terminal_chip_molded"
+			(at 0 0 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "6742cb15-9406-4fa0-949c-9f4d44299dce")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.107836 -0.36)
+			(end 0.107836 -0.36)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "49fa5cce-af2f-4359-ad06-9245024b9170")
+		)
+		(fp_line
+			(start -0.107836 0.36)
+			(end 0.107836 0.36)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "dac57eae-a73c-4442-9ee9-38ad961a5d43")
+		)
+		(fp_rect
+			(start -0.91 -0.46)
+			(end 0.91 0.46)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+			(uuid "87aa1968-f4de-4176-9e41-9de1bdd0b20e")
+		)
+		(fp_rect
+			(start -0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.Fab")
+			(uuid "a5c25ae0-cf6c-47e4-af83-09fe3cff8117")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "8eee0d28-07f6-4dc0-b47d-cdd45d46370a")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.48 0)
+			(size 0.56 0.62)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "DPA_N")
+			(uuid "c982a5a0-e064-4341-95fd-a161a4b62b42")
+		)
+		(pad "2" smd roundrect
+			(at 0.48 0)
+			(size 0.56 0.62)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "DPB_N")
+			(uuid "ce9ccee6-5687-405d-9f8d-dfc1bfdc1186")
+		)
+		(embedded_fonts no)
+		(model "${KICAD10_3DMODEL_DIR}/Capacitor_SMD.3dshapes/C_0402_1005Metric.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "PinHeader_1x02_P2.54mm_Vertical"
+		(layer "F.Cu")
+		(uuid "76929de9-6636-4672-934d-9648a191fda8")
+		(at 26 15)
+		(descr "Through hole straight pin header, 1x02, 2.54mm pitch, single row")
+		(tags "Through hole pin header THT 1x02 2.54mm single row")
+		(property "Reference" "J2"
+			(at 0 -2.38 0)
+			(layer "F.SilkS")
+			(uuid "ecbff302-5b0b-4240-840f-0f39de4805cc")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "PinHeader_1x02_P2.54mm_Vertical"
+			(at 0 4.92 0)
+			(layer "F.Fab")
+			(uuid "ce92ab08-c3a8-42f4-b452-8c266ff620ef")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "74ecc6f6-6516-49b4-8efe-6f1ac21fdabe")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "155a2069-07eb-466c-8d19-f03e727fd1e3")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "KiLib_Generator" "connector/pin_header_socket"
+			(at 0 0 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "34154515-5bb9-456a-9c30-2a5b7635d60f")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -1.38 -1.38)
+			(end 0 -1.38)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "7598cc4a-87e8-4a5a-8591-f13c4225ccfa")
+		)
+		(fp_line
+			(start -1.38 0)
+			(end -1.38 -1.38)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "aef362d7-f24f-45e8-8a71-d38504772545")
+		)
+		(fp_line
+			(start -1.38 1.27)
+			(end -1.38 3.92)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "e33b821d-9ced-489a-a3c6-9c105655b8c4")
+		)
+		(fp_line
+			(start -1.38 1.27)
+			(end 1.38 1.27)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "781cdd1a-6a03-4c63-89a7-e659dbd9aaad")
+		)
+		(fp_line
+			(start -1.38 3.92)
+			(end 1.38 3.92)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "c63f2f98-b045-45de-a3bf-a521aa35f474")
+		)
+		(fp_line
+			(start 1.38 1.27)
+			(end 1.38 3.92)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "15c55a1b-7448-4a95-93b6-aaeda96e30c8")
+		)
+		(fp_rect
+			(start -1.77 -1.77)
+			(end 1.77 4.32)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+			(uuid "48e445f0-736d-4d33-a6f6-acfcef7a536f")
+		)
+		(fp_line
+			(start -1.27 -0.635)
+			(end -0.635 -1.27)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e3a93606-d8b7-4bed-93b7-364b2f2491dc")
+		)
+		(fp_line
+			(start -1.27 3.81)
+			(end -1.27 -0.635)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b27e9365-a710-49b4-abed-7292303d571c")
+		)
+		(fp_line
+			(start -0.635 -1.27)
+			(end 1.27 -1.27)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "233f6195-cfe6-4846-affc-df52ed852243")
+		)
+		(fp_line
+			(start 1.27 -1.27)
+			(end 1.27 3.81)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b391c5ec-4ea2-435a-a6ba-0767a2541cbd")
+		)
+		(fp_line
+			(start 1.27 3.81)
+			(end -1.27 3.81)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "5b6f6bb5-90ee-4109-a161-519b92024bae")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 1.27 90)
+			(layer "F.Fab")
+			(uuid "fdcf0582-10ae-4b26-8292-8c825f62c5a1")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "1" thru_hole rect
+			(at 0 0)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "DPB_P")
+			(uuid "4482aec3-bff6-4e01-925c-18cb567e9037")
+		)
+		(pad "2" thru_hole circle
+			(at 0 2.54)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "DPB_N")
+			(uuid "9fe71e8d-5cf6-46bf-95ba-c02470d71aa6")
+		)
+		(embedded_fonts no)
+		(model "${KICAD10_3DMODEL_DIR}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_1x02_P2.54mm_Vertical.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "PinHeader_1x02_P2.54mm_Vertical"
+		(layer "F.Cu")
+		(uuid "76929de9-6636-4672-934d-9648a191fda8")
+		(at 10 15)
+		(descr "Through hole straight pin header, 1x02, 2.54mm pitch, single row")
+		(tags "Through hole pin header THT 1x02 2.54mm single row")
+		(property "Reference" "J1"
+			(at 0 -2.38 0)
+			(layer "F.SilkS")
+			(uuid "86bd15e0-cb93-49e6-a3a6-9a9a1ea955d9")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "PinHeader_1x02_P2.54mm_Vertical"
+			(at 0 4.92 0)
+			(layer "F.Fab")
+			(uuid "72870487-a93b-427e-b89b-9e43cb8c8dc8")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "16e0aada-b705-424a-85d8-f6ea0f18a55d")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "37cd7d60-13ab-4f65-b90c-47162a2d88c2")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "KiLib_Generator" "connector/pin_header_socket"
+			(at 0 0 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "34154515-5bb9-456a-9c30-2a5b7635d60f")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -1.38 -1.38)
+			(end 0 -1.38)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "7598cc4a-87e8-4a5a-8591-f13c4225ccfa")
+		)
+		(fp_line
+			(start -1.38 0)
+			(end -1.38 -1.38)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "aef362d7-f24f-45e8-8a71-d38504772545")
+		)
+		(fp_line
+			(start -1.38 1.27)
+			(end -1.38 3.92)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "e33b821d-9ced-489a-a3c6-9c105655b8c4")
+		)
+		(fp_line
+			(start -1.38 1.27)
+			(end 1.38 1.27)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "781cdd1a-6a03-4c63-89a7-e659dbd9aaad")
+		)
+		(fp_line
+			(start -1.38 3.92)
+			(end 1.38 3.92)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "c63f2f98-b045-45de-a3bf-a521aa35f474")
+		)
+		(fp_line
+			(start 1.38 1.27)
+			(end 1.38 3.92)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "15c55a1b-7448-4a95-93b6-aaeda96e30c8")
+		)
+		(fp_rect
+			(start -1.77 -1.77)
+			(end 1.77 4.32)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+			(uuid "48e445f0-736d-4d33-a6f6-acfcef7a536f")
+		)
+		(fp_line
+			(start -1.27 -0.635)
+			(end -0.635 -1.27)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e3a93606-d8b7-4bed-93b7-364b2f2491dc")
+		)
+		(fp_line
+			(start -1.27 3.81)
+			(end -1.27 -0.635)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b27e9365-a710-49b4-abed-7292303d571c")
+		)
+		(fp_line
+			(start -0.635 -1.27)
+			(end 1.27 -1.27)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "233f6195-cfe6-4846-affc-df52ed852243")
+		)
+		(fp_line
+			(start 1.27 -1.27)
+			(end 1.27 3.81)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b391c5ec-4ea2-435a-a6ba-0767a2541cbd")
+		)
+		(fp_line
+			(start 1.27 3.81)
+			(end -1.27 3.81)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "5b6f6bb5-90ee-4109-a161-519b92024bae")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 1.27 90)
+			(layer "F.Fab")
+			(uuid "fdcf0582-10ae-4b26-8292-8c825f62c5a1")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "1" thru_hole rect
+			(at 0 0)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "DPA_P")
+			(uuid "4482aec3-bff6-4e01-925c-18cb567e9037")
+		)
+		(pad "2" thru_hole circle
+			(at 0 2.54)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "DPA_N")
+			(uuid "9fe71e8d-5cf6-46bf-95ba-c02470d71aa6")
+		)
+		(embedded_fonts no)
+		(model "${KICAD10_3DMODEL_DIR}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_1x02_P2.54mm_Vertical.step"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(gr_line
+		(start 5 5)
+		(end 31 5)
+		(stroke
+			(width 0.1)
+			(type default)
+		)
+		(layer "Edge.Cuts")
+		(uuid "776cc718-7c84-428e-91f8-12e737cb99c4")
+	)
+	(gr_line
+		(start 5 25)
+		(end 5 5)
+		(stroke
+			(width 0.1)
+			(type default)
+		)
+		(layer "Edge.Cuts")
+		(uuid "70bb63a3-fc37-4d10-be6c-8a0cd5016411")
+	)
+	(gr_line
+		(start 31 5)
+		(end 31 25)
+		(stroke
+			(width 0.1)
+			(type default)
+		)
+		(layer "Edge.Cuts")
+		(uuid "dfabdcea-89e7-4f5f-b293-188c024389a8")
+	)
+	(gr_line
+		(start 31 25)
+		(end 5 25)
+		(stroke
+			(width 0.1)
+			(type default)
+		)
+		(layer "Edge.Cuts")
+		(uuid "b5729d89-7cee-4845-9dd0-bf8a187bb197")
+	)
+	(embedded_fonts no)
+)

--- a/kicad_parser.py
+++ b/kicad_parser.py
@@ -141,6 +141,8 @@ class Footprint:
     layer: str
     pads: List[Pad] = field(default_factory=list)
     value: str = ""  # Component value (e.g., "MCF5213", "100nF", "10K")
+    dnp: bool = False  # Do-not-populate / no-pop. A no-pop series part is an open
+                       # circuit, so its pads do NOT bridge two nets into one signal.
 
 
 @dataclass
@@ -1213,6 +1215,13 @@ def extract_footprints_and_pads(content: str, nets: Dict[int, Net], name_to_id: 
         value_match = re.search(r'\(property\s+"Value"\s+"([^"]+)"', fp_text)
         value = value_match.group(1) if value_match else ""
 
+        # Extract the do-not-populate flag from the footprint (attr ...) token.
+        # KiCad 7+ writes a standalone `dnp` keyword among the attr flags
+        # (e.g. "(attr smd dnp exclude_from_pos_files)"). A no-pop part is an
+        # open circuit, so callers must not treat its pads as bridging two nets.
+        attr_match = re.search(r'\(attr\b([^)]*)\)', fp_text)
+        is_dnp = bool(attr_match and re.search(r'\bdnp\b', attr_match.group(1)))
+
         footprint = Footprint(
             reference=reference,
             footprint_name=fp_name,
@@ -1220,7 +1229,8 @@ def extract_footprints_and_pads(content: str, nets: Dict[int, Net], name_to_id: 
             y=fp_y,
             rotation=fp_rotation,
             layer=fp_layer,
-            value=value
+            value=value,
+            dnp=is_dnp
         )
 
         # Extract pads
@@ -1961,6 +1971,14 @@ def build_pcb_data_from_board(board, guide_layer: str = "User.1",
         except Exception:
             fp_value = ""
 
+        # DNP (do-not-populate) flag — kept at parity with the text parser. A
+        # no-pop series part is an open circuit, so its pads must not be treated
+        # as bridging two nets into one logical net. IsDNP() is KiCad 7+.
+        try:
+            fp_dnp = bool(fp.IsDNP())
+        except Exception:
+            fp_dnp = False
+
         footprint = Footprint(
             reference=reference,
             footprint_name=fp_name,
@@ -1968,7 +1986,8 @@ def build_pcb_data_from_board(board, guide_layer: str = "User.1",
             y=fp_y,
             rotation=fp_rotation,
             layer=fp_layer,
-            value=fp_value
+            value=fp_value,
+            dnp=fp_dnp
         )
 
         # Extract pads

--- a/kicad_routing_plugin/differential_gui.py
+++ b/kicad_routing_plugin/differential_gui.py
@@ -572,6 +572,13 @@ class DifferentialTab(wx.Panel):
         self.intra_match_check.SetToolTip("Add meanders to shorter track of each pair for P/N matching")
         options_sizer.Add(self.intra_match_check, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 5)
 
+        self.ac_couple_check = wx.CheckBox(self, label="AC-coupled end-to-end matching")
+        self.ac_couple_check.SetValue(False)
+        self.ac_couple_check.SetToolTip("Length-match diff pairs split by series DC-blocking caps "
+                                        "end-to-end: detect the cap chain and match the whole P path "
+                                        "vs N path across the caps, not each side alone (#196)")
+        options_sizer.Add(self.ac_couple_check, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 5)
+
         self.hide_short_check = wx.CheckBox(self, label="Hide short routes")
         self.hide_short_check.SetValue(True)
         self.hide_short_check.SetToolTip(
@@ -905,6 +912,7 @@ class DifferentialTab(wx.Panel):
                 fix_polarity=config.get('fix_polarity', True),
                 gnd_via_enabled=config.get('gnd_via_enabled', True),
                 diff_pair_intra_match=config.get('diff_pair_intra_match', False),
+                ac_couple_match=config.get('ac_couple_match', False),
                 enable_layer_switch=config.get('enable_layer_switch', True),
                 debug_lines=config.get('debug_lines', False),
                 verbose=config.get('verbose', False),
@@ -1134,6 +1142,7 @@ class DifferentialTab(wx.Panel):
             'fix_polarity': self.fix_polarity_check.GetValue(),
             'gnd_via_enabled': self.gnd_via_check.GetValue(),
             'diff_pair_intra_match': self.intra_match_check.GetValue(),
+            'ac_couple_match': self.ac_couple_check.GetValue(),
         }
 
     def _on_use_netclass_changed(self, event):

--- a/kicad_routing_plugin/settings_persistence.py
+++ b/kicad_routing_plugin/settings_persistence.py
@@ -158,6 +158,7 @@ def get_dialog_settings(dialog):
         'fix_polarity_check': dialog.differential_tab.fix_polarity_check.GetValue(),
         'gnd_via_check': dialog.differential_tab.gnd_via_check.GetValue(),
         'intra_match_check': dialog.differential_tab.intra_match_check.GetValue(),
+        'ac_couple_check': dialog.differential_tab.ac_couple_check.GetValue(),
         'diff_hide_short': dialog.differential_tab.hide_short_check.GetValue(),
 
         # Fanout tab settings
@@ -511,6 +512,8 @@ def restore_dialog_settings(dialog, settings):
         dialog.differential_tab.gnd_via_check.SetValue(settings['gnd_via_check'])
     if 'intra_match_check' in settings:
         dialog.differential_tab.intra_match_check.SetValue(settings['intra_match_check'])
+    if 'ac_couple_check' in settings:
+        dialog.differential_tab.ac_couple_check.SetValue(settings['ac_couple_check'])
     if 'diff_hide_short' in settings:
         dialog.differential_tab.hide_short_check.SetValue(settings['diff_hide_short'])
         dialog.differential_tab.pair_panel.set_hide_short(settings['diff_hide_short'])

--- a/kicad_routing_plugin/swig_gui.py
+++ b/kicad_routing_plugin/swig_gui.py
@@ -2056,6 +2056,7 @@ class RoutingDialog(wx.Dialog):
         self.differential_tab.fix_polarity_check.SetValue(False)
         self.differential_tab.gnd_via_check.SetValue(False)
         self.differential_tab.intra_match_check.SetValue(False)
+        self.differential_tab.ac_couple_check.SetValue(False)
 
         # Reset fanout tab
         self.fanout_tab.fanout_type.SetSelection(0)

--- a/length_matching.py
+++ b/length_matching.py
@@ -1153,7 +1153,7 @@ def _apply_meanders_to_net_with_iteration(
     group_clearance_index,
     metric_func,
     extra_length_func,
-) -> Tuple[dict, List[Segment], int]:
+) -> Tuple[dict, List[Segment], int, float]:
     """
     Apply meanders to a single net with bump iteration and amplitude scaling.
 
@@ -1175,7 +1175,7 @@ def _apply_meanders_to_net_with_iteration(
         extra_length_func: Function(metric_deficit) -> extra_length in mm
 
     Returns:
-        Tuple of (modified_result_or_segments, final_segments, bump_count)
+        Tuple of (modified_result_or_segments, final_segments, bump_count, final_metric)
     """
     from net_queries import calculate_route_length
 
@@ -1435,7 +1435,7 @@ def apply_length_matching_to_group(
         modified, new_segments, bump_count, new_length = _apply_meanders_to_net_with_iteration(
             result, target_length, current_length, config.length_match_tolerance,
             config, pcb_data, already_processed_segments, already_processed_vias,
-            group_clearance_index, length_metric, length_to_length, "mm"
+            group_clearance_index, length_metric, length_to_length
         )
 
         print(f"      {net_name}: new length = {new_length:.2f}mm ({bump_count} bumps)")
@@ -1588,7 +1588,7 @@ def apply_time_matching_to_group(
         modified, new_segments, bump_count, new_time = _apply_meanders_to_net_with_iteration(
             result, target_time, current_time, config.time_match_tolerance,
             config, pcb_data, already_processed_segments, already_processed_vias,
-            group_clearance_index, time_metric, time_to_length, "ps"
+            group_clearance_index, time_metric, time_to_length
         )
 
         print(f"      {net_name}: new time = {new_time:.2f}ps ({bump_count} bumps)")
@@ -2384,6 +2384,110 @@ def apply_meanders_to_diff_pair(
     return result, 0
 
 
+def _lengthen_net_with_meanders(
+    segments: List[Segment],
+    net_id: int,
+    paired_net_id: int,
+    vias: List,
+    stub_length: float,
+    current_length: float,
+    target_length: float,
+    delta: float,
+    config: GridRouteConfig,
+    pcb_data: PCBData,
+) -> Tuple[List[Segment], float, int]:
+    """Add meanders to ONE net's ``segments`` to lengthen it toward
+    ``target_length`` (total = routed + ``stub_length``), starting from
+    ``current_length`` (the same total before meandering) with a positive
+    ``delta`` gap to close.
+
+    Shared by intra-pair P/N matching and end-to-end AC-coupled (XNet) matching
+    so the bump-count + amplitude-scaling search lives in exactly one place.
+    ``paired_net_id`` is the net's coupled partner on this run (reduced
+    clearance). Returns ``(meandered_segments, new_total_length, bump_count)``;
+    ``bump_count == 0`` means no meanders could be fit (segments/length returned
+    unchanged) and the caller decides how to report it.
+    """
+    # Meander geometry: entry chamfer + 2 risers + 2 top chamfers + exit chamfer.
+    # For n bumps: extra ~= n * (2*amplitude - 2.34*chamfer).
+    chamfer = CHAMFER_SIZE
+    min_amplitude = 0.1  # Minimum useful amplitude (smaller for small deltas)
+    max_amplitude = config.meander_amplitude  # Default 1.0mm
+
+    # Pick a bump count + initial amplitude that should hit the delta in one
+    # shot, then refine by scaling below.
+    max_extra_per_bump = 2 * max_amplitude - 2.34 * chamfer  # ~1.766mm at amplitude=1.0
+    num_bumps_needed = max(1, int(math.ceil(delta / max_extra_per_bump)))
+    initial_amplitude = (delta / num_bumps_needed + 2.34 * chamfer) / 2
+    initial_amplitude = max(min_amplitude, min(initial_amplitude, max_amplitude))
+
+    # Pass paired_net_id to use reduced clearance for the coupled partner track,
+    # and min_bumps to get exactly the calculated number of bumps.
+    meandered_segments, bump_count = apply_meanders_to_route(
+        segments,
+        delta,
+        config,
+        pcb_data=pcb_data,
+        net_id=net_id,
+        paired_net_id=paired_net_id,
+        amplitude_override=initial_amplitude,
+        min_bumps=num_bumps_needed
+    )
+
+    if bump_count == 0:
+        return segments, current_length, 0
+
+    new_routed = calculate_route_length(meandered_segments, vias, pcb_data)
+    new_length = new_routed + stub_length
+
+    # Keep track of best result (closest to target)
+    best_segments = meandered_segments
+    best_length = new_length
+    best_bump_count = bump_count
+
+    # Scale amplitude to converge on target (keep the closest result).
+    for scale_iter in range(5):
+        if abs(new_length - target_length) <= config.length_match_tolerance:
+            break
+
+        actual_extra = new_length - current_length
+        if actual_extra < MIN_SEGMENT_LENGTH or bump_count == 0:
+            break  # No meaningful extra was added
+
+        needed_extra = target_length - current_length
+        # amplitude that would give needed_extra with the current bump_count
+        target_amplitude = (needed_extra / bump_count + 2.34 * chamfer) / 2
+        if target_amplitude < 0.2:
+            break  # Amplitude too small, accept current result
+
+        new_meandered_segments, new_bump_count = apply_meanders_to_route(
+            segments,
+            delta,
+            config,
+            pcb_data=pcb_data,
+            net_id=net_id,
+            min_bumps=bump_count,  # Keep same bump count
+            amplitude_override=target_amplitude,
+            paired_net_id=paired_net_id
+        )
+
+        if new_bump_count == 0:
+            break  # Scaling failed, use best result so far
+
+        new_routed = calculate_route_length(new_meandered_segments, vias, pcb_data)
+        new_length = new_routed + stub_length
+
+        if abs(new_length - target_length) < abs(best_length - target_length):
+            best_segments = new_meandered_segments
+            best_length = new_length
+            best_bump_count = new_bump_count
+            bump_count = new_bump_count
+        else:
+            break  # Not improving, stop
+
+    return best_segments, best_length, best_bump_count
+
+
 def apply_intra_pair_length_matching(
     result: dict,
     config: GridRouteConfig,
@@ -2515,109 +2619,16 @@ def apply_intra_pair_length_matching(
 
     print(f"    P/N intra-pair: P={p_length:.3f}mm, N={n_length:.3f}mm, delta={delta:.3f}mm, adding meanders to {shorter_label}")
 
-    # Step 1: Generate initial meanders
-    # Meander geometry: entry chamfer + 2 risers + 2 top chamfers + exit chamfer
-    # For 1 bump: extra = 2*amplitude - 2.34*chamfer
-    # For n bumps: extra ≈ n * (2*amplitude - 2.34*chamfer) (approximately, first bump has entry/exit)
-    chamfer = CHAMFER_SIZE
-    min_amplitude = 0.1  # Minimum useful amplitude (smaller for intra-pair small deltas)
-    max_amplitude = config.meander_amplitude  # Default 1.0mm
-
-    # Calculate max extra per bump at max amplitude
-    max_extra_per_bump = 2 * max_amplitude - 2.34 * chamfer  # ~1.766mm at amplitude=1.0
-
-    # Determine number of bumps needed
-    num_bumps_needed = max(1, int(math.ceil(delta / max_extra_per_bump)))
-
-    # Calculate amplitude for this number of bumps to hit target delta
-    # extra = n * (2*amp - 2.34*chamfer)
-    # amp = (extra/n + 2.34*chamfer) / 2
-    initial_amplitude = (delta / num_bumps_needed + 2.34 * chamfer) / 2
-    initial_amplitude = max(min_amplitude, min(initial_amplitude, max_amplitude))
-
-    # Pass paired_net_id to use reduced clearance for the paired track
-    # Use min_bumps to ensure we get exactly the calculated number of bumps
-    meandered_segments, bump_count = apply_meanders_to_route(
-        shorter_segments,
-        delta,
-        config,
-        pcb_data=pcb_data,
-        net_id=shorter_net_id,
-        paired_net_id=longer_net_id,
-        amplitude_override=initial_amplitude,
-        min_bumps=num_bumps_needed
+    # Lengthen the shorter track to match the longer one (shared meander
+    # search — see _lengthen_net_with_meanders, also used by XNet matching).
+    meandered_segments, new_shorter_length, bump_count = _lengthen_net_with_meanders(
+        shorter_segments, shorter_net_id, longer_net_id, shorter_vias,
+        shorter_stub_length, shorter_length, target_length, delta, config, pcb_data,
     )
 
     if bump_count == 0:
         print(f"    P/N intra-pair: could not fit meanders")
         return result
-
-    # Calculate new length including stub (to compare with target which includes stub)
-    new_shorter_routed = calculate_route_length(meandered_segments, shorter_vias, pcb_data)
-    new_shorter_length = new_shorter_routed + shorter_stub_length
-
-    # Keep track of best result (closest to target)
-    best_segments = meandered_segments
-    best_length = new_shorter_length
-    best_bump_count = bump_count
-
-    # Step 2: Scale amplitude to hit target length (iterate to refine)
-    # For a meander bump: extra_length ≈ 2*amplitude - 2.34*chamfer per bump
-    # Rearranging: amplitude ≈ (extra_length/bump_count + 2.34*chamfer) / 2
-    for scale_iter in range(5):
-        new_delta = abs(new_shorter_length - target_length)
-        if new_delta <= config.length_match_tolerance:
-            break
-
-        # Calculate target amplitude based on needed extra length
-        actual_extra = new_shorter_length - shorter_length
-        if actual_extra < MIN_SEGMENT_LENGTH or bump_count == 0:
-            break  # No meaningful extra was added
-
-        needed_extra = target_length - shorter_length
-        # Calculate amplitude that would give needed_extra with current bump_count
-        # extra = bump_count * (2*amplitude - 2.34*chamfer)
-        # amplitude = (extra/bump_count + 2.34*chamfer) / 2
-        target_amplitude = (needed_extra / bump_count + 2.34 * chamfer) / 2
-
-        if target_amplitude < 0.2:
-            # Amplitude too small, accept current result
-            break
-
-        # Regenerate with target amplitude
-        new_meandered_segments, new_bump_count = apply_meanders_to_route(
-            shorter_segments,
-            delta,
-            config,
-            pcb_data=pcb_data,
-            net_id=shorter_net_id,
-            min_bumps=bump_count,  # Keep same bump count
-            amplitude_override=target_amplitude,
-            paired_net_id=longer_net_id
-        )
-
-        if new_bump_count == 0:
-            # Scaling failed, use best result so far
-            break
-
-        new_shorter_routed = calculate_route_length(new_meandered_segments, shorter_vias, pcb_data)
-        new_shorter_length = new_shorter_routed + shorter_stub_length
-
-        # Update best if this is closer to target
-        if abs(new_shorter_length - target_length) < abs(best_length - target_length):
-            best_segments = new_meandered_segments
-            best_length = new_shorter_length
-            best_bump_count = new_bump_count
-            meandered_segments = new_meandered_segments
-            bump_count = new_bump_count
-        else:
-            # Not improving, stop
-            break
-
-    # Use best result
-    meandered_segments = best_segments
-    new_shorter_length = best_length
-    bump_count = best_bump_count
 
     # Check if meanders actually improved delta (don't make things worse)
     new_delta = abs(new_shorter_length - target_length)
@@ -2645,3 +2656,148 @@ def apply_intra_pair_length_matching(
     print(f"    P/N intra-pair: {bump_count} bumps added, new {shorter_label}={new_shorter_length:.3f}mm, new delta={new_delta:.3f}mm")
 
     return result
+
+
+def _ac_coupled_member_lengths(result, p_net_id, n_net_id, pcb_data):
+    """Per-member P and N conductor contributions for end-to-end matching.
+
+    Mirrors apply_intra_pair_length_matching's measurement (routed length plus
+    polarity-aware stub lengths) but returns BOTH sides plus the raw segment / via
+    lists so the caller can lengthen one member net in place.
+    """
+    from net_queries import calculate_route_length
+    segs = result.get('new_segments', [])
+    vias = result.get('new_vias', [])
+    p_segs = [s for s in segs if s.net_id == p_net_id]
+    n_segs = [s for s in segs if s.net_id == n_net_id]
+    p_vias = [v for v in vias if v.net_id == p_net_id]
+    n_vias = [v for v in vias if v.net_id == n_net_id]
+    p_routed = calculate_route_length(p_segs, p_vias, pcb_data)
+    n_routed = calculate_route_length(n_segs, n_vias, pcb_data)
+
+    # Polarity-aware stub totals (each member can be independently polarity-fixed,
+    # matching apply_intra_pair_length_matching's post-swap accounting).
+    p_src = result.get('p_src_stub_length', 0.0)
+    p_tgt = result.get('p_tgt_stub_length', 0.0)
+    n_src = result.get('n_src_stub_length', 0.0)
+    n_tgt = result.get('n_tgt_stub_length', 0.0)
+    if result.get('polarity_fixed', False):
+        p_stub, n_stub = p_src + n_tgt, n_src + p_tgt
+    else:
+        p_stub, n_stub = p_src + p_tgt, n_src + n_tgt
+
+    return {
+        'result': result,
+        'p_net_id': p_net_id, 'n_net_id': n_net_id,
+        'p_segs': p_segs, 'n_segs': n_segs,
+        'p_vias': p_vias, 'n_vias': n_vias,
+        'p_stub': p_stub, 'n_stub': n_stub,
+        'p_routed': p_routed, 'n_routed': n_routed,
+        'p_len': p_routed + p_stub, 'n_len': n_routed + n_stub,
+    }
+
+
+def apply_ac_coupled_length_matching(xnet, routed_results, config, pcb_data):
+    """End-to-end length-match one AC-coupled XNet (issue #196).
+
+    Matches the concatenated P conductor (the sum of every member pair's P net)
+    against the concatenated N conductor, then distributes the compensating
+    meanders across the member segments: first onto members where the shorter
+    conductor is *also* the locally-shorter net (so it reduces local intra-pair
+    skew too), then spilling any remainder onto the member with the most routed
+    copper (the most meander room). The meanders are added one MEMBER NET at a
+    time (never a concatenated list -- each half's own copper would otherwise read
+    as a foreign net at zero clearance). Length-only, mirroring intra-pair.
+
+    Edits each member result's 'new_segments' in place. Returns the final
+    end-to-end skew in mm (or None if a member was not fully routed); degrades
+    gracefully on congestion and never falsely claims a match it could not make.
+    """
+    tol = config.length_match_tolerance
+    name = "+".join(xnet.base_names)
+
+    members = []
+    for m in xnet.members:
+        res = routed_results.get(m.p_net_id)
+        if res is None or routed_results.get(m.n_net_id) is None:
+            print(f"    AC-couple {name}: member '{m.base_name}' not fully routed; "
+                  f"skipping end-to-end match")
+            return None
+        md = _ac_coupled_member_lengths(res, m.p_net_id, m.n_net_id, pcb_data)
+        md['base'] = m.base_name
+        members.append(md)
+
+    total_p = sum(md['p_len'] for md in members)
+    total_n = sum(md['n_len'] for md in members)
+    delta = abs(total_p - total_n)
+    bridges = ", ".join(xnet.bridge_refs)
+    print(f"    AC-couple {name}: end-to-end P={total_p:.3f}mm, N={total_n:.3f}mm, "
+          f"delta={delta:.3f}mm (coupled via {bridges})")
+    if delta <= tol:
+        print(f"    AC-couple {name}: already matched (delta={delta:.3f}mm <= {tol}mm)")
+        return delta
+
+    # Shorter conductor S receives the meanders; L is the longer (the target).
+    S, L = ('p', 'n') if total_p < total_n else ('n', 'p')
+    need = delta
+
+    # Plan per-member additions:
+    #  phase 1 - bring members where S is locally shorter up to LOCAL match (this
+    #            also reduces their local intra-pair skew), capped at the total need;
+    #  phase 2 - spill any remaining end-to-end deficit onto the member with the
+    #            most routed S copper (proxy for the most meander room).
+    plan = [0.0] * len(members)
+    remaining = need
+    by_headroom = sorted(
+        range(len(members)),
+        key=lambda i: members[i][f'{L}_len'] - members[i][f'{S}_len'],
+        reverse=True,
+    )
+    for i in by_headroom:
+        if remaining <= tol:
+            break
+        headroom = members[i][f'{L}_len'] - members[i][f'{S}_len']
+        if headroom <= tol:
+            continue
+        a = min(remaining, headroom)
+        plan[i] += a
+        remaining -= a
+    if remaining > tol:
+        spill = max(range(len(members)), key=lambda i: members[i][f'{S}_routed'])
+        plan[spill] += remaining
+        remaining = 0.0
+
+    # Apply: lengthen each planned member's S net once (never re-meander a net).
+    added_total = 0.0
+    for i, want in enumerate(plan):
+        if want <= tol:
+            continue
+        md = members[i]
+        s_id, l_id = md[f'{S}_net_id'], md[f'{L}_net_id']
+        cur = md[f'{S}_len']
+        new_segs, new_len, bumps = _lengthen_net_with_meanders(
+            md[f'{S}_segs'], s_id, l_id, md[f'{S}_vias'], md[f'{S}_stub'],
+            cur, cur + want, want, config, pcb_data,
+        )
+        if bumps <= 0:
+            print(f"      {md['base']}: could not fit meanders on {S.upper()} "
+                  f"(wanted +{want:.3f}mm)")
+            continue
+        added = new_len - cur
+        res = md['result']
+        res['new_segments'] = [s for s in res['new_segments']
+                               if s.net_id != s_id] + new_segs
+        md[f'{S}_len'] = new_len
+        added_total += added
+        print(f"      {md['base']}: +{added:.3f}mm on {S.upper()} ({bumps} bumps)")
+
+    new_total_s = (total_p if S == 'p' else total_n) + added_total
+    new_total_l = total_n if S == 'p' else total_p
+    new_delta = abs(new_total_l - new_total_s)
+    if added_total <= tol:
+        print(f"    AC-couple {name}: could not fit end-to-end meanders "
+              f"(residual delta={delta:.3f}mm)")
+    else:
+        print(f"    AC-couple {name}: added {added_total:.3f}mm to {S.upper()}, "
+              f"end-to-end delta {delta:.3f} -> {new_delta:.3f}mm")
+    return new_delta

--- a/pcb_modification.py
+++ b/pcb_modification.py
@@ -6,7 +6,7 @@ self-intersecting or redundant segments.
 """
 
 import math
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from kicad_parser import PCBData, Segment, Via
 from routing_utils import pos_key, POSITION_DECIMALS, into_pad_frame_point

--- a/route_diff.py
+++ b/route_diff.py
@@ -163,6 +163,7 @@ def batch_route_diff_pairs(input_file: str, output_file: str, net_names: List[st
                 time_match_tolerance: float = defaults.TIME_MATCH_TOLERANCE,
                 diff_chamfer_extra: float = defaults.DIFF_PAIR_CHAMFER_EXTRA,
                 diff_pair_intra_match: bool = False,
+                ac_couple_match: bool = False,
                 debug_memory: bool = False,
                 mps_reverse_rounds: bool = False,
                 mps_layer_swap: bool = False,
@@ -191,6 +192,8 @@ def batch_route_diff_pairs(input_file: str, output_file: str, net_names: List[st
         gnd_via_enabled: Add GND vias near diff pair signal vias (default: True)
         diff_chamfer_extra: Chamfer multiplier for diff pair meanders (default: 1.5)
         diff_pair_intra_match: Enable intra-pair P/N length matching (default: False)
+        ac_couple_match: End-to-end length-match AC-coupled diff pairs split by series
+            DC-blocking caps, matching the concatenated P vs N path (#196) (default: False)
         return_results: If True, return results data instead of writing to file
         pcb_data: Optional pre-parsed PCBData (if None, loads from input_file)
 
@@ -291,6 +294,7 @@ def batch_route_diff_pairs(input_file: str, output_file: str, net_names: List[st
         gnd_via_enabled=gnd_via_enabled,
         diff_chamfer_extra=diff_chamfer_extra,
         diff_pair_intra_match=diff_pair_intra_match,
+        ac_couple_match=ac_couple_match,
     )
     if direction_order is not None:
         config_kwargs['direction_order'] = direction_order
@@ -303,6 +307,21 @@ def batch_route_diff_pairs(input_file: str, output_file: str, net_names: List[st
     # Find differential pairs from all provided nets
     diff_pairs: Dict[str, DiffPairNet] = find_differential_pairs(pcb_data, net_names)
     diff_pair_net_ids = set()  # Net IDs that are part of differential pairs
+
+    # Detect AC-coupled XNets (#196): differential pairs split into two base-named
+    # pairs by series DC-blocking caps, to be length-matched END-TO-END after
+    # routing (see the AC-couple pass below). Pure read of pcb_data -- gathers a
+    # side-structure only, never touching diff_pairs / net order / pcb_data, so the
+    # routed result is byte-identical when --ac-couple-match is off.
+    ac_xnets = []
+    if config.ac_couple_match:
+        from diff_xnet import find_ac_coupled_xnets
+        ac_xnets, ac_warnings = find_ac_coupled_xnets(pcb_data, diff_pairs)
+        for _w in ac_warnings:
+            print(f"  WARNING: {_w}")
+        for _xn in ac_xnets:
+            print(f"  AC-coupled XNet: {'+'.join(_xn.base_names)} "
+                  f"(coupled via {', '.join(_xn.bridge_refs)})")
 
     if not diff_pairs:
         print(f"Error: No differential pairs found matching the patterns!")
@@ -775,6 +794,14 @@ def batch_route_diff_pairs(input_file: str, output_file: str, net_names: List[st
 
         # Process each diff pair once (using p_net_id as key to avoid duplicates)
         processed_pairs = set()
+        # AC-coupled (XNet) member pairs are matched end-to-end below, not per-side;
+        # skip them here so the two passes don't fight (double-meander). Gated on
+        # the flag so intra-pair behavior is unchanged when --ac-couple-match is off.
+        xnet_member_p_net_ids = set()
+        if config.ac_couple_match:
+            for _xn in ac_xnets:
+                for _m in _xn.members:
+                    xnet_member_p_net_ids.add(_m.p_net_id)
         for net_id, result in routed_results.items():
             if not result.get('is_diff_pair'):
                 continue
@@ -782,6 +809,8 @@ def batch_route_diff_pairs(input_file: str, output_file: str, net_names: List[st
             if p_net_id is None or p_net_id in processed_pairs:
                 continue
             processed_pairs.add(p_net_id)
+            if p_net_id in xnet_member_p_net_ids:
+                continue  # matched end-to-end by the AC-couple pass (#196)
 
             # Get pair name for logging
             pair_info = diff_pair_by_net_id.get(net_id)
@@ -791,6 +820,25 @@ def batch_route_diff_pairs(input_file: str, output_file: str, net_names: List[st
             seg_count_before = len(result.get('new_segments', []))
             apply_intra_pair_length_matching(result, config, pcb_data)
             seg_count_after = len(result.get('new_segments', []))
+
+    # Apply end-to-end AC-coupled (XNet) length matching if configured (#196).
+    # Runs AFTER group + intra-pair matching; for its member pairs it supersedes
+    # per-side intra-pair (skipped above) by matching the concatenated P vs N path
+    # and placing the compensating meanders on whichever segment has room.
+    ac_coupled_summary = []
+    if config.ac_couple_match and ac_xnets:
+        from length_matching import apply_ac_coupled_length_matching
+        print("\n" + "=" * 60)
+        print("End-to-end AC-coupled diff-pair length matching (#196)")
+        print("=" * 60)
+        for _xn in ac_xnets:
+            _skew = apply_ac_coupled_length_matching(_xn, routed_results, config, pcb_data)
+            if _skew is not None:
+                ac_coupled_summary.append({
+                    'nets': "+".join(_xn.base_names),
+                    'skew_mm': round(_skew, 4),
+                    'bridges': _xn.bridge_refs,
+                })
 
     # Sync pcb_data with length-matched segments
     sync_pcb_data_segments(pcb_data, routed_results, original_segment_ids, state, config)
@@ -893,6 +941,8 @@ def batch_route_diff_pairs(input_file: str, output_file: str, net_names: List[st
         # taps below the nominal). Grade/check_drc the board at this floor.
         'min_clearance_used': __import__('clearance_ledger').effective(clearance),
     }
+    if ac_coupled_summary:
+        summary['ac_coupled_xnets'] = ac_coupled_summary
     print(f"JSON_SUMMARY: {json.dumps(summary)}")
 
     # Write output file or return results for direct application
@@ -1170,6 +1220,10 @@ Examples:
                         help="Chamfer multiplier for diff pair meanders (default: 1.5, >1 avoids P/N crossings)")
     parser.add_argument("--diff-pair-intra-match", action="store_true",
                         help="Enable intra-pair P/N length matching (add meanders to shorter track of each diff pair)")
+    parser.add_argument("--ac-couple-match", action="store_true",
+                        help="End-to-end length-match AC-coupled differential pairs split by series DC-blocking "
+                             "caps (#196): auto-detect the cap chain, match the concatenated P path vs the N path, "
+                             "and place the compensating meanders on whichever segment has room. Off by default.")
 
     # Rip-up and retry options
     parser.add_argument("--max-ripup", type=int, default=3,
@@ -1349,6 +1403,7 @@ Examples:
                 time_match_tolerance=args.time_match_tolerance,
                 diff_chamfer_extra=args.diff_chamfer_extra,
                 diff_pair_intra_match=args.diff_pair_intra_match,
+                ac_couple_match=args.ac_couple_match,
                 debug_memory=args.debug_memory,
                 mps_reverse_rounds=args.mps_reverse_rounds,
                 mps_layer_swap=args.mps_layer_swap,

--- a/routing_config.py
+++ b/routing_config.py
@@ -100,6 +100,7 @@ class GridRouteConfig:
     meander_amplitude: float = 1.0  # mm - height of meander perpendicular to trace
     diff_chamfer_extra: float = 1.5  # Chamfer multiplier for diff pair meanders (>1 avoids P/N crossings)
     diff_pair_intra_match: bool = False  # Enable intra-pair P/N length matching (meander shorter track)
+    ac_couple_match: bool = False  # End-to-end length-match AC-coupled pairs split by series caps (#196)
     # Hybrid escape: when a coupled pair's terminal connector can't clear foreign
     # copper (#165 graze), keep the coupled middle and defer each terminal leg to
     # a point-to-point single-ended join instead of failing the whole pair.

--- a/tests/test_ac_coupled_match.py
+++ b/tests/test_ac_coupled_match.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""
+Tests for end-to-end AC-coupled differential-pair length matching (issue #196).
+
+Covers:
+  * XNet detection (board-free unit tests): symmetric cap chains are stitched;
+    asymmetric / DNP / decoupling / cross-polarity cases are NOT; multi-cap chains
+    fold into one group.
+  * Concatenated, polarity-aware measurement (_ac_coupled_member_lengths unit test).
+  * Integration on the issue's repro board (kicad_files/cap_chain.kicad_pcb): with
+    --ac-couple-match the XNet is detected, the concatenated P-vs-N skew is reported
+    in JSON_SUMMARY, and both sides still route.
+  * Control: without the flag there is no ac_coupled_xnets key (per-side behavior,
+    so the routed board is unaffected).
+
+Run with a Python that has the Rust router + numpy/scipy/shapely, e.g.:
+    python3 tests/test_ac_coupled_match.py
+"""
+import json
+import os
+import re
+import subprocess
+import sys
+from types import SimpleNamespace
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT_DIR = os.path.dirname(TESTS_DIR)
+sys.path.insert(0, ROOT_DIR)
+sys.path.insert(0, os.path.join(ROOT_DIR, "rust_router"))
+
+from kicad_parser import Segment                       # noqa: E402
+from routing_config import DiffPairNet                 # noqa: E402
+from diff_xnet import find_ac_coupled_xnets            # noqa: E402
+from length_matching import _ac_coupled_member_lengths  # noqa: E402
+
+BOARD = os.path.join(ROOT_DIR, "kicad_files", "cap_chain.kicad_pcb")
+GEOM = ["--layers", "F.Cu", "B.Cu", "--track-width", "0.15", "--diff-pair-gap", "0.25",
+        "--diff-pair-intra-match", "--no-fix-polarity"]
+NETS = ["DPA_P", "DPA_N", "DPB_P", "DPB_N"]
+
+
+# ----------------------------------------------------------------------------- helpers
+def _pad(net_id):
+    return SimpleNamespace(net_id=net_id)
+
+
+def _fp(pad_nets, dnp=False):
+    return SimpleNamespace(pads=[_pad(n) for n in pad_nets], dnp=dnp)
+
+
+def _pairs(*specs):
+    return {b: DiffPairNet(base_name=b, p_net_id=p, n_net_id=n,
+                           p_net_name=b + "_P", n_net_name=b + "_N")
+            for b, p, n in specs}
+
+
+def _detect(footprints, pairs):
+    return find_ac_coupled_xnets(SimpleNamespace(footprints=footprints), pairs)
+
+
+def _run_route(out, extra):
+    cmd = [sys.executable, "route_diff.py", BOARD, out, "--nets", *NETS] + GEOM + extra
+    r = subprocess.run(cmd, cwd=ROOT_DIR, capture_output=True, text=True)
+    m = re.search(r"JSON_SUMMARY:\s*(\{.*\})", r.stdout)
+    summary = json.loads(m.group(1)) if m else None
+    return r, summary
+
+
+# ----------------------------------------------------------------------------- tests
+def run():
+    fails = []
+
+    # nets: DPA_P=1 DPA_N=2 DPB_P=3 DPB_N=4 DPC_P=5 DPC_N=6 GND=99
+    AB = _pairs(("DPA", 1, 2), ("DPB", 3, 4))
+
+    # 1. symmetric: C1 bridges P (1<->3), C2 bridges N (2<->4) -> one XNet, 2 members
+    xn, w = _detect({"C1": _fp([1, 3]), "C2": _fp([2, 4])}, AB)
+    if not (len(xn) == 1 and len(xn[0].members) == 2 and not w):
+        fails.append(f"symmetric: expected 1 XNet of 2 members, got {len(xn)} xnets / warns={w}")
+    elif sorted(xn[0].base_names) != ["DPA", "DPB"] or sorted(xn[0].bridge_refs) != ["C1", "C2"]:
+        fails.append(f"symmetric: wrong members/bridges: {xn[0].base_names} {xn[0].bridge_refs}")
+
+    # 2. asymmetric (only P bridged) -> no XNet, one warning
+    xn, w = _detect({"C1": _fp([1, 3])}, AB)
+    if len(xn) != 0 or len(w) != 1:
+        fails.append(f"asymmetric: expected 0 XNets + 1 warning, got {len(xn)} / {len(w)}")
+
+    # 3. DNP on the P bridge -> only N bridged -> asymmetric -> no XNet
+    xn, w = _detect({"C1": _fp([1, 3], dnp=True), "C2": _fp([2, 4])}, AB)
+    if len(xn) != 0:
+        fails.append(f"DNP: a no-pop cap must not bridge; expected 0 XNets, got {len(xn)}")
+
+    # 4. decoupling cap (a pad on GND=99, not a pair net) ignored; real chain still found
+    xn, w = _detect({"C1": _fp([1, 3]), "C2": _fp([2, 4]), "C3": _fp([1, 99])}, AB)
+    if not (len(xn) == 1 and len(xn[0].members) == 2):
+        fails.append(f"decoupling-cap: expected 1 XNet of 2 members, got {len(xn)}")
+
+    # 5. chain A--B--C via 4 caps -> one XNet of 3 members
+    ABC = _pairs(("DPA", 1, 2), ("DPB", 3, 4), ("DPC", 5, 6))
+    xn, w = _detect({"C1": _fp([1, 3]), "C2": _fp([2, 4]),
+                     "C3": _fp([3, 5]), "C4": _fp([4, 6])}, ABC)
+    if not (len(xn) == 1 and len(xn[0].members) == 3):
+        fails.append(f"chain: expected 1 XNet of 3 members, got "
+                     f"{len(xn)} / {[m.base_name for m in xn[0].members] if xn else None}")
+
+    # 6. inert: no caps -> nothing detected, no warnings
+    xn, w = _detect({}, AB)
+    if xn != [] or w != []:
+        fails.append(f"inert: expected nothing, got {len(xn)} xnets / {len(w)} warns")
+
+    # 7. cross-polarity (P<->N swapped) bridge -> not supported, ignored
+    xn, w = _detect({"C1": _fp([1, 4]), "C2": _fp([2, 3])}, AB)
+    if len(xn) != 0:
+        fails.append(f"cross-polarity: expected 0 XNets, got {len(xn)}")
+
+    # 8. measurement: concatenated, polarity-aware per-member lengths.
+    def seg(x1, y1, x2, y2, net):
+        return Segment(start_x=x1, start_y=y1, end_x=x2, end_y=y2,
+                       width=0.1, layer="F.Cu", net_id=net)
+    fake_pcb = SimpleNamespace()
+    res = {"is_diff_pair": True, "p_net_id": 1, "n_net_id": 2,
+           "new_segments": [seg(0, 0, 10, 0, 1), seg(0, 1, 12, 1, 2)],  # P=10mm, N=12mm
+           "new_vias": [],
+           "p_src_stub_length": 0.0, "p_tgt_stub_length": 0.0,
+           "n_src_stub_length": 0.0, "n_tgt_stub_length": 0.0,
+           "polarity_fixed": False}
+    md = _ac_coupled_member_lengths(res, 1, 2, fake_pcb)
+    if not (abs(md["p_len"] - 10.0) < 1e-6 and abs(md["n_len"] - 12.0) < 1e-6):
+        fails.append(f"measurement: P/N routed length wrong: {md['p_len']} / {md['n_len']}")
+
+    # 8b. polarity swap re-routes the target stubs between P and N
+    res2 = dict(res, polarity_fixed=True,
+                p_src_stub_length=1.0, p_tgt_stub_length=2.0,
+                n_src_stub_length=3.0, n_tgt_stub_length=4.0)
+    md2 = _ac_coupled_member_lengths(res2, 1, 2, fake_pcb)
+    # swapped: p_stub = p_src + n_tgt = 1+4 = 5 ; n_stub = n_src + p_tgt = 3+2 = 5
+    if not (abs(md2["p_len"] - 15.0) < 1e-6 and abs(md2["n_len"] - 17.0) < 1e-6):
+        fails.append(f"polarity-swap stubs wrong: p_len={md2['p_len']} n_len={md2['n_len']}")
+
+    # 9. INTEGRATION on the issue's repro board: detection + reporting + routes.
+    if not os.path.exists(BOARD):
+        fails.append(f"integration: fixture missing: {BOARD}")
+    else:
+        out = os.path.join(TESTS_DIR, "_cap_chain_out.kicad_pcb")
+        try:
+            r, summary = _run_route(out, ["--ac-couple-match"])
+            if summary is None:
+                fails.append("integration: no JSON_SUMMARY emitted\n" + r.stdout[-800:] + r.stderr[-800:])
+            elif summary.get("successful") != 2:
+                fails.append(f"integration: expected 2 pairs routed, got {summary.get('successful')}")
+            elif "ac_coupled_xnets" not in summary:
+                fails.append("integration: --ac-couple-match did not add 'ac_coupled_xnets' to JSON_SUMMARY")
+            else:
+                xnets = summary["ac_coupled_xnets"]
+                if len(xnets) != 1 or xnets[0].get("nets") != "DPA+DPB":
+                    fails.append(f"integration: wrong XNet summary: {xnets}")
+                elif sorted(xnets[0].get("bridges", [])) != ["C1", "C2"]:
+                    fails.append(f"integration: wrong bridges: {xnets[0].get('bridges')}")
+                elif not isinstance(xnets[0].get("skew_mm"), (int, float)):
+                    fails.append(f"integration: skew_mm not reported: {xnets[0]}")
+
+            # 10. CONTROL: without the flag, no ac_coupled_xnets key (per-side behavior).
+            r2, summary2 = _run_route(out, [])
+            if summary2 is None:
+                fails.append("control: no JSON_SUMMARY emitted")
+            elif "ac_coupled_xnets" in summary2:
+                fails.append("control: ac_coupled_xnets present without --ac-couple-match (not inert)")
+        finally:
+            base = out[:-len(".kicad_pcb")]
+            for ext in (".kicad_pcb", ".kicad_pro", ".kicad_prl"):
+                if os.path.exists(base + ext):
+                    os.remove(base + ext)
+
+    # ----------------------------------------------------------------------- report
+    if fails:
+        for f in fails:
+            print(f"  FAIL  {f}")
+        print(f"\n{len(fails)} check(s) FAILED")
+        return False
+    print("PASS  AC-coupled XNet detection + measurement + integration")
+    return True
+
+
+if __name__ == "__main__":
+    sys.exit(0 if run() else 1)


### PR DESCRIPTION
## Sorry up front, this one's bigger than I'd like 🙏

I normally try hard to keep PRs small and surgical, and I know a large diff is more to review. I genuinely couldn't find a smaller way to do #196 *correctly*: detecting the AC-coupling topology, matching the concatenated path end-to-end, and keeping the CLI / GUI / settings in parity are interdependent, so a partial version would be either wrong or misleading. To make it as reviewable as possible I've split it into single-purpose commits and kept the whole feature **provably inert when the flag is off**. Thanks for bearing with me.

## What this does

Fixes #196. When a differential pair is AC-coupled through series DC-blocking caps it splits into two base-named pairs : `DPA_P/DPA_N` (driver→caps) and `DPB_P/DPB_N` (caps→receiver). `route_diff` length-matches each side's P/N independently and has no concept that they're one signal, so the end-to-end skew the receiver actually sees :`len(DPA_P)+len(DPB_P)` vs `len(DPA_N)+len(DPB_N)` is neither reported nor matched.

This adds the industry-standard **extended-net / XNet** treatment behind a new `--ac-couple-match` flag (off by default):

1. **Detect** the cap chain (`diff_xnet.py`): a 2-pad cap bridging `A_P↔B_P` plus a partner bridging `A_N↔B_N` joins two pairs into one XNet. Conservative symmetric bridges only, signal nets only, **DNP/no-pop caps treated as open circuits and skipped**, multi-cap chains supported, asymmetric junctions warned and left to per-side behavior.
2. **Match end-to-end** (`apply_ac_coupled_length_matching`): measure the concatenated P vs N conductor (polarity/stub-aware), then place the compensating meanders on whichever segment has room, preferring the segment where it also reduces local intra-pair skew and **report the end-to-end skew** in `JSON_SUMMARY` as `ac_coupled_xnets`. For its member pairs it supersedes per-side intra-pair matching so the two passes don't fight.
3. Reuses the existing meander engine via a shared `_lengthen_net_with_meanders()` core refactored out of `apply_intra_pair_length_matching()` (behavior unchanged). no parallel matching subsystem.

Wired through the CLI (`--ac-couple-match`), the Differential GUI tab + `settings_persistence`, with docs in `length-matching.md` and `api-routing-config.md`.

## ⚠️ One unrelated fix is bundled in (happy to split it out)

While testing I hit a **pre-existing import-breaking bug on `main`**: `pcb_modification.py` (from `2148f33`, `fix(#224)`) annotates a parameter `List[Dict]` but never imports `Dict`, so **`route_diff` fails to import under any Python** (`NameError: name 'Dict' is not defined`). CI didn't catch it because it doesn't run the functional tests. The first commit here is the one-word fix; nothing else works without it. Glad to move it to its own PR if you prefer.

## Inertness (byte-identical when off)

With the flag off, every new path is skipped and the only un-gated change (the intra-pair refactor) is logic-preserving. I verified the routed **geometry is byte-identical** to clean `main` + the `Dict` fix by parsing both outputs and comparing segment/via multisets — MD5 is meaningless here since KiCad emits fresh random track UUIDs each run.

## Test results

Run under a Python with the router + numpy/scipy/shapely:

```
test_ac_coupled_match            PASS   detection ×7 + concat/polarity measurement + integration + control
test_diff_pair_route             PASS   5/5 pairs
test_diff_pair_detection         PASS
test_diff_layer_costs_response   PASS   (routes pairs → exercises the shared meander refactor)
test_multipoint_diff_route       PASS
run_doc_examples                 27 run, 5 failed   (all pre-existing missing-fixture cases; was 6 before
                                                    the Dict fix — this PR recovers one)
```

On the issue's repro board (`kicad_files/cap_chain.kicad_pcb`, built by the script in #196), `--ac-couple-match` now surfaces the end-to-end skew `main` never reported:

```
AC-coupled XNet: DPA+DPB (coupled via C1, C2)
AC-couple DPA+DPB: end-to-end P=20.089mm, N=19.974mm, delta=0.115mm (coupled via C1, C2)
JSON_SUMMARY: {... "ac_coupled_xnets": [{"nets": "DPA+DPB", "skew_mm": 0.1148, "bridges": ["C1", "C2"]}]}
```

On this near-symmetric synthetic board the residual is a fixed ~0.115 mm pad/stub asymmetry just over the 0.1 mm tolerance, so it correctly reports "could not fit" rather than faking a match — the multi-mm skew in the issue came from real-board congestion. The meander path itself is the same one intra-pair uses, exercised by the routing tests above.

## Background / references

The end-to-end "extended net" approach and the signal-integrity rationale are well established; the design follows these:

- **Altium — Defining High-Speed Signal Paths with xSignals** — an xSignal is two nets joined by a series component (incl. capacitors); Length / Matched-Length rules span the whole path. https://www.altium.com/documentation/altium-designer/defining-high-speed-signal-paths-with-xsignals
- **Cadence / OrCAD X — XNet (eXtended Net)** — a net joined to another across a series passive; Constraint Manager bundles the segment lengths into one value. https://resources.pcb.cadence.com/blog/2024-orcad-x-create-remove-xnet-step-by-step-guide-cadence
- **TI SPRAAR7E — High-Speed Interface Layout Guidelines** — intra-pair skew budgets (5 mil for USB3/SATA/PCIe). https://www.ti.com/lit/an/spraar7e/spraar7e.pdf
- **Samtec, DesignCon 2024 — "Comparing the Different Metrics of Intra-Pair Skew in Tracking Channel Performance"** — residual skew converts differential energy to common mode; why end-to-end skew is the receiver-relevant metric; caution against blindly zeroing it. https://suddendocs.samtec.com/notesandwhitepapers/samtec-dc24-paper-comparing-the-different-metrics-of-intra-pair-skew-in-tracking-channel-performance.pdf
- **Intra-Pair Skew Propagation Graph (ISPG)**, arXiv 2026 (preprint) — total channel skew = sum of per-segment contributions, i.e. the formal basis for concatenating across the caps. https://arxiv.org/abs/2605.08570
- **Obstacle-Aware Length-Matching Routing for Any-Direction Traces**, DAC 2024 — confirms academic length-matchers are purely geometric and don't model cap-split topology, so the XNet has to be a constraint layer above the meandering. https://arxiv.org/abs/2407.19195
- KiCad 8/9/10 has no native cross-series-component tuning (KiCad 10 added delay tuning, not xnets — tracked at https://gitlab.com/kicad/code/kicad/-/issues/18118), so this is built into the tool.

## Known limitations / follow-ups

- Length-only (mirrors intra-pair); a delay-aware variant and routing the pair *coupled through* the cap break (via the #243 hybrid) are natural follow-ups.
- Exactly-2-pad caps only — 4-pad arrays / multi-pair packages fall back to per-side matching + a warning.
- Pad-escape length isn't counted (inherited limitation from intra-pair matching).
