### PR TITLE
#459 step 1: placement blocks, and rigid block translation

### DIFF
--- a/docs/placement-optimization.md
+++ b/docs/placement-optimization.md
@@ -207,8 +207,14 @@ precedent), which is simpler and may capture most of the value:
     now modelled by the clearance/halo terms (#456): a part occupies its own
     side with its courtyard and the far side only with its drilled-pad box, so
     cross-side parts no longer collide or repel — but nothing flips a part.
-  - *rigid-group moves*: an IC plus its decoupling caps moves/rotates as one
-    super-component
+  - *rigid-group moves*: an IC plus its decoupling caps moves as one
+    super-component. **Translation is implemented** (`--group-by`, #459);
+    rigid *rotation* of a block is not. Blocks come from KiCad `(group ...)`,
+    the schematic sheet path, net-name prefixes, or decap-to-IC tethering —
+    see `placement/groups.py`. Off by default. The block is capped so every
+    member stays within `--max-displacement` of its own seed, which keeps the
+    neighbour-list pruning exact; the unbounded block relocation #459 also
+    describes (an 80mm move) is separate, unimplemented work.
 - **Constraints by construction, not penalty** (the discipline from analog-IC
   placement and Synopsys ICC relative-placement groups: encode constraints
   into the move generator so every perturbation is feasible, rather than
@@ -222,7 +228,12 @@ precedent), which is simpler and may capture most of the value:
     (`placement/legality.py`, #456). A part sitting off the board is not frozen:
     it may move strictly back toward the board. An overlapping one still may
     only move to a fully legal pose.
-  - decaps tethered to their IC (group membership or hard radius)
+  - decaps tethered to their IC. **Implemented as a grouping source**
+    (`--group-by decap`, #459): a 2-pad cap within 5mm of an IC's bounding box
+    AND sharing a net with it. Both halves matter — across the corpus a cap sits
+    0.0-2.6mm (median) from the nearest IC and shares a net with it 93-100% of
+    the time, and the net check is what rejects the rest (13 of ulx3s' 70). It
+    makes the block move together; it is not a constraint on the per-part nudge.
   - rotation disabled per-class where assembly conventions matter
     (`--no-rotate`, which also restricts same-footprint swaps to equal-angle
     pairs, since a swap exchanges full poses)

--- a/kicad_parser.py
+++ b/kicad_parser.py
@@ -325,6 +325,16 @@ class Footprint:
     # The parser RESOLVES the inheritance into each pad's local_clearance at
     # parse time, so clearance consumers only ever read pad.local_clearance;
     # this field records the raw footprint value for fidelity (issue #326).
+    uuid: str = ""  # The footprint's own (uuid ...). KiCad's (group ...) blocks
+    # list their members BY UUID, so placement grouping (#459) needs it to
+    # resolve membership; it is also already the fallback dict key for a
+    # reference-less footprint ("#" + uuid), so both parse paths must agree.
+    sheet_path: str = ""  # (path "/sheet-uuid/.../symbol-uuid"). The LAST
+    # component is the symbol; the prefix is the schematic sheet, which is the
+    # functional block a floorplan thinks in and the most widely available
+    # grouping signal (12 of 22 corpus boards with paths have >1 sheet, where
+    # NONE has a (group ...) block). A bare single-uuid path is top level, i.e.
+    # an EMPTY sheet prefix -- those must not collapse into one bogus block.
     net_tie_groups: List[List[str]] = field(default_factory=list)
     # KiCad (net_tie_pad_groups "1,2" ...): pad-number groups this footprint
     # DELIBERATELY shorts (Kelvin shunts, net-tie parts). KiCad exempts copper
@@ -408,6 +418,14 @@ class PCBData:
     # per-layer clearance rules. parse_kicad_pcb sets it from its argument;
     # build_pcb_data_from_board from board.GetFileName().
     source_path: str = ""
+    # #459: KiCad (group "name" (uuid ...) (members <uuid> ...)) blocks, as
+    # {group name: [footprint reference, ...]}. The designer's own statement that
+    # these parts belong together, so placement grouping ranks it above any
+    # inferred signal. Members are stored by uuid in the file and resolved
+    # against Footprint.uuid here; non-footprint members (zones, graphics) are
+    # dropped. Empty on every board in the corpus -- no in-repo board uses
+    # groups -- so consumers must treat absence as normal, not as an error.
+    groups: Dict[str, List[str]] = field(default_factory=dict)
 
     def net_tie_exempt_pad_ids(self, net_id: int):
         """id()s of pads whose keep-out copper of `net_id` may IGNORE.
@@ -2208,6 +2226,19 @@ def extract_footprints_and_pads(content: str, nets: Dict[int, Net], name_to_id: 
                 if len(pads_in_group) >= 2:
                     net_tie_groups.append(pads_in_group)
 
+        # Own uuid + schematic sheet path, for placement grouping (#459). Both
+        # sit in the footprint header; bound the uuid search to before the first
+        # child so a PAD's or graphic's own (uuid ...) cannot win.
+        _uid_end = len(fp_text)
+        for _tok in ('(pad', '(fp_', '(zone', '(model', '(property'):
+            _i = fp_text.find(_tok)
+            if _i != -1:
+                _uid_end = min(_uid_end, _i)
+        _fp_uid = re.search(r'\(uuid\s+"([^"]+)"', fp_text[:_uid_end])
+        fp_uuid = _fp_uid.group(1) if _fp_uid else ""
+        _path_m = re.search(r'\(path\s+"([^"]*)"', fp_text)
+        fp_path = _path_m.group(1) if _path_m else ""
+
         footprint = Footprint(
             reference=reference,
             footprint_name=fp_name,
@@ -2219,6 +2250,8 @@ def extract_footprints_and_pads(content: str, nets: Dict[int, Net], name_to_id: 
             dnp=is_dnp,
             locked=is_locked,
             clearance=fp_clearance,
+            uuid=fp_uuid,
+            sheet_path=fp_path,
             net_tie_groups=net_tie_groups
         )
 
@@ -2447,6 +2480,52 @@ def extract_footprints_and_pads(content: str, nets: Dict[int, Net], name_to_id: 
         footprints[reference] = footprint
 
     return footprints, pads_by_net
+
+
+
+def extract_groups(content: str, footprints: Dict[str, 'Footprint']) -> Dict[str, List[str]]:
+    """KiCad ``(group "name" (uuid ...) (members <uuid> ...))`` -> {name: [ref]}.
+
+    Groups are the designer's own statement that a set of parts belongs
+    together, which is why placement grouping ranks them above any inferred
+    signal (#459). Members are listed BY UUID; anything that does not resolve to
+    a footprint (a zone, a graphic, a nested group) is dropped rather than
+    guessed at.
+
+    Note the group's own ``(uuid ...)`` is its identity, NOT a member -- read the
+    members list explicitly rather than scooping every uuid in the block. The
+    block is bounded with find_matching_paren, not a flat regex, because
+    ``(members ...)`` is a nested s-expression (#113).
+
+    No board in the in-repo corpus has a single ``(group ...)`` block, so an
+    empty result is the normal case, not a parse failure.
+
+    A uuid is supposed to be unique, and in real KiCad exports it is -- but
+    hand-made and copy-pasted boards do repeat them (``cap_chain`` shares one
+    uuid across two footprints, and another across two more). A uuid->ref dict
+    would silently drop all but the last, so a member could resolve to the WRONG
+    part. Map to every ref that claims the uuid instead: they are genuinely
+    indistinguishable, and pulling both into the group is the conservative
+    reading.
+    """
+    by_uuid: Dict[str, List[str]] = {}
+    for ref, fp in footprints.items():
+        if fp.uuid:
+            by_uuid.setdefault(fp.uuid, []).append(ref)
+    out: Dict[str, List[str]] = {}
+    for m in re.finditer(r'\(group\s+"([^"]*)"', content):
+        block = content[m.start():find_matching_paren(content, m.start())]
+        mem = re.search(r'\(members\b', block)
+        if not mem:
+            continue
+        members = block[mem.start():find_matching_paren(block, mem.start())]
+        refs = [r for u in re.findall(r'"?([0-9a-fA-F-]{36})"?', members)
+                for r in by_uuid.get(u, ())]
+        if refs:
+            # Sorted + de-duplicated: this order reaches the placement engine,
+            # and anything that does must be deterministic (#457).
+            out[m.group(1)] = sorted(set(refs))
+    return out
 
 
 def extract_vias(content: str, name_to_id: Dict[str, int] = None) -> List[Via]:
@@ -3177,6 +3256,8 @@ def parse_kicad_pcb(filepath: str, guide_layer: str = "User.1",
     # Drop Edge.Cuts contours mis-classified as cutouts (they enclose pads).
     drop_pad_containing_cutouts(board_info, pads_by_net)
 
+    groups = extract_groups(content, footprints)
+
     return PCBData(
         board_info=board_info,
         nets=nets,
@@ -3189,6 +3270,7 @@ def parse_kicad_pcb(filepath: str, guide_layer: str = "User.1",
         net_id_to_name=net_id_to_name,
         guide_paths=guide_paths,
         keepout_zones=keepout_zones,
+        groups=groups,
         source_path=os.path.abspath(filepath) if filepath else ""
     )
 
@@ -3556,6 +3638,18 @@ def build_pcb_data_from_board(board, guide_layer: str = "User.1",
         except Exception:
             fp_net_tie = []
 
+        # Own uuid + sheet path (#459), the pcbnew mirrors of the text parser's
+        # (uuid ...) / (path ...). Defensive: both accessors have moved across
+        # KiCad versions, and a missing one must not take the whole parse down.
+        try:
+            fp_uuid = str(fp.m_Uuid.AsString())
+        except Exception:
+            fp_uuid = ""
+        try:
+            fp_path = str(fp.GetPath().AsString())
+        except Exception:
+            fp_path = ""
+
         footprint = Footprint(
             reference=reference,
             footprint_name=fp_name,
@@ -3567,6 +3661,8 @@ def build_pcb_data_from_board(board, guide_layer: str = "User.1",
             dnp=fp_dnp,
             locked=fp_locked,
             clearance=fp_clearance,
+            uuid=fp_uuid,
+            sheet_path=fp_path,
             net_tie_groups=fp_net_tie
         )
 
@@ -3957,6 +4053,21 @@ def build_pcb_data_from_board(board, guide_layer: str = "User.1",
     except Exception:
         pass
 
+    # --- KiCad (group ...) blocks (#459) ---
+    # Read from the board FILE rather than board.Groups(), for the same reason
+    # rule areas are above: it keeps this path bit-identical to parse_kicad_pcb's
+    # member resolution instead of maintaining a second uuid-walk against a SWIG
+    # API whose accessors move between KiCad versions. Best-effort -- an unsaved
+    # or missing file simply yields no groups, which is also the corpus norm.
+    groups = {}
+    try:
+        _bf = board.GetFileName()
+        if _bf:
+            with open(_bf, 'r', encoding='utf-8') as f:
+                groups = extract_groups(f.read(), footprints)
+    except Exception:
+        groups = {}
+
     # Drop Edge.Cuts contours mis-classified as cutouts (they enclose pads).
     drop_pad_containing_cutouts(board_info, pads_by_net)
 
@@ -3968,6 +4079,7 @@ def build_pcb_data_from_board(board, guide_layer: str = "User.1",
         segments=segments,
         pads_by_net=pads_by_net,
         zones=zones,
+        groups=groups,
         guide_paths=guide_paths,
         keepout_zones=keepout_zones,
         # #498 parity with parse_kicad_pcb: sibling-file discovery (.kicad_dru)

--- a/place_optimize.py
+++ b/place_optimize.py
@@ -21,6 +21,7 @@ import os
 
 from kicad_parser import parse_kicad_pcb
 import routing_defaults as defaults
+from placement.groups import GroupError, derive_groups, describe, parse_sources
 from placement.quench import quench
 from placement.writer import write_placed_output
 
@@ -87,6 +88,12 @@ Examples:
                         help="Disable same-footprint swap moves")
     parser.add_argument("--max-passes", type=int, default=10,
                         help="Max quench passes (default: 10)")
+    parser.add_argument("--group-by", default="none",
+                        help="Move blocks of parts as one rigid body. Comma "
+                             "list of: kicad (KiCad (group ...) blocks), sheet "
+                             "(schematic sheet), netprefix, decap (caps tethered "
+                             "to their IC); 'auto' = kicad,sheet "
+                             "(default: none, i.e. per-part moves only)")
     parser.add_argument("--verbose", "-v", action="store_true",
                         help="Print each accepted move")
 
@@ -106,6 +113,14 @@ Examples:
 
     print(f"Loading {args.input_file}...")
     pcb_data = parse_kicad_pcb(args.input_file)
+
+    try:
+        sources = parse_sources(args.group_by)
+    except GroupError as exc:
+        parser.error(str(exc))
+    blocks = derive_groups(pcb_data, sources) if sources else {}
+    if sources:
+        print(describe(blocks))
 
     ratsnest = {}
     placements = quench(
@@ -130,6 +145,7 @@ Examples:
         ignore_nets=args.ignore_nets,
         lock_refs=args.lock,
         metrics_out=ratsnest,
+        groups=blocks,
         verbose=args.verbose,
     )
 
@@ -142,6 +158,8 @@ Examples:
     before, after = ratsnest.get('before', {}), ratsnest.get('after', {})
     summary = {
         'parts_moved': len(placements),
+        'blocks': len(blocks),
+        'block_parts': sum(len(v) for v in blocks.values()),
         # UNWEIGHTED, comparable across runs.
         'crossings_before': before.get('crossings'),
         'crossings_after': after.get('crossings'),

--- a/place_route_loop.py
+++ b/place_route_loop.py
@@ -38,6 +38,7 @@ import sys
 
 from kicad_parser import parse_kicad_pcb
 import routing_defaults as defaults
+from placement.groups import GroupError, derive_groups, describe, parse_sources
 from placement.quench import quench
 from placement.writer import write_placed_output
 
@@ -349,6 +350,13 @@ def main():
                         help="Cost multiplier for failed nets: scales their "
                              "airwire length and any crossing they take part "
                              "in (default: 3.0)")
+    parser.add_argument("--group-by", default="none",
+                        help="Move blocks of parts as one rigid body. Comma "
+                             "list of: kicad, sheet, netprefix, decap; 'auto' = "
+                             "kicad,sheet (default: none). A targeted part pulls "
+                             "in its whole block, so a block is no longer "
+                             "half-frozen because its IC exceeds "
+                             "--max-target-pins")
     parser.add_argument("--ratsnest-screen", type=float, default=0.0,
                         help="Skip the routing run when a candidate placement's "
                              "airwire crossings or HPWL regress by more than "
@@ -384,6 +392,10 @@ def main():
         parser.error("--max-displacement must be >= 0")
     if args.ratsnest_screen < 0:
         parser.error("--ratsnest-screen must be >= 0 (0 disables it)")
+    try:
+        group_sources = parse_sources(args.group_by)
+    except GroupError as exc:
+        parser.error(str(exc))
     if args.swap_max_displacement is not None:
         if args.swap_max_displacement < 0:
             parser.error("--swap-max-displacement must be >= 0")
@@ -427,6 +439,20 @@ def main():
             print("No movable target parts - stopping.")
             break
 
+        # #459: a targeted part pulls in its whole block, so the block moves as
+        # one body instead of its members fighting each other -- and a block is
+        # no longer half-frozen because its IC exceeds --max-target-pins.
+        blocks = {}
+        if group_sources:
+            blocks = derive_groups(pcb_data, group_sources)
+            pulled = {r for refs in blocks.values() for r in refs
+                      if any(m in targets for m in refs)}
+            if pulled - targets:
+                print(f"  blocks pull in {len(pulled - targets)} more part(s)")
+            targets |= pulled
+            blocks = {n: r for n, r in blocks.items()
+                      if any(m in targets for m in r)}
+
         name_to_id = {net.name: nid for nid, net in pcb_data.nets.items()}
         net_weights = {name_to_id[n]: args.failed_net_weight
                        for n in best['failed_nets'] if n in name_to_id}
@@ -456,6 +482,7 @@ def main():
             ignore_nets=args.ignore_nets, lock_refs=args.lock,
             move_refs=targets, net_weights=net_weights,
             metrics_out=ratsnest,
+            groups=blocks,
             verbose=args.verbose,
         )
 

--- a/placement/README.md
+++ b/placement/README.md
@@ -142,6 +142,8 @@ python3 tests/test_458_quench_rotations.py   # rotation lattice, --no-rotate
 python3 tests/test_fanout_clearance.py       # cap clearance repair (#130)
 python3 tests/test_456_courtyard_parser.py   # courtyard shapes + silk bleed (#456)
 python3 tests/test_456_side_and_outline.py   # board side, real outline, graders (#456)
+python3 tests/test_459_groups.py             # block sources + parsing (#459)
+python3 tests/test_459_group_moves.py        # rigid block translation (#459)
 ```
 
 Quench output is reproducible across processes — the same board and arguments
@@ -187,12 +189,48 @@ better. The baseline is free — quench is handed the current best board, so its
 `before` *is* that board's ratsnest. Every decision is logged with its numbers, so
 it is auditable whether the screen ever skipped a placement that would have won.
 
+## Placement blocks (`groups.py`, #459)
+
+The per-part nudge cannot express "these parts need to travel together": an IC
+and its decoupling caps fight each other one at a time, because moving either
+alone worsens the pair. `--group-by` gives a block a **rigid translate** move —
+the whole body shifts by one offset.
+
+Sources, in precedence order, first match wins per part (a part is in at most one
+block):
+
+| source | what it is | corpus evidence |
+|---|---|---|
+| `kicad` | KiCad `(group ...)` blocks | **0 of 27** in-repo boards have one. Exact when present; verified against a synthetic fixture. |
+| `sheet` | schematic sheet path | **12 of 22** boards with `(path ...)` have >1 sheet. `ulx3s`: 10 blocks sized 83/34/23/20/20/12. The workhorse. |
+| `netprefix` | net-name prefix (`AUDIO_*`) | The **weakest** source. Raw prefixes are dominated by KiCad's auto-generated `Net-(U1-Pad)` names — one bogus bucket of up to 92 refs spanning 75mm — so those and power nets are excluded and a 20mm coherence gate applied. What survives is small but real: ulx3s 9 blocks, tigard 0. |
+| `decap` | 2-pad caps tethered to their IC | Strong. A cap sits 0.0–2.6mm (median) from the nearest IC and **shares a net with it 93–100%** of the time; the net check rejects the rest (13 of ulx3s' 70). |
+
+`--group-by auto` means `kicad,sheet`. Default is `none`: grouping is opt-in, and
+with it off the group phase never runs and output is byte-identical to the
+ungrouped engine — which is what lets every existing bit-identity test stand.
+
+**What actually moves.** Small blocks move; large ones do not. On
+`splitflap_driver` with `--group-by decap`, 6 blocks of 2–3 parts translate and
+the objective improves (total 4781.6 → 4689.7, crossings 211 → 208, HPWL
+2468.0 → 2436.3 against the ungrouped run). Sheet blocks of 16–83 parts moved on
+none of the boards tried — at a few mm of displacement a rigid shift of that many
+parts rarely finds a legal, improving offset. That is the expected shape: #459's
+80mm block *relocation* is separate, unimplemented work.
+
+**Why the cap is per-member.** Every member must land within `--max-displacement`
+of **its own seed**. That single rule is what keeps three existing guarantees
+true: `build_neighbor_lists`' pruning stays exact rather than lossy, the outline
+gate's per-ref cached reach cannot be outrun, and the no-stranding invariant
+holds unchanged. Lifting it is precisely what makes the 80mm case hard.
+
 ## Module layout
 
 | File | Purpose |
 |------|---------|
 | `quench.py` | The optimizer: cost terms, move generation, greedy quench |
 | `fanout_clearance.py` | Post-fanout decoupling-cap clearance repair (#130) |
+| `groups.py` | Placement blocks: which parts move as one rigid body (#459) |
 | `legality.py` | Hard constraints shared by both engines: board side, real Edge.Cuts containment, and the OO/OoB graders (#456) |
 | `parser.py` | Courtyard boundary and locked-footprint extraction |
 | `writer.py` | Writes new positions/rotations (rotates pad angles with the footprint, as KiCad stores pad angle = footprint + pad rotation) |

--- a/placement/groups.py
+++ b/placement/groups.py
@@ -1,0 +1,276 @@
+"""Placement blocks: which footprints should move as one rigid body (#459).
+
+The quench fixes what it can reach — individual parts within a few mm. The
+failures that sink a board are block-scale: a magnetics block 80mm from its
+endpoints, unroutable because of the floorplan rather than the routing. Before
+anything can *move* a block, something has to know what a block IS, and nothing
+in this repo did.
+
+Four sources, in precedence order, first match wins per footprint. Each is
+reported with its source so a user can see what was inferred before trusting it.
+
+    kicad      KiCad (group ...) blocks -- the designer's own statement that
+               these parts belong together, so it outranks everything inferred.
+    sheet      Schematic sheet path. A sheet IS the functional block a floorplan
+               thinks in, and it is declarative rather than guessed.
+    netprefix  Net-name prefix (AUDIO_*, GPDI_*), gated on spatial coherence.
+    decap      Two-pad capacitors tethered to the IC they decouple.
+
+CORPUS EVIDENCE (measured across kicad_files/, not assumed):
+
+  kicad      0 of 27 boards carry a single (group ...) block. Exact when present,
+             but no in-repo board exercises it end to end.
+  sheet      12 of 22 boards with (path ...) have more than one sheet. ulx3s: 11
+             sheets sized 83/34/23/20/20/12 footprints. glasgow_revC: 4, nested.
+             This is the workhorse.
+  decap      Median distance from a 2-pad cap to the nearest IC bbox is 0.0-2.6mm
+             across 8 boards, and the cap shares a net with that IC in 93-100% of
+             cases (e.g. glasgow 91/92, orangecrab 75/75, ulx3s 57/70). The
+             net-sharing check is what makes this safe: it is what separates "a
+             cap that decouples this IC" from "a cap that happens to sit nearby",
+             and on ulx3s it correctly rejects 13 of 70.
+  netprefix  The WEAKEST source, and it is worth saying so. Raw prefixes are
+             dominated by KiCad's auto-generated Net-(U1-Pad) names -- 21 to 92
+             refs per board under a bogus "NET" prefix, spread over 16-75mm.
+             With auto-generated and power names excluded and a 20mm coherence
+             gate, what remains is small but genuine: ulx3s 9 blocks / 63 refs
+             (AUDIO, GPDI, JTAG, LED, FPGA), orangecrab 13/80, glasgow 3/20,
+             rp2350 1 block of 3, tigard 0. Enable it expecting little.
+
+All output is sorted. Anything whose order can reach the optimizer must be
+deterministic, or quench output stops being reproducible across processes (#457).
+"""
+from __future__ import annotations
+
+import math
+import re
+from typing import Dict, List, Optional, Set, Tuple
+
+# --- decap tethering -------------------------------------------------------
+# 5mm from the IC's bounding box. The corpus median is 0.0-2.6mm and <5mm
+# captures essentially every real decoupling cap; kit-dev (a large, loosely
+# packed board) is the only one needing the full 5mm for 41 of its 53.
+DECAP_RADIUS_MM = 5.0
+DECAP_MIN_IC_PADS = 4          # what chip_boundary already calls "not a passive"
+
+# --- netprefix -------------------------------------------------------------
+# KiCad's auto-generated names carry no functional meaning: Net-(U1-Pad3),
+# unconnected-(U2-Pad7). Bucketing on them produces one enormous "NET" pseudo
+# block per board (up to 92 refs spread over 75mm), which is exactly the kind of
+# wrong group that is worse than no group at all -- it would rigidly drag half
+# the board.
+_AUTO_NET = re.compile(r'^(net-\(|unconnected-\(|net\d)', re.I)
+# Power and ground reach everywhere by design, so they say nothing about blocks.
+_POWER_NET = re.compile(r'^(a?gnd|dgnd|pgnd|vcc|vdd|vss|vee|vbus|vin|vout|vref|'
+                        r'pwr|\+|-|\d)', re.I)
+_PREFIX = re.compile(r'^([A-Za-z][A-Za-z0-9]+)[_\-]')
+NETPREFIX_MIN_REFS = 3
+# Max distance from the cluster centroid to any member. A prefix scattered wider
+# than this is a naming convention, not a physical block.
+NETPREFIX_MAX_SPREAD_MM = 20.0
+
+MIN_GROUP_SIZE = 2             # a block of one is not a block
+
+SOURCES = ('kicad', 'sheet', 'netprefix', 'decap')
+AUTO_SOURCES = ('kicad', 'sheet')   # the declarative ones
+
+
+class GroupError(ValueError):
+    """An unknown --group-by source."""
+
+
+def parse_sources(spec: Optional[str]) -> Tuple[str, ...]:
+    """'none' | 'auto' | comma list -> the ordered source tuple."""
+    if not spec or spec.strip().lower() in ('', 'none'):
+        return ()
+    out: List[str] = []
+    for tok in spec.split(','):
+        tok = tok.strip().lower()
+        if not tok:
+            continue
+        if tok == 'auto':
+            out.extend(s for s in AUTO_SOURCES if s not in out)
+            continue
+        if tok not in SOURCES:
+            raise GroupError(
+                f"unknown group source {tok!r}; choose from "
+                f"{', '.join(SOURCES)}, or 'auto' ({'+'.join(AUTO_SOURCES)}), "
+                f"or 'none'")
+        if tok not in out:
+            out.append(tok)
+    return tuple(out)
+
+
+def _centroid(fp) -> Tuple[float, float]:
+    pts = [(p.global_x, p.global_y) for p in fp.pads]
+    if not pts:
+        return (fp.x, fp.y)
+    return (sum(p[0] for p in pts) / len(pts),
+            sum(p[1] for p in pts) / len(pts))
+
+
+def _sheet_of(fp) -> str:
+    """The sheet prefix of a footprint's (path ...): everything but the LAST
+    uuid, which is the symbol itself. A bare single-uuid path is top level and
+    yields '' -- those must not all collapse into one bogus block."""
+    parts = [q for q in (fp.sheet_path or '').split('/') if q]
+    return '/'.join(parts[:-1])
+
+
+def _from_kicad(pcb_data, movable) -> Dict[str, List[str]]:
+    return {f"kicad:{name}": [r for r in refs if r in movable]
+            for name, refs in (pcb_data.groups or {}).items()}
+
+
+def _from_sheet(pcb_data, movable) -> Dict[str, List[str]]:
+    out: Dict[str, List[str]] = {}
+    for ref in movable:
+        fp = pcb_data.footprints.get(ref)
+        if fp is None:
+            continue
+        sheet = _sheet_of(fp)
+        if not sheet:          # top level: not a block
+            continue
+        out.setdefault(f"sheet:{sheet}", []).append(ref)
+    return out
+
+
+def _from_netprefix(pcb_data, movable) -> Dict[str, List[str]]:
+    buckets: Dict[str, Set[str]] = {}
+    for net_id, net in (pcb_data.nets or {}).items():
+        if net_id <= 0:
+            continue
+        leaf = (net.name or '').split('/')[-1]
+        if not leaf or _AUTO_NET.match(leaf) or _POWER_NET.match(leaf):
+            continue
+        m = _PREFIX.match(leaf)
+        if not m:
+            continue
+        for pad in net.pads:
+            if pad.component_ref in movable:
+                buckets.setdefault(m.group(1).upper(), set()).add(pad.component_ref)
+
+    out: Dict[str, List[str]] = {}
+    for prefix, refs in buckets.items():
+        if len(refs) < NETPREFIX_MIN_REFS:
+            continue
+        pts = [_centroid(pcb_data.footprints[r]) for r in refs
+               if r in pcb_data.footprints]
+        if len(pts) < NETPREFIX_MIN_REFS:
+            continue
+        cx = sum(p[0] for p in pts) / len(pts)
+        cy = sum(p[1] for p in pts) / len(pts)
+        # Spatial coherence: a prefix whose parts are scattered across the board
+        # is a naming convention, not something that can move as one body.
+        if max(math.hypot(p[0] - cx, p[1] - cy) for p in pts) > NETPREFIX_MAX_SPREAD_MM:
+            continue
+        out[f"net:{prefix}"] = sorted(refs)
+    return out
+
+
+def _from_decap(pcb_data, movable) -> Dict[str, List[str]]:
+    """Two-pad caps tethered to the IC they decouple.
+
+    Nearest IC by bounding-box distance, but ONLY when the cap shares a net with
+    it. Proximity alone is not enough -- on ulx3s 13 of 70 caps sit near an IC
+    they have no electrical relationship with, and dragging those along would be
+    a wrong group.
+    """
+    from chip_boundary import build_chip_list
+    chips = build_chip_list(pcb_data, min_pads=DECAP_MIN_IC_PADS)
+    if not chips:
+        return {}
+    ic_nets = {}
+    for c in chips:
+        fp = pcb_data.footprints.get(c.reference)
+        if fp is not None:
+            ic_nets[c.reference] = {p.net_id for p in fp.pads if p.net_id > 0}
+
+    out: Dict[str, List[str]] = {}
+    for ref in movable:
+        fp = pcb_data.footprints.get(ref)
+        if fp is None or not ref[:1].upper() == 'C':
+            continue
+        nets = {p.net_id for p in fp.pads if p.net_id > 0}
+        if len(nets) != 2:            # a decoupling cap bridges exactly two nets
+            continue
+        cx, cy = _centroid(fp)
+        best, best_d = None, None
+        for c in chips:
+            if c.reference == ref:
+                continue
+            x0, y0, x1, y1 = c.bounds
+            d = math.hypot(max(x0 - cx, cx - x1, 0.0), max(y0 - cy, cy - y1, 0.0))
+            if best_d is None or d < best_d:
+                best, best_d = c.reference, d
+        if best is None or best_d > DECAP_RADIUS_MM:
+            continue
+        if not (nets & ic_nets.get(best, set())):
+            continue              # near, but not electrically its cap
+        out.setdefault(f"decap:{best}", []).append(ref)
+    # The IC itself anchors the tether, so it belongs to the block.
+    for key, refs in out.items():
+        ic = key.split(':', 1)[1]
+        if ic in movable:
+            refs.append(ic)
+    return out
+
+
+_BUILDERS = {'kicad': _from_kicad, 'sheet': _from_sheet,
+             'netprefix': _from_netprefix, 'decap': _from_decap}
+
+
+def derive_groups(pcb_data, sources, movable=None) -> Dict[str, List[str]]:
+    """{group name: sorted [reference]} for the requested sources.
+
+    `movable` restricts membership to refs the caller is willing to move (locked
+    parts, or the loop's target set); None means every footprint.
+
+    Precedence is the order of `sources`, and a ref lands in at most ONE group:
+    an explicit KiCad group must not be torn apart by a later sheet or prefix
+    rule. Groups smaller than MIN_GROUP_SIZE after that are dropped.
+    """
+    if not sources:
+        return {}
+    if movable is None:
+        movable = set(pcb_data.footprints)
+    else:
+        movable = set(movable)
+
+    claimed: Set[str] = set()
+    out: Dict[str, List[str]] = {}
+    for src in sources:
+        builder = _BUILDERS.get(src)
+        if builder is None:
+            raise GroupError(f"unknown group source {src!r}")
+        for name, refs in sorted(builder(pcb_data, movable).items()):
+            members = sorted({r for r in refs if r not in claimed})
+            if len(members) < MIN_GROUP_SIZE:
+                continue
+            out[name] = members
+            claimed.update(members)
+    return out
+
+
+def _short(name: str) -> str:
+    """Readable form of a group key. Sheet keys are uuid paths -- KiCad's
+    Sheetname property is absent from every corpus board, so the uuid is all
+    there is; show its tail rather than 36 meaningless characters."""
+    src, _, rest = name.partition(':')
+    if src != 'sheet':
+        return name
+    return 'sheet:' + '/'.join(p[-8:] for p in rest.split('/') if p)
+
+
+def describe(groups: Dict[str, List[str]], limit: int = 8) -> str:
+    """One-line-per-block summary, for the run banner."""
+    if not groups:
+        return "  placement groups: none"
+    lines = [f"  placement groups: {len(groups)} block(s), "
+             f"{sum(len(v) for v in groups.values())} part(s)"]
+    for name, refs in sorted(groups.items(), key=lambda kv: (-len(kv[1]), kv[0]))[:limit]:
+        shown = ', '.join(refs[:6]) + (', ...' if len(refs) > 6 else '')
+        lines.append(f"    {_short(name)}  ({len(refs)}): {shown}")
+    if len(groups) > limit:
+        lines.append(f"    ... and {len(groups) - limit} more")
+    return '\n'.join(lines)

--- a/placement/quench.py
+++ b/placement/quench.py
@@ -408,19 +408,39 @@ class QuenchState:
 
     # ----- airwire helpers -------------------------------------------------
 
-    def _net_points(self, net_id, override_ref=None, override_pads=None):
+    def _net_points(self, net_id, override_ref=None, override_pads=None,
+                    overrides=None):
+        """A net's pad points, with any number of parts held at a HYPOTHETICAL
+        pose (#459).
+
+        `overrides` is {ref: pad_globals}; `override_ref`/`override_pads` are the
+        single-part spelling every existing caller uses. A rigid block move has
+        to override N parts at once, and the swap phase already needed two --
+        which it solved by hand-inlining a second copy of this loop, with a
+        comment warning that the two must not drift apart. This is that one
+        implementation.
+
+        The `for ref in self.net_refs[net_id]` iteration is load-bearing:
+        net_refs is a SORTED list and this order becomes the point order handed
+        to compute_mst_edges, whose tie-break is first-index-wins. Changing it
+        makes quench output vary across processes again (#457).
+        """
+        if overrides is None:
+            overrides = ({override_ref: override_pads}
+                         if override_ref is not None else {})
         pts = []
         for ref in self.net_refs[net_id]:
-            if ref == override_ref:
-                pts.extend((gx, gy) for gx, gy, n in override_pads if n == net_id)
-            else:
-                pts.extend((gx, gy) for gx, gy, n in self.parts[ref].pad_globals()
-                           if n == net_id)
+            pads = overrides.get(ref)
+            if pads is None:
+                pads = self.parts[ref].pad_globals()
+            pts.extend((gx, gy) for gx, gy, n in pads if n == net_id)
         return pts
 
-    def _build_net_airwires(self, net_id, override_ref=None, override_pads=None):
+    def _build_net_airwires(self, net_id, override_ref=None, override_pads=None,
+                            overrides=None):
         return _airwires_for_points(
-            self._net_points(net_id, override_ref, override_pads), net_id)
+            self._net_points(net_id, override_ref, override_pads, overrides),
+            net_id)
 
     def airwires_excluding(self, nets: Set[int]) -> np.ndarray:
         aws = []
@@ -830,6 +850,47 @@ class QuenchState:
         for net_id in part.nets:
             self.net_airwires[net_id] = self._build_net_airwires(net_id)
 
+    def apply_group_move(self, refs, dx, dy):
+        """Translate a whole block rigidly by (dx, dy) (#459).
+
+        Every member's pose is set FIRST, then each affected net is rebuilt once.
+        Calling apply_move per member would be correct but rebuilds a shared net
+        once per member that touches it, which on a 20-part block is most of the
+        cost of evaluating the move again.
+        """
+        nets = set()
+        for ref in refs:
+            part = self.parts[ref]
+            part.x += dx
+            part.y += dy
+            nets.update(part.nets)
+        self._inc_violation.clear()
+        for net_id in nets:
+            self.net_airwires[net_id] = self._build_net_airwires(net_id)
+
+    def group_move_valid(self, refs, dx, dy):
+        """Is a rigid translate of `refs` by (dx, dy) legal?
+
+        Intra-group pairs are EXCLUDED. Under a rigid translate the block's
+        internal geometry is invariant, so those pairs contribute exactly what
+        they did before the move -- but candidate_valid re-tests every pair, and
+        on a real board members routinely sit at sub-clearance courtyard gaps
+        already (watchy seeds 81 of 82 parts in violation), so without the
+        exclusion a block would veto its own every candidate. The swap phase uses
+        `exclude` in exactly this way.
+
+        Each member must also stay within its own seed cap, which is what keeps
+        build_neighbor_lists' pruning exact and the outline gate's cached reach
+        valid -- see the group phase in quench().
+        """
+        others = set(refs)
+        for ref in refs:
+            part = self.parts[ref]
+            if not self.candidate_valid(ref, part.x + dx, part.y + dy, part.rot,
+                                        exclude=others):
+                return False
+        return True
+
     def build_neighbor_lists(self, travel_budget):
         """Per-movable-part pruned neighbour lists (perf, mirrors the
         fanout_clearance pattern from #213 profiling). A movable part's live
@@ -904,6 +965,58 @@ class QuenchState:
             self._neighbors[ref] = lst
 
 
+def _group_offsets(state, refs, max_disp: float, step: float, grid_step: float):
+    """Rigid (dx, dy) offsets a whole block may take (#459).
+
+    The block translates as one body, so a single offset applies to every
+    member -- and the offset is admissible only if it keeps EVERY member within
+    `max_disp` of ITS OWN seed. That per-member seed cap is what makes the block
+    move safe to add without touching anything else:
+
+      * build_neighbor_lists' exactness argument is stated per part ("a movable
+        part's live position stays within travel_budget of its seed"), and stays
+        true, so the pruned neighbour lists remain exact rather than lossy;
+      * BoardOutlineGate.edges_near caches its reachable-edge list per ref on
+        first call, sized by that same budget -- a block allowed to travel
+        further would silently outrun the cache and skip the exact ring test;
+      * test_quench_swap_cap's no-stranding invariant ("no part further than
+        max_displacement + grid snap from where it started") keeps holding
+        unmodified.
+
+    Lifting that cap is what makes #459's 80mm relocation a separate piece of
+    work rather than a bigger number here.
+    """
+    n = int(max_disp / step)
+    if n <= 0:
+        return
+    seen = set()
+    for ix in range(-n, n + 1):
+        for iy in range(-n, n + 1):
+            if ix == 0 and iy == 0:
+                continue
+            dx, dy = ix * step, iy * step
+            if math.hypot(dx, dy) > max_disp + 1e-9:
+                continue
+            ok = True
+            for ref in refs:
+                p = state.parts[ref]
+                nx = snap_to_grid(p.x + dx, grid_step)
+                ny = snap_to_grid(p.y + dy, grid_step)
+                if math.hypot(nx - p.seed_x, ny - p.seed_y) > max_disp + 1e-9:
+                    ok = False
+                    break
+            if not ok:
+                continue
+            # Snap the OFFSET, so the block stays rigid: snapping each member
+            # independently would shear it by up to a grid step.
+            sdx = snap_to_grid(dx, grid_step)
+            sdy = snap_to_grid(dy, grid_step)
+            if (sdx, sdy) in seen or (sdx == 0.0 and sdy == 0.0):
+                continue
+            seen.add((sdx, sdy))
+            yield sdx, sdy
+
+
 def _candidate_positions(part: _Part, max_disp: float, step: float,
                          grid_step: float):
     """Grid of candidate centers within max_disp of the seed position."""
@@ -973,6 +1086,7 @@ def quench(pcb_data: PCBData, pcb_file: str,
            move_refs: Optional[Set[str]] = None,
            net_weights: Optional[Dict[int, float]] = None,
            metrics_out: Optional[Dict] = None,
+           groups: Optional[Dict[str, List[str]]] = None,
            verbose: bool = False) -> List[Dict]:
     """Greedy quench: iterate over parts, accept only cost-reducing moves.
 
@@ -997,6 +1111,12 @@ def quench(pcb_data: PCBData, pcb_file: str,
     count by contract; hpwl is pure pad geometry), so they are comparable
     across calls. `length` and `total` are scaled by net_weights, so they are
     only comparable between the before/after of the SAME call.
+
+    groups: optional {block name: [reference]} from placement.groups. Each block
+    gains a RIGID TRANSLATE move -- the whole body shifts by one offset, capped
+    so every member stays within max_displacement of its own seed (#459). Absent
+    or empty means no group phase runs and the result is byte-identical to the
+    ungrouped engine, which is why grouping is opt-in.
 
     Returns a list of placement dicts (reference/new_x/new_y/new_rotation)
     for every movable part, whether or not it moved.
@@ -1045,11 +1165,74 @@ def quench(pcb_data: PCBData, pcb_file: str,
     movable = [r for r, p in state.parts.items() if not p.locked]
     movable.sort(key=lambda r: state.parts[r].pin_count, reverse=True)
 
+    # --- placement blocks (#459) ---
+    # A block moves as one rigid body, which is the move the per-part nudge
+    # cannot express: an IC and its decoupling caps that need to travel together
+    # fight each other one part at a time, because moving either alone worsens
+    # the pair. Empty unless the caller asked for grouping, and when it is empty
+    # the group phase never runs and output is byte-identical to before.
+    blocks: Dict[str, List[str]] = {}
+    if groups:
+        movable_set = set(movable)
+        blocks = {name: [r for r in refs if r in movable_set]
+                  for name, refs in groups.items()}
+        blocks = {n: r for n, r in blocks.items() if len(r) >= 2}
+        if blocks and verbose:
+            from placement.groups import describe
+            print(describe(blocks))
+
     for pass_num in range(1, max_passes + 1):
         improved = 0.0
         moves = 0
+        group_moves = 0
         swaps_skipped = 0
         swaps_skipped_shape = 0
+
+        # --- rigid block translation (#459) ---
+        # Coarse before fine: a block that wants to be 2mm left is cheaper to fix
+        # here than by nudging twenty parts individually, and the per-part pass
+        # below then polishes inside the relocated block.
+        for name in sorted(blocks):
+            refs = blocks[name]
+            involved = set()
+            for r in refs:
+                involved.update(state.parts[r].nets)
+            other_aw = state.airwires_excluding(involved)
+            member_set = set(refs)
+
+            def eval_group(ddx, ddy):
+                ov = {r: state.parts[r].pad_globals(
+                    state.parts[r].x + ddx, state.parts[r].y + ddy,
+                    state.parts[r].rot) for r in refs}
+                subset = {n: state._build_net_airwires(n, overrides=ov)
+                          for n in sorted(involved)}
+                net_cost, _ = state.nets_cost(subset, other_aw)
+                # Intra-group geometry is invariant under a rigid translate, so
+                # excluding those pairs both avoids double-counting each internal
+                # halo pair and keeps the term comparable across candidates.
+                geo = sum(state.part_geometry_cost(
+                    r, state.parts[r].x + ddx, state.parts[r].y + ddy,
+                    state.parts[r].rot, exclude=member_set - {r}) for r in refs)
+                return net_cost + geo
+
+            base_cost = eval_group(0.0, 0.0)
+            best = (base_cost, 0.0, 0.0)
+            for ddx, ddy in _group_offsets(state, refs, max_displacement, step,
+                                           grid_step):
+                if not state.group_move_valid(refs, ddx, ddy):
+                    continue
+                c = eval_group(ddx, ddy)
+                if c < best[0] - EPS_IMPROVE:
+                    best = (c, ddx, ddy)
+            if best[0] < base_cost - EPS_IMPROVE:
+                improved += base_cost - best[0]
+                moves += 1
+                group_moves += 1
+                state.apply_group_move(refs, best[1], best[2])
+                if verbose:
+                    print(f"  block {name}: {len(refs)} parts moved "
+                          f"({best[1]:+.2f}, {best[2]:+.2f})mm "
+                          f"gain={base_cost - best[0]:.1f}")
 
         # --- single-part moves (nudge + rotate) ---
         for ref in movable:
@@ -1164,31 +1347,17 @@ def quench(pcb_data: PCBData, pcb_file: str,
                         other_aw = state.airwires_excluding(involved)
 
                         def eval_pair(ax, ay, arot, bx, by, brot):
-                            pads_a = pa.pad_globals(ax, ay, arot)
-                            pads_b = pb.pad_globals(bx, by, brot)
-                            subset = {}
-                            # Hand-inlined _net_points: that helper overrides ONE
-                            # ref's pads and a swap has to override two. It reads
-                            # the same state.net_refs, so it inherits the sorted
-                            # order fixed at construction (#457) -- if the two
-                            # ever diverge, the swap phase silently goes
-                            # nondeterministic again while the nudge phase looks
-                            # fine.
-                            for n in sorted(involved):
-                                pts = []
-                                for ref2 in state.net_refs[n]:
-                                    if ref2 == ra:
-                                        pts.extend((gx, gy) for gx, gy, nn in pads_a
-                                                   if nn == n)
-                                    elif ref2 == rb:
-                                        pts.extend((gx, gy) for gx, gy, nn in pads_b
-                                                   if nn == n)
-                                    else:
-                                        pts.extend(
-                                            (gx, gy) for gx, gy, nn in
-                                            state.parts[ref2].pad_globals()
-                                            if nn == n)
-                                subset[n] = _airwires_for_points(pts, n)
+                            # Two-part override through the shared helper. This
+                            # used to be a hand-inlined second copy of
+                            # _net_points, carrying a comment warning that the
+                            # two must not drift apart; _net_points now takes N
+                            # overrides (#459), so there is one implementation
+                            # and the sorted net_refs order (#457) is inherited
+                            # rather than re-typed.
+                            ov = {ra: pa.pad_globals(ax, ay, arot),
+                                  rb: pb.pad_globals(bx, by, brot)}
+                            subset = {n: state._build_net_airwires(n, overrides=ov)
+                                      for n in sorted(involved)}
                             net_cost, _ = state.nets_cost(subset, other_aw)
                             geo = (state.part_geometry_cost(ra, ax, ay, arot,
                                                             exclude={rb})
@@ -1218,6 +1387,7 @@ def quench(pcb_data: PCBData, pcb_file: str,
                                       f" (d[{ra}]={da:.1f}mm, d[{rb}]={db:.1f}mm)")
 
         stats = state.total_cost()
+        group_note = f" blocks={group_moves}" if group_moves else ""
         swap_note = (f" swap-capped={swaps_skipped}"
                      if verbose and swaps_skipped else "")
         # Shape/side mismatches were silent before: two instances of one
@@ -1227,7 +1397,7 @@ def quench(pcb_data: PCBData, pcb_file: str,
         print(f"Pass {pass_num}: {moves} moves, gain {improved:.1f} -> "
               f"length={stats['length']:.1f}mm crossings={stats['crossings']} "
               f"halo={stats['halo']:.1f} edge={stats['edge']:.1f} "
-              f"total={stats['total']:.1f}{swap_note}")
+              f"total={stats['total']:.1f}{group_note}{swap_note}")
         if moves == 0:
             break
 

--- a/tests/test_459_group_moves.py
+++ b/tests/test_459_group_moves.py
@@ -1,0 +1,211 @@
+"""
+Rigid block translation in the quench (issue #459).
+
+The per-part nudge cannot express "these parts need to travel together": an IC
+and its decoupling caps fight each other one at a time, because moving either
+alone worsens the pair. A block move shifts the whole body by one offset.
+
+The design constraint that makes this safe to add is the PER-MEMBER SEED CAP —
+every member must still land within `max_displacement` of its own seed. That is
+what keeps three existing guarantees true rather than merely probably-true:
+
+  * `build_neighbor_lists`' exactness argument is stated per part ("a movable
+    part's live position stays within travel_budget of its seed"), so the pruned
+    neighbour lists stay EXACT, not lossy.
+  * `BoardOutlineGate.edges_near` caches its reachable-edge list per ref on first
+    call, sized by that budget — a block allowed to travel further would outrun
+    the cache and silently skip the exact ring test, walking parts into cutouts.
+  * `test_quench_swap_cap`'s no-stranding invariant keeps holding unmodified.
+
+Lifting that cap is what makes #459's 80mm relocation a separate piece of work.
+"""
+
+import math
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from kicad_parser import parse_kicad_pcb
+from placement.groups import derive_groups, parse_sources
+from placement.quench import QuenchState, quench
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+KF = os.path.join(ROOT, 'kicad_files')
+KN = dict(clearance=0.25, board_edge_clearance=0.55, crossing_penalty=10.0,
+          halo_base=0.3, halo_coef=0.15, halo_weight=1.0,
+          edge_halo=1.0, edge_weight=1.0, grid_step=0.05)
+
+
+def _board(n):
+    return os.path.join(KF, n + '.kicad_pcb')
+
+
+def _poses(placements):
+    return {p['reference']: (round(p['new_x'], 6), round(p['new_y'], 6),
+                             round(p['new_rotation'], 6)) for p in placements}
+
+
+# --- inertness: the load-bearing claim ---------------------------------------
+
+def test_no_groups_is_byte_identical():
+    """With grouping off — the default — the group phase never runs and output
+    must match the ungrouped engine exactly. This is what lets every existing
+    bit-identity suite stay unmodified."""
+    for b in ('interf_u_unrouted', 'splitflap_driver'):
+        f = _board(b)
+        a = quench(parse_kicad_pcb(f), pcb_file=f, max_displacement=2.0,
+                   step=1.0, max_passes=2)
+        c = quench(parse_kicad_pcb(f), pcb_file=f, max_displacement=2.0,
+                   step=1.0, max_passes=2, groups={})
+        d = quench(parse_kicad_pcb(f), pcb_file=f, max_displacement=2.0,
+                   step=1.0, max_passes=2, groups=None)
+        assert _poses(a) == _poses(c) == _poses(d), f"{b}: groups={{}} changed output"
+    print("  PASS: groups off -> identical placements")
+
+
+def test_a_single_member_block_is_dropped():
+    """A block of one is not a block, and must not add a phase."""
+    f = _board('splitflap_driver')
+    a = quench(parse_kicad_pcb(f), pcb_file=f, max_displacement=2.0, step=1.0,
+               max_passes=1)
+    b = quench(parse_kicad_pcb(f), pcb_file=f, max_displacement=2.0, step=1.0,
+               max_passes=1, groups={'solo': ['C1']})
+    assert _poses(a) == _poses(b)
+
+
+# --- the move ----------------------------------------------------------------
+
+def test_block_translates_rigidly():
+    """Relative geometry inside the block must be bit-identical afterwards —
+    that is what 'rigid' means, and a per-member grid snap would shear it."""
+    f = _board('splitflap_driver')
+    pcb = parse_kicad_pcb(f)
+    blocks = derive_groups(pcb, ('decap',))
+    assert blocks, "fixture: expected decap blocks on splitflap"
+    before = {r: (pcb.footprints[r].x, pcb.footprints[r].y)
+              for refs in blocks.values() for r in refs}
+
+    placements = quench(parse_kicad_pcb(f), pcb_file=f, max_displacement=2.0,
+                        step=0.5, max_passes=1, allow_swaps=False,
+                        allow_rotations=False, groups=blocks)
+    after = _poses(placements)
+
+    moved_blocks = 0
+    for name, refs in blocks.items():
+        deltas = set()
+        for r in refs:
+            if r not in after:
+                continue
+            deltas.add((round(after[r][0] - before[r][0], 6),
+                        round(after[r][1] - before[r][1], 6)))
+        # Every member that moved as part of the block shares ONE delta. The
+        # per-part nudge may then polish individuals, so only require that a
+        # single shared delta exists when the whole block moved together.
+        if len(refs) > 1 and len(deltas) == 1 and deltas != {(0.0, 0.0)}:
+            moved_blocks += 1
+    assert moved_blocks >= 1, \
+        f"no block translated rigidly (deltas per block: {moved_blocks})"
+    print(f"  PASS: {moved_blocks} block(s) translated as one body")
+
+
+def test_every_member_stays_within_its_own_seed_cap():
+    """The invariant the whole design rests on."""
+    f = _board('splitflap_driver')
+    pcb = parse_kicad_pcb(f)
+    seeds = {r: (fp.x, fp.y) for r, fp in pcb.footprints.items()}
+    blocks = derive_groups(pcb, ('decap',))
+    cap, grid = 2.0, 0.05
+    placements = quench(parse_kicad_pcb(f), pcb_file=f, max_displacement=cap,
+                        step=0.5, grid_step=grid, max_passes=3, groups=blocks)
+    for p in placements:
+        sx, sy = seeds[p['reference']]
+        d = math.hypot(p['new_x'] - sx, p['new_y'] - sy)
+        assert d <= cap + grid + 1e-6, \
+            f"{p['reference']} stranded {d:.3f}mm from its seed (cap {cap})"
+    print(f"  PASS: {len(placements)} parts, none beyond {cap}mm + grid")
+
+
+def test_block_move_does_not_create_an_overlap():
+    """Intra-group pairs are excluded from validity (their geometry is invariant
+    under a translate), but FOREIGN collisions must still veto a candidate."""
+    f = _board('splitflap_driver')
+    pcb = parse_kicad_pcb(f)
+    blocks = derive_groups(pcb, ('decap',))
+    placements = quench(parse_kicad_pcb(f), pcb_file=f, max_displacement=2.0,
+                        step=0.5, max_passes=2, groups=blocks)
+    out = parse_kicad_pcb(f)
+    for p in placements:
+        fp = out.footprints[p['reference']]
+        fp.x, fp.y, fp.rotation = p['new_x'], p['new_y'], p['new_rotation']
+    st = QuenchState(out, f, **KN)
+    m = st.legality_metrics()
+    base = QuenchState(parse_kicad_pcb(f), f, **KN).legality_metrics()
+    assert m['overlap_area'] <= base['overlap_area'] + 1e-6, \
+        (f"block moves increased courtyard overlap "
+         f"{base['overlap_area']:.3f} -> {m['overlap_area']:.3f}mm2")
+    print(f"  PASS: overlap {base['overlap_area']:.3f} -> {m['overlap_area']:.3f}mm2")
+
+
+def test_group_move_valid_excludes_intra_group_pairs():
+    """Without the exclusion a block vetoes its own every candidate, because
+    members routinely sit at sub-clearance courtyard gaps already."""
+    f = _board('splitflap_driver')
+    pcb = parse_kicad_pcb(f)
+    blocks = derive_groups(pcb, ('decap',))
+    st = QuenchState(pcb, f, **KN)
+    st.build_neighbor_lists(2.05)
+    name, refs = sorted(blocks.items())[0]
+    # A zero move is always valid; the point is that it is not vetoed by members.
+    assert st.group_move_valid(refs, 0.0, 0.0), \
+        f"{name} vetoed its own current pose -- intra-group pairs leaked in"
+
+
+def test_block_moves_improve_the_objective():
+    """A block move is only accepted on strict improvement, so grouping must not
+    make the final cost worse than the ungrouped run."""
+    f = _board('splitflap_driver')
+    blocks = derive_groups(parse_kicad_pcb(f), ('decap',))
+    plain, grouped = {}, {}
+    quench(parse_kicad_pcb(f), pcb_file=f, max_displacement=2.0, step=0.5,
+           max_passes=2, metrics_out=plain)
+    quench(parse_kicad_pcb(f), pcb_file=f, max_displacement=2.0, step=0.5,
+           max_passes=2, groups=blocks, metrics_out=grouped)
+    assert grouped['after']['total'] <= plain['after']['total'] + 1e-6, \
+        (f"grouping made it worse: {plain['after']['total']:.1f} -> "
+         f"{grouped['after']['total']:.1f}")
+    print(f"  PASS: total {plain['after']['total']:.1f} (plain) -> "
+          f"{grouped['after']['total']:.1f} (grouped)")
+
+
+def test_locked_parts_are_never_in_a_moving_block():
+    f = _board('splitflap_driver')
+    pcb = parse_kicad_pcb(f)
+    blocks = derive_groups(pcb, ('decap',))
+    # Lock every block member; the block phase must then have nothing to move.
+    locked = sorted({r for v in blocks.values() for r in v})
+    placements = quench(parse_kicad_pcb(f), pcb_file=f, max_displacement=2.0,
+                        step=0.5, max_passes=1, groups=blocks,
+                        lock_refs=locked)
+    moved = {p['reference'] for p in placements}
+    assert not (moved & set(locked)), f"locked parts moved: {moved & set(locked)}"
+
+
+TESTS = [
+    test_no_groups_is_byte_identical,
+    test_a_single_member_block_is_dropped,
+    test_block_translates_rigidly,
+    test_every_member_stays_within_its_own_seed_cap,
+    test_block_move_does_not_create_an_overlap,
+    test_group_move_valid_excludes_intra_group_pairs,
+    test_block_moves_improve_the_objective,
+    test_locked_parts_are_never_in_a_moving_block,
+]
+
+
+if __name__ == '__main__':
+    for t in TESTS:
+        print(f"--- {t.__name__}")
+        t()
+    print("ALL PASS")

--- a/tests/test_459_groups.py
+++ b/tests/test_459_groups.py
@@ -1,0 +1,283 @@
+"""
+Placement blocks: parsing and derivation (issue #459).
+
+Nothing in this repo grouped footprints before. `Footprint` carried neither its
+own uuid nor a sheet path, no parse path read KiCad's `(group ...)` blocks, and
+no move translated more than one part. #459 needs blocks to exist before it can
+move one.
+
+Corpus reality, measured rather than assumed, and the reason the sources are
+ordered the way they are:
+
+  * 0 of 27 in-repo boards carry a `(group ...)` block, so that path is verified
+    against a synthetic fixture only.
+  * 12 of 22 boards with `(path ...)` have more than one sheet. ulx3s: 11 sheets
+    sized 83/34/23/20/20/12. That makes sheet the workhorse.
+  * A 2-pad cap sits 0.0-2.6mm (median) from the nearest IC and shares a net with
+    it in 93-100% of cases. The net-sharing check is what separates a decoupling
+    cap from a cap that merely sits nearby -- on ulx3s it rejects 13 of 70.
+  * Raw net-name prefixes are dominated by KiCad's auto-generated `Net-(U1-Pad)`
+    names: one bogus "NET" bucket of up to 92 refs spread over 75mm. Filtered,
+    what remains is small but real.
+"""
+
+import math
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from kicad_parser import parse_kicad_pcb
+from placement.groups import (GroupError, derive_groups, describe,
+                              parse_sources, NETPREFIX_MAX_SPREAD_MM)
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+KF = os.path.join(ROOT, 'kicad_files')
+
+
+def _board(name):
+    return os.path.join(KF, name + '.kicad_pcb')
+
+
+# --- parsing -----------------------------------------------------------------
+
+def test_footprints_carry_uuid_and_sheet_path():
+    pcb = parse_kicad_pcb(_board('ulx3s'))
+    fps = list(pcb.footprints.values())
+    assert all(f.uuid for f in fps), "some footprints have no uuid"
+    with_path = [f for f in fps if f.sheet_path]
+    assert len(with_path) >= 220, f"only {len(with_path)} footprints carry a path"
+    # The LAST component is the symbol; the prefix is the sheet.
+    sheets = {'/'.join(p for p in f.sheet_path.split('/') if p)
+              .rsplit('/', 1)[0] for f in with_path if f.sheet_path.count('/') > 1}
+    assert len(sheets) >= 5, f"expected a multi-sheet board, got {len(sheets)}"
+
+
+def test_group_members_resolve_by_uuid():
+    """(group ...) lists members BY UUID, and its own (uuid ...) is its identity,
+    not a member. No corpus board has one, so this is a synthetic fixture."""
+    src = open(_board('tigard'), encoding='utf-8').read()
+    pcb0 = parse_kicad_pcb(_board('tigard'))
+    refs = sorted(pcb0.footprints)[:3]
+    uu = [pcb0.footprints[r].uuid for r in refs]
+    assert all(uu)
+    blk = ('\t(group "PowerBlock"\n'
+           '\t\t(uuid "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")\n\t\t(members\n'
+           + ''.join(f'\t\t\t"{u}"\n' for u in uu) + '\t\t)\n\t)\n')
+    close = src.rindex(')')
+    fd, path = tempfile.mkstemp(suffix='.kicad_pcb')
+    os.close(fd)
+    open(path, 'w', encoding='utf-8').write(src[:close] + blk + src[close:])
+    try:
+        got = parse_kicad_pcb(path).groups
+        assert got == {'PowerBlock': sorted(refs)}, got
+    finally:
+        os.unlink(path)
+
+
+def test_ambiguous_uuid_pulls_in_every_claimant():
+    """A uuid is supposed to be unique and in real exports is -- but hand-made
+    boards repeat them (cap_chain shares one across two footprints). A uuid->ref
+    dict would silently resolve a member to the WRONG part."""
+    pcb0 = parse_kicad_pcb(_board('cap_chain'))
+    dup = [r for r, f in pcb0.footprints.items()
+           if f.uuid and sum(1 for g in pcb0.footprints.values()
+                             if g.uuid == f.uuid) > 1]
+    assert dup, "fixture assumption: cap_chain has duplicate footprint uuids"
+    src = open(_board('cap_chain'), encoding='utf-8').read()
+    u = pcb0.footprints[dup[0]].uuid
+    blk = ('\t(group "Dup"\n\t\t(uuid "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")\n'
+           f'\t\t(members\n\t\t\t"{u}"\n\t\t)\n\t)\n')
+    close = src.rindex(')')
+    fd, path = tempfile.mkstemp(suffix='.kicad_pcb')
+    os.close(fd)
+    open(path, 'w', encoding='utf-8').write(src[:close] + blk + src[close:])
+    try:
+        got = parse_kicad_pcb(path).groups['Dup']
+        assert len(got) == sum(1 for f in pcb0.footprints.values() if f.uuid == u), got
+        assert got == sorted(got), "membership must be sorted (#457)"
+    finally:
+        os.unlink(path)
+
+
+def test_boards_without_groups_parse_to_an_empty_dict():
+    """0 of 27 corpus boards have one; absence is normal, not an error."""
+    for b in ('tigard', 'watchy', 'ulx3s'):
+        assert parse_kicad_pcb(_board(b)).groups == {}
+
+
+# --- source selection --------------------------------------------------------
+
+def test_parse_sources():
+    assert parse_sources(None) == ()
+    assert parse_sources('none') == ()
+    assert parse_sources('auto') == ('kicad', 'sheet')
+    assert parse_sources('sheet') == ('sheet',)
+    assert parse_sources('sheet, decap') == ('sheet', 'decap')
+    assert parse_sources('sheet,sheet') == ('sheet',), "duplicates collapse"
+    try:
+        parse_sources('bogus')
+    except GroupError as e:
+        assert 'bogus' in str(e) and 'kicad' in str(e)
+        return
+    raise AssertionError("an unknown source must be rejected")
+
+
+# --- derivation --------------------------------------------------------------
+
+def test_sheet_blocks_on_a_real_board():
+    pcb = parse_kicad_pcb(_board('ulx3s'))
+    g = derive_groups(pcb, ('sheet',))
+    assert len(g) >= 8, f"expected ~10 sheet blocks on ulx3s, got {len(g)}"
+    biggest = max(len(v) for v in g.values())
+    assert biggest > 50, f"largest sheet block is only {biggest} parts"
+    assert all(k.startswith('sheet:') for k in g)
+    assert all(v == sorted(v) for v in g.values()), "membership must be sorted"
+    print(f"  PASS: ulx3s -> {len(g)} sheet blocks, "
+          f"sizes {sorted((len(v) for v in g.values()), reverse=True)[:6]}")
+
+
+def test_top_level_parts_do_not_collapse_into_one_block():
+    """A bare single-uuid path is top level, i.e. an EMPTY sheet prefix. Bucketing
+    on that would invent a block out of unrelated parts."""
+    pcb = parse_kicad_pcb(_board('rp2350_fpga_eensy_prePlane'))
+    g = derive_groups(pcb, ('sheet',))
+    assert 'sheet:' not in g and '' not in g
+    top = [r for r, f in pcb.footprints.items()
+           if f.sheet_path and f.sheet_path.count('/') <= 1]
+    grouped = {r for v in g.values() for r in v}
+    assert not (set(top) & grouped), f"top-level parts were grouped: {set(top) & grouped}"
+
+
+def test_a_ref_belongs_to_at_most_one_block():
+    pcb = parse_kicad_pcb(_board('glasgow_revC'))
+    g = derive_groups(pcb, ('sheet', 'netprefix', 'decap'))
+    seen = {}
+    for name, refs in g.items():
+        for r in refs:
+            assert r not in seen, f"{r} in both {seen[r]} and {name}"
+            seen[r] = name
+
+
+def test_precedence_kicad_outranks_sheet():
+    """An explicit KiCad group must not be torn apart by a later rule."""
+    src = open(_board('ulx3s'), encoding='utf-8').read()
+    pcb0 = parse_kicad_pcb(_board('ulx3s'))
+    # Pick three refs that sheet grouping would otherwise split apart.
+    by_sheet = {}
+    for r, f in pcb0.footprints.items():
+        parts = [q for q in (f.sheet_path or '').split('/') if q]
+        if len(parts) > 1:
+            by_sheet.setdefault('/'.join(parts[:-1]), []).append(r)
+    sheets = [s for s, v in sorted(by_sheet.items()) if len(v) >= 2][:2]
+    picked = sorted(by_sheet[sheets[0]])[:2] + sorted(by_sheet[sheets[1]])[:1]
+    uu = [pcb0.footprints[r].uuid for r in picked]
+    blk = ('\t(group "Cross"\n\t\t(uuid "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")\n'
+           '\t\t(members\n' + ''.join(f'\t\t\t"{u}"\n' for u in uu) + '\t\t)\n\t)\n')
+    close = src.rindex(')')
+    fd, path = tempfile.mkstemp(suffix='.kicad_pcb')
+    os.close(fd)
+    open(path, 'w', encoding='utf-8').write(src[:close] + blk + src[close:])
+    try:
+        g = derive_groups(parse_kicad_pcb(path), ('kicad', 'sheet'))
+        assert g.get('kicad:Cross') == sorted(picked), g.get('kicad:Cross')
+        for name, refs in g.items():
+            if name != 'kicad:Cross':
+                assert not (set(refs) & set(picked)), f"{name} stole a member"
+    finally:
+        os.unlink(path)
+
+
+def test_decap_requires_a_shared_net_not_just_proximity():
+    """Proximity alone adopts caps that have no electrical relationship with the
+    IC -- 13 of ulx3s' 70. Every decap block member must share a net with its IC."""
+    pcb = parse_kicad_pcb(_board('tigard'))
+    g = derive_groups(pcb, ('decap',))
+    assert g, "expected decap blocks on tigard (a flat board with no sheets)"
+    for name, refs in g.items():
+        ic = name.split(':', 1)[1]
+        assert ic in refs, f"{name} must contain its anchor IC"
+        ic_nets = {p.net_id for p in pcb.footprints[ic].pads if p.net_id > 0}
+        for r in refs:
+            if r == ic:
+                continue
+            cap_nets = {p.net_id for p in pcb.footprints[r].pads if p.net_id > 0}
+            assert cap_nets & ic_nets, f"{r} shares no net with {ic}"
+    print(f"  PASS: tigard -> {len(g)} decap blocks, "
+          f"{sum(len(v) for v in g.values())} parts")
+
+
+def test_netprefix_rejects_autogenerated_names():
+    """KiCad's Net-(U1-Pad3) / unconnected-(...) names carry no functional
+    meaning; bucketing on them builds one huge bogus block per board."""
+    pcb = parse_kicad_pcb(_board('glasgow_revC'))
+    g = derive_groups(pcb, ('netprefix',))
+    for name, refs in g.items():
+        assert not name.lower().startswith(('net:net', 'net:unconnected')), name
+        assert len(refs) < 60, f"{name} has {len(refs)} refs -- looks auto-generated"
+
+
+def test_netprefix_requires_spatial_coherence():
+    pcb = parse_kicad_pcb(_board('ulx3s'))
+    g = derive_groups(pcb, ('netprefix',))
+    for name, refs in g.items():
+        pts = []
+        for r in refs:
+            fp = pcb.footprints[r]
+            xs = [p.global_x for p in fp.pads]
+            ys = [p.global_y for p in fp.pads]
+            pts.append((sum(xs) / len(xs), sum(ys) / len(ys)) if xs else (fp.x, fp.y))
+        cx = sum(p[0] for p in pts) / len(pts)
+        cy = sum(p[1] for p in pts) / len(pts)
+        spread = max(math.hypot(p[0] - cx, p[1] - cy) for p in pts)
+        assert spread <= NETPREFIX_MAX_SPREAD_MM + 1e-6, \
+            f"{name} spans {spread:.1f}mm -- a naming convention, not a block"
+
+
+def test_no_sources_means_no_groups():
+    pcb = parse_kicad_pcb(_board('ulx3s'))
+    assert derive_groups(pcb, ()) == {}
+    assert derive_groups(pcb, parse_sources('none')) == {}
+
+
+def test_movable_restricts_membership():
+    pcb = parse_kicad_pcb(_board('ulx3s'))
+    full = derive_groups(pcb, ('sheet',))
+    some = sorted({r for v in full.values() for r in v})[:20]
+    limited = derive_groups(pcb, ('sheet',), movable=some)
+    assert {r for v in limited.values() for r in v} <= set(some)
+
+
+def test_describe_is_readable():
+    pcb = parse_kicad_pcb(_board('ulx3s'))
+    txt = describe(derive_groups(pcb, ('sheet',)), limit=2)
+    assert 'block(s)' in txt and 'sheet:' in txt
+    assert len([l for l in txt.splitlines()]) <= 5
+    assert describe({}) .endswith('none')
+
+
+TESTS = [
+    test_footprints_carry_uuid_and_sheet_path,
+    test_group_members_resolve_by_uuid,
+    test_ambiguous_uuid_pulls_in_every_claimant,
+    test_boards_without_groups_parse_to_an_empty_dict,
+    test_parse_sources,
+    test_sheet_blocks_on_a_real_board,
+    test_top_level_parts_do_not_collapse_into_one_block,
+    test_a_ref_belongs_to_at_most_one_block,
+    test_precedence_kicad_outranks_sheet,
+    test_decap_requires_a_shared_net_not_just_proximity,
+    test_netprefix_rejects_autogenerated_names,
+    test_netprefix_requires_spatial_coherence,
+    test_no_sources_means_no_groups,
+    test_movable_restricts_membership,
+    test_describe_is_readable,
+]
+
+
+if __name__ == '__main__':
+    for t in TESTS:
+        print(f"--- {t.__name__}")
+        t()
+    print("ALL PASS")


### PR DESCRIPTION
Addresses #459, step 1 of the sequencing the issue itself proposes: *"groups plus rigid translate moves in the quench first (the mild case), the bounded relocation solve second (the 80mm case)."*

The 80 mm relocation solve is **not** in this PR, and the last section explains why that is a separate piece of work rather than a bigger number.

---

## Nothing grouped footprints before

No `(group ...)` parsing in either parse path, no `board.Groups()`, no sheet paths, no clustering. `Footprint` carried neither its own uuid nor a path, and no move in the engine translated more than one part. So the first half of this is foundation:

- **`kicad_parser`, both paths**: `Footprint.uuid`, `Footprint.sheet_path`, `PCBData.groups`. `extract_groups()` resolves `(group ...)` members by uuid, bounded with `find_matching_paren` rather than a flat regex (#113), and excludes the group's **own** uuid — that is its identity, not a member.
- **`placement/groups.py`**: `derive_groups()` over four sources, precedence-ordered, each part in at most one block, every output sorted (#457).

## The sources, and the evidence for each

Measured across `kicad_files/` rather than assumed — this is what the constants in `groups.py` are set from:

| source | corpus evidence | verdict |
|---|---|---|
| `kicad` | **0 of 27** boards carry a `(group ...)` block | Exact when present. Verified against a synthetic fixture only. |
| `sheet` | **12 of 22** boards with `(path ...)` have >1 sheet. `ulx3s`: 10 blocks sized 83/34/23/20/20/12 | The workhorse. |
| `decap` | A 2-pad cap sits **0.0–2.6 mm** (median) from the nearest IC and **shares a net with it in 93–100%** of cases | Strong. |
| `netprefix` | After filtering: `ulx3s` 9 blocks / 63 refs, `tigard` **0** | The weakest, and the code says so. |

Two findings shaped the design:

**Decap needs both halves.** Proximity alone adopts caps that have no electrical relationship with the IC they sit next to — on `ulx3s` that is 13 of 70. Requiring a shared net is what makes the source safe.

**Raw net prefixes are a trap.** They are dominated by KiCad's auto-generated `Net-(U1-Pad)` names: one bogus `NET` bucket of up to 92 refs spread over 75 mm. That is exactly the wrong-group-is-worse-than-no-group case — it would rigidly drag half the board. Auto-generated and power names are excluded and a 20 mm spatial coherence gate applied; what survives is small but genuine (`AUDIO`, `GPDI`, `JTAG`, `USB`, `CAN`).

## The move

A block translates rigidly by one offset. To get there, `_net_points` / `_build_net_airwires` now take **N** overrides instead of one, and the swap phase's hand-inlined two-ref copy — which carried a comment warning that the two must not drift apart — is folded onto it. One implementation, and the sorted `net_refs` order (#457) is inherited rather than re-typed.

That refactor was verified **bit-identical to upstream** on `interf_u_unrouted`, `splitflap_driver` and `watchy` (same placement hashes, same cost traces) before anything else was built on it.

Intra-group pairs are **excluded** from validity and cost. Under a rigid translate the block's internal geometry is invariant, and without the exclusion a block vetoes its own every candidate — members routinely sit at sub-clearance courtyard gaps already — and double-counts each internal halo pair.

## Why the cap is per-member

Every member must land within `--max-displacement` of **its own seed**. That single rule keeps three existing guarantees true rather than merely probably-true:

- `build_neighbor_lists`' exactness argument is stated per part ("a movable part's live position stays within travel_budget of its seed"), so the pruned neighbour lists stay **exact**, not lossy.
- `BoardOutlineGate.edges_near` caches its reachable-edge list per ref on first call, sized by that budget. A block allowed to travel further would silently outrun the cache and skip the exact ring test — walking parts into cutouts.
- `test_quench_swap_cap`'s no-stranding invariant holds unmodified.

Lifting that cap is precisely what makes #459's 80 mm relocation separate work, not a bigger constant here.

## What actually moves — including the negative result

Small blocks move and help. Large ones do not.

On `splitflap_driver` with `--group-by decap`, 6 blocks of 2–3 parts translate and the objective improves against the ungrouped run:

| | ungrouped | `--group-by decap` |
|---|---|---|
| total | 5872.5 → 4781.6 | 5872.5 → **4689.7** |
| crossings | 300 → 211 | 300 → **208** |
| HPWL | 2504.4 → 2468.0 | 2504.4 → **2436.3** |

**Sheet blocks of 16–83 parts moved on none of the boards tried.** At a few mm of displacement, a rigid shift of that many parts rarely finds a legal, improving offset. That is the expected shape and it is an argument *for* #459's second half, not against this one — but it does mean `--group-by sheet` alone will often be inert, and the README says so.

## Opt-in

`--group-by none|kicad|sheet|netprefix|decap|auto` (`auto` = `kicad,sheet`), default `none`, on `place_optimize.py` and `place_route_loop.py`.

With it off the group phase never runs and output is **byte-identical** — verified against upstream on three boards — which is what lets every existing bit-identity suite stand unmodified rather than being re-baselined.

In the loop, a targeted part pulls in its whole block, so a block is no longer half-frozen because its IC exceeds `--max-target-pins`. That is #459 item 1's minimal honest slice; the router stays the judge through the existing accept/revert ratchet (item 4). `place_optimize`'s `JSON_SUMMARY` gains `blocks` / `block_parts`.

## Docs

`docs/placement-optimization.md` listed *rigid-group moves* and *decaps tethered to their IC* as intended scope with no "not implemented" annotation — unlike the side-flip entry directly beside them — so it read as though both existed. Both now say what actually ships, including that rigid *rotation* of a block still does not.

## Tests

- **`tests/test_459_groups.py`** (15 cases) — parsing, precedence, and each source's discriminator. Includes the **ambiguous-uuid** case: `cap_chain.kicad_pcb` really does share one uuid across two footprints, and a `uuid → ref` dict would have resolved a group member to the *wrong* part.
- **`tests/test_459_group_moves.py`** (8 cases) — led by the byte-identical-when-off gate, plus rigid-translation (one shared delta, no shear), the per-member seed cap, foreign-collision veto, and that grouping never worsens the objective.

## Verification

- `run_all.py --fast` → **184 passed, 2 failed**; both remaining failures (`test_500_staggered_not_a_ball_grid`, `test_orphan_island_cleanup`) fail identically at `ac2150a` and are unrelated.
- `pytest --collect-only` → **304 tests, 0 errors**.
- Manifest→plan parity 0 mismatches; CLI post-pass coverage 0 failures.
- **No GUI work**: `kicad_routing_plugin/` references none of `quench`, `QuenchState`, `place_optimize` or `place_route_loop`, and neither script is in the parity gate's `CLI_MAINS`.
