### PR TITLE
gate: point the finalize-oracle gate at a TRACKED fixture (it has never run)

### DIFF
--- a/tests/test_gui_finalize_oracle_inrun.py
+++ b/tests/test_gui_finalize_oracle_inrun.py
@@ -31,9 +31,23 @@ REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # Needs real zones AND at least one INCOMPLETE plane net: the finalize is a
 # plane pass, and a board whose pours are already whole exits before it ever
 # reaches the oracle leg (which is how two earlier fixture picks here made
-# the gate vacuously "pass"). This one has both GND and +3.3V pours reading
-# unconnected, and routes in seconds.
-BOARD = os.path.join(REPO, 'kicad_files', 'kit-out-plane.kicad_pcb')
+# the gate vacuously "pass").
+#
+# It must ALSO be a board a fresh clone actually has. The previous pick,
+# kit-out-plane.kicad_pcb, is an OUTPUT of tests/test_kit_route.py and was
+# untracked + gitignored by 25de9022 (#426) on 2026-07-18 -- 17 days before
+# this gate was written -- so it has never existed on any clone, and this
+# file has only ever run where a stale artifact happened to be left behind.
+# /kicad_files/kit-out*.kicad_pcb is still in .gitignore; do not point back
+# at it. Regenerating it is not an option either: it is a full route of
+# kit-dev-coldfire (minutes), which is exactly what tests/fixture_boards.py
+# declines to cover.
+#
+# lvds_converter_dualclk_gnd.kicad_pcb is TRACKED, carries a real /GND pour
+# that reads unconnected (the run's improvement gate reports the pour
+# gaining /GND, 42 -> 41 disconnected pads), and the whole gate runs in
+# under a second on it.
+BOARD = os.path.join(REPO, 'kicad_files', 'lvds_converter_dualclk_gnd.kicad_pcb')
 
 from kicad_parser import parse_kicad_pcb            # noqa: E402
 from route import batch_route                       # noqa: E402
@@ -48,12 +62,23 @@ def _run(with_callback):
         if os.path.exists(src):
             shutil.copy(src, board.replace('.kicad_pcb', ext))
 
+    if not os.path.exists(BOARD):
+        raise SystemExit(
+            f"FAIL: fixture board is missing: {BOARD}\n"
+            "  This gate needs a TRACKED board. A generated/gitignored one "
+            "makes it unrunnable on every fresh clone (see the note above).")
+
     pcb = parse_kicad_pcb(board)
     zone_nets = sorted({pcb.nets[z.net_id].name for z in (pcb.zones or [])
                         if z.net_id in pcb.nets})
     if not zone_nets:
-        print("SKIP: fixture board has no zone nets")
-        return None
+        # Deliberately NOT a skip. A fixture with no zone nets never reaches
+        # the plane finalize, so the gate would report success while testing
+        # nothing -- the silent non-coverage this file's own note warns about.
+        raise SystemExit(
+            "FAIL: fixture board has no zone nets, so the plane finalize -- "
+            "and the oracle leg this gate exists to check -- never runs. "
+            "Pick a fixture with a real, incomplete pour.")
 
     staged = []
 
@@ -80,8 +105,6 @@ def main():
     # 1. WITH a staging callback: the leg runs in-run, and the deferred
     #    hand-off to the applier must NOT be posted (both would double-run).
     r = _run(True)
-    if r is None:
-        return 0
     if r['staged'] < 1:
         failures.append("stage_board_fn was never called -- the finalize "
                         "did not try to stage a board for the oracle")


### PR DESCRIPTION
`tests/test_gui_finalize_oracle_inrun.py` reads a board that **no clone has**, so
the #562 regression it exists to catch has been unguarded since the day the gate
landed.

## The bug

```
25de9022  (#426, 2026-07-18)  untracked kit-out* and added
                              /kicad_files/kit-out*.kicad_pcb to .gitignore
8bfa9011  (      2026-08-04)  added this gate, reading exactly that path
```

The gate was written **17 days after its fixture stopped being tracked**. It has
only ever passed on a working copy where a stale artifact from an older
`test_kit_route.py` run happened to be left in `kicad_files/` — that test now
writes to a temp dir (which is what #426 was), so nothing regenerates it either.

## Reproduce it

Any fresh clone:

```bash
git clone https://github.com/drandyhaas/KiCadRoutingTools.git && cd KiCadRoutingTools
python3 build_router.py
python3 tests/test_gui_finalize_oracle_inrun.py; echo "exit=$?"
```

**Before (on `main`):**

```
FileNotFoundError: [Errno 2] No such file or directory:
  '.../kicad_files/kit-out-plane.kicad_pcb'
exit=1
```

Confirming it can never be there:

```bash
$ git log --all --oneline -- 'kicad_files/kit-out-plane*' | head -1
25de9022 #426: kit route test writes to a temp dir; untrack stale kit-out fixtures
$ git check-ignore -v kicad_files/kit-out-plane.kicad_pcb
.gitignore:48:/kicad_files/kit-out*.kicad_pcb   kicad_files/kit-out-plane.kicad_pcb
```

**After (this PR):**

```
GUI finalize oracle: runs in-run when a board can be staged, falls back to the
post-apply hand-off when it cannot. OK
exit=0
```

## The fix

Regenerating the old fixture is **not** the fix — it is a full route of
kit-dev-coldfire (minutes), which is exactly the cost `tests/fixture_boards.py`
deliberately declines to cover: *"a test wanting those should use a tracked board
instead."*

So this uses a tracked board. I probed every tracked board in `kicad_files/` for
the two properties the fixture note requires:

| tracked board | zone nets | reaches the oracle leg? |
|---|---|---|
| `flat_hierarchy.kicad_pcb` | `GND` | no — already fully connected, never reaches the finalize |
| `sonde_u.kicad_pcb` | `GND` | yes, but the pour reads complete |
| **`lvds_converter_dualclk_gnd.kicad_pcb`** | `/GND` | **yes, and the pour reads INCOMPLETE** |
| `kit-dev-coldfire-xilinx_5213.kicad_pcb` | `+3.3V`, `GND` | yes, but it is the minutes-long route |

`lvds_converter_dualclk_gnd.kicad_pcb` keeps both properties — a real pour, and one
that reads incomplete (the run's own improvement gate reports it gaining `/GND`,
42 → 41 disconnected pads) — and the whole gate runs in **under a second** on it.

## The new fixture is not a vacuous pass

The fixture note warns that *"two earlier fixture picks here made the gate vacuously
pass"*, so I checked rather than assumed. Re-introducing the #562 deferred-oracle
implementation (forcing the `stage_board_fn` branch off in `route.py`) makes the
gate fail with **both** of its intended messages:

```
FAIL:
  - stage_board_fn was never called -- the finalize did not try to stage a board
    for the oracle
  - deferred spec posted even though staging worked -- the oracle would run twice,
    and the in-run verdict is the one that can feed custody
exit=1
```

Summary:

```
on main                            exit 1   (FileNotFoundError -- gate cannot run)
with this change                   exit 0
with the #562 regression re-added  exit 1   (both intended failures)
```

## Also: stop it recurring silently

Two paths could put this gate back to "reports success while testing nothing":

- **missing fixture** — now fails loudly with a message naming the tracked-board
  requirement, instead of a raw `FileNotFoundError` from `shutil.copy`.
- **fixture with no zone nets** — was `print("SKIP"); return None`, which `main()`
  turned into `exit 0`. A board with no zone nets never reaches the plane finalize,
  so that is a green gate testing nothing — the same silent non-coverage this
  file's own fixture note, and `tests/fixture_boards.py`, warn about. Now a
  failure.

## Blast radius

Test-only. No engine, CLI, or GUI code is touched — no flag, no default, no engine
parameter, so the "Claude-settable end to end" checklist is inert.

## Testing

```
tests/test_gui_finalize_oracle_inrun.py     FAIL on main  ->  PASS
tests/run_all.py --fast                     212 passed, 2 failed, 46 skipped
```

The 2 remaining failures are unrelated to this change:

- `test_pad_offset_keepout.py` — a real bug on `main`, fixed separately in #634
  (this branch is cut from `main`, so it still fails here).
- `test_live_board_zone_deletion.py` — Windows `cp1252` can't encode `Ω` from
  `plane_resistance.print_single_net_resistance`; passes under `python3 -X utf8`.
  It calls `create_plane` as a library, so it never gets the
  `enable_utf8_console()` that the CLI `main()`s install. Happy to file that
  separately if you want it fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
