### PR TITLE
placement: scope the milled-ring swallow rule to NON-owners (#628 follow-up)

### DIFF
--- a/py_router/placement/fanout_clearance.py
+++ b/py_router/placement/fanout_clearance.py
@@ -244,7 +244,13 @@ class _Repair:
         # _blocked_geom. Per-cap laziness: only caps whose reachable disk can
         # touch a ring pay for the exact test. The gate itself now lives in
         # placement/legality.py, shared with quench (#456 item 2).
-        self.edge_gate = BoardOutlineGate(pcb_data.board_info, margin)
+        # footprints=: milled-ring ownership, so a cap over its own milled relief
+        # is not blocked at its seed pose (#628 follow-up). Threaded here as well
+        # as in quench because this engine runs the SAME swallow rule through the
+        # same gate -- a cap whose two pads are what got the ring reclassified
+        # would otherwise have every candidate rejected and freeze.
+        self.edge_gate = BoardOutlineGate(pcb_data.board_info, margin,
+                                          footprints=pcb_data.footprints)
         self._edge_margin = margin
         self._edge_active = self.edge_gate.active
         self._max_disp_cap = max_displacement_cap
@@ -519,11 +525,14 @@ class _Repair:
             ref, cap.rect(cap.seed_x, cap.seed_y, cap.seed_rot),
             self._max_disp_cap)
 
-    def _rect_edge_blocked(self, rect):
+    def _rect_edge_blocked(self, rect, ref=None):
         """True when a candidate courtyard rect leaves the REAL board outline,
         enters a cutout, or comes within the edge margin of either (#370 B2 --
-        the bbox `usable` inset is blind to cutouts / curved outlines)."""
-        return self.edge_gate.rect_blocked(rect)
+        the bbox `usable` inset is blind to cutouts / curved outlines).
+
+        `ref` exempts the mover from the swallow rule on milled rings it owns
+        (#628 follow-up); real cutouts are never exempt."""
+        return self.edge_gate.rect_blocked(rect, ref=ref)
 
     def _overlap(self, a, b):
         """Courtyard-clearance shortfall between two rects (0 if clear)."""
@@ -655,7 +664,7 @@ class _Repair:
         # Real outline / cutout gate (#370 B2): only when the bbox inset is
         # not exact (non-rect outline or cutouts) and this cap can reach one.
         if self._edge_active and self._cap_may_reach_edge(ref, cap) \
-                and self._rect_edge_blocked(rect):
+                and self._rect_edge_blocked(rect, ref=ref):
             return True
         # only same-side parts/caps within reach can collide (pre-pruned)
         for idx, r in self.cap_static[ref]:

--- a/py_router/placement/legality.py
+++ b/py_router/placement/legality.py
@@ -36,6 +36,25 @@ the margin of a ring edge. The swallow probe (`_swallow_pts`) is what closes
 that hole, and it must see BOTH kinds of interior ring -- `board_cutouts` AND
 the milled `board_edge_contours` that `drop_pad_containing_cutouts`
 reclassified (#505). It saw only the former until #628.
+
+**...but a milled ring's OWNER may swallow its own relief.** `board_edge_contours`
+has exactly one producer -- `drop_pad_containing_cutouts` -- and it moves a
+contour there only when the contour encloses **>= 2 pad centres**. So every
+milled contour has a part living inside it BY CONSTRUCTION, and when that part's
+courtyard is bigger than the ring (a connector over a milled relief) the #628
+probe called the part board-violating at its own hand-placed seed pose. That is
+not a hole in the board the part fell into; it is the part's own relief. Charging
+it there is worse than useless: `violation()` going 0 -> margin at the seed hands
+quench's unfreeze branch (`quench.py:686-700`, which accepts any overlap-free
+pose whose board term merely DECREASES) a licence to walk the part toward a real
+board edge, and makes the #456 scorecard report a correct hand placement as
+`oob_count 1`. So the milled half of the probe is scoped by OWNERSHIP: the gate
+precomputes ring -> owning refs at the SEED poses (stable board geometry, computed
+once), and `rect_blocked`/`rect_outside_amount` take an optional `ref` that skips
+the rings that ref owns. `ref=None` is exactly the pre-#636 behaviour, so a caller
+that does not pass one is unchanged. Two things this deliberately does NOT do:
+real `cutouts` are never owner-skipped (a part may never swallow a real hole), and
+nothing here gives milled contours containment semantics (see `_swallow_pts`).
 """
 from __future__ import annotations
 
@@ -196,6 +215,62 @@ def pair_overlap_area(a_sides, a_side, a_rect, a_tht,
     return worst
 
 
+# --- milled-ring ownership ---------------------------------------------------
+
+def _iter_footprints(footprints) -> Iterable:
+    """Footprint objects from either a {ref: fp} mapping or a plain iterable."""
+    if footprints is None:
+        return ()
+    values = getattr(footprints, 'values', None)
+    return values() if callable(values) else footprints
+
+
+def ring_owner_refs(ring, footprints) -> frozenset:
+    """Component refs with at least one PAD CENTRE inside `ring`.
+
+    The ownership predicate for the milled-ring swallow rule. It mirrors the
+    producer: `drop_pad_containing_cutouts` reclassifies a contour into
+    `board_edge_contours` exactly when >= 2 pad centres fall inside it, using
+    this same ray-cast test, so "the ring encloses this part's own pads" is
+    precisely "this part is (part of) the reason the ring is milled geometry".
+
+    The threshold here is >= 1, not the producer's >= 2, and that is deliberate:
+    the producer counts pads BOARD-WIDE, so a ring can be reclassified by one pad
+    from each of two parts. Requiring 2 per part would then charge both of them
+    for their own shared relief -- the same regression, one arity up. Each part
+    is exempted only for the rings its own pads sit in; a ring it has no pad in
+    is still a foreign relief it may not swallow.
+
+    Poses are the SEED poses (`pad.global_x/global_y` as parsed). A ring's owner
+    is stable board geometry, so this is computed once at gate construction
+    rather than re-derived per candidate pose.
+    """
+    if len(ring) < 3:
+        return frozenset()
+    xs = [p[0] for p in ring]
+    ys = [p[1] for p in ring]
+    rx0, rx1, ry0, ry1 = min(xs), max(xs), min(ys), max(ys)
+    # Local import: this module is imported at the top of both placement
+    # engines and otherwise pulls nothing but math/typing.
+    from kicad_parser import _pt_in_ring
+    owners = set()
+    for fp in _iter_footprints(footprints):
+        ref = getattr(fp, 'reference', None)
+        if not ref or ref in owners:
+            continue
+        for pad in (getattr(fp, 'pads', None) or ()):
+            px = getattr(pad, 'global_x', None)
+            py = getattr(pad, 'global_y', None)
+            if px is None or py is None:
+                continue
+            if not (rx0 <= px <= rx1 and ry0 <= py <= ry1):
+                continue        # bbox prune before the ray cast
+            if _pt_in_ring(px, py, ring):
+                owners.add(ref)
+                break
+    return frozenset(owners)
+
+
 # --- board outline gate ------------------------------------------------------
 
 class BoardOutlineGate:
@@ -226,11 +301,18 @@ class BoardOutlineGate:
     * `milled` -- `board_edge_contours` (#505): Edge.Cuts geometry KiCad mills
       along that is neither a hole nor an outer ring. They carry an EDGE
       CLEARANCE role only; they are deliberately NOT given containment
-      semantics -- see `_swallow_pts`.
+      semantics -- see `_swallow_pts`. Each has an OWNER set (`milled_owners`,
+      parallel list): the refs whose own pads sit inside it, which the swallow
+      rule does not fire on -- see `ring_owner_refs`.
     * `rings` -- the flat union, what the distance tests measure against.
+
+    Pass `footprints` (a `{ref: Footprint}` mapping or any iterable of
+    footprints, i.e. `pcb_data.footprints`) to enable the ownership scoping;
+    without it every milled ring is ownerless and the gate behaves exactly as it
+    did before, which is what keeps a caller that does not supply them unchanged.
     """
 
-    def __init__(self, board_info, margin: float):
+    def __init__(self, board_info, margin: float, footprints=None):
         # Function-local import: check_drc pulls the DRC stack, and this module
         # is imported at the top of both placement engines. Same reason
         # fanout_clearance imported it locally.
@@ -245,10 +327,24 @@ class BoardOutlineGate:
         self.milled = [c for c in
                        (getattr(board_info, 'board_edge_contours', None) or [])
                        if len(c) >= 3]
+        # ring -> the refs that own it, computed ONCE from the seed poses. Every
+        # milled contour encloses >= 2 pad centres by construction (that is the
+        # reclassification predicate), so this is never uniformly empty on a
+        # board that has one -- unless no footprints were supplied.
+        self.milled_owners = [ring_owner_refs(c, footprints) for c in self.milled]
         # One representative vertex per interior ring, for the swallow probe in
-        # rect_blocked / rect_outside_amount. Any vertex serves: a ring wholly
-        # inside the rect has every vertex inside it, and a ring only partly
-        # inside is already caught by the corner and edge tests.
+        # rect_blocked / rect_outside_amount, paired with the ring's owner set.
+        # Any vertex serves: a ring wholly inside the rect has every vertex
+        # inside it, and a ring only partly inside is already caught by the
+        # corner and edge tests.
+        #
+        # CUTOUTS ARE ALWAYS OWNERLESS (empty set), and that is a rule, not an
+        # accident of the data: a part may never swallow a real hole, owner or
+        # not. Ownership is vacuous there anyway -- a ring enclosing >= 2 pad
+        # centres is not a cutout by the time it reaches here (it was
+        # reclassified) -- but a cutout enclosing ONE pad centre survives as a
+        # cutout, so the exemption has to be denied explicitly rather than left
+        # to the arithmetic.
         #
         # DELIBERATELY NOT a containment rule. A milled contour's interior is
         # NOT declared off-board here, and must not be: board_edge_contours
@@ -256,10 +352,13 @@ class BoardOutlineGate:
         # bus_pirate5's 60.8x80.2mm inner ring) with a milled SLOT (interior =
         # not board), and the parser cannot tell them apart. Calling the
         # interior off-board re-opens #291, where bus_pirate5 lost all 870 pads
-        # and the run broke the chain. "A part may not swallow a milled ring"
-        # is true for both readings, which is exactly why it is safe.
-        self._swallow_pts = ([r[0] for r in self.cutouts]
-                             + [r[0] for r in self.milled])
+        # and the run broke the chain. "A part may not swallow a milled ring it
+        # does not own" is true for both readings, which is exactly why it is
+        # safe.
+        self._swallow_pts = (
+            [(r[0][0], r[0][1], frozenset()) for r in self.cutouts]
+            + [(c[0][0], c[0][1], own)
+               for c, own in zip(self.milled, self.milled_owners)])
         self.margin = margin
         self.bounds = getattr(board_info, 'board_bounds', None)
         self.usable = None
@@ -329,13 +428,21 @@ class BoardOutlineGate:
         return bool(self.edges_near(key, seed_rect, travel, center))
 
     # -- level 3: the exact tests
-    def rect_blocked(self, rect, edges=None) -> bool:
+    def rect_blocked(self, rect, edges=None, ref=None) -> bool:
         """True when a rect leaves the real outline, enters a cutout, comes
         within the edge margin of any Edge.Cuts ring, or SWALLOWS an interior
-        ring (a cutout or a milled contour) whole.
+        ring (a cutout or a milled contour it does not own) whole.
 
         `edges` restricts the distance test to a pre-filtered edge list from
         `edges_near`; omitted, every ring edge is measured.
+
+        `ref` is the component being tested. Naming it exempts the rect from the
+        swallow rule on the MILLED rings that ref owns -- its own relief, not a
+        hole it fell into. `ref=None` (the default) charges every ring, which is
+        the pre-#636 behaviour and keeps any caller that does not pass one
+        unchanged. Real cutouts are never exempt. `rect_outside_amount` applies
+        the identical skip; the two must agree or the documented
+        `rect_outside_amount == 0 iff not rect_blocked` invariant breaks.
         """
         from check_drc import _point_on_board, _seg_seg_dist_coords
         x0, y0, x1, y1 = rect
@@ -349,8 +456,11 @@ class BoardOutlineGate:
                                         ex1, ey1, ex2, ey2) < self.margin:
                     return True
         # An interior ring FULLY INSIDE the rect evades both tests above -- no
-        # corner is off-board and no rect edge comes near a ring edge (#628).
-        for (cx, cy) in self._swallow_pts:
+        # corner is off-board and no rect edge comes near a ring edge (#628),
+        # unless it is a milled ring this very part owns.
+        for (cx, cy, owners) in self._swallow_pts:
+            if ref is not None and ref in owners:
+                continue
             if x0 <= cx <= x1 and y0 <= cy <= y1:
                 return True
         return False
@@ -367,7 +477,8 @@ class BoardOutlineGate:
         return (max(0.0, u[0] - rect[0]) + max(0.0, u[1] - rect[1])
                 + max(0.0, rect[2] - u[2]) + max(0.0, rect[3] - u[3]))
 
-    def rect_outside_amount(self, rect, exact: bool = True, edges=None) -> float:
+    def rect_outside_amount(self, rect, exact: bool = True, edges=None,
+                            ref=None) -> float:
         """Magnitude of a rect's board-boundary violation; 0 iff fully legal.
 
         Zero exactly when the bbox inset holds AND `rect_blocked` is False, so
@@ -379,6 +490,10 @@ class BoardOutlineGate:
         established via `may_reach` that this rect cannot come near a ring. The
         ring terms are ~100x the cost of the bbox term, and in a hot candidate
         loop most parts are nowhere near an edge.
+
+        `ref` scopes the milled-ring swallow rule exactly as in `rect_blocked`,
+        and MUST be passed by any caller that passes it there -- the invariant
+        above is what lets `violation()==0` imply the hard gate passes.
         """
         amt = self.bbox_outside_amount(rect)
         if not (self.active and exact):
@@ -399,10 +514,13 @@ class BoardOutlineGate:
                     default=float('inf'))
             if d < self.margin:
                 amt += self.margin - d
-        # Swallowed interior ring (cutout or milled contour), same probe and
-        # same charge as rect_blocked's -- the two must agree on legality or
-        # `violation()==0` stops implying `not rect_blocked()` (#628).
-        for (cx, cy) in self._swallow_pts:
+        # Swallowed interior ring (cutout or unowned milled contour), same probe,
+        # same owner skip and same charge as rect_blocked's -- the two must agree
+        # on legality or `violation()==0` stops implying `not rect_blocked()`
+        # (#628).
+        for (cx, cy, owners) in self._swallow_pts:
+            if ref is not None and ref in owners:
+                continue
             if x0 <= cx <= x1 and y0 <= cy <= y1:
                 amt += self.margin
         return amt
@@ -481,14 +599,21 @@ def placement_overlap_area(parts: Sequence[GradedPart]) -> float:
 
 
 def placement_out_of_board(parts: Sequence[GradedPart], board_info,
-                           margin: float) -> OutOfBoard:
-    """OoB: how many parts leave the real board outline, and by how much."""
-    gate = BoardOutlineGate(board_info, margin)
+                           margin: float, footprints=None) -> OutOfBoard:
+    """OoB: how many parts leave the real board outline, and by how much.
+
+    `footprints` (`pcb_data.footprints`) enables the milled-ring ownership
+    scoping, so a connector sitting over its own milled relief is not graded
+    out-of-board (#628). Omitted, every milled ring is ownerless and the grade is
+    unchanged -- but a scorecard that has the footprints should pass them, or it
+    will report a correct hand placement as `oob_count 1`.
+    """
+    gate = BoardOutlineGate(board_info, margin, footprints=footprints)
     count = 0
     amount = 0.0
     area = 0.0
     for p in parts:
-        amt = gate.rect_outside_amount(p.rect)
+        amt = gate.rect_outside_amount(p.rect, ref=p.ref)
         if amt > EPS:
             count += 1
             amount += amt

--- a/py_router/placement/quench.py
+++ b/py_router/placement/quench.py
@@ -318,7 +318,11 @@ class QuenchState:
         # true Edge.Cuts rings and self-disables when the bbox inset is already
         # exact (single rectangular ring, no cutouts) or when the parser found no
         # usable ring at all -- in which case behaviour is unchanged.
-        self.edge_gate = BoardOutlineGate(pcb_data.board_info, margin)
+        # footprints=: lets the gate precompute which milled Edge.Cuts ring each
+        # part OWNS (its own pads sit inside it), so a connector over a milled
+        # relief is not board-violating at its own seed pose (#628 follow-up).
+        self.edge_gate = BoardOutlineGate(pcb_data.board_info, margin,
+                                          footprints=pcb_data.footprints)
         self.clearance = clearance
         self.crossing_penalty = crossing_penalty
         self.length_weight = length_weight
@@ -576,8 +580,11 @@ class QuenchState:
         # near a ring pays only the bbox term (the ring terms cost ~100x), and
         # one that can measures only against the edges it can actually reach.
         near = self._edges_near(ref) if self.edge_gate.active else None
+        # ref=: same owner scoping as candidate_valid's rect_blocked call. The
+        # two MUST pass the same ref or `violation()==0` stops implying the hard
+        # gate passes, which is the invariant the unfreeze branch rides on.
         board = self.edge_gate.rect_outside_amount(
-            rects[0], exact=bool(near), edges=near)
+            rects[0], exact=bool(near), edges=near, ref=ref)
         overlap = 0.0
         if limit is not None and board > limit:
             return board, overlap
@@ -642,7 +649,7 @@ class QuenchState:
         # against only those edges.
         if legal and self.edge_gate.active:
             near = self._edges_near(ref)
-            if near and self.edge_gate.rect_blocked(rect, edges=near):
+            if near and self.edge_gate.rect_blocked(rect, edges=near, ref=ref):
                 legal = False
         if legal:
             if self._neighbors is not None and ref in self._neighbors:
@@ -832,7 +839,7 @@ class QuenchState:
         oob_amount = 0.0
         oob_area = 0.0
         for p in parts:
-            amt = self.edge_gate.rect_outside_amount(p.rect)
+            amt = self.edge_gate.rect_outside_amount(p.rect, ref=p.ref)
             if amt > legality.EPS:
                 oob_count += 1
                 oob_amount += amt

--- a/tests/test_628_owner_not_charged.py
+++ b/tests/test_628_owner_not_charged.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""Regression test for the #628 follow-up -- the milled-ring swallow rule must
+not fire on the part that OWNS the ring.
+
+#636 made `BoardOutlineGate`'s swallow probe see the milled `board_edge_contours`
+as well as `board_cutouts`, which closed a real hole. But `board_edge_contours`
+has exactly ONE producer -- `drop_pad_containing_cutouts` -- and it moves a
+contour there only when the contour encloses **>= 2 pad centres**. So every
+milled contour has a part living inside it BY CONSTRUCTION, and when that part's
+courtyard is bigger than the ring (a connector over a milled relief) the probe
+called the part board-violating at its own hand-placed seed pose:
+
+    J1 seed violation()                 0.0   -> 0.55
+    candidate_valid('J1', 4.45, 20.0)   False -> True
+
+The second line is the damage. A part whose seed reads as violating enters
+quench's UNFREEZE branch (`quench.py:686-700`), which accepts any overlap-free
+pose whose board term merely DECREASES -- so quench would walk J1 to 0.45mm from
+a board edge that requires 0.55mm, exactly what the comment at `quench.py:668-675`
+exists to prevent. It also makes the #456 scorecard report a correct hand
+placement as `oob_count 1`.
+
+The fix scopes the MILLED half of the probe by ownership (`ring_owner_refs`,
+computed once at the seed poses) and threads a `ref` through `rect_blocked` /
+`rect_outside_amount`. This test pins all four corners of that:
+
+  * the OWNER is legal over its own relief, and is still refused a sub-clearance
+    pose (the unfreeze licence is gone);
+  * a NON-owner swallowing a foreign relief is STILL blocked (#636 survives) --
+    pinned on the same board and the same gate as the owner case, so the two
+    cannot be confused for a board-level opt-out;
+  * ownership is PER RING, not per part: J1 owns ring1 and is still blocked on
+    ring2, which SW17 owns;
+  * a real `cutouts` entry is NEVER owner-skipped, even when it encloses the
+    tested part's own pad. A part may not swallow a real hole, owner or not.
+
+`tests/test_628_milled_contour_legality.py` is the other half and must keep
+passing unmodified: its SW17 swallows a ring owned by a back-side B1, i.e. a
+non-owner case.
+
+    python3 tests/test_628_owner_not_charged.py
+"""
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'py_router'))  # #522
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'py_tools'))  # #522
+
+from kicad_parser import parse_kicad_pcb  # noqa: E402
+from placement import legality  # noqa: E402
+from placement.legality import BoardOutlineGate  # noqa: E402
+from placement.quench import QuenchState  # noqa: E402
+
+fails = []
+
+
+def check(name, cond):
+    print(("  ok  " if cond else " FAIL ") + name)
+    if not cond:
+        fails.append(name)
+
+
+# --- API shims -------------------------------------------------------------
+# On the UNFIXED gate none of the ownership API exists, so a plain call raises
+# and the run aborts before it reaches the substantive checks. These report a
+# clean FAIL once per missing piece and fall back to the old call, so a red run
+# names the behaviours that regressed rather than dying at import time.
+_MISSING = set()
+
+
+def _api(name, cond):
+    if name not in _MISSING:
+        _MISSING.add(name)
+        check("API: " + name, cond)
+
+
+def _gate(board_info, footprints):
+    """BoardOutlineGate with the ownership precompute enabled."""
+    try:
+        g = BoardOutlineGate(board_info, MARGIN, footprints=footprints)
+    except TypeError:
+        _api("BoardOutlineGate takes footprints=", False)
+        return BoardOutlineGate(board_info, MARGIN)
+    _api("BoardOutlineGate takes footprints=", True)
+    return g
+
+
+def _blocked(gate, rect, ref):
+    try:
+        v = gate.rect_blocked(rect, ref=ref)
+    except TypeError:
+        _api("rect_blocked takes ref=", False)
+        return gate.rect_blocked(rect)
+    _api("rect_blocked takes ref=", True)
+    return v
+
+
+def _amount(gate, rect, ref):
+    try:
+        v = gate.rect_outside_amount(rect, ref=ref)
+    except TypeError:
+        _api("rect_outside_amount takes ref=", False)
+        return gate.rect_outside_amount(rect)
+    _api("rect_outside_amount takes ref=", True)
+    return v
+
+
+def _owner_refs(ring, footprints):
+    fn = getattr(legality, 'ring_owner_refs', None)
+    if fn is None:
+        _api("legality.ring_owner_refs exists", False)
+        return None
+    _api("legality.ring_owner_refs exists", True)
+    return fn(ring, footprints)
+
+
+# The canonical QuenchState knobs (same set tests/test_628_milled_contour_legality
+# and tests/test_456_side_and_outline use); board_edge_clearance is the gate margin.
+KNOBS = dict(clearance=0.25, board_edge_clearance=0.55, crossing_penalty=10.0,
+             halo_base=0.3, halo_coef=0.15, halo_weight=1.0,
+             edge_halo=1.0, edge_weight=1.0, grid_step=0.05)
+MARGIN = KNOBS['board_edge_clearance']
+
+
+def _rect_edge(x1, y1, x2, y2, tag):
+    """Four Edge.Cuts gr_lines forming a closed axis-aligned rectangle."""
+    pts = [(x1, y1), (x2, y1), (x2, y2), (x1, y2)]
+    return "\n".join(
+        f' (gr_line (start {pts[i][0]} {pts[i][1]}) '
+        f'(end {pts[(i + 1) % 4][0]} {pts[(i + 1) % 4][1]}) '
+        f'(layer "Edge.Cuts") (width 0.05) (uuid "{tag}{i}"))' for i in range(4))
+
+
+# --------------------------------------------------------------------------
+# Fixture A -- the pinned repro, plus a second relief with a DIFFERENT owner.
+#
+# Outline 0..60 x 0..40. Two milled rings:
+#   ring1  20..24 x 19..21  owned by J1  (front, connector over a relief)
+#   ring2  34..38 x 19..21  owned by SW17 (back)
+# Each part sits centred on its own ring with an 8x8mm courtyard, so each
+# SWALLOWS its own ring at its seed pose and could swallow the other's by moving
+# 14mm along x. The two are on OPPOSITE board sides and are both plain SMD, so
+# they share no side and cannot interact through the courtyard-overlap term --
+# every verdict below is the board term alone.
+#
+# The two pads inside each ring are what make drop_pad_containing_cutouts
+# reclassify it (predicate: >= 2 enclosed pad centres); without them the rings
+# would stay plain cutouts and the swallow probe would fire for a different
+# reason entirely (test_fixture_shape below makes that a failure).
+# --------------------------------------------------------------------------
+BOARD_TWO_RELIEFS = f'''(kicad_pcb
+ (version 20241229)
+ (net 0 "")
+ (net 1 "NA")
+ (net 2 "NB")
+{_rect_edge(0, 0, 60, 40, 'o')}
+{_rect_edge(20, 19, 24, 21, 'm')}
+{_rect_edge(34, 19, 38, 21, 'n')}
+ (footprint "test:conn" (layer "F.Cu") (at 22 20)
+  (property "Reference" "J1" (at 0 -2) (layer "F.SilkS"))
+  (fp_rect (start -4 -4) (end 4 4) (layer "F.CrtYd") (uuid "cyJ1"))
+  (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "NA") (uuid "pJ1a"))
+  (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "NA") (uuid "pJ1b"))
+ )
+ (footprint "test:sw" (layer "B.Cu") (at 36 20)
+  (property "Reference" "SW17" (at 0 -2) (layer "B.SilkS"))
+  (fp_rect (start -4 -4) (end 4 4) (layer "B.CrtYd") (uuid "cySW"))
+  (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "B.Cu") (net 2 "NB") (uuid "pSWa"))
+  (pad "2" smd rect (at 0.5 0) (size 0.6 0.6) (layers "B.Cu") (net 2 "NB") (uuid "pSWb"))
+ )
+)
+'''
+
+# --------------------------------------------------------------------------
+# Fixture B -- a REAL cutout that encloses ONE of J2's pad centres.
+#
+# One pad is below drop_pad_containing_cutouts' >= 2 threshold, so the ring stays
+# a genuine board_cutouts hole. J2 would be its owner under the milled rule --
+# and must be charged anyway. J2's second pad is at +5mm, outside the hole, so
+# the footprint straddles it exactly as a part over a milled relief would.
+# --------------------------------------------------------------------------
+BOARD_REAL_CUTOUT = f'''(kicad_pcb
+ (version 20241229)
+ (net 0 "")
+ (net 1 "NA")
+{_rect_edge(0, 0, 60, 40, 'o')}
+{_rect_edge(20, 19, 24, 21, 'h')}
+ (footprint "test:conn" (layer "F.Cu") (at 22 20)
+  (property "Reference" "J2" (at 0 -2) (layer "F.SilkS"))
+  (fp_rect (start -4 -4) (end 4 4) (layer "F.CrtYd") (uuid "cyJ2"))
+  (pad "1" smd rect (at -0.5 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "NA") (uuid "pJ2a"))
+  (pad "2" smd rect (at 5 0) (size 0.6 0.6) (layers "F.Cu") (net 1 "NA") (uuid "pJ2b"))
+ )
+)
+'''
+
+J1_SEED = (18.0, 16.0, 26.0, 24.0)      # J1's courtyard at (22, 20): swallows ring1
+SW17_SEED = (32.0, 16.0, 40.0, 24.0)    # SW17's courtyard at (36, 20): swallows ring2
+RING1 = (20.0, 19.0, 24.0, 21.0)
+RING2 = (34.0, 19.0, 38.0, 21.0)
+# The pose the unfreeze branch would have walked J1 to: courtyard 8mm wide with
+# its LEFT edge 0.45mm from x=0, against a required board_edge_clearance of 0.55.
+BADX, BADY = 4.45, 20.0
+
+
+def _write(text):
+    fd, path = tempfile.mkstemp(suffix='.kicad_pcb')
+    with os.fdopen(fd, 'w') as f:
+        f.write(text)
+    return path
+
+
+# --------------------------------------------------------------------------
+# 1. Fixture sanity + the ownership map itself.
+# --------------------------------------------------------------------------
+def test_fixture_shape_and_owner_map():
+    path = _write(BOARD_TWO_RELIEFS)
+    try:
+        pcb = parse_kicad_pcb(path)
+        bi = pcb.board_info
+        ec = [c for c in (getattr(bi, 'board_edge_contours', None) or [])
+              if len(c) >= 3]
+        cut = [c for c in (bi.board_cutouts or []) if len(c) >= 3]
+        check("fixture: both interior rings reclassified as MILLED "
+              f"(board_edge_contours == 2, got {len(ec)})", len(ec) == 2)
+        check(f"fixture: neither is a cutout (board_cutouts == 0, got {len(cut)})",
+              len(cut) == 0)
+        gate = _gate(bi, pcb.footprints)
+        check("fixture: gate active with outline + 2 milled rings",
+              gate.active and len(gate.rings) == 3)
+        owners = getattr(gate, 'milled_owners', None)
+        check("gate exposes milled_owners, one entry per milled ring",
+              isinstance(owners, list) and len(owners or []) == 2)
+        if owners and len(owners) == 2:
+            # Rings keep board_edge_contours order; identify by geometry rather
+            # than by index so a parser reorder cannot silently pass this.
+            by_x = {min(p[0] for p in c): o
+                    for c, o in zip(gate.milled, owners)}
+            check(f"ring1 (x0=20) is owned by exactly {{J1}}, got {by_x.get(20.0)}",
+                  by_x.get(20.0) == frozenset({'J1'}))
+            check(f"ring2 (x0=34) is owned by exactly {{SW17}}, got {by_x.get(34.0)}",
+                  by_x.get(34.0) == frozenset({'SW17'}))
+        check("fixture: J1's seed courtyard is inside the bbox inset, so ONLY "
+              "the ring tests can reject it",
+              gate.bbox_outside_amount(J1_SEED) == 0.0)
+        check("fixture: J1's seed courtyard really does contain ring1 whole",
+              J1_SEED[0] < RING1[0] and J1_SEED[1] < RING1[1]
+              and RING1[2] < J1_SEED[2] and RING1[3] < J1_SEED[3])
+        # Without footprints the gate cannot know about ownership, and must
+        # behave exactly as it did before this change.
+        bare = BoardOutlineGate(bi, MARGIN)
+        check("no footprints supplied -> every milled ring is ownerless",
+              all(o == frozenset()
+                  for o in (getattr(bare, 'milled_owners', None) or [])))
+    finally:
+        os.unlink(path)
+
+
+# --------------------------------------------------------------------------
+# 2. The gate primitives: the owner is exempt, ref=None is unchanged, and the
+#    two primitives agree (legality.py:373 / :403-404 invariant).
+# --------------------------------------------------------------------------
+def test_gate_primitives_scope_by_owner():
+    path = _write(BOARD_TWO_RELIEFS)
+    try:
+        pcb = parse_kicad_pcb(path)
+        gate = _gate(pcb.board_info, pcb.footprints)
+
+        check("owner: rect_blocked(J1 seed, ref='J1') is False",
+              _blocked(gate, J1_SEED, 'J1') is False)
+        amt_owner = _amount(gate, J1_SEED, 'J1')
+        check(f"owner: rect_outside_amount(J1 seed, ref='J1') == 0 ({amt_owner})",
+              amt_owner == 0.0)
+        check("owner: the two primitives agree",
+              _blocked(gate, J1_SEED, 'J1') == (amt_owner > 0.0))
+
+        # ref=None must keep charging -- any caller not updated is unchanged.
+        check("ref=None: rect_blocked(J1 seed) still True (default unchanged)",
+              gate.rect_blocked(J1_SEED) is True)
+        check("ref=None: rect_outside_amount(J1 seed) still > 0",
+              gate.rect_outside_amount(J1_SEED) > 0.0)
+
+        # #636 survives: a non-owner swallowing a foreign relief is blocked.
+        check("non-owner: rect_blocked(J1 seed, ref='SW17') is True",
+              _blocked(gate, J1_SEED, 'SW17') is True)
+        amt_foreign = _amount(gate, J1_SEED, 'SW17')
+        check(f"non-owner: rect_outside_amount > 0 ({amt_foreign})",
+              amt_foreign > 0.0)
+        check("non-owner: the two primitives agree",
+              _blocked(gate, J1_SEED, 'SW17') == (amt_foreign > 0.0))
+
+        # Ownership is PER RING: J1's exemption on ring1 buys it nothing on ring2.
+        check("per-ring: rect_blocked(SW17 seed, ref='J1') is True",
+              _blocked(gate, SW17_SEED, 'J1') is True)
+        check("per-ring: ...and scores a violation",
+              _amount(gate, SW17_SEED, 'J1') > 0.0)
+        check("per-ring: SW17 IS exempt on its own ring2",
+              _blocked(gate, SW17_SEED, 'SW17') is False
+              and _amount(gate, SW17_SEED, 'SW17') == 0.0)
+
+        # An unknown ref owns nothing, so it is charged like ref=None.
+        check("an unknown ref owns nothing and is charged",
+              _blocked(gate, J1_SEED, 'NOSUCHPART') is True)
+    finally:
+        os.unlink(path)
+
+
+# --------------------------------------------------------------------------
+# 3. THE POINT OF THE TEST: end to end through QuenchState.candidate_valid.
+#    The gate primitives alone would not have caught this -- the damage is that
+#    a seed reading as violating opens the unfreeze branch.
+# --------------------------------------------------------------------------
+def test_owner_is_legal_at_seed_and_still_refused_a_subclearance_pose():
+    path = _write(BOARD_TWO_RELIEFS)
+    try:
+        pcb = parse_kicad_pcb(path)
+        st = QuenchState(pcb, path, **KNOBS)
+
+        v = st.violation('J1')
+        check(f"owner J1 is LEGAL at its hand-placed seed (violation {v})",
+              v == 0.0)
+        check("owner SW17 is LEGAL at its hand-placed seed",
+              st.violation('SW17') == 0.0)
+
+        # The regression itself: with J1 reading as violating, the unfreeze
+        # branch accepts any overlap-free pose whose board term decreases, and
+        # 4.45 (0.45mm from the edge, 0.55 required) is such a pose.
+        bad = (BADX - 4.0, BADY - 4.0, BADX + 4.0, BADY + 4.0)
+        check("the bad pose really is sub-clearance "
+              f"(rect x0 {bad[0]} < usable x0 {st.usable[0]})",
+              bad[0] < st.usable[0])
+        check(f"candidate_valid('J1', {BADX}, {BADY}) is REFUSED",
+              st.candidate_valid('J1', BADX, BADY, 0.0) is False)
+        check("violation() scores that pose as illegal",
+              st.violation('J1', BADX, BADY, 0.0) > 0.0)
+
+        # The owner is not frozen either: a small nudge on its own relief is fine.
+        check("owner J1 may still be nudged over its own relief",
+              st.candidate_valid('J1', 22.4, 20.0, 0.0) is True)
+
+        # #636 survives end to end: J1 may not move onto SW17's relief, and
+        # vice versa. Both parts are legal at their seeds, so this is the strict
+        # gate rejecting, not the unfreeze branch.
+        check("non-owner: candidate_valid('J1', 36, 20) over SW17's relief "
+              "is REFUSED", st.candidate_valid('J1', 36.0, 20.0, 0.0) is False)
+        check("non-owner: candidate_valid('SW17', 22, 20) over J1's relief "
+              "is REFUSED", st.candidate_valid('SW17', 22.0, 20.0, 0.0) is False)
+        check("non-owner: violation() scores J1 over ring2 as illegal",
+              st.violation('J1', 36.0, 20.0, 0.0) > 0.0)
+
+        # #456 scorecard: a correct hand placement must not grade out-of-board.
+        m = st.legality_metrics()
+        check(f"scorecard: oob_count == 0 on the hand placement ({m['oob_count']})",
+              m['oob_count'] == 0)
+        check(f"scorecard: oob_amount == 0 ({m['oob_amount']})",
+              m['oob_amount'] == 0.0)
+    finally:
+        os.unlink(path)
+
+
+# --------------------------------------------------------------------------
+# 4. Real cutouts are UNAFFECTED: a part may never swallow a real hole, owner
+#    or not. Fixture B's cutout encloses one of J2's own pad centres, so J2
+#    would qualify as its owner under the milled rule.
+# --------------------------------------------------------------------------
+def test_real_cutout_is_never_owner_skipped():
+    path = _write(BOARD_REAL_CUTOUT)
+    try:
+        pcb = parse_kicad_pcb(path)
+        bi = pcb.board_info
+        cut = [c for c in (bi.board_cutouts or []) if len(c) >= 3]
+        ec = [c for c in (getattr(bi, 'board_edge_contours', None) or [])
+              if len(c) >= 3]
+        check("fixture: one enclosed pad is below the >= 2 reclassification "
+              f"threshold, so it stays a CUTOUT ({len(cut)})", len(cut) == 1)
+        check(f"fixture: nothing was milled ({len(ec)})", len(ec) == 0)
+        check("fixture: J2 still has both pads after parse",
+              len(pcb.footprints['J2'].pads) == 2)
+        # J2 WOULD be the owner if this ring were milled -- that is what makes
+        # the check below a real statement rather than a vacuous one.
+        check("J2 encloses a pad of the cutout ring (it would be its owner)",
+              _owner_refs(cut[0], pcb.footprints) == frozenset({'J2'}))
+
+        gate = _gate(bi, pcb.footprints)
+        check("gate.milled is empty, so milled_owners is too",
+              gate.milled == []
+              and (getattr(gate, 'milled_owners', None) or []) == [])
+        check("cutout: rect_blocked(J2 seed, ref='J2') is STILL True",
+              _blocked(gate, J1_SEED, 'J2') is True)
+        amt = _amount(gate, J1_SEED, 'J2')
+        check(f"cutout: rect_outside_amount(..., ref='J2') is STILL > 0 ({amt})",
+              amt > 0.0)
+        check("cutout: the two primitives agree",
+              _blocked(gate, J1_SEED, 'J2') == (amt > 0.0))
+
+        st = QuenchState(pcb, path, **KNOBS)
+        check("cutout: QuenchState scores J2 over the hole as illegal",
+              st.violation('J2') > 0.0)
+    finally:
+        os.unlink(path)
+
+
+def run():
+    for t in (test_fixture_shape_and_owner_map,
+              test_gate_primitives_scope_by_owner,
+              test_owner_is_legal_at_seed_and_still_refused_a_subclearance_pose,
+              test_real_cutout_is_never_owner_skipped):
+        print(f"--- {t.__name__}")
+        t()
+    print()
+    if fails:
+        print("FAILED: %d check(s): %s" % (len(fails), fails))
+        return 1
+    print("All checks passed")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(run())


### PR DESCRIPTION
Fixes the regression my own PR #636 introduced (merged as `b7e0d52a`, ported to
`placement` as `1bf5c312`). Sorry for the round trip — I flagged this on #636 and
drafted it, but it merged before that was seen.

## The regression

#636 made `BoardOutlineGate`'s swallow probe see the milled `board_edge_contours`,
not just `board_cutouts`. That closed a real hole — but it regressed the part that
**owns** the ring.

`board_edge_contours` has exactly one producer, `drop_pad_containing_cutouts`
(`py_router/kicad_parser.py:2105`), and it moves a contour there **only when the
contour encloses >= 2 pad centres**. So every milled contour has a component living
inside it *by construction* — which also means the "milled slot, interior = not
board" half of the safety argument in #636's description was unreachable, and that
argument was wrong.

Pinned repro (outline 0..60 x 0..40, milled ring 20..24 x 19..21, connector `J1` at
(22,20) with an 8x8 courtyard and its two SMD pads inside the ring;
`clearance=0.25`, `board_edge_clearance=0.55`):

| | `b7e0d52a` | this PR |
|---|---|---|
| `st.violation('J1')` at its hand-placed seed | **0.55** | **0.0** |
| `st.candidate_valid('J1', 4.45, 20.0)` | **True** | **False** |
| `st.legality_metrics()['oob_count']` | **2** | **0** |
| `st.legality_metrics()['oob_amount']` | **1.1** | **0.0** |

Row 2 is the damage, and it is worse than a mis-grade. A part whose seed reads as
violating enters quench's **unfreeze branch** (`placement/quench.py:686-700`), which
accepts any overlap-free pose whose board term merely *decreases*. So quench would
walk `J1` to **0.45 mm from a board edge that requires 0.55 mm** — exactly the
failure the comment at `quench.py:668-675` exists to prevent.

## The fix

Scope the **milled** half of the swallow probe by ownership.

- New `legality.ring_owner_refs(ring, footprints)` — refs with at least one pad
  centre inside the ring, using the same ray cast (`kicad_parser._pt_in_ring`) as
  the producer. A ring's owner is stable board geometry, so it is computed **once**,
  at seed poses, into a new public `BoardOutlineGate.milled_owners`.
- `BoardOutlineGate.__init__` takes an optional `footprints`; all three
  construction sites pass `pcb_data.footprints`.
- `rect_blocked(..., ref=None)` and `rect_outside_amount(..., ref=None)` apply the
  **identical** skip. Callers threaded: `quench.py` `violation_parts` /
  `candidate_valid` / `legality_metrics`, `legality.placement_out_of_board`, and
  `fanout_clearance._blocked_geom`.

**Why `>= 1` pad, not the producer's `>= 2`.** The producer counts pads board-wide,
so a ring can be reclassified by one pad from each of two parts. Requiring 2 per
part would then charge both for their own shared relief — the same regression one
arity up. Each part is exempt only on rings its own pads sit in.

## What is deliberately unchanged

- **#636 survives for non-owners.** A part swallowing someone else's relief is still
  blocked, and the exemption is **per ring**, not per part.
  `tests/test_628_milled_contour_legality.py` passes **unmodified** (its SW17
  swallows a ring owned by back-side B1 — a non-owner case).
- **Real cutouts are never owner-skipped.** Ownership is *almost* vacuous there, but
  a cutout enclosing **one** pad centre survives reclassification, so the exemption
  is denied explicitly in code rather than left to the arithmetic — with a test on
  exactly that fixture.
- **No containment semantics** for milled contours; their interior stays on-board
  (#291).
- **`ref=None` is byte-for-byte the old behaviour**, so any caller not updated is
  unchanged. Pinned by explicit checks.
- **Both primitives apply the same skip**, preserving the documented
  `rect_outside_amount == 0` iff `not rect_blocked` invariant (`legality.py:373`,
  `:403-404`).

## Tests

New `tests/test_628_owner_not_charged.py`. Fixture A carries **two** milled reliefs
with **different** owners on **opposite board sides** (front J1 owns ring1, back
SW17 owns ring2), both plain SMD, so no courtyard-overlap term can confound a
verdict — one board, one gate, both directions. Fixture B is a **real cutout**
enclosing one of J2's own pad centres, so J2 *would* qualify as its owner under the
milled rule, which is what makes that check a real statement.

It drives `QuenchState.candidate_valid`, not just the gate primitives — the
primitives alone would not have caught this, because the damage is the unfreeze
*licence*, not the primitive's answer.

**Red/green:** with only the three source files reverted to `b7e0d52a` (test
untouched), it fails 15 checks including `owner J1 is LEGAL at its hand-placed seed
(violation 0.55)` and `candidate_valid('J1', 4.45, 20.0) is REFUSED` — while every
non-owner and `ref=None` control already passes there, which is the point. With the
patch, all 45 pass.

## Verification

```
tests/run_all.py --fast -j 4 --timeout 240     217 passed, 0 failed, 46 skipped
tests/test_628_milled_contour_legality.py      PASS (unmodified)
tests/gui_parity/test_manifest_plan_parity.py  rc=0  (35 flag-checks, 0 mismatches)
tests/gui_parity/test_cli_postpass_coverage.py rc=0  (0 failures, 0 warnings)
tests/gui_parity/test_settings_roundtrip.py    rc=0  (181 keys)
```

`test_settings_roundtrip` was run under `C:\Program Files\KiCad\10.0\bin\python.exe`
(pcbnew 10.0.1 / wx 4.2.2). `test_gui_engine_parity.py` could not produce a verdict
here for an environmental reason unrelated to this change: KiCad's bundled python
lacks `scipy`/`shapely`, so `route_planes.py:33`'s startup check raises and the GUI
leg emits 0 segments.

No new CLI flag, engine parameter, or post-pass — the GUI reaches this through the
shared `repair_fanout_clearance` / quench engine functions.

## Limitations, stated plainly

1. **Ownership is frozen at the seed pose**, by design (a ring's owner is stable
   board geometry). Under a large `travel` budget an owner could in principle
   re-swallow its own relief from a pose where its pads no longer sit inside it.
   Recomputing per pose would make the answer pose-dependent and break the
   `edges_near` caching contract.
2. **The exemption is swallow-only.** A connector whose relief is not at least
   `board_edge_clearance` inside its courtyard still reads as violating at its seed
   via the ordinary ring-proximity test. Measured on a tight fixture: pre-#636 0.60,
   `b7e0d52a` 1.15, this PR 0.60 — i.e. this restores the pre-#636 number exactly.
   That residual 0.60 predates #636 and is out of scope here.
3. **`placement_out_of_board`'s `footprints` defaults to `None`**, and its only
   callers today are tests, so that standalone grader keeps the charging behaviour
   unless a caller opts in. `QuenchState.legality_metrics()` — the path the #456
   scorecard uses — does pass ownership, so this is latent, not live.
   `py_router/placement/README.md:271` ("report the same geometry the optimizer
   gates on") is now conditionally true; happy to update it if you'd like.
4. **Threshold argued, not corpus-measured.** No `ab_replay_grade` /
   `cloud_replay_sets` run. The boards to look at are the ones that trip the
   `drop_pad_containing_cutouts` warning (crkbd, bus_pirate5).

**`placement` branch:** `py_placer/placement/legality.py` is 1352 lines against
`main`'s 454, so this needs a hand port like `1bf5c312` did. I confirmed the
regression is identical there (`cae97962` to `1bf5c312`: same 0.0 -> 0.55 and
False -> True). Say the word and I'll port it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
