### PR TITLE
tests: unbreak the A/B replay harness (it has not parsed since 2026-08-06) and 6 stale reds

### DIFF
--- a/tests/stress/ab_replay_grade.py
+++ b/tests/stress/ab_replay_grade.py
@@ -238,8 +238,8 @@ def grade(pcb, clearance, baseline=None):
             import json as _json
             sys.path.insert(0, str(REPO))
             sys.path.insert(0, str(REPO / 'py_router'))  # #522
-            sys.path.insert(0, os.path.join(str(REPO / 'py_router')), 'py_placer'))  # #522/py_placer layout
-            sys.path.insert(0, os.path.join(str(REPO / 'py_router')), 'py_tools'))  # #522/py_placer layout
+            sys.path.insert(0, str(REPO / 'py_placer'))  # #522/py_placer layout
+            sys.path.insert(0, str(REPO / 'py_tools'))   # #522/py_placer layout
             from fix_kicad_drc_settings import project_copper_clearance
             with open(pro) as _f:
                 _recorded = project_copper_clearance(_json.load(_f))

--- a/tests/test_431_animator_port.py
+++ b/tests/test_431_animator_port.py
@@ -119,7 +119,7 @@ def test_the_duplications_are_gone():
     """The point of the port. Each of these is a second implementation of
     something the shared stack already owns."""
     import ast
-    path = os.path.join(ROOT, 'animate_fanout_clearance.py')
+    path = os.path.join(ROOT, 'py_tools', 'animate_fanout_clearance.py')
     src = open(path, encoding='utf-8').read()
     tree = ast.parse(src)
     fn = next(n for n in ast.walk(tree)
@@ -142,7 +142,7 @@ def test_the_duplications_are_gone():
 
 
 def test_the_shared_easing_helpers_are_imported_not_copied():
-    src = open(os.path.join(ROOT, 'animate_fanout_clearance.py'),
+    src = open(os.path.join(ROOT, 'py_tools', 'animate_fanout_clearance.py'),
                encoding='utf-8').read()
     assert 'from movie_camera import' in src
     for name in ('def _smoothstep', 'def _lerp_rect', 'def _net_color'):

--- a/tests/test_431_render_seams.py
+++ b/tests/test_431_render_seams.py
@@ -17,7 +17,13 @@ comparison of two images produced by the same Pillow.
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+# #522 moved the engine modules out of the repo root into py_router/ (and the
+# placement family into py_placer/, the leaf tools into py_tools/).
+for _p in (_ROOT, os.path.join(_ROOT, 'py_router'),
+           os.path.join(_ROOT, 'py_placer'), os.path.join(_ROOT, 'py_tools')):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
 
 from PIL import Image, ImageChops, ImageDraw  # noqa: E402
 

--- a/tests/test_549_track_clearance.py
+++ b/tests/test_549_track_clearance.py
@@ -15,7 +15,10 @@ import sys
 
 _TESTS = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(_TESTS)
-for p in (ROOT, _TESTS):
+# #522 moved the engine modules out of the repo root into py_router/ (and the
+# placement family into py_placer/, the leaf tools into py_tools/).
+for p in (ROOT, _TESTS, os.path.join(ROOT, 'py_router'),
+          os.path.join(ROOT, 'py_placer'), os.path.join(ROOT, 'py_tools')):
     if p not in sys.path:
         sys.path.insert(0, p)
 

--- a/tests/test_blocker_kind_attribution.py
+++ b/tests/test_blocker_kind_attribution.py
@@ -18,7 +18,10 @@ from contextlib import redirect_stdout
 
 _TESTS = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(_TESTS)
-for p in (ROOT, _TESTS):
+# #522 moved the engine modules out of the repo root into py_router/ (and the
+# placement family into py_placer/, the leaf tools into py_tools/).
+for p in (ROOT, _TESTS, os.path.join(ROOT, 'py_router'),
+          os.path.join(ROOT, 'py_placer'), os.path.join(ROOT, 'py_tools')):
     if p not in sys.path:
         sys.path.insert(0, p)
 

--- a/tests/test_placement_probe.py
+++ b/tests/test_placement_probe.py
@@ -79,6 +79,16 @@ def probe(board, nets, workdir, route_args=None):
 
 
 def main(argv=None):
+    # This is an OPT-IN two-board A/B driver, not a self-running test: --off
+    # and --on are required, so a bare `test_placement_probe.py` (which is how
+    # tests/run_all.py invokes every test_*.py) can only ever exit 2 on
+    # argparse. Skip cleanly instead, the same way the KiCad-python gates skip
+    # when their interpreter is absent -- a red that no change can fix teaches
+    # the reader to ignore the failure list.
+    if not (sys.argv[1:] if argv is None else list(argv)):
+        print("SKIP: opt-in A/B probe -- needs --off BOARD --on BOARD "
+              "(it ROUTES both boards; see CLAUDE.md)")
+        return 0
     p = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter)

--- a/tests/test_stub_to_stub_mst.py
+++ b/tests/test_stub_to_stub_mst.py
@@ -20,7 +20,10 @@ import sys
 
 _TESTS = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(_TESTS)
-for p in (ROOT, _TESTS):
+# #522 moved the engine modules out of the repo root into py_router/ (and the
+# placement family into py_placer/, the leaf tools into py_tools/).
+for p in (ROOT, _TESTS, os.path.join(ROOT, 'py_router'),
+          os.path.join(ROOT, 'py_placer'), os.path.join(ROOT, 'py_tools')):
     if p not in sys.path:
         sys.path.insert(0, p)
 


### PR DESCRIPTION
Follow-on to #638. Diagnosing this branch's red tests turned up a broken **tool**, not just broken tests.

## The one that matters: the A/B replay harness does not parse

`tests/stress/ab_replay_grade.py` has two lines that are not valid Python:

```python
sys.path.insert(0, os.path.join(str(REPO / 'py_router')), 'py_placer'))
sys.path.insert(0, os.path.join(str(REPO / 'py_router')), 'py_tools'))
```

Parens misplaced by a #522 path edit, in since `bec03cf0` (2026-08-06). A `SyntaxError` is raised at **import** time, so the enclosing `try/except` — written to make a missing project file non-fatal — never gets a chance to run.

That file is **the whole-set A/B replay harness CLAUDE.md points at** for regression-testing an engine change across the board corpus:

> To regression-test or A/B an engine change across the board corpus, use `tests/stress/ab_replay_grade.py` (whole-set replay + DRC/connectivity grading)

So it has been unusable for over a week, and the only symptom was `tests/test_405_edge_reconcile.py` failing — it imports the harness purely for its path wiring, so a broken *tool* surfaced as an unrelated red *test*. After the fix `ab_replay_grade.py --help` runs and `test_405` passes.

## Five tests still pointing at the pre-#522 layout

#522 moved the engine modules to `py_router/`, the placement family to `py_placer/` and the leaf tools to `py_tools/`; these were never repointed:

| test | failure |
|---|---|
| `test_431_render_seams`, `test_blocker_kind_attribution`, `test_stub_to_stub_mst` | `ModuleNotFoundError: kicad_parser` — only the repo root (and `tests/`) on `sys.path` |
| `test_549_track_clearance` | `ModuleNotFoundError: kicad_dru`, same cause |
| `test_431_animator_port` | opened `animate_fanout_clearance.py` at the repo root; it lives in `py_tools/` now (its own `sys.path` block was already correct, so only the two file reads needed fixing) |

## One red that no change could ever fix

`test_placement_probe` is an opt-in **two-board A/B driver** whose `--off`/`--on` are `required=True`, so the bare invocation `run_all` gives every `test_*.py` could only ever exit 2 on argparse. It now prints `SKIP` and exits 0 when called with no arguments — the way the KiCad-python gates skip when their interpreter is missing — while a real invocation still gets argparse's required-argument enforcement.

A permanent red that nobody can fix is how a reader learns to ignore the failure list, which is the same failure mode as the never-running gate #635 found.

## Deliberately not touched

These two are real assertions rather than plumbing, and mixing triage into a mechanical cleanup would bury them:

- `test_549_floorplan_grade` — "an unresolved block is an error not a silent pass" fails on a board grading `trustworthy: True`.
- `test_run8_skills_generic` — two skill-text content checks ("no skill names a specific board or work dir"), likely stale after a skills edit.

## Verification

`tests/run_all.py --fast`, same box, across the whole wave:

| state | result |
|---|---|
| branch point (`1bf5c312`) | 242 passed / **10 failed** |
| after #638 (scoping + the `15d11f9c` pick) | 244 passed / **9 failed** |
| with this commit | 251 passed / **2 failed** |

Every fixed test verified individually, and the two survivors are the ones named above. Test-and-harness only: no engine, CLI or GUI code is touched, so the parity checklist is inert.
