### PR TITLE
Fix via copper clearance from existing drill holes

### DIFF
--- a/obstacle_map.py
+++ b/obstacle_map.py
@@ -1160,17 +1160,21 @@ def _add_polygon_edge_obstacles(obstacles: GridObstacleMap, polygons,
 
 def block_via_cells_near_drills(obstacles: GridObstacleMap,
                                  drill_holes, via_drill: float,
-                                 hole_to_hole_clearance: float, grid_step: float):
-    """Block via-placement cells within the hole-to-hole drill minimum of each
-    drill hole.
+                                 hole_to_hole_clearance: float, grid_step: float,
+                                 via_size: float = 0.0,
+                                 copper_to_hole_clearance: float = 0.0):
+    """Block via-placement cells within the required clearance of each drill.
 
     A via placed on the grid sits at its cell's real center; block the cell when
-    that center is within the required center-to-center distance of the REAL
-    drill center, tested in mm -- NOT as a floored/quantized integer-cell disk.
+    that center is within the larger of the drill-to-drill and via-copper-to-hole
+    center distances from the REAL drill center, tested in mm -- NOT as a
+    floored/quantized integer-cell disk.
     Flooring the radius (or centering the disk on the quantized drill cell) lets
     a via land a sub-cell inside the hole-to-hole minimum (issue #70 / #125:
     PAD-DRILL-VIA-DRILL at the default 0.1mm grid). Being exact in mm avoids both
     the under-block (a real fab violation) and the over-block (lost routability).
+    Reserving only the via drill also lets a larger via annulus touch an existing
+    hole while its drill still clears (issue #441, vfo_ctrl hole_clearance).
 
     Shared by the signal router (add_drill_hole_obstacles) and route_planes
     (_add_drill_hole_via_obstacles) so both enforce the keepout identically.
@@ -1181,14 +1185,20 @@ def block_via_cells_near_drills(obstacles: GridObstacleMap,
         via_drill: drill diameter of the via being placed (mm)
         hole_to_hole_clearance: minimum drill edge-to-edge clearance (mm)
         grid_step: grid resolution (mm)
+        via_size: outer copper diameter of the via being placed (mm)
+        copper_to_hole_clearance: minimum via copper to drill edge clearance (mm)
     """
-    if hole_to_hole_clearance <= 0:
+    if hole_to_hole_clearance <= 0 and \
+       (via_size <= 0 or copper_to_hole_clearance <= 0):
         return
     coord = GridCoord(grid_step)
     cells = []
     for hx, hy, drill_dia in drill_holes:
-        # Required center-to-center distance = drill/2 + via_drill/2 + clearance.
-        required_dist = drill_dia / 2.0 + via_drill / 2.0 + hole_to_hole_clearance
+        h2h_dist = drill_dia / 2.0 + via_drill / 2.0 + max(
+            hole_to_hole_clearance, 0.0)
+        copper_hole_dist = drill_dia / 2.0 + via_size / 2.0 + max(
+            copper_to_hole_clearance, 0.0)
+        required_dist = max(h2h_dist, copper_hole_dist)
         req_sq = required_dist * required_dist
         gx, gy = coord.to_grid(hx, hy)
         expand = coord.to_grid_dist_safe(required_dist) + 1  # ceil + 1-cell bbox margin
@@ -1413,10 +1423,12 @@ def add_drill_hole_obstacles(obstacles: GridObstacleMap, pcb_data: PCBData,
         config.grid_step, list(range(len(config.layers))),
         extra_clearance=extra_clearance, include_plated=False)
 
-    # Via keep-out (hole-to-hole drill minimum) near every drill.
-    if config.hole_to_hole_clearance > 0 and drill_holes:
+    # Via keep-out near every drill: enforce both drill-to-drill spacing and
+    # the via annulus's copper-to-hole floor (#441).
+    if drill_holes and (config.hole_to_hole_clearance > 0 or config.clearance > 0):
         block_via_cells_near_drills(obstacles, drill_holes, config.via_drill,
-                                    config.hole_to_hole_clearance, config.grid_step)
+                                    config.hole_to_hole_clearance, config.grid_step,
+                                    config.via_size, config.clearance)
 
 
 def add_net_stubs_as_obstacles(obstacles: GridObstacleMap, pcb_data: PCBData,

--- a/plane_obstacle_builder.py
+++ b/plane_obstacle_builder.py
@@ -762,7 +762,7 @@ def _add_board_edge_track_obstacles(obstacles: GridObstacleMap, pcb_data: PCBDat
 def _add_drill_hole_via_obstacles(obstacles: GridObstacleMap, pcb_data: PCBData,
                                     config: GridRouteConfig, exclude_net_id: int):
     """Block via placement near existing drill holes."""
-    if config.hole_to_hole_clearance <= 0:
+    if config.hole_to_hole_clearance <= 0 and config.clearance <= 0:
         return
 
     # Collect drill holes
@@ -789,7 +789,8 @@ def _add_drill_hole_via_obstacles(obstacles: GridObstacleMap, pcb_data: PCBData,
     # the signal router) rather than a disk centred on the quantized drill cell,
     # so a stitching via cannot land a sub-cell inside the minimum (issue #70).
     block_via_cells_near_drills(obstacles, drill_holes, config.via_drill,
-                                config.hole_to_hole_clearance, config.grid_step)
+                                config.hole_to_hole_clearance, config.grid_step,
+                                config.via_size, config.clearance)
 
 
 def block_via_position(obstacles: GridObstacleMap, via_x: float, via_y: float,

--- a/tests/test_drill_hole_keepout.py
+++ b/tests/test_drill_hole_keepout.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""Hole-to-hole via keepout must be enforced by REAL mm distance, not a floored
-integer-cell disk, so a via cannot land a sub-cell inside the drill hole-to-hole
-minimum (issue #70 / #125 -- the castor_pollux RV3 PAD-DRILL-VIA-DRILL).
+"""Via-to-drill keepout must enforce both hole-to-hole and copper-to-hole by
+REAL mm distance, not a floored integer-cell disk, so a via cannot land a
+sub-cell inside either minimum (issues #70/#125 and #441).
 
     python3 tests/test_drill_hole_keepout.py
 """
@@ -34,7 +34,8 @@ def run():
 
     # Reproduce the castor_pollux geometry: a 3.0mm mounting-lug drill, default
     # 0.1mm grid, via drill 0.3, hole-to-hole 0.2 -> required c-c = 1.85mm.
-    cfg = GridRouteConfig(grid_step=0.1, via_drill=0.3, hole_to_hole_clearance=0.2)
+    cfg = GridRouteConfig(grid_step=0.1, via_size=0.6, via_drill=0.3,
+                          clearance=0.1, hole_to_hole_clearance=0.2)
     coord = GridCoord(cfg.grid_step)
     pcb = _pcb_with_pad(79.80, 80.70, 3.0)
 
@@ -49,10 +50,18 @@ def run():
     vx, vy = coord.to_grid(81.50, 81.40)
     check("violating via cell (1.838mm < 1.85) is blocked", obs.is_via_blocked(vx, vy))
 
-    # A cell just outside the minimum must remain free (no over-blocking).
-    # (81.50,81.50): distance sqrt(1.7^2+0.8^2)=1.879mm > 1.85mm.
+    # This cell clears the 1.85mm drill-to-drill minimum but not the larger
+    # 1.90mm copper-to-hole minimum (1.5 + 0.3 + 0.1).
+    # (81.50,81.50): distance sqrt(1.7^2+0.8^2)=1.879mm.
     ox, oy = coord.to_grid(81.50, 81.50)
-    check("cell beyond the minimum (1.879mm) stays free", not obs.is_via_blocked(ox, oy))
+    check("h2h-legal but copper-to-hole violating via cell is blocked",
+          obs.is_via_blocked(ox, oy))
+
+    # Just beyond both constraints remains routable.
+    # (81.60,81.50): distance sqrt(1.8^2+0.8^2)=1.970mm > 1.90mm.
+    jx, jy = coord.to_grid(81.60, 81.50)
+    check("cell beyond both drill and copper-to-hole minima stays free",
+          not obs.is_via_blocked(jx, jy))
 
     # A cell well inside is blocked; a far cell is free.
     ix, iy = coord.to_grid(80.50, 80.70)   # 0.70mm away
@@ -66,9 +75,9 @@ def run():
             print(f"  FAIL  {f}")
         print(f"\n{len(fails)} failure(s)")
         return 1
-    print("  PASS  hole-to-hole via keepout enforced by mm distance: blocks the")
-    print("        sub-cell-inside via, leaves just-outside/far cells free")
-    print("\n4/4 checks passed")
+    print("  PASS  via-to-drill keepout enforces hole-to-hole and copper-to-hole")
+    print("        by exact mm distance without blocking cells beyond both floors")
+    print("\n5/5 checks passed")
     return 0
 
 


### PR DESCRIPTION
## Summary

- reserve via cells by the larger of drill-to-drill and via-copper-to-hole clearance
- apply the shared rule to both signal-routing and plane-routing initial via maps
- add a regression for an h2h-legal cell whose via annulus still violates KiCad hole clearance

This addresses the zero-distance `hole_clearance` residual class reported for `vfo_ctrl` in #441. It intentionally does not close the umbrella issue, which tracks several independent boards and defect classes.

## Why

Initial via maps only expanded existing drills by `existing_drill/2 + new_via_drill/2 + hole_to_hole`. A larger via annulus could therefore touch an existing hole even though the two drill edges met the hole-to-hole floor. Newly placed session vias already used the larger copper/drill reservation, so initial and incremental maps disagreed.

## Validation

- `python3 tests/run_all.py --fast --timeout 300 drill_hole npth_hole gnd_via shared_via plane_via via_reuse bare_pad` (7 passed)
- `python3 tests/gui_parity/test_manifest_plan_parity.py`
- `python3 tests/gui_parity/test_cli_postpass_coverage.py`
- `python3 -m py_compile obstacle_map.py plane_obstacle_builder.py tests/test_drill_hole_keepout.py`
- `git diff --check`