### PR TITLE
diff_pair_custody: demote on no coupled trunk copper kept, not on member count

### DIFF
--- a/py_router/diff_pair_custody.py
+++ b/py_router/diff_pair_custody.py
@@ -162,6 +162,29 @@ def build_pair_reports(state, diff_pair_ids_to_route, member_audit,
         incomplete = [nm for tag, nm in (('p', pair.p_net_name),
                                          ('n', pair.n_net_name))
                       if not aud.get(tag, True)]
+        # 'partial' credit discriminator: a partial pair KEEPS its
+        # routed_diff_pairs credit while it kept ANY coupled trunk copper;
+        # it is demoted ONLY when it kept no coupled trunk copper at all.
+        # (An earlier rule demoted on member count -- 'partial' + both
+        # members incomplete -- which misfires on multipoint pairs whose
+        # extra pads are DELIBERATELY deferred: tigard /USB_D keeps a
+        # coupled, DRC-clean trunk while the redundant J1-row pads close in
+        # the designed single-ended follow-up, expected step-level state,
+        # not false success; that rule dropped test_tigard_usb_diff from
+        # 12/12 to 9/12 with the copper unchanged. Incomplete members are
+        # already counted as pad deficit at chain level, so credit with a
+        # real coupled trunk hides nothing.) Trunk signal, recorded not
+        # derived: 'is_diff_pair' is stamped ONLY by the coupled-route
+        # constructors (route_diff_pair_with_obstacles, the multipoint leg
+        # merge) -- never by single-ended results -- and 'new_segments'
+        # nonempty means that coupled result committed real copper.
+        no_coupled_trunk = bool(
+            outcome == 'partial'
+            and not any(rr.get('is_diff_pair') and rr.get('new_segments')
+                        for rr in (_rr_p, _rr_n) if rr))
+        if no_coupled_trunk:
+            print(f"{RED}DEMOTED {pair_name}: no coupled trunk copper kept "
+                  f"-- 'partial' pair dropped from routed_diff_pairs{RESET}")
         rep = {
             'pair': pair_name,
             'p_net': pair.p_net_name,
@@ -172,18 +195,25 @@ def build_pair_reports(state, diff_pair_ids_to_route, member_audit,
             'failure_stage': (diag.get('stage')
                               ) if outcome in ('failed', 'deferred') else None,
             'incomplete_members': incomplete,
-            # A COUPLED claim contradicted by actual pad connectivity: the
-            # "one member silently incomplete" class (#514, peaksat CAN).
-            # 'partial' is deliberately NOT in this tuple: a partial pair
-            # already DECLARES disconnected members (its peeled terminals
-            # close in the single-ended follow-up, which runs after this
-            # audit), so flagging it here made every multipoint pair with a
-            # by-design peeled leg -- tigard /USB_D's redundant J1 row --
-            # read as a contradicted claim and demoted it from
+            # A summary claim contradicted by the actual copper. Two causes:
+            # (1) a COUPLED claim contradicted by actual pad connectivity --
+            # the "one member silently incomplete" class (#514, peaksat CAN).
+            # 'partial'-with-incomplete-members is deliberately NOT that: a
+            # partial pair already DECLARES disconnected members (its peeled
+            # terminals close in the single-ended follow-up, which runs
+            # after this audit), so flagging it here made every multipoint
+            # pair with a by-design peeled leg -- tigard /USB_D's redundant
+            # J1 row -- read as a contradicted claim and demoted it from
             # routed_diff_pairs while its trunk was coupled and its board
             # finished clean. incomplete_members stays populated either way.
-            'member_audit_mismatch': bool(outcome == 'coupled'
-                                          and incomplete),
+            # (2) a PARTIAL claim with no coupled trunk copper kept at all
+            # (no_coupled_trunk above) -- there is no coupled route to
+            # credit. route_diff reads this flag to move the pair from
+            # routed_diff_pairs to partial_diff_pairs.
+            'member_audit_mismatch': bool((outcome == 'coupled'
+                                           and incomplete)
+                                          or no_coupled_trunk),
+            'no_coupled_trunk': no_coupled_trunk,
         }
         if diag.get('blocking_nets'):
             rep['blocking_nets'] = diag['blocking_nets']
@@ -201,6 +231,7 @@ def build_pair_reports(state, diff_pair_ids_to_route, member_audit,
             'failure_stage': 'pre-route',
             'incomplete_members': [p_name, n_name],
             'member_audit_mismatch': False,
+            'no_coupled_trunk': False,
         })
     return sorted(reports, key=lambda r: r['pair'])
 

--- a/tests/test_diff_pair_custody.py
+++ b/tests/test_diff_pair_custody.py
@@ -85,7 +85,13 @@ def test_pair_reports():
         ('D', mk(7, 8, '/D_P', '/D_N')),    # deferred (electrically short)
         ('E', mk(9, 10, '/E_P', '/E_N')),   # partial: coupled + peeled terminals
     ]
-    st.routed_results = {1: {}, 2: {}, 3: {}, 4: {}, 9: {}, 10: {}}
+    # E's shared result is a real coupled route (the trunk-credit
+    # discriminator reads is_diff_pair + new_segments; see
+    # test_partial_trunk_kept_keeps_credit /
+    # test_partial_no_trunk_demotes for both directions of that rule).
+    _e_trunk = {'is_diff_pair': True, 'new_segments': [SimpleNamespace()],
+                'new_vias': []}
+    st.routed_results = {1: {}, 2: {}, 3: {}, 4: {}, 9: _e_trunk, 10: _e_trunk}
     st.diff_pair_single_ended_nets = {7: '/D_P', 8: '/D_N', 9: '/E_P', 10: '/E_N'}
     record_pair_diag(st, 'C', outcome='failed', reason='congestion',
                      stage='initial-route', blocking_nets=['X'])
@@ -115,6 +121,9 @@ def test_pair_reports():
           and reps['D']['failure_reason'] == 'electrically-short')
     check("E coupled+peeled -> partial",
           reps['E']['outcome'] == 'partial')
+    check("E partial with trunk -> not demoted",
+          not reps['E']['member_audit_mismatch']
+          and not reps['E']['no_coupled_trunk'])
     check("skipped fanout pair reported",
           reps['F']['outcome'] == 'skipped'
           and reps['F']['failure_reason'] == 'fanout-self-overlap')
@@ -125,6 +134,64 @@ def test_pair_reports():
     import json
     check("reports JSON-serializable",
           bool(json.dumps(list(reps.values()))))
+
+
+def _mk_pair(p, n, pn, nn):
+    return SimpleNamespace(p_net_id=p, n_net_id=n, p_net_name=pn,
+                           n_net_name=nn)
+
+
+def _reports_with_output(st, pairs, audit):
+    import contextlib
+    import io
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        reps = {r['pair']: r for r in build_pair_reports(st, pairs, audit)}
+    return reps, buf.getvalue()
+
+
+def test_partial_trunk_kept_keeps_credit():
+    """Direction 1 (maintainer's tigard counterexample, unit-level): a
+    'partial' pair that KEPT coupled trunk copper keeps its
+    routed_diff_pairs credit -- even with BOTH members incomplete. The
+    deferred pads (tigard /USB_D's redundant J1 row) close in the designed
+    single-ended follow-up: expected step-level state, not false success;
+    incomplete members are already counted as pad deficit at chain level."""
+    st = _fake_state()
+    trunk = {'is_diff_pair': True, 'new_segments': [SimpleNamespace()],
+             'new_vias': []}
+    st.routed_results = {1: trunk, 2: trunk}
+    st.diff_pair_single_ended_nets = {1: '/G_P', 2: '/G_N'}
+    reps, out = _reports_with_output(
+        st, [('G', _mk_pair(1, 2, '/G_P', '/G_N'))],
+        {'G': {'p': False, 'n': False}})
+    check("partial + trunk kept + both members incomplete -> credit KEPT",
+          reps['G']['outcome'] == 'partial'
+          and not reps['G']['member_audit_mismatch']
+          and not reps['G']['no_coupled_trunk'])
+    check("kept pair prints no demotion line", 'DEMOTED' not in out)
+
+
+def test_partial_no_trunk_demotes():
+    """Direction 2: a 'partial' pair that kept NO coupled trunk copper at
+    all is demoted (member_audit_mismatch -> partial_diff_pairs, off the
+    routed_diff_pairs credit list), and the demotion line says why."""
+    st = _fake_state()
+    # Members carry results, but none is a coupled route with committed
+    # segments -- there is no coupled trunk to credit.
+    hollow = {'new_segments': [], 'new_vias': []}
+    st.routed_results = {3: hollow, 4: hollow}
+    st.diff_pair_single_ended_nets = {3: '/H_P', 4: '/H_N'}
+    reps, out = _reports_with_output(
+        st, [('H', _mk_pair(3, 4, '/H_P', '/H_N'))],
+        {'H': {'p': False, 'n': False}})
+    check("partial + NO coupled trunk copper -> DEMOTED",
+          reps['H']['outcome'] == 'partial'
+          and reps['H']['member_audit_mismatch']
+          and reps['H']['no_coupled_trunk'])
+    check("demotion line names the pair and the reason",
+          any('DEMOTED H' in ln and 'no coupled trunk copper kept' in ln
+              for ln in out.splitlines()))
 
 
 def _mk_state(pcb, cfg):
@@ -251,6 +318,8 @@ def main():
     test_classifier()
     test_custody_recording()
     test_pair_reports()
+    test_partial_trunk_kept_keeps_credit()
+    test_partial_no_trunk_demotes()
     print("-" * 60)
     test_reconcile_restore_first()
     test_reconcile_refused_then_partial()


### PR DESCRIPTION
The revised custody demotion, per your review on #616/#623/#624 — rebuilt from scratch on current `placement` (`d6d7b6ed`), not carried from the old stack.

**The discriminator is the one you named: demote only on no coupled trunk copper kept.** The signal is recorded, not derived: `is_diff_pair` is stamped only by the coupled-route constructors (`diff_pair_routing.py` single-leg, `diff_pair_multipoint.py` leg merge), never by single-ended results, and a nonempty `new_segments` on that shared result dict means the coupled route committed real copper. A `partial` pair keeps its `routed_diff_pairs` credit while any coupled trunk copper exists; it is demoted, with the reason printed by name, only when none does. Member count is not consulted. The demotion feeds the existing member-audit channel inside `batch_route_diff_pairs`, so CLI and GUI inherit identically, plus an additive `no_coupled_trunk` JSON key so graders can tell the two demotion causes apart.

**Verification:**
- `tests/test_tigard_usb_diff.py`: **12/12** — all three variants keep `"routed_diff_pairs": ["/USB_D"]`, the deliberately-deferred multipoint shape from your counterexample keeps its credit.
- Custody suite: **37/37** — two new pins, one per direction (partial + trunk kept + both members incomplete → credit kept; partial + no trunk → demoted with the reason line), and fixture E upgraded to carry a real coupled-trunk result.
- Diff-pair battery at this tip, all green: diff_pair_route 5/5, watchy passthrough + hybrid escape, esp_prog 1/1, multipoint_diff_route 7/7, multipoint_failed_edge_reporting 6/6, qfn_csi_underpad_diff 2/2, diff_se_member_fallback 16/16.

**Stated honestly:** the demotion direction is exercised at unit level only — no board in the tracked corpus produces a partial-without-trunk pair in a live route (the battery boards all keep their trunks, which is why they stay green). And when the demotion fires, `route_diff.py`'s generic MEMBER AUDIT MISMATCH line prints beside the specific reason line; rewording that generic line would touch `route_diff.py`, which this PR deliberately does not.
