### PR TITLE
placement: the reconstruct ladder, reseat, orbits, and instruments that stopped lying

### DIFF
--- a/.gui-parity-checked
+++ b/.gui-parity-checked
@@ -627,3 +627,19 @@ HEAD 2026-07-30 parity audit 191abc4..d73b1d6 (3 commits). Outcome: no gaps.
     gate runs a fanout step; ea992d9), its stale _path bootstrap
     (3c4fc48), and the #562 rename breaking every recorded manifest's
     repair step (relocate_moved_scripts rename table, 89914ce).
+
+ADDENDUM 2026-08-12 (PR: board floors + false success) -- scope: the one
+GUI-relevant change in this PR is kicad_routing_plugin/swig_gui.py
+_effective_geometry_floor gaining the declared-0 guard (a board writing 0 for
+"not configured" was taken as a real hole-to-hole floor by the GUI while the
+CLI's resolver treated it as unset: measured, GUI drilled h2h 0.1 vs CLI 0.2,
+same board, same settings, under fab-overrides). The plane-edge helper beside
+it already guarded > 1e-9; this closes the divergence in the other helper.
+  * Pinned by tests/gui_parity/test_geometry_floor_leak.py (runs under real
+    KiCad python; "declared-0.0 hole_to_hole, fab floor 0.1 -> GUI 0.2
+    (CLI 0.2) ... 0 problem(s)").
+  * Parity evidence on the source branch (KiCad 10.0, pcbnew 10.0.0,
+    wx 4.2.2): test_gui_engine_parity VERDICT PARITY, copper sets IDENTICAL
+    (segments 1307=1307, vias 144=144, 0 one-sided); test_manifest_plan_parity
+    OK; test_cli_postpass_coverage 7 registered / 14 in use / 1 acknowledged
+    CLI-only (run_drc fanout graze audit, report-only) / 0 unreachable.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,18 @@ Linux distros). On Windows, if `python3` is missing, fall back to `py -3`
 or `python` — don't retry blindly. Add `-X utf8` when a script prints
 special characters (Ω etc.) to avoid Windows encoding errors.
 
+**On Windows/Git Bash, `export MSYS2_ARG_CONV_EXCL='*'` before any command
+carrying NET NAMES.** MSYS2 rewrites any argument starting with `/` into a
+Windows path, and **every KiCad net name is `/`-prefixed**: `/+1V1` reaches the
+tool as `C:/Program Files/Git/+1V1`. Nothing warns, because a tool cannot tell a
+mangled net name from a net that does not exist. Measured: 61 nets passed to
+`--ignore-nets`, 4 survived (the four not starting with `/`), and the resulting
+render reported 1315 crossings where the truth was 357. It hits `--nets`,
+`--ignore-nets`, `--power-nets`, `--rip-existing-nets` — every net-name argument.
+**The variable is not free**: it also disables conversion for legitimate paths,
+so `~/Documents/...` then arrives as an unusable `/c/Users/...`. Pass
+Windows-style paths (`C:/Users/...`) in the same command.
+
 ## Building the Rust Router
 
 Use `build_router.py` to build the Rust router:
@@ -142,6 +154,55 @@ Validate routed boards against the *real* spec, with the right checker — most
   `--no-clamp-netclasses` flags are **removed** (the `--clearance` ceiling replaces
   both; `--net-clearances <json>` gives explicit per-net control). Grade multi-class
   boards at the netclasses that survived (`kicad_drc_compare._staged_copy`).
+
+## What a placement run is FOR (read before grading one)
+
+**The objective is a board that ROUTES: parts arranged so they work together,
+and zero `unrouted` and zero `broken` nets at the end. It is NOT restoring
+parts to the poses they had before.**
+
+This is stated here because the perturbed-corpus rig (#411) grades on
+`recovery` and `home /N`, which measure **distance to the original pose** —
+and those are the wrong headline for this goal. A placement that is
+electrically excellent but arranged differently scores ~0 recovery. Measured,
+run 10: `recovery` **−0.0014** and `home` **0/30** on a run that took
+copper-free DRC 9 → 0, assembly blocking 4 → 0, and `check_assembly` from NOT
+BUILDABLE to **buildable**. The headline said failure about a board that had
+become strictly more buildable.
+
+So, when grading a placement:
+
+- **Lead with the routed outcome** — `board_score`'s `blocking`
+  (`unrouted + broken` first, then the rest), with `quality` (vias,
+  copper_mm, segments) as the tie-break once `blocking` is 0.
+- **Keep `recovery` as a DIAGNOSTIC, never the score.** It is how you catch a
+  run that wandered — `collateral_pad_rms` rising (run 10: 0.000 → 3.670 mm)
+  means parts nothing had damaged were moved, which is a real defect. But a
+  negative recovery on a board that got more buildable is not a failure of
+  the run.
+- **The human original is a BENCHMARK TO APPROACH, not a pose to match**
+  (its vias / copper_mm / segments), because a human layout is one solution,
+  not the only one.
+
+**A part whose pad copper lies outside the outline is the top-priority
+placement defect**, ahead of every clearance graze: its nets cannot be routed
+at all, so it converts one-for-one into `unrouted` and `broken`. Measured, run
+10: 11 such parts produced ALL 13 unrouted nets and most of the 37 broken ones.
+Read it off `render_placement --json-out`'s
+`checklist.a_off_outline.pad_copper` — a whole-board pass/fail verdict is the
+wrong channel for it.
+
+**Scope a placement search to the refs the gate names.** When a gate names
+specific parts, free exactly those and lock everything else. A global sweep
+orders its violators by its own priority — usually worst-off-board first — and
+may never reach the ones actually blocking you. Measured: freeing 2 parts and
+locking the other 105 cleared both blocking pairs in **63 seconds**, where
+whole-board sweeps ran 10+ minutes without touching them.
+
+**Repair searches start from the part's CURRENT pose**, which carries no
+information once a part is tens of millimetres from where it belongs. Expect
+cost to grow sharply with the displacement cap, and prefer re-seating such a
+part over nudging it.
 
 ## Stress testing & A/B replay
 

--- a/check_complete.py
+++ b/check_complete.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""Is this board DONE? The one command that answers it, and fails closed.
+
+    python3 -X utf8 check_complete.py BOARD [--authored-from ORIGINAL] \
+        [--intent J] [--impedance-nets G...] [--length-groups J] \
+        [--net-min-widths J] [--min-track-width MM] [--min-via-diameter MM] \
+        [--clearance MM] [--json PATH]
+
+`board_score` is the authority on `blocking`, and it is honest about being
+incomplete -- but read alone it says "done" too easily, three separate ways:
+
+  * IT EXITS 0 WITH FOUR OF NINE COMPONENTS UNGRADED. floorplan, impedance,
+    length and net_widths return `skipped(...)` when their flag is absent, and
+    `ungraded` does not touch the exit code. A board nobody graded exits 0.
+  * `undersized` IS SILENTLY PERMISSIVE without spec numbers. It runs at the
+    FAB floor for the layer count, so `undersized == 0` is not "the sizes are
+    right" -- one board had 141 of 141 vias violating a 0.6mm spec while
+    clearing the 0.25mm two-layer floor.
+  * IT HAS NO COMPONENT AT ALL for orphan stubs, weird copper, pad overlaps or
+    channel starvation. Several of those are run by the routing chain and none
+    of them reaches the scalar.
+
+And underneath all of it, the DRC writeback rewrites the board's own
+manufacturing floors down to whatever was produced and then everything grades
+against the new value. That is disclosed in a printed line and enforced by
+nothing.
+
+So this aggregates, and the difference from board_score is the direction it
+fails in. Three verdict classes, and only one of them is "done":
+
+    DONE        every component that could be graded is graded and clean
+    INCOMPLETE  a component RAN and could not answer, or an instrument this
+                adds found something -- exit 4
+    UNSOUND     the board grades clean against floors it rewrote -- exit 5
+
+UNGRADED components do NOT block DONE -- a board with no spec files has nothing
+to grade them against, and making that fatal would put every corpus board
+permanently in the failing state -- but they are NAMED in the verdict line,
+because a component nothing examined is UNEXAMINED and never clean.
+
+Exit: 0 done, 2 usage, 3 board state, 4 incomplete, 5 unsound floors.
+"""
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+# #522/py_placer layout: the engine modules (kicad_parser, cli_banner, ...)
+# live in py_router/py_tools/py_placer, not at the repo root, so inserting
+# only ROOT left `import cli_banner` failing when run as a script.
+sys.path.insert(0, ROOT)
+for _pkg in ('py_router', 'py_tools', 'py_placer'):
+    _d = os.path.join(ROOT, _pkg)
+    if os.path.isdir(_d):
+        sys.path.insert(0, _d)
+SKILL_SCRIPTS = os.path.join(ROOT, '.claude', 'skills', 'plan-pcb-routing',
+                             'scripts')
+PY = [sys.executable, '-X', 'utf8']
+
+DONE, USAGE, BOARD_STATE, INCOMPLETE, UNSOUND = 0, 2, 3, 4, 5
+
+
+TIMED_OUT = 124                     # the shell's code, and deliberately so:
+                                    # a caller reading 124 is reading "killed
+                                    # by a clock", which is what happened.
+
+
+def _run(args, timeout=3600):
+    """Run a checker. A timeout is a RESULT, not an exception.
+
+    This process is the thing a gate reads, so it must not die on the slowest
+    board in the corpus: board_score alone fans out to check_drc, and on a
+    6-layer board this runs six orphan-stub sweeps beside it. An uncaught
+    TimeoutExpired propagates out of main and takes the whole document with it
+    (see the finally in main) -- which loses the verdict on exactly the boards
+    a close-out exists for.
+    """
+    try:
+        p = subprocess.run(PY + args, capture_output=True, text=True,
+                           encoding='utf-8', errors='replace', cwd=ROOT,
+                           timeout=timeout,
+                           env=dict(os.environ, KRT_NO_BANNER='1'))
+    except subprocess.TimeoutExpired:
+        return TIMED_OUT, f'timed out after {timeout}s'
+    return p.returncode, (p.stdout or '') + (p.stderr or '')
+
+
+def copper_layers(board):
+    """-> (layers, error). The error is a STRING, never a raised exception.
+
+    Returning a bare [] on a parse failure would make "this board has no copper
+    layers" and "nobody could read this board" the same answer, which is the
+    conflation this whole file exists to refuse. The caller records the error
+    as a reason rather than sweeping a partial sweep in as a clean one.
+    """
+    try:
+        from kicad_parser import parse_kicad_pcb
+        return list(parse_kicad_pcb(board).board_info.copper_layers or []), None
+    except Exception as exc:                                    # noqa: BLE001
+        return [], f'{type(exc).__name__}: {exc}'
+
+
+def fab_floor_integrity(board, authored_from):
+    """Does this board's copper sit below the floors its project ONCE declared?
+
+    The writeback only ever loosens: every constraint is set to min(current,
+    target) and the target is the smallest object actually placed. So a board
+    that routed at 0.0889 rewrites its own 0.2 minimum and then grades clean
+    against it -- measured at 5629 of 5933 segments below the original floor,
+    with check_drc, board_score and KiCad's own DRC all reading clean.
+
+    Needs the ORIGINAL project to compare against, because a chain overwrites
+    the floors in place. Without it, say the check did not run rather than
+    implying it passed.
+    """
+    from fix_kicad_drc_settings import (FAB_FLOOR_KEYS, find_project,
+                                        scan_board_minima)
+    if not authored_from:
+        return {'ran': False, 'reason': 'no --authored-from: the chain rewrites '
+                                        'the floors in place, so there is '
+                                        'nothing left to compare against'}
+    pro = find_project(authored_from)
+    if not os.path.isfile(pro):
+        return {'ran': False, 'reason': f'no project beside {authored_from}'}
+    try:
+        with open(pro, encoding='utf-8') as fh:
+            authored = ((json.load(fh).get('board') or {})
+                        .get('design_settings') or {}).get('rules') or {}
+    except Exception as exc:                                # noqa: BLE001
+        return {'ran': False, 'reason': f'unreadable project: {exc}'}
+    now = scan_board_minima(board) or {}
+    relaxed = []
+    unmeasured = []
+    for key, label in FAB_FLOOR_KEYS:
+        was, is_ = authored.get(key), now.get(key)
+        if isinstance(was, (int, float)) and not isinstance(is_, (int, float)):
+            # The board DECLARES this floor and nothing here can measure it --
+            # scan_board_minima reads object sizes only, no pairwise geometry,
+            # so copper-to-hole has no measured counterpart. Silently skipping
+            # it made `relaxed: []` read as "every declared floor is honoured"
+            # when one of them had never been looked at. Name it instead.
+            unmeasured.append({'key': key, 'label': label, 'authored': was})
+            continue
+        if isinstance(was, (int, float)) and isinstance(is_, (int, float)) \
+                and is_ < was - 1e-9:
+            relaxed.append({'key': key, 'label': label, 'authored': was,
+                            'on_board': is_})
+    return {'ran': True, 'relaxed': relaxed, 'unmeasured': unmeasured,
+            'authored_from': authored_from}
+
+
+def _grade(a, doc):
+    """Fill `doc` and return the exit code. Raises only on a genuine bug.
+
+    Split out of main so main can own a try/finally: the document must be
+    written even when this raises, because the boards that break an instrument
+    are exactly the boards a close-out is being asked about.
+    """
+    # ---- 1. board_score, with every spec flag the caller has ---------------
+    # The intermediate goes to a temp dir, not next to the board: a checker
+    # that drops files into the directory it is inspecting turns a read-only
+    # question into a write, and on a corpus directory that is somebody's
+    # source tree.
+    import tempfile
+    scratch = tempfile.mkdtemp(prefix='check_complete.')
+    try:
+        score_path = os.path.join(scratch, 'score.json')
+        args = [os.path.join(SKILL_SCRIPTS, 'board_score.py'), a.board,
+                '--json', score_path, '--quiet']
+        for flag, val in (('--clearance', a.clearance), ('--intent', a.intent),
+                          ('--length-groups', a.length_groups),
+                          ('--net-min-widths', a.net_min_widths),
+                          ('--min-track-width', a.min_track_width),
+                          ('--min-via-diameter', a.min_via_diameter),
+                          ('--min-via-drill', a.min_via_drill)):
+            if val is not None:
+                args += [flag, str(val)]
+        if a.impedance_nets:
+            args += ['--impedance-nets'] + list(a.impedance_nets)
+        code, out = _run(args, timeout=a.timeout)
+        score = {}
+        if os.path.isfile(score_path):
+            with open(score_path, encoding='utf-8') as fh:
+                score = json.load(fh)
+    finally:
+        shutil.rmtree(scratch, ignore_errors=True)
+
+    doc['score'] = score
+    # Hoisted so a gate can bind this document to a board by CONTENT rather
+    # than by path, reusing the sha board_score already computed.
+    doc['board_sha'] = score.get('board_sha')
+    blocking = score.get('blocking')
+    ungraded = sorted(score.get('ungraded') or [])
+    unknown = sorted(score.get('unknown') or [])
+    score_failed = (code == TIMED_OUT or not score)
+
+    # ---- 1b. is there a board here at all? ---------------------------------
+    # ALWAYS, including under --skip-slow. `parse_kicad_pcb` is lenient: a
+    # truncated file yields an EMPTY board rather than an error, and an empty
+    # board has nothing to violate, so every component grades 0 and the verdict
+    # was DONE. "Nothing to grade" is not "graded clean" -- that is the whole
+    # claim of this file, and it failed it on the cheapest possible input.
+    # A real board always declares at least two copper layers.
+    layers, lyr_err = copper_layers(a.board)
+    doc['copper_layers'] = layers
+    if lyr_err:
+        doc['copper_layers_error'] = lyr_err
+
+    # ---- 2. the instruments board_score has no component for ---------------
+    extra = {}
+    if not a.skip_slow:
+        # check_orphan_stubs hardcodes four layers, so on a 6+ layer board the
+        # inner ones are never scanned and it says nothing about them. Ask per
+        # layer instead of accepting a partial sweep as a clean one.
+        stub_hits, stub_ran, stub_exits = 0, [], {}
+        for ly in layers:
+            c, o = _run([os.path.join('py_tools', 'check_orphan_stubs.py'),
+                         a.board, '--layer', ly],
+                        timeout=a.timeout)
+            stub_ran.append(ly)
+            stub_exits[ly] = c
+            if c == 1:
+                stub_hits += 1
+        extra['orphan_stubs'] = {'ran': not lyr_err, 'layers': stub_ran,
+                                 'exits': stub_exits,
+                                 'layers_with_orphans': stub_hits}
+        if lyr_err:
+            extra['orphan_stubs']['error'] = lyr_err
+        # 1 is "orphans found"; 0 is clean. ANY OTHER CODE IS THE INSTRUMENT
+        # FAILING, not the board passing -- a traceback also exits 1 and an
+        # argparse error exits 2, and 2 used to be counted as clean because
+        # only `c == 1` was tested. The siblings below use `clean = c == 0`,
+        # which fails in the safe direction; this now matches them.
+        bad = sorted(ly for ly, c in stub_exits.items() if c not in (0, 1))
+        if bad:
+            extra['orphan_stubs']['failed_layers'] = bad
+        for name, cmd in (
+                ('weird_copper', [os.path.join('py_router', 'check_weird.py'),
+                                  a.board]),
+                ('pad_overlaps', [os.path.join('py_router', 'check_pads.py'),
+                                  a.board, '--cross-footprint'])):
+            c, o = _run(cmd, timeout=a.timeout)
+            extra[name] = {'ran': True, 'exit': c, 'clean': c == 0}
+    doc['components'] = extra
+
+    # ---- 3. the fab floors this board grades itself against ----------------
+    try:
+        floors = fab_floor_integrity(a.board, a.authored_from)
+    except Exception as exc:                                    # noqa: BLE001
+        floors = {'ran': False,
+                  'reason': f'the floor check itself failed: '
+                            f'{type(exc).__name__}: {exc}'}
+    doc['fab_floors'] = floors
+
+    # ---- the verdict -------------------------------------------------------
+    reasons = []
+    if lyr_err:
+        reasons.append(f'the board did not parse: {lyr_err}')
+    elif not layers:
+        reasons.append('this file declares NO copper layers -- it did not '
+                       'parse into a board. Every component then grades 0 '
+                       'against nothing, which is not a clean board')
+    if score_failed:
+        reasons.append('board_score produced no score'
+                       + (f' (exit {code})' if code == TIMED_OUT else ''))
+    if unknown:
+        reasons.append('a component RAN and could not answer: '
+                       + ', '.join(unknown))
+    if blocking is None and not score_failed:
+        reasons.append('blocking is null -- something was not graded, and a '
+                       'null is not a zero')
+    elif blocking:
+        reasons.append(f'blocking = {blocking}')
+    for name, r in sorted(extra.items()):
+        if r.get('error'):
+            reasons.append(f'{name}: did not run ({r["error"]})')
+        elif r.get('failed_layers'):
+            reasons.append(f'{name}: the instrument failed on '
+                           f'{", ".join(r["failed_layers"])} -- '
+                           f'not examined, and not clean')
+        elif r.get('layers_with_orphans'):
+            reasons.append(f'{name}: {r["layers_with_orphans"]} layer(s) carry '
+                           f'orphan stubs')
+        elif r.get('clean') is False:
+            reasons.append(f'{name}: not clean (exit {r.get("exit")})')
+
+    # An UNMEASURED declared floor is not a pass. It does not make the board
+    # UNSOUND on its own -- nothing measured a violation -- but it must not
+    # vanish, because `fab_floors.relaxed == []` is exactly the sentence a
+    # reader takes for "every declared floor is honoured". Append it to the
+    # INCOMPLETE reasons so it travels with the verdict.
+    if floors.get('unmeasured'):
+        _um = ', '.join(f'{r["label"]} (declared {r["authored"]})'
+                        for r in floors['unmeasured'])
+        reasons.append(f'declared fab floor(s) NOT measured by this check, so '
+                       f'unknown rather than honoured: {_um} -- grade with '
+                       f'check_drc.py, which reads them')
+    if floors.get('relaxed'):
+        worst = ', '.join(f'{r["label"]} {r["authored"]} -> {r["on_board"]}'
+                          for r in floors['relaxed'])
+        verdict, code_out = 'UNSOUND', UNSOUND
+        why = (f'this board carries copper below floors its project once '
+               f'declared ({worst}). Every checker grades against the NEW '
+               f'value, so a clean report here means the rule moved, not the '
+               f'copper. Confirm the fab supports it before calling it done.')
+    elif reasons:
+        verdict, code_out = 'INCOMPLETE', INCOMPLETE
+        why = '; '.join(reasons)
+    else:
+        verdict, code_out = 'DONE', DONE
+        why = 'every component that could be graded is graded and clean'
+
+    if ungraded:
+        why += ('. UNEXAMINED, and not passed: ' + ', '.join(ungraded)
+                + ' -- nothing was asked to grade them, so they are unknown '
+                  'rather than clean')
+    doc['verdict'] = verdict
+    doc['reason'] = why
+    doc['ungraded'] = ungraded
+    return code_out
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('board')
+    ap.add_argument('--authored-from', default=None,
+                    help='the board the chain STARTED from -- its project '
+                         'carries the floors this one should still respect')
+    ap.add_argument('--clearance', type=float, default=None)
+    ap.add_argument('--intent', default=None)
+    ap.add_argument('--impedance-nets', nargs='+', default=None)
+    ap.add_argument('--length-groups', default=None)
+    ap.add_argument('--net-min-widths', default=None)
+    ap.add_argument('--min-track-width', type=float, default=None)
+    ap.add_argument('--min-via-diameter', type=float, default=None)
+    ap.add_argument('--min-via-drill', type=float, default=None)
+    ap.add_argument('--skip-slow', action='store_true',
+                    help='the added instruments only; board_score always runs. '
+                         'NOTE this empties `components`, so the document is '
+                         'then weaker than the board_score it wraps -- a gate '
+                         'reading it should say so')
+    ap.add_argument('--timeout', type=float, default=3600, metavar='S',
+                    help='per-instrument wall clock (default 3600). A timeout '
+                         'is recorded as exit 124, never raised')
+    ap.add_argument('--json', default=None, metavar='PATH')
+    a = ap.parse_args(argv)
+
+    if not os.path.isfile(a.board):
+        print(f'no such board: {a.board}', file=sys.stderr)
+        return BOARD_STATE
+
+    # Absolute, because _run uses cwd=ROOT. A relative board path resolves
+    # against ROOT inside the subprocess and against the caller's cwd out here,
+    # so from any directory but the repo root board_score was handed a path
+    # that does not exist -- and returned an empty score, which became a FALSE
+    # `INCOMPLETE: blocking is null`. `doc['board']` was abspathed already, so
+    # the document even looked correctly bound. The existing test does
+    # os.chdir(ROOT), which is why this never surfaced.
+    a.board = os.path.abspath(a.board)
+    if a.authored_from:
+        a.authored_from = os.path.abspath(a.authored_from)
+
+    doc = {'schema': 1, 'kind': 'board-complete',
+           'board': a.board, 'board_sha': None, 'components': {}, 'score': {},
+           'fab_floors': {}, 'ungraded': [],
+           'verdict': 'INCOMPLETE',
+           'reason': 'the close-out itself did not finish'}
+
+    code_out = INCOMPLETE
+    try:
+        code_out = _grade(a, doc)
+    except Exception as exc:                                    # noqa: BLE001
+        # An instrument that dies must not take the document with it. This
+        # file's own doctrine -- "say the check did not run rather than
+        # implying it passed" -- was written for fab_floor_integrity and never
+        # applied to its own failure modes: the --json write used to be the
+        # last statement, so anything above it that raised produced no
+        # document at all, on precisely the broken boards a gate is for.
+        doc['verdict'] = 'INCOMPLETE'
+        doc['reason'] = (f'the close-out itself did not finish: '
+                         f'{type(exc).__name__}: {exc}')
+        code_out = INCOMPLETE
+    finally:
+        print(f"VERDICT: {doc['verdict']} -- {doc['reason']}")
+        if a.json:
+            try:
+                with open(a.json, 'w', encoding='utf-8') as fh:
+                    json.dump(doc, fh, indent=1, sort_keys=True, default=str)
+                print(f'  JSON -> {a.json}')
+            except OSError as exc:
+                print(f'  could not write {a.json}: {exc}', file=sys.stderr)
+    return code_out
+
+
+if __name__ == '__main__':
+    import cli_banner
+    cli_banner.install()
+    sys.exit(main())

--- a/kicad_routing_plugin/swig_gui.py
+++ b/kicad_routing_plugin/swig_gui.py
@@ -754,6 +754,23 @@ class RoutingDialog(wx.Dialog):
             else:
                 netclass = _get_netclass_parameters('Default') or {}
                 board_val = netclass.get(name)
+            # A declared 0 is UNSET, not a floor of zero -- KiCad writes 0 into
+            # these fields for "not configured". Every other resolver in the
+            # tree applies that rule (list_nets.board_floor / board_floor_knobs,
+            # resolve_cli_floor, and _effective_plane_edge_clearance just above,
+            # which already guarded `> 1e-9`); this branch tested only
+            # `is not None` and so diverged from the CLI.
+            #
+            # Masked in the default tier, because _fab_floored then pins a 0.0
+            # up to the 0.2 fab hole-to-hole floor and the CLI lands on 0.2
+            # too. NOT masked once the fab floor moves: with a --fab-overrides
+            # declaring hole_to_hole 0.10 (fab_floor_ladder collapses to that
+            # one hard rung, and the GUI reaches it through the fab_tier /
+            # fab_overrides_path controls), a board declaring 0.0 resolved to
+            # GUI 0.1 against CLI 0.2 -- the GUI drilling twice as close as the
+            # CLI on the same board and the same settings.
+            if board_val is not None and board_val <= 0:
+                board_val = None
             val = board_val if board_val is not None else getattr(self, name).GetValue()
         return self._fab_floored(name, val)
 

--- a/py_placer/converge.py
+++ b/py_placer/converge.py
@@ -47,6 +47,7 @@ import _path  # noqa: F401  (py_placer -> py_router/py_tools on sys.path)
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -152,6 +153,177 @@ def check_rip_invariants(nets, rip_set, power_nets=(), impedance_nets=()):
     return out
 
 
+# ------------------------------------------- a lens verdict against the score
+
+#: lens name -> the score components a PASS on it CONTRADICTS.
+#:
+#: Only lenses whose subject is unambiguous are listed. `connectivity` asks "is
+#: every net actually joined", which is exactly `unrouted` + `broken`; `drc`
+#: asks "does the copper break a rule", which is `drc` + `undersized`. `spec` is
+#: deliberately ABSENT: it covers impedance, length and net widths, every one of
+#: which is routinely ungraded, and an ungraded component contradicts nothing.
+LENS_COMPONENTS = {
+    'connectivity': ('unrouted', 'broken'),
+    'drc': ('drc', 'undersized'),
+}
+
+_LENS_RE = r'^VERDICT=(PASS|FAIL):lens=([A-Za-z0-9_-]+)'
+
+#: Stop conditions a `--final --kind completion` row may carry when a lens
+#: FAILED. Two vocabularies, both of record: the routing half's NUMBERS
+#: (convergence.md §3 -- 2 budget spent, 4 measured-unfixable) and the outer
+#: loop's verdict NAMES as `verdict` prints them and L5 interpolates them.
+#: DONE-EXHAUSTED is deliberately absent -- with a FAIL lens it is a
+#: contradiction, refused above the membership check.
+FAIL_COMPATIBLE_STOPS = ('2', '4', 'STUCK', 'BUDGET')
+
+
+def score_component(score, key):
+    """The graded count for `key`, or None when NOTHING measured it.
+
+    `blocking_by` first (board_score's own breakdown), then
+    `components[key]['count']` and only when that component actually `ran`.
+    None means UNGRADED, and that is the conservative half of every check
+    built on this: a component nobody graded can never contradict a verdict.
+    """
+    if not isinstance(score, dict):
+        return None
+    by = score.get('blocking_by')
+    if isinstance(by, dict) and key in by:
+        v = by.get(key)
+        return None if isinstance(v, bool) or not isinstance(v, (int, float)) \
+            else v
+    comp = (score.get('components') or {}).get(key)
+    if isinstance(comp, dict) and comp.get('ran') is True:
+        v = comp.get('count')
+        if not isinstance(v, bool) and isinstance(v, (int, float)):
+            return v
+    return None
+
+
+def _grades_another_board(board, score):
+    """Does this score payload demonstrably grade a DIFFERENT board?
+
+    True only when `board_sha` is present AND differs. Absent sha, unreadable
+    board, missing board_store: False -- "I could not tell" must not switch a
+    check off. Baseline rows legitimately attach a parent score to a rejected
+    candidate (record already WARNS about that), and a check that compared a
+    verdict about board A against board B's numbers would be the same class of
+    mistake it exists to catch.
+    """
+    psha = (score or {}).get('board_sha') if isinstance(score, dict) else None
+    if not psha or not board or not os.path.isfile(board):
+        return False
+    try:
+        from board_store import sha256_file
+        return sha256_file(board) != psha
+    except Exception:                                           # noqa: BLE001
+        return False
+
+
+def lens_contradictions(lenses, score):
+    """[(lens, component, count)] where a PASS verdict contradicts the score.
+
+    `record --lens` took the verdict string VERBATIM and validated only its
+    FORMAT, so nothing ever compared it against the numbers sitting in the same
+    row. Measured (run 17, ledger iteration 21): a `--final` row carrying
+    `VERDICT=PASS:lens=connectivity` on a score reporting unrouted 32 and
+    broken 47, while route.log -- 2.65 MB and 19 JSON_SUMMARY blocks -- held
+    ZERO `VERDICT=` lines, because no verifier had ever run. That row passed L3,
+    L4 and L5 untested and was corrected only because a human challenged it.
+
+    The row already carries the score, so the contradiction is arithmetic.
+    Conservative by construction: only a component with a DEFINITE positive
+    count contradicts, a null never does, and a FAIL verdict is honest about
+    any number at all.
+    """
+    out = []
+    for raw in (lenses or []):
+        m = re.match(_LENS_RE, str(raw or '').strip())
+        if not m or m.group(1) != 'PASS':
+            continue
+        # CASE-FOLDED. The grammar accepts [A-Za-z0-9_-]+ and the table is
+        # lower-case, so `lens=Connectivity` matched the format check, missed
+        # the table, and was written -- the whole gate bypassed by a shift key.
+        for key in LENS_COMPONENTS.get(m.group(2).lower(), ()):
+            n = score_component(score, key)
+            if isinstance(n, (int, float)) and n > 0:
+                out.append((m.group(2), key, n))
+    return out
+
+
+# ------------------------------------------- two scores that measured the same
+
+#: The flag that makes each component gradeable, when the score itself does not
+#: say. board_score's own `components[k].reason` names it verbatim ("no
+#: --impedance-nets given; impedance is ungraded"), so that is preferred and
+#: this is only the fallback for a payload that carries `ungraded` alone.
+_UNGRADED_FLAG = {'floorplan': '--intent', 'impedance': '--impedance-nets',
+                  'length': '--length-groups', 'net_widths': '--net-min-widths'}
+
+
+def ungraded_set(score):
+    """Which components this score did NOT measure, or None if unknowable.
+
+    Two sources, unioned, because either can be absent: board_score's own
+    `ungraded` list, and every key `blocking_by` reports as null. A null in
+    `blocking_by` IS the component saying it did not answer.
+    """
+    if not isinstance(score, dict):
+        return None
+    out, seen = set(), False
+    ung = score.get('ungraded')
+    if isinstance(ung, list):
+        out |= {str(x) for x in ung}
+        seen = True
+    by = score.get('blocking_by')
+    if isinstance(by, dict):
+        out |= {str(k) for k, v in by.items() if v is None}
+        seen = True
+    return out if seen else None
+
+
+def commensurability(old, new):
+    """(differ, hint, false_improvement) -- or None when the two are comparable.
+
+    Two `blocking` totals are only comparable if they are totals over the SAME
+    components. Measured (run 17, cycles 2 and 3 of the same board): 78 against
+    79, and a decision taken on the difference. Graded commensurably -- with
+    --impedance-nets, which neither run passed and which the board warrants --
+    both score 92 (32 unrouted / 46 broken, tied net for net), and the board
+    called WORSE was one impedance crossing BETTER. The whole gap was which
+    components each run happened to measure.
+
+    `false_improvement` is the dangerous shape: `blocking` went DOWN while the
+    graded set got strictly SMALLER. Routing accepts a lap on strict improvement
+    of `blocking`, so a lap that quietly measures one fewer component looks like
+    progress and enters the ledger as a false monotone trend.
+    """
+    a_ung, b_ung = ungraded_set(old), ungraded_set(new)
+    if a_ung is None or b_ung is None:
+        return None                     # nothing to compare against
+    differ = sorted(a_ung ^ b_ung)
+    if not differ:
+        return None
+    bits = []
+    for k in differ:
+        why = ''
+        for side in (old, new):
+            comp = ((side or {}).get('components') or {}).get(k) \
+                if isinstance(side, dict) else None
+            if isinstance(comp, dict) and comp.get('ran') is False \
+                    and comp.get('reason'):
+                why = str(comp['reason'])
+                break
+        bits.append(f'{k} ({why or _UNGRADED_FLAG.get(k, "no flag recorded")})')
+    ob, nb = (old or {}).get('blocking'), (new or {}).get('blocking')
+    false_improvement = (
+        isinstance(ob, (int, float)) and isinstance(nb, (int, float))
+        and not isinstance(ob, bool) and not isinstance(nb, bool)
+        and nb < ob and b_ung > a_ung)   # graded strictly FEWER components
+    return differ, '; '.join(bits), false_improvement
+
+
 # ------------------------------------------------------------------ the verbs
 
 class _StdoutToStderr:
@@ -199,19 +371,36 @@ def cmd_poses(a):
                                    board_edge_clearance=board_edge_clearance)
     diag = {}
     with _StdoutToStderr():
+        # Armed INSIDE the guard: this verb's stdout is a JSON document, and
+        # krt_deadline's DEADLINE:/PROGRESS: lines would land in the middle of
+        # it. The guard sends them to stderr, where they belong.
+        import krt_deadline
+        _dl = krt_deadline.arm(a.deadline, tool='converge poses')
         poses = pose_score.rank_poses(pcb, a.board, a.ref, radius=a.radius,
                                       step=a.step, limit=a.limit, state=st,
-                                      diagnostics=diag)
+                                      diagnostics=diag,
+                                      cancel_check=(_dl.cancel_check('sweep')
+                                                    if _dl else None))
     if not poses:
         # The dropped-pose census is the difference between "this part has
         # nowhere to go" and "your knobs veto even staying put" (run-7 S4:
         # flip-in-place WAS enumerated, then silently dropped).
+        _cut = bool(diag.get('stopped_early'))
         print(json.dumps({'ref': a.ref, 'poses': [], 'knobs': knobs,
                           'dropped_total': diag.get('dropped_total', 0),
                           'dropped_in_place': diag.get('dropped_in_place', []),
-                          'note': 'no legal pose, including staying put'},
+                          'stopped_early': _cut,
+                          # "no legal pose" is a VERDICT about the part. A cut
+                          # sweep has not earned it: with --deadline 0 the
+                          # check fires before even the identity offset, so the
+                          # old text diagnosed a part whose poses were never
+                          # enumerated.
+                          'note': ('the sweep was cut by --deadline before it '
+                                   'finished -- this is NOT a verdict about '
+                                   'the part' if _cut else
+                                   'no legal pose, including staying put')},
                          indent=1))
-        return 1
+        return 2 if _cut else 1
 
     if a.route:
         if not a.affected:
@@ -233,7 +422,12 @@ def cmd_poses(a):
                 p['route'] = {'failures': n, 'note': note,
                               'iterations': res['summary'].get('total_iterations'),
                               'vias': res['summary'].get('total_vias')}
-    print(json.dumps({'ref': a.ref, 'base_cost': poses[0]['cost'] - poses[0]['delta'],
+    # A cut sweep returns a DIFFERENT best pose with a byte-identical document
+    # shape -- measured, r=3/s=0.25: full ran 176s and chose rot 0; the same
+    # call with --deadline 4 ran 7s and chose rot 90, with no key marking it
+    # partial. A ranking nobody can tell is partial is worse than a slow one.
+    print(json.dumps({'ref': a.ref, 'stopped_early': bool(diag.get('stopped_early')),
+                      'base_cost': poses[0]['cost'] - poses[0]['delta'],
                       'knobs': knobs,
                       'dropped_total': diag.get('dropped_total', 0),
                       'dropped_in_place': diag.get('dropped_in_place', []),
@@ -281,6 +475,30 @@ def cmd_where(a):
 
 def cmd_record(a):
     from board_store import BoardStore, Ledger
+    # --score-file: the payload as a PATH, not as argv.
+    #
+    # `--score` is JSON text, and every caller passes `--score "$(cat ...)"`.
+    # board_score payloads run 24-49 kB (they repeat every net name in both
+    # `unrouted.nets` and `connectivity_nets`, and carry the whole assembly
+    # `pairs` array), so past roughly 32 kB of total argv the SHELL fails with
+    # `Argument list too long` and exits 126 -- before `record` ever execs.
+    # Nothing is written, and because the 126 belongs to the shell rather than
+    # to this tool, a caller who does not re-count the ledger rows sees no
+    # error at all. Run 9 lost a lap that way and found it only by chance.
+    #
+    # `verdict --score` was already a path (it is open()ed), so this makes the
+    # two subcommands agree rather than inventing a convention.
+    if getattr(a, 'score_file', None):
+        if a.score:
+            print("record: pass --score OR --score-file, not both.",
+                  file=sys.stderr)
+            return 2
+        try:
+            with open(a.score_file, encoding='utf-8') as _sf:
+                a.score = _sf.read()
+        except OSError as _e:
+            print(f"record: --score-file unreadable: {_e}", file=sys.stderr)
+            return 2
     # Refuse an --argv that can never replay (run-7 F4: entries recorded with
     # placeholder script names made replay a reconstruction, which is exactly
     # what the ledger exists to prevent). Nothing is written on refusal.
@@ -294,14 +512,127 @@ def cmd_record(a):
                   f"produced the board), or omit --argv for a prose-only "
                   f"entry. Nothing was written.", file=sys.stderr)
             return 2
-    # A run-closing record must name its stop condition (run-7 F5: the final
-    # entry shipped a headline count that contradicted the oracle; forcing
-    # the stop condition into the record is what makes the close-out gradable).
+    # Lens verdicts are stored RAW, so the grammar stays owned by
+    # verifier-prompts.md and a malformed line stays visible instead of being
+    # normalised into something that reads like a pass. Refuse the shape at
+    # write time -- same posture as --argv above -- so the ledger never holds a
+    # row that cannot be read back.
+    if a.lens:
+        _badl = [v for v in a.lens if not re.match(_LENS_RE, v.strip())]
+        if _badl:
+            print("record: --lens takes the verifier's VERDICT= line verbatim, "
+                  "e.g. 'VERDICT=PASS:lens=connectivity' or "
+                  "'VERDICT=FAIL:lens=drc;finding=...;evidence=...'. "
+                  f"Not: {_badl[0]!r}. Nothing was written.", file=sys.stderr)
+            return 2
+    # THE VERDICT AGAINST THE NUMBERS IN THE SAME ROW. Format was the only
+    # thing ever checked, so a PASS could be recorded beside the score that
+    # refutes it -- see lens_contradictions for the measured row. Refuse before
+    # anything is written, the same posture as --argv and the lens grammar.
+    _score_doc = None
+    if a.score:
+        try:
+            _score_doc = json.loads(a.score)
+        except Exception:                                       # noqa: BLE001
+            _score_doc = None
+    if a.lens and isinstance(_score_doc, dict) and \
+            _grades_another_board(a.board, _score_doc):
+        # NEVER SILENT. The skip is correct -- a verdict about this board must
+        # not be judged with another board's numbers -- but an unannounced
+        # skip is a door: attach any other board's score and the whole gate
+        # switches off. Say that it did not run, and why.
+        print("record NOTE: the lens-vs-score check did NOT run -- the score "
+              "payload's board_sha names a different board than --board, so "
+              "its numbers are not about the board these verdicts describe. "
+              "The lens verdicts below are recorded UNCHECKED.",
+              file=sys.stderr)
+    elif a.lens and isinstance(_score_doc, dict):
+        _contra = lens_contradictions(a.lens, _score_doc)
+        if _contra:
+            _lines = '\n'.join(
+                f'    VERDICT=PASS:lens={lens}   vs   score {comp} = {n:g}'
+                for lens, comp, n in _contra)
+            print(
+                f"record: a lens verdict CONTRADICTS the score in this same "
+                f"row.\n{_lines}\n\n"
+                f"A PASS is a claim about the board, and the numbers being "
+                f"recorded beside it say otherwise. Measured (run 17): a "
+                f"--final row carried VERDICT=PASS:lens=connectivity on 32 "
+                f"unrouted nets and 47 broken joins, and the route log held no "
+                f"VERDICT= line at all -- no verifier had run. That row passed "
+                f"L3, L4 and L5 untested.\n\n"
+                f"Either fix the board and re-score it, or record what the "
+                f"verifier actually found:\n"
+                f"  --lens 'VERDICT=FAIL:lens={_contra[0][0]};finding=<what is "
+                f"wrong>;evidence=<file#/path/to/the/number>'\n\n"
+                f"An UNGRADED component (null) is never a contradiction, so "
+                f"this only fires on a count that was measured. Nothing was "
+                f"written.", file=sys.stderr)
+            return 2
+    # THE DECLARATION THE VERDICT TEXT ALREADY PROMISED. `verdict`'s own
+    # too-few-laps sentence offers two levers -- "give it something further to
+    # optimise (or to say on the record that there is nothing)" -- and only the
+    # first had a mechanism. This is the parenthetical: a row that says a half
+    # has nothing further, WITH A REASON, in the one place the loop reads.
+    # A reason is mandatory because the declaration is the claim; without it
+    # this would be --flat by another name.
+    if a.exhausted and not (a.exhausted_reason or '').strip():
+        print(f"record: --exhausted {a.exhausted} needs "
+              f"--exhausted-reason \"<what was tried and why nothing is "
+              f"left>\". The declaration IS the evidence -- an unreasoned one "
+              f"is just a lower --flat with extra steps. Nothing was written.",
+              file=sys.stderr)
+        return 2
     if a.final and not a.stop_condition:
         print("record: --final requires --stop-condition (which of the run's "
               "stop conditions ended it). Nothing was written.",
               file=sys.stderr)
         return 2
+    # A run-closing record must carry the routed-board lenses. `blocking == 0`
+    # and "every lens passes" are two different claims and the second had no
+    # mechanism at all -- verifier-prompts.md states the conjunct and nothing
+    # computed it, so a close-out could be written with no lens ever dispatched.
+    if a.final and a.kind == 'completion':
+        _seen = set()
+        for v in (a.lens or []):
+            _m = __import__('re').match(r'^VERDICT=(PASS|FAIL):lens=([A-Za-z0-9_-]+)',
+                                        v.strip())
+            if _m:
+                _seen.add(_m.group(2))
+        _need = {'connectivity', 'drc', 'spec'}
+        _miss = sorted(_need - _seen)
+        if _miss:
+            print(f"record: --final needs the routed-board lenses and is "
+                  f"missing {', '.join(_miss)}. Dispatch them "
+                  f"(routing_driver --stage V5 fans them out) and pass each "
+                  f"VERDICT= line as --lens. `blocking == 0` is not `every "
+                  f"lens passes`. Nothing was written.", file=sys.stderr)
+            return 2
+        _failed = [v for v in (a.lens or []) if v.strip().startswith('VERDICT=FAIL')]
+        _sc = (a.stop_condition or '').strip()
+        # TWO STOP VOCABULARIES ARE OF RECORD, and both must be acceptable as
+        # printed: the routing half closes on the NUMBERS of convergence.md §3,
+        # and the outer loop's L5 interpolates the verdict NAMES this tool's
+        # own `verdict` subcommand prints. L5's command was refused verbatim
+        # here for exactly that gap -- a FAIL lens is the NORMAL case on the
+        # STUCK/BUDGET paths. DONE-EXHAUSTED is the exception: done-and-
+        # measured-done IS the all-lenses-pass claim.
+        if _failed and _sc == 'DONE-EXHAUSTED':
+            print(f"record: {len(_failed)} lens FAILED under --stop-condition "
+                  f"DONE-EXHAUSTED. Done-and-measured-done IS the every-lens-"
+                  f"passes claim, so a FAIL beside it is the contradiction "
+                  f"L5's cross-check exists to refuse. Record STUCK or BUDGET "
+                  f"(or fix the board and re-dispatch the lens), never a done "
+                  f"a lens denies. Nothing was written.", file=sys.stderr)
+            return 2
+        if _failed and _sc not in FAIL_COMPATIBLE_STOPS:
+            print(f"record: {len(_failed)} lens FAILED, so this run did not "
+                  f"finish clean -- --stop-condition must be 2 (budget spent), "
+                  f"4 (measured-unfixable and said so), or the loop verdict "
+                  f"naming the same thing (STUCK, BUDGET), not "
+                  f"{a.stop_condition!r}. A FAIL means `blocking` was not "
+                  f"really zero. Nothing was written.", file=sys.stderr)
+            return 2
     store = BoardStore(a.store or os.path.join(os.path.dirname(a.ledger), 'boards'))
     sha = store.put(a.board)
     # Run-3 B4: three ledger entries shipped carrying a PRIOR board's score
@@ -351,7 +682,25 @@ def cmd_record(a):
     #     not change a board, so an entry whose argv is a checker records no
     #     lever at all -- the board moved for a reason the ledger did not keep.
     if a.argv:
-        _exe = os.path.basename(str(a.argv[0])).lower()
+        # Skip past the interpreter to the SCRIPT. This guard inspected
+        # argv[0], which is `python3` for every invocation the doctrine
+        # teaches (`python3 -X utf8 <script> ...`) -- so it had never fired
+        # once, on any entry, in any run. The same blindness applies to the
+        # replay guard above, which was validating that an interpreter exists
+        # rather than that a command can replay.
+        _toks = [str(t) for t in a.argv]
+        _script = ''
+        for _t in _toks:
+            _base = os.path.basename(_t).lower()
+            if _base.endswith('.py'):
+                _script = _base
+                break
+            if _base.startswith('python') or _t.startswith('-') or \
+                    _base in ('utf8', 'timeout', 'env', 'nice'):
+                continue
+            _script = _base
+            break
+        _exe = _script or os.path.basename(_toks[0]).lower()
         if _exe.endswith('.py'):
             _exe = _exe[:-3]
         _stem = _exe.split()[0]
@@ -373,17 +722,98 @@ def cmd_record(a):
                   f"order is meant to be the order things happened; a "
                   f"back-filled entry cannot support that claim.",
                   file=sys.stderr)
+    # (4) A score that measured a DIFFERENT SET OF COMPONENTS than the lap it
+    #     will be compared against. `blocking` is a total, and two totals over
+    #     different component sets are not larger and smaller versions of each
+    #     other -- see commensurability() for the measured 78-vs-79 that was
+    #     really 92-vs-92. Warned always; REFUSED only in the one shape that is
+    #     definitely a false improvement, because that is the shape routing's
+    #     accept rule turns into an accepted lap.
+    _half = _HALF.get(a.kind)
+    if _half and isinstance(_score_doc, dict):
+        _pacc = None
+        for _r in reversed(_prior):
+            if _r.get('accepted') and _HALF.get(_r.get('kind')) == _half \
+                    and isinstance(_r.get('score'), dict):
+                _pacc = _r
+                break
+        _cm = commensurability((_pacc or {}).get('score'), _score_doc) \
+            if _pacc else None
+        if _cm:
+            _differ, _hint, _false = _cm
+            if _false and not a.rejected and not a.accept_incommensurable:
+                print(
+                    f"record: this lap looks like an IMPROVEMENT only because "
+                    f"it graded FEWER components.\n"
+                    f"  blocking {(_pacc.get('score') or {}).get('blocking')} "
+                    f"-> {_score_doc.get('blocking')}, but the components that "
+                    f"differ are: {_hint}\n\n"
+                    + (f"Routing accepts a lap on STRICT improvement of "
+                       f"`blocking`, so " if _half == 'routing' else
+                       f"This half's laps are ranked by `blocking` and the "
+                       f"plateau test compares them, so ") +
+                    f"a lap that quietly measures one component "
+                    f"less enters the ledger as progress and the history "
+                    f"acquires a false monotone trend. Measured (run 17): two "
+                    f"cycles compared as 78 vs 79 were 92 vs 92 once both were "
+                    f"graded with --impedance-nets, and the board called worse "
+                    f"was one impedance crossing better.\n\n"
+                    f"Re-score this board with the SAME flags as iteration "
+                    f"{_pacc.get('iteration')}, or record it "
+                    f"--rejected, or say why the comparison stands anyway:\n"
+                    f"  --accept-incommensurable \"<the reason>\"\n"
+                    f"Nothing was written.", file=sys.stderr)
+                return 2
+            print(f"record WARNING: INCOMMENSURABLE with iteration "
+                  f"{_pacc.get('iteration')}, the last accepted {_half} lap: "
+                  f"the two scores did not grade the same components "
+                  f"({_hint}). `blocking` is a total, so the difference "
+                  f"between these two rows is partly a difference in what was "
+                  f"MEASURED, not in the board.", file=sys.stderr)
     prev = lg.last_accepted()
     entry = {'iteration': len(lg.entries()), 'kind': a.kind,
              'parent_sha': (prev or {}).get('result_sha'),
              'result_sha': sha, 'lever': a.lever,
              'lever_argv': list(a.argv) if a.argv else None,
              'score': json.loads(a.score) if a.score else None,
+             'renders': list(a.render_json) if a.render_json else None,
+             'lenses': list(a.lens) if a.lens else None,
+             # Split on whitespace and commas so `--scope-refs "$(cat locks.txt)"`
+             # records 45 refs rather than one 45-ref string.
+             'scope_refs': ([t for chunk in a.scope_refs
+                             for t in re.split(r'[\s,]+', chunk) if t]
+                            or None) if a.scope_refs else None,
              'accepted': not a.rejected}
+    # A placement lap moved parts. The skill mandates the move be LOOKED AT,
+    # and run 9 skipped that for an entire campaign without anything noticing
+    # -- including afterwards, because the record kept no trace either way. A
+    # warning, not a refusal: a rejected lap or a no-move gate row legitimately
+    # has nothing to show. But silence must stop being indistinguishable from
+    # compliance.
+    if a.kind == 'placement' and not a.render_json and not a.rejected:
+        print("record NOTE: this placement lap records no --render-json. The "
+              "read mandates are only auditable through the ledger; without "
+              "one, a skipped read and an absent trigger look identical later. "
+              "Attach the render you read, or say in --lever why there was "
+              "no trigger.", file=sys.stderr)
     if a.final:
         entry['final'] = True
         entry['stop_condition'] = a.stop_condition
+    if a.exhausted:
+        entry['exhausted'] = {'half': a.exhausted,
+                              'reason': a.exhausted_reason.strip()}
+    if a.accept_incommensurable:
+        # The disposition belongs in the row, not only in the console the
+        # refusal was cleared from. Same shape as --exhausted: what is recorded
+        # is that somebody decided, not that the numbers passed.
+        entry['accepted_incommensurable'] = str(a.accept_incommensurable).strip()
     e = lg.append(entry)
+    if a.exhausted:
+        print(f"recorded: {a.exhausted} declared EXHAUSTED. `verdict` will "
+              f"stop asking that half to plateau, and the reason is in the "
+              f"ledger where the film and every re-entry read it. A later "
+              f"recorded lap of that half SUPERSEDES this declaration.",
+              file=sys.stderr)
     print(json.dumps(e, indent=1, sort_keys=True))
     # Failing-net NAMES belong in the record (run-7 S10/F5): a score that
     # carries only a count forces every later read to re-derive which nets,
@@ -446,6 +876,392 @@ def cmd_replay(a):
     return subprocess.run(argv, cwd=ROOT).returncode
 
 
+CONTINUE, DONE, STUCK, BUDGET = 4, 0, 5, 6
+
+#: Which half of the loop a ledger row belongs to. `systemic` is neither -- it
+#: changes how the chain measures itself, not the board -- so it can never make
+#: a half look like it is still improving.
+_HALF = {'placement': 'placement', 'completion': 'routing'}
+
+
+def _score_key(score):
+    """(blocking, quality) as a comparable tuple, or None if not gradeable.
+
+    Lexicographic, never a weighted sum: a weighted sum lets a router buy off a
+    disconnected net with a lower via count. `blocking == None` is NOT zero --
+    it means a component that was asked for could not answer -- so it sorts
+    worse than any real number rather than reading as a perfect board.
+    """
+    if not isinstance(score, dict):
+        return None
+    b = score.get('blocking')
+    q = score.get('quality') or {}
+    # A quality tuple carrying None (board_score.quality returns {'error': ...}
+    # when the board will not parse) makes min() raise TypeError the moment two
+    # rows tie on `blocking`. Untested until now because the self-tests use a
+    # uniform empty quality. Sort unknowns LAST rather than crashing.
+    quality = tuple(v if isinstance(v, (int, float)) else float('inf')
+                    for v in (q.get('vias'), q.get('copper_mm'),
+                              q.get('segments')))
+    if b is None:
+        # NOT `inf`. A row whose score never measured `blocking` used to rank
+        # as the worst possible board, and `inf >= inf` then made the plateau
+        # test TRUE -- so an unmeasured lap read as a plateaued one, which is
+        # the opposite of what it is. Returning None drops it from the window
+        # entirely (the callers already filter None), so a half is judged on
+        # laps that actually measured something.
+        return None
+    return (b, quality)
+
+
+def _declaration(rows, half):
+    """(reason, live) for the last `--exhausted <half>` row, else None.
+
+    `live` is False when a lap of that half was recorded AFTER the declaration:
+    the half went back to work, so the claim "there is nothing further" is
+    stale. Superseding it needs no flag and no deletion -- running the half
+    again is the retraction.
+    """
+    found, live = None, False
+    for r in rows:
+        dec = r.get('exhausted')
+        if isinstance(dec, dict) and dec.get('half') == half:
+            found, live = (str(dec.get('reason') or '').strip()
+                           or 'no reason recorded'), True
+        elif found is not None and _HALF.get(r.get('kind')) == half:
+            live = False
+    return None if found is None else (found, live)
+
+
+def _half_state(rows, half, flat):
+    """Can this half still improve? -- with the evidence it was decided from.
+
+    Returns a dict: flat, laps, accepted, rejected, why, and (when they apply)
+    declared / declared_superseded / incommensurable / compared. `why` is one of
+    declared-exhausted, too-few-laps, no-comparison, plateau, improving.
+
+    THE COUNTER COUNTS REJECTED LAPS TOO, and that is the fix for a gate that
+    could not be satisfied. It used to count accepted rows only, while L5's own
+    closing paragraph instructs "Record the lap you are about to run, accepted
+    or rejected. A rejected lap is data" -- so recording a rejected lap could
+    not satisfy the gate it was offered for. Worse, routing accepts a lap only
+    on STRICT improvement, so a half that is genuinely exhausted has no honest
+    accepted lap left to produce: the gate demanded the one thing a finished
+    half cannot make. A recorded rejection is exactly the evidence that a half
+    tried and did not improve, which is what a plateau IS.
+
+    An accepted lap whose score never measured `blocking` COUNTS AS A LAP but
+    carries no key, so it can be compared with nothing. Dropping it entirely
+    was worse than it looks: on the real run-17 ledger the placement half then
+    read `plateau` from a window of two cycle-1 accepted laps plus three
+    cycle-2 REJECTIONS, while five accepted cycle-2 laps were invisible for
+    having `score: null`. A half that ran five laps must not read as one that
+    stopped. A rejection needs no score, because the rejection is itself the
+    measurement.
+
+    Measured (neo6502, run 15): the placement half satisfied its OWN close-out
+    in 4 accepted laps -- every gate clean, residue named -- against a --flat of
+    5. It could never plateau, so L5 returned CONTINUE forever while reporting
+    the half as "still improving", which it was not.
+    """
+    dec = _declaration(rows, half)
+    ev = []                      # (accepted, key, score) in ledger order
+    for r in rows:
+        if _HALF.get(r.get('kind')) != half:
+            continue
+        if not r.get('accepted'):
+            ev.append((False, None, r.get('score')))
+            continue
+        ev.append((True, _score_key(r.get('score')), r.get('score')))
+    n_acc = sum(1 for e in ev if e[0])
+    out = {'laps': len(ev), 'accepted': n_acc, 'rejected': len(ev) - n_acc,
+           'flat': False, 'why': 'too-few-laps'}
+    if dec and dec[1]:
+        out.update(flat=True, why='declared-exhausted', declared=dec[0])
+        return out
+    if dec and not dec[1]:
+        out['declared_superseded'] = dec[0]
+    if len(ev) < flat:
+        # NOT the same as "still improving" -- say which. The threshold is
+        # `flat` and the test is `<`: a window of exactly `flat` laps is
+        # answerable, and the guard used to be `<=`, which demanded flat+1
+        # while the refusal text said flat. It read as self-contradictory
+        # because it was.
+        return out
+    window = ev[-flat:]
+    if not any(acc for acc, _k, _s in window):
+        # Every lap in the window was REJECTED. Nothing improved, by
+        # construction -- that is a plateau stated by the half itself.
+        out.update(flat=True, why='plateau')
+        return out
+    # Did this half improve ACROSS ITS OWN last `flat` laps?
+    #
+    # `best_before = min(keys[:-flat])` asked a different question: has the
+    # window beaten the best lap EVER seen before it. One large early
+    # improvement then pins the bar for the rest of the run. Measured on run 9:
+    # the pour took the routing half to 297 on its first lap, and the series
+    # [297, 371, 365, 340, 330, 320] -- a necessary rise at the fanout, then
+    # five laps of strict improvement -- reported flat:true, because 320 never
+    # beat 297. A half that is demonstrably still moving read as plateaued,
+    # which is exactly the DONE-vs-STUCK confusion this function exists to
+    # prevent.
+    #
+    # (Replacing it with `keys[-flat-1]` does NOT fix that case -- on a
+    # 6-lap ledger that IS the 297. The baseline has to be the window's own
+    # first lap.)
+    #
+    # ...AND IMPROVEMENT IS ONLY CREDITED WITHIN A COMPARABLE RUN. Two
+    # `blocking` totals over different component sets are not larger and
+    # smaller versions of each other, so a drop across such a pair is not
+    # evidence that the half improved -- it may be evidence that it measured
+    # less. The window is split into maximal runs of consecutive laps that
+    # actually compare (both scored, same graded set), and the half is
+    # `improving` if ANY run shows a lap beating that run's own first lap.
+    #
+    # It is deliberately NOT "judge the leading run and discard the rest": that
+    # is what this did first, and one incommensurable pair at the FRONT then
+    # collapsed the window to a single lap, where `min(keys[:1]) >= keys[0]` is
+    # a tautology. Measured on the fix itself: the series 78 -> 70 -> 60 -> 50
+    # -> 40, four consecutive comparable improvements of 10 each, reported
+    # `plateau` and ended the run at STUCK because the FIRST pair did not
+    # compare. Guarding against a false improvement must not manufacture a
+    # false plateau; both are the same error.
+    # Comparability is a property of TWO SCORES -- their graded component sets
+    # -- and of nothing else. So a rejection or an unscored lap is simply not
+    # in this sequence; it does not stand BETWEEN two scores and separate them.
+    # Making it break the run was a second false plateau, measured over all
+    # 7776 accept/reject windows of 5: 441 flipped `improving` -> `plateau`
+    # (78, 78, 78, REJ, 40 ended the run at STUCK on a half whose last lap took
+    # blocking 78 -> 40), and 2313 flipped `plateau` -> unanswerable, on the
+    # alternating accept/reject pattern that IS normal routing.
+    seq = [(k, s) for acc, k, s in window if acc and k is not None]
+    runs, cur, hints = [], [], []
+    for k, s in seq:
+        cm = commensurability(cur[-1][1], s) if cur else None
+        if cm:
+            hints.append(cm[1])
+            runs.append(cur)
+            cur = []
+        cur.append((k, s))
+    runs.append(cur)
+    runs = [[k for k, _s in r] for r in runs if len(r) >= 2]
+    # An ACCEPTED lap that recorded no `blocking` is unjudged, and a plateau
+    # asserted over unjudged laps is the "reported clean because unexamined"
+    # error this toolchain names everywhere else. An improvement, by contrast,
+    # is a DEFINITE finding and stands whatever else is in the window. So:
+    # improvement wins; a plateau requires every accepted lap to have been
+    # judged; anything else is not answerable and says so. A REJECTION is not
+    # unjudged -- the rejection is itself the measurement.
+    unjudged = sum(1 for acc, k, _s in window if acc and k is None)
+    if any(min(r) < r[0] for r in runs):
+        out.update(flat=False, why='improving')
+    elif runs and not unjudged:
+        out.update(flat=True, why='plateau')
+    else:
+        # Answerable again after one more comparable lap, after `flat`
+        # rejections, or by declaring the half exhausted on the record. NAME
+        # the cause: these three call for different actions, and a message
+        # that guesses tells a still-improving half to declare itself finished.
+        out.update(flat=False, why='no-comparison', unjudged=unjudged,
+                   blocked=('unjudged' if unjudged else
+                            'incommensurable' if hints else 'single-lap'))
+    if hints:
+        out['incommensurable'] = '; '.join(sorted(set(hints)))
+        out['compared'] = sum(len(r) for r in runs)
+    return out
+
+
+def _half_is_flat(rows, half, flat):
+    """(is_flat, n_laps, reason) -- the tuple view of _half_state."""
+    st = _half_state(rows, half, flat)
+    return st['flat'], st['laps'], st['why']
+
+
+def _halves_note(st):
+    """One line naming HOW each half came to be blocked.
+
+    A DONE reached because a half was DECLARED exhausted is a different claim
+    from one reached by five measured laps, and the terminal artifact has to
+    say which -- the declaration carries a human's reason, not a measurement.
+    """
+    bits = []
+    for h in ('placement', 'routing'):
+        s = st[h]
+        if s.get('why') == 'declared-exhausted':
+            bits.append(f'{h}: DECLARED exhausted -- {s.get("declared")}')
+        else:
+            bits.append(f'{h}: {s["laps"]} laps, {s["accepted"]} accepted + '
+                        f'{s["rejected"]} rejected')
+    return '; '.join(bits)
+
+
+def cmd_verdict(a):
+    """Continue, or stop -- and say WHICH kind of stop it was.
+
+    Every stop RULE in this toolchain is written down (a 5-lap placement cap,
+    four routing stop conditions, a budget of 100, "5 consecutive flat") and
+    not one of them had a MECHANISM: no counter, no budget check, no read of
+    the ledger that gated continuation. `final` and `stop_condition` were
+    written and never read back. So a run that stopped because it was finished
+    and a run that stopped because it was stuck produced the same artifact.
+
+    Reaching `blocking == 0` is the FLOOR, not the finish. The score is
+    lexicographic (blocking, quality) and quality orders the boards that
+    already got there, so the loop keeps pulling levers on the second key and
+    stops only when NEITHER half can improve EITHER key -- which is what
+    "fully blocked in both placement and routing" means, measured.
+    """
+    from board_store import Ledger
+    rows = Ledger(a.ledger).entries()
+    score, err = None, None
+    if a.score:
+        try:
+            with open(a.score, encoding='utf-8') as fh:
+                score = json.load(fh)
+        except Exception as exc:                            # noqa: BLE001
+            err = f'{type(exc).__name__}: {exc}'
+    if score is None:
+        print(json.dumps({'verdict': 'NO-SCORE', 'reason': (
+            err or '--score is required: the verdict is about a board, and '
+            'without its score there is nothing to be blocked or done ABOUT.'
+        )}, indent=1, sort_keys=True))
+        return 2
+
+    scored = [r for r in rows if _score_key(r.get('score')) is not None]
+    key = _score_key(score)
+    blocking = key[0]
+    st = {h: _half_state(rows, h, a.flat) for h in ('placement', 'routing')}
+    flat_p, flat_r = st['placement']['flat'], st['routing']['flat']
+    laps_p, laps_r = st['placement']['laps'], st['routing']['laps']
+    why_p, why_r = st['placement']['why'], st['routing']['why']
+
+    doc = {'ledger_rows': len(rows), 'scored_rows': len(scored),
+           'budget': a.budget, 'flat': a.flat,
+           'blocking': None if blocking == float('inf') else blocking,
+           'quality': score.get('quality'),
+           'ungraded': sorted(score.get('ungraded') or []),
+           'unknown': sorted(score.get('unknown') or []),
+           # `accepted_laps` is kept and still means accepted laps only; `laps`
+           # is what the plateau test counts, and it counts REJECTED laps too
+           # -- see _half_state. They differ, so both are published rather than
+           # one quietly changing meaning under a reader.
+           'placement': dict(st['placement'],
+                             accepted_laps=st['placement']['accepted']),
+           'routing': dict(st['routing'],
+                           accepted_laps=st['routing']['accepted'])}
+
+    if len(rows) >= a.budget:
+        doc.update(verdict='BUDGET', reason=(
+            f'{len(rows)} ledger entries written, budget {a.budget}. Report '
+            f'the best-scoring board AND every remaining blocker, itemised '
+            f'with its measurement.'))
+        code = BUDGET
+    elif not (flat_p and flat_r):
+        still = [h for h, f in (('placement', flat_p), ('routing', flat_r))
+                 if not f]
+        # Say WHICH of the two causes applies, per half. They call for opposite
+        # actions and the old sentence offered both at once.
+        _why = {'placement': why_p, 'routing': why_r}
+        _parts = []
+        for h in still:
+            if _why[h] == 'too-few-laps':
+                _parts.append(
+                    f'{h} has run {st[h]["laps"]} recorded lap(s) '
+                    f'({st[h]["accepted"]} accepted + {st[h]["rejected"]} '
+                    f'rejected), fewer than the {a.flat} this test needs, so '
+                    f'whether it plateaued is NOT YET ANSWERABLE -- which is '
+                    f'not the same as "it is still improving". A REJECTED lap '
+                    f'counts here: it is exactly the evidence that a half '
+                    f'tried and did not improve, and routing accepts only on '
+                    f'strict improvement, so an exhausted half has no honest '
+                    f'accepted lap left to give. Either give it something '
+                    f'further to optimise and record the lap (accepted or '
+                    f'rejected), or say on the record that there is nothing:\n'
+                    f'    python3 -X utf8 py_placer/converge.py record --ledger '
+                    f'{a.ledger} \\\n'
+                    f'        --board <the board> --kind systemic \\\n'
+                    f'        --exhausted {h} --exhausted-reason "<what was '
+                    f'tried and why nothing is left>" \\\n'
+                    f'        --lever "declaration: {h} has nothing further"\n'
+                    f'  Lowering --flat is not one of the options')
+            elif _why[h] == 'no-comparison':
+                _parts.append(
+                    f'{h} has {st[h]["laps"]} recorded lap(s) but no two of the '
+                    f'last {a.flat} can be COMPARED -- '
+                    + {'unjudged': (
+                        f'{st[h].get("unjudged")} accepted lap(s) in that '
+                        f'window recorded no `blocking`, and a lap that '
+                        f'measured nothing is evidence in neither direction'),
+                       'incommensurable': (
+                        f'they were not graded over the same components '
+                        f'({st[h].get("incommensurable")})'),
+                       'single-lap': (
+                        'only one of them carries a score, and one number '
+                        'compared with nothing is not a trend')}[
+                           st[h].get('blocked', 'single-lap')]
+                    + f'. So whether it plateaued is NOT ANSWERABLE, which is '
+                      f'not "it did not". Re-score its laps the same way, or '
+                      f'declare the half exhausted on the record:\n'
+                      f'    python3 -X utf8 py_placer/converge.py record --ledger '
+                      f'{a.ledger} \\\n'
+                      f'        --board <the board> --kind systemic \\\n'
+                      f'        --exhausted {h} --exhausted-reason "<what was '
+                      f'tried and why nothing is left>"')
+            else:
+                _parts.append(
+                    f'{h} improved within its last {a.flat} laps, so it has '
+                    f'more to give')
+        doc.update(verdict='CONTINUE', improving=still,
+                   why={h: _why[h] for h in still}, reason=(
+            '; '.join(_parts) + '. Reaching blocking == 0 is the floor, not '
+            'the finish -- keep pulling levers on quality until neither half '
+            'can improve either key.'))
+        code = CONTINUE
+    elif blocking == 0:
+        doc.update(verdict='DONE-EXHAUSTED', reason=(
+            'blocking == 0 and neither half improved in its last '
+            f'{a.flat} recorded laps ({_halves_note(st)}). This is the best '
+            f'board these levers found.'))
+        code = DONE
+    else:
+        doc.update(verdict='STUCK', reason=(
+            f'blocking == {doc["blocking"]} and neither half improved in its '
+            f'last {a.flat} recorded laps ({_halves_note(st)}). Stopping here '
+            f'is legitimate; calling the board finished is not. Itemise every '
+            f'remaining blocker with the measurement that proves it.'))
+        code = STUCK
+
+    # LOUD, on every verdict, never only on the one it happened to change.
+    # A plateau or an improvement read off two totals that graded different
+    # components is a claim about the instrument, not about the board.
+    for h in ('placement', 'routing'):
+        _ic = st[h].get('incommensurable')
+        if _ic:
+            doc['reason'] += (
+                f' NOT COMPARABLE: {h} laps in the window were graded over '
+                f'different components ({_ic}), so improvement was judged only '
+                f'within the {st[h].get("compared", 0)} lap(s) that do compare '
+                f'with each other. Measured '
+                f'(run 17): two cycles compared as 78 vs 79 were 92 vs 92 once '
+                f'both were graded with --impedance-nets, and the board called '
+                f'worse was one impedance crossing better. Re-score with the '
+                f'same flags to make the comparison mean anything.')
+    if doc['ungraded']:
+        # Not fatal: a board with no spec files has nothing to grade those
+        # components against, and making it fatal would put every corpus board
+        # permanently in STUCK. But it is never silent -- a component nothing
+        # examined is UNEXAMINED, and DONE must say so out loud.
+        doc['reason'] += (' UNEXAMINED, and not passed: '
+                          + ', '.join(doc['ungraded']) + '.')
+    if doc['unknown']:
+        doc['reason'] += (' A component RAN and could not answer: '
+                          + ', '.join(doc['unknown'])
+                          + ' -- fix the instrument before trusting any '
+                            'verdict here.')
+    print(json.dumps(doc, indent=1, sort_keys=True))
+    return code
+
+
 def cmd_status(a):
     from board_store import Ledger
     lg = Ledger(a.ledger)
@@ -469,7 +1285,15 @@ def build_parser():
     q.add_argument('--ref', required=True)
     q.add_argument('--radius', type=float, default=2.0)
     q.add_argument('--step', type=float, default=0.5)
-    q.add_argument('--limit', type=int, default=12)
+    q.add_argument('--limit', type=int, default=12,
+                   help='how many ranked poses to RETURN. It does not bound '
+                        'the sweep: every candidate is still evaluated. Use '
+                        '--deadline for that.')
+    q.add_argument('--deadline', type=float, default=None, metavar='SECONDS',
+                   help='wall-clock budget for the candidate sweep. The sweep '
+                        'is radius/step rings x rotations and each candidate '
+                        'pays a full cost evaluation; --limit only truncates '
+                        'the result. Env: KRT_DEADLINE_S')
     q.add_argument('--clearance', type=float, default=None,
                    help='pose-legality clearance (default: the board\'s own '
                         'Default netclass, else 0.25; run-7 S4 -- a fixed '
@@ -507,7 +1331,63 @@ def build_parser():
                    default='completion')
     r.add_argument('--lever', default=None)
     r.add_argument('--score', default=None, help='JSON')
+    r.add_argument('--score-file', default=None, metavar='PATH',
+                   help='the score payload as a FILE. Prefer this: '
+                        '--score "$(cat ...)" exceeds the OS argv limit at '
+                        '~32kB and the shell then exits 126 BEFORE record '
+                        'runs, so the lap is lost with no error. Mutually '
+                        'exclusive with --score.')
+    r.add_argument('--render-json', action='append', default=None,
+                   metavar='PATH',
+                   help='render_placement --json-out document(s) that were '
+                        'READ for this lap; repeatable. Stored as '
+                        'entry["renders"]. The [read: ...] convention lived in '
+                        'free-text --lever, so an audit could not tell a '
+                        'skipped mandate from an absent trigger.')
+    r.add_argument('--lens', action='append', default=None, metavar='VERDICT',
+                   help='a verifier lens verdict, VERBATIM: '
+                        '"VERDICT=PASS:lens=connectivity" or '
+                        '"VERDICT=FAIL:lens=drc;finding=...;evidence=...". '
+                        'Repeatable; stored raw as entry["lenses"]. Same '
+                        'reason as --render-json: a verdict that lives in '
+                        'free-text --lever cannot be told from a lens nobody '
+                        'ran. --final requires the three routed-board lenses.')
+    r.add_argument('--scope-refs', action='append', default=None,
+                   metavar='REF',
+                   help='the refs this lap was ALLOWED to move -- its search '
+                        'scope. Repeatable; a whitespace/comma-separated list '
+                        'is split, so a lock file reads straight in. Stored as '
+                        'entry["scope_refs"]. Same reason as --lens and '
+                        '--render-json: a scope that lives in free-text '
+                        '--lever cannot be told from a lap that scoped nothing '
+                        'and swept the board. Run 16 moved 76 of 113 parts '
+                        'across laps whose scopes existed only as loose '
+                        'lock_*.txt files nothing reads.')
     r.add_argument('--rejected', action='store_true')
+    r.add_argument('--exhausted', choices=('placement', 'routing'),
+                   default=None,
+                   help='declare ON THE RECORD that this half has nothing '
+                        'further to optimise. `verdict` then stops asking it '
+                        'to plateau. This is the lever its own too-few-laps '
+                        'text has always named -- "or to say on the record '
+                        'that there is nothing" -- and which no flag '
+                        'implemented: routing accepts only on strict '
+                        'improvement, so an exhausted half cannot produce the '
+                        'accepted lap the counter wanted. Needs '
+                        '--exhausted-reason. A later recorded lap of that half '
+                        'SUPERSEDES it. --kind systemic is the natural kind: '
+                        'the declaration changes no copper.')
+    r.add_argument('--exhausted-reason', default=None, metavar='REASON',
+                   help='what was tried and why nothing is left. Mandatory '
+                        'with --exhausted: the declaration IS the evidence, '
+                        'and an unreasoned one is just a lower --flat.')
+    r.add_argument('--accept-incommensurable', default=None, metavar='REASON',
+                   help='record a lap whose score graded FEWER components than '
+                        'the last accepted lap of its half even though '
+                        '`blocking` fell -- i.e. an improvement that may be an '
+                        'artefact of measuring less. Needs a reason, and the '
+                        'reason is what gets recorded: the numbers are not '
+                        'being judged, a person is.')
     r.add_argument('--final', action='store_true',
                    help='mark the run-closing record; requires --stop-condition')
     r.add_argument('--stop-condition', default=None,
@@ -534,6 +1414,23 @@ def build_parser():
     t = sub.add_parser('status', help='budget spent, completion vs systemic')
     t.add_argument('--ledger', required=True)
     t.set_defaults(fn=cmd_status)
+
+    v = sub.add_parser('verdict',
+                       help='continue, or stop -- and which kind of stop')
+    v.add_argument('--ledger', required=True)
+    v.add_argument('--score', required=True,
+                   help="the current board's score JSON (board_score --json)")
+    v.add_argument('--budget', type=int, default=100,
+                   help='ledger entries this run may write (default 100, the '
+                        'figure convergence.md already states)')
+    v.add_argument('--flat', type=int, default=5,
+                   help='RECORDED laps -- accepted OR rejected -- a half may go '
+                        'without improving before it counts as blocked '
+                        '(default 5, ditto). A rejected lap counts because it '
+                        'is the evidence that the half tried and did not '
+                        'improve; routing accepts only on strict improvement, '
+                        'so an exhausted half has no accepted lap left to give.')
+    v.set_defaults(fn=cmd_verdict)
     return p
 
 

--- a/py_placer/place_optimize.py
+++ b/py_placer/place_optimize.py
@@ -57,10 +57,27 @@ Examples:
                         help="Candidate grid step in mm (default: 1.0)")
     parser.add_argument("--grid-step", type=float, default=defaults.GRID_STEP,
                         help=f"Routing grid snap in mm (default: {defaults.GRID_STEP})")
-    parser.add_argument("--clearance", type=float, default=defaults.CLEARANCE,
-                        help=f"Min courtyard gap in mm (default: {defaults.CLEARANCE})")
-    parser.add_argument("--board-edge-clearance", type=float, default=0.55,
-                        help="Hard clearance from board edge in mm (default: 0.55)")
+    # BOARD-FIRST, like check_floorplan and converge. `None` is the "not
+    # given" signal these knobs never had: a fixed 0.25 on a board whose
+    # declared floor is 0.2 grades 34% more shortfall and double the oob count,
+    # and this tool VETOES candidate moves on that number -- so the wrong floor
+    # does not just mis-report, it steers the search.
+    parser.add_argument("--clearance", type=float, default=None,
+                        help="Min courtyard gap in mm (default: the board's "
+                             "own Default net-class clearance, else "
+                             f"{defaults.CLEARANCE})")
+    parser.add_argument("--board-edge-clearance", type=float, default=None,
+                        help="Hard clearance from board edge in mm (default: "
+                             "the board's own min_copper_edge_clearance, else "
+                             "0.55)")
+    parser.add_argument("--deadline", type=float, default=None,
+                        metavar="SECONDS",
+                        help="Wall-clock budget for the quench. Without one "
+                             "this tool has no clock at all: it is silent "
+                             "between its 'Pad legality before' line and its "
+                             "'N parts moved' line, so a long run and a hung "
+                             "one are indistinguishable, and killing it "
+                             "produces no JSON_SUMMARY. Env: KRT_DEADLINE_S")
     parser.add_argument("--crossing-penalty", type=float, default=10.0,
                         help="Cost in mm per airwire crossing (default: 10)")
     parser.add_argument("--length-weight", type=float, default=1.0,
@@ -123,6 +140,15 @@ Examples:
 
     args = parser.parse_args()
 
+    # Run-7 S1: unset knobs grade at the BOARD's floor, not fixed constants.
+    from list_nets import board_floor_knobs
+    args.clearance, args.board_edge_clearance, _knobs = board_floor_knobs(
+        args.input_file, args.clearance, args.board_edge_clearance)
+    print(f"legality at clearance {args.clearance} "
+          f"({_knobs['clearance']['source']}), edge "
+          f"{args.board_edge_clearance} "
+          f"({_knobs['board_edge_clearance']['source']})")
+
     if args.swap_max_displacement is not None:
         if args.swap_max_displacement < 0:
             parser.error("--swap-max-displacement must be >= 0")
@@ -184,16 +210,27 @@ Examples:
     # Exact pad/hole legality of the INPUT (file poses): the before half of
     # the report pair. Gate-currency tallies live inside the quench; this is
     # the phantom-free number an auditor compares.
-    from placement.legality import grade_pad_legality
+    from placement.legality import (grade_pad_legality,
+                                    format_oob_clause as _oob_clause)
     legality_before = None
     if not args.courtyard_only:
         legality_before = grade_pad_legality(pcb_data, args.clearance)
         print(f"Pad legality before: {legality_before['pad_conflicts']} "
               f"conflict pair(s), {legality_before['hole_conflicts']} hole "
               f"conflict(s), {legality_before['oob_pad_count']} part(s) with "
-              f"pad copper off-board")
+              f"pad copper off-board"
+              + (": " + _oob_clause(legality_before)
+                 if _oob_clause(legality_before) else ""))
 
     ratsnest = {}
+    import krt_deadline
+    # Bound BEFORE arming: the atexit hook resolves this name when the process
+    # dies, and a kill between arm() and the summary build would otherwise
+    # raise inside the hook and print nothing at all -- the exact silence this
+    # is here to remove. place_seed.py does the same for the same reason.
+    summary = {'parts_moved': 0}
+    _dl = krt_deadline.arm(args.deadline, tool='place_optimize',
+                           on_partial=lambda: summary)
     placements = quench(
         pcb_data,
         pcb_file=args.input_file,
@@ -225,6 +262,9 @@ Examples:
         pad_legality=not args.courtyard_only,
         min_gain_per_mm=args.min_gain_per_mm,
         move_unconnected=args.move_unconnected,
+        cancel_check=(_dl.cancel_check('quench') if _dl else None),
+        progress_callback=(krt_deadline.stdout_progress(deadline=_dl)
+                           if _dl else None),
     )
 
     print(f"{len(placements)} parts moved")
@@ -241,7 +281,7 @@ Examples:
     # so nothing downstream could gate on what a quench run actually achieved.
     # Same shape as route_planes.py's JSON_SUMMARY (#487's plane-resistance fix).
     before, after = ratsnest.get('before', {}), ratsnest.get('after', {})
-    summary = {
+    summary.update({
         'parts_moved': len(placements),
         'blocks': len(blocks),
         'block_parts': sum(len(v) for v in blocks.values()),
@@ -255,7 +295,16 @@ Examples:
         'airwire_length_after': after.get('length'),
         'cost_before': before.get('total'),
         'cost_after': after.get('total'),
-    }
+        # The two pad-conflict numbers here are DIFFERENT CURRENCIES and sat
+        # adjacent under near-identical names, ~2x apart on one unchanged
+        # board. `pad_conflict_pairs` is the quench's AABB gate currency
+        # (conservative: a bbox graze on a rotated or round pad counts, and a
+        # pair over PAIR_TEST_CAP falls back to an extent-level verdict).
+        # `pad_conflicts_before/_after` re-grade the written file with exact
+        # pad geometry and carry no phantoms. A >= B is structural, not a bug.
+        'pad_conflict_pairs_currency': 'aabb-gate (conservative, phantoms)',
+        'pad_conflicts_currency': 'exact geometry (phantom-free)',
+    })
     summary.update(ratsnest.get('legality', {}))
     # After half of the exact report pair, graded on the WRITTEN file so it
     # covers exactly what the next step will read. WARN on any worsened
@@ -267,7 +316,9 @@ Examples:
         print(f"Pad legality after: {legality_after['pad_conflicts']} "
               f"conflict pair(s), {legality_after['hole_conflicts']} hole "
               f"conflict(s), {legality_after['oob_pad_count']} part(s) with "
-              f"pad copper off-board")
+              f"pad copper off-board"
+              + (": " + _oob_clause(legality_after)
+                 if _oob_clause(legality_after) else ""))
         for key in ('pad_conflicts', 'hole_conflicts', 'oob_pad_count'):
             summary[f'{key}_before'] = legality_before[key]
             summary[f'{key}_after'] = legality_after[key]
@@ -277,7 +328,11 @@ Examples:
                       f"the legality gate should have prevented this")
         summary['pad_shortfall_before'] = legality_before['pad_shortfall']
         summary['pad_shortfall_after'] = legality_after['pad_shortfall']
-    print("JSON_SUMMARY: " + json.dumps(summary))
+    if _dl is not None and _dl.expired():
+        krt_deadline.mark(summary, _dl)
+        krt_deadline.emit(summary, deadline=_dl)
+        return krt_deadline.DEADLINE_EXIT
+    krt_deadline.emit(summary, deadline=_dl)
 
 
 if __name__ == "__main__":

--- a/py_placer/place_portfolio.py
+++ b/py_placer/place_portfolio.py
@@ -135,9 +135,9 @@ Examples:
                    help="Quench candidate grid step in mm (default: 1.0)")
     p.add_argument("--grid-step", type=float, default=defaults.GRID_STEP,
                    help=f"Routing grid snap in mm (default: {defaults.GRID_STEP})")
-    p.add_argument("--clearance", type=float, default=defaults.CLEARANCE,
+    p.add_argument("--clearance", type=float, default=None,
                    help=f"Min courtyard gap in mm (default: {defaults.CLEARANCE})")
-    p.add_argument("--board-edge-clearance", type=float, default=0.55,
+    p.add_argument("--board-edge-clearance", type=float, default=None,
                    help="Hard clearance from board edge in mm (default: 0.55)")
     p.add_argument("--crossing-penalty", type=float, default=30.0,
                    help="Cost per airwire crossing (default: 30, guidance)")
@@ -182,6 +182,15 @@ Examples:
                         "verdict outranks the window one (a candidate can "
                         "win its window while losing the board). Costs two "
                         "extra full routes.")
+    p.add_argument("--deadline", type=float, default=None, metavar="SECONDS",
+                   help="Wall-clock budget for candidate GENERATION (the "
+                        "quench inside each candidate, and the candidate loop "
+                        "itself). Scoring is bounded separately by "
+                        "--plane-score-budget and --route-timeout. Without "
+                        "one the quench inside every candidate has no clock: "
+                        "--plane-score-budget and --route-timeout bound the "
+                        "PROBE subprocesses, not the search. Env: "
+                        "KRT_DEADLINE_S")
     p.add_argument("--route-timeout", type=float, default=900,
                    help="Seconds per probe route (default: 900)")
     # Presentation & provenance
@@ -323,6 +332,17 @@ def _montage(path, rows, out_dir):
 def main():
     parser = build_parser()
     args = parser.parse_args()
+
+    # Run-7 S1 / run-13 F6: unset floors come from the BOARD, not a constant.
+    # A fixed 0.25 on a board declaring 0.2 measured 34% more shortfall and
+    # double the oob count -- and these tools VETO candidate moves on it, so a
+    # wrong floor steers the search, it does not merely mis-report.
+    from list_nets import board_floor_knobs
+    args.clearance, args.board_edge_clearance, _knobs = board_floor_knobs(
+        args.input_file, args.clearance, args.board_edge_clearance)
+    print(f"legality at clearance {args.clearance} "
+          f"({_knobs['clearance']['source']}), edge {args.board_edge_clearance} "
+          f"({_knobs['board_edge_clearance']['source']})")
     # The probe/render subprocesses run with cwd=ROOT (the repo), so a path
     # relative to the CALLER's cwd silently breaks every one of them
     # (measured: 3/3 probe routes rc=1 "no summary", 6/6 renders rc=1, on a
@@ -379,18 +399,42 @@ def main():
     else:
         swap_blocks = derive_groups(pcb, sources) if sources else {}
 
+    import krt_deadline
+    # `_pf_partial` is MUTATED, never rebound, so the atexit hook reports the
+    # stage that was actually running rather than a frozen string.
+    _pf_partial = {'stage': 'portfolio.generate'}
+    _dl = krt_deadline.arm(args.deadline, tool='place_portfolio',
+                           on_partial=lambda: _pf_partial)
     result = portfolio.generate(
         args.input_file, args.out_dir, seed=args.seed,
         n_candidates=args.candidates, strategies=args.strategy,
         radius=args.radius, lock_globs=args.lock,
         ignore_nets=args.ignore_nets, swap_blocks=swap_blocks,
-        quench_kw=_quench_kw(args, intent), only=args.only)
+        quench_kw=_quench_kw(args, intent), only=args.only,
+        cancel_check=(_dl.cancel_check('portfolio') if _dl else None),
+        progress_callback=(krt_deadline.stdout_progress(deadline=_dl)
+                           if _dl else None))
     baseline = result['baseline']
     cands = result['candidates']
     free = result['free']
 
     if args.only is not None:
+        if not cands:
+            # The candidate loop can stop on a spent budget before producing
+            # anything, and --only is the REPLAY path: `_replay_argv` strips
+            # --ledger/--montage/--only but keeps an absolute --deadline, so a
+            # recorded replay inherits the original run's clock and lands here
+            # with an empty list. Exit like a spent budget, not an IndexError.
+            krt_deadline.seal()
+            print('JSON_SUMMARY: ' + json.dumps(
+                {'only': args.only, 'candidates': 0, 'complete': False,
+                 'status': 'deadline' if (_dl and _dl.expired()) else 'empty',
+                 'reason': 'the candidate was never generated -- the budget '
+                           'was spent before the loop reached it'},
+                sort_keys=True))
+            return krt_deadline.DEADLINE_EXIT if (_dl and _dl.expired()) else 4
         c = cands[0]
+        krt_deadline.seal()
         print("JSON_SUMMARY: " + json.dumps(
             {'only': args.only, 'strategy': c.strategy, 'board': c.board,
              'seed_board': c.seed_board, 'perturbed': len(c.poses),
@@ -673,6 +717,7 @@ def main():
               "than the baseline) -- best falls back to the baseline; read "
               "portfolio.json before adopting a violator deliberately")
     best_c = by_index.get(best, baseline) if best is not None else None
+    krt_deadline.seal()
     print("JSON_SUMMARY: " + json.dumps({
         'candidates': len(cands) + 1, 'viable': len(viable),
         'kept': len(kept), 'best': best,

--- a/py_placer/place_reconstruct.py
+++ b/py_placer/place_reconstruct.py
@@ -48,6 +48,13 @@ def _promote_staged(staged: str, final: str) -> None:
             os.replace(src, final_base + ext)
 
 
+#: The stage names that actually gate code. `classify` runs unconditionally
+#: (it is a prerequisite for everything below it, `reconstruct.classify` at the
+#: top of the pipeline) and is listed here so the default string round-trips.
+_STAGES = ('classify', 'fit', 'vector', 'assign', 'exchange', 'reseat',
+           'legalize')
+
+
 def main():
     import routing_defaults as defaults
 
@@ -65,8 +72,20 @@ Examples:
                    help="Optional floorplan intent (edge connectors exempt "
                         "from off-board repair; zones constrain re-seating)")
     p.add_argument("--stages",
-                   default="classify,fit,vector,assign,exchange,legalize",
-                   help="Comma list of stages to run (default: all)")
+                   default="classify,fit,vector,assign,exchange,reseat,"
+                           "legalize",
+                   help="Comma list of stages to run. Valid: classify, fit, "
+                        "vector, assign, exchange, reseat, legalize "
+                        "(default: all). `classify` runs regardless -- it is "
+                        "a prerequisite. `assign` also needs fit or vector to "
+                        "have produced candidates. `reseat` lifts the parts "
+                        "whose pad CENTRES are off the outline and re-seats "
+                        "them from scratch at their net centroids -- it runs "
+                        "before `legalize` because no cap ladder anchored on "
+                        "a part's current pose can carry it back onto the "
+                        "board, and legalize's minimal-move cleanup is much "
+                        "cheaper once everything is on it. An unknown name is "
+                        "an error, not a silent no-op.")
     p.add_argument("--anchor-extent", default="auto",
                    help="Anchor tier threshold in mm, or 'auto' = "
                         "max(3.5, P75 of pad-extent diagonals)")
@@ -84,16 +103,63 @@ Examples:
                         "boundary partners are home (run-4 F2/F4). Each "
                         "round is gated and pruned; the loop stops early "
                         "when a round moves nothing")
+    p.add_argument("--lock", nargs="+", default=None, metavar="REF",
+                   help="Reference globs this run may NOT move, on top of the "
+                        "board's own (locked yes) stamps. Every sibling "
+                        "placement tool has this and reconstruct did not -- "
+                        "the tool whose whole job is moving parts was the one "
+                        "with no way to say which parts it may not move. "
+                        "Scoping it therefore meant stamping temporary lock "
+                        "bits INTO the board being measured, which "
+                        "check_assembly then waives on and #521 reads.")
     p.add_argument("--max-move", type=float, default=5.0,
                    help="Legalize-stage displacement cap ladder tops out here "
                         "(default: 5.0)")
-    p.add_argument("--clearance", type=float, default=defaults.CLEARANCE)
-    p.add_argument("--board-edge-clearance", type=float, default=0.55)
+    p.add_argument("--clearance", type=float, default=None)
+    p.add_argument("--board-edge-clearance", type=float, default=None)
     p.add_argument("--grid-step", type=float, default=defaults.GRID_STEP)
     p.add_argument("--dry-run", action="store_true",
                    help="Print the stage reports and move list; write nothing")
+    p.add_argument("--deadline", type=float, default=None, metavar="SECONDS",
+                   help="Wall-clock budget. The legalize sweep has no internal "
+                        "bound and ran 46 min without terminating on a 217-part "
+                        "board (run 9); with a budget it stops between "
+                        "violators, keeps the seats it made, reports the rest "
+                        "in deadline_skipped, and exits 7. Default: no budget "
+                        "(a wall-clock default would break replay "
+                        "determinism). ANY harness with an external timeout "
+                        "should pass this at ~0.8x its own. Env: KRT_DEADLINE_S")
     args = p.parse_args()
+
+    # Run-7 S1 / run-13 F6: unset floors come from the BOARD, not a constant.
+    # A fixed 0.25 on a board declaring 0.2 measured 34% more shortfall and
+    # double the oob count -- and these tools VETO candidate moves on it, so a
+    # wrong floor steers the search, it does not merely mis-report.
+    from list_nets import board_floor_knobs
+    args.clearance, args.board_edge_clearance, _knobs = board_floor_knobs(
+        args.input_file, args.clearance, args.board_edge_clearance)
+    print(f"legality at clearance {args.clearance} "
+          f"({_knobs['clearance']['source']}), edge {args.board_edge_clearance} "
+          f"({_knobs['board_edge_clearance']['source']})")
     stages = {s.strip() for s in args.stages.split(',') if s.strip()}
+    # A misspelt stage used to be accepted silently and gate nothing, so
+    # `--stages legalise` ran no legalize and exited 0 with a clean-looking
+    # summary -- the same silent-lie class as the hang below.
+    _unknown = sorted(stages - set(_STAGES))
+    if _unknown:
+        p.error(f"unknown stage(s) {', '.join(_unknown)}; valid stages are "
+                f"{', '.join(_STAGES)}")
+
+    # Armed HERE, before the refusal paths below, not next to the first stage.
+    # The refusals (no Edge.Cuts, board carries copper, no legality layer)
+    # printed to stderr and returned with no JSON_SUMMARY at all, so a caller
+    # scraping the summary could not tell a refusal from a kill. `report` is
+    # mutated in place from here on and the flush hook sees whatever it holds.
+    report = {}
+    import krt_deadline
+    _dl = krt_deadline.arm(args.deadline, tool='place_reconstruct',
+                           on_partial=lambda: report)
+    report['stages_requested'] = sorted(stages)
 
     if not args.dry_run:
         try:
@@ -132,17 +198,26 @@ Examples:
               file=sys.stderr)
         return UNPLACED_EXIT
 
+    # Two lock sources, resolved once so every consumer agrees: the file's
+    # own (locked yes) stamps (read inside QuenchState) and these globs.
+    _extra_locked = set()
+    if args.lock:
+        import fnmatch as _fn
+        _extra_locked = {r for r in pcb.footprints
+                         if any(_fn.fnmatch(r, pat) for pat in args.lock)}
+        print(f"Locked via --lock: {len(_extra_locked)} ref(s)"
+              + (f": {', '.join(sorted(_extra_locked)[:8])}"
+                 if _extra_locked else " -- NO ref matched, check the globs"))
     state = pose_score.make_state(
         pcb, args.input_file, clearance=args.clearance,
         board_edge_clearance=args.board_edge_clearance,
-        grid_step=args.grid_step)
+        grid_step=args.grid_step, extra_locked_refs=_extra_locked or None)
     if state.legality_ctx is None:
         print("place_reconstruct: pad legality layer unavailable on this "
               "state; refusing to run blind.", file=sys.stderr)
         return 2
 
     notes = []
-    report = {}
 
     tiers = reconstruct.classify(state, intent, args.anchor_extent)
     report['tiers'] = tiers.as_dict()
@@ -181,8 +256,7 @@ Examples:
     report['edge_bands'] = {r: m for r, m in sorted(edge_bands.items())}
 
     base = reconstruct.measure(state, edge_bands)
-    print(f"Gate before: pad_pairs={base[0]} hole={base[1]} oob={base[2]} "
-          f"stacks={base[3]} hpwl={base[4]} overlap={base[5]}")
+    print(f"Gate before: {reconstruct.format_gate(base)}")
     report['gate_before'] = list(base)
 
     proposals = {}
@@ -218,6 +292,36 @@ Examples:
                               for d in derived))
             vectors = vectors + [d['v'] for d in derived]
         report['vectors_derived'] = [list(d['v']) for d in derived]
+
+        # SAY SO WHEN THERE IS NO STRUCTURAL HYPOTHESIS.
+        #
+        # Run 9: three derived vectors with support 6, 6 and 4 against a
+        # 107-part displaced block -- they explained ~15% of the damage -- and
+        # the run then moved 80 parts on that basis and reported nothing
+        # unusual. The near-inert recovery (+0.045, 0/107 home) was visible in
+        # this ratio at minute four and was not discovered until the audit.
+        # A render of the same board shows it instantly: the move arrows are
+        # broadly parallel over one region, so there IS structure the detector
+        # is not recovering. That is a finding about the DETECTOR, and it
+        # belongs in the log while there is still time to act on it.
+        _sup = sum(d['support'] for d in derived) if derived else 0
+        _movable = len([r for r in state.parts if not state.parts[r].locked])
+        report['vector_support'] = {
+            'derived_support_total': _sup,
+            'pattern_vectors': len(vectors) - len(derived),
+            'movable_parts': _movable,
+            'fraction_explained': (round(_sup / _movable, 4)
+                                   if _movable else None),
+        }
+        if derived and _movable and (_sup / _movable) < 0.25:
+            print(f"  WARNING: the derived vectors explain only {_sup} of "
+                  f"{_movable} movable part(s) ({_sup / _movable:.0%}). This "
+                  f"run is proceeding WITHOUT a confident structural "
+                  f"hypothesis -- expect the assignment to move parts on weak "
+                  f"evidence and recovery to be near-inert. If the damage "
+                  f"looks like a coherent block in a render, the detector is "
+                  f"missing it; that is a finding about the detector, not "
+                  f"about the board.")
 
     # F2: declared edge entries whose edge could not be named (implausible
     # pose) -- their objective term is the EDGE metric, not the net-anchor
@@ -288,9 +392,7 @@ Examples:
             print(f"  exchange: {n_refs} part(s) moved in "
                   f"{len(xrep['accepted'])} joint move(s)"
                   + (f" ({len(xpruned)} pruned back)" if xpruned else "")
-                  + f"; gate now pad_pairs={base[0]} hole={base[1]} "
-                  f"oob={base[2]} stacks={base[3]} hpwl={base[4]} "
-                  f"overlap={base[5]}")
+                  + f"; gate now {reconstruct.format_gate(base)}")
         return sorted(set(xold) - set(xpruned))
 
     moved = []
@@ -298,6 +400,18 @@ Examples:
     xmoved_all = []
     if 'assign' in stages and (vectors or proposals):
         for rnd in range(max(1, args.assign_rounds)):
+            # BETWEEN ROUNDS. `--deadline` used to reach only reseat and
+            # legalize, so parse, state build, classify, fit, vector, every
+            # assign round (each one a scipy ILP) and exchange all ran outside
+            # it, so `--deadline 0` could run a board to COMPLETION and still
+            # report `complete: true` -- measured on tigard__swap: 7s, assign
+            # and exchange both ran, exit 0. A round is the right unit:
+            # the ILP inside one is not interruptible, and the partial is the
+            # previous round's board, which is coherent.
+            if _dl is not None and _dl.check('assign'):
+                notes.append(f"assign: stopped after {rnd} round(s) (budget)")
+                print(f"  assign: stopping after {rnd} round(s) (budget)")
+                break
             cands, pattern = reconstruct.build_candidates(
                 state, tiers, vectors, proposals, edge_bands=edge_bands)
             n_multi = sum(1 for c in cands.values() if len(c) > 1)
@@ -315,6 +429,7 @@ Examples:
                     x, y = cands[ref][k]
                     state.apply_move(ref, x, y, state.parts[ref].rot)
             after = reconstruct.measure(state, edge_bands)
+            before_round = base
             rmoved = []
             if after <= base:
                 # Run-4 F3(b): the gate is one board-wide tuple, so an
@@ -323,9 +438,16 @@ Examples:
                 # input inside a hugely-improving set). Per-part revert
                 # sweep, gated on strict tuple improvement -- monotone,
                 # board-only.
-                pruned = reconstruct.prune_assignment(state, old, notes,
-                                                      edge_bands=edge_bands,
-                                                      exempt=set(edge_pref))
+                # ...and a move the tuple rates EQUAL is reverted too unless
+                # it agrees with a kept vector. A zero-net part in free space
+                # touches no term the tuple has, so `strictly better` never
+                # fires for it and a 26.27mm carry to another hole's seat
+                # survived a sweep written to catch exactly that.
+                pruned = reconstruct.prune_assignment(
+                    state, old, notes, edge_bands=edge_bands,
+                    exempt=set(edge_pref),
+                    evidenced=reconstruct.evidenced_moves(
+                        state, old, list(vectors) + list(derived)))
                 all_pruned.extend(pruned)
                 after = reconstruct.measure(state, edge_bands)
                 base = after
@@ -335,9 +457,32 @@ Examples:
                 print(f"  assign round {rnd + 1} APPLIED: {len(rmoved)} "
                       f"part(s) moved"
                       + (f" ({len(pruned)} pruned back)" if pruned else "")
-                      + f"; gate now pad_pairs={after[0]} hole={after[1]} "
-                      f"oob={after[2]} stacks={after[3]} hpwl={after[4]} "
-                      f"overlap={after[5]}")
+                      + f"; gate now {reconstruct.format_gate(after)}")
+                # The accept rule is smaller-OR-EQUAL, so a round can move
+                # parts and change nothing the gate can see. That is not
+                # neutral: displacement is unbounded, and a run was measured
+                # taking a mounting hole 26mm and rotating a connector 90 deg
+                # on an equal tuple -- both had been at their correct poses.
+                # The rung above says an unimproving proposal means "the
+                # determinant was not on the board", so at minimum say it out
+                # loud rather than reporting a move as progress.
+                if rmoved and after == before_round:
+                    dists = []
+                    for r in rmoved:
+                        ox, oy, orot = old[r]
+                        p = state.parts[r]
+                        dists.append((r, math.hypot(p.x - ox, p.y - oy),
+                                      (p.rot - orot) % 360.0))
+                    worst = max(dists, key=lambda t: t[1])
+                    print(f"    UNEVIDENCED: the gate did not change, so "
+                          f"nothing measured justifies {len(rmoved)} move(s). "
+                          f"Largest: {worst[0]} {worst[1]:.2f}mm"
+                          + (f", rot {worst[2]:+.0f} deg" if worst[2] else "")
+                          + ". Check these against their input poses before "
+                            "trusting the result.")
+                    report.setdefault('unevidenced_moves', []).extend(
+                        {'ref': r, 'mm': round(d, 4), 'rot': round(ro, 1)}
+                        for r, d, ro in sorted(dists, key=lambda t: -t[1]))
             else:
                 for ref, (x, y, rot) in old.items():
                     state.apply_move(ref, x, y, rot)
@@ -359,6 +504,13 @@ Examples:
     report['assign_pruned'] = sorted(set(all_pruned))
     report['assign_moved'] = sorted(moved)
     report['gate_after_assign'] = list(base)
+    # Membership FIRST: `check()` latches `stopped_in` on its first call, so
+    # testing the clock before the stage set made a run report it stopped in
+    # `exchange` when exchange was never requested.
+    if 'exchange' in stages and _dl is not None and _dl.check('exchange'):
+        notes.append('exchange: skipped (budget)')
+        print('  exchange: skipped (budget)')
+        stages = stages - {'exchange'}
     if 'exchange' in stages:
         report['exchange'] = {
             'attempts': xrep_all['attempts'],
@@ -385,6 +537,68 @@ Examples:
     for n in notes:
         print(f"  NOTE: {n}")
 
+    def _run_reseat(board_path):
+        """Re-seat the off-outline parts of `board_path` IN PLACE.
+
+        The rung between `exchange` and `legalize`: exchange carries parts the
+        damage moved by a DETECTED vector, and legalize nudges parts that are
+        nearly right, so a part that is neither -- tens of millimetres out with
+        no surviving family to over-determine a vector -- falls between them
+        and nothing in the ladder moves it. Measured on a 107-part board: 11
+        such parts, and every one of the 13 nets the router could not attempt
+        had a pad on one of them.
+        """
+        pcb2 = parse_kicad_pcb(board_path)
+        rep = seeder.reseat_scope(
+            pcb2, board_path, intent, group_sources=(),
+            lock_globs=args.lock,
+            clearance=args.clearance,
+            board_edge_clearance=args.board_edge_clearance,
+            grid_step=args.grid_step,
+            # The scope's own bands are filtered out INSIDE: a ref being
+            # re-seated has forfeited its declared band (the band was measured
+            # off the pose being discarded), and leaving it in makes the gate
+            # read `oob 4.348` on a board with parts 158mm off the outline.
+            edge_bands=edge_bands, deadline=_dl,
+            progress=krt_deadline.stdout_progress(deadline=_dl))
+        for n in rep['notes']:
+            print(f"  NOTE: {n}")
+        if rep['edge_bands_dropped']:
+            print("  reseat dropped the declared band of: "
+                  + ", ".join(f"{r} ({m:g})" for r, m in
+                              sorted(rep['edge_bands_dropped'].items())))
+        if rep['moves']:
+            tmp = board_path + '.reseat'
+            write_placed_output(board_path, tmp, rep['moves'])
+            os.replace(tmp, board_path)
+        print(f"  reseat ({rep['scope_source']}): {len(rep['scope'])} in "
+              f"scope, {len(rep['reseated'])} re-seated, "
+              f"{len(rep['unseated'])} unseated, {len(rep['refused'])} "
+              f"refused; OFF-OUTLINE PARTS {len(rep['witnesses_before'])} -> "
+              f"{len(rep['witnesses_after'])}"
+              + ('' if rep['accepted'] else '  [GATE REFUSED]'))
+        print(f"  reseat gate: {reconstruct.format_gate(rep['gate_before'])}"
+              f"  ->  {reconstruct.format_gate(rep['gate_after'])}")
+        return rep
+
+    def _reseat_report(rep, preview=False):
+        d = {'scope': rep['scope'], 'scope_source': rep['scope_source'],
+             'reseated': rep['reseated'], 'unseated': rep['unseated'],
+             'refused': rep['refused'], 'pruned': rep['pruned'],
+             'edge_bands_dropped': rep['edge_bands_dropped'],
+             'gate_before': rep['gate_before'],
+             'gate_after': rep['gate_after'],
+             'accepted': rep['accepted'],
+             # `witnesses_after` is the number that predicts routability --
+             # NOT `reseated`, which counts effort.
+             'witnesses_before': rep['witnesses_before'],
+             'witnesses_after': rep['witnesses_after'],
+             'deadline_skipped': rep.get('deadline_skipped', []),
+             'complete': rep.get('complete', True)}
+        if preview:
+            d['preview'] = True
+        return d
+
     def _run_legalize(board_path):
         """Legalize `board_path` IN PLACE; returns the seeder's report."""
         pcb2 = parse_kicad_pcb(board_path)
@@ -393,9 +607,11 @@ Examples:
             caps = list(caps) + [args.max_move]
         rep = seeder.repair_placement(
             pcb2, board_path, intent, group_sources=(),
+            lock_globs=args.lock,
             clearance=args.clearance,
             board_edge_clearance=args.board_edge_clearance,
-            grid_step=args.grid_step, caps=caps)
+            grid_step=args.grid_step, caps=caps, deadline=_dl,
+            progress=krt_deadline.stdout_progress(deadline=_dl))
         for n in rep['notes']:
             print(f"  NOTE: {n}")
         if rep['moves']:
@@ -415,21 +631,29 @@ Examples:
         # parts when it really ran. A preview that silently skips the stage is
         # worse than no preview. Stage it in a temp dir instead and report what
         # legalize WOULD do; the caller's output path is still never written.
-        if 'legalize' in stages:
+        if {'reseat', 'legalize'} & stages:
             import tempfile
             with tempfile.TemporaryDirectory() as _td:
                 _preview = os.path.join(
                     _td, os.path.basename(args.output_file) or 'preview.kicad_pcb')
                 write_placed_output(args.input_file, _preview, placements)
                 copy_siblings(args.input_file, _preview)
-                _rep = _run_legalize(_preview)
-                report['legalize'] = {
-                    'preview': True,
-                    'repaired': _rep['repaired'],
-                    'unrepairable': _rep['unrepairable'],
-                    'would_move': sorted(m['reference'] for m in _rep['moves']),
-                }
-        print("JSON_SUMMARY: " + json.dumps(report, sort_keys=True))
+                # Same ORDER as the real run, so the legalize preview is taken
+                # against the RE-SEATED board rather than one the real run
+                # would never hand it.
+                if 'reseat' in stages:
+                    report['reseat'] = _reseat_report(_run_reseat(_preview),
+                                                      preview=True)
+                if 'legalize' in stages:
+                    _rep = _run_legalize(_preview)
+                    report['legalize'] = {
+                        'preview': True,
+                        'repaired': _rep['repaired'],
+                        'unrepairable': _rep['unrepairable'],
+                        'would_move': sorted(m['reference']
+                                             for m in _rep['moves']),
+                    }
+        krt_deadline.emit(report, deadline=_dl)
         return 0
 
     # Run-7 A11: the output used to be written BEFORE legalize ran, so a run
@@ -441,10 +665,61 @@ Examples:
     write_placed_output(args.input_file, staged, placements)
     copy_siblings(args.input_file, staged)
 
+    if 'reseat' in stages:
+        _rs = _run_reseat(staged)
+        report['reseat'] = _reseat_report(_rs)
+        if not _rs.get('complete', True):
+            krt_deadline.mark(
+                report, _dl,
+                staged_board=staged, output=None,
+                board_stage='pre-legalize + %d reseat(s)'
+                            % len(_rs['reseated']),
+                deadline_skipped=_rs.get('deadline_skipped', []))
+            print(f"  DEADLINE: reseat stopped with "
+                  f"{len(_rs.get('deadline_skipped', []))} part(s) untried. "
+                  f"The output path was NOT written; the partial board is "
+                  f"at:\n    {staged}", file=sys.stderr)
+            krt_deadline.emit(report, deadline=_dl)
+            return krt_deadline.DEADLINE_EXIT
+
     if 'legalize' in stages:
         rep = _run_legalize(staged)
         report['legalize'] = {'repaired': rep['repaired'],
-                              'unrepairable': rep['unrepairable']}
+                              'unrepairable': rep['unrepairable'],
+                              'deadline_skipped': rep.get('deadline_skipped', []),
+                              'complete': rep.get('complete', True)}
+        if not rep.get('complete', True):
+            # Run-7 A11's invariant, kept verbatim: the OUTPUT path only ever
+            # holds a complete board. So on a deadline hit we promote NOTHING
+            # and simply name the staged board, which already exists, already
+            # has a distinguishing name, and already survives a kill -- the only
+            # defect today is that nobody is told it is there.
+            #
+            # Deliberately NOT a --promote-partial flag: that re-creates the
+            # exact defect A11 fixed, behind a switch a harness author will
+            # turn on without reading the rationale. A caller who genuinely
+            # wants the pre-legalize board can copy_board the staged path AFTER
+            # reading a summary that says complete:false -- an explicit act by
+            # someone who has seen the warning.
+            krt_deadline.mark(
+                report, _dl,
+                staged_board=staged,
+                output=None,
+                board_stage='pre-legalize + %d of %d legalize seat(s)'
+                            % (len(rep['repaired']),
+                               len(rep['repaired']) + len(rep.get(
+                                   'deadline_skipped', []))),
+                legalize_repaired=len(rep['repaired']),
+                deadline_skipped=rep.get('deadline_skipped', []))
+            print(f"  DEADLINE: legalize stopped with "
+                  f"{len(rep.get('deadline_skipped', []))} violator(s) "
+                  f"untried. The output path was NOT written; the partial "
+                  f"board is at:\n    {staged}\n  It carries the assign/"
+                  f"exchange result plus {len(rep['repaired'])} legalize "
+                  f"seat(s). Copy it with copy_board.py if you want it.",
+                  file=sys.stderr)
+            krt_deadline.emit(report, deadline=_dl)
+            return krt_deadline.DEADLINE_EXIT
 
     _promote_staged(staged, args.output_file)
 
@@ -470,6 +745,12 @@ Examples:
           f"{final['hole_conflicts']} hole conflict(s), "
           f"{final['oob_pad_count']} part(s) with pad copper off-board, "
           f"{body['blocking']} blocking body pair(s)")
+    _oc = __import__('placement.legality', fromlist=['x']).format_oob_clause(final)
+    if _oc:
+        # Printed BEFORE the edge_connectors advice below, because that advice
+        # tells the reader to declare a by-design overhang -- and this measure
+        # fires on a part sitting INSIDE the board by a clearance band.
+        print(f"  off-board parts: {_oc}")
     for q in body['blocking_pairs']:
         print(f"  BODY STACK: {q.a} <-> {q.b} {q.kind} {q.area_mm2}mm2 "
               f"side {q.side} -- not physically buildable")
@@ -477,7 +758,7 @@ Examples:
         print("  (off-board residue that no cap could repair: if it is a "
               "by-design overhang -- a card edge, a switch actuator -- "
               "declare it in an intent's edge_connectors; it is then exempt)")
-    print("JSON_SUMMARY: " + json.dumps(report, sort_keys=True))
+    krt_deadline.emit(report, deadline=_dl)
     # Exit 4 = residual PAD/HOLE conflicts or a blocking BODY pair -- the
     # defect classes this tool exists to remove. Off-board residue is
     # reported (and by-design overhang is indistinguishable from defect

--- a/py_placer/place_route_loop.py
+++ b/py_placer/place_route_loop.py
@@ -60,6 +60,10 @@ from route_summary import (merge_route_summaries, SUMMARY_RE as _SUMMARY_RE,
                            RECONCILE_ABORTED as _RECONCILE_ABORTED,
                            EFFORT_KEYS as _EFFORT_KEYS)
 
+# route.py's own "I stopped on my budget" code. Imported, not literal 7, so
+# this loop cannot drift from the tool it shells.
+from krt_deadline import DEADLINE_EXIT as _DEADLINE_EXIT
+
 
 def _log_tail(log: str, lines: int = 15) -> str:
     """Last few log lines, so an error names the real failure instead of
@@ -142,8 +146,14 @@ def run_route(pcb_file: str, routed_file: str, route_args: str, log_file: str,
     # glyph and lose the whole round.
     with open(log_file, encoding='utf-8', errors='replace') as f:
         log = f.read()
-    if rc != 0:
-        # route.py exits 0 even when nets fail; its only deliberate non-zero
+    # route.py's deadline exit (7) is a ROUTING RESULT, not a crash: the board
+    # is written, the summary is stamped `complete: false`, and the diagnosis
+    # the operator needs is the one below -- which the generic rc!=0 raise
+    # would preempt with "exited 7", a number that means nothing to a reader.
+    # Fall through and let the PARTIAL branch speak. (route.py grew --deadline
+    # after this check was written; before that, 7 was unreachable here.)
+    if rc != 0 and rc != _DEADLINE_EXIT:
+        # route.py exits 0 even when nets fail; its other deliberate non-zero
         # exit is "No nets matched the given patterns!". So non-zero means a
         # crash, an unreadable board or a --route-args typo, none of which is
         # a routing result.
@@ -152,8 +162,29 @@ def run_route(pcb_file: str, routed_file: str, route_args: str, log_file: str,
 
     summary = merge_route_summaries(log)
     if summary is None:
-        raise RuntimeError(f"route.py produced no JSON_SUMMARY (see {log_file})"
-                           f"\n" + _log_tail(log))
+        raise RuntimeError(
+            f"route.py produced no JSON_SUMMARY (see {log_file})"
+            + (f" -- and it exited {rc} (its deadline), so it was killed "
+               f"before it could print one. Raise --deadline."
+               if rc == _DEADLINE_EXIT else "")
+            + "\n" + _log_tail(log))
+    # A PARTIAL run is exactly as fatal as no summary, and this check is what
+    # keeps the deadline work from making things worse. Before deadlines
+    # existed, a killed step produced no summary at all and the raise above
+    # caught it. A `complete: false` summary PARSES -- so without this, the
+    # loop would consume an unfinished run's numbers as if they were a whole
+    # board's, which is a quieter and worse failure than the one it replaced.
+    # `.get('complete', True)` so pre-change logs are unaffected.
+    if not summary.get('complete', True):
+        raise RuntimeError(
+            f"route.py produced a PARTIAL JSON_SUMMARY "
+            f"(status={summary.get('status')!r}, "
+            f"stopped_in={summary.get('stopped_in')!r}, "
+            f"elapsed={summary.get('elapsed_s')}s of "
+            f"{summary.get('deadline_s')}s) -- the run stopped on its own "
+            f"deadline and its tallies are not a whole-board result. Raise "
+            f"--deadline, or drop it, and re-run.\nsee {log_file}\n"
+            + _log_tail(log))
 
     return metrics_from_summary(summary, log, extra_targets)
 

--- a/py_placer/place_seed.py
+++ b/py_placer/place_seed.py
@@ -53,8 +53,8 @@ Examples:
     p.add_argument("--ignore-nets", nargs="+", default=None, metavar="NET",
                    help="Net patterns excluded from the polish's airwire "
                         "scoring (plane-routed rails)")
-    p.add_argument("--clearance", type=float, default=defaults.CLEARANCE)
-    p.add_argument("--board-edge-clearance", type=float, default=0.55)
+    p.add_argument("--clearance", type=float, default=None)
+    p.add_argument("--board-edge-clearance", type=float, default=None)
     p.add_argument("--grid-step", type=float, default=defaults.GRID_STEP)
     p.add_argument("--max-displacement", type=float, default=3.0,
                    help="Polish displacement cap in mm (default: 3.0)")
@@ -92,15 +92,55 @@ Examples:
                         "legality move, worst first, each seated nearest its "
                         "current pose with an escalating displacement cap. "
                         "The opposite contract of --force")
+    p.add_argument("--reseat", nargs="*", default=None, metavar="REF",
+                   help="LIFT the named parts and re-seat them FROM SCRATCH "
+                        "at their net centroids, holding every other part "
+                        "fixed as an obstacle. With no REF the scope is the "
+                        "off-outline pad-CENTRE census "
+                        "(reconstruct.damage_witnesses), which is zero on all "
+                        "33 corpus boards -- so a bare --reseat on a healthy "
+                        "board is a no-op that exits 0. Unlike --repair, the "
+                        "part's CURRENT POSE IS NOT THE SEARCH CENTRE: a part "
+                        "30mm from where it belongs carries no information "
+                        "about where it belongs, and --repair's cap ladder "
+                        "tops out at 5mm from the wrong centre. REF accepts "
+                        "fnmatch globs. Any edge_connector declaration on a "
+                        "scope ref is DROPPED (the band was measured off the "
+                        "pose being discarded). Composes with --repair and "
+                        "runs BEFORE it. Judge it on witnesses_after, not on "
+                        "how far anything moved")
+    p.add_argument("--deadline", type=float, default=None, metavar="SECONDS",
+                   help="Wall-clock budget for --repair/--reseat. The repair "
+                        "sweep has no internal bound (violators x caps x 36 "
+                        "ring sweeps x O(parts)); with a budget it stops "
+                        "between violators, keeps the seats it made, reports "
+                        "the rest in deadline_skipped and exits 7. Default: "
+                        "no budget (a wall-clock default would break replay "
+                        "determinism). ANY harness with an external timeout "
+                        "should pass this at ~0.8x its own -- on Windows an "
+                        "external kill is TerminateProcess and leaves NO "
+                        "output at all. Env: KRT_DEADLINE_S")
     p.add_argument("--dry-run", action="store_true",
-                   help="With --repair: print the move list and grades, "
-                        "write nothing")
+                   help="With --repair/--reseat: print the move list and "
+                        "grades, write nothing")
     args = p.parse_args()
-    if args.repair and args.force:
-        p.error("--repair and --force are mutually exclusive (repair moves "
-                "only violators; force re-derives everything)")
-    if args.dry_run and not args.repair:
-        p.error("--dry-run only applies to --repair")
+
+    # Run-7 S1 / run-13 F6: unset floors come from the BOARD, not a constant.
+    # A fixed 0.25 on a board declaring 0.2 measured 34% more shortfall and
+    # double the oob count -- and these tools VETO candidate moves on it, so a
+    # wrong floor steers the search, it does not merely mis-report.
+    from list_nets import board_floor_knobs
+    args.clearance, args.board_edge_clearance, _knobs = board_floor_knobs(
+        args.input_file, args.clearance, args.board_edge_clearance)
+    print(f"legality at clearance {args.clearance} "
+          f"({_knobs['clearance']['source']}), edge {args.board_edge_clearance} "
+          f"({_knobs['board_edge_clearance']['source']})")
+    if (args.repair or args.reseat is not None) and args.force:
+        p.error("--repair/--reseat and --force are mutually exclusive (they "
+                "move only the parts that need it; force re-derives "
+                "everything)")
+    if args.dry_run and not (args.repair or args.reseat is not None):
+        p.error("--dry-run only applies to --repair / --reseat")
 
     try:
         from redo_record import record_invocation
@@ -139,42 +179,157 @@ Examples:
               f"{st.vias} via(s); seeding moves footprints and would strand "
               f"every track. Seed the unrouted board.", file=sys.stderr)
         return UNPLACED_EXIT
-    if args.repair:
+    if args.repair or args.reseat is not None:
+        import math as _math
+        import tempfile
+        import krt_deadline
         if st.unplaced:
-            print("place_seed: --repair needs a PLACED board (this one is "
-                  "unplaced -- seed it instead).", file=sys.stderr)
+            print("place_seed: --repair/--reseat need a PLACED board (this "
+                  "one is unplaced -- seed it instead).", file=sys.stderr)
             return UNPLACED_EXIT
-        result = seeder.repair_placement(
-            pcb, args.input_file, intent, group_sources=sources,
-            clearance=args.clearance,
-            board_edge_clearance=args.board_edge_clearance,
-            grid_step=args.grid_step)
-        for note in result['notes']:
-            print(f"  NOTE: {note}")
-        max_move = 0.0
-        for mv in result['moves']:
-            fp = pcb.footprints.get(mv['reference'])
-            if fp is not None:
-                import math as _math
-                max_move = max(max_move, _math.hypot(mv['new_x'] - fp.x,
-                                                     mv['new_y'] - fp.y))
-        print(f"Repair: {len(result['violators'])} violator(s), "
-              f"{len(result['repaired'])} repaired "
-              f"({len(result['moves'])} moved, max {max_move:.2f}mm), "
-              f"{len(result.get('unresolved') or [])} unresolved, "
-              f"{len(result['unrepairable'])} unrepairable")
-        summary = {'repaired': len(result['repaired']),
-                   'unrepairable': len(result['unrepairable']),
-                   'moved_refs': [m['reference'] for m in result['moves']],
-                   'max_move_mm': round(max_move, 3),
-                   'dry_run': args.dry_run,
+        summary = {'dry_run': args.dry_run,
                    'output': None if args.dry_run else args.output_file}
-        summary.update({f'{k}_before': v
-                        for k, v in result['pad_report_before'].items()})
+        # Armed BEFORE the passes, so the flush hook covers every return
+        # below -- the refusals above print no summary at all today, which is
+        # how a killed run and a refused one look identical to a scraper.
+        _dl = krt_deadline.arm(args.deadline, tool='place_seed',
+                               on_partial=lambda: summary)
+        _prog = krt_deadline.stdout_progress(deadline=_dl)
+
+        # Both passes stage into a temp dir and the finished board is copied
+        # to the output path once, at the end. That keeps --dry-run honest
+        # (--reseat then --repair previews the repair against the RE-SEATED
+        # board, which is what the real run would do) and keeps the output
+        # path from ever holding a half-finished result (run-7 A11).
+        _stage = tempfile.TemporaryDirectory()
+        cur, cur_pcb = args.input_file, pcb
+        exit_rc = 0
+
+        def _advance(moves, tag):
+            """Apply `moves` onto a fresh staged board; advances cur/cur_pcb."""
+            nonlocal cur, cur_pcb
+            if not moves:
+                return
+            nxt = os.path.join(_stage.name, f'{tag}.kicad_pcb')
+            write_placed_output(cur, nxt, moves)
+            copy_siblings(cur, nxt)
+            cur = nxt
+            cur_pcb = parse_kicad_pcb(cur)
+
+        reseat = None
+        if args.reseat is not None:
+            # `nargs='*'`: bare --reseat is [] and means AUTO scope; None is
+            # the flag being absent.
+            reseat = seeder.reseat_scope(
+                cur_pcb, cur, intent,
+                refs=(args.reseat or None), group_sources=sources,
+                clearance=args.clearance,
+                board_edge_clearance=args.board_edge_clearance,
+                grid_step=args.grid_step, seed=args.seed,
+                deadline=_dl, progress=_prog)
+            for note in reseat['notes']:
+                print(f"  NOTE: {note}")
+            _rmax = 0.0
+            for mv in reseat['moves']:
+                fp = cur_pcb.footprints.get(mv['reference'])
+                if fp is not None:
+                    _rmax = max(_rmax, _math.hypot(mv['new_x'] - fp.x,
+                                                  mv['new_y'] - fp.y))
+            print(f"Reseat ({reseat['scope_source']}): "
+                  f"{len(reseat['scope'])} in scope, "
+                  f"{len(reseat['reseated'])} re-seated "
+                  f"(max {_rmax:.2f}mm), {len(reseat['unseated'])} unseated, "
+                  f"{len(reseat['refused'])} refused; "
+                  f"OFF-OUTLINE PARTS {len(reseat['witnesses_before'])} -> "
+                  f"{len(reseat['witnesses_after'])}"
+                  + ('' if reseat['accepted'] else '  [GATE REFUSED]'))
+            print(f"  gate {reseat['gate_before']} -> {reseat['gate_after']}")
+            summary.update({
+                'reseat': True,
+                'scope': reseat['scope'],
+                'scope_source': reseat['scope_source'],
+                'reseated': len(reseat['reseated']),
+                'reseated_refs': reseat['reseated'],
+                'unseated': reseat['unseated'],
+                'refused': reseat['refused'],
+                'edge_bands_dropped': reseat['edge_bands_dropped'],
+                # THE load-bearing number: it is the one that predicts
+                # routability. `reseated` counts moves, which is effort.
+                'witnesses_before': len(reseat['witnesses_before']),
+                'witnesses_after': len(reseat['witnesses_after']),
+                'witnesses_after_refs': reseat['witnesses_after'],
+                'gate_before': reseat['gate_before'],
+                'gate_after': reseat['gate_after'],
+                'accepted': reseat['accepted'],
+                'reseat_max_move_mm': round(_rmax, 3),
+            })
+            _advance(reseat['moves'], 'reseat')
+            if reseat['edge_bands_dropped']:
+                # Grade against what the pass actually honoured. Keeping the
+                # dropped declarations would charge the repair for repairing:
+                # a part brought home from 160mm out then reads "sits nearest
+                # the west edge but is declared on the east edge".
+                intent = reseat['intent_used']
+                print(f"  (final grade excludes the "
+                      f"{len(reseat['edge_bands_dropped'])} dropped edge "
+                      f"declaration(s): a band measured off a discarded pose "
+                      f"is not a spec to grade the homecoming against)")
+            if reseat['unseated'] or reseat['refused'] \
+                    or not reseat['accepted']:
+                exit_rc = 4
+
+        result = None
+        if args.repair:
+            result = seeder.repair_placement(
+                cur_pcb, cur, intent, group_sources=sources,
+                clearance=args.clearance,
+                board_edge_clearance=args.board_edge_clearance,
+                grid_step=args.grid_step, deadline=_dl, progress=_prog)
+            for note in result['notes']:
+                print(f"  NOTE: {note}")
+            max_move = 0.0
+            for mv in result['moves']:
+                fp = cur_pcb.footprints.get(mv['reference'])
+                if fp is not None:
+                    max_move = max(max_move, _math.hypot(mv['new_x'] - fp.x,
+                                                         mv['new_y'] - fp.y))
+            print(f"Repair: {len(result['violators'])} violator(s), "
+                  f"{len(result['repaired'])} repaired "
+                  f"({len(result['moves'])} moved, max {max_move:.2f}mm), "
+                  f"{len(result.get('unresolved') or [])} unresolved, "
+                  f"{len(result['unrepairable'])} unrepairable")
+            summary.update({
+                'repaired': len(result['repaired']),
+                'unrepairable': len(result['unrepairable']),
+                'moved_refs': [m['reference'] for m in result['moves']],
+                'max_move_mm': round(max_move, 3),
+                'deadline_skipped': result.get('deadline_skipped') or [],
+            })
+            summary.update({f'{k}_before': v
+                            for k, v in result['pad_report_before'].items()})
+            _advance(result['moves'], 'repair')
+            if result['unrepairable']:
+                exit_rc = 4
+
+        summary['complete'] = ((result or {}).get('complete', True)
+                               and (reseat or {}).get('complete', True))
+        if not summary['complete'] and _dl is not None:
+            # Unlike place_reconstruct, the output IS written on expiry: the
+            # partial is coherent by construction here (a part is either fully
+            # seated, with every seat legality-checked before it was taken, or
+            # untouched), so there is no pre-legalize staging step whose result
+            # would be invalid to hand on.
+            krt_deadline.mark(
+                summary, _dl,
+                reseat_skipped=(reseat or {}).get('deadline_skipped') or [],
+                repair_skipped=(result or {}).get('deadline_skipped') or [],
+                output=None if args.dry_run else args.output_file)
         if not args.dry_run:
-            write_placed_output(args.input_file, args.output_file,
-                                result['moves'])
-            copy_siblings(args.input_file, args.output_file)
+            # A no-op still writes a board: the next step in a chain is handed
+            # a path, and "nothing needed doing" must not look like "the tool
+            # produced nothing".
+            write_placed_output(cur, args.output_file, [])
+            copy_siblings(cur, args.output_file)
             from placement.legality import grade_pad_legality
             pcb_out = parse_kicad_pcb(args.output_file)
             pads_after = grade_pad_legality(pcb_out, args.clearance)
@@ -187,10 +342,14 @@ Examples:
             summary['grade_errors'] = len(graded.errors)
             summary['pad_conflicts_after'] = pads_after['pad_conflicts']
             summary['hole_conflicts_after'] = pads_after['hole_conflicts']
-            print("JSON_SUMMARY: " + json.dumps(summary, sort_keys=True))
-            return 4 if (result['unrepairable'] or graded.errors) else 0
-        print("JSON_SUMMARY: " + json.dumps(summary, sort_keys=True))
-        return 4 if result['unrepairable'] else 0
+            summary['oob_pad_count_after'] = pads_after['oob_pad_count']
+            if graded.errors:
+                exit_rc = 4
+        _stage.cleanup()
+        krt_deadline.emit(summary, deadline=_dl)
+        if not summary['complete']:
+            return krt_deadline.DEADLINE_EXIT
+        return exit_rc
 
     if not st.unplaced and not st.partially_unplaced and not args.force:
         # PARTIALLY unplaced boards (a stacked pile beside real placements --
@@ -208,10 +367,47 @@ Examples:
     # re-derive; --force widens the scope back to everything unlocked.
     seed_refs = None
     if st.partially_unplaced and not st.unplaced and not args.force:
-        seed_refs = set(st.stacked_refs)
+        # SCOPE FOLLOWS THE GATE. `partially_unplaced` is now decided on the
+        # SUSPECT subset -- co-located parts that are not markers and not on
+        # opposite sides -- so scoping the seed from the full `stacked_refs`
+        # would re-seed the very parts the gate had just exonerated. A
+        # front/back fiducial pair shares a coordinate BY DESIGN; a run that
+        # tripped over one genuine pile would have moved every such pair on the
+        # board as a side effect, and nothing downstream would attribute it.
+        seed_refs = set(st.stacked_suspect_refs)
+        _benign = len(set(st.stacked_refs) - seed_refs)
         print(f"place_seed: partially unplaced -- seeding only the "
-              f"{len(seed_refs)} stacked part(s); the rest stand as placed "
-              f"(--force re-seeds everything unlocked)")
+              f"{len(seed_refs)} stacked part(s) that look like a pile; the "
+              f"rest stand as placed (--force re-seeds everything unlocked)"
+              + (f". {_benign} other co-located part(s) are left alone "
+                 f"(markers, or opposite sides of the board)" if _benign else ""))
+        # ...unless every one of them is (locked yes) IN THE FILE, in which
+        # case `seed_from_intent` treats them as authoritatively placed
+        # (seeder.py:396-400) and THE PILE CANNOT BE SEEDED AT ALL. Not exotic:
+        # this toolchain STAMPS its own locks (seeder.stamp_locked, on
+        # place_seed's own output), so a pile created by an earlier seeding run
+        # arrives here locked and gets announced as the scope of a run that
+        # then cannot touch it.
+        #
+        # Care with the claim: this is NOT "the run does nothing". The polish
+        # pass is on by default and moves plenty -- measured on a 65-part
+        # fixture, 41 parts moved while all three piled refs stayed put. That
+        # is exactly why refusing is right rather than pedantic: continuing
+        # would exit 0 having rearranged two thirds of the board and left the
+        # one thing this branch exists to fix untouched.
+        _movable = [r for r in sorted(seed_refs)
+                    if not getattr(pcb.footprints.get(r), 'locked', False)]
+        if not _movable:
+            print(f"place_seed: all {len(seed_refs)} of those part(s) are "
+                  f"(locked yes) in the file, so the pile CANNOT be seeded -- "
+                  f"seed_from_intent treats a file-locked ref as already "
+                  f"placed. Continuing would still move other parts (the "
+                  f"polish pass is on by default) and exit 0 with the pile "
+                  f"exactly as it is, so this refuses instead. Unlock those "
+                  f"refs to seed them; --force re-seeds the WHOLE board and "
+                  f"discards the existing placement; place_optimize.py is the "
+                  f"tool if polish was all you wanted.", file=sys.stderr)
+            return UNPLACED_EXIT
 
     rng = random.Random(f"{args.seed}")
     result = seeder.seed_from_intent(

--- a/py_placer/placement/floorplan.py
+++ b/py_placer/placement/floorplan.py
@@ -60,6 +60,27 @@ WARN = 'warn'
 DEFAULT_ZONE_TOLERANCE_MM = 0.5
 DEFAULT_ENVELOPE_TOLERANCE_MM = 0.5
 
+#: Floor for how large an OBSERVED overhang may be and still be emitted as a
+#: declared edge band. An observation entry converts what the board DOES into
+#: what the spec ALLOWS, and above this there is no plausible reading under
+#: which it is a spec: a part hanging 160 mm off an 81 mm board is not an edge
+#: connector with a 160 mm band, it is a part that was dragged off the board.
+#:
+#: The real cap is `max(this, the part's own largest dimension)` -- an overhang
+#: cannot exceed the part's own size without the part being entirely off the
+#: outline -- and this floor keeps a small part's legitimate band (a 0603 test
+#: point half off the edge, a switch actuator) from being called damage.
+#:
+#: Measured, run 10: `check_floorplan --emit-intent --declare-classes` on a
+#: damaged board declared all ELEVEN off-board parts edge connectors with bands
+#: equal to their damage displacement (R7 east 34.792 ... TP4 north 160.062).
+#: Every downstream consumer then went blind: seeder's off-board census skips
+#: declared edge refs, so `--repair` found 5 violators and none of the 11; and
+#: reconstruct's gate read `oob = 4.348` on a board with parts 158 mm out
+#: (929.671 without the bands). This generalises the mount_hole refusal below,
+#: which already knows this failure mode for one part class.
+EDGE_BAND_SANITY_MM = 5.0
+
 _TOP_LEVEL_KEYS = {
     'schema', 'kind', 'board', 'units', 'envelope', 'defaults', 'blocks',
     'keepouts', 'edge_connectors', 'decaps', 'must_lock', 'legality_budget',
@@ -157,6 +178,21 @@ class Intent:
             return float(zone.tolerance_mm)
         return float(self.defaults.get('zone_tolerance_mm',
                                        DEFAULT_ZONE_TOLERANCE_MM))
+
+
+def empty_intent(board: str = '') -> Intent:
+    """An intent that declares nothing -- every construct empty.
+
+    For engine paths that are intent-DRIVEN but must still run when the caller
+    has none (`place_reconstruct` without `--intent`, `place_seed --reseat` on a
+    board with no floorplan file). Declaring nothing is not the same as having
+    no intent object: the seeding stages read zones, edge bands and must_lock
+    off it, and each of those reads is a no-op here rather than a branch at
+    every site."""
+    return Intent(schema=SCHEMA_VERSION, kind=KIND, board=board, units='mm',
+                  envelope={}, defaults={}, blocks=(), keepouts=(),
+                  edge_connectors=(), decaps={}, must_lock=(),
+                  legality_budget={}, health={}, severity={})
 
 
 # --------------------------------------------------------------------------
@@ -1113,6 +1149,12 @@ def grade(intent: Intent, pcb_data, pcb_file: str, *,
                'outside_fraction': (None if st.outside_fraction is None
                                     else round(st.outside_fraction, 4)),
                'stacked_refs': list(st.stacked_refs),
+               # The subset `partially_unplaced` is actually decided on, and
+               # the one place_seed scopes its seed from. Without it a reader
+               # sees `partially_unplaced: false` beside a non-empty
+               # `stacked_refs` and has no way to tell "suppressed as markers /
+               # opposite sides" from a bug in the check.
+               'stacked_suspect_refs': list(st.stacked_suspect_refs),
                'segments': st.segments, 'vias': st.vias},
         health=health_out,
         rules_run=tuple(ran), rules_skipped=skipped,
@@ -1272,11 +1314,28 @@ def emit_intent(pcb_data, pcb_file: str, *,
                                     f'sits fully on-board')
         return None
 
+    def _band_cap(ref: str) -> float:
+        """The largest overhang that can still be READ as a declared band.
+
+        An overhang wider than the part itself puts the part entirely off the
+        outline, which no spec expresses; below that, `EDGE_BAND_SANITY_MM`
+        keeps a small part's legitimate band from being called damage."""
+        rect = parts[ref].rect
+        try:
+            extent = max(abs(rect[2] - rect[0]), abs(rect[3] - rect[1]))
+        except Exception:                                       # noqa: BLE001
+            extent = 0.0
+        return max(EDGE_BAND_SANITY_MM, extent)
+
     conns = []
     declared = set()
     for ref in sorted(parts):
         amt = state.edge_gate.rect_outside_amount(parts[ref].rect)
         if amt > legality.EPS:
+            # An OBSERVED overhang above the sanity cap is not a band. Emitting
+            # it as one launders the damage into the spec that is supposed to
+            # gate the damage's repair -- see EDGE_BAND_SANITY_MM.
+            over_cap = amt > _band_cap(ref)
             fp = (pcb_data.footprints or {}).get(ref)
             pc = None
             if fp is not None:
@@ -1306,16 +1365,45 @@ def emit_intent(pcb_data, pcb_file: str, *,
                     entry['class'] = pc.name
                     entry['source'] = 'auto-class'
                     entry['overhang_mm'] = default_band(pc.name, fp)
+                elif over_cap:
+                    entry['overhang_mm'] = {'min': 0.0,
+                                            'max': round(_band_cap(ref), 3)}
+                    entry['overhang_capped'] = True
+                    entry['observed_overhang_mm'] = round(amt, 3)
+                    entry['note'] += (
+                        f'; observed overhang {amt:.3f}mm exceeds any '
+                        f'plausible band ({_band_cap(ref):.3f}mm) and is '
+                        f'treated as DAMAGE, not an allowance')
                 else:
                     entry['overhang_mm'] = {'min': 0.0,
                                             'max': round(amt + 0.5, 3)}
                 conns.append(entry)
                 declared.add(ref)
                 continue
-            entry = {'ref': ref, 'edge': _nearest_edge(parts[ref].rect,
-                                                       bounds),
-                     'overhang_mm': {'min': 0.0,
-                                     'max': round(amt + 0.5, 3)}}
+            if over_cap:
+                # NO `edge` key: the schema supports edge-less entries and both
+                # the seeder's stage 1 (seeder.py:409-417) and its repair path
+                # already handle them by declining to guess. The band is capped
+                # rather than emitted at the observed amount, so a consumer
+                # that reads only `overhang_mm` cannot be blinded either.
+                entry = {'ref': ref,
+                         'overhang_mm': {'min': 0.0,
+                                         'max': round(_band_cap(ref), 3)},
+                         'overhang_capped': True,
+                         'observed_overhang_mm': round(amt, 3),
+                         'note': (f'overhang observed at {amt:.3f}mm, which '
+                                  f'exceeds any plausible band '
+                                  f'({_band_cap(ref):.3f}mm) -- treated as '
+                                  f'DAMAGE, not an allowance: no edge is '
+                                  f'declared and the excess is charged. An '
+                                  f'observation entry that blesses this is '
+                                  f'how a 160mm displacement became a 160mm '
+                                  f'spec allowance (run 10)')}
+            else:
+                entry = {'ref': ref, 'edge': _nearest_edge(parts[ref].rect,
+                                                           bounds),
+                         'overhang_mm': {'min': 0.0,
+                                         'max': round(amt + 0.5, 3)}}
             if declare_classes and pc is not None \
                     and pc.name in ('edge_receptacle', 'edge_actuator'):
                 entry['class'] = pc.name

--- a/py_placer/placement/legality.py
+++ b/py_placer/placement/legality.py
@@ -1028,6 +1028,22 @@ class LegalityContext:
         self.pose_of = pose_of
         self.seed_of = seed_of
         self._baselines: Dict[Tuple[str, str], PairShortfall] = {}
+        # run-19: a PILE seed is not a license. Every conjunct of pads_ok is
+        # relative to seed_baseline, and on a pile the seed pair carries huge
+        # base.pad with pad_overlap and stack both True -- so ANY smaller
+        # intersection passed (measured: the SW23/SW28<->U2 blocker pairs).
+        # A seed bucket of >= 3 parts at one round(coord, 3) point is the
+        # pile signature; every part in one loses its baseline license and
+        # must be absolutely clean toward every neighbor. Deliberately above
+        # 2: a legitimate two-part by-design overlap (run 18's under-module
+        # R1<->U2 pairs) KEEPS its license.
+        _buckets: Dict[Tuple[float, float], List[str]] = {}
+        for _ref in part_pads:
+            _sx, _sy = seed_of(_ref)[:2]
+            _buckets.setdefault((round(_sx, 3), round(_sy, 3)),
+                                []).append(_ref)
+        self._degenerate_refs = frozenset(
+            r for refs in _buckets.values() if len(refs) >= 3 for r in refs)
 
     # -- pair measurement ------------------------------------------------------
     def pair_shortfall(self, a: str, b: str, pose_a=None,
@@ -1081,6 +1097,11 @@ class LegalityContext:
         return PairShortfall(pad_short, overlap, hole, stack)
 
     def seed_baseline(self, a: str, b: str) -> PairShortfall:
+        # The single choke point every consumer routes through (pads_ok and
+        # swap_pads_ok): a part from a degenerate seed bucket gets the ZERO
+        # baseline, which is exactly the semantics a pile deserves.
+        if a in self._degenerate_refs or b in self._degenerate_refs:
+            return ZERO_SHORTFALL
         key = (a, b) if a <= b else (b, a)
         base = self._baselines.get(key)
         if base is None:

--- a/py_placer/placement/legality.py
+++ b/py_placer/placement/legality.py
@@ -1131,6 +1131,33 @@ class LegalityContext:
         return self.gate.rect_outside_amount(ext, exact=exact, edges=edges)
 
 
+def format_oob_clause(report, limit: int = 6) -> str:
+    """One line naming the off-board parts AND which measure produced them.
+
+    Lives beside the measure so the CLIs that print it cannot drift -- hand
+    copying a basis string into each is the Class-2 CLI drift CLAUDE.md warns
+    about, and no parity gate covers a print.
+
+    Sorted by AMOUNT, worst first. Sorting by ref and then truncating hides the
+    offenders that matter: on one board the four mounting holes at 3.0mm sat
+    behind five fiducials at 0.875mm. That is the run-4 census-cap defect,
+    which this module already records elsewhere.
+    """
+    refs = list(report.get('oob_pad_refs') or [])
+    if not refs:
+        return ''
+    refs.sort(key=lambda ra: -ra[1])
+    shown = ', '.join('{} ({}mm)'.format(r, a) for r, a in refs[:limit])
+    more = ' ... showing {} of {}'.format(limit, len(refs)) if len(refs) > limit else ''
+    basis = (
+        "    (part pad AABB -- pads PLUS NPTH drill circles, summed over the "
+        "union rect's four sides -- against an outline inflated by the GRADING "
+        "CLEARANCE. It moves when --clearance moves, so a hit here is not "
+        "necessarily copper off the outline. The per-pad, margin-0 outline "
+        "measure is render_placement's checklist.a_off_outline.pad_copper.)")
+    return shown + more + "\n" + basis
+
+
 def grade_pad_legality(pcb_data, clearance: float, exact: bool = True,
                        edge_margin: Optional[float] = None,
                        worst_n: int = 10) -> Dict[str, object]:
@@ -1245,6 +1272,10 @@ def grade_pad_legality(pcb_data, clearance: float, exact: bool = True,
 
     oob_count = 0
     oob_amount = 0.0
+    # NAME them. This returned a bare count, so the three CLIs that print it
+    # ("N part(s) with pad copper off-board") could not say WHICH part -- one
+    # run deduced the single ref by elimination.
+    oob_refs = []
     board_info = getattr(pcb_data, 'board_info', None)
     if board_info is not None and getattr(board_info, 'board_bounds', None):
         gate = BoardOutlineGate(board_info,
@@ -1259,12 +1290,25 @@ def grade_pad_legality(pcb_data, clearance: float, exact: bool = True,
             if amt > EPS:
                 oob_count += 1
                 oob_amount += amt
+                oob_refs.append([ref, round(amt, 4)])
     worst.sort(key=lambda t: -t[2])
     return {'pad_conflicts': pad_conflicts,
             'pad_shortfall': round(pad_shortfall, 4),
             'hole_conflicts': hole_conflicts,
             'oob_pad_count': oob_count,
             'oob_pad_amount': round(oob_amount, 4),
+            'oob_pad_refs': sorted(oob_refs),
+            # WHICH QUANTITY THIS IS. Three tools print "pad copper
+            # off-board" for three different measurements. This one is the
+            # part's pad AABB against an outline inflated by the GRADING
+            # CLEARANCE -- so it moves when --clearance moves, and a rotated
+            # part reports a breach no pad makes. render_placement's
+            # `checklist.a_off_outline.pad_copper` is the per-PAD, margin-0
+            # outline measure the docs designate as authoritative.
+            'oob_pad_basis': ('part pad AABB vs outline inflated by the '
+                              'grading clearance (NOT the per-pad outline '
+                              'measure; see render_placement '
+                              'checklist.a_off_outline.pad_copper)'),
             # worst_n <= 0 = list ALL (run-4 F5: the repair rung's census
             # was silently capped at 10 movers on a 20-pair board).
             'worst': worst[:worst_n] if worst_n and worst_n > 0 else worst,

--- a/py_placer/placement/lock_advisor.py
+++ b/py_placer/placement/lock_advisor.py
@@ -30,6 +30,20 @@ the output says so.
 
 A ref matched by rules from two DIFFERENT evidence channels (one geometric, one
 lexical) promotes to `high`: two channels that fail independently.
+
+## Structure is the third question, and it used to be unasked
+
+Every rule above asks what a part IS (a connector, a hole) or where it sits
+relative to the OUTLINE. Neither can see that a part is a member of an
+ARRANGEMENT -- a ring of LEDs, a bolt circle, a fiducial triangle -- and a
+placement search that cannot see one will happily take a member out of it to
+buy a legality number. Measured: a 63-second targeted `place_optimize` lap
+moved a decoupling cap 30 mm (and flipped it 180 deg) out of a geometrically
+perfect 8-fold ring, and was reported as the run's best moment.
+`reconstruct.fit_family_orbits` supplies that fact and `family_orbit_seat`
+promotes it to HIGH, because a fitted seat is a decision the board already
+made. It is silent on all 33 healthy corpus boards (a complete orbit has no
+free slot and an over-determined fit needs one).
 """
 from __future__ import annotations
 
@@ -123,12 +137,59 @@ def _prefix(ref: str) -> str:
     return (m.group(1) if m else '').upper()
 
 
+def _straddles_outline(gate, rect) -> Optional[bool]:
+    """Is any of this rect still ON the board?
+
+    An overhang means two opposite things depending on the answer, and the
+    advisor used to conflate them. A part MOUNTED to the edge -- a connector,
+    a castellated module -- straddles the outline: its pads are on the board,
+    which is how it is soldered, and only its shell hangs past the edge. A part
+    that has been DISPLACED sits wholly outside, touching nothing.
+
+    Both report an overhang, so overhang alone cannot tell them apart, and
+    treating every overhang as an edge-mount promotes the damage itself to a
+    lock recommendation -- which freezes it exactly where it must not stay.
+
+    None when there is no outline to ask.
+
+    A rectangular board has no rings at all -- the gate reports `active=False`
+    because its outline IS its bounding box -- and `_point_on_board` answers
+    True for every point when handed no outer ring. Asking it alone would make
+    this test say "straddles" for a part parked far off the board, which is the
+    answer that costs the most. Fall back to the bounds in that case.
+    """
+    if gate is None or rect is None:
+        return None
+    x0, y0, x1, y1 = rect
+    pts = ((x0, y0), (x1, y0), (x1, y1), (x0, y1),
+           ((x0 + x1) / 2.0, (y0 + y1) / 2.0))
+    outer = getattr(gate, 'outer', None)
+    if outer:
+        try:
+            from check_drc import _point_on_board
+            return any(_point_on_board(px, py, outer, gate.cutouts)
+                       for px, py in pts)
+        except Exception:
+            return None
+    bounds = getattr(gate, 'bounds', None)
+    if not bounds:
+        return None
+    bx0, by0, bx1, by1 = bounds
+    return any(bx0 <= px <= bx1 and by0 <= py <= by1 for px, py in pts)
+
+
 def advise_locks(pcb_data, pcb_file: Optional[str] = None, *,
                  lock_patterns: Optional[Sequence[str]] = None,
                  min_confidence: str = 'medium',
                  edge_margin: float = 1.0,
+                 conflict_clearance: Optional[float] = None,
                  use_globs: bool = False) -> LockAdvice:
-    """Findings for every footprint, sorted (confidence, ref). Never mutates."""
+    """Findings for every footprint, sorted (confidence, ref). Never mutates.
+
+    `conflict_clearance` is the floor the pad-conflict demotion grades at.
+    None = read the board's own Default netclass (never a guessed round
+    number), else `routing_defaults.CLEARANCE`.
+    """
     from placement.legality import BoardOutlineGate, footprint_side
     from placement.placement_state import _global_rect
     from placement.legality import rotate_local_bounds
@@ -160,6 +221,72 @@ def advise_locks(pcb_data, pcb_file: Optional[str] = None, *,
             gate = BoardOutlineGate(pcb_data.board_info, 0.0)
     except Exception:
         gate = None
+
+    # A part whose pad copper INTERSECTS another part's is not lockable, at any
+    # confidence a lexical rule can supply. Freezing one side of a short does
+    # not resolve it -- it decides, silently, that the OTHER side is the one to
+    # move, and the other side may be the part that was never damaged.
+    #
+    # Measured, run 11 (smartknob): J3 shorted R20. J3 was promoted to HIGH on
+    # `near_board_edge` + a `J` prefix and locked; the repair then had no legal
+    # pose for R20 within any cap and re-seated it 11.883 mm, which was the
+    # entire collateral of that run -- and R20 had been at its correct pose all
+    # along, while J3 was a member of a 30-part block displaced 38.65 mm.
+    #
+    # (The first version of this guard keyed on "edge proximity is vacuous on
+    # an annular board". Measurement refuted it: on that very board the edge
+    # rule fires on 20 of 84 on-board parts, 24% -- discriminating, not
+    # vacuous. Participating in a short is the signal that actually separates
+    # J3 from the 16 ring members, and unlike displacement it is derivable from
+    # the board alone.)
+    # Graded at the advisor's own edge_margin-independent floor: a conflict is
+    # a shortfall against the board's clearance, so clearance 0 finds nothing
+    # (measured: 0 pairs at 0.0, 5 at 0.2 on run 11's board).
+    _cc = conflict_clearance
+    if _cc is None:
+        try:
+            from list_nets import board_default_netclass_clearance
+            _cc = board_default_netclass_clearance(pcb_file) if pcb_file else None
+        except Exception:
+            _cc = None
+    if not _cc:
+        try:
+            from routing_defaults import CLEARANCE as _DEF_CLR
+            _cc = _DEF_CLR
+        except Exception:
+            _cc = 0.25
+    _conflict_refs: set = set()
+    try:
+        from placement.legality import grade_pad_legality
+        _rep = grade_pad_legality(pcb_data, _cc, worst_n=0)
+        for _a, _b, _mm in (_rep.get('worst') or ()):
+            _conflict_refs.add(_a)
+            _conflict_refs.add(_b)
+    except Exception:
+        _conflict_refs = set()
+
+    # STRUCTURE the advisor could not previously see. A part standing on a
+    # fitted family orbit -- an LED ring, a fiducial circle, a bolt circle --
+    # is at a seat the board already chose, and every other rule here is blind
+    # to it: they ask what a part IS (a connector, a hole) or where it is
+    # relative to the OUTLINE, never whether it is a member of an arrangement.
+    #
+    # Measured, run 10: an 8-fold LED ring (D1-D8) and its 8 decoupling caps
+    # (C1-C8) were geometrically perfect on the damaged board. The advisor
+    # rated D1-D8 and C7/C8 MEDIUM, the run's --lock list took HIGH only, and a
+    # 63-second legality search then flung C7 30 mm across the board (flipped
+    # 180 deg) and pulled D7 7 mm out of the ring to buy a legality number.
+    # Six of the eight ring caps survived BY ACCIDENT, on an edge-proximity
+    # rule that had no idea a ring existed. This finding is what would have
+    # made that lap impossible.
+    orbit_seat: Dict[str, object] = {}
+    try:
+        import pose_score
+        from placement import reconstruct as _recon
+        _st = pose_score.make_state(pcb_data, pcb_file or '')
+        orbit_seat = _recon.orbit_seats(_recon.fit_family_orbits(_st))
+    except Exception:                                          # noqa: BLE001
+        orbit_seat = {}
 
     for ref, fp in sorted((pcb_data.footprints or {}).items()):
         if not fp.pads:
@@ -202,11 +329,26 @@ def advise_locks(pcb_data, pcb_file: Optional[str] = None, *,
                 f"cost, so only the halo term decides where it goes")
             geometric = True
 
-        # --- rule 2: the body leaves the outline. Geometric fact.
+        # --- rule 2: the body leaves the outline. Geometric fact -- but WHICH
+        # fact depends on whether the body still straddles the edge.
+        displaced_off_board = False
         if out is not None and out > 1e-6:
-            rules.append('off_board_overhang')
-            reasons.append(f"courtyard leaves the board outline by {out:.2f} mm")
-            geometric = True
+            if _straddles_outline(gate, rect) is False:
+                # Wholly outside. This is displacement evidence, and the
+                # opposite of a reason to freeze the part where it lies.
+                rules.append('off_board_entirely')
+                reasons.append(
+                    f"body lies WHOLLY off the board (outline violation "
+                    f"{out:.2f} mm, no corner or centre on the board). An "
+                    f"edge-mounted part straddles the outline; this one "
+                    f"touches nothing, so the overhang is evidence of "
+                    f"DISPLACEMENT, not of an edge seat.")
+                displaced_off_board = True
+            else:
+                rules.append('off_board_overhang')
+                reasons.append(
+                    f"courtyard leaves the board outline by {out:.2f} mm")
+                geometric = True
         # --- rule 3: close to the edge. Measurement exact, inference weak.
         elif clr is not None and clr < edge_margin:
             rules.append('near_board_edge')
@@ -243,6 +385,28 @@ def advise_locks(pcb_data, pcb_file: Optional[str] = None, *,
                            f"({', '.join(sorted(pins & _IFACE_PINS))[:40]})")
             lexical = True
 
+        # --- rule 7: at seat on a fitted family orbit. Geometric fact.
+        _orb = orbit_seat.get(ref)
+        if _orb is not None:
+            rules.append('family_orbit_seat')
+            others = [r for r in _orb.inliers if r != ref]
+            reasons.append(
+                f"at seat on a fitted {_orb.m}-fold family orbit "
+                f"(r = {_orb.r:.4f} mm about "
+                f"({_orb.cx:.4f}, {_orb.cy:.4f}), {len(_orb.inliers)} of "
+                f"{_orb.slots} seats filled), corroborated by "
+                f"{len(others)} other member(s): "
+                f"{', '.join(others[:8])}"
+                f"{'...' if len(others) > 8 else ''}. This pose is a decision "
+                f"the board already made and no wirelength or legality gain "
+                f"may buy it -- a search that moves one member out of an "
+                f"intact array has dismantled a structure to improve a number")
+            ev['orbit_family'] = _orb.family
+            ev['orbit_m'] = _orb.m
+            ev['orbit_radius_mm'] = round(_orb.r, 4)
+            ev['orbit_corroborating'] = len(others)
+            geometric = True
+
         # --- advisory (reported, deliberately NOT in the lock list)
         if len(netted) >= HIGH_PIN_ADVISORY:
             adv.advisories.append({
@@ -268,7 +432,17 @@ def advise_locks(pcb_data, pcb_file: Optional[str] = None, *,
             continue
 
         conf = 'high' if ('mounting_hole_npth' in rules
-                          or 'off_board_overhang' in rules) else None
+                          or 'off_board_overhang' in rules
+                          or 'family_orbit_seat' in rules) else None
+        if displaced_off_board:
+            # A lock is not a placement. Whatever else this part looks like,
+            # it is not where it belongs, and the paste-ready line must not
+            # carry it -- pasting it freezes the damage.
+            conf = 'low'
+            reasons.append(
+                "[DEMOTED: wholly off-board. Reconstruct or repair this part "
+                "onto the board before considering a lock; a lock here "
+                "records the damaged pose as a decision.]")
         if conf is None:
             # Two INDEPENDENT evidence channels beat either alone.
             if geometric and lexical:
@@ -287,6 +461,30 @@ def advise_locks(pcb_data, pcb_file: Optional[str] = None, *,
         # of the paste-ready list -- run 3's J1 carried three lexical
         # connector signals at MEDIUM, and a medium-cutoff round trip would
         # have frozen it 15.8 mm from its true edge slot.
+        # Participates in a pad SHORT: never HIGH, whatever agreed to promote
+        # it. A lock here is not "this pose is a decision", it is "the other
+        # part is the one that moves" -- a choice the advisor has no evidence
+        # to make, and which cost run 11 its whole collateral figure.
+        # ...UNLESS the part stands on a fitted family orbit. That is
+        # independent, positive evidence the pose is right, and it is exactly
+        # what separates the two populations here: on run 11's board the
+        # conflict set is {C7, U2, D7, C18, R13, J3, R20, C20, U3}, and C7/D7
+        # are LED-ring members on complete 8-of-8 orbits whose lock is the very
+        # thing that stops a legality search dismantling the ring (run 10 flung
+        # C7 30 mm and pulled D7 out of it). Demoting them would re-enable that.
+        # J3 carries no such corroboration, so it is the one that drops.
+        if (ref in _conflict_refs and conf == 'high'
+                and 'family_orbit_seat' not in rules):
+            conf = 'medium'
+            ev['pad_conflict'] = True
+            reasons.append(
+                "[DEMOTED from HIGH: this part's pad copper conflicts with "
+                "another part's, and nothing independent corroborates this "
+                "pose. Locking one side of a conflict does not resolve it, it "
+                "silently elects the other side to move -- and that side may be "
+                "the part that was never displaced. Resolve the conflict, then "
+                "reconsider the lock.]")
+
         if pc.name == 'edge_receptacle' and plaus is False:
             conf = 'low'
             reasons.append(
@@ -370,6 +568,12 @@ def to_json(adv: LockAdvice) -> Dict:
                       'class_confidence': f.class_confidence,
                       'pose_plausible': f.pose_plausible} for f in adv.findings],
         'advisories': adv.advisories,
+        # The tally goes in the FILE, not only on stdout. The placement
+        # driver's next stage gates on `unlocked_high`, reading it from this
+        # JSON -- and this JSON did not carry it, so the guard read None,
+        # decided there was nothing to object to, and passed. A gate whose key
+        # its own producer omits is a gate that never fires.
+        **adv.tally(),
         'lock_patterns': adv.lock_patterns(),
         'lock_argv': (['--lock'] + adv.lock_patterns()) if adv.lock_patterns() else [],
     }

--- a/py_placer/placement/perturb.py
+++ b/py_placer/placement/perturb.py
@@ -325,6 +325,46 @@ def _placements(state, offsets: Dict[str, Tuple[float, float]]) -> List[Dict]:
     return out
 
 
+def _all_at_current(state, placements: List[Dict], pcb_data=None) -> List[Dict]:
+    """Every part, so the FORMATTING of `(at)` says nothing about the draw.
+
+    `placement.writer.write_placed_output` rewrites `(at x y)` with six decimals
+    for exactly the footprints it is handed, and leaves every other one
+    byte-identical. That makes the moved set readable straight off the output
+    text, with no tooling and no truth: run 14's perturbed block was recovered
+    by counting six-decimal `(at)` forms -- 24 of 235, against 0 on two
+    untouched corpus boards -- and it survived a copper strip. This module's own
+    docstring says the kind, dose, seed and block are "disclosed nowhere", and
+    the block was in the file the whole time. Every past run leaked its the same
+    way.
+
+    So hand the writer EVERY part: the members at their new pose, everyone else
+    at the pose they already have. One formatter, one precision, no subset to
+    count. Poses are unchanged for non-members -- only their formatting is.
+    """
+    by_ref = {p['reference']: p for p in placements}
+    fps = (pcb_data.footprints or {}) if pcb_data is not None else {}
+    out = []
+    for ref in sorted(state.parts):
+        if ref in by_ref:
+            out.append(by_ref[ref])
+            continue
+        # The pose AS PARSED, not the state's. `make_state` normalises rotation
+        # into [0, 360), so a footprint written `-90` comes back as `270` -- the
+        # same angle, and a 360 delta to anything that compares the numbers
+        # without normalising. These parts did not move; nothing about them
+        # should change but the number of decimals.
+        fp = fps.get(ref)
+        if fp is not None:
+            out.append({'reference': ref, 'new_x': round(fp.x, 6),
+                        'new_y': round(fp.y, 6), 'new_rotation': fp.rotation})
+            continue
+        p = state.parts[ref]
+        out.append({'reference': ref, 'new_x': round(p.x, 6),
+                    'new_y': round(p.y, 6), 'new_rotation': p.rot})
+    return out
+
+
 def _pile_placements(state, members: Sequence[str], pcb_data) -> List[Dict]:
     """Collapse `members` onto ONE coordinate.
 
@@ -360,7 +400,8 @@ def perturb(board: str, out_board: str, *, kind: str = 'translate',
             max_fanout: int = 20, grid_step: float = 0.1,
             clearance: float = 0.25, board_edge_clearance: float = 0.55,
             on_overflow: str = 'clip', seed: int = 0,
-            write_record: bool = True) -> Dict:
+            write_record: bool = True,
+            control_out: Optional[str] = None) -> Dict:
     """Write a perturbed board plus its ground-truth record. Returns the record.
 
     The CONTROL is the `--dose 0` pass of this same writer, never the raw input
@@ -368,6 +409,18 @@ def perturb(board: str, out_board: str, *, kind: str = 'translate',
     `move_copper_text_to_silkscreen` over the whole file and can inject via
     moves -- so comparing a perturbed output against the raw input would differ
     by a text transformation nobody accounted for.
+
+    `control_out` IS THE FENCE, and the default is the unsafe one kept only for
+    compatibility. The control is the human placement pose-for-pose, so writing
+    it beside `out_board` -- which is what happens when this is None -- drops
+    ground truth INSIDE the directory the run then works in, where any glob, any
+    `--before`, any tool taking a directory can read it. Run 12 caught it by
+    reading a directory listing and moved the file out by hand; a run that did
+    not look would have been fenced on paper and open in fact. Pass a path
+    outside the work dir (`<subject>/_truth/`, see tests/stress/RUNBOOK.md).
+
+    Either way the destination is PRINTED, so a staging script cannot be
+    unaware of where truth landed -- silence was the other half of the defect.
     """
     if kind not in KINDS:
         raise ValueError(f'unknown kind {kind!r}; have {", ".join(KINDS)}')
@@ -508,10 +561,28 @@ def perturb(board: str, out_board: str, *, kind: str = 'translate',
                                                    grid_step=grid_step))
 
     # The control: the SAME writer, dose 0.
-    control = os.path.splitext(out_board)[0] + '.control.kicad_pcb'
-    write_placed_output(board, control, [])
+    control = (control_out or
+               os.path.splitext(out_board)[0] + '.control.kicad_pcb')
+    _cdir = os.path.dirname(os.path.abspath(control))
+    if _cdir:
+        os.makedirs(_cdir, exist_ok=True)
+    # EVERY part, not none: same reason the perturbed board below gets the
+    # full list. A control formatted differently from its subject is itself a
+    # comparison anyone could make.
+    write_placed_output(board, control, _all_at_current(st, [], pcb))
     copy_siblings(board, control)
-    write_placed_output(board, out_board, placements)
+    # Say where truth went, ALWAYS. This board carries the original placement
+    # pose-for-pose; a caller that does not know its path cannot fence it.
+    _inside = (os.path.dirname(os.path.abspath(control)) ==
+               os.path.dirname(os.path.abspath(out_board)))
+    print(f"CONTROL (GROUND TRUTH) -> {os.path.abspath(control)}", flush=True)
+    if _inside and control_out is None:
+        print("  WARNING: that is the SAME directory as the perturbed output, "
+              "so the human placement is inside the work dir the run will "
+              "read. Pass control_out=<somewhere outside> (the staging recipe "
+              "uses a sibling _truth/), or fence_audit --mode create will "
+              "report it as a LEAK -- which it is.", flush=True)
+    write_placed_output(board, out_board, _all_at_current(st, placements, pcb))
     copy_siblings(board, out_board)
 
     ctrl_pcb = parse_kicad_pcb(control)
@@ -561,8 +632,20 @@ def perturb(board: str, out_board: str, *, kind: str = 'translate',
         'perturbed_pad_rms']
 
     if write_record:
-        with open(os.path.splitext(out_board)[0] + '.perturb.json', 'w',
-                  encoding='utf-8') as fh:
+        # THE RECORD FOLLOWS THE CONTROL, because it carries `original_poses`
+        # and is therefore ground truth just as literally as the control board
+        # is. Leaving it in the work dir while the control was fenced would move
+        # the leak rather than close it (run 12 moved it out by hand for exactly
+        # this reason). With `control_out` unset the control sits beside
+        # `out_board`, so this resolves to the historical path unchanged.
+        _stem = os.path.splitext(os.path.basename(out_board))[0]
+        record_path = (os.path.splitext(out_board)[0] + '.perturb.json'
+                       if control_out is None
+                       else os.path.join(os.path.dirname(os.path.abspath(control)),
+                                         _stem + '.perturb.json'))
+        with open(record_path, 'w', encoding='utf-8') as fh:
             json.dump(record, fh, indent=1, sort_keys=True)
             fh.write('\n')
+        print(f"RECORD (GROUND TRUTH) -> {os.path.abspath(record_path)}",
+              flush=True)
     return record

--- a/py_placer/placement/placement_state.py
+++ b/py_placer/placement/placement_state.py
@@ -70,6 +70,12 @@ class PlacementState:
     # must not be able to manufacture an "unplaced" verdict.
     outside_fraction: Optional[float] = None
     stacked_refs: List[str] = field(default_factory=list)
+    #: The subset of `stacked_refs` that is not explicable as deliberate
+    #: co-location -- i.e. neither on a side the others cannot reach (a DRILLED
+    #: part reaches both) nor a marker class. Being LOCKED is deliberately not
+    #: an excuse; see the NOTE in `_suspect_in`. `partially_unplaced` keys on
+    #: THIS, not on `stacked_refs`.
+    stacked_suspect_refs: List[str] = field(default_factory=list)
     segments: int = 0
     vias: int = 0
 
@@ -107,7 +113,109 @@ def assess_placement(pcb_data, pcb_file: Optional[str] = None,
         pos.setdefault((round(fp.x, 3), round(fp.y, 3)), []).append(fp.reference)
     st.distinct_positions = len(pos)
     dup_refs = sorted(r for refs in pos.values() if len(refs) > 1 for r in refs)
+
+    # A CO-LOCATED PAIR IS NOT AUTOMATICALLY A PILE-UP. This was bare origin
+    # equality over every pad-bearing footprint, so six fiducials sitting on
+    # four mounting holes -- placed there deliberately, and stamped
+    # `(locked yes)` -- reported "N footprint(s) are stacked ... typically a
+    # netlist re-import dropping new parts at one spot", on a board where
+    # nothing had moved. TWO filters, both from data already in hand and both
+    # already trusted elsewhere in this codebase:
+    #
+    #   * opposite SIDES cannot pile up -- unless a part is DRILLED, which puts
+    #     it on both. legality._sides_interact draws exactly that line
+    #     ("None = through (both sides)"), and this filter now follows it.
+    #   * a MARKER class (fiducial / mount_hole / testpoint) is co-located by
+    #     design. legality._MARKER waives exactly this set for assembly.
+    #
+    # A third filter, "every part in the group is LOCKED", was tried and
+    # REMOVED -- see the NOTE in _suspect_in. It is named here because the
+    # field docstring and the operator-facing reason string both used to
+    # advertise it, which is worse than not having it.
+    #
+    # The strong signal (s1) keeps every ref, because a genuine pile-up buries
+    # markers and locks along with everything else; only the weak
+    # `partially_unplaced` signal is filtered.
+    _by_ref = {fp.reference: fp for fp in fps}
+    #: Matches legality._MARKER, which waives exactly this set for assembly.
+    _MARKER_CLASSES = ('fiducial', 'mount_hole', 'testpoint')
+
+    def _marker(ref):
+        try:
+            from placement.part_class import classify_part
+            # `.name`, not `.kind`. PartClass has fields (name, confidence,
+            # evidence); reading `.kind` raised AttributeError straight into
+            # the except below, so this whole filter was dead code while the
+            # warning text advertised it.
+            return classify_part(_by_ref[ref], ref).name in _MARKER_CLASSES
+        except Exception:                                   # noqa: BLE001
+            return False
+
+    def _sides_of(ref):
+        """Which physical sides this footprint occupies: ('F',), ('B',) or both.
+
+        A DRILLED part is on both, and that is not a nicety -- it is the case
+        this partition got wrong. `legality.footprint_side` alone put tigard's
+        J2 (F.Cu, nine 1.0mm drilled pads) and JP1 (B.Cu) in different groups,
+        each alone on its side, so both were exonerated. Moved to one
+        coordinate they produce SIX pad conflicts by `grade_pad_legality` --
+        this function was the only thing in the repo saying they were fine, and
+        it said so because it modelled a through-hole part as living on one
+        side. `legality._sides_interact` has always drawn the other line
+        ("None = through (both sides)"); `footprint_side` /
+        `footprint_has_through_pads` are the canonical readers, so use them
+        rather than comparing `fp.layer` strings.
+        """
+        fp = _by_ref[ref]
+        try:
+            from placement.legality import (footprint_has_through_pads,
+                                            footprint_side)
+            if footprint_has_through_pads(fp):
+                return ('F', 'B')
+            return (footprint_side(fp),)
+        except Exception:                                   # noqa: BLE001
+            # Unknown side is the SUSPICIOUS answer, not the safe one: put it
+            # on both so it groups with everything at this coordinate.
+            return ('F', 'B')
+
+    def _suspect_in(refs_at_one_spot):
+        """The refs at ONE coordinate that are not explicable, PER SIDE.
+
+        Partitioned by side rather than tested group-wide. A group-wide test
+        let ONE back-side part exonerate an arbitrarily large front-side pile:
+        measured, 105 parts at a single coordinate with one on the far side
+        reported zero suspects and an empty reason list -- silence about a
+        board in a far worse state than the one this filter was written for.
+        Parts on opposite sides cannot collide; parts on the SAME side still
+        can, however many neighbours the far side has -- and a drilled part is
+        on both sides, so it collides with either.
+        """
+        out = set()
+        by_side = {'F': [], 'B': []}
+        for r in refs_at_one_spot:
+            for s in _sides_of(r):
+                by_side[s].append(r)
+        for _side, group in by_side.items():
+            if len(group) < 2:
+                continue                    # alone on its side: nothing to hit
+            if all(_marker(r) for r in group):
+                continue                    # co-located by design
+            # NOTE what is deliberately NOT here: "all locked". A lock records
+            # a decision about WHERE a part goes; it does not make two parts
+            # able to occupy one space. And this toolchain stamps its own locks
+            # -- seeder.stamp_locked, called on place_seed's output -- so a
+            # pile-up the tools CREATED would have been invisible to the check
+            # meant to catch pile-ups. Markers are the real discriminator: a
+            # fiducial and a mounting hole are different physical things and
+            # share a coordinate by design. Costs nothing on the corpus: every
+            # board that changed was already suppressed by side or by class.
+            out.update(group)
+        return sorted(out)      # a through part appears in both side-groups
+
+    suspect = sorted(r for refs in pos.values() if len(refs) > 1
+                     for r in _suspect_in(refs))
     st.stacked_refs = dup_refs
+    st.stacked_suspect_refs = suspect
     st.duplicate_fraction = len(dup_refs) / len(fps)
     s1 = (st.duplicate_fraction >= th['dup_fraction']
           and st.distinct_positions <= max(3, 0.1 * len(fps)))
@@ -136,7 +244,7 @@ def assess_placement(pcb_data, pcb_file: Optional[str] = None,
                                        else round(st.outside_fraction, 3))}
 
     st.unplaced = bool(s1 or (s2 and s3) or (s3 and st.distinct_positions <= 2))
-    st.partially_unplaced = (not st.unplaced) and 0 < st.duplicate_fraction
+    st.partially_unplaced = (not st.unplaced) and bool(suspect)
 
     if s1:
         st.reasons.append(
@@ -150,10 +258,16 @@ def assess_placement(pcb_data, pcb_file: Optional[str] = None,
         st.reasons.append(
             f"{st.outside_fraction:.0%} of footprints lie outside the board outline")
     if st.partially_unplaced:
+        _benign_n = len(dup_refs) - len(suspect)
         st.reasons.append(
-            f"{len(dup_refs)} footprint(s) are stacked on another "
-            f"({', '.join(dup_refs[:8])}) -- typically a netlist re-import "
-            f"dropping new parts at one spot on an otherwise-placed board")
+            f"{len(suspect)} footprint(s) are stacked on another "
+            f"({', '.join(suspect[:8])}) -- typically a netlist re-import "
+            f"dropping new parts at one spot on an otherwise-placed board"
+            + (f" [{_benign_n} further co-located ref(s) look deliberate "
+               f"(the far side of the board, or a marker class) and are not "
+               f"counted -- note being LOCKED is NOT one of the excuses, "
+               f"because this toolchain stamps its own locks]"
+               if _benign_n else ""))
     return st
 
 

--- a/py_placer/placement/portfolio.py
+++ b/py_placer/placement/portfolio.py
@@ -559,7 +559,16 @@ def score_candidate(cand: Candidate, *, free: Sequence[str],
                        f"{baseline_oob}")
     # Pad+drill layer gates, same baseline-relative shape as the two above.
     pad_pairs = cand.metrics.get('pad_conflict_pairs', 0) or 0
-    if pad_pairs > baseline_pad_pairs:
+    # run-19: a PILE seed's baseline carries hundreds of pad pairs, and "no
+    # worse than the baseline" then licenses ANY smaller intersection count.
+    # Above 50 the baseline is degenerate -- compare against 0, and say so.
+    if baseline_pad_pairs > 50:
+        if pad_pairs > 0:
+            reasons.append(
+                f"{pad_pairs} pad-clearance conflict pair(s) vs 0: the seed "
+                f"baseline's {baseline_pad_pairs} is pile-degenerate (> 50) "
+                f"and licenses nothing")
+    elif pad_pairs > baseline_pad_pairs:
         reasons.append(f"{pad_pairs} pad-clearance conflict pair(s) vs the "
                        f"baseline's {baseline_pad_pairs}")
     hole_sf = cand.metrics.get('hole_shortfall', 0.0) or 0.0

--- a/py_placer/placement/portfolio.py
+++ b/py_placer/placement/portfolio.py
@@ -364,7 +364,8 @@ def pose_distance_mm(final_a: Dict[str, Tuple[float, float, float]],
 
 
 def _quench_to(src_board: str, dst_board: str, quench_kw: Dict,
-               groups: Optional[Dict]) -> Tuple[Dict, Dict]:
+               groups: Optional[Dict], cancel_check=None,
+               progress_callback=None) -> Tuple[Dict, Dict]:
     """Parse src, quench in-process, write the result AGAINST src (the seed
     file), carry siblings. Returns (metrics, final_poses)."""
     from kicad_parser import parse_kicad_pcb
@@ -373,7 +374,8 @@ def _quench_to(src_board: str, dst_board: str, quench_kw: Dict,
     pcb_local = parse_kicad_pcb(src_board)
     m: Dict = {}
     placements = quench(pcb_local, pcb_file=src_board, metrics_out=m,
-                        groups=groups, **quench_kw)
+                        groups=groups, cancel_check=cancel_check,
+                        progress_callback=progress_callback, **quench_kw)
     write_placed_output(src_board, dst_board, placements)
     copy_siblings(src_board, dst_board)
     return m, _final_poses(pcb_local, placements)
@@ -388,7 +390,8 @@ def generate(input_file: str, out_dir: str, *, seed: int = 0,
              swap_blocks: Optional[Dict[str, Sequence[str]]] = None,
              quench_kw: Optional[Dict] = None,
              groups: Optional[Dict] = None,
-             only: Optional[int] = None) -> Dict:
+             only: Optional[int] = None,
+             cancel_check=None, progress_callback=None) -> Dict:
     """Generate the portfolio: baseline quench (candidate 0) plus perturbed
     candidates 1..n_candidates-1, all boards written under `out_dir`.
 
@@ -423,7 +426,8 @@ def generate(input_file: str, out_dir: str, *, seed: int = 0,
     if only is None:
         print(f"[portfolio] candidate 0 (baseline): plain quench")
         board0 = os.path.join(out_dir, 'baseline_quenched.kicad_pcb')
-        m, final = _quench_to(input_file, board0, qkw, groups)
+        m, final = _quench_to(input_file, board0, qkw, groups, cancel_check=cancel_check,
+                   progress_callback=progress_callback)
         rms, moved = _displacement(final, origin, free)
         baseline = Candidate(
             index=0, strategy='baseline', seed_board=input_file, board=board0,
@@ -433,6 +437,12 @@ def generate(input_file: str, out_dir: str, *, seed: int = 0,
     indices = [only] if only is not None else list(range(1, n_candidates))
     candidates: List[Candidate] = []
     for i in indices:
+        # BETWEEN CANDIDATES, which is this loop's real unit: each one is a
+        # full quench over the whole board. Checking inside the quench too
+        # (it has its own hook) bounds the tail; this bounds the count.
+        if cancel_check is not None and cancel_check():
+            print(f"  portfolio: stopping before candidate {i} (budget)")
+            break
         if i < 1:
             raise ValueError(f"candidate index {i} out of range (baseline is "
                              f"not regenerable via only=; it has no stream)")
@@ -471,7 +481,8 @@ def generate(input_file: str, out_dir: str, *, seed: int = 0,
         write_placed_output(input_file, seed_board, poses)
         copy_siblings(input_file, seed_board)
         board = os.path.join(out_dir, f'cand_{i:02d}.kicad_pcb')
-        m, final = _quench_to(seed_board, board, qkw, groups)
+        m, final = _quench_to(seed_board, board, qkw, groups, cancel_check=cancel_check,
+                   progress_callback=progress_callback)
         rms, moved = _displacement(final, origin, free)
         cand.seed_board = seed_board
         cand.board = board

--- a/py_placer/placement/quench.py
+++ b/py_placer/placement/quench.py
@@ -1643,7 +1643,9 @@ def quench(pcb_data: PCBData, pcb_file: str,
            min_gain_per_mm: float = 0.1,
            move_unconnected: bool = False,
            corridor_weight: float = 0.0,
-           corridor_specs: Optional[Sequence[Dict]] = None) -> List[Dict]:
+           corridor_specs: Optional[Sequence[Dict]] = None,
+           cancel_check=None,
+           progress_callback=None) -> List[Dict]:
     """Greedy quench: iterate over parts, accept only cost-reducing moves.
 
     align_weight / align_radius / align_span, orient_weight: the #548 tidiness
@@ -1758,7 +1760,21 @@ def quench(pcb_data: PCBData, pcb_file: str,
             from placement.groups import describe
             print(describe(blocks))
 
+    stopped = False
     for pass_num in range(1, max_passes + 1):
+        # COOPERATIVE STOP. This engine had no clock of any kind -- no cancel
+        # hook, no progress, no iteration bound but max_passes -- and it is
+        # what `place_optimize` and `place_portfolio` run. A 217-part board hung
+        # a whole run behind it, indistinguishable from slow work because the
+        # only output is one line per COMPLETED pass.
+        #
+        # A partial is coherent here by construction: apply_move mutates the
+        # state in place and the return below reads state.parts, so stopping
+        # between parts yields a valid, less-optimised board -- never a torn
+        # one. There is no staging step to invalidate.
+        if cancel_check is not None and cancel_check():
+            print(f"  quench: stopping at pass {pass_num} (budget)")
+            break
         improved = 0.0
         moves = 0
         group_moves = 0
@@ -1816,7 +1832,17 @@ def quench(pcb_data: PCBData, pcb_file: str,
                           f"gain={base_cost - best[0]:.1f}")
 
         # --- single-part moves (nudge + rotate) ---
-        for ref in movable:
+        for _mi, ref in enumerate(movable):
+            # Per PART, not per candidate pose: one monotonic read per
+            # violator is the granularity krt_deadline documents, and a part
+            # costs O(candidates x rotations x parts) so it is a real unit.
+            if cancel_check is not None and cancel_check():
+                print(f"  quench: stopping mid-pass {pass_num} at "
+                      f"{_mi}/{len(movable)} (budget)")
+                stopped = True
+                break
+            if progress_callback is not None:
+                progress_callback(_mi, len(movable), f'quench pass {pass_num}')
             part = state.parts[ref]
             involved = set(part.nets)
             other_aw = state.airwires_excluding(involved)
@@ -1878,6 +1904,12 @@ def quench(pcb_data: PCBData, pcb_file: str,
             for fp_name, refs in by_fp.items():
                 if len(refs) < 2:
                     continue
+                # The swap phase is O(n^2) per footprint group and runs AFTER
+                # the per-part sweep, so a budget spent above must not be
+                # re-spent here.
+                if cancel_check is not None and cancel_check():
+                    stopped = True
+                    break
                 for i in range(len(refs)):
                     for j in range(i + 1, len(refs)):
                         ra, rb = refs[i], refs[j]
@@ -2004,6 +2036,8 @@ def quench(pcb_data: PCBData, pcb_file: str,
               f"length={stats['length']:.1f}mm crossings={stats['crossings']} "
               f"halo={stats['halo']:.1f} edge={stats['edge']:.1f} "
               f"total={stats['total']:.1f}{group_note}{swap_note}")
+        if stopped:
+            break
         if moves == 0:
             break
 

--- a/py_placer/placement/reachability.py
+++ b/py_placer/placement/reachability.py
@@ -312,6 +312,22 @@ class Reachability:
                 or self.bottleneck_mm < self.track_mm)
 
     @property
+    def measured(self) -> bool:
+        """Did this run ask an answerable question at all?
+
+        `target_cells == 0` means "no other island of this net is inside the
+        view" -- the pad is already joined to everything nearby, or the margin
+        is too small. That is NOT a verdict, and the CLI has always known it
+        (exit 2, never 1). But `bottleneck_mm` is None in that case, so `caged`
+        is True, so `to_dict()` stamped `verdict: CAGED` anyway -- and a caller
+        reading the documented `--json` payload instead of the exit code got a
+        confident CAGED for a question nobody answered. Measured on run 15: 7
+        CAGED reported where 3 was the truth, on a classification where a single
+        CAGED flips the whole loop into re-entering placement.
+        """
+        return self.target_cells > 0
+
+    @property
     def margin_um(self) -> Optional[float]:
         if self.bottleneck_mm is None:
             return None
@@ -324,7 +340,13 @@ class Reachability:
                 'bottleneck_mm': (None if self.bottleneck_mm is None
                                   else round(self.bottleneck_mm, 5)),
                 'wide_open': self.wide_open,
-                'verdict': 'CAGED' if self.caged else 'PASSABLE',
+                # NO-TARGET is a third state, not a shade of CAGED -- see
+                # `measured`. It matches the CLI's long-standing exit 2, so the
+                # JSON and the exit code finally agree, and `verdict == 'CAGED'`
+                # becomes safe to test directly.
+                'verdict': ('CAGED' if self.caged else 'PASSABLE')
+                           if self.measured else 'NO-TARGET',
+                'measured': self.measured,
                 'margin_um': (None if self.margin_um is None
                               else round(self.margin_um, 2)),
                 'target_cells': self.target_cells,
@@ -341,7 +363,15 @@ class Reachability:
                  f"grid       {self.grid[0]}x{self.grid[1]} @ {self.step_mm}mm"]
         if self.note:
             lines.append(f"note       {self.note}")
-        if self.bottleneck_mm is None:
+        if not self.measured:
+            # Same third state the JSON carries, and the same one the CLI has
+            # always signalled with exit 2. Printing CAGED here said the
+            # opposite of what the exit code said.
+            lines.append("BOTTLENECK not measured: nothing of this net to "
+                         "reach inside the view")
+            lines.append("VERDICT    NO-TARGET -- this is NOT a verdict. Widen "
+                         "--margin, or this is not a reachability question.")
+        elif self.bottleneck_mm is None:
             lines.append("BOTTLENECK none: no positive-slack path exists at "
                          "any grid")
             lines.append("VERDICT    CAGED for any track width")

--- a/py_placer/placement/reconstruct.py
+++ b/py_placer/placement/reconstruct.py
@@ -145,6 +145,31 @@ def _cross_group_contact(state, groups, snap):
     return None
 
 
+#: The gate tuple's terms, in order, as ONE definition.
+#:
+#: These names used to be repeated in the f-strings that print the gate. When
+#: `locked_contacts` was prepended to `measure()`, those f-strings kept their
+#: old indices and every term printed under its NEIGHBOUR's name: an executor
+#: reading `oob=0.0` was reading the hole shortfall, on a board carrying a part
+#: 44 mm off the outline. That matters beyond cosmetics -- the reconstruct
+#: ladder's apply rule is "improves the violation count AND does not increase
+#: the off-board amount", so the mislabelled term is a hard conjunct someone
+#: has to compare by eye. Print via `format_gate` and the labels cannot drift
+#: from the tuple again.
+GATE_TERMS = ('locked_contacts', 'pad_pairs', 'hole', 'oob', 'stacks',
+              'hpwl', 'overlap')
+
+
+def format_gate(t) -> str:
+    """One labelled line for a gate tuple, or a loud one if it has changed."""
+    if len(t) != len(GATE_TERMS):
+        return (f'GATE TUPLE CHANGED ({len(t)} terms, {len(GATE_TERMS)} names '
+                f'-- update GATE_TERMS): ' + ' '.join(f'[{i}]={v!r}'
+                                                      for i, v in enumerate(t)))
+    return ' '.join(f'{n}={v:g}' if isinstance(v, (int, float)) else f'{n}={v}'
+                    for n, v in zip(GATE_TERMS, t))
+
+
 def measure(state, edge_bands=None) -> Tuple:
     """The lexicographic gate tuple. Smaller-or-equal is acceptable.
 
@@ -229,8 +254,50 @@ def classify(state, intent=None, anchor_extent='auto') -> Tiers:
         refs_all = sorted(state.parts)
         for pat in intent.must_lock:
             t.locked |= set(_fn.filter(refs_all, pat))
+    # UNWIRED, not pin-count-zero (run-10 A1). The frame tier means "this
+    # part's position is not a netlist question". `pin_count == 0` reads that
+    # off the pad count, which assumes a net-less mounting hole is also
+    # PAD-less -- true for a bare NPTH, false for every `MountingHole_*_Pad*`
+    # footprint, whose plated pad KiCad gives a real, non-zero net id under an
+    # `unconnected-(REF-PadN)` placeholder NAME. `quench` builds `pads_local`
+    # with `net_id > 0`, so such a hole counts a pin and misses this tier.
+    #
+    # Measured on the run-10 subject, whose 9 mounting holes are all of that
+    # kind: `zero_net` came out EMPTY, and two things followed silently.
+    # `fit_corner_insets` scans `zero_net | locked`, so it saw only the 2
+    # holes the FILE happened to lock, found no group of >=2 in distinct
+    # corners, and returned {} -- disabling the hole-pattern fit, the one rung
+    # that can carry a part an arbitrary distance home. `rigid_vectors` is
+    # pattern-gated, so it then had nothing either, and the whole structural
+    # ladder was inert while `legalize` (capped at --max-move) was left to do
+    # the work alone. The other 7 holes also landed in `smalls`, i.e. free for
+    # a search to move a mounting hole.
+    #
+    # Ask the netlist instead: a pad whose net touches no OTHER part is not a
+    # connection -- which is the same >=2-parts rule the routable denominator
+    # uses. Strictly wider than the old test (a part with no pads has no nets,
+    # so `all(...)` is vacuously true) and it frames only parts nothing wires:
+    # on the subject board exactly the 9 holes plus 6 `Z*` mechanical parts,
+    # and none of the 11 parts the damage displaced.
+    _net_parts: Dict[int, set] = {}
+    for _r, _p in state.parts.items():
+        for _nid in (getattr(_p, 'nets', ()) or ()):
+            _net_parts.setdefault(_nid, set()).add(_r)
+    #
+    # AND DRILLED, when it has pads at all (run-10 W17). "Nothing wires it" is
+    # necessary and not sufficient: on a single-part fixture board the sole
+    # part's net-neighbourhood is trivially solo, so the unwired test alone
+    # framed the one part the board exists to place -- measured on three
+    # in-repo QFN fanout fixtures. A part carrying pads earns the frame only
+    # if those pads are DRILLED, which is what separates a plated mounting
+    # hole from an unwired SMD part, and is the same `has_tht` filter
+    # `fit_corner_insets` applies to whatever this tier hands it. A part with
+    # no pads at all keeps the old unconditional pass.
     t.zero_net = {r for r, p in state.parts.items()
-                  if p.pin_count == 0 and r not in t.locked}
+                  if r not in t.locked
+                  and all(len(_net_parts.get(nid, ())) < 2
+                          for nid in (getattr(p, 'nets', ()) or ()))
+                  and (p.pin_count == 0 or getattr(p, 'has_tht', False))}
     free = [r for r in state.parts if r not in t.locked | t.zero_net]
     exts = sorted(part_extent_mm(state, r) for r in free)
     if anchor_extent == 'auto':
@@ -252,14 +319,87 @@ def classify(state, intent=None, anchor_extent='auto') -> Tiers:
 # fit_pattern (propose-only)
 # --------------------------------------------------------------------------
 
+def _slot_on_board(state, x: float, y: float) -> bool:
+    """Is a constructed slot actually on the board?
+
+    Slots are built from the bounding box, and a notched or rounded board has
+    bbox corners that are not on it. Enumerating those offers a hole a seat it
+    could never occupy.
+    """
+    b = state.board
+    if not (b[0] - 1e-6 <= x <= b[2] + 1e-6 and b[1] - 1e-6 <= y <= b[3] + 1e-6):
+        return False
+    gate = getattr(getattr(state, 'legality_ctx', None), 'gate', None)
+    outer = getattr(gate, 'outer', None)
+    if not outer:
+        return True                       # bbox IS the outline; already checked
+    try:
+        from check_drc import _point_on_board
+        return bool(_point_on_board(x, y, outer, gate.cutouts))
+    except Exception:
+        return True
+
+
+def _pattern_slots(state, inset_x: float, inset_y: float, mid_edges: bool):
+    """The seats a hole family at this inset can occupy: 4 corners, +4 mid-edges.
+
+    A slot is (edge-perpendicular inset, along-edge position). A CORNER fixes
+    the along-position to the inset from the adjacent perpendicular edge; a
+    MID-EDGE slot fixes it to that edge's midpoint, at the same perpendicular
+    inset. Both are derived from the one inset the survivors over-determine --
+    a mid-edge slot invents no new parameter.
+    """
+    b = state.board
+    mx, my = (b[0] + b[2]) / 2.0, (b[1] + b[3]) / 2.0
+    slots = {'SW': (b[0] + inset_x, b[1] + inset_y),
+             'NW': (b[0] + inset_x, b[3] - inset_y),
+             'SE': (b[2] - inset_x, b[1] + inset_y),
+             'NE': (b[2] - inset_x, b[3] - inset_y)}
+    if mid_edges:
+        slots.update({'W': (b[0] + inset_x, my), 'E': (b[2] - inset_x, my),
+                      'S': (mx, b[1] + inset_y), 'N': (mx, b[3] - inset_y)})
+    return {k: (round(x, 4), round(y, 4)) for k, (x, y) in slots.items()
+            if _slot_on_board(state, x, y)}
+
+
 def fit_corner_insets(state, tiers: Tiers) -> Dict[str, List[Tuple[float, float]]]:
-    """Corner-inset fit over zero-net DRILLED parts (mounting holes).
+    """Hole-pattern fit over zero-net DRILLED parts (mounting holes).
 
     Survivors: holes whose (inset_x, inset_y) agree with a common inset within
     GRID_TOL, in DISTINCT corners. >= 2 survivors over-determine a
-    translation; non-conforming holes get every FREE corner at the fitted
-    inset as proposed positions. Propose-only: the assign stage (or its gate)
-    decides."""
+    translation; holes seated by no family get every FREE slot of every fitted
+    family as proposed positions. Propose-only: the assign stage (or its gate)
+    decides.
+
+    Four things this gets right that the corner-only version did not, each
+    measured on a board damaged by a 66mm rigid swap:
+
+    EVERY GROUP, not the largest. A board can carry two legitimate hole
+    families (one corpus board has {3.302, 3.302} and {7.62, 1.27}). Fitting
+    only the largest makes the second family's members read as displaced, and
+    they then compete for the first family's free seat -- which is how two
+    holes that had never moved became claimants.
+
+    MID-EDGE SLOTS. A hole one inset in from an edge, mid-span along it, is an
+    ordinary mounting pattern and the corner model has no hypothesis for it. On
+    the measured board the displaced hole's true home is exactly the north
+    edge's midpoint at the fitted inset; with no slot there its offset agreed
+    with nothing, the support >= 2 rule discarded the one correct offset along
+    with three wrong ones, and the whole ladder produced no vector.
+
+    ...but ONLY WHEN OVER-SUBSCRIBED. Mid-edge slots sit nearer the board
+    centre than the corners, so on a board whose corner model is sufficient
+    they hand DIST_TIEBREAK_PER_MM a closer wrong answer. Enumerate them only
+    when the corner model cannot seat everyone: survivors + unseated unlocked
+    holes > 4. Counting only UNLOCKED holes is load-bearing -- one corpus board
+    carries five locked zero-net through-hole connectors that would otherwise
+    inflate demand on every board it appears with.
+
+    AT SEAT IS GLOBAL. A hole matching any fitted family's inset is at seat: it
+    is not a candidate, and its slot is taken. Scoping that to one family is
+    what let a correct hole be offered another family's corner.
+    """
+    from collections import defaultdict
     b = state.board
     corners = {'SW': (b[0], b[1]), 'NW': (b[0], b[3]),
                'SE': (b[2], b[1]), 'NE': (b[2], b[3])}
@@ -272,7 +412,6 @@ def fit_corner_insets(state, tiers: Tiers) -> Dict[str, List[Tuple[float, float]
                    key=lambda kv: abs(p.x - kv[1][0]) + abs(p.y - kv[1][1]))
         holes.append((ref, best[0], abs(p.x - best[1][0]),
                       abs(p.y - best[1][1])))
-    from collections import defaultdict
     groups = defaultdict(list)
     for ref, corner, ix, iy in holes:
         # PER-AXIS conformance (run-8 A1). This used to demand ix ~= iy, i.e.
@@ -283,39 +422,375 @@ def fit_corner_insets(state, tiers: Tiers) -> Dict[str, List[Tuple[float, float]
         # holes, not with each other.
         groups[(round(ix / GRID_TOL), round(iy / GRID_TOL))].append(
             (ref, corner, (ix, iy)))
-    proposals: Dict[str, List[Tuple[float, float]]] = {}
+
+    fits = []
     for _key, members in sorted(groups.items(), key=lambda kv: -len(kv[1])):
         distinct = {m[1] for m in members}
         if len(members) < 2 or len(distinct) != len(members):
             continue
-        inset_x = sum(m[2][0] for m in members) / len(members)
-        inset_y = sum(m[2][1] for m in members) / len(members)
-        survivors = {m[0] for m in members}
-        free_corners = [c for c in corners if c not in distinct]
-        for ref, _c, ix, iy in holes:
-            if ref in tiers.locked:
+        fits.append((sum(m[2][0] for m in members) / len(members),
+                     sum(m[2][1] for m in members) / len(members),
+                     {m[0] for m in members}))
+    if not fits:
+        return {}
+
+    # RECOGNISE GENEROUSLY, OFFER CONSERVATIVELY.
+    #
+    # "At seat" is positional -- is this hole standing on a pattern seat? -- and
+    # is asked against every slot the families could have, mid-edge included,
+    # whether or not those slots are offered to anyone. Asking it about INSETS
+    # instead gets a mid-edge hole wrong: its nearest-corner inset is the
+    # along-edge distance (99.06mm on the measured board), which matches no
+    # family, so a hole standing exactly on its own seat reads as displaced --
+    # and the corpus sweep duly caught this proposing a healthy board's hole a
+    # move to the position it was already in.
+    #
+    # Being generous here is the safe direction: it only ever REMOVES
+    # candidates. Offering a slot is the risky direction, and that stays behind
+    # the pigeonhole gate below.
+    every_slot = []
+    for inset_x, inset_y, _s in fits:
+        every_slot.extend(_pattern_slots(state, inset_x, inset_y, True).values())
+
+    def at_seat(ref) -> bool:
+        p = state.parts[ref]
+        return any(abs(p.x - sx) <= GRID_TOL and abs(p.y - sy) <= GRID_TOL
+                   for sx, sy in every_slot)
+
+    # Demand is board-wide, so a hole seated by family B never inflates family
+    # A's pigeonhole count.
+    candidates = [ref for ref, _c, _ix, _iy in holes
+                  if ref not in tiers.locked and not at_seat(ref)]
+
+    proposals: Dict[str, List[Tuple[float, float]]] = defaultdict(list)
+    for inset_x, inset_y, survivors in fits:
+        over = len(survivors) + len(candidates) > 4
+        slots = _pattern_slots(state, inset_x, inset_y, over)
+        taken = {name for name, (sx, sy) in slots.items()
+                 if any(abs(state.parts[r].x - sx) <= GRID_TOL
+                        and abs(state.parts[r].y - sy) <= GRID_TOL
+                        for r, _c, _ix, _iy in holes)}
+        free = [xy for name, xy in sorted(slots.items()) if name not in taken]
+        for ref in candidates:
+            proposals[ref].extend(free)
+    return {r: sorted(set(c)) for r, c in proposals.items() if c}
+
+
+# --------------------------------------------------------------------------
+# family orbits -- a DETECTOR, deliberately not a proposal source
+# --------------------------------------------------------------------------
+
+#: A family member's radius must agree with the consensus to this (mm).
+ORBIT_RADIUS_TOL_MM = 0.20
+#: ...and its angular residue with its class to this (degrees).
+ORBIT_ANGLE_TOL_DEG = 0.75
+#: Fewest members that may define an orbit. Measured: the corpus no-op below
+#: holds at 5, 4 and 3 -- 5 is chosen because the fit has four continuous
+#: parameters (cx, cy, r, theta0) plus a discrete m, and five members give ten
+#: observations.
+ORBIT_MIN_INLIERS = 5
+#: Rotational orders tried. 2 is excluded by the CURVATURE guard: a 2-fold
+#: "orbit" is a point reflection and has no curvature at all, so any two parts
+#: anywhere define one.
+ORBIT_M_RANGE = range(3, 25)
+#: OVER-DETERMINATION: distinct SEATS a residue class must occupy. Seats, not
+#: members -- two co-located parts are one piece of evidence about a pattern.
+ORBIT_MIN_SEATS_PER_CLASS = 3
+#: OCCUPANCY: fraction of the orbit's slots that must actually be filled.
+ORBIT_MIN_OCCUPANCY = 0.60
+#: SCALE: the fitted circle must be at most this fraction of the board
+#: diagonal, and its centre on the board. A near-collinear family fits an
+#: enormous circle exactly as a long airwire fits a damage vector.
+ORBIT_MAX_RADIUS_FRAC = 0.75
+#: Deterministic bound on circumcentre hypotheses per family. A 100-member
+#: family has 161700 triples; the stride covers the whole family rather than a
+#: prefix of it, so a ring whose refs sort late is not missed.
+ORBIT_MAX_HYPOTHESES = 4000
+
+
+class OrbitFit:
+    """One fitted rotational orbit of a footprint family."""
+    __slots__ = ('family', 'cx', 'cy', 'r', 'm', 'residues', 'slots',
+                 'inliers', 'free_slots')
+
+    def __init__(self, family, cx, cy, r, m, residues, slots, inliers,
+                 free_slots):
+        self.family = family
+        self.cx, self.cy, self.r, self.m = cx, cy, r, m
+        self.residues = residues
+        self.slots = slots
+        self.inliers = inliers
+        self.free_slots = free_slots
+
+    def as_dict(self):
+        return {'family': self.family,
+                'centre': [round(self.cx, 4), round(self.cy, 4)],
+                'radius_mm': round(self.r, 4), 'm': self.m,
+                'residues_deg': [round(a, 4) for a in self.residues],
+                'slots': self.slots, 'inliers': list(self.inliers),
+                'free_slots': [[round(x, 4), round(y, 4)]
+                               for x, y in self.free_slots]}
+
+    def __repr__(self):                     # pragma: no cover - diagnostics
+        return (f'OrbitFit({self.family} m={self.m}x{len(self.residues)} '
+                f'r={self.r:.4f} c=({self.cx:.4f},{self.cy:.4f}) '
+                f'{len(self.inliers)}/{self.slots})')
+
+
+def _circumcentre(p1, p2, p3):
+    ax, ay = p1
+    bx, by = p2
+    cx, cy = p3
+    d = 2.0 * (ax * (by - cy) + bx * (cy - ay) + cx * (ay - by))
+    if abs(d) < 1e-9:
+        return None                     # collinear: no finite circumcentre
+    a2, b2, c2 = ax * ax + ay * ay, bx * bx + by * by, cx * cx + cy * cy
+    ux = (a2 * (by - cy) + b2 * (cy - ay) + c2 * (ay - by)) / d
+    uy = (a2 * (cx - bx) + b2 * (ax - cx) + c2 * (bx - ax)) / d
+    return (ux, uy)
+
+
+def fit_family_orbits(state, tiers=None, *,
+                      min_inliers: int = ORBIT_MIN_INLIERS
+                      ) -> List[OrbitFit]:
+    """Footprint families that lie on a regular rotational orbit.
+
+    A DETECTOR and nothing else. It proposes no poses and contributes no gate
+    term; its whole product is the fact "this part is AT SEAT on a fitted
+    orbit, corroborated by N others". Two consumers want that fact and neither
+    needs a proposal: `lock_advisor` (protect an intact array from a legality
+    search) and any model that would otherwise claim an at-seat part is
+    displaced -- `fit_corner_insets` has no hypothesis for a rotational
+    pattern, and on the measured board read H2, standing on an exact 3-fold
+    orbit with H1/H3 (radii agreeing to 0.8 nanometres), as displaced and
+    offered it a 5.2 mm move.
+
+    THE GUARDS ARE THE DESIGN. Un-guarded this is the shape that got
+    `airwire_cluster_vectors` refuted (`:1045`,
+    `tests/test_run8_airwire_refuted.py`), so the firing rate on the 33 HEALTHY
+    in-repo corpus boards was measured guard by guard BEFORE shipping any of
+    it, and `tests/test_orbit_fit_noop.py` pins the whole matrix:
+
+        no guards at all                                 28 of 33 fire
+        + scale        (r <= 0.75*diag, centre on board) 28 of 33
+        + curvature    (m >= 3)                          28 of 33
+        + over-determination (>= 3 distinct SEATS/class) 14 of 33
+        + occupancy    (>= 0.60 of slots filled)          7 of 33
+        + min_inliers 4                                   2 of 33
+        + min_inliers 5   <- SHIPPED                      0 of 33
+
+      scale               r <= ORBIT_MAX_RADIUS_FRAC * board diagonal, centre
+                          inside the bbox
+      curvature           m >= 3 (a 2-fold orbit is a point reflection)
+      over-determination  every residue class occupies >= 3 distinct SEATS
+      occupancy           filled seats >= ORBIT_MIN_OCCUPANCY * slots
+      min_inliers         >= 5 members on the fitted orbit
+
+    TWO CORRECTIONS TO THE INVESTIGATION THAT PROPOSED THIS, both measured
+    here and both in the direction that flattered the proposal:
+
+    1. It reported the un-guarded rate as 6 of 33 and claimed the guarded rate
+       stayed 0 with min_inliers lowered to 4 and to 3. Neither reproduces: the
+       un-guarded rate is 28 of 33, and relaxing min_inliers to 4 and 3 fires
+       on 2 and 7 boards. `min_inliers` is a load-bearing guard here, not a
+       formality, and lowering it is a regression rather than a free widening.
+    2. Over-determination MUST count distinct seats, not members. Counting
+       members, glasgow_revC's six `Fiducial_0.75mm_Mask1.5mm` -- which are
+       three positions with a front/back pair at each -- read as six
+       corroborations of a 10-fold orbit through three points, and that fit
+       passed every other guard. Two co-located parts are one piece of evidence
+       about a pattern.
+
+    WHAT THE THRESHOLD COSTS, stated rather than left to be discovered: a
+    3- or 4-member orbit is below `min_inliers` and is NOT detected. On the
+    measured board that means the exact 3-fold mounting-hole orbit H1/H2/H3
+    (radii agreeing to 0.8 nanometres) is invisible here, so this detector does
+    NOT refute `fit_corner_insets`' claim that H2 -- which is at seat -- is
+    displaced. That refutation needs either a hole-specific relaxation or a
+    different model; it is not delivered by this one.
+
+    A near-collinear line of parts is REFUSED, not fitted -- which is correct
+    behaviour and not a gap: the case that motivates wanting one (six 0603s at
+    1.5 mm pitch, all six displaced together) has no surviving member to anchor
+    a line, and a pattern fitter with no survivors must propose nothing.
+    Re-seating owns that case (`seeder.reseat_scope`).
+
+    `tiers` is accepted for symmetry with `fit_corner_insets` and is unused:
+    an orbit is a property of a family's geometry, not of a part's size tier.
+    """
+    from collections import defaultdict
+    from itertools import combinations
+
+    b = state.board
+    diag = math.hypot(b[2] - b[0], b[3] - b[1])
+    r_max = ORBIT_MAX_RADIUS_FRAC * diag
+
+    families: Dict[str, List[str]] = defaultdict(list)
+    for ref in sorted(state.parts):
+        fam = getattr(state.parts[ref], 'footprint_name', None)
+        if fam:
+            families[fam].append(ref)
+
+    fits: List[OrbitFit] = []
+    for fam in sorted(families):
+        members = families[fam]
+        if len(members) < min_inliers:
+            continue
+        pts = {r: (state.parts[r].x, state.parts[r].y) for r in members}
+
+        # ---- centre hypotheses: circumcentres of member triples ------------
+        total = len(members) * (len(members) - 1) * (len(members) - 2) // 6
+        stride = max(1, total // ORBIT_MAX_HYPOTHESES)
+        seen_c = set()
+        centres = []
+        for i, tri in enumerate(combinations(members, 3)):
+            if i % stride:
                 continue
-            # AT-HOME survivors are not proposals (run-8 A1). A hole already
-            # sitting on the fitted pattern has nothing to be moved to, and
-            # offering it every free corner is how a correct hole gets
-            # swapped into a wrong one -- the degeneracy that cost a earlier
-            # run ~0.16 of recovery. Its conformance is still what
-            # over-determines the fit; it just is not a candidate.
-            if ref in survivors:
+            c = _circumcentre(*(pts[t] for t in tri))
+            if c is None:
                 continue
-            if (abs(ix - inset_x) <= GRID_TOL
-                    and abs(iy - inset_y) <= GRID_TOL):
+            key = (round(c[0] / 0.01), round(c[1] / 0.01))
+            if key in seen_c:
                 continue
-            cand = []
-            for c in free_corners:
-                cx, cy = corners[c]
-                px = cx + inset_x if cx == b[0] else cx - inset_x
-                py = cy + inset_y if cy == b[1] else cy - inset_y
-                cand.append((round(px, 4), round(py, 4)))
-            if cand:
-                proposals[ref] = cand
-        break
-    return proposals
+            seen_c.add(key)
+            centres.append(c)
+
+        best = None
+        for (cx, cy) in centres:
+            if not (b[0] <= cx <= b[2] and b[1] <= cy <= b[3]):
+                continue                                        # scale guard
+            radii = sorted((math.hypot(pts[r][0] - cx, pts[r][1] - cy), r)
+                           for r in members)
+            # Consensus radius = the largest run within tolerance.
+            i = 0
+            while i < len(radii):
+                j = i
+                while (j + 1 < len(radii)
+                       and radii[j + 1][0] - radii[i][0] <= ORBIT_RADIUS_TOL_MM):
+                    j += 1
+                run = radii[i:j + 1]
+                i = j + 1
+                if len(run) < min_inliers:
+                    continue
+                rr = sum(t[0] for t in run) / len(run)
+                if rr > r_max or rr < 1e-6:
+                    continue                                    # scale guard
+                cand = _fit_orbit_m(fam, cx, cy, rr,
+                                    [t[1] for t in run], pts, min_inliers)
+                if cand is None:
+                    continue
+                key = (-len(cand.inliers), cand.slots - len(cand.inliers),
+                       -cand.m)
+                if best is None or key < best[0]:
+                    best = (key, cand)
+        if best is not None:
+            fits.append(best[1])
+    return fits
+
+
+def _fit_orbit_m(family, cx, cy, r, refs, pts, min_inliers):
+    """Best rotational order for `refs` on the circle (cx, cy, r), or None."""
+    angles = {ref: math.degrees(math.atan2(pts[ref][1] - cy,
+                                           pts[ref][0] - cx)) % 360.0
+              for ref in refs}
+    best = None
+    for m in ORBIT_M_RANGE:
+        step = 360.0 / m
+        # Residue classes: the angle reduced mod the rotational step. A
+        # complete orbit of an m-fold pattern with k independent seeds has
+        # exactly k classes, each occupied m times.
+        buckets: Dict[int, List[str]] = {}
+        bucket_res: Dict[int, float] = {}       # each class's REFERENCE residue
+        for ref, a in sorted(angles.items()):
+            res = a % step
+            hit = None
+            for key, r0 in bucket_res.items():
+                d = abs(res - r0)
+                if min(d, step - d) <= ORBIT_ANGLE_TOL_DEG:
+                    hit = key
+                    break
+            if hit is None:
+                hit = round(res / ORBIT_ANGLE_TOL_DEG)
+                bucket_res[hit] = res
+            buckets.setdefault(hit, []).append(ref)
+        # OVER-DETERMINATION, counted in SLOTS rather than in members. A
+        # residue class seen once or twice is a fitted free parameter, not
+        # evidence -- and the members holding it must be at DIFFERENT seats.
+        # Measured: glasgow_revC carries six `Fiducial_0.75mm_Mask1.5mm` at
+        # three positions (a front/back pair at each), and counting members
+        # made 3 distinct points look like 6 corroborations, which was enough
+        # for a 10-fold "orbit" through them to survive every other guard. Two
+        # co-located parts are one piece of evidence about a pattern.
+        #
+        # The slot index is taken RELATIVE TO THE CLASS'S REFERENCE RESIDUE,
+        # never by flooring the raw angle: a residue that wraps (an angle of
+        # 179.99999 deg on a 45 deg step has residue 44.99999, which IS the
+        # same class as 0.0) floors into the PREVIOUS slot, so an exact 8-fold
+        # ring read as two members sharing a seat and was mis-fitted as 4-fold
+        # with two residue classes.
+        occupied = {}                   # (class, k) -> refs on that seat
+        for k, v in sorted(buckets.items()):
+            for ref in v:
+                slot = int(round((angles[ref] - bucket_res[k]) / step)) % m
+                occupied.setdefault((k, slot), []).append(ref)
+        seats_per_class: Dict[int, set] = {}
+        for (k, slot) in occupied:
+            seats_per_class.setdefault(k, set()).add(slot)
+        classes = {k: v for k, v in buckets.items()
+                   if len(seats_per_class.get(k, ()))
+                   >= ORBIT_MIN_SEATS_PER_CLASS}
+        if not classes:
+            continue
+        inliers = sorted(ref for v in classes.values() for ref in v)
+        if len(inliers) < min_inliers:
+            continue
+        slots = len(classes) * m
+        filled = sum(len(seats_per_class[k]) for k in classes)
+        # OCCUPANCY: 5 parts spread over a 21-slot orbit is a coincidence, and
+        # so are 3 seats of 10.
+        if filled < ORBIT_MIN_OCCUPANCY * slots:
+            continue
+        # Circular mean about the class reference, for the same wrap reason:
+        # averaging 0.0 and 44.99999 arithmetically gives 22.5, which is not a
+        # residue any member has.
+        residues = tuple(sorted(
+            (bucket_res[k] + sum(((angles[ref] % step) - bucket_res[k]
+                                  + step / 2.0) % step - step / 2.0
+                                 for ref in v) / len(v)) % step
+            for k, v in classes.items()))
+        # Pick the m with the FEWEST FREE SLOTS; ties go to the larger m.
+        key = (slots - filled, -m)
+        if best is None or key < best[0]:
+            free = []
+            seated = [angles[ref] for ref in inliers]
+            for res in residues:
+                for k in range(m):
+                    a = (res + k * (360.0 / m)) % 360.0
+                    if any(min(abs(a - oa), 360.0 - abs(a - oa))
+                           <= ORBIT_ANGLE_TOL_DEG for oa in seated):
+                        continue
+                    free.append((cx + r * math.cos(math.radians(a)),
+                                 cy + r * math.sin(math.radians(a))))
+            best = (key, OrbitFit(family, cx, cy, r, m, residues, slots,
+                                  tuple(inliers), tuple(sorted(free))))
+    return None if best is None else best[1]
+
+
+def orbit_seats(fits: Sequence['OrbitFit'], min_corroborating: int = 3
+                ) -> Dict[str, 'OrbitFit']:
+    """{ref: the fit it is AT SEAT on}, for fits with enough corroboration.
+
+    `min_corroborating` counts the OTHER members holding the same orbit, so 3
+    means a part plus three others agreeing on centre, radius and pitch. That
+    is the threshold at which the fit stops being a description of the part
+    itself: four points over-determine a circle's three parameters."""
+    out: Dict[str, OrbitFit] = {}
+    for f in fits:
+        if len(f.inliers) < min_corroborating + 1:
+            continue
+        for ref in f.inliers:
+            out.setdefault(ref, f)
+    return out
 
 
 # --------------------------------------------------------------------------
@@ -411,10 +886,77 @@ def edge_metric(state, ref: str, x: float, y: float,
     return state.edge_gate.edge_clearance(rect)
 
 
+def damage_witnesses(state) -> Dict[str, str]:
+    """Refs carrying a NAMED structural witness that they are misplaced.
+
+    Not a vector source. The off-board idea was measured as one and refuted:
+    containment leaves a box 30x11mm wide with sixty conflict-free candidate
+    vectors, hpwl's minimum among them sits 7.6mm from the truth and scores the
+    truth WORSE, and on a swap the joint box is infeasible. Same shape as the
+    airwire refutation -- sound detector, ordinary-layout chooser.
+
+    As a WITNESS it is sound, and the no-op is a property rather than a
+    threshold: a pad centre off the outline is the negation of a
+    manufacturability invariant, because you cannot solder to air. Measured
+    across 33 corpus boards plus 5 controls: ZERO witnesses.
+
+    The form matters and only one form has that guarantee. Measured on the same
+    boards, a pad-EXTENT bounding box against the outline fires on a healthy
+    module wider than its own board, and against a ROUNDED outline it fires on
+    four locked mounting holes whose round pads are entirely inside but whose
+    AABB corners clear the corner arc. Pad CENTRES fire on none of them.
+    """
+    out: Dict[str, str] = {}
+    ctx = getattr(state, 'legality_ctx', None)
+    if ctx is None:
+        return out
+    for ref, pp in sorted((ctx.parts or {}).items()):
+        p = state.parts.get(ref)
+        if p is None:
+            continue
+        try:
+            rects = pp.pad_rects(p.x, p.y, p.rot)
+        except Exception:                                   # noqa: BLE001
+            continue
+        for rect in rects or ():
+            x0, y0, x1, y1 = rect[0], rect[1], rect[2], rect[3]
+            if not _slot_on_board(state, (x0 + x1) / 2.0, (y0 + y1) / 2.0):
+                out[ref] = 'off_board'
+                break
+    return out
+
+
+def evidenced_moves(state, old: Dict[str, Tuple[float, float, float]],
+                    vectors, tol: float = 2 * GRID_TOL) -> Set[str]:
+    """Refs whose displacement AGREES with a kept vector, up to sign and step.
+
+    The damage hypothesis is "parts displaced by k*v"; a move that matches it
+    is evidence, and a move that matches nothing is a seat the solver liked.
+    Both look identical to a board-wide gate tuple when the part carries no
+    net, which is why this exists as a separate question from the tuple.
+    """
+    out: Set[str] = set()
+    steps = (-2, -1, 1, 2)
+    for ref, (x, y, _r) in (old or {}).items():
+        p = state.parts.get(ref)
+        if p is None:
+            continue
+        dx, dy = p.x - x, p.y - y
+        if math.hypot(dx, dy) < GRID_TOL:
+            continue                    # did not move; nothing to justify
+        for vx, vy in (vectors or ()):
+            if any(math.hypot(dx - k * vx, dy - k * vy) <= tol
+                   for k in steps):
+                out.add(ref)
+                break
+    return out
+
+
 def prune_assignment(state, old: Dict[str, Tuple[float, float, float]],
                      notes: Optional[List[str]] = None,
                      edge_bands: Optional[Dict[str, float]] = None,
-                     exempt: Optional[Set[str]] = None) -> List[str]:
+                     exempt: Optional[Set[str]] = None,
+                     evidenced: Optional[Set[str]] = None) -> List[str]:
     """Per-part revert sweep after an ACCEPTED assignment (run-4 F3b).
 
     The stage gate is one board-wide lexicographic tuple, so an assignment
@@ -426,7 +968,22 @@ def prune_assignment(state, old: Dict[str, Tuple[float, float, float]],
     tuple STRICTLY improves. Board-only, monotone by construction: the
     sweep can only improve the tuple, and a revert that would reintroduce a
     conflict is rejected by the same tuple.
+
+    `evidenced` names the refs whose chosen pose came from real evidence -- a
+    corroborated pattern slot, or a +/-v offset of a kept vector. For anything
+    NOT in that set, an EQUAL tuple is also grounds to revert, and that is the
+    hole a measured 26.27 mm move went through: a mounting hole was carried to
+    another hole's seat, the gate tuple came out byte-identical (a zero-net
+    part in free space touches no term the tuple has), so `< base` never fired
+    and the move survived a sweep written to catch exactly that. A move nothing
+    measured justifies is not a tie to be broken in its favour.
+
+    Strictness is deliberately NOT applied to the round accept upstream: a
+    displaced hole coming home is gate-neutral by construction for the same
+    reason, so requiring strict improvement there would reject the homecoming
+    the whole fit exists to produce.
     """
+    evidenced = evidenced or set()
     pruned: List[str] = []
 
     def moved_dist(item):
@@ -446,7 +1003,8 @@ def prune_assignment(state, old: Dict[str, Tuple[float, float, float]],
         base = measure(state, edge_bands)
         cur = (p.x, p.y, p.rot)
         state.apply_move(ref, x, y, rot)
-        if measure(state, edge_bands) < base:
+        after = measure(state, edge_bands)
+        if after < base or (after == base and ref not in evidenced):
             pruned.append(ref)
         else:
             state.apply_move(ref, *cur)

--- a/py_placer/placement/recovery.py
+++ b/py_placer/placement/recovery.py
@@ -148,7 +148,33 @@ def displacement_to_original(poses_now: Dict[str, Pose],
     out_set = [v for r, v in per_part.items() if r not in members]
     home = [r for r in members
             if per_part.get(r, float('inf')) <= HOME_TOLERANCE_MM]
+    # A SINGLE threshold saturates and then carries no signal. Run 9 measured
+    # `parts_home_frac` = 0.0 for the damaged board AND for the recovered one,
+    # while `recovery` moved +0.045 -- so the headline metric could not
+    # distinguish "moved nothing" from "moved 80 parts most of the way", which
+    # is the distinction the experiment exists to make. The curve is pure
+    # derivation from `per_part`, which is already computed above.
+    _in = sorted(in_set)
+    def _frac(t):
+        return round(sum(1 for v in _in if v <= t) / len(_in), 6) if _in else None
+    # The ladder runs well past HOME_TOLERANCE_MM on purpose. Measured on run 9:
+    # a ladder stopping at 20mm was ALSO all-zero on both boards, because the
+    # median displacement was 28.6mm -- i.e. a curve can saturate exactly like
+    # the single threshold it replaces, just more verbosely. `per_part_median`
+    # below is the scalar that cannot saturate, and it is the one that showed
+    # the movement there (28.580 -> 27.277mm). Keep the ladder FIXED rather than
+    # deriving it per board: an adaptive ladder is not comparable between two
+    # boards, which is the whole point of reporting it.
+    home_curve = {t: _frac(t) for t in (0.5, 1.0, HOME_TOLERANCE_MM,
+                                        5.0, 10.0, 20.0, 50.0, 100.0)}
+    if _in:
+        _m = len(_in) // 2
+        median = round(_in[_m] if len(_in) % 2 else (_in[_m - 1] + _in[_m]) / 2.0, 6)
+    else:
+        median = None
     return {
+        'home_curve': home_curve,
+        'per_part_median': median,
         'perturbed_pad_rms': round(_rms(in_set), 6),
         'perturbed_pad_max': round(max(in_set), 6) if in_set else 0.0,
         'perturbed_centre_rms': round(_rms([centre[r] for r in members
@@ -248,6 +274,39 @@ def frozen_net_ids(pcb_data, ignore_net_ids: Sequence[int] = ()) -> List[int]:
     for nid, pads in (getattr(pcb_data, 'pads_by_net', None) or {}).items():
         if nid and nid not in ignored and len(pads) >= 2:
             out.append(nid)
+    return sorted(out)
+
+
+def dirty_net_ids(pcb_routed, drc_json_path: str) -> List[int]:
+    """Net ids carrying a DRC violation, from `check_drc.py --json`.
+
+    The missing half of `connectivity_tally`'s contract. `dirty_nets` has never
+    once been supplied by any caller, so `PRR`/`NRR` -- the DRC-CLEAN forms,
+    which are the ones OmniRouting actually defines -- have always come back
+    `None`, and only the `_connected` forms carried a number. This is the whole
+    producer: check_drc writes `items[].net1` / `net2` as net NAMES, and the
+    parsed board maps names to ids.
+
+    Names, not ids, is deliberate on check_drc's side and is why this cannot be
+    a one-liner at the call site: an id is meaningless without the net table of
+    the exact board it came from, and a report outlives the board it graded.
+    An unresolvable name is DROPPED rather than guessed -- silently widening
+    the dirty set would depress PRR on nets that are clean.
+    """
+    import json as _json
+    try:
+        with open(drc_json_path, encoding='utf-8') as fh:
+            doc = _json.load(fh)
+    except Exception:                                          # noqa: BLE001
+        return []
+    by_name = {n.name: nid for nid, n in (pcb_routed.nets or {}).items()
+               if n.name}
+    out = set()
+    for item in (doc.get('items') or ()):
+        for key in ('net1', 'net2'):
+            nid = by_name.get(item.get(key))
+            if nid is not None:
+                out.add(nid)
     return sorted(out)
 
 
@@ -414,6 +473,12 @@ def static_metrics(pcb_data, board_path: str, record: Optional[Dict] = None
         'block_displacement_ran': bool(bd),
         'state': {'unplaced': state.unplaced,
                   'partially_unplaced': state.partially_unplaced,
+                  # The refs the flag above is actually decided on. Without it
+                  # a scorecard shows `partially_unplaced: false` beside a
+                  # non-zero `signals.duplicate_fraction` and a reader cannot
+                  # tell "suppressed as markers / far side" from a broken
+                  # check. Same reason floorplan's `state` block carries it.
+                  'stacked_suspect_refs': list(state.stacked_suspect_refs),
                   'has_copper': state.has_copper,
                   'signals': state.signals},
     }

--- a/py_placer/placement/seeder.py
+++ b/py_placer/placement/seeder.py
@@ -70,7 +70,8 @@ def _rect_inside(rect, outer, tol: float) -> bool:
 def _try_place(state, ref: str, tx: float, ty: float, exclude: Set[str],
                constraint=None, tol: float = 0.5,
                max_disp: Optional[float] = None,
-               info: Optional[Dict] = None) -> Optional[float]:
+               info: Optional[Dict] = None,
+               deadline=None) -> Optional[float]:
     """Nearest FULLY-CONTAINED legal pose to (tx, ty); applies the move and
     returns True.
 
@@ -151,6 +152,22 @@ def _try_place(state, ref: str, tx: float, ty: float, exclude: Set[str],
                         # run-7 A3: a ring whose step exceeds the cap can
                         # contribute nothing but used to burn a full sweep
                         continue
+                    # Budget check at the RING head (36 per call: 3 clearance
+                    # levels x 4 rotations x 3 bands) -- negligible, and it
+                    # bounds one pathological part's overrun to a single ring
+                    # sweep instead of a whole cap ladder. Deliberately NOT in
+                    # the `for dx, dy in _offsets(...)` loop below: that is the
+                    # innermost loop and _offsets already materialises ~3700
+                    # tuples per call, so the band check bounds it adequately.
+                    # Returns None rather than raising, so the caller's existing
+                    # "no legal pose" path handles it with no new control flow --
+                    # but `info` records WHY, because reporting an unfinished
+                    # search as a measured failure is the same silent lie this
+                    # whole change exists to remove.
+                    if deadline is not None and deadline.expired():
+                        if info is not None:
+                            info['deadline'] = True
+                        return None
                     for dx, dy in _offsets(radius, step):
                         if (max_disp is not None
                                 and math.hypot(dx, dy) > max_disp + 1e-9):
@@ -325,7 +342,8 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
                      grid_step: float = 0.1,
                      seed_refs: Optional[Set[str]] = None,
                      anchors_first: bool = False,
-                     anchor_rounds: int = 1) -> Dict:
+                     anchor_rounds: int = 1,
+                     deadline=None, progress=None) -> Dict:
     """Compute a full placement for an unplaced board from its intent.
 
     Returns {'placements': [...], 'lock_refs': [...], 'unseated': [...],
@@ -336,7 +354,16 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
     `seed_refs`, when given, scopes the seeding to exactly those refs: every
     other part is treated as authoritatively placed where it stands (the
     PARTIALLY-unplaced case -- a stacked pile beside a real placement, where
-    re-deriving the placed parts would discard someone's work).
+    re-deriving the placed parts would discard someone's work, and the
+    LIFT-AND-RE-SEAT case -- see `reseat_scope`).
+
+    `deadline` is an optional `krt_deadline.Deadline`, checked between parts in
+    the connectivity-centroid stage (the only unbounded one -- stages 1/1.5/2
+    are O(declared entries)). The partial is coherent by construction: a part
+    is either fully seated, and in `placements`, or untouched. Untouched parts
+    are named in `deadline_skipped` and are NOT `unseated` -- a search that ran
+    out of clock has measured nothing. `progress` is an optional
+    `(current, total, label)` callback.
     """
     import pose_score
     from placement import floorplan
@@ -655,7 +682,21 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
                      f"{thr:.2f}mm) seed before {len(unplaced) - len(anchors)}"
                      f" small(s): {', '.join(anchors)}")
         queue = anchors + [r for r in queue if r not in set(anchors)]
-    for ref in queue:
+    deadline_skipped: List[str] = []
+    for _qi, ref in enumerate(queue):
+        if deadline is not None and deadline.check('seed'):
+            deadline_skipped = list(queue[_qi:])
+            notes.append(
+                f"deadline reached after {_qi}/{len(queue)} part(s); "
+                f"{len(deadline_skipped)} left at their input poses and "
+                f"reported in deadline_skipped (NOT unseated -- they were "
+                f"never tried)")
+            break
+        if progress is not None:
+            try:
+                progress(_qi, len(queue), f'seat {ref}')
+            except Exception:                                   # noqa: BLE001
+                pass
         target = _partner_centroid(state, ref, placed) or center
         jx, jy = _jitter()
         rot_before = state.parts[ref].rot
@@ -723,7 +764,9 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
                    'new_rotation': state.parts[ref].rot}
                   for ref in sorted(placed)]
     return {'placements': placements, 'lock_refs': lock_refs,
-            'unseated': sorted(unseated), 'notes': notes}
+            'unseated': sorted(unseated), 'notes': notes,
+            'deadline_skipped': deadline_skipped,
+            'complete': not deadline_skipped}
 
 
 def stamp_locked(board_file: str, refs: Sequence[str]) -> int:
@@ -774,11 +817,13 @@ DISPROPORTION_FLOOR_MM = 1.0
 
 
 def repair_placement(pcb_data, pcb_file: str, intent, *,
+                     lock_globs: Optional[Sequence[str]] = None,
                      group_sources: Sequence[str] = (),
                      clearance: float = 0.25,
                      board_edge_clearance: float = 0.55,
                      grid_step: float = 0.1,
-                     caps: Sequence[float] = REPAIR_CAPS_MM) -> Dict:
+                     caps: Sequence[float] = REPAIR_CAPS_MM,
+                     deadline=None, progress=None) -> Dict:
     """Violation-driven minimal-move repair of a PLACED board (#place_seed
     --repair). Everything clean freezes; only violators move, worst first,
     each seated by the seeder's own search targeted at its CURRENT pose with
@@ -794,18 +839,45 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
     seating (the stamp in the file survives the positional rewrite, so no
     re-stamping is needed). A file-locked ref OUTSIDE must_lock is not this
     tool's to move: reported in `unrepairable`.
+
+    `deadline` is an optional `krt_deadline.Deadline`. This sweep has no
+    internal bound -- its cost is violators x caps x 36 ring sweeps x O(parts)
+    per candidate -- and on a 217-part board it ran 46 minutes without
+    terminating (run 9). When a budget is supplied the loop stops between
+    violators, keeps every seat it already made, and reports the untouched ones
+    in `deadline_skipped`. Those are NOT `unrepairable`: a search that ran out
+    of clock has measured nothing, and filing it as a failure is the same class
+    of lie as the silent hang.
+
+    `progress` is an optional `(current, total, label)` callback -- the sweep is
+    otherwise completely silent between its census line and its final line.
     """
     import pose_score
     from placement import floorplan, legality as _leg
 
+    # A caller's --lock globs, on top of the file's own (locked yes) stamps.
+    # These two entry points RE-PARSE the board and build their own state, so
+    # a lock resolved by the CLI never reached them -- `--lock` was honoured
+    # by five reconstruct stages and silently ignored by the two that move the
+    # most parts. Feeding it here means the existing `.locked` checks below
+    # (the unrepairable filter, and reseat's refusal list) pick it up for free.
+    _extra_locked = {r for pat in (lock_globs or [])
+                     for r in fnmatch.filter(sorted(pcb_data.footprints), pat)}
     state = pose_score.make_state(
         pcb_data, pcb_file, clearance=clearance,
-        board_edge_clearance=board_edge_clearance, grid_step=grid_step)
+        board_edge_clearance=board_edge_clearance, grid_step=grid_step,
+        extra_locked_refs=_extra_locked or None)
     refs_all = sorted(pcb_data.footprints)
     notes: List[str] = []
     must_lock = {r for pat in intent.must_lock
                  for r in fnmatch.filter(refs_all, pat)} if intent else set()
-    edge_refs = {c['ref'] for c in intent.edge_connectors} if intent else set()
+    # {ref: declared band max mm}. The off-board census below charges only the
+    # EXCESS past the band, not nothing at all -- see the note there.
+    edge_band: Dict[str, float] = {}
+    if intent:
+        for _c in intent.edge_connectors:
+            edge_band[_c['ref']] = float(
+                (_c.get('overhang_mm') or {}).get('max') or 0.0)
 
     blocks, _probs = floorplan.resolve_blocks(intent, pcb_data, group_sources) \
         if intent else ({}, [])
@@ -831,6 +903,28 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
     def _charge(ref, amt):
         if ref in state.parts:
             weight[ref] = weight.get(ref, 0.0) + amt
+
+    # Refs known to be misplaced on structural grounds, not inferred from size.
+    try:
+        from placement import reconstruct as _recon
+        witnesses = set(_recon.damage_witnesses(state))
+    except Exception:                                       # noqa: BLE001
+        witnesses = set()
+
+    def _mover_key(r):
+        """Which member of a conflicting pair should move.
+
+        Pin count is a proxy for "the small part is the cheap one to move",
+        and on a DAMAGED board it is the wrong question: it will happily move
+        a small connector that is exactly where it belongs out from under a
+        large part that is not. A ref carrying a structural witness -- a pad
+        centre off the outline, which a shipped board cannot have -- is KNOWN
+        to be misplaced, so it sorts first whatever its size.
+
+        On a board with no witnesses this changes nothing, and that is every
+        healthy board in the corpus: measured zero witnesses on all 33.
+        """
+        return (0 if r in witnesses else 1, state.parts[r].pin_count, r)
 
     graded = None
     if intent is not None:
@@ -862,7 +956,7 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
         # one available -- the partner was never tried, and the pair was
         # reported unrepairable. Both are candidates now; the weights keep the
         # preferred one first in the worst-first order.
-        ordered = sorted(free, key=lambda r: (state.parts[r].pin_count, r))
+        ordered = sorted(free, key=_mover_key)
         _charge(ordered[0], mm)
         for partner in ordered[1:]:
             partner_of.setdefault(ordered[0], []).append(partner)
@@ -882,7 +976,7 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
             notes.append(f"body stack {bp.a}<->{bp.b} ({bp.area_mm2}mm2): "
                          f"both file-locked -- not repairable here")
             continue
-        ordered = sorted(free, key=lambda r: (state.parts[r].pin_count, r))
+        ordered = sorted(free, key=_mover_key)
         # mm2 -> a strong mm-equivalent charge: a stack is never cosmetic
         _charge(ordered[0], max(1.0, bp.area_mm2))
         for partner in ordered[1:]:
@@ -895,9 +989,20 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
     # margined courtyard test flagged and "repaired" exactly those.
     zero_gate = _leg.BoardOutlineGate(pcb_data.board_info, 0.0)
     part_pads = _leg.build_part_pads(pcb_data.footprints, clearance)
+    #
+    # A DECLARED edge ref is exempt only WHILE ITS OVERHANG IS INSIDE ITS
+    # DECLARED BAND; past that the excess is charged like anyone else's. The
+    # exemption used to be unbounded (`if ref in edge_refs: continue`), which
+    # is safe only while the bands are a spec. Once `check_floorplan
+    # --emit-intent` is run on a DAMAGED board they are not: run 10 emitted
+    # bands equal to each part's damage displacement (up to 160 mm on an 81 mm
+    # board) and this census then skipped all ELEVEN off-board parts -- the
+    # repair reported 5 violators, none of them the ones whose pads were in the
+    # air, and all 13 unrouted nets had a pad on one of them. floorplan's
+    # EDGE_BAND_SANITY_MM stops such a band being emitted; this stops one that
+    # already exists (an older intent, a hand-written one) from blinding the
+    # census.
     for ref, part in state.parts.items():
-        if ref in edge_refs:
-            continue    # declared overhang is by design
         pp = part_pads.get(ref)
         if pp is None:
             continue
@@ -906,6 +1011,17 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
         if ext is None:
             continue
         amt = zero_gate.rect_outside_amount(ext)
+        band = edge_band.get(ref)
+        if band is not None:
+            excess = amt - band
+            if excess > 1e-6:
+                notes.append(
+                    f"{ref}: overhangs {amt:.3f}mm against a declared band of "
+                    f"{band:.3f}mm -- the {excess:.3f}mm EXCESS is charged "
+                    f"(a declared band exempts the overhang it declares, not "
+                    f"any overhang)")
+                _charge(ref, excess)
+            continue
         if amt > 1e-6:
             _charge(ref, amt)
 
@@ -941,7 +1057,24 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
     failed: List[str] = []
     zero_move: List[str] = []   # run-7 A2: honesty re-grade candidates
     moves: List[Dict] = []
-    for ref in violators:
+    deadline_skipped: List[str] = []
+    for _vi, ref in enumerate(violators):
+        # Budget check at the VIOLATOR head: one monotonic read per violator,
+        # and each violator costs seconds (caps x 36 ring sweeps x O(parts)).
+        # The partial is coherent by construction -- a violator is either fully
+        # seated, with its move in `moves`, or untouched.
+        if deadline is not None and deadline.check('legalize'):
+            deadline_skipped = list(violators[_vi:])
+            notes.append(
+                f"deadline reached after {_vi}/{len(violators)} violator(s); "
+                f"{len(deadline_skipped)} left untouched and reported in "
+                f"deadline_skipped (NOT unrepairable -- they were never tried)")
+            break
+        if progress is not None:
+            try:
+                progress(_vi, len(violators), f'repair {ref}')
+            except Exception:                                  # noqa: BLE001
+                pass
         part = state.parts[ref]
         was_locked = part.locked      # always False here: locked refs are
                                       # already in `unrepairable` (see above)
@@ -989,7 +1122,8 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
         for cap in caps:
             info: Dict = {}
             clr = _try_place(state, ref, ox, oy, set(), constraint=rect,
-                             tol=tol, max_disp=cap, info=info)
+                             tol=tol, max_disp=cap, info=info,
+                             deadline=deadline)
             if clr is not None:
                 placed_at = cap
                 if info.get('anchor_zone'):
@@ -1001,7 +1135,7 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
             zx = (z.rect[0] + z.rect[2]) / 2.0
             zy = (z.rect[1] + z.rect[3]) / 2.0
             clr = _try_place(state, ref, zx, zy, set(), constraint=rect,
-                             tol=tol)
+                             tol=tol, deadline=deadline)
             if clr is not None:
                 placed_at = 'zone'
         part.locked = was_locked
@@ -1017,7 +1151,8 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
                 pox, poy, porot = pp.x, pp.y, pp.rot
                 for cap in caps:
                     if _try_place(state, partner, pox, poy, set(),
-                                  max_disp=cap) is not None:
+                                  max_disp=cap,
+                                  deadline=deadline) is not None:
                         pd = math.hypot(pp.x - pox, pp.y - poy)
                         if pd > 1e-9:
                             seated_partner = (partner, pd)
@@ -1077,7 +1212,13 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
     # board whose pad/body census did not move are UNRESOLVED, so the fix
     # loop can see it stalled instead of believing "repaired" forever.
     unresolved = []
-    if zero_move and state.legality_ctx is not None:
+    if deadline_skipped:
+        # Skip the honesty re-grade on a partial run. It is O(zero_move x parts)
+        # with pair_shortfall, it can only DOWNGRADE `repaired`, and a partial
+        # run's `repaired` is already qualified by complete:false -- so paying
+        # for it here would just spend the clock we already ran out of.
+        notes.append("unresolved re-grade skipped: run stopped on its deadline")
+    elif zero_move and state.legality_ctx is not None:
         # Post-repair poses live on the STATE (pcb_data still holds the
         # file's input poses), so the re-grade uses the state's own pair
         # machinery in the gate currency.
@@ -1101,7 +1242,286 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
     return {'moves': moves, 'repaired': repaired, 'unrepairable':
             unrepairable + failed, 'unresolved': unresolved,
             'violators': violators, 'notes': notes,
+            'deadline_skipped': deadline_skipped,
+            'complete': not deadline_skipped,
             'pad_report_before': {k: pads[k] for k in
                                   ('pad_conflicts', 'hole_conflicts',
                                    'oob_pad_count')},
             'grade_errors_before': len(graded.errors) if graded else None}
+
+
+def reseat_scope(pcb_data, pcb_file: str, intent, *,
+                 lock_globs: Optional[Sequence[str]] = None,
+                 refs: Optional[Sequence[str]] = None,
+                 group_sources: Sequence[str] = (),
+                 clearance: float = 0.25,
+                 board_edge_clearance: float = 0.55,
+                 grid_step: float = 0.1,
+                 seed: int = 0,
+                 edge_bands: Optional[Dict[str, float]] = None,
+                 deadline=None, progress=None) -> Dict:
+    """LIFT a subset of parts and re-seat them FROM SCRATCH at their net
+    centroids, holding every other part fixed as an obstacle.
+
+    The contract that distinguishes this from `repair_placement`: **the part's
+    current pose is never consulted.** Every other repair path in this stack --
+    `--repair`'s cap ladder, `place_optimize`'s nudge, `place_portfolio`'s
+    strategies, reconstruct's `{stay, +v, -v, pattern slot}` candidate sets --
+    searches outward from where the part IS. That is the right question for a
+    part that is nearly home and no question at all for one that is tens of
+    millimetres out: a pose 30 mm from where a part belongs carries no
+    information about where it belongs, and the cost of hunting from it grows
+    with the cap while the chance of a hit does not. Measured on a 107-part
+    board with 11 parts 7-32 mm off the outline: `--repair` spent 4 m 55 s and
+    attempted none of them (its ladder tops out at 5 mm from the wrong centre);
+    `place_reconstruct --max-move 40` ran over 8.5 min; this pass seated 11 of
+    11 in 6.3 s.
+
+    Not a recovery pass. It puts parts where the NETLIST wants them, not where
+    they were, so `recovery` will not improve and `collateral_pad_rms` will
+    grow. The number to judge it on is `witnesses_after` -- the count of parts
+    whose pad centres are still off the outline -- because that is the one that
+    predicts routability: on the board above, the same 11 refs carried a pad on
+    every one of the 13 nets the router could not attempt, one for one.
+
+    Scope: `refs` (fnmatch globs over the board's references), else AUTO =
+    `reconstruct.damage_witnesses` -- refs with a pad CENTRE off the outline,
+    which is the negation of a manufacturability invariant (you cannot solder
+    to air) and is corpus-calibrated to ZERO on all 33 healthy boards. An empty
+    scope returns `{'reseated': []}` and is a RESULT, not a failure.
+
+    Every refusal is named in `notes`: a ref absent from the board, and a ref
+    locked in the file or in the intent's `must_lock` (a locked pose is not
+    this tool's to move -- the same rule `repair_placement` applies, for the
+    run-7 reason recorded there).
+
+    The scope's own `edge_connectors` declarations are DROPPED before seeding,
+    and this is mandatory rather than hygiene: `seed_from_intent`'s stage 1
+    places a declared edge connector with NO legality gate, at the middle of
+    its band, and then walks it outward. Measured with the bands left in, on an
+    intent auto-emitted from the damaged board, it threw TP4 to y = 30255 and
+    R12 to x = -3971 -- thirty metres off an 81 mm board. A ref being re-seated
+    has forfeited its band anyway: the band was measured off the pose being
+    discarded.
+
+    Gate, three conjuncts, because one lexicographic tuple is not enough here:
+
+      1. Per-seat and structural, already free: `_try_place` demands full
+         containment and `candidate_valid` -> `pads_ok` refuses any pose that
+         worsens a pad pair, introduces an any-net stack, or worsens a hole
+         shortfall.
+      2. Board-wide `reconstruct.measure` with `edge_bands` computed EXCLUDING
+         the scope, then a per-part `prune_assignment` sweep with
+         `evidenced=scope` (a part coming back onto the board is gate-neutral
+         on several terms by construction, exactly like the mounting-hole
+         homecoming that rule was written for).
+      3. A pass-specific conjunct the tuple cannot express: `oob` must STRICTLY
+         improve AND the witness count must not rise. The tuple's lexicographic
+         comparison stops at the first differing term, and a re-seat moves
+         `oob` (index 3) hugely in its own favour -- which would HIDE a new
+         stack, an hpwl blow-up or piled-on overlap below it. This conjunct is
+         what stops the pass 'succeeding' by moving a part sideways.
+
+    Returns `{'moves', 'reseated', 'refused', 'unseated', 'scope',
+    'scope_source', 'notes', 'gate_before', 'gate_after', 'accepted',
+    'witnesses_before', 'witnesses_after', 'edge_bands_dropped', 'pruned',
+    'deadline_skipped', 'complete'}`.
+
+    NOT `placement/reseat.py`, which is a different mechanism for a different
+    problem (Hungarian re-assignment of a proximity-tethered decap cluster onto
+    rings around its anchor IC, refusing outright when the members' nets are
+    rails). Do not merge them.
+    """
+    import dataclasses
+    import pose_score
+    from placement import floorplan, reconstruct as _recon
+
+    if intent is None:
+        intent = floorplan.empty_intent(pcb_file)
+
+    # A caller's --lock globs, on top of the file's own (locked yes) stamps.
+    # These two entry points RE-PARSE the board and build their own state, so
+    # a lock resolved by the CLI never reached them -- `--lock` was honoured
+    # by five reconstruct stages and silently ignored by the two that move the
+    # most parts. Feeding it here means the existing `.locked` checks below
+    # (the unrepairable filter, and reseat's refusal list) pick it up for free.
+    _extra_locked = {r for pat in (lock_globs or [])
+                     for r in fnmatch.filter(sorted(pcb_data.footprints), pat)}
+    state = pose_score.make_state(
+        pcb_data, pcb_file, clearance=clearance,
+        board_edge_clearance=board_edge_clearance, grid_step=grid_step,
+        extra_locked_refs=_extra_locked or None)
+    refs_all = sorted(pcb_data.footprints)
+    notes: List[str] = []
+    must_lock = {r for pat in intent.must_lock
+                 for r in fnmatch.filter(refs_all, pat)}
+
+    # ---- scope resolution --------------------------------------------------
+    witnesses_before = _recon.damage_witnesses(state)
+    if refs is None:
+        scope = set(witnesses_before)
+        scope_source = 'auto:damage_witnesses'
+    else:
+        scope = set()
+        scope_source = 'explicit'
+        for pat in refs:
+            hits = fnmatch.filter(refs_all, pat)
+            if not hits:
+                notes.append(f"{pat}: matches no reference on this board")
+            scope.update(hits)
+
+    refused: Dict[str, str] = {}
+    for ref in sorted(scope):
+        if ref not in state.parts:
+            refused[ref] = 'not a movable part on this board'
+        elif state.parts[ref].locked:
+            # NAME THE SOURCE. This said "(locked yes) in the file"
+            # unconditionally, which is false for a ref locked by --lock -- and
+            # sends the reader hunting the board for a stamp that is not there.
+            if ref in _extra_locked:
+                refused[ref] = ("locked by --lock on this invocation -- not "
+                                "this tool's to move")
+            else:
+                why = ("in must_lock, which grades the lock rather than "
+                       "licensing a move" if ref in must_lock
+                       else "not in must_lock")
+                refused[ref] = (f"(locked yes) in the file ({why}) -- not "
+                                f"this tool's to move")
+    for ref, why in sorted(refused.items()):
+        notes.append(f"{ref}: {why}")
+    scope -= set(refused)
+
+    def _empty(reason: str) -> Dict:
+        notes.append(reason)
+        return {'moves': [], 'reseated': [], 'refused': sorted(refused),
+                'intent_used': intent,
+                'unseated': [], 'scope': [], 'scope_source': scope_source,
+                'notes': notes, 'reason': reason,
+                'gate_before': list(_recon.measure(state, edge_bands or {})),
+                'gate_after': list(_recon.measure(state, edge_bands or {})),
+                'accepted': True, 'pruned': [],
+                'witnesses_before': sorted(witnesses_before),
+                'witnesses_after': sorted(witnesses_before),
+                'edge_bands_dropped': {}, 'deadline_skipped': [],
+                'complete': True}
+
+    if not scope:
+        # A no-op is a RESULT. On a healthy board the auto scope is empty by
+        # construction (zero witnesses on all 33 corpus boards), and that is
+        # the property that makes this pass safe to put in a default ladder.
+        # "No part NEEDS re-seating" is a claim about the board. When every
+        # candidate was refused for being locked, the truthful claim is about
+        # the LOCKS -- one run reported this while its own census still said
+        # `OFF-OUTLINE PARTS 1 -> 1`.
+        if refused:
+            return _empty(f'{len(refused)} candidate(s) were refused (locked), '
+                          f'so nothing was left to re-seat -- this is not '
+                          f'"no part needs it"')
+        return _empty('no part needs re-seating'
+                      if refs is None else
+                      'every named ref was refused or matched nothing')
+
+    # ---- edge bands: the scope forfeits its own ----------------------------
+    if edge_bands is None:
+        edge_bands = {}
+        for c in intent.edge_connectors:
+            if c['ref'] in state.parts:
+                band = c.get('overhang_mm') or {}
+                edge_bands[c['ref']] = float(band.get('max') or 2.0)
+    gate_bands = {r: m for r, m in edge_bands.items() if r not in scope}
+
+    dropped = {}
+    keep = []
+    for c in intent.edge_connectors:
+        if c['ref'] in scope:
+            dropped[c['ref']] = float((c.get('overhang_mm') or {}).get('max')
+                                      or 0.0)
+        else:
+            keep.append(c)
+    if dropped:
+        notes.append(
+            "dropped the edge declaration of " + ", ".join(
+                f"{r} (band {m:g}mm)" for r, m in sorted(dropped.items()))
+            + " -- a ref being re-seated has forfeited its band, which was "
+              "measured off the pose being discarded. Stage 1 seats a declared "
+              "edge connector with NO legality gate; leaving these in threw a "
+              "part 30km off the board in a measured probe.")
+    intent2 = dataclasses.replace(intent, edge_connectors=tuple(keep))
+
+    # ---- seat ---------------------------------------------------------------
+    before = _recon.measure(state, gate_bands)
+    old = {r: (state.parts[r].x, state.parts[r].y, state.parts[r].rot)
+           for r in sorted(scope)}
+    res = seed_from_intent(
+        pcb_data, pcb_file, intent2, random.Random(f"{seed}"),
+        group_sources=group_sources, clearance=clearance,
+        board_edge_clearance=board_edge_clearance, grid_step=grid_step,
+        seed_refs=set(scope), deadline=deadline, progress=progress)
+    notes.extend(res['notes'])
+
+    # `placements` covers every PLACED ref -- 101 of 107 on the measured board
+    # -- and `make_state` normalises rotation mod 360, so returning all of them
+    # rewrites -112.5 -> 247.5 on parts this pass never touched and pollutes
+    # every diff, every movie frame and every recovery measurement. Filter.
+    seated = {p['reference']: p for p in res['placements']
+              if p['reference'] in scope}
+    for ref, p in sorted(seated.items()):
+        state.apply_move(ref, p['new_x'], p['new_y'], p['new_rotation'])
+
+    # ---- gate ---------------------------------------------------------------
+    pruned = _recon.prune_assignment(state, old, notes,
+                                     edge_bands=gate_bands,
+                                     evidenced=set(scope))
+    after = _recon.measure(state, gate_bands)
+    witnesses_after = _recon.damage_witnesses(state)
+    _oob = _recon.GATE_TERMS.index('oob')
+    accepted = (after[_oob] < before[_oob]
+                and len(witnesses_after) <= len(witnesses_before))
+    if not accepted:
+        for ref, (x, y, rot) in old.items():
+            state.apply_move(ref, x, y, rot)
+        witnesses_after = _recon.damage_witnesses(state)
+        after = _recon.measure(state, gate_bands)
+        notes.append(
+            f"REVERTED: re-seating {len(scope)} part(s) did not strictly "
+            f"improve the off-board amount ({before[_oob]:g} -> "
+            f"{after[_oob]:g}) or raised the witness count "
+            f"({len(witnesses_before)} -> {len(witnesses_after)}). Both "
+            f"conjuncts are required: the gate tuple is lexicographic, so a "
+            f"large oob win would hide a new stack or an hpwl blow-up below "
+            f"it, and a sideways move that changes neither is not a re-seat.")
+
+    moves = []
+    if accepted:
+        for ref in sorted(scope):
+            p = state.parts[ref]
+            ox, oy, orot = old[ref]
+            if (math.hypot(p.x - ox, p.y - oy) > 1e-9
+                    or abs(p.rot - orot) > 1e-9):
+                moves.append({'reference': ref, 'new_x': p.x, 'new_y': p.y,
+                              'new_rotation': p.rot})
+
+    return {'moves': moves,
+            # The intent with the scope's edge declarations removed. A caller
+            # that GRADES the result must grade against this, not the intent it
+            # loaded: an entry declaring a 160 mm band was measured off the pose
+            # this pass just discarded, so grading the homecoming against it
+            # charges the repair for repairing (measured: 10 `R10 sits nearest
+            # the west edge but is declared on the east edge` errors on a board
+            # whose 11 off-outline parts had all come home). That is the same
+            # laundering as the band itself, one step later.
+            'intent_used': intent2,
+            'reseated': sorted(m['reference'] for m in moves),
+            'refused': sorted(refused),
+            'unseated': sorted(r for r in res['unseated'] if r in scope),
+            'scope': sorted(scope), 'scope_source': scope_source,
+            'notes': notes,
+            'gate_before': list(before), 'gate_after': list(after),
+            'accepted': accepted, 'pruned': sorted(pruned),
+            'witnesses_before': sorted(witnesses_before),
+            'witnesses_after': sorted(witnesses_after),
+            'edge_bands_dropped': {r: m for r, m in sorted(dropped.items())},
+            'deadline_skipped': sorted(r for r in
+                                       res.get('deadline_skipped') or ()
+                                       if r in scope),
+            'complete': res.get('complete', True)}

--- a/py_placer/pose_score.py
+++ b/py_placer/pose_score.py
@@ -59,7 +59,8 @@ def make_state(pcb_data, board_path: str, *, clearance: float = 0.25,
                halo_base: float = 0.5, halo_coef: float = 0.15,
                halo_weight: float = 2.0, edge_halo: float = 2.0,
                edge_weight: float = 2.0,
-               ignore_net_ids=None, net_weights=None, move_refs=None):
+               ignore_net_ids=None, net_weights=None, move_refs=None,
+               extra_locked_refs=None):
     """A QuenchState used purely as an oracle -- built, queried, thrown away.
 
     Defaults mirror the placement guidance rather than quench's own library
@@ -74,13 +75,15 @@ def make_state(pcb_data, board_path: str, *, clearance: float = 0.25,
         halo_coef=halo_coef, halo_weight=halo_weight, edge_halo=edge_halo,
         edge_weight=edge_weight, grid_step=grid_step,
         length_weight=length_weight, ignore_net_ids=ignore_net_ids,
-        net_weights=net_weights, move_refs=move_refs)
+        net_weights=net_weights, move_refs=move_refs,
+        extra_locked_refs=extra_locked_refs)
 
 
 def rank_poses(pcb_data, board_path: str, ref: str, *, radius: float = 2.0,
                step: float = 0.5, rotations: Sequence[float] = ROTATIONS,
                limit: int = 12, allow_rotations: bool = True,
                state=None, diagnostics: Optional[Dict] = None,
+               cancel_check=None,
                **state_kw) -> List[Dict]:
     """Legal poses for `ref`, cheapest first.
 
@@ -122,6 +125,17 @@ def rank_poses(pcb_data, board_path: str, ref: str, *, radius: float = 2.0,
     dropped_total = 0
     dropped_in_place = []
     for dx, dy in _offsets(radius, step):
+        # THE SWEEP, which `--limit` never bounded: limit truncates the sorted
+        # RESULT on the last line of this function, while every candidate here
+        # has already paid a full total_cost() plus ref_inversions(). A 30mm /
+        # 0.25mm ring set is 231,392 candidates and --limit 12 evaluates all of
+        # them. `_offsets` yields flat POINTS, not rings, so this runs once
+        # per candidate position (58,081 for r=30/s=0.25) -- finer than a
+        # ring and still negligible against a full cost evaluation.
+        if cancel_check is not None and cancel_check():
+            if diagnostics is not None:
+                diagnostics['stopped_early'] = True
+            break
         for rot in rots:
             x, y = x0 + dx, y0 + dy
             if not st.candidate_valid(ref, x, y, rot):

--- a/py_router/animate_route.py
+++ b/py_router/animate_route.py
@@ -377,7 +377,14 @@ def _write_mp4(frames, out, fps) -> bool:
     try:
         import numpy as np
         import imageio.v2 as imageio
-    except Exception:
+    except Exception as e:
+        # SAY SO. The encode-failure branch below prints and this one did not,
+        # so a missing imageio-ffmpeg silently produced a .gif where the caller
+        # asked for .mp4 -- the only trace being a `wrote ...` line with a
+        # different extension than the one requested. Two branches, one
+        # consequence, and only one of them was audible.
+        print(f"animate_route: mp4 unavailable ({e}); falling back to GIF. "
+              f"`pip install imageio imageio-ffmpeg` for mp4.", file=sys.stderr)
         return False
     try:
         # yuv420p (broadly playable: browsers, QuickTime, Slack, social) needs
@@ -416,7 +423,22 @@ def save_movie(frames, out, fps, end_hold, png_dir=None):
         dur = max(20, int(1000 / max(0.1, fps)))
         frames[0].save(out, save_all=True, append_images=seq[1:],
                        duration=dur, loop=0, optimize=False)
-        print(f"animate_route: wrote {out} ({len(frames)} frames, {dur}ms each, "
+        # Count what LANDED, not what was handed to the encoder. Pillow's GIF
+        # writer collapses runs of byte-identical frames into one frame with an
+        # accumulated duration, and this film is full of such runs by
+        # construction -- card holds and the end hold are literal repeats of a
+        # single Image. So `len(frames)` overstates the file: one run printed
+        # 377 and wrote 348, and the gap was only found by counting the
+        # delivered GIF by hand. A number nobody can reconcile against the
+        # artifact is worse than no number.
+        _n = len(frames)
+        try:
+            from PIL import Image as _PILImage, ImageSequence
+            with _PILImage.open(out) as _chk:
+                _n = sum(1 for _ in ImageSequence.Iterator(_chk))
+        except Exception:                                       # noqa: BLE001
+            pass
+        print(f"animate_route: wrote {out} ({_n} frames, {dur}ms each, "
               f"{frames[0].size[0]}x{frames[0].size[1]})")
     if png_dir:
         os.makedirs(png_dir, exist_ok=True)

--- a/py_router/bga_fanout/__init__.py
+++ b/py_router/bga_fanout/__init__.py
@@ -628,6 +628,27 @@ def manage_vias(
 
     Returns:
         Tuple of (vias_to_add, vias_to_remove)
+
+    KNOWN GAP, NOT FIXED HERE -- D10's self-blindness, in this function.
+    `vias_to_add` is appended to below and never read back, and BOTH guards
+    that gate an append iterate `pcb_data.vias` only: `would_overlap_existing_via`
+    and `via_in_pad_conflict`'s drill loop. So two vias added in ONE call are
+    never tested against each other -- the same shape as the qfn underpad
+    escape's, where the fix was to test each candidate against this run's own
+    output as well as the input board (`qfn_fanout.run_output_conflict`, which
+    is reusable and would be this code's second caller).
+
+    Structurally verified by reading; the IMPACT is UNMEASURED, deliberately
+    stated as such. A 0.5mm-pitch BGA taking via 0.45 + clearance 0.1 needs
+    0.55mm between adjacent ball centres and has 0.50 -- but `clamp_via_to_pad`
+    shrinks a via to fit its pad first, and on that pitch it may clamp far
+    enough to make the pair legal anyway. Whether this bites needs measuring
+    on a real fine-pitch BGA before anyone claims it does.
+
+    `via_in_pad_conflict` also prices its drill floor at the flat
+    `routing_defaults.HOLE_TO_HOLE_CLEARANCE` rather than the board's own
+    `min_hole_to_hole` -- the D9/D11 substitute-a-constant class, unclosed
+    here (qfn_fanout resolves it board-first, wrapped at the fab floor).
     """
     def find_nearby_via(x: float, y: float, net_id: int, max_dist: float):
         """Find an existing via on the same net within max_dist of position."""

--- a/py_router/bga_fanout/underpad.py
+++ b/py_router/bga_fanout/underpad.py
@@ -541,6 +541,32 @@ def generate_underpad_escape(footprint: Footprint,
     floors = fab_floor_ladder(_copper)
     clamp_stats = {'clamped': 0, 'floor': 0, 'escalated': 0}
 
+    # DRILL FLOOR, board-first and raise-only. `_via_site_conflict` below spaced
+    # every drill it places at the flat routing_defaults.HOLE_TO_HOLE_CLEARANCE
+    # and this module never read the board at all -- grepping it for
+    # board_floor / board_constraint / min_hole_to_hole / resolve_hole_clearance
+    # returned nothing. So a board declaring min_hole_to_hole 0.3 got its BGA
+    # underpad drills spaced at 0.2: the D9/D11 substitute-a-constant class,
+    # in the direction that IGNORES a board asking for MORE.
+    #
+    # RAISE-ONLY IN THE CODE, not only in this comment (the Q4 lesson):
+    # board_floor is board-authoritative and will happily return a declared
+    # 0.10, so the fab floor is wrapped in explicitly. check_join.py:118-122 is
+    # the same shape and was the correct model. qfn_fanout does this too; this
+    # is its sibling engine and was the one still ignoring the board.
+    from list_nets import board_floor as _board_floor
+    _h2h_decl, _h2h_src = _board_floor(
+        getattr(pcb_data, 'source_path', "") or "", 'hole_to_hole',
+        None, HOLE_TO_HOLE_CLEARANCE)
+    _h2h_fab = fab_floor_min(_copper).get('hole_to_hole', 0.0)
+    _h2h = max(_h2h_decl, _h2h_fab)
+    if _h2h_src == 'board constraint' and _h2h_decl > HOLE_TO_HOLE_CLEARANCE:
+        print(f"  Hole-to-hole {_h2h:g}mm (from the board's own "
+              f"min_hole_to_hole)")
+    elif _h2h_src == 'board constraint' and _h2h_decl < _h2h_fab:
+        print(f"  Board min_hole_to_hole {_h2h_decl:g}mm is below the "
+              f"{_h2h_fab:g}mm fab hole-to-hole floor; using {_h2h:g}mm.")
+
     def via_for_pad(p):
         """Clamped (size, drill, keepout_radius) for a via dropped in pad p."""
         cs, cd, status, rung = clamp_via_to_pad(via_size, via_drill, p, floors)
@@ -891,19 +917,19 @@ def generate_underpad_escape(footprint: Footprint,
             vdr = (via_drill or 0.0) / 2.0
         for (ox, oy, orr, odr, onid) in ctx['vias']:
             d = math.hypot(ox - x, oy - y)
-            if d < vdr + odr + HOLE_TO_HOLE_CLEARANCE - 1e-6:
+            if d < vdr + odr + _h2h - 1e-6:
                 return "drill hole-to-hole vs a via"
             if onid != net_id and d < vr + orr + clearance - 1e-6:
                 return "via ring vs a foreign via"
         for (ox, oy, orr, odr, onid) in ([] if skip_resv else ctx['resv']):
             d = math.hypot(ox - x, oy - y)
-            if d < vdr + odr + HOLE_TO_HOLE_CLEARANCE - 1e-6:
+            if d < vdr + odr + _h2h - 1e-6:
                 return "drill hole-to-hole vs a reserved via site"
             if onid != net_id and d < vr + orr + clearance - 1e-6:
                 return "via ring vs a reserved via site"
         for (px, py, half, pdr, pnid, has_cu) in ctx['pads']:
             d = math.hypot(px - x, py - y)
-            if pdr and d < vdr + pdr + HOLE_TO_HOLE_CLEARANCE - 1e-6:
+            if pdr and d < vdr + pdr + _h2h - 1e-6:
                 return "drill hole-to-hole vs a pad drill"
             if has_cu and pnid != net_id and d < vr + half + clearance - 1e-6:
                 return "via ring vs a foreign pad"

--- a/py_router/check_connected.py
+++ b/py_router/check_connected.py
@@ -24,6 +24,11 @@ from net_queries import expand_pad_layers
 # tests/test_component_multipoint.py) and > ~0.02 (COINCIDENCE_TOL).
 STRICT_JOINT_OVERLAP = 0.05
 
+# Zone layers already reported as not-a-copper-layer-of-this-board.
+# check_net_connectivity runs once PER NET, so without this the same phantom
+# layer would be announced fifty-odd times on one board.
+_WARNED_PHANTOM_ZONE_LAYERS: Set[str] = set()
+
 
 def point_in_polygon(x: float, y: float, polygon: List[Tuple[float, float]]) -> bool:
     """Check if a point (x, y) is inside a polygon using ray casting algorithm.
@@ -687,9 +692,32 @@ def check_net_connectivity(net_id: int, segments: List[Segment], vias: List[Via]
             # Skip wildcards like "*.Cu" - they don't represent actual layers
             if layer.endswith('.Cu') and not layer.startswith('*'):
                 copper_layer_set.add(layer)
+    # A zone layer is cross-checked against the board's OWN copper layers, not
+    # merely tested for a '.Cu' suffix (#run11). route_planes once accepted a
+    # net:layer pair as a layer name and wrote (layer "GND:B.Cu") into the zone:
+    # KiCad refuses such a file outright, but "GND:B.Cu".endswith('.Cu') is
+    # True, so the phantom layer joined this census, expand_pad_layers spread
+    # through-hole pads onto it, and the pour was credited 70/70 when the honest
+    # figure was 69/70. Every checker downstream of this function inherited that
+    # lie. GUARD: only when the board declares copper layers -- a board whose
+    # stackup failed to parse degrades to the old behaviour rather than having
+    # every zone rejected.
+    _board_copper = set(getattr(getattr(pcb_data, 'board_info', None),
+                                'copper_layers', None) or ())
     for zone in zones:
-        if zone.layer.endswith('.Cu'):
-            copper_layer_set.add(zone.layer)
+        if not zone.layer.endswith('.Cu'):
+            continue
+        if _board_copper and zone.layer not in _board_copper:
+            if zone.layer not in _WARNED_PHANTOM_ZONE_LAYERS:
+                _WARNED_PHANTOM_ZONE_LAYERS.add(zone.layer)
+                print(f"WARNING: zone on layer '{zone.layer}', which is NOT a "
+                      f"copper layer of this board "
+                      f"({', '.join(sorted(_board_copper))}). KiCad cannot open "
+                      f"this file; its copper is NOT credited here. A net:layer "
+                      f"pair passed to route_planes --plane-layers writes exactly "
+                      f"this.")
+            continue
+        copper_layer_set.add(zone.layer)
 
     # Sort layers: F.Cu first, then In*.Cu in order, then B.Cu last
     def layer_sort_key(layer):
@@ -1528,6 +1556,34 @@ def run_connectivity_check(pcb_file: str, net_patterns: Optional[List[str]] = No
                         continue
                 unrouted_nets.append((net_id, net_info.name, len(pads_by_net[net_id])))
 
+    # A scope that matched NOTHING is not a clean board. This printed
+    # `Checking 0 nets matching: [...]` and then went on to
+    # `ALL NETS FULLY CONNECTED!` and exit 0 -- so a typo'd or shell-mangled
+    # --nets turned the instrument the project says to always run before
+    # calling a route clean into a rubber stamp, invisible to `&&` and to
+    # `set -e`. Found live when a shell rewrote `/IO_Banks/Z0` into a Windows
+    # path. Same failure mode as the oracle branch ~200 lines below, which was
+    # already fixed there.
+    if (net_patterns or component) and not nets_to_check:
+        _what = []
+        if net_patterns:
+            _what.append(f"--nets {net_patterns}")
+        if component:
+            _what.append(f"component {component}")
+        print(f"ERROR: {' and '.join(_what)} matched NO nets on this board. "
+              f"That is a scope that selected nothing, not a board that is "
+              f"connected -- refusing to report a result. Check the pattern "
+              f"(a leading '/' is rewritten by some shells; MSYS_NO_PATHCONV=1 "
+              f"on Git Bash), or drop the flag to check every net.",
+              file=sys.stderr)
+        # Returned as an issue rather than an exit code: this function's
+        # contract is List[Dict] and library callers unpack it. main() maps
+        # `scope_error` to exit 2, which is distinct from 1 ("found real
+        # problems") so a caller can tell a bad scope from a bad board.
+        return [{'scope_error': True, 'net_patterns': net_patterns,
+                 'component': component,
+                 'description': 'the requested scope matched no nets'}]
+
     if not quiet:
         if net_patterns and component:
             print(f"Checking {len(nets_to_check)} nets on {component} matching: {net_patterns}")
@@ -1642,6 +1698,19 @@ def run_connectivity_check(pcb_file: str, net_patterns: Optional[List[str]] = No
             from kicad_oracle import find_kicad_cli, kicad_unconnected
             _cli = find_kicad_cli()
             _links = kicad_unconnected(pcb_file, _cli) if _cli else None
+            if _links is None and not quiet:
+                # There was no `else` here, so "the oracle ran and agreed" and
+                # "the oracle never ran" printed identically -- i.e. nothing --
+                # and the run still ended `ALL NETS FULLY CONNECTED!` / exit 0.
+                # On a board with zones that is the difference between a graded
+                # result and an ungraded one, and the reader could not tell.
+                # kicad_unconnected() returns None for a missing CLI, a DRC
+                # timeout (ORACLE_DRC_TIMEOUT 240s), a bad return code, or
+                # unreadable JSON; only the timeout prints anything of its own.
+                print(f"  NOTE: the KiCad grade reconciliation did NOT run "
+                      f"({'kicad-cli not found' if not _cli else 'the oracle returned nothing -- DRC timeout, bad exit, or unreadable output'})."
+                      f" Zone-covered nets below are graded by the copper model "
+                      f"ALONE; KiCad has not agreed with them.")
             if _links is not None:
                 _linked_nets = {lk[0] for lk in _links}
                 _reclass = [i for i in issues
@@ -1857,4 +1926,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     issues = run_connectivity_check(args.pcb, args.nets, args.tolerance, args.quiet, args.verbose, args.component, args.routed_only)
+    # 2 = the scope selected nothing, so no board was graded. Deliberately not
+    # 1: a caller must be able to tell "your pattern is wrong" from "this board
+    # has unconnected nets", and must never read either as success.
+    if any(i.get('scope_error') for i in issues):
+        sys.exit(2)
     sys.exit(1 if issues else 0)

--- a/py_router/check_drc.py
+++ b/py_router/check_drc.py
@@ -1558,6 +1558,7 @@ def render_violation_panels(pcb_file: str, violations: List[dict],
 def run_drc(pcb_file: str, clearance: float = 0.1, net_patterns: Optional[List[str]] = None,
             debug_output: bool = False, quiet: bool = False,
             hole_to_hole_clearance: float = defaults.HOLE_TO_HOLE_CLEARANCE, board_edge_clearance: float = 0.0,
+            hole_clearance: float = 0.0,
             clearance_margin: float = 0.05, max_print: int = 20,
             min_track_width: Optional[float] = None,
             min_via_diameter: Optional[float] = None,
@@ -2378,8 +2379,15 @@ def run_drc(pcb_file: str, clearance: float = 0.1, net_patterns: Optional[List[s
     # Each hole is its drill CAPSULE ((x1,y1),(x2,y2),r): a slot drill's real
     # shape. Round drills degenerate to a zero-length capsule (the old circle).
     from kicad_parser import pad_drill_capsule
-    # JLC "NPTH to Track" fab floor (never below the graded clearance).
-    npth_clr = max(clearance, defaults.NPTH_TO_TRACK_CLEARANCE)
+    # JLC "NPTH to Track" fab floor (never below the graded clearance), raised
+    # to the board's own `min_hole_clearance` when it declares a tighter-than-
+    # -default requirement. Without that third term this check graded every
+    # board at a HARDCODED 0.20 and never opened the project at all, so copper
+    # sitting in a board's authored copper-to-hole band read clean -- measured
+    # on neo6502: three NPTH holes at 0.2126/0.2263/0.2263 mm against an
+    # authored min_hole_clearance of 0.25, clean at 0.20, and clean BEFORE any
+    # ratchet as well, because the key was never consulted in the first place.
+    npth_clr = max(clearance, defaults.NPTH_TO_TRACK_CLEARANCE, hole_clearance)
     # Each entry: (p1, p2, r, net_id, ref, required_clr, copper_exempt).
     # NPTH (no-copper) pad holes graded at the fab floor -- or the pad's own
     # clearance OVERRIDE when larger (KiCad's hole_clearance honors it; #326
@@ -3133,6 +3141,11 @@ if __name__ == "__main__":
                              f'(default: {defaults.HOLE_TO_HOLE_CLEARANCE}, the fab floor — same as routing)')
     parser.add_argument('--board-edge-clearance', type=float, default=0.0,
                         help='Minimum clearance from board edge in mm (0 = use --clearance value)')
+    parser.add_argument('--hole-clearance', type=float, default=0.0,
+                        help=f'Minimum COPPER-to-drill-hole clearance in mm '
+                             f'(0 = auto: the project\'s min_hole_clearance, else '
+                             f'the {defaults.NPTH_TO_TRACK_CLEARANCE} fab floor). '
+                             f'Raises the floor, never lowers it.')
     parser.add_argument('--clearance-margin', type=float, default=0.05,
                         help='Fraction of clearance to use as tolerance (default: 0.05 = 5%%). Violations smaller than clearance*margin are ignored.')
     parser.add_argument('--nets', '-n', nargs='+', default=None,
@@ -3252,12 +3265,27 @@ if __name__ == "__main__":
             if not args.quiet:
                 print(f"Hole-to-hole clearance {_pro_h2h:.4g} mm "
                       f"(from project min_hole_to_hole)")
+        # COPPER-to-hole, the third of the same family and the one that was
+        # missing. The two blocks above board-derive their floors; this check
+        # did not, and graded every board at the hardcoded 0.20
+        # NPTH_TO_TRACK_CLEARANCE instead -- so a board declaring
+        # min_hole_clearance 0.25 had its authored 0.20-0.25 band graded clean,
+        # and no ratchet was needed to hide it (neo6502: 3 NPTH holes, tightest
+        # 0.2126 mm). Same shape as the two above: raise, never lower.
+        _pro_hclr = float(_rules.get('constraints', {})
+                          .get('min_hole_clearance') or 0.0)
+        if _pro_hclr > args.hole_clearance:
+            args.hole_clearance = _pro_hclr
+            if not args.quiet:
+                print(f"Copper-to-hole clearance {_pro_hclr:.4g} mm "
+                      f"(from project min_hole_clearance)")
     except Exception as e:
         if not args.quiet:
             print(f"  (netclass/edge rules not read: {e})")
 
     violations = run_drc(args.pcb, args.clearance, args.nets, args.debug_lines, args.quiet,
                          args.hole_to_hole_clearance, args.board_edge_clearance,
+                         args.hole_clearance,
                          args.clearance_margin, max_print=args.max_print,
                          min_track_width=args.min_track_width,
                          min_via_diameter=args.min_via_diameter,

--- a/py_router/check_weird.py
+++ b/py_router/check_weird.py
@@ -28,6 +28,10 @@ Categories:
   unsupported-via    a via with no same-net track copper reaching its barrel,
                      not inside a same-net pad, and not inside a same-net
                      zone polygon (a floating via).
+  dangling-via       a via whose same-net copper reaches it on exactly ONE of
+                     the layers it spans, so the barrel joins nothing. This is
+                     KiCad's own `via_dangling` rule; it is a strictly weaker
+                     condition than unsupported-via, which needs ZERO support.
   orphan-island      a connected group of same-net track copper (segments,
                      possibly with vias) that reaches NO pad of the net --
                      dead copper stranded by a rip or a superseded route.
@@ -61,7 +65,7 @@ from pcb_modification import _point_anchored, _prune_net_cycles, _pt_seg_dist
 
 CATEGORIES = ['dangling-end', 'soft-joint', 'redundant-cycle',
               'removable-segment', 'stacked-copper', 'unsupported-via',
-              'orphan-island']
+              'dangling-via', 'orphan-island']
 # Cost cap for the per-segment removable scan (spec: skip unless --thorough).
 MAX_SEGS_PER_NET = 500
 _CELL = 1.0  # spatial-grid cell (mm) fed to _point_anchored, as in the pruner
@@ -465,36 +469,47 @@ def _check_unsupported_vias(net_id, name, net_segs, net_vias, net_pads,
     for v in net_vias:
         span = _via_span(v, copper_layers)
         r = (getattr(v, 'size', 0.6) or 0.6) / 2.0
-        supported = False
+        # Collect WHICH layers support the barrel, not merely whether any does.
+        # A via exists to join layers, so one supported layer means it joins
+        # nothing -- that is KiCad's own `via_dangling` rule ("fewer than two
+        # layers connected"), and short-circuiting at the first hit could not
+        # express it: run 11 shipped a board KiCad flagged with 64 dangling
+        # vias while this check reported none, because every one of them had
+        # copper on exactly one end.
+        sup = set()
         for s in net_segs:
-            if s.layer not in span:
+            if s.layer not in span or s.layer in sup:
                 continue
             if _pt_seg_dist(v.x, v.y, s.start_x, s.start_y,
                             s.end_x, s.end_y) < r + s.width / 2 - 1e-6:
-                supported = True
-                break
-        if not supported:
-            for p in net_pads:
-                if getattr(p, 'pad_type', '') == 'np_thru_hole':
-                    continue  # NPTH pads have no copper
-                if p.drill and p.drill > 0:
-                    on_layer = True  # plated barrel spans all copper layers
-                else:
-                    pl = set(p.layers or [])
-                    on_layer = bool(span & pl) or any('*' in L for L in pl)
-                if on_layer and _point_in_pad(v.x, v.y, p, margin=COINCIDENCE_TOL):
-                    supported = True
-                    break
-        if not supported:
-            for z in net_zones:
-                if z.layer in span and point_in_polygon(v.x, v.y, z.polygon):
-                    supported = True
-                    break
-        if not supported:
-            layer_str = ','.join(v.layers) if v.layers else '*.Cu'
+                sup.add(s.layer)
+        for p in net_pads:
+            if getattr(p, 'pad_type', '') == 'np_thru_hole':
+                continue  # NPTH pads have no copper
+            if p.drill and p.drill > 0:
+                on = set(span)  # plated barrel spans all copper layers
+            else:
+                pl = set(p.layers or [])
+                on = set(span) if any('*' in L for L in pl) else (span & pl)
+            if on and not on <= sup and _point_in_pad(
+                    v.x, v.y, p, margin=COINCIDENCE_TOL):
+                sup |= on
+        for z in net_zones:
+            if z.layer in span and z.layer not in sup and point_in_polygon(
+                    v.x, v.y, z.polygon):
+                sup.add(z.layer)
+        layer_str = ','.join(v.layers) if v.layers else '*.Cu'
+        if not sup:
             findings.append(_finding(
                 'unsupported-via', name, layer_str, v.x, v.y,
                 "floating via: no same-net track, pad, or zone reaches it",
+                size=getattr(v, 'size', None)))
+        elif len(sup) == 1 and len(span) > 1:
+            findings.append(_finding(
+                'dangling-via', name, layer_str, v.x, v.y,
+                f"dangling via: same-net copper reaches it on {next(iter(sup))} "
+                f"only, so it spans {len(span)} layer(s) but joins none "
+                f"(KiCad via_dangling)",
                 size=getattr(v, 'size', None)))
 
 

--- a/py_router/cli_banner.py
+++ b/py_router/cli_banner.py
@@ -53,12 +53,65 @@ def command_line() -> str:
     return ' '.join(_quote(a) for a in head)
 
 
+def install_dash_hint() -> None:
+    """Explain the one argparse failure a real net name can cause.
+
+    Run 14 lost a lap to this. The board carried a net called ``-12V`` -- not
+    exotic; every bipolar analog board has one -- and ``route.py --nets ...
+    -12V ...`` died with::
+
+        route.py: error: unrecognized arguments: -12V
+
+    no board, no JSON_SUMMARY, exit 2. ``--nets`` is ``nargs='+'``, so argparse
+    takes a leading ``-`` as the start of a flag. The same hole is in every
+    name-taking list flag across route.py, route_diff.py, route_planes.py,
+    route_disconnected_planes.py, check_drc.py and check_connected.py -- 30-odd
+    of them -- and the fix at each call site is the same one character:
+    ``--nets=-12V``.
+
+    Rather than patch thirty parsers, this patches ``ArgumentParser.error`` once
+    from ``install()``, which every instrument already calls. The GUI never
+    calls ``install()``, so no GUI path changes.
+    """
+    import argparse
+    import re
+    orig = argparse.ArgumentParser.error
+    if getattr(orig, '_krt_dash_hint', False):
+        return
+
+    def error(self, message):                       # noqa: D401
+        try:
+            m = re.search(r'unrecognized arguments:\s*(.+)$', str(message))
+            bad = [t for t in (m.group(1).split() if m else [])
+                   if t.startswith('-') and t != '-']
+            if bad:
+                t = bad[0]
+                sys.stderr.write(
+                    "\n  NOTE: %r begins with '-', so argparse read it as a "
+                    "flag rather than a value.\n"
+                    "        A net (or layer) whose NAME starts with '-' must "
+                    "be attached with '=':\n"
+                    "            --nets=%s          not   --nets %s\n"
+                    "        Every name-taking list flag here has this shape "
+                    "(--nets, --power-nets,\n"
+                    "        --rip-existing-nets, --plane-layers, ...).\n\n"
+                    % (t, t, t))
+                sys.stderr.flush()
+        except Exception:               # a hint must never mask the real error
+            pass
+        return orig(self, message)
+
+    error._krt_dash_hint = True
+    argparse.ArgumentParser.error = error
+
+
 def install() -> None:
     """Print the CMD banner now; print EXIT=<rc> when the process ends."""
     global _installed
     if _installed or os.environ.get('KRT_NO_BANNER'):
         return
     _installed = True
+    install_dash_hint()
     # Line-buffer the log (run-7 A11). Redirected to a file, stdout is
     # BLOCK-buffered, so a run that is killed -- a timeout, a stall, a closed
     # session -- loses whatever sits in the 8KB buffer. One run-7 board's

--- a/py_router/diff_pair_custody.py
+++ b/py_router/diff_pair_custody.py
@@ -182,8 +182,18 @@ def build_pair_reports(state, diff_pair_ids_to_route, member_audit,
             # read as a contradicted claim and demoted it from
             # routed_diff_pairs while its trunk was coupled and its board
             # finished clean. incomplete_members stays populated either way.
-            'member_audit_mismatch': bool(outcome == 'coupled'
-                                          and incomplete),
+            # ...but a 'partial' pair with BOTH members incomplete is not the
+            # protected case. The tigard exemption above is about ONE peeled
+            # leg closing in the single-ended follow-up; a pair where neither
+            # member ends up connected has nothing coupled left to credit, and
+            # counting it as routed is the same #514 defect wearing the
+            # 'partial' label (run 11: /USB_D reported "1/1 routed" with both
+            # /USB_D+ and /USB_D- in incomplete_members). Member COUNT is the
+            # discriminator the outcome label alone cannot supply.
+            'member_audit_mismatch': bool(
+                incomplete and (outcome == 'coupled'
+                                or (outcome == 'partial'
+                                    and len(incomplete) == 2))),
         }
         if diag.get('blocking_nets'):
             rep['blocking_nets'] = diag['blocking_nets']

--- a/py_router/fab_tiers.py
+++ b/py_router/fab_tiers.py
@@ -236,6 +236,9 @@ def check_param_floors(copper_layer_count, tier=None, overrides=None, **params):
     return viols
 
 
+_escalation_lever_said = []
+
+
 def warn_fab_escalation(context):
     """Emit a one-line warning (deduped per run, per context) that a routing step
     dropped below the standard floor to the more-costly advanced floor."""
@@ -245,6 +248,13 @@ def warn_fab_escalation(context):
     print(f"  WARNING: {context}: escalated standard->advanced fab floor "
           f"(0.25/0.15 via etc., more costly to fab); pass --fab-tier advanced to "
           f"silence, or --fab-overrides to pin your own floor (forbids escalation)")
+    if not _escalation_lever_said:
+        _escalation_lever_said.append(True)
+        print("           NOTE: --via-size cannot prevent this. The via is "
+              "re-derived from min(pad.size_x, pad.size_y) floored at the fab "
+              "ladder, so RAISING --via-size makes the clamp fire more "
+              "readily, never less. --fab-overrides collapses the ladder to a "
+              "single rung and is the only flag that forbids the escalation.")
 
 
 # --- Override file + argparse helpers ----------------------------------------

--- a/py_router/fix_kicad_drc_settings.py
+++ b/py_router/fix_kicad_drc_settings.py
@@ -371,6 +371,16 @@ FAB_FLOOR_KEYS = (
     ("min_via_annular_width", "via annular ring"),
     ("min_via_drill", "via drill"),
     ("min_through_hole_diameter", "hole diameter"),
+    # Copper-to-hole. It belongs here and not with the aspirational netclass
+    # clearances: it is a drill-REGISTRATION constraint, the same family as
+    # annular ring above, and relaxing it is a claim about what the fab can
+    # make. Measured on neo6502: a chain lowered it 0.25 -> 0.20 and the
+    # disclosure said nothing, because this tuple did not list it, so
+    # `relaxed: []` was a blind pass over three NPTH holes carrying copper at
+    # 0.2126/0.2263/0.2263 mm. NOTE it is DECLARATION-only: scan_board_minima
+    # measures object sizes and no pairwise geometry, so no measured
+    # counterpart exists for this key.
+    ("min_hole_clearance", "copper-to-hole clearance"),
 )
 
 

--- a/py_router/kicad_oracle.py
+++ b/py_router/kicad_oracle.py
@@ -46,10 +46,41 @@ KICAD_CLI_CANDIDATES = [
 # far sooner and its remaining rounds are skipped.
 ORACLE_DRC_TIMEOUT = 240
 
-# realpath() of boards whose kicad-cli DRC blew ORACLE_DRC_TIMEOUT once. The
-# oracle is called once per plane-repair step, so remembering a slow board
-# stops it re-burning the timeout on every later step of the same run.
+# Boards whose kicad-cli DRC blew ORACLE_DRC_TIMEOUT once. The oracle is called
+# once per plane-repair step, so remembering a slow board stops it re-burning
+# the timeout on every later step of the same run.
+#
+# KEYED ON A FILL-COST SIGNATURE, NOT ON THE PATH. The path key never fired in
+# practice: a chain writes a NEW output board each step (r1c, r1b, r2, r3...),
+# so every step got a fresh key and re-burned the full 240s. Measured on run 9:
+# a board KiCad could not fill in 300s was re-attempted at every step of the
+# chain, and each attempt cost the whole timeout.
+#
+# What actually drives the fill cost is the ZONE geometry, the outline, and the
+# pad field -- not the routed copper, which grows between steps. So the memo
+# keys on those, which stay stable across a chain while the copper changes.
+# It is a heuristic and it is the honest one available: a board that could not
+# be filled with these zones and these pads will not become fillable because
+# thirty more tracks were added.
 _ORACLE_TIMED_OUT = set()
+
+
+def _fill_cost_key(board_file: str):
+    """(zones, pads, footprints, outline-ish) -- stable across a routing chain.
+
+    Falls back to the realpath when the board cannot be read, which restores the
+    old behaviour rather than failing closed on a parse error.
+    """
+    try:
+        from kicad_parser import parse_kicad_pcb
+        pcb = parse_kicad_pcb(board_file)
+        bb = pcb.board_info.board_bounds or (0, 0, 0, 0)
+        return ('fill', len(getattr(pcb, 'zones', ()) or ()),
+                sum(len(f.pads) for f in pcb.footprints.values()),
+                len(pcb.footprints),
+                tuple(round(v, 2) for v in bb))
+    except Exception:                                          # noqa: BLE001
+        return ('path', os.path.realpath(board_file))
 
 # The oracle reads ONLY unconnected_items, which KiCad's connectivity engine
 # computes independently of the geometric DRC rule providers. Forcing every
@@ -80,20 +111,46 @@ _IGNORE_SEVERITIES = [
 
 
 def find_kicad_cli() -> Optional[str]:
-    for c in KICAD_CLI_CANDIDATES:
-        if c and os.path.exists(c):
-            return c
-    # KICAD_CLI env override, then versioned Windows installs (not on PATH;
-    # newest wins). Run 5 silently skipped every oracle recheck on Windows
-    # because none of the unix candidates exist there.
+    # The ENV OVERRIDE GOES FIRST. It used to be checked after the unix
+    # candidates, so `KICAD_CLI=/my/build/kicad-cli` was ignored on any machine
+    # that also had a packaged one -- an override that the presence of a
+    # default silently defeats is not an override.
     env = os.environ.get('KICAD_CLI', '')
     if env and os.path.exists(env):
         return env
+    for c in KICAD_CLI_CANDIDATES:
+        if c and os.path.exists(c):
+            return c
+    # Versioned Windows installs (not on PATH; newest wins). Run 5 silently
+    # skipped every oracle recheck on Windows because none of the unix
+    # candidates exist there. The single hard-coded root missed a 32-bit
+    # install, a per-user install, and any non-C: drive -- all of which fail
+    # exactly like "no KiCad", i.e. silently, because a missing oracle is
+    # indistinguishable from a clean one downstream.
     if sys.platform == 'win32':
         import glob
-        hits = sorted(glob.glob(r'C:\Program Files\KiCad\*\bin\kicad-cli.exe'))
+        roots = [os.environ.get('ProgramFiles', r'C:\Program Files'),
+                 os.environ.get('ProgramFiles(x86)', r'C:\Program Files (x86)'),
+                 os.environ.get('ProgramW6432', ''),
+                 os.path.join(os.environ.get('LOCALAPPDATA', ''), 'Programs'),
+                 r'C:\Program Files']
+        hits = []
+        for root in roots:
+            if not root:
+                continue
+            hits += glob.glob(os.path.join(root, 'KiCad', '*', 'bin',
+                                           'kicad-cli.exe'))
         if hits:
-            return hits[-1]
+            # Newest KiCad by version-ish directory name, de-duplicated: the
+            # roots overlap (ProgramFiles and ProgramW6432 are usually equal).
+            def _ver(p):
+                try:
+                    return tuple(int(x) for x in
+                                 os.path.basename(os.path.dirname(
+                                     os.path.dirname(p))).split('.'))
+                except ValueError:
+                    return (0,)
+            return sorted(set(hits), key=_ver)[-1]
     return None
 
 
@@ -187,7 +244,7 @@ def kicad_unconnected(board_file: str, kicad_cli: str,
             data = json.load(f)
     except subprocess.TimeoutExpired:
         dt = time.monotonic() - t0
-        _ORACLE_TIMED_OUT.add(os.path.realpath(board_file))
+        _ORACLE_TIMED_OUT.add(_fill_cost_key(board_file))
         print(f"  KiCad-oracle recheck: WARNING kicad-cli DRC timed out after "
               f"{dt:.0f}s (>{timeout}s) on {os.path.basename(board_file)}; "
               f"skipping the oracle for this board")
@@ -1026,7 +1083,7 @@ def oracle_reconnect(board_file: str, net_names, config,
     # A board whose DRC already blew ORACLE_DRC_TIMEOUT once (#420) will do it
     # again on every later plane-repair step of this run -- skip it outright
     # rather than re-burn minutes of wall time for the same lost result.
-    if os.path.realpath(board_file) in _ORACLE_TIMED_OUT:
+    if _fill_cost_key(board_file) in _ORACLE_TIMED_OUT:
         print("  KiCad-oracle recheck: kicad-cli DRC previously timed out on "
               "this board, skipping")
         return {'available': False, 'rounds': 0, 'links_routed': 0,

--- a/py_router/krt_deadline.py
+++ b/py_router/krt_deadline.py
@@ -1,0 +1,465 @@
+"""Wall-clock deadlines and a guaranteed JSON_SUMMARY for long-running stages.
+
+Run 9 lost two stages to the same shape: `place_reconstruct --stages legalize`
+and `route_disconnected_planes` each ran to an external `timeout(1)`, wrote no
+output file, printed no `JSON_SUMMARY`, and exited with **the shell's** 124
+rather than any code the tool chose. From the log they were indistinguishable
+from a hang, and because both stage their output and promote it only at the end,
+a kill left nothing at the output path either.
+
+The family is wider than those two -- `EXACT_FILL_TIMEOUT` (300 s) and
+`ORACLE_DRC_TIMEOUT` (240 s) both degrade to a fallback with no failure signal,
+and `converge record` can fail before it execs at all. What they share:
+
+    a long silent phase after a complete-looking report, an exit code that
+    belongs to the shell rather than the tool, and staged output that leaves
+    nothing behind on a kill.
+
+This module fixes the part that is fixable from inside the process: a stage that
+knows its own budget stops ITSELF, keeps the work it has done, says so in the
+summary, and exits with a code it chose.
+
+Usage -- `arm()` once, then a cooperative check in the hot loop::
+
+    import krt_deadline
+    dl = krt_deadline.arm(args.deadline, tool='place_reconstruct',
+                          on_partial=lambda: report)     # None == no budget
+    ...
+    for violator in violators:
+        if dl and dl.check('legalize'):
+            break
+    ...
+    finally:
+        krt_deadline.emit(report, deadline=dl)
+
+`emit()` is the single print site and fires at most once per process, so calling
+it from the success path AND a `finally` AND the atexit hook is safe.
+
+WHY THIS IS NOT PART OF `cli_banner`
+------------------------------------
+1. `cli_banner.install()` returns early when `KRT_NO_BANNER` is set
+   (`cli_banner.py:59`), and `board_score.run_tool` sets `KRT_NO_BANNER='1'` for
+   every checker it shells (`board_score.py:108-119`). A summary emitter
+   suppressed the same way would go dark exactly where `board_score` reads.
+   Nothing here consults `KRT_NO_BANNER`.
+2. The tools that NEED a deadline are largely the ones that deliberately do NOT
+   carry the banner (`route_disconnected_planes.py`, `route.py`,
+   `place_route_loop.py`). Folding the deadline into `cli_banner` would make
+   adopting it mean adopting `CMD:`/`EXIT=` on their stdout -- a separate and
+   riskier decision this repo takes seriously (`converge.py:692`: "converge's
+   stdout is a JSON API").
+
+`atexit` runs LIFO, so a hook registered by `arm()` AFTER `cli_banner.install()`
+fires BEFORE the banner's `EXIT=` hook. That gives `JSON_SUMMARY:` then `EXIT=`,
+which is the order every consumer wants. **That ordering is load-bearing.**
+
+WHAT THIS CANNOT DO
+-------------------
+Measured on Windows, so nobody expects more than this delivers::
+
+    external `timeout 1`, tool has NO deadline   -> shell rc 124,
+                                                    0 JSON_SUMMARY lines,
+                                                    0 EXIT lines
+    external `timeout 5`, tool deadline 0.4s     -> rc 7, status "deadline",
+                                                    partial result intact,
+                                                    EXIT=7
+
+The first row is run 9's actual case and it stays **unfixable from inside the
+process**: a native win32 process cannot receive a POSIX SIGTERM, and under Git
+Bash the kill resolves to `TerminateProcess`, which is uncatchable -- no handler,
+no `atexit`, no flush. Anyone designing around a SIGTERM handler here is
+designing for a platform that did not produce the bug.
+
+So: **setting a budget BELOW whatever the harness allows is the whole
+mechanism.** The signal handlers below only help for a polite SIGINT/SIGTERM
+(interactive Ctrl+C, POSIX CI). The remaining defence for the uncatchable case is
+line buffering (already done, `cli_banner.py:69-74`), the `DEADLINE:` breadcrumb
+this module prints at arm time, and a progress heartbeat -- which is why
+`stdout_progress` is here and not cosmetic.
+
+DELIBERATELY NOT DONE
+---------------------
+* **A watchdog thread that prints and calls `os._exit`.** It fires even when the
+  main thread is inside a C call, which is seductive -- and it emits state the
+  main thread is mid-mutation of, skips `atexit` (losing `EXIT=`, the exact
+  defect being fixed), and can interleave a partial line into stdout. Both hot
+  loops here are pure Python and reach a cooperative check.
+* **A `DeadlineExceeded` exception.** `route_disconnected_planes.py` is full of
+  `except Exception` swallowers -- `:2474` sits directly on the hot path -- so an
+  exception-based deadline would be caught and converted into a printed note,
+  which is precisely the silent failure being removed. Cooperative flag checks
+  and `return None` only.
+* **A generous default budget.** A wall clock default would make the same board
+  produce a different output on a slower machine, which this repo cares about
+  specifically (`tests/test_457_determinism.py`, `redo_commands.sh` replays). The
+  default is None; the budget belongs to the harness that already owns a clock.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from typing import Any, Callable, Dict, Optional
+
+#: Exit code a stage returns when its OWN budget stopped it.
+#:
+#: Not 124 -- that is the shell's, and erasing the tool/shell distinction is the
+#: confusion being removed. Not 4 -- in these tools 4 asserts a MEASURED defect
+#: class (`route_disconnected_planes.py:3616-3623` advises "reconnect them, or
+#: re-run without --rip-blocker-nets", which presumes a completed run), and a
+#: run that never finished has measured nothing. Not 5 -- already spoken for
+#: repo-wide: `converge.py:446` STUCK and `check_complete.py` UNSOUND. 7 is
+#: unused anywhere, which is what a harness needs.
+DEADLINE_EXIT = 7
+
+_emitted = False
+_summary_fn: Optional[Callable[[], Dict[str, Any]]] = None
+_installed = False
+_signalled = False
+_current: Optional['Deadline'] = None
+
+
+def current() -> Optional['Deadline']:
+    """The budget armed for this process, if any.
+
+    A deliberate global, for the one case threading cannot reach: work buried
+    under a shared engine that no caller in the chain can pass a parameter to.
+    The motivating case is `plane_fragility.register_plane_fragility`, invoked
+    from `route.py:batch_route` -- so EVERY batch_route on a board KiCad cannot
+    fill pays the full 300s EXACT_FILL_TIMEOUT, and the plane repair calls
+    batch_route many times. That is the root cause of both non-terminations
+    measured in run 9, and no signature between the CLI and that call site
+    carries a budget.
+
+    Use it only where a parameter genuinely cannot reach; everywhere else pass
+    the Deadline explicitly.
+    """
+    return _current
+
+
+class Deadline:
+    """A wall-clock budget. Never construct with 0 meaning "no budget" -- use
+    `arm(None)`; `--deadline 0` is a legitimate "stop immediately", which the
+    tests rely on.
+
+    `expired()` is a subtraction and a comparison -- cheap enough for a loop that
+    runs once per violator or once per pad. Do NOT call it per candidate pose;
+    the granularity that matters is "can the partial be described coherently",
+    not "how soon do we notice".
+    """
+
+    __slots__ = ('seconds', 'started', 'tool', 'stopped_in')
+
+    def __init__(self, seconds: Optional[float], tool: str = ''):
+        self.seconds = None if seconds is None else float(seconds)
+        self.started = time.monotonic()
+        self.tool = tool
+        self.stopped_in: Optional[str] = None
+
+    def expired(self, reserve: float = 0.0) -> bool:
+        """True once the budget (minus `reserve`) is spent, or on a signal.
+
+        `reserve` carves a band off the end so a caller can stop its main work
+        early and still have clock left for a mandatory tail step. See
+        `cancel_check`.
+        """
+        if _signalled:
+            return True
+        if self.seconds is None:
+            return False
+        return (time.monotonic() - self.started) >= max(0.0,
+                                                        self.seconds - reserve)
+
+    def check(self, label: str, reserve: float = 0.0) -> bool:
+        """`expired()`, recording WHICH phase owned the clock when it went.
+
+        The label lands in the summary as `stopped_in`, which is the difference
+        between "it timed out" and "it timed out in the legalize sweep with 88
+        violators left".
+        """
+        if self.expired(reserve):
+            if self.stopped_in is None:
+                self.stopped_in = label
+            return True
+        return False
+
+    def cancel_check(self, label: str = '', reserve: float = 0.0):
+        """A zero-arg closure for engines that already take a `cancel_check`.
+
+        `route_disconnected_planes` (`:762`) and `route.py` (`:370`) both accept
+        one and honour it at every loop head -- so a deadline there is this
+        closure, not new machinery.
+        """
+        def _cancel() -> bool:
+            return self.check(label, reserve) if label else self.expired(reserve)
+        return _cancel
+
+    def remaining(self) -> Optional[float]:
+        if self.seconds is None:
+            return None
+        return max(0.0, self.seconds - (time.monotonic() - self.started))
+
+    def elapsed(self) -> float:
+        return time.monotonic() - self.started
+
+    def __repr__(self) -> str:  # pragma: no cover - diagnostics only
+        cap = 'none' if self.seconds is None else f'{self.seconds:g}s'
+        return f'<Deadline {self.tool} cap={cap} elapsed={self.elapsed():.1f}s>'
+
+
+def arm(seconds: Optional[float], *, tool: str,
+        on_partial: Optional[Callable[[], Dict[str, Any]]] = None
+        ) -> Optional[Deadline]:
+    """Start a budget, announce it, and arrange a partial flush if interrupted.
+
+    Precedence: the `seconds` argument, else `$KRT_DEADLINE_S` (so a harness can
+    set one budget for a whole chain with one export), else None.
+
+    Returns None when there is no budget, so callers can write `if dl and
+    dl.check(...)` and pay nothing when the feature is off.
+
+    The `DEADLINE:` line it prints is deliberate: a log WITHOUT it is proof no
+    budget was set, which is the standing diagnosis for the next 46-minute run.
+    """
+    if seconds is None:
+        env = os.environ.get('KRT_DEADLINE_S')
+        if env:
+            try:
+                seconds = float(env)
+            except ValueError:
+                print(f"krt_deadline: ignoring unparseable KRT_DEADLINE_S="
+                      f"{env!r}", file=sys.stderr)
+    global _current
+    dl = None if seconds is None else Deadline(seconds, tool=tool)
+    _current = dl
+    if dl is not None:
+        print(f"DEADLINE: {dl.seconds:g}s ({tool})", flush=True)
+    # Install the flush hook even with NO budget. The atexit hook is what makes
+    # "a JSON_SUMMARY on every path" true -- it covers early returns, argparse
+    # errors and unhandled exceptions, which is why the callers need no
+    # try/finally around a main() with a dozen return statements. Without this,
+    # the guarantee would only exist for runs that happened to set a budget.
+    if on_partial is not None:
+        _install(on_partial, dl)
+    return dl
+
+
+def emit(report: Optional[Dict[str, Any]], *, complete: bool = True,
+         status: str = 'ok', deadline: Optional[Deadline] = None) -> bool:
+    """The ONE `JSON_SUMMARY:` print site. Fires at most once per process.
+
+    Returns True if this call did the printing. A payload that will not
+    serialise is reported rather than swallowed -- a summary that vanished is the
+    defect this module exists to remove, so it must not reappear as an exception.
+    """
+    global _emitted
+    if _emitted or report is None:
+        return False
+    _emitted = True
+    doc = dict(report)
+    doc.setdefault('complete', complete)
+    doc.setdefault('status', status)
+    if deadline is not None:
+        doc.setdefault('deadline_s', deadline.seconds)
+        doc.setdefault('elapsed_s', round(deadline.elapsed(), 1))
+        if deadline.stopped_in:
+            doc.setdefault('stopped_in', deadline.stopped_in)
+    try:
+        print('JSON_SUMMARY: ' + json.dumps(doc, sort_keys=True, default=str),
+              flush=True)
+    except Exception as exc:                                   # noqa: BLE001
+        try:
+            print('JSON_SUMMARY: ' + json.dumps(
+                {'complete': False, 'status': 'error',
+                 'error': f'summary unserialisable: {exc}'}), flush=True)
+        except Exception:                                      # pragma: no cover
+            pass
+    return True
+
+
+def seal() -> bool:
+    """Declare the JSON_SUMMARY already published, WITHOUT printing one.
+
+    For a tool whose engine prints its own summary. `route.py` and
+    `route_diff.py` are the cases: `batch_route` builds a large summary and
+    `print`s it directly, and it does so once per pass (the reconciliation
+    self-invoke prints a second), so routing them through `emit()` -- which
+    fires at most once -- would swallow every summary after the first.
+
+    Without this the atexit flush would see `_emitted` still False on a
+    perfectly successful run and publish the contentless partial report armed
+    at `--deadline` time, printing a SECOND, contradicting
+    `{"complete": false, "status": "incomplete"}` line after the real one. That
+    is a measured defect, not a hypothetical: it shipped in
+    `route_disconnected_planes` (run 11, v6_r7) and any consumer keying on the
+    LAST JSON_SUMMARY read a good run as a failed one.
+
+    Returns True if this call did the sealing.
+    """
+    global _emitted
+    if _emitted:
+        return False
+    _emitted = True
+    return True
+
+
+def stamp(report: Dict[str, Any]) -> Dict[str, Any]:
+    """Stamp THIS PROCESS's spent budget onto a summary someone else prints.
+
+    The companion to `seal()`, and the reason neither is a new engine kwarg:
+    `batch_route`'s summary is the only one `route.py` emits, and
+    `place_route_loop` already refuses a `complete: false` tally
+    (`place_route_loop.py:162`) while `route_summary.merge_summaries` already
+    makes incompleteness sticky across passes. The one missing piece was the
+    stamp itself, and it is read through `current()` rather than threaded
+    through the signature -- so the GUI, which never arms a budget, is inert
+    here and no parity gate is involved.
+
+    A no-op unless a budget was armed AND actually cut the work short, so a
+    summary from a run that finished inside its budget is byte-identical to
+    before.
+
+    "Cut short" is `stopped_in or expired()`, not `expired()` alone. A caller
+    using a RESERVE band (`cancel_check(label, reserve=...)`, which
+    route_planes and route_disconnected_planes both need so the bounded tail
+    still has clock) trips its loops at `deadline - reserve` -- and if that
+    tail then finishes before the wall clock runs out, the run is past its
+    cancel and NOT past its deadline. Testing `expired()` alone would report
+    that partial board as complete, which is precisely the confusion this
+    module exists to remove. `stopped_in` is set by `Deadline.check` at the
+    moment the cancel fires, so it is the durable record.
+    """
+    dl = _current
+    if dl is None or not (dl.stopped_in or dl.expired()):
+        return report
+    report['complete'] = False
+    report['status'] = 'deadline'
+    report['deadline_s'] = dl.seconds
+    report['elapsed_s'] = round(dl.elapsed(), 1)
+    report['stopped_in'] = dl.stopped_in
+    return report
+
+
+def mark(report: Dict[str, Any], dl: Deadline, **partial: Any
+         ) -> Dict[str, Any]:
+    """Stamp `report` as a partial result, in the shape consumers rely on.
+
+    `complete` is the machine gate -- read it as `.get('complete', True)` so
+    pre-change logs degrade correctly. `status` is the branching discriminator:
+    a cancel is not a deadline is not a crash, and encoding the reason only as a
+    bool loses that.
+
+    `status` is `"deadline"`, not `"timeout"` -- `timeout` already means
+    something else in these summaries (`max_iterations`, A* budgets).
+    """
+    report['complete'] = False
+    report['status'] = 'deadline'
+    report['deadline_s'] = dl.seconds
+    report['elapsed_s'] = round(dl.elapsed(), 1)
+    report['stopped_in'] = dl.stopped_in
+    if partial:
+        report.setdefault('partial', {}).update(partial)
+    return report
+
+
+def stdout_progress(min_interval: float = 15.0,
+                    deadline: Optional[Deadline] = None):
+    """A throttled `(current, total, label)` callback for CLI progress.
+
+    `route_disconnected_planes` already invokes `progress_callback` at ~9 sites;
+    it is None on the CLI path only because it was built for the GUI. Passing
+    this lights all of them up with no new print statements.
+
+    Throttling matters: one of those sites fires per pad and would otherwise
+    flood a 96-pad board's log. `PROGRESS:` is a distinct prefix that cannot
+    match `route_summary.SUMMARY_RE`.
+    """
+    state = {'last': 0.0}
+
+    def _progress(current=0, total=0, label='') -> None:
+        now = time.monotonic()
+        if now - state['last'] < min_interval:
+            return
+        state['last'] = now
+        frac = f"{current}/{total}  " if total else ''
+        clock = ''
+        if deadline is not None and deadline.seconds is not None:
+            clock = f"  [t={deadline.elapsed():.0f}s/{deadline.seconds:g}s]"
+        try:
+            print(f"PROGRESS: {frac}{label}{clock}", flush=True)
+        except Exception:                                      # noqa: BLE001
+            pass
+    return _progress
+
+
+def _install(on_partial: Callable[[], Dict[str, Any]],
+             dl: Optional[Deadline]) -> None:
+    """atexit + signal wiring. Every registration is defensive: a missing signal
+    must not stop the tool from running."""
+    global _installed, _summary_fn
+    _summary_fn = on_partial
+    if _installed:
+        return
+    _installed = True
+
+    import atexit
+
+    @atexit.register
+    def _flush() -> None:                                      # pragma: no cover
+        if _emitted or _summary_fn is None:
+            return
+        try:
+            rep = _summary_fn()
+        except Exception as exc:                               # noqa: BLE001
+            emit({'error': f'partial summary unavailable: {exc}'},
+                 complete=False, status='error')
+            return
+        # Name the reason accurately: a run that died on an early return is
+        # `incomplete`, not `deadline`. Conflating them would put the wrong
+        # diagnosis in the one artefact that survives.
+        if _signalled:
+            status = 'cancelled'
+        elif dl is not None and dl.expired():
+            status = 'deadline'
+            mark(rep, dl)
+        else:
+            status = 'incomplete'
+        emit(rep, complete=False, status=status, deadline=dl)
+
+    try:
+        import signal
+
+        def _on_signal(signum, _frame):                        # noqa: ANN001
+            # Set a flag ONLY. Printing from a handler can interleave into a
+            # half-written stdout line and corrupt the very JSON_SUMMARY a
+            # scraper reads; the atexit hook does the I/O instead. A second
+            # identical signal restores the default so Ctrl+C twice always
+            # kills.
+            global _signalled
+            if _signalled:
+                signal.signal(signum, signal.SIG_DFL)
+                return
+            _signalled = True
+            sys.exit(130 if signum == getattr(signal, 'SIGINT', None)
+                     else DEADLINE_EXIT)
+
+        for _name in ('SIGTERM', 'SIGINT', 'SIGBREAK'):
+            _sig = getattr(signal, _name, None)
+            if _sig is None:
+                continue
+            try:
+                signal.signal(_sig, _on_signal)
+            except (ValueError, OSError, RuntimeError):
+                pass          # not the main thread, or platform refuses it
+    except Exception:                                          # noqa: BLE001
+        pass
+
+
+def reset_for_test() -> None:
+    """Test hook: forget that a summary was emitted."""
+    global _emitted, _installed, _summary_fn, _signalled
+    _emitted = False
+    _installed = False
+    _summary_fn = None
+    _signalled = False

--- a/py_router/list_nets.py
+++ b/py_router/list_nets.py
@@ -268,6 +268,47 @@ def board_constraint(pcb_path, key, design_rules=None):
         return None
 
 
+def board_floor_declaration(pcb_path, design_rules=None):
+    """What this board DECLARES about its own DRC floors -- and whether that is
+    nothing at all.
+
+    Returns ``{'classes': int, 'constraints': int, 'source': str|None,
+    'declares_nothing': bool}``. ``declares_nothing`` is True when the board
+    carries NO net class and NO board constraint from any source -- no sibling
+    ``.kicad_pro``, and no KiCad 6/7 ``(net_class ...)`` block in the board
+    file either.
+
+    Why the graders need this rather than just a value (run-12 Tier 1.3): every
+    floor accessor here answers ``None`` on such a board, and each grader then
+    quietly substitutes its own constant (``routing_defaults.CLEARANCE`` 0.25,
+    check_drc's 0.2). Measured on tigard, which ships no project: a whole
+    placement baseline was graded against a fallback with nothing in the
+    transcript recording that the number was a fallback rather than the board's
+    own. That is the "grade at a floor the board was not routed to" failure
+    CLAUDE.md warns about, reached from the other direction -- and unlike a
+    board that declares 0.25, there is no value to compare against to notice it.
+
+    Report-only. Nothing here changes a floor or an exit code; it exists so a
+    grader can NAME its fallback.
+
+    A board whose rules could not be READ answers ``declares_nothing: False``
+    plus an ``error``, never True: "I could not look" is not "there is nothing
+    there", and a disclosure that fires on a read failure is the kind of line
+    readers learn to skip.
+    """
+    try:
+        dr = design_rules if design_rules is not None else read_design_rules(pcb_path)
+    except Exception as exc:                                   # noqa: BLE001
+        return {'classes': 0, 'constraints': 0, 'source': None,
+                'declares_nothing': False,
+                'error': f'{type(exc).__name__}: {exc}'}
+    classes = dr.get('classes') or {}
+    constraints = dr.get('constraints') or {}
+    return {'classes': len(classes), 'constraints': len(constraints),
+            'source': dr.get('source'),
+            'declares_nothing': not classes and not constraints}
+
+
 def board_floor_knobs(pcb_path, clearance=None, board_edge_clearance=None,
                       clearance_default=0.25, edge_default=0.55,
                       design_rules=None):
@@ -284,10 +325,17 @@ def board_floor_knobs(pcb_path, clearance=None, board_edge_clearance=None,
     records each value's source (``'cli'`` | ``'board netclass'`` |
     ``'board constraint'`` | ``'fixed default'``) for JSON disclosure.
     """
+    # A non-positive declared value is UNSET, not a floor of zero -- KiCad
+    # writes 0 into these fields for "not configured", and reading it as a real
+    # floor collapses every consumer to no clearance at all. `board_floor`
+    # below encodes the same rule; this helper predates it and did NOT, so a
+    # project declaring `min_copper_edge_clearance: 0.0` silently gave
+    # render_placement a 0.0 edge floor (every edge-halo and oob term
+    # vanishing) where it had previously used 0.55.
     knobs = {}
     if clearance is None:
         v = board_default_netclass_clearance(pcb_path, design_rules)
-        clearance, src = ((v, 'board netclass') if v is not None
+        clearance, src = ((v, 'board netclass') if v is not None and v > 0
                           else (clearance_default, 'fixed default'))
     else:
         src = 'cli'
@@ -295,13 +343,167 @@ def board_floor_knobs(pcb_path, clearance=None, board_edge_clearance=None,
     if board_edge_clearance is None:
         v = board_constraint(pcb_path, 'min_copper_edge_clearance',
                              design_rules)
-        board_edge_clearance, src = ((v, 'board constraint') if v is not None
+        board_edge_clearance, src = ((v, 'board constraint')
+                                     if v is not None and v > 0
                                      else (edge_default, 'fixed default'))
     else:
         src = 'cli'
     knobs['board_edge_clearance'] = {'value': board_edge_clearance,
                                      'source': src}
     return clearance, board_edge_clearance, knobs
+
+
+# Where each floor legitimately comes from: (Default-netclass key, board
+# constraint key). None means "this floor is not expressed there".
+#
+# `clearance` deliberately has NO constraint fallback. `min_clearance` is an
+# unreliable edit-floor -- it is 0.0 on the measured board and stale-large on
+# others (see effective_floors' note at :86) -- so falling back to it would
+# resolve a board declaring a 0.2 netclass to 0.0 and relax every consumer to
+# nothing. The netclass is the honest source for clearance; the constraints are
+# the honest source for the hole/edge floors, which no netclass expresses.
+_FLOOR_SOURCES = {
+    'clearance':            ('clearance',    None),
+    'track_width':          ('track_width',  'min_track_width'),
+    'via_diameter':         ('via_diameter', 'min_via_diameter'),
+    'via_drill':            ('via_drill',    None),
+    'board_edge_clearance': (None,           'min_copper_edge_clearance'),
+    'hole_clearance':       (None,           'min_hole_clearance'),
+    'hole_to_hole':         (None,           'min_hole_to_hole'),
+}
+
+
+def board_floor(pcb_path, name, explicit=None, fallback=None,
+                design_rules=None):
+    """ONE floor, resolved BOARD-FIRST. Returns ``(value, source)``.
+
+    Precedence, the same one `board_floor_knobs` uses and with the same source
+    vocabulary (``'cli'`` | ``'board netclass'`` | ``'board constraint'`` |
+    ``'fixed default'``): an explicit value wins, then the board's own Default
+    netclass, then its board constraint, then the caller's fallback.
+
+    This exists because instruments kept substituting their own constant for a
+    value the board declares, each in its own way, and each wrong in a
+    different direction. Measured here: `check_channels` at its old 0.25/0.3
+    constants reported 334 escape lanes where the board's own 0.2/0.254 floor
+    gives 399 -- 65 lanes understated. (The originating report measured 304 vs
+    378 on the same board at 0.2/0.2; same direction and scale, different track
+    width.) It also invented a deficit on a face that had none -- a phantom
+    that would have steered a placement search. `obstacle_map` priced NPTH at
+    a hardcoded max(clearance, 0.20) while the board declared
+    ``min_hole_clearance`` 0.25, and a route came within 0.2263 mm of an NPTH:
+    a real 0.0237 mm violation, routing-introduced.
+
+    A non-positive constraint is treated as UNSET rather than as a floor of
+    zero. KiCad writes 0 for "not configured" in these fields, and reading it
+    as a genuine 0 relaxes the consumer to nothing -- the same trap that keeps
+    `min_clearance` out of the table above.
+
+    IT IS NOT RAISE-ONLY, and nothing here pretends otherwise. Once a declared
+    value is positive it is returned as-is, with NO max() against `fallback`,
+    so a board can resolve a floor DOWNWARDS. That is the point for a tool
+    that GRADES EXISTING COPPER: `check_assembly` must measure at the board's
+    own clearance even when it sits below the packaged default, or it
+    manufactures phantom violations on copper placed correctly (CLAUDE.md,
+    "Grade DRC at the clearance the board was actually routed to").
+
+    THE DISTINCTION IS GRADE-vs-PREDICT, not tool-by-tool. `check_channels`
+    was listed here as another such consumer and that was wrong: it does not
+    grade copper, it PREDICTS routability, so a declared lane pitch finer than
+    the fab can etch makes it promise capacity nobody can build. Measured on
+    tigard --refs U3 (fab floors 0.09 / 0.0762): a declared 0.05/0.05 took its
+    deficit faces from 3 to 1 and U3's supply from 29 to 120, hiding two real
+    deficits. It now wraps at the fab floor (check_channels.py, `_fab`). A
+    predictive consumer needs the wrap; a grading one must not have it.
+
+    A consumer for which downward is a FAB question must therefore wrap this
+    in its own max(), exactly as `resolve_hole_clearance`'s consumers do
+    (obstacle_map.py:1580, plane_obstacle_builder.py:1208) -- that helper is
+    called "raise-only" only because of those wraps, never on its own.
+    Measured: a project declaring ``min_hole_to_hole: 0.10`` resolves here to
+    ``(0.1, 'board constraint')``, and the qfn underpad escape spaced this
+    run's drills at 0.10 -- below the 0.20 JLC fab floor -- until it grew the
+    wrap (qfn_fanout/__init__.py, ``_h2h_fab``). The routing CLIs get the same
+    protection from `enforce_fab_floors`, which runs on args right after
+    `resolve_cli_floor`; an engine-internal read like the qfn one does not,
+    because that pins a value it never reads.
+    """
+    if name not in _FLOOR_SOURCES:
+        raise KeyError(f"unknown floor {name!r}; "
+                       f"known: {', '.join(sorted(_FLOOR_SOURCES))}")
+    if explicit is not None:
+        return float(explicit), 'cli'
+    cls_key, con_key = _FLOOR_SOURCES[name]
+    # The guard wraps the ACCESSORS too, not just read_design_rules: a caller
+    # may hand in its own `design_rules`, and a malformed one raises inside
+    # board_default_netclass_param / board_constraint rather than here.
+    try:
+        dr = (design_rules if design_rules is not None
+              else read_design_rules(pcb_path))
+        if cls_key:
+            v = board_default_netclass_param(pcb_path, cls_key, dr)
+            if v is not None and v > 0:
+                return float(v), 'board netclass'
+        if con_key:
+            v = board_constraint(pcb_path, con_key, dr)
+            if v is not None and v > 0:
+                return float(v), 'board constraint'
+    except Exception:                                          # noqa: BLE001
+        # "I could not look" is NOT "there is nothing there" -- the same
+        # distinction board_floor_declaration exists to preserve. The VALUE is
+        # the fallback either way, but the source must not claim the board was
+        # read and found silent, or a corrupt .kicad_pro reads in a table
+        # exactly like a board that genuinely declares nothing.
+        return _num(fallback), 'unreadable project'
+    return _num(fallback), 'fixed default'
+
+
+def _num(v):
+    """Fallbacks are returned in the same type the board paths return."""
+    return None if v is None else float(v)
+
+
+def resolve_cli_floor(pcb_path, name, explicit, fallback, flag):
+    """One routing-CLI geometry floor, resolved board-first and ANNOUNCED with
+    its real source. Returns the value.
+
+    THE SPLIT THIS CLOSES. `board_floor` / `board_floor_knobs` /
+    `resolve_hole_clearance` -- and the GUI's own
+    `_effective_plane_edge_clearance` -- all treat a declared 0 as UNSET,
+    because that is what KiCad writes into these fields for "not configured".
+    The four routing mains did not: each carried its own copy of
+    ``board_constraint(...) if ... is not None else <default>``, an
+    ``is not None`` test with no positivity guard, eight sites in all
+    (route.py 3725/3731, route_diff.py 1947/1953, route_planes.py 4940/4946,
+    route_disconnected_planes.py 3410/3416).
+
+    So on a board declaring ``min_copper_edge_clearance: 0.0`` the two halves
+    of the place/route loop read one declared floor two ways: the placement
+    half (render_placement, check_floorplan, converge -- all via
+    board_floor_knobs) resolved 0.55 ``[fixed default]``, while the routing
+    half took a REAL floor of 0.0 and printed *"using the board
+    min_copper_edge_clearance 0.0mm"* -- claiming the board had declared what
+    it had in fact left unset. The plane engines were worse than misleading:
+    a declared 0.0 dropped their zone inset from PLANE_EDGE_CLEARANCE 0.5 to
+    0.0, while the GUI's plane tab held 0.5 because it already had the guard.
+
+    The FALLBACKS legitimately differ between callers and are NOT unified
+    here: the signal mains fall back to BOARD_EDGE_CLEARANCE 0.0, which is a
+    deliberate sentinel meaning "no edge rule declared, use the copper-copper
+    clearance instead" (route.py:896, obstacle_map.py:797), while the plane
+    mains fall back to PLANE_EDGE_CLEARANCE 0.5 and the placement model to
+    0.55. What must agree -- and now does -- is whether the board declared
+    anything at all, and what the tool SAYS about where its number came from.
+
+    The source tag is printed in the same ``[board constraint]`` /
+    ``[fixed default]`` / ``[unreadable project]`` vocabulary the placement
+    instruments use, because "fixed default" means the board declared nothing,
+    not that it agreed.
+    """
+    value, src = board_floor(pcb_path, name, explicit, fallback)
+    if src != 'cli':
+        print(f"{flag} not given; using {value}mm [{src}].")
+    return value
 
 
 def net_clearance_map_by_id(pcb_path, nets, design_rules=None):

--- a/py_router/net_rescue.py
+++ b/py_router/net_rescue.py
@@ -37,6 +37,7 @@ Design constraints (#331/#371 review):
 import env_knobs
 import math
 import os
+import collections as _c
 import time
 from dataclasses import replace
 from typing import Dict, List, Optional, Tuple
@@ -464,7 +465,7 @@ def rescue_failed_nets(state, single_ended_nets, net_clearances=None,
     'unchanged', 'pads_reconnected', 'widths', 'time'}) or None when there was
     nothing to rescue (or KICAD_NET_RESCUE=0).
 
-    'widths' is {net: {'requested_mm', 'delivered_mm'}} for every net the
+    'widths' is {net: {'requested_mm', 'delivered_mm', and when the rescue emitted width-bearing copper, rescue_* keys describing THIS RESCUE's segments only}} for every net the
     rescue touched -- the width provenance that used to vanish: the ladder
     re-routes at the floor and reports the net `recovered` with
     `failed_single` empty, so a 0.8mm request silently shipping as 0.15mm
@@ -653,9 +654,56 @@ def rescue_failed_nets(state, single_ended_nets, net_clearances=None,
         # was asked and what was delivered so the JSON tells the truth without
         # anyone re-measuring the board.
         _req_w = config.get_net_track_width(net_id, config.layers[0])
-        _del_w = min(used_widths) if used_widths else _req_w
-        summary['widths'][net_name] = {'requested_mm': round(_req_w, 4),
-                                       'delivered_mm': round(_del_w, 4)}
+        # A HISTOGRAM, not a scalar. `delivered_mm` was min(used_widths) under
+        # a name that reads as "what it got", and this net's copper is
+        # routinely MIXED: one rail came out 59 segments at 0.0889, 3 at
+        # 0.1998 and 67 at 0.2, reported as 0.0889. Both readings mislead in
+        # opposite directions -- the minimum makes a mostly-wide rail look
+        # uniformly thin, and a mean would hide the thin run entirely.
+        #
+        # Ampacity is set by the NARROWEST series segment, so `min` stays and
+        # keeps its meaning; `by_width` is what tells a reader whether that
+        # minimum is the whole net or a short neck. Taken from the emitted
+        # segments rather than the requested widths, because a request is not
+        # a result -- impedance and neckdown both diverge from it.
+        _hist = _c.Counter(round(float(getattr(sg, 'width', 0.0)), 4)
+                           for sg in merged['new_segments']
+                           if getattr(sg, 'width', None))
+        _del_w = min(_hist) if _hist else (min(used_widths) if used_widths
+                                           else _req_w)
+        _w = {
+            'requested_mm': round(_req_w, 4),
+            'delivered_mm': round(_del_w, 4),          # the NARROWEST, as before
+        }
+        if _hist:
+            # SCOPED, and named so. This histogram covers the copper THIS
+            # RESCUE emitted -- not the net's whole copper. That distinction
+            # is the difference between informing a reader and misleading one:
+            # the finding that motivated it measured +1V2 across the finished
+            # board as 59 segments @ 0.0889, 3 @ 0.1998 and 67 @ 0.2, but only
+            # the 0.0889 run came from the rescue. An unscoped name here would
+            # show a single 0.0889 bin and look like CORROBORATION of exactly
+            # the "uniformly thin" reading the finding was warning against.
+            #
+            # Emitted widths, not the requested rung: a request is not a
+            # result, and neckdown and the oracle's width clamp both diverge
+            # from it (measured: a 0.2 rung emitting a 0.1 and a 0.4 segment).
+            _w.update({
+                'rescue_min_mm': round(_del_w, 4),
+                'rescue_max_mm': round(max(_hist), 4),
+                'rescue_segments_emitted': sum(_hist.values()),
+                'rescue_by_width': {f'{w:g}': n for w, n in sorted(_hist.items())},
+                'scope': ('THIS RESCUE ONLY -- not the net. Counts are as '
+                          'EMITTED, before cycle-prune drops redundant loop '
+                          'segments, so the board can carry fewer. For the '
+                          "net's whole width profile, measure the board."),
+            })
+        else:
+            # No emitted segment carried a width (a vias-only edge). Say that,
+            # rather than asserting a min and max over an empty histogram.
+            _w['scope'] = ('this rescue emitted no width-bearing segment; '
+                           'delivered_mm falls back to the requested rung')
+        summary['widths'][net_name] = _w
         _thin = (f", {YELLOW}width {_del_w:g} vs requested {_req_w:g}{RESET}"
                  if _del_w < _req_w - 1e-9 else "")
         print(f"    {GREEN}{'fully reconnected' if fully else 'improved'}{RESET} "

--- a/py_router/obstacle_map.py
+++ b/py_router/obstacle_map.py
@@ -1439,6 +1439,61 @@ def block_track_cells_near_override_pad_holes(obstacles: GridObstacleMap,
         obstacles.add_blocked_cells_batch(np.hstack([arr, layer_col]))
 
 
+_HOLE_CLR_CACHE = {}          # board path -> declared min_hole_clearance (mm)
+_HOLE_CLR_ANNOUNCED = set()
+
+
+def resolve_hole_clearance(pcb_data: PCBData, config) -> float:
+    """The copper-to-HOLE floor this board declares, in mm (0.0 = none).
+
+    Resolved ENGINE-SIDE off ``PCBData.source_path`` (the #498 mechanism built
+    for exactly this), so both fronts inherit it with no wiring. An explicit
+    ``config.hole_clearance`` wins and stops the read.
+
+    WHO ACTUALLY INHERITS IT, precisely -- everything routed through
+    ``add_drill_hole_obstacles`` (signal, diff pairs, BGA/QFN fanout, via
+    ``build_base_obstacle_map``), plus ``plane_obstacle_builder`` which builds
+    its own map and therefore needed the call adding separately. It is NOT a
+    universal fix: the flat ``NPTH_TO_TRACK_CLEARANCE`` still stands in
+    ``plane_region_connector`` (taps / region joins / reconnects),
+    ``pcb_modification`` and ``placement/fanout_clearance``. Those are the same
+    defect and are not yet closed; do not read this helper's existence as
+    covering them.
+
+    Why it exists: this keep-out was priced at a hardcoded
+    ``max(clearance, NPTH_TO_TRACK_CLEARANCE)`` -- a flat 0.20 fab floor -- and
+    never read the board, while `check_drc` DOES read `min_hole_clearance`
+    (:2390). So on a board declaring 0.25 the router would route into a band its
+    own checker then flagged. Measured: a route came within 0.2263 mm of BUS1's
+    NPTH against a declared 0.25, a real 0.0237 mm violation, routing-introduced
+    and confirmed independently by kicad-cli. It was the single DRC failure on
+    that board.
+
+    Cached per board path: the obstacle map is rebuilt per net, and this would
+    otherwise re-read the project file thousands of times in one run.
+    """
+    explicit = getattr(config, 'hole_clearance', 0.0) or 0.0
+    if explicit > 0:
+        return float(explicit)
+    path = getattr(pcb_data, 'source_path', "") or ""
+    if not path:
+        return 0.0
+    if path not in _HOLE_CLR_CACHE:
+        try:
+            from list_nets import board_constraint
+            v = board_constraint(path, 'min_hole_clearance')
+            _HOLE_CLR_CACHE[path] = float(v) if v and v > 0 else 0.0
+        except Exception:                                       # noqa: BLE001
+            _HOLE_CLR_CACHE[path] = 0.0
+    v = _HOLE_CLR_CACHE[path]
+    if v > defaults.NPTH_TO_TRACK_CLEARANCE and path not in _HOLE_CLR_ANNOUNCED:
+        _HOLE_CLR_ANNOUNCED.add(path)
+        print(f"Copper-to-hole clearance {v:g}mm (from the board's own "
+              f"min_hole_clearance, above the {defaults.NPTH_TO_TRACK_CLEARANCE}"
+              f"mm fab floor)")
+    return v
+
+
 def add_drill_hole_obstacles(obstacles: GridObstacleMap, pcb_data: PCBData,
                               config: GridRouteConfig, nets_to_route_set: set,
                               extra_clearance: float = 0.0):
@@ -1461,6 +1516,9 @@ def add_drill_hole_obstacles(obstacles: GridObstacleMap, pcb_data: PCBData,
         config: Routing configuration
         nets_to_route_set: Set of net IDs being routed (excluded from blocking)
     """
+    # The board's own copper-to-hole floor, once per call (cached per board).
+    _hole_clr = resolve_hole_clearance(pcb_data, config)
+
     drill_holes = []   # every drill -> via (hole-to-hole) keep-out
     npth_holes = []    # no-copper holes only -> track keep-out
     npth_slot_holes = []  # milled SLOT subset: board-edge clearance applies (#448)
@@ -1517,7 +1575,10 @@ def add_drill_hole_obstacles(obstacles: GridObstacleMap, pcb_data: PCBData,
         # extra_clearance covers geometry offset from the routed centerline
         # (diff-pair P/N tracks ride +-(gap+width)/2 off it), matching how every
         # other obstacle in that base map is inflated (issue #268).
-        npth_clr = max(config.clearance, defaults.NPTH_TO_TRACK_CLEARANCE) + extra_clearance
+        # `_hole_clr` is the BOARD's own min_hole_clearance -- raise-only, so a
+        # board declaring nothing is byte-identical (see resolve_hole_clearance).
+        npth_clr = (max(config.clearance, defaults.NPTH_TO_TRACK_CLEARANCE,
+                        _hole_clr) + extra_clearance)
         block_track_cells_near_drills(obstacles, npth_holes, config.track_width,
                                       npth_clr, config.grid_step,
                                       list(range(len(config.layers))))
@@ -1532,7 +1593,8 @@ def add_drill_hole_obstacles(obstacles: GridObstacleMap, pcb_data: PCBData,
         edge_eff = (config.board_edge_clearance if config.board_edge_clearance > 0
                     else config.clearance)
         slot_clr = edge_eff + extra_clearance
-        if slot_clr > max(config.clearance, defaults.NPTH_TO_TRACK_CLEARANCE) + extra_clearance:
+        if slot_clr > max(config.clearance, defaults.NPTH_TO_TRACK_CLEARANCE,
+                          _hole_clr) + extra_clearance:
             block_track_cells_near_drills(obstacles, npth_slot_holes,
                                           config.track_width, slot_clr,
                                           config.grid_step,

--- a/py_router/plane_fragility.py
+++ b/py_router/plane_fragility.py
@@ -371,8 +371,39 @@ def _compute_cells_and_states(pcb_data: PCBData, config: GridRouteConfig,
     src = getattr(pcb_data, 'source_path', None)
     if not polys and src and os.path.isfile(src):
         try:
-            from kicad_exact_fill import refill_islands
-            fills = refill_islands(src)
+            from kicad_exact_fill import refill_islands, EXACT_FILL_TIMEOUT
+            # BOUND THE FILL BY THE RUN'S REMAINING BUDGET. This call is reached
+            # from route.py:batch_route, so it runs on EVERY batch_route -- and
+            # on a board KiCad's ZONE_FILLER cannot fill (measured: a 217-part
+            # 4-layer board) each one pays the full 300s EXACT_FILL_TIMEOUT.
+            # The plane repair issues many batch_route calls, which is the root
+            # cause of both non-terminations measured in run 9. No signature
+            # between the CLI and here carries a budget, hence the global.
+            _t = EXACT_FILL_TIMEOUT
+            try:
+                import krt_deadline
+                _dl = krt_deadline.current()
+            except Exception:                                  # noqa: BLE001
+                _dl = None
+            if _dl is not None:
+                _left = _dl.remaining()
+                if _dl.expired() or (_left is not None and _left < 5.0):
+                    raise TimeoutError(
+                        'run budget spent; not starting a KiCad refill')
+                # Never let one fill eat the whole remaining budget.
+                _t = max(5, int(min(_t, (_left or _t) * 0.5)))
+            fills = refill_islands(src, timeout=_t, verbose=True)
+            if fills is None:
+                # refill_islands documents a None return, and this was the ONE
+                # call site in the repo that dereferenced it anyway. The
+                # resulting `'NoneType' object has no attribute 'items'` was
+                # printed as if it were the diagnosis, while the real reason --
+                # a 300s timeout, or pcbnew missing -- was computed inside
+                # refill_islands and discarded. verbose=True above makes it say
+                # so; this branch stops the AttributeError masquerading as one.
+                raise RuntimeError(
+                    f'KiCad refill returned nothing within {_t}s '
+                    f'(fill timed out, or pcbnew unavailable)')
             polys = [(name_to_id.get(_net, -1), layer, poly)
                      for (_net, layer), pp in fills.items() for poly in pp]
             if polys:

--- a/py_router/plane_obstacle_builder.py
+++ b/py_router/plane_obstacle_builder.py
@@ -1199,7 +1199,14 @@ def build_routing_obstacle_map(
             if pad.drill > 0 and not _pad_has_copper(pad):
                 from kicad_parser import pad_drill_circles
                 npth_holes.extend(pad_drill_circles(pad))
-    npth_clr = max(config.clearance, defaults.NPTH_TO_TRACK_CLEARANCE)
+    # Board-first, exactly as the signal obstacle map does (#D11). The plane
+    # engines build their own map and never call add_drill_hole_obstacles, so
+    # fixing that one alone left plane taps / region joins / reconnects still
+    # pricing NPTH at the flat 0.20 fab floor on a board declaring more.
+    # Raise-only: a board declaring nothing is byte-identical.
+    from obstacle_map import resolve_hole_clearance
+    npth_clr = max(config.clearance, defaults.NPTH_TO_TRACK_CLEARANCE,
+                   resolve_hole_clearance(pcb_data, config))
     block_track_cells_near_drills(obstacles, npth_holes, route_track_w,
                                   npth_clr, config.grid_step, [layer_idx])
     # Holes of pads carrying a clearance OVERRIDE (pad.local_clearance): KiCad's

--- a/py_router/plane_region_connector.py
+++ b/py_router/plane_region_connector.py
@@ -439,6 +439,14 @@ def _regions_from_fill_models(net_id, pcb_data, coord, plane_layer,
     # Coarse-grid cells per plane-layer fill component: one vectorized
     # gather of each model's label array at the analysis-grid cell centres.
     cells_by_comp: Dict[tuple, Set[Tuple[int, int]]] = {}
+    # First island key seen at each coarse cell, and the (few) collisions. A
+    # cell claimed by two keys is a point where TWO models both predict fill --
+    # see the co-located union below. Only the FIRST key per cell is kept
+    # (union is transitive, so pairing every later key with it yields the same
+    # partition): storing a set per cell instead costs ~60MB of Python sets on
+    # a board-wide pour, for the same answer.
+    first_key_by_cell: Dict[Tuple[int, int], tuple] = {}
+    colocated_pairs: List[Tuple[tuple, tuple]] = []
     gxs = np.arange(min_gx, max_gx + 1)
     gys = np.arange(min_gy, max_gy + 1)
     if gxs.size == 0 or gys.size == 0:
@@ -456,8 +464,12 @@ def _regions_from_fill_models(net_id, pcb_data, coord, plane_layer,
         lab[np.ix_(sel_x, sel_y)] = m.labels[ix[sel_x][:, None], iy[sel_y]]
         nz = np.nonzero(lab)
         for ii, jj in zip(nz[0].tolist(), nz[1].tolist()):
-            cells_by_comp.setdefault((id(m), int(lab[ii, jj])), set()).add(
-                (int(gxs[ii]), int(gys[jj])))
+            _key = (id(m), int(lab[ii, jj]))
+            _cell = (int(gxs[ii]), int(gys[jj]))
+            cells_by_comp.setdefault(_key, set()).add(_cell)
+            _prev = first_key_by_cell.setdefault(_cell, _key)
+            if _prev != _key:
+                colocated_pairs.append((_prev, _key))
 
     if not cells_by_comp:
         return None
@@ -473,6 +485,26 @@ def _regions_from_fill_models(net_id, pcb_data, coord, plane_layer,
     # every island any single chain touches.
     uf = UnionFind()
     _pt_uf = UnionFind()
+
+    # CO-LOCATED islands are ONE piece of copper. A ZoneFillModel is built per
+    # ZONE and labels that zone's fill in isolation, but KiCad merges the fills
+    # of same-net zones on the same layer into a single pour -- so a patch pour
+    # dropped inside a board-wide pour yields two island keys over the very same
+    # copper, and nothing below ever unions them (the segment-chain and barrel
+    # passes both credit one key per layer). The join loop then sees a split
+    # that does not exist: it picks the pair at distance ~0, the A* answers with
+    # a zero-length or 0.1mm "strap", and the pair is burned as UNVERIFIED.
+    # Measured on neo6502 GND (27 sub-mm priority-16962 patch pours inside the
+    # board-wide F.Cu pour): 42 model regions where the fill-aware grader counts
+    # 13 components. Two models predicting fill at the SAME point means copper
+    # exists there in both fills, which on one net and one layer is one
+    # conductor -- so union them. Coarse sampling can only MISS an overlap
+    # (the over-split direction this module already prefers), never invent one.
+    _colo_uf = UnionFind()          # co-located unions ONLY, for the log line
+    for _ka, _kb in colocated_pairs:
+        uf.union(_ka, _kb)
+        _colo_uf.union(_ka, _kb)
+    n_islands = len({_colo_uf.find(_ck) for _ck in cells_by_comp})
 
     def _pk(layer, x, y):
         return (layer, round(x, 3), round(y, 3))
@@ -607,8 +639,13 @@ def _regions_from_fill_models(net_id, pcb_data, coord, plane_layer,
         return ([region_anchors[0] if region_anchors else []],
                 [region_cells[0] if region_cells else set()],
                 [region_islands[0] if region_islands else set()])
+    # Report the island count AFTER the co-located union -- the raw
+    # len(cells_by_comp) counts one key per (zone model, label), so overlapping
+    # same-net zones inflate it next to a region count that already merged them.
+    _colo = len(cells_by_comp) - n_islands
+    _colo_note = f", {_colo} co-located key(s) fused" if _colo > 0 else ""
     print(f"  Region discovery from fill model: {len(region_anchors)} "
-          f"region(s) ({len(cells_by_comp)} fill island(s), "
+          f"region(s) ({n_islands} fill island(s){_colo_note}, "
           f"{len(singletons)} off-fill anchor(s), "
           f"{sum(1 for a in region_anchors if not a)} orphan island(s))")
     return region_anchors, region_cells, region_islands
@@ -1425,13 +1462,27 @@ def find_region_connection_points(
     return mst_edges
 
 
+# How many open-space candidates are material-tested before giving up (a model
+# query per probe is not free). The probe ORDER is what makes this bound safe:
+# candidates are ranked most-open first and then NEAREST THE REGION'S CENTROID.
+# Ranking by raw grid order instead is a trap -- the net's own copper is
+# excluded from the obstacle map, so clearance saturates across most of the
+# +-search_radius box and the tie-break decides everything; grid order then
+# probes only the far-left columns (2.5% of the box at a 0.1mm routing grid,
+# every one of them ~5mm off the region), so the search reports "no valid open
+# point" while hundreds sit next to the region, and the fallback silently stops
+# rescuing exactly the hemmed-in shards it exists for.
+_OPEN_SPACE_VALIDITY_PROBES = 256
+
+
 def find_open_space_point(
     anchors: List[Tuple[float, float]],
     base_obstacles: GridObstacleMap,
     plane_layer_idx: int,
     coord: GridCoord,
     search_radius: float = 5.0,
-    bounds: Optional[Tuple[float, float, float, float]] = None
+    bounds: Optional[Tuple[float, float, float, float]] = None,
+    validity=None
 ) -> Optional[Tuple[float, float]]:
     """
     Find the most open space near a region's anchors - a point with maximum clearance from obstacles.
@@ -1442,6 +1493,20 @@ def find_open_space_point(
         plane_layer_idx: Layer index to check for obstacles
         coord: Grid coordinate converter
         search_radius: How far from anchors to search (mm)
+        validity: Optional callable(x, y) -> bool the returned point must
+            satisfy. WITHOUT it this function answers "where is the emptiest
+            cell within search_radius of the region's centroid", which is a
+            question about the OBSTACLE MAP and says nothing about the
+            region's own copper -- the emptiest cell is typically a bare gap
+            metres of grid away from any fill. Fed to the connection A* as an
+            extra seed (see _try_route_between_regions) that point is the
+            cheapest cell in the neighbourhood, so the search lands on it and
+            the strap's end connects nothing (neo6502 GND: 15 joins routed
+            open-space-to-open-space, one of them a 0.1mm strap between two
+            regions' open points, all correctly rejected by the #479 endpoint
+            verification -- which then burned each pair's whole try
+            allowance). Callers that use the result as a seed MUST pass the
+            same material predicate the join is verified against.
 
     Returns:
         (x, y) of the most open point, or None if no good point found
@@ -1458,6 +1523,7 @@ def find_open_space_point(
 
     best_clearance = 0
     best_point = None
+    candidates: List[Tuple[int, int, int, int]] = []
 
     # Search in a grid around the centroid
     for dx in range(-search_radius_grid, search_radius_grid + 1):
@@ -1484,13 +1550,28 @@ def find_open_space_point(
             # Calculate clearance - distance to nearest blocked cell
             clearance = _calculate_clearance(gx, gy, base_obstacles, plane_layer_idx, max_check=10)
 
-            if clearance > best_clearance:
-                best_clearance = clearance
-                best_point = coord.to_float(gx, gy)
+            if validity is None:
+                if clearance > best_clearance:
+                    best_clearance = clearance
+                    best_point = coord.to_float(gx, gy)
+            elif clearance >= 2:
+                # Deterministic order: most open first, then nearest the
+                # region, then grid order (see _OPEN_SPACE_VALIDITY_PROBES).
+                candidates.append((-clearance,
+                                   (gx - center_gx) ** 2 + (gy - center_gy) ** 2,
+                                   gx, gy))
 
-    # Only return if we found a point with meaningful clearance (at least 2 grid steps)
-    if best_clearance >= 2:
-        return best_point
+    if validity is None:
+        # Only return if we found a point with meaningful clearance (at least 2 grid steps)
+        if best_clearance >= 2:
+            return best_point
+        return None
+
+    candidates.sort()
+    for _c, _d2, gx, gy in candidates[:_OPEN_SPACE_VALIDITY_PROBES]:
+        fx, fy = coord.to_float(gx, gy)
+        if validity(fx, fy):
+            return (fx, fy)
     return None
 
 
@@ -1541,6 +1622,8 @@ def _try_route_between_regions(
     bounds: Optional[Tuple[float, float, float, float]] = None,
     pcb_data=None,
     net_id: Optional[int] = None,
+    open_ok_i=None,
+    open_ok_j=None,
 ) -> Tuple[Optional[Tuple[List[Tuple[float, float, str]], List[Tuple[float, float]]]], float, Optional[Tuple[float, float]]]:
     """
     Try to route between two regions, attempting multiple track widths.
@@ -1560,6 +1643,12 @@ def _try_route_between_regions(
         max_iterations: Max routing iterations
         coord: Grid coordinate converter
         verbose: Print debug info
+        open_ok_i / open_ok_j: material predicates callable(x, y) -> bool for
+            the two regions. The open-space fallback below seeds the A* with a
+            point that is merely EMPTY, not on either region -- these gate it
+            so a fallback seed can only be a point the join's endpoint
+            verification would accept as that region's material. Omitted
+            (None) restores the pre-fix behavior of seeding any open cell.
 
     Returns:
         Tuple of (route_result, track_width_used, open_space_via_if_used)
@@ -1639,8 +1728,10 @@ def _try_route_between_regions(
     if result is None:
         # Can't route even at min width - try open-space fallback
         _t0 = _time.time()
-        open_i = find_open_space_point(anchors_i, base_obstacles, plane_layer_idx, coord, bounds=bounds)
-        open_j = find_open_space_point(anchors_j, base_obstacles, plane_layer_idx, coord, bounds=bounds)
+        open_i = find_open_space_point(anchors_i, base_obstacles, plane_layer_idx, coord,
+                                       bounds=bounds, validity=open_ok_i)
+        open_j = find_open_space_point(anchors_j, base_obstacles, plane_layer_idx, coord,
+                                       bounds=bounds, validity=open_ok_j)
         _dt_open = _time.time() - _t0
         _attempt_details.append(f"open-search {_dt_open:.2f}s")
         _total_route_time += _dt_open
@@ -1919,6 +2010,53 @@ def route_disconnected_regions(
             comp_np[root] = arr
         return arr
 
+    # ENDPOINT / SEED MATERIAL TEST (#479 duodyne): a point counts as a
+    # component's own copper when it sits on one of the component's fill
+    # ISLANDS per the model, within one analysis cell of its fill cells, or
+    # within 0.75mm of an anchor / earlier strap vertex. Used for BOTH the
+    # post-route endpoint verification below AND (since neo6502 GND) the
+    # open-space fallback seed, so the search can no longer be handed a seed
+    # the gate will reject.
+    #
+    # `strict` drops the 0.75mm branch. That branch is a post-hoc ACCEPTANCE
+    # tolerance -- fine for judging a strap the router already committed to,
+    # wrong as the objective a seed SEARCH optimizes against, because the
+    # search would then hunt for a point that barely passes it and hand back a
+    # strap ending up to 0.75mm of bare board short of the pour (#479's own
+    # failure mode at a smaller radius). It also admits earlier straps'
+    # vertices, which comp_pts stores LAYER-STRIPPED, so a B.Cu vertex would
+    # vouch for an F.Cu point. Seed gating and the coincident-merge guard use
+    # strict; the endpoint verification keeps the tolerance it shipped with.
+    def _on_material(_root, _pt, strict=False):
+        # Exact test first: does the landing point sit on one of the
+        # component's fill ISLANDS per the model? (The coarse cell sets
+        # below starve thin real islands -- quickfeather U6.29's joins
+        # died UNVERIFIED on legitimate landings.)
+        _keys = comp_islands.get(_root)
+        if _keys:
+            for _ms in _join_models.values():
+                for _m in _ms:
+                    _c = _m.query_component(_pt[0], _pt[1],
+                                            size=min_track_width)
+                    if _c is not None and _c > 0 \
+                            and (id(_m), _c) in _keys:
+                        return True
+        _gx, _gy = cell_coord.to_grid(_pt[0], _pt[1])
+        _cs = comp_cells.get(_root, ())
+        for _dx in (-1, 0, 1):
+            for _dy in (-1, 0, 1):
+                if (_gx + _dx, _gy + _dy) in _cs:
+                    return True
+        if strict:
+            return False
+        _arr = _comp_arr(_root)
+        if _arr.size:
+            _d2 = ((_arr[:, 0] - _pt[0]) ** 2
+                   + (_arr[:, 1] - _pt[1]) ** 2)
+            if float(_d2.min()) <= 0.75 * 0.75:
+                return True
+        return False
+
     pair_cache: Dict[frozenset, Optional[tuple]] = {}
     # A failed pair is retried ONLY when a later merge meaningfully shrinks
     # its gap (< 0.75x the distance it failed at), and at most 3 times total:
@@ -1940,6 +2078,50 @@ def route_disconnected_regions(
         # Failed marks survive under a REKEYED identity: the merged blob keeps
         # root min(i,j), so a failed pair {blob, X} keeps its key and its
         # distance gate; only distances are recomputed.
+
+    def _merge_components(root_i, root_j, route_points):
+        """Merge two components. The union's points PLUS the strap's vertices
+        become landing space for every later join (trace reuse): a later join
+        Ts into the strap instead of paralleling it. `route_points` may be
+        empty (a coincident pair merged without emitting copper)."""
+        _keep = min(root_i, root_j)
+        _gone = root_j if _keep == root_i else root_i
+        comp_members[_keep] = comp_members[root_i] + comp_members[root_j]
+        comp_pts[_keep] = (comp_pts[root_i] + comp_pts[root_j]
+                           + [(p[0], p[1]) for p in route_points])
+        comp_cells[_keep] = (comp_cells.get(root_i, set())
+                             | comp_cells.get(root_j, set())
+                             | {cell_coord.to_grid(p[0], p[1])
+                                for p in route_points})
+        comp_success[_keep] = (comp_success.get(root_i, 0)
+                               + comp_success.get(root_j, 0) + 1)
+        comp_strikes[_keep] = (comp_strikes.get(root_i, 0)
+                               + comp_strikes.get(root_j, 0))
+        comp_islands[_keep] = (comp_islands.get(root_i, set())
+                               | comp_islands.get(root_j, set()))
+        if _gone != _keep:
+            comp_members.pop(_gone, None)
+            comp_pts.pop(_gone, None)
+            comp_cells.pop(_gone, None)
+            comp_strikes.pop(_gone, None)
+            comp_success.pop(_gone, None)
+            comp_islands.pop(_gone, None)
+            comp_roots.discard(_gone)
+        comp_np.pop(root_i, None)
+        comp_np.pop(root_j, None)
+        # Rekey failure gates onto the merged root (tightest distance, most
+        # tries survive), then drop stale cached distances to the blob --
+        # they get recomputed, and the retry gate decides eligibility.
+        for _k in [k for k in failed_at if k & {root_i, root_j}]:
+            _other = next(iter(_k - {root_i, root_j}), None)
+            _e = failed_at.pop(_k)
+            if _other is None or _other == _keep:
+                continue
+            _nk = frozenset((_keep, _other))
+            _p = failed_at.get(_nk)
+            failed_at[_nk] = _e if _p is None else (min(_e[0], _p[0]),
+                                                   max(_e[1], _p[1]))
+        _invalidate_pairs(root_i, root_j)
 
     def _pair_closest(ra, rb):
         Pa, Pb = _comp_arr(ra), _comp_arr(rb)
@@ -2044,6 +2226,7 @@ def route_disconnected_regions(
     vias: List[Dict] = []
     routes_added = 0
     routes_failed = 0
+    routes_coincident = 0   # pairs that turned out to be the same copper
     previous_routes: List[List[Tuple[float, float]]] = []
 
     # Create a single reusable router for all MST edges
@@ -2066,7 +2249,7 @@ def route_disconnected_regions(
         if _pick is None:
             break   # every remaining component pair already failed to route
         (dist, point_i, point_j), (root_i, root_j) = _pick
-        edge_idx = routes_added + routes_failed
+        edge_idx = routes_added + routes_failed + routes_coincident
         # The merged component point sets play the per-region anchor role:
         # member anchors + fill subsamples + earlier straps' vertices.
         anchors_i = comp_pts[root_i]
@@ -2129,6 +2312,14 @@ def route_disconnected_regions(
                                          if p not in anchors_j], point_j, 512)
         reduced = (len(seed_i) < len(full_i)) or (len(seed_j) < len(full_j))
 
+        # Material predicates for THIS pair's open-space fallback seeds: the
+        # fallback point must be copper the endpoint verification will credit
+        # to that component, or the strap it produces connects nothing.
+        _open_ok_i = (lambda _x, _y, _r=root_i:
+                      _on_material(_r, (_x, _y), strict=True))
+        _open_ok_j = (lambda _x, _y, _r=root_j:
+                      _on_material(_r, (_x, _y), strict=True))
+
         # Progress indicator
         seed_note = f" (seed {len(seed_i)}x{len(seed_j)})" if reduced else ""
         print(f"    [{edge_idx+1}/{planned}] Component {root_i} ({len(comp_members[root_i])} region(s), {len(anchors_i)} pts) <-> Component {root_j} ({len(comp_members[root_j])} region(s), {len(anchors_j)} pts){seed_note}...", end=" ", flush=True)
@@ -2153,6 +2344,8 @@ def route_disconnected_regions(
                 router=plane_router,
                 pcb_data=pcb_data,
                 net_id=net_id,
+                open_ok_i=_open_ok_i,
+                open_ok_j=_open_ok_j,
             )
 
         # Try routing with multiple track widths using helper function
@@ -2192,6 +2385,8 @@ def route_disconnected_regions(
                 router=plane_router,
                 pcb_data=pcb_data,
                 net_id=net_id,
+                open_ok_i=_open_ok_i,
+                open_ok_j=_open_ok_j,
             )
 
         # Last resort (#217 castor +3.3VA): the corridor between two regions
@@ -2236,6 +2431,8 @@ def route_disconnected_regions(
                 router=plane_router,
                 pcb_data=pcb_data,
                 net_id=net_id,
+                open_ok_i=_open_ok_i,
+                open_ok_j=_open_ok_j,
             )
 
         if result is None:
@@ -2265,6 +2462,34 @@ def route_disconnected_regions(
             route_points,
             keep={(round(vx, 3), round(vy, 3)) for vx, vy in via_positions})
 
+        # COINCIDENT PAIR: the A* reached a target cell from a source cell in
+        # ZERO steps, so one grid cell on one layer is claimed by BOTH
+        # components' seed sets -- typically because the model split ONE piece
+        # of copper (overlapping same-net zones on a layer are labelled per
+        # zone, so a patch pour inside a board-wide pour becomes a second
+        # component over the same fill). Merge and emit NOTHING: a zero-length
+        # strap is not copper, and the old path reported it as UNVERIFIED
+        # "ends=None/None", which burned the pair's whole try allowance and
+        # left the phantom region in the tally forever (neo6502 GND).
+        #
+        # A shared seed CELL is not by itself proof of shared copper: seed
+        # lists also carry earlier straps' vertices (layer-stripped) and a
+        # gated open-space point, and two seeds within one grid step quantize
+        # together. So demand the meeting point be STRICT material for BOTH
+        # components before fusing them -- otherwise fall through to the
+        # endpoint verification, which refuses and re-queues the pair. Merging
+        # on the weaker evidence would be exactly the silent false "joined"
+        # that #479's verification exists to stop.
+        if len(route_points) < 2:
+            _mp = route_points[0] if route_points else None
+            if _mp is not None and _on_material(root_i, _mp, strict=True) \
+                    and _on_material(root_j, _mp, strict=True):
+                print(f"{GREEN}COINCIDENT{RESET} (same copper at "
+                      f"({_mp[0]:.2f},{_mp[1]:.2f}) -- merged, no join needed)")
+                routes_coincident += 1
+                _merge_components(root_i, root_j, route_points)
+                continue
+
         # ENDPOINT VERIFICATION (#479 duodyne): join success was previously
         # self-reported by the A* against its obstacle map -- the open-space
         # fallback in particular drops a via at "the most open point near the
@@ -2272,38 +2497,9 @@ def route_disconnected_regions(
         # 5 of duodyne's 23 joins shipped dangling vias/stubs while Prim
         # recorded the pair as merged (7 pad islands reached the gate
         # floating behind an all-OK report). Require each strap end to land
-        # on its component's MATERIAL: within one analysis cell of the
-        # component's fill cells, or within 0.75mm of an anchor / earlier
-        # strap vertex. An unverified join is a FAILED join: no copper is
-        # emitted and the pair re-enters the retry policy.
-        def _on_material(_root, _pt):
-            # Exact test first: does the landing point sit on one of the
-            # component's fill ISLANDS per the model? (The coarse cell sets
-            # below starve thin real islands -- quickfeather U6.29's joins
-            # died UNVERIFIED on legitimate landings.)
-            _keys = comp_islands.get(_root)
-            if _keys:
-                for _ms in _join_models.values():
-                    for _m in _ms:
-                        _c = _m.query_component(_pt[0], _pt[1],
-                                                size=min_track_width)
-                        if _c is not None and _c > 0 \
-                                and (id(_m), _c) in _keys:
-                            return True
-            _gx, _gy = cell_coord.to_grid(_pt[0], _pt[1])
-            _cs = comp_cells.get(_root, ())
-            for _dx in (-1, 0, 1):
-                for _dy in (-1, 0, 1):
-                    if (_gx + _dx, _gy + _dy) in _cs:
-                        return True
-            _arr = _comp_arr(_root)
-            if _arr.size:
-                _d2 = ((_arr[:, 0] - _pt[0]) ** 2
-                       + (_arr[:, 1] - _pt[1]) ** 2)
-                if float(_d2.min()) <= 0.75 * 0.75:
-                    return True
-            return False
-
+        # on its component's MATERIAL (see _on_material above the loop). An
+        # unverified join is a FAILED join: no copper is emitted and the pair
+        # re-enters the retry policy.
         _verified = False
         if len(route_points) >= 2:
             _e0, _e1 = route_points[0], route_points[-1]
@@ -2311,6 +2507,42 @@ def route_disconnected_regions(
                           and _on_material(root_j, _e1))
                          or (_on_material(root_i, _e1)
                              and _on_material(root_j, _e0)))
+        if not _verified and os.environ.get('KRT_JOIN_VERIFY_DEBUG'):
+            def _dbg(_root, _pt):
+                if _pt is None:
+                    return 'pt=None'
+                _keys = comp_islands.get(_root)
+                _hits = []
+                for _lay, _ms in _join_models.items():
+                    for _m in _ms:
+                        _c = _m.query_component(_pt[0], _pt[1],
+                                                size=min_track_width)
+                        if _c is not None and _c > 0:
+                            _hits.append((_lay, id(_m), _c,
+                                          (id(_m), _c) in (_keys or ())))
+                _gx, _gy = cell_coord.to_grid(_pt[0], _pt[1])
+                _cs = comp_cells.get(_root, ())
+                _cellhit = any((_gx + _dx, _gy + _dy) in _cs
+                               for _dx in (-1, 0, 1) for _dy in (-1, 0, 1))
+                _arr = _comp_arr(_root)
+                _dmin = None
+                if _arr.size:
+                    _dmin = float(np.sqrt(((_arr[:, 0] - _pt[0]) ** 2
+                                           + (_arr[:, 1] - _pt[1]) ** 2).min()))
+                return (f'root={_root} nkeys={len(_keys or ())} '
+                        f'ncells={len(_cs)} npts={_arr.shape[0]} '
+                        f'cellhit={_cellhit} dmin={_dmin} '
+                        f'modelhits={_hits[:6]}')
+            _d0, _d1 = (route_points[0], route_points[-1]) \
+                if len(route_points) >= 2 else (None, None)
+            print(f"\n      VERIFY-DEBUG pair=({root_i},{root_j}) dist={dist:.3f}"
+                  f" pi={point_i} pj={point_j} npts={len(route_points)}")
+            print(f"        e0 {_d0} vs i: {_dbg(root_i, _d0)}")
+            print(f"        e0 {_d0} vs j: {_dbg(root_j, _d0)}")
+            print(f"        e1 {_d1} vs i: {_dbg(root_i, _d1)}")
+            print(f"        e1 {_d1} vs j: {_dbg(root_j, _d1)}")
+            if len(route_points) < 6:
+                print(f"        route={route_points}")
         if not _verified:
             _e0, _e1 = (route_points[0], route_points[-1]) \
                 if len(route_points) >= 2 else (None, None)
@@ -2473,54 +2705,15 @@ def route_disconnected_regions(
                                     _near[0], _near[1])
 
         routes_added += 1
-
-        # Merge the two components. The union's points PLUS this strap's
-        # vertices become landing space for every later join (trace reuse):
-        # a later join Ts into the strap instead of paralleling it.
-        _keep = min(root_i, root_j)
-        _gone = root_j if _keep == root_i else root_i
-        comp_members[_keep] = comp_members[root_i] + comp_members[root_j]
-        comp_pts[_keep] = (comp_pts[root_i] + comp_pts[root_j]
-                           + [(p[0], p[1]) for p in route_points])
-        comp_cells[_keep] = (comp_cells.get(root_i, set())
-                             | comp_cells.get(root_j, set())
-                             | {cell_coord.to_grid(p[0], p[1])
-                                for p in route_points})
-        comp_success[_keep] = (comp_success.get(root_i, 0)
-                               + comp_success.get(root_j, 0) + 1)
-        comp_strikes[_keep] = (comp_strikes.get(root_i, 0)
-                               + comp_strikes.get(root_j, 0))
-        comp_islands[_keep] = (comp_islands.get(root_i, set())
-                               | comp_islands.get(root_j, set()))
-        if _gone != _keep:
-            comp_members.pop(_gone, None)
-            comp_pts.pop(_gone, None)
-            comp_cells.pop(_gone, None)
-            comp_strikes.pop(_gone, None)
-            comp_success.pop(_gone, None)
-            comp_islands.pop(_gone, None)
-            comp_roots.discard(_gone)
-        comp_np.pop(root_i, None)
-        comp_np.pop(root_j, None)
-        # Rekey failure gates onto the merged root (tightest distance, most
-        # tries survive), then drop stale cached distances to the blob --
-        # they get recomputed, and the retry gate decides eligibility.
-        for _k in [k for k in failed_at if k & {root_i, root_j}]:
-            _other = next(iter(_k - {root_i, root_j}), None)
-            _e = failed_at.pop(_k)
-            if _other is None or _other == _keep:
-                continue
-            _nk = frozenset((_keep, _other))
-            _p = failed_at.get(_nk)
-            failed_at[_nk] = _e if _p is None else (min(_e[0], _p[0]),
-                                                   max(_e[1], _p[1]))
-        _invalidate_pairs(root_i, root_j)
+        _merge_components(root_i, root_j, route_points)
 
     # Summary for this net
+    _coin_note = (f", {routes_coincident} coincident pair(s) merged without copper"
+                  if routes_coincident else "")
     if routes_failed > 0:
-        print(f"  {YELLOW}Result: {routes_added}/{planned} join(s) succeeded, {routes_failed} attempt(s) failed{RESET}")
-    elif routes_added > 0:
-        print(f"  {GREEN}Result: All {routes_added} route(s) succeeded{RESET}")
+        print(f"  {YELLOW}Result: {routes_added}/{planned} join(s) succeeded, {routes_failed} attempt(s) failed{_coin_note}{RESET}")
+    elif routes_added > 0 or routes_coincident:
+        print(f"  {GREEN}Result: All {routes_added} route(s) succeeded{_coin_note}{RESET}")
 
     return segments, vias, routes_added, previous_routes, connectivity_paths
 

--- a/py_router/qfn_fanout/__init__.py
+++ b/py_router/qfn_fanout/__init__.py
@@ -118,6 +118,130 @@ def _board_edge_model(pcb_data, clearance, board_edge_clearance):
     return edge_clear, rings, outer, cutouts
 
 
+def run_output_conflict(vx, vy, net_id, placed, px=None, py=None, *,
+                        via_size, via_drill, clearance, track_width,
+                        hole_to_hole, adds_via=True):
+    """Does a candidate via (and its stub) collide with THIS RUN's own output?
+
+    D10. The underpad escape's `via_clears` tested a candidate against the
+    board it was handed -- `foreign_vias` / `foreign_pads` / `foreign_tracks`
+    are a snapshot taken once, before anything is placed -- and against the via
+    CENTRES emitted so far. It never saw the STUBS the same run emitted, so it
+    approved vias sitting on copper it had just laid itself, and those escapes
+    came back DRC CONTACTS.
+
+    Measured: U2 (QFN56) reported 39 of 46 escapes under
+    `--escape-method underpad --allow-via-in-pad` and the gate rejected every
+    one as a contact -- while the geometry was fine (a 1.4 mm moat admitting a
+    0.7 mm via at all 56 pads, `pad_via == 0`, a real 0.700 mm via placeable
+    DRC-clean in U2.43, true capacity 11 of 14 lanes per side). A valid escape
+    strategy reported as impossible, and two cycles skipped fanout on it.
+
+    `placed` entries are ``(via_x, via_y, net_id, pad_x, pad_y)``; the stub
+    runs pad -> via. A through-via conflicts with copper on ANY layer, so the
+    stubs are tested exactly the way `foreign_tracks` is -- the difference is
+    only that these cannot be in that list.
+
+    Module-level and pure so it is testable directly: the caller is a closure
+    over fifteen locals, and a check this consequential should not be reachable
+    only by routing a whole board.
+
+    ``adds_via=False`` is the REUSE case (#479 audit gap 2): the position is an
+    existing board via, so this run adds no drill and no via copper -- only the
+    bridging stub. Everything about that via's spacing is a fact of the input
+    board, not something this run creates, so pricing it as a NEW via at
+    ``config.via_size`` judges two vias that already exist, at a size neither
+    has, for a spacing this run does not produce. Measured on
+    kicad_files/routed_output.kicad_pcb U2 (B.Cu, track/clearance 0.1, via
+    0.45/0.25, --escape-method underpad --allow-via-in-pad): with the via terms
+    applied, all 7 reuse candidates were rejected on the different-net floor
+    ``via_size + clearance`` = 0.55 against pre-existing 0.30 vias sitting at
+    0.400 mm -- legal (0.15+0.15+0.10) and already on the board. That cost
+    Net-(U2A-DATA_30) its escape and put a fresh drill where a reuse would have
+    served: 28 vias / 12 dropped / 30 tracks became 29 / 13 / 31.
+
+    The VIA-TO-VIA term is not merely wrong there, it is REDUNDANT. Every
+    entry in `placed` is either a via this run created -- already tested
+    against this reuse target in `via_clears`'s `foreign_vias` loop at exact
+    pairwise sizes (``via_size/2 + fs/2 + clearance``, and
+    ``(via_drill + fd)/2 + h2h`` for same net) -- or another pre-existing via,
+    whose spacing is the board's.
+
+    TERM 1 (the candidate via against a stub this run emitted) is dropped for
+    a different and weaker reason, stated here rather than overclaimed: the
+    reuse target's POSITION is not this run's doing, so a stub grazing it is
+    a defect of that stub, which is already emitted. Rejecting the reuse does
+    not remove the graze -- it only forces a fresh drill elsewhere and leaves
+    the graze in place. It is a false remedy, not a check.
+
+    That it fires at all exposes a REAL and separate gap, measured rather than
+    assumed: an emitted stub is never tested against a pre-existing via on
+    another FANNED net, because `build_base_obstacle_map(nets_to_route=...)`
+    excludes every net being escaped (obstacle_map.py:105), so
+    `check_line_clearance` cannot see it, and `via_clears` tests only the via
+    CENTRE against `foreign_vias`, never the stub. Measured on U2: 5 emitted
+    stubs sit inside a foreign pre-existing via's floor, one of them at
+    0.0000mm, and in all 5 the via's net is a fanned one. That count is
+    IDENTICAL at 715c821 and here, so it is pre-existing and untouched by this
+    change -- and it wants its own fix in the stub check, not an accidental
+    partial cover for the subset of vias that happen to be reuse targets.
+
+    So with ``adds_via=False`` only the new STUB is tested against this run's
+    own output, which is the only copper the reuse emits. A stub shorter than
+    POSITION_TOLERANCE emits no track at all (the commit loop skips it), so it
+    conflicts with nothing.
+
+    Returns True when the candidate must be REJECTED.
+    """
+    from geometry_utils import segment_to_segment_distance
+    from obstacle_map import point_to_segment_distance
+
+    via_half = via_size / 2 + clearance - 1e-6
+    track_half = track_width / 2
+    if not adds_via and (px is None
+                         or math.hypot(px - vx, py - vy) <= POSITION_TOLERANCE):
+        return False                    # reuse with no stub emits no copper
+    for entry in placed:
+        qx, qy, qn = entry[0], entry[1], entry[2]
+        qpx = entry[3] if len(entry) > 3 else None
+        qpy = entry[4] if len(entry) > 4 else None
+        # Via-to-via. Same-net floor was via_size*0.5 -- BELOW drill
+        # hole-to-hole for standard vias (#479 audit gap 2); both are via_drill.
+        # Skipped for a REUSE: no drill and no via copper is added, so there is
+        # no new pair for this run to space.
+        if adds_via:
+            floor = (via_size + clearance) if qn != net_id \
+                else max(via_size * 0.5, via_drill + hole_to_hole)
+            if math.hypot(vx - qx, vy - qy) < floor - 1e-6:
+                return True
+        if qn == net_id:
+            continue                           # own-net copper is no obstacle
+        has_stub = (qpx is not None
+                    and math.hypot(qpx - qx, qpy - qy) > POSITION_TOLERANCE)
+        # 1. the candidate VIA against the stub already emitted for that via.
+        #    Dropped for a reuse because the target's POSITION is not this
+        #    run's doing: the graze belongs to that already-emitted stub, and
+        #    refusing the reuse only buys a fresh drill while leaving it. See
+        #    run_output_conflict's docstring for the separate, measured gap
+        #    this exposes (stub vs pre-existing via on another FANNED net).
+        if adds_via and has_stub \
+                and point_to_segment_distance(vx, vy, qpx, qpy, qx, qy) \
+                < via_half + track_half:
+            return True
+        if px is None:
+            continue
+        # 2. the candidate's own STUB against that placed via, and
+        # 3. stub against stub -- the same blindness, the other way round.
+        if point_to_segment_distance(qx, qy, px, py, vx, vy) \
+                < via_half + track_half:
+            return True
+        if has_stub and segment_to_segment_distance(
+                px, py, vx, vy, qpx, qpy, qx, qy) \
+                < track_width + clearance - 1e-6:
+            return True
+    return False
+
+
 def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
                          track_width, clearance, via_size, via_drill, grid_step,
                          allow_via_in_pad=False, board_edge_clearance=0.0):
@@ -155,6 +279,7 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
     -- nothing here assumes a group shares an edge axis."""
     from obstacle_map import (build_base_obstacle_map, build_layer_map,
                               check_line_clearance, point_to_segment_distance)
+    from geometry_utils import segment_to_segment_distance
     from bga_fanout.reroute import _seg_hits_pad
     from bga_fanout.geometry import clamp_via_to_pad
     from list_nets import fab_floor_ladder, fab_floor_min, warn_fab_escalation
@@ -194,7 +319,40 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
         _own_via_pos.setdefault(v.net_id, []).append((v.x, v.y))
     from kicad_parser import pad_drill_circles as _pdc
     import routing_defaults as _rd
-    _h2h = _rd.HOLE_TO_HOLE_CLEARANCE
+    # BOARD-FIRST, same rule as every other floor: a board declaring
+    # min_hole_to_hole above the packaged default was having its drills spaced
+    # at the default instead. Discovered via source_path so the GUI inherits it.
+    #
+    # RAISE-ONLY IN THE CODE, not only in this comment. `board_floor` is
+    # board-AUTHORITATIVE, not raise-only -- it returns whatever the board
+    # declares once it is positive, with no max() against the fallback, and
+    # that is correct for the floors it mostly serves (check_channels and
+    # check_assembly must grade at the board's own clearance even when that is
+    # BELOW their default, or they manufacture phantom violations). It is a
+    # DRILL floor here, so the same freedom is a fab hazard: a project
+    # declaring `min_hole_to_hole: 0.10` resolved to (0.1, 'board constraint')
+    # and spaced this run's drills below the 0.20 JLC floor. `resolve_hole_clearance`
+    # is called raise-only for the same reason, and is raise-only only because
+    # ITS consumers wrap it in a max() (obstacle_map.py:1580,
+    # plane_obstacle_builder.py:1208) -- this is that wrap. The engine cannot
+    # lean on the CLI's enforce_fab_floors: that pins args.hole_to_hole_clearance,
+    # a value this code path never reads.
+    from list_nets import board_floor
+    _h2h_decl, _h2h_src = board_floor(
+        getattr(pcb_data, 'source_path', "") or "", 'hole_to_hole',
+        None, _rd.HOLE_TO_HOLE_CLEARANCE)
+    _h2h_fab = fab_floor_min(_copper).get('hole_to_hole', 0.0)
+    _h2h = max(_h2h_decl, _h2h_fab)
+    if _h2h_src == 'board constraint' and _h2h_decl > _rd.HOLE_TO_HOLE_CLEARANCE:
+        print(f"  Hole-to-hole {_h2h:g}mm (from the board's own "
+              f"min_hole_to_hole)")
+    elif _h2h_src == 'board constraint' and _h2h_decl < _h2h_fab:
+        # Never SILENTLY relaxed -- the whole point of the guard is that a
+        # board file cannot lower a fab floor without saying so. A user who
+        # genuinely has a finer fab declares it with --fab-tier/--fab-overrides,
+        # which is what fab_floor_min reads.
+        print(f"  Board min_hole_to_hole {_h2h_decl:g}mm is below the "
+              f"{_h2h_fab:g}mm fab hole-to-hole floor; using {_h2h:g}mm.")
     _drilled_pad_holes = [(hx, hy, hd)
                           for p in foreign_pads if p.drill and p.drill > 0
                           for (hx, hy, hd) in _pdc(p)]
@@ -212,7 +370,27 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
     from check_drc import _point_to_rings_distance as _pt_rings_dist
     from check_drc import _point_on_board as _pt_on_board
 
-    def via_clears(vx, vy, net_id, placed):
+    def via_clears(vx, vy, net_id, placed, px=None, py=None):
+        """Is a via at (vx, vy) legal, given the board AND this run's own output?
+
+        `foreign_vias` / `foreign_pads` / `foreign_tracks` above are a SNAPSHOT
+        of the INPUT board, taken once. `placed` is what this run has emitted so
+        far -- and it used to carry only via CENTRES, so the STUBS this run laid
+        from each pad to each via were invisible to every later candidate. The
+        test therefore approved vias sitting on copper it had just emitted
+        itself, and each such escape came back a DRC CONTACT.
+
+        Measured: U2 (QFN, 56 pads) reported 39 of 46 escapes under
+        `--escape-method underpad --allow-via-in-pad`, and the gate rejected
+        every one of them as a contact. The wall was NOT geometry -- U2 has a
+        1.4 mm moat that admits a 0.7 mm via at all 56 pads, `pad_via == 0` in
+        every run, and a real 0.700 mm via IS placeable DRC-clean in pad U2.43.
+        True capacity is 11 of 14 lanes per side. So a valid escape strategy
+        reported as impossible, and two cycles skipped fanout on that premise.
+
+        `px, py` are the candidate's OWN pad, so its stub can be tested too --
+        the same blindness in the other direction.
+        """
         if _edge_rings:
             if not _pt_on_board(vx, vy, _edge_outer, _edge_cutouts):
                 return False
@@ -245,14 +423,10 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
             if point_to_segment_distance(vx, vy, sx0, sy0, sx1, sy1) \
                     < via_size / 2 + sw / 2 + clearance - 1e-6:
                 return False
-        for qx, qy, qn in placed:
-            # Same-net floor was via_size*0.5 -- BELOW drill hole-to-hole for
-            # standard vias (#479 audit gap 2); both holes are via_drill here.
-            floor = (via_size + clearance) if qn != net_id \
-                else max(via_size * 0.5, via_drill + _h2h)
-            if math.hypot(vx - qx, vy - qy) < floor - 1e-6:
-                return False
-        return True
+        return not run_output_conflict(
+            vx, vy, net_id, placed, px, py,
+            via_size=via_size, via_drill=via_drill, clearance=clearance,
+            track_width=track_width, hole_to_hole=_h2h)
 
     def snap(v):
         return round(v / grid_step) * grid_step if grid_step > 0 else v
@@ -296,15 +470,41 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
                 _best = (_d, ovx, ovy)
         if _best is not None:
             _rvx, _rvy = _best[1], _best[2]
+            # `check_line_clearance` reads the INPUT-board obstacle map, so on
+            # its own this branch is blind to everything this run has emitted
+            # -- the reuse path was one of two ways a position is returned, and
+            # the only one that never consulted via_clears. The bridging stub
+            # it emits can still cross another net's stub or via laid earlier
+            # in the same run, and the position was then appended to
+            # placed_global as though it had been checked.
+            #
+            # It calls run_output_conflict directly rather than via_clears:
+            # the reused via IS on the board, so it is in `foreign_vias` at
+            # distance 0 from itself, and the full test would reject every
+            # reuse on its own same-net drill floor. Only this run's output is
+            # in question here.
+            #
+            # And `adds_via=False`, because a reuse adds NO drill and NO via
+            # copper -- only the bridging stub. Pricing the existing via as a
+            # new one at config.via_size rejected every reuse on this board:
+            # 0.30 board vias 0.400mm apart (legal at 0.15+0.15+0.10, and
+            # already there) judged against a demanded 0.55. That was measured
+            # as Net-(U2A-DATA_30) losing its escape to a fresh drill --
+            # 28/12/30 vias/dropped/tracks becoming 29/13/31 on U2.
             if (obs_layer_idx is None or
                     check_line_clearance(obstacles, px, py, _rvx, _rvy,
-                                         obs_layer_idx, cfg)):
+                                         obs_layer_idx, cfg)) \
+                    and not run_output_conflict(
+                        _rvx, _rvy, pi.pad.net_id, placed, px, py,
+                        via_size=via_size, via_drill=via_drill,
+                        clearance=clearance, track_width=track_width,
+                        hole_to_hole=_h2h, adds_via=False):
                 return (_rvx, _rvy)
         for d in candidate_offsets(pi.pad_width, mode):
             vx, vy = snap(px + ex * d), snap(py + ey * d)
             stub_ok = (obs_layer_idx is None or
                        check_line_clearance(obstacles, px, py, vx, vy, obs_layer_idx, cfg))
-            if stub_ok and via_clears(vx, vy, pi.pad.net_id, placed):
+            if stub_ok and via_clears(vx, vy, pi.pad.net_id, placed, px, py):
                 return (vx, vy)
         return None
 
@@ -316,7 +516,10 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
             pos = place_pin(pis[idx], mode_fn(idx), placed)
             results[idx] = pos
             if pos is not None:
-                placed.append((pos[0], pos[1], pis[idx].pad.net_id))
+                # Carry the PAD origin, so the stub this placement implies is
+                # visible to every later candidate in the same run (D10).
+                placed.append((pos[0], pos[1], pis[idx].pad.net_id,
+                               pis[idx].pad.global_x, pis[idx].pad.global_y))
         return results
 
     # Stagger configurations, tried in order; the most-escaped wins, ties keep
@@ -368,8 +571,10 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
                 dropped.append(pi.pad.net_name)
                 continue
             vx, vy = pos
-            placed_global.append((vx, vy, pi.pad.net_id))
             px, py = pi.pad.global_x, pi.pad.global_y
+            # Committed across SIDES: side 2's candidates must see side 1's
+            # stubs, not only its via centres (D10).
+            placed_global.append((vx, vy, pi.pad.net_id, px, py))
             # Reused an existing same-net via (#479 audit gap 2): emit only
             # the bridging stub, never a duplicate drill.
             if any(abs(vx - ox) < 1e-4 and abs(vy - oy) < 1e-4

--- a/py_router/repair_planes.py
+++ b/py_router/repair_planes.py
@@ -2203,6 +2203,20 @@ def repair_planes(
 
         def _gate_oracle_query():
             import tempfile
+            # A cancelled run does not get to spend another 300s here. Both
+            # branches below shell out -- exact_unconnected via pcbnew's
+            # ZONE_FILLER (EXACT_FILL_TIMEOUT 300s) and the kicad-cli fallback
+            # via ORACLE_DRC_TIMEOUT (240s) -- and neither honours cancel_check,
+            # because neither existed as a cancellation point. Measured: a
+            # repair that cancelled cleanly at 45s then sat in a KiCad
+            # exact_fill child until the EXTERNAL timeout killed it at 200s,
+            # which handed back exactly the race the budget just won. The gate
+            # is a verification pass, not a correctness one; skipping it leaves
+            # the partial board written and gated by everything upstream.
+            if cancel_check is not None and cancel_check():
+                print("  guaranteed-join gate: SKIPPED (cancelled; the gate "
+                      "oracle shells out and would overrun the budget)")
+                return None
             try:
                 _tmp = tempfile.NamedTemporaryFile(
                     suffix='.kicad_pcb', delete=False)
@@ -3255,6 +3269,26 @@ Examples:
     from fix_kicad_drc_settings import add_drc_fix_args
     add_drc_fix_args(parser)
 
+    parser.add_argument("--deadline", type=float, default=None,
+                        metavar="SECONDS",
+                        help="Wall-clock budget for the REPAIR LOOPS. Not a "
+                             "hard cap on total runtime: the cancel is "
+                             "cooperative, and the bounded tail (fills, write, "
+                             "cleanup) still runs, so expect to overshoot -- "
+                             "measured 109s on a 45s budget. What it "
+                             "guarantees is TERMINATION on the tool's own "
+                             "terms: without it this tool ran 40 min "
+                             "(--rip-blocker-nets) and 25 min (plain) on a "
+                             "217-part board and never wrote a board at all "
+                             "(run 9). With it: cancels at the loop heads, "
+                             "writes the partial board, exits 7, and marks the "
+                             "summary complete:false. Set it well BELOW any "
+                             "external timeout. A reserve band is held back so "
+                             "the ripped-net reconnect still runs -- without "
+                             "it, ripped nets ship stripped and the board is "
+                             "WORSE than its input. Default: no budget. "
+                             "Env: KRT_DEADLINE_S")
+
     from fab_tiers import (add_fab_tier_args, fab_tier_from_args, set_default_fab_tier,
                            enforce_fab_floors, count_copper_layers_in_file)
     add_fab_tier_args(parser)
@@ -3363,7 +3397,31 @@ Examples:
         for net, layer in zone_pairs:
             print(f"  {net} on {layer}")
 
+    # The deadline is ONE CLOSURE handed to plumbing this engine already has:
+    # `cancel_check` is a first-class parameter honoured at every loop head and
+    # forwarded into each inner batch_route, and on cancel the write branch
+    # still runs -- so a cancelled run yields a real, gated, strictly-better
+    # board. It was None on the CLI path only because this call never passed
+    # one. `progress_callback` is the same story: ~9 call sites, all dark on the
+    # CLI because it was built for the GUI.
+    #
+    # RESERVE BAND, and this one is a correctness hazard rather than a nicety:
+    # the end-of-run rip-casualty reconnect issues its OWN batch_route with the
+    # same cancel_check. If the budget were already spent, that reconnect would
+    # do nothing and every net ripped earlier would ship stripped -- a partial
+    # board WORSE than its input. So the repair loops trip early, at
+    # deadline - reserve, leaving clock for the reconnect.
+    import krt_deadline
+    _rdp_report = {'tool': 'repair_planes'}
+    _dl = krt_deadline.arm(args.deadline, tool='repair_planes',
+                           on_partial=lambda: _rdp_report)
+    _reserve = max(30.0, (args.deadline or 0) * 0.2) if _dl else 0.0
+
     _rdp_result = repair_planes(
+        cancel_check=(_dl.cancel_check('plane repair', reserve=_reserve)
+                      if _dl else None),
+        progress_callback=(krt_deadline.stdout_progress(deadline=_dl)
+                           if _dl else None),
         input_file=args.input_file,
         output_file=args.output_file,
 
@@ -3424,7 +3482,21 @@ Examples:
     # KiCad's REAL fill produces can survive every model-based pass (castor
     # +3.3VA bare island, lumenpnp U5 pocket). Ask kicad-cli for the exact
     # missing links on the processed nets and route precisely those.
-    if not args.dry_run and not args.no_kicad_recheck and args.output_file:
+    # A deadline hit skips it. The recheck shells out to kicad-cli, which
+    # carries its own 240s ORACLE_DRC_TIMEOUT and can itself refill the board
+    # (300s EXACT_FILL_TIMEOUT) -- so running it after the budget is already
+    # spent hands the race straight back to the external timeout we just won.
+    # Measured: a cancelled repair reached "Plane repair cancelled" in ~45s and
+    # then sat for minutes inside a KiCad exact_fill child. The partial board is
+    # already written and already gated; the recheck is an improvement pass, not
+    # a correctness one, and its absence is disclosed in the summary.
+    _deadline_hit = bool(_dl and _dl.expired())
+    if _deadline_hit:
+        _rdp_report['oracle_recheck'] = 'skipped: deadline'
+        print("  KiCad-oracle recheck: SKIPPED (deadline reached; the pass "
+              "shells out to kicad-cli and would overrun the budget)")
+    if (not args.dry_run and not args.no_kicad_recheck and args.output_file
+            and not _deadline_hit):
         from kicad_oracle import oracle_reconnect
         from routing_config import GridRouteConfig
         # #338: the oracle pass runs on OUTPUT_FILE, whose sibling .kicad_pro
@@ -3512,7 +3584,40 @@ Examples:
     # A10: nets this step ripped and could neither reconnect nor restore. They
     # ship OPEN, so they belong in the summary by name and in the exit code.
     _summary["ripped_still_open"] = list(LAST_RIPPED_STILL_OPEN)
-    print("JSON_SUMMARY: " + _json.dumps(_summary))
+    # A cancelled run must not exit 0. It wrote a real, gated board -- unlike
+    # place_reconstruct, this tool's cancel path writes, because a partial plane
+    # repair is strictly-better copper rather than a half-legalized placement --
+    # but it did not finish, and a caller reading exit 0 would treat a partial
+    # as complete. `complete` is the machine gate; `status` says why.
+    if _dl is not None and _dl.expired():
+        _summary["complete"] = False
+        _summary["status"] = "deadline"
+        _summary["deadline_s"] = _dl.seconds
+        _summary["elapsed_s"] = round(_dl.elapsed(), 1)
+        _summary["stopped_in"] = _dl.stopped_in
+        _rdp_report.update(_summary)
+        krt_deadline.emit(_summary, complete=False, status='deadline',
+                          deadline=_dl)
+        print(f"{RED}DEADLINE: this run stopped on its own budget after "
+              f"{_dl.elapsed():.0f}s of {_dl.seconds:g}s. The board at "
+              f"{args.output_file} is a PARTIAL repair -- real copper, fully "
+              f"gated, but the sweep did not finish. Do not read it as "
+              f"clean.{RESET}")
+        if LAST_RIPPED_STILL_OPEN:
+            print(f"{RED}  ...and {len(LAST_RIPPED_STILL_OPEN)} ripped net(s) "
+                  f"ship OPEN: {', '.join(LAST_RIPPED_STILL_OPEN)}{RESET}")
+        return krt_deadline.DEADLINE_EXIT
+    # Emit through krt_deadline, NOT a raw print. `_emitted` is set only inside
+    # krt_deadline.emit(), so a bare print left it False and the atexit flush
+    # then published the contentless partial report armed at --deadline time --
+    # every successful run printed a SECOND, contradicting
+    # `{"complete": false, "status": "incomplete"}` line after the real one
+    # (run 11, v6_r7: total_regions 7, complete true, then incomplete). Any
+    # consumer keying on the LAST JSON_SUMMARY read a good repair as a failed
+    # one. The deadline branch above already does this; this is the other half.
+    _rdp_report.update(_summary)
+    krt_deadline.emit(_summary, complete=_summary.get("complete", True),
+                      status=_summary.get("status", "ok"))
 
     if LAST_RIPPED_STILL_OPEN:
         print(f"{RED}RIP CASUALTIES SHIP OPEN ({len(LAST_RIPPED_STILL_OPEN)}): "
@@ -3537,6 +3642,14 @@ route_planes = repair_planes
 if __name__ == "__main__":
     from console_encoding import enable_utf8_console
     enable_utf8_console()  # cp1252-safe non-ASCII prints (issue #152)
+    # CMD/EXIT self-echo (run-3 B1). This file was a deliberate non-adopter
+    # while it had no way to stop itself: its long silent phases ended in an
+    # external kill, and `atexit` does not run on one, so the banner would have
+    # promised an EXIT= line that never arrived. With --deadline the tool exits
+    # on its own terms, so the line is now truthful -- and this is the script
+    # whose exit code was hardest to tell from the shell's.
+    import cli_banner
+    cli_banner.install()
     # run-8: propagate main()'s verdict -- it returns 4 when plane repair
     # leaves rip casualties unconnected, which used to be one red line and
     # exit 0.

--- a/py_router/repair_planes.py
+++ b/py_router/repair_planes.py
@@ -3268,7 +3268,7 @@ Examples:
     # keep their larger PLANE_EDGE_CLEARANCE fallback when the board declares none.
     # Resolved here, before enforce_fab_floors and every downstream use.
     from list_nets import (board_default_netclass_clearance, board_default_netclass_param,
-                           board_constraint)
+                           resolve_cli_floor)
     for _pname, _nckey, _fallback in (('track_width', 'track_width', defaults.TRACK_WIDTH),
                                       ('via_size', 'via_diameter', defaults.VIA_SIZE),
                                       ('via_drill', 'via_drill', defaults.VIA_DRILL)):
@@ -3291,20 +3291,16 @@ Examples:
               f"clearance {args.clearance}mm.")
     else:
         args.clearance = min(_dflt_clr, _ceiling) if _dflt_clr is not None else _ceiling
-    if args.hole_to_hole_clearance is None:
-        _h2h = board_constraint(args.input_file, 'min_hole_to_hole')
-        args.hole_to_hole_clearance = _h2h if _h2h is not None else defaults.HOLE_TO_HOLE_CLEARANCE
-        print(f"--hole-to-hole-clearance not given; using "
-              f"{'the board min_hole_to_hole' if _h2h is not None else 'the fallback'} "
-              f"{args.hole_to_hole_clearance}mm.")
-    if args.board_edge_clearance is None:
-        # Planes keep their larger edge keep-out (PLANE_EDGE_CLEARANCE) only when
-        # the board declares no edge rule of its own.
-        _edge = board_constraint(args.input_file, 'min_copper_edge_clearance')
-        args.board_edge_clearance = _edge if _edge is not None else defaults.PLANE_EDGE_CLEARANCE
-        print(f"--board-edge-clearance not given; using "
-              f"{'the board min_copper_edge_clearance' if _edge is not None else 'the fallback'} "
-              f"{args.board_edge_clearance}mm.")
+    # Shared resolver (list_nets.resolve_cli_floor); see route_planes.py -- a
+    # DECLARED 0.0 is "no edge rule of its own", not a rule of zero, so the
+    # plane inset stays PLANE_EDGE_CLEARANCE as the GUI's plane tab already had
+    # it.
+    args.hole_to_hole_clearance = resolve_cli_floor(
+        args.input_file, 'hole_to_hole', args.hole_to_hole_clearance,
+        defaults.HOLE_TO_HOLE_CLEARANCE, '--hole-to-hole-clearance')
+    args.board_edge_clearance = resolve_cli_floor(
+        args.input_file, 'board_edge_clearance', args.board_edge_clearance,
+        defaults.PLANE_EDGE_CLEARANCE, '--board-edge-clearance')
     set_default_fab_tier(*fab_tier_from_args(args))
     _pinned_floors = enforce_fab_floors(
         count_copper_layers_in_file(args.input_file),

--- a/py_router/route.py
+++ b/py_router/route.py
@@ -994,6 +994,22 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
                         if net.name in _scope_names}
                        | {nid for _name, nid in net_ids})
     if not net_ids:
+        # The caller named nets and NOT ONE of them exists on this board. That
+        # is an input error, not a no-op: the old soft return wrote an
+        # unchanged passthrough copy and reported rc 0, so a net list whose
+        # names all missed (run 11: a CRLF file gave every one of 88 names a
+        # trailing \r) looked exactly like "nothing left to do". Raise, so the
+        # CLI exits non-zero and the GUI surfaces a real error, instead of both
+        # of them reporting success over an untouched board.
+        if net_names:
+            from routing_exceptions import NetNotFoundError
+            raise NetNotFoundError(
+                list(net_names),
+                f"None of the {len(net_names)} requested net name(s) exist on "
+                f"this board -- nothing was routed and no copper was written. "
+                f"Check for stray whitespace (a CRLF net list gives every name "
+                f"a trailing carriage return) or a stale net list. "
+                f"First few: {', '.join(repr(n) for n in list(net_names)[:5])}")
         print("No valid nets to route!")
         if return_results:
             return 0, 0, 0.0, _empty_results_data()
@@ -3078,6 +3094,24 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
         # move successful/failed (scope-based), so they get their own key --
         # a caller that only reads the scoped tallies must still see them.
         summary['ripped_open'] = _ripped_open
+        # ...and say whether the VERDICT already counts them. The verdict is
+        # `failed_single + open_single + pad-deficit`; `ripped_open` is in none
+        # of the first two by construction (it is scope-EXCLUDED), and the
+        # deficit ships as two bare scalars with no per-net attribution, so
+        # membership in the third was untestable from the summary. One run's
+        # true open count was therefore a RANGE -- 58 to 61 -- that no
+        # published field could narrow. This names the uncounted set instead of
+        # leaving the reader to guess it.
+        _counted = set(summary.get('failed_single') or []) \
+            | set(summary.get('open_single') or [])
+        summary['ripped_open_uncounted'] = sorted(
+            n for n in _ripped_open if n not in _counted)
+        summary['ripped_open_note'] = (
+            'ripped_open nets are OUTSIDE this run\'s --nets scope, so they '
+            'move neither failed_single nor open_single. Those listed in '
+            'ripped_open_uncounted are additionally not in either scoped term: '
+            'if they are also outside the multipoint pad deficit, the run\'s '
+            'open-net verdict is understated by that many.')
     try:
         from protected_nets import PROTECTED_SKIPPED
         if PROTECTED_SKIPPED:
@@ -3218,6 +3252,36 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
                 for _n, _r in sorted(_amp.items())]
     except Exception:
         pass
+    # A budget the CLI armed must reach THIS summary -- it is the only one
+    # route.py prints, and a cancelled run still falls through to here (the
+    # cancel breaks the routing loops, it does not skip the write), so without
+    # the stamp a partial board reported `complete` by omission. Inert when no
+    # budget was armed or the budget was not spent, which is every GUI call and
+    # every run that finished in time.
+    try:
+        import krt_deadline as _kdl
+        _kdl.stamp(summary)
+    except Exception:
+        pass
+    # WHICH SUMMARY IS THIS? A run that fires the reconciliation sub-pass emits
+    # a SECOND JSON_SUMMARY, scoped to that subset, and the only thing saying so
+    # was a prose "Note:" printed after it. Anything that scrapes the last
+    # JSON_SUMMARY -- a tail, a grep, a person -- then reads the subset's tally
+    # as the run's. Measured on run 14: one A/B arm emitted two summaries and
+    # the other one, so the arms were compared at `routed_single: 1` against
+    # `121` and the wrong arm looked catastrophic.
+    #
+    # Derived from the sink rather than a new kwarg, because the sink's own
+    # contract already IS this distinction: "the first pass and, when it fires,
+    # the reconciliation sub-run's".
+    summary['scope'] = 'run' if not _SUMMARY_SINK else 'reconciliation-subset'
+    if summary['scope'] != 'run':
+        # These are recomputed over the WHOLE board even in the subset pass, so
+        # a reader merging tallies must not add them twice.
+        summary['board_scoped_keys'] = [k for k in ('stacked_copper',
+                                                    'power_trace_ampacity',
+                                                    'min_clearance_used')
+                                        if k in summary]
     print(f"JSON_SUMMARY: {json.dumps(summary)}")
     _SUMMARY_SINK.append(summary)
 
@@ -4327,8 +4391,11 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
                           f"still failed -- one more lap on the updated "
                           f"board")
             print("Note: the JSON_SUMMARY above covers only the "
-                  "reconciliation subset; the run's full tally is the "
-                  "earlier JSON_SUMMARY plus these recoveries.")
+                  "reconciliation subset (it carries scope="
+                  "\"reconciliation-subset\"); the run's full tally is the "
+                  "earlier JSON_SUMMARY, the one with scope=\"run\", plus "
+                  "these recoveries. Never scrape the LAST JSON_SUMMARY of a "
+                  "route log -- count them, or read the scope.")
             if _rok:
                 successful += _rok
                 failed = max(0, failed - _rok)
@@ -4415,6 +4482,27 @@ if __name__ == "__main__":
     # the run (issue #152).
     from console_encoding import enable_utf8_console
     enable_utf8_console()
+    # CMD/EXIT self-echo (run-3 B1). CLI-`__main__`-only by construction: the
+    # GUI imports batch_route and never runs this block.
+    #
+    # This file was a deliberate non-adopter while it had no way to stop itself
+    # -- its long silent phases ended in an external kill, and `atexit` does not
+    # run on one, so the banner would have promised an EXIT= line that never
+    # arrived. `--deadline` is what makes the promise truthful, which is why the
+    # two landed in that order. The gap it closes: the convergence-
+    # ledger protocol says to paste a tool's own CMD: line into
+    # `converge record --argv`, which was unsatisfiable for a routing lap --
+    # run 11 hand-wrote replay scripts instead.
+    #
+    # NOT under --capabilities, whose whole stdout is ONE JSON document a
+    # consumer does `json.loads()` on (see the block near parse_args, and
+    # converge.py:787 for the same rule stated for the same reason). A `CMD:`
+    # line ahead of it is a JSONDecodeError at char 0, which is a broken API
+    # rather than a noisy log. Raw argv, because the flag is answered before
+    # argparse runs -- the banner has to be decided before then too.
+    if '--capabilities' not in sys.argv[1:]:
+        import cli_banner
+        cli_banner.install()
     from redo_record import record_invocation
     record_invocation()  # stress-test redo manifest (#132); no-op unless REDO_MANIFEST set
 
@@ -4586,6 +4674,22 @@ For differential pair routing, use route_diff.py:
                              "either one alone is wrong -- the first counts every recovery as a "
                              "failure, the second narrows the whole-board pad-pair denominator to "
                              "the retried subset. Prefer this over parsing stdout.")
+    parser.add_argument("--deadline", type=float, default=None, metavar="SECONDS",
+                        help="Wall-clock budget for the ROUTING LOOPS. Not a hard "
+                             "cap on total runtime -- the cancel is cooperative and "
+                             "the bounded tail (write, cleanup, DRC writeback) still "
+                             "runs -- so expect to overshoot. What it guarantees is "
+                             "TERMINATION on THIS tool's terms: it stops between "
+                             "nets, writes the copper it has, and prints a "
+                             "JSON_SUMMARY carrying complete=false / status=deadline "
+                             "before exiting 7. Without it an external kill on "
+                             "Windows is TerminateProcess, which leaves NO summary "
+                             "and NO exit code of ours -- run 11 lost a lap that way "
+                             "and only a re-parse of the output board established "
+                             "the engine had in fact finished. ANY harness with an "
+                             "external timeout should pass this at ~0.8x its own. "
+                             "Default: no budget (a wall-clock default would break "
+                             "replay determinism). Env: KRT_DEADLINE_S")
     parser.add_argument("--neckdown-length", type=float, default=defaults.NECKDOWN_LENGTH,
                         help="Length in mm of narrow track from the target pad on neck-down tap routes; the track "
                              "returns to the power width beyond this where clearance allows (default: 2.5)")
@@ -4914,10 +5018,15 @@ For differential pair routing, use route_diff.py:
               "--list-groups to see what exists.", file=sys.stderr)
         sys.exit(2)
 
-    # Combine positional net_patterns and --nets argument
+    # Combine positional net_patterns and --nets argument.
+    # Strip surrounding whitespace, as route_diff.py already does: a net list
+    # read from a CRLF file hands every name a trailing '\r', which matches
+    # nothing and (before the guard in batch_route) reported success over an
+    # untouched board. Names are never meaningfully whitespace-padded.
     all_patterns = list(args.net_patterns) if args.net_patterns else []
     if args.nets:
         all_patterns.extend(args.nets)
+    all_patterns = [p.strip() for p in all_patterns if p.strip()]
 
     # --force-reroute rips every selected net; without an explicit scope the
     # default-'*' below would silently select the WHOLE BOARD for rip+reroute.
@@ -5012,6 +5121,22 @@ For differential pair routing, use route_diff.py:
     if not net_names:
         print("No nets matched the given patterns!")
         sys.exit(1)
+
+    # ...and the case that guard cannot see: net_names is NON-empty but every
+    # entry is a literal that matched nothing. expand_net_patterns deliberately
+    # passes an unmatched literal through (callers may name nets a board does
+    # not carry), so the list is full of names that will all fail to resolve.
+    # batch_route then found zero net_ids, wrote an unchanged passthrough copy
+    # and returned rc 0 -- indistinguishable from "nothing left to do". Run 11
+    # lost a lap to it: a CRLF net list gave all 88 names a trailing '\r'.
+    # batch_route now raises for the GUI's benefit; the CLI refuses here so the
+    # exit code is a clean 2 rather than a traceback.
+    if not resolve_net_ids(pcb_data, net_names):
+        print(f"route.py: error: none of the {len(net_names)} requested net "
+              f"name(s) exist on this board -- nothing would be routed. Check "
+              f"for stray whitespace or a stale net list. First few: "
+              f"{', '.join(repr(n) for n in net_names[:5])}", file=sys.stderr)
+        sys.exit(2)
 
     # --undo: strip the scoped nets' copper instead of routing them.
     if args.undo:
@@ -5137,12 +5262,34 @@ For differential pair routing, use route_diff.py:
             print(f"Netclass clearances for {len(_net_clearances_map)} net(s), {_mode} "
                   f"(mm: {_classes}); cross-class max(A,B) respected.")
 
+    # The deadline is ONE CLOSURE handed to plumbing this engine already has:
+    # `cancel_check` is honoured at every routing/reroute/rescue/cleanup loop
+    # head and forwards into the reconciliation self-invoke via
+    # `_reconcile_kwargs`, and on cancel the loops BREAK rather than raise -- so
+    # the write, the summary and the DRC writeback all still run and a cancelled
+    # run yields a real, gated, partial board rather than nothing. It was None
+    # on the CLI path only because this call never passed one; `progress_callback`
+    # is the same story (built for the GUI, dark on the CLI).
+    #
+    # No `try/finally` and no wrapper: `krt_deadline.arm`'s atexit hook is what
+    # makes "a JSON_SUMMARY on every path" true here, covering the early
+    # `sys.exit`s, argparse errors and unhandled exceptions that this inline
+    # __main__ block has a dozen of. `seal()` below then stops that hook from
+    # contradicting the engine's own summary on a run that finished.
+    import krt_deadline
+    _route_report = {'tool': 'route.py', 'board': args.input_file}
+    _dl = krt_deadline.arm(args.deadline, tool='route',
+                           on_partial=lambda: _route_report)
+
     # --preview: the engine already supports this -- return_results=True with
     # an empty output_file routes fully, mutates only the in-memory PCBData
     # and writes nothing. This just exposes it on the CLI (#459 follow-on).
     _preview_out = batch_route(args.input_file,
                 "" if args.preview else args.output_file, net_names,
                 return_results=args.preview,
+                cancel_check=(_dl.cancel_check('routing') if _dl else None),
+                progress_callback=(krt_deadline.stdout_progress(deadline=_dl)
+                                   if _dl else None),
                 direction_order=args.direction,
                 ordering_strategy=args.ordering,
                 disable_bga_zones=args.no_bga_zones,
@@ -5226,6 +5373,22 @@ For differential pair routing, use route_diff.py:
                 add_teardrops=args.add_teardrops,
                 collect_stats=args.stats)
 
+    # batch_route printed the authoritative JSON_SUMMARY (stamped by
+    # krt_deadline.stamp when the budget was spent). Seal so the atexit flush
+    # does not publish a second, contradicting `incomplete` line after it.
+    krt_deadline.seal()
+    # `stopped_in or expired()`: the durable record that the cancel fired, not
+    # just "the wall clock has since passed". See krt_deadline.stamp.
+    _deadline_hit = bool(_dl and (_dl.stopped_in or _dl.expired()))
+    if _deadline_hit:
+        print(f"{RED}DEADLINE: this run stopped on its own budget after "
+              f"{_dl.elapsed():.0f}s of {_dl.seconds:g}s"
+              + (f" (in {_dl.stopped_in})" if _dl.stopped_in else "")
+              + f". The board at {args.output_file or '(none)'} is a PARTIAL "
+              f"route -- real, gated copper, but nets were left unattempted. "
+              f"Do not read it as clean; the JSON_SUMMARY above carries "
+              f"complete=false.{RESET}")
+
     if args.preview:
         _ok, _fail, _t, _data = _preview_out
         _res = _data.get('results') or []
@@ -5256,7 +5419,7 @@ For differential pair routing, use route_diff.py:
         # run with failed nets also exits 0, so exiting 1 here would make the
         # read-only mode the only one that can kill a `set -e` redo_commands.sh
         # replay -- at a step that changes nothing.
-        sys.exit(0)
+        sys.exit(krt_deadline.DEADLINE_EXIT if _deadline_hit else 0)
 
     # Castellated landings (run-6 fix 1.7): pull track ends that landed inside
     # a castellated pad's edge-clearance zone back to the pad's inner reach.
@@ -5307,3 +5470,11 @@ For differential pair routing, use route_diff.py:
             persist_impedance_specs(_pro, consume_impedance_specs())
         except Exception as e:
             print(f"  (skipped protected-nets record: {e})")
+
+    # LAST, and non-zero: the post-passes above are bounded and belong to the
+    # partial board (skipping the DRC writeback would strand the output without
+    # its floor -- the #441 hazard). Exiting 0 here would let a caller read an
+    # unfinished route as a finished one; `complete: false` in the summary is the
+    # machine gate, this is the shell's.
+    if _deadline_hit:
+        sys.exit(krt_deadline.DEADLINE_EXIT)

--- a/py_router/route.py
+++ b/py_router/route.py
@@ -4791,7 +4791,7 @@ For differential pair routing, use route_diff.py:
     # constraint minimum). Resolved here, before enforce_fab_floors and every
     # downstream use. Stashed on args for drc_fix_kwargs (the writeback clamp).
     from list_nets import (board_default_netclass_clearance, board_default_netclass_param,
-                           board_constraint)
+                           resolve_cli_floor)
     # #435 companion: whether --track-width was EXPLICITLY set. If NOT, each net
     # routes at its OWN netclass track width engine-side (not the single board
     # Default-class width). --impedance derives width per layer, so it counts as
@@ -4828,18 +4828,18 @@ For differential pair routing, use route_diff.py:
     else:
         # min(Default class, ceiling) so Default is capped like every other class.
         args.clearance = min(_dflt_clr, _ceiling) if _dflt_clr is not None else _ceiling
-    if args.hole_to_hole_clearance is None:
-        _h2h = board_constraint(args.input_file, 'min_hole_to_hole')
-        args.hole_to_hole_clearance = _h2h if _h2h is not None else defaults.HOLE_TO_HOLE_CLEARANCE
-        print(f"--hole-to-hole-clearance not given; using "
-              f"{'the board min_hole_to_hole' if _h2h is not None else 'the fallback'} "
-              f"{args.hole_to_hole_clearance}mm.")
-    if args.board_edge_clearance is None:
-        _edge = board_constraint(args.input_file, 'min_copper_edge_clearance')
-        args.board_edge_clearance = _edge if _edge is not None else defaults.BOARD_EDGE_CLEARANCE
-        print(f"--board-edge-clearance not given; using "
-              f"{'the board min_copper_edge_clearance' if _edge is not None else 'the fallback'} "
-              f"{args.board_edge_clearance}mm.")
+    # Both floors go through the SHARED resolver (list_nets.resolve_cli_floor),
+    # so a declared 0 -- KiCad's "not configured" -- reads as UNSET here exactly
+    # as it does on the placement half of the loop. Read straight, these two
+    # constraints made the two halves disagree about one declared number: 0.55
+    # [fixed default] in render_placement/check_floorplan/converge against a
+    # REAL 0.0 here, announced as "the board min_copper_edge_clearance 0.0mm".
+    args.hole_to_hole_clearance = resolve_cli_floor(
+        args.input_file, 'hole_to_hole', args.hole_to_hole_clearance,
+        defaults.HOLE_TO_HOLE_CLEARANCE, '--hole-to-hole-clearance')
+    args.board_edge_clearance = resolve_cli_floor(
+        args.input_file, 'board_edge_clearance', args.board_edge_clearance,
+        defaults.BOARD_EDGE_CLEARANCE, '--board-edge-clearance')
     set_default_fab_tier(*fab_tier_from_args(args))
     _pinned_floors = enforce_fab_floors(
         count_copper_layers_in_file(args.input_file),

--- a/py_router/route_diff.py
+++ b/py_router/route_diff.py
@@ -1808,7 +1808,7 @@ Examples:
     # default to the board's own constraint minimum when omitted. Resolved before
     # enforce_fab_floors; _clamp_netclasses is stashed for drc_fix_kwargs.
     from list_nets import (board_default_netclass_clearance, board_default_netclass_param,
-                           board_constraint)
+                           resolve_cli_floor)
     # #435: whether the diff geometry was EXPLICITLY set on the CLI. If NOT, each
     # pair falls back engine-side to its OWN netclass diff_pair_gap/width (not the
     # board Default class), so a multi-class board routes every pair to its own
@@ -1871,18 +1871,14 @@ Examples:
         print(f"Diff-pair gap {args.diff_pair_gap}mm is below clearance "
               f"{args.clearance}mm; raising gap to clearance (#441).")
         args.diff_pair_gap = args.clearance
-    if args.hole_to_hole_clearance is None:
-        _h2h = board_constraint(args.input_file, 'min_hole_to_hole')
-        args.hole_to_hole_clearance = _h2h if _h2h is not None else defaults.HOLE_TO_HOLE_CLEARANCE
-        print(f"--hole-to-hole-clearance not given; using "
-              f"{'the board min_hole_to_hole' if _h2h is not None else 'the fallback'} "
-              f"{args.hole_to_hole_clearance}mm.")
-    if args.board_edge_clearance is None:
-        _edge = board_constraint(args.input_file, 'min_copper_edge_clearance')
-        args.board_edge_clearance = _edge if _edge is not None else defaults.BOARD_EDGE_CLEARANCE
-        print(f"--board-edge-clearance not given; using "
-              f"{'the board min_copper_edge_clearance' if _edge is not None else 'the fallback'} "
-              f"{args.board_edge_clearance}mm.")
+    # Shared resolver: a declared 0 is UNSET, the same rule the placement half
+    # of the loop applies (list_nets.resolve_cli_floor).
+    args.hole_to_hole_clearance = resolve_cli_floor(
+        args.input_file, 'hole_to_hole', args.hole_to_hole_clearance,
+        defaults.HOLE_TO_HOLE_CLEARANCE, '--hole-to-hole-clearance')
+    args.board_edge_clearance = resolve_cli_floor(
+        args.input_file, 'board_edge_clearance', args.board_edge_clearance,
+        defaults.BOARD_EDGE_CLEARANCE, '--board-edge-clearance')
     set_default_fab_tier(*fab_tier_from_args(args))
     _pinned_floors = enforce_fab_floors(
         count_copper_layers_in_file(args.input_file),

--- a/py_router/route_diff.py
+++ b/py_router/route_diff.py
@@ -108,6 +108,13 @@ import rust_alloc  # noqa: E402,F401  # issue #419: set MIMALLOC_PURGE_DELAY bef
 from grid_router import GridObstacleMap, GridRouter
 
 
+#: Set when the --nets patterns resolved to no differential pair at all.
+#: Read by main() to exit non-zero: the refusal used to print `Error:` and
+#: return (0, 0, 0.0), which main discarded, so the process exited 0 and a
+#: chained caller walked past an unrouted board.
+_NO_PAIRS_MATCHED = False
+
+
 def batch_route_diff_pairs(input_file: str, output_file: str, net_names: List[str],
                 layers: List[str] = None,
                 layer_costs: Optional[List[float]] = None,
@@ -514,6 +521,11 @@ def batch_route_diff_pairs(input_file: str, output_file: str, net_names: List[st
                   f"(coupled via {', '.join(_xn.bridge_refs)})")
 
     if not diff_pairs:
+        # A precise sentinel. Inferring this from a (0, 0) return conflates it
+        # with a legitimate run in which every pair DEFERRED to single-ended
+        # routing -- also 0 routed, 0 failed, and not an error at all.
+        global _NO_PAIRS_MATCHED
+        _NO_PAIRS_MATCHED = True
         print(f"Error: No differential pairs found matching the patterns!")
         print("  Differential pairs must have _P/_N, P/N, or +/- suffixes.")
         print(f"  Patterns provided: {net_names}")
@@ -1314,6 +1326,16 @@ def batch_route_diff_pairs(input_file: str, output_file: str, net_names: List[st
         else:
             failed_diff_pairs.append(pair_name)
 
+    # A pair the audit demoted to PARTIAL was already counted in `successful`
+    # by the coupled-route loop, so the headline and the JSON key still claimed
+    # it. Take it back here, after the audit has spoken and BEFORE either the
+    # printed summary or the returned tuple reads the counter -- the GUI reads
+    # `successful` raw (differential_gui.py), so fixing only the print site
+    # would leave the GUI and JSON_SUMMARY saying different things than the
+    # member audit sitting next to them.
+    if partial_diff_pairs:
+        successful = max(0, successful - len(partial_diff_pairs))
+
     # Count total vias from results
     total_vias = sum(len(r.get('new_vias', [])) for r in results)
 
@@ -1345,6 +1367,20 @@ def batch_route_diff_pairs(input_file: str, output_file: str, net_names: List[st
     if single_ended_diff_pairs:
         print(f"  Single-ended:  {len(single_ended_diff_pairs)} (electrically short - "
               f"deferred to single-ended routing)")
+        # ...and say how those members ACTUALLY came out. The headline above
+        # reads `Diff pairs: 0/2 routed` on a step where every member net got
+        # copper and connected, so a log tail -- which is what a grep, a CI
+        # summary or a person reads -- shows total failure off a fully
+        # successful step. Run 14 had to open the JSON to find out otherwise.
+        _fb = se_fallback_summary or {}
+        _rt, _pt, _fl = (len(_fb.get('routed') or []),
+                         len(_fb.get('partial') or []),
+                         len(_fb.get('failed') or []))
+        if _rt or _pt or _fl:
+            _tail = (f", {_pt} partial" if _pt else '') + \
+                    (f", {RED}{_fl} FAILED{RESET}" if _fl else '')
+            print(f"  SE fallback:   {_rt}/{_rt + _pt + _fl} member net(s) "
+                  f"routed{_tail}")
     if skipped_bad_fanout:
         print(f"  {RED}Skipped:       {len(skipped_bad_fanout)} (fanout stubs self-overlap - "
               f"fix the fanout, #242){RESET}")
@@ -1387,6 +1423,14 @@ def batch_route_diff_pairs(input_file: str, output_file: str, net_names: List[st
     }
     if ac_coupled_summary:
         summary['ac_coupled_xnets'] = ac_coupled_summary
+    # See route.py's identical stamp: a budget armed by the CLI must reach the
+    # one summary this engine prints, because the cancel path still writes.
+    # Inert with no budget armed (every GUI call) or a budget not spent.
+    try:
+        import krt_deadline as _kdl
+        _kdl.stamp(summary)
+    except Exception:
+        pass
     print(f"JSON_SUMMARY: {json.dumps(summary)}")
 
     # Write output file or return results for direct application
@@ -1546,6 +1590,10 @@ def batch_route_diff_pairs(input_file: str, output_file: str, net_names: List[st
 if __name__ == "__main__":
     from console_encoding import enable_utf8_console
     enable_utf8_console()  # cp1252-safe non-ASCII prints (issue #152)
+    # CMD/EXIT self-echo (run-3 B1); see route.py for why this waited for
+    # --deadline. CLI-`__main__`-only: the GUI imports the engine function.
+    import cli_banner
+    cli_banner.install()
     import argparse
     from redo_record import record_invocation
     record_invocation()  # stress-test redo manifest (#132); no-op unless REDO_MANIFEST set
@@ -1783,6 +1831,21 @@ Examples:
     parser.add_argument("--ripped-route-avoidance-cost", type=float, default=defaults.RIPPED_ROUTE_AVOIDANCE_COST,
                         help=f"Soft penalty cost for routing through ripped corridors (0 = disabled, default: {defaults.RIPPED_ROUTE_AVOIDANCE_COST})")
 
+    parser.add_argument("--deadline", type=float, default=None, metavar="SECONDS",
+                        help="Wall-clock budget for the ROUTING LOOPS. Not a hard "
+                             "cap on total runtime -- the cancel is cooperative and "
+                             "the bounded tail (write, DRC writeback) still runs -- "
+                             "so expect to overshoot. What it guarantees is "
+                             "TERMINATION on THIS tool's terms: it stops between "
+                             "pairs, writes the copper it has, and prints a "
+                             "JSON_SUMMARY carrying complete=false / status=deadline "
+                             "before exiting 7. Without it an external kill on "
+                             "Windows is TerminateProcess, which leaves NO summary "
+                             "and NO exit code of ours. ANY harness with an external "
+                             "timeout should pass this at ~0.8x its own. Default: no "
+                             "budget (a wall-clock default would break replay "
+                             "determinism). Env: KRT_DEADLINE_S")
+
     # Debug options
     parser.add_argument("--debug-lines", action="store_true",
                         help="Output debug geometry on User.3 (connectors), User.4 (stub dirs), User.8 (simplified), User.9 (raw A*)")
@@ -1983,8 +2046,22 @@ Examples:
                   f"(mm: {_classes}); diff-pair routing respects cross-class max(A,B). "
                   f"Override with --net-clearances.")
 
+    # See route.py: the deadline is ONE closure into plumbing this engine
+    # already has. `cancel_check` breaks the pair/reroute/cleanup loops rather
+    # than raising, so the write and the summary still happen and a cancelled
+    # run yields real, gated copper. The atexit hook armed here is what makes a
+    # JSON_SUMMARY land on the paths that never reach the engine at all.
+    import krt_deadline
+    _rd_report = {'tool': 'route_diff.py', 'board': args.input_file}
+    _dl = krt_deadline.arm(args.deadline, tool='route_diff',
+                           on_partial=lambda: _rd_report)
+
     batch_route_diff_pairs(args.input_file, args.output_file, net_names,
                 net_clearances=_net_clearances_map,
+                cancel_check=(_dl.cancel_check('diff-pair routing')
+                              if _dl else None),
+                progress_callback=(krt_deadline.stdout_progress(deadline=_dl)
+                                   if _dl else None),
                 direction_order=args.direction,
                 ordering_strategy=args.ordering,
                 disable_bga_zones=args.no_bga_zones,
@@ -2061,6 +2138,22 @@ Examples:
                 schematic_dir=args.schematic_dir,
                 add_teardrops=args.add_teardrops)
 
+    # The engine printed the authoritative JSON_SUMMARY (stamped by
+    # krt_deadline.stamp when the budget was spent). Seal so the atexit flush
+    # does not publish a second, contradicting `incomplete` line after it.
+    krt_deadline.seal()
+    # `stopped_in or expired()`: the durable record that the cancel fired, not
+    # just "the wall clock has since passed". See krt_deadline.stamp.
+    _deadline_hit = bool(_dl and (_dl.stopped_in or _dl.expired()))
+    if _deadline_hit:
+        print(f"{RED}DEADLINE: this run stopped on its own budget after "
+              f"{_dl.elapsed():.0f}s of {_dl.seconds:g}s"
+              + (f" (in {_dl.stopped_in})" if _dl.stopped_in else "")
+              + f". The board at {args.output_file or '(none)'} is a PARTIAL "
+              f"route -- real, gated copper, but pairs were left unattempted. "
+              f"Do not read it as clean; the JSON_SUMMARY above carries "
+              f"complete=false.{RESET}")
+
     # Make the output project's DRC design rules consistent with the floors we
     # just routed to (issue #160), mirroring route.py, so a manual DRC in KiCad
     # flags only genuine problems instead of stock-default noise.
@@ -2096,3 +2189,21 @@ Examples:
             persist_impedance_specs(_pro, consume_impedance_specs())
         except Exception as e:
             print(f"  (skipped protected-nets record: {e})")
+
+    # LAST, and non-zero: the bounded post-passes above belong to the partial
+    # board (skipping the DRC writeback would strand the output without its
+    # floor -- the #441 hazard), but a caller reading exit 0 would treat an
+    # unfinished route as a finished one.
+    if _deadline_hit:
+        sys.exit(krt_deadline.DEADLINE_EXIT)
+    # AFTER the deadline: a run that ran out of clock exits 7, and that is the
+    # more specific fact. This is the other false success -- the patterns
+    # matched no pair at all, which used to print `Error:` and exit 0 because
+    # main called the router as a bare statement. Measured: a shell rewrote
+    # every `/IO_Banks/Z*` argument into a Windows path and 14 patterns matched
+    # nothing.
+    if _NO_PAIRS_MATCHED:
+        print("route_diff: the --nets patterns matched no differential pair, "
+              "so nothing was routed. Exiting non-zero so a chained caller "
+              "does not read this as success.", file=sys.stderr)
+        sys.exit(2)

--- a/py_router/route_planes.py
+++ b/py_router/route_planes.py
@@ -3905,7 +3905,7 @@ Examples:
     # keep their larger PLANE_EDGE_CLEARANCE fallback when the board declares none.
     # Resolved here, before enforce_fab_floors and every downstream use.
     from list_nets import (board_default_netclass_clearance, board_default_netclass_param,
-                           board_constraint)
+                           resolve_cli_floor)
     for _pname, _nckey, _fallback in (('track_width', 'track_width', defaults.TRACK_WIDTH),
                                       ('via_size', 'via_diameter', defaults.VIA_SIZE),
                                       ('via_drill', 'via_drill', defaults.VIA_DRILL)):
@@ -3928,20 +3928,18 @@ Examples:
               f"clearance {args.clearance}mm.")
     else:
         args.clearance = min(_dflt_clr, _ceiling) if _dflt_clr is not None else _ceiling
-    if args.hole_to_hole_clearance is None:
-        _h2h = board_constraint(args.input_file, 'min_hole_to_hole')
-        args.hole_to_hole_clearance = _h2h if _h2h is not None else defaults.HOLE_TO_HOLE_CLEARANCE
-        print(f"--hole-to-hole-clearance not given; using "
-              f"{'the board min_hole_to_hole' if _h2h is not None else 'the fallback'} "
-              f"{args.hole_to_hole_clearance}mm.")
-    if args.board_edge_clearance is None:
-        # Planes keep their larger edge keep-out (PLANE_EDGE_CLEARANCE) only when
-        # the board declares no edge rule of its own.
-        _edge = board_constraint(args.input_file, 'min_copper_edge_clearance')
-        args.board_edge_clearance = _edge if _edge is not None else defaults.PLANE_EDGE_CLEARANCE
-        print(f"--board-edge-clearance not given; using "
-              f"{'the board min_copper_edge_clearance' if _edge is not None else 'the fallback'} "
-              f"{args.board_edge_clearance}mm.")
+    # Shared resolver (list_nets.resolve_cli_floor). Planes keep their larger
+    # edge keep-out (PLANE_EDGE_CLEARANCE) only when the board declares no edge
+    # rule of its own -- and a DECLARED 0.0 is exactly that case, KiCad's "not
+    # configured". Read straight it was taken as a rule, dropping the plane
+    # inset from 0.5 to 0.0 while the GUI's plane tab held 0.5 (swig_gui.py
+    # _effective_plane_edge_clearance already had the `> 1e-9` guard).
+    args.hole_to_hole_clearance = resolve_cli_floor(
+        args.input_file, 'hole_to_hole', args.hole_to_hole_clearance,
+        defaults.HOLE_TO_HOLE_CLEARANCE, '--hole-to-hole-clearance')
+    args.board_edge_clearance = resolve_cli_floor(
+        args.input_file, 'board_edge_clearance', args.board_edge_clearance,
+        defaults.PLANE_EDGE_CLEARANCE, '--board-edge-clearance')
     set_default_fab_tier(*fab_tier_from_args(args))
     _pinned_floors = enforce_fab_floors(
         count_copper_layers_in_file(args.input_file),

--- a/py_router/route_planes.py
+++ b/py_router/route_planes.py
@@ -2665,6 +2665,23 @@ def _stitch_plane_area_vias(
     return new_via_dicts
 
 
+#: The pad tally from the last create_plane() in this process.
+#: #487 folded plane RESISTANCE into the machine-readable summary for exactly
+#: this reason and stopped one field short: the summary could report the
+#: plane's ampacity but not whether it reached its pads. `complete: true,
+#: status: "ok", EXIT=0` was the entire machine-readable story of a pour that
+#: left 5 pads open -- the number is held three times inside create_plane, and
+#: main() calls it as a bare statement, so none of it survived.
+_LAST_PAD_TALLY: dict = {}
+
+
+def consume_pad_tally() -> dict:
+    """Take (and clear) the last pour's pad tally."""
+    global _LAST_PAD_TALLY
+    out, _LAST_PAD_TALLY = dict(_LAST_PAD_TALLY), {}
+    return out
+
+
 def create_plane(
     input_file: str,
     output_file: str,
@@ -2791,6 +2808,31 @@ def create_plane(
     # copper in different ORDER, and list position leaks into decisions.
     from kicad_parser import canonicalize_pcb_data_order
     canonicalize_pcb_data_order(pcb_data)
+
+    # --plane-layers takes BARE copper layer names positionally matched to
+    # --nets, but the natural thing to type (and what the routing skill's R1
+    # stage used to instruct) is a net:layer pair. The argument is untyped
+    # `str`, so "GND:B.Cu" was accepted AS A LAYER NAME, travelled through
+    # generate_zone_sexpr, and was written verbatim as (layer "GND:B.Cu").
+    # KiCad then refuses the whole file ("Failed to load board") -- while every
+    # in-repo checker read it happily, because check_connected's copper-layer
+    # census only tested `endswith('.Cu')`. Two full routing laps of run 11
+    # were spent on boards nobody could open.
+    #
+    # Engine-side, not in main(): main() never parses the board so it cannot
+    # validate, and this way the CLI, the GUI planes tab and
+    # route_disconnected_planes all inherit the guard (same reasoning as the
+    # copper-to-edge rule below).
+    _copper = list(getattr(pcb_data.board_info, 'copper_layers', None) or ())
+    if _copper:
+        _bad = [l for l in plane_layers if l not in _copper]
+        if _bad:
+            print(f"Error: {', '.join(sorted(set(_bad)))} is not a copper layer "
+                  f"of this board ({', '.join(_copper)}). --plane-layers takes "
+                  f"BARE layer names positionally matched to --nets "
+                  f"(e.g. --nets GND GNDA --plane-layers B.Cu B.Cu), "
+                  f"not net:layer pairs.")
+            return _empty_plane_results(return_results)
 
     # Route trace (#482): plane creation builds its tap tracks/vias as dicts in
     # all_new_segments/all_new_vias (never touching pcb_data.segments), so record
@@ -3539,6 +3581,8 @@ def create_plane(
         print(f"  Nets processed: {len(net_names)}")
         print(f"  Total new vias placed: {total_vias_placed}")
         print(f"  Total traces added: {total_traces_added}")
+        _LAST_PAD_TALLY['failed_pads'] = int(total_failed_pads)
+        _LAST_PAD_TALLY['pads_needing_vias'] = int(total_pads_needing_vias)
         if total_failed_pads > 0:
             print(f"  Total failed pads: {total_failed_pads}")
 
@@ -3667,6 +3711,7 @@ def create_plane(
             output_file, net_ids, net_names, plane_layers)
         if geo_results:
             geo_failed = sum(info['failed'] for info in geo_results.values())
+            _LAST_PAD_TALLY['geometric_failed'] = int(geo_failed)
             if geo_failed != total_failed_pads:
                 print(f"\n  {geo_failed} pad(s) are not connected to their "
                       f"plane by the pour alone -- EXPECTED (#562): the plane "
@@ -3770,10 +3815,13 @@ Examples:
     parser.add_argument("--nets", "-n", nargs="+", required=True,
                         help="Net name(s) for the plane(s) (e.g., GND VCC)")
     parser.add_argument("--plane-layers", "-p", nargs="+", required=True,
-                        help="Plane layer(s) for the zone(s), one per net (e.g., In1.Cu In2.Cu)")
+                        help="BARE copper layer name(s) for the zone(s), one per net, "
+                             "positionally matched to --nets (e.g., In1.Cu In2.Cu). "
+                             "NOT net:layer pairs -- 'GND:B.Cu' is not a layer name and "
+                             "is refused against the board's own copper layers.")
 
     # Via and track geometry
-    parser.add_argument("--via-size", type=float, default=None, help="Via outer diameter in mm (default: the board Default net-class via, else 0.5)")
+    parser.add_argument("--via-size", type=float, default=None, help="Via outer diameter in mm (default: the board Default net-class via, else 0.5). NOT a hard floor: a tap into a fine-pitch pad field can escalate to the --fab-tier via and print a per-via warning, because a 0.5mm via does not fit a 0.5mm-pitch TQFP. Pass --fab-overrides to forbid the escalation -- at the cost of the taps that then cannot be made")
     parser.add_argument("--via-drill", type=float, default=None, help="Via drill size in mm (default: the board Default net-class via drill, else 0.3)")
     parser.add_argument("--track-width", type=float, default=None, help="Track width for via-to-pad connections in mm (default: the board Default net-class width, else 0.3)")
     parser.add_argument("--clearance", type=float, default=None, help="Copper clearance CEILING in mm. When given, every net class (Default included) is capped at min(class, this) and the writeback clamps. When OMITTED, each net routes at its own net-class clearance (base = the board's Default class, else 0.25).")
@@ -3839,6 +3887,22 @@ Examples:
                         help="Edge-to-edge clearance (mm) between stitching vias and same-net pads. "
                              "-1 (default) allows via-in-pad placement; any value >= 0 forces vias "
                              "outside same-net pads with that clearance.")
+
+    parser.add_argument("--deadline", type=float, default=None, metavar="SECONDS",
+                        help="Wall-clock budget for the PLANE LOOPS. Not a hard cap "
+                             "on total runtime -- the cancel is cooperative and the "
+                             "bounded tail (fills, write, cleanup, DRC writeback) "
+                             "still runs -- so expect to overshoot. What it "
+                             "guarantees is TERMINATION on THIS tool's terms: it "
+                             "stops between regions, writes the copper it has, and "
+                             "prints a JSON_SUMMARY carrying complete=false / "
+                             "status=deadline before exiting 7. Without it an "
+                             "external kill on Windows is TerminateProcess, which "
+                             "leaves NO summary and NO exit code of ours. ANY "
+                             "harness with an external timeout should pass this at "
+                             "~0.8x its own. Default: no budget (a wall-clock "
+                             "default would break replay determinism). "
+                             "Env: KRT_DEADLINE_S")
 
     # Debug options
     parser.add_argument("--dry-run", action="store_true", help="Analyze without writing output")
@@ -4016,7 +4080,27 @@ Examples:
     _out_before = (os.path.getmtime(args.output_file)
                    if args.output_file and os.path.isfile(args.output_file) else None)
 
+    # The deadline is ONE closure into plumbing this engine already has:
+    # `cancel_check` is honoured at every region/pad/route loop head and the
+    # write branch still runs on cancel, so a cancelled run yields a real,
+    # gated, partial pour rather than nothing.
+    #
+    # RESERVE BAND, same correctness reason as route_disconnected_planes': the
+    # bounded tail after the engine (GND return vias, plane copper cleanup, the
+    # DRC-floor writeback) is what makes the partial board readable, and the
+    # KiCad-exact-fill validation inside the engine can itself burn minutes. So
+    # the region loops trip early, leaving clock for the tail.
+    import krt_deadline
+    _rp_report = {'tool': 'route_planes.py', 'board': args.input_file}
+    _dl = krt_deadline.arm(args.deadline, tool='route_planes',
+                           on_partial=lambda: _rp_report)
+    _reserve = max(30.0, (args.deadline or 0) * 0.2) if _dl else 0.0
+
     create_plane(
+        cancel_check=(_dl.cancel_check('plane create', reserve=_reserve)
+                      if _dl else None),
+        progress_callback=(krt_deadline.stdout_progress(deadline=_dl)
+                           if _dl else None),
         input_file=args.input_file,
         output_file=args.output_file,
         ripup_blocker_select=args.ripup_blocker_select,
@@ -4214,10 +4298,44 @@ Examples:
         "min_clearance_used": _cl.effective(args.clearance),
         "plane_nets": sorted(set(args.nets)),
     }
+    # `plane_nets` is a de-duplicated NAME list, and --nets/--plane-layers are
+    # matched POSITIONALLY, so `--nets GND GND --plane-layers In1.Cu In2.Cu`
+    # collapses two poured zones into one entry and the second one vanishes from
+    # the record entirely. Run 14 poured GND on both inner layers and its
+    # summary said `"plane_nets": ["GND"]`. Keep that key as it was -- consumers
+    # read it -- and state the actual zones alongside.
+    try:
+        _layers = list(getattr(args, 'plane_layers', None) or [])
+        _summary["plane_zones"] = [
+            {"net": _n, "layer": (_layers[_i] if _i < len(_layers) else None)}
+            for _i, _n in enumerate(args.nets)]
+    except Exception:                                       # noqa: BLE001
+        pass
     # #487: the plane resistance/ampacity numbers used to live only in stdout
     # ("report-only ... print and discard"). Fold the per-net results the
     # engine noted into the machine-readable summary so chains/graders/skills
     # can gate on them.
+    # The pad tally. Without it `complete: true, status: "ok", EXIT=0` is the
+    # whole machine-readable story of a pour that left pads open -- the text
+    # said "Total failed pads: 5" and the JSON had no channel for it at all.
+    _pt = consume_pad_tally()
+    if _pt:
+        _summary["pads"] = _pt
+        # SAY that this is one tally over every zone. The engine aggregates, so
+        # `failed_pads: 12` on a two-zone pour does not say which zone failed,
+        # and a reader pairing it with a single-entry `plane_nets` would
+        # reasonably assume it was scoped to that one net.
+        _summary["pads_scope"] = ("all zones in this run, summed -- not per "
+                                  "zone; see plane_zones for what was poured")
+        # `geometric_failed` is recorded but does NOT flip the status: under
+        # the pours-first architecture the plane step places no taps, so pads
+        # unreached by the pour alone are EXPECTED here (#562) -- the route
+        # step welds them and its finalize verifies/repairs. Only
+        # `failed_pads` (the engine's own via-placement failures) marks the
+        # pour incomplete.
+        if _pt.get('failed_pads'):
+            _summary["status"] = "incomplete-pads"
+
     try:
         from plane_resistance import consume_resistance_results
         _res = consume_resistance_results()
@@ -4234,10 +4352,45 @@ Examples:
                 for _n, _r in sorted(_res.items())]
     except Exception:
         pass
-    print("JSON_SUMMARY: " + _json.dumps(_summary))
+
+    # Emit through krt_deadline, NOT a raw print. `_emitted` is set only inside
+    # krt_deadline.emit(), so a bare print leaves it False and the atexit flush
+    # then publishes the contentless partial report armed at --deadline time --
+    # a SECOND, contradicting `{"complete": false, "status": "incomplete"}` line
+    # after the real one, which any consumer keying on the LAST JSON_SUMMARY
+    # reads as a failed run. (Measured in route_disconnected_planes, run 11.)
+    # `stopped_in`, not just `expired()`. The reserve band means the region
+    # loops trip at `deadline - reserve`, so a run whose bounded tail then
+    # finishes BEFORE the wall clock runs out is past its cancel and not past
+    # its deadline -- `expired()` alone would report a partial pour as
+    # complete, which is the exact confusion this whole mechanism removes.
+    # `stopped_in` is set by `Deadline.check` at the moment the cancel fires,
+    # so it is the durable record that the loops were cut short.
+    if _dl is not None and (_dl.stopped_in or _dl.expired()):
+        krt_deadline.stamp(_summary)
+        _rp_report.update(_summary)
+        krt_deadline.emit(_summary, complete=False, status='deadline',
+                          deadline=_dl)
+        print(f"{RED}DEADLINE: this run stopped on its own budget after "
+              f"{_dl.elapsed():.0f}s of {_dl.seconds:g}s"
+              + (f" (in {_dl.stopped_in})" if _dl.stopped_in else "")
+              + f". The board at {args.output_file or '(none)'} is a PARTIAL "
+              f"pour -- real copper, fully gated, but the plane work did not "
+              f"finish. Do not read it as clean.{RESET}")
+        return krt_deadline.DEADLINE_EXIT
+    _rp_report.update(_summary)
+    krt_deadline.emit(_summary)
+    return 0
 
 
 if __name__ == "__main__":
     from console_encoding import enable_utf8_console
     enable_utf8_console()  # cp1252-safe non-ASCII prints (issue #152)
-    main()
+    # CMD/EXIT self-echo (run-3 B1); see route.py for why this waited for
+    # --deadline. CLI-`__main__`-only: the GUI imports create_plane.
+    import cli_banner
+    cli_banner.install()
+    # `or 0`: main() has one early `return` (the net/plane-layer count
+    # mismatch) that returns None, and returning None from sys.exit is 0 --
+    # which is what this block did before, so that path is unchanged.
+    sys.exit(main() or 0)

--- a/py_router/route_render.py
+++ b/py_router/route_render.py
@@ -472,16 +472,56 @@ class BoardRenderer:
         return self.frame()
 
     def _label(self, img: Image.Image, text: str) -> None:
+        """Stamp the caption top-left, WRAPPING rather than clipping.
+
+        This measured the text width and then never used it, so PIL clipped at
+        the image edge and the overflow was simply gone. Measured on a 217-part
+        board: the caption built 156 chars and ~117 fit, so `hole-conflict
+        0.60mm` and `oob 7` -- a fab blocker and the off-board count, i.e. two
+        of the four questions the checklist exists to answer -- were absent
+        from the picture while the strip looked complete because it ended at a
+        plausible-looking field. A verdict strip that silently drops its last
+        fields is worse than no strip: it reads as the whole story.
+        """
         d = ImageDraw.Draw(img)
         font = load_font(max(12, self.H // 55))
         pad = 6
+        avail = max(80, self.W - 2 * pad - 6)
+
+        def _w(s):
+            try:
+                bb = d.textbbox((0, 0), s, font=font)
+                return bb[2] - bb[0]
+            except Exception:
+                return 8 * len(s)
+
+        # Break on the caption's own field separator so a wrap never lands
+        # mid-number; fall back to words, then to the raw string.
+        parts = [p.strip() for p in text.split('|')] if '|' in text \
+            else text.split(' ')
+        joiner = '  |  ' if '|' in text else ' '
+        lines, cur = [], ''
+        for p in parts:
+            cand = (cur + joiner + p) if cur else p
+            if cur and _w(cand) > avail:
+                lines.append(cur)
+                cur = p
+            else:
+                cur = cand
+        if cur:
+            lines.append(cur)
+        if not lines:
+            return
         try:
-            bb = d.textbbox((0, 0), text, font=font)
-            tw, th = bb[2] - bb[0], bb[3] - bb[1]
+            lh = (d.textbbox((0, 0), 'Ag', font=font)[3]
+                  - d.textbbox((0, 0), 'Ag', font=font)[1]) + 4
         except Exception:
-            tw, th = 8 * len(text), 12
-        d.rectangle([pad - 3, pad - 3, pad + tw + 3, pad + th + 5], fill=(0, 0, 0))
-        d.text((pad, pad), text, fill=(240, 240, 240), font=font)
+            lh = 16
+        box_w = max(_w(ln) for ln in lines)
+        d.rectangle([pad - 3, pad - 3, pad + box_w + 3,
+                     pad + lh * len(lines) + 5], fill=(0, 0, 0))
+        for i, ln in enumerate(lines):
+            d.text((pad, pad + i * lh), ln, fill=(240, 240, 240), font=font)
 
 
 def render_board_file(board_path: str, out_png: Optional[str] = None,

--- a/py_router/route_summary.py
+++ b/py_router/route_summary.py
@@ -71,6 +71,41 @@ def merge_summaries(summaries: List[Dict], aborted: bool = False) -> Optional[Di
     for key in EFFORT_KEYS:
         merged[key] = sum(s.get(key, 0) for s in summaries)
 
+    # INCOMPLETENESS IS STICKY. `complete: false` marks a run that stopped on
+    # its own deadline, and merging is last-wins for everything not named
+    # above -- so a complete second pass would erase a partial first pass's
+    # disclosure and the merged tally would read as a whole-board result built
+    # partly on numbers nobody finished computing. Same reasoning as `aborted`
+    # just below: what matters is what is definitely on disk. `.get(...,
+    # True)` leaves every pre-deadline log untouched.
+    if any(not s.get('complete', True) for s in summaries):
+        merged['complete'] = False
+        _p = next((s for s in summaries if not s.get('complete', True)), {})
+        for k in ('status', 'stopped_in', 'deadline_s', 'elapsed_s'):
+            if _p.get(k) is not None:
+                merged[k] = _p[k]
+
+    # THE ORACLE'S ANSWER IS STICKY IN THE OTHER DIRECTION. `oracle_check` is
+    # not a last-wins field: the reconciliation sub-run never reaches the
+    # oracle block, so it emits the initialiser `'skipped'`, and last-wins then
+    # threw away a real answer from pass 1. Measured: a log carrying 10+
+    # `ORACLE CHECK:` lines where KiCad contradicted in-process grading merged
+    # to `oracle_check: 'skipped'` -- so the run's verdict rested on the
+    # router's own tally while the summary said the authority had not been
+    # consulted at all.
+    #
+    # Precedence, worst-news-first: a contradiction outranks agreement, which
+    # outranks "could not ask", which outranks "did not ask".
+    _ORACLE_RANK = {'failed': 4, 'ok': 3, 'unavailable': 2, 'disabled': 1}
+
+    def _orank(v):
+        return _ORACLE_RANK.get(str(v).split(' ')[0], 0)
+
+    _oracles = [s.get('oracle_check') for s in summaries
+                if s.get('oracle_check') is not None]
+    if _oracles:
+        merged['oracle_check'] = max(_oracles, key=_orank)
+
     # Rebuild the pad-pair tallies and the blockers key, which last-wins would
     # silently narrow to the reconcile subset (a 50/40 whole-board reading
     # becomes the sub-run's 3/2, or vanishes entirely). Skipped when aborted:

--- a/py_router/routing_config.py
+++ b/py_router/routing_config.py
@@ -157,6 +157,14 @@ class GridRouteConfig:
                                            # Hole-to-Hole Spacing" (keep in sync with
                                            # routing_defaults.HOLE_TO_HOLE_CLEARANCE)
     board_edge_clearance: float = 0.0  # mm - clearance from board edge (0 = use track clearance)
+    # mm - copper-to-HOLE floor (KiCad's `min_hole_clearance`). 0 = not set by
+    # the caller, so the obstacle builder reads the board's own constraint and
+    # falls back to routing_defaults.NPTH_TO_TRACK_CLEARANCE. It is NOT the same
+    # rule as hole_to_hole_clearance (drill-to-drill): this one keeps TRACKS off
+    # an NPTH wall. The router used to hardcode the 0.20 fab floor here while
+    # check_drc already read min_hole_clearance, so on a board declaring 0.25 the
+    # router would happily route into a band its own checker then flagged.
+    hole_clearance: float = 0.0
     # HARD floor the neck-down may not cross (0 = no floor beyond the fab tier's).
     # `track_width` is a REQUEST: when a wide route will not fit, the neck-down
     # retries the whole net at the layer/default width and the run reports success

--- a/py_tools/check_assembly.py
+++ b/py_tools/check_assembly.py
@@ -16,7 +16,8 @@ courtyard kisses -- the corpus measured 235 -- so the placement fix loop
 targets the pairs OUR moves introduced, never a shipped design's own).
 
 Exit codes: 0 = clean, 2 = usage/load error, 4 = a blocking pair OR copper
-landing on a KiCad-locked part (see LOCKED-PART CONTACT).
+landing on a KiCad-locked part (see LOCKED-PART CONTACT) OR a coincident-
+origin stack (see COINCIDENT ORIGINS).
 """
 import _path  # noqa: F401  (py_tools -> py_router/py_placer on sys.path)
 
@@ -139,6 +140,41 @@ def main():
                            pcb_file=args.board)
     leg = grade_pad_legality(pcb, clearance, worst_n=0)
 
+    # COINCIDENT ORIGINS (run-19, measured twice): SW17+SW34+REF_PUCK_R all at
+    # one point graded `buildable (blocking 0)` -- the pair currency counts pad
+    # INTERSECTIONS, and the rotated pads happened to interleave. A stack of
+    # parts at one origin is unbuildable whatever the pads do, so it is its own
+    # blocking channel. The grouping and the exoneration are placement_state's
+    # prior art, reused rather than re-derived: assess_placement buckets every
+    # pad-bearing footprint by round(coord, 3), partitions each bucket by
+    # physical side (a drilled part is on both), and exonerates all-marker
+    # side-groups (fiducials, mounting holes, testpoints -- mouse-bites and
+    # graphics markers are co-located by design and must NOT flag). A bucket is
+    # a finding here only when it holds >= 2 suspect NON-marker parts: one real
+    # part sitting on a fiducial is not a stack of parts.
+    from placement.part_class import classify_part
+    from placement.placement_state import assess_placement
+    _MARKER_CLASSES = ('fiducial', 'mount_hole', 'testpoint')
+
+    def _marker(ref):
+        try:
+            return classify_part(pcb.footprints[ref],
+                                 ref).name in _MARKER_CLASSES
+        except Exception:                                      # noqa: BLE001
+            return False
+
+    _suspect = assess_placement(pcb, pcb_file=args.board).stacked_suspect_refs
+    _buckets = {}
+    for _ref in _suspect:
+        _fp = pcb.footprints.get(_ref)
+        if _fp is None:
+            continue
+        _buckets.setdefault((round(_fp.x, 3), round(_fp.y, 3)),
+                            []).append(_ref)
+    stack_groups = [{'point': [pt[0], pt[1]], 'refs': refs}
+                    for pt, refs in sorted(_buckets.items())
+                    if sum(1 for r in refs if not _marker(r)) >= 2]
+
     new_advisory = None
     if args.baseline:
         try:
@@ -171,6 +207,14 @@ def main():
         for sh in getattr(q, 'shorts', ()) or ():
             print(f"        SHORT: {sh}")
 
+    if stack_groups:
+        print(f"  COINCIDENT ORIGINS ({len(stack_groups)}): parts stacked at "
+              f"one point. Rotated pads can interleave, so the pad-"
+              f"intersection channel alone can grade a stack buildable.")
+        for grp in stack_groups:
+            print(f"    {' '.join(grp['refs'])} @ "
+                  f"({grp['point'][0]}, {grp['point'][1]})")
+
     locked_contact = g.get('locked_contact_pairs') or []
     if locked_contact:
         print(f"  LOCKED-PART CONTACT ({len(locked_contact)}): copper lands on "
@@ -189,8 +233,12 @@ def main():
           f"{leg['hole_conflicts']} hole conflict(s), "
           f"{leg['oob_pad_count']} part(s) with pad copper off-board"
           + (": " + _clause if _clause else ""))
-    verdict = ('NOT BUILDABLE' if (g['blocking'] or locked_contact)
-               else 'buildable (blocking 0)')
+    # ONE predicate, used verbatim at all three sites (verdict, JSON
+    # `buildable`, exit code). Three re-derivations of `blocking or
+    # locked_contact` is how the coincident-origin channel would have reached
+    # two of them and silently missed the third.
+    not_buildable = bool(g['blocking'] or locked_contact or stack_groups)
+    verdict = 'NOT BUILDABLE' if not_buildable else 'buildable (blocking 0)'
     print(f"  VERDICT: {verdict}")
 
     if args.json:
@@ -213,7 +261,7 @@ def main():
             # wrong got it wrong quietly: board_score's assembly component
             # reads `blocking` alone, and the recovery arm scraped this
             # verdict back out of stdout rather than reading the JSON.
-            'buildable': not (g['blocking'] or locked_contact),
+            'buildable': not not_buildable,
             'verdict': verdict,
             'locked_contacts': len(locked_contact),
             'advisory': g['advisory'],
@@ -234,6 +282,11 @@ def main():
             'oob_pad_refs': leg.get('oob_pad_refs') or [],
             'oob_pad_basis': leg.get('oob_pad_basis'),
             'locked_contact_pairs': [q._asdict() for q in locked_contact],
+            # run-19: parts stacked at one origin, marker classes exonerated.
+            # Groups, not fake N*(N-1)/2 pair entries -- a stack is one
+            # finding about one point, and the fix is one re-seat per part.
+            'coincident_origin_groups': stack_groups,
+            'coincident_origins': len(stack_groups),
         }
         if new_advisory is not None:
             doc['baseline'] = args.baseline
@@ -242,7 +295,7 @@ def main():
             json.dump(doc, f, indent=1, sort_keys=True)
         print(f"  JSON -> {args.json}")
 
-    return 4 if (g['blocking'] or locked_contact) else 0
+    return 4 if not_buildable else 0
 
 
 if __name__ == "__main__":

--- a/py_tools/check_assembly.py
+++ b/py_tools/check_assembly.py
@@ -32,7 +32,10 @@ def main():
     p.add_argument("--intent", default=None, metavar="JSON",
                    help="Floorplan intent; only its overlap_waivers are read")
     p.add_argument("--clearance", type=float, default=None,
-                   help="Pad-model clearance (default: routing_defaults)")
+                   help="Pad-model clearance in mm. Default: the board's own "
+                        "Default net-class clearance, else routing_defaults. "
+                        "The effective value and its source are printed and "
+                        "written to --json")
     p.add_argument("--baseline", default=None, metavar="BOARD",
                    help="Report advisory pairs NEW relative to this board "
                         "(the placement-loop currency)")
@@ -44,8 +47,78 @@ def main():
     from kicad_parser import parse_kicad_pcb
     from placement.legality import grade_body_overlap, grade_pad_legality
 
-    clearance = (args.clearance if args.clearance is not None
-                 else defaults.CLEARANCE)
+    # GRADE AT THE BOARD'S OWN FLOOR, and say where that came from.
+    #
+    # This default USED to be a flat routing_defaults.CLEARANCE (0.25) that did
+    # not read the board, while every router resolves the board's own Default
+    # netclass first. So the tool routinely graded STRICTER than the board it
+    # was grading. Measured on one 0.2mm board: pad_conflicts 96 at the default
+    # vs 39 at the board's own floor -- `blocking` and `locked_contacts` were
+    # identical, because those pairs are true pad INTERSECTIONS rather than
+    # clearance grazes, which is why it survived this long.
+    #
+    # The previous decision here was to keep the constant and merely DISCLOSE
+    # it, on the grounds that board_score and the stress harness shell this
+    # tool and re-basing their numbers was the bigger change. That trade is now
+    # reversed deliberately: a disclosure only helps a reader who acts on it,
+    # and the run that motivated this read the numbers, not the note. The
+    # re-basing is real but bounded -- it moves the pad/hole ECHO counts toward
+    # the truth and leaves `blocking` (the field board_score consumes) alone.
+    #
+    # "Every board in kicad_files/ declares no floor and so is bit-identical"
+    # is what stood here, and it is FALSE. Two project siblings are committed:
+    #
+    #     $ git ls-files kicad_files/*.kicad_pro
+    #     kicad_files/flat_hierarchy.kicad_pro     Default clearance 0.2
+    #     kicad_files/routed_output.kicad_pro      Default clearance 0.09
+    #
+    # so on those two this tool re-based from the 0.25 constant to 0.2 and to
+    # 0.09. What IS bit-identical is the VERDICT, which is the weaker claim
+    # that should have been made: measured at 5894b95^ vs HEAD, both boards
+    # report pad_conflicts 0 -> 0 and buildable True -> True; only the graded
+    # clearance and its recorded source moved. Grading at the board's own
+    # clearance is right HERE because this tool grades existing geometry --
+    # check_channels PREDICTS routability and therefore needs a fab floor
+    # instead (see list_nets.board_floor, grade-vs-predict).
+    _board_clr = None
+    _decl = None
+    try:
+        from list_nets import (board_default_netclass_clearance,
+                               board_floor_declaration)
+        _board_clr = board_default_netclass_clearance(args.board)
+        _decl = board_floor_declaration(args.board)
+    except Exception:                                          # noqa: BLE001
+        pass
+    from list_nets import board_floor
+    clearance, _src = board_floor(args.board, 'clearance', args.clearance,
+                                  defaults.CLEARANCE)
+    print(f"  grading at clearance {clearance}mm  [{_src}]")
+    # A board that declares NOTHING is a DIFFERENT case from one whose Default
+    # class happens to match (run-12 Tier 1.3). The comparison below can only
+    # fire when there IS a declared value to compare against, so on a
+    # project-less board -- tigard ships none -- this tool said "grading at
+    # 0.25mm [routing_defaults]" and nothing recorded that 0.25 was a fallback
+    # rather than agreement. Name it.
+    if _decl is not None and _decl['declares_nothing']:
+        print(f"  NOTE: this board declares NO net class and NO board "
+              f"constraint (no sibling .kicad_pro, no (net_class) block), so "
+              f"{clearance}mm is a FALLBACK rather than the board's own floor. "
+              f"Pass --clearance <the value the copper was routed to> if you "
+              f"know it; the pad/hole ECHO counts move with it, `blocking` "
+              f"usually does not.")
+    # The note now fires on the OPPOSITE case, which is the only one left that
+    # can be a mistake: the caller OVERRODE a floor the board does declare.
+    # Before, the tool could silently disagree with the board; now only a human
+    # can, and they should be told they did.
+    if args.clearance is not None and _board_clr is not None \
+            and abs(_board_clr - clearance) > 1e-9:
+        print(f"  NOTE: --clearance {clearance}mm overrides this board's own "
+              f"Default net-class clearance of {_board_clr}mm, so this grade "
+              f"is {'STRICTER' if clearance > _board_clr else 'LOOSER'} than "
+              f"the board asks for. Drop --clearance to grade at the board's "
+              f"floor. Expect the pad/hole ECHO counts to move; `blocking` "
+              f"usually will not, because blocking pairs are pad "
+              f"intersections rather than clearance grazes.")
 
     waivers = ()
     if args.intent:
@@ -110,9 +183,12 @@ def main():
               "standoff, a panel cut-out). A placement search may not settle "
               "this by moving the other part somewhere it likes better, and a "
               "waiver class chosen for unlocked parts does not apply here.")
+    from placement.legality import format_oob_clause
+    _clause = format_oob_clause(leg)
     print(f"  pad/hole/oob echo: {leg['pad_conflicts']} pad pair(s), "
           f"{leg['hole_conflicts']} hole conflict(s), "
-          f"{leg['oob_pad_count']} part(s) with pad copper off-board")
+          f"{leg['oob_pad_count']} part(s) with pad copper off-board"
+          + (": " + _clause if _clause else ""))
     verdict = ('NOT BUILDABLE' if (g['blocking'] or locked_contact)
                else 'buildable (blocking 0)')
     print(f"  VERDICT: {verdict}")
@@ -121,7 +197,25 @@ def main():
         doc = {
             'board': args.board,
             'clearance': clearance,
+            # 'cli' | 'board netclass' | 'fixed default' -- two grades are
+            # comparable only when this agrees, and the scalar alone cannot
+            # say whether 0.25 was the board's answer or this tool's.
+            'clearance_source': _src,
+            # run-12 Tier 1.3: True when `clearance` above is this tool's
+            # fallback because the board declared no floor at all -- which a
+            # reader comparing the scalar across boards cannot otherwise tell
+            # from a board that genuinely asks for it.
+            'board_declares_no_floor': bool(_decl and _decl['declares_nothing']),
             'blocking': g['blocking'],
+            # The verdict itself, and the scalar behind half of it. Without
+            # these every reader re-derives `blocking == 0 and not
+            # locked_contact_pairs` for itself -- and the ones that got it
+            # wrong got it wrong quietly: board_score's assembly component
+            # reads `blocking` alone, and the recovery arm scraped this
+            # verdict back out of stdout rather than reading the JSON.
+            'buildable': not (g['blocking'] or locked_contact),
+            'verdict': verdict,
+            'locked_contacts': len(locked_contact),
             'advisory': g['advisory'],
             'waived': g['waived'],
             'pairs': [q._asdict() for q in g['pairs']],
@@ -131,6 +225,14 @@ def main():
             'hole_conflicts': leg['hole_conflicts'],
             'oob_pad_count': leg['oob_pad_count'],
             'oob_pad_amount': leg['oob_pad_amount'],
+            # The MACHINE path, which is the one that matters here: this doc is
+            # what loop_driver's L2 gate reads, and that gate refuses with "N
+            # part(s) carry pad copper OFF the board -- their nets cannot be
+            # routed at all". It could not name the part, and the count it
+            # gates on moves with --clearance, so a clearance-band graze reads
+            # as copper in the air. Both facts now travel with the number.
+            'oob_pad_refs': leg.get('oob_pad_refs') or [],
+            'oob_pad_basis': leg.get('oob_pad_basis'),
             'locked_contact_pairs': [q._asdict() for q in locked_contact],
         }
         if new_advisory is not None:

--- a/py_tools/check_floorplan.py
+++ b/py_tools/check_floorplan.py
@@ -102,6 +102,14 @@ def build_parser():
                         "it connects to, and what crosses each declared bus "
                         "corridor. Advisory -- these say the floorplan will "
                         "fight the router, not that it breaks the intent")
+    p.add_argument('--require-rules', type=int, default=0, metavar='N',
+                   help='fail unless at least N rules actually RAN. Default 0 '
+                        '(off), which keeps the long-standing contract that a '
+                        'vacuous intent exits 0 -- but that contract is how an '
+                        'intent running ZERO rules constrained two placement '
+                        'laps with nothing, twice, and every consumer stayed '
+                        'silent. A caller that means "grade this" should pass '
+                        '--require-rules 1.')
     p.add_argument('--exit-zero', action='store_true',
                    help='report violations but exit 0 anyway')
     p.add_argument('-q', '--quiet', action='store_true',
@@ -193,6 +201,19 @@ def main(argv=None):
     s['clearance_used'] = knobs['clearance']
     s['edge_clearance_used'] = knobs['board_edge_clearance']
     print("JSON_SUMMARY: " + json.dumps(s, sort_keys=True))
+    # "0 violations" and "0 rules ran" must not look the same to a machine --
+    # this module's own docstring says so, and until now only the DATA said it
+    # (`rules_run` / `rules_skipped`); the exit code could not. Opt-in, so the
+    # pinned default contract is untouched.
+    _ran = s.get('rules_run', 0)
+    if args.require_rules and _ran < args.require_rules:
+        print(f"  FAIL: --require-rules {args.require_rules}, but {_ran} "
+              f"rule(s) ran. A grade that ran no rules is a VACUOUS PASS, not "
+              f"a clean board: {s.get('rules_skipped', 0)} rule(s) were "
+              f"skipped because the intent declares nothing they apply to.",
+              file=sys.stderr)
+        if not args.exit_zero:
+            return VIOLATIONS_EXIT
     if result.errors and not args.exit_zero:
         return VIOLATIONS_EXIT
     return 0

--- a/py_tools/check_reachability.py
+++ b/py_tools/check_reachability.py
@@ -25,6 +25,12 @@ then `--clearance` as the base), so the verdict is graded at what the board
 would actually route at rather than at a guessed round number.
 
 Exit codes: 0 PASSABLE, 1 CAGED, 2 usage/geometry error.
+
+**1 is reserved for the geometry verdict and nothing else.** An argument that
+names nothing on this board -- a misspelled ref, a pad number that is not there,
+an unreadable board file -- exits 2 with what it could not resolve. It used to
+exit 1, because `raise SystemExit(msg)` does, and a caller acting on exit 1
+re-enters placement and throws away every routed board.
 """
 import _path  # noqa: F401  (py_tools -> py_router/py_placer on sys.path)
 import argparse
@@ -33,25 +39,78 @@ import os
 import sys
 
 
+class Unresolvable(Exception):
+    """The arguments do not name anything on this board.
+
+    Its own exception type because the ALTERNATIVE was `raise SystemExit(msg)`,
+    and SystemExit with a message exits **1** -- which in this tool is the CAGED
+    verdict, the most expensive answer it can give. Measured:
+
+        --pad NOSUCH.9  -> exit 1   a typo
+        --pad RM1.1.1   -> exit 1   a real pad, named "1.1"
+        --pad U1.1      -> exit 2   the honest "nothing to reach here"
+
+    The loop's L3 stage treats "a single genuine CAGED on the copper-free board"
+    as sufficient to re-enter placement, and re-entering placement discards every
+    routed board. So a misspelling could buy the most expensive misclassification
+    in the loop, and nearly did. `target_cells == 0` was already guarded against
+    a false PASSABLE (:224); this is the same guard on the other side, and the
+    false CAGED is the costlier of the two.
+    """
+
+
 def _resolve_pad(pcb, spec):
-    """'U3.23' -> (x, y, net_id, layer). The layer is the pad's own."""
+    """'U3.23' -> (x, y, net_id, layer). The layer is the pad's own.
+
+    Splits at EVERY dot and keeps what the BOARD actually has, rather than
+    splitting on the last one positionally. KiCad pad numbers are strings and
+    are allowed to contain dots -- RM1 on the measured board has a pad literally
+    named "1.1", so `RM1.1.1` rsplit to ref `RM1.1` (no such footprint) and the
+    tool reported the geometry verdict CAGED for a pad that exists and is fine.
+    """
     if '.' not in spec:
-        raise SystemExit(f"--pad wants REF.PADNUM, got {spec!r}")
-    ref, num = spec.rsplit('.', 1)
-    fp = pcb.footprints.get(ref)
-    if fp is None:
-        raise SystemExit(f"no footprint {ref!r} on this board")
-    for p in fp.pads:
-        if str(p.pad_number) == num:
-            layers = [l for l in (p.layers or []) if l.endswith('.Cu')]
-            layer = None
-            if p.drill and p.drill > 0:
-                layer = None                      # any; caller picks the first
-            elif layers and layers[0] != '*.Cu':
-                layer = layers[0]
-            return p.global_x, p.global_y, p.net_id, layer
-    raise SystemExit(f"{ref} has no pad {num!r} "
-                     f"(has: {', '.join(str(p.pad_number) for p in fp.pads[:12])})")
+        raise Unresolvable(f"--pad wants REF.PADNUM, got {spec!r}")
+    # Every place the dot could be, scored against the board.
+    cands, tried_refs = [], []
+    for i, ch in enumerate(spec):
+        if ch != '.':
+            continue
+        ref, num = spec[:i], spec[i + 1:]
+        tried_refs.append(ref)
+        fp = pcb.footprints.get(ref)
+        if fp is None or not num:
+            continue
+        for p in fp.pads:
+            if str(p.pad_number) == num:
+                cands.append((ref, num, p))
+                break                            # first pad of that number wins
+    if not cands:
+        known = [r for r in tried_refs if r in pcb.footprints]
+        if known:
+            fp = pcb.footprints[known[-1]]
+            have = ', '.join(str(p.pad_number) for p in fp.pads[:12])
+            more = '' if len(fp.pads) <= 12 else f' ... (+{len(fp.pads) - 12})'
+            raise Unresolvable(
+                f"footprint {known[-1]!r} exists but has no pad "
+                f"{spec[len(known[-1]) + 1:]!r} (has: {have}{more})")
+        raise Unresolvable(
+            f"no footprint on this board matches any prefix of {spec!r} "
+            f"(tried: {', '.join(repr(r) for r in tried_refs)})")
+    if len(cands) > 1:
+        # Genuinely ambiguous -- e.g. footprint "A" with pad "1.1" AND footprint
+        # "A.1" with pad "1". Guessing would be a silent wrong answer about
+        # which pad was graded, which is the whole failure mode being fixed.
+        where = '; '.join(f"{r} pad {n!r}" for r, n, _ in cands)
+        raise Unresolvable(f"{spec!r} is ambiguous on this board -- it could be "
+                           f"{where}. Nothing here can decide which you meant.")
+    _ref, _num, p = cands[0]
+    layers = [l for l in (p.layers or []) if l.endswith('.Cu')]
+    layer = None
+    if p.drill and p.drill > 0:
+        layer = None                              # any; caller picks the first
+    elif layers and layers[0] != '*.Cu':
+        layer = layers[0]
+    return p.global_x, p.global_y, p.net_id, layer
 
 
 def main(argv=None):
@@ -91,20 +150,46 @@ def main(argv=None):
     from kicad_parser import parse_kicad_pcb  # _path put py_router on sys.path
     from placement import reachability
 
-    pcb = parse_kicad_pcb(args.board)
+    # An unreadable board is exit 2 for the same reason a bad --pad is: an
+    # uncaught exception here exits 1, which reads as CAGED to every caller.
+    if not os.path.isfile(args.board):
+        print(f"cannot resolve: no such board file: {args.board}",
+              file=sys.stderr)
+        return 2
+    try:
+        pcb = parse_kicad_pcb(args.board)
+    except Exception as exc:                                    # noqa: BLE001
+        print(f"cannot resolve: {args.board} did not parse: "
+              f"{type(exc).__name__}: {exc}", file=sys.stderr)
+        return 2
 
+    # EVERY argument-resolution failure below leaves here as exit 2. None of
+    # them is a statement about the board's geometry, and 1 is reserved for the
+    # one statement that is (CAGED). See Unresolvable.
     layer_first = None
-    if args.pad:
-        x, y, nid, layer_first = _resolve_pad(pcb, args.pad)
-        seed = (x, y)
-        net_id = nid
-        if not net_id:
-            raise SystemExit(f"{args.pad} has no net -- nothing to reach")
-    else:
-        if not (args.at and args.net):
-            raise SystemExit("give --pad REF.NUM, or both --at x,y and --net")
-        seed = tuple(float(v) for v in args.at.split(','))
-        net_id = None
+    try:
+        if args.pad:
+            x, y, nid, layer_first = _resolve_pad(pcb, args.pad)
+            seed = (x, y)
+            net_id = nid
+            if not net_id:
+                raise Unresolvable(f"{args.pad} has no net -- nothing to reach")
+        else:
+            if not (args.at and args.net):
+                raise Unresolvable(
+                    "give --pad REF.NUM, or both --at x,y and --net")
+            try:
+                seed = tuple(float(v) for v in args.at.split(','))
+            except ValueError:
+                raise Unresolvable(f"--at wants x,y in mm, got {args.at!r}")
+            if len(seed) != 2:
+                raise Unresolvable(f"--at wants x,y in mm, got {args.at!r}")
+            net_id = None
+    except Unresolvable as exc:
+        print(f"cannot resolve: {exc}", file=sys.stderr)
+        print("(exit 2 -- this is an argument that names nothing on this board, "
+              "NOT the CAGED geometry verdict, which is exit 1)", file=sys.stderr)
+        return 2
 
     # Knobs from the BOARD, not from round numbers.
     import list_nets
@@ -130,7 +215,27 @@ def main(argv=None):
               else list(pcb.board_info.copper_layers or ('F.Cu', 'B.Cu')))
     if layer_first and layer_first in layers:     # the seed's own layer first
         layers = [layer_first] + [l for l in layers if l != layer_first]
-    view = ([float(v) for v in args.view.split(',')] if args.view else None)
+    # --view gets the same treatment as --at, and for the same reason: a
+    # traceback here exits 1, which is the CAGED verdict. Garbage floats raised
+    # ValueError out of this line; the wrong COUNT of them survived to raise
+    # IndexError deep inside reachability.slack_field. Both read as "no route
+    # exists at any grid" to a caller branching on the exit code.
+    view = None
+    if args.view:
+        try:
+            view = [float(v) for v in args.view.split(',')]
+        except ValueError:
+            print(f"cannot resolve: --view wants x0,y0,x1,y1 in mm, got "
+                  f"{args.view!r}", file=sys.stderr)
+            return 2
+        if len(view) != 4:
+            print(f"cannot resolve: --view wants FOUR values x0,y0,x1,y1, got "
+                  f"{len(view)} in {args.view!r}", file=sys.stderr)
+            return 2
+        if view[2] <= view[0] or view[3] <= view[1]:
+            print(f"cannot resolve: --view must have x1>x0 and y1>y0, got "
+                  f"{args.view!r}", file=sys.stderr)
+            return 2
 
     try:
         r = reachability.pad_reachability(

--- a/py_tools/make_film.py
+++ b/py_tools/make_film.py
@@ -379,8 +379,17 @@ def build_film(shots, size=DEFAULT_SIZE, fps=DEFAULT_FPS, supersample=1,
 
     if not quiet:
         n_cards = sum(1 for s in shots if s['kind'] == 'card')
+        # "assembled", not "frames": this is the list handed to the writer, and
+        # the GIF encoder collapses runs of identical frames (card holds, the
+        # end hold), so the file that lands holds FEWER. Printing both as
+        # "frames" invited exactly one reconciliation failure -- 377 here, 348
+        # in the delivered GIF, and nothing said which was the film. The
+        # `animate_route: wrote ...` line below counts the artifact itself; that
+        # is the number to quote.
         print(f"make_film: {len(boards)} beats ({n_att} attempts), "
-              f"{n_cards} cards, {len(out)} frames", file=sys.stderr)
+              f"{n_cards} cards, {len(out)} frames assembled "
+              f"(the writer reports what the file actually holds)",
+              file=sys.stderr)
     return out
 
 

--- a/py_tools/render_placement.py
+++ b/py_tools/render_placement.py
@@ -78,6 +78,9 @@ class PlacementModel:
         self.state = None
         self.no_outline = False
         self.metrics: Dict[str, object] = {}
+        # Which floors this model was built at, and where each came from.
+        # Always present, so a caller never has to guess whether it was set.
+        self.floor_knobs: Dict[str, Dict] = {}
         if exact:
             self.state = self._build_state(quench_kwargs or {})
         if self.state is not None:
@@ -85,7 +88,23 @@ class PlacementModel:
 
     def _build_state(self, kw):
         from placement.quench import QuenchState
-        args = dict(clearance=defaults.CLEARANCE, board_edge_clearance=0.55,
+        from list_nets import board_floor_knobs
+        # BOARD-FIRST floors, resolved HERE rather than in main() so the CLI and
+        # every library caller get the same answer -- and so this instrument
+        # agrees with place_optimize, which has resolved them this way since
+        # run-7 S1 (place_optimize.py:144). Until now it did not: the renderer
+        # hardcoded 0.25/0.55 while the optimizer read the board, so on any
+        # board declaring its own floor the two disagreed about the geometry
+        # they were supposedly sharing. On the measured board that is 0.2 and
+        # 0.5, not 0.25 and 0.55.
+        #
+        # An explicit --clearance still wins: board_floor_knobs takes a non-None
+        # value as 'cli' and returns it unchanged.
+        clr, edge, self.floor_knobs = board_floor_knobs(
+            self.pcb_file, clearance=kw.get('clearance'),
+            board_edge_clearance=kw.get('board_edge_clearance'),
+            clearance_default=defaults.CLEARANCE, edge_default=0.55)
+        args = dict(clearance=clr, board_edge_clearance=edge,
                     crossing_penalty=10.0, halo_base=0.5, halo_coef=0.25,
                     halo_weight=2.0, edge_halo=2.0, edge_weight=2.0,
                     grid_step=defaults.GRID_STEP, length_weight=1.0)
@@ -203,11 +222,12 @@ def legality_findings(model) -> Dict[str, object]:
 
     Channels are labelled because run 3 lost time to an UNLABELLED
     two-channel disagreement: `oob_refs_pad_copper` measures each part's PAD
-    extent against the board bbox (what the dashed-red overlay draws);
-    `oob_refs_courtyard` measures the courtyard rect against the outline
+    extent against the board OUTLINE (what the dashed-red overlay draws);
+    `oob_refs_courtyard` measures the courtyard rect against the same outline
     gate (what `oob_count` in the metrics counts). They legitimately differ
     -- an NPTH mounting hole has no pad copper, a courtyard overhang may
-    carry no copper.
+    carry no copper -- but they differ only in WHICH RECT they measure. Both
+    fall back to the bounding box only when the model carries no outline.
     """
     cached = getattr(model, '_legality_findings', None)
     if cached is not None:
@@ -221,6 +241,39 @@ def legality_findings(model) -> Dict[str, object]:
     ctx = getattr(state, 'legality_ctx', None) if state is not None else None
     if ctx is not None:
         b = state.board
+        # Measure the pad extent against the REAL outline, not the bounding
+        # box. The board is not its bounding box: on a board with an inner
+        # cutout (the run-11 smartknob has 1 ring + 5 cutouts) a part sitting
+        # dead-centre in the hole scored oob = 0, so this channel -- which the
+        # placement skill calls the top-priority placement gate, because
+        # off-outline pad copper converts one-for-one into unrouted nets --
+        # was structurally blind exactly where it mattered. The courtyard
+        # channel 25 lines below has always used the outline gate; the two are
+        # meant to differ in WHICH RECT they measure (pad extent vs courtyard),
+        # not in which board. Bounding box stays as the fallback for a model
+        # with no outline.
+        # ZERO margin, deliberately. state.edge_gate carries the board-edge
+        # CLEARANCE margin, so reusing it would report every part merely inside
+        # the edge band as off-outline -- on run 11's board that turned 8 real
+        # breaches into 21 findings, and this channel gates the placement->
+        # routing hand-off. The question here is only "is pad copper outside
+        # the outline", which is the margin-0 form. The ring geometry is
+        # already computed, so this is a shallow copy, not a re-parse.
+        _pad_gate = None
+        if not getattr(model, 'no_outline', False):
+            _src = getattr(state, 'edge_gate', None)
+            _pad_gate = getattr(state, '_pad_edge_gate_m0', None)
+            if _pad_gate is None and _src is not None:
+                import copy as _copy
+                _pad_gate = _copy.copy(_src)
+                _pad_gate.margin = 0.0
+                if getattr(_pad_gate, 'bounds', None) is not None:
+                    _pad_gate.usable = tuple(_pad_gate.bounds)
+                _pad_gate._near = {}
+                try:
+                    state._pad_edge_gate_m0 = _pad_gate
+                except Exception:
+                    pass
         for ref in sorted(ctx.parts):
             p = state.parts.get(ref)
             if p is None:
@@ -228,8 +281,24 @@ def legality_findings(model) -> Dict[str, object]:
             ext = ctx.parts[ref].extent(p.x, p.y, p.rot)
             if ext is None:
                 continue
-            oob = (max(0.0, b[0] - ext[0]) + max(0.0, ext[2] - b[2])
-                   + max(0.0, b[1] - ext[1]) + max(0.0, ext[3] - b[3]))
+            oob = None
+            if _pad_gate is not None:
+                try:
+                    # Per PAD rect, not the part's whole axis-aligned extent.
+                    # That extent is an AABB over every pad, so a part rotated
+                    # off-axis near an edge (run 11's J1 sits at 45 deg) has
+                    # AABB corners well outside its real copper and reported a
+                    # breach no pad actually makes. This channel gates the
+                    # hand-off to routing, so a false positive here costs a
+                    # refusal on a healthy board.
+                    _rects = ctx.parts[ref].pad_rects(p.x, p.y, p.rot)
+                    oob = max((_pad_gate.rect_outside_amount(r[:4])
+                               for r in _rects), default=0.0)
+                except Exception:
+                    oob = None
+            if oob is None:
+                oob = (max(0.0, b[0] - ext[0]) + max(0.0, ext[2] - b[2])
+                       + max(0.0, b[1] - ext[1]) + max(0.0, ext[3] - b[3]))
             if oob > 1e-6:
                 out['oob_refs_pad_copper'].append([ref, round(oob, 4)])
         refs = sorted(ctx.parts)
@@ -635,7 +704,339 @@ def overlay_for(spec: PanelSpec):
             draw_arrows(d, r, spec.moves)
         if o.get('labels', True):
             draw_ref_labels(d, r, m, prom)
+        if o.get('legend', True):
+            draw_legend(d, r, spec)
     return _draw
+
+
+def draw_legend(d, r, spec) -> None:
+    """A colour key, bottom-left.
+
+    The encoding lived only in source comments, so reading a panel correctly
+    depended on having read render_placement.py -- and the two colours most
+    likely to be misread are the two that matter: solid red is a BODY STACK
+    (parts physically overlapping, unfixable by any router) while a red ring is
+    a clearance shortfall (often fixable). A reader who conflates them draws
+    the wrong conclusion from the picture, which is worse than not looking.
+
+    Only the keys this panel can actually show are drawn -- a legend listing
+    arrows on a panel with no --before is itself misinformation.
+    """
+    rows = [(C_CONFLICT, 'dashed', 'pad copper off-board'),
+            (C_CONFLICT, 'ring', 'pad/hole clearance short'),
+            (C_CONFLICT, 'solid', 'BODY STACK - parts overlap'),
+            (C_HOLE, 'ring', 'NPTH keepout'),
+            (C_LOCKED, 'hatch', 'KiCad-locked (never moved)')]
+    if spec.moves:
+        rows.append((C_ARROW, 'arrow', 'moved since --before'))
+    if spec.hot_nets:
+        rows.append((C_AIR_FAIL, 'line', 'failed net'))
+    try:
+        # Overlays draw on the SUPERSAMPLED canvas, which is `ss` times the
+        # output size -- so `r.H` (the output height) put the legend at 1/ss of
+        # the way up the image, on top of the board, instead of at the bottom.
+        # The caption escapes this because _label draws on the final image.
+        ss = max(1, int(getattr(r, 'ss', 1)))
+        W, H = r.W * ss, r.H * ss
+        font = load_font(max(10, H // 78))
+        pad, sw = 6 * ss, max(10, H // 90)
+        lh = sw + 5
+        h = lh * len(rows) + 8
+        w = max(int(d.textlength(t, font=font)) for _, _, t in rows) + sw + 20
+        y0 = H - h - pad
+        d.rectangle([pad, y0, pad + w, y0 + h], fill=(0, 0, 0))
+        for i, (col, kind, text) in enumerate(rows):
+            yy = y0 + 4 + i * lh
+            box = [pad + 6, yy, pad + 6 + sw, yy + sw]
+            if kind == 'solid':
+                d.rectangle(box, fill=col)
+            elif kind == 'ring':
+                d.ellipse(box, outline=col, width=2)
+            elif kind == 'dashed':
+                for k in range(0, sw, 4):
+                    d.line([box[0] + k, box[1], box[0] + k + 2, box[1]], fill=col)
+                    d.line([box[0] + k, box[3], box[0] + k + 2, box[3]], fill=col)
+            elif kind == 'hatch':
+                d.rectangle(box, outline=col, width=1)
+                for k in range(0, sw, 3):
+                    d.line([box[0] + k, box[3], box[0] + sw, box[1] + k], fill=col)
+            elif kind == 'arrow':
+                d.line([box[0], box[3], box[2], box[1]], fill=col, width=2)
+            else:
+                d.line([box[0], (box[1] + box[3]) // 2,
+                        box[2], (box[1] + box[3]) // 2], fill=col, width=2)
+            d.text((pad + 6 + sw + 6, yy - 1), text, fill=(225, 225, 225),
+                   font=font)
+    except Exception:                                          # noqa: BLE001
+        pass          # a legend is never worth failing a render over
+
+
+def crop_findings(model, view) -> Dict[str, int]:
+    """How many legality findings lie INSIDE `view`.
+
+    A finding counts when any part it names overlaps the rect -- for a pair,
+    either member. That is deliberately inclusive: a stack half in frame is
+    still the thing the crop is showing, and undercounting it would recreate
+    the whole-board-tally problem in the other direction.
+    """
+    x0, y0, x1, y1 = view
+
+    def _hit(ref):
+        r = model.rect(ref)
+        return bool(r) and not (r[2] < x0 or r[0] > x1 or r[3] < y0 or r[1] > y1)
+
+    f = legality_findings(model)
+    out = {}
+    out['body stacks'] = sum(1 for p in f['body_overlap_pairs_refs']
+                             if _hit(p[0]) or _hit(p[1]))
+    out['pad pairs'] = sum(1 for p in f['pad_conflict_pairs_refs']
+                           if _hit(p[0]) or _hit(p[1]))
+    out['hole conflicts'] = sum(1 for p in f['hole_conflict_pairs_refs']
+                                if _hit(p[0]) or _hit(p[1]))
+    out['off-board'] = sum(1 for r, _ in (f['oob_refs_pad_copper']
+                                          + f['oob_refs_courtyard']) if _hit(r))
+    return out
+
+
+def _ref_centres(model, refs):
+    """(x, y) centre of each ref's courtyard rect, skipping refs with none."""
+    out = {}
+    for r in refs:
+        rc = model.rect(r)
+        if rc:
+            out[r] = ((rc[0] + rc[2]) / 2.0, (rc[1] + rc[3]) / 2.0)
+    return out
+
+
+def _pocket_views(model, refs, gap: float, cap: int):
+    """Spatially cluster `refs` and return [(view_rect, [ref, ...]), ...].
+
+    Reuses the same `cluster_points` / `union_view` the route-failure `--focus`
+    path uses -- the question "do these findings share one pocket or scatter"
+    is identical whether the findings are failed nets or overlapping parts, and
+    it is the question that decides local-fix vs systemic.
+    """
+    centres = _ref_centres(model, refs)
+    if not centres:
+        return []
+    inv = {}
+    for r, xy in centres.items():
+        inv.setdefault((round(xy[0], 4), round(xy[1], 4)), []).append(r)
+    out = []
+    for cl in cluster_points(list(centres.values()), gap)[:cap]:
+        v = union_view([(x, y, x, y) for x, y in cl], gap / 2)
+        members = sorted({r for x, y in cl
+                          for r in inv.get((round(x, 4), round(y, 4)), [])})
+        out.append((v, members))
+    out.sort(key=lambda t: -len(t[1]))
+    return out
+
+
+def _pair_key(entry):
+    """A finding's identity across two boards: the refs, order-independent."""
+    if len(entry) >= 2 and isinstance(entry[1], str):
+        return tuple(sorted(entry[:2]))
+    return (entry[0],)
+
+
+def describe_pair(before_model, after_model, args):
+    """What the move FIXED, what it BROKE, and what it left alone.
+
+    Two panels side by side answer "does it look different". They do not answer
+    the question a move is judged on, which is whether the specific findings
+    moved -- and a reader comparing two counts (46 stacks then 46 stacks) will
+    conclude nothing changed when in fact eleven were resolved and eleven new
+    ones appeared somewhere else. Only the by-NAME diff shows that, and it is
+    the same reason the ledger records failing nets by name rather than by
+    count.
+    """
+    b, a = legality_findings(before_model), legality_findings(after_model)
+    L, J = [], {}
+    L.append("")
+    L.append("WHAT THE MOVE DID  (findings by NAME, not by count -- a count "
+             "that stays level hides a swap)")
+    CATS = (('body stacks', 'body_overlap_pairs_refs'),
+            ('pad-clearance pairs', 'pad_conflict_pairs_refs'),
+            ('hole conflicts', 'hole_conflict_pairs_refs'),
+            ('off-board (pad copper)', 'oob_refs_pad_copper'),
+            ('off-board (courtyard)', 'oob_refs_courtyard'))
+    for label, key in CATS:
+        bs = {_pair_key(e) for e in b[key]}
+        as_ = {_pair_key(e) for e in a[key]}
+        fixed, new, kept = sorted(bs - as_), sorted(as_ - bs), sorted(bs & as_)
+        J[key] = {'fixed': ['<->'.join(k) for k in fixed],
+                  'new': ['<->'.join(k) for k in new],
+                  'kept': len(kept), 'before': len(bs), 'after': len(as_)}
+        if not (bs or as_):
+            continue
+        verdict = ('no change' if not fixed and not new
+                   else f"{len(fixed)} fixed, {len(new)} NEW, {len(kept)} kept")
+        L.append(f"  {label}: {len(bs)} -> {len(as_)}   [{verdict}]")
+        if fixed:
+            L.append("    fixed: " + ", ".join('<->'.join(k) for k in fixed[:8])
+                     + ("..." if len(fixed) > 8 else ""))
+        if new:
+            L.append("    NEW:   " + ", ".join('<->'.join(k) for k in new[:8])
+                     + ("..." if len(new) > 8 else ""))
+    net_new = sum(len(v['new']) for v in J.values())
+    net_fixed = sum(len(v['fixed']) for v in J.values())
+    J['net_fixed'], J['net_new'] = net_fixed, net_new
+    L.append("")
+    if net_new and not net_fixed:
+        L.append(f"  VERDICT: this move introduced {net_new} finding(s) and "
+                 f"resolved none.")
+    elif net_new:
+        L.append(f"  VERDICT: {net_fixed} resolved, {net_new} introduced. A "
+                 f"level count is NOT no-change -- read the names above.")
+    elif net_fixed:
+        L.append(f"  VERDICT: {net_fixed} resolved, none introduced.")
+    else:
+        L.append("  VERDICT: no legality finding changed identity.")
+    for mk, mlabel in (('crossings', 'crossings'), ('hpwl', 'hpwl mm'),
+                       ('overlap_area', 'overlap mm2')):
+        bm, am = before_model.metrics.get(mk), after_model.metrics.get(mk)
+        if bm is not None and am is not None:
+            arrow = '->' if abs(am - bm) > 1e-9 else '=='
+            J[mk] = {'before': round(bm, 4), 'after': round(am, 4)}
+            L.append(f"  {mlabel}: {bm:.2f} {arrow} {am:.2f}"
+                     + ("   (worse)" if am > bm + 1e-9 else
+                        "   (better)" if am < bm - 1e-9 else ""))
+    return "\n".join(L), J
+
+
+def describe(model, fnd, moves, args, panel_paths):
+    """Say what is IN the picture, then say what to run to see it better.
+
+    A render was being produced and not read -- across a whole campaign, once --
+    and the honest reason is that a picture answers nothing until somebody
+    forms a sentence about it. The JSON already carried the refs; nobody was
+    going to assemble them into "these 46 stacks sit in 3 pockets, the biggest
+    is around U1" by hand, every time.
+
+    So the tool does it: the findings, grouped where they physically are, with
+    the crop command for each group and the flags that clear the clutter. The
+    numbers still come from the checklist -- this narrates them, it does not
+    re-derive them.
+    """
+    L, J = [], {}
+    n_stack = len(fnd['body_overlap_pairs_refs'])
+    n_pad = len(fnd['pad_conflict_pairs_refs'])
+    n_hole = len(fnd['hole_conflict_pairs_refs'])
+    oob_pc = fnd['oob_refs_pad_copper']
+    oob_cy = fnd['oob_refs_courtyard']
+
+    L.append("WHAT THIS PANEL SHOWS")
+    if not (n_stack or n_pad or n_hole or oob_pc or oob_cy):
+        L.append("  no legality findings: nothing off the outline, no part on "
+                 "another part, no hole conflict.")
+    if oob_pc:
+        L.append(f"  {len(oob_pc)} part(s) with pad COPPER off the outline "
+                 f"(dashed red): "
+                 + ", ".join(f"{r} by {a:g}mm" for r, a in oob_pc[:8]))
+        L.append("    -> their nets cannot be routed at all; this is "
+                 "placement-shaped, not routing-shaped.")
+    if oob_cy:
+        L.append(f"  {len(oob_cy)} part(s) with COURTYARD off the outline: "
+                 + ", ".join(f"{r} by {a:g}mm" for r, a in oob_cy[:8]))
+    if n_stack:
+        L.append(f"  {n_stack} BODY STACK(S) -- pads of two parts physically "
+                 f"overlapping (solid red). Not a clearance graze; no router "
+                 f"can fix one.")
+    if n_pad:
+        L.append(f"  {n_pad} pad-clearance pair(s) (red rings).")
+    if n_hole:
+        L.append(f"  {n_hole} hole conflict(s) (orange) -- a fab blocker that "
+                 f"is not a body overlap, so `blocking` does not count it.")
+    if fnd['locked_refs']:
+        L.append(f"  {len(fnd['locked_refs'])} KiCad-LOCKED part(s) (hatched): "
+                 + ", ".join(fnd['locked_refs'][:10]))
+        L.append("    -> a search may not settle a conflict by moving the "
+                 "locked side; the OTHER part must move.")
+    if moves:
+        big = sorted(moves, key=lambda m: -m.get('dist', 0.0))[:6]
+        L.append(f"  {len(moves)} part(s) moved vs --before (yellow arrows); "
+                 f"largest: "
+                 + ", ".join(f"{m['reference']} {m.get('dist', 0.0):.2f}mm"
+                             for m in big))
+
+    # --- the WORST findings, each with a crop that frames exactly it ---------
+    #
+    # Clustering everything implicated does NOT work here and the failure is
+    # instructive: on a 50x49mm board with 54 implicated parts, single-linkage
+    # at the default 10mm gap merges them into one 42mm "pocket" -- i.e. the
+    # whole board, which is the panel you already have. A crop is only useful
+    # when it frames ONE finding, so rank by severity and frame the pair.
+    worst = []
+    for a_, b_, sf in fnd['pad_conflict_pairs_refs']:
+        worst.append((sf, 'pad-clearance', (a_, b_), f'{sf:g}mm short'))
+    for a_, b_, sf in fnd['hole_conflict_pairs_refs']:
+        worst.append((sf + 1e6, 'hole', (a_, b_), f'{sf:g}mm short'))
+    for r, amt in oob_pc:
+        worst.append((amt + 1e9, 'off-board pad copper', (r,), f'{amt:g}mm out'))
+    for r, amt in oob_cy:
+        worst.append((amt, 'off-board courtyard', (r,), f'{amt:g}mm out'))
+    _stackset = {tuple(sorted(p[:2])) for p in fnd['body_overlap_pairs_refs']}
+    worst.sort(key=lambda t: -t[0])
+
+    board = args.board
+    same = []
+    # The EFFECTIVE clearance, always -- this line's whole job is "run this and
+    # get the same numbers", and a run that omitted --clearance reproduces only
+    # if the board's project has not moved since. Naming it pins the render to
+    # a value instead of to a file that can change underneath it.
+    _clr = (model.floor_knobs.get('clearance') or {}).get('value')
+    if _clr is not None:
+        same.append(f"--clearance {_clr:g}")
+    if args.ignore_nets:
+        same.append("--ignore-nets " + " ".join(args.ignore_nets))
+    same_s = (" " + " ".join(same)) if same else ""
+
+    shots = []
+    for _sev, kind, refs, note in worst[:args.max_focus]:
+        rects = [model.rect(r) for r in refs if model.rect(r)]
+        if not rects:
+            continue
+        v = union_view(rects, 1.5, min_size=6.0)
+        stacked = tuple(sorted(refs)) in _stackset
+        shots.append({'kind': kind, 'refs': list(refs), 'note': note,
+                      'body_stack': stacked, 'view': [round(c, 3) for c in v]})
+    J['worst'] = shots
+    if shots:
+        L.append("")
+        L.append(f"THE WORST {len(shots)}, framed one per crop")
+        for i, s in enumerate(shots, 1):
+            L.append(f"  {i}. {' <-> '.join(s['refs'])}  {s['kind']}, "
+                     f"{s['note']}"
+                     + ("  [also a BODY STACK]" if s['body_stack'] else ""))
+            v = s['view']
+            L.append(f"     python3 -X utf8 py_tools/render_placement.py {board}"
+                     f" --view {v[0]},{v[1]},{v[2]},{v[3]}{same_s}"
+                     f" --no-ratsnest -o wk/worst{i}.png")
+    L.append("")
+    L.append("SEE THE WHOLE PICTURE AGAIN, uncluttered")
+    L.append(f"  python3 -X utf8 py_tools/render_placement.py {board}{same_s} "
+             f"--no-ratsnest --no-labels -o wk/clean.png")
+    L.append(f"  python3 -X utf8 py_tools/render_placement.py {board}{same_s} "
+             f"--focus -o wk/focus/    # a panel per legality pocket")
+    L.append("")
+    L.append("DECLUTTER  (add these when the panel is too busy to read)")
+    L.append("  --no-ratsnest    drop the airwires -- the biggest source of "
+             "visual noise on a dense board")
+    L.append("  --no-labels      drop ref designators (keep them on crops, "
+             "drop them board-wide)")
+    L.append("  --no-ghosts --no-arrows   drop the --before overlay when you "
+             "want the CURRENT state alone")
+    L.append("  --ratsnest-nets '<glob>'  show ONE bus instead of all of them")
+    L.append("  --per-side / --flat       split or merge the two sides")
+    if not args.ignore_nets:
+        L.append("  --ignore-nets <plane nets>  a plane-routed rail's airwire "
+                 "is a fiction; excluding it is what makes crossings/hpwl "
+                 "reproduce the optimizer's own numbers")
+    # Deliberately NOT storing the narrative text in the JSON. It is ~2kB of
+    # prose that duplicates what was just printed, and an oversized payload is
+    # the exact failure `converge record --score-file` had to be added for.
+    # The structured `worst` entries carry everything a later reader needs.
+    return "\n".join(L), J
 
 
 def caption(spec: PanelSpec, extra: Optional[Dict] = None) -> str:
@@ -646,6 +1047,21 @@ def caption(spec: PanelSpec, extra: Optional[Dict] = None) -> str:
     bits = [spec.label] if spec.label else []
     if spec.side:
         bits.append(f"side {spec.side}")
+    if spec.view:
+        # COUNT THE FINDINGS THAT ARE ACTUALLY IN THIS CROP.
+        #
+        # `spec.model.metrics` is whole-board, always -- it comes from the
+        # optimizer's model, which has no notion of a view. Labelling that
+        # "WHOLE-BOARD" was honest but not much use: a reader looking at a 19mm
+        # crop still had no idea how many of the 46 stacks were in front of
+        # them. So report both, local first, and keep the whole-board scope
+        # label on the rest.
+        v = spec.view
+        loc = crop_findings(spec.model, v)
+        local = ", ".join(f"{n} {k}" for k, n in loc.items() if n)
+        bits.append(f"CROP {v[0]:.1f},{v[1]:.1f}-{v[2]:.1f},{v[3]:.1f}mm")
+        bits.append("IN CROP: " + (local if local else "no findings"))
+        bits.append("board totals below")
     for k, fmt in (('crossings', '{:.0f}'), ('hpwl', '{:.1f}mm')):
         if m.get(k) is not None:
             bits.append(f"{k} " + fmt.format(m[k]))
@@ -738,6 +1154,11 @@ Examples:
                         'draws over an F part with no distinction)')
     _bool_pair(p, 'borders', True, 'draw component courtyards (default: on)')
     _bool_pair(p, 'labels', True, 'draw component references (default: on)')
+    _bool_pair(p, 'legend', True,
+               'draw the colour key bottom-left (default: on). The encoding '
+               'used to live only in source comments, and the two colours most '
+               'easily confused are the two that matter: solid red is a body '
+               'stack no router can fix, a red ring is a clearance shortfall.')
     _bool_pair(p, 'ratsnest', True, 'draw airwires (default: on)')
     _bool_pair(p, 'pads', True, 'draw pads (default: on)')
     _bool_pair(p, 'ghosts', True, 'draw seed rects when --before is given')
@@ -758,8 +1179,15 @@ Examples:
                    help='draw EVERY net, not just the moved/attributed ones. The '
                         'hairball switch: on a dense board this reproduces exactly '
                         'the unreadable ratsnest KiCad already shows')
-    p.add_argument('--metrics', choices=('exact', 'none'), default='exact')
-    p.add_argument('--clearance', type=float, default=None)
+    p.add_argument('--clearance', type=float, default=None,
+                   help="pad clearance in mm for the legality/halo metrics. "
+                        "DEFAULT: the board's own Default net-class clearance, "
+                        "else its min_clearance constraint, else "
+                        f"{defaults.CLEARANCE}. The effective value and its "
+                        "source are printed, and land in the JSON as "
+                        "instrument.floors -- this flag documented no default "
+                        "at all, and four renders in one run were graded at a "
+                        "clearance nothing recorded")
     # Same spelling and semantics as place_optimize's. Without it this tool
     # cannot reproduce a run's crossings/hpwl whenever the optimizer was given
     # --ignore-nets -- which is the normal case, since the plane nets have to be
@@ -779,6 +1207,25 @@ Examples:
                         '--json). A separate flag rather than an optional '
                         'argument on --json, so `--json BOARD` can never '
                         'swallow the positional (run-4 G1)')
+    p.add_argument('--pair', action='store_true',
+                   help='render the --before board AND this one as separate '
+                        'panels with byte-identical instrument settings, and '
+                        'diff their legality findings BY NAME. `--before` '
+                        'alone overlays ghosts and arrows on one panel, which '
+                        'shows what MOVED; --pair shows what the move FIXED '
+                        'and BROKE, which is what it should be judged on.')
+    p.add_argument('--no-describe', action='store_true',
+                   help='suppress the WHAT THIS PANEL SHOWS / LOOK CLOSER / '
+                        'DECLUTTER narrative. On by default: a render that '
+                        'does not say what is in it gets produced and not '
+                        'read, which is measured, not hypothetical.')
+    p.add_argument('--gate', action='store_true',
+                   help='Exit 4 when the checklist finds anything: a part off '
+                        'the outline, a pad-clearance or body-overlap pair, a '
+                        'hole conflict, or a move count that disagrees with '
+                        '--expect-moved. Default stays exit 0 -- seeing a '
+                        'broken board is this tool\'s job -- but a caller who '
+                        'wants a verdict should not have to re-read the JSON.')
     p.add_argument('--expect-moved', type=int, default=None, metavar='N',
                    help='the number of parts the step claims it moved; the '
                         "JSON checklist then carries d={moved, expected, "
@@ -786,6 +1233,52 @@ Examples:
                         'of recalled (run-4 G5)')
     p.add_argument('--quiet', action='store_true')
     return p
+
+
+def net_pattern_report(pcb, patterns, flag: str) -> dict:
+    """Did the net list this render was given actually MATCH anything?
+
+    There was no field in the `instrument` block where "61 requested, 51
+    matched" could ever appear, and that absence is exactly why a mangled net
+    list went undetected: `board_score` published `--ignore-nets` candidates
+    double-escaped, 10 of 61 matched nothing, and the render came back hpwl
+    +45.6% / crossings +129.5% on a board that had not changed. Both numbers
+    were internally consistent; the render simply scored a different net
+    population than the one asked for, and said nothing.
+
+    A pattern that matches nothing is ALWAYS worth reporting, even when it is
+    intentional (a glob written for a family of boards). The cost of the note
+    is a line; the cost of its absence was measured above.
+
+    Returns per-pattern truth, not just a total, because the total cannot name
+    the offender: `matched` is how many of the given patterns hit >= 1 net.
+    """
+    import fnmatch
+    names = [n.name for n in pcb.nets.values() if n.name]
+    pats = list(patterns or ())
+    hit = {p: sum(1 for nm in names if fnmatch.fnmatch(nm, p)) for p in pats}
+    unmatched = sorted(p for p, c in hit.items() if not c)
+    return {'flag': flag,
+            'requested': len(pats),
+            'matched': len(pats) - len(unmatched),
+            'unmatched': unmatched,
+            'nets_matched': sum(1 for nm in names
+                                if any(fnmatch.fnmatch(nm, p) for p in pats))}
+
+
+def warn_unmatched(report: dict) -> None:
+    """Say it on stderr, where a non-zero result cannot be scrolled past."""
+    if not report.get('unmatched'):
+        return
+    shown = ', '.join(repr(p) for p in report['unmatched'][:8])
+    more = '' if len(report['unmatched']) <= 8 else \
+        f" (+{len(report['unmatched']) - 8} more)"
+    print(f"WARNING: {report['flag']} -- {report['requested']} requested, "
+          f"{report['matched']} matched. These matched NO net on this board: "
+          f"{shown}{more}. The metrics below were computed over a DIFFERENT "
+          f"net population than the one you asked for. A name that is merely "
+          f"misspelled or mis-escaped is indistinguishable here from a net "
+          f"that does not exist -- check it against the board.", file=sys.stderr)
 
 
 def _load_summary(path):
@@ -837,6 +1330,16 @@ def main(argv=None):
     from placement.placement_state import gate_or_exit
     state = gate_or_exit(pcb, args.board, 'render_placement.py', warn_only=True)
 
+    # DECLARED vs MATCHED, for every net list this run was handed. Computed even
+    # when the list is empty so the fields exist unconditionally -- a key that
+    # appears only on failure is a key no reader knows to look for.
+    net_lists = {'ignore_nets': net_pattern_report(pcb, args.ignore_nets,
+                                                   '--ignore-nets'),
+                 'ratsnest_nets': net_pattern_report(pcb, args.ratsnest_nets,
+                                                     '--ratsnest-nets')}
+    for _rep in net_lists.values():
+        warn_unmatched(_rep)
+
     ignore_ids = None
     if args.ignore_nets:
         import fnmatch
@@ -844,13 +1347,60 @@ def main(argv=None):
                       if any(fnmatch.fnmatch(net.name, pat)
                              for pat in args.ignore_nets)}
         if not args.quiet:
-            print(f"Ignoring {len(ignore_ids)} nets for airwire scoring")
+            _r = net_lists['ignore_nets']
+            print(f"Ignoring {len(ignore_ids)} nets for airwire scoring "
+                  f"({_r['matched']}/{_r['requested']} patterns matched)")
 
+    # exact=True is not a default here, it is a requirement: the render path
+    # below reads `model.state` unconditionally (`state.parts`), so a stateless
+    # model raises AttributeError before anything is drawn. There used to be a
+    # `--metrics {exact,none}` flag suggesting otherwise; it was never read, and
+    # wiring it up produced exactly that crash. Removed rather than left
+    # lying -- a flag that accepts a value and changes nothing reads as a knob
+    # somebody already thought about. Making `none` real means teaching the
+    # render path to draw without a state, which is a different change.
     model = PlacementModel(pcb, args.board, exact=True,
                            quench_kwargs={'clearance': args.clearance,
                                           'ignore_net_ids': ignore_ids})
 
+    # WHICH FLOOR, and WHERE FROM -- the same disclosure board_score makes with
+    # floors.source. Four renders in the measured run omitted --clearance and
+    # nothing in their output said what was used instead.
+    if not args.quiet:
+        _k = model.floor_knobs
+        print("floors     " + ", ".join(
+            f"{n.replace('_', ' ')} {d['value']}mm [{d['source']}]"
+            for n, d in _k.items()))
+
     moves = moved_parts(parse_kicad_pcb(args.before), pcb) if args.before else []
+
+    # --pair: build a SECOND model on the before board, with byte-identical
+    # instrument settings. Same clearance, same ignored nets -- otherwise the
+    # two sets of metrics are not comparable and the delta below is fiction.
+    before_model = None
+    if args.pair:
+        if not args.before:
+            print("render_placement: --pair needs --before <the board this one "
+                  "came from>", file=sys.stderr)
+            return 2
+        _bpcb = parse_kicad_pcb(args.before)
+        _bignore = set()
+        if args.ignore_nets:
+            _bignore = {nid for nid, net in _bpcb.nets.items()
+                        if net.name and any(fnmatch.fnmatch(net.name, pat)
+                                            for pat in args.ignore_nets)}
+        # Pass the AFTER board's RESOLVED floors explicitly, rather than the
+        # unresolved --clearance. Board-first resolution reads each board's own
+        # project sibling, and the two boards need not agree: a routing chain's
+        # DRC writeback lowers the project's clearance to whatever was routed
+        # (CLAUDE.md, the fab-floor ratchet), so `before` and `after` can carry
+        # different floors and the pair would then be graded at two different
+        # clearances while claiming to be one instrument. Byte-identical
+        # settings is the whole contract of --pair.
+        _pair_floors = {n: d['value'] for n, d in model.floor_knobs.items()}
+        before_model = PlacementModel(
+            _bpcb, args.before, exact=True,
+            quench_kwargs={'ignore_net_ids': _bignore, **_pair_floors})
     failed, blockers, route_metrics = _load_summary(args.summary_json)
     prominent = {m['reference'] for m in moves} | \
         model.refs_of_nets(model.net_ids_for(failed))
@@ -921,18 +1471,51 @@ def main(argv=None):
             print("  (no back-side footprints and no B.Cu: skipping the B panel)")
 
     panels = []
+    if before_model is not None:
+        # BEFORE first, so a reader scanning the panel list sees them in the
+        # order the change happened. No ghosts/arrows on it -- it IS the ghost.
+        _bopts = dict(opts) if isinstance(opts, dict) else opts
+        for side in sides:
+            panels.append(PanelSpec(before_model, view=view, side=side,
+                                    prominent=prominent, moves=(),
+                                    hot_nets=failed, blocker_nets=blockers,
+                                    pick_nets=pick,
+                                    label=f"BEFORE {os.path.basename(args.before)}",
+                                    opts=_bopts))
     for side in sides:
         panels.append(PanelSpec(model, view=view, side=side, prominent=prominent,
                                 moves=moves, hot_nets=failed,
                                 blocker_nets=blockers, pick_nets=pick,
-                                label=tag, opts=opts))
+                                label=(f"AFTER {tag}" if before_model is not None
+                                       else tag),
+                                opts=opts))
+    _leg_pockets = []
     if args.focus and not args.summary_json:
-        # Run-4 G7: --focus derives its clusters from the summary's failed
-        # nets; without --summary-json it silently emitted one panel and
-        # nothing said why.
-        print("  WARNING: --focus emits nothing without --summary-json "
-              "(the failed-net clusters come from the route summary)",
-              file=sys.stderr)
+        # Run-4 G7 made --focus warn here, because its clusters came from the
+        # route summary's failed nets and without one it emitted a single panel
+        # and said nothing. But the same question -- one pocket or scattered --
+        # is worth asking of the LEGALITY findings, which need no route at all,
+        # and on a copper-free board that is the only version of the question
+        # available. So --focus now clusters those instead of refusing.
+        _f = legality_findings(model)
+        _hot = sorted({r for p in _f['body_overlap_pairs_refs'] for r in p[:2]}
+                      | {r for p in _f['pad_conflict_pairs_refs'] for r in p[:2]}
+                      | {r for p in _f['hole_conflict_pairs_refs'] for r in p[:2]}
+                      | {r for r, _ in _f['oob_refs_pad_copper']}
+                      | {r for r, _ in _f['oob_refs_courtyard']})
+        _leg_pockets = _pocket_views(model, _hot, args.focus_gap, args.max_focus)
+        if not _leg_pockets:
+            print("  NOTE: --focus found nothing to focus on -- no route "
+                  "summary was given and this board has no legality findings.",
+                  file=sys.stderr)
+        for i, (fview, members) in enumerate(_leg_pockets):
+            panels.append(PanelSpec(model, view=fview, side=None,
+                                    prominent=prominent, moves=moves,
+                                    hot_nets=failed, blocker_nets=blockers,
+                                    pick_nets=pick,
+                                    label=f"{tag} pocket {i + 1} "
+                                          f"({', '.join(members[:3])})",
+                                    opts=opts))
     if args.focus and failed:
         pts = model.net_points(model.net_ids_for(failed))
         for i, cl in enumerate(cluster_points(pts, args.focus_gap)[:args.max_focus]):
@@ -967,21 +1550,42 @@ def main(argv=None):
     if as_dir:
         os.makedirs(out, exist_ok=True)
     written = []
+    written_paths = set()
     stem, ext = os.path.splitext(out)
     for i, spec in enumerate(panels):
         img = render_panel(spec, size=args.size, supersample=args.supersample,
                            extra=extra)
+        # The suffix must DISTINGUISH the panel, and it only knew about `side`
+        # and the literal word "focus". So --pair with --flat gave both panels
+        # an empty suffix and the AFTER silently overwrote the BEFORE (one file
+        # where the JSON promised two), and the legality-pocket panels collided
+        # the same way because their label says "pocket". Derive it from the
+        # label, and guarantee uniqueness rather than trusting the derivation.
         suffix_bits = []
         if spec.side:
             suffix_bits.append(spec.side)
-        if 'focus' in spec.label:
+        _lab = (spec.label or '').lower()
+        if 'before' in _lab:
+            suffix_bits.append('before')
+        elif 'after' in _lab:
+            suffix_bits.append('after')
+        if 'focus' in _lab:
             suffix_bits.append(f"focus{i}")
+        elif 'pocket' in _lab:
+            suffix_bits.append(f"pocket{i}")
         if as_dir:
             path = os.path.join(out, "_".join([tag] + suffix_bits) + ".png")
         elif multi_file:
             path = stem + "".join("_" + s for s in suffix_bits) + (ext or '.png')
         else:
             path = out
+        if multi_file or as_dir:
+            _base, _e = os.path.splitext(path)
+            _n = 2
+            while path in written_paths:
+                path = f"{_base}_{_n}{_e}"
+                _n += 1
+        written_paths.add(path)
         img.save(path)
         written.append(path)
         if not args.quiet:
@@ -1010,9 +1614,22 @@ def main(argv=None):
                 'before': os.path.abspath(args.before) if args.before else None,
                 'summary_json': (os.path.abspath(args.summary_json)
                                  if args.summary_json else None),
-                'clearance': args.clearance,
+                # `clearance` used to record args.clearance, i.e. None on
+                # every run that did not pass the flag -- so the document
+                # named no clearance at all for the runs most likely to be
+                # graded at the wrong one. It is now the EFFECTIVE value,
+                # with what was requested and where it came from beside it.
+                'clearance': model.floor_knobs.get(
+                    'clearance', {}).get('value'),
+                'clearance_requested': args.clearance,
+                'floors': model.floor_knobs,
                 'ignore_nets': sorted(args.ignore_nets or []),
                 'ratsnest_nets': sorted(args.ratsnest_nets or []),
+                # DECLARED vs MATCHED. Without these there was no field in
+                # this document where "61 requested, 51 matched" could
+                # appear, so a net list that silently missed had to be
+                # checked by hand, outside the tool -- and was not.
+                'net_lists': net_lists,
                 'size': args.size, 'supersample': args.supersample,
             },
             # Mandate 8's four questions, quotable (run-4 G5). Channels are
@@ -1038,10 +1655,53 @@ def main(argv=None):
             },
             'unplaced': state.unplaced, 'no_outline': model.no_outline,
         }
+        if not args.no_describe:
+            _txt, _dj = describe(model, legality_findings(model), moves, args,
+                                 [p['path'] for p in doc['panels']])
+            doc['describe'] = _dj
+            print()
+            print(_txt)
+            if before_model is not None:
+                _ptxt, _pj = describe_pair(before_model, model, args)
+                doc['pair'] = _pj
+                print(_ptxt)
         if args.json_out:
             with open(args.json_out, 'w', encoding='utf-8') as f:
                 json.dump(doc, f, indent=2, sort_keys=True, default=str)
         print("JSON_SUMMARY: " + json.dumps(doc, sort_keys=True, default=str))
+        if args.gate:
+            # Opt-in verdict. The default stays 0 on purpose -- SEEING an
+            # unplaced or broken board is this tool's job, and a renderer that
+            # refuses to render one is useless. But the checklist could report
+            # off-board parts, body stacks and hole conflicts while the tool
+            # exited 0, so a caller who wanted a verdict had to re-implement the
+            # reading. --gate makes the picture's own findings decide.
+            _fail = {
+                'a_off_outline.pad_copper':
+                    len(doc['checklist']['a_off_outline']['pad_copper']),
+                'a_off_outline.courtyard':
+                    len(doc['checklist']['a_off_outline']['courtyard']),
+                'b_pad_clearance_pairs':
+                    len(doc['checklist']['b_pad_clearance_pairs']),
+                'b_body_overlap_pairs':
+                    len(doc['checklist']['b_body_overlap_pairs']),
+                'c_hole_conflicts':
+                    len(doc['checklist']['c_hole_conflicts']),
+            }
+            _hit = {k: v for k, v in _fail.items() if v}
+            _moved = doc['checklist']['d_moved']
+            if _moved.get('match') is False:
+                _hit['d_moved'] = (f"moved {_moved.get('moved')} != expected "
+                                   f"{_moved.get('expected')}")
+            if _hit:
+                print("GATE: FAIL -- " + '; '.join(f'{k}={v}'
+                                                   for k, v in _hit.items()),
+                      file=sys.stderr)
+                return 4
+            print("GATE: PASS -- checklist a/b/c clear"
+                  + ("" if _moved.get('match') is None
+                     else f", moved {_moved.get('moved')} as expected"),
+                  file=sys.stderr)
     return 0
 
 

--- a/tests/gui_parity/test_geometry_floor_leak.py
+++ b/tests/gui_parity/test_geometry_floor_leak.py
@@ -122,6 +122,8 @@ def main():
             bad.append((n, f"leaked: board {board_vals[n]} but resolves {got} "
                            f"after a reset (CLI would use {board_vals[n]})"))
 
+    bad += _declared_zero_is_unset(dlg)
+
     print(f"board: {os.path.basename(board_path)}")
     for n in FLOORS:
         print(f"  {n:26s} board={board_vals[n]:<8} "
@@ -130,6 +132,77 @@ def main():
     for n, why in bad:
         print(f"    {n}: {why}")
     return 1 if bad else 0
+
+
+def _declared_zero_is_unset(dlg):
+    """A board declaring 0 must be UNSET on this side too, as on the CLI.
+
+    `_effective_geometry_floor`'s unchecked branch took the board value on
+    `is not None` alone. KiCad writes 0 into these fields for "not
+    configured", and every other resolver in the tree treats that as unset --
+    list_nets.board_floor, board_floor_knobs, resolve_cli_floor, and
+    `_effective_plane_edge_clearance` ten lines above it, which already
+    guarded `> 1e-9`. This branch did not.
+
+    It is MASKED in the default fab tier: `_fab_floored` pins a 0.0 up to the
+    0.20 fab hole-to-hole floor, and the CLI lands on 0.20 as well, so the two
+    agree by accident. Move the fab floor and they stop agreeing. With a
+    fab-overrides declaring hole_to_hole 0.10 -- reachable from the GUI via the
+    fab_tier / fab_overrides_path controls, and collapsing fab_floor_ladder to
+    that single hard rung -- a board declaring 0.0 gave GUI 0.10 against CLI
+    0.20: the GUI drilling twice as close as the CLI on the same board.
+
+    Driven through the REAL dialog rather than a mirrored config, per the
+    CLAUDE.md note that hand-mirrored parity maps silently drift.
+    """
+    import tempfile
+    from kicad_routing_plugin import swig_gui
+    out = []
+    # Force the "board declares 0.0" case without needing such a board.
+    real = swig_gui._get_board_minimum_constraints
+    swig_gui._get_board_minimum_constraints = lambda *a, **k: {
+        'min_hole_to_hole': 0.0}
+    saved_path = dlg.fab_overrides_path.GetValue()
+    tmp = tempfile.mkdtemp()
+    ovr = os.path.join(tmp, 'fine.fab')
+    with open(ovr, 'w', encoding='utf-8') as f:
+        f.write("# a fab that really can drill closer\n"
+                "hole_to_hole = 0.10\n")
+    try:
+        # 1. Default tier: both sides land on the 0.20 fab floor, which is why
+        #    this divergence is invisible until the fab floor moves.
+        got_default = dlg._effective_geometry_floor('hole_to_hole_clearance')
+        if abs(got_default - 0.20) > 1e-9:
+            out.append(('hole_to_hole_clearance',
+                        f"declared 0.0 at the default tier resolves "
+                        f"{got_default}, expected the 0.20 fab floor"))
+        # 2. The unmasking case, driven through the REAL control a user sets:
+        #    an override FILE lowering the fab hole-to-hole floor to 0.10.
+        #    _fab_floor_for_ctrl reads fab_overrides_path and parses it, so
+        #    set_default_fab_tier alone does NOT reach this path.
+        dlg.fab_overrides_path.SetValue(ovr)
+        floor = dlg._fab_floor_for_ctrl('hole_to_hole_clearance')
+        if floor is None or abs(floor - 0.10) > 1e-9:
+            out.append(('<fixture>',
+                        f"the override file did not lower the fab floor "
+                        f"(got {floor}); this check would prove nothing"))
+        got = dlg._effective_geometry_floor('hole_to_hole_clearance')
+        # The CLI resolves 0.2 here: board_floor calls a declared 0.0 unset and
+        # falls back to HOLE_TO_HOLE_CLEARANCE 0.2, which enforce_fab_floors
+        # only ever raises.
+        if abs(got - 0.20) > 1e-9:
+            out.append(('hole_to_hole_clearance',
+                        f"declared 0.0 under a 0.10 fab override resolves "
+                        f"{got}; the CLI resolves 0.2, so the GUI would drill "
+                        f"{0.2 / got:.1f}x closer on the same board"))
+        print(f"  declared-0.0 hole_to_hole, fab floor {floor} -> GUI {got} "
+              f"(CLI 0.2)")
+    finally:
+        swig_gui._get_board_minimum_constraints = real
+        dlg.fab_overrides_path.SetValue(saved_path)
+        import shutil
+        shutil.rmtree(tmp, ignore_errors=True)
+    return out
 
 
 if __name__ == '__main__':

--- a/tests/run_all.py
+++ b/tests/run_all.py
@@ -76,7 +76,7 @@ def main():
               f'({sum(is_integration(f) for f in tests)} integration).')
         return 0
 
-    passed, failed, skipped = [], [], []
+    passed, failed, skipped, timed_out = [], [], [], []
     t0 = time.time()
     for f in tests:
         name = os.path.basename(f)
@@ -85,11 +85,22 @@ def main():
             print(f'SKIP  {name}  (integration; --fast)')
             continue
         try:
-            r = subprocess.run([sys.executable, f], cwd=ROOT,
-                               capture_output=True, text=True, timeout=args.timeout)
+            # `text=True` alone decodes with the LOCALE default (cp1252 on
+            # Windows) and raises UnicodeDecodeError in the reader thread the
+            # moment any child prints a byte it cannot decode -- a degree sign,
+            # an ohm, a micro. That killed the whole runner mid-suite with a
+            # threading traceback and NO summary, which reads as "the tests
+            # crashed" rather than "the runner cannot read them". Every other
+            # subprocess call in this repo already pins utf-8 + replace.
+            r = subprocess.run([sys.executable, '-X', 'utf8', f], cwd=ROOT,
+                               capture_output=True, text=True,
+                               encoding='utf-8', errors='replace',
+                               timeout=args.timeout)
         except subprocess.TimeoutExpired:
             failed.append(name)
-            print(f'FAIL  {name}  (timeout after {args.timeout:.0f}s)')
+            timed_out.append(name)
+            print(f'TIME  {name}  (timeout after {args.timeout:.0f}s -- NOT a '
+                  f'failed assertion; re-run it alone before treating it as one)')
             continue
         if r.returncode == 0:
             passed.append(name)
@@ -100,10 +111,22 @@ def main():
             print(f'FAIL  {name}  (exit {r.returncode})\n{tail}')
 
     dt = time.time() - t0
-    print(f'\n{len(passed)} passed, {len(failed)} failed, {len(skipped)} skipped '
-          f'in {dt:.1f}s')
-    if failed:
-        print('Failed: ' + ', '.join(failed))
+    # A TIMEOUT AND A FAILED ASSERTION ARE DIFFERENT FACTS, and the summary used
+    # to render them identically -- one `failed` list, one "N failed" count. A
+    # clean baseline run reported "336 passed, 8 failed"; two of those eight
+    # were slow integration tests that PASS when run alone with headroom, and
+    # finding that out took a manual re-run of each. Anyone comparing a run
+    # against a recorded baseline needs the split, because a timeout moving in
+    # or out of the list is a machine-speed fact, not a code fact.
+    _real = [n for n in failed if n not in timed_out]
+    print(f'\n{len(passed)} passed, {len(_real)} failed, '
+          f'{len(timed_out)} timed out, {len(skipped)} skipped in {dt:.1f}s')
+    if _real:
+        print('Failed: ' + ', '.join(_real))
+    if timed_out:
+        print(f'Timed out at {args.timeout:.0f}s: ' + ', '.join(timed_out))
+        print('  A timeout is not evidence of a broken test. Re-run each one '
+              'alone (or raise --timeout) before recording it as a failure.')
     return 1 if failed else 0
 
 

--- a/tests/run_utils.py
+++ b/tests/run_utils.py
@@ -29,3 +29,106 @@ def run(cmd: str, unbuffered: bool = False) -> None:
     result = subprocess.run(args, cwd=ROOT_DIR)
     if result.returncode != 0:
         print(f"Command failed with exit code {result.returncode}")
+
+
+# ---------------------------------------------------------------------------
+# Refusal assertions -- "it failed" is not "it failed for the reason I meant"
+# ---------------------------------------------------------------------------
+#
+# A NEGATIVE CONTROL THAT CANNOT DISTINGUISH ITS OWN BREAKAGE FROM THE DEFECT IT
+# TESTS WILL EVENTUALLY REPORT A FALSE CLEAN. This is the same defect class the
+# tools themselves keep exhibiting -- an instrument that can fail two ways and
+# reports one -- and it is easier to hit in a test, because a test's failure
+# path is the path nobody looks at.
+#
+# Observed, all in one session, every one reporting "the guard held" or "the
+# feature is absent" when neither was true:
+#
+#   * a negative control exited 1 from a ModuleNotFoundError (the copy under
+#     test lived in a temp dir with no sys.path entry) -- read as "the gate
+#     refused";
+#   * a probe called a function name that does not exist and reported the
+#     feature missing;
+#   * evidence passed as `<(echo '{...}')`, whose fd is gone by the time a
+#     Windows child opens it -- read as "the stage never mentions it";
+#   * a section splitter matched the wrong header and reported zero mentions;
+#   * an assertion that `--deadline 0` must always produce a partial, which is
+#     false on a board with no work to abandon.
+#
+# `must_refuse` separates the two outcomes. An ACCIDENT (import error,
+# traceback, argparse usage, missing file) is reported as a BROKEN TEST, never
+# as a satisfied guard.
+
+_ACCIDENTS = (
+    'Traceback (most recent call last)', 'ModuleNotFoundError', 'ImportError',
+    'SyntaxError', 'IndentationError', 'NameError', 'AttributeError',
+    'No such file or directory', 'unrecognized arguments',
+    'error: argument', 'command not found', 'Errno 2',
+)
+
+
+def _accident(out: str):
+    for a in _ACCIDENTS:
+        if a in out:
+            return a
+    return None
+
+
+def check(argv, *, refuse=None, code=None, accept=False, timeout=900,
+          cwd=None, allow=()):
+    """Run `argv`; assert it refused FOR THE STATED REASON, or accepted.
+
+    refuse : substring the refusal must contain -- the reason, not just failure.
+    code   : exact exit code, when the contract names one.
+    accept : assert success instead (exit 0 and no traceback).
+    allow  : accident substrings that are legitimate here (e.g. a test that
+             deliberately feeds a bad argument and wants argparse's message).
+
+    Returns the CompletedProcess. Raises AssertionError with the output on any
+    mismatch -- including a failure that happened for an unrelated reason,
+    which is reported as a broken test rather than a passing assertion.
+    """
+    r = subprocess.run([str(a) for a in argv], capture_output=True, text=True,
+                       encoding='utf-8', errors='replace',
+                       cwd=cwd or ROOT_DIR, timeout=timeout)
+    out = (r.stdout or '') + (r.stderr or '')
+    tail = out[-1200:]
+    acc = _accident(out)
+    if acc and acc not in allow:
+        raise AssertionError(
+            f"BROKEN TEST, not a satisfied guard: the command died from "
+            f"{acc!r}, which is unrelated to what this check asserts. "
+            f"A control that cannot tell its own breakage from the defect it "
+            f"tests reports a false clean.\n  argv: {argv}\n{tail}")
+    if accept:
+        if r.returncode != 0:
+            raise AssertionError(f"expected success, got exit "
+                                 f"{r.returncode}\n  argv: {argv}\n{tail}")
+        return r
+    if r.returncode == 0:
+        raise AssertionError(f"expected a REFUSAL, got exit 0 -- the guard did "
+                             f"not hold\n  argv: {argv}\n{tail}")
+    if code is not None and r.returncode != code:
+        raise AssertionError(f"expected exit {code}, got {r.returncode}\n"
+                             f"  argv: {argv}\n{tail}")
+    if refuse and refuse not in out:
+        raise AssertionError(
+            f"it failed, but NOT for the stated reason. Expected the output to "
+            f"mention {refuse!r}.\n  argv: {argv}\n{tail}")
+    return r
+
+
+def evidence(path, what='evidence'):
+    """Assert a file exists and is non-empty BEFORE it is used as input.
+
+    The `<(echo ...)` process-substitution trap: the fd is gone by the time a
+    native Windows child opens it, so the stage refuses for a reason that has
+    nothing to do with what is being tested, and the test reads that refusal as
+    its answer. Materialise evidence to a real file and check it here.
+    """
+    if not os.path.isfile(path):
+        raise AssertionError(f"{what} does not exist: {path} -- a check whose "
+                             f"INPUT is missing tests nothing")
+    if os.path.getsize(path) == 0:
+        raise AssertionError(f"{what} is empty: {path}")
+    return path

--- a/tests/stress/RUNBOOK.md
+++ b/tests/stress/RUNBOOK.md
@@ -787,6 +787,20 @@ anyone run it, run 14 would have picked a different board or expected the
 redraw. `stage_blind` now redraws by itself, but that only rescues an unlucky
 draw; it cannot rescue an unsuitable board.
 
+### 1b. Choose damage kinds the fence can adjudicate
+
+A qualified board can still stage an **undecidable** run: on a grid-homed
+board, `swap` and `translate` recovery is byte-identical to the truth board
+BY CONSTRUCTION — every displaced part's home pose is a grid point any honest
+search also lands on, so a perfect result and a truth-file LEAK produce the
+same bytes and the fence cannot tell them apart (run 18's undecidable LEAK
+verdict). Before staging, pick from `KINDS` (`placement/perturb.py:56` —
+`translate`, `wrong_side`, `swap`, `scatter`, `pile`) with the fence in mind:
+on grid-homed boards prefer `pile`/`scatter`, whose recovered poses carry no
+byte-identity shortcut, or pre-declare the secondary tell (which independent
+measurement will separate an honest recovery from a leak) BEFORE the damage
+is drawn. A tell declared after the result is an accusation, not a fence.
+
 ### 2. Run a positive control first
 
 The series has no control arm, so every null is ambiguous between "the placer

--- a/tests/stress/RUNBOOK.md
+++ b/tests/stress/RUNBOOK.md
@@ -733,3 +733,168 @@ they interoperate with `--compare` and `--regrade`.
 - **Wave dirs are write-once** (`ab_<what>_MMDD` + same-day `a`/`b`/`c`): re-running
   into an existing dir reads back the sibling `.kicad_pro` DRC floor and silently
   changes the routing — it looks like non-determinism but isn't.
+
+## Choosing a subject BEFORE you stage it (read this first)
+
+Four perturbed-corpus runs have posted a recovery near zero, and only one of
+them (run 8, the corner-only slot model) was the placer's fault. Run 7 was a
+wrong basin, run 9 was three tools failing to terminate, run 14 was a dose
+clipped to 0.100 mm. **Three of the four were the measurement rig, and each one
+cost an hour of chain time to discover.** Most of that is avoidable, because the
+questions are cheap to ask up front and nobody was asking them.
+
+### 0. You need UNROUTED candidates, and the corpus is nearly empty
+
+`boards_unrouted_set1/` currently holds exactly one board. Qualify against
+unrouted twins, not against `boards_set1/`: a routed board is refused by
+`placement_driver --stage P0`, and its copper encodes the original poses (run 14
+measured 301 of 569 pads sitting within 5 um of their own track endpoint, which
+`fence_audit` cannot see because it compares poses and never opens copper).
+
+```bash
+python3 -X utf8 tests/stress/strip_copper_only.py \
+    $STRESS/boards_set1/<name>.kicad_pcb $STRESS/boards_unrouted_set1/<name>.kicad_pcb
+```
+
+**Do NOT use `strip_routing.py` or `prep_set2.py` for this.** They are corpus
+normalizers and they rewrite `Edge.Cuts`, so the subject would no longer share an
+outline with the human reference it is graded against. `strip_copper_only.py`
+drops exactly four form types (top-level `segment`, `arc`, `via`, and
+`filled_polygon` inside zones) and leaves poses, pads, zones, stackup and outline
+untouched; verified on castor_pollux, 14241 segments and 358 vias to zero with an
+identical pose digest and identical bounds.
+
+### 1. Qualify the board (seconds, not an hour)
+
+```bash
+python3 -X utf8 tests/stress/qualify_subject.py \
+    $STRESS/boards_unrouted_set1/*.kicad_pcb --draws 8
+```
+
+It perturbs to a temp dir, grades copper-free, and prints aggregates only (rates
+and medians, never the kind, block, seed or direction), so it is safe to run on a
+board you then intend to stage blind. Three verdicts:
+
+| verdict | meaning |
+|---|---|
+| `REJECT` | the rig cannot damage this board. Draws clip to nothing, so `recovery` and `home /N` will read near-perfect whatever the run does. |
+| `WEAK` | usable, but a coin flip decides whether the run gets a subject. Redraw and never assume the dose landed. |
+| `GOOD` | the dose lands nearly every time AND the copper-free gates fire. Only this is a subject. |
+
+Run 14's board scores **WEAK** on this test (6 of 8 draws land; applied dose
+ranges 0.100 to 57.2 mm, and the 0.100 is the draw the run actually got). Had
+anyone run it, run 14 would have picked a different board or expected the
+redraw. `stage_blind` now redraws by itself, but that only rescues an unlucky
+draw; it cannot rescue an unsuitable board.
+
+### 2. Run a positive control first
+
+The series has no control arm, so every null is ambiguous between "the placer
+failed" and "the rig failed". **tigard is the known positive**: run 3 delivered
+recovery +0.133 with 26 of 51 parts home. Re-run it whenever the rig changes.
+If it reproduces, a null elsewhere means something. If it does not, you have
+found the next rig bug for the price of a board you already understand.
+
+### 3. Confirm the damage actually threatens ROUTABILITY
+
+`qualify_subject.py` stops at the copper-free gates because routing is the
+expensive half. The question it cannot answer is the one that decides whether a
+placement run can succeed at all:
+
+```bash
+# the original must route ...
+python3 -X utf8 py_router/route.py <control>.kicad_pcb /tmp/ctl.kicad_pcb --nets "*" --deadline 900
+python3 -X utf8 py_router/check_connected.py /tmp/ctl.kicad_pcb
+# ... and the damaged one must NOT
+python3 -X utf8 py_router/route.py <staged>.kicad_pcb  /tmp/dmg.kicad_pcb --nets "*" --deadline 900
+python3 -X utf8 py_router/check_connected.py /tmp/dmg.kicad_pcb
+```
+
+**A placement-focused subject is one where a material dose makes the board
+unroutable and recovery makes it routable again.** That is falsifiable, it is
+what the tool is actually for, and it is the doctrine's own metric: lead on
+`blocking`, keep `recovery` as a diagnostic. On run 14 the damaged board routed
+to `blocking 0` unaided, which means the placement half had nothing to prove
+even before the dose was found to be 0.1 mm.
+
+### 4. Do not pay for a full route per trial
+
+Placement science needs many trials; a full chain costs about an hour and most
+of that is routing that tells you nothing new. Grade trials with the copper-free
+battery plus `tests/test_placement_probe.py`, which scopes the route CAUSALLY
+(the nets `net_affinity` flagged plus the declared corridor nets, fixed from the
+OFF board) rather than by which parts moved. Scoping by moved parts is circular:
+a term that moves nothing scores a perfect null. Run the full chain once, at the
+end, on the arm you intend to keep.
+
+### 5. Report shape
+
+Lead with `blocking`. Report `recovery` and `home /N` as diagnostics, and state
+the applied dose next to them every time, because a recovery number without the
+dose that produced it is uninterpretable. `collateral_pad_rms` is the one
+recovery figure that signals a real defect: it means parts nothing had damaged
+were moved (run 9: 0.000 to 1.171 mm; run 10: 0.000 to 3.670 mm).
+
+## Staging a perturbed subject (#411 recovery rig)
+
+A recovery experiment measures how close a repaired placement lands to the
+original, and that number means nothing if the tools could have read the
+original. So the staging has exactly one rule:
+
+**Ground truth never enters the work dir. Stage it into a SIBLING `_truth/`
+from the start, and audit by CONTENT before the run.**
+
+```
+wk/<run>/<subject>/         <- THE WORK DIR. every tool runs here.
+    board.kicad_pcb         <- the damaged board, the only input
+wk/<run>/_truth/<subject>/  <- fenced, OUTSIDE the work dir. nothing reads it.
+    control.kicad_pcb       <- the human placement, pose for pose
+    board.perturb.json      <- the record: it embeds `original_poses`
+```
+
+`placement.perturb.perturb(..., control_out=...)` puts both there in one call —
+the record follows the control — and prints where each landed:
+
+```python
+P.perturb(src, 'wk/run12/tigard/board.kicad_pcb',
+          kind=kind, dose_mm=dose, seed=seed,
+          control_out='wk/run12/_truth/tigard/control.kicad_pcb')
+```
+
+**Omitting `control_out` is the unsafe default and is kept only for
+compatibility.** It writes `<out>.control.kicad_pcb` beside the damaged board —
+the human placement, inside the directory the run then works in, where any glob
+or `--before` can reach it. `perturb()` prints a WARNING when it does this;
+`tests/stress/perturb_batch.py` shows the fenced form (`_truth/` a sibling of
+the dose cells).
+
+Audit before the run and again after, by content, never by name:
+
+```bash
+python3 -X utf8 tests/stress/fence_audit.py \
+    --control wk/run12/_truth/tigard/control.kicad_pcb \
+    --workdir wk/run12/tigard --mode create        # exit 4 == a leak
+# ... the run ...
+python3 -X utf8 tests/stress/fence_audit.py \
+    --control wk/run12/_truth/tigard/control.kicad_pcb \
+    --workdir wk/run12/tigard --mode audit
+```
+
+`--mode create` writes `.fence-manifest.json`, which is what later tells a
+*recovered* board (produced by the run, reaching truth — the experiment
+succeeding) apart from a *leaked* one (present at creation). There is no
+name-based exemption for `*.control.kicad_pcb`: a control inside the work dir is
+a leak whatever it is called, because the next carrier will have a different
+name.
+
+**And none for `*.perturb.json` either — `DEFAULT_ALLOW` is empty.** The audit
+now opens `.json` files and reads `original_poses` out of them, so a
+perturbation record is caught by content like anything else. That exemption
+existed while the scan walked only `.kicad_pcb`, i.e. while it exempted a file
+the tool could not open; making the scan live turned it into a working blind
+spot. This is the *default* path, not a corner case — `perturb()` without
+`control_out` writes the record beside the damaged board, inside the fence, and
+that record embeds the human placement pose-for-pose. Stage with `control_out=`
+pointing at a **sibling** `_truth/` (never a child of the work dir — the audit
+recurses into it) and neither file ever enters. The record test reads bytes, so
+re-saving it as UTF-16 does not evade it.

--- a/tests/stress/arm_report.py
+++ b/tests/stress/arm_report.py
@@ -1,0 +1,536 @@
+#!/usr/bin/env python3
+"""The recovery table, measured — not assembled by hand.
+
+    python3 -X utf8 tests/stress/arm_report.py <workdir> --result <board> \
+        [--human <the original routed board>] [--out REPORT.md]
+
+Emits one table, one row per version of the board:
+
+    | run | recovery | home /N | vias | copper mm | buildable |
+
+Every number comes from the instrument that owns it. That is the whole point:
+the last run's table was written by hand and three of its numbers were wrong in
+the flattering direction — pad CENTRES quoted as pad copper (so every excursion
+was understated and the fourth off-board part vanished from a list the same
+paragraph counted as four), three of six unrepairable parts quoted, and a stop
+condition claimed with two of five laps used.
+
+TRUTH OPENS AT ONE POINT, and it is marked below. Everything before it reads
+only the boards in the work dir. The control's poses arrive inside the perturb
+record (`original_poses`), which is why the fence forbids that file to the run
+itself and allows it here.
+
+Two rules inherited from `placement/recovery.py`, both of which the previous
+arm broke:
+
+  * displacement is measured in PAD space, not between footprint origins. A
+    part rotated in place moves its origin 0.00 mm and its pads up to 49 mm,
+    so an origin-distance "home" count reports a rotated part as home. The
+    correct value is already computed by `displacement_to_original`.
+  * `N` is the FROZEN perturbed member list, never re-derived from the board.
+    Re-deriving it scores a different set of parts at every dose.
+
+Exit: 0 wrote the report, 2 usage/missing inputs.
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+os.chdir(ROOT)
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_placer'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_tools'))  # #522/py_placer layout
+os.environ.setdefault('KRT_NO_BANNER', '1')
+
+SKILL_SCRIPTS = os.path.join(ROOT, '.claude', 'skills', 'plan-pcb-routing',
+                             'scripts')
+PY = [sys.executable, '-X', 'utf8']
+
+
+def _run(args, timeout=1800):
+    p = subprocess.run(PY + args, capture_output=True, text=True,
+                       encoding='utf-8', errors='replace', cwd=ROOT,
+                       timeout=timeout)
+    return p.returncode, (p.stdout or '') + (p.stderr or '')
+
+
+def quality(board):
+    """vias / copper_mm / segments, from board_score's own helper."""
+    sys.path.insert(0, SKILL_SCRIPTS)
+    try:
+        import board_score
+        return board_score.quality(board)
+    except Exception as exc:                                # noqa: BLE001
+        return {'error': f'{type(exc).__name__}: {exc}'}
+
+
+def blocking(board, clearance, tmp):
+    """board_score's `blocking_by`, i.e. the ROUTED OUTCOME with its work list.
+
+    `unrouted` and `broken` are the two numbers the objective is stated in, and
+    this report has never printed either. Its `vias`/`copper_mm` columns are
+    board_score's `quality`, which that tool's own doctrine says is a tiebreak
+    comparable ONLY once `blocking == 0` -- so the two routing-looking columns
+    were the two that mean nothing until the number nobody printed is zero."""
+    jp = os.path.join(tmp, os.path.basename(board) + '.score.json')
+    args = [os.path.join(SKILL_SCRIPTS, 'board_score.py'), board,
+            '--clearance', str(clearance), '--json', jp]
+    code, out = _run(args)
+    if not os.path.isfile(jp):
+        return {'error': f'board_score exit {code}', 'log': out[-300:]}
+    with open(jp, encoding='utf-8') as fh:
+        doc = json.load(fh)
+    return {'blocking': doc.get('blocking'),
+            'by': doc.get('blocking_by') or {},
+            'ungraded': doc.get('ungraded') or [],
+            'unrouted_shape': (doc.get('components') or {}).get('unrouted', {}),
+            'quality': doc.get('quality') or {}}
+
+
+def route(board, record, clearance, tmp):
+    """PRR / RR over the FROZEN denominators -- the continuous channel.
+
+    `score_board`'s `route` block has existed, been tested and been DEAD since
+    it was written: `routed_path` has never once been supplied by any caller
+    (`perturb.py:556`, `perturb_batch.py:313,342`), so every record ever
+    written carries `route: {ran: False}`. The result board IS the routed
+    board, so `routed_path` is simply the board being reported on.
+
+    It is printed BESIDE `unrouted`/`broken`, never instead of them: they
+    disagree by construction (check_connected skips nets with no copper at all;
+    connectivity_tally keeps them in the denominator) and the gap is
+    informative. A counts-only headline also cannot tell "one net short" from
+    "half the board", which is exactly the distinction a recovery run needs."""
+    from placement import recovery as R
+    from kicad_parser import parse_kicad_pcb
+    try:
+        jp = os.path.join(tmp, os.path.basename(board) + '.drc.json')
+        _run(['py_router/check_drc.py', board, '--clearance', str(clearance),
+              '--json', jp])
+        dirty = R.dirty_net_ids(parse_kicad_pcb(board), jp)
+        return R.score_board(board, record, routed_path=board,
+                             dirty_nets=dirty).get('route') or {}
+    except Exception as exc:                                   # noqa: BLE001
+        return {'ran': False, 'reason': f'{type(exc).__name__}: {exc}'}
+
+
+def buildable(board, clearance, tmp):
+    """check_assembly's own verdict, read from its JSON rather than its text."""
+    jp = os.path.join(tmp, os.path.basename(board) + '.assembly.json')
+    code, out = _run(['py_tools/check_assembly.py', board, '--clearance',
+                      str(clearance), '--json', jp])
+    if not os.path.isfile(jp):
+        return {'error': f'check_assembly exit {code}', 'log': out[-300:]}
+    with open(jp, encoding='utf-8') as fh:
+        doc = json.load(fh)
+    # `buildable`/`verdict` are keys now; recompute only for an older JSON, and
+    # say so rather than silently disagreeing with the tool.
+    if 'buildable' not in doc:
+        doc['buildable'] = not (doc.get('blocking')
+                                or doc.get('locked_contact_pairs'))
+        doc['verdict'] = 'derived (tool predates the verdict key)'
+    return doc
+
+
+def _collateral_refs(damaged, result, members, tol=0.05):
+    """[(ref, pad_mm, rot_delta)] for parts OUTSIDE the block that moved.
+
+    `collateral_pad_rms` has been computed since this module existed and read
+    by nothing, and when runs 9 and 10 finally printed it, it was a bare
+    scalar. On run 10 it was the ONLY instrument that saw the run tear two
+    members out of a geometrically perfect 8-fold LED ring -- and it said
+    `3.6697`, with no name attached, so nobody could act on it. A number
+    without a work list is not an instrument.
+
+    IN PAD SPACE, via `recovery.part_displacement`, which is the same measure
+    the scalar aggregates -- so the names and the number are in one currency,
+    and a part rotated in place (origin moves 0.00 mm, pads move plenty) is not
+    silently reported as unmoved. Hand-rolling an origin distance here is the
+    exact defect `tests/test_run9_arm_report.py` forbids by name.
+
+    Measured against the DAMAGED board, not the control: these are parts the
+    damage never touched, so their damaged pose IS their original one, and
+    reading it needs no access to truth.
+    """
+    from placement import recovery as R
+    from kicad_parser import parse_kicad_pcb
+    try:
+        a, b = parse_kicad_pcb(damaged), parse_kicad_pcb(result)
+    except Exception:                                          # noqa: BLE001
+        return []
+    was, now = R.board_poses(a), R.board_poses(b)
+    block = set(members or ())
+    out = []
+    for ref, pose in sorted(now.items()):
+        base = was.get(ref)
+        fp = (b.footprints or {}).get(ref)
+        if base is None or fp is None or ref in block:
+            continue
+        d = R.part_displacement(fp, pose, base)
+        dr = (pose[2] - base[2]) % 360.0
+        dr = dr - 360.0 if dr > 180.0 else dr
+        if d > tol or abs(dr) > 0.5:
+            out.append((ref, d, dr))
+    return sorted(out, key=lambda t: -t[1])
+
+
+def _fmt(v, nd=2):
+    if v is None:
+        return '—'
+    if isinstance(v, float):
+        return f'{v:.{nd}f}'
+    return str(v)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('workdir')
+    ap.add_argument('--result', required=True,
+                    help='the board this run produced')
+    ap.add_argument('--control', default=None,
+                    help='the control board (default: the sibling '
+                         '<workdir>/../_truth/, else .../_truth/<subject>/, '
+                         'else the legacy <workdir>/) -- used for the fence '
+                         'audit only; the poses come from the perturb record')
+    ap.add_argument('--record', default=None,
+                    help='the perturb record (same search as --control; '
+                         'a record found INSIDE the work dir is a fence leak '
+                         'and the audit below will say so)')
+    ap.add_argument('--damaged', default=None,
+                    help='the damaged input (default <workdir>/'
+                         'perturbed.kicad_pcb)')
+    ap.add_argument('--human', default=None,
+                    help='the original ROUTED board, for the reference row')
+    ap.add_argument('--clearance', type=float, default=None,
+                    help="default: the board's own Default netclass")
+    ap.add_argument('--out', default=None,
+                    help='default <workdir>/REPORT.md')
+    a = ap.parse_args(argv)
+
+    wd = a.workdir
+    if not os.path.isdir(wd):
+        print(f'no such work dir: {wd}', file=sys.stderr)
+        return 2
+    damaged = a.damaged or os.path.join(wd, 'perturbed.kicad_pcb')
+    # TRUTH DEFAULTS LOOK OUTSIDE THE FENCE, WHICH MEANS A SIBLING.
+    #
+    # These used to default straight into the work dir -- the layout
+    # `perturb(control_out=None)` produces and the one the staging recipe
+    # exists to avoid. `fence_audit` now treats a pose RECORD inside the fence
+    # as a leak the same way it already treated the control, so this tool's own
+    # defaults named a directory that the audit it runs below reports as a LEAK
+    # (measured on wk/run8/glasgow_revC: exit 0 before, exit 4 after).
+    #
+    # `<workdir>/_truth` would be no better: it is still INSIDE the work dir,
+    # so `fence_audit` walks straight into it and reports both files. Every
+    # real staged run puts truth in a SIBLING of the work dir, in one of two
+    # shapes, and `stage_blind.py` takes the path as an argument rather than
+    # deriving it -- so try both known shapes, then fall back to the legacy
+    # in-dir location so an old work dir still reports at all (the audit will
+    # name it, which is the point).
+    #
+    #     wk/run13/glasgow  + wk/run13/_truth/            <- sibling
+    #     wk/run10/smartknob + wk/run10/_truth/smartknob/ <- sibling, per subject
+    _parent = os.path.dirname(os.path.abspath(wd))
+    _subject = os.path.basename(os.path.abspath(wd))
+
+    def _truth(name, *alts):
+        """First existing candidate: sibling _truth, per-subject, then legacy.
+
+        `alts` are alternative FILE names for the same artifact. stage_blind
+        writes `control.kicad_pcb` for its own dose-0 copy and
+        `perturbed.control.kicad_pcb` for perturb's, and run 12's truth dir
+        carries both -- so a single hardcoded name resolved on some staged runs
+        and not others, for a reason that has nothing to do with the layout.
+        """
+        for nm in (name,) + alts:
+            for cand in (os.path.join(_parent, '_truth', nm),
+                         os.path.join(_parent, '_truth', _subject, nm),
+                         os.path.join(wd, nm)):
+                if os.path.isfile(cand):
+                    return cand
+        return os.path.join(wd, name)          # for the missing-input message
+
+    control = a.control or _truth('perturbed.control.kicad_pcb',
+                                  'control.kicad_pcb')
+    record_p = a.record or _truth('perturbed.perturb.json',
+                                  'board.perturb.json')
+    # `control` is checked too. It was the one input that could go missing
+    # silently: the fence row degraded to "fence_audit exit 2" in the report,
+    # which reads like the audit ran and found nothing.
+    for p in (damaged, a.result, record_p, control):
+        if not os.path.isfile(p):
+            print(f'missing input: {p}', file=sys.stderr)
+            return 2
+
+    from list_nets import board_default_netclass_clearance
+
+    def _floor(board):
+        """EACH board grades at ITS OWN floor, not the damaged board's.
+
+        The floors genuinely differ along a chain: `route.py`'s `.kicad_pro`
+        writeback clamps the Default netclass DOWN to whatever was actually
+        routed, so a result board legitimately carries a tighter floor than the
+        input it came from. Forcing one number on every row grades the result
+        STRICTER than the route used, which manufactures phantom sub-clearance
+        grazes -- measured on run 10: the damaged board's floor is 0.2, its
+        result board's is 0.127, and grading the result at 0.2 reported 90 DRC
+        violations on a board its own run measured at 0. --clearance still
+        forces one floor on every row when a comparison needs that.
+        """
+        if a.clearance is not None:
+            return a.clearance
+        return board_default_netclass_clearance(board) or 0.25
+
+    clearance = _floor(damaged)
+
+    tmp = os.path.join(wd, '_report')
+    os.makedirs(tmp, exist_ok=True)
+
+    # ---- board-only measurements ------------------------------------------
+    rows = []
+    for label, board in (('damaged input', damaged), ('this run', a.result)):
+        _c = _floor(board)
+        rows.append({'run': label, 'board': board, 'quality': quality(board),
+                     'clearance': _c,
+                     'assembly': buildable(board, _c, tmp),
+                     'score': blocking(board, _c, tmp)})
+
+    human = None
+    if a.human and os.path.isfile(a.human):
+        from tests.stress.compare_to_original import (profile,
+                                                      original_degeneracy)
+        prof = profile(a.human)
+        # A "human original" with no copper cannot be a reference, and 7 of 75
+        # wave references had none. Say which, rather than printing zeros as
+        # though they were a comparison.
+        human = {'run': 'human original', 'board': a.human, 'profile': prof,
+                 'degeneracy': original_degeneracy(prof),
+                 'quality': quality(a.human),
+                 'clearance': _floor(a.human),
+                 'assembly': buildable(a.human, _floor(a.human), tmp),
+                 'score': blocking(a.human, _floor(a.human), tmp)}
+
+    # ---- truth opens HERE, and only here ----------------------------------
+    from placement import recovery as R
+    from kicad_parser import parse_kicad_pcb
+    with open(record_p, encoding='utf-8') as fh:
+        record = json.load(fh)
+    orig = {r: tuple(v) for r, v in (record.get('original_poses') or {}).items()}
+    members = list((record.get('block') or {}).get('members') or [])
+    n = len(members)
+
+    def displacement(board):
+        pcb = parse_kicad_pcb(board)
+        return R.displacement_to_original(R.board_poses(pcb), orig,
+                                          pcb.footprints, subset=members)
+
+    for r in rows + ([human] if human else []):
+        r['route'] = route(r['board'], record, r['clearance'], tmp)
+
+    d_dmg = displacement(damaged)
+    d_res = displacement(a.result)
+    d0, d1 = d_dmg['perturbed_pad_rms'], d_res['perturbed_pad_rms']
+
+    def home_count(d):
+        frac = d.get('parts_home_frac')
+        return None if frac is None else int(round(frac * n))
+
+    rows[0].update(recovery=None, home=home_count(d_dmg), rms=d0,
+                   median=d_dmg.get('per_part_median'),
+                   collateral=d_dmg.get('collateral_pad_rms'),
+                   displacement=d_dmg)
+    rows[1].update(recovery=R.recovery_fraction(d0, d1),
+                   home=home_count(d_res), rms=d1,
+                   median=d_res.get('per_part_median'),
+                   collateral=d_res.get('collateral_pad_rms'),
+                   displacement=d_res)
+    # `collateral_pad_rms` -- how far the run moved parts it was NOT asked to
+    # move -- has been computed since this module existed and READ BY NOTHING:
+    # it was serialised into REPORT.json and never looked at again. Run 9 took
+    # it from 0.000 to 1.171mm, i.e. it displaced undamaged parts, and no gate
+    # or report mentioned it. A recovery run that damages what it did not
+    # perturb is a specific, detectable failure and it belongs in the table.
+    _coll = d_res.get('collateral_pad_rms') or 0.0
+    if _coll > 0.5:
+        print(f"\n!! COLLATERAL DAMAGE: this run moved parts OUTSIDE the "
+              f"perturbed block by {_coll:.3f}mm RMS (the damaged input's "
+              f"figure was {d_dmg.get('collateral_pad_rms', 0.0):.3f}). "
+              f"Parts nobody asked it to touch have been displaced.\n")
+    if human:
+        human.update(recovery=None, home=n, rms=0.0)
+
+    code, fence = _run(['tests/stress/fence_audit.py', '--control', control,
+                        '--workdir', wd, '--mode', 'audit'])
+    fence_verdict = next((ln.strip() for ln in fence.splitlines()
+                          if 'VERDICT:' in ln), f'fence_audit exit {code}')
+
+    # ---- the table ----------------------------------------------------------
+    #
+    # THE OBJECTIVE IS A BOARD THAT ROUTES. This table used to lead with
+    # `recovery` and `home /N`, which measure distance to the ORIGINAL POSE, and
+    # on run 10 that headline said failure about a board that had gone from NOT
+    # BUILDABLE to buildable, copper-free DRC 9 to 0, and pad-pair routability
+    # 3.78% to 76.47% -- because its 30-part block had been solved a different
+    # way. A placement that is electrically excellent but arranged differently
+    # scores ~0 recovery. So: routed outcome first, legality second, effort
+    # third, distance-to-truth demoted to the diagnostic block below.
+    all_rows = rows + ([human] if human else [])
+
+    def _q(r, key, nd=0):
+        """Quality is a TIEBREAK, comparable only once blocking == 0 -- so it
+        is parenthesised while anything is still blocking, per board_score's
+        own doctrine."""
+        v = (r.get('quality') or {}).get(key)
+        s = _fmt(v, nd)
+        return s if (r.get('score') or {}).get('blocking') == 0 else f'({s})'
+
+    out = [f'# Recovery report — {os.path.basename(wd)}', '',
+           'Each board is graded at ITS OWN Default-netclass floor '
+           + ', '.join(f'({r["run"]} {r["clearance"]}mm)'
+                       for r in rows + ([human] if human else []))
+           + ('' if a.clearance is None else
+              f' -- OVERRIDDEN to {a.clearance}mm on every row by --clearance')
+           + f'. N = {n} (the frozen perturbed member list, '
+             f'{d_res.get("members_scored")} scored).', '',
+           '**The objective is a board that ROUTES** — zero `unrouted`, zero '
+           '`broken`. Rank on `(unrouted + broken + drc, −PRR, vias, '
+           'copper_mm)`. `recovery` is a DIAGNOSTIC below, never the score.',
+           '',
+           '| run | unrouted | broken | PRR | RR | drc | assembly | vias | '
+           'copper mm |',
+           '|---|---|---|---|---|---|---|---|---|']
+    for r in all_rows:
+        by = (r.get('score') or {}).get('by') or {}
+        rt = r.get('route') or {}
+        asm = r.get('assembly') or {}
+        out.append('| {} | {} | {} | {} | {} | {} | {} | {} | {} |'.format(
+            r['run'], _fmt(by.get('unrouted')), _fmt(by.get('broken')),
+            '—' if rt.get('PRR_connected') is None
+            else f'{rt["PRR_connected"]:.2f}%',
+            '—' if rt.get('RR_connected') is None
+            else f'{rt["RR_connected"]:.2f}%',
+            _fmt(by.get('drc')),
+            'buildable' if asm.get('buildable') else 'NOT BUILDABLE',
+            _q(r, 'vias'), _q(r, 'copper_mm', 1)))
+    out += ['',
+            'Quality columns are parenthesised while `blocking > 0`: they are '
+            'a tiebreak and are not comparable until it is zero. The human '
+            'original is a **benchmark to approach, not a pose to match** — '
+            'what it contributes is the cost floor at blocking 0, and its '
+            '`recovery`/`home` cells are `1.0` and `N/N` by definition and '
+            'carry no information, which is why they are not printed.',
+            '',
+            f'- fence: {fence_verdict}']
+    for r in all_rows:
+        rt = r.get('route') or {}
+        if rt.get('PRR') is not None:
+            out.append(f'- {r["run"]}: DRC-clean PRR {rt["PRR"]:.2f}% / NRR '
+                       f'{rt.get("NRR", 0.0):.2f}% (the `_connected` columns '
+                       f'above do not require DRC-cleanliness)')
+        elif rt.get('ran') is False:
+            out.append(f'- {r["run"]}: routed grade UNMEASURED '
+                       f'({rt.get("reason")})')
+    for r in all_rows:
+        sc = r.get('score') or {}
+        pb = (sc.get('unrouted_shape') or {}).get('placement_blocked') or {}
+        if pb:
+            out.append(
+                f'- **{r["run"]}: {len(pb)} of {sc["by"].get("unrouted")} '
+                f'unrouted net(s) are PLACEMENT-BLOCKED** — fewer than 2 pads '
+                f'ON the board, so no router setting reaches them: '
+                f'{" ".join((sc.get("unrouted_shape") or {}).get("placement_blocked_refs") or [])}')
+        if sc.get('ungraded'):
+            out.append(f'- {r["run"]}: ungraded (NOT passes) — '
+                       f'{", ".join(sc["ungraded"])}')
+    if human and human['degeneracy']:
+        out.append(f'- **the human reference is {human["degeneracy"]}** — its '
+                   f'copper cannot serve as a comparison, so read that row as '
+                   f'a placement reference only.')
+    for r in all_rows:
+        asm = r.get('assembly') or {}
+        if asm.get('error'):
+            out.append(f'- {r["run"]}: assembly UNMEASURED ({asm["error"]})')
+        elif not asm.get('buildable'):
+            out.append(f'- {r["run"]}: {asm.get("verdict")} — blocking '
+                       f'{asm.get("blocking")}, locked contacts '
+                       f'{asm.get("locked_contacts")}, '
+                       f'{asm.get("oob_pad_count")} part(s) with pad copper '
+                       f'off-board')
+
+    # ---- DIAGNOSTIC: did the run move the parts it was asked to move? -------
+    #
+    # Not the score. These answer one question -- whether the run went where it
+    # was pointed -- and the answer is useful even when it is bad news about a
+    # board that got better.
+    out += ['', '## Diagnostic — distance to the original poses', '',
+            'These are NOT the score. A run that solves the board a different '
+            'way scores ~0 here and may still be the better board; what they '
+            'catch is a run that WANDERED.', '',
+            f'- recovery: '
+            + ('—' if rows[1].get('recovery') is None
+               else f'{rows[1]["recovery"]:+.4f}')
+            + f'  |  home {_fmt(rows[1].get("home"))} / {n}',
+            f'- distance to truth (pad RMS): damaged {d0:.4f} → '
+            f'result {d1:.4f}',
+            '- `home` is pad-space, at '
+            f'`recovery.HOME_TOLERANCE_MM` = {R.HOME_TOLERANCE_MM} mm — a part '
+            'rotated in place moves its origin 0.00 mm and its pads much '
+            'further, so an origin-distance count would call it home.']
+    if d_res.get('rot_mismatch_total'):
+        out.append(f'- rotation mismatches: {d_res["rot_mismatch_total"]} '
+                   f'({", ".join(d_res.get("rot_mismatch") or [])})')
+    # collateral, WITH NAMES. It was the only instrument that saw run 10 tear
+    # two members out of an intact 8-fold ring, and it reported that as the
+    # bare scalar 3.6697 with nothing attached.
+    _cnames = _collateral_refs(damaged, a.result, members)
+    out.append(
+        f'- collateral (parts OUTSIDE the perturbed block, pad RMS): '
+        f'{d_dmg.get("collateral_pad_rms", 0.0):.4f} → {_coll:.4f}'
+        + ('' if not _cnames else
+           '\n  - moved: ' + ', '.join(f'**{r}** {d:.3f} mm'
+                                       + (f' (rot {ro:+.0f}°)' if ro else '')
+                                       for r, d, ro in _cnames)))
+    if _coll > 0.5:
+        out.append(
+            f'- **COLLATERAL DAMAGE**: this run displaced parts nobody asked '
+            f'it to touch. That is a real defect whatever the headline says, '
+            f'and it is how an intact structure gets dismantled to buy a '
+            f'legality number.')
+    _usr = None
+    try:
+        _usr = R.unit_spread_ratio(R.board_poses(parse_kicad_pcb(a.result)),
+                                   orig, members)
+    except Exception:                                          # noqa: BLE001
+        pass
+    if _usr is not None:
+        _g = R._gyration(orig, members)
+        out.append(f'- unit spread ratio: {_usr:.4f} against an original '
+                   f'gyration of '
+                   + ('—' if _g is None else f'{_g:.3f} mm')
+                   + ' (the ratio is unreadable without it: 1.03 on a 50 mm '
+                     'unit means "cannot tell", not "not torn")')
+
+    text = '\n'.join(out) + '\n'
+    dest = a.out or os.path.join(wd, 'REPORT.md')
+    with open(dest, 'w', encoding='utf-8') as fh:
+        fh.write(text)
+    print(text)
+    print(f'REPORT -> {dest}')
+    jp = os.path.splitext(dest)[0] + '.json'
+    with open(jp, 'w', encoding='utf-8') as fh:
+        json.dump({'workdir': wd, 'clearance': clearance, 'N': n,
+                   'fence': fence_verdict, 'rows': all_rows}, fh, indent=1,
+                  sort_keys=True, default=str)
+    print(f'JSON   -> {jp}')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/stress/calibrate_congestion_ratio.py
+++ b/tests/stress/calibrate_congestion_ratio.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""What ratio, if any, separates a healthy placement repair from a legality-only one?
+
+    python3 -X utf8 tests/stress/calibrate_congestion_ratio.py --out wk/calibration
+    python3 -X utf8 tests/stress/calibrate_congestion_ratio.py --boards neo6502 --quick
+
+P-close refuses a close-out when ``hpwl_gain < ratio * halo_gain``, where each
+gain is ``(before - after) / before`` of a ``render_placement`` metric. The
+``ratio`` shipped at **0.25, chosen and not measured**. This script measures it,
+and is allowed to conclude the gate is wrong.
+
+Why a ratio and not an absolute
+-------------------------------
+A blind run cannot see the undamaged control, so "how much of the DAMAGE did we
+repair" is not computable at close-out time. What is computable is the
+disparity between two gains against the board the run started from: if halo
+closed most of its gap while hpwl closed almost none, the repair was local and
+the arrangement was left alone. That is run 15's shape (halo 49.4%, hpwl 3.1%)
+and the board it produced failed routing on 29 nets no parameter could reach.
+
+Three populations, because a threshold needs both sides
+-------------------------------------------------------
+  undamaged -> itself      halo_gain ~ 0. The ratio must never be applied here;
+                           this exercises the `halo_gain < 0.25` early-out.
+  damaged -> repaired      the signal. What ratio do HEALTHY repairs reach?
+  damaged -> legality-only  run 15's shape. Must be REFUSED, or the gate is
+                           worthless.
+
+"Healthy" is defined by LEGALITY OUTCOME (check_assembly blocking -> 0), never
+by the metric under test. Defining it by hpwl would make this circular.
+
+The knob trap
+-------------
+``halo`` is a PENALTY, so it depends on halo_base/halo_coef/halo_weight and the
+clearance. ``render_placement._build_state`` uses halo_coef 0.25 /
+crossing_penalty 10.0 / length_weight 1.0; ``pose_score.make_state`` (behind
+``recovery.static_metrics``) uses 0.15 / 30.0 / 0.3, and discards halo anyway.
+**A halo from anywhere but PlacementModel is not comparable to the gate's.** So
+this script builds PlacementModel directly -- which is byte-identical to
+``--json-out``'s metrics block by construction (render_placement.py: the payload
+is literally ``dict(model.metrics)``) and costs ~0.2-0.8 s with no PNGs.
+
+Any ratio measured here is therefore only valid for those weights. That is a
+finding about the gate, and it belongs in the write-up.
+"""
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_placer'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_tools'))  # #522/py_placer layout
+
+CORPUS = os.path.expanduser('~/Documents/kicad_stress_test/boards_unrouted_set1')
+
+#: qualify.json (run 15, --draws 8, graded at 0.2) rated exactly these GOOD.
+#: haxophone and upsy_desky came back WEAK -- the dose lands on fewer than 8 in
+#: 10 draws -- so a calibration point from them would mostly measure the rig.
+GOOD = ('neo6502', 'urchin', 'piantor')
+
+
+def sh(cmd, timeout=1800):
+    """(rc, stdout+stderr). Never raises on a tool's own failure."""
+    env = dict(os.environ, KRT_NO_BANNER='1')
+    try:
+        p = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                           encoding='utf-8', errors='replace', timeout=timeout,
+                           cwd=ROOT, env=env)
+        return p.returncode, p.stdout
+    except subprocess.TimeoutExpired:
+        return 124, f'TIMEOUT after {timeout}s'
+
+
+def metrics(board, clearance):
+    """halo/hpwl/crossings exactly as the gate sees them.
+
+    PlacementModel, not recovery.static_metrics -- see "the knob trap" above.
+    """
+    from kicad_parser import parse_kicad_pcb
+    from render_placement import PlacementModel
+    m = PlacementModel(parse_kicad_pcb(board), board, exact=True,
+                       quench_kwargs={'clearance': clearance,
+                                      'ignore_net_ids': set()}).metrics
+    return {k: m.get(k) for k in ('halo', 'hpwl', 'crossings', 'total')}
+
+
+def board_floor(board):
+    """The board's own Default-netclass clearance. Never a round number."""
+    pro = os.path.splitext(board)[0] + '.kicad_pro'
+    try:
+        d = json.load(open(pro, encoding='utf-8'))
+        for c in d['net_settings']['classes']:
+            if c.get('name') == 'Default':
+                return float(c.get('clearance') or 0.2)
+    except Exception:                                           # noqa: BLE001
+        pass
+    return 0.2
+
+
+def assembly_blocking(board, clearance):
+    """check_assembly's blocking count -- the LEGALITY definition of healthy."""
+    with tempfile.TemporaryDirectory() as t:
+        j = os.path.join(t, 'a.json')
+        rc, _ = sh([sys.executable, '-X', 'utf8',
+                    os.path.join(ROOT, 'py_tools', 'check_assembly.py'), board,
+                    '--clearance', str(clearance), '--json', j], timeout=900)
+        try:
+            return int(json.load(open(j, encoding='utf-8')).get('blocking'))
+        except Exception:                                       # noqa: BLE001
+            return None
+
+
+def gains(before, after):
+    """(before-after)/before per key, the gate's own arithmetic."""
+    out = {}
+    for k in ('halo', 'hpwl', 'crossings'):
+        b, n = before.get(k), after.get(k)
+        ok = (isinstance(b, (int, float)) and isinstance(n, (int, float))
+              and b > 0)
+        out[k] = ((b - n) / b) if ok else None
+    return out
+
+
+def run_board(name, out_dir, quick=False):
+    """Damage, repair two ways, and measure every step. Returns a row dict."""
+    src = os.path.join(CORPUS, f'{name}.kicad_pcb')
+    if not os.path.isfile(src):
+        return {'board': name, 'error': f'no such board: {src}'}
+    floor = board_floor(src)
+    wk = os.path.join(out_dir, name)
+    truth = os.path.join(out_dir, '_truth', name)
+    for d in (wk, truth):
+        os.makedirs(d, exist_ok=True)
+    row = {'board': name, 'clearance': floor}
+
+    t0 = time.time()
+    rc, log = sh([sys.executable, '-X', 'utf8',
+                  os.path.join(ROOT, 'tests/stress/stage_blind.py'),
+                  src, wk, truth, '--kind', 'swap'], timeout=1800)
+    dmg = os.path.join(wk, 'board.kicad_pcb')
+    if rc != 0 or not os.path.isfile(dmg):
+        return dict(row, error=f'stage_blind rc={rc}: {log.strip()[-300:]}')
+    row['stage_seconds'] = round(time.time() - t0, 1)
+
+    row['pristine'] = metrics(src, floor)
+    row['damaged'] = metrics(dmg, floor)
+    row['pristine_blocking'] = assembly_blocking(src, floor)
+    row['damaged_blocking'] = assembly_blocking(dmg, floor)
+
+    # POPULATION 1 -- undamaged against itself. The gate must not even reach
+    # its ratio here (halo_gain ~ 0 trips the early-out).
+    row['g_null'] = gains(row['pristine'], row['pristine'])
+
+    # POPULATION 2 -- a REAL repair. The full ladder is what a placement half
+    # actually runs; `legalize` is the stage that clears blocking pairs.
+    full = os.path.join(wk, 'repaired.kicad_pcb')
+    t0 = time.time()
+    rc, log = sh([sys.executable, '-X', 'utf8',
+                  os.path.join(ROOT, 'py_placer', 'place_reconstruct.py'), dmg, full,
+                  '--clearance', str(floor),
+                  '--deadline', '300' if quick else '900'],
+                 timeout=400 if quick else 1200)
+    row['repair_rc'] = rc
+    row['repair_seconds'] = round(time.time() - t0, 1)
+    if os.path.isfile(full):
+        row['repaired'] = metrics(full, floor)
+        row['repaired_blocking'] = assembly_blocking(full, floor)
+        row['g_repair'] = gains(row['damaged'], row['repaired'])
+    else:
+        row['repair_error'] = log.strip()[-300:]
+
+    # POPULATION 3 -- legality only. `legalize` alone moves parts just enough to
+    # clear violations and does nothing about the arrangement: run 15's shape,
+    # reproduced deliberately rather than waited for.
+    lego = os.path.join(wk, 'legality_only.kicad_pcb')
+    t0 = time.time()
+    rc, log = sh([sys.executable, '-X', 'utf8',
+                  os.path.join(ROOT, 'py_placer', 'place_reconstruct.py'), dmg, lego,
+                  '--stages', 'classify,legalize', '--clearance', str(floor),
+                  '--deadline', '300' if quick else '900'],
+                 timeout=400 if quick else 1200)
+    row['legality_rc'] = rc
+    row['legality_seconds'] = round(time.time() - t0, 1)
+    if os.path.isfile(lego):
+        row['legality_only'] = metrics(lego, floor)
+        row['legality_only_blocking'] = assembly_blocking(lego, floor)
+        row['g_legality'] = gains(row['damaged'], row['legality_only'])
+    else:
+        row['legality_error'] = log.strip()[-300:]
+    return row
+
+
+def verdict_line(g, ratio):
+    """What the gate would DO with these gains, in the gate's own logic."""
+    if not g or g.get('halo') is None or g.get('hpwl') is None:
+        return 'unmeasurable'
+    if g['halo'] < 0.25:
+        return 'pass (early-out: legality barely moved)'
+    return ('pass' if g['hpwl'] >= ratio * g['halo']
+            else f'REFUSE (hpwl {g["hpwl"]:.3f} < {ratio} x halo {g["halo"]:.3f})')
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--out', default='wk/calibration')
+    ap.add_argument('--boards', nargs='*', default=list(GOOD),
+                    help=f'default: the qualify.json GOOD set {GOOD}')
+    ap.add_argument('--ratio', type=float, default=0.25,
+                    help='the ratio to REPORT against (default: the shipped 0.25)')
+    ap.add_argument('--quick', action='store_true',
+                    help='shorter deadlines; for a smoke run, not for a verdict')
+    a = ap.parse_args()
+
+    out = os.path.join(ROOT, a.out) if not os.path.isabs(a.out) else a.out
+    os.makedirs(out, exist_ok=True)
+    rows = []
+    for name in a.boards:
+        print(f'=== {name} ===', flush=True)
+        r = run_board(name, out, quick=a.quick)
+        rows.append(r)
+        print(json.dumps(r, indent=1), flush=True)
+        json.dump(rows, open(os.path.join(out, 'rows.json'), 'w'), indent=1)
+
+    print('\n' + '=' * 78)
+    print(f'{"board":10s} {"population":16s} {"halo_gain":>10s} {"hpwl_gain":>10s} '
+          f'{"ratio":>8s}  {"blocking":>9s}  verdict @ {a.ratio}')
+    for r in rows:
+        if r.get('error'):
+            print(f'{r["board"]:10s} ERROR {r["error"]}')
+            continue
+        for pop, gk, bk in (('undamaged->self', 'g_null', 'pristine_blocking'),
+                            ('damaged->repair', 'g_repair', 'repaired_blocking'),
+                            ('damaged->legality', 'g_legality',
+                             'legality_only_blocking')):
+            g = r.get(gk)
+            if not g:
+                print(f'{r["board"]:10s} {pop:16s} (not produced)')
+                continue
+            hg, pg = g.get('halo'), g.get('hpwl')
+            rat = (pg / hg) if (hg and pg is not None and hg > 0) else None
+            print(f'{r["board"]:10s} {pop:16s} '
+                  f'{("%.4f" % hg) if hg is not None else "-":>10s} '
+                  f'{("%.4f" % pg) if pg is not None else "-":>10s} '
+                  f'{("%.4f" % rat) if rat is not None else "-":>8s}  '
+                  f'{str(r.get(bk)):>9s}  {verdict_line(g, a.ratio)}')
+    print('=' * 78)
+    print(f'rows -> {os.path.join(out, "rows.json")}')
+    print('\nREAD IT LIKE THIS: the gate is USEFUL only if damaged->repair passes'
+          '\nand damaged->legality REFUSES, on every board. If both pass, the'
+          '\nratio is too low. If both refuse, it is too high -- or hpwl does not'
+          '\nseparate these populations at all, which is outcome 2 and means the'
+          '\ngate should REPORT rather than refuse.')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/stress/corpus_noop_sweep.py
+++ b/tests/stress/corpus_noop_sweep.py
@@ -53,7 +53,7 @@ def _signature(res):
     if res.get('refused'):
         return f'refused:{res["refused"]}'
     parts = []
-    for key in ('moved', 'proposed', 'legalize_moves'):
+    for key in ('moved', 'proposed', 'legalize_moves', 'unevidenced'):
         vals = sorted(res.get(key) or [])
         if vals:
             parts.append(f'{key}={",".join(vals)}')
@@ -98,14 +98,28 @@ def sweep_reconstruct(board, workdir):
     # A proposal that the gate rejected is still a proposal: the sweep asks
     # whether the tool SAW damage on a healthy board, not only whether it
     # applied any.
-    proposed = sorted((rep.get('proposals') or {}).keys()) \
-        if isinstance(rep.get('proposals'), dict) else []
+    # The key is `fit_proposals` (place_reconstruct.py:191). This read said
+    # `proposals`, so it was ALWAYS [] -- the one arm of the signature that
+    # exists to catch "a vector source fires on a healthy hole pattern" was
+    # blind to precisely that, on every board, since the arm was written.
+    # Accept the old name too: a sweep is only a change detector if it can
+    # read a baseline recorded before the rename.
+    props = rep.get('fit_proposals')
+    if not isinstance(props, dict):
+        props = rep.get('proposals')
+    proposed = sorted(props.keys()) if isinstance(props, dict) else []
     vectors = (list(rep.get('vectors') or [])
                + list(rep.get('vectors_derived') or [])
                + list(rep.get('vectors_airwire') or []))
     legal = (rep.get('legalize') or {}).get('would_move') or []
+    # An UNEVIDENCED move -- one the gate tuple cannot see -- is a silent
+    # regression of exactly the kind this sweep exists for, and it was not in
+    # the signature either.
+    unevidenced = sorted({m.get('ref') for m in (rep.get('unevidenced_moves')
+                                                 or []) if m.get('ref')})
     return {'moved': moved, 'proposed': proposed,
-            'vectors': len(vectors), 'legalize_moves': list(legal)}, None
+            'vectors': len(vectors), 'legalize_moves': list(legal),
+            'unevidenced': unevidenced}, None
 
 
 def sweep_repair(board, workdir):

--- a/tests/stress/fence_audit.py
+++ b/tests/stress/fence_audit.py
@@ -15,7 +15,14 @@ Naming cannot close that hole, because the next carrier will have a different
 name (a `.bak`, a `board_orig.kicad_pcb`, a candidate copied out of an archive).
 So this audit ignores names and asks the only question that matters:
 
-    does any board in this work dir carry the control's poses?
+    does any FILE in this work dir carry the control's poses?
+
+Boards, and pose RECORDS: a perturbation record embeds `original_poses`
+verbatim, so it is ground truth in JSON clothing and gets no name exemption
+either. This matters on the default path, not a contrived one --
+`perturb(..., control_out=None)` writes that record BESIDE the output board,
+i.e. inside the fence. Stage with `control_out=<a dir outside the work dir>`
+and the record never enters.
 
 Two modes, because the same content means opposite things before and after a run:
 
@@ -54,24 +61,56 @@ import math
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(, 'py_router'))  # #522/py_placer layout
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(, 'py_placer'))  # #522/py_placer layout
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(, 'py_tools'))  # #522/py_placer layout
-    os.path.abspath(__file__)))))
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_placer'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_tools'))  # #522/py_placer layout
 
 from kicad_parser import parse_kicad_pcb  # noqa: E402
 from placement import recovery  # noqa: E402
 
 MANIFEST_NAME = '.fence-manifest.json'
 
-# Carriers the protocol declares as truth ON PURPOSE. They are audit-only
-# inputs the workers may not read; this audit's job is finding the ones nobody
-# declared, so these are excluded from the leak report by name.
-DEFAULT_ALLOW = (
-    '*.control.kicad_pcb',
-    '*.perturb.json',
-)
+# Carriers the protocol declares as truth ON PURPOSE, excluded from the leak
+# report by name.
+#
+# `*.control.kicad_pcb` USED TO BE HERE AND IS GONE (run-12 Tier 0). It made
+# the same bytes a LEAK or CLEAN depending only on the filename: a copy of the
+# control under any other name was reported, the control itself was not --
+# while `perturb()` wrote it into the output directory by default, so the most
+# likely carrier of all was the one carrier this audit ignored. That
+# contradicts the docstring above ("Naming cannot close that hole ... So this
+# audit ignores names"), and a name-based exemption for the single most likely
+# carrier is exactly the hole the module exists to close. A control INSIDE the
+# work dir is now a LEAK, which is what this module says it believes.
+#
+# The legitimate cases are still covered: `control_real` (below) never reports
+# the audit's OWN reference, and `--allow` remains for a caller that genuinely
+# means it.
+#
+# DEFAULT_ALLOW IS EMPTY, AND THAT IS THE POINT.
+#
+# It used to hold `*.perturb.json`. That was harmless only while it was a lie:
+# `scan()` walked `.kicad_pcb` alone, so the entry exempted a file the module
+# could not open anyway. Teaching the scan to read `.json` turned an inert
+# declaration into a working blind spot -- and not a hypothetical one.
+# `placement.perturb.perturb(...)` with `control_out` unset writes the record
+# BESIDE THE OUTPUT BOARD (perturb.py:596-602), i.e. inside the work dir, and
+# that record embeds `original_poses` verbatim. So the default perturbation
+# path drops complete ground truth into the fence, and this tuple told the
+# audit to walk past it.
+#
+# The module's thesis is that a leak is CONTENT, not a filename; it already
+# applies that to the control ("A control INSIDE the work dir is now a LEAK",
+# above). A record is the same truth in JSON clothing, so it gets the same
+# answer. The declared record lives in `_truth/`, OUTSIDE the work dir, which
+# is what `control_out` is for and what the staging recipe does -- a record
+# inside the fence is a staging mistake, and this is the tool that says so.
+#
+# `--allow` remains for a caller who genuinely means it.
+DEFAULT_ALLOW = ()
 
 # A board counts as truth-carrying when this fraction of its shared refs sit
 # within POSE_TOL of the control. Not 1.0: a leak is still a leak when one
@@ -109,33 +148,211 @@ def pose_match(poses_a, poses_b):
     return hits / len(shared), len(shared), worst
 
 
-def scan(workdir, control_poses, allow):
-    """Every .kicad_pcb in workdir, scored against the control's poses."""
+def _json_poses(path):
+    """{ref: (x, y, rot)} out of a perturbation RECORD, or None.
+
+    The record embeds `original_poses` verbatim -- it is ground truth in JSON
+    clothing, and the scan filtered on the extension before opening anything,
+    so this module named a carrier it structurally could not see.
+
+    Read BYTES and let `json.loads` sniff the encoding. Opening as utf-8 text
+    made the audit defeatable by re-saving the record as UTF-16 -- same keys,
+    same truth, `UnicodeDecodeError` into the bare `except`, waved through as
+    "ordinary JSON". `json.loads` applies RFC-4627 BOM detection and accepts
+    utf-8, utf-8-sig, utf-16 and utf-32 alike (verified), so the content test
+    stops depending on how the file was saved.
+    """
+    try:
+        with open(path, 'rb') as fh:
+            doc = json.loads(fh.read())
+    except Exception:                                   # noqa: BLE001
+        return None
+    if not isinstance(doc, dict):
+        return None
+    # `original_poses` ONLY. A `poses` alias was tried and dropped: across 561
+    # real driver-output JSONs in this repo it matched nothing (no writer emits
+    # a top-level ref->[x,y,rot] dict under that name), so it bought no
+    # coverage -- while the `kind == 'record'` branch in main() is
+    # unconditional, meaning anything this function claims can NEVER be classed
+    # as recovery. A future tool writing its RESULT as {"poses": {...}} would
+    # therefore have had a perfect reconstruction -- the case the module
+    # docstring insists must not be a breach ("one run-7 board did, at
+    # d1 = 0.000000") -- reported as a LEAK. Speculative coverage is not worth
+    # a mechanism that misclassifies the experiment succeeding.
+    for key in ('original_poses',):
+        raw = doc.get(key)
+        if isinstance(raw, dict) and raw:
+            out = {}
+            for ref, v in raw.items():
+                if isinstance(v, (list, tuple)) and len(v) >= 3:
+                    try:
+                        out[ref] = (float(v[0]), float(v[1]),
+                                    float(v[2]) % 360.0)
+                    except (TypeError, ValueError):
+                        continue
+            if out:
+                return out
+    return None
+
+
+#: Extensions the scan opens. This module's thesis -- "the next carrier will
+#: have a different name" -- applies to EXTENSIONS exactly as it does to stems,
+#: and the scan used to stop at `.kicad_pcb`.
+SCANNED_EXT = ('.kicad_pcb', '.json')
+
+
+#: A pad centre and a track end are "the same point" within this. Run 14
+#: measured 301 of 569 netted pads sitting within 5 um of their own track
+#: endpoint, so the coincidence is exact, not approximate.
+COPPER_TOL_MM = 0.01
+#: Below this many displaced pads the fraction is noise, not a signal.
+COPPER_MIN_PADS = 5
+#: Fraction of DISPLACED control pads that must still have copper at the
+#: control's position. Deliberately low: on an honestly routed board the
+#: expected value is ZERO, because copper laid down for a pad that has since
+#: moved does not stay behind at the old coordinate. Anything materially above
+#: zero is the signal, and the baseline test below is what keeps a densely
+#: routed board from tripping it.
+COPPER_FRAC = 0.15
+
+
+def _netted_pad_xy(pcb):
+    """Rounded (x, y) of every pad that carries a net."""
+    out = set()
+    for fp in (pcb.footprints or {}).values():
+        for pad in fp.pads:
+            if pad.net_id:
+                out.add((round(pad.global_x, 3), round(pad.global_y, 3)))
+    return out
+
+
+def _copper_points(pcb):
+    """Every point copper touches: segment ends and via centres."""
+    pts = set()
+    for s in (pcb.segments or []):
+        pts.add((round(s.start_x, 3), round(s.start_y, 3)))
+        pts.add((round(s.end_x, 3), round(s.end_y, 3)))
+    for v in (pcb.vias or []):
+        pts.add((round(v.x, 3), round(v.y, 3)))
+    return pts
+
+
+def copper_carries_poses(pcb, control_pads):
+    """(displaced, hits, frac) -- does this board's COPPER mark the control's pads?
+
+    `scan()` compares POSES and never opens copper, and that is a hole with a
+    measured size. A subject staged from a routed corpus board keeps the human
+    routing while the parts move out from under it, so the track ends go on
+    marking where each part BELONGS. Run 14 shipped exactly that: fence_audit
+    said CLEAN on a board whose copper located 301 of 569 pads to within 5 um,
+    and the leak was only closed later, by a copper strip done for an unrelated
+    reason.
+
+    THE TRAP THIS AVOIDS: a board whose placement was successfully RECOVERED
+    has its pads back at the control's coordinates, so "copper sits on control
+    pads" is true of the best possible outcome as well as the worst. The
+    discriminator is displacement. Score only the control pads this board has
+    moved AWAY from -- if copper still sits where those pads used to be, the
+    copper is telling you where they belong, and that is the leak. A recovered
+    board has almost no displaced pads to score, and a board routed honestly at
+    NEW positions has no copper at the old ones.
+    """
+    own = _netted_pad_xy(pcb)
+    displaced = control_pads - own
+    stayed = control_pads & own
+    if len(displaced) < COPPER_MIN_PADS:
+        return len(displaced), 0, 0.0, 0.0
+    pts = _copper_points(pcb)
+    if not pts:
+        return len(displaced), 0, 0.0, 0.0
+
+    step = int(round(COPPER_TOL_MM * 1000))
+
+    def _covered(pads):
+        """How many of these coordinates have copper sitting on them."""
+        n = 0
+        for (px, py) in pads:
+            bx, by = int(round(px * 1000)), int(round(py * 1000))
+            for dx in range(-step, step + 1):
+                for dy in range(-step, step + 1):
+                    if ((bx + dx) / 1000.0, (by + dy) / 1000.0) in pts:
+                        n += 1
+                        break
+                else:
+                    continue
+                break
+        return n
+
+    hits = _covered(displaced)
+    rate = hits / float(len(displaced))
+    # THE BASELINE. Boards differ enormously in how often a track actually
+    # terminates on a pad CENTRE -- one fixture here does it for 18% of pads,
+    # run 14's board for 53% -- so a bare fraction is not comparable across
+    # boards and any fixed threshold is arbitrary. The pads that did NOT move
+    # give the board's own rate for free, and the comparison is scale-free:
+    # copper laid out on the CONTROL's placement covers displaced pads at least
+    # as often as it covers the ones that stayed put, while copper laid out
+    # honestly on THIS placement covers the displaced positions essentially
+    # never.
+    base = (_covered(stayed) / float(len(stayed))) if stayed else 0.0
+    return len(displaced), hits, rate, base
+
+
+def scan(workdir, control_poses, allow, control_pads=None):
+    """Every scannable file in workdir, scored against the control's poses."""
     rows = []
     for root, _dirs, files in os.walk(workdir):
         for name in sorted(files):
-            if not name.endswith('.kicad_pcb'):
+            if not name.endswith(SCANNED_EXT):
                 continue
             path = os.path.join(root, name)
             rel = os.path.relpath(path, workdir).replace('\\', '/')
             if any(fnmatch.fnmatch(rel, pat) or fnmatch.fnmatch(name, pat)
                    for pat in allow):
                 continue
+            _copper = None
             try:
-                poses = recovery.board_poses(parse_kicad_pcb(path))
+                if name.endswith('.json'):
+                    poses = _json_poses(path)
+                    if poses is None:
+                        continue        # ordinary JSON, not a pose carrier
+                else:
+                    _pcb = parse_kicad_pcb(path)
+                    poses = recovery.board_poses(_pcb)
+                    if control_pads:
+                        _copper = copper_carries_poses(_pcb, control_pads)
             except Exception as exc:                    # unparseable is not a leak
                 rows.append({'file': rel, 'error': str(exc)[:120]})
                 continue
             frac, shared, worst = pose_match(poses, control_poses)
-            rows.append({
+            _kind = 'record' if name.endswith('.json') else 'board'
+            _by_pose = frac >= MATCH_FRAC and shared > 0
+            # Materially above zero AND no rarer than on the pads that stayed
+            # put. The second half is what stops a densely routed board that
+            # happens to terminate on many pad centres from tripping it.
+            _by_copper = bool(_copper and _copper[2] >= COPPER_FRAC
+                              and _copper[2] >= _copper[3])
+            row = {
                 'file': rel,
+                'kind': _kind,
                 'match_frac': round(frac, 6),
                 'refs_shared': shared,
                 'worst_mm': None if worst is None else round(worst, 6),
-                'carries_truth': frac >= MATCH_FRAC and shared > 0,
+                'carries_truth': _by_pose or _by_copper,
+                # WHICH channel carries it, because the two have different
+                # fixes: poses mean a control board got copied in, copper means
+                # the subject was staged from a routed board and never stripped.
+                'truth_channel': ('poses' if _by_pose else
+                                  'copper' if _by_copper else None),
                 'sha256': _sha256(path),
                 'mtime': os.path.getmtime(path),
-            })
+            }
+            if _copper is not None:
+                row['copper_displaced_pads'] = _copper[0]
+                row['copper_hits_on_control'] = _copper[1]
+                row['copper_frac'] = round(_copper[2], 6)
+                row['copper_baseline_frac'] = round(_copper[3], 6)
+            rows.append(row)
     return rows
 
 
@@ -159,12 +376,14 @@ def main(argv=None):
         return 2
 
     allow = list(DEFAULT_ALLOW) + list(args.allow)
-    control_poses = recovery.board_poses(parse_kicad_pcb(args.control))
+    _control_pcb = parse_kicad_pcb(args.control)
+    control_poses = recovery.board_poses(_control_pcb)
+    control_pads = _netted_pad_xy(_control_pcb)
     # The control may itself live inside the work dir under any name; never
     # report the audit's own reference as a leak.
     control_real = os.path.realpath(args.control)
 
-    rows = [r for r in scan(args.workdir, control_poses, allow)
+    rows = [r for r in scan(args.workdir, control_poses, allow, control_pads)
             if os.path.realpath(os.path.join(args.workdir, r['file'])) != control_real]
 
     manifest_path = os.path.join(args.workdir, MANIFEST_NAME)
@@ -176,7 +395,19 @@ def main(argv=None):
             print(f'fence_audit: manifest unreadable ({exc}); every '
                   f'truth-carrying board is reported as a LEAK', file=sys.stderr)
 
+    if args.mode == 'audit' and manifest is None:
+        # SAY it. The unreadable-manifest path above warns; the ABSENT one said
+        # nothing, so audit silently became strict where create had been silent
+        # -- and a reader could not tell "no board carried truth" from "there
+        # was no record to check against".
+        print('fence_audit: no creation manifest in this work dir, so no board '
+              'has provenance. Every truth-carrying board will be reported as '
+              'a LEAK. Run --mode create BEFORE the run to record one.',
+              file=sys.stderr)
+
     at_creation = set((manifest or {}).get('files', []))
+    at_creation_shas = (manifest or {}).get('shas') or {}
+    control_sha = (manifest or {}).get('control_sha256')
     leaks, recovered, errors = [], [], []
     for row in rows:
         if 'error' in row:
@@ -185,9 +416,41 @@ def main(argv=None):
             continue
         elif args.mode == 'create':
             leaks.append(row)
-        elif manifest is None or row['file'] in at_creation:
-            row['reason'] = ('present at work-dir creation' if manifest
-                             else 'no creation manifest -- provenance unknown')
+        elif row.get('kind') == 'record':
+            # FIRST among the audit branches, because it is the one reason that
+            # holds no matter what the manifest says. Ordered after them it was
+            # unreachable in the commonest case -- no manifest -- and the row
+            # came back "provenance unknown", which invites someone to fix it
+            # by running --mode create. That would record the record and make
+            # it permanently exempt. A pose RECORD carries `original_poses`
+            # verbatim and no placement run reconstructs one, so provenance is
+            # not the question.
+            row['reason'] = ('a pose RECORD inside the fence -- records are '
+                             'never reconstructed, so this is truth arriving, '
+                             'not recovery')
+            leaks.append(row)
+        elif manifest is None:
+            row['reason'] = 'no creation manifest -- provenance unknown'
+            leaks.append(row)
+        elif row['file'] in at_creation \
+                and at_creation_shas.get(row['file']) == row.get('sha256'):
+            # UNCHANGED since creation, so it is an input that already carried
+            # truth. The sha is what makes that testable: this branch used to
+            # key on the PATH alone, which meant a board the run REWROTE in
+            # place -- a recovery landing on the control's poses -- was
+            # reported as "present at work-dir creation". The better the run
+            # did, the more certainly it fired. `shas` was recorded here for
+            # exactly this and was never read.
+            row['reason'] = 'present at work-dir creation, unchanged since'
+            leaks.append(row)
+        elif control_sha and row.get('sha256') == control_sha:
+            # A BYTE COPY OF THE CONTROL is not a reconstruction. A real
+            # recovery differs in copper, UUIDs and netclasses even when every
+            # pose matches; identical bytes mean the file was copied, not
+            # rebuilt. Without this, `cp control.kicad_pcb r4_final.kicad_pcb`
+            # was classed "produced by the run" and exited 0.
+            row['reason'] = ('byte-identical to the control -- copied, not '
+                             'reconstructed')
             leaks.append(row)
         else:
             row['reason'] = 'produced by the run (recovery reaching truth)'
@@ -208,34 +471,80 @@ def main(argv=None):
         'mode': args.mode,
         'workdir': args.workdir.replace('\\', '/'),
         'control': args.control.replace('\\', '/'),
-        'boards_scanned': len(rows),
+        # `files_scanned`, not `boards_scanned`: the scan reads pose RECORDS as
+        # well as boards, and a count that says "boards" while including
+        # records is the same category error the name exemption was.
+        'files_scanned': len(rows),
         'leaks': leaks,
         'recovered_to_truth': recovered,
         'unparseable': errors,
         'verdict': 'LEAK' if leaks else 'CLEAN',
     }
     if args.json:
+        if args.mode == 'create':
+            # CREATE runs with the fence UP. `worst_mm` IS the applied dose and
+            # `match_frac` is the block size -- the two things the staging
+            # script captures stdout to conceal. A leak verdict needs neither.
+            #
+            # `copper_displaced_pads` is the block size too, stated even more
+            # directly: it counts the pads the perturbation moved. It was added
+            # to this report and had to be added here in the same breath.
+            _strip = ('match_frac', 'worst_mm', 'refs_shared', 'mtime',
+                      'copper_displaced_pads', 'copper_hits_on_control',
+                      'copper_frac', 'copper_baseline_frac')
+            for _b in ('leaks', 'recovered_to_truth'):
+                report[_b] = [{k: v for k, v in r.items() if k not in _strip}
+                              for r in report[_b]]
+            report['note'] = ('create mode: per-board metrics withheld -- they '
+                              'disclose the perturbation dose and block size '
+                              'while the fence is still up')
         print(json.dumps(report, indent=1, sort_keys=True))
     else:
         print(f'fence_audit [{args.mode}] {args.workdir}: '
-              f'{len(rows)} board(s) scanned against {args.control}')
+              f'{len(rows)} file(s) scanned against {args.control}')
         for row in errors:
             print(f'  UNPARSEABLE {row["file"]}: {row["error"]}')
         for row in recovered:
             print(f'  ok  {row["file"]}: matches the control '
                   f'({row["match_frac"]:.3f}) -- {row["reason"]}')
         for row in leaks:
-            print(f'  LEAK {row["file"]}: carries the control\'s placement '
-                  f'({row["match_frac"]:.3f} of {row["refs_shared"]} refs '
-                  f'within {POSE_TOL_MM}mm)'
+            # NAME THE CHANNEL. The two leaks have different causes and
+            # different fixes, and printing the pose fraction for a copper leak
+            # describes a number that did not fire: run 14's own board matched
+            # only 0.874 of refs, well under the pose threshold, and was caught
+            # entirely by its copper.
+            if row.get('truth_channel') == 'copper':
+                # The COUNTS are the block size, so they are withheld while the
+                # fence is still up -- exactly like match_frac in the JSON. The
+                # channel is what the operator needs; the number is what the
+                # run must not see.
+                _cnt = ('' if args.mode == 'create' else
+                        f' ({row.get("copper_hits_on_control")} of '
+                        f'{row.get("copper_displaced_pads")} displaced pads '
+                        f'still have copper at the control\'s position)')
+                _how = (f'its COPPER marks the control\'s placement{_cnt}. '
+                        f'This board was staged from a ROUTED board and never '
+                        f'stripped -- the tracks point at where each part '
+                        f'belongs. Strip it with '
+                        f'tests/stress/strip_copper_only.py')
+            else:
+                _how = (f'carries the control\'s placement '
+                        f'({row["match_frac"]:.3f} of {row["refs_shared"]} '
+                        f'refs within {POSE_TOL_MM}mm)')
+            print(f'  LEAK {row["file"]}: {_how}'
                   + (f' -- {row["reason"]}' if row.get('reason') else ''))
         if leaks:
-            print(f'  VERDICT: LEAK -- {len(leaks)} board(s) carry ground truth '
-                  f'inside the work dir. Move them outside the fence before the '
-                  f'run, or declare them with --allow.')
+            _nb = sum(1 for r in leaks if r.get('kind') != 'record')
+            _nr = len(leaks) - _nb
+            _what = ' + '.join(([f'{_nb} board(s)'] if _nb else [])
+                               + ([f'{_nr} pose record(s)'] if _nr else []))
+            print(f'  VERDICT: LEAK -- {_what} carry ground truth inside the '
+                  f'work dir. Move them outside the fence before the run -- '
+                  f'that is what perturb(control_out=...) is for -- or declare '
+                  f'them with --allow.')
         else:
-            print('  VERDICT: CLEAN (no undeclared board carries the control\'s '
-                  'placement)')
+            print('  VERDICT: CLEAN (no undeclared board OR pose record '
+                  'carries the control\'s placement)')
     return 4 if leaks else 0
 
 

--- a/tests/stress/grade_final.py
+++ b/tests/stress/grade_final.py
@@ -185,8 +185,14 @@ def main():
             m = re.search(r"FOUND (\d+) DRC", o)
             grade["drc"] = int(m.group(1)) if m else (0 if "NO DRC" in o else None)
             grade["drc_final_raw"] = grade["drc"]
+            # `[^\n]*:` -- check_drc's per-type header carries an optional
+            # ` -- N in CONTACT` suffix, so a pinned `):` returned {} on every
+            # contact-carrying board. `drc` above is unaffected (different
+            # regex), so the symptom was a silently MISSING breakdown beside a
+            # correct total. `[A-Z0-9-]` matches board_score's char class so a
+            # numeric type name cannot reintroduce the same silence.
             grade["by_type"] = dict((k.strip(), int(v)) for k, v in
-                                    re.findall(r"^([A-Z][A-Z -]+?) violations \((\d+)\):", o, re.M))
+                                    re.findall(r"^([A-Z0-9][A-Z0-9 -]+?) violations \((\d+)\)[^\n]*:", o, re.M))
         except Exception as e2:
             grade["drc"] = None; grade["drc_err"] = str(e2)[:100]
     try:

--- a/tests/stress/manifest_to_plan.py
+++ b/tests/stress/manifest_to_plan.py
@@ -172,8 +172,17 @@ BOOL_FLAGS = {
 # --output still feeds the chain-pruning file list. --net-clearances is a
 # board-specific JSON path; the GUI derives the same map from the board's live
 # net classes, so a replayed plan carries no param for it.
+#
+# --deadline is a HARNESS budget, not a routing parameter: it changes nothing
+# about the copper, only how long the process is allowed to spend making it, and
+# the recorded number belongs to whatever external timeout the recording harness
+# had. The GUI has no equivalent and needs none -- it has a live Cancel button
+# driving the same `cancel_check`. Without this entry it falls through to the
+# unknown-flag branch and lands in the plan as a `deadline` param that no dialog
+# control matches, which the executor then drops silently; consuming it here
+# says so on purpose instead.
 IGNORE_FLAGS = {'--output', '--summary-json', '--schematic-dir', '--report',
-                '--net-clearances'}
+                '--net-clearances', '--deadline'}
 
 # Per-tool flag renames: bga_fanout calls the trace width --width (routed to the
 # Basic-tab track_width, which BGA fanout reads). qfn_fanout also uses --width

--- a/tests/stress/perturb_batch.py
+++ b/tests/stress/perturb_batch.py
@@ -252,10 +252,21 @@ def do_board(name, kind, out_dir, doses):
     for dose in doses:
         cell = os.path.join(work, f'd{dose:g}')
         os.makedirs(cell, exist_ok=True)
+        # GROUND TRUTH LIVES OUTSIDE THE CELL. The cell is the work dir every
+        # arm runs in, and the control is the human placement pose-for-pose --
+        # left beside `perturbed.kicad_pcb` (perturb's compatibility default)
+        # any glob, any `--before`, any tool taking a directory could read it,
+        # so the experiment would be fenced on paper and open in fact. `_truth/`
+        # is a sibling of the d<dose> cells, so `fence_audit --workdir <cell>`
+        # never walks it.
+        truth = os.path.join(work, '_truth', f'd{dose:g}')
+        os.makedirs(truth, exist_ok=True)
         perturbed = os.path.join(cell, 'perturbed.kicad_pcb')
         try:
             rec = P.perturb(board, perturbed, kind=kind, dose_mm=dose,
-                            ignore_nets=IGNORE_NETS)
+                            ignore_nets=IGNORE_NETS,
+                            control_out=os.path.join(truth,
+                                                     'control.kicad_pcb'))
         except Exception as exc:                            # noqa: BLE001
             rows.append({'board': name, 'kind': kind, 'dose_mm_requested': dose,
                          'status': 'error', 'reason': f'{type(exc).__name__}: {exc}'})
@@ -273,7 +284,9 @@ def do_board(name, kind, out_dir, doses):
         # per perturbed unit at its ORIGINAL bbox. Emitted intent alone is
         # vacuous on boards with no sheets (tigard/splitflap: 0 zones), so
         # without this the grader would PASS a wildly perturbed board.
-        intent = os.path.join(cell, 'truth_intent.json')
+        # It is DERIVED from truth (the unit's original bbox), so it belongs in
+        # `_truth/` with the control -- it is the grader's input, never an arm's.
+        intent = os.path.join(truth, 'truth_intent.json')
         _emit_truth_intent(control, members, intent)
 
         # Step 0b on the perturbed board -- what the skill would actually see.

--- a/tests/stress/placement_recovery_arm.py
+++ b/tests/stress/placement_recovery_arm.py
@@ -11,6 +11,14 @@ perturb.json (see the workdir prep in the run-8 notes), and prints one JSON
 object: the gate numbers, the graded output, how many vectors each source
 produced, the rigid-consistency count, and the recovery.
 
+THAT LAYOUT IS NOW A LEAK, and this reader is kept on it only to stay usable
+against the run-8 dirs that already exist. Truth living in the work dir is what
+run-12 Tier 0 closed: `fence_audit --mode create` reports a control inside the
+work dir whatever it is named, and `perturb(control_out=...)` puts the control
+AND the record in a sibling `_truth/`. Stage anything NEW that way
+(tests/stress/RUNBOOK.md, "Staging a perturbed subject") and point `ctrl` at
+the fenced path; do not copy this dir shape forward.
+
 Two rules this encodes, both learned the expensive way:
 
   * the applied dose must exceed the home tolerance, or the arm cannot measure

--- a/tests/stress/qualify_subject.py
+++ b/tests/stress/qualify_subject.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Is this board a usable subject for a perturbed-corpus run? Answer before staging.
+
+    python3 -X utf8 tests/stress/qualify_subject.py BOARD [BOARD ...] [--draws 5]
+
+Run 14 chose castor_pollux because it was the largest set-1 board no run had
+used. That is not a qualification. The draw it got was clipped to 0.100 mm, the
+board stayed perfectly legal, and an hour of chain time proved that an
+undamaged board was undamaged. Nothing in the rig could have told anyone in
+advance, because nobody asks the question this script asks.
+
+Three outcomes are possible and only one of them is a subject:
+
+  REJECT  the rig cannot damage this board. Draws clip to nothing, so
+          `recovery` and `home /N` will read near-perfect no matter what any
+          placement search does or does not do.
+  WEAK    the dose lands, but the copper-free gates stay clean. The damage is
+          real and invisible to every instrument the placement half owns, so a
+          repair loop has nothing to aim at and nothing to verify against.
+  GOOD    the dose lands AND the gates fire. Now a placement run can fail, and
+          a placement run that fails is the only kind that can succeed.
+
+This is deliberately CHEAP: it perturbs to a temp dir and grades copper-free,
+so it costs seconds per draw instead of the hour a full chain costs. It routes
+nothing. The routability question ("does the damaged board actually fail to
+route, and does the original succeed") is the expensive half and stays a manual
+step; see tests/stress/RUNBOOK.md.
+
+It prints AGGREGATES ONLY -- rates and medians over the draws -- and never the
+kind, block, seed or direction of any individual draw. So it is safe to run on
+a board you intend to stage blind afterwards, which is the whole point.
+"""
+import argparse
+import contextlib
+import io
+import json
+import os
+import random
+import re
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_placer'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_tools'))  # #522/py_placer layout
+
+from kicad_parser import parse_kicad_pcb  # noqa: E402
+import placement.perturb as P  # noqa: E402
+from stage_blind import (board_scale_mm, DOSE_BAND, MIN_MATERIAL_MM,  # noqa: E402
+                         MATERIAL_FRAC)
+
+#: Verdict bands. A board must land a material dose ALMOST every time to be a
+#: subject, not merely more often than not: a run stakes an hour of chain time
+#: on a single draw, so a 50% clip rate is a coin flip on whether the run has a
+#: subject at all. That is what happened on run 14.
+LAND_REJECT = 0.5      #: below this, the rig cannot damage the board
+LAND_GOOD = 0.8        #: at or above this, the draw is dependable
+FIRE_GOOD = 0.5        #: fraction of landed draws that must trip a gate
+
+
+def _board_clearance(board):
+    """The board's own Default netclass clearance, else the routing default."""
+    try:
+        from list_nets import board_default_netclass_clearance
+        v = board_default_netclass_clearance(board)
+        if v:
+            return float(v)
+    except Exception:                                   # noqa: BLE001
+        pass
+    return 0.25
+
+
+def _gates(board, clearance):
+    """(drc_violations, assembly_blocking) on the COPPER-FREE board."""
+    drc = subprocess.run(
+        [sys.executable, '-X', 'utf8', os.path.join(ROOT, 'py_router', 'check_drc.py'), board,
+         '--clearance', str(clearance), '--check-pad-edge'],
+        capture_output=True, text=True)
+    # check_drc emits exactly two summary shapes -- `FOUND {n} DRC VIOLATIONS:`
+    # and `NO DRC VIOLATIONS FOUND!`. It has never printed "Total violations",
+    # so the old scan for that string was dead code that ALWAYS fell through to
+    # a fallback counting every line containing "VIOLATION" -- the FOUND banner
+    # plus one per type header, i.e. `1 + n_types`, never the real count (a
+    # 40-violation board read as 3). It only ever fed a `> 0` boolean, so the
+    # verdicts were right by luck rather than by measurement.
+    nv = 0
+    if 'NO DRC VIOLATIONS' not in drc.stdout:
+        m = re.search(r'^FOUND (\d+) DRC VIOLATIONS', drc.stdout, re.M)
+        if m:
+            nv = int(m.group(1))
+        else:
+            # No recognisable summary: do not invent a number. -1 is "unknown",
+            # which is still truthy for the `> 0` gate but cannot be mistaken
+            # for a measured count if this is ever read quantitatively.
+            nv = -1
+    asm = subprocess.run(
+        [sys.executable, '-X', 'utf8', os.path.join(ROOT, 'py_tools', 'check_assembly.py'),
+         board, '--clearance', str(clearance)],
+        capture_output=True, text=True)
+    blocking = 0
+    for line in asm.stdout.splitlines():
+        s = line.strip()
+        if s.startswith('blocking '):
+            blocking = int(s.split()[1])
+            break
+    return nv, blocking
+
+
+def qualify(board, draws=5, seed=None):
+    pcb = parse_kicad_pcb(board)
+    scale = board_scale_mm(pcb)
+    if scale is None:
+        return {'board': board, 'verdict': 'REJECT',
+                'reason': 'no usable outline, so a dose cannot be scaled to it'}
+    if pcb.segments or pcb.vias:
+        return {'board': board, 'verdict': 'REJECT',
+                'reason': 'board carries copper; strip it first (the placement '
+                          'gate refuses a routed board, and the copper encodes '
+                          'the original poses)'}
+
+    rng = random.Random(seed if seed is not None
+                        else int.from_bytes(os.urandom(8), 'big'))
+    clearance = _board_clearance(board)
+    tmp = tempfile.mkdtemp(prefix='qualify_')
+    landed, fired, applied, blocked = 0, 0, [], []
+    try:
+        for _ in range(draws):
+            kind = rng.choice(P.KINDS)
+            dose = max(3.0, scale * rng.uniform(*DOSE_BAND))
+            out = os.path.join(tmp, 'p.kicad_pcb')
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
+                rec = P.perturb(board, out, kind=kind, dose_mm=dose,
+                                seed=int.from_bytes(os.urandom(4), 'big'),
+                                write_record=False,
+                                control_out=os.path.join(tmp, 'c.kicad_pcb'))
+            a = float(rec.get('dose_mm_applied') or 0.0)
+            applied.append(a)
+            if rec.get('status') == 'ok' and \
+                    a >= max(MIN_MATERIAL_MM, MATERIAL_FRAC * dose):
+                landed += 1
+                nv, blk = _gates(out, clearance)
+                blocked.append((nv, blk))
+                if nv > 0 or blk > 0:
+                    fired += 1
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    land_rate = landed / float(draws)
+    fire_rate = (fired / float(landed)) if landed else 0.0
+    # Bands chosen against run 14: castor_pollux lands about half its draws,
+    # which is not REJECT (the board CAN be damaged; at 2.0 mm it goes NOT
+    # BUILDABLE) but is emphatically not GOOD either, because a coin flip
+    # decides whether the run has a subject at all. That case has to have a
+    # name, and WEAK is it.
+    if land_rate < LAND_REJECT:
+        verdict, reason = 'REJECT', (
+            'only %d of %d draws landed a material dose; recovery here would '
+            'measure the clip, not the run' % (landed, draws))
+    elif land_rate < LAND_GOOD:
+        verdict, reason = 'WEAK', (
+            'only %d of %d draws landed a material dose; usable, but expect '
+            'to redraw and never assume the dose landed' % (landed, draws))
+    elif fire_rate < FIRE_GOOD:
+        verdict, reason = 'WEAK', (
+            'doses land (%d/%d) but only %d made a copper-free gate fire; the '
+            'damage is largely invisible to the placement half'
+            % (landed, draws, fired))
+    else:
+        verdict, reason = 'GOOD', (
+            '%d of %d draws landed, and %d of those made a gate fire'
+            % (landed, draws, fired))
+    return {'board': board, 'verdict': verdict, 'reason': reason,
+            'draws': draws, 'landed': landed, 'gates_fired': fired,
+            'land_rate': round(land_rate, 3), 'fire_rate': round(fire_rate, 3),
+            'applied_mm_median': round(statistics.median(applied), 3) if applied else None,
+            'applied_mm_min': round(min(applied), 3) if applied else None,
+            'applied_mm_max': round(max(applied), 3) if applied else None,
+            'graded_at_clearance': clearance, 'board_scale_mm': round(scale, 1)}
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument('boards', nargs='+')
+    ap.add_argument('--draws', type=int, default=5,
+                    help='draws per board (default 5). More is better and '
+                         'costs seconds; the variance between draws is the '
+                         'thing run 14 got caught by.')
+    ap.add_argument('--seed', type=int, default=None,
+                    help='make the QUALIFICATION reproducible. Does not seed '
+                         'the run you stage afterwards.')
+    ap.add_argument('--json', dest='json_out', default=None)
+    a = ap.parse_args()
+
+    rows = []
+    for b in a.boards:
+        r = qualify(b, draws=a.draws, seed=a.seed)
+        rows.append(r)
+        print('%-9s %-34s %s' % (r['verdict'], os.path.basename(b), r['reason']))
+        if r.get('applied_mm_median') is not None:
+            print('          applied dose mm: median %.3f, range %.3f to %.3f'
+                  ' | graded at clearance %.3f'
+                  % (r['applied_mm_median'], r['applied_mm_min'],
+                     r['applied_mm_max'], r['graded_at_clearance']))
+    if a.json_out:
+        with open(a.json_out, 'w', encoding='utf-8') as f:
+            json.dump(rows, f, indent=1)
+        print('  JSON -> %s' % a.json_out)
+    good = [r for r in rows if r['verdict'] == 'GOOD']
+    print('\n%d of %d qualify as subjects' % (len(good), len(rows)))
+    return 0 if good else 1
+
+
+if __name__ == '__main__':
+    import cli_banner
+    cli_banner.install()
+    sys.exit(main())

--- a/tests/stress/qualify_subject.py
+++ b/tests/stress/qualify_subject.py
@@ -208,6 +208,9 @@ def main():
                   % (r['applied_mm_median'], r['applied_mm_min'],
                      r['applied_mm_max'], r['graded_at_clearance']))
     if a.json_out:
+        # run 19 lost a qualification JSON to a not-yet-created directory
+        # AFTER all the draws had been paid for. Make the parent, then write.
+        os.makedirs(os.path.dirname(a.json_out) or '.', exist_ok=True)
         with open(a.json_out, 'w', encoding='utf-8') as f:
             json.dump(rows, f, indent=1)
         print('  JSON -> %s' % a.json_out)

--- a/tests/stress/stage_blind.py
+++ b/tests/stress/stage_blind.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Stage a BLIND perturbed subject: damaged board here, truth over there.
+
+    python3 -X utf8 tests/stress/stage_blind.py SRC.kicad_pcb WORKDIR TRUTHDIR
+
+The run may open WORKDIR/board.kicad_pcb and nothing else. TRUTHDIR gets the
+control, the perturbation record and the draw, and is not read until the board
+is frozen. Pair it with `fence_audit.py --mode create` immediately afterwards.
+
+Disclosure discipline, tightened against the leaks earlier runs found:
+
+  * The writer's own "Modified N footprint positions" line is a dose/block
+    tell, so every call runs with stdout captured and discarded.
+  * Run 10 disclosed `PERTURBED BLOCK N` because its report's `home /N`
+    denominator needed it, and a watcher correctly called that a leak: a
+    `swap` draw unions two disjoint blocks and so reports a distinctly larger
+    N than the other kinds. This script discloses NOTHING about the block. The
+    denominator is read from the record at AUDIT time, when the fence is
+    already down; the run itself is scored on the routed outcome, which needs
+    no truth at all.
+  * There is deliberately NO redraw gate. Run 10 used `home_frac <= 0.20`,
+    an asymmetric filter that bites mainly on `scatter` and is therefore
+    itself informative about the kind.
+
+THE DOSE IS SCALED TO THE BOARD, and this file used to only claim that.
+The previous version called `placement.perturb.max_feasible_dose(pcb)` with one
+positional argument against a signature of `(state, members, u, *, grid_step,
+dose_cap, ...)`. Binding failed on ARITY, before any board data was touched --
+so the `except` was not a guard, it was the ONLY path, and a hard-coded 30.0 mm
+was the scale for every board on earth. The docstring's "a band of the board's
+own max feasible dose" was not unverifiable; it was always false.
+
+It cannot be fixed by correcting the arity either: `max_feasible_dose` answers
+"how far can THIS block travel along THIS direction, up to dose_cap" -- it is
+bounded by the cap you pass, so it cannot be used to DERIVE a dose, and it
+needs a block and a direction that do not exist until after the draw. There is
+no board-maximum mode to call.
+
+So the scale comes from a real board property instead: the outline's smaller
+span, which is what actually bounds how far a part can move and still be on
+the board. `perturb()` independently clips whatever is asked for
+(`on_overflow='clip'`), and the APPLIED dose is recorded in the record as
+`max_feasible_dose_mm` / `clipped` -- so the truth dir holds what landed, not
+what was requested.
+
+AND THE APPLIED DOSE IS NOW CHECKED, which is the other half of that sentence
+and was missing. Recording what landed in the truth dir is no use to a run that
+is told "damage applied" either way. Run 14 staged castor_pollux with a
+requested dose of >= 4.248 mm and an applied dose of 0.100 mm -- the mutation's
+own `grid_step` -- because the block was hard against the outline and
+`on_overflow='clip'` ate 98% of it. Nothing in this file read `rec['clipped']`,
+`rec['status']` or `rec['dose_mm_applied']`, so it exited 0. The run then spent
+an hour proving, correctly, that an undamaged board was undamaged.
+
+A draw is now accepted only if it MEASURABLY landed (see MIN_MATERIAL_MM /
+MATERIAL_FRAC below), and otherwise redrawn up to MAX_DRAWS times before the
+script refuses outright. The disclosure stays fence-safe: one line saying a
+redraw happened, with no count, no kind, no block and no dose.
+"""
+import contextlib
+import io
+import json
+import os
+import random
+import shutil
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_placer'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_tools'))  # #522/py_placer layout
+
+from kicad_parser import parse_kicad_pcb  # noqa: E402
+import placement.perturb as P  # noqa: E402
+
+#: Fraction of the board's smaller span a single draw may ask for. The low end
+#: has to be material (a 1 mm nudge on an 80 mm board is not a recovery test)
+#: and the high end has to leave the board recognisable.
+DOSE_BAND = (0.06, 0.22)
+
+#: A draw is only a subject if the damage ACTUALLY LANDED. `perturb()` clips to
+#: the outline (`on_overflow='clip'`), so a block hard against an edge can be
+#: asked for 4 mm and moved 0.1 mm -- and the old code printed "damage applied"
+#: and exited 0 regardless, because it never read `rec['clipped']`,
+#: `rec['status']` or `rec['dose_mm_applied']`. Run 14 (castor_pollux) was
+#: staged that way: 24 parts displaced by 0.100 mm, which is exactly the
+#: mutation's own `grid_step`. Every placement instrument reported the board
+#: clean, correctly, and the recovery half of the run was void before it began.
+#:
+#: So the draw is now CHECKED and, if it did not land, REDRAWN. The bar is
+#: measured off `dose_mm_applied` -- the grader's own perturbed-pad RMS, which
+#: is what `recovery` later divides by -- and not off the requested dose, which
+#: is the number that lied.
+MIN_MATERIAL_MM = 1.0      #: absolute floor; 10x the 0.1 mm legalize grid step
+MATERIAL_FRAC = 0.35       #: ...and at least this much of what was asked for
+MAX_DRAWS = 12             #: redraw budget before refusing outright
+
+
+def board_scale_mm(pcb):
+    """The board's smaller outline span, or None when it declares no outline.
+
+    This is a REAL board property, unlike the constant it replaces. It is the
+    dimension that actually bounds a displacement: a part pushed further than
+    this along the short axis is off the board whatever the dose says.
+    """
+    b = getattr(pcb.board_info, 'board_bounds', None)
+    if not b:
+        return None
+    w, h = abs(b[2] - b[0]), abs(b[3] - b[1])
+    return min(w, h) if w > 0 and h > 0 else None
+
+
+def main(src, workdir, truthdir, kinds=None):
+    """`kinds` narrows the draw to a subset of KINDS, or None for all of them.
+
+    NARROWING IS A DISCLOSURE, and the run must say so. The kinds displace very
+    different fractions of a board -- measured on neo6502, `pile` moves 67% of
+    the parts and `translate` 27% -- so a run that wants the placement half
+    exercised has a legitimate reason to ask for one. What it costs is exactly
+    one bit of the fence: the run is still blind to the block, the dose and the
+    seed, but it knows the kind. Report it that way rather than implying a full
+    blind draw.
+    """
+    os.makedirs(workdir, exist_ok=True)
+    os.makedirs(truthdir, exist_ok=True)
+
+    pool = tuple(kinds) if kinds else P.KINDS
+    bad = [k for k in pool if k not in P.KINDS]
+    if bad:
+        raise SystemExit('stage_blind: unknown kind(s) %s. Valid: %s'
+                         % (', '.join(bad), ' '.join(P.KINDS)))
+
+    rng = random.Random(int.from_bytes(os.urandom(16), 'big'))
+
+    # The AUDIT reference: a plain copy of the source. The perturbation writes
+    # its own dose-0 control below, straight into the truth dir -- it must
+    # never be derived from `out`, which is what put the human placement inside
+    # the work dir in the first place (run-12 Tier 0).
+    control = os.path.join(truthdir, 'control.kicad_pcb')
+    shutil.copyfile(src, control)
+    for ext in ('.kicad_pro', '.kicad_prl'):
+        sib = os.path.splitext(src)[0] + ext
+        if os.path.exists(sib):
+            shutil.copyfile(sib, os.path.join(truthdir, 'control' + ext))
+
+    out = os.path.join(workdir, 'board.kicad_pcb')
+
+    # Computed under capture -- the scale is itself a size tell, and so is
+    # every rejected draw.
+    buf = io.StringIO()
+    attempts = []
+    rec = kind = seed = dose = None
+    with contextlib.redirect_stdout(buf), contextlib.redirect_stderr(buf):
+        pcb = parse_kicad_pcb(src)
+        scale = board_scale_mm(pcb)
+        if scale is None:
+            raise SystemExit(
+                'stage_blind: this board declares no usable outline, so a '
+                'dose cannot be scaled to it. Refusing rather than falling '
+                'back to a constant -- a silent constant is what this script '
+                'shipped for three runs.')
+        for _ in range(MAX_DRAWS):
+            k = rng.choice(pool)
+            s = int.from_bytes(os.urandom(4), 'big')
+            d = max(3.0, scale * rng.uniform(*DOSE_BAND))
+            # control_out FENCES BOTH HALVES OF TRUTH IN ONE CALL. Without it
+            # the tool writes `board.control.kicad_pcb` -- the human placement,
+            # pose for pose -- and `board.perturb.json` (it embeds
+            # `original_poses`) beside the damaged board, INSIDE the work dir
+            # the run then reads.
+            r = P.perturb(src, out, kind=k, dose_mm=d, seed=s,
+                          write_record=True,
+                          control_out=os.path.join(
+                              truthdir, 'perturbed.control.kicad_pcb'))
+            applied = float(r.get('dose_mm_applied') or 0.0)
+            need = max(MIN_MATERIAL_MM, MATERIAL_FRAC * d)
+            landed = r.get('status') == 'ok' and applied >= need
+            attempts.append({'kind': k, 'seed': s, 'dose_mm_requested': d,
+                             'dose_mm_applied': applied, 'required': need,
+                             'clipped': bool(r.get('clipped')),
+                             'status': r.get('status'), 'accepted': landed})
+            if landed:
+                rec, kind, seed, dose = r, k, s, d
+                break
+
+    if rec is None:
+        # Same shape as the outline guard: refuse rather than hand back a cell
+        # that looks like a result and is not one. The message names no kind,
+        # no block and no dose -- only that this BOARD would not take one.
+        raise SystemExit(
+            'stage_blind: no draw landed a material dose on this board after '
+            '%d attempts, so there is no subject to stage. Refusing rather '
+            'than emitting a board whose damage is at the grid step -- that '
+            'is what voided run 14.' % MAX_DRAWS)
+
+    with open(os.path.join(truthdir, 'draw.json'), 'w', encoding='utf-8') as f:
+        json.dump({'kind': kind, 'dose_mm': dose, 'seed': seed,
+                   'dose_mm_applied': rec.get('dose_mm_applied'),
+                   'clipped': bool(rec.get('clipped')),
+                   'board_scale_mm': scale, 'dose_band': list(DOSE_BAND),
+                   'material_floor_mm': MIN_MATERIAL_MM,
+                   'material_frac': MATERIAL_FRAC,
+                   'draws': attempts, 'source': src}, f, indent=1)
+    written = os.path.join(truthdir, 'board.perturb.json')
+    want = os.path.join(truthdir, 'perturbed.perturb.json')
+    if os.path.exists(written):
+        shutil.move(written, want)
+    for cand in (os.path.splitext(out)[0] + '.perturb.json',):
+        if os.path.exists(cand):
+            shutil.move(cand, want)
+    if not os.path.exists(want):
+        with open(want, 'w', encoding='utf-8') as f:
+            json.dump(rec, f, indent=1)
+
+    # The ONLY disclosure: board shape, which is visible on the board anyway.
+    # NOT the scale, the band, the dose, the kind, the seed or the block.
+    p = parse_kicad_pcb(out)
+    b = p.board_info.board_bounds
+    print(f"parts {len(p.footprints)} | nets "
+          f"{len([n for n in p.nets.values() if n.name])} | copper layers "
+          f"{len(p.board_info.copper_layers)} "
+          f"({', '.join(p.board_info.copper_layers)}) | bbox "
+          f"{b[2]-b[0]:.1f} x {b[3]-b[1]:.1f}")
+    print(f"segments {len(p.segments)} | vias {len(p.vias)}")
+    if len(attempts) > 1:
+        # Fence-safe: says a redraw happened and why, and nothing about the
+        # kind, the block, the seed or the dose. Deliberately carries no count
+        # -- how MANY draws a board rejects is a property of the board, and the
+        # run does not need it. The full attempt list is in the truth dir.
+        print("stage_blind: redrew (dose infeasible for this board)")
+    print("damage applied; kind/dose/seed/block written to the truth dir "
+          "and disclosed nowhere")
+
+
+if __name__ == '__main__':
+    import argparse
+    ap = argparse.ArgumentParser(
+        description=__doc__.strip().splitlines()[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('src'); ap.add_argument('workdir'); ap.add_argument('truthdir')
+    ap.add_argument('--kind', action='append', metavar='KIND',
+                    help='narrow the draw to this perturbation kind '
+                         '(repeatable). Valid: ' + ' '.join(P.KINDS) + '. The '
+                         'kinds displace very different fractions of a board '
+                         '(measured: pile 67%%, translate 27%%), so a run that '
+                         'wants the PLACEMENT half exercised has a reason to '
+                         'ask. It costs one bit of the fence -- still blind to '
+                         'block, dose and seed, but not to kind -- so SAY SO '
+                         'in the report.')
+    _a = ap.parse_args()
+    main(_a.src, _a.workdir, _a.truthdir, _a.kind)

--- a/tests/stress/strip_copper_only.py
+++ b/tests/stress/strip_copper_only.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Remove ONLY copper from a .kicad_pcb, preserving everything else.
+
+Makes the unrouted twin of a routed corpus board, which is what a
+perturbed-corpus run needs as a subject: `placement_driver --stage P0`
+refuses a board carrying copper, and on a ROUTED board that copper also
+encodes the original poses (run 14 measured 301 of 569 pads within 5 um of
+their own track endpoint, which `fence_audit` cannot see because it
+compares poses and never opens copper).
+
+    python3 -X utf8 tests/stress/strip_copper_only.py SRC.kicad_pcb DST.kicad_pcb
+
+Why this exists instead of `tests/stress/strip_routing.py` / `prep_set2.py`:
+those are corpus NORMALIZERS and they rewrite `Edge.Cuts` (RDP-simplify the
+outline, rebuild it as chained segments, drop graphics). The routing skill
+forbids them for exactly that reason -- the outline is a mechanical decision.
+For a recovery run the outline must stay bit-identical, because the final board
+is compared against a human reference that has the ORIGINAL outline.
+
+So this removes, and removes nothing else:
+  * top-level `(segment ...)`  -- straight track copper
+  * top-level `(arc ...)`      -- curved track copper (this board is arc-heavy)
+  * top-level `(via ...)`
+  * `(filled_polygon ...)` inside zones -- the pour result, not the pour intent
+
+Zone DEFINITIONS survive: a zone is design intent (which net pours where), not
+routing output, and dropping it would silently delete part of the board's
+design. Footprints, pads, graphics, `Edge.Cuts`, `setup`, stackup, netlist and
+every uuid are untouched.
+
+The scanner is quote-aware: KiCad s-expr strings may contain parentheses, and a
+naive depth counter desyncs on the first `(gr_text "foo (bar)")`.
+"""
+import os
+import re
+import shutil
+import sys
+
+DROP_TOP = {'segment', 'arc', 'via'}
+DROP_NESTED = {'filled_polygon'}
+_HEAD = re.compile(r'\(\s*([A-Za-z_0-9]+)')
+
+
+def _forms(text):
+    """Yield (start, end, depth, head) for every s-expression form."""
+    stack = []
+    in_str = False
+    esc = False
+    for i, ch in enumerate(text):
+        if in_str:
+            if esc:
+                esc = False
+            elif ch == '\\':
+                esc = True
+            elif ch == '"':
+                in_str = False
+            continue
+        if ch == '"':
+            in_str = True
+        elif ch == '(':
+            stack.append(i)
+        elif ch == ')':
+            if not stack:
+                raise SystemExit('unbalanced ")" at offset %d' % i)
+            s = stack.pop()
+            m = _HEAD.match(text, s)
+            yield s, i + 1, len(stack), (m.group(1) if m else '')
+    if stack:
+        raise SystemExit('unbalanced "(" -- %d unclosed' % len(stack))
+
+
+def strip(text):
+    cuts = []
+    for s, e, depth, head in _forms(text):
+        if depth == 1 and head in DROP_TOP:
+            cuts.append((s, e))
+        elif depth >= 2 and head in DROP_NESTED:
+            cuts.append((s, e))
+    # Forms are yielded innermost-first; keep only outermost non-overlapping.
+    cuts.sort()
+    merged = []
+    for s, e in cuts:
+        if merged and s < merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], e))
+        else:
+            merged.append((s, e))
+    out = []
+    prev = 0
+    for s, e in merged:
+        # also swallow the run of whitespace that indented the dropped form
+        b = s
+        while b > prev and text[b - 1] in ' \t':
+            b -= 1
+        if b > prev and text[b - 1] == '\n':
+            b -= 1
+        out.append(text[prev:b])
+        prev = e
+    out.append(text[prev:])
+    return ''.join(out), len(merged)
+
+
+def main(src, dst):
+    text = open(src, encoding='utf-8').read()
+    new, n = strip(text)
+    os.makedirs(os.path.dirname(os.path.abspath(dst)), exist_ok=True)
+    with open(dst, 'w', encoding='utf-8', newline='') as f:
+        f.write(new)
+    for ext in ('.kicad_pro', '.kicad_prl', '.kicad_dru'):
+        sib = os.path.splitext(src)[0] + ext
+        if os.path.exists(sib):
+            shutil.copyfile(sib, os.path.splitext(dst)[0] + ext)
+    print('dropped %d copper form(s); %d -> %d chars' % (n, len(text), len(new)))
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 3:
+        raise SystemExit(__doc__.strip().splitlines()[2].strip())
+    main(sys.argv[1], sys.argv[2])

--- a/tests/test_431_render_placement.py
+++ b/tests/test_431_render_placement.py
@@ -497,6 +497,73 @@ def test_focus_without_summary_json_warns():
         shutil.rmtree(d, ignore_errors=True)
 
 
+# --- D8: the render must be able to say its net list missed -----------------
+#
+# There was NO field in the instrument block where "61 requested, 51 matched"
+# could ever appear, and that absence is why a mangled net list went undetected:
+# board_score published `--ignore-nets` candidates double-escaped, 10 of 61
+# matched nothing, and the render reported hpwl +45.6% / crossings +129.5% on an
+# identical board. Both renders were internally consistent. The operator had to
+# compare declared against matched by hand, outside the tool.
+
+def test_net_pattern_report_counts_declared_against_matched():
+    """The unit the JSON field is built from -- no rendering needed."""
+    pcb = parse_kicad_pcb(PLACED)
+    names = [n.name for n in pcb.nets.values() if n.name]
+    real = names[0]
+    rep = RP.net_pattern_report(pcb, [real, 'NOSUCHNET', 'ALSO_NOT_HERE*'],
+                                '--ignore-nets')
+    assert rep['requested'] == 3, rep
+    assert rep['matched'] == 1, rep
+    assert rep['unmatched'] == ['ALSO_NOT_HERE*', 'NOSUCHNET'], rep
+    assert rep['nets_matched'] >= 1, rep
+    # An empty list is not a failure, and must still produce the fields --
+    # a key that appears only on failure is a key no reader looks for.
+    empty = RP.net_pattern_report(pcb, None, '--ratsnest-nets')
+    assert empty == {'flag': '--ratsnest-nets', 'requested': 0, 'matched': 0,
+                     'unmatched': [], 'nets_matched': 0}, empty
+
+
+def test_a_net_list_that_missed_is_reported_in_the_json_and_on_stderr():
+    """The single change that would have caught the double-escaping."""
+    import json as _json
+    d = tempfile.mkdtemp()
+    try:
+        js = os.path.join(d, 'r.json')
+        # 'GND' exists on this board; the other two cannot. The second is the
+        # measured shape exactly -- a real net name carrying one backslash too
+        # many, which is indistinguishable from a net that does not exist.
+        r = _run(PLACED, '-o', os.path.join(d, 'r.png'), '--json-out', js,
+                 '--size', '300', '--supersample', '1',
+                 '--ignore-nets', 'GND', 'NOSUCHNET', '/GPIO10\\\\OE3#')
+        assert r.returncode == 0, r.stderr[-600:]
+
+        rep = _json.load(open(js, encoding='utf-8'))['instrument']['net_lists']
+        ig = rep['ignore_nets']
+        assert (ig['requested'], ig['matched']) == (3, 1), ig
+        assert ig['unmatched'] == ['/GPIO10\\\\OE3#', 'NOSUCHNET'], ig
+        assert 'ratsnest_nets' in rep, 'both net lists must be reported'
+
+        # ...and it must SAY so, unprompted. A JSON field nobody opens is not
+        # a warning.
+        assert '3 requested, 1 matched' in r.stderr, r.stderr[-600:]
+        assert 'NOSUCHNET' in r.stderr, r.stderr[-600:]
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+def test_a_fully_matching_net_list_stays_quiet():
+    """The warning has to mean something, so it must not fire on a good run."""
+    d = tempfile.mkdtemp()
+    try:
+        r = _run(PLACED, '-o', os.path.join(d, 'r.png'), '--size', '300',
+                 '--supersample', '1', '--ignore-nets', 'GND')
+        assert r.returncode == 0, r.stderr[-600:]
+        assert 'matched NO net' not in r.stderr, r.stderr[-400:]
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
 def test_legality_findings_cached_once_per_model():
     m = _model()
     a = RP.legality_findings(m)

--- a/tests/test_431_render_placement.py
+++ b/tests/test_431_render_placement.py
@@ -486,13 +486,23 @@ def test_expect_moved_mismatch_is_reported_not_fatal():
         shutil.rmtree(d, ignore_errors=True)
 
 
-def test_focus_without_summary_json_warns():
+def test_focus_without_summary_json_clusters_legality_findings():
+    """--focus with no --summary-json used to warn and emit nothing (run-4
+    G7); it now clusters the LEGALITY findings -- which need no route summary
+    -- into pocket panels instead of refusing. Pin the refusal-free path: no
+    warning, and the pocket siblings actually land next to the base render."""
     d = tempfile.mkdtemp()
     try:
         r = _run(PLACED, '-o', os.path.join(d, 'r.png'), '--focus',
                  '--size', '320', '--supersample', '1')
         assert r.returncode == 0
-        assert '--focus emits nothing without --summary-json' in r.stderr
+        assert '--focus emits nothing without --summary-json' not in r.stderr
+        assert os.path.exists(os.path.join(d, 'r.png'))
+        pockets = sorted(f for f in os.listdir(d) if 'pocket' in f)
+        assert pockets, (r.stdout, r.stderr)
+        # This fixture HAS legality findings, so the empty-board NOTE must
+        # not fire either -- the pockets ARE the focus output.
+        assert 'found nothing to focus on' not in r.stderr, r.stderr
     finally:
         shutil.rmtree(d, ignore_errors=True)
 

--- a/tests/test_assembly_coincident_stack.py
+++ b/tests/test_assembly_coincident_stack.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""check_assembly must grade a coincident-origin stack NOT BUILDABLE.
+
+Run 19, measured twice: SW17+SW34+REF_PUCK_R all at (128.399, 61.001) graded
+`buildable (blocking 0)` -- the pair currency counts pad INTERSECTIONS, and
+the rotated pads happened to interleave. A stack of parts at one origin is
+unbuildable whatever the pads do, so it is now its own blocking channel:
+`coincident_origin_groups` / `coincident_origins` in the JSON, COINCIDENT
+ORIGINS in the findings, and the verdict/exit-code flip.
+
+Three cases, on one fixture board:
+
+  * a stack whose pads DON'T intersect (the run-19 shape: blocking stays 0)
+    flips the verdict through the new channel alone -- exit 4, NOT BUILDABLE,
+    and the JSON group names both refs;
+  * the unmodified board still grades clean, exit 0;
+  * a marker pair (two mounting holes moved onto one point) is exonerated by
+    the stack channel -- markers are co-located by design (mouse-bites,
+    fiducials), exactly placement_state's `_suspect_in` prior art.
+
+Run: python3 -X utf8 tests/test_assembly_coincident_stack.py
+"""
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_placer'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_tools'))  # #522/py_placer layout
+os.environ.setdefault('KRT_NO_BANNER', '1')
+
+FIXTURE = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
+TOOL = os.path.join(ROOT, 'py_tools', 'check_assembly.py')
+
+FAILURES = []
+
+
+def check(name, cond, detail=''):
+    print(f'  {"PASS" if cond else "FAIL"}  {name}'
+          + (f'\n        {detail}' if not cond and detail else ''))
+    if not cond:
+        FAILURES.append(name)
+
+
+def run_tool(board, json_out):
+    r = subprocess.run([sys.executable, '-X', 'utf8', TOOL, board,
+                        '--json', json_out],
+                       capture_output=True, text=True, encoding='utf-8',
+                       errors='replace', timeout=600, cwd=ROOT)
+    doc = None
+    if os.path.isfile(json_out):
+        with open(json_out, encoding='utf-8') as f:
+            doc = json.load(f)
+    return r.returncode, r.stdout + r.stderr, doc
+
+
+def rewrite(text, old_at, new_at, out_path):
+    """Move one footprint by rewriting its `(at x y ...)` line, and REFUSE to
+    write a board the substitution did not change -- a drifted fixture must
+    fail loudly here, not downstream as a mystery-clean grade."""
+    moved = text.replace(old_at, new_at, 1)
+    if moved == text:
+        raise AssertionError(f'fixture drift: {old_at!r} not found in '
+                             f'{FIXTURE}')
+    with open(out_path, 'w', encoding='utf-8') as f:
+        f.write(moved)
+    return out_path
+
+
+def main():
+    text = open(FIXTURE, encoding='utf-8').read()
+    tmp = tempfile.mkdtemp(prefix='coincident_stack_')
+    try:
+        print('a stack whose pads INTERLEAVE is caught by the new channel')
+        # C1 (an 0603) moved onto C3's origin (an 8x10 elec cap whose pads sit
+        # ~3mm out): no pad intersects, so `blocking` stays 0 -- exactly the
+        # run-19 shape the pair currency graded `buildable (blocking 0)`.
+        board = rewrite(text, '(at 200.66 34.29 90)', '(at 144.78 31.75 90)',
+                        os.path.join(tmp, 'stacked.kicad_pcb'))
+        code, out, doc = run_tool(board, os.path.join(tmp, 'stacked.json'))
+        check('exit code 4', code == 4, f'exit {code}\n{out[-600:]}')
+        check('verdict NOT BUILDABLE', 'NOT BUILDABLE' in out, out[-600:])
+        check('...through the stack channel alone (blocking 0)',
+              doc is not None and doc.get('blocking') == 0,
+              str(doc and doc.get('blocking')))
+        check('JSON buildable False', doc is not None
+              and doc.get('buildable') is False, str(doc and doc.get('buildable')))
+        groups = (doc or {}).get('coincident_origin_groups') or []
+        check('one JSON group naming both refs',
+              len(groups) == 1 and sorted(groups[0]['refs']) == ['C1', 'C3'],
+              str(groups))
+        check('scalar coincident_origins is the group count',
+              (doc or {}).get('coincident_origins') == 1,
+              str((doc or {}).get('coincident_origins')))
+        check('the findings block prints the group',
+              'COINCIDENT ORIGINS' in out and '@ (144.78, 31.75)' in out,
+              out[-600:])
+
+        print('the unmodified board still grades clean')
+        clean = os.path.join(tmp, 'clean.kicad_pcb')
+        shutil.copyfile(FIXTURE, clean)
+        code, out, doc = run_tool(clean, os.path.join(tmp, 'clean.json'))
+        check('exit code 0', code == 0, f'exit {code}\n{out[-600:]}')
+        check('buildable, zero groups', doc is not None
+              and doc.get('buildable') is True
+              and doc.get('coincident_origins') == 0
+              and doc.get('coincident_origin_groups') == [], str(doc)[:300])
+
+        print('a marker pair at one point is exonerated by the stack channel')
+        # H1 moved onto H2 (both M3 mounting holes): co-located markers are
+        # by-design (mouse-bites, fiducials) and must NOT flag as a stack.
+        # Their annular pads DO physically intersect, so the OLD blocking
+        # channel still fires -- correctly, and that is not under test here.
+        board = rewrite(text, '(at 28.702 28.702)', '(at 220.218 28.702)',
+                        os.path.join(tmp, 'markers.kicad_pcb'))
+        code, out, doc = run_tool(board, os.path.join(tmp, 'markers.json'))
+        check('no COINCIDENT ORIGINS finding', 'COINCIDENT ORIGINS' not in out,
+              out[-600:])
+        check('zero groups in the JSON', doc is not None
+              and doc.get('coincident_origins') == 0
+              and doc.get('coincident_origin_groups') == [],
+              str(doc and doc.get('coincident_origin_groups')))
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    print()
+    if FAILURES:
+        print(f'FAIL: {len(FAILURES)} check(s): {", ".join(FAILURES)}')
+        return 1
+    print('OK')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_bga_fanout_underpad.py
+++ b/tests/test_bga_fanout_underpad.py
@@ -73,12 +73,93 @@ def main():
     bcu_edge = any(t['layer'] == 'B.Cu' for t in t2)
     checks.append(("bottom-side edge escape uses B.Cu", bcu_edge))
 
+    checks += _q7_drill_floor_reads_the_board()
+
     for name, ok in checks:
         print(f"  [{'PASS' if ok else 'FAIL'}] {name}")
     n_pass = sum(1 for _, ok in checks if ok)
     print(f"\n{n_pass}/{len(checks)} checks passed")
     print("=" * 60)
     return 0 if n_pass == len(checks) else 1
+
+
+def _q7_drill_floor_reads_the_board():
+    """The underpad escape's drill floor was a constant, and the board unread.
+
+    `_via_site_conflict` spaced every drill at the flat
+    routing_defaults.HOLE_TO_HOLE_CLEARANCE, and grepping bga_fanout/underpad.py
+    for board_floor / board_constraint / min_hole_to_hole / resolve_hole_clearance
+    returned NOTHING -- the module never read the board at all. So a board
+    declaring min_hole_to_hole 0.4 got its BGA underpad drills spaced at 0.2:
+    the D9/D11 substitute-a-constant class, in the direction that ignores a
+    board asking for MORE. qfn_fanout is the sibling engine and already reads
+    it; check_join.py:118-122 is the board-first AND raise-only model.
+
+    Measured on ulx3s U1 (plane_drop at its 'auto' DEFAULT -- the rest of this
+    file pins it 'off', and with it off `_via_site_conflict` never governs a
+    site here, so the floor is inert and this gap is invisible):
+
+        declared        before          after
+        (nothing)   224 vias 0.3657   224 vias 0.3657   <- control, identical
+        0.4         224 vias 0.3657   224 vias 0.6000   <- board ignored/obeyed
+        0.10        224 vias 0.3657   224 vias 0.6000 + fab-pin disclosure
+
+    A declared 0.4 costs NO escapes; only the spacing moves.
+    """
+    import io
+    import json
+    import math
+    import shutil
+    import contextlib
+    import tempfile
+    out = []
+    if not os.path.exists(BOARD):
+        return out
+
+    # plane_drop left at its 'auto' default on purpose (see the docstring).
+    params = {k: v for k, v in PARAMS.items() if k != 'plane_drop'}
+
+    def run(h2h):
+        with tempfile.TemporaryDirectory() as tmp:
+            b = os.path.join(tmp, 'u.kicad_pcb')
+            shutil.copyfile(BOARD, b)
+            if h2h is not None:
+                with open(os.path.splitext(b)[0] + '.kicad_pro', 'w',
+                          encoding='utf-8') as f:
+                    json.dump({'board': {'design_settings': {
+                        'rules': {'min_hole_to_hole': h2h}}}}, f)
+            pcb = parse_kicad_pcb(b)
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                _t, vias, _vr, failed = generate_bga_fanout(
+                    pcb.footprints["U1"], pcb, layers=LAYERS, **params)
+            gap = min((math.hypot(a['x'] - c['x'], a['y'] - c['y'])
+                       - (a.get('drill', 0.2) + c.get('drill', 0.2)) / 2
+                       for i, a in enumerate(vias)
+                       for c in vias[i + 1:]), default=None)
+            return len(vias), len(failed), gap, buf.getvalue()
+
+    base_n, _bf, base_gap, base_said = run(None)
+    decl_n, decl_f, decl_gap, decl_said = run(0.4)
+    sub_n, _sf, sub_gap, sub_said = run(0.10)
+
+    # The defect, in one line: the board's own rule was not honoured.
+    out.append(("#Q7 a declared min_hole_to_hole 0.4 spaces the drills",
+                decl_gap is not None and decl_gap >= 0.4 - 1e-9))
+    out.append(("#Q7 ...and it says the board is where that came from",
+                "from the board's own" in decl_said))
+    # It must not buy the spacing by dropping escapes.
+    out.append(("#Q7 ...at no cost in escaped balls",
+                decl_n == base_n and decl_f == 0))
+    # Raise-only: a sub-fab declaration is pinned UP, and disclosed.
+    out.append(("#Q7 a sub-fab 0.10 is pinned to the fab floor, not obeyed",
+                sub_gap is not None and sub_gap >= 0.2 - 1e-9
+                and "below the" in sub_said))
+    # CONTROL: a board declaring nothing must be byte-identical to before.
+    out.append(("#Q7 a board declaring nothing is unchanged",
+                base_gap is not None and abs(base_gap - 0.3657) < 0.01
+                and base_n == 224 and 'ole-to-hole' not in base_said))
+    return out
 
 
 if __name__ == "__main__":

--- a/tests/test_board_floors.py
+++ b/tests/test_board_floors.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+"""Board-declared DRC floors resolve the same way on every consumer.
+
+A declared 0 is UNSET (KiCad writes 0 for "not configured"), an explicit
+value wins, and the fallback is only used when the board declares nothing --
+with the source announced. Pins list_nets.board_floor / resolve_cli_floor,
+the four routing mains' floor reads, and the qfn underpad drill floor wrap.
+
+Run: python3 -X utf8 tests/test_board_floors.py
+"""
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # #522 layout
+sys.path.insert(0, os.path.join(ROOT, 'py_placer'))  # #522 layout
+sys.path.insert(0, os.path.join(ROOT, 'py_tools'))  # #522 layout
+os.environ.setdefault('KRT_NO_BANNER', '1')
+
+import routing_defaults as defaults                            # noqa: E402
+
+FAILURES = []
+
+def check(name, cond, detail=''):
+    print(f'  {"PASS" if cond else "FAIL"}  {name}'
+          + (f'\n        {detail}' if not cond and detail else ''))
+    if not cond:
+        FAILURES.append(name)
+
+
+# --- D9: three more instruments that substituted a constant for the board ----
+#
+# check_channels and check_assembly defaulted --clearance to routing_defaults
+# 0.25 and never read the board; render_placement documented no default at all.
+# Measured on a board whose floor is 0.2 with a 0.254 track: check_channels at
+# its old constants reported 334 escape lanes where the board's own floor gives
+# 399 -- a 65-lane understatement, and an invented deficit on a face that had
+# none. A phantom deficit steers a placement search at the thing that is not
+# wrong.
+
+def _fixture(tmp, clearance=0.1, track=0.15, extra_rules=None):
+    """A board that DECLARES a floor, built to order.
+
+    Most boards in kicad_files/ declare nothing -- but NOT all of them, which
+    is the correction in the module docstring: flat_hierarchy and
+    routed_output ship committed .kicad_pro siblings. Those two are used
+    directly by _q5_committed_projects_are_real; this fixture exists so the
+    resolver's OTHER branches (a value the corpus does not happen to declare,
+    the 0.0 trap, a malformed project) are reachable at all."""
+    import shutil
+    src = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
+    dst = os.path.join(tmp, 'declared.kicad_pcb')
+    shutil.copyfile(src, dst)
+    import json as _json
+    rules = {'min_clearance': 0.0}        # the trap: KiCad writes 0 for "unset"
+    rules.update(extra_rules or {})
+    with open(os.path.splitext(dst)[0] + '.kicad_pro', 'w',
+              encoding='utf-8') as f:
+        _json.dump({'net_settings': {'classes': [
+            {'name': 'Default', 'clearance': clearance, 'track_width': track}]},
+            'board': {'design_settings': {'rules': rules}}}, f)
+    return dst
+
+
+def _d9_shared_resolver():
+    """One helper, so the three instruments cannot each be wrong differently."""
+    import tempfile
+    from list_nets import board_floor
+    with tempfile.TemporaryDirectory() as tmp:
+        b = _fixture(tmp)
+        print('board_floor resolves board-first')
+        check('an explicit value wins and is labelled cli',
+              board_floor(b, 'clearance', 0.42, 0.25) == (0.42, 'cli'))
+        check('unset reads the board netclass',
+              board_floor(b, 'clearance', None, 0.25) == (0.1, 'board netclass'),
+              str(board_floor(b, 'clearance', None, 0.25)))
+        check('track width too',
+              board_floor(b, 'track_width', None, 0.3) == (0.15, 'board netclass'))
+        # THE min_clearance TRAP. The fixture declares min_clearance 0.0, which
+        # KiCad writes for "not configured". Reading it as a real floor would
+        # resolve a board asking for 0.1 down to 0.0 and relax every consumer
+        # to nothing -- so `clearance` must never fall back to that constraint.
+        check('min_clearance 0.0 does NOT override the netclass',
+              board_floor(b, 'clearance', None, 0.25)[0] == 0.1)
+        # A constraint-only floor, which no netclass expresses (D11's case).
+        b2 = _fixture(tmp, extra_rules={'min_hole_clearance': 0.25})
+        check('a hole floor comes from the board constraint',
+              board_floor(b2, 'hole_clearance', None, 0.2)
+              == (0.25, 'board constraint'),
+              str(board_floor(b2, 'hole_clearance', None, 0.2)))
+
+    print('a board declaring nothing still falls back, and says so')
+    nodecl = os.path.join(ROOT, 'kicad_files', 'tigard.kicad_pcb')
+    check('fallback is labelled fixed default',
+          board_floor(nodecl, 'clearance', None, 0.25) == (0.25, 'fixed default'))
+    check('"could not read the project" is not "declares nothing"',
+          board_floor(os.path.join(tmp, 'nope.kicad_pcb'), 'clearance',
+                      None, 0.25, design_rules=_Boom())[1] == 'unreadable project')
+
+    # THE 0.0 TRAP, in the OLDER helper. board_floor guards it; board_floor_knobs
+    # did not, and render_placement is wired to board_floor_knobs -- so a project
+    # declaring `min_copper_edge_clearance: 0.0` (KiCad's "not configured") gave
+    # the placement model a REAL edge floor of zero where it had used 0.55.
+    #
+    # WHAT THAT ACTUALLY COSTS, measured on interf_u_unrouted_placed with a
+    # 0.0-declaring project (NOT the "every edge/halo term collapses" I first
+    # wrote in the commit message -- quench takes max(clearance, edge), so 0.0
+    # degrades to the 0.2 pad clearance rather than to nothing, and `edge` and
+    # `halo` do not move at all):
+    #
+    #     edge  15.516 -> 15.516     halo 303.803 -> 303.803   (unchanged)
+    #     oob_amount  22.039 -> 24.489      oob_area 398.51 -> 445.44
+    #
+    # i.e. it UNDER-REPORTS off-board pad copper by ~11%, which CLAUDE.md names
+    # as the top-priority placement defect ("converts one-for-one into unrouted
+    # and broken"). Under-reporting that is the harm; it is smaller and more
+    # specific than the sweeping claim, and the number is the point.
+    # The two helpers must agree about the one trap this module documents.
+    print('a declared 0.0 is UNSET in both floor helpers, not a floor of zero')
+    from list_nets import board_floor_knobs
+    import tempfile as _tf
+    with _tf.TemporaryDirectory() as z:
+        b = _fixture(z, clearance=0.2,
+                     extra_rules={'min_copper_edge_clearance': 0.0})
+        _clr, _edge, knobs = board_floor_knobs(b)
+        check('board_floor_knobs does not return a 0.0 edge floor',
+              _edge == 0.55 and knobs['board_edge_clearance']['source']
+              == 'fixed default', str(knobs['board_edge_clearance']))
+        check('board_floor agrees',
+              board_floor(b, 'board_edge_clearance', None, 0.55)
+              == (0.55, 'fixed default'))
+
+
+# --- Q3: the ROUTING half read the same two constraints its own way ---------
+#
+# D9 put the `> 0` guard in the placement helpers and stopped there. The four
+# routing mains each kept a private copy of
+# `board_constraint(...) if ... is not None else <default>` -- eight sites, an
+# `is not None` test with no positivity guard -- so one declared floor got two
+# answers depending on which half of the loop asked.
+#
+# On a board declaring `min_copper_edge_clearance: 0.0` (KiCad's "not
+# configured"): placement / floorplan / render resolved 0.55 [fixed default];
+# route.py took a REAL floor of 0.0 while printing "using the board
+# min_copper_edge_clearance 0.0mm" -- announcing a declaration that was not
+# one. The plane engines were worse than misleading: their inset fell from
+# PLANE_EDGE_CLEARANCE 0.5 to 0.0, on the very comment that says they keep 0.5
+# "only when the board declares no edge rule of its own". The GUI's plane tab
+# was already right (swig_gui._effective_plane_edge_clearance guards `> 1e-9`),
+# so this was a CLI-only divergence from the GUI as well.
+
+_CLI_FLOOR_SITES = ('py_router/route.py', 'py_router/route_diff.py',
+                    'py_router/route_planes.py', 'py_router/repair_planes.py')
+_RAW_KEYS = ('min_hole_to_hole', 'min_copper_edge_clearance')
+
+
+def _q3_routing_half_uses_the_same_resolver():
+    import io
+    import contextlib
+    import tempfile
+    from list_nets import (board_floor, board_floor_knobs, resolve_cli_floor)
+
+    print('one declared floor, one number, on both halves of the loop')
+    with tempfile.TemporaryDirectory() as tmp:
+        # A board that DECLARES a positive edge rule. Both halves must land on
+        # it -- this is the "one number" claim in its testable form.
+        decl = _fixture(tmp, extra_rules={'min_copper_edge_clearance': 0.3,
+                                          'min_hole_to_hole': 0.3})
+        _c, edge_place, knobs = board_floor_knobs(decl)
+        with contextlib.redirect_stdout(io.StringIO()):
+            edge_sig = resolve_cli_floor(decl, 'board_edge_clearance', None,
+                                         defaults.BOARD_EDGE_CLEARANCE, '--x')
+            edge_pln = resolve_cli_floor(decl, 'board_edge_clearance', None,
+                                         defaults.PLANE_EDGE_CLEARANCE, '--x')
+        check('a DECLARED 0.3 edge rule is 0.3 on the placement half',
+              edge_place == 0.3
+              and knobs['board_edge_clearance']['source'] == 'board constraint',
+              str(knobs['board_edge_clearance']))
+        check('...and 0.3 on the routing half, signal and plane alike',
+              edge_sig == 0.3 and edge_pln == 0.3,
+              f'signal {edge_sig}, plane {edge_pln}')
+
+    print('a DECLARED 0.0 is UNSET on the routing half too')
+    with tempfile.TemporaryDirectory() as tmp:
+        z = _fixture(tmp, extra_rules={'min_copper_edge_clearance': 0.0,
+                                       'min_hole_to_hole': 0.0})
+        _c, edge_place, knobs = board_floor_knobs(z)
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            edge_sig = resolve_cli_floor(z, 'board_edge_clearance', None,
+                                         defaults.BOARD_EDGE_CLEARANCE, '--x')
+            edge_pln = resolve_cli_floor(z, 'board_edge_clearance', None,
+                                         defaults.PLANE_EDGE_CLEARANCE, '--x')
+            h2h = resolve_cli_floor(z, 'hole_to_hole', None,
+                                    defaults.HOLE_TO_HOLE_CLEARANCE, '--y')
+        said = buf.getvalue()
+
+        # BOTH halves must reach the same VERDICT about the board: it declared
+        # nothing. The fallbacks then legitimately differ -- BOARD_EDGE_CLEARANCE
+        # 0.0 is a deliberate "no edge rule, use the copper-copper clearance"
+        # sentinel (route.py:896, obstacle_map.py:797), the plane engines want
+        # 0.5, the placement model 0.55 -- and are NOT unified here.
+        check('placement half: declared 0.0 reads as fixed default',
+              edge_place == 0.55
+              and knobs['board_edge_clearance']['source'] == 'fixed default',
+              str(knobs['board_edge_clearance']))
+        check('routing half agrees the board declared nothing',
+              board_floor(z, 'board_edge_clearance', None, 0.0)[1]
+              == 'fixed default'
+              and board_floor(z, 'hole_to_hole', None, 0.2)[1]
+              == 'fixed default')
+        # The value fixes, each measured against what the old raw read gave.
+        check('plane inset stays PLANE_EDGE_CLEARANCE (was 0.0)',
+              edge_pln == defaults.PLANE_EDGE_CLEARANCE, f'got {edge_pln}')
+        check('hole-to-hole stays the packaged floor (was 0.0)',
+              h2h == defaults.HOLE_TO_HOLE_CLEARANCE, f'got {h2h}')
+        check('the signal sentinel is unchanged at 0.0',
+              edge_sig == defaults.BOARD_EDGE_CLEARANCE, f'got {edge_sig}')
+        # And it must stop claiming the board said so.
+        check('the print no longer attributes 0.0 to the board',
+              'min_copper_edge_clearance' not in said
+              and 'min_hole_to_hole' not in said, said.strip())
+        check('the print names its source in the placement vocabulary',
+              said.count('[fixed default]') == 3, said.strip())
+
+    # THE WIRING. Every check above passes with all eight call sites reverted
+    # to the raw read -- the exact hole D10 was pulled up for. So assert the
+    # mains actually route through the resolver, and that the raw read is gone.
+    print('all four routing mains go through the one resolver')
+    import ast
+    for fn in _CLI_FLOOR_SITES:
+        src = open(os.path.join(ROOT, fn), encoding='utf-8').read()
+        tree = ast.parse(src)
+        floors = set()
+        raw = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call) or not node.args:
+                continue
+            fname = getattr(node.func, 'id', None) or getattr(
+                node.func, 'attr', None)
+            first_str = [a.value for a in node.args
+                         if isinstance(a, ast.Constant)
+                         and isinstance(a.value, str)]
+            if fname == 'resolve_cli_floor':
+                floors.update(first_str)
+            elif fname == 'board_constraint':
+                raw += [s for s in first_str if s in _RAW_KEYS]
+        check(f'{fn}: both floors via resolve_cli_floor',
+              {'hole_to_hole', 'board_edge_clearance'} <= floors,
+              f'found {sorted(floors)}')
+        check(f'{fn}: no raw board_constraint read of either key',
+              not raw, f'raw reads: {raw}')
+
+    # ...and the mains ACTUALLY PRINT it, which the AST check cannot show. Each
+    # runs in ~1.3s on a net that matches nothing, so this is the CLI's own
+    # answer rather than a model of it. At 62f7c13^ these lines read "using the
+    # board min_copper_edge_clearance 0.0mm" and the plane engines resolved 0.0.
+    print('...and each main prints the resolved floor, crediting the right source')
+    import subprocess
+    import tempfile
+    # (flag-shape, edge-floor-expected) per main; hole-to-hole is 0.2 for all.
+    mains = [
+        ('py_router/route.py', lambda i, o: [i, o, '--nets', '__none__'], 0.0),
+        ('py_router/route_diff.py', lambda i, o: [i, '--output', o, '--nets', '__none__'], 0.0),
+        ('py_router/route_planes.py', lambda i, o: [i, '--output', o, '--nets', '__none__',
+                                          '--plane-layers', 'B.Cu'], 0.5),
+        ('py_router/repair_planes.py',
+         lambda i, o: [i, '--output', o, '--nets', '__none__',
+                       '--plane-layers', 'B.Cu'], 0.5),
+    ]
+    with tempfile.TemporaryDirectory() as tmp:
+        z = _fixture(tmp, extra_rules={'min_copper_edge_clearance': 0.0,
+                                       'min_hole_to_hole': 0.0})
+        for fn, argv, edge in mains:
+            out = os.path.join(tmp, 'o_' + fn.replace('.py', '') + '.kicad_pcb')
+            r = subprocess.run([sys.executable, '-X', 'utf8', fn] + argv(z, out),
+                               cwd=ROOT, capture_output=True, text=True,
+                               timeout=300)
+            lines = [ln.strip() for ln in (r.stdout or '').splitlines()
+                     if ln.startswith('--hole-to-hole-clearance not given')
+                     or ln.startswith('--board-edge-clearance not given')]
+            said = ' '.join(lines)
+            check(f'{fn}: prints both resolved floors',
+                  len(lines) == 2, said or (r.stderr or '')[-300:])
+            check(f'{fn}: hole-to-hole 0.2 [fixed default], not a declared 0.0',
+                  f'--hole-to-hole-clearance not given; using 0.2mm '
+                  f'[fixed default].' in said, said)
+            check(f'{fn}: board edge {edge} [fixed default]',
+                  f'--board-edge-clearance not given; using {edge}mm '
+                  f'[fixed default].' in said, said)
+            check(f'{fn}: does not credit the board for what it left unset',
+                  'min_copper_edge_clearance' not in said
+                  and 'min_hole_to_hole' not in said, said)
+
+
+# --- Q4: board_floor is NOT raise-only, and a drill consumer must wrap it ---
+#
+# board_floor returns the declared value whenever it is positive, with no
+# max() against the fallback. For most of its table that is exactly right --
+# check_channels / check_assembly must grade at the board's own clearance even
+# when it is BELOW their default. For a DRILL floor it is a fab hazard, and the
+# qfn underpad escape claimed "Raise-only in practice" while doing no such
+# thing: a project declaring `min_hole_to_hole: 0.10` spaced that run's drills
+# at 0.10, under the 0.20 JLC floor. `resolve_hole_clearance` is raise-only
+# only because ITS consumers wrap it; this is the same wrap, and the same
+# demonstration.
+
+def _qfn_fixture(tmp, h2h):
+    """tigard (a real QFN board) with a project declaring min_hole_to_hole."""
+    import shutil
+    import json as _json
+    src = os.path.join(ROOT, 'kicad_files', 'tigard.kicad_pcb')
+    if not os.path.exists(src):
+        return None
+    dst = os.path.join(tmp, 'h2h.kicad_pcb')
+    shutil.copyfile(src, dst)
+    with open(os.path.splitext(dst)[0] + '.kicad_pro', 'w',
+              encoding='utf-8') as f:
+        _json.dump({'net_settings': {'classes': [
+            {'name': 'Default', 'clearance': 0.2, 'track_width': 0.25}]},
+            'board': {'design_settings': {'rules': {'min_hole_to_hole': h2h}}}},
+            f)
+    return dst
+
+
+def _qfn_effective_h2h(board):
+    """The hole_to_hole the underpad escape actually routes with.
+
+    Read off what the engine FEEDS run_output_conflict, which is where
+    f1dd280 said the value goes -- not re-derived, or the test would only be
+    checking arithmetic it wrote itself.
+    """
+    import io
+    import contextlib
+    from kicad_parser import parse_kicad_pcb
+    import qfn_fanout as Q
+
+    seen = []
+    real = Q.run_output_conflict
+
+    def spy(*a, **kw):
+        seen.append(kw.get('hole_to_hole'))
+        return real(*a, **kw)
+
+    Q.run_output_conflict = spy
+    try:
+        pcb = parse_kicad_pcb(board)
+        with contextlib.redirect_stdout(io.StringIO()) as buf:
+            Q.generate_qfn_fanout(
+                pcb.footprints["U3"], pcb, net_filter=["/USB_DP", "/USB_DN"],
+                layer="F.Cu", track_width=0.1, clearance=0.1, grid_step=0.05,
+                escape_method="underpad", via_size=0.45, via_drill=0.25)
+    finally:
+        Q.run_output_conflict = real
+    return (set(v for v in seen if v is not None), buf.getvalue())
+
+
+def _q4_a_declared_value_must_not_relax_a_fab_floor():
+    import tempfile
+    from list_nets import board_floor
+    from fab_tiers import fab_floor_min
+
+    print('board_floor is board-authoritative, NOT raise-only')
+    with tempfile.TemporaryDirectory() as tmp:
+        b = _fixture(tmp, extra_rules={'min_hole_to_hole': 0.10})
+        # The CLAIM, corrected: this is the documented behaviour, not a bug to
+        # fix in the helper -- check_channels needs exactly this freedom.
+        check('a declared 0.10 resolves DOWN, and says it came from the board',
+              board_floor(b, 'hole_to_hole', None, 0.2)
+              == (0.1, 'board constraint'),
+              str(board_floor(b, 'hole_to_hole', None, 0.2)))
+
+    fab = fab_floor_min(4).get('hole_to_hole')
+    check('the fab hole-to-hole floor is the thing being protected',
+          fab == 0.20, f'got {fab}')
+
+    print('...so the qfn DRILL consumer wraps it, and discloses the pin')
+    with tempfile.TemporaryDirectory() as tmp:
+        b = _qfn_fixture(tmp, 0.10)
+        if b is None:
+            print('  SKIP  no tigard board (qfn drill floor)')
+            return
+        got, said = _qfn_effective_h2h(b)
+        check('a declared 0.10 does NOT space this run\'s drills at 0.10',
+              got == {0.20}, f'engine used {sorted(got)}')
+        check('...and it is not relaxed SILENTLY',
+              'below the 0.2mm fab hole-to-hole floor' in said, said.strip())
+
+    print('...while a declared value ABOVE the floor still wins')
+    with tempfile.TemporaryDirectory() as tmp:
+        b = _qfn_fixture(tmp, 0.30)
+        got, said = _qfn_effective_h2h(b)
+        check('a declared 0.30 raises the drill spacing to 0.30',
+              got == {0.30}, f'engine used {sorted(got)}')
+        check('...and says the board is where it came from',
+              "from the board's own" in said, said.strip())
+
+    print('...and a board declaring nothing is byte-identical')
+    with tempfile.TemporaryDirectory() as tmp:
+        import shutil
+        src = os.path.join(ROOT, 'kicad_files', 'tigard.kicad_pcb')
+        dst = os.path.join(tmp, 'silent.kicad_pcb')
+        shutil.copyfile(src, dst)          # no .kicad_pro sibling at all
+        got, said = _qfn_effective_h2h(dst)
+        check('the packaged default stands, unannounced',
+              got == {defaults.HOLE_TO_HOLE_CLEARANCE}
+              and 'hole-to-hole' not in said.lower(), f'{sorted(got)}')
+
+
+class _Boom(dict):
+    """A design_rules stand-in that raises when read, to exercise the
+    'I could not look' branch without corrupting a real project file."""
+    def get(self, *a, **k):
+        raise OSError('unreadable')
+
+
+
+def main():
+    _d9_shared_resolver()
+    _q3_routing_half_uses_the_same_resolver()
+    _q4_a_declared_value_must_not_relax_a_fab_floor()
+    print()
+    if FAILURES:
+        print(f'FAIL: {len(FAILURES)} check(s): {", ".join(FAILURES)}')
+        return 1
+    print('OK')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_broken_worklist.py
+++ b/tests/test_broken_worklist.py
@@ -18,6 +18,10 @@ import sys
 HERE = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(HERE)
 sys.path.insert(0, os.path.join(ROOT, '.claude', 'skills', 'plan-pcb-routing', 'scripts'))
+# board_score's own main() puts the clone root on sys.path before it calls
+# anything; a test calling those functions directly has to do the same, or
+# `kicad_parser` is missing and the net-name audit reports UNGRADED forever.
+sys.path.insert(0, ROOT)
 
 import board_score as bs                                        # noqa: E402
 
@@ -164,6 +168,130 @@ def test_a_fully_connected_board_reports_empty_lists_not_missing_keys():
     conn = _parse('ALL NETS FULLY CONNECTED\n')
     assert conn['broken'] == 0 and conn['unrouted'] == 0
     print('  PASS: a clean board is clean')
+
+
+# --- D6: one payload, one spelling of every net -------------------------------
+#
+# `poured_nets` is the ONLY net-name field in the score read out of the raw file
+# text instead of through the parser, and the file escapes a backslash. Measured
+# on neo6502, from a single json.dump:
+#     poured_nets   : '/GPIO10\\OE3#'   <- two backslashes
+#     unrouted.nets : '/GPIO10\OE3#'    <- one, and the board agrees
+# A consumer built --ignore-nets from the first, 10 of 61 names matched nothing,
+# and the render came back hpwl +45.6% / crossings +129.5% on an unchanged board.
+
+# A net name with a backslash, as the FILE stores it (escaped). This is the
+# neo6502 shape exactly: the file says `\\`, the net is one `\`.
+ESCAPED_BOARD = (
+    '(kicad_pcb (version 20240108)\n'
+    '\t(net 0 "")\n'
+    '\t(net 1 "/GPIO10\\\\OE3#")\n'
+    '\t(net 2 "GND")\n'
+    '\t(zone (net 1) (net_name "/GPIO10\\\\OE3#") (layer "B.Cu") (hatch edge 0.5))\n'
+    '\t(zone (net 2) (net_name "GND") (layer "B.Cu") (hatch edge 0.5))\n'
+    ')\n')
+
+# What the parser -- and therefore the board, check_connected, and every other
+# field of the score -- calls those two nets.
+TRUE_NAMES = ['/GPIO10\\OE3#', 'GND']
+
+
+def _write(d, name, text):
+    p = os.path.join(d, name)
+    with open(p, 'w', encoding='utf-8') as f:
+        f.write(text)
+    return p
+
+
+def test_poured_nets_is_spelled_the_way_the_board_spells_it():
+    """The field must survive a round trip through the board's own parser."""
+    import tempfile
+    from kicad_parser import parse_kicad_pcb
+    with tempfile.TemporaryDirectory() as d:
+        b = _write(d, 'b.kicad_pcb', ESCAPED_BOARD)
+        real = bs.run_tool
+        bs.run_tool = lambda root, tool, board, *a, **k: (1, SAMPLE)
+        try:
+            conn = bs.score_connectivity('.', b)
+        finally:
+            bs.run_tool = real
+        truth = sorted(n.name for n in parse_kicad_pcb(b).nets.values() if n.name)
+
+    assert conn['poured_nets'] == TRUE_NAMES, (
+        f'poured_nets must spell nets as the board does.\n'
+        f'  got   : {conn["poured_nets"]}\n  want  : {TRUE_NAMES}')
+    assert conn['poured_nets'] == truth, (
+        f'poured_nets disagrees with the parser on the same file: '
+        f'{conn["poured_nets"]} vs {truth}')
+    print('  PASS: poured_nets is unescaped, and matches the parser exactly')
+
+
+def test_poured_nets_carries_its_meaning_in_the_payload():
+    """It means "the handler is route_disconnected_planes", NOT "this is a
+    plane". A consumer read it the second way and removed 332 of 545 pads
+    (72%) from its own analysis. The sentence has to travel WITH the list --
+    a comment in board_score.py is invisible to whoever reads the JSON."""
+    conn = _parse(SAMPLE)
+    meaning = conn.get('poured_nets_meaning', '')
+    assert meaning and 'NOT' in meaning and 'ignore-nets' in meaning, \
+        f'poured_nets must publish what it means, got {meaning!r}'
+    print('  PASS: poured_nets ships its own definition')
+
+
+def test_every_published_net_name_exists_on_the_board():
+    """The self-check that makes a future D6 impossible to publish silently.
+
+    A mangled name and an absent net are INDISTINGUISHABLE downstream -- both
+    match nothing, neither complains. Only the tool that emitted the name can
+    tell them apart, so it has to be the one that looks.
+    """
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        b = _write(d, 'b.kicad_pcb', ESCAPED_BOARD)
+
+        good = {'connectivity_nets': ['GND'],
+                'components': {'broken': {'poured_nets': TRUE_NAMES},
+                               'unrouted': {'nets': ['/GPIO10\\OE3#']}}}
+        a = bs.audit_net_names(b, good)
+        assert a['ran'] and a['unknown_count'] == 0, \
+            f'a correct payload must audit clean, got {a}'
+        assert a['checked'] == 4, f'all four names must be checked, got {a}'
+
+        # The exact defect, reconstructed: poured_nets double-escaped while
+        # unrouted.nets is right -- one payload, two spellings.
+        bad = {'connectivity_nets': ['GND'],
+               'components': {'broken': {'poured_nets': ['/GPIO10\\\\OE3#']},
+                              'unrouted': {'nets': ['/GPIO10\\OE3#']}}}
+        a = bs.audit_net_names(b, bad)
+        assert a['unknown_count'] == 1, \
+            f'the double-escaped name must be caught, got {a}'
+        assert a['unknown'] == {'components.broken.poured_nets':
+                                ['/GPIO10\\\\OE3#']}, \
+            f'the audit must name the FIELD that is wrong, got {a["unknown"]}'
+
+        # Fields whose job is naming things that do NOT exist are excluded on
+        # purpose; auditing them would report every correct run as broken.
+        spec = {'components': {
+            'net_widths': {'nets': {'GND': {}},
+                           'patterns_matching_no_routed_net': ['NOPE*']},
+            'length': {'groups': {'B': {'missing_nets': ['ALSO_NOT_HERE'],
+                                        'worst': 'GND'}}}}}
+        a = bs.audit_net_names(b, spec)
+        assert a['unknown_count'] == 0, \
+            f'spec-finding fields must not be audited as net names, got {a}'
+    print('  PASS: every published net name is checked against the board')
+
+
+def test_the_audit_refuses_to_pass_a_board_it_could_not_read():
+    """`0 unknown` from a board with no net table is the vacuity trap this
+    file guards everywhere else -- it must say `ran: false` instead."""
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        b = _write(d, 'b.kicad_pcb', '(kicad_pcb (version 20240108))\n')
+        a = bs.audit_net_names(b, {'connectivity_nets': ['GND']})
+    assert a['ran'] is False and 'unknown_count' not in a, \
+        f'no net table is not a pass, got {a}'
+    print('  PASS: an unreadable board audits UNGRADED, not clean')
 
 
 if __name__ == '__main__':

--- a/tests/test_check_join.py
+++ b/tests/test_check_join.py
@@ -146,7 +146,9 @@ def test_usage_errors_exit_2():
         r = _run([b, 'N1', '104,116,In1.Cu', '107,116,In1.Cu'])
         assert r.returncode == 2 and 'not a copper layer' in r.stderr
         r = _run([b, 'N1', 'garbage'])
-        assert r.returncode == 2
+        # Not a bare `== 2`: argparse, an ImportError and a parse crash all
+        # exit 2, so the code alone cannot say the guard held.
+        assert r.returncode == 2 and 'Traceback' not in r.stderr, r.stderr[-400:]
     print("  PASS: unknown net / bad layer / bad token all exit 2")
 
 

--- a/tests/test_converge.py
+++ b/tests/test_converge.py
@@ -158,13 +158,492 @@ def test_record_final_requires_stop_condition():
         r = _cv(['record', '--ledger', led, '--board', BOARD, '--final'])
         assert r.returncode == 2 and 'stop-condition' in r.stderr
         assert not os.path.exists(led), "nothing may be written on refusal"
+        # A completion --final now also needs the routed-board lens verdicts:
+        # `blocking == 0` and "every lens passes" are two different claims and
+        # only the first ever had a number, so a close-out could be written
+        # with no lens dispatched at all.
         r = _cv(['record', '--ledger', led, '--board', BOARD, '--final',
                  '--stop-condition', 'plateau: 3 iterations, no new copper'])
+        assert r.returncode == 2 and 'routed-board lenses' in r.stderr, r.stderr
+        assert not os.path.exists(led), "nothing may be written on refusal"
+        lenses = ['--lens', 'VERDICT=PASS:lens=connectivity',
+                  '--lens', 'VERDICT=PASS:lens=drc',
+                  '--lens', 'VERDICT=PASS:lens=spec']
+        r = _cv(['record', '--ledger', led, '--board', BOARD, '--final',
+                 '--stop-condition', 'plateau: 3 iterations, no new copper']
+                + lenses)
         assert r.returncode == 0, r.stderr
         e = json.loads(r.stdout)
         assert e.get('final') is True
         assert e.get('stop_condition', '').startswith('plateau')
+        assert len(e.get('lenses') or []) == 3, e.get('lenses')
     print("  PASS: --final without --stop-condition is refused; with it, recorded")
+
+
+def test_record_final_wants_the_lens_verdicts():
+    """A FAILED lens means `blocking` was not really zero, so the run did not
+    finish clean -- stop condition 1 is then not available to it."""
+    with tempfile.TemporaryDirectory() as td:
+        led = os.path.join(td, 'l.jsonl')
+        r = _cv(['record', '--ledger', led, '--board', BOARD, '--lever', 'x',
+                 '--lens', 'all three passed'])
+        assert r.returncode == 2 and 'verbatim' in r.stderr, r.stderr
+        assert not os.path.exists(led), "nothing may be written on refusal"
+
+        base = ['record', '--ledger', led, '--board', BOARD, '--final',
+                '--lens', 'VERDICT=PASS:lens=connectivity',
+                '--lens', 'VERDICT=FAIL:lens=drc;finding=short;evidence=x',
+                '--lens', 'VERDICT=PASS:lens=spec']
+        r = _cv(base + ['--stop-condition', '1'])
+        assert r.returncode == 2 and 'lens FAILED' in r.stderr, r.stderr
+        r = _cv(base + ['--stop-condition', '4'])
+        assert r.returncode == 0, r.stderr
+        assert json.loads(r.stdout).get('lenses')[1].startswith('VERDICT=FAIL')
+    print("  PASS: lens grammar is enforced, and a FAIL forbids condition 1")
+
+
+def test_record_refuses_a_lens_verdict_its_own_score_contradicts():
+    """D1. `--lens` was validated for FORMAT and never against anything.
+
+    Measured (run 17, ledger iteration 21): a --final row carrying
+    VERDICT=PASS:lens=connectivity on a score reporting 32 unrouted nets and 47
+    broken joins, while route.log -- 2.65 MB, 19 JSON_SUMMARY blocks -- held
+    zero VERDICT= lines, because no verifier had ever run. That row passed L3,
+    L4 and L5 untested and was corrected only when a human challenged it.
+    """
+    with tempfile.TemporaryDirectory() as td:
+        led = os.path.join(td, 'l.jsonl')
+
+        def sc(doc, name):
+            p = os.path.join(td, name)
+            json.dump(doc, open(p, 'w', encoding='utf-8'))
+            return p
+
+        # The measured row, to the number.
+        run17 = sc({'blocking': 79, 'quality': {},
+                    'blocking_by': {'unrouted': 32, 'broken': 47, 'drc': 0,
+                                    'undersized': 0}}, 's.json')
+        final = ['record', '--ledger', led, '--board', BOARD, '--final',
+                 '--kind', 'completion', '--stop-condition', '1',
+                 '--score-file', run17,
+                 '--lens', 'VERDICT=PASS:lens=connectivity',
+                 '--lens', 'VERDICT=PASS:lens=drc',
+                 '--lens', 'VERDICT=PASS:lens=spec']
+        r = _cv(final)
+        assert r.returncode == 2, (r.returncode, r.stdout[:400])
+        assert 'CONTRADICTS' in r.stderr, r.stderr
+        assert 'unrouted = 32' in r.stderr and 'broken = 47' in r.stderr, r.stderr
+        assert 'VERDICT=FAIL:lens=connectivity' in r.stderr, \
+            'the refusal must name the honest verdict it will accept'
+        assert not os.path.exists(led), 'nothing may be written on refusal'
+
+        # ...and the honest verdict IS accepted (stop condition 4: measured
+        # unfixable and said so).
+        r = _cv(['record', '--ledger', led, '--board', BOARD, '--final',
+                 '--kind', 'completion', '--stop-condition', '4',
+                 '--score-file', run17,
+                 '--lens', 'VERDICT=FAIL:lens=connectivity;finding=32 nets '
+                           'carry no copper;evidence=score.json#/blocking_by',
+                 '--lens', 'VERDICT=PASS:lens=drc',
+                 '--lens', 'VERDICT=PASS:lens=spec'])
+        assert r.returncode == 0, r.stderr
+
+        # CONSERVATIVE: an UNGRADED component is not a contradiction. This is
+        # the half that keeps the check from refusing correct rows -- most
+        # boards ship with impedance/length/net_widths null.
+        # (fresh ledgers below: a second row in the SAME half would also be
+        # tested for commensurability, which is a different gate)
+        r = _cv(['record', '--ledger', os.path.join(td, 'l2.jsonl'),
+                 '--board', BOARD,
+                 '--kind', 'completion', '--lever', 'x',
+                 '--score-file', sc({'blocking': 0, 'quality': {},
+                                     'blocking_by': {'unrouted': 0, 'broken': 0,
+                                                     'drc': None,
+                                                     'undersized': None}},
+                                    'null.json'),
+                 '--lens', 'VERDICT=PASS:lens=drc'])
+        assert r.returncode == 0, r.stderr
+        assert 'CONTRADICTS' not in r.stderr, r.stderr
+
+        # ...and a score that demonstrably grades ANOTHER board does not fire
+        # it either: that would be judging a verdict about board A with board
+        # B's numbers, the same mistake in the other direction.
+        r = _cv(['record', '--ledger', os.path.join(td, 'l3.jsonl'),
+                 '--board', BOARD, '--kind',
+                 'completion', '--lever', 'baseline row',
+                 '--score-file', sc({'blocking': 9, 'board_sha': 'f' * 64,
+                                     'quality': {},
+                                     'blocking_by': {'unrouted': 9}},
+                                    'other.json'),
+                 '--lens', 'VERDICT=PASS:lens=connectivity'])
+        assert r.returncode == 0, r.stderr
+        assert 'CONTRADICTS' not in r.stderr, r.stderr
+    print("  PASS: a PASS lens beside a contradicting count is refused, named")
+
+
+def test_plateau_counts_rejected_laps_and_states_the_true_threshold():
+    """D2. The gate was unsatisfiable by construction.
+
+    The guard was `<=`, so --flat 5 needed SIX accepted laps while the refusal
+    said five; it counted accepted rows only, though L5 instructs "Record the
+    lap you are about to run, accepted or rejected"; and routing accepts only
+    on strict improvement, so an exhausted half has no honest accepted lap left
+    to produce. Two consecutive refusals came out byte-identical.
+    """
+    acc = {'kind': 'completion', 'accepted': True,
+           'score': {'blocking': 0, 'quality': {}, 'ungraded': []}}
+    rej = {'kind': 'completion', 'accepted': False, 'score': None}
+
+    # EXACTLY --flat accepted laps is answerable, and answers `plateau`.
+    st = converge._half_state([acc] * 5, 'routing', 5)
+    assert st['why'] == 'plateau' and st['flat'] is True, st
+
+    # A REJECTED lap is plateau evidence: it is precisely the record of a half
+    # that tried and did not improve.
+    st = converge._half_state([acc] * 2 + [rej] * 3, 'routing', 5)
+    assert st['laps'] == 5 and st['accepted'] == 2 and st['rejected'] == 3, st
+    assert st['flat'] is True and st['why'] == 'plateau', st
+
+    # ...and a half that really is still moving is still not flat.
+    moving = [dict(acc, score={'blocking': b, 'quality': {}, 'ungraded': []})
+              for b in (9, 8, 7, 6, 5)]
+    st = converge._half_state(moving, 'routing', 5)
+    assert st['flat'] is False and st['why'] == 'improving', st
+
+    # The refusal text must state the threshold it actually applies.
+    with tempfile.TemporaryDirectory() as td:
+        led = os.path.join(td, 'l.jsonl')
+        with open(led, 'w', encoding='utf-8') as fh:
+            for i, r in enumerate([acc] * 2):
+                fh.write(json.dumps(dict(r, iteration=i)) + '\n')
+        p = os.path.join(td, 's.json')
+        json.dump({'blocking': 0, 'quality': {}, 'ungraded': []},
+                  open(p, 'w', encoding='utf-8'))
+        r = _cv(['verdict', '--ledger', led, '--score', p, '--flat', '5'])
+        doc = json.loads(r.stdout)
+        assert doc['verdict'] == 'CONTINUE', doc
+        assert '2 recorded lap(s)' in doc['reason'], doc['reason']
+        assert 'fewer than the 5 this test needs' in doc['reason'], doc['reason']
+        assert '--exhausted routing' in doc['reason'], \
+            'the text names a remedy; the remedy must be a real flag'
+    print("  PASS: the plateau counter counts rejections and states its true "
+          "threshold")
+
+
+def test_a_half_can_declare_itself_exhausted_on_the_record():
+    """D2, the remedy the verdict text has always promised and never had.
+
+    "the lever is to give it something further to optimise (or to say on the
+    record that there is nothing)" -- and no flag implemented the parenthetical.
+    --accept-residue / --accept-unclosed / --accept-congestion are documented as
+    deliberately non-overlapping and none touches the counter, while --flat is
+    forbidden by the same sentence.
+    """
+    with tempfile.TemporaryDirectory() as td:
+        led = os.path.join(td, 'l.jsonl')
+        p = os.path.join(td, 's.json')
+        json.dump({'blocking': 0, 'quality': {}, 'ungraded': []},
+                  open(p, 'w', encoding='utf-8'))
+
+        def rec(*extra):
+            return _cv(['record', '--ledger', led, '--board', BOARD,
+                        '--kind', 'systemic'] + list(extra))
+
+        # A declaration with no reason is just a lower --flat with extra steps.
+        r = rec('--exhausted', 'routing', '--lever', 'nothing left')
+        assert r.returncode == 2 and 'exhausted-reason' in r.stderr, r.stderr
+        assert not os.path.exists(led), 'nothing may be written on refusal'
+
+        r = rec('--exhausted', 'routing', '--lever', 'declaration',
+                '--exhausted-reason',
+                'every rip depth and grid tried; the 32 open nets need a lane '
+                'no parameter creates')
+        assert r.returncode == 0, r.stderr
+        assert json.loads(r.stdout)['exhausted']['half'] == 'routing'
+
+        for i in range(5):                       # placement plateaus normally
+            assert _cv(['record', '--ledger', led, '--board', BOARD, '--kind',
+                        'placement', '--lever', f'lap {i}',
+                        '--score', json.dumps({'blocking': 0, 'quality': {},
+                                               'ungraded': []})]
+                       ).returncode == 0
+        doc = json.loads(_cv(['verdict', '--ledger', led, '--score', p]).stdout)
+        assert doc['verdict'] == 'DONE-EXHAUSTED', doc['verdict']
+        assert doc['routing']['why'] == 'declared-exhausted', doc['routing']
+        assert 'DECLARED exhausted' in doc['reason'], doc['reason']
+        assert 'no parameter creates' in doc['reason'], \
+            'the reason a human gave is the evidence; it must reach the artifact'
+
+        # Running that half again RETRACTS the declaration -- no flag, no edit.
+        assert _cv(['record', '--ledger', led, '--board', BOARD, '--kind',
+                    'completion', '--lever', 'back to work']).returncode == 0
+        doc = json.loads(_cv(['verdict', '--ledger', led, '--score', p]).stdout)
+        assert doc['verdict'] == 'CONTINUE', doc['verdict']
+        assert doc['routing'].get('declared_superseded'), doc['routing']
+    print("  PASS: a half can be declared exhausted, with a reason, and a "
+          "later lap retracts it")
+
+
+def test_two_scores_that_graded_different_components_do_not_compare():
+    """D12. Two `blocking` totals over different component sets are not larger
+    and smaller versions of each other.
+
+    Measured (run 17, cycles 2 and 3 of one board): compared as 78 vs 79 and a
+    decision taken on the difference. Graded commensurably -- with
+    --impedance-nets, which neither run passed and which the board warrants --
+    both score 92 (32 unrouted / 46 broken, tied net for net), and the board
+    called WORSE was one impedance crossing BETTER.
+    """
+    full = {'blocking': 79, 'quality': {}, 'ungraded': [],
+            'blocking_by': {'unrouted': 32, 'broken': 46, 'drc': 1,
+                            'impedance': 0}}
+    part = {'blocking': 78, 'quality': {}, 'ungraded': ['impedance'],
+            'blocking_by': {'unrouted': 32, 'broken': 46, 'drc': 0,
+                            'impedance': None},
+            'components': {'impedance': {
+                'ran': False,
+                'reason': 'no --impedance-nets given; impedance is ungraded'}}}
+    differ, hint, false_improvement = converge.commensurability(full, part)
+    assert differ == ['impedance'] and false_improvement is True, (differ, hint)
+    assert '--impedance-nets' in hint, hint
+    assert converge.commensurability(full, dict(full, blocking=70)) is None, \
+        'two scores over the same component set compare normally'
+
+    with tempfile.TemporaryDirectory() as td:
+        led = os.path.join(td, 'l.jsonl')
+
+        def sc(doc, name):
+            p = os.path.join(td, name)
+            json.dump(doc, open(p, 'w', encoding='utf-8'))
+            return p
+
+        def rec(score, *extra):
+            return _cv(['record', '--ledger', led, '--board', BOARD, '--kind',
+                        'completion', '--lever', 'lap', '--score-file', score]
+                       + list(extra))
+
+        assert rec(sc(full, 'c2.json')).returncode == 0
+        # 79 -> 78 while grading one component LESS. Routing accepts on strict
+        # improvement, so this is how a ledger acquires a false monotone trend.
+        r = rec(sc(part, 'c3.json'))
+        assert r.returncode == 2, (r.returncode, r.stdout[:300])
+        assert 'graded FEWER components' in r.stderr, r.stderr
+        assert 'impedance' in r.stderr and '--impedance-nets' in r.stderr
+        r = rec(sc(part, 'c3b.json'), '--accept-incommensurable',
+                'both re-scored at 92 out of band; they tie')
+        assert r.returncode == 0, r.stderr
+        assert json.loads(r.stdout)['accepted_incommensurable'].startswith(
+            'both re-scored'), 'the disposition belongs in the row'
+
+    # ...and the verdict never CREDITS an improvement across such a pair.
+    def acc(s):
+        return {'kind': 'completion', 'accepted': True, 'score': s}
+
+    st = converge._half_state([acc(full)] * 4 + [acc(part)], 'routing', 5)
+    assert st['flat'] is True, \
+        '78 after four 79s is not an improvement when it graded one less'
+    assert st['incommensurable'] and st['compared'] == 4, st
+
+    # ...but guarding a false improvement must not MANUFACTURE a false plateau.
+    # Judging only the LEADING comparable run collapsed a window to one lap
+    # whenever its first pair did not compare, and `min(keys[:1]) >= keys[0]`
+    # is a tautology: 78 -> 70 -> 60 -> 50 -> 40, four comparable improvements
+    # of 10 each, reported `plateau` and ended the run at STUCK.
+    def _s(b, ung=()):
+        return {'blocking': b, 'quality': {}, 'ungraded': list(ung),
+                'blocking_by': {'unrouted': b,
+                                'impedance': (None if ung else 0)}}
+
+    st = converge._half_state(
+        [acc(_s(78, ['impedance']))] + [acc(_s(b)) for b in (70, 60, 50, 40)],
+        'routing', 5)
+    assert st['why'] == 'improving', \
+        'an incommensurable FIRST pair must not discard four real improvements'
+    print("  PASS: incommensurable scores are refused at record and never "
+          "credited as improvement")
+
+
+def test_a_plateau_is_never_claimed_over_laps_nothing_measured():
+    """A plateau asserted over laps that measured nothing is the
+    "reported clean because unexamined" error, in the stop rule.
+
+    Measured on the real run-17 ledger: the placement half read `plateau` from
+    a window of two cycle-1 accepted laps plus three cycle-2 REJECTIONS, while
+    five accepted cycle-2 laps were invisible for carrying `score: null`.
+    """
+    def acc(b):
+        return {'kind': 'completion', 'accepted': True,
+                'score': {'blocking': b, 'quality': {}, 'ungraded': []}}
+
+    rej = {'kind': 'completion', 'accepted': False, 'score': None}
+    unscored = {'kind': 'completion', 'accepted': True, 'score': None}
+
+    st = converge._half_state([acc(0), acc(0)] + [unscored] * 3, 'routing', 5)
+    assert st['why'] == 'no-comparison' and st['unjudged'] == 3, st
+    assert st['blocked'] == 'unjudged', st
+    assert st['flat'] is False, 'an unjudged lap is not evidence of a plateau'
+    # An unscored ACCEPTED lap is still a lap: it must not vanish from the
+    # count while rejections are kept.
+    assert st['laps'] == 5 and st['accepted'] == 5, st
+    # A window whose only accepted lap cannot be compared with anything is
+    # likewise not answerable -- it used to read `plateau` off a single key,
+    # where `min(keys[:1]) >= keys[0]` is a tautology.
+    st = converge._half_state([rej] * 4 + [acc(40)], 'routing', 5)
+    assert st['why'] == 'no-comparison' and st['flat'] is False, st
+    assert st['blocked'] == 'single-lap', st
+    # ...while an ALL-rejected window is a definite plateau: a rejection is
+    # itself the measurement.
+    assert converge._half_state([rej] * 5, 'routing', 5)['why'] == 'plateau'
+
+    # A REJECTION DOES NOT SEPARATE TWO SCORES. Comparability is a property of
+    # two scores' graded component sets and of nothing else, so treating a
+    # rejection as a break in the chain was a second false plateau -- measured
+    # over all 7776 accept/reject windows of 5, 441 flipped `improving` ->
+    # `plateau` and 2313 flipped `plateau` -> unanswerable, on the alternating
+    # accept/reject pattern that IS normal routing.
+    assert converge._half_state(
+        [acc(78), acc(78), acc(78), rej, acc(40)], 'routing', 5
+    )['why'] == 'improving', 'a rejection must not hide the lap after it'
+    assert converge._half_state(
+        [acc(40), rej, acc(40), rej, acc(40)], 'routing', 5
+    )['why'] == 'plateau', 'alternating accept/reject must still be judgeable'
+
+    # THE MESSAGE MUST NAME THE RIGHT CAUSE. The three blocked states call for
+    # different actions, and a text that guessed told a still-improving half to
+    # declare itself exhausted.
+    def _incomm(b, ung):
+        return {'kind': 'completion', 'accepted': True,
+                'score': {'blocking': b, 'quality': {}, 'ungraded': list(ung),
+                          'blocking_by': {'unrouted': b,
+                                          'impedance': None if ung else 0}}}
+
+    st = converge._half_state(
+        [_incomm(9, []), _incomm(9, ['impedance']), rej, rej, rej],
+        'routing', 5)
+    assert st['blocked'] == 'incommensurable', st
+    with tempfile.TemporaryDirectory() as td:
+        def _v(rows, name):
+            p = os.path.join(td, name)
+            with open(p, 'w', encoding='utf-8') as fh:
+                for i, r in enumerate(rows):
+                    fh.write(json.dumps(dict(r, iteration=i)) + '\n')
+            s = os.path.join(td, name + '.score')
+            json.dump({'blocking': 0, 'quality': {}, 'ungraded': []},
+                      open(s, 'w', encoding='utf-8'))
+            return json.loads(_cv(['verdict', '--ledger', p,
+                                   '--score', s]).stdout)['reason']
+
+        flat_p = [{'kind': 'placement', 'accepted': True,
+                   'score': {'blocking': 0, 'quality': {}, 'ungraded': []}}] * 5
+        r = _v(flat_p + [acc(0), acc(0)] + [unscored] * 3, 'u.jsonl')
+        assert 'recorded no `blocking`' in r, r
+        assert 'not graded over the same components' not in r, r
+        r = _v(flat_p + [rej] * 4 + [acc(40)], 's.jsonl')
+        assert 'only one of them carries a score' in r, r
+    print("  PASS: a plateau needs every lap in the window to have been judged")
+
+
+def test_a_lens_verdict_is_never_skipped_silently():
+    """The lens-vs-score check is skipped when the score grades another board
+    -- correctly, but an UNANNOUNCED skip is a door: attach any other board's
+    score and the whole gate switches off. Replaying all 56 real run-17 rows
+    with their original board_sha against a dummy board gave 0 refusals."""
+    with tempfile.TemporaryDirectory() as td:
+        led = os.path.join(td, 'l.jsonl')
+        p = os.path.join(td, 's.json')
+        json.dump({'blocking': 9, 'board_sha': 'f' * 64,
+                   'blocking_by': {'unrouted': 9, 'broken': 0}},
+                  open(p, 'w', encoding='utf-8'))
+        r = _cv(['record', '--ledger', led, '--board', BOARD, '--kind',
+                 'completion', '--lever', 'x', '--score-file', p,
+                 '--lens', 'VERDICT=PASS:lens=connectivity'])
+        assert r.returncode == 0, r.stderr
+        assert 'did NOT run' in r.stderr and 'UNCHECKED' in r.stderr, r.stderr
+
+    # A capitalised lens name used to pass the format check, miss the
+    # lower-case table and never be compared at all.
+    bad = {'blocking': 79, 'blocking_by': {'unrouted': 32, 'broken': 47}}
+    for name in ('connectivity', 'Connectivity', 'CONNECTIVITY'):
+        assert converge.lens_contradictions(
+            [f'VERDICT=PASS:lens={name}'], bad), name
+    print("  PASS: a skipped lens check says so; a capitalised lens still "
+          "compares")
+
+
+def test_the_exhausted_declaration_does_not_leak_between_halves():
+    """One half declaring itself finished must not finish the other, and a
+    `systemic` row -- which changes no copper -- must not retract it."""
+    dec = {'kind': 'systemic', 'accepted': True,
+           'exhausted': {'half': 'placement', 'reason': 'nothing left'}}
+    lap = {'kind': 'completion', 'accepted': True,
+           'score': {'blocking': 0, 'quality': {}, 'ungraded': []}}
+    # ON THE DECLARATION ALONE. Asserting on [dec, lap] proved nothing: the
+    # routing lap in that list retracts a leaked declaration, so the assertion
+    # passed even with the half check deleted -- verified by mutation.
+    assert converge._half_state([dec], 'placement', 5)['why'] \
+        == 'declared-exhausted'
+    assert converge._half_state([dec], 'routing', 5)['why'] != \
+        'declared-exhausted', 'a declaration must not cross halves'
+    rows = [dec, lap]
+    assert converge._half_state(rows, 'placement', 5)['why'] \
+        == 'declared-exhausted', 'the other half\'s lap does not retract it'
+    # A systemic row after the declaration is not a lap of that half.
+    assert converge._half_state(
+        [dec, {'kind': 'systemic', 'accepted': True}], 'placement', 5
+    )['why'] == 'declared-exhausted'
+    # ...but a PLACEMENT lap after it is, and it retracts.
+    assert converge._half_state(
+        [dec, {'kind': 'placement', 'accepted': True}], 'placement', 5
+    )['why'] != 'declared-exhausted'
+    print("  PASS: --exhausted binds to its own half and only its own laps "
+          "retract it")
+
+
+def test_every_incommensurable_pair_is_reported_even_when_it_changes_nothing():
+    """The WARNING must fire on ANY incommensurable pair, not only the shape
+    that gets refused -- and the verdict must say so on EVERY verdict, not
+    only the one it happened to change."""
+    with tempfile.TemporaryDirectory() as td:
+        led = os.path.join(td, 'l.jsonl')
+
+        def sc(doc, name):
+            p = os.path.join(td, name)
+            json.dump(doc, open(p, 'w', encoding='utf-8'))
+            return p
+
+        full = {'blocking': 70, 'quality': {}, 'ungraded': [],
+                'blocking_by': {'unrouted': 70, 'impedance': 0}}
+        # blocking ROSE, so this is not a false improvement and is not refused
+        # -- but the two rows still did not measure the same thing.
+        worse = {'blocking': 90, 'quality': {}, 'ungraded': ['impedance'],
+                 'blocking_by': {'unrouted': 90, 'impedance': None}}
+        assert _cv(['record', '--ledger', led, '--board', BOARD, '--kind',
+                    'completion', '--lever', 'a',
+                    '--score-file', sc(full, 'a.json')]).returncode == 0
+        r = _cv(['record', '--ledger', led, '--board', BOARD, '--kind',
+                 'completion', '--lever', 'b',
+                 '--score-file', sc(worse, 'b.json')])
+        assert r.returncode == 0, r.stderr
+        assert 'INCOMMENSURABLE' in r.stderr, r.stderr
+
+        # And on the verdict, whatever the verdict is.
+        rows = ([{'kind': 'placement', 'accepted': True, 'score': full}] * 5
+                + [{'kind': 'completion', 'accepted': True, 'score': full}] * 4
+                + [{'kind': 'completion', 'accepted': True, 'score': worse}])
+        lp = os.path.join(td, 'v.jsonl')
+        with open(lp, 'w', encoding='utf-8') as fh:
+            for i, r2 in enumerate(rows):
+                fh.write(json.dumps(dict(r2, iteration=i)) + '\n')
+        doc = json.loads(_cv(['verdict', '--ledger', lp,
+                              '--score', sc(full, 'v.json')]).stdout)
+        assert 'NOT COMPARABLE' in doc['reason'], doc['reason']
+        assert '--impedance-nets' in doc['reason'], doc['reason']
+        # The window is judged over maximal comparable RUNS, not "the first N",
+        # and N could be 0 -- the sentence has to describe what happened.
+        assert 'within the 4 lap(s) that do compare' in doc['reason'], \
+            doc['reason']
+    print("  PASS: every incommensurable pair is reported, at record and at "
+          "verdict")
 
 
 def test_record_score_failures_want_names():
@@ -309,6 +788,82 @@ def test_board_score_emits_board_sha():
     assert doc.get('board_sha') == sha256_file(BOARD), \
         "board_score must bind its payload to the graded file"
     print("  PASS: board_score embeds board_sha")
+
+
+def test_l5_printed_final_command_runs_as_printed():
+    """D1: the run-closing command L5 prints must be ACCEPTED by converge,
+    verbatim, for every terminal verdict. The refusal-driven executor recovers
+    from a refused command, but a driver whose doctrine is "paste these exact
+    commands" may not print one its own tool refuses: the STUCK/BUDGET paths
+    carry a FAIL lens as the normal case, and DONE-EXHAUSTED must never sit
+    beside one."""
+    import shlex
+    sys.path.insert(0, os.path.join(
+        ROOT, '.claude', 'skills', 'plan-pcb-placement-and-routing', 'scripts'))
+    from loop_driver import final_record_command
+
+    _PASS = {'connectivity': 'VERDICT=PASS:lens=connectivity',
+             'drc': 'VERDICT=PASS:lens=drc',
+             'spec': 'VERDICT=PASS:lens=spec'}
+    _FAIL_DRC = ('VERDICT=FAIL:lens=drc;finding=3 clearance violations;'
+                 'evidence=score.json#/blocking_by/drc')
+    _CLEAN = {'blocking': 0, 'blocking_by':
+              {'unrouted': 0, 'broken': 0, 'drc': 0, 'undersized': 0}}
+    _DIRTY = {'blocking': 3, 'blocking_by':
+              {'unrouted': 0, 'broken': 0, 'drc': 3, 'undersized': 0}}
+
+    def run_as_printed(name, lens_by_name, score_doc, led):
+        score = os.path.join(os.path.dirname(led), 'score.json')
+        with open(score, 'w', encoding='utf-8') as f:
+            json.dump(score_doc, f)
+        text = final_record_command(led.replace('\\', '/'),
+                                    BOARD.replace('\\', '/'),
+                                    score.replace('\\', '/'), name)
+        toks = shlex.split(text.replace('\\\n', ' '))
+        assert toks[0] == 'python3' and toks[3] == 'py_placer/converge.py', \
+            toks[:4]
+        toks[0] = sys.executable
+        # The three placeholder slots must be present AND recognisable -- if
+        # the driver's wording drifts, fail here rather than silently testing
+        # a different command than the one printed.
+        subst = {f'<the {lens} VERDICT= line, verbatim>': line
+                 for lens, line in lens_by_name.items()}
+        hit = 0
+        for i, t in enumerate(toks):
+            if t in subst:
+                toks[i] = subst[t]
+                hit += 1
+        assert hit == 3, f'expected 3 lens placeholders, found {hit}: {toks}'
+        ia = toks.index('--argv')
+        toks = toks[:ia + 1] + [sys.executable, '-c', 'pass']
+        return subprocess.run(toks, capture_output=True, text=True,
+                              encoding='utf-8', errors='replace', cwd=ROOT)
+
+    with tempfile.TemporaryDirectory() as td:
+        # DONE-EXHAUSTED: every lens passes, clean score.
+        r = run_as_printed('DONE-EXHAUSTED', _PASS, _CLEAN,
+                           os.path.join(td, 'done.jsonl'))
+        assert r.returncode == 0, r.stderr
+        e = json.loads(r.stdout)
+        assert e.get('final') is True and \
+            e.get('stop_condition') == 'DONE-EXHAUSTED'
+        # STUCK and BUDGET: a FAIL lens is the NORMAL case, not a refusal.
+        for name in ('STUCK', 'BUDGET'):
+            lenses = dict(_PASS, drc=_FAIL_DRC)
+            r = run_as_printed(name, lenses, _DIRTY,
+                               os.path.join(td, name + '.jsonl'))
+            assert r.returncode == 0, f'{name}: {r.stderr}'
+            e = json.loads(r.stdout)
+            assert e.get('stop_condition') == name
+            assert any(v.startswith('VERDICT=FAIL') for v in e['lenses'])
+        # DONE-EXHAUSTED beside a FAIL lens is the one contradiction.
+        led = os.path.join(td, 'contra.jsonl')
+        r = run_as_printed('DONE-EXHAUSTED', dict(_PASS, drc=_FAIL_DRC),
+                           _DIRTY, led)
+        assert r.returncode == 2 and 'contradiction' in r.stderr, r.stderr
+        assert not os.path.exists(led), "nothing may be written on refusal"
+    print("  PASS: L5's printed --final command runs as printed, "
+          "all three verdicts")
 
 
 if __name__ == '__main__':

--- a/tests/test_film_composition.py
+++ b/tests/test_film_composition.py
@@ -203,7 +203,10 @@ def test_the_cli_runs_end_to_end():
         r = subprocess.run(
             [sys.executable, '-X', 'utf8', os.path.join(ROOT, 'py_tools', 'make_film.py'),
              '-o', out], capture_output=True, text=True, cwd=ROOT)
-        assert r.returncode == 2, "no boards is a clean refusal, not a crash"
+        # The message claimed "not a crash" while nothing checked that -- a
+        # crash exiting 2 passed. Assert what the sentence says.
+        assert r.returncode == 2 and 'Traceback' not in (r.stderr or ''), \
+            f"no boards must be a clean refusal, not a crash: {(r.stderr or '')[-400:]}"
     print("  PASS: the CLI films a chain and refuses an empty one")
 
 

--- a/tests/test_npth_seed_floor.py
+++ b/tests/test_npth_seed_floor.py
@@ -79,12 +79,111 @@ def run():
     check('clear reported point kept',
           any(round(p[0], 2) == 2.0 for p in pts))
 
+    _d11_obstacle_map_reads_the_board(check)
+
     print()
     if fails:
         print(f'{len(fails)} FAILURE(S): {fails}')
         return 1
     print('all checks passed')
     return 0
+
+
+# --- D11: the ROUTER's NPTH keep-out must read min_hole_clearance too --------
+#
+# obstacle_map priced NPTH holes at a hardcoded
+# max(config.clearance, NPTH_TO_TRACK_CLEARANCE) -- a flat 0.20 fab floor that
+# never read the board -- while check_drc DOES read min_hole_clearance
+# (check_drc.py:2390). So on a board declaring 0.25 the router routed into a
+# band its own checker then flagged. Measured: a route came within 0.2263 mm of
+# BUS1's NPTH against a declared 0.25 -- a real 0.0237 mm violation,
+# routing-introduced, confirmed independently by kicad-cli, and the single DRC
+# failure on that board.
+
+def _declaring_board(tmp, **rules):
+    """A board file whose sibling project declares board constraints."""
+    import json
+    p = os.path.join(tmp, 'b.kicad_pcb')
+    with open(p, 'w', encoding='utf-8') as f:
+        f.write('(kicad_pcb (version 20240108))\n')
+    with open(os.path.join(tmp, 'b.kicad_pro'), 'w', encoding='utf-8') as f:
+        json.dump({'board': {'design_settings': {'rules': rules}}}, f)
+    return p
+
+
+def _d11_obstacle_map_reads_the_board(check):
+    import tempfile
+    import obstacle_map
+    from routing_config import GridRouteConfig
+
+    print()
+    print('D11: the NPTH track keep-out reads the board, not a constant')
+
+    with tempfile.TemporaryDirectory() as tmp:
+        quiet_dir = os.path.join(tmp, 'silent')
+        os.makedirs(quiet_dir, exist_ok=True)
+        declares = _declaring_board(tmp, min_hole_clearance=0.25)
+        silent = _declaring_board(quiet_dir)          # declares no constraints
+
+        cfg = GridRouteConfig()
+        cfg.clearance = 0.15
+        obstacle_map._HOLE_CLR_CACHE.clear()
+
+        pcb = SimpleNamespace(source_path=declares)
+        check('a board declaring 0.25 resolves to 0.25',
+              obstacle_map.resolve_hole_clearance(pcb, cfg) == 0.25)
+
+        quiet = SimpleNamespace(source_path=silent)
+        check('a board declaring nothing resolves to 0.0 (fab floor applies)',
+              obstacle_map.resolve_hole_clearance(quiet, cfg) == 0.0)
+
+        check('an in-memory board with no source_path resolves to 0.0',
+              obstacle_map.resolve_hole_clearance(
+                  SimpleNamespace(source_path=''), cfg) == 0.0)
+
+        cfg_x = GridRouteConfig()
+        cfg_x.clearance = 0.15
+        cfg_x.hole_clearance = 0.4
+        check('an explicit config value wins over the board',
+              obstacle_map.resolve_hole_clearance(pcb, cfg_x) == 0.4)
+
+        # THE POINT: the clearance actually handed to the keep-out stamper.
+        # 0.20 (fab) and 0.15 (routing) are both below the declared 0.25, so
+        # the old expression yielded 0.20 -- 0.05mm too close, which is how a
+        # 0.2263mm approach to a 0.25 hole got built.
+        captured = []
+        real = obstacle_map.block_track_cells_near_drills
+        real_via = obstacle_map.block_via_cells_near_drills
+        obstacle_map.block_track_cells_near_drills = (
+            lambda o, holes, tw, clr, step, layers: captured.append(clr))
+        obstacle_map.block_via_cells_near_drills = (
+            lambda *a, **k: None)
+        try:
+            for board, label, want in ((declares, 'declared 0.25', 0.25),
+                                       (silent, 'nothing declared', 0.20)):
+                captured.clear()
+                obstacle_map.add_drill_hole_obstacles(
+                    _FakeObstacles(), _npth_board(board), cfg, set())
+                check(f'NPTH keep-out priced at {want} when {label}',
+                      captured and abs(captured[0] - want) < 1e-9,
+                      )
+                if captured:
+                    print(f'        priced at {captured[0]:.4g}mm')
+        finally:
+            obstacle_map.block_track_cells_near_drills = real
+            obstacle_map.block_via_cells_near_drills = real_via
+
+
+class _FakeObstacles:
+    """add_drill_hole_obstacles only passes this through to the stampers."""
+
+
+def _npth_board(path):
+    pad = _npth(10.0, 10.0, 2.0)
+    pad.pad_number, pad.component_ref = 'H1', 'BUS1'
+    pad.local_clearance = 0.0
+    return SimpleNamespace(pads_by_net={0: [pad]}, vias=[], segments=[],
+                           zones=[], source_path=path)
 
 
 if __name__ == '__main__':

--- a/tests/test_orbit_fit_noop.py
+++ b/tests/test_orbit_fit_noop.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""`reconstruct.fit_family_orbits` must be SILENT on healthy boards.
+
+Same shape, and for the same reason, as `tests/test_run8_airwire_refuted.py`:
+a detector that fires on ordinary layout is not a detector. The airwire source
+was refuted at 6 of 33, and an un-guarded orbit fit is a related failure -- a
+near-collinear family of resistors fits an enormous circle exactly as a long
+airwire fits a damage vector.
+
+The value of this file is not the 0; it is the MATRIX. Each guard's
+contribution is pinned, so relaxing one shows up here as a number moving rather
+than being rediscovered on a board somebody shipped. Two of these rows exist
+because the investigation that proposed the fitter got them wrong in the
+direction that flattered it: it reported the un-guarded rate as 6 of 33 (it is
+28) and claimed the guarded rate stayed 0 with `min_inliers` at 4 and 3 (it is
+2 and 7). `min_inliers` is a load-bearing guard, not a formality.
+
+Run:  python3 tests/test_orbit_fit_noop.py
+"""
+import contextlib
+import glob
+import io
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_placer'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_tools'))  # #522/py_placer layout
+
+import pose_score                                              # noqa: E402
+from kicad_parser import parse_kicad_pcb                       # noqa: E402
+from placement import reconstruct as R                         # noqa: E402
+
+CORPUS = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                      'kicad_files')
+
+#: (label, min_inliers, guard overrides) -> boards of the corpus that fire.
+#: Ordered so each row adds ONE guard to the row above it.
+MATRIX = [
+    ('no guards at all', 3,
+     dict(ORBIT_MAX_RADIUS_FRAC=1e9, ORBIT_M_RANGE=range(2, 25),
+          ORBIT_MIN_SEATS_PER_CLASS=1, ORBIT_MIN_OCCUPANCY=0.0), 28),
+    ('+ scale', 3,
+     dict(ORBIT_M_RANGE=range(2, 25), ORBIT_MIN_SEATS_PER_CLASS=1,
+          ORBIT_MIN_OCCUPANCY=0.0), 28),
+    ('+ curvature (m >= 3)', 3,
+     dict(ORBIT_MIN_SEATS_PER_CLASS=1, ORBIT_MIN_OCCUPANCY=0.0), 28),
+    ('+ over-determination (>= 3 distinct SEATS/class)', 3,
+     dict(ORBIT_MIN_OCCUPANCY=0.0), 14),
+    ('+ occupancy (>= 0.60 of slots filled)', 3, {}, 7),
+    ('+ min_inliers 4', 4, {}, 2),
+    ('+ min_inliers 5  [SHIPPED]', 5, {}, 0),
+]
+
+
+def _states():
+    out = {}
+    for b in sorted(glob.glob(os.path.join(CORPUS, '*.kicad_pcb'))):
+        with contextlib.redirect_stdout(io.StringIO()), \
+                contextlib.redirect_stderr(io.StringIO()):
+            pcb = parse_kicad_pcb(b)
+            out[os.path.basename(b)] = pose_score.make_state(pcb, b)
+    return out
+
+
+def _fire(states, min_inliers, patch):
+    saved = {k: getattr(R, k) for k in patch}
+    for k, v in patch.items():
+        setattr(R, k, v)
+    try:
+        out = {}
+        for n, st in states.items():
+            f = R.fit_family_orbits(st, min_inliers=min_inliers)
+            if f:
+                out[n] = f
+        return out
+    finally:
+        for k, v in saved.items():
+            setattr(R, k, v)
+
+
+def main():
+    states = _states()
+    assert len(states) >= 30, f'corpus shrank to {len(states)} boards'
+    print(f'corpus: {len(states)} healthy boards\n')
+    bad = []
+    for label, mi, patch, expect in MATRIX:
+        fired = _fire(states, mi, patch)
+        ok = len(fired) == expect
+        print(f'  {"ok " if ok else "FAIL"} {label:<50} '
+              f'{len(fired):>2} of {len(states)} fire  (expect {expect})')
+        if not ok:
+            bad.append((label, len(fired), expect, sorted(fired)))
+
+    # The one that actually gates behaviour, stated separately so a reader
+    # cannot miss it among the diagnostic rows.
+    shipped = _fire(states, R.ORBIT_MIN_INLIERS, {})
+    print(f'\n  SHIPPED CONFIGURATION: {len(shipped)} of {len(states)} '
+          f'healthy boards fire')
+    if shipped:
+        bad.append(('shipped config is not a no-op', len(shipped), 0,
+                    sorted(shipped)))
+        for n, f in sorted(shipped.items()):
+            print(f'     {n}: {[repr(x) for x in f]}')
+
+    # ...and the detector must still SEE a real orbit, or a no-op is trivial.
+    # A synthetic one, so this does not depend on a wk/ artifact.
+    fit = R._fit_orbit_m(
+        'synthetic', 0.0, 0.0, 10.0,
+        [f'D{i}' for i in range(8)],
+        {f'D{i}': (10.0 * __import__('math').cos(__import__('math').radians(45 * i)),
+                   10.0 * __import__('math').sin(__import__('math').radians(45 * i)))
+         for i in range(8)}, 5)
+    if fit is None or fit.m != 8 or len(fit.inliers) != 8 or fit.free_slots:
+        bad.append(('a perfect 8-fold ring was not detected', fit, 'm=8 8/8', []))
+        print(f'  FAIL an exact 8-fold ring of 8 members: {fit!r}')
+    else:
+        print(f'  ok  an exact 8-fold ring of 8 members is detected: {fit!r}')
+
+    # ...and a ring with ONE member removed exposes exactly one free slot,
+    # which is the fact `lock_advisor` and any future consumer key on.
+    gone = R._fit_orbit_m(
+        'synthetic', 0.0, 0.0, 10.0,
+        [f'D{i}' for i in range(7)],
+        {f'D{i}': (10.0 * __import__('math').cos(__import__('math').radians(45 * i)),
+                   10.0 * __import__('math').sin(__import__('math').radians(45 * i)))
+         for i in range(7)}, 5)
+    if gone is None or len(gone.free_slots) != 1:
+        bad.append(('a ring missing one member did not expose one free slot',
+                    gone, '1 free slot', []))
+        print(f'  FAIL a 7-of-8 ring: {gone!r}')
+    else:
+        print(f'  ok  a 7-of-8 ring exposes exactly 1 free slot: {gone!r}')
+
+    if bad:
+        print('\nFAILURES:')
+        for row in bad:
+            print('  ', row)
+        return 1
+    print('\nPASS')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_pile_baseline_license.py
+++ b/tests/test_pile_baseline_license.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""A pile-degenerate seed must not license pad intersections.
+
+Run 19, cycle 1: every conjunct of `LegalityContext.pads_ok` is relative to
+`seed_baseline`, and on a PILE the seed pair carries huge `base.pad` with
+`pad_overlap` and `stack` both True -- so ANY smaller intersection passed,
+producing the SW23/SW28<->U2 blocker pairs on the shipped board.
+
+The fix sits at the single choke point every consumer routes through
+(`seed_baseline`, feeding `pads_ok` and `swap_pads_ok`): a seed bucket of
+>= 3 parts at one round(coord, 3) point is the pile signature, and every part
+in one gets the ZERO baseline -- its pose must be absolutely clean toward
+every neighbor. Deliberately >= 3, not >= 2: a legitimate two-part by-design
+overlap (run 18's under-module R1<->U2 pairs) KEEPS its baseline license,
+and this test pins BOTH sides of that line.
+
+Run: python3 -X utf8 tests/test_pile_baseline_license.py
+"""
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_placer'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_tools'))  # #522/py_placer layout
+os.environ.setdefault('KRT_NO_BANNER', '1')
+
+from kicad_parser import Footprint, Pad                        # noqa: E402
+from placement import legality                                 # noqa: E402
+
+FAILURES = []
+
+
+def check(name, cond, detail=''):
+    print(f'  {"PASS" if cond else "FAIL"}  {name}'
+          + (f'\n        {detail}' if not cond and detail else ''))
+    if not cond:
+        FAILURES.append(name)
+
+
+_NET = iter(range(1, 100))
+
+
+def two_pad_part(ref):
+    """A 2-pad 0603-ish SMD part in the part frame (fp at origin), every pad
+    on its own net so cross-part contact is a different-net intersection."""
+    pads = [Pad(ref, str(i + 1), x, 0.0, x, 0.0, 0.8, 0.9, 'rect',
+                ['F.Cu'], next(_NET), f'/N{ref}{i}', pad_type='smd')
+            for i, x in enumerate((-0.5, 0.5))]
+    return Footprint(ref, f'test:{ref}', 0.0, 0.0, 0.0, 'F.Cu', pads=pads)
+
+
+def main():
+    fps = {r: two_pad_part(r) for r in ('A', 'B', 'C', 'D', 'E')}
+    part_pads = legality.build_part_pads(fps, 0.2)
+    # A, B, C piled at ONE seed point (>= 3: degenerate). D, E share a seed
+    # point too, but as a PAIR (run 18's by-design under-module overlap).
+    seed = {'A': (10.0, 10.0, 0.0), 'B': (10.0, 10.0, 0.0),
+            'C': (10.0, 10.0, 0.0),
+            'D': (50.0, 50.0, 0.0), 'E': (50.0, 50.0, 0.0)}
+    cur = {'A': (20.0, 10.0, 0.0), 'B': (30.0, 10.0, 0.0),
+           'C': (40.0, 10.0, 0.0),
+           'D': (50.0, 50.0, 0.0), 'E': (50.0, 50.0, 0.0)}
+    ctx = legality.LegalityContext(part_pads, None, 0.2,
+                                   pose_of=lambda r: cur[r],
+                                   seed_of=lambda r: seed[r])
+
+    print('the pile (3 parts at one seed point) licenses NOTHING')
+    check('a piled part\'s baseline is ZERO_SHORTFALL',
+          ctx.seed_baseline('A', 'B') is legality.ZERO_SHORTFALL)
+    # A proposes B's exact current pose: a full different-net pad
+    # intersection. Pre-fix the pile baseline carried the same intersection
+    # (cur.pad == base.pad) and pads_ok ACCEPTED this pose.
+    check('pads_ok REFUSES a pose carrying a pad intersection',
+          ctx.pads_ok('A', 30.0, 10.0, 0.0, ['B']) is False)
+    check('a clean pose is still accepted for a piled part',
+          ctx.pads_ok('A', 20.0, 10.0, 0.0, ['B', 'C']) is True)
+
+    print('the 2-part by-design overlap KEEPS its license (run 18)')
+    base_de = ctx.seed_baseline('D', 'E')
+    check('the designed pair\'s baseline still carries its overlap',
+          base_de.pad > 0 and base_de.stack, str(base_de))
+    check('pads_ok still admits the designed pose',
+          ctx.pads_ok('D', 50.0, 50.0, 0.0, ['E']) is True)
+
+    print()
+    if FAILURES:
+        print(f'FAIL: {len(FAILURES)} check(s): {", ".join(FAILURES)}')
+        return 1
+    print('OK')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_place_reconstruct.py
+++ b/tests/test_place_reconstruct.py
@@ -81,6 +81,9 @@ class TestReseatRung(unittest.TestCase):
 
     def test_ladder_order(self):
         sys.path.insert(0, ROOT)
+        sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # placement split
+        sys.path.insert(0, os.path.join(ROOT, 'py_tools'))  # placement split
+        sys.path.insert(0, os.path.join(ROOT, 'py_placer'))  # placement split
         import place_reconstruct as pr
         s = pr._STAGES
         self.assertIn('reseat', s)
@@ -133,6 +136,9 @@ class TestReseatRung(unittest.TestCase):
         158 mm off the outline, and every candidate looks equally good.
         """
         sys.path.insert(0, ROOT)
+        sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # placement split
+        sys.path.insert(0, os.path.join(ROOT, 'py_tools'))  # placement split
+        sys.path.insert(0, os.path.join(ROOT, 'py_placer'))  # placement split
         import tempfile
         from kicad_parser import parse_kicad_pcb
         from placement import floorplan, seeder

--- a/tests/test_place_reconstruct.py
+++ b/tests/test_place_reconstruct.py
@@ -68,5 +68,116 @@ class TestReconstructSwap(unittest.TestCase):
             self.assertEqual(moved, [])
 
 
+class TestReseatRung(unittest.TestCase):
+    """The `reseat` rung: parts no vector can carry and no cap can reach.
+
+    It sits between `exchange` and `legalize` deliberately -- exchange moves
+    parts the damage displaced by a DETECTED vector, legalize nudges parts that
+    are nearly right, and a part tens of millimetres out with no surviving
+    family to over-determine a vector falls between them. Nothing in the ladder
+    moved those, and on the measured board they carried a pad on every one of
+    the 13 nets the router refused to attempt.
+    """
+
+    def test_ladder_order(self):
+        sys.path.insert(0, ROOT)
+        import place_reconstruct as pr
+        s = pr._STAGES
+        self.assertIn('reseat', s)
+        self.assertLess(s.index('exchange'), s.index('reseat'))
+        self.assertLess(s.index('reseat'), s.index('legalize'))
+        # ...and the DEFAULT ladder runs it, or it ships switched off and
+        # every caller has to know to ask for it. Asserted on what the run
+        # REPORTS it requested, not on the help text.
+        if not os.path.exists(CONTROL):
+            self.skipTest('control board not present')
+        import json
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            r = run_reconstruct(CONTROL, os.path.join(td, 'o.kicad_pcb'),
+                                '--dry-run')
+            line = next(l for l in r.stdout.splitlines()
+                        if l.startswith('JSON_SUMMARY:'))
+            doc = json.loads(line.split(':', 1)[1])
+            self.assertIn('reseat', doc['stages_requested'],
+                          'the default --stages must include reseat')
+
+    def test_reseat_is_a_noop_on_a_healthy_board(self):
+        if not os.path.exists(CONTROL):
+            self.skipTest('control board not present')
+        import json
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            out = os.path.join(td, 'recon.kicad_pcb')
+            r = run_reconstruct(CONTROL, out, '--stages', 'classify,reseat',
+                                '--dry-run')
+            self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+            line = next(l for l in r.stdout.splitlines()
+                        if l.startswith('JSON_SUMMARY:'))
+            doc = json.loads(line.split(':', 1)[1])
+            self.assertIn('reseat', doc, doc)
+            rs = doc['reseat']
+            self.assertEqual(rs['scope'], [], rs)
+            self.assertEqual(rs['witnesses_before'], [], rs)
+            self.assertEqual(rs['witnesses_after'], [], rs)
+            self.assertEqual(rs['scope_source'], 'auto:damage_witnesses')
+
+    def test_reseat_measures_with_SCOPE_FILTERED_edge_bands(self):
+        """The scope forfeits its own declared band, in the GATE too.
+
+        This is the whole reason the pass can be graded at all. An intent
+        emitted off a damaged board declares each off-board part an edge
+        connector with a band equal to its damage displacement, and
+        `pad_oob_amount` charges only the excess past the band -- so with those
+        bands in place the gate reads `oob = 4.348` on a board carrying parts
+        158 mm off the outline, and every candidate looks equally good.
+        """
+        sys.path.insert(0, ROOT)
+        import tempfile
+        from kicad_parser import parse_kicad_pcb
+        from placement import floorplan, seeder
+        from placement import reconstruct as rec
+        from placement.writer import write_placed_output
+        import pose_score
+
+        board = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
+        if not os.path.exists(board):
+            self.skipTest('fixture board not present')
+        with tempfile.TemporaryDirectory() as td:
+            pcb = parse_kicad_pcb(board)
+            bb = pcb.board_info.board_bounds
+            victims = [r for r, fp in sorted(pcb.footprints.items())
+                       if fp.pads][:3]
+            dmg = os.path.join(td, 'dmg.kicad_pcb')
+            write_placed_output(board, dmg, [
+                {'reference': r, 'new_x': bb[2] + 25.0 + 5.0 * i,
+                 'new_y': (bb[1] + bb[3]) / 2,
+                 'new_rotation': pcb.footprints[r].rotation or 0}
+                for i, r in enumerate(victims)])
+            dpcb = parse_kicad_pcb(dmg)
+            st = pose_score.make_state(dpcb, dmg)
+            scope = set(rec.damage_witnesses(st))
+            self.assertEqual(sorted(scope), sorted(victims))
+
+            # A band big enough to swallow the damage, as a laundered intent
+            # would carry. The gate must NOT see it for a scope ref.
+            bands = {r: 500.0 for r in victims}
+            self.assertLess(rec.measure(st, bands)[rec.GATE_TERMS.index('oob')],
+                            1.0, 'the laundered band hides the damage')
+            filtered = {r: m for r, m in bands.items() if r not in scope}
+            self.assertGreater(
+                rec.measure(st, filtered)[rec.GATE_TERMS.index('oob')], 50.0,
+                'filtering the scope out exposes it again')
+
+            # ...and reseat_scope does that filtering itself, given the map.
+            rep = seeder.reseat_scope(dpcb, dmg, floorplan.empty_intent(dmg),
+                                      edge_bands=bands)
+            oob = rec.GATE_TERMS.index('oob')
+            self.assertGreater(rep['gate_before'][oob], 50.0, rep['gate_before'])
+            self.assertLess(rep['gate_after'][oob], rep['gate_before'][oob])
+            self.assertTrue(rep['accepted'], rep['notes'])
+            self.assertEqual(rep['witnesses_after'], [], rep)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_place_seed.py
+++ b/tests/test_place_seed.py
@@ -122,5 +122,151 @@ with tempfile.TemporaryDirectory() as d:
     check("seed output carries the .kicad_dru sibling",
           os.path.isfile(os.path.join(d, 's.kicad_dru')))
 
+    # ---------------------------------------------------------------- --reseat
+    #
+    # A part tens of millimetres off the outline is unreachable by every
+    # minimal-move repair in this stack, because they all search outward from
+    # the part's CURRENT pose. Measured on a real damaged board: --repair spent
+    # 4m55s and attempted none of the 11 such parts. --reseat lifts them.
+    print("\n--reseat")
+
+    # (a) HEALTHY BOARD: the auto scope is empty and the pass is a no-op that
+    # exits 0. This is the property that makes it safe in a default ladder --
+    # the census is corpus-calibrated to zero on all 33 in-repo boards.
+    r = run([seed_py, BOARD, os.path.join(d, 'h.kicad_pcb'),
+             '--intent', intent_path, '--reseat', '--dry-run'])
+    check("healthy board: bare --reseat exits 0", r.returncode == 0,
+          f"rc={r.returncode} {(r.stdout + r.stderr)[-300:]}")
+    s = summary(r)
+    check("healthy board: auto scope is empty", s['scope'] == [], str(s['scope']))
+    check("healthy board: no witnesses before OR after",
+          s['witnesses_before'] == 0 and s['witnesses_after'] == 0)
+
+    # (b) DAMAGED BOARD, synthesized here so the test owns its own fixture:
+    # push three parts well outside the outline.
+    victims = [ref for ref, fp in sorted(pcb.footprints.items())
+               if fp.pads][:3]
+    far_x = b[2] + 25.0
+    dmg = os.path.join(d, 'dmg.kicad_pcb')
+    write_placed_output(BOARD, dmg, [
+        {'reference': ref, 'new_x': far_x + 5.0 * i, 'new_y': cy,
+         'new_rotation': pcb.footprints[ref].rotation or 0}
+        for i, ref in enumerate(victims)])
+
+    import pose_score
+    from placement import reconstruct as _rec
+    _dpcb = parse_kicad_pcb(dmg)
+    _dst = pose_score.make_state(_dpcb, dmg)
+    wit = sorted(_rec.damage_witnesses(_dst))
+    check("damage_witnesses names exactly the parts pushed off",
+          wit == sorted(victims), f"{wit} vs {sorted(victims)}")
+
+    # (c) THE LAUNDERED-BAND REGRESSION. An intent emitted off the DAMAGED
+    # board must NOT convert those overhangs into declared edge bands: run 10
+    # emitted bands equal to each part's damage displacement (up to 160mm on an
+    # 81mm board), which blinded the repair census, the reconstruct gate and
+    # the intent grade all at once. The entry is capped AND loses its `edge`.
+    dmg_intent = os.path.join(d, 'dmg_intent.json')
+    _di = emit_intent(_dpcb, dmg, declare_classes=True)
+    with open(dmg_intent, 'w', encoding='utf-8') as f:
+        json.dump(_di, f)
+    _ec = {c['ref']: c for c in _di.get('edge_connectors') or ()}
+    _bad = [(v, _ec[v].get('overhang_mm', {}).get('max'), _ec[v].get('edge'))
+            for v in victims if v in _ec]
+    check("a 25mm+ overhang is emitted WITHOUT an edge (treated as damage)",
+          all(e is None for _r, _m, e in _bad) and len(_bad) == len(victims),
+          str(_bad))
+    check("...and its band is CAPPED, not the observed displacement",
+          all(m is not None and m <= 25.0 for _r, m, _e in _bad), str(_bad))
+    check("...and the entry says so in machine-readable form",
+          all(_ec[v].get('overhang_capped') for v in victims if v in _ec))
+    # The counterfactual, pinned because this is the kind of finding that gets
+    # re-litigated: seeding WITH such a band is not a small error. Stage 1
+    # places a declared edge connector with no legality gate at the middle of
+    # its band, and a 160mm band threw a part THIRTY KILOMETRES off the board.
+    check("the uncapped band would have been >= the displacement",
+          all(m < 20.0 for _r, m, _e in _bad),
+          'cap must be far below the ~25-35mm observed overhang')
+
+    # (d) THE PASS ITSELF: auto scope, all seated, witnesses to zero.
+    out_r = os.path.join(d, 'r.kicad_pcb')
+    r = run([seed_py, dmg, out_r, '--intent', dmg_intent, '--reseat'])
+    check("--reseat on the damaged board exits 0", r.returncode == 0,
+          f"rc={r.returncode} {(r.stdout + r.stderr)[-400:]}")
+    s = summary(r)
+    check("--reseat auto scope is exactly the witnesses",
+          s['scope'] == sorted(victims), str(s['scope']))
+    check("--reseat scope_source names the census",
+          s['scope_source'] == 'auto:damage_witnesses')
+    check("witnesses_after is 0 -- THE number that predicts routability",
+          s['witnesses_after'] == 0,
+          f"{s['witnesses_before']} -> {s['witnesses_after']}")
+    check("every scope part was seated", s['unseated'] == [] and
+          s['reseated'] == len(victims), str(s))
+    check("the gate ACCEPTED", s['accepted'] is True)
+    _gb, _ga = s['gate_before'], s['gate_after']
+    _oob = _rec.GATE_TERMS.index('oob')
+    check("oob strictly improved", _ga[_oob] < _gb[_oob],
+          f"{_gb[_oob]} -> {_ga[_oob]}")
+    check("nothing ABOVE oob in the gate tuple worsened",
+          all(_ga[i] <= _gb[i] for i in range(_oob)),
+          f"{_gb[:_oob]} -> {_ga[:_oob]}")
+    check("no scope ref kept an edge declaration",
+          set(s['edge_bands_dropped']) <= set(victims))
+
+    # (e) THE CAUSAL PROPERTY, and the reason the pass exists: every net that
+    # had a pad OFF THE BOARD has none afterwards. That is the thing which
+    # converts one-for-one into `unrouted` -- on the measured board the 11
+    # off-board parts carried a pad on every one of the 13 nets the router
+    # refused to attempt.
+    #
+    # `placement_blocked` (< 2 ON-BOARD pads, board_score's split) is the
+    # STRICTER form and is asserted only when the fixture actually produces
+    # one: whether an off-board pad drops its net below two on-board pads
+    # depends on which parts got pushed off, and here they are decaps on rails
+    # with many other pads. The general property above holds either way.
+    from check_drc import make_off_board_test
+    from net_queries import routable_pad_count
+
+    def net_shapes(board):
+        p = parse_kicad_pcb(board)
+        off = make_off_board_test(p.board_info)
+        dirty, blocked = set(), set()
+        for nid, pads in p.pads_by_net.items():
+            if nid not in p.nets or len(pads) < 2:
+                continue
+            if any(off(q.global_x, q.global_y) for q in pads):
+                dirty.add(p.nets[nid].name)
+            if routable_pad_count(p, nid, off) < 2:
+                blocked.add(p.nets[nid].name)
+        return dirty, blocked
+
+    _d0, _b0 = net_shapes(dmg)
+    _d1, _b1 = net_shapes(out_r)
+    check("damaged board HAS nets with an off-board pad", bool(_d0),
+          str(sorted(_d0)[:6]))
+    check("after --reseat NO net has an off-board pad", not _d1,
+          str(sorted(_d1)[:6]))
+    check("placement-blocked nets do not survive the pass", not _b1,
+          f"before {sorted(_b0)[:4]} after {sorted(_b1)[:4]}")
+
+    # (f) determinism across PYTHONHASHSEED, same as the seeding path above.
+    out_r2 = os.path.join(d, 'r2.kicad_pcb')
+    r = run([seed_py, dmg, out_r2, '--intent', dmg_intent, '--reseat'],
+            hashseed="12345")
+    check("--reseat is byte-identical across hash seeds",
+          r.returncode == 0
+          and open(out_r, 'rb').read() == open(out_r2, 'rb').read())
+
+    # (g) refusals are NAMED, never silent.
+    r = run([seed_py, dmg, os.path.join(d, 'n.kicad_pcb'),
+             '--intent', dmg_intent, '--reseat', 'NOSUCHREF', '--dry-run'])
+    check("an unmatched ref is named in the notes",
+          'NOSUCHREF' in r.stdout, r.stdout[-300:])
+    r = run([seed_py, dmg, os.path.join(d, 'f.kicad_pcb'),
+             '--intent', dmg_intent, '--reseat', '--force'])
+    check("--reseat with --force is a usage error", r.returncode == 2,
+          f"rc={r.returncode}")
+
 print(f"\n{passed}/{passed + failed} checks passed")
 sys.exit(1 if failed else 0)

--- a/tests/test_qfn_underpad.py
+++ b/tests/test_qfn_underpad.py
@@ -58,12 +58,348 @@ def main():
             if d < VIA_SIZE + CLEARANCE - 1e-6:
                 fails.append(f"vias too close: {d:.3f} < {VIA_SIZE + CLEARANCE}")
 
+    fails += _d10_self_blindness()
+
     if fails:
         print("FAIL: " + "; ".join(fails))
         return 1
     print(f"PASS: pair escaped as {len(vias)} staggered through-vias, "
           f"min different-net spacing OK")
     return 0
+
+
+# --- D10: the candidate test must see the run's OWN emitted copper ----------
+#
+# `via_clears` tested a candidate against the board it was handed -- a snapshot
+# taken before anything was placed -- and against the via CENTRES emitted so
+# far. It never saw the STUBS the same run emitted, so it approved vias sitting
+# on copper it had just laid, and those escapes came back DRC CONTACTS.
+#
+# Measured: U2 (QFN56) reported 39 of 46 escapes under `--escape-method underpad
+# --allow-via-in-pad` and the gate rejected every one as a contact -- while a
+# hostile verifier established the geometry was fine (1.4mm moat admitting a
+# 0.7mm via at all 56 pads, pad_via == 0, a real 0.700mm via placeable DRC-clean
+# in U2.43, true capacity 11 of 14 lanes per side).
+
+KN = dict(via_size=0.7, via_drill=0.4, clearance=0.2, track_width=0.15,
+          hole_to_hole=0.2)
+
+
+def _d10_self_blindness():
+    from qfn_fanout import run_output_conflict as conflict
+    bad = []
+
+    def check(name, cond):
+        print(("PASS: " if cond else "FAIL: ") + name)
+        if not cond:
+            bad.append(name)
+
+    # Net 1: pad at (0,0), via at (0,2) -- so a 2mm stub runs up x=0.
+    stub = [(0.0, 2.0, 1, 0.0, 0.0)]
+
+    # A net-2 via at (0,1) sits ON that stub, yet is 1.0mm from the via centre
+    # -- comfortably past the 0.9mm different-net via floor (0.7+0.2). So the
+    # via-to-via test PASSES it, and ONLY the stub test can reject it. This is
+    # exactly the shape that shipped contacts.
+    check('a via sitting on this run\'s own stub is rejected',
+          conflict(0.0, 1.0, 2, stub, **KN))
+    # ...and it is ONLY the stub that rejects it: with the stub removed from
+    # the entry (a bare via centre, the old 3-tuple shape) the same candidate
+    # is accepted. Asserting the arithmetic instead would test literals.
+    check('...the SAME candidate passes when that stub is not recorded',
+          not conflict(0.0, 1.0, 2, [(0.0, 2.0, 1)], **KN))
+
+    # Same net: its own stub is not an obstacle.
+    check('a SAME-net via on the same stub is allowed',
+          not conflict(0.0, 1.0, 1, stub, **KN))
+
+    # Clear of everything.
+    check('a via clear of both the stub and the via is allowed',
+          not conflict(3.0, 1.0, 2, stub, **KN))
+
+    # The candidate's OWN stub must be tested too -- here the via lands clear
+    # but its stub from (0.6,1.0) sweeps across the placed via at (0,2)... use
+    # a pad whose stub passes the foreign via.
+    check('a candidate whose own STUB crosses a placed via is rejected',
+          conflict(-2.0, 2.0, 2, stub, px=2.0, py=2.0, **KN))
+
+    # Stub-vs-stub, ISOLATED. A parallel-stubs case would be tautological: two
+    # stubs close enough to graze also put their vias inside the 0.9mm
+    # different-net via floor, so the via-to-via test alone would reject it and
+    # the assertion would pass with the stub logic deleted. Cross them instead,
+    # with a long placed stub, so every other pair is far above its floor:
+    #   cand via <-> placed via  2.50mm (floor 0.90)
+    #   cand via <-> placed stub 2.00mm (floor 0.625)
+    #   placed via <-> cand stub 1.50mm (floor 0.625)
+    # Only the stub-vs-stub distance (0) can fire.
+    long_stub = [(0.0, 3.0, 1, 0.0, 0.0)]
+    check('a candidate whose STUB crosses an emitted stub is rejected',
+          conflict(2.0, 1.5, 2, long_stub, px=-2.0, py=1.5, **KN))
+    check('...and the same crossing on its OWN net is allowed',
+          not conflict(2.0, 1.5, 1, long_stub, px=-2.0, py=1.5, **KN))
+
+    # A via-in-pad entry has a zero-length stub and must not be read as one.
+    inpad = [(5.0, 5.0, 1, 5.0, 5.0)]
+    check('a zero-length (via-in-pad) stub is not treated as copper',
+          not conflict(5.0, 6.0, 2, inpad, **KN))
+
+    bad += _d10_wiring()
+    bad += _q2_reuse_adds_no_via()
+    return bad
+
+
+# --- Q2: a REUSE adds no drill and no via copper, only the stub -------------
+#
+# The D10 follow-up wired the reuse branch into run_output_conflict -- correctly,
+# because that branch was blind to this run's own output -- but priced the
+# REUSED via as a NEW one. The reuse target is an existing board via; on
+# routed_output.kicad_pcb those are 0.30, and the partners they were judged
+# against are also pre-existing 0.30 vias sitting at 0.400mm: legal
+# (0.15 + 0.15 + 0.10) and already on the board. Priced at config via_size 0.45
+# the test demanded 0.55 and rejected all 7 reuse candidates -- judging two vias
+# that already exist, at a size neither has, for a spacing this run does not
+# create.
+#
+# Measured on kicad_files/routed_output.kicad_pcb, U2, B.Cu, track/clearance
+# 0.1, via 0.45/0.25, --escape-method underpad --allow-via-in-pad:
+#
+#     715c821 (before D10 follow-up)  28 vias / 12 dropped / 30 tracks
+#     f1dd280 (the follow-up)         29 vias / 13 dropped / 31 tracks
+#
+# Net-(U2A-DATA_30) lost its escape and a fresh drill appeared where a reuse
+# would have served -- which is what #479 audit gap 2's reuse path exists to
+# prevent.
+
+# The numbers off that board, so the geometry under test is the measured one.
+REUSE_KN = dict(via_size=0.45, via_drill=0.25, clearance=0.1, track_width=0.1,
+                hole_to_hole=0.2)
+U2_BOARD = os.path.join(ROOT, "kicad_files", "routed_output.kicad_pcb")
+
+
+def _q2_reuse_adds_no_via():
+    from qfn_fanout import run_output_conflict as conflict
+    bad = []
+
+    def check(name, cond, detail=""):
+        print(("PASS: " if cond else "FAIL: ") + name + (f"  [{detail}]"
+                                                         if detail else ""))
+        if not cond:
+            bad.append(name)
+
+    # The BOARD first, deliberately: the checks below pass `adds_via`, which
+    # does not exist before the fix, so on the unfixed engine they raise rather
+    # than measure. Running the counts first makes the pre-fix failure a
+    # measured 29/13/31 instead of a TypeError.
+    bad += _q2_reuse_end_to_end()
+
+    # The exact rejection the verifier isolated, in board coordinates. A
+    # pre-existing 0.30 via on another net at (213.5625, 105.7) fed by a stub
+    # from its pad at (213.5625, 105.5); the reuse candidate is a pre-existing
+    # 0.30 via at (213.5625, 106.1), bridged from the pad at (213.5625, 106.3).
+    placed = [(213.5625, 105.7, 80, 213.5625, 105.5)]
+    cand = (213.5625, 106.1, 107)
+    pad = dict(px=213.5625, py=106.3)
+    gap = 106.1 - 105.7
+
+    check('the measured spacing is the legal one for two 0.30 vias',
+          abs(gap - 0.400) < 1e-9 and 0.400 >= 0.15 + 0.15 + 0.10 - 1e-9,
+          f"gap {gap:.4f}, true floor 0.40, demanded "
+          f"{REUSE_KN['via_size'] + REUSE_KN['clearance']:.2f}")
+    # Pricing it as a NEW via is what rejected it: this is the f1dd280 call.
+    check('priced as a NEW via, the legal reuse is rejected (the regression)',
+          conflict(*cand, placed, **pad, **REUSE_KN))
+    # ...and suppressing the via terms -- which is what "adds no via" means --
+    # accepts it. Only `adds_via` differs between these two lines, so nothing
+    # else can be what changed the verdict.
+    check('a reuse adds no drill and no via copper, so it is accepted',
+          not conflict(*cand, placed, **pad, adds_via=False, **REUSE_KN))
+
+    # The stub is still tested, or the branch would be blind again -- which is
+    # the D10 gap this must not reopen. A reuse whose BRIDGING STUB crosses
+    # another net's stub is rejected even with adds_via=False.
+    crossing = [(0.0, 3.0, 1, 0.0, 0.0)]        # placed stub up x=0, y 0..3
+    check('a reuse whose stub crosses an emitted stub is still rejected',
+          conflict(2.0, 1.5, 2, crossing, px=-2.0, py=1.5, adds_via=False,
+                   **REUSE_KN))
+    # ...and its stub against a placed VIA, the other direction.
+    check('a reuse whose stub runs over a placed via is still rejected',
+          conflict(2.0, 3.0, 2, [(0.0, 3.0, 1, 0.0, 0.0)], px=-2.0, py=3.0,
+                   adds_via=False, **REUSE_KN))
+    # Same net is still exempt.
+    check('a same-net reuse crossing its own stub is allowed',
+          not conflict(2.0, 1.5, 1, crossing, px=-2.0, py=1.5, adds_via=False,
+                       **REUSE_KN))
+    # A reuse landing ON the pad emits no track at all (the commit loop skips
+    # a sub-tolerance stub), so it can conflict with nothing.
+    check('a reuse with no stub to emit conflicts with nothing',
+          not conflict(0.0, 1.0, 2, [(0.0, 1.0, 1, 0.0, 0.0)], px=0.0, py=1.0,
+                       adds_via=False, **REUSE_KN))
+
+    # TERM 1 IN ISOLATION -- the candidate VIA against a stub this run already
+    # emitted. This is the third of the three edits the reuse fix made, and it
+    # was the one nothing tested: reverting ONLY the `adds_via and` guard on
+    # term 1 leaves the whole suite green and U2 at 28/12/30, because term 1
+    # never fires for a reuse candidate on this corpus. Untestable-by-corpus is
+    # not untestable, so the geometry is constructed instead.
+    #
+    # Candidate reuse via at (0,0) on net 2, bridged from its pad at (0,-0.5).
+    # Placed: a net-1 via far away at (0,3), fed by a stub from its pad at
+    # (0.3,0) -- so that STUB passes 0.2985mm from the candidate via.
+    #   term 1  cand via   <-> placed stub  0.2985  (floor 0.375)  FIRES
+    #   via-via cand via   <-> placed via   3.000   (floor 0.550)  clear
+    #   term 2  placed via <-> cand stub    3.000   (floor 0.375)  clear
+    #   term 3  cand stub  <-> placed stub  0.2985  (floor 0.200)  clear
+    # so term 1 is the ONLY thing that can decide either call.
+    t1 = [(0.0, 3.0, 1, 0.3, 0.0)]
+    check('term 1 fires for a NEW via whose position this run chose',
+          conflict(0.0, 0.0, 2, t1, px=0.0, py=-0.5, **REUSE_KN))
+    check('...and is suppressed for a REUSE, whose position it did not choose',
+          not conflict(0.0, 0.0, 2, t1, px=0.0, py=-0.5, adds_via=False,
+                       **REUSE_KN))
+    return bad
+
+
+def _q2_reuse_end_to_end():
+    """The measured board, not just the pure function.
+
+    The pure-function checks above would all pass with `adds_via` accepted and
+    ignored at the call site -- the same "tested the function, left the wiring
+    uncovered" hole D10 was pulled up for. So assert the counts off the board
+    the regression was measured on.
+    """
+    import io
+    import contextlib
+    from qfn_fanout import generate_qfn_fanout as fanout
+    bad = []
+
+    def check(name, cond, detail=""):
+        print(("PASS: " if cond else "FAIL: ") + name + (f"  [{detail}]"
+                                                         if detail else ""))
+        if not cond:
+            bad.append(name)
+
+    if not os.path.exists(U2_BOARD):
+        print("SKIP: corpus board not found (U2 reuse counts)")
+        return bad
+
+    pcb = parse_kicad_pcb(U2_BOARD)
+    with contextlib.redirect_stdout(io.StringIO()):
+        tracks, vias, dropped = fanout(
+            pcb.footprints["U2"], pcb, layer="B.Cu", track_width=0.1,
+            clearance=0.1, grid_step=0.05, escape_method="underpad",
+            via_size=0.45, via_drill=0.25, allow_via_in_pad=True)
+
+    got = (len(vias), len(dropped), len(tracks))
+    check('U2 underpad reuse: 28 vias / 12 dropped / 30 tracks',
+          got == (28, 12, 30), f"got {got[0]} / {got[1]} / {got[2]}")
+    # The specific net the regression cost, named -- a count can drift back
+    # into place for an unrelated reason, this cannot.
+    check('Net-(U2A-DATA_30) keeps its escape (it reuses an existing via)',
+          'Net-(U2A-DATA_30)' not in dropped,
+          f"{len(dropped)} dropped")
+    return bad
+
+
+def _wiring_spy(ref, net_filter, **kw):
+    """Run the underpad escape with `run_output_conflict` spied on.
+
+    Returns what the engine FED the checker, plus the engine's own per-side pad
+    grouping read back off its own output (not re-derived here -- the point is
+    to observe the run, not to model it).
+    """
+    import io
+    import re
+    import contextlib
+    import qfn_fanout as Q
+
+    seen = {'entries': [], 'with_pad': 0, 'calls': 0, 'max_placed': 0}
+    real = Q.run_output_conflict
+
+    def spy(vx, vy, net_id, placed, px=None, py=None, **kwargs):
+        seen['calls'] += 1
+        if px is not None:
+            seen['with_pad'] += 1
+        seen['entries'].extend(placed)
+        seen['max_placed'] = max(seen['max_placed'], len(placed))
+        return real(vx, vy, net_id, placed, px, py, **kwargs)
+
+    Q.run_output_conflict = spy
+    try:
+        pcb = parse_kicad_pcb(BOARD)
+        with contextlib.redirect_stdout(io.StringIO()) as buf:
+            Q.generate_qfn_fanout(
+                pcb.footprints[ref], pcb, net_filter=net_filter, layer="F.Cu",
+                track_width=0.1, clearance=CLEARANCE, grid_step=0.05,
+                escape_method="underpad", via_size=VIA_SIZE, via_drill=0.25,
+                **kw)
+    finally:
+        Q.run_output_conflict = real
+
+    seen['sides'] = {m.group(1): int(m.group(2)) for m in
+                     (re.match(r'\s+(\w+): (\d+) pads$', ln)
+                      for ln in buf.getvalue().splitlines()) if m}
+    return seen
+
+
+def _d10_wiring():
+    """The pure function is not the fix -- the WIRING is.
+
+    Testing only `run_output_conflict` leaves the three call-site edits that
+    actually connect it (passing the pad into `via_clears`, and recording the
+    pad origin in `placed` / `placed_global`) completely uncovered: they can
+    all be reverted with every test still green. So assert the wiring itself,
+    by watching what the engine feeds the checker on a real board.
+    """
+    bad = []
+
+    def check(name, cond, detail=""):
+        print(("PASS: " if cond else "FAIL: ") + name + (f"  [{detail}]"
+                                                         if detail else ""))
+        if not cond:
+            bad.append(name)
+
+    if not os.path.exists(BOARD):
+        print("SKIP: corpus board not found (wiring check)")
+        return bad
+
+    seen = _wiring_spy("U3", ["/USB_DP", "/USB_DN"])
+    check('the engine actually consults the in-run conflict test',
+          seen['calls'] > 0)
+    # If via_clears stopped forwarding the pad, this is 0 and the candidate's
+    # own stub goes untested.
+    check("every candidate is offered with its OWN pad (its stub)",
+          seen['calls'] > 0 and seen['with_pad'] == seen['calls'])
+    # If `placed` reverted to 3-tuples, the emitted stubs become invisible.
+    check('recorded placements carry the pad origin, not just the via centre',
+          seen['entries'] and all(len(e) == 5 for e in seen['entries']))
+
+    # THE CROSS-SIDE HALF, which the fixture above cannot reach. D10's commit
+    # message claims the fix covers stubs "within a side AND across sides via
+    # placed_global" -- but `net_filter=["/USB_DP","/USB_DN"]` yields ONE side
+    # (left: 2 pads), so placed_global is still empty when trial() runs and no
+    # placed_global entry ever reaches the checker. Measured per-mutation
+    # against the combined revert: dropping px/py from the via_clears call
+    # exits 1, a 3-tuple in `trial` exits 1, and a 3-tuple in `placed_global`
+    # exits 0 -- SURVIVES. An unfiltered U3 spans four sides and kills it.
+    wide = _wiring_spy("U3", None)
+    biggest = max(wide['sides'].values() or [0])
+    check('the cross-side fixture really does span more than one side',
+          len(wide['sides']) >= 2, f"sides {wide['sides']}")
+    # WHY THIS BOUND IS EXACT: inside one side's trial, `placed` starts at
+    # len(placed_global) and trial() itself has appended at most (that side's
+    # pads - 1) entries before any given call. So with NO cross-side carry,
+    # max_placed <= biggest - 1. Seeing max_placed >= biggest therefore proves
+    # placed_global was non-empty when a later side ran -- it is a direct
+    # assertion about placed_global, not a proxy for one.
+    check('placed_global carried committed placements INTO a later side',
+          wide['max_placed'] >= biggest,
+          f"max placed {wide['max_placed']}, biggest side {biggest}")
+    # ...and THAT is what kills mutation C: those carried entries are the only
+    # ones that come from placed_global rather than from trial's own append.
+    check('...and the cross-side entries carry the pad origin too',
+          wide['entries'] and all(len(e) == 5 for e in wide['entries']),
+          f"{sorted(set(len(e) for e in wide['entries']))}-tuples seen")
+    return bad
 
 
 if __name__ == "__main__":

--- a/tests/test_reachability.py
+++ b/tests/test_reachability.py
@@ -22,21 +22,26 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'py_router'))  # placement split
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'py_tools'))  # placement split
 
+# The GEOMETRY tests need scipy; the EXIT-CODE tests below do not, and must not
+# inherit its skip -- an exit code that means "the placement is impossible" is
+# not something to leave unguarded because an optional dependency is missing.
 try:
     from placement import reachability
     from placement.reachability import ScipyRequired
     reachability._require_scipy()
+    HAVE_SCIPY = True
 except Exception as exc:                          # noqa: BLE001
-    print(f"SKIP: {exc}")
-    sys.exit(0)
+    print(f"SKIP (geometry tests only): {exc}")
+    HAVE_SCIPY = False
 
 
 class _Pad:
-    def __init__(self, x, y, sx, sy, net_id, layers=('F.Cu',), drill=0.0):
+    def __init__(self, x, y, sx, sy, net_id, layers=('F.Cu',), drill=0.0,
+                 number='1'):
         self.global_x, self.global_y = x, y
         self.size_x, self.size_y = sx, sy
         self.net_id, self.layers, self.drill = net_id, list(layers), drill
-        self.pad_number, self.pad_type, self.rect_rotation = '1', 'smd', 0.0
+        self.pad_number, self.pad_type, self.rect_rotation = number, 'smd', 0.0
 
 
 class _Fp:
@@ -198,7 +203,118 @@ def test_a_seed_off_the_net_is_an_error_not_a_guess():
     raise AssertionError("expected a ValueError")
 
 
+# --- D7: exit 1 is the geometry verdict, and nothing else may borrow it -------
+#
+# `raise SystemExit(msg)` exits 1, and 1 is CAGED. Measured on the run board:
+#
+#     --pad NOSUCH.9  -> exit 1      a typo
+#     --pad RM1.1.1   -> exit 1      a REAL pad; RM1's pads are named "1.1"
+#     --pad U1.1      -> exit 2      the honest "nothing to reach in view"
+#
+# The loop's L3 stage takes one genuine CAGED on the copper-free board as enough
+# to re-enter placement, and re-entering placement discards every routed board.
+# So a misspelling bought the most expensive misclassification the loop has.
+import check_reachability as cr                                 # noqa: E402
+import subprocess                                               # noqa: E402
+
+BOARD = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                     'kicad_files', 'splitflap_driver.kicad_pcb')
+
+
+class _NumFp:
+    def __init__(self, pads):
+        self.pads = pads
+
+
+class _NumPcb:
+    """Just the `footprints` slice `_resolve_pad` reads."""
+    def __init__(self, by_ref):
+        self.footprints = {k: _NumFp(v) for k, v in by_ref.items()}
+
+
+def _pad(number, net_id=7):
+    return _Pad(1.0, 2.0, 0.5, 0.5, net_id, number=number)
+
+
+def test_a_dotted_pad_number_resolves_against_the_board():
+    """KiCad pad numbers are strings and may contain dots. RM1 on the measured
+    board has a pad literally named "1.1", so rsplit('.', 1) asked for footprint
+    "RM1.1" -- which does not exist -- and the tool answered CAGED about a pad
+    that is fine."""
+    pcb = _NumPcb({'RM1': [_pad('1.1'), _pad('1.2')], 'C1': [_pad('1')]})
+    x, y, net_id, _layer = cr._resolve_pad(pcb, 'RM1.1.1')
+    assert (x, y, net_id) == (1.0, 2.0, 7), 'RM1 pad "1.1" must resolve'
+    x, y, net_id, _layer = cr._resolve_pad(pcb, 'C1.1')
+    assert net_id == 7, 'the ordinary REF.NUM case must keep working'
+    print('  PASS: a dotted pad number resolves to the pad the board has')
+
+
+def test_an_unresolvable_pad_raises_rather_than_naming_a_verdict():
+    pcb = _NumPcb({'U1': [_pad('1')]})
+    for spec, want in (('NOSUCH.9', 'no footprint'),
+                       ('U1.99', 'no pad'),
+                       ('U1', 'REF.PADNUM')):
+        try:
+            cr._resolve_pad(pcb, spec)
+        except cr.Unresolvable as exc:
+            assert want in str(exc), f'{spec}: want {want!r} in {exc}'
+        else:
+            raise AssertionError(f'{spec} must not resolve')
+    # It must never GUESS when the board genuinely allows two readings.
+    ambiguous = _NumPcb({'A': [_pad('1.1')], 'A.1': [_pad('1')]})
+    try:
+        cr._resolve_pad(ambiguous, 'A.1.1')
+    except cr.Unresolvable as exc:
+        assert 'ambiguous' in str(exc), exc
+    else:
+        raise AssertionError('A.1.1 is genuinely ambiguous and must say so')
+    print('  PASS: unresolvable and ambiguous specs raise Unresolvable')
+
+
+def _cli(*args):
+    p = subprocess.run([sys.executable, '-X', 'utf8',
+                        os.path.join(os.path.dirname(os.path.dirname(
+                            os.path.abspath(__file__))), 'py_tools', 'check_reachability.py')]
+                       + list(args),
+                       stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                       encoding='utf-8', errors='replace')
+    return p.returncode, p.stdout + p.stderr
+
+
+def test_the_cli_never_exits_CAGED_for_something_it_could_not_resolve():
+    """The exit code is the whole interface here -- callers branch on it."""
+    if not os.path.isfile(BOARD):
+        print(f'  SKIP: no {BOARD}')
+        return
+    for args in (('--pad', 'NOSUCH.9'), ('--pad', 'U1.99999'),
+                 ('--at', 'not-a-number', '--net', 'GND'), (),
+                 # --view was missed the first time round, and it fails in TWO
+                 # ways: garbage floats raise ValueError here, while the wrong
+                 # COUNT of good floats survives to an IndexError deep inside
+                 # reachability.slack_field. Both were tracebacks, so both
+                 # exited 1 = CAGED.
+                 ('--pad', 'U1.1', '--view', 'not,a,number,here'),
+                 ('--pad', 'U1.1', '--view', '1,2,3'),
+                 ('--pad', 'U1.1', '--view', '5,5,1,1')):
+        rc, out = _cli(BOARD, *args)
+        assert rc == 2, (f'{args or "(no seed)"} must exit 2, got {rc}. '
+                         f'1 is CAGED and re-enters placement.\n{out}')
+        assert 'cannot resolve' in out, f'{args}: must say what it could not '\
+                                        f'resolve, got:\n{out}'
+    rc, out = _cli('no-such-board.kicad_pcb', '--pad', 'U1.1')
+    assert rc == 2, f'an unreadable board must exit 2, got {rc}\n{out}'
+    print('  PASS: every unresolvable argument exits 2, naming what it was')
+
+
 if __name__ == '__main__':
+    for fn in (test_a_dotted_pad_number_resolves_against_the_board,
+               test_an_unresolvable_pad_raises_rather_than_naming_a_verdict,
+               test_the_cli_never_exits_CAGED_for_something_it_could_not_resolve):
+        print(fn.__name__)
+        fn()
+    if not HAVE_SCIPY:
+        print('\nGEOMETRY TESTS SKIPPED (no scipy); exit-code tests passed')
+        sys.exit(0)
     for fn in (test_the_measured_throat_matches_the_closed_form,
                test_a_gap_too_narrow_is_CAGED_and_a_wide_one_is_PASSABLE,
                test_it_resolves_a_few_microns_either_side_of_the_track_width,

--- a/tests/test_region_join_nearest_pair.py
+++ b/tests/test_region_join_nearest_pair.py
@@ -1,20 +1,39 @@
 #!/usr/bin/env python3
-"""Vectorized region-join closest-approach is bit-identical to the brute force (#351).
+"""Region-join pair selection and seeding.
 
-`find_region_connection_points` measured closest approach between every region
-pair with a pure-Python O(N_i x N_j) double loop over (anchors + subsampled fill
-cells) -- the dominant cost of the region-join MST on big multi-region plane nets.
-It now uses one numpy argmin over the row-major dist^2 matrix per pair.
+1. Vectorized closest-approach is bit-identical to the brute force (#351).
+   `find_region_connection_points` measured closest approach between every region
+   pair with a pure-Python O(N_i x N_j) double loop over (anchors + subsampled fill
+   cells) -- the dominant cost of the region-join MST on big multi-region plane nets.
+   It now uses one numpy argmin over the row-major dist^2 matrix per pair.
+   The selection MUST be unchanged (the chosen points feed which copper the router
+   bridges): np.argmin returns the FIRST global minimum in (i-outer, j-inner) order,
+   exactly the brute force's strict-`<` first-minimum tie-break. Pinned against a
+   verbatim copy of the old loop over randomized inputs (including ties, empty
+   regions, and a daisho-class perf case).
 
-The selection MUST be unchanged (the chosen points feed which copper the router
-bridges): np.argmin returns the FIRST global minimum in (i-outer, j-inner) order,
-exactly the brute force's strict-`<` first-minimum tie-break. This test pins that
-equivalence against a verbatim copy of the old loop over randomized inputs
-(including ties, empty regions, and a daisho-class perf case).
+2. The open-space fallback seed must be ON the region (neo6502 GND).
+   `find_open_space_point` answers "where is the emptiest cell within 5mm of the
+   region's centroid" -- a question about the OBSTACLE MAP, not about the
+   region's copper -- and `_try_route_between_regions` fed that point to the A*
+   as an extra source/target seed. Being the cheapest cell around, the search
+   lands on it, so the strap's end is bare board: neo6502's GND repair produced
+   15 such straps (including a 0.1mm one between two regions' open points), all
+   correctly rejected by the #479 endpoint verification, which then burned each
+   pair's whole try allowance so the real join was never retried. The seed must
+   now satisfy the SAME material predicate the join is verified against.
+
+3. A zero-length route means the pair is the same copper, not a failed join.
+   Overlapping same-net zones on one layer are labelled per zone, so a patch pour
+   inside a board-wide pour becomes a second "region" over identical fill; the A*
+   answers with a one-point path. That is merged without copper, not reported as
+   an UNVERIFIED failure.
 
 Run:  python3 tests/test_region_join_nearest_pair.py [-v]
 """
 import argparse
+import contextlib
+import io
 import math
 import os
 import random
@@ -26,9 +45,10 @@ sys.path.insert(0, ROOT)
 sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # #522
 sys.path.insert(0, os.path.join(ROOT, 'py_tools'))  # #522
 
-from routing_config import GridCoord
+from routing_config import GridCoord, GridRouteConfig
 import plane_region_connector as prc
 from plane_region_connector import find_region_connection_points, UnionFind
+from grid_router import GridObstacleMap
 
 
 def _reference(region_anchors, region_cells, coord):
@@ -62,6 +82,292 @@ def _reference(region_anchors, region_cells, coord):
             if len(mst) == n - 1:
                 break
     return mst
+
+
+def _config():
+    return GridRouteConfig(track_width=0.2, clearance=0.2, via_size=0.7,
+                           via_drill=0.4, grid_step=0.1,
+                           layers=['F.Cu', 'B.Cu'])
+
+
+def check_open_space_seed_validity(verbose=False):
+    """`find_open_space_point` must never hand back a point its caller's
+    material predicate rejects, and must be unchanged when nothing is rejected."""
+    coord = GridCoord(0.1)
+    obs = GridObstacleMap(1)
+    anchors = [(8.0, 8.0)]
+    bounds = (0.0, 0.0, 20.0, 20.0)
+
+    # Nothing is blocked, so EVERY cell in the search square ties at the
+    # clearance cap. The ungated scan keeps the first tie in raw grid order --
+    # the far bottom-left corner of the +-5mm box, ~7mm off the region. This is
+    # the defect shape measured on neo6502 (open points 3-5mm off the region
+    # they seed), pinned here because it is what the predicate must stop.
+    unguarded = prc.find_open_space_point(anchors, obs, 0, coord, bounds=bounds)
+    assert unguarded is not None, "no open point found at all"
+    d_far = math.hypot(unguarded[0] - 8.0, unguarded[1] - 8.0)
+    assert d_far > 3.0, \
+        f"expected the unguarded scan to pick a far corner, got {unguarded}"
+
+    # The gated scan must rank the tied cells NEAREST THE REGION, not by grid
+    # order: the probe budget is finite, and grid order spends all of it on the
+    # far edge of the box (2.5% of a +-5mm box at this 0.1mm grid), which
+    # reports "no valid point" while thousands sit on the region. A predicate
+    # that accepts everything therefore lands on the centroid, NOT on the
+    # ungated far corner.
+    permissive = prc.find_open_space_point(anchors, obs, 0, coord, bounds=bounds,
+                                           validity=lambda x, y: True)
+    assert permissive is not None and \
+        math.hypot(permissive[0] - 8.0, permissive[1] - 8.0) <= 0.5, \
+        f"gated scan is not ranked by distance to the region: {permissive}"
+
+    # ...so a predicate that only credits the region's own 1mm neighbourhood
+    # still FINDS a point. (Returning None here would mean the guard silently
+    # disabled the fallback instead of correcting it.)
+    guarded = prc.find_open_space_point(
+        anchors, obs, 0, coord, bounds=bounds,
+        validity=lambda x, y: math.hypot(x - 8.0, y - 8.0) <= 1.0)
+    assert guarded is not None, \
+        "the probe budget threw away every valid candidate near the region"
+    assert math.hypot(guarded[0] - 8.0, guarded[1] - 8.0) <= 1.0, \
+        f"returned a point its own validity rejects: {guarded}"
+
+    # A predicate nothing in range satisfies yields None -- an absent seed
+    # beats a bogus one; it must never fall back to the far corner.
+    starved = prc.find_open_space_point(anchors, obs, 0, coord, bounds=bounds,
+                                        validity=lambda x, y: False)
+    assert starved is None, f"ignored its own validity and returned {starved}"
+    if verbose:
+        print(f"  unguarded={unguarded} permissive={permissive} guarded={guarded}")
+    print("PASS: find_open_space_point honors the material predicate")
+
+
+def check_open_space_seed_is_gated(verbose=False):
+    """`_try_route_between_regions` must gate its open-space seed on the
+    region's material, so an off-region point can no longer become a strap end."""
+    FAR = (50.0, 50.0)
+    seen_validity = []
+
+    def fake_open(anchors, base_obstacles, plane_layer_idx, coord,
+                  search_radius=5.0, bounds=None, validity=None):
+        seen_validity.append(validity)
+        if validity is not None and not validity(FAR[0], FAR[1]):
+            return None
+        return FAR
+
+    def fake_route(source_points, target_points, **kw):
+        # The corridor is walled: a path exists ONLY from the open-space point.
+        if FAR in source_points and FAR in target_points:
+            return ([(FAR[0], FAR[1], 'F.Cu'),
+                     (FAR[0] + 0.1, FAR[1], 'F.Cu')], []), 10
+        return None, kw.get('max_iterations', 1)
+
+    anchors_i = [(1.0, 1.0)]
+    anchors_j = [(30.0, 30.0)]
+    kw = dict(base_obstacles=GridObstacleMap(2), plane_layer_idx=0,
+              routing_layers=['F.Cu', 'B.Cu'], config=_config(),
+              net_vias=[], max_track_width=0.4, min_track_width=0.2,
+              max_iterations=1000, coord=GridCoord(0.1),
+              bounds=(0.0, 0.0, 60.0, 60.0))
+
+    real_open, real_route = prc.find_open_space_point, prc.route_plane_connection_wide
+    prc.find_open_space_point = fake_open
+    prc.route_plane_connection_wide = fake_route
+    try:
+        # Ungated (legacy behaviour): the bogus open-space strap IS produced --
+        # both its ends sit 40mm+ from either region.
+        legacy, _w, _v, _ex = prc._try_route_between_regions(
+            anchors_i, anchors_j, **kw)
+        assert legacy is not None, "fixture no longer reproduces the defect"
+        assert legacy[0][0][:2] == FAR, \
+            f"expected the strap to start on the open point, got {legacy[0][0]}"
+
+        # Gated on material: neither region credits the open point, so no seed
+        # is offered and no strap is invented.
+        seen_validity.clear()
+        off_region = lambda x, y: False           # noqa: E731
+        gated, _w, _v, _ex = prc._try_route_between_regions(
+            anchors_i, anchors_j, open_ok_i=off_region, open_ok_j=off_region,
+            **kw)
+        assert gated is None, \
+            f"an off-material open seed still produced a strap: {gated}"
+        assert seen_validity and all(v is not None for v in seen_validity), \
+            "the material predicate never reached find_open_space_point"
+
+        # A region that DOES credit the point keeps its rescue.
+        on_region = lambda x, y: True             # noqa: E731
+        kept, _w, _v, _ex = prc._try_route_between_regions(
+            anchors_i, anchors_j, open_ok_i=on_region, open_ok_j=on_region,
+            **kw)
+        assert kept is not None, "a legitimate open-space rescue was lost"
+    finally:
+        prc.find_open_space_point = real_open
+        prc.route_plane_connection_wide = real_route
+    print("PASS: the open-space fallback seed is gated on region material")
+
+
+def _stub_board():
+    """Smallest PCBData the region-join loop will accept: two GND pads, no
+    copper, no zones (so the fill models are inert and the regions come from
+    the stubbed detector below)."""
+    from kicad_parser import PCBData, BoardInfo, Net, Pad
+    bi = BoardInfo(layers={0: 'F.Cu', 31: 'B.Cu'},
+                   copper_layers=['F.Cu', 'B.Cu'],
+                   board_bounds=(0.0, 0.0, 20.0, 20.0))
+    pads = []
+    for i, (x, y) in enumerate(((1.0, 1.0), (15.0, 15.0))):
+        p = Pad(pad_number=str(i + 1), net_id=1, net_name='GND',
+                global_x=x, global_y=y, local_x=0.0, local_y=0.0,
+                size_x=1.0, size_y=1.0, shape='circle',
+                layers=['F.Cu'], drill=0.0, component_ref=f'R{i}')
+        pads.append(p)
+    return PCBData(board_info=bi,
+                   nets={1: Net(net_id=1, name='GND', pads=pads)},
+                   footprints={}, vias=[], segments=[],
+                   pads_by_net={1: pads}, zones=[])
+
+
+def _run_join_loop(meet_pt, cells_a, cells_b):
+    """Drive route_disconnected_regions over two stubbed regions whose join
+    attempt returns a ONE-POINT route landing at `meet_pt`. Returns
+    (stdout, segments, vias, routes_added)."""
+    def fake_regions(*a, **kw):
+        # region 1 carries no anchors -> the #513 "already bridged" shortcut is
+        # skipped and the join loop actually runs.
+        return ([[(0.5, 0.5)], []], [cells_a, cells_b], [], [set(), set()])
+
+    def fake_try(anchors_i, anchors_j, **kw):
+        return (([meet_pt], []), 0.2, None, False)
+
+    real_regions, real_try = (prc.find_disconnected_zone_regions,
+                              prc._try_route_between_regions)
+    prc.find_disconnected_zone_regions = fake_regions
+    prc._try_route_between_regions = fake_try
+    buf = io.StringIO()
+    try:
+        with contextlib.redirect_stdout(buf):
+            segs, vias, added, _paths, _cp = prc.route_disconnected_regions(
+                net_id=1, net_name='GND', plane_layer='F.Cu',
+                zone_bounds=(0.0, 0.0, 20.0, 20.0), pcb_data=_stub_board(),
+                config=_config(), base_obstacles=GridObstacleMap(2),
+                layer_map={'F.Cu': 0, 'B.Cu': 1}, analysis_grid_step=0.5)
+    finally:
+        prc.find_disconnected_zone_regions = real_regions
+        prc._try_route_between_regions = real_try
+    return buf.getvalue(), segs, vias, added
+
+
+def check_coincident_pair_merges_without_copper(verbose=False):
+    """A one-point route means a source cell IS a target cell. When that cell
+    is STRICT material for both components they are the same copper: merge
+    them silently instead of reporting `UNVERIFIED ends=None/None` (which
+    burned the pair's try allowance forever). When it is not, the merge is a
+    false "plane joined" and must still be refused."""
+    # Analysis grid is 0.5mm, so cell (gx,gy) covers mm (gx*0.5, gy*0.5).
+    # The two regions' cell sets ABUT at gx=10 (mm 5.0): a shared cell there is
+    # real evidence of shared copper.
+    cells_a = {(gx, gy) for gx in range(6, 11) for gy in range(6, 11)}
+    cells_b = {(gx, gy) for gx in range(10, 15) for gy in range(6, 11)}
+    out, segs, vias, added = _run_join_loop((5.0, 4.0, 'F.Cu'), cells_a, cells_b)
+    if verbose:
+        print('  ' + out.replace('\n', '\n  ').strip())
+    assert 'UNVERIFIED' not in out, \
+        "a zero-length route on shared copper is still a failed join:\n" + out
+    assert 'COINCIDENT' in out, \
+        "the coincident pair was not recognised:\n" + out
+    assert not segs and not vias, \
+        f"a zero-length strap emitted copper: {len(segs)} seg(s), {len(vias)} via(s)"
+    assert added == 0, f"a zero-length strap was counted as a join ({added})"
+
+    # NEGATIVE: two regions 5mm apart whose seed lists merely quantized onto
+    # one routing cell. A zero-length "join" there fuses genuinely disconnected
+    # copper while emitting nothing -- the silent false merge #479 exists to
+    # stop -- so it must be refused, not merged.
+    far_a = {(gx, gy) for gx in range(0, 3) for gy in range(0, 3)}
+    far_b = {(gx, gy) for gx in range(20, 23) for gy in range(20, 23)}
+    out2, segs2, vias2, added2 = _run_join_loop((30.0, 30.0, 'F.Cu'),
+                                                far_a, far_b)
+    assert 'COINCIDENT' not in out2, \
+        "fused two disconnected components on a shared seed cell:\n" + out2
+    assert 'UNVERIFIED' in out2, \
+        "an off-material zero-length route was not refused:\n" + out2
+    assert not segs2 and not vias2 and added2 == 0, \
+        "the refused pair still shipped copper"
+    print("PASS: a coincident region pair merges without copper; a false one is refused")
+
+
+def check_open_space_gate_reaches_every_rung(verbose=False):
+    """Every `_try_route_between_regions` call in the join loop must carry the
+    material predicates. The escalation rungs (retry-full, budget-x5,
+    narrow-width) are separate call sites, and dropping the kwargs from one of
+    them re-opens the bug on exactly the hard pairs that reach it."""
+    import ast
+    import inspect
+    import textwrap
+    src = textwrap.dedent(inspect.getsource(prc.route_disconnected_regions))
+    tree = ast.parse(src)
+    sites = [n for n in ast.walk(tree)
+             if isinstance(n, ast.Call)
+             and getattr(n.func, 'id', None) == '_try_route_between_regions']
+    assert len(sites) >= 3, \
+        f"expected the seed + budget-x5 + narrow-width rungs, found {len(sites)}"
+    for n in sites:
+        kws = {k.arg for k in n.keywords}
+        assert {'open_ok_i', 'open_ok_j'} <= kws, \
+            (f"_try_route_between_regions call at line {n.lineno} of "
+             f"route_disconnected_regions does not gate its open-space seed "
+             f"(kwargs: {sorted(kws)})")
+    if verbose:
+        print(f"  {len(sites)} gated call site(s)")
+    print("PASS: every join rung gates its open-space seed")
+
+
+def check_colocated_islands_are_one_region(verbose=False):
+    """Two same-net zones on ONE layer whose fills overlap are ONE conductor:
+    KiCad merges same-net fills, but a ZoneFillModel is built per ZONE and
+    labels its fill in isolation, so a patch pour inside a board-wide pour used
+    to become a second region over identical copper -- a phantom split the join
+    loop then tried (and failed) to bridge."""
+    from kicad_parser import PCBData, BoardInfo, Net, Zone
+    from plane_fill_model import get_fill_models
+
+    def rect(x0, y0, x1, y1):
+        return [(x0, y0), (x1, y0), (x1, y1), (x0, y1)]
+
+    def board(zones):
+        bi = BoardInfo(layers={0: 'F.Cu'}, copper_layers=['F.Cu'],
+                       board_bounds=(0.0, 0.0, 20.0, 20.0))
+        return PCBData(board_info=bi, nets={1: Net(1, 'GND')}, footprints={},
+                       vias=[], segments=[], pads_by_net={}, zones=zones)
+
+    def regions(pcb, anchors):
+        models = get_fill_models(pcb, 1)
+        return prc._regions_from_fill_models(
+            1, pcb, GridCoord(0.5), 'F.Cu', {'F.Cu'}, models, anchors,
+            (0.0, 0.0, 20.0, 20.0), 0.5)
+
+    # The SMALL zone is listed first, so `_comp_key_at` (first model with fill
+    # wins) credits an anchor inside it to the patch island and an anchor
+    # outside it to the board-wide island: two keys, one piece of copper.
+    over = board([Zone(net_id=1, net_name='GND', layer='F.Cu',
+                       polygon=rect(5.0, 5.0, 9.0, 9.0), priority=1),
+                  Zone(net_id=1, net_name='GND', layer='F.Cu',
+                       polygon=rect(0.5, 0.5, 19.5, 19.5))])
+    ra, _rc, _ri = regions(over, [(7.0, 7.0), (15.0, 15.0)])
+    assert len(ra) == 1, \
+        f"overlapping same-net pours still split into {len(ra)} regions"
+
+    # NEGATIVE: two same-net pours that never share a point stay two regions.
+    apart = board([Zone(net_id=1, net_name='GND', layer='F.Cu',
+                        polygon=rect(0.5, 0.5, 6.0, 6.0)),
+                   Zone(net_id=1, net_name='GND', layer='F.Cu',
+                        polygon=rect(13.0, 13.0, 19.5, 19.5))])
+    ra2, _rc2, _ri2 = regions(apart, [(3.0, 3.0), (16.0, 16.0)])
+    assert len(ra2) == 2, \
+        f"disjoint same-net pours were fused into {len(ra2)} region(s)"
+    if verbose:
+        print(f"  overlapping -> {len(ra)} region(s); disjoint -> {len(ra2)}")
+    print("PASS: co-located fill islands are one region, disjoint ones are not")
 
 
 def run(verbose=False):
@@ -128,3 +434,8 @@ if __name__ == "__main__":
     ap.add_argument("-v", "--verbose", action="store_true")
     args = ap.parse_args()
     run(args.verbose)
+    check_open_space_seed_validity(args.verbose)
+    check_open_space_seed_is_gated(args.verbose)
+    check_open_space_gate_reaches_every_rung(args.verbose)
+    check_coincident_pair_merges_without_copper(args.verbose)
+    check_colocated_islands_are_one_region(args.verbose)

--- a/tests/test_run14_dash_net_hint.py
+++ b/tests/test_run14_dash_net_hint.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""A net whose NAME starts with '-' must not cost a lap (run 14).
+
+castor_pollux has a net called `-12V`. `route.py --nets ... -12V ...` is
+`nargs='+'`, so argparse read the name as a flag:
+
+    route.py: error: unrecognized arguments: -12V
+
+exit 2, no board, no JSON_SUMMARY. Both arms of run 14's plane-mapping A/B died
+that way and the lap had to be re-run. The fix is one character at the call site
+(`--nets=-12V`) but nothing said so, and thirty-odd sibling list flags across six
+tools share the shape.
+
+`cli_banner.install()` -- which every instrument already calls -- now patches
+`ArgumentParser.error` once so the hint appears wherever it happens. These tests
+pin that the hint fires, that it does not fire on unrelated errors, that it never
+masks the real error, and that the workaround it recommends actually works.
+"""
+import argparse
+import io
+import contextlib
+import os
+import subprocess
+import sys
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_placer'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_tools'))  # #522/py_placer layout
+
+import cli_banner  # noqa: E402
+
+BOARD = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
+
+
+class DashHintUnitTest(unittest.TestCase):
+
+    def setUp(self):
+        cli_banner.install_dash_hint()
+        self.p = argparse.ArgumentParser(prog='t', add_help=False)
+        self.p.add_argument('--nets', nargs='+')
+
+    def _err(self, argv):
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            with self.assertRaises(SystemExit):
+                self.p.parse_args(argv)
+        return buf.getvalue()
+
+    def test_hint_fires_on_a_leading_dash_value(self):
+        out = self._err(['--nets', '+12V', '-12V'])
+        self.assertIn("'-12V'", out)
+        self.assertIn('--nets=-12V', out)
+
+    def test_the_real_argparse_error_still_prints(self):
+        out = self._err(['--nets', '+12V', '-12V'])
+        self.assertIn('unrecognized arguments', out,
+                      'the hint must add to the error, never replace it')
+
+    def test_no_hint_on_an_unrelated_error(self):
+        p = argparse.ArgumentParser(prog='t', add_help=False)
+        p.add_argument('--size', type=int)
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            with self.assertRaises(SystemExit):
+                p.parse_args(['--size', 'banana'])
+        self.assertNotIn('begins with', buf.getvalue())
+
+    def test_patch_is_idempotent(self):
+        before = argparse.ArgumentParser.error
+        cli_banner.install_dash_hint()
+        cli_banner.install_dash_hint()
+        self.assertIs(argparse.ArgumentParser.error, before,
+                      'install must not stack wrappers')
+
+
+class DashHintCliTest(unittest.TestCase):
+    """Through a real instrument, as the run actually hit it."""
+
+    def _run(self, args):
+        return subprocess.run([sys.executable, '-X', 'utf8',
+                               os.path.join(ROOT, 'py_router', 'route.py')] + args,
+                              capture_output=True, text=True, timeout=600)
+
+    def test_route_py_emits_the_hint_and_still_exits_2(self):
+        r = self._run([BOARD, os.path.join(ROOT, '_no_such_out.kicad_pcb'),
+                       '--nets', '+12V', '-12V'])
+        self.assertEqual(r.returncode, 2)
+        both = r.stdout + r.stderr
+        self.assertIn('--nets=-12V', both)
+        self.assertIn('unrecognized arguments', both)
+
+    def test_the_recommended_form_parses(self):
+        """The hint must recommend something that actually works.
+
+        Asserted on the MESSAGE, not the exit code: this fixture board has no
+        `-12V`, so route.py rightly refuses with its own exit 2 ("none of the
+        requested nets exist"). That refusal is proof the value got through
+        argparse -- which is the whole claim. Checking the code alone would
+        confuse two different exit 2s.
+        """
+        r = self._run([BOARD, os.path.join(ROOT, '_no_such_out.kicad_pcb'),
+                       '--nets=-12V', '--skip-routing'])
+        both = r.stdout + r.stderr
+        self.assertNotIn('unrecognized arguments', both,
+                         'the documented workaround must not be an argparse '
+                         'error: ' + both[-300:])
+        self.assertIn('-12V', both,
+                      'the net name must reach the tool as a VALUE')
+        self.assertNotIn('begins with', both,
+                         'and the hint must not fire when nothing is wrong')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/test_run14_stage_blind_dose.py
+++ b/tests/test_run14_stage_blind_dose.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""stage_blind must not publish a draw whose damage never landed (run 14).
+
+Run 14 staged castor_pollux with a requested dose of >= 4.248 mm and an APPLIED
+dose of 0.100 mm -- `perturb()`'s own `grid_step` -- because the drawn block sat
+hard against the outline and `on_overflow='clip'` ate 98% of the dose.
+`stage_blind` printed `damage applied` and exited 0 without reading
+`rec['clipped']`, `rec['status']` or `rec['dose_mm_applied']`, so the run spent
+an hour proving that an undamaged board was undamaged, and its recovery half was
+void before it began.
+
+These tests pin the three behaviours that close it:
+
+  1. a draw that lands is accepted unchanged, and says nothing extra;
+  2. a draw that does NOT land is redrawn, and the disclosure stays fence-safe
+     (a redraw happened -- not how many, not the kind, not the dose);
+  3. a board that will not take a material dose at all is REFUSED, rather than
+     emitting a subject whose damage is at the grid step.
+
+`perturb` is stubbed: the point under test is stage_blind's acceptance rule, and
+driving the real mutation would make the test a perturbation test instead.
+"""
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_placer'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_tools'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'tests', 'stress'))
+
+BOARD = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
+
+
+def _fake_record(out_board, control_out, applied, *, status='ok',
+                 clipped=False):
+    """The subset of `perturb()`'s record that stage_blind reads."""
+    shutil.copyfile(BOARD, out_board)
+    if control_out:
+        shutil.copyfile(BOARD, control_out)
+    return {'status': status, 'clipped': clipped,
+            'dose_mm_applied': applied, 'max_feasible_dose_mm': applied,
+            'block': {'name': 'stub', 'members': []},
+            'original_poses': {}}
+
+
+class StageBlindDoseTest(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix='sb14_')
+        self.work = os.path.join(self.tmp, 'work')
+        self.truth = os.path.join(self.tmp, 'truth')
+        import stage_blind
+        self.sb = stage_blind
+        self._real = stage_blind.P.perturb
+        self.calls = []
+
+    def tearDown(self):
+        self.sb.P.perturb = self._real
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _install(self, applied_seq):
+        """Stub perturb to return each applied dose in turn, then the last."""
+        seq = list(applied_seq)
+
+        def fake(src, out_board, **kw):
+            a = seq[len(self.calls)] if len(self.calls) < len(seq) else seq[-1]
+            self.calls.append({'dose_mm': kw.get('dose_mm'), 'applied': a})
+            return _fake_record(out_board, kw.get('control_out'), a,
+                                clipped=a < kw.get('dose_mm', 0))
+        self.sb.P.perturb = fake
+
+    def _draw(self):
+        with open(os.path.join(self.truth, 'draw.json'), encoding='utf-8') as f:
+            return json.load(f)
+
+    # ------------------------------------------------------------------
+    def test_landing_draw_is_accepted_first_time(self):
+        self._install([40.0])
+        self.sb.main(BOARD, self.work, self.truth)
+        self.assertEqual(len(self.calls), 1, 'a landing draw must not redraw')
+        d = self._draw()
+        self.assertEqual(len(d['draws']), 1)
+        self.assertTrue(d['draws'][0]['accepted'])
+        self.assertEqual(d['dose_mm_applied'], 40.0)
+
+    def test_grid_step_draw_is_redrawn(self):
+        """The run-14 case: applied 0.1 mm against a multi-mm request."""
+        self._install([0.1, 0.1, 40.0])
+        self.sb.main(BOARD, self.work, self.truth)
+        self.assertEqual(len(self.calls), 3, 'must keep drawing until it lands')
+        d = self._draw()
+        self.assertEqual([a['accepted'] for a in d['draws']],
+                         [False, False, True])
+        # the accepted draw is the one written to the top-level keys
+        self.assertEqual(d['dose_mm_applied'], 40.0)
+
+    def test_redraw_disclosure_is_fence_safe(self):
+        """One line, no count, no kind, no dose, no block."""
+        self._install([0.1, 0.1, 0.1, 40.0])
+        import contextlib
+        import io
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            self.sb.main(BOARD, self.work, self.truth)
+        out = buf.getvalue()
+        line = [l for l in out.splitlines() if 'redrew' in l]
+        self.assertEqual(len(line), 1, 'exactly one redraw line')
+        line = line[0]
+        self.assertIn('dose infeasible', line)
+        d = self._draw()
+        # nothing that identifies the draw may reach the disclosure
+        self.assertNotIn(str(d['kind']), line)
+        self.assertNotIn('%.1f' % d['dose_mm'], line)
+        self.assertNotIn(str(d['seed']), line)
+        # ...and no digit at all, so it cannot carry the rejected-draw count
+        self.assertFalse(any(c.isdigit() for c in line),
+                         'the redraw line must carry no number: %r' % line)
+        # the board-shape line is a deliberate, pre-existing disclosure and is
+        # NOT what this test guards -- assert the two are separate lines.
+        self.assertNotIn('parts', line)
+
+    def test_board_that_never_lands_is_refused(self):
+        self._install([0.1])
+        with self.assertRaises(SystemExit) as cm:
+            self.sb.main(BOARD, self.work, self.truth)
+        msg = str(cm.exception)
+        self.assertIn('no draw landed', msg)
+        self.assertEqual(len(self.calls), self.sb.MAX_DRAWS,
+                         'must exhaust the redraw budget before refusing')
+
+    def test_material_bar_is_relative_as_well_as_absolute(self):
+        """1.2 mm clears the 1.0 mm absolute floor but not the relative one.
+
+        The requested dose is BOARD-SCALED, so it cannot be assumed: this
+        fixture's short span is 30.5 mm, which puts the request at 3.0-6.7 mm,
+        and at the bottom of that range 1.2 mm legitimately clears
+        `0.35 * dose` too. (Caught by running this suite eight times, not once
+        -- it failed 2/8 before the scale was pinned.) Pin the scale so the
+        relative bar is the only thing under test.
+        """
+        real_scale = self.sb.board_scale_mm
+        self.addCleanup(setattr, self.sb, 'board_scale_mm', real_scale)
+        self.sb.board_scale_mm = lambda pcb: 200.0      # -> dose 12-44 mm
+        self._install([1.2, 40.0])
+        self.sb.main(BOARD, self.work, self.truth)
+        d = self._draw()
+        self.assertGreater(self.sb.MATERIAL_FRAC * d['draws'][0]['dose_mm_requested'],
+                           1.2, 'the relative bar must be the binding one here')
+        self.assertGreater(1.2, self.sb.MIN_MATERIAL_MM,
+                           'and the absolute floor must NOT be')
+        self.assertEqual(len(self.calls), 2,
+                         'a dose far below what was asked for is not a subject')
+
+    def test_cli_still_runs_end_to_end(self):
+        """The real perturb, unstubbed, through the command line."""
+        self.sb.P.perturb = self._real
+        w = os.path.join(self.tmp, 'w2')
+        t = os.path.join(self.tmp, 't2')
+        r = subprocess.run(
+            [sys.executable, '-X', 'utf8',
+             os.path.join(ROOT, 'tests', 'stress', 'stage_blind.py'),
+             BOARD, w, t],
+            capture_output=True, text=True, timeout=900)
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn('damage applied', r.stdout)
+        self.assertTrue(os.path.isfile(os.path.join(w, 'board.kicad_pcb')))
+        d = json.load(open(os.path.join(t, 'draw.json'), encoding='utf-8'))
+        applied = d['dose_mm_applied']
+        need = max(self.sb.MIN_MATERIAL_MM,
+                   self.sb.MATERIAL_FRAC * d['dose_mm'])
+        self.assertGreaterEqual(
+            applied, need,
+            'the shipped subject must carry a dose that actually landed')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/test_run15_fence_and_channels.py
+++ b/tests/test_run15_fence_and_channels.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Three channels that carried information nobody meant to send.
+
+1. `fence_audit` compared POSES and never opened copper. A subject staged from
+   a routed corpus board keeps the human routing while the parts move out from
+   under it, so the track ends go on marking where each part BELONGS. Run 14
+   shipped exactly that and the audit said CLEAN; the leak was closed later, by
+   a copper strip done for an unrelated reason.
+
+2. `placement.writer.write_placed_output` rewrites `(at)` with six decimals for
+   exactly the footprints it is handed. That made the perturbed block readable
+   off the output text with no tooling and no truth -- 24 six-decimal forms of
+   235 on run 14's subject, against 0 on untouched corpus boards -- while
+   `perturb`'s own docstring said the block was disclosed nowhere.
+
+3. `route_planes`' summary de-duplicated `plane_nets` to a name list, so a pour
+   onto two layers recorded one zone and the second vanished from the machine
+   channel entirely.
+"""
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_placer'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_tools'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'tests', 'stress'))
+
+BOARD = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
+#: The copper fence needs a subject that CARRIES copper, which is the whole
+#: scenario: a board staged from a routed corpus board and never stripped.
+#: splitflap_driver is the stripped form and has none, so it cannot express the
+#: leak at all -- using it here would have made the test pass by having nothing
+#: to find.
+ROUTED_BOARD = os.path.join(ROOT, 'kicad_files',
+                            'rp2350_fpga_eensy_prePlane.kicad_pcb')
+
+
+def six_decimal_ats(path):
+    """How many `(at x y)` forms carry the writer's six-decimal signature."""
+    with open(path, encoding='utf-8') as f:
+        text = f.read()
+    return sum(1 for x, _y in re.findall(r'\(at (-?\d+\.?\d*) (-?\d+\.?\d*)', text)
+               if '.' in x and len(x.split('.')[-1]) == 6)
+
+
+class CopperFenceTest(unittest.TestCase):
+    """fence_audit must see a placement carried in copper."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix='fence15_')
+        self.wd = os.path.join(self.tmp, 'work')
+        os.makedirs(self.wd)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _audit(self, mode='create', as_json=False):
+        cmd = [sys.executable, '-X', 'utf8',
+               os.path.join(ROOT, 'tests', 'stress', 'fence_audit.py'),
+               '--control', self.control, '--workdir', self.wd, '--mode', mode]
+        if as_json:
+            cmd.append('--json')
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=900)
+        return r.returncode, r.stdout + r.stderr
+
+    def _stage(self, kind='translate', dose=6.0):
+        """A real perturbation, with the source's copper left in place."""
+        import placement.perturb as P
+        self.control = os.path.join(self.tmp, 'control.kicad_pcb')
+        out = os.path.join(self.wd, 'board.kicad_pcb')
+        P.perturb(ROUTED_BOARD, out, kind=kind, dose_mm=dose, seed=99,
+                  write_record=False, control_out=self.control)
+        return out
+
+    def test_a_stripped_board_is_clean(self):
+        out = self._stage()
+        # The subject as the rig SHOULD hand it over: no copper.
+        subprocess.run([sys.executable, '-X', 'utf8',
+                        os.path.join(ROOT, 'tests', 'stress',
+                                     'strip_copper_only.py'), out, out + '.s'],
+                       capture_output=True, text=True, timeout=900)
+        shutil.move(out + '.s', out)
+        code, txt = self._audit()
+        self.assertIn('CLEAN', txt, txt[-500:])
+
+    def test_copper_that_marks_displaced_pads_is_a_leak(self):
+        """The run-14 case: the perturbed board still carrying its routing."""
+        self._stage()
+        code, txt = self._audit()
+        self.assertIn('LEAK', txt, txt[-600:])
+        self.assertIn('COPPER', txt,
+                      'and it must say WHICH channel carried it, because the '
+                      'fix differs: poses mean a control got copied in, copper '
+                      'means the subject was never stripped')
+
+    def test_create_mode_withholds_the_counts(self):
+        """The counts ARE the block size, and the fence is still up."""
+        self._stage()
+        _c, txt = self._audit()
+        self.assertIn('COPPER', txt)
+        self.assertNotIn('displaced pads still have copper', txt,
+                         'create mode must name the channel without the number')
+        _c, js = self._audit(as_json=True)
+        payload = json.loads(js[js.index('{'):])
+        for row in payload.get('leaks', []):
+            for k in ('copper_displaced_pads', 'copper_hits_on_control',
+                      'copper_frac'):
+                self.assertNotIn(k, row, k + ' discloses the block size')
+
+    def test_audit_mode_does_show_them(self):
+        self._stage()
+        self._audit(mode='create')          # lay down the manifest
+        _c, txt = self._audit(mode='audit')
+        self.assertIn('displaced pads still have copper', txt,
+                      'once the fence is down the number is what you need')
+
+
+class AtFormattingLeakTest(unittest.TestCase):
+    """The moved set must not be readable off the output text."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix='atleak15_')
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _perturb(self):
+        import placement.perturb as P
+        out = os.path.join(self.tmp, 'out.kicad_pcb')
+        ctl = os.path.join(self.tmp, 'ctl.kicad_pcb')
+        rec = P.perturb(BOARD, out, kind='translate', dose_mm=4.0, seed=1234,
+                        write_record=False, control_out=ctl)
+        return out, ctl, rec
+
+    def test_the_signature_does_not_count_the_block(self):
+        out, ctl, rec = self._perturb()
+        from kicad_parser import parse_kicad_pcb
+        total = len(parse_kicad_pcb(out).footprints)
+        moved = len(rec['block']['members'])
+        self.assertGreater(total, moved, 'fixture must not move every part')
+        self.assertEqual(six_decimal_ats(out), total,
+                         'every footprint goes through the same formatter, so '
+                         'the count is the board, not the draw')
+        self.assertNotEqual(six_decimal_ats(out), moved,
+                            'this is the number that used to be readable')
+
+    def test_the_control_is_formatted_the_same_way(self):
+        out, ctl, _rec = self._perturb()
+        self.assertEqual(six_decimal_ats(out), six_decimal_ats(ctl),
+                         'a control formatted differently from its subject is '
+                         'itself a comparison anyone could make')
+
+    def test_unmoved_parts_keep_their_pose_and_rotation_exactly(self):
+        _out, ctl, _rec = self._perturb()
+        from kicad_parser import parse_kicad_pcb
+        a, c = parse_kicad_pcb(BOARD), parse_kicad_pcb(ctl)
+        for ref, fa in a.footprints.items():
+            fc = c.footprints.get(ref)
+            self.assertIsNotNone(fc, ref)
+            self.assertAlmostEqual(fa.x, fc.x, places=6, msg=ref)
+            self.assertAlmostEqual(fa.y, fc.y, places=6, msg=ref)
+            # make_state normalises -90 to 270; writing that back would be a
+            # 360 delta to anything comparing the numbers unnormalised.
+            self.assertAlmostEqual(fa.rotation, fc.rotation, places=6, msg=ref)
+
+
+class PlaneZoneChannelTest(unittest.TestCase):
+    """A pour onto two layers must appear as two zones."""
+
+    def test_summary_names_every_zone_not_the_deduplicated_net(self):
+        tmp = tempfile.mkdtemp(prefix='pz15_')
+        try:
+            out = os.path.join(tmp, 'p.kicad_pcb')
+            r = subprocess.run(
+                [sys.executable, '-X', 'utf8',
+                 os.path.join(ROOT, 'py_router', 'route_planes.py'), BOARD, out,
+                 '--nets', 'GND', 'GND',
+                 '--plane-layers', 'F.Cu', 'B.Cu', '--deadline', '240'],
+                capture_output=True, text=True, timeout=900)
+            line = [l for l in (r.stdout + r.stderr).splitlines()
+                    if l.startswith('JSON_SUMMARY:')]
+            self.assertTrue(line, (r.stdout + r.stderr)[-800:])
+            d = json.loads(line[-1].split('JSON_SUMMARY: ', 1)[1])
+            self.assertEqual(d.get('plane_nets'), ['GND'],
+                             'the de-duplicated key stays as it was')
+            zones = d.get('plane_zones')
+            self.assertEqual(len(zones or []), 2,
+                             'both poured zones must be in the record')
+            self.assertEqual([z['layer'] for z in zones], ['F.Cu', 'B.Cu'])
+            self.assertIn('pads_scope', d,
+                          'and the aggregated pad tally must say it is one '
+                          'tally over every zone')
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/test_run8_fence_audit.py
+++ b/tests/test_run8_fence_audit.py
@@ -40,6 +40,40 @@ BOARD = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
 CLEAN, LEAK = 0, 4
 
 
+def _sha(path):
+    import hashlib
+    return hashlib.sha256(open(path, 'rb').read()).hexdigest()
+
+
+def _reserialise(src, dst):
+    """Same poses, different bytes -- the shape a real recovery has.
+
+    A `shutil.copy` fixture cannot distinguish a reconstruction from a copy,
+    which is precisely the hole the audit used to have. Writing the board back
+    out through the writer reproduces every footprint pose and changes the
+    file, so the fixture tests the property the audit now tests.
+
+    THE WRITER IS NOW IDEMPOTENT ON ITS OWN OUTPUT. `perturb` hands it every
+    footprint rather than only the moved ones -- the `(at)` formatting used to
+    fingerprint the perturbed block -- so a control it produced is already in
+    writer form and re-serialising it changes nothing. The byte difference a
+    real recovery has (fresh uuids, different copper) is not reproduced by a
+    pose rewrite any more, so the fixture states it explicitly: a trailing
+    newline is legal s-expression whitespace, invisible to the parser, and
+    keeps this test about the AUDIT's sha-vs-pose logic rather than about how
+    the writer happens to format.
+    """
+    from kicad_parser import parse_kicad_pcb
+    from placement.writer import write_placed_output
+    pcb = parse_kicad_pcb(src)
+    write_placed_output(src, dst, [
+        {'reference': ref, 'new_x': fp.x, 'new_y': fp.y,
+         'new_rotation': fp.rotation}
+        for ref, fp in sorted(pcb.footprints.items())])
+    with open(dst, 'a', encoding='utf-8') as fh:
+        fh.write('\n')
+
+
 def run_audit(control, workdir, mode):
     proc = subprocess.run(
         [sys.executable, '-X', 'utf8', AUDIT, '--control', control,
@@ -48,14 +82,33 @@ def run_audit(control, workdir, mode):
     return proc.returncode, (proc.stdout or '') + (proc.stderr or '')
 
 
-def make_case(tmp):
-    """control + a perturbed board whose poses differ from it."""
+def make_case(tmp, truth_dir=None):
+    """control + a perturbed board whose poses differ from it.
+
+    `control_out` is passed on purpose. Without it `perturb` writes the
+    perturbation RECORD beside the output board (perturb.py:596-602) -- inside
+    the work dir -- and that record embeds `original_poses` verbatim. This
+    fixture used to take that default, so case 1 below ("a work dir holding
+    only the perturbed board is clean") was staging a full ground-truth carrier
+    and passing anyway, because `DEFAULT_ALLOW` exempted `*.perturb.json` by
+    name. Staging it the way the RUNBOOK says to stage it makes case 1 test
+    what its name claims, and case 1b pins the behaviour that name-exemption
+    used to hide.
+    """
     from placement.perturb import perturb
 
-    control = os.path.join(tmp, 'perturbed.control.kicad_pcb')
-    shutil.copy(BOARD, control)
+    # The default is a SIBLING of the work dir, never `<tmp>/_truth`: a truth
+    # dir nested inside the work dir is still inside the fence, and
+    # `fence_audit` walks into it and reports both files. Every caller passes
+    # an explicit path today, so this default is only ever a trap for the next
+    # one.
+    truth = truth_dir or os.path.join(os.path.dirname(os.path.abspath(tmp)),
+                                      '_truth')
+    os.makedirs(truth, exist_ok=True)
+    control = os.path.join(truth, 'perturbed.control.kicad_pcb')
     perturbed = os.path.join(tmp, 'perturbed.kicad_pcb')
-    perturb(control, perturbed, kind='translate', seed=91, dose_mm=8.0)
+    perturb(BOARD, perturbed, kind='translate', seed=91, dose_mm=8.0,
+            control_out=control)
     return control, perturbed
 
 
@@ -71,13 +124,46 @@ def main():
     with tempfile.TemporaryDirectory() as tmp:
         wd = os.path.join(tmp, 'wk')
         os.makedirs(wd)
-        control, perturbed = make_case(wd)
+        control, perturbed = make_case(wd, truth_dir=os.path.join(tmp, '_truth'))
 
-        # 1. clean: the work dir holds the perturbed board and the DECLARED
-        #    control only. The control is excluded by name on purpose -- the
-        #    audit hunts undeclared carriers.
+        # 1. clean: the work dir holds the perturbed board and nothing else.
+        #    The control lives OUTSIDE, in _truth/, which is where the staging
+        #    recipe puts it.
         code, out = run_audit(control, wd, 'audit')
         check('perturbed-only work dir is CLEAN', code == CLEAN, out)
+
+        # 1b. the record is truth in JSON clothing, and it is what the DEFAULT
+        #     perturb path drops into the work dir. `DEFAULT_ALLOW` used to
+        #     exempt it by name, so this exact file could sit in the fence and
+        #     the audit would report CLEAN.
+        rec = os.path.join(wd, 'perturbed.perturb.json')
+        with open(rec, 'w', encoding='utf-8') as fh:
+            import json as _json
+            from kicad_parser import parse_kicad_pcb as _pk
+            _json.dump({'original_poses': {
+                r: [f.x, f.y, f.rotation]
+                for r, f in _pk(control).footprints.items()}}, fh)
+        code, out = run_audit(control, wd, 'audit')
+        check('a pose RECORD inside the fence is a LEAK', code == LEAK, out)
+        check('the record leak names the file',
+              'perturbed.perturb.json' in out, out)
+        check('and says records are never reconstructed',
+              'never reconstructed' in out, out)
+
+        # 1c. same truth, saved as UTF-16. The content test must not depend on
+        #     how the file was encoded -- reading it as utf-8 text raised
+        #     UnicodeDecodeError into a bare except and waved it through.
+        with open(rec, encoding='utf-8') as fh:
+            _raw = fh.read()
+        os.remove(rec)
+        rec16 = os.path.join(wd, 'notes.json')
+        with open(rec16, 'w', encoding='utf-16') as fh:
+            fh.write(_raw)
+        code, out = run_audit(control, wd, 'audit')
+        check('a UTF-16 pose record is still a LEAK', code == LEAK, out)
+        os.remove(rec16)
+        code, out = run_audit(control, wd, 'audit')
+        check('and the dir is CLEAN again once it is gone', code == CLEAN, out)
 
         # 2. the leak, under a name nobody would fence
         leaked = os.path.join(wd, 'stripped.kicad_pcb')
@@ -94,8 +180,28 @@ def main():
         check('create writes the manifest',
               os.path.isfile(os.path.join(wd, '.fence-manifest.json')), out)
 
+        # A byte-identical COPY of the control is not a reconstruction, and
+        # used to be reported as one: `shutil.copy` + a name not in the
+        # manifest was classed 'produced by the run' and exited 0. That is the
+        # laundering route -- copy the control, and the audit congratulates
+        # you. A real recovery differs in copper, UUIDs and netclasses even
+        # when every pose matches, which is exactly what `control_sha256` in
+        # the manifest is for.
+        laundered = os.path.join(wd, 'r4_copied.kicad_pcb')
+        shutil.copy(control, laundered)
+        code, out = run_audit(control, wd, 'audit')
+        check('a byte-identical copy of the control is a LEAK, not a recovery',
+              code == LEAK, out)
+        check('...and says it was copied rather than rebuilt',
+              'copied, not reconstructed' in out, out)
+        os.remove(laundered)
+
+        # A GENUINE reconstruction: same poses, different bytes. Re-serialising
+        # through the writer reproduces every pose and changes the file, which
+        # is the shape a real recovery has.
         recovered = os.path.join(wd, 'r4_final.kicad_pcb')
-        shutil.copy(control, recovered)          # a perfect reconstruction
+        _reserialise(control, recovered)
+        assert _sha(recovered) != _sha(control), 'fixture must differ in bytes'
         code, out = run_audit(control, wd, 'audit')
         check('a board produced BY the run that reaches truth is not a leak',
               code == CLEAN, out)

--- a/tests/test_run8_lock_displacement.py
+++ b/tests/test_run8_lock_displacement.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""A displaced part must never be recommended for a lock.
+
+Found by running the combined placement+routing skill on a deliberately
+scrambled board. The placement half's second stage says "separate the parts
+whose position is NOT a netlist question" and runs the lock advisor. On that
+board the advisor promoted to HIGH -- and printed in its paste-ready `--lock`
+line -- three parts whose ONLY qualifying reason was:
+
+    courtyard leaves the board outline by 44.44 mm
+    courtyard leaves the board outline by 21.80 mm
+    courtyard leaves the board outline by  8.88 mm
+
+Those were the scrambled parts. Pasting that line freezes the damage as a
+decision, and every later stage then treats the wrong pose as ground truth --
+the wrong-basin failure, handed to the executor by a tool it was told to trust.
+
+The rule itself is sound for the case it was written for: an edge connector or
+a castellated module DOES leave the outline, and that overhang is a real signal
+that its position is a mechanical fact. What was missing is that the same
+measurement has two opposite meanings:
+
+    straddling  -- pads on the board, shell past the edge   -> mechanical fact
+    wholly off  -- touching nothing                         -> displacement
+
+So the test is not the magnitude, it is whether any of the body is still on the
+board. Magnitude alone cannot separate them: a big connector on a small board
+can out-hang a small part parked just past the edge.
+
+Note what this does NOT fix, deliberately: a part hanging PARTLY off an edge is
+geometrically indistinguishable from a genuine edge-mounted part, so it stays
+HIGH. Separating those needs corroboration this rule does not have.
+
+Run: python3 -X utf8 tests/test_run8_lock_displacement.py
+"""
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+os.chdir(ROOT)
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_placer'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_tools'))  # #522/py_placer layout
+os.environ['KRT_NO_BANNER'] = '1'
+
+from kicad_parser import parse_kicad_pcb                       # noqa: E402
+from placement.lock_advisor import advise_locks, _straddles_outline  # noqa: E402
+
+BOARD = os.path.join('kicad_files', 'splitflap_driver.kicad_pcb')
+
+FAILURES = []
+
+
+def check(name, cond, detail=''):
+    print(f'  {"PASS" if cond else "FAIL"}  {name}'
+          + (f'\n        {detail}' if not cond and detail else ''))
+    if not cond:
+        FAILURES.append(name)
+
+
+def advise(pcb):
+    return advise_locks(pcb, None, min_confidence='medium')
+
+
+def by_ref(adv):
+    return {f.ref: f for f in adv.findings}
+
+
+def main():
+    pcb = parse_kicad_pcb(BOARD)
+    bounds = pcb.board_info.board_bounds
+    check('the reference board has bounds', bounds is not None)
+
+    base = by_ref(advise(pcb))
+    base_high = {r for r, f in base.items() if f.confidence == 'high'}
+    print(f'  (undamaged: {len(base_high)} HIGH finding(s))')
+
+    # Pick a part the undamaged board does NOT already flag, so the assertion
+    # below is about the displacement and not about what the part is.
+    victim = next((r for r in sorted(pcb.footprints)
+                   if r not in base and pcb.footprints[r].pads), None)
+    check('there is an unflagged part to displace', victim is not None,
+          'every part is already a lock finding on the clean board')
+    if victim is None:
+        return 1
+
+    # Park it well clear of the board, the way a swap or a bad import does.
+    fp = pcb.footprints[victim]
+    home = (fp.x, fp.y)
+    fp.x = bounds[0] - 60.0
+    fp.y = bounds[1] - 60.0
+    for pad in fp.pads:
+        pad.global_x = fp.x + (pad.local_x or 0.0)
+        pad.global_y = fp.y + (pad.local_y or 0.0)
+
+    dmg = by_ref(advise(pcb))
+    f = dmg.get(victim)
+    check(f'the displaced part is reported at all ({victim})', f is not None)
+    if f is None:
+        return 1
+
+    check('...and is NOT high confidence', f.confidence != 'high',
+          f'confidence={f.confidence} rules={f.rules}')
+    check('...and is classified as displacement, not an edge seat',
+          'off_board_entirely' in f.rules and 'off_board_overhang' not in f.rules,
+          str(f.rules))
+    check('...and says why, in the finding itself',
+          any('WHOLLY off the board' in r for r in f.reasons))
+    pats = advise(pcb).lock_patterns()
+    check('...and the paste-ready lock line does not carry it',
+          victim not in pats, f'--lock {" ".join(pats)}')
+
+    # The parts that were HIGH for real reasons must stay HIGH: this is a
+    # demotion of one specific misreading, not a general weakening.
+    still = {r for r, ff in dmg.items() if ff.confidence == 'high'}
+    check('every other HIGH finding survives unchanged',
+          base_high - {victim} <= still,
+          f'lost: {sorted(base_high - {victim} - still)}')
+
+    fp.x, fp.y = home
+
+    print('the straddle test itself')
+
+    class _RectGate:
+        outer = None
+        cutouts = ()
+
+        def __init__(self, b):
+            self.bounds = b
+
+    g = _RectGate((0.0, 0.0, 100.0, 50.0))
+    check('a body wholly outside does not straddle',
+          _straddles_outline(g, (-30.0, -30.0, -20.0, -20.0)) is False)
+    check('a body hanging over an edge does straddle',
+          _straddles_outline(g, (90.0, 20.0, 115.0, 30.0)) is True)
+    check('a body fully inside straddles (it is not off-board at all)',
+          _straddles_outline(g, (10.0, 10.0, 20.0, 20.0)) is True)
+    check('no bounds and no outline answers None, not a guess',
+          _straddles_outline(_RectGate(None), (0.0, 0.0, 1.0, 1.0)) is None)
+
+    print()
+    if FAILURES:
+        print(f'FAIL: {len(FAILURES)} check(s): {", ".join(FAILURES)}')
+        return 1
+    print('OK')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_run8_slot_fit.py
+++ b/tests/test_run8_slot_fit.py
@@ -97,6 +97,54 @@ def main():
     got = reconstruct.fit_corner_insets(S(BOARD, parts), T(parts))
     check('one survivor does not over-determine a pattern', not got, str(got))
 
+    # ---- run-9: the cases the corner-only model could not express ----------
+    #
+    # A hole one inset in from an edge, mid-span along it, is an ordinary
+    # mounting pattern. With no slot there, a displaced member's offset agrees
+    # with nothing, the support >= 2 rule discards the one correct offset along
+    # with the wrong ones, and the ladder mints no vector at all.
+    print('a hole at an edge MIDPOINT is at seat, not displaced')
+    parts = {'H1': P(3.0, 3.0), 'H2': P(97.0, 3.0), 'H3': P(3.0, 77.0),
+             'H4': P(97.0, 77.0), 'H5': P(50.0, 77.0)}
+    got = reconstruct.fit_corner_insets(S(BOARD, parts), T(parts))
+    check('a mid-edge hole standing on its own seat is not proposed',
+          not got, str(got))
+    check('...specifically, it is not offered the place it already occupies',
+          (50.0, 77.0) not in got.get('H5', []), str(got.get('H5')))
+
+    print('mid-edge slots appear only when the corner model is over-subscribed')
+    # Four corners occupied, two displaced: demand 4 + 2 = 6 > 4.
+    parts = {'H1': P(3.0, 3.0), 'H2': P(97.0, 3.0), 'H3': P(3.0, 77.0),
+             'H4': P(97.0, 77.0), 'H5': P(40.0, 40.0), 'H6': P(60.0, 41.0)}
+    got = reconstruct.fit_corner_insets(S(BOARD, parts), T(parts))
+    check('both displaced holes get proposals', set(got) == {'H5', 'H6'},
+          str(sorted(got)))
+    check('...and the mid-edge seats are among them',
+          (50.0, 77.0) in got.get('H5', []) and (50.0, 3.0) in got.get('H5', []),
+          str(got.get('H5')))
+    check('...while every corner is correctly taken',
+          (3.0, 3.0) not in got.get('H5', []), str(got.get('H5')))
+
+    # The gate that keeps this from breaking the shipped single-hole case: one
+    # free corner and one claimant needs no mid-edge slot, and offering one
+    # hands the nearest-slot tiebreak a closer WRONG answer.
+    print('...and NOT when one free corner suffices')
+    parts = {'H1': P(3.0, 3.0), 'H2': P(97.0, 3.0), 'H3': P(3.0, 77.0),
+             'H4': P(50.0, 40.0)}
+    got = reconstruct.fit_corner_insets(S(BOARD, parts), T(parts))
+    check('the sole claimant is offered the free corner', got.get('H4') == [(97.0, 77.0)],
+          str(got.get('H4')))
+
+    print('two hole families are both fitted')
+    # An imperial board with a (3,3) family and a (7.62,1.27) family. Fitting
+    # only the largest makes the second family read as displaced, and its
+    # members then compete for the first family's free seat.
+    parts = {'H1': P(3.0, 3.0), 'H2': P(97.0, 3.0), 'H3': P(3.0, 77.0),
+             'A1': P(7.62, 1.27), 'A2': P(92.38, 78.73)}
+    got = reconstruct.fit_corner_insets(S(BOARD, parts), T(parts))
+    check('neither family member is treated as displaced',
+          'A1' not in got and 'A2' not in got, str(sorted(got)))
+
     print()
     if FAILURES:
         print(f'FAIL: {len(FAILURES)} check(s): {", ".join(FAILURES)}')

--- a/tests/test_run9_arm_report.py
+++ b/tests/test_run9_arm_report.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""The recovery table is measured, and the two ways it used to lie are shut.
+
+The previous run's table was assembled by hand and three of its numbers were
+wrong, all in the flattering direction. Two of those were tool defects rather
+than typing:
+
+1. HOME WAS COUNTED IN THE WRONG SPACE. `placement_recovery_arm.py` computed
+   it from footprint-ORIGIN distance with a hardcoded 2.0, against
+   `recovery.py`'s own headline rule that displacement is measured in PAD
+   space. A part rotated in place moves its origin 0.00 mm and its pads up to
+   49 mm, so an origin-distance count reports a rotated part as home. The
+   correct value was already computed and thrown away.
+
+2. `check_assembly --json` CARRIED NO VERDICT. Every reader re-derived
+   `blocking == 0 and not locked_contact_pairs` for itself, and the ones that
+   got it wrong got it wrong quietly -- the arm scraped the verdict back out of
+   stdout, and board_score's assembly component reads `blocking` alone.
+
+Run: python3 -X utf8 tests/test_run9_arm_report.py
+"""
+import json
+import math
+import os
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+os.chdir(ROOT)
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_placer'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_tools'))  # #522/py_placer layout
+os.environ.setdefault('KRT_NO_BANNER', '1')
+
+BOARD = os.path.join('kicad_files', 'splitflap_driver.kicad_pcb')
+FAILURES = []
+
+
+def check(name, cond, detail=''):
+    print(f'  {"PASS" if cond else "FAIL"}  {name}'
+          + (f'\n        {detail}' if not cond and detail else ''))
+    if not cond:
+        FAILURES.append(name)
+
+
+def main():
+    print('check_assembly states its own verdict, so nobody re-derives it')
+    with tempfile.TemporaryDirectory() as tmp:
+        jp = os.path.join(tmp, 'a.json')
+        p = subprocess.run(
+            [sys.executable, '-X', 'utf8', 'py_tools/check_assembly.py', BOARD,
+             '--json', jp], capture_output=True, text=True, encoding='utf-8',
+            errors='replace', cwd=ROOT)
+        doc = json.load(open(jp, encoding='utf-8'))
+        for key in ('buildable', 'verdict', 'locked_contacts'):
+            check(f'--json carries {key!r}', key in doc, str(sorted(doc)))
+        check('buildable agrees with the exit code',
+              doc.get('buildable') == (p.returncode == 0),
+              f'buildable={doc.get("buildable")} exit={p.returncode}')
+        check('buildable agrees with the printed verdict',
+              doc.get('buildable') == ('NOT BUILDABLE' not in doc['verdict']),
+              doc.get('verdict'))
+        check('locked_contacts is a count, not a list',
+              isinstance(doc.get('locked_contacts'), int),
+              type(doc.get('locked_contacts')).__name__)
+
+    print('home is counted in PAD space, not between footprint origins')
+    # Rotate one part in place. Its origin does not move at all; its pads do.
+    # An origin-distance count calls that home; the pad-space one must not.
+    from kicad_parser import parse_kicad_pcb
+    from placement import recovery as R
+    pcb = parse_kicad_pcb(BOARD)
+    poses = R.board_poses(pcb)
+    ref = max(poses, key=lambda r: len(pcb.footprints[r].pads or []))
+    x, y, rot = poses[ref]
+    spun = dict(poses)
+    spun[ref] = (x, y, (rot + 180.0) % 360.0)
+
+    d = R.displacement_to_original(spun, poses, pcb.footprints, subset=[ref])
+    origin_mm = math.hypot(0.0, 0.0)
+    check(f'the origin did not move ({ref})', origin_mm == 0.0)
+    check('...but the pad-space displacement did',
+          d['perturbed_pad_rms'] > R.HOME_TOLERANCE_MM,
+          f'pad rms {d["perturbed_pad_rms"]}')
+    check('...so the part is NOT counted as home',
+          d['parts_home_frac'] == 0.0, str(d['parts_home_frac']))
+    check('...and the rotation is reported, not swallowed',
+          d['rot_mismatch_total'] == 1, str(d.get('rot_mismatch')))
+
+    print('the report tool reads that value rather than recomputing it')
+    src = open(os.path.join(ROOT, 'tests', 'stress', 'arm_report.py'),
+               encoding='utf-8').read()
+    check('arm_report uses parts_home_frac', 'parts_home_frac' in src)
+    check('...and does not hand-roll an origin distance',
+          'math.hypot' not in src, 'a hypot in here is the old bug returning')
+    check('...and takes the frozen member list as N',
+          "['block']" in src or '"block"' in src or "'block'" in src)
+    check('...and opens truth at ONE marked point',
+          'truth opens HERE' in src)
+    check('...and guards a copper-less human reference',
+          'original_degeneracy' in src)
+
+
+    print('an EQUAL tuple is no tie-break in favour of an unevidenced move')
+    # The hole A2 closes: a zero-net part in free space touches no term the
+    # gate tuple has, so `strictly better` never fires for it and a carry to
+    # another part's seat survives the sweep that exists to catch it.
+    from placement import reconstruct as Rc
+    class _P:
+        def __init__(s, x, y, rot=0.0):
+            s.x, s.y, s.rot = x, y, rot
+    class _S:
+        def __init__(s, parts):
+            s.parts = parts
+    st = _S({'A': _P(10.0, 20.0), 'B': _P(0.0, 0.0)})
+    old = {'A': (10.0 - 65.5, 20.0 + 11.3, 0.0), 'B': (5.0, 5.0, 0.0)}
+    ev = Rc.evidenced_moves(st, old, [(65.5, -11.3)])
+    check('a move matching a kept vector is evidenced', ev == {'A'}, str(ev))
+    ev2 = Rc.evidenced_moves(st, old, [])
+    check('with no vector, nothing is evidenced', ev2 == set(), str(ev2))
+    ev3 = Rc.evidenced_moves(st, {'A': (10.0, 20.0, 0.0)}, [(65.5, -11.3)])
+    check('a part that did not move needs no justification', ev3 == set(),
+          str(ev3))
+    st2 = _S({'A': _P(10.0 + 131.0, 20.0 - 22.6)})
+    ev4 = Rc.evidenced_moves(st2, {'A': (10.0, 20.0, 0.0)}, [(65.5, -11.3)])
+    check('a move of 2v is evidenced too (the lattice is +/-1, +/-2)',
+          ev4 == {'A'}, str(ev4))
+    check('prune takes an evidenced set',
+          'evidenced' in Rc.prune_assignment.__code__.co_varnames)
+
+
+    print('the off-board witness is silent on healthy boards, by construction')
+    from pose_score import make_state
+    for lab, bd, clr in (('splitflap', BOARD, 0.15),
+                         ('tigard', os.path.join('kicad_files',
+                                                 'tigard.kicad_pcb'), 0.09)):
+        st = make_state(parse_kicad_pcb(bd), bd, clearance=clr)
+        w = Rc.damage_witnesses(st)
+        check(f'no witness on healthy {lab}', not w, str(sorted(w)))
+    check('the mover preference consults it',
+          'witnesses' in open(os.path.join(ROOT, 'py_placer', 'placement', 'seeder.py'),
+                              encoding='utf-8').read())
+
+    print()
+    if FAILURES:
+        print(f'FAIL: {len(FAILURES)} check(s): {", ".join(FAILURES)}')
+        return 1
+    print('OK')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_run9_check_complete.py
+++ b/tests/test_run9_check_complete.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+""""Is this board done?" gets a command, and it fails closed.
+
+`board_score` is the authority on `blocking` and it says "done" too easily read
+alone. It exits 0 with four of nine components UNGRADED (their flags were not
+passed, and `ungraded` does not touch the exit code); `undersized` runs at the
+FAB floor when no spec numbers are given, so 0 there is not "the sizes are
+right"; and it has no component at all for orphan stubs, weird copper or pad
+overlaps.
+
+Underneath all of it the DRC writeback only ever LOOSENS -- every constraint
+set to min(current, target), target being the smallest object actually placed
+-- so a board that routed below its own declared minimum rewrites that minimum
+and then grades clean against the new one. Measured once at 5629 of 5933
+segments below the original floor with every checker reading clean. That was
+disclosed in a printed line and enforced by nothing.
+
+What this pins:
+
+  * UNGRADED does not make a board fail, but is always NAMED. A board with no
+    spec files has nothing to grade those components against, and making it
+    fatal would put every corpus board permanently in the failing state.
+  * a relaxed FAB FLOOR is UNSOUND and outranks everything else, because it is
+    the one failure where the clean report is itself the evidence.
+  * the verdict classes have distinct exit codes.
+
+Run: python3 -X utf8 tests/test_run9_check_complete.py
+"""
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+os.chdir(ROOT)
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_placer'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_tools'))  # #522/py_placer layout
+os.environ.setdefault('KRT_NO_BANNER', '1')
+
+DONE, USAGE, BOARD_STATE, INCOMPLETE, UNSOUND = 0, 2, 3, 4, 5
+BOARD = os.path.join('kicad_files', 'splitflap_driver.kicad_pcb')
+FAILURES = []
+
+
+def check(name, cond, detail=''):
+    print(f'  {"PASS" if cond else "FAIL"}  {name}'
+          + (f'\n        {detail}' if not cond and detail else ''))
+    if not cond:
+        FAILURES.append(name)
+
+
+def run(*args):
+    p = subprocess.run(
+        [sys.executable, '-X', 'utf8', 'check_complete.py', *args],
+        capture_output=True, text=True, encoding='utf-8', errors='replace',
+        cwd=ROOT, timeout=1800)
+    return p.returncode, (p.stdout or '') + (p.stderr or '')
+
+
+def main():
+    print('the verdict classes are distinct')
+    check('DONE / INCOMPLETE / UNSOUND / usage / board-state are 5 codes',
+          len({DONE, INCOMPLETE, UNSOUND, USAGE, BOARD_STATE}) == 5)
+
+    print('a board that does not exist is a board-state answer, not a verdict')
+    code, out = run('no_such_board.kicad_pcb')
+    check('missing board -> exit 3', code == BOARD_STATE, f'exit {code}')
+
+    print('UNGRADED is named, and does not decide the verdict by itself')
+    code, out = run(BOARD, '--clearance', '0.15', '--skip-slow')
+    for comp in ('floorplan', 'impedance', 'length', 'net_widths'):
+        check(f'{comp} is named as unexamined', comp in out, out[-200:])
+    check('...and called UNEXAMINED, not passed', 'UNEXAMINED' in out,
+          out[-200:])
+    check('an unrouted board is INCOMPLETE for its blocking, not its ungraded',
+          code == INCOMPLETE and 'blocking' in out, f'exit {code}')
+
+    print('a relaxed fab floor is UNSOUND, and outranks the rest')
+    with tempfile.TemporaryDirectory() as tmp:
+        from fix_kicad_drc_settings import find_project, scan_board_minima
+        b = os.path.join(tmp, 'b.kicad_pcb')
+        shutil.copyfile(BOARD, b)
+        src_pro = find_project(BOARD)
+        pro = os.path.join(tmp, 'b.kicad_pro')
+        if os.path.isfile(src_pro):
+            shutil.copyfile(src_pro, pro)
+        else:
+            json.dump({'board': {'design_settings': {'rules': {}}}},
+                      open(pro, 'w', encoding='utf-8'))
+
+        # Whichever fab floor this board actually has an object for. A
+        # copper-free board has no track or via minimum at all, only a hole
+        # diameter -- so pinning one key by name would make this test a
+        # statement about the fixture rather than the mechanism.
+        from fix_kicad_drc_settings import FAB_FLOOR_KEYS
+        minima = scan_board_minima(b) or {}
+        key, got = next(((k, minima[k]) for k, _lbl in FAB_FLOOR_KEYS
+                         if isinstance(minima.get(k), (int, float))),
+                        (None, None))
+        check('the board reports some fab minimum to compare against',
+              key is not None, str(minima))
+        if key is None:
+            return 1
+        label = dict(FAB_FLOOR_KEYS)[key]
+
+        # Declare a floor the board's own copper does not meet. This is the
+        # ratchet's shape: the project once said one thing, the copper says
+        # another, and every checker reads the project.
+        authored = os.path.join(tmp, 'authored.kicad_pcb')
+        shutil.copyfile(b, authored)
+        doc = {'board': {'design_settings': {'rules': {key: got + 0.05}}}}
+        json.dump(doc, open(os.path.join(tmp, 'authored.kicad_pro'), 'w',
+                            encoding='utf-8'))
+
+        code, out = run(b, '--clearance', '0.15', '--skip-slow',
+                        '--authored-from', authored)
+        check('copper below an authored floor -> UNSOUND', code == UNSOUND,
+              f'exit {code}: {out[-200:]}')
+        check('...and it names the floor that moved',
+              label in out and '->' in out, out[-260:])
+        check('...and says the clean report is the symptom',
+              'the rule moved, not the copper' in out, out[-260:])
+
+        # Without the reference there is nothing to compare against, and
+        # saying so is different from saying it passed.
+        code2, out2 = run(b, '--clearance', '0.15', '--skip-slow')
+        check('with no --authored-from the floor check does not claim a pass',
+              code2 != UNSOUND, f'exit {code2}')
+
+    # ---- the document is a GATE INPUT, so it has to survive its own -------
+    # ---- failures and be bindable to a board ------------------------------
+    print('the close-out document holds up as something a gate can read')
+    with tempfile.TemporaryDirectory() as td:
+        jp = os.path.join(td, 'close.json')
+
+        # A relative board path from a cwd that is NOT the repo root. _run
+        # uses cwd=ROOT, so before the abspath fix board_score was handed a
+        # path that does not resolve, returned nothing, and the verdict became
+        # a FALSE "INCOMPLETE: blocking is null" wearing a correctly-bound
+        # doc['board']. Every other test in this file runs after os.chdir(ROOT),
+        # which is exactly why it survived.
+        sub = os.path.join(td, 'elsewhere')
+        os.makedirs(sub)
+        rel = os.path.relpath(os.path.join(ROOT, BOARD), sub)
+        p = subprocess.run(
+            [sys.executable, '-X', 'utf8',
+             os.path.join(ROOT, 'check_complete.py'), rel,
+             '--skip-slow', '--json', jp],
+            capture_output=True, text=True, encoding='utf-8',
+            errors='replace', cwd=sub, timeout=1800)
+        out = (p.stdout or '') + (p.stderr or '')
+        check('a relative board path from another cwd still resolves',
+              'blocking is null' not in out and 'no score' not in out,
+              out[-300:])
+        doc = {}
+        if os.path.isfile(jp):
+            with open(jp, encoding='utf-8') as fh:
+                doc = json.load(fh)
+        check('...and the document names itself for a shape test',
+              doc.get('kind') == 'board-complete' and doc.get('schema') == 1,
+              repr({k: doc.get(k) for k in ('kind', 'schema')}))
+        # Bind by CONTENT, not by path: a gate comparing paths accepts a
+        # close-out for a board that has since been rewritten.
+        import hashlib
+        h = hashlib.sha256(open(os.path.join(ROOT, BOARD), 'rb').read())
+        check('...and carries board_sha, matching the file on disk',
+              doc.get('board_sha') == h.hexdigest(),
+              f'doc {doc.get("board_sha")!r}')
+        # --skip-slow empties `components`, so a gate that only checks keys
+        # would accept a document strictly weaker than the score it wraps.
+        check('--skip-slow leaves components empty, visibly',
+              doc.get('components') == {}, repr(doc.get('components'))[:120])
+
+        # An unreadable board must still produce a document that SAYS so. The
+        # --json write used to be the last statement, so anything that raised
+        # above it produced no document at all.
+        bad = os.path.join(td, 'truncated.kicad_pcb')
+        with open(bad, 'w', encoding='utf-8') as fh:
+            fh.write('(kicad_pcb (version 20221018)\n')      # unterminated
+        jp2 = os.path.join(td, 'close2.json')
+        code3, out3 = run(bad, '--json', jp2)
+        check('an unparseable board still writes a document',
+              os.path.isfile(jp2), out3[-300:])
+        if os.path.isfile(jp2):
+            with open(jp2, encoding='utf-8') as fh:
+                d2 = json.load(fh)
+            check('...and it is never DONE', d2.get('verdict') != 'DONE',
+                  repr(d2.get('verdict')))
+            check('...and it says the instrument did not run, not that it passed',
+                  'did not' in (d2.get('reason') or '')
+                  or 'no score' in (d2.get('reason') or ''),
+                  repr(d2.get('reason'))[:220])
+        check('...and the exit code is not success', code3 != DONE,
+              f'exit {code3}')
+
+    print()
+    if FAILURES:
+        print(f'FAIL: {len(FAILURES)} check(s): {", ".join(FAILURES)}')
+        return 1
+    print('OK')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_run9_verdict.py
+++ b/tests/test_run9_verdict.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""The loop gets a stop MECHANISM, not another stop rule.
+
+Every stop rule in this toolchain was already written down -- a 5-lap placement
+cap, four routing stop conditions, a budget of 100, "5 consecutive flat" -- and
+not one of them had a mechanism. No counter, no budget check, no read of the
+ledger that gated continuation; `final` and `stop_condition` were written by
+converge.py and read back by nothing. So a run that stopped because the board
+was finished and a run that stopped because it was stuck produced the same
+artifact, and the difference lived only in whatever the report chose to say.
+
+`converge.py verdict` is that mechanism. What this pins:
+
+  * the four verdicts are DISTINGUISHABLE BY EXIT CODE, so a driver can branch
+    on them without parsing prose;
+  * reaching `blocking == 0` is the FLOOR, not the finish -- a solved board
+    whose quality is still improving gets CONTINUE, because the score is
+    lexicographic and quality orders the boards that already got there;
+  * only ACCEPTED laps count toward a plateau. A rejected lap is data (it is
+    what makes a plateau detectable) but treating it as evidence the half can
+    still move would reset the counter on every rejection and the loop would
+    never stop;
+  * `blocking == null` is not zero. It means a component that was asked for
+    could not answer, and it must never read as a perfect board;
+  * UNGRADED components do not block DONE -- a corpus board has no spec files,
+    so four of nine components cannot be graded and making that fatal would put
+    every board permanently in STUCK -- but DONE must NAME them as unexamined.
+
+Run: python3 -X utf8 tests/test_run9_verdict.py
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+os.chdir(ROOT)
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_placer'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_tools'))  # #522/py_placer layout
+
+CONTINUE, DONE, STUCK, BUDGET, USAGE = 4, 0, 5, 6, 2
+
+FAILURES = []
+
+
+def check(name, cond, detail=''):
+    print(f'  {"PASS" if cond else "FAIL"}  {name}'
+          + (f'\n        {detail}' if not cond and detail else ''))
+    if not cond:
+        FAILURES.append(name)
+
+
+def score(blocking, vias=10, copper=100.0, segments=50, ungraded=(), unknown=()):
+    return {'blocking': blocking,
+            'quality': {'vias': vias, 'copper_mm': copper,
+                        'segments': segments},
+            'ungraded': list(ungraded), 'unknown': list(unknown)}
+
+
+def run(tmp, rows, board_score, budget=100, flat=5):
+    """Write a ledger + score and ask for the verdict. Returns (code, doc)."""
+    lp = os.path.join(tmp, 'ledger.jsonl')
+    with open(lp, 'w', encoding='utf-8') as fh:
+        for i, r in enumerate(rows):
+            fh.write(json.dumps(dict(r, iteration=i)) + '\n')
+    sp = os.path.join(tmp, 'score.json')
+    with open(sp, 'w', encoding='utf-8') as fh:
+        json.dump(board_score, fh)
+    p = subprocess.run(
+        [sys.executable, '-X', 'utf8', 'py_placer/converge.py', 'verdict',
+         '--ledger', lp, '--score', sp,
+         '--budget', str(budget), '--flat', str(flat)],
+        capture_output=True, text=True, encoding='utf-8', errors='replace',
+        cwd=ROOT)
+    try:
+        doc = json.loads(p.stdout)
+    except Exception:
+        doc = {'stdout': p.stdout, 'stderr': p.stderr}
+    return p.returncode, doc
+
+
+def lap(kind, blocking, accepted=True, **kw):
+    return {'kind': kind, 'accepted': accepted,
+            'score': score(blocking, **kw)}
+
+
+def main():
+    with tempfile.TemporaryDirectory() as tmp:
+        print('a half that is still improving means CONTINUE')
+        rows = ([lap('placement', 9 - i) for i in range(6)]
+                + [lap('completion', 9 - i) for i in range(6)])
+        code, doc = run(tmp, rows, score(3))
+        check('improving on both halves -> CONTINUE', code == CONTINUE,
+              f'exit {code}: {doc.get("verdict")}')
+
+        print('blocking == 0 is the FLOOR, not the finish')
+        # Routing keeps shaving vias after blocking hits 0. The loop must not
+        # stop: quality orders the boards that already got there.
+        rows = ([lap('placement', 0) for _ in range(6)]
+                + [lap('completion', 0, vias=40 - i) for i in range(6)])
+        code, doc = run(tmp, rows, score(0, vias=34))
+        check('a solved board whose QUALITY still improves -> CONTINUE',
+              code == CONTINUE, f'exit {code}: {doc.get("verdict")}')
+        check('...and it names which half is still moving',
+              doc.get('improving') == ['routing'], str(doc.get('improving')))
+
+        print('both halves plateaued, and the board is solved')
+        rows = ([lap('placement', 0) for _ in range(6)]
+                + [lap('completion', 0) for _ in range(6)])
+        code, doc = run(tmp, rows, score(0))
+        check('blocking 0 + both halves flat -> DONE-EXHAUSTED', code == DONE,
+              f'exit {code}: {doc.get("verdict")}')
+
+        print('both halves plateaued, and the board is NOT solved')
+        rows = ([lap('placement', 4) for _ in range(6)]
+                + [lap('completion', 4) for _ in range(6)])
+        code, doc = run(tmp, rows, score(4))
+        check('blocking > 0 + both halves flat -> STUCK', code == STUCK,
+              f'exit {code}: {doc.get("verdict")}')
+        check('...and it refuses to call that finished',
+              'calling the board finished is not' in doc.get('reason', ''),
+              doc.get('reason', '')[:120])
+
+        print('the four verdicts are distinguishable by exit code')
+        check('CONTINUE, DONE, STUCK and BUDGET are four distinct codes',
+              len({CONTINUE, DONE, STUCK, BUDGET}) == 4)
+
+        print('the budget is enforced, not merely documented')
+        rows = [lap('completion', 4) for _ in range(12)]
+        code, doc = run(tmp, rows, score(4), budget=12)
+        check('ledger rows >= budget -> BUDGET', code == BUDGET,
+              f'exit {code}: {doc.get("verdict")}')
+        check('...and it outranks STUCK, so the report says which ended it',
+              doc.get('verdict') == 'BUDGET', str(doc.get('verdict')))
+
+        print('only ACCEPTED laps count toward a plateau')
+        # Rejected laps carry improving scores. If they counted, this half
+        # would look like it is still moving and the loop would never stop.
+        rows = ([lap('placement', 0) for _ in range(6)]
+                + [lap('completion', 0) for _ in range(6)]
+                + [lap('completion', 9 - i, accepted=False) for i in range(6)])
+        code, doc = run(tmp, rows, score(0))
+        check('a run of REJECTED improvements does not reset the plateau',
+              code == DONE, f'exit {code}: {doc.get("verdict")}')
+
+        print('blocking == null is not zero')
+        rows = ([lap('placement', 0) for _ in range(6)]
+                + [lap('completion', 0) for _ in range(6)])
+        code, doc = run(tmp, rows, score(None))
+        check('an ungradeable board is never DONE', code != DONE,
+              f'exit {code}: {doc.get("verdict")}')
+        check('...and the verdict reports blocking as null, not 0',
+              doc.get('blocking') is None, str(doc.get('blocking')))
+
+        print('UNGRADED does not block DONE, but is never silent')
+        rows = ([lap('placement', 0) for _ in range(6)]
+                + [lap('completion', 0) for _ in range(6)])
+        code, doc = run(tmp, rows, score(
+            0, ungraded=('floorplan', 'impedance', 'length', 'net_widths')))
+        check('a board with no spec files can still reach DONE', code == DONE,
+              f'exit {code}: {doc.get("verdict")}')
+        check('...and DONE names every unexamined component',
+              all(c in doc.get('reason', '') for c in
+                  ('floorplan', 'impedance', 'length', 'net_widths')),
+              doc.get('reason', ''))
+        check('...calling them UNEXAMINED, not passed',
+              'UNEXAMINED' in doc.get('reason', ''), doc.get('reason', ''))
+
+        print('a component that RAN and could not answer is called out')
+        code, doc = run(tmp, rows, score(0, unknown=('impedance',)))
+        check('unknown names the instrument to fix',
+              'could not answer' in doc.get('reason', ''),
+              doc.get('reason', ''))
+
+        print('a verdict about no board is refused')
+        lp = os.path.join(tmp, 'ledger.jsonl')
+        p = subprocess.run(
+            [sys.executable, '-X', 'utf8', 'py_placer/converge.py', 'verdict',
+             '--ledger', lp, '--score', os.path.join(tmp, 'nope.json')],
+            capture_output=True, text=True, encoding='utf-8', cwd=ROOT)
+        check('an unreadable score is exit 2, not a guess',
+              p.returncode == USAGE, f'exit {p.returncode}')
+
+        print('a fresh ledger is CONTINUE, not DONE')
+        code, doc = run(tmp, [], score(0))
+        check('no laps yet means the halves have not plateaued',
+              code == CONTINUE, f'exit {code}: {doc.get("verdict")}')
+
+    print()
+    if FAILURES:
+        print(f'FAIL: {len(FAILURES)} check(s): {", ".join(FAILURES)}')
+        return 1
+    print('OK')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
**Stacked on #616** — this branch includes #616's commits; the placement work is the 9 commits from "reconstruct: the ladder trusted any equal-cost move…" onward. After #616 merges this rebases to show only its own diff.

The placement engine work from perturbed-corpus runs 8–17, re-rooted onto the #522 layout (`py_placer/`, `py_tools/`), plus the stress rig that grades it.

## Engine

- **Reconstruct ladder**: the hole-pattern fit learns per-group families, mid-edge slots and positional at-seat; an orbit detector corroborates seats; an unevidenced equal-cost move is pruned rather than trusted (an equal gate tuple is no tie-break in an unevidenced move's favour); the frame tier keys on the netlist, not `pin_count == 0`; off-board damage witnesses come from a pad-centre census.
- **Reseat**: a repair search that starts from the current pose knows nothing at 40 mm — `place_seed --reseat` lifts a far-from-home part and re-seats it on the fitted family orbit instead of nudging it, behind a 3-conjunct gate.
- **Instrument honesty**: off-outline pad copper measured against the true Edge.Cuts outline per-pad (the placement half's top-priority gate — it converts one-for-one into unrouted nets); `check_assembly` publishes `buildable`/`verdict`/`locked_contacts` and keys its oracle memo on fill cost, not a path every step renames; `check_reachability` reserves exit 1 for CAGED and exits 2 when the question was not answerable; `check_floorplan --require-rules` refuses a vacuous pass; the emit-intent edge band is capped so 160 mm of damage cannot launder itself into "by the edge, by design".
- **Deadlines**: every placement search takes `--deadline` (exit 7, summary guaranteed) through the `krt_deadline` module #616 introduces.
- **converge + check_complete**: the ledger grows lens-verdict grammar with a lens-vs-score contradiction refusal (a PASS beside the numbers that refute it is evidence about the verifier, not the board), commensurability guards, `--exhausted <half>` declarations with mandatory reasons, `--score-file` (a 49 kB score no longer dies on argv limits), and a four-code verdict; `check_complete` is the close-out instrument that fails closed — orphan stubs, weird copper, pad overlaps, and fab floors compared against the AUTHORED project so a board cannot grade itself against floors it rewrote.

## Stress rig (`tests/stress/`)

stage_blind (the dose is checked against the material floor and redrawn — "damage applied" on a clipped dose voids the recovery half before it starts), fence_audit (content-based truth fence; **this commit also repairs the file at tip, which is currently a SyntaxError** — a #522 shim was inserted mid-expression at line 58), arm_report, qualify_subject ("is this board a usable perturbed subject" in seconds), strip_copper_only, calibrate_congestion_ratio (its first result refuted the threshold it was built to calibrate; the gate now reports instead of gating), and `_truth/` staging throughout.

## Live validation

This exact engine + rig closed a blind perturbed board end to end yesterday: piantor staged blind (kind sealed), placement half repaired a ±(72.6, 6.4) mm two-group exchange to all-gates-green with an independent verifier PASS, routing half took it to blocking 0 / DRC 0 at authored floors. The run's report and ledger are reproducible from the rig in this PR.

## Testing

Targeted suites green on this branch: place_seed 37/37, reconstruct (0 errors; corpus-dependent checks skip), slot-fit, stage-blind dose 6/6, fence-and-channels 8/8, arm_report/verdict/check_complete suites, converge 27, render_placement 28, reachability. Five tests in this PR's set are deliberately red until the skill PR stacks on top (they pin `board_score`/loop-driver shares that land there) — each is named in its commit. Full `run_all` on the stack: 294 passed with every red pre-existing at tip on our test box (tip baseline measured; see #615 for why a fresh tip clone cannot run at all).
