### PR TITLE
Placement portfolio + intent-driven seeding: real placement options instead of one deterministic answer

### DIFF
--- a/.claude/skills/plan-pcb-routing/SKILL.md
+++ b/.claude/skills/plan-pcb-routing/SKILL.md
@@ -22,11 +22,12 @@ python3 -X utf8 place_optimize.py board.kicad_pcb --suggest-locks
 
 | board state | run placement? | tool |
 |---|---|---|
-| **unplaced** (test it — see below) | **NO** — out of scope; report and stop | — |
+| **unplaced** (test it — see below) | follow the **unplaced ladder** below — seeder, then intent-driven `place_seed.py`, and report-and-stop only when NEITHER applies | see below |
 | careful hand placement, routing not yet attempted | **NO** | — |
 | routing already completed clean | **NO** — *unless* a spec clause placement could fix is still violated; see the last row of 9.3d | — |
 | board already carries copper (the tools exit 3) | **NO** — placement moves footprints, not tracks | — |
 | rough / imported / auto-generated placement | yes | `place_optimize.py --max-displacement 3` |
+| placed, and the user wants placement OPTIONS — or a converged run's remaining failures were classified **floorplan-shaped** | yes — generate a SLATE, not a nudge | `place_portfolio.py` (Step 0c-bis) |
 | routing FAILED and `/diagnose-routing-failures` blames **congestion / blockers** | yes | `place_route_loop.py` |
 | routing FAILED and the diagnosis is **parameters** (grid, ripup budget, layer costs) | **NO** — fix the parameters | — |
 
@@ -57,14 +58,40 @@ len({(round(f.x, 3), round(f.y, 3)) for f in pcb.footprints.values()}) < len(pcb
 `state_unplaced` / `state_partially_unplaced` / `state_spread_ratio` for the
 cases where an outline does exist.
 
-This toolchain **refines** an existing placement; it does not place a board from
-scratch. Report that plainly, tell the user to place the parts in KiCad, and
-offer to show them the current state:
+This toolchain does not place a board from scratch **unaided** — but "report
+and stop" is the LAST rung of a ladder now, not the first answer. Walk it in
+order:
 
-**If the repo has its own seeder** (a script that writes a starting floorplan and
-the outline from the spec), that is the placement step — run it, then treat its
-output as the "rough / generated placement" row of the table above. The skill
-does not place a board, but it should not stop in front of a repo that does.
+1. **The repo has its own seeder** (a script that writes a starting floorplan
+   and the outline from the spec): that is the placement step — run it, then
+   treat its output as the "rough / generated placement" row of the table
+   above. If the seeder takes a `--seed`/`--variant` axis, that plus
+   Step 0c-bis is how you offer the user OPTIONS instead of one take-it-or-
+   leave-it arrangement.
+2. **No seeder, but an intent exists — or the spec states placement facts**
+   (connector edges, a fixed regulator cluster, a decap rule): author/verify
+   the intent with the Step 0e machinery, then generate the seed from it:
+
+   ```bash
+   python3 -X utf8 place_seed.py board.kicad_pcb seed.kicad_pcb \
+       --intent floorplan.json [--seed N]
+   ```
+
+   The seeder turns the intent's constructs into placement (edge bands →
+   edge poses, single-ref zones → the spec coordinate, multi-ref zones →
+   a packed block, everything else → its connectivity centroid), stamps
+   `must_lock` refs `(locked yes)`, polishes, and **grades its own output
+   against the same intent** — exit 4 means the seed does not satisfy the
+   intent it was built from, and says which rule broke. Rotations: the input
+   rotation is kept when it fits, with a noted 90° lattice fallback when it
+   does not; a part whose rotation is a DECISION (pin order) must be locked —
+   the intent schema cannot express one, and an unlocked load-bearing
+   rotation was never protected from the quench either. Explore rotations
+   deliberately with the portfolio's `poses` strategy afterwards.
+3. **Neither** — no seeder, no intent, and the spec pins nothing (or there
+   is no outline; the outline is spec-owned and is never invented): report
+   that plainly, tell the user to place the parts in KiCad, and offer to
+   show them the current state.
 
 **Then copy the `.kicad_pro` and `.kicad_dru` onto its output yourself.** A
 seeder writes a `.kicad_pcb` and, like `place_optimize.py`, usually nothing else
@@ -244,6 +271,59 @@ python3 -X utf8 place_route_loop.py board.kicad_pcb board_repaired.kicad_pcb \
 
 Costly: it re-routes the whole board every round. `--ratsnest-screen 20` buys
 some of that back by skipping candidates whose ratsnest clearly regressed.
+
+### Step 0c-bis: when one placement is not enough — the portfolio
+
+The quench is deterministic by design, so re-running Step 0c can never
+produce a different arrangement — every run walks into the same local
+minimum, and each converged run's measurements tend to get folded back into
+the seed as constants, ratcheting the search space smaller. When the right
+question is "what are the placement OPTIONS", generate a slate:
+
+```bash
+python3 -X utf8 place_portfolio.py board.kicad_pcb --out-dir pf --seed 0 \
+    --intent floorplan.json --ignore-nets <the Step 5 plane nets> \
+    --lock <the 0a/0b locks>
+```
+
+**WHEN:** (a) run N+1 of a converged board whose remaining failures were
+classified **floorplan-shaped** (9.3d) — the portfolio explores exactly the
+axis those findings blame; (b) right after a seeder produced the first
+placement, before sinking a full chain into the only arrangement anyone has
+ever tried; (c) the user asks for options. It runs on the placed PRE-ROUTE
+board (copper → exit 3), and candidate 0 is always the plain quench of the
+input — "keep what I have" stays a first-class outcome.
+
+**The acceptance rule generalizes K-way, and stays a conjunction.** The
+Step 0c rule (metrics no worse + intent passes + repo gates pass) applies
+**per candidate against the baseline row**; the portfolio pre-applies the
+first two as its hard gates, the repo-local gates are still yours to run on
+the candidate you pick. Among survivors:
+
+1. Prefer `ranking_routed` over `ranking_static` — the probe tier
+   (`--route-top`, default: baseline + top 2) routes one SHARED affected-net
+   set, so its `failures`/`iterations` compare like with like. Never adopt
+   on static rank alone when the budget allows one probe route: crossings
+   and hpwl are proxies, and the router is the judge that counts.
+2. Ties go to the LEAST displacement (the slate is diverse by construction —
+   kept candidates sit ≥ `--diversity-mm` apart in pose distance — so a tie
+   is a real tie, not two clones).
+3. A `backfilled` entry in portfolio.json means the diversity bar was not
+   met and that candidate is a near-clone kept only to fill the count —
+   weigh it accordingly.
+
+**Reading the slate is ONE image-budget item, not K.** The per-candidate
+renders (or the `--montage` grid) answer a single question — which
+arrangement — so read them together as one budgeted read, then quote
+`portfolio.json`'s numbers, not the pictures, as evidence.
+
+**Adopting a candidate:** copy it out WITH its siblings (`copy_board.py` —
+the portfolio writes `.kicad_pro`/`.kicad_dru` next to every candidate), and
+it becomes the input to the normal chain. With `--ledger`, every kept
+candidate is stored content-addressed with an exact `--only N` replay
+command (`converge.py replay` runs it); record your adoption as an
+`accepted: true` entry so the chain's provenance survives. Same `--seed` +
+same input reproduces the whole portfolio byte for byte.
 
 ### Step 0d: see it before trusting it
 
@@ -747,7 +827,9 @@ HOW MUCH (never clearance from pixels).
 - Default to **not** running placement. The measured verdict is that the quench
   is a repair tool for rough/generated placements, not a polish pass — on a good
   hand placement it was neutral at best and its default weights caused 2 new
-  routing failures.
+  routing failures. (Exploring OPTIONS is different from polishing: when the
+  question is "which arrangement", `place_portfolio.py` generates a diverse
+  slate without touching the default path — Step 0c-bis.)
 - Run the lock advisor **before** the first placement run, and read the reasons
   rather than pasting the list blind.
 - Keep `--max-displacement` at ~3 mm. It is the dominant safety knob; 10 mm with
@@ -1872,11 +1954,15 @@ Based on the analysis, generate a step-by-step plan. The general order is:
 ### Routing Order Rationale
 
 0. **Placement (conditional -- normally SKIPPED).** Run it ONLY for a rough /
-   imported / generated placement, or when routing has already FAILED and
-   `/diagnose-routing-failures` blames congestion rather than parameters. See
-   Step 0's decision table; the default is **do not run it**. Run the lock
-   advisor first and pass its `--lock` list. A placement step claims NO nets
-   (see the Step 5b carve-out) and invalidates every downstream routed board.
+   imported / generated placement, when routing has already FAILED and
+   `/diagnose-routing-failures` blames congestion rather than parameters, or
+   when the user wants placement OPTIONS / a converged run's failures were
+   floorplan-shaped (then it is `place_portfolio.py`, Step 0c-bis — a slate,
+   not a nudge; and an unplaced board with an intent gets `place_seed.py`
+   first, per the Step 0 ladder). See Step 0's decision table; the default is
+   **do not run it**. Run the lock advisor first and pass its `--lock` list.
+   A placement step claims NO nets (see the Step 5b carve-out) and
+   invalidates every downstream routed board.
 1. **Fanout** (if needed) - Escape routing first, while the board is empty. Exclude
    nets that planes will handle (`"*" "!GND" "!VCC"`) — the exclusion also marks
    them for automatic **plane-drop vias** (#424): each excluded plane ball gets a

--- a/docs/floorplan-intent.md
+++ b/docs/floorplan-intent.md
@@ -18,6 +18,14 @@ python3 check_floorplan.py board.kicad_pcb --intent floorplan.json
 python3 check_floorplan.py board.kicad_pcb --intent floorplan.json --json findings.json
 ```
 
+The intent is also a GENERATOR input, not only a grader's: `place_seed.py`
+turns a declared intent into an initial placement for an unplaced board
+(zones, edge bands, locks and decap rules become placement constraints, and
+the emitted seed is graded against the same intent it was built from), and
+`place_portfolio.py` uses the intent as the hard gate plus the `health`
+signals when ranking K perturbed placement candidates. See
+`placement/README.md` for both.
+
 ## The board outline is not editable by this toolchain
 
 `envelope` is **read from the board**, never authored. A part outside it is a

--- a/docs/placement-optimization.md
+++ b/docs/placement-optimization.md
@@ -453,6 +453,53 @@ This validates the core hypothesis of the whole investigation: **proxies
 propose, the router disposes.** Wall-clock cost was ~5 routing runs
 (~4 minutes total on this board).
 
+## The portfolio: diversity without giving up determinism
+
+Everything above converges on ONE answer: the quench is a zero-temperature
+greedy descent, deliberately de-randomized (#457), so the same board and
+knobs produce the same placement byte for byte. That is the right property
+for reproducibility and exactly the wrong one for exploring — a re-run can
+never say "here is a different arrangement worth considering".
+
+`place_portfolio.py` injects diversity at the SEED instead of un-suppressing
+it in the engine, which keeps both properties at once:
+
+- Each candidate is a legal perturbation of the input placement — `jitter`
+  (seeded disc offsets of the free parts), `poses` (rotation variants of the
+  highest-pin free parts, pruned by `pair_order.ref_inversions` so a
+  rotation that provably raises the forced-crossing floor is never even
+  quenched), `swap` (position exchanges inside a declared block, the move
+  the quench's own displacement-capped swap phase cannot reach).
+- Every candidate is then quenched by the ORDINARY engine — `quench.py` is
+  not modified, and a default `place_optimize.py` run is bit-identical with
+  the portfolio in the tree.
+- Randomness is scoped, never ambient: candidate i draws from
+  `random.Random(f"{seed}:{i}:{strategy}")`, so the portfolio is a pure
+  function of (board, knobs, seed) and any single candidate replays alone
+  via `--only i`. `tests/test_portfolio_determinism.py` pins this across
+  PYTHONHASHSEED values, test_457-style.
+- Ranking is a lexicographic tuple of numbers this document already
+  establishes as trustworthy — crossings, the inversion lower bound, hpwl,
+  the floorplan health signals, displacement — and the top candidates are
+  probe-ROUTED (`--route-top`, default 2), because proxies propose and the
+  router disposes applies to a slate exactly as it applies to a single
+  repair.
+
+The perturb-then-descend shape is classical basin hopping (Wales & Doye) —
+the "extend the scorer to evaluate a perturbation" note in the SA section
+above, finally built, with the acceptance step replaced by an explicit
+ranked presentation to the user.
+
+`place_seed.py` is the same idea one step earlier: for a board with NO
+placement yet, a declared floorplan intent (zones, edge bands, locks, decap
+rules — `docs/floorplan-intent.md`) carries exactly the unmodeled
+constraints whose absence makes naive from-scratch placement fail (see "Why
+from-scratch autoplacement fails" above). The seeder turns the intent's
+constructs into a legal, seeded initial placement, grades its own output
+against the same intent, and hands the result to the portfolio. The
+from-scratch verdict stands: unaided is still out of scope; *aided by a
+declared intent* is now a supported path.
+
 ## References and further reading
 
 ### PCB-specific placement research

--- a/place_portfolio.py
+++ b/place_portfolio.py
@@ -1,0 +1,498 @@
+#!/usr/bin/env python3
+"""K diverse placement candidates from one placed board, ranked and rendered.
+
+Usage:
+  python place_portfolio.py board.kicad_pcb --out-dir DIR [options]
+
+The quench (place_optimize.py) is deterministic by design, so re-running it
+never produces a different placement. This tool generates real OPTIONS: legal
+seeded perturbations of the input placement (jitter / rotation variants /
+block-interior swaps), each quenched with the ordinary engine, scored without
+routing, pruned to a diverse slate, probe-routed at the top, and presented as
+per-candidate renders plus a machine-readable portfolio.json.
+
+Candidate 0 is always the plain quench of the input -- "keep what I have" is a
+first-class outcome and the identity anchor (its numbers equal a place_optimize
+run with the same knobs). Same --seed + same input => byte-identical portfolio;
+--only N regenerates exactly candidate N, which is what a ledger replays.
+
+Exit codes: 0 at least one viable candidate; 2 bad arguments; 3 the board is
+not in a state placement may touch (unplaced, or already carries copper);
+4 the run completed but zero candidates passed the hard gates.
+
+See docs/placement-optimization.md (Portfolio section) for the background.
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+
+
+def _parse_strategies(text):
+    from placement.portfolio import DEFAULT_STRATEGIES
+    out = tuple(s.strip() for s in text.split(',') if s.strip())
+    bad = [s for s in out if s not in DEFAULT_STRATEGIES]
+    if bad or not out:
+        raise argparse.ArgumentTypeError(
+            f"unknown strategy {', '.join(bad) or '(none)'}; "
+            f"choose from {', '.join(DEFAULT_STRATEGIES)}")
+    return out
+
+
+def build_parser():
+    import routing_defaults as defaults
+    from placement.cli_gates import add_board_state_args, add_tidiness_args
+
+    p = argparse.ArgumentParser(
+        description="Placement portfolio: K diverse candidates from one seed.",
+        formatter_class=argparse.RawDescriptionHelpFormatter, epilog="""
+Examples:
+  python place_portfolio.py board.kicad_pcb --out-dir pf
+  python place_portfolio.py board.kicad_pcb --out-dir pf --seed 7 \\
+      --intent floorplan.json --ignore-nets GND VCC --route-top 0
+""")
+    p.add_argument("input_file", help="Input KiCad PCB file (placed, unrouted)")
+    p.add_argument("--out-dir", required=True,
+                   help="Directory for candidate boards, renders and "
+                        "portfolio.json")
+    p.add_argument("--seed", type=int, default=0,
+                   help="Perturbation seed -- the ONLY source of randomness. "
+                        "Same seed + same input reproduces the portfolio "
+                        "byte for byte (default: 0)")
+    p.add_argument("--candidates", type=int, default=12,
+                   help="How many candidates to generate, baseline included "
+                        "(default: 12)")
+    p.add_argument("--keep", type=int, default=5,
+                   help="How many diverse candidates to present, on top of "
+                        "the always-present baseline (default: 5)")
+    p.add_argument("--strategy", type=_parse_strategies,
+                   default=('jitter', 'poses', 'swap'), metavar="LIST",
+                   help="Comma list of perturbation strategies, allocated "
+                        "round-robin (default: jitter,poses,swap)")
+    p.add_argument("--radius", type=float, default=4.0,
+                   help="Jitter amplitude in mm (default: 4.0). With the "
+                        "quench's own --max-displacement this bounds total "
+                        "exploration; 10mm-class values destroy corridors")
+    p.add_argument("--diversity-mm", type=float, default=2.0,
+                   help="Minimum pairwise pose distance among kept candidates "
+                        "(default: 2.0). Below it a candidate is a near-clone "
+                        "and is skipped in favour of the next-ranked one")
+    p.add_argument("--intent", default=None, metavar="JSON",
+                   help="Floorplan intent: hard gate (error-free grade "
+                        "required) plus the health signals in the rank key")
+    p.add_argument("--group-by", default="auto",
+                   help="Block sources for swap moves and intent grading "
+                        "(comma list of kicad/sheet/netprefix/decap; 'auto' = "
+                        "kicad,sheet; default: auto). NOT passed to the "
+                        "quench: candidate 0 stays identical to a default "
+                        "place_optimize run")
+    p.add_argument("--lock", nargs="+", default=None, metavar="REF",
+                   help="Reference patterns the portfolio must not perturb "
+                        "(board (locked yes) refs are always honored)")
+    p.add_argument("--ignore-nets", nargs="+", default=None, metavar="NET",
+                   help="Net patterns excluded from airwire scoring and probe "
+                        "routes (plane-routed rails)")
+    # Quench knobs, place_optimize spellings. Defaults follow the placement
+    # GUIDANCE (pose_score.make_state) rather than place_optimize's library
+    # defaults, so ranking and quenching optimize the same objective.
+    p.add_argument("--max-displacement", type=float, default=3.0,
+                   help="Quench displacement cap in mm (default: 3.0, the "
+                        "measured sweet spot; a repo-measured value outranks "
+                        "this)")
+    p.add_argument("--step", type=float, default=1.0,
+                   help="Quench candidate grid step in mm (default: 1.0)")
+    p.add_argument("--grid-step", type=float, default=defaults.GRID_STEP,
+                   help=f"Routing grid snap in mm (default: {defaults.GRID_STEP})")
+    p.add_argument("--clearance", type=float, default=defaults.CLEARANCE,
+                   help=f"Min courtyard gap in mm (default: {defaults.CLEARANCE})")
+    p.add_argument("--board-edge-clearance", type=float, default=0.55,
+                   help="Hard clearance from board edge in mm (default: 0.55)")
+    p.add_argument("--crossing-penalty", type=float, default=30.0,
+                   help="Cost per airwire crossing (default: 30, guidance)")
+    p.add_argument("--length-weight", type=float, default=0.3,
+                   help="Weight on airwire length (default: 0.3, guidance)")
+    p.add_argument("--halo-base", type=float, default=0.5)
+    p.add_argument("--halo-coef", type=float, default=0.15,
+                   help="Extra halo per sqrt(pin count) (default: 0.15, "
+                        "guidance)")
+    p.add_argument("--halo-weight", type=float, default=2.0)
+    p.add_argument("--edge-halo", type=float, default=2.0)
+    p.add_argument("--edge-weight", type=float, default=2.0)
+    p.add_argument("--no-rotate", action="store_true",
+                   help="Disable quench rotation moves")
+    p.add_argument("--no-swap", action="store_true",
+                   help="Disable quench same-footprint swap moves")
+    p.add_argument("--max-passes", type=int, default=10)
+    # Probe tier
+    p.add_argument("--route-top", type=int, default=2,
+                   help="Probe-route the baseline plus the top N kept "
+                        "candidates and rank the probed subset by measured "
+                        "failures/iterations (default: 2; 0 = static ranking "
+                        "only)")
+    p.add_argument("--route-args", nargs="+", default=None,
+                   help="Extra args for the probe routes (e.g. --clearance)")
+    p.add_argument("--route-timeout", type=float, default=900,
+                   help="Seconds per probe route (default: 900)")
+    # Presentation & provenance
+    p.add_argument("--no-render", action="store_true",
+                   help="Skip the per-candidate PNGs")
+    p.add_argument("--montage", default=None, metavar="PNG",
+                   help="Also paste the kept candidates into one labeled grid")
+    p.add_argument("--ledger", default=None, metavar="PATH",
+                   help="Record each kept candidate in a board_store ledger "
+                        "with an exact --only replay command")
+    p.add_argument("--only", type=int, default=None, metavar="N",
+                   help="Regenerate exactly candidate N (>=1) and exit -- the "
+                        "replay primitive. Skips scoring, renders and probes")
+    add_board_state_args(p)
+    add_tidiness_args(p)
+    return p
+
+
+def _quench_kw(args):
+    return dict(
+        max_displacement=args.max_displacement, step=args.step,
+        grid_step=args.grid_step, clearance=args.clearance,
+        board_edge_clearance=args.board_edge_clearance,
+        crossing_penalty=args.crossing_penalty,
+        length_weight=args.length_weight, halo_base=args.halo_base,
+        halo_coef=args.halo_coef, halo_weight=args.halo_weight,
+        edge_halo=args.edge_halo, edge_weight=args.edge_weight,
+        allow_rotations=not args.no_rotate, allow_swaps=not args.no_swap,
+        max_passes=args.max_passes, ignore_nets=args.ignore_nets,
+        lock_refs=args.lock, align_weight=args.align_weight,
+        align_radius=args.align_radius, align_span=args.align_span,
+        orient_weight=args.orient_weight)
+
+
+def _replay_argv(args, index):
+    """The exact command that regenerates candidate `index`: this run's own
+    argv with the recording/presentation flags stripped and --only appended.
+    Stored in the ledger so `converge.py replay` is a one-liner."""
+    argv = list(sys.argv[1:])
+    for flag in ('--ledger', '--montage', '--only'):
+        while flag in argv:
+            i = argv.index(flag)
+            del argv[i:i + 2]
+    if '--no-render' not in argv:
+        argv.append('--no-render')
+    return ([sys.executable, '-X', 'utf8',
+             os.path.join(ROOT, 'place_portfolio.py')]
+            + argv + ['--only', str(index)])
+
+
+def _affected_nets(pcb_data, cands, ignore_ids):
+    """Union of net names incident to any probed candidate's moved refs.
+    One shared set, so every probe routes the SAME nets and the verdicts
+    compare like with like."""
+    refs = set()
+    for c in cands:
+        refs.update(c.moved_refs)
+    names = set()
+    for ref in sorted(refs):
+        fp = pcb_data.footprints.get(ref)
+        if fp is None:
+            continue
+        for pad in fp.pads:
+            if pad.net_id > 0 and pad.net_id not in ignore_ids:
+                names.add(pad.net_name)
+    return sorted(n for n in names if n)
+
+
+def _probe(board, nets, args):
+    """One probe route; returns the JSON-safe verdict row."""
+    from converge import scoped_route, route_verdict
+    try:
+        res = scoped_route(board, nets, extra_args=args.route_args or [],
+                           timeout=args.route_timeout)
+    except subprocess.TimeoutExpired:
+        return {'failures': None, 'note': f'timeout after {args.route_timeout}s',
+                'iterations': None, 'nets': len(nets)}
+    n, note = route_verdict(res['summary'])
+    return {'failures': n, 'note': note,
+            'iterations': res['summary'].get('total_iterations'),
+            'vias': res['summary'].get('total_vias'), 'nets': len(nets),
+            'returncode': res['returncode']}
+
+
+def _render(board, before, out_png, ignore_nets):
+    argv = [sys.executable, '-X', 'utf8',
+            os.path.join(ROOT, 'render_placement.py'), board,
+            '--before', before, '-o', out_png]
+    if ignore_nets:
+        argv += ['--ignore-nets'] + list(ignore_nets)
+    r = subprocess.run(argv, capture_output=True, text=True, encoding='utf-8',
+                       errors='replace', cwd=ROOT)
+    if r.returncode != 0:
+        print(f"WARNING: render failed for {os.path.basename(board)} "
+              f"(rc={r.returncode}): {r.stdout[-200:]}", file=sys.stderr)
+        return False
+    return True
+
+
+def _montage(path, rows, out_dir):
+    """Paste the kept candidates' PNGs into one labeled grid. Presentation
+    only: a failure here never fails the run."""
+    try:
+        from PIL import Image, ImageDraw
+    except ImportError:
+        print("WARNING: --montage needs PIL; skipped", file=sys.stderr)
+        return False
+    imgs = []
+    for label, png in rows:
+        if png and os.path.isfile(png):
+            imgs.append((label, Image.open(png)))
+    if not imgs:
+        return False
+    cols = min(3, len(imgs))
+    cell_w = max(im.width for _, im in imgs)
+    cell_h = max(im.height for _, im in imgs) + 24
+    rows_n = (len(imgs) + cols - 1) // cols
+    sheet = Image.new('RGB', (cols * cell_w, rows_n * cell_h), 'white')
+    draw = ImageDraw.Draw(sheet)
+    for k, (label, im) in enumerate(imgs):
+        cx, cy = (k % cols) * cell_w, (k // cols) * cell_h
+        sheet.paste(im, (cx, cy + 24))
+        draw.text((cx + 6, cy + 4), label, fill='black')
+    sheet.save(path)
+    print(f"Wrote {path}")
+    return True
+
+
+def main():
+    parser = build_parser()
+    args = parser.parse_args()
+    if args.only is not None and args.only < 1:
+        parser.error("--only takes a candidate index >= 1 (0 is the baseline "
+                     "quench, which needs no stream to reproduce)")
+    if args.only is None:
+        try:
+            from redo_record import record_invocation
+            record_invocation()
+        except Exception:
+            pass
+
+    from kicad_parser import parse_kicad_pcb
+    from placement import portfolio
+    from placement.groups import GroupError, derive_groups, parse_sources
+    from placement.placement_state import gate_or_exit
+
+    print(f"Loading {args.input_file}...")
+    pcb = parse_kicad_pcb(args.input_file)
+    gate_or_exit(pcb, args.input_file, 'place_portfolio.py',
+                 allow_unplaced=args.allow_unplaced,
+                 allow_routed=args.allow_routed)
+
+    try:
+        sources = parse_sources(args.group_by)
+    except GroupError as exc:
+        parser.error(str(exc))
+
+    intent = None
+    if args.intent:
+        from placement import floorplan
+        try:
+            intent = floorplan.load_intent(args.intent)
+        except (OSError, ValueError) as exc:
+            print(f"cannot load intent {args.intent}: {exc}", file=sys.stderr)
+            return 2
+
+    # Swap blocks: the intent's declared blocks when given (zones are the
+    # designer's grouping), else the structural sources. Never handed to the
+    # quench itself -- candidate 0 must equal a default place_optimize run.
+    if intent is not None:
+        from placement import floorplan
+        swap_blocks, _problems = floorplan.resolve_blocks(intent, pcb, sources)
+    else:
+        swap_blocks = derive_groups(pcb, sources) if sources else {}
+
+    result = portfolio.generate(
+        args.input_file, args.out_dir, seed=args.seed,
+        n_candidates=args.candidates, strategies=args.strategy,
+        radius=args.radius, lock_globs=args.lock,
+        ignore_nets=args.ignore_nets, swap_blocks=swap_blocks,
+        quench_kw=_quench_kw(args), only=args.only)
+    baseline = result['baseline']
+    cands = result['candidates']
+    free = result['free']
+
+    if args.only is not None:
+        c = cands[0]
+        print("JSON_SUMMARY: " + json.dumps(
+            {'only': args.only, 'strategy': c.strategy, 'board': c.board,
+             'seed_board': c.seed_board, 'perturbed': len(c.poses),
+             'out_dir': args.out_dir}, sort_keys=True))
+        return 0
+
+    # ----- score ------------------------------------------------------------
+    from placement.floorplan import UntrustworthyOutline
+    baseline_overlap = baseline.metrics.get('overlap_area', 0.0)
+    baseline_oob = baseline.metrics.get('oob_count', 0)
+    try:
+        for c in cands:
+            portfolio.score_candidate(
+                c, free=free, baseline_overlap=baseline_overlap,
+                baseline_oob=baseline_oob, clearance=args.clearance,
+                board_edge_clearance=args.board_edge_clearance,
+                grid_step=args.grid_step, ignore_nets=args.ignore_nets,
+                intent=intent, group_sources=sources)
+        portfolio.score_candidate(
+            baseline, free=free, baseline_overlap=baseline_overlap,
+            baseline_oob=baseline_oob, clearance=args.clearance,
+            board_edge_clearance=args.board_edge_clearance,
+            grid_step=args.grid_step, ignore_nets=args.ignore_nets,
+            intent=intent, group_sources=sources)
+    except UntrustworthyOutline as exc:
+        print(f"board outline cannot be trusted for grading: {exc}",
+              file=sys.stderr)
+        return 3
+
+    ranking_static = portfolio.rank_static(cands)
+    kept, backfilled = portfolio.select_diverse(
+        cands, ranking_static, args.keep, args.diversity_mm, free, baseline)
+    by_index = {c.index: c for c in cands}
+    viable = [c.index for c in cands if c.viable]
+
+    for c in cands:
+        state = ('viable' if c.viable else
+                 'barren' if not c.board else 'gated out')
+        print(f"  cand {c.index:2d} [{c.strategy:8s}] {state}: "
+              f"crossings={c.metrics.get('crossings')} "
+              f"hpwl={c.metrics.get('hpwl')} "
+              f"inv={c.metrics.get('inversions')} "
+              f"disp={c.displacement_rms:.2f}mm"
+              + (f"  ({'; '.join(c.gates.get('reasons', []))})"
+                 if not c.viable and c.gates.get('reasons') else ''))
+    if backfilled:
+        print(f"NOTE: only {len(kept) - len(backfilled)} candidate(s) sit "
+              f">= {args.diversity_mm}mm apart; {len(backfilled)} backfilled "
+              f"by rank ({', '.join(map(str, backfilled))}) -- the slate is "
+              f"less diverse than --keep asked for")
+
+    # ----- probe tier -------------------------------------------------------
+    ranking_routed = []
+    if args.route_top > 0 and kept:
+        from place_route_loop import _ratsnest_screen
+        ids = portfolio.ignore_net_ids(pcb, args.ignore_nets)
+        probe_cands = [by_index[i] for i in kept[:args.route_top]]
+        nets = _affected_nets(pcb, [baseline] + probe_cands, ids)
+        routable = sum(1 for nid, net in pcb.nets.items()
+                       if nid > 0 and nid not in ids and len(net.pads) >= 2)
+        if routable and len(nets) > 0.5 * routable:
+            nets = ['*'] + [f'!{p}' for p in (args.ignore_nets or [])]
+            print(f"[probe] affected set exceeds half the board -- "
+                  f"full probe routes")
+        elif not nets:
+            print("[probe] no affected nets; skipping the probe tier")
+        if nets:
+            print(f"[probe] routing {len(nets)} net pattern(s) on baseline + "
+                  f"top {len(probe_cands)}")
+            baseline.route = _probe(baseline.board, nets, args)
+            base_rat = {'crossings': baseline.metrics.get('crossings'),
+                        'hpwl': baseline.metrics.get('hpwl')}
+            for c in probe_cands:
+                skip, note = _ratsnest_screen(
+                    base_rat, {'crossings': c.metrics.get('crossings'),
+                               'hpwl': c.metrics.get('hpwl')}, 25.0)
+                if skip:
+                    c.route = {'failures': None, 'iterations': None,
+                               'note': f'route skipped: {note}'}
+                    print(f"[probe] cand {c.index}: skipped ({note})")
+                    continue
+                c.route = _probe(c.board, nets, args)
+                print(f"[probe] cand {c.index}: failures="
+                      f"{c.route['failures']} ({c.route['note']})")
+            probed = [c for c in [baseline] + probe_cands
+                      if c.route and c.route.get('failures') is not None]
+            static_pos = {idx: k for k, idx in
+                          enumerate([baseline.index] + ranking_static)}
+            probed.sort(key=lambda c: (c.route['failures'],
+                                       c.route.get('iterations') or 0,
+                                       static_pos.get(c.index, 1 << 30)))
+            ranking_routed = [c.index for c in probed]
+
+    # ----- renders ----------------------------------------------------------
+    renders = {}
+    if not args.no_render:
+        png0 = os.path.join(args.out_dir, 'baseline.png')
+        if _render(baseline.board, args.input_file, png0, args.ignore_nets):
+            renders[0] = png0
+        for i in kept:
+            c = by_index[i]
+            png = os.path.join(args.out_dir, f'cand_{i:02d}.png')
+            if _render(c.board, args.input_file, png, args.ignore_nets):
+                renders[i] = png
+    if args.montage:
+        rows = [(f"#0 baseline  x={baseline.metrics.get('crossings')} "
+                 f"hpwl={baseline.metrics.get('hpwl')}", renders.get(0))]
+        for i in kept:
+            c = by_index[i]
+            rows.append((f"#{i} {c.strategy}  x={c.metrics.get('crossings')} "
+                         f"hpwl={c.metrics.get('hpwl')}", renders.get(i)))
+        _montage(args.montage, rows, args.out_dir)
+
+    # ----- ledger -----------------------------------------------------------
+    if args.ledger:
+        from board_store import BoardStore, Ledger
+        store = BoardStore(os.path.join(
+            os.path.dirname(os.path.abspath(args.ledger)), 'boards'))
+        lg = Ledger(args.ledger)
+        base_sha = store.put(baseline.board)
+        lg.append({'iteration': len(lg.entries()), 'kind': 'completion',
+                   'lever': 'portfolio-baseline', 'result_sha': base_sha,
+                   'parent_sha': None, 'lever_argv': None,
+                   'score': {'crossings': baseline.metrics.get('crossings'),
+                             'hpwl': baseline.metrics.get('hpwl')},
+                   'accepted': False})
+        for i in kept:
+            c = by_index[i]
+            sha = store.put(c.board)
+            lg.append({'iteration': len(lg.entries()), 'kind': 'completion',
+                       'lever': f'portfolio-{c.strategy}', 'result_sha': sha,
+                       'parent_sha': base_sha,
+                       'lever_argv': _replay_argv(args, i),
+                       'score': {'crossings': c.metrics.get('crossings'),
+                                 'inversions': c.metrics.get('inversions'),
+                                 'hpwl': c.metrics.get('hpwl'),
+                                 'health_penalty':
+                                     c.metrics.get('health_penalty'),
+                                 'route': c.route},
+                       'accepted': False})
+        print(f"Recorded baseline + {len(kept)} candidate(s) in {args.ledger} "
+              f"(adoption = your accepted:true entry, or converge.py record)")
+
+    # ----- portfolio.json + summary -----------------------------------------
+    doc = {'input': args.input_file, 'seed': args.seed,
+           'argv': sys.argv[1:], 'free': free,
+           'diversity_mm': args.diversity_mm,
+           'baseline': baseline.to_dict(),
+           'candidates': [c.to_dict() for c in cands],
+           'ranking_static': ranking_static,
+           'ranking_routed': ranking_routed,
+           'kept': kept, 'backfilled': backfilled,
+           'renders': {str(k): v for k, v in renders.items()}}
+    doc_path = os.path.join(args.out_dir, 'portfolio.json')
+    with open(doc_path, 'w', encoding='utf-8') as f:
+        json.dump(doc, f, indent=1, sort_keys=True)
+    print(f"Wrote {doc_path}")
+
+    best = (ranking_routed[0] if ranking_routed
+            else (ranking_static[0] if ranking_static else None))
+    best_c = by_index.get(best, baseline) if best is not None else None
+    print("JSON_SUMMARY: " + json.dumps({
+        'candidates': len(cands) + 1, 'viable': len(viable),
+        'kept': len(kept), 'best': best,
+        'best_crossings': (best_c.metrics.get('crossings')
+                           if best_c else None),
+        'baseline_crossings': baseline.metrics.get('crossings'),
+        'best_hpwl': best_c.metrics.get('hpwl') if best_c else None,
+        'baseline_hpwl': baseline.metrics.get('hpwl'),
+        'out_dir': args.out_dir}, sort_keys=True))
+    return 0 if viable else 4
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/place_seed.py
+++ b/place_seed.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Generate an initial placement for an UNPLACED board from its floorplan intent.
+
+Usage:
+  python place_seed.py input.kicad_pcb output.kicad_pcb --intent floorplan.json
+
+The placement stack refines and deliberately does not place from scratch
+UNAIDED -- but a declared intent carries the constraints a from-scratch run
+lacks: zones, edge bands, locks, decap rules. This tool turns that intent into
+a legal starting placement (see placement/seeder.py for exactly what each
+construct becomes), stamps the intent's must_lock refs `(locked yes)` into the
+output, runs a quench polish over the free parts, and then GRADES its own
+output against the same intent -- a seed that fails the intent it was built
+from is a defect, not a result.
+
+Different --seed values produce genuinely different legal seeds (packing order
+and target jitter); the same seed reproduces byte for byte. Compose with
+place_portfolio.py to diversify and rank what this emits.
+
+Exit codes: 0 seeded and graded clean; 2 bad arguments; 3 the board cannot be
+seeded (no Edge.Cuts outline -- the outline is spec-owned and will not be
+invented -- or the board is already placed / carries copper); 4 the seed was
+written but parts could not be seated or the intent grade has errors.
+"""
+import argparse
+import json
+import os
+import sys
+
+
+def main():
+    import routing_defaults as defaults
+
+    p = argparse.ArgumentParser(
+        description="Intent-driven initial placement for an unplaced board.",
+        formatter_class=argparse.RawDescriptionHelpFormatter, epilog="""
+Examples:
+  python place_seed.py board.kicad_pcb seed.kicad_pcb --intent floorplan.json
+  python place_seed.py board.kicad_pcb seed.kicad_pcb --intent fp.json --seed 3
+""")
+    p.add_argument("input_file", help="Input KiCad PCB (unplaced parts + outline)")
+    p.add_argument("output_file", help="Output board with the seeded placement")
+    p.add_argument("--intent", required=True, metavar="JSON",
+                   help="Floorplan intent: the constraint source AND the "
+                        "acceptance gate for the emitted seed")
+    p.add_argument("--seed", type=int, default=0,
+                   help="Packing-order/jitter seed; same seed reproduces byte "
+                        "for byte (default: 0)")
+    p.add_argument("--group-by", default="auto",
+                   help="Block sources for resolving the intent's `group` "
+                        "references (default: auto = kicad,sheet)")
+    p.add_argument("--ignore-nets", nargs="+", default=None, metavar="NET",
+                   help="Net patterns excluded from the polish's airwire "
+                        "scoring (plane-routed rails)")
+    p.add_argument("--clearance", type=float, default=defaults.CLEARANCE)
+    p.add_argument("--board-edge-clearance", type=float, default=0.55)
+    p.add_argument("--grid-step", type=float, default=defaults.GRID_STEP)
+    p.add_argument("--max-displacement", type=float, default=3.0,
+                   help="Polish displacement cap in mm (default: 3.0)")
+    p.add_argument("--no-polish", action="store_true",
+                   help="Skip the quench polish; emit the raw packed seed")
+    p.add_argument("--force", action="store_true",
+                   help="Re-seed a board that already looks placed. The "
+                        "existing placement is DISCARDED; to explore around "
+                        "it instead, use place_portfolio.py")
+    args = p.parse_args()
+
+    try:
+        from redo_record import record_invocation
+        record_invocation()
+    except Exception:
+        pass
+
+    import random
+    from kicad_parser import parse_kicad_pcb
+    from placement import floorplan, seeder
+    from placement.groups import GroupError, parse_sources
+    from placement.placement_state import UNPLACED_EXIT, assess_placement
+    from placement.portfolio import copy_siblings
+    from placement.writer import write_placed_output
+
+    try:
+        sources = parse_sources(args.group_by)
+    except GroupError as exc:
+        p.error(str(exc))
+    try:
+        intent = floorplan.load_intent(args.intent)
+    except (OSError, ValueError) as exc:
+        print(f"cannot load intent {args.intent}: {exc}", file=sys.stderr)
+        return 2
+
+    print(f"Loading {args.input_file}...")
+    pcb = parse_kicad_pcb(args.input_file)
+    if pcb.board_info.board_bounds is None:
+        print("place_seed: this board has no Edge.Cuts outline. The outline "
+              "is spec-owned -- draw it (or have the repo's seeder write it "
+              "from the spec) before seeding a placement.", file=sys.stderr)
+        return UNPLACED_EXIT
+    st = assess_placement(pcb, args.input_file)
+    if st.has_copper:
+        print(f"place_seed: this board carries {st.segments} segment(s) and "
+              f"{st.vias} via(s); seeding moves footprints and would strand "
+              f"every track. Seed the unrouted board.", file=sys.stderr)
+        return UNPLACED_EXIT
+    if not st.unplaced and not args.force:
+        print("place_seed: this board already looks PLACED. Seeding would "
+              "discard that placement; use place_portfolio.py to explore "
+              "variations of it, or --force to re-seed anyway.",
+              file=sys.stderr)
+        return UNPLACED_EXIT
+
+    rng = random.Random(f"{args.seed}")
+    result = seeder.seed_from_intent(
+        pcb, args.input_file, intent, rng, group_sources=sources,
+        clearance=args.clearance,
+        board_edge_clearance=args.board_edge_clearance,
+        grid_step=args.grid_step)
+    for note in result['notes']:
+        print(f"  NOTE: {note}")
+    print(f"Seeded {len(result['placements'])} part(s); "
+          f"{len(result['unseated'])} unseated; "
+          f"{len(result['lock_refs'])} to lock")
+
+    write_placed_output(args.input_file, args.output_file,
+                        result['placements'])
+    n_locked = seeder.stamp_locked(args.output_file, result['lock_refs'])
+    copy_siblings(args.input_file, args.output_file)
+    print(f"Stamped (locked yes) on {n_locked} part(s)")
+
+    ratsnest = {}
+    if not args.no_polish:
+        from placement.quench import quench
+        pcb_seeded = parse_kicad_pcb(args.output_file)
+        # Guidance weights, same as place_portfolio: the seed should be
+        # polished by the objective the later steps rank with. Locks ride in
+        # from the file (must_lock was just stamped); edge connectors are
+        # locked per-call so the polish cannot walk them off their band.
+        edge_refs = [c['ref'] for c in intent.edge_connectors]
+        placements = quench(
+            pcb_seeded, pcb_file=args.output_file,
+            max_displacement=args.max_displacement,
+            step=1.0, grid_step=args.grid_step, clearance=args.clearance,
+            board_edge_clearance=args.board_edge_clearance,
+            crossing_penalty=30.0, length_weight=0.3, halo_base=0.5,
+            halo_coef=0.15, halo_weight=2.0, edge_halo=2.0, edge_weight=2.0,
+            ignore_nets=args.ignore_nets,
+            lock_refs=edge_refs or None, metrics_out=ratsnest)
+        if placements:
+            tmp = args.output_file + '.polish'
+            write_placed_output(args.output_file, tmp, placements)
+            os.replace(tmp, args.output_file)
+
+    # ---- self-check: the seed must grade clean against its own intent ------
+    pcb_out = parse_kicad_pcb(args.output_file)
+    try:
+        graded = floorplan.grade(intent, pcb_out, args.output_file,
+                                 group_sources=sources,
+                                 clearance=args.clearance,
+                                 board_edge_clearance=args.board_edge_clearance)
+    except floorplan.UntrustworthyOutline as exc:
+        print(f"place_seed: outline cannot be trusted for grading: {exc}",
+              file=sys.stderr)
+        return UNPLACED_EXIT
+    for v in graded.errors[:10]:
+        print(f"  GRADE ERROR [{v.rule}] {v.message}")
+    after = ratsnest.get('after', {})
+    summary = {'placed': len(result['placements']),
+               'unseated': len(result['unseated']),
+               'locked': n_locked,
+               'grade_errors': len(graded.errors),
+               'grade_warnings': len(graded.warnings),
+               'crossings': after.get('crossings'),
+               'hpwl': (round(after['hpwl'], 3)
+                        if after.get('hpwl') is not None else None),
+               'output': args.output_file}
+    print("JSON_SUMMARY: " + json.dumps(summary, sort_keys=True))
+    if result['unseated'] or graded.errors:
+        print("place_seed: the seed does NOT satisfy its intent -- see the "
+              "errors above. It was still written, for inspection.",
+              file=sys.stderr)
+        return 4
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/placement/README.md
+++ b/placement/README.md
@@ -2,10 +2,12 @@
 
 Perturbative placement optimization for KiCad PCB files. Starts from an
 existing (hand- or AI-made) placement and improves it for routability —
-it does not place boards from scratch. Background research and experiment
-results: [docs/placement-optimization.md](../docs/placement-optimization.md).
+it does not place boards from scratch *unaided* (`place_seed.py` below is
+the aided path: a declared floorplan intent carries the constraints a
+from-scratch run lacks). Background research and experiment results:
+[docs/placement-optimization.md](../docs/placement-optimization.md).
 
-Two command-line tools sit on top of this module:
+Four command-line tools sit on top of this module:
 
 ## place_optimize.py — greedy quench
 
@@ -64,6 +66,85 @@ python place_route_loop.py input.kicad_pcb repaired.kicad_pcb \
 On the kit-dev-coldfire demo board this repaired the hand placement from
 3 failed nets to 0 with 4.8× less router effort, moving only
 resistors/caps/jumpers.
+
+## place_portfolio.py — K diverse candidates from one placement
+
+The quench is deterministic by design (#457), so re-running it never produces
+a different placement: every run walks into the same local minimum. When the
+question is "what are my placement OPTIONS", this tool generates them: legal
+seeded perturbations of the input placement (`jitter` disc offsets, `poses`
+rotation variants pruned by `pair_order` inversions, `swap` block-interior
+position exchanges), each quenched with the ordinary engine, scored **without
+routing**, pruned to a diverse slate, probe-routed at the top, and presented
+as per-candidate renders plus `portfolio.json`.
+
+```bash
+python place_portfolio.py board.kicad_pcb --out-dir pf --seed 0 \
+    --intent floorplan.json --ignore-nets GND VCC
+```
+
+What the contract guarantees:
+
+- **Candidate 0 is the plain quench of the input** — "keep what I have" is a
+  first-class outcome, and its numbers equal a `place_optimize.py` run with
+  the same knobs (asserted by `tests/test_portfolio.py`).
+- **Same `--seed` + same input ⇒ byte-identical portfolio**, across
+  `PYTHONHASHSEED` values. Each candidate draws from its own
+  `random.Random(f"{seed}:{i}:{strategy}")` stream, so `--only N`
+  regenerates candidate N alone, byte-identically — that is the replay
+  primitive the `--ledger` records (`converge.py replay` runs it).
+- **Hard gates, then an ungameable rank.** A candidate is ranked only if it
+  adds no courtyard overlap and no out-of-board parts beyond the baseline's,
+  and (with `--intent`) grades error-free. Rank is lexicographic over
+  numbers the repo already trusts: `(crossings, inversions, hpwl,
+  health_penalty, displacement, index)` — no new magic weights.
+- **Diversity is pose distance, not hpwl distance** (hpwl reads per-net
+  extremes, so a mirrored arrangement can tie a clone). Kept candidates sit
+  ≥ `--diversity-mm` apart, the baseline included; when fewer survive, the
+  slate is backfilled by rank and SAYS so.
+- **Probe tier (`--route-top 2` by default)**: baseline + top kept candidates
+  are actually routed (one shared affected-net set, so verdicts compare like
+  with like; the `_ratsnest_screen` veto skips a probe on a candidate whose
+  ratsnest clearly regressed). `portfolio.json` carries TWO rankings —
+  `ranking_static` and `ranking_routed` — because measured copper and a
+  proxy must not interleave in one list.
+
+A board that already carries copper is refused (exit 3): placement moves
+footprints, not tracks. Run the portfolio on the placed pre-route board and
+re-route the chosen candidate.
+
+## place_seed.py — intent-driven initial placement
+
+The aided from-scratch path. Given an UNPLACED board (netlist import, a
+generator's pile) plus a floorplan intent, it emits a legal starting
+placement: edge connectors on their declared edge inside their overhang band,
+single-ref zones at the spec coordinate, multi-ref zones packed radially,
+everything else at the nearest legal pose to its connectivity centroid (which
+is also what lands a decap next to its IC). The intent's `must_lock` refs are
+stamped `(locked yes)` into the output, a quench polish tidies the free
+parts, and the result is **graded against the same intent it was built
+from** — a seed that fails its own intent exits 4, deliberately.
+
+```bash
+python place_seed.py unplaced.kicad_pcb seed.kicad_pcb --intent floorplan.json
+python place_seed.py unplaced.kicad_pcb seed3.kicad_pcb --intent floorplan.json --seed 3
+```
+
+Rotations: the input rotation is tried in full first and kept when it fits; a
+part with no contained legal pose at it falls back to its 90° lattice (noted
+in the output — measured: an LDO with 0 legal poses at rot 0 and 3 at rot 90
+on a packed board). A part whose rotation is a *decision* (pin order, the U3
+rot-180 case) must be **locked** — the intent schema cannot express a
+rotation, and an unlocked load-bearing rotation was never protected from the
+quench either. Explore rotations deliberately with
+`place_portfolio.py --strategy poses`.
+
+Requires an Edge.Cuts outline (exit 3 without one — the outline is spec-owned
+and will not be invented) and refuses a board that already looks placed
+(use `place_portfolio.py` to explore around an existing placement, or
+`--force` to discard it). Different `--seed` values give genuinely different
+legal seeds; the same seed reproduces byte for byte. The two compose:
+`place_seed --seed N` → `place_portfolio` diversifies and ranks.
 
 ## place_fanout_clearance.py — decoupling-cap clearance repair (issue #130)
 
@@ -150,6 +231,10 @@ python3 tests/test_456_courtyard_parser.py   # courtyard shapes + silk bleed (#4
 python3 tests/test_456_side_and_outline.py   # board side, real outline, graders (#456)
 python3 tests/test_459_groups.py             # block sources + parsing (#459)
 python3 tests/test_459_group_moves.py        # rigid block translation (#459)
+python3 tests/test_portfolio_strategies.py   # perturbation strategy invariants
+python3 tests/test_portfolio_determinism.py  # portfolio seed/replay contract (slow)
+python3 tests/test_portfolio.py              # portfolio smoke + identity anchor (slow)
+python3 tests/test_place_seed.py             # intent-driven seeding (slow)
 ```
 
 Quench output is reproducible across processes — the same board and arguments
@@ -625,6 +710,8 @@ is followed by a settle beat, so the moves only play once the camera has arrived
 | File | Purpose |
 |------|---------|
 | `quench.py` | The optimizer: cost terms, move generation, greedy quench |
+| `portfolio.py` | K diverse candidates: perturbation strategies, gates, ranking, diversity selection |
+| `seeder.py` | Intent-driven initial placement for unplaced boards, and `(locked yes)` stamping |
 | `../group_routing.py` | Block → net scoping, and the undo, for `route.py` (#459) |
 | `fanout_clearance.py` | Post-fanout decoupling-cap clearance repair (#130) |
 | `groups.py` | Placement blocks: which parts move as one rigid body (#459) |

--- a/placement/portfolio.py
+++ b/placement/portfolio.py
@@ -1,0 +1,627 @@
+"""K diverse placement candidates from one seed placement.
+
+The quench is a zero-temperature greedy descent, and the placement stack is
+deterministic by DESIGN (#457): same input, same knobs, same board, byte for
+byte. That is the right property for reproducibility and exactly the wrong one
+for exploring -- every run walks into the same local minimum, so "more
+placement options" cannot come from re-running.
+
+Diversity is therefore INJECTED at the seed, never un-suppressed: each
+candidate is a legal PERTURBATION of the input placement (seeded jitter /
+rotation variants / block-interior swaps), quenched with the ordinary engine,
+then scored WITHOUT routing and pruned to a diverse, ranked slate. The
+determinism contract survives intact:
+
+  * every candidate draws from its own ``random.Random(f"{seed}:{i}:{strat}")``
+    stream, so candidate i is byte-reproducible independently of the others --
+    which is what makes ``--only N`` an exact replay primitive for a ledger;
+  * everything else iterates sorted; there is no unseeded randomness, no
+    clock, and no set-of-strings order anywhere in this module;
+  * the quench engine is consumed through its public surface and never
+    modified -- a plain place_optimize.py run is bit-identical with this
+    module in the tree.
+
+Perturbations are generated ON a shared oracle QuenchState and validated with
+``candidate_valid`` as they are proposed (later parts see earlier ones already
+moved), then written to a seed board with ``write_placed_output`` and quenched
+from THAT file. Writing the quench result against the seed file -- exactly what
+place_optimize does for its own input -- is what neutralizes quench's return
+filter (a part that lands back on its perturbed seed is omitted from the
+return, which is only safe when the output is written over the same seed).
+"""
+from __future__ import annotations
+
+import fnmatch
+import math
+import os
+import random
+import shutil
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Sequence, Set, Tuple
+
+DEFAULT_STRATEGIES: Tuple[str, ...] = ('jitter', 'poses', 'swap')
+# How many of the highest-pin-count free parts the `poses` strategy enumerates
+# rotation variants for. Rotations of multi-pin parts are where pin order lives
+# (the U3 rot-180 case: 9 forced inversions -> 0); a 2-pad passive's rotation
+# rarely changes anything the jitter cannot.
+POSES_TOP_PARTS = 6
+# Rejection-resampling budget per part for the seeded strategies. Bounded so a
+# dense board terminates; a part that finds no legal sample simply stays put,
+# which is a smaller perturbation, not an error.
+SAMPLE_ATTEMPTS = 20
+EPS = 1e-6
+
+
+@dataclass
+class Candidate:
+    """One portfolio row: where it came from, what it became, how it measures."""
+    index: int
+    strategy: str
+    seed_board: str = ''            # the perturbed (pre-quench) board, or ''
+    board: str = ''                 # the quenched result, or '' when barren
+    poses: List[Dict] = field(default_factory=list)   # the perturbation
+    final_poses: Dict[str, Tuple[float, float, float]] = field(
+        default_factory=dict)       # ref -> (x, y, rot) after the quench
+    moved_refs: List[str] = field(default_factory=list)
+    displacement_rms: float = 0.0
+    metrics: Dict = field(default_factory=dict)
+    gates: Dict = field(default_factory=dict)
+    intent: Optional[Dict] = None
+    health: Optional[Dict] = None
+    route: Optional[Dict] = None
+    note: str = ''
+
+    @property
+    def viable(self) -> bool:
+        return bool(self.board) and bool(self.gates.get('passed'))
+
+    def to_dict(self) -> Dict:
+        d = {'index': self.index, 'strategy': self.strategy,
+             'seed_board': self.seed_board, 'board': self.board,
+             'poses': self.poses,
+             'final_poses': {r: [round(v, 4) for v in p]
+                             for r, p in sorted(self.final_poses.items())},
+             'moved_refs': self.moved_refs,
+             'displacement_rms': round(self.displacement_rms, 3),
+             'metrics': self.metrics, 'gates': self.gates,
+             'note': self.note}
+        if self.intent is not None:
+            d['intent'] = self.intent
+        if self.health is not None:
+            d['health'] = self.health
+        if self.route is not None:
+            d['route'] = self.route
+        return d
+
+
+# --------------------------------------------------------------------------
+# board / state plumbing
+# --------------------------------------------------------------------------
+
+def free_refs(pcb_data, pcb_file: str,
+              lock_globs: Optional[Sequence[str]] = None) -> List[str]:
+    """Sorted refs the portfolio may perturb: pad-bearing, not `(locked yes)`
+    on the board, not matching a --lock glob. The same two lock sources the
+    quench itself honors, resolved once so every consumer agrees."""
+    from placement.parser import extract_locked_refs
+    locked = set(extract_locked_refs(pcb_file))
+    out = []
+    for ref, fp in pcb_data.footprints.items():
+        if not fp.pads:
+            continue
+        if ref in locked:
+            continue
+        if lock_globs and any(fnmatch.fnmatch(ref, p) for p in lock_globs):
+            continue
+        out.append(ref)
+    return sorted(out)
+
+
+def ignore_net_ids(pcb_data, patterns: Optional[Sequence[str]]) -> Set[int]:
+    """Net ids matching the --ignore-nets patterns (plane-routed rails)."""
+    ids: Set[int] = set()
+    if patterns:
+        for net_id, net in pcb_data.nets.items():
+            if any(fnmatch.fnmatch(net.name, p) for p in patterns):
+                ids.add(net_id)
+    return ids
+
+
+def make_oracle(pcb_data, pcb_file: str, *, free: Sequence[str],
+                clearance: float, board_edge_clearance: float,
+                grid_step: float, ignore_ids: Set[int]):
+    """The shared scoring/legality state. Guidance weights (pose_score), the
+    run's geometry knobs, and `move_refs=free` so `.locked` on each part
+    matches what the portfolio is allowed to touch."""
+    import pose_score
+    return pose_score.make_state(
+        pcb_data, pcb_file, clearance=clearance,
+        board_edge_clearance=board_edge_clearance, grid_step=grid_step,
+        ignore_net_ids=ignore_ids, move_refs=set(free))
+
+
+def _snapshot(state, refs: Sequence[str]) -> Dict[str, Tuple[float, float, float]]:
+    return {r: (state.parts[r].x, state.parts[r].y, state.parts[r].rot)
+            for r in refs if r in state.parts}
+
+
+def _restore(state, snap: Dict[str, Tuple[float, float, float]]) -> None:
+    for ref in sorted(snap):
+        x, y, rot = snap[ref]
+        p = state.parts[ref]
+        if (p.x, p.y, p.rot) != (x, y, rot):
+            state.apply_move(ref, x, y, rot)
+
+
+def copy_siblings(src_board: str, dst_board: str) -> None:
+    """Carry the project/rules siblings (#441): a board without its .kicad_pro
+    grades at the stock netclass, so every written candidate gets the input's
+    siblings -- the probe routes and any later adoption read them."""
+    src_base = os.path.splitext(src_board)[0]
+    dst_base = os.path.splitext(dst_board)[0]
+    for ext in ('.kicad_pro', '.kicad_dru', '.kicad_prl'):
+        s = src_base + ext
+        if os.path.isfile(s):
+            shutil.copyfile(s, dst_base + ext)
+
+
+# --------------------------------------------------------------------------
+# perturbation strategies
+# --------------------------------------------------------------------------
+# Each strategy PROPOSES poses on the oracle state, validating with
+# candidate_valid and applying accepted moves as it goes -- so a later part is
+# tested against its already-perturbed peers, and the emitted set is legal as a
+# WHOLE, not merely pairwise against the original board. The caller owns the
+# snapshot/restore bracket.
+
+def perturb_jitter(state, refs: Sequence[str], rng: random.Random,
+                   radius: float, attempts: int = SAMPLE_ATTEMPTS) -> List[Dict]:
+    """Uniform-disc offset per free ref, rotation unchanged. The direct
+    basin-escape for a zero-temperature descent: the quench cannot leave a
+    local minimum, so the seed does it instead, bounded by `radius`.
+
+    A part whose INCUMBENT pose is not fully legal is skipped, not jittered.
+    Two real populations live there: parts off the board by design (edge
+    connectors, castellated rows -- candidate_valid's toward-the-board branch
+    would happily walk one inboard and silently break its overhang spec) and
+    dense hand-packed parts already under the courtyard clearance (any
+    accepted sample would be a lateral trade the quench's own gate refuses).
+    Skipping draws nothing from the rng, so the stream stays stable."""
+    poses: List[Dict] = []
+    for ref in refs:
+        part = state.parts.get(ref)
+        if part is None:
+            continue
+        if not state.candidate_valid(ref, part.x, part.y, part.rot):
+            continue
+        for _ in range(attempts):
+            r = radius * math.sqrt(rng.random())
+            th = 2.0 * math.pi * rng.random()
+            x = round(part.x + r * math.cos(th), 4)
+            y = round(part.y + r * math.sin(th), 4)
+            if state.candidate_valid(ref, x, y, part.rot):
+                state.apply_move(ref, x, y, part.rot)
+                poses.append({'reference': ref, 'new_x': x, 'new_y': y,
+                              'new_rotation': part.rot})
+                break
+    return poses
+
+
+def perturb_poses(state, refs: Sequence[str],
+                  variant_index: int) -> Optional[List[Dict]]:
+    """Deterministic rotation variant: one of the top multi-pin free parts
+    turned to a legal rotation that does not RAISE its forced-crossing floor.
+
+    The inversion prune is the point -- ``pair_order.ref_inversions`` is a
+    lower bound no router can remove, so a rotation that increases it is
+    provably worse before any quench is paid (the U3 rot-180 story, run 5:
+    the cost was indifferent, the inversion count was not). Returns None when
+    `variant_index` runs past the legal variants: that strategy round is
+    barren, which the caller reports rather than papers over."""
+    from placement.pair_order import ref_inversions
+    ranked = sorted((r for r in refs
+                     if r in state.parts and state.parts[r].pin_count >= 2),
+                    key=lambda r: (-state.parts[r].pin_count, r))[:POSES_TOP_PARTS]
+    variants: List[Tuple[str, float]] = []
+    for ref in ranked:
+        part = state.parts[ref]
+        # Same incumbent guard as jitter: a part off the board or already
+        # under clearance must not be offered rotations through
+        # candidate_valid's improvement branch.
+        if not state.candidate_valid(ref, part.x, part.y, part.rot):
+            continue
+        base_inv = ref_inversions(state, ref)
+        for delta in (90.0, 180.0, 270.0):
+            rot = (part.rot + delta) % 360
+            if not state.candidate_valid(ref, part.x, part.y, rot):
+                continue
+            if ref_inversions(state, ref, part.x, part.y, rot) > base_inv:
+                continue
+            variants.append((ref, rot))
+    if variant_index >= len(variants):
+        return None
+    ref, rot = variants[variant_index]
+    part = state.parts[ref]
+    state.apply_move(ref, part.x, part.y, rot)
+    return [{'reference': ref, 'new_x': part.x, 'new_y': part.y,
+             'new_rotation': rot}]
+
+
+def perturb_swaps(state, blocks: Dict[str, Sequence[str]], rng: random.Random,
+                  n_swaps: int, attempts: int = SAMPLE_ATTEMPTS) -> List[Dict]:
+    """Exchange the positions of two free members of one block, n_swaps times.
+
+    This is the rearrangement the quench's own swap phase cannot reach: its
+    swaps are capped by max_displacement and same-footprint only, so two
+    different parts across a zone never trade places. Each exchange is tested
+    part-vs-world with the partner excluded (it vacates), plus an exact
+    pair test of the two NEW poses against each other.
+
+    Members are filtered to FREE parts here, not left to geometry:
+    candidate_valid answers "is this pose legal", never "may this part move",
+    so without the filter a swap could relocate a locked connector."""
+    def _free_members(refs):
+        # Free AND legally seated: the same incumbent guard jitter applies --
+        # an off-board or sub-clearance part must not be traded through
+        # candidate_valid's improvement branch.
+        return sorted(r for r in refs
+                      if r in state.parts and not state.parts[r].locked
+                      and state.parts[r].pin_count > 0
+                      and state.candidate_valid(
+                          r, state.parts[r].x, state.parts[r].y,
+                          state.parts[r].rot))
+
+    eligible = sorted(name for name, refs in blocks.items()
+                      if len(_free_members(refs)) >= 2)
+    if not eligible:
+        return []
+    poses: Dict[str, Dict] = {}
+    made = 0
+    for _ in range(attempts):
+        if made >= n_swaps:
+            break
+        name = eligible[rng.randrange(len(eligible))]
+        members = _free_members(blocks[name])
+        a, b = rng.sample(members, 2)
+        pa, pb = state.parts[a], state.parts[b]
+        ax, ay, bx, by = pa.x, pa.y, pb.x, pb.y
+        if not state.candidate_valid(a, bx, by, pa.rot, exclude={b}):
+            continue
+        if not state.candidate_valid(b, ax, ay, pb.rot, exclude={a}):
+            continue
+        # candidate_valid excluded the partner, so the two NEW poses were
+        # never tested against each other; do it exactly.
+        gap = pa.gap_to(pb, pa.rects(bx, by, pa.rot), pb.rects(ax, ay, pb.rot))
+        if gap is not None and gap < state.clearance:
+            continue
+        state.apply_move(a, bx, by, pa.rot)
+        state.apply_move(b, ax, ay, pb.rot)
+        poses[a] = {'reference': a, 'new_x': bx, 'new_y': by,
+                    'new_rotation': pa.rot}
+        poses[b] = {'reference': b, 'new_x': ax, 'new_y': ay,
+                    'new_rotation': pb.rot}
+        made += 1
+    return [poses[r] for r in sorted(poses)]
+
+
+# --------------------------------------------------------------------------
+# generation
+# --------------------------------------------------------------------------
+
+def _final_poses(pcb_data, placements: List[Dict]) -> Dict[str, Tuple[float, float, float]]:
+    """Seed poses overlaid with the quench's returned moves. The quench omits
+    parts that ended exactly on their seed, so the overlay IS the final state."""
+    out = {ref: (fp.x, fp.y, fp.rotation % 360)
+           for ref, fp in pcb_data.footprints.items() if fp.pads}
+    for p in placements:
+        out[p['reference']] = (p['new_x'], p['new_y'], p['new_rotation'])
+    return out
+
+
+def _displacement(final: Dict[str, Tuple[float, float, float]],
+                  origin: Dict[str, Tuple[float, float, float]],
+                  free: Sequence[str]) -> Tuple[float, List[str]]:
+    """(rms displacement over free refs, refs that moved) vs the input board."""
+    moved = []
+    acc = 0.0
+    n = 0
+    for ref in free:
+        if ref not in final or ref not in origin:
+            continue
+        fx, fy, frot = final[ref]
+        ox, oy, orot = origin[ref]
+        d = math.hypot(fx - ox, fy - oy)
+        rot_changed = abs((frot - orot) % 360) > 1e-3
+        if d > 1e-4 or rot_changed:
+            moved.append(ref)
+        acc += d * d + (1.0 if rot_changed else 0.0)
+        n += 1
+    return (math.sqrt(acc / n) if n else 0.0), moved
+
+
+def pose_distance_mm(final_a: Dict[str, Tuple[float, float, float]],
+                     final_b: Dict[str, Tuple[float, float, float]],
+                     free: Sequence[str]) -> float:
+    """RMS pose distance over the free refs; a rotation difference counts a
+    flat 1.0. Pose distance, not hpwl distance, deliberately: hpwl reads only
+    per-net extremes, so a mirrored or permuted arrangement can tie a clone --
+    this measures "a genuinely different placement" directly."""
+    acc = 0.0
+    n = 0
+    for ref in free:
+        if ref not in final_a or ref not in final_b:
+            continue
+        ax, ay, arot = final_a[ref]
+        bx, by, brot = final_b[ref]
+        acc += (ax - bx) ** 2 + (ay - by) ** 2
+        if abs((arot - brot) % 360) > 1e-3:
+            acc += 1.0
+        n += 1
+    return math.sqrt(acc / n) if n else 0.0
+
+
+def _quench_to(src_board: str, dst_board: str, quench_kw: Dict,
+               groups: Optional[Dict]) -> Tuple[Dict, Dict]:
+    """Parse src, quench in-process, write the result AGAINST src (the seed
+    file), carry siblings. Returns (metrics, final_poses)."""
+    from kicad_parser import parse_kicad_pcb
+    from placement.quench import quench
+    from placement.writer import write_placed_output
+    pcb_local = parse_kicad_pcb(src_board)
+    m: Dict = {}
+    placements = quench(pcb_local, pcb_file=src_board, metrics_out=m,
+                        groups=groups, **quench_kw)
+    write_placed_output(src_board, dst_board, placements)
+    copy_siblings(src_board, dst_board)
+    return m, _final_poses(pcb_local, placements)
+
+
+def generate(input_file: str, out_dir: str, *, seed: int = 0,
+             n_candidates: int = 12,
+             strategies: Sequence[str] = DEFAULT_STRATEGIES,
+             radius: float = 4.0,
+             lock_globs: Optional[Sequence[str]] = None,
+             ignore_nets: Optional[Sequence[str]] = None,
+             swap_blocks: Optional[Dict[str, Sequence[str]]] = None,
+             quench_kw: Optional[Dict] = None,
+             groups: Optional[Dict] = None,
+             only: Optional[int] = None) -> Dict:
+    """Generate the portfolio: baseline quench (candidate 0) plus perturbed
+    candidates 1..n_candidates-1, all boards written under `out_dir`.
+
+    Deterministic by contract: candidate i's stream is
+    ``random.Random(f"{seed}:{i}:{strategy}")`` and its `poses` variant index
+    is the round number ``(i-1) // len(strategies)`` -- both functions of i
+    alone, so ``only=i`` regenerates that candidate byte-identically without
+    running the others.
+
+    Returns {'baseline': Candidate|None, 'candidates': [Candidate], 'free': [...]}.
+    """
+    from kicad_parser import parse_kicad_pcb
+    from placement.writer import write_placed_output
+
+    os.makedirs(out_dir, exist_ok=True)
+    qkw = dict(quench_kw or {})
+    strategies = tuple(strategies)
+    if not strategies:
+        raise ValueError("no strategies enabled")
+
+    pcb = parse_kicad_pcb(input_file)
+    free = free_refs(pcb, input_file, lock_globs)
+    ids = ignore_net_ids(pcb, ignore_nets)
+    oracle = make_oracle(
+        pcb, input_file, free=free,
+        clearance=qkw.get('clearance', 0.25),
+        board_edge_clearance=qkw.get('board_edge_clearance', 0.55),
+        grid_step=qkw.get('grid_step', 0.1), ignore_ids=ids)
+    origin = {ref: (p.x, p.y, p.rot) for ref, p in oracle.parts.items()}
+
+    baseline: Optional[Candidate] = None
+    if only is None:
+        print(f"[portfolio] candidate 0 (baseline): plain quench")
+        board0 = os.path.join(out_dir, 'baseline_quenched.kicad_pcb')
+        m, final = _quench_to(input_file, board0, qkw, groups)
+        rms, moved = _displacement(final, origin, free)
+        baseline = Candidate(
+            index=0, strategy='baseline', seed_board=input_file, board=board0,
+            final_poses=final, moved_refs=moved, displacement_rms=rms,
+            metrics=_quench_metrics(m))
+
+    indices = [only] if only is not None else list(range(1, n_candidates))
+    candidates: List[Candidate] = []
+    for i in indices:
+        if i < 1:
+            raise ValueError(f"candidate index {i} out of range (baseline is "
+                             f"not regenerable via only=; it has no stream)")
+        strategy = strategies[(i - 1) % len(strategies)]
+        rng = random.Random(f"{seed}:{i}:{strategy}")
+        snap = _snapshot(oracle, free)
+        note = ''
+        if strategy == 'jitter':
+            poses = perturb_jitter(oracle, free, rng, radius)
+        elif strategy == 'poses':
+            poses = perturb_poses(oracle, free, (i - 1) // len(strategies))
+            if poses is None:
+                poses = []
+                note = ('poses: no rotation variant left at round '
+                        f'{(i - 1) // len(strategies)}')
+        elif strategy == 'swap':
+            n_swaps = rng.randint(1, 3)
+            poses = perturb_swaps(oracle, swap_blocks or {}, rng, n_swaps)
+            if not poses and not swap_blocks:
+                note = 'swap: no blocks resolved (pass --intent or --group-by)'
+        else:
+            raise ValueError(f"unknown strategy {strategy!r}")
+        _restore(oracle, snap)
+
+        cand = Candidate(index=i, strategy=strategy, poses=poses, note=note)
+        if not poses:
+            cand.note = cand.note or f'{strategy}: produced no perturbation'
+            cand.gates = {'passed': False, 'reasons': [cand.note]}
+            candidates.append(cand)
+            print(f"[portfolio] candidate {i} ({strategy}): barren -- {cand.note}")
+            continue
+
+        print(f"[portfolio] candidate {i} ({strategy}): "
+              f"{len(poses)} part(s) perturbed")
+        seed_board = os.path.join(out_dir, f'cand_{i:02d}.seed.kicad_pcb')
+        write_placed_output(input_file, seed_board, poses)
+        copy_siblings(input_file, seed_board)
+        board = os.path.join(out_dir, f'cand_{i:02d}.kicad_pcb')
+        m, final = _quench_to(seed_board, board, qkw, groups)
+        rms, moved = _displacement(final, origin, free)
+        cand.seed_board = seed_board
+        cand.board = board
+        cand.final_poses = final
+        cand.moved_refs = moved
+        cand.displacement_rms = rms
+        cand.metrics = _quench_metrics(m)
+        candidates.append(cand)
+
+    return {'baseline': baseline, 'candidates': candidates, 'free': free}
+
+
+def _quench_metrics(m: Dict) -> Dict:
+    """The unweighted, cross-run-comparable slice of a quench's metrics_out."""
+    after = m.get('after', {})
+    leg = m.get('legality', {})
+    return {'crossings': after.get('crossings'),
+            'hpwl': round(after.get('hpwl', 0.0), 3),
+            'length': round(after.get('length', 0.0), 3),
+            'overlap_area': round(leg.get('overlap_area', 0.0), 4),
+            'oob_count': leg.get('oob_count', 0),
+            'oob_amount': round(leg.get('oob_amount', 0.0), 4)}
+
+
+# --------------------------------------------------------------------------
+# scoring, ranking, diversity
+# --------------------------------------------------------------------------
+
+def score_candidate(cand: Candidate, *, free: Sequence[str],
+                    baseline_overlap: float, baseline_oob: int = 0,
+                    clearance: float, board_edge_clearance: float,
+                    grid_step: float, ignore_nets: Optional[Sequence[str]],
+                    intent=None, group_sources: Sequence[str] = ()) -> None:
+    """Fill gates / inversions / intent / health for one quenched candidate.
+
+    Hard gates (fail => not ranked, reason kept): legality (no MORE courtyard
+    overlap and no MORE out-of-board parts than the baseline -- both measured
+    against the baseline rather than zero, because a legitimate board can
+    already carry both: edge connectors and castellated rows overhang the
+    outline by design, and dense hand placements sit under the courtyard
+    clearance) and, when an intent is given, an error-free
+    ``floorplan.grade``. Health signals are ADVISORY (they join the rank key,
+    not the gate) -- routability.py states why: they say the floorplan will
+    fight the router, not that it is wrong.
+    """
+    from kicad_parser import parse_kicad_pcb
+    from placement.pair_order import pair_inversions
+
+    if not cand.board:
+        return
+    pcb = parse_kicad_pcb(cand.board)
+    ids = ignore_net_ids(pcb, ignore_nets)
+    state = make_oracle(pcb, cand.board, free=free, clearance=clearance,
+                        board_edge_clearance=board_edge_clearance,
+                        grid_step=grid_step, ignore_ids=ids)
+    inv_total = sum(m['inversions'] for m in pair_inversions(state).values())
+    cand.metrics['inversions'] = inv_total
+
+    reasons: List[str] = []
+    overlap = cand.metrics.get('overlap_area', 0.0)
+    if overlap > baseline_overlap + EPS:
+        reasons.append(f"courtyard overlap {overlap:.4f}mm2 exceeds the "
+                       f"baseline's {baseline_overlap:.4f}mm2")
+    oob = cand.metrics.get('oob_count', 0)
+    if oob > baseline_oob:
+        reasons.append(f"{oob} part(s) out of board vs the baseline's "
+                       f"{baseline_oob}")
+
+    health_penalty = 0
+    if intent is not None:
+        from placement import floorplan
+        result = floorplan.grade(intent, pcb, cand.board,
+                                 group_sources=group_sources,
+                                 clearance=clearance,
+                                 board_edge_clearance=board_edge_clearance,
+                                 with_health=True)
+        errors = [v.to_dict() for v in result.errors]
+        cand.intent = {'errors': len(errors), 'warnings': len(result.warnings),
+                       'violations': errors[:10]}
+        if errors:
+            reasons.append(f"{len(errors)} intent violation(s): "
+                           + '; '.join(v['message'] for v in errors[:3]))
+        h = result.health or {}
+        rows = h.get('bus_corridors') or []
+        intrusions = sum(len(r.get('intrusions') or ()) for r in rows)
+        health_penalty = (int(h.get('bus_foreign_crossings') or 0)
+                          + intrusions + int(h.get('blocks_displaced') or 0))
+        cand.health = {
+            'bus_foreign_crossings': h.get('bus_foreign_crossings'),
+            'intrusions': intrusions,
+            'blocks_displaced': h.get('blocks_displaced'),
+            'block_displacement_max_mm': h.get('block_displacement_max_mm'),
+            'penalty': health_penalty}
+    cand.metrics['health_penalty'] = health_penalty
+    cand.gates = {'passed': not reasons, 'reasons': reasons}
+
+
+def rank_key(cand: Candidate) -> Tuple:
+    """The static order: lexicographic over numbers the repo already trusts,
+    most significant first, no new magic weights.
+
+      crossings      the first-class pre-route judge (raw count)
+      inversions     the forced-crossing floor -- equal-crossings ties break
+                     toward the more REMOVABLE set (pair_order is a lower
+                     bound a router cannot beat)
+      hpwl           order-invariant geometry
+      health         advisory floorplan-fight signals (0 without an intent)
+      displacement   least disturbance wins what is left
+      index          stability
+    """
+    m = cand.metrics
+    return (m.get('crossings', 1 << 30),
+            m.get('inversions', 1 << 30),
+            round(m.get('hpwl', float('inf')), 3),
+            m.get('health_penalty', 0),
+            round(cand.displacement_rms, 2),
+            cand.index)
+
+
+def rank_static(cands: Sequence[Candidate]) -> List[int]:
+    """Indices of the gate-passing candidates, best first."""
+    return [c.index for c in sorted((c for c in cands if c.viable),
+                                    key=rank_key)]
+
+
+def select_diverse(cands: Sequence[Candidate], order: Sequence[int],
+                   keep: int, min_dist_mm: float,
+                   free: Sequence[str],
+                   baseline: Optional[Candidate]) -> Tuple[List[int], List[int]]:
+    """Walk the ranked order, keeping a candidate only when it sits at least
+    `min_dist_mm` (pose distance) from everything already kept -- the baseline
+    included, so a candidate that quenched back into the incumbent's basin is
+    recognized as "no new option" rather than presented twice. When fewer than
+    `keep` survive, backfill by rank and SAY so (second return value): a slate
+    padded with near-clones must not read as a diverse one.
+    """
+    by_index = {c.index: c for c in cands}
+    kept: List[int] = []
+    kept_poses = [baseline.final_poses] if baseline is not None else []
+    for idx in order:
+        if len(kept) >= keep:
+            break
+        c = by_index[idx]
+        if all(pose_distance_mm(c.final_poses, p, free) >= min_dist_mm
+               for p in kept_poses):
+            kept.append(idx)
+            kept_poses.append(c.final_poses)
+    backfilled: List[int] = []
+    if len(kept) < keep:
+        for idx in order:
+            if len(kept) >= keep:
+                break
+            if idx not in kept:
+                kept.append(idx)
+                backfilled.append(idx)
+    return kept, backfilled

--- a/placement/seeder.py
+++ b/placement/seeder.py
@@ -1,0 +1,395 @@
+"""Generate an initial placement from a declared floorplan intent.
+
+The placement stack refines; it deliberately does not place from scratch
+UNAIDED (placement_state.py:13, docs/placement-optimization.md) -- handed a
+pile of parts it has nothing to inherit constraints from. This module is the
+aided path: the intent file IS the constraint carrier (zones, edge bands,
+locks, decap rules), so a board whose repo declares one can get a legal,
+deterministic, seeded starting placement instead of a refusal.
+
+What each intent construct becomes, in placement order:
+
+  1. ``edge_connectors``   the declared edge, overhang centered in the band,
+                           distributed evenly along the edge. Placed WITHOUT
+                           the legality gate: overhanging the outline is the
+                           point, and candidate_valid would veto it.
+  2. single-ref zones      the zone center -- the "few hundred microns around
+                           the spec coordinate" pattern for spec-pinned parts.
+  3. multi-ref zones       members packed radially from the zone center,
+                           highest pin count first, constrained to the zone
+                           rect plus its declared tolerance.
+  4. everything else       nearest legal pose to the centroid of its already-
+                           placed partners (fanout-capped, so GND does not
+                           drag everything to the board middle) -- which is
+                           also what lands a decap next to its IC.
+
+Rotations: the input rotation is tried IN FULL first and kept when it fits;
+a part with no contained legal pose at it falls back to its 90-degree
+lattice, and the note names the change. The intent schema cannot express a
+rotation, so a part whose rotation is a DECISION (pin order, the U3 rot-180
+case) must be locked -- an unlocked load-bearing rotation was never
+protected from the quench either. Explore rotations deliberately with
+place_portfolio's `poses` strategy.
+
+Determinism: the only randomness is ``random.Random(f"{seed}")`` -- it breaks
+ties in the packing order and jitters non-spec targets, so different seeds
+give genuinely different (still legal) seeds while the same seed reproduces
+byte for byte. Everything else iterates sorted (#457).
+"""
+from __future__ import annotations
+
+import fnmatch
+import math
+import random
+import re
+from typing import Dict, List, Optional, Sequence, Set, Tuple
+
+# Ring-search enumeration: nearest-first out to this radius, then a FINE ring
+# near the target, then a coarse whole-board sweep. The fine pass exists
+# because a packed board's remaining windows can be sub-millimeter -- measured:
+# the 51x21 board's LDO had exactly one fully-legal window left, 0.09mm tall,
+# which both a 1.0mm ring and a 2.0mm sweep step straight over. A part that
+# finds nothing anywhere is reported UNSEATED, never silently dropped.
+SEARCH_RADIUS_MM = 30.0
+SEARCH_STEP_MM = 1.0
+SEARCH_FINE_RADIUS_MM = 16.0
+SEARCH_FINE_STEP_MM = 0.25
+FALLBACK_STEP_MM = 2.0
+TARGET_JITTER_MM = 1.5
+
+
+def _rect_inside(rect, outer, tol: float) -> bool:
+    return (rect[0] >= outer[0] - tol and rect[1] >= outer[1] - tol
+            and rect[2] <= outer[2] + tol and rect[3] <= outer[3] + tol)
+
+
+def _try_place(state, ref: str, tx: float, ty: float, exclude: Set[str],
+               constraint=None, tol: float = 0.5) -> bool:
+    """Nearest FULLY-CONTAINED legal pose to (tx, ty); applies the move and
+    returns True.
+
+    `exclude` carries the not-yet-placed refs: the pile they still form at
+    their meaningless input coordinates must not veto real poses.
+
+    candidate_valid alone is not the right gate here: for a part whose
+    INCUMBENT pose is off the board (a generator's default position can be),
+    its #456 branch accepts poses that move strictly TOWARD the board while
+    still outside it -- measured: a free LDO seeded 2.7mm outside the
+    outline, "placed", unseated 0. Placement from scratch has no incumbent
+    worth improving on, so full containment is demanded explicitly; the only
+    deliberate off-board poses are the edge connectors, which stage 1 places
+    without this helper.
+
+    The part's CURRENT rotation is tried in full first, then the rest of its
+    90-degree lattice: an unplaced pile's rotation is a generator default,
+    not a decision, and a large part can have NO contained legal pose at it
+    while fitting fine turned 90 (measured: the same LDO, 0 poses at rot 0
+    against 3 at rot 90 on a packed 51x21 board). A part whose rotation IS a
+    decision must be locked -- an unlocked "load-bearing rotation" was never
+    protected from the quench either (the U3 lesson). The caller can see a
+    fallback fired by comparing the part's rot before and after.
+
+    Returns the courtyard clearance the pose was found at, or None. The full
+    clearance is demanded first; when the whole board offers nothing, the
+    search reruns at half, then at a 0.02mm floor -- dense boards carry
+    sub-clearance courtyard pairs BY DESIGN (the reference hand seed for the
+    51x21 board places its LDO 0.04mm from a locked decap; a 0.05 floor
+    still refused that board), and refusing to seed what a human
+    deliberately packs would fail real boards. Courtyards carry their own
+    margin, so a small courtyard-to-courtyard gap is not a copper hazard. A
+    relaxed placement is a NOTE for the caller, never silent."""
+    from pose_score import _offsets
+    part = state.parts[ref]
+
+    def _ok(x, y, rot):
+        if state.edge_gate.rect_outside_amount(part.rect(x, y, rot)) > 1e-9:
+            return False
+        return state.candidate_valid(ref, x, y, rot, exclude=exclude)
+
+    full = state.clearance
+    try:
+        for clr in (full, full / 2.0, min(0.02, full)):
+            # candidate_valid reads state.clearance; the incumbent-violation
+            # cache is keyed on it implicitly, so clear it on every change.
+            state.clearance = clr
+            state._inc_violation.clear()
+            for rot in [part.rot] + [(part.rot + d) % 360
+                                     for d in (90.0, 180.0, 270.0)]:
+                for radius, step in ((SEARCH_RADIUS_MM, SEARCH_STEP_MM),
+                                     (SEARCH_FINE_RADIUS_MM,
+                                      SEARCH_FINE_STEP_MM)):
+                    for dx, dy in _offsets(radius, step):
+                        x, y = round(tx + dx, 3), round(ty + dy, 3)
+                        if constraint is not None and not _rect_inside(
+                                part.rect(x, y, rot), constraint, tol):
+                            continue
+                        if _ok(x, y, rot):
+                            state.apply_move(ref, x, y, rot)
+                            return clr
+                if constraint is not None:
+                    continue    # a zone-constrained part stays in its zone
+                u = state.usable
+                grid = []
+                nx = max(1, int((u[2] - u[0]) / FALLBACK_STEP_MM))
+                ny = max(1, int((u[3] - u[1]) / FALLBACK_STEP_MM))
+                for i in range(nx + 1):
+                    for j in range(ny + 1):
+                        x = round(u[0] + i * FALLBACK_STEP_MM, 3)
+                        y = round(u[1] + j * FALLBACK_STEP_MM, 3)
+                        grid.append(((x - tx) ** 2 + (y - ty) ** 2, x, y))
+                grid.sort()
+                for _, x, y in grid:
+                    if _ok(x, y, rot):
+                        state.apply_move(ref, x, y, rot)
+                        return clr
+    finally:
+        state.clearance = full
+        state._inc_violation.clear()
+    return None
+
+
+def _edge_pose(part, bounds, edge: str, frac: float, overhang: float
+               ) -> Tuple[float, float]:
+    """Center coordinates that put the part's courtyard `overhang` mm past
+    the named edge of the BOUNDING BOX, at fraction `frac` along it. A first
+    guess only -- see _edge_correct for why it cannot be the answer."""
+    lx0, ly0, lx1, ly1 = part.rect(0.0, 0.0, part.rot)
+    x0, y0, x1, y1 = bounds
+    if edge == 'north':
+        return x0 + (x1 - x0) * frac, y0 - overhang - ly0
+    if edge == 'south':
+        return x0 + (x1 - x0) * frac, y1 + overhang - ly1
+    if edge == 'west':
+        return x0 - overhang - lx0, y0 + (y1 - y0) * frac
+    if edge == 'east':
+        return x1 + overhang - lx1, y0 + (y1 - y0) * frac
+    raise ValueError(f"unknown edge {edge!r}")
+
+
+def _edge_correct(state, ref: str, edge: str, x: float, y: float,
+                  target: float) -> Tuple[float, float]:
+    """Walk the pose along the edge normal until the MEASURED overhang hits
+    `target`. The analytic pose measures against the bounding box, but the
+    grade's rule_edge_connector measures rect_outside_amount against the real
+    Edge.Cuts rings -- on a non-rectangular outline the two differ by the
+    local inset, and a seed placed by the bbox grades over its declared band
+    (measured on splitflap: 4 connectors 0.1-0.2mm past their max)."""
+    part = state.parts[ref]
+    for _ in range(4):
+        amt = state.edge_gate.rect_outside_amount(part.rect(x, y, part.rot))
+        err = target - amt
+        if abs(err) < 0.02:
+            break
+        if edge == 'north':
+            y -= err
+        elif edge == 'south':
+            y += err
+        elif edge == 'west':
+            x -= err
+        else:
+            x += err
+    return x, y
+
+
+def _partner_centroid(state, ref: str, placed: Set[str],
+                      max_fanout: int = 20) -> Optional[Tuple[float, float]]:
+    """Centroid of already-placed partners' pads on shared nets. Nets owned by
+    more than `max_fanout` parts are excluded for the routability.py reason:
+    they reach everywhere by design and would collapse every centroid onto the
+    board middle. Plane nets are NOT otherwise excluded here -- for a decap,
+    the rail net is exactly what tethers it to its IC."""
+    part = state.parts.get(ref)
+    if part is None:
+        return None
+    xs: List[float] = []
+    ys: List[float] = []
+    for nid in part.nets:
+        owners = state.net_refs.get(nid, ())
+        if len(owners) > max_fanout:
+            continue
+        for other in owners:
+            if other == ref or other not in placed:
+                continue
+            for gx, gy, pn in state.parts[other].pad_globals():
+                if pn == nid:
+                    xs.append(gx)
+                    ys.append(gy)
+    if not xs:
+        return None
+    return sum(xs) / len(xs), sum(ys) / len(ys)
+
+
+def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
+                     group_sources: Sequence[str] = (),
+                     clearance: float = 0.25,
+                     board_edge_clearance: float = 0.55,
+                     grid_step: float = 0.1) -> Dict:
+    """Compute a full placement for an unplaced board from its intent.
+
+    Returns {'placements': [...], 'lock_refs': [...], 'unseated': [...],
+    'notes': [...]}. `placements` covers every ref that was placed (writer
+    format); `unseated` names parts NO legal pose was found for -- the caller
+    reports them and the grade fails, deliberately.
+    """
+    import pose_score
+    from placement import floorplan
+
+    state = pose_score.make_state(
+        pcb_data, pcb_file, clearance=clearance,
+        board_edge_clearance=board_edge_clearance, grid_step=grid_step)
+    bounds = state.board
+    refs_all = sorted(pcb_data.footprints)
+    notes: List[str] = []
+
+    blocks, block_problems = floorplan.resolve_blocks(
+        intent, pcb_data, group_sources)
+    for v in block_problems:
+        notes.append(v.message)
+    zones_by_name = {z.name: z for z in intent.blocks if z.rect is not None}
+
+    lock_refs: List[str] = sorted({
+        r for pat in intent.must_lock for r in fnmatch.filter(refs_all, pat)})
+
+    placed: Set[str] = set()
+    unplaced: Set[str] = {r for r, p in state.parts.items()}
+    unseated: List[str] = []
+    # A part locked IN THE FILE is already authoritatively placed -- a caller
+    # that pre-placed its spec-fixed parts and stamped them (locked yes) must
+    # not have the seeder re-derive them. Treated as placed from the start:
+    # they anchor the connectivity centroids and obstruct packing, and every
+    # later stage (edge connectors included) skips them.
+    for ref in sorted(state.parts):
+        if state.parts[ref].locked:
+            placed.add(ref)
+            unplaced.discard(ref)
+    # Deterministic tie-break values, drawn once in sorted order so the
+    # stream never depends on set iteration.
+    tiebreak = {r: rng.random() for r in sorted(state.parts)}
+
+    def _order(refs):
+        return sorted((r for r in refs if r in unplaced),
+                      key=lambda r: (-state.parts[r].pin_count, tiebreak[r]))
+
+    def _jitter():
+        return (rng.uniform(-TARGET_JITTER_MM, TARGET_JITTER_MM),
+                rng.uniform(-TARGET_JITTER_MM, TARGET_JITTER_MM))
+
+    # ---- 1. edge connectors: spec geometry, no legality gate ---------------
+    by_edge: Dict[str, List[Dict]] = {}
+    for c in intent.edge_connectors:
+        if c['ref'] not in state.parts:
+            notes.append(f"edge connector {c['ref']} is not on this board")
+        elif c['ref'] in unplaced:
+            by_edge.setdefault(c.get('edge') or 'south', []).append(c)
+    for edge in sorted(by_edge):
+        specs = sorted(by_edge[edge], key=lambda c: c['ref'])
+        for k, c in enumerate(specs):
+            ref = c['ref']
+            part = state.parts[ref]
+            band = c.get('overhang_mm') or {}
+            lo = float(band.get('min', 0.0))
+            hi = band.get('max')
+            overhang = (lo + float(hi)) / 2.0 if hi is not None else max(lo, 0.5)
+            frac = (k + 1) / (len(specs) + 1)
+            x, y = _edge_pose(part, bounds, edge, frac, overhang)
+            x, y = _edge_correct(state, ref, edge, x, y, overhang)
+            state.apply_move(ref, round(x, 3), round(y, 3), part.rot)
+            placed.add(ref)
+            unplaced.discard(ref)
+
+    # ---- 2. zoned blocks: radial pack from the zone center -----------------
+    # A single-member zone is the spec-coordinate pattern (a rect a few
+    # hundred microns wide around where the spec pins the part), so it gets
+    # the exact center; multi-member zones jitter each target so different
+    # seeds pack differently.
+    for name in sorted(zones_by_name):
+        z = zones_by_name[name]
+        members = _order(blocks.get(name, ()))
+        if not members:
+            continue
+        cx = (z.rect[0] + z.rect[2]) / 2.0
+        cy = (z.rect[1] + z.rect[3]) / 2.0
+        tol = intent.zone_tolerance(z)
+        for ref in members:
+            jx, jy = (0.0, 0.0) if len(members) == 1 else _jitter()
+            rot_before = state.parts[ref].rot
+            clr = _try_place(state, ref, cx + jx, cy + jy, unplaced - {ref},
+                             constraint=z.rect, tol=tol)
+            if clr is not None:
+                placed.add(ref)
+                unplaced.discard(ref)
+                if state.parts[ref].rot != rot_before:
+                    notes.append(f"{ref}: rotated {rot_before:g} -> "
+                                 f"{state.parts[ref].rot:g} (no contained "
+                                 f"pose at the input rotation)")
+                if clr < state.clearance:
+                    notes.append(f"{ref}: placed at reduced courtyard "
+                                 f"clearance {clr:g} (none at "
+                                 f"{state.clearance:g})")
+            else:
+                unseated.append(ref)
+                notes.append(f"{ref}: no legal pose inside zone {name!r}")
+
+    # ---- 3. the rest: connectivity centroid --------------------------------
+    center = ((bounds[0] + bounds[2]) / 2.0, (bounds[1] + bounds[3]) / 2.0)
+    for ref in _order(sorted(unplaced)):
+        target = _partner_centroid(state, ref, placed) or center
+        jx, jy = _jitter()
+        rot_before = state.parts[ref].rot
+        clr = _try_place(state, ref, target[0] + jx, target[1] + jy,
+                         unplaced - {ref})
+        if clr is not None:
+            placed.add(ref)
+            unplaced.discard(ref)
+            if state.parts[ref].rot != rot_before:
+                notes.append(f"{ref}: rotated {rot_before:g} -> "
+                             f"{state.parts[ref].rot:g} (no contained pose "
+                             f"at the input rotation)")
+            if clr < state.clearance:
+                notes.append(f"{ref}: placed at reduced courtyard clearance "
+                             f"{clr:g} (none at {state.clearance:g})")
+        else:
+            unseated.append(ref)
+            notes.append(f"{ref}: no legal pose anywhere on the board")
+
+    placements = [{'reference': ref,
+                   'new_x': state.parts[ref].x, 'new_y': state.parts[ref].y,
+                   'new_rotation': state.parts[ref].rot}
+                  for ref in sorted(placed)]
+    return {'placements': placements, 'lock_refs': lock_refs,
+            'unseated': sorted(unseated), 'notes': notes}
+
+
+def stamp_locked(board_file: str, refs: Sequence[str]) -> int:
+    """Insert `(locked yes)` into the named footprints, in place.
+
+    Inserted immediately after the footprint's opening token, which is before
+    the first pad -- the position placement/parser.extract_locked_refs (and
+    KiCad itself) reads it from. The grade's must_lock rule demands the lock
+    IN THE FILE, so writing the intent's locks here is what makes the emitted
+    seed grade clean rather than merely hoped-correct."""
+    from kicad_parser import find_matching_paren
+    with open(board_file, 'r', encoding='utf-8') as f:
+        content = f.read()
+    want = set(refs)
+    count = 0
+    starts = [m.start() for m in re.finditer(r'\(footprint\s+"', content)]
+    for start in reversed(starts):
+        end = find_matching_paren(content, start)
+        fp_text = content[start:end]
+        m = re.search(r'\(property\s+"Reference"\s+"([^"]+)"', fp_text)
+        if not m or m.group(1) not in want:
+            continue
+        if re.search(r'\(locked\s+yes\)', fp_text[:fp_text.find('(pad')
+                                                  if '(pad' in fp_text else len(fp_text)]):
+            continue
+        open_m = re.match(r'\(footprint\s+"[^"]*"', fp_text)
+        if not open_m:
+            continue
+        at = open_m.end()
+        content = (content[:start + at] + '\n\t\t(locked yes)'
+                   + content[start + at:])
+        count += 1
+    with open(board_file, 'w', encoding='utf-8') as f:
+        f.write(content)
+    return count

--- a/tests/test_place_seed.py
+++ b/tests/test_place_seed.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""place_seed: an unplaced pile + an intent must become a placement that
+grades clean against that same intent, deterministically per seed.
+
+The pile fixture is synthesized (every part stacked at the board center, the
+test_431 trick) and the intent is emitted OFF the real placed board, so the
+seeder is asked for an arrangement that provably exists."""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for p in (REPO,):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+BOARD = os.path.join(REPO, "kicad_files", "splitflap_driver.kicad_pcb")
+
+passed = failed = 0
+
+
+def check(name, ok, detail=""):
+    global passed, failed
+    passed += bool(ok)
+    failed += not ok
+    print(f"  {'OK  ' if ok else 'FAIL'} {name}{(' -- ' + detail) if detail else ''}")
+
+
+def run(argv, hashseed="0", timeout=1800):
+    env = dict(os.environ, PYTHONHASHSEED=hashseed,
+               PYTHONIOENCODING='utf-8')
+    return subprocess.run([sys.executable, '-X', 'utf8'] + argv,
+                          capture_output=True, text=True, encoding='utf-8',
+                          errors='replace', cwd=REPO, env=env,
+                          timeout=timeout)
+
+
+def summary(r):
+    line = next(l for l in r.stdout.splitlines()
+                if l.startswith('JSON_SUMMARY:'))
+    return json.loads(line.split(':', 1)[1])
+
+
+if not os.path.isfile(BOARD):
+    print("SKIP: fixture missing")
+    sys.exit(0)
+
+from kicad_parser import parse_kicad_pcb
+from placement.floorplan import emit_intent
+from placement.writer import write_placed_output
+
+with tempfile.TemporaryDirectory() as d:
+    pcb = parse_kicad_pcb(BOARD)
+    n_parts = sum(1 for fp in pcb.footprints.values() if fp.pads)
+    b = pcb.board_info.board_bounds
+    cx, cy = (b[0] + b[2]) / 2, (b[1] + b[3]) / 2
+    pile = os.path.join(d, 'pile.kicad_pcb')
+    write_placed_output(BOARD, pile, [
+        {'reference': ref, 'new_x': cx, 'new_y': cy, 'new_rotation': 0}
+        for ref, fp in sorted(pcb.footprints.items()) if fp.pads])
+    intent_path = os.path.join(d, 'intent.json')
+    with open(intent_path, 'w', encoding='utf-8') as f:
+        json.dump(emit_intent(pcb, BOARD), f)
+
+    seed_py = os.path.join(REPO, 'place_seed.py')
+    out_a = os.path.join(d, 'a.kicad_pcb')
+    r = run([seed_py, pile, out_a, '--intent', intent_path])
+    check("seed run exits 0", r.returncode == 0,
+          (r.stdout + r.stderr)[-500:])
+    s = summary(r)
+    check("all parts placed", s['placed'] == n_parts,
+          f"{s['placed']}/{n_parts}")
+    check("no unseated parts", s['unseated'] == 0)
+    check("grade has zero errors", s['grade_errors'] == 0)
+
+    # deterministic per seed, across PYTHONHASHSEED
+    out_b = os.path.join(d, 'b.kicad_pcb')
+    r = run([seed_py, pile, out_b, '--intent', intent_path], hashseed="12345")
+    check("re-run exits 0", r.returncode == 0)
+    check("same seed is byte-identical across hash seeds",
+          open(out_a, 'rb').read() == open(out_b, 'rb').read())
+
+    out_c = os.path.join(d, 'c.kicad_pcb')
+    r = run([seed_py, pile, out_c, '--intent', intent_path, '--seed', '3'])
+    check("--seed 3 exits 0/4", r.returncode in (0, 4), f"rc={r.returncode}")
+    check("--seed 3 differs",
+          open(out_a, 'rb').read() != open(out_c, 'rb').read())
+
+    # a placed board is refused without --force
+    r = run([seed_py, BOARD, os.path.join(d, 'x.kicad_pcb'),
+             '--intent', intent_path])
+    check("placed board refused with exit 3", r.returncode == 3,
+          f"rc={r.returncode}")
+    check("refusal names place_portfolio as the explore path",
+          'place_portfolio' in (r.stdout + r.stderr))
+
+    # the emitted seed is a valid input for the portfolio (composition)
+    from placement.placement_state import assess_placement
+    st = assess_placement(parse_kicad_pcb(out_a), out_a)
+    check("seeded board assesses as PLACED", not st.unplaced,
+          '; '.join(st.reasons))
+
+print(f"\n{passed}/{passed + failed} checks passed")
+sys.exit(1 if failed else 0)

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""place_portfolio smoke: boards + renders + JSON emitted, gates honest,
+candidate 0 is the place_optimize identity anchor, diversity holds among the
+kept slate, and the refusal exits fire (unplaced board -> 3, zero viable
+candidates -> 4)."""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for p in (REPO,):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+BOARD = os.path.join(REPO, "kicad_files", "splitflap_driver.kicad_pcb")
+
+passed = failed = 0
+
+
+def check(name, ok, detail=""):
+    global passed, failed
+    passed += bool(ok)
+    failed += not ok
+    print(f"  {'OK  ' if ok else 'FAIL'} {name}{(' -- ' + detail) if detail else ''}")
+
+
+def run(argv, timeout=1800):
+    return subprocess.run([sys.executable, '-X', 'utf8'] + argv,
+                          capture_output=True, text=True, encoding='utf-8',
+                          errors='replace', cwd=REPO, timeout=timeout,
+                          env=dict(os.environ, PYTHONIOENCODING='utf-8'))
+
+
+if not os.path.isfile(BOARD):
+    print("SKIP: fixture missing")
+    sys.exit(0)
+
+with tempfile.TemporaryDirectory() as d:
+    out = os.path.join(d, 'pf')
+
+    # ---- 1. the main run: renders on, static ranking only ------------------
+    r = run([os.path.join(REPO, 'place_portfolio.py'), BOARD,
+             '--out-dir', out, '--seed', '0', '--candidates', '4',
+             '--keep', '2', '--route-top', '0'])
+    check("portfolio run exits 0", r.returncode == 0,
+          (r.stdout + r.stderr)[-500:])
+    doc_path = os.path.join(out, 'portfolio.json')
+    check("portfolio.json exists", os.path.isfile(doc_path))
+    doc = json.load(open(doc_path, encoding='utf-8'))
+    check("baseline board written", os.path.isfile(
+        os.path.join(out, 'baseline_quenched.kicad_pcb')))
+    check("baseline render written",
+          os.path.isfile(os.path.join(out, 'baseline.png')))
+    check("baseline .kicad_pro sibling carried", os.path.isfile(
+        os.path.join(out, 'baseline_quenched.kicad_pro'))
+          == os.path.isfile(os.path.splitext(BOARD)[0] + '.kicad_pro'))
+
+    kept = doc['kept']
+    cands = {c['index']: c for c in doc['candidates']}
+    check("kept is non-empty", bool(kept))
+    for i in kept:
+        check(f"kept cand {i} board exists",
+              os.path.isfile(os.path.join(out, f'cand_{i:02d}.kicad_pcb')))
+        check(f"kept cand {i} passed its gates",
+              cands[i]['gates'].get('passed') is True,
+              str(cands[i]['gates']))
+        check(f"kept cand {i} render written",
+              os.path.isfile(os.path.join(out, f'cand_{i:02d}.png')))
+
+    # every ranked candidate is viable, and the ranking is over gate-passers
+    for i in doc['ranking_static']:
+        check(f"ranked cand {i} is viable",
+              cands[i]['gates'].get('passed') is True)
+
+    # ---- 2. diversity among the kept, non-backfilled slate -----------------
+    from placement.portfolio import pose_distance_mm
+    div = doc['diversity_mm']
+    genuine = [i for i in kept if i not in doc['backfilled']]
+    poses = {i: {r: tuple(p) for r, p in cands[i]['final_poses'].items()}
+             for i in kept}
+    base_poses = {r: tuple(p)
+                  for r, p in doc['baseline']['final_poses'].items()}
+    for k, i in enumerate(genuine):
+        dist = pose_distance_mm(poses[i], base_poses, doc['free'])
+        check(f"kept cand {i} sits >= {div}mm from the baseline",
+              dist >= div - 1e-6, f"{dist:.3f}mm")
+        for j in genuine[:k]:
+            dist = pose_distance_mm(poses[i], poses[j], doc['free'])
+            check(f"kept cands {j}/{i} sit >= {div}mm apart",
+                  dist >= div - 1e-6, f"{dist:.3f}mm")
+
+    # ---- 3. candidate 0 == place_optimize with the same knobs --------------
+    opt_out = os.path.join(d, 'opt.kicad_pcb')
+    r = run([os.path.join(REPO, 'place_optimize.py'), BOARD, opt_out,
+             '--max-displacement', '3', '--length-weight', '0.3',
+             '--crossing-penalty', '30', '--halo-coef', '0.15'])
+    line = next(l for l in r.stdout.splitlines()
+                if l.startswith('JSON_SUMMARY:'))
+    opt = json.loads(line.split(':', 1)[1])
+    base_m = doc['baseline']['metrics']
+    check("baseline crossings == place_optimize's",
+          base_m['crossings'] == opt['crossings_after'],
+          f"{base_m['crossings']} vs {opt['crossings_after']}")
+    check("baseline hpwl == place_optimize's",
+          abs(base_m['hpwl'] - opt['hpwl_after']) < 1e-3,
+          f"{base_m['hpwl']} vs {opt['hpwl_after']}")
+
+    # ---- 4. refusals -------------------------------------------------------
+    # unplaced pile -> exit 3, nothing generated
+    from kicad_parser import parse_kicad_pcb
+    from placement.writer import write_placed_output
+    pcb = parse_kicad_pcb(BOARD)
+    b = pcb.board_info.board_bounds
+    cx, cy = (b[0] + b[2]) / 2, (b[1] + b[3]) / 2
+    pile = os.path.join(d, 'pile.kicad_pcb')
+    write_placed_output(BOARD, pile, [
+        {'reference': ref, 'new_x': cx, 'new_y': cy, 'new_rotation': 0}
+        for ref, fp in sorted(pcb.footprints.items()) if fp.pads])
+    r = run([os.path.join(REPO, 'place_portfolio.py'), pile,
+             '--out-dir', os.path.join(d, 'pf_pile'), '--no-render'])
+    check("unplaced board refused with exit 3", r.returncode == 3,
+          f"rc={r.returncode}")
+
+    # impossible intent -> every candidate gated -> exit 4
+    bad_intent = os.path.join(d, 'bad_intent.json')
+    from placement.floorplan import emit_intent
+    intent_doc = emit_intent(pcb, BOARD)
+    intent_doc['must_lock'] = ['ZZNOSUCHREF*']
+    with open(bad_intent, 'w', encoding='utf-8') as f:
+        json.dump(intent_doc, f)
+    r = run([os.path.join(REPO, 'place_portfolio.py'), BOARD,
+             '--out-dir', os.path.join(d, 'pf_bad'), '--seed', '0',
+             '--candidates', '2', '--keep', '1', '--route-top', '0',
+             '--no-render', '--intent', bad_intent])
+    check("all-candidates-gated run exits 4", r.returncode == 4,
+          f"rc={r.returncode}\n{(r.stdout + r.stderr)[-300:]}")
+
+print(f"\n{passed}/{passed + failed} checks passed")
+sys.exit(1 if failed else 0)

--- a/tests/test_portfolio_determinism.py
+++ b/tests/test_portfolio_determinism.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""place_portfolio's determinism contract, test_457-style.
+
+Same --seed + same input must be byte-identical ACROSS PYTHONHASHSEED values
+(the #457 hazard: set-of-strings iteration reaching anything that decides a
+move), a different --seed must actually change the portfolio, and --only N
+must regenerate candidate N byte-identically -- that is the property the
+ledger's replay command rests on.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BOARD = os.path.join(REPO, "kicad_files", "splitflap_driver.kicad_pcb")
+
+passed = failed = 0
+
+
+def check(name, ok, detail=""):
+    global passed, failed
+    passed += bool(ok)
+    failed += not ok
+    print(f"  {'OK  ' if ok else 'FAIL'} {name}{(' -- ' + detail) if detail else ''}")
+
+
+def run(out_dir, *extra, hashseed="0"):
+    env = dict(os.environ, PYTHONHASHSEED=hashseed, PYTHONIOENCODING='utf-8')
+    argv = [sys.executable, '-X', 'utf8',
+            os.path.join(REPO, 'place_portfolio.py'), BOARD,
+            '--out-dir', out_dir, '--seed', '0', '--candidates', '3',
+            '--keep', '2', '--route-top', '0', '--no-render'] + list(extra)
+    r = subprocess.run(argv, capture_output=True, text=True, encoding='utf-8',
+                       errors='replace', env=env, cwd=REPO, timeout=1200)
+    return r
+
+
+def canon_json(out_dir):
+    """portfolio.json with the run's own out-dir path neutralized, so runs
+    into different directories compare equal iff everything else is."""
+    with open(os.path.join(out_dir, 'portfolio.json'), encoding='utf-8') as f:
+        text = f.read()
+    return text.replace(json.dumps(out_dir)[1:-1], '@OUT@')
+
+
+def board_bytes(out_dir, name):
+    with open(os.path.join(out_dir, name), 'rb') as f:
+        return f.read()
+
+
+if not os.path.isfile(BOARD):
+    print("SKIP: fixture missing")
+    sys.exit(0)
+
+with tempfile.TemporaryDirectory() as d:
+    dirs = {k: os.path.join(d, k) for k in
+            ('h0', 'h1', 'h12345', 'seed1', 'only')}
+
+    # 1. identical across PYTHONHASHSEED (and across processes)
+    for key, hs in (('h0', '0'), ('h1', '1'), ('h12345', '12345')):
+        r = run(dirs[key], hashseed=hs)
+        check(f"run under PYTHONHASHSEED={hs} exits 0", r.returncode == 0,
+              (r.stdout + r.stderr)[-400:])
+    j0, j1, j2 = (canon_json(dirs[k]) for k in ('h0', 'h1', 'h12345'))
+    check("portfolio.json identical across hash seeds",
+          j0 == j1 == j2)
+    b0 = board_bytes(dirs['h0'], 'cand_01.kicad_pcb')
+    check("cand_01 board identical across hash seeds",
+          b0 == board_bytes(dirs['h1'], 'cand_01.kicad_pcb')
+          == board_bytes(dirs['h12345'], 'cand_01.kicad_pcb'))
+    check("baseline board identical across hash seeds",
+          board_bytes(dirs['h0'], 'baseline_quenched.kicad_pcb')
+          == board_bytes(dirs['h1'], 'baseline_quenched.kicad_pcb'))
+
+    # 2. a different --seed actually changes the perturbation
+    r = subprocess.run(
+        [sys.executable, '-X', 'utf8',
+         os.path.join(REPO, 'place_portfolio.py'), BOARD,
+         '--out-dir', dirs['seed1'], '--seed', '1', '--candidates', '3',
+         '--keep', '2', '--route-top', '0', '--no-render'],
+        capture_output=True, text=True, encoding='utf-8', errors='replace',
+        cwd=REPO, timeout=1200)
+    check("seed 1 exits 0/4", r.returncode in (0, 4), f"rc={r.returncode}")
+    check("seed 1 cand_01 differs from seed 0's",
+          board_bytes(dirs['seed1'], 'cand_01.kicad_pcb') != b0)
+
+    # 3. --only N regenerates candidate N byte-identically
+    r = run(dirs['only'], '--only', '1')
+    check("--only 1 exits 0", r.returncode == 0,
+          (r.stdout + r.stderr)[-400:])
+    check("--only 1 board matches the full run's cand_01",
+          board_bytes(dirs['only'], 'cand_01.kicad_pcb') == b0)
+    check("--only 1 skipped the baseline", not os.path.isfile(
+        os.path.join(dirs['only'], 'baseline_quenched.kicad_pcb')))
+
+print(f"\n{passed}/{passed + failed} checks passed")
+sys.exit(1 if failed else 0)

--- a/tests/test_portfolio_strategies.py
+++ b/tests/test_portfolio_strategies.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Unit tests for the portfolio perturbation strategies, in-process.
+
+The invariants each strategy must hold: jitter emits only candidate_valid
+poses within its radius; the poses strategy never emits a rotation that
+RAISES the part's forced-crossing floor (pair_order.ref_inversions is a lower
+bound a router cannot beat, so raising it is provably worse); swaps exchange
+only FREE, mutually-legal members; and free_refs honors both lock sources
+(board `(locked yes)` and --lock globs)."""
+import math
+import os
+import random
+import shutil
+import sys
+import tempfile
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for p in (REPO,):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+BOARD = os.path.join(REPO, "kicad_files", "splitflap_driver.kicad_pcb")
+
+passed = failed = 0
+
+
+def check(name, ok, detail=""):
+    global passed, failed
+    passed += bool(ok)
+    failed += not ok
+    print(f"  {'OK  ' if ok else 'FAIL'} {name}{(' -- ' + detail) if detail else ''}")
+
+
+if not os.path.isfile(BOARD):
+    print("SKIP: fixture missing")
+    sys.exit(0)
+
+from kicad_parser import parse_kicad_pcb
+from placement import portfolio
+from placement.pair_order import ref_inversions
+
+pcb = parse_kicad_pcb(BOARD)
+free = portfolio.free_refs(pcb, BOARD, None)
+state = portfolio.make_oracle(pcb, BOARD, free=free, clearance=0.25,
+                              board_edge_clearance=0.55, grid_step=0.1,
+                              ignore_ids=set())
+origin = {r: (state.parts[r].x, state.parts[r].y, state.parts[r].rot)
+          for r in free}
+
+
+def restore():
+    for r in sorted(origin):
+        x, y, rot = origin[r]
+        p = state.parts[r]
+        if (p.x, p.y, p.rot) != (x, y, rot):
+            state.apply_move(r, x, y, rot)
+
+
+# ---- jitter ----------------------------------------------------------------
+RADIUS = 3.0
+poses = portfolio.perturb_jitter(state, free, random.Random("t"), RADIUS)
+check("jitter produced poses", len(poses) > 0, f"{len(poses)}")
+check("jitter refs are free refs",
+      all(p['reference'] in set(free) for p in poses))
+ok_radius = all(
+    math.hypot(p['new_x'] - origin[p['reference']][0],
+               p['new_y'] - origin[p['reference']][1]) <= RADIUS + 1e-6
+    for p in poses)
+check("jitter displacements within radius", ok_radius)
+# each emitted pose is individually legal against the FINAL perturbed state
+# minus itself (the sequential-validation contract)
+all_valid = all(
+    state.candidate_valid(p['reference'], p['new_x'], p['new_y'],
+                          p['new_rotation'])
+    for p in poses)
+check("every jitter pose legal in the perturbed state", all_valid)
+restore()
+poses2 = portfolio.perturb_jitter(state, free, random.Random("t"), RADIUS)
+restore()
+check("jitter deterministic for a fixed rng seed", poses == poses2)
+poses3 = portfolio.perturb_jitter(state, free, random.Random("u"), RADIUS)
+restore()
+check("different rng seed produces different jitter", poses != poses3)
+
+# ---- poses -----------------------------------------------------------------
+n_variants = 0
+while True:
+    result = portfolio.perturb_poses(state, free, n_variants)
+    if result is None:
+        restore()
+        break
+    (p,) = result
+    ref = p['reference']
+    restore()
+    before = ref_inversions(state, ref)
+    after = ref_inversions(state, ref, p['new_x'], p['new_y'],
+                           p['new_rotation'])
+    if after > before:
+        check(f"poses variant {n_variants} ({ref}) does not raise inversions",
+              False, f"{before} -> {after}")
+    rot_delta = (p['new_rotation'] - origin[ref][2]) % 360
+    if rot_delta not in (90.0, 180.0, 270.0):
+        check(f"poses variant {n_variants} is a rotation change",
+              False, f"delta {rot_delta}")
+    n_variants += 1
+check("poses enumerated at least one variant", n_variants > 0,
+      f"{n_variants}")
+check("variant index past the end returns None",
+      portfolio.perturb_poses(state, free, n_variants) is None)
+restore()
+
+# ---- swaps -----------------------------------------------------------------
+# synthesize a block from same-side free parts; include a locked ref to prove
+# the free-member filter, not just hope for it
+same_side = [r for r in free if state.parts[r].side == 'F'][:6]
+locked_ref = next(r for r in sorted(state.parts) if r not in free) \
+    if any(r not in free for r in state.parts) else None
+block = {'blk': list(same_side) + ([locked_ref] if locked_ref else [])}
+sw = portfolio.perturb_swaps(state, block, random.Random("s"), 2)
+check("swap produced an exchange", len(sw) >= 2, f"{len(sw)}")
+check("swap never moved a locked ref",
+      all(p['reference'] in set(free) for p in sw))
+by_ref = {p['reference']: p for p in sw}
+# positions are exchanges: the multiset of (x, y) before == after
+before_xy = sorted((origin[r][0], origin[r][1]) for r in by_ref)
+after_xy = sorted((p['new_x'], p['new_y']) for p in sw)
+check("swap positions are an exchange of existing positions",
+      before_xy == after_xy)
+restore()
+check("swap with no blocks is barren",
+      portfolio.perturb_swaps(state, {}, random.Random("s"), 2) == [])
+
+# ---- free_refs lock sources ------------------------------------------------
+sub = portfolio.free_refs(pcb, BOARD, ['C*'])
+check("--lock glob excludes matching refs",
+      not any(r.startswith('C') for r in sub) and len(sub) < len(free))
+with tempfile.TemporaryDirectory() as d:
+    locked_board = os.path.join(d, 'locked.kicad_pcb')
+    shutil.copyfile(BOARD, locked_board)
+    victim = free[0]
+    from placement.seeder import stamp_locked
+    n = stamp_locked(locked_board, [victim])
+    check("stamp_locked stamped one part", n == 1, f"{n}")
+    pcb2 = parse_kicad_pcb(locked_board)
+    free2 = portfolio.free_refs(pcb2, locked_board, None)
+    check("board (locked yes) excludes the ref from free_refs",
+          victim not in free2 and len(free2) == len(free) - 1)
+
+print(f"\n{passed}/{passed + failed} checks passed")
+sys.exit(1 if failed else 0)


### PR DESCRIPTION
## Why

Every /plan-pcb-routing run starts from 100% the same placement, and that is structural, at three reinforcing levels: the skill doctrine forbids generating a placement (report-and-stop is the first answer for an unplaced board), the one escape hatch routes to a repo seeder that is typically a hardcoded constant, and the quench is deterministic **by design** (#457 — no RNG, no seed knob, iteration deliberately de-randomized), so re-running can never propose a different arrangement. The acceptance rule is a keep/discard filter over one result; no code path in the tree could produce or compare a second candidate.

This adds the missing half — generation and K-way comparison — without touching the determinism that makes results reproducible.

## What

**`place_portfolio.py` + `placement/portfolio.py`** — K diverse candidates from one placed board:
- Seeded legal perturbations (`jitter` disc offsets, `poses` rotation variants pruned by `pair_order` inversions, `swap` block-interior exchanges), each quenched by the **unmodified** engine.
- Candidate 0 is always the plain quench of the input — "keep what I have" is a first-class outcome, and its numbers equal a `place_optimize` run with the same knobs (asserted in tests).
- Hard gates (no new overlap/oob beyond the baseline; error-free intent grade), then an ungameable lexicographic rank `(crossings, inversions, hpwl, health penalty, displacement)`; kept slate is pose-distance-diverse with named backfills.
- Probe tier default ON (`--route-top 2`): baseline + top candidates routed over one **shared** affected-net set; `portfolio.json` carries `ranking_static` and `ranking_routed` separately — measured copper never interleaves with a proxy.
- Determinism contract: candidate *i* draws only from `random.Random(f"{seed}:{i}:{strategy}")`; same seed ⇒ byte-identical portfolio across `PYTHONHASHSEED` values; `--only N` regenerates one candidate byte-identically — the replay primitive `--ledger` records (BoardStore/Ledger, `converge.py replay`).

**`place_seed.py` + `placement/seeder.py`** — intent-driven initial placement for unplaced boards. The "no from-scratch" verdict stands *unaided*; a declared floorplan intent carries the constraints whose absence made naive autoplacement fail: edge bands → edge poses (Newton-corrected against real Edge.Cuts rings), single-ref zones → the spec coordinate, multi-ref zones → radial packs, the rest → connectivity centroids. `must_lock` refs stamped `(locked yes)`; already-locked input parts are authoritative and packed around; the emitted seed is **graded against the intent it was built from** (exit 4 on failure). Rotation kept when it fits, noted 90° lattice fallback otherwise; a fine 0.25 mm ring pass runs before the (noted) clearance ladder, because a packed board's last legal window measured 0.09 mm tall.

**Skill doctrine** — the unplaced row becomes a ladder (seeder → `place_seed` from intent → report-and-stop as the *last* rung); new Step 0c-bis (when to run a portfolio, the K-way generalization of the acceptance conjunction, slate = one image-budget item); Step 6 and Do/Don't updated. Docs: `placement/README.md` tool sections, `docs/placement-optimization.md` portfolio chapter, `docs/floorplan-intent.md` generator note.

## Verified

- `tests/test_portfolio_determinism.py` 11/11 (PYTHONHASHSEED 0/1/12345 byte-identity, seed variation, `--only` replay), `tests/test_portfolio.py` 14/14 (identity anchor, diversity floor, exit 3/4 refusals), `tests/test_portfolio_strategies.py` 15/15 (inversion prune, locked-member and incumbent-legality guards), `tests/test_place_seed.py` 11/11 (65/65 seated pile→seed, grade-clean, per-seed byte identity).
- `tests/test_457_determinism.py` unchanged and passing; both no-wx GUI parity gates pass (GUI has no placement tab — verified — so no parity wiring).
- On test-board (companion commit `4f344bc` on `p9-layout-run6`): `make_board --variant generated --seed 0/1` both pass `check_floorplan_intent` + `check_channel_utilisation` (42.9%), differ in all 13 free parts, never move a locked one; U3's load-bearing rot-180 pose is now locked + must_lock instead of comment-carried.
