### PR TITLE
#504: ratsnest metrics export + pre-route screen, and five merged-PR defect fixes

### DIFF
--- a/bga_fanout/__init__.py
+++ b/bga_fanout/__init__.py
@@ -1915,8 +1915,15 @@ def generate_bga_fanout(footprint: Footprint,
                 if k not in ('footprint', 'pcb_data', '_dump')}
         _cfg['component'] = getattr(footprint, 'reference', None)
         _dump('bga_fanout', _cfg)
-    except Exception:
-        pass
+    except Exception as _e:
+        # A missing dep / stale Rust router must NOT be swallowed here. Before
+        # #457 that surfaced as SystemExit -- a BaseException, which this clause
+        # never caught -- but the checks now raise StartupCheckError, which IS an
+        # Exception, so this debug probe silently ate a real startup failure on
+        # every fanout call.
+        from startup_checks import StartupCheckError
+        if isinstance(_e, StartupCheckError):
+            raise
 
     if layers is None:
         layers = ["F.Cu", "B.Cu"]

--- a/length_matching.py
+++ b/length_matching.py
@@ -40,10 +40,24 @@ def _pad_bounding_radius(pad) -> float:
     up to sqrt(2) beyond that. A time-match arm approaching a roundrect
     corner-on passed the check while physically grazing the corner 59um deep
     (a13 ddr-a3 vs GND pad C210.2: model 0.57, true corner reach 0.789).
-    Circle pads are exact at max/2; every other shape gets the half-diagonal
-    -- slightly conservative for oval/roundrect, the correct direction for a
-    placement check."""
-    if getattr(pad, 'shape', '') == 'circle':
+    Circle AND OVAL pads are exact at max/2: an oval is a stadium (a rect with
+    semicircular ends), so its farthest copper is the end cap on the long axis --
+    it has no corner to reach. Giving it the half-diagonal inflated every oval by
+    up to sqrt(2), which is the shape of essentially every through-hole pad
+    (measured: all 1225 ovals in kicad_files/, mean +274um, worst +966um), and it
+    contradicted the convention this repo applies everywhere else -- see
+    check_drc.py, obstacle_map.py, obstacle_cache.py, and especially
+    diff_pair_routing.py's `short if pad.shape in ('circle','oval') else
+    short * sqrt(2)`, which is this same corner correction.
+
+    Every other shape gets the half-diagonal -- exact for rect, slightly
+    conservative for roundrect (its corners are rounded by roundrect_rratio),
+    which is the correct direction for a placement check.
+
+    Known gap: a `custom` pad's copper lives in Pad.polygons, not size_x/size_y,
+    so this UNDER-bounds it. Pre-existing and out of scope here, but this helper
+    is where a fix belongs."""
+    if getattr(pad, 'shape', '') in ('circle', 'oval'):
         return max(pad.size_x or 0, pad.size_y or 0) / 2.0
     return math.hypot(pad.size_x or 0, pad.size_y or 0) / 2.0
 

--- a/place_optimize.py
+++ b/place_optimize.py
@@ -16,6 +16,7 @@ footprints never move.
 See docs/placement-optimization.md for the background research.
 """
 
+import json
 import os
 
 from kicad_parser import parse_kicad_pcb
@@ -106,6 +107,7 @@ Examples:
     print(f"Loading {args.input_file}...")
     pcb_data = parse_kicad_pcb(args.input_file)
 
+    ratsnest = {}
     placements = quench(
         pcb_data,
         pcb_file=args.input_file,
@@ -127,11 +129,32 @@ Examples:
         max_passes=args.max_passes,
         ignore_nets=args.ignore_nets,
         lock_refs=args.lock,
+        metrics_out=ratsnest,
         verbose=args.verbose,
     )
 
     print(f"{len(placements)} parts moved")
     write_placed_output(args.input_file, args.output_file, placements)
+
+    # #504: the ratsnest and legality numbers used to be printed and discarded,
+    # so nothing downstream could gate on what a quench run actually achieved.
+    # Same shape as route_planes.py's JSON_SUMMARY (#487's plane-resistance fix).
+    before, after = ratsnest.get('before', {}), ratsnest.get('after', {})
+    summary = {
+        'parts_moved': len(placements),
+        # UNWEIGHTED, comparable across runs.
+        'crossings_before': before.get('crossings'),
+        'crossings_after': after.get('crossings'),
+        'hpwl_before': before.get('hpwl'),
+        'hpwl_after': after.get('hpwl'),
+        # Scaled by net_weights -- compare before/after within THIS run only.
+        'airwire_length_before': before.get('length'),
+        'airwire_length_after': after.get('length'),
+        'cost_before': before.get('total'),
+        'cost_after': after.get('total'),
+    }
+    summary.update(ratsnest.get('legality', {}))
+    print("JSON_SUMMARY: " + json.dumps(summary))
 
 
 if __name__ == "__main__":

--- a/place_route_loop.py
+++ b/place_route_loop.py
@@ -288,6 +288,41 @@ def better(a, b):
     return a['iterations'] < b['iterations'] * 0.95
 
 
+def _ratsnest_screen(before, after, pct):
+    """(skip, note) -- should this candidate skip its routing run? (#504)
+
+    Routing is the honest judge but an expensive one, often minutes per round.
+    A candidate whose ratsnest got clearly WORSE than the board it came from is
+    very unlikely to route better, so it is not worth paying for.
+
+    Screens on `crossings` and `hpwl` only. Both are unweighted -- crossings is
+    a raw count by contract, hpwl is pure pad geometry -- whereas `length` and
+    `total` are scaled by the per-round net_weights this loop sets from
+    --failed-net-weight. (before/after share the weights within one quench call,
+    so length is safe to REPORT; it just is not a stable thing to threshold on.)
+
+    pct <= 0 disables the screen, which is the default: skipping a placement
+    that would in fact have won is a real cost, so this is opt-in and every
+    decision is logged with its numbers.
+    """
+    if not pct or pct <= 0 or not before or not after:
+        return False, ""
+    worse = []
+    note = []
+    for key, label in (('crossings', 'crossings'), ('hpwl', 'hpwl')):
+        b, a = before.get(key), after.get(key)
+        if b is None or a is None:
+            continue
+        delta = (a - b) / b * 100.0 if b else (100.0 if a else 0.0)
+        note.append(f"{label} {b:g}->{a:g} ({delta:+.1f}%)")
+        if delta > pct:
+            worse.append(f"{label} {delta:+.1f}%")
+    txt = ", ".join(note)
+    if worse:
+        return True, f"{txt}  [regressed > {pct:g}%: {', '.join(worse)}]"
+    return False, txt
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Router-in-the-loop placement repair.",
@@ -314,6 +349,11 @@ def main():
                         help="Cost multiplier for failed nets: scales their "
                              "airwire length and any crossing they take part "
                              "in (default: 3.0)")
+    parser.add_argument("--ratsnest-screen", type=float, default=0.0,
+                        help="Skip the routing run when a candidate placement's "
+                             "airwire crossings or HPWL regress by more than "
+                             "this percent against the board it came from -- a "
+                             "cheap pre-route filter (0 = disabled, the default)")
     parser.add_argument("--step", type=float, default=0.5,
                         help="Candidate grid step in mm (default: 0.5)")
     parser.add_argument("--length-weight", type=float, default=0.3)
@@ -342,6 +382,8 @@ def main():
 
     if args.max_displacement < 0:
         parser.error("--max-displacement must be >= 0")
+    if args.ratsnest_screen < 0:
+        parser.error("--ratsnest-screen must be >= 0 (0 disables it)")
     if args.swap_max_displacement is not None:
         if args.swap_max_displacement < 0:
             parser.error("--swap-max-displacement must be >= 0")
@@ -355,6 +397,7 @@ def main():
     cur_file = os.path.join(work, 'loop_round0.kicad_pcb')
     shutil.copy(args.input_file, cur_file)
 
+    screened = 0
     print("Round 0: routing initial placement...")
     best = run_route(cur_file, os.path.join(work, 'loop_round0_routed.kicad_pcb'),
                      args.route_args, os.path.join(work, 'loop_round0_route.log'))
@@ -395,6 +438,7 @@ def main():
               f" (max_disp={max_disp:.1f}mm, swap cap={swap_cap:.1f}mm):"
               f" {', '.join(sorted(targets))}")
 
+        ratsnest = {}
         placements = quench(
             pcb_data, pcb_file=cur_file,
             max_displacement=max_disp,
@@ -411,6 +455,7 @@ def main():
             allow_swaps=not args.no_swap,
             ignore_nets=args.ignore_nets, lock_refs=args.lock,
             move_refs=targets, net_weights=net_weights,
+            metrics_out=ratsnest,
             verbose=args.verbose,
         )
 
@@ -420,12 +465,34 @@ def main():
             max_disp *= 1.5
             continue
 
+        # #504: quench was handed the CURRENT best board, so its own 'before' IS
+        # that board's ratsnest and 'after' is the candidate's -- the screen gets
+        # its baseline for free, with no second QuenchState (which would re-read
+        # the board for courtyards and locked refs) and no round-0 bootstrap.
+        rn_before = ratsnest.get('before', {})
+        rn_after = ratsnest.get('after', {})
+        skip, why = _ratsnest_screen(rn_before, rn_after, args.ratsnest_screen)
+        if why:
+            print(f"  ratsnest: {why}")
+        if skip:
+            print(f"  SCREENED - skipping the routing run, widening the nudge cap"
+                  f" (swap cap stays {swap_cap:.1f}mm).")
+            screened += 1
+            max_disp *= 1.5
+            continue
+
         cand_file = os.path.join(work, f'loop_round{rnd}.kicad_pcb')
         write_placed_output(cur_file, cand_file, placements)
 
         metrics = run_route(
             cand_file, os.path.join(work, f'loop_round{rnd}_routed.kicad_pcb'),
             args.route_args, os.path.join(work, f'loop_round{rnd}_route.log'))
+        # Report-only, exactly like the pad_pairs_* keys above: every round now
+        # records placement quality next to the routing result. better() is
+        # deliberately untouched -- reworking the comparator is #458's scope.
+        metrics['ratsnest_crossings'] = rn_after.get('crossings')
+        metrics['ratsnest_hpwl'] = rn_after.get('hpwl')
+        metrics['ratsnest_length'] = rn_after.get('length')
         print(f"  -> failures={metrics['failures']}"
               f" iterations={metrics['iterations']:,} vias={metrics['vias']}")
 
@@ -441,6 +508,9 @@ def main():
             max_disp *= 1.5
 
     shutil.copy(cur_file, args.output_file)
+    if args.ratsnest_screen > 0:
+        print(f"Ratsnest screen: {screened} round(s) skipped the routing run"
+              f" at {args.ratsnest_screen:g}% regression.")
     print(f"Final: failures={best['failures']} iterations={best['iterations']:,}"
           f" vias={best['vias']}")
     print(f"Wrote {args.output_file}")

--- a/placement/README.md
+++ b/placement/README.md
@@ -158,6 +158,35 @@ only each net's pad-position extremes, so unlike the MST length and the crossing
 count it is invariant to airwire order. If HPWL agrees and crossings do not, the
 two runs differ in tie-breaks rather than in placement quality.
 
+## Ratsnest metrics, and the pre-route screen (#504)
+
+The quench cost function computes airwire length and crossings on every pass, and
+`hpwl()` is pure pad geometry. Those numbers used to be printed and discarded.
+They are now exported:
+
+- `quench(..., metrics_out=d)` fills `d` with `{'before', 'after', 'legality'}` —
+  an out-param rather than a changed return, since the return is consumed
+  positionally by both CLIs and four test files.
+- `place_optimize.py` emits them as a `JSON_SUMMARY:` line, so a chain or grader
+  can gate on what a run achieved instead of scraping stdout.
+- `place_route_loop.py` records `ratsnest_crossings` / `ratsnest_hpwl` /
+  `ratsnest_length` in each round's metrics dict, report-only beside the
+  `pad_pairs_*` keys. `better()` is deliberately untouched — reworking the
+  comparator is #458.
+
+**Which numbers compare.** `crossings` (a raw count by contract) and `hpwl` are
+unweighted, so they are comparable across runs. `length` and `total` are scaled
+by `net_weights`, so they only compare between the `before` and `after` of the
+*same* call — which is why the screen thresholds on the first two.
+
+**`--ratsnest-screen N`** (percent, `0` = disabled, the default) skips the routing
+run when a candidate's crossings or HPWL regress by more than N% against the board
+it came from. Routing is the honest judge but an expensive one, often minutes per
+round; a candidate whose ratsnest clearly got worse is very unlikely to route
+better. The baseline is free — quench is handed the current best board, so its own
+`before` *is* that board's ratsnest. Every decision is logged with its numbers, so
+it is auditable whether the screen ever skipped a placement that would have won.
+
 ## Module layout
 
 | File | Purpose |

--- a/placement/legality.py
+++ b/placement/legality.py
@@ -245,7 +245,7 @@ class BoardOutlineGate:
         return self._edges
 
     # -- level 2: cached reachability prune
-    def edges_near(self, key, seed_rect, travel: float) -> list:
+    def edges_near(self, key, seed_rect, travel: float, center=None) -> list:
         """Cached: the ring edges a part seeded at `seed_rect` could ever bring
         a pose within the edge margin of, given `travel` of displacement budget.
 
@@ -255,23 +255,39 @@ class BoardOutlineGate:
         the exact test should measure against instead of every ring, which is
         what keeps a dense candidate loop affordable (the segment-to-ring
         distances dominated a naive port).
+
+        `center` is the part's pose ORIGIN, and callers whose parts can ROTATE
+        must pass it. Measuring the span from the seed rect's own centre assumes
+        the rect stays centred there, which is false for a courtyard that is
+        off-centre from the footprint origin: a 90/180/270 pose swings it about
+        the origin, and the reachable disk drawn around the seed centre can then
+        miss an edge the part really can reach. Rotation preserves distance FROM
+        THE ORIGIN, so the max origin-to-corner distance bounds every pose
+        exactly. (Omitting it is safe only for parts that never rotate, or whose
+        courtyard is origin-symmetric -- the fanout caps this prune came from.)
         """
         near = self._near.get(key)
         if near is None:
-            cx = (seed_rect[0] + seed_rect[2]) / 2.0
-            cy = (seed_rect[1] + seed_rect[3]) / 2.0
-            span = math.hypot(seed_rect[2] - cx, seed_rect[3] - cy)
+            if center is not None:
+                cx, cy = center
+                span = max(math.hypot(px - cx, py - cy)
+                           for px in (seed_rect[0], seed_rect[2])
+                           for py in (seed_rect[1], seed_rect[3]))
+            else:
+                cx = (seed_rect[0] + seed_rect[2]) / 2.0
+                cy = (seed_rect[1] + seed_rect[3]) / 2.0
+                span = math.hypot(seed_rect[2] - cx, seed_rect[3] - cy)
             reach = travel + span + self.margin + EPS
-            # An edge farther than reach from the SEED centre cannot come within
+            # An edge farther than reach from that centre cannot come within
             # margin of any reachable pose: every point of a reachable rect lies
-            # within travel + span of that centre.
+            # within travel + span of it.
             near = [e for e in self.edges()
                     if point_to_seg_dist(cx, cy, *e) <= reach]
             self._near[key] = near
         return near
 
-    def may_reach(self, key, seed_rect, travel: float) -> bool:
-        return bool(self.edges_near(key, seed_rect, travel))
+    def may_reach(self, key, seed_rect, travel: float, center=None) -> bool:
+        return bool(self.edges_near(key, seed_rect, travel, center))
 
     # -- level 3: the exact tests
     def rect_blocked(self, rect, edges=None) -> bool:

--- a/placement/quench.py
+++ b/placement/quench.py
@@ -161,30 +161,35 @@ def _through_pad_bounds_local(fp):
     hole's own extent rather than the pad copper's -- the far side sees the
     barrel and the lead, and the annular ring on that side is part of it.
     """
-    # Inverse of local_to_global's rotation, for pads whose drill is OFFSET from
-    # their copper: hole_x/hole_y are BOARD coordinates, so the delta from the
-    # copper centre has to be rotated back into the footprint's local frame
-    # before it can be added to local_x/local_y.
-    ang = math.radians(-(fp.rotation or 0.0))
-    cos_a, sin_a = math.cos(ang), math.sin(ang)
+    # `local_x/local_y` is the pad ANCHOR in the footprint's frame, and for a
+    # drilled pad the anchor IS the hole: kicad_parser records hole_x/hole_y as
+    # the pre-offset position and only then shifts global_x/global_y to the
+    # copper centre. So the hole needs no offset correction at all -- an earlier
+    # version "corrected" local_* by (hole - global), which is minus the offset,
+    # landing the box one full offset on the WRONG side of the hole.
+    #
+    # size_x/size_y are BOARD-axis resolved (kicad_parser swaps them for a pad at
+    # ~90 degrees), so they cannot be used as local half-extents directly -- that
+    # transposed the box on every 90/270-degree footprint (kit-dev SW_ONOFF201
+    # modelled 2.54 x 13.97 where the truth is 3.81 x 12.70, under-blocking
+    # 1.27mm). Project them through the pad's local tilt exactly as
+    # placement/utility.compute_footprint_bbox_local does.
     xs, ys = [], []
     for p in (fp.pads or []):
         d = getattr(p, 'drill', 0) or 0
         if d <= 0:
             continue
-        lx, ly = p.local_x, p.local_y
-        hx, hy = getattr(p, 'hole_x', None), getattr(p, 'hole_y', None)
-        if hx is not None and hy is not None:
-            gdx, gdy = hx - p.global_x, hy - p.global_y
-            lx += gdx * cos_a + gdy * sin_a       # R(-ang) applied to the delta
-            ly += -gdx * sin_a + gdy * cos_a
-        r = d / 2.0
+        local_tilt = math.radians((getattr(p, 'rect_rotation', 0.0) or 0.0)
+                                  + (fp.rotation or 0.0))
+        c, s = abs(math.cos(local_tilt)), abs(math.sin(local_tilt))
+        hx, hy = (getattr(p, 'size_x', 0) or 0) / 2.0, (getattr(p, 'size_y', 0) or 0) / 2.0
         # An oval/slotted hole is bounded by the pad extent it sits in; taking
         # the larger of drill radius and half pad size keeps a slot covered.
-        rx = max(r, (getattr(p, 'size_x', 0) or 0) / 2.0)
-        ry = max(r, (getattr(p, 'size_y', 0) or 0) / 2.0)
-        xs += [lx - rx, lx + rx]
-        ys += [ly - ry, ly + ry]
+        r = d / 2.0
+        rx = max(r, hx * c + hy * s)
+        ry = max(r, hx * s + hy * c)
+        xs += [p.local_x - rx, p.local_x + rx]
+        ys += [p.local_y - ry, p.local_y + ry]
     if not xs:
         return None
     return (min(xs), min(ys), max(xs), max(ys))
@@ -637,13 +642,24 @@ class QuenchState:
                         legal = False
                         break
                     continue
-                # Fast path: two plain SMD parts. Same side, then the original
-                # inline AABB test -- no function calls, as before the side rule.
+                # Fast path: two plain SMD parts, same side. The per-axis test is
+                # an early-OUT, not the verdict -- clearing it on any axis proves
+                # the true gap clears too, but failing it does not prove the
+                # reverse, because the gap is EUCLIDEAN. Two rects offset
+                # diagonally by (0.2, 0.2) at clearance 0.25 fail every axis while
+                # rect_gap is hypot(0.2,0.2)=0.283, i.e. legal. Using the axis
+                # test as the answer made candidate_valid REJECT poses that
+                # violation_parts (:577) and _halo_pair_penalty (:447) both score
+                # as legal -- so violation()==0 did not imply the hard gate
+                # passes, and the unfreeze branch could walk a part into a pose
+                # the ordinary gate forbids.
                 if other.side != part.side:
                     continue
                 r = other.rect()
-                if not (rect[2] + clr <= r[0] or r[2] + clr <= rect[0]
+                if (rect[2] + clr <= r[0] or r[2] + clr <= rect[0]
                         or rect[3] + clr <= r[1] or r[3] + clr <= rect[1]):
+                    continue                    # provably clear
+                if rect_gap(rect, r) < clr:
                     legal = False
                     break
         if legal:
@@ -676,8 +692,11 @@ class QuenchState:
         Empty means the exact ring test is skippable for every pose it can take."""
         part = self.parts[ref]
         travel = 0.0 if part.locked else self._travel_budget
+        # center= the pose ORIGIN: a part ROTATES about it, so an off-centre
+        # courtyard's rect swings and the seed-rect-centred disk can miss an edge.
         return self.edge_gate.edges_near(
-            ref, part.rect(part.seed_x, part.seed_y, part.orig_rot), travel)
+            ref, part.rect(part.seed_x, part.seed_y, part.orig_rot), travel,
+            center=(part.seed_x, part.seed_y))
 
     def _edges_near_halo(self, ref) -> list:
         """Like _edges_near but sized to the SOFT edge_halo radius. Inflating
@@ -687,7 +706,7 @@ class QuenchState:
         travel = 0.0 if part.locked else self._travel_budget
         return self.edge_gate.edges_near(
             (ref, 'halo'), part.rect(part.seed_x, part.seed_y, part.orig_rot),
-            travel + self.edge_halo)
+            travel + self.edge_halo, center=(part.seed_x, part.seed_y))
 
     def _may_reach_edge(self, ref) -> bool:
         return bool(self._edges_near(ref))
@@ -953,6 +972,7 @@ def quench(pcb_data: PCBData, pcb_file: str,
            lock_refs: Optional[List[str]] = None,
            move_refs: Optional[Set[str]] = None,
            net_weights: Optional[Dict[int, float]] = None,
+           metrics_out: Optional[Dict] = None,
            verbose: bool = False) -> List[Dict]:
     """Greedy quench: iterate over parts, accept only cost-reducing moves.
 
@@ -960,6 +980,23 @@ def quench(pcb_data: PCBData, pcb_file: str,
     net's airwire length is scaled by its weight and every crossing it takes
     part in is priced at max(weight_a, weight_b). Absent or all-ones leaves
     the cost exactly unchanged.
+
+    metrics_out: optional dict, filled in place with the ratsnest and legality
+    numbers this function already computes and used to print and discard (#504):
+
+        {'before': {...}, 'after': {...}, 'legality': {...}}
+
+    where before/after are `QuenchState.total_cost()` -- length, crossings,
+    halo, edge, hpwl, total -- and legality is `legality_metrics()`. An
+    out-param rather than a changed return type on purpose: the return is
+    consumed positionally by both CLIs and four test files, and one of those
+    binds this signature with inspect.signature. Same note/consume shape as
+    plane_resistance's consume_resistance_results (#487).
+
+    Reading them: `crossings` and `hpwl` are UNWEIGHTED (crossings is a raw
+    count by contract; hpwl is pure pad geometry), so they are comparable
+    across calls. `length` and `total` are scaled by net_weights, so they are
+    only comparable between the before/after of the SAME call.
 
     Returns a list of placement dicts (reference/new_x/new_y/new_rotation)
     for every movable part, whether or not it moved.
@@ -1199,6 +1236,13 @@ def quench(pcb_data: PCBData, pcb_file: str,
           f"crossings {before['crossings']} -> {after['crossings']}, "
           f"hpwl {before['hpwl']:.1f} -> {after['hpwl']:.1f}mm, "
           f"total {before['total']:.1f} -> {after['total']:.1f}")
+
+    if metrics_out is not None:
+        # #504: hand back what we just printed, instead of discarding it. The
+        # caller owns the dict, so this cannot change the return contract.
+        metrics_out['before'] = dict(before)
+        metrics_out['after'] = dict(after)
+        metrics_out['legality'] = state.legality_metrics()
 
     return [{'reference': ref,
              'new_x': p.x, 'new_y': p.y, 'new_rotation': p.rot}

--- a/tests/test_456_side_and_outline.py
+++ b/tests/test_456_side_and_outline.py
@@ -448,6 +448,87 @@ def test_state_legality_metrics_report_a_real_overlap():
     os.unlink(path)
 
 
+# --- #504 follow-up: defects in the merged #456 far-side model ----------------
+
+def test_far_side_box_is_not_transposed_on_a_rotated_footprint():
+    """D1: size_x/size_y are BOARD-axis resolved (kicad_parser swaps them for a
+    pad at ~90 degrees), so using them as LOCAL half-extents transposed the box
+    on every 90/270-degree footprint -- kit-dev SW_ONOFF201 was modelled
+    2.54 x 13.97 where the truth is 3.81 x 12.70, under-blocking 1.27mm on the
+    far side. The box must be projected through the pad's local tilt, exactly as
+    placement/utility.compute_footprint_bbox_local does."""
+    from placement.quench import _through_pad_bounds_local
+    board = os.path.join(KICAD_FILES, 'kit-dev-coldfire-xilinx_5213.kicad_pcb')
+    if not os.path.exists(board):
+        return
+    pcb = parse_kicad_pcb(board)
+    checked = 0
+    for ref, fp in pcb.footprints.items():
+        drilled = [p for p in fp.pads if (p.drill or 0) > 0]
+        if not drilled:
+            continue
+        b = _through_pad_bounds_local(fp)
+        xs, ys = [], []
+        for p in drilled:
+            sx, sy = p.size_x, p.size_y
+            if abs((fp.rotation % 180) - 90) < 1.0:   # board->local axis swap
+                sx, sy = sy, sx
+            rx, ry = max((p.drill or 0) / 2, sx / 2), max((p.drill or 0) / 2, sy / 2)
+            xs += [p.local_x - rx, p.local_x + rx]
+            ys += [p.local_y - ry, p.local_y + ry]
+        assert abs((b[2] - b[0]) - (max(xs) - min(xs))) < 1e-6,             f"{ref} (rot {fp.rotation}): width {b[2]-b[0]:.3f} vs {max(xs)-min(xs):.3f}"
+        assert abs((b[3] - b[1]) - (max(ys) - min(ys))) < 1e-6,             f"{ref} (rot {fp.rotation}): height {b[3]-b[1]:.3f} vs {max(ys)-min(ys):.3f}"
+        checked += 1
+    assert checked > 5, f"only checked {checked} THT footprints"
+    print(f"  PASS: {checked} THT footprints, no transposed far-side box")
+
+
+def test_far_side_box_sits_on_the_hole_not_offset_from_it():
+    """D2: local_x/local_y IS the hole for a drilled pad -- kicad_parser records
+    hole_x/hole_y BEFORE shifting global_x/global_y to the copper centre. The
+    old code 'corrected' by (hole - global), which is MINUS the offset, landing
+    the box a full offset on the wrong side."""
+    from placement.quench import _through_pad_bounds_local
+
+    class _P:
+        shape = 'circle'
+        rect_rotation = 0.0
+        def __init__(s):
+            s.local_x, s.local_y = 0.0, 0.0      # anchor == hole, local frame
+            s.size_x = s.size_y = 1.0
+            s.drill = 0.8
+            s.global_x, s.global_y = 10.3, 20.0  # copper, shifted +0.3 in x
+            s.hole_x, s.hole_y = 10.0, 20.0      # anchor in board coords
+
+    class _F:
+        rotation = 0.0
+        pads = [_P()]
+
+    b = _through_pad_bounds_local(_F())
+    cx, cy = (b[0] + b[2]) / 2.0, (b[1] + b[3]) / 2.0
+    assert abs(cx) < 1e-9 and abs(cy) < 1e-9,         f"far-side box centred at ({cx}, {cy}); the hole is at the local origin"
+
+
+def test_diagonal_near_miss_agrees_between_the_gate_and_the_grader():
+    """D4: candidate_valid's SMD fast path used the per-axis test as the VERDICT
+    while violation_parts falls through to the EUCLIDEAN gap. Two courtyards
+    offset diagonally by (0.2, 0.2) at clearance 0.25 have a true gap of 0.283 --
+    legal -- but failed every axis, so violation()==0 while candidate_valid()
+    said False."""
+    body = (_part('U1', 150.0, 100.0, 'F.Cu', 1, 'NA', cy=1.0)
+            + _part('C1', 165.0, 100.0, 'F.Cu', 2, 'NB', cy=1.0))
+    st, path = _state(body)
+    x = y = None
+    x, y = 150.0 + 2.0 + 0.2, 100.0 + 2.0 + 0.2      # dx = dy = 0.2 past U1
+    gap = legality.rect_gap(st.parts['C1'].rect(x, y, 0.0), st.parts['U1'].rect())
+    assert gap > st.clearance, f"fixture error: gap {gap} <= clearance"
+    assert st.violation('C1', x, y, 0.0) == 0.0, "grader should call this legal"
+    assert st.candidate_valid('C1', x, y, 0.0),         "the hard gate must agree with the grader on a diagonal near-miss"
+    # ... and a genuine same-side overlap is still rejected.
+    assert not st.candidate_valid('C1', 150.0, 100.0, 0.0)
+    os.unlink(path)
+
+
 TESTS = [
     test_back_side_part_under_front_part_is_not_a_collision,
     test_same_side_overlap_is_still_a_collision,
@@ -466,6 +547,9 @@ TESTS = [
     test_out_of_board_grader,
     test_state_legality_metrics_are_zero_on_a_legal_placement,
     test_state_legality_metrics_report_a_real_overlap,
+    test_far_side_box_is_not_transposed_on_a_rotated_footprint,
+    test_far_side_box_sits_on_the_hole_not_offset_from_it,
+    test_diagonal_near_miss_agrees_between_the_gate_and_the_grader,
 ]
 
 

--- a/tests/test_458_loop_steering.py
+++ b/tests/test_458_loop_steering.py
@@ -81,9 +81,15 @@ def _loop_board():
     return path, tempfile.mkdtemp()
 
 
-def _run_loop(extra_args, rounds=4, quench_result=None):
+def _run_loop(extra_args, rounds=4, quench_result=None,
+              quench_metrics=None, route_calls=None):
     """Run main() with the routing step, the quench and the writer replaced.
-    Returns the list of kwargs quench was called with, one entry per round."""
+    Returns the list of kwargs quench was called with, one entry per round.
+
+    quench_metrics: optional {'before':..., 'after':...} the fake quench writes
+    into the caller's metrics_out, so the #504 ratsnest screen has numbers.
+    route_calls: optional list that receives one entry per run_route call, so a
+    test can assert the screen actually SKIPPED the routing run."""
     calls = []
     placements = ([{'reference': 'C1', 'new_x': 151.0, 'new_y': 100.0,
                     'new_rotation': 0.0}] if quench_result is None
@@ -91,9 +97,13 @@ def _run_loop(extra_args, rounds=4, quench_result=None):
 
     def fake_quench(pcb_data, **kw):
         calls.append(dict(kw))
+        if quench_metrics is not None and kw.get('metrics_out') is not None:
+            kw['metrics_out'].update(quench_metrics)
         return placements
 
     def fake_run_route(pcb_file, routed_file, route_args, log_file):
+        if route_calls is not None:
+            route_calls.append(pcb_file)
         # Every candidate scores exactly like round 0, so better() is False
         # and every round is REJECTED: the cap widens on every round.
         return {'failures': 2, 'failed_nets': ['NA'], 'blockers': [],
@@ -502,6 +512,64 @@ def test_missing_summary_raises_with_the_log_tail():
         raise AssertionError("a log with no summary must raise")
 
 
+# --- #504: the ratsnest screen ------------------------------------------------
+
+_WORSE = {'before': {'crossings': 100, 'hpwl': 1000.0, 'length': 1000.0,
+                     'total': 1.0},
+          'after': {'crossings': 130, 'hpwl': 1000.0, 'length': 1000.0,
+                    'total': 0.9}}
+_BETTER = {'before': {'crossings': 100, 'hpwl': 1000.0, 'length': 1000.0,
+                      'total': 1.0},
+           'after': {'crossings': 80, 'hpwl': 900.0, 'length': 900.0,
+                     'total': 0.5}}
+
+
+def test_screen_skips_the_routing_run_on_a_regressed_candidate():
+    """The whole point of #504 part 2: routing is minutes per round, so a
+    candidate whose ratsnest clearly got worse must not be paid for."""
+    routed = []
+    _run_loop(['--ratsnest-screen', '5'], rounds=3,
+              quench_metrics=_WORSE, route_calls=routed)
+    # round 0 always routes the initial placement; every candidate is screened.
+    assert len(routed) == 1,         f"expected only the round-0 route, got {len(routed)} routing runs"
+
+
+def test_screen_off_by_default_routes_every_candidate():
+    routed = []
+    _run_loop([], rounds=3, quench_metrics=_WORSE, route_calls=routed)
+    assert len(routed) == 4,         f"screen must be opt-in: expected 1 + 3 routing runs, got {len(routed)}"
+
+
+def test_screen_lets_an_improving_candidate_through():
+    routed = []
+    _run_loop(['--ratsnest-screen', '5'], rounds=3,
+              quench_metrics=_BETTER, route_calls=routed)
+    assert len(routed) == 4,         f"an improving candidate must still be routed, got {len(routed)}"
+
+
+def test_screen_is_inert_when_quench_reports_nothing():
+    """A fake/old quench that fills no metrics_out must never cause a skip."""
+    routed = []
+    _run_loop(['--ratsnest-screen', '5'], rounds=2,
+              quench_metrics=None, route_calls=routed)
+    assert len(routed) == 3, f"got {len(routed)}"
+
+
+def test_loop_passes_metrics_out_to_quench():
+    calls = _run_loop([], rounds=1)
+    assert 'metrics_out' in calls[0],         "the loop must ask quench for its ratsnest numbers"
+    assert isinstance(calls[0]['metrics_out'], dict)
+
+
+def test_negative_screen_is_rejected():
+    try:
+        _run_loop(['--ratsnest-screen', '-1'], rounds=1)
+    except SystemExit as e:
+        assert e.code == 2, f"argparse should exit 2, got {e.code}"
+        return
+    raise AssertionError("--ratsnest-screen -1 must be rejected")
+
+
 TESTS = [
     test_swap_cap_held_while_displacement_widens,
     test_swap_cap_held_when_quench_finds_nothing,
@@ -524,6 +592,12 @@ TESTS = [
     test_route_py_is_invoked_by_absolute_path_in_utf8_mode,
     test_nonzero_exit_raises_and_names_the_real_error,
     test_missing_summary_raises_with_the_log_tail,
+    test_screen_skips_the_routing_run_on_a_regressed_candidate,
+    test_screen_off_by_default_routes_every_candidate,
+    test_screen_lets_an_improving_candidate_through,
+    test_screen_is_inert_when_quench_reports_nothing,
+    test_loop_passes_metrics_out_to_quench,
+    test_negative_screen_is_rejected,
 ]
 
 

--- a/tests/test_504_ratsnest_metrics.py
+++ b/tests/test_504_ratsnest_metrics.py
@@ -1,0 +1,197 @@
+"""
+Ratsnest metrics are exported, and screen candidates before routing (issue #504).
+
+The quench cost function already computed airwire length and crossings on every
+pass, and #457 added HPWL — then printed all of it and threw it away. Nothing
+outside the optimizer could see what a placement run achieved, so nothing could
+gate on it.
+
+`quench(metrics_out=...)` now hands those numbers back, `place_optimize.py` emits
+them as a JSON_SUMMARY, and `place_route_loop.py` records them per round and can
+use them to skip a routing run that is very unlikely to help.
+
+Reading the numbers: `crossings` and `hpwl` are UNWEIGHTED (crossings is a raw
+count by contract; hpwl is pure pad geometry), so they compare across calls.
+`length` and `total` are scaled by net_weights, so they only compare between the
+before/after of one call — which is why the screen thresholds on the first two.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from kicad_parser import parse_kicad_pcb
+from place_route_loop import _ratsnest_screen, better
+from placement.quench import QuenchState, quench
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BOARD = os.path.join(ROOT, 'kicad_files', 'interf_u_unrouted.kicad_pcb')
+KN = dict(clearance=0.25, board_edge_clearance=0.55, crossing_penalty=10.0,
+          halo_base=0.3, halo_coef=0.15, halo_weight=1.0,
+          edge_halo=1.0, edge_weight=1.0, grid_step=0.05)
+
+
+# --- the out-param ------------------------------------------------------------
+
+def test_metrics_out_is_populated_and_matches_total_cost():
+    """The exported numbers must be the ones the optimizer actually acted on,
+    not a second implementation that can drift."""
+    m = {}
+    quench(parse_kicad_pcb(BOARD), pcb_file=BOARD, max_displacement=2.0,
+           step=1.0, max_passes=1, metrics_out=m)
+    assert set(m) == {'before', 'after', 'legality'}, f"keys: {sorted(m)}"
+    for phase in ('before', 'after'):
+        for key in ('total', 'length', 'crossings', 'halo', 'edge', 'hpwl'):
+            assert key in m[phase], f"{phase} missing {key}"
+    # 'before' is the untouched board, so an independent QuenchState must agree.
+    st = QuenchState(parse_kicad_pcb(BOARD), BOARD, **KN)
+    ref = st.total_cost()
+    assert m['before']['crossings'] == ref['crossings'], \
+        f"before.crossings {m['before']['crossings']} != {ref['crossings']}"
+    assert abs(m['before']['hpwl'] - ref['hpwl']) < 1e-9
+    for key in ('overlap_area', 'oob_count', 'oob_amount', 'oob_area'):
+        assert key in m['legality'], f"legality missing {key}"
+    print(f"  PASS: crossings {m['before']['crossings']} -> {m['after']['crossings']}, "
+          f"hpwl {m['before']['hpwl']:.1f} -> {m['after']['hpwl']:.1f}")
+
+
+def test_metrics_out_is_optional_and_non_breaking():
+    """Every existing caller passes no metrics_out and must still get a list."""
+    out = quench(parse_kicad_pcb(BOARD), pcb_file=BOARD, max_displacement=2.0,
+                 step=1.0, max_passes=1)
+    assert isinstance(out, list), f"return type changed: {type(out).__name__}"
+    assert all(set(p) == {'reference', 'new_x', 'new_y', 'new_rotation'}
+               for p in out), "placement dict shape changed"
+
+
+def test_quench_only_improves_its_own_objective():
+    """Sanity for anything screening on these: the optimizer is monotone in
+    `total`, but NOT necessarily in any single term — which is exactly why a
+    per-term screen is meaningful."""
+    m = {}
+    quench(parse_kicad_pcb(BOARD), pcb_file=BOARD, max_displacement=2.0,
+           step=1.0, max_passes=2, metrics_out=m)
+    assert m['after']['total'] <= m['before']['total'] + 1e-6, \
+        f"total regressed: {m['before']['total']} -> {m['after']['total']}"
+
+
+# --- the screen ---------------------------------------------------------------
+
+def test_screen_disabled_by_default():
+    before = {'crossings': 100, 'hpwl': 1000.0}
+    after = {'crossings': 500, 'hpwl': 9000.0}      # catastrophically worse
+    for pct in (0, 0.0, None):
+        skip, _ = _ratsnest_screen(before, after, pct)
+        assert not skip, f"screen fired with pct={pct!r}; it must be opt-in"
+
+
+def test_screen_fires_on_a_regression_beyond_the_threshold():
+    before = {'crossings': 100, 'hpwl': 1000.0}
+    after = {'crossings': 110, 'hpwl': 1000.0}      # +10% crossings
+    skip, why = _ratsnest_screen(before, after, 5.0)
+    assert skip, f"expected a skip at +10% vs 5% threshold: {why}"
+    assert 'crossings' in why and '+10.0%' in why, f"note not auditable: {why}"
+    skip, why = _ratsnest_screen(before, after, 20.0)
+    assert not skip, f"+10% must pass a 20% threshold: {why}"
+
+
+def test_screen_fires_on_hpwl_too():
+    before = {'crossings': 100, 'hpwl': 1000.0}
+    after = {'crossings': 100, 'hpwl': 1200.0}      # +20% hpwl
+    skip, why = _ratsnest_screen(before, after, 5.0)
+    assert skip and 'hpwl' in why, f"hpwl regression not screened: {why}"
+
+
+def test_screen_lets_an_improvement_through():
+    before = {'crossings': 100, 'hpwl': 1000.0}
+    after = {'crossings': 80, 'hpwl': 950.0}
+    skip, why = _ratsnest_screen(before, after, 5.0)
+    assert not skip, f"an improving candidate was screened: {why}"
+    assert '-20.0%' in why, f"note should still report the numbers: {why}"
+
+
+def test_screen_always_reports_its_numbers():
+    """The issue asks that the decision be auditable every round."""
+    _, why = _ratsnest_screen({'crossings': 10, 'hpwl': 5.0},
+                              {'crossings': 10, 'hpwl': 5.0}, 5.0)
+    assert 'crossings 10->10' in why and 'hpwl 5->5' in why, why
+
+
+def test_screen_is_inert_without_metrics():
+    """A quench that filled nothing must never cause a skip."""
+    for b, a in (({}, {}), ({'crossings': 1}, {}), (None, None)):
+        skip, _ = _ratsnest_screen(b, a, 5.0)
+        assert not skip
+
+
+def test_screen_handles_a_zero_baseline():
+    """crossings 0 -> 0 is not a regression; 0 -> n is."""
+    skip, _ = _ratsnest_screen({'crossings': 0, 'hpwl': 1.0},
+                               {'crossings': 0, 'hpwl': 1.0}, 5.0)
+    assert not skip, "0 -> 0 must not be a regression"
+    skip, _ = _ratsnest_screen({'crossings': 0, 'hpwl': 1.0},
+                               {'crossings': 3, 'hpwl': 1.0}, 5.0)
+    assert skip, "0 -> 3 must be a regression"
+
+
+# --- the reporting plumbing ---------------------------------------------------
+
+def test_better_ignores_the_ratsnest_keys():
+    """Report-only, exactly like pad_pairs_*: reworking the comparator is #458."""
+    a = {'failures': 1, 'iterations': 100, 'ratsnest_crossings': 999,
+         'ratsnest_hpwl': 9e9}
+    b = {'failures': 2, 'iterations': 100, 'ratsnest_crossings': 1,
+         'ratsnest_hpwl': 1.0}
+    assert better(a, b), "failures must still decide, regardless of ratsnest"
+    c = dict(a, failures=2)
+    assert not better(c, b), "equal failures + equal iterations must not flip"
+
+
+def test_place_optimize_emits_a_parseable_json_summary():
+    import tempfile
+    fd, out = tempfile.mkstemp(suffix='.kicad_pcb')
+    os.close(fd)
+    r = subprocess.run([sys.executable, os.path.join(ROOT, 'place_optimize.py'),
+                        BOARD, out, '--max-displacement', '2', '--step', '1',
+                        '--max-passes', '1'],
+                       capture_output=True, text=True, cwd=ROOT)
+    assert r.returncode == 0, f"place_optimize failed:\n{r.stdout[-800:]}{r.stderr[-400:]}"
+    lines = [l for l in r.stdout.splitlines() if l.startswith('JSON_SUMMARY: ')]
+    assert lines, f"no JSON_SUMMARY emitted:\n{r.stdout[-800:]}"
+    d = json.loads(lines[-1].split('JSON_SUMMARY: ', 1)[1])
+    for key in ('parts_moved', 'crossings_before', 'crossings_after',
+                'hpwl_before', 'hpwl_after', 'airwire_length_before',
+                'airwire_length_after', 'overlap_area', 'oob_count'):
+        assert key in d, f"summary missing {key}: {sorted(d)}"
+    assert isinstance(d['crossings_after'], int)
+    print(f"  PASS: summary crossings {d['crossings_before']} -> {d['crossings_after']}")
+    for p in (out, os.path.splitext(out)[0] + '.kicad_pro'):
+        if os.path.exists(p):
+            os.unlink(p)
+
+
+TESTS = [
+    test_metrics_out_is_populated_and_matches_total_cost,
+    test_metrics_out_is_optional_and_non_breaking,
+    test_quench_only_improves_its_own_objective,
+    test_screen_disabled_by_default,
+    test_screen_fires_on_a_regression_beyond_the_threshold,
+    test_screen_fires_on_hpwl_too,
+    test_screen_lets_an_improvement_through,
+    test_screen_always_reports_its_numbers,
+    test_screen_is_inert_without_metrics,
+    test_screen_handles_a_zero_baseline,
+    test_better_ignores_the_ratsnest_keys,
+    test_place_optimize_emits_a_parseable_json_summary,
+]
+
+
+if __name__ == '__main__':
+    for t in TESTS:
+        print(f"--- {t.__name__}")
+        t()
+    print("ALL PASS")

--- a/tests/test_meander_net_width.py
+++ b/tests/test_meander_net_width.py
@@ -20,6 +20,7 @@ Covers:
 
 Run with:  python3 tests/test_meander_net_width.py
 """
+import math
 import os
 import sys
 
@@ -268,6 +269,41 @@ def test_diff_pair_widths():
         _fail(f"diff-pair wide net should pull meander back (base={base}, wide={wide})")
 
 
+def test_oval_pad_is_bounded_exactly_not_by_the_diagonal():
+    """#504 follow-up to #526: an OVAL pad is a stadium -- a rect with
+    semicircular ends -- so its farthest copper is the end cap on the long axis
+    and its exact bounding radius is max(sx,sy)/2, same as a circle. It has no
+    corner to reach.
+
+    _pad_bounding_radius originally special-cased only 'circle', so every oval
+    was inflated by up to sqrt(2). Oval is the shape of essentially every
+    through-hole pad: across kicad_files/ all 1225 of them were over-modelled,
+    mean +274um, worst +966um (kit-dev J201.2, 5.0x4.8: 2.5 -> 3.466). That
+    also contradicted the convention the rest of the repo applies -- see
+    check_drc, obstacle_map, obstacle_cache, and diff_pair_routing's
+    `short if pad.shape in ('circle','oval') else short * sqrt(2)`, which is
+    this same corner correction."""
+    from length_matching import _pad_bounding_radius
+
+    class _P:
+        def __init__(s, shape, sx, sy):
+            s.shape, s.size_x, s.size_y = shape, sx, sy
+
+    for shape, sx, sy in (('oval', 2.4, 2.4), ('oval', 5.0, 4.801),
+                          ('oval', 1.7, 3.4), ('circle', 1.7, 1.7)):
+        got = _pad_bounding_radius(_P(shape, sx, sy))
+        want = max(sx, sy) / 2.0
+        if abs(got - want) > 1e-9:
+            _fail(f"{shape} {sx}x{sy}: radius {got:.4f}, want exactly {want:.4f}")
+
+    # rect/roundrect must KEEP the half-diagonal -- that is #526's fix.
+    for shape in ('rect', 'roundrect'):
+        got = _pad_bounding_radius(_P(shape, 1.09, 1.14))
+        want = math.hypot(1.09, 1.14) / 2.0
+        if abs(got - want) > 1e-9:
+            _fail(f"{shape}: radius {got:.4f}, want the half-diagonal {want:.4f}")
+
+
 if __name__ == "__main__":
     test_single_ended_widths()
     test_own_width_override()
@@ -275,4 +311,5 @@ if __name__ == "__main__":
     test_diff_pair_widths()
     test_board_edge_keepout()
     test_pad_corner_reach()
+    test_oval_pad_is_bounded_exactly_not_by_the_diagonal()
     print("PASS  meander keep-out sized from actual net width (#175)")


### PR DESCRIPTION
Closes #504.

Two halves of #504, plus fixes for five defects in already-merged work — three of them mine from #456/#457, one from #526.

---

# #504 part 1 — export the metrics

The quench cost function computes airwire length and crossings on every pass, and #457 added `hpwl()`. All of it was printed and discarded, so nothing outside the optimizer could see what a placement run achieved.

- **`quench(..., metrics_out=d)`** fills `d` with `{'before', 'after', 'legality'}`. An **out-param, not a changed return** — the return is consumed positionally by both CLIs and four test files, one of which binds the signature with `inspect.signature`. Same note/consume shape as `plane_resistance`'s `consume_resistance_results` (#487), which exists for exactly this reason.
- **`place_optimize.py`** emits a `JSON_SUMMARY:` line. It had none at all, so a chain or grader can now gate on the numbers instead of scraping stdout.
- **`place_route_loop.py`** records `ratsnest_crossings` / `ratsnest_hpwl` / `ratsnest_length` per round, report-only beside the existing `pad_pairs_*` keys. **`better()` is deliberately untouched** — reworking the comparator is #458's scope, as both the issue and that comment say.

**Which numbers compare.** `crossings` (a raw count by contract) and `hpwl` are unweighted, so they compare across runs. `length` and `total` are scaled by `net_weights`, so they only compare between the `before` and `after` of the *same* call.

# #504 part 2 — the pre-route screen

`--ratsnest-screen N` (percent, `0` = disabled, the default) skips the routing run when a candidate's crossings or HPWL regress by more than N% against the board it came from.

**The baseline is free.** `quench` is handed the current best board, so its own `before` *is* that board's ratsnest — no second `QuenchState` (which re-reads the board for courtyards and locked refs) and no round-0 bootstrapping problem. It thresholds on crossings and HPWL only, for the weighting reason above. Every decision is logged with its numbers, per the issue's ask that it be auditable whether the screen ever skipped a placement that would have won.

Verified end to end on `splitflap_driver` with iterations capped to force failures:

```
Round 1: ratsnest: crossings 300->191 (-36.3%), hpwl 2504.44->2479.18 (-1.0%)
         -> failures=28   ACCEPTED (was failures=45)
Round 2: ratsnest: crossings 191->177 (-7.3%),  hpwl 2479.18->2462.21 (-0.7%)
         -> failures=11   ACCEPTED (was failures=28)
Ratsnest screen: 0 round(s) skipped the routing run at 5% regression.
```

Both rounds improved and both were correctly let through — nothing falsely screened — and the crossings drop tracked the failure drop (45 → 28 → 11).

---

# Five defects in merged work

Each verified by measurement here, not taken on report.

### D1 — the THT far-side box was transposed on rotated footprints *(mine, #456)*

`_through_pad_bounds_local` mixed **board-frame** `size_x/size_y` into the footprint **local** frame, then rotated again. `kicad_parser` swaps those for a pad at ~90°, so on every 90/270° footprint the box came out transposed:

| | modelled | truth |
|---|---|---|
| `kit-dev` `SW_ONOFF201` (rot 90°) | **2.54 × 13.97** | **3.81 × 12.70** |

That **under-blocks 1.27 mm** on exactly the rotated THT connectors, headers and switches the far-side rule exists to catch. Now projected through the pad's local tilt, the way `placement/utility.compute_footprint_bbox_local` already did it — 41 THT footprints on that board, 0 mismatches.

### D2 — the drill-offset correction was wrong in premise *(mine, #456)*

`local_x/local_y` is the pad **anchor**, and `kicad_parser` records `hole_x/hole_y` *before* shifting `global_x/global_y` to the copper centre — so `local_*` **is** the hole and the correction must be zero. The old code applied `(hole - global)`, which is *minus* the offset, landing the box a full offset on the wrong side. Correction deleted.

### D3 — oval pads inflated by up to √2 *(#526)*

`_pad_bounding_radius` special-cased only `'circle'`. An **oval is a stadium** — its farthest copper is the end cap, exact radius `max(sx,sy)/2`, no corner to reach.

**All 1225 ovals in `kicad_files/` were over-modelled, mean +274 µm, worst +966 µm** (`kit-dev` `J201.2`, 5.0×4.8: 2.5 → 3.466). Oval is the shape of essentially every through-hole pad, so this needlessly shrank meander amplitude on THT-heavy boards. It also contradicted this repo's convention at 12+ sites — notably `diff_pair_routing.py`'s `short if pad.shape in ('circle','oval') else short * sqrt(2)`, which is the *same* corner correction with oval on the exact side. `rect`/`roundrect` keep the half-diagonal, which is #526's actual fix.

### D4 — the hard gate and the grader disagreed *(mine, #456/#457)*

`candidate_valid`'s SMD/SMD fast path used the per-axis (L∞) test as the **verdict**, while `violation_parts` and `_halo_pair_penalty` use it only as an early-out and fall through to the **Euclidean** `rect_gap`. Two courtyards offset diagonally by (0.2, 0.2) at clearance 0.25 have a true gap of 0.283 — legal — but fail every axis.

So `violation() == 0` did **not** imply the hard gate passes, and #456's unfreeze branch could walk a part into a pose the ordinary gate forbids. This falsified the docstring I wrote claiming the two cannot disagree. The axis test is now an early-**out** only.

### D5 — a startup failure became silent *(mine, #457)*

`bga_fanout`'s `except Exception: pass` around a debug probe began swallowing `StartupCheckError`: before #457 the same failure was `SystemExit`, a `BaseException` that clause never caught. A missing dependency or stale Rust router is re-raised again.

### Hardening — not a fixed bug

`BoardOutlineGate.edges_near` derived its reach from the seed **rect's** centre, but a part rotates about its **origin**, so an off-centre courtyard's rect swings and the disk could miss an edge. A report claimed a 4× under-report on `watchy`; **my own sweep — every movable part × 4 rotations × 5 offsets — found zero divergence**, so I am stating this as hardening rather than a fix. `edges_near` now takes an optional `center=` and quench passes the pose origin, which bounds every rotation exactly.

---

# Tests

- **`tests/test_504_ratsnest_metrics.py`** — 12 cases: the out-param matches an independently built `QuenchState.total_cost()`, the return stays non-breaking, screen threshold / zero-baseline / inert-without-metrics behaviour, `better()` unaffected by the new keys, and `place_optimize`'s summary parses.
- **6 screen cases in `test_458_loop_steering.py`** — its `_run_loop` harness gains `quench_metrics` and `route_calls`, so a test can assert `run_route` was **not** called on a screened round.
- **D1/D2/D4 regressions** in `test_456_side_and_outline.py`; **D3** in `test_meander_net_width.py` beside #526's own `test_pad_corner_reach` — verified to **fail** against the `'circle'`-only form.

# Verification

- `run_all.py --fast` → **182 passed, 2 failed**; both remaining failures (`test_500_staggered_not_a_ball_grid`, `test_orphan_island_cleanup`) occur identically at `aa0c7cf` and are unrelated.
- `pytest tests/ --collect-only` → **281 tests, 0 errors**.
- Manifest→plan parity 0 mismatches; CLI post-pass coverage 0 failures.
- `watchy` legality is **unchanged** by D4 (overlap 9.10 → 0.23 mm², oob 13 → 3), so the README figures stand.

**No GUI work.** `kicad_routing_plugin/` has zero references to `quench`, `QuenchState`, `place_optimize` or `place_route_loop`, and neither script is in the parity gate's `CLI_MAINS` — stated explicitly because CLAUDE.md tells a reviewer to grep there.
