### PR TITLE
fix: add missing typing imports and fix Path | None syntax for Python…

### DIFF
--- a/kicad_parser.py
+++ b/kicad_parser.py
@@ -6,7 +6,7 @@ import re
 import math
 import json
 from dataclasses import dataclass, field
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List, Optional, Tuple
 from pathlib import Path
 
 

--- a/kicad_routing_plugin/board_swaps.py
+++ b/kicad_routing_plugin/board_swaps.py
@@ -15,6 +15,7 @@ This module deliberately avoids wx so it can be used headless.
 """
 
 from routing_utils import pos_key
+from typing import Type
 
 
 def _to_mm_key(pcbnew, point):

--- a/kicad_routing_plugin/claude_gui.py
+++ b/kicad_routing_plugin/claude_gui.py
@@ -19,6 +19,7 @@ import threading
 import subprocess
 
 import wx
+from typing import Set
 
 PLUGIN_DIR = os.path.dirname(os.path.abspath(__file__))
 ROOT_DIR = os.path.dirname(PLUGIN_DIR)

--- a/kicad_routing_plugin/settings_persistence.py
+++ b/kicad_routing_plugin/settings_persistence.py
@@ -3,6 +3,7 @@ KiCad Routing Tools - Dialog Settings Persistence
 
 Handles saving and restoring dialog settings between invocations.
 """
+from typing import Set
 
 
 def get_dialog_settings(dialog):

--- a/kicad_routing_plugin/swig_gui.py
+++ b/kicad_routing_plugin/swig_gui.py
@@ -10,6 +10,7 @@ import sys
 import time
 import wx
 import threading
+from typing import List
 
 # Add parent directory to path
 PLUGIN_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/obstacle_map.py
+++ b/obstacle_map.py
@@ -5,7 +5,7 @@ Builds GridObstacleMap objects from PCB data, adding obstacles for segments,
 vias, pads, BGA exclusion zones, and routed paths.
 """
 
-from typing import List, Optional, Tuple, Dict, Set, Union
+from typing import Dict, List, Mapping, Optional, Set, Tuple, Union
 from dataclasses import dataclass, field
 import numpy as np
 import math

--- a/package_pcm.py
+++ b/package_pcm.py
@@ -44,6 +44,7 @@ import tempfile
 import urllib.request
 import zipfile
 from pathlib import Path
+from typing import Optional
 
 
 SCRIPT_DIR = Path(__file__).parent.resolve()
@@ -99,7 +100,7 @@ def read_version():
     return (SCRIPT_DIR / "VERSION").read_text().strip()
 
 
-def stage_plugins(stage_root: Path, binary_dir: Path | None = None):
+def stage_plugins(stage_root: Path, binary_dir: Optional[Path] = None):
     """Copy the repo working tree (minus ROOT_EXCLUDE / IGNORE_PATTERNS) into
     <stage_root>/plugins/.
 
@@ -142,7 +143,7 @@ def _download_asset(version: str, asset_name: str, dest: Path):
         shutil.copyfileobj(resp, f)
 
 
-def install_binaries(plugins_dir: Path, version: str, binary_dir: Path | None):
+def install_binaries(plugins_dir: Path, version: str, binary_dir: Optional[Path]):
     """Place ALL platform Rust binaries into plugins/rust_router/ under their
     platform-suffix names. The plugin's startup resolver picks the right one.
     """

--- a/pcb_modification.py
+++ b/pcb_modification.py
@@ -6,7 +6,7 @@ self-intersecting or redundant segments.
 """
 
 import math
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from kicad_parser import PCBData, Segment, Via
 from routing_utils import pos_key, POSITION_DECIMALS, into_pad_frame_point

--- a/plane_obstacle_builder.py
+++ b/plane_obstacle_builder.py
@@ -7,7 +7,7 @@ Provides functions to build obstacle maps for:
 """
 
 import math
-from typing import List, Dict, Tuple, Optional
+from typing import Dict, List, Optional, Tuple, cast
 
 import numpy as np
 


### PR DESCRIPTION
Fix Python 3.9 typing compatibility (KiCad's bundled Python)

KiCad ships Python 3.9 on macOS and Windows. Three issues prevented install_plugin.py and the plugin from loading on Python 3.9:

- Path | None union syntax (PEP 604) in install_plugin.py and package_pcm.py — only valid Python 3.10+, replaced with Optional[Path]
- Missing from typing import statements in 8 files (Dict, List, Set, Mapping, Type, cast, Optional) — these names have never been builtins and require explicit imports

No logic changes; annotation-only fixes.

**Test:
Rebuilt on my Mac and was able to use KRT**

Files changed:
- package_pcm.py: Path | None → Optional[Path] (×2) + add Optional import
- kicad_parser.py: sort typing imports (Counter was already in collections)
- kicad_routing_plugin/board_swaps.py: add Type
- kicad_routing_plugin/claude_gui.py: add Set
- kicad_routing_plugin/settings_persistence.py: add Set (after docstring)
- kicad_routing_plugin/swig_gui.py: add List
- obstacle_map.py: add Mapping
- pcb_modification.py: add Dict
- plane_obstacle_builder.py: add cast