### PR TITLE
tests: fixture_boards could not build ANY recipe -- #522 moved its CLI scripts

### DIFF
--- a/tests/fixture_boards.py
+++ b/tests/fixture_boards.py
@@ -91,6 +91,24 @@ class FixtureBuildError(RuntimeError):
     """A fixture board could not be produced from its tracked root."""
 
 
+# #522 moved the CLI scripts out of the repo root (bga_fanout / qfn_fanout /
+# route_planes -> py_router/). The recipes above name them bare, so resolve
+# here rather than in every lambda: a recipe added later gets this for free,
+# and a script that moves again is one list entry instead of N.
+_SCRIPT_DIRS = ('py_router', 'py_placer', 'py_tools', '')
+
+
+def _script_path(name):
+    """Absolute path to a fixture recipe's CLI script, by bare filename."""
+    for d in _SCRIPT_DIRS:
+        p = os.path.join(ROOT, d, name) if d else os.path.join(ROOT, name)
+        if os.path.isfile(p):
+            return p
+    raise FixtureBuildError(
+        f"fixture recipe wants {name}, which is in none of "
+        f"{', '.join(repr(d or '<root>') for d in _SCRIPT_DIRS)}")
+
+
 def _build(name, path):
     src_name, argv_for = _RECIPES[name]
     src = ensure(src_name)
@@ -102,7 +120,8 @@ def _build(name, path):
     stem = path[:-len('.kicad_pcb')]
     tmp_stem = f"{stem}.building{os.getpid()}"
     tmp = tmp_stem + '.kicad_pcb'
-    argv = [sys.executable] + argv_for(src, tmp)
+    argv = argv_for(src, tmp)
+    argv = [sys.executable, _script_path(argv[0])] + list(argv[1:])
     print(f"  [fixture] building {name} from {os.path.basename(src)} ...")
     try:
         r = subprocess.run(argv, capture_output=True, text=True, cwd=ROOT)

--- a/tests/test_431_animator_port.py
+++ b/tests/test_431_animator_port.py
@@ -25,7 +25,24 @@ import animate_fanout_clearance as AFC  # noqa: E402
 from kicad_parser import parse_kicad_pcb  # noqa: E402
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-BOARD = os.path.join(ROOT, 'kicad_files', 'fanout_output1.kicad_pcb')
+
+
+def _board():
+    """fanout_output1.kicad_pcb, BUILT if absent.
+
+    It is a fanout OUTPUT, gitignored (.gitignore: /kicad_files/fanout_output*)
+    -- so reading it straight from kicad_files/ passes only on a box where an
+    earlier run happened to leave one behind, and is a permanent red on a clean
+    checkout. fixture_boards knows its recipe (chained back to the tracked
+    haasoscope_pro_max_test.kicad_pcb), so ask for it instead of assuming it.
+
+    Resolved lazily rather than at import: `ensure` may SHELL OUT to build the
+    chain, and a module-level call would charge that to collection even for the
+    tests here that need no board at all.
+    """
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    from fixture_boards import ensure
+    return ensure('fanout_output1.kicad_pcb')
 
 
 class _Rec:
@@ -79,7 +96,7 @@ def test_it_renders_with_a_board_and_draws_the_substrate():
     try:
         out = os.path.join(d, 'a.gif')
         got = AFC.render_gif(_Rec(), out, size=300, sub_frames=4, fps=20,
-                             pcb=parse_kicad_pcb(BOARD))
+                             pcb=parse_kicad_pcb(_board()))
         assert got and os.path.getsize(out) > 500
         n, sizes = _frames(out)
         assert n > 5


### PR DESCRIPTION
Follow-up to the #639 review. You caught that my `test_431_animator_port` fix was verified on a box where the board it wants already existed — a fair hit, and exactly the failure mode that PR was fixing. Chasing it properly found the bigger defect underneath.

## What the review caught

`test_431_animator_port` read `kicad_files/fanout_output1.kicad_pcb` directly. That is a fanout **output**, gitignored (`.gitignore:41`), so the test could only ever pass where an earlier run left one behind — and my `exit=0` could not see it, because my box had the artifact.

It now asks `fixture_boards.ensure()` for the board, **lazily**: `ensure` may shell out to build the chain, and a module-level call would charge that to collection even for the tests in that file which need no board at all.

## The defect underneath

Removing the artifact to check the fix didn't produce a build. It produced:

```
python: can't open file '<repo>/bga_fanout.py': [Errno 2] No such file or directory
```

Every `_RECIPES` entry names its CLI script bare — `bga_fanout.py`, `qfn_fanout.py`, `route_planes.py` — and `_build` runs it with `cwd=ROOT`. **#522 moved all three into `py_router/`.** So `fixture_boards` could not build a single one of its five recipes, and every `ensure()` for a missing board raised `FixtureBuildError` instead.

On a clean checkout — precisely when `ensure()` is load-bearing — the whole mechanism was dead. Your own run shows the symptom: **3 of your 10 reds were `FixtureBuildError`**.

Fixed in **one place** rather than in four lambdas: `_script_path()` resolves the bare name across `py_router` / `py_placer` / `py_tools` / root, so a recipe added later inherits it and a script that moves again is one list entry instead of N. It raises `FixtureBuildError` naming the directories it searched, rather than letting the interpreter's "can't open file" surface as an opaque build failure.

## Verified by removing the boards, not by a green run

That is the whole point of your review, so the verification is the experiment, not a count. With **all five** buildable fixtures deleted:

```
  [fixture] building qfn_fanned_out.kicad_pcb from haasoscope_pro_max_test.kicad_pcb ...
  [fixture] building fanout_starting_point.kicad_pcb from qfn_fanned_out.kicad_pcb ...
  [fixture] building fanout_output1.kicad_pcb from fanout_starting_point.kicad_pcb ...
  [fixture] building fanout_output2.kicad_pcb from fanout_output1.kicad_pcb ...
  [fixture] building interf_u_plane.kicad_pcb from interf_u_unrouted.kicad_pcb ...
ALL FIXTURES PRESENT
```

- `test_431_animator_port` passes **from that state** (builds its chain, then `ALL PASS`).
- The other `ensure()` consumers — `test_pad_global_nm_grid`, `test_457_fresh_clone_fixtures`, `test_411_placement_siblings`, `test_493_interpreter_independence` — pass against the rebuilt boards.

**On numbers:** `run_all --fast` on my box cannot demonstrate this, because my box has the artifacts and those tests were already green here. A pass/fail count would have hidden this defect exactly as it hid the first one. I'd expect it to clear your 3 `FixtureBuildError` reds and `test_431_animator_port`; worth confirming on your box, which is the one that reproduces a clean checkout.

## Not addressed here

Your remaining reds that need the `ulx3s` board or the calibrated stress corpus are a different class (genuinely external inputs, not a broken mechanism), as are `test_549_floorplan_grade` and `test_run8_skills_generic` — still assertions, still deserving their own triage.

Test-and-harness only: no engine, CLI or GUI code touched.
