### PR TITLE
qfn underpad escape: test the pad->via stub against pre-existing vias (#619)

### DIFF
--- a/py_router/qfn_fanout/__init__.py
+++ b/py_router/qfn_fanout/__init__.py
@@ -200,6 +200,13 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
     _own_via_pos: Dict[int, List[Tuple[float, float]]] = {}
     for v in pcb_data.vias:
         _own_via_pos.setdefault(v.net_id, []).append((v.x, v.y))
+    # #619: the obstacle map ERASES every via on a fanned net (nets_to_route
+    # above), so the pad->via bridging stub below was never tested against a
+    # pre-existing via belonging to ANOTHER net we're escaping right now -- the
+    # exact hole the surface fan closes geometrically with _fanned_existing_vias
+    # (#257). Keep them for the stub test; the VIA position itself is already
+    # covered by via_clears/foreign_vias.
+    _unmapped_vias = [v for v in pcb_data.vias if v.net_id in fanned_nets]
     from kicad_parser import pad_drill_circles as _pdc
     import routing_defaults as _rd
     _h2h = _rd.HOLE_TO_HOLE_CLEARANCE
@@ -262,6 +269,23 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
                 return False
         return True
 
+    def stub_clears_unmapped(px, py, vx, vy, net_id):
+        # #619: pad->via stub vs a PRE-EXISTING via on another fanned net, which
+        # `obstacles` does not contain. Same test as the surface fan's #257 loop.
+        # Deliberately LAYER-BLIND, matching that loop and the graders around it:
+        # check_drc.check_via_segment_overlap ignores via.layers ("vias go
+        # through all layers") and obstacle_map._add_via_obstacle stamps every
+        # via on every layer, so filtering a blind/buried via out here would emit
+        # copper this repo's own DRC flags. (The surface fan's SEGMENT half does
+        # layer-filter -- segments really are single-layer objects.)
+        for v in _unmapped_vias:
+            if v.net_id == net_id:
+                continue
+            if point_to_segment_distance(v.x, v.y, px, py, vx, vy) \
+                    < v.size / 2 + track_width / 2 + clearance - 1e-6:
+                return False
+        return True
+
     def snap(v):
         return round(v / grid_step) * grid_step if grid_step > 0 else v
 
@@ -306,12 +330,32 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
             _rvx, _rvy = _best[1], _best[2]
             if (obs_layer_idx is None or
                     check_line_clearance(obstacles, px, py, _rvx, _rvy,
-                                         obs_layer_idx, cfg)):
+                                         obs_layer_idx, cfg)) \
+                    and stub_clears_unmapped(px, py, _rvx, _rvy, pi.pad.net_id):
                 return (_rvx, _rvy)
+        # #619 note on cost: a pad rejected by stub_clears_unmapped is DROPPED,
+        # not re-placed. Without allow_via_in_pad every candidate offset is
+        # `px + ex*d` for growing d -- further out along the SAME escape ray --
+        # so a via sitting on that ray blocks every remaining candidate too.
+        # Measured over every footprint with >=4 pads on the 22 tracked in-repo
+        # boards (408 of them, NO package-name filter): 7 footprints change,
+        # 22 escapes withdrawn, and the ladder recovers 0 of the REJECTED pads.
+        # (orangecrab_ext_pll U3 does gain one escape -- SPI_CONFIG_MOSI, which
+        # main drops -- but that is a DIFFERENT pad taking the offset a
+        # withdrawn neighbour freed, not this ladder recovering.) Recovering a
+        # rejected pad needs a new mechanism: a lateral offset, or on-pad
+        # offsets without --allow-via-in-pad.
+        # On orangecrab_ext_pll U7 (WLCSP-20, 0.4mm pitch) that cost is real and
+        # not free: all four GND balls are withdrawn, and after the full chain
+        # (pour + route) all eight of the part's GND pads are left unreached,
+        # where main reached them across stubs shorting GND to four other nets
+        # (d=0.0000 through the via centres). See the PR for the end-to-end
+        # measurement; taking this trade is a judgement, not a free win.
         for d in candidate_offsets(pi.pad_width, mode):
             vx, vy = snap(px + ex * d), snap(py + ey * d)
             stub_ok = (obs_layer_idx is None or
-                       check_line_clearance(obstacles, px, py, vx, vy, obs_layer_idx, cfg))
+                       check_line_clearance(obstacles, px, py, vx, vy, obs_layer_idx, cfg)) \
+                and stub_clears_unmapped(px, py, vx, vy, pi.pad.net_id)
             if stub_ok and via_clears(vx, vy, pi.pad.net_id, placed):
                 return (vx, vy)
         return None

--- a/tests/test_619_qfn_underpad_stub_vs_existing_via.py
+++ b/tests/test_619_qfn_underpad_stub_vs_existing_via.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+"""Issue #619 -- the QFN under-pad (via-drop) escape emitted its pad->via
+bridging stub without ever testing it against a PRE-EXISTING via that belongs
+to another net in the SAME fanout call.
+
+Mechanism: `_underpad_via_escape` builds its obstacle map with
+`build_base_obstacle_map(..., nets_to_route=list(fanned_nets))`, which ERASES
+every piece of copper on a net being escaped -- including vias already on the
+board for those nets (a re-run, a post-route fanout, a second part sharing the
+bus). The candidate via position is still checked geometrically by
+`via_clears` (it scans `pcb_data.vias` directly), but the STUB was only checked
+through the obstacle map, so it could be routed straight across -- or straight
+THROUGH -- a foreign via. The surface fan has a geometric backstop for exactly
+this (`_fanned_existing_vias`, issue #257); the under-pad path had none.
+
+Seven checks:
+
+1. INJECTION REGRESSION (the pin) + NEGATIVE CONTROL. `kicad_files/tigard.kicad_pcb`
+   U3 is a QFN-64 on a board with ZERO vias, so the baseline is uncontaminated.
+   Learn where net A's escape stub lands, re-parse, drop a via on net B onto
+   that path, and re-run with BOTH nets in the filter (both must be in
+   `fanned_nets` or the map would not erase the via). Assert the MECHANISM
+   directly (the same map built with `nets_to_route=[A, B]` reports the stub
+   line CLEAR, while `nets_to_route=[A]` reports it BLOCKED), assert no emitted
+   track comes within `v.size/2 + track_width/2 + clearance` of the injected
+   via -- and assert the EXACT emitted tuple, because post-fix net A emits
+   nothing at all and "no stub inside the floor" would otherwise pass vacuously
+   for any change that dropped every pad.
+   The NEGATIVE CONTROL is the other half: the same via injected OFF the escape
+   ray, 0.4000 mm from the stub against a 0.3750 mm floor, must NOT block it --
+   the baseline `(2, 2, [])` has to survive. Without it the gate could be
+   arbitrarily over-strict; multiplying the floor by 5 passes every other check
+   in this section and fails only here.
+
+2. NO-OP GUARD WITH THE LOOP LIVE. The only guard worth having is a footprint
+   that DOES carry pre-existing vias on its fanned nets -- so `_unmapped_vias`
+   is non-empty and the new loop really runs -- and is still byte-identical.
+   `orangecrab_ext_pll` U5 (7 such vias), U8 (5) and U9 (7) are those. A board
+   whose fanned nets carry NO via makes `_unmapped_vias` EMPTY and
+   `stub_clears_unmapped` a constant `True`; that guards nothing, so
+   `rp2350_fpga_eensy_prePlane` U5 is kept only as the explicitly-labelled
+   degenerate case.
+
+3. MEASURED BOARD PIN. `kicad_files/routed_output.kicad_pcb` U2 (QFN-76, 383
+   pre-existing vias, 89 of them on the fanned nets) at track 0.1 /
+   clearance 0.1 / via 0.45-0.25 emitted seven stubs inside a different-net
+   via's clearance floor (0.0000, 0.1000 and 0.2000x5 against a 0.300 floor;
+   the 0.0000 one ran through a foreign via CENTRE -- a dead short). Assert
+   zero, and pin the resulting escape tally so a collapse to zero escapes is
+   a failure rather than a pass.
+
+4. SECOND MEASURED BOARD. `kicad_files/rp2350_fpga_eensy_prePlane.kicad_pcb`
+   U6 (QFN-60, 70 vias, 34 on the fanned nets) emitted two stubs at 0.3370
+   and 0.2408 against a 0.375 floor. Assert zero, same pinned tally.
+
+5. THE STARKEST CASE. `orangecrab_ext_pll` U7 is a WLCSP-20 at 0.4 mm pitch
+   with 17 pre-existing vias on its fanned nets. Pre-fix it escaped all four
+   GND balls -- and every one of the four stubs ran through the CENTRE of a
+   foreign net's via (5 violations, all at d=0.0000). Post-fix it emits ZERO
+   vias and drops all four. This is the largest single behaviour change in the
+   corpus and the honest cost of the fix; nothing else in this file pins it.
+   `orangecrab_ext_pll` U1 (same package) is pinned beside it.
+
+6. THE FIX IS NOT MONOTONE. `orangecrab_ext_pll` U3 (csBGA-132, 92 vias on the
+   fanned nets) drops IO_SCK and QSPI_D2 that used to escape, but RECOVERS
+   SPI_CONFIG_MOSI, which the pre-fix engine dropped -- withdrawing one escape
+   frees the offset another pad needed. Pinned so "the gate only ever removes
+   escapes" cannot be asserted without measuring.
+
+7. LAYER-SCOPE DECISION PIN. The new loop deliberately does NOT filter by
+   `via.layers`: `check_drc.check_via_segment_overlap` grades a via against
+   segments on EVERY copper layer regardless of the via's span, and
+   `obstacle_map._add_via_obstacle` stamps every via on every layer. A
+   layer-filtered backstop would emit copper this repo's own grader flags.
+   Pinned here so that if check_drc ever becomes layer-aware, this fails and
+   points at the fanout loop that should follow it.
+
+    python3 tests/test_619_qfn_underpad_stub_vs_existing_via.py
+"""
+import contextlib
+import io
+import math
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'py_router'))  # #522
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'py_tools'))  # #522
+
+from kicad_parser import parse_kicad_pcb, Via, Segment
+from qfn_fanout import generate_qfn_fanout
+from geometry_utils import point_to_segment_distance
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TIGARD = os.path.join(REPO, "kicad_files", "tigard.kicad_pcb")
+MEASURED = os.path.join(REPO, "kicad_files", "routed_output.kicad_pcb")
+RP2350 = os.path.join(REPO, "kicad_files", "rp2350_fpga_eensy_prePlane.kicad_pcb")
+ORANGECRAB = os.path.join(REPO, "kicad_files", "orangecrab_ext_pll.kicad_pcb")
+
+TRACK_W, CLEARANCE, VIA_SIZE, VIA_DRILL, GRID = 0.1, 0.1, 0.45, 0.25, 0.05
+FLOOR = VIA_SIZE / 2 + TRACK_W / 2 + CLEARANCE     # 0.3750 mm
+
+fails = []
+
+
+def check(name, cond):
+    print(("  ok  " if cond else " FAIL ") + name)
+    if not cond:
+        fails.append(name)
+
+
+def _fanout(pcb, ref, net_filter, layer="F.Cu"):
+    """Run the under-pad escape quietly; returns (tracks, vias, dropped)."""
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        return generate_qfn_fanout(
+            pcb.footprints[ref], pcb, net_filter=net_filter, layer=layer,
+            track_width=TRACK_W, clearance=CLEARANCE, grid_step=GRID,
+            escape_method="underpad", via_size=VIA_SIZE, via_drill=VIA_DRILL)
+
+
+def _stub_via_violations(tracks, vias, clearance=CLEARANCE):
+    """Emitted tracks that sit inside a DIFFERENT-net via's clearance floor."""
+    out = []
+    for t in tracks:
+        (x0, y0), (x1, y1) = t['start'], t['end']
+        for v in vias:
+            if v.net_id == t['net_id']:
+                continue
+            d = point_to_segment_distance(v.x, v.y, x0, y0, x1, y1)
+            floor = v.size / 2 + t['width'] / 2 + clearance
+            if d < floor - 1e-6:
+                out.append((d, floor, t['net_id'], v.net_id, (v.x, v.y)))
+    out.sort()
+    return out
+
+
+def _fanned_via_count(pcb, ref):
+    """Exactly the set `_unmapped_vias` holds: pre-existing vias on a net this
+    fanout call is escaping. Zero here == the new loop is a constant True."""
+    fanned = {p.net_id for p in pcb.footprints[ref].pads if p.net_id}
+    return sum(1 for v in pcb.vias if v.net_id in fanned)
+
+
+def _report(tag, tracks, vias, dropped, viol):
+    print(f"      {tag}: tracks={len(tracks)} vias={len(vias)} "
+          f"dropped={len(dropped)}")
+    for d, floor, tn, vn, pos in viol[:10]:
+        print(f"      d={d:.4f} need>={floor:.4f} stub net {tn} vs via net {vn} @{pos}")
+
+
+# --------------------------------------------------------------------------
+# 1. Injection regression + negative control.
+# --------------------------------------------------------------------------
+def test_injected_foreign_via_blocks_stub():
+    print("\n1. injection regression + negative control (tigard U3, QFN-64)")
+    pcb = parse_kicad_pcb(TIGARD)
+    check("tigard has ZERO board vias (uncontaminated baseline)",
+          len(pcb.vias) == 0)
+
+    net_a, net_b = "/BD0", "/BD1"
+    nid_a = next(n for n, net in pcb.nets.items() if net.name == net_a)
+    nid_b = next(n for n, net in pcb.nets.items() if net.name == net_b)
+
+    # Where does net A's stub land with nothing in the way?
+    tracks, vias, dropped = _fanout(pcb, "U3", [net_a, net_b])
+    a_stubs = [t for t in tracks if t['net_id'] == nid_a]
+    check("baseline: both nets escape, nothing dropped",
+          (len(tracks), len(vias), sorted(dropped)) == (2, 2, []))
+    if not a_stubs:
+        return
+    (ax0, ay0), (ax1, ay1) = a_stubs[0]['start'], a_stubs[0]['end']
+    ix, iy = (ax0 + ax1) / 2.0, (ay0 + ay1) / 2.0   # dead centre of the stub
+
+    # Re-parse and inject a via on net B right on top of net A's stub.
+    pcb2 = parse_kicad_pcb(TIGARD)
+    pcb2.vias.append(Via(x=ix, y=iy, size=VIA_SIZE, drill=0.2,
+                         layers=["F.Cu", "B.Cu"], net_id=nid_b))
+
+    # -- MECHANISM: the injected via really is absent from the map the escape
+    #    builds. nets_to_route=[A, B] erases it (the escape's own call);
+    #    nets_to_route=[A] keeps it. Same map, same line, opposite answers.
+    from obstacle_map import (build_base_obstacle_map, build_layer_map,
+                              check_line_clearance)
+    from routing_config import GridRouteConfig
+    cfg = GridRouteConfig(layers=list(pcb2.board_info.copper_layers),
+                          track_width=TRACK_W, clearance=CLEARANCE)
+    lidx = build_layer_map(cfg.layers)["F.Cu"]
+    obs_ab = build_base_obstacle_map(pcb2, cfg, nets_to_route=[nid_a, nid_b],
+                                     extra_clearance=TRACK_W / 2)
+    obs_a = build_base_obstacle_map(pcb2, cfg, nets_to_route=[nid_a],
+                                    extra_clearance=TRACK_W / 2)
+    check("mechanism: map(nets_to_route=[A,B]) reports the stub line CLEAR "
+          "(injected via erased)",
+          check_line_clearance(obs_ab, ax0, ay0, ax1, ay1, lidx, cfg) is True)
+    check("mechanism: map(nets_to_route=[A]) reports the same line BLOCKED "
+          "(injected via present)",
+          check_line_clearance(obs_a, ax0, ay0, ax1, ay1, lidx, cfg) is False)
+
+    # -- OUTCOME: no emitted stub may graze the injected via.
+    tracks2, vias2, dropped2 = _fanout(pcb2, "U3", [net_a, net_b])
+    print(f"      post-injection: tracks={len(tracks2)} vias={len(vias2)} "
+          f"dropped={sorted(dropped2)}")
+    viol = _stub_via_violations(tracks2, pcb2.vias)
+    for d, floor, tn, vn, pos in viol:
+        print(f"      d={d:.4f} need>={floor:.4f} stub net {tn} vs via net {vn} @{pos}")
+    check("no emitted stub is inside the injected via's clearance floor",
+          not viol)
+
+    # -- COUNTER-GUARD: the check above is satisfied by emitting nothing, so
+    #    pin what the fix actually does. Net A is DROPPED (the candidate_offsets
+    #    ladder only walks FURTHER OUT along the same escape ray, so once a via
+    #    sits on that ray every remaining offset is blocked too -- there is no
+    #    recovery path). Net B keeps its escape, and it is the #479 reuse
+    #    bridge to the injected via (its own net), so no new via is emitted.
+    check(f"counter-guard: net A ({net_a}) is DROPPED, not silently re-routed",
+          net_a in dropped2)
+    check("counter-guard: exact post-injection tuple (1 track, 0 vias, "
+          "dropped=['/BD0']) -- a change that dropped EVERY pad would fail here",
+          (len(tracks2), len(vias2), sorted(dropped2)) == (1, 0, [net_a]))
+    check("counter-guard: the surviving track belongs to net B",
+          len(tracks2) == 1 and tracks2[0]['net_id'] == nid_b)
+
+    # -- NEGATIVE CONTROL (the other direction): the same via injected OFF the
+    #    escape ray, just OUTSIDE the floor, must NOT block anything. This is
+    #    the only check in this file with teeth against an OVER-strict gate:
+    #    multiplying the floor by 5 leaves every check above passing and fails
+    #    only here.
+    dx, dy = ax1 - ax0, ay1 - ay0
+    L = math.hypot(dx, dy)
+    perp_x, perp_y = -dy / L, dx / L                # unit normal to the stub
+    off = 0.40                                      # > FLOOR (0.3750), < 5*FLOOR
+    nx, ny = ix + perp_x * off, iy + perp_y * off
+    pcb3 = parse_kicad_pcb(TIGARD)
+    pcb3.vias.append(Via(x=nx, y=ny, size=VIA_SIZE, drill=0.2,
+                         layers=["F.Cu", "B.Cu"], net_id=nid_b))
+    d_ctrl = point_to_segment_distance(nx, ny, ax0, ay0, ax1, ay1)
+    print(f"      negative control: via on net B at d={d_ctrl:.4f} from net A's "
+          f"stub (floor {FLOOR:.4f})")
+    check(f"negative control is in the band an over-strict floor would catch "
+          f"({FLOOR:.4f} <= {d_ctrl:.4f} < {5 * FLOOR:.4f})",
+          FLOOR <= d_ctrl < 5 * FLOOR)
+    tracks3, vias3, dropped3 = _fanout(pcb3, "U3", [net_a, net_b])
+    print(f"      negative control: tracks={len(tracks3)} vias={len(vias3)} "
+          f"dropped={sorted(dropped3)}")
+    check("negative control: a via OUTSIDE the floor does NOT block the stub "
+          "-- baseline (2 tracks, 2 vias, nothing dropped) survives",
+          (len(tracks3), len(vias3), sorted(dropped3)) == (2, 2, []))
+
+
+# --------------------------------------------------------------------------
+# 2. No-op guard, with the loop LIVE (and the degenerate case labelled).
+# --------------------------------------------------------------------------
+def test_no_op_when_gate_finds_nothing_to_reject():
+    print("\n2. no-op guard")
+    print("   2a. LOOP LIVE: pre-existing vias ON the fanned nets, and the "
+          "gate rejects none of them")
+    for ref, n_exp, expect in (("U5", 7, (13, 13, 3)),
+                               ("U8", 5, (7, 7, 3)),
+                               ("U9", 7, (15, 15, 9))):
+        pcb = parse_kicad_pcb(ORANGECRAB)
+        n_fanned = _fanned_via_count(pcb, ref)
+        check(f"orangecrab_ext_pll {ref}: _unmapped_vias is NON-EMPTY "
+              f"({n_fanned} pre-existing vias on the fanned nets, expected "
+              f"{n_exp}) -- the new loop actually runs here",
+              n_fanned == n_exp and n_fanned > 0)
+        tracks, vias, dropped = _fanout(pcb, ref, None,
+                                        layer=pcb.footprints[ref].layer)
+        print(f"      orangecrab_ext_pll {ref}: tracks={len(tracks)} "
+              f"vias={len(vias)} dropped={len(dropped)}")
+        check(f"orangecrab_ext_pll {ref}: escape tally unchanged by the new "
+              f"gate {expect} -- it does not over-reject",
+              (len(tracks), len(vias), len(dropped)) == expect)
+
+    print("   2b. DEGENERATE (labelled): board HAS vias but none on a fanned "
+          "net, so _unmapped_vias is EMPTY and the gate is a constant True")
+    pcb = parse_kicad_pcb(RP2350)
+    n_fanned = _fanned_via_count(pcb, "U5")
+    check(f"rp2350_fpga_eensy_prePlane U5: {len(pcb.vias)} board vias, "
+          f"{n_fanned} on a fanned net -- this guard is INERT BY "
+          f"CONSTRUCTION, not evidence the gate is well-behaved",
+          len(pcb.vias) > 0 and n_fanned == 0)
+    tracks, vias, dropped = _fanout(pcb, "U5", None,
+                                    layer=pcb.footprints["U5"].layer)
+    print(f"      rp2350_fpga_eensy_prePlane U5: tracks={len(tracks)} "
+          f"vias={len(vias)} dropped={len(dropped)}")
+    check("rp2350_fpga_eensy_prePlane U5: escape tally unchanged (3, 3, 1)",
+          (len(tracks), len(vias), len(dropped)) == (3, 3, 1))
+
+
+# --------------------------------------------------------------------------
+# 3. The board the issue measured.
+# --------------------------------------------------------------------------
+def test_measured_board_u2():
+    print("\n3. measured board (routed_output U2, QFN-76, 383 existing vias)")
+    pcb = parse_kicad_pcb(MEASURED)
+    check("board carries pre-existing vias on the fanned nets (the condition "
+          f"under test); got {_fanned_via_count(pcb, 'U2')}",
+          _fanned_via_count(pcb, "U2") > 50)
+    tracks, vias, dropped = _fanout(pcb, "U2", None)
+    viol = _stub_via_violations(tracks, pcb.vias)
+    _report("U2", tracks, vias, dropped, viol)
+    # Guard against a trivial pass: the escape must still do real work, and
+    # the exact cost of the fix is pinned (26 -> 19 vias, 15 -> 22 dropped).
+    check("U2 escape tally pinned at 20 tracks / 19 vias / 22 dropped "
+          "(was 27 / 26 / 15 pre-fix)",
+          (len(tracks), len(vias), len(dropped)) == (20, 19, 22))
+    check("no emitted stub sits inside a different-net existing via's floor "
+          f"(was 7 pre-fix, incl. one through a via centre); got {len(viol)}",
+          not viol)
+
+
+# --------------------------------------------------------------------------
+# 4. The second regressing board found by the corpus sweep.
+# --------------------------------------------------------------------------
+def test_measured_board_rp2350_u6():
+    print("\n4. second measured board (rp2350_fpga_eensy_prePlane U6, QFN-60)")
+    pcb = parse_kicad_pcb(RP2350)
+    check("U6 has pre-existing vias on its fanned nets; got "
+          f"{_fanned_via_count(pcb, 'U6')}",
+          _fanned_via_count(pcb, "U6") > 10)
+    tracks, vias, dropped = _fanout(pcb, "U6", None)
+    viol = _stub_via_violations(tracks, pcb.vias)
+    _report("U6", tracks, vias, dropped, viol)
+    check("U6 escape tally pinned at 10 tracks / 7 vias / 37 dropped "
+          "(was 12 / 9 / 35 pre-fix)",
+          (len(tracks), len(vias), len(dropped)) == (10, 7, 37))
+    check("no emitted stub sits inside a different-net existing via's floor "
+          f"(was 2 pre-fix, at d=0.3370 and d=0.2408 vs a 0.375 floor); "
+          f"got {len(viol)}",
+          not viol)
+
+
+# --------------------------------------------------------------------------
+# 5. The starkest case in the corpus: a fine-pitch WLCSP that escaped every
+#    GND ball through the CENTRE of a foreign via, and now escapes none.
+# --------------------------------------------------------------------------
+def test_orangecrab_wlcsp_u7_and_u1():
+    print("\n5. starkest case (orangecrab_ext_pll U7/U1, WLCSP-20 @ 0.4mm pitch)")
+    for ref, n_exp, expect, n_viol_pre in (("U7", 17, (2, 0, 4), 5),
+                                           ("U1", 17, (2, 0, 4), 4)):
+        pcb = parse_kicad_pcb(ORANGECRAB)
+        check(f"{ref} has pre-existing vias on its fanned nets; got "
+              f"{_fanned_via_count(pcb, ref)} (expected {n_exp})",
+              _fanned_via_count(pcb, ref) == n_exp)
+        tracks, vias, dropped = _fanout(pcb, ref, None,
+                                        layer=pcb.footprints[ref].layer)
+        viol = _stub_via_violations(tracks, pcb.vias)
+        _report(ref, tracks, vias, dropped, viol)
+        check(f"{ref} escape tally pinned at 2 tracks / 0 vias / 4 dropped "
+              f"-- EVERY GND ball is withdrawn, this is the fix's largest "
+              f"single cost and it is deliberate",
+              (len(tracks), len(vias), len(dropped)) == expect)
+        check(f"{ref}: the four withdrawn escapes are all GND",
+              sorted(dropped) == ["GND"] * 4)
+        check(f"{ref}: no emitted stub sits inside a different-net existing "
+              f"via's floor (was {n_viol_pre} pre-fix, every one at d=0.0000 "
+              f"-- straight through a foreign via centre); got {len(viol)}",
+              not viol)
+
+
+# --------------------------------------------------------------------------
+# 6. The gate is not monotone: it also RECOVERS an escape.
+# --------------------------------------------------------------------------
+def test_orangecrab_u3_recovers_an_escape():
+    print("\n6. not monotone (orangecrab_ext_pll U3, csBGA-132)")
+    pcb = parse_kicad_pcb(ORANGECRAB)
+    check(f"U3 has pre-existing vias on its fanned nets; got "
+          f"{_fanned_via_count(pcb, 'U3')}",
+          _fanned_via_count(pcb, "U3") == 92)
+    tracks, vias, dropped = _fanout(pcb, "U3", None,
+                                    layer=pcb.footprints["U3"].layer)
+    viol = _stub_via_violations(tracks, pcb.vias)
+    _report("U3", tracks, vias, dropped, viol)
+    check("U3 escape tally pinned at 45 tracks / 45 vias / 50 dropped "
+          "(was 47 / 47 / 48 pre-fix)",
+          (len(tracks), len(vias), len(dropped)) == (45, 45, 50))
+    check("U3: IO_SCK and QSPI_D2 are withdrawn (they escaped pre-fix)",
+          "IO_SCK" in dropped and "QSPI_D2" in dropped)
+    check("U3: SPI_CONFIG_MOSI is RECOVERED -- it was DROPPED pre-fix and "
+          "escapes now, so the gate is not merely subtractive",
+          "SPI_CONFIG_MOSI" not in dropped)
+    check(f"U3: no emitted stub sits inside a different-net existing via's "
+          f"floor (was 2 pre-fix); got {len(viol)}", not viol)
+
+
+# --------------------------------------------------------------------------
+# 7. Layer-scope decision pin (why the new loop does NOT read via.layers).
+# --------------------------------------------------------------------------
+def test_backstop_layer_blindness_matches_check_drc():
+    print("\n7. layer scope: the backstop is layer-blind because check_drc is")
+    from check_drc import check_via_segment_overlap
+    # A BURIED via that touches neither F.Cu nor B.Cu ...
+    buried = Via(x=10.0, y=10.0, size=0.45, drill=0.25,
+                 layers=["In1.Cu", "In2.Cu"], net_id=1)
+    # ... and a track on F.Cu running straight through its centre.
+    seg = Segment(start_x=9.0, start_y=10.0, end_x=11.0, end_y=10.0,
+                  width=TRACK_W, layer="F.Cu", net_id=2)
+    hit, overlap = check_via_segment_overlap(buried, seg, CLEARANCE)
+    print(f"      check_via_segment_overlap(buried In1/In2 via, F.Cu seg) "
+          f"-> hit={hit} overlap={overlap:.4f}mm")
+    check("check_drc grades a via against segments on EVERY copper layer "
+          "regardless of via.layers, so a layer-filtered fanout backstop "
+          "would ship copper this repo's own grader flags",
+          hit is True)
+    # And the shipped backstop agrees: same geometry, same verdict.
+    d = point_to_segment_distance(buried.x, buried.y, seg.start_x, seg.start_y,
+                                  seg.end_x, seg.end_y)
+    check(f"the backstop's own floor test agrees (d={d:.4f} < {FLOOR:.4f})",
+          d < FLOOR - 1e-6)
+
+
+def run():
+    for board in (TIGARD, MEASURED, RP2350, ORANGECRAB):
+        if not os.path.exists(board):
+            print(f"FAIL: missing board {board}")
+            return 1
+    test_injected_foreign_via_blocks_stub()
+    test_no_op_when_gate_finds_nothing_to_reject()
+    test_measured_board_u2()
+    test_measured_board_rp2350_u6()
+    test_orangecrab_wlcsp_u7_and_u1()
+    test_orangecrab_u3_recovers_an_escape()
+    test_backstop_layer_blindness_matches_check_drc()
+    print()
+    if fails:
+        print("FAILED: %d check(s): %s" % (len(fails), fails))
+        return 1
+    print("All checks passed")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(run())


### PR DESCRIPTION
Closes #619.

`_underpad_via_escape` never tested its pad→via bridging stub against a
pre-existing via belonging to **another net in the same fanout call**. It shipped
stubs straight through foreign via centres — dead shorts.

**Read the cost first.** Corpus-wide this withdraws **22 escapes on 7 footprints**,
and there is no recovery path. On `orangecrab_ext_pll` U7 it withdraws *every*
GND escape, and after the full designed chain (fanout → pour → route) **all
eight of U7's GND pads are left unreached**, where the pre-fix leg reached them —
across five dead shorts that survive into the final routed board. That trade is
measured end-to-end in [What this costs](#what-this-costs), together with the
control run that limits how much it proves (the same regression appears on a
chain where U7 is never fanned out at all, so the sensitive quantity is the
whole-board GND route). CONTRIBUTING says *"a fix that trades a DRC violation for
a disconnected pad is not a fix"*, and on U7 that is at least arguably the trade.
I am not hiding it; the maintainer should judge it.

> **Correction to the first version of this PR.** It reported *"exactly 2
> footprints change … 9 escapes withdrawn … zero pads left disconnected."* All
> three were wrong. The sweep behind them filtered footprints by a QFN/QFP
> **name** pattern, which is not how the tool selects parts: `qfn_fanout.py -c`
> accepts any reference (`py_router/qfn_fanout/__init__.py~:1069` is only
> `if args.component not in pcb_data.footprints`) and the GUI dropdown lists every footprint
> with enough pads, no package filter
> (`kicad_routing_plugin/fanout_gui.py:251-273`). Under-pad via-drop is the
> fine-pitch/CSP escape method — a WLCSP-20 at 0.4 mm pitch is its core case, not
> an out-of-scope one. Re-swept with no name filter: **7 footprints change, 22
> escapes withdrawn, 25 violations removed, and on U7 eight pads are left
> disconnected.**

---

## Reproduce

The issue's own configuration includes `--allow-via-in-pad`, which is why it
quotes **5** stubs on U2 while the default ladder gives **7**. Both are real and
both go to zero; the knob is stated with each number below.

```bash
# BEFORE (on main)
python3 py_router/qfn_fanout.py kicad_files/routed_output.kicad_pcb -c U2 \
    --escape-method underpad -w 0.1 --clearance 0.1 \
    --via-size 0.45 --via-drill 0.25 --grid-step 0.05 -o /tmp/u2_pre.kicad_pcb
python3 py_router/check_drc.py /tmp/u2_pre.kicad_pcb | grep -E '^(FOUND|[A-Z-]+ violations)'

# AFTER (on this branch), to a FRESH output path
python3 py_router/qfn_fanout.py kicad_files/routed_output.kicad_pcb -c U2 \
    --escape-method underpad -w 0.1 --clearance 0.1 \
    --via-size 0.45 --via-drill 0.25 --grid-step 0.05 -o /tmp/u2_post.kicad_pcb
python3 py_router/check_drc.py /tmp/u2_post.kicad_pcb | grep -E '^(FOUND|[A-Z-]+ violations)'
```

### `routed_output` U2 (QFN-76), default ladder

```
BEFORE (main):
  Underpad via-drop: 26 vias placed, 15 dropped (pitch 0.40, via 0.45, stagger 0.427 mm)
Writing 27 tracks and 26 vias to <out>...
FOUND 48 DRC VIOLATIONS:
SEGMENT-CROSSING violations (17):
SEGMENT-SEGMENT violations (21):
VIA-SEGMENT violations (7):
VIA-DRILL-HOLE violations (3):

AFTER (this branch):
  Underpad via-drop: 19 vias placed, 22 dropped (pitch 0.40, via 0.45, stagger 0.427 mm)
Writing 20 tracks and 19 vias to <out>...
FOUND 18 DRC VIOLATIONS:
SEGMENT-CROSSING violations (9):
SEGMENT-SEGMENT violations (6):
VIA-DRILL-HOLE violations (3):
```

The seven `VIA-SEGMENT` entries, verbatim — note the fourth, whose 0.290 mm
overlap on a 0.300 mm floor means the stub runs through the via **centre**:

```
VIA-SEGMENT violations (7):
----------------------------------------
  Via:Net-(U2A-DATA_19) <-> Seg:Net-(U2A-DATA_17)
    Layer: F.Cu, Overlap: 0.090mm
    Via: (212.10,100.70)
    Seg: (213.56,100.50)-(210.65,100.50)
  Via:Net-(U2A-DATA_19) <-> Seg:Net-(U2A-DATA_18)
    Layer: F.Cu, Overlap: 0.090mm
    Via: (212.10,100.70)
    Seg: (213.56,100.90)-(211.50,100.90)
  Via:Net-(U2A-DATA_6) <-> Seg:Net-(U2A-DATA_7)
    Layer: F.Cu, Overlap: 0.090mm
    Via: (218.20,96.90)
    Seg: (218.40,98.46)-(218.40,94.70)
  Via:Net-(U2A-~{TXE}) <-> Seg:Net-(U2A-BE_3)
    Layer: F.Cu, Overlap: 0.290mm
    Via: (216.80,108.50)
    Seg: (216.80,107.34)-(216.80,109.40)
  Via:Net-(U2A-~{OE}) <-> Seg:Net-(U2A-~{RESET})
    Layer: F.Cu, Overlap: 0.090mm
    Via: (219.80,108.40)
    Seg: (220.00,107.34)-(220.00,108.95)
  Via:Net-(U2A-DATA_2) <-> Seg:Net-(U2A-DATA_0)
    Layer: F.Cu, Overlap: 0.090mm
    Via: (221.30,96.70)
    Seg: (221.20,98.46)-(221.20,95.15)
  Via:Net-(U2A-DATA_21) <-> Seg:Net-(U2A-DATA_20)
    Layer: F.Cu, Overlap: 0.090mm
    Via: (212.40,101.90)
    Seg: (213.56,101.70)-(211.10,101.70)
```

`VIA-SEGMENT` 7 → 0; `check_drc` 48 → 18. With `--allow-via-in-pad` — the
issue's configuration — the same board reports **5 → 0** and the tally goes
`29 / 28 / 13` → `24 / 23 / 18`.

### `orangecrab_ext_pll` U7 (WLCSP-20 @ 0.4 mm pitch) — the starkest case

```bash
python3 py_router/qfn_fanout.py kicad_files/orangecrab_ext_pll.kicad_pcb -c U7 \
    --escape-method underpad -w 0.1 --clearance 0.1 \
    --via-size 0.45 --via-drill 0.25 --grid-step 0.05 -o <out>
```

```
BEFORE (main):
  Underpad via-drop: 4 vias placed, 0 dropped (pitch 0.40, via 0.45, stagger 0.427 mm)
Writing 6 tracks and 4 vias to <out>...
JSON_SUMMARY: {"component": "U7", "requested": 2, "escaped": 2, "failed": 0,
  "unescaped_nets": [], ...
  "drc_grazes": {"pad_via": 27, "via_segment": 5, "pad_segment": 7, "segment_segment": 1, "total": 40}

AFTER (this branch):
  Underpad via-drop: 0 vias placed, 4 dropped (pitch 0.40, via 0.45, stagger 0.427 mm)
    dropped (no clear via offset): ['GND', 'GND', 'GND', 'GND']
Writing 2 tracks and 0 vias to <out>...
JSON_SUMMARY: {"component": "U7", "requested": 2, "escaped": 1, "failed": 1,
  "unescaped_nets": ["GND"], ...
  "drc_grazes": {"pad_via": 27, "via_segment": 0, "pad_segment": 0, "segment_segment": 0, "total": 27}, "min_clearance_used": 0.1}
```

Graded at the clearance the escape actually routed to (`--clearance 0.1` on all
three, per CLAUDE.md), the fanout's own contribution is visible:

| board | `check_drc` @ 0.1 | breakdown |
|---|---|---|
| `kicad_files/orangecrab_ext_pll.kicad_pcb` (no fanout) | **27** | PAD-VIA 27 (the board's own via-in-pad, pre-existing) |
| pre-fix U7 fanout output | **40** | + SEG-SEG 1, VIA-SEG 5, PAD-SEG 7 |
| post-fix U7 fanout output | **27** | nothing added |

Those five `VIA-SEGMENT` entries are the bug, verbatim, and they are shorts:

```
VIA-SEGMENT violations (5):
----------------------------------------
  Via:/sheetPower/PGOOD_P1.35V <-> Seg:GND
    Layer: F.Cu, Overlap: 0.300mm
    Via: (151.75,98.25)
    Seg: (152.15,98.25)-(150.45,98.25)
  Via:P1.35V <-> Seg:GND
    Layer: F.Cu, Overlap: 0.300mm
    Via: (151.75,97.05)
    Seg: (152.15,97.05)-(149.15,97.05)
  Via:VSYS <-> Seg:GND
    Layer: F.Cu, Overlap: 0.300mm
    Via: (152.95,98.25)
    Seg: (152.55,98.25)-(153.85,98.25)
  Via:Net-(L3-Pad1) <-> Seg:GND
    Layer: F.Cu, Overlap: 0.300mm
    Via: (152.95,97.05)
    Seg: (152.55,97.05)-(154.70,97.05)
  Via:Net-(L3-Pad1) <-> Seg:GND
    Layer: F.Cu, Overlap: 0.300mm
    Via: (153.35,97.05)
    Seg: (152.55,97.05)-(154.70,97.05)
```

Every one of those segments starts on a U7 GND ball (B1 `152.15,98.25`,
B4 `152.15,97.05`, C1 `152.55,98.25`, C4 `152.55,97.05`) and runs through the
centre of a via on `PGOOD_P1.35V`, `P1.35V`, `VSYS` or `Net-(L3-Pad1)`: distance
`0.0000` against a `0.3750` floor. GND shorted to four other nets.

---

## Root cause

`_underpad_via_escape` builds its obstacle map with

```python
obstacles = build_base_obstacle_map(pcb_data, cfg, nets_to_route=list(fanned_nets), ...)
```

`nets_to_route` **erases** every piece of copper on a net being escaped
(`obstacle_map.py:277` for vias, `:309` for pads) — correct for the net's *own*
copper, but it also erases the vias of **every other net in the same fanout
call**. The candidate VIA position survived this because `via_clears` scans
`pcb_data.vias` directly. The pad→via **stub** did not: its only test was
`check_line_clearance(obstacles, ...)`, against the map those vias had been
deleted from.

The surface fan closes exactly this hole geometrically — `_fanned_existing_vias`
at `qfn_fanout/__init__.py~:748` / `:781-785` (post-patch line numbers), issue
#257. The under-pad path had no equivalent.

## The change

The engine diff is 46 added lines, of which **13 are code** and the rest are
comment: `_unmapped_vias` — the erased set, mirrored — plus
`stub_clears_unmapped`, the **via half** of the surface fan's #257 loop applied
to the pad→via stub, `and`-ed into both the #479 reuse-bridge gate and the
candidate-offset gate. No new import, parameter, flag, or CLI post-pass. The
code is unchanged from the previous revision of this PR; what changed is the
measurement around it, the cost comment, and the test.

---

## Blast radius: full corpus sweep, no name filter

Every footprint with ≥4 pads on every tracked in-repo board — **408 footprints
across 22 boards, no package filter of any kind** — run through
`generate_qfn_fanout(..., escape_method="underpad")` at track 0.1 / clearance 0.1
/ via 0.45–0.25 / grid 0.05, on both engine legs, comparing exact emitted
geometry (track endpoints, via positions, drop list).

```
gate-live (>=1 pre-existing via on a fanned net): 110
byte-identical emitted geometry                 : 401
CHANGED                                         : 7
```

| board / part | package | on-fanned vias | pre tracks/vias/dropped | post | stub-vs-via viol pre → post |
|---|---|---|---|---|---|
| `orangecrab_ext_pll` U1 | WLCSP-20 | 17 | 5 / 3 / 1 | **2 / 0 / 4** | **4 → 0** |
| `orangecrab_ext_pll` U2 | WLCSP-20 | 15 | 6 / 4 / 1 | **4 / 2 / 3** | **3 → 0** |
| `orangecrab_ext_pll` U3 | csBGA-132 | 92 | 47 / 47 / 48 | **45 / 45 / 50** | **2 → 0** |
| `orangecrab_ext_pll` U7 | WLCSP-20 | 17 | 6 / 4 / 0 | **2 / 0 / 4** | **5 → 0** |
| `routed_output` U2 | QFN-76 | 89 | 27 / 26 / 15 | **20 / 19 / 22** | **7 → 0** |
| `rp2350_fpga_eensy_prePlane` U2 | WLCSP-49 | 50 | 6 / 4 / 18 | **4 / 2 / 20** | **2 → 0** |
| `rp2350_fpga_eensy_prePlane` U6 | QFN-60 | 34 | 12 / 9 / 35 | **10 / 7 / 37** | **2 → 0** |

```
escapes withdrawn total: 22   violations removed total: 25
residual stub-vs-pre-existing-via across all 408 footprints: base 25 -> fix 0
```

The other 298 footprints have **zero** pre-existing vias on their fanned nets, so
`_unmapped_vias` is empty and the gate is a constant `True`; the 103 gate-live
footprints that do not appear above run the loop and it rejects nothing. Both
were measured, not argued.

Same sweep with `--allow-via-in-pad`: the same 7 footprints change, **20 escapes
withdrawn, 27 violations removed, residual 0**. The ladder recovers essentially
nothing there either — the only movement is one swap on U3 (`FPGA_RESET`
un-dropped, `IO_SCK` dropped).

### The fix is not purely subtractive

`orangecrab_ext_pll` U3 drops `IO_SCK` and `QSPI_D2`, which used to escape, but
**recovers** `SPI_CONFIG_MOSI`, which the pre-fix engine dropped: withdrawing one
escape frees the offset another pad needed. Pinned by check 6 of the test so
"the gate only ever removes escapes" cannot be asserted without measuring.

---

## What this costs

**There is no recovery path, and that is geometric rather than bad luck**:
without `--allow-via-in-pad` every candidate offset is `snap(px + ex*d, py + ey*d)`
for growing `d` — the same escape ray, further out — so a via sitting on that ray
lengthens the stub *through* it and blocks every remaining candidate. Of the 22
withdrawn escapes the ladder recovers 0.

### `orangecrab_ext_pll` U7 — a genuine cost, stated plainly

This is the case where the fix loses connectivity. Both legs were run through the
**complete designed chain for a pre-plane board** — fanout, then a bare GND pour
(`route_planes.py --nets GND --plane-layers In1.Cu`, #562: no per-pad taps), then
`route.py -n GND` whose in-run finalize welds the pads — and graded on the
**routed** board, not on the fanout output:

```bash
python3 py_router/route_planes.py <U7_fan> <U7_plane> --nets GND \
    --plane-layers In1.Cu --track-width 0.1 --clearance 0.1 --grid-step 0.05
python3 py_router/route.py <U7_plane> --output <U7_routed> -n GND \
    --track-width 0.1 --clearance 0.1 --grid-step 0.05
python3 py_router/check_connected.py <U7_routed> -n GND
```

```
BASE (main), final routed board:
  GND (net 5): Segments: 824, Vias: 26, Pads: 304
    Disconnected components: 2
    Disconnected pads:
      (171.65, 105.20) on F.Cu [U4]
  -> U7's 8 GND balls: 8 reached, 0 disconnected.

FIX (this branch), final routed board:
  GND (net 5): Segments: 871, Vias: 23, Pads: 304
    Disconnected components: 3
    Disconnected pads: 15, of which 8 are U7's
  -> U7's 8 GND balls: 0 reached, 8 DISCONNECTED
     (B1 B2 B3 B4 C1 C2 C3 C4, all on F.Cu)
```

**Eight GND balls that the pre-fix chain reached are not reached after this
change.** That is the honest cost and I am not going to argue it away.

What the pre-fix chain reached them *with* is the other half of the ledger.
`check_drc --clearance 0.1` on the two **final routed** boards:

| final routed board | total | seg-seg | via-seg | pad-seg | pad-via |
|---|---|---|---|---|---|
| base (`main`) | **40** | 1 | **5** | 8 | 26 |
| fix (this branch) | **28** | 0 | **0** | 2 | 26 |

The five `VIA-SEGMENT` entries on the base board are the same five listed above,
unchanged by pour and route: they are still in the shipped artifact. So on U7 the
choice is between a board where GND reaches those eight balls **through shorts to
`PGOOD_P1.35V`, `P1.35V`, `VSYS` and `Net-(L3-Pad1)`**, and a board where the
fanout declines the escape, reports `"unescaped_nets": ["GND"]`, and leaves the
balls for a later step or a wider parameter set. I believe the second is right —
a pad connected through a short is not connected — but it is a judgement call on
a real regression in `check_connected`, not a free win, and the maintainer should
make it.

`orangecrab_ext_pll` U1, U2 and `rp2350_fpga_eensy_prePlane` U2 withdraw GND
escapes in the same shape. **U1 was carried through the identical chain, and its
own pads survive**: all eight of U1's GND balls are reached on *both* legs.

```
BASE (main), U1 chain, final routed board:  GND 2 components, 4 disconnected pads
                                            {'U4': 3, 'C43': 1}   U1's 8 GND balls: 8 reached
FIX  (this branch), same chain:             GND 3 components, 15 disconnected pads
                                            {'U4': 1, 'C18': 1, 'R16': 1, 'U7': 8,
                                             'R33': 1, 'C16': 1, 'J4': 2}
                                            U1's 8 GND balls: 8 reached
```

**That U1 run is also the control that limits how much the U7 result proves.**
Nothing in the U1 chain fans out U7 at all — on either leg U7's balls have no
escape — yet the base leg reaches them and the fix leg does not, with exactly
the same 15-pad breakdown as the fix leg's U7 chain. So the failing quantity is
the **whole-board GND route**, which is sensitive to small perturbations
anywhere on the board; the withdrawn escapes are an input to it, not a proven
sole cause. The direction is consistent (fix leg → U7 unreached in both chains,
base leg → reached in both), but CLAUDE.md is explicit that a per-board result
of this size is not a default-change-grade measurement, and I am not going to
claim more than two chains support. What is not in doubt: the pre-fix board
ships the five shorts, and the post-fix board does not.

**`routed_output` U2 — 7 escapes withdrawn, all 7 pads still reached.**

```
$ python3 py_router/check_connected.py kicad_files/routed_output.kicad_pcb \
      -n "Net-(U2A-BE_3)" "Net-(U2A-DATA_0)" "Net-(U2A-DATA_7)" \
         "Net-(U2A-DATA_17)" "Net-(U2A-DATA_18)" "Net-(U2A-DATA_20)" "Net-(U2A-~{RESET})"
Found 1701 segments, 383 vias, 1079 pads
Checking 7 nets matching: [...]

FOUND 2 ISSUES:
  Net-(U2A-BE_3) (net 83):    Disconnected pads: (216.80, 107.34) on F.Cu [U2]
  Net-(U2A-~{RESET}) (net 91): Disconnected pads: (220.00, 107.34) on F.Cu [U2]
```

Five of the seven (`DATA_0/7/17/18/20`) were **already fully connected before the
fanout ran** — their withdrawn escape was redundant copper that also violated
DRC. Route the other two from the bare pad on the post-fix fanout output:

```
$ python3 py_router/route.py <u2_post> --output <u2_post_routed> -n <the 7 nets> \
      --track-width 0.1 --clearance 0.1 --grid-step 0.05
Routing 7 nets: ['Net-(U2A-BE_3)', 'Net-(U2A-DATA_0)', 'Net-(U2A-DATA_7)', 'Net-(U2A-DATA_17)', 'Net-(U2A-DATA_18)']...
Skipping 5 already-routed net(s): Already fully connected
Routing 2 single-ended net(s)...
[1/2] Routing Net-(U2A-BE_3) (id=83)
  SUCCESS: 30 segments, 1 vias, 897 iterations, length=20.00mm (stubs=4.47mm) (2.24s)
[2/2] Routing Net-(U2A-~{RESET}) (id=91)
  SUCCESS: 44 segments, 1 vias, 39021 iterations, length=38.84mm (stubs=6.15mm) (0.97s)
Routing complete

$ python3 py_router/check_connected.py <u2_post_routed> -n <the 7 nets>
Found 4167 segments, 587 vias, 1079 pads
ALL NETS FULLY CONNECTED!
```

On this board the withdrawn escapes cost nothing: every one of the seven pads is
reached.

**`rp2350_fpga_eensy_prePlane` U6 — 2 escapes withdrawn.** Both nets were already
fully connected on the input board:

```
$ python3 py_router/check_connected.py kicad_files/rp2350_fpga_eensy_prePlane.kicad_pcb \
      -n '/RP2354A/FPGA.~{STATUS}' '/RP2354A/RP.UART1_TX'
Checking 2 nets matching: ['/RP2354A/FPGA.~{STATUS}', '/RP2354A/RP.UART1_TX']

ALL NETS FULLY CONNECTED!
```

### Do not cite the board-level `check_connected` number

```
kicad_files/routed_output.kicad_pcb (NO fanout at all): FOUND 188 ISSUES  (Unrouted nets: 6)
<u2_pre>  (pre-fix fanout) :                            FOUND 188 ISSUES  (Unrouted nets: 5)
<u2_post> (post-fix fanout):                            FOUND 188 ISSUES  (Unrouted nets: 5)
```

The **unmodified input board scores 188 too**, so at board level the metric
cannot distinguish 26 escapes from 19 from none. The same trap applies one level
up: `check_connected` on a *fanout output* is not the artifact either — dropped
escapes go to `failed_nets` and the main router is supposed to pick those balls
up. That is why the U7 measurement above is taken on the routed board, and why
it is bad news rather than a null result.

---

## Scope, and what this does NOT fix

**Vias only.** This is the **via half** of the surface fan's #257 rule, not parity
with it. The surface fan enforces both `_fanned_existing_segs` (layer-scoped) and
`_fanned_existing_vias`; only the second is ported. The residual on
`routed_output` U2:

| | `check_drc` total | seg-crossing | seg-seg | via-seg | via-drill |
|---|---|---|---|---|---|
| input board (no fanout) | 4 | 0 | 1 | 0 | 3 |
| pre-fix fanout output | 48 | 17 | 21 | 7 | 3 |
| post-fix fanout output | 18 | 9 | 6 | 0 | 3 |

The fanout still ships **14 new segment-class violations** there after this fix.
`obstacle_map.py` opens the identical hole for pre-existing **segments** on fanned
nets. Its own issue.

**Pre-existing PADS on fanned nets are also untested.** `nets_to_route` erases
pads at `obstacle_map.py:309` exactly as it erases vias at `:277`, so the stub is
untested against a pre-existing pad on a fanned net too. Counted with
`check_drc.check_pad_segment_overlap` over all 408 footprints, both legs:

```
stub vs pre-existing pad on a fanned net:   base 72 -> fix 44   (default)
                                            base 70 -> fix 44   (--allow-via-in-pad)
```

Post-fix it is live on tracked in-repo boards: `orangecrab_ext_pll` U3 = 16,
`rp2350_fpga_eensy_prePlane` U6 = 1, `routed_output` U2 = 0. The 16 is
corroborated by the tool's own post-run audit, which reports
`"pad_segment": 16` for that run (transcript below). The fix reduces the total
as a side effect (44 < 72) but does not address it; that is the pad half of the
same `nets_to_route` hole and belongs with the segment half.

**Vias placed in the same run are still not stub-tested, and this gap is LIVE.**
`_unmapped_vias` is pre-existing vias only; vias placed earlier in the same call
live in `placed`/`placed_global` and are consumed only by `via_clears`
(centre-to-centre). Counted with `check_drc.check_via_segment_overlap`, emitted
stub vs same-run emitted via, over all 408 footprints:

```
default                : base 14 -> fix 14   (orangecrab U3 = 13, orangecrab U2 = 1)
--allow-via-in-pad     : base 27 -> fix 27
```

Not a regression — base equals fix — but **not latent either**. An earlier draft
of this PR said *"0 grazes … a latent gap, not a live one"* and used that to
justify deferring it; that was measured with the same name-filtered sweep and was
wrong. The tool's own post-run audit says so directly on this branch:

```
$ python3 py_router/qfn_fanout.py kicad_files/orangecrab_ext_pll.kicad_pcb -c U3 \
      --escape-method underpad -w 0.1 --clearance 0.1 --via-size 0.45 --via-drill 0.25 --grid-step 0.05
JSON_SUMMARY: {"component": "U3", ...
  "drc_grazes": {"pad_via": 27, "via_segment": 13, "pad_segment": 16, "segment_segment": 38, "total": 106}, ...}
```

(`via_segment` 13 there is exactly the same-run count; the pre-existing-via half
is 0 post-fix. On `main` the same run reports `via_segment: 15` = 13 same-run + 2
pre-existing.) Still its own issue, but on the strength of "measured and live",
not "measured and zero".

**The new loop is deliberately layer-blind.** It does not filter by `via.layers`,
so a blind/buried via on a fanned net still blocks a stub on a layer it does not
reach. Intentional: `check_drc.check_via_segment_overlap` ignores `via.layers`
outright (*"Standard through-hole vias go through ALL copper layers"*) and
`obstacle_map._add_via_obstacle` stamps every via on **every** layer. A
layer-filtered backstop would emit copper this repo's own grader flags, and would
make a fanned-net via behave differently from an identical non-fanned one. Check
7 of the new test pins this to `check_drc`'s behaviour, so the day `check_drc`
becomes layer-aware the test fails and points at the loop that should follow it.

---

## Tests

`tests/test_619_qfn_underpad_stub_vs_existing_via.py` — seven checks:

1. **Injection regression + negative control** (tigard U3, a QFN-64 on a board
   with **zero** vias, so the baseline is uncontaminated). Learn where net A's
   stub lands, re-parse, inject a via on net B onto that path, re-run with both
   nets in the filter. Asserts the **mechanism** — the same map built with
   `nets_to_route=[A,B]` reports the stub line CLEAR while `nets_to_route=[A]`
   reports it BLOCKED — plus the exact post-injection tuple
   `(1 track, 0 vias, dropped=['/BD0'])`, because post-fix net A emits nothing
   and "no stub inside the floor" would otherwise pass for any change that
   dropped every pad.
   The **negative control** is new: the same via injected *off* the escape ray at
   `d=0.4000` against the `0.3750` floor must **not** block anything, and the
   baseline `(2, 2, [])` must survive. It is the only check in the file with
   teeth against an over-strict gate (see the mutation below).
2. **No-op guard with the loop LIVE.** `orangecrab_ext_pll` U5 (7 pre-existing
   vias on its fanned nets), U8 (5) and U9 (7) — footprints where
   `_unmapped_vias` is non-empty, the loop really executes, and the output is
   still byte-identical (13/13/3, 7/7/3, 15/15/9). The previous version of this
   test used boards with **zero** vias on the fanned nets, where
   `stub_clears_unmapped` is a constant `True` and the guard proves nothing;
   that case is kept but explicitly labelled degenerate.
3. **`routed_output` U2** — zero stub-vs-via violations (was 7), exact tally
   `20 / 19 / 22`.
4. **`rp2350_fpga_eensy_prePlane` U6** — zero (was 2), exact tally `10 / 7 / 37`.
5. **`orangecrab_ext_pll` U7 and U1** — the starkest cases, `2 / 0 / 4` each,
   all four withdrawn escapes on GND, zero violations (was 5 and 4, every one at
   `d=0.0000`). Nothing pinned these before.
6. **`orangecrab_ext_pll` U3** — the non-monotone case: `IO_SCK` and `QSPI_D2`
   withdrawn, `SPI_CONFIG_MOSI` recovered, exact tally `45 / 45 / 50`.
7. **Layer-scope decision pin** (above).

### Red / green

Reverting only `py_router/qfn_fanout/__init__.py` to `main`
(`git checkout main -- py_router/qfn_fanout/__init__.py`) and re-running:

```
 FAIL no emitted stub is inside the injected via's clearance floor
 FAIL counter-guard: net A (/BD0) is DROPPED, not silently re-routed
 FAIL counter-guard: exact post-injection tuple (1 track, 0 vias, dropped=['/BD0']) ...
 FAIL counter-guard: the surviving track belongs to net B
 FAIL U2 escape tally pinned at 20 tracks / 19 vias / 22 dropped (was 27 / 26 / 15 pre-fix)
 FAIL no emitted stub sits inside a different-net existing via's floor (was 7 pre-fix ...); got 7
 FAIL U6 escape tally pinned at 10 tracks / 7 vias / 37 dropped (was 12 / 9 / 35 pre-fix)
 FAIL no emitted stub sits inside a different-net existing via's floor (was 2 pre-fix ...); got 2
 FAIL U7 escape tally pinned at 2 tracks / 0 vias / 4 dropped ...
 FAIL U7: the four withdrawn escapes are all GND
 FAIL U7: no emitted stub sits inside a different-net existing via's floor (was 5 pre-fix ...); got 5
 FAIL U1 escape tally pinned at 2 tracks / 0 vias / 4 dropped ...
 FAIL U1: the four withdrawn escapes are all GND
 FAIL U1: no emitted stub sits inside a different-net existing via's floor (was 4 pre-fix ...); got 4
 FAIL U3 escape tally pinned at 45 tracks / 45 vias / 50 dropped (was 47 / 47 / 48 pre-fix)
 FAIL U3: IO_SCK and QSPI_D2 are withdrawn (they escaped pre-fix)
 FAIL U3: SPI_CONFIG_MOSI is RECOVERED -- it was DROPPED pre-fix and escapes now ...
 FAIL U3: no emitted stub sits inside a different-net existing via's floor (was 2 pre-fix); got 2
FAILED: 18 check(s)
```

with the offending distances printed by the base run itself:

```
      d=0.0000 need>=0.3750 stub net 3 vs via net 4 @(53.95, 61.650000000000006)
      d=0.0000 need>=0.3000 stub net 83 vs via net 98 @(216.8, 108.5)
      d=0.0000 need>=0.3000 stub net 5 vs via net 66 @(151.749999, 97.050001)
      d=0.0000 need>=0.3000 stub net 5 vs via net 152 @(152.949999, 97.050001)
      d=0.2408 need>=0.3750 stub net 47 vs via net 35 @(143.95, 108.95)
```

With the fix restored: **All checks passed** (13.1 s).

### Mutation evidence for the new checks

**Over-strict gate** — multiply the new floor by 5
(`< 5.0 * (v.size / 2 + track_width / 2 + clearance)`):

```
 FAIL negative control: a via OUTSIDE the floor does NOT block the stub -- baseline (2 tracks, 2 vias, nothing dropped) survives
 FAIL U2 escape tally ...   FAIL U6 escape tally ...   FAIL U7 ...   FAIL U1 ...   FAIL U3 ...
FAILED: 9 check(s)
```

The negative control catches it by name. Without it the whole injection section
passed under this mutation and only the brittle tallies failed.

**The review also proposed `_unmapped_vias = list(pcb_data.vias)` as a "plausible
wrong implementation" the test should catch — it is not wrong, and no test can
catch it.** I applied that exact mutation and re-ran the full 408-footprint
sweep against the shipped fix:

```
SWEEP DIFF SHIPPED FIX vs M1 mutation (_unmapped_vias = list(pcb_data.vias))
byte-identical emitted geometry                 : 408
CHANGED                                         : 0
```

Every footprint is byte-identical, `routed_output` U2 included (`20 / 19 / 22`,
not the `4 / 4 / 47` the review reported). The reason is structural: the vias the
mutation adds are the ones `nets_to_route` did *not* erase, so
`check_line_clearance` already rejects any stub grazing them — the extra loop is
redundant, not stricter. The filter is there for cost, not correctness.

### Suite and gates

```
217 passed, 0 failed, 46 skipped in 191.2s     # tests/run_all.py --fast -j 4 --timeout 240
```

```
Converter parity: 35 flag-checks across 1 manifest(s), 0 mismatch(es).
Param->control resolution: 12 params checked, 0 unresolved.        # test_manifest_plan_parity.py (exit 0)

CLI post-pass coverage: 8 registered, 15 in active CLI use, 1 CLI-only acknowledged,
0 unreachable call(s), 0 failure(s), 0 warning(s).                 # test_cli_postpass_coverage.py (exit 0)
```

**Perf.** The new loop is `O(escapes x pre-existing vias on the fanned nets)`.
Timed on the two heaviest corpus cases and on a synthetic board with 3000 vias
injected *onto* the fanned nets (min of 3 runs each):

```
                                                        main      this branch
routed_output U2                                        1.23 s      1.03 s
orangecrab_ext_pll U3 (csBGA-132, 285 pads)             3.39 s      3.20 s
routed_output U2 + 3000 injected on-fanned vias         0.31 s      0.33 s
```

No regression. (The injected case is faster than the clean one on both legs
because the flooded board leaves almost nothing to escape — 0/0/52 post-fix,
1/0/51 on main.)

## CLI / GUI parity

The fix is inside the shared engine function, and `fanout_gui.py:1504` calls
`generate_qfn_fanout` directly with `escape_method` from config, so the GUI
fanout tab inherits it with no wiring. No new parameter, flag, or CLI post-pass,
so nothing to thread through `ai_plan.py` / `manifest_to_plan.py` /
`settings_persistence.py`. The new loop reads only `v.x / v.y / v.size /
v.net_id`, the same four fields `via_clears` already reads from `pcb_data.vias`;
`build_pcb_data_from_board` (the pcbnew path,
`py_router/kicad_parser.py:3543`) populates all four, so both `PCBData` construction paths
feed it identically.

`.kicad_dru` is handled: `generate_qfn_fanout` swaps the scalar `clearance` to
the escape-layer rule value at `py_router/qfn_fanout/__init__.py~:542-550`
*before* calling `_underpad_via_escape` (`:627`), so the new gate inherits the
tightened/relaxed value.

---

## What I could not verify

- **The GUI side of the changed code has no gate.** `tests/gui_parity/test_fanout_rotated_gui.py`
  is the only fanout gate. Re-run on this branch under KiCad python
  (`C:\Program Files\KiCad\10.0\bin\python.exe`, `pcbnew 10.0.1 / wx 4.2.2 msw
  (phoenix) wxWidgets 3.3.2`) it reports `10/10 rotated-QFN fanout parity checks
  passed`, exit 0 — but its own output says `CLI: 104 tracks, 0 vias` /
  `GUI: 104 tracks, 0 vias`, i.e. it drives the **surface** fan and never enters
  `_underpad_via_escape`. The CLI/GUI argument above is code inspection, not a
  gate.
- **`tests/gui_parity/test_gui_engine_parity.py` ran but its GUI leg could not.**
  Re-run on this branch it aborts the GUI leg with
  `startup_checks.StartupCheckError: ERROR: Missing required Python libraries`
  and reports `segments: CLI=1268 GUI=0 common=0`, `copper sets identical: False`.
  Confirmed cause: that interpreter has neither library —
  `python -c "import scipy"` → `ModuleNotFoundError: No module named 'scipy'`,
  same for `shapely`. Pre-existing environment gap in this machine's KiCad
  python, not a divergence from this change; that gate's plan is signal + plane
  and never calls `generate_qfn_fanout`. Not fixed here because it means
  installing packages into the user's KiCad install.
- **No corpus-scale (`tests/stress/`) replay.** The sweep is the 22 tracked
  in-repo boards. Whether the changed escape counts move downstream routing
  outcomes on the stress corpus is unmeasured; the U7 chain above is a single
  end-to-end data point, not a corpus result.
- **Only U7 and U1 were carried through the full pour+route chain.**
  `orangecrab_ext_pll` U2 and `rp2350_fpga_eensy_prePlane` U2 withdraw GND
  escapes in the same shape and were not chained; I would expect a similar
  connectivity loss on them and did not measure it.
- **The exact-tally pins** (`(1,0,['/BD0'])`, `20/19/22`, `10/7/37`, `2/0/4`,
  `45/45/50`, `13/13/3`, `7/7/3`, `15/15/9`, `3/3/1`) are deliberately brittle:
  any future change to the escape ladder fails them and forces re-measurement.
  Intended, but a real maintenance cost.
- **Check 2's guards do not catch over-strictness.** Under the ×5 floor mutation
  U5/U8/U9 still pass — their pre-existing vias are simply far from the stubs.
  Their value is that the loop *executes* and rejects nothing, which the previous
  version of the test never established; the negative control in check 1 is what
  guards the floor.
- **Two of the seven changed footprints are NOT pinned by a test.** Tests 3–6
  cover `routed_output` U2, `rp2350_fpga_eensy_prePlane` U6,
  `orangecrab_ext_pll` U7, U1 and U3 — five of the seven.
  `orangecrab_ext_pll` U2 and `rp2350_fpga_eensy_prePlane` U2 are measured in
  the sweep but nothing in the repo would notice if they drifted. They are the
  smallest deltas (3 → 0 and 2 → 0 violations) and each would have cost another
  ~0.3 s of suite time; I left them out to keep the pin count honest rather than
  exhaustive, which is a judgement a reviewer may disagree with.
- **Five untracked working-copy boards are excluded.** `git status --ignored`
  lists `fanout_output1`, `fanout_output2`, `fanout_starting_point`,
  `interf_u_plane` and `qfn_fanned_out` as gitignored scratch outputs (27 files
  in `kicad_files/`, 22 tracked). The sweep drives off
  `git ls-files 'kicad_files/*.kicad_pcb'`, so those are not in the table — they
  would not exist in a fresh clone.
- **The sweep and residual scripts live outside the repo**, so the 408-footprint
  table is not re-runnable from a clean clone without rewriting the loop.

## Post-review addendum (second adversarial pass)

A second independent review reproduced **every quantitative claim in this PR
independently — including the ones that argue against the change**: it rewrote
the 408-footprint sweep from scratch (no name filter; same 408/110/401/7 and the
same drop deltas), re-ran both full pour+route chains (byte-for-byte the numbers
above, including the U1 control), applied the ×5-floor mutation (caught by the
negative control, by name), and confirmed the `_unmapped_vias = list(pcb_data.vias)`
mutation is byte-identical on 408/408 footprints — the filter is for cost, not
correctness. Its two findings were cosmetic (one transcribed digit, five line
citations stale by 11 comment lines) and are corrected in this description.

The one call it leaves with you, deliberately: on `orangecrab_ext_pll` this fix
does literally what CONTRIBUTING forbids — 8 GND balls go from reached to
unreached on the routed board. The counter-argument stands as verified: they were
"reached" through five dead shorts to `PGOOD_P1.35V`/`P1.35V`/`VSYS`/`Net-(L3-Pad1)`
that survive into the shipped board, and the U1 control chain shows the same
GND-route failure shape with U7 never fanned at all — so the withdrawn escapes
are an input to a whole-board GND routing problem, not a proven sole cause. Your
call whether copper-that-is-a-short counts as connectivity worth keeping.
