### PR TITLE
#617: honour the board's declared min_hole_clearance where the engine chooses where copper goes

### DIFF
--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -249,6 +249,19 @@ class _Repair:
         self._edge_active = self.edge_gate.active
         self._max_disp_cap = max_displacement_cap
         self.clearance = clearance
+        # #617: KiCad's copper-to-hole rule is the BOARD's `min_hole_clearance`
+        # whenever it declares one above the 0.20 NPTH fab floor -- the same
+        # value check_drc grades at. The NPTH keep-out rects below were grown
+        # to the flat floor only, so on such a board a cap pad could be parked
+        # in the declared band and read clean here while the checker flagged
+        # it. Raise-only and cached per board path, so a board that declares
+        # nothing keeps byte-identical keep-outs. `config` is None because the
+        # placement engine has no GridRouteConfig anywhere in this call chain
+        # (repair_fanout_clearance takes scalars); the board read is driven by
+        # pcb_data.source_path, so the declared floor arrives regardless.
+        from obstacle_map import resolve_hole_clearance
+        self.npth_floor = max(defaults.NPTH_TO_TRACK_CLEARANCE,
+                              resolve_hole_clearance(pcb_data, None))
         self.grid_step = grid_step
         self.capture_radius = capture_radius
         # cap_prefix may list several reference prefixes (e.g. "C,R" = caps and
@@ -354,8 +367,7 @@ class _Repair:
                     # the rect; net -1 never matches a cap pad's net (even a
                     # net-tied mounting hole is not connectable copper, #328).
                     if (p.drill or 0) > 0:
-                        grow = max(0.0, defaults.NPTH_TO_TRACK_CLEARANCE
-                                   - clearance)
+                        grow = max(0.0, self.npth_floor - clearance)
                         for hx, hy, hd in pad_drill_circles(p):
                             hr = hd / 2.0 + grow
                             self.foreign_pads.append(
@@ -1018,6 +1030,13 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
     edge_rings, edge_outer, edge_cutouts = board_edge_geometry(
         getattr(pcb_data, 'board_info', None))
     bounds = getattr(getattr(pcb_data, 'board_info', None), 'board_bounds', None)
+    # #617 deliberately leaves this at the flat fab floor. The mover searches a
+    # 0.6 mm budget for a spot where BOTH the relocated via and its connector
+    # back to the stub validate; raising the connector's hole floor does not
+    # relocate the via somewhere better, it makes the whole search return "no
+    # clear spot" and the #130 pad-via graze the pass exists to fix persists.
+    # Measured on the #370-B3 harness with a declared 0.25: raised -> 0 moves,
+    # 0 connectors; flat -> 1 move, 1 connector.
     npth_clr = max(clearance, defaults.NPTH_TO_TRACK_CLEARANCE)
 
     def edge_ok_point(x, y, r):

--- a/py_router/cleanup_pipeline.py
+++ b/py_router/cleanup_pipeline.py
@@ -268,7 +268,11 @@ def run_post_route_cleanup(results, pcb_data, scope_net_ids, config, *,
         # #436: cross-class-aware graze fix — measure shortfall against each
         # net's own netclass floor and each foreign net's class, not the global
         # clearance (daisho's 456 same-class grid grazes, cparti's SW1-vs-SMA).
-        net_clearances=_nc, board_edge_clearance=_bec)
+        net_clearances=_nc, board_edge_clearance=_bec,
+        # #617: this front HAS a config, so the explicit
+        # `config.hole_clearance` override reaches resolve_hole_clearance
+        # rather than being silently dropped. Both fronts call this pipeline.
+        config=config)
     counts['microshifted'] = _ms_segs
     _trace('microshift')
     strip.extend(_ms_strip)

--- a/py_router/obstacle_map.py
+++ b/py_router/obstacle_map.py
@@ -1453,12 +1453,36 @@ def resolve_hole_clearance(pcb_data: PCBData, config) -> float:
     WHO ACTUALLY INHERITS IT, precisely -- everything routed through
     ``add_drill_hole_obstacles`` (signal, diff pairs, BGA/QFN fanout, via
     ``build_base_obstacle_map``), plus ``plane_obstacle_builder`` which builds
-    its own map and therefore needed the call adding separately. It is NOT a
-    universal fix: the flat ``NPTH_TO_TRACK_CLEARANCE`` still stands in
-    ``plane_region_connector`` (taps / region joins / reconnects),
-    ``pcb_modification`` and ``placement/fanout_clearance``. Those are the same
-    defect and are not yet closed; do not read this helper's existence as
-    covering them.
+    its own map and therefore needed the call adding separately. #617 added the
+    call at every site that DECIDES WHERE COPPER GOES in the three engines this
+    docstring used to name as uncovered: ``plane_region_connector``
+    (``npth_floor_ok`` seeds, ``wide_route_clear`` legs, ``build_base_obstacles``
+    stamps), ``pcb_modification`` (``_seg_worst_offender``'s shortfall ranking
+    and ``nudge_grazing_microshift``'s detector + acceptance gate) and
+    ``placement/fanout_clearance`` (``_Repair``'s NPTH keep-out rects).
+
+    STILL AT THE FLAT ``NPTH_TO_TRACK_CLEARANCE``, and deliberately so -- read
+    this before "finishing the job":
+
+    * ``pcb_modification.close_soft_joints`` and ``_connector_clear`` gate a
+      BRIDGE between two pieces of copper that already exist (a soft joint's
+      caps already overlap; a stub snap spans at most 1.5 track widths). When
+      such a bridge violates a declared floor the flanking copper almost always
+      does too, so raising the gate drops the repair without removing the
+      violation -- measured, 99.96% of the refusals it would add.
+    * ``pcb_modification.nudge_grazing_octolinear`` and
+      ``placement/fanout_clearance.nudge_vias_for_unresolved`` are all-or-
+      nothing repairs: refusing their one clearing candidate abandons the
+      defect they exist to fix (measured: a -0.1 mm net-to-net overlap left in
+      place; a #130 pad-via graze left unrelocated) rather than routing around
+      the hole.
+    * ``placement/legality.PartPads`` builds its NPTH keep-out radii from a bare
+      ``fp``/``clearance`` pair with no board pointer in hand, so it cannot call
+      this helper without a threaded parameter.
+
+    The rule the first three encode: raise this floor on passes that CHOOSE
+    where new copper goes or that MOVE copper by a measured shortfall, not on
+    passes whose only alternative to their one candidate is doing nothing.
 
     Why it exists: this keep-out was priced at a hardcoded
     ``max(clearance, NPTH_TO_TRACK_CLEARANCE)`` -- a flat 0.20 fab floor -- and

--- a/py_router/pcb_modification.py
+++ b/py_router/pcb_modification.py
@@ -3733,9 +3733,17 @@ def nudge_grazing_microshift(results, pcb_data: PCBData, scope_net_ids=None,
     # #617: raised to the board's own min_hole_clearance when it declares one
     # above that floor. This pass MOVES copper by the measured shortfall, so
     # raising the floor both makes it SEE a declared-band graze it used to miss
-    # and stops it "fixing" other copper INTO that band. Every candidate is
-    # still re-validated against all foreign copper, so it can only remove a
-    # graze. Raise-only.
+    # and stops it "fixing" other copper INTO that band. Raise-only.
+    #
+    # DELIBERATE TRADE the raised floor makes: the same term sits in the
+    # candidate-acceptance clears() below, so on a DECLARING board a copper-
+    # graze repair whose only escape direction points at a hole is REFUSED
+    # outright when every candidate would land inside the declared band --
+    # the graze stays. That is the right side of the trade (check_drc grades
+    # the declared band as a real violation since #616, so "fixing" the graze
+    # would manufacture a counted DRC hit), but it is a trade, not a free
+    # win: on a silent board the same repair proceeds.
+    # tests/test_617_pcb_modification_hole_clearance.py pins both arms.
     npth_clr = max(clearance, NPTH_TO_TRACK_CLEARANCE,
                    resolve_hole_clearance(pcb_data, config))
 

--- a/py_router/pcb_modification.py
+++ b/py_router/pcb_modification.py
@@ -479,6 +479,17 @@ def close_soft_joints(results, pcb_data: PCBData, scope_net_ids, config,
     clr = config.clearance if clearance is None else clearance
     # NPTH holes are graded at the higher NPTH-to-track fab floor, not the
     # routing clearance (#370 B2; mirrors the microshift's #308 term).
+    #
+    # #617 deliberately does NOT raise this to the board's declared
+    # min_hole_clearance. A soft joint spans two dangling ends whose caps
+    # ALREADY overlap (`gap < (w1+w2)/2` below), so the bridge's copper sits
+    # inside copper that already exists: when the bridge violates a declared
+    # floor the flanking segments almost always do too, and refusing the
+    # bridge drops a `segment-endpoint-gap` repair without removing the
+    # violation. Measured over 12.2M bridge geometries at a declared 0.25:
+    # the raised gate refuses 44.29% of them and in 99.96% of those refusals
+    # the violation is present either way. The declared floor belongs on the
+    # passes that MOVE copper (nudge_grazing_microshift), not here.
     npth_clr = max(clr, NPTH_TO_TRACK_CLEARANCE)
 
     def rk(x, y):
@@ -1036,6 +1047,12 @@ def _connector_clear(x1, y1, x2, y2, width, layer, net_id, pcb_data, clearance,
     # NPTH (no-copper) drill holes (#370 B2): the pad/via/segment loops below
     # all measure to COPPER, so a connector drawn straight across a mounting
     # hole passed every check. Slot/offset drills handled by the capsule.
+    #
+    # #617 deliberately leaves this at the flat fab floor, for the same reason
+    # as close_soft_joints: a stub-snap connector bridges a gap of at most
+    # 1.5 track widths between copper that already exists, so raising it to a
+    # declared min_hole_clearance drops the `snap_stub_gaps` repair without
+    # removing the violation in 99.96% of the geometries where it fires.
     npth_clr = max(clearance, NPTH_TO_TRACK_CLEARANCE)
     if _seg_foreign_hole_dist(pcb_data, net_id, x1, y1, x2, y2) \
             < npth_clr + half - 1e-4:
@@ -3255,6 +3272,17 @@ def nudge_grazing_octolinear(results, pcb_data: PCBData, scope_net_ids=None,
     # NPTH (no-copper) drill holes are graded at the higher NPTH-to-track floor,
     # and the copper distance terms don't see them (#370 B2; the microshift
     # sibling gained this term for #308, this re-bend path never did).
+    #
+    # #617 deliberately leaves this at the flat fab floor. The re-bend is
+    # all-or-nothing: when its only clearing bend runs inside a declared
+    # min_hole_clearance band, raising the gate does not move the copper
+    # elsewhere, it abandons the graze repair. Measured on a fixture whose jog
+    # overlaps a foreign pad by 0.1 mm, declaring 0.25: raised, the re-bend is
+    # refused and the -0.1000 net-to-net OVERLAP stays; flat, the re-bend fires
+    # and the overlap becomes +0.3500 at the cost of a 0.2200 hole gap. Trading
+    # a 0.1 mm short for a 0.03 mm hole shortfall is not an improvement. The
+    # sibling micro-shift, which moves copper by the measured shortfall instead
+    # of choosing among fixed bends, does carry the declared floor.
     npth_clr = max(clearance, NPTH_TO_TRACK_CLEARANCE)
 
     def eff_clr(nid):
@@ -3468,7 +3496,8 @@ def nudge_grazing_octolinear(results, pcb_data: PCBData, scope_net_ids=None,
             nets_changed, original_to_remove, added_segments)
 
 
-def _seg_worst_offender(pcb_data, net_id, s, clearance, net_clearances=None):
+def _seg_worst_offender(pcb_data, net_id, s, clearance, net_clearances=None,
+                        config=None):
     """The single worst foreign-copper offender below clearance of segment `s`:
     returns (shortfall_mm, t, away_x, away_y) or None. t is the parameter of the
     closest approach along `s`; (away_x, away_y) is the unit direction that
@@ -3480,11 +3509,17 @@ def _seg_worst_offender(pcb_data, net_id, s, clearance, net_clearances=None):
     element's class EXCESS over `clearance` is subtracted from its distance, so
     the shortfall ranking and the away-shift honor KiCad's pairwise max(own,
     foreign) per offender (e.g. a signal grazing an SMA-class trace is ranked by
-    its 0.35 shortfall, not the 0.1 global)."""
+    its 0.35 shortfall, not the 0.1 global).
+
+    #617: `config` is optional and used only for `resolve_hole_clearance`'s
+    explicit `config.hole_clearance` override -- the board read itself is
+    driven by `pcb_data.source_path`, so a caller with no config in hand still
+    gets the board's declared floor."""
     import numpy as np
     from single_ended_routing import (_foreign_pad_arrays, _foreign_seg_arrays,
                                       _foreign_via_arrays, _foreign_hole_capsules)
     from routing_defaults import NPTH_TO_TRACK_CLEARANCE
+    from obstacle_map import resolve_hole_clearance
 
     def _excess(fnids):
         # per-foreign class clearance above `clearance` (the moving net's floor)
@@ -3498,7 +3533,12 @@ def _seg_worst_offender(pcb_data, net_id, s, clearance, net_clearances=None):
     # (issue #308, urti GND vs J3's hole). Their required clearance differs from
     # the copper terms, so the worst offender is chosen by SHORTFALL, not raw
     # edge distance (a hole 0.15 away can out-rank a via 0.12 away).
-    hole_required = max(clearance, NPTH_TO_TRACK_CLEARANCE) + s.width / 2.0
+    # #617: the board's own min_hole_clearance raises this floor too, so the
+    # shortfall ranking sees the same band check_drc grades at. This is a
+    # DETECTOR -- raising it can only make a real violation visible to the
+    # micro-shift, never refuse a repair.
+    hole_required = max(clearance, NPTH_TO_TRACK_CLEARANCE,
+                        resolve_hole_clearance(pcb_data, config)) + s.width / 2.0
     x1, y1, x2, y2 = s.start_x, s.start_y, s.end_x, s.end_y
     n = max(2, int(math.hypot(x2 - x1, y2 - y1) / 0.005) + 1)
     ts = np.linspace(0.0, 1.0, n + 1)
@@ -3644,7 +3684,8 @@ def nudge_grazing_microshift(results, pcb_data: PCBData, scope_net_ids=None,
                              max_shift: float = 0.025,
                              keep_input_copper: bool = False,
                              net_clearances=None,
-                             board_edge_clearance: float = 0.0) -> Tuple[int, int, List[Segment], List[Segment]]:
+                             board_edge_clearance: float = 0.0,
+                             config=None) -> Tuple[int, int, List[Segment], List[Segment]]:
     """Micro-shift copper that still grazes after prune / re-bend / neck (#276).
 
     Complements nudge_grazing_octolinear, which keeps a jog's anchor endpoints
@@ -3675,16 +3716,28 @@ def nudge_grazing_microshift(results, pcb_data: PCBData, scope_net_ids=None,
     in the DRC report rather than be papered over with a wild move.
 
     Returns (segments_changed, nets_changed, original_segments_to_remove,
-    added_segments) -- same contract as nudge_grazing_octolinear."""
+    added_segments) -- same contract as nudge_grazing_octolinear.
+
+    #617: `config` is optional and only feeds `resolve_hole_clearance`'s
+    explicit `config.hole_clearance` override; the board's declared
+    min_hole_clearance is read off `pcb_data.source_path` either way."""
     from collections import defaultdict
     from check_connected import check_net_connectivity
     from single_ended_routing import (_seg_foreign_pad_dist, _seg_foreign_seg_dist,
                                       _seg_foreign_via_dist, _seg_foreign_hole_dist)
     from routing_defaults import NPTH_TO_TRACK_CLEARANCE
+    from obstacle_map import resolve_hole_clearance
 
     # NPTH (no-copper) drill holes are graded at the higher NPTH-to-track floor,
     # and the copper distance terms don't see them (issue #308, urti GND vs J3).
-    npth_clr = max(clearance, NPTH_TO_TRACK_CLEARANCE)
+    # #617: raised to the board's own min_hole_clearance when it declares one
+    # above that floor. This pass MOVES copper by the measured shortfall, so
+    # raising the floor both makes it SEE a declared-band graze it used to miss
+    # and stops it "fixing" other copper INTO that band. Every candidate is
+    # still re-validated against all foreign copper, so it can only remove a
+    # graze. Raise-only.
+    npth_clr = max(clearance, NPTH_TO_TRACK_CLEARANCE,
+                   resolve_hole_clearance(pcb_data, config))
 
     def eff_clr(nid):
         # #436: the moving net's own clearance floor = max(global, its netclass).
@@ -3796,7 +3849,8 @@ def nudge_grazing_microshift(results, pcb_data: PCBData, scope_net_ids=None,
                            or id(s) in added_ids)
                        and grazes(s)]
             offenders = [(s, _seg_worst_offender(pcb_data, net_id, s, eff_clr(net_id),
-                                                 net_clearances=net_clearances))
+                                                 net_clearances=net_clearances,
+                                                 config=config))
                          for s in grazing]
             offenders = [(s, o) for s, o in offenders if o is not None]
             if not offenders:

--- a/py_router/plane_region_connector.py
+++ b/py_router/plane_region_connector.py
@@ -24,7 +24,7 @@ from bresenham_utils import walk_line
 from obstacle_map import (add_board_edge_obstacles, add_user_keepout_obstacles,
                           add_rule_area_keepout_obstacles,
                           _batch_cells_one_layer, _batch_vias,
-                          block_track_cells_near_drills,
+                          block_track_cells_near_drills, resolve_hole_clearance,
                           block_track_cells_near_override_pad_holes, _pad_has_copper)
 from plane_obstacle_builder import (
     _precompute_circle_offsets,
@@ -1269,7 +1269,7 @@ def _npth_holes(pcb_data):
     return holes
 
 
-def npth_floor_ok(x, y, pcb_data, track_half: float) -> bool:
+def npth_floor_ok(x, y, pcb_data, track_half: float, config=None) -> bool:
     """False when track copper of half-width `track_half` centered at (x, y)
     would violate the NPTH-to-track fab floor of a no-copper drill (#390).
 
@@ -1277,8 +1277,15 @@ def npth_floor_ok(x, y, pcb_data, track_half: float) -> bool:
     the obstacle map's (correct) NPTH drill keep-out -- so every fill-derived
     seed must respect the floor itself. The fill-validity margin ladder must
     never relax below this: zone fill lawfully sits closer to an NPTH than
-    track copper may (crkbd GNDR strap seeded 0.15 from the rEXSW1 hole edge)."""
-    floor = defaults.NPTH_TO_TRACK_CLEARANCE + track_half
+    track copper may (crkbd GNDR strap seeded 0.15 from the rEXSW1 hole edge).
+
+    #617: the floor is raised to the BOARD's own `min_hole_clearance` when it
+    declares one above the 0.20 fab value (`resolve_hole_clearance`, raise-only
+    and cached per board path). `config` is optional -- the read is driven by
+    ``pcb_data.source_path``, so seed callers with no config in hand still get
+    the board's value; passing one only adds the explicit override."""
+    floor = max(defaults.NPTH_TO_TRACK_CLEARANCE,
+                resolve_hole_clearance(pcb_data, config)) + track_half
     for hx, hy, hdia in _npth_holes(pcb_data):
         if math.hypot(x - hx, y - hy) < hdia / 2.0 + floor:
             return False
@@ -2817,6 +2824,10 @@ def wide_route_clear(route_points, width, pcb_data, net_id, config,
         return best
 
     _clr_max_by_layer = {}
+    # #617: the board's own copper-to-hole floor, resolved once per call
+    # (cached per board path inside the helper). Raise-only, so a board that
+    # declares nothing keeps this predicate's decisions bit-identical.
+    _hole_clr = resolve_hole_clearance(pcb_data, config)
 
     for (x1, y1, x2, y2, layer) in legs:
         bb = (min(x1, x2), min(y1, y2), max(x1, x2), max(y1, y2))
@@ -2861,7 +2872,8 @@ def wide_route_clear(route_points, width, pcb_data, net_id, config,
         # math per leg), so both share this superset gate. NPTH's req is
         # half + hdia/2 + npth_clr with the drill inside the pad body, so
         # pext + max(local, clr_max, config.clearance, NPTH floor) bounds it.
-        _npth_bound = max(config.clearance, defaults.NPTH_TO_TRACK_CLEARANCE)
+        _npth_bound = max(config.clearance, defaults.NPTH_TO_TRACK_CLEARANCE,
+                          _hole_clr)
         preq = half + _pext + _pdrill + np.maximum(_plocal,
                                                    max(clr_max, _npth_bound))
         for pi in np.nonzero((bb[0] - preq <= _px) & (_px <= bb[2] + preq)
@@ -2894,7 +2906,8 @@ def wide_route_clear(route_points, width, pcb_data, net_id, config,
                             return False
                 if is_th:
                     npth_clr = max(config.clearance,
-                                   defaults.NPTH_TO_TRACK_CLEARANCE) \
+                                   defaults.NPTH_TO_TRACK_CLEARANCE,
+                                   _hole_clr) \
                         if p.pad_type == 'np_thru_hole' else None
                     if npth_clr is not None:
                         for hx, hy, hdia in pad_drill_circles(p):
@@ -3149,7 +3162,10 @@ def build_base_obstacles(
     # the hard fab requirement and cell centers at >= the radius stay free, so
     # this blocks the minimum area that avoids real copper-to-hole violations.
     if npth_holes:
-        npth_clr = max(config.clearance, defaults.NPTH_TO_TRACK_CLEARANCE)
+        # #617: raised to the board's own min_hole_clearance when it declares
+        # one above the fab floor (raise-only; inert on a silent board).
+        npth_clr = max(config.clearance, defaults.NPTH_TO_TRACK_CLEARANCE,
+                       resolve_hole_clearance(pcb_data, config))
         block_track_cells_near_drills(obstacles, npth_holes, track_width,
                                       npth_clr, config.grid_step,
                                       list(range(num_layers)))

--- a/tests/test_617_pcb_modification_hole_clearance.py
+++ b/tests/test_617_pcb_modification_hole_clearance.py
@@ -57,6 +57,7 @@ from single_ended_routing import (_seg_foreign_hole_dist, _seg_foreign_pad_dist,
 from pcb_modification import (_connector_clear, _seg_worst_offender,
                               close_soft_joints, nudge_grazing_microshift,
                               nudge_grazing_octolinear)
+from routing_defaults import NPTH_TO_TRACK_CLEARANCE
 from synth import make_pad, make_pcb, make_seg
 
 HOLE_X, HOLE_Y = 10.0, 10.0
@@ -145,6 +146,7 @@ def run():
 
         _worst_offender(check, declares, silent)
         _microshift(check, declares, silent)
+        _microshift_trade(check, declares, silent)
         _soft_joint_stays_flat(check, declares)
         _connector_stays_flat(check, declares)
         _octolinear_stays_flat(check, declares)
@@ -225,6 +227,51 @@ def _microshift(check, declares, silent):
         else:
             check('untouched copper keeps its exact geometry',
                   abs(hole1 - BAND) < 1e-9 and abs(cop1 - cop0) < 1e-12)
+    print()
+
+
+# === CHANGED site 2b: the acceptance-gate TRADE, pinned as policy ==========
+def _microshift_trade(check, declares, silent):
+    """The raised floor also sits in the candidate-acceptance clears(), so a
+    copper-graze repair whose only escape direction points at a hole is
+    REFUSED on a declaring board when every candidate would land inside the
+    declared band -- the graze stays. That is deliberate (since #616,
+    check_drc counts the declared band as a real violation, so 'fixing' the
+    graze would manufacture a counted DRC hit), but it is a TRADE, and this
+    pins BOTH arms so it can never be mistaken for a free win. Fixture: a
+    net-1 track grazing a foreign pad from below, with a mask-only NPTH just
+    beneath the track, so the only clearing shift direction is toward the
+    hole."""
+    print('CHANGED site 2b: acceptance gate -- the declaring-board trade is '
+          'deliberate and pinned')
+    yh = 0.86
+    pads = {2: [make_pad(net_id=2, x=2.0, y=0.34, ref='R1', num='1',
+                         size_x=0.3, size_y=0.3, shape='rect',
+                         layers=['F.Cu'], pad_type='smd')],
+            0: [_npth(2.0, -yh, 1.0, layers=('F.Mask', 'B.Mask'))]}
+    for path, label, repaired in ((declares, 'declared 0.25', False),
+                                  (silent, 'nothing declared', True)):
+        s = make_seg(0.0, 0.0, 4.0, 0.0, width=0.2, net_id=1)
+        pcb = _pcb(path, [s], pads, bounds=(-5.0, -5.0, 15.0, 15.0))
+        cop0, hole0 = min(_copper_gaps(pcb)), min(_hole_gaps(pcb))
+        changed, nets, _rm, _add = nudge_grazing_microshift(
+            [], pcb, clearance=0.1)
+        cop1, hole1 = min(_copper_gaps(pcb)), min(_hole_gaps(pcb))
+        print(f'        {label}: segs_changed={changed} nets={nets}; '
+              f'foreign-copper {cop0:+.4f} -> {cop1:+.4f}; '
+              f'copper-to-hole {hole0:.4f} -> {hole1:.4f}')
+        if repaired:
+            check('silent board: the copper-graze repair PROCEEDS (the flat '
+                  'floor permits the shift toward the hole)',
+                  nets == 1 and cop1 > cop0)
+            check('and stays legal at the flat NPTH floor',
+                  hole1 >= NPTH_TO_TRACK_CLEARANCE - 1e-4)
+        else:
+            check('declaring board: the same repair is REFUSED rather than '
+                  'moved into the declared band (the deliberate trade)',
+                  nets == 0 and abs(cop1 - cop0) < 1e-12)
+            check('and the incumbent copper-to-hole clearance is untouched',
+                  abs(hole1 - hole0) < 1e-12)
     print()
 
 

--- a/tests/test_617_pcb_modification_hole_clearance.py
+++ b/tests/test_617_pcb_modification_hole_clearance.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+"""Issue #617, engine 2/3: pcb_modification's graze REPAIR must read
+min_hole_clearance -- and its bridge/re-bend gates must NOT.
+
+`check_drc` grades copper-to-hole at the board's own `min_hole_clearance`
+(check_drc.py:2390) and `obstacle_map.resolve_hole_clearance` (#616) exposes it
+to the engines, while every NPTH term in this module was priced at a flat
+`max(clearance, NPTH_TO_TRACK_CLEARANCE)` = 0.20 mm. Five sites were candidates
+for the fix; #617 changes TWO of them, and this test pins BOTH halves of that
+decision, because the difference is measured, not stylistic:
+
+  CHANGED -- passes that MOVE copper by a measured shortfall. Raising the floor
+  makes them SEE a real violation they used to miss, and the move is validated
+  against all foreign copper before it lands:
+      _seg_worst_offender        the shortfall ranking that drives the shift
+      nudge_grazing_microshift   the graze DETECTOR + the shift acceptance gate
+
+  DELIBERATELY UNCHANGED -- passes whose only alternative to their single
+  candidate is doing nothing. Raising the floor there does not move copper
+  somewhere legal, it abandons the repair:
+      close_soft_joints          bridges two dangling ends whose caps ALREADY
+                                 overlap, so the flanking copper is already in
+                                 violation (measured below: the refusal buys
+                                 1.5um on a 28.5um violation)
+      _connector_clear           same shape -- a stub snap spans at most
+                                 1.5 track widths of EXISTING copper
+      nudge_grazing_octolinear   all-or-nothing re-bend: refusing it leaves the
+                                 net-to-net copper OVERLAP it was repairing
+
+The three "unchanged" cases are kept as CHANGE DETECTORS with their measured
+numbers, so a later pass at "finishing the job" has to re-measure rather than
+rediscover this the hard way.
+
+Every case is built on a board whose sibling project DECLARES
+`min_hole_clearance: 0.25`, with copper at exactly 0.22 mm from the NPTH hole
+wall -- legal at the flat 0.20 fab floor, a 0.03 mm violation of what the board
+actually asks for. Each changed case is paired with the SAME geometry on a
+board declaring nothing, pinning that the change is RAISE-ONLY.
+
+    python3 tests/test_617_pcb_modification_hole_clearance.py
+"""
+import json
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'py_router'))  # #522
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'py_tools'))  # #522
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import obstacle_map
+from kicad_parser import BoardInfo
+from routing_config import GridRouteConfig
+from single_ended_routing import (_seg_foreign_hole_dist, _seg_foreign_pad_dist,
+                                  _seg_foreign_seg_dist, _seg_foreign_via_dist)
+from pcb_modification import (_connector_clear, _seg_worst_offender,
+                              close_soft_joints, nudge_grazing_microshift,
+                              nudge_grazing_octolinear)
+from synth import make_pad, make_pcb, make_seg
+
+HOLE_X, HOLE_Y = 10.0, 10.0
+DRILL = 1.0                 # -> hole wall at radius 0.5
+W = 0.2                     # track width -> half 0.1
+DECLARED = 0.25
+BAND = 0.22                 # copper-to-hole-WALL gap under test
+Y = HOLE_Y + DRILL / 2.0 + BAND + W / 2.0       # 10.82: centreline of the copper
+CLEARANCE = 0.15            # routing clearance, below both floors
+# A foreign-net pad above the copper under test: near enough that a shift
+# toward it is measurable, far enough that a legal shift exists.
+FOREIGN_Y = 11.30
+FOREIGN_SIZE = 0.30
+
+
+def _board_dir(tmp, name, **rules):
+    """A board file whose sibling project declares `rules` (KiCad writes
+    min_hole_clearance into board.design_settings.rules)."""
+    d = os.path.join(tmp, name)
+    os.makedirs(d, exist_ok=True)
+    pcb = os.path.join(d, 'b.kicad_pcb')
+    with open(pcb, 'w', encoding='utf-8') as f:
+        f.write('(kicad_pcb (version 20240108))\n')
+    with open(os.path.join(d, 'b.kicad_pro'), 'w', encoding='utf-8') as f:
+        json.dump({'board': {'design_settings': {'rules': rules}}}, f)
+    return pcb
+
+
+def _npth(x, y, drill, layers=('*.Cu', '*.Mask')):
+    return make_pad(net_id=0, x=x, y=y, ref='BUS1', num='H1', size_x=drill,
+                    size_y=drill, shape='circle', layers=list(layers),
+                    drill=drill, pad_type='np_thru_hole')
+
+
+def _pcb(path, segs=(), pads=None, bounds=(0.0, 0.0, 20.0, 20.0)):
+    """A board rooted at `path`, so the engines resolve the declared floor
+    through PCBData.source_path (the #498 mechanism resolve_hole_clearance
+    uses)."""
+    bi = BoardInfo(layers={}, copper_layers=['F.Cu', 'B.Cu'],
+                   board_bounds=bounds)
+    return make_pcb(board_info=bi, segments=list(segs),
+                    pads_by_net=(pads if pads is not None
+                                 else {0: [_npth(HOLE_X, HOLE_Y, DRILL)]}),
+                    source_path=path, zones=[])
+
+
+def _hole_gaps(pcb, net_id=1):
+    return [_seg_foreign_hole_dist(pcb, s.net_id, s.start_x, s.start_y,
+                                   s.end_x, s.end_y) - s.width / 2.0
+            for s in pcb.segments if s.net_id == net_id]
+
+
+def _copper_gaps(pcb, net_id=1):
+    """Closest approach to FOREIGN COPPER (pads, tracks, vias) -- the defect
+    class these passes must never make worse."""
+    out = []
+    for s in pcb.segments:
+        if s.net_id != net_id:
+            continue
+        a = (s.start_x, s.start_y, s.end_x, s.end_y)
+        out.append(min(
+            _seg_foreign_pad_dist(pcb, s.net_id, *a, s.layer),
+            _seg_foreign_seg_dist(pcb, s.net_id, *a, s.layer),
+            _seg_foreign_via_dist(pcb, s.net_id, *a, s.layer)) - s.width / 2.0)
+    return out
+
+
+def run():
+    fails = []
+
+    def check(name, cond):
+        print(('PASS' if cond else 'FAIL') + f': {name}')
+        if not cond:
+            fails.append(name)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        declares = _board_dir(tmp, 'declares', min_hole_clearance=DECLARED)
+        silent = _board_dir(tmp, 'silent')
+        obstacle_map._HOLE_CLR_CACHE.clear()
+
+        print(f'board declares min_hole_clearance = {DECLARED}mm; the copper '
+              f'under test sits {BAND}mm off the hole wall')
+        print(f'  hole ({HOLE_X}, {HOLE_Y}) drill {DRILL}; track width {W} '
+              f'centred at y={Y:.4g}')
+        print()
+
+        _worst_offender(check, declares, silent)
+        _microshift(check, declares, silent)
+        _soft_joint_stays_flat(check, declares)
+        _connector_stays_flat(check, declares)
+        _octolinear_stays_flat(check, declares)
+
+    print()
+    if fails:
+        print(f'{len(fails)} FAILURE(S): {fails}')
+        return 1
+    print('all checks passed')
+    return 0
+
+
+# === CHANGED site 1: _seg_worst_offender -- the shortfall ranking ===========
+def _worst_offender(check, declares, silent):
+    print('CHANGED site 1: _seg_worst_offender -- the graze shortfall ranking')
+    out = {}
+    for path, label in ((declares, 'declared 0.25'), (silent, 'nothing declared')):
+        s = make_seg(8.0, Y, 12.0, Y, width=W, net_id=1)
+        out[label] = _seg_worst_offender(_pcb(path, [s]), 1, s, CLEARANCE)
+        got = out[label]
+        print(f'        {label}: '
+              + (f'shortfall {got[0]:.4f}mm' if got else 'no offender'))
+    dec = out['declared 0.25']
+    check('the declared floor makes the 0.22 approach a ranked offender',
+          dec is not None and abs(dec[0] - (DECLARED - BAND)) < 1e-3)
+    check('nothing declared -> still no offender (raise-only)',
+          out['nothing declared'] is None)
+
+    # #617/F5: the helper's documented `config.hole_clearance` override now
+    # reaches this site instead of being dropped on the floor.
+    cfg = GridRouteConfig()
+    cfg.hole_clearance = 0.40
+    s = make_seg(8.0, Y, 12.0, Y, width=W, net_id=1)
+    try:
+        got = _seg_worst_offender(_pcb(silent, [s]), 1, s, CLEARANCE, config=cfg)
+        shown = f'shortfall {got[0]:.4f}mm' if got else 'no offender'
+    except TypeError as exc:            # no `config` parameter at all (base)
+        got, shown = None, f'TypeError: {exc}'
+    print(f'        explicit config.hole_clearance=0.40 on the SILENT board: '
+          f'{shown}')
+    check('an explicit config.hole_clearance reaches this site',
+          got is not None and abs(got[0] - (0.40 - BAND)) < 1e-3)
+    print()
+
+
+# === CHANGED site 2: nudge_grazing_microshift -- detector + acceptance ======
+def _microshift(check, declares, silent):
+    """The pass that MOVES copper. It must (a) see the declared-band graze,
+    (b) actually clear it, and (c) not make the foreign-COPPER clearance it
+    was already honouring any worse -- the paired assertion that separates a
+    real repair from a refusal dressed up as one."""
+    print('CHANGED site 2: nudge_grazing_microshift -- detector + shift '
+          'acceptance')
+    pads = {0: [_npth(HOLE_X, HOLE_Y, DRILL)],
+            2: [make_pad(net_id=2, x=10.0, y=FOREIGN_Y, ref='R1', num='1',
+                         size_x=FOREIGN_SIZE, size_y=FOREIGN_SIZE,
+                         shape='rect', layers=['F.Cu'], pad_type='smd')]}
+    for path, label, want in ((declares, 'declared 0.25', True),
+                              (silent, 'nothing declared', False)):
+        s = make_seg(8.0, Y, 12.0, Y, width=W, net_id=1)
+        pcb = _pcb(path, [s], pads)
+        hole0, cop0 = min(_hole_gaps(pcb)), min(_copper_gaps(pcb))
+        res = [{'new_segments': [s], 'new_vias': []}]
+        changed, nets, _rm, _add = nudge_grazing_microshift(
+            res, pcb, {1}, clearance=CLEARANCE, max_shift=0.06)
+        hole1, cop1 = min(_hole_gaps(pcb)), min(_copper_gaps(pcb))
+        print(f'        {label}: segs_changed={changed} nets={nets}; '
+              f'copper-to-hole {hole0:.4f} -> {hole1:.4f}; '
+              f'foreign-copper {cop0:.4f} -> {cop1:.4f}')
+        check(f'micro-shift {"fires" if want else "stays inert"} when {label}',
+              (nets == 1) is want)
+        if want:
+            check('the shifted copper now clears the DECLARED floor',
+                  hole1 >= DECLARED - 1e-4)
+            check('and the foreign-COPPER clearance it was already honouring '
+                  'is still honoured (no repair traded away)',
+                  cop1 >= CLEARANCE - 1e-4)
+        else:
+            check('untouched copper keeps its exact geometry',
+                  abs(hole1 - BAND) < 1e-9 and abs(cop1 - cop0) < 1e-12)
+    print()
+
+
+# === UNCHANGED site 1: close_soft_joints ===================================
+def _soft_joint_stays_flat(check, declares):
+    """Change detector. The two dangling ends' caps already overlap, so the
+    bridge sits inside copper that is ALREADY in violation: gating it on the
+    declared floor drops a `segment-endpoint-gap` repair and leaves the
+    violation exactly where it was."""
+    print('UNCHANGED site 1: close_soft_joints -- bridge still at the flat '
+          'fab floor')
+    segs = [make_seg(8.0, Y, 9.9, Y, width=W, net_id=1),
+            make_seg(10.05, Y, 12.0, Y, width=W, net_id=1)]
+    pcb = _pcb(declares, segs)
+    before = min(_hole_gaps(pcb))
+    cfg = GridRouteConfig()
+    cfg.clearance = CLEARANCE
+    n = close_soft_joints([], pcb, {1}, cfg)
+    after = min(_hole_gaps(pcb))
+    print(f'        declared 0.25: bridges={n}; min copper-to-hole '
+          f'{before:.4f} -> {after:.4f}')
+    check('the bridge is still laid on a DECLARING board (the repair is kept)',
+          n == 1)
+    check('and refusing it would not have helped: the flanking copper already '
+          f'violates {DECLARED} at {before:.4f}mm',
+          before < DECLARED - 1e-9)
+    check('the bridge itself costs only what the existing copper already cost '
+          '(<0.01mm)', (before - after) < 0.01)
+    _bridge_sweep(check)
+    print()
+
+
+def _bridge_sweep(check):
+    """The fixture above is one geometry; this is the whole family, exactly.
+
+    Two collinear track pieces on y=0 whose facing ends are `gap` apart, width
+    w, and an NPTH of diameter d at (hx, hy); the bridge spans the gap. Sweep
+    w, d, gap (0.25x..1.5x w, covering both the soft-joint and stub-snap
+    limits) and the hole position on a 5um lattice, and count how often
+    refusing the bridge would actually REMOVE the violation (pre >= FLOOR >
+    post) rather than merely drop the repair."""
+    import numpy as np
+
+    def gap_to(hx, hy, x1, x2, w, d):
+        return np.hypot(hx - np.minimum(np.maximum(hx, x1), x2), hy) \
+            - w / 2.0 - d / 2.0
+
+    tot = refuse = sole = 0
+    for w in (0.10, 0.15, 0.20, 0.25, 0.30):
+        for d in (0.6, 0.8, 1.0, 1.5, 2.0):
+            for gmul in (0.25, 0.5, 0.75, 1.0, 1.25, 1.5):
+                g = gmul * w
+                hx = np.arange(-1.0, 1.0001, 0.005)[:, None]
+                hy = np.arange(0.0, 1.5001, 0.005)[None, :]
+                pre = np.minimum(gap_to(hx, hy, -2.0, -g / 2, w, d),
+                                 gap_to(hx, hy, g / 2, 2.0, w, d))
+                post = np.minimum(pre, gap_to(hx, hy, -g / 2, g / 2, w, d))
+                live = post >= -w          # bridge inside the hole = nonsense
+                hit = live & (post < DECLARED)
+                tot += int(live.sum())
+                refuse += int(hit.sum())
+                sole += int((hit & (pre >= DECLARED)).sum())
+    pct = 100.0 * (refuse - sole) / refuse
+    print(f'        sweep: {tot:,} bridge geometries at a declared {DECLARED}; '
+          f'a raised gate would refuse {refuse:,} ({100.0 * refuse / tot:.2f}%)'
+          f' and in {pct:.4f}% of those the violation is present ANYWAY')
+    check('over the whole bridge family, >99% of the refusals a raised gate '
+          'would add remove no violation at all', pct > 99.0)
+
+
+# === UNCHANGED site 2: _connector_clear ====================================
+def _connector_stays_flat(check, declares):
+    """Change detector. `snap_stub_gaps` closes a dangling end with a
+    connector spanning at most 1.5 track widths of EXISTING copper -- same
+    shape as the soft joint, same conclusion."""
+    print('UNCHANGED site 2: _connector_clear -- stub snap still at the flat '
+          'fab floor')
+    ok = _connector_clear(8.0, Y, 12.0, Y, W, 'F.Cu', 1, _pcb(declares),
+                          CLEARANCE)
+    print(f'        declared 0.25: connector {BAND}mm off the wall '
+          f'accepted={ok}')
+    check('the stub-snap connector is still accepted on a DECLARING board',
+          ok)
+    print()
+
+
+# === UNCHANGED site 3: nudge_grazing_octolinear ============================
+def _octolinear_stays_flat(check, declares):
+    """Change detector, and the sharpest of the three. A net-1 jog
+    A(0,0) -> apex(1,0.5) -> B(2,0) whose apex OVERLAPS a foreign pad by
+    0.1 mm. The only clearing octolinear bend is the direct A-B line, which
+    runs 0.22 mm off a mask-only NPTH at (1, -0.62). Gating the re-bend on a
+    declared 0.25 does not route around the hole -- it leaves the net-to-net
+    copper overlap in place."""
+    print('UNCHANGED site 3: nudge_grazing_octolinear -- re-bend still at the '
+          'flat fab floor')
+    segs = [make_seg(0.0, 0.0, 1.0, 0.5, width=W, net_id=1),
+            make_seg(1.0, 0.5, 2.0, 0.0, width=W, net_id=1)]
+    pads = {
+        2: [make_pad(net_id=2, x=1.0, y=0.6, ref='R1', num='1',
+                     size_x=0.3, size_y=0.3, shape='rect',
+                     layers=['F.Cu'], pad_type='smd')],
+        # mask-only NPTH: no phantom copper, so ONLY the hole floor could stop
+        # the re-bend (mirrors the #370 B2 fixture).
+        0: [_npth(1.0, -0.62, 0.6, layers=('F.Mask', 'B.Mask'))],
+    }
+    pcb = _pcb(declares, segs, pads, bounds=(-5.0, -5.0, 15.0, 15.0))
+    pad0, hole0 = min(_copper_gaps(pcb)), min(_hole_gaps(pcb))
+    _changed, nets, _rm, _add = nudge_grazing_octolinear([], pcb, clearance=0.1)
+    pad1, hole1 = min(_copper_gaps(pcb)), min(_hole_gaps(pcb))
+    print(f'        declared 0.25: nets re-bent={nets}; foreign-pad '
+          f'{pad0:+.4f} -> {pad1:+.4f} (negative = net-to-net OVERLAP); '
+          f'copper-to-hole {hole0:.4f} -> {hole1:.4f}')
+    check('the re-bend still fires on a DECLARING board', nets == 1)
+    check('and it repairs a real net-to-net copper OVERLAP',
+          pad0 < 0.0 and pad1 > 0.0)
+    check('which is a bigger defect than the hole shortfall it leaves '
+          f'({-pad0:.4f}mm short vs {DECLARED - hole1:.4f}mm)',
+          -pad0 > (DECLARED - hole1))
+
+
+if __name__ == '__main__':
+    sys.exit(run())

--- a/tests/test_617_placement_fanout_hole_clearance.py
+++ b/tests/test_617_placement_fanout_hole_clearance.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""Issue #617, engine 3/3: placement/fanout_clearance must read
+min_hole_clearance in its keep-out geometry -- and not in its via mover.
+
+The decoupling-cap repair (#130) grew its NPTH keep-out rects to a flat
+`NPTH_TO_TRACK_CLEARANCE` (0.20) and validated its via-mover connectors at a
+flat `max(clearance, NPTH_TO_TRACK_CLEARANCE)`. `check_drc` grades
+copper-to-hole at the BOARD's `min_hole_clearance` (check_drc.py:2390), so on a
+board declaring 0.25 this pass parked cap pads inside a band its own checker
+then flagged. #617 changes ONE of the two sites:
+
+  CHANGED    `_Repair`'s NPTH keep-out rects -- the cost model the whole search
+             descends. Raising it makes the pass SEE the shortfall and MOVE the
+             cap out of the band; every other cap it was already repairing is
+             still repaired.
+  UNCHANGED  `nudge_vias_for_unresolved`'s connector gate -- the mover searches
+             a 0.6 mm budget for a spot where the relocated via AND its
+             connector back to the stub both validate. Raising the connector's
+             hole floor does not find a better spot, it makes the whole search
+             return "no clear spot" and the #130 pad-via graze the pass exists
+             to fix persists. Kept below as a CHANGE DETECTOR with its numbers.
+
+Case 1 runs the REAL repair pass end to end on a REAL in-repo board
+(`kicad_files/orangecrab_ext_pll.kicad_pcb`) staged into a temp dir beside a
+project that DECLARES `min_hole_clearance: 0.25`, with an NPTH mounting hole
+placed 0.22 mm off the pad copper of a cap that is otherwise CLEAN -- so the
+hole is the only reason to move it. Both arms are graded on the same board.
+
+    python3 tests/test_617_placement_fanout_hole_clearance.py
+"""
+import json
+import math
+import os
+import shutil
+import sys
+import tempfile
+from types import SimpleNamespace
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))   # #522
+sys.path.insert(0, os.path.join(ROOT, 'py_placer'))   # placement split
+sys.path.insert(0, os.path.join(ROOT, 'py_tools'))    # #522
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import obstacle_map
+from kicad_parser import BoardInfo, Pad, Segment, Via, parse_kicad_pcb
+from single_ended_routing import _seg_foreign_hole_dist
+from placement.fanout_clearance import (_Repair, nudge_vias_for_unresolved,
+                                        repair_fanout_clearance)
+from synth import make_pad, make_pcb
+
+BOARD = os.path.join(ROOT, 'kicad_files', 'orangecrab_ext_pll.kicad_pcb')
+CLEAR = 0.1
+DECLARED = 0.25
+BAND = 0.22                 # copper-to-hole-WALL gap under test
+HOLE_DRILL = 1.0
+
+
+def _declaring_project(d, **rules):
+    with open(os.path.join(d, 'b.kicad_pro'), 'w', encoding='utf-8') as f:
+        json.dump({'board': {'design_settings': {'rules': rules}}}, f)
+
+
+def _stage_real_board(tmp, name, **rules):
+    """A COPY of the in-repo board plus a sibling project declaring `rules`."""
+    d = os.path.join(tmp, name)
+    os.makedirs(d, exist_ok=True)
+    dst = os.path.join(d, 'b.kicad_pcb')
+    shutil.copyfile(BOARD, dst)
+    _declaring_project(d, **rules)
+    return dst
+
+
+def _stub_board(tmp, name, **rules):
+    """A bare board file plus a sibling project declaring `rules` (case 2 uses
+    synthetic PCBData; only the project has to exist on disk)."""
+    d = os.path.join(tmp, name)
+    os.makedirs(d, exist_ok=True)
+    pcb = os.path.join(d, 'b.kicad_pcb')
+    with open(pcb, 'w', encoding='utf-8') as f:
+        f.write('(kicad_pcb (version 20240108))\n')
+    _declaring_project(d, **rules)
+    return pcb
+
+
+def _seed_state(path):
+    return _Repair(parse_kicad_pcb(path), path, CLEAR, 0.1, 0.55, 1.0, 2.0,
+                   0.3, 'C', set())
+
+
+def _add_mounting_hole(pcb, hole):
+    """Attach an NPTH mounting hole to a DETERMINISTICALLY chosen non-cap,
+    non-resistor footprint (sorted by reference, not dict order)."""
+    host = sorted(r for r in pcb.footprints if not r.startswith(('C', 'R')))[0]
+    pcb.footprints[host].pads.append(Pad(
+        component_ref=host, pad_number='H9', global_x=hole[0],
+        global_y=hole[1], local_x=0.0, local_y=0.0, size_x=HOLE_DRILL,
+        size_y=HOLE_DRILL, shape='circle', layers=['*.Cu', '*.Mask'],
+        net_id=0, net_name='', drill=HOLE_DRILL, pad_type='np_thru_hole'))
+    return host
+
+
+def _wall_gap(rects, hole):
+    """Smallest hole-wall-to-pad-copper gap over a cap's pad rects."""
+    best = math.inf
+    for r in rects:
+        dx = max(r[0] - hole[0], 0.0, hole[0] - r[2])
+        dy = max(r[1] - hole[1], 0.0, hole[1] - r[3])
+        best = min(best, math.hypot(dx, dy) - HOLE_DRILL / 2.0)
+    return best
+
+
+def run():
+    fails = []
+
+    def check(name, cond):
+        print(('PASS' if cond else 'FAIL') + f': {name}')
+        if not cond:
+            fails.append(name)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        obstacle_map._HOLE_CLR_CACHE.clear()
+        _cap_repair(check, tmp)
+        _via_mover_stays_flat(check, tmp)
+
+    print()
+    if fails:
+        print(f'{len(fails)} FAILURE(S): {fails}')
+        return 1
+    print('all checks passed')
+    return 0
+
+
+# === CHANGED: _Repair's NPTH keep-out, graded through the REAL repair pass ===
+def _cap_repair(check, tmp):
+    print(f'CHANGED site: _Repair NPTH keep-out -- {os.path.basename(BOARD)}, '
+          f'graded through repair_fanout_clearance')
+    silent = _stage_real_board(tmp, 'real_silent')
+
+    # Pick, deterministically, a movable near-BGA cap that is ALREADY clean of
+    # foreign copper, so the mounting hole below is the ONLY reason to move it.
+    seed = _seed_state(silent)
+    clean = sorted(r for r, c in seed.caps.items()
+                   if seed.graze_penalty(r, c, c.x, c.y, c.rot) <= 0.0)
+    cap_ref = clean[0]
+    rect = min(seed.caps[cap_ref].pad_rects(), key=lambda r: r[0])
+    hole = (rect[0] - (HOLE_DRILL / 2.0 + BAND), (rect[1] + rect[3]) / 2.0)
+    print(f'        {len(seed.caps)} movable near-BGA caps, {len(clean)} of '
+          f'them already clean -> using {cap_ref}')
+    print(f'        {cap_ref} pad edge x={rect[0]:.4f}; NPTH drill '
+          f'{HOLE_DRILL} at ({hole[0]:.4f}, {hole[1]:.4f}) -> {BAND}mm of wall '
+          f'gap (legal at the flat 0.20 floor, 0.03 inside a declared 0.25)')
+
+    got = {}
+    for label, rules in (('nothing declared', {}),
+                         ('declared 0.25', {'min_hole_clearance': DECLARED})):
+        path = _stage_real_board(tmp, label.replace(' ', '_'), **rules)
+        pcb = parse_kicad_pcb(path)
+        _add_mounting_hole(pcb, hole)
+        res = repair_fanout_clearance(pcb, path, clearance=CLEAR,
+                                      cap_prefix='C', max_passes=30)
+        moved = {m['reference']: m for m in res['placements']}
+        cap = _Repair(pcb, path, CLEAR, 0.1, 0.55, 1.0, 2.0, 0.3, 'C',
+                      set()).caps[cap_ref]
+        if cap_ref in moved:
+            m = moved[cap_ref]
+            rects = cap.pad_rects(m['new_x'], m['new_y'], m['new_rotation'])
+            where = f"MOVED to ({m['new_x']:.4f}, {m['new_y']:.4f})"
+        else:
+            rects, where = cap.pad_rects(), 'NOT moved'
+        gap = _wall_gap(rects, hole)
+        got[label] = (gap, len(res['unresolved']), len(res['placements']))
+        print(f'        {label}: {cap_ref} {where}; pad-to-hole-wall gap '
+              f'{gap:.4f}mm; {len(res["placements"])} cap(s) moved, '
+              f'{len(res["unresolved"])} unresolved')
+
+    check(f'the base leaves {cap_ref} inside the declared band '
+          f'(gap {got["nothing declared"][0]:.4f} < {DECLARED})',
+          got['nothing declared'][0] < DECLARED - 1e-6)
+    check('the declared 0.25 makes the pass MOVE it out of the band '
+          '(the violation is removed, not just scored)',
+          got['declared 0.25'][0] >= DECLARED - 1e-6)
+    check('and no repair is traded away: 0 unresolved caps on BOTH arms',
+          got['nothing declared'][1] == 0 and got['declared 0.25'][1] == 0)
+    print()
+
+
+# === UNCHANGED: nudge_vias_for_unresolved's connector gate ==================
+class _FakeCap:
+    """Minimal stand-in for _Cap: one fixed pad rect (the #370 B3 harness)."""
+
+    def __init__(self, rects):
+        self._rects = list(rects)
+        self.side = 'F'
+        self.x = self.y = self.rot = 0.0
+
+    def pad_rects(self, x=None, y=None, rot=None):
+        return self._rects
+
+
+class _FakeSt:
+    """Minimal stand-in for _Repair: one cap, permanently 'unresolved'."""
+
+    def __init__(self, cap_rects):
+        self.caps = {'C1': _FakeCap(cap_rects)}
+        self.vias = []
+
+    def graze_penalty(self, ref, cap, x, y, rot):
+        return 1.0
+
+
+BAR = (0.2, 0.9, 1.8, 1.1, 2)   # cap pad bar under the via: only +y escapes
+NPTH = (1.0, 0.98)              # 0.42 below the via -> 0.32 of centreline room
+NPTH_DRILL = 0.2
+
+
+def _mover_board(path):
+    bi = BoardInfo(layers={}, copper_layers=['F.Cu', 'B.Cu'],
+                   board_bounds=(0.0, 0.0, 3.0, 3.0))
+    pads = {0: [make_pad(net_id=0, x=NPTH[0], y=NPTH[1], ref='BUS1',
+                         num='H1', size_x=NPTH_DRILL, size_y=NPTH_DRILL,
+                         shape='circle', layers=['F.Mask', 'B.Mask'],
+                         drill=NPTH_DRILL, pad_type='np_thru_hole')]}
+    via = Via(x=1.0, y=1.4, size=0.5, drill=0.3, layers=['F.Cu', 'B.Cu'],
+              net_id=3)
+    stub = Segment(start_x=1.0, start_y=1.6, end_x=1.0, end_y=1.4, width=0.2,
+                   layer='F.Cu', net_id=3)
+    return make_pcb(board_info=bi, vias=[via], segments=[stub],
+                    footprints={'C1': SimpleNamespace(layer='F.Cu', pads=[])},
+                    pads_by_net=pads, source_path=path, zones=[])
+
+
+def _via_mover_stays_flat(check, tmp):
+    """Change detector. On the #370-B3 harness the mover's only validated spot
+    puts its connector 0.22 mm off the NPTH. Raising the gate to a declared
+    0.25 returns 0 moves and 0 connectors -- the offending via never relocates
+    and the pad-via graze stays. Keeping the flat floor keeps the repair."""
+    print('UNCHANGED site: nudge_vias_for_unresolved -- connector gate still '
+          'at the flat fab floor')
+    declares = _stub_board(tmp, 'stub_declares', min_hole_clearance=DECLARED)
+    pcb = _mover_board(declares)
+    moves, segs = nudge_vias_for_unresolved(_FakeSt([BAR]), pcb, CLEAR)
+    gaps = [_seg_foreign_hole_dist(pcb, s['net_id'], s['start'][0],
+                                   s['start'][1], s['end'][0], s['end'][1])
+            - s['width'] / 2.0 for s in segs]
+    print(f'        declared 0.25: {len(moves)} move(s), {len(segs)} '
+          f'connector(s)'
+          + (f'; copper-to-hole gap {gaps[0]:.4f}mm' if gaps else ''))
+    check('the offending via still relocates on a DECLARING board (the #130 '
+          'repair is kept)', len(moves) == 1 and len(segs) == 1)
+    check(f'its connector lands in the declared band ({BAND}mm) -- the cost of '
+          'keeping the repair, stated rather than hidden',
+          bool(gaps) and abs(gaps[0] - BAND) < 1e-4)
+
+
+if __name__ == '__main__':
+    sys.exit(run())

--- a/tests/test_617_plane_connector_hole_clearance.py
+++ b/tests/test_617_plane_connector_hole_clearance.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Issue #617, engine 1/3: plane_region_connector must read min_hole_clearance.
+
+#616 gave the router `obstacle_map.resolve_hole_clearance` -- the board's own
+declared copper-to-hole floor -- and wired it into `add_drill_hole_obstacles`
+and `plane_obstacle_builder`. Its docstring named the engines it did NOT reach,
+and this is the first of them: the plane-repair connector (taps / region joins
+/ reconnects) priced every NPTH keep-out at a flat
+`max(config.clearance, NPTH_TO_TRACK_CLEARANCE)` -- 0.20 mm, never reading the
+board -- at THREE independent sites:
+
+    npth_floor_ok        the non-relaxable seed/anchor floor (#390)
+    wide_route_clear     the per-leg legality predicate for width upgrades
+    build_base_obstacles the repair router's own NPTH track keep-out stamp
+
+`check_drc` DOES read `min_hole_clearance` (check_drc.py:2390), so on a board
+declaring 0.25 all three approved plane-repair copper inside the 0.20-0.25
+band its own checker then flagged -- measured on neo6502 at 0.2263 mm against
+a declared 0.25.
+
+All three are SEARCH constraints over new copper, never one-shot repairs: each
+case therefore asserts BOTH halves -- copper inside the declared band is
+refused, AND copper at/outside the declared floor is still accepted, so the
+seed/route/cell search still has somewhere to go. (The passes whose only
+alternative to their single candidate is doing nothing are deliberately NOT
+changed by #617; see test_617_pcb_modification_hole_clearance.py.)
+
+Every case is built on a board whose sibling project DECLARES
+`min_hole_clearance: 0.25`, and geometry placed at exactly 0.22 mm of
+copper-to-hole-wall: legal at the flat 0.20 fab floor, a 0.03 mm violation of
+what the board actually asks for. A silent-board control pins that the change
+is RAISE-ONLY (a board declaring nothing keeps every old decision).
+
+    python3 tests/test_617_plane_connector_hole_clearance.py
+"""
+import json
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'py_router'))  # #522
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'py_tools'))  # #522
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import obstacle_map
+import plane_region_connector as prc
+from kicad_parser import BoardInfo
+from routing_config import GridRouteConfig
+from synth import make_pad, make_pcb
+
+# The board's NPTH mounting hole and the geometry under test.
+HOLE_X, HOLE_Y = 10.0, 10.0
+DRILL = 1.0                 # -> hole wall at radius 0.5
+TRACK_W = 0.2               # -> half-width 0.1
+DECLARED = 0.25             # what the board asks for
+BAND = 0.22                 # copper-to-hole-WALL gap under test
+# Centreline offset that puts the copper edge BAND off the hole wall.
+CENTRE = HOLE_X + DRILL / 2.0 + BAND + TRACK_W / 2.0     # 10.82
+# Centreline offset that CLEARS the declared floor (the alternative the search
+# still has once the band is refused).
+CLEAR_CENTRE = HOLE_X + DRILL / 2.0 + DECLARED + TRACK_W / 2.0 + 0.01
+CLEARANCE = 0.15            # routing clearance, below both floors
+
+
+def _board_dir(tmp, name, **rules):
+    """A board file whose sibling project declares `rules` (KiCad's
+    board.design_settings.rules block, where min_hole_clearance lives)."""
+    d = os.path.join(tmp, name)
+    os.makedirs(d, exist_ok=True)
+    pcb = os.path.join(d, 'b.kicad_pcb')
+    with open(pcb, 'w', encoding='utf-8') as f:
+        f.write('(kicad_pcb (version 20240108))\n')
+    with open(os.path.join(d, 'b.kicad_pro'), 'w', encoding='utf-8') as f:
+        json.dump({'board': {'design_settings': {'rules': rules}}}, f)
+    return pcb
+
+
+def _npth_pad():
+    return make_pad(net_id=0, x=HOLE_X, y=HOLE_Y, ref='BUS1', num='H1',
+                    size_x=DRILL, size_y=DRILL, shape='circle',
+                    layers=['*.Cu', '*.Mask'], drill=DRILL,
+                    pad_type='np_thru_hole')
+
+
+def _pcb(path, bounds=(0.0, 0.0, 20.0, 20.0)):
+    """A one-mounting-hole board rooted at `path` (so the engine's board read
+    resolves through PCBData.source_path, the #498 mechanism)."""
+    bi = BoardInfo(layers={0: 'F.Cu', 31: 'B.Cu'},
+                   copper_layers=['F.Cu', 'B.Cu'],
+                   board_bounds=bounds)
+    return make_pcb(board_info=bi, pads_by_net={0: [_npth_pad()]},
+                    source_path=path)
+
+
+def _config(grid_step=0.1):
+    cfg = GridRouteConfig()
+    cfg.clearance = CLEARANCE
+    cfg.track_width = TRACK_W
+    cfg.grid_step = grid_step
+    cfg.layers = ['F.Cu', 'B.Cu']
+    cfg.board_edge_clearance = 0.0
+    return cfg
+
+
+def run():
+    fails = []
+
+    def check(name, cond):
+        print(('PASS' if cond else 'FAIL') + f': {name}')
+        if not cond:
+            fails.append(name)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        declares = _board_dir(tmp, 'declares', min_hole_clearance=DECLARED)
+        silent = _board_dir(tmp, 'silent')
+        obstacle_map._HOLE_CLR_CACHE.clear()
+
+        print(f'board declares min_hole_clearance = {DECLARED}mm; geometry '
+              f'sits {BAND}mm off the hole wall')
+        print(f'  hole  ({HOLE_X}, {HOLE_Y}) drill {DRILL} -> wall at r='
+              f'{DRILL / 2.0}')
+        print(f'  track width {TRACK_W} centred at x={CENTRE:.4g} -> copper '
+              f'edge {BAND}mm from the wall')
+        print()
+
+        _seed_floor(check, declares, silent)
+        _leg_legality(check, declares, silent)
+        _base_map_stamp(check, declares, silent)
+
+    print()
+    if fails:
+        print(f'{len(fails)} FAILURE(S): {fails}')
+        return 1
+    print('all checks passed')
+    return 0
+
+
+# --- site 1: npth_floor_ok (route seed / anchor points, #390) ---------------
+def _seed_floor(check, declares, silent):
+    print('site 1: npth_floor_ok -- the non-relaxable seed floor')
+    half = TRACK_W / 2.0
+
+    ok_declared = prc.npth_floor_ok(CENTRE, HOLE_Y, _pcb(declares), half)
+    print(f'        seed at x={CENTRE:.4g} on the DECLARING board: '
+          f'accepted={ok_declared}')
+    check('declared 0.25 rejects a seed 0.22 off the hole wall',
+          not ok_declared)
+
+    ok_silent = prc.npth_floor_ok(CENTRE, HOLE_Y, _pcb(silent), half)
+    print(f'        same seed on a board declaring NOTHING: '
+          f'accepted={ok_silent}')
+    check('a board declaring nothing still accepts it (raise-only)',
+          ok_silent)
+
+    # No repair is given up: the seeder still has candidates -- everything at
+    # or beyond the declared floor is accepted on the declaring board.
+    ok_alt = prc.npth_floor_ok(CLEAR_CENTRE, HOLE_Y, _pcb(declares), half)
+    print(f'        alternative seed at x={CLEAR_CENTRE:.4g} '
+          f'({DECLARED + 0.01:.2f}mm off the wall): accepted={ok_alt}')
+    check('a seed outside the DECLARED floor stays accepted', ok_alt)
+    print()
+
+
+# --- site 2: wide_route_clear (per-leg legality for the width upgrade) ------
+def _leg_legality(check, declares, silent):
+    print('site 2: wide_route_clear -- per-leg legality')
+    cfg = _config()
+    pts = [(CENTRE, 8.0, 'F.Cu'), (CENTRE, 12.0, 'F.Cu')]
+
+    clear_declared = prc.wide_route_clear(pts, TRACK_W, _pcb(declares), 1, cfg)
+    print(f'        leg past the hole on the DECLARING board: '
+          f'clear={clear_declared}')
+    check('declared 0.25 rejects a leg 0.22 off the hole wall',
+          not clear_declared)
+
+    clear_silent = prc.wide_route_clear(pts, TRACK_W, _pcb(silent), 1, cfg)
+    print(f'        same leg on a board declaring NOTHING: '
+          f'clear={clear_silent}')
+    check('a board declaring nothing still passes the leg (raise-only)',
+          clear_silent)
+
+    alt = prc.wide_route_clear([(CLEAR_CENTRE, 8.0, 'F.Cu'),
+                                (CLEAR_CENTRE, 12.0, 'F.Cu')],
+                               TRACK_W, _pcb(declares), 1, cfg)
+    print(f'        alternative leg at x={CLEAR_CENTRE:.4g}: clear={alt}')
+    check('a leg outside the DECLARED floor stays clear', alt)
+    print()
+
+
+# --- site 3: build_base_obstacles (the repair router's NPTH keep-out) -------
+def _base_map_stamp(check, declares, silent):
+    """Run the REAL stamp and query the REAL map, rather than intercepting the
+    clearance argument: what matters is which cells the repair router may use.
+
+    Grid step 0.01 over a 6x6mm board so the 0.22 band is exactly on-grid and
+    well clear of the board-edge keep-out:
+      cell x=10.82  -> copper edge 0.22 off the wall  (inside a declared 0.25)
+      cell x=10.86  -> copper edge 0.26 off the wall  (the alternative)
+    """
+    print('site 3: build_base_obstacles -- the NPTH track keep-out stamp')
+    step = 0.01
+    cfg = _config(grid_step=step)
+    band_gx = round(CENTRE / step)                      # 1082 -> 10.82mm
+    alt_gx = round((HOLE_X + DRILL / 2.0 + 0.26 + TRACK_W / 2.0) / step)
+    gy = round(HOLE_Y / step)
+    bounds = (HOLE_X - 3.0, HOLE_Y - 3.0, HOLE_X + 3.0, HOLE_Y + 3.0)
+
+    got = {}
+    for path, label in ((declares, 'declared 0.25'), (silent, 'nothing declared')):
+        obstacles, _lm = prc.build_base_obstacles(
+            {1}, ['F.Cu', 'B.Cu'], _pcb(path, bounds), cfg, TRACK_W, 0.2)
+        got[label] = (bool(obstacles.is_blocked(band_gx, gy, 0)),
+                      bool(obstacles.is_blocked(alt_gx, gy, 0)))
+        print(f'        {label}: cell at {BAND}mm off the wall '
+              f'blocked={got[label][0]}; cell at 0.26mm off the wall '
+              f'blocked={got[label][1]}')
+
+    check('the declared 0.25 blocks a track cell 0.22 off the hole wall',
+          got['declared 0.25'][0])
+    check('a board declaring nothing leaves that cell free (raise-only)',
+          not got['nothing declared'][0])
+    check('the keep-out stays minimal -- a cell 0.26 off the wall is free on '
+          'BOTH boards, so the repair router still has a way past the hole',
+          not got['declared 0.25'][1] and not got['nothing declared'][1])
+
+
+if __name__ == '__main__':
+    sys.exit(run())


### PR DESCRIPTION
Closes #617. Branches from and targets `placement` (the prerequisite, #616's `resolve_hole_clearance`, does not exist on `main` — the triage that concluded this was unreproducible ran there).

## What was wrong

`check_drc` grades copper-to-hole at the board's own `min_hole_clearance` (`check_drc.py:2390`). #616 added `obstacle_map.resolve_hole_clearance` — that value, resolved engine-side off `PCBData.source_path`, cached per board path — and wired it into `add_drill_hole_obstacles` and `plane_obstacle_builder`. Its docstring then named three engines it did **not** reach. All three still priced every NPTH keep-out at a flat `max(clearance, NPTH_TO_TRACK_CLEARANCE)` = 0.20 mm, so on a board declaring 0.25 they accepted — and in places actively created — copper in the 0.20–0.25 band the project's own checker flagged.

## What changed, and what deliberately did not

I looked at eleven candidate sites and **changed six** (seven call sites). The dividing line is measured, not stylistic:

**Changed — sites that CHOOSE where new copper goes, or that MOVE copper by a measured shortfall.** Raising the floor there sends the search somewhere legal, or makes a repair pass see a violation it used to miss.

| engine | site | what it is |
|---|---|---|
| `plane_region_connector` | `npth_floor_ok` | the non-relaxable route-seed/anchor floor (#390); gains an optional `config=None` |
| | `wide_route_clear` | the exact NPTH leg check **and** its bbox superset gate — resolved once per call into `_hole_clr` so the gate stays the strict superset its comment requires |
| | `build_base_obstacles` | the plane-repair router's NPTH track keep-out stamp |
| `pcb_modification` | `_seg_worst_offender` | the shortfall ranking that drives the micro-shift (a detector) |
| | `nudge_grazing_microshift` | the graze detector **and** the shift-acceptance gate |
| `placement/fanout_clearance` | `_Repair.__init__` | the NPTH foreign-pad keep-out rects the whole cap search descends |

**Not changed — four sites where I measured that raising the floor removes the repair without removing the violation.** Each is kept in the tests as a change detector carrying its own numbers, and `resolve_hole_clearance`'s docstring records the rule.

- **`close_soft_joints` / `_connector_clear`** gate a *bridge* between two pieces of copper that already exist (a soft joint's caps already overlap by definition — `gap < (w1+w2)/2`, `pcb_modification.py:552`; a stub snap spans at most `1.5 x` the track width, `snap_stub_gaps`'s `max_gap_factor`). On the fixture, at a declared 0.25: the base lays the bridge and the tightest copper-to-hole gap goes `0.2215 → 0.2200`; refusing it leaves `0.2215`, which **still violates 0.25**. The refusal buys 1.5 µm on a 28.5 µm violation the flanking copper already caused, and costs a `segment-endpoint-gap` repair. Over the whole family (12,196,014 geometries sweeping width, drill, gap and hole position; run by the test in <1 s): a raised gate refuses **44.29%** of bridges and in **99.9613%** of those refusals the violation is present either way.
- **`nudge_grazing_octolinear`** is an all-or-nothing re-bend. On the fixture, declared 0.25: base — foreign-pad gap `−0.1000 → +0.3500` (it repairs a real net-to-net copper **overlap**) at the cost of a 0.2200 hole gap; raised — the re-bend is refused, the hole reads 0.6018, and the **−0.1 mm short stays**. Trading a 0.1 mm short for a 0.03 mm hole shortfall is not an improvement.
- **`nudge_vias_for_unresolved`** searches a 0.6 mm budget for a spot where the relocated via *and* its connector both validate. Raised, on the #370-B3 harness at a declared 0.25, it prints `no clear spot for C1's offending via at (1.00, 1.40) within 0.6mm` and returns **0 moves, 0 connectors** — the via never relocates and the #130 pad-via graze persists. Flat: 1 move, 1 connector.

Raise-only everywhere: a board declaring nothing (or ≤ 0.20) keeps byte-identical decisions, pinned by a silent-board control on every changed case. No CLI flag, no GUI control, no new user-facing parameter — every site is inside a shared engine function, so both fronts inherit it (`build_pcb_data_from_board` sets `source_path` from `board.GetFileName()`, `kicad_parser.py:4506`).

`_seg_worst_offender` and `nudge_grazing_microshift` gain an optional `config=None` so the helper's documented "an explicit `config.hole_clearance` wins" is actually true where a caller has a config; `run_post_route_cleanup` (the shared pipeline both fronts call) passes its config through. The three remaining `None` sites genuinely have no `GridRouteConfig` anywhere in their call chain (`cleanup_plane_taps_grazing` and `repair_fanout_clearance` take scalars).

## Reproduce

```bash
git fetch origin placement && git checkout -b fix/617 origin/placement
# apply this PR, then:
python3 tests/test_617_plane_connector_hole_clearance.py
python3 tests/test_617_pcb_modification_hole_clearance.py
python3 tests/test_617_placement_fanout_hole_clearance.py
```

RED on the base (revert only the engines; never `git stash` in a worktree — the ref is shared):

```bash
git checkout origin/placement -- py_router/plane_region_connector.py \
    py_router/pcb_modification.py py_router/obstacle_map.py \
    py_router/cleanup_pipeline.py py_placer/placement/fanout_clearance.py
python3 tests/test_617_plane_connector_hole_clearance.py    # exit 1, 3 failures
python3 tests/test_617_pcb_modification_hole_clearance.py   # exit 1, 4 failures
python3 tests/test_617_placement_fanout_hole_clearance.py   # exit 1, 1 failure
git checkout HEAD -- py_router/ py_placer/                  # restore
```

The change-detector rows for the four unchanged sites PASS on both arms — that is the point of them.

## Measured

### 1. `plane_region_connector` (real blocked cells, not a mocked argument)

```
site 1: npth_floor_ok -- the non-relaxable seed floor
        seed at x=10.82 on the DECLARING board: accepted=False
PASS: declared 0.25 rejects a seed 0.22 off the hole wall
        same seed on a board declaring NOTHING: accepted=True
PASS: a board declaring nothing still accepts it (raise-only)
        alternative seed at x=10.86 (0.26mm off the wall): accepted=True
PASS: a seed outside the DECLARED floor stays accepted

site 2: wide_route_clear -- per-leg legality
        leg past the hole on the DECLARING board: clear=False
PASS: declared 0.25 rejects a leg 0.22 off the hole wall
        same leg on a board declaring NOTHING: clear=True
PASS: a board declaring nothing still passes the leg (raise-only)
        alternative leg at x=10.86: clear=True
PASS: a leg outside the DECLARED floor stays clear

site 3: build_base_obstacles -- the NPTH track keep-out stamp
        declared 0.25: cell at 0.22mm off the wall blocked=True; cell at 0.26mm off the wall blocked=False
        nothing declared: cell at 0.22mm off the wall blocked=False; cell at 0.26mm off the wall blocked=False
PASS: the declared 0.25 blocks a track cell 0.22 off the hole wall
PASS: a board declaring nothing leaves that cell free (raise-only)
PASS: the keep-out stays minimal -- a cell 0.26 off the wall is free on BOTH boards, so the repair router still has a way past the hole
```

On the base arm those three read `accepted=True`, `clear=True`, `blocked=False`. Every case asserts **both** halves: the declared band is refused, and geometry at/outside the declared floor is still accepted — these are search constraints, so the seeder/router/cell search still has somewhere to go.

### 2. `pcb_modification`

```
CHANGED site 1: _seg_worst_offender -- the graze shortfall ranking
        declared 0.25: shortfall 0.0300mm
        nothing declared: no offender
        explicit config.hole_clearance=0.40 on the SILENT board: shortfall 0.1800mm

CHANGED site 2: nudge_grazing_microshift -- detector + shift acceptance
        declared 0.25: segs_changed=4 nets=1; copper-to-hole 0.2200 -> 0.2540; foreign-copper 0.2201 -> 0.1960
        nothing declared: segs_changed=0 nets=0; copper-to-hole 0.2200 -> 0.2200; foreign-copper 0.2201 -> 0.2201
```

Base: `no offender`, `TypeError: _seg_worst_offender() got an unexpected keyword argument 'config'`, and `segs_changed=0 nets=0` with the hole gap left at 0.2200.

The micro-shift row carries a paired assertion: the shift bows the copper *away from the hole*, so it costs 2.4 µm of margin against the foreign pad on the other side (0.2201 → 0.1960) — still well above the 0.15 routing clearance, so no repair is traded away. Stated rather than hidden.

The three unchanged sites, on a DECLARING board, at HEAD:

```
UNCHANGED site 1: close_soft_joints -- bridge still at the flat fab floor
        declared 0.25: bridges=1; min copper-to-hole 0.2215 -> 0.2200
        sweep: 12,196,014 bridge geometries at a declared 0.25; a raised gate would refuse 5,401,470 (44.29%) and in 99.9613% of those the violation is present ANYWAY

UNCHANGED site 2: _connector_clear -- stub snap still at the flat fab floor
        declared 0.25: connector 0.22mm off the wall accepted=True

UNCHANGED site 3: nudge_grazing_octolinear -- re-bend still at the flat fab floor
        declared 0.25: nets re-bent=1; foreign-pad -0.1000 -> +0.3500 (negative = net-to-net OVERLAP); copper-to-hole 0.6018 -> 0.2200
```

### 3. `placement/fanout_clearance` — graded end to end on a real in-repo board

`kicad_files/orangecrab_ext_pll.kicad_pcb`, copied into a temp dir beside a project declaring 0.25, with a 1.0 mm NPTH mounting hole placed 0.22 mm off the pad copper of a movable near-BGA cap that is **otherwise clean** (chosen deterministically, so the hole is the only reason to move it), then run through the real `repair_fanout_clearance`:

```
        51 movable near-BGA caps, 38 of them already clean -> using C14
        C14 pad edge x=154.5020; NPTH drill 1.0 at (153.7820, 97.8300) -> 0.22mm of wall gap
  nothing declared: Caps initially grazing foreign copper: 13
                    C14 NOT moved; pad-to-hole-wall gap 0.2200mm; 35 cap(s) moved, 0 unresolved
  declared 0.25:    Caps initially grazing foreign copper: 14 (C14 is now seen)
                    C14 MOVED to (155.5000, 98.4000); pad-to-hole-wall gap 1.0181mm; 36 cap(s) moved, 0 unresolved
```

The violation is **removed, not merely scored**, and the paired assertion holds: **0 unresolved caps on both arms**, and the 13 caps the base was already repairing are still repaired.

## Regression

`python3 tests/run_all.py --fast -j 4 --timeout 240`, both arms in the same environment:

```
with patch   240 passed, 15 failed (the placement branch baseline; 1 sometimes times out under load), 103 skipped in 422.4s
baseline     237 passed, 15 failed, 0 timed out, 103 skipped in 355.3s
```

The 15 failing names are **identical, name for name**, on both arms — pre-existing in this environment, untouched here (`test_405_edge_reconcile`, `test_431_animator_port`, `test_431_render_seams`, `test_493_interpreter_independence`, `test_506_507_plan_movie_tools`, `test_549_floorplan_grade`, `test_549_track_clearance`, `test_blocker_kind_attribution`, `test_gui_finalize_oracle_inrun`, `test_pad_global_nm_grid`, `test_placement_probe`, `test_run6_body_overlap`, `test_run8_locked_contact`, `test_run8_skills_generic`, `test_stub_to_stub_mst`). The +3 is the new tests. The baseline arm reverts the five engine files to `origin/placement` and moves the three new tests out of `tests/`.

Both wx-free parity gates pass at HEAD:

```
$ python3 tests/gui_parity/test_manifest_plan_parity.py
Converter parity: 36 flag-checks across 1 manifest(s), 0 mismatch(es).
Param->control resolution: 12 params checked, 0 unresolved.
Placement-block flags: OK (--group survives, --undo/--preview refused).
Placement tools: OK (refused loudly, chain intact).
exit=0

$ python3 tests/gui_parity/test_cli_postpass_coverage.py
CLI post-pass coverage: 8 registered, 15 in active CLI use, 1 CLI-only acknowledged,
0 unreachable call(s), 0 failure(s), 0 warning(s).
exit=0
```

## Limitations — please read these before merging

**1. On real boards this changes nothing measurable.** I staged declaring projects (`min_hole_clearance` 0.25 and 0.6) beside in-repo boards and ran both arms on identical inputs to fresh output paths, comparing UUID-free geometry (segment/via/footprint-pose multisets):

| run | declared | `min_clearance_used` | result |
|---|---|---|---|
| `route.py` splitflap_driver, `--clearance 0.15` | 0.25 | 0.15 | **identical** (1522 segs, 177 vias, 65 poses) |
| `route.py` splitflap_driver, default | 0.6 | 0.25 | **identical** (1554 segs, 178 vias) |
| `route.py` tigard, `--clearance 0.15` | 0.25 | 0.1 (its netclass) | **identical** (1926 segs, 171 vias) |
| `route_planes.py` rp2350 (GND/+3V3 → In1/In2), `--clearance 0.15` | 0.25 | 0.15 | **identical** (905 segs, 70 vias) |
| `repair_planes.py` on that output, `--clearance 0.15` | 0.15 (inherited — see limitation 2) | 0.1 | **identical** (1757 segs, 126 vias) |
| `place_fanout_clearance.py` orangecrab, `--clearance 0.15` | 0.25 | 0.15 | **identical** (742 segs, 136 vias, 165 poses) |
| `place_fanout_clearance.py` orangecrab, default | 0.6 | 0.25 | **identical** |

Six of the seven runs printed `Copper-to-hole clearance …mm (from the board's own min_hole_clearance…)`, so the raised floor really was active — it simply never changed a decision. So: **no regressions on any real board, and no demonstrated benefit on any real board either.** The evidence that this is a fix is the engine-level and end-to-end-on-a-planted-hole measurements above, not a corpus win.

The one in-repo board with a genuine sub-declared approach makes the point: rp2350's tightest copper-to-NPTH gap is **0.2092 mm on both arms** — but that copper is in the *input* file (the input board measures 0.2092 too). #617 governs where the tools **put** copper; it does not move copper that was already there.

**2. The fix is bounded by the DRC writeback, from step 2 of a chain onward.** `fix_kicad_drc_settings.compute_targets` sets the output project's `min_hole_clearance` to the routed `clearance` whenever no explicit hole clearance is given — and `route.py` has **no `--hole-clearance` flag** (only `check_drc.py` does), so that is always. Measured on my own chain:

```
in/rp25.kicad_pro       min_hole_clearance = 0.25   (input, declaring)
fix/rp25.kicad_pro      min_hole_clearance = 0.15
fix/rp25rep.kicad_pro   min_hole_clearance = 0.1
```

with the step printing

```
  FAB FLOOR RELAXED -- the output project declares a smaller minimum than the board originally did:
    copper-to-hole clearance: 0.25 -> 0.15 mm
```

So in any chain that routes tighter than the board's declared hole floor, **only the first step reads the declared value**; `repair_planes` / `place_fanout_clearance` / most graze-repair work run later and see the relaxed number. (When the routed clearance is *not* below the declared floor the value survives: `route.py splitflap_driver` with no `--clearance` wrote `min_hole_clearance = 0.25` unchanged.) This is inherited from #616, not introduced here, and it is disclosed loudly rather than silently — but it materially bounds what #617 buys, and closing it means giving the route scripts a `--hole-clearance` (a separate change with its own CLI/GUI threading).

**3. The change is inert whenever the routing clearance already meets the declared floor**, because every site is a `max()`. It only bites when `declared > max(clearance, 0.20)`.

**4. No corpus A/B.** `tests/stress/ab_replay_grade.py` needs the fetched corpus; not run. The change is provably inert on boards declaring nothing (silent-board controls on every case), but a corpus board declaring above 0.20 *and* routed below it would now route differently, and I have not measured whether that costs routed nets anywhere. The plausible cost shape is a plane seed or leg refused where it used to be taken: the three `plane_region_connector` sites are search constraints and the tests show geometry at/outside the declared floor is still accepted, but a search can still come up empty, in which case a region stays unconnected rather than being connected with violating copper.

**5. KiCad-python gates not run** (`test_gui_engine_parity.py`, `test_settings_roundtrip.py`). No flag, no dialog control, no CLI post-pass; the new `config=` parameter is passed by `run_post_route_cleanup`, which both fronts call, so it cannot diverge at the edge. `grep -rn` over `kicad_routing_plugin/` for every touched function name returns nothing, so the GUI reaches all of them only through the shared engines. Confirmed by reading, not by executing the GUI path.

**6. `tests/run_doc_examples.py` fails on both arms** — `31 run, 75 skipped, 7 failed`, exit 1. The six are `GridRouteConfig fields missing from docs/api-routing-config.md: hole_clearance, netclass_width_floors` (the #616 field) plus five `FileNotFoundError` blocks on gitignored fixture boards (`docs/api-kicad-parser.md` block 9, `docs/api-net-analysis.md` block 29, `docs/api-impedance.md` blocks 10/12/13). `git diff origin/placement -- py_router/routing_config.py docs/` is **empty**, so this patch neither caused nor fixes it.

**7. `placement/legality.PartPads` (`py_placer/placement/legality.py:911`) still has the same defect** — `npth_grow = max(0.0, NPTH_TO_TRACK_CLEARANCE - clearance)` from a bare `(fp, clearance)` pair with no board pointer, so it cannot call the helper without threading a new parameter through its callers. Recorded explicitly in `resolve_hole_clearance`'s docstring alongside the four deliberate non-sites, so the next reader inherits an accurate map rather than an implied "all done".

**8. The four dropped sites are still permissive in a narrow sense.** On a declaring board they can still add or accept copper in the 0.20–declared band; the measured argument is that refusing them costs more than it buys. A better fix for the two all-or-nothing repairs would be to *prefer* a hole-clean candidate when one exists and fall back when none does — a real change to their candidate ranking, not a one-expression change. I did not attempt it.

## Post-review addendum (second adversarial pass)

A second independent review re-ran everything above and confirmed all six prior
findings genuinely fixed. It surfaced one more thing, now handled in the head
commit rather than papered over:

- **The microshift acceptance-gate trade is now pinned as policy.** The raised
  floor sits in `nudge_grazing_microshift`'s candidate gate too, so on a
  declaring board a copper-graze repair whose only escape direction points at a
  hole is refused when every candidate would land inside the declared band —
  the graze stays. That is the right side of the trade (`check_drc` counts the
  declared band as a real violation since #616, so the "repair" would
  manufacture a counted DRC hit), but the old comment claimed the pass "can
  only remove a graze", which denied it. The comment now states the trade and
  `test_617_pcb_modification_hole_clearance.py` site 2b pins **both** arms:
  declaring → refused, incumbent untouched (`+0.0900 → +0.0900`, hole
  `0.2600 → 0.2600`); silent → the repair proceeds at the flat floor
  (`+0.0900 → +0.1033`, hole `0.2600 → 0.2460`).
- Two small corrections to this description from that pass: `run_doc_examples`
  shows **7** pre-existing failures on both arms (not 6), and the GUI *is* on
  the `_Repair` path via `fanout_gui.repair_fanout_clearance` — harmlessly, as
  `config` is `None` there either way, but stated now rather than implied
  untouched.
