### PR TITLE
routing: boards graded at constants they contradict, and tools that reported success falsely

### DIFF
--- a/.gui-parity-checked
+++ b/.gui-parity-checked
@@ -627,3 +627,19 @@ HEAD 2026-07-30 parity audit 191abc4..d73b1d6 (3 commits). Outcome: no gaps.
     gate runs a fanout step; ea992d9), its stale _path bootstrap
     (3c4fc48), and the #562 rename breaking every recorded manifest's
     repair step (relocate_moved_scripts rename table, 89914ce).
+
+ADDENDUM 2026-08-12 (PR: board floors + false success) -- scope: the one
+GUI-relevant change in this PR is kicad_routing_plugin/swig_gui.py
+_effective_geometry_floor gaining the declared-0 guard (a board writing 0 for
+"not configured" was taken as a real hole-to-hole floor by the GUI while the
+CLI's resolver treated it as unset: measured, GUI drilled h2h 0.1 vs CLI 0.2,
+same board, same settings, under fab-overrides). The plane-edge helper beside
+it already guarded > 1e-9; this closes the divergence in the other helper.
+  * Pinned by tests/gui_parity/test_geometry_floor_leak.py (runs under real
+    KiCad python; "declared-0.0 hole_to_hole, fab floor 0.1 -> GUI 0.2
+    (CLI 0.2) ... 0 problem(s)").
+  * Parity evidence on the source branch (KiCad 10.0, pcbnew 10.0.0,
+    wx 4.2.2): test_gui_engine_parity VERDICT PARITY, copper sets IDENTICAL
+    (segments 1307=1307, vias 144=144, 0 one-sided); test_manifest_plan_parity
+    OK; test_cli_postpass_coverage 7 registered / 14 in use / 1 acknowledged
+    CLI-only (run_drc fanout graze audit, report-only) / 0 unreachable.

--- a/kicad_routing_plugin/swig_gui.py
+++ b/kicad_routing_plugin/swig_gui.py
@@ -754,6 +754,23 @@ class RoutingDialog(wx.Dialog):
             else:
                 netclass = _get_netclass_parameters('Default') or {}
                 board_val = netclass.get(name)
+            # A declared 0 is UNSET, not a floor of zero -- KiCad writes 0 into
+            # these fields for "not configured". Every other resolver in the
+            # tree applies that rule (list_nets.board_floor / board_floor_knobs,
+            # resolve_cli_floor, and _effective_plane_edge_clearance just above,
+            # which already guarded `> 1e-9`); this branch tested only
+            # `is not None` and so diverged from the CLI.
+            #
+            # Masked in the default tier, because _fab_floored then pins a 0.0
+            # up to the 0.2 fab hole-to-hole floor and the CLI lands on 0.2
+            # too. NOT masked once the fab floor moves: with a --fab-overrides
+            # declaring hole_to_hole 0.10 (fab_floor_ladder collapses to that
+            # one hard rung, and the GUI reaches it through the fab_tier /
+            # fab_overrides_path controls), a board declaring 0.0 resolved to
+            # GUI 0.1 against CLI 0.2 -- the GUI drilling twice as close as the
+            # CLI on the same board and the same settings.
+            if board_val is not None and board_val <= 0:
+                board_val = None
             val = board_val if board_val is not None else getattr(self, name).GetValue()
         return self._fab_floored(name, val)
 

--- a/krt_capabilities.py
+++ b/krt_capabilities.py
@@ -27,10 +27,33 @@ import sys
 
 ROOT = os.path.dirname(os.path.abspath(__file__))
 
+# The #522/placement-split layout spread the tools over py_router/, py_tools/
+# and py_placer/. A consumer keeps naming them bare ('route.py'), so every
+# lookup resolves through _tool_path, which accepts EITHER layout -- flat for
+# an older clone, packaged for this one.
+_TOOL_DIRS = ('', 'py_router', 'py_tools', 'py_placer')
+
+
+def _tool_path(root, mod):
+    """Absolute path to `mod`, wherever the #522/placement-split layout put it.
+
+    Falls back to the flat join so the error message a missing module produces
+    still names the place the caller expected it.
+    """
+    for d in _TOOL_DIRS:
+        p = os.path.join(root, d, mod)
+        if os.path.isfile(p):
+            return p
+    return os.path.join(root, mod)
+
+
 # The modules a consumer is likely to depend on by name. Presence is reported
 # for every one; absence is only an ERROR when --require asks for it.
+# `route_disconnected_planes.py` was RENAMED to `repair_planes.py`; a consumer
+# pinning the old name still gets an honest "module not present" from
+# missing(), which looks up un-inventoried names itself.
 KNOWN_MODULES = (
-    'route.py', 'route_diff.py', 'route_planes.py', 'route_disconnected_planes.py',
+    'route.py', 'route_diff.py', 'route_planes.py', 'repair_planes.py',
     'place_optimize.py', 'place_route_loop.py', 'place_fanout_clearance.py',
     'bga_fanout.py', 'qfn_fanout.py',
     'check_drc.py', 'check_connected.py', 'check_floorplan.py',
@@ -41,7 +64,7 @@ KNOWN_MODULES = (
 
 # Scripts whose flag set a consumer may want to pin.
 FLAG_SCRIPTS = ('route.py', 'route_diff.py', 'route_planes.py',
-                'route_disconnected_planes.py', 'place_route_loop.py',
+                'repair_planes.py', 'place_route_loop.py',
                 'place_optimize.py', 'check_drc.py', 'check_floorplan.py')
 
 _FLAG_RE = re.compile(r'add_argument\(\s*["\'](--[A-Za-z0-9][A-Za-z0-9-]*)["\']')
@@ -127,8 +150,8 @@ def script_flags(path, _depth=1):
 
 
 def capabilities(root=ROOT):
-    mods = {m: os.path.isfile(os.path.join(root, m)) for m in KNOWN_MODULES}
-    flags = {s: script_flags(os.path.join(root, s))
+    mods = {m: os.path.isfile(_tool_path(root, m)) for m in KNOWN_MODULES}
+    flags = {s: script_flags(_tool_path(root, s))
              for s in FLAG_SCRIPTS if mods.get(s)}
     out = {
         'schema': 1,
@@ -138,6 +161,9 @@ def capabilities(root=ROOT):
         'flags': flags,
     }
     try:                                    # best-effort, never fatal
+        _eng = os.path.join(root, 'py_router')
+        if os.path.isdir(_eng) and _eng not in sys.path:
+            sys.path.insert(0, _eng)        # #522 layout: the engine dir
         import routing_defaults as _d
         out['version'] = getattr(_d, 'VERSION', None)
     except Exception:
@@ -163,7 +189,7 @@ def missing(caps, required):
     gaps = []
     for token in required:
         mod, _, flag = token.partition(':')
-        path = os.path.join(root, mod)
+        path = _tool_path(root, mod)
         present = caps['modules'].get(mod)
         if present is None:                      # not in the inventory: look
             present = os.path.isfile(path)

--- a/py_placer/place_route_loop.py
+++ b/py_placer/place_route_loop.py
@@ -60,6 +60,10 @@ from route_summary import (merge_route_summaries, SUMMARY_RE as _SUMMARY_RE,
                            RECONCILE_ABORTED as _RECONCILE_ABORTED,
                            EFFORT_KEYS as _EFFORT_KEYS)
 
+# route.py's own "I stopped on my budget" code. Imported, not literal 7, so
+# this loop cannot drift from the tool it shells.
+from krt_deadline import DEADLINE_EXIT as _DEADLINE_EXIT
+
 
 def _log_tail(log: str, lines: int = 15) -> str:
     """Last few log lines, so an error names the real failure instead of
@@ -142,8 +146,14 @@ def run_route(pcb_file: str, routed_file: str, route_args: str, log_file: str,
     # glyph and lose the whole round.
     with open(log_file, encoding='utf-8', errors='replace') as f:
         log = f.read()
-    if rc != 0:
-        # route.py exits 0 even when nets fail; its only deliberate non-zero
+    # route.py's deadline exit (7) is a ROUTING RESULT, not a crash: the board
+    # is written, the summary is stamped `complete: false`, and the diagnosis
+    # the operator needs is the one below -- which the generic rc!=0 raise
+    # would preempt with "exited 7", a number that means nothing to a reader.
+    # Fall through and let the PARTIAL branch speak. (route.py grew --deadline
+    # after this check was written; before that, 7 was unreachable here.)
+    if rc != 0 and rc != _DEADLINE_EXIT:
+        # route.py exits 0 even when nets fail; its other deliberate non-zero
         # exit is "No nets matched the given patterns!". So non-zero means a
         # crash, an unreadable board or a --route-args typo, none of which is
         # a routing result.
@@ -152,8 +162,29 @@ def run_route(pcb_file: str, routed_file: str, route_args: str, log_file: str,
 
     summary = merge_route_summaries(log)
     if summary is None:
-        raise RuntimeError(f"route.py produced no JSON_SUMMARY (see {log_file})"
-                           f"\n" + _log_tail(log))
+        raise RuntimeError(
+            f"route.py produced no JSON_SUMMARY (see {log_file})"
+            + (f" -- and it exited {rc} (its deadline), so it was killed "
+               f"before it could print one. Raise --deadline."
+               if rc == _DEADLINE_EXIT else "")
+            + "\n" + _log_tail(log))
+    # A PARTIAL run is exactly as fatal as no summary, and this check is what
+    # keeps the deadline work from making things worse. Before deadlines
+    # existed, a killed step produced no summary at all and the raise above
+    # caught it. A `complete: false` summary PARSES -- so without this, the
+    # loop would consume an unfinished run's numbers as if they were a whole
+    # board's, which is a quieter and worse failure than the one it replaced.
+    # `.get('complete', True)` so pre-change logs are unaffected.
+    if not summary.get('complete', True):
+        raise RuntimeError(
+            f"route.py produced a PARTIAL JSON_SUMMARY "
+            f"(status={summary.get('status')!r}, "
+            f"stopped_in={summary.get('stopped_in')!r}, "
+            f"elapsed={summary.get('elapsed_s')}s of "
+            f"{summary.get('deadline_s')}s) -- the run stopped on its own "
+            f"deadline and its tallies are not a whole-board result. Raise "
+            f"--deadline, or drop it, and re-run.\nsee {log_file}\n"
+            + _log_tail(log))
 
     return metrics_from_summary(summary, log, extra_targets)
 

--- a/py_router/bga_fanout/__init__.py
+++ b/py_router/bga_fanout/__init__.py
@@ -628,6 +628,27 @@ def manage_vias(
 
     Returns:
         Tuple of (vias_to_add, vias_to_remove)
+
+    KNOWN GAP, NOT FIXED HERE -- D10's self-blindness, in this function.
+    `vias_to_add` is appended to below and never read back, and BOTH guards
+    that gate an append iterate `pcb_data.vias` only: `would_overlap_existing_via`
+    and `via_in_pad_conflict`'s drill loop. So two vias added in ONE call are
+    never tested against each other -- the same shape as the qfn underpad
+    escape's, where the fix was to test each candidate against this run's own
+    output as well as the input board (`qfn_fanout.run_output_conflict`, which
+    is reusable and would be this code's second caller).
+
+    Structurally verified by reading; the IMPACT is UNMEASURED, deliberately
+    stated as such. A 0.5mm-pitch BGA taking via 0.45 + clearance 0.1 needs
+    0.55mm between adjacent ball centres and has 0.50 -- but `clamp_via_to_pad`
+    shrinks a via to fit its pad first, and on that pitch it may clamp far
+    enough to make the pair legal anyway. Whether this bites needs measuring
+    on a real fine-pitch BGA before anyone claims it does.
+
+    `via_in_pad_conflict` also prices its drill floor at the flat
+    `routing_defaults.HOLE_TO_HOLE_CLEARANCE` rather than the board's own
+    `min_hole_to_hole` -- the D9/D11 substitute-a-constant class, unclosed
+    here (qfn_fanout resolves it board-first, wrapped at the fab floor).
     """
     def find_nearby_via(x: float, y: float, net_id: int, max_dist: float):
         """Find an existing via on the same net within max_dist of position."""

--- a/py_router/bga_fanout/underpad.py
+++ b/py_router/bga_fanout/underpad.py
@@ -541,6 +541,32 @@ def generate_underpad_escape(footprint: Footprint,
     floors = fab_floor_ladder(_copper)
     clamp_stats = {'clamped': 0, 'floor': 0, 'escalated': 0}
 
+    # DRILL FLOOR, board-first and raise-only. `_via_site_conflict` below spaced
+    # every drill it places at the flat routing_defaults.HOLE_TO_HOLE_CLEARANCE
+    # and this module never read the board at all -- grepping it for
+    # board_floor / board_constraint / min_hole_to_hole / resolve_hole_clearance
+    # returned nothing. So a board declaring min_hole_to_hole 0.3 got its BGA
+    # underpad drills spaced at 0.2: the D9/D11 substitute-a-constant class,
+    # in the direction that IGNORES a board asking for MORE.
+    #
+    # RAISE-ONLY IN THE CODE, not only in this comment (the Q4 lesson):
+    # board_floor is board-authoritative and will happily return a declared
+    # 0.10, so the fab floor is wrapped in explicitly. check_join.py:118-122 is
+    # the same shape and was the correct model. qfn_fanout does this too; this
+    # is its sibling engine and was the one still ignoring the board.
+    from list_nets import board_floor as _board_floor
+    _h2h_decl, _h2h_src = _board_floor(
+        getattr(pcb_data, 'source_path', "") or "", 'hole_to_hole',
+        None, HOLE_TO_HOLE_CLEARANCE)
+    _h2h_fab = fab_floor_min(_copper).get('hole_to_hole', 0.0)
+    _h2h = max(_h2h_decl, _h2h_fab)
+    if _h2h_src == 'board constraint' and _h2h_decl > HOLE_TO_HOLE_CLEARANCE:
+        print(f"  Hole-to-hole {_h2h:g}mm (from the board's own "
+              f"min_hole_to_hole)")
+    elif _h2h_src == 'board constraint' and _h2h_decl < _h2h_fab:
+        print(f"  Board min_hole_to_hole {_h2h_decl:g}mm is below the "
+              f"{_h2h_fab:g}mm fab hole-to-hole floor; using {_h2h:g}mm.")
+
     def via_for_pad(p):
         """Clamped (size, drill, keepout_radius) for a via dropped in pad p."""
         cs, cd, status, rung = clamp_via_to_pad(via_size, via_drill, p, floors)
@@ -891,19 +917,19 @@ def generate_underpad_escape(footprint: Footprint,
             vdr = (via_drill or 0.0) / 2.0
         for (ox, oy, orr, odr, onid) in ctx['vias']:
             d = math.hypot(ox - x, oy - y)
-            if d < vdr + odr + HOLE_TO_HOLE_CLEARANCE - 1e-6:
+            if d < vdr + odr + _h2h - 1e-6:
                 return "drill hole-to-hole vs a via"
             if onid != net_id and d < vr + orr + clearance - 1e-6:
                 return "via ring vs a foreign via"
         for (ox, oy, orr, odr, onid) in ([] if skip_resv else ctx['resv']):
             d = math.hypot(ox - x, oy - y)
-            if d < vdr + odr + HOLE_TO_HOLE_CLEARANCE - 1e-6:
+            if d < vdr + odr + _h2h - 1e-6:
                 return "drill hole-to-hole vs a reserved via site"
             if onid != net_id and d < vr + orr + clearance - 1e-6:
                 return "via ring vs a reserved via site"
         for (px, py, half, pdr, pnid, has_cu) in ctx['pads']:
             d = math.hypot(px - x, py - y)
-            if pdr and d < vdr + pdr + HOLE_TO_HOLE_CLEARANCE - 1e-6:
+            if pdr and d < vdr + pdr + _h2h - 1e-6:
                 return "drill hole-to-hole vs a pad drill"
             if has_cu and pnid != net_id and d < vr + half + clearance - 1e-6:
                 return "via ring vs a foreign pad"

--- a/py_router/check_connected.py
+++ b/py_router/check_connected.py
@@ -24,6 +24,11 @@ from net_queries import expand_pad_layers
 # tests/test_component_multipoint.py) and > ~0.02 (COINCIDENCE_TOL).
 STRICT_JOINT_OVERLAP = 0.05
 
+# Zone layers already reported as not-a-copper-layer-of-this-board.
+# check_net_connectivity runs once PER NET, so without this the same phantom
+# layer would be announced fifty-odd times on one board.
+_WARNED_PHANTOM_ZONE_LAYERS: Set[str] = set()
+
 
 def point_in_polygon(x: float, y: float, polygon: List[Tuple[float, float]]) -> bool:
     """Check if a point (x, y) is inside a polygon using ray casting algorithm.
@@ -687,9 +692,32 @@ def check_net_connectivity(net_id: int, segments: List[Segment], vias: List[Via]
             # Skip wildcards like "*.Cu" - they don't represent actual layers
             if layer.endswith('.Cu') and not layer.startswith('*'):
                 copper_layer_set.add(layer)
+    # A zone layer is cross-checked against the board's OWN copper layers, not
+    # merely tested for a '.Cu' suffix (#run11). route_planes once accepted a
+    # net:layer pair as a layer name and wrote (layer "GND:B.Cu") into the zone:
+    # KiCad refuses such a file outright, but "GND:B.Cu".endswith('.Cu') is
+    # True, so the phantom layer joined this census, expand_pad_layers spread
+    # through-hole pads onto it, and the pour was credited 70/70 when the honest
+    # figure was 69/70. Every checker downstream of this function inherited that
+    # lie. GUARD: only when the board declares copper layers -- a board whose
+    # stackup failed to parse degrades to the old behaviour rather than having
+    # every zone rejected.
+    _board_copper = set(getattr(getattr(pcb_data, 'board_info', None),
+                                'copper_layers', None) or ())
     for zone in zones:
-        if zone.layer.endswith('.Cu'):
-            copper_layer_set.add(zone.layer)
+        if not zone.layer.endswith('.Cu'):
+            continue
+        if _board_copper and zone.layer not in _board_copper:
+            if zone.layer not in _WARNED_PHANTOM_ZONE_LAYERS:
+                _WARNED_PHANTOM_ZONE_LAYERS.add(zone.layer)
+                print(f"WARNING: zone on layer '{zone.layer}', which is NOT a "
+                      f"copper layer of this board "
+                      f"({', '.join(sorted(_board_copper))}). KiCad cannot open "
+                      f"this file; its copper is NOT credited here. A net:layer "
+                      f"pair passed to route_planes --plane-layers writes exactly "
+                      f"this.")
+            continue
+        copper_layer_set.add(zone.layer)
 
     # Sort layers: F.Cu first, then In*.Cu in order, then B.Cu last
     def layer_sort_key(layer):
@@ -1528,6 +1556,34 @@ def run_connectivity_check(pcb_file: str, net_patterns: Optional[List[str]] = No
                         continue
                 unrouted_nets.append((net_id, net_info.name, len(pads_by_net[net_id])))
 
+    # A scope that matched NOTHING is not a clean board. This printed
+    # `Checking 0 nets matching: [...]` and then went on to
+    # `ALL NETS FULLY CONNECTED!` and exit 0 -- so a typo'd or shell-mangled
+    # --nets turned the instrument the project says to always run before
+    # calling a route clean into a rubber stamp, invisible to `&&` and to
+    # `set -e`. Found live when a shell rewrote `/IO_Banks/Z0` into a Windows
+    # path. Same failure mode as the oracle branch ~200 lines below, which was
+    # already fixed there.
+    if (net_patterns or component) and not nets_to_check:
+        _what = []
+        if net_patterns:
+            _what.append(f"--nets {net_patterns}")
+        if component:
+            _what.append(f"component {component}")
+        print(f"ERROR: {' and '.join(_what)} matched NO nets on this board. "
+              f"That is a scope that selected nothing, not a board that is "
+              f"connected -- refusing to report a result. Check the pattern "
+              f"(a leading '/' is rewritten by some shells; MSYS_NO_PATHCONV=1 "
+              f"on Git Bash), or drop the flag to check every net.",
+              file=sys.stderr)
+        # Returned as an issue rather than an exit code: this function's
+        # contract is List[Dict] and library callers unpack it. main() maps
+        # `scope_error` to exit 2, which is distinct from 1 ("found real
+        # problems") so a caller can tell a bad scope from a bad board.
+        return [{'scope_error': True, 'net_patterns': net_patterns,
+                 'component': component,
+                 'description': 'the requested scope matched no nets'}]
+
     if not quiet:
         if net_patterns and component:
             print(f"Checking {len(nets_to_check)} nets on {component} matching: {net_patterns}")
@@ -1642,6 +1698,19 @@ def run_connectivity_check(pcb_file: str, net_patterns: Optional[List[str]] = No
             from kicad_oracle import find_kicad_cli, kicad_unconnected
             _cli = find_kicad_cli()
             _links = kicad_unconnected(pcb_file, _cli) if _cli else None
+            if _links is None and not quiet:
+                # There was no `else` here, so "the oracle ran and agreed" and
+                # "the oracle never ran" printed identically -- i.e. nothing --
+                # and the run still ended `ALL NETS FULLY CONNECTED!` / exit 0.
+                # On a board with zones that is the difference between a graded
+                # result and an ungraded one, and the reader could not tell.
+                # kicad_unconnected() returns None for a missing CLI, a DRC
+                # timeout (ORACLE_DRC_TIMEOUT 240s), a bad return code, or
+                # unreadable JSON; only the timeout prints anything of its own.
+                print(f"  NOTE: the KiCad grade reconciliation did NOT run "
+                      f"({'kicad-cli not found' if not _cli else 'the oracle returned nothing -- DRC timeout, bad exit, or unreadable output'})."
+                      f" Zone-covered nets below are graded by the copper model "
+                      f"ALONE; KiCad has not agreed with them.")
             if _links is not None:
                 _linked_nets = {lk[0] for lk in _links}
                 _reclass = [i for i in issues
@@ -1857,4 +1926,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     issues = run_connectivity_check(args.pcb, args.nets, args.tolerance, args.quiet, args.verbose, args.component, args.routed_only)
+    # 2 = the scope selected nothing, so no board was graded. Deliberately not
+    # 1: a caller must be able to tell "your pattern is wrong" from "this board
+    # has unconnected nets", and must never read either as success.
+    if any(i.get('scope_error') for i in issues):
+        sys.exit(2)
     sys.exit(1 if issues else 0)

--- a/py_router/check_drc.py
+++ b/py_router/check_drc.py
@@ -1558,6 +1558,7 @@ def render_violation_panels(pcb_file: str, violations: List[dict],
 def run_drc(pcb_file: str, clearance: float = 0.1, net_patterns: Optional[List[str]] = None,
             debug_output: bool = False, quiet: bool = False,
             hole_to_hole_clearance: float = defaults.HOLE_TO_HOLE_CLEARANCE, board_edge_clearance: float = 0.0,
+            hole_clearance: float = 0.0,
             clearance_margin: float = 0.05, max_print: int = 20,
             min_track_width: Optional[float] = None,
             min_via_diameter: Optional[float] = None,
@@ -2378,8 +2379,15 @@ def run_drc(pcb_file: str, clearance: float = 0.1, net_patterns: Optional[List[s
     # Each hole is its drill CAPSULE ((x1,y1),(x2,y2),r): a slot drill's real
     # shape. Round drills degenerate to a zero-length capsule (the old circle).
     from kicad_parser import pad_drill_capsule
-    # JLC "NPTH to Track" fab floor (never below the graded clearance).
-    npth_clr = max(clearance, defaults.NPTH_TO_TRACK_CLEARANCE)
+    # JLC "NPTH to Track" fab floor (never below the graded clearance), raised
+    # to the board's own `min_hole_clearance` when it declares a tighter-than-
+    # -default requirement. Without that third term this check graded every
+    # board at a HARDCODED 0.20 and never opened the project at all, so copper
+    # sitting in a board's authored copper-to-hole band read clean -- measured
+    # on neo6502: three NPTH holes at 0.2126/0.2263/0.2263 mm against an
+    # authored min_hole_clearance of 0.25, clean at 0.20, and clean BEFORE any
+    # ratchet as well, because the key was never consulted in the first place.
+    npth_clr = max(clearance, defaults.NPTH_TO_TRACK_CLEARANCE, hole_clearance)
     # Each entry: (p1, p2, r, net_id, ref, required_clr, copper_exempt).
     # NPTH (no-copper) pad holes graded at the fab floor -- or the pad's own
     # clearance OVERRIDE when larger (KiCad's hole_clearance honors it; #326
@@ -3133,6 +3141,11 @@ if __name__ == "__main__":
                              f'(default: {defaults.HOLE_TO_HOLE_CLEARANCE}, the fab floor — same as routing)')
     parser.add_argument('--board-edge-clearance', type=float, default=0.0,
                         help='Minimum clearance from board edge in mm (0 = use --clearance value)')
+    parser.add_argument('--hole-clearance', type=float, default=0.0,
+                        help=f'Minimum COPPER-to-drill-hole clearance in mm '
+                             f'(0 = auto: the project\'s min_hole_clearance, else '
+                             f'the {defaults.NPTH_TO_TRACK_CLEARANCE} fab floor). '
+                             f'Raises the floor, never lowers it.')
     parser.add_argument('--clearance-margin', type=float, default=0.05,
                         help='Fraction of clearance to use as tolerance (default: 0.05 = 5%%). Violations smaller than clearance*margin are ignored.')
     parser.add_argument('--nets', '-n', nargs='+', default=None,
@@ -3252,12 +3265,27 @@ if __name__ == "__main__":
             if not args.quiet:
                 print(f"Hole-to-hole clearance {_pro_h2h:.4g} mm "
                       f"(from project min_hole_to_hole)")
+        # COPPER-to-hole, the third of the same family and the one that was
+        # missing. The two blocks above board-derive their floors; this check
+        # did not, and graded every board at the hardcoded 0.20
+        # NPTH_TO_TRACK_CLEARANCE instead -- so a board declaring
+        # min_hole_clearance 0.25 had its authored 0.20-0.25 band graded clean,
+        # and no ratchet was needed to hide it (neo6502: 3 NPTH holes, tightest
+        # 0.2126 mm). Same shape as the two above: raise, never lower.
+        _pro_hclr = float(_rules.get('constraints', {})
+                          .get('min_hole_clearance') or 0.0)
+        if _pro_hclr > args.hole_clearance:
+            args.hole_clearance = _pro_hclr
+            if not args.quiet:
+                print(f"Copper-to-hole clearance {_pro_hclr:.4g} mm "
+                      f"(from project min_hole_clearance)")
     except Exception as e:
         if not args.quiet:
             print(f"  (netclass/edge rules not read: {e})")
 
     violations = run_drc(args.pcb, args.clearance, args.nets, args.debug_lines, args.quiet,
                          args.hole_to_hole_clearance, args.board_edge_clearance,
+                         args.hole_clearance,
                          args.clearance_margin, max_print=args.max_print,
                          min_track_width=args.min_track_width,
                          min_via_diameter=args.min_via_diameter,

--- a/py_router/check_weird.py
+++ b/py_router/check_weird.py
@@ -28,6 +28,10 @@ Categories:
   unsupported-via    a via with no same-net track copper reaching its barrel,
                      not inside a same-net pad, and not inside a same-net
                      zone polygon (a floating via).
+  dangling-via       a via whose same-net copper reaches it on exactly ONE of
+                     the layers it spans, so the barrel joins nothing. This is
+                     KiCad's own `via_dangling` rule; it is a strictly weaker
+                     condition than unsupported-via, which needs ZERO support.
   orphan-island      a connected group of same-net track copper (segments,
                      possibly with vias) that reaches NO pad of the net --
                      dead copper stranded by a rip or a superseded route.
@@ -61,7 +65,7 @@ from pcb_modification import _point_anchored, _prune_net_cycles, _pt_seg_dist
 
 CATEGORIES = ['dangling-end', 'soft-joint', 'redundant-cycle',
               'removable-segment', 'stacked-copper', 'unsupported-via',
-              'orphan-island']
+              'dangling-via', 'orphan-island']
 # Cost cap for the per-segment removable scan (spec: skip unless --thorough).
 MAX_SEGS_PER_NET = 500
 _CELL = 1.0  # spatial-grid cell (mm) fed to _point_anchored, as in the pruner
@@ -465,36 +469,47 @@ def _check_unsupported_vias(net_id, name, net_segs, net_vias, net_pads,
     for v in net_vias:
         span = _via_span(v, copper_layers)
         r = (getattr(v, 'size', 0.6) or 0.6) / 2.0
-        supported = False
+        # Collect WHICH layers support the barrel, not merely whether any does.
+        # A via exists to join layers, so one supported layer means it joins
+        # nothing -- that is KiCad's own `via_dangling` rule ("fewer than two
+        # layers connected"), and short-circuiting at the first hit could not
+        # express it: run 11 shipped a board KiCad flagged with 64 dangling
+        # vias while this check reported none, because every one of them had
+        # copper on exactly one end.
+        sup = set()
         for s in net_segs:
-            if s.layer not in span:
+            if s.layer not in span or s.layer in sup:
                 continue
             if _pt_seg_dist(v.x, v.y, s.start_x, s.start_y,
                             s.end_x, s.end_y) < r + s.width / 2 - 1e-6:
-                supported = True
-                break
-        if not supported:
-            for p in net_pads:
-                if getattr(p, 'pad_type', '') == 'np_thru_hole':
-                    continue  # NPTH pads have no copper
-                if p.drill and p.drill > 0:
-                    on_layer = True  # plated barrel spans all copper layers
-                else:
-                    pl = set(p.layers or [])
-                    on_layer = bool(span & pl) or any('*' in L for L in pl)
-                if on_layer and _point_in_pad(v.x, v.y, p, margin=COINCIDENCE_TOL):
-                    supported = True
-                    break
-        if not supported:
-            for z in net_zones:
-                if z.layer in span and point_in_polygon(v.x, v.y, z.polygon):
-                    supported = True
-                    break
-        if not supported:
-            layer_str = ','.join(v.layers) if v.layers else '*.Cu'
+                sup.add(s.layer)
+        for p in net_pads:
+            if getattr(p, 'pad_type', '') == 'np_thru_hole':
+                continue  # NPTH pads have no copper
+            if p.drill and p.drill > 0:
+                on = set(span)  # plated barrel spans all copper layers
+            else:
+                pl = set(p.layers or [])
+                on = set(span) if any('*' in L for L in pl) else (span & pl)
+            if on and not on <= sup and _point_in_pad(
+                    v.x, v.y, p, margin=COINCIDENCE_TOL):
+                sup |= on
+        for z in net_zones:
+            if z.layer in span and z.layer not in sup and point_in_polygon(
+                    v.x, v.y, z.polygon):
+                sup.add(z.layer)
+        layer_str = ','.join(v.layers) if v.layers else '*.Cu'
+        if not sup:
             findings.append(_finding(
                 'unsupported-via', name, layer_str, v.x, v.y,
                 "floating via: no same-net track, pad, or zone reaches it",
+                size=getattr(v, 'size', None)))
+        elif len(sup) == 1 and len(span) > 1:
+            findings.append(_finding(
+                'dangling-via', name, layer_str, v.x, v.y,
+                f"dangling via: same-net copper reaches it on {next(iter(sup))} "
+                f"only, so it spans {len(span)} layer(s) but joins none "
+                f"(KiCad via_dangling)",
                 size=getattr(v, 'size', None)))
 
 

--- a/py_router/cli_banner.py
+++ b/py_router/cli_banner.py
@@ -53,12 +53,65 @@ def command_line() -> str:
     return ' '.join(_quote(a) for a in head)
 
 
+def install_dash_hint() -> None:
+    """Explain the one argparse failure a real net name can cause.
+
+    Run 14 lost a lap to this. The board carried a net called ``-12V`` -- not
+    exotic; every bipolar analog board has one -- and ``route.py --nets ...
+    -12V ...`` died with::
+
+        route.py: error: unrecognized arguments: -12V
+
+    no board, no JSON_SUMMARY, exit 2. ``--nets`` is ``nargs='+'``, so argparse
+    takes a leading ``-`` as the start of a flag. The same hole is in every
+    name-taking list flag across route.py, route_diff.py, route_planes.py,
+    route_disconnected_planes.py, check_drc.py and check_connected.py -- 30-odd
+    of them -- and the fix at each call site is the same one character:
+    ``--nets=-12V``.
+
+    Rather than patch thirty parsers, this patches ``ArgumentParser.error`` once
+    from ``install()``, which every instrument already calls. The GUI never
+    calls ``install()``, so no GUI path changes.
+    """
+    import argparse
+    import re
+    orig = argparse.ArgumentParser.error
+    if getattr(orig, '_krt_dash_hint', False):
+        return
+
+    def error(self, message):                       # noqa: D401
+        try:
+            m = re.search(r'unrecognized arguments:\s*(.+)$', str(message))
+            bad = [t for t in (m.group(1).split() if m else [])
+                   if t.startswith('-') and t != '-']
+            if bad:
+                t = bad[0]
+                sys.stderr.write(
+                    "\n  NOTE: %r begins with '-', so argparse read it as a "
+                    "flag rather than a value.\n"
+                    "        A net (or layer) whose NAME starts with '-' must "
+                    "be attached with '=':\n"
+                    "            --nets=%s          not   --nets %s\n"
+                    "        Every name-taking list flag here has this shape "
+                    "(--nets, --power-nets,\n"
+                    "        --rip-existing-nets, --plane-layers, ...).\n\n"
+                    % (t, t, t))
+                sys.stderr.flush()
+        except Exception:               # a hint must never mask the real error
+            pass
+        return orig(self, message)
+
+    error._krt_dash_hint = True
+    argparse.ArgumentParser.error = error
+
+
 def install() -> None:
     """Print the CMD banner now; print EXIT=<rc> when the process ends."""
     global _installed
     if _installed or os.environ.get('KRT_NO_BANNER'):
         return
     _installed = True
+    install_dash_hint()
     # Line-buffer the log (run-7 A11). Redirected to a file, stdout is
     # BLOCK-buffered, so a run that is killed -- a timeout, a stall, a closed
     # session -- loses whatever sits in the 8KB buffer. One run-7 board's

--- a/py_router/diff_pair_custody.py
+++ b/py_router/diff_pair_custody.py
@@ -182,8 +182,18 @@ def build_pair_reports(state, diff_pair_ids_to_route, member_audit,
             # read as a contradicted claim and demoted it from
             # routed_diff_pairs while its trunk was coupled and its board
             # finished clean. incomplete_members stays populated either way.
-            'member_audit_mismatch': bool(outcome == 'coupled'
-                                          and incomplete),
+            # ...but a 'partial' pair with BOTH members incomplete is not the
+            # protected case. The tigard exemption above is about ONE peeled
+            # leg closing in the single-ended follow-up; a pair where neither
+            # member ends up connected has nothing coupled left to credit, and
+            # counting it as routed is the same #514 defect wearing the
+            # 'partial' label (run 11: /USB_D reported "1/1 routed" with both
+            # /USB_D+ and /USB_D- in incomplete_members). Member COUNT is the
+            # discriminator the outcome label alone cannot supply.
+            'member_audit_mismatch': bool(
+                incomplete and (outcome == 'coupled'
+                                or (outcome == 'partial'
+                                    and len(incomplete) == 2))),
         }
         if diag.get('blocking_nets'):
             rep['blocking_nets'] = diag['blocking_nets']

--- a/py_router/fix_kicad_drc_settings.py
+++ b/py_router/fix_kicad_drc_settings.py
@@ -371,6 +371,16 @@ FAB_FLOOR_KEYS = (
     ("min_via_annular_width", "via annular ring"),
     ("min_via_drill", "via drill"),
     ("min_through_hole_diameter", "hole diameter"),
+    # Copper-to-hole. It belongs here and not with the aspirational netclass
+    # clearances: it is a drill-REGISTRATION constraint, the same family as
+    # annular ring above, and relaxing it is a claim about what the fab can
+    # make. Measured on neo6502: a chain lowered it 0.25 -> 0.20 and the
+    # disclosure said nothing, because this tuple did not list it, so
+    # `relaxed: []` was a blind pass over three NPTH holes carrying copper at
+    # 0.2126/0.2263/0.2263 mm. NOTE it is DECLARATION-only: scan_board_minima
+    # measures object sizes and no pairwise geometry, so no measured
+    # counterpart exists for this key.
+    ("min_hole_clearance", "copper-to-hole clearance"),
 )
 
 

--- a/py_router/kicad_oracle.py
+++ b/py_router/kicad_oracle.py
@@ -46,10 +46,41 @@ KICAD_CLI_CANDIDATES = [
 # far sooner and its remaining rounds are skipped.
 ORACLE_DRC_TIMEOUT = 240
 
-# realpath() of boards whose kicad-cli DRC blew ORACLE_DRC_TIMEOUT once. The
-# oracle is called once per plane-repair step, so remembering a slow board
-# stops it re-burning the timeout on every later step of the same run.
+# Boards whose kicad-cli DRC blew ORACLE_DRC_TIMEOUT once. The oracle is called
+# once per plane-repair step, so remembering a slow board stops it re-burning
+# the timeout on every later step of the same run.
+#
+# KEYED ON A FILL-COST SIGNATURE, NOT ON THE PATH. The path key never fired in
+# practice: a chain writes a NEW output board each step (r1c, r1b, r2, r3...),
+# so every step got a fresh key and re-burned the full 240s. Measured on run 9:
+# a board KiCad could not fill in 300s was re-attempted at every step of the
+# chain, and each attempt cost the whole timeout.
+#
+# What actually drives the fill cost is the ZONE geometry, the outline, and the
+# pad field -- not the routed copper, which grows between steps. So the memo
+# keys on those, which stay stable across a chain while the copper changes.
+# It is a heuristic and it is the honest one available: a board that could not
+# be filled with these zones and these pads will not become fillable because
+# thirty more tracks were added.
 _ORACLE_TIMED_OUT = set()
+
+
+def _fill_cost_key(board_file: str):
+    """(zones, pads, footprints, outline-ish) -- stable across a routing chain.
+
+    Falls back to the realpath when the board cannot be read, which restores the
+    old behaviour rather than failing closed on a parse error.
+    """
+    try:
+        from kicad_parser import parse_kicad_pcb
+        pcb = parse_kicad_pcb(board_file)
+        bb = pcb.board_info.board_bounds or (0, 0, 0, 0)
+        return ('fill', len(getattr(pcb, 'zones', ()) or ()),
+                sum(len(f.pads) for f in pcb.footprints.values()),
+                len(pcb.footprints),
+                tuple(round(v, 2) for v in bb))
+    except Exception:                                          # noqa: BLE001
+        return ('path', os.path.realpath(board_file))
 
 # The oracle reads ONLY unconnected_items, which KiCad's connectivity engine
 # computes independently of the geometric DRC rule providers. Forcing every
@@ -80,20 +111,46 @@ _IGNORE_SEVERITIES = [
 
 
 def find_kicad_cli() -> Optional[str]:
-    for c in KICAD_CLI_CANDIDATES:
-        if c and os.path.exists(c):
-            return c
-    # KICAD_CLI env override, then versioned Windows installs (not on PATH;
-    # newest wins). Run 5 silently skipped every oracle recheck on Windows
-    # because none of the unix candidates exist there.
+    # The ENV OVERRIDE GOES FIRST. It used to be checked after the unix
+    # candidates, so `KICAD_CLI=/my/build/kicad-cli` was ignored on any machine
+    # that also had a packaged one -- an override that the presence of a
+    # default silently defeats is not an override.
     env = os.environ.get('KICAD_CLI', '')
     if env and os.path.exists(env):
         return env
+    for c in KICAD_CLI_CANDIDATES:
+        if c and os.path.exists(c):
+            return c
+    # Versioned Windows installs (not on PATH; newest wins). Run 5 silently
+    # skipped every oracle recheck on Windows because none of the unix
+    # candidates exist there. The single hard-coded root missed a 32-bit
+    # install, a per-user install, and any non-C: drive -- all of which fail
+    # exactly like "no KiCad", i.e. silently, because a missing oracle is
+    # indistinguishable from a clean one downstream.
     if sys.platform == 'win32':
         import glob
-        hits = sorted(glob.glob(r'C:\Program Files\KiCad\*\bin\kicad-cli.exe'))
+        roots = [os.environ.get('ProgramFiles', r'C:\Program Files'),
+                 os.environ.get('ProgramFiles(x86)', r'C:\Program Files (x86)'),
+                 os.environ.get('ProgramW6432', ''),
+                 os.path.join(os.environ.get('LOCALAPPDATA', ''), 'Programs'),
+                 r'C:\Program Files']
+        hits = []
+        for root in roots:
+            if not root:
+                continue
+            hits += glob.glob(os.path.join(root, 'KiCad', '*', 'bin',
+                                           'kicad-cli.exe'))
         if hits:
-            return hits[-1]
+            # Newest KiCad by version-ish directory name, de-duplicated: the
+            # roots overlap (ProgramFiles and ProgramW6432 are usually equal).
+            def _ver(p):
+                try:
+                    return tuple(int(x) for x in
+                                 os.path.basename(os.path.dirname(
+                                     os.path.dirname(p))).split('.'))
+                except ValueError:
+                    return (0,)
+            return sorted(set(hits), key=_ver)[-1]
     return None
 
 
@@ -187,7 +244,7 @@ def kicad_unconnected(board_file: str, kicad_cli: str,
             data = json.load(f)
     except subprocess.TimeoutExpired:
         dt = time.monotonic() - t0
-        _ORACLE_TIMED_OUT.add(os.path.realpath(board_file))
+        _ORACLE_TIMED_OUT.add(_fill_cost_key(board_file))
         print(f"  KiCad-oracle recheck: WARNING kicad-cli DRC timed out after "
               f"{dt:.0f}s (>{timeout}s) on {os.path.basename(board_file)}; "
               f"skipping the oracle for this board")
@@ -1026,7 +1083,7 @@ def oracle_reconnect(board_file: str, net_names, config,
     # A board whose DRC already blew ORACLE_DRC_TIMEOUT once (#420) will do it
     # again on every later plane-repair step of this run -- skip it outright
     # rather than re-burn minutes of wall time for the same lost result.
-    if os.path.realpath(board_file) in _ORACLE_TIMED_OUT:
+    if _fill_cost_key(board_file) in _ORACLE_TIMED_OUT:
         print("  KiCad-oracle recheck: kicad-cli DRC previously timed out on "
               "this board, skipping")
         return {'available': False, 'rounds': 0, 'links_routed': 0,

--- a/py_router/krt_deadline.py
+++ b/py_router/krt_deadline.py
@@ -1,0 +1,465 @@
+"""Wall-clock deadlines and a guaranteed JSON_SUMMARY for long-running stages.
+
+Run 9 lost two stages to the same shape: `place_reconstruct --stages legalize`
+and `route_disconnected_planes` each ran to an external `timeout(1)`, wrote no
+output file, printed no `JSON_SUMMARY`, and exited with **the shell's** 124
+rather than any code the tool chose. From the log they were indistinguishable
+from a hang, and because both stage their output and promote it only at the end,
+a kill left nothing at the output path either.
+
+The family is wider than those two -- `EXACT_FILL_TIMEOUT` (300 s) and
+`ORACLE_DRC_TIMEOUT` (240 s) both degrade to a fallback with no failure signal,
+and `converge record` can fail before it execs at all. What they share:
+
+    a long silent phase after a complete-looking report, an exit code that
+    belongs to the shell rather than the tool, and staged output that leaves
+    nothing behind on a kill.
+
+This module fixes the part that is fixable from inside the process: a stage that
+knows its own budget stops ITSELF, keeps the work it has done, says so in the
+summary, and exits with a code it chose.
+
+Usage -- `arm()` once, then a cooperative check in the hot loop::
+
+    import krt_deadline
+    dl = krt_deadline.arm(args.deadline, tool='place_reconstruct',
+                          on_partial=lambda: report)     # None == no budget
+    ...
+    for violator in violators:
+        if dl and dl.check('legalize'):
+            break
+    ...
+    finally:
+        krt_deadline.emit(report, deadline=dl)
+
+`emit()` is the single print site and fires at most once per process, so calling
+it from the success path AND a `finally` AND the atexit hook is safe.
+
+WHY THIS IS NOT PART OF `cli_banner`
+------------------------------------
+1. `cli_banner.install()` returns early when `KRT_NO_BANNER` is set
+   (`cli_banner.py:59`), and `board_score.run_tool` sets `KRT_NO_BANNER='1'` for
+   every checker it shells (`board_score.py:108-119`). A summary emitter
+   suppressed the same way would go dark exactly where `board_score` reads.
+   Nothing here consults `KRT_NO_BANNER`.
+2. The tools that NEED a deadline are largely the ones that deliberately do NOT
+   carry the banner (`route_disconnected_planes.py`, `route.py`,
+   `place_route_loop.py`). Folding the deadline into `cli_banner` would make
+   adopting it mean adopting `CMD:`/`EXIT=` on their stdout -- a separate and
+   riskier decision this repo takes seriously (`converge.py:692`: "converge's
+   stdout is a JSON API").
+
+`atexit` runs LIFO, so a hook registered by `arm()` AFTER `cli_banner.install()`
+fires BEFORE the banner's `EXIT=` hook. That gives `JSON_SUMMARY:` then `EXIT=`,
+which is the order every consumer wants. **That ordering is load-bearing.**
+
+WHAT THIS CANNOT DO
+-------------------
+Measured on Windows, so nobody expects more than this delivers::
+
+    external `timeout 1`, tool has NO deadline   -> shell rc 124,
+                                                    0 JSON_SUMMARY lines,
+                                                    0 EXIT lines
+    external `timeout 5`, tool deadline 0.4s     -> rc 7, status "deadline",
+                                                    partial result intact,
+                                                    EXIT=7
+
+The first row is run 9's actual case and it stays **unfixable from inside the
+process**: a native win32 process cannot receive a POSIX SIGTERM, and under Git
+Bash the kill resolves to `TerminateProcess`, which is uncatchable -- no handler,
+no `atexit`, no flush. Anyone designing around a SIGTERM handler here is
+designing for a platform that did not produce the bug.
+
+So: **setting a budget BELOW whatever the harness allows is the whole
+mechanism.** The signal handlers below only help for a polite SIGINT/SIGTERM
+(interactive Ctrl+C, POSIX CI). The remaining defence for the uncatchable case is
+line buffering (already done, `cli_banner.py:69-74`), the `DEADLINE:` breadcrumb
+this module prints at arm time, and a progress heartbeat -- which is why
+`stdout_progress` is here and not cosmetic.
+
+DELIBERATELY NOT DONE
+---------------------
+* **A watchdog thread that prints and calls `os._exit`.** It fires even when the
+  main thread is inside a C call, which is seductive -- and it emits state the
+  main thread is mid-mutation of, skips `atexit` (losing `EXIT=`, the exact
+  defect being fixed), and can interleave a partial line into stdout. Both hot
+  loops here are pure Python and reach a cooperative check.
+* **A `DeadlineExceeded` exception.** `route_disconnected_planes.py` is full of
+  `except Exception` swallowers -- `:2474` sits directly on the hot path -- so an
+  exception-based deadline would be caught and converted into a printed note,
+  which is precisely the silent failure being removed. Cooperative flag checks
+  and `return None` only.
+* **A generous default budget.** A wall clock default would make the same board
+  produce a different output on a slower machine, which this repo cares about
+  specifically (`tests/test_457_determinism.py`, `redo_commands.sh` replays). The
+  default is None; the budget belongs to the harness that already owns a clock.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from typing import Any, Callable, Dict, Optional
+
+#: Exit code a stage returns when its OWN budget stopped it.
+#:
+#: Not 124 -- that is the shell's, and erasing the tool/shell distinction is the
+#: confusion being removed. Not 4 -- in these tools 4 asserts a MEASURED defect
+#: class (`route_disconnected_planes.py:3616-3623` advises "reconnect them, or
+#: re-run without --rip-blocker-nets", which presumes a completed run), and a
+#: run that never finished has measured nothing. Not 5 -- already spoken for
+#: repo-wide: `converge.py:446` STUCK and `check_complete.py` UNSOUND. 7 is
+#: unused anywhere, which is what a harness needs.
+DEADLINE_EXIT = 7
+
+_emitted = False
+_summary_fn: Optional[Callable[[], Dict[str, Any]]] = None
+_installed = False
+_signalled = False
+_current: Optional['Deadline'] = None
+
+
+def current() -> Optional['Deadline']:
+    """The budget armed for this process, if any.
+
+    A deliberate global, for the one case threading cannot reach: work buried
+    under a shared engine that no caller in the chain can pass a parameter to.
+    The motivating case is `plane_fragility.register_plane_fragility`, invoked
+    from `route.py:batch_route` -- so EVERY batch_route on a board KiCad cannot
+    fill pays the full 300s EXACT_FILL_TIMEOUT, and the plane repair calls
+    batch_route many times. That is the root cause of both non-terminations
+    measured in run 9, and no signature between the CLI and that call site
+    carries a budget.
+
+    Use it only where a parameter genuinely cannot reach; everywhere else pass
+    the Deadline explicitly.
+    """
+    return _current
+
+
+class Deadline:
+    """A wall-clock budget. Never construct with 0 meaning "no budget" -- use
+    `arm(None)`; `--deadline 0` is a legitimate "stop immediately", which the
+    tests rely on.
+
+    `expired()` is a subtraction and a comparison -- cheap enough for a loop that
+    runs once per violator or once per pad. Do NOT call it per candidate pose;
+    the granularity that matters is "can the partial be described coherently",
+    not "how soon do we notice".
+    """
+
+    __slots__ = ('seconds', 'started', 'tool', 'stopped_in')
+
+    def __init__(self, seconds: Optional[float], tool: str = ''):
+        self.seconds = None if seconds is None else float(seconds)
+        self.started = time.monotonic()
+        self.tool = tool
+        self.stopped_in: Optional[str] = None
+
+    def expired(self, reserve: float = 0.0) -> bool:
+        """True once the budget (minus `reserve`) is spent, or on a signal.
+
+        `reserve` carves a band off the end so a caller can stop its main work
+        early and still have clock left for a mandatory tail step. See
+        `cancel_check`.
+        """
+        if _signalled:
+            return True
+        if self.seconds is None:
+            return False
+        return (time.monotonic() - self.started) >= max(0.0,
+                                                        self.seconds - reserve)
+
+    def check(self, label: str, reserve: float = 0.0) -> bool:
+        """`expired()`, recording WHICH phase owned the clock when it went.
+
+        The label lands in the summary as `stopped_in`, which is the difference
+        between "it timed out" and "it timed out in the legalize sweep with 88
+        violators left".
+        """
+        if self.expired(reserve):
+            if self.stopped_in is None:
+                self.stopped_in = label
+            return True
+        return False
+
+    def cancel_check(self, label: str = '', reserve: float = 0.0):
+        """A zero-arg closure for engines that already take a `cancel_check`.
+
+        `route_disconnected_planes` (`:762`) and `route.py` (`:370`) both accept
+        one and honour it at every loop head -- so a deadline there is this
+        closure, not new machinery.
+        """
+        def _cancel() -> bool:
+            return self.check(label, reserve) if label else self.expired(reserve)
+        return _cancel
+
+    def remaining(self) -> Optional[float]:
+        if self.seconds is None:
+            return None
+        return max(0.0, self.seconds - (time.monotonic() - self.started))
+
+    def elapsed(self) -> float:
+        return time.monotonic() - self.started
+
+    def __repr__(self) -> str:  # pragma: no cover - diagnostics only
+        cap = 'none' if self.seconds is None else f'{self.seconds:g}s'
+        return f'<Deadline {self.tool} cap={cap} elapsed={self.elapsed():.1f}s>'
+
+
+def arm(seconds: Optional[float], *, tool: str,
+        on_partial: Optional[Callable[[], Dict[str, Any]]] = None
+        ) -> Optional[Deadline]:
+    """Start a budget, announce it, and arrange a partial flush if interrupted.
+
+    Precedence: the `seconds` argument, else `$KRT_DEADLINE_S` (so a harness can
+    set one budget for a whole chain with one export), else None.
+
+    Returns None when there is no budget, so callers can write `if dl and
+    dl.check(...)` and pay nothing when the feature is off.
+
+    The `DEADLINE:` line it prints is deliberate: a log WITHOUT it is proof no
+    budget was set, which is the standing diagnosis for the next 46-minute run.
+    """
+    if seconds is None:
+        env = os.environ.get('KRT_DEADLINE_S')
+        if env:
+            try:
+                seconds = float(env)
+            except ValueError:
+                print(f"krt_deadline: ignoring unparseable KRT_DEADLINE_S="
+                      f"{env!r}", file=sys.stderr)
+    global _current
+    dl = None if seconds is None else Deadline(seconds, tool=tool)
+    _current = dl
+    if dl is not None:
+        print(f"DEADLINE: {dl.seconds:g}s ({tool})", flush=True)
+    # Install the flush hook even with NO budget. The atexit hook is what makes
+    # "a JSON_SUMMARY on every path" true -- it covers early returns, argparse
+    # errors and unhandled exceptions, which is why the callers need no
+    # try/finally around a main() with a dozen return statements. Without this,
+    # the guarantee would only exist for runs that happened to set a budget.
+    if on_partial is not None:
+        _install(on_partial, dl)
+    return dl
+
+
+def emit(report: Optional[Dict[str, Any]], *, complete: bool = True,
+         status: str = 'ok', deadline: Optional[Deadline] = None) -> bool:
+    """The ONE `JSON_SUMMARY:` print site. Fires at most once per process.
+
+    Returns True if this call did the printing. A payload that will not
+    serialise is reported rather than swallowed -- a summary that vanished is the
+    defect this module exists to remove, so it must not reappear as an exception.
+    """
+    global _emitted
+    if _emitted or report is None:
+        return False
+    _emitted = True
+    doc = dict(report)
+    doc.setdefault('complete', complete)
+    doc.setdefault('status', status)
+    if deadline is not None:
+        doc.setdefault('deadline_s', deadline.seconds)
+        doc.setdefault('elapsed_s', round(deadline.elapsed(), 1))
+        if deadline.stopped_in:
+            doc.setdefault('stopped_in', deadline.stopped_in)
+    try:
+        print('JSON_SUMMARY: ' + json.dumps(doc, sort_keys=True, default=str),
+              flush=True)
+    except Exception as exc:                                   # noqa: BLE001
+        try:
+            print('JSON_SUMMARY: ' + json.dumps(
+                {'complete': False, 'status': 'error',
+                 'error': f'summary unserialisable: {exc}'}), flush=True)
+        except Exception:                                      # pragma: no cover
+            pass
+    return True
+
+
+def seal() -> bool:
+    """Declare the JSON_SUMMARY already published, WITHOUT printing one.
+
+    For a tool whose engine prints its own summary. `route.py` and
+    `route_diff.py` are the cases: `batch_route` builds a large summary and
+    `print`s it directly, and it does so once per pass (the reconciliation
+    self-invoke prints a second), so routing them through `emit()` -- which
+    fires at most once -- would swallow every summary after the first.
+
+    Without this the atexit flush would see `_emitted` still False on a
+    perfectly successful run and publish the contentless partial report armed
+    at `--deadline` time, printing a SECOND, contradicting
+    `{"complete": false, "status": "incomplete"}` line after the real one. That
+    is a measured defect, not a hypothetical: it shipped in
+    `route_disconnected_planes` (run 11, v6_r7) and any consumer keying on the
+    LAST JSON_SUMMARY read a good run as a failed one.
+
+    Returns True if this call did the sealing.
+    """
+    global _emitted
+    if _emitted:
+        return False
+    _emitted = True
+    return True
+
+
+def stamp(report: Dict[str, Any]) -> Dict[str, Any]:
+    """Stamp THIS PROCESS's spent budget onto a summary someone else prints.
+
+    The companion to `seal()`, and the reason neither is a new engine kwarg:
+    `batch_route`'s summary is the only one `route.py` emits, and
+    `place_route_loop` already refuses a `complete: false` tally
+    (`place_route_loop.py:162`) while `route_summary.merge_summaries` already
+    makes incompleteness sticky across passes. The one missing piece was the
+    stamp itself, and it is read through `current()` rather than threaded
+    through the signature -- so the GUI, which never arms a budget, is inert
+    here and no parity gate is involved.
+
+    A no-op unless a budget was armed AND actually cut the work short, so a
+    summary from a run that finished inside its budget is byte-identical to
+    before.
+
+    "Cut short" is `stopped_in or expired()`, not `expired()` alone. A caller
+    using a RESERVE band (`cancel_check(label, reserve=...)`, which
+    route_planes and route_disconnected_planes both need so the bounded tail
+    still has clock) trips its loops at `deadline - reserve` -- and if that
+    tail then finishes before the wall clock runs out, the run is past its
+    cancel and NOT past its deadline. Testing `expired()` alone would report
+    that partial board as complete, which is precisely the confusion this
+    module exists to remove. `stopped_in` is set by `Deadline.check` at the
+    moment the cancel fires, so it is the durable record.
+    """
+    dl = _current
+    if dl is None or not (dl.stopped_in or dl.expired()):
+        return report
+    report['complete'] = False
+    report['status'] = 'deadline'
+    report['deadline_s'] = dl.seconds
+    report['elapsed_s'] = round(dl.elapsed(), 1)
+    report['stopped_in'] = dl.stopped_in
+    return report
+
+
+def mark(report: Dict[str, Any], dl: Deadline, **partial: Any
+         ) -> Dict[str, Any]:
+    """Stamp `report` as a partial result, in the shape consumers rely on.
+
+    `complete` is the machine gate -- read it as `.get('complete', True)` so
+    pre-change logs degrade correctly. `status` is the branching discriminator:
+    a cancel is not a deadline is not a crash, and encoding the reason only as a
+    bool loses that.
+
+    `status` is `"deadline"`, not `"timeout"` -- `timeout` already means
+    something else in these summaries (`max_iterations`, A* budgets).
+    """
+    report['complete'] = False
+    report['status'] = 'deadline'
+    report['deadline_s'] = dl.seconds
+    report['elapsed_s'] = round(dl.elapsed(), 1)
+    report['stopped_in'] = dl.stopped_in
+    if partial:
+        report.setdefault('partial', {}).update(partial)
+    return report
+
+
+def stdout_progress(min_interval: float = 15.0,
+                    deadline: Optional[Deadline] = None):
+    """A throttled `(current, total, label)` callback for CLI progress.
+
+    `route_disconnected_planes` already invokes `progress_callback` at ~9 sites;
+    it is None on the CLI path only because it was built for the GUI. Passing
+    this lights all of them up with no new print statements.
+
+    Throttling matters: one of those sites fires per pad and would otherwise
+    flood a 96-pad board's log. `PROGRESS:` is a distinct prefix that cannot
+    match `route_summary.SUMMARY_RE`.
+    """
+    state = {'last': 0.0}
+
+    def _progress(current=0, total=0, label='') -> None:
+        now = time.monotonic()
+        if now - state['last'] < min_interval:
+            return
+        state['last'] = now
+        frac = f"{current}/{total}  " if total else ''
+        clock = ''
+        if deadline is not None and deadline.seconds is not None:
+            clock = f"  [t={deadline.elapsed():.0f}s/{deadline.seconds:g}s]"
+        try:
+            print(f"PROGRESS: {frac}{label}{clock}", flush=True)
+        except Exception:                                      # noqa: BLE001
+            pass
+    return _progress
+
+
+def _install(on_partial: Callable[[], Dict[str, Any]],
+             dl: Optional[Deadline]) -> None:
+    """atexit + signal wiring. Every registration is defensive: a missing signal
+    must not stop the tool from running."""
+    global _installed, _summary_fn
+    _summary_fn = on_partial
+    if _installed:
+        return
+    _installed = True
+
+    import atexit
+
+    @atexit.register
+    def _flush() -> None:                                      # pragma: no cover
+        if _emitted or _summary_fn is None:
+            return
+        try:
+            rep = _summary_fn()
+        except Exception as exc:                               # noqa: BLE001
+            emit({'error': f'partial summary unavailable: {exc}'},
+                 complete=False, status='error')
+            return
+        # Name the reason accurately: a run that died on an early return is
+        # `incomplete`, not `deadline`. Conflating them would put the wrong
+        # diagnosis in the one artefact that survives.
+        if _signalled:
+            status = 'cancelled'
+        elif dl is not None and dl.expired():
+            status = 'deadline'
+            mark(rep, dl)
+        else:
+            status = 'incomplete'
+        emit(rep, complete=False, status=status, deadline=dl)
+
+    try:
+        import signal
+
+        def _on_signal(signum, _frame):                        # noqa: ANN001
+            # Set a flag ONLY. Printing from a handler can interleave into a
+            # half-written stdout line and corrupt the very JSON_SUMMARY a
+            # scraper reads; the atexit hook does the I/O instead. A second
+            # identical signal restores the default so Ctrl+C twice always
+            # kills.
+            global _signalled
+            if _signalled:
+                signal.signal(signum, signal.SIG_DFL)
+                return
+            _signalled = True
+            sys.exit(130 if signum == getattr(signal, 'SIGINT', None)
+                     else DEADLINE_EXIT)
+
+        for _name in ('SIGTERM', 'SIGINT', 'SIGBREAK'):
+            _sig = getattr(signal, _name, None)
+            if _sig is None:
+                continue
+            try:
+                signal.signal(_sig, _on_signal)
+            except (ValueError, OSError, RuntimeError):
+                pass          # not the main thread, or platform refuses it
+    except Exception:                                          # noqa: BLE001
+        pass
+
+
+def reset_for_test() -> None:
+    """Test hook: forget that a summary was emitted."""
+    global _emitted, _installed, _summary_fn, _signalled
+    _emitted = False
+    _installed = False
+    _summary_fn = None
+    _signalled = False

--- a/py_router/list_nets.py
+++ b/py_router/list_nets.py
@@ -268,6 +268,47 @@ def board_constraint(pcb_path, key, design_rules=None):
         return None
 
 
+def board_floor_declaration(pcb_path, design_rules=None):
+    """What this board DECLARES about its own DRC floors -- and whether that is
+    nothing at all.
+
+    Returns ``{'classes': int, 'constraints': int, 'source': str|None,
+    'declares_nothing': bool}``. ``declares_nothing`` is True when the board
+    carries NO net class and NO board constraint from any source -- no sibling
+    ``.kicad_pro``, and no KiCad 6/7 ``(net_class ...)`` block in the board
+    file either.
+
+    Why the graders need this rather than just a value (run-12 Tier 1.3): every
+    floor accessor here answers ``None`` on such a board, and each grader then
+    quietly substitutes its own constant (``routing_defaults.CLEARANCE`` 0.25,
+    check_drc's 0.2). Measured on tigard, which ships no project: a whole
+    placement baseline was graded against a fallback with nothing in the
+    transcript recording that the number was a fallback rather than the board's
+    own. That is the "grade at a floor the board was not routed to" failure
+    CLAUDE.md warns about, reached from the other direction -- and unlike a
+    board that declares 0.25, there is no value to compare against to notice it.
+
+    Report-only. Nothing here changes a floor or an exit code; it exists so a
+    grader can NAME its fallback.
+
+    A board whose rules could not be READ answers ``declares_nothing: False``
+    plus an ``error``, never True: "I could not look" is not "there is nothing
+    there", and a disclosure that fires on a read failure is the kind of line
+    readers learn to skip.
+    """
+    try:
+        dr = design_rules if design_rules is not None else read_design_rules(pcb_path)
+    except Exception as exc:                                   # noqa: BLE001
+        return {'classes': 0, 'constraints': 0, 'source': None,
+                'declares_nothing': False,
+                'error': f'{type(exc).__name__}: {exc}'}
+    classes = dr.get('classes') or {}
+    constraints = dr.get('constraints') or {}
+    return {'classes': len(classes), 'constraints': len(constraints),
+            'source': dr.get('source'),
+            'declares_nothing': not classes and not constraints}
+
+
 def board_floor_knobs(pcb_path, clearance=None, board_edge_clearance=None,
                       clearance_default=0.25, edge_default=0.55,
                       design_rules=None):
@@ -284,10 +325,17 @@ def board_floor_knobs(pcb_path, clearance=None, board_edge_clearance=None,
     records each value's source (``'cli'`` | ``'board netclass'`` |
     ``'board constraint'`` | ``'fixed default'``) for JSON disclosure.
     """
+    # A non-positive declared value is UNSET, not a floor of zero -- KiCad
+    # writes 0 into these fields for "not configured", and reading it as a real
+    # floor collapses every consumer to no clearance at all. `board_floor`
+    # below encodes the same rule; this helper predates it and did NOT, so a
+    # project declaring `min_copper_edge_clearance: 0.0` silently gave
+    # render_placement a 0.0 edge floor (every edge-halo and oob term
+    # vanishing) where it had previously used 0.55.
     knobs = {}
     if clearance is None:
         v = board_default_netclass_clearance(pcb_path, design_rules)
-        clearance, src = ((v, 'board netclass') if v is not None
+        clearance, src = ((v, 'board netclass') if v is not None and v > 0
                           else (clearance_default, 'fixed default'))
     else:
         src = 'cli'
@@ -295,13 +343,167 @@ def board_floor_knobs(pcb_path, clearance=None, board_edge_clearance=None,
     if board_edge_clearance is None:
         v = board_constraint(pcb_path, 'min_copper_edge_clearance',
                              design_rules)
-        board_edge_clearance, src = ((v, 'board constraint') if v is not None
+        board_edge_clearance, src = ((v, 'board constraint')
+                                     if v is not None and v > 0
                                      else (edge_default, 'fixed default'))
     else:
         src = 'cli'
     knobs['board_edge_clearance'] = {'value': board_edge_clearance,
                                      'source': src}
     return clearance, board_edge_clearance, knobs
+
+
+# Where each floor legitimately comes from: (Default-netclass key, board
+# constraint key). None means "this floor is not expressed there".
+#
+# `clearance` deliberately has NO constraint fallback. `min_clearance` is an
+# unreliable edit-floor -- it is 0.0 on the measured board and stale-large on
+# others (see effective_floors' note at :86) -- so falling back to it would
+# resolve a board declaring a 0.2 netclass to 0.0 and relax every consumer to
+# nothing. The netclass is the honest source for clearance; the constraints are
+# the honest source for the hole/edge floors, which no netclass expresses.
+_FLOOR_SOURCES = {
+    'clearance':            ('clearance',    None),
+    'track_width':          ('track_width',  'min_track_width'),
+    'via_diameter':         ('via_diameter', 'min_via_diameter'),
+    'via_drill':            ('via_drill',    None),
+    'board_edge_clearance': (None,           'min_copper_edge_clearance'),
+    'hole_clearance':       (None,           'min_hole_clearance'),
+    'hole_to_hole':         (None,           'min_hole_to_hole'),
+}
+
+
+def board_floor(pcb_path, name, explicit=None, fallback=None,
+                design_rules=None):
+    """ONE floor, resolved BOARD-FIRST. Returns ``(value, source)``.
+
+    Precedence, the same one `board_floor_knobs` uses and with the same source
+    vocabulary (``'cli'`` | ``'board netclass'`` | ``'board constraint'`` |
+    ``'fixed default'``): an explicit value wins, then the board's own Default
+    netclass, then its board constraint, then the caller's fallback.
+
+    This exists because instruments kept substituting their own constant for a
+    value the board declares, each in its own way, and each wrong in a
+    different direction. Measured here: `check_channels` at its old 0.25/0.3
+    constants reported 334 escape lanes where the board's own 0.2/0.254 floor
+    gives 399 -- 65 lanes understated. (The originating report measured 304 vs
+    378 on the same board at 0.2/0.2; same direction and scale, different track
+    width.) It also invented a deficit on a face that had none -- a phantom
+    that would have steered a placement search. `obstacle_map` priced NPTH at
+    a hardcoded max(clearance, 0.20) while the board declared
+    ``min_hole_clearance`` 0.25, and a route came within 0.2263 mm of an NPTH:
+    a real 0.0237 mm violation, routing-introduced.
+
+    A non-positive constraint is treated as UNSET rather than as a floor of
+    zero. KiCad writes 0 for "not configured" in these fields, and reading it
+    as a genuine 0 relaxes the consumer to nothing -- the same trap that keeps
+    `min_clearance` out of the table above.
+
+    IT IS NOT RAISE-ONLY, and nothing here pretends otherwise. Once a declared
+    value is positive it is returned as-is, with NO max() against `fallback`,
+    so a board can resolve a floor DOWNWARDS. That is the point for a tool
+    that GRADES EXISTING COPPER: `check_assembly` must measure at the board's
+    own clearance even when it sits below the packaged default, or it
+    manufactures phantom violations on copper placed correctly (CLAUDE.md,
+    "Grade DRC at the clearance the board was actually routed to").
+
+    THE DISTINCTION IS GRADE-vs-PREDICT, not tool-by-tool. `check_channels`
+    was listed here as another such consumer and that was wrong: it does not
+    grade copper, it PREDICTS routability, so a declared lane pitch finer than
+    the fab can etch makes it promise capacity nobody can build. Measured on
+    tigard --refs U3 (fab floors 0.09 / 0.0762): a declared 0.05/0.05 took its
+    deficit faces from 3 to 1 and U3's supply from 29 to 120, hiding two real
+    deficits. It now wraps at the fab floor (check_channels.py, `_fab`). A
+    predictive consumer needs the wrap; a grading one must not have it.
+
+    A consumer for which downward is a FAB question must therefore wrap this
+    in its own max(), exactly as `resolve_hole_clearance`'s consumers do
+    (obstacle_map.py:1580, plane_obstacle_builder.py:1208) -- that helper is
+    called "raise-only" only because of those wraps, never on its own.
+    Measured: a project declaring ``min_hole_to_hole: 0.10`` resolves here to
+    ``(0.1, 'board constraint')``, and the qfn underpad escape spaced this
+    run's drills at 0.10 -- below the 0.20 JLC fab floor -- until it grew the
+    wrap (qfn_fanout/__init__.py, ``_h2h_fab``). The routing CLIs get the same
+    protection from `enforce_fab_floors`, which runs on args right after
+    `resolve_cli_floor`; an engine-internal read like the qfn one does not,
+    because that pins a value it never reads.
+    """
+    if name not in _FLOOR_SOURCES:
+        raise KeyError(f"unknown floor {name!r}; "
+                       f"known: {', '.join(sorted(_FLOOR_SOURCES))}")
+    if explicit is not None:
+        return float(explicit), 'cli'
+    cls_key, con_key = _FLOOR_SOURCES[name]
+    # The guard wraps the ACCESSORS too, not just read_design_rules: a caller
+    # may hand in its own `design_rules`, and a malformed one raises inside
+    # board_default_netclass_param / board_constraint rather than here.
+    try:
+        dr = (design_rules if design_rules is not None
+              else read_design_rules(pcb_path))
+        if cls_key:
+            v = board_default_netclass_param(pcb_path, cls_key, dr)
+            if v is not None and v > 0:
+                return float(v), 'board netclass'
+        if con_key:
+            v = board_constraint(pcb_path, con_key, dr)
+            if v is not None and v > 0:
+                return float(v), 'board constraint'
+    except Exception:                                          # noqa: BLE001
+        # "I could not look" is NOT "there is nothing there" -- the same
+        # distinction board_floor_declaration exists to preserve. The VALUE is
+        # the fallback either way, but the source must not claim the board was
+        # read and found silent, or a corrupt .kicad_pro reads in a table
+        # exactly like a board that genuinely declares nothing.
+        return _num(fallback), 'unreadable project'
+    return _num(fallback), 'fixed default'
+
+
+def _num(v):
+    """Fallbacks are returned in the same type the board paths return."""
+    return None if v is None else float(v)
+
+
+def resolve_cli_floor(pcb_path, name, explicit, fallback, flag):
+    """One routing-CLI geometry floor, resolved board-first and ANNOUNCED with
+    its real source. Returns the value.
+
+    THE SPLIT THIS CLOSES. `board_floor` / `board_floor_knobs` /
+    `resolve_hole_clearance` -- and the GUI's own
+    `_effective_plane_edge_clearance` -- all treat a declared 0 as UNSET,
+    because that is what KiCad writes into these fields for "not configured".
+    The four routing mains did not: each carried its own copy of
+    ``board_constraint(...) if ... is not None else <default>``, an
+    ``is not None`` test with no positivity guard, eight sites in all
+    (route.py 3725/3731, route_diff.py 1947/1953, route_planes.py 4940/4946,
+    route_disconnected_planes.py 3410/3416).
+
+    So on a board declaring ``min_copper_edge_clearance: 0.0`` the two halves
+    of the place/route loop read one declared floor two ways: the placement
+    half (render_placement, check_floorplan, converge -- all via
+    board_floor_knobs) resolved 0.55 ``[fixed default]``, while the routing
+    half took a REAL floor of 0.0 and printed *"using the board
+    min_copper_edge_clearance 0.0mm"* -- claiming the board had declared what
+    it had in fact left unset. The plane engines were worse than misleading:
+    a declared 0.0 dropped their zone inset from PLANE_EDGE_CLEARANCE 0.5 to
+    0.0, while the GUI's plane tab held 0.5 because it already had the guard.
+
+    The FALLBACKS legitimately differ between callers and are NOT unified
+    here: the signal mains fall back to BOARD_EDGE_CLEARANCE 0.0, which is a
+    deliberate sentinel meaning "no edge rule declared, use the copper-copper
+    clearance instead" (route.py:896, obstacle_map.py:797), while the plane
+    mains fall back to PLANE_EDGE_CLEARANCE 0.5 and the placement model to
+    0.55. What must agree -- and now does -- is whether the board declared
+    anything at all, and what the tool SAYS about where its number came from.
+
+    The source tag is printed in the same ``[board constraint]`` /
+    ``[fixed default]`` / ``[unreadable project]`` vocabulary the placement
+    instruments use, because "fixed default" means the board declared nothing,
+    not that it agreed.
+    """
+    value, src = board_floor(pcb_path, name, explicit, fallback)
+    if src != 'cli':
+        print(f"{flag} not given; using {value}mm [{src}].")
+    return value
 
 
 def net_clearance_map_by_id(pcb_path, nets, design_rules=None):

--- a/py_router/net_rescue.py
+++ b/py_router/net_rescue.py
@@ -37,6 +37,7 @@ Design constraints (#331/#371 review):
 import env_knobs
 import math
 import os
+import collections as _c
 import time
 from dataclasses import replace
 from typing import Dict, List, Optional, Tuple
@@ -464,7 +465,7 @@ def rescue_failed_nets(state, single_ended_nets, net_clearances=None,
     'unchanged', 'pads_reconnected', 'widths', 'time'}) or None when there was
     nothing to rescue (or KICAD_NET_RESCUE=0).
 
-    'widths' is {net: {'requested_mm', 'delivered_mm'}} for every net the
+    'widths' is {net: {'requested_mm', 'delivered_mm', and when the rescue emitted width-bearing copper, rescue_* keys describing THIS RESCUE's segments only}} for every net the
     rescue touched -- the width provenance that used to vanish: the ladder
     re-routes at the floor and reports the net `recovered` with
     `failed_single` empty, so a 0.8mm request silently shipping as 0.15mm
@@ -653,9 +654,56 @@ def rescue_failed_nets(state, single_ended_nets, net_clearances=None,
         # was asked and what was delivered so the JSON tells the truth without
         # anyone re-measuring the board.
         _req_w = config.get_net_track_width(net_id, config.layers[0])
-        _del_w = min(used_widths) if used_widths else _req_w
-        summary['widths'][net_name] = {'requested_mm': round(_req_w, 4),
-                                       'delivered_mm': round(_del_w, 4)}
+        # A HISTOGRAM, not a scalar. `delivered_mm` was min(used_widths) under
+        # a name that reads as "what it got", and this net's copper is
+        # routinely MIXED: one rail came out 59 segments at 0.0889, 3 at
+        # 0.1998 and 67 at 0.2, reported as 0.0889. Both readings mislead in
+        # opposite directions -- the minimum makes a mostly-wide rail look
+        # uniformly thin, and a mean would hide the thin run entirely.
+        #
+        # Ampacity is set by the NARROWEST series segment, so `min` stays and
+        # keeps its meaning; `by_width` is what tells a reader whether that
+        # minimum is the whole net or a short neck. Taken from the emitted
+        # segments rather than the requested widths, because a request is not
+        # a result -- impedance and neckdown both diverge from it.
+        _hist = _c.Counter(round(float(getattr(sg, 'width', 0.0)), 4)
+                           for sg in merged['new_segments']
+                           if getattr(sg, 'width', None))
+        _del_w = min(_hist) if _hist else (min(used_widths) if used_widths
+                                           else _req_w)
+        _w = {
+            'requested_mm': round(_req_w, 4),
+            'delivered_mm': round(_del_w, 4),          # the NARROWEST, as before
+        }
+        if _hist:
+            # SCOPED, and named so. This histogram covers the copper THIS
+            # RESCUE emitted -- not the net's whole copper. That distinction
+            # is the difference between informing a reader and misleading one:
+            # the finding that motivated it measured +1V2 across the finished
+            # board as 59 segments @ 0.0889, 3 @ 0.1998 and 67 @ 0.2, but only
+            # the 0.0889 run came from the rescue. An unscoped name here would
+            # show a single 0.0889 bin and look like CORROBORATION of exactly
+            # the "uniformly thin" reading the finding was warning against.
+            #
+            # Emitted widths, not the requested rung: a request is not a
+            # result, and neckdown and the oracle's width clamp both diverge
+            # from it (measured: a 0.2 rung emitting a 0.1 and a 0.4 segment).
+            _w.update({
+                'rescue_min_mm': round(_del_w, 4),
+                'rescue_max_mm': round(max(_hist), 4),
+                'rescue_segments_emitted': sum(_hist.values()),
+                'rescue_by_width': {f'{w:g}': n for w, n in sorted(_hist.items())},
+                'scope': ('THIS RESCUE ONLY -- not the net. Counts are as '
+                          'EMITTED, before cycle-prune drops redundant loop '
+                          'segments, so the board can carry fewer. For the '
+                          "net's whole width profile, measure the board."),
+            })
+        else:
+            # No emitted segment carried a width (a vias-only edge). Say that,
+            # rather than asserting a min and max over an empty histogram.
+            _w['scope'] = ('this rescue emitted no width-bearing segment; '
+                           'delivered_mm falls back to the requested rung')
+        summary['widths'][net_name] = _w
         _thin = (f", {YELLOW}width {_del_w:g} vs requested {_req_w:g}{RESET}"
                  if _del_w < _req_w - 1e-9 else "")
         print(f"    {GREEN}{'fully reconnected' if fully else 'improved'}{RESET} "

--- a/py_router/obstacle_map.py
+++ b/py_router/obstacle_map.py
@@ -1439,6 +1439,61 @@ def block_track_cells_near_override_pad_holes(obstacles: GridObstacleMap,
         obstacles.add_blocked_cells_batch(np.hstack([arr, layer_col]))
 
 
+_HOLE_CLR_CACHE = {}          # board path -> declared min_hole_clearance (mm)
+_HOLE_CLR_ANNOUNCED = set()
+
+
+def resolve_hole_clearance(pcb_data: PCBData, config) -> float:
+    """The copper-to-HOLE floor this board declares, in mm (0.0 = none).
+
+    Resolved ENGINE-SIDE off ``PCBData.source_path`` (the #498 mechanism built
+    for exactly this), so both fronts inherit it with no wiring. An explicit
+    ``config.hole_clearance`` wins and stops the read.
+
+    WHO ACTUALLY INHERITS IT, precisely -- everything routed through
+    ``add_drill_hole_obstacles`` (signal, diff pairs, BGA/QFN fanout, via
+    ``build_base_obstacle_map``), plus ``plane_obstacle_builder`` which builds
+    its own map and therefore needed the call adding separately. It is NOT a
+    universal fix: the flat ``NPTH_TO_TRACK_CLEARANCE`` still stands in
+    ``plane_region_connector`` (taps / region joins / reconnects),
+    ``pcb_modification`` and ``placement/fanout_clearance``. Those are the same
+    defect and are not yet closed; do not read this helper's existence as
+    covering them.
+
+    Why it exists: this keep-out was priced at a hardcoded
+    ``max(clearance, NPTH_TO_TRACK_CLEARANCE)`` -- a flat 0.20 fab floor -- and
+    never read the board, while `check_drc` DOES read `min_hole_clearance`
+    (:2390). So on a board declaring 0.25 the router would route into a band its
+    own checker then flagged. Measured: a route came within 0.2263 mm of BUS1's
+    NPTH against a declared 0.25, a real 0.0237 mm violation, routing-introduced
+    and confirmed independently by kicad-cli. It was the single DRC failure on
+    that board.
+
+    Cached per board path: the obstacle map is rebuilt per net, and this would
+    otherwise re-read the project file thousands of times in one run.
+    """
+    explicit = getattr(config, 'hole_clearance', 0.0) or 0.0
+    if explicit > 0:
+        return float(explicit)
+    path = getattr(pcb_data, 'source_path', "") or ""
+    if not path:
+        return 0.0
+    if path not in _HOLE_CLR_CACHE:
+        try:
+            from list_nets import board_constraint
+            v = board_constraint(path, 'min_hole_clearance')
+            _HOLE_CLR_CACHE[path] = float(v) if v and v > 0 else 0.0
+        except Exception:                                       # noqa: BLE001
+            _HOLE_CLR_CACHE[path] = 0.0
+    v = _HOLE_CLR_CACHE[path]
+    if v > defaults.NPTH_TO_TRACK_CLEARANCE and path not in _HOLE_CLR_ANNOUNCED:
+        _HOLE_CLR_ANNOUNCED.add(path)
+        print(f"Copper-to-hole clearance {v:g}mm (from the board's own "
+              f"min_hole_clearance, above the {defaults.NPTH_TO_TRACK_CLEARANCE}"
+              f"mm fab floor)")
+    return v
+
+
 def add_drill_hole_obstacles(obstacles: GridObstacleMap, pcb_data: PCBData,
                               config: GridRouteConfig, nets_to_route_set: set,
                               extra_clearance: float = 0.0):
@@ -1461,6 +1516,9 @@ def add_drill_hole_obstacles(obstacles: GridObstacleMap, pcb_data: PCBData,
         config: Routing configuration
         nets_to_route_set: Set of net IDs being routed (excluded from blocking)
     """
+    # The board's own copper-to-hole floor, once per call (cached per board).
+    _hole_clr = resolve_hole_clearance(pcb_data, config)
+
     drill_holes = []   # every drill -> via (hole-to-hole) keep-out
     npth_holes = []    # no-copper holes only -> track keep-out
     npth_slot_holes = []  # milled SLOT subset: board-edge clearance applies (#448)
@@ -1517,7 +1575,10 @@ def add_drill_hole_obstacles(obstacles: GridObstacleMap, pcb_data: PCBData,
         # extra_clearance covers geometry offset from the routed centerline
         # (diff-pair P/N tracks ride +-(gap+width)/2 off it), matching how every
         # other obstacle in that base map is inflated (issue #268).
-        npth_clr = max(config.clearance, defaults.NPTH_TO_TRACK_CLEARANCE) + extra_clearance
+        # `_hole_clr` is the BOARD's own min_hole_clearance -- raise-only, so a
+        # board declaring nothing is byte-identical (see resolve_hole_clearance).
+        npth_clr = (max(config.clearance, defaults.NPTH_TO_TRACK_CLEARANCE,
+                        _hole_clr) + extra_clearance)
         block_track_cells_near_drills(obstacles, npth_holes, config.track_width,
                                       npth_clr, config.grid_step,
                                       list(range(len(config.layers))))
@@ -1532,7 +1593,8 @@ def add_drill_hole_obstacles(obstacles: GridObstacleMap, pcb_data: PCBData,
         edge_eff = (config.board_edge_clearance if config.board_edge_clearance > 0
                     else config.clearance)
         slot_clr = edge_eff + extra_clearance
-        if slot_clr > max(config.clearance, defaults.NPTH_TO_TRACK_CLEARANCE) + extra_clearance:
+        if slot_clr > max(config.clearance, defaults.NPTH_TO_TRACK_CLEARANCE,
+                          _hole_clr) + extra_clearance:
             block_track_cells_near_drills(obstacles, npth_slot_holes,
                                           config.track_width, slot_clr,
                                           config.grid_step,

--- a/py_router/plane_fragility.py
+++ b/py_router/plane_fragility.py
@@ -371,8 +371,39 @@ def _compute_cells_and_states(pcb_data: PCBData, config: GridRouteConfig,
     src = getattr(pcb_data, 'source_path', None)
     if not polys and src and os.path.isfile(src):
         try:
-            from kicad_exact_fill import refill_islands
-            fills = refill_islands(src)
+            from kicad_exact_fill import refill_islands, EXACT_FILL_TIMEOUT
+            # BOUND THE FILL BY THE RUN'S REMAINING BUDGET. This call is reached
+            # from route.py:batch_route, so it runs on EVERY batch_route -- and
+            # on a board KiCad's ZONE_FILLER cannot fill (measured: a 217-part
+            # 4-layer board) each one pays the full 300s EXACT_FILL_TIMEOUT.
+            # The plane repair issues many batch_route calls, which is the root
+            # cause of both non-terminations measured in run 9. No signature
+            # between the CLI and here carries a budget, hence the global.
+            _t = EXACT_FILL_TIMEOUT
+            try:
+                import krt_deadline
+                _dl = krt_deadline.current()
+            except Exception:                                  # noqa: BLE001
+                _dl = None
+            if _dl is not None:
+                _left = _dl.remaining()
+                if _dl.expired() or (_left is not None and _left < 5.0):
+                    raise TimeoutError(
+                        'run budget spent; not starting a KiCad refill')
+                # Never let one fill eat the whole remaining budget.
+                _t = max(5, int(min(_t, (_left or _t) * 0.5)))
+            fills = refill_islands(src, timeout=_t, verbose=True)
+            if fills is None:
+                # refill_islands documents a None return, and this was the ONE
+                # call site in the repo that dereferenced it anyway. The
+                # resulting `'NoneType' object has no attribute 'items'` was
+                # printed as if it were the diagnosis, while the real reason --
+                # a 300s timeout, or pcbnew missing -- was computed inside
+                # refill_islands and discarded. verbose=True above makes it say
+                # so; this branch stops the AttributeError masquerading as one.
+                raise RuntimeError(
+                    f'KiCad refill returned nothing within {_t}s '
+                    f'(fill timed out, or pcbnew unavailable)')
             polys = [(name_to_id.get(_net, -1), layer, poly)
                      for (_net, layer), pp in fills.items() for poly in pp]
             if polys:

--- a/py_router/plane_obstacle_builder.py
+++ b/py_router/plane_obstacle_builder.py
@@ -1199,7 +1199,14 @@ def build_routing_obstacle_map(
             if pad.drill > 0 and not _pad_has_copper(pad):
                 from kicad_parser import pad_drill_circles
                 npth_holes.extend(pad_drill_circles(pad))
-    npth_clr = max(config.clearance, defaults.NPTH_TO_TRACK_CLEARANCE)
+    # Board-first, exactly as the signal obstacle map does (#D11). The plane
+    # engines build their own map and never call add_drill_hole_obstacles, so
+    # fixing that one alone left plane taps / region joins / reconnects still
+    # pricing NPTH at the flat 0.20 fab floor on a board declaring more.
+    # Raise-only: a board declaring nothing is byte-identical.
+    from obstacle_map import resolve_hole_clearance
+    npth_clr = max(config.clearance, defaults.NPTH_TO_TRACK_CLEARANCE,
+                   resolve_hole_clearance(pcb_data, config))
     block_track_cells_near_drills(obstacles, npth_holes, route_track_w,
                                   npth_clr, config.grid_step, [layer_idx])
     # Holes of pads carrying a clearance OVERRIDE (pad.local_clearance): KiCad's

--- a/py_router/plane_region_connector.py
+++ b/py_router/plane_region_connector.py
@@ -439,6 +439,14 @@ def _regions_from_fill_models(net_id, pcb_data, coord, plane_layer,
     # Coarse-grid cells per plane-layer fill component: one vectorized
     # gather of each model's label array at the analysis-grid cell centres.
     cells_by_comp: Dict[tuple, Set[Tuple[int, int]]] = {}
+    # First island key seen at each coarse cell, and the (few) collisions. A
+    # cell claimed by two keys is a point where TWO models both predict fill --
+    # see the co-located union below. Only the FIRST key per cell is kept
+    # (union is transitive, so pairing every later key with it yields the same
+    # partition): storing a set per cell instead costs ~60MB of Python sets on
+    # a board-wide pour, for the same answer.
+    first_key_by_cell: Dict[Tuple[int, int], tuple] = {}
+    colocated_pairs: List[Tuple[tuple, tuple]] = []
     gxs = np.arange(min_gx, max_gx + 1)
     gys = np.arange(min_gy, max_gy + 1)
     if gxs.size == 0 or gys.size == 0:
@@ -456,8 +464,12 @@ def _regions_from_fill_models(net_id, pcb_data, coord, plane_layer,
         lab[np.ix_(sel_x, sel_y)] = m.labels[ix[sel_x][:, None], iy[sel_y]]
         nz = np.nonzero(lab)
         for ii, jj in zip(nz[0].tolist(), nz[1].tolist()):
-            cells_by_comp.setdefault((id(m), int(lab[ii, jj])), set()).add(
-                (int(gxs[ii]), int(gys[jj])))
+            _key = (id(m), int(lab[ii, jj]))
+            _cell = (int(gxs[ii]), int(gys[jj]))
+            cells_by_comp.setdefault(_key, set()).add(_cell)
+            _prev = first_key_by_cell.setdefault(_cell, _key)
+            if _prev != _key:
+                colocated_pairs.append((_prev, _key))
 
     if not cells_by_comp:
         return None
@@ -473,6 +485,26 @@ def _regions_from_fill_models(net_id, pcb_data, coord, plane_layer,
     # every island any single chain touches.
     uf = UnionFind()
     _pt_uf = UnionFind()
+
+    # CO-LOCATED islands are ONE piece of copper. A ZoneFillModel is built per
+    # ZONE and labels that zone's fill in isolation, but KiCad merges the fills
+    # of same-net zones on the same layer into a single pour -- so a patch pour
+    # dropped inside a board-wide pour yields two island keys over the very same
+    # copper, and nothing below ever unions them (the segment-chain and barrel
+    # passes both credit one key per layer). The join loop then sees a split
+    # that does not exist: it picks the pair at distance ~0, the A* answers with
+    # a zero-length or 0.1mm "strap", and the pair is burned as UNVERIFIED.
+    # Measured on neo6502 GND (27 sub-mm priority-16962 patch pours inside the
+    # board-wide F.Cu pour): 42 model regions where the fill-aware grader counts
+    # 13 components. Two models predicting fill at the SAME point means copper
+    # exists there in both fills, which on one net and one layer is one
+    # conductor -- so union them. Coarse sampling can only MISS an overlap
+    # (the over-split direction this module already prefers), never invent one.
+    _colo_uf = UnionFind()          # co-located unions ONLY, for the log line
+    for _ka, _kb in colocated_pairs:
+        uf.union(_ka, _kb)
+        _colo_uf.union(_ka, _kb)
+    n_islands = len({_colo_uf.find(_ck) for _ck in cells_by_comp})
 
     def _pk(layer, x, y):
         return (layer, round(x, 3), round(y, 3))
@@ -607,8 +639,13 @@ def _regions_from_fill_models(net_id, pcb_data, coord, plane_layer,
         return ([region_anchors[0] if region_anchors else []],
                 [region_cells[0] if region_cells else set()],
                 [region_islands[0] if region_islands else set()])
+    # Report the island count AFTER the co-located union -- the raw
+    # len(cells_by_comp) counts one key per (zone model, label), so overlapping
+    # same-net zones inflate it next to a region count that already merged them.
+    _colo = len(cells_by_comp) - n_islands
+    _colo_note = f", {_colo} co-located key(s) fused" if _colo > 0 else ""
     print(f"  Region discovery from fill model: {len(region_anchors)} "
-          f"region(s) ({len(cells_by_comp)} fill island(s), "
+          f"region(s) ({n_islands} fill island(s){_colo_note}, "
           f"{len(singletons)} off-fill anchor(s), "
           f"{sum(1 for a in region_anchors if not a)} orphan island(s))")
     return region_anchors, region_cells, region_islands
@@ -1425,13 +1462,27 @@ def find_region_connection_points(
     return mst_edges
 
 
+# How many open-space candidates are material-tested before giving up (a model
+# query per probe is not free). The probe ORDER is what makes this bound safe:
+# candidates are ranked most-open first and then NEAREST THE REGION'S CENTROID.
+# Ranking by raw grid order instead is a trap -- the net's own copper is
+# excluded from the obstacle map, so clearance saturates across most of the
+# +-search_radius box and the tie-break decides everything; grid order then
+# probes only the far-left columns (2.5% of the box at a 0.1mm routing grid,
+# every one of them ~5mm off the region), so the search reports "no valid open
+# point" while hundreds sit next to the region, and the fallback silently stops
+# rescuing exactly the hemmed-in shards it exists for.
+_OPEN_SPACE_VALIDITY_PROBES = 256
+
+
 def find_open_space_point(
     anchors: List[Tuple[float, float]],
     base_obstacles: GridObstacleMap,
     plane_layer_idx: int,
     coord: GridCoord,
     search_radius: float = 5.0,
-    bounds: Optional[Tuple[float, float, float, float]] = None
+    bounds: Optional[Tuple[float, float, float, float]] = None,
+    validity=None
 ) -> Optional[Tuple[float, float]]:
     """
     Find the most open space near a region's anchors - a point with maximum clearance from obstacles.
@@ -1442,6 +1493,20 @@ def find_open_space_point(
         plane_layer_idx: Layer index to check for obstacles
         coord: Grid coordinate converter
         search_radius: How far from anchors to search (mm)
+        validity: Optional callable(x, y) -> bool the returned point must
+            satisfy. WITHOUT it this function answers "where is the emptiest
+            cell within search_radius of the region's centroid", which is a
+            question about the OBSTACLE MAP and says nothing about the
+            region's own copper -- the emptiest cell is typically a bare gap
+            metres of grid away from any fill. Fed to the connection A* as an
+            extra seed (see _try_route_between_regions) that point is the
+            cheapest cell in the neighbourhood, so the search lands on it and
+            the strap's end connects nothing (neo6502 GND: 15 joins routed
+            open-space-to-open-space, one of them a 0.1mm strap between two
+            regions' open points, all correctly rejected by the #479 endpoint
+            verification -- which then burned each pair's whole try
+            allowance). Callers that use the result as a seed MUST pass the
+            same material predicate the join is verified against.
 
     Returns:
         (x, y) of the most open point, or None if no good point found
@@ -1458,6 +1523,7 @@ def find_open_space_point(
 
     best_clearance = 0
     best_point = None
+    candidates: List[Tuple[int, int, int, int]] = []
 
     # Search in a grid around the centroid
     for dx in range(-search_radius_grid, search_radius_grid + 1):
@@ -1484,13 +1550,28 @@ def find_open_space_point(
             # Calculate clearance - distance to nearest blocked cell
             clearance = _calculate_clearance(gx, gy, base_obstacles, plane_layer_idx, max_check=10)
 
-            if clearance > best_clearance:
-                best_clearance = clearance
-                best_point = coord.to_float(gx, gy)
+            if validity is None:
+                if clearance > best_clearance:
+                    best_clearance = clearance
+                    best_point = coord.to_float(gx, gy)
+            elif clearance >= 2:
+                # Deterministic order: most open first, then nearest the
+                # region, then grid order (see _OPEN_SPACE_VALIDITY_PROBES).
+                candidates.append((-clearance,
+                                   (gx - center_gx) ** 2 + (gy - center_gy) ** 2,
+                                   gx, gy))
 
-    # Only return if we found a point with meaningful clearance (at least 2 grid steps)
-    if best_clearance >= 2:
-        return best_point
+    if validity is None:
+        # Only return if we found a point with meaningful clearance (at least 2 grid steps)
+        if best_clearance >= 2:
+            return best_point
+        return None
+
+    candidates.sort()
+    for _c, _d2, gx, gy in candidates[:_OPEN_SPACE_VALIDITY_PROBES]:
+        fx, fy = coord.to_float(gx, gy)
+        if validity(fx, fy):
+            return (fx, fy)
     return None
 
 
@@ -1541,6 +1622,8 @@ def _try_route_between_regions(
     bounds: Optional[Tuple[float, float, float, float]] = None,
     pcb_data=None,
     net_id: Optional[int] = None,
+    open_ok_i=None,
+    open_ok_j=None,
 ) -> Tuple[Optional[Tuple[List[Tuple[float, float, str]], List[Tuple[float, float]]]], float, Optional[Tuple[float, float]]]:
     """
     Try to route between two regions, attempting multiple track widths.
@@ -1560,6 +1643,12 @@ def _try_route_between_regions(
         max_iterations: Max routing iterations
         coord: Grid coordinate converter
         verbose: Print debug info
+        open_ok_i / open_ok_j: material predicates callable(x, y) -> bool for
+            the two regions. The open-space fallback below seeds the A* with a
+            point that is merely EMPTY, not on either region -- these gate it
+            so a fallback seed can only be a point the join's endpoint
+            verification would accept as that region's material. Omitted
+            (None) restores the pre-fix behavior of seeding any open cell.
 
     Returns:
         Tuple of (route_result, track_width_used, open_space_via_if_used)
@@ -1639,8 +1728,10 @@ def _try_route_between_regions(
     if result is None:
         # Can't route even at min width - try open-space fallback
         _t0 = _time.time()
-        open_i = find_open_space_point(anchors_i, base_obstacles, plane_layer_idx, coord, bounds=bounds)
-        open_j = find_open_space_point(anchors_j, base_obstacles, plane_layer_idx, coord, bounds=bounds)
+        open_i = find_open_space_point(anchors_i, base_obstacles, plane_layer_idx, coord,
+                                       bounds=bounds, validity=open_ok_i)
+        open_j = find_open_space_point(anchors_j, base_obstacles, plane_layer_idx, coord,
+                                       bounds=bounds, validity=open_ok_j)
         _dt_open = _time.time() - _t0
         _attempt_details.append(f"open-search {_dt_open:.2f}s")
         _total_route_time += _dt_open
@@ -1919,6 +2010,53 @@ def route_disconnected_regions(
             comp_np[root] = arr
         return arr
 
+    # ENDPOINT / SEED MATERIAL TEST (#479 duodyne): a point counts as a
+    # component's own copper when it sits on one of the component's fill
+    # ISLANDS per the model, within one analysis cell of its fill cells, or
+    # within 0.75mm of an anchor / earlier strap vertex. Used for BOTH the
+    # post-route endpoint verification below AND (since neo6502 GND) the
+    # open-space fallback seed, so the search can no longer be handed a seed
+    # the gate will reject.
+    #
+    # `strict` drops the 0.75mm branch. That branch is a post-hoc ACCEPTANCE
+    # tolerance -- fine for judging a strap the router already committed to,
+    # wrong as the objective a seed SEARCH optimizes against, because the
+    # search would then hunt for a point that barely passes it and hand back a
+    # strap ending up to 0.75mm of bare board short of the pour (#479's own
+    # failure mode at a smaller radius). It also admits earlier straps'
+    # vertices, which comp_pts stores LAYER-STRIPPED, so a B.Cu vertex would
+    # vouch for an F.Cu point. Seed gating and the coincident-merge guard use
+    # strict; the endpoint verification keeps the tolerance it shipped with.
+    def _on_material(_root, _pt, strict=False):
+        # Exact test first: does the landing point sit on one of the
+        # component's fill ISLANDS per the model? (The coarse cell sets
+        # below starve thin real islands -- quickfeather U6.29's joins
+        # died UNVERIFIED on legitimate landings.)
+        _keys = comp_islands.get(_root)
+        if _keys:
+            for _ms in _join_models.values():
+                for _m in _ms:
+                    _c = _m.query_component(_pt[0], _pt[1],
+                                            size=min_track_width)
+                    if _c is not None and _c > 0 \
+                            and (id(_m), _c) in _keys:
+                        return True
+        _gx, _gy = cell_coord.to_grid(_pt[0], _pt[1])
+        _cs = comp_cells.get(_root, ())
+        for _dx in (-1, 0, 1):
+            for _dy in (-1, 0, 1):
+                if (_gx + _dx, _gy + _dy) in _cs:
+                    return True
+        if strict:
+            return False
+        _arr = _comp_arr(_root)
+        if _arr.size:
+            _d2 = ((_arr[:, 0] - _pt[0]) ** 2
+                   + (_arr[:, 1] - _pt[1]) ** 2)
+            if float(_d2.min()) <= 0.75 * 0.75:
+                return True
+        return False
+
     pair_cache: Dict[frozenset, Optional[tuple]] = {}
     # A failed pair is retried ONLY when a later merge meaningfully shrinks
     # its gap (< 0.75x the distance it failed at), and at most 3 times total:
@@ -1940,6 +2078,50 @@ def route_disconnected_regions(
         # Failed marks survive under a REKEYED identity: the merged blob keeps
         # root min(i,j), so a failed pair {blob, X} keeps its key and its
         # distance gate; only distances are recomputed.
+
+    def _merge_components(root_i, root_j, route_points):
+        """Merge two components. The union's points PLUS the strap's vertices
+        become landing space for every later join (trace reuse): a later join
+        Ts into the strap instead of paralleling it. `route_points` may be
+        empty (a coincident pair merged without emitting copper)."""
+        _keep = min(root_i, root_j)
+        _gone = root_j if _keep == root_i else root_i
+        comp_members[_keep] = comp_members[root_i] + comp_members[root_j]
+        comp_pts[_keep] = (comp_pts[root_i] + comp_pts[root_j]
+                           + [(p[0], p[1]) for p in route_points])
+        comp_cells[_keep] = (comp_cells.get(root_i, set())
+                             | comp_cells.get(root_j, set())
+                             | {cell_coord.to_grid(p[0], p[1])
+                                for p in route_points})
+        comp_success[_keep] = (comp_success.get(root_i, 0)
+                               + comp_success.get(root_j, 0) + 1)
+        comp_strikes[_keep] = (comp_strikes.get(root_i, 0)
+                               + comp_strikes.get(root_j, 0))
+        comp_islands[_keep] = (comp_islands.get(root_i, set())
+                               | comp_islands.get(root_j, set()))
+        if _gone != _keep:
+            comp_members.pop(_gone, None)
+            comp_pts.pop(_gone, None)
+            comp_cells.pop(_gone, None)
+            comp_strikes.pop(_gone, None)
+            comp_success.pop(_gone, None)
+            comp_islands.pop(_gone, None)
+            comp_roots.discard(_gone)
+        comp_np.pop(root_i, None)
+        comp_np.pop(root_j, None)
+        # Rekey failure gates onto the merged root (tightest distance, most
+        # tries survive), then drop stale cached distances to the blob --
+        # they get recomputed, and the retry gate decides eligibility.
+        for _k in [k for k in failed_at if k & {root_i, root_j}]:
+            _other = next(iter(_k - {root_i, root_j}), None)
+            _e = failed_at.pop(_k)
+            if _other is None or _other == _keep:
+                continue
+            _nk = frozenset((_keep, _other))
+            _p = failed_at.get(_nk)
+            failed_at[_nk] = _e if _p is None else (min(_e[0], _p[0]),
+                                                   max(_e[1], _p[1]))
+        _invalidate_pairs(root_i, root_j)
 
     def _pair_closest(ra, rb):
         Pa, Pb = _comp_arr(ra), _comp_arr(rb)
@@ -2044,6 +2226,7 @@ def route_disconnected_regions(
     vias: List[Dict] = []
     routes_added = 0
     routes_failed = 0
+    routes_coincident = 0   # pairs that turned out to be the same copper
     previous_routes: List[List[Tuple[float, float]]] = []
 
     # Create a single reusable router for all MST edges
@@ -2066,7 +2249,7 @@ def route_disconnected_regions(
         if _pick is None:
             break   # every remaining component pair already failed to route
         (dist, point_i, point_j), (root_i, root_j) = _pick
-        edge_idx = routes_added + routes_failed
+        edge_idx = routes_added + routes_failed + routes_coincident
         # The merged component point sets play the per-region anchor role:
         # member anchors + fill subsamples + earlier straps' vertices.
         anchors_i = comp_pts[root_i]
@@ -2129,6 +2312,14 @@ def route_disconnected_regions(
                                          if p not in anchors_j], point_j, 512)
         reduced = (len(seed_i) < len(full_i)) or (len(seed_j) < len(full_j))
 
+        # Material predicates for THIS pair's open-space fallback seeds: the
+        # fallback point must be copper the endpoint verification will credit
+        # to that component, or the strap it produces connects nothing.
+        _open_ok_i = (lambda _x, _y, _r=root_i:
+                      _on_material(_r, (_x, _y), strict=True))
+        _open_ok_j = (lambda _x, _y, _r=root_j:
+                      _on_material(_r, (_x, _y), strict=True))
+
         # Progress indicator
         seed_note = f" (seed {len(seed_i)}x{len(seed_j)})" if reduced else ""
         print(f"    [{edge_idx+1}/{planned}] Component {root_i} ({len(comp_members[root_i])} region(s), {len(anchors_i)} pts) <-> Component {root_j} ({len(comp_members[root_j])} region(s), {len(anchors_j)} pts){seed_note}...", end=" ", flush=True)
@@ -2153,6 +2344,8 @@ def route_disconnected_regions(
                 router=plane_router,
                 pcb_data=pcb_data,
                 net_id=net_id,
+                open_ok_i=_open_ok_i,
+                open_ok_j=_open_ok_j,
             )
 
         # Try routing with multiple track widths using helper function
@@ -2192,6 +2385,8 @@ def route_disconnected_regions(
                 router=plane_router,
                 pcb_data=pcb_data,
                 net_id=net_id,
+                open_ok_i=_open_ok_i,
+                open_ok_j=_open_ok_j,
             )
 
         # Last resort (#217 castor +3.3VA): the corridor between two regions
@@ -2236,6 +2431,8 @@ def route_disconnected_regions(
                 router=plane_router,
                 pcb_data=pcb_data,
                 net_id=net_id,
+                open_ok_i=_open_ok_i,
+                open_ok_j=_open_ok_j,
             )
 
         if result is None:
@@ -2265,6 +2462,34 @@ def route_disconnected_regions(
             route_points,
             keep={(round(vx, 3), round(vy, 3)) for vx, vy in via_positions})
 
+        # COINCIDENT PAIR: the A* reached a target cell from a source cell in
+        # ZERO steps, so one grid cell on one layer is claimed by BOTH
+        # components' seed sets -- typically because the model split ONE piece
+        # of copper (overlapping same-net zones on a layer are labelled per
+        # zone, so a patch pour inside a board-wide pour becomes a second
+        # component over the same fill). Merge and emit NOTHING: a zero-length
+        # strap is not copper, and the old path reported it as UNVERIFIED
+        # "ends=None/None", which burned the pair's whole try allowance and
+        # left the phantom region in the tally forever (neo6502 GND).
+        #
+        # A shared seed CELL is not by itself proof of shared copper: seed
+        # lists also carry earlier straps' vertices (layer-stripped) and a
+        # gated open-space point, and two seeds within one grid step quantize
+        # together. So demand the meeting point be STRICT material for BOTH
+        # components before fusing them -- otherwise fall through to the
+        # endpoint verification, which refuses and re-queues the pair. Merging
+        # on the weaker evidence would be exactly the silent false "joined"
+        # that #479's verification exists to stop.
+        if len(route_points) < 2:
+            _mp = route_points[0] if route_points else None
+            if _mp is not None and _on_material(root_i, _mp, strict=True) \
+                    and _on_material(root_j, _mp, strict=True):
+                print(f"{GREEN}COINCIDENT{RESET} (same copper at "
+                      f"({_mp[0]:.2f},{_mp[1]:.2f}) -- merged, no join needed)")
+                routes_coincident += 1
+                _merge_components(root_i, root_j, route_points)
+                continue
+
         # ENDPOINT VERIFICATION (#479 duodyne): join success was previously
         # self-reported by the A* against its obstacle map -- the open-space
         # fallback in particular drops a via at "the most open point near the
@@ -2272,38 +2497,9 @@ def route_disconnected_regions(
         # 5 of duodyne's 23 joins shipped dangling vias/stubs while Prim
         # recorded the pair as merged (7 pad islands reached the gate
         # floating behind an all-OK report). Require each strap end to land
-        # on its component's MATERIAL: within one analysis cell of the
-        # component's fill cells, or within 0.75mm of an anchor / earlier
-        # strap vertex. An unverified join is a FAILED join: no copper is
-        # emitted and the pair re-enters the retry policy.
-        def _on_material(_root, _pt):
-            # Exact test first: does the landing point sit on one of the
-            # component's fill ISLANDS per the model? (The coarse cell sets
-            # below starve thin real islands -- quickfeather U6.29's joins
-            # died UNVERIFIED on legitimate landings.)
-            _keys = comp_islands.get(_root)
-            if _keys:
-                for _ms in _join_models.values():
-                    for _m in _ms:
-                        _c = _m.query_component(_pt[0], _pt[1],
-                                                size=min_track_width)
-                        if _c is not None and _c > 0 \
-                                and (id(_m), _c) in _keys:
-                            return True
-            _gx, _gy = cell_coord.to_grid(_pt[0], _pt[1])
-            _cs = comp_cells.get(_root, ())
-            for _dx in (-1, 0, 1):
-                for _dy in (-1, 0, 1):
-                    if (_gx + _dx, _gy + _dy) in _cs:
-                        return True
-            _arr = _comp_arr(_root)
-            if _arr.size:
-                _d2 = ((_arr[:, 0] - _pt[0]) ** 2
-                       + (_arr[:, 1] - _pt[1]) ** 2)
-                if float(_d2.min()) <= 0.75 * 0.75:
-                    return True
-            return False
-
+        # on its component's MATERIAL (see _on_material above the loop). An
+        # unverified join is a FAILED join: no copper is emitted and the pair
+        # re-enters the retry policy.
         _verified = False
         if len(route_points) >= 2:
             _e0, _e1 = route_points[0], route_points[-1]
@@ -2311,6 +2507,42 @@ def route_disconnected_regions(
                           and _on_material(root_j, _e1))
                          or (_on_material(root_i, _e1)
                              and _on_material(root_j, _e0)))
+        if not _verified and os.environ.get('KRT_JOIN_VERIFY_DEBUG'):
+            def _dbg(_root, _pt):
+                if _pt is None:
+                    return 'pt=None'
+                _keys = comp_islands.get(_root)
+                _hits = []
+                for _lay, _ms in _join_models.items():
+                    for _m in _ms:
+                        _c = _m.query_component(_pt[0], _pt[1],
+                                                size=min_track_width)
+                        if _c is not None and _c > 0:
+                            _hits.append((_lay, id(_m), _c,
+                                          (id(_m), _c) in (_keys or ())))
+                _gx, _gy = cell_coord.to_grid(_pt[0], _pt[1])
+                _cs = comp_cells.get(_root, ())
+                _cellhit = any((_gx + _dx, _gy + _dy) in _cs
+                               for _dx in (-1, 0, 1) for _dy in (-1, 0, 1))
+                _arr = _comp_arr(_root)
+                _dmin = None
+                if _arr.size:
+                    _dmin = float(np.sqrt(((_arr[:, 0] - _pt[0]) ** 2
+                                           + (_arr[:, 1] - _pt[1]) ** 2).min()))
+                return (f'root={_root} nkeys={len(_keys or ())} '
+                        f'ncells={len(_cs)} npts={_arr.shape[0]} '
+                        f'cellhit={_cellhit} dmin={_dmin} '
+                        f'modelhits={_hits[:6]}')
+            _d0, _d1 = (route_points[0], route_points[-1]) \
+                if len(route_points) >= 2 else (None, None)
+            print(f"\n      VERIFY-DEBUG pair=({root_i},{root_j}) dist={dist:.3f}"
+                  f" pi={point_i} pj={point_j} npts={len(route_points)}")
+            print(f"        e0 {_d0} vs i: {_dbg(root_i, _d0)}")
+            print(f"        e0 {_d0} vs j: {_dbg(root_j, _d0)}")
+            print(f"        e1 {_d1} vs i: {_dbg(root_i, _d1)}")
+            print(f"        e1 {_d1} vs j: {_dbg(root_j, _d1)}")
+            if len(route_points) < 6:
+                print(f"        route={route_points}")
         if not _verified:
             _e0, _e1 = (route_points[0], route_points[-1]) \
                 if len(route_points) >= 2 else (None, None)
@@ -2473,54 +2705,15 @@ def route_disconnected_regions(
                                     _near[0], _near[1])
 
         routes_added += 1
-
-        # Merge the two components. The union's points PLUS this strap's
-        # vertices become landing space for every later join (trace reuse):
-        # a later join Ts into the strap instead of paralleling it.
-        _keep = min(root_i, root_j)
-        _gone = root_j if _keep == root_i else root_i
-        comp_members[_keep] = comp_members[root_i] + comp_members[root_j]
-        comp_pts[_keep] = (comp_pts[root_i] + comp_pts[root_j]
-                           + [(p[0], p[1]) for p in route_points])
-        comp_cells[_keep] = (comp_cells.get(root_i, set())
-                             | comp_cells.get(root_j, set())
-                             | {cell_coord.to_grid(p[0], p[1])
-                                for p in route_points})
-        comp_success[_keep] = (comp_success.get(root_i, 0)
-                               + comp_success.get(root_j, 0) + 1)
-        comp_strikes[_keep] = (comp_strikes.get(root_i, 0)
-                               + comp_strikes.get(root_j, 0))
-        comp_islands[_keep] = (comp_islands.get(root_i, set())
-                               | comp_islands.get(root_j, set()))
-        if _gone != _keep:
-            comp_members.pop(_gone, None)
-            comp_pts.pop(_gone, None)
-            comp_cells.pop(_gone, None)
-            comp_strikes.pop(_gone, None)
-            comp_success.pop(_gone, None)
-            comp_islands.pop(_gone, None)
-            comp_roots.discard(_gone)
-        comp_np.pop(root_i, None)
-        comp_np.pop(root_j, None)
-        # Rekey failure gates onto the merged root (tightest distance, most
-        # tries survive), then drop stale cached distances to the blob --
-        # they get recomputed, and the retry gate decides eligibility.
-        for _k in [k for k in failed_at if k & {root_i, root_j}]:
-            _other = next(iter(_k - {root_i, root_j}), None)
-            _e = failed_at.pop(_k)
-            if _other is None or _other == _keep:
-                continue
-            _nk = frozenset((_keep, _other))
-            _p = failed_at.get(_nk)
-            failed_at[_nk] = _e if _p is None else (min(_e[0], _p[0]),
-                                                   max(_e[1], _p[1]))
-        _invalidate_pairs(root_i, root_j)
+        _merge_components(root_i, root_j, route_points)
 
     # Summary for this net
+    _coin_note = (f", {routes_coincident} coincident pair(s) merged without copper"
+                  if routes_coincident else "")
     if routes_failed > 0:
-        print(f"  {YELLOW}Result: {routes_added}/{planned} join(s) succeeded, {routes_failed} attempt(s) failed{RESET}")
-    elif routes_added > 0:
-        print(f"  {GREEN}Result: All {routes_added} route(s) succeeded{RESET}")
+        print(f"  {YELLOW}Result: {routes_added}/{planned} join(s) succeeded, {routes_failed} attempt(s) failed{_coin_note}{RESET}")
+    elif routes_added > 0 or routes_coincident:
+        print(f"  {GREEN}Result: All {routes_added} route(s) succeeded{_coin_note}{RESET}")
 
     return segments, vias, routes_added, previous_routes, connectivity_paths
 

--- a/py_router/qfn_fanout/__init__.py
+++ b/py_router/qfn_fanout/__init__.py
@@ -118,6 +118,130 @@ def _board_edge_model(pcb_data, clearance, board_edge_clearance):
     return edge_clear, rings, outer, cutouts
 
 
+def run_output_conflict(vx, vy, net_id, placed, px=None, py=None, *,
+                        via_size, via_drill, clearance, track_width,
+                        hole_to_hole, adds_via=True):
+    """Does a candidate via (and its stub) collide with THIS RUN's own output?
+
+    D10. The underpad escape's `via_clears` tested a candidate against the
+    board it was handed -- `foreign_vias` / `foreign_pads` / `foreign_tracks`
+    are a snapshot taken once, before anything is placed -- and against the via
+    CENTRES emitted so far. It never saw the STUBS the same run emitted, so it
+    approved vias sitting on copper it had just laid itself, and those escapes
+    came back DRC CONTACTS.
+
+    Measured: U2 (QFN56) reported 39 of 46 escapes under
+    `--escape-method underpad --allow-via-in-pad` and the gate rejected every
+    one as a contact -- while the geometry was fine (a 1.4 mm moat admitting a
+    0.7 mm via at all 56 pads, `pad_via == 0`, a real 0.700 mm via placeable
+    DRC-clean in U2.43, true capacity 11 of 14 lanes per side). A valid escape
+    strategy reported as impossible, and two cycles skipped fanout on it.
+
+    `placed` entries are ``(via_x, via_y, net_id, pad_x, pad_y)``; the stub
+    runs pad -> via. A through-via conflicts with copper on ANY layer, so the
+    stubs are tested exactly the way `foreign_tracks` is -- the difference is
+    only that these cannot be in that list.
+
+    Module-level and pure so it is testable directly: the caller is a closure
+    over fifteen locals, and a check this consequential should not be reachable
+    only by routing a whole board.
+
+    ``adds_via=False`` is the REUSE case (#479 audit gap 2): the position is an
+    existing board via, so this run adds no drill and no via copper -- only the
+    bridging stub. Everything about that via's spacing is a fact of the input
+    board, not something this run creates, so pricing it as a NEW via at
+    ``config.via_size`` judges two vias that already exist, at a size neither
+    has, for a spacing this run does not produce. Measured on
+    kicad_files/routed_output.kicad_pcb U2 (B.Cu, track/clearance 0.1, via
+    0.45/0.25, --escape-method underpad --allow-via-in-pad): with the via terms
+    applied, all 7 reuse candidates were rejected on the different-net floor
+    ``via_size + clearance`` = 0.55 against pre-existing 0.30 vias sitting at
+    0.400 mm -- legal (0.15+0.15+0.10) and already on the board. That cost
+    Net-(U2A-DATA_30) its escape and put a fresh drill where a reuse would have
+    served: 28 vias / 12 dropped / 30 tracks became 29 / 13 / 31.
+
+    The VIA-TO-VIA term is not merely wrong there, it is REDUNDANT. Every
+    entry in `placed` is either a via this run created -- already tested
+    against this reuse target in `via_clears`'s `foreign_vias` loop at exact
+    pairwise sizes (``via_size/2 + fs/2 + clearance``, and
+    ``(via_drill + fd)/2 + h2h`` for same net) -- or another pre-existing via,
+    whose spacing is the board's.
+
+    TERM 1 (the candidate via against a stub this run emitted) is dropped for
+    a different and weaker reason, stated here rather than overclaimed: the
+    reuse target's POSITION is not this run's doing, so a stub grazing it is
+    a defect of that stub, which is already emitted. Rejecting the reuse does
+    not remove the graze -- it only forces a fresh drill elsewhere and leaves
+    the graze in place. It is a false remedy, not a check.
+
+    That it fires at all exposes a REAL and separate gap, measured rather than
+    assumed: an emitted stub is never tested against a pre-existing via on
+    another FANNED net, because `build_base_obstacle_map(nets_to_route=...)`
+    excludes every net being escaped (obstacle_map.py:105), so
+    `check_line_clearance` cannot see it, and `via_clears` tests only the via
+    CENTRE against `foreign_vias`, never the stub. Measured on U2: 5 emitted
+    stubs sit inside a foreign pre-existing via's floor, one of them at
+    0.0000mm, and in all 5 the via's net is a fanned one. That count is
+    IDENTICAL at 715c821 and here, so it is pre-existing and untouched by this
+    change -- and it wants its own fix in the stub check, not an accidental
+    partial cover for the subset of vias that happen to be reuse targets.
+
+    So with ``adds_via=False`` only the new STUB is tested against this run's
+    own output, which is the only copper the reuse emits. A stub shorter than
+    POSITION_TOLERANCE emits no track at all (the commit loop skips it), so it
+    conflicts with nothing.
+
+    Returns True when the candidate must be REJECTED.
+    """
+    from geometry_utils import segment_to_segment_distance
+    from obstacle_map import point_to_segment_distance
+
+    via_half = via_size / 2 + clearance - 1e-6
+    track_half = track_width / 2
+    if not adds_via and (px is None
+                         or math.hypot(px - vx, py - vy) <= POSITION_TOLERANCE):
+        return False                    # reuse with no stub emits no copper
+    for entry in placed:
+        qx, qy, qn = entry[0], entry[1], entry[2]
+        qpx = entry[3] if len(entry) > 3 else None
+        qpy = entry[4] if len(entry) > 4 else None
+        # Via-to-via. Same-net floor was via_size*0.5 -- BELOW drill
+        # hole-to-hole for standard vias (#479 audit gap 2); both are via_drill.
+        # Skipped for a REUSE: no drill and no via copper is added, so there is
+        # no new pair for this run to space.
+        if adds_via:
+            floor = (via_size + clearance) if qn != net_id \
+                else max(via_size * 0.5, via_drill + hole_to_hole)
+            if math.hypot(vx - qx, vy - qy) < floor - 1e-6:
+                return True
+        if qn == net_id:
+            continue                           # own-net copper is no obstacle
+        has_stub = (qpx is not None
+                    and math.hypot(qpx - qx, qpy - qy) > POSITION_TOLERANCE)
+        # 1. the candidate VIA against the stub already emitted for that via.
+        #    Dropped for a reuse because the target's POSITION is not this
+        #    run's doing: the graze belongs to that already-emitted stub, and
+        #    refusing the reuse only buys a fresh drill while leaving it. See
+        #    run_output_conflict's docstring for the separate, measured gap
+        #    this exposes (stub vs pre-existing via on another FANNED net).
+        if adds_via and has_stub \
+                and point_to_segment_distance(vx, vy, qpx, qpy, qx, qy) \
+                < via_half + track_half:
+            return True
+        if px is None:
+            continue
+        # 2. the candidate's own STUB against that placed via, and
+        # 3. stub against stub -- the same blindness, the other way round.
+        if point_to_segment_distance(qx, qy, px, py, vx, vy) \
+                < via_half + track_half:
+            return True
+        if has_stub and segment_to_segment_distance(
+                px, py, vx, vy, qpx, qpy, qx, qy) \
+                < track_width + clearance - 1e-6:
+            return True
+    return False
+
+
 def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
                          track_width, clearance, via_size, via_drill, grid_step,
                          allow_via_in_pad=False, board_edge_clearance=0.0):
@@ -155,6 +279,7 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
     -- nothing here assumes a group shares an edge axis."""
     from obstacle_map import (build_base_obstacle_map, build_layer_map,
                               check_line_clearance, point_to_segment_distance)
+    from geometry_utils import segment_to_segment_distance
     from bga_fanout.reroute import _seg_hits_pad
     from bga_fanout.geometry import clamp_via_to_pad
     from list_nets import fab_floor_ladder, fab_floor_min, warn_fab_escalation
@@ -194,7 +319,40 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
         _own_via_pos.setdefault(v.net_id, []).append((v.x, v.y))
     from kicad_parser import pad_drill_circles as _pdc
     import routing_defaults as _rd
-    _h2h = _rd.HOLE_TO_HOLE_CLEARANCE
+    # BOARD-FIRST, same rule as every other floor: a board declaring
+    # min_hole_to_hole above the packaged default was having its drills spaced
+    # at the default instead. Discovered via source_path so the GUI inherits it.
+    #
+    # RAISE-ONLY IN THE CODE, not only in this comment. `board_floor` is
+    # board-AUTHORITATIVE, not raise-only -- it returns whatever the board
+    # declares once it is positive, with no max() against the fallback, and
+    # that is correct for the floors it mostly serves (check_channels and
+    # check_assembly must grade at the board's own clearance even when that is
+    # BELOW their default, or they manufacture phantom violations). It is a
+    # DRILL floor here, so the same freedom is a fab hazard: a project
+    # declaring `min_hole_to_hole: 0.10` resolved to (0.1, 'board constraint')
+    # and spaced this run's drills below the 0.20 JLC floor. `resolve_hole_clearance`
+    # is called raise-only for the same reason, and is raise-only only because
+    # ITS consumers wrap it in a max() (obstacle_map.py:1580,
+    # plane_obstacle_builder.py:1208) -- this is that wrap. The engine cannot
+    # lean on the CLI's enforce_fab_floors: that pins args.hole_to_hole_clearance,
+    # a value this code path never reads.
+    from list_nets import board_floor
+    _h2h_decl, _h2h_src = board_floor(
+        getattr(pcb_data, 'source_path', "") or "", 'hole_to_hole',
+        None, _rd.HOLE_TO_HOLE_CLEARANCE)
+    _h2h_fab = fab_floor_min(_copper).get('hole_to_hole', 0.0)
+    _h2h = max(_h2h_decl, _h2h_fab)
+    if _h2h_src == 'board constraint' and _h2h_decl > _rd.HOLE_TO_HOLE_CLEARANCE:
+        print(f"  Hole-to-hole {_h2h:g}mm (from the board's own "
+              f"min_hole_to_hole)")
+    elif _h2h_src == 'board constraint' and _h2h_decl < _h2h_fab:
+        # Never SILENTLY relaxed -- the whole point of the guard is that a
+        # board file cannot lower a fab floor without saying so. A user who
+        # genuinely has a finer fab declares it with --fab-tier/--fab-overrides,
+        # which is what fab_floor_min reads.
+        print(f"  Board min_hole_to_hole {_h2h_decl:g}mm is below the "
+              f"{_h2h_fab:g}mm fab hole-to-hole floor; using {_h2h:g}mm.")
     _drilled_pad_holes = [(hx, hy, hd)
                           for p in foreign_pads if p.drill and p.drill > 0
                           for (hx, hy, hd) in _pdc(p)]
@@ -212,7 +370,27 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
     from check_drc import _point_to_rings_distance as _pt_rings_dist
     from check_drc import _point_on_board as _pt_on_board
 
-    def via_clears(vx, vy, net_id, placed):
+    def via_clears(vx, vy, net_id, placed, px=None, py=None):
+        """Is a via at (vx, vy) legal, given the board AND this run's own output?
+
+        `foreign_vias` / `foreign_pads` / `foreign_tracks` above are a SNAPSHOT
+        of the INPUT board, taken once. `placed` is what this run has emitted so
+        far -- and it used to carry only via CENTRES, so the STUBS this run laid
+        from each pad to each via were invisible to every later candidate. The
+        test therefore approved vias sitting on copper it had just emitted
+        itself, and each such escape came back a DRC CONTACT.
+
+        Measured: U2 (QFN, 56 pads) reported 39 of 46 escapes under
+        `--escape-method underpad --allow-via-in-pad`, and the gate rejected
+        every one of them as a contact. The wall was NOT geometry -- U2 has a
+        1.4 mm moat that admits a 0.7 mm via at all 56 pads, `pad_via == 0` in
+        every run, and a real 0.700 mm via IS placeable DRC-clean in pad U2.43.
+        True capacity is 11 of 14 lanes per side. So a valid escape strategy
+        reported as impossible, and two cycles skipped fanout on that premise.
+
+        `px, py` are the candidate's OWN pad, so its stub can be tested too --
+        the same blindness in the other direction.
+        """
         if _edge_rings:
             if not _pt_on_board(vx, vy, _edge_outer, _edge_cutouts):
                 return False
@@ -245,14 +423,10 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
             if point_to_segment_distance(vx, vy, sx0, sy0, sx1, sy1) \
                     < via_size / 2 + sw / 2 + clearance - 1e-6:
                 return False
-        for qx, qy, qn in placed:
-            # Same-net floor was via_size*0.5 -- BELOW drill hole-to-hole for
-            # standard vias (#479 audit gap 2); both holes are via_drill here.
-            floor = (via_size + clearance) if qn != net_id \
-                else max(via_size * 0.5, via_drill + _h2h)
-            if math.hypot(vx - qx, vy - qy) < floor - 1e-6:
-                return False
-        return True
+        return not run_output_conflict(
+            vx, vy, net_id, placed, px, py,
+            via_size=via_size, via_drill=via_drill, clearance=clearance,
+            track_width=track_width, hole_to_hole=_h2h)
 
     def snap(v):
         return round(v / grid_step) * grid_step if grid_step > 0 else v
@@ -296,15 +470,41 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
                 _best = (_d, ovx, ovy)
         if _best is not None:
             _rvx, _rvy = _best[1], _best[2]
+            # `check_line_clearance` reads the INPUT-board obstacle map, so on
+            # its own this branch is blind to everything this run has emitted
+            # -- the reuse path was one of two ways a position is returned, and
+            # the only one that never consulted via_clears. The bridging stub
+            # it emits can still cross another net's stub or via laid earlier
+            # in the same run, and the position was then appended to
+            # placed_global as though it had been checked.
+            #
+            # It calls run_output_conflict directly rather than via_clears:
+            # the reused via IS on the board, so it is in `foreign_vias` at
+            # distance 0 from itself, and the full test would reject every
+            # reuse on its own same-net drill floor. Only this run's output is
+            # in question here.
+            #
+            # And `adds_via=False`, because a reuse adds NO drill and NO via
+            # copper -- only the bridging stub. Pricing the existing via as a
+            # new one at config.via_size rejected every reuse on this board:
+            # 0.30 board vias 0.400mm apart (legal at 0.15+0.15+0.10, and
+            # already there) judged against a demanded 0.55. That was measured
+            # as Net-(U2A-DATA_30) losing its escape to a fresh drill --
+            # 28/12/30 vias/dropped/tracks becoming 29/13/31 on U2.
             if (obs_layer_idx is None or
                     check_line_clearance(obstacles, px, py, _rvx, _rvy,
-                                         obs_layer_idx, cfg)):
+                                         obs_layer_idx, cfg)) \
+                    and not run_output_conflict(
+                        _rvx, _rvy, pi.pad.net_id, placed, px, py,
+                        via_size=via_size, via_drill=via_drill,
+                        clearance=clearance, track_width=track_width,
+                        hole_to_hole=_h2h, adds_via=False):
                 return (_rvx, _rvy)
         for d in candidate_offsets(pi.pad_width, mode):
             vx, vy = snap(px + ex * d), snap(py + ey * d)
             stub_ok = (obs_layer_idx is None or
                        check_line_clearance(obstacles, px, py, vx, vy, obs_layer_idx, cfg))
-            if stub_ok and via_clears(vx, vy, pi.pad.net_id, placed):
+            if stub_ok and via_clears(vx, vy, pi.pad.net_id, placed, px, py):
                 return (vx, vy)
         return None
 
@@ -316,7 +516,10 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
             pos = place_pin(pis[idx], mode_fn(idx), placed)
             results[idx] = pos
             if pos is not None:
-                placed.append((pos[0], pos[1], pis[idx].pad.net_id))
+                # Carry the PAD origin, so the stub this placement implies is
+                # visible to every later candidate in the same run (D10).
+                placed.append((pos[0], pos[1], pis[idx].pad.net_id,
+                               pis[idx].pad.global_x, pis[idx].pad.global_y))
         return results
 
     # Stagger configurations, tried in order; the most-escaped wins, ties keep
@@ -368,8 +571,10 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
                 dropped.append(pi.pad.net_name)
                 continue
             vx, vy = pos
-            placed_global.append((vx, vy, pi.pad.net_id))
             px, py = pi.pad.global_x, pi.pad.global_y
+            # Committed across SIDES: side 2's candidates must see side 1's
+            # stubs, not only its via centres (D10).
+            placed_global.append((vx, vy, pi.pad.net_id, px, py))
             # Reused an existing same-net via (#479 audit gap 2): emit only
             # the bridging stub, never a duplicate drill.
             if any(abs(vx - ox) < 1e-4 and abs(vy - oy) < 1e-4

--- a/py_router/repair_planes.py
+++ b/py_router/repair_planes.py
@@ -2203,6 +2203,20 @@ def repair_planes(
 
         def _gate_oracle_query():
             import tempfile
+            # A cancelled run does not get to spend another 300s here. Both
+            # branches below shell out -- exact_unconnected via pcbnew's
+            # ZONE_FILLER (EXACT_FILL_TIMEOUT 300s) and the kicad-cli fallback
+            # via ORACLE_DRC_TIMEOUT (240s) -- and neither honours cancel_check,
+            # because neither existed as a cancellation point. Measured: a
+            # repair that cancelled cleanly at 45s then sat in a KiCad
+            # exact_fill child until the EXTERNAL timeout killed it at 200s,
+            # which handed back exactly the race the budget just won. The gate
+            # is a verification pass, not a correctness one; skipping it leaves
+            # the partial board written and gated by everything upstream.
+            if cancel_check is not None and cancel_check():
+                print("  guaranteed-join gate: SKIPPED (cancelled; the gate "
+                      "oracle shells out and would overrun the budget)")
+                return None
             try:
                 _tmp = tempfile.NamedTemporaryFile(
                     suffix='.kicad_pcb', delete=False)
@@ -3255,6 +3269,26 @@ Examples:
     from fix_kicad_drc_settings import add_drc_fix_args
     add_drc_fix_args(parser)
 
+    parser.add_argument("--deadline", type=float, default=None,
+                        metavar="SECONDS",
+                        help="Wall-clock budget for the REPAIR LOOPS. Not a "
+                             "hard cap on total runtime: the cancel is "
+                             "cooperative, and the bounded tail (fills, write, "
+                             "cleanup) still runs, so expect to overshoot -- "
+                             "measured 109s on a 45s budget. What it "
+                             "guarantees is TERMINATION on the tool's own "
+                             "terms: without it this tool ran 40 min "
+                             "(--rip-blocker-nets) and 25 min (plain) on a "
+                             "217-part board and never wrote a board at all "
+                             "(run 9). With it: cancels at the loop heads, "
+                             "writes the partial board, exits 7, and marks the "
+                             "summary complete:false. Set it well BELOW any "
+                             "external timeout. A reserve band is held back so "
+                             "the ripped-net reconnect still runs -- without "
+                             "it, ripped nets ship stripped and the board is "
+                             "WORSE than its input. Default: no budget. "
+                             "Env: KRT_DEADLINE_S")
+
     from fab_tiers import (add_fab_tier_args, fab_tier_from_args, set_default_fab_tier,
                            enforce_fab_floors, count_copper_layers_in_file)
     add_fab_tier_args(parser)
@@ -3363,7 +3397,31 @@ Examples:
         for net, layer in zone_pairs:
             print(f"  {net} on {layer}")
 
+    # The deadline is ONE CLOSURE handed to plumbing this engine already has:
+    # `cancel_check` is a first-class parameter honoured at every loop head and
+    # forwarded into each inner batch_route, and on cancel the write branch
+    # still runs -- so a cancelled run yields a real, gated, strictly-better
+    # board. It was None on the CLI path only because this call never passed
+    # one. `progress_callback` is the same story: ~9 call sites, all dark on the
+    # CLI because it was built for the GUI.
+    #
+    # RESERVE BAND, and this one is a correctness hazard rather than a nicety:
+    # the end-of-run rip-casualty reconnect issues its OWN batch_route with the
+    # same cancel_check. If the budget were already spent, that reconnect would
+    # do nothing and every net ripped earlier would ship stripped -- a partial
+    # board WORSE than its input. So the repair loops trip early, at
+    # deadline - reserve, leaving clock for the reconnect.
+    import krt_deadline
+    _rdp_report = {'tool': 'repair_planes'}
+    _dl = krt_deadline.arm(args.deadline, tool='repair_planes',
+                           on_partial=lambda: _rdp_report)
+    _reserve = max(30.0, (args.deadline or 0) * 0.2) if _dl else 0.0
+
     _rdp_result = repair_planes(
+        cancel_check=(_dl.cancel_check('plane repair', reserve=_reserve)
+                      if _dl else None),
+        progress_callback=(krt_deadline.stdout_progress(deadline=_dl)
+                           if _dl else None),
         input_file=args.input_file,
         output_file=args.output_file,
 
@@ -3424,7 +3482,21 @@ Examples:
     # KiCad's REAL fill produces can survive every model-based pass (castor
     # +3.3VA bare island, lumenpnp U5 pocket). Ask kicad-cli for the exact
     # missing links on the processed nets and route precisely those.
-    if not args.dry_run and not args.no_kicad_recheck and args.output_file:
+    # A deadline hit skips it. The recheck shells out to kicad-cli, which
+    # carries its own 240s ORACLE_DRC_TIMEOUT and can itself refill the board
+    # (300s EXACT_FILL_TIMEOUT) -- so running it after the budget is already
+    # spent hands the race straight back to the external timeout we just won.
+    # Measured: a cancelled repair reached "Plane repair cancelled" in ~45s and
+    # then sat for minutes inside a KiCad exact_fill child. The partial board is
+    # already written and already gated; the recheck is an improvement pass, not
+    # a correctness one, and its absence is disclosed in the summary.
+    _deadline_hit = bool(_dl and _dl.expired())
+    if _deadline_hit:
+        _rdp_report['oracle_recheck'] = 'skipped: deadline'
+        print("  KiCad-oracle recheck: SKIPPED (deadline reached; the pass "
+              "shells out to kicad-cli and would overrun the budget)")
+    if (not args.dry_run and not args.no_kicad_recheck and args.output_file
+            and not _deadline_hit):
         from kicad_oracle import oracle_reconnect
         from routing_config import GridRouteConfig
         # #338: the oracle pass runs on OUTPUT_FILE, whose sibling .kicad_pro
@@ -3512,7 +3584,40 @@ Examples:
     # A10: nets this step ripped and could neither reconnect nor restore. They
     # ship OPEN, so they belong in the summary by name and in the exit code.
     _summary["ripped_still_open"] = list(LAST_RIPPED_STILL_OPEN)
-    print("JSON_SUMMARY: " + _json.dumps(_summary))
+    # A cancelled run must not exit 0. It wrote a real, gated board -- unlike
+    # place_reconstruct, this tool's cancel path writes, because a partial plane
+    # repair is strictly-better copper rather than a half-legalized placement --
+    # but it did not finish, and a caller reading exit 0 would treat a partial
+    # as complete. `complete` is the machine gate; `status` says why.
+    if _dl is not None and _dl.expired():
+        _summary["complete"] = False
+        _summary["status"] = "deadline"
+        _summary["deadline_s"] = _dl.seconds
+        _summary["elapsed_s"] = round(_dl.elapsed(), 1)
+        _summary["stopped_in"] = _dl.stopped_in
+        _rdp_report.update(_summary)
+        krt_deadline.emit(_summary, complete=False, status='deadline',
+                          deadline=_dl)
+        print(f"{RED}DEADLINE: this run stopped on its own budget after "
+              f"{_dl.elapsed():.0f}s of {_dl.seconds:g}s. The board at "
+              f"{args.output_file} is a PARTIAL repair -- real copper, fully "
+              f"gated, but the sweep did not finish. Do not read it as "
+              f"clean.{RESET}")
+        if LAST_RIPPED_STILL_OPEN:
+            print(f"{RED}  ...and {len(LAST_RIPPED_STILL_OPEN)} ripped net(s) "
+                  f"ship OPEN: {', '.join(LAST_RIPPED_STILL_OPEN)}{RESET}")
+        return krt_deadline.DEADLINE_EXIT
+    # Emit through krt_deadline, NOT a raw print. `_emitted` is set only inside
+    # krt_deadline.emit(), so a bare print left it False and the atexit flush
+    # then published the contentless partial report armed at --deadline time --
+    # every successful run printed a SECOND, contradicting
+    # `{"complete": false, "status": "incomplete"}` line after the real one
+    # (run 11, v6_r7: total_regions 7, complete true, then incomplete). Any
+    # consumer keying on the LAST JSON_SUMMARY read a good repair as a failed
+    # one. The deadline branch above already does this; this is the other half.
+    _rdp_report.update(_summary)
+    krt_deadline.emit(_summary, complete=_summary.get("complete", True),
+                      status=_summary.get("status", "ok"))
 
     if LAST_RIPPED_STILL_OPEN:
         print(f"{RED}RIP CASUALTIES SHIP OPEN ({len(LAST_RIPPED_STILL_OPEN)}): "
@@ -3537,6 +3642,14 @@ route_planes = repair_planes
 if __name__ == "__main__":
     from console_encoding import enable_utf8_console
     enable_utf8_console()  # cp1252-safe non-ASCII prints (issue #152)
+    # CMD/EXIT self-echo (run-3 B1). This file was a deliberate non-adopter
+    # while it had no way to stop itself: its long silent phases ended in an
+    # external kill, and `atexit` does not run on one, so the banner would have
+    # promised an EXIT= line that never arrived. With --deadline the tool exits
+    # on its own terms, so the line is now truthful -- and this is the script
+    # whose exit code was hardest to tell from the shell's.
+    import cli_banner
+    cli_banner.install()
     # run-8: propagate main()'s verdict -- it returns 4 when plane repair
     # leaves rip casualties unconnected, which used to be one red line and
     # exit 0.

--- a/py_router/repair_planes.py
+++ b/py_router/repair_planes.py
@@ -3268,7 +3268,7 @@ Examples:
     # keep their larger PLANE_EDGE_CLEARANCE fallback when the board declares none.
     # Resolved here, before enforce_fab_floors and every downstream use.
     from list_nets import (board_default_netclass_clearance, board_default_netclass_param,
-                           board_constraint)
+                           resolve_cli_floor)
     for _pname, _nckey, _fallback in (('track_width', 'track_width', defaults.TRACK_WIDTH),
                                       ('via_size', 'via_diameter', defaults.VIA_SIZE),
                                       ('via_drill', 'via_drill', defaults.VIA_DRILL)):
@@ -3291,20 +3291,16 @@ Examples:
               f"clearance {args.clearance}mm.")
     else:
         args.clearance = min(_dflt_clr, _ceiling) if _dflt_clr is not None else _ceiling
-    if args.hole_to_hole_clearance is None:
-        _h2h = board_constraint(args.input_file, 'min_hole_to_hole')
-        args.hole_to_hole_clearance = _h2h if _h2h is not None else defaults.HOLE_TO_HOLE_CLEARANCE
-        print(f"--hole-to-hole-clearance not given; using "
-              f"{'the board min_hole_to_hole' if _h2h is not None else 'the fallback'} "
-              f"{args.hole_to_hole_clearance}mm.")
-    if args.board_edge_clearance is None:
-        # Planes keep their larger edge keep-out (PLANE_EDGE_CLEARANCE) only when
-        # the board declares no edge rule of its own.
-        _edge = board_constraint(args.input_file, 'min_copper_edge_clearance')
-        args.board_edge_clearance = _edge if _edge is not None else defaults.PLANE_EDGE_CLEARANCE
-        print(f"--board-edge-clearance not given; using "
-              f"{'the board min_copper_edge_clearance' if _edge is not None else 'the fallback'} "
-              f"{args.board_edge_clearance}mm.")
+    # Shared resolver (list_nets.resolve_cli_floor); see route_planes.py -- a
+    # DECLARED 0.0 is "no edge rule of its own", not a rule of zero, so the
+    # plane inset stays PLANE_EDGE_CLEARANCE as the GUI's plane tab already had
+    # it.
+    args.hole_to_hole_clearance = resolve_cli_floor(
+        args.input_file, 'hole_to_hole', args.hole_to_hole_clearance,
+        defaults.HOLE_TO_HOLE_CLEARANCE, '--hole-to-hole-clearance')
+    args.board_edge_clearance = resolve_cli_floor(
+        args.input_file, 'board_edge_clearance', args.board_edge_clearance,
+        defaults.PLANE_EDGE_CLEARANCE, '--board-edge-clearance')
     set_default_fab_tier(*fab_tier_from_args(args))
     _pinned_floors = enforce_fab_floors(
         count_copper_layers_in_file(args.input_file),

--- a/py_router/route.py
+++ b/py_router/route.py
@@ -4881,6 +4881,11 @@ For differential pair routing, use route_diff.py:
         # asks it precisely because it does not yet trust anything else this
         # clone would tell it. sys.exit rather than return: this block lives
         # directly under `if __name__ == "__main__":`, not inside a main().
+        # krt_capabilities lives at the REPO root, one level above this
+        # engine dir (#522 layout), so hop up before importing it.
+        _repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        if _repo_root not in sys.path:
+            sys.path.insert(0, _repo_root)
         from krt_capabilities import capabilities as _caps
         print(json.dumps(_caps(), indent=1, sort_keys=True))
         sys.exit(0)

--- a/py_router/route.py
+++ b/py_router/route.py
@@ -994,6 +994,22 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
                         if net.name in _scope_names}
                        | {nid for _name, nid in net_ids})
     if not net_ids:
+        # The caller named nets and NOT ONE of them exists on this board. That
+        # is an input error, not a no-op: the old soft return wrote an
+        # unchanged passthrough copy and reported rc 0, so a net list whose
+        # names all missed (run 11: a CRLF file gave every one of 88 names a
+        # trailing \r) looked exactly like "nothing left to do". Raise, so the
+        # CLI exits non-zero and the GUI surfaces a real error, instead of both
+        # of them reporting success over an untouched board.
+        if net_names:
+            from routing_exceptions import NetNotFoundError
+            raise NetNotFoundError(
+                list(net_names),
+                f"None of the {len(net_names)} requested net name(s) exist on "
+                f"this board -- nothing was routed and no copper was written. "
+                f"Check for stray whitespace (a CRLF net list gives every name "
+                f"a trailing carriage return) or a stale net list. "
+                f"First few: {', '.join(repr(n) for n in list(net_names)[:5])}")
         print("No valid nets to route!")
         if return_results:
             return 0, 0, 0.0, _empty_results_data()
@@ -3078,6 +3094,24 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
         # move successful/failed (scope-based), so they get their own key --
         # a caller that only reads the scoped tallies must still see them.
         summary['ripped_open'] = _ripped_open
+        # ...and say whether the VERDICT already counts them. The verdict is
+        # `failed_single + open_single + pad-deficit`; `ripped_open` is in none
+        # of the first two by construction (it is scope-EXCLUDED), and the
+        # deficit ships as two bare scalars with no per-net attribution, so
+        # membership in the third was untestable from the summary. One run's
+        # true open count was therefore a RANGE -- 58 to 61 -- that no
+        # published field could narrow. This names the uncounted set instead of
+        # leaving the reader to guess it.
+        _counted = set(summary.get('failed_single') or []) \
+            | set(summary.get('open_single') or [])
+        summary['ripped_open_uncounted'] = sorted(
+            n for n in _ripped_open if n not in _counted)
+        summary['ripped_open_note'] = (
+            'ripped_open nets are OUTSIDE this run\'s --nets scope, so they '
+            'move neither failed_single nor open_single. Those listed in '
+            'ripped_open_uncounted are additionally not in either scoped term: '
+            'if they are also outside the multipoint pad deficit, the run\'s '
+            'open-net verdict is understated by that many.')
     try:
         from protected_nets import PROTECTED_SKIPPED
         if PROTECTED_SKIPPED:
@@ -3218,6 +3252,36 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
                 for _n, _r in sorted(_amp.items())]
     except Exception:
         pass
+    # A budget the CLI armed must reach THIS summary -- it is the only one
+    # route.py prints, and a cancelled run still falls through to here (the
+    # cancel breaks the routing loops, it does not skip the write), so without
+    # the stamp a partial board reported `complete` by omission. Inert when no
+    # budget was armed or the budget was not spent, which is every GUI call and
+    # every run that finished in time.
+    try:
+        import krt_deadline as _kdl
+        _kdl.stamp(summary)
+    except Exception:
+        pass
+    # WHICH SUMMARY IS THIS? A run that fires the reconciliation sub-pass emits
+    # a SECOND JSON_SUMMARY, scoped to that subset, and the only thing saying so
+    # was a prose "Note:" printed after it. Anything that scrapes the last
+    # JSON_SUMMARY -- a tail, a grep, a person -- then reads the subset's tally
+    # as the run's. Measured on run 14: one A/B arm emitted two summaries and
+    # the other one, so the arms were compared at `routed_single: 1` against
+    # `121` and the wrong arm looked catastrophic.
+    #
+    # Derived from the sink rather than a new kwarg, because the sink's own
+    # contract already IS this distinction: "the first pass and, when it fires,
+    # the reconciliation sub-run's".
+    summary['scope'] = 'run' if not _SUMMARY_SINK else 'reconciliation-subset'
+    if summary['scope'] != 'run':
+        # These are recomputed over the WHOLE board even in the subset pass, so
+        # a reader merging tallies must not add them twice.
+        summary['board_scoped_keys'] = [k for k in ('stacked_copper',
+                                                    'power_trace_ampacity',
+                                                    'min_clearance_used')
+                                        if k in summary]
     print(f"JSON_SUMMARY: {json.dumps(summary)}")
     _SUMMARY_SINK.append(summary)
 
@@ -4327,8 +4391,11 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
                           f"still failed -- one more lap on the updated "
                           f"board")
             print("Note: the JSON_SUMMARY above covers only the "
-                  "reconciliation subset; the run's full tally is the "
-                  "earlier JSON_SUMMARY plus these recoveries.")
+                  "reconciliation subset (it carries scope="
+                  "\"reconciliation-subset\"); the run's full tally is the "
+                  "earlier JSON_SUMMARY, the one with scope=\"run\", plus "
+                  "these recoveries. Never scrape the LAST JSON_SUMMARY of a "
+                  "route log -- count them, or read the scope.")
             if _rok:
                 successful += _rok
                 failed = max(0, failed - _rok)
@@ -4415,6 +4482,27 @@ if __name__ == "__main__":
     # the run (issue #152).
     from console_encoding import enable_utf8_console
     enable_utf8_console()
+    # CMD/EXIT self-echo (run-3 B1). CLI-`__main__`-only by construction: the
+    # GUI imports batch_route and never runs this block.
+    #
+    # This file was a deliberate non-adopter while it had no way to stop itself
+    # -- its long silent phases ended in an external kill, and `atexit` does not
+    # run on one, so the banner would have promised an EXIT= line that never
+    # arrived. `--deadline` is what makes the promise truthful, which is why the
+    # two landed in that order. The gap it closes: the convergence-
+    # ledger protocol says to paste a tool's own CMD: line into
+    # `converge record --argv`, which was unsatisfiable for a routing lap --
+    # run 11 hand-wrote replay scripts instead.
+    #
+    # NOT under --capabilities, whose whole stdout is ONE JSON document a
+    # consumer does `json.loads()` on (see the block near parse_args, and
+    # converge.py:787 for the same rule stated for the same reason). A `CMD:`
+    # line ahead of it is a JSONDecodeError at char 0, which is a broken API
+    # rather than a noisy log. Raw argv, because the flag is answered before
+    # argparse runs -- the banner has to be decided before then too.
+    if '--capabilities' not in sys.argv[1:]:
+        import cli_banner
+        cli_banner.install()
     from redo_record import record_invocation
     record_invocation()  # stress-test redo manifest (#132); no-op unless REDO_MANIFEST set
 
@@ -4586,6 +4674,22 @@ For differential pair routing, use route_diff.py:
                              "either one alone is wrong -- the first counts every recovery as a "
                              "failure, the second narrows the whole-board pad-pair denominator to "
                              "the retried subset. Prefer this over parsing stdout.")
+    parser.add_argument("--deadline", type=float, default=None, metavar="SECONDS",
+                        help="Wall-clock budget for the ROUTING LOOPS. Not a hard "
+                             "cap on total runtime -- the cancel is cooperative and "
+                             "the bounded tail (write, cleanup, DRC writeback) still "
+                             "runs -- so expect to overshoot. What it guarantees is "
+                             "TERMINATION on THIS tool's terms: it stops between "
+                             "nets, writes the copper it has, and prints a "
+                             "JSON_SUMMARY carrying complete=false / status=deadline "
+                             "before exiting 7. Without it an external kill on "
+                             "Windows is TerminateProcess, which leaves NO summary "
+                             "and NO exit code of ours -- run 11 lost a lap that way "
+                             "and only a re-parse of the output board established "
+                             "the engine had in fact finished. ANY harness with an "
+                             "external timeout should pass this at ~0.8x its own. "
+                             "Default: no budget (a wall-clock default would break "
+                             "replay determinism). Env: KRT_DEADLINE_S")
     parser.add_argument("--neckdown-length", type=float, default=defaults.NECKDOWN_LENGTH,
                         help="Length in mm of narrow track from the target pad on neck-down tap routes; the track "
                              "returns to the power width beyond this where clearance allows (default: 2.5)")
@@ -4914,10 +5018,15 @@ For differential pair routing, use route_diff.py:
               "--list-groups to see what exists.", file=sys.stderr)
         sys.exit(2)
 
-    # Combine positional net_patterns and --nets argument
+    # Combine positional net_patterns and --nets argument.
+    # Strip surrounding whitespace, as route_diff.py already does: a net list
+    # read from a CRLF file hands every name a trailing '\r', which matches
+    # nothing and (before the guard in batch_route) reported success over an
+    # untouched board. Names are never meaningfully whitespace-padded.
     all_patterns = list(args.net_patterns) if args.net_patterns else []
     if args.nets:
         all_patterns.extend(args.nets)
+    all_patterns = [p.strip() for p in all_patterns if p.strip()]
 
     # --force-reroute rips every selected net; without an explicit scope the
     # default-'*' below would silently select the WHOLE BOARD for rip+reroute.
@@ -5012,6 +5121,22 @@ For differential pair routing, use route_diff.py:
     if not net_names:
         print("No nets matched the given patterns!")
         sys.exit(1)
+
+    # ...and the case that guard cannot see: net_names is NON-empty but every
+    # entry is a literal that matched nothing. expand_net_patterns deliberately
+    # passes an unmatched literal through (callers may name nets a board does
+    # not carry), so the list is full of names that will all fail to resolve.
+    # batch_route then found zero net_ids, wrote an unchanged passthrough copy
+    # and returned rc 0 -- indistinguishable from "nothing left to do". Run 11
+    # lost a lap to it: a CRLF net list gave all 88 names a trailing '\r'.
+    # batch_route now raises for the GUI's benefit; the CLI refuses here so the
+    # exit code is a clean 2 rather than a traceback.
+    if not resolve_net_ids(pcb_data, net_names):
+        print(f"route.py: error: none of the {len(net_names)} requested net "
+              f"name(s) exist on this board -- nothing would be routed. Check "
+              f"for stray whitespace or a stale net list. First few: "
+              f"{', '.join(repr(n) for n in net_names[:5])}", file=sys.stderr)
+        sys.exit(2)
 
     # --undo: strip the scoped nets' copper instead of routing them.
     if args.undo:
@@ -5137,12 +5262,34 @@ For differential pair routing, use route_diff.py:
             print(f"Netclass clearances for {len(_net_clearances_map)} net(s), {_mode} "
                   f"(mm: {_classes}); cross-class max(A,B) respected.")
 
+    # The deadline is ONE CLOSURE handed to plumbing this engine already has:
+    # `cancel_check` is honoured at every routing/reroute/rescue/cleanup loop
+    # head and forwards into the reconciliation self-invoke via
+    # `_reconcile_kwargs`, and on cancel the loops BREAK rather than raise -- so
+    # the write, the summary and the DRC writeback all still run and a cancelled
+    # run yields a real, gated, partial board rather than nothing. It was None
+    # on the CLI path only because this call never passed one; `progress_callback`
+    # is the same story (built for the GUI, dark on the CLI).
+    #
+    # No `try/finally` and no wrapper: `krt_deadline.arm`'s atexit hook is what
+    # makes "a JSON_SUMMARY on every path" true here, covering the early
+    # `sys.exit`s, argparse errors and unhandled exceptions that this inline
+    # __main__ block has a dozen of. `seal()` below then stops that hook from
+    # contradicting the engine's own summary on a run that finished.
+    import krt_deadline
+    _route_report = {'tool': 'route.py', 'board': args.input_file}
+    _dl = krt_deadline.arm(args.deadline, tool='route',
+                           on_partial=lambda: _route_report)
+
     # --preview: the engine already supports this -- return_results=True with
     # an empty output_file routes fully, mutates only the in-memory PCBData
     # and writes nothing. This just exposes it on the CLI (#459 follow-on).
     _preview_out = batch_route(args.input_file,
                 "" if args.preview else args.output_file, net_names,
                 return_results=args.preview,
+                cancel_check=(_dl.cancel_check('routing') if _dl else None),
+                progress_callback=(krt_deadline.stdout_progress(deadline=_dl)
+                                   if _dl else None),
                 direction_order=args.direction,
                 ordering_strategy=args.ordering,
                 disable_bga_zones=args.no_bga_zones,
@@ -5226,6 +5373,22 @@ For differential pair routing, use route_diff.py:
                 add_teardrops=args.add_teardrops,
                 collect_stats=args.stats)
 
+    # batch_route printed the authoritative JSON_SUMMARY (stamped by
+    # krt_deadline.stamp when the budget was spent). Seal so the atexit flush
+    # does not publish a second, contradicting `incomplete` line after it.
+    krt_deadline.seal()
+    # `stopped_in or expired()`: the durable record that the cancel fired, not
+    # just "the wall clock has since passed". See krt_deadline.stamp.
+    _deadline_hit = bool(_dl and (_dl.stopped_in or _dl.expired()))
+    if _deadline_hit:
+        print(f"{RED}DEADLINE: this run stopped on its own budget after "
+              f"{_dl.elapsed():.0f}s of {_dl.seconds:g}s"
+              + (f" (in {_dl.stopped_in})" if _dl.stopped_in else "")
+              + f". The board at {args.output_file or '(none)'} is a PARTIAL "
+              f"route -- real, gated copper, but nets were left unattempted. "
+              f"Do not read it as clean; the JSON_SUMMARY above carries "
+              f"complete=false.{RESET}")
+
     if args.preview:
         _ok, _fail, _t, _data = _preview_out
         _res = _data.get('results') or []
@@ -5256,7 +5419,7 @@ For differential pair routing, use route_diff.py:
         # run with failed nets also exits 0, so exiting 1 here would make the
         # read-only mode the only one that can kill a `set -e` redo_commands.sh
         # replay -- at a step that changes nothing.
-        sys.exit(0)
+        sys.exit(krt_deadline.DEADLINE_EXIT if _deadline_hit else 0)
 
     # Castellated landings (run-6 fix 1.7): pull track ends that landed inside
     # a castellated pad's edge-clearance zone back to the pad's inner reach.
@@ -5307,3 +5470,11 @@ For differential pair routing, use route_diff.py:
             persist_impedance_specs(_pro, consume_impedance_specs())
         except Exception as e:
             print(f"  (skipped protected-nets record: {e})")
+
+    # LAST, and non-zero: the post-passes above are bounded and belong to the
+    # partial board (skipping the DRC writeback would strand the output without
+    # its floor -- the #441 hazard). Exiting 0 here would let a caller read an
+    # unfinished route as a finished one; `complete: false` in the summary is the
+    # machine gate, this is the shell's.
+    if _deadline_hit:
+        sys.exit(krt_deadline.DEADLINE_EXIT)

--- a/py_router/route.py
+++ b/py_router/route.py
@@ -4791,7 +4791,7 @@ For differential pair routing, use route_diff.py:
     # constraint minimum). Resolved here, before enforce_fab_floors and every
     # downstream use. Stashed on args for drc_fix_kwargs (the writeback clamp).
     from list_nets import (board_default_netclass_clearance, board_default_netclass_param,
-                           board_constraint)
+                           resolve_cli_floor)
     # #435 companion: whether --track-width was EXPLICITLY set. If NOT, each net
     # routes at its OWN netclass track width engine-side (not the single board
     # Default-class width). --impedance derives width per layer, so it counts as
@@ -4828,18 +4828,18 @@ For differential pair routing, use route_diff.py:
     else:
         # min(Default class, ceiling) so Default is capped like every other class.
         args.clearance = min(_dflt_clr, _ceiling) if _dflt_clr is not None else _ceiling
-    if args.hole_to_hole_clearance is None:
-        _h2h = board_constraint(args.input_file, 'min_hole_to_hole')
-        args.hole_to_hole_clearance = _h2h if _h2h is not None else defaults.HOLE_TO_HOLE_CLEARANCE
-        print(f"--hole-to-hole-clearance not given; using "
-              f"{'the board min_hole_to_hole' if _h2h is not None else 'the fallback'} "
-              f"{args.hole_to_hole_clearance}mm.")
-    if args.board_edge_clearance is None:
-        _edge = board_constraint(args.input_file, 'min_copper_edge_clearance')
-        args.board_edge_clearance = _edge if _edge is not None else defaults.BOARD_EDGE_CLEARANCE
-        print(f"--board-edge-clearance not given; using "
-              f"{'the board min_copper_edge_clearance' if _edge is not None else 'the fallback'} "
-              f"{args.board_edge_clearance}mm.")
+    # Both floors go through the SHARED resolver (list_nets.resolve_cli_floor),
+    # so a declared 0 -- KiCad's "not configured" -- reads as UNSET here exactly
+    # as it does on the placement half of the loop. Read straight, these two
+    # constraints made the two halves disagree about one declared number: 0.55
+    # [fixed default] in render_placement/check_floorplan/converge against a
+    # REAL 0.0 here, announced as "the board min_copper_edge_clearance 0.0mm".
+    args.hole_to_hole_clearance = resolve_cli_floor(
+        args.input_file, 'hole_to_hole', args.hole_to_hole_clearance,
+        defaults.HOLE_TO_HOLE_CLEARANCE, '--hole-to-hole-clearance')
+    args.board_edge_clearance = resolve_cli_floor(
+        args.input_file, 'board_edge_clearance', args.board_edge_clearance,
+        defaults.BOARD_EDGE_CLEARANCE, '--board-edge-clearance')
     set_default_fab_tier(*fab_tier_from_args(args))
     _pinned_floors = enforce_fab_floors(
         count_copper_layers_in_file(args.input_file),

--- a/py_router/route_diff.py
+++ b/py_router/route_diff.py
@@ -1808,7 +1808,7 @@ Examples:
     # default to the board's own constraint minimum when omitted. Resolved before
     # enforce_fab_floors; _clamp_netclasses is stashed for drc_fix_kwargs.
     from list_nets import (board_default_netclass_clearance, board_default_netclass_param,
-                           board_constraint)
+                           resolve_cli_floor)
     # #435: whether the diff geometry was EXPLICITLY set on the CLI. If NOT, each
     # pair falls back engine-side to its OWN netclass diff_pair_gap/width (not the
     # board Default class), so a multi-class board routes every pair to its own
@@ -1871,18 +1871,14 @@ Examples:
         print(f"Diff-pair gap {args.diff_pair_gap}mm is below clearance "
               f"{args.clearance}mm; raising gap to clearance (#441).")
         args.diff_pair_gap = args.clearance
-    if args.hole_to_hole_clearance is None:
-        _h2h = board_constraint(args.input_file, 'min_hole_to_hole')
-        args.hole_to_hole_clearance = _h2h if _h2h is not None else defaults.HOLE_TO_HOLE_CLEARANCE
-        print(f"--hole-to-hole-clearance not given; using "
-              f"{'the board min_hole_to_hole' if _h2h is not None else 'the fallback'} "
-              f"{args.hole_to_hole_clearance}mm.")
-    if args.board_edge_clearance is None:
-        _edge = board_constraint(args.input_file, 'min_copper_edge_clearance')
-        args.board_edge_clearance = _edge if _edge is not None else defaults.BOARD_EDGE_CLEARANCE
-        print(f"--board-edge-clearance not given; using "
-              f"{'the board min_copper_edge_clearance' if _edge is not None else 'the fallback'} "
-              f"{args.board_edge_clearance}mm.")
+    # Shared resolver: a declared 0 is UNSET, the same rule the placement half
+    # of the loop applies (list_nets.resolve_cli_floor).
+    args.hole_to_hole_clearance = resolve_cli_floor(
+        args.input_file, 'hole_to_hole', args.hole_to_hole_clearance,
+        defaults.HOLE_TO_HOLE_CLEARANCE, '--hole-to-hole-clearance')
+    args.board_edge_clearance = resolve_cli_floor(
+        args.input_file, 'board_edge_clearance', args.board_edge_clearance,
+        defaults.BOARD_EDGE_CLEARANCE, '--board-edge-clearance')
     set_default_fab_tier(*fab_tier_from_args(args))
     _pinned_floors = enforce_fab_floors(
         count_copper_layers_in_file(args.input_file),

--- a/py_router/route_diff.py
+++ b/py_router/route_diff.py
@@ -108,6 +108,13 @@ import rust_alloc  # noqa: E402,F401  # issue #419: set MIMALLOC_PURGE_DELAY bef
 from grid_router import GridObstacleMap, GridRouter
 
 
+#: Set when the --nets patterns resolved to no differential pair at all.
+#: Read by main() to exit non-zero: the refusal used to print `Error:` and
+#: return (0, 0, 0.0), which main discarded, so the process exited 0 and a
+#: chained caller walked past an unrouted board.
+_NO_PAIRS_MATCHED = False
+
+
 def batch_route_diff_pairs(input_file: str, output_file: str, net_names: List[str],
                 layers: List[str] = None,
                 layer_costs: Optional[List[float]] = None,
@@ -514,6 +521,11 @@ def batch_route_diff_pairs(input_file: str, output_file: str, net_names: List[st
                   f"(coupled via {', '.join(_xn.bridge_refs)})")
 
     if not diff_pairs:
+        # A precise sentinel. Inferring this from a (0, 0) return conflates it
+        # with a legitimate run in which every pair DEFERRED to single-ended
+        # routing -- also 0 routed, 0 failed, and not an error at all.
+        global _NO_PAIRS_MATCHED
+        _NO_PAIRS_MATCHED = True
         print(f"Error: No differential pairs found matching the patterns!")
         print("  Differential pairs must have _P/_N, P/N, or +/- suffixes.")
         print(f"  Patterns provided: {net_names}")
@@ -1314,6 +1326,16 @@ def batch_route_diff_pairs(input_file: str, output_file: str, net_names: List[st
         else:
             failed_diff_pairs.append(pair_name)
 
+    # A pair the audit demoted to PARTIAL was already counted in `successful`
+    # by the coupled-route loop, so the headline and the JSON key still claimed
+    # it. Take it back here, after the audit has spoken and BEFORE either the
+    # printed summary or the returned tuple reads the counter -- the GUI reads
+    # `successful` raw (differential_gui.py), so fixing only the print site
+    # would leave the GUI and JSON_SUMMARY saying different things than the
+    # member audit sitting next to them.
+    if partial_diff_pairs:
+        successful = max(0, successful - len(partial_diff_pairs))
+
     # Count total vias from results
     total_vias = sum(len(r.get('new_vias', [])) for r in results)
 
@@ -1345,6 +1367,20 @@ def batch_route_diff_pairs(input_file: str, output_file: str, net_names: List[st
     if single_ended_diff_pairs:
         print(f"  Single-ended:  {len(single_ended_diff_pairs)} (electrically short - "
               f"deferred to single-ended routing)")
+        # ...and say how those members ACTUALLY came out. The headline above
+        # reads `Diff pairs: 0/2 routed` on a step where every member net got
+        # copper and connected, so a log tail -- which is what a grep, a CI
+        # summary or a person reads -- shows total failure off a fully
+        # successful step. Run 14 had to open the JSON to find out otherwise.
+        _fb = se_fallback_summary or {}
+        _rt, _pt, _fl = (len(_fb.get('routed') or []),
+                         len(_fb.get('partial') or []),
+                         len(_fb.get('failed') or []))
+        if _rt or _pt or _fl:
+            _tail = (f", {_pt} partial" if _pt else '') + \
+                    (f", {RED}{_fl} FAILED{RESET}" if _fl else '')
+            print(f"  SE fallback:   {_rt}/{_rt + _pt + _fl} member net(s) "
+                  f"routed{_tail}")
     if skipped_bad_fanout:
         print(f"  {RED}Skipped:       {len(skipped_bad_fanout)} (fanout stubs self-overlap - "
               f"fix the fanout, #242){RESET}")
@@ -1387,6 +1423,14 @@ def batch_route_diff_pairs(input_file: str, output_file: str, net_names: List[st
     }
     if ac_coupled_summary:
         summary['ac_coupled_xnets'] = ac_coupled_summary
+    # See route.py's identical stamp: a budget armed by the CLI must reach the
+    # one summary this engine prints, because the cancel path still writes.
+    # Inert with no budget armed (every GUI call) or a budget not spent.
+    try:
+        import krt_deadline as _kdl
+        _kdl.stamp(summary)
+    except Exception:
+        pass
     print(f"JSON_SUMMARY: {json.dumps(summary)}")
 
     # Write output file or return results for direct application
@@ -1546,6 +1590,10 @@ def batch_route_diff_pairs(input_file: str, output_file: str, net_names: List[st
 if __name__ == "__main__":
     from console_encoding import enable_utf8_console
     enable_utf8_console()  # cp1252-safe non-ASCII prints (issue #152)
+    # CMD/EXIT self-echo (run-3 B1); see route.py for why this waited for
+    # --deadline. CLI-`__main__`-only: the GUI imports the engine function.
+    import cli_banner
+    cli_banner.install()
     import argparse
     from redo_record import record_invocation
     record_invocation()  # stress-test redo manifest (#132); no-op unless REDO_MANIFEST set
@@ -1783,6 +1831,21 @@ Examples:
     parser.add_argument("--ripped-route-avoidance-cost", type=float, default=defaults.RIPPED_ROUTE_AVOIDANCE_COST,
                         help=f"Soft penalty cost for routing through ripped corridors (0 = disabled, default: {defaults.RIPPED_ROUTE_AVOIDANCE_COST})")
 
+    parser.add_argument("--deadline", type=float, default=None, metavar="SECONDS",
+                        help="Wall-clock budget for the ROUTING LOOPS. Not a hard "
+                             "cap on total runtime -- the cancel is cooperative and "
+                             "the bounded tail (write, DRC writeback) still runs -- "
+                             "so expect to overshoot. What it guarantees is "
+                             "TERMINATION on THIS tool's terms: it stops between "
+                             "pairs, writes the copper it has, and prints a "
+                             "JSON_SUMMARY carrying complete=false / status=deadline "
+                             "before exiting 7. Without it an external kill on "
+                             "Windows is TerminateProcess, which leaves NO summary "
+                             "and NO exit code of ours. ANY harness with an external "
+                             "timeout should pass this at ~0.8x its own. Default: no "
+                             "budget (a wall-clock default would break replay "
+                             "determinism). Env: KRT_DEADLINE_S")
+
     # Debug options
     parser.add_argument("--debug-lines", action="store_true",
                         help="Output debug geometry on User.3 (connectors), User.4 (stub dirs), User.8 (simplified), User.9 (raw A*)")
@@ -1983,8 +2046,22 @@ Examples:
                   f"(mm: {_classes}); diff-pair routing respects cross-class max(A,B). "
                   f"Override with --net-clearances.")
 
+    # See route.py: the deadline is ONE closure into plumbing this engine
+    # already has. `cancel_check` breaks the pair/reroute/cleanup loops rather
+    # than raising, so the write and the summary still happen and a cancelled
+    # run yields real, gated copper. The atexit hook armed here is what makes a
+    # JSON_SUMMARY land on the paths that never reach the engine at all.
+    import krt_deadline
+    _rd_report = {'tool': 'route_diff.py', 'board': args.input_file}
+    _dl = krt_deadline.arm(args.deadline, tool='route_diff',
+                           on_partial=lambda: _rd_report)
+
     batch_route_diff_pairs(args.input_file, args.output_file, net_names,
                 net_clearances=_net_clearances_map,
+                cancel_check=(_dl.cancel_check('diff-pair routing')
+                              if _dl else None),
+                progress_callback=(krt_deadline.stdout_progress(deadline=_dl)
+                                   if _dl else None),
                 direction_order=args.direction,
                 ordering_strategy=args.ordering,
                 disable_bga_zones=args.no_bga_zones,
@@ -2061,6 +2138,22 @@ Examples:
                 schematic_dir=args.schematic_dir,
                 add_teardrops=args.add_teardrops)
 
+    # The engine printed the authoritative JSON_SUMMARY (stamped by
+    # krt_deadline.stamp when the budget was spent). Seal so the atexit flush
+    # does not publish a second, contradicting `incomplete` line after it.
+    krt_deadline.seal()
+    # `stopped_in or expired()`: the durable record that the cancel fired, not
+    # just "the wall clock has since passed". See krt_deadline.stamp.
+    _deadline_hit = bool(_dl and (_dl.stopped_in or _dl.expired()))
+    if _deadline_hit:
+        print(f"{RED}DEADLINE: this run stopped on its own budget after "
+              f"{_dl.elapsed():.0f}s of {_dl.seconds:g}s"
+              + (f" (in {_dl.stopped_in})" if _dl.stopped_in else "")
+              + f". The board at {args.output_file or '(none)'} is a PARTIAL "
+              f"route -- real, gated copper, but pairs were left unattempted. "
+              f"Do not read it as clean; the JSON_SUMMARY above carries "
+              f"complete=false.{RESET}")
+
     # Make the output project's DRC design rules consistent with the floors we
     # just routed to (issue #160), mirroring route.py, so a manual DRC in KiCad
     # flags only genuine problems instead of stock-default noise.
@@ -2096,3 +2189,21 @@ Examples:
             persist_impedance_specs(_pro, consume_impedance_specs())
         except Exception as e:
             print(f"  (skipped protected-nets record: {e})")
+
+    # LAST, and non-zero: the bounded post-passes above belong to the partial
+    # board (skipping the DRC writeback would strand the output without its
+    # floor -- the #441 hazard), but a caller reading exit 0 would treat an
+    # unfinished route as a finished one.
+    if _deadline_hit:
+        sys.exit(krt_deadline.DEADLINE_EXIT)
+    # AFTER the deadline: a run that ran out of clock exits 7, and that is the
+    # more specific fact. This is the other false success -- the patterns
+    # matched no pair at all, which used to print `Error:` and exit 0 because
+    # main called the router as a bare statement. Measured: a shell rewrote
+    # every `/IO_Banks/Z*` argument into a Windows path and 14 patterns matched
+    # nothing.
+    if _NO_PAIRS_MATCHED:
+        print("route_diff: the --nets patterns matched no differential pair, "
+              "so nothing was routed. Exiting non-zero so a chained caller "
+              "does not read this as success.", file=sys.stderr)
+        sys.exit(2)

--- a/py_router/route_planes.py
+++ b/py_router/route_planes.py
@@ -3905,7 +3905,7 @@ Examples:
     # keep their larger PLANE_EDGE_CLEARANCE fallback when the board declares none.
     # Resolved here, before enforce_fab_floors and every downstream use.
     from list_nets import (board_default_netclass_clearance, board_default_netclass_param,
-                           board_constraint)
+                           resolve_cli_floor)
     for _pname, _nckey, _fallback in (('track_width', 'track_width', defaults.TRACK_WIDTH),
                                       ('via_size', 'via_diameter', defaults.VIA_SIZE),
                                       ('via_drill', 'via_drill', defaults.VIA_DRILL)):
@@ -3928,20 +3928,18 @@ Examples:
               f"clearance {args.clearance}mm.")
     else:
         args.clearance = min(_dflt_clr, _ceiling) if _dflt_clr is not None else _ceiling
-    if args.hole_to_hole_clearance is None:
-        _h2h = board_constraint(args.input_file, 'min_hole_to_hole')
-        args.hole_to_hole_clearance = _h2h if _h2h is not None else defaults.HOLE_TO_HOLE_CLEARANCE
-        print(f"--hole-to-hole-clearance not given; using "
-              f"{'the board min_hole_to_hole' if _h2h is not None else 'the fallback'} "
-              f"{args.hole_to_hole_clearance}mm.")
-    if args.board_edge_clearance is None:
-        # Planes keep their larger edge keep-out (PLANE_EDGE_CLEARANCE) only when
-        # the board declares no edge rule of its own.
-        _edge = board_constraint(args.input_file, 'min_copper_edge_clearance')
-        args.board_edge_clearance = _edge if _edge is not None else defaults.PLANE_EDGE_CLEARANCE
-        print(f"--board-edge-clearance not given; using "
-              f"{'the board min_copper_edge_clearance' if _edge is not None else 'the fallback'} "
-              f"{args.board_edge_clearance}mm.")
+    # Shared resolver (list_nets.resolve_cli_floor). Planes keep their larger
+    # edge keep-out (PLANE_EDGE_CLEARANCE) only when the board declares no edge
+    # rule of its own -- and a DECLARED 0.0 is exactly that case, KiCad's "not
+    # configured". Read straight it was taken as a rule, dropping the plane
+    # inset from 0.5 to 0.0 while the GUI's plane tab held 0.5 (swig_gui.py
+    # _effective_plane_edge_clearance already had the `> 1e-9` guard).
+    args.hole_to_hole_clearance = resolve_cli_floor(
+        args.input_file, 'hole_to_hole', args.hole_to_hole_clearance,
+        defaults.HOLE_TO_HOLE_CLEARANCE, '--hole-to-hole-clearance')
+    args.board_edge_clearance = resolve_cli_floor(
+        args.input_file, 'board_edge_clearance', args.board_edge_clearance,
+        defaults.PLANE_EDGE_CLEARANCE, '--board-edge-clearance')
     set_default_fab_tier(*fab_tier_from_args(args))
     _pinned_floors = enforce_fab_floors(
         count_copper_layers_in_file(args.input_file),

--- a/py_router/route_planes.py
+++ b/py_router/route_planes.py
@@ -2665,6 +2665,23 @@ def _stitch_plane_area_vias(
     return new_via_dicts
 
 
+#: The pad tally from the last create_plane() in this process.
+#: #487 folded plane RESISTANCE into the machine-readable summary for exactly
+#: this reason and stopped one field short: the summary could report the
+#: plane's ampacity but not whether it reached its pads. `complete: true,
+#: status: "ok", EXIT=0` was the entire machine-readable story of a pour that
+#: left 5 pads open -- the number is held three times inside create_plane, and
+#: main() calls it as a bare statement, so none of it survived.
+_LAST_PAD_TALLY: dict = {}
+
+
+def consume_pad_tally() -> dict:
+    """Take (and clear) the last pour's pad tally."""
+    global _LAST_PAD_TALLY
+    out, _LAST_PAD_TALLY = dict(_LAST_PAD_TALLY), {}
+    return out
+
+
 def create_plane(
     input_file: str,
     output_file: str,
@@ -2791,6 +2808,31 @@ def create_plane(
     # copper in different ORDER, and list position leaks into decisions.
     from kicad_parser import canonicalize_pcb_data_order
     canonicalize_pcb_data_order(pcb_data)
+
+    # --plane-layers takes BARE copper layer names positionally matched to
+    # --nets, but the natural thing to type (and what the routing skill's R1
+    # stage used to instruct) is a net:layer pair. The argument is untyped
+    # `str`, so "GND:B.Cu" was accepted AS A LAYER NAME, travelled through
+    # generate_zone_sexpr, and was written verbatim as (layer "GND:B.Cu").
+    # KiCad then refuses the whole file ("Failed to load board") -- while every
+    # in-repo checker read it happily, because check_connected's copper-layer
+    # census only tested `endswith('.Cu')`. Two full routing laps of run 11
+    # were spent on boards nobody could open.
+    #
+    # Engine-side, not in main(): main() never parses the board so it cannot
+    # validate, and this way the CLI, the GUI planes tab and
+    # route_disconnected_planes all inherit the guard (same reasoning as the
+    # copper-to-edge rule below).
+    _copper = list(getattr(pcb_data.board_info, 'copper_layers', None) or ())
+    if _copper:
+        _bad = [l for l in plane_layers if l not in _copper]
+        if _bad:
+            print(f"Error: {', '.join(sorted(set(_bad)))} is not a copper layer "
+                  f"of this board ({', '.join(_copper)}). --plane-layers takes "
+                  f"BARE layer names positionally matched to --nets "
+                  f"(e.g. --nets GND GNDA --plane-layers B.Cu B.Cu), "
+                  f"not net:layer pairs.")
+            return _empty_plane_results(return_results)
 
     # Route trace (#482): plane creation builds its tap tracks/vias as dicts in
     # all_new_segments/all_new_vias (never touching pcb_data.segments), so record
@@ -3539,6 +3581,8 @@ def create_plane(
         print(f"  Nets processed: {len(net_names)}")
         print(f"  Total new vias placed: {total_vias_placed}")
         print(f"  Total traces added: {total_traces_added}")
+        _LAST_PAD_TALLY['failed_pads'] = int(total_failed_pads)
+        _LAST_PAD_TALLY['pads_needing_vias'] = int(total_pads_needing_vias)
         if total_failed_pads > 0:
             print(f"  Total failed pads: {total_failed_pads}")
 
@@ -3667,6 +3711,7 @@ def create_plane(
             output_file, net_ids, net_names, plane_layers)
         if geo_results:
             geo_failed = sum(info['failed'] for info in geo_results.values())
+            _LAST_PAD_TALLY['geometric_failed'] = int(geo_failed)
             if geo_failed != total_failed_pads:
                 print(f"\n  {geo_failed} pad(s) are not connected to their "
                       f"plane by the pour alone -- EXPECTED (#562): the plane "
@@ -3770,10 +3815,13 @@ Examples:
     parser.add_argument("--nets", "-n", nargs="+", required=True,
                         help="Net name(s) for the plane(s) (e.g., GND VCC)")
     parser.add_argument("--plane-layers", "-p", nargs="+", required=True,
-                        help="Plane layer(s) for the zone(s), one per net (e.g., In1.Cu In2.Cu)")
+                        help="BARE copper layer name(s) for the zone(s), one per net, "
+                             "positionally matched to --nets (e.g., In1.Cu In2.Cu). "
+                             "NOT net:layer pairs -- 'GND:B.Cu' is not a layer name and "
+                             "is refused against the board's own copper layers.")
 
     # Via and track geometry
-    parser.add_argument("--via-size", type=float, default=None, help="Via outer diameter in mm (default: the board Default net-class via, else 0.5)")
+    parser.add_argument("--via-size", type=float, default=None, help="Via outer diameter in mm (default: the board Default net-class via, else 0.5). NOT a hard floor: a tap into a fine-pitch pad field can escalate to the --fab-tier via and print a per-via warning, because a 0.5mm via does not fit a 0.5mm-pitch TQFP. Pass --fab-overrides to forbid the escalation -- at the cost of the taps that then cannot be made")
     parser.add_argument("--via-drill", type=float, default=None, help="Via drill size in mm (default: the board Default net-class via drill, else 0.3)")
     parser.add_argument("--track-width", type=float, default=None, help="Track width for via-to-pad connections in mm (default: the board Default net-class width, else 0.3)")
     parser.add_argument("--clearance", type=float, default=None, help="Copper clearance CEILING in mm. When given, every net class (Default included) is capped at min(class, this) and the writeback clamps. When OMITTED, each net routes at its own net-class clearance (base = the board's Default class, else 0.25).")
@@ -3839,6 +3887,22 @@ Examples:
                         help="Edge-to-edge clearance (mm) between stitching vias and same-net pads. "
                              "-1 (default) allows via-in-pad placement; any value >= 0 forces vias "
                              "outside same-net pads with that clearance.")
+
+    parser.add_argument("--deadline", type=float, default=None, metavar="SECONDS",
+                        help="Wall-clock budget for the PLANE LOOPS. Not a hard cap "
+                             "on total runtime -- the cancel is cooperative and the "
+                             "bounded tail (fills, write, cleanup, DRC writeback) "
+                             "still runs -- so expect to overshoot. What it "
+                             "guarantees is TERMINATION on THIS tool's terms: it "
+                             "stops between regions, writes the copper it has, and "
+                             "prints a JSON_SUMMARY carrying complete=false / "
+                             "status=deadline before exiting 7. Without it an "
+                             "external kill on Windows is TerminateProcess, which "
+                             "leaves NO summary and NO exit code of ours. ANY "
+                             "harness with an external timeout should pass this at "
+                             "~0.8x its own. Default: no budget (a wall-clock "
+                             "default would break replay determinism). "
+                             "Env: KRT_DEADLINE_S")
 
     # Debug options
     parser.add_argument("--dry-run", action="store_true", help="Analyze without writing output")
@@ -4016,7 +4080,27 @@ Examples:
     _out_before = (os.path.getmtime(args.output_file)
                    if args.output_file and os.path.isfile(args.output_file) else None)
 
+    # The deadline is ONE closure into plumbing this engine already has:
+    # `cancel_check` is honoured at every region/pad/route loop head and the
+    # write branch still runs on cancel, so a cancelled run yields a real,
+    # gated, partial pour rather than nothing.
+    #
+    # RESERVE BAND, same correctness reason as route_disconnected_planes': the
+    # bounded tail after the engine (GND return vias, plane copper cleanup, the
+    # DRC-floor writeback) is what makes the partial board readable, and the
+    # KiCad-exact-fill validation inside the engine can itself burn minutes. So
+    # the region loops trip early, leaving clock for the tail.
+    import krt_deadline
+    _rp_report = {'tool': 'route_planes.py', 'board': args.input_file}
+    _dl = krt_deadline.arm(args.deadline, tool='route_planes',
+                           on_partial=lambda: _rp_report)
+    _reserve = max(30.0, (args.deadline or 0) * 0.2) if _dl else 0.0
+
     create_plane(
+        cancel_check=(_dl.cancel_check('plane create', reserve=_reserve)
+                      if _dl else None),
+        progress_callback=(krt_deadline.stdout_progress(deadline=_dl)
+                           if _dl else None),
         input_file=args.input_file,
         output_file=args.output_file,
         ripup_blocker_select=args.ripup_blocker_select,
@@ -4214,10 +4298,44 @@ Examples:
         "min_clearance_used": _cl.effective(args.clearance),
         "plane_nets": sorted(set(args.nets)),
     }
+    # `plane_nets` is a de-duplicated NAME list, and --nets/--plane-layers are
+    # matched POSITIONALLY, so `--nets GND GND --plane-layers In1.Cu In2.Cu`
+    # collapses two poured zones into one entry and the second one vanishes from
+    # the record entirely. Run 14 poured GND on both inner layers and its
+    # summary said `"plane_nets": ["GND"]`. Keep that key as it was -- consumers
+    # read it -- and state the actual zones alongside.
+    try:
+        _layers = list(getattr(args, 'plane_layers', None) or [])
+        _summary["plane_zones"] = [
+            {"net": _n, "layer": (_layers[_i] if _i < len(_layers) else None)}
+            for _i, _n in enumerate(args.nets)]
+    except Exception:                                       # noqa: BLE001
+        pass
     # #487: the plane resistance/ampacity numbers used to live only in stdout
     # ("report-only ... print and discard"). Fold the per-net results the
     # engine noted into the machine-readable summary so chains/graders/skills
     # can gate on them.
+    # The pad tally. Without it `complete: true, status: "ok", EXIT=0` is the
+    # whole machine-readable story of a pour that left pads open -- the text
+    # said "Total failed pads: 5" and the JSON had no channel for it at all.
+    _pt = consume_pad_tally()
+    if _pt:
+        _summary["pads"] = _pt
+        # SAY that this is one tally over every zone. The engine aggregates, so
+        # `failed_pads: 12` on a two-zone pour does not say which zone failed,
+        # and a reader pairing it with a single-entry `plane_nets` would
+        # reasonably assume it was scoped to that one net.
+        _summary["pads_scope"] = ("all zones in this run, summed -- not per "
+                                  "zone; see plane_zones for what was poured")
+        # `geometric_failed` is recorded but does NOT flip the status: under
+        # the pours-first architecture the plane step places no taps, so pads
+        # unreached by the pour alone are EXPECTED here (#562) -- the route
+        # step welds them and its finalize verifies/repairs. Only
+        # `failed_pads` (the engine's own via-placement failures) marks the
+        # pour incomplete.
+        if _pt.get('failed_pads'):
+            _summary["status"] = "incomplete-pads"
+
     try:
         from plane_resistance import consume_resistance_results
         _res = consume_resistance_results()
@@ -4234,10 +4352,45 @@ Examples:
                 for _n, _r in sorted(_res.items())]
     except Exception:
         pass
-    print("JSON_SUMMARY: " + _json.dumps(_summary))
+
+    # Emit through krt_deadline, NOT a raw print. `_emitted` is set only inside
+    # krt_deadline.emit(), so a bare print leaves it False and the atexit flush
+    # then publishes the contentless partial report armed at --deadline time --
+    # a SECOND, contradicting `{"complete": false, "status": "incomplete"}` line
+    # after the real one, which any consumer keying on the LAST JSON_SUMMARY
+    # reads as a failed run. (Measured in route_disconnected_planes, run 11.)
+    # `stopped_in`, not just `expired()`. The reserve band means the region
+    # loops trip at `deadline - reserve`, so a run whose bounded tail then
+    # finishes BEFORE the wall clock runs out is past its cancel and not past
+    # its deadline -- `expired()` alone would report a partial pour as
+    # complete, which is the exact confusion this whole mechanism removes.
+    # `stopped_in` is set by `Deadline.check` at the moment the cancel fires,
+    # so it is the durable record that the loops were cut short.
+    if _dl is not None and (_dl.stopped_in or _dl.expired()):
+        krt_deadline.stamp(_summary)
+        _rp_report.update(_summary)
+        krt_deadline.emit(_summary, complete=False, status='deadline',
+                          deadline=_dl)
+        print(f"{RED}DEADLINE: this run stopped on its own budget after "
+              f"{_dl.elapsed():.0f}s of {_dl.seconds:g}s"
+              + (f" (in {_dl.stopped_in})" if _dl.stopped_in else "")
+              + f". The board at {args.output_file or '(none)'} is a PARTIAL "
+              f"pour -- real copper, fully gated, but the plane work did not "
+              f"finish. Do not read it as clean.{RESET}")
+        return krt_deadline.DEADLINE_EXIT
+    _rp_report.update(_summary)
+    krt_deadline.emit(_summary)
+    return 0
 
 
 if __name__ == "__main__":
     from console_encoding import enable_utf8_console
     enable_utf8_console()  # cp1252-safe non-ASCII prints (issue #152)
-    main()
+    # CMD/EXIT self-echo (run-3 B1); see route.py for why this waited for
+    # --deadline. CLI-`__main__`-only: the GUI imports create_plane.
+    import cli_banner
+    cli_banner.install()
+    # `or 0`: main() has one early `return` (the net/plane-layer count
+    # mismatch) that returns None, and returning None from sys.exit is 0 --
+    # which is what this block did before, so that path is unchanged.
+    sys.exit(main() or 0)

--- a/py_router/route_render.py
+++ b/py_router/route_render.py
@@ -472,16 +472,56 @@ class BoardRenderer:
         return self.frame()
 
     def _label(self, img: Image.Image, text: str) -> None:
+        """Stamp the caption top-left, WRAPPING rather than clipping.
+
+        This measured the text width and then never used it, so PIL clipped at
+        the image edge and the overflow was simply gone. Measured on a 217-part
+        board: the caption built 156 chars and ~117 fit, so `hole-conflict
+        0.60mm` and `oob 7` -- a fab blocker and the off-board count, i.e. two
+        of the four questions the checklist exists to answer -- were absent
+        from the picture while the strip looked complete because it ended at a
+        plausible-looking field. A verdict strip that silently drops its last
+        fields is worse than no strip: it reads as the whole story.
+        """
         d = ImageDraw.Draw(img)
         font = load_font(max(12, self.H // 55))
         pad = 6
+        avail = max(80, self.W - 2 * pad - 6)
+
+        def _w(s):
+            try:
+                bb = d.textbbox((0, 0), s, font=font)
+                return bb[2] - bb[0]
+            except Exception:
+                return 8 * len(s)
+
+        # Break on the caption's own field separator so a wrap never lands
+        # mid-number; fall back to words, then to the raw string.
+        parts = [p.strip() for p in text.split('|')] if '|' in text \
+            else text.split(' ')
+        joiner = '  |  ' if '|' in text else ' '
+        lines, cur = [], ''
+        for p in parts:
+            cand = (cur + joiner + p) if cur else p
+            if cur and _w(cand) > avail:
+                lines.append(cur)
+                cur = p
+            else:
+                cur = cand
+        if cur:
+            lines.append(cur)
+        if not lines:
+            return
         try:
-            bb = d.textbbox((0, 0), text, font=font)
-            tw, th = bb[2] - bb[0], bb[3] - bb[1]
+            lh = (d.textbbox((0, 0), 'Ag', font=font)[3]
+                  - d.textbbox((0, 0), 'Ag', font=font)[1]) + 4
         except Exception:
-            tw, th = 8 * len(text), 12
-        d.rectangle([pad - 3, pad - 3, pad + tw + 3, pad + th + 5], fill=(0, 0, 0))
-        d.text((pad, pad), text, fill=(240, 240, 240), font=font)
+            lh = 16
+        box_w = max(_w(ln) for ln in lines)
+        d.rectangle([pad - 3, pad - 3, pad + box_w + 3,
+                     pad + lh * len(lines) + 5], fill=(0, 0, 0))
+        for i, ln in enumerate(lines):
+            d.text((pad, pad + i * lh), ln, fill=(240, 240, 240), font=font)
 
 
 def render_board_file(board_path: str, out_png: Optional[str] = None,

--- a/py_router/route_summary.py
+++ b/py_router/route_summary.py
@@ -71,6 +71,41 @@ def merge_summaries(summaries: List[Dict], aborted: bool = False) -> Optional[Di
     for key in EFFORT_KEYS:
         merged[key] = sum(s.get(key, 0) for s in summaries)
 
+    # INCOMPLETENESS IS STICKY. `complete: false` marks a run that stopped on
+    # its own deadline, and merging is last-wins for everything not named
+    # above -- so a complete second pass would erase a partial first pass's
+    # disclosure and the merged tally would read as a whole-board result built
+    # partly on numbers nobody finished computing. Same reasoning as `aborted`
+    # just below: what matters is what is definitely on disk. `.get(...,
+    # True)` leaves every pre-deadline log untouched.
+    if any(not s.get('complete', True) for s in summaries):
+        merged['complete'] = False
+        _p = next((s for s in summaries if not s.get('complete', True)), {})
+        for k in ('status', 'stopped_in', 'deadline_s', 'elapsed_s'):
+            if _p.get(k) is not None:
+                merged[k] = _p[k]
+
+    # THE ORACLE'S ANSWER IS STICKY IN THE OTHER DIRECTION. `oracle_check` is
+    # not a last-wins field: the reconciliation sub-run never reaches the
+    # oracle block, so it emits the initialiser `'skipped'`, and last-wins then
+    # threw away a real answer from pass 1. Measured: a log carrying 10+
+    # `ORACLE CHECK:` lines where KiCad contradicted in-process grading merged
+    # to `oracle_check: 'skipped'` -- so the run's verdict rested on the
+    # router's own tally while the summary said the authority had not been
+    # consulted at all.
+    #
+    # Precedence, worst-news-first: a contradiction outranks agreement, which
+    # outranks "could not ask", which outranks "did not ask".
+    _ORACLE_RANK = {'failed': 4, 'ok': 3, 'unavailable': 2, 'disabled': 1}
+
+    def _orank(v):
+        return _ORACLE_RANK.get(str(v).split(' ')[0], 0)
+
+    _oracles = [s.get('oracle_check') for s in summaries
+                if s.get('oracle_check') is not None]
+    if _oracles:
+        merged['oracle_check'] = max(_oracles, key=_orank)
+
     # Rebuild the pad-pair tallies and the blockers key, which last-wins would
     # silently narrow to the reconcile subset (a 50/40 whole-board reading
     # becomes the sub-run's 3/2, or vanishes entirely). Skipped when aborted:

--- a/py_router/routing_config.py
+++ b/py_router/routing_config.py
@@ -157,6 +157,14 @@ class GridRouteConfig:
                                            # Hole-to-Hole Spacing" (keep in sync with
                                            # routing_defaults.HOLE_TO_HOLE_CLEARANCE)
     board_edge_clearance: float = 0.0  # mm - clearance from board edge (0 = use track clearance)
+    # mm - copper-to-HOLE floor (KiCad's `min_hole_clearance`). 0 = not set by
+    # the caller, so the obstacle builder reads the board's own constraint and
+    # falls back to routing_defaults.NPTH_TO_TRACK_CLEARANCE. It is NOT the same
+    # rule as hole_to_hole_clearance (drill-to-drill): this one keeps TRACKS off
+    # an NPTH wall. The router used to hardcode the 0.20 fab floor here while
+    # check_drc already read min_hole_clearance, so on a board declaring 0.25 the
+    # router would happily route into a band its own checker then flagged.
+    hole_clearance: float = 0.0
     # HARD floor the neck-down may not cross (0 = no floor beyond the fab tier's).
     # `track_width` is a REQUEST: when a wide route will not fit, the neck-down
     # retries the whole net at the layer/default width and the run reports success

--- a/tests/gui_parity/test_geometry_floor_leak.py
+++ b/tests/gui_parity/test_geometry_floor_leak.py
@@ -122,6 +122,8 @@ def main():
             bad.append((n, f"leaked: board {board_vals[n]} but resolves {got} "
                            f"after a reset (CLI would use {board_vals[n]})"))
 
+    bad += _declared_zero_is_unset(dlg)
+
     print(f"board: {os.path.basename(board_path)}")
     for n in FLOORS:
         print(f"  {n:26s} board={board_vals[n]:<8} "
@@ -130,6 +132,77 @@ def main():
     for n, why in bad:
         print(f"    {n}: {why}")
     return 1 if bad else 0
+
+
+def _declared_zero_is_unset(dlg):
+    """A board declaring 0 must be UNSET on this side too, as on the CLI.
+
+    `_effective_geometry_floor`'s unchecked branch took the board value on
+    `is not None` alone. KiCad writes 0 into these fields for "not
+    configured", and every other resolver in the tree treats that as unset --
+    list_nets.board_floor, board_floor_knobs, resolve_cli_floor, and
+    `_effective_plane_edge_clearance` ten lines above it, which already
+    guarded `> 1e-9`. This branch did not.
+
+    It is MASKED in the default fab tier: `_fab_floored` pins a 0.0 up to the
+    0.20 fab hole-to-hole floor, and the CLI lands on 0.20 as well, so the two
+    agree by accident. Move the fab floor and they stop agreeing. With a
+    fab-overrides declaring hole_to_hole 0.10 -- reachable from the GUI via the
+    fab_tier / fab_overrides_path controls, and collapsing fab_floor_ladder to
+    that single hard rung -- a board declaring 0.0 gave GUI 0.10 against CLI
+    0.20: the GUI drilling twice as close as the CLI on the same board.
+
+    Driven through the REAL dialog rather than a mirrored config, per the
+    CLAUDE.md note that hand-mirrored parity maps silently drift.
+    """
+    import tempfile
+    from kicad_routing_plugin import swig_gui
+    out = []
+    # Force the "board declares 0.0" case without needing such a board.
+    real = swig_gui._get_board_minimum_constraints
+    swig_gui._get_board_minimum_constraints = lambda *a, **k: {
+        'min_hole_to_hole': 0.0}
+    saved_path = dlg.fab_overrides_path.GetValue()
+    tmp = tempfile.mkdtemp()
+    ovr = os.path.join(tmp, 'fine.fab')
+    with open(ovr, 'w', encoding='utf-8') as f:
+        f.write("# a fab that really can drill closer\n"
+                "hole_to_hole = 0.10\n")
+    try:
+        # 1. Default tier: both sides land on the 0.20 fab floor, which is why
+        #    this divergence is invisible until the fab floor moves.
+        got_default = dlg._effective_geometry_floor('hole_to_hole_clearance')
+        if abs(got_default - 0.20) > 1e-9:
+            out.append(('hole_to_hole_clearance',
+                        f"declared 0.0 at the default tier resolves "
+                        f"{got_default}, expected the 0.20 fab floor"))
+        # 2. The unmasking case, driven through the REAL control a user sets:
+        #    an override FILE lowering the fab hole-to-hole floor to 0.10.
+        #    _fab_floor_for_ctrl reads fab_overrides_path and parses it, so
+        #    set_default_fab_tier alone does NOT reach this path.
+        dlg.fab_overrides_path.SetValue(ovr)
+        floor = dlg._fab_floor_for_ctrl('hole_to_hole_clearance')
+        if floor is None or abs(floor - 0.10) > 1e-9:
+            out.append(('<fixture>',
+                        f"the override file did not lower the fab floor "
+                        f"(got {floor}); this check would prove nothing"))
+        got = dlg._effective_geometry_floor('hole_to_hole_clearance')
+        # The CLI resolves 0.2 here: board_floor calls a declared 0.0 unset and
+        # falls back to HOLE_TO_HOLE_CLEARANCE 0.2, which enforce_fab_floors
+        # only ever raises.
+        if abs(got - 0.20) > 1e-9:
+            out.append(('hole_to_hole_clearance',
+                        f"declared 0.0 under a 0.10 fab override resolves "
+                        f"{got}; the CLI resolves 0.2, so the GUI would drill "
+                        f"{0.2 / got:.1f}x closer on the same board"))
+        print(f"  declared-0.0 hole_to_hole, fab floor {floor} -> GUI {got} "
+              f"(CLI 0.2)")
+    finally:
+        swig_gui._get_board_minimum_constraints = real
+        dlg.fab_overrides_path.SetValue(saved_path)
+        import shutil
+        shutil.rmtree(tmp, ignore_errors=True)
+    return out
 
 
 if __name__ == '__main__':

--- a/tests/run_all.py
+++ b/tests/run_all.py
@@ -76,7 +76,7 @@ def main():
               f'({sum(is_integration(f) for f in tests)} integration).')
         return 0
 
-    passed, failed, skipped = [], [], []
+    passed, failed, skipped, timed_out = [], [], [], []
     t0 = time.time()
     for f in tests:
         name = os.path.basename(f)
@@ -85,11 +85,22 @@ def main():
             print(f'SKIP  {name}  (integration; --fast)')
             continue
         try:
-            r = subprocess.run([sys.executable, f], cwd=ROOT,
-                               capture_output=True, text=True, timeout=args.timeout)
+            # `text=True` alone decodes with the LOCALE default (cp1252 on
+            # Windows) and raises UnicodeDecodeError in the reader thread the
+            # moment any child prints a byte it cannot decode -- a degree sign,
+            # an ohm, a micro. That killed the whole runner mid-suite with a
+            # threading traceback and NO summary, which reads as "the tests
+            # crashed" rather than "the runner cannot read them". Every other
+            # subprocess call in this repo already pins utf-8 + replace.
+            r = subprocess.run([sys.executable, '-X', 'utf8', f], cwd=ROOT,
+                               capture_output=True, text=True,
+                               encoding='utf-8', errors='replace',
+                               timeout=args.timeout)
         except subprocess.TimeoutExpired:
             failed.append(name)
-            print(f'FAIL  {name}  (timeout after {args.timeout:.0f}s)')
+            timed_out.append(name)
+            print(f'TIME  {name}  (timeout after {args.timeout:.0f}s -- NOT a '
+                  f'failed assertion; re-run it alone before treating it as one)')
             continue
         if r.returncode == 0:
             passed.append(name)
@@ -100,10 +111,22 @@ def main():
             print(f'FAIL  {name}  (exit {r.returncode})\n{tail}')
 
     dt = time.time() - t0
-    print(f'\n{len(passed)} passed, {len(failed)} failed, {len(skipped)} skipped '
-          f'in {dt:.1f}s')
-    if failed:
-        print('Failed: ' + ', '.join(failed))
+    # A TIMEOUT AND A FAILED ASSERTION ARE DIFFERENT FACTS, and the summary used
+    # to render them identically -- one `failed` list, one "N failed" count. A
+    # clean baseline run reported "336 passed, 8 failed"; two of those eight
+    # were slow integration tests that PASS when run alone with headroom, and
+    # finding that out took a manual re-run of each. Anyone comparing a run
+    # against a recorded baseline needs the split, because a timeout moving in
+    # or out of the list is a machine-speed fact, not a code fact.
+    _real = [n for n in failed if n not in timed_out]
+    print(f'\n{len(passed)} passed, {len(_real)} failed, '
+          f'{len(timed_out)} timed out, {len(skipped)} skipped in {dt:.1f}s')
+    if _real:
+        print('Failed: ' + ', '.join(_real))
+    if timed_out:
+        print(f'Timed out at {args.timeout:.0f}s: ' + ', '.join(timed_out))
+        print('  A timeout is not evidence of a broken test. Re-run each one '
+              'alone (or raise --timeout) before recording it as a failure.')
     return 1 if failed else 0
 
 

--- a/tests/run_utils.py
+++ b/tests/run_utils.py
@@ -29,3 +29,106 @@ def run(cmd: str, unbuffered: bool = False) -> None:
     result = subprocess.run(args, cwd=ROOT_DIR)
     if result.returncode != 0:
         print(f"Command failed with exit code {result.returncode}")
+
+
+# ---------------------------------------------------------------------------
+# Refusal assertions -- "it failed" is not "it failed for the reason I meant"
+# ---------------------------------------------------------------------------
+#
+# A NEGATIVE CONTROL THAT CANNOT DISTINGUISH ITS OWN BREAKAGE FROM THE DEFECT IT
+# TESTS WILL EVENTUALLY REPORT A FALSE CLEAN. This is the same defect class the
+# tools themselves keep exhibiting -- an instrument that can fail two ways and
+# reports one -- and it is easier to hit in a test, because a test's failure
+# path is the path nobody looks at.
+#
+# Observed, all in one session, every one reporting "the guard held" or "the
+# feature is absent" when neither was true:
+#
+#   * a negative control exited 1 from a ModuleNotFoundError (the copy under
+#     test lived in a temp dir with no sys.path entry) -- read as "the gate
+#     refused";
+#   * a probe called a function name that does not exist and reported the
+#     feature missing;
+#   * evidence passed as `<(echo '{...}')`, whose fd is gone by the time a
+#     Windows child opens it -- read as "the stage never mentions it";
+#   * a section splitter matched the wrong header and reported zero mentions;
+#   * an assertion that `--deadline 0` must always produce a partial, which is
+#     false on a board with no work to abandon.
+#
+# `must_refuse` separates the two outcomes. An ACCIDENT (import error,
+# traceback, argparse usage, missing file) is reported as a BROKEN TEST, never
+# as a satisfied guard.
+
+_ACCIDENTS = (
+    'Traceback (most recent call last)', 'ModuleNotFoundError', 'ImportError',
+    'SyntaxError', 'IndentationError', 'NameError', 'AttributeError',
+    'No such file or directory', 'unrecognized arguments',
+    'error: argument', 'command not found', 'Errno 2',
+)
+
+
+def _accident(out: str):
+    for a in _ACCIDENTS:
+        if a in out:
+            return a
+    return None
+
+
+def check(argv, *, refuse=None, code=None, accept=False, timeout=900,
+          cwd=None, allow=()):
+    """Run `argv`; assert it refused FOR THE STATED REASON, or accepted.
+
+    refuse : substring the refusal must contain -- the reason, not just failure.
+    code   : exact exit code, when the contract names one.
+    accept : assert success instead (exit 0 and no traceback).
+    allow  : accident substrings that are legitimate here (e.g. a test that
+             deliberately feeds a bad argument and wants argparse's message).
+
+    Returns the CompletedProcess. Raises AssertionError with the output on any
+    mismatch -- including a failure that happened for an unrelated reason,
+    which is reported as a broken test rather than a passing assertion.
+    """
+    r = subprocess.run([str(a) for a in argv], capture_output=True, text=True,
+                       encoding='utf-8', errors='replace',
+                       cwd=cwd or ROOT_DIR, timeout=timeout)
+    out = (r.stdout or '') + (r.stderr or '')
+    tail = out[-1200:]
+    acc = _accident(out)
+    if acc and acc not in allow:
+        raise AssertionError(
+            f"BROKEN TEST, not a satisfied guard: the command died from "
+            f"{acc!r}, which is unrelated to what this check asserts. "
+            f"A control that cannot tell its own breakage from the defect it "
+            f"tests reports a false clean.\n  argv: {argv}\n{tail}")
+    if accept:
+        if r.returncode != 0:
+            raise AssertionError(f"expected success, got exit "
+                                 f"{r.returncode}\n  argv: {argv}\n{tail}")
+        return r
+    if r.returncode == 0:
+        raise AssertionError(f"expected a REFUSAL, got exit 0 -- the guard did "
+                             f"not hold\n  argv: {argv}\n{tail}")
+    if code is not None and r.returncode != code:
+        raise AssertionError(f"expected exit {code}, got {r.returncode}\n"
+                             f"  argv: {argv}\n{tail}")
+    if refuse and refuse not in out:
+        raise AssertionError(
+            f"it failed, but NOT for the stated reason. Expected the output to "
+            f"mention {refuse!r}.\n  argv: {argv}\n{tail}")
+    return r
+
+
+def evidence(path, what='evidence'):
+    """Assert a file exists and is non-empty BEFORE it is used as input.
+
+    The `<(echo ...)` process-substitution trap: the fd is gone by the time a
+    native Windows child opens it, so the stage refuses for a reason that has
+    nothing to do with what is being tested, and the test reads that refusal as
+    its answer. Materialise evidence to a real file and check it here.
+    """
+    if not os.path.isfile(path):
+        raise AssertionError(f"{what} does not exist: {path} -- a check whose "
+                             f"INPUT is missing tests nothing")
+    if os.path.getsize(path) == 0:
+        raise AssertionError(f"{what} is empty: {path}")
+    return path

--- a/tests/test_bga_fanout_underpad.py
+++ b/tests/test_bga_fanout_underpad.py
@@ -73,12 +73,93 @@ def main():
     bcu_edge = any(t['layer'] == 'B.Cu' for t in t2)
     checks.append(("bottom-side edge escape uses B.Cu", bcu_edge))
 
+    checks += _q7_drill_floor_reads_the_board()
+
     for name, ok in checks:
         print(f"  [{'PASS' if ok else 'FAIL'}] {name}")
     n_pass = sum(1 for _, ok in checks if ok)
     print(f"\n{n_pass}/{len(checks)} checks passed")
     print("=" * 60)
     return 0 if n_pass == len(checks) else 1
+
+
+def _q7_drill_floor_reads_the_board():
+    """The underpad escape's drill floor was a constant, and the board unread.
+
+    `_via_site_conflict` spaced every drill at the flat
+    routing_defaults.HOLE_TO_HOLE_CLEARANCE, and grepping bga_fanout/underpad.py
+    for board_floor / board_constraint / min_hole_to_hole / resolve_hole_clearance
+    returned NOTHING -- the module never read the board at all. So a board
+    declaring min_hole_to_hole 0.4 got its BGA underpad drills spaced at 0.2:
+    the D9/D11 substitute-a-constant class, in the direction that ignores a
+    board asking for MORE. qfn_fanout is the sibling engine and already reads
+    it; check_join.py:118-122 is the board-first AND raise-only model.
+
+    Measured on ulx3s U1 (plane_drop at its 'auto' DEFAULT -- the rest of this
+    file pins it 'off', and with it off `_via_site_conflict` never governs a
+    site here, so the floor is inert and this gap is invisible):
+
+        declared        before          after
+        (nothing)   224 vias 0.3657   224 vias 0.3657   <- control, identical
+        0.4         224 vias 0.3657   224 vias 0.6000   <- board ignored/obeyed
+        0.10        224 vias 0.3657   224 vias 0.6000 + fab-pin disclosure
+
+    A declared 0.4 costs NO escapes; only the spacing moves.
+    """
+    import io
+    import json
+    import math
+    import shutil
+    import contextlib
+    import tempfile
+    out = []
+    if not os.path.exists(BOARD):
+        return out
+
+    # plane_drop left at its 'auto' default on purpose (see the docstring).
+    params = {k: v for k, v in PARAMS.items() if k != 'plane_drop'}
+
+    def run(h2h):
+        with tempfile.TemporaryDirectory() as tmp:
+            b = os.path.join(tmp, 'u.kicad_pcb')
+            shutil.copyfile(BOARD, b)
+            if h2h is not None:
+                with open(os.path.splitext(b)[0] + '.kicad_pro', 'w',
+                          encoding='utf-8') as f:
+                    json.dump({'board': {'design_settings': {
+                        'rules': {'min_hole_to_hole': h2h}}}}, f)
+            pcb = parse_kicad_pcb(b)
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                _t, vias, _vr, failed = generate_bga_fanout(
+                    pcb.footprints["U1"], pcb, layers=LAYERS, **params)
+            gap = min((math.hypot(a['x'] - c['x'], a['y'] - c['y'])
+                       - (a.get('drill', 0.2) + c.get('drill', 0.2)) / 2
+                       for i, a in enumerate(vias)
+                       for c in vias[i + 1:]), default=None)
+            return len(vias), len(failed), gap, buf.getvalue()
+
+    base_n, _bf, base_gap, base_said = run(None)
+    decl_n, decl_f, decl_gap, decl_said = run(0.4)
+    sub_n, _sf, sub_gap, sub_said = run(0.10)
+
+    # The defect, in one line: the board's own rule was not honoured.
+    out.append(("#Q7 a declared min_hole_to_hole 0.4 spaces the drills",
+                decl_gap is not None and decl_gap >= 0.4 - 1e-9))
+    out.append(("#Q7 ...and it says the board is where that came from",
+                "from the board's own" in decl_said))
+    # It must not buy the spacing by dropping escapes.
+    out.append(("#Q7 ...at no cost in escaped balls",
+                decl_n == base_n and decl_f == 0))
+    # Raise-only: a sub-fab declaration is pinned UP, and disclosed.
+    out.append(("#Q7 a sub-fab 0.10 is pinned to the fab floor, not obeyed",
+                sub_gap is not None and sub_gap >= 0.2 - 1e-9
+                and "below the" in sub_said))
+    # CONTROL: a board declaring nothing must be byte-identical to before.
+    out.append(("#Q7 a board declaring nothing is unchanged",
+                base_gap is not None and abs(base_gap - 0.3657) < 0.01
+                and base_n == 224 and 'ole-to-hole' not in base_said))
+    return out
 
 
 if __name__ == "__main__":

--- a/tests/test_board_floors.py
+++ b/tests/test_board_floors.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+"""Board-declared DRC floors resolve the same way on every consumer.
+
+A declared 0 is UNSET (KiCad writes 0 for "not configured"), an explicit
+value wins, and the fallback is only used when the board declares nothing --
+with the source announced. Pins list_nets.board_floor / resolve_cli_floor,
+the four routing mains' floor reads, and the qfn underpad drill floor wrap.
+
+Run: python3 -X utf8 tests/test_board_floors.py
+"""
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # #522 layout
+sys.path.insert(0, os.path.join(ROOT, 'py_placer'))  # #522 layout
+sys.path.insert(0, os.path.join(ROOT, 'py_tools'))  # #522 layout
+os.environ.setdefault('KRT_NO_BANNER', '1')
+
+import routing_defaults as defaults                            # noqa: E402
+
+FAILURES = []
+
+def check(name, cond, detail=''):
+    print(f'  {"PASS" if cond else "FAIL"}  {name}'
+          + (f'\n        {detail}' if not cond and detail else ''))
+    if not cond:
+        FAILURES.append(name)
+
+
+# --- D9: three more instruments that substituted a constant for the board ----
+#
+# check_channels and check_assembly defaulted --clearance to routing_defaults
+# 0.25 and never read the board; render_placement documented no default at all.
+# Measured on a board whose floor is 0.2 with a 0.254 track: check_channels at
+# its old constants reported 334 escape lanes where the board's own floor gives
+# 399 -- a 65-lane understatement, and an invented deficit on a face that had
+# none. A phantom deficit steers a placement search at the thing that is not
+# wrong.
+
+def _fixture(tmp, clearance=0.1, track=0.15, extra_rules=None):
+    """A board that DECLARES a floor, built to order.
+
+    Most boards in kicad_files/ declare nothing -- but NOT all of them, which
+    is the correction in the module docstring: flat_hierarchy and
+    routed_output ship committed .kicad_pro siblings. Those two are used
+    directly by _q5_committed_projects_are_real; this fixture exists so the
+    resolver's OTHER branches (a value the corpus does not happen to declare,
+    the 0.0 trap, a malformed project) are reachable at all."""
+    import shutil
+    src = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
+    dst = os.path.join(tmp, 'declared.kicad_pcb')
+    shutil.copyfile(src, dst)
+    import json as _json
+    rules = {'min_clearance': 0.0}        # the trap: KiCad writes 0 for "unset"
+    rules.update(extra_rules or {})
+    with open(os.path.splitext(dst)[0] + '.kicad_pro', 'w',
+              encoding='utf-8') as f:
+        _json.dump({'net_settings': {'classes': [
+            {'name': 'Default', 'clearance': clearance, 'track_width': track}]},
+            'board': {'design_settings': {'rules': rules}}}, f)
+    return dst
+
+
+def _d9_shared_resolver():
+    """One helper, so the three instruments cannot each be wrong differently."""
+    import tempfile
+    from list_nets import board_floor
+    with tempfile.TemporaryDirectory() as tmp:
+        b = _fixture(tmp)
+        print('board_floor resolves board-first')
+        check('an explicit value wins and is labelled cli',
+              board_floor(b, 'clearance', 0.42, 0.25) == (0.42, 'cli'))
+        check('unset reads the board netclass',
+              board_floor(b, 'clearance', None, 0.25) == (0.1, 'board netclass'),
+              str(board_floor(b, 'clearance', None, 0.25)))
+        check('track width too',
+              board_floor(b, 'track_width', None, 0.3) == (0.15, 'board netclass'))
+        # THE min_clearance TRAP. The fixture declares min_clearance 0.0, which
+        # KiCad writes for "not configured". Reading it as a real floor would
+        # resolve a board asking for 0.1 down to 0.0 and relax every consumer
+        # to nothing -- so `clearance` must never fall back to that constraint.
+        check('min_clearance 0.0 does NOT override the netclass',
+              board_floor(b, 'clearance', None, 0.25)[0] == 0.1)
+        # A constraint-only floor, which no netclass expresses (D11's case).
+        b2 = _fixture(tmp, extra_rules={'min_hole_clearance': 0.25})
+        check('a hole floor comes from the board constraint',
+              board_floor(b2, 'hole_clearance', None, 0.2)
+              == (0.25, 'board constraint'),
+              str(board_floor(b2, 'hole_clearance', None, 0.2)))
+
+    print('a board declaring nothing still falls back, and says so')
+    nodecl = os.path.join(ROOT, 'kicad_files', 'tigard.kicad_pcb')
+    check('fallback is labelled fixed default',
+          board_floor(nodecl, 'clearance', None, 0.25) == (0.25, 'fixed default'))
+    check('"could not read the project" is not "declares nothing"',
+          board_floor(os.path.join(tmp, 'nope.kicad_pcb'), 'clearance',
+                      None, 0.25, design_rules=_Boom())[1] == 'unreadable project')
+
+    # THE 0.0 TRAP, in the OLDER helper. board_floor guards it; board_floor_knobs
+    # did not, and render_placement is wired to board_floor_knobs -- so a project
+    # declaring `min_copper_edge_clearance: 0.0` (KiCad's "not configured") gave
+    # the placement model a REAL edge floor of zero where it had used 0.55.
+    #
+    # WHAT THAT ACTUALLY COSTS, measured on interf_u_unrouted_placed with a
+    # 0.0-declaring project (NOT the "every edge/halo term collapses" I first
+    # wrote in the commit message -- quench takes max(clearance, edge), so 0.0
+    # degrades to the 0.2 pad clearance rather than to nothing, and `edge` and
+    # `halo` do not move at all):
+    #
+    #     edge  15.516 -> 15.516     halo 303.803 -> 303.803   (unchanged)
+    #     oob_amount  22.039 -> 24.489      oob_area 398.51 -> 445.44
+    #
+    # i.e. it UNDER-REPORTS off-board pad copper by ~11%, which CLAUDE.md names
+    # as the top-priority placement defect ("converts one-for-one into unrouted
+    # and broken"). Under-reporting that is the harm; it is smaller and more
+    # specific than the sweeping claim, and the number is the point.
+    # The two helpers must agree about the one trap this module documents.
+    print('a declared 0.0 is UNSET in both floor helpers, not a floor of zero')
+    from list_nets import board_floor_knobs
+    import tempfile as _tf
+    with _tf.TemporaryDirectory() as z:
+        b = _fixture(z, clearance=0.2,
+                     extra_rules={'min_copper_edge_clearance': 0.0})
+        _clr, _edge, knobs = board_floor_knobs(b)
+        check('board_floor_knobs does not return a 0.0 edge floor',
+              _edge == 0.55 and knobs['board_edge_clearance']['source']
+              == 'fixed default', str(knobs['board_edge_clearance']))
+        check('board_floor agrees',
+              board_floor(b, 'board_edge_clearance', None, 0.55)
+              == (0.55, 'fixed default'))
+
+
+# --- Q3: the ROUTING half read the same two constraints its own way ---------
+#
+# D9 put the `> 0` guard in the placement helpers and stopped there. The four
+# routing mains each kept a private copy of
+# `board_constraint(...) if ... is not None else <default>` -- eight sites, an
+# `is not None` test with no positivity guard -- so one declared floor got two
+# answers depending on which half of the loop asked.
+#
+# On a board declaring `min_copper_edge_clearance: 0.0` (KiCad's "not
+# configured"): placement / floorplan / render resolved 0.55 [fixed default];
+# route.py took a REAL floor of 0.0 while printing "using the board
+# min_copper_edge_clearance 0.0mm" -- announcing a declaration that was not
+# one. The plane engines were worse than misleading: their inset fell from
+# PLANE_EDGE_CLEARANCE 0.5 to 0.0, on the very comment that says they keep 0.5
+# "only when the board declares no edge rule of its own". The GUI's plane tab
+# was already right (swig_gui._effective_plane_edge_clearance guards `> 1e-9`),
+# so this was a CLI-only divergence from the GUI as well.
+
+_CLI_FLOOR_SITES = ('py_router/route.py', 'py_router/route_diff.py',
+                    'py_router/route_planes.py', 'py_router/repair_planes.py')
+_RAW_KEYS = ('min_hole_to_hole', 'min_copper_edge_clearance')
+
+
+def _q3_routing_half_uses_the_same_resolver():
+    import io
+    import contextlib
+    import tempfile
+    from list_nets import (board_floor, board_floor_knobs, resolve_cli_floor)
+
+    print('one declared floor, one number, on both halves of the loop')
+    with tempfile.TemporaryDirectory() as tmp:
+        # A board that DECLARES a positive edge rule. Both halves must land on
+        # it -- this is the "one number" claim in its testable form.
+        decl = _fixture(tmp, extra_rules={'min_copper_edge_clearance': 0.3,
+                                          'min_hole_to_hole': 0.3})
+        _c, edge_place, knobs = board_floor_knobs(decl)
+        with contextlib.redirect_stdout(io.StringIO()):
+            edge_sig = resolve_cli_floor(decl, 'board_edge_clearance', None,
+                                         defaults.BOARD_EDGE_CLEARANCE, '--x')
+            edge_pln = resolve_cli_floor(decl, 'board_edge_clearance', None,
+                                         defaults.PLANE_EDGE_CLEARANCE, '--x')
+        check('a DECLARED 0.3 edge rule is 0.3 on the placement half',
+              edge_place == 0.3
+              and knobs['board_edge_clearance']['source'] == 'board constraint',
+              str(knobs['board_edge_clearance']))
+        check('...and 0.3 on the routing half, signal and plane alike',
+              edge_sig == 0.3 and edge_pln == 0.3,
+              f'signal {edge_sig}, plane {edge_pln}')
+
+    print('a DECLARED 0.0 is UNSET on the routing half too')
+    with tempfile.TemporaryDirectory() as tmp:
+        z = _fixture(tmp, extra_rules={'min_copper_edge_clearance': 0.0,
+                                       'min_hole_to_hole': 0.0})
+        _c, edge_place, knobs = board_floor_knobs(z)
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            edge_sig = resolve_cli_floor(z, 'board_edge_clearance', None,
+                                         defaults.BOARD_EDGE_CLEARANCE, '--x')
+            edge_pln = resolve_cli_floor(z, 'board_edge_clearance', None,
+                                         defaults.PLANE_EDGE_CLEARANCE, '--x')
+            h2h = resolve_cli_floor(z, 'hole_to_hole', None,
+                                    defaults.HOLE_TO_HOLE_CLEARANCE, '--y')
+        said = buf.getvalue()
+
+        # BOTH halves must reach the same VERDICT about the board: it declared
+        # nothing. The fallbacks then legitimately differ -- BOARD_EDGE_CLEARANCE
+        # 0.0 is a deliberate "no edge rule, use the copper-copper clearance"
+        # sentinel (route.py:896, obstacle_map.py:797), the plane engines want
+        # 0.5, the placement model 0.55 -- and are NOT unified here.
+        check('placement half: declared 0.0 reads as fixed default',
+              edge_place == 0.55
+              and knobs['board_edge_clearance']['source'] == 'fixed default',
+              str(knobs['board_edge_clearance']))
+        check('routing half agrees the board declared nothing',
+              board_floor(z, 'board_edge_clearance', None, 0.0)[1]
+              == 'fixed default'
+              and board_floor(z, 'hole_to_hole', None, 0.2)[1]
+              == 'fixed default')
+        # The value fixes, each measured against what the old raw read gave.
+        check('plane inset stays PLANE_EDGE_CLEARANCE (was 0.0)',
+              edge_pln == defaults.PLANE_EDGE_CLEARANCE, f'got {edge_pln}')
+        check('hole-to-hole stays the packaged floor (was 0.0)',
+              h2h == defaults.HOLE_TO_HOLE_CLEARANCE, f'got {h2h}')
+        check('the signal sentinel is unchanged at 0.0',
+              edge_sig == defaults.BOARD_EDGE_CLEARANCE, f'got {edge_sig}')
+        # And it must stop claiming the board said so.
+        check('the print no longer attributes 0.0 to the board',
+              'min_copper_edge_clearance' not in said
+              and 'min_hole_to_hole' not in said, said.strip())
+        check('the print names its source in the placement vocabulary',
+              said.count('[fixed default]') == 3, said.strip())
+
+    # THE WIRING. Every check above passes with all eight call sites reverted
+    # to the raw read -- the exact hole D10 was pulled up for. So assert the
+    # mains actually route through the resolver, and that the raw read is gone.
+    print('all four routing mains go through the one resolver')
+    import ast
+    for fn in _CLI_FLOOR_SITES:
+        src = open(os.path.join(ROOT, fn), encoding='utf-8').read()
+        tree = ast.parse(src)
+        floors = set()
+        raw = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not node.args:
+                continue
+            fname = getattr(node.func, 'id', None) or getattr(
+                node.func, 'attr', None)
+            first_str = [a.value for a in node.args
+                         if isinstance(a, ast.Constant)
+                         and isinstance(a.value, str)]
+            if fname == 'resolve_cli_floor':
+                floors.update(first_str)
+            elif fname == 'board_constraint':
+                raw += [s for s in first_str if s in _RAW_KEYS]
+        check(f'{fn}: both floors via resolve_cli_floor',
+              {'hole_to_hole', 'board_edge_clearance'} <= floors,
+              f'found {sorted(floors)}')
+        check(f'{fn}: no raw board_constraint read of either key',
+              not raw, f'raw reads: {raw}')
+
+    # ...and the mains ACTUALLY PRINT it, which the AST check cannot show. Each
+    # runs in ~1.3s on a net that matches nothing, so this is the CLI's own
+    # answer rather than a model of it. At 62f7c13^ these lines read "using the
+    # board min_copper_edge_clearance 0.0mm" and the plane engines resolved 0.0.
+    print('...and each main prints the resolved floor, crediting the right source')
+    import subprocess
+    import tempfile
+    # (flag-shape, edge-floor-expected) per main; hole-to-hole is 0.2 for all.
+    mains = [
+        ('py_router/route.py', lambda i, o: [i, o, '--nets', '__none__'], 0.0),
+        ('py_router/route_diff.py', lambda i, o: [i, '--output', o, '--nets', '__none__'], 0.0),
+        ('py_router/route_planes.py', lambda i, o: [i, '--output', o, '--nets', '__none__',
+                                          '--plane-layers', 'B.Cu'], 0.5),
+        ('py_router/repair_planes.py',
+         lambda i, o: [i, '--output', o, '--nets', '__none__',
+                       '--plane-layers', 'B.Cu'], 0.5),
+    ]
+    with tempfile.TemporaryDirectory() as tmp:
+        z = _fixture(tmp, extra_rules={'min_copper_edge_clearance': 0.0,
+                                       'min_hole_to_hole': 0.0})
+        for fn, argv, edge in mains:
+            out = os.path.join(tmp, 'o_' + fn.replace('.py', '') + '.kicad_pcb')
+            r = subprocess.run([sys.executable, '-X', 'utf8', fn] + argv(z, out),
+                               cwd=ROOT, capture_output=True, text=True,
+                               timeout=300)
+            lines = [ln.strip() for ln in (r.stdout or '').splitlines()
+                     if ln.startswith('--hole-to-hole-clearance not given')
+                     or ln.startswith('--board-edge-clearance not given')]
+            said = ' '.join(lines)
+            check(f'{fn}: prints both resolved floors',
+                  len(lines) == 2, said or (r.stderr or '')[-300:])
+            check(f'{fn}: hole-to-hole 0.2 [fixed default], not a declared 0.0',
+                  f'--hole-to-hole-clearance not given; using 0.2mm '
+                  f'[fixed default].' in said, said)
+            check(f'{fn}: board edge {edge} [fixed default]',
+                  f'--board-edge-clearance not given; using {edge}mm '
+                  f'[fixed default].' in said, said)
+            check(f'{fn}: does not credit the board for what it left unset',
+                  'min_copper_edge_clearance' not in said
+                  and 'min_hole_to_hole' not in said, said)
+
+
+# --- Q4: board_floor is NOT raise-only, and a drill consumer must wrap it ---
+#
+# board_floor returns the declared value whenever it is positive, with no
+# max() against the fallback. For most of its table that is exactly right --
+# check_channels / check_assembly must grade at the board's own clearance even
+# when it is BELOW their default. For a DRILL floor it is a fab hazard, and the
+# qfn underpad escape claimed "Raise-only in practice" while doing no such
+# thing: a project declaring `min_hole_to_hole: 0.10` spaced that run's drills
+# at 0.10, under the 0.20 JLC floor. `resolve_hole_clearance` is raise-only
+# only because ITS consumers wrap it; this is the same wrap, and the same
+# demonstration.
+
+def _qfn_fixture(tmp, h2h):
+    """tigard (a real QFN board) with a project declaring min_hole_to_hole."""
+    import shutil
+    import json as _json
+    src = os.path.join(ROOT, 'kicad_files', 'tigard.kicad_pcb')
+    if not os.path.exists(src):
+        return None
+    dst = os.path.join(tmp, 'h2h.kicad_pcb')
+    shutil.copyfile(src, dst)
+    with open(os.path.splitext(dst)[0] + '.kicad_pro', 'w',
+              encoding='utf-8') as f:
+        _json.dump({'net_settings': {'classes': [
+            {'name': 'Default', 'clearance': 0.2, 'track_width': 0.25}]},
+            'board': {'design_settings': {'rules': {'min_hole_to_hole': h2h}}}},
+            f)
+    return dst
+
+
+def _qfn_effective_h2h(board):
+    """The hole_to_hole the underpad escape actually routes with.
+
+    Read off what the engine FEEDS run_output_conflict, which is where
+    f1dd280 said the value goes -- not re-derived, or the test would only be
+    checking arithmetic it wrote itself.
+    """
+    import io
+    import contextlib
+    from kicad_parser import parse_kicad_pcb
+    import qfn_fanout as Q
+
+    seen = []
+    real = Q.run_output_conflict
+
+    def spy(*a, **kw):
+        seen.append(kw.get('hole_to_hole'))
+        return real(*a, **kw)
+
+    Q.run_output_conflict = spy
+    try:
+        pcb = parse_kicad_pcb(board)
+        with contextlib.redirect_stdout(io.StringIO()) as buf:
+            Q.generate_qfn_fanout(
+                pcb.footprints["U3"], pcb, net_filter=["/USB_DP", "/USB_DN"],
+                layer="F.Cu", track_width=0.1, clearance=0.1, grid_step=0.05,
+                escape_method="underpad", via_size=0.45, via_drill=0.25)
+    finally:
+        Q.run_output_conflict = real
+    return (set(v for v in seen if v is not None), buf.getvalue())
+
+
+def _q4_a_declared_value_must_not_relax_a_fab_floor():
+    import tempfile
+    from list_nets import board_floor
+    from fab_tiers import fab_floor_min
+
+    print('board_floor is board-authoritative, NOT raise-only')
+    with tempfile.TemporaryDirectory() as tmp:
+        b = _fixture(tmp, extra_rules={'min_hole_to_hole': 0.10})
+        # The CLAIM, corrected: this is the documented behaviour, not a bug to
+        # fix in the helper -- check_channels needs exactly this freedom.
+        check('a declared 0.10 resolves DOWN, and says it came from the board',
+              board_floor(b, 'hole_to_hole', None, 0.2)
+              == (0.1, 'board constraint'),
+              str(board_floor(b, 'hole_to_hole', None, 0.2)))
+
+    fab = fab_floor_min(4).get('hole_to_hole')
+    check('the fab hole-to-hole floor is the thing being protected',
+          fab == 0.20, f'got {fab}')
+
+    print('...so the qfn DRILL consumer wraps it, and discloses the pin')
+    with tempfile.TemporaryDirectory() as tmp:
+        b = _qfn_fixture(tmp, 0.10)
+        if b is None:
+            print('  SKIP  no tigard board (qfn drill floor)')
+            return
+        got, said = _qfn_effective_h2h(b)
+        check('a declared 0.10 does NOT space this run\'s drills at 0.10',
+              got == {0.20}, f'engine used {sorted(got)}')
+        check('...and it is not relaxed SILENTLY',
+              'below the 0.2mm fab hole-to-hole floor' in said, said.strip())
+
+    print('...while a declared value ABOVE the floor still wins')
+    with tempfile.TemporaryDirectory() as tmp:
+        b = _qfn_fixture(tmp, 0.30)
+        got, said = _qfn_effective_h2h(b)
+        check('a declared 0.30 raises the drill spacing to 0.30',
+              got == {0.30}, f'engine used {sorted(got)}')
+        check('...and says the board is where it came from',
+              "from the board's own" in said, said.strip())
+
+    print('...and a board declaring nothing is byte-identical')
+    with tempfile.TemporaryDirectory() as tmp:
+        import shutil
+        src = os.path.join(ROOT, 'kicad_files', 'tigard.kicad_pcb')
+        dst = os.path.join(tmp, 'silent.kicad_pcb')
+        shutil.copyfile(src, dst)          # no .kicad_pro sibling at all
+        got, said = _qfn_effective_h2h(dst)
+        check('the packaged default stands, unannounced',
+              got == {defaults.HOLE_TO_HOLE_CLEARANCE}
+              and 'hole-to-hole' not in said.lower(), f'{sorted(got)}')
+
+
+class _Boom(dict):
+    """A design_rules stand-in that raises when read, to exercise the
+    'I could not look' branch without corrupting a real project file."""
+    def get(self, *a, **k):
+        raise OSError('unreadable')
+
+
+
+def main():
+    _d9_shared_resolver()
+    _q3_routing_half_uses_the_same_resolver()
+    _q4_a_declared_value_must_not_relax_a_fab_floor()
+    print()
+    if FAILURES:
+        print(f'FAIL: {len(FAILURES)} check(s): {", ".join(FAILURES)}')
+        return 1
+    print('OK')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_check_join.py
+++ b/tests/test_check_join.py
@@ -146,7 +146,9 @@ def test_usage_errors_exit_2():
         r = _run([b, 'N1', '104,116,In1.Cu', '107,116,In1.Cu'])
         assert r.returncode == 2 and 'not a copper layer' in r.stderr
         r = _run([b, 'N1', 'garbage'])
-        assert r.returncode == 2
+        # Not a bare `== 2`: argparse, an ImportError and a parse crash all
+        # exit 2, so the code alone cannot say the guard held.
+        assert r.returncode == 2 and 'Traceback' not in r.stderr, r.stderr[-400:]
     print("  PASS: unknown net / bad layer / bad token all exit 2")
 
 

--- a/tests/test_krt_capabilities.py
+++ b/tests/test_krt_capabilities.py
@@ -22,7 +22,8 @@ import sys
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, ROOT)
 
-from krt_capabilities import capabilities, missing, script_flags  # noqa: E402
+from krt_capabilities import (capabilities, missing, script_flags,  # noqa: E402
+                              _tool_path)
 
 
 def _run(args, cwd=ROOT):
@@ -42,8 +43,8 @@ def test_the_inventory_is_json_and_complete():
 
 def test_flags_are_read_without_importing():
     """Asking 'can you do X' must not be able to trigger a side effect."""
-    flags = script_flags(os.path.join(ROOT, 'route.py'))
-    for f in ('--track-width-floor', '--json-out', '--nets', '--rip-existing-nets'):
+    flags = script_flags(_tool_path(ROOT, 'route.py'))
+    for f in ('--track-width', '--json-out', '--nets', '--rip-existing-nets'):
         assert f in flags, f"{f} not discovered in route.py"
     assert script_flags(os.path.join(ROOT, 'no_such_file.py')) == []
     print("  PASS: flags read from source, missing file is empty not fatal")
@@ -51,8 +52,8 @@ def test_flags_are_read_without_importing():
 
 def test_require_passes_on_what_this_clone_has():
     r = _run([os.path.join(ROOT, 'krt_capabilities.py'), '--require',
-              'route.py:--track-width-floor', 'route.py:--json-out',
-              'route_disconnected_planes.py:--net-layers',
+              'route.py:--track-width', 'route.py:--json-out',
+              'repair_planes.py:--plane-layers',
               'place_route_loop.py:--accept-cmd', 'check_floorplan.py'])
     assert r.returncode == 0, r.stderr
     print("  PASS: --require exits 0 when every token is satisfied")
@@ -84,7 +85,7 @@ def test_route_py_answers_without_a_board():
     """`route.py --capabilities` must work with no positional argument: the
     question is asked before there is any trust in the clone, so requiring a
     board to ask it defeats the purpose."""
-    r = _run([os.path.join(ROOT, 'route.py'), '--capabilities'])
+    r = _run([_tool_path(ROOT, 'route.py'), '--capabilities'])
     assert r.returncode == 0, r.stderr[-800:]
     caps = json.loads(r.stdout)
     assert caps['modules']['route.py'] is True
@@ -134,7 +135,7 @@ def test_a_script_does_NOT_inherit_another_CLIs_flags():
     # These four are argparse errors on the real CLI -- verified by --help.
     for token in ('route_planes.py:--net-clearances',
                   'route_planes.py:--track-width-floor',
-                  'route_disconnected_planes.py:--net-clearances',
+                  'repair_planes.py:--net-clearances',
                   'route_diff.py:--track-width-floor'):
         assert k.missing(caps, [token]), \
             f'{token} does not exist on that CLI and must be reported missing'
@@ -143,8 +144,8 @@ def test_a_script_does_NOT_inherit_another_CLIs_flags():
     # from the fab_tiers registrar (0 ArgumentParser, 2 add_argument), which is
     # exactly the hop that must survive.
     for token in ('route_planes.py:--fab-overrides',
-                  'route_disconnected_planes.py:--net-layers',
-                  'route_disconnected_planes.py:--track-width-floor',
+                  'repair_planes.py:--plane-layers',
+                  'repair_planes.py:--fab-overrides',
                   'route.py:--net-clearances',
                   'route_diff.py:--net-clearances',
                   'qfn_fanout.py:--escape-method'):

--- a/tests/test_npth_seed_floor.py
+++ b/tests/test_npth_seed_floor.py
@@ -79,12 +79,111 @@ def run():
     check('clear reported point kept',
           any(round(p[0], 2) == 2.0 for p in pts))
 
+    _d11_obstacle_map_reads_the_board(check)
+
     print()
     if fails:
         print(f'{len(fails)} FAILURE(S): {fails}')
         return 1
     print('all checks passed')
     return 0
+
+
+# --- D11: the ROUTER's NPTH keep-out must read min_hole_clearance too --------
+#
+# obstacle_map priced NPTH holes at a hardcoded
+# max(config.clearance, NPTH_TO_TRACK_CLEARANCE) -- a flat 0.20 fab floor that
+# never read the board -- while check_drc DOES read min_hole_clearance
+# (check_drc.py:2390). So on a board declaring 0.25 the router routed into a
+# band its own checker then flagged. Measured: a route came within 0.2263 mm of
+# BUS1's NPTH against a declared 0.25 -- a real 0.0237 mm violation,
+# routing-introduced, confirmed independently by kicad-cli, and the single DRC
+# failure on that board.
+
+def _declaring_board(tmp, **rules):
+    """A board file whose sibling project declares board constraints."""
+    import json
+    p = os.path.join(tmp, 'b.kicad_pcb')
+    with open(p, 'w', encoding='utf-8') as f:
+        f.write('(kicad_pcb (version 20240108))\n')
+    with open(os.path.join(tmp, 'b.kicad_pro'), 'w', encoding='utf-8') as f:
+        json.dump({'board': {'design_settings': {'rules': rules}}}, f)
+    return p
+
+
+def _d11_obstacle_map_reads_the_board(check):
+    import tempfile
+    import obstacle_map
+    from routing_config import GridRouteConfig
+
+    print()
+    print('D11: the NPTH track keep-out reads the board, not a constant')
+
+    with tempfile.TemporaryDirectory() as tmp:
+        quiet_dir = os.path.join(tmp, 'silent')
+        os.makedirs(quiet_dir, exist_ok=True)
+        declares = _declaring_board(tmp, min_hole_clearance=0.25)
+        silent = _declaring_board(quiet_dir)          # declares no constraints
+
+        cfg = GridRouteConfig()
+        cfg.clearance = 0.15
+        obstacle_map._HOLE_CLR_CACHE.clear()
+
+        pcb = SimpleNamespace(source_path=declares)
+        check('a board declaring 0.25 resolves to 0.25',
+              obstacle_map.resolve_hole_clearance(pcb, cfg) == 0.25)
+
+        quiet = SimpleNamespace(source_path=silent)
+        check('a board declaring nothing resolves to 0.0 (fab floor applies)',
+              obstacle_map.resolve_hole_clearance(quiet, cfg) == 0.0)
+
+        check('an in-memory board with no source_path resolves to 0.0',
+              obstacle_map.resolve_hole_clearance(
+                  SimpleNamespace(source_path=''), cfg) == 0.0)
+
+        cfg_x = GridRouteConfig()
+        cfg_x.clearance = 0.15
+        cfg_x.hole_clearance = 0.4
+        check('an explicit config value wins over the board',
+              obstacle_map.resolve_hole_clearance(pcb, cfg_x) == 0.4)
+
+        # THE POINT: the clearance actually handed to the keep-out stamper.
+        # 0.20 (fab) and 0.15 (routing) are both below the declared 0.25, so
+        # the old expression yielded 0.20 -- 0.05mm too close, which is how a
+        # 0.2263mm approach to a 0.25 hole got built.
+        captured = []
+        real = obstacle_map.block_track_cells_near_drills
+        real_via = obstacle_map.block_via_cells_near_drills
+        obstacle_map.block_track_cells_near_drills = (
+            lambda o, holes, tw, clr, step, layers: captured.append(clr))
+        obstacle_map.block_via_cells_near_drills = (
+            lambda *a, **k: None)
+        try:
+            for board, label, want in ((declares, 'declared 0.25', 0.25),
+                                       (silent, 'nothing declared', 0.20)):
+                captured.clear()
+                obstacle_map.add_drill_hole_obstacles(
+                    _FakeObstacles(), _npth_board(board), cfg, set())
+                check(f'NPTH keep-out priced at {want} when {label}',
+                      captured and abs(captured[0] - want) < 1e-9,
+                      )
+                if captured:
+                    print(f'        priced at {captured[0]:.4g}mm')
+        finally:
+            obstacle_map.block_track_cells_near_drills = real
+            obstacle_map.block_via_cells_near_drills = real_via
+
+
+class _FakeObstacles:
+    """add_drill_hole_obstacles only passes this through to the stampers."""
+
+
+def _npth_board(path):
+    pad = _npth(10.0, 10.0, 2.0)
+    pad.pad_number, pad.component_ref = 'H1', 'BUS1'
+    pad.local_clearance = 0.0
+    return SimpleNamespace(pads_by_net={0: [pad]}, vias=[], segments=[],
+                           zones=[], source_path=path)
 
 
 if __name__ == '__main__':

--- a/tests/test_qfn_underpad.py
+++ b/tests/test_qfn_underpad.py
@@ -58,12 +58,348 @@ def main():
             if d < VIA_SIZE + CLEARANCE - 1e-6:
                 fails.append(f"vias too close: {d:.3f} < {VIA_SIZE + CLEARANCE}")
 
+    fails += _d10_self_blindness()
+
     if fails:
         print("FAIL: " + "; ".join(fails))
         return 1
     print(f"PASS: pair escaped as {len(vias)} staggered through-vias, "
           f"min different-net spacing OK")
     return 0
+
+
+# --- D10: the candidate test must see the run's OWN emitted copper ----------
+#
+# `via_clears` tested a candidate against the board it was handed -- a snapshot
+# taken before anything was placed -- and against the via CENTRES emitted so
+# far. It never saw the STUBS the same run emitted, so it approved vias sitting
+# on copper it had just laid, and those escapes came back DRC CONTACTS.
+#
+# Measured: U2 (QFN56) reported 39 of 46 escapes under `--escape-method underpad
+# --allow-via-in-pad` and the gate rejected every one as a contact -- while a
+# hostile verifier established the geometry was fine (1.4mm moat admitting a
+# 0.7mm via at all 56 pads, pad_via == 0, a real 0.700mm via placeable DRC-clean
+# in U2.43, true capacity 11 of 14 lanes per side).
+
+KN = dict(via_size=0.7, via_drill=0.4, clearance=0.2, track_width=0.15,
+          hole_to_hole=0.2)
+
+
+def _d10_self_blindness():
+    from qfn_fanout import run_output_conflict as conflict
+    bad = []
+
+    def check(name, cond):
+        print(("PASS: " if cond else "FAIL: ") + name)
+        if not cond:
+            bad.append(name)
+
+    # Net 1: pad at (0,0), via at (0,2) -- so a 2mm stub runs up x=0.
+    stub = [(0.0, 2.0, 1, 0.0, 0.0)]
+
+    # A net-2 via at (0,1) sits ON that stub, yet is 1.0mm from the via centre
+    # -- comfortably past the 0.9mm different-net via floor (0.7+0.2). So the
+    # via-to-via test PASSES it, and ONLY the stub test can reject it. This is
+    # exactly the shape that shipped contacts.
+    check('a via sitting on this run\'s own stub is rejected',
+          conflict(0.0, 1.0, 2, stub, **KN))
+    # ...and it is ONLY the stub that rejects it: with the stub removed from
+    # the entry (a bare via centre, the old 3-tuple shape) the same candidate
+    # is accepted. Asserting the arithmetic instead would test literals.
+    check('...the SAME candidate passes when that stub is not recorded',
+          not conflict(0.0, 1.0, 2, [(0.0, 2.0, 1)], **KN))
+
+    # Same net: its own stub is not an obstacle.
+    check('a SAME-net via on the same stub is allowed',
+          not conflict(0.0, 1.0, 1, stub, **KN))
+
+    # Clear of everything.
+    check('a via clear of both the stub and the via is allowed',
+          not conflict(3.0, 1.0, 2, stub, **KN))
+
+    # The candidate's OWN stub must be tested too -- here the via lands clear
+    # but its stub from (0.6,1.0) sweeps across the placed via at (0,2)... use
+    # a pad whose stub passes the foreign via.
+    check('a candidate whose own STUB crosses a placed via is rejected',
+          conflict(-2.0, 2.0, 2, stub, px=2.0, py=2.0, **KN))
+
+    # Stub-vs-stub, ISOLATED. A parallel-stubs case would be tautological: two
+    # stubs close enough to graze also put their vias inside the 0.9mm
+    # different-net via floor, so the via-to-via test alone would reject it and
+    # the assertion would pass with the stub logic deleted. Cross them instead,
+    # with a long placed stub, so every other pair is far above its floor:
+    #   cand via <-> placed via  2.50mm (floor 0.90)
+    #   cand via <-> placed stub 2.00mm (floor 0.625)
+    #   placed via <-> cand stub 1.50mm (floor 0.625)
+    # Only the stub-vs-stub distance (0) can fire.
+    long_stub = [(0.0, 3.0, 1, 0.0, 0.0)]
+    check('a candidate whose STUB crosses an emitted stub is rejected',
+          conflict(2.0, 1.5, 2, long_stub, px=-2.0, py=1.5, **KN))
+    check('...and the same crossing on its OWN net is allowed',
+          not conflict(2.0, 1.5, 1, long_stub, px=-2.0, py=1.5, **KN))
+
+    # A via-in-pad entry has a zero-length stub and must not be read as one.
+    inpad = [(5.0, 5.0, 1, 5.0, 5.0)]
+    check('a zero-length (via-in-pad) stub is not treated as copper',
+          not conflict(5.0, 6.0, 2, inpad, **KN))
+
+    bad += _d10_wiring()
+    bad += _q2_reuse_adds_no_via()
+    return bad
+
+
+# --- Q2: a REUSE adds no drill and no via copper, only the stub -------------
+#
+# The D10 follow-up wired the reuse branch into run_output_conflict -- correctly,
+# because that branch was blind to this run's own output -- but priced the
+# REUSED via as a NEW one. The reuse target is an existing board via; on
+# routed_output.kicad_pcb those are 0.30, and the partners they were judged
+# against are also pre-existing 0.30 vias sitting at 0.400mm: legal
+# (0.15 + 0.15 + 0.10) and already on the board. Priced at config via_size 0.45
+# the test demanded 0.55 and rejected all 7 reuse candidates -- judging two vias
+# that already exist, at a size neither has, for a spacing this run does not
+# create.
+#
+# Measured on kicad_files/routed_output.kicad_pcb, U2, B.Cu, track/clearance
+# 0.1, via 0.45/0.25, --escape-method underpad --allow-via-in-pad:
+#
+#     715c821 (before D10 follow-up)  28 vias / 12 dropped / 30 tracks
+#     f1dd280 (the follow-up)         29 vias / 13 dropped / 31 tracks
+#
+# Net-(U2A-DATA_30) lost its escape and a fresh drill appeared where a reuse
+# would have served -- which is what #479 audit gap 2's reuse path exists to
+# prevent.
+
+# The numbers off that board, so the geometry under test is the measured one.
+REUSE_KN = dict(via_size=0.45, via_drill=0.25, clearance=0.1, track_width=0.1,
+                hole_to_hole=0.2)
+U2_BOARD = os.path.join(ROOT, "kicad_files", "routed_output.kicad_pcb")
+
+
+def _q2_reuse_adds_no_via():
+    from qfn_fanout import run_output_conflict as conflict
+    bad = []
+
+    def check(name, cond, detail=""):
+        print(("PASS: " if cond else "FAIL: ") + name + (f"  [{detail}]"
+                                                         if detail else ""))
+        if not cond:
+            bad.append(name)
+
+    # The BOARD first, deliberately: the checks below pass `adds_via`, which
+    # does not exist before the fix, so on the unfixed engine they raise rather
+    # than measure. Running the counts first makes the pre-fix failure a
+    # measured 29/13/31 instead of a TypeError.
+    bad += _q2_reuse_end_to_end()
+
+    # The exact rejection the verifier isolated, in board coordinates. A
+    # pre-existing 0.30 via on another net at (213.5625, 105.7) fed by a stub
+    # from its pad at (213.5625, 105.5); the reuse candidate is a pre-existing
+    # 0.30 via at (213.5625, 106.1), bridged from the pad at (213.5625, 106.3).
+    placed = [(213.5625, 105.7, 80, 213.5625, 105.5)]
+    cand = (213.5625, 106.1, 107)
+    pad = dict(px=213.5625, py=106.3)
+    gap = 106.1 - 105.7
+
+    check('the measured spacing is the legal one for two 0.30 vias',
+          abs(gap - 0.400) < 1e-9 and 0.400 >= 0.15 + 0.15 + 0.10 - 1e-9,
+          f"gap {gap:.4f}, true floor 0.40, demanded "
+          f"{REUSE_KN['via_size'] + REUSE_KN['clearance']:.2f}")
+    # Pricing it as a NEW via is what rejected it: this is the f1dd280 call.
+    check('priced as a NEW via, the legal reuse is rejected (the regression)',
+          conflict(*cand, placed, **pad, **REUSE_KN))
+    # ...and suppressing the via terms -- which is what "adds no via" means --
+    # accepts it. Only `adds_via` differs between these two lines, so nothing
+    # else can be what changed the verdict.
+    check('a reuse adds no drill and no via copper, so it is accepted',
+          not conflict(*cand, placed, **pad, adds_via=False, **REUSE_KN))
+
+    # The stub is still tested, or the branch would be blind again -- which is
+    # the D10 gap this must not reopen. A reuse whose BRIDGING STUB crosses
+    # another net's stub is rejected even with adds_via=False.
+    crossing = [(0.0, 3.0, 1, 0.0, 0.0)]        # placed stub up x=0, y 0..3
+    check('a reuse whose stub crosses an emitted stub is still rejected',
+          conflict(2.0, 1.5, 2, crossing, px=-2.0, py=1.5, adds_via=False,
+                   **REUSE_KN))
+    # ...and its stub against a placed VIA, the other direction.
+    check('a reuse whose stub runs over a placed via is still rejected',
+          conflict(2.0, 3.0, 2, [(0.0, 3.0, 1, 0.0, 0.0)], px=-2.0, py=3.0,
+                   adds_via=False, **REUSE_KN))
+    # Same net is still exempt.
+    check('a same-net reuse crossing its own stub is allowed',
+          not conflict(2.0, 1.5, 1, crossing, px=-2.0, py=1.5, adds_via=False,
+                       **REUSE_KN))
+    # A reuse landing ON the pad emits no track at all (the commit loop skips
+    # a sub-tolerance stub), so it can conflict with nothing.
+    check('a reuse with no stub to emit conflicts with nothing',
+          not conflict(0.0, 1.0, 2, [(0.0, 1.0, 1, 0.0, 0.0)], px=0.0, py=1.0,
+                       adds_via=False, **REUSE_KN))
+
+    # TERM 1 IN ISOLATION -- the candidate VIA against a stub this run already
+    # emitted. This is the third of the three edits the reuse fix made, and it
+    # was the one nothing tested: reverting ONLY the `adds_via and` guard on
+    # term 1 leaves the whole suite green and U2 at 28/12/30, because term 1
+    # never fires for a reuse candidate on this corpus. Untestable-by-corpus is
+    # not untestable, so the geometry is constructed instead.
+    #
+    # Candidate reuse via at (0,0) on net 2, bridged from its pad at (0,-0.5).
+    # Placed: a net-1 via far away at (0,3), fed by a stub from its pad at
+    # (0.3,0) -- so that STUB passes 0.2985mm from the candidate via.
+    #   term 1  cand via   <-> placed stub  0.2985  (floor 0.375)  FIRES
+    #   via-via cand via   <-> placed via   3.000   (floor 0.550)  clear
+    #   term 2  placed via <-> cand stub    3.000   (floor 0.375)  clear
+    #   term 3  cand stub  <-> placed stub  0.2985  (floor 0.200)  clear
+    # so term 1 is the ONLY thing that can decide either call.
+    t1 = [(0.0, 3.0, 1, 0.3, 0.0)]
+    check('term 1 fires for a NEW via whose position this run chose',
+          conflict(0.0, 0.0, 2, t1, px=0.0, py=-0.5, **REUSE_KN))
+    check('...and is suppressed for a REUSE, whose position it did not choose',
+          not conflict(0.0, 0.0, 2, t1, px=0.0, py=-0.5, adds_via=False,
+                       **REUSE_KN))
+    return bad
+
+
+def _q2_reuse_end_to_end():
+    """The measured board, not just the pure function.
+
+    The pure-function checks above would all pass with `adds_via` accepted and
+    ignored at the call site -- the same "tested the function, left the wiring
+    uncovered" hole D10 was pulled up for. So assert the counts off the board
+    the regression was measured on.
+    """
+    import io
+    import contextlib
+    from qfn_fanout import generate_qfn_fanout as fanout
+    bad = []
+
+    def check(name, cond, detail=""):
+        print(("PASS: " if cond else "FAIL: ") + name + (f"  [{detail}]"
+                                                         if detail else ""))
+        if not cond:
+            bad.append(name)
+
+    if not os.path.exists(U2_BOARD):
+        print("SKIP: corpus board not found (U2 reuse counts)")
+        return bad
+
+    pcb = parse_kicad_pcb(U2_BOARD)
+    with contextlib.redirect_stdout(io.StringIO()):
+        tracks, vias, dropped = fanout(
+            pcb.footprints["U2"], pcb, layer="B.Cu", track_width=0.1,
+            clearance=0.1, grid_step=0.05, escape_method="underpad",
+            via_size=0.45, via_drill=0.25, allow_via_in_pad=True)
+
+    got = (len(vias), len(dropped), len(tracks))
+    check('U2 underpad reuse: 28 vias / 12 dropped / 30 tracks',
+          got == (28, 12, 30), f"got {got[0]} / {got[1]} / {got[2]}")
+    # The specific net the regression cost, named -- a count can drift back
+    # into place for an unrelated reason, this cannot.
+    check('Net-(U2A-DATA_30) keeps its escape (it reuses an existing via)',
+          'Net-(U2A-DATA_30)' not in dropped,
+          f"{len(dropped)} dropped")
+    return bad
+
+
+def _wiring_spy(ref, net_filter, **kw):
+    """Run the underpad escape with `run_output_conflict` spied on.
+
+    Returns what the engine FED the checker, plus the engine's own per-side pad
+    grouping read back off its own output (not re-derived here -- the point is
+    to observe the run, not to model it).
+    """
+    import io
+    import re
+    import contextlib
+    import qfn_fanout as Q
+
+    seen = {'entries': [], 'with_pad': 0, 'calls': 0, 'max_placed': 0}
+    real = Q.run_output_conflict
+
+    def spy(vx, vy, net_id, placed, px=None, py=None, **kwargs):
+        seen['calls'] += 1
+        if px is not None:
+            seen['with_pad'] += 1
+        seen['entries'].extend(placed)
+        seen['max_placed'] = max(seen['max_placed'], len(placed))
+        return real(vx, vy, net_id, placed, px, py, **kwargs)
+
+    Q.run_output_conflict = spy
+    try:
+        pcb = parse_kicad_pcb(BOARD)
+        with contextlib.redirect_stdout(io.StringIO()) as buf:
+            Q.generate_qfn_fanout(
+                pcb.footprints[ref], pcb, net_filter=net_filter, layer="F.Cu",
+                track_width=0.1, clearance=CLEARANCE, grid_step=0.05,
+                escape_method="underpad", via_size=VIA_SIZE, via_drill=0.25,
+                **kw)
+    finally:
+        Q.run_output_conflict = real
+
+    seen['sides'] = {m.group(1): int(m.group(2)) for m in
+                     (re.match(r'\s+(\w+): (\d+) pads$', ln)
+                      for ln in buf.getvalue().splitlines()) if m}
+    return seen
+
+
+def _d10_wiring():
+    """The pure function is not the fix -- the WIRING is.
+
+    Testing only `run_output_conflict` leaves the three call-site edits that
+    actually connect it (passing the pad into `via_clears`, and recording the
+    pad origin in `placed` / `placed_global`) completely uncovered: they can
+    all be reverted with every test still green. So assert the wiring itself,
+    by watching what the engine feeds the checker on a real board.
+    """
+    bad = []
+
+    def check(name, cond, detail=""):
+        print(("PASS: " if cond else "FAIL: ") + name + (f"  [{detail}]"
+                                                         if detail else ""))
+        if not cond:
+            bad.append(name)
+
+    if not os.path.exists(BOARD):
+        print("SKIP: corpus board not found (wiring check)")
+        return bad
+
+    seen = _wiring_spy("U3", ["/USB_DP", "/USB_DN"])
+    check('the engine actually consults the in-run conflict test',
+          seen['calls'] > 0)
+    # If via_clears stopped forwarding the pad, this is 0 and the candidate's
+    # own stub goes untested.
+    check("every candidate is offered with its OWN pad (its stub)",
+          seen['calls'] > 0 and seen['with_pad'] == seen['calls'])
+    # If `placed` reverted to 3-tuples, the emitted stubs become invisible.
+    check('recorded placements carry the pad origin, not just the via centre',
+          seen['entries'] and all(len(e) == 5 for e in seen['entries']))
+
+    # THE CROSS-SIDE HALF, which the fixture above cannot reach. D10's commit
+    # message claims the fix covers stubs "within a side AND across sides via
+    # placed_global" -- but `net_filter=["/USB_DP","/USB_DN"]` yields ONE side
+    # (left: 2 pads), so placed_global is still empty when trial() runs and no
+    # placed_global entry ever reaches the checker. Measured per-mutation
+    # against the combined revert: dropping px/py from the via_clears call
+    # exits 1, a 3-tuple in `trial` exits 1, and a 3-tuple in `placed_global`
+    # exits 0 -- SURVIVES. An unfiltered U3 spans four sides and kills it.
+    wide = _wiring_spy("U3", None)
+    biggest = max(wide['sides'].values() or [0])
+    check('the cross-side fixture really does span more than one side',
+          len(wide['sides']) >= 2, f"sides {wide['sides']}")
+    # WHY THIS BOUND IS EXACT: inside one side's trial, `placed` starts at
+    # len(placed_global) and trial() itself has appended at most (that side's
+    # pads - 1) entries before any given call. So with NO cross-side carry,
+    # max_placed <= biggest - 1. Seeing max_placed >= biggest therefore proves
+    # placed_global was non-empty when a later side ran -- it is a direct
+    # assertion about placed_global, not a proxy for one.
+    check('placed_global carried committed placements INTO a later side',
+          wide['max_placed'] >= biggest,
+          f"max placed {wide['max_placed']}, biggest side {biggest}")
+    # ...and THAT is what kills mutation C: those carried entries are the only
+    # ones that come from placed_global rather than from trial's own append.
+    check('...and the cross-side entries carry the pad origin too',
+          wide['entries'] and all(len(e) == 5 for e in wide['entries']),
+          f"{sorted(set(len(e) for e in wide['entries']))}-tuples seen")
+    return bad
 
 
 if __name__ == "__main__":

--- a/tests/test_region_join_nearest_pair.py
+++ b/tests/test_region_join_nearest_pair.py
@@ -1,20 +1,39 @@
 #!/usr/bin/env python3
-"""Vectorized region-join closest-approach is bit-identical to the brute force (#351).
+"""Region-join pair selection and seeding.
 
-`find_region_connection_points` measured closest approach between every region
-pair with a pure-Python O(N_i x N_j) double loop over (anchors + subsampled fill
-cells) -- the dominant cost of the region-join MST on big multi-region plane nets.
-It now uses one numpy argmin over the row-major dist^2 matrix per pair.
+1. Vectorized closest-approach is bit-identical to the brute force (#351).
+   `find_region_connection_points` measured closest approach between every region
+   pair with a pure-Python O(N_i x N_j) double loop over (anchors + subsampled fill
+   cells) -- the dominant cost of the region-join MST on big multi-region plane nets.
+   It now uses one numpy argmin over the row-major dist^2 matrix per pair.
+   The selection MUST be unchanged (the chosen points feed which copper the router
+   bridges): np.argmin returns the FIRST global minimum in (i-outer, j-inner) order,
+   exactly the brute force's strict-`<` first-minimum tie-break. Pinned against a
+   verbatim copy of the old loop over randomized inputs (including ties, empty
+   regions, and a daisho-class perf case).
 
-The selection MUST be unchanged (the chosen points feed which copper the router
-bridges): np.argmin returns the FIRST global minimum in (i-outer, j-inner) order,
-exactly the brute force's strict-`<` first-minimum tie-break. This test pins that
-equivalence against a verbatim copy of the old loop over randomized inputs
-(including ties, empty regions, and a daisho-class perf case).
+2. The open-space fallback seed must be ON the region (neo6502 GND).
+   `find_open_space_point` answers "where is the emptiest cell within 5mm of the
+   region's centroid" -- a question about the OBSTACLE MAP, not about the
+   region's copper -- and `_try_route_between_regions` fed that point to the A*
+   as an extra source/target seed. Being the cheapest cell around, the search
+   lands on it, so the strap's end is bare board: neo6502's GND repair produced
+   15 such straps (including a 0.1mm one between two regions' open points), all
+   correctly rejected by the #479 endpoint verification, which then burned each
+   pair's whole try allowance so the real join was never retried. The seed must
+   now satisfy the SAME material predicate the join is verified against.
+
+3. A zero-length route means the pair is the same copper, not a failed join.
+   Overlapping same-net zones on one layer are labelled per zone, so a patch pour
+   inside a board-wide pour becomes a second "region" over identical fill; the A*
+   answers with a one-point path. That is merged without copper, not reported as
+   an UNVERIFIED failure.
 
 Run:  python3 tests/test_region_join_nearest_pair.py [-v]
 """
 import argparse
+import contextlib
+import io
 import math
 import os
 import random
@@ -26,9 +45,10 @@ sys.path.insert(0, ROOT)
 sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # #522
 sys.path.insert(0, os.path.join(ROOT, 'py_tools'))  # #522
 
-from routing_config import GridCoord
+from routing_config import GridCoord, GridRouteConfig
 import plane_region_connector as prc
 from plane_region_connector import find_region_connection_points, UnionFind
+from grid_router import GridObstacleMap
 
 
 def _reference(region_anchors, region_cells, coord):
@@ -62,6 +82,292 @@ def _reference(region_anchors, region_cells, coord):
             if len(mst) == n - 1:
                 break
     return mst
+
+
+def _config():
+    return GridRouteConfig(track_width=0.2, clearance=0.2, via_size=0.7,
+                           via_drill=0.4, grid_step=0.1,
+                           layers=['F.Cu', 'B.Cu'])
+
+
+def check_open_space_seed_validity(verbose=False):
+    """`find_open_space_point` must never hand back a point its caller's
+    material predicate rejects, and must be unchanged when nothing is rejected."""
+    coord = GridCoord(0.1)
+    obs = GridObstacleMap(1)
+    anchors = [(8.0, 8.0)]
+    bounds = (0.0, 0.0, 20.0, 20.0)
+
+    # Nothing is blocked, so EVERY cell in the search square ties at the
+    # clearance cap. The ungated scan keeps the first tie in raw grid order --
+    # the far bottom-left corner of the +-5mm box, ~7mm off the region. This is
+    # the defect shape measured on neo6502 (open points 3-5mm off the region
+    # they seed), pinned here because it is what the predicate must stop.
+    unguarded = prc.find_open_space_point(anchors, obs, 0, coord, bounds=bounds)
+    assert unguarded is not None, "no open point found at all"
+    d_far = math.hypot(unguarded[0] - 8.0, unguarded[1] - 8.0)
+    assert d_far > 3.0, \
+        f"expected the unguarded scan to pick a far corner, got {unguarded}"
+
+    # The gated scan must rank the tied cells NEAREST THE REGION, not by grid
+    # order: the probe budget is finite, and grid order spends all of it on the
+    # far edge of the box (2.5% of a +-5mm box at this 0.1mm grid), which
+    # reports "no valid point" while thousands sit on the region. A predicate
+    # that accepts everything therefore lands on the centroid, NOT on the
+    # ungated far corner.
+    permissive = prc.find_open_space_point(anchors, obs, 0, coord, bounds=bounds,
+                                           validity=lambda x, y: True)
+    assert permissive is not None and \
+        math.hypot(permissive[0] - 8.0, permissive[1] - 8.0) <= 0.5, \
+        f"gated scan is not ranked by distance to the region: {permissive}"
+
+    # ...so a predicate that only credits the region's own 1mm neighbourhood
+    # still FINDS a point. (Returning None here would mean the guard silently
+    # disabled the fallback instead of correcting it.)
+    guarded = prc.find_open_space_point(
+        anchors, obs, 0, coord, bounds=bounds,
+        validity=lambda x, y: math.hypot(x - 8.0, y - 8.0) <= 1.0)
+    assert guarded is not None, \
+        "the probe budget threw away every valid candidate near the region"
+    assert math.hypot(guarded[0] - 8.0, guarded[1] - 8.0) <= 1.0, \
+        f"returned a point its own validity rejects: {guarded}"
+
+    # A predicate nothing in range satisfies yields None -- an absent seed
+    # beats a bogus one; it must never fall back to the far corner.
+    starved = prc.find_open_space_point(anchors, obs, 0, coord, bounds=bounds,
+                                        validity=lambda x, y: False)
+    assert starved is None, f"ignored its own validity and returned {starved}"
+    if verbose:
+        print(f"  unguarded={unguarded} permissive={permissive} guarded={guarded}")
+    print("PASS: find_open_space_point honors the material predicate")
+
+
+def check_open_space_seed_is_gated(verbose=False):
+    """`_try_route_between_regions` must gate its open-space seed on the
+    region's material, so an off-region point can no longer become a strap end."""
+    FAR = (50.0, 50.0)
+    seen_validity = []
+
+    def fake_open(anchors, base_obstacles, plane_layer_idx, coord,
+                  search_radius=5.0, bounds=None, validity=None):
+        seen_validity.append(validity)
+        if validity is not None and not validity(FAR[0], FAR[1]):
+            return None
+        return FAR
+
+    def fake_route(source_points, target_points, **kw):
+        # The corridor is walled: a path exists ONLY from the open-space point.
+        if FAR in source_points and FAR in target_points:
+            return ([(FAR[0], FAR[1], 'F.Cu'),
+                     (FAR[0] + 0.1, FAR[1], 'F.Cu')], []), 10
+        return None, kw.get('max_iterations', 1)
+
+    anchors_i = [(1.0, 1.0)]
+    anchors_j = [(30.0, 30.0)]
+    kw = dict(base_obstacles=GridObstacleMap(2), plane_layer_idx=0,
+              routing_layers=['F.Cu', 'B.Cu'], config=_config(),
+              net_vias=[], max_track_width=0.4, min_track_width=0.2,
+              max_iterations=1000, coord=GridCoord(0.1),
+              bounds=(0.0, 0.0, 60.0, 60.0))
+
+    real_open, real_route = prc.find_open_space_point, prc.route_plane_connection_wide
+    prc.find_open_space_point = fake_open
+    prc.route_plane_connection_wide = fake_route
+    try:
+        # Ungated (legacy behaviour): the bogus open-space strap IS produced --
+        # both its ends sit 40mm+ from either region.
+        legacy, _w, _v, _ex = prc._try_route_between_regions(
+            anchors_i, anchors_j, **kw)
+        assert legacy is not None, "fixture no longer reproduces the defect"
+        assert legacy[0][0][:2] == FAR, \
+            f"expected the strap to start on the open point, got {legacy[0][0]}"
+
+        # Gated on material: neither region credits the open point, so no seed
+        # is offered and no strap is invented.
+        seen_validity.clear()
+        off_region = lambda x, y: False           # noqa: E731
+        gated, _w, _v, _ex = prc._try_route_between_regions(
+            anchors_i, anchors_j, open_ok_i=off_region, open_ok_j=off_region,
+            **kw)
+        assert gated is None, \
+            f"an off-material open seed still produced a strap: {gated}"
+        assert seen_validity and all(v is not None for v in seen_validity), \
+            "the material predicate never reached find_open_space_point"
+
+        # A region that DOES credit the point keeps its rescue.
+        on_region = lambda x, y: True             # noqa: E731
+        kept, _w, _v, _ex = prc._try_route_between_regions(
+            anchors_i, anchors_j, open_ok_i=on_region, open_ok_j=on_region,
+            **kw)
+        assert kept is not None, "a legitimate open-space rescue was lost"
+    finally:
+        prc.find_open_space_point = real_open
+        prc.route_plane_connection_wide = real_route
+    print("PASS: the open-space fallback seed is gated on region material")
+
+
+def _stub_board():
+    """Smallest PCBData the region-join loop will accept: two GND pads, no
+    copper, no zones (so the fill models are inert and the regions come from
+    the stubbed detector below)."""
+    from kicad_parser import PCBData, BoardInfo, Net, Pad
+    bi = BoardInfo(layers={0: 'F.Cu', 31: 'B.Cu'},
+                   copper_layers=['F.Cu', 'B.Cu'],
+                   board_bounds=(0.0, 0.0, 20.0, 20.0))
+    pads = []
+    for i, (x, y) in enumerate(((1.0, 1.0), (15.0, 15.0))):
+        p = Pad(pad_number=str(i + 1), net_id=1, net_name='GND',
+                global_x=x, global_y=y, local_x=0.0, local_y=0.0,
+                size_x=1.0, size_y=1.0, shape='circle',
+                layers=['F.Cu'], drill=0.0, component_ref=f'R{i}')
+        pads.append(p)
+    return PCBData(board_info=bi,
+                   nets={1: Net(net_id=1, name='GND', pads=pads)},
+                   footprints={}, vias=[], segments=[],
+                   pads_by_net={1: pads}, zones=[])
+
+
+def _run_join_loop(meet_pt, cells_a, cells_b):
+    """Drive route_disconnected_regions over two stubbed regions whose join
+    attempt returns a ONE-POINT route landing at `meet_pt`. Returns
+    (stdout, segments, vias, routes_added)."""
+    def fake_regions(*a, **kw):
+        # region 1 carries no anchors -> the #513 "already bridged" shortcut is
+        # skipped and the join loop actually runs.
+        return ([[(0.5, 0.5)], []], [cells_a, cells_b], [], [set(), set()])
+
+    def fake_try(anchors_i, anchors_j, **kw):
+        return (([meet_pt], []), 0.2, None, False)
+
+    real_regions, real_try = (prc.find_disconnected_zone_regions,
+                              prc._try_route_between_regions)
+    prc.find_disconnected_zone_regions = fake_regions
+    prc._try_route_between_regions = fake_try
+    buf = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(buf):
+            segs, vias, added, _paths, _cp = prc.route_disconnected_regions(
+                net_id=1, net_name='GND', plane_layer='F.Cu',
+                zone_bounds=(0.0, 0.0, 20.0, 20.0), pcb_data=_stub_board(),
+                config=_config(), base_obstacles=GridObstacleMap(2),
+                layer_map={'F.Cu': 0, 'B.Cu': 1}, analysis_grid_step=0.5)
+    finally:
+        prc.find_disconnected_zone_regions = real_regions
+        prc._try_route_between_regions = real_try
+    return buf.getvalue(), segs, vias, added
+
+
+def check_coincident_pair_merges_without_copper(verbose=False):
+    """A one-point route means a source cell IS a target cell. When that cell
+    is STRICT material for both components they are the same copper: merge
+    them silently instead of reporting `UNVERIFIED ends=None/None` (which
+    burned the pair's try allowance forever). When it is not, the merge is a
+    false "plane joined" and must still be refused."""
+    # Analysis grid is 0.5mm, so cell (gx,gy) covers mm (gx*0.5, gy*0.5).
+    # The two regions' cell sets ABUT at gx=10 (mm 5.0): a shared cell there is
+    # real evidence of shared copper.
+    cells_a = {(gx, gy) for gx in range(6, 11) for gy in range(6, 11)}
+    cells_b = {(gx, gy) for gx in range(10, 15) for gy in range(6, 11)}
+    out, segs, vias, added = _run_join_loop((5.0, 4.0, 'F.Cu'), cells_a, cells_b)
+    if verbose:
+        print('  ' + out.replace('\n', '\n  ').strip())
+    assert 'UNVERIFIED' not in out, \
+        "a zero-length route on shared copper is still a failed join:\n" + out
+    assert 'COINCIDENT' in out, \
+        "the coincident pair was not recognised:\n" + out
+    assert not segs and not vias, \
+        f"a zero-length strap emitted copper: {len(segs)} seg(s), {len(vias)} via(s)"
+    assert added == 0, f"a zero-length strap was counted as a join ({added})"
+
+    # NEGATIVE: two regions 5mm apart whose seed lists merely quantized onto
+    # one routing cell. A zero-length "join" there fuses genuinely disconnected
+    # copper while emitting nothing -- the silent false merge #479 exists to
+    # stop -- so it must be refused, not merged.
+    far_a = {(gx, gy) for gx in range(0, 3) for gy in range(0, 3)}
+    far_b = {(gx, gy) for gx in range(20, 23) for gy in range(20, 23)}
+    out2, segs2, vias2, added2 = _run_join_loop((30.0, 30.0, 'F.Cu'),
+                                                far_a, far_b)
+    assert 'COINCIDENT' not in out2, \
+        "fused two disconnected components on a shared seed cell:\n" + out2
+    assert 'UNVERIFIED' in out2, \
+        "an off-material zero-length route was not refused:\n" + out2
+    assert not segs2 and not vias2 and added2 == 0, \
+        "the refused pair still shipped copper"
+    print("PASS: a coincident region pair merges without copper; a false one is refused")
+
+
+def check_open_space_gate_reaches_every_rung(verbose=False):
+    """Every `_try_route_between_regions` call in the join loop must carry the
+    material predicates. The escalation rungs (retry-full, budget-x5,
+    narrow-width) are separate call sites, and dropping the kwargs from one of
+    them re-opens the bug on exactly the hard pairs that reach it."""
+    import ast
+    import inspect
+    import textwrap
+    src = textwrap.dedent(inspect.getsource(prc.route_disconnected_regions))
+    tree = ast.parse(src)
+    sites = [n for n in ast.walk(tree)
+             if isinstance(n, ast.Call)
+             and getattr(n.func, 'id', None) == '_try_route_between_regions']
+    assert len(sites) >= 3, \
+        f"expected the seed + budget-x5 + narrow-width rungs, found {len(sites)}"
+    for n in sites:
+        kws = {k.arg for k in n.keywords}
+        assert {'open_ok_i', 'open_ok_j'} <= kws, \
+            (f"_try_route_between_regions call at line {n.lineno} of "
+             f"route_disconnected_regions does not gate its open-space seed "
+             f"(kwargs: {sorted(kws)})")
+    if verbose:
+        print(f"  {len(sites)} gated call site(s)")
+    print("PASS: every join rung gates its open-space seed")
+
+
+def check_colocated_islands_are_one_region(verbose=False):
+    """Two same-net zones on ONE layer whose fills overlap are ONE conductor:
+    KiCad merges same-net fills, but a ZoneFillModel is built per ZONE and
+    labels its fill in isolation, so a patch pour inside a board-wide pour used
+    to become a second region over identical copper -- a phantom split the join
+    loop then tried (and failed) to bridge."""
+    from kicad_parser import PCBData, BoardInfo, Net, Zone
+    from plane_fill_model import get_fill_models
+
+    def rect(x0, y0, x1, y1):
+        return [(x0, y0), (x1, y0), (x1, y1), (x0, y1)]
+
+    def board(zones):
+        bi = BoardInfo(layers={0: 'F.Cu'}, copper_layers=['F.Cu'],
+                       board_bounds=(0.0, 0.0, 20.0, 20.0))
+        return PCBData(board_info=bi, nets={1: Net(1, 'GND')}, footprints={},
+                       vias=[], segments=[], pads_by_net={}, zones=zones)
+
+    def regions(pcb, anchors):
+        models = get_fill_models(pcb, 1)
+        return prc._regions_from_fill_models(
+            1, pcb, GridCoord(0.5), 'F.Cu', {'F.Cu'}, models, anchors,
+            (0.0, 0.0, 20.0, 20.0), 0.5)
+
+    # The SMALL zone is listed first, so `_comp_key_at` (first model with fill
+    # wins) credits an anchor inside it to the patch island and an anchor
+    # outside it to the board-wide island: two keys, one piece of copper.
+    over = board([Zone(net_id=1, net_name='GND', layer='F.Cu',
+                       polygon=rect(5.0, 5.0, 9.0, 9.0), priority=1),
+                  Zone(net_id=1, net_name='GND', layer='F.Cu',
+                       polygon=rect(0.5, 0.5, 19.5, 19.5))])
+    ra, _rc, _ri = regions(over, [(7.0, 7.0), (15.0, 15.0)])
+    assert len(ra) == 1, \
+        f"overlapping same-net pours still split into {len(ra)} regions"
+
+    # NEGATIVE: two same-net pours that never share a point stay two regions.
+    apart = board([Zone(net_id=1, net_name='GND', layer='F.Cu',
+                        polygon=rect(0.5, 0.5, 6.0, 6.0)),
+                   Zone(net_id=1, net_name='GND', layer='F.Cu',
+                        polygon=rect(13.0, 13.0, 19.5, 19.5))])
+    ra2, _rc2, _ri2 = regions(apart, [(3.0, 3.0), (16.0, 16.0)])
+    assert len(ra2) == 2, \
+        f"disjoint same-net pours were fused into {len(ra2)} region(s)"
+    if verbose:
+        print(f"  overlapping -> {len(ra)} region(s); disjoint -> {len(ra2)}")
+    print("PASS: co-located fill islands are one region, disjoint ones are not")
 
 
 def run(verbose=False):
@@ -128,3 +434,8 @@ if __name__ == "__main__":
     ap.add_argument("-v", "--verbose", action="store_true")
     args = ap.parse_args()
     run(args.verbose)
+    check_open_space_seed_validity(args.verbose)
+    check_open_space_seed_is_gated(args.verbose)
+    check_open_space_gate_reaches_every_rung(args.verbose)
+    check_coincident_pair_merges_without_copper(args.verbose)
+    check_colocated_islands_are_one_region(args.verbose)

--- a/tests/test_run14_dash_net_hint.py
+++ b/tests/test_run14_dash_net_hint.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""A net whose NAME starts with '-' must not cost a lap (run 14).
+
+castor_pollux has a net called `-12V`. `route.py --nets ... -12V ...` is
+`nargs='+'`, so argparse read the name as a flag:
+
+    route.py: error: unrecognized arguments: -12V
+
+exit 2, no board, no JSON_SUMMARY. Both arms of run 14's plane-mapping A/B died
+that way and the lap had to be re-run. The fix is one character at the call site
+(`--nets=-12V`) but nothing said so, and thirty-odd sibling list flags across six
+tools share the shape.
+
+`cli_banner.install()` -- which every instrument already calls -- now patches
+`ArgumentParser.error` once so the hint appears wherever it happens. These tests
+pin that the hint fires, that it does not fire on unrelated errors, that it never
+masks the real error, and that the workaround it recommends actually works.
+"""
+import argparse
+import io
+import contextlib
+import os
+import subprocess
+import sys
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_placer'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_tools'))  # #522/py_placer layout
+
+import cli_banner  # noqa: E402
+
+BOARD = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
+
+
+class DashHintUnitTest(unittest.TestCase):
+
+    def setUp(self):
+        cli_banner.install_dash_hint()
+        self.p = argparse.ArgumentParser(prog='t', add_help=False)
+        self.p.add_argument('--nets', nargs='+')
+
+    def _err(self, argv):
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            with self.assertRaises(SystemExit):
+                self.p.parse_args(argv)
+        return buf.getvalue()
+
+    def test_hint_fires_on_a_leading_dash_value(self):
+        out = self._err(['--nets', '+12V', '-12V'])
+        self.assertIn("'-12V'", out)
+        self.assertIn('--nets=-12V', out)
+
+    def test_the_real_argparse_error_still_prints(self):
+        out = self._err(['--nets', '+12V', '-12V'])
+        self.assertIn('unrecognized arguments', out,
+                      'the hint must add to the error, never replace it')
+
+    def test_no_hint_on_an_unrelated_error(self):
+        p = argparse.ArgumentParser(prog='t', add_help=False)
+        p.add_argument('--size', type=int)
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            with self.assertRaises(SystemExit):
+                p.parse_args(['--size', 'banana'])
+        self.assertNotIn('begins with', buf.getvalue())
+
+    def test_patch_is_idempotent(self):
+        before = argparse.ArgumentParser.error
+        cli_banner.install_dash_hint()
+        cli_banner.install_dash_hint()
+        self.assertIs(argparse.ArgumentParser.error, before,
+                      'install must not stack wrappers')
+
+
+class DashHintCliTest(unittest.TestCase):
+    """Through a real instrument, as the run actually hit it."""
+
+    def _run(self, args):
+        return subprocess.run([sys.executable, '-X', 'utf8',
+                               os.path.join(ROOT, 'py_router', 'route.py')] + args,
+                              capture_output=True, text=True, timeout=600)
+
+    def test_route_py_emits_the_hint_and_still_exits_2(self):
+        r = self._run([BOARD, os.path.join(ROOT, '_no_such_out.kicad_pcb'),
+                       '--nets', '+12V', '-12V'])
+        self.assertEqual(r.returncode, 2)
+        both = r.stdout + r.stderr
+        self.assertIn('--nets=-12V', both)
+        self.assertIn('unrecognized arguments', both)
+
+    def test_the_recommended_form_parses(self):
+        """The hint must recommend something that actually works.
+
+        Asserted on the MESSAGE, not the exit code: this fixture board has no
+        `-12V`, so route.py rightly refuses with its own exit 2 ("none of the
+        requested nets exist"). That refusal is proof the value got through
+        argparse -- which is the whole claim. Checking the code alone would
+        confuse two different exit 2s.
+        """
+        r = self._run([BOARD, os.path.join(ROOT, '_no_such_out.kicad_pcb'),
+                       '--nets=-12V', '--skip-routing'])
+        both = r.stdout + r.stderr
+        self.assertNotIn('unrecognized arguments', both,
+                         'the documented workaround must not be an argparse '
+                         'error: ' + both[-300:])
+        self.assertIn('-12V', both,
+                      'the net name must reach the tool as a VALUE')
+        self.assertNotIn('begins with', both,
+                         'and the hint must not fire when nothing is wrong')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Two themes, one constraint honored throughout: nearly everything here is additive or a demonstrably-wrong rewrite of at most a dozen lines per site, each with a test that fails on the unpatched tree. Net footprint: ~212 existing lines modified (56 of those are the four duplicated floor-read blocks one shared resolver deletes) against ~2,400 added, most of it tests and one new module.

## Theme A — the board declares a floor, and the code used a constant

- **One resolver for CLI floors** (`list_nets.resolve_cli_floor` + the declared-0 guard in `board_floor_knobs`), wired through all four routing mains. KiCad writes 0 for "not configured"; the mains' private `is not None` reads took it as a real floor. Measured: a declared `min_copper_edge_clearance: 0.0` printed "using the board … 0.0mm" and dropped the plane inset 0.5 → 0.0, while the GUI plane tab already guarded `> 1e-9`. Pinned by `tests/test_board_floors.py`, which also runs each main live on a declared-0.0 board. (This file re-creates the surviving checks from the test removed with #579, minus the removed feature's blocks, under a new name.)
- **`min_hole_clearance` reaches the router and its checker** (`obstacle_map.resolve_hole_clearance`, `routing_config.hole_clearance`, `plane_obstacle_builder`, `check_drc --hole-clearance` with project auto-read, `FAB_FLOOR_KEYS`). Measured: a kicad-cli-confirmed 0.0237 mm routing-introduced violation, and neo6502 shipping 3 NPTH at 0.2126/0.2263 mm against an authored 0.25, graded clean because nothing consulted the key. Pinned by `tests/test_npth_seed_floor.py`.
- **BGA underpad escape reads the board's `min_hole_to_hole`** (fab-wrapped, tighten-only). Measured on ulx3s (declares 0.4): drill gap 0.3657 → 0.6000; control board byte-identical. 13 checks in `tests/test_bga_fanout_underpad.py`.
- **QFN underpad: candidates tested against this run's own output** (`run_output_conflict`, cross-side), and a reused via priced as a reuse (`adds_via=False`). Pinned regression on `kicad_files/routed_output.kicad_pcb` U2: 29/13/31 → 28/12/30. The original headline symptom (39/46 rejected escapes) did not reproduce and the body of the commit says so — the structural gap plus the regression pin are the evidence.
- **GUI/CLI floor divergence closed**: `_effective_geometry_floor` gains the declared-0 guard its sibling plane-edge helper already had (GUI drilled h2h 0.1 vs CLI 0.2, same board, same settings). Pinned under real KiCad python by `tests/gui_parity/test_geometry_floor_leak.py`; `.gui-parity-checked` gains a scoped addendum with the parity evidence (copper sets identical, 1307 segments / 144 vias, CLI = GUI).

## Theme B — false success

- `route.py`: a `--nets` list where every name missed wrote a passthrough copy and exited 0 (run 11 lost two laps to boards KiCad refuses to load while every in-repo checker read them fine); CRLF names stripped; summary gains `scope` + `ripped_open_uncounted` so the last `JSON_SUMMARY` of a log can't masquerade as the whole run.
- `route_diff.py`: zero matched pairs exited 0; a `partial` pair with both members incomplete counted `successful` (fixed engine-side — the GUI reads `successful` raw).
- `route_planes.py`: `"GND:B.Cu"` was accepted as a layer name and KiCad refused the written file; the pad tally reaches the JSON summary (recording `geometric_failed` without flipping status on it — under pours-first those are expected at the plane step).
- `check_connected.py`: a phantom zone layer joined the copper census (69/70 graded 70/70); a scope that matches nothing exits 2.
- `check_weird.py`: new `dangling-via` category — KiCad flagged 64 on a board where this tool flagged 0.
- `diff_pair_custody.py`: a pair the audit demoted to partial kept its credit.
- `kicad_oracle.py`: the timeout memo keyed on a realpath every chain step renames (240 s re-burned per step) — now keyed on the fill-cost signature; `KICAD_CLI` env override first; broader Windows discovery.
- `route_summary.py`: `oracle_check` merges worst-news-first — a real KiCad contradiction was erased by a later subset-pass `skipped`.
- `plane_fragility.py`: the one call site that dereferenced `refill_islands`' documented None return.
- `plane_region_connector.py`: the open-space fallback seeded strap ends on bare board 3–5 mm from the region (clearance saturates off the plane net's own copper; the strict first-maximum tie-break picks the far corner in raw grid order). Seeding on region material takes neo6502's GND from 15 of 41 region joins dead-by-construction to 0; two healthy boards byte-identical; `validity=None` keeps the old path verbatim. Pinned by `tests/test_region_join_nearest_pair.py`.

## Riders both themes stand on

- `py_router/krt_deadline.py` (new): cooperative `--deadline` in the four mains — arm/stamp/seal, exit 7, a guaranteed `JSON_SUMMARY` on the way out. The wiring is one closure into the `cancel_check`/`progress_callback` parameters the engine functions already have; `place_route_loop` treats exit 7 as a partial result with a summary, not a failed step. (An external kill leaves no summary and no exit code of the tool's own — that is the gap this closes from the inside.)
- `cli_banner.install_dash_hint`: `--nets -12V` is an argparse death, not a routing result; adopted only in the four mains (prefixed `JSON_SUMMARY:` lines, no bare-JSON stdout mode touched).
- `tests/run_all.py`/`run_utils.py`: timeouts reported as `TIME`, separate from `FAIL`, with per-child utf8.

## Testing

The board-floor family ran green inside a patched worktree of `0f45ba2b` before this branch existed (43/43 board-floor checks including live subprocess runs of all four mains, 13/13 BGA, 26/26 QFN, the GUI leak test under KiCad 10.0 python), and again on this branch. Full `tests/run_all.py` on the source branch: 341 passed, 6 failed — all six pre-existing and unrelated (the two #549 floorplan grades, multipoint_diff, tigard_usb 9/12, the opt-in placement probe, the skills-generic lint), 2 known-slow timeouts.

Two deliberate behavior deltas vs tip, so they don't surprise a reviewer's test run: `test_multipoint_diff_route` (7/7 → 1/7 scenarios couple-routed) and `test_tigard_usb_diff` (12/12 → 9/12) — the router now enforcing `min_hole_clearance` and the stricter pair-success accounting make `route_diff` defer pairs it previously couple-routed; the boards still finish connected and DRC-clean through the single-ended follow-up. These land at exactly the levels our source branch has carried since the fixes went in.

Note on running any of this from a fresh clone: the tip currently refuses to start after `build_router.py` (prebuilt 0.20.1 vs Cargo 0.20.0 strict equality) — filed as #615 with details; we test with a local uncommitted Cargo bump.
