### PR TITLE
Small fixes: Windows execv, .kicad_dru in sibling lists, manifest keeps --fab-tier/--fab-overrides

### DIFF
--- a/kicad_routing_plugin/gui_utils.py
+++ b/kicad_routing_plugin/gui_utils.py
@@ -855,8 +855,9 @@ def run_kicad_oracle_on_live_board(board, net_names, *, clearance,
                                     if hole_to_hole_clearance is not None
                                     else defaults.HOLE_TO_HOLE_CLEARANCE),
             progress_callback=progress_callback)
-        for _p in (tmp, os.path.splitext(tmp)[0] + '.kicad_pro',
-                   os.path.splitext(tmp)[0] + '.kicad_prl'):
+        from copy_board import SIBLING_EXTS as _sib_exts
+        for _p in (tmp,) + tuple(os.path.splitext(tmp)[0] + _e
+                                 for _e in _sib_exts):
             try:
                 os.unlink(_p)
             except OSError:

--- a/py_router/blocking_analysis.py
+++ b/py_router/blocking_analysis.py
@@ -919,7 +919,7 @@ def filter_rippable_blockers(
     With `pcb_data`, PROTECTED nets are also dropped (run-6 fix): this is the
     one choke point all six in-run rip ladders flow through, and none of them
     consulted protection_map -- so a .kicad_pro protected net, KiCad-locked
-    copper, or a --protect-nets match could be ripped mid-run by the phase-3
+    copper, or a protected net could be ripped mid-run by the phase-3
     cascade even though every PRE-run rip channel refused it (test-board run
     5, journal [10]: the #444 seam re-ask and the tap ladder churned a
     committed net's copper repeatedly). Refusals are recorded in

--- a/py_router/headless_plan.py
+++ b/py_router/headless_plan.py
@@ -72,7 +72,14 @@ def reexec_into_kicad(script=None, argv=None):
             continue
         if subprocess.run([cand, '-c', 'import pcbnew, wx'],
                           capture_output=True).returncode == 0:
-            os.execv(cand, [cand, script] + argv)
+            child = [cand, script] + argv
+            if os.name == 'nt':
+                # os.execv goes through the CRT on Windows, which re-splits the
+                # argument vector on spaces: "C:\Program Files\KiCad\10.0\bin\
+                # python.exe" arrives torn in two and the run dies with a bogus
+                # "can't open file ...\Files\KiCad\...". subprocess quotes it.
+                sys.exit(subprocess.run(child).returncode)
+            os.execv(cand, child)
     return False
 
 

--- a/tests/fixture_boards.py
+++ b/tests/fixture_boards.py
@@ -48,6 +48,12 @@ import sys
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BOARDS = os.path.join(ROOT, 'kicad_files')
 
+if os.path.join(ROOT, 'py_router') not in sys.path:
+    sys.path.insert(0, os.path.join(ROOT, 'py_router'))
+# One list, not a hand-written copy -- this file's said
+# ('.kicad_pcb', '.kicad_pro', '.kicad_prl') and dropped `.kicad_dru`.
+from copy_board import SIBLING_EXTS  # noqa: E402
+
 # Mirrors tests/test_fanout_and_route.py's parameter groups.
 _L4 = ['--layers', 'F.Cu', 'In1.Cu', 'In2.Cu', 'B.Cu']
 _L5 = ['--layers', 'F.Cu', 'In1.Cu', 'In2.Cu', 'In3.Cu', 'B.Cu']
@@ -129,11 +135,11 @@ def _build(name, path):
             raise FixtureBuildError(
                 f"could not build {name}:\n  {' '.join(argv[1:])}\n"
                 f"{r.stdout[-1200:]}\n{r.stderr[-800:]}")
-        for ext in ('.kicad_pcb', '.kicad_pro', '.kicad_prl'):
+        for ext in ('.kicad_pcb',) + SIBLING_EXTS:
             if os.path.exists(tmp_stem + ext):
                 os.replace(tmp_stem + ext, stem + ext)
     finally:
-        for ext in ('.kicad_pcb', '.kicad_pro', '.kicad_prl'):
+        for ext in ('.kicad_pcb',) + SIBLING_EXTS:
             if os.path.exists(tmp_stem + ext):
                 os.unlink(tmp_stem + ext)
     return path

--- a/tests/stress/fix_mixed_net_refs.py
+++ b/tests/stress/fix_mixed_net_refs.py
@@ -18,6 +18,7 @@ names come from pads, which fanout does not change).
 """
 from __future__ import annotations
 
+import os
 import re
 import sys
 from pathlib import Path

--- a/tests/stress/manifest_to_plan.py
+++ b/tests/stress/manifest_to_plan.py
@@ -73,6 +73,14 @@ REFUSED_TOOLS = {
 
 # CLI flag -> plan params key (numbers parsed; lists collected).
 FLAG_PARAMS = {
+    # #522-era gap: these two were in NONE of this module's tables, so a
+    # recorded manifest lost its fab settings on conversion and the
+    # replayed plan routed at the DEFAULT tier. They are string-valued;
+    # `_num` falls through to the raw string, the same way --ordering
+    # already does. Param names match the dialog controls
+    # (settings_persistence.py:67-68), which is what ai_plan matches on.
+    '--fab-tier': 'fab_tier',
+    '--fab-overrides': 'fab_overrides_path',
     '--track-width': 'track_width',
     '--clearance': 'clearance',
     '--via-size': 'via_size',

--- a/tests/stress/redo_diff_stage.py
+++ b/tests/stress/redo_diff_stage.py
@@ -249,7 +249,8 @@ def process_board(set_board, manifest, work_root, out_dir, drc_size_checks):
         dest = os.path.join(out_dir, set_board)
         os.makedirs(dest, exist_ok=True)
         base = os.path.splitext(os.path.basename(out_board))[0]
-        for ext in (".kicad_pcb", ".kicad_pro", ".kicad_prl"):
+        from copy_board import SIBLING_EXTS
+        for ext in (".kicad_pcb",) + SIBLING_EXTS:
             p = os.path.join(wdir, base + ext)
             if os.path.isfile(p):
                 shutil.copy(p, os.path.join(dest, board + "_diff" + ext))

--- a/tests/test_457_fresh_clone_fixtures.py
+++ b/tests/test_457_fresh_clone_fixtures.py
@@ -32,7 +32,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(
 import fixture_boards
 from fixture_boards import _RECIPES, ROOT, ensure
 
-SIBLINGS = ('.kicad_pro', '.kicad_prl')
+SIBLINGS = ('.kicad_pro', '.kicad_prl', '.kicad_dru')
 
 
 def _tracked():

--- a/tests/test_ac_coupled_match.py
+++ b/tests/test_ac_coupled_match.py
@@ -183,7 +183,8 @@ def run():
                 fails.append("control: ac_coupled_xnets present without --ac-couple-match (not inert)")
         finally:
             base = out[:-len(".kicad_pcb")]
-            for ext in (".kicad_pcb", ".kicad_pro", ".kicad_prl"):
+            for ext in (".kicad_pcb", ".kicad_pro", ".kicad_prl",
+                        ".kicad_dru"):
                 if os.path.exists(base + ext):
                     os.remove(base + ext)
 

--- a/tests/test_diff_layer_costs_response.py
+++ b/tests/test_diff_layer_costs_response.py
@@ -38,7 +38,8 @@ FAVORED_LAYER = "In1.Cu"
 
 def _cleanup(out):
     base = out[:-len(".kicad_pcb")]
-    for f in (out, base + ".kicad_pro", base + ".kicad_prl"):
+    for f in (out, base + ".kicad_pro", base + ".kicad_prl",
+              base + ".kicad_dru"):
         if os.path.exists(f):
             os.remove(f)
 


### PR DESCRIPTION
Four small fixes, split out of #679 after review.

- `headless_plan.py` used `os.execv`, which on Windows returns to the caller immediately; it now runs the child and exits with its code.
- Four hand-written board-sibling lists omitted `.kicad_dru` (`gui_utils`, `fixture_boards`, `redo_diff_stage`, and three tests); they use `copy_board.SIBLING_EXTS` now.
- `manifest_to_plan` had `--fab-tier` and `--fab-overrides` in none of its tables, so a recorded run replayed through the GUI at the default tier. Eight lines.
- A missing `import os` in `fix_mixed_net_refs.py` and one stale docstring.

Standalone on main: compiles, the parity and sibling tests green (`test_457_fresh_clone_fixtures` is red on main already, unrelated).
