### PR TITLE
#162: resolve same-net self-crossings in the shared cleanup pipeline (delete-only)

### DIFF
--- a/docs/api-pcb-modification.md
+++ b/docs/api-pcb-modification.md
@@ -95,7 +95,44 @@ the routing pipeline applies both so the model and the output file agree.
 > redundant with `sweep_dead_ends`). `add_route_to_pcb_data` now commits routed
 > segments directly; connectivity cleanup is handled by `prune_redundant_cycles`
 > and the whole-net dead-end trim `sweep_dead_ends` (#84). The residual same-net
-> self-crossings are tracked in #162.
+> self-crossings are handled by `prune_self_crossing_segments` (#162) — by
+> DELETION only, never by moving an endpoint.
+
+```python
+prune_self_crossing_segments(results, pcb_data, scope_net_ids=None,
+                             keep_input_copper=False)
+    -> (segments_removed, nets_pruned, original_segments_to_remove)
+```
+
+Resolves same-net **self-crossings** (issue #162) — two segments of one net
+crossing in an interior X, which `check_drc` reports as a
+`same-net self-crossing` warning. `prune_redundant_cycles` cannot see them:
+its node set is built from segment *endpoint* clusters, and an X has no
+endpoint at the intersection, so the loop it closes is invisible to the tree
+invariant.
+
+**Delete-only.** For each crossing the shorter arm is tried first, and a
+removal is accepted only if every guard `prune_redundant_cycles` uses still
+passes: `check_net_connectivity` still connected with no extra components and
+no extra disconnected pads, no via loses its support (#209), and
+`_restore_soft_joint_bridges` (#319) does not put the segment back. A crossing
+whose *both* arms are load-bearing is left alone — the pass never extends or
+snaps an endpoint to the crossing point, which is what `fix_self_intersections`
+did wrong (#159). Copper graphics (#337) are never candidates, and a whole net
+is skipped when it is zoned, when **any** of its copper is KiCad-locked (#521 —
+the lock need not be on the arm being tried), or when it is net 0 / has fewer
+than two pads (`check_net_connectivity` calls a pad-less net *connected*, so
+every gate would pass vacuously).
+
+`scope_net_ids` is a scope, **not** a protection list: the pipeline passes the
+same `_sub_scope` the cycle prune and the strict collapse get, which subtracts
+only the caller's `protect_net_ids`. Protected matched groups, impedance nets
+and diff pairs are in scope, exactly as they are for those two passes.
+
+Runs inside `cleanup_pipeline.run_post_route_cleanup` at step 7b, so both the
+CLI and the GUI front get it; there is no flag. Strictly inert on a net with no
+self-crossing. It runs *before* `close_soft_joints`, so a crossing that a later
+pipeline pass manufactures is out of its reach.
 
 ## `geometry_utils.py`
 

--- a/py_router/cleanup_pipeline.py
+++ b/py_router/cleanup_pipeline.py
@@ -42,6 +42,7 @@ from pcb_modification import (
     nudge_grazing_microshift,
     nudge_grazing_vias,
     prune_redundant_cycles,
+    prune_self_crossing_segments,
     collapse_strict_redundant,
     remove_orphan_islands,
     sweep_dead_ends,
@@ -118,6 +119,9 @@ def run_post_route_cleanup(results, pcb_data, scope_net_ids, config, *,
       6. nudge_grazing_vias    -- re-bend / micro-shift load-bearing grazes the
                                   prune must keep (#224/#276/#280).
       7. prune_redundant_cycles -- per-net tree invariant (RAM_A9 loops).
+      7b. prune_self_crossing_segments -- #162: the cycle prune's blind spot,
+                                  a same-net X with no endpoint at the
+                                  intersection. DELETE-ONLY, same guards.
       8. sweep_dead_ends       -- trim dead-end spurs and unsupported vias.
       9. neck_wide_segments_grazing_pads -- width-only fix for wide power
                                   trunks overlapping a fine-pitch foreign pad.
@@ -347,6 +351,31 @@ def run_post_route_cleanup(results, pcb_data, scope_net_ids, config, *,
         if _cy_segs:
             print(f"{label}Cycle prune: removed {_cy_segs} redundant loop "
                   f"segment(s) across {_cy_nets} net(s)")
+
+    # Same-net SELF-CROSSING prune (#162), right after the cycle prune because
+    # it is the cycle prune's blind spot: a pure X has no endpoint at the
+    # intersection, so the endpoint-cluster tree invariant never sees the loop
+    # it closes. DELETE-ONLY -- no endpoint ever moves (the #159 lesson: the
+    # geometric "fix" that extends/snaps a segment to the crossing trades a
+    # KiCad-permitted warning for real DRC violations).
+    #
+    # Scope: the same _sub_scope as the cycle prune and the strict collapse,
+    # which subtracts ONLY protect_net_ids (route.py's _protect_unfinished --
+    # nets with failed pads, plus unrouted single-ended nets). It does NOT
+    # exclude #521-protected matched groups, impedance nets or diff pairs:
+    # those reach the pipeline through sweep_scope_ids (name-filtered) and,
+    # from route_diff.py, as the scope itself. Same exposure as its two
+    # neighbours here -- the pass carries its own net-level guards instead
+    # (locked copper, zoned nets, pad-less nets; see its docstring).
+    _prog("self-crossing prune")
+    _xc_segs, _xc_nets, _xc_strip = prune_self_crossing_segments(
+        results, pcb_data, _sub_scope, keep_input_copper=keep_input_copper)
+    counts['self_crossings_pruned'] = _xc_segs
+    _trace('self_crossings')
+    strip.extend(_xc_strip)
+    if _xc_segs:
+        print(f"{label}Self-crossing prune: removed {_xc_segs} redundant "
+              f"same-net crossing segment(s) across {_xc_nets} net(s)")
 
     # Strict-redundant collapse (#217 classes 1-2): superseded parallel
     # chains and pad/via-buried tails that are redundant under the strict

--- a/py_router/pcb_modification.py
+++ b/py_router/pcb_modification.py
@@ -2254,6 +2254,70 @@ def neck_wide_segments_grazing_pads(results, pcb_data, config) -> int:
     return necked
 
 
+class _ViaSupport(NamedTuple):
+    supported_vias: object          # (seglist) -> set of via indices
+    supported_excluding: object     # (excluded_seg_indices) -> same, or None
+
+
+def _via_support_model(net_vias, net_pads, net_segs=None) -> _ViaSupport:
+    """The #209 via-support model shared by the subtractive per-net passes.
+
+    A via survives ``sweep_dead_ends`` only if a kept same-net segment ENDPOINT
+    lands within 0.05mm of it, or a pad covers it -- so a removal that drops a
+    via's last support would be followed by the sweep culling that via and
+    disconnecting the net. Both ``_prune_net_cycles`` and
+    ``prune_self_crossing_segments`` gate on it; this is the single copy.
+
+    ``supported_vias(seglist)`` -> set of indices into ``net_vias``.
+
+    ``supported_excluding(excluded_indices)`` is the same answer for
+    ``net_segs`` minus those indices, but costs O(vias) per query instead of
+    O(vias x segments) -- available only when ``net_segs`` is passed, and
+    exactly equal to ``supported_vias([s for i, s in enumerate(net_segs)
+    if i not in excluded])`` (pinned over all subsets of a fixture by
+    tests/test_162_self_crossing_prune.py).
+    """
+    vias = list(net_vias or [])
+    # Pad coverage points, mirroring sweep_dead_ends' via-support model exactly.
+    pad_cover = []
+    for p in (net_pads or []):
+        px = getattr(p, 'global_x', getattr(p, 'x', 0.0))
+        py = getattr(p, 'global_y', getattr(p, 'y', 0.0))
+        ps = max(getattr(p, 'size_x', 0.5), getattr(p, 'size_y', 0.5))
+        pad_cover.append((px, py, ps))
+    pad_backed = {i for i, v in enumerate(vias)
+                  if any(math.hypot(v.x - cx, v.y - cy) < cs / 2 + 0.05
+                         for cx, cy, cs in pad_cover)}
+
+    def _touches(v, sg):
+        return (math.hypot(v.x - sg.start_x, v.y - sg.start_y) < 0.05
+                or math.hypot(v.x - sg.end_x, v.y - sg.end_y) < 0.05)
+
+    def supported_vias(seglist):
+        out = set(pad_backed)
+        for i, v in enumerate(vias):
+            if i in out:
+                continue
+            if any(_touches(v, sg) for sg in seglist):
+                out.add(i)
+        return out
+
+    supported_excluding = None
+    if net_segs is not None:
+        by_via = [{k for k, sg in enumerate(net_segs) if _touches(v, sg)}
+                  for v in vias]
+
+        def supported_excluding(excluded=()):  # noqa: F811 (index-based twin)
+            ex = set(excluded)
+            out = set(pad_backed)
+            for i, sup in enumerate(by_via):
+                if i not in out and (sup - ex):
+                    out.add(i)
+            return out
+
+    return _ViaSupport(supported_vias, supported_excluding)
+
+
 def _prune_net_cycles(net_id: int, net_segs: List[Segment], net_vias, net_pads,
                       fgrid, fcell: float, fmax_rad: float, clearance: float,
                       protected_ids=None):
@@ -2419,25 +2483,8 @@ def _prune_net_cycles(net_id: int, net_segs: List[Segment], net_vias, net_pads,
         return net_segs, []
     base_comps = base.get('num_components') or 1
     base_disc = len(base.get('disconnected_pads') or [])
-    # Pad coverage points, mirroring sweep_dead_ends' via-support model exactly.
-    pad_cover = []
-    for p in (net_pads or []):
-        px = getattr(p, 'global_x', getattr(p, 'x', 0.0))
-        py = getattr(p, 'global_y', getattr(p, 'y', 0.0))
-        ps = max(getattr(p, 'size_x', 0.5), getattr(p, 'size_y', 0.5))
-        pad_cover.append((px, py, ps))
-
-    def supported_vias(seglist):
-        # A via survives sweep_dead_ends only if a kept same-net segment endpoint
-        # lands within 0.05mm of it, or a pad covers it (see sweep_dead_ends).
-        out = set()
-        for i, v in enumerate(net_vias or []):
-            if any(math.hypot(v.x - sg.start_x, v.y - sg.start_y) < 0.05 or
-                   math.hypot(v.x - sg.end_x, v.y - sg.end_y) < 0.05 for sg in seglist) \
-               or any(math.hypot(v.x - cx, v.y - cy) < cs / 2 + 0.05
-                      for cx, cy, cs in pad_cover):
-                out.add(i)
-        return out
+    # The #209 via-support model (shared with prune_self_crossing_segments).
+    supported_vias = _via_support_model(net_vias, net_pads).supported_vias
 
     cur = list(net_segs)
     cur_supported = supported_vias(cur)
@@ -2557,6 +2604,283 @@ def prune_redundant_cycles(results, pcb_data: PCBData, scope_net_ids=None,
             continue  # revert: keep all of this net's copper
         nets_pruned += 1
         for s in removed:
+            if id(s) in routed_seg_ids:
+                removed_routed_ids.add(id(s))
+            else:
+                original_to_remove.append(s)
+
+    if removed_routed_ids:
+        for r in results:
+            segs = r.get('new_segments')
+            if segs:
+                r['new_segments'] = [s for s in segs if id(s) not in removed_routed_ids]
+    if removed_routed_ids or original_to_remove:
+        orig_ids = {id(s) for s in original_to_remove}
+        pcb_data.segments = [s for s in pcb_data.segments
+                             if id(s) not in removed_routed_ids and id(s) not in orig_ids]
+
+    return len(removed_routed_ids) + len(original_to_remove), nets_pruned, original_to_remove
+
+
+def _self_crossing_pairs(net_segs):
+    """Same-net, same-LAYER geometric X-crossings among one net's segments.
+
+    The predicate is ``check_drc.segments_cross`` -- literally the one
+    check_drc counts the #162 "same-net self-crossing" warning from -- so a
+    crossing this resolves is a crossing the checker stops reporting.
+    Endpoint-sharing and collinear-overlap are NOT crossings there (only a
+    true interior X is), which is exactly the shape #162 is about.
+
+    Spatially hashed at 1mm so the scan costs ~O(local density), not O(n^2)
+    per net. Returns [(i, j, (cx, cy))] in a deterministic order.
+    """
+    from collections import defaultdict
+    from check_drc import segments_cross
+
+    _CELL = 1.0
+    grid = defaultdict(list)
+    for i, s in enumerate(net_segs):
+        lo_x = int(min(s.start_x, s.end_x) // _CELL)
+        hi_x = int(max(s.start_x, s.end_x) // _CELL)
+        lo_y = int(min(s.start_y, s.end_y) // _CELL)
+        hi_y = int(max(s.start_y, s.end_y) // _CELL)
+        for gx in range(lo_x, hi_x + 1):
+            for gy in range(lo_y, hi_y + 1):
+                grid[(gx, gy)].append(i)
+
+    seen = set()
+    out = []
+    for cell in sorted(grid):
+        idxs = grid[cell]
+        for a in range(len(idxs)):
+            for b in range(a + 1, len(idxs)):
+                i, j = idxs[a], idxs[b]
+                if i > j:
+                    i, j = j, i
+                if (i, j) in seen:
+                    continue
+                seen.add((i, j))
+                s1, s2 = net_segs[i], net_segs[j]
+                if s1.layer != s2.layer:
+                    continue
+                crosses, pt = segments_cross(s1, s2)
+                if crosses:
+                    out.append((i, j, pt))
+    # Deterministic order: the crossing point, then the segment indices.
+    out.sort(key=lambda t: (round(t[2][0], 6), round(t[2][1], 6), t[0], t[1]))
+    return out
+
+
+def _self_crossing_rank(s):
+    """Removal preference for the two arms of a self-crossing X: the SHORTER
+    arm first (less copper at risk), then a pure-geometry tie-break so the
+    choice never depends on board/list order."""
+    return (math.hypot(s.end_x - s.start_x, s.end_y - s.start_y), s.layer,
+            min((s.start_x, s.start_y), (s.end_x, s.end_y)),
+            max((s.start_x, s.start_y), (s.end_x, s.end_y)),
+            getattr(s, 'width', 0.0) or 0.0)
+
+
+def prune_self_crossing_segments(results, pcb_data: PCBData, scope_net_ids=None,
+                                 keep_input_copper: bool = False
+                                 ) -> Tuple[int, int, List[Segment]]:
+    """Resolve same-net SELF-CROSSINGS by DELETION ONLY (issue #162).
+
+    Nothing in the cleanup pipeline sees a pure X: ``_prune_net_cycles``' node
+    set is built from segment ENDPOINT clusters, and a self-crossing has no
+    endpoint at the intersection, so the loop it closes is invisible to the
+    union-find tree invariant. Measured on the two in-repo boards that carry
+    the defect: ``prune_redundant_cycles`` in isolation removes 1 segment on
+    ``routed_output`` and 2 on ``rp2350_fpga_eensy_prePlane`` and resolves
+    ZERO of their crossings (2 -> 2 and 4 -> 4) -- it is blind to the shape,
+    not idle. Every other subtractive pass is whole-segment / endpoint-graph
+    based too. ``check_drc`` only *warns*.
+
+    NOT the only pass that can reach this shape, and it is not first in line:
+    ``collapse_strict_redundant`` runs right after and, on ``routed_output``,
+    removes the same arm on its own (measured in isolation: 2 -> 1 crossings,
+    dropping ``Net-(U2A-~{RXF}) In1.Cu (217.7,107.7)->(217.4,108.0)``). Through
+    the real pipeline that board's shipped copper is therefore IDENTICAL with
+    and without this pass; the shipped delta is on ``rp2350`` only.
+
+    This pass DELETES; it never moves an endpoint. That is the whole design.
+    ``fix_self_intersections`` (deleted in #159) resolved the same shape by
+    EXTENDING a segment to the crossing point, which manufactured long
+    non-orthonormal diagonals across foreign copper; the obvious "snap the
+    shorter tail back to the crossing" trim has the same failure mode one step
+    down -- it converts KiCad-permitted cosmetic warnings into counted
+    ``segment-endpoint-gap`` DRC violations (gaps above
+    ``connectivity.COINCIDENCE_TOL`` are counted, see check_drc). So: a
+    crossing is resolved only when one of its two arms is provably redundant
+    copper, and is otherwise LEFT ALONE.
+
+    For each crossing, the shorter arm is tried first and a removal is
+    accepted only if EVERY existing guard passes -- the same gates
+    ``prune_redundant_cycles`` uses:
+
+      * copper graphics (#337) are never candidates; a net is skipped ENTIRELY
+        when it is zoned (planes are meshes, not trees), when ANY of its
+        segments or vias is KiCad-locked (#521: locked copper makes its whole
+        net off-limits, with no override -- the lock need not be on the arm
+        being tried), and when it is net 0 or has fewer than two pads (every
+        gate below is vacuous without pads to grade);
+      * under ``keep_input_copper`` only this-run copper is a candidate;
+      * ``check_net_connectivity`` still reports connected, with no increase
+        in ``num_components`` and none in ``disconnected_pads``;
+      * no via loses its support (the #209 gate: a via the dead-end sweep
+        would then cull);
+      * ``_restore_soft_joint_bridges`` (#319) does not put a removal back,
+        so a removal can never manufacture a soft joint.
+
+    SCOPE IS NOT A PROTECTION LIST. The pipeline hands this pass the same
+    ``_sub_scope`` as the cycle prune and the strict collapse, which subtracts
+    only ``protect_net_ids`` (route.py's ``_protect_unfinished``: nets with
+    failed pads plus unrouted single-ended nets). #521-protected matched
+    groups, impedance nets and diff pairs ARE in scope -- ``route_diff.py``
+    even calls the pipeline with the diff-pair nets as the scope. That is the
+    same exposure the neighbouring subtractive passes already have; do not
+    read the pipeline call site as excluding them.
+
+    COST: one connectivity graph per crossing-carrying net
+    (``return_graph=True``), then ``analyze_conn_excluding`` per candidate
+    (#263: O(net_size + candidates), not O(net_size x candidates)), one
+    batched soft-joint guard per net, and one AUTHORITATIVE
+    ``check_net_connectivity`` recompute per net that actually lost copper --
+    if that recompute disagrees with the graph model, the whole net's removals
+    are reverted, so no net is ever left in a state the real checker has not
+    blessed.
+
+    Runs inside the shared cleanup pipeline, so BOTH fronts (CLI and GUI) get
+    it; no flag, no new engine parameter. It sits at step 7b, BEFORE
+    ``close_soft_joints`` -- crossings a later pipeline pass manufactures are
+    out of its reach (measured on rp2350: ``close_soft_joints`` creates 3, on
+    base and on this branch alike).
+
+    STRICTLY INERT on a net with no self-crossing: the per-net scan returns
+    empty and the function touches neither ``results`` nor
+    ``pcb_data.segments`` (the list object is not even reassigned).
+
+    Returns (segments_removed, nets_pruned, original_segments_to_remove)."""
+    from collections import defaultdict
+
+    routed_seg_ids = set()
+    for r in results:
+        for s in r.get('new_segments') or []:
+            routed_seg_ids.add(id(s))
+
+    zoned_nets = {z.net_id for z in (getattr(pcb_data, 'zones', []) or [])}
+    # #521: KiCad-LOCKED copper makes its NET never-rippable with no override,
+    # and the lock can sit on any of the net's copper -- including copper this
+    # call's scope filter excludes. Scan the whole board, skip the whole net.
+    locked_nets = {s.net_id for s in pcb_data.segments
+                   if getattr(s, 'locked', False)}
+    locked_nets |= {v.net_id for v in pcb_data.vias
+                    if getattr(v, 'locked', False)}
+    segs_by_net = defaultdict(list)
+    for s in pcb_data.segments:
+        if scope_net_ids is not None and s.net_id not in scope_net_ids:
+            continue
+        if getattr(s, 'graphic', False):
+            continue  # copper graphics are immutable input art (#337)
+        segs_by_net[s.net_id].append(s)
+
+    vias_by_net = defaultdict(list)
+    for v in pcb_data.vias:
+        vias_by_net[v.net_id].append(v)
+
+    from check_connected import check_net_connectivity, analyze_conn_excluding
+
+    removed_routed_ids = set()
+    original_to_remove = []
+    nets_pruned = 0
+
+    for net_id in sorted(segs_by_net):
+        if not net_id:
+            continue  # unassigned copper: there is no net to grade
+        if net_id in zoned_nets:  # planes / pours are meshes, not trees
+            continue
+        if net_id in locked_nets:  # #521: user-pinned net, no override
+            continue
+        net_segs = segs_by_net[net_id]
+        if len(net_segs) < 2:
+            continue
+        net_pads = pcb_data.pads_by_net.get(net_id, [])
+        if len(net_pads) < 2:
+            # check_net_connectivity calls a pad-less net "connected" with
+            # num_components 0, so every gate below would pass vacuously and
+            # the pass would delete copper it cannot grade at all.
+            continue
+        crossings = _self_crossing_pairs(net_segs)
+        if not crossings:
+            continue  # the inertness gate: a crossing-free net costs one scan
+
+        net_vias = vias_by_net.get(net_id, [])
+        r0 = check_net_connectivity(net_id, net_segs, net_vias, net_pads, [],
+                                    return_graph=True)
+        if r0.get('connected') is False:
+            continue  # already broken: never trim a net we cannot grade
+        graph = r0.get('graph')
+        if not graph or not graph.get('pad_ids'):
+            continue
+        base = analyze_conn_excluding(graph, ())
+        if not base.get('connected'):
+            continue  # graph model disagrees with the recompute: hands off
+        base_comps = base.get('num_components') or 1
+        base_disc = len(base.get('disconnected_pads') or [])
+
+        support = _via_support_model(net_vias, net_pads, net_segs)
+        idx_of = {id(s): i for i, s in enumerate(net_segs)}
+        excluded = set()
+        cur_supported = support.supported_excluding(excluded)
+        dropped = []
+        for (i, j, _pt) in crossings:
+            if i in excluded or j in excluded:
+                continue  # an earlier removal already opened this X
+            for cand in sorted((net_segs[i], net_segs[j]),
+                               key=_self_crossing_rank):
+                ci = idx_of[id(cand)]
+                if keep_input_copper and id(cand) not in routed_seg_ids:
+                    continue  # input copper is read-only for this caller
+                trial_excl = excluded | {ci}
+                t = analyze_conn_excluding(graph, tuple(sorted(trial_excl)))
+                if not (t.get('connected')
+                        and (t.get('num_components') or 1) <= base_comps
+                        and len(t.get('disconnected_pads') or []) <= base_disc):
+                    continue
+                if support.supported_excluding(trial_excl) < cur_supported:
+                    continue  # #209: would strand a via the sweep then culls
+                excluded = trial_excl
+                cur_supported = support.supported_excluding(excluded)
+                dropped.append(cand)
+                break
+
+        if not dropped:
+            continue  # both arms load-bearing on every crossing: leave them
+        survivors = [s for k, s in enumerate(net_segs) if k not in excluded]
+        # #319, batched exactly as collapse_strict_redundant batches it: put
+        # back any removal that manufactured a soft joint, so close_soft_joints
+        # never sees a joint a cleanup pass created. Batching (rather than one
+        # _restore_soft_joint_bridges call per candidate) is what keeps the
+        # gate O(net) per net instead of O(net x crossings); measured to give
+        # the identical removal set on both in-repo boards and on the
+        # synthetic SJ fixture.
+        survivors, dropped = _restore_soft_joint_bridges(
+            survivors, dropped, net_vias, net_pads)
+        if not dropped:
+            continue
+        # AUTHORITATIVE confirm. analyze_conn_excluding replays a graph built
+        # from the FULL segment list, so it diverges from a real recompute if a
+        # removal empties a copper layer (its documented caveat). Grade the
+        # final survivor set with the real checker; if it is worse than the net
+        # started, revert EVERY removal on this net.
+        after = check_net_connectivity(net_id, survivors, net_vias, net_pads)
+        if not (after.get('connected')
+                and (after.get('num_components') or 1) <= (r0.get('num_components') or 1)
+                and len(after.get('disconnected_pads') or [])
+                <= len(r0.get('disconnected_pads') or [])):
+            continue  # revert: keep all of this net's copper
+        nets_pruned += 1
+        for s in dropped:
             if id(s) in routed_seg_ids:
                 removed_routed_ids.add(id(s))
             else:
@@ -5305,7 +5629,10 @@ def add_route_to_pcb_data(pcb_data: PCBData, result: dict, debug_lines: bool = F
         # collapse_appendices) removed: it "fixed" same-net crossings by extending a
         # segment to a far off-grid endpoint, creating long non-orthonormal diagonals
         # that crossed foreign copper (#159). prune_redundant_cycles + sweep_dead_ends
-        # cover connectivity; the residual cosmetic self-crossings are tracked in #162.
+        # cover connectivity; the residual cosmetic self-crossings are resolved
+        # DELETE-ONLY, once per run, by prune_self_crossing_segments (#162) -- in the
+        # cleanup pipeline, not here: a per-commit clean cannot know whether the arm
+        # it drops is the one a LATER net's copper is about to make redundant.
         cleaned_segments.extend(net_segs)
 
     # Filter out very short (degenerate) segments. A dropped segment whose BOTH

--- a/py_router/pcb_modification.py
+++ b/py_router/pcb_modification.py
@@ -2631,19 +2631,48 @@ def _self_crossing_pairs(net_segs):
     Endpoint-sharing and collinear-overlap are NOT crossings there (only a
     true interior X is), which is exactly the shape #162 is about.
 
-    Spatially hashed at 1mm so the scan costs ~O(local density), not O(n^2)
-    per net. Returns [(i, j, (cx, cy))] in a deterministic order.
+    Spatially hashed at 1mm. NOTE the hash indexes each segment's BOUNDING
+    BOX, not its traversed cells, so a long diagonal lands in ~O(length^2)
+    cells and a board full of them costs MORE than the naive pairwise scan
+    (measured: 150 board-spanning diagonals -> 11x slower than O(n^2), same
+    pairs). The guard below therefore falls back to the plain double loop
+    when the bbox-cell fanout exceeds the pairwise cost. In-repo nets are
+    tiny either way (worst observed: 130 cell inserts). Returns
+    [(i, j, (cx, cy))] in a deterministic order.
     """
     from collections import defaultdict
     from check_drc import segments_cross
 
     _CELL = 1.0
-    grid = defaultdict(list)
-    for i, s in enumerate(net_segs):
+    n = len(net_segs)
+    spans = []
+    total_cells = 0
+    for s in net_segs:
         lo_x = int(min(s.start_x, s.end_x) // _CELL)
         hi_x = int(max(s.start_x, s.end_x) // _CELL)
         lo_y = int(min(s.start_y, s.end_y) // _CELL)
         hi_y = int(max(s.start_y, s.end_y) // _CELL)
+        spans.append((lo_x, hi_x, lo_y, hi_y))
+        total_cells += (hi_x - lo_x + 1) * (hi_y - lo_y + 1)
+
+    if total_cells > n * n:
+        # Bbox fanout would out-cost the pairwise scan (long diagonals):
+        # do the simple thing. Same predicate, same deterministic order.
+        out = []
+        for i in range(n):
+            for j in range(i + 1, n):
+                s1, s2 = net_segs[i], net_segs[j]
+                if s1.layer != s2.layer:
+                    continue
+                crosses, pt = segments_cross(s1, s2)
+                if crosses:
+                    out.append((i, j, pt))
+        out.sort(key=lambda t: (round(t[2][0], 6), round(t[2][1], 6),
+                                t[0], t[1]))
+        return out
+
+    grid = defaultdict(list)
+    for i, (lo_x, hi_x, lo_y, hi_y) in enumerate(spans):
         for gx in range(lo_x, hi_x + 1):
             for gy in range(lo_y, hi_y + 1):
                 grid[(gx, gy)].append(i)

--- a/tests/test_162_self_crossing_prune.py
+++ b/tests/test_162_self_crossing_prune.py
@@ -1,0 +1,551 @@
+#!/usr/bin/env python3
+"""#162: same-net SELF-CROSSINGS are resolved by DELETION, never by geometry.
+
+`fix_self_intersections` was deleted in #159 (it "fixed" a crossing by
+EXTENDING a segment to a far off-grid point, manufacturing long
+non-orthonormal diagonals across foreign copper). Nothing replaced it, so a
+same-net X survived every cleanup pass -- `prune_redundant_cycles` builds its
+node set from segment ENDPOINT clusters and an X has no endpoint at the
+intersection, so the loop it closes is invisible to the tree invariant -- and
+`check_drc` only warns about it.
+
+`prune_self_crossing_segments` closes that hole DELETE-ONLY: it drops one arm
+of the X when that arm is provably redundant copper, and leaves the crossing
+alone otherwise. No endpoint ever moves.
+
+What this pins:
+  1. the pass exists and fires (synthetic POS + the two tracked in-repo boards
+     that carry the defect);
+  2. the DELETE-ONLY invariant -- every surviving segment is the SAME object
+     with the same geometry; the pass may only shorten the segment list;
+  3. the over-removal guards: an X whose both arms are load-bearing is left
+     alone (NEG), the #319 soft-joint guard is live (SJ), a net carrying
+     KiCad-locked copper is never touched (#521), and a pad-less / unassigned
+     net -- where every connectivity gate would pass vacuously -- is skipped;
+  4. the pipeline wiring -- the fix arrives via the SHARED
+     `run_post_route_cleanup`, so both fronts (CLI and GUI) get it;
+  5. THE SHIPPED DELTA, measured the way production runs it: the real boards
+     are A/B'd through `run_post_route_cleanup` with the pass stubbed out vs
+     live. That is deliberately NOT the same as calling the pass directly on a
+     raw board -- on `routed_output` the arm this pass would take is ALSO
+     reachable by `collapse_strict_redundant`, so the shipped copper there is
+     identical with and without it, and only `rp2350` sees a real delta.
+
+    python3 tests/test_162_self_crossing_prune.py
+"""
+import collections
+import io
+import contextlib
+import os
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, REPO)
+sys.path.insert(0, os.path.join(REPO, 'py_router'))  # #522
+sys.path.insert(0, os.path.join(REPO, 'py_tools'))  # #522
+sys.path.insert(0, os.path.join(REPO, 'tests'))
+
+from kicad_parser import BoardInfo, parse_kicad_pcb
+from routing_config import GridRouteConfig
+from check_drc import segments_cross
+from check_connected import check_net_connectivity
+import cleanup_pipeline
+from cleanup_pipeline import run_post_route_cleanup
+from pcb_modification import _soft_joint_pairs
+
+try:
+    from pcb_modification import _via_support_model
+except ImportError:  # pre-#162 tree
+    _via_support_model = None
+from synth import make_pad, make_seg, make_via, make_pcb
+
+try:
+    from pcb_modification import prune_self_crossing_segments
+except ImportError:  # pre-#162 tree
+    prune_self_crossing_segments = None
+
+NET = 7
+
+fails = []
+
+
+def check(name, cond, detail=""):
+    print(("  PASS  " if cond else "  FAIL  ") + name + (f"  {detail}" if detail else ""))
+    if not cond:
+        fails.append(name)
+
+
+def _seg(x1, y1, x2, y2, w=0.2, layer='F.Cu'):
+    return make_seg(x1, y1, x2, y2, width=w, layer=layer, net_id=NET)
+
+
+def _pad(ref, x, y, size=0.4):
+    return make_pad(NET, x, y, ref=ref, size_x=size, size_y=size, net_name='N')
+
+
+def _board(segs, pads):
+    return make_pcb(board_info=BoardInfo(layers={}, copper_layers=['F.Cu', 'B.Cu'],
+                                         board_bounds=None),
+                    segments=list(segs), pads_by_net={NET: list(pads)})
+
+
+def _sig(s):
+    """A segment's full geometric signature -- what DELETE-ONLY must preserve."""
+    return (round(s.start_x, 9), round(s.start_y, 9), round(s.end_x, 9),
+            round(s.end_y, 9), round(s.width, 9), s.layer, s.net_id)
+
+
+def n_crossings(segs):
+    """check_drc's own same-net self-crossing predicate, counted pairwise."""
+    n = 0
+    for i in range(len(segs)):
+        for j in range(i + 1, len(segs)):
+            if segs[i].net_id == segs[j].net_id and segments_cross(segs[i], segs[j])[0]:
+                n += 1
+    return n
+
+
+def _cfg():
+    return GridRouteConfig(grid_step=0.1, clearance=0.15, via_size=0.6,
+                           track_width=0.2, via_drill=0.3,
+                           layers=['F.Cu', 'B.Cu'])
+
+
+# --------------------------------------------------------------------------
+# Fixture POS: a short redundant link L crossed by a near-collinear connector
+# D. This is the shape measured on the real boards: D's copper covers both of
+# L's endpoints, so L adds nothing -- but the endpoint graph sees L as a
+# BRIDGE (removing it splits n(1.0,0) from n(1.5,0)), which is exactly why
+# prune_redundant_cycles keeps it.
+#
+#   pad P1 --T1-- (1.0,0) --L-- (1.5,0) --T2-- pad P2
+#           D: (0.9,-0.1) ------------> (1.6,0.1)   crosses L at (1.25, 0)
+# --------------------------------------------------------------------------
+def pos_fixture():
+    pads = [_pad('P1', 0, 0), _pad('P2', 3, 0),
+            _pad('P3', 0.9, -0.1, size=0.1), _pad('P4', 1.6, 0.1, size=0.1)]
+    t1 = _seg(0, 0, 1.0, 0)
+    link = _seg(1.0, 0, 1.5, 0)
+    t2 = _seg(1.5, 0, 3.0, 0)
+    conn = _seg(0.9, -0.1, 1.6, 0.1)
+    return [t1, link, t2, conn], pads, link
+
+
+# --------------------------------------------------------------------------
+# Fixture NEG: an X whose BOTH arms are the sole bridge to a pad pair. The
+# net is connected (via the side link), so the connectivity gate -- not the
+# "already broken, don't touch" early-out -- is what must refuse both arms.
+# --------------------------------------------------------------------------
+def neg_fixture():
+    pads = [_pad('N1', 0, 0), _pad('N2', 2, 2), _pad('N3', 2, 0), _pad('N4', 0, 2)]
+    a = _seg(0, 0, 2, 2)
+    b = _seg(2, 0, 0, 2)
+    side = _seg(2, 2, 2, 0)
+    return [a, b, side], pads
+
+
+# --------------------------------------------------------------------------
+# Fixture SJ: the SHORTER arm (a 100um link, tried first) is connectivity-safe
+# to remove but its removal leaves two cap-overlapping dangles -- a soft joint
+# the #319 guard must refuse. The longer arm is a sole bridge to two pads.
+# Net effect: NOTHING is removed and the crossing ships, which is the correct
+# delete-only answer.
+# --------------------------------------------------------------------------
+def sj_fixture():
+    pads = [_pad('R1', 0, 0), _pad('R2', 3, 0),
+            _pad('R3', 1.0, -1.0), _pad('R4', 1.1, 1.0)]
+    w1 = _seg(0, 0, 1.0, 0)
+    link = _seg(1.0, 0, 1.1, 0)
+    w3 = _seg(1.1, 0, 3.0, 0)
+    stem = _seg(1.0, -1.0, 1.1, 1.0)
+    return [w1, link, w3, stem], pads, link, stem
+
+
+def run_synthetic():
+    print("Synthetic fixtures (direct pass)")
+    if prune_self_crossing_segments is None:
+        check("pcb_modification.prune_self_crossing_segments exists", False,
+              "ImportError -- nothing in the cleanup pipeline resolves a "
+              "same-net X (#162)")
+        return
+    check("pcb_modification.prune_self_crossing_segments exists", True)
+
+    # --- POS -------------------------------------------------------------
+    segs, pads, link = pos_fixture()
+    before_sigs = [_sig(s) for s in segs]
+    pcb = _board(segs, pads)
+    check("POS: fixture really carries one same-net self-crossing",
+          n_crossings(pcb.segments) == 1, f"crossings={n_crossings(pcb.segments)}")
+    n, nets, strip = prune_self_crossing_segments([], pcb, {NET})
+    check("POS: one segment removed", n == 1, f"removed={n} nets={nets}")
+    check("POS: the crossing is gone", n_crossings(pcb.segments) == 0,
+          f"crossings={n_crossings(pcb.segments)}")
+    check("POS: exactly the redundant link was dropped",
+          not any(s is link for s in pcb.segments) and len(pcb.segments) == 3)
+    check("POS: the removal is reported for the writer's strip list",
+          [id(s) for s in strip] == [id(link)], f"strip={len(strip)}")
+    c = check_net_connectivity(NET, pcb.segments, pcb.vias, pads)
+    check("POS: net still connected, no pad stranded",
+          c.get('connected') and (c.get('num_components') or 1) == 1
+          and not (c.get('disconnected_pads') or []),
+          f"connected={c.get('connected')} comps={c.get('num_components')} "
+          f"disc={len(c.get('disconnected_pads') or [])}")
+    check("POS: no soft joint manufactured",
+          len(_soft_joint_pairs(pcb.segments, pcb.vias, pads)) == 0)
+    # DELETE-ONLY: every survivor is the SAME object with identical geometry.
+    surviving = [_sig(s) for s in pcb.segments]
+    check("POS: DELETE-ONLY -- every survivor's geometry is byte-identical",
+          all(sg in before_sigs for sg in surviving)
+          and all(any(s is o for o in segs) for s in pcb.segments),
+          f"{len(surviving)} survivors")
+
+    # --- NEG -------------------------------------------------------------
+    segs, pads = neg_fixture()
+    pcb = _board(segs, pads)
+    base = check_net_connectivity(NET, pcb.segments, pcb.vias, pads)
+    check("NEG: fixture is a CONNECTED net with one crossing",
+          n_crossings(pcb.segments) == 1 and base.get('connected') is True,
+          f"crossings={n_crossings(pcb.segments)} connected={base.get('connected')}")
+    n, nets, strip = prune_self_crossing_segments([], pcb, {NET})
+    check("NEG: both arms load-bearing -> nothing removed", n == 0 and strip == [],
+          f"removed={n}")
+    check("NEG: board untouched", len(pcb.segments) == 3
+          and all(any(s is o for o in segs) for s in pcb.segments))
+
+    # --- SJ --------------------------------------------------------------
+    segs, pads, link, stem = sj_fixture()
+    pcb = _board(segs, pads)
+    # Prove the two gates in isolation first, so a later behavior change
+    # cannot make this fixture pass for the wrong reason.
+    without_link = [s for s in segs if s is not link]
+    c_link = check_net_connectivity(NET, without_link, [], pads)
+    base_j = _soft_joint_pairs(segs, [], pads)
+    new_j = _soft_joint_pairs(without_link, [], pads) - base_j
+    check("SJ: dropping the SHORT arm is connectivity-safe...",
+          c_link.get('connected') is True
+          and not (c_link.get('disconnected_pads') or []),
+          f"connected={c_link.get('connected')}")
+    check("SJ: ...but manufactures a soft joint (the #319 gate's job)",
+          len(base_j) == 0 and len(new_j) == 1, f"new soft-joint pairs={len(new_j)}")
+    without_stem = [s for s in segs if s is not stem]
+    c_stem = check_net_connectivity(NET, without_stem, [], pads)
+    check("SJ: dropping the LONG arm strands pads (connectivity gate's job)",
+          c_stem.get('connected') is False
+          and len(c_stem.get('disconnected_pads') or []) == 2,
+          f"connected={c_stem.get('connected')} "
+          f"disc={len(c_stem.get('disconnected_pads') or [])}")
+    n, nets, strip = prune_self_crossing_segments([], pcb, {NET})
+    check("SJ: no arm is safe -> nothing removed, the crossing ships",
+          n == 0 and n_crossings(pcb.segments) == 1, f"removed={n}")
+
+
+def run_pipeline():
+    print("Shared cleanup pipeline (both fronts)")
+    segs, pads, link = pos_fixture()
+    pcb = _board(segs, pads)
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        out = run_post_route_cleanup([], pcb, {NET}, _cfg())
+    check("pipeline: run_post_route_cleanup resolves the crossing",
+          n_crossings(pcb.segments) == 0,
+          f"crossings={n_crossings(pcb.segments)} segs={len(pcb.segments)}")
+    check("pipeline: the removal is counted",
+          out.counts.get('self_crossings_pruned') == 1,
+          f"counts={out.counts.get('self_crossings_pruned')}")
+    check("pipeline: the removed input segment is in input_strip_segments",
+          any(s is link for s in out.input_strip_segments),
+          f"strip={len(out.input_strip_segments)}")
+    c = check_net_connectivity(NET, pcb.segments, pcb.vias, pads)
+    check("pipeline: net still connected, no pad stranded",
+          c.get('connected') and not (c.get('disconnected_pads') or []))
+
+    # The NEG fixture must survive the WHOLE pipeline unchanged: nothing else
+    # may quietly "resolve" a crossing whose arms are both load-bearing.
+    segs, pads = neg_fixture()
+    pcb = _board(segs, pads)
+    with contextlib.redirect_stdout(io.StringIO()):
+        out = run_post_route_cleanup([], pcb, {NET}, _cfg())
+    check("pipeline: load-bearing X survives the whole pipeline",
+          n_crossings(pcb.segments) == 1 and len(pcb.segments) == 3,
+          f"crossings={n_crossings(pcb.segments)} segs={len(pcb.segments)}")
+
+
+# --------------------------------------------------------------------------
+# Real in-repo boards, driven through the SHIPPING path.
+#
+# These two are the ONLY tracked kicad_files/*.kicad_pcb that carry the defect
+# (scanned: 22 boards, 6 crossings, all on these two). Production never calls
+# the pass on a raw board -- it calls run_post_route_cleanup, where six other
+# passes run first and four run after. So the A/B here is the SAME pipeline
+# with the pass stubbed out vs live, which is the only comparison that pins
+# what actually ships:
+#
+#   routed_output:  crossings 1 -> 1, copper multiset IDENTICAL. The pass fires
+#                   (self_crossings_pruned == 1) but collapse_strict_redundant
+#                   reaches the same arm on its own, so nothing changes on the
+#                   board. Pinned as identity ON PURPOSE -- claiming a 2 -> 1
+#                   win here would be false.
+#   rp2350:         crossings 7 -> 5, three fewer segments (the two arms plus
+#                   one dead end the sweep then trims). The 7 is not a typo:
+#                   close_soft_joints manufactures 3 crossings on this board on
+#                   BOTH legs, after this pass has already run.
+#
+# Asserted as inequalities with the measured numbers as detail strings, so a
+# future re-generation of either board cannot turn a real improvement into a
+# red -- but a regression of the pass to a no-op on rp2350 WILL go red.
+# --------------------------------------------------------------------------
+REAL = [('routed_output.kicad_pcb', dict(raw=2, off=1, on=1, pruned=1, same_copper=True)),
+        ('rp2350_fpga_eensy_prePlane.kicad_pcb',
+         dict(raw=4, off=7, on=5, pruned=2, same_copper=False))]
+
+
+def _noop_pass(results, pcb_data, scope_net_ids=None, keep_input_copper=False):
+    return 0, 0, []
+
+
+def _pipeline_leg(path, live):
+    """Run the real pipeline on a fresh parse, with the #162 pass live or
+    stubbed out. Returns (pcb, counts)."""
+    pcb = parse_kicad_pcb(path)
+    cfg = GridRouteConfig(grid_step=0.1, clearance=0.09, via_size=0.6,
+                          track_width=0.2, via_drill=0.3,
+                          layers=list(pcb.board_info.copper_layers))
+    scope = ({s.net_id for s in pcb.segments} | {v.net_id for v in pcb.vias}) - {0}
+    real = cleanup_pipeline.prune_self_crossing_segments
+    if not live:
+        cleanup_pipeline.prune_self_crossing_segments = _noop_pass
+    try:
+        with contextlib.redirect_stdout(io.StringIO()):
+            out = run_post_route_cleanup([], pcb, scope, cfg)
+    finally:
+        cleanup_pipeline.prune_self_crossing_segments = real
+    return pcb, out.counts
+
+
+def _copper(pcb):
+    return collections.Counter(_sig(s) for s in pcb.segments)
+
+
+def run_real_boards():
+    print("Tracked in-repo boards -- through run_post_route_cleanup (the shipping path)")
+    if prune_self_crossing_segments is None:
+        check("real boards: pass available", False, "ImportError")
+        return
+    for name, want in REAL:
+        path = os.path.join(REPO, 'kicad_files', name)
+        if not os.path.exists(path):
+            check(f"{name}: present", False, path)
+            continue
+        raw = parse_kicad_pcb(path)
+        n_raw = n_crossings(raw.segments)
+        check(f"{name}: reproduces the #162 warning", n_raw == want['raw'],
+              f"same-net self-crossings on the raw board={n_raw} "
+              f"(expected {want['raw']})")
+
+        off, c_off = _pipeline_leg(path, live=False)
+        on, c_on = _pipeline_leg(path, live=True)
+        x_off, x_on = n_crossings(off.segments), n_crossings(on.segments)
+
+        check(f"{name}: the pass fires inside the pipeline",
+              c_on.get('self_crossings_pruned', 0) >= 1
+              and c_off.get('self_crossings_pruned', 0) == 0,
+              f"self_crossings_pruned live={c_on.get('self_crossings_pruned')} "
+              f"stubbed={c_off.get('self_crossings_pruned')} "
+              f"(measured at authoring time: {want['pruned']})")
+        check(f"{name}: the SHIPPED board never gains a crossing", x_on <= x_off,
+              f"pipeline crossings stubbed={x_off} live={x_on} "
+              f"(measured at authoring time: {want['off']} -> {want['on']})")
+
+        same = _copper(off) == _copper(on)
+        if want['same_copper']:
+            # Honest pin: here the pass changes NOTHING that ships, because
+            # collapse_strict_redundant already removes the same arm.
+            check(f"{name}: shipped copper is IDENTICAL with and without the pass",
+                  same and x_on == x_off,
+                  f"segs {len(off.segments)}/{len(on.segments)}, "
+                  f"crossings {x_off}/{x_on}, strict_collapsed "
+                  f"{c_off.get('strict_collapsed')} -> {c_on.get('strict_collapsed')}")
+        else:
+            check(f"{name}: the pass is what removes the crossings",
+                  x_on < x_off and not same,
+                  f"crossings {x_off} -> {x_on}; segs {len(off.segments)} -> "
+                  f"{len(on.segments)}; counts live={dict(sorted(c_on.items()))}")
+
+        # SAFETY, graded on the SHIPPED boards: for every net whose copper the
+        # pass changed, the live leg must be no worse than the stubbed leg --
+        # connectivity, components, disconnected pads and soft joints.
+        def by_net(pcb):
+            d = {}
+            for s in pcb.segments:
+                d.setdefault(s.net_id, []).append(s)
+            return d
+
+        seg_off, seg_on = by_net(off), by_net(on)
+        via_off, via_on = {}, {}
+        for v in off.vias:
+            via_off.setdefault(v.net_id, []).append(v)
+        for v in on.vias:
+            via_on.setdefault(v.net_id, []).append(v)
+        changed = sorted(nid for nid in set(seg_off) | set(seg_on)
+                         if collections.Counter(_sig(s) for s in seg_off.get(nid, []))
+                         != collections.Counter(_sig(s) for s in seg_on.get(nid, [])))
+        ok, detail = True, []
+        for nid in changed:
+            pads = on.pads_by_net.get(nid, [])
+            b = check_net_connectivity(nid, seg_off.get(nid, []), via_off.get(nid, []), pads)
+            a = check_net_connectivity(nid, seg_on.get(nid, []), via_on.get(nid, []), pads)
+            nm = on.nets.get(nid)
+            nm = nm.name if nm else str(nid)
+            jb = len(_soft_joint_pairs(seg_off.get(nid, []), via_off.get(nid, []), pads))
+            ja = len(_soft_joint_pairs(seg_on.get(nid, []), via_on.get(nid, []), pads))
+            good = (bool(a.get('connected')) >= bool(b.get('connected'))
+                    and (a.get('num_components') or 1) <= (b.get('num_components') or 1)
+                    and len(a.get('disconnected_pads') or [])
+                    <= len(b.get('disconnected_pads') or []) and ja <= jb)
+            ok = ok and good
+            detail.append(f"{nm}: connected {b.get('connected')}->{a.get('connected')}, "
+                          f"comps {b.get('num_components')}->{a.get('num_components')}, "
+                          f"disc {len(b.get('disconnected_pads') or [])}->"
+                          f"{len(a.get('disconnected_pads') or [])}, "
+                          f"soft joints {jb}->{ja}")
+        check(f"{name}: every net the pass changed is no worse than without it", ok,
+              "; ".join(detail) or "no net changed")
+
+        # The pass's OWN invariant (the pipeline's other passes do move copper,
+        # so this can only be asserted on a direct call): DELETE-ONLY.
+        pcb = parse_kicad_pcb(path)
+        sigs = {id(s): _sig(s) for s in pcb.segments}
+        n, nets, strip = prune_self_crossing_segments([], pcb, None)
+        check(f"{name}: DELETE-ONLY -- no survivor moved",
+              n >= 1 and all(id(s) in sigs and _sig(s) == sigs[id(s)]
+                             for s in pcb.segments),
+              f"removed {n} on {nets} net(s), {len(pcb.segments)} segments remain")
+        check(f"{name}: every removal is reported to the writer",
+              len(strip) == n, f"strip={len(strip)} removed={n}")
+
+
+# --------------------------------------------------------------------------
+# INERTNESS: on a board with no same-net self-crossing the pass must be a
+# strict no-op -- it may not even reassign pcb_data.segments.
+# --------------------------------------------------------------------------
+def run_inertness():
+    print("Inertness on crossing-free boards")
+    if prune_self_crossing_segments is None:
+        check("inertness: pass available", False, "ImportError")
+        return
+    clean = ['orangecrab_ext_pll.kicad_pcb', 'lvds_converter_dualclk_gnd.kicad_pcb',
+             'qfn_diffpair_escape.kicad_pcb', 'qfn_interior_pads.kicad_pcb']
+    for name in clean:
+        path = os.path.join(REPO, 'kicad_files', name)
+        if not os.path.exists(path):
+            check(f"{name}: present", False, path)
+            continue
+        pcb = parse_kicad_pcb(path)
+        seg_list_id = id(pcb.segments)
+        before = [_sig(s) for s in pcb.segments]
+        n, nets, strip = prune_self_crossing_segments([], pcb, None)
+        check(f"{name}: strict no-op",
+              n == 0 and nets == 0 and strip == []
+              and id(pcb.segments) == seg_list_id
+              and [_sig(s) for s in pcb.segments] == before,
+              f"{len(before)} segments, removed={n}")
+
+
+# --------------------------------------------------------------------------
+# NET-LEVEL SKIPS. Each of these is a shape where the connectivity gate is
+# either forbidden (locked) or VACUOUS (no pads to grade), so without an
+# explicit skip the pass would delete copper on the strength of a gate that
+# cannot fail.
+# --------------------------------------------------------------------------
+def run_skips():
+    print("Net-level skips")
+    if prune_self_crossing_segments is None:
+        check("skips: pass available", False, "ImportError")
+        return
+
+    # #521: KiCad-LOCKED copper makes its NET never-rippable, no override. The
+    # lock may sit on EITHER arm -- gating on the candidate alone would just
+    # delete the other one.
+    for lock_short in (True, False):
+        segs, pads, link = pos_fixture()
+        (link if lock_short else segs[3]).locked = True
+        pcb = _board(segs, pads)
+        n, nets, strip = prune_self_crossing_segments([], pcb, {NET})
+        where = "the SHORT arm (tried first)" if lock_short else "the LONG arm"
+        check(f"LOCK: locked {where} -> the whole net is off-limits",
+              n == 0 and nets == 0 and strip == [] and len(pcb.segments) == 4,
+              f"removed={n} segs={len(pcb.segments)}")
+    # a lock on a VIA of the net counts too, and on copper outside the scope
+    segs, pads, link = pos_fixture()
+    v = make_via(0.0, 0.0, net_id=NET)
+    v.locked = True
+    pcb = make_pcb(board_info=BoardInfo(layers={}, copper_layers=['F.Cu', 'B.Cu'],
+                                        board_bounds=None),
+                   segments=list(segs), vias=[v], pads_by_net={NET: list(pads)})
+    n, _nets, _strip = prune_self_crossing_segments([], pcb, {NET})
+    check("LOCK: a locked VIA also protects the net", n == 0, f"removed={n}")
+
+    # Pad-less / unassigned nets: check_net_connectivity calls a pad-less net
+    # connected with num_components 0, so every gate passes vacuously.
+    x = [_seg(0, 0, 2, 2), _seg(2, 0, 0, 2), _seg(2, 2, 2, 0)]
+    for label, net_id, pads in (("net_id == 0 (unassigned copper)", 0, []),
+                                ("a net with ZERO pads", NET, []),
+                                ("a net with ONE pad", NET, [_pad('S1', 0, 0)])):
+        segs = [make_seg(s.start_x, s.start_y, s.end_x, s.end_y, net_id=net_id)
+                for s in x]
+        pcb = make_pcb(board_info=BoardInfo(layers={}, copper_layers=['F.Cu', 'B.Cu'],
+                                            board_bounds=None),
+                       segments=segs,
+                       pads_by_net=({net_id: pads} if pads else {}))
+        check(f"PADS: {label} really carries a crossing",
+              n_crossings(pcb.segments) == 1)
+        # scope_net_ids=None is the signature default AND what the docs show.
+        n, nets, strip = prune_self_crossing_segments([], pcb, None)
+        check(f"PADS: {label} -> nothing deleted",
+              n == 0 and nets == 0 and len(pcb.segments) == 3,
+              f"removed={n} remaining={len(pcb.segments)}")
+
+
+# --------------------------------------------------------------------------
+# The index-based via-support twin must agree EXACTLY with the list-based one
+# it replaced -- that equivalence is the whole basis of the #263-shaped speedup
+# (the pass calls it once per candidate instead of rebuilding O(vias x segs)).
+# --------------------------------------------------------------------------
+def run_via_support_equivalence():
+    print("Via-support model: index twin == list original")
+    if _via_support_model is None:
+        check("via support: helper available", False, "ImportError")
+        return
+    segs = [_seg(0, 0, 1, 0), _seg(1, 0, 2, 0), _seg(2, 0, 3, 0),
+            _seg(1, 0, 1, 1, layer='B.Cu'), _seg(3, 0, 3, 1)]
+    vias = [make_via(1.0, 0.0, net_id=NET), make_via(3.0, 0.0, net_id=NET),
+            make_via(9.0, 9.0, net_id=NET)]
+    pads = [_pad('V1', 0, 0), _pad('V2', 9, 9, size=1.0)]
+    m = _via_support_model(vias, pads, segs)
+    ok = True
+    for mask in range(1 << len(segs)):
+        excl = {i for i in range(len(segs)) if mask >> i & 1}
+        kept = [s for i, s in enumerate(segs) if i not in excl]
+        if m.supported_vias(kept) != m.supported_excluding(excl):
+            ok = False
+            break
+    check("every one of the 32 segment subsets agrees", ok,
+          f"{1 << len(segs)} subsets, {len(vias)} vias, {len(pads)} pads")
+
+
+def run():
+    run_synthetic()
+    run_skips()
+    run_via_support_equivalence()
+    run_pipeline()
+    run_real_boards()
+    run_inertness()
+    if fails:
+        print(f"\n{len(fails)} FAILED: " + ", ".join(fails))
+        return 1
+    print("\nAll #162 self-crossing prune checks passed")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(run())


### PR DESCRIPTION
Closes #162.

`fix_self_intersections` was deleted in d37a0074 (#159) because it "fixed" a
same-net X by *extending* a segment to a far off-grid endpoint, manufacturing
long non-orthonormal diagonals across foreign copper. Nothing replaced it, so
today **no cleanup pass resolves a same-net self-crossing** and `check_drc`
only warns. This adds a **delete-only** pass that resolves the ones that can be
resolved without moving a single endpoint.

## Root cause, exactly

`_prune_net_cycles` (`py_router/pcb_modification.py`) builds its node set from
segment **endpoint clusters** (`rep_items`). A pure X has *no endpoint at the
intersection*, so no node lies there and the redundant loop the crossing closes
is invisible to the union-find tree invariant. Every other subtractive pass is
whole-segment / endpoint-graph based too.

Measured in isolation on the two in-repo boards that carry the defect — the
cycle prune is **blind to the shape, not idle**:

```
routed_output.kicad_pcb                    prune_redundant_cycles     removed   1 seg(s); crossings 2 -> 2
routed_output.kicad_pcb                    collapse_strict_redundant  removed  18 seg(s); crossings 2 -> 1
      resolved (106, 'In1.Cu', 217.6, 107.8)
rp2350_fpga_eensy_prePlane.kicad_pcb       prune_redundant_cycles     removed   2 seg(s); crossings 4 -> 4
rp2350_fpga_eensy_prePlane.kicad_pcb       collapse_strict_redundant  removed   2 seg(s); crossings 4 -> 4
```

Note the second line: on `routed_output` the existing **strict collapse already
takes the arm this pass would take**. That fact shapes the whole evidence
section below.

## What this PR does

Adds `pcb_modification.prune_self_crossing_segments`, called from the **shared**
`cleanup_pipeline.run_post_route_cleanup` at step 7b, immediately after the
cycle prune (its blind spot) — so **both fronts (CLI and GUI) get it**. No flag,
no new engine parameter, so no `FLAG_PARAMS` / dialog-control plumbing and
neither parity gate's registry changes.

**Delete-only. No endpoint ever moves.** For each crossing the shorter arm is
tried first, and a removal is accepted only if every guard the cycle prune
already uses still passes:

* connectivity still connected, `num_components` not increased,
  `disconnected_pads` not increased;
* no via loses its support (the #209 gate);
* `_restore_soft_joint_bridges` (#319) does not put the segment back.

Copper graphics (#337) are never candidates, and a **whole net** is skipped when

* it is zoned (planes are meshes, not trees);
* **any** of its segments or vias is KiCad-locked — #521 is a *net*-level rule
  ("never-rippable with NO override"), and the lock need not be on the arm being
  tried;
* it is net 0, or has fewer than two pads — `check_net_connectivity` calls a
  pad-less net *connected* with `num_components` 0, so every gate above would
  pass vacuously.

**A crossing whose both arms are load-bearing is left alone.** I deliberately
did **not** implement the "snap the shorter tail back to the crossing point"
trim: that is #159's failure mode one step down — a `segment-endpoint-gap` above
`connectivity.COINCIDENCE_TOL` is a *counted* DRC violation in `check_drc`, so
the trim would clear a KiCad-permitted warning by creating a real one.

### Scope is not a protection list

The pipeline hands this pass the same `_sub_scope` as the cycle prune and the
strict collapse, which subtracts **only** `protect_net_ids` (route.py's
`_protect_unfinished`). #521-protected matched groups, impedance nets and diff
pairs **are** in scope — `route_diff.py` calls the pipeline with the diff-pair
nets *as* the scope. That is not new exposure. On **`main`**, with a net
registered protected *and* impedance-declared and passed as the entire scope:

```
protection_map / notes see it as protected: True
segments 4 -> 2; counts={'cycles_pruned': 1, 'strict_collapsed': 1}
   Cycle prune: removed 1 redundant loop segment(s) across 1 net(s)
   Strict collapse: removed 1 redundant segment(s) (superseded parallel/buried copper)
```

Identical on this branch. The docstrings now say this plainly instead of
claiming an exclusion that never existed.

## Before / after — measured through the path that actually ships

Production never calls the pass on a raw board; it calls
`run_post_route_cleanup`, where six passes run first and four run after. So the
A/B below is the **same pipeline with the pass stubbed out vs live**, on a fresh
parse each leg, graded with `check_drc.py` at 0.09 and `check_connected.py`:

| board | same-net self-crossing (check_drc) | other DRC | check_connected |
|---|---|---|---|
| `routed_output.kicad_pcb` | **1 → 1** | `VIA-DRILL-HOLE (3)` → `VIA-DRILL-HOLE (3)` | 188 issues, **report byte-identical** |
| `rp2350_fpga_eensy_prePlane.kicad_pcb` | **6 → 4** | `NO DRC VIOLATIONS FOUND!` → `NO DRC VIOLATIONS FOUND!` | 2 issues, **report byte-identical** |

```
$ diff <(check_connected stubbed | tail -n +3) <(check_connected live | tail -n +3)   # both boards
DIFF_EXIT=0
```

Two things in that table need saying out loud rather than glossing:

* **On `routed_output` this pass changes nothing that ships.** The shipped
  copper multiset (segments *and* vias) hashes identically with and without it —
  `47466f7887b2747d` both legs — because `collapse_strict_redundant` removes the
  same arm on its own (`strict_collapsed` just moves 17 → 16). It fires
  (`self_crossings_pruned: 1`) but the board is the same board.
* **The 6 on `rp2350` is not a typo.** The raw board has 4. `close_soft_joints`
  (step 10) *manufactures* crossings with the bridge copper it adds, on `main`
  and on this branch alike — a stage trace hooked to the pipeline's own
  `progress_callback` puts every added crossing after the last callback. This
  pass runs at 7b and cannot see them. So the shipped board comes back to its
  input count of 4; it does not go below it. That is a separate defect and it is
  filed as such, not fixed here.

**Real coverage: 2 of the 6 in-repo crossings, on 1 of the 2 boards.** On the
other four (`/RP2354A/1V1`, `Net-(U6-VREG_AVDD)`, `Net-(U2A-~{TXE})`, and the
strict-collapse-reachable one) *both* arms are load-bearing bridges, or another
pass gets there first.

`rp2350` ships **3** fewer segments, not 2: the two arms plus one dead end the
sweep then trims (`dead_ends_swept` 0 → 1 on the live leg only).

### Reproduce (copy-paste, tracked in-repo board, no corpus, no route run)

```bash
python3 py_router/check_drc.py kicad_files/rp2350_fpga_eensy_prePlane.kicad_pcb -c 0.09 | tail -7

python3 - /tmp/rp2350_trimmed.kicad_pcb <<'PY'
import sys
sys.path[:0] = ['.', 'py_router', 'py_tools', 'rust_router']
from kicad_parser import parse_kicad_pcb
from kicad_writer import remove_segments_from_content
from pcb_modification import prune_self_crossing_segments
src, dst = 'kicad_files/rp2350_fpga_eensy_prePlane.kicad_pcb', sys.argv[1]
pcb = parse_kicad_pcb(src)
n, nets, strip = prune_self_crossing_segments([], pcb, None)
print(f'prune_self_crossing_segments: removed {n} segment(s) on {nets} net(s)')
for s in strip:
    print(f'  {pcb.nets[s.net_id].name}  {s.layer}  '
          f'({s.start_x},{s.start_y})->({s.end_x},{s.end_y})  w={s.width}')
txt = open(src, encoding='utf-8').read()
txt, k = remove_segments_from_content(
    txt, strip, net_id_to_name={i: v.name for i, v in pcb.nets.items()})
open(dst, 'w', encoding='utf-8', newline='').write(txt)
PY

python3 py_router/check_drc.py /tmp/rp2350_trimmed.kicad_pcb -c 0.09 | tail -7
python3 py_router/check_connected.py /tmp/rp2350_trimmed.kicad_pcb | tail -8
```

Real captured output:

```
NO DRC VIOLATIONS FOUND!
WARNINGS (4, not DRC failures):
  same-net self-crossing: 4 (same-net copper overlap; permitted by KiCad DRC)

prune_self_crossing_segments: removed 2 segment(s) on 2 net(s)
  /RP2354A/SWDIO  F.Cu  (149.65,111.15)->(149.7,111.2)  w=0.09
  /RP2354A/SCL  F.Cu  (153.2,104.9)->(153.1,104.9)  w=0.09

NO DRC VIOLATIONS FOUND!
WARNINGS (2, not DRC failures):
  same-net self-crossing: 2 (same-net copper overlap; permitted by KiCad DRC)

FOUND 2 ISSUES:
  Unrouted nets (2):
    +3V3 (48 pads)
    GND (87 pads)
```

The two `Unrouted nets` are the board's pre-existing un-poured planes (it is a
`prePlane` fixture) — identical before and after, and the full
`check_connected.py` report is byte-identical (`DIFF_EXIT=0`).

## Inertness — the default path is unchanged where there is no crossing

There is no flag, so "default path unchanged" has to mean *byte-identical
output*. Three independent measurements:

**1. All 33 tracked `kicad_files/*.kicad_pcb` through the pipeline, base vs
branch** (17 have copper):

```
BYTE-IDENTICAL shipped copper AND identical other-pass counts: 15
CHANGED: 2
   routed_output.kicad_pcb: segs 517->517, self_crossings_pruned=1
        strict_collapsed: 17 -> 16          (copper hash still identical)
   rp2350_fpga_eensy_prePlane.kicad_pcb: segs 903->900, self_crossings_pruned=2
        dead_ends_swept: 0 -> 1
boards that errored (base, fix): 0
cycles_pruned identical on every board: True
```

**2. A real end-to-end `route.py` of `splitflap_driver.kicad_pcb`**, base and
branch, to fresh output paths, comparing the UUID-free copper multiset (never
file hashes — CLAUDE.md):

```
A: sf_base  segments=1437 vias=168
B: sf_fix   segments=1437 vias=168
segment multiset identical: True   (A-only=0, B-only=0)
via     multiset identical: True   (A-only=0, B-only=0)
```

Every other pass line is character-identical (`Cycle prune: removed 149 ...`,
`Strict collapse: removed 11 ...`, `Octolinear smoothing: 83 span(s)`,
`Bridged 2 soft joint(s)`), and the new pass prints nothing.

**3. Strict object-level no-op** pinned in the test on four crossing-free
tracked boards: nothing removed, `nets_pruned == 0`, `strip == []`, and
`id(pcb_data.segments)` unchanged — the list object is not even reassigned.

**Determinism**: one distinct removal set across six shuffled segment/via
orderings, on both boards.

## Cost

One connectivity graph per crossing-carrying net (`return_graph=True`), then
`analyze_conn_excluding` per candidate (#263: O(net_size + candidates) instead
of O(net_size × candidates)), an O(vias)-per-query index twin of the #209
via-support model, and the #319 guard batched per net exactly as
`collapse_strict_redundant` batches it. Back-to-back on one machine, a naive
per-candidate rebuild vs what ships:

| segments | crossings | per-candidate rebuild | shipped |
|---|---|---|---|
| 516 | 4 | 0.40 s | **0.06 s** |
| 1516 | 4 | 0.57 s | **0.23 s** |
| 3016 | 4 | 1.03 s | **0.41 s** |
| 1660 | 40 | 5.95 s | **0.49 s** |
| 2100 | 150 | 32.44 s | **1.63 s** |

`analyze_conn_excluding` replays a graph built from the *full* segment list, so
it can diverge from a true recompute if a removal empties a copper layer (its
documented caveat). Every net that actually loses copper therefore gets **one
authoritative `check_net_connectivity` recompute** at the end; if it disagrees
with the graph model, every removal on that net is reverted. Nothing ships in a
state the real checker has not graded.

The #209 via-support model is now a single shared helper (`_via_support_model`)
used by both `_prune_net_cycles` and this pass instead of two copies —
`cycles_pruned` is unchanged on every tracked board.

## Where the crossings come from (issue acceptance item 1)

Measured, not speculated: on `rp2350_fpga_eensy_prePlane` **all 4** crossings
have one arm at width exactly `0.0889` — `single_ended_routing._fab_track_floor`
for a 6-layer board, i.e. a terminal connector necked by `_neck_terminal_grazes`
— even though only 59 of the board's 904 segments (6.5 %) carry that width. The
matching code path is the `_merge_terminal_to_exact` bailout at
`py_router/single_ended_routing.py:749`. I have the 4/4 correlation and the code
path, **not** a captured `Segment.__init__` stack — producing one needs
regenerating the fanout chain. Flagging that as unfinished rather than claiming
it.

## Tests

`tests/test_162_self_crossing_prune.py` (standalone, no wx, picked up by
`run_all.py --fast`). 48 checks:

* **POS / NEG / SJ** synthetic fixtures — the redundant-link-crossed-by-a-
  connector shape measured on the real boards; an X whose arms are both sole
  bridges (nothing removed, and it survives the *whole* pipeline); and the
  #319 fixture where the short arm is connectivity-safe but manufactures a soft
  joint while the long arm strands two pads (both gates asserted *in isolation*
  first, so the fixture cannot pass for the wrong reason).
* **Net-level skips** — a lock on either arm, and a locked *via*, take the whole
  net off-limits; net 0, a zero-pad net and a one-pad net are untouched at the
  documented default `scope_net_ids=None`.
* **Via-support equivalence** — the index twin matches the list original on all
  32 subsets of a fixture.
* **Pipeline wiring** — the fix arrives through `run_post_route_cleanup`, is
  counted, and the removed input segment lands in `input_strip_segments`.
* **Real boards through the shipping path** — `run_post_route_cleanup` with the
  pass stubbed vs live, asserting the pass fires, that the shipped board never
  gains a crossing, that `routed_output`'s copper is **identical** (pinned as
  identity on purpose — claiming a win there would be false), that `rp2350`'s
  crossings drop, and that every net the pass changed is no worse than without
  it (connectivity, components, disconnected pads, soft joints).
* **Inertness** — strict no-op on four crossing-free tracked boards.

Red on `main` (engine files from `main`, test file from this branch) — 8 failed,
including a genuine *behavioral* red, not only the missing symbol:

```
  FAIL  pipeline: run_post_route_cleanup resolves the crossing  crossings=1 segs=4
  FAIL  pipeline: the removal is counted  counts=None
  FAIL  pipeline: the removed input segment is in input_strip_segments  strip=0
  PASS  pipeline: net still connected, no pad stranded
  PASS  pipeline: load-bearing X survives the whole pipeline  crossings=1 segs=3
EXIT=1
```

And a **mutation red**: with the pass neutered to `return 0, 0, []`, the
real-board section goes red on *both* boards —

```
5 FAILED: routed_output.kicad_pcb: the pass fires inside the pipeline,
routed_output.kicad_pcb: DELETE-ONLY -- no survivor moved,
rp2350_fpga_eensy_prePlane.kicad_pcb: the pass fires inside the pipeline,
rp2350_fpga_eensy_prePlane.kicad_pcb: the pass is what removes the crossings,
rp2350_fpga_eensy_prePlane.kicad_pcb: DELETE-ONLY -- no survivor moved
```

A direct-call test would have stayed green through that on `routed_output`,
which is exactly why the section drives the pipeline.

## Regressions

```
$ python3 tests/run_all.py --fast -j 4 --timeout 240
217 passed, 0 failed, 46 skipped in 198.6s

$ python3 tests/gui_parity/test_manifest_plan_parity.py
Converter parity: 35 flag-checks across 1 manifest(s), 0 mismatch(es).
Param->control resolution: 12 params checked, 0 unresolved.

$ python3 tests/gui_parity/test_cli_postpass_coverage.py
CLI post-pass coverage: 8 registered, 15 in active CLI use, 1 CLI-only acknowledged,
0 unreachable call(s), 0 failure(s), 0 warning(s).
```

No parity registration needed: the pass lives inside the shared engine function,
not a CLI `main()`, and adds no flag.

`run_doc_examples.py`: 4 failures, **identical on `main`** (missing fixture
boards in `api-impedance.md` / `api-net-analysis.md`). Confirmed by reverting
only my doc file: the same 4 fail, 31 run, only the skip count moves 77 → 78.

## Known residuals

* **Coverage is 2 of 6, on 1 of 2 boards** — and on `routed_output` nothing
  ships differently. Four crossings have two load-bearing arms or are already
  reachable by another pass.
* **The pipeline still manufactures crossings after this pass runs.**
  `close_soft_joints` takes `rp2350` from 4 to 6; this pass brings it back to 4,
  not below. A second, post-pipeline run of the same pass would take it to 1
  (measured) — but that inverts the documented #319 ordering ("`close_soft_joints`
  is the LAST copper step … so every joint close sees is router-born, never one
  a cleanup pass manufactured"), which deserves its own change and its own
  grading. Filed separately.
* **The cost table is a synthetic worst case.** Its residual driver is
  `_soft_joint_pairs`' O(dangles²) pair loop, which the fixture makes
  adversarial (300 free dangles). Real boards have far fewer. 1.63 s is a
  measurement, not a bound.
* **The graph-model caveat is covered by a net-level revert, not by exactness** —
  a divergence reverts the whole net rather than the single bad candidate. None
  was observed on any in-repo board.
* **The batched #319 guard loses one fallback**: if the shorter arm fails *only*
  the soft-joint gate, the longer arm is no longer tried. Measured identical
  removals on both in-repo boards and on the SJ fixture; no in-repo case
  exercises the difference.
* **The 8 crossings tabulated in the issue are on a corpus board I cannot
  measure here**, and acceptance item 1 is a width correlation plus a read code
  path, not a captured stack.
* **The 46 `--fast`-skipped integration tests were not run.** The end-to-end
  `route.py` A/B and the 33-board pipeline sweep cover the same ground for this
  change, but a full `run_all` is worth a CI slot.
* **Unrelated pre-existing bug found while working here, deliberately not fixed
  in this PR**: `check_connected.analyze_conn_excluding` computes `copper_roots`
  twice (the block is duplicated verbatim) and never returns
  `num_copper_components`, so the island-stranding gate at
  `pcb_modification.py:1809` and `check_weird.py:393` is vacuous —
  `analyze_conn_excluding` returns only
  `['connected', 'disconnected_pads', 'num_components']`. Filed separately;
  turning a dead gate live changes how much copper `collapse_strict_redundant`
  removes and needs its own grading.

## Post-review addendum (second adversarial pass)

A second independent review re-ran everything and confirmed all prior findings
genuinely fixed, the pass never disconnects anything, and the limitations
section holds. It surfaced one new latent defect, fixed in the head commit:

- **The 1mm spatial hash indexed each segment's bounding box, not its traversed
  cells** — a net of board-spanning diagonals paid ~O(length²) cell inserts and
  measured **11× slower** than the naive pairwise scan the old docstring claimed
  it avoided (identical pairs both ways). Latent — the worst in-repo net is 130
  inserts — but the docstring claim was false. It now states the truth, and the
  scan falls back to the plain double loop when the bbox fanout exceeds the
  pairwise cost. Both paths verified equivalent over 200 random tangles plus a
  long-diagonal board (same pairs, same deterministic order).

Three corrections to numbers quoted earlier in this description, from the same
pass: the sweep statement is precisely **22 tracked boards, 11 with copper, 9
byte-identical**; the red run's real failure line is `12 FAILED:` of which the 5
named checks are the load-bearing subset; and the doc-example failure count is
environment-dependent — the claim that holds is base-parity (identical failures
on both arms), not the absolute count.
