### PR TITLE
route: net in both --nets and --rip-existing-nets is re-routed (automates the #515 recipe)

### DIFF
--- a/route.py
+++ b/route.py
@@ -851,25 +851,36 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
         _write_passthrough_output(input_file, output_file)
         return 0, 0, 0.0
 
-    net_ids, _already_routed = filter_already_routed(pcb_data, net_ids, config)
-    # #515: --rip-existing-nets only rips copper that BLOCKS a net being
-    # routed; a net dropped here as already-connected never routes, so naming
-    # it in both --nets and --rip-existing-nets is a no-op. Warn instead of
-    # staying silent (the flag for a true rip+re-route was declined in #515;
-    # recipe: delete the net's copper first, then route it normally).
-    if rip_existing_nets and net_names:
-        from net_queries import matches_net_filter as _mnf_ripwarn
-        _rip_noop = [n for n, _reason in _already_routed
-                     if not _reason.startswith('Only')
-                     and _mnf_ripwarn(n, rip_existing_nets)]
-        if _rip_noop:
-            print(f"WARNING: {len(_rip_noop)} net(s) named in both --nets and "
-                  f"--rip-existing-nets are already fully connected and will "
-                  f"NOT be re-routed ({', '.join(_rip_noop[:6])}"
-                  f"{', ...' if len(_rip_noop) > 6 else ''}). "
-                  f"--rip-existing-nets only rips nets that block another "
-                  f"route; to force a fresh re-route, delete the net's copper "
-                  f"first and route it again (#515).")
+    # #515 follow-up: a net named in BOTH --nets and --rip-existing-nets is an
+    # explicit request to REPLACE its existing (connected-but-unwanted) route.
+    # The #515 warning documented the manual recipe ("delete the net's copper
+    # first, then route it normally") -- this automates exactly that recipe for
+    # exactly that flag combination: the net re-enters the route set and its
+    # copper is pre-stripped so the router replans from scratch. Nets matched
+    # by --rip-existing-nets but NOT selected by --nets keep the #515
+    # blocking-rip-only semantics unchanged.
+    net_ids, _ = filter_already_routed(pcb_data, net_ids, config,
+                                       force_route_patterns=rip_existing_nets)
+    prestripped_segments: List = []
+    prestripped_vias: List = []
+    if rip_existing_nets:
+        from net_queries import matches_net_filter as _mnf71
+        _rip_ids = {nid for name, nid in net_ids
+                    if _mnf71(name, rip_existing_nets)}
+        if _rip_ids:
+            prestripped_segments = [s for s in pcb_data.segments
+                                    if s.net_id in _rip_ids]
+            prestripped_vias = [v for v in pcb_data.vias if v.net_id in _rip_ids]
+        if prestripped_segments or prestripped_vias:
+            pcb_data.segments = [s for s in pcb_data.segments
+                                 if s.net_id not in _rip_ids]
+            pcb_data.vias = [v for v in pcb_data.vias if v.net_id not in _rip_ids]
+            _names = sorted({pcb_data.nets[n].name for n in _rip_ids
+                             if n in pcb_data.nets})
+            print(f"Pre-route rip: stripped {len(prestripped_segments)} "
+                  f"segment(s) / {len(prestripped_vias)} via(s) from "
+                  f"{len(_names)} net(s) selected for re-route: "
+                  f"{', '.join(_names[:6])}")
     if not net_ids:
         print("All nets are already fully connected - nothing to route!")
         if return_results:
@@ -1807,6 +1818,17 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
         stale_input_vias = list(stale_input_vias) + \
             [v for v in state.tap_relocation_removed_vias
              if id(v) not in _known_trv]
+    # #71: pre-route-ripped originals were removed from pcb_data before the
+    # originals snapshot, so no strip computation above can see them -- merge
+    # explicitly or the writer re-emits them from the input text.
+    if prestripped_segments:
+        _known_ps = {id(s) for s in dead_end_input_segments}
+        dead_end_input_segments = list(dead_end_input_segments) + \
+            [s for s in prestripped_segments if id(s) not in _known_ps]
+    if prestripped_vias:
+        _known_pv = {id(v) for v in stale_input_vias}
+        stale_input_vias = list(stale_input_vias) + \
+            [v for v in prestripped_vias if id(v) not in _known_pv]
     if state.tap_relocation_removed_segments or state.tap_relocation_removed_vias:
         print(f"Stripping {len(state.tap_relocation_removed_segments)} "
               f"segment(s) + {len(state.tap_relocation_removed_vias)} via(s) "

--- a/routing_common.py
+++ b/routing_common.py
@@ -308,10 +308,17 @@ def warn_targets_outside_board(pcb_data: PCBData,
 def filter_already_routed(
     pcb_data: PCBData,
     net_ids: List[Tuple[str, int]],
-    config: GridRouteConfig
+    config: GridRouteConfig,
+    force_route_patterns: Optional[List[str]] = None
 ) -> Tuple[List[Tuple[str, int]], List[Tuple[str, str]]]:
     """
     Filter out nets that are already fully connected.
+
+    force_route_patterns (#71): nets matching these patterns are routed even
+    when fully connected — --rip-existing-nets exists to REPLACE a connected-
+    but-violating route, and the downstream stale-input-copper strip (#220)
+    removes the old copper. Without this the skip fires first and a connected
+    net is unrippable.
 
     Uses check_net_connectivity for robust connectivity checking that handles:
     - Track-based connectivity with T-junctions
@@ -354,7 +361,12 @@ def filter_already_routed(
     already_routed = []
     nets_to_route = []
 
+    from net_queries import matches_net_filter
+
     for net_name, net_id in net_ids:
+        if force_route_patterns and matches_net_filter(net_name, force_route_patterns):
+            nets_to_route.append((net_name, net_id))
+            continue
         net_segments = segments_by_net.get(net_id, [])
         net_vias = vias_by_net.get(net_id, [])
         net_pads = pcb_data.pads_by_net.get(net_id, [])

--- a/tests/test_rip_forces_reroute.py
+++ b/tests/test_rip_forces_reroute.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Issue #71: --rip-existing-nets must force a CONNECTED net back into the
+route set.
+
+filter_already_routed graded any fully-connected net "Already fully connected"
+and skipped it BEFORE the rip patterns were consulted, so a connected-but-DRC-
+violating net (e.g. routed at 0.25mm from an HV corridor that requires 0.35)
+was unrippable: the only way to re-route it was hand-deleting its copper from
+the board text. force_route_patterns short-circuits the connectivity grade for
+rip-matched nets; route.py then pre-strips their copper (pre-route rip) so the
+router replans from scratch and the writer's removal lists drop the originals.
+
+    python3 tests/test_rip_forces_reroute.py
+"""
+import os
+import sys
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from routing_common import filter_already_routed
+
+
+def _pad(x, y, net, ref="R1"):
+    return SimpleNamespace(global_x=x, global_y=y, net_id=net,
+                           pad_type="smd", size_x=0.6, size_y=0.6,
+                           drill=0.0, layers=["F.Cu"],
+                           component_ref=ref, pad_number="1",
+                           shape="rect", rect_rotation=0.0,
+                           roundrect_rratio=0.0, polygons=None)
+
+
+def _seg(x1, y1, x2, y2, net, layer="F.Cu"):
+    return SimpleNamespace(start_x=x1, start_y=y1, end_x=x2, end_y=y2,
+                           width=0.15, layer=layer, net_id=net)
+
+
+def _board():
+    # net 7 "VIOLATOR": two pads joined by one segment => fully connected
+    pads = [_pad(0.0, 0.0, 7), _pad(5.0, 0.0, 7)]
+    segs = [_seg(0.0, 0.0, 5.0, 0.0, 7)]
+    net = SimpleNamespace(name="VIOLATOR", net_id=7, pads=pads)
+    return SimpleNamespace(
+        nets={7: net}, pads_by_net={7: pads}, segments=segs, vias=[],
+        zones=[], footprints=[], board_outlines=[])
+
+
+def main():
+    pcb = _board()
+    net_ids = [("VIOLATOR", 7)]
+    cfg = SimpleNamespace(layers=["F.Cu", "B.Cu"])
+
+    to_route, skipped = filter_already_routed(pcb, net_ids, cfg)
+    assert to_route == [], "baseline: connected net must be skipped"
+    assert skipped and skipped[0][0] == "VIOLATOR"
+
+    to_route, skipped = filter_already_routed(
+        pcb, net_ids, cfg, force_route_patterns=["VIOLATOR"])
+    assert to_route == [("VIOLATOR", 7)], \
+        "rip-matched connected net must re-enter the route set (#71)"
+
+    to_route, _ = filter_already_routed(
+        pcb, net_ids, cfg, force_route_patterns=["OTHER_*"])
+    assert to_route == [], "non-matching pattern must not force-route"
+
+    print("OK: #71 rip forces connected net back into the route set")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
#515 declined a general force-reroute flag and added a warning documenting the manual recipe: *delete the net's copper first, then route it normally*. This PR automates exactly that recipe, for exactly the flag combination the warning fires on — naming a net in **both** `--nets` and `--rip-existing-nets` is an explicit request to replace its existing route.

- `filter_already_routed` gains `force_route_patterns`: rip-matched *selected* nets skip the already-connected grade and re-enter the route set.
- Their copper is pre-stripped from `pcb_data` before the originals snapshot, so the router replans from scratch; the stripped originals are merged into the writer's removal lists (the writer copies the input file verbatim, so pcb_data removal alone would still ship the old copper).
- Nets matched by `--rip-existing-nets` but **not** selected by `--nets` keep #515's blocking-rip-only semantics unchanged — no behavior change outside the previously-warned no-op case.

Motivation: a connected-but-DRC-violating route (ours squeaked past a 0.35 mm HV clearance corridor at 0.25 mm) previously required hand-editing the board file to get the router to touch it. This also unlocks a useful post-route quality pass: per-net isolated rip+reroute, keeping the result only when strictly shorter.

Test: `tests/test_rip_forces_reroute.py`; functionally verified on a 6-layer 82-net board (rip → replan → clean DRC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)