### PR TITLE
placement: the swallow probe must see milled contours too (#628, legality half)

### DIFF
--- a/py_router/placement/legality.py
+++ b/py_router/placement/legality.py
@@ -28,6 +28,14 @@ interior cutout -- a part gets nudged into the hole. `BoardOutlineGate` measures
 against the real Edge.Cuts rings, with the three-level short-circuit that makes
 it affordable: board-level opt-out when the outline IS its bbox, a cached
 per-part reachable-disk prune, then the exact ring test.
+
+**An interior ring can be SWALLOWED WHOLE.** Both exact tests work from the
+rect's four corners and four edges, so a rect large enough to contain an entire
+interior ring passes them: no corner is off-board and no rect edge comes within
+the margin of a ring edge. The swallow probe (`_swallow_pts`) is what closes
+that hole, and it must see BOTH kinds of interior ring -- `board_cutouts` AND
+the milled `board_edge_contours` that `drop_pad_containing_cutouts`
+reclassified (#505). It saw only the former until #628.
 """
 from __future__ import annotations
 
@@ -210,6 +218,16 @@ class BoardOutlineGate:
     Caching note: a key's answer is computed from the pose and budget of the
     FIRST call, so a caller whose budget grows later must use a distinct key.
     Over-estimating `travel` is always safe (more edges, same verdict).
+
+    Three ring collections, and they mean different things:
+
+    * `cutouts` -- real holes. Also drive the on-board (inside-outline,
+      outside-cutouts) point test, so their INTERIOR is off-board.
+    * `milled` -- `board_edge_contours` (#505): Edge.Cuts geometry KiCad mills
+      along that is neither a hole nor an outer ring. They carry an EDGE
+      CLEARANCE role only; they are deliberately NOT given containment
+      semantics -- see `_swallow_pts`.
+    * `rings` -- the flat union, what the distance tests measure against.
     """
 
     def __init__(self, board_info, margin: float):
@@ -221,6 +239,27 @@ class BoardOutlineGate:
         self.rings = rings
         self.outer = outer
         self.cutouts = cutouts
+        # Milled interior contours (#505). Already inside `rings` (that is what
+        # board_edge_geometry does with them), so the distance tests see them;
+        # kept separately because the SWALLOW probe needs them too (#628).
+        self.milled = [c for c in
+                       (getattr(board_info, 'board_edge_contours', None) or [])
+                       if len(c) >= 3]
+        # One representative vertex per interior ring, for the swallow probe in
+        # rect_blocked / rect_outside_amount. Any vertex serves: a ring wholly
+        # inside the rect has every vertex inside it, and a ring only partly
+        # inside is already caught by the corner and edge tests.
+        #
+        # DELIBERATELY NOT a containment rule. A milled contour's interior is
+        # NOT declared off-board here, and must not be: board_edge_contours
+        # mixes a real inner OUTLINE (interior = board -- crkbd's nested half,
+        # bus_pirate5's 60.8x80.2mm inner ring) with a milled SLOT (interior =
+        # not board), and the parser cannot tell them apart. Calling the
+        # interior off-board re-opens #291, where bus_pirate5 lost all 870 pads
+        # and the run broke the chain. "A part may not swallow a milled ring"
+        # is true for both readings, which is exactly why it is safe.
+        self._swallow_pts = ([r[0] for r in self.cutouts]
+                             + [r[0] for r in self.milled])
         self.margin = margin
         self.bounds = getattr(board_info, 'board_bounds', None)
         self.usable = None
@@ -291,8 +330,9 @@ class BoardOutlineGate:
 
     # -- level 3: the exact tests
     def rect_blocked(self, rect, edges=None) -> bool:
-        """True when a rect leaves the real outline, enters a cutout, or comes
-        within the edge margin of either.
+        """True when a rect leaves the real outline, enters a cutout, comes
+        within the edge margin of any Edge.Cuts ring, or SWALLOWS an interior
+        ring (a cutout or a milled contour) whole.
 
         `edges` restricts the distance test to a pre-filtered edge list from
         `edges_near`; omitted, every ring edge is measured.
@@ -308,9 +348,9 @@ class BoardOutlineGate:
                 if _seg_seg_dist_coords(ax, ay, bx, by,
                                         ex1, ey1, ex2, ey2) < self.margin:
                     return True
-        # A cutout ring FULLY INSIDE the rect evades both tests above.
-        for cut in self.cutouts:
-            cx, cy = cut[0]
+        # An interior ring FULLY INSIDE the rect evades both tests above -- no
+        # corner is off-board and no rect edge comes near a ring edge (#628).
+        for (cx, cy) in self._swallow_pts:
             if x0 <= cx <= x1 and y0 <= cy <= y1:
                 return True
         return False
@@ -359,8 +399,10 @@ class BoardOutlineGate:
                     default=float('inf'))
             if d < self.margin:
                 amt += self.margin - d
-        for cut in self.cutouts:
-            cx, cy = cut[0]
+        # Swallowed interior ring (cutout or milled contour), same probe and
+        # same charge as rect_blocked's -- the two must agree on legality or
+        # `violation()==0` stops implying `not rect_blocked()` (#628).
+        for (cx, cy) in self._swallow_pts:
             if x0 <= cx <= x1 and y0 <= cy <= y1:
                 amt += self.margin
         return amt

--- a/tests/test_628_milled_contour_legality.py
+++ b/tests/test_628_milled_contour_legality.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Regression test for issue #628 (LIVE half) -- a candidate rect that SWALLOWS a
+milled interior contour whole was judged LEGAL.
+
+`BoardOutlineGate`'s two exact tests work from a rect's four corners and four
+edges. A rect large enough to contain an entire interior ring passes both: every
+corner is on-board (a milled contour is not a cutout, so it does not make its
+interior off-board) and no rect edge comes within the margin of a ring edge. The
+"swallowed ring" probe exists precisely for that case -- but it iterated
+`self.cutouts` only, so it never saw `board_edge_contours`, the milled Edge.Cuts
+geometry `drop_pad_containing_cutouts` reclassifies (#505). A part could be
+placed straight over a milled slot and `violation()` reported 0.0.
+
+The boundary-CROSSING case was already handled (the rect's own edges come within
+the margin of the milled ring's edges, and `board_edge_geometry` puts those rings
+in `rings`); this test pins that as a control so the fix is not mistaken for it.
+
+NOT part of the fix, deliberately: milled contours are given no CONTAINMENT
+semantics. `board_edge_contours` mixes a real inner OUTLINE (interior = board:
+crkbd, bus_pirate5) with a milled SLOT (interior = not board) and the parser
+cannot tell them apart, so declaring the interior off-board re-opens #291
+(bus_pirate5 lost all 870 pads). "A part may not swallow a milled ring" is true
+under both readings. The final check below pins that non-rule.
+
+    python3 tests/test_628_milled_contour_legality.py
+"""
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'py_router'))  # #522
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'py_tools'))  # #522
+
+from kicad_parser import parse_kicad_pcb  # noqa: E402
+from placement.legality import BoardOutlineGate  # noqa: E402
+from placement.quench import QuenchState  # noqa: E402
+
+fails = []
+
+
+def check(name, cond):
+    print(("  ok  " if cond else " FAIL ") + name)
+    if not cond:
+        fails.append(name)
+
+
+# The canonical QuenchState knobs (same set tests/test_456_side_and_outline.py
+# uses); board_edge_clearance is the gate margin.
+KNOBS = dict(clearance=0.25, board_edge_clearance=0.55, crossing_penalty=10.0,
+             halo_base=0.3, halo_coef=0.15, halo_weight=1.0,
+             edge_halo=1.0, edge_weight=1.0, grid_step=0.05)
+MARGIN = KNOBS['board_edge_clearance']
+
+
+def _rect_edge(x1, y1, x2, y2, tag):
+    """Four Edge.Cuts gr_lines forming a closed axis-aligned rectangle."""
+    pts = [(x1, y1), (x2, y1), (x2, y2), (x1, y2)]
+    return "\n".join(
+        f' (gr_line (start {pts[i][0]} {pts[i][1]}) '
+        f'(end {pts[(i + 1) % 4][0]} {pts[(i + 1) % 4][1]}) '
+        f'(layer "Edge.Cuts") (width 0.05) (uuid "{tag}{i}"))' for i in range(4))
+
+
+def _board(inner_pads: bool) -> str:
+    """Board outline 0..60 x 0..40 with an interior Edge.Cuts ring 20..24 x 19..21.
+
+    `inner_pads` puts two pads inside that ring, which is what makes
+    drop_pad_containing_cutouts RECLASSIFY it from a cutout into a milled
+    contour (board_edge_contours). Without them it stays a genuine cutout --
+    the control fixture for the half of the probe that already worked.
+
+    SW17 is a front-side part with an 8x8mm courtyard, seeded at (30, 20) where
+    it is clear of everything; the pose under test is (22, 20), whose courtyard
+    18..26 x 16..24 contains the whole interior ring. The pads inside the ring
+    live on a BACK-side part, so no courtyard overlap can confound the verdict.
+    """
+    inner = ''
+    if inner_pads:
+        inner = '''
+ (footprint "test:slot" (layer "B.Cu") (at 22 20)
+  (property "Reference" "B1" (at 0 -2) (layer "B.SilkS"))
+  (fp_rect (start -0.3 -0.3) (end 0.3 0.3) (layer "B.CrtYd") (uuid "cyB1"))
+  (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "B.Cu") (net 1 "NA") (uuid "pB1a"))
+  (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "B.Cu") (net 1 "NA") (uuid "pB1b"))
+ )'''
+    return f'''(kicad_pcb
+ (version 20241229)
+ (net 0 "")
+ (net 1 "NA")
+ (net 2 "NB")
+{_rect_edge(0, 0, 60, 40, 'o')}
+{_rect_edge(20, 19, 24, 21, 'm')}{inner}
+ (footprint "test:sw" (layer "F.Cu") (at 30 20)
+  (property "Reference" "SW17" (at 0 -2) (layer "F.SilkS"))
+  (fp_rect (start -4 -4) (end 4 4) (layer "F.CrtYd") (uuid "cySW"))
+  (pad "1" smd rect (at -1 0) (size 0.6 0.6) (layers "F.Cu") (net 2 "NB") (uuid "pSWa"))
+  (pad "2" smd rect (at 1 0) (size 0.6 0.6) (layers "F.Cu") (net 2 "NB") (uuid "pSWb"))
+ )
+)
+'''
+
+
+def _write(inner_pads: bool):
+    fd, path = tempfile.mkstemp(suffix='.kicad_pcb')
+    with os.fdopen(fd, 'w') as f:
+        f.write(_board(inner_pads))
+    return path
+
+
+SWALLOW = (18.0, 16.0, 26.0, 24.0)   # SW17's courtyard at (22, 20)
+CROSSING = (22.0, 16.0, 30.0, 24.0)  # straddles the ring's right edge
+CLEAR = (40.0, 5.0, 44.0, 9.0)       # nowhere near anything
+
+
+# --------------------------------------------------------------------------
+# 1. Fixture sanity. If the reclassification ever stops happening, the interior
+#    ring degrades into a plain board_cutouts entry and the swallow probe would
+#    catch it for the WRONG reason -- these two checks make that a failure.
+# --------------------------------------------------------------------------
+def test_fixture_is_a_milled_contour_not_a_cutout():
+    path = _write(inner_pads=True)
+    try:
+        bi = parse_kicad_pcb(path).board_info
+        ec = [c for c in (getattr(bi, 'board_edge_contours', None) or [])
+              if len(c) >= 3]
+        cut = [c for c in (bi.board_cutouts or []) if len(c) >= 3]
+        check("fixture: exactly one milled contour (board_edge_contours == 1)",
+              len(ec) == 1)
+        check("fixture: NOT a cutout (board_cutouts == 0)", len(cut) == 0)
+        gate = BoardOutlineGate(bi, MARGIN)
+        check("fixture: gate is active (outline + milled ring = 2 rings)",
+              gate.active and len(gate.rings) == 2)
+        # getattr, not attribute access: on the unfixed gate this attribute does
+        # not exist and the test must report a clean FAIL here rather than
+        # aborting before it reaches the substantive checks below.
+        check("gate.milled carries the contour",
+              len(getattr(gate, 'milled', None) or []) == 1)
+        check("fixture: the swallow rect is INSIDE the bbox inset "
+              "(so only the ring tests can reject it)",
+              gate.bbox_outside_amount(SWALLOW) == 0.0)
+    finally:
+        os.unlink(path)
+
+
+# --------------------------------------------------------------------------
+# 2. The bug: a rect that swallows the milled contour whole.
+# --------------------------------------------------------------------------
+def test_swallowed_milled_contour_is_illegal():
+    path = _write(inner_pads=True)
+    try:
+        gate = BoardOutlineGate(parse_kicad_pcb(path).board_info, MARGIN)
+        check("swallowed milled contour -> rect_blocked",
+              gate.rect_blocked(SWALLOW) is True)
+        amt = gate.rect_outside_amount(SWALLOW)
+        check(f"swallowed milled contour -> rect_outside_amount > 0 ({amt})",
+              amt > 0.0)
+        # The two must agree, or `violation()==0` stops implying the hard gate
+        # passes and the unfreeze branch can walk a part into a blocked pose.
+        check("rect_blocked and rect_outside_amount agree on the swallow",
+              gate.rect_blocked(SWALLOW) == (amt > 0.0))
+    finally:
+        os.unlink(path)
+
+
+# --------------------------------------------------------------------------
+# 3. Controls: the CROSSING case must stay caught (it already was, #505), and a
+#    rect nowhere near the geometry must stay legal (no over-rejection).
+# --------------------------------------------------------------------------
+def test_crossing_and_clear_rects_are_unchanged():
+    path = _write(inner_pads=True)
+    try:
+        gate = BoardOutlineGate(parse_kicad_pcb(path).board_info, MARGIN)
+        check("control: a rect CROSSING the milled contour is still blocked",
+              gate.rect_blocked(CROSSING) is True)
+        check("control: ...and still scores a violation",
+              gate.rect_outside_amount(CROSSING) > 0.0)
+        check("control: a rect clear of everything is still legal",
+              gate.rect_blocked(CLEAR) is False)
+        check("control: ...and still scores 0",
+              gate.rect_outside_amount(CLEAR) == 0.0)
+    finally:
+        os.unlink(path)
+
+
+# --------------------------------------------------------------------------
+# 4. The cutout half of the probe is untouched: the same geometry WITHOUT the
+#    enclosed pads stays a genuine board cutout and is still swallow-detected.
+# --------------------------------------------------------------------------
+def test_genuine_cutout_swallow_still_detected():
+    path = _write(inner_pads=False)
+    try:
+        bi = parse_kicad_pcb(path).board_info
+        cut = [c for c in (bi.board_cutouts or []) if len(c) >= 3]
+        check("control fixture: no enclosed pads -> stays a real cutout",
+              len(cut) == 1)
+        gate = BoardOutlineGate(bi, MARGIN)
+        check("control: a swallowed CUTOUT is blocked (pre-existing behaviour)",
+              gate.rect_blocked(SWALLOW) is True)
+        check("control: ...and scores a violation",
+              gate.rect_outside_amount(SWALLOW) > 0.0)
+    finally:
+        os.unlink(path)
+
+
+# --------------------------------------------------------------------------
+# 5. End to end through the optimizer's hard gate: SW17 is seeded clear at
+#    (30, 20) and must not be allowed to move onto the milled slot.
+# --------------------------------------------------------------------------
+def test_quench_candidate_over_a_milled_slot_is_refused():
+    path = _write(inner_pads=True)
+    try:
+        pcb = parse_kicad_pcb(path)
+        st = QuenchState(pcb, path, **KNOBS)
+        check("fixture: SW17's seed pose is legal",
+              st.violation('SW17') == 0.0)
+        check("fixture: the candidate pose is inside the bbox inset",
+              st.usable[0] <= SWALLOW[0] and st.usable[1] <= SWALLOW[1]
+              and SWALLOW[2] <= st.usable[2] and SWALLOW[3] <= st.usable[3])
+        check("candidate_valid refuses a pose swallowing the milled slot",
+              not st.candidate_valid('SW17', 22.0, 20.0, 0.0))
+        check("violation() scores that pose as illegal",
+              st.violation('SW17', 22.0, 20.0, 0.0) > 0.0)
+        # ... and a genuinely clear pose is still accepted.
+        check("a clear pose is still accepted",
+              st.candidate_valid('SW17', 45.0, 20.0, 0.0))
+    finally:
+        os.unlink(path)
+
+
+# --------------------------------------------------------------------------
+# 6. The #291 trap: the fix must add NO containment rule. A milled contour's
+#    interior stays ON-BOARD -- a small part sitting inside the slot is judged
+#    by clearance to the milled edges, never by "you are in a hole".
+# --------------------------------------------------------------------------
+def test_milled_interior_is_not_declared_off_board():
+    path = _write(inner_pads=True)
+    try:
+        bi = parse_kicad_pcb(path).board_info
+        gate = BoardOutlineGate(bi, MARGIN)
+        check("milled contour is NOT in gate.cutouts (the on-board test)",
+              not gate.cutouts)
+        from check_drc import _point_on_board  # noqa: E402
+        check("a point INSIDE the milled contour is still on-board (#291)",
+              _point_on_board(22.0, 20.0, gate.outer, gate.cutouts))
+        # A tiny rect wholly inside the ring swallows nothing and leaves the
+        # board nowhere; only the margin to the milled edges may bite it. At
+        # 22 +/- 0.2 x 20 +/- 0.2 the nearest milled edge is 0.8mm away.
+        tiny = (21.8, 19.8, 22.2, 20.2)
+        check("a small part inside the milled slot is judged by CLEARANCE only",
+              gate.rect_blocked(tiny) is False
+              and gate.rect_outside_amount(tiny) == 0.0)
+    finally:
+        os.unlink(path)
+
+
+def run():
+    for t in (test_fixture_is_a_milled_contour_not_a_cutout,
+              test_swallowed_milled_contour_is_illegal,
+              test_crossing_and_clear_rects_are_unchanged,
+              test_genuine_cutout_swallow_still_detected,
+              test_quench_candidate_over_a_milled_slot_is_refused,
+              test_milled_interior_is_not_declared_off_board):
+        print(f"--- {t.__name__}")
+        t()
+    print()
+    if fails:
+        print("FAILED: %d check(s): %s" % (len(fails), fails))
+        return 1
+    print("All checks passed")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(run())


### PR DESCRIPTION
Refs #628 — closes the **legality half only**. Please keep the issue open; see
"What this does not close" below.

## The bug

`BoardOutlineGate`'s two exact tests both work from a rect's four corners and four
edges. A rect large enough to **contain an entire interior ring** passes both: no
corner is off-board, and no rect edge comes within the margin of a ring edge. The
swallow probe in `rect_blocked` / `rect_outside_amount` exists precisely to close
that hole — but it iterated `self.cutouts` only, so it never saw the milled
`board_edge_contours` that `drop_pad_containing_cutouts` reclassified (#505).

Result: a part whose courtyard swallows a milled slot whole passes every placement
gate.

## Reproduce it

The new test is the reproduction. Against `main`:

```bash
git checkout main -- py_router/placement/legality.py
python3 tests/test_628_milled_contour_legality.py
```

**Before:**

```
 FAIL gate.milled carries the contour
 FAIL swallowed milled contour -> rect_blocked
 FAIL swallowed milled contour -> rect_outside_amount > 0 (0.0)
 FAIL candidate_valid refuses a pose swallowing the milled slot
 FAIL violation() scores that pose as illegal
FAILED: 5 check(s)
exit=1
```

**After:** `exit=0`, all checks pass.

The fixture is synthetic: outline 0..60 × 0..40, a milled slot 20..24 × 19..21
containing two pads (so `drop_pad_containing_cutouts` reclassifies it), and an SW17
courtyard 18..26 × 16..24 that swallows the slot. It asserts
`board_edge_contours == 1` **and** `board_cutouts == 0` up front, so it cannot pass
for the wrong reason if the fixture ever degrades into a plain cutout.

## The fix

`BoardOutlineGate.__init__` now also captures the milled contours and precomputes
one representative vertex per interior ring:

```python
self._swallow_pts = [r[0] for r in self.cutouts] + [r[0] for r in self.milled]
```

and both probes iterate that instead of `self.cutouts`. `return True` /
`amt += self.margin` are unchanged, so the two methods keep their invariant
(`violation() == 0` still implies `not rect_blocked()`).

Any vertex serves as the representative: a ring wholly inside the rect has every
vertex inside it, and a ring only partly inside is already caught by the corner and
edge tests.

### What this deliberately does NOT do

It does **not** give milled contours containment semantics ("the interior is
off-board"). `board_edge_contours` mixes a real inner **outline** (interior = board:
crkbd's nested half, bus_pirate5's inner ring) with a milled **slot** (interior =
not board), and the parser cannot tell them apart. Declaring the interior off-board
re-opens #291, where bus_pirate5 lost all 870 pads.

*"A part may not swallow a milled ring"* is true under **both** readings — which is
exactly why this fix is safe. There is a test pinning that the interior stays
on-board.

## Blast radius

Placement-only (`py_router/placement/legality.py`); no copper is touched, so DRC and
connectivity deltas are impossible by construction. No flag, no default, no engine
parameter — the "Claude-settable end to end" checklist is inert.

**Inertness on existing fixtures is measured, not asserted.** Parsing every board in
`kicad_files/`:

```
boards scanned: 27
boards with a non-empty board_edge_contours: 0
=> _swallow_pts is byte-identical to the old cutouts-only probe on all of them
```

So every existing test is provably unaffected.

## What this does not close

The issue also names `check_reachability`, `check_assembly` and
`placement/seeder.py`. Those do not exist in this repository:

```
check_reachability       : 0 hits
check_assembly           : 0 hits
placement/seeder.py      : 0 hits
```

They appear to be the reporter's own harness, so I have not touched that half —
hence "Refs", not "Fixes". You may want to split the issue.

Also worth noting: the issue's headline premise ("`legality.py` never consumes the
classification") is **stale** since #505 — the boundary-*crossing* case already
works. The live defect is the swallowed-whole sibling, which is what this fixes.

## Testing

```
tests/test_628_milled_contour_legality.py     FAIL (5 checks) on main -> PASS
tests/run_all.py --fast                       212 passed, 3 failed, 46 skipped
tests/gui_parity/test_manifest_plan_parity.py    exit 0
tests/gui_parity/test_cli_postpass_coverage.py   exit 0
```

The 3 failures are identical to the `main` baseline on this box and unrelated to
this change — `test_pad_offset_keepout.py` (real bug on main, fixed in #634),
`test_gui_finalize_oracle_inrun.py` (missing fixture, fixed in #635), and
`test_live_board_zone_deletion.py` (Windows cp1252 vs `Ω`; passes under
`python3 -X utf8`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
