### PR TITLE
Fix NameError: import Dict in pcb_modification.py

### DIFF
--- a/pcb_modification.py
+++ b/pcb_modification.py
@@ -6,7 +6,7 @@ self-intersecting or redundant segments.
 """
 
 import math
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from kicad_parser import PCBData, Segment, Via
 from routing_utils import pos_key, POSITION_DECIMALS, into_pad_frame_point


### PR DESCRIPTION
## Bug
Importing `pcb_modification` raises `NameError`, which takes down `route.py` (it imports `pcb_modification` at module load) and every other importer:

```
$ python3 route.py kicad_files/interf_u_unrouted_placed.kicad_pcb out.kicad_pcb
  File ".../pcb_modification.py", line 1263, in <module>
    def cleanup_plane_taps_grazing(pcb_data: PCBData, all_new_segments: List[Dict], ...
NameError: name 'Dict' is not defined. Did you mean: 'dict'?
```

`cleanup_plane_taps_grazing()` is annotated `all_new_segments: List[Dict]`, but the module imports only `List, Optional, Tuple` from `typing` (line 9). With no `from __future__ import annotations`, the signature is evaluated at import time, so the module can't be imported at all.

## Fix
Add `Dict` to the `typing` import — one line.

## Verification
- `python3 -c "import pcb_modification"` now succeeds (was raising `NameError`).
- `python3 route.py kicad_files/interf_u_unrouted_placed.kicad_pcb out.kicad_pcb` routes end-to-end (787 track segments + 82 vias written).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
