### PR TITLE
bga_fanout: disclose via-in-pad drills below the board's min_hole_to_hole (#618)

### DIFF
--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -613,6 +613,37 @@ end-jog is validated against the full obstacle map (foreign pads + tracks +
 vias): a jog that would extend into a foreign obstacle is dropped, leaving an
 on-grid stub end the router can launch from (issue #149).
 
+**Via-in-pad drill spacing is the BALL PITCH, and the run says so (#618).** A
+via-in-pad sits at the ball centre, so the closest drill spacing this engine
+can reach is `pitch - drill` — 0.600 mm on an 0.8 mm array with a 0.2 mm
+drill — and no `min_hole_to_hole` the board declares can move it. When the
+emitted drills fall below the board's own declared floor (fab-wrapped, read
+via `list_nets.board_floor`), the run prints a `WARNING (#618)` naming the
+offending BALL PADS and records the finding in
+`JSON_SUMMARY.hole_to_hole` (`floor` / `declared` / `source` / `min_gap` /
+`violations` / `by_kind` / `pads` / `pad_count` / `worst`). This is a
+DISCLOSURE, not a refusal: the vias are still emitted, `failed` stays a
+routing verdict, and for the `by_kind.ball_to_ball` pairs the fix belongs at
+the source — relax `min_hole_to_hole` for that part, use a smaller
+`--via-drill`, or escape it without via-in-pad. Enforcing the floor instead
+takes the violations to 0 and costs escapes — measured at a declared 0.9,
+ulx3s U1 on the default engine goes 186 → 171 escaped (21 → 33 failed) and
+glasgow_revC U30 on `--escape-method channel` goes 98 → 63 escaped (1 → 36
+failed) — which is the board owner's call to make, not a default.
+
+Read `by_kind` before acting on the count. `ball_to_ball` is the package
+talking and the engine cannot help; `against_existing` (a new via too close
+to a hole already on the board) and `new_to_new` are sites the engine could
+in principle have put elsewhere, so they read as router findings, not board
+findings. A negative `min_gap` means two holes physically OVERLAP. `pads`
+lists at most 24 ball-pad names — `pad_count` is the true number — and
+`worst` at most 12 pairs, so a 900-ball part cannot swamp the summary line.
+One limitation to know about: the floor is read from the sibling
+`.kicad_pro` only. A board that expresses `hole_to_hole` as a custom
+`.kicad_dru` rule instead (`kicad_dru.py` models `clearance` constraints
+only) is graded at the flat fab default and stays silent — the same blind
+spot the under-pad escape and the QFN engine have, not one introduced here.
+
 ### Example
 
 ```bash

--- a/py_router/bga_fanout/__init__.py
+++ b/py_router/bga_fanout/__init__.py
@@ -3278,11 +3278,17 @@ def audit_via_hole_to_hole(footprint: Footprint,
                   f"via-in-pad.")
         _movable = kinds['against_existing'] + kinds['new_to_new']
         if _movable:
-            print(f"    {_movable} pair(s) are NOT pinned by the ball grid "
-                  f"({kinds['against_existing']} against a hole that was "
-                  f"already on the board): the site could not clear the other "
-                  f"hole, so read those as an engine finding -- a smaller "
-                  f"--via-drill or a different escape may move them.")
+            # NOT "not pinned by the ball grid" -- measured, the new drill in
+            # these pairs usually IS at a ball centre; what distinguishes them
+            # is that the OTHER end is copper already on the board, so the
+            # conflict is not purely the package's fault.
+            print(f"    {_movable} pair(s) have their OTHER end in a hole "
+                  f"that was already on the board "
+                  f"({kinds['against_existing']} against pre-existing copper): "
+                  f"the site could not clear that hole, so read those as an "
+                  f"engine/board finding rather than a package limit -- a "
+                  f"smaller --via-drill, a different escape, or skipping "
+                  f"via-in-pad on that ball may resolve them.")
         shown = ", ".join(f"{a}<->{b} {g:.4f}mm" for g, a, b, _k in pairs[:6])
         print(f"    worst: {shown}"
               + (f" (+{len(pairs) - 6} more)" if len(pairs) > 6 else ""))

--- a/py_router/bga_fanout/__init__.py
+++ b/py_router/bga_fanout/__init__.py
@@ -3039,6 +3039,255 @@ def _generate_bga_fanout_core(footprint: Footprint,
 # the GUI results panel. Refreshed by every top-level generate_bga_fanout call.
 LAST_PLANE_DROP_REPORT: Dict = {}
 
+# Per-call drill hole-to-hole audit of the vias this fanout emits (#618).
+# Refreshed by every top-level generate_bga_fanout call; see
+# audit_via_hole_to_hole for what is in it and why it is report-only.
+LAST_HOLE_TO_HOLE_REPORT: Dict = {}
+
+
+def audit_via_hole_to_hole(footprint: Footprint,
+                           pcb_data: PCBData,
+                           vias_to_add: List[Dict],
+                           vias_to_remove: Optional[List[Dict]] = None,
+                           verbose: bool = True) -> Dict:
+    """DISCLOSE emitted via drills spaced below the board's own floor (#618).
+
+    A BGA via-in-pad sits at the BALL CENTRE, so the drill spacing this engine
+    can achieve is fixed by the package: ``pitch - drill``. On a 0.8mm-pitch
+    array with a 0.2mm drill that is 0.600mm, and NOTHING in the fanout can
+    move it -- the site is the ball. A board declaring ``min_hole_to_hole``
+    above that therefore gets copper it cannot build, and until now got it
+    SILENTLY. Measured (via 0.35 / drill 0.2, 4 layers, declared 0.9):
+
+      * glasgow_revC U30, ``escape_method='channel'``: 76 vias, 307 tracks,
+        1 failed, min drill gap 0.600mm -- and the emitted copper is
+        BYTE-IDENTICAL to the same run with nothing declared. The declaration
+        was inert in every respect, including the log, while 114 via pairs sat
+        below it.
+      * ulx3s U1 -- the board the issue names -- on the DEFAULT
+        ``escape_method='auto'``, everything else stock: 186/207 escaped, 21
+        failed, 144 vias, 184 pairs at 0.600mm. The declaration is not merely
+        ignored: the same run with nothing declared escapes 204/204 with 0
+        failed, so the board PAYS escapes for a floor its output then violates
+        184 times. The log prints "Hole-to-hole 0.9mm (from the board's own
+        min_hole_to_hole)" on the way past.
+
+    WHICH ENGINE emits the violating drills has to be measured, not read off
+    the log, and the log invites exactly the wrong conclusion. ``auto`` runs
+    the CHANNEL escape and then, PER PASS, retries with the under-pad grid and
+    keeps whichever dropped fewer balls (#288) -- and a fanout makes several
+    such passes, only one of which supplies the vias that ship. On ulx3s U1
+    the log says "Under-pad escape wins" twice, yet stamping every returned
+    via with the ``escape_method`` of the core call that created it shows all
+    138 escape vias came from the one pass that KEPT ITS CHANNEL RESULT, and
+    all 184 violating pairs are channel-via vs channel-via (glasgow_revC U30
+    on ``auto``: 71/71 channel vias, 100/100 pairs; haasoscope_pro_max U3:
+    151/151, 131/131. In each case the pass whose under-pad arm won
+    contributed 0 vias). So the live enforcement point is the channel engine's
+    ``manage_vias.via_in_pad_conflict``, whose own docstring already names the
+    two halves: it prices its drill floor at the flat
+    ``routing_defaults.HOLE_TO_HOLE_CLEARANCE`` rather than the board's
+    ``min_hole_to_hole``, and never reads back this run's own ``vias_to_add``.
+
+    The under-pad engine's ``_via_site_conflict`` is NOT the gap (#616 taught
+    that one to read the board), and forcing it settles the question:
+    ``escape_method='underpad'`` on the same ulx3s U1 at the same declared 0.9
+    emits 53 vias with ZERO violating pairs (min gap 0.931mm). Every sub-floor
+    drill on that board comes from the channel arm. The audit still grades the
+    EMITTED VIAS rather than any one engine's decisions, because which arm
+    ships is decided per pass at run time: the report is about the copper, not
+    about the code path that produced it.
+
+    This function does NOT enforce the floor, deliberately. Enforcement was
+    built and measured (arm A = ``via_in_pad_conflict`` resolving its floor
+    from the board AND testing candidates against this run's own
+    ``vias_to_add``). It takes every violation to 0 and costs escapes, at the
+    same declared 0.9:
+
+        ulx3s U1      auto     186 -> 171 escaped, 21 -> 33 failed, 184 -> 0
+        glasgow  U30  auto      98 ->  89 escaped,  1 -> 10 failed, 100 -> 0
+        glasgow  U30  channel   98 ->  63 escaped,  1 -> 36 failed, 114 -> 0
+        orangecrab U3 channel   70 ->  65 escaped, 39 -> 45 failed,  12 -> 0
+                      (declared 0.4)
+
+    Trading escapes for a rule the PACKAGE contradicts is a policy call for
+    the board owner, not a default, and four boards cannot settle it. There is
+    a second reason to keep this hands-off: the sibling issue #620 asks for
+    the same edit to the same function, and its fix was abandoned after two
+    reviews measured a connectivity regression from it -- ``manage_vias`` runs
+    to completion and the caller then deletes whole nets' vias, so candidates
+    get refused against blockers that never ship. Naming the violation costs
+    nothing and leaves the call where it belongs; deciding it needs the corpus
+    A/B in ``tests/stress/cloud_replay_sets.py``.
+
+    Graded pairs are the ones THIS RUN caused: new-vs-new among ``vias_to_add``,
+    and new-vs-existing against board vias (minus the ones ``vias_to_remove``
+    deletes) and drilled pads. Existing-vs-existing is somebody else's
+    finding. The floor is board-first and fab-wrapped, the
+    same resolution the under-pad engine uses (``list_nets.board_floor`` ->
+    ``max(declared, fab)``), so a board declaring nothing is graded at the flat
+    ``routing_defaults.HOLE_TO_HOLE_CLEARANCE`` and stays silent unless it is
+    genuinely violated.
+
+    Returns (and publishes as ``LAST_HOLE_TO_HOLE_REPORT``) a dict with:
+    ``floor`` / ``declared`` / ``source`` / ``vias`` / ``min_gap`` /
+    ``violations`` / ``by_kind`` / ``pads`` / ``pad_count`` / ``worst`` (up to
+    12 named pairs). ``min_gap`` is the smallest gap among GRADED pairs: every
+    new-vs-new pair, and every pre-existing hole within ``floor + 1mm`` of a
+    new via (a dense board carries thousands of holes and none of the distant
+    ones can violate). A gap is NEGATIVE when the two holes physically
+    overlap, and that is counted and reported like any other -- only an EXACT
+    co-location (centres within 1um of a pre-existing hole, i.e. a via this
+    run re-emits rather than adds) is skipped, because it is the same hole.
+
+    ``by_kind`` splits the count three ways, because the remedy differs:
+    ``ball_to_ball`` pairs are two ball-centre via-in-pad sites and the engine
+    genuinely cannot move them; ``against_existing`` pairs put a new via
+    against a hole that was already on the board, and ``new_to_new`` pairs
+    involve a new via that is not at a ball centre -- both of those the engine
+    could in principle have placed elsewhere. ``pads`` names the offending
+    BALL PADS only (never a bare coordinate), capped at 24 entries with the
+    true total in ``pad_count`` so a 900-ball part cannot swamp the summary.
+    """
+    report: Dict = {'violations': 0, 'vias': len(vias_to_add)}
+    if not vias_to_add:
+        return report
+    try:
+        from list_nets import board_floor as _board_floor
+    except Exception:                                          # noqa: BLE001
+        return report
+    src_path = getattr(pcb_data, 'source_path', "") or ""
+    declared, source = _board_floor(src_path, 'hole_to_hole', None,
+                                    defaults.HOLE_TO_HOLE_CLEARANCE)
+    copper = len(getattr(pcb_data.board_info, 'copper_layers', None) or []) or 4
+    floor = max(declared, fab_floor_min(copper).get('hole_to_hole', 0.0))
+    report.update({'floor': round(floor, 6), 'declared': round(declared, 6),
+                   'source': source})
+
+    # Name a hole by the pad it sits in when it does (via-in-pad is the whole
+    # point of the issue); otherwise by its net. Ball centres are exact, so an
+    # 0.05mm match is generous and never picks the wrong ball on any pitch this
+    # engine handles.
+    def _name(x, y, net_id):
+        for p in footprint.pads:
+            if math.hypot(p.global_x - x, p.global_y - y) < 0.05:
+                return f"{footprint.reference}/{p.pad_number}"
+        net = pcb_data.nets.get(net_id)
+        return (f"{net.name}@({x:.3f},{y:.3f})" if net and net.name
+                else f"({x:.3f},{y:.3f})")
+
+    # Every drilled hole already on the board, plus this run's own vias. Pad
+    # drills use the capsule (slots/offset holes) like via_in_pad_conflict.
+    from kicad_parser import pad_drill_capsule
+    # A via this run DELETES is not a hole the output has, so it must not be
+    # graded against (the writer drops it from the board).
+    gone = {(round(v['x'], 6), round(v['y'], 6)) for v in (vias_to_remove or [])}
+    existing = []                       # (x1, y1, x2, y2, radius, label)
+    for v in pcb_data.vias:
+        r = (getattr(v, 'drill', 0) or 0.0) / 2.0
+        if r > 0 and (round(v.x, 6), round(v.y, 6)) not in gone:
+            # Carry the position: without it two distinct offenders read as
+            # the same string in `worst` and nobody can find either.
+            existing.append((v.x, v.y, v.x, v.y, r,
+                             f"an existing via @({v.x:.3f},{v.y:.3f})"))
+    for pads in pcb_data.pads_by_net.values():
+        for p in pads:
+            if (getattr(p, 'drill', 0) or 0) > 0:
+                (c1x, c1y), (c2x, c2y), prad = pad_drill_capsule(p)
+                existing.append((c1x, c1y, c2x, c2y, prad,
+                                 f"pad {p.component_ref}/{p.pad_number}"))
+
+    def _seg_d(x, y, x1, y1, x2, y2):
+        dx, dy = x2 - x1, y2 - y1
+        L2 = dx * dx + dy * dy
+        if L2 <= 0:
+            return math.hypot(x - x1, y - y1)
+        t = max(0.0, min(1.0, ((x - x1) * dx + (y - y1) * dy) / L2))
+        return math.hypot(x - (x1 + t * dx), y - (y1 + t * dy))
+
+    ball = footprint.reference + '/'
+    pairs = []          # (gap, label_a, label_b, kind)
+    min_gap = None
+    for i, a in enumerate(vias_to_add):
+        ar = (a.get('drill') or 0.0) / 2.0
+        if ar <= 0:
+            continue
+        an = _name(a['x'], a['y'], a.get('net_id'))
+        for b in vias_to_add[i + 1:]:
+            br = (b.get('drill') or 0.0) / 2.0
+            if br <= 0:
+                continue
+            gap = math.hypot(a['x'] - b['x'], a['y'] - b['y']) - ar - br
+            if min_gap is None or gap < min_gap:
+                min_gap = gap
+            if gap < floor - 1e-6:
+                bn = _name(b['x'], b['y'], b.get('net_id'))
+                pairs.append((gap, an, bn,
+                              'ball' if an.startswith(ball)
+                              and bn.startswith(ball) else 'new'))
+        # Axis prefilter: a hole further away than this in x or y cannot be
+        # within `floor`, and a dense board carries thousands of them.
+        ax, ay = a['x'], a['y']
+        for (x1, y1, x2, y2, orad, label) in existing:
+            reach = floor + ar + orad + 1.0
+            if (ax < min(x1, x2) - reach or ax > max(x1, x2) + reach
+                    or ay < min(y1, y2) - reach or ay > max(y1, y2) + reach):
+                continue
+            # Co-location is decided on the CENTRES, never on the sign of the
+            # gap: a via re-emitted at an existing hole is the SAME hole and is
+            # skipped, but a via that merely OVERLAPS one is the worst
+            # violation there is and must not be filtered out along with it
+            # (#619 / #620 are about engines doing exactly that).
+            d = _seg_d(ax, ay, x1, y1, x2, y2)
+            if d < 1e-6:
+                continue
+            gap = d - ar - orad
+            if min_gap is None or gap < min_gap:
+                min_gap = gap
+            if gap < floor - 1e-6:
+                pairs.append((gap, an, label, 'existing'))
+
+    pairs.sort(key=lambda t: t[0])
+    kinds = {'ball_to_ball': 0, 'new_to_new': 0, 'against_existing': 0}
+    _kmap = {'ball': 'ball_to_ball', 'new': 'new_to_new',
+             'existing': 'against_existing'}
+    for _g, _a, _b, _k in pairs:
+        kinds[_kmap[_k]] += 1
+    report['min_gap'] = None if min_gap is None else round(min_gap, 6)
+    report['violations'] = len(pairs)
+    report['by_kind'] = kinds
+    report['worst'] = [{'gap': round(g, 6), 'a': a, 'b': b}
+                       for g, a, b, _k in pairs[:12]]
+    named = sorted({n for _g, a, b, _k in pairs for n in (a, b)
+                    if n.startswith(ball)})
+    report['pad_count'] = len(named)
+    report['pads'] = named[:24]
+    if pairs and verbose:
+        whose = ("the board's own declared min_hole_to_hole"
+                 if source == 'board constraint' else 'the fab hole-to-hole floor')
+        print(f"  WARNING (#618): {len(pairs)} emitted via pair(s) are drilled "
+              f"closer than {whose} {floor:g}mm -- smallest gap "
+              f"{pairs[0][0]:.4f}mm.")
+        if kinds['ball_to_ball']:
+            print(f"    {kinds['ball_to_ball']} pair(s) are two BALL-CENTRE "
+                  f"via-in-pad sites: that spacing is the package pitch minus "
+                  f"the drill, so this engine cannot space them further apart "
+                  f"and the copper is UNMANUFACTURABLE against the rule as it "
+                  f"stands. Fix at the source: relax min_hole_to_hole for this "
+                  f"part, use a smaller --via-drill, or escape it without "
+                  f"via-in-pad.")
+        _movable = kinds['against_existing'] + kinds['new_to_new']
+        if _movable:
+            print(f"    {_movable} pair(s) are NOT pinned by the ball grid "
+                  f"({kinds['against_existing']} against a hole that was "
+                  f"already on the board): the site could not clear the other "
+                  f"hole, so read those as an engine finding -- a smaller "
+                  f"--via-drill or a different escape may move them.")
+        shown = ", ".join(f"{a}<->{b} {g:.4f}mm" for g, a, b, _k in pairs[:6])
+        print(f"    worst: {shown}"
+              + (f" (+{len(pairs) - 6} more)" if len(pairs) > 6 else ""))
+    return report
+
 
 def generate_plane_drops(footprint: Footprint,
                          pcb_data: PCBData,
@@ -3249,6 +3498,20 @@ def generate_bga_fanout(footprint: Footprint,
         tracks = tracks + d_tracks
         vias_to_add = vias_to_add + d_vias
         LAST_PLANE_DROP_REPORT.update(rep)
+
+    # #618 disclosure: name the drills this run spaced below the board's own
+    # min_hole_to_hole instead of shipping them silently. Report-only -- it
+    # never removes a via -- and it lives here, in the SHARED engine, so the
+    # GUI fanout tab discloses it too (CLAUDE.md Class 1). Never fatal: a
+    # disclosure that can abort a routing run is worse than the silence.
+    LAST_HOLE_TO_HOLE_REPORT.clear()
+    if _pad_filter is None and not _single_pass:
+        try:
+            LAST_HOLE_TO_HOLE_REPORT.update(
+                audit_via_hole_to_hole(footprint, pcb_data, vias_to_add,
+                                       vias_to_remove))
+        except Exception as _e:                                # noqa: BLE001
+            LAST_HOLE_TO_HOLE_REPORT.update({'error': str(_e)})
     return tracks, vias_to_add, vias_to_remove, failed_nets
 
 
@@ -3566,6 +3829,14 @@ def main():
         # #424 D2: per-net plane-ball drop counts (gap/in_pad/existing/failed);
         # empty when the pass is off or the part has no plane balls.
         'plane_drop': dict(LAST_PLANE_DROP_REPORT),
+        # #618: drill hole-to-hole audit of the vias this run emitted, graded
+        # against the board's OWN min_hole_to_hole (fab-wrapped). `violations`
+        # > 0 means the escape shipped copper the declared rule forbids;
+        # `by_kind.ball_to_ball` is the part it could not have done otherwise
+        # (via-in-pad sites are the ball centres), the rest is engine-side.
+        # `pads` is capped at 24 names, `pad_count` is the true total.
+        # Report-only; `failed` above stays a routing verdict.
+        'hole_to_hole': dict(LAST_HOLE_TO_HOLE_REPORT),
     }
     print(f"JSON_SUMMARY: {_json.dumps(summary)}")
 

--- a/tests/test_bga_via_hole_to_hole_disclosure.py
+++ b/tests/test_bga_via_hole_to_hole_disclosure.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""Regression test for issue #618: BGA via-in-pad drill spacing is the ball
+pitch, and a declared min_hole_to_hole moves NOTHING -- so the run must at
+least SAY SO.
+
+  python3 tests/test_bga_via_hole_to_hole_disclosure.py
+
+A BGA via-in-pad sits at the ball centre, so the drill spacing the fanout can
+reach is fixed by the package: `pitch - drill`. On a 0.8mm array with a 0.2mm
+drill that is 0.600mm. A board declaring `min_hole_to_hole` 0.9 therefore gets
+copper it cannot build -- and before this fix it got it SILENTLY: nothing in
+the log, and nothing in the JSON summary either (`failed` counts balls that
+found no escape, which is a different question).
+
+Measured on the unpatched tree (glasgow_revC U30, escape_method='channel',
+declared 0.9): 76 vias, 307 tracks, 1 failed, min drill gap 0.600mm, 114 via
+pairs below the declared rule, and the emitted copper BYTE-FOR-BYTE identical
+to the same run with nothing declared -- the declaration was inert in every
+respect including the log.
+
+This test pins the DISCLOSURE, not enforcement. Enforcing the floor takes the
+violations to 0 and costs escapes (measured at declared 0.9: ulx3s U1 on the
+default engine 186 -> 171 escaped / 21 -> 33 failed; glasgow_revC U30 on
+channel 98 -> 63 escaped / 1 -> 36 failed), which is a policy call for the
+board owner; see #618. What is pinned here:
+
+  - a board declaring nothing is SILENT (no #618 line) and its report says so,
+  - a board declaring 0.9 gets a report naming the violating BALL PADS, a
+    WARNING on stdout, and the SAME copper as the silent run (report-only),
+  - the default escape_method='auto' path discloses too, and the finding is
+    an order of magnitude larger than the run's `failed` ledger, so `failed`
+    was never going to be how a caller heard about it,
+  - a 0.5mm-pitch part (orangecrab U3) discloses at a declared 0.4,
+  - the CLI's JSON_SUMMARY carries `hole_to_hole` with the named pads,
+  - the audit itself is pure: same input, same answer, nothing mutated,
+  - and the new-vs-EXISTING-hole half is graded on a board that really has
+    holes (routed_output: 383 via drills): a via clearing a real
+    board hole is silent, a via OVERLAPPING one is reported with a negative
+    gap (the worst violation there is -- an earlier draft dropped every
+    negative gap as "co-located" and reported such a board as clean), and a
+    via re-emitted exactly AT an existing hole is the same hole, not a pair.
+
+Skips cleanly when a board is absent.
+"""
+import io
+import json
+import contextlib
+import hashlib
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # #522
+sys.path.insert(0, os.path.join(ROOT, 'py_tools'))  # #522
+
+from kicad_parser import parse_kicad_pcb
+import bga_fanout as bf
+from bga_fanout import generate_bga_fanout
+
+GLASGOW = os.path.join(ROOT, "kicad_files", "glasgow_revC.kicad_pcb")
+ORANGECRAB = os.path.join(ROOT, "kicad_files", "orangecrab_ext_pll.kicad_pcb")
+SMALL = os.path.join(ROOT, "kicad_files", "qfn_interior_pads.kicad_pcb")
+ROUTED = os.path.join(ROOT, "kicad_files", "routed_output.kicad_pcb")
+LAYERS = ["F.Cu", "In1.Cu", "In2.Cu", "B.Cu"]
+PARAMS = dict(track_width=0.12, clearance=0.1, via_size=0.35, via_drill=0.2)
+
+CHECKS = []
+
+
+def check(name, ok, detail=""):
+    CHECKS.append((name, bool(ok)))
+    print(f"  [{'PASS' if ok else 'FAIL'}] {name}" + (f"  ({detail})" if detail else ""))
+
+
+def _staged(tmp, board, h2h):
+    """Copy `board` (+ its siblings) into tmp, declaring min_hole_to_hole."""
+    dst = os.path.join(tmp, os.path.basename(board))
+    shutil.copyfile(board, dst)
+    pro_src = os.path.splitext(board)[0] + '.kicad_pro'
+    data = {}
+    if os.path.exists(pro_src):
+        with open(pro_src, encoding='utf-8') as f:
+            data = json.load(f)
+    if h2h is not None:
+        data.setdefault('board', {}).setdefault('design_settings', {}) \
+            .setdefault('rules', {})['min_hole_to_hole'] = h2h
+        with open(os.path.splitext(dst)[0] + '.kicad_pro', 'w',
+                  encoding='utf-8') as f:
+            json.dump(data, f)
+    elif os.path.exists(pro_src):
+        shutil.copyfile(pro_src, os.path.splitext(dst)[0] + '.kicad_pro')
+    return dst
+
+
+def fanout(board, ref, h2h, method):
+    """Run the shared engine on a staged copy. Returns (report, said, copper)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        pcb = parse_kicad_pcb(_staged(tmp, board, h2h))
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            tracks, vias, _rm, failed = generate_bga_fanout(
+                pcb.footprints[ref], pcb, layers=LAYERS,
+                escape_method=method, **PARAMS)
+        report = dict(getattr(bf, 'LAST_HOLE_TO_HOLE_REPORT', {}) or {})
+        copper = hashlib.sha256(repr(
+            sorted((round(v['x'], 6), round(v['y'], 6), v.get('size'),
+                    v.get('drill'), v.get('net_id')) for v in vias)
+            + sorted((t['start'], t['end'], t.get('layer'), t.get('net_id'))
+                     for t in tracks)).encode()).hexdigest()[:16]
+        return report, buf.getvalue(), copper, len(vias), len(tracks), len(failed)
+
+
+def real_board_checks():
+    if not os.path.exists(GLASGOW):
+        print(f"  [SKIP] board not present: {GLASGOW}")
+        return
+
+    # --- CONTROL: the board declares nothing -------------------------------
+    rep0, said0, cu0, nv0, nt0, nf0 = fanout(GLASGOW, "U30", None, 'channel')
+    check("control: a board declaring nothing gets no #618 warning",
+          '#618' not in said0, f"{nv0} vias, {nt0} tracks")
+    check("control: ...and the report grades it at the fab default, 0 violations",
+          rep0.get('source') == 'fixed default' and rep0.get('violations') == 0,
+          f"source={rep0.get('source')} floor={rep0.get('floor')} "
+          f"violations={rep0.get('violations')}")
+
+    # --- THE DEFECT: the same run, with 0.9 declared ------------------------
+    rep9, said9, cu9, nv9, nt9, nf9 = fanout(GLASGOW, "U30", 0.9, 'channel')
+    check("#618 the declared 0.9 moves NO copper (the defect, unchanged)",
+          cu9 == cu0 and (nv9, nt9, nf9) == (nv0, nt0, nf0),
+          f"{nv9} vias / {nt9} tracks / {nf9} failed, sha {cu9} vs {cu0}")
+    check("#618 ...and the drills really are below it",
+          rep9.get('min_gap') is not None and rep9['min_gap'] < 0.9 - 1e-9,
+          f"min drill gap {rep9.get('min_gap')}mm vs declared 0.9")
+    check("#618 the run now DISCLOSES it in the report",
+          rep9.get('violations', 0) > 0 and rep9.get('floor') == 0.9
+          and rep9.get('source') == 'board constraint',
+          f"{rep9.get('violations')} violating pairs at floor "
+          f"{rep9.get('floor')} from {rep9.get('source')}")
+    check("#618 ...and on stdout, as a WARNING",
+          '#618' in said9 and 'UNMANUFACTURABLE' in said9)
+    # The pads, by name -- the whole point of the disclosure.
+    pads = rep9.get('pads') or []
+    worst = rep9.get('worst') or []
+    check("#618 ...naming the BALL PADS, not just a count",
+          len(pads) >= 2 and all(p.startswith('U30/') for p in pads),
+          f"{len(pads)} pads, e.g. {pads[:4]}")
+    # ...capped, so a 900-ball part cannot swamp the summary line, with the
+    # true total kept alongside.
+    check("#618 ...capped at 24 names, with the true total in pad_count",
+          len(pads) <= 24 and rep9.get('pad_count', 0) > len(pads)
+          and rep9.get('by_kind', {}).get('ball_to_ball', 0) > 0,
+          f"pads={len(pads)} pad_count={rep9.get('pad_count')} "
+          f"by_kind={rep9.get('by_kind')}")
+    check("#618 ...and the worst pairs carry both ends and the gap",
+          bool(worst) and all({'gap', 'a', 'b'} <= set(w) for w in worst)
+          and worst[0]['gap'] == rep9.get('min_gap'),
+          f"worst[0]={worst[0] if worst else None}")
+    check("#618 ...with at least one named pad printed in the WARNING",
+          any(p in said9 for p in pads[:8]))
+
+    # --- The DEFAULT engine ('auto') is the one users actually hit ----------
+    repA, saidA, _cuA, nvA, _ntA, nfA = fanout(GLASGOW, "U30", 0.9, 'auto')
+    check("#618 escape_method='auto' (the DEFAULT) discloses too",
+          repA.get('violations', 0) > 0 and '#618' in saidA,
+          f"{nvA} vias, {repA.get('violations')} violating pairs, "
+          f"min gap {repA.get('min_gap')}mm")
+    # The routing verdict cannot be how a caller learns about this: the run
+    # EMITTED every one of these vias. `failed` counts balls that got no
+    # escape, and it is an order of magnitude smaller than the finding.
+    check("#618 ...and the failure ledger does not carry it",
+          repA.get('violations', 0) > max(nfA, 1) * 5,
+          f"{repA.get('violations')} violating pairs vs failed={nfA}")
+
+    # --- A 0.5mm-pitch part, the issue's "fine-pitch BGA" ------------------
+    if os.path.exists(ORANGECRAB):
+        rep4, said4, _c4, nv4, _t4, _f4 = fanout(ORANGECRAB, "U3", 0.4, 'channel')
+        check("#618 a 0.5mm-pitch BGA (orangecrab U3) discloses at 0.4",
+              rep4.get('violations', 0) > 0
+              and rep4.get('min_gap', 9) < 0.4 - 1e-9 and '#618' in said4,
+              f"{nv4} vias, {rep4.get('violations')} pairs, "
+              f"min gap {rep4.get('min_gap')}mm")
+    else:
+        print(f"  [SKIP] board not present: {ORANGECRAB}")
+
+
+def unit_checks():
+    """The audit itself, on hand-placed holes -- exact, and no routing."""
+    if not os.path.exists(SMALL):
+        print(f"  [SKIP] board not present: {SMALL}")
+        return
+    audit_via_hole_to_hole = getattr(bf, 'audit_via_hole_to_hole', None)
+    if audit_via_hole_to_hole is None:
+        # Unpatched tree: the audit does not exist. Record it as the failure
+        # it is and let the real-board checks below report the SYMPTOM.
+        check("unit: bga_fanout exposes audit_via_hole_to_hole", False,
+              "no such symbol -- the engine cannot disclose anything")
+        return
+
+    def audit(h2h, vias):
+        with tempfile.TemporaryDirectory() as tmp:
+            pcb = parse_kicad_pcb(_staged(tmp, SMALL, h2h))
+            fp = next(iter(pcb.footprints.values()))
+            with contextlib.redirect_stdout(io.StringIO()):
+                return audit_via_hole_to_hole(fp, pcb, vias), fp
+
+    # Two holes 0.6mm apart, drill 0.2 -> 0.4mm edge-to-edge, far from any
+    # copper on the fixture (offset well outside the board's own geometry).
+    def pair(dx):
+        return [{'x': 500.0, 'y': 500.0, 'size': 0.35, 'drill': 0.2, 'net_id': 0},
+                {'x': 500.0 + dx, 'y': 500.0, 'size': 0.35, 'drill': 0.2,
+                 'net_id': 0}]
+
+    rep, _fp = audit(0.5, pair(0.6))
+    check("unit: 0.4mm edge-to-edge under a declared 0.5 is one violation",
+          rep['violations'] == 1 and abs(rep['min_gap'] - 0.4) < 1e-9
+          and rep['floor'] == 0.5, f"{rep}")
+    # `pads` promises BALL PADS. These holes are nowhere near a ball, so the
+    # list must be EMPTY rather than carrying a coordinate string -- the pair
+    # is still fully described in `worst`.
+    check("unit: `pads` names ball pads only, never a bare coordinate",
+          rep['pads'] == [] and rep['pad_count'] == 0
+          and rep['worst'][0]['a'].startswith('(')
+          and rep['by_kind'] == {'ball_to_ball': 0, 'new_to_new': 1,
+                                 'against_existing': 0}, f"{rep}")
+    rep, _fp = audit(None, pair(0.6))
+    check("unit: the same holes are legal at the fab default 0.2",
+          rep['violations'] == 0 and rep['floor'] == 0.2, f"{rep}")
+    rep, _fp = audit(0.5, pair(0.75))
+    check("unit: 0.55mm edge-to-edge clears the declared 0.5",
+          rep['violations'] == 0 and abs(rep['min_gap'] - 0.55) < 1e-9, f"{rep}")
+    # A declaration BELOW the fab floor is pinned up, never obeyed downwards.
+    rep, _fp = audit(0.05, pair(0.22))
+    check("unit: a sub-fab declaration is wrapped at the fab hole-to-hole floor",
+          rep['floor'] >= 0.2 - 1e-9 and rep['violations'] == 1,
+          f"floor={rep['floor']} violations={rep['violations']}")
+    # Purity: the audit must not touch the list it is given.
+    vias = pair(0.6)
+    before = json.dumps(vias, sort_keys=True)
+    r1, _fp = audit(0.5, vias)
+    r2, _fp = audit(0.5, vias)
+    check("unit: the audit is pure (input untouched, answer stable)",
+          json.dumps(vias, sort_keys=True) == before
+          and r1['violations'] == r2['violations']
+          and r1['min_gap'] == r2['min_gap'])
+    # No vias at all -> a report, never a crash.
+    rep, _fp = audit(0.5, [])
+    check("unit: an empty via list reports 0, not an error",
+          rep.get('violations') == 0 and 'error' not in rep, f"{rep}")
+
+
+def existing_hole_checks():
+    """The new-vs-EXISTING-hole half, on a board that HAS holes.
+
+    The unit checks above hand-place their holes far outside the fixture, so
+    `existing` is empty and this whole branch never runs there. routed_output
+    carries 383 real via drills, so the branch is exercised for what it must
+    get right: a legal gap is silent, an OVERLAP is reported (an earlier draft
+    dropped every negative gap as "co-located" and reported a board with
+    intersecting holes as clean, `min_gap` and all), and a via re-emitted
+    exactly at an existing hole is that same hole, not a pair.
+    """
+    if not os.path.exists(ROUTED):
+        print(f"  [SKIP] board not present: {ROUTED}")
+        return
+    audit_via_hole_to_hole = getattr(bf, 'audit_via_hole_to_hole', None)
+    if audit_via_hole_to_hole is None:
+        check("unit: a new via overlapping an existing board hole is reported",
+              False, "no audit_via_hole_to_hole symbol")
+        return
+    with tempfile.TemporaryDirectory() as tmp:
+        pcb = parse_kicad_pcb(_staged(tmp, ROUTED, 0.5))
+        fp = pcb.footprints['U3']
+
+        def audit(vias):
+            with contextlib.redirect_stdout(io.StringIO()):
+                return audit_via_hole_to_hole(fp, pcb, list(vias))
+
+        holes = [(v.x, v.y, (v.drill or 0) / 2.0)
+                 for v in pcb.vias if (v.drill or 0) > 0]
+        n_via_holes = len(holes)
+        for pads in pcb.pads_by_net.values():
+            for p in pads:
+                if (getattr(p, 'drill', 0) or 0) > 0:
+                    holes.append((p.global_x, p.global_y, p.drill / 2.0))
+        floor = audit([{'x': 500.0, 'y': 500.0, 'size': 0.35, 'drill': 0.2,
+                        'net_id': 0}])['floor']
+        nr = 0.1                                    # the new via's drill / 2
+        # An ISOLATED existing via, so the assertions can be exact counts. The
+        # audit's prefilter box around a new via is floor + radii + 1mm, so
+        # reject any candidate with a SECOND hole inside that box once the new
+        # via sits at its furthest test offset.
+        iso = None
+        for (x, y, r) in holes[:n_via_holes]:
+            far = r + nr + floor + 0.05             # the legal-case offset
+            if all(abs(hx - (x + far)) > floor + nr + hr + 1.0
+                   or abs(hy - y) > floor + nr + hr + 1.0
+                   for (hx, hy, hr) in holes if (hx, hy) != (x, y)):
+                iso = (x, y, r)
+                break
+        if iso is None:
+            print("  [SKIP] no isolated existing via on the fixture")
+            return
+        vx, vy, vr = iso
+
+        def one(dx):
+            return [{'x': vx + dx, 'y': vy, 'size': 0.35, 'drill': 2 * nr,
+                     'net_id': 0}]
+        legal = audit(one(vr + nr + floor + 0.05))
+        check("unit: a new via clearing a REAL board hole by 0.05mm is silent",
+              legal['violations'] == 0
+              and abs(legal['min_gap'] - (floor + 0.05)) < 1e-6,
+              f"{n_via_holes} board vias, isolated one at "
+              f"({vx:.3f},{vy:.3f}); {legal}")
+        over = audit(one((vr + nr) * 0.5))          # centres inside each other
+        worst_b = (over.get('worst') or [{}])[0].get('b', '')
+        check("unit: a new via OVERLAPPING a real board hole is REPORTED",
+              over['violations'] == 1 and (over['min_gap'] or 0) < 0
+              and over['by_kind']['against_existing'] == 1
+              and worst_b.startswith('an existing via @('),
+              f"{over}")
+        same = audit(one(0.0))                      # the SAME hole, re-emitted
+        check("unit: a via re-emitted AT an existing hole is that same hole",
+              same['violations'] == 0 and same['min_gap'] is None, f"{same}")
+
+
+def cli_summary_check():
+    """The CLI's JSON_SUMMARY must carry the finding (the planner reads it)."""
+    if not os.path.exists(ORANGECRAB):
+        print(f"  [SKIP] board not present: {ORANGECRAB}")
+        return
+    with tempfile.TemporaryDirectory() as tmp:
+        board = _staged(tmp, ORANGECRAB, 0.9)
+        out = os.path.join(tmp, 'out.kicad_pcb')
+        cmd = [sys.executable, '-X', 'utf8',
+               os.path.join(ROOT, 'py_router', 'bga_fanout.py'), board,
+               '--component', 'U4', '--escape-method', 'channel',
+               '--layers'] + LAYERS + [
+               '--track-width', '0.12', '--clearance', '0.1',
+               '--via-size', '0.35', '--via-drill', '0.2', '-o', out]
+        p = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+        line = [ln for ln in p.stdout.splitlines()
+                if ln.startswith('JSON_SUMMARY:')]
+        if not line:
+            check("CLI JSON_SUMMARY carries hole_to_hole", False,
+                  f"no JSON_SUMMARY (exit {p.returncode})")
+            return
+        summary = json.loads(line[-1].split('JSON_SUMMARY:', 1)[1])
+        h2h = summary.get('hole_to_hole') or {}
+        check("CLI JSON_SUMMARY carries the hole_to_hole finding",
+              h2h.get('violations', 0) > 0 and h2h.get('floor') == 0.9
+              and h2h.get('source') == 'board constraint',
+              f"hole_to_hole={h2h}")
+        check("CLI ...naming the pad, while `failed` still reads 0",
+              any(str(p_).startswith('U4/') for p_ in (h2h.get('pads') or []))
+              and summary.get('failed') == 0,
+              f"pads={h2h.get('pads')} failed={summary.get('failed')}")
+
+
+def main():
+    print("=" * 70)
+    print("Issue #618: BGA via-in-pad hole-to-hole disclosure")
+    print("=" * 70)
+    unit_checks()
+    existing_hole_checks()
+    real_board_checks()
+    cli_summary_check()
+    n_pass = sum(1 for _n, ok in CHECKS if ok)
+    print(f"\n{n_pass}/{len(CHECKS)} checks passed")
+    print("=" * 70)
+    return 0 if n_pass == len(CHECKS) and CHECKS else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes the **disclosure** half of #618. Enforcement was built, measured on four cases, and deliberately not shipped — see "Why not enforcement". Settling it needs a corpus A/B a maintainer would have to run.

## Reproduce (copy-paste, ~20 s)

```bash
mkdir -p /tmp/618 && cp kicad_files/glasgow_revC.kicad_pcb /tmp/618/g.kicad_pcb
printf '{"board":{"design_settings":{"rules":{"min_hole_to_hole":0.9}}}}' > /tmp/618/g.kicad_pro
python3 py_router/bga_fanout.py /tmp/618/g.kicad_pcb --component U30 \
    --escape-method channel --layers F.Cu In1.Cu In2.Cu B.Cu \
    --track-width 0.12 --clearance 0.1 --via-size 0.35 --via-drill 0.2 \
    -o /tmp/618/out.kicad_pcb
```

### Before

```
Writing 307 tracks to /tmp/618/out.kicad_pcb...
JSON_SUMMARY: {"component": "U30", "requested": 99, "escaped": 98, "failed": 1,
"unescaped_nets": ["/IO_Banks/QB1"], "skipped_nc": 1, "clearance": 0.1,
"track_width": 0.12, "layers": ["F.Cu", "In1.Cu", "In2.Cu", "B.Cu"],
"drc_grazes": {...}, "min_clearance_used": 0.1, "deferred_fanout_nets": [],
"plane_drop": {...}}
```

No `hole_to_hole` key. No `#618` line anywhere in the log. The board it just wrote carries 76 via drills whose closest pair is **0.600 mm** apart under a rule that says 0.900 — 114 such pairs.

### After

```
  WARNING (#618): 114 emitted via pair(s) are drilled closer than the board's own declared min_hole_to_hole 0.9mm -- smallest gap 0.6000mm.
    114 pair(s) are two BALL-CENTRE via-in-pad sites: that spacing is the package pitch minus the drill, so this engine cannot space them further apart and the copper is UNMANUFACTURABLE against the rule as it stands. Fix at the source: relax min_hole_to_hole for this part, use a smaller --via-drill, or escape it without via-in-pad.
    worst: U30/A1<->U30/A2 0.6000mm, U30/A1<->U30/B1 0.6000mm, U30/A2<->U30/A3 0.6000mm, U30/A2<->U30/B2 0.6000mm, U30/A3<->U30/B3 0.6000mm, U30/A4<->U30/A5 0.6000mm (+108 more)
Writing 307 tracks to /tmp/618/out.kicad_pcb...
JSON_SUMMARY: {..., "hole_to_hole": {"violations": 114, "vias": 76, "floor": 0.9,
"declared": 0.9, "source": "board constraint", "min_gap": 0.6,
"by_kind": {"ball_to_ball": 114, "new_to_new": 0, "against_existing": 0},
"worst": [{"gap": 0.6, "a": "U30/A1", "b": "U30/A2"}, ...],
"pad_count": 76, "pads": ["U30/A1", "U30/A10", ... 24 names]}}
```

**The written board is unchanged.** Both runs: 307 segments / 76 vias, uuid-masked whole-file sha `0d892e9b9d9a232a`, copper sha `da5dc4cb6bb6edb1`.

## What is actually wrong, and where

A via-in-pad sits at the **ball centre**, so the best drill spacing available is `pitch - drill` — 0.600 mm on an 0.8 mm array with a 0.2 mm drill. Nothing in the fanout can move it. The board asks for 0.9, the engine grades against a hardcoded 0.2, never compares its own new vias to each other, and ships the result with no comment.

It reproduces on the **DEFAULT `escape_method='auto'`**, on the board the issue names, with everything else stock (ulx3s U1, declared 0.9): **186/207 escaped, 21 failed, 144 vias, 184 pairs at 0.600 mm**. With nothing declared the same run escapes **204/204 with 0 failed** — the board pays 21 dropped balls for a floor its output then violates 184 times. The log even prints `Hole-to-hole 0.9mm (from the board's own min_hole_to_hole)` on the way past.

**Which engine emits those drills has to be measured, not read off the log** — and the log invites the wrong answer. `auto` retries **per pass** with the under-pad grid and keeps whichever dropped fewer balls (#288), and a fanout makes several passes, only one of which supplies the vias that ship. Stamping every returned via with the `escape_method` of the core call that created it, on the real CLI path:

```
ulx3s U1, auto, declared 0.9:
  [ATTRIB] core call depth=3 escape_method='underpad' -> 42 vias (42 newly stamped)
    Under-pad escape wins: 44 -> 38 dropped ball(s); using it
  [ATTRIB] core call depth=2 escape_method='auto' -> 42 vias (0 newly stamped)
  [ATTRIB] core call depth=3 escape_method='underpad' -> 41 vias (41 newly stamped)
    Under-pad escape did not improve (33 dropped) - keeping the channel result
  [ATTRIB] core call depth=2 escape_method='auto' -> 138 vias (138 newly stamped)
  [ATTRIB] core call depth=1 escape_method='auto' -> 138 vias (0 newly stamped)
  [ATTRIB] vias by engine: [('?', 6), ('auto', 138)]        # '?' = plane-drop vias
  [ATTRIB] new-vs-new violating pairs by engine pair: [(('auto', 'auto'), 184)]  total=184
```

The pass whose under-pad arm "wins" contributes 42 vias that are then discarded; the pass that ships kept its **channel** result. Same on the others — glasgow_revC U30 `auto`: 71/71 channel vias, 100/100 pairs. haasoscope_pro_max U3 `auto`: 151/151, 131/131.

The control settles it: forcing `--escape-method underpad` on ulx3s U1 at the same declared 0.9 gives

```
"hole_to_hole": {"violations": 0, "vias": 53, "floor": 0.9, "declared": 0.9,
                 "source": "board constraint", "min_gap": 0.931371}
```

So the live enforcement gap is the **channel** engine's `manage_vias.via_in_pad_conflict`, whose own docstring already names both halves — it prices its drill floor at the flat `routing_defaults.HOLE_TO_HOLE_CLEARANCE` rather than the board's `min_hole_to_hole`, and never reads back this run's own `vias_to_add`. It is **not** the under-pad engine's `_via_site_conflict`, which #616 taught to read the board.

## Measurements (via 0.35 / drill 0.2, 4 layers, declared 0.9 unless noted)

| board / part | pitch | engine | escaped | failed | vias | min drill gap | pairs below the rule |
|---|---|---|---|---|---|---|---|
| ulx3s U1 | 0.8 | `auto` (default) | 186/207 | 21 | 144 | **0.600** | **184** |
| haasoscope_pro_max U3 | 0.8 | `auto` | 201/216 | 15 | 208 | **0.600** | **131** |
| glasgow_revC U30 | 0.8 | `auto` | 98/99 | 1 | 71 | **0.600** | **100** |
| glasgow_revC U30 | 0.8 | `channel` | 98/99 | 1 | 76 | **0.600** | **114** |
| orangecrab_ext_pll U3, declared 0.4 | 0.5 | `channel` | 70/109 | 39 | 16 | **0.350** | **12** |

Controls, same runs with the project declaring nothing — both **silent**, no `#618` line: ulx3s U1 `auto` → 204/204 escaped, 0 failed, 224 vias, min gap 0.365685; glasgow U30 `channel` → 98/99, 1 failed, 76 vias, min gap 0.6. Both above the 0.2 fab floor, so nothing fires.

## Not every violation is the package's fault

orangecrab U3 at a declared 0.4 shows the split the report now makes:

```
  WARNING (#618): 12 emitted via pair(s) are drilled closer than the board's own declared min_hole_to_hole 0.4mm -- smallest gap 0.3500mm.
    4 pair(s) are two BALL-CENTRE via-in-pad sites: that spacing is the package pitch minus the drill, so this engine cannot space them further apart and the copper is UNMANUFACTURABLE against the rule as it stands. Fix at the source: relax min_hole_to_hole for this part, use a smaller --via-drill, or escape it without via-in-pad.
    8 pair(s) are NOT pinned by the ball grid (8 against a hole that was already on the board): the site could not clear the other hole, so read those as an engine finding -- a smaller --via-drill or a different escape may move them.
    worst: U3/B17<->an existing via @(163.650,104.650) 0.3500mm, U3/C9<->an existing via @(163.650,101.150) 0.3500mm, ... (+6 more)
```

`by_kind` carries that split into `JSON_SUMMARY` (`{"ball_to_ball": 4, "new_to_new": 0, "against_existing": 8}`), so a reader is not sent to the board owner for a violation the router could have avoided.

## Why not enforcement

Arm A — `via_in_pad_conflict` resolving its floor from the board **and** testing candidates against this run's own `vias_to_add` — was built, measured, and thrown away. It takes every violation to 0 and costs escapes:

| board / part | engine | escaped | failed | vias | pairs |
|---|---|---|---|---|---|
| ulx3s U1 | `auto` | 186 → **171** | 21 → **33** | 144 → 53 | 184 → 0 |
| glasgow_revC U30 | `auto` | 98 → **89** | 1 → **10** | 71 → 18 | 100 → 0 |
| glasgow_revC U30 | `channel` | 98 → **63** | 1 → **36** | 76 → 38 | 114 → 0 |
| orangecrab U3 (declared 0.4) | `channel` | 70 → **65** | 39 → **45** | 16 → 26 | 12 → 0 |

Two independent reasons to leave it alone:

1. **The rule being enforced is one the package contradicts.** You cannot put a via in an 0.8 mm-pitch ball and also hold 0.9 mm hole-to-hole. Whether to drop a dozen to three dozen escapes for it is the board owner's call, not a default — and four boards do not settle it. **Deciding it needs a corpus A/B** (`tests/stress/cloud_replay_sets.py`).
2. **The same edit was already tried, and abandoned.** Sibling issue #620 asks for exactly this change to exactly this function. Its fix was dropped after two independent reviews measured a connectivity regression from it — `manage_vias` runs to completion and the caller *then* deletes whole nets' vias, so candidates get refused against blockers that never ship. (I could not reproduce that regression on the command form I was given: with `--fab-overrides via_drill=0.35` orangecrab U3 emits only 2 tracks, so the guard never fires and arm A is inert there too. Cited as the sibling investigation's finding, not this PR's.)

Naming the violation costs nothing and leaves the call where it belongs. That is what ships.

## What ships

`audit_via_hole_to_hole()` in `py_router/bga_fanout/__init__.py`, called at the end of `generate_bga_fanout`:

- Grades only the holes **this run caused** — new-vs-new among `vias_to_add`, and new-vs-existing against board vias (minus the ones `vias_to_remove` deletes) and drilled pads. Existing-vs-existing is somebody else's finding.
- Floor is board-first and fab-wrapped, resolved exactly as the under-pad engine does (`list_nets.board_floor` → `max(declared, fab)`), so a board declaring nothing is graded at the flat 0.2 and stays silent, and a sub-fab declaration is pinned up rather than obeyed downwards.
- **Overlapping holes count.** Co-location is decided on the centres (`d < 1e-6` → the same hole, re-emitted), never on the sign of the gap, so a via that physically intersects an existing hole is reported with a negative gap instead of being filtered out as "co-located".
- Emits the `WARNING (#618)` above and publishes `bga_fanout.LAST_HOLE_TO_HOLE_REPORT`, which reaches the CLI as `JSON_SUMMARY.hole_to_hole` (`floor` / `declared` / `source` / `min_gap` / `violations` / `by_kind` / `pads` / `pad_count` / `worst`). `pads` is BALL PADS only, capped at 24 names with the true total in `pad_count`; `worst` at most 12 pairs, each existing hole labelled with its position.
- **Report-only.** It removes no via and moves no copper; `failed` stays a routing verdict. Wrapped in try/except so a disclosure can never abort a run.

It lives in the **shared engine**, not a CLI `main()`, so the GUI path runs the audit too and its WARNING lands in KiCad's console (CLAUDE.md Class 1 — no new GUI wiring, and `test_cli_postpass_coverage` needs no new registration). To be precise: nothing in the GUI *reads* `LAST_HOLE_TO_HOLE_REPORT` — the same precedent as `LAST_PLANE_DROP_REPORT` — so the disclosure there is the printed warning, not a dialog.

## Purely additive — proven

`git diff origin/placement --shortstat` → **3 files changed, 681 insertions(+), 0 deletions.** The engine gains a module global, a function nothing else calls, one call at the end of `generate_bga_fanout` whose result goes only into `LAST_HOLE_TO_HOLE_REPORT` (the `return` tuple is untouched), and one JSON key.

Base vs patched, same command, uuid-masked whole-file sha (+ copper sha):

| case | base | patched |
|---|---|---|
| glasgow U30 `channel` @0.9 | `0d892e9b9d9a232a` — 307 seg / 76 vias / `da5dc4cb6bb6edb1` | identical |
| glasgow U30 `auto` @0.9 | `3e926a648bd0a396` — 345 seg / 71 vias / `f60d0fa75ba770c7` | identical |
| orangecrab U3 `channel` @0.4 | `384d6e635e467921` — 984 seg / 143 vias / `44735e52eb1653be` | identical |
| ulx3s U1 `auto` @0.9 | `c1be2ac7181d2bb3` — 729 seg / 144 vias / `e04c3b3bbcd98d3e` | identical |
| orangecrab U3 `--fab-overrides <file with via_drill = 0.35>` (the #620 command) | 746 seg / 143 vias | identical (`--fab-overrides` takes a FILE; re-measured with a real overrides file by the second review) |

On the #620 command the full stdout logs were diffed: the only differences are the output path strings and the added `hole_to_hole` key — the entire `plane_drop` ledger and the strap-pool lines match line for line. `check_connected.py` on both outputs is byte-identical (`FOUND 151 ISSUES`, `GND (net 5): ... Disconnected components: 299` on both sides).

## Testing

`tests/test_bga_via_hole_to_hole_disclosure.py` — **25 checks**, 10 of them hand-placed holes with no routing. On the base engine it fails 15/17; with the patch, 25/25. Two checks pass on the base by design: they are the defect statement — the base emits identical copper (sha `6c535991010bdcb9`, 76 vias / 307 tracks / 1 failed) declared or not, and says nothing.

Four of those checks cover the new-vs-existing-hole half against `kicad_files/routed_output.kicad_pcb` (383 real via drills): a via clearing a real board hole is silent, a via **overlapping** one is reported (`min_gap: -0.125`, `by_kind.against_existing: 1`), and a via re-emitted exactly at an existing hole is that same hole, not a pair.

Regression: `run_all.py --fast -j 4 --timeout 240` → **239 passed / 14 failed / 0 timed out** patched, **238 / 14 / 1 timed out** base, with an **identical failure list** (all 14 pre-existing and unrelated). The one-test delta is `test_placement_ab.py`, which timed out at the 240 s limit on the slower base run (526 s wall vs 384 s) and passed on the patched run. Both wx-free parity gates pass unchanged.

GUI input verified under KiCad 10.0.1's own python: `build_pcb_data_from_board` sets the same `source_path` as the text parser and `list_nets.board_floor` resolves `(0.9, 'board constraint')` identically on both fronts.

## Not covered

- `qfn_fanout` has the same via-in-pad shape; unmeasured, out of scope for this issue.
- The floor is read from the sibling `.kicad_pro` only. A board expressing `hole_to_hole` as a `.kicad_dru` custom rule is graded at the flat fab default and stays silent (`kicad_dru.py` models `clearance` constraints only) — documented, repo-wide, not introduced here.
- KiCad's bundled python has no scipy/shapely here, so a full headless GUI fanout run was not possible; only the front-end input was measured.
- `min_gap` is over graded pairs: pre-existing holes further than `floor + 1 mm` from a new via are not enumerated. Violation counting is unaffected — nothing outside that reach can be below the floor.

## Post-review addendum (second adversarial pass)

The second review verified everything load-bearing independently: it rebuilt the
violation counter from the output board's s-expressions with no bga_fanout code
(exact agreement on all five runs), swept the overlap boundary on 27 offsets
against brute force (0 mismatches, including gap == floor to the fourth decimal),
byte-compared four base-vs-patched cases including the #620 command (identical,
full-stdout diff empty after path lines), reproduced the engine-attribution trace
verbatim, and re-ran the suite both sides (identical failure lists, 239/14 both).
Its three minor findings are fixed: the `against_existing` gloss no longer claims
the pair is unpinned by the ball grid (measured: 8 of 8 such pairs DO have their
new drill at a ball centre — the distinguishing fact is the OTHER end being
pre-existing board copper, and the shipped wording now says that); the
`--fab-overrides` table row now shows the real file-based command form and the
re-measured numbers; and the GUI claim above is stated precisely.
