### PR TITLE
length_matching: revert AC-coupled meanders when end-to-end delta would grow; document --length-match-group interaction (#460)

### DIFF
--- a/docs/length-matching.md
+++ b/docs/length-matching.md
@@ -124,3 +124,4 @@ To size the meanders, the required extra delay is converted to extra length usin
 - Meanders are added to one straight run per route; if no run can absorb the required extra length within clearance limits, the route may end outside tolerance (a warning is printed).
 - Very tight surroundings can force the amplitude to its 0.2mm minimum, limiting how much length a run can add.
 - Meanders are not placed across layer changes.
+- `--ac-couple-match` runs after `--length-match-group`; a pair that is both an XNet member and in a match group may be meandered again by the end-to-end pass, perturbing its group-matched length. Keep AC-coupled pairs out of match groups.

--- a/length_matching.py
+++ b/length_matching.py
@@ -2891,9 +2891,11 @@ def apply_ac_coupled_length_matching(xnet, routed_results, config, pcb_data):
     time (never a concatenated list -- each half's own copper would otherwise read
     as a foreign net at zero clearance). Length-only, mirroring intra-pair.
 
-    Edits each member result's 'new_segments' in place. Returns the final
-    end-to-end skew in mm (or None if a member was not fully routed); degrades
-    gracefully on congestion and never falsely claims a match it could not make.
+    Edits each member result's 'new_segments' in place. Reverts all member
+    edits and returns the original delta when the end-to-end skew would not
+    improve (mirroring intra-pair's guard, #460). Returns the final end-to-end
+    skew in mm (or None if a member was not fully routed); degrades gracefully
+    on congestion and never falsely claims a match it could not make.
     """
     tol = config.length_match_tolerance
     name = "+".join(xnet.base_names)
@@ -2951,6 +2953,7 @@ def apply_ac_coupled_length_matching(xnet, routed_results, config, pcb_data):
 
     # Apply: lengthen each planned member's S net once (never re-meander a net).
     added_total = 0.0
+    snapshots = {}  # id(res) -> (res, pre-pass new_segments) for the #460 revert
     for i, want in enumerate(plan):
         if want <= tol:
             continue
@@ -2967,6 +2970,8 @@ def apply_ac_coupled_length_matching(xnet, routed_results, config, pcb_data):
             continue
         added = new_len - cur
         res = md['result']
+        if id(res) not in snapshots:
+            snapshots[id(res)] = (res, list(res['new_segments']))
         res['new_segments'] = [s for s in res['new_segments']
                                if s.net_id != s_id] + new_segs
         md[f'{S}_len'] = new_len
@@ -2976,6 +2981,15 @@ def apply_ac_coupled_length_matching(xnet, routed_results, config, pcb_data):
     new_total_s = (total_p if S == 'p' else total_n) + added_total
     new_total_l = total_n if S == 'p' else total_p
     new_delta = abs(new_total_l - new_total_s)
+    if added_total > tol and new_delta >= delta:
+        # Mirror intra-pair's guard: a matching pass never degrades the board.
+        # End-to-end compare only -- the phase-2 spill member is deliberately
+        # overshot locally, so a per-member guard would reject valid plans.
+        for res_obj, orig_segs in snapshots.values():
+            res_obj['new_segments'] = orig_segs
+        print(f"    AC-couple {name}: meanders would increase end-to-end delta "
+              f"({new_delta:.3f}mm >= {delta:.3f}mm), reverting")
+        return delta
     if added_total <= tol:
         print(f"    AC-couple {name}: could not fit end-to-end meanders "
               f"(residual delta={delta:.3f}mm)")

--- a/tests/test_ac_coupled_match.py
+++ b/tests/test_ac_coupled_match.py
@@ -12,6 +12,9 @@ Covers:
     in JSON_SUMMARY, and both sides still route.
   * Control: without the flag there is no ac_coupled_xnets key (per-side behavior,
     so the routed board is unaffected).
+  * Guard (#460): the pass reverts member new_segments and reports the original
+    skew when meandering would grow the end-to-end delta; an exact-hit plan
+    still applies (board-free unit tests with a stubbed meander engine).
 
 Run with a Python that has the Rust router + numpy/scipy/shapely, e.g.:
     python3 tests/test_ac_coupled_match.py
@@ -31,6 +34,7 @@ sys.path.insert(0, os.path.join(ROOT_DIR, "rust_router"))
 from kicad_parser import Segment                       # noqa: E402
 from routing_config import DiffPairNet                 # noqa: E402
 from diff_xnet import find_ac_coupled_xnets            # noqa: E402
+import length_matching                                 # noqa: E402
 from length_matching import _ac_coupled_member_lengths  # noqa: E402
 
 BOARD = os.path.join(ROOT_DIR, "kicad_files", "cap_chain.kicad_pcb")
@@ -158,6 +162,16 @@ def run():
                     fails.append(f"integration: wrong bridges: {xnets[0].get('bridges')}")
                 elif not isinstance(xnets[0].get("skew_mm"), (int, float)):
                     fails.append(f"integration: skew_mm not reported: {xnets[0]}")
+                else:
+                    # Guard contract (#460): matching never degrades the board,
+                    # so the reported skew is bounded by the pre-match delta.
+                    mdelta = re.search(
+                        r"AC-couple DPA\+DPB: end-to-end P=[\d.]+mm, "
+                        r"N=[\d.]+mm, delta=([\d.]+)mm", r.stdout)
+                    if mdelta and xnets[0]["skew_mm"] > float(mdelta.group(1)) + 1e-6:
+                        fails.append(
+                            f"integration: skew_mm {xnets[0]['skew_mm']} exceeds "
+                            f"pre-match delta {mdelta.group(1)} (guard contract)")
 
             # 10. CONTROL: without the flag, no ac_coupled_xnets key (per-side behavior).
             r2, summary2 = _run_route(out, [])
@@ -170,6 +184,78 @@ def run():
             for ext in (".kicad_pcb", ".kicad_pro", ".kicad_prl"):
                 if os.path.exists(base + ext):
                     os.remove(base + ext)
+
+    # --------- guard (#460): end-to-end revert, unit (board-free) ---------
+    # Two member pairs: DPA P=10/N=12 (nets 1/2), DPB P=10/N=11 (nets 3/4)
+    # -> total P=20, N=23, delta=3.0, S='p'; phase-1 plan +2.0/+1.0, no spill.
+    def _ac_res(p_id, n_id, y, p_end, n_end):
+        return {"is_diff_pair": True, "p_net_id": p_id, "n_net_id": n_id,
+                "new_segments": [seg(0, y, p_end, y, p_id),
+                                 seg(0, y + 1, n_end, y + 1, n_id)],
+                "new_vias": [],
+                "p_src_stub_length": 0.0, "p_tgt_stub_length": 0.0,
+                "n_src_stub_length": 0.0, "n_tgt_stub_length": 0.0,
+                "polarity_fixed": False}
+
+    def _ac_fixture():
+        res_a = _ac_res(1, 2, 0, 10, 12)
+        res_b = _ac_res(3, 4, 2, 10, 11)
+        rr = {1: res_a, 2: res_a, 3: res_b, 4: res_b}
+        xnet = SimpleNamespace(
+            base_names=["DPA", "DPB"], bridge_refs=["C1", "C2"],
+            members=[SimpleNamespace(base_name="DPA", p_net_id=1, n_net_id=2),
+                     SimpleNamespace(base_name="DPB", p_net_id=3, n_net_id=4)])
+        return res_a, res_b, rr, xnet
+
+    cfg = SimpleNamespace(length_match_tolerance=0.1)
+
+    # 11. overshooting meanders (3x the ask -> added 9.0 >= 2*delta 6.0) are
+    # reverted: new_segments restored to the exact original objects and the
+    # ORIGINAL delta is returned so JSON skew_mm matches the restored board.
+    def _overshoot(segments, net_id, paired_net_id, vias, stub_length,
+                   current_length, target_length, delta, config, pcb_data):
+        extra = 3 * (target_length - current_length)
+        return (list(segments) + [seg(50, 50, 50 + extra, 50, net_id)],
+                current_length + extra, 2)
+
+    res_a, res_b, rr, xnet = _ac_fixture()
+    orig_a = list(res_a["new_segments"])
+    orig_b = list(res_b["new_segments"])
+    real_fn = length_matching._lengthen_net_with_meanders
+    length_matching._lengthen_net_with_meanders = _overshoot
+    try:
+        skew = length_matching.apply_ac_coupled_length_matching(
+            xnet, rr, cfg, fake_pcb)
+    finally:
+        length_matching._lengthen_net_with_meanders = real_fn
+    if not (isinstance(skew, float) and abs(skew - 3.0) < 1e-6):
+        fails.append(f"guard: expected original delta 3.0 returned, got {skew}")
+    if res_a["new_segments"] != orig_a or res_b["new_segments"] != orig_b:
+        fails.append("guard: new_segments not restored after revert")
+    elif not all(a is b for a, b in zip(res_a["new_segments"], orig_a)):
+        fails.append("guard: restored segments are copies, not the originals")
+
+    # 12. an exact-hit plan (added 3.0 -> delta 0.0 < 3.0) still applies:
+    # the guard must not over-trigger on the improving path.
+    def _exact(segments, net_id, paired_net_id, vias, stub_length,
+               current_length, target_length, delta, config, pcb_data):
+        extra = target_length - current_length
+        return (list(segments) + [seg(50, 50, 50 + extra, 50, net_id)],
+                target_length, 1)
+
+    res_a, res_b, rr, xnet = _ac_fixture()
+    length_matching._lengthen_net_with_meanders = _exact
+    try:
+        skew = length_matching.apply_ac_coupled_length_matching(
+            xnet, rr, cfg, fake_pcb)
+    finally:
+        length_matching._lengthen_net_with_meanders = real_fn
+    if not (isinstance(skew, float) and skew < 1e-6):
+        fails.append(f"guard-positive: expected matched skew ~0.0, got {skew}")
+    if len(res_a["new_segments"]) != 3 or len(res_b["new_segments"]) != 3:
+        fails.append(
+            f"guard-positive: meanders not applied "
+            f"({len(res_a['new_segments'])}/{len(res_b['new_segments'])} segs)")
 
     # ----------------------------------------------------------------------- report
     if fails:


### PR DESCRIPTION
Fixes #460. Both items were scoped as acceptable follow-ups in the #245 review.

## What

1. `apply_ac_coupled_length_matching` now mirrors intra-pair's "don't make it worse" guard: each member's `new_segments` is snapshotted before its first mutation, and if the end-to-end delta would not improve (`new_delta >= delta`, the same comparison intra-pair uses), all member edits are reverted and the original delta is returned so the JSON `skew_mm` matches the restored board.
2. `docs/length-matching.md` gains a Limitations bullet: `--ac-couple-match` runs after `--length-match-group`, so a pair that is both an XNet member and in a match group may be meandered twice; keep AC-coupled pairs out of match groups.

## Design notes

- The compare is end-to-end only. The phase-2 spill member is deliberately overshot past its local delta, so a per-member guard would reject valid plans. Snapshot/restore (keyed by `id(res)`) is needed because commits happen per member inside the apply loop, unlike intra-pair's single mutation point.
- The guard requires `added_total > tol`, so the existing "could not fit end-to-end meanders" message keeps ownership of the nothing-was-added case.
- Returning the original delta (not None) keeps `ac_coupled_xnets` honest: None means "member not routed" and would drop the XNet from the summary.
- Considered and not done: excluding XNet members from `run_length_matching` (mirroring the intra-pair skip at route_diff.py:1058). That would change behavior for existing dual-flag users and needs a signature change shared with route.py, and the passes do not strictly fight (the end-to-end match still holds; only the group's pair-to-pair equality is perturbed), so the docs caveat covers it. Happy to file it as its own follow-up if anyone hits it in practice.
- Known nit left as is: the AC pass does not refresh `route_length` / `p_routed_length` / `n_routed_length` after meandering. Nothing reads those fields after the matching passes.

## Testing

- `tests/test_ac_coupled_match.py` gains two board-free unit checks with a stubbed meander engine: an overshooting plan (added 9.0mm >= 2*delta) is reverted, with `new_segments` restored to the exact original objects and the original delta returned; an exact-hit plan still applies, so the guard does not over-trigger on the improving path. The integration check now also asserts `skew_mm` does not exceed the pre-match delta parsed from stdout.
- Pass locally (Python 3.8.16): detection/measurement checks plus the two new guard checks; `tests/test_meander_net_width.py`; `tests/test_diff_intra_pair_pinch.py`; `tests/run_doc_examples.py` at 28 run / 5 failed, identical to the pre-existing baseline (missing api-doc fixtures), no new failures.
- The two subprocess integration checks could not run here: the Rust router fails to import on this Python 3.8 (`dlopen: _PyCMethod_New not found`, a 3.9+ symbol), identically with and without this change (verified via stash). The failure is at route_diff.py startup, upstream of anything this diff touches.
- Inert when off: the pass is reachable only under `config.ac_couple_match and ac_xnets` (route_diff.py:1075), so without the flag the diff is byte-inert. With the flag on, the improving path is untouched; the guard only converts a skew-increasing commit into a restore.
