### PR TITLE
Fix KiCad-wide SIGABRT on Route: make every SaveBoard snapshot skip the project-settings save

### DIFF
--- a/kicad_routing_plugin/ai_gui.py
+++ b/kicad_routing_plugin/ai_gui.py
@@ -66,7 +66,10 @@ def board_path_for_analysis(board_filename):
         base = os.path.basename(board_filename) if board_filename else "board.kicad_pcb"
         snapshot = os.path.join(tempfile.gettempdir(), f"kicadrt_analysis_{base}")
         try:
-            pcbnew.SaveBoard(snapshot, board)
+            # aSkipSettings: analysis snapshot; writing a .kicad_pro besides
+            # would crash on pre-KiCad-10 projects (uncaught C++ type_error
+            # in the .kicad_pro merge; see _stage_live_board in swig_gui.py).
+            pcbnew.SaveBoard(snapshot, board, aSkipSettings=True)
             return snapshot
         except Exception as e:
             wx.MessageBox(

--- a/kicad_routing_plugin/gui_utils.py
+++ b/kicad_routing_plugin/gui_utils.py
@@ -715,7 +715,12 @@ def run_kicad_oracle_on_live_board(board, net_names, *, clearance,
         with tempfile.NamedTemporaryFile(suffix='.kicad_pcb',
                                          delete=False) as f:
             tmp = f.name
-        pcbnew.SaveBoard(tmp, board)
+        # aSkipSettings: rules reach the oracle via project_from below, never
+        # via a temp-sibling .kicad_pro -- and the implicit settings save
+        # aborts KiCad on worker threads for pre-KiCad-10 projects (uncaught
+        # C++ type_error in the .kicad_pro merge; see _stage_live_board in
+        # swig_gui.py).
+        pcbnew.SaveBoard(tmp, board, aSkipSettings=True)
         # #490: stage the REAL project's netclasses for the refill, or the
         # exact-fill link source runs at stock rules.
         try:

--- a/kicad_routing_plugin/movie_recorder.py
+++ b/kicad_routing_plugin/movie_recorder.py
@@ -212,7 +212,11 @@ class MovieRecorder:
             if board is None:
                 return None
             path = os.path.join(self._temp_dir(), f"{name}.kicad_pcb")
-            pcbnew.SaveBoard(path, board)
+            # aSkipSettings: frames only need copper; the settings save
+            # aborts KiCad on worker threads for pre-KiCad-10 projects
+            # (uncaught C++ type_error in the .kicad_pro merge; see
+            # _stage_live_board in swig_gui.py).
+            pcbnew.SaveBoard(path, board, aSkipSettings=True)
             return path
         except Exception as e:
             self._log(f"{YELLOW}Routing movie: snapshot failed ({e}){RESET}")

--- a/kicad_routing_plugin/swig_gui.py
+++ b/kicad_routing_plugin/swig_gui.py
@@ -3237,7 +3237,15 @@ class RoutingDialog(wx.Dialog):
                     with tempfile.NamedTemporaryFile(
                             suffix='.kicad_pcb', delete=False) as _f:
                         _p = _f.name
-                    pcbnew.SaveBoard(_p, _b)
+                    # aSkipSettings: the oracle leg needs the copper, not a
+                    # .kicad_pro. KiCad 10's implicit project-settings save
+                    # merges the pre-migration on-disk project JSON with its
+                    # migrated in-memory view and throws on any key whose
+                    # type changed (KiCad 9 wrote sheet_component_classes as
+                    # [], 10 holds an object) -- and with no C++ handler
+                    # above this worker thread, that throw aborts ALL of
+                    # KiCad. Snapshots must always skip the settings save.
+                    pcbnew.SaveBoard(_p, _b, aSkipSettings=True)
                     return _p
                 except Exception as e:
                     print(f"(could not stage the live board for the "

--- a/py_router/headless_plan.py
+++ b/py_router/headless_plan.py
@@ -177,7 +177,12 @@ def run_plan(board_path, steps, indices=None, snapshot_dir=None,
             snap = os.path.join(snapshot_dir, snapshot_format.format(
                 prefix=snapshot_prefix, n=index + 1, action=action))
             try:
-                pcbnew.SaveBoard(snap, board)
+                # aSkipSettings: per-step copper snapshot, no .kicad_pro
+                # wanted (KiCad 10's settings save merges the pre-migration
+                # on-disk project JSON with its migrated in-memory view;
+                # an uncaught type_error aborts the process on any
+                # pre-KiCad-10 project).
+                pcbnew.SaveBoard(snap, board, aSkipSettings=True)
                 result['snapshots'].append(snap)
             except Exception as e:
                 result['log'].append(f"snapshot step {index + 1} failed: {e}")
@@ -190,7 +195,13 @@ def run_plan(board_path, steps, indices=None, snapshot_dir=None,
                 # Save back to the same path, beside the .kicad_pro that
                 # PlanExecutor._write_drc_floors just stamped with the routed
                 # floors -- a board without its floor grades wrong (#441).
-                pcbnew.SaveBoard(board_path, board)
+                # aSkipSettings for two reasons: the implicit settings save
+                # would REWRITE that just-stamped .kicad_pro from KiCad's
+                # in-memory (pre-stamp) view, silently dropping the floors;
+                # and on pre-KiCad-10 projects it aborts the process outright
+                # (uncaught type_error merging the pre-migration file with
+                # the migrated in-memory settings).
+                pcbnew.SaveBoard(board_path, board, aSkipSettings=True)
             except Exception as e:
                 result['log'].append(f"final save failed: {e}")
         app.ExitMainLoop()

--- a/py_router/kicad_exact_fill.py
+++ b/py_router/kicad_exact_fill.py
@@ -52,7 +52,10 @@ if board is None:
 filler = pcbnew.ZONE_FILLER(board)
 zones = board.Zones()
 filler.Fill(zones)
-pcbnew.SaveBoard(dst, board)
+# aSkipSettings: dst is parsed for island polygons only; the settings save
+# aborts this subprocess (SIGABRT, degrading the fill to the raster model)
+# when the staged project predates KiCad 10.
+pcbnew.SaveBoard(dst, board, aSkipSettings=True)
 print("REFILL_OK", len(list(zones)))
 """
 

--- a/py_router/kicad_parser.py
+++ b/py_router/kicad_parser.py
@@ -4317,7 +4317,12 @@ def build_pcb_data_from_board(board, guide_layer: str = "User.1",
             import pcbnew as _pcbnew
             fd, tmp = tempfile.mkstemp(suffix='.kicad_pcb')
             os.close(fd)
-            _pcbnew.SaveBoard(tmp, _board)
+            # aSkipSettings: the memo keys on the saved BOARD bytes and the
+            # refill takes its rules from project_from, so a temp-sibling
+            # .kicad_pro is never read -- and writing one aborts KiCad on
+            # pre-KiCad-10 projects (uncaught type_error merging the
+            # pre-migration file with the migrated in-memory settings).
+            _pcbnew.SaveBoard(tmp, _board, aSkipSettings=True)
             with open(tmp, 'rb') as _fh:
                 _key = hashlib.sha256(_fh.read()).digest()
             if _key in _memo:


### PR DESCRIPTION
## What breaks

Clicking **Route** in the plugin can kill the entire KiCad process — no traceback, no dialog, straight to a macOS crash report:

```
EXC_CRASH (SIGABRT), Abort trap: 6
libc++abi: terminating due to uncaught exception of type
  nlohmann::json_abi_v3_11_3::detail::type_error:
  [json.exception.type_error.312] cannot use update() with array
```

Faulting thread (from the `.ips` report): a **Python worker thread** →
`_wrap_SaveBoard` → `SaveBoard(wxString&, BOARD*, PCB_FILE_T, bool)` →
`SETTINGS_MANAGER::SaveProjectAs` → `PROJECT_FILE::SaveToFile` →
`JSON_SETTINGS::SaveToFile` → `nlohmann::json::update` → `__cxa_throw` → `std::terminate`.

The same abort also takes down headless plan runs and the exact-fill refill child process (we found a stack of identical `Python-*.ips` reports from CLI sessions — the refill dying this way silently degrades fills to the raster model via the `REFILL_FAIL` path).

## Root cause

`pcbnew.SaveBoard(path, board)` defaults `aSkipSettings=False`, so besides the board it writes a `.kicad_pro` next to `path`. In KiCad 10, `JSON_SETTINGS::SaveToFile` builds that file by merging `m_original` — the project JSON **as originally parsed from disk, captured before any migration** (the source comments literally say "Save whatever we loaded, before doing any migration etc") — with the post-migration in-memory settings:

```cpp
nlohmann::json toSave = m_internals->m_original;
...
toSave.update( m_internals->begin(), m_internals->end(), /* merge_objects = */ true );
// ^ outside the try/catch; only the serialization below is guarded
```

With `merge_objects=true`, nlohmann's `update()` recurses into any key present on both sides and **throws `type_error.312` when the in-memory value is an object but the on-disk value is an array**. Every project last saved by KiCad 9 contains exactly that: `component_class_settings.sheet_component_classes` is `[]` on disk, but KiCad 10 represents it as an object (`{"enabled": false}`) and ships no migration for the type change. We proved the key by dumping the in-memory JSON (save against a stripped `.kicad_pro`) and type-diffing: flipping only that `[]` to `{}` in the project file makes the crash vanish.

So: **any KiCad-9-era project + any `SaveBoard` that doesn't skip settings = C++ exception.** On the GUI main thread wx would catch it; on the routing worker thread there is no C++ handler above the throw, so `std::terminate` aborts all of KiCad. (Arguably also a KiCad bug — the merge sits outside the `try`, and the migration is missing — but the plugin should be safe regardless of if/when KiCad hardens it.)

## Repro (no plugin needed)

Any project whose `.kicad_pro` was last written by KiCad 9, using KiCad 10's bundled Python:

```python
import pcbnew, threading
b = pcbnew.LoadBoard("board.kicad_pcb")   # .kicad_pro beside it has "sheet_component_classes": []
t = threading.Thread(target=lambda: pcbnew.SaveBoard("/tmp/snap.kicad_pcb", b))
t.start(); t.join()
# -> libc++abi: terminating ... type_error.312 "cannot use update() with array", exit 134
```

With `pcbnew.SaveBoard("/tmp/snap.kicad_pcb", b, aSkipSettings=True)` the same call saves and survives.

The board that found this is a private 6-layer BGA design (per CONTRIBUTING: saying so rather than attaching); the recipe above reproduces on any KiCad-9-saved project.

## The fix

Every `SaveBoard` in shipped code is a board-content save, never a settings save — so pass `aSkipSettings=True` (in the API since KiCad 7; the plugin requires 9.0+) at all eight call sites:

| Site | Context |
|---|---|
| `swig_gui.py` `_stage_live_board` | worker thread, oracle staging — **the Route-click crash** |
| `gui_utils.py` oracle temp save | rules already travel via `project_from`, never a temp-sibling `.kicad_pro` |
| `ai_gui.py` analysis snapshot | temp-dir snapshot |
| `movie_recorder.py` `_snapshot` | worker thread, movie frames |
| `headless_plan.py` step snapshots | copper-only snapshots |
| `headless_plan.py` final save | see below |
| `kicad_parser.py` `_live_fill` | memo keys on the saved **board** bytes; unaffected |
| `kicad_exact_fill.py` `_REFILL_SCRIPT` | child process was dying with SIGABRT when the staged project predates KiCad 10 |

The `headless_plan.py` final save gets a second benefit: it writes beside the `.kicad_pro` that `PlanExecutor._write_drc_floors` **just stamped** (#441). The implicit settings save was rewriting that file from KiCad's pre-stamp in-memory view — on new-format projects it silently discarded the floors; on old-format projects it aborted the run.

## Verification

- On the crashing board: unpatched call pattern aborts (exit 134, message above); patched pattern saves the full board from a worker thread and exits 0. Snapshot `.kicad_pcb` is byte-identical in size to the unpatched save; no stray `.kicad_pro` beside temp files anymore.
- `python3 tests/run_all.py --fast`: failure set **identical to main** before/after (the 45 failures on this machine are pre-existing `shapely`-missing environment failures; 168 pass both ways).
- Parity gates: `tests/gui_parity/test_manifest_plan_parity.py` and `tests/gui_parity/test_cli_postpass_coverage.py` both pass.

## Versions

KiCadRoutingTools 0.20.2 @ 15292a0 · KiCad 10.0.4 · macOS 26.5.1 (arm64) · bundled Python 3.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)
