### PR TITLE
Run-8 prep: the summary stops lying (opens, restores, stacked vias); seed ranking, hand-join verifier, rule-1 conjunction; run-7's 15 skill edits + a 7-agent defect audit

### DIFF
--- a/.claude/skills/plan-pcb-routing/SKILL.md
+++ b/.claude/skills/plan-pcb-routing/SKILL.md
@@ -173,6 +173,14 @@ coordinate, a pitch, a mating standard or an enclosure feature is fixed:
 | castellated edges | the carrier's pad field | pad centred **on** the outline |
 | test points, antennas, sensors | mechanical or RF | an antenna keepout is not negotiable |
 
+The table is the mechanical-facts slice of a broader taxonomy (#118): **part
+classes obey different placement logic** — a decap is governed by pin
+proximity, a connector by the mating standard, a crystal by field distance
+and leg symmetry, a series termination by being the chain's free terminal, a
+bulk cap by almost nothing. When a part fits no row above, ask which CLASS
+governs it — and which rule and grading signal that class implies — before
+treating it as free for the optimizer to trade.
+
 **2. Lock every one of them, and pass the locks to EVERY placement invocation.**
 Not just the first — `place_optimize`, `place_route_loop` and every retry:
 
@@ -1451,6 +1459,14 @@ Use `list_nets.py` to detect differential pairs and power/ground nets:
 python3 list_nets.py path/to/file.kicad_pcb --diff-pairs --power
 ```
 
+**While the spec's widths are in hand, check each declared width against the
+net's smallest pad and its neighbor pitch NOW.** A 0.4 mm trace cannot leave
+a 0.200 mm QFN pad (the neckdown handles the pad END, but a width wider than
+`pitch − clearance` cannot pass BETWEEN neighbors on the escape), and a
+width the geometry cannot carry found here is a spec conversation; found at
+Step 9 it reads as a mystery routing failure and has twice been written up
+as one ("walled in by its neighbours" — the wall was the width).
+
 ### Read the board's design rules and pass them to the CLI
 
 The router does NOT read the board's design rules — it falls back to a generic
@@ -1962,6 +1978,15 @@ multiple rails). Follow its methodology here, seeded by the `list_nets.py --powe
 output, and put the resulting net -> layer assignments into the plan's
 `route_planes` steps. Nets it leaves to wide traces become `--power-nets` /
 `--power-nets-widths` on the route step instead.
+
+**Routing is as much about planes as traces (#118): treat pour continuity as
+first-class work, not cleanup.** The same lens exists at three stages and
+they should agree — `--plane-score` at placement time (portfolio candidates
+priced by the fill's islands/necks), the #424 fragility field in-run (signal
+routes pay to cross the pour's straits), and the `fragmented_nets` /
+`stacked_copper` summary keys at grading. A run that only meets the pour at
+the repair step has skipped the two stages where the damage was cheap to
+avoid.
 
 Report to user:
 - Identified GND nets and pad counts
@@ -3687,6 +3712,16 @@ victim keeps rotating across MORE than two nets as you permute the order, stop
 permuting: score each order as its own full-chain lineage and let the ledger
 pick (9.3d's rip-return row) — and if the same victim SET survives every order,
 it is capacity (the lane ledger has the number), not ordering.
+
+**The tooling-vs-placement discriminator (#118), for a converged board with
+few failures left:** ask whether a competent human could hand-route the
+remaining nets on THIS placement. If yes, the gap is tooling — file it as a
+systemic finding and take rung 8, which exists for exactly this. If no human
+could either, it is placement or capacity — the lane ledger has the number,
+and the finding goes to the next run's Step 0, not to more router laps.
+Run 7's west fan answered "no human could" (~25 exact-clearance candidates,
+every one within 0.1 mm of committed constrained copper), which is what made
+it a capacity finding rather than an engine complaint.
 
 **After ANY placement change every downstream routed board is stale** — re-run
 the chain from the placed board. Never keep a routed artifact from before it.

--- a/.claude/skills/plan-pcb-routing/SKILL.md
+++ b/.claude/skills/plan-pcb-routing/SKILL.md
@@ -678,7 +678,12 @@ only in `check_floorplan`'s `outline` block.
   (JSON_SUMMARY / the EXIT line / the final tally block) or parse it; never
   conclude from a truncated grep. Run 6 logged three incidents on three
   different instruments read three different lossy ways; the instrument was
-  right every time.
+  right every time. **An oracle LISTING gets the same rule**: never `head`/
+  `tail` it — consume the whole list and assert the lines you consumed equal
+  the count the instrument itself printed. Run 7's close-out shipped "5
+  opens" off a `tail -5` of a list whose sixth line (SWDIO) sat above the
+  window; the oracle had printed 6, and the wrong number reached the final
+  report and the promotion decision before the watcher caught it.
 - **Before concluding a clause is geometrically unsatisfiable, check your own
   flags.** One net was reported "walled in by its neighbours" when the actual
   blocker was a `--track-width 0.4` the analyst had passed: a 0.4 mm trace cannot
@@ -3256,6 +3261,7 @@ writing a script to answer a question, check whether one of them already does.
 | the endgame work list, join by join | `kicad_unconnected.py board --pairs-json wk/pairs.json`, or `converge.py where BOARD --oracle` | each remaining join as an exact net + pad↔copper endpoint pair (x/y/layer/kind) — the JOIN SPEC for a scoped route, no re-deriving from prose. `where --oracle` prints the pairs then runs forensics on exactly those nets |
 | what kind of failure is this | `converge.py where` / the router's own hint | the hint names the flag and the nets (9.3b); it diagnoses better than the score does |
 | where should this part go, facing which way | `converge.py poses BOARD --ref R` | ranks legal (x, y, rotation) poses by placement cost in **milliseconds**, with a per-component breakdown, and `--route` pays for tier 3 on only the top few |
+| will this hand join fit, BEFORE committing it | `check_join.py BOARD NET x,y,layer ... via:x,y` | stages the candidate polyline+vias onto a copy of the board and diffs the REAL check_drc engine (netclasses, `.kicad_dru`, rotated pads, edge, hole-to-hole), plus missing-via and same-net-stack checks DRC omits. Exit 0 clean / 1 violations. Rung 8's condition 3 |
 | is this even the engine I pinned | `route.py --capabilities` / `krt_capabilities.py --require` | a chain can otherwise run green against a clone missing the module it depends on. **Spelling is `module:--flag`, WITH the dashes.** And ground-truth a PLANE-step flag with `--help`: `--require` scans imports one level to catch shared registrars, and both plane scripts import `route.py` — so they used to inherit its whole vocabulary and answer OK for flags argparse rejects with exit 2 (fixed, but the lesson stands: a capability gate is evidence, not proof) |
 | step back to iteration N | `converge.py step-back --iteration N` | byte-exact, because the board is addressed by content instead of by a path three iterations overwrote |
 | re-run what iteration N did | `converge.py replay --iteration N` | replays the recorded argv. If it refuses, the ledger recorded prose instead of a command — fix the ledger, not the memory |
@@ -3271,6 +3277,21 @@ oracle itself at end of run — `oracle_check`/`oracle_open` in JSON_SUMMARY —
 and a `fragmented_nets` key names pad-connected nets whose copper is several
 KiCad islands; both feed its own reconciliation. `oracle_check: unavailable`
 means the run had no kicad-cli and you are on in-process grading alone.)
+
+**The divergence is a MODE, not an event.** After the model's success channel
+is caught lying ONCE on a board (`failed_single`/routed tallies vs oracle
+opens), demote it for the remainder of that board's endgame: the oracle's
+`--pairs-json` work list is the only open-set, every accept runs the oracle,
+and after every FAILED call diff the board itself (per-net segment/via
+counts, duplicate vias at identical coords) before trusting "no change" — a
+failed rip-restore can write fragments while reporting success. Run 7 held
+the trust order per event but kept consuming the model's tallies lap after
+lap, and paid one oracle run of latency for each of three defect classes.
+(The engine now counts routed-but-OPEN nets in `open_single`, grades
+terminal restores before claiming them — `terminal_restores` — and dedups
+stacked vias with a `stacked_copper` disclosure; a summary carrying those
+keys has already had this class of lie audited once, which narrows the gap
+but does not repeal the trust order.)
 
 **Ratchet floors measured by a refill-jittery instrument (kicad-cli DRC) flap
 at exact equality.** (1) A single exit-4 at floor==count is a RE-MEASURE
@@ -3623,7 +3644,11 @@ read-case 3 or 7. **Record NON-triggers the same way**: when a mandate's
 trigger is checked and absent, say so in the entry (`[checked: 0 B.Cu parts ->
 no --per-side]`) — an unrecorded non-trigger is indistinguishable from a
 skipped mandate to any later audit (run 6's watcher had to grep the board to
-tell them apart).
+tell them apart). **A pose decision is read-case 5 even when the arithmetic
+is decisive**: a rot-0-vs-rot-180 call made on `components.inversions` alone,
+with no side-by-side ratsnest reads in the ledger, is a mandate skipped —
+run 7 decided the U3 pose twice that way; the number was right, and the
+breach is still a breach the audit had to flag.
 
 **What `record` actually writes is this, and only this:**
 
@@ -3651,7 +3676,14 @@ record of the one thing 9.3d says decides an iteration. Until they do exist,
 **Record the failing nets by NAME, not by count.** Counts hide whack-a-mole
 completely: measured on one run, `unrouted` read **4 → 4** across an iteration
 that had in fact fixed four nets and broken five different ones. The scalar said
-"no progress"; the names said the iteration was churning.
+"no progress"; the names said the iteration was churning. **This applies to
+PROBE records too, and to the BASELINE side of every comparison**: run 7's
+adoption entry recorded `full_probe_failures: 41` — a count — and the 41
+names the ADOPTED board failed appeared nowhere, so the routing phase's first
+whack-a-mole comparison had nothing to diff against. A probe verdict enters
+the ledger as names (`score.failed_nets`, or the names in the lever text),
+for the candidate AND the baseline row it beat. `record` now nags exactly
+this: a score carrying `failures` without `failed_nets` draws a NOTE.
 
 **`parent_sha` is the board this iteration actually came from** — `record`
 derives it from the last accepted entry, not from iteration N−1. When you need a
@@ -3661,6 +3693,18 @@ reuse an output path across iterations**: a ledger that says
 `wk/placed.kicad_pcb` when three iterations wrote that name is unauditable, and
 one that named a *rejected* board as the parent of everything downstream got
 shipped.
+
+**The argv must be real, and the close-out must name its stop condition —
+`record` now enforces both.** An `--argv` whose first token is neither an
+existing file nor on PATH is refused (exit 2, nothing written): run 7's
+endgame recorded `["python3","-X","utf8","dummy"]`, which `replay` can never
+run — a placeholder argv turns the ledger back into prose. The run-closing
+entry takes `--final --stop-condition '<which of 9.5 fired>'`; `--final`
+without a stop condition is refused the same way. And **before quoting a
+headline in the lever text, diff it against the SAME entry's score payload**:
+run 7's final entry said "SWD closed, 5 opens" while its own score listed
+SWDIO among 6 unrouted — the prose shipped into the report and the correction
+cost a commit. The score is the record; the lever text is a caption of it.
 
 **Log the systemic/completion split in the final report**: *"41 iterations: 9
 systemic, 32 completion"* is a fact about how the budget was spent, and a run that
@@ -3719,23 +3763,62 @@ pulling at you, write the next ledger entry instead:
   rungs than you have tried: rip set → grid → layer → via cost → width → order →
   placement → hand-authored micro-copper.
 
-**Rung 8, hand-authored micro-copper, exists — with three hard conditions.**
-Only after every mechanical rung is exhausted; only with **round-cap arithmetic
-off the ACTUAL copper widths** (a track's reach is `endpoint + width/2`; run 5
-authored 0.427 and 0.442 mm candidates that both failed the arithmetic before
-0.465 mm passed); and **always re-gated** — drc + connectivity + score on the
-edited board, recorded in the ledger like any other lever, revert on regression.
-A hand segment that skips the gate is not a fix, it is an unmeasured edit.
+**Rung 8, hand-authored micro-copper, exists — with FIVE hard conditions.**
+
+1. **Only after every mechanical rung is exhausted** (dru lifts, nc-map fixes,
+   scoped grids, rip sets — run 7 entered rung 8 only after all four were
+   demonstrably spent, and that part it got right).
+2. **Round-cap arithmetic off the ACTUAL copper widths** (a track's reach is
+   `endpoint + width/2`; run 5 authored 0.427 and 0.442 mm candidates that
+   both failed the arithmetic before 0.465 mm passed).
+3. **A join verifier BEFORE the first segment, graded against ALL copper.**
+   Reach is the easy half; the shorts live in the other half — third-party
+   segments, vias, pads, pour. Run every candidate polyline+via through
+   `check_join.py BOARD NET x,y,layer ... via:x,y` — it stages the candidate
+   onto a copy of the board and diffs the REAL check_drc engine (netclasses,
+   `.kicad_dru` layers, rotated pads, board edge, hole-to-hole), plus the
+   join-specific checks DRC omits: a layer change with no `via:` and same-net
+   via stacks. (No check_join in the pinned engine? A scratch-board
+   `check_drc.py` run per candidate is the zero-build version.) Measured,
+   run 7: pad-edge-only arithmetic at 0.1575+ margins authored **42 shorts**;
+   the verifier was built mid-recovery instead of first.
+4. **Re-gate EVERY edit** — drc + connectivity + score on the edited board,
+   recorded in the ledger like any other lever, revert on regression. Per
+   EDIT, not per phase: run 7 gated a whole hand-copper session on
+   connectivity alone with DRC deferred, and the deferred DRC was where the
+   42 shorts surfaced. A hand segment that skips the gate is not a fix, it is
+   an unmeasured edit.
+5. **Lock it, and commit it FIRST.** Stamp every hand-authored segment and via
+   `(locked yes)` at authoring time — locked copper's net is never
+   rip-eligible (#521), which is exactly the semantics a hand join needs: no
+   later `--rip-existing-nets` glob, in-run ladder, or plane-repair
+   `--rip-blocker-nets` picker may treat the one corridor you proved as free
+   space (measured, run 7: the plane repair picked three hand-routed GPIOs as
+   tap blockers and ripped them; unlock deliberately if a rebuild must move
+   them). And hand joins are the most constrained copper on the board — one
+   proven corridor, zero router flexibility — so constrained-first applies
+   across the hand/router boundary: commit them BEFORE the flexible nets'
+   final routing and make the router route around them (strip and re-route
+   the flexible set last if needed). Never author a hand join into a fabric
+   of committed copper the router could have placed elsewhere (measured,
+   run 7: fixed-joins-first closed at 0 shorts where the reverse order had
+   authored 42).
 
 **Rung 8 has TWO exits: placed-and-gated copper, or an exhaustive NO-JOIN —
-and the second is a result, not a failure.** A sweep that clears no candidate
-at physical clearance IS the hostile rebuild the watcher pattern demands, over
-its enumerated families — record the envelope (width, clearance, path
-families, step) in the ledger like any lever. Pair it with ONE scoped route at
-the router's own hinted finest grid to cover paths outside the families;
-together they close the stop-3 checklist for that pad. Do not follow a NO-JOIN
-sweep with more router laps at the grid that already failed (run 6 ran two
-rotation laps after its sweep proved the fabric sealed).
+and the second is a result, not a failure, but ONLY when it ships all four
+parts:** (1) the sweep envelope (width, clearance, path families, step)
+recorded in the ledger like any lever; (2) ONE scoped route at the router's
+own hinted finest grid (0.025 at ≤0.4 mm pitch) to cover paths outside the
+enumerated families; (3) a `--view` crop of the region, read and ledgered;
+(4) the verification-mode disclosure — a fanned-out hostile rebuild, or the
+single-agent statement that the sweep itself is the rebuild. A NO-JOIN
+missing any part is a HYPOTHESIS, and every report that quotes it must say
+so (run 7's west-fan capacity claim shipped with the envelope, the
+finest-grid route and the crop all missing — it is a hypothesis pending the
+next run, by this rule). A complete sweep IS the hostile rebuild the watcher
+pattern demands; do not follow it with more router laps at the grid that
+already failed (run 6 ran two rotation laps after its sweep proved the
+fabric sealed).
 
 **A worked case of stopping wrongly, because it is the most expensive mistake in
 this document.** One run reported four unrouted nets, wrote up "stop condition 3"

--- a/.claude/skills/plan-pcb-routing/SKILL.md
+++ b/.claude/skills/plan-pcb-routing/SKILL.md
@@ -67,7 +67,9 @@ order:
    treat its output as the "rough / generated placement" row of the table
    above. If the seeder takes a `--seed`/`--variant` axis, that plus
    Step 0c-bis is how you offer the user OPTIONS instead of one take-it-or-
-   leave-it arrangement.
+   leave-it arrangement — but rank the SEEDS first (`compare_seeds.py`, next
+   rung): the portfolio explores around ONE seed and cannot rank across
+   them.
 2. **No seeder, but an intent exists — or the spec states placement facts**
    (connector edges, a fixed regulator cluster, a decap rule): author/verify
    the intent with the Step 0e machinery, then generate the seed from it:
@@ -86,8 +88,41 @@ order:
    rotation is kept when it fits, with a noted 90° lattice fallback when it
    does not; a part whose rotation is a DECISION (pin order) must be locked —
    the intent schema cannot express one, and an unlocked load-bearing
-   rotation was never protected from the quench either. Explore rotations
-   deliberately with the portfolio's `poses` strategy afterwards.
+   rotation was never protected from the quench either. Explore a LOCKED
+   part's rotation with Step 0a-bis arithmetic (below) — **the portfolio's
+   `poses` strategy never perturbs locked refs, so it cannot explore exactly
+   the rotations the lock protects** (measured, run 7: five poses iterations
+   across two slates, zero pose changes; the winning rot-180 came only from
+   the manual 0a-bis pass).
+
+   **When the seeder takes `--seed`, rank the seeds with ONE identical
+   full-board probe each BEFORE sinking 0a-bis/portfolio effort into any of
+   them** — crossings/hpwl cannot rank seeds, and the portfolio's shared-net
+   window never crosses seeds (measured, run 7: the crossings-best seed's
+   family probed 53 full-board failures while a crossings-middle seed probed
+   39, at a third of the search effort — the whole first portfolio line was
+   spent on the seed the wider instrument then displaced). That is one
+   command now:
+
+   ```bash
+   python3 -X utf8 compare_seeds.py board.kicad_pcb --intent floorplan.json \
+       --seeds 0 1 2 --out-dir wk/seedcmp --ignore-nets <the Step 5 plane nets>
+   ```
+
+   It runs place_seed per seed (a seed failing its own intent gate is
+   recorded, never ranked), probes every survivor with the SAME net patterns
+   and route args, and emits the ranked table + `seeds.json` +
+   `best_seed`.
+
+   **For every must_lock part under a HARD geometric clause, run Step 0a-bis
+   ON THE SEEDED OUTPUT before the portfolio** — the seeder keeps the pile's
+   input rotation, which is a generator default, not a decision. If a
+   rotation wins on inversions, apply it with `write_placed_output` and
+   RE-SEAT the decaps that served its supply pins (`seeder._try_place` at
+   the relocated pin, zone-constrained), then re-run the pin-exact gate:
+   rotating a part moves its pins, and a decap seated to the old pin
+   silently breaks the proximity clause (measured, run 7: 7.74 mm vs the
+   3 mm limit until the re-seat).
 3. **Neither** — no seeder, no intent, and the spec pins nothing (or there
    is no outline; the outline is spec-owned and is never invented): report
    that plainly, tell the user to place the parts in KiCad, and offer to
@@ -146,6 +181,13 @@ python3 -X utf8 place_optimize.py board.kicad_pcb placed.kicad_pcb \
     --lock 'J*' 'H*' 'U1' --max-displacement 2
 ```
 
+`(locked yes)` stamped in the board file (a seeder's `must_lock` output)
+satisfies this for every place_* tool — the file lock is honored everywhere
+`--lock` is. When you rely on it instead of `--lock`, say so once in the
+ledger, so an auditor can tell a carried lock from a dropped one (run 7's
+portfolio argvs carried no `--lock` and the audit had to reverse-engineer
+that the in-file stamps made it harmless).
+
 **3. Record them in the intent, so they are GRADED and not merely hoped for.**
 A lock you forgot to re-pass is silent. A `must_lock` the grader checks is not:
 
@@ -198,6 +240,19 @@ The mechanical tools: `converge.py poses --ref U3` ranks legal poses and its
 tie). A **series part in a matched chain** (source-termination resistor, AC
 cap) is a *free terminal*: its pose is the knob that sets where the chain's
 segment lands, so enumerate its poses too, not just the ICs'.
+
+**Read `poses` output with two caveats** (run-7 S4). The JSON now discloses
+its `knobs` (unset clearance/edge resolve from the BOARD's own floor) and a
+`dropped_in_place` census — a nonempty `dropped_in_place` on a thin or empty
+ranking means the knobs (or the lattice) vetoed rotations at the part's own
+spot, not that the part is stuck; check the resolved knobs against the
+board's floor before believing "no legal pose". And the candidate lattice
+does not necessarily contain the part's CURRENT coordinate, so check the
+four rotations AT THE PART'S OWN (x, y) with `candidate_valid` besides
+reading the ranked list — the cheapest and most common 0a-bis candidate,
+flip in place, can be absent from an otherwise-legal ranking (measured:
+U3 rot-180 legal in place on two seeds where the enumeration listed no
+rot-180 pose at all).
 
 Run this **second**, after Step 0a, and read the reasons. Nothing is locked
 automatically, deliberately: a wrong auto-lock silently freezes a part that
@@ -296,15 +351,34 @@ input — "keep what I have" stays a first-class outcome.
 
 **The acceptance rule generalizes K-way, and stays a conjunction.** The
 Step 0c rule (metrics no worse + intent passes + repo gates pass) applies
-**per candidate against the baseline row**; the portfolio pre-applies the
-first two as its hard gates, the repo-local gates are still yours to run on
-the candidate you pick. Among survivors:
+**per candidate against the baseline row**. What the portfolio enforces as
+HARD gates is legality + intent (rule 2); **rule 1 — metrics no worse than
+the baseline — is ANNOTATED, not gated**: violators carry `gates.rule1` /
+`rule1_violators` in portfolio.json and are excluded from the
+JSON_SUMMARY `best` pick (which falls back to the baseline), but they stay
+in the rankings. Verify rule 1 YOURSELF against the baseline row before
+adopting ANY index (measured, run 7: a slate's routed-best carried
+crossings 74 vs baseline 67 with hpwl also worse; only the manual
+conjunction check at adoption caught it). The repo-local gates are still
+yours to run on the candidate you pick. Among survivors:
 
 1. Prefer `ranking_routed` over `ranking_static` — the probe tier
    (`--route-top`, default: baseline + top 2) routes one SHARED affected-net
    set, so its `failures`/`iterations` compare like with like. Never adopt
    on static rank alone when the budget allows one probe route: crossings
    and hpwl are proxies, and the router is the judge that counts.
+   **`ranking_routed: []` with `--route-top >= 1` means the probe tier
+   FAILED, not that it was skipped** — read the `[probe]` log lines and fix
+   before adopting; empty-routed is never a license to adopt on static rank
+   (measured: caller-relative paths broke every probe rc=1 and the slate
+   silently degraded to static). And **the shared window compares like with
+   like WITHIN the slate; it is not whole-board routability** — it routes
+   only the affected nets (run 7: 13–16 of 45). Pruning on it is fine;
+   before ADOPTING on it, pass `--full-probe`: it routes the WHOLE board on
+   the baseline + the window winner and that verdict outranks the window
+   (measured: window-best 14 failures, same board full-probed 52 vs
+   baseline 41 — verdict reversed). `probe_kind` in the summary says which
+   instrument produced the ranking you are reading.
 2. Ties go to the LEAST displacement (the slate is diverse by construction —
    kept candidates sit ≥ `--diversity-mm` apart in pose distance — so a tie
    is a real tie, not two clones).
@@ -355,6 +429,15 @@ python3 -X utf8 check_floorplan.py board.kicad_pcb --intent /tmp/intent.json --h
 Exit **0** clean, **4** violations, **3** the board is not in a state it can
 grade. Each violation carries the measured number beside the limit it broke, so
 `--json` output is quotable evidence rather than an opinion.
+
+**The grading knobs resolve from the BOARD when unset** — the legality rules
+inflate part rects by the grading clearance, so a fixed default looser than
+the board's floor manufactures phantom oob/overlap findings (run-7 S1: a
+phantom 5th oob part, budget 4, exit 4, on a board that grades 0 errors at
+its real 0.15/0.3 floor). The JSON_SUMMARY discloses `clearance_used` /
+`edge_clearance_used` with their source — quote them with any violation you
+report, and pass explicit `--clearance`/`--board-edge-clearance` only when
+you mean to grade at a different floor than the board's own.
 
 Worth declaring, in rough order of value: `must_lock` for the parts the lock
 advisor flagged; `edge_connectors` for anything that is *meant* to overhang

--- a/.gui-parity-checked
+++ b/.gui-parity-checked
@@ -1,3 +1,36 @@
+HEAD 2026-08-03 parity audit 8bd1344..b60d597 (11 commits, the post-run-7
+wave). Outcome: no gaps.
+
+  * Engine honesty (4775c7b): open_single classification, terminal-restore
+    grading, via dedup + stacked_copper -- ALL inside batch_route /
+    reroute_loop / rip_restore (shared functions, both fronts inherit);
+    summary keys are additive, no new engine kwargs surfaced to either
+    front, no CLI-main post-passes (the dedup runs pre-write inside
+    batch_route, which is exactly why the gate's copper sets stay
+    identical).
+  * converge (13cb297), check_floorplan/check_join (fc1c200),
+    compare_seeds (99c4018), plane_score (cb2ede5): analysis/verification
+    CLIs with no board-mutating GUI counterpart needed; place_portfolio's
+    new --full-probe/--plane-score/--plane-score-budget are placement
+    flags, CLI-only by design like the rest of the placement family (the
+    manifest converter refuses placement tools loudly -- prior precedent).
+  * kicad_exact_fill.find_kicad_python now probes versioned Windows
+    installs (C:\Program Files\KiCad\10.0\...) -- shared helper; the GUI's
+    live-fill path never needed it, the CLI exact-fill consumers were
+    silently disabled on standard Windows installs before this.
+  * Gates at b60d597 (2026-08-03, Windows KiCad 10.0 python, wx 4.2.2):
+    test_gui_engine_parity VERDICT: PARITY -- segments CLI=GUI=1307, vias
+    144=144, copper sets IDENTICAL (kicad_unconnected/drc both -1: kicad-cli
+    grading skipped identically on both sides in the gate env; the exact
+    copper-set comparison is the decisive check). test_manifest_plan_parity
+    0 mismatches (placement-block flags refused loudly).
+    test_cli_postpass_coverage 7 registered, 0 failures (run_drc stays the
+    acknowledged report-only CLI-only pass). Marker convention caveat: the
+    gate's plan is signal+plane, so diff-pair/impedance params ride on
+    test_manifest_plan_parity only.
+
+== previous audit ==
+
 MERGED 2026-08-02: upstream/main (d7a8ab2..cae82e3, #424/#529/#556/#465,
 Rust 0.19.3) merged into issue-549-floorplan-intent at ad559bf, on top of the
 run-7 prep wave (11 commits). Gates re-run on the MERGED state, grid_router

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,16 @@ Validate routed boards against the *real* spec, with the right checker — most
 - **Routers can report false success.** A router's own "routed" tally may come from
   a local/heuristic proxy while pads stay disconnected; re-verify with the
   authoritative, zone/fill-aware `check_net_connectivity` before trusting it.
+- **Read the failure buckets by their real definitions (run-7 wave).**
+  `failed_single` = "no result at all"; `open_single` = a KEPT result whose pads
+  are still disconnected (non-multipoint only — multipoint shortfalls are the
+  pad deficit); a verdict is `len(failed_single) + len(open_single) +
+  pad-deficit` (converge.route_verdict / place_route_loop count exactly this).
+  `terminal_restores` names rip victims restored at terminal failure with their
+  outcome ('full' is the only success; 'full_open'/'stub' ship broken).
+  `stacked_copper` disclosures are same-net duplicate copper KiCad's DRC will
+  never flag — the writer dedups exact via stacks before writing, and what
+  survives is in the summary, not silent.
 - **Net classes are RESPECTED (PR392), and `--clearance` is a pure CEILING over ALL
   of them (#439).** The router honors KiCad's pairwise `max(classA, classB)` between
   nets of different classes — including copper routed earlier in the SAME call (in-run)

--- a/check_floorplan.py
+++ b/check_floorplan.py
@@ -76,12 +76,14 @@ def build_parser():
                         "Deriving is read-only here, which is why this defaults "
                         "ON unlike on the placement CLIs")
     p.add_argument('--clearance', type=float, metavar='MM',
-                   help='clearance the legality model grades at (default: the '
-                        'routing default). Pass the floor the board was routed '
-                        'to, or halo and overlap are graded at the wrong gap')
+                   help="clearance the legality model grades at (default: "
+                        "the board's own Default netclass, else 0.25). "
+                        "Grading a fixed constant tighter than the board's "
+                        "floor manufactures phantom violations")
     p.add_argument('--board-edge-clearance', type=float, metavar='MM',
-                   help='board-edge clearance for the outline gate '
-                        '(default: 0.55)')
+                   help="board-edge clearance for the outline gate (default: "
+                        "the board's own min_copper_edge_clearance, else "
+                        "0.55)")
     p.add_argument('--health', action='store_true',
                    help="also report the routability signals from the intent's "
                         "`health` block: how far each block sits from the parts "
@@ -142,10 +144,20 @@ def main(argv=None):
     except IntentError as exc:
         parser_error(str(exc))
 
+    # Run-7 S1: unset knobs grade at the BOARD's floor, not fixed constants
+    # (a 0.25 default on a 0.15 board manufactured phantom oob findings).
+    from list_nets import board_floor_knobs
+    clearance, edge_clearance, knobs = board_floor_knobs(
+        args.board, args.clearance, args.board_edge_clearance)
+    if not args.quiet:
+        print(f"grading at clearance {clearance} "
+              f"({knobs['clearance']['source']}), edge {edge_clearance} "
+              f"({knobs['board_edge_clearance']['source']})")
+
     try:
         result = grade(intent, pcb, args.board, group_sources=sources or (),
-                       clearance=args.clearance,
-                       board_edge_clearance=args.board_edge_clearance,
+                       clearance=clearance,
+                       board_edge_clearance=edge_clearance,
                        with_health=args.health)
     except UntrustworthyOutline as exc:
         print(f"ERROR: {args.board}: {exc}", file=sys.stderr)
@@ -164,7 +176,10 @@ def main(argv=None):
         if not args.quiet:
             print(f"  wrote {args.json}")
 
-    print("JSON_SUMMARY: " + json.dumps(summary(result), sort_keys=True))
+    s = summary(result)
+    s['clearance_used'] = knobs['clearance']
+    s['edge_clearance_used'] = knobs['board_edge_clearance']
+    print("JSON_SUMMARY: " + json.dumps(s, sort_keys=True))
     if result.errors and not args.exit_zero:
         return VIOLATIONS_EXIT
     return 0

--- a/check_join.py
+++ b/check_join.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Verify a candidate hand-join (polyline + vias) against ALL board copper,
+BEFORE the first segment is committed.
+
+Promoted from run 7's wk7/join_check.py, built mid-run after hand-authored
+copper shipped 42 invisible shorts: connectivity gates said "connected", and
+KiCad's DRC was only consulted at the end. The prototype checked AABB pads at
+two hardcoded constants; this version stages the candidate onto a copy of the
+board and lets the REAL check_drc engine grade it -- rotated pads, custom pad
+polygons, netclass pairwise clearances, per-layer .kicad_dru rules, board
+edge, hole-to-hole, all for free -- then adds the join-specific checks the
+DRC deliberately does not do: layer transitions without a via, and same-net
+via stacks (KiCad permits those, so only this tool will ever flag them).
+
+    python check_join.py BOARD NET x,y,layer x,y,layer ... [via:x,y ...]
+
+The polyline is the join: consecutive points on the SAME layer become track
+segments; a layer change between consecutive points must happen at the SAME
+coordinate AND carry a via: token there, or it is a missing-via violation.
+Track width and via geometry default from the board's own Default netclass.
+
+Exit 0 clean, 1 violations, 2 usage errors.
+"""
+import argparse
+import json
+import math
+import os
+import shutil
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, ROOT)
+
+COORD_TOL = 1e-3   # mm: polyline vertices this close are the same point
+
+
+def build_parser():
+    p = argparse.ArgumentParser(
+        description="Verify a candidate hand-join against ALL board copper "
+                    "before committing it.",
+        formatter_class=argparse.RawDescriptionHelpFormatter, epilog="""
+Examples:
+  python check_join.py b.kicad_pcb SWDIO 132.1,75.4,F.Cu 133.0,75.4,F.Cu
+  python check_join.py b.kicad_pcb GPIO1 130.0,70.0,F.Cu 130.0,70.0,B.Cu \\
+      130.5,72.0,B.Cu via:130.0,70.0
+""")
+    p.add_argument('board', help='the .kicad_pcb the join would be added to')
+    p.add_argument('net', help='EXACT net name the join belongs to')
+    p.add_argument('tokens', nargs='+', metavar='x,y,layer|via:x,y',
+                   help='polyline points (x,y,layer) and via positions '
+                        '(via:x,y), in order')
+    p.add_argument('--width', type=float, default=None,
+                   help="track width in mm (default: the board's Default "
+                        "netclass track_width, else 0.3)")
+    p.add_argument('--via-size', type=float, default=None,
+                   help="via outer diameter (default: board netclass, "
+                        "else 0.5)")
+    p.add_argument('--via-drill', type=float, default=None,
+                   help="via drill (default: board netclass, else 0.3)")
+    p.add_argument('--keep-staged', metavar='PATH', default=None,
+                   help='also write the staged board (input + candidate) '
+                        'here, for inspection in KiCad')
+    p.add_argument('-q', '--quiet', action='store_true',
+                   help='print only the verdict and the violations')
+    return p
+
+
+def _parse_tokens(tokens, parser):
+    pts, vias = [], []
+    for tok in tokens:
+        try:
+            if tok.startswith('via:'):
+                x, y = tok[4:].split(',')
+                vias.append((float(x), float(y)))
+            else:
+                x, y, layer = tok.split(',')
+                pts.append((float(x), float(y), layer))
+        except ValueError:
+            parser.error(f"cannot parse token {tok!r} (want x,y,layer or "
+                         f"via:x,y)")
+    if len(pts) < 2 and not vias:
+        parser.error("a join needs at least two polyline points (or a via)")
+    return pts, vias
+
+
+def _drc_knobs(board, quiet):
+    """The same board-first knob resolution check_drc's own CLI performs, so
+    the staged grade equals what plain check_drc.py would say."""
+    clearance = 0.2
+    try:
+        from fix_kicad_drc_settings import find_project, project_copper_clearance
+        pro = find_project(board)
+        if os.path.isfile(pro):
+            with open(pro, encoding='utf-8') as f:
+                pc = project_copper_clearance(json.load(f))
+            if pc:
+                clearance = pc
+    except Exception:
+        pass
+    net_clearances = None
+    edge = 0.0
+    h2h = None
+    try:
+        import routing_defaults as defaults
+        h2h = defaults.HOLE_TO_HOLE_CLEARANCE
+        from list_nets import read_design_rules, net_clearance_map
+        from kicad_parser import extract_nets, detect_kicad_version
+        rules = read_design_rules(board)
+        if rules.get('classes'):
+            with open(board, encoding='utf-8', errors='replace') as f:
+                content = f.read()
+            net_objs, _ = extract_nets(content, detect_kicad_version(content))
+            del content
+            net_clearances = net_clearance_map(
+                board, [n.name for n in net_objs.values()], rules=rules) or None
+        edge = float(rules.get('constraints', {})
+                     .get('min_copper_edge_clearance') or 0.0)
+        pro_h2h = float(rules.get('constraints', {})
+                        .get('min_hole_to_hole') or 0.0)
+        if pro_h2h > h2h:
+            h2h = pro_h2h
+    except Exception as e:
+        if not quiet:
+            print(f"  (netclass/edge rules not read: {e})")
+    return clearance, net_clearances, edge, h2h
+
+
+def _violation_sig(v):
+    def _r(loc):
+        try:
+            return tuple(round(float(x), 3) for x in loc)
+        except (TypeError, ValueError):
+            return (str(loc),)
+    locs = sorted(_r(v.get(k)) for k in ('loc1', 'loc2') if v.get(k))
+    return (v.get('type'), tuple(sorted((str(v.get('net1')),
+                                         str(v.get('net2'))))),
+            v.get('layer'), tuple(locs))
+
+
+def _stage_board(board, out_path, pcb, net_id, cand_segs, cand_vias):
+    """input board text + the candidate copper appended as real s-exprs."""
+    from kicad_parser import board_uses_name_nets
+    from kicad_writer import generate_segment_sexpr, generate_via_sexpr
+    with open(board, encoding='utf-8', errors='replace') as f:
+        content = f.read()
+    # Match the net-token format the file ACTUALLY uses (the output_writer
+    # rule): a name token in a numbered-net file double-parses the copper.
+    net_name = ((pcb.net_id_to_name or {}).get(net_id)
+                if board_uses_name_nets(content) else None)
+    blocks = []
+    for s in cand_segs:
+        blocks.append(generate_segment_sexpr(
+            (s.start_x, s.start_y), (s.end_x, s.end_y), s.width, s.layer,
+            net_id, net_name=net_name))
+    for v in cand_vias:
+        blocks.append(generate_via_sexpr(v.x, v.y, v.size, v.drill,
+                                         v.layers, net_id,
+                                         net_name=net_name))
+    tail = content.rstrip()
+    if not tail.endswith(')'):
+        raise ValueError(f"{board} does not end with a closing paren")
+    idx = content.rindex(')')
+    with open(out_path, 'w', encoding='utf-8') as f:
+        f.write(content[:idx] + '\n'.join(blocks) + '\n' + content[idx:])
+    from placement.portfolio import copy_siblings
+    copy_siblings(board, out_path)
+
+
+def main(argv=None):
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    args.board = os.path.abspath(args.board)
+    if not os.path.isfile(args.board):
+        parser.error(f"{args.board}: no such file")
+    pts, via_pts = _parse_tokens(args.tokens, parser)
+
+    from kicad_parser import Segment, Via, parse_kicad_pcb
+    import routing_defaults as defaults
+    from list_nets import board_default_netclass_param
+
+    pcb = parse_kicad_pcb(args.board)
+    net_id = next((nid for nid, n in pcb.nets.items()
+                   if n.name == args.net), None)
+    if net_id is None:
+        print(f"check_join: no net named {args.net!r} on this board "
+              f"(names are exact; check with list_nets.py)", file=sys.stderr)
+        return 2
+    copper = list(pcb.board_info.copper_layers or ['F.Cu', 'B.Cu'])
+    bad_layers = sorted({p[2] for p in pts} - set(copper))
+    if bad_layers:
+        print(f"check_join: {', '.join(bad_layers)} is not a copper layer "
+              f"of this board ({', '.join(copper)})", file=sys.stderr)
+        return 2
+
+    width = (args.width
+             or board_default_netclass_param(args.board, 'track_width')
+             or defaults.TRACK_WIDTH)
+    via_size = (args.via_size
+                or board_default_netclass_param(args.board, 'via_diameter')
+                or defaults.VIA_SIZE)
+    via_drill = (args.via_drill
+                 or board_default_netclass_param(args.board, 'via_drill')
+                 or defaults.VIA_DRILL)
+
+    # ---- candidate geometry + the join-shape checks ------------------------
+    violations = []
+    cand_segs = []
+    for p, q in zip(pts, pts[1:]):
+        if p[2] == q[2]:
+            if math.hypot(q[0] - p[0], q[1] - p[1]) > COORD_TOL:
+                cand_segs.append(Segment(
+                    start_x=p[0], start_y=p[1], end_x=q[0], end_y=q[1],
+                    width=width, layer=p[2], net_id=net_id))
+            continue
+        # A layer change: must happen in place, over a via. The prototype
+        # silently DROPPED these pairs, so a join relying on a transition
+        # was never checked as drawn.
+        if math.hypot(q[0] - p[0], q[1] - p[1]) > COORD_TOL:
+            violations.append(
+                f"missing-via: layer change {p[2]} -> {q[2]} between "
+                f"({p[0]:.3f},{p[1]:.3f}) and ({q[0]:.3f},{q[1]:.3f}) is "
+                f"also a MOVE -- a transition happens at one coordinate; "
+                f"add the point twice (once per layer) plus via:x,y")
+        elif not any(math.hypot(vx - p[0], vy - p[1]) <= COORD_TOL
+                     for vx, vy in via_pts):
+            violations.append(
+                f"missing-via: layer change {p[2]} -> {q[2]} at "
+                f"({p[0]:.3f},{p[1]:.3f}) has no via: token there")
+    cand_vias = [Via(x=vx, y=vy, size=via_size, drill=via_drill,
+                     layers=[copper[0], copper[-1]], net_id=net_id)
+                 for vx, vy in via_pts]
+
+    # ---- same-net stacks (the DRC will NEVER flag these) -------------------
+    from check_weird import stacked_copper_over_model
+    own_segs = [s for s in pcb.segments if s.net_id == net_id]
+    own_vias = [v for v in pcb.vias if v.net_id == net_id]
+    pre = {_violation_sig_stub(f) for f in stacked_copper_over_model(
+        {net_id: own_segs}, {net_id: own_vias}, lambda n: args.net)}
+    for f in stacked_copper_over_model(
+            {net_id: own_segs + cand_segs}, {net_id: own_vias + cand_vias},
+            lambda n: args.net):
+        if _violation_sig_stub(f) not in pre:
+            violations.append(f"stacked-copper: {f['detail']} "
+                              f"[{f['layer']}]")
+
+    # ---- the real DRC engine, staged-vs-baseline ---------------------------
+    if cand_segs or cand_vias:
+        from check_drc import run_drc
+        clearance, net_clearances, edge, h2h = _drc_knobs(args.board,
+                                                          args.quiet)
+        if not args.quiet:
+            print(f"grading at clearance {clearance} "
+                  f"(+netclasses/.kicad_dru as check_drc resolves them)")
+        tmp = tempfile.mkdtemp(prefix='check_join_')
+        try:
+            staged = os.path.join(tmp, 'staged.kicad_pcb')
+            _stage_board(args.board, staged, pcb, net_id, cand_segs,
+                         cand_vias)
+            if args.keep_staged:
+                shutil.copy(staged, args.keep_staged)
+                for ext in ('.kicad_pro', '.kicad_dru'):
+                    sib = os.path.splitext(staged)[0] + ext
+                    if os.path.isfile(sib):
+                        shutil.copy(sib, os.path.splitext(
+                            os.path.abspath(args.keep_staged))[0] + ext)
+            common = dict(clearance=clearance, net_patterns=[args.net],
+                          quiet=True, hole_to_hole_clearance=h2h,
+                          board_edge_clearance=edge, max_print=0,
+                          check_sizes=False, print_summary=False,
+                          net_clearances=net_clearances)
+            base_v = {(_violation_sig(v))
+                      for v in run_drc(args.board, **common)
+                      if not v.get('accepted')}
+            for v in run_drc(staged, **common):
+                if v.get('accepted') or _violation_sig(v) in base_v:
+                    continue
+                loc = v.get('loc1') or v.get('loc2') or ()
+                loc_s = ','.join(f"{float(x):.3f}" for x in loc[:2]) if loc else '?'
+                violations.append(
+                    f"{v.get('type')}: {v.get('net1')} vs {v.get('net2')}"
+                    f" [{v.get('layer') or '*'}] near ({loc_s})"
+                    + (f" -- {v.get('distance'):.3f}mm"
+                       if isinstance(v.get('distance'), float) else ''))
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    for msg in violations:
+        print(f"  VIOLATION {msg}")
+    print('CLEAN' if not violations else f'{len(violations)} violation(s)')
+    return 0 if not violations else 1
+
+
+def _violation_sig_stub(f):
+    return (f['category'], f['layer'], round(f['x'], 3), round(f['y'], 3))
+
+
+if __name__ == '__main__':
+    from console_encoding import enable_utf8_console
+    enable_utf8_console()
+    sys.exit(main())

--- a/check_weird.py
+++ b/check_weird.py
@@ -442,6 +442,22 @@ def _check_stacked(net_id, name, net_segs, net_vias, findings):
                             size=getattr(v, 'size', None)))
 
 
+def stacked_copper_over_model(segs_by_net, vias_by_net, net_name):
+    """The stacked-copper check over a per-net write model (run-7 E3).
+
+    route.py calls this on the copper it is ABOUT to write, after its via
+    dedup, so anything still stacked is surfaced in the run summary instead
+    of shipping silently (KiCad permits same-net stacks, so no DRC ever
+    flags them). `net_name` is a net_id -> str callable. Returns the same
+    finding dicts check_weird's CLI reports.
+    """
+    findings = []
+    for nid in sorted(set(segs_by_net) | set(vias_by_net)):
+        _check_stacked(nid, net_name(nid), segs_by_net.get(nid, []),
+                       vias_by_net.get(nid, []), findings)
+    return findings
+
+
 def _check_unsupported_vias(net_id, name, net_segs, net_vias, net_pads,
                             net_zones, copper_layers, findings):
     """Floating vias: no same-net track copper reaching the barrel, no

--- a/compare_seeds.py
+++ b/compare_seeds.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Rank place_seed seeds by ONE identical full-board probe each.
+
+Run 7 hand-rolled exactly this: three seeds, each graded against the intent,
+then compared -- and the comparison that actually discriminated was a
+FULL-BOARD probe route per seed, not the portfolio's shared-window probe and
+not crossings (crossings ranked seed 0 first; the probe measured seed 2 at
+39 failures vs seed 0's 53 and run 7 shipped on seed 2). The skill's ladder
+now calls for identical full-board probes on the seed axis; this CLI is that
+step as one command instead of an afternoon of bookkeeping.
+
+Per seed: place_seed subprocess (the seed must GRADE CLEAN against its own
+intent -- a seed failing its gate is recorded but never ranked) -> one
+full-board probe via converge.scoped_route, every seed routed with the SAME
+net patterns and the SAME route args, verdicts via route_verdict (which
+counts routed-but-OPEN nets). Output: a ranked table, seeds.json in
+--out-dir, and a JSON_SUMMARY line with best_seed.
+
+    python compare_seeds.py board.kicad_pcb --intent floorplan.json \\
+        --seeds 0 1 2 --out-dir seedcmp --ignore-nets GND VCC
+
+Exit 0 when at least one seed was probed; 4 when every seed failed its
+intent gate (nothing rankable); 2 for usage errors.
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+
+
+def build_parser():
+    p = argparse.ArgumentParser(
+        description="Rank place_seed seeds by one identical full-board "
+                    "probe each.",
+        formatter_class=argparse.RawDescriptionHelpFormatter, epilog="""
+Examples:
+  python compare_seeds.py board.kicad_pcb --intent fp.json --seeds 0 1 2 \\
+      --out-dir seedcmp --ignore-nets GND VCC
+  python compare_seeds.py board.kicad_pcb --intent fp.json --seeds 0 5 \\
+      --out-dir seedcmp --route-args --clearance 0.15
+""")
+    p.add_argument("input_file", help="Unplaced board (outline + parts pile)")
+    p.add_argument("--intent", required=True,
+                   help="Floorplan intent, forwarded to place_seed")
+    p.add_argument("--seeds", type=int, nargs="+", default=[0, 1, 2],
+                   help="Seed values to generate and rank (default: 0 1 2)")
+    p.add_argument("--out-dir", required=True,
+                   help="Directory for seed boards + seeds.json")
+    p.add_argument("--ignore-nets", nargs="+", default=None,
+                   help="Net patterns excluded from the probe (plane-routed "
+                        "rails) and forwarded to place_seed's polish")
+    p.add_argument("--seed-args", nargs="+", default=None,
+                   help="Extra args forwarded verbatim to every place_seed "
+                        "call (e.g. --clearance 0.15)")
+    p.add_argument("--route-args", nargs="+", default=None,
+                   help="Extra args for every probe route -- identical "
+                        "across seeds by construction")
+    p.add_argument("--route-timeout", type=int, default=1800,
+                   help="Per-probe timeout in seconds (default: 1800)")
+    p.add_argument("--skip-gated", action="store_true", default=True,
+                   help=argparse.SUPPRESS)
+    p.add_argument("--probe-gated", action="store_true",
+                   help="Probe seeds that FAILED their intent gate too "
+                        "(recorded but still never ranked above a clean "
+                        "seed)")
+    return p
+
+
+def _run_place_seed(args, seed, out_board):
+    argv = [sys.executable, '-X', 'utf8',
+            os.path.join(ROOT, 'place_seed.py'), args.input_file, out_board,
+            '--intent', args.intent, '--seed', str(seed)]
+    if args.ignore_nets:
+        argv += ['--ignore-nets'] + list(args.ignore_nets)
+    if args.seed_args:
+        argv += list(args.seed_args)
+    r = subprocess.run(argv, capture_output=True, text=True,
+                       encoding='utf-8', errors='replace', cwd=ROOT)
+    summary = {}
+    for line in r.stdout.splitlines():
+        if line.startswith('JSON_SUMMARY:'):
+            try:
+                summary = json.loads(line.split(':', 1)[1])
+            except ValueError:
+                pass
+    return r, summary
+
+
+def main():
+    parser = build_parser()
+    args = parser.parse_args()
+    # Subprocesses run with cwd=ROOT: a caller-relative path silently breaks
+    # every one of them (the place_portfolio lesson, 8bd1344). Absolutize at
+    # the door.
+    args.input_file = os.path.abspath(args.input_file)
+    args.intent = os.path.abspath(args.intent)
+    args.out_dir = os.path.abspath(args.out_dir)
+    if len(set(args.seeds)) != len(args.seeds):
+        parser.error("--seeds has duplicates")
+    os.makedirs(args.out_dir, exist_ok=True)
+    try:
+        from redo_record import record_invocation
+        record_invocation()
+    except Exception:
+        pass
+
+    from converge import route_verdict, scoped_route
+
+    full_nets = ['*'] + [f'!{p}' for p in (args.ignore_nets or [])]
+    rows = []
+    for seed in args.seeds:
+        out_board = os.path.join(args.out_dir, f'seed_{seed}.kicad_pcb')
+        print(f"[seed {seed}] place_seed -> {os.path.basename(out_board)}")
+        r, s = _run_place_seed(args, seed, out_board)
+        row = {'seed': seed, 'board': out_board,
+               'place_seed_rc': r.returncode,
+               'grade_errors': s.get('grade_errors'),
+               'unseated': s.get('unseated'),
+               'crossings': s.get('crossings'), 'hpwl': s.get('hpwl'),
+               'probe': None}
+        if r.returncode not in (0, 4):
+            row['note'] = ('place_seed failed: '
+                           + (r.stderr or r.stdout)[-300:].strip())
+            print(f"[seed {seed}] FAILED (rc={r.returncode})")
+            rows.append(row)
+            continue
+        row['gated'] = (r.returncode == 4)
+        if row['gated']:
+            print(f"[seed {seed}] fails its intent gate "
+                  f"({s.get('grade_errors')} error(s), "
+                  f"{s.get('unseated')} unseated)"
+                  + ("" if args.probe_gated else " -- not probed"))
+            if not args.probe_gated:
+                rows.append(row)
+                continue
+        print(f"[seed {seed}] probing full board "
+              f"({len(full_nets)} pattern(s))")
+        try:
+            res = scoped_route(out_board, full_nets,
+                               extra_args=args.route_args or [],
+                               timeout=args.route_timeout)
+        except subprocess.TimeoutExpired:
+            row['probe'] = {'failures': None,
+                            'note': f'timeout after {args.route_timeout}s'}
+            rows.append(row)
+            continue
+        n, note = route_verdict(res['summary'])
+        row['probe'] = {'failures': n, 'note': note, 'probe_kind': 'full',
+                        'iterations': res['summary'].get('total_iterations'),
+                        'vias': res['summary'].get('total_vias'),
+                        'returncode': res['returncode']}
+        print(f"[seed {seed}] failures={n} ({note})")
+        rows.append(row)
+
+    # Rank: clean-gated probed seeds first by (failures, iterations, seed);
+    # probed-but-gated after them; everything else last, unranked.
+    def _key(row):
+        pr = row.get('probe') or {}
+        f = pr.get('failures')
+        return (0 if (f is not None and not row.get('gated')) else
+                1 if f is not None else 2,
+                f if f is not None else 1 << 30,
+                pr.get('iterations') or 0,
+                row['seed'])
+
+    ranked = sorted(rows, key=_key)
+    print("\nseed  gate   failures  iterations  crossings  hpwl")
+    for row in ranked:
+        pr = row.get('probe') or {}
+        gate = ('FAIL' if row.get('gated') else
+                'ok' if row.get('place_seed_rc') == 0 else 'ERR')
+        print(f"{row['seed']:>4}  {gate:<5}  "
+              f"{str(pr.get('failures', '-')):>8}  "
+              f"{str(pr.get('iterations', '-')):>10}  "
+              f"{str(row.get('crossings', '-')):>9}  "
+              f"{str(row.get('hpwl', '-')):>8}")
+
+    best = next((r for r in ranked
+                 if (r.get('probe') or {}).get('failures') is not None
+                 and not r.get('gated')), None)
+    doc = {'input': args.input_file, 'intent': args.intent,
+           'seeds': args.seeds, 'probe_nets': full_nets,
+           'route_args': args.route_args or [], 'rows': rows,
+           'ranking': [r['seed'] for r in ranked],
+           'best_seed': best['seed'] if best else None}
+    doc_path = os.path.join(args.out_dir, 'seeds.json')
+    with open(doc_path, 'w', encoding='utf-8') as f:
+        json.dump(doc, f, indent=1, sort_keys=True)
+    print(f"Wrote {doc_path}")
+    print("JSON_SUMMARY: " + json.dumps({
+        'seeds': len(args.seeds), 'probed': sum(1 for r in rows if r['probe']),
+        'gated': sum(1 for r in rows if r.get('gated')),
+        'best_seed': best['seed'] if best else None,
+        'best_failures': ((best.get('probe') or {}).get('failures')
+                          if best else None),
+        'out_dir': args.out_dir}, sort_keys=True))
+    if best is not None:
+        return 0
+    if rows and all(r.get('gated') for r in rows):
+        print("compare_seeds: every seed failed its intent gate -- nothing "
+              "rankable. Fix the intent or the pile first.", file=sys.stderr)
+        return 4
+    return 4 if not any(r['probe'] for r in rows) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/converge.py
+++ b/converge.py
@@ -175,28 +175,13 @@ def _pose_knobs(board, clearance, board_edge_clearance):
     The old fixed argparse defaults (0.25/0.55) silently vetoed legal
     rotations on any board routed to a tighter floor (0.15/0.3): the grader
     was stricter than the board's own spec, and `poses` reported "no legal
-    pose" for poses the router would happily route. Mirror the route.py
-    mains' resolution order: explicit CLI value > the board's own Default
-    netclass / board constraint > the fixed default.
+    pose" for poses the router would happily route. Resolution order (shared
+    with check_floorplan via list_nets.board_floor_knobs): explicit CLI
+    value > the board's own Default netclass / board constraint > the fixed
+    default.
     """
-    from list_nets import board_default_netclass_clearance, board_constraint
-    knobs = {}
-    if clearance is None:
-        v = board_default_netclass_clearance(board)
-        clearance, src = ((v, 'board netclass') if v is not None
-                          else (0.25, 'fixed default'))
-    else:
-        src = 'cli'
-    knobs['clearance'] = {'value': clearance, 'source': src}
-    if board_edge_clearance is None:
-        v = board_constraint(board, 'min_copper_edge_clearance')
-        board_edge_clearance, src = ((v, 'board constraint') if v is not None
-                                     else (0.55, 'fixed default'))
-    else:
-        src = 'cli'
-    knobs['board_edge_clearance'] = {'value': board_edge_clearance,
-                                     'source': src}
-    return clearance, board_edge_clearance, knobs
+    from list_nets import board_floor_knobs
+    return board_floor_knobs(board, clearance, board_edge_clearance)
 
 
 def cmd_poses(a):

--- a/converge.py
+++ b/converge.py
@@ -83,11 +83,16 @@ def route_verdict(summary):
     if not summary:
         return None, 'no summary'
     failed = list(summary.get('failed_single') or [])
+    # Routed-but-OPEN nets (kept result, disconnected pads). Before this key a
+    # non-multipoint open net weighed ZERO here -- probes read failures=0 on
+    # boards shipping open copper. Multipoint nets are excluded from the key by
+    # the emitter, so adding it to the pad deficit cannot double-count.
+    opened = list(summary.get('open_single') or [])
     fm = [d.get('net_name') if isinstance(d, dict) else d
           for d in (summary.get('failed_multipoint') or [])]
     deficit = (summary.get('multipoint_pads_total', 0)
                - summary.get('multipoint_pads_connected', 0))
-    n = len(failed) + max(0, deficit)
+    n = len(failed) + len(opened) + max(0, deficit)
     parts = []
     if failed or fm:
         parts.append('failed: ' + ', '.join(sorted(set(failed + fm))[:6]))

--- a/converge.py
+++ b/converge.py
@@ -169,19 +169,59 @@ class _StdoutToStderr:
         return False
 
 
+def _pose_knobs(board, clearance, board_edge_clearance):
+    """Resolve unset pose knobs from the BOARD (run-7 S4).
+
+    The old fixed argparse defaults (0.25/0.55) silently vetoed legal
+    rotations on any board routed to a tighter floor (0.15/0.3): the grader
+    was stricter than the board's own spec, and `poses` reported "no legal
+    pose" for poses the router would happily route. Mirror the route.py
+    mains' resolution order: explicit CLI value > the board's own Default
+    netclass / board constraint > the fixed default.
+    """
+    from list_nets import board_default_netclass_clearance, board_constraint
+    knobs = {}
+    if clearance is None:
+        v = board_default_netclass_clearance(board)
+        clearance, src = ((v, 'board netclass') if v is not None
+                          else (0.25, 'fixed default'))
+    else:
+        src = 'cli'
+    knobs['clearance'] = {'value': clearance, 'source': src}
+    if board_edge_clearance is None:
+        v = board_constraint(board, 'min_copper_edge_clearance')
+        board_edge_clearance, src = ((v, 'board constraint') if v is not None
+                                     else (0.55, 'fixed default'))
+    else:
+        src = 'cli'
+    knobs['board_edge_clearance'] = {'value': board_edge_clearance,
+                                     'source': src}
+    return clearance, board_edge_clearance, knobs
+
+
 def cmd_poses(a):
     from kicad_parser import parse_kicad_pcb
     import pose_score
+    clearance, board_edge_clearance, knobs = _pose_knobs(
+        a.board, a.clearance, a.board_edge_clearance)
     with _StdoutToStderr():
         pcb = parse_kicad_pcb(a.board)
-        st = pose_score.make_state(pcb, a.board, clearance=a.clearance,
-                                   board_edge_clearance=a.board_edge_clearance)
+        st = pose_score.make_state(pcb, a.board, clearance=clearance,
+                                   board_edge_clearance=board_edge_clearance)
+    diag = {}
     with _StdoutToStderr():
         poses = pose_score.rank_poses(pcb, a.board, a.ref, radius=a.radius,
-                                      step=a.step, limit=a.limit, state=st)
+                                      step=a.step, limit=a.limit, state=st,
+                                      diagnostics=diag)
     if not poses:
-        print(json.dumps({'ref': a.ref, 'poses': [],
-                          'note': 'no legal pose, including staying put'}, indent=1))
+        # The dropped-pose census is the difference between "this part has
+        # nowhere to go" and "your knobs veto even staying put" (run-7 S4:
+        # flip-in-place WAS enumerated, then silently dropped).
+        print(json.dumps({'ref': a.ref, 'poses': [], 'knobs': knobs,
+                          'dropped_total': diag.get('dropped_total', 0),
+                          'dropped_in_place': diag.get('dropped_in_place', []),
+                          'note': 'no legal pose, including staying put'},
+                         indent=1))
         return 1
 
     if a.route:
@@ -205,6 +245,9 @@ def cmd_poses(a):
                               'iterations': res['summary'].get('total_iterations'),
                               'vias': res['summary'].get('total_vias')}
     print(json.dumps({'ref': a.ref, 'base_cost': poses[0]['cost'] - poses[0]['delta'],
+                      'knobs': knobs,
+                      'dropped_total': diag.get('dropped_total', 0),
+                      'dropped_in_place': diag.get('dropped_in_place', []),
                       'poses': poses}, indent=1))
     return 0
 
@@ -249,17 +292,57 @@ def cmd_where(a):
 
 def cmd_record(a):
     from board_store import BoardStore, Ledger
+    # Refuse an --argv that can never replay (run-7 F4: entries recorded with
+    # placeholder script names made replay a reconstruction, which is exactly
+    # what the ledger exists to prevent). Nothing is written on refusal.
+    if a.argv:
+        import shutil
+        exe = a.argv[0]
+        if not (os.path.isfile(exe) or shutil.which(exe)):
+            print(f"record: --argv starts with '{exe}', which is neither an "
+                  f"existing file nor an executable on PATH -- this entry "
+                  f"could never replay. Record the REAL command (the one that "
+                  f"produced the board), or omit --argv for a prose-only "
+                  f"entry. Nothing was written.", file=sys.stderr)
+            return 2
+    # A run-closing record must name its stop condition (run-7 F5: the final
+    # entry shipped a headline count that contradicted the oracle; forcing
+    # the stop condition into the record is what makes the close-out gradable).
+    if a.final and not a.stop_condition:
+        print("record: --final requires --stop-condition (which of the run's "
+              "stop conditions ended it). Nothing was written.",
+              file=sys.stderr)
+        return 2
     store = BoardStore(a.store or os.path.join(os.path.dirname(a.ledger), 'boards'))
     sha = store.put(a.board)
     lg = Ledger(a.ledger)
     prev = lg.last_accepted()
-    e = lg.append({'iteration': len(lg.entries()), 'kind': a.kind,
-                   'parent_sha': (prev or {}).get('result_sha'),
-                   'result_sha': sha, 'lever': a.lever,
-                   'lever_argv': list(a.argv) if a.argv else None,
-                   'score': json.loads(a.score) if a.score else None,
-                   'accepted': not a.rejected})
+    entry = {'iteration': len(lg.entries()), 'kind': a.kind,
+             'parent_sha': (prev or {}).get('result_sha'),
+             'result_sha': sha, 'lever': a.lever,
+             'lever_argv': list(a.argv) if a.argv else None,
+             'score': json.loads(a.score) if a.score else None,
+             'accepted': not a.rejected}
+    if a.final:
+        entry['final'] = True
+        entry['stop_condition'] = a.stop_condition
+    e = lg.append(entry)
     print(json.dumps(e, indent=1, sort_keys=True))
+    # Failing-net NAMES belong in the record (run-7 S10/F5): a score that
+    # carries only a count forces every later read to re-derive which nets,
+    # and a truncated re-derivation shipped a wrong close-out.
+    sc = e.get('score') or {}
+    fails = sc.get('failures')
+    names = sc.get('failed_nets') or sc.get('failed') or []
+    if fails:
+        if names:
+            print("failing nets: " + ", ".join(str(n) for n in names[:12]),
+                  file=sys.stderr)
+        else:
+            print(f"NOTE: score records failures={fails} but names no nets -- "
+                  f"add 'failed_nets' to the score JSON so the ledger stays "
+                  f"readable without re-deriving the open set.",
+                  file=sys.stderr)
     return 0
 
 
@@ -330,8 +413,14 @@ def build_parser():
     q.add_argument('--radius', type=float, default=2.0)
     q.add_argument('--step', type=float, default=0.5)
     q.add_argument('--limit', type=int, default=12)
-    q.add_argument('--clearance', type=float, default=0.25)
-    q.add_argument('--board-edge-clearance', type=float, default=0.55)
+    q.add_argument('--clearance', type=float, default=None,
+                   help='pose-legality clearance (default: the board\'s own '
+                        'Default netclass, else 0.25; run-7 S4 -- a fixed '
+                        'default tighter than the board floor silently '
+                        'vetoes legal poses)')
+    q.add_argument('--board-edge-clearance', type=float, default=None,
+                   help='pose-legality edge clearance (default: the board\'s '
+                        'own min_copper_edge_clearance, else 0.55)')
     q.add_argument('--route', action='store_true',
                    help='also run tier 3 (a scoped route) on the top poses')
     q.add_argument('--route-top', type=int, default=2,
@@ -361,8 +450,14 @@ def build_parser():
     r.add_argument('--lever', default=None)
     r.add_argument('--score', default=None, help='JSON')
     r.add_argument('--rejected', action='store_true')
+    r.add_argument('--final', action='store_true',
+                   help='mark the run-closing record; requires --stop-condition')
+    r.add_argument('--stop-condition', default=None,
+                   help='which stop condition ended the run (with --final)')
     r.add_argument('--argv', nargs=argparse.REMAINDER, default=None,
-                   help='the command that produced it -- what makes replay possible')
+                   help='the command that produced it -- what makes replay '
+                        'possible. Refused (exit 2) when its first token is '
+                        'neither an existing file nor on PATH.')
     r.set_defaults(fn=cmd_record)
 
     s = sub.add_parser('step-back', help='check out an earlier board, exactly')

--- a/diff_pair_custody.py
+++ b/diff_pair_custody.py
@@ -172,9 +172,17 @@ def build_pair_reports(state, diff_pair_ids_to_route, member_audit,
             'failure_stage': (diag.get('stage')
                               ) if outcome in ('failed', 'deferred') else None,
             'incomplete_members': incomplete,
-            # Coupled/partial claim contradicted by actual pad connectivity:
-            # the "one member silently incomplete" class.
-            'member_audit_mismatch': bool(outcome in ('coupled', 'partial')
+            # A COUPLED claim contradicted by actual pad connectivity: the
+            # "one member silently incomplete" class (#514, peaksat CAN).
+            # 'partial' is deliberately NOT in this tuple: a partial pair
+            # already DECLARES disconnected members (its peeled terminals
+            # close in the single-ended follow-up, which runs after this
+            # audit), so flagging it here made every multipoint pair with a
+            # by-design peeled leg -- tigard /USB_D's redundant J1 row --
+            # read as a contradicted claim and demoted it from
+            # routed_diff_pairs while its trunk was coupled and its board
+            # finished clean. incomplete_members stays populated either way.
+            'member_audit_mismatch': bool(outcome == 'coupled'
                                           and incomplete),
         }
         if diag.get('blocking_nets'):

--- a/docs/placement-optimization.md
+++ b/docs/placement-optimization.md
@@ -500,6 +500,49 @@ against the same intent, and hands the result to the portfolio. The
 from-scratch verdict stands: unaided is still out of scope; *aided by a
 declared intent* is now a supported path.
 
+## Roadmap: placement science after run 7 (August 2026)
+
+Run 7 (the first clean-slate run whose placement this stack generated) and
+the discussion-#118 thread converged on the same diagnosis: the candidate
+score is built from signal proxies while several measured placement
+failures live elsewhere. Ordered by cost-to-value, cheapest first; item 1
+is implemented, the rest are documented targets.
+
+1. **Plane fragility in the candidate score — implemented** (`--plane-score`
+   on `place_portfolio.py`, backed by `plane_score.py`). Quench and
+   portfolio were plane-blind while the router-side #424 machinery already
+   prices exact fill damage. The score pours the declared plane nets on a
+   scratch copy (KiCad ZONE_FILLER refill), and folds (islands, neck sum)
+   into `rank_key` — islands before hpwl, neck sum after it. Trust it only
+   after calibration on boards with a measured probe order (run 7's seed
+   archive is the first known-answer case).
+
+2. **Channel occupancy as a nonlocality proxy.** `check_channel_utilisation`
+   and the intent's `bus_corridors` already measure what crosses a declared
+   channel; neither feeds the candidate score. A candidate that fills a
+   corridor past capacity fails ROUTING nonlocally — the failure surfaces on
+   whatever net routes last, far from the part that caused it (run 7's
+   west-fan capacity finding is exactly this shape). Wire corridor
+   occupancy into `score_candidate` next to `health_penalty`.
+
+3. **The #411 undo-a-known-good-placement harness.** The grading
+   instrument this document keeps needing: take a board a human placed and
+   routed clean, scramble it in controlled ways, and measure which score
+   terms recover the ranking. Move-set and weight work should wait for it —
+   without the harness every new term is calibrated on anecdotes.
+
+4. **Per-component best-location heatmap** (the #118 ask): for a chosen
+   part, render the board as a heatmap of the candidate score over
+   positions (with matching JSON), so a human can SEE why the optimizer
+   wants a part somewhere — and where the score is flat, which is where
+   declared intent has to carry the decision.
+
+5. **Part-class rule table as seeder configuration.** #118's taxonomy:
+   different part classes obey different placement logic (decap ≠ connector
+   ≠ crystal ≠ series termination). The seeder hardcodes a version of this;
+   making it a declared table would let a repo tune class behavior without
+   engine edits.
+
 ## References and further reading
 
 ### PCB-specific placement research

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -126,6 +126,62 @@ VIOLATION: Track too close to track
   Distance: 0.185mm (minimum: 0.2mm)
 ```
 
+## Hand-Join Verifier (`check_join.py`)
+
+Verifies a CANDIDATE hand-join (a polyline of track points plus optional
+vias) against all board copper, before the first segment is committed —
+promoted from the run-7 endgame, where hand-authored copper verified only
+against its target pads shipped 42 shorts.
+
+```bash
+python check_join.py BOARD NET x,y,layer x,y,layer ... [via:x,y ...]
+```
+
+Consecutive same-layer points become track segments; a layer change must
+happen at one coordinate over a `via:` token or it is a `missing-via`
+violation. The candidate is staged onto a copy of the board and graded by
+the real `check_drc` engine (staged-vs-baseline diff), so netclass pairwise
+clearances, `.kicad_dru` layer rules, rotated pads, custom pad polygons,
+board-edge and hole-to-hole all apply — plus a same-net via-stack check
+KiCad's DRC deliberately never does. Track width and via geometry default
+from the board's own Default netclass; override with `--width` /
+`--via-size` / `--via-drill`. `--keep-staged PATH` writes the staged board
+for inspection in KiCad. Exit 0 clean, 1 violations, 2 usage errors.
+
+## Seed Comparator (`compare_seeds.py`)
+
+Ranks `place_seed.py` seeds by ONE identical full-board probe route each —
+the seed-axis instrument crossings/hpwl cannot be (measured: crossings
+ranked a seed family first that probed 53 full-board failures while a
+crossings-middle seed probed 39).
+
+```bash
+python compare_seeds.py board.kicad_pcb --intent floorplan.json \
+    --seeds 0 1 2 --out-dir seedcmp --ignore-nets GND VCC
+```
+
+Per seed: a `place_seed` run (a seed failing its own intent gate is
+recorded but never ranked), then a probe of `'*'` minus the ignored nets
+with identical route args. Emits a ranked table, `seeds.json`, and a
+`JSON_SUMMARY` with `best_seed`. Exit 0 with a ranked winner, 4 when
+nothing was rankable.
+
+## Plane-Fragility Placement Score (`plane_score.py`)
+
+Pours the named plane nets on a scratch copy of a board (full-outline
+zones, KiCad ZONE_FILLER refill) and reduces the fill to
+`(islands, neck_sum)` — how many pieces the pour lands in, and the #424
+fragility field summed over it. Used by `place_portfolio.py --plane-score`
+to price placements by what they do to the pour; meaningful RELATIVELY,
+candidate vs candidate on the same board, and only where the pour layer
+shares parts with the placement (a bottom pour under an all-top board is
+placement-invariant). Requires KiCad python for the refill; exits 3 when
+unavailable rather than guessing from drawn outlines.
+
+```bash
+python plane_score.py board.kicad_pcb --plane-nets GND 3V3:F.Cu
+```
+
 ## Connectivity Checker (`check_connected.py`)
 
 Verifies that all nets are fully connected after routing. Detects two types of issues:

--- a/kicad_exact_fill.py
+++ b/kicad_exact_fill.py
@@ -57,9 +57,19 @@ _KICAD_PYTHONS = [
 ]
 
 
+def _windows_versioned_pythons():
+    """Standard Windows installs are VERSIONED (C:\\Program Files\\KiCad\\
+    10.0\\bin\\python.exe); the versionless path above matches none of them,
+    which silently disabled every exact-fill consumer on Windows. Newest
+    version first."""
+    import glob
+    return sorted(glob.glob(r"C:\Program Files\KiCad\*\bin\python.exe"),
+                  reverse=True)
+
+
 def find_kicad_python() -> Optional[str]:
     """Path of a python that can import pcbnew, or None."""
-    for cand in _KICAD_PYTHONS:
+    for cand in _KICAD_PYTHONS + _windows_versioned_pythons():
         if cand and os.path.isfile(cand):
             return cand
     return None

--- a/kicad_routing_plugin/gui_utils.py
+++ b/kicad_routing_plugin/gui_utils.py
@@ -116,7 +116,7 @@ def apply_castellated_landing_retract(board, board_edge_clearance):
         return 0
     try:
         import pcbnew
-        from kicad_parser import build_pcb_data_from_board
+        from kicad_parser import build_pcb_data_from_board, mm_to_iu
         from pcb_modification import compute_castellated_landing_retract
         pcb = build_pcb_data_from_board(board)
         delta = compute_castellated_landing_retract(pcb, board_edge_clearance)
@@ -142,7 +142,12 @@ def apply_castellated_landing_retract(board, board_edge_clearance):
             if mv is None:
                 continue
             end, nx, ny = mv
-            pt = pcbnew.VECTOR2I(pcbnew.FromMM(nx), pcbnew.FromMM(ny))
+            # mm_to_iu, never pcbnew.FromMM: FromMM truncates (1 nm low on
+            # ~2% of 4-decimal coordinates), so the GUI would store a
+            # different integer than the CLI's text write of the same
+            # retracted endpoint -- the #493 divergence class this module's
+            # own docstring promises cannot happen.
+            pt = pcbnew.VECTOR2I(mm_to_iu(nx), mm_to_iu(ny))
             if end == 'start':
                 item.SetStart(pt)
             else:

--- a/list_nets.py
+++ b/list_nets.py
@@ -268,6 +268,42 @@ def board_constraint(pcb_path, key, design_rules=None):
         return None
 
 
+def board_floor_knobs(pcb_path, clearance=None, board_edge_clearance=None,
+                      clearance_default=0.25, edge_default=0.55,
+                      design_rules=None):
+    """Resolve grading/legality knobs BOARD-first (run-7 S1/S4).
+
+    An explicit value wins; an unset one resolves from the board's own
+    Default netclass clearance / min_copper_edge_clearance constraint; only
+    a project-less board falls back to the fixed default. Grading a board at
+    a fixed constant tighter than its own floor manufactures phantom
+    violations (S1: check_floorplan oob), and one LOOSER lets real ones
+    pass; the same mistake vetoed legal poses in converge (S4).
+
+    Returns ``(clearance, board_edge_clearance, knobs)`` where ``knobs``
+    records each value's source (``'cli'`` | ``'board netclass'`` |
+    ``'board constraint'`` | ``'fixed default'``) for JSON disclosure.
+    """
+    knobs = {}
+    if clearance is None:
+        v = board_default_netclass_clearance(pcb_path, design_rules)
+        clearance, src = ((v, 'board netclass') if v is not None
+                          else (clearance_default, 'fixed default'))
+    else:
+        src = 'cli'
+    knobs['clearance'] = {'value': clearance, 'source': src}
+    if board_edge_clearance is None:
+        v = board_constraint(pcb_path, 'min_copper_edge_clearance',
+                             design_rules)
+        board_edge_clearance, src = ((v, 'board constraint') if v is not None
+                                     else (edge_default, 'fixed default'))
+    else:
+        src = 'cli'
+    knobs['board_edge_clearance'] = {'value': board_edge_clearance,
+                                     'source': src}
+    return clearance, board_edge_clearance, knobs
+
+
 def net_clearance_map_by_id(pcb_path, nets, design_rules=None):
     """Resolve each net to its net-class clearance (mm) from the sibling
     .kicad_pro netclasses, for the routing CLIs' cross-class clearance map.

--- a/place_portfolio.py
+++ b/place_portfolio.py
@@ -134,6 +134,25 @@ Examples:
                         "only)")
     p.add_argument("--route-args", nargs="+", default=None,
                    help="Extra args for the probe routes (e.g. --clearance)")
+    p.add_argument("--plane-score", nargs="+", default=None,
+                   metavar="NET[:LAYER]",
+                   help="pour these nets on a scratch copy of every viable "
+                        "candidate (KiCad ZONE_FILLER refill, the #424 "
+                        "exact-fill truth) and fold plane fragility into "
+                        "the ranking: island count before hpwl, neck sum "
+                        "after it. A bare NET pours the last copper layer. "
+                        "Needs KiCad python; see plane_score.py")
+    p.add_argument("--plane-score-budget", type=float, default=300.0,
+                   help="total seconds for --plane-score across all "
+                        "candidates; on overrun the plane terms are "
+                        "annotated but EXCLUDED from the ranking "
+                        "(default: 300)")
+    p.add_argument("--full-probe", action="store_true",
+                   help="After the shared-window probe, route the WHOLE "
+                        "board on the baseline + the window winner; that "
+                        "verdict outranks the window one (a candidate can "
+                        "win its window while losing the board). Costs two "
+                        "extra full routes.")
     p.add_argument("--route-timeout", type=float, default=900,
                    help="Seconds per probe route (default: 900)")
     # Presentation & provenance
@@ -362,6 +381,62 @@ def main():
               file=sys.stderr)
         return 3
 
+    # ----- plane-fragility scoring (--plane-score, #118 follow-up) ----------
+    # Pour the declared plane nets on a scratch copy of every board (KiCad
+    # refill, the #424 exact-fill truth) and fold the result into the rank:
+    # island count before hpwl, neck sum after it (see portfolio.rank_key).
+    # All-or-nothing: partial coverage would rank scored candidates against
+    # unscored ones, so on budget overrun / no KiCad python the flat rank
+    # keys are stripped and only the annotation (metrics['plane']) survives.
+    if args.plane_score:
+        import time as _time
+        from plane_score import parse_plane_specs, plane_fragility_score
+        specs = parse_plane_specs(
+            args.plane_score,
+            list(pcb.board_info.copper_layers or ['F.Cu', 'B.Cu']))
+        contenders = [baseline] + [c for c in cands if c.board]
+        t0 = _time.time()
+        incomplete = False
+        for c in contenders:
+            spent = _time.time() - t0
+            if spent > args.plane_score_budget:
+                print(f"[plane] budget {args.plane_score_budget:.0f}s "
+                      f"exhausted before cand {c.index} -- plane terms "
+                      f"EXCLUDED from ranking (partial coverage ranks "
+                      f"unfairly); annotations kept")
+                incomplete = True
+                break
+            sc = plane_fragility_score(c.board, specs,
+                                       grid_step=args.grid_step)
+            if sc is None:
+                print("[plane] refill unavailable (KiCad python not found, "
+                      "or no named net) -- plane scoring skipped")
+                incomplete = True
+                break
+            c.metrics['plane'] = sc
+            c.metrics['plane_islands'] = sc['islands']
+            c.metrics['plane_neck'] = sc['neck_sum']
+            who = 'baseline' if c.index == 0 else f'cand {c.index}'
+            print(f"[plane] {who}: islands={sc['islands']} "
+                  f"neck={sc['neck_sum']}mm-eq")
+        if incomplete:
+            for c in contenders:
+                c.metrics.pop('plane_islands', None)
+                c.metrics.pop('plane_neck', None)
+
+    # Rule 1 of the acceptance conjunction, K-way (run-7 S6): annotate every
+    # candidate whose crossings/hpwl are WORSE than the baseline row.
+    # Annotate, not gate: violators stay ranked and probed, they are only
+    # barred from the silent JSON_SUMMARY['best'] pick below.
+    rule1_violators = set()
+    for c in cands:
+        if not c.board:
+            continue
+        r1 = portfolio.rule1_check(c, baseline)
+        c.gates['rule1'] = r1
+        if r1:
+            rule1_violators.add(c.index)
+
     ranking_static = portfolio.rank_static(cands)
     kept, backfilled = portfolio.select_diverse(
         cands, ranking_static, args.keep, args.diversity_mm, free, baseline)
@@ -376,6 +451,8 @@ def main():
               f"hpwl={c.metrics.get('hpwl')} "
               f"inv={c.metrics.get('inversions')} "
               f"disp={c.displacement_rms:.2f}mm"
+              + (f"  RULE1: {'; '.join(c.gates['rule1'])}"
+                 if c.gates.get('rule1') else '')
               + (f"  ({'; '.join(c.gates.get('reasons', []))})"
                  if not c.viable and c.gates.get('reasons') else ''))
     if backfilled:
@@ -386,6 +463,7 @@ def main():
 
     # ----- probe tier -------------------------------------------------------
     ranking_routed = []
+    window_kind = 'window'
     if args.route_top > 0 and kept:
         from place_route_loop import _ratsnest_screen
         ids = portfolio.ignore_net_ids(pcb, args.ignore_nets)
@@ -395,6 +473,7 @@ def main():
                        if nid > 0 and nid not in ids and len(net.pads) >= 2)
         if routable and len(nets) > 0.5 * routable:
             nets = ['*'] + [f'!{p}' for p in (args.ignore_nets or [])]
+            window_kind = 'full'
             print(f"[probe] affected set exceeds half the board -- "
                   f"full probe routes")
         elif not nets:
@@ -403,6 +482,7 @@ def main():
             print(f"[probe] routing {len(nets)} net pattern(s) on baseline + "
                   f"top {len(probe_cands)}")
             baseline.route = _probe(baseline.board, nets, args)
+            baseline.route['probe_kind'] = window_kind
             base_rat = {'crossings': baseline.metrics.get('crossings'),
                         'hpwl': baseline.metrics.get('hpwl')}
             for c in probe_cands:
@@ -415,6 +495,7 @@ def main():
                     print(f"[probe] cand {c.index}: skipped ({note})")
                     continue
                 c.route = _probe(c.board, nets, args)
+                c.route['probe_kind'] = window_kind
                 print(f"[probe] cand {c.index}: failures="
                       f"{c.route['failures']} ({c.route['note']})")
             probed = [c for c in [baseline] + probe_cands
@@ -425,6 +506,36 @@ def main():
                                        c.route.get('iterations') or 0,
                                        static_pos.get(c.index, 1 << 30)))
             ranking_routed = [c.index for c in probed]
+
+    # ----- full-board probe (--full-probe, run-7 S2/S7) ---------------------
+    # The window probe compares like with like on the AFFECTED set, but a
+    # candidate can win its window while losing the board (the run-7 adoption
+    # question was answered by exactly this escalation, hand-rolled). Route
+    # the whole board on the baseline + the window winner; this verdict
+    # OUTRANKS the window one.
+    ranking_full = []
+    if args.full_probe and ranking_routed and window_kind != 'full':
+        full_nets = ['*'] + [f'!{p}' for p in (args.ignore_nets or [])]
+        top_cand = next((by_index[i] for i in ranking_routed if i != 0), None)
+        contenders = [baseline] + ([top_cand] if top_cand is not None else [])
+        print(f"[probe] FULL-BOARD probe (--full-probe): baseline"
+              + (f" + cand {top_cand.index}" if top_cand is not None else ""))
+        for c in contenders:
+            c.route_full = _probe(c.board, full_nets, args)
+            c.route_full['probe_kind'] = 'full'
+            who = 'baseline' if c.index == 0 else f'cand {c.index}'
+            print(f"[probe/full] {who}: failures={c.route_full['failures']} "
+                  f"({c.route_full['note']})")
+        probed_f = [c for c in contenders
+                    if c.route_full and c.route_full.get('failures') is not None]
+        probed_f.sort(key=lambda c: (c.route_full['failures'],
+                                     c.route_full.get('iterations') or 0,
+                                     c.index))
+        ranking_full = [c.index for c in probed_f]
+    elif args.full_probe and window_kind == 'full':
+        # The window probe already routed the whole board; its ranking IS the
+        # full verdict.
+        ranking_full = list(ranking_routed)
 
     # ----- renders ----------------------------------------------------------
     renders = {}
@@ -484,6 +595,8 @@ def main():
            'candidates': [c.to_dict() for c in cands],
            'ranking_static': ranking_static,
            'ranking_routed': ranking_routed,
+           'ranking_full': ranking_full,
+           'rule1_violators': sorted(rule1_violators),
            'kept': kept, 'backfilled': backfilled,
            'renders': {str(k): v for k, v in renders.items()}}
     doc_path = os.path.join(args.out_dir, 'portfolio.json')
@@ -491,12 +604,25 @@ def main():
         json.dump(doc, f, indent=1, sort_keys=True)
     print(f"Wrote {doc_path}")
 
-    best = (ranking_routed[0] if ranking_routed
-            else (ranking_static[0] if ranking_static else None))
+    # Headline pick: probe ranking (full-board when --full-probe ran) over
+    # static, first index that passes rule 1. Every ranked candidate
+    # violating rule 1 -> fall back to the BASELINE, never to a violator
+    # (run-7 S6: a worse-on-both-proxies candidate topped the slate).
+    ranking_primary = ranking_full or ranking_routed
+    best = portfolio.select_best(ranking_primary, ranking_static,
+                                 rule1_violators)
+    if best is None and (ranking_primary or ranking_static):
+        best = 0
+        print("NOTE: every ranked candidate violates rule 1 (metrics worse "
+              "than the baseline) -- best falls back to the baseline; read "
+              "portfolio.json before adopting a violator deliberately")
     best_c = by_index.get(best, baseline) if best is not None else None
     print("JSON_SUMMARY: " + json.dumps({
         'candidates': len(cands) + 1, 'viable': len(viable),
         'kept': len(kept), 'best': best,
+        'probe_kind': ('full' if ranking_full
+                       else (window_kind if ranking_routed else None)),
+        'rule1_excluded': sorted(rule1_violators),
         'best_crossings': (best_c.metrics.get('crossings')
                            if best_c else None),
         'baseline_crossings': baseline.metrics.get('crossings'),

--- a/place_portfolio.py
+++ b/place_portfolio.py
@@ -265,6 +265,18 @@ def _montage(path, rows, out_dir):
 def main():
     parser = build_parser()
     args = parser.parse_args()
+    # The probe/render subprocesses run with cwd=ROOT (the repo), so a path
+    # relative to the CALLER's cwd silently breaks every one of them
+    # (measured: 3/3 probe routes rc=1 "no summary", 6/6 renders rc=1, on a
+    # portfolio invoked from a board repo). Absolutize at the door.
+    args.input_file = os.path.abspath(args.input_file)
+    args.out_dir = os.path.abspath(args.out_dir)
+    if args.montage:
+        args.montage = os.path.abspath(args.montage)
+    if args.ledger:
+        args.ledger = os.path.abspath(args.ledger)
+    if args.intent:
+        args.intent = os.path.abspath(args.intent)
     if args.only is not None and args.only < 1:
         parser.error("--only takes a candidate index >= 1 (0 is the baseline "
                      "quench, which needs no stream to reproduce)")

--- a/place_route_loop.py
+++ b/place_route_loop.py
@@ -182,7 +182,14 @@ def metrics_from_summary(summary: dict, log: str = '',
                     for d in summary.get('failed_multipoint', [])]
     mp_deficit = (summary.get('multipoint_pads_total', 0)
                   - summary.get('multipoint_pads_connected', 0))
-    failures = len(summary.get('failed_single', [])) + mp_deficit
+    # open_single: kept-result nets with disconnected pads. Their names are
+    # already in failed_nets via failed_multipoint; the COUNT needs its own
+    # term because a non-multipoint open net contributes nothing to either
+    # failed_single or the pad deficit (the emitter excludes multipoint nets
+    # from the key, so this cannot double-count against mp_deficit).
+    failures = (len(summary.get('failed_single', []))
+                + len(summary.get('open_single', []))
+                + mp_deficit)
 
     # Blocker nets from frontier diagnostics. Prefer the structured
     # JSON_SUMMARY 'blockers' key (#409): the last-wins attribution of nets

--- a/place_seed.py
+++ b/place_seed.py
@@ -102,19 +102,33 @@ Examples:
               f"{st.vias} via(s); seeding moves footprints and would strand "
               f"every track. Seed the unrouted board.", file=sys.stderr)
         return UNPLACED_EXIT
-    if not st.unplaced and not args.force:
+    if not st.unplaced and not st.partially_unplaced and not args.force:
+        # PARTIALLY unplaced boards (a stacked pile beside real placements --
+        # a netlist re-import, or a seeder that pinned only the spec-fixed
+        # parts) are a legitimate seeding target, not a refusal: locked parts
+        # are treated as authoritative and the pile is what gets placed.
         print("place_seed: this board already looks PLACED. Seeding would "
               "discard that placement; use place_portfolio.py to explore "
               "variations of it, or --force to re-seed anyway.",
               file=sys.stderr)
         return UNPLACED_EXIT
 
+    # Partially unplaced without --force: seed ONLY the stacked pile. The
+    # genuinely-placed unlocked parts are someone's work, not this tool's to
+    # re-derive; --force widens the scope back to everything unlocked.
+    seed_refs = None
+    if st.partially_unplaced and not st.unplaced and not args.force:
+        seed_refs = set(st.stacked_refs)
+        print(f"place_seed: partially unplaced -- seeding only the "
+              f"{len(seed_refs)} stacked part(s); the rest stand as placed "
+              f"(--force re-seeds everything unlocked)")
+
     rng = random.Random(f"{args.seed}")
     result = seeder.seed_from_intent(
         pcb, args.input_file, intent, rng, group_sources=sources,
         clearance=args.clearance,
         board_edge_clearance=args.board_edge_clearance,
-        grid_step=args.grid_step)
+        grid_step=args.grid_step, seed_refs=seed_refs)
     for note in result['notes']:
         print(f"  NOTE: {note}")
     print(f"Seeded {len(result['placements'])} part(s); "
@@ -151,12 +165,63 @@ Examples:
             os.replace(tmp, args.output_file)
 
     # ---- self-check: the seed must grade clean against its own intent ------
-    pcb_out = parse_kicad_pcb(args.output_file)
+    def _grade():
+        pcb_out = parse_kicad_pcb(args.output_file)
+        return floorplan.grade(intent, pcb_out, args.output_file,
+                               group_sources=sources,
+                               clearance=args.clearance,
+                               board_edge_clearance=args.board_edge_clearance)
+
     try:
-        graded = floorplan.grade(intent, pcb_out, args.output_file,
-                                 group_sources=sources,
-                                 clearance=args.clearance,
-                                 board_edge_clearance=args.board_edge_clearance)
+        graded = _grade()
+        # The quench has no zone term, so a polish nudge can walk a declared
+        # zone member past its tolerance (measured: a crystal load cap,
+        # 0.86mm past its zone's edge at one seed). A plain revert to the
+        # seeded pose is not enough -- the polish moved NEIGHBORS into that
+        # space too (measured: 0.784mm2 of new overlap) -- so the part is
+        # RE-SEATED: the seeder's own search, targeted at its seeded pose,
+        # constrained to its zone, against the post-polish board.
+        if not args.no_polish:
+            broke = sorted({v.ref for v in graded.errors
+                            if v.rule == 'zone_containment' and v.ref})
+            if broke:
+                import pose_score
+                pcb_cur = parse_kicad_pcb(args.output_file)
+                st = pose_score.make_state(
+                    pcb_cur, args.output_file, clearance=args.clearance,
+                    board_edge_clearance=args.board_edge_clearance,
+                    grid_step=args.grid_step)
+                blocks2, _p = floorplan.resolve_blocks(intent, pcb_cur,
+                                                       sources)
+                zone_of = {}
+                for z in intent.blocks:
+                    if z.rect is None:
+                        continue
+                    for r in blocks2.get(z.name, ()):
+                        zone_of.setdefault(r, z)
+                seeded_pose = {p['reference']: p for p in result['placements']}
+                fixes = []
+                for ref in broke:
+                    z = zone_of.get(ref)
+                    sp = seeded_pose.get(ref)
+                    if z is None or sp is None or ref not in st.parts:
+                        continue
+                    clr = seeder._try_place(
+                        st, ref, sp['new_x'], sp['new_y'], set(),
+                        constraint=z.rect, tol=intent.zone_tolerance(z))
+                    if clr is not None:
+                        p2 = st.parts[ref]
+                        fixes.append({'reference': ref, 'new_x': p2.x,
+                                      'new_y': p2.y, 'new_rotation': p2.rot})
+                if fixes:
+                    print(f"  polish walked "
+                          f"{', '.join(f['reference'] for f in fixes)} out "
+                          f"of a declared zone; re-seated in-zone against "
+                          f"the polished board")
+                    tmp = args.output_file + '.reseat'
+                    write_placed_output(args.output_file, tmp, fixes)
+                    os.replace(tmp, args.output_file)
+                    graded = _grade()
     except floorplan.UntrustworthyOutline as exc:
         print(f"place_seed: outline cannot be trusted for grading: {exc}",
               file=sys.stderr)

--- a/placement/portfolio.py
+++ b/placement/portfolio.py
@@ -69,6 +69,7 @@ class Candidate:
     intent: Optional[Dict] = None
     health: Optional[Dict] = None
     route: Optional[Dict] = None
+    route_full: Optional[Dict] = None   # --full-probe verdict (whole board)
     note: str = ''
 
     @property
@@ -91,6 +92,8 @@ class Candidate:
             d['health'] = self.health
         if self.route is not None:
             d['route'] = self.route
+        if self.route_full is not None:
+            d['route_full'] = self.route_full
         return d
 
 
@@ -574,7 +577,15 @@ def rank_key(cand: Candidate) -> Tuple:
       inversions     the forced-crossing floor -- equal-crossings ties break
                      toward the more REMOVABLE set (pair_order is a lower
                      bound a router cannot beat)
+      plane_islands  --plane-score only (0 otherwise): how many pieces the
+                     poured plane lands in. Before hpwl deliberately -- a
+                     split pour is a MEASURED plane-step loss the repair
+                     step must stitch, and hpwl is a proxy (#118: "routing
+                     is as much about planes as traces")
       hpwl           order-invariant geometry
+      plane_neck     --plane-score only: the #424 fragility field summed
+                     over the fill (mm-equivalents, whole-mm rounded) --
+                     a neck tiebreak below hpwl
       health         advisory floorplan-fight signals (0 without an intent)
       displacement   least disturbance wins what is left
       index          stability
@@ -582,7 +593,9 @@ def rank_key(cand: Candidate) -> Tuple:
     m = cand.metrics
     return (m.get('crossings', 1 << 30),
             m.get('inversions', 1 << 30),
+            m.get('plane_islands', 0),
             round(m.get('hpwl', float('inf')), 3),
+            round(m.get('plane_neck', 0.0)),
             m.get('health_penalty', 0),
             round(cand.displacement_rms, 2),
             cand.index)
@@ -592,6 +605,50 @@ def rank_static(cands: Sequence[Candidate]) -> List[int]:
     """Indices of the gate-passing candidates, best first."""
     return [c.index for c in sorted((c for c in cands if c.viable),
                                     key=rank_key)]
+
+
+def rule1_check(cand: Candidate, baseline: Candidate) -> List[str]:
+    """Rule 1 of the Step-0c acceptance conjunction, applied K-way (run-7
+    S6): crossings and hpwl must be NO WORSE than the baseline row.
+
+    The hard gates in score_candidate are legality + intent (rule 2). This
+    metric clause was DOCUMENTED as pre-applied but never was, so a
+    candidate measuring worse on both proxies could top the slate and ship
+    through JSON_SUMMARY['best'] unremarked. Pure: returns the violation
+    strings; empty means it passes. Violators are still ranked, probed and
+    recorded -- they are only barred from being the silent headline pick
+    (select_best); a probe verdict that argues for one anyway is a decision
+    the operator makes deliberately, reading portfolio.json.
+    """
+    out: List[str] = []
+    bm, cm = baseline.metrics, cand.metrics
+    bx, cx = bm.get('crossings'), cm.get('crossings')
+    if bx is not None and cx is not None and cx > bx:
+        out.append(f'crossings {cx} > baseline {bx}')
+    bh, ch = bm.get('hpwl'), cm.get('hpwl')
+    if bh is not None and ch is not None and ch > bh + EPS:
+        out.append(f'hpwl {ch:.1f} > baseline {bh:.1f}')
+    return out
+
+
+def select_best(ranking_primary: Sequence[int], ranking_static: Sequence[int],
+                rule1_violators: Set[int]) -> Optional[int]:
+    """The slate's headline pick: the first ranked index that passes rule 1.
+
+    `ranking_primary` (a probe ranking -- full-board when --full-probe ran,
+    else the shared-window one) outranks the static ranking. The baseline
+    (index 0) trivially passes rule 1 against itself, so "keep what you
+    have" stays a first-class outcome. Returns None when nothing ranked
+    passes -- the caller falls back to the baseline, never to a violator.
+    """
+    seen = set()
+    for idx in list(ranking_primary) + list(ranking_static):
+        if idx in seen:
+            continue
+        seen.add(idx)
+        if idx == 0 or idx not in rule1_violators:
+            return idx
+    return None
 
 
 def select_diverse(cands: Sequence[Candidate], order: Sequence[int],

--- a/placement/seeder.py
+++ b/placement/seeder.py
@@ -193,11 +193,17 @@ def _edge_correct(state, ref: str, edge: str, x: float, y: float,
 
 def _partner_centroid(state, ref: str, placed: Set[str],
                       max_fanout: int = 20) -> Optional[Tuple[float, float]]:
-    """Centroid of already-placed partners' pads on shared nets. Nets owned by
-    more than `max_fanout` parts are excluded for the routability.py reason:
-    they reach everywhere by design and would collapse every centroid onto the
-    board middle. Plane nets are NOT otherwise excluded here -- for a decap,
-    the rail net is exactly what tethers it to its IC."""
+    """Centroid of already-placed partners on shared nets: ONE vote per
+    (partner footprint, net), each vote the mean of that partner's matching
+    pads. Voting per PAD (the pre-run-7 behavior) let a partner with
+    duplicated pins outvote one with a single pin -- a USB-C receptacle's
+    doubled A6/B6 DP pads pulled the 27R series pair 2:1 toward the
+    connector, seating R7 15.3mm from the U1 face the intent named. Nets
+    owned by more than `max_fanout` parts are excluded for the
+    routability.py reason: they reach everywhere by design and would
+    collapse every centroid onto the board middle. Plane nets are NOT
+    otherwise excluded here -- for a decap, the rail net is exactly what
+    tethers it to its IC."""
     part = state.parts.get(ref)
     if part is None:
         return None
@@ -210,10 +216,13 @@ def _partner_centroid(state, ref: str, placed: Set[str],
         for other in owners:
             if other == ref or other not in placed:
                 continue
-            for gx, gy, pn in state.parts[other].pad_globals():
-                if pn == nid:
-                    xs.append(gx)
-                    ys.append(gy)
+            pxs = [gx for gx, gy, pn in state.parts[other].pad_globals()
+                   if pn == nid]
+            pys = [gy for gx, gy, pn in state.parts[other].pad_globals()
+                   if pn == nid]
+            if pxs:
+                xs.append(sum(pxs) / len(pxs))
+                ys.append(sum(pys) / len(pys))
     if not xs:
         return None
     return sum(xs) / len(xs), sum(ys) / len(ys)

--- a/placement/seeder.py
+++ b/placement/seeder.py
@@ -223,13 +223,19 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
                      group_sources: Sequence[str] = (),
                      clearance: float = 0.25,
                      board_edge_clearance: float = 0.55,
-                     grid_step: float = 0.1) -> Dict:
+                     grid_step: float = 0.1,
+                     seed_refs: Optional[Set[str]] = None) -> Dict:
     """Compute a full placement for an unplaced board from its intent.
 
     Returns {'placements': [...], 'lock_refs': [...], 'unseated': [...],
     'notes': [...]}. `placements` covers every ref that was placed (writer
     format); `unseated` names parts NO legal pose was found for -- the caller
     reports them and the grade fails, deliberately.
+
+    `seed_refs`, when given, scopes the seeding to exactly those refs: every
+    other part is treated as authoritatively placed where it stands (the
+    PARTIALLY-unplaced case -- a stacked pile beside a real placement, where
+    re-deriving the placed parts would discard someone's work).
     """
     import pose_score
     from placement import floorplan
@@ -257,9 +263,11 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
     # that pre-placed its spec-fixed parts and stamped them (locked yes) must
     # not have the seeder re-derive them. Treated as placed from the start:
     # they anchor the connectivity centroids and obstruct packing, and every
-    # later stage (edge connectors included) skips them.
+    # later stage (edge connectors included) skips them. The same applies to
+    # every ref outside an explicit `seed_refs` scope.
     for ref in sorted(state.parts):
-        if state.parts[ref].locked:
+        if state.parts[ref].locked or (seed_refs is not None
+                                       and ref not in seed_refs):
             placed.add(ref)
             unplaced.discard(ref)
     # Deterministic tie-break values, drawn once in sorted order so the
@@ -297,6 +305,19 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
             placed.add(ref)
             unplaced.discard(ref)
 
+    # Decap-governed caps are claimed by stage 2.5, never zone-packed: a
+    # zone is a REGION and the decap rule is a distance to a specific pin --
+    # a cap packed anywhere in a 15x9 zone routinely lands >3mm from the pin
+    # it exists to serve (measured: the flash decap, zone-packed, graded
+    # 3.5mm from the flash's VCC pin).
+    decap_spec = getattr(intent, 'decaps', None) or {}
+    decap_scope: Set[str] = set()
+    if decap_spec.get('max_distance_mm') is not None:
+        exempt = tuple(decap_spec.get('exempt') or ())
+        decap_scope = {r for r in state.parts
+                       if r[0] == 'C' and state.parts[r].pin_count == 2
+                       and not any(fnmatch.fnmatch(r, pat) for pat in exempt)}
+
     # ---- 2. zoned blocks: radial pack from the zone center -----------------
     # A single-member zone is the spec-coordinate pattern (a rect a few
     # hundred microns wide around where the spec pins the part), so it gets
@@ -304,7 +325,8 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
     # seeds pack differently.
     for name in sorted(zones_by_name):
         z = zones_by_name[name]
-        members = _order(blocks.get(name, ()))
+        members = [r for r in _order(blocks.get(name, ()))
+                   if r not in decap_scope]
         if not members:
             continue
         cx = (z.rect[0] + z.rect[2]) / 2.0
@@ -329,6 +351,115 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
             else:
                 unseated.append(ref)
                 notes.append(f"{ref}: no legal pose inside zone {name!r}")
+
+    # ---- 2.5 decap-governed caps: one cap per supply PIN -------------------
+    # A 100nF's two nets are a rail and GND -- both usually above the fanout
+    # cap -- so the generic centroid stage would park every decap mid-board
+    # and a pin-exact decap gate (3mm pad-edge per SUPPLY PIN) would fail.
+    # The iteration is PIN-FIRST, not cap-first: a cap-first greedy spends
+    # every cap on the biggest IC's pads and starves the flash (measured --
+    # all ten caps claimed U1 pads, U3.8 graded 3.5mm). Pins are the rail
+    # pads of PLACED ICs (U-prefix: a castellated row carries the rail too
+    # and must not eat a claim), pair-collapsed (adjacent same-rail pins
+    # under 1mm share one cap by design), biggest owner first; each pin
+    # takes a matching-rail cap, preferring one whose declared zone CONTAINS
+    # the pin so a zone-member cap serves its own block.
+    if decap_scope:
+        avail = [r for r in _order(sorted(unplaced)) if r in decap_scope]
+        rail_of: Dict[str, int] = {}
+        for ref in avail:
+            rail = min((nid for nid in state.parts[ref].nets
+                        if len(state.net_refs.get(nid, ())) >= 2),
+                       key=lambda nid: (len(state.net_refs[nid]), nid),
+                       default=None)
+            if rail is not None:
+                rail_of[ref] = rail
+        rails = set(rail_of.values())
+        pins: List[Tuple[int, str, float, float, int]] = []
+        for owner in sorted(placed):
+            if owner[0] != 'U':
+                continue
+            o = state.parts[owner]
+            for gx, gy, pn in o.pad_globals():
+                if pn in rails:
+                    pins.append((-o.pin_count, owner, round(gx, 3),
+                                 round(gy, 3), pn))
+        pins.sort()
+        zone_of_cap = {}
+        for name in sorted(zones_by_name):
+            for r in blocks.get(name, ()):
+                if r in decap_scope and r not in zone_of_cap:
+                    zone_of_cap[r] = zones_by_name[name]
+
+        def _seat(ref, tx, ty, owner, pn, constraint=None, tol=0.5):
+            clr = _try_place(state, ref, tx, ty, unplaced - {ref},
+                             constraint=constraint, tol=tol)
+            if clr is None and constraint is not None:
+                clr = _try_place(state, ref, tx, ty, unplaced - {ref})
+            if clr is None:
+                return False
+            avail.remove(ref)
+            placed.add(ref)
+            unplaced.discard(ref)
+            p2 = state.parts[ref]
+            net = getattr(pcb_data.nets.get(pn), 'name', pn)
+            notes.append(f"{ref}: decap for {owner} pad(s) near ({tx}, {ty})"
+                         f" [{net}], landed "
+                         f"{math.hypot(p2.x - tx, p2.y - ty):.2f}mm"
+                         + (f" at reduced clearance {clr:g}"
+                            if clr < state.clearance else ""))
+            return True
+
+        # Pass 1: a cap declared in a zone serves a pin INSIDE that zone --
+        # the flash's own decap covers the flash, whatever the owner-size
+        # ordering says.
+        remaining = []
+        for key in pins:
+            _, owner, x, y, pn = key
+            hit = next((r for r in avail if rail_of.get(r) == pn
+                        and zone_of_cap.get(r) is not None
+                        and zone_of_cap[r].rect[0] <= x <= zone_of_cap[r].rect[2]
+                        and zone_of_cap[r].rect[1] <= y <= zone_of_cap[r].rect[3]),
+                       None)
+            if hit is not None and _seat(
+                    hit, x, y, owner, pn,
+                    constraint=zone_of_cap[hit].rect,
+                    tol=intent.zone_tolerance(zone_of_cap[hit])):
+                continue
+            remaining.append(key)
+
+        # Pass 2, per rail: CLUSTER the remaining pins until they fit the
+        # remaining caps, then seat one cap per cluster centroid. Twelve
+        # graded pins over ten caps is the DESIGNED shape -- adjacent supply
+        # pins share a cap -- so the collapse radius grows (1.0 -> 3.0mm)
+        # until every pin belongs to a served cluster; a fixed radius either
+        # starves the last pin or wastes two caps on one pair (both
+        # measured).
+        for rail in sorted(rails):
+            pins_r = [k for k in remaining if k[4] == rail]
+            caps_r = [r for r in avail if rail_of.get(r) == rail]
+            if not pins_r or not caps_r:
+                continue
+            radius = 1.0
+            while True:
+                clusters: List[List[Tuple]] = []
+                for key in pins_r:
+                    _, owner, x, y, pn = key
+                    home = next((c for c in clusters
+                                 if c[0][1] == owner
+                                 and math.hypot(x - c[0][2], y - c[0][3])
+                                 <= radius), None)
+                    (home.append(key) if home is not None
+                     else clusters.append([key]))
+                if len(clusters) <= len(caps_r) or radius >= 3.0:
+                    break
+                radius += 0.5
+            for cluster, ref in zip(clusters, list(caps_r)):
+                cx2 = round(sum(k[2] for k in cluster) / len(cluster), 3)
+                cy2 = round(sum(k[3] for k in cluster) / len(cluster), 3)
+                _seat(ref, cx2, cy2, cluster[0][1], rail)
+            # pins beyond the cap supply, and caps no pin wanted, fall
+            # through to the generic stage, which reports honestly
 
     # ---- 3. the rest: connectivity centroid --------------------------------
     center = ((bounds[0] + bounds[2]) / 2.0, (bounds[1] + bounds[3]) / 2.0)

--- a/plane_score.py
+++ b/plane_score.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Plane-fragility as a PLACEMENT score (#118 follow-up, run-7 wave).
+
+The placement stack judges candidates by crossings/hpwl/inversions -- all
+signal-net proxies. "Routing is as much about planes as traces" (#118): a
+placement that fragments the ground pour or squeezes it through necks loses
+at the PLANE step, and nothing in the candidate score sees it coming, while
+the router-side #424 machinery already prices exact fill damage.
+
+This module closes that half: pour the declared plane nets on a SCRATCH copy
+of a candidate board (full-outline zones, KiCad ZONE_FILLER refill via
+kicad_exact_fill -- the same truth #424 consumes), then run the #424
+fragility field over the fill and reduce it to two placement-comparable
+numbers:
+
+    islands    how many pieces the pour lands in (fragmentation -- a
+               categorical loss; the repair step will have to stitch)
+    neck_sum   the fragility field summed over the fill, in mm-equivalents
+               (necks are wall-to-wall high-cost cells; wide pour is ~free)
+
+Both are meaningful RELATIVELY, candidate vs candidate on the same board --
+absolute values scale with outline/boundary length. Returns None when no
+KiCad python exists for the refill (the score is then honestly unavailable,
+never guessed from drawn outlines).
+"""
+from __future__ import annotations
+
+import math
+import os
+import shutil
+import tempfile
+from types import SimpleNamespace
+from typing import Dict, List, Optional, Sequence, Tuple
+
+REFERENCE_GRID_STEP = 0.1
+
+
+def parse_plane_specs(tokens: Sequence[str], copper_layers: Sequence[str]):
+    """['GND', '3V3:F.Cu'] -> [(net, layer)]; a bare net pours the LAST
+    copper layer (the classic bottom ground pour)."""
+    out = []
+    for tok in tokens:
+        if ':' in tok:
+            net, layer = tok.split(':', 1)
+        else:
+            net, layer = tok, copper_layers[-1]
+        out.append((net, layer))
+    return out
+
+
+def plane_fragility_score(board: str, specs: Sequence[Tuple[str, str]],
+                          grid_step: float = 0.1,
+                          keep_staged: Optional[str] = None) -> Optional[Dict]:
+    """Score one board. `specs` is [(net_name, layer), ...].
+
+    Returns {'islands', 'neck_sum', 'cells', 'per_net'} or None when the
+    KiCad refill is unavailable (no pcbnew python on this machine).
+    """
+    from kicad_parser import board_uses_name_nets, parse_kicad_pcb
+    from kicad_writer import generate_zone_sexpr
+    from kicad_exact_fill import refill_islands
+
+    pcb = parse_kicad_pcb(board)
+    bounds = pcb.board_info.board_bounds
+    if bounds is None:
+        return None
+    copper = list(pcb.board_info.copper_layers or ['F.Cu', 'B.Cu'])
+    name_to_id = {n.name: nid for nid, n in pcb.nets.items()}
+    with open(board, encoding='utf-8', errors='replace') as f:
+        content = f.read()
+    use_names = board_uses_name_nets(content)
+
+    x0, y0, x1, y1 = bounds
+    outline = [(x0, y0), (x1, y0), (x1, y1), (x0, y1)]
+    blocks = []
+    for i, (net, layer) in enumerate(specs):
+        nid = name_to_id.get(net)
+        if nid is None:
+            continue
+        blocks.append(generate_zone_sexpr(
+            nid, net, layer, outline, use_net_name=use_names,
+            # distinct priorities: overlapping same-priority zones tie-break
+            # on UUID and the fill varies run to run (kicad_writer note)
+            priority=i))
+    if not blocks:
+        return None
+
+    tmp = tempfile.mkdtemp(prefix='plane_score_')
+    try:
+        staged = os.path.join(tmp, os.path.basename(board))
+        idx = content.rindex(')')
+        with open(staged, 'w', encoding='utf-8') as f:
+            f.write(content[:idx] + '\n'.join(blocks) + '\n' + content[idx:])
+        for ext in ('.kicad_pro', '.kicad_dru'):
+            sib = os.path.splitext(board)[0] + ext
+            if os.path.isfile(sib):
+                shutil.copyfile(sib, os.path.splitext(staged)[0] + ext)
+        if keep_staged:
+            shutil.copyfile(staged, keep_staged)
+
+        fills = refill_islands(staged)
+        if fills is None:
+            return None
+
+        wanted = {(net, layer) for net, layer in specs}
+        per_net = {}
+        for (net, layer), polys in fills.items():
+            if (net, layer) in wanted:
+                per_net[f'{net}:{layer}'] = len(polys)
+        islands = sum(per_net.values())
+
+        # The #424 field over the poured board. The staged pcb_data gets the
+        # ALREADY-COMPUTED fill as its provider so the field prices the exact
+        # fill without a second refill subprocess.
+        from plane_fragility import compute_plane_fragility_cells
+        pcb2 = parse_kicad_pcb(staged)
+        pcb2.exact_fill_provider = lambda: fills
+        config = SimpleNamespace(
+            grid_step=grid_step, layers=copper,
+            cell_cost=lambda mm: int(mm * 1000 / REFERENCE_GRID_STEP))
+        cells = compute_plane_fragility_cells(pcb2, config)
+        # cost units -> mm-equivalents (cell_cost inverse), summed
+        neck_sum = float(cells[:, 3].sum()) * REFERENCE_GRID_STEP / 1000.0 \
+            if len(cells) else 0.0
+        return {'islands': islands,
+                'neck_sum': round(neck_sum, 3),
+                'cells': int(len(cells)),
+                'per_net': per_net}
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def main(argv=None):
+    import argparse
+    import json as _json
+    p = argparse.ArgumentParser(
+        description="Plane-fragility placement score: pour the named nets "
+                    "on a scratch copy and price the fill's necks/islands.")
+    p.add_argument('board')
+    p.add_argument('--plane-nets', nargs='+', required=True,
+                   metavar='NET[:LAYER]',
+                   help='nets to pour (bare NET pours the last copper layer)')
+    p.add_argument('--grid-step', type=float, default=0.1)
+    p.add_argument('--keep-staged', default=None)
+    args = p.parse_args(argv)
+    from kicad_parser import parse_kicad_pcb
+    pcb = parse_kicad_pcb(args.board)
+    specs = parse_plane_specs(args.plane_nets,
+                              list(pcb.board_info.copper_layers
+                                   or ['F.Cu', 'B.Cu']))
+    score = plane_fragility_score(args.board, specs,
+                                  grid_step=args.grid_step,
+                                  keep_staged=args.keep_staged)
+    if score is None:
+        print("plane_score: unavailable (no KiCad python for the refill, "
+              "no outline, or no named net exists)")
+        return 3
+    print("JSON_SUMMARY: " + _json.dumps(score, sort_keys=True))
+    return 0
+
+
+if __name__ == '__main__':
+    import sys
+    sys.exit(main())

--- a/pose_score.py
+++ b/pose_score.py
@@ -79,7 +79,8 @@ def make_state(pcb_data, board_path: str, *, clearance: float = 0.25,
 def rank_poses(pcb_data, board_path: str, ref: str, *, radius: float = 2.0,
                step: float = 0.5, rotations: Sequence[float] = ROTATIONS,
                limit: int = 12, allow_rotations: bool = True,
-               state=None, **state_kw) -> List[Dict]:
+               state=None, diagnostics: Optional[Dict] = None,
+               **state_kw) -> List[Dict]:
     """Legal poses for `ref`, cheapest first.
 
     Returns `[{x, y, rot, cost, delta, dist_mm, legal}]`, sorted by cost. `delta`
@@ -88,7 +89,12 @@ def rank_poses(pcb_data, board_path: str, ref: str, *, radius: float = 2.0,
     answer and one a caller should be able to get without paying for a route.
 
     Illegal poses are dropped, not scored: an illegal pose has no meaningful
-    cost, and returning one ranked would invite a caller to try it.
+    cost, and returning one ranked would invite a caller to try it. They are
+    no longer dropped SILENTLY, though (run-7 S4): pass `diagnostics={}` and
+    it comes back with `dropped_total` and `dropped_in_place` -- the rotations
+    at the part's OWN (x, y) that candidate_valid vetoed. An empty ranked list
+    whose dropped_in_place includes the part's current rotation says "the
+    knobs veto even staying put", which is a knob problem, not a pose answer.
     """
     st = state if state is not None else make_state(pcb_data, board_path, **state_kw)
     part = st.parts.get(ref) if hasattr(st, 'parts') else None
@@ -112,10 +118,15 @@ def rank_poses(pcb_data, board_path: str, ref: str, *, radius: float = 2.0,
     base_inv = ref_inversions(st, ref)
 
     scored = []
+    dropped_total = 0
+    dropped_in_place = []
     for dx, dy in _offsets(radius, step):
         for rot in rots:
             x, y = x0 + dx, y0 + dy
             if not st.candidate_valid(ref, x, y, rot):
+                dropped_total += 1
+                if dx == 0.0 and dy == 0.0:
+                    dropped_in_place.append(rot)
                 continue
             st.apply_move(ref, x, y, rot)
             cost = st.total_cost()
@@ -135,6 +146,9 @@ def rank_poses(pcb_data, board_path: str, ref: str, *, radius: float = 2.0,
                      for k, v in cost.items() if k != 'total'},
                     inversions=inv - base_inv),
             })
+    if diagnostics is not None:
+        diagnostics['dropped_total'] = dropped_total
+        diagnostics['dropped_in_place'] = dropped_in_place
     # cost, then least disturbance, then a stable rotation order
     scored.sort(key=lambda p: (p['cost'], p['dist_mm'], p['rot']))
     return scored[:limit]

--- a/reroute_loop.py
+++ b/reroute_loop.py
@@ -557,7 +557,7 @@ def run_reroute_loop(
                         pcb_data, config, ripped_net_id,
                         working_obstacles=state.working_obstacles,
                         net_obstacles_cache=state.net_obstacles_cache)
-                    if _tr == 'full':
+                    if _tr in ('full', 'full_open'):
                         _sv, _rids, _wir = pcb_data._rip_saved[ripped_net_id]
                         restore_net(ripped_net_id, _sv, _rids, _wir,
                                     pcb_data, routed_net_ids, routed_net_paths,
@@ -568,12 +568,24 @@ def run_reroute_loop(
                                     state.ripped_route_layer_costs,
                                     state.ripped_route_via_positions,
                                     refused_sink=state.collision_refused_net_ids)
-                        print(f"  RIP-RESTORE (#468): {ripped_net_name} restored "
-                              f"to its pre-rip route (reroute failed, corridor "
-                              f"still clear)")
-                        if _wir:
-                            successful += 1
+                        state.terminal_restores[ripped_net_id] = _tr
+                        if _tr == 'full':
+                            print(f"  RIP-RESTORE (#468): {ripped_net_name} restored "
+                                  f"to its pre-rip route (reroute failed, corridor "
+                                  f"still clear)")
+                            if _wir:
+                                successful += 1
+                        else:
+                            # Conflict-free but NOT connected: the saved payload
+                            # never covered every pad. Keep the copper, refuse
+                            # the success claim (run-7 E2).
+                            print(f"  {RED}RIP-RESTORE (#468): {ripped_net_name} "
+                                  f"restored its pre-rip copper but the net "
+                                  f"remains OPEN -- counted failed{RESET}")
+                            failed += 1
                     else:
+                        if _tr == 'stub':
+                            state.terminal_restores[ripped_net_id] = 'stub'
                         failed += 1
 
         elif reroute_item[0] == 'diff_pair':
@@ -1035,7 +1047,7 @@ def run_reroute_loop(
                         pcb_data, config, ripped_pair.p_net_id,
                         working_obstacles=state.working_obstacles,
                         net_obstacles_cache=state.net_obstacles_cache)
-                    if _tr == 'full':
+                    if _tr in ('full', 'full_open'):
                         _sv, _rids, _wir = pcb_data._rip_saved[ripped_pair.p_net_id]
                         restore_net(ripped_pair.p_net_id, _sv, _rids, _wir,
                                     pcb_data, routed_net_ids, routed_net_paths,
@@ -1046,11 +1058,22 @@ def run_reroute_loop(
                                     state.ripped_route_layer_costs,
                                     state.ripped_route_via_positions,
                                     refused_sink=state.collision_refused_net_ids)
-                        print(f"  RIP-RESTORE (#468): pair {ripped_pair_name} "
-                              f"restored to its pre-rip route")
-                        if _wir:
-                            successful += 1
+                        state.terminal_restores[ripped_pair.p_net_id] = _tr
+                        state.terminal_restores[ripped_pair.n_net_id] = _tr
+                        if _tr == 'full':
+                            print(f"  RIP-RESTORE (#468): pair {ripped_pair_name} "
+                                  f"restored to its pre-rip route")
+                            if _wir:
+                                successful += 1
+                        else:
+                            print(f"  {RED}RIP-RESTORE (#468): pair "
+                                  f"{ripped_pair_name} restored its pre-rip "
+                                  f"copper but remains OPEN -- counted failed{RESET}")
+                            failed += 1
                     else:
+                        if _tr == 'stub':
+                            state.terminal_restores[ripped_pair.p_net_id] = 'stub'
+                            state.terminal_restores[ripped_pair.n_net_id] = 'stub'
                         failed += 1
 
     return successful, failed, total_time, total_iterations, route_index

--- a/rip_restore.py
+++ b/rip_restore.py
@@ -137,8 +137,11 @@ def try_terminal_restore(pcb_data: PCBData, config: GridRouteConfig,
                          net_id: int, working_obstacles=None,
                          net_obstacles_cache=None) -> Optional[str]:
     """At a rip victim's TERMINAL reroute failure: 'full' when the saved
-    copper is conflict-free (caller must then run restore_net, which pops
-    the registry and does all bookkeeping); 'stub' when only the escape
+    copper is conflict-free AND grades connected (caller must then run
+    restore_net, which pops the registry and does all bookkeeping);
+    'full_open' when it is conflict-free but the restored net would still
+    have disconnected pads -- the caller should restore it (more copper
+    than nothing) WITHOUT counting a success; 'stub' when only the escape
     subset could be re-inserted (done here, pcb_data-only); None when
     nothing was recoverable."""
     reg = getattr(pcb_data, '_rip_saved', None)
@@ -153,6 +156,34 @@ def try_terminal_restore(pcb_data: PCBData, config: GridRouteConfig,
     own = set(ripped_ids) | {net_id}
 
     if not _copper_conflicts(pcb_data, config, own, segments, vias):
+        # Conflict-free is necessary, not sufficient (run-7 E2): the saved
+        # payload can itself be partial -- recorded off a net that was already
+        # broken, or one whose copper never covered every pad -- and restoring
+        # it while claiming success ships an open net reported as routed.
+        # Grade the POST-RESTORE state (the net's copper still on the board
+        # plus the payload) with the authoritative union-find, per member net
+        # (a pair payload carries both ids in ripped_ids).
+        try:
+            from check_connected import (check_net_connectivity,
+                                         net_break_within_outlines)
+            for _nid in sorted(own):
+                pads = pcb_data.pads_by_net.get(_nid, [])
+                if len(pads) < 2:
+                    continue
+                segs_all = ([s for s in pcb_data.segments if s.net_id == _nid]
+                            + [s for s in segments if s.net_id == _nid])
+                vias_all = ([v for v in pcb_data.vias if v.net_id == _nid]
+                            + [v for v in vias if v.net_id == _nid])
+                zones = [z for z in getattr(pcb_data, 'zones', []) or []
+                         if z.net_id == _nid]
+                _r = check_net_connectivity(_nid, segs_all, vias_all, pads,
+                                            zones, tolerance=0.02,
+                                            pcb_data=pcb_data)
+                _broken, _dp = net_break_within_outlines(pcb_data, _r)
+                if _broken and _dp:
+                    return 'full_open'
+        except Exception:
+            pass  # grading must never turn a restorable net into a strip
         return 'full'
 
     stub_segs, stub_vias = _stub_subset(pcb_data, net_id, segments, vias)
@@ -184,7 +215,8 @@ def try_terminal_restore(pcb_data: PCBData, config: GridRouteConfig,
         pcb_data.segments.extend(kept_s)
         pcb_data.vias.extend(kept_v)
     name = pcb_data.nets[net_id].name if net_id in pcb_data.nets else str(net_id)
-    print(f"  RIP-RESTORE (#468): {name} kept its escape stub "
-          f"({len(kept_s)} seg(s), {len(kept_v)} via(s)) -- full restore "
-          f"would short against copper routed since the rip")
+    print(f"  RIP-RESTORE (#468): {name} remains UNROUTED -- kept only its "
+          f"escape stub ({len(kept_s)} seg(s), {len(kept_v)} via(s)) so the "
+          f"pads keep their landing sites; full restore would short against "
+          f"copper routed since the rip")
     return 'stub'

--- a/route.py
+++ b/route.py
@@ -2110,6 +2110,59 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
                 for _dv in _cd['dropped_vias']:
                     print(f"      dropped via @ ({_dv['x']:.3f}, {_dv['y']:.3f})")
 
+    # ---- VIA DEDUP (run-7 E3) ----------------------------------------------
+    # Failed/partial attempts can leave a result emitting a via at the exact
+    # position of a surviving input via, or of another result's via for the
+    # same net: identical coords, same span -- two barrels stacked in one
+    # hole. KiCad tolerates same-net stacks, so no DRC flags them; they ship
+    # silently and read as parser/net rot when the file is inspected later.
+    # Drop the duplicates from the write list HERE, before total_vias and the
+    # authoritative sweep, so the tally, the sweep, the writer and the GUI
+    # results all see the same deduped copper. Same-net only (the key carries
+    # net_id): cross-net coincidence is a real short the DRC sweep owns.
+    _DEDUP_VIA_TOL_MM = 0.01
+    _survive_via_strip = {id(v) for v in stale_input_vias}
+
+    def _via_dedup_key(v):
+        return (v.net_id, tuple(v.layers or ()),
+                round(v.x / _DEDUP_VIA_TOL_MM), round(v.y / _DEDUP_VIA_TOL_MM))
+
+    _kept_via_keys = set()
+    for _lst0 in _orig_via_by_net.values():
+        for _v0 in _lst0:
+            if id(_v0) not in _survive_via_strip:
+                _kept_via_keys.add(_via_dedup_key(_v0))
+    for _v0 in all_swap_vias:
+        _kept_via_keys.add(_via_dedup_key(_v0))
+    _via_dup_dropped = []
+    for _r0 in results:
+        _nv0 = _r0.get('new_vias') or []
+        if not _nv0:
+            continue
+        _kept0 = []
+        for _v0 in _nv0:
+            _k0 = _via_dedup_key(_v0)
+            if _k0 in _kept_via_keys:
+                _via_dup_dropped.append(_v0)
+                continue
+            _kept_via_keys.add(_k0)
+            _kept0.append(_v0)
+        if len(_kept0) != len(_nv0):
+            _r0['new_vias'] = _kept0
+    if _via_dup_dropped:
+        # Keep pcb_data == write model: remove the dropped OBJECTS from the
+        # board too -- unless the same object also survives as a kept
+        # occurrence (the same via listed by two results keeps its first).
+        _kept_obj_ids = {id(v) for _r0 in results
+                         for v in (_r0.get('new_vias') or [])}
+        _drop_obj_ids = {id(v) for v in _via_dup_dropped} - _kept_obj_ids
+        if _drop_obj_ids:
+            pcb_data.vias = [v for v in pcb_data.vias
+                             if id(v) not in _drop_obj_ids]
+        print(f"Via dedup: dropped {len(_via_dup_dropped)} duplicate stacked "
+              f"via(s) already present at the same position/span for the "
+              f"same net")
+
     # Count total vias from results
     total_vias = sum(len(r.get('new_vias', [])) for r in results)
 
@@ -2163,6 +2216,31 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
     # sweep's model -- phantom failed_multipoint entries.
     for _s in all_swap_segments:
         _segs_by_net.setdefault(_s.net_id, []).append(_s)
+
+    # ---- STACKED-COPPER SURFACING (run-7 E3) -------------------------------
+    # The dedup above drops the attributable duplicates; census what is STILL
+    # stacked on the write model (duplicate same-net segments, coincident
+    # same-net vias) and surface it in the summary. check_drc stays silent on
+    # same-net stacks by design (KiCad permits them), so without this the
+    # only way to see one was to read the raw file.
+    stacked_copper_findings = []
+    try:
+        from check_weird import stacked_copper_over_model
+        stacked_copper_findings = stacked_copper_over_model(
+            _segs_by_net, _vias_by_net,
+            lambda _n: (pcb_data.nets[_n].name if _n in pcb_data.nets
+                        else f"Net {_n}"))
+    except Exception as _swe:
+        print(f"  (stacked-copper check failed: {_swe})")
+    if stacked_copper_findings:
+        print(f"\n{RED}WARNING: {len(stacked_copper_findings)} stacked-copper "
+              f"finding(s) on the write model (same-net duplicates KiCad "
+              f"will not flag):{RESET}")
+        for _f in stacked_copper_findings[:8]:
+            print(f"  {RED}{_f['net']} {_f['layer']}: {_f['detail']}{RESET}")
+        if len(stacked_copper_findings) > 8:
+            print(f"  {RED}... and {len(stacked_copper_findings) - 8} more{RESET}")
+
     _zones_by_net: Dict[int, list] = {}
     for _z in getattr(pcb_data, 'zones', []) or []:
         _zones_by_net.setdefault(_z.net_id, []).append(_z)
@@ -2252,7 +2330,14 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
     _cov_disturbed = (set(getattr(state, 'casualty_custody', {}) or {})
                       | set(state.collision_refused_net_ids or set())
                       | {s.net_id for s in _stale_input_segs}
-                      | {v.net_id for v in stale_input_vias})
+                      | {v.net_id for v in stale_input_vias}
+                      # #468 follow-up: a broken terminal restore ('full_open'
+                      # / 'stub') puts the original copper BACK, unwinding the
+                      # stale-strip signal above -- without this the net leaves
+                      # the disturbed set and ships open, unreported.
+                      | {nid for nid, v in
+                         (getattr(state, 'terminal_restores', None) or {}).items()
+                         if v != 'full'})
     _cov_classified = {nid for _, nid in single_ended_nets} | set(routed_results)
     for _nid in sorted((_cov_disturbed & sweep_scope_ids) - _cov_classified):
         _pads = pcb_data.pads_by_net.get(_nid, [])
@@ -2436,24 +2521,41 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
     # if it is fully connected (issue #189): one that routed a result but left
     # pads disconnected (a failed MST edge) is in failed_multipoint_ids and is
     # NOT routed. failed_single stays "no result at all" so the place/route loop
-    # does not double-count it (its deficit is already in mp_deficit).
+    # does not double-count it (its deficit is already in mp_deficit). The third
+    # bucket, open_single, names the nets BETWEEN those two: a kept result whose
+    # copper still leaves pads disconnected. Multipoint nets are excluded from
+    # it -- their shortfall is already priced pad-by-pad in the multipoint
+    # deficit, and counting the net again would double-charge it; a
+    # non-multipoint open net previously contributed to NO count at all, so a
+    # verdict of failed_single + pad-deficit read 0 while the board shipped
+    # open (run-7 west-fan class).
     routed_single = []
     failed_single = []
     failed_single_ids = []  # Track IDs for history output
+    open_single = []
+    open_single_ids = []
     for net_name, net_id in single_ended_nets:
         if net_id in fully_routed_ids:
             routed_single.append(net_name)
         elif net_id not in routed_results:
             failed_single.append(net_name)
             failed_single_ids.append(net_id)
+        elif not routed_results[net_id].get('is_multipoint'):
+            open_single.append(net_name)
+            open_single_ids.append(net_id)
 
     # Print human-readable summary
     print("\n" + "=" * 60)
     print("Routing complete")
     print("=" * 60)
     if single_ended_nets:
-        if failed_single:
-            print(f"  {RED}Single-ended:  {len(routed_single)}/{len(single_ended_nets)} routed ({len(failed_single)} FAILED){RESET}")
+        if failed_single or open_single:
+            _bad_bits = []
+            if failed_single:
+                _bad_bits.append(f"{len(failed_single)} FAILED")
+            if open_single:
+                _bad_bits.append(f"{len(open_single)} OPEN")
+            print(f"  {RED}Single-ended:  {len(routed_single)}/{len(single_ended_nets)} routed ({', '.join(_bad_bits)}){RESET}")
         else:
             print(f"  Single-ended:  {len(routed_single)}/{len(single_ended_nets)} routed")
     if multipoint_nets > 0:
@@ -2479,6 +2581,12 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
         print(f"\n{RED}Failed single-ended nets:{RESET}")
         for net_name in failed_single:
             print(f"  {RED}{net_name}{RESET}")
+    if open_single:
+        # A kept result is NOT a connection: these nets ship copper with pads
+        # still disconnected (pad detail follows in the multi-point list).
+        print(f"\n{RED}Routed-but-OPEN single-ended nets (result kept, pads disconnected):{RESET}")
+        for net_name in open_single:
+            print(f"  {RED}{net_name}{RESET}")
     if failed_multipoint:
         print(f"\n{RED}Failed multi-point connections:{RESET}")
         for item in failed_multipoint:
@@ -2486,14 +2594,21 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
             for pad in item['failed_pads']:
                 print(f"  {RED}{net_name}: {pad['component_ref']} pad {pad['pad_number']} at ({pad['x']:.2f}, {pad['y']:.2f}) not connected{RESET}")
 
-    # Print history for all failed nets (helps debug why they failed)
-    if failed_single_ids:
-        print_failed_net_histories(state, failed_single_ids, pcb_data)
+    # Print history for all failed nets (helps debug why they failed) --
+    # open nets included: their history shows which attempt left the stub.
+    if failed_single_ids or open_single_ids:
+        print_failed_net_histories(state, failed_single_ids + open_single_ids,
+                                   pcb_data)
 
     from target_swap import summarize_target_swaps  # cycle-safe swap list (#380)
     summary = {
         'routed_single': routed_single,
         'failed_single': failed_single,
+        # Nets with a KEPT result whose pads are still disconnected (their pad
+        # detail is in failed_multipoint). Excludes multipoint nets, whose
+        # shortfall is already the multipoint pad deficit -- so a verdict may
+        # safely count len(failed_single) + len(open_single) + pad-deficit.
+        'open_single': open_single,
         'failed_multipoint': [
             {
                 'net_name': item['net_name'],
@@ -2537,10 +2652,23 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
         # T5 coverage gate: disturbed out-of-scope nets shipping broken
         # (additive; also present as failed_multipoint entries above).
         summary['coverage_gate_nets'] = coverage_gate_nets
+    if getattr(state, 'terminal_restores', None):
+        # #468 follow-up (run-7 E2): terminal-restore outcomes per net --
+        # 'full' is a true restoration; 'full_open' restored copper that never
+        # covered every pad; 'stub' kept only the escape stubs. Additive; the
+        # broken outcomes are also graded by the sweeps/coverage gate above.
+        summary['terminal_restores'] = {
+            (pcb_data.nets[_n].name if _n in pcb_data.nets else str(_n)): _v
+            for _n, _v in sorted(state.terminal_restores.items())}
     if fragmented_nets:
         # #549 C3: pad-connected nets whose copper is several KiCad islands
         # (additive; also present as failed_multipoint entries above).
         summary['fragmented_nets'] = fragmented_nets
+    if stacked_copper_findings:
+        # run-7 E3: same-net duplicate copper still on the write model after
+        # the via dedup (additive; KiCad's DRC never flags same-net stacks,
+        # so this key is the only disclosure).
+        summary['stacked_copper'] = stacked_copper_findings
     summary['oracle_check'] = oracle_check
     if oracle_open:
         # #549 B-1: KiCad's own open-link counts for this run's scope

--- a/route_planes.py
+++ b/route_planes.py
@@ -3407,8 +3407,17 @@ def create_plane(
                 progress_callback(0, 0, f"{net_name}: building via obstacle map...")
             obstacles = build_via_obstacle_map(pcb_data, config, net_id,
                                                same_net_pad_clearance=same_net_pad_clearance)
-            # Also block positions of vias we've already placed in previous nets
+            # Also block positions of vias we've already placed in previous nets.
+            # from_restore entries are EXCLUDED: a restored rip victim's vias
+            # are already back in pcb_data, so build_via_obstacle_map has
+            # priced them at their float centre -- stamping them again here at
+            # session-via pricing (grid-snapped centre, <= drill ring) is a
+            # conservative over-block, and it is what made the balance audit's
+            # fresh rebuild diverge from the correctly-maintained map (the
+            # same filter the pcb_data sync below already applies).
             for placed_via in all_new_vias:
+                if placed_via.get('from_restore'):
+                    continue
                 block_via_position(obstacles, placed_via['x'], placed_via['y'], coord,
                                    hole_to_hole_clearance, via_drill,
                                    via_size, config.clearance)
@@ -4095,10 +4104,18 @@ def create_plane(
         # class as #208): after all rips/placements the maintained map must
         # equal a fresh rebuild from the CURRENT pcb_data plus the session vias
         # (mirroring its Step-7 construction + per-placement blocking).
+        # from_restore vias are filtered for the same reason as at Step 7:
+        # they are already in pcb_data, so the fresh rebuild prices them at
+        # their float centre -- stamping them AGAIN at snapped-centre session
+        # pricing contaminated the audit's reference and flagged the correct
+        # maintained map as "under-blocked" (a single boundary cell, false
+        # positive). Both filters are required together: filtering only the
+        # audit flips the report to the mirror-image "wrongly-blocked" leak.
         if env_knobs.OBSTACLE_AUDIT and obstacles is not None:
             _audit_plane_via_map(obstacles, pcb_data, config, net_id,
                                  same_net_pad_clearance,
-                                 all_new_vias + new_vias, coord,
+                                 [v for v in all_new_vias + new_vias
+                                  if not v.get('from_restore')], coord,
                                  hole_to_hole_clearance, via_drill, via_size,
                                  net_name)
 

--- a/route_summary.py
+++ b/route_summary.py
@@ -42,8 +42,9 @@ def merge_summaries(summaries: List[Dict], aborted: bool = False) -> Optional[Di
 
     Per field class:
 
-    * FAILURE STATE (failed_single / failed_multipoint / multipoint_pads_*)
-      comes from the LAST summary, and is exact rather than a delta. Every net
+    * FAILURE STATE (failed_single / open_single / failed_multipoint /
+      multipoint_pads_*) comes from the LAST summary, and is exact rather
+      than a delta. Every net
       with a nonzero failure term is in the retry set by construction, and the
       sub-run re-derives each retried net's pad counts over ALL of that net's
       pads from the final-board union-find, so the last summary's numbers are

--- a/routing_state.py
+++ b/routing_state.py
@@ -82,6 +82,12 @@ class RoutingState:
     # restore, so they were left ripped instead. Given a clean reroute pass
     # after Phase 3 so the collision-safe restore does not cost completion.
     collision_refused_net_ids: Set[int] = field(default_factory=set)
+    # #468 follow-up (run-7 E2): terminal-restore outcomes, net_id ->
+    # 'full' | 'full_open' | 'stub'. 'full_open' and 'stub' nets ship broken:
+    # route.py folds them into the coverage-gate disturbed set (a full restore
+    # unwinds the stale-strip signal the gate otherwise keys on) and exports
+    # the outcomes as summary['terminal_restores'].
+    terminal_restores: Dict[int, str] = field(default_factory=dict)
     # Rip-up cycle guard across the reroute QUEUE (extends the phase3 recursion
     # guard, commit e3e4b57, to the single-ended rip/reroute paths). Maps a net to
     # the set of nets that ripped it (transitively) to get here; that net must not

--- a/single_ended_routing.py
+++ b/single_ended_routing.py
@@ -3890,8 +3890,18 @@ def _route_multipoint_taps_impl(
         # a legal launch (its stubs, trunks, vias on all layers), exactly
         # like Phase 1's island-wide launch. Restricted to routed components
         # (#189). sorted() for GUI/CLI order-independence.
+        # The ids MUST come from the same labeling that keys
+        # _p3_island_cells: `routed_components` is Phase-1's labeling, and
+        # get_terminal_component_info renumbers densely after Phase-1 copper
+        # merges pads -- indexing the fresh map with the stale ids collided
+        # a routed pad's old singleton label with an UNROUTED island's fresh
+        # label, seeding sources on the target's own island. A* then popped
+        # a source that was the goal on iteration 1 and credited a
+        # zero-length phantom "routed" edge -- the exact #189 violation this
+        # branch guards against (test_432 scenario C: 2/0 edges where the
+        # truth was 1/1, and on real boards a suppressed failure record).
         if _p3_use_islands:
-            for _cid in sorted(routed_components):
+            for _cid in sorted({_p3_comps.get(i, i) for i in routed_indices}):
                 _isl = _p3_island_cells.get(_cid)
                 if not _isl:
                     continue
@@ -3923,8 +3933,12 @@ def _route_multipoint_taps_impl(
         # landing cell back to ITS owner point, never the distant pad centre.
         _tgt_isl = {}
         if _p3_use_islands:
+            # Same ID-space rule as the source seeding above: look the
+            # target's island up through the FRESH labeling, not Phase-1's
+            # pad_components (the stale id usually missed entirely, so #545
+            # F2 target-island landing silently never worked).
             _tgt_isl = _p3_island_cells.get(
-                pad_components.get(tgt_idx, tgt_idx), {})
+                _p3_comps.get(tgt_idx, tgt_idx), {})
             if _tgt_isl:
                 _tset = set(targets)
                 for _cell in _tgt_isl:

--- a/tests/test_431_round_sidecar.py
+++ b/tests/test_431_round_sidecar.py
@@ -73,7 +73,8 @@ def test_run_route_is_now_a_one_line_caller():
     """If someone re-inlines the body, the renderer and the loop start drifting."""
     import inspect
     src = inspect.getsource(L.run_route)
-    assert 'return metrics_from_summary(summary, log)' in src
+    # arg list left open: #549 added extra_targets and the pin broke
+    assert 'return metrics_from_summary(summary, log' in src
     assert 'failed_multipoint' not in src, "the parsing belongs in the pure function"
 
 

--- a/tests/test_431_skill_commands.py
+++ b/tests/test_431_skill_commands.py
@@ -300,7 +300,10 @@ def test_the_score_is_the_gate_and_the_router_is_not_the_judge():
     conv = os.path.join(ROOT, '.claude/skills/plan-pcb-routing/references/convergence.md')
     assert os.path.isfile(conv), "references/convergence.md is missing"
     ctext = open(conv, encoding='utf-8').read()
-    for key in ('ledger.jsonl', 'parent_board', 'stopped_by', 'blocking'):
+    # parent_sha / "stop condition" are the REAL schema (board_store.Ledger +
+    # converge.py record); the old parent_board/stopped_by names never existed
+    # in any writer and the pin rotted silently.
+    for key in ('ledger.jsonl', 'parent_sha', 'stop condition', 'blocking'):
         assert key in ctext, f"convergence.md does not document `{key}`"
     # The ledger has to be the one the TOOLS read. `board_store.Ledger` is
     # append-only JSONL and `converge.py record` is its only writer, so a
@@ -310,8 +313,11 @@ def test_the_score_is_the_gate_and_the_router_is_not_the_judge():
     for verb in ('record', 'status'):
         assert f'converge.py {verb}' in ctext or f'converge.py {verb}' in skill, \
             f"neither the skill nor convergence.md names `converge.py {verb}`"
-    assert '"limit": 100' in ctext, \
-        "the ledger template must carry the same budget the prose states (100)"
+    # The ledger is bare JSONL with NO wrapper object (convergence.md says so
+    # itself), so there is no "limit" field to pin -- the budget lives in
+    # prose and in stop condition 2's "100 ledger entries actually written".
+    assert '100 per board' in ctext, \
+        "convergence.md must state the 100-per-board budget"
     print("  PASS: score is the gate, router self-report demoted, loop bounded")
 
 

--- a/tests/test_459_group_routing.py
+++ b/tests/test_459_group_routing.py
@@ -55,13 +55,23 @@ def test_internal_and_touching_differ_and_both_are_useful():
     print(f"  PASS: sheet block -> {len(inner)} internal of {len(outer)} touching")
 
 
-def test_a_decap_block_has_no_internal_nets():
-    """Not a bug -- a decoupling cap bridges VCC to GND, both board-wide. It is
-    why 'touching' has to exist as a scope."""
+def test_a_decap_block_is_mostly_boundary_nets():
+    """A decoupling cap bridges a rail to GND, and board-wide nets cross the
+    block boundary -- which is why 'touching' has to exist as a scope. But
+    "0% internal by construction" is FALSE since f38204e tethers caps on
+    their RAIL: an IC's own local regulator rail (IC + its bypass caps only,
+    tigard's VREG) is legitimately 100% internal to the decap block. GND
+    must never be internal; anything internal must also be touching."""
     pcb = parse_kicad_pcb(FLAT)
     refs = block_refs(pcb, 'decap:U3', parse_sources('decap'))
-    assert block_net_names(pcb, refs, 'internal') == []
-    assert len(block_net_names(pcb, refs, 'touching')) > 10
+    inner = set(block_net_names(pcb, refs, 'internal'))
+    outer = set(block_net_names(pcb, refs, 'touching'))
+    assert inner == {'VREG'}, (
+        f"internal nets {sorted(inner)}: expected exactly the FT2232H's "
+        f"local VREG rail (its owners are U3 + its own bypass caps, all "
+        f"inside the block since f38204e's rail tethering)")
+    assert 'GND' not in inner and inner < outer
+    assert len(outer) > 10
 
 
 def test_unknown_block_names_what_exists():
@@ -433,7 +443,7 @@ def test_preview_of_an_undone_block_reports_real_additions():
 
 TESTS = [
     test_internal_and_touching_differ_and_both_are_useful,
-    test_a_decap_block_has_no_internal_nets,
+    test_a_decap_block_is_mostly_boundary_nets,
     test_unknown_block_names_what_exists,
     test_short_name_is_accepted,
     test_list_groups_reports_both_net_counts,

--- a/tests/test_549_floorplan_cli.py
+++ b/tests/test_549_floorplan_cli.py
@@ -183,6 +183,25 @@ def test_the_summary_carries_the_keys_a_caller_branches_on():
     print(f"  PASS: {len(s)} keys, all JSON-round-trippable")
 
 
+def test_grading_knobs_resolve_from_the_board_and_are_disclosed():
+    """Run-7 S1: a fixed 0.25 default on a 0.15-floor board manufactured
+    phantom oob findings. Unset knobs must resolve from the board and the
+    summary must say what was used, with its source."""
+    code, out, _ = _run(BOARD, '--intent', _emit_once(), '-q')
+    s = _summary(out)
+    for k in ('clearance_used', 'edge_clearance_used'):
+        assert k in s, f"JSON_SUMMARY lost {k}"
+        assert 'value' in s[k] and 'source' in s[k], s[k]
+        assert s[k]['source'] in ('cli', 'board netclass', 'board constraint',
+                                  'fixed default'), s[k]
+    code, out, _ = _run(BOARD, '--intent', _emit_once(), '-q',
+                        '--clearance', '0.11')
+    s = _summary(out)
+    assert s['clearance_used'] == {'value': 0.11, 'source': 'cli'}, (
+        "an explicit --clearance must win and be labeled cli")
+    print("  PASS: knobs resolve board-first and the summary discloses them")
+
+
 def test_the_full_json_carries_the_measured_numbers():
     raw = json.load(open(_emit_once(), encoding='utf-8'))
     x0, y0, x1, y1 = raw['envelope']['rect']

--- a/tests/test_check_join.py
+++ b/tests/test_check_join.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""check_join.py: the hand-join verifier, promoted from run 7's prototype.
+
+The prototype (wk7/join_check.py) modeled pads as axis-aligned boxes at two
+hardcoded constants, never checked zones, dropped layer transitions on the
+floor, and skipped own-net vias entirely. This version stages the candidate
+onto a copy of the board and diffs the REAL check_drc engine, so the cases
+below include exactly what the prototype missed:
+
+  * a 45-degree-rotated pad whose true corner sticks out of its AABB;
+  * a layer change with no via (missing-via);
+  * a candidate via stacked on an existing own-net via (KiCad permits
+    same-net stacks -- only this tool will ever flag one).
+"""
+import os
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+
+BOARD_TEXT = '''(kicad_pcb
+	(version 20241229)
+	(generator "test_check_join")
+	(general
+		(thickness 1.6)
+	)
+	(layers
+		(0 "F.Cu" signal)
+		(31 "B.Cu" signal)
+		(44 "Edge.Cuts" user)
+	)
+	(net 0 "")
+	(net 1 "N1")
+	(net 2 "VICTIM")
+	(footprint "test:R45"
+		(layer "F.Cu")
+		(at 110 110 45)
+		(property "Reference" "R1"
+			(at 0 -2 0)
+			(layer "F.SilkS")
+			(effects (font (size 1 1) (thickness 0.15)))
+		)
+		(pad "1" smd rect
+			(at 0 0 45)
+			(size 2 1)
+			(layers "F.Cu")
+			(net 2 "VICTIM")
+		)
+	)
+	(gr_rect
+		(start 100 100)
+		(end 120 120)
+		(stroke (width 0.1) (type default))
+		(layer "Edge.Cuts")
+	)
+	(via
+		(at 115 115)
+		(size 0.5)
+		(drill 0.3)
+		(layers "F.Cu" "B.Cu")
+		(net 1)
+	)
+)
+'''
+
+
+def _board(d):
+    p = os.path.join(d, 'j.kicad_pcb')
+    with open(p, 'w', encoding='utf-8') as f:
+        f.write(BOARD_TEXT)
+    return p
+
+
+def _run(args):
+    return subprocess.run([sys.executable, '-X', 'utf8',
+                           os.path.join(ROOT, 'check_join.py')] + args,
+                          capture_output=True, text=True, encoding='utf-8',
+                          errors='replace', cwd=ROOT)
+
+
+def test_clean_join_is_clean():
+    with tempfile.TemporaryDirectory() as d:
+        b = _board(d)
+        r = _run([b, 'N1', '104,116,F.Cu', '107,116,F.Cu'])
+        assert 'CLEAN' in r.stdout, r.stdout + r.stderr
+        assert r.returncode == 0
+    print("  PASS: a join in free space is CLEAN, exit 0")
+
+
+def test_rotated_pad_corner_is_caught():
+    """Track at y=111.2 near the 45-degree pad at (110,110), size 2x1: the
+    TRUE rotated corner reaches y=111.06 (0.064mm gap to the track edge, a
+    real violation at 0.2 clearance); the axis-aligned box ends at y=110.5
+    (0.625mm gap -- 'clean'). The prototype's AABB model passed this."""
+    with tempfile.TemporaryDirectory() as d:
+        b = _board(d)
+        r = _run([b, 'N1', '108,111.2,F.Cu', '112,111.2,F.Cu'])
+        assert r.returncode == 1, (
+            "the rotated pad's corner violation was missed -- the AABB "
+            "model is back:\n" + r.stdout + r.stderr)
+        assert 'VICTIM' in r.stdout, r.stdout
+    print("  PASS: 45-degree pad corner caught (the AABB blind spot)")
+
+
+def test_straight_short_is_caught():
+    with tempfile.TemporaryDirectory() as d:
+        b = _board(d)
+        r = _run([b, 'N1', '108,110,F.Cu', '112,110,F.Cu'])
+        assert r.returncode == 1 and 'VICTIM' in r.stdout, (
+            r.stdout + r.stderr)
+    print("  PASS: a track through a foreign pad is a violation")
+
+
+def test_layer_change_without_via_is_missing_via():
+    with tempfile.TemporaryDirectory() as d:
+        b = _board(d)
+        r = _run([b, 'N1', '104,116,F.Cu', '105,116,F.Cu', '105,116,B.Cu',
+                  '105,118,B.Cu'])
+        assert r.returncode == 1 and 'missing-via' in r.stdout, (
+            "a layer transition with no via: token must be a violation "
+            "(the prototype silently dropped these pairs):\n" + r.stdout)
+        # ... and WITH the via it is clean
+        r = _run([b, 'N1', '104,116,F.Cu', '105,116,F.Cu', '105,116,B.Cu',
+                  '105,118,B.Cu', 'via:105,116'])
+        assert r.returncode == 0 and 'CLEAN' in r.stdout, r.stdout + r.stderr
+    print("  PASS: missing-via flagged; the same join with via: is CLEAN")
+
+
+def test_candidate_via_on_existing_own_net_via_is_stacked():
+    with tempfile.TemporaryDirectory() as d:
+        b = _board(d)
+        r = _run([b, 'N1', 'via:115,115'])
+        assert r.returncode == 1 and 'stacked-copper' in r.stdout, (
+            "an own-net via stack must be flagged -- KiCad's DRC permits "
+            "it, so nothing else ever will:\n" + r.stdout + r.stderr)
+    print("  PASS: own-net via stack flagged")
+
+
+def test_usage_errors_exit_2():
+    with tempfile.TemporaryDirectory() as d:
+        b = _board(d)
+        r = _run([b, 'NOSUCHNET', '104,116,F.Cu', '107,116,F.Cu'])
+        assert r.returncode == 2 and 'no net named' in r.stderr, r.stderr
+        r = _run([b, 'N1', '104,116,In1.Cu', '107,116,In1.Cu'])
+        assert r.returncode == 2 and 'not a copper layer' in r.stderr
+        r = _run([b, 'N1', 'garbage'])
+        assert r.returncode == 2
+    print("  PASS: unknown net / bad layer / bad token all exit 2")
+
+
+if __name__ == '__main__':
+    fns = [v for k, v in sorted(globals().items()) if k.startswith('test_')]
+    for fn in fns:
+        print(f"--- {fn.__name__}")
+        fn()
+    print("ALL PASS")

--- a/tests/test_compare_seeds.py
+++ b/tests/test_compare_seeds.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""compare_seeds.py: the seed-axis comparator, one command instead of a
+hand-rolled afternoon.
+
+Run 7's measured lesson: crossings CANNOT rank seeds (they ranked seed 0
+first; identical full-board probes measured seed 2 at 39 failures vs seed 0's
+53, and the run shipped on seed 2). The comparator generates each seed with
+place_seed, refuses to rank seeds that fail their own intent gate, and probes
+every survivor with the SAME full-board net patterns and route args.
+
+Also under test: the 8bd1344 lesson -- caller-relative paths must be
+absolutized at the door, because every subprocess runs with cwd=ROOT.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+
+BOARD = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
+
+
+def _pile(d):
+    """Stack every footprint at board center: the unplaced-pile fixture."""
+    from kicad_parser import parse_kicad_pcb
+    from placement.writer import write_placed_output
+    pcb = parse_kicad_pcb(BOARD)
+    b = pcb.board_info.board_bounds
+    cx, cy = (b[0] + b[2]) / 2, (b[1] + b[3]) / 2
+    pile = os.path.join(d, 'pile.kicad_pcb')
+    write_placed_output(BOARD, pile, [
+        {'reference': ref, 'new_x': cx, 'new_y': cy, 'new_rotation': 0}
+        for ref, fp in sorted(pcb.footprints.items()) if fp.pads])
+    return pile, pcb
+
+
+def test_end_to_end_ranked_table_from_relative_paths():
+    if not os.path.isfile(BOARD):
+        print("  SKIP: fixture missing")
+        return
+    with tempfile.TemporaryDirectory() as d:
+        pile, pcb = _pile(d)
+        intent_path = os.path.join(d, 'intent.json')
+        from placement.floorplan import emit_intent
+        with open(intent_path, 'w', encoding='utf-8') as f:
+            json.dump(emit_intent(pcb, BOARD), f)
+
+        # Deliberately RELATIVE paths from a cwd that is neither ROOT nor the
+        # temp dir's parent: without absolutize-at-the-door every place_seed/
+        # probe subprocess (cwd=ROOT) would silently miss them.
+        r = subprocess.run(
+            [sys.executable, '-X', 'utf8',
+             os.path.join(ROOT, 'compare_seeds.py'),
+             os.path.relpath(pile, d),
+             '--intent', os.path.relpath(intent_path, d),
+             '--seeds', '0', '1',
+             '--out-dir', 'seedcmp'],
+            capture_output=True, text=True, encoding='utf-8',
+            errors='replace', cwd=d, timeout=3600,
+            env=dict(os.environ, PYTHONIOENCODING='utf-8'))
+        out = r.stdout + r.stderr
+        assert r.returncode in (0, 4), out[-1500:]
+
+        doc_path = os.path.join(d, 'seedcmp', 'seeds.json')
+        assert os.path.isfile(doc_path), (
+            "seeds.json missing -- relative --out-dir was not absolutized:\n"
+            + out[-800:])
+        doc = json.load(open(doc_path, encoding='utf-8'))
+        assert [row['seed'] for row in doc['rows']] == [0, 1]
+        assert sorted(doc['ranking']) == [0, 1]
+        for row in doc['rows']:
+            assert os.path.isfile(row['board']), f"seed board missing: {row}"
+            if row.get('probe'):
+                assert row['probe']['probe_kind'] == 'full'
+                assert isinstance(row['probe']['failures'], int), row['probe']
+        line = next(l for l in r.stdout.splitlines()
+                    if l.startswith('JSON_SUMMARY:'))
+        s = json.loads(line.split(':', 1)[1])
+        assert s['seeds'] == 2
+        if r.returncode == 0:
+            assert s['best_seed'] in (0, 1)
+            best_row = next(x for x in doc['rows']
+                            if x['seed'] == s['best_seed'])
+            assert not best_row.get('gated'), (
+                "a seed that fails its own intent gate must never rank best")
+        else:
+            assert s['best_seed'] is None
+    print("  PASS: ranked table + seeds.json from caller-relative paths")
+
+
+def test_duplicate_seeds_refused():
+    r = subprocess.run(
+        [sys.executable, '-X', 'utf8',
+         os.path.join(ROOT, 'compare_seeds.py'), BOARD,
+         '--intent', 'x.json', '--seeds', '1', '1', '--out-dir', 'y'],
+        capture_output=True, text=True, encoding='utf-8', errors='replace',
+        cwd=ROOT)
+    assert r.returncode == 2 and 'duplicates' in r.stderr
+    print("  PASS: duplicate --seeds refused")
+
+
+if __name__ == '__main__':
+    fns = [v for k, v in sorted(globals().items()) if k.startswith('test_')]
+    for fn in fns:
+        print(f"--- {fn.__name__}")
+        fn()
+    print("ALL PASS")

--- a/tests/test_converge.py
+++ b/tests/test_converge.py
@@ -117,8 +117,11 @@ def test_record_step_back_replay_round_trip():
         return
     with tempfile.TemporaryDirectory() as td:
         led = os.path.join(td, 'l.jsonl')
+        # sys.executable, not 'echo': echo is a shell builtin, so it neither
+        # replays on Windows nor passes the record-time replayability guard.
         r = _cv(['record', '--ledger', led, '--board', BOARD,
-                 '--lever', 'seed', '--argv', 'echo', 'replayed-ok'])
+                 '--lever', 'seed', '--argv', sys.executable, '-c',
+                 "print('replayed-ok')"])
         assert r.returncode == 0, r.stderr
         sha = json.loads(r.stdout)['result_sha']
 
@@ -131,6 +134,51 @@ def test_record_step_back_replay_round_trip():
         r = _cv(['replay', '--ledger', led, '--iteration', '0'])
         assert r.returncode == 0 and 'replayed-ok' in r.stdout
     print("  PASS: record -> step-back (byte-exact) -> replay")
+
+
+def test_record_refuses_an_argv_that_cannot_replay():
+    """Run-7 F4: entries recorded with placeholder script names made replay a
+    reconstruction -- exactly what the ledger exists to prevent."""
+    with tempfile.TemporaryDirectory() as td:
+        led = os.path.join(td, 'l.jsonl')
+        r = _cv(['record', '--ledger', led, '--board', BOARD,
+                 '--lever', 'x', '--argv', 'route_v12_placeholder.sh', 'b.pcb'])
+        assert r.returncode == 2, (r.returncode, r.stderr)
+        assert 'never replay' in r.stderr
+        assert not os.path.exists(led), "nothing may be written on refusal"
+    print("  PASS: a placeholder --argv is refused, ledger untouched")
+
+
+def test_record_final_requires_stop_condition():
+    with tempfile.TemporaryDirectory() as td:
+        led = os.path.join(td, 'l.jsonl')
+        r = _cv(['record', '--ledger', led, '--board', BOARD, '--final'])
+        assert r.returncode == 2 and 'stop-condition' in r.stderr
+        assert not os.path.exists(led), "nothing may be written on refusal"
+        r = _cv(['record', '--ledger', led, '--board', BOARD, '--final',
+                 '--stop-condition', 'plateau: 3 iterations, no new copper'])
+        assert r.returncode == 0, r.stderr
+        e = json.loads(r.stdout)
+        assert e.get('final') is True
+        assert e.get('stop_condition', '').startswith('plateau')
+    print("  PASS: --final without --stop-condition is refused; with it, recorded")
+
+
+def test_record_score_failures_want_names():
+    """Run-7 S10/F5: a score carrying only a COUNT forces every later read to
+    re-derive which nets -- and a truncated re-derivation shipped a wrong
+    close-out. Names print when given; a count without names draws a NOTE."""
+    with tempfile.TemporaryDirectory() as td:
+        led = os.path.join(td, 'l.jsonl')
+        r = _cv(['record', '--ledger', led, '--board', BOARD,
+                 '--score', '{"failures": 3}'])
+        assert r.returncode == 0
+        assert 'names no nets' in r.stderr, r.stderr
+        r = _cv(['record', '--ledger', led, '--board', BOARD,
+                 '--score', '{"failures": 2, "failed_nets": ["SWDIO", "GPIO1"]}'])
+        assert r.returncode == 0
+        assert 'SWDIO' in r.stderr and 'GPIO1' in r.stderr, r.stderr
+    print("  PASS: failing-net names surface; a bare count draws a NOTE")
 
 
 def test_a_prose_only_entry_refuses_to_replay_without_a_traceback():

--- a/tests/test_converge_pose_knobs.py
+++ b/tests/test_converge_pose_knobs.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""`converge poses` grades pose legality at the BOARD's floor, and says so.
+
+Run-7 S4: `poses` ran at fixed argparse defaults (clearance 0.25, edge 0.55)
+on a board routed to 0.15/0.3. candidate_valid then vetoed rotations the
+router would happily route -- including flip-in-place, which WAS enumerated
+(the offset list starts at (0,0)) and then silently dropped. The run read
+"no legal pose" as a fact about the part when it was a fact about the knobs.
+
+Contract under test:
+  * unset knobs resolve from the board's own Default netclass /
+    min_copper_edge_clearance (explicit CLI values still win);
+  * the JSON discloses the resolved knobs AND their source;
+  * dropped poses are censused (`dropped_total`, `dropped_in_place`), so an
+    empty ranking is diagnosable as a knob problem vs a genuinely stuck part.
+"""
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+
+import converge  # noqa: E402
+
+BOARD = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
+
+
+def _cv(args, **kw):
+    return subprocess.run([sys.executable, '-X', 'utf8',
+                           os.path.join(ROOT, 'converge.py')] + args,
+                          capture_output=True, text=True, encoding='utf-8',
+                          errors='replace', cwd=ROOT, **kw)
+
+
+def test_cli_values_always_win():
+    c, e, knobs = converge._pose_knobs(BOARD, 0.2, 0.3)
+    assert (c, e) == (0.2, 0.3)
+    assert knobs['clearance']['source'] == 'cli'
+    assert knobs['board_edge_clearance']['source'] == 'cli'
+    print("  PASS: explicit CLI knobs are untouched")
+
+
+def test_unset_knobs_resolve_from_the_board_project():
+    with tempfile.TemporaryDirectory() as td:
+        b = os.path.join(td, 'b.kicad_pcb')
+        shutil.copy(BOARD, b)
+        with open(os.path.join(td, 'b.kicad_pro'), 'w', encoding='utf-8') as f:
+            json.dump({'net_settings': {'classes': [
+                           {'name': 'Default', 'clearance': 0.15}]},
+                       'board': {'design_settings': {'rules': {
+                           'min_copper_edge_clearance': 0.3}}}}, f)
+        c, e, knobs = converge._pose_knobs(b, None, None)
+        assert c == 0.15, f"expected the board's 0.15, got {c}"
+        assert e == 0.3, f"expected the board's 0.3, got {e}"
+        assert knobs['clearance']['source'] == 'board netclass'
+        assert knobs['board_edge_clearance']['source'] == 'board constraint'
+    print("  PASS: unset knobs resolve from the board's own floors")
+
+
+def test_projectless_board_falls_back_and_says_so():
+    assert not os.path.exists(os.path.splitext(BOARD)[0] + '.kicad_pro'), (
+        "fixture grew a .kicad_pro -- update this test")
+    c, e, knobs = converge._pose_knobs(BOARD, None, None)
+    assert (c, e) == (0.25, 0.55)
+    assert knobs['clearance']['source'] == 'fixed default'
+    assert knobs['board_edge_clearance']['source'] == 'fixed default'
+    print("  PASS: a projectless board falls back to the old defaults, labeled")
+
+
+def test_poses_json_discloses_knobs_and_drops():
+    if not os.path.isfile(BOARD):
+        print("  SKIP: fixture missing")
+        return
+    r = _cv(['poses', BOARD, '--ref', 'C1', '--radius', '0.5',
+             '--step', '0.5', '--limit', '3'])
+    assert r.returncode == 0, r.stderr[-800:]
+    d = json.loads(r.stdout)
+    assert 'knobs' in d and 'clearance' in d['knobs'], d.keys()
+    assert 'source' in d['knobs']['clearance']
+    assert 'dropped_total' in d and 'dropped_in_place' in d, (
+        "the dropped-pose census must be in the JSON")
+    print("  PASS: poses JSON carries knobs + dropped-pose census")
+
+
+def test_impossible_knobs_report_dropped_in_place():
+    """A clearance no pose can satisfy: the ranking is empty, and the census
+    must say flip-in-place was vetoed -- the S4 diagnosis in one field."""
+    if not os.path.isfile(BOARD):
+        print("  SKIP: fixture missing")
+        return
+    r = _cv(['poses', BOARD, '--ref', 'C1', '--radius', '0.5',
+             '--step', '0.5', '--clearance', '50'])
+    assert r.returncode == 1, (r.returncode, r.stdout[:400])
+    d = json.loads(r.stdout)
+    assert d['poses'] == []
+    assert d['dropped_in_place'], (
+        "with an impossible clearance, the part's own rotations must appear "
+        "in dropped_in_place -- silence here is exactly the S4 failure")
+    assert d['knobs']['clearance']['value'] == 50.0
+    print("  PASS: empty ranking is diagnosable (dropped_in_place populated)")
+
+
+if __name__ == '__main__':
+    fns = [v for k, v in sorted(globals().items()) if k.startswith('test_')]
+    for fn in fns:
+        print(f"--- {fn.__name__}")
+        fn()
+    print("ALL PASS")

--- a/tests/test_kit_route.py
+++ b/tests/test_kit_route.py
@@ -90,7 +90,13 @@ def main():
 
     def wpath(name):
         # run() executes from ROOT_DIR, so hand it a path relative to that.
-        return os.path.relpath(os.path.join(workdir, name), ROOT_DIR)
+        # Forward slashes, deliberately: run() parses the command with
+        # shlex.split (POSIX rules), which EATS backslashes -- a Windows
+        # relpath like ..\..\AppData\... collapsed into one literal filename
+        # and the whole chain silently wrote kit-out* into the repo root,
+        # the exact #426 repo-dirtying this temp dir exists to prevent.
+        return os.path.relpath(os.path.join(workdir, name),
+                               ROOT_DIR).replace(os.sep, '/')
 
     out       = wpath('kit-out.kicad_pcb')
     out_plane = wpath('kit-out-plane.kicad_pcb')

--- a/tests/test_netclass_clamp.py
+++ b/tests/test_netclass_clamp.py
@@ -1,12 +1,16 @@
 #!/usr/bin/env python3
 """Issue #295 / #439: the standalone fix_kicad_drc_settings writeback clamps EVERY
-net class (Default and the impedance design's HDMI/USB/Zxx classes) DOWN to the
-routed floor so KiCad's per-net-class DRC does not storm copper legitimately routed
-at the smaller run clearance. #439 removed the old --no-clamp-netclasses flag: the
-standalone fixer always clamps (clamping only ever lowers a class to the copper
-actually routed, so it is always DRC-safe). To PRESERVE a class spec instead, route
-with route.py and OMIT --clearance -- the router then honors each class in full and
-the writeback keeps it. The .kicad_pcb is never touched.
+net class's CLEARANCE (Default and the impedance design's HDMI/USB/Zxx classes)
+DOWN to the routed floor so KiCad's per-net-class DRC does not storm copper
+legitimately routed at the smaller run clearance. Since 6b971f1 the non-Default
+clamp is restricted to _NONDEFAULT_CLAMP_FIELDS (clearance + the diff-pair
+readback fields): per-class track_width/via_diameter/via_drill are declared
+geometry (an impedance class's width IS its spec) and are preserved. #439
+removed the old --no-clamp-netclasses flag: the standalone fixer always clamps
+(the clearance clamp only ever lowers a class to the copper actually routed, so
+it is always DRC-safe). To PRESERVE a class spec in full, route with route.py
+and OMIT --clearance -- the router then honors each class and the writeback
+keeps it. The .kicad_pcb is never touched.
 """
 import json
 import os
@@ -60,22 +64,31 @@ def main():
     def near(a, b):
         return abs((a if a is not None else -1) - b) <= 1e-9
 
-    # DEFAULT behaviour (clamp on): both Default and the impedance class drop to
-    # the routed floor.
+    # DEFAULT behaviour (clamp on): every class's CLEARANCE drops to the routed
+    # floor (KiCad's one DRC-enforced per-class field). Since 6b971f1, a
+    # non-Default class's track/via values are PRESERVED: they are declared
+    # geometry, not DRC constraints -- clamping them destroyed impedance specs
+    # (a QFN fanout rewrote USB_FS_DIFF's 0.8mm width to 0.15 on nets it never
+    # routed). Z100_inner's 0.162 track_width IS its 100-ohm spec. The Default
+    # class still clamps in full (it is the writeback's own floor record).
     with tempfile.TemporaryDirectory() as tmp:
         cls = _run(tmp)
         if not near(cls["Default"]["clearance"], 0.09):
             fails.append(f"[clamp] Default.clearance = {cls['Default'].get('clearance')}, expected 0.09")
+        if not near(cls["Default"]["track_width"], 0.0889):
+            fails.append(f"[clamp] Default.track_width = {cls['Default'].get('track_width')}, expected 0.0889")
         if not near(cls["Z100_inner"]["clearance"], 0.09):
             fails.append(f"[clamp] Z100_inner.clearance = {cls['Z100_inner'].get('clearance')}, expected 0.09 (should clamp)")
-        if not near(cls["Z100_inner"]["track_width"], 0.0889):
-            fails.append(f"[clamp] Z100_inner.track_width = {cls['Z100_inner'].get('track_width')}, expected 0.0889")
+        if not near(cls["Z100_inner"]["track_width"], 0.162):
+            fails.append(f"[clamp] Z100_inner.track_width = {cls['Z100_inner'].get('track_width')}, "
+                         "expected 0.162 preserved (declared geometry, not DRC-enforced; 6b971f1)")
 
     if fails:
         print("FAIL: " + "; ".join(fails))
         return 1
-    print("PASS: the standalone writeback clamps every net class (Default + impedance) "
-          "to the routed floor; --no-clamp-netclasses is gone (#439)")
+    print("PASS: the standalone writeback clamps every class's CLEARANCE to the "
+          "routed floor and preserves non-Default declared geometry (6b971f1); "
+          "--no-clamp-netclasses is gone (#439)")
     return 0
 
 

--- a/tests/test_obstacle_map_balance.py
+++ b/tests/test_obstacle_map_balance.py
@@ -53,7 +53,8 @@ def check(name, cond, detail=""):
         FAILS.append(name)
 
 
-def run_cmd(args, audit=True, ledger=False, tap_verify=False):
+def run_cmd(args, audit=True, ledger=False, tap_verify=False,
+            fragility_off=False):
     env = dict(os.environ)
     env.pop("KICAD_OBSTACLE_AUDIT", None)
     env.pop("KICAD_OBSTACLE_LEDGER", None)
@@ -64,6 +65,15 @@ def run_cmd(args, audit=True, ledger=False, tap_verify=False):
         env["KICAD_OBSTACLE_LEDGER"] = "1"
     if tap_verify:
         env["TAP_MAP_VERIFY"] = "1"
+    if fragility_off:
+        # The stage-1 churn recipe's last routing failure is cost-surface
+        # sensitive: with the #424 plane-fragility field priced from the
+        # EXACT KiCad fill (which depends on whether a KiCad python is
+        # discoverable on the machine), the failing MST edge routes and the
+        # recipe stops churning -- making the balance checks vacuous and the
+        # test environment-dependent. Pin the field off for that stage; the
+        # audit under churn is what this test exists to exercise.
+        env["KICAD_PLANE_FRAGILITY_COST"] = "0"
     p = subprocess.run([sys.executable, "-X", "utf8"] + args, cwd=ROOT_DIR,
                        env=env, capture_output=True, text=True, timeout=1200)
     return p.returncode, p.stdout + p.stderr
@@ -79,7 +89,7 @@ def main():
                        "--track-width", "0.8", "--clearance", "0.7",
                        "--via-size", "1.0", "--via-drill", "0.6",
                        "--layers", "F.Cu", "B.Cu", "--max-ripup", "10"],
-                      ledger=True)
+                      ledger=True, fragility_off=True)
     check("route.py: run completed", rc == 0, f"rc={rc}")
     rips = len(re.findall(r"[Rr]ipping|Extending to N", log))
     check("route.py: rip churn engaged (recipe still churns)", rips >= 1, f"rips={rips}")

--- a/tests/test_open_single_verdict.py
+++ b/tests/test_open_single_verdict.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""`open_single` -- routed-but-OPEN nets are COUNTED, not just named.
+
+A net can keep a result while its copper leaves pads disconnected (a near-miss
+stub). Before this key it landed in neither `routed_single` nor `failed_single`:
+its pads showed up in `failed_multipoint` (names only), but every verdict that
+counts failures -- converge.route_verdict, place_route_loop.metrics_from_summary
+-- read `len(failed_single) + pad-deficit`, and a NON-multipoint open net
+contributes to neither term. Probes read failures=0 on boards shipping open
+copper (run-7: failed_single [] while the oracle listed six opens).
+
+The contract under test:
+  * route.py emits `open_single` (always present; multipoint nets excluded --
+    their shortfall is already the pad deficit, so verdicts may add the terms).
+  * route_verdict and metrics_from_summary count it.
+  * Summaries WITHOUT the key (older logs) degrade to the old arithmetic.
+"""
+import inspect
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+
+
+def test_route_verdict_counts_open_single():
+    from converge import route_verdict
+    base = {'failed_single': ['A'], 'open_single': ['B'],
+            'failed_multipoint': [{'net_name': 'B', 'failed_pads': []}],
+            'multipoint_pads_total': 0, 'multipoint_pads_connected': 0}
+    n, note = route_verdict(base)
+    assert n == 2, f"failed A + open B must count 2, got {n} ({note})"
+    assert 'B' in note, "the open net's name must reach the note"
+
+    legacy = dict(base)
+    legacy.pop('open_single')
+    n_legacy, _ = route_verdict(legacy)
+    assert n_legacy == 1, (
+        "a summary without the key must degrade to the old arithmetic")
+    print("  PASS: route_verdict counts open_single (and degrades without it)")
+
+
+def test_route_verdict_no_double_count_with_pad_deficit():
+    """Multipoint opens are priced by the deficit; open_single excludes them by
+    contract, so a summary carrying both terms adds cleanly."""
+    from converge import route_verdict
+    s = {'failed_single': [], 'open_single': ['B'],
+         'failed_multipoint': [{'net_name': 'B', 'failed_pads': []},
+                               {'net_name': 'MP', 'failed_pads': []}],
+         'multipoint_pads_total': 10, 'multipoint_pads_connected': 7}
+    n, _ = route_verdict(s)
+    assert n == 4, f"open B (1) + pad deficit (3) must count 4, got {n}"
+    print("  PASS: open_single adds to the pad deficit without double-count")
+
+
+def test_metrics_from_summary_counts_open_single():
+    from place_route_loop import metrics_from_summary
+    s = {'failed_single': ['A'], 'open_single': ['B'],
+         'failed_multipoint': [{'net_name': 'B', 'failed_pads': []}],
+         'multipoint_pads_total': 0, 'multipoint_pads_connected': 0,
+         'blockers': []}
+    m = metrics_from_summary(s)
+    assert m['failures'] == 2, f"expected 2 failures, got {m['failures']}"
+    assert m['failed_nets'].count('B') == 1, (
+        "the open net is a target exactly once (via failed_multipoint)")
+
+    legacy = dict(s)
+    legacy.pop('open_single')
+    assert metrics_from_summary(legacy)['failures'] == 1
+    print("  PASS: metrics_from_summary counts open_single")
+
+
+def test_route_py_classification_has_the_third_bucket():
+    """Source-level: the scope loop must classify kept-result broken nets."""
+    import route
+    src = inspect.getsource(route.batch_route)
+    m = re.search(r"for net_name, net_id in single_ended_nets:(.*?)\n\n",
+                  src, re.S)
+    assert m, "the summary classification loop moved -- update this test"
+    loop = m.group(0)
+    assert 'open_single.append' in loop, (
+        "a net with a result but broken pads must land in open_single, "
+        "not fall through unclassified")
+    assert 'is_multipoint' in loop, (
+        "multipoint nets must be excluded from open_single (their shortfall "
+        "is already the pad deficit -- counting both double-charges)")
+    assert "'open_single': open_single" in src, (
+        "the summary dict must carry the key")
+    print("  PASS: route.py classifies the routed-but-OPEN bucket")
+
+
+def test_end_to_end_key_present_and_clean():
+    """A real run emits the key (empty on a clean route)."""
+    board = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
+    if not os.path.isfile(board):
+        print("  SKIP: fixture missing")
+        return
+    with tempfile.TemporaryDirectory() as td:
+        js = os.path.join(td, 's.json')
+        out = os.path.join(td, 's.kicad_pcb')
+        r = subprocess.run([sys.executable, '-X', 'utf8',
+                            os.path.join(ROOT, 'route.py'), board, out,
+                            '--nets', 'GND', '--json-out', js],
+                           capture_output=True, text=True, encoding='utf-8',
+                           errors='replace', cwd=ROOT)
+        assert r.returncode == 0, r.stdout[-2000:]
+        summary = json.load(open(js, encoding='utf-8'))
+        assert 'open_single' in summary, (
+            "open_single must always be present so verdict consumers can "
+            "rely on it (absent = pre-key log, not 'clean')")
+        assert summary['open_single'] == [], (
+            f"clean GND route reported open nets: {summary['open_single']}")
+    print("  PASS: real run emits open_single (empty when clean)")
+
+
+if __name__ == '__main__':
+    fns = [v for k, v in sorted(globals().items()) if k.startswith('test_')]
+    for fn in fns:
+        print(f"--- {fn.__name__}")
+        fn()
+    print("ALL PASS")

--- a/tests/test_place_seed.py
+++ b/tests/test_place_seed.py
@@ -102,5 +102,22 @@ with tempfile.TemporaryDirectory() as d:
     check("seeded board assesses as PLACED", not st.unplaced,
           '; '.join(st.reasons))
 
+    # sibling carry (d310ab3 regression): the seeder is the FIRST step that
+    # touches the board, so a dropped .kicad_pro propagates a stock-netclass
+    # floor through the whole chain (#441 class). Give the pile siblings and
+    # the output must get them too.
+    with open(os.path.join(d, 'pile.kicad_pro'), 'w', encoding='utf-8') as f:
+        json.dump({'net_settings': {'classes': [
+            {'name': 'Default', 'clearance': 0.15}]}}, f)
+    with open(os.path.join(d, 'pile.kicad_dru'), 'w', encoding='utf-8') as f:
+        f.write('(version 1)\n')
+    out_s = os.path.join(d, 's.kicad_pcb')
+    r = run([seed_py, pile, out_s, '--intent', intent_path])
+    check("sibling run exits 0", r.returncode == 0)
+    check("seed output carries the .kicad_pro sibling",
+          os.path.isfile(os.path.join(d, 's.kicad_pro')))
+    check("seed output carries the .kicad_dru sibling",
+          os.path.isfile(os.path.join(d, 's.kicad_dru')))
+
 print(f"\n{passed}/{passed + failed} checks passed")
 sys.exit(1 if failed else 0)

--- a/tests/test_plane_score.py
+++ b/tests/test_plane_score.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Plane fragility as a placement score (--plane-score, #118 follow-up).
+
+The candidate score was plane-blind: crossings/hpwl/inversions are signal
+proxies, while a placement that splits the ground pour or squeezes it through
+necks loses at the PLANE step -- and #424 already prices exact fill damage
+router-side. Contract under test:
+
+  * plane_score.plane_fragility_score pours the named nets on a scratch copy
+    and reduces the KiCad fill to (islands, neck_sum) -- honest None when no
+    KiCad python exists;
+  * rank_key orders plane_islands BEFORE hpwl (a split pour is a measured
+    loss, hpwl is a proxy) and plane_neck after it (tiebreak);
+  * absent metrics leave the ranking exactly as before (flag off = inert).
+"""
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+
+from placement.portfolio import Candidate, rank_key  # noqa: E402
+
+BOARD = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
+
+
+def _cand(index, crossings=10, hpwl=100.0, **extra):
+    c = Candidate(index=index, strategy='jitter', board='b.kicad_pcb')
+    c.metrics = dict({'crossings': crossings, 'inversions': 0, 'hpwl': hpwl},
+                     **extra)
+    return c
+
+
+def test_parse_plane_specs():
+    from plane_score import parse_plane_specs
+    specs = parse_plane_specs(['GND', '3V3:F.Cu'], ['F.Cu', 'B.Cu'])
+    assert specs == [('GND', 'B.Cu'), ('3V3', 'F.Cu')], specs
+    print("  PASS: bare net pours the last copper layer; NET:LAYER explicit")
+
+
+def test_islands_outrank_hpwl():
+    whole = _cand(1, hpwl=120.0, plane_islands=1, plane_neck=50.0)
+    split = _cand(2, hpwl=100.0, plane_islands=2, plane_neck=50.0)
+    assert rank_key(whole) < rank_key(split), (
+        "a split pour must rank below a whole one even at better hpwl -- "
+        "a measured plane loss outranks a proxy")
+    print("  PASS: plane_islands ranks before hpwl")
+
+
+def test_neck_breaks_hpwl_ties_only():
+    a = _cand(1, hpwl=100.0, plane_islands=1, plane_neck=40.0)
+    b = _cand(2, hpwl=100.0, plane_islands=1, plane_neck=90.0)
+    assert rank_key(a) < rank_key(b), "equal hpwl: fewer necks wins"
+    c = _cand(1, hpwl=90.0, plane_islands=1, plane_neck=500.0)
+    d = _cand(2, hpwl=100.0, plane_islands=1, plane_neck=1.0)
+    assert rank_key(c) < rank_key(d), "hpwl still outranks the neck sum"
+    print("  PASS: plane_neck is a below-hpwl tiebreak")
+
+
+def test_absent_metrics_leave_ranking_unchanged():
+    a = _cand(1, hpwl=100.0)
+    b = _cand(2, hpwl=110.0)
+    assert rank_key(a) < rank_key(b)
+    assert rank_key(a)[2] == 0, "no --plane-score -> islands term is 0"
+    print("  PASS: flag off is inert")
+
+
+def test_portfolio_flag_exists():
+    import place_portfolio
+    p = place_portfolio.build_parser()
+    a = p.parse_args([BOARD, '--out-dir', 'x',
+                      '--plane-score', 'GND', '--plane-score-budget', '60'])
+    assert a.plane_score == ['GND'] and a.plane_score_budget == 60.0
+    print("  PASS: --plane-score / --plane-score-budget parse")
+
+
+def test_score_smoke_on_splitflap():
+    from kicad_exact_fill import find_kicad_python
+    if find_kicad_python() is None:
+        print("  SKIP: no KiCad python for the refill")
+        return
+    if not os.path.isfile(BOARD):
+        print("  SKIP: fixture missing")
+        return
+    from plane_score import plane_fragility_score
+    sc = plane_fragility_score(BOARD, [('GND', 'B.Cu')])
+    assert sc is not None, "refill available but score came back None"
+    assert sc['islands'] >= 1 and sc['neck_sum'] > 0, sc
+    assert 'GND:B.Cu' in sc['per_net']
+    print(f"  PASS: splitflap GND pour scored "
+          f"(islands={sc['islands']}, neck={sc['neck_sum']})")
+
+
+if __name__ == '__main__':
+    fns = [v for k, v in sorted(globals().items()) if k.startswith('test_')]
+    for fn in fns:
+        print(f"--- {fn.__name__}")
+        fn()
+    print("ALL PASS")

--- a/tests/test_portfolio_rule1.py
+++ b/tests/test_portfolio_rule1.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""The portfolio applies rule 1 of the acceptance conjunction, K-way.
+
+Run-7 S6: SKILL.md claimed the portfolio "pre-applies the first two
+[acceptance-rule parts] as its hard gates". As measured, the hard gates were
+legality + intent only -- the METRIC clause (crossings/hpwl no worse than the
+baseline) was never checked, and a candidate worse on both proxies could top
+the slate and ship through JSON_SUMMARY['best'] unremarked.
+
+Contract under test:
+  * rule1_check is pure and per-candidate-vs-baseline;
+  * select_best never silently picks a violator (probe rank outranks static;
+    the baseline always passes against itself; all-violators -> None);
+  * violators are ANNOTATED (gates.rule1 + doc.rule1_violators), not gated --
+    they stay ranked and probed;
+  * --full-probe exists, and probe rows are labeled with probe_kind.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+
+from placement.portfolio import Candidate, rule1_check, select_best  # noqa: E402
+
+BOARD = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
+
+
+def _cand(index, crossings, hpwl, board='b.kicad_pcb'):
+    c = Candidate(index=index, strategy='jitter', board=board)
+    c.metrics = {'crossings': crossings, 'hpwl': hpwl}
+    return c
+
+
+def test_rule1_check_measures_against_the_baseline_row():
+    base = _cand(0, 50, 600.0)
+    assert rule1_check(_cand(1, 45, 590.0), base) == []
+    assert rule1_check(_cand(2, 50, 600.0), base) == [], "equal is no worse"
+    v = rule1_check(_cand(3, 60, 590.0), base)
+    assert len(v) == 1 and 'crossings' in v[0], v
+    v = rule1_check(_cand(4, 45, 700.0), base)
+    assert len(v) == 1 and 'hpwl' in v[0], v
+    v = rule1_check(_cand(5, 60, 700.0), base)
+    assert len(v) == 2, f"worse on both must list both: {v}"
+    print("  PASS: rule1_check prices both proxies against the baseline")
+
+
+def test_select_best_never_silently_picks_a_violator():
+    # Window probe ranked a violator first: best skips to the next passer.
+    assert select_best([3, 1, 2], [1, 2, 3], {3}) == 1
+    # Probe ranking outranks static.
+    assert select_best([2, 1], [1, 2], set()) == 2
+    # The baseline (0) always passes -- "keep what you have" is first-class.
+    assert select_best([0, 3], [3], {3}) == 0
+    # Everything ranked violates -> None (caller falls back to baseline).
+    assert select_best([3, 4], [4, 3], {3, 4}) is None
+    # No probe tier: first static passer.
+    assert select_best([], [5, 6], {5}) == 6
+    print("  PASS: select_best skips violators, probe outranks static")
+
+
+def test_full_probe_flag_and_labels_exist():
+    import place_portfolio
+    p = place_portfolio.build_parser()
+    a = p.parse_args([BOARD, '--out-dir', 'x', '--full-probe'])
+    assert a.full_probe is True
+    src = open(os.path.join(ROOT, 'place_portfolio.py'), encoding='utf-8').read()
+    assert "probe_kind" in src and "'full'" in src, (
+        "probe rows must be labeled window vs full")
+    assert "ranking_full" in src
+    print("  PASS: --full-probe flag + probe_kind labels present")
+
+
+def test_end_to_end_annotation_reaches_portfolio_json():
+    if not os.path.isfile(BOARD):
+        print("  SKIP: fixture missing")
+        return
+    with tempfile.TemporaryDirectory() as d:
+        out = os.path.join(d, 'pf')
+        r = subprocess.run(
+            [sys.executable, '-X', 'utf8',
+             os.path.join(ROOT, 'place_portfolio.py'), BOARD,
+             '--out-dir', out, '--seed', '0', '--candidates', '3',
+             '--keep', '1', '--route-top', '0', '--no-render'],
+            capture_output=True, text=True, encoding='utf-8',
+            errors='replace', cwd=ROOT,
+            env=dict(os.environ, PYTHONIOENCODING='utf-8'))
+        assert r.returncode in (0, 4), (r.stdout + r.stderr)[-500:]
+        doc = json.load(open(os.path.join(out, 'portfolio.json'),
+                             encoding='utf-8'))
+        assert 'rule1_violators' in doc, "doc must annotate rule-1 violators"
+        assert 'ranking_full' in doc
+        for c in doc['candidates']:
+            if c['board']:
+                assert 'rule1' in c['gates'], (
+                    f"cand {c['index']} missing gates.rule1")
+        line = next(l for l in r.stdout.splitlines()
+                    if l.startswith('JSON_SUMMARY:'))
+        s = json.loads(line.split(':', 1)[1])
+        assert 'rule1_excluded' in s and 'probe_kind' in s
+        best = s['best']
+        if best is not None and best != 0:
+            assert best not in s['rule1_excluded'], (
+                f"best={best} is a rule-1 violator -- the S6 bug is back")
+    print("  PASS: rule-1 annotation + summary keys survive a real run")
+
+
+if __name__ == '__main__':
+    fns = [v for k, v in sorted(globals().items()) if k.startswith('test_')]
+    for fn in fns:
+        print(f"--- {fn.__name__}")
+        fn()
+    print("ALL PASS")

--- a/tests/test_rip_restore_verdict.py
+++ b/tests/test_rip_restore_verdict.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Terminal rip-restore must not claim success for copper that isn't connected.
+
+Run-7 E2: a rip victim's terminal restore graded the saved payload only for
+CLEARANCE conflicts. A payload that was partial (recorded off an already-broken
+net, or one whose copper never covered every pad) restored cleanly, printed a
+success line, and counted `successful += 1` -- the run reported a routed net
+that shipped open.
+
+Contract under test:
+  * try_terminal_restore returns 'full' only when the post-restore state also
+    GRADES CONNECTED (authoritative union-find), 'full_open' when conflict-free
+    but broken;
+  * the stub path's message says the net remains UNROUTED (it used to read
+    like a success);
+  * both reroute_loop call sites count success only on 'full' and record the
+    outcome in state.terminal_restores;
+  * route.py folds broken outcomes into the coverage-gate disturbed set (a
+    full restore unwinds the stale-strip signal the gate otherwise keys on)
+    and exports summary['terminal_restores'].
+"""
+import contextlib
+import inspect
+import io
+import os
+import sys
+from types import SimpleNamespace
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+
+from kicad_parser import BoardInfo, Net, Pad, PCBData, Segment  # noqa: E402
+from rip_restore import try_terminal_restore  # noqa: E402
+
+
+def _pad(x, y, net_id, name, ref='U1', num='1'):
+    return Pad(component_ref=ref, pad_number=num, global_x=x, global_y=y,
+               local_x=0.0, local_y=0.0, size_x=1.0, size_y=1.0,
+               shape='rect', layers=['F.Cu'], net_id=net_id, net_name=name,
+               pad_type='smd')
+
+
+def _board(extra_segments=()):
+    pads = [_pad(0.0, 0.0, 1, 'N1', num='1'), _pad(5.0, 0.0, 1, 'N1', num='2')]
+    pcb = PCBData(
+        board_info=BoardInfo(layers={0: 'F.Cu'}, copper_layers=['F.Cu']),
+        nets={1: Net(1, 'N1', pads), 2: Net(2, 'N2')},
+        footprints={},
+        vias=[],
+        segments=list(extra_segments),
+        pads_by_net={1: pads})
+    return pcb
+
+
+def _seg(x1, y1, x2, y2, net_id, width=0.2):
+    return Segment(start_x=x1, start_y=y1, end_x=x2, end_y=y2,
+                   width=width, layer='F.Cu', net_id=net_id)
+
+
+CONFIG = SimpleNamespace(clearance=0.2)
+
+
+def test_connected_payload_is_full():
+    pcb = _board()
+    pcb._rip_saved = {1: ({'new_segments': [_seg(0, 0, 5, 0, 1)],
+                           'new_vias': []}, {1}, True)}
+    assert try_terminal_restore(pcb, CONFIG, 1) == 'full'
+    print("  PASS: conflict-free AND connected payload -> 'full'")
+
+
+def test_partial_payload_is_full_open_not_full():
+    """The E2 lie: conflict-free copper that never reaches pad 2."""
+    pcb = _board()
+    pcb._rip_saved = {1: ({'new_segments': [_seg(0, 0, 2, 0, 1)],
+                           'new_vias': []}, {1}, True)}
+    verdict = try_terminal_restore(pcb, CONFIG, 1)
+    assert verdict == 'full_open', (
+        f"a payload leaving pad 2 disconnected must grade 'full_open', "
+        f"got {verdict!r} -- restoring it as 'full' ships an open net "
+        f"counted as routed")
+    print("  PASS: partial payload -> 'full_open', never 'full'")
+
+
+def test_stub_message_says_unrouted():
+    """Foreign copper blocks the full restore; only the pad-A stub survives.
+    The message must read as a failure, not a success."""
+    blocker = _seg(2.5, -1.0, 2.5, 1.0, 2)
+    pcb = _board(extra_segments=[blocker])
+    pcb._rip_saved = {1: ({'new_segments': [_seg(0, 0, 1, 0, 1),
+                                            _seg(1, 0, 5, 0, 1)],
+                           'new_vias': []}, {1}, True)}
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        verdict = try_terminal_restore(pcb, CONFIG, 1)
+    assert verdict == 'stub', f"expected 'stub', got {verdict!r}"
+    out = buf.getvalue()
+    assert 'UNROUTED' in out, (
+        f"the stub print must say the net remains UNROUTED, got: {out!r}")
+    print("  PASS: stub path inserts the stub and says UNROUTED")
+
+
+def test_reroute_loop_counts_success_only_on_full():
+    import reroute_loop
+    src = inspect.getsource(reroute_loop)
+    n_sites = src.count("try_terminal_restore(")
+    assert n_sites >= 2, "expected both (single + pair) terminal-restore sites"
+    assert src.count("_tr in ('full', 'full_open')") >= 2, (
+        "both call sites must restore on 'full_open' (more copper than "
+        "nothing) while refusing the success claim")
+    assert src.count('state.terminal_restores[') >= 4, (
+        "both call sites must record outcomes in state.terminal_restores "
+        "(single net + both pair members, full and stub paths)")
+    print("  PASS: reroute_loop counts success only on 'full' and records outcomes")
+
+
+def test_route_py_exports_and_gates_terminal_restores():
+    import route
+    src = inspect.getsource(route.batch_route)
+    assert "summary['terminal_restores']" in src, (
+        "route.py must export terminal-restore outcomes additively")
+    m_cov = src.find('_cov_disturbed = (')
+    assert m_cov != -1
+    cov_block = src[m_cov:m_cov + 900]
+    assert 'terminal_restores' in cov_block, (
+        "broken terminal restores must join the coverage-gate disturbed set "
+        "-- a full restore unwinds the stale-strip signal the gate keys on")
+    print("  PASS: route.py gates and exports terminal restores")
+
+
+if __name__ == '__main__':
+    fns = [v for k, v in sorted(globals().items()) if k.startswith('test_')]
+    for fn in fns:
+        print(f"--- {fn.__name__}")
+        fn()
+    print("ALL PASS")

--- a/tests/test_seeder_partner_centroid.py
+++ b/tests/test_seeder_partner_centroid.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""_partner_centroid votes once per (partner footprint, net), not per pad.
+
+Run-7 root cause for the backwards 27R pair: the centroid averaged PADS, so a
+partner with duplicated pins outvoted one with a single pin. A USB-C
+receptacle's doubled A6/B6 DP pads pulled the series resistors 2:1 toward the
+connector; R7 seated 15.3mm from the U1 face the intent named ("against U1's
+west face"), and the run spent an iteration re-seating the pair by hand.
+"""
+import os
+import sys
+from types import SimpleNamespace
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+
+from placement.seeder import _partner_centroid  # noqa: E402
+
+
+def _part(nets, pads):
+    """pads: list of (x, y, net_id)."""
+    return SimpleNamespace(nets=set(nets), pad_globals=lambda: list(pads))
+
+
+def test_duplicated_pads_no_longer_outvote():
+    # J1: USB-C style, TWO pads on net 1 (A6+B6 mirror). U1: ONE pad on net 1.
+    state = SimpleNamespace(
+        parts={
+            'R7': _part([1], [(20.0, 5.0, 1)]),
+            'J1': _part([1], [(0.0, 0.0, 1), (0.0, 10.0, 1)]),
+            'U1': _part([1], [(10.0, 5.0, 1)]),
+        },
+        net_refs={1: ('R7', 'J1', 'U1')})
+    c = _partner_centroid(state, 'R7', placed={'J1', 'U1'})
+    assert c is not None
+    x, y = c
+    # One vote each: J1 votes (0, 5), U1 votes (10, 5) -> centroid (5, 5).
+    # Per-pad voting gave ((0+0+10)/3, (0+10+5)/3) = (3.33, 5): biased 2:1
+    # toward the connector.
+    assert abs(x - 5.0) < 1e-9, (
+        f"expected x=5.0 (one vote per partner), got {x:.3f} -- per-pad "
+        f"voting bias is back")
+    assert abs(y - 5.0) < 1e-9
+    print("  PASS: duplicated pads collapse to one vote per partner")
+
+
+def test_multi_net_partner_still_votes_per_net():
+    """A partner sharing TWO nets with the part legitimately votes twice --
+    once per net -- because each net is its own pull."""
+    state = SimpleNamespace(
+        parts={
+            'C1': _part([1, 2], [(0.0, 0.0, 1), (0.0, 1.0, 2)]),
+            'U1': _part([1, 2], [(4.0, 0.0, 1), (8.0, 0.0, 2)]),
+        },
+        net_refs={1: ('C1', 'U1'), 2: ('C1', 'U1')})
+    x, y = _partner_centroid(state, 'C1', placed={'U1'})
+    assert abs(x - 6.0) < 1e-9, f"two per-net votes (4+8)/2=6, got {x}"
+    print("  PASS: one vote per (partner, net), so shared nets each pull")
+
+
+def test_fanout_and_empty_cases_unchanged():
+    state = SimpleNamespace(
+        parts={'R1': _part([1], [(0.0, 0.0, 1)]),
+               'U1': _part([1], [(5.0, 0.0, 1)])},
+        net_refs={1: tuple(f'P{i}' for i in range(30))})  # >max_fanout
+    assert _partner_centroid(state, 'R1', placed={'U1'}) is None
+    assert _partner_centroid(state, 'MISSING', placed=set()) is None
+    print("  PASS: fanout exclusion and missing-ref cases unchanged")
+
+
+if __name__ == '__main__':
+    fns = [v for k, v in sorted(globals().items()) if k.startswith('test_')]
+    for fn in fns:
+        print(f"--- {fn.__name__}")
+        fn()
+    print("ALL PASS")

--- a/tests/test_via_dedup_stacked.py
+++ b/tests/test_via_dedup_stacked.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Run-7 E3: stacked duplicate vias must be deduped, and what survives must
+be DISCLOSED.
+
+Failed/partial attempts could leave a result emitting a via at the exact
+position/span of a surviving input via (or another result's via for the same
+net): two barrels in one hole. KiCad's DRC permits same-net stacks, so nothing
+flagged them -- the stacks shipped and read as parser/net rot when the raw
+file was inspected (run-7 spent a scare on exactly that).
+
+Contract under test:
+  * check_weird.stacked_copper_over_model reports coincident same-net vias
+    and duplicate same-net segments over a per-net write model;
+  * route.py runs a same-net via dedup BEFORE total_vias / the authoritative
+    sweep (so tally, sweep, writer and GUI results agree) and exports
+    summary['stacked_copper'] for what remains;
+  * a clean run emits no stacked_copper key.
+"""
+import inspect
+import json
+import os
+import re
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+
+from kicad_parser import Segment, Via  # noqa: E402
+
+
+def _via(x, y, net_id):
+    return Via(x=x, y=y, size=0.6, drill=0.3, layers=['F.Cu', 'B.Cu'],
+               net_id=net_id)
+
+
+def _seg(x1, y1, x2, y2, net_id):
+    return Segment(start_x=x1, start_y=y1, end_x=x2, end_y=y2,
+                   width=0.2, layer='F.Cu', net_id=net_id)
+
+
+def test_model_check_reports_stacked_vias_and_segments():
+    from check_weird import stacked_copper_over_model
+    segs = {1: [_seg(0, 0, 5, 0, 1), _seg(0, 0, 5, 0, 1)]}   # exact duplicate
+    vias = {1: [_via(2, 2, 1), _via(2.005, 2, 1)],           # 5um apart: stacked
+            2: [_via(10, 10, 2)]}                            # lone via: clean
+    found = stacked_copper_over_model(segs, vias, lambda n: f'N{n}')
+    cats = sorted(f['category'] for f in found)
+    assert cats == ['stacked-copper', 'stacked-copper'], (
+        f"expected one via stack + one segment stack, got {found}")
+    nets = {f['net'] for f in found}
+    assert nets == {'N1'}, f"the lone via on N2 must not be flagged: {nets}"
+    print("  PASS: model check reports stacked vias + duplicate segments")
+
+
+def test_far_apart_vias_are_not_stacked():
+    from check_weird import stacked_copper_over_model
+    vias = {1: [_via(2, 2, 1), _via(2.5, 2, 1)]}  # 0.5mm apart: a real pair
+    found = stacked_copper_over_model({}, vias, lambda n: f'N{n}')
+    assert found == [], f"0.5mm-apart same-net vias are legitimate: {found}"
+    print("  PASS: separated same-net vias stay unflagged")
+
+
+def test_route_py_dedups_before_tally_and_sweep():
+    import route
+    src = inspect.getsource(route.batch_route)
+    i_dedup = src.find('VIA DEDUP')
+    i_tally = src.find('total_vias = sum(')
+    i_sweep = src.find('_sweep_strip_via_ids =')
+    i_stacked = src.find('STACKED-COPPER SURFACING')
+    assert -1 not in (i_dedup, i_tally, i_sweep, i_stacked), (
+        "dedup / tally / sweep / surfacing blocks not all present")
+    assert i_dedup < i_tally < i_sweep < i_stacked, (
+        "the dedup must run BEFORE the via tally and the authoritative sweep "
+        "so tally, sweep, writer and GUI results all see the deduped copper")
+    assert re.search(r"net_id.*layers", src[i_dedup:i_tally], re.S), (
+        "the dedup key must be same-net and same-span -- cross-net "
+        "coincidence is a real short the DRC sweep owns, never dedup it")
+    assert "summary['stacked_copper']" in src
+    print("  PASS: route.py dedups before tally/sweep and exports the key")
+
+
+def test_end_to_end_clean_run_has_no_stacked_key():
+    board = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
+    if not os.path.isfile(board):
+        print("  SKIP: fixture missing")
+        return
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        js = os.path.join(td, 's.json')
+        out = os.path.join(td, 's.kicad_pcb')
+        r = subprocess.run([sys.executable, '-X', 'utf8',
+                            os.path.join(ROOT, 'route.py'), board, out,
+                            '--nets', 'GND', '--json-out', js],
+                           capture_output=True, text=True, encoding='utf-8',
+                           errors='replace', cwd=ROOT)
+        assert r.returncode == 0, r.stdout[-2000:]
+        summary = json.load(open(js, encoding='utf-8'))
+        assert 'stacked_copper' not in summary, (
+            f"clean run reported stacks: {summary.get('stacked_copper')}")
+    print("  PASS: clean run ships no stacked_copper key")
+
+
+if __name__ == '__main__':
+    fns = [v for k, v in sorted(globals().items()) if k.startswith('test_')]
+    for fn in fns:
+        print(f"--- {fn.__name__}")
+        fn()
+    print("ALL PASS")


### PR DESCRIPTION
Run 7 was the first clean-slate run whose placement the skill generated from spec pins alone (test-board `p9-layout-run7`, not promoted — 6 open nets, a measured west-fan capacity finding). Its audit produced 21 findings across three watcher passes, three documented engine defects with repros, and two mid-run tools worth promoting. This PR is that audit turned into code, plus a 7-agent post-wave investigation that root-caused every remaining test failure on the branch — and fixed the two real defects it found.

## The engine stops lying (all inside `batch_route`, GUI-parity free)

Run 7 shipped six open nets while every failure tally read zero. Three defects, each with the run-7 repro:

- **`open_single`** — a net with a KEPT result whose pads are still disconnected landed in neither `routed_single` nor `failed_single`, and a non-multipoint one contributed to NO count: probes read `failures=0` on open boards. New always-present summary key (multipoint excluded — its shortfall is already the pad deficit), counted by `converge.route_verdict` and `place_route_loop.metrics_from_summary`, last-wins in `merge_summaries`.
- **Terminal rip-restores are graded before they claim success** — a restore checked CLEARANCE only, so a partial payload restored cleanly, printed success, and counted `successful += 1`. Now the post-restore state runs the authoritative union-find: `full` requires connected, `full_open` restores the copper but refuses the claim, the stub print says the net remains UNROUTED, and outcomes ship as `summary[terminal_restores]` + feed the coverage gate (a restore unwinds the stale-strip signal the gate keys on).
- **Via dedup + `stacked_copper`** — failed attempts left byte-duplicate vias stacked in one hole; KiCad permits same-net stacks so no DRC ever flags them (run 7 spent a debugging scare on exactly that). Same-net/same-span dedup runs before the via tally and the authoritative sweep so tally, sweep, writer and GUI see identical copper; what still stacks is censused by the new `check_weird.stacked_copper_over_model` and disclosed.

## Instruments grade at the board's own floor, and the ledger grows guards

- `converge poses` and `check_floorplan` resolved unset clearance knobs from fixed constants (0.25/0.55) — stricter than a 0.15/0.3 board's own spec, so poses vetoed legal rotations (including flip-in-place, which WAS enumerated then silently dropped) and check_floorplan manufactured a phantom 5th out-of-board part against a budget of 4. Both now resolve from the board (shared `list_nets.board_floor_knobs`), disclose value + source in JSON, and `rank_poses` censuses dropped poses (`dropped_in_place`).
- `converge record` refuses an `--argv` that can never replay (run 7's endgame recorded `["python3","-X","utf8","dummy"]`), requires `--stop-condition` with `--final`, and nags when a score carries `failures` without `failed_nets`.

## Placement: rank the seeds, verify the conjunction, see the planes

- **`_partner_centroid` votes once per (partner footprint, net)** — per-pad voting let the USB-C receptacle's doubled A6/B6 pads pull the 27R series pair 2:1 toward the connector; run 7 found R7 seated 15.3 mm from the U1 face the intent named.
- **`compare_seeds.py`** (new CLI) — the seed-axis comparator run 7 hand-rolled. Crossings cannot rank seeds (measured: they ranked seed 0 first; identical full-board probes measured seed 2 at 39 failures vs 53, and the run shipped on seed 2). Per seed: place_seed (an intent-gate failure is recorded, never ranked) → one identical full-board probe → ranked table + `seeds.json` + `best_seed`.
- **Rule 1 of the acceptance conjunction, enforced** — the skill claimed the portfolio "pre-applies metrics-no-worse as a hard gate"; as measured, a candidate with crossings 74 vs baseline 67 (hpwl also worse) topped `ranking_routed`. New `rule1_check`/`select_best`: violators are annotated (`gates.rule1`, `rule1_violators`) and barred from the silent `best` pick (baseline fallback), while staying ranked and probed.
- **`--full-probe`** — a candidate can win its shared window while losing the board (measured: window-best 14 failures, same board full-probed 52 vs baseline 41 — verdict reversed). Routes the whole board on baseline + window winner; that verdict outranks the window; `probe_kind` labels which instrument produced the ranking.
- **`--plane-score`** (#118's sharpest gap: the candidate score was plane-blind while #424 prices exact fill damage router-side) — new `plane_score.py` pours the declared nets on a scratch copy (ZONE_FILLER refill) and folds (islands, neck-sum) into `rank_key`: islands before hpwl (a split pour is a measured loss; hpwl is a proxy), neck-sum after it as a tiebreak. All-or-nothing coverage; inert without the flag. Calibrated honestly on run 7's archived seeds: **inert on the board's real B.Cu pour** (no back-side parts pre-route), directionally supportive on a hypothetical shared-layer pour — recorded in the test-board journal as not-yet-validated, with the roadmap for channels/#411/heatmap in `docs/placement-optimization.md`.

## `check_join.py` — the hand-join verifier, promoted

Run 7's endgame authored hand micro-copper verified against its target pads only; kicad-cli later found **42 shorts** in it, and the run built a verifier mid-recovery. The promotion stages the candidate polyline+vias onto a copy of the board and diffs the REAL `check_drc` engine (netclass pairwise clearances, `.kicad_dru` layers, rotated pads, board edge, hole-to-hole) — plus the join-specific checks DRC deliberately omits: layer changes without a `via:` (missing-via) and same-net via stacks. The test fixture carries a 45°-rotated pad whose true corner sticks 0.06 mm past its AABB — the exact class the prototype graded clean.

## Skill: 15 audit edits in three commits

Rung 8 grows from three hard conditions to five (verifier-before-first-segment; re-gate EVERY edit; lock hand copper `(locked yes)` at authoring + commit it constrained-FIRST — the rebuild that did closed at 0 shorts where the reverse order authored 42), and the NO-JOIN exit becomes a four-part gate whose absence downgrades the claim to a hypothesis (run 7's west-fan claim is the worked example). The trust order becomes a MODE: after the first confirmed model lie, the oracle's `--pairs-json` is the only open-set for that board's remainder. Ledger doctrine: probe records carry failing-net NAMES for candidate AND baseline; never head/tail an oracle listing (the run's close-out shipped "5 opens" off a `tail -5` while the oracle printed 6). Plus the seeding/portfolio corrections (S1–S13) and four short #118 notes (part-class taxonomy, width-vs-pitch feasibility at spec time, pour continuity as first-class work, the human-hand-route tooling-vs-placement discriminator).

## The post-wave investigation (7 agents), and its fixes

Full-suite run: 280 passed, 8 failed. Every failure was root-caused; none was caused by the wave (two were its side effects on a churn recipe, see below). The two REAL defects found are fixed here:

| finding | verdict | fix |
|---|---|---|
| test_432 scenario C | **engine defect** (d73b1d6): #545 island launch indexed the fresh island map with Phase-1's stale component ids — the collision seeded route sources on the target's own island, A* popped the goal on iteration 1, and a zero-length phantom "routed" edge suppressed the failure record, rip cascade and orphan fallback | both lookups now use the fresh `_p3_comps` labeling; 35/35 + `test_component_multipoint` green |
| test_tigard_usb_diff | **over-broad #514 audit** (c501a80): `member_audit_mismatch` fired for `partial` pairs, demoting every pair with a by-design peeled leg (tigard's redundant J1 row) while its trunk coupled and its board finished clean | `partial` dropped from the mismatch tuple — it already declares its opens; peaksat-class `coupled`-with-opens still demotes; 12/12 |
| test_obstacle_map_balance (via-map check) | **audit false positive**, latent upstream: restored rip-victims' vias were stamped into the audit's reference AGAIN at snapped-centre session pricing, flagging the correctly-maintained map as under-blocked by one boundary cell | `from_restore` filtered at both consumers (Step-7 blocking + audit); filtering only one flips the report to the mirror-image leak, so both are required |
| test_obstacle_map_balance (churn checks) | recipe drift: this wave's Windows KiCad-python discovery fix let the #424 exact-fill fragility field price the recipe's board, its last failing edge routed, and the churn vanished | the stage-1 recipe pins `KICAD_PLANE_FRAGILITY_COST=0` — churn restored, machine-independent |
| test_493 | **1-nm CLI/GUI divergence**: the castellated-retract GUI twin used truncating `pcbnew.FromMM` (~2% of 4-decimal coordinates land 1 nm low vs the CLI's text write) | `mm_to_iu`, like every other GUI apply path |
| test_459 / test_netclass_clamp | test drift behind two deliberate engine changes (f38204e rail tethering; 6b971f1 declared-geometry preservation) | assertions re-pinned to the current, correct contracts |
| test_kit_route | Windows path mangling: `shlex.split` eats backslashes, so the test silently wrote into the repo root | forward-slash relpaths |

## Verification

- New tests per item: `test_open_single_verdict`, `test_rip_restore_verdict`, `test_via_dedup_stacked`, `test_converge_pose_knobs`, `test_seeder_partner_centroid`, `test_portfolio_rule1`, `test_compare_seeds`, `test_check_join`, `test_plane_score`; extended: `test_converge`, `test_549_floorplan_cli`, `test_place_seed` (sibling-carry regression).
- Full suite: 280 passed pre-fixes with all 8 failures dispositioned above and green after the fixes (compare_seeds/kit_route re-verified standalone; their run_all-only failures were parallel-load artifacts).
- Parity: `test_manifest_plan_parity` and `test_cli_postpass_coverage` untouched-green; `test_gui_engine_parity` VERDICT PARITY, copper sets IDENTICAL (segments 1307/1307, vias 144/144) — the via dedup behaves identically on both fronts. `.gui-parity-checked` updated. `find_kicad_python` now probes versioned Windows installs (`C:\Program Files\KiCad\10.0\...`) — the versionless path matched nothing, silently disabling every exact-fill consumer on standard Windows installs.
- Windows test-infra repairs along the way: the `converge record` round-trip used bash-builtin `echo` as its `--argv`; `test_431_round_sidecar` pinned a pre-#549 argument list; two stale pins in `test_431_skill_commands` (`parent_board`/`stopped_by` never existed in any writer).

Sibling test-board PR-less commits (same session, `p9-layout-run7`): the corrected `nc_after_xtal.json` (the pad-inclusive 0.45 double-enforced the dru's track rule and sealed the east-face rail pins), PCB14 ratchet 253→242 (observed twice), the castellation mating-counterpart spec note (v0.6.1: solder-down carrier, not a header), and a check_dru armed-rules gate from the r17 forensics (the best board's sibling dru was re-lifted in the run's final retry and never re-restored; the gate refuses rule-less grades outright).

https://claude.ai/code/session_01QEKiSmu7cTk4vv7F2zeWR4
