### PR TITLE
Fix TypeError in place_route_loop when a multipoint net fails to route

### DIFF
--- a/place_route_loop.py
+++ b/place_route_loop.py
@@ -55,7 +55,11 @@ def run_route(pcb_file: str, routed_file: str, route_args: str, log_file: str):
     summary = json.loads(m.group(1))
 
     failed_nets = list(summary.get('failed_single', []))
-    failed_nets += list(summary.get('failed_multipoint', []))
+    # failed_multipoint entries are dicts {net_name, failed_pads}; keep just the
+    # name so failed_nets is uniformly net-name strings (downstream uses them as
+    # dict keys -> a dict here raises "unhashable type: 'dict'").
+    failed_nets += [d['net_name'] if isinstance(d, dict) else d
+                    for d in summary.get('failed_multipoint', [])]
     mp_deficit = (summary.get('multipoint_pads_total', 0)
                   - summary.get('multipoint_pads_connected', 0))
     failures = len(summary.get('failed_single', [])) + mp_deficit


### PR DESCRIPTION
## Bug
`place_route_loop.py` crashes right after the first route on any board that has an unrouted multipoint net:

```
Round 0: routing initial placement...
  failures=26 iterations=2,453,233 vias=514
Traceback (most recent call last):
  File ".../place_route_loop.py", line 80, in nets_to_refs
    nid = name_to_id.get(name)
TypeError: unhashable type: 'dict'
```

`run_route()` builds `failed_nets` from `failed_single` (net-name **strings**) **plus** `failed_multipoint` — but those entries are **dicts** `{net_name, failed_pads}`. `nets_to_refs()` then calls `name_to_id.get(name)` (and `main()`'s `net_weights` comprehension does `name_to_id[n]`), using a dict as a dict key → `TypeError: unhashable type: 'dict'`. The repair loop dies before it can move anything.

## Fix
Extract `net_name` from the multipoint dicts so `failed_nets` is uniformly net-name strings.

## Verification
- **Before:** crashes entering round 1 with the traceback above (207-part board, 26 failures after round 0).
- **After:** runs past round 0 into the placement-repair quench — no traceback; reaches the part-move + re-route step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
