### PR TITLE
quench: cap swap displacement + prune candidate scans (#430); fix the loop's steering (#458)

### DIFF
--- a/docs/placement-optimization.md
+++ b/docs/placement-optimization.md
@@ -206,8 +206,9 @@ precedent), which is simpler and may capture most of the value:
   into the move generator so every perturbation is feasible, rather than
   penalizing violations):
   - respect `locked` flags (already parsed by `placement/parser.py`)
-  - `--max-displacement` radius from the seed position, so output reads as
-    "your placement, nudged" and inherited human constraints survive
+  - `--max-displacement` radius from the seed position — enforced for every
+    move type, swaps included — so output reads as "your placement, nudged"
+    and inherited human constraints survive
   - courtyard non-overlap via the existing rect machinery
   - decaps tethered to their IC (group membership or hard radius)
   - rotation disabled per-class where assembly conventions matter
@@ -273,7 +274,8 @@ that's the documented failure mode of wirelength-driven placement.
 
 Implemented as `place_optimize.py` + `placement/quench.py`: greedy quench
 (nudge within `--max-displacement` of the seed, 90° rotations with correct
-pad-angle rewriting, same-footprint swaps), cost = `length_weight`·airwire
+pad-angle rewriting, displacement-capped same-footprint swaps), cost =
+`length_weight`·airwire
 length + `crossing_penalty`·crossings + pin-count-scaled halo + soft edge
 margin. Test board: `interf_u` (25 parts, PGA120 + bus connectors, 2 layers),
 pipeline `route_planes` → `bga_fanout U9` → `route.py` with the
@@ -354,7 +356,10 @@ Refined conclusions:
 - `--max-displacement` is the dominant safety knob: small caps keep the
   human's macro structure (bus corridors, cluster geometry) intact by
   construction, which is the entire value of seeding from a human placement.
-  ~3 mm was the sweet spot on both boards tested.
+  ~3 mm was the sweet spot on both boards tested. The cap is now airtight:
+  no move type — swaps included — can take a part beyond it, and
+  `--swap-max-displacement` can tighten (never exceed) it for swaps
+  specifically.
 - The big halos backfire on dense boards: with `--halo-coef 0.5` the
   144-pin Xilinx demands a 6.5 mm halo that a dense board cannot satisfy, so
   the halo gradient dominates everything and scatters the layout. Modest

--- a/docs/placement-optimization.md
+++ b/docs/placement-optimization.md
@@ -143,7 +143,10 @@ crossing counter is the non-differentiable version of the same quantity —
 fine, since SA doesn't need gradients. The theory behind crossing counts is
 topological routing (SURF, DAC 1991): zero airwire crossings on a layer means
 a planar ratsnest, i.e. routable on that layer in the topological sense; every
-crossing costs a via pair or a detour.
+crossing costs a via pair or a detour. Because a crossing is a conflict
+*between two nets*, the natural way to prioritize one net is to price each
+crossing by the larger of the two nets' weights: the cost of a conflict then
+tracks the most important net it obstructs.
 
 For reference, RUDY (the standard VLSI congestion proxy) smears each net's
 expected wire area uniformly over its bounding box —
@@ -193,7 +196,9 @@ precedent), which is simpler and may capture most of the value:
   - *nudge*: translate within a window that shrinks as temperature drops;
     optionally bias toward the part's optimal region (median of connected
     nets' bounding boxes — O(pins) to compute)
-  - *rotate*: 0/90/180/270
+  - *rotate*: 0/90/180/270, relative to the part's own placement angle (a
+    45°-placed part rotates on the 45/135/225/315 lattice, so deliberate
+    non-orthogonal placement is preserved rather than snapped to the axes)
   - *swap*: same-footprint pairs (footprint-identical R/C swaps are free
     wins; mixed-size swaps are usually illegal anyway, so restrict by
     footprint compatibility)
@@ -212,6 +217,8 @@ precedent), which is simpler and may capture most of the value:
   - courtyard non-overlap via the existing rect machinery
   - decaps tethered to their IC (group membership or hard radius)
   - rotation disabled per-class where assembly conventions matter
+    (`--no-rotate`, which also restricts same-footprint swaps to equal-angle
+    pairs, since a swap exchanges full poses)
 - **Cost**: Δ(crossings)·penalty + Δ(airwire length) + density/halo term —
   all incrementally updatable (only airwires touching the moved part's nets
   change). Mostly already in `rust_placer`; extending the scorer to evaluate
@@ -277,7 +284,10 @@ Implemented as `place_optimize.py` + `placement/quench.py`: greedy quench
 pad-angle rewriting, displacement-capped same-footprint swaps), cost =
 `length_weight`·airwire
 length + `crossing_penalty`·crossings + pin-count-scaled halo + soft edge
-margin. Test board: `interf_u` (25 parts, PGA120 + bus connectors, 2 layers),
+margin. Both airwire terms take optional per-net weights: a net's length is
+multiplied by its weight, and each crossing is priced at the larger of the
+two crossing nets' weights, so an unweighted board is untouched
+(max(1, 1) = 1). Test board: `interf_u` (25 parts, PGA120 + bus connectors, 2 layers),
 pipeline `route_planes` → `bga_fanout U9` → `route.py` with the
 `tests/test_interf_u.py` arguments. Router iterations ≈ effort; vias and
 completion are the quality metrics.
@@ -359,7 +369,8 @@ Refined conclusions:
   ~3 mm was the sweet spot on both boards tested. The cap is now airtight:
   no move type — swaps included — can take a part beyond it, and
   `--swap-max-displacement` can tighten (never exceed) it for swaps
-  specifically.
+  specifically. The router-in-the-loop widening below widens **nudges only**:
+  the swap cap holds at its base value for the whole run.
 - The big halos backfire on dense boards: with `--halo-coef 0.5` the
   144-pin Xilinx demands a 6.5 mm halo that a dense board cannot satisfy, so
   the halo gradient dominates everything and scatters the layout. Modest
@@ -372,18 +383,34 @@ Refined conclusions:
 The proxy-only results above motivated closing the loop: use the *router's
 own failure diagnostics* to decide what to move. Each round:
 
-1. Route the board; parse the JSON summary (failed nets, iterations) and the
-   frontier blocking analysis (which nets wall off each failed route).
+1. Route the board; parse the run's JSON summaries and the frontier blocking
+   analysis (which nets wall off each failed route). Note the plural:
+   `route.py` runs an end-of-run reconciliation pass whenever the first pass
+   left failures, and prints a second summary scoped to the retried nets.
+   The failure lists in that last summary are the still-open set, while
+   router effort adds across both passes.
 2. Build the movable set: parts owning pads of the **failed nets** (move the
    endpoint out of the congested pocket) and of the **blocker nets** (move
    the anchor so the blocking wall re-routes) — excluding high-pin-count
    parts (`--max-target-pins 40`: moving a resistor that anchors a blocker
    is low-risk; dragging a 144-pin QFP is how placements get destroyed).
-3. Micro-quench only those parts, with failed nets' airwires weighted 3×.
+3. Micro-quench only those parts, with the failed nets weighted 3×
+   (`--failed-net-weight`) — both their airwire *length* and any *crossing*
+   they take part in, the latter priced at the larger of the two nets'
+   weights. Weighting length alone was near-inert: at the loop's own knobs
+   the crossing term is ~96% of the objective, so scaling a length
+   coefficient from 0.3 to 0.9 against a crossing coefficient of 30 moved a
+   typical failed net by less than the cost of a fifth of one crossing.
 4. Re-route. Accept only if (failures, then iterations) improves; otherwise
-   revert and widen the displacement cap 1.5× for the next attempt.
+   revert and widen the displacement cap 1.5× for the next attempt — the
+   nudge radius only. The swap cap stays at its base value, so a widened
+   round cannot become a long-range swap.
 
-Result on kit-dev-coldfire from the hand placement:
+Result on kit-dev-coldfire from the hand placement (recorded before #458;
+`failures` was then the pre-reconciliation count and `router iterations` the
+first pass only, so both columns would read slightly differently today: fewer
+failures where the reconciliation pass recovers a net, and more iterations
+because that pass's own effort is now counted):
 
 | round | action | failures | router iterations | vias |
 |---|---|---|---|---|
@@ -397,11 +424,12 @@ less router effort — by moving only resistors/caps/jumpers** (49 parts
 total; the ICs and connectors never moved). The reject-and-revert mechanism
 did real work: two of four candidate placements made things worse and were
 discarded, which is exactly the proxy-blindness the loop exists to catch.
-Costs: +36 vias, and same-footprint swaps are not displacement-capped (one
-resistor traveled 32 mm via swap — fine for generic pull-ups, but worth a
-cap or flag for parts where location is meaningful). DRC: the same
-PAD-SEGMENT micro-overlap artifact the router produces on the baseline (16
-occurrences) appears somewhat more often on the repaired board (30).
+Costs: +36 vias. (This run predates the swap displacement cap — one resistor
+traveled 32 mm via an uncapped swap, which is what #430 fixed. Swaps are now
+capped like every other move, and the loop holds that cap at its base value
+while it widens the nudge radius, #458.) DRC: the same PAD-SEGMENT
+micro-overlap artifact the router produces on the baseline (16 occurrences)
+appears somewhat more often on the repaired board (30).
 
 This validates the core hypothesis of the whole investigation: **proxies
 propose, the router disposes.** Wall-clock cost was ~5 routing runs

--- a/place_optimize.py
+++ b/place_optimize.py
@@ -6,10 +6,12 @@ Usage:
 
 Starts from the current (hand- or AI-made) placement and applies a greedy
 quench: small nudges, 90-degree rotations, and same-footprint swaps that
-reduce airwire length + crossings + a whitespace (halo) penalty. Each part
-stays within --max-displacement of its original position, so the output is
-"your placement, nudged" - implicit constraints encoded in the original
-placement survive. Locked footprints never move.
+reduce airwire length + crossings + a whitespace (halo) penalty. Every move
+type keeps each part within --max-displacement of its original position -
+same-footprint swaps obey the same cap (or the tighter
+--swap-max-displacement) - so the output is "your placement, nudged" and
+implicit constraints encoded in the original placement survive. Locked
+footprints never move.
 
 See docs/placement-optimization.md for the background research.
 """
@@ -40,6 +42,10 @@ Examples:
     parser.add_argument("--max-displacement", type=float, default=10.0,
                         help="Max distance a part may move from its original "
                              "position in mm (default: 10)")
+    parser.add_argument("--swap-max-displacement", type=float, default=None,
+                        help="Max distance a swap may move each part from its "
+                             "original position in mm; must not exceed "
+                             "--max-displacement (default: equal to it)")
     parser.add_argument("--step", type=float, default=1.0,
                         help="Candidate grid step in mm (default: 1.0)")
     parser.add_argument("--grid-step", type=float, default=defaults.GRID_STEP,
@@ -85,6 +91,13 @@ Examples:
 
     args = parser.parse_args()
 
+    if args.swap_max_displacement is not None:
+        if args.swap_max_displacement < 0:
+            parser.error("--swap-max-displacement must be >= 0")
+        if args.swap_max_displacement > args.max_displacement:
+            parser.error("--swap-max-displacement must not exceed "
+                         "--max-displacement")
+
     if args.output_file is None:
         base, ext = os.path.splitext(args.input_file)
         args.output_file = base + '_optimized' + ext
@@ -97,6 +110,7 @@ Examples:
         pcb_data,
         pcb_file=args.input_file,
         max_displacement=args.max_displacement,
+        swap_max_displacement=args.swap_max_displacement,
         step=args.step,
         grid_step=args.grid_step,
         clearance=args.clearance,

--- a/place_route_loop.py
+++ b/place_route_loop.py
@@ -121,7 +121,13 @@ def main():
                         help="Max repair rounds (default: 5)")
     parser.add_argument("--max-displacement", type=float, default=3.0,
                         help="Initial displacement cap per round in mm "
-                             "(default: 3; widened 1.5x after a rejected round)")
+                             "(default: 3; widened 1.5x after a rejected "
+                             "round - nudges only, never swaps)")
+    parser.add_argument("--swap-max-displacement", type=float, default=None,
+                        help="Displacement cap for same-footprint swaps in mm; "
+                             "must not exceed --max-displacement and is NOT "
+                             "widened between rounds (default: the initial "
+                             "--max-displacement)")
     parser.add_argument("--max-target-pins", type=int, default=40,
                         help="Don't move parts with more connected pins than "
                              "this (default: 40)")
@@ -142,10 +148,26 @@ def main():
     parser.add_argument("--grid-step", type=float, default=defaults.GRID_STEP)
     parser.add_argument("--ignore-nets", nargs="+", default=None)
     parser.add_argument("--lock", nargs="+", default=None)
+    parser.add_argument("--no-rotate", action="store_true",
+                        help="Disable rotation moves")
+    parser.add_argument("--no-swap", action="store_true",
+                        help="Disable same-footprint swap moves")
+    parser.add_argument("--verbose", "-v", action="store_true",
+                        help="Print each accepted quench move and the "
+                             "per-pass swap-capped count")
     parser.add_argument("--work-dir", default=None,
                         help="Directory for intermediate files "
                              "(default: alongside output)")
     args = parser.parse_args()
+
+    if args.max_displacement < 0:
+        parser.error("--max-displacement must be >= 0")
+    if args.swap_max_displacement is not None:
+        if args.swap_max_displacement < 0:
+            parser.error("--swap-max-displacement must be >= 0")
+        if args.swap_max_displacement > args.max_displacement:
+            parser.error("--swap-max-displacement must not exceed "
+                         "--max-displacement")
 
     work = args.work_dir or os.path.dirname(os.path.abspath(args.output_file))
     os.makedirs(work, exist_ok=True)
@@ -160,6 +182,14 @@ def main():
           f" vias={best['vias']}")
 
     max_disp = args.max_displacement
+    # The swap cap is pinned to the BASE displacement and never widened (#458).
+    # A rejected round widens the NUDGE radius, a local search around each
+    # part's own seed that a real re-route then validates. Widening the swap
+    # cap in lockstep turns a 3mm budget into a 15mm teleport after four
+    # rejections, which is the #430 stranding failure coming back through the
+    # loop. Swaps get one fixed budget for the whole run.
+    swap_cap = (args.max_displacement if args.swap_max_displacement is None
+                else args.swap_max_displacement)
 
     for rnd in range(1, args.rounds + 1):
         if best['failures'] == 0:
@@ -182,11 +212,14 @@ def main():
         print(f"  blockers={best['blockers'][:8]}"
               f"{'...' if len(best['blockers']) > 8 else ''}")
         print(f"  targeting {len(targets)} parts"
-              f" (max_disp={max_disp:.1f}mm): {', '.join(sorted(targets))}")
+              f" (max_disp={max_disp:.1f}mm, swap cap={swap_cap:.1f}mm):"
+              f" {', '.join(sorted(targets))}")
 
         placements = quench(
             pcb_data, pcb_file=cur_file,
-            max_displacement=max_disp, step=args.step,
+            max_displacement=max_disp,
+            swap_max_displacement=swap_cap,
+            step=args.step,
             grid_step=args.grid_step, clearance=args.clearance,
             board_edge_clearance=args.board_edge_clearance,
             crossing_penalty=args.crossing_penalty,
@@ -194,12 +227,16 @@ def main():
             halo_base=args.halo_base, halo_coef=args.halo_coef,
             halo_weight=args.halo_weight,
             edge_halo=args.edge_halo, edge_weight=args.edge_weight,
+            allow_rotations=not args.no_rotate,
+            allow_swaps=not args.no_swap,
             ignore_nets=args.ignore_nets, lock_refs=args.lock,
             move_refs=targets, net_weights=net_weights,
+            verbose=args.verbose,
         )
 
         if not placements:
-            print("  Quench found no improving moves - widening cap.")
+            print(f"  Quench found no improving moves - widening the nudge cap"
+                  f" (swap cap stays {swap_cap:.1f}mm).")
             max_disp *= 1.5
             continue
 
@@ -219,7 +256,8 @@ def main():
             cur_file = cand_file
             max_disp = args.max_displacement
         else:
-            print("  REJECTED - reverting, widening displacement cap.")
+            print(f"  REJECTED - reverting, widening the nudge cap"
+                  f" (swap cap stays {swap_cap:.1f}mm).")
             max_disp *= 1.5
 
     shutil.copy(cur_file, args.output_file)

--- a/place_route_loop.py
+++ b/place_route_loop.py
@@ -40,19 +40,100 @@ import routing_defaults as defaults
 from placement.quench import quench
 from placement.writer import write_placed_output
 
+_SUMMARY_RE = re.compile(r'JSON_SUMMARY: (\{.*\})')
+
+# route.py prints this from the except around its reconciliation self-invoke
+# (route.py:2294). The sub-run prints its JSON_SUMMARY BEFORE the board is
+# written, so a summary followed by this marker advertises recoveries that may
+# never have reached the file on disk.
+_RECONCILE_ABORTED = 'final reconciliation pass failed:'
+
+# Counters that measure WORK DONE, so they add across passes. Everything else
+# in a summary is state, and state is whatever the LAST pass measured.
+_EFFORT_KEYS = ('total_iterations', 'total_vias', 'total_time')
+
+
+def merge_route_summaries(log: str):
+    """Reduce every JSON_SUMMARY in a route.py log to one honest tally.
+
+    route.py runs an end-of-run reconciliation pass (route.py:2144, #348)
+    exactly when the first pass left failures. It self-invokes batch_route one
+    level deep on the written board and prints a SECOND JSON_SUMMARY, scoped
+    to the retried nets, whose failure lists route.py itself calls "the honest
+    still-open set". Reading only the first summary counted every
+    reconciliation recovery as a failure: the loop quenched parts anchoring
+    nets that were already solved, and better() compared tallies taken at
+    different points in the run.
+
+    Per field class:
+
+    * FAILURE STATE (failed_single / failed_multipoint / multipoint_pads_*)
+      comes from the LAST summary, and is exact rather than a delta. Every net
+      with a nonzero failure term is in the retry set by construction, and the
+      sub-run re-derives each retried net's pad counts over ALL of that net's
+      pads from the final-board union-find (route.py:1840), so the last
+      summary's numbers are absolute. Summing pad counts would double-count.
+    * EFFORT (total_iterations / total_vias / total_time) is SUMMED: both
+      passes are work this placement cost the router, and better()'s iteration
+      tiebreak should see all of it. Taking effort from the last summary would
+      make a badly failing candidate look cheap, since the reconciliation pass
+      only re-routes a handful of nets.
+    * Anything else is last-wins.
+
+    Degrades to the single-summary case unchanged: no failures, or a sub-run
+    that returned before printing, leaves one summary that is both the first
+    and the last. Returns None when the log carries no summary at all.
+    """
+    raw = _SUMMARY_RE.findall(log)
+    if not raw:
+        return None
+    summaries = [json.loads(s) for s in raw]
+
+    # A reconciliation that raised AFTER printing its summary claims
+    # recoveries the board write may never have committed; fall back to the
+    # first pass, which is what is definitely on disk.
+    aborted = log.rfind(_RECONCILE_ABORTED) > log.rfind(raw[-1])
+    merged = dict(summaries[0] if aborted else summaries[-1])
+
+    for key in _EFFORT_KEYS:
+        merged[key] = sum(s.get(key, 0) for s in summaries)
+
+    # Coverage-gate nets (route.py:1881) have NO routed result, so their pads
+    # never reach multipoint_pads_total and the caller's
+    # failures = len(failed_single) + pad-deficit weighs them ZERO, though
+    # they ship at broken copper. Give each one weight 1, matching what
+    # failed_single gives a net that produced no result at all, by widening
+    # the pad denominator. They are in neither failed_single nor the pad
+    # tallies (route.py:1887 excludes single_ended_nets and routed_results),
+    # so this cannot double-count. It matters most on the LAST summary: those
+    # are nets the reconciliation pass ITSELF broke through its rip
+    # escalation, and without this the loop can read failures=0 on a board
+    # shipping disconnected copper and stop.
+    gate = merged.get('coverage_gate_nets') or []
+    if gate:
+        merged['multipoint_pads_total'] = (
+            merged.get('multipoint_pads_total', 0) + len(gate))
+    return merged
+
+
+def _run_route_cmd(cmd, log_file):
+    """Launch route.py with stdout and stderr captured to log_file; return its
+    exit code. Split out from run_route so the whole tally can be driven
+    against a canned log without launching a child process."""
+    with open(log_file, 'w') as f:
+        return subprocess.run(cmd, stdout=f, stderr=subprocess.STDOUT).returncode
+
 
 def run_route(pcb_file: str, routed_file: str, route_args: str, log_file: str):
     """Run route.py, return (metrics dict, log text)."""
     cmd = [sys.executable, 'route.py', pcb_file, routed_file] + \
         shlex.split(route_args)
-    with open(log_file, 'w') as f:
-        subprocess.run(cmd, stdout=f, stderr=subprocess.STDOUT)
+    _run_route_cmd(cmd, log_file)
     log = open(log_file).read()
 
-    m = re.search(r'JSON_SUMMARY: (\{.*\})', log)
-    if not m:
+    summary = merge_route_summaries(log)
+    if summary is None:
         raise RuntimeError(f"route.py produced no JSON_SUMMARY (see {log_file})")
-    summary = json.loads(m.group(1))
 
     failed_nets = list(summary.get('failed_single', []))
     # failed_multipoint entries are dicts {net_name, failed_pads}; keep just the

--- a/place_route_loop.py
+++ b/place_route_loop.py
@@ -40,6 +40,13 @@ import routing_defaults as defaults
 from placement.quench import quench
 from placement.writer import write_placed_output
 
+# The loop shells out to the route.py sitting NEXT TO THIS FILE. A bare
+# relative 'route.py' only resolved when the caller's cwd happened to be the
+# repo root, and the failure surfaced as the misleading "produced no
+# JSON_SUMMARY" instead of "no such file" (#458).
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+_ROUTE_PY = os.path.join(_SCRIPT_DIR, 'route.py')
+
 _SUMMARY_RE = re.compile(r'JSON_SUMMARY: (\{.*\})')
 
 # route.py prints this from the except around its reconciliation self-invoke
@@ -116,24 +123,47 @@ def merge_route_summaries(log: str):
     return merged
 
 
+def _log_tail(log: str, lines: int = 15) -> str:
+    """Last few log lines, so an error names the real failure instead of
+    burying it behind a path the operator has to go open."""
+    return ''.join(f"  | {ln}\n" for ln in log.splitlines()[-lines:])
+
+
 def _run_route_cmd(cmd, log_file):
     """Launch route.py with stdout and stderr captured to log_file; return its
     exit code. Split out from run_route so the whole tally can be driven
     against a canned log without launching a child process."""
-    with open(log_file, 'w') as f:
+    with open(log_file, 'w', encoding='utf-8') as f:
         return subprocess.run(cmd, stdout=f, stderr=subprocess.STDOUT).returncode
 
 
 def run_route(pcb_file: str, routed_file: str, route_args: str, log_file: str):
     """Run route.py, return (metrics dict, log text)."""
-    cmd = [sys.executable, 'route.py', pcb_file, routed_file] + \
+    # Absolute path to the sibling route.py, so the loop runs from any cwd.
+    # No cwd= override: route.py resolves its own assets from __file__, and
+    # relative paths inside --route-args (--net-clearances foo.json) must keep
+    # resolving against the OPERATOR's cwd, which a cwd= would silently break.
+    # -X utf8 mirrors how the test suite invokes route.py.
+    cmd = [sys.executable, '-X', 'utf8', _ROUTE_PY, pcb_file, routed_file] + \
         shlex.split(route_args)
-    _run_route_cmd(cmd, log_file)
-    log = open(log_file).read()
+    rc = _run_route_cmd(cmd, log_file)
+    # errors='replace': route.py forces its own stream to UTF-8, but a cp1252
+    # default locale on the READING side would raise on the first non-ASCII
+    # glyph and lose the whole round.
+    with open(log_file, encoding='utf-8', errors='replace') as f:
+        log = f.read()
+    if rc != 0:
+        # route.py exits 0 even when nets fail; its only deliberate non-zero
+        # exit is "No nets matched the given patterns!". So non-zero means a
+        # crash, an unreadable board or a --route-args typo, none of which is
+        # a routing result.
+        raise RuntimeError(f"route.py exited {rc} (see {log_file})\n"
+                           + _log_tail(log))
 
     summary = merge_route_summaries(log)
     if summary is None:
-        raise RuntimeError(f"route.py produced no JSON_SUMMARY (see {log_file})")
+        raise RuntimeError(f"route.py produced no JSON_SUMMARY (see {log_file})"
+                           f"\n" + _log_tail(log))
 
     failed_nets = list(summary.get('failed_single', []))
     # failed_multipoint entries are dicts {net_name, failed_pads}; keep just the

--- a/place_route_loop.py
+++ b/place_route_loop.py
@@ -10,7 +10,8 @@ parts that could help those routes succeed:
   - parts owning pads of the blocker nets (move the anchor so the blocking
     wall re-routes),
 
-with the failed nets' airwires given extra weight in the quench cost.
+with the failed nets given extra weight in the quench cost: their airwire
+length and any crossing they take part in.
 High-pin-count parts are excluded from targeting (--max-target-pins) - moving
 a resistor that anchors a blocker net is low-risk; dragging a 144-pin QFP to
 fix one net is how placements get destroyed.
@@ -243,8 +244,9 @@ def main():
                         help="Don't move parts with more connected pins than "
                              "this (default: 40)")
     parser.add_argument("--failed-net-weight", type=float, default=3.0,
-                        help="Airwire weight multiplier for failed nets "
-                             "(default: 3.0)")
+                        help="Cost multiplier for failed nets: scales their "
+                             "airwire length and any crossing they take part "
+                             "in (default: 3.0)")
     parser.add_argument("--step", type=float, default=0.5,
                         help="Candidate grid step in mm (default: 0.5)")
     parser.add_argument("--length-weight", type=float, default=0.3)

--- a/placement/README.md
+++ b/placement/README.md
@@ -10,9 +10,9 @@ Two command-line tools sit on top of this module:
 ## place_optimize.py — greedy quench
 
 Small nudges (capped by `--max-displacement`), 90° rotations, and
-same-footprint swaps that reduce airwire length + crossings + a whitespace
-(halo) penalty scaled by pin count + a soft board-edge margin. Locked
-footprints never move.
+same-footprint swaps (capped by `--swap-max-displacement`, default: the same
+cap) that reduce airwire length + crossings + a whitespace (halo) penalty
+scaled by pin count + a soft board-edge margin. Locked footprints never move.
 
 ```bash
 # Conservative polish (recommended starting point)
@@ -27,7 +27,8 @@ Key options:
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `--max-displacement` | 10 mm | Max distance a part may move from its seed position (3 mm recommended; large values can destroy the placement's macro structure) |
+| `--max-displacement` | 10 mm | Max distance a part may move from its seed position; applies to nudges and swaps alike (3 mm recommended; large values can destroy the placement's macro structure) |
+| `--swap-max-displacement` | = max-displacement | Displacement cap for swap moves; must be ≤ `--max-displacement` |
 | `--ignore-nets` | – | Net patterns excluded from airwire scoring (plane-routed power nets) |
 | `--lock` | – | Reference patterns to pin in place (connectors, mounting-critical parts) |
 | `--halo-coef` | 0.25 | Extra whitespace per √(pin count); keep modest (~0.15) on dense boards |

--- a/placement/README.md
+++ b/placement/README.md
@@ -9,10 +9,12 @@ Two command-line tools sit on top of this module:
 
 ## place_optimize.py — greedy quench
 
-Small nudges (capped by `--max-displacement`), 90° rotations, and
-same-footprint swaps (capped by `--swap-max-displacement`, default: the same
-cap) that reduce airwire length + crossings + a whitespace (halo) penalty
-scaled by pin count + a soft board-edge margin. Locked footprints never move.
+Small nudges (capped by `--max-displacement`), 90° rotations (on each part's
+own angular lattice, so a part placed at 45° rotates to 135/225/315 rather
+than snapping to the axes), and same-footprint swaps (capped by
+`--swap-max-displacement`, default: the same cap) that reduce airwire length
++ crossings + a whitespace (halo) penalty scaled by pin count + a soft
+board-edge margin. Locked footprints never move.
 
 ```bash
 # Conservative polish (recommended starting point)
@@ -32,20 +34,31 @@ Key options:
 | `--ignore-nets` | – | Net patterns excluded from airwire scoring (plane-routed power nets) |
 | `--lock` | – | Reference patterns to pin in place (connectors, mounting-critical parts) |
 | `--halo-coef` | 0.25 | Extra whitespace per √(pin count); keep modest (~0.15) on dense boards |
-| `--no-rotate` / `--no-swap` | off | Disable rotation / swap moves |
+| `--no-rotate` / `--no-swap` | off | Disable rotation / swap moves. `--no-rotate` freezes every part's angle: nudges keep the current rotation, and same-footprint swaps are restricted to pairs that already share one, since a swap exchanges full poses and a mixed-angle pair would rotate both parts |
 
 ## place_route_loop.py — router-in-the-loop repair
 
 Routes the board with the real router, reads the failure diagnostics
 (failed nets + the blocker nets named in the frontier analysis), and
-micro-quenches only the small parts that could help those routes succeed.
-Re-routes and keeps the new placement only if (failures, router effort)
-actually improves; otherwise reverts and widens the search.
+micro-quenches only the small parts that could help those routes succeed,
+weighting the failed nets so both their airwire length and any crossing they
+take part in cost more. Re-routes and keeps the new placement only if
+(failures, router effort) actually improves; otherwise reverts and widens the
+search.
+
+The tally counts the router's end-of-run reconciliation pass, so a net that
+pass recovers is not treated as a failure in the next round. A rejected round
+widens the **nudge** search 1.5×; the swap cap does not move. It stays at
+`--swap-max-displacement` (default: the initial `--max-displacement`), so
+widening the search can never turn into a long-range swap.
+`--swap-max-displacement`, `--no-rotate` and `--no-swap` work here exactly as
+they do in `place_optimize.py`, and `--verbose` surfaces each accepted quench
+move plus the per-pass `swap-capped=N` count.
 
 ```bash
 python place_route_loop.py input.kicad_pcb repaired.kicad_pcb \
     --route-args '--nets "/*" "Net-*" --track-width 0.2 --clearance 0.2 ...' \
-    --ignore-nets GND "+3.3V" --lock "J*"
+    --ignore-nets GND "+3.3V" --lock "J*" --swap-max-displacement 2
 ```
 
 On the kit-dev-coldfire demo board this repaired the hand placement from

--- a/placement/quench.py
+++ b/placement/quench.py
@@ -213,6 +213,9 @@ class QuenchState:
         for net_id in self.net_refs:
             self.net_airwires[net_id] = self._build_net_airwires(net_id)
 
+        # Optional pruned neighbour lists (see build_neighbor_lists)
+        self._neighbors = None
+
     # ----- airwire helpers -------------------------------------------------
 
     def _net_points(self, net_id, override_ref=None, override_pads=None):
@@ -262,7 +265,11 @@ class QuenchState:
         part = self.parts[ref]
         rect = part.rect(x, y, rot)
         pen = self._edge_penalty(rect)
-        for other_ref, other in self.parts.items():
+        if self._neighbors is not None and ref in self._neighbors:
+            others = ((o, self.parts[o]) for o in self._neighbors[ref])
+        else:
+            others = self.parts.items()
+        for other_ref, other in others:
             if other_ref == ref or (exclude and other_ref in exclude):
                 continue
             pen += self._halo_pair_penalty(part, rect, other, other.rect())
@@ -274,7 +281,11 @@ class QuenchState:
         if (rect[0] < self.usable[0] or rect[1] < self.usable[1]
                 or rect[2] > self.usable[2] or rect[3] > self.usable[3]):
             return False
-        for other_ref, other in self.parts.items():
+        if self._neighbors is not None and ref in self._neighbors:
+            others = ((o, self.parts[o]) for o in self._neighbors[ref])
+        else:
+            others = self.parts.items()
+        for other_ref, other in others:
             if other_ref == ref or (exclude and other_ref in exclude):
                 continue
             r = other.rect()
@@ -334,6 +345,44 @@ class QuenchState:
         part.x, part.y, part.rot = x, y, rot
         for net_id in part.nets:
             self.net_airwires[net_id] = self._build_net_airwires(net_id)
+
+    def build_neighbor_lists(self, travel_budget):
+        """Per-movable-part pruned neighbour lists (perf, mirrors the
+        fanout_clearance pattern from #213 profiling). A movable part's live
+        position stays within travel_budget of its seed (nudge candidates are
+        radius-checked against the seed; swaps are capped by swap_cap <=
+        max_displacement), and rect() only ever reads bounds_by_rot, so the
+        union-of-rotations box at the seed inflated by the budget contains
+        every rect the part can ever occupy. Any pair whose per-axis seed gap
+        exceeds both budgets plus the largest interaction reach (hard
+        clearance / summed halos) can NEVER interact -- excluding it is exact
+        for candidate_valid AND part_geometry_cost, not an approximation."""
+        geom = {}
+        for ref, p in self.parts.items():
+            if p.locked:
+                geom[ref] = (p.rect(), 0.0)
+            else:
+                u0 = min(b[0] for b in p.bounds_by_rot.values())
+                u1 = min(b[1] for b in p.bounds_by_rot.values())
+                u2 = max(b[2] for b in p.bounds_by_rot.values())
+                u3 = max(b[3] for b in p.bounds_by_rot.values())
+                geom[ref] = ((p.seed_x + u0, p.seed_y + u1,
+                              p.seed_x + u2, p.seed_y + u3), travel_budget)
+        self._neighbors = {}
+        for ref, p in self.parts.items():
+            if p.locked:
+                continue
+            ra, ba = geom[ref]
+            lst = []
+            for oref, (rb, bb) in geom.items():
+                if oref == ref:
+                    continue
+                m = ba + bb + max(self.clearance,
+                                  p.halo + self.parts[oref].halo) + 1e-9
+                if (ra[2] + m >= rb[0] and rb[2] + m >= ra[0]
+                        and ra[3] + m >= rb[1] and rb[3] + m >= ra[1]):
+                    lst.append(oref)
+            self._neighbors[ref] = lst
 
 
 def _candidate_positions(part: _Part, max_disp: float, step: float,
@@ -417,6 +466,7 @@ def quench(pcb_data: PCBData, pcb_file: str,
                         extra_locked_refs=extra_locked,
                         move_refs=move_refs,
                         net_weights=net_weights)
+    state.build_neighbor_lists(max_displacement + grid_step)
 
     before = state.total_cost()
     print(f"Initial: length={before['length']:.1f}mm "

--- a/placement/quench.py
+++ b/placement/quench.py
@@ -5,7 +5,9 @@ Greedy quench placement optimizer: perturbative refinement of an existing
 Starts from the current placement and repeatedly tries, for each component,
 small moves within --max-displacement of its seed position plus 90-degree
 rotations and same-footprint swaps, accepting only improvements
-(zero-temperature anneal). Locked components never move.
+(zero-temperature anneal). Same-footprint swaps are accepted only if both
+parts land within swap_max_displacement (default: max_displacement) of
+their own seed positions. Locked components never move.
 
 Cost = total airwire length
      + crossing_penalty * airwire crossings
@@ -357,6 +359,7 @@ def _candidate_positions(part: _Part, max_disp: float, step: float,
 
 def quench(pcb_data: PCBData, pcb_file: str,
            max_displacement: float = 10.0,
+           swap_max_displacement: Optional[float] = None,
            step: float = 1.0,
            grid_step: float = 0.1,
            clearance: float = 0.25,
@@ -381,6 +384,16 @@ def quench(pcb_data: PCBData, pcb_file: str,
     Returns a list of placement dicts (reference/new_x/new_y/new_rotation)
     for every movable part, whether or not it moved.
     """
+    if swap_max_displacement is not None:
+        if swap_max_displacement < 0:
+            raise ValueError("swap_max_displacement must be >= 0")
+        if swap_max_displacement > max_displacement + 1e-9:
+            raise ValueError(
+                "swap_max_displacement must be <= max_displacement "
+                "(each part must stay within max_displacement of its seed)")
+    swap_cap = (max_displacement if swap_max_displacement is None
+                else swap_max_displacement)
+
     ignore_net_ids: Set[int] = set()
     if ignore_nets:
         import fnmatch
@@ -416,6 +429,7 @@ def quench(pcb_data: PCBData, pcb_file: str,
     for pass_num in range(1, max_passes + 1):
         improved = 0.0
         moves = 0
+        swaps_skipped = 0
 
         # --- single-part moves (nudge + rotate) ---
         for ref in movable:
@@ -472,6 +486,23 @@ def quench(pcb_data: PCBData, pcb_file: str,
                     for j in range(i + 1, len(refs)):
                         ra, rb = refs[i], refs[j]
                         pa, pb = state.parts[ra], state.parts[rb]
+                        # Swapping must keep each part within swap_cap of
+                        # its OWN seed position
+                        if (math.hypot(pb.x - pa.seed_x, pb.y - pa.seed_y) > swap_cap + 1e-9
+                                or math.hypot(pa.x - pb.seed_x, pa.y - pb.seed_y) > swap_cap + 1e-9):
+                            swaps_skipped += 1
+                            continue
+                        # Courtyards are extracted per-ref, so the same
+                        # footprint_name doesn't guarantee identical bounds
+                        if pa.bounds_by_rot[0.0] != pb.bounds_by_rot[0.0]:
+                            continue
+                        # rect() falls back to rot-0 bounds for unknown
+                        # rotations; add the partner's rotation lazily so
+                        # non-90-degree swaps use correct geometry
+                        for p_dst, inherited in ((pa, pb.rot % 360), (pb, pa.rot % 360)):
+                            if inherited not in p_dst.bounds_by_rot:
+                                p_dst.bounds_by_rot[inherited] = _rotate_local_bounds(
+                                    *p_dst.bounds_by_rot[0.0], inherited)
                         involved = set(pa.nets) | set(pb.nets)
                         other_aw = state.airwires_excluding(involved)
 
@@ -515,13 +546,18 @@ def quench(pcb_data: PCBData, pcb_file: str,
                             state.apply_move(ra, pb.x, pb.y, pb.rot)
                             state.apply_move(rb, ax, ay, arot)
                             if verbose:
-                                print(f"  swap {ra} <-> {rb} gain={gain:.1f}")
+                                da = math.hypot(pa.x - pa.seed_x, pa.y - pa.seed_y)
+                                db = math.hypot(pb.x - pb.seed_x, pb.y - pb.seed_y)
+                                print(f"  swap {ra} <-> {rb} gain={gain:.1f}"
+                                      f" (d[{ra}]={da:.1f}mm, d[{rb}]={db:.1f}mm)")
 
         stats = state.total_cost()
+        swap_note = (f" swap-capped={swaps_skipped}"
+                     if verbose and swaps_skipped else "")
         print(f"Pass {pass_num}: {moves} moves, gain {improved:.1f} -> "
               f"length={stats['length']:.1f}mm crossings={stats['crossings']} "
               f"halo={stats['halo']:.1f} edge={stats['edge']:.1f} "
-              f"total={stats['total']:.1f}")
+              f"total={stats['total']:.1f}{swap_note}")
         if moves == 0:
             break
 

--- a/placement/quench.py
+++ b/placement/quench.py
@@ -357,15 +357,27 @@ class QuenchState:
         exceeds both budgets plus the largest interaction reach (hard
         clearance / summed halos) can NEVER interact -- excluding it is exact
         for candidate_valid AND part_geometry_cost, not an approximation."""
+        # A swap can hand a part any rotation currently held by a movable
+        # same-footprint partner (the swap path adds the bounds entry lazily,
+        # after this build), so each part's union box must cover its whole
+        # group's rotation set, not just its own bounds_by_rot entries.
+        group_rots: Dict[str, set] = {}
+        for p in self.parts.values():
+            if not p.locked:
+                group_rots.setdefault(p.footprint_name, set()).update(
+                    p.bounds_by_rot)
         geom = {}
         for ref, p in self.parts.items():
             if p.locked:
                 geom[ref] = (p.rect(), 0.0)
             else:
-                u0 = min(b[0] for b in p.bounds_by_rot.values())
-                u1 = min(b[1] for b in p.bounds_by_rot.values())
-                u2 = max(b[2] for b in p.bounds_by_rot.values())
-                u3 = max(b[3] for b in p.bounds_by_rot.values())
+                boxes = [p.bounds_by_rot[r] if r in p.bounds_by_rot
+                         else _rotate_local_bounds(*p.bounds_by_rot[0.0], r)
+                         for r in group_rots[p.footprint_name]]
+                u0 = min(b[0] for b in boxes)
+                u1 = min(b[1] for b in boxes)
+                u2 = max(b[2] for b in boxes)
+                u3 = max(b[3] for b in boxes)
                 geom[ref] = ((p.seed_x + u0, p.seed_y + u1,
                               p.seed_x + u2, p.seed_y + u3), travel_budget)
         self._neighbors = {}

--- a/placement/quench.py
+++ b/placement/quench.py
@@ -162,10 +162,16 @@ class _Part:
         else:
             lb = compute_footprint_bbox_local(fp)
         self.bounds_by_rot = {r: _rotate_local_bounds(*lb, r) for r in ROTATIONS}
-        # Non-90-degree seed rotations keep their own bounds entry
-        if fp.rotation % 90 != 0:
-            self.bounds_by_rot[fp.rotation % 360] = _rotate_local_bounds(
-                *lb, fp.rotation)
+        # A non-90-degree seed rotation brings its WHOLE 90-degree lattice:
+        # those are the poses _candidate_rotations offers such a part, and
+        # build_neighbor_lists unions bounds_by_rot over the movable
+        # same-footprint group, so recording them here is what keeps the
+        # pruning boxes covering every pose the group can reach.
+        base = fp.rotation % 90
+        if base:
+            for r in ROTATIONS:
+                rot = (base + r) % 360
+                self.bounds_by_rot[rot] = _rotate_local_bounds(*lb, rot)
         self.seed_x, self.seed_y = fp.x, fp.y
         self.x, self.y, self.rot = fp.x, fp.y, fp.rotation % 360
         self.orig_rot = fp.rotation % 360
@@ -419,7 +425,11 @@ class QuenchState:
         # A swap can hand a part any rotation currently held by a movable
         # same-footprint partner (the swap path adds the bounds entry lazily,
         # after this build), so each part's union box must cover its whole
-        # group's rotation set, not just its own bounds_by_rot entries.
+        # group's rotation set, not just its own bounds_by_rot entries. Since
+        # _Part records the full 90-degree lattice of a non-orthogonal seed,
+        # that union is exactly {seed angle + 90k} over every movable part of
+        # the group, which is the closure of what a swap can hand over and a
+        # nudge can then rotate within.
         group_rots: Dict[str, set] = {}
         for p in self.parts.values():
             if not p.locked:
@@ -475,6 +485,32 @@ def _candidate_positions(part: _Part, max_disp: float, step: float,
                 seen.add(key)
                 out.append((cx, cy))
     return out
+
+
+def _candidate_rotations(part: _Part, allow_rotations: bool) -> List[float]:
+    """Rotation candidates for a nudge move.
+
+    The 90-degree lattice through the part's CURRENT angle, plus the lattice
+    through its seed angle when a swap has moved it off that one. Two
+    consequences beyond the old "the four axis rotations, but only if the seed
+    is orthogonal" rule: a part placed at 45 degrees can rotate at all, to
+    135/225/315, staying on its own lattice rather than being snapped onto the
+    axes; and the current pose is always among the candidates, so such a part
+    can be MOVED while KEEPING its angle.
+
+    Generated in ROTATIONS order from a base of rot % 90, so for any part
+    sitting at a multiple of 90, which is every part on a board with only
+    orthogonal footprint rotations, this returns exactly ROTATIONS: same
+    values, same order. The order is load-bearing, not style: the caller keeps
+    the FIRST strict minimum, so a reordered list would silently change which
+    pose wins a tie. Do not rewrite this as a set.
+    """
+    if not allow_rotations:
+        return [part.rot]
+    bases = [part.rot % 90]
+    if part.orig_rot % 90 != bases[0]:
+        bases.append(part.orig_rot % 90)
+    return [(b + r) % 360 for b in bases for r in ROTATIONS]
 
 
 def quench(pcb_data: PCBData, pcb_file: str,
@@ -573,8 +609,17 @@ def quench(pcb_data: PCBData, pcb_file: str,
                 return net_cost + geo_cost
 
             current_cost = eval_at(part.x, part.y, part.rot)
-            rotations = (ROTATIONS if allow_rotations and part.orig_rot % 90 == 0
-                         else [part.rot])
+            rotations = _candidate_rotations(part, allow_rotations)
+            for rot in rotations:
+                # A swap can hand a part an angle from ANOTHER seed's lattice,
+                # in a group holding two different non-orthogonal seeds. Add
+                # the bounds entry so rect() does not silently fall back to
+                # rot-0 geometry. Every such angle is already inside the group
+                # closure build_neighbor_lists unioned, so this cannot
+                # invalidate the pruning. No-op for orthogonal parts.
+                if rot not in part.bounds_by_rot:
+                    part.bounds_by_rot[rot] = _rotate_local_bounds(
+                        *part.bounds_by_rot[0.0], rot)
 
             best = (current_cost, part.x, part.y, part.rot)
             for cx, cy in _candidate_positions(part, max_displacement, step,

--- a/placement/quench.py
+++ b/placement/quench.py
@@ -612,6 +612,16 @@ def quench(pcb_data: PCBData, pcb_file: str,
                     for j in range(i + 1, len(refs)):
                         ra, rb = refs[i], refs[j]
                         pa, pb = state.parts[ra], state.parts[rb]
+                        # A swap exchanges FULL poses, rotation included, so a
+                        # mixed-angle pair rotates both parts. --no-rotate
+                        # promises that no move changes any part's rotation:
+                        # restrict swaps to pairs that already share one, which
+                        # also keeps the exchange rotation-neutral and so
+                        # preserves the occupied-space invariance that lets
+                        # swaps skip candidate_valid. Checked before the cap so
+                        # swaps_skipped keeps counting cap rejections only.
+                        if not allow_rotations and abs(pa.rot - pb.rot) > 1e-9:
+                            continue
                         # Swapping must keep each part within swap_cap of
                         # its OWN seed position
                         if (math.hypot(pb.x - pa.seed_x, pb.y - pa.seed_y) > swap_cap + 1e-9

--- a/placement/quench.py
+++ b/placement/quench.py
@@ -17,6 +17,12 @@ Cost = total airwire length
 The halo term spreads apart parts that are not pulled together by shared
 nets — things that *can* be far apart may as well be, to leave routing room,
 especially around high-pin-count parts.
+
+Both airwire terms accept optional per-net weights (`net_weights`): a net's
+airwire length is scaled by its weight, and each crossing is priced by the
+larger of the two crossing nets' weights, so place_route_loop.py can bias the
+whole objective toward the nets the router failed on. An unweighted board is
+untouched, since max(1, 1) = 1.
 """
 from __future__ import annotations
 
@@ -74,11 +80,20 @@ def _aw_array(airwires) -> np.ndarray:
     return np.asarray(airwires, dtype=float)
 
 
-def _count_crossings_np(a: np.ndarray, b: np.ndarray) -> int:
+def _count_crossings_np(a: np.ndarray, b: np.ndarray,
+                        net_w: Optional[np.ndarray] = None):
     """Count crossings between airwire sets a (n,5) and b (m,5), skipping
-    same-net pairs and pairs sharing an endpoint (within 1um)."""
+    same-net pairs and pairs sharing an endpoint (within 1um).
+
+    Returns (count, weighted). `count` is the raw unweighted pair count, kept
+    as an int for reporting. `weighted` prices each crossing at
+    max(net_w[net_a], net_w[net_b]), the per-net weighting from #458, where
+    net_w is a net-id-indexed weight lookup (QuenchState._net_w). With net_w
+    None the two are equal and `weighted` is exactly float(count), so
+    unweighted callers get bit-identical costs.
+    """
     if len(a) == 0 or len(b) == 0:
-        return 0
+        return 0, 0.0
     eps = 0.001
     a1x = a[:, 0][:, None]; a1y = a[:, 1][:, None]
     a2x = a[:, 2][:, None]; a2y = a[:, 3][:, None]
@@ -100,15 +115,35 @@ def _count_crossings_np(a: np.ndarray, b: np.ndarray) -> int:
         (ccw(a1x, a1y, b1x, b1y, b2x, b2y) != ccw(a2x, a2y, b1x, b1y, b2x, b2y)) &
         (ccw(a1x, a1y, a2x, a2y, b1x, b1y) != ccw(a1x, a1y, a2x, a2y, b2x, b2y))
     )
-    return int(np.count_nonzero(inter & ~same_net & ~shared))
+    hits = inter & ~same_net & ~shared
+    count = int(np.count_nonzero(hits))
+    if net_w is None:
+        return count, float(count)
+    # Column 4 carries the net id as a float; every id that can appear there
+    # is a key of QuenchState.net_airwires, which net_w is sized to cover.
+    wa = net_w[a[:, 4].astype(np.intp)]
+    wb = net_w[b[:, 4].astype(np.intp)]
+    return count, float(np.sum(np.maximum(wa[:, None], wb[None, :])[hits]))
 
 
-def _count_crossings_within(a: np.ndarray) -> int:
-    """Crossings among one airwire set (each unordered pair counted once)."""
+def _count_crossings_within(a: np.ndarray,
+                            net_w: Optional[np.ndarray] = None):
+    """Crossings among one airwire set (each unordered pair counted once).
+    Returns (count, weighted), as _count_crossings_np."""
     if len(a) < 2:
-        return 0
-    total = _count_crossings_np(a, a)
-    return total // 2
+        return 0, 0.0
+    total, weighted = _count_crossings_np(a, a, net_w)
+    half = total // 2
+    if net_w is None:
+        # Keep the historical integer halving bit-exact. The ccw predicate for
+        # (i,j) and (j,i) are different floating point expressions of the same
+        # orientation, so `total` is not PROVABLY even and float(total)/2 is
+        # not always float(total // 2). Do not "simplify" this branch away.
+        return half, float(half)
+    # max(w_i, w_j) is symmetric and so is the crossing relation, so every
+    # unordered pair contributes twice with the same weight; dividing by 2.0
+    # is exact in binary floating point.
+    return half, weighted / 2.0
 
 
 class _Part:
@@ -213,6 +248,20 @@ class QuenchState:
         for net_id in self.net_refs:
             self.net_airwires[net_id] = self._build_net_airwires(net_id)
 
+        # Dense net_id -> weight lookup for the crossing kernel, derived once
+        # from net_weights (which is not mutated after construction) and sized
+        # to cover every net id that can appear in an airwire array's column 4.
+        # None when there is nothing to weight, which short-circuits the
+        # crossing kernel back onto its exact integer path.
+        self._net_w = None
+        if self.net_weights:
+            size = max(max(self.net_weights),
+                       max(self.net_airwires, default=-1)) + 1
+            self._net_w = np.ones(size)
+            for net_id, w in self.net_weights.items():
+                if net_id >= 0:
+                    self._net_w[net_id] = w
+
         # Optional pruned neighbour lists (see build_neighbor_lists)
         self._neighbors = None
 
@@ -307,22 +356,32 @@ class QuenchState:
     def nets_cost(self, net_airwires_subset: Dict[int, List],
                   other_airwires: np.ndarray):
         """Length + crossing cost of the given nets' airwires, counting
-        crossings against `other_airwires` and among themselves."""
+        crossings against `other_airwires` and among themselves.
+
+        Returns (cost, crossings). The cost prices each crossing at the larger
+        of the two nets' weights (#458), so a weighted net's crossings, not
+        just its far cheaper length, carry the weight; `crossings` stays the
+        raw unweighted count for reporting."""
         own = []
         for lst in net_airwires_subset.values():
             own.extend(lst)
         own_arr = _aw_array(own)
         length = self._weighted_length(own_arr)
-        crossings = _count_crossings_np(own_arr, other_airwires)
-        crossings += _count_crossings_within(own_arr)
-        return self.length_weight * length + self.crossing_penalty * crossings, crossings
+        n_out, w_out = _count_crossings_np(own_arr, other_airwires, self._net_w)
+        n_in, w_in = _count_crossings_within(own_arr, self._net_w)
+        return (self.length_weight * length
+                + self.crossing_penalty * (w_out + w_in)), n_out + n_in
 
     # ----- full cost (for reporting) ---------------------------------------
 
     def total_cost(self):
         all_aw = _aw_array([aw for lst in self.net_airwires.values() for aw in lst])
         length = self._weighted_length(all_aw)
-        crossings = _count_crossings_within(all_aw)
+        # `crossings` stays the raw unweighted count so the pass banner and
+        # any count-based expectation are unchanged; `total` is the objective
+        # the quench actually minimizes, which is weighted (#458), matching
+        # `length`, which has always been weighted.
+        crossings, w_crossings = _count_crossings_within(all_aw, self._net_w)
         halo = 0.0
         edge = 0.0
         refs = list(self.parts)
@@ -334,7 +393,7 @@ class QuenchState:
                 pb = self.parts[rb]
                 halo += self._halo_pair_penalty(pa, rect_a, pb, pb.rect())
         total = (self.length_weight * length
-                 + self.crossing_penalty * crossings + halo + edge)
+                 + self.crossing_penalty * w_crossings + halo + edge)
         return {'total': total, 'length': length, 'crossings': crossings,
                 'halo': halo, 'edge': edge}
 
@@ -441,6 +500,11 @@ def quench(pcb_data: PCBData, pcb_file: str,
            net_weights: Optional[Dict[int, float]] = None,
            verbose: bool = False) -> List[Dict]:
     """Greedy quench: iterate over parts, accept only cost-reducing moves.
+
+    net_weights: optional {net_id: weight} priority multipliers. A weighted
+    net's airwire length is scaled by its weight and every crossing it takes
+    part in is priced at max(weight_a, weight_b). Absent or all-ones leaves
+    the cost exactly unchanged.
 
     Returns a list of placement dicts (reference/new_x/new_y/new_rotation)
     for every movable part, whether or not it moved.

--- a/tests/test_458_loop_steering.py
+++ b/tests/test_458_loop_steering.py
@@ -1,0 +1,191 @@
+"""
+Tests for how place_route_loop steers the quench (issue #458).
+
+The loop widens --max-displacement 1.5x after a rejected round. Since #455
+gave quench a swap cap that DEFAULTS to max_displacement, that widening used
+to widen swap teleports in lockstep: a 3mm base reaches 15mm after four
+rejections, which is the #430 stranding failure coming back through the loop.
+The loop now passes swap_max_displacement explicitly and holds it at the base
+value while the nudge radius grows, and it plumbs --no-rotate / --no-swap /
+--verbose through to quench.
+
+Nothing is routed here. The routing step, the quench and the writer are
+replaced with recorders, so the whole file is a unit test: no router binary,
+no board is written, and it stays in the run_all.py --fast lane.
+"""
+
+import inspect
+import os
+import shutil
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import place_route_loop as prl
+from placement.quench import quench as real_quench
+
+
+def _loop_board():
+    """One movable 2-pad part C1 on net NA plus a locked anchor J1 on the
+    same net, inside a (100,80)-(200,120) outline. The loop only needs the
+    board to parse and to yield one movable target ref for net NA."""
+    body = '(kicad_pcb\n\t(version 20241229)\n'
+    body += '\t(net 0 "")\n\t(net 1 "NA")\n'
+    body += '''\t(gr_rect
+\t\t(start 100 80)
+\t\t(end 200 120)
+\t\t(stroke
+\t\t\t(width 0.1)
+\t\t\t(type solid)
+\t\t)
+\t\t(layer "Edge.Cuts")
+\t\t(uuid "edge1")
+\t)
+\t(footprint "test:CAP2P"
+\t\t(layer "F.Cu")
+\t\t(uuid "fp-C1")
+\t\t(at 150 100)
+\t\t(property "Reference" "C1"
+\t\t\t(at 0 0)
+\t\t)
+\t\t(pad "1" smd rect
+\t\t\t(at -0.5 0)
+\t\t\t(size 0.8 0.8)
+\t\t\t(layers "F.Cu")
+\t\t\t(net 1 "NA")
+\t\t\t(uuid "p1-C1")
+\t\t)
+\t)
+\t(footprint "test:PIN"
+\t\t(layer "F.Cu")
+\t\t(locked yes)
+\t\t(uuid "fp-J1")
+\t\t(at 170 100)
+\t\t(property "Reference" "J1"
+\t\t\t(at 0 0)
+\t\t)
+\t\t(pad "1" smd rect
+\t\t\t(at 0 0)
+\t\t\t(size 1 1)
+\t\t\t(layers "F.Cu")
+\t\t\t(net 1 "NA")
+\t\t\t(uuid "p1-J1")
+\t\t)
+\t)
+)
+'''
+    fd, path = tempfile.mkstemp(suffix='.kicad_pcb')
+    with os.fdopen(fd, 'w') as f:
+        f.write(body)
+    return path, tempfile.mkdtemp()
+
+
+def _run_loop(extra_args, rounds=4, quench_result=None):
+    """Run main() with the routing step, the quench and the writer replaced.
+    Returns the list of kwargs quench was called with, one entry per round."""
+    calls = []
+    placements = ([{'reference': 'C1', 'new_x': 151.0, 'new_y': 100.0,
+                    'new_rotation': 0.0}] if quench_result is None
+                  else quench_result)
+
+    def fake_quench(pcb_data, **kw):
+        calls.append(dict(kw))
+        return placements
+
+    def fake_run_route(pcb_file, routed_file, route_args, log_file):
+        # Every candidate scores exactly like round 0, so better() is False
+        # and every round is REJECTED: the cap widens on every round.
+        return {'failures': 2, 'failed_nets': ['NA'], 'blockers': [],
+                'iterations': 1000, 'vias': 0}
+
+    board, work = _loop_board()
+    saved = (prl.quench, prl.run_route, prl.write_placed_output, sys.argv)
+    prl.quench = fake_quench
+    prl.run_route = fake_run_route
+    prl.write_placed_output = lambda src, dst, pl: shutil.copy(src, dst)
+    sys.argv = ['place_route_loop.py', board,
+                os.path.join(work, 'out.kicad_pcb'),
+                '--route-args', '--nets "*"', '--rounds', str(rounds),
+                '--max-displacement', '3.0', '--work-dir', work] + extra_args
+    try:
+        prl.main()
+    finally:
+        (prl.quench, prl.run_route, prl.write_placed_output,
+         sys.argv) = saved
+        os.unlink(board)
+        shutil.rmtree(work, ignore_errors=True)
+    return calls
+
+
+def test_swap_cap_held_while_displacement_widens():
+    """The headline invariant: four rejected rounds widen the nudge cap from
+    3mm to 10.1mm while the swap cap stays at the base 3mm."""
+    calls = _run_loop([])
+    assert len(calls) == 4, f"expected one quench per round, got {len(calls)}"
+    assert [c['max_displacement'] for c in calls] == [3.0, 4.5, 6.75, 10.125]
+    assert [c['swap_max_displacement'] for c in calls] == [3.0, 3.0, 3.0, 3.0]
+    for c in calls:
+        # quench() raises ValueError if this is ever violated.
+        assert c['swap_max_displacement'] <= c['max_displacement'] + 1e-9
+
+
+def test_swap_cap_held_when_quench_finds_nothing():
+    """The other widening site: an empty quench result widens the cap without
+    a candidate route, and must not widen swaps either."""
+    calls = _run_loop([], quench_result=[])
+    assert [c['max_displacement'] for c in calls] == [3.0, 4.5, 6.75, 10.125]
+    assert [c['swap_max_displacement'] for c in calls] == [3.0] * 4
+
+
+def test_swap_cap_flag_overrides_the_base():
+    calls = _run_loop(['--swap-max-displacement', '1.0'])
+    assert [c['swap_max_displacement'] for c in calls] == [1.0] * 4
+
+
+def test_rotate_and_swap_flags_reach_quench():
+    """--no-rotate / --no-swap / --verbose exist on the loop and arrive at
+    quench; without them both move types stay enabled."""
+    calls = _run_loop([])
+    assert all(c['allow_rotations'] is True and c['allow_swaps'] is True
+               and c['verbose'] is False for c in calls), \
+        "defaults must keep both move types enabled and stay quiet"
+    calls = _run_loop(['--no-rotate', '--no-swap', '--verbose'])
+    assert all(c['allow_rotations'] is False and c['allow_swaps'] is False
+               and c['verbose'] is True for c in calls)
+
+
+def test_kwargs_match_the_real_quench_signature():
+    """Guards the recorder itself: binding the captured kwargs against the
+    real signature fails on a renamed keyword that a stub would swallow."""
+    sig = inspect.signature(real_quench)
+    for c in _run_loop([]):
+        sig.bind(None, **c)
+
+
+def test_swap_cap_above_displacement_is_rejected():
+    """Mirrors place_optimize.py's argparse check rather than letting the
+    value reach quench and raise ValueError from inside a round."""
+    try:
+        _run_loop(['--swap-max-displacement', '9.0'])
+    except SystemExit as exc:
+        assert exc.code != 0
+    else:
+        raise AssertionError("--swap-max-displacement 9.0 must be rejected "
+                             "against a 3.0mm --max-displacement")
+
+
+TESTS = [
+    test_swap_cap_held_while_displacement_widens,
+    test_swap_cap_held_when_quench_finds_nothing,
+    test_swap_cap_flag_overrides_the_base,
+    test_rotate_and_swap_flags_reach_quench,
+    test_kwargs_match_the_real_quench_signature,
+    test_swap_cap_above_displacement_is_rejected,
+]
+
+
+if __name__ == '__main__':
+    for fn in TESTS:
+        fn()
+    print("ALL PASS")

--- a/tests/test_458_loop_steering.py
+++ b/tests/test_458_loop_steering.py
@@ -349,6 +349,43 @@ def test_merge_returns_none_without_a_summary():
         is None
 
 
+# --- how route.py is invoked (issue #458 drive-by) ---------------------
+
+def test_route_py_is_invoked_by_absolute_path_in_utf8_mode():
+    """A bare relative 'route.py' only resolved from the repo root, and the
+    failure surfaced as "produced no JSON_SUMMARY" rather than the real
+    error."""
+    _, calls = _metrics_for(LOG_ONE_PASS)
+    cmd = calls[-1]
+    assert cmd[1:3] == ['-X', 'utf8'], cmd
+    assert os.path.isabs(cmd[3]), cmd
+    assert cmd[3] == os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        'route.py'), cmd
+
+
+def test_nonzero_exit_raises_and_names_the_real_error():
+    """route.py exits 0 even when nets fail, so a non-zero code is a crash or
+    a bad invocation. It used to be swallowed."""
+    try:
+        _metrics_for("No nets matched the given patterns!\n", rc=2)
+    except RuntimeError as exc:
+        assert 'exited 2' in str(exc), exc
+        assert 'No nets matched' in str(exc), exc
+    else:
+        raise AssertionError("a non-zero exit code must not be swallowed")
+
+
+def test_missing_summary_raises_with_the_log_tail():
+    try:
+        _metrics_for("Traceback (most recent call last):\nKeyError: 'nets'\n")
+    except RuntimeError as exc:
+        assert 'JSON_SUMMARY' in str(exc), exc
+        assert "KeyError: 'nets'" in str(exc), exc
+    else:
+        raise AssertionError("a log with no summary must raise")
+
+
 TESTS = [
     test_swap_cap_held_while_displacement_widens,
     test_swap_cap_held_when_quench_finds_nothing,
@@ -364,6 +401,9 @@ TESTS = [
     test_aborted_reconciliation_falls_back_to_the_first_summary,
     test_reconciliation_without_a_summary_degrades_to_the_first,
     test_merge_returns_none_without_a_summary,
+    test_route_py_is_invoked_by_absolute_path_in_utf8_mode,
+    test_nonzero_exit_raises_and_names_the_real_error,
+    test_missing_summary_raises_with_the_log_tail,
 ]
 
 

--- a/tests/test_458_loop_steering.py
+++ b/tests/test_458_loop_steering.py
@@ -175,6 +175,180 @@ def test_swap_cap_above_displacement_is_rejected():
                              "against a 3.0mm --max-displacement")
 
 
+# --- the round tally (issue #458 item 1) -------------------------------
+#
+# route.py runs an end-of-run reconciliation pass exactly when the first pass
+# left failures, and prints a second JSON_SUMMARY scoped to the retried nets.
+# The loop used to read the FIRST summary, so every net the reconciliation
+# recovered still counted as failed. The logs below are trimmed to the lines
+# the loop actually parses.
+
+LOG_TWO_PASS = '''Frontier blocking analysis:
+  1. /VBUS: 46 (31.7%), 12 uniq (26%)
+  2. /GND: 20 (13.8%), 4 uniq (20%)
+JSON_SUMMARY: {"failed_single": ["/A", "/B"], "failed_multipoint": \
+[{"net_name": "/C", "failed_pads": [{"component_ref": "U1", \
+"pad_number": "3"}, {"component_ref": "U2", "pad_number": "7"}]}], \
+"multipoint_pads_total": 20, "multipoint_pads_connected": 18, \
+"total_iterations": 1000, "total_vias": 300, "total_time": 12.5}
+
+Final reconciliation: retrying 3 incomplete net(s) against the finished \
+board: /A, /B, /C
+Frontier blocking analysis:
+  1. /MD1: 7 (9.1%), 2 uniq (28%)
+JSON_SUMMARY: {"failed_single": ["/B"], "failed_multipoint": \
+[{"net_name": "/C", "failed_pads": [{"component_ref": "U1", \
+"pad_number": "3"}]}], "multipoint_pads_total": 12, \
+"multipoint_pads_connected": 11, "total_iterations": 40, "total_vias": 7, \
+"total_time": 0.4}
+Note: the JSON_SUMMARY above covers only the reconciliation subset; the \
+run's full tally is the earlier JSON_SUMMARY plus these recoveries.
+'''
+
+LOG_ONE_PASS = '''  Single-ended:  4/4 routed
+JSON_SUMMARY: {"failed_single": [], "failed_multipoint": [], \
+"multipoint_pads_total": 20, "multipoint_pads_connected": 20, \
+"total_iterations": 777, "total_vias": 42, "total_time": 9.0}
+'''
+
+# The reconciliation pass may escalate to rip authority over hinted blockers,
+# and its own coverage gate then reports a net that was never in the retry
+# set: a net the reconciliation itself broke.
+LOG_RECON_BROKE = '''JSON_SUMMARY: {"failed_single": ["/A"], \
+"failed_multipoint": [], "multipoint_pads_total": 20, \
+"multipoint_pads_connected": 20, "total_iterations": 900, "total_vias": 50, \
+"total_time": 8.0}
+
+Final reconciliation: retrying 1 incomplete net(s) against the finished \
+board: /A
+JSON_SUMMARY: {"failed_single": [], "failed_multipoint": \
+[{"net_name": "/GND_RET", "failed_pads": [{"component_ref": "J1", \
+"pad_number": "1"}, {"component_ref": "J1", "pad_number": "2"}]}], \
+"coverage_gate_nets": ["/GND_RET"], "multipoint_pads_total": 6, \
+"multipoint_pads_connected": 6, "total_iterations": 60, "total_vias": 3, \
+"total_time": 0.6}
+'''
+
+# The sub-run prints its summary BEFORE the board is written, so an exception
+# during the write leaves the pass-1 board on disk under a summary that
+# advertises recoveries. route.py:2295 wraps that message in RED/RESET.
+LOG_RECON_ABORTED = '''JSON_SUMMARY: {"failed_single": ["/A", "/B"], \
+"failed_multipoint": [], "multipoint_pads_total": 10, \
+"multipoint_pads_connected": 10, "total_iterations": 500, "total_vias": 20, \
+"total_time": 5.0}
+
+Final reconciliation: retrying 2 incomplete net(s) against the finished \
+board: /A, /B
+JSON_SUMMARY: {"failed_single": [], "failed_multipoint": [], \
+"multipoint_pads_total": 4, "multipoint_pads_connected": 4, \
+"total_iterations": 30, "total_vias": 2, "total_time": 0.3}
+\033[91m  final reconciliation pass failed: [Errno 28] No space left on \
+device\033[0m
+'''
+
+LOG_RECON_NO_SUMMARY = '''JSON_SUMMARY: {"failed_single": ["/A"], \
+"failed_multipoint": [], "multipoint_pads_total": 0, \
+"multipoint_pads_connected": 0, "total_iterations": 300, "total_vias": 11, \
+"total_time": 3.0}
+
+Final reconciliation: retrying 1 incomplete net(s) against the finished \
+board: /A
+All nets are already fully connected - nothing to route!
+'''
+
+
+def _metrics_for(log_text, rc=0):
+    """Drive run_route against a canned route.py log, no child process."""
+    work = tempfile.mkdtemp()
+    calls = []
+
+    def fake(cmd, log_file):
+        calls.append(list(cmd))
+        with open(log_file, 'w', encoding='utf-8') as f:
+            f.write(log_text)
+        return rc
+
+    saved = prl._run_route_cmd
+    prl._run_route_cmd = fake
+    try:
+        metrics = prl.run_route(os.path.join(work, 'in.kicad_pcb'),
+                                os.path.join(work, 'out.kicad_pcb'),
+                                '--nets *', os.path.join(work, 'route.log'))
+    finally:
+        prl._run_route_cmd = saved
+        shutil.rmtree(work, ignore_errors=True)
+    return metrics, calls
+
+
+def test_reconciliation_recoveries_are_not_counted_as_failures():
+    """/A was recovered by the reconciliation pass, /B is still open and /C
+    recovered one of its two open pads. Reading the first summary gave 4."""
+    metrics, _ = _metrics_for(LOG_TWO_PASS)
+    assert metrics['failures'] == 2, metrics
+    assert '/A' not in metrics['failed_nets'], metrics['failed_nets']
+    assert set(metrics['failed_nets']) == {'/B', '/C'}, metrics['failed_nets']
+
+
+def test_effort_counters_are_summed_across_passes():
+    """Both passes are work this placement cost the router, so better()'s
+    iteration tiebreak has to see both."""
+    metrics, _ = _metrics_for(LOG_TWO_PASS)
+    assert metrics['iterations'] == 1040, metrics
+    assert metrics['vias'] == 307, metrics
+
+
+def test_blockers_are_unioned_across_both_passes():
+    """The blocker scrape reads the whole log, so it already spans both
+    passes. Pinned so a future switch to a summary key cannot narrow it."""
+    metrics, _ = _metrics_for(LOG_TWO_PASS)
+    assert metrics['blockers'] == ['/GND', '/MD1', '/VBUS'], metrics
+
+
+def test_single_summary_run_is_unchanged():
+    """A clean run has no reconciliation pass and one summary, which is both
+    the first and the last: same numbers as before the fix, effort not
+    doubled."""
+    metrics, _ = _metrics_for(LOG_ONE_PASS)
+    assert metrics['failures'] == 0
+    assert metrics['failed_nets'] == []
+    assert metrics['iterations'] == 777
+    assert metrics['vias'] == 42
+
+
+def test_a_net_the_reconciliation_broke_is_reported_and_weighed():
+    """A coverage-gate net has no routed result, so its pads never reach
+    multipoint_pads_total and it would otherwise weigh zero: the loop would
+    read failures=0 on a board shipping disconnected copper and stop."""
+    metrics, _ = _metrics_for(LOG_RECON_BROKE)
+    assert metrics['failed_nets'] == ['/GND_RET'], metrics['failed_nets']
+    assert '/A' not in metrics['failed_nets']
+    assert metrics['failures'] >= 1, metrics
+
+
+def test_aborted_reconciliation_falls_back_to_the_first_summary():
+    """The sub-run printed a summary and then died, so the board on disk is
+    still the first pass's. Failure state falls back; effort still sums."""
+    metrics, _ = _metrics_for(LOG_RECON_ABORTED)
+    assert metrics['failures'] == 2, metrics
+    assert set(metrics['failed_nets']) == {'/A', '/B'}, metrics['failed_nets']
+    assert metrics['iterations'] == 530, metrics
+
+
+def test_reconciliation_without_a_summary_degrades_to_the_first():
+    """The sub-run can return before printing anything, e.g. when every
+    retried net turns out to be connected already."""
+    metrics, _ = _metrics_for(LOG_RECON_NO_SUMMARY)
+    assert metrics['failures'] == 1, metrics
+    assert metrics['failed_nets'] == ['/A']
+    assert metrics['iterations'] == 300
+
+
+def test_merge_returns_none_without_a_summary():
+    assert prl.merge_route_summaries('') is None
+    assert prl.merge_route_summaries('Traceback (most recent call last):\n') \
+        is None
+
+
 TESTS = [
     test_swap_cap_held_while_displacement_widens,
     test_swap_cap_held_when_quench_finds_nothing,
@@ -182,6 +356,14 @@ TESTS = [
     test_rotate_and_swap_flags_reach_quench,
     test_kwargs_match_the_real_quench_signature,
     test_swap_cap_above_displacement_is_rejected,
+    test_reconciliation_recoveries_are_not_counted_as_failures,
+    test_effort_counters_are_summed_across_passes,
+    test_blockers_are_unioned_across_both_passes,
+    test_single_summary_run_is_unchanged,
+    test_a_net_the_reconciliation_broke_is_reported_and_weighed,
+    test_aborted_reconciliation_falls_back_to_the_first_summary,
+    test_reconciliation_without_a_summary_degrades_to_the_first,
+    test_merge_returns_none_without_a_summary,
 ]
 
 

--- a/tests/test_458_quench_net_weights.py
+++ b/tests/test_458_quench_net_weights.py
@@ -1,0 +1,295 @@
+"""
+Tests for per-net weighting of airwire crossings (issue #458).
+
+net_weights used to scale airwire LENGTH only. At place_route_loop's own
+knobs (length_weight 0.3, crossing_penalty 30) the crossing term is about 96%
+of the objective, so --failed-net-weight 3.0 raised a length coefficient from
+0.3 to 0.9 against a crossing coefficient of 30: on a real board that moved a
+typical failed net by about a fifth of one crossing. Each crossing is now
+priced at max of the two crossing nets' weights, so a weighted net's whole
+contribution scales by its weight, which is what the flag has always claimed.
+
+max() is the rule that keeps an unweighted board untouched, since
+max(1, 1) = 1. That backward compatibility is not an accident and is pinned
+below: the reported crossing count stays a raw int, and the unweighted code
+path is the same integer arithmetic it always was.
+
+The two-pose fixture is built so the weighting flips the optimizer's CHOICE,
+not just its arithmetic: with the nudge grid at step=10 inside a 20x21mm
+outline, exactly two candidate poses survive board containment, and they
+cross different nets.
+"""
+
+import math
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import numpy as np
+
+from kicad_parser import parse_kicad_pcb
+from placement.quench import (QuenchState, quench, _aw_array,
+                              _count_crossings_np, _count_crossings_within)
+
+INTERF_U = os.path.join(os.path.dirname(__file__), '..', 'kicad_files',
+                        'interf_u_unrouted.kicad_pcb')
+
+
+def _cap_footprint(ref, x, y, net_id, net_name):
+    """Movable 2-pad part; pad 1 (at -0.5,0) carries the net."""
+    return f'''\t(footprint "test:CAP2P"
+\t\t(layer "F.Cu")
+\t\t(uuid "fp-{ref}")
+\t\t(at {x} {y})
+\t\t(property "Reference" "{ref}"
+\t\t\t(at 0 0)
+\t\t)
+\t\t(pad "1" smd rect
+\t\t\t(at -0.5 0)
+\t\t\t(size 0.8 0.8)
+\t\t\t(layers "F.Cu")
+\t\t\t(net {net_id} "{net_name}")
+\t\t\t(uuid "p1-{ref}")
+\t\t)
+\t)
+'''
+
+
+def _anchor_footprint(ref, x, y, net_id, net_name):
+    """Locked single-pad net anchor (a connector pin the airwire pulls at)."""
+    return f'''\t(footprint "test:PIN"
+\t\t(layer "F.Cu")
+\t\t(locked yes)
+\t\t(uuid "fp-{ref}")
+\t\t(at {x} {y})
+\t\t(property "Reference" "{ref}"
+\t\t\t(at 0 0)
+\t\t)
+\t\t(pad "1" smd rect
+\t\t\t(at 0 0)
+\t\t\t(size 1 1)
+\t\t\t(layers "F.Cu")
+\t\t\t(net {net_id} "{net_name}")
+\t\t\t(uuid "p1-{ref}")
+\t\t)
+\t)
+'''
+
+
+def _crossing_board():
+    """Movable M on net NX inside a (40,45)-(60,66) outline, with its anchor
+    JX at (58,55). With step=10 and max_displacement=10 the candidate grid is
+    five points and board containment leaves exactly two: the seed (50,60) and
+    (50,50).
+
+    From the seed, M's airwire to JX crosses the NF pair once. From (50,50) it
+    crosses the NK1 and NK2 pairs, twice. So the unweighted cost prefers the
+    seed (1 crossing < 2) and weighting NF by 3 flips it (3 > 2)."""
+    body = '(kicad_pcb\n\t(version 20241229)\n'
+    body += ('\t(net 0 "")\n\t(net 1 "NX")\n\t(net 2 "NF")\n'
+             '\t(net 3 "NK1")\n\t(net 4 "NK2")\n')
+    body += '''\t(gr_rect
+\t\t(start 40 45)
+\t\t(end 60 66)
+\t\t(stroke
+\t\t\t(width 0.1)
+\t\t\t(type solid)
+\t\t)
+\t\t(layer "Edge.Cuts")
+\t\t(uuid "edge1")
+\t)
+'''
+    body += _cap_footprint('M', 50.0, 60.0, 1, 'NX')
+    body += _anchor_footprint('JX', 58.0, 55.0, 1, 'NX')
+    body += _anchor_footprint('JF1', 53.75, 56.5, 2, 'NF')
+    body += _anchor_footprint('JF2', 53.75, 58.5, 2, 'NF')
+    body += _anchor_footprint('JK1a', 52.0, 50.5, 3, 'NK1')
+    body += _anchor_footprint('JK1b', 52.0, 52.5, 3, 'NK1')
+    body += _anchor_footprint('JK2a', 55.5, 52.5, 4, 'NK2')
+    body += _anchor_footprint('JK2b', 55.5, 54.5, 4, 'NK2')
+    body += ')\n'
+    fd, path = tempfile.mkstemp(suffix='.kicad_pcb')
+    with os.fdopen(fd, 'w') as f:
+        f.write(body)
+    return path
+
+
+# Pure crossing objective: length and every geometry term zeroed, so each
+# number below is exactly crossing_penalty * weighted crossings.
+KNOBS = dict(max_displacement=10.0, step=10.0, grid_step=0.1,
+             length_weight=0.0, crossing_penalty=30.0,
+             halo_base=0.0, halo_coef=0.0, halo_weight=0.0,
+             edge_halo=0.0, edge_weight=0.0,
+             allow_rotations=False, allow_swaps=False, max_passes=2)
+
+NX, NF = 1, 2
+
+
+def _state(path, net_weights=None):
+    return QuenchState(parse_kicad_pcb(path), path, 0.25, 0.55, 30.0,
+                       0.0, 0.0, 0.0, 0.0, 0.0, 0.1, 0.0,
+                       net_weights=net_weights)
+
+
+def _pose_subset(state, x, y):
+    part = state.parts['M']
+    return {NX: state._build_net_airwires(
+        NX, override_ref='M', override_pads=part.pad_globals(x, y, part.rot))}
+
+
+def _random_airwires(rng, n, n_nets):
+    """Pseudo-random (n,5) airwire array over a 50x50 box."""
+    pts = rng.uniform(0.0, 50.0, size=(n, 4))
+    nets = rng.integers(1, n_nets + 1, size=(n, 1)).astype(float)
+    return np.hstack([pts, nets])
+
+
+def test_unweighted_path_is_bit_identical():
+    """All-ones weights must reproduce the integer count exactly, and the
+    weighted figure must be exactly float(count). Equality on the floats, not
+    approximate equality: this is what keeps every existing quench result
+    from shifting by an ulp."""
+    rng = np.random.default_rng(458)
+    a = _random_airwires(rng, 400, 12)
+    b = _random_airwires(rng, 400, 12)
+    ones = np.ones(13)
+
+    n_none, w_none = _count_crossings_np(a, b)
+    n_ones, w_ones = _count_crossings_np(a, b, ones)
+    assert n_none > 0, "fixture must actually produce crossings"
+    assert n_ones == n_none
+    assert w_none == float(n_none)
+    assert w_ones == float(n_none)
+
+    n_none, w_none = _count_crossings_within(a)
+    n_ones, w_ones = _count_crossings_within(a, ones)
+    assert n_none > 0
+    assert n_ones == n_none
+    assert w_none == float(n_none)
+    assert w_ones == float(n_none)
+
+
+def test_within_halving_is_exact_under_weights():
+    """Two crossing pairs: nets 1x2 (both weight 1) and nets 3x4 (net 4
+    weighted 3). The a-vs-a matrix counts every unordered pair twice with the
+    same weight, so halving is exact."""
+    a = _aw_array([(0.0, 0.0, 10.0, 10.0, 1.0),
+                   (0.0, 10.0, 10.0, 0.0, 2.0),
+                   (20.0, 0.0, 30.0, 10.0, 3.0),
+                   (20.0, 10.0, 30.0, 0.0, 4.0)])
+    w = np.ones(5)
+    w[4] = 3.0
+    total, w_total = _count_crossings_np(a, a, w)
+    half, w_half = _count_crossings_within(a, w)
+    assert (total, w_total) == (4, 8.0), (total, w_total)
+    assert (half, w_half) == (2, 4.0), (half, w_half)
+    assert w_half * 2.0 == w_total
+
+
+def test_crossing_weight_is_max_of_the_two_nets():
+    """A crossing is a conflict between two nets, priced by the larger of the
+    two weights. Not the sum (which would double every ordinary crossing),
+    not the product (which over-prices a weighted-vs-weighted crossing), not
+    the mean (which would silently deliver less than the flag says)."""
+    w = np.ones(6)
+    w[2] = 3.0
+    w[3] = 3.0
+
+    def cross(net_a, net_b):
+        a = _aw_array([(0.0, 0.0, 10.0, 10.0, float(net_a))])
+        b = _aw_array([(0.0, 10.0, 10.0, 0.0, float(net_b))])
+        count, weighted = _count_crossings_np(a, b, w)
+        assert count == 1
+        return weighted
+
+    assert cross(1, 4) == 1.0, "ordinary crossing keeps its unit price"
+    assert cross(2, 4) == 3.0, "weighted vs ordinary costs the weight"
+    assert cross(4, 2) == 3.0, "and the rule is symmetric"
+    assert cross(2, 3) == 3.0, "weighted vs weighted is max, not sum/product"
+
+
+def test_nets_cost_reports_raw_count_and_weighted_cost():
+    """The cost is weighted; the count that comes back with it is not."""
+    path = _crossing_board()
+    try:
+        plain, weighted = _state(path), _state(path, {NF: 3.0})
+        other_p = plain.airwires_excluding({NX})
+        other_w = weighted.airwires_excluding({NX})
+        for (x, y), exp_plain, exp_weighted, exp_count in (
+                ((50.0, 60.0), 30.0, 90.0, 1),
+                ((50.0, 50.0), 60.0, 60.0, 2)):
+            cp, np_count = plain.nets_cost(_pose_subset(plain, x, y), other_p)
+            cw, nw_count = weighted.nets_cost(_pose_subset(weighted, x, y),
+                                              other_w)
+            assert cp == exp_plain, ((x, y), cp)
+            assert cw == exp_weighted, ((x, y), cw)
+            assert np_count == nw_count == exp_count, ((x, y), np_count,
+                                                       nw_count)
+            assert isinstance(np_count, int) and isinstance(nw_count, int)
+    finally:
+        os.unlink(path)
+
+
+def test_total_cost_crossings_stay_an_unweighted_int():
+    """The pass banner prints stats['crossings'] with no format spec, so it
+    has to stay an int and stay unweighted; only 'total' takes the weight."""
+    path = _crossing_board()
+    try:
+        plain = _state(path).total_cost()
+        weighted = _state(path, {NF: 3.0}).total_cost()
+        assert isinstance(plain['crossings'], int)
+        assert isinstance(weighted['crossings'], int)
+        assert weighted['crossings'] == plain['crossings'] == 1
+        assert plain['total'] == 30.0, plain
+        assert weighted['total'] == 90.0, weighted
+    finally:
+        os.unlink(path)
+
+
+def test_weighting_flips_the_optimizer_choice():
+    """The point of the fix. Same board, same knobs, only net_weights
+    differs: unweighted the seed wins (1 crossing beats 2) and nothing moves;
+    weighting NF by 3 makes the seed's single crossing cost 3 and M moves.
+    Before the fix both runs returned []."""
+    path = _crossing_board()
+    try:
+        assert quench(parse_kicad_pcb(path), path, **KNOBS) == [], \
+            "unweighted, the seed pose is cheapest and nothing should move"
+        moved = quench(parse_kicad_pcb(path), path,
+                       net_weights={NF: 3.0}, **KNOBS)
+        assert moved == [{'reference': 'M', 'new_x': 50.0, 'new_y': 50.0,
+                          'new_rotation': 0.0}], moved
+    finally:
+        os.unlink(path)
+
+
+def test_all_ones_weights_are_a_no_op_on_a_real_board():
+    """Backward compatibility end to end: weighting every net by 1.0 must
+    produce the same placement as passing no weights at all. Same process,
+    because quench output varies across processes with the hash seed (#457)."""
+    plain = quench(parse_kicad_pcb(INTERF_U), INTERF_U,
+                   max_displacement=2.0, step=1.0, max_passes=2)
+    pcb = parse_kicad_pcb(INTERF_U)
+    ones = quench(pcb, INTERF_U, max_displacement=2.0, step=1.0, max_passes=2,
+                  net_weights={nid: 1.0 for nid in pcb.nets})
+    assert plain, "fixture should produce at least one improving move"
+    assert plain == ones, "all-ones weights must not change the placement"
+
+
+TESTS = [
+    test_unweighted_path_is_bit_identical,
+    test_within_halving_is_exact_under_weights,
+    test_crossing_weight_is_max_of_the_two_nets,
+    test_nets_cost_reports_raw_count_and_weighted_cost,
+    test_total_cost_crossings_stay_an_unweighted_int,
+    test_weighting_flips_the_optimizer_choice,
+    test_all_ones_weights_are_a_no_op_on_a_real_board,
+]
+
+
+if __name__ == '__main__':
+    for fn in TESTS:
+        fn()
+    print("ALL PASS")

--- a/tests/test_458_quench_rotations.py
+++ b/tests/test_458_quench_rotations.py
@@ -19,11 +19,13 @@ import math
 import os
 import sys
 import tempfile
+from types import SimpleNamespace
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from kicad_parser import parse_kicad_pcb
-from placement.quench import quench
+from placement.quench import (QuenchState, ROTATIONS, _candidate_rotations,
+                              _rotate_local_bounds, quench)
 
 INTERF_U = os.path.join(os.path.dirname(__file__), '..', 'kicad_files',
                         'interf_u_unrouted.kicad_pcb')
@@ -182,11 +184,258 @@ def test_no_rotate_changes_no_rotation_on_a_real_board():
             f"{placement['new_rotation']} under --no-rotate"
 
 
+# --- the rotation lattice (issue #458 item 4b) -------------------------
+#
+# Rotation candidates used to be the four axis rotations, offered only when
+# the part's SEED rotation was a multiple of 90. So a part placed at 45 could
+# never rotate at all, and one that inherited 45 from a swap partner could
+# only move by snapping back onto a multiple of 90. Candidates are now the
+# lattice through the part's own current angle (plus its seed's lattice when
+# a swap moved it off), which leaves every orthogonal board untouched.
+
+def _rot_part_footprint(ref, x, y, rot, net_id=0, net_name=''):
+    """Movable 2-pad part with square pads at local (+-3, 0); only pad 1
+    carries a net, so the airwire endpoint is the part's own angle made
+    visible."""
+    net = f'\n\t\t\t(net {net_id} "{net_name}")' if net_id else ''
+    return f'''\t(footprint "test:ROT2P"
+\t\t(layer "F.Cu")
+\t\t(uuid "fp-{ref}")
+\t\t(at {x} {y} {rot})
+\t\t(property "Reference" "{ref}"
+\t\t\t(at 0 0)
+\t\t)
+\t\t(pad "1" smd rect
+\t\t\t(at 3 0 {rot})
+\t\t\t(size 0.8 0.8)
+\t\t\t(layers "F.Cu"){net}
+\t\t\t(uuid "p1-{ref}")
+\t\t)
+\t\t(pad "2" smd rect
+\t\t\t(at -3 0 {rot})
+\t\t\t(size 0.8 0.8)
+\t\t\t(layers "F.Cu")
+\t\t\t(uuid "p2-{ref}")
+\t\t)
+\t)
+'''
+
+
+def _rot45_board(anchor_x, anchor_y, seed_rot=45.0):
+    """One movable part seeded at `seed_rot` at (150,100) with its net anchor
+    at (anchor_x, anchor_y). With the nudge grid frozen the only move
+    available is a rotation."""
+    body = '(kicad_pcb\n\t(version 20241229)\n\t(net 0 "")\n\t(net 1 "NA")\n'
+    body += '''\t(gr_rect
+\t\t(start 100 80)
+\t\t(end 200 120)
+\t\t(stroke
+\t\t\t(width 0.1)
+\t\t\t(type solid)
+\t\t)
+\t\t(layer "Edge.Cuts")
+\t\t(uuid "edge1")
+\t)
+'''
+    body += _rot_part_footprint('R1', 150.0, 100.0, seed_rot, 1, 'NA')
+    body += _anchor_footprint('J1', anchor_x, anchor_y, 1, 'NA')
+    body += ')\n'
+    fd, path = tempfile.mkstemp(suffix='.kicad_pcb')
+    with os.fdopen(fd, 'w') as f:
+        f.write(body)
+    return path
+
+
+def _state(path, grid_step=0.1):
+    """QuenchState with every geometry weight zeroed, so the only cost that
+    moves is airwire length."""
+    return QuenchState(parse_kicad_pcb(path), path, 0.25, 0.55, 10.0,
+                       0.0, 0.0, 0.0, 0.0, 0.0, grid_step, 1.0)
+
+
+def test_candidate_rotations_are_unchanged_for_orthogonal_parts():
+    """The byte-identity guard, mechanized. For a part at a multiple of 90
+    the candidate list is ROTATIONS itself: same values, and the SAME ORDER,
+    because the caller keeps the first strict minimum, so the order decides
+    ties."""
+    for rot in ROTATIONS:
+        part = SimpleNamespace(rot=rot, orig_rot=rot)
+        assert _candidate_rotations(part, True) == ROTATIONS, rot
+        assert _candidate_rotations(part, False) == [rot], rot
+
+
+def test_candidate_rotations_on_a_45_degree_lattice():
+    """A 45-degree part rotates on its own lattice instead of not at all, and
+    a part that a swap moved off its seed lattice keeps both, current first,
+    so nothing reachable before becomes unreachable."""
+    p = SimpleNamespace(rot=45.0, orig_rot=45.0)
+    assert _candidate_rotations(p, True) == [45.0, 135.0, 225.0, 315.0]
+    p = SimpleNamespace(rot=45.0, orig_rot=0.0)
+    assert _candidate_rotations(p, True) == [45.0, 135.0, 225.0, 315.0,
+                                             0.0, 90.0, 180.0, 270.0]
+    p = SimpleNamespace(rot=0.0, orig_rot=45.0)
+    assert _candidate_rotations(p, True) == [0.0, 90.0, 180.0, 270.0,
+                                             45.0, 135.0, 225.0, 315.0]
+
+
+def test_every_part_on_an_orthogonal_board_keeps_the_old_candidate_list():
+    """The claim "no change on a board with only 90-degree rotations",
+    checked against a real 25-part board rather than argued."""
+    state = QuenchState(parse_kicad_pcb(INTERF_U), INTERF_U, 0.25, 0.55,
+                        10.0, 0.5, 0.25, 2.0, 2.0, 2.0, 0.1)
+    assert state.parts, "board should have parts"
+    for ref, part in state.parts.items():
+        assert _candidate_rotations(part, True) == ROTATIONS, ref
+
+
+def test_part_records_the_whole_lattice_for_a_non_orthogonal_seed():
+    """White box: a 45-degree seed brings 135/225/315 too. That is what keeps
+    build_neighbor_lists' group closure covering every reachable pose without
+    the closure code itself having to change."""
+    path = _rot45_board(150.0, 100.0)
+    try:
+        part = _state(path).parts['R1']
+        assert set(part.bounds_by_rot) == {0.0, 45.0, 90.0, 135.0,
+                                           180.0, 225.0, 270.0, 315.0}
+        lb = part.bounds_by_rot[0.0]
+        for r in (135.0, 225.0, 315.0):
+            assert part.bounds_by_rot[r] == _rotate_local_bounds(*lb, r), r
+    finally:
+        os.unlink(path)
+
+
+def test_45_seeded_part_rotates_on_its_own_lattice():
+    """Behaviour: with the nudge grid frozen and swaps off, the only move
+    available is a rotation. The part rotates to 135, which is where its
+    anchor is. Before the fix it could not rotate at all, and it must never
+    be snapped onto a multiple of 90."""
+    path = _rot45_board(120.0, 90.0)
+    try:
+        result = quench(parse_kicad_pcb(path), path, max_displacement=5.0,
+                        step=1000.0, grid_step=0.1, length_weight=1.0,
+                        crossing_penalty=10.0, halo_base=0.0, halo_coef=0.0,
+                        halo_weight=0.0, edge_halo=0.0, edge_weight=0.0,
+                        allow_swaps=False, max_passes=2)
+        assert [(r['reference'], r['new_rotation']) for r in result] == \
+            [('R1', 135.0)], result
+    finally:
+        os.unlink(path)
+
+
+def _lattice_board(dy, seed_rot=45.0):
+    """A movable part with an OFF-CENTRE courtyard, local (-1,-3,3,3), seeded
+    at `seed_rot`, plus a small movable part `dy` below it. Off-centre
+    matters: for the origin-symmetric courtyards of ordinary passives the
+    45-degree lattice boxes are all congruent, so only an asymmetric one can
+    tell the lattice closure apart from the seed-only closure."""
+    pads = ''
+    for i, (px, py) in enumerate(((-0.5, -2.5), (-0.5, 2.5),
+                                  (2.5, -2.5), (2.5, 2.5)), 1):
+        net = '\n\t\t\t(net 1 "NA")' if i == 1 else ''
+        pads += f'''\t\t(pad "{i}" smd rect
+\t\t\t(at {px} {py} {seed_rot})
+\t\t\t(size 1 1)
+\t\t\t(layers "F.Cu"){net}
+\t\t\t(uuid "p{i}-R1")
+\t\t)
+'''
+    body = '(kicad_pcb\n\t(version 20241229)\n\t(net 0 "")\n\t(net 1 "NA")\n'
+    body += '''\t(gr_rect
+\t\t(start 100 80)
+\t\t(end 200 140)
+\t\t(stroke
+\t\t\t(width 0.1)
+\t\t\t(type solid)
+\t\t)
+\t\t(layer "Edge.Cuts")
+\t\t(uuid "edge1")
+\t)
+'''
+    body += (f'\t(footprint "test:BIG4P"\n\t\t(layer "F.Cu")\n'
+             f'\t\t(uuid "fp-R1")\n\t\t(at 150 100 {seed_rot})\n'
+             f'\t\t(property "Reference" "R1"\n\t\t\t(at 0 0)\n\t\t)\n'
+             + pads + '\t)\n')
+    body += f'''\t(footprint "test:SMALL2P"
+\t\t(layer "F.Cu")
+\t\t(uuid "fp-R2")
+\t\t(at 150 {100.0 + dy} 0)
+\t\t(property "Reference" "R2"
+\t\t\t(at 0 0)
+\t\t)
+\t\t(pad "1" smd rect
+\t\t\t(at -0.5 0 0)
+\t\t\t(size 0.6 0.8)
+\t\t\t(layers "F.Cu")
+\t\t\t(net 1 "NA")
+\t\t\t(uuid "p1-R2")
+\t\t)
+\t\t(pad "2" smd rect
+\t\t\t(at 0.5 0 0)
+\t\t\t(size 0.6 0.8)
+\t\t\t(layers "F.Cu")
+\t\t\t(uuid "p2-R2")
+\t\t)
+\t)
+)
+'''
+    fd, path = tempfile.mkstemp(suffix='.kicad_pcb')
+    with os.fdopen(fd, 'w') as f:
+        f.write(body)
+    return path
+
+
+def test_neighbor_lists_cover_the_relative_rotation_lattice():
+    """The pruning boxes have to cover every pose the candidate list offers,
+    not just the seed's own box. Since a 45-seeded part can now reach 225,
+    and 225's box on an off-centre courtyard sticks out further than the
+    seed-only closure, a neighbour between the two reaches must survive
+    pruning. This is a new-invariant test, not an old-bug reproduction: it
+    exists so _Part's eager lattice and _candidate_rotations cannot drift
+    apart later, and the failure mode if they do is silent, because rect()
+    falls back to rot-0 bounds instead of raising."""
+    budget, clearance = 1.0, 0.25
+    dy = 6.6
+    path = _lattice_board(dy)
+    try:
+        state = _state(path)
+        r1, r2 = state.parts['R1'], state.parts['R2']
+        assert r1.halo == 0.0 and r2.halo == 0.0, "knobs must zero the halos"
+        lb = r1.bounds_by_rot[0.0]
+        assert lb == (-1.0, -3.0, 3.0, 3.0), lb
+
+        def reach(rots):
+            """How far below its seed R1's union box extends, plus the
+            interaction margin, minus R2's own upward extent: the largest dy
+            at which R2 can still be a neighbour."""
+            top = max(_rotate_local_bounds(*lb, r)[3] for r in rots)
+            margin = budget + budget + max(clearance, r1.halo + r2.halo)
+            return top + margin - min(
+                _rotate_local_bounds(*r2.bounds_by_rot[0.0], r)[1]
+                for r in ROTATIONS)
+
+        seed_only = reach(list(ROTATIONS) + [45.0])
+        lattice = reach(list(ROTATIONS) + [45.0, 135.0, 225.0, 315.0])
+        assert seed_only < dy < lattice, (seed_only, dy, lattice)
+
+        state.build_neighbor_lists(budget)
+        assert 'R2' in state._neighbors['R1'], \
+            f"pruning must keep a neighbour the 225-degree pose can reach: " \
+            f"{state._neighbors}"
+    finally:
+        os.unlink(path)
+
+
 TESTS = [
     test_rotation_exchanging_swap_fires_when_rotations_are_allowed,
     test_no_rotate_blocks_a_rotation_exchanging_swap,
     test_no_rotate_still_allows_equal_rotation_swaps,
     test_no_rotate_changes_no_rotation_on_a_real_board,
+    test_candidate_rotations_are_unchanged_for_orthogonal_parts,
+    test_candidate_rotations_on_a_45_degree_lattice,
+    test_every_part_on_an_orthogonal_board_keeps_the_old_candidate_list,
+    test_part_records_the_whole_lattice_for_a_non_orthogonal_seed,
+    test_45_seeded_part_rotates_on_its_own_lattice,
+    test_neighbor_lists_cover_the_relative_rotation_lattice,
 ]
 
 

--- a/tests/test_458_quench_rotations.py
+++ b/tests/test_458_quench_rotations.py
@@ -1,0 +1,196 @@
+"""
+Tests for quench rotation semantics (issue #458).
+
+--no-rotate gated the nudge phase's rotation candidates and nothing else. A
+same-footprint swap exchanges FULL poses, rotation included, so a 0-degree
+part could still come out at 90 degrees under a flag documented as "disable
+rotation moves". Swaps are now restricted to pairs that already share a
+rotation when rotations are off, which also keeps the exchange
+rotation-neutral: with identical rot-0 courtyards each part's rectangle is
+then a pure translate of the other's, so the occupied-space invariance that
+lets swaps skip candidate_valid is strengthened rather than weakened.
+
+The discriminating pair is test_no_rotate_blocks_a_rotation_exchanging_swap
+and test_no_rotate_still_allows_equal_rotation_swaps: same board, same
+knobs, same improving swap, differing only in the two parts' seed angles.
+"""
+
+import math
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from kicad_parser import parse_kicad_pcb
+from placement.quench import quench
+
+INTERF_U = os.path.join(os.path.dirname(__file__), '..', 'kicad_files',
+                        'interf_u_unrouted.kicad_pcb')
+
+
+def _cap_footprint(ref, x, y, net_id, net_name, rot=0.0):
+    """Movable 2-pad part at an explicit rotation; pad 1 carries the net.
+
+    Square pads on purpose. For a footprint without a courtyard the local
+    bbox is derived from the pads, so oblong pads at different footprint
+    rotations can produce different rot-0 bounds, and the swap identity guard
+    would then reject the pair before any of this code runs, making every
+    assertion below vacuously true."""
+    return f'''\t(footprint "test:CAP2P"
+\t\t(layer "F.Cu")
+\t\t(uuid "fp-{ref}")
+\t\t(at {x} {y} {rot})
+\t\t(property "Reference" "{ref}"
+\t\t\t(at 0 0)
+\t\t)
+\t\t(pad "1" smd rect
+\t\t\t(at -0.5 0 {rot})
+\t\t\t(size 0.8 0.8)
+\t\t\t(layers "F.Cu")
+\t\t\t(net {net_id} "{net_name}")
+\t\t\t(uuid "p1-{ref}")
+\t\t)
+\t\t(pad "2" smd rect
+\t\t\t(at 0.5 0 {rot})
+\t\t\t(size 0.8 0.8)
+\t\t\t(layers "F.Cu")
+\t\t\t(uuid "p2-{ref}")
+\t\t)
+\t)
+'''
+
+
+def _anchor_footprint(ref, x, y, net_id, net_name):
+    """Locked single-pad net anchor (a connector pin the airwire pulls at)."""
+    return f'''\t(footprint "test:PIN"
+\t\t(layer "F.Cu")
+\t\t(locked yes)
+\t\t(uuid "fp-{ref}")
+\t\t(at {x} {y})
+\t\t(property "Reference" "{ref}"
+\t\t\t(at 0 0)
+\t\t)
+\t\t(pad "1" smd rect
+\t\t\t(at 0 0)
+\t\t\t(size 1 1)
+\t\t\t(layers "F.Cu")
+\t\t\t(net {net_id} "{net_name}")
+\t\t\t(uuid "p1-{ref}")
+\t\t)
+\t)
+'''
+
+
+def _swap_board(d, c1_rot=0.0, c2_rot=90.0):
+    """Two movable same-footprint parts, C1@(150,100) on net NA and
+    C2@(150+d,100) on net NB, with locked anchors J1 (net NA) to the right of
+    both and J2 (net NB) to the left. C1's net pulls it right and C2's pulls
+    it left, so swapping them shortens both airwires by d."""
+    body = '(kicad_pcb\n\t(version 20241229)\n'
+    body += '\t(net 0 "")\n\t(net 1 "NA")\n\t(net 2 "NB")\n'
+    body += '''\t(gr_rect
+\t\t(start 100 80)
+\t\t(end 200 120)
+\t\t(stroke
+\t\t\t(width 0.1)
+\t\t\t(type solid)
+\t\t)
+\t\t(layer "Edge.Cuts")
+\t\t(uuid "edge1")
+\t)
+'''
+    body += _cap_footprint('C1', 150.0, 100.0, 1, 'NA', c1_rot)
+    body += _cap_footprint('C2', 150.0 + d, 100.0, 2, 'NB', c2_rot)
+    body += _anchor_footprint('J1', 150.0 + d + 20.0, 100.0, 1, 'NA')
+    body += _anchor_footprint('J2', 130.0, 100.0, 2, 'NB')
+    body += ')\n'
+    fd, path = tempfile.mkstemp(suffix='.kicad_pcb')
+    with os.fdopen(fd, 'w') as f:
+        f.write(body)
+    return path
+
+
+# step=1000 makes the nudge grid degenerate to the seed point, so any change
+# of position comes from the swap block.
+SWAP_ONLY = dict(step=1000.0, max_passes=2)
+
+
+def test_rotation_exchanging_swap_fires_when_rotations_are_allowed():
+    """Anti-vacuity for the pair below, and the behaviour --no-rotate has to
+    suppress: with rotations allowed the mixed-angle pair does swap, so the
+    swap really is improving, in cap, and past the identity guard."""
+    path = _swap_board(3, c1_rot=0.0, c2_rot=90.0)
+    try:
+        result = quench(parse_kicad_pcb(path), path, max_displacement=5.0,
+                        allow_rotations=True, **SWAP_ONLY)
+        by_ref = {r['reference']: r for r in result}
+        assert set(by_ref) == {'C1', 'C2'}, f"fixture is vacuous: {result}"
+        assert by_ref['C1']['new_x'] == 153.0, result
+        assert by_ref['C2']['new_x'] == 150.0, result
+    finally:
+        os.unlink(path)
+
+
+def test_no_rotate_blocks_a_rotation_exchanging_swap():
+    """The fix: the same improving, in-cap swap is refused under --no-rotate,
+    because accepting it would hand each part the other's rotation."""
+    path = _swap_board(3, c1_rot=0.0, c2_rot=90.0)
+    try:
+        result = quench(parse_kicad_pcb(path), path, max_displacement=5.0,
+                        allow_rotations=False, **SWAP_ONLY)
+        assert result == [], \
+            f"--no-rotate must not accept a swap that rotates both parts: " \
+            f"{result}"
+    finally:
+        os.unlink(path)
+
+
+def test_no_rotate_still_allows_equal_rotation_swaps():
+    """--no-rotate is not a blanket swap kill. A same-angle pair still swaps,
+    and the exchange is rotation-neutral, which is why it remains safe to
+    skip candidate_valid: the occupied rectangles are unchanged."""
+    path = _swap_board(3, c1_rot=90.0, c2_rot=90.0)
+    try:
+        result = quench(parse_kicad_pcb(path), path, max_displacement=5.0,
+                        allow_rotations=False, **SWAP_ONLY)
+        by_ref = {r['reference']: r for r in result}
+        assert set(by_ref) == {'C1', 'C2'}, result
+        assert by_ref['C1']['new_x'] == 153.0, result
+        assert by_ref['C2']['new_x'] == 150.0, result
+        assert by_ref['C1']['new_rotation'] == 90.0, result
+        assert by_ref['C2']['new_rotation'] == 90.0, result
+    finally:
+        os.unlink(path)
+
+
+def test_no_rotate_changes_no_rotation_on_a_real_board():
+    """Contract check on a real board: a full --no-rotate run, nudges and
+    swaps together, returns no part at an angle other than its seed. This one
+    is a contract test, not a bug reproduction: whether it would have failed
+    before the fix depends on whether a mixed-angle swap happens to be
+    improving on this particular board."""
+    pcb = parse_kicad_pcb(INTERF_U)
+    seed = {ref: fp.rotation % 360 for ref, fp in pcb.footprints.items()}
+    result = quench(pcb, INTERF_U, max_displacement=3.0, step=1.0,
+                    max_passes=3, allow_rotations=False)
+    assert result, "fixture should still produce improving moves"
+    for placement in result:
+        ref = placement['reference']
+        assert placement['new_rotation'] == seed[ref], \
+            f"{ref} rotated from {seed[ref]} to " \
+            f"{placement['new_rotation']} under --no-rotate"
+
+
+TESTS = [
+    test_rotation_exchanging_swap_fires_when_rotations_are_allowed,
+    test_no_rotate_blocks_a_rotation_exchanging_swap,
+    test_no_rotate_still_allows_equal_rotation_swaps,
+    test_no_rotate_changes_no_rotation_on_a_real_board,
+]
+
+
+if __name__ == '__main__':
+    for fn in TESTS:
+        fn()
+    print("ALL PASS")

--- a/tests/test_quench_neighbor_lists.py
+++ b/tests/test_quench_neighbor_lists.py
@@ -287,6 +287,158 @@ def test_neighbor_lists_cover_rotation_fallback():
     os.unlink(path)
 
 
+# An accepted swap hands a part its partner's rotation, inserting the bounds
+# entry into bounds_by_rot AFTER build_neighbor_lists ran -- so each part's
+# seed box must union over its whole movable same-footprint group's rotation
+# set, not just its own entries. Discriminating geometry: S3 is a 4-pad
+# square part (local bbox +-3.0, halo 1.0) seeded at 0 degrees, whose own
+# entries are the four coinciding 90-degree boxes (half 3.0); its group-mate
+# S1 (same footprint, movable) is seeded at 45 degrees, adding a rotated box
+# of half 3*sqrt(2) = 4.2426 to the group closure. Against S2 (union half
+# 0.8, halo 0.85355), margin
+#   m = 1.0 + 1.0 + max(0.25, 1.0 + 0.85355) + 1e-9 = 3.85355
+# so the y reach is 3.0 + 0.8 + m = 7.6536 for S3's own box and
+# 4.2426 + 0.8 + m = 8.8962 for the closure box. S2_DY = 8.2 sits between:
+# an own-entries-only build prunes the pair, the group closure keeps it.
+# (No in-budget pose can make the pair actually collide from this band --
+# the margin spends both budgets while a probe moves only one part -- so
+# the guard is structural: membership plus the differential lock check.)
+S3_XY = (20.0, 20.0)
+S1_XY = (45.0, 45.0)
+S1_ROT = 45.0
+SQ_PAD = 2.5             # 4 pads at local (+-2.5, +-2.5), size 1x1
+S2_DY = 8.2
+
+
+def _swap_rot_board(lock_s1=False):
+    """60x60mm board: square 4-pad S1 at 45 degrees + same-footprint S3 at
+    0 degrees + small S2 straight below S3 (see block comment). Locking S1
+    removes it from the movable group, so S3's closure loses the 45-degree
+    entry. Writes the board to a temp file, returns (pcb_data, path)."""
+    body = '(kicad_pcb\n\t(version 20241229)\n'
+    body += '\t(net 0 "")\n\t(net 1 "NA")\n\t(net 2 "NB")\n'
+    body += '''\t(gr_rect
+\t\t(start 0 0)
+\t\t(end 60 60)
+\t\t(stroke
+\t\t\t(width 0.1)
+\t\t\t(type solid)
+\t\t)
+\t\t(layer "Edge.Cuts")
+\t\t(uuid "edge1")
+\t)
+'''
+    def square(ref, x, y, rot, locked):
+        at = f'(at {x} {y} {rot:.0f})' if rot else f'(at {x} {y})'
+        lock = '\t\t(locked yes)\n' if locked else ''
+        fp = f'''\t(footprint "test:SQ4P"
+\t\t(layer "F.Cu")
+\t\t(uuid "fp-{ref}")
+{lock}\t\t{at}
+\t\t(property "Reference" "{ref}"
+\t\t\t(at 0 0)
+\t\t)
+'''
+        for i, (px, py) in enumerate(
+                [(-SQ_PAD, -SQ_PAD), (SQ_PAD, -SQ_PAD),
+                 (-SQ_PAD, SQ_PAD), (SQ_PAD, SQ_PAD)]):
+            fp += f'''\t\t(pad "{i + 1}" smd rect
+\t\t\t(at {px} {py} {rot:.0f})
+\t\t\t(size 1 1)
+\t\t\t(layers "F.Cu")
+\t\t\t(net 1 "NA")
+\t\t\t(uuid "p{i + 1}-{ref}")
+\t\t)
+'''
+        return fp + '\t)\n'
+
+    body += square('S1', S1_XY[0], S1_XY[1], S1_ROT, lock_s1)
+    body += square('S3', S3_XY[0], S3_XY[1], 0.0, False)
+    body += f'''\t(footprint "test:SMALL2P"
+\t\t(layer "F.Cu")
+\t\t(uuid "fp-S2")
+\t\t(at {S3_XY[0]} {S3_XY[1] + S2_DY})
+\t\t(property "Reference" "S2"
+\t\t\t(at 0 0)
+\t\t)
+\t\t(pad "1" smd rect
+\t\t\t(at -0.5 0)
+\t\t\t(size 0.6 0.8)
+\t\t\t(layers "F.Cu")
+\t\t\t(net 2 "NB")
+\t\t\t(uuid "p1-S2")
+\t\t)
+\t\t(pad "2" smd rect
+\t\t\t(at 0.5 0)
+\t\t\t(size 0.6 0.8)
+\t\t\t(layers "F.Cu")
+\t\t\t(net 2 "NB")
+\t\t\t(uuid "p2-S2")
+\t\t)
+\t)
+'''
+    body += ')\n'
+    fd, path = tempfile.mkstemp(suffix='.kicad_pcb')
+    with os.fdopen(fd, 'w') as f:
+        f.write(body)
+    return parse_kicad_pcb(path), path
+
+
+def test_neighbor_lists_cover_swap_inherited_rotations():
+    """White-box guard for the group-rotation closure: a 0-degree-seeded part
+    must get pruning boxes covering rotations it can only acquire by swapping
+    with a movable same-footprint partner (the swap path adds the bounds
+    entry lazily, after the lists are built)."""
+    pcb, path = _swap_rot_board()
+    state = QuenchState(pcb, path, **KNOBS)
+    s1, s2, s3 = state.parts['S1'], state.parts['S2'], state.parts['S3']
+    assert 45.0 in s1.bounds_by_rot
+    assert 45.0 not in s3.bounds_by_rot, \
+        "S3 must not have the 45-degree entry itself -- the closure adds it"
+
+    # Hand-computed discrimination with the implementation's own numbers:
+    # S3's own-entries union box must miss S2, the group closure must not.
+    m = BUDGET + BUDGET + max(state.clearance, s3.halo + s2.halo) + 1e-9
+    s2_union = _seed_box(s2, (
+        min(b[0] for b in s2.bounds_by_rot.values()),
+        min(b[1] for b in s2.bounds_by_rot.values()),
+        max(b[2] for b in s2.bounds_by_rot.values()),
+        max(b[3] for b in s2.bounds_by_rot.values())))
+    s3_own = _seed_box(s3, (
+        min(b[0] for b in s3.bounds_by_rot.values()),
+        min(b[1] for b in s3.bounds_by_rot.values()),
+        max(b[2] for b in s3.bounds_by_rot.values()),
+        max(b[3] for b in s3.bounds_by_rot.values())))
+    b45 = s1.bounds_by_rot[45.0]
+    s3_closure = _seed_box(s3, (
+        min(s3.bounds_by_rot[0.0][0], b45[0]),
+        min(s3.bounds_by_rot[0.0][1], b45[1]),
+        max(s3.bounds_by_rot[0.0][2], b45[2]),
+        max(s3.bounds_by_rot[0.0][3], b45[3])))
+    assert not _margin_overlaps(s3_own, s2_union, m), \
+        "geometry no longer discriminates: S3's own box already reaches S2"
+    assert _margin_overlaps(s3_closure, s2_union, m), \
+        "geometry no longer discriminates: the closure box misses S2"
+
+    state.build_neighbor_lists(BUDGET)
+    assert 'S2' in state._neighbors['S3'], \
+        "S3 lost swap-reachable neighbour S2 (own-entries-only seed box?)"
+    assert 'S3' in state._neighbors['S2']
+
+    # Differential proof that the group closure (not slack) kept the pair:
+    # with S1 locked it leaves the movable group, S3 can never acquire the
+    # 45-degree rotation, and excluding S2 becomes exact again.
+    pcb_l, path_l = _swap_rot_board(lock_s1=True)
+    locked_state = QuenchState(pcb_l, path_l, **KNOBS)
+    assert locked_state.parts['S1'].locked
+    locked_state.build_neighbor_lists(BUDGET)
+    assert 'S2' not in locked_state._neighbors['S3'], \
+        "locked S1 must not contribute rotations to S3's closure"
+
+    os.unlink(path)
+    os.unlink(path_l)
+
+
 if __name__ == '__main__':
     test_neighbor_list_parity()
     mp = pytest.MonkeyPatch()
@@ -295,4 +447,5 @@ if __name__ == '__main__':
     finally:
         mp.undo()
     test_neighbor_lists_cover_rotation_fallback()
+    test_neighbor_lists_cover_swap_inherited_rotations()
     print("ALL PASS")

--- a/tests/test_quench_neighbor_lists.py
+++ b/tests/test_quench_neighbor_lists.py
@@ -1,0 +1,298 @@
+"""
+Tests for the quench pruned neighbour lists (issue #430).
+
+candidate_valid / part_geometry_cost used to scan every part for every
+candidate pose (O(parts) per probe, O(parts^2) per pass). The fix adds
+QuenchState.build_neighbor_lists(travel_budget): per-movable-ref lists built
+from union-of-bounds_by_rot seed rectangles, keeping only pairs whose
+axis-wise seed gap is within both parts' travel budgets plus the largest
+interaction reach (hard clearance / summed halos). Because a movable part can
+never leave its seed-centered union box inflated by the budget, excluding a
+far pair is EXACT -- pruned pairs can neither collide nor contribute halo
+penalty -- so consumers must return bit-identical results with and without
+the lists. quench() builds the lists with budget max_displacement+grid_step.
+
+CROSS-PROCESS quench output is nondeterministic (pre-existing: _net_points
+iterates a set, so ordering follows PYTHONHASHSEED); every equality
+comparison here is same-process by construction.
+"""
+
+import math
+import os
+import random
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+
+from kicad_parser import parse_kicad_pcb
+from placement.quench import ROTATIONS, QuenchState, quench
+
+ORANGECRAB = os.path.join(os.path.dirname(__file__), '..', 'kicad_files',
+                          'orangecrab_ext_pll.kicad_pcb')
+INTERF_U = os.path.join(os.path.dirname(__file__), '..', 'kicad_files',
+                        'interf_u_unrouted.kicad_pcb')
+
+# The nine QuenchState knob arguments, set to the quench() defaults.
+KNOBS = dict(clearance=0.25, board_edge_clearance=0.55, crossing_penalty=10.0,
+             halo_base=0.5, halo_coef=0.25, halo_weight=2.0,
+             edge_halo=2.0, edge_weight=2.0, grid_step=0.1)
+
+
+def test_neighbor_list_parity():
+    """Pruned and brute-force consumers are bit-identical (the pruning is
+    exact, not approximate): for sampled refs x offsets x rotations, a state
+    with built neighbour lists and an unbuilt twin agree exactly on
+    candidate_valid and part_geometry_cost. Skipped pairs contribute exactly
+    +0.0 in the same summation order, so `==` on the floats is the right
+    assertion, not approx."""
+    pcb = parse_kicad_pcb(ORANGECRAB)
+    built = QuenchState(pcb, ORANGECRAB, **KNOBS)
+    plain = QuenchState(pcb, ORANGECRAB, **KNOBS)
+    assert built._neighbors is None, "lists must be opt-in (None until built)"
+    # quench(max_displacement=10.0) would build with 10.0 + grid_step
+    built.build_neighbor_lists(10.0 + 0.1)
+    assert plain._neighbors is None
+
+    movable = [r for r, p in built.parts.items() if not p.locked]
+    random.seed(430)
+    sample = random.sample(movable, min(12, len(movable)))
+
+    # Poses stay within the travel budget (max offset hypot = 10 <= 10.1),
+    # which is the regime the exactness guarantee covers.
+    offsets = [(0.0, 0.0), (10.0, 0.0), (-10.0, 0.0),
+               (0.0, 10.0), (0.0, -10.0), (7.0, 7.0)]
+    nonzero_costs = 0
+    for ref in sample:
+        part = built.parts[ref]
+        for dx, dy in offsets:
+            x, y = part.seed_x + dx, part.seed_y + dy
+            for rot in ROTATIONS:
+                assert (built.candidate_valid(ref, x, y, rot)
+                        == plain.candidate_valid(ref, x, y, rot)), \
+                    f"candidate_valid diverged: {ref} at +({dx},{dy}) rot={rot}"
+                a = built.part_geometry_cost(ref, x, y, rot)
+                b = plain.part_geometry_cost(ref, x, y, rot)
+                assert a == b, (f"part_geometry_cost diverged: {ref} at "
+                                f"+({dx},{dy}) rot={rot}: {a!r} != {b!r}")
+                if a > 0.0:
+                    nonzero_costs += 1
+        # exclude= must thread through both code paths identically
+        if built._neighbors[ref]:
+            excl = {built._neighbors[ref][0]}
+            assert (built.part_geometry_cost(ref, exclude=excl)
+                    == plain.part_geometry_cost(ref, exclude=excl)), \
+                f"part_geometry_cost(exclude={excl}) diverged for {ref}"
+            assert (built.candidate_valid(ref, part.seed_x, part.seed_y,
+                                          part.rot, exclude=excl)
+                    == plain.candidate_valid(ref, part.seed_x, part.seed_y,
+                                             part.rot, exclude=excl)), \
+                f"candidate_valid(exclude={excl}) diverged for {ref}"
+    assert nonzero_costs > 0, \
+        "vacuous fixture: no pose produced a nonzero geometry cost"
+
+    # The lists must actually prune something, or the perf fix is a no-op.
+    assert min(len(v) for v in built._neighbors.values()) \
+        < len(built.parts) - 1, "neighbour lists pruned nothing"
+
+
+def test_quench_output_unchanged_by_pruning(monkeypatch):
+    """Same-process A/B: a full quench run with the neighbour lists vs one
+    with build_neighbor_lists no-opped (leaving _neighbors None, i.e. the
+    brute-force fallback) must return the exact same placements. Each run
+    parses the board fresh for isolation."""
+    pcb1 = parse_kicad_pcb(INTERF_U)
+    pruned = quench(pcb1, INTERF_U, max_displacement=2, step=1.0, max_passes=2)
+
+    monkeypatch.setattr(QuenchState, 'build_neighbor_lists',
+                        lambda self, budget: None)
+    pcb2 = parse_kicad_pcb(INTERF_U)
+    brute = quench(pcb2, INTERF_U, max_displacement=2, step=1.0, max_passes=2)
+
+    assert pruned, "fixture should produce at least one improving move"
+    assert pruned == brute, (
+        f"pruning changed the quench result:\n  with lists: {pruned}\n"
+        f"  brute force: {brute}")
+
+
+# ---- rotation-fallback coverage board (test 3) -----------------------------
+#
+# R1 is an elongated 2-pad part (pads 8mm apart, 1x1mm -> 0-degree local bbox
+# 9.0 x 1.0mm, half-extents 4.5 x 0.5) SEEDED AT 45 DEGREES, so _Part adds a
+# bounds_by_rot[45] entry (half-extents (4.5+0.5)/sqrt(2) = 3.5355 square).
+# R2 is a small 2-pad part (union half-extents 0.8) placed R2_DY straight
+# below R1. Discriminating geometry, with both parts movable at
+# BUDGET = 1.0 each and margin
+#   m = 1.0 + 1.0 + max(clearance=0.25, halo_R1 + halo_R2) + 1e-9
+#     = 2.0 + 2 * (0.5 + 0.25 * sqrt(2)) + 1e-9          = 3.7071,
+# the center-to-center y reach against R2's union box (0.8) is:
+#   R1 0-degree box  (y half 0.5)   : 0.5    + 0.8 + m = 5.007
+#   R1 45-degree box (y half 3.5355): 3.5355 + 0.8 + m = 8.043
+#   R1 union box     (y half 4.5)   : 4.5    + 0.8 + m = 9.007
+# R2_DY = 6.5 sits BETWEEN 5.007 and 8.043: a (buggy) 0-degree-only seed box
+# would prune the pair, while the 45-degree entry alone -- and hence the
+# union the implementation takes over bounds_by_rot -- keeps it. (For this
+# elongated part the 90-degree entries also reach 6.5; the union covers
+# every entry, and the hand check below contrasts box0 vs 45 vs union.)
+R1_XY = (30.0, 30.0)
+R1_ROT = 45.0
+R1_PAD_HALF_SPAN = 4.0   # pads at local (+-4, 0), size 1x1
+R2_DY = 6.5
+BUDGET = 1.0
+# Parity probe within BUDGET of the seed (0.9 <= 1.0) that moves R1 close
+# enough for its halo to reach R2 (gap 1.66 < summed halos 1.707): the cost
+# is nonzero ONLY if R2 survived pruning, so parity here proves membership
+# behaviorally, not just structurally.
+R1_PROBE_NEAR_R2 = (30.0, 30.9)
+
+
+def _rot45_board():
+    """60x60mm board, R1 at 45 degrees + R2 below it (see block comment).
+    Writes the board to a temp file, returns (pcb_data, path)."""
+    body = '(kicad_pcb\n\t(version 20241229)\n'
+    body += '\t(net 0 "")\n\t(net 1 "NA")\n\t(net 2 "NB")\n'
+    body += '''\t(gr_rect
+\t\t(start 0 0)
+\t\t(end 60 60)
+\t\t(stroke
+\t\t\t(width 0.1)
+\t\t\t(type solid)
+\t\t)
+\t\t(layer "Edge.Cuts")
+\t\t(uuid "edge1")
+\t)
+'''
+    # Pad angles repeat the footprint rotation (KiCad writes absolute angles).
+    body += f'''\t(footprint "test:LONG2P"
+\t\t(layer "F.Cu")
+\t\t(uuid "fp-R1")
+\t\t(at {R1_XY[0]} {R1_XY[1]} {R1_ROT:.0f})
+\t\t(property "Reference" "R1"
+\t\t\t(at 0 0)
+\t\t)
+\t\t(pad "1" smd rect
+\t\t\t(at -{R1_PAD_HALF_SPAN} 0 {R1_ROT:.0f})
+\t\t\t(size 1 1)
+\t\t\t(layers "F.Cu")
+\t\t\t(net 1 "NA")
+\t\t\t(uuid "p1-R1")
+\t\t)
+\t\t(pad "2" smd rect
+\t\t\t(at {R1_PAD_HALF_SPAN} 0 {R1_ROT:.0f})
+\t\t\t(size 1 1)
+\t\t\t(layers "F.Cu")
+\t\t\t(net 1 "NA")
+\t\t\t(uuid "p2-R1")
+\t\t)
+\t)
+'''
+    body += f'''\t(footprint "test:SMALL2P"
+\t\t(layer "F.Cu")
+\t\t(uuid "fp-R2")
+\t\t(at {R1_XY[0]} {R1_XY[1] + R2_DY})
+\t\t(property "Reference" "R2"
+\t\t\t(at 0 0)
+\t\t)
+\t\t(pad "1" smd rect
+\t\t\t(at -0.5 0)
+\t\t\t(size 0.6 0.8)
+\t\t\t(layers "F.Cu")
+\t\t\t(net 2 "NB")
+\t\t\t(uuid "p1-R2")
+\t\t)
+\t\t(pad "2" smd rect
+\t\t\t(at 0.5 0)
+\t\t\t(size 0.6 0.8)
+\t\t\t(layers "F.Cu")
+\t\t\t(net 2 "NB")
+\t\t\t(uuid "p2-R2")
+\t\t)
+\t)
+'''
+    body += ')\n'
+    fd, path = tempfile.mkstemp(suffix='.kicad_pcb')
+    with os.fdopen(fd, 'w') as f:
+        f.write(body)
+    return parse_kicad_pcb(path), path
+
+
+def _seed_box(part, bounds):
+    return (part.seed_x + bounds[0], part.seed_y + bounds[1],
+            part.seed_x + bounds[2], part.seed_y + bounds[3])
+
+
+def _margin_overlaps(ra, rb, m):
+    """The exact axis-wise inclusion test build_neighbor_lists applies."""
+    return (ra[2] + m >= rb[0] and rb[2] + m >= ra[0]
+            and ra[3] + m >= rb[1] and rb[3] + m >= ra[1])
+
+
+def test_neighbor_lists_cover_rotation_fallback():
+    """White-box guard: the seed rectangles must be the union over ALL
+    bounds_by_rot entries (including the non-90-degree seed rotation _Part
+    records), never just the 0-degree box -- otherwise a 45-degree-seeded
+    part's true footprint sticks out of its pruning box and real neighbours
+    get dropped."""
+    pcb, path = _rot45_board()
+    state = QuenchState(pcb, path, **KNOBS)
+    r1, r2 = state.parts['R1'], state.parts['R2']
+    assert r1.rot == 45.0
+    assert 45.0 in r1.bounds_by_rot, "_Part must record the non-90 seed entry"
+
+    # Hand-computed margin test with the implementation's own numbers:
+    # the 0-degree-only box would prune the pair, the 45-degree entry (and
+    # so the union) keeps it. This proves R2_DY genuinely discriminates.
+    m = BUDGET + BUDGET + max(state.clearance, r1.halo + r2.halo) + 1e-9
+    r2_union = _seed_box(r2, (
+        min(b[0] for b in r2.bounds_by_rot.values()),
+        min(b[1] for b in r2.bounds_by_rot.values()),
+        max(b[2] for b in r2.bounds_by_rot.values()),
+        max(b[3] for b in r2.bounds_by_rot.values())))
+    r1_box0 = _seed_box(r1, r1.bounds_by_rot[0.0])
+    r1_box45 = _seed_box(r1, r1.bounds_by_rot[45.0])
+    r1_union = _seed_box(r1, (
+        min(b[0] for b in r1.bounds_by_rot.values()),
+        min(b[1] for b in r1.bounds_by_rot.values()),
+        max(b[2] for b in r1.bounds_by_rot.values()),
+        max(b[3] for b in r1.bounds_by_rot.values())))
+    assert not _margin_overlaps(r1_box0, r2_union, m), \
+        "geometry no longer discriminates: 0-degree box already reaches R2"
+    assert _margin_overlaps(r1_box45, r2_union, m), \
+        "geometry no longer discriminates: 45-degree box misses R2"
+    assert _margin_overlaps(r1_union, r2_union, m)
+
+    state.build_neighbor_lists(BUDGET)
+    assert 'R2' in state._neighbors['R1'], \
+        "45-degree-seeded R1 lost its real neighbour R2 (0-degree-only box?)"
+    assert 'R1' in state._neighbors['R2'], \
+        "R2 lost its real neighbour R1 (0-degree-only box?)"
+
+    # Behaviour parity at the 45-degree pose against an unbuilt twin,
+    # including a probe where R1's halo actually reaches R2: a nonzero,
+    # bit-identical cost is only possible if the pair survived pruning.
+    twin = QuenchState(pcb, path, **KNOBS)
+    assert twin._neighbors is None
+    poses = [(R1_XY[0], R1_XY[1], R1_ROT),
+             (R1_PROBE_NEAR_R2[0], R1_PROBE_NEAR_R2[1], R1_ROT)]
+    for x, y, rot in poses:
+        assert (state.part_geometry_cost('R1', x, y, rot)
+                == twin.part_geometry_cost('R1', x, y, rot)), (x, y, rot)
+        assert (state.candidate_valid('R1', x, y, rot)
+                == twin.candidate_valid('R1', x, y, rot)), (x, y, rot)
+    assert state.part_geometry_cost('R1', *R1_PROBE_NEAR_R2, R1_ROT) > 0.0, \
+        "probe pose should incur a halo penalty against R2"
+
+    os.unlink(path)
+
+
+if __name__ == '__main__':
+    test_neighbor_list_parity()
+    mp = pytest.MonkeyPatch()
+    try:
+        test_quench_output_unchanged_by_pruning(mp)
+    finally:
+        mp.undo()
+    test_neighbor_lists_cover_rotation_fallback()
+    print("ALL PASS")

--- a/tests/test_quench_swap_cap.py
+++ b/tests/test_quench_swap_cap.py
@@ -1,0 +1,202 @@
+"""
+Tests for the quench swap displacement cap (issue #430).
+
+Same-footprint swaps used to teleport parts arbitrarily far from their seed
+positions (only the improvement mattered), stranding components outside the
+--max-displacement contract. The fix rejects any swap where either part would
+land beyond swap_max_displacement (default: max_displacement) of its OWN
+seed, and adds the swap_max_displacement knob to tighten swaps independently.
+
+The synthetic swap board isolates the swap phase: with step=1000 the nudge
+grid degenerates to the seed point only (n = int(max_disp/1000) = 0), which
+is skipped as the current pose, so ANY movement must come from the swap
+block. The final test runs the full optimizer on a real board and checks the
+headline #430 invariant: no returned part ends up further than
+max_displacement (+ grid snap slop) from where it started.
+"""
+
+import math
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+
+from kicad_parser import parse_kicad_pcb
+from placement.quench import quench
+
+INTERF_U = os.path.join(os.path.dirname(__file__), '..', 'kicad_files',
+                        'interf_u_unrouted.kicad_pcb')
+
+
+def _cap_footprint(ref, x, y, net_id, net_name, locked=False):
+    """Movable 2-pad 1.6x0.8mm part; pad 1 (at -0.5,0) carries the net."""
+    # (locked yes) must sit in the footprint header, BEFORE the first (pad
+    # (placement/parser.py extract_locked_refs requirement).
+    lock = '\t\t(locked yes)\n' if locked else ''
+    return f'''\t(footprint "test:CAP2P"
+\t\t(layer "F.Cu")
+{lock}\t\t(uuid "fp-{ref}")
+\t\t(at {x} {y})
+\t\t(property "Reference" "{ref}"
+\t\t\t(at 0 0)
+\t\t)
+\t\t(pad "1" smd rect
+\t\t\t(at -0.5 0)
+\t\t\t(size 0.6 0.8)
+\t\t\t(layers "F.Cu")
+\t\t\t(net {net_id} "{net_name}")
+\t\t\t(uuid "p1-{ref}")
+\t\t)
+\t\t(pad "2" smd rect
+\t\t\t(at 0.5 0)
+\t\t\t(size 0.6 0.8)
+\t\t\t(layers "F.Cu")
+\t\t\t(uuid "p2-{ref}")
+\t\t)
+\t)
+'''
+
+
+def _anchor_footprint(ref, x, y, net_id, net_name):
+    """Locked single-pad net anchor (a connector pin the airwire pulls at)."""
+    return f'''\t(footprint "test:PIN"
+\t\t(layer "F.Cu")
+\t\t(locked yes)
+\t\t(uuid "fp-{ref}")
+\t\t(at {x} {y})
+\t\t(property "Reference" "{ref}"
+\t\t\t(at 0 0)
+\t\t)
+\t\t(pad "1" smd rect
+\t\t\t(at 0 0)
+\t\t\t(size 1 1)
+\t\t\t(layers "F.Cu")
+\t\t\t(net {net_id} "{net_name}")
+\t\t\t(uuid "p1-{ref}")
+\t\t)
+\t)
+'''
+
+
+def _swap_board(d, lock_c2=False):
+    """Two movable same-footprint 2-pad parts C1@(150,100) on net NA and
+    C2@(150+d,100) on net NB, plus locked anchors J1 (net NA) at
+    (150+d+20,100) and J2 (net NB) at (130,100). C1's net pulls it right,
+    C2's pulls it left, so swapping C1<->C2 shortens both airwires by d
+    (improving for any d>0). Board outline (100,80)-(200,120) Edge.Cuts.
+    Writes the board to a temp file, returns (pcb_data, path)."""
+    body = '(kicad_pcb\n\t(version 20241229)\n'
+    body += '\t(net 0 "")\n\t(net 1 "NA")\n\t(net 2 "NB")\n'
+    body += '''\t(gr_rect
+\t\t(start 100 80)
+\t\t(end 200 120)
+\t\t(stroke
+\t\t\t(width 0.1)
+\t\t\t(type solid)
+\t\t)
+\t\t(layer "Edge.Cuts")
+\t\t(uuid "edge1")
+\t)
+'''
+    body += _cap_footprint('C1', 150.0, 100.0, 1, 'NA')
+    body += _cap_footprint('C2', 150.0 + d, 100.0, 2, 'NB', locked=lock_c2)
+    body += _anchor_footprint('J1', 150.0 + d + 20.0, 100.0, 1, 'NA')
+    body += _anchor_footprint('J2', 130.0, 100.0, 2, 'NB')
+    body += ')\n'
+    fd, path = tempfile.mkstemp(suffix='.kicad_pcb')
+    with os.fdopen(fd, 'w') as f:
+        f.write(body)
+    return parse_kicad_pcb(path), path
+
+
+# step=1000 makes the nudge phase a guaranteed no-op (only candidate is the
+# seed point, skipped as the current pose): any movement comes from swaps.
+SWAP_ONLY = dict(step=1000.0, allow_rotations=False, max_passes=2)
+
+
+def test_swap_beyond_cap_rejected():
+    """An IMPROVING swap (gain 2*d = 16mm) is still rejected when the parts
+    would land beyond the cap from their own seeds (8mm > 5mm)."""
+    pcb, path = _swap_board(8)
+    result = quench(pcb, path, max_displacement=5.0, **SWAP_ONLY)
+    assert result == [], \
+        f"swap beyond max_displacement must be rejected, got {result}"
+
+
+def test_swap_within_cap_accepted_and_reported():
+    """The same improving swap fires when within the cap (3mm <= 5mm), and
+    both parts are reported with exchanged positions."""
+    pcb, path = _swap_board(3)
+    result = quench(pcb, path, max_displacement=5.0, **SWAP_ONLY)
+    by_ref = {r['reference']: r for r in result}
+    assert set(by_ref) == {'C1', 'C2'}, f"expected both caps swapped: {result}"
+    assert by_ref['C1']['new_x'] == 153.0
+    assert by_ref['C1']['new_y'] == 100.0
+    assert by_ref['C2']['new_x'] == 150.0
+    assert by_ref['C2']['new_y'] == 100.0
+
+
+def test_swap_cap_flag_tightens():
+    """swap_max_displacement < max_displacement rejects a swap the general
+    cap would allow (the exact swap accepted in the previous test)."""
+    pcb, path = _swap_board(3)
+    result = quench(pcb, path, max_displacement=5.0,
+                    swap_max_displacement=2.0, **SWAP_ONLY)
+    assert result == [], \
+        f"swap beyond swap_max_displacement must be rejected, got {result}"
+
+
+def test_locked_parts_never_swap():
+    """A locked part is never a swap partner and never appears in the
+    result, even when swapping with it would improve the cost."""
+    pcb, path = _swap_board(3, lock_c2=True)
+    result = quench(pcb, path, max_displacement=5.0, **SWAP_ONLY)
+    assert all(r['reference'] != 'C2' for r in result), \
+        f"locked C2 must never move: {result}"
+    # With its only same-footprint partner locked, C1 has nothing to swap
+    # with and the nudge phase is frozen, so nothing moves at all.
+    assert result == []
+
+
+def test_swap_cap_validation():
+    """swap_max_displacement must be within [0, max_displacement]."""
+    pcb, path = _swap_board(3)
+    with pytest.raises(ValueError):
+        quench(pcb, path, max_displacement=5.0, swap_max_displacement=6.0,
+               **SWAP_ONLY)
+    with pytest.raises(ValueError):
+        quench(pcb, path, max_displacement=5.0, swap_max_displacement=-1.0,
+               **SWAP_ONLY)
+
+
+def test_no_stranding_after_full_run():
+    """Headline #430 invariant on a real board: a full quench run (nudges,
+    rotations AND swaps) leaves every reported part within max_displacement
+    (plus the grid_step snap slop) of its input position."""
+    pcb = parse_kicad_pcb(INTERF_U)
+    orig = {ref: (fp.x, fp.y) for ref, fp in pcb.footprints.items()}
+    max_disp = 3.0
+    result = quench(pcb, INTERF_U, max_displacement=max_disp, step=1.0,
+                    max_passes=3)
+    assert result, "fixture should produce at least one improving move"
+    for placement in result:
+        ref = placement['reference']
+        ox, oy = orig[ref]
+        dist = math.hypot(placement['new_x'] - ox, placement['new_y'] - oy)
+        # 0.1 = default grid_step: candidate positions snap to the grid, so a
+        # radius-capped candidate can end up at most one snap past the cap.
+        assert dist <= max_disp + 0.1 + 1e-6, \
+            f"{ref} stranded {dist:.3f}mm from seed (cap {max_disp}mm)"
+
+
+if __name__ == '__main__':
+    test_swap_beyond_cap_rejected()
+    test_swap_within_cap_accepted_and_reported()
+    test_swap_cap_flag_tightens()
+    test_locked_parts_never_swap()
+    test_swap_cap_validation()
+    test_no_stranding_after_full_run()
+    print("ALL PASS")

--- a/tests/test_quench_swap_cap.py
+++ b/tests/test_quench_swap_cap.py
@@ -124,6 +124,7 @@ def test_swap_beyond_cap_rejected():
     result = quench(pcb, path, max_displacement=5.0, **SWAP_ONLY)
     assert result == [], \
         f"swap beyond max_displacement must be rejected, got {result}"
+    os.unlink(path)
 
 
 def test_swap_within_cap_accepted_and_reported():
@@ -137,6 +138,7 @@ def test_swap_within_cap_accepted_and_reported():
     assert by_ref['C1']['new_y'] == 100.0
     assert by_ref['C2']['new_x'] == 150.0
     assert by_ref['C2']['new_y'] == 100.0
+    os.unlink(path)
 
 
 def test_swap_cap_flag_tightens():
@@ -147,6 +149,7 @@ def test_swap_cap_flag_tightens():
                     swap_max_displacement=2.0, **SWAP_ONLY)
     assert result == [], \
         f"swap beyond swap_max_displacement must be rejected, got {result}"
+    os.unlink(path)
 
 
 def test_locked_parts_never_swap():
@@ -159,6 +162,7 @@ def test_locked_parts_never_swap():
     # With its only same-footprint partner locked, C1 has nothing to swap
     # with and the nudge phase is frozen, so nothing moves at all.
     assert result == []
+    os.unlink(path)
 
 
 def test_swap_cap_validation():
@@ -170,6 +174,7 @@ def test_swap_cap_validation():
     with pytest.raises(ValueError):
         quench(pcb, path, max_displacement=5.0, swap_max_displacement=-1.0,
                **SWAP_ONLY)
+    os.unlink(path)
 
 
 def test_no_stranding_after_full_run():


### PR DESCRIPTION
Fixes drandyhaas/KiCadRoutingTools#430
Fixes drandyhaas/KiCadRoutingTools#458

## The three defects, and their fixes

**1. Swaps bypassed `--max-displacement`.** Same-footprint swaps exchanged part poses with no displacement check at all — only the cost gain mattered — violating the documented "each part stays within `--max-displacement` of its original position" guarantee. Fix: a new `swap_max_displacement` kwarg on `quench()` (default `None` = `max_displacement`; `ValueError` if above it or negative). The swap pair loop now rejects any swap that would leave either part beyond the cap from its **own** seed, checked before the expensive cost evaluations; the verbose pass line reports `swap-capped=N`. Exposed on `place_optimize.py` as `--swap-max-displacement` (can tighten the cap for swaps specifically, never exceed it); `place_route_loop.py` inherits the capped behavior through the default (note: the loop's 1.5x widening on rejected rounds widens the swap cap in lockstep; tracked with the loop's other steering gaps in #458). Two hardening guards ride along: same-name footprints with differing per-ref courtyard bounds no longer swap, and a part inheriting its partner's non-90° rotation now gets exact `_rotate_local_bounds` entries instead of `rect()`'s silent rot-0 fallback.

**2. Parts stranded outside their nudge disk.** A swap used to be able to teleport a part beyond `--max-displacement`, where every subsequent nudge candidate (generated around the immutable seed) was out of reach — the part was stranded, unrecoverable by later passes. Now impossible by construction: the swap cap ≤ `max_displacement` keeps every part inside its seed-centered candidate disk at all times. Seeds stay immutable and no re-seed machinery was added — see design decisions below.

**3. O(all-parts) candidate scans.** `candidate_valid` and `part_geometry_cost` scanned every part per candidate pose (O(parts²) per pass). New `QuenchState.build_neighbor_lists(travel_budget)` ports the pruned-neighbor pattern from `fanout_clearance` (#213 profiling): per-part lists built once from union-of-rotations seed rects, axis-wise overlap test with margin `budget_a + budget_b + max(clearance, halo_a + halo_b)`. Because a part's live position provably stays within the budget of its seed, the pruning is **exact**, not approximate — a dedicated test enforces bit-identical results with and without the lists. Wired up as `build_neighbor_lists(max_displacement + grid_step)`.

## Design decisions

- **Strict cap rather than cap-plus-repair.** The repo's own experiments (docs/placement-optimization.md) found ~3 mm displacement the sweet spot on both boards tested and uncapped movement actively harmful to the placement's macro structure. So the cap is airtight for every move type, and swap-driven large perturbations are deliberately not "repaired" back — they simply never happen.
- **No re-seeding.** Seeds stay immutable; re-seeding after a swap would let displacement accumulate across passes and silently reintroduce the unbounded-drift failure mode. Large-perturbation exploration is deferred to the #407 block-relocation direction, where it belongs.
- **Swaps still skip `candidate_valid`.** Safe because of the occupied-space invariance the new identity guard enforces: two parts may only swap when their courtyard bounds are identical, so the set of occupied rectangles is unchanged by the exchange.

## Verification

- **9 new tests** (`tests/test_quench_swap_cap.py`, `tests/test_quench_neighbor_lists.py`): improving-but-over-cap swap rejected, in-cap swap accepted with exchanged positions, `swap_max_displacement` tightening, locked parts never swap, kwarg validation, no-stranding invariant on a full `interf_u` run, pruned-vs-brute-force bit-exact parity (`candidate_valid` + `part_geometry_cost` + full-run placements), and a white-box guard that the seed rects union over all `bounds_by_rot` entries including non-90° seed rotations. All pass, plus the existing `tests/test_fanout_clearance.py` (12/12).
- **End-to-end** on `kicad_files/interf_u_unrouted.kicad_pcb` at `--max-displacement 3`: `check_drc.py` reports `NO DRC VIOLATIONS FOUND!` before and after; `check_connected.py` reports `FOUND 110 ISSUES / Unrouted nets (110)` on both input and optimized output (counts compared, not file hashes, per CONTRIBUTING).
- **Timing** with `python3 place_optimize.py kicad_files/kit-dev-coldfire-xilinx_5213.kicad_pcb <out> --max-displacement 5 --max-passes 2` (160 footprints): ~110 s wall pre-fix → ~69 s post-fix (68.7 s / 69.6 s over two runs), ~1.6×. The win grows as `--max-displacement` shrinks.

## Possible follow-up (pre-existing, not addressed here)

`QuenchState._net_points` iterates the `net_refs` **set**, so airwire point ordering — and through MST tie-breaking, quench output — varies across processes with `PYTHONHASHSEED`. Same-process runs are deterministic (the parity tests rely on this). Now tracked in #457 (which also covers a second set-iteration site inside the swap evaluation).

---

## Also closes #458: the four ways the loop steers the quench badly

#458 was filed against this PR's head. One of its items is a regression this
PR would otherwise ship: `place_route_loop.py` widens `--max-displacement`
1.5x after every rejected round and never passed `swap_max_displacement`,
which defaults to `max_displacement`. So the cap this PR adds would have
widened in lockstep, turning a 3mm budget into 15.2mm after four rejections,
which is exactly the #430 stranding failure coming back through the other
front end. Fixing it here rather than in a follow-up seemed right, and the
other three items plus the drive-by came along since they are the same
subsystem. Six commits, each self-contained; happy to split any of them out.

**1. `place_route_loop`: hold the swap cap at the base displacement.** The
loop now passes `swap_max_displacement` explicitly and pins it to the base
value for the whole run, so widening the local nudge search can never become
a long-range swap. The three knobs the loop never plumbed are real flags with
the same names `place_optimize.py` uses: `--swap-max-displacement` (validated
at the argparse layer, mirroring `place_optimize.py`, rather than letting the
value reach quench and raise from inside a round), `--no-rotate`,
`--no-swap`, plus `--verbose` so the `swap-capped=N` diagnostic this PR adds
is reachable from the loop at all. A negative `--max-displacement` is
rejected too: passing the swap cap explicitly would otherwise turn it into a
traceback where it used to be silently inert.

**2. `place_route_loop`: count reconciliation recoveries in the round tally.**
`route.py` runs its end-of-run reconciliation pass (#348) exactly when the
first pass left failures, and prints a second `JSON_SUMMARY` scoped to the
retried nets. The loop read the first one, so a net that pass recovered still
counted as failed: the loop then quenched parts anchoring nets that were
already solved, and `better()` compared tallies taken at different points in
the run. `merge_route_summaries` now takes failure state from the **last**
summary and **sums** effort across all of them.

Failure state from the last summary is exact rather than a delta: every net
with a nonzero failure term is in the retry set by construction, and the
sub-run re-derives each retried net's pad counts over all of that net's pads
from the final-board union-find (route.py:1840), so those numbers are
absolute. Summing pad counts would double-count. Effort sums because both
passes are work the placement cost the router; taking iterations from the
last summary would make a badly failing candidate look cheap, since the
reconciliation pass only re-routes a handful of nets. On a single summary,
which is what a clean run produces, the reduction is exactly the old
behaviour.

Two cases the case walk turned up, both pinned by tests. A reconciliation
that raises **after** printing its summary claims recoveries the board write
may never have committed, since route.py prints the summary before writing;
failure state falls back to the first pass, which is what is definitely on
disk. And coverage-gate nets have no routed result, so their pads never reach
`multipoint_pads_total` and they weighed zero even though they ship at broken
copper; each now counts 1. That second one matters most on the last summary,
because those are nets the reconciliation itself broke through its rip
escalation, and without it the loop can read `failures=0` on a board shipping
disconnected copper and stop. **It is four lines and droppable if you would
rather not change that count.**

**3. `place_route_loop`: run route.py by absolute path and check its exit
code** (the drive-by in #458). A bare relative `route.py` only worked when
the caller's cwd happened to be the repo root; from anywhere else the child
exited 2 with "no such file", the code was discarded, and the operator got
"route.py produced no JSON_SUMMARY". Two related holes closed while there:
the log is read as UTF-8 with `errors='replace'` (the bare `open()` decoded
with the locale default, so a cp1252 locale died on the first non-ASCII glyph
and lost the round), and both `RuntimeError`s carry the last 15 log lines. No
`cwd=` override, deliberately: route.py resolves its own assets from
`__file__`, and relative paths inside `--route-args` must keep resolving
against the operator's cwd.

**4. `quench`: price each crossing by the heavier of the two nets' weights.**
`net_weights` scaled airwire length only, and length is the small term. On
kit-dev-coldfire at the loop's own knobs the objective splits 3.5% length,
95.7% crossings, 0.9% halo and edge, so `--failed-net-weight 3.0` raised a
length coefficient from 0.3 to 0.9 against a crossing coefficient of 30:
about 6 out of 66000 for a net of median airwire length, a fifth of one
crossing. The mechanism the loop is documented around was numerically
invisible.

`max(w_a, w_b)` rather than sum, product or mean. It is neutral at all-ones,
so an unweighted board is untouched and `--crossing-penalty` keeps meaning
"the cost of an ordinary crossing"; it prices a conflict by the most
important net it obstructs; and it is the only rule under which the flag's
number is literally the multiplier. `_count_crossings_np` already broadcasts
net ids into an `(n,m)` `same_net` matrix, so this needs no new data, just a
weight matrix on the same broadcast. Both crossing helpers return
`(count, weighted)`: the cost uses the weighted figure, the count stays a raw
int, so `total_cost()['crossings']` and the per-pass banner are unchanged.
About 2% on the crossing kernel, weighted runs only.

**Disclosure:** the same numeric `--failed-net-weight` now has roughly 30x
more leverage, because the weightable share of the objective went from 3.5%
to essentially all of it. Loop defaults are unchanged and no second knob is
added.

**5. `quench`: `--no-rotate` must stop swaps from exchanging rotations.**
`allow_rotations` gated the nudge phase's candidate list and nothing else,
but a swap exchanges full poses. On the two-part fixture in the new test,
`--no-rotate` used to return C1 at 90 and C2 at 0: both parts rotated,
neither by a rotation move. Swaps are now restricted to pairs that already
share a rotation when rotations are off, which also keeps the exchange
rotation-neutral and so **strengthens** the occupied-space invariance this
PR relies on to skip `candidate_valid`. The check sits before the cap check
so `swaps_skipped` keeps counting cap rejections only.

This is a contract defect rather than a geometry one: because a swap
exchanges full poses between parts with identical courtyards, the set of
poses on the board is unchanged and no overlap was ever produced. What was
wrong is that a user who typed `--no-rotate` got a board where the part he
placed at 0 sits at 90. **Honest cost:** the flag now also declines
mixed-angle same-footprint pairs, which on real boards is most of them.
Equal-angle pairs as a share of all same-footprint pairs: kit-dev-coldfire
625/2160, orangecrab_ext_pll 559/2132, tigard 216/628, glasgow_revC
1901/4792, interf_u 7/21. The default path is untouched, since the guard is
dead code whenever rotations are allowed.

**6. `quench`: rotation candidates relative to the part's own angle.**
Candidates were the four axis rotations, offered only when the **seed**
rotation was a multiple of 90. So a part placed at 45 degrees never tried a
rotation at all, and a part that inherited 45 from a swap partner was offered
only 0/90/180/270, i.e. its only way to move was to snap onto an axis.
Candidates are now the 90-degree lattice through the part's current angle,
plus the lattice through its seed angle when a swap moved it off that one,
which is strictly additive: nothing reachable before becomes unreachable.

This is a no-op on any board whose footprint rotations are all multiples of
90, which is 20 of the 22 boards in `kicad_files` and all three used by the
placement tests. Candidates are built in `ROTATIONS` order from a base of
`rot % 90`, so such a part gets `ROTATIONS` itself: same values, same order.
The order is asserted because the caller keeps the first strict minimum, so a
reordered list silently changes which pose wins a tie; the two tempting
rewrites that break it (a set literal, and using `part.rot` instead of
`part.rot % 90` as the base) are called out in the code.

`_Part` now records the whole lattice of a non-orthogonal seed, which is what
keeps `build_neighbor_lists` exact **without touching its code**: it already
unions `bounds_by_rot` over the movable same-footprint group, and with the
full lattice recorded that union is `{seed angle + 90k}` over the group,
precisely the closure of what a swap can hand over and a nudge can then
rotate within. Measured pruning cost on the four non-orthogonal parts in
`kicad_files` (glasgow_revC R9 at 45, rp2350_fpga_eensy_prePlane R9/C28/D1 at
315): zero, because their courtyards are origin-symmetric and the four
lattice boxes are congruent. Worst case for an off-centre courtyard is a
doubling of the box area, scoped to one footprint group.

### Verification (#458 commits)

- **Byte-identity on real boards.** With `PYTHONHASHSEED` pinned (quench
  output varies across processes, #457), a full `quench()` run on
  `interf_u_unrouted` returns byte-identical placements at `91a90b2` and at
  the head of this PR, at three different seeds; same result on
  `orangecrab_ext_pll` (165 parts). So commits 4 to 6 above change nothing on
  an unweighted, all-orthogonal board, which is every board in the test
  fixtures. Passing an explicit all-ones weight for every net also returns
  the same placement as passing none.
- **The existing quench tests pass unmodified**: `test_quench_swap_cap.py`
  6/6 and `test_quench_neighbor_lists.py` 4/4, including the bit-exact
  pruning parity test and the group-rotation closure test.
- **Three new test files**, all in the `--fast` lane (no child process, so
  `run_all.py`'s source sniffing keeps them out of the integration set):
  - `tests/test_458_loop_steering.py`, the first test this file has ever had.
    It replaces the routing step, the quench and the writer with recorders,
    and asserts that four rejected rounds walk `max_displacement`
    3 / 4.5 / 6.75 / 10.125 while `swap_max_displacement` stays 3.0. The
    captured kwargs are bound against the real `quench` signature so a
    renamed keyword fails there instead of silently doing nothing. The tally
    half drives `run_route` against canned two-pass logs: recoveries not
    counted, effort summed, blockers still unioned across both passes, a
    single-summary run unchanged, a net the reconciliation itself broke
    reported and weighed, the aborted-reconciliation fallback, and the
    sub-run-printed-nothing degradation.
  - `tests/test_458_quench_net_weights.py`. The decisive one is
    `test_weighting_flips_the_optimizer_choice`: one board, one set of knobs,
    only `net_weights` differs, and the optimizer's answer changes from "stay
    at the seed" to "move". Before the fix both runs returned `[]`. Also
    pinned: all-ones reproduces the integer count exactly with `==` on the
    floats, the weighted halving is exact, `max` and not sum or product, and
    `stats['crossings']` is still an unweighted int.
  - `tests/test_458_quench_rotations.py`. The discriminating pair for
    `--no-rotate` is one board and one set of knobs differing only in the two
    parts' seed angles: the mixed-angle pair is refused, the equal-angle pair
    still swaps. For the lattice, the neighbour-list test derives its
    threshold from `_rotate_local_bounds` rather than hard-coding it, and
    uses an off-centre courtyard on purpose, since for the origin-symmetric
    courtyards of ordinary passives every lattice box is congruent and only
    an asymmetric one can tell the two closures apart.
- `tests/run_all.py --fast`: 176 passed, 1 failed, 33 skipped. The baseline at `91a90b2` in the
  same environment is 173 passed, 1 failed, 33 skipped: the three new files
  are the delta, and `test_506_507_plan_movie_tools.py` fails identically on
  both sides, so it is pre-existing here and not a delta from these commits.
- **Real-board loop run** on `kicad_files/kit-dev-coldfire-xilinx_5213.kicad_pcb`:
  the loop runs end to end with the new flags and the cap visibly holds.
  `max_disp` widened 3.0 / 4.5 / 6.8 across the rejected rounds while
  `swap cap=3.0mm` never moved, and `--verbose` shows the `swap-capped=N`
  line, a diagnostic the loop previously had no way to display. Failures 43
  to 39 over five rounds.

  I ran the same chain three ways to see what the change actually does. Both
  the first two produce a byte-equivalent round-0 route (identical checker
  counts on both sides), so the only difference is the steering. The third
  is this PR's code with `--failed-net-weight 1.0`, which makes the new
  crossing weighting a proven no-op while every other fix stays active:

  | final board | failures | check_connected | SEG-SEG | VIA-SEG | PAD-SEG | PAD-VIA |
  |---|---|---|---|---|---|---|
  | `91a90b2` | 40 | 44 issues | 73 | 20 | 21 | 14 |
  | this PR, weight 3.0 | 39 | **41 issues** | 103 | 40 | 75 | 17 |
  | this PR, weight 1.0 | 39 | **41 issues** | 84 | 62 | 39 | 16 |

  Those violation counts are graded at `--clearance 0.2`. That is the wrong
  floor to judge these boards by, and it took me a while to see it: on this
  chain the router escalates and reports `min_clearance_used: 0.1` on **all
  three** runs, so a 0.2mm grade is counting copper the router deliberately
  laid finer. **Graded at 0.1mm, all three final boards are
  `NO DRC VIOLATIONS FOUND`.** Checking the severity of every 0.2mm-graded
  violation confirms it: the worst overlap is exactly 0.1000mm, i.e. a
  minimum actual copper-to-copper gap of 0.1000mm, and that worst case is
  **identical on the baseline board, on this PR's board, and on the shared
  round-0 input**. Nothing touches on any of them. Every violation sits in a
  90 micron band between 0.100 and 0.190mm.

  So the counts are a measure of how much sub-0.2mm copper each run ended up
  with, and they are volatile: VIA-SEGMENT goes 20 / 40 / 62 and PAD-SEGMENT
  21 / 75 / 39 across the three runs with no monotone relationship to the
  weighting. Round to round within a single run they swing just as hard (the
  baseline's own last re-route took it from 170 total rows down to 130 while
  moving 5 parts). Of the incidents that appear in this PR's final round, 20
  of 25 are more than 10mm from any of the 4 parts that round moved, and the
  largest cluster sits on an unmoved part 12 to 19mm away. The mechanism is
  which global routing solution the router happens to land on, not the
  placement. With one run per configuration I cannot rule out that the
  steering systematically produces grazier routing, and I am not going to
  claim otherwise from n=1; what I can say is that no board in this
  experiment has copper closer than the 0.1mm the router itself chose, and
  connectivity improved on both of this PR's runs.

  Two findings from that experiment that are worth more than the DRC numbers:

  **The tally is what changes the trajectory, not the crossing weighting.**
  Re-scoring the identical round-1 candidate board under both semantics: the
  old reading gives 42 failures against a 42-failure incumbent and accepts on
  a 0.44% iteration margin; the new reading gives 44 against 43 and rejects.
  That single flip sends the two runs down different paths, and everything
  downstream follows. Isolating the quench objective with identical inputs
  and a pinned `PYTHONHASHSEED`, the crossing weighting moves 1 part by
  0.50mm at a 3mm cap and up to 3 parts at a 6.8mm cap: real, but secondary.
  The weight-1.0 run above reaches the same 39 failures and 41 issues as the
  weight-3.0 run, so on this board the weighting bought no connectivity
  either. Worth knowing why: 43 of 276 scored nets are weighted here, and
  82.9% of all crossings touch at least one of them, so the weighting is
  close to a global scale factor rather than a selective bias. It should
  matter more on a board with a handful of failures, which is the regime the
  loop is documented for.

  **A disclosure about the new tally I only found by measuring.** On this
  board the reconciliation pass recovers nothing; it re-derives the same 43
  still-open nets as `42 single-ended + 1 multipoint with 1 open pad` where
  the first pass called them `33 single-ended + 10 multipoint with 9 open
  pads`. Both readings are describing the same 43 nets, but the new one
  counts each reclassified net as 1 instead of by its pad deficit, so
  `failures` reads 1 to 2 higher and is **less** sensitive to partial
  progress on a multipoint net than it used to be. I think the new number is
  the more honest one (43 nets are open, and the old formula only undercounts
  because it prices multipoint nets per pad and single-ended nets per net),
  but the loss of partial-progress sensitivity is real, and it is exactly the
  granularity problem #432's pad-pair tallies exist to solve. Reworking
  `better()` onto that metric is the part of #458 I have deliberately not
  done here.

- `git merge-tree` against current `main` (`e8c72fe`): still conflict-free.

### Decisions worth stating, so they are not re-proposed

- **No `--no-final-reconcile` flag on route.py.** It would let the loop skip
  the reconciliation during search rounds, but `route.py` is in both
  `PARITY_SURFACES` and the GUI parity `CLI_MAINS`, so a new engine flag
  drags in the whole GUI thread-through checklist plus both gates, and the
  benefit is nil: that pass is a fraction of a second against rounds of
  millions of iterations, and skipping it during search would make the loop
  optimise against a metric the final board is not graded on, which is #458
  by another route.
- **The crossing weighting is severable.** It is one commit (`d880c81`) and
  dropping it leaves the other five intact. Measured above it is the
  secondary effect, not the driver of the trajectory change, and on this
  board it bought no connectivity, so I would understand wanting it split
  out and evidenced on a board in the loop's documented regime first.
- **No second crossing-weight knob** and no change to the loop's default
  weights. One flag, one meaning; changing `--length-weight` or
  `--crossing-penalty` would also invalidate the experiment tables in
  docs/placement-optimization.md.
- **No `--max-passes` on the loop** (quench's default already matches
  `place_optimize.py`) and **no absolute ceiling on the widening**
  (`--rounds` already bounds it; an unbounded nudge search is a different
  failure mode).
- **Position-only swaps rejected** as the fix for `--no-rotate`. Putting a
  wide rectangle where a tall one was breaks the occupied-space invariance
  exactly when it matters, and since swaps skip `candidate_valid` the
  resulting courtyard overlap would ship silently. Making it safe costs a
  `candidate_valid` call per part plus an explicit A-against-B clearance
  test, and the result is a new move type rather than a fix to the flag.

### Notes for review

- **Parity cost.** `place_route_loop.py` is in neither `PARITY_SURFACES` nor
  the GUI parity `CLI_MAINS`, so commits 1 to 3 add none. `placement/` is
  already in this PR's audit scope, and `kicad_routing_plugin/` contains no
  quench call site at all, so that audit stays a formality.
- **Overlap with #432.** That PR also edits `run_route`. Commit 2 leaves
  `place_route_loop.py` lines 56 to 76 byte-identical, so #432's hunk applies
  at an offset with no conflict whichever lands first. One thing to fix at
  that point: under a last-wins merge #432's `pad_pairs_connected` and
  `pad_pairs_total` would become reconcile-subset-scoped. The right merge,
  and it goes in one place inside `merge_route_summaries`, is to take
  `pad_pairs_total` from the first summary (the full-scope denominator) and
  add the per-net deficit recovered, using `pad_pairs_open`'s per-net counts,
  since a net fully recovered in pass 2 is simply absent from pass 2's
  `pad_pairs_open`.
- **Known gap, not fixed here.** `failed_multipoint` entries from the
  non-multipoint multi-pad path are also zero-weight in the loop's
  `failures`, and nothing in the summary distinguishes them from the ones
  that do carry pad counts. Unchanged by these commits; happy to file it.
- **The docs table.** The kit-dev-coldfire round table in
  docs/placement-optimization.md was recorded under the old tally, so its
  failure counts are pre-reconciliation and its iteration counts cover the
  first pass only. The exact command chain behind those numbers was not
  recorded with them, so I annotated the table rather than substituting
  numbers from a chain that may not be the same one. Say the word and I will
  re-measure it under whatever chain you consider canonical.
