### PR TITLE
placement: scope the #628 swallow probe to foreign rings (fixes the #636 port regression) + pick 15d11f9c

### DIFF
--- a/py_placer/placement/legality.py
+++ b/py_placer/placement/legality.py
@@ -248,8 +248,15 @@ class BoardOutlineGate:
         # interior off-board re-opens #291, where bus_pirate5 lost all 870 pads
         # and the run broke the chain. "A part may not swallow a milled ring"
         # is true for both readings, which is exactly why it is safe.
-        self._swallow_pts = ([r[0] for r in self.cutouts]
-                             + [r[0] for r in self.milled])
+        #
+        # Carries the ring's IDENTITY, not just its vertex: a part whose own
+        # pads sit inside a milled ring must be allowed to swallow THAT ring
+        # (see rings_enclosing / skip_rings below). Ids are indices into
+        # cutouts + milled, in that order.
+        self._swallow_pts = (
+            [(i, r[0][0], r[0][1]) for i, r in enumerate(self.cutouts)]
+            + [(len(self.cutouts) + i, r[0][0], r[0][1])
+               for i, r in enumerate(self.milled)])
         self.margin = margin
         self.bounds = getattr(board_info, 'board_bounds', None)
         self.usable = None
@@ -318,13 +325,46 @@ class BoardOutlineGate:
     def may_reach(self, key, seed_rect, travel: float, center=None) -> bool:
         return bool(self.edges_near(key, seed_rect, travel, center))
 
+    def rings_enclosing(self, points) -> frozenset:
+        """Ids of the MILLED rings enclosing any of `points` -- a part's OWN
+        milled relief, for the `skip_rings` argument of the two probes.
+
+        Only milled contours can be owned, by construction:
+        `drop_pad_containing_cutouts` moves every ring enclosing >= 2 pad
+        centres OUT of board_cutouts and into board_edge_contours, so no ring
+        left in `self.cutouts` encloses a pad and no cutout id can ever land in
+        a skip set. That is what keeps the genuine-cutout half of the swallow
+        probe untouchable rather than merely untouched.
+
+        >= 1 enclosed pad, not >= 2: two parts with one pad each inside a ring
+        are both partial owners and both must be exempt. Pad CENTRES and the
+        same containment test the parser used to reclassify the ring in the
+        first place (kicad_parser.drop_pad_containing_cutouts -> _pt_in_ring).
+        """
+        if not self.milled:
+            return frozenset()
+        from check_drc import _point_in_poly
+        base = len(self.cutouts)
+        owned = set()
+        for i, ring in enumerate(self.milled):
+            for (px, py) in points:
+                if _point_in_poly(px, py, ring):
+                    owned.add(base + i)
+                    break
+        return frozenset(owned)
+
     # -- level 3: the exact tests
-    def rect_blocked(self, rect, edges=None) -> bool:
+    def rect_blocked(self, rect, edges=None, skip_rings=None) -> bool:
         """True when a rect leaves the real outline, enters a cutout, or comes
         within the edge margin of either.
 
         `edges` restricts the distance test to a pre-filtered edge list from
         `edges_near`; omitted, every ring edge is measured.
+
+        `skip_rings` (from `rings_enclosing`) exempts the tested part's OWN
+        milled rings from the swallow probe -- a connector over its own milled
+        relief may swallow it, and without this it is judged board-violating at
+        its own hand-placed pose.
         """
         from check_drc import _point_on_board, _seg_seg_dist_coords
         x0, y0, x1, y1 = rect
@@ -339,7 +379,9 @@ class BoardOutlineGate:
                     return True
         # An interior ring FULLY INSIDE the rect evades both tests above -- no
         # corner is off-board and no rect edge comes near a ring edge (#628).
-        for (cx, cy) in self._swallow_pts:
+        for (rid, cx, cy) in self._swallow_pts:
+            if skip_rings and rid in skip_rings:
+                continue  # the part's own milled relief
             if x0 <= cx <= x1 and y0 <= cy <= y1:
                 return True
         return False
@@ -356,7 +398,8 @@ class BoardOutlineGate:
         return (max(0.0, u[0] - rect[0]) + max(0.0, u[1] - rect[1])
                 + max(0.0, rect[2] - u[2]) + max(0.0, rect[3] - u[3]))
 
-    def rect_outside_amount(self, rect, exact: bool = True, edges=None) -> float:
+    def rect_outside_amount(self, rect, exact: bool = True, edges=None,
+                            skip_rings=None) -> float:
         """Magnitude of a rect's board-boundary violation; 0 iff fully legal.
 
         Zero exactly when the bbox inset holds AND `rect_blocked` is False, so
@@ -368,6 +411,9 @@ class BoardOutlineGate:
         established via `may_reach` that this rect cannot come near a ring. The
         ring terms are ~100x the cost of the bbox term, and in a hot candidate
         loop most parts are nowhere near an edge.
+
+        `skip_rings` must match what `rect_blocked` is given for the same rect,
+        or the two stop agreeing on legality (see the swallow probe below).
         """
         amt = self.bbox_outside_amount(rect)
         if not (self.active and exact):
@@ -391,7 +437,9 @@ class BoardOutlineGate:
         # Swallowed interior ring (cutout or milled contour), same probe and
         # same charge as rect_blocked's -- the two must agree on legality or
         # `violation()==0` stops implying `not rect_blocked()` (#628).
-        for (cx, cy) in self._swallow_pts:
+        for (rid, cx, cy) in self._swallow_pts:
+            if skip_rings and rid in skip_rings:
+                continue  # the part's own milled relief
             if x0 <= cx <= x1 and y0 <= cy <= y1:
                 amt += self.margin
         return amt
@@ -1330,7 +1378,13 @@ def grade_pad_legality(pcb_data, clearance: float, exact: bool = True,
             ext = pp.extent(fp.x, fp.y, fp.rotation or 0.0)
             if ext is None:
                 continue
-            amt = gate.rect_outside_amount(ext)
+            # A part whose own pads sit in a milled relief may span it -- e.g. a
+            # connector with pins around its shield slot, whose pad EXTENT
+            # swallows the ring. Ownership from the FILE's own poses, which is
+            # what this function grades (#628).
+            own = gate.rings_enclosing(
+                [(p.global_x, p.global_y) for p in pads_by_ref.get(ref, ())])
+            amt = gate.rect_outside_amount(ext, skip_rings=own)
             if amt > EPS:
                 oob_count += 1
                 oob_amount += amt

--- a/py_placer/placement/quench.py
+++ b/py_placer/placement/quench.py
@@ -558,6 +558,9 @@ class QuenchState:
         # ref -> violation of its CURRENT pose; whole-dict invalidated on any
         # move, since a move changes its neighbours' violations too.
         self._inc_violation: Dict[str, float] = {}
+        # ref -> ids of the milled rings its OWN pads sit inside (#628). Keyed
+        # on the SEED pose, so unlike _inc_violation this NEVER invalidates.
+        self._owned_rings_cache: Dict[str, frozenset] = {}
 
         # --- #548: alignment and orientation, both OFF unless asked for ------
         self.align_weight = float(align_weight)
@@ -967,7 +970,8 @@ class QuenchState:
         # one that can measures only against the edges it can actually reach.
         near = self._edges_near(ref) if self.edge_gate.active else None
         board = self.edge_gate.rect_outside_amount(
-            rects[0], exact=bool(near), edges=near)
+            rects[0], exact=bool(near), edges=near,
+            skip_rings=self._owned_rings(ref))
         overlap = 0.0
         if limit is not None and board > limit:
             return board, overlap
@@ -1035,7 +1039,8 @@ class QuenchState:
         # against only those edges.
         if legal and self.edge_gate.active:
             near = self._edges_near(ref)
-            if near and self.edge_gate.rect_blocked(rect, edges=near):
+            if near and self.edge_gate.rect_blocked(
+                    rect, edges=near, skip_rings=self._owned_rings(ref)):
                 legal = False
         if legal:
             if self._neighbors is not None and ref in self._neighbors:
@@ -1165,6 +1170,30 @@ class QuenchState:
         return self.edge_gate.edges_near(
             ref, part.rect(part.seed_x, part.seed_y, part.orig_rot), travel,
             center=(part.seed_x, part.seed_y))
+
+    def _owned_rings(self, ref) -> frozenset:
+        """Cached: the milled rings this part's OWN pads sit inside (#628).
+
+        A milled contour is reclassified out of board_cutouts precisely BECAUSE
+        it encloses >= 2 pad centres, so such a ring always has a part living on
+        it -- a connector over its own milled relief. Without this exemption the
+        swallow probe judges that part board-violating at its own hand-placed
+        pose, and because a genuinely sub-clearance edge pose then scores LOWER,
+        the unfreeze branch below walks it off the board edge.
+
+        Keyed on the SEED pose and never invalidated, like _edges_near: seed
+        ownership is what the reclassification itself was computed from, and it
+        is the anti-gaming choice -- ownership taken at the CANDIDATE pose would
+        let any part claim a ring merely by moving onto it.
+        """
+        owned = self._owned_rings_cache.get(ref)
+        if owned is None:
+            part = self.parts[ref]
+            pts = [(gx, gy) for (gx, gy, _net) in
+                   part.pad_globals(part.seed_x, part.seed_y, part.orig_rot)]
+            owned = self.edge_gate.rings_enclosing(pts) if pts else frozenset()
+            self._owned_rings_cache[ref] = owned
+        return owned
 
     def _edges_near_halo(self, ref) -> list:
         """Like _edges_near but sized to the SOFT edge_halo radius. Inflating
@@ -1303,7 +1332,11 @@ class QuenchState:
         oob_amount = 0.0
         oob_area = 0.0
         for p in parts:
-            amt = self.edge_gate.rect_outside_amount(p.rect)
+            # skip_rings: a part over its own milled relief is legal there, and
+            # this is the #456 scorecard -- without it a correct hand placement
+            # reports oob_count 1 (#628).
+            amt = self.edge_gate.rect_outside_amount(
+                p.rect, skip_rings=self._owned_rings(p.ref))
             if amt > legality.EPS:
                 oob_count += 1
                 oob_amount += amt

--- a/py_router/console_encoding.py
+++ b/py_router/console_encoding.py
@@ -26,3 +26,54 @@ def enable_utf8_console():
             stream.reconfigure(encoding="utf-8", errors="replace")
         except Exception:
             pass
+
+
+# Readable ASCII stand-ins, used only when the stream genuinely cannot encode
+# the glyph. 'replace' alone would render "3.500 m?" -- the unit silently lost,
+# which is worse than a plain-ASCII spelling.
+_ASCII_FALLBACKS = {
+    "Ω": "ohm",   # GREEK CAPITAL OMEGA (impedance / resistance)
+    "Ω": "ohm",   # OHM SIGN
+    "µ": "u",     # MICRO SIGN
+    "→": "->",
+    "±": "+/-",
+    "⚠": "!",
+    "²": "^2",
+    "×": "x",
+}
+
+
+def ascii_safe(text, stream=None):
+    """``text`` with any glyph the target stream cannot encode spelled out.
+
+    For CLI entry points :func:`enable_utf8_console` is the better fix -- it
+    keeps the real glyph. This is for the OTHER caller shape: shared engine
+    functions invoked IN-PROCESS (a test, a script, an embedder), where no
+    ``__main__`` block ran and stdout is still the interpreter's default. On a
+    cp1252 Windows console that made a library ``print`` of "mΩ" abort the whole
+    run -- the CLI was protected, the same engine function called directly was
+    not (the CLAUDE.md CLI/GUI parity shape: a fix in ``main()`` is not a fix in
+    the engine).
+
+    Returns ``text`` unchanged whenever the stream can encode it, so UTF-8
+    consoles -- the normal case -- keep the real symbols.
+    """
+    if not text:
+        return text
+    stream = stream if stream is not None else sys.stdout
+    enc = getattr(stream, "encoding", None)
+    if not enc:
+        return text
+    try:
+        text.encode(enc)
+        return text
+    except UnicodeEncodeError:
+        pass
+    except (LookupError, TypeError):
+        return text
+    out = "".join(_ASCII_FALLBACKS.get(ch, ch) for ch in text)
+    try:
+        out.encode(enc)
+        return out
+    except UnicodeEncodeError:
+        return out.encode(enc, errors="replace").decode(enc, errors="replace")

--- a/py_router/plane_resistance.py
+++ b/py_router/plane_resistance.py
@@ -18,6 +18,7 @@ from typing import List, Dict, Tuple, Optional
 from shapely.geometry import Polygon as ShapelyPolygon, LineString, Point
 from shapely.validation import make_valid
 
+from console_encoding import ascii_safe
 from routing_constants import (
     IPC_2221_EXPONENT_DT,
     IPC_2221_EXPONENT_AREA,
@@ -618,7 +619,11 @@ def print_single_net_resistance(result: Dict, net_name: str):
     print(f"    Path length: {result['path_length']:.1f} mm (diagonal)")
     print(f"    Avg width:   {result['avg_width']:.1f} mm")
     r_str = f"{result['resistance']*1000:.3f} mΩ" if result['resistance'] < float('inf') else "N/A"
-    print(f"    Resistance:  {r_str}")
+    # ascii_safe, not a bare print: create_plane is a SHARED ENGINE function and
+    # is called in-process (tests, scripts, the GUI) where route_planes.py's
+    # __main__ enable_utf8_console() never ran. On a cp1252 console that made
+    # this one line abort the whole pour.
+    print(ascii_safe(f"    Resistance:  {r_str}"))
     # An out-of-range area is NOT a rating: say so instead of printing a bare
     # number the reader will take as one (#489 §6).
     if result.get('max_current', 0) <= 0:
@@ -648,7 +653,7 @@ def print_multi_net_resistance(results: Dict[str, Dict]):
     label = _conditions_label(first) if first else "(1 oz copper, 10°C rise)"
     print(f"\n  Plane Resistance Analysis {label}:")
     print(f"  {'-'*74}")
-    print(f"  {'Net':<25} {'Path(mm)':<10} {'AvgW(mm)':<10} {'R(mΩ)':<10} {'Imax(A)':<12}")
+    print(ascii_safe(f"  {'Net':<25} {'Path(mm)':<10} {'AvgW(mm)':<10} {'R(mΩ)':<10} {'Imax(A)':<12}"))
     print(f"  {'-'*74}")
 
     any_extrapolated = False

--- a/tests/test_457_fresh_clone_fixtures.py
+++ b/tests/test_457_fresh_clone_fixtures.py
@@ -20,6 +20,7 @@ Two invariants, both of which were violated:
 """
 
 import os
+import re
 import subprocess
 import sys
 
@@ -98,6 +99,47 @@ def test_consumers_do_not_silently_skip_a_missing_fixture():
         print(f"  PASS: {fname} -> fixture_boards ({board})")
 
 
+def test_no_test_reads_an_untracked_board_directly():
+    """DERIVED cousin of the check above -- it names no test file.
+
+    The list in test_consumers_do_not_silently_skip_a_missing_fixture is
+    hand-maintained, so it only ever covers the consumers that existed when it
+    was written. test_gui_finalize_oracle_inrun.py was added later, read
+    kicad_files/kit-out-plane.kicad_pcb (gitignored, and produced by NOTHING
+    since #426 moved test_kit_route's outputs to a temp workdir), and sailed
+    past this gate -- crashing on a fresh clone while passing locally against a
+    stale leftover from the old chain.
+
+    So derive the consumer set instead of listing it: any test that resolves a
+    board out of kicad_files/ which git does not track must go through
+    fixture_boards. Matching is deliberately narrow -- a literal
+    'kicad_files/x.kicad_pcb' or a join of 'kicad_files', 'x.kicad_pcb' -- so
+    the many tests that write x.kicad_pcb into their own tempdir are not
+    swept in.
+    """
+    pats = [re.compile(r"['\"]kicad_files[/\\]([A-Za-z0-9_.\-]+\.kicad_pcb)['\"]"),
+            re.compile(r"['\"]kicad_files['\"]\s*,\s*['\"]([A-Za-z0-9_.\-]+\.kicad_pcb)['\"]")]
+    tracked = _tracked()
+    here = os.path.dirname(os.path.abspath(__file__))
+    offenders = []
+    for fname in sorted(os.listdir(here)):
+        if not (fname.startswith('test_') and fname.endswith('.py')):
+            continue
+        src = open(os.path.join(here, fname), encoding='utf-8').read()
+        boards = set()
+        for p in pats:
+            boards |= set(p.findall(src))
+        missing = sorted(b for b in boards if f'kicad_files/{b}' not in tracked)
+        if missing and 'fixture_boards' not in src:
+            offenders.append(f"{fname}: {', '.join(missing)}")
+    assert not offenders, (
+        "test(s) reading an UNTRACKED board straight out of kicad_files/:\n  "
+        + "\n  ".join(offenders)
+        + "\nOn a fresh clone that board does not exist. Add a recipe to "
+          "tests/fixture_boards.py and call ensure(), or use a tracked board.")
+    print("  PASS: no test reads an untracked kicad_files/ board directly")
+
+
 def test_fixtures_build_from_a_clean_state():
     """End to end: every fixture is producible right now."""
     for name in _RECIPES:
@@ -124,6 +166,7 @@ TESTS = [
     test_every_recipe_roots_in_a_tracked_board,
     test_no_tracked_project_file_without_its_board,
     test_consumers_do_not_silently_skip_a_missing_fixture,
+    test_no_test_reads_an_untracked_board_directly,
     test_fixtures_build_from_a_clean_state,
     test_building_a_fixture_leaves_no_tracked_file_modified,
 ]

--- a/tests/test_628_milled_contour_legality.py
+++ b/tests/test_628_milled_contour_legality.py
@@ -34,7 +34,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'py_tools'))  # #522
 
 from kicad_parser import parse_kicad_pcb  # noqa: E402
-from placement.legality import BoardOutlineGate  # noqa: E402
+from placement.legality import BoardOutlineGate, grade_pad_legality  # noqa: E402
 from placement.quench import QuenchState  # noqa: E402
 
 fails = []
@@ -255,13 +255,142 @@ def test_milled_interior_is_not_declared_off_board():
         os.unlink(path)
 
 
+# --------------------------------------------------------------------------
+# 7-10. The OWNER half. A milled contour is reclassified out of board_cutouts
+#    precisely BECAUSE it encloses >= 2 pad centres, so such a ring ALWAYS has
+#    a part living on it -- the shape below is a connector with a milled relief
+#    in its middle and pins around it. Charging that part for swallowing its
+#    own relief is what the first cut of this fix did, and it is worse than
+#    noise: a genuinely sub-clearance edge pose scores LOWER than the seed, so
+#    candidate_valid's unfreeze branch (quench.py, "moves strictly back toward
+#    the board") ACCEPTS walking the connector off the board edge.
+# --------------------------------------------------------------------------
+def _owner_board() -> str:
+    """J1 owns the relief: two pads INSIDE it (which is what reclassifies the
+    ring) and four pins AROUND it, so BOTH its courtyard (17.5..26.5 x
+    16.5..23.5) and its pad extent (17.7..26.3 x 16.7..23.3) swallow the ring
+    20..24 x 19..21. SW17 is the control, seeded clear at (40, 20) and owning
+    nothing."""
+    pads = "\n".join(
+        f'  (pad "{n}" smd rect (at {dx} {dy}) (size 0.6 0.6) '
+        f'(layers "F.Cu") (net 1 "NA") (uuid "pJ1{n}"))'
+        for n, dx, dy in ((1, -0.5, 0), (2, 0.5, 0),      # inside the relief
+                          (3, -4, 0), (4, 4, 0),          # pins around it
+                          (5, 0, -3), (6, 0, 3)))
+    return f'''(kicad_pcb
+ (version 20241229)
+ (net 0 "")
+ (net 1 "NA")
+ (net 2 "NB")
+{_rect_edge(0, 0, 60, 40, 'o')}
+{_rect_edge(20, 19, 24, 21, 'm')}
+ (footprint "test:conn" (layer "F.Cu") (at 22 20)
+  (property "Reference" "J1" (at 0 -5) (layer "F.SilkS"))
+  (fp_rect (start -4.5 -3.5) (end 4.5 3.5) (layer "F.CrtYd") (uuid "cyJ1"))
+{pads}
+ )
+ (footprint "test:sw" (layer "F.Cu") (at 40 20)
+  (property "Reference" "SW17" (at 0 -2) (layer "F.SilkS"))
+  (fp_rect (start -4 -4) (end 4 4) (layer "F.CrtYd") (uuid "cySW"))
+  (pad "1" smd rect (at -1 0) (size 0.6 0.6) (layers "F.Cu") (net 2 "NB") (uuid "pSWa"))
+  (pad "2" smd rect (at 1 0) (size 0.6 0.6) (layers "F.Cu") (net 2 "NB") (uuid "pSWb"))
+ )
+)
+'''
+
+
+def _write_owner():
+    fd, path = tempfile.mkstemp(suffix='.kicad_pcb')
+    with os.fdopen(fd, 'w') as f:
+        f.write(_owner_board())
+    return path
+
+
+OWNER_SEED = (17.5, 16.5, 26.5, 23.5)   # J1's courtyard at its own (22, 20)
+
+
+def test_owner_fixture_and_gate_scoping():
+    """The gate charges the owner's rect WITHOUT skip_rings and clears it WITH
+    -- so the exemption is what does it, not a fixture accident."""
+    path = _write_owner()
+    try:
+        pcb = parse_kicad_pcb(path)
+        gate = BoardOutlineGate(pcb.board_info, MARGIN)
+        check("owner fixture: the ring is a milled contour", len(gate.milled) == 1)
+        own = gate.rings_enclosing([(21.5, 20.0), (22.5, 20.0)])
+        check("rings_enclosing names the ring the pads sit in", len(own) == 1)
+        check("a part that owns NOTHING gets an empty set",
+              gate.rings_enclosing([(40.0, 20.0)]) == frozenset())
+        check("unscoped: the owner's rect is still charged (guard intact)",
+              gate.rect_blocked(OWNER_SEED) is True
+              and gate.rect_outside_amount(OWNER_SEED) > 0.0)
+        check("scoped: its own relief is exempt",
+              gate.rect_blocked(OWNER_SEED, skip_rings=own) is False
+              and gate.rect_outside_amount(OWNER_SEED, skip_rings=own) == 0.0)
+        check("the exemption is per-RING: a foreign rect is still charged",
+              gate.rect_blocked(SWALLOW, skip_rings=frozenset()) is True)
+    finally:
+        os.unlink(path)
+
+
+def test_owner_is_legal_at_its_own_seed_pose():
+    path = _write_owner()
+    try:
+        pcb = parse_kicad_pcb(path)
+        st = QuenchState(pcb, path, **KNOBS)
+        check("the ring owner is legal at its own hand-placed pose",
+              st.violation('J1') == 0.0)
+        check("...and the control part is too", st.violation('SW17') == 0.0)
+    finally:
+        os.unlink(path)
+
+
+def test_owner_is_not_walked_off_the_board_edge():
+    """THE regression. With the owner falsely scored 0.55 at its seed, a pose
+    0.45mm from a board edge that requires 0.55 scores LOWER (0.40), and the
+    unfreeze branch accepts the move."""
+    path = _write_owner()
+    try:
+        pcb = parse_kicad_pcb(path)
+        st = QuenchState(pcb, path, **KNOBS)
+        walk_x = 0.45 + 4.5          # courtyard half-width 4.5 -> x0 = 0.45
+        check("a sub-clearance edge pose IS a violation",
+              st.violation('J1', walk_x, 20.0, 0.0) > 0.0)
+        check("candidate_valid refuses to walk the owner to the board edge",
+              not st.candidate_valid('J1', walk_x, 20.0, 0.0))
+    finally:
+        os.unlink(path)
+
+
+def test_owner_scores_clean_on_both_scorecards():
+    """#456: a correct hand placement must not report oob. Two INDEPENDENT
+    paths reach it -- quench's legality_metrics (courtyard) and
+    grade_pad_legality (pad extent) -- and both must be scoped."""
+    path = _write_owner()
+    try:
+        pcb = parse_kicad_pcb(path)
+        st = QuenchState(pcb, path, **KNOBS)
+        lm = st.legality_metrics()
+        check("legality_metrics: no phantom oob_count",
+              lm['oob_count'] == 0 and lm['oob_amount'] == 0.0)
+        g = grade_pad_legality(pcb, KNOBS['clearance'], edge_margin=MARGIN)
+        check("grade_pad_legality: no phantom oob_pad_count",
+              g['oob_pad_count'] == 0 and not g['oob_pad_refs'])
+    finally:
+        os.unlink(path)
+
+
 def run():
     for t in (test_fixture_is_a_milled_contour_not_a_cutout,
               test_swallowed_milled_contour_is_illegal,
               test_crossing_and_clear_rects_are_unchanged,
               test_genuine_cutout_swallow_still_detected,
               test_quench_candidate_over_a_milled_slot_is_refused,
-              test_milled_interior_is_not_declared_off_board):
+              test_milled_interior_is_not_declared_off_board,
+              test_owner_fixture_and_gate_scoping,
+              test_owner_is_legal_at_its_own_seed_pose,
+              test_owner_is_not_walked_off_the_board_edge,
+              test_owner_scores_clean_on_both_scorecards):
         print(f"--- {t.__name__}")
         t()
     print()

--- a/tests/test_console_encoding_ascii_safe.py
+++ b/tests/test_console_encoding_ascii_safe.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""A non-ASCII glyph in a SHARED ENGINE print must not abort the run.
+
+Windows consoles default to cp1252, which cannot encode the Ohm sign. The CLI
+entry points already guard with console_encoding.enable_utf8_console(), but that
+runs in `if __name__ == "__main__"` -- so it does nothing for the OTHER caller
+shape, which is the whole point of this file:
+
+    create_plane(...)          # shared engine, called IN-PROCESS
+
+A test, a script, or an embedder that imports the engine directly never executes
+route_planes.py's __main__, so stdout stays the interpreter's default. On a
+cp1252 console that made plane_resistance's one "mOhm" line raise
+UnicodeEncodeError and take the entire pour down with it -- the CLI protected,
+the same engine function called directly not. That is the CLAUDE.md CLI/GUI
+parity shape exactly: a fix in main() is not a fix in the engine.
+
+The GUI escaped it only because gui_utils.StdoutRedirector has its own
+try/except (issue #152). This pins the engine-side fix.
+
+    python3 tests/test_console_encoding_ascii_safe.py
+"""
+import io
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))
+sys.path.insert(0, os.path.join(ROOT, 'py_tools'))
+
+from console_encoding import ascii_safe               # noqa: E402
+from plane_resistance import print_single_net_resistance   # noqa: E402
+
+
+def _cp1252_stream():
+    """A stream that behaves like a Windows console: strict, cp1252."""
+    return io.TextIOWrapper(io.BytesIO(), encoding='cp1252', errors='strict')
+
+
+def test_utf8_stream_keeps_the_real_glyph():
+    """The normal case must not be degraded into ASCII."""
+    utf8 = io.TextIOWrapper(io.BytesIO(), encoding='utf-8')
+    assert ascii_safe("1.103 mΩ", utf8) == "1.103 mΩ"
+    print("  PASS: UTF-8 stream keeps the real symbol")
+
+
+def test_cp1252_stream_gets_a_readable_spelling():
+    """Not '?' -- a bare replace loses the unit, which is worse than ASCII."""
+    got = ascii_safe("1.103 mΩ", _cp1252_stream())
+    assert got == "1.103 mohm", got
+    assert '?' not in got, "fell back to lossy replacement instead of a spelling"
+    print(f"  PASS: cp1252 stream -> {got!r}")
+
+
+def test_both_omega_codepoints_are_covered():
+    """U+03A9 (GREEK CAPITAL OMEGA) and U+2126 (OHM SIGN) both appear in the
+    tree; a map keyed on only one of them would still crash on the other."""
+    for cp in ('Ω', 'Ω'):
+        got = ascii_safe(f"1.0 m{cp}", _cp1252_stream())
+        assert got == "1.0 mohm", (cp, got)
+    print("  PASS: both omega codepoints spell out")
+
+
+def test_engine_print_survives_a_cp1252_console():
+    """The actual regression: this print used to abort the pour."""
+    result = {'path_length': 180.74, 'avg_width': 78.6, 'resistance': 0.001103,
+              'max_current': 56.62, 'max_current_ipc2152': 56.62,
+              'in_chart_range': True, 'is_internal': False,
+              'copper_oz': 1.0, 'temp_rise': 10.0}
+    buf = _cp1252_stream()
+    old = sys.stdout
+    sys.stdout = buf
+    try:
+        print_single_net_resistance(result, 'GND')
+    except UnicodeEncodeError as e:      # pragma: no cover - the bug
+        sys.stdout = old
+        raise AssertionError(
+            f"print_single_net_resistance still crashes on a cp1252 console: {e}")
+    finally:
+        sys.stdout = old
+    buf.flush()
+    text = buf.buffer.getvalue().decode('cp1252')
+    line = [ln for ln in text.splitlines() if 'Resistance:' in ln]
+    assert line, f"no resistance line emitted:\n{text}"
+    assert 'mohm' in line[0], line[0]
+    print(f"  PASS: engine print survived ->{line[0]}")
+
+
+def test_ascii_safe_is_defensive_about_odd_streams():
+    """It is called from library code; it must never be the thing that raises."""
+    class NoEncoding:
+        encoding = None
+    class Weird:
+        encoding = 'not-a-real-codec'
+    assert ascii_safe("mΩ", NoEncoding()) == "mΩ"
+    assert ascii_safe("mΩ", Weird()) == "mΩ"
+    assert ascii_safe("", _cp1252_stream()) == ""
+    assert ascii_safe(None, _cp1252_stream()) is None
+    print("  PASS: degrades quietly on streams it cannot interrogate")
+
+
+TESTS = [
+    test_utf8_stream_keeps_the_real_glyph,
+    test_cp1252_stream_gets_a_readable_spelling,
+    test_both_omega_codepoints_are_covered,
+    test_engine_print_survives_a_cp1252_console,
+    test_ascii_safe_is_defensive_about_odd_streams,
+]
+
+
+def main():
+    fails = []
+    for t in TESTS:
+        try:
+            t()
+        except AssertionError as e:
+            fails.append(f"{t.__name__}: {e}")
+    print("=" * 60)
+    if fails:
+        print("FAIL:")
+        for f in fails:
+            print(f"  - {f}")
+        return 1
+    print(f"{len(TESTS)}/{len(TESTS)} checks passed")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_gui_finalize_oracle_inrun.py
+++ b/tests/test_gui_finalize_oracle_inrun.py
@@ -31,15 +31,45 @@ REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # Needs real zones AND at least one INCOMPLETE plane net: the finalize is a
 # plane pass, and a board whose pours are already whole exits before it ever
 # reaches the oracle leg (which is how two earlier fixture picks here made
-# the gate vacuously "pass"). This one has both GND and +3.3V pours reading
-# unconnected, and routes in seconds.
-BOARD = os.path.join(REPO, 'kicad_files', 'kit-out-plane.kicad_pcb')
+# the gate vacuously "pass").
+#
+# It must ALSO be a board a fresh clone actually has. The original pick,
+# kit-out-plane.kicad_pcb, is an OUTPUT of tests/test_kit_route.py that
+# 25de9022 (#426, 2026-07-18) untracked and gitignored -- 17 days BEFORE this
+# gate was written (8bfa9011) -- and #426 also pointed that test at a temp
+# workdir, so nothing regenerates it either. The gate therefore never ran on
+# any clone; it only ever passed where a stale artifact happened to survive in
+# kicad_files/. /kicad_files/kit-out*.kicad_pcb is still gitignored: do not
+# point back at it.
+#
+# A TRACKED board is preferred over generating one (PR #635). Generating is
+# cheap here -- pouring planes onto the unrouted root is ~1.5s, not the
+# minutes a full kit-dev-coldfire route would cost -- but a static tracked
+# board cannot drift: a generated fixture silently goes vacuous the day the
+# engine gets good enough to leave its pour complete, and this gate's whole
+# failure mode is passing while testing nothing.
+#
+# lvds_converter_dualclk_gnd.kicad_pcb carries a real /GND pour that reads
+# unconnected (the run's improvement gate reports it gaining /GND, 42 -> 41
+# disconnected pads) and the whole gate runs in about a second. Verified
+# non-vacuous: re-introducing the #562 deferred-oracle behaviour makes it fail
+# with BOTH of its intended messages.
+BOARD = os.path.join(REPO, 'kicad_files', 'lvds_converter_dualclk_gnd.kicad_pcb')
 
 from kicad_parser import parse_kicad_pcb            # noqa: E402
 from route import batch_route                       # noqa: E402
 
 
 def _run(with_callback):
+    # BEFORE the copy, not after: shutil.copy raises FileNotFoundError itself,
+    # so a check placed below it can never run and the caller just gets the
+    # raw traceback this message exists to replace.
+    if not os.path.exists(BOARD):
+        raise SystemExit(
+            f"FAIL: fixture board is missing: {BOARD}\n"
+            "  This gate needs a TRACKED board. A generated/gitignored one "
+            "makes it unrunnable on every fresh clone (see the note above).")
+
     work = tempfile.mkdtemp(prefix='finalize_oracle_')
     board = os.path.join(work, 'in.kicad_pcb')
     shutil.copy(BOARD, board)
@@ -52,8 +82,14 @@ def _run(with_callback):
     zone_nets = sorted({pcb.nets[z.net_id].name for z in (pcb.zones or [])
                         if z.net_id in pcb.nets})
     if not zone_nets:
-        print("SKIP: fixture board has no zone nets")
-        return None
+        # Deliberately NOT a skip. A fixture with no zone nets never reaches
+        # the plane finalize, so the gate would report success while testing
+        # nothing -- the silent non-coverage this file's own note warns about,
+        # and main() turned that None into exit 0.
+        raise SystemExit(
+            "FAIL: fixture board has no zone nets, so the plane finalize -- "
+            "and the oracle leg this gate exists to check -- never runs. "
+            "Pick a fixture with a real, incomplete pour.")
 
     staged = []
 
@@ -80,8 +116,6 @@ def main():
     # 1. WITH a staging callback: the leg runs in-run, and the deferred
     #    hand-off to the applier must NOT be posted (both would double-run).
     r = _run(True)
-    if r is None:
-        return 0
     if r['staged'] < 1:
         failures.append("stage_board_fn was never called -- the finalize "
                         "did not try to stage a board for the oracle")


### PR DESCRIPTION
Two fixes to the fallout from the #634/#635/#636 wave, on the branch where placement work actually happens.

Refs #628. Please keep that issue open — this is still the legality half only.

## 1. The swallow probe must skip a part's OWN milled ring

`1bf5c312` ported PR #636 here verbatim — including the "holds under BOTH readings" safety argument that [its author had already retracted](https://github.com/drandyhaas/KiCadRoutingTools/pull/636#issuecomment-5295529186) in the PR thread after finding a regression in his own fix. The claim is unreachable: `board_edge_contours` has exactly one producer, `drop_pad_containing_cutouts`, which moves a ring there **only when it encloses ≥ 2 pad centres**. Every milled ring therefore has a part living on it.

### Measured at `1bf5c312`

Fixture is the realistic shape: a connector `J1` with a **milled relief in its middle** — two pads inside it (which is *why* the ring is reclassified) and four pins around it, so both its courtyard and its pad extent swallow the ring. `board_edge_clearance = 0.55`:

```
violation('J1')  at its own hand-placed pose      = 0.55     (should be 0)
candidate_valid('J1', 0.45mm from a board edge)   = True     <-- the harm
legality_metrics()['oob_count']                   = 1
grade_pad_legality()['oob_pad_count']             = 1   refs [['J1', 0.55]]
```

The seed scores 0.55 and a genuinely sub-clearance edge pose scores 0.40, so `candidate_valid`'s unfreeze branch — which accepts any overlap-free pose whose board term merely *decreases* — **walks the connector off its correct hand placement to 0.45 mm from an edge that requires 0.55**. That is exactly the bug class the comment above that branch exists to prevent.

**Not identified in the PR thread:** there is a *second, independent* scorecard path. `grade_pad_legality` grades the **pad extent**, not the courtyard, and reaches the same false verdict whenever the owner has pins *around* its relief — feeding `place_seed` / `place_optimize` / `place_reconstruct` / `check_assembly`, not just the #456 scorecard. Scoping only the quench path leaves that one lying.

### The fix — scope the probe, don't revert the guard

- `_swallow_pts` gains **ring identity** (it was a flat point list, which is the only reason this needed an API change at all).
- `rings_enclosing(points) -> frozenset` names the **milled** rings enclosing a part's own pad centres, via `check_drc._point_in_poly` — the same containment test the parser used to reclassify the ring.
- Both probes take `skip_rings=None`; all ~20 call sites stay source-compatible.
- Ownership is **≥ 1** enclosed pad (two parts with one pad each inside a ring are both partial owners), taken from the **seed pose** and cached, never invalidated — candidate-pose ownership would let any part claim a ring by moving onto it.
- Threaded into the four sites that charge at a non-zero margin: `violation_parts`, `candidate_valid`, `legality_metrics`, `grade_pad_legality`. Deliberately **not** threaded elsewhere, with the reason recorded at each site: margin-0 gates are numerically inert (the probe charges `+= self.margin`), and `labels.py` tests a **silk-label box**, which must not inherit a part's ring exemption.

Only the milled half is ever skippable, so the genuine-cutout half of the probe is safe **by construction** rather than by argument: no ring left in `board_cutouts` encloses a pad, so no cutout id can reach a skip set.

**Scope discipline:** the segment-distance term also charges a tight-fitting owner, but that predates `1bf5c312` and is left alone — in the fixture above the courtyard clears the ring by 2–3 mm, far beyond the 0.55 margin, so the entire false charge was the swallow probe. Fixing a regression is not the place to change long-standing semantics.

### Tests

`tests/test_628_milled_contour_legality.py` grows four cases; **the existing six are untouched**:

- the gate charges the owner's rect **without** `skip_rings` and clears it **with** — so the exemption is what does it, not a fixture accident;
- the owner is legal at its own pose;
- `candidate_valid` **refuses** the edge walk (the actual harm);
- both scorecards read 0.

`SW17`, which owns nothing, must still be refused over the ring — the **anti-over-scoping control**: a fix that exempts everyone passes the owner cases and fails that one.

Verified to fail before it passes: with the quench threading reverted, the three quench-side checks fail; `grade_pad_legality`'s was measured at 1 on the unmodified tree.

## 2. Cherry-pick `15d11f9c` — a gate that had never run here

`tests/test_gui_finalize_oracle_inrun.py` on this branch still read `kicad_files/kit-out-plane.kicad_pcb`, untracked and gitignored since #426 — so the #562 regression it exists to catch has been unguarded here, and it was one of this branch's pre-existing red tests. The pick also brings `py_router/console_encoding.py` (the cp1252 `Ω` failure) and `tests/test_457_fresh_clone_fixtures.py`. It now passes:

```
GUI finalize oracle: runs in-run when a board can be staged, falls back to the
post-apply hand-off when it cannot. OK
```

## Verification

- `tests/run_all.py --fast`, same box, before and after: baseline **242 passed / 10 failed**, after **244 passed / 9 failed**. The failing set is the baseline's *minus* `test_gui_finalize_oracle_inrun.py`, with no new entries; the +2 passes are that gate and the new `test_console_encoding_ascii_safe.py`. The 9 remaining reds are pre-existing on this branch and untouched by either commit.
- `tests/test_628_milled_contour_legality.py` — 10 tests / 36 checks green.
- `tests/test_456_side_and_outline.py` and `tests/test_fanout_clearance.py` — pass (the other consumers of the gate primitives).
- Placement-only change: no flag, no default, no engine parameter, no GUI surface, so the CLI/GUI parity checklist is inert.

`main`'s copy (`py_router/placement/legality.py`) carries the same defect; happy to send the identical patch there.
