### PR TITLE
parser + endpoints: uuid-less copper parses; copper-group vias are route terminals

### DIFF
--- a/connectivity.py
+++ b/connectivity.py
@@ -1028,6 +1028,32 @@ def _get_net_endpoints_ordered(pcb_data: PCBData, net_id: int, config: GridRoute
                         if (gx1, gy1) != (gx2, gy2):
                             targets.append((gx2, gy2, layer_idx, seg.end_x, seg.end_y))
 
+                # #72: each group's VIAS are terminals on every routing layer
+                # (a via spans the whole stack). Without this, a group whose
+                # segments all sit on layers OUTSIDE config.layers -- e.g. an
+                # F.Cu pad stub + escape via, routed with --layers In2/In3 --
+                # contributes no endpoint at all and the net is unroutable
+                # even though its via is reachable on every inner layer.
+                # Case 2 below has done this for years; Case 1 never did.
+                def _group_vias(g):
+                    pts = set()
+                    for _sg in g:
+                        pts.add((round(_sg.start_x, POSITION_DECIMALS),
+                                 round(_sg.start_y, POSITION_DECIMALS)))
+                        pts.add((round(_sg.end_x, POSITION_DECIMALS),
+                                 round(_sg.end_y, POSITION_DECIMALS)))
+                    return [v for v in net_vias
+                            if any(abs(v.x - px) < 0.05 and abs(v.y - py) < 0.05
+                                   for px, py in pts)]
+                for _vlist, _side in ((_group_vias(source_segs), sources),
+                                      (_group_vias(target_segs), targets)):
+                    for via in _vlist:
+                        gx, gy = coord.to_grid(via.x, via.y)
+                        for layer in config.layers:
+                            layer_idx = layer_map.get(layer)
+                            if layer_idx is not None:
+                                _side.append((gx, gy, layer_idx, via.x, via.y))
+
             if sources and targets:
                 return sources, targets, None
 

--- a/kicad_parser.py
+++ b/kicad_parser.py
@@ -2459,7 +2459,11 @@ def extract_vias(content: str, name_to_id: Dict[str, int] = None) -> List[Via]:
     # without it a LOCKED via matched nothing at all (the segment-side #150
     # bug, via edition): never an obstacle, never protected.
     # (via blind ...) / (via micro ...): the type token precedes (at ...)
-    via_pattern = r'\(via\s+(?:blind\s+|micro\s+)?\(at\s+([\d.-]+)\s+([\d.-]+)\)\s+\(size\s+([\d.-]+)\)\s+\(drill\s+([\d.-]+)\)\s+\(layers\s+"([^"]+)"\s+"([^"]+)"\)\s+(?:\(locked\s+yes\)\s+)?(?:\(free\s+(yes|no)\)\s+)?(?:\(locked\s+yes\)\s+)?\(net\s+(\d+)\)\s+\(uuid\s+"([^"]+)"\)'
+    # uuid OPTIONAL: KiCad accepts uuid-less vias, and tool-injected copper
+    # often omits it. A required uuid silently DROPPED such vias from the
+    # model -- the router then planned straight through real barrels.
+    via_pattern = r'\(via\s+(?:blind\s+|micro\s+)?\(at\s+([\d.-]+)\s+([\d.-]+)\)\s+\(size\s+([\d.-]+)\)\s+\(drill\s+([\d.-]+)\)\s+\(layers\s+"([^"]+)"\s+"([^"]+)"\)\s+(?:\(locked\s+yes\)\s+)?(?:\(free\s+(yes|no)\)\s+)?(?:\(locked\s+yes\)\s+)?\(net\s+(\d+)\)(?:\s+\(uuid\s+"([^"]+)"\))?'
+
 
     for m in re.finditer(via_pattern, content, re.DOTALL):
         free_value = m.group(7)  # "yes", "no", or None
@@ -2470,7 +2474,7 @@ def extract_vias(content: str, name_to_id: Dict[str, int] = None) -> List[Via]:
             drill=float(m.group(4)),
             layers=[m.group(5), m.group(6)],
             net_id=int(m.group(8)),
-            uuid=m.group(9),
+            uuid=m.group(9) or "",
             free=(free_value == "yes"),
             locked='(locked yes)' in m.group(0)
         )
@@ -2702,7 +2706,8 @@ def extract_segments(content: str, name_to_id: Dict[str, int] = None) -> List[Se
     # emits it between width/layer or layer/net, so allow it at both spots -
     # otherwise a locked track parses to nothing, never becomes an obstacle, and
     # the router lays copper straight through it (issue #150).
-    segment_pattern = r'\(segment\s+\(start\s+([\d.-]+)\s+([\d.-]+)\)\s+\(end\s+([\d.-]+)\s+([\d.-]+)\)\s+\(width\s+([\d.-]+)\)\s+(?:\(locked\s+yes\)\s+)?\(layer\s+"([^"]+)"\)\s+(?:\(locked\s+yes\)\s+)?\(net\s+(\d+)\)\s+\(uuid\s+"([^"]+)"\)'
+    # uuid OPTIONAL (#74), same reason as the via pattern above.
+    segment_pattern = r'\(segment\s+\(start\s+([\d.-]+)\s+([\d.-]+)\)\s+\(end\s+([\d.-]+)\s+([\d.-]+)\)\s+\(width\s+([\d.-]+)\)\s+(?:\(locked\s+yes\)\s+)?\(layer\s+"([^"]+)"\)\s+(?:\(locked\s+yes\)\s+)?\(net\s+(\d+)\)(?:\s+\(uuid\s+"([^"]+)"\))?'
 
     for m in re.finditer(segment_pattern, content, re.DOTALL):
         segment = Segment(
@@ -2713,7 +2718,7 @@ def extract_segments(content: str, name_to_id: Dict[str, int] = None) -> List[Se
             width=float(m.group(5)),
             layer=m.group(6),
             net_id=int(m.group(7)),
-            uuid=m.group(8),
+            uuid=m.group(8) or "",
             # Store original strings for exact file matching
             start_x_str=m.group(1),
             start_y_str=m.group(2),

--- a/tests/test_group_vias_as_terminals.py
+++ b/tests/test_group_vias_as_terminals.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Issue #72: Case-1 copper groups must expose their VIAS as route terminals.
+
+get_net_endpoints Case 1 (two+ copper groups) emitted only segment endpoints,
+each bound to its segment's layer. A group whose segments all sit on layers
+OUTSIDE config.layers -- the canonical shape: an F.Cu pad stub ending in an
+escape via, routed with --layers In2/In3 to duck under an HV corridor --
+contributed no endpoint at all and the net was unroutable, even though its
+via is reachable on every inner layer. Case 2 has added vias for years.
+
+    python3 tests/test_group_vias_as_terminals.py
+"""
+import os
+import sys
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "rust_router"))
+
+from connectivity import get_net_endpoints
+
+
+def _seg(x1, y1, x2, y2, layer="F.Cu", net=5):
+    return SimpleNamespace(start_x=x1, start_y=y1, end_x=x2, end_y=y2,
+                           width=0.1, layer=layer, net_id=net)
+
+
+def _via(x, y, net=5):
+    return SimpleNamespace(x=x, y=y, size=0.25, drill=0.15, net_id=net,
+                           layers=["F.Cu", "B.Cu"])
+
+
+def _pad(x, y, net=5, ref="J1"):
+    return SimpleNamespace(global_x=x, global_y=y, net_id=net,
+                           pad_type="smd", size_x=0.2, size_y=0.7,
+                           drill=0.0, layers=["F.Cu"], component_ref=ref,
+                           pad_number="1", shape="rect", rect_rotation=0.0,
+                           roundrect_rratio=0.0, polygons=None)
+
+
+def main():
+    # Two groups, both entirely on F.Cu, each ending in a via:
+    #   group A: pad(10,10) + stub to via(12,10)
+    #   group B: pad(40,40) + stub to via(38,40)
+    pads = [_pad(10, 10, ref="J1"), _pad(40, 40, ref="R2")]
+    segs = [_seg(10, 10, 12, 10), _seg(40, 40, 38, 40)]
+    vias = [_via(12, 10), _via(38, 40)]
+    net = SimpleNamespace(name="THERM", net_id=5, pads=pads)
+    pcb = SimpleNamespace(nets={5: net}, pads_by_net={5: pads},
+                          segments=segs, vias=vias, zones=[], footprints=[],
+                          board_outlines=[], board_info=None)
+
+    # Inner layers only: F.Cu segment endpoints all drop out; only the vias
+    # can carry terminals.
+    cfg = SimpleNamespace(layers=["In2.Cu", "In3.Cu"], grid_step=0.05)
+    sources, targets, err = get_net_endpoints(pcb, 5, cfg)
+    assert err is None, f"unexpected error: {err}"
+    assert sources and targets, \
+        "via-anchored groups must produce terminals on inner layers (#72)"
+    src_xy = {(round(s[3], 2), round(s[4], 2)) for s in sources}
+    tgt_xy = {(round(t[3], 2), round(t[4], 2)) for t in targets}
+    assert src_xy in ({(12.0, 10.0)}, {(38.0, 40.0)}), src_xy
+    assert tgt_xy in ({(12.0, 10.0)}, {(38.0, 40.0)}) and tgt_xy != src_xy
+    layer_idxs = {s[2] for s in sources} | {t[2] for t in targets}
+    assert layer_idxs == {0, 1}, \
+        f"via terminals must exist on every routing layer, got {layer_idxs}"
+
+    print("OK: #72 Case-1 group vias serve as terminals on all routing layers")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_parse_uuidless_copper.py
+++ b/tests/test_parse_uuidless_copper.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Issue #74: uuid-less segments and vias must parse.
+
+KiCad accepts copper without a (uuid ...) token, and tool-injected copper
+(stitch vias, escape stubs) frequently omits it. The strict via/segment
+patterns required uuid, so such copper was SILENTLY absent from the model:
+the router planned straight through real via barrels (AQM-1K Tier-1: 52 of
+203 vias invisible; a +3V3 reroute crossed an invisible GND stitch via at
+0.014mm), and same-net vias could not serve as route terminals.
+
+    python3 tests/test_parse_uuidless_copper.py
+"""
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "rust_router"))
+
+from kicad_parser import parse_kicad_pcb
+
+BOARD = """(kicad_pcb (version 20241229) (generator "test")
+  (general (thickness 1.6))
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (44 "Edge.Cuts" user)
+  )
+  (net 0 "")
+  (net 1 "SIG")
+  (net 2 "GND")
+  (segment (start 10 10) (end 20 10) (width 0.2) (layer "F.Cu") (net 1) (uuid "aaaa"))
+  (segment (start 20 10) (end 30 10) (width 0.2) (layer "F.Cu") (net 1))
+  (via (at 30 10) (size 0.6) (drill 0.3) (layers "F.Cu" "B.Cu") (net 1) (uuid "bbbb"))
+  (via (at 15 12) (size 0.25) (drill 0.15) (layers "F.Cu" "B.Cu") (net 2))
+)
+"""
+
+
+def main():
+    with tempfile.NamedTemporaryFile("w", suffix=".kicad_pcb",
+                                     delete=False) as f:
+        f.write(BOARD)
+        path = f.name
+    try:
+        pcb = parse_kicad_pcb(path)
+    finally:
+        os.unlink(path)
+
+    assert len(pcb.segments) == 2, \
+        f"expected 2 segments (1 uuid-less), got {len(pcb.segments)}"
+    assert len(pcb.vias) == 2, \
+        f"expected 2 vias (1 uuid-less), got {len(pcb.vias)}"
+    uuidless_via = [v for v in pcb.vias if v.net_id == 2]
+    assert uuidless_via and uuidless_via[0].size == 0.25
+    assert uuidless_via[0].uuid == ""
+    uuidless_seg = [s for s in pcb.segments if s.start_x == 20.0]
+    assert uuidless_seg and uuidless_seg[0].uuid == ""
+
+    print("OK: #74 uuid-less segments and vias parse")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Two connectivity-model fixes, found together on a real 6-layer board:

**1. `kicad_parser`: uuid-less segments/vias silently vanish.** The via/segment regexes require a `(uuid ...)` token, but KiCad itself accepts uuid-less copper, and tool-injected copper (stitch vias, escape stubs, scripts) often omits it. Such items are silently absent from the model — measured 52 of 203 vias invisible on one board, with the router then planning a track 0.014 mm from an invisible via barrel (a manufactured short that no stage could see). uuid is now an optional group in both patterns (rebased over the new `(locked yes)` handling — both compose).

**2. `get_net_endpoints` Case 1: copper-group vias are not terminals.** With two+ copper groups, only segment endpoints are emitted, each bound to its segment's layer. A group whose segments sit entirely outside `--layers` — canonical shape: an F.Cu pad stub ending in an escape via, routed `--layers In2.Cu In3.Cu` to duck under an HV corridor — contributes no endpoint at all and the net is unroutable, even though its via is reachable on every inner layer. Case 2 (one group + unconnected pads) has emitted vias as all-layer endpoints for years; Case 1 now does the same, with vias associated to their group by proximity to its segment endpoints.

Tests: `tests/test_parse_uuidless_copper.py`, `tests/test_group_vias_as_terminals.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)