### PR TITLE
fix: pad keep-out generator emitted zero cells on a warm memo cache

### DIFF
--- a/py_router/routing_utils.py
+++ b/py_router/routing_utils.py
@@ -205,13 +205,21 @@ def iter_pad_blocked_cells(
     # sub-grid deviation (diff pair P/N offsets) pass a larger buffer.
     if corner_buffer is None:
         corner_buffer = grid_step / 2
-    key = (half_width, half_height, margin, grid_step, corner_radius,
-           corner_buffer, off_x, off_y, rotation_deg)
-    offs = _PAD_OFFSETS_CACHE.get(key)
-    if offs is not None:
-        out = np.empty_like(offs)
-        np.add(offs, np.array([[pad_gx, pad_gy]], dtype=np.int32), out=out)
-        return out
+    # DELIBERATELY NOT MEMOIZED -- do not paste the _PAD_OFFSETS_CACHE
+    # fast-path from pad_blocked_cells_array in here. Two reasons:
+    #   1. This is a GENERATOR. `return <array>` inside one is not a result,
+    #      it is a bare StopIteration -- the fast path would yield NOTHING
+    #      and the pad would silently get no keep-out at all. That shipped
+    #      once (02f5375a, v0.20.4) and emptied this function on every warm
+    #      cache; tests/test_pad_offset_keepout.py pins it.
+    #   2. Even done correctly it would be wrong to share: this scalar
+    #      rasterizer is the INDEPENDENT reference implementation that
+    #      test_pad_offset_keepout.py grades the vectorized twin against.
+    #      Serving it from the twin's cache makes that cross-check vacuous
+    #      (and only when the cache happens to be warm, so it would pass or
+    #      fail by call order). The perf case for the memo is entirely
+    #      pad_blocked_cells_array's -- that is the twin every obstacle
+    #      builder actually calls.
     rotated = abs(rotation_deg) > 1e-9 and abs(abs(rotation_deg) - 180.0) > 1e-9
     if rotated:
         _rrad = math.radians(rotation_deg)

--- a/tests/test_pad_offset_keepout.py
+++ b/tests/test_pad_offset_keepout.py
@@ -18,8 +18,11 @@ from routing_utils import pad_blocked_cells_array, iter_pad_blocked_cells
 
 def run():
     fails = []
+    total = 0
 
     def check(name, cond):
+        nonlocal total
+        total += 1
         if not cond:
             fails.append(name)
 
@@ -52,11 +55,31 @@ def run():
     check("cell beyond margin stays free", (0, 13) not in blocked(off_y))
 
     # iter_pad_blocked_cells (plane generator) must agree with the array twin.
-    gen = {(gx, gy) for gx, gy in
-           iter_pad_blocked_cells(pad_gx, pad_gy, half_w, half_h, margin, grid,
-                                  corner_radius=0.0, off_y=off_y)}
+    # NOTE the ordering is load-bearing: `blocked()` above has already run, so
+    # pad_blocked_cells_array's memo (_PAD_OFFSETS_CACHE) is WARM for exactly
+    # this geometry key. The generator must not be served from that cache --
+    # see the "DELIBERATELY NOT MEMOIZED" note in routing_utils. A memo
+    # fast-path pasted into the generator returns instead of yielding, so it
+    # emits zero cells and every pad silently loses its keep-out (02f5375a,
+    # shipped in v0.20.4).
+    def gen_cells(off):
+        return {(gx, gy) for gx, gy in
+                iter_pad_blocked_cells(pad_gx, pad_gy, half_w, half_h, margin,
+                                       grid, corner_radius=0.0, off_y=off)}
+
+    gen = gen_cells(off_y)
     check("generator blocks the sub-cell-inside cell too", target in gen)
     check("generator matches array twin", gen == blocked(off_y))
+    # Explicit non-emptiness, so a generator that yields nothing fails with a
+    # message that names the cause instead of only tripping the set compare.
+    check("generator yields cells on a WARM array-twin cache", len(gen) > 0)
+    # And it must stay independent of call order: cold-cache first, then warm.
+    for key_off, name in ((0.021, "cold"), (0.021, "warm-after-array")):
+        if name == "warm-after-array":
+            pad_blocked_cells_array(pad_gx, pad_gy, half_w, half_h, margin,
+                                    grid, corner_radius=0.0, off_y=key_off)
+        got = gen_cells(key_off)
+        check(f"generator is call-order independent ({name})", len(got) > 0)
 
     print("=" * 60)
     if fails:
@@ -66,7 +89,7 @@ def run():
         return 1
     print("  PASS  pad keepout measured from the real center: blocks the")
     print("        sub-cell-inside cell (array + generator agree), no over-block")
-    print("\n5/5 checks passed")
+    print(f"\n{total}/{total} checks passed")
     return 0
 
 


### PR DESCRIPTION
`iter_pad_blocked_cells` silently yields **no keep-out cells at all** once
`pad_blocked_cells_array` has run for the same pad geometry.

Introduced in 02f5375a (`perf: pad-offset memo + LRU/budget rework of the raster
caches`), shipped in **v0.20.4**. `tests/test_pad_offset_keepout.py` fails on stock
`main` because of it.

## The bug

02f5375a added the `_PAD_OFFSETS_CACHE` fast-path to `pad_blocked_cells_array`, and
pasted the same six lines into `iter_pad_blocked_cells`:

```python
offs = _PAD_OFFSETS_CACHE.get(key)
if offs is not None:
    out = np.empty_like(offs)
    np.add(offs, np.array([[pad_gx, pad_gy]], dtype=np.int32), out=out)
    return out          # <-- iter_pad_blocked_cells is a GENERATOR
```

`return <value>` inside a generator is not a result — it is a bare `StopIteration`.
So on every cache hit the generator yields nothing and the pad loses its keep-out
entirely, with no error and no warning.

The cache is shared between the two twins and **only the array twin writes to it**,
so the trigger is just "`pad_blocked_cells_array` ran first for this geometry" — the
normal case in any real obstacle build.

## Reproduce it

Save as `repro.py` in the repo root, on stock `main`:

```python
import os, sys
ROOT = os.path.dirname(os.path.abspath(__file__))
sys.path.insert(0, ROOT); sys.path.insert(0, os.path.join(ROOT, 'py_router'))
from routing_utils import iter_pad_blocked_cells, pad_blocked_cells_array

# One ordinary pad: 1.95 x 0.60 mm, 0.30 mm keep-out margin, 0.05 mm grid.
geom = dict(half_width=0.975, half_height=0.30, margin=0.30,
            grid_step=0.05, corner_radius=0.0, off_y=0.016)

print("generator, cold cache :", len(list(iter_pad_blocked_cells(0, 0, **geom))))
print("array twin            :", len(pad_blocked_cells_array(0, 0, **geom)))
print("generator, warm cache :", len(list(iter_pad_blocked_cells(0, 0, **geom))))
```

**Before (stock `main`, 52b006c7):**

```
generator, cold cache : 1214
array twin            : 1214
generator, warm cache :    0     <-- same pad, same args
```

**After (this PR):**

```
generator, cold cache : 1214
array twin            : 1214
generator, warm cache : 1214
```

The existing test catches it too — it calls the array twin before the generator, so
the cache is warm by the time it grades them against each other:

```
$ python3 tests/test_pad_offset_keepout.py     # on stock main
  FAIL  generator blocks the sub-cell-inside cell too
  FAIL  generator matches array twin
2 failure(s)
```

## The fix

**Drop the memo from the generator** rather than repair it.

Repairing it (yielding the cached rows instead of returning them) would fix the
crash-free-but-empty symptom, but sharing the twin's cache is wrong on its own
terms: this scalar rasterizer is the *independent reference implementation* that
`test_pad_offset_keepout.py` grades the vectorized twin against. Serving it out of
that twin's cache makes the cross-check vacuous — and only when the cache happens to
be warm, so it would pass or fail by call order.

The perf case for the memo (2.04M calls / 84s on orangecrab) is entirely
`pad_blocked_cells_array`'s. That is the twin every obstacle builder actually calls
(`obstacle_map`, `obstacle_cache`, `plane_obstacle_builder` all reach for the array
form), and it is **untouched** by this PR — no perf change. A comment at the site
records both reasons so the fast-path doesn't get pasted back in.

I also swept the tree for the same shape; this was the only generator in the
repository with a value-returning `return`.

## Blast radius

Small, and deliberately so:

- `pad_blocked_cells_array` — **unchanged**, so the hot obstacle-build path and the
  02f5375a speedup are unaffected.
- No production caller reaches `iter_pad_blocked_cells` today (the three modules
  that import it have all migrated to the array twin), so this is a latent defect
  rather than an active routing bug — but it is a documented public API
  (`docs/api-routing-config.md`, README) that currently returns nothing, and it
  breaks the suite at HEAD.
- No CLI/GUI parity surface: no flag, no default, no engine parameter.

## Testing

```
tests/test_pad_offset_keepout.py       FAIL on main  ->  PASS  (8/8 checks)
tests/run_all.py --fast                3 failed      ->  2 failed
tests/gui_parity/test_manifest_plan_parity.py    PASS (35 flag-checks, 0 mismatches)
tests/gui_parity/test_cli_postpass_coverage.py   PASS (0 failures, 0 warnings)
```

The two remaining `run_all --fast` failures are pre-existing and environmental on
this box, unrelated to this change:

- `test_gui_finalize_oracle_inrun.py` — wants `kicad_files/kit-out-plane.kicad_pcb`,
  which isn't in the repo.
- `test_live_board_zone_deletion.py` — Windows `cp1252` can't encode `Ω` from
  `plane_resistance.print_single_net_resistance`; passes under `python3 -X utf8`.

The test is also strengthened so this can't regress quietly: it now names the
warm-cache case, asserts the generator is non-empty, and checks both call orders,
instead of only tripping the set-compare as a side effect of test ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
