### PR TITLE
Fix SameFileError in route_diff.py --overwrite when no pair routes

### DIFF
--- a/route_diff.py
+++ b/route_diff.py
@@ -939,8 +939,11 @@ def batch_route_diff_pairs(input_file: str, output_file: str, net_names: List[st
         # (the chains route '*' from the diff step's output); without this the
         # whole chain FileNotFoundErrors on the missing board (issues #90, #167).
         if not wrote and output_file:
-            import shutil
-            shutil.copy(input_file, output_file)
+            import shutil, os
+            # under --overwrite, output_file IS input_file: the board is already
+            # there, so skip the copy (shutil.copy would raise SameFileError).
+            if os.path.abspath(input_file) != os.path.abspath(output_file):
+                shutil.copy(input_file, output_file)
             if state.diff_pair_single_ended_nets:
                 print(f"\nAll diff pairs deferred to single-ended (no coupled copper "
                       f"added); wrote board through to {output_file} for the "


### PR DESCRIPTION
## Bug
`route_diff.py --overwrite` crashes with `shutil.SameFileError` whenever no differential pair can be coupled-routed:

```
$ python3 route_diff.py board.kicad_pcb --overwrite --nets ETH_TXP ETH_TXN ETH_RXP ETH_RXN
...
shutil.SameFileError: 'board.kicad_pcb' and 'board.kicad_pcb' are the same file
```

Under `--overwrite`, `output_file` is set to `input_file` (argparse, ~line 1244). When `wrote == False`, the pass-through at the end of `batch_route_diff_pairs()` runs `shutil.copy(input_file, output_file)` — copying the board onto itself — which raises `SameFileError`. This kills any pipeline that uses `route_diff --overwrite` as a stage (e.g. route planes → route → `route_diff --overwrite` on one board file).

## Fix
Skip the copy when `input_file` and `output_file` resolve to the same path — the board is already at the output path, so there is nothing to copy. The informational "wrote board through unchanged" message still prints.

## Verification
On a board whose only pair can't be coupled-routed:
- **before:** `SameFileError` traceback, non-zero exit.
- **after:** exits 0, prints "No diff pair could be coupled-routed; wrote board through unchanged … so the pipeline can continue", board intact (205 footprints).

(Independent of #247; verified with that fix applied so the module imports.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
