### PR TITLE
#406: grade connection_width (min copper web) in the kicad-cli cross-check

### DIFF
--- a/tests/stress/RUNBOOK.md
+++ b/tests/stress/RUNBOOK.md
@@ -357,6 +357,16 @@ harmless.
    copper_edge_clearance on edge-connector fingers is design intent, not a
    routing defect. The no-LLM replay grader (ab_replay_grade.py) now records
    the same fields automatically.
+   CONNECTION_WIDTH (#406): the cross-check also grades KiCad's min-copper-web
+   class, SEPARATELY from the copper classes (check_drc has no counterpart --
+   the artifact lives in KiCad's own float-borderline web measurement, so web
+   items never count as KICAD-ONLY). KiCad ships the checker OFF
+   (min_connection 0, warning severity); the staged copy turns it on at the
+   author's min_connection when set, else the project's min_track_width (the
+   post-route ledger floors it at the smallest object on the board). Recorded
+   as `kicad_connection_width` (None = not graded: no recorded floor) +
+   `connection_width_min`; ab_replay_grade compares the count per board (connw
+   column) and gates the A/B verdict on its delta.
 8. OOM REGRESSION CHECK (issue #81, fixed): the obstacle-map polygon pass is
    now chunked; DEFAULT grids should stay well under the 4 GB cap on every
    board. Use the default --grid-step unless component pitch demands finer.

--- a/tests/stress/_gitver.py
+++ b/tests/stress/_gitver.py
@@ -8,8 +8,23 @@ results/wave dir self-documents the code that created it.
 """
 import datetime
 import json
+import os
 import subprocess
 from pathlib import Path
+
+# A/B ablation knobs that change engine behavior without changing the
+# checkout (KICAD_NO_SOFT_JOINT_BRIDGE, KICAD_NO_JOG_CHORD, ...). A wave run
+# with one of these set is a DIFFERENT experiment than the same commit without
+# it, so provenance must record them -- otherwise the off/on attribution of an
+# A/B table rests on operator memory. KICAD_* catches the whole family
+# (future knobs included); the explicit extras are the non-prefixed ones.
+_KNOB_EXTRAS = ("PRUNE_CONN_VERIFY",)
+
+
+def env_knobs():
+    """The engine-behavior env knobs set right now, as {name: value}."""
+    return {k: v for k, v in sorted(os.environ.items())
+            if k.startswith("KICAD_") or k in _KNOB_EXTRAS}
 
 
 def git_version(repo):
@@ -33,6 +48,7 @@ def git_version(repo):
         "dirty": bool(g("status", "--porcelain")),
         "subject": g("log", "-1", "--pretty=%s"),
         "committed_at": g("log", "-1", "--date=iso", "--pretty=%cd"),
+        "knobs": env_knobs(),
     }
 
 
@@ -55,6 +71,7 @@ def write_git_version(out_dir, repo, label=None):
         f"subject:   {ver['subject']}",
         f"committed: {ver['committed_at']}",
         f"captured:  {ver['captured_at']}",
+        f"knobs:     {ver.get('knobs') or '(none)'}",
     ]
     out.joinpath("git_version.txt").write_text("\n".join(lines) + "\n")
     return ver
@@ -75,7 +92,13 @@ def load_git_version(near_path):
 
 
 def format_version(ver):
-    """One-line summary for logs / compare headers ('label=v0.17.3-5-gabc1234')."""
+    """One-line summary for logs / compare headers ('label=v0.17.3-5-gabc1234
+    [KICAD_NO_JOG_CHORD=1]'). Knobs are part of the experiment's identity, so
+    the compare header must show them."""
     if not ver or not ver.get("describe"):
         return "unknown"
-    return f"{ver['label']}={ver['describe']}" if ver.get("label") else ver["describe"]
+    s = f"{ver['label']}={ver['describe']}" if ver.get("label") else ver["describe"]
+    knobs = ver.get("knobs")
+    if knobs:
+        s += " [" + " ".join(f"{k}={v}" for k, v in sorted(knobs.items())) + "]"
+    return s

--- a/tests/stress/ab_replay_grade.py
+++ b/tests/stress/ab_replay_grade.py
@@ -206,7 +206,8 @@ def _kicad_grade(pcb, clearance, baseline=None, intentional_edge_band_nets=None)
     edge-clearance violation on those nets is accepted-by-design and dropped from
     both engines (net-scoped), reported as kicad_intentional_edge /
     checkdrc_intentional_edge."""
-    _none = {"kicad_drc": None, "kicad_only": None, "checkdrc_only": None}
+    _none = {"kicad_drc": None, "kicad_only": None, "checkdrc_only": None,
+             "kicad_connection_width": None}
     try:
         sys.path.insert(0, str(REPO / "tests" / "stress"))
         from kicad_drc_compare import KICAD_CLI, compare_board_data
@@ -220,7 +221,10 @@ def _kicad_grade(pcb, clearance, baseline=None, intentional_edge_band_nets=None)
                 "kicad_only": data["kicad_only"], "checkdrc_only": data["checkdrc_only"],
                 "kicad_matched": data["matched"],
                 "kicad_intentional_edge": data.get("kicad_intentional_edge", 0),
-                "checkdrc_intentional_edge": data.get("checkdrc_intentional_edge", 0)}
+                "checkdrc_intentional_edge": data.get("checkdrc_intentional_edge", 0),
+                # #406 min copper web (KiCad-only class; None = not graded).
+                "kicad_connection_width": data.get("kicad_connection_width"),
+                "connection_width_min": data.get("connection_width_min")}
     except Exception:
         return _none
 
@@ -336,7 +340,8 @@ def do_board(set_dir, out_dir, label, board):
                          intentional_edge_band_nets=intentional))
     dps = f"{res['diff_pairs_coupled']}/{res['diff_pairs_total']}" if res['diff_pairs_total'] else "-"
     print(f"[{label}] {board}: chain={'ok' if done else 'BROKEN'} "
-          f"drc={res['drc']} kdrc={res.get('kicad_drc')} conn={res['conn']} compl={res['completion_pct']}% "
+          f"drc={res['drc']} kdrc={res.get('kicad_drc')} cw={res.get('kicad_connection_width')} "
+          f"conn={res['conn']} compl={res['completion_pct']}% "
           f"dpair={dps} t={res['total_seconds']}s peak={res['peak_rss_mb']}MB final={res['final']}", flush=True)
     return res
 
@@ -449,10 +454,14 @@ def compare(old_json, new_json):
     def _drc(r):
         v = r.get("drc_real")
         return v if v is not None else r.get("drc")
-    print(f"{'board':14} {'drc o->n':>11} {'incompl o->n':>13} {'compl% o->n':>13} "
+    # #406 min copper web (kicad-cli class, graded when a floor is recorded).
+    # None (not graded / pre-#406 summary / no kicad-cli) contributes no delta.
+    def _cw(r):
+        return r.get("kicad_connection_width")
+    print(f"{'board':14} {'drc o->n':>11} {'connw o->n':>12} {'incompl o->n':>13} {'compl% o->n':>13} "
           f"{'dpair o->n':>13} {'time(s) o->n':>16} {'peakMB o->n':>15}  note")
-    print("-" * 128)
-    drc_delta = incompl_delta = dpair_delta = 0
+    print("-" * 140)
+    drc_delta = incompl_delta = dpair_delta = cw_delta = 0
     t_old = t_new = 0.0
     time_old, time_new = {}, {}   # per-tool wall-clock summed across boards (speedup view)
     pk_old, pk_new = {}, {}       # per-tool peak RSS = max across boards (memory view)
@@ -461,14 +470,16 @@ def compare(old_json, new_json):
         oc = o and o["chain_complete"]
         nc = n and n["chain_complete"]
         if not (oc and nc):
-            print(f"{b:14} {'-':>11} {'-':>13} {'-':>13} {'-':>13} {'-':>16} {'-':>15}  chain incomplete "
+            print(f"{b:14} {'-':>11} {'-':>12} {'-':>13} {'-':>13} {'-':>13} {'-':>16} {'-':>15}  chain incomplete "
                   f"(old={'ok' if oc else 'broken'}, new={'ok' if nc else 'broken'}) -- excluded")
             continue
         oi, ni = _incompl(o), _incompl(n)
         od, nd = _drc(o), _drc(n)
         dd = (nd - od) if (od is not None and nd is not None) else 0
         cd = (ni - oi) if (oi is not None and ni is not None) else 0  # incomplete-net delta
-        drc_delta += dd; incompl_delta += cd
+        ocw, ncw = _cw(o), _cw(n)
+        cwd = (ncw - ocw) if (ocw is not None and ncw is not None) else 0  # web delta (#406)
+        drc_delta += dd; incompl_delta += cd; cw_delta += cwd
         # coupled diff-pair count (fewer coupled = quality regression)
         ocp, ncp = o.get("diff_pairs_coupled"), n.get("diff_pairs_coupled")
         odt, ndt = o.get("diff_pairs_total"), n.get("diff_pairs_total")
@@ -488,20 +499,23 @@ def compare(old_json, new_json):
         op, npc = o.get("completion_pct"), n.get("completion_pct")
         po, pn = o.get("peak_rss_mb"), n.get("peak_rss_mb")
         flag = ""
-        if dd > 0 or cd > 0 or dpd < 0:    flag = "  <-- REGRESSION"
-        elif dd < 0 or cd < 0 or dpd > 0:  flag = "  improved"
+        if dd > 0 or cd > 0 or dpd < 0 or cwd > 0:    flag = "  <-- REGRESSION"
+        elif dd < 0 or cd < 0 or dpd > 0 or cwd < 0:  flag = "  improved"
         # #408: annotate when accepted-by-design edge items were subtracted, so a
         # drop from raw drc to drc_real is visible rather than looking like noise.
         nie = n.get("drc_intentional_edge") or 0
         if nie:
             flag += f"  (#408 -{nie} edge accepted)"
         speed = f"  ({to/tn:.2f}x)" if (to and tn) else ""
-        print(f"{b:14} {_fmt(od):>4} -> {_fmt(nd):<4} {_fmt(oi):>5} -> {_fmt(ni):<5} "
+        print(f"{b:14} {_fmt(od):>4} -> {_fmt(nd):<4} {_fmt(ocw):>4} -> {_fmt(ncw):<4} "
+              f"{_fmt(oi):>5} -> {_fmt(ni):<5} "
               f"{_fmt(op):>5} -> {_fmt(npc):<5} {dp_o:>5} -> {dp_n:<5} "
               f"{_fmt(to):>6} -> {_fmt(tn):<6}{speed:>9} {_fmt(po):>6} -> {_fmt(pn):<6}{flag}")
-    print("-" * 128)
-    verdict = "REGRESSION" if (drc_delta > 0 or incompl_delta > 0 or dpair_delta < 0) else "no regression"
-    print(f"net delta: drc {drc_delta:+d}, incomplete nets {incompl_delta:+d} "
+    print("-" * 140)
+    verdict = ("REGRESSION" if (drc_delta > 0 or incompl_delta > 0
+                                or dpair_delta < 0 or cw_delta > 0) else "no regression")
+    print(f"net delta: drc {drc_delta:+d}, connection_width {cw_delta:+d} (#406), "
+          f"incomplete nets {incompl_delta:+d} "
           f"(unrouted + connectivity-issue), coupled diff-pairs {dpair_delta:+d}"
           f"  ==>  {verdict}")
     if t_old and t_new:
@@ -517,7 +531,8 @@ def compare(old_json, new_json):
     else:
         print("(timing/peak not available in one/both summaries -- re-run waves with the "
               "current ab_replay_grade to capture per-step timing + peak memory)")
-    return drc_delta <= 0 and incompl_delta <= 0 and dpair_delta >= 0
+    return (drc_delta <= 0 and incompl_delta <= 0 and dpair_delta >= 0
+            and cw_delta <= 0)
 
 
 def main():

--- a/tests/stress/classify_connection_width.py
+++ b/tests/stress/classify_connection_width.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Classify kicad-cli connection_width items: float-dust artifact vs real neck.
+
+KiCad's connection_width checker measures the copper web through its own
+float-borderline polygon arithmetic; a cap landing EXACTLY tangent to
+adjacent same-net copper (routine grid arithmetic) can read as a micro-void
+with a sub-minimum web on copper that is provably >= the floor everywhere
+(#406; measured live: 0.079 mm reported on >= 0.2 mm copper). This tool
+separates the two populations with the same polygon-erosion proof used to
+root-cause that emission:
+
+  For each flagged position, build the net's local copper union (segments as
+  round-capped buffers + pads, within RADIUS mm), take the connected
+  component nearest the flag, erode by floor/2 * (1-EPS), and test whether it
+  SURVIVES connected. A real neck (< floor web) erodes through and splits or
+  vanishes; an artifact (copper >= floor everywhere) survives as one piece.
+
+Limitations: zones are not modeled (stripped-corpus outputs carry none); a
+flag on zone copper classifies as NO-COPPER-FOUND rather than guessing.
+
+  python3 tests/stress/classify_connection_width.py <wave_dir> [--boards-dir <unrouted_dir>]
+  python3 tests/stress/classify_connection_width.py --board <final.kicad_pcb> [--baseline <unrouted>]
+  python3 tests/stress/classify_connection_width.py --self-test
+"""
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(REPO / "tests" / "stress"))
+
+RADIUS = 5.0   # mm of local copper context around the flagged position
+EPS = 1e-3     # relative erosion shortfall (stay strictly inside the floor)
+
+
+def _pad_shape(pad):
+    from shapely.geometry import Point, box
+    if pad.drill and pad.pad_type == "np_thru_hole":
+        return None
+    w, h = (pad.size_x or 0) / 2.0, (pad.size_y or 0) / 2.0
+    if w <= 0 or h <= 0:
+        return None
+    if pad.shape == "circle":
+        return Point(pad.global_x, pad.global_y).buffer(w, quad_segs=32)
+    shp = box(pad.global_x - w, pad.global_y - h, pad.global_x + w, pad.global_y + h)
+    if pad.shape in ("oval", "roundrect"):
+        r = min(w, h) * (1.0 if pad.shape == "oval" else 0.25)
+        shp = shp.buffer(-r).buffer(r, quad_segs=16)
+    rot = getattr(pad, "rect_rotation", 0) or 0
+    if rot:
+        import shapely.affinity as aff
+        shp = aff.rotate(shp, rot, origin=(pad.global_x, pad.global_y))
+    return shp
+
+
+def classify_board(final, floor_mm, items):
+    """items: [{'nets': set, 'pos': (x,y), ...}] -> same dicts + 'verdict'."""
+    from shapely.geometry import LineString, Point
+    from shapely.ops import unary_union
+    from kicad_parser import parse_kicad_pcb
+
+    pcb = parse_kicad_pcb(str(final))
+    name_to_id = {n.name: nid for nid, n in pcb.nets.items()}
+    out = []
+    for it in items:
+        x, y = it["pos"]
+        net_ids = {name_to_id[n] for n in it["nets"] if n in name_to_id}
+        shapes = []
+        for s in pcb.segments:
+            if net_ids and s.net_id not in net_ids:
+                continue
+            if not s.layer.endswith(".Cu"):
+                continue
+            seg = LineString([(s.start_x, s.start_y), (s.end_x, s.end_y)])
+            if seg.distance(Point(x, y)) < RADIUS:
+                shapes.append(seg.buffer(s.width / 2.0, quad_segs=32))
+        for fp in pcb.footprints.values():
+            for pad in fp.pads:
+                if net_ids and pad.net_id not in net_ids:
+                    continue
+                if abs(pad.global_x - x) < RADIUS and abs(pad.global_y - y) < RADIUS:
+                    shp = _pad_shape(pad)
+                    if shp is not None:
+                        shapes.append(shp)
+        if not shapes:
+            out.append({**it, "verdict": "NO-COPPER-FOUND"})
+            continue
+        union = unary_union(shapes)
+        comps = list(union.geoms) if union.geom_type == "MultiPolygon" else [union]
+        comp = min(comps, key=lambda c: c.distance(Point(x, y)))
+        eroded = comp.buffer(-(floor_mm / 2.0) * (1.0 - EPS))
+        if eroded.is_empty:
+            verdict = "REAL-NECK (erodes away)"
+        elif eroded.geom_type == "MultiPolygon" and len(list(eroded.geoms)) > 1:
+            verdict = "REAL-NECK (splits)"
+        else:
+            verdict = "ARTIFACT (copper >= floor, survives erosion)"
+        out.append({**it, "verdict": verdict})
+    return out
+
+
+_TEST_BOARD = """(kicad_pcb
+	(version 20260206)
+	(generator "pcbnew")
+	(generator_version "10.0")
+	(general
+		(thickness 1.6)
+		(legacy_teardrops no)
+	)
+	(paper "A4")
+	(layers
+		(0 "F.Cu" signal)
+		(2 "B.Cu" signal)
+		(25 "Edge.Cuts" user)
+	)
+	(setup
+		(pad_to_mask_clearance 0)
+	)
+	(net 0 "")
+	(net 1 "N1")
+{segments})
+"""
+
+_SEG = """	(segment
+		(start {x1} {y1})
+		(end {x2} {y2})
+		(width {w})
+		(layer "F.Cu")
+		(net "N1")
+		(uuid "00000000-0000-0000-0000-0000000000{i:02d}")
+	)
+"""
+
+
+def self_test():
+    """Validate BOTH branches on known geometry before trusting any verdict:
+    a 0.05 mm bridge under a 0.2 floor MUST classify REAL-NECK; the live-jog
+    copper (three 0.2 mm segments, provably >= 0.2 everywhere) MUST classify
+    ARTIFACT."""
+    import tempfile
+    ok = True
+    with tempfile.TemporaryDirectory(prefix="cwclass_") as d:
+        cases = [
+            ("neck", [((10, 10), (18, 10), 1), ((18, 10), (22, 10), 0.05),
+                      ((22, 10), (30, 10), 1)],
+             (20.0, 10.0), "REAL-NECK"),
+            ("jog", [((31.5, 59.4), (27.7, 59.4), 0.2),
+                     ((27.7, 59.4), (27.7, 59.2), 0.2),
+                     ((27.7, 59.2), (27.9, 59.0), 0.2)],
+             (27.7, 59.3), "ARTIFACT"),
+        ]
+        for name, segs, pos, want in cases:
+            body = "".join(_SEG.format(x1=a[0], y1=a[1], x2=b[0], y2=b[1],
+                                       w=w, i=i)
+                           for i, (a, b, w) in enumerate(segs))
+            p = os.path.join(d, name + ".kicad_pcb")
+            with open(p, "w") as f:
+                f.write(_TEST_BOARD.format(segments=body))
+            v = classify_board(p, 0.2, [{"nets": {"N1"}, "pos": pos}])[0]["verdict"]
+            good = v.startswith(want)
+            ok &= good
+            print(f"  {'PASS' if good else 'FAIL'}  {name}: {v} (want {want}*)")
+    print("self-test", "OK" if ok else "FAILED")
+    return 0 if ok else 1
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("wave", nargs="?", help="wave dir with summary.json")
+    ap.add_argument("--board", help="single final .kicad_pcb")
+    ap.add_argument("--baseline")
+    ap.add_argument("--boards-dir", help="unrouted inputs for baselines")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    from kicad_drc_compare import compare_board_data
+
+    jobs = []
+    if args.board:
+        jobs.append((Path(args.board), args.baseline))
+    elif args.wave:
+        wave = Path(args.wave)
+        for r in json.loads((wave / "summary.json").read_text()):
+            if r.get("kicad_connection_width"):
+                final = wave / r["board"] / (r["final"] or "final.kicad_pcb")
+                base = (Path(args.boards_dir) / f"{r['board']}.kicad_pcb"
+                        if args.boards_dir else None)
+                jobs.append((final, str(base) if base and base.exists() else None))
+    else:
+        ap.error("need a wave dir, --board, or --self-test")
+
+    if not jobs:
+        print("no boards with connection_width items")
+        return 0
+    total = {"artifact": 0, "real": 0, "other": 0}
+    for final, base in jobs:
+        data = compare_board_data(str(final), baseline=base)
+        items = data.get("connection_width_items") or []
+        floor_mm = data.get("connection_width_min")
+        if not items or not floor_mm:
+            print(f"{final}: no items on regrade")
+            continue
+        for v in classify_board(final, floor_mm, items):
+            kind = ("artifact" if v["verdict"].startswith("ARTIFACT")
+                    else "real" if v["verdict"].startswith("REAL") else "other")
+            total[kind] += 1
+            print(f"{Path(final).parent.name}: {v['verdict']:44s} "
+                  f"{sorted(v['nets'])} @ {v['pos']}  {v.get('desc', '')[:50]}")
+    print(f"\nclassified: {total['artifact']} artifact(s), {total['real']} "
+          f"real neck(s), {total['other']} unresolved")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/stress/fetch_set4.py
+++ b/tests/stress/fetch_set4.py
@@ -35,7 +35,7 @@ def main():
             print(f"  FAIL {b['repo']}  <- {b['raw_url']}")
             continue
         ok += 1
-        print(f"  OK  {b['repo']:42} v{b['version']:<9} {dest.stat().st_size // 1024}KB")
+        print(f"  OK  {b['repo']:42} v{b.get('version', '?'):<9} {dest.stat().st_size // 1024}KB")
     print(f"\n{ok}/{len(boards)} set-4 sources -> {out_dir}")
     return 0 if ok == len(boards) else 1
 

--- a/tests/stress/kicad_drc_compare.py
+++ b/tests/stress/kicad_drc_compare.py
@@ -23,6 +23,14 @@ Known-benign asymmetries filtered out:
   * check_drc warnings (same-net copper classes + sub-coincidence gaps) --
     KiCad permits same-net overlap outright.
 
+Graded SEPARATELY (#406, never matched against check_drc): KiCad's
+`connection_width` min-copper-web class. The checker is OFF by default
+(min_connection 0, warning severity), so _staged_copy stages the constraint
+(author-set min_connection kept, else the project's min_track_width) and
+lifts the severity; the count is reported as kicad_connection_width (None =
+not graded -- no recorded floor). check_drc has no counterpart by design:
+the flagged artifact lives in KiCad's own float-borderline web measurement.
+
 Usage:
   python3 tests/stress/kicad_drc_compare.py <board.kicad_pcb> [...]
   python3 tests/stress/kicad_drc_compare.py --wave <wave_dir>   # summary.json
@@ -32,6 +40,7 @@ import json
 import math
 import os
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -39,8 +48,10 @@ import tempfile
 REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, REPO)
 
-KICAD_CLI = os.environ.get(
-    "KICAD_CLI", "/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli")
+# Env var wins; else PATH (Windows/Linux installs put kicad-cli there, the
+# kicad_oracle.py idiom); else the macOS app-bundle default.
+KICAD_CLI = (os.environ.get("KICAD_CLI") or shutil.which("kicad-cli")
+             or "/Applications/KiCad/KiCad.app/Contents/MacOS/kicad-cli")
 
 # kicad violation types that correspond to copper-clearance/short classes
 # check_drc grades. Everything else (annular_width, courtyard, silk, thermal,
@@ -52,12 +63,20 @@ KICAD_COPPER_TYPES = {
     "copper_edge_clearance",
 }
 
+# Min-copper-web class (#406): graded SEPARATELY from the copper-clearance
+# classes -- check_drc has no counterpart (the artifact lives in KiCad's own
+# float-borderline web measurement, which a from-scratch geometric check
+# cannot reproduce), so these items never enter the match and can never
+# pollute kicad_only (the check_drc-false-negative alarm channel).
+KICAD_WEB_TYPES = {"connection_width"}
+
 MATCH_RADIUS_MM = 0.5
 
 
 def run_kicad_drc(board: str):
     """Run kicad-cli DRC, return (violations, error) with items filtered to
-    copper classes. Each -> {type, nets:frozenset, pos:(x,y), desc}."""
+    copper + web classes. Each -> {type, nets:frozenset, pos:(x,y), desc,
+    kinds} (kinds = the offending item kinds, e.g. ('track', 'zone'))."""
     with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
         out_json = f.name
     try:
@@ -78,22 +97,26 @@ def run_kicad_drc(board: str):
     out = []
     for v in data.get("violations", []):
         vtype = v.get("type", "")
-        if vtype not in KICAD_COPPER_TYPES:
+        if vtype not in KICAD_COPPER_TYPES and vtype not in KICAD_WEB_TYPES:
             continue
         nets = set()
         pos = None
+        kinds = set()
         for item in v.get("items", []):
             d = item.get("description", "")
             # descriptions look like: "Track [/NET] on F.Cu, length ..." or
             # "Via [/NET] on F.Cu - B.Cu" or "Pad 3 [/NET] of U1 on F.Cu"
             if "[" in d and "]" in d:
                 nets.add(d[d.index("[") + 1:d.index("]")])
+            if d:
+                kinds.add(d.split()[0].lower())
             p = item.get("pos")
             if pos is None and p:
                 pos = (float(p.get("x", 0.0)), float(p.get("y", 0.0)))
         out.append({"type": vtype, "nets": frozenset(nets),
                     "pos": pos or (0.0, 0.0),
-                    "desc": v.get("description", "")})
+                    "desc": v.get("description", ""),
+                    "kinds": tuple(sorted(kinds))})
     return out, None
 
 
@@ -329,6 +352,29 @@ def _drop_intentional_edge(items, edge_types, intentional_nets):
     return kept, dropped
 
 
+def _web_min_connection(cfg: dict):
+    """The min-copper-web width (mm) a board should be graded at (#406), from
+    its .kicad_pro: an author-set `min_connection` is a real design rule and
+    wins; otherwise the project's `min_track_width` (the post-route ledger
+    floors it at the smallest object on the board, so the graded condition is
+    "a copper web narrower than the narrowest intentional track"). None when
+    neither is recorded -- connection_width is then NOT graded (KiCad's
+    default min_connection is 0 = checker off), and the caller reports None
+    rather than a fake clean 0."""
+    try:
+        rules = cfg.get("board", {}).get("design_settings", {}).get("rules", {})
+        for key in ("min_connection", "min_track_width"):
+            try:
+                v = float(rules.get(key))
+            except (TypeError, ValueError):
+                continue
+            if v > 0:
+                return v
+    except AttributeError:
+        pass
+    return None
+
+
 def _staged_copy(board: str, clearance: float):
     clearance = float(clearance)
     """Copy board + sibling .kicad_pro into a temp dir with the DEFAULT
@@ -389,6 +435,19 @@ def _staged_copy(board: str, clearance: float):
     sev = cfg["board"]["design_settings"].setdefault("rule_severities", {})
     for k in ("silk_over_copper", "silk_overlap", "silk_edge_clearance"):
         sev[k] = "ignore"
+    # Min copper web (#406): KiCad's connection_width checker is OFF by default
+    # (min_connection 0) and warning-severity, so routed-copper micro-webs were
+    # invisible to every automated consumer in the repo -- the corpus gave NO
+    # signal on the class. Same config-artifact family as the #338 edge rule:
+    # stage the constraint (author-set min_connection kept, else the project's
+    # min_track_width; see _web_min_connection) and lift the severity to error
+    # so the --severity-error run reports it. Items are graded SEPARATELY from
+    # the copper-clearance classes (KICAD_WEB_TYPES) -- check_drc has no
+    # counterpart to match against.
+    web_min = _web_min_connection(cfg)
+    if web_min is not None:
+        rules["min_connection"] = web_min
+        sev["connection_width"] = "error"
     json.dump(cfg, open(pro2, "w"))
     return d, b2
 
@@ -483,11 +542,32 @@ def compare_board_data(board: str, label: str = None, clearance: float = None,
     kicad, err = kicad_items_for(board, clearance)
     if err:
         return {"board": label, "skip": err}
-    pre = 0
+    # Min copper web (#406): split the web class out BEFORE baseline
+    # subtraction and matching -- the positional subtraction pass is
+    # type-blind, so pooling would let a baseline clearance item consume a
+    # final web item (and vice versa); and check_drc has no web counterpart,
+    # so matching would orphan every item into kicad_only (the false-negative
+    # alarm channel). web_min mirrors the _staged_copy condition: None =
+    # connection_width was NOT graded (no staged run / no recorded floor),
+    # reported as None rather than a fake clean 0.
+    web_min = None
+    if clearance:
+        pro = os.path.splitext(board)[0] + ".kicad_pro"
+        try:
+            web_min = _web_min_connection(
+                json.load(open(pro)) if os.path.exists(pro) else {})
+        except Exception:  # noqa: BLE001 -- unreadable project = not graded
+            web_min = None
+    web_items = [v for v in kicad if v["type"] in KICAD_WEB_TYPES]
+    kicad = [v for v in kicad if v["type"] not in KICAD_WEB_TYPES]
+    pre = web_pre = 0
     if baseline and os.path.exists(baseline):
         base_items, berr = kicad_items_for(baseline, clearance)
         if not berr and base_items:
+            base_web = [v for v in base_items if v["type"] in KICAD_WEB_TYPES]
+            base_items = [v for v in base_items if v["type"] not in KICAD_WEB_TYPES]
             kicad, pre = _subtract_baseline(kicad, base_items)
+            web_items, web_pre = _subtract_baseline(web_items, base_web)
     cd = run_check_drc(board, clearance, netclasses=not bool(clearance))
     # Symmetric baseline subtraction (#405): drop the input's own check_drc
     # items too (e.g. vfo_ctrl's 23 FG chassis-ground segments already <edge on
@@ -538,6 +618,12 @@ def compare_board_data(board: str, label: str = None, clearance: float = None,
             "pairs_both": len(kpairs & cpairs),
             "pairs_kicad_only": len(pk_only), "pairs_checkdrc_only": len(pc_only),
             "verdict": verdict,
+            # #406 min copper web: None = not graded (no recorded floor).
+            "kicad_connection_width": (len(web_items) if web_min is not None
+                                       else None),
+            "connection_width_min": web_min,
+            "connection_width_preexisting": web_pre,
+            "connection_width_items": web_items,
             "kicad_only_items": kicad_only, "checkdrc_only_items": cd_only}
 
 
@@ -545,7 +631,8 @@ def compare_board_data(board: str, label: str = None, clearance: float = None,
 _SUMMARY_KEYS = ("board", "kicad", "kicad_preexisting", "check_drc",
                  "kicad_intentional_edge", "checkdrc_intentional_edge",
                  "matched", "kicad_only", "checkdrc_only",
-                 "pairs_kicad_only", "pairs_checkdrc_only")
+                 "pairs_kicad_only", "pairs_checkdrc_only",
+                 "kicad_connection_width", "connection_width_min")
 
 
 def compare_board(board: str, label: str = None, clearance: float = None,
@@ -565,14 +652,24 @@ def compare_board(board: str, label: str = None, clearance: float = None,
     ie = data.get("kicad_intentional_edge", 0) or data.get("checkdrc_intentional_edge", 0)
     ie_note = (f" [#408: -{data.get('kicad_intentional_edge', 0)} kicad / "
                f"-{data.get('checkdrc_intentional_edge', 0)} check_drc intentional edge]") if ie else ""
+    # #406 min copper web: separate class, not matched against check_drc.
+    cw = data.get("kicad_connection_width")
+    cw_min = data.get("connection_width_min")
+    cw_pre = data.get("connection_width_preexisting", 0)
+    cw_pre_note = f" (+{cw_pre} pre-existing, subtracted)" if cw_pre else ""
+    cw_note = (f" connwidth={cw}@<{cw_min}mm{cw_pre_note}" if cw is not None
+               else " connwidth=not-graded")
     print(f"{label}: kicad={data['kicad']}{pre_note} check_drc={data['check_drc']}{cd_pre_note} "
           f"matched={data['matched']} kicad_only={data['kicad_only']} checkdrc_only={data['checkdrc_only']}{ie_note} | "
           f"net-pairs: both={data['pairs_both']} kicad_only={data['pairs_kicad_only']} "
-          f"checkdrc_only={data['pairs_checkdrc_only']}  {data['verdict']}")
+          f"checkdrc_only={data['pairs_checkdrc_only']} |{cw_note}  {data['verdict']}")
     for kv in data["kicad_only_items"]:
         print(f"    KICAD-ONLY  {kv['type']:16s} {sorted(kv['nets'])} @ {kv['pos']}  {kv.get('desc','')[:60]}")
     for cv in data["checkdrc_only_items"]:
         print(f"    CHECKDRC-ONLY {cv['type']:16s} {sorted(cv['nets'])} @ {cv['pos']}")
+    for wv in data.get("connection_width_items", []):
+        print(f"    CONNWIDTH   {'/'.join(wv.get('kinds', ())) or '?':16s} "
+              f"{sorted(wv['nets'])} @ {wv['pos']}  {wv.get('desc', '')[:60]}")
     return {k: data[k] for k in _SUMMARY_KEYS}
 
 
@@ -623,6 +720,11 @@ def main():
           f"{len(div)} diverged "
           f"(kicad_only total {sum(r['kicad_only'] for r in rows)}, "
           f"checkdrc_only total {sum(r['checkdrc_only'] for r in rows)})")
+    # #406 min copper web -- graded on boards with a recorded floor only.
+    cw_rows = [r for r in rows if r.get("kicad_connection_width") is not None]
+    print(f"connection_width: {sum(r['kicad_connection_width'] for r in cw_rows)} "
+          f"item(s) on {len(cw_rows)} graded board(s) "
+          f"({len(rows) - len(cw_rows)} not graded: no recorded min floor)")
     return 1 if div else 0
 
 

--- a/tests/stress/kicad_drc_compare.py
+++ b/tests/stress/kicad_drc_compare.py
@@ -376,7 +376,6 @@ def _web_min_connection(cfg: dict):
 
 
 def _staged_copy(board: str, clearance: float):
-    clearance = float(clearance)
     """Copy board + sibling .kicad_pro into a temp dir with the DEFAULT
     net-class clearance forced to `clearance`, so KiCad grades at the SAME
     constraint check_drc uses (the routed clearance) instead of the board's
@@ -390,6 +389,7 @@ def _staged_copy(board: str, clearance: float):
     classes down (the old behaviour) would grade that copper LOOSER than it was
     routed and hide genuine class-clearance shortfalls."""
     import shutil
+    clearance = float(clearance)
     d = tempfile.mkdtemp(prefix="kdrc_")
     b2 = os.path.join(d, os.path.basename(board))
     shutil.copy(board, b2)

--- a/tests/test_connection_width_grading.py
+++ b/tests/test_connection_width_grading.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""connection_width grading (#406): the min-copper-web class in the kicad-cli
+cross-check harness.
+
+KiCad's connection_width checker is OFF by default (min_connection 0) and
+warning-severity, so routed-copper micro-webs were invisible to every
+automated consumer -- the corpus gave NO signal on the class. The harness now
+stages the constraint (author-set min_connection kept, else the project's
+min_track_width) and grades the class SEPARATELY from the copper-clearance
+classes, so items never pollute kicad_only (the check_drc-false-negative
+alarm channel).
+
+Known positive by construction: a wide-thin-wide copper bridge whose web is
+narrower than the staged floor MUST be flagged (exercises the FAIL branch
+before any corpus number is trusted). Requires kicad-cli; SKIPs cleanly (exit
+0 with a note) when it is not installed.
+
+    python3 tests/test_connection_width_grading.py
+"""
+import json
+import os
+import shutil
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                                "tests", "stress"))
+
+from kicad_drc_compare import KICAD_CLI, compare_board_data  # noqa: E402
+
+BOARD_TMPL = """(kicad_pcb
+	(version 20260206)
+	(generator "pcbnew")
+	(generator_version "10.0")
+	(general
+		(thickness 1.6)
+		(legacy_teardrops no)
+	)
+	(paper "A4")
+	(layers
+		(0 "F.Cu" signal)
+		(2 "B.Cu" signal)
+		(25 "Edge.Cuts" user)
+	)
+	(setup
+		(pad_to_mask_clearance 0)
+	)
+	(net 0 "")
+	(net 1 "N1")
+	(gr_rect
+		(start 5 5)
+		(end 40 20)
+		(stroke
+			(width 0.1)
+			(type solid)
+		)
+		(layer "Edge.Cuts")
+	)
+	(segment (start 10 10) (end 18 10) (width 1) (layer "F.Cu") (net 1))
+	(segment (start 18 10) (end 22 10) (width {bridge}) (layer "F.Cu") (net 1))
+	(segment (start 22 10) (end 30 10) (width 1) (layer "F.Cu") (net 1))
+)
+"""
+
+
+def _write_board(d, name, bridge, rules=None):
+    """Board + sibling .kicad_pro (rules=None -> no project written)."""
+    board = os.path.join(d, name + ".kicad_pcb")
+    with open(board, "w") as f:
+        f.write(BOARD_TMPL.format(bridge=bridge))
+    if rules is not None:
+        pro = {"board": {"design_settings": {"rules": rules}},
+               "net_settings": {"classes": [{"name": "Default", "clearance": 0.1}]},
+               "meta": {"filename": name + ".kicad_pro", "version": 3}}
+        with open(os.path.join(d, name + ".kicad_pro"), "w") as f:
+            json.dump(pro, f)
+    return board
+
+
+def run():
+    if not (KICAD_CLI and os.path.exists(KICAD_CLI)):
+        print("SKIP: kicad-cli not found (KICAD_CLI env / PATH / app bundle)")
+        return 0
+
+    passed = failed = 0
+
+    def check(name, cond):
+        nonlocal passed, failed
+        passed += bool(cond)
+        failed += not cond
+        print(f"  {'PASS' if cond else 'FAIL'}  {name}")
+
+    d = tempfile.mkdtemp(prefix="cw_test_")
+    try:
+        # FAIL branch, staged via min_track_width: a 0.15 web under a recorded
+        # 0.2 min_track_width (no author min_connection) must be flagged.
+        b = _write_board(d, "neck", bridge=0.15, rules={"min_track_width": 0.2})
+        r = compare_board_data(b)
+        check("thin web flagged (min_track_width staging)",
+              r.get("kicad_connection_width") == 1)
+        check("graded at the min_track_width floor",
+              r.get("connection_width_min") == 0.2)
+        check("web item carries its net",
+              any("N1" in wv["nets"] for wv in r.get("connection_width_items", [])))
+        check("web items never enter kicad_only",
+              r.get("kicad_only") == 0 and r.get("checkdrc_only") == 0)
+
+        # PASS branch: a web at exactly the floor is legal copper.
+        b = _write_board(d, "wide", bridge=0.2, rules={"min_track_width": 0.2})
+        r = compare_board_data(b)
+        check("web at the floor is clean", r.get("kicad_connection_width") == 0)
+
+        # Author rule wins: min_connection 0.3 over min_track_width 0.2 -- a
+        # 0.25 web is legal by track width but violates the author's rule.
+        b = _write_board(d, "author", bridge=0.25,
+                         rules={"min_connection": 0.3, "min_track_width": 0.2})
+        r = compare_board_data(b)
+        check("author-set min_connection wins over min_track_width",
+              r.get("kicad_connection_width") == 1
+              and r.get("connection_width_min") == 0.3)
+
+        # Not graded: no .kicad_pro -> no clearance, no floor -> None (visible
+        # as not-graded), never a fake clean 0.
+        b = _write_board(d, "nopro", bridge=0.15, rules=None)
+        r = compare_board_data(b)
+        check("no recorded floor grades as None, not 0",
+              r.get("kicad_connection_width") is None)
+
+        # No floor recorded (project exists, neither key): also not graded.
+        b = _write_board(d, "nofloor", bridge=0.15, rules={})
+        r = compare_board_data(b)
+        check("project without floor keys grades as None",
+              r.get("kicad_connection_width") is None)
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+    print(f"{passed}/{passed + failed} connection_width grading tests passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/tests/test_connection_width_grading.py
+++ b/tests/test_connection_width_grading.py
@@ -57,9 +57,30 @@ BOARD_TMPL = """(kicad_pcb
 		)
 		(layer "Edge.Cuts")
 	)
-	(segment (start 10 10) (end 18 10) (width 1) (layer "F.Cu") (net 1))
-	(segment (start 18 10) (end 22 10) (width {bridge}) (layer "F.Cu") (net 1))
-	(segment (start 22 10) (end 30 10) (width 1) (layer "F.Cu") (net 1))
+	(segment
+		(start 10 10)
+		(end 18 10)
+		(width 1)
+		(layer "F.Cu")
+		(net "N1")
+		(uuid "00000000-0000-0000-0000-000000000001")
+	)
+	(segment
+		(start 18 10)
+		(end 22 10)
+		(width {bridge})
+		(layer "F.Cu")
+		(net "N1")
+		(uuid "00000000-0000-0000-0000-000000000002")
+	)
+	(segment
+		(start 22 10)
+		(end 30 10)
+		(width 1)
+		(layer "F.Cu")
+		(net "N1")
+		(uuid "00000000-0000-0000-0000-000000000003")
+	)
 )
 """
 


### PR DESCRIPTION
## What

Adds KiCad's `connection_width` (min-copper-web) class to the stress grading
loop, per #406's "add a connection_width check to the grader" option:

- `kicad_drc_compare._staged_copy` stages the constraint: an author-set
  `min_connection` is a real design rule and wins; otherwise the project's
  `min_track_width` (the post-route ledger floors it at the smallest object on
  the board — `scan_board_minima`, fix_kicad_drc_settings.py:316-318 — so the
  graded condition is "a web narrower than the narrowest intentional track").
  Severity is lifted to error for the existing `--severity-error` run. No
  recorded floor = **not graded**, reported `None` — never a fake clean 0.
- The class is graded **separately** from the copper-clearance classes:
  split out before #405 baseline subtraction (the positional pass is
  type-blind) and never matched against check_drc — so web items cannot
  pollute `kicad_only`, the check_drc-false-negative alarm channel. check_drc
  has no counterpart **by design**: the flagged artifact lives in KiCad's own
  float-borderline web measurement, which a from-scratch geometric check
  cannot reproduce.
- `ab_replay_grade` threads `kicad_connection_width` through grade(), the
  per-board line, and compare() (column, net-delta line, verdict).
- `tests/stress/classify_connection_width.py`: triage tool separating real
  necks from float-dust artifacts by polygon erosion (build the net's local
  copper union at the flagged position, erode by floor/2: a real neck splits
  or vanishes, an artifact survives connected). `--self-test` validates both
  verdict branches on known geometry.
- Provenance: `_gitver` now records the `KICAD_*` ablation-knob environment
  into `git_version.json` and the compare header — a wave with an ablation
  knob set is a different experiment than the same commit without it.
- `KICAD_CLI` falls back to `shutil.which("kicad-cli")` (kicad_oracle idiom),
  so the harness runs on Windows/Linux without the env var.
- Drive-by: fetch_set4 no longer KeyErrors on manifest entries without
  `version` (14/15 entries lack it).

## Why the corpus was blind (three independent reasons)

KiCad ships the checker OFF (`min_connection` = 0), at warning severity
(invisible to `--severity-error`), and `KICAD_COPPER_TYPES` filtered the type
out. All three had to change for the corpus to see the class.

## Gate test

`tests/test_connection_width_grading.py` (8 checks): the FAIL branch fires on
a known-positive thin web before any corpus number is trusted; floor-at-min
legal; author-rule precedence; None-not-0 for ungraded boards; no kicad_only
pollution. SKIPs cleanly without kicad-cli.

## What it measures on the corpus (uniform route.py chain, sets 3+4+5)

- Baseline incidence: 12 items over 33 boards (8 boards affected).
  Classified: **11 float-dust artifacts** (pad/track tangencies, none
  jog-shaped) and **1 REAL sub-floor neck** (a20_can: a track cap landing on
  a pad CORNER, joined through a thin sliver) — a router-produced defect that
  is DRC-clean and fully connected, invisible to every existing check. The
  instrument catches both populations and the classifier separates them.
- Determinism: identical counts (incl. cw) on re-route with identical inputs.
- Stability under copper change: the flag can relocate, mint, or vanish when
  copper changes (2846 rewritten jogs moved 2 items, minted 1, and 1 vanished
  with a broken net) — that flappiness is inherent to the artifact class, not
  the instrument.

## Decision point for you (explicit)

compare() currently **gates the A/B verdict** on the net connection_width
delta. Argument for: this exact gate caught a systematic artifact-minter in
local A/B (see the #406 comment). Argument against: under heavy unrelated
copper churn the float lottery re-rolls ~1 item/~13 boards, so occasional
±1 false REGRESSIONs on large corpora are expected. If your corpus shows too
much flap, downgrading to informational is a two-line change
(compare() verdict + RUNBOOK sentence); the per-board column and net-delta
line stay either way. I shipped the conservative default and can flip it in
this PR if you prefer.

## Files

- tests/stress/kicad_drc_compare.py (staging + separate web class + which())
- tests/stress/ab_replay_grade.py (threading + compare column/verdict)
- tests/stress/classify_connection_width.py (new, with --self-test)
- tests/stress/_gitver.py (knob provenance)
- tests/test_connection_width_grading.py (new, 8 checks)
- tests/stress/RUNBOOK.md (cross-check section)
- tests/stress/fetch_set4.py (KeyError fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
