### PR TITLE
route.py: --deadline with a reserve band, and machine-readable run output

### DIFF
--- a/py_placer/placement/reachability.py
+++ b/py_placer/placement/reachability.py
@@ -44,6 +44,7 @@ because a silently-degraded reachability answer is worse than none.
 from __future__ import annotations
 
 import math
+import os
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Sequence, Tuple
 
@@ -212,7 +213,8 @@ def slack_field(pcb, target_net_id, layer, view, base_clearance,
 # widest path
 # --------------------------------------------------------------------------
 
-def widest_path(slacks, targets, via_ok, seed_xy, seed_layer, view, step):
+def widest_path(slacks, targets, via_ok, seed_xy, seed_layer, view, step,
+                return_throat=False):
     """Kruskal widest path over a multi-layer grid; returns mm or None.
 
     Nodes are (cell, layer). In-layer edges join adjacent ACTIVE cells; a via
@@ -223,6 +225,13 @@ def widest_path(slacks, targets, via_ok, seed_xy, seed_layer, view, step):
     Returns the largest t such that a path exists using only cells of slack
     >= t. Exact for the raster: no search order, no grid alignment, no
     heuristic. None means no positive-slack path exists at any width.
+
+    `return_throat=True` returns `(value, (layer, x_mm, y_mm))` instead. The
+    cell that CLOSED the path is the throat -- the narrowest point on the widest
+    route -- and it was already in hand here (`lay`, `x`, `y` at the moment the
+    seed joins the target) and thrown away at the bare `return float(val)`.
+    Every consumer that wanted to say WHERE the bottleneck was had to go and
+    find it again by eye. `None` throat when there is no path.
     """
     L = len(slacks)
     h, w = slacks[0].shape
@@ -274,8 +283,13 @@ def widest_path(slacks, targets, via_ok, seed_xy, seed_layer, view, step):
                 if other != lay and active[other * n + cell]:
                     union(idx, other * n + cell)
         if active[seed] and find(seed) == find(TARGET):
-            return float(val)
-    return None
+            if not return_throat:
+                return float(val)
+            # `lay`, `y`, `x` are this cell -- the LAST one activated, i.e. the
+            # narrowest on the widest path. Cell centre, not corner.
+            return float(val), (lay, view[0] + (x + 0.5) * step,
+                                view[1] + (y + 0.5) * step)
+    return (None, None) if return_throat else None
 
 
 @dataclass
@@ -295,6 +309,17 @@ class Reachability:
     grid: Tuple[int, int]
     note: str = ''
     open_room_mm: float = 0.0     # the cap free space was clamped to
+    # WHERE the bottleneck is: (layer_index, x_mm, y_mm), or None when there is
+    # no path. Everything below exists because run 20 measured a throat, printed
+    # the number, and then had to hand-assemble the coordinates, the blocking
+    # refs and the relief distance into an English paragraph in a ledger string
+    # -- three tools' stdout, none of it consumable by anything downstream.
+    throat_cell: Optional[Tuple[int, float, float]] = None
+    #: The base clearance the field was built at. Needed to convert between the
+    #: two SPACES this class reports in -- see `gap_mm`.
+    clearance_mm: float = 0.0
+    #: Foreign copper nearest the throat: [{ref, pad, kind, x, y, layer, dist}].
+    near: Tuple[dict, ...] = ()
 
     @property
     def wide_open(self) -> bool:
@@ -333,6 +358,34 @@ class Reachability:
             return None
         return 1000.0 * (self.bottleneck_mm - self.track_mm)
 
+    @property
+    def gap_mm(self) -> Optional[float]:
+        """The bottleneck in GAP space -- the physical edge-to-edge distance.
+
+        `bottleneck_mm` is in SLACK space: `slack = 2 * (dist - clearance)`
+        (see `slack_field`), which is the widest TRACK that fits. The physical
+        gap between the two pieces of copper is `bottleneck + 2 * clearance`.
+
+        The two are different numbers for the same throat and mixing them is
+        easy: run 20's ledger recorded `0.409/0.450mm` (gap space) beside
+        `-37.69um` (track space) in one sentence, as if they described the same
+        measurement. Publishing both, each labelled, is why this property
+        exists.
+        """
+        if self.bottleneck_mm is None:
+            return None
+        return self.bottleneck_mm + 2.0 * self.clearance_mm
+
+    @property
+    def throat(self) -> Optional[dict]:
+        """The throat in world coordinates, or None."""
+        if not self.throat_cell:
+            return None
+        lay, x, y = self.throat_cell
+        return {'x': round(x, 4), 'y': round(y, 4),
+                'layer': self.layers[lay] if lay < len(self.layers)
+                else str(lay)}
+
     def to_dict(self):
         return {'net': self.net, 'seed': list(self.seed),
                 'layers': list(self.layers), 'step_mm': self.step_mm,
@@ -353,7 +406,69 @@ class Reachability:
                 'via_legal_fraction': round(self.via_legal_fraction, 4),
                 'grid': list(self.grid), 'view': [round(v, 3)
                                                   for v in self.view],
-                'note': self.note}
+                'note': self.note,
+                # ADDITIVE. Every key above is unchanged, and a test pins that
+                # -- consumers of this payload predate the defect record.
+                'throat': self.throat,
+                'clearance_mm': self.clearance_mm,
+                'gap_mm': (None if self.gap_mm is None
+                           else round(self.gap_mm, 5)),
+                'near': [dict(n) for n in self.near]}
+
+    def defect_record(self, board=None, board_sha=None, relief=(),
+                      instrument='check_reachability', floors=None):
+        """This measurement as a `defect-record` document -- the shared shape.
+
+        One document, produced by any tool, read by the render, the ledger and
+        the driver. Everything in it was already computed here and thrown away
+        at the point of formatting; this is plumbing, not new measurement.
+
+        Returns None when there is nothing to report (no verdict, or PASSABLE).
+        """
+        if not self.measured or not self.caged:
+            return None
+        thr = self.throat
+        # The two spaces, both stated, both labelled, with what converts them.
+        measure = {'space': 'track_width',
+                   'have_mm': (None if self.bottleneck_mm is None
+                               else round(self.bottleneck_mm, 5)),
+                   'need_mm': self.track_mm,
+                   'short_mm': (None if self.bottleneck_mm is None else
+                                round(self.track_mm - self.bottleneck_mm, 5)),
+                   'resolution_mm': self.step_mm,
+                   'gap_mm': (None if self.gap_mm is None
+                              else round(self.gap_mm, 5)),
+                   'gap_need_mm': round(self.track_mm
+                                        + 2.0 * self.clearance_mm, 5),
+                   'derived_from': 'have_mm + 2 * instrument.floors.'
+                                   'clearance.value'}
+        refs, pads = [], []
+        for n in self.near:
+            if n.get('ref') and n['ref'] not in refs:
+                refs.append(n['ref'])
+            if n.get('pad') and n['pad'] not in pads:
+                pads.append(n['pad'])
+        d = {'kind': 'throat', 'verdict': 'CAGED', 'net': self.net,
+             'seed': {'x': round(self.seed[0], 4), 'y': round(self.seed[1], 4),
+                      'layer': self.layers[0] if self.layers else None},
+             'at': thr, 'refs': refs, 'pads': pads, 'measure': measure,
+             'view': [round(v, 4) for v in self.view],
+             'relief': [dict(r) for r in relief],
+             'instrument': {'source': instrument, 'floors': dict(floors or {}),
+                            'step_mm': self.step_mm,
+                            'search_view': [round(v, 4) for v in self.view]}}
+        if len(self.near) >= 2:
+            d['span'] = {'a': {k: self.near[0].get(k)
+                               for k in ('x', 'y', 'layer', 'kind')},
+                         'b': {k: self.near[1].get(k)
+                               for k in ('x', 'y', 'layer', 'kind')}}
+        doc = {'kind': 'defect-record', 'version': 1, 'count': 1,
+               'defects': [d]}
+        if board:
+            doc['board'] = os.path.abspath(board)
+        if board_sha:
+            doc['board_sha'] = board_sha
+        return doc
 
     def format_text(self):
         lines = [f"net        {self.net} from ({self.seed[0]}, "
@@ -389,6 +504,66 @@ class Reachability:
                 f"VERDICT    {'CAGED' if self.caged else 'PASSABLE'} at track "
                 f"{self.track_mm}mm  (margin {self.margin_um:+.1f} um)")
         return '\n'.join(lines)
+
+
+def nearest_foreign(pcb, x, y, net_id, layers=None, k=2, radius_mm=2.0):
+    """The k nearest pieces of FOREIGN copper to (x, y), nearest first.
+
+    "Which two things form this throat" is the question every reader asks
+    immediately after "how wide is it", and answering it took a second tool and
+    a hand-assembled sentence. Modelled on `net_forensics`' wall inventory,
+    which already does exactly this inventory with `REF.PAD` naming -- this is
+    the same walk with a k-nearest cut instead of a printed table.
+
+    Each entry: {kind, ref, pad, net, x, y, layer, dist}. Distances are to the
+    OBJECT CENTRE (a pad's copper centre, a segment's nearer endpoint), not to
+    its edge: the edge-to-edge number is what `gap_mm` reports, and conflating
+    the two is the error this module keeps trying to make impossible.
+    """
+    lay = set(layers or ())
+    out = []
+    for fp in pcb.footprints.values():
+        for p in fp.pads:
+            if p.net_id == net_id:
+                continue
+            if getattr(p, 'pad_type', '') == 'np_thru_hole':
+                continue
+            if lay and not (p.drill or set(p.layers or ()) & lay):
+                continue
+            d = math.hypot(p.global_x - x, p.global_y - y)
+            if d <= radius_mm:
+                out.append({'kind': 'pad', 'ref': fp.reference,
+                            'pad': f'{fp.reference}.{p.pad_number}',
+                            'net': (pcb.nets[p.net_id].name
+                                    if p.net_id in pcb.nets else None),
+                            'x': round(p.global_x, 4), 'y': round(p.global_y, 4),
+                            'layer': (p.layers or [None])[0],
+                            'dist': round(d, 5)})
+    for v in pcb.vias:
+        if v.net_id == net_id:
+            continue
+        d = math.hypot(v.x - x, v.y - y)
+        if d <= radius_mm:
+            out.append({'kind': 'via', 'ref': None, 'pad': None,
+                        'net': (pcb.nets[v.net_id].name
+                                if v.net_id in pcb.nets else None),
+                        'x': round(v.x, 4), 'y': round(v.y, 4),
+                        'layer': None, 'dist': round(d, 5)})
+    for s in pcb.segments:
+        if s.net_id == net_id:
+            continue
+        if lay and s.layer not in lay:
+            continue
+        d = min(math.hypot(s.start_x - x, s.start_y - y),
+                math.hypot(s.end_x - x, s.end_y - y))
+        if d <= radius_mm:
+            out.append({'kind': 'segment', 'ref': None, 'pad': None,
+                        'net': (pcb.nets[s.net_id].name
+                                if s.net_id in pcb.nets else None),
+                        'x': round(s.start_x, 4), 'y': round(s.start_y, 4),
+                        'layer': s.layer, 'dist': round(d, 5)})
+    out.sort(key=lambda e: e['dist'])
+    return tuple(out[:k])
 
 
 def pad_reachability(pcb, seed_xy, net_name=None, net_id=None, *,
@@ -492,12 +667,17 @@ def pad_reachability(pcb, seed_xy, net_name=None, net_id=None, *,
         note = ("no other island of this net is inside the view -- the pad is "
                 "already joined to everything nearby. Widen --margin, or this "
                 "is not a reachability question")
-    b = (None if n_t == 0
-         else widest_path(slacks, targets, via_ok, seed_xy, 0, view, step))
+    b, throat = ((None, None) if n_t == 0
+                 else widest_path(slacks, targets, via_ok, seed_xy, 0, view,
+                                  step, return_throat=True))
+    near = ()
+    if throat:
+        near = nearest_foreign(pcb, throat[1], throat[2], net_id, layers)
     return Reachability(
         net=name, net_id=net_id, seed=(seed_xy[0], seed_xy[1]), layers=layers,
         step_mm=step, track_mm=track_mm, via_mm=via_mm, view=view,
         bottleneck_mm=b, target_cells=n_t,
         via_legal_fraction=float(via_ok.mean()),
         grid=(slacks[0].shape[1], slacks[0].shape[0]), note=note,
-        open_room_mm=_open_room(view))
+        open_room_mm=_open_room(view),
+        throat_cell=throat, clearance_mm=base_clearance, near=near)

--- a/py_placer/placement/routability.py
+++ b/py_placer/placement/routability.py
@@ -1007,3 +1007,49 @@ def pair_channel_widths(pcb_data, *, clearance: float,
                          'parts_in_channel': sorted(inside)[:12]})
     rows.sort(key=lambda r: r['channel_mm'])
     return rows
+
+
+def relief_move(rect_a, rect_b, need_mm, limit_mm=5.0, tol_mm=1e-6):
+    """How far must B move, per axis direction, for the A-B gap to reach need_mm?
+
+    Answers the question a throat measurement leaves open: "so what do I DO?".
+    Run 20 measured a 0.409 mm gap against a 0.450 mm need and then had to work
+    out by hand that moving R7 east by ~0.042 mm would clear it.
+
+    Bisection on `rect_gap`, which already returns the diagonal corner distance
+    for rects that miss on both axes -- i.e. exactly the geometry being measured.
+    Four axis directions; a direction that cannot reach `need_mm` within
+    `limit_mm` is omitted rather than reported as a large number.
+
+    Every result is stamped `bound: "lower"` and that is not decoration. This is
+    a TWO-BODY answer on a board with hundreds of bodies: moving B by this much
+    clears THIS pair and may create another. It is the smallest move that could
+    possibly work, never a solution.
+    """
+    from placement.legality import rect_gap
+
+    def shifted(d, t):
+        dx, dy = {'east': (t, 0.0), 'west': (-t, 0.0),
+                  'north': (0.0, -t), 'south': (0.0, t)}[d]
+        return (rect_b[0] + dx, rect_b[1] + dy,
+                rect_b[2] + dx, rect_b[3] + dy)
+
+    out = []
+    for d in ('east', 'west', 'north', 'south'):
+        if rect_gap(rect_a, shifted(d, limit_mm)) < need_mm - tol_mm:
+            continue                       # unreachable within the cap: say nothing
+        lo, hi = 0.0, limit_mm
+        if rect_gap(rect_a, rect_b) >= need_mm - tol_mm:
+            out.append({'dir': d, 'min_mm': 0.0, 'bound': 'lower'})
+            continue
+        for _ in range(60):
+            mid = (lo + hi) / 2.0
+            if rect_gap(rect_a, shifted(d, mid)) >= need_mm:
+                hi = mid
+            else:
+                lo = mid
+            if hi - lo < tol_mm:
+                break
+        out.append({'dir': d, 'min_mm': round(hi, 6), 'bound': 'lower'})
+    out.sort(key=lambda r: r['min_mm'])
+    return out

--- a/py_router/krt_deadline.py
+++ b/py_router/krt_deadline.py
@@ -1,0 +1,486 @@
+"""Wall-clock deadlines and a guaranteed JSON_SUMMARY for long-running stages.
+
+Run 9 lost two stages to the same shape: `place_reconstruct --stages legalize`
+and `route_disconnected_planes` each ran to an external `timeout(1)`, wrote no
+output file, printed no `JSON_SUMMARY`, and exited with **the shell's** 124
+rather than any code the tool chose. From the log they were indistinguishable
+from a hang, and because both stage their output and promote it only at the end,
+a kill left nothing at the output path either.
+
+The family is wider than those two -- `EXACT_FILL_TIMEOUT` (300 s) and
+`ORACLE_DRC_TIMEOUT` (240 s) both degrade to a fallback with no failure signal,
+and `converge record` can fail before it execs at all. What they share:
+
+    a long silent phase after a complete-looking report, an exit code that
+    belongs to the shell rather than the tool, and staged output that leaves
+    nothing behind on a kill.
+
+This module fixes the part that is fixable from inside the process: a stage that
+knows its own budget stops ITSELF, keeps the work it has done, says so in the
+summary, and exits with a code it chose.
+
+Usage -- `arm()` once, then a cooperative check in the hot loop::
+
+    import krt_deadline
+    dl = krt_deadline.arm(args.deadline, tool='place_reconstruct',
+                          on_partial=lambda: report)     # None == no budget
+    ...
+    for violator in violators:
+        if dl and dl.check('legalize'):
+            break
+    ...
+    finally:
+        krt_deadline.emit(report, deadline=dl)
+
+`emit()` is the single print site and fires at most once per process, so calling
+it from the success path AND a `finally` AND the atexit hook is safe.
+
+WHY THIS IS NOT PART OF `cli_banner`
+------------------------------------
+1. `cli_banner.install()` returns early when `KRT_NO_BANNER` is set
+   (`cli_banner.py:59`), and `board_score.run_tool` sets `KRT_NO_BANNER='1'` for
+   every checker it shells (`board_score.py:108-119`). A summary emitter
+   suppressed the same way would go dark exactly where `board_score` reads.
+   Nothing here consults `KRT_NO_BANNER`.
+2. The tools that NEED a deadline are largely the ones that deliberately do NOT
+   carry the banner (`route_disconnected_planes.py`, `route.py`,
+   `place_route_loop.py`). Folding the deadline into `cli_banner` would make
+   adopting it mean adopting `CMD:`/`EXIT=` on their stdout -- a separate and
+   riskier decision this repo takes seriously (`converge.py:692`: "converge's
+   stdout is a JSON API").
+
+`atexit` runs LIFO, so a hook registered by `arm()` AFTER `cli_banner.install()`
+fires BEFORE the banner's `EXIT=` hook. That gives `JSON_SUMMARY:` then `EXIT=`,
+which is the order every consumer wants. **That ordering is load-bearing.**
+
+WHAT THIS CANNOT DO
+-------------------
+Measured on Windows, so nobody expects more than this delivers::
+
+    external `timeout 1`, tool has NO deadline   -> shell rc 124,
+                                                    0 JSON_SUMMARY lines,
+                                                    0 EXIT lines
+    external `timeout 5`, tool deadline 0.4s     -> rc 7, status "deadline",
+                                                    partial result intact,
+                                                    EXIT=7
+
+The first row is run 9's actual case and it stays **unfixable from inside the
+process**: a native win32 process cannot receive a POSIX SIGTERM, and under Git
+Bash the kill resolves to `TerminateProcess`, which is uncatchable -- no handler,
+no `atexit`, no flush. Anyone designing around a SIGTERM handler here is
+designing for a platform that did not produce the bug.
+
+So: **setting a budget BELOW whatever the harness allows is the whole
+mechanism.** The signal handlers below only help for a polite SIGINT/SIGTERM
+(interactive Ctrl+C, POSIX CI). The remaining defence for the uncatchable case is
+line buffering (already done, `cli_banner.py:69-74`), the `DEADLINE:` breadcrumb
+this module prints at arm time, and a progress heartbeat -- which is why
+`stdout_progress` is here and not cosmetic.
+
+DELIBERATELY NOT DONE
+---------------------
+* **A watchdog thread that prints and calls `os._exit`.** It fires even when the
+  main thread is inside a C call, which is seductive -- and it emits state the
+  main thread is mid-mutation of, skips `atexit` (losing `EXIT=`, the exact
+  defect being fixed), and can interleave a partial line into stdout. Both hot
+  loops here are pure Python and reach a cooperative check.
+* **A `DeadlineExceeded` exception.** `route_disconnected_planes.py` is full of
+  `except Exception` swallowers -- `:2474` sits directly on the hot path -- so an
+  exception-based deadline would be caught and converted into a printed note,
+  which is precisely the silent failure being removed. Cooperative flag checks
+  and `return None` only.
+* **A generous default budget.** A wall clock default would make the same board
+  produce a different output on a slower machine, which this repo cares about
+  specifically (`tests/test_457_determinism.py`, `redo_commands.sh` replays). The
+  default is None; the budget belongs to the harness that already owns a clock.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from typing import Any, Callable, Dict, Optional
+
+#: Exit code a stage returns when its OWN budget stopped it.
+#:
+#: Not 124 -- that is the shell's, and erasing the tool/shell distinction is the
+#: confusion being removed. Not 4 -- in these tools 4 asserts a MEASURED defect
+#: class (`route_disconnected_planes.py:3616-3623` advises "reconnect them, or
+#: re-run without --rip-blocker-nets", which presumes a completed run), and a
+#: run that never finished has measured nothing. Not 5 -- already spoken for
+#: repo-wide: `converge.py:446` STUCK and `check_complete.py` UNSOUND. 7 is
+#: unused anywhere, which is what a harness needs.
+DEADLINE_EXIT = 7
+
+_emitted = False
+_summary_fn: Optional[Callable[[], Dict[str, Any]]] = None
+_installed = False
+_signalled = False
+_current: Optional['Deadline'] = None
+
+
+def current() -> Optional['Deadline']:
+    """The budget armed for this process, if any.
+
+    A deliberate global, for the one case threading cannot reach: work buried
+    under a shared engine that no caller in the chain can pass a parameter to.
+    The motivating case is `plane_fragility.register_plane_fragility`, invoked
+    from `route.py:batch_route` -- so EVERY batch_route on a board KiCad cannot
+    fill pays the full 300s EXACT_FILL_TIMEOUT, and the plane repair calls
+    batch_route many times. That is the root cause of both non-terminations
+    measured in run 9, and no signature between the CLI and that call site
+    carries a budget.
+
+    Use it only where a parameter genuinely cannot reach; everywhere else pass
+    the Deadline explicitly.
+    """
+    return _current
+
+
+class Deadline:
+    """A wall-clock budget. Never construct with 0 meaning "no budget" -- use
+    `arm(None)`; `--deadline 0` is a legitimate "stop immediately", which the
+    tests rely on.
+
+    `expired()` is a subtraction and a comparison -- cheap enough for a loop that
+    runs once per violator or once per pad. Do NOT call it per candidate pose;
+    the granularity that matters is "can the partial be described coherently",
+    not "how soon do we notice".
+    """
+
+    __slots__ = ('seconds', 'started', 'tool', 'stopped_in')
+
+    def __init__(self, seconds: Optional[float], tool: str = ''):
+        self.seconds = None if seconds is None else float(seconds)
+        self.started = time.monotonic()
+        self.tool = tool
+        self.stopped_in: Optional[str] = None
+
+    def expired(self, reserve: float = 0.0) -> bool:
+        """True once the budget (minus `reserve`) is spent, or on a signal.
+
+        `reserve` carves a band off the end so a caller can stop its main work
+        early and still have clock left for a mandatory tail step. See
+        `cancel_check`.
+        """
+        if _signalled:
+            return True
+        if self.seconds is None:
+            return False
+        return (time.monotonic() - self.started) >= max(0.0,
+                                                        self.seconds - reserve)
+
+    def check(self, label: str, reserve: float = 0.0) -> bool:
+        """`expired()`, recording WHICH phase owned the clock when it went.
+
+        The label lands in the summary as `stopped_in`, which is the difference
+        between "it timed out" and "it timed out in the legalize sweep with 88
+        violators left".
+        """
+        if self.expired(reserve):
+            if self.stopped_in is None:
+                self.stopped_in = label
+            return True
+        return False
+
+    def cancel_check(self, label: str = '', reserve: float = 0.0):
+        """A zero-arg closure for engines that already take a `cancel_check`.
+
+        `route_disconnected_planes` (`:762`) and `route.py` (`:370`) both accept
+        one and honour it at every loop head -- so a deadline there is this
+        closure, not new machinery.
+        """
+        def _cancel() -> bool:
+            return self.check(label, reserve) if label else self.expired(reserve)
+        return _cancel
+
+    def remaining(self) -> Optional[float]:
+        if self.seconds is None:
+            return None
+        return max(0.0, self.seconds - (time.monotonic() - self.started))
+
+    def elapsed(self) -> float:
+        return time.monotonic() - self.started
+
+    def __repr__(self) -> str:  # pragma: no cover - diagnostics only
+        cap = 'none' if self.seconds is None else f'{self.seconds:g}s'
+        return f'<Deadline {self.tool} cap={cap} elapsed={self.elapsed():.1f}s>'
+
+
+def arm(seconds: Optional[float], *, tool: str,
+        on_partial: Optional[Callable[[], Dict[str, Any]]] = None
+        ) -> Optional[Deadline]:
+    """Start a budget, announce it, and arrange a partial flush if interrupted.
+
+    Precedence: the `seconds` argument, else `$KRT_DEADLINE_S` (so a harness can
+    set one budget for a whole chain with one export), else None.
+
+    Returns None when there is no budget, so callers can write `if dl and
+    dl.check(...)` and pay nothing when the feature is off.
+
+    The `DEADLINE:` line it prints is deliberate: a log WITHOUT it is proof no
+    budget was set, which is the standing diagnosis for the next 46-minute run.
+    """
+    if seconds is None:
+        env = os.environ.get('KRT_DEADLINE_S')
+        if env:
+            try:
+                seconds = float(env)
+            except ValueError:
+                print(f"krt_deadline: ignoring unparseable KRT_DEADLINE_S="
+                      f"{env!r}", file=sys.stderr)
+    global _current
+    dl = None if seconds is None else Deadline(seconds, tool=tool)
+    _current = dl
+    if dl is not None:
+        print(f"DEADLINE: {dl.seconds:g}s ({tool})", flush=True)
+    # Install the flush hook even with NO budget. The atexit hook is what makes
+    # "a JSON_SUMMARY on every path" true -- it covers early returns, argparse
+    # errors and unhandled exceptions, which is why the callers need no
+    # try/finally around a main() with a dozen return statements. Without this,
+    # the guarantee would only exist for runs that happened to set a budget.
+    if on_partial is not None:
+        _install(on_partial, dl)
+    return dl
+
+
+def emit(report: Optional[Dict[str, Any]], *, complete: bool = True,
+         status: str = 'ok', deadline: Optional[Deadline] = None) -> bool:
+    """The ONE `JSON_SUMMARY:` print site. Fires at most once per process.
+
+    Returns True if this call did the printing. A payload that will not
+    serialise is reported rather than swallowed -- a summary that vanished is the
+    defect this module exists to remove, so it must not reappear as an exception.
+    """
+    global _emitted
+    if _emitted or report is None:
+        return False
+    _emitted = True
+    doc = dict(report)
+    doc.setdefault('complete', complete)
+    doc.setdefault('status', status)
+    if deadline is not None:
+        doc.setdefault('deadline_s', deadline.seconds)
+        doc.setdefault('elapsed_s', round(deadline.elapsed(), 1))
+        if deadline.stopped_in:
+            doc.setdefault('stopped_in', deadline.stopped_in)
+    try:
+        print('JSON_SUMMARY: ' + json.dumps(doc, sort_keys=True, default=str),
+              flush=True)
+    except Exception as exc:                                   # noqa: BLE001
+        try:
+            print('JSON_SUMMARY: ' + json.dumps(
+                {'complete': False, 'status': 'error',
+                 'error': f'summary unserialisable: {exc}'}), flush=True)
+        except Exception:                                      # pragma: no cover
+            pass
+    return True
+
+
+def seal() -> bool:
+    """Declare the JSON_SUMMARY already published, WITHOUT printing one.
+
+    For a tool whose engine prints its own summary. `route.py` and
+    `route_diff.py` are the cases: `batch_route` builds a large summary and
+    `print`s it directly, and it does so once per pass (the reconciliation
+    self-invoke prints a second), so routing them through `emit()` -- which
+    fires at most once -- would swallow every summary after the first.
+
+    Without this the atexit flush would see `_emitted` still False on a
+    perfectly successful run and publish the contentless partial report armed
+    at `--deadline` time, printing a SECOND, contradicting
+    `{"complete": false, "status": "incomplete"}` line after the real one. That
+    is a measured defect, not a hypothetical: it shipped in
+    `route_disconnected_planes` (run 11, v6_r7) and any consumer keying on the
+    LAST JSON_SUMMARY read a good run as a failed one.
+
+    Returns True if this call did the sealing.
+    """
+    global _emitted
+    if _emitted:
+        return False
+    _emitted = True
+    return True
+
+
+def stamp(report: Dict[str, Any]) -> Dict[str, Any]:
+    """Stamp THIS PROCESS's spent budget onto a summary someone else prints.
+
+    The companion to `seal()`, and the reason neither is a new engine kwarg:
+    `batch_route`'s summary is the only one `route.py` emits, and
+    `place_route_loop` already refuses a `complete: false` tally
+    (`place_route_loop.py:162`) while `route_summary.merge_summaries` already
+    makes incompleteness sticky across passes. The one missing piece was the
+    stamp itself, and it is read through `current()` rather than threaded
+    through the signature -- so the GUI, which never arms a budget, is inert
+    here and no parity gate is involved.
+
+    A no-op unless a budget was armed AND actually cut the work short, so a
+    summary from a run that finished inside its budget is byte-identical to
+    before.
+
+    "Cut short" is `stopped_in or expired()`, not `expired()` alone. A caller
+    using a RESERVE band (`cancel_check(label, reserve=...)`, which
+    route_planes and route_disconnected_planes both need so the bounded tail
+    still has clock) trips its loops at `deadline - reserve` -- and if that
+    tail then finishes before the wall clock runs out, the run is past its
+    cancel and NOT past its deadline. Testing `expired()` alone would report
+    that partial board as complete, which is precisely the confusion this
+    module exists to remove. `stopped_in` is set by `Deadline.check` at the
+    moment the cancel fires, so it is the durable record.
+    """
+    dl = _current
+    if dl is None or not (dl.stopped_in or dl.expired()):
+        return report
+    report['complete'] = False
+    report['status'] = 'deadline'
+    report['deadline_s'] = dl.seconds
+    report['elapsed_s'] = round(dl.elapsed(), 1)
+    report['stopped_in'] = dl.stopped_in
+    return report
+
+
+def mark(report: Dict[str, Any], dl: Deadline, **partial: Any
+         ) -> Dict[str, Any]:
+    """Stamp `report` as a partial result, in the shape consumers rely on.
+
+    `complete` is the machine gate -- read it as `.get('complete', True)` so
+    pre-change logs degrade correctly. `status` is the branching discriminator:
+    a cancel is not a deadline is not a crash, and encoding the reason only as a
+    bool loses that.
+
+    `status` is `"deadline"`, not `"timeout"` -- `timeout` already means
+    something else in these summaries (`max_iterations`, A* budgets).
+    """
+    report['complete'] = False
+    report['status'] = 'deadline'
+    report['deadline_s'] = dl.seconds
+    report['elapsed_s'] = round(dl.elapsed(), 1)
+    report['stopped_in'] = dl.stopped_in
+    if partial:
+        report.setdefault('partial', {}).update(partial)
+    return report
+
+
+def stdout_progress(min_interval: float = 15.0,
+                    deadline: Optional[Deadline] = None,
+                    heartbeat_file: Optional[str] = None):
+    """A throttled `(current, total, label)` callback for CLI progress.
+
+    `route_disconnected_planes` already invokes `progress_callback` at ~9 sites;
+    it is None on the CLI path only because it was built for the GUI. Passing
+    this lights all of them up with no new print statements.
+
+    Throttling matters: one of those sites fires per pad and would otherwise
+    flood a 96-pad board's log. `PROGRESS:` is a distinct prefix that cannot
+    match `route_summary.SUMMARY_RE`.
+
+    run-23: `heartbeat_file` (default $KRT_PROGRESS_FILE) additionally
+    rewrites one small JSON doc per tick, atomically -- a waiter or a
+    RUN_STATE reader polls one file for liveness instead of tailing a log
+    that only grows when something prints.
+    """
+    state = {'last': 0.0}
+    hb = heartbeat_file or os.environ.get('KRT_PROGRESS_FILE') or None
+
+    def _progress(current=0, total=0, label='') -> None:
+        now = time.monotonic()
+        if now - state['last'] < min_interval:
+            return
+        state['last'] = now
+        frac = f"{current}/{total}  " if total else ''
+        clock = ''
+        if deadline is not None and deadline.seconds is not None:
+            clock = f"  [t={deadline.elapsed():.0f}s/{deadline.seconds:g}s]"
+        try:
+            print(f"PROGRESS: {frac}{label}{clock}", flush=True)
+        except Exception:                                      # noqa: BLE001
+            pass
+        if hb:
+            try:
+                doc = {'t': time.time(), 'current': current, 'total': total,
+                       'label': label,
+                       'elapsed_s': (round(deadline.elapsed(), 1)
+                                     if deadline is not None else None),
+                       'deadline_s': (deadline.seconds
+                                      if deadline is not None else None)}
+                tmp = hb + '.tmp'
+                with open(tmp, 'w', encoding='utf-8') as f:
+                    json.dump(doc, f)
+                os.replace(tmp, hb)
+            except Exception:                                  # noqa: BLE001
+                pass
+    return _progress
+
+
+def _install(on_partial: Callable[[], Dict[str, Any]],
+             dl: Optional[Deadline]) -> None:
+    """atexit + signal wiring. Every registration is defensive: a missing signal
+    must not stop the tool from running."""
+    global _installed, _summary_fn
+    _summary_fn = on_partial
+    if _installed:
+        return
+    _installed = True
+
+    import atexit
+
+    @atexit.register
+    def _flush() -> None:                                      # pragma: no cover
+        if _emitted or _summary_fn is None:
+            return
+        try:
+            rep = _summary_fn()
+        except Exception as exc:                               # noqa: BLE001
+            emit({'error': f'partial summary unavailable: {exc}'},
+                 complete=False, status='error')
+            return
+        # Name the reason accurately: a run that died on an early return is
+        # `incomplete`, not `deadline`. Conflating them would put the wrong
+        # diagnosis in the one artefact that survives.
+        if _signalled:
+            status = 'cancelled'
+        elif dl is not None and dl.expired():
+            status = 'deadline'
+            mark(rep, dl)
+        else:
+            status = 'incomplete'
+        emit(rep, complete=False, status=status, deadline=dl)
+
+    try:
+        import signal
+
+        def _on_signal(signum, _frame):                        # noqa: ANN001
+            # Set a flag ONLY. Printing from a handler can interleave into a
+            # half-written stdout line and corrupt the very JSON_SUMMARY a
+            # scraper reads; the atexit hook does the I/O instead. A second
+            # identical signal restores the default so Ctrl+C twice always
+            # kills.
+            global _signalled
+            if _signalled:
+                signal.signal(signum, signal.SIG_DFL)
+                return
+            _signalled = True
+            sys.exit(130 if signum == getattr(signal, 'SIGINT', None)
+                     else DEADLINE_EXIT)
+
+        for _name in ('SIGTERM', 'SIGINT', 'SIGBREAK'):
+            _sig = getattr(signal, _name, None)
+            if _sig is None:
+                continue
+            try:
+                signal.signal(_sig, _on_signal)
+            except (ValueError, OSError, RuntimeError):
+                pass          # not the main thread, or platform refuses it
+    except Exception:                                          # noqa: BLE001
+        pass
+
+
+def reset_for_test() -> None:
+    """Test hook: forget that a summary was emitted."""
+    global _emitted, _installed, _summary_fn, _signalled
+    _emitted = False
+    _installed = False
+    _summary_fn = None
+    _signalled = False

--- a/py_router/reroute_loop.py
+++ b/py_router/reroute_loop.py
@@ -588,9 +588,23 @@ def run_reroute_loop(
                     if not ripped_items:
                         print(f"  {RED}ROUTE FAILED - no rippable blockers found{RESET}")
                         from routing_diagnostics import static_boxin_hint, condense_hint
-                        hint = condense_hint(static_boxin_hint(result, config, pcb_data))
+                        hint, _boxin = static_boxin_hint(
+                            result, config, pcb_data, return_verdict=True)
+                        hint = condense_hint(hint)
                         if hint:
                             print(f"  {hint}")
+                        if _boxin:
+                            # NO function-local import here. `record_net_event`
+                            # is imported at module scope (line 12) and used at
+                            # four other points in THIS function; a local import
+                            # rebinds the name for the whole function body, so
+                            # the earlier uses raise UnboundLocalError before
+                            # this line is ever reached. It crashed route.py on
+                            # any board where a reroute SUCCEEDED -- caught by
+                            # test_compare_seeds, which had been a timeout at
+                            # baseline and so was carrying no signal at all.
+                            record_net_event(state, ripped_net_id,
+                                             "boxed_in_static", _boxin)
                     # Remove from pending_multipoint_nets to prevent Phase 3 from
                     # trying to route taps for a net with no main route.
                     if ripped_net_id in state.pending_multipoint_nets:

--- a/py_router/route.py
+++ b/py_router/route.py
@@ -266,6 +266,7 @@ def _empty_results_data() -> dict:
         'segments_to_remove': [],
         'vias_to_remove': [],
         'blockers': [],
+        'boxed_in': [],
         'pad_pairs_open': [],
     }
 
@@ -3383,6 +3384,7 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
     # a net that failed early but was later rescued/rerouted is filtered out
     # here because the final failed sets are authoritative.
     blockers_report = []
+    boxed_in_report = []
     try:
         _final_failed_ids = list(dict.fromkeys(
             failed_single_ids + [m['net_id'] for m in failed_multipoint]))
@@ -3413,8 +3415,27 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
                     'net': _name, 'stage': 'preexisting',
                     'blocked_by': [{'net': _bn, 'preexisting': True}
                                    for _bn in _pre103]})
+            # The static-vs-congestion verdict, as its OWN key. The router has
+            # printed "boxed in by static obstacles ... not by congestion" on
+            # every such failure since #95, and run 20 spent three grid
+            # refinements (0.05 -> 0.025 -> 0.0125, ~40 min) against exactly
+            # that sentence, because a sentence is not something a gate can read.
+            #
+            # DELIBERATELY NOT inside `blockers`. The routing skill's own
+            # classifier row is "`blockers` empty; the log says boxed in" --
+            # making `blockers` non-empty here would break the clause being
+            # fixed. The row becomes "`blockers` empty AND `boxed_in` names the
+            # net": one JSON test, no regex.
+            _bx = None
+            for _ev in (state.net_history.get(_nid) or []):
+                if _ev.get('event') == 'boxed_in_static':
+                    _bx = _ev.get('details') or _bx
+            if _bx:
+                boxed_in_report.append(dict(_bx, net=_name))
         if blockers_report:
             summary['blockers'] = blockers_report
+        if boxed_in_report:
+            summary['boxed_in'] = boxed_in_report
     except Exception:
         blockers_report = []
     # #409 follow-up: pad-pair routability tallies (PRR ingredients: connected
@@ -3566,6 +3587,11 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
             'vias_to_remove': stale_input_vias,
             # #409: same data as JSON_SUMMARY['blockers'] (may be empty).
             'blockers': blockers_report,
+            # ...and the static-vs-congestion verdict beside it, same data as
+            # JSON_SUMMARY['boxed_in']. The GUI reads results_data, not the
+            # printed summary, so a key that only reaches stdout does not
+            # reach the plugin (CLAUDE.md's Class-1 CLI/GUI gap).
+            'boxed_in': boxed_in_report,
             # #409 follow-up: same data as JSON_SUMMARY['pad_pairs_open']
             # (may be empty).
             'pad_pairs_open': pad_pairs_open_report,
@@ -3874,12 +3900,25 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
                                      if not _mnf9(n, net_names)})
                 _zpairs = [(n, l) for n, l in _zpairs if _mnf9(n, net_names)]
                 if _excluded9:
-                    print(f"{RED}  Plane finalize: zone net(s) "
+                    print(f"{RED}  WARNING: Plane finalize: zone net(s) "
                           f"{', '.join(_excluded9)} are OUTSIDE this route's "
                           f"--nets scope -- excluded from the finalize BY "
                           f"PLAN. Since #562 a pour alone connects nothing: "
                           f"unless a later route step covers these nets, "
                           f"their pads ship disconnected.{RESET}")
+                    # ...and in the SUMMARY, not only in the log. A later grade
+                    # can see disconnected plane pads but cannot tell whether a
+                    # step declined to weld them BY PLAN or failed to; run 20
+                    # hit this twice before designing around it, both times by
+                    # reading the log by eye.
+                    #
+                    # NOTE the printed `JSON_SUMMARY:` line predates the
+                    # finalize, so it does NOT carry this key. `summary` is in
+                    # `_SUMMARY_SINK` by reference, so `--json-out` does, as do
+                    # in-process callers reading the returned dict. A consumer
+                    # that greps the log line still needs the WARNING above --
+                    # which is why it is a WARNING now.
+                    summary['finalize_excluded_nets'] = _excluded9
             # PRE-GATE for the MODEL-BASED legs (engine taps/joins +
             # cleanup): run them only for zone nets the fill-aware checker
             # says are incomplete on THIS run's board (pcb_data == file
@@ -4973,6 +5012,24 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
             print(f"  route summary written to {json_out}")
         except Exception as _e:
             print(f"  WARNING: could not write --json-out {json_out}: {_e}")
+
+    # run-23: ONE compact authoritative line per outermost run, CLI and GUI
+    # alike. The big JSON_SUMMARY lines are 6-20KB each and their scope
+    # semantics need the log's own warning paragraph; agents consuming them
+    # paid that in context per lap. `final_reconcile` is True only on the
+    # outermost call (every sub-run -- plane finalize, end-of-run reconcile --
+    # passes False, the #562 recursion guard), so nested passes never emit a
+    # second MIN line. Deliberately AFTER the reconcile block: this line
+    # carries the merged tally or it is a lie.
+    if final_reconcile:
+        try:
+            from route_summary import merge_summaries as _ms, summary_min
+            _m = _ms(list(_SUMMARY_SINK), _RECONCILE_RAISED[0])
+            if _m:
+                print("JSON_SUMMARY_MIN: "
+                      + json.dumps(summary_min(_m), sort_keys=True))
+        except Exception as _e:                                 # noqa: BLE001
+            print(f"  WARNING: could not emit JSON_SUMMARY_MIN: {_e}")
 
     from net_story import net_story_enabled, dump_net_story
     if net_story_enabled():

--- a/py_router/route.py
+++ b/py_router/route.py
@@ -383,6 +383,7 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
                 add_teardrops: bool = False,
                 collect_stats: bool = False,
                 cancel_check=None,
+                tail_cancel_check=None,
                 progress_callback=None,
                 return_results: bool = False,
                 pcb_data=None,
@@ -521,6 +522,12 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
                # forwarding.
                'oracle_links'):
         _reconcile_kwargs.pop(_k, None)
+    # run-23: the TAIL closure. `cancel_check` may carry a reserve band
+    # (the routing loops stop early to leave room for the tail); the tail
+    # legs -- plane finalize, oracle reconnect, the reconcile sub-run -- run
+    # INSIDE that reserve and must therefore use a reserve-0 closure, or
+    # they would refuse to start in the very window reserved for them.
+    _tail_cc = tail_cancel_check or cancel_check
     # #572 lap-authority channel: cleared at ENTRY so an early return can
     # never leave a previous invocation's hints for the caller to harvest.
     batch_route._forced_link_hints = {}
@@ -3501,6 +3508,17 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
                 for _n, _r in sorted(_amp.items())]
     except Exception:
         pass
+    # A budget the CLI armed must reach THIS summary -- it is the only one
+    # route.py prints, and a cancelled run still falls through to here (the
+    # cancel breaks the routing loops, it does not skip the write), so without
+    # the stamp a partial board reported `complete` by omission. Inert when no
+    # budget was armed or the budget was not spent, which is every GUI call and
+    # every run that finished in time.
+    try:
+        import krt_deadline as _kdl
+        _kdl.stamp(summary)
+    except Exception:
+        pass
     # WHICH SUMMARY IS THIS? A run that fires the reconciliation sub-pass emits
     # a SECOND JSON_SUMMARY, scoped to that subset, and the only thing saying so
     # was a prose "Note:" printed after it. Anything that scrapes the last
@@ -3956,6 +3974,7 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
                     _b4vias9 = list(pcb_data.vias)
                     _rdp_engine(
                         input_file or "", "", _zn, _zl,
+                        cancel_check=_tail_cc,
                         track_width=config.track_width,
                         clearance=config.clearance,
                         grid_step=config.grid_step,
@@ -4041,6 +4060,7 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
                 else:
                     _rdp_engine(
                         output_file, output_file, _zn, _zl,
+                        cancel_check=_tail_cc,
                         track_width=config.track_width,
                         clearance=config.clearance,
                         grid_step=config.grid_step,
@@ -4258,7 +4278,7 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
                     track_via_clearance=defaults.PLANE_TRACK_VIA_CLEARANCE,
                     hole_to_hole_clearance=config.hole_to_hole_clearance,
                     progress_callback=_opc9,
-                    cancel_check=cancel_check,
+                    cancel_check=_tail_cc,
                     project_from=input_file)
                 print(f"  [finalize timing] oracle leg: "
                       f"{_time9.time() - _t9:.1f}s")
@@ -4470,7 +4490,21 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
             net.name for nid, net in pcb_data.nets.items()
             if nid in _scope_pre9 and nid not in _copper_pre9
             and nid not in _zone_pre9 and len(net.pads) >= 2)
+    # run-23: the reconcile is 1-3 laps, each paying a full re-parse + base
+    # obstacle map + per-net cache rebuild before its cancel_check is ever
+    # consulted -- minutes of unstoppable work entered AFTER the budget was
+    # spent (R4: 732s of 420, the tail was most of the overshoot). Entering
+    # on an expired deadline is refused HERE, with the reason printed, so
+    # the skip is a recorded fact instead of a mystery.
+    _rec_expired = bool(_tail_cc and _tail_cc())
+    if (_rec_expired and final_reconcile and not skip_routing
+            and (failed_single or failed_multipoint or _custody_nets9
+                 or _victim_retry_names or open_single or _zero_pre9)):
+        print(f"{RED}Final reconciliation SKIPPED: the deadline is spent. "
+              f"The failure lists above are the honest still-open set; rerun "
+              f"with a larger --deadline (or none) to retry them.{RESET}")
     if (final_reconcile and not skip_routing and not _ckpt_stop
+            and not _rec_expired
             and (output_file or return_results)
             and (failed_single or failed_multipoint or _custody_nets9
                  or _victim_retry_names or open_single or _zero_pre9)):
@@ -4516,7 +4550,12 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
             # THIS run; a forwarded flag would re-strip the retried nets'
             # partial copper (and thrash on a second failure).
             _rk.update(final_reconcile=False, skip_routing=False,
-                       force_reroute=False, rip_preexisting=False)
+                       force_reroute=False, rip_preexisting=False,
+                       # run-23: the sub-run IS the tail -- a reserve-banded
+                       # closure here would stop it in the window reserved
+                       # for it.
+                       cancel_check=_tail_cc)
+            _rk.pop('tail_cancel_check', None)
             # #572 (fix direction 2): hand the oracle's EXACT unroutable
             # links to the sub-run as forced edges. Without them the
             # sub-run's model-credited connectivity both skips the custody
@@ -5147,14 +5186,14 @@ if __name__ == "__main__":
     # CMD/EXIT self-echo (run-3 B1). CLI-`__main__`-only by construction: the
     # GUI imports batch_route and never runs this block.
     #
-    # Caveat this banner cannot escape: an EXTERNAL kill (a harness timeout, and
-    # on Windows TerminateProcess in particular) skips `atexit`, so the promised
-    # EXIT= line never arrives. The tool has no self-budget to fall back on --
-    # deliberately, since no result it produces may depend on a wall clock -- so
-    # a harness that kills this process owns that gap. The gap the banner does
-    # close: the convergence-ledger protocol says to paste a tool's own CMD:
-    # line into `converge record --argv`, which was unsatisfiable for a routing
-    # lap -- run 11 hand-wrote replay scripts instead.
+    # This file was a deliberate non-adopter while it had no way to stop itself
+    # -- its long silent phases ended in an external kill, and `atexit` does not
+    # run on one, so the banner would have promised an EXIT= line that never
+    # arrived. `--deadline` is what makes the promise truthful, which is why the
+    # two landed in that order. The gap it closes: the convergence-
+    # ledger protocol says to paste a tool's own CMD: line into
+    # `converge record --argv`, which was unsatisfiable for a routing lap --
+    # run 11 hand-wrote replay scripts instead.
     #
     # NOT under --capabilities, whose whole stdout is ONE JSON document a
     # consumer does `json.loads()` on (see the block near parse_args, and
@@ -5339,6 +5378,22 @@ For differential pair routing, use route_diff.py:
                              "either one alone is wrong -- the first counts every recovery as a "
                              "failure, the second narrows the whole-board pad-pair denominator to "
                              "the retried subset. Prefer this over parsing stdout.")
+    parser.add_argument("--deadline", type=float, default=None, metavar="SECONDS",
+                        help="Wall-clock budget for the ROUTING LOOPS. Not a hard "
+                             "cap on total runtime -- the cancel is cooperative and "
+                             "the bounded tail (write, cleanup, DRC writeback) still "
+                             "runs -- so expect to overshoot. What it guarantees is "
+                             "TERMINATION on THIS tool's terms: it stops between "
+                             "nets, writes the copper it has, and prints a "
+                             "JSON_SUMMARY carrying complete=false / status=deadline "
+                             "before exiting 7. Without it an external kill on "
+                             "Windows is TerminateProcess, which leaves NO summary "
+                             "and NO exit code of ours -- run 11 lost a lap that way "
+                             "and only a re-parse of the output board established "
+                             "the engine had in fact finished. ANY harness with an "
+                             "external timeout should pass this at ~0.8x its own. "
+                             "Default: no budget (a wall-clock default would break "
+                             "replay determinism). Env: KRT_DEADLINE_S")
     parser.add_argument("--neckdown-length", type=float, default=defaults.NECKDOWN_LENGTH,
                         help="Length in mm of narrow track from the target pad on neck-down tap routes; the track "
                              "returns to the power width beyond this where clearance allows (default: 2.5)")
@@ -5964,12 +6019,44 @@ For differential pair routing, use route_diff.py:
             print(f"Netclass clearances for {len(_net_clearances_map)} net(s), {_mode} "
                   f"(mm: {_classes}); cross-class max(A,B) respected.")
 
+    # The deadline is ONE CLOSURE handed to plumbing this engine already has:
+    # `cancel_check` is honoured at every routing/reroute/rescue/cleanup loop
+    # head and forwards into the reconciliation self-invoke via
+    # `_reconcile_kwargs`, and on cancel the loops BREAK rather than raise -- so
+    # the write, the summary and the DRC writeback all still run and a cancelled
+    # run yields a real, gated, partial board rather than nothing. It was None
+    # on the CLI path only because this call never passed one; `progress_callback`
+    # is the same story (built for the GUI, dark on the CLI).
+    #
+    # No `try/finally` and no wrapper: `krt_deadline.arm`'s atexit hook is what
+    # makes "a JSON_SUMMARY on every path" true here, covering the early
+    # `sys.exit`s, argparse errors and unhandled exceptions that this inline
+    # __main__ block has a dozen of. `seal()` below then stops that hook from
+    # contradicting the engine's own summary on a run that finished.
+    import krt_deadline
+    _route_report = {'tool': 'route.py', 'board': args.input_file}
+    _dl = krt_deadline.arm(args.deadline, tool='route',
+                           on_partial=lambda: _route_report)
+
     # --preview: the engine already supports this -- return_results=True with
     # an empty output_file routes fully, mutates only the in-memory PCBData
     # and writes nothing. This just exposes it on the CLI (#459 follow-on).
+    # run-23: a RESERVE BAND, the repair_planes pattern. R4 overshot 732s of
+    # 420 because the routing loop consumed the whole budget and everything
+    # after it (write, plane finalize, oracle, 3 reconcile laps) was pure
+    # overshoot. The routing loops now stop at deadline-minus-reserve; the
+    # tail legs run inside the reserve and carry their own reserve-0 closure
+    # (threaded into plane finalize / oracle / reconcile below), so they stop
+    # AT the deadline instead of never.
+    _reserve = (max(30.0, (args.deadline or 0) * 0.2) if _dl else 0.0)
     _preview_out = batch_route(args.input_file,
                 "" if args.preview else args.output_file, net_names,
                 return_results=args.preview,
+                cancel_check=(_dl.cancel_check('routing', reserve=_reserve)
+                              if _dl else None),
+                tail_cancel_check=(_dl.cancel_check('finalize')
+                                   if _dl else None),
+                progress_callback=krt_deadline.stdout_progress(deadline=_dl),
                 direction_order=args.direction,
                 ordering_strategy=args.ordering,
                 disable_bga_zones=args.no_bga_zones,
@@ -6055,6 +6142,22 @@ For differential pair routing, use route_diff.py:
                 add_teardrops=args.add_teardrops,
                 collect_stats=args.stats)
 
+    # batch_route printed the authoritative JSON_SUMMARY (stamped by
+    # krt_deadline.stamp when the budget was spent). Seal so the atexit flush
+    # does not publish a second, contradicting `incomplete` line after it.
+    krt_deadline.seal()
+    # `stopped_in or expired()`: the durable record that the cancel fired, not
+    # just "the wall clock has since passed". See krt_deadline.stamp.
+    _deadline_hit = bool(_dl and (_dl.stopped_in or _dl.expired()))
+    if _deadline_hit:
+        print(f"{RED}DEADLINE: this run stopped on its own budget after "
+              f"{_dl.elapsed():.0f}s of {_dl.seconds:g}s"
+              + (f" (in {_dl.stopped_in})" if _dl.stopped_in else "")
+              + f". The board at {args.output_file or '(none)'} is a PARTIAL "
+              f"route -- real, gated copper, but nets were left unattempted. "
+              f"Do not read it as clean; the JSON_SUMMARY above carries "
+              f"complete=false.{RESET}")
+
     if args.preview:
         _ok, _fail, _t, _data = _preview_out
         _res = _data.get('results') or []
@@ -6085,7 +6188,7 @@ For differential pair routing, use route_diff.py:
         # run with failed nets also exits 0, so exiting 1 here would make the
         # read-only mode the only one that can kill a `set -e` redo_commands.sh
         # replay -- at a step that changes nothing.
-        sys.exit(0)
+        sys.exit(krt_deadline.DEADLINE_EXIT if _deadline_hit else 0)
     # #600: when the improvement gate reverted the output, it IS the input
     # board -- byte for byte, siblings included. Every post-pass below must
     # stand down: the castellated retract MUTATES the board (so the revert
@@ -6154,4 +6257,12 @@ For differential pair routing, use route_diff.py:
                 persist_same_net_pad_clearance(_pro, args.same_net_pad_clearance)
         except Exception as e:
             print(f"  (skipped protected-nets record: {e})")
+
+    # LAST, and non-zero: the post-passes above are bounded and belong to the
+    # partial board (skipping the DRC writeback would strand the output without
+    # its floor -- the #441 hazard). Exiting 0 here would let a caller read an
+    # unfinished route as a finished one; `complete: false` in the summary is the
+    # machine gate, this is the shell's.
+    if _deadline_hit:
+        sys.exit(krt_deadline.DEADLINE_EXIT)
 

--- a/py_router/route_summary.py
+++ b/py_router/route_summary.py
@@ -21,10 +21,18 @@ import json
 import re
 from typing import Dict, List, Optional
 
-__all__ = ['merge_summaries', 'merge_route_summaries',
-           'SUMMARY_RE', 'RECONCILE_ABORTED', 'EFFORT_KEYS']
+__all__ = ['merge_summaries', 'merge_route_summaries', 'summary_min',
+           'SUMMARY_RE', 'SUMMARY_MIN_RE', 'RECONCILE_ABORTED', 'EFFORT_KEYS']
 
 SUMMARY_RE = re.compile(r'JSON_SUMMARY: (\{.*\})')
+
+# run-23: the one-line compact tally route.py prints at the end of every
+# OUTERMOST run (CLI and GUI alike). The big JSON_SUMMARY lines measured
+# 6-20KB each, several per log with scope semantics the log itself warns
+# about; every agent that consumed them paid that in context, per lap. This
+# line is the authoritative merged verdict in <1KB. The trailing colon-space
+# differs from SUMMARY_RE's subject, so neither regex can eat the other.
+SUMMARY_MIN_RE = re.compile(r'JSON_SUMMARY_MIN: (\{.*\})')
 
 # route.py prints this from the except around its reconciliation self-invoke.
 # The sub-run prints its JSON_SUMMARY BEFORE the board is written, so a summary
@@ -133,12 +141,19 @@ def merge_summaries(summaries: List[Dict], aborted: bool = False) -> Optional[Di
                 merged['pad_pairs_connected'] = first.get('pad_pairs_connected', 0)
                 if 'pad_pairs_open' in first:
                     merged['pad_pairs_open'] = first['pad_pairs_open']
-        if 'blockers' in first and 'blockers' not in merged:
-            _failed = set(merged.get('failed_single') or [])
-            _failed |= {d.get('net_name') if isinstance(d, dict) else d
-                        for d in (merged.get('failed_multipoint') or [])}
-            merged['blockers'] = [e for e in first['blockers']
-                                  if e.get('net') in _failed]
+        # `blockers` and `boxed_in` are both first-pass attribution: the
+        # reconcile sub-run re-routes a SUBSET and its summary carries neither,
+        # so without this a merged summary loses the evidence for nets that are
+        # still failing. Filtered to the nets that ARE still failing, so a net
+        # the reconcile fixed does not carry a stale accusation.
+        _failed = None
+        for _k in ('blockers', 'boxed_in'):
+            if _k in first and _k not in merged:
+                if _failed is None:
+                    _failed = set(merged.get('failed_single') or [])
+                    _failed |= {d.get('net_name') if isinstance(d, dict) else d
+                                for d in (merged.get('failed_multipoint') or [])}
+                merged[_k] = [e for e in first[_k] if e.get('net') in _failed]
 
     # Coverage-gate nets have NO routed result, so their pads never reach
     # multipoint_pads_total and a caller's
@@ -168,3 +183,50 @@ def merge_route_summaries(log: str) -> Optional[Dict]:
     summaries = [json.loads(s) for s in raw]
     aborted = log.rfind(RECONCILE_ABORTED) > log.rfind(raw[-1])
     return merge_summaries(summaries, aborted)
+
+
+def summary_min(merged: Dict, name_cap: int = 20) -> Dict:
+    """The <1KB verdict an agent reads INSTEAD of the big summaries.
+
+    Every value here is derived from the MERGED tally, so it carries the
+    "run-scope plus recoveries" semantics automatically -- the trap the log
+    warns about ("never scrape the LAST JSON_SUMMARY") cannot be re-imported
+    through this line. Name lists are capped at `name_cap` with an explicit
+    '+N more' marker, never silently truncated.
+
+    Deliberately ABSENT: power_widths, ampacity, stacked copper --
+    forensics that stay in the big summaries / --json-out. And the DRC-floor
+    writeback verdict, which does not exist yet when this prints: the
+    writeback runs afterwards and reports on its own, so a consumer must
+    read both -- this line says nothing about whether the floors held.
+    """
+    def _names(vals) -> List[str]:
+        names = [str(v) for v in (vals or [])]
+        if len(names) > name_cap:
+            return names[:name_cap] + [f'+{len(names) - name_cap} more']
+        return names
+
+    pairs = merged.get('pad_pairs_open') or []
+    tr = merged.get('terminal_restores') or {}
+    broken_restores = sorted(n for n, v in tr.items()
+                             if v in ('full_open', 'stub'))
+    total = merged.get('multipoint_pads_total') or 0
+    conn = merged.get('multipoint_pads_connected') or 0
+    return {
+        'scope': 'merged',
+        'complete': merged.get('complete', True),
+        'status': merged.get('status', 'ok'),
+        'routed': merged.get('successful'),
+        'failed': merged.get('failed'),
+        'failed_single': _names(merged.get('failed_single')),
+        'open_single': _names(merged.get('open_single')),
+        'multipoint_deficit': max(0, total - conn),
+        'pad_pairs_open': {
+            'count': len(pairs),
+            'nets': _names(sorted({p.get('net') for p in pairs
+                                   if p.get('net')}))},
+        'terminal_restores_broken': _names(broken_restores),
+        'min_clearance_used': merged.get('min_clearance_used'),
+        'vias': merged.get('total_vias'),
+        'duration_s': merged.get('elapsed_s') or merged.get('total_time'),
+    }

--- a/py_router/routing_diagnostics.py
+++ b/py_router/routing_diagnostics.py
@@ -540,7 +540,7 @@ def preexisting_blocker_hint(blocked_cells, config, pcb_data, net_id,
             f"cannot be), then bisect if you want a minimal rip." + prot_txt, names)
 
 
-def static_boxin_hint(result, config, pcb_data=None) -> str:
+def static_boxin_hint(result, config, pcb_data=None, *, return_verdict=False):
     """One-line hint when a route died immediately with nothing rippable.
 
     A failure with almost no A* iterations and no rippable blockers means the
@@ -548,12 +548,22 @@ def static_boxin_hint(result, config, pcb_data=None) -> str:
     clearance expansion) - typical for fine-pitch (0.4-0.65 mm) packages at
     coarse grid/clearance settings - not by other nets' routes (issue #95).
     Returns '' when the failure doesn't match that signature.
+
+    `return_verdict=True` returns `(hint, verdict_or_None)` -- the same shape
+    `preexisting_blocker_hint`'s `return_names=True` already uses. The verdict
+    is the whole static-vs-congestion decision, which this function computes in
+    two lines and then FORMATS INTO A STRING. Run 20 printed that string on
+    every residual failure while three grid refinements were spent against it,
+    because nothing downstream could read a sentence.
     """
+    def _ret(hint, verdict=None):
+        return (hint, verdict) if return_verdict else hint
+
     if result is None:
-        return ""
+        return _ret("")
     iters = result.get('iterations_forward', 0) + result.get('iterations_backward', 0)
     if iters >= 20000:
-        return ""
+        return _ret("")
     finer = config.grid_step / 2
     # Don't steer users into an OOM (issue #105): halving the grid step
     # quadruples cell count. Above ~4M cells per layer, suggest scoping the
@@ -566,10 +576,90 @@ def static_boxin_hint(result, config, pcb_data=None) -> str:
             grid_advice = (f"--grid-step {finer:g} scoped to just the failing nets "
                            f"via --nets (board-global it is ~{cells / 1e6:.0f}M "
                            f"cells/layer and may exhaust memory)")
-    return (f"Hint: search exhausted after only {iters} iterations with no rippable "
-            f"blockers - the start/target pads are boxed in by static obstacles "
-            f"(neighboring pads + clearance), not by congestion. For fine-pitch "
-            f"parts try a finer grid and/or smaller clearance/track, e.g. "
-            f"{grid_advice} --clearance 0.15 --track-width 0.15 "
-            f"(current: grid {config.grid_step:g}, clearance {config.clearance:g}, "
-            f"track {config.track_width:g} mm)")
+    # WHAT TO ADVISE depends on whether the geometry has anywhere left to go.
+    # The old text hardcoded `--clearance 0.15 --track-width 0.15` regardless of
+    # `config`, so on run 20 -- routing at exactly 0.15/0.15 -- it advised the
+    # values already in force, and the only novel token in the whole hint was
+    # the grid. Three grid refinements followed, ~40 minutes, with the same
+    # three nets failing at every resolution.
+    #
+    # The floor is the BOARD's own declaration, not the fab minimum. Going
+    # below what the board declares is the ratchet this repo keeps
+    # rediscovering -- a run that "finds travel" by routing under the board's
+    # own class has not found travel, it has moved the goalposts and every
+    # later grader then reads clean. Measured on run 20: at the fab rung
+    # (0.0762 track) there is apparent room; at the board's declared 0.15 there
+    # is none, and none was the truth.
+    _floor_c = _floor_t = None
+    _src = getattr(pcb_data, 'source_path', None) if pcb_data is not None else None
+    if _src:
+        try:
+            from list_nets import board_floor, read_design_rules
+            _dr = read_design_rules(_src)
+            _floor_c = board_floor(_src, 'clearance', design_rules=_dr)[0]
+            _floor_t = board_floor(_src, 'track_width', design_rules=_dr)[0]
+        except Exception:                                   # noqa: BLE001
+            _floor_c = _floor_t = None
+    _has_c = _floor_c is not None and config.clearance > _floor_c + 1e-9
+    _has_t = _floor_t is not None and config.track_width > _floor_t + 1e-9
+    # BOTH axes, not either. `or` here asserted "at the floor" from ONE readable
+    # floor -- so a board declaring min_track_width but no netclass (clearance
+    # has no board-constraint fallback in list_nets._FLOOR_SOURCES) reported
+    # at_floor TRUE while running at clearance 0.90 against a 0.15 track floor,
+    # and L4 REFUSED the parameter lever on it. Dropping `--clearance 0.9` was
+    # precisely the working move. An axis whose floor cannot be read may have
+    # travel; the honest answer there is UNKNOWN, which refuses nothing.
+    _both_read = _floor_c is not None and _floor_t is not None
+    if _both_read and not (_has_c or _has_t):
+        _at = ', '.join(
+            f'{k} {v:g}' for k, v in (('clearance', _floor_c),
+                                      ('track', _floor_t)) if v is not None)
+        _advice = (
+            f"the geometry is ALREADY at this board's declared floor ({_at}), "
+            + f"so there is nothing left to pair a finer grid with. A finer "
+              f"grid alone resolves the SAME obstacles more precisely -- it "
+              f"does not make the gap wider. THIS IS A PLACEMENT/FLOORPLAN "
+              f"FINDING, NOT A PARAMETER ONE: measure it with "
+              f"check_reachability on the COPPER-FREE board and re-enter "
+              f"placement")
+    else:
+        _room = []
+        if _has_c:
+            _room.append(f"--clearance {_floor_c:g}")
+        if _has_t:
+            _room.append(f"--track-width {_floor_t:g}")
+        _advice = (
+            f"for fine-pitch parts try a finer grid PAIRED with the geometry "
+            f"that still has travel, e.g. {grid_advice}"
+            + (' ' + ' '.join(_room) if _room else '')
+            + (" (the grid is the COMPLEMENT, never the lever on its own)"
+               if _room else
+               " -- no declared floor was readable here, so whether the "
+               "geometry has travel is unknown; check the board's netclass "
+               "before spending a grid lap"))
+    return _ret(
+        f"Hint: search exhausted after only {iters} iterations with no rippable "
+        f"blockers - the start/target pads are boxed in by static obstacles "
+        f"(neighboring pads + clearance), not by congestion. {_advice} "
+        f"(current: grid {config.grid_step:g}, clearance {config.clearance:g}, "
+        f"track {config.track_width:g} mm)",
+        # The verdict, as data. `geometry` is what was IN FORCE -- whether that
+        # is at the board's floor is a question this function cannot answer
+        # (it holds a config, not a project), so it publishes the numbers and
+        # lets the guard that does hold the floors decide.
+        {'verdict': 'boxed_in_static', 'iterations': iters,
+         'geometry': {'grid_step': config.grid_step,
+                      'clearance': config.clearance,
+                      'track_width': config.track_width,
+                      'via_diameter': getattr(config, 'via_diameter', None)},
+         # The floors the geometry was compared against, and the ANSWER. The
+         # guard at L4 must not re-derive this: two instruments deriving one
+         # verdict two ways is how the same board gets classified twice.
+         # `at_floor` is None when no floor could be read -- unknown, never a
+         # silent False.
+         'floors': {'clearance': _floor_c, 'track_width': _floor_t},
+         # False when SOME axis provably has travel; True only when BOTH floors
+         # were read and neither does; None when an unread floor leaves it
+         # genuinely unknown. The guard at L4 refuses only on True.
+         'at_floor': (False if (_has_c or _has_t)
+                      else (True if _both_read else None))})

--- a/py_router/single_ended_loop.py
+++ b/py_router/single_ended_loop.py
@@ -1457,11 +1457,18 @@ def route_single_ended_nets(
                 from routing_diagnostics import (static_boxin_hint,
                                                  preexisting_blocker_hint,
                                                  condense_hint)
-                hint = static_boxin_hint(result, config, pcb_data)
+                hint, _boxin = static_boxin_hint(result, config, pcb_data,
+                                                 return_verdict=True)
                 if hint:
                     hint = condense_hint(hint)
                     if hint:
                         print(f"  {hint}")
+                if _boxin:
+                    # The verdict, not just the sentence. `preexisting_blockers`
+                    # below has been recorded and serialized since #301; this
+                    # one -- the static-vs-congestion decision the whole retry
+                    # ladder turns on -- was print-only.
+                    record_net_event(state, net_id, "boxed_in_static", _boxin)
                 # #301: the blockers may be PRE-EXISTING copper (earlier run/
                 # step) the rip-up attribution cannot see -- name them and the
                 # --rip-existing-nets retry. Cells were popped into

--- a/py_tools/check_reachability.py
+++ b/py_tools/check_reachability.py
@@ -113,6 +113,58 @@ def _resolve_pad(pcb, spec):
     return p.global_x, p.global_y, p.net_id, layer
 
 
+def _relief_for(pcb, r, track_mm, clearance):
+    """"So what do I DO?" -- how far the blocking part must move, or nothing.
+
+    Deliberately narrow. It answers only when the two nearest things at the
+    throat are pads belonging to two DIFFERENT footprints, because that is the
+    only case where "move this part" is the shape of the answer. A throat formed
+    by a segment, a via, or two pads of the same part is a different question
+    (rip that copper, re-fan that part) and returning a plausible-looking
+    distance for it would be a wrong instruction, which is worse than none.
+
+    The distance is between the two FOOTPRINT pad bounding boxes, and the need
+    is in GAP space: `track + 2*clearance`, not the track width. Reporting a
+    track-space number here would ask for a move roughly 2*clearance too small.
+    """
+    near = getattr(r, 'near', ()) or ()
+    if len(near) < 2:
+        return []
+    a, b = near[0], near[1]
+    if a.get('kind') != 'pad' or b.get('kind') != 'pad':
+        return []
+    if not a.get('ref') or not b.get('ref') or a['ref'] == b['ref']:
+        return []
+
+    def _bbox(ref):
+        fp = pcb.footprints.get(ref)
+        if not fp or not fp.pads:
+            return None
+        xs0 = [p.global_x - p.size_x / 2.0 for p in fp.pads]
+        ys0 = [p.global_y - p.size_y / 2.0 for p in fp.pads]
+        xs1 = [p.global_x + p.size_x / 2.0 for p in fp.pads]
+        ys1 = [p.global_y + p.size_y / 2.0 for p in fp.pads]
+        return (min(xs0), min(ys0), max(xs1), max(ys1))
+
+    ra, rb = _bbox(a['ref']), _bbox(b['ref'])
+    if not ra or not rb:
+        return []
+    from placement.routability import relief_move
+    need = track_mm + 2.0 * clearance
+    # BOTH movers, not one. The pair is symmetric as geometry but not as a
+    # decision: these are whole-footprint bounding boxes, so a 100-pin QFN and
+    # the 0402 beside it give different distances for the same throat, and
+    # naming only the first-listed one hands the operator "move the QFN" when
+    # nudging the resistor is the cheap answer. Sorted so the smallest move
+    # leads, and each entry says WHICH part it is asking to move.
+    out = [dict(m, ref=b['ref'], against=a['ref'], need_mm=round(need, 5))
+           for m in relief_move(ra, rb, need)]
+    out += [dict(m, ref=a['ref'], against=b['ref'], need_mm=round(need, 5))
+            for m in relief_move(rb, ra, need)]
+    out.sort(key=lambda m: m['min_mm'])
+    return out
+
+
 def main(argv=None):
     p = argparse.ArgumentParser(
         description=__doc__,
@@ -144,7 +196,25 @@ def main(argv=None):
                         "(default 4.0). Reachability is LOCAL; a whole board "
                         "at 10um costs memory for nothing")
     p.add_argument('--view', default=None, help="x0,y0,x1,y1 to override")
-    p.add_argument('--json', action='store_true')
+    p.add_argument('--json', action='store_true',
+                   help="dump the result dict to STDOUT. NOTE stdout also "
+                        "carries this tool's CMD: banner and any parser "
+                        "warning, so `json.load(stdout)` fails at char 0 -- "
+                        "use --json-out for a machine-readable answer.")
+    p.add_argument('--defect-json', metavar='PATH', default=None,
+                   help="write a `defect-record` document here when the "
+                        "verdict is CAGED: the throat coordinates, the "
+                        "blocking refs, the shortfall in BOTH spaces, and a "
+                        "relief distance. render_placement --defect-json draws "
+                        "it; converge record --defect-json carries it; "
+                        "loop_driver L3/L4 read it. Nothing is written for a "
+                        "PASSABLE or NO-TARGET measurement -- a record "
+                        "describes a defect.")
+    p.add_argument('--json-out', metavar='PATH', default=None,
+                   help="write the result dict to PATH. This is the "
+                        "machine-readable channel (the convention every other "
+                        "tool here uses); stdout stays human. Combines with "
+                        "the text output rather than replacing it.")
     args = p.parse_args(argv)
 
     from kicad_parser import parse_kicad_pcb  # _path put py_router on sys.path
@@ -197,14 +267,21 @@ def main(argv=None):
         dr = list_nets.read_design_rules(args.board)
     except Exception:                             # noqa: BLE001
         dr = None
-    def _board(key, fallback):
-        v = list_nets.board_default_netclass_param(args.board, key, dr)
-        return float(v) if v else fallback
-    clearance = args.clearance if args.clearance is not None else _board(
-        'clearance', 0.2)
-    track = args.track if args.track is not None else _board('track_width',
-                                                             0.15)
-    via = args.via if args.via is not None else _board('via_diameter', 0.6)
+    # `board_floor` rather than a local closure: it returns the SOURCE beside
+    # the value ('cli' | 'board netclass' | 'board constraint' | 'fixed
+    # default'), which is what lets the defect record say where each floor came
+    # from instead of publishing three bare numbers a reader cannot audit.
+    floors = {}
+
+    def _board(key, explicit, fallback, label=None):
+        v, src = list_nets.board_floor(args.board, key, explicit=explicit,
+                                       fallback=fallback, design_rules=dr)
+        floors[label or key] = {'value': v, 'source': src}
+        return v
+
+    clearance = _board('clearance', args.clearance, 0.2)
+    track = _board('track_width', args.track, 0.15)
+    via = _board('via_diameter', args.via, 0.6)
     try:
         net_clearances = list_nets.net_clearance_map_by_id(
             args.board, {i: n.name for i, n in pcb.nets.items()}, dr)
@@ -237,12 +314,69 @@ def main(argv=None):
                   f"{args.view!r}", file=sys.stderr)
             return 2
 
+    auto_widened = None
     try:
         r = reachability.pad_reachability(
             pcb, seed, net_name=args.net, net_id=net_id, layers=layers,
             view=view, track_mm=track, via_mm=via, base_clearance=clearance,
             net_clearances=net_clearances, step=args.step,
             margin_mm=args.margin)
+        # run-23: NO-TARGET at the default view means the net's other island
+        # sits beyond --margin, NOT that the question is unanswerable -- and
+        # the manual retry ladder measured badly (--margin 12 took 128s,
+        # --margin 18 306s, --margin 25 timed out at 10 minutes with NO
+        # data, because cells scale as (span/step)^2 at the fixed step).
+        # Locate the nearest other island by VECTOR union-find (no raster),
+        # widen the view to hold seed + its closest point, and coarsen the
+        # step so the grid stays ~1200^2 whatever the span. Coarse-locate;
+        # the step used rides in the result so readings stay comparable --
+        # re-measure a found throat on a small box at native step.
+        if (r.target_cells == 0 and view is None
+                and net_id is not None):
+            import math as _math
+            from net_forensics import _components
+            sx, sy = seed
+            best = None
+            own_d, own_i = None, None
+            comp_pts = []
+            for comp in _components(pcb, net_id):
+                pts = [p for _k, _o, ps in comp for p in ps]
+                if not pts:
+                    continue
+                d = min(_math.hypot(px - sx, py - sy) for px, py in pts)
+                comp_pts.append((d, pts))
+                if own_d is None or d < own_d:
+                    own_d, own_i = d, len(comp_pts) - 1
+            for i, (_d, pts) in enumerate(comp_pts):
+                if i == own_i:
+                    continue
+                for px, py in pts:
+                    dd = _math.hypot(px - sx, py - sy)
+                    if best is None or dd < best[0]:
+                        best = (dd, px, py)
+            if best is not None:
+                _d, px, py = best
+                x0 = min(sx, px) - args.margin
+                x1 = max(sx, px) + args.margin
+                y0 = min(sy, py) - args.margin
+                y1 = max(sy, py) + args.margin
+                span = max(x1 - x0, y1 - y0)
+                step2 = max(args.step, span / 1200.0)
+                print(f"  NO-TARGET at the default +/-{args.margin:g}mm "
+                      f"view; nearest other island of this net is "
+                      f"{best[0]:.2f}mm away -- auto-widening to "
+                      f"[{x0:.1f},{y0:.1f},{x1:.1f},{y1:.1f}] at step "
+                      f"{step2:g}mm")
+                r = reachability.pad_reachability(
+                    pcb, seed, net_name=args.net, net_id=net_id,
+                    layers=layers, view=[x0, y0, x1, y1], track_mm=track,
+                    via_mm=via, base_clearance=clearance,
+                    net_clearances=net_clearances, step=step2,
+                    margin_mm=args.margin)
+                auto_widened = {
+                    'view': [round(v, 2) for v in (x0, y0, x1, y1)],
+                    'step_mm': round(step2, 4),
+                    'nearest_island_mm': round(best[0], 2)}
     except reachability.ScipyRequired as exc:
         print(str(exc), file=sys.stderr)
         return 2
@@ -251,13 +385,77 @@ def main(argv=None):
         return 2
 
     source = 'from --flags' if args.clearance is not None else 'from the board'
+    if args.defect_json:
+        _sha = None
+        try:
+            import hashlib
+            with open(args.board, 'rb') as _fh:
+                _sha = hashlib.sha256(_fh.read()).hexdigest()
+        except OSError:
+            pass
+        _relief = []
+        # A relief distance needs two RECTS, and this tool measures a raster
+        # throat -- so it is offered only when the two nearest things are pads
+        # whose footprints we can bound. Absent rather than guessed: a wrong
+        # "move R7 east by X" is worse than no instruction.
+        try:
+            _relief = _relief_for(pcb, r, track_mm=track, clearance=clearance)
+        except Exception:                                   # noqa: BLE001
+            _relief = []
+        doc = r.defect_record(board=args.board, board_sha=_sha,
+                              relief=_relief, floors=floors)
+        if doc is None:
+            print(f"  no defect record written to {args.defect_json}: this "
+                  f"measurement is {r.to_dict()['verdict']}, and a record "
+                  f"describes a DEFECT")
+        else:
+            try:
+                with open(args.defect_json, 'w', encoding='utf-8') as fh:
+                    json.dump(doc, fh, indent=1)
+                print(f"  DEFECT RECORD -> {args.defect_json}")
+            except OSError as exc:
+                print(f"  could not write {args.defect_json}: {exc}",
+                      file=sys.stderr)
+    _doc = r.to_dict()
+    if auto_widened:
+        # The reading is only comparable at its own step -- say which.
+        _doc['auto_widened'] = auto_widened
+    if args.json_out:
+        try:
+            with open(args.json_out, 'w', encoding='utf-8') as fh:
+                json.dump(_doc, fh, indent=2)
+            print(f"  JSON -> {args.json_out}")
+        except OSError as exc:
+            print(f"  could not write {args.json_out}: {exc}", file=sys.stderr)
     if args.json:
-        print(json.dumps(r.to_dict(), indent=2))
+        print(json.dumps(_doc, indent=2))
     else:
         print(f"board      {os.path.basename(args.board)}")
         print(f"knobs      clearance {clearance}mm, track {track}mm, "
               f"via {via}mm ({source})")
         print(r.format_text())
+        # WHERE, beside how much. The number alone sent run 20 to two more
+        # tools and a hand-assembled paragraph.
+        _t = r.throat
+        if _t:
+            _who = ', '.join(n.get('pad') or f"{n['kind']}@{n['net']}"
+                             for n in (r.near or ()))
+            print(f"throat     ({_t['x']}, {_t['y']}) on {_t['layer']}"
+                  + (f"  between {_who}" if _who else ''))
+            if r.gap_mm is not None:
+                print(f"           gap {r.gap_mm:.4f}mm vs "
+                      f"{r.track_mm + 2 * r.clearance_mm:.4f}mm needed "
+                      f"(gap space); track {r.bottleneck_mm:.4f} vs "
+                      f"{r.track_mm:.4f} (track space) -- same throat, two "
+                      f"spaces, related by 2 x clearance {r.clearance_mm}")
+            if r.caged:
+                _side = max(0.5, 4.0 * (r.track_mm - (r.bottleneck_mm or 0.0)))
+                print(f"look at it:\n"
+                      f"  python3 -X utf8 py_tools/render_placement.py "
+                      f"{os.path.basename(args.board)} --focus \\\n"
+                      f"      --view {_t['x'] - _side / 2:.3f},"
+                      f"{_t['y'] - _side / 2:.3f},{_t['x'] + _side / 2:.3f},"
+                      f"{_t['y'] + _side / 2:.3f} --size 1600")
         if r.target_cells and not r.caged:
             print("\nPASSABLE means a route EXISTS at this width. If the "
                   "router failed here, that is a finding about the router "

--- a/py_tools/net_forensics.py
+++ b/py_tools/net_forensics.py
@@ -161,6 +161,38 @@ def _history(net_name, log_path, out):
         out(f"  (log unreadable: {e})")
 
 
+def net_data(pcb, net):
+    """The islands-and-gap facts as DATA (run-23): what _describe prints.
+
+    Exists because this tool was text-only, so run 23's teammates re-derived
+    the island gap by hand to feed their rip-set decisions -- the number
+    (/TXLED's 20.27mm span) lived in a paragraph nothing could consume.
+    """
+    comps = _components(pcb, net.net_id)
+    doc = {'net': net.name, 'net_id': net.net_id, 'islands': [], 'gap': None}
+    for c in comps:
+        doc['islands'].append({
+            'segs': sum(1 for k, _, _ in c if k == 'seg'),
+            'vias': sum(1 for k, _, _ in c if k == 'via'),
+            'pads': [f"{o.component_ref}.{o.pad_number}"
+                     for k, o, _ in c if k == 'pad'],
+            'layers': sorted({o.layer for k, o, _ in c if k == 'seg'})})
+    if len(comps) >= 2:
+        best = (9e9, None, None)
+        for _k, _o, ps in comps[0]:
+            for p1 in ps:
+                for _k2, _o2, ps2 in comps[1]:
+                    for p2 in ps2:
+                        d = math.hypot(p1[0] - p2[0], p1[1] - p2[1])
+                        if d < best[0]:
+                            best = (d, p1, p2)
+        d, p1, p2 = best
+        doc['gap'] = {'mm': round(d, 3),
+                      'from': [round(p1[0], 3), round(p1[1], 3)],
+                      'to': [round(p2[0], 3), round(p2[1], 3)]}
+    return doc
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__.split('\n')[0])
     ap.add_argument('board')
@@ -168,6 +200,10 @@ def main():
     ap.add_argument('--radius', type=float, default=1.0)
     ap.add_argument('--route-log', action='append', default=[])
     ap.add_argument('--log', help='also append the report to this file')
+    ap.add_argument('--json', metavar='PATH', default=None,
+                    help='also write {nets: [islands+gap docs]} here '
+                         '(run-23: the gap number was text-only and had to '
+                         'be re-derived by hand to feed rip-set decisions)')
     args = ap.parse_args()
 
     from kicad_parser import parse_kicad_pcb
@@ -179,15 +215,24 @@ def main():
         if sink:
             sink.write(line + '\n')
 
+    docs = []
     out(f"# net_forensics: {args.board}")
     for nm in args.nets:
         net = next((x for x in pcb.nets.values() if x.name == nm), None)
         if net is None:
             out(f"\n=== {nm}: NOT FOUND ===")
+            docs.append({'net': nm, 'error': 'not found'})
             continue
         _describe(pcb, net, args.radius, out)
+        docs.append(net_data(pcb, net))
         for lp in args.route_log:
             _history(nm, lp, out)
+    if args.json:
+        import json as _json
+        with open(args.json, 'w', encoding='utf-8') as f:
+            _json.dump({'board': args.board, 'nets': docs}, f, indent=1,
+                       sort_keys=True)
+        out(f"  JSON -> {args.json}")
     if sink:
         sink.close()
 

--- a/tests/test_boxed_in_summary.py
+++ b/tests/test_boxed_in_summary.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""The static-vs-congestion verdict stops being a sentence.
+
+The router has printed "boxed in by static obstacles (neighboring pads +
+clearance), not by congestion" on this failure shape since #95. Run 20 spent
+three grid refinements against exactly that sentence -- 0.05 -> 0.025 -> 0.0125,
+about 40 minutes, with the same three nets failing at every resolution -- because
+a sentence is not something a gate can read. Its sibling
+`preexisting_blocker_hint` has been recorded via `record_net_event` and
+serialized since #301; this one, the decision the whole retry ladder turns on,
+was print-only.
+
+THE INVARIANT THIS FILE EXISTS FOR: `summary['boxed_in']` is a SEPARATE key that
+adds NOTHING to `summary['blockers']`. The routing skill's classifier row is
+"`blockers` empty; the log says boxed in", so a verdict that leaked into
+`blockers` would silently turn every box-in into a congestion finding -- breaking
+the very clause being fixed. The row becomes "`blockers` empty AND `boxed_in`
+names the net": one JSON test, no regex.
+
+Note the invariant is NOT "`blockers` is empty on this fixture". It is not: the
+frontier analysis legitimately attributes the static WALL, because since e2ffa29
+pre-existing copper is rip-candidate and therefore attributable. The two keys
+answer different questions -- WHICH copper is in the way, versus whether anything
+RIPPABLE is in the way at all -- and the test asserts they keep their own schemas.
+
+    python3 tests/test_boxed_in_summary.py
+"""
+import io
+import json
+import os
+import re
+import sys
+from contextlib import redirect_stdout
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+_R = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for _p in (_R, os.path.join(_R, 'py_router'), os.path.join(_R, 'py_tools')):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from kicad_parser import BoardInfo                                # noqa: E402
+from synth import make_net, make_pad, make_pcb, make_seg          # noqa: E402
+
+X, WALL = 1, 2
+CHECKS = []
+
+
+def check(name, ok, detail=''):
+    CHECKS.append((name, ok))
+    print(f"  {'PASS' if ok else 'FAIL'}: {name}" + (f' -- {detail}' if not ok else ''))
+
+
+def _board():
+    """X's source pad sealed inside a box of STATIC copper.
+
+    Static on purpose: the wall is pre-existing and out of scope, and with
+    `max_rip_up_count=0` nothing is rippable at all. That is the exact
+    signature -- a search that dies in almost no iterations with no rippable
+    blockers -- and it is a geometry fact, not a congestion one.
+    """
+    bi = BoardInfo(layers={0: 'F.Cu', 31: 'B.Cu'},
+                   copper_layers=['F.Cu', 'B.Cu'],
+                   board_bounds=(0.0, 0.0, 10.0, 10.0))
+    pads = {X: [make_pad(X, 2.0, 5.0, ref='U1', num='1', net_name='X',
+                         size_x=0.3, size_y=0.3),
+                make_pad(X, 8.0, 5.0, ref='U2', num='1', net_name='X',
+                         size_x=0.3, size_y=0.3)],
+            WALL: []}
+    # A sealed box around the source pad, on BOTH layers so a via cannot
+    # escape either.
+    segs = []
+    for lay in ('F.Cu', 'B.Cu'):
+        segs += [make_seg(1.4, 4.4, 2.6, 4.4, net_id=WALL, width=0.4, layer=lay),
+                 make_seg(1.4, 5.6, 2.6, 5.6, net_id=WALL, width=0.4, layer=lay),
+                 make_seg(1.4, 4.4, 1.4, 5.6, net_id=WALL, width=0.4, layer=lay),
+                 make_seg(2.6, 4.4, 2.6, 5.6, net_id=WALL, width=0.4, layer=lay)]
+    return make_pcb(nets={X: make_net(X, 'X'), WALL: make_net(WALL, 'WALL')},
+                    segments=segs, pads_by_net=pads, board_info=bi)
+
+
+def main():
+    from route import batch_route
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        _ok, _fail, _t, results_data = batch_route(
+                    'synthetic', '', ['X'], layers=['F.Cu', 'B.Cu'],
+                    clearance=0.2, track_width=0.2, via_size=0.5,
+                    via_drill=0.3, grid_step=0.1,
+                    ordering_strategy='original', final_reconcile=False,
+                    max_rip_up_count=0, return_results=True, pcb_data=_board())
+    out = buf.getvalue()
+    m = re.findall(r'JSON_SUMMARY: (\{.*\})', out)
+    check('JSON_SUMMARY present', bool(m))
+    summary = json.loads(m[-1]) if m else {}
+
+    check('X failed to route (the fixture is a cage, not a routable board)',
+          'X' in (summary.get('failed_single') or []),
+          str(summary.get('failed_single')))
+
+    boxed = summary.get('boxed_in')
+    if not isinstance(boxed, list):
+        check("summary carries a 'boxed_in' key", False,
+              f'{boxed!r} -- the hint printed: '
+              + ('yes' if 'boxed in by static obstacles' in out else 'NO, so '
+                 'this fixture no longer reproduces the signature and the test '
+                 'is measuring nothing'))
+    else:
+        check("summary carries a 'boxed_in' key", True)
+        check('it names the failing net',
+              [e.get('net') for e in boxed] == ['X'], str(boxed))
+        e = boxed[0]
+        check("the verdict is 'boxed_in_static'",
+              e.get('verdict') == 'boxed_in_static', str(e))
+        check('it carries the iteration count the decision was made on',
+              isinstance(e.get('iterations'), int) and e['iterations'] < 20000,
+              str(e.get('iterations')))
+        g = e.get('geometry') or {}
+        check('and the geometry that was IN FORCE, so a guard can ask whether '
+              'it is at the board floor',
+              abs((g.get('grid_step') or 0) - 0.1) < 1e-9
+              and abs((g.get('clearance') or 0) - 0.2) < 1e-9
+              and abs((g.get('track_width') or 0) - 0.2) < 1e-9, str(g))
+
+    # THE INVARIANT, stated correctly. It is NOT "`blockers` is empty" -- on
+    # this fixture the frontier analysis legitimately attributes the WALL, and
+    # since e2ffa29 pre-existing copper is rip-candidate and so attributable.
+    # The invariant is that `boxed_in` is a SEPARATE key that adds nothing to
+    # `blockers`: the skill's classifier row reads both, and a verdict that
+    # leaked into `blockers` would silently turn every box-in into a
+    # congestion finding -- breaking the clause this key exists to make
+    # readable.
+    _bl = summary.get('blockers') or []
+    check("no `blockers` entry carries a boxed-in verdict",
+          all(set(b) <= {'net', 'stage', 'blocked_by'} for b in _bl),
+          f'{[sorted(b) for b in _bl]} -- `blockers` entries must keep exactly '
+          f'their #409/#301 schema')
+    check('and no `boxed_in` entry carries blocker attribution',
+          all('blocked_by' not in e for e in (boxed if isinstance(boxed, list)
+                                              else [])),
+          str(boxed) + ' -- the two answer different questions: WHICH copper '
+          'is in the way, versus whether anything rippable is in the way at all')
+
+    # GUI parity: the plugin reads results_data, never the printed summary.
+    check('results_data carries the same boxed_in (GUI parity)',
+          results_data.get('boxed_in') == summary.get('boxed_in'),
+          f'{results_data.get("boxed_in")!r} vs {summary.get("boxed_in")!r}')
+
+    # And the prose is still printed, because a human reading a log is still a
+    # consumer -- the key is additive, not a replacement.
+    check('the human-readable hint is still printed',
+          'boxed in by static obstacles' in out, out[-400:])
+
+    bad = [n for n, ok in CHECKS if not ok]
+    print(f"\n{len(CHECKS) - len(bad)} passed, {len(bad)} failed")
+    return 1 if bad else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_deadline.py
+++ b/tests/test_deadline.py
@@ -1,0 +1,131 @@
+"""The deadline contract: a stage that stops itself must SAY so, and a partial
+must be exactly as fatal as no result at all.
+
+Run 9 lost two stages to an external `timeout`: no output board, no
+JSON_SUMMARY, and an exit code belonging to the shell rather than the tool. The
+fix lets a stage stop on its own budget -- which introduces a NEW hazard the
+tests below exist to pin: a partial summary PARSES, so a consumer that only
+checked "is there a summary" would now silently accept an unfinished run's
+tallies as a whole board's. That would be quieter, and worse, than the failure
+it replaced.
+
+    python3 -X utf8 tests/test_deadline.py
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_placer'))  # #522/py_placer layout
+sys.path.insert(0, os.path.join(ROOT, 'py_tools'))  # #522/py_placer layout
+
+BAD = []
+
+
+def want(cond, label):
+    print(f"  {'PASS' if cond else 'FAIL'}  {label}")
+    if not cond:
+        BAD.append(label)
+
+
+def test_deadline_primitives():
+    import krt_deadline as K
+    K.reset_for_test()
+    want(K.arm(None, tool='t') is None,
+         'no budget -> arm() returns None, so callers pay nothing')
+    K.reset_for_test()
+    d = K.arm(0, tool='t')
+    want(d is not None and d.expired(),
+         '--deadline 0 is a real budget (stop now), not an absent one')
+    K.reset_for_test()
+    d = K.Deadline(1.0, tool='t')
+    want(d.expired(reserve=1.0) and not d.expired(),
+         'the reserve band trips early while the raw deadline has clock left')
+    K.reset_for_test()
+    d = K.Deadline(0.0, tool='t')
+    cc = d.cancel_check('repair')
+    want(callable(cc) and cc() and d.stopped_in == 'repair',
+         'cancel_check() is a zero-arg closure and records the phase')
+    K.reset_for_test()
+    want(K.emit({'a': 1}) and not K.emit({'a': 2}),
+         'emit() fires at most once (a second JSON_SUMMARY would be merged '
+         'as a later pass and overwrite the real tally)')
+    K.reset_for_test()
+    want(K.emit({'x': 1}) is True, 'emit() is callable after reset')
+    K.reset_for_test()
+    r = {}
+    K.mark(r, K.Deadline(1.0, tool='t'), staged_board='s.kicad_pcb')
+    want(r['complete'] is False and r['status'] == 'deadline'
+         and r['partial']['staged_board'] == 's.kicad_pcb',
+         'mark() stamps complete:false, status:"deadline" and the partial')
+    want(K.DEADLINE_EXIT not in (0, 4, 124),
+         'the deadline exit code collides with neither the shell nor "measured '
+         'defect"')
+
+
+def test_partial_is_as_fatal_as_missing():
+    """The regression the deadline work could have introduced."""
+    from route_summary import merge_summaries
+    part = {'complete': False, 'status': 'deadline', 'stopped_in': 'repair',
+            'failed_single': ['A'], 'elapsed_s': 61.0, 'deadline_s': 60}
+    full = {'complete': True, 'status': 'ok', 'failed_single': []}
+    m = merge_summaries([part, full])
+    want(m.get('complete') is False,
+         'a complete LATER pass cannot whitewash a partial earlier one')
+    want(m.get('stopped_in') == 'repair',
+         'the merged summary keeps WHY it was partial')
+    m2 = merge_summaries([{'failed_single': []}, {'failed_single': []}])
+    want(m2.get('complete', True) is True,
+         'pre-deadline logs (no `complete` key) still read as complete')
+
+    src = open(os.path.join(ROOT, 'py_placer', 'place_route_loop.py'), encoding='utf-8').read()
+    want("summary.get('complete', True)" in src,
+         'place_route_loop REJECTS a partial summary -- a partial parses, so '
+         '"is there a summary" is no longer a sufficient check')
+
+
+# NOTE (#621 x run-23 merge): the two subprocess tests that used to sit here
+# drove `place_reconstruct --stages legalize --deadline ...`. Upstream #621
+# deleted place_reconstruct's wall-clock budget (passing --deadline there is
+# now an argparse error), so those tests assert a contract the tool no longer
+# offers and were removed in the integration merge. The budget facility
+# itself survives on route.py / place_seed / place_plan; its route.py
+# reserve + cancellable tail is pinned by tests/test_run23_deadline_reserve.py,
+# and the unit halves below (krt_deadline primitives, merge_summaries
+# stickiness, place_route_loop's partial rejection, --stages validation)
+# still bind.
+
+
+def test_stages_are_validated():
+    # Via run_utils.check, which separates "the guard held" from "my control
+    # broke". A bare `returncode == 2` here would also pass on an argparse
+    # typo, an ImportError or a missing board -- and `--stages` validation is
+    # itself argparse-adjacent, so that confusion is one keystroke away.
+    # `allow` because p.error() IS an argparse usage message: it is the
+    # expected mechanism here, not an accident.
+    sys.path.insert(0, os.path.join(ROOT, 'tests'))
+    from run_utils import check
+    try:
+        check([sys.executable, '-X', 'utf8',
+               os.path.join(ROOT, 'py_placer', 'place_reconstruct.py'), 'a.kicad_pcb',
+               'b.kicad_pcb', '--stages', 'legalise'],
+              refuse='unknown stage', code=2, allow=('error: argument',))
+        ok = True
+    except AssertionError as e:
+        ok = False
+        print('   ' + str(e)[:300])
+    want(ok, 'a misspelt --stages is an ERROR naming the valid stages, not a '
+             'silent no-op that gates nothing and exits 0')
+
+
+if __name__ == '__main__':
+    for fn in (test_deadline_primitives, test_partial_is_as_fatal_as_missing,
+               test_stages_are_validated):
+        print(fn.__name__)
+        fn()
+    print('FAIL: %d' % len(BAD) if BAD else 'OK')
+    sys.exit(1 if BAD else 0)

--- a/tests/test_run23_deadline_reserve.py
+++ b/tests/test_run23_deadline_reserve.py
@@ -1,0 +1,72 @@
+"""Deadline reserve band + cancellable tail + heartbeat file (run-23).
+
+R4 overshot its --deadline 1.74x (732s of 420) because the routing loop
+consumed the whole budget and the tail -- write, plane finalize, oracle,
+reconcile laps -- ran deadline-blind after it. Pinned here: the routing
+closure carries a reserve (max(30, 20%)); the tail legs get a reserve-0
+closure; the reconcile refuses to START on a spent deadline (with the
+reason printed); stdout_progress can heartbeat to $KRT_PROGRESS_FILE; and
+a run WITHOUT --deadline behaves exactly as before.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BOARD = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
+
+
+def _route(out, *argv, env_extra=None):
+    env = dict(os.environ, PYTHONPATH=ROOT, PYTHONIOENCODING='utf-8',
+               KRT_NO_BANNER='1', **(env_extra or {}))
+    return subprocess.run(
+        [sys.executable, '-X', 'utf8',
+         os.path.join(ROOT, 'py_router', 'route.py'), BOARD, out, *argv],
+        capture_output=True, text=True, env=env, cwd=ROOT)
+
+
+class TestDeadline(unittest.TestCase):
+    def test_tight_deadline_is_bounded_and_honest(self):
+        with tempfile.TemporaryDirectory() as td:
+            out = os.path.join(td, 'r.kicad_pcb')
+            hb = os.path.join(td, 'hb.json')
+            t0 = time.time()
+            r = _route(out, '--deadline', '5',
+                       env_extra={'KRT_PROGRESS_FILE': hb})
+            wall = time.time() - t0
+            # deadline 5 + reserve 30 + parse/write slack. The measured
+            # failure mode was 1.74x overshoot on a 420s budget; the bound
+            # here is deliberately loose for CI, tight against that.
+            self.assertLess(wall, 120)
+            self.assertEqual(r.returncode, 7, r.stdout[-400:])  # DEADLINE_EXIT
+            # The partial run still emits the authoritative MIN line, and it
+            # says INCOMPLETE -- a cancelled run yields a real gated verdict.
+            line = [ln for ln in r.stdout.splitlines()
+                    if ln.startswith('JSON_SUMMARY_MIN: ')]
+            self.assertEqual(len(line), 1)
+            doc = json.loads(line[0].split(': ', 1)[1])
+            self.assertFalse(doc['complete'])
+            # Heartbeat file ticked at least once.
+            self.assertTrue(os.path.exists(hb))
+            self.assertIn('label', json.load(open(hb, encoding='utf-8')))
+
+    def test_no_deadline_behavior_unchanged(self):
+        with tempfile.TemporaryDirectory() as td:
+            out = os.path.join(td, 'r.kicad_pcb')
+            r = _route(out)
+            self.assertEqual(r.returncode, 0, r.stdout[-400:])
+            self.assertNotIn('Final reconciliation SKIPPED', r.stdout)
+            line = [ln for ln in r.stdout.splitlines()
+                    if ln.startswith('JSON_SUMMARY_MIN: ')]
+            doc = json.loads(line[0].split(': ', 1)[1])
+            self.assertTrue(doc['complete'])
+            self.assertEqual(doc['failed'], 0)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=1)

--- a/tests/test_run23_summary_min.py
+++ b/tests/test_run23_summary_min.py
@@ -1,0 +1,89 @@
+"""JSON_SUMMARY_MIN: one compact authoritative line per outermost run.
+
+Run 23's route logs carried 53 JSON_SUMMARY lines, the longest 19.8KB, with
+scope semantics the log itself warns about ("never scrape the LAST
+JSON_SUMMARY") -- and every agent consuming them paid that in context, per
+lap. The MIN line is the merged verdict in <1KB, printed exactly once per
+outermost batch_route (final_reconcile gates it, so plane-finalize and
+reconcile sub-runs can never emit a second one).
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))
+
+BOARD = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
+
+
+class TestSummaryMin(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.td = tempfile.TemporaryDirectory()
+        out = os.path.join(cls.td.name, 'routed.kicad_pcb')
+        cls.json_out = os.path.join(cls.td.name, 'sum.json')
+        env = dict(os.environ, PYTHONPATH=ROOT, PYTHONIOENCODING='utf-8',
+                   KRT_NO_BANNER='1')
+        r = subprocess.run(
+            [sys.executable, '-X', 'utf8',
+             os.path.join(ROOT, 'py_router', 'route.py'),
+             BOARD, out, '--json-out', cls.json_out, '--deadline', '240'],
+            capture_output=True, text=True, env=env, cwd=ROOT)
+        assert r.returncode == 0, r.stdout[-800:]
+        cls.log = r.stdout
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.td.cleanup()
+
+    def test_exactly_one_min_line_and_it_is_last(self):
+        from route_summary import SUMMARY_MIN_RE, SUMMARY_RE
+        mins = SUMMARY_MIN_RE.findall(self.log)
+        self.assertEqual(len(mins), 1, f'{len(mins)} MIN lines')
+        # Authoritative-last: the MIN line must come after every big summary,
+        # or a tail-reader can still scrape a subset-scope line by accident.
+        self.assertGreater(self.log.rfind('JSON_SUMMARY_MIN: '),
+                           max((self.log.rfind('JSON_SUMMARY: '), -1)))
+        # And the two regexes must not eat each other.
+        for big in SUMMARY_RE.findall(self.log):
+            json.loads(big)   # every big match is still valid standalone JSON
+
+    def test_min_matches_the_merged_json_out(self):
+        from route_summary import SUMMARY_MIN_RE, summary_min
+        got = json.loads(SUMMARY_MIN_RE.findall(self.log)[0])
+        merged = json.load(open(self.json_out, encoding='utf-8'))
+        self.assertEqual(got, summary_min(merged))
+        self.assertEqual(got['scope'], 'merged')
+
+    def test_min_is_small(self):
+        from route_summary import SUMMARY_MIN_RE
+        line = SUMMARY_MIN_RE.findall(self.log)[0]
+        self.assertLess(len(line), 2048, f'{len(line)} bytes')
+
+    def test_run23_partial_log_reduces_honestly(self):
+        """The line must carry deadline-partial truth: complete=false,
+        status=deadline, the failing nets by name -- validated against the
+        log run 23 actually produced (R4, the 732s/420s overshoot), when
+        that log is present."""
+        log_path = os.path.join(ROOT, 'wk', 'run23', 'tigard', 'logs',
+                                'R4_route.log')
+        if not os.path.exists(log_path):
+            self.skipTest('run-23 work dir not present')
+        from route_summary import merge_route_summaries, summary_min
+        m = merge_route_summaries(
+            open(log_path, encoding='utf-8', errors='replace').read())
+        got = summary_min(m)
+        self.assertFalse(got['complete'])
+        self.assertEqual(got['status'], 'deadline')
+        self.assertIn('/TXLED', got['failed_single'])
+        self.assertLess(len(json.dumps(got)), 1024)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=1)


### PR DESCRIPTION
Deadline handling and machine-readable run output, split out of #679 after review. Two commits, one PR, because they depend on each other: the short summary line is how a deadline verdict gets read, and each one's test needs the other.

## What changes for a user

**Commit 1, deadline.** `route.py --deadline SECONDS` (or `KRT_DEADLINE_S`): the routing loops stop at deadline minus a reserve, the tail legs (plane finalize, oracle, reconcile) run inside the reserve on their own closure, a reconcile that would start on a spent budget is refused with the reason printed, and the board written is a real partial route with `complete=false / status=deadline` in its summary and exit code 7. Without a budget nothing changes. The motivation is Windows: an external kill there is `TerminateProcess`, which leaves no summary and no exit code of ours, and a whole lap was once lost that way.

**Commit 2, output.** One `JSON_SUMMARY_MIN:` line per outermost route with the merged tally; the "boxed in by static obstacles" verdict becomes a summary key (`boxed_in`, next to `blockers`) and plane-finalize exclusions become `finalize_excluded_nets`, both previously only sentences in the log; `check_reachability` gets auto-widen and `--json-out`, `net_forensics` gets `--json`.

## Files

`py_router/krt_deadline.py` (new, stdlib only), `route.py` (deadline plumbing and the summary keys), `route_summary.py`, `routing_diagnostics.py`, `reroute_loop.py`, `single_ended_loop.py`, `py_tools/check_reachability.py` (plus the two placement helpers it is built on and whose changes its auto-widen and `--defect-json` relief need: `placement/reachability.py` and `placement/routability.py`), `py_tools/net_forensics.py`, and four tests. 14 files. Standalone on main: compiles, all four tests green (`test_deadline`, `test_run23_deadline_reserve`, `test_run23_summary_min`, `test_boxed_in_summary`), plus upstream's `test_json_out_summary` still green.
