### PR TITLE
Recovery-run harness and loop gates (serves #411)

### DIFF
--- a/.claude/skills/plan-pcb-placement-and-routing/SKILL.md
+++ b/.claude/skills/plan-pcb-placement-and-routing/SKILL.md
@@ -145,6 +145,23 @@ the failure, and without `--accept-cmd` its comparator cannot see the thing you
 are trying to fix (a length, a width, a clause). An ACCEPTED round is not a
 verdict -- grade the output with the same battery either skill would use.
 
+## Eyes at the boundaries (run-23)
+
+Numbers gate legality; nothing gated LOOKING, and run 23 shipped a board a
+human rejected at a glance (15 courtyard interpenetrations, four mid-board
+connectors) while every key read clean — its orchestrator viewed ONE image in
+4.7 hours, after the failure. Two driver gates now refuse without a written
+review: L2 needs `wk/review_handoff.md`, the L5 terminal close needs
+`wk/review_close.md`. The protocol is BLIND-FIRST: produce
+`render_placement --review-sheet`, VIEW it, write your observations
+(connectors vs edges with distances, density pockets vs empty regions,
+anything wrong no key names) **before reading any checklist key**, then a
+reconciliation paragraph dispositioning each observation against a named
+number — or refuse the boundary. Observations must carry distances/mm² the
+keys alone cannot produce; that is what separates a review from theater.
+Reorient any time with `loop_driver --status` (RUN_STATE.json is the NOW
+view; the ledger stays the authority).
+
 ## What a run DELIVERS
 
 Four artifacts, every time, in the work dir. A run that produces the board alone

--- a/.claude/skills/plan-pcb-placement-and-routing/references/evidence-map.md
+++ b/.claude/skills/plan-pcb-placement-and-routing/references/evidence-map.md
@@ -198,11 +198,12 @@ on this page describes what a step *claims*; this describes what the board *is*.
 | `blocking` | **must reach 0 before the board is deliverable.** `unrouted + broken + drc + undersized + floorplan + impedance + length` |
 | `blocking_by.<component>` | names WHERE the blocking sits. **The largest entry is NOT automatically the lever** -- that rule wrecked a run. Choose by the connectivity-first ladder (unrouted -> broken -> widths -> floorplan -> drc); an entry's size ranks within a rung, never across rungs |
 | `quality` = `{vias, copper_mm, segments}` | tie-break **only** at `blocking == 0`. Comparing it earlier lets a router trade a disconnected net for a lower via count |
-| `ungraded` | components nothing examined (no `--intent`, no `--impedance-nets`, no `--length-groups`). **Report as unexamined, never as clean** |
+| `ungraded` | components that were MEASURABLE and nobody asked for (no `--intent`, no `--net-min-widths`). **Report as unexamined, never as clean** |
+| `not_applicable` | components the BOARD declares no requirement for — no matched group or diff pair in `protected_nets`, no `net_impedance`. There is nothing to grade, so this does NOT block a close-out and passing the flag would invent a requirement. Still printed, so "no such requirement" stays distinguishable from "nobody looked" |
 | `unknown` | a component that was asked for and could not run. `blocking` is `null`, not 0 — the loop must not stop here |
 | `components.drc.graded_at` | the clearance actually graded at. Confirm it is the routed floor; stricter invents violations, looser hides them |
 | `components.drc.by_type` | `segment-segment`, `pad-segment`, … — clearance conflicts |
-| `components.undersized.by_type` | `track-width`, `via-size`, `via-drill-size` — **sub-spec copper** |
+| `components.undersized.by_type` | `track-width`, `via-size`, `via-drill-size` — **sub-spec copper**, graded separately per floor. Note what this cannot see: diameter and drill are tested independently, so a via whose ring is zero (a 0.3/0.3 via) passes both — a removal of such vias earns no credit here; state it in the ledger |
 | `components.floorplan.rules_run` / `.rules_skipped` | `0 violations` with `0 rules run` is a vacuous pass. Quote both |
 | `connectivity_nets` | *which* nets failed. Same nets every iteration ⇒ parameters; different nets ⇒ congestion |
 | exit code | `0` blocking is zero · `4` graded with blockers · `3` board state · `2` args · `1` crash |

--- a/.claude/skills/plan-pcb-placement-and-routing/references/verifier-prompts.md
+++ b/.claude/skills/plan-pcb-placement-and-routing/references/verifier-prompts.md
@@ -11,6 +11,15 @@ VERDICT=PASS:lens=<lens>
 VERDICT=FAIL:lens=<lens>;finding=<one line>;evidence=<path#json-pointer|path@x,y>;route=<step>
 ```
 
+**And WRITES that same line to `wk/turn<N>/verdict_<lens>.txt` before
+returning** (run-23). The reply is a notification, and notifications get
+lost: run 23's connectivity and drc lens verdicts never reached the parent
+— it waited on them, was nudged, and had to re-derive both lenses inline.
+The FILE is the delivery channel; the reply is a courtesy copy. A parent
+expecting a verdict polls for the file, never for a message, and a verdict
+file that never appears is itself the finding ("the verifier died"), not a
+reason to assume PASS.
+
 `evidence=` must point into the round's own files — `wk/place.log#JSON_SUMMARY.
 crossings_after`, `wk/intent.json#/violations/3`, `wk/view/board_F.png@112.4,63.1`.
 **A verifier that cannot fill it has not verified anything.**
@@ -142,8 +151,10 @@ VERDICT=FAIL:lens=drc;finding=8 vias below the 0.6 mm spec on B.Cu;
   evidence=wk/score.json#/components/undersized/by_type/via-size;route=Step 2
 ```
 
-1. **Record the verdict with `converge.py record --lens`**, passing the
-   `VERDICT=` line verbatim (repeatable; stored raw as `entry["lenses"]`). It
+1. **Record the verdict with `converge.py record --lens`**, reading the
+   `VERDICT=` line from `wk/turn<N>/verdict_<lens>.txt` — the file the
+   verifier wrote, never a reply you remember — and passing it verbatim
+   (repeatable; stored raw as `entry["lenses"]`). It
    refuses at write time anything that is not a `VERDICT=(PASS|FAIL):lens=…`
    line, so a malformed verdict stays visible instead of being normalised into
    something that reads like a pass — and `--final` refuses without all three

--- a/.claude/skills/plan-pcb-placement-and-routing/scripts/board_score.py
+++ b/.claude/skills/plan-pcb-placement-and-routing/scripts/board_score.py
@@ -148,9 +148,25 @@ def run_tool(root: str, tool: str, *args) -> tuple:
     return p.returncode, p.stdout
 
 
-def skipped(reason: str) -> dict:
-    """A component that did not run. `count` is None, never 0 (see Vacuity)."""
-    return {'ran': False, 'reason': reason, 'count': None}
+def skipped(reason: str, applicable: bool = True) -> dict:
+    """A component that did not run. `count` is None, never 0 (see Vacuity).
+
+    `applicable=False` says the BOARD CARRIES NO SUCH REQUIREMENT -- there is no
+    length-matched group declared, no impedance net, no per-net width clause --
+    so there is nothing to grade and passing the flag would INVENT a
+    requirement. That is a different fact from "measurable, and nobody asked",
+    and collapsing the two cost run 20 a waiver: L5 refused to close because
+    `length` and `net_widths` were both "never examined", and closing needed
+    `--accept-unclosed ungraded` -- one waiver covering a real gap (net_widths,
+    genuinely measurable) and a non-question (length, on a board with no match
+    group at all). A standing false waiver on every simple board is how a real
+    one stops being read.
+
+    The reason string was already here to carry the distinction; nothing
+    downstream read it.
+    """
+    return {'ran': False, 'reason': reason, 'count': None,
+            'applicable': applicable}
 
 
 def _unescape_net_name(s: str) -> str:
@@ -481,9 +497,38 @@ def score_floorplan(root: str, board: str, intent: str, tmp: str) -> dict:
             'violations': [v.get('rule') for v in (d.get('violations') or [])]}
 
 
+def _board_declares(board: str, key: str) -> bool:
+    """Does the board's sibling project DECLARE something of this kind?
+
+    The chain already records its own design intent there (#521): matched
+    groups and routed diff pairs under `protected_nets`, impedance specs under
+    `net_impedance`. A board carrying neither has no length group to match and
+    no impedance net to hold, so asking for those is not a gap in the grade --
+    there is nothing to grade, and passing the flag would invent a requirement.
+
+    Conservative: anything unreadable answers True, so a component stays
+    `ungraded` (which blocks a close-out) rather than being silently excused.
+    """
+    try:
+        from fix_kicad_drc_settings import find_project
+        pro = find_project(board)
+        if not os.path.isfile(pro):
+            return False
+        with open(pro, encoding='utf-8') as fh:
+            krt = (json.load(fh).get('kicad_routing_tools') or {})
+        return bool(krt.get(key))
+    except Exception:                                       # noqa: BLE001
+        return True
+
+
 def score_impedance(root: str, board: str, nets, tmp: str) -> dict:
     """check_impedance -- reference-plane continuity and declared-gap audit."""
     if not nets:
+        if not _board_declares(board, 'net_impedance'):
+            return skipped(
+                'this board declares no impedance net (no `net_impedance` in '
+                'its project), so there is no impedance requirement to grade',
+                applicable=False)
         return skipped('no --impedance-nets given; impedance is ungraded')
     out_json = os.path.join(tmp, 'impedance.json')
     rc, out = run_tool(root, 'check_impedance.py', board, '--nets', *nets,
@@ -522,6 +567,11 @@ def score_length(board: str, groups_file: str) -> dict:
     branch and matches no real signal path.
     """
     if not groups_file:
+        if not _board_declares(board, 'protected_nets'):
+            return skipped(
+                'this board declares no matched group or routed diff pair (no '
+                '`protected_nets` in its project), so there is no length-match '
+                'requirement to grade', applicable=False)
         return skipped('no --length-groups given; length matching is ungraded')
     if not os.path.isfile(groups_file):
         return skipped(f'length-groups file not found: {groups_file}')
@@ -661,8 +711,12 @@ def _floors(board: str, sizes: dict) -> dict:
     `requested` is what the caller passed; `board` is what the project declares
     now. They differ exactly when a spec floor is tighter than the board's own.
     """
+    # Only the FLOORS. `sizes` also carries --fab-tier / --fab-overrides, which
+    # are forwarded to the child but are not floors, and a consumer reading this
+    # as {name: mm} got a string.
     out = {'requested': {k.lstrip('-').replace('-', '_'): v
-                         for k, v in (sizes or {}).items() if v is not None}}
+                         for k, v in (sizes or {}).items()
+                         if isinstance(v, (int, float)) and not isinstance(v, bool)}}
     try:
         import list_nets
         dr = list_nets.read_design_rules(board)
@@ -812,6 +866,14 @@ def build_parser():
     g.add_argument('--min-via-drill', type=float, metavar='MM')
     g.add_argument('--size-margin', type=float, metavar='MM',
                    help='absolute tolerance on the size checks (default: exact floor)')
+    # Declared here rather than via fab_tiers.add_fab_tier_args: this script
+    # parses its arguments BEFORE it puts the engine dirs on sys.path, so the
+    # shared helper is not importable yet. Kept default=None (not 'standard')
+    # so an unpassed flag is not forwarded and check_drc keeps its own default.
+    g.add_argument('--fab-tier', choices=('standard', 'advanced'), default=None,
+                   help='forwarded verbatim to check_drc.py')
+    g.add_argument('--fab-overrides', metavar='FILE', default=None,
+                   help='forwarded verbatim to check_drc.py')
     p.add_argument('--impedance-nets', nargs='+', metavar='GLOB',
                    help='route.py --nets glob syntax, SPACE separated; commas '
                         'inside a token are split too (a comma-joined list used '
@@ -850,7 +912,13 @@ def main():
     sizes = {'--min-track-width': args.min_track_width,
              '--min-via-diameter': args.min_via_diameter,
              '--min-via-drill': args.min_via_drill,
-             '--size-margin': args.size_margin}
+             '--size-margin': args.size_margin,
+             # Forwarded, not dropped. These select the floor check_drc grades
+             # against, so withholding them made an override floor unreachable
+             # from the score: the two tools graded one board at two different
+             # fab tiers and neither said so.
+             '--fab-tier': args.fab_tier,
+             '--fab-overrides': args.fab_overrides}
     # A real temp dir, NOT a dotfile beside the board: these are intermediate
     # JSONs nobody reads twice, and scoring a board must leave nothing behind in
     # the user's project. `--json` is the copy you keep.
@@ -911,7 +979,17 @@ def main():
              'label': args.label, 'blocking': blocking,
              'blocking_by': {k: v.get('count') for k, v in parts.items()},
              'advisory': {k: v.get('count') for k, v in advisory.items()},
-             'ungraded': sorted(k for k, v in parts.items() if v.get('ran') is False),
+             # SPLIT. `ungraded` is measurable-but-unasked and still blocks a
+             # close-out; `not_applicable` is "this board has no such
+             # requirement" and does not. Both stay in the payload and on the
+             # printed line -- "not applicable" must be VISIBLE, not silently
+             # dropped, or the next reader cannot tell it from a gap.
+             'ungraded': sorted(k for k, v in parts.items()
+                                if v.get('ran') is False
+                                and v.get('applicable', True)),
+             'not_applicable': sorted(k for k, v in parts.items()
+                                      if v.get('ran') is False
+                                      and not v.get('applicable', True)),
              'unknown': sorted(unknown), 'quality': quality(args.board),
              'components': {**parts, **advisory},
              'floors': _floors(args.board, sizes),
@@ -929,8 +1007,23 @@ def main():
     bits = ' '.join(f'{k}={v}' for k, v in score['blocking_by'].items()
                     if v is not None)
     q = score['quality']
+    # THE COMPONENT SET, on the identity line and not only in the JSON. Run 20
+    # produced `blocking` 12, 13 and 18 for ONE board under three flag sets, and
+    # nothing on the printed line said so. Two scores over different components
+    # are not comparable, and a reader has to be able to see that at a glance --
+    # `blocking` is a scalar summed over things that are not the same kind of
+    # thing, so the set it was summed over is part of the number's meaning.
+    _scope = []
+    if score.get('ungraded'):
+        _scope.append('ungraded: ' + ','.join(score['ungraded']))
+    if score.get('not_applicable'):
+        _scope.append('n/a: ' + ','.join(score['not_applicable']))
+    if score.get('unknown'):
+        _scope.append('UNKNOWN: ' + ','.join(score['unknown']))
     print(f"BLOCKING={blocking}  ({bits})  "
-          f"vias={q.get('vias')} copper_mm={q.get('copper_mm')}")
+          f"vias={q.get('vias')} copper_mm={q.get('copper_mm')}"
+          + (f"  [over {len(score['blocking_by'])} components; "
+             + '; '.join(_scope) + ']' if _scope else ''))
     _adv_bits = ' '.join(f'{k}={v}' for k, v in score['advisory'].items() if v)
     if _adv_bits:
         print(f"ADVISORY (floor-governed, not blocking): {_adv_bits}")
@@ -980,6 +1073,11 @@ def main():
     if score['ungraded']:
         # Loud, because this is the difference between "clean" and "unexamined".
         print(f"UNGRADED (not scored, not passed): {', '.join(score['ungraded'])}")
+    if score.get('not_applicable'):
+        # Quieter, and still printed: a reader must be able to see WHY a
+        # component is absent from the score rather than infer it.
+        print("NOT APPLICABLE (this board declares no such requirement): "
+              + ', '.join(score['not_applicable']))
     if unknown:
         print(f"UNKNOWN (asked for, could not run): {', '.join(unknown)}")
         return 4

--- a/.claude/skills/plan-pcb-placement-and-routing/scripts/loop_driver.py
+++ b/.claude/skills/plan-pcb-placement-and-routing/scripts/loop_driver.py
@@ -38,6 +38,7 @@ import hashlib
 import json
 import os
 import re
+import re as _re_wk
 import sys
 import time
 
@@ -206,6 +207,129 @@ def _score_board_mismatch(board, payload):
 # that one gated, this one annotates, and a threshold nobody acts on does not
 # need to be right -- it needs to be roughly where the interesting cases are.
 _CONGESTION_RATIO = 0.25
+
+
+def _load_route_summary(path):
+    """(summary, err). Accepts a bare JSON file OR a route LOG.
+
+    The loop's own L2 contract hands the operator `route.log -- the one carrying
+    JSON_SUMMARY`, and `--route-summary` used to `json.load` it, fail, and skip
+    the box-in precondition with a NOTE. The guard that exists to stop run 20's
+    40 minutes of futile grid laps was therefore OFF for anyone who passed the
+    artifact the loop told them to produce, and it failed OPEN.
+
+    Delegates to `route_summary.merge_route_summaries`, which is also what
+    `render_placement --summary-json` uses. NOT a "take the last JSON_SUMMARY"
+    scan: a run that fires the reconciliation sub-pass emits a SECOND summary
+    scoped to that subset, so the last line is the subset's tally, not the
+    run's -- route.py says so in its own comment.
+    """
+    if not path:
+        return None, ''
+    if not os.path.isfile(path):
+        return None, f'--route-summary {path}: no such file'
+    try:
+        txt = open(path, encoding='utf-8', errors='replace').read()
+    except OSError as exc:
+        return None, f'--route-summary {path}: unreadable ({exc})'
+    try:
+        return json.loads(txt), ''
+    except ValueError:
+        pass
+    try:
+        from route_summary import merge_route_summaries
+        merged = merge_route_summaries(txt)
+    except Exception as exc:                                # noqa: BLE001
+        return None, (f'--route-summary {path}: not JSON, and the log parse '
+                      f'failed ({type(exc).__name__}: {exc})')
+    if not merged:
+        return None, (f'--route-summary {path}: no JSON_SUMMARY line in it, so '
+                      f'it is neither a summary nor a route log')
+    return merged, ''
+
+
+def _guard_static_boxin(a):
+    """(ok, why) -- refuse a GRID lever the router has already said cannot help.
+
+    The router prints "boxed in by static obstacles ... not by congestion" on
+    every such failure, and since the `boxed_in` key it also SAYS it in JSON,
+    with the geometry it was running and whether that geometry sits at the
+    board's declared floor.
+
+    A finer grid resolves the SAME obstacles more precisely. It does not make a
+    gap wider. So when the geometry is at the floor, the parameter family is
+    spent and a grid lap is a measured waste: run 20 spent three of them,
+    0.05 -> 0.025 -> 0.0125, roughly 40 minutes, with `unrouted` at exactly
+    BUSY / Net-(U4-XTAL_P) / SCK at every resolution.
+
+    REFUSES on that case, mirroring `_guard_congestion` -- warn-only was tried
+    by circumstance in run 20, the warning was on screen on every residual
+    failure, and the three laps were spent anyway. REPORTS, never refuses, when
+    the geometry still has travel: there the grid is a legitimate COMPLEMENT to
+    a geometry change, just never the lever alone.
+
+    Silent when there is no `--route-summary`, no box-in verdict, or the verdict
+    cannot say whether the geometry is at the floor. This guard exists to stop a
+    KNOWN-futile lever; "I could not tell" must not become "you failed".
+    """
+    if not getattr(a, 'route_summary', None):
+        return True, ''
+    summary, _serr = _load_route_summary(a.route_summary)
+    if _serr:
+        return True, (f'  NOTE: {_serr}, so the static-boxin precondition was '
+                      f'not checked.')
+    boxed = summary.get('boxed_in') or []
+    if not boxed:
+        return True, ''
+    nets = ', '.join(str(e.get('net')) for e in boxed[:6])
+    at_floor = [e for e in boxed if e.get('at_floor') is True]
+    unknown = [e for e in boxed if e.get('at_floor') is None]
+    g = (boxed[0].get('geometry') or {})
+    geom = (f"grid {g.get('grid_step')}, clearance {g.get('clearance')}, "
+            f"track {g.get('track_width')}")
+    if not at_floor:
+        _tail = ('' if not unknown else
+                 f' ({len(unknown)} of them could not read a declared floor, so '
+                 f'whether the geometry has travel is UNKNOWN there.)')
+        return True, (
+            f'  NOTE: the router reports {len(boxed)} net(s) boxed in by STATIC '
+            f'obstacles, not congestion: {nets}. Running {geom}.{_tail}\n'
+            f'  A finer grid resolves the same obstacles more precisely; it does '
+            f'not make a gap wider. Pair it with the geometry that still has '
+            f'travel -- the grid is the complement, never the lever alone.')
+    _why = str(getattr(a, 'accept_boxin', None) or '').strip()
+    if _why:
+        # The REASON, echoed into the stage body -- mirroring
+        # --accept-congestion. A waiver whose justification lives only in a
+        # shell history is one nobody can review later, and the ledger is what
+        # the next pass reads.
+        return True, (
+            f'  --accept-boxin: proceeding against a static-boxin verdict on '
+            f'{nets}, whose geometry is at the declared floor ({geom}).\n'
+            f'  Reason on the record: {_why}')
+    return False, (
+        f'The router says these nets are boxed in by STATIC obstacles, not by '
+        f'congestion, and the geometry is ALREADY at this board\'s declared '
+        f'floor:\n\n'
+        f'  nets:     {nets}\n'
+        f'  running:  {geom}\n'
+        f'  floors:   {(boxed[0].get("floors") or {})}\n\n'
+        f'A finer grid resolves the SAME obstacles more precisely. It does not '
+        f'make a gap wider, and there is no geometry left to pair it with -- so '
+        f'the parameter family is spent on these nets.\n\n'
+        f'Measured (run 20): three grid refinements against exactly this '
+        f'verdict, 0.05 -> 0.025 -> 0.0125, ~40 minutes, with `unrouted` at '
+        f'exactly BUSY / Net-(U4-XTAL_P) / SCK at every resolution.\n\n'
+        f'Measure it as placement instead -- check_reachability on the '
+        f'COPPER-FREE board, which is the only board on which a CAGED verdict '
+        f'means placement rather than rip-up depth:\n'
+        f'  python3 -X utf8 py_tools/check_reachability.py <copper-free board> \\\n'
+        f'      --pad <REF.PAD on one of those nets> --track <the floor> \\\n'
+        f'      --defect-json wk/defect.json\n'
+        f'  ... --stage L3 --defect-json wk/defect.json '
+        f'--route-summary {a.route_summary}\n\n'
+        f'If you have a reason this is still a parameter problem, say it:\n'
+        f'  --accept-boxin "<why a grid/parameter lever will help here>"')
 
 
 def _guard_congestion(a):
@@ -592,11 +716,127 @@ def _log_invocation(a, stage, out, code):
                'out_sha': hashlib.sha256(
                    (out or '').encode('utf-8')).hexdigest()[:16],
                'out_lines': len((out or '').splitlines())}
+        _note_inner_half(p, row)
         with open(p, 'a', encoding='utf-8') as fh:
             fh.write(json.dumps(row, sort_keys=True) + '\n')
+        # run-23: stamp the stage onto the workdir's NOW view. The ledger-
+        # derived body of RUN_STATE.json is owned by converge.write_run_state
+        # (every `record` refreshes it); the driver only merges in what it
+        # alone knows -- the last stage and whether it refused -- so a fresh
+        # agent reorients from ONE file instead of tailing three logs.
+        try:
+            sp = os.path.join(d, 'RUN_STATE.json')
+            st = {}
+            if os.path.exists(sp):
+                with open(sp, encoding='utf-8') as sf:
+                    st = json.load(sf)
+            st.update({'last_stage': stage, 'stage_exit': code,
+                       'stage_refused': bool(code == 4),
+                       'stage_written_at': row['iso']})
+            tmp = sp + '.tmp'
+            with open(tmp, 'w', encoding='utf-8') as sf:
+                json.dump(st, sf, indent=1, sort_keys=True)
+            os.replace(tmp, sp)
+        except Exception:                                    # noqa: BLE001
+            pass
         return p
     except Exception:                                       # noqa: BLE001
         return None
+
+
+def _status(a) -> int:
+    """--status: the NOW view, one command (run-23).
+
+    Refreshes RUN_STATE.json from the ledger via converge (subprocess, the
+    same authority every record goes through), prints it, then the last 5
+    driver stages and timed commands. Degrades gracefully on an empty or
+    absent workdir: an honest 'nothing recorded yet' beats a traceback.
+    """
+    import subprocess
+    work = _work(a)
+    if a.ledger and os.path.exists(a.ledger):
+        subprocess.run([sys.executable, '-X', 'utf8',
+                        os.path.join(ROOT, 'py_placer', 'converge.py'),
+                        'status', '--ledger', os.path.abspath(a.ledger)],
+                       cwd=ROOT, capture_output=True, text=True)
+    sp = os.path.join(work, 'RUN_STATE.json')
+    if os.path.exists(sp):
+        with open(sp, encoding='utf-8') as f:
+            print(f.read())
+    else:
+        print(f'RUN_STATE: nothing recorded yet ({sp} does not exist -- no '
+              f'lap has been recorded and no stage has run against this '
+              f'workdir).')
+    for name, label in (('loop_driver.log', 'driver stages'),
+                        ('cmd_timing.jsonl', 'timed commands')):
+        p = os.path.join(work, name)
+        if not os.path.exists(p):
+            continue
+        try:
+            with open(p, encoding='utf-8') as f:
+                tail = [json.loads(ln) for ln in f.read().splitlines()[-5:]
+                        if ln.strip()]
+        except (OSError, ValueError):
+            continue
+        print(f'last {len(tail)} {label}:')
+        for r in tail:
+            if name == 'loop_driver.log':
+                print(f"  {r.get('iso')}  {r.get('stage')}  exit "
+                      f"{r.get('exit')}"
+                      + ('  REFUSED' if r.get('refused') else ''))
+            else:
+                print(f"  {r.get('iso_start')}  {r.get('label')}  exit "
+                      f"{r.get('exit')}  {r.get('wall_s')}s")
+    return 0
+
+
+#: How long two invocations of the same stage against the same ledger have to be
+#: apart before they stop looking like the outer loop and an inner half both
+#: driving. Deliberately short: a legitimate re-run after fixing a refusal takes
+#: minutes of work, not seconds.
+_INNER_HALF_WINDOW_S = 180.0
+
+
+def _note_inner_half(logpath, row):
+    """Say so when an inner half appears to be driving the outer loop.
+
+    Run 20's routing teammate called `--stage L2` on the frozen board seconds
+    after being spawned -- the run-14 shape the delegation rule exists to
+    prevent, where the half that knows more than its parent quietly does the
+    parent's job and the classification never travels up. It was caught only
+    because a watcher happened to be reading the log.
+
+    REPORTS, never refuses. A legitimate re-run of a stage must not be blocked,
+    and this cannot distinguish the two with certainty -- it can only make the
+    shape visible at the moment it happens instead of in a post-mortem.
+    """
+    try:
+        with open(logpath, encoding='utf-8') as fh:
+            tail = fh.readlines()[-40:]
+    except OSError:
+        return
+    for line in reversed(tail):
+        try:
+            prev = json.loads(line)
+        except ValueError:
+            continue
+        if prev.get('stage') != row['stage']:
+            continue
+        if (row['t'] - float(prev.get('t') or 0)) > _INNER_HALF_WINDOW_S:
+            return                       # older than the window: nothing to say
+        if prev.get('board') == row['board'] and prev.get('cwd') == row['cwd']:
+            return                       # a plain re-run of the same thing
+        print(f'loop_driver NOTE: --stage {row["stage"]} was already invoked '
+              f'{row["t"] - float(prev.get("t") or 0):.0f}s ago against this '
+              f'same ledger, on a DIFFERENT board:\n'
+              f'    then: {prev.get("board")}\n'
+              f'    now:  {row["board"]}\n'
+              f'  If that earlier call was an inner half driving the outer '
+              f'loop, its classification never reaches the parent and the '
+              f'parent re-runs work it never authorised (the run-14 shape). '
+              f'Not refused -- a legitimate re-run looks the same from here.',
+              file=sys.stderr)
+        return
 
 
 #: Never open anything but the board you were given. A delegated half is a fresh
@@ -732,7 +972,9 @@ message.
   close-out    : {_asm}
                  python3 -X utf8 py_tools/check_assembly.py {_placed} \\
                      --clearance <the board's own floor> \\
-                     --json {_asm}
+                     --baseline {a.board} --json {_asm}
+                 (--baseline ARMS the run-23 courtyard gate; without it a
+                 pair your moves placed stays report-only)
   render       : {_rend}
                  the render_placement.py --json-out you actually READ
   freeze refs  : {_refs}
@@ -813,7 +1055,8 @@ def l2(a):
                 'gate alone and use ITS output:\n'
                 '  python3 -X utf8 py_router/check_drc.py <board> --clearance <floor> '
                 '--json wk/drc0.json\n'
-                '  python3 -X utf8 py_tools/check_assembly.py <board> --json '
+                '  python3 -X utf8 py_tools/check_assembly.py <board> '
+                '--baseline <the board the run started from> --json '
                 'wk/assembly0.json')
     # Bind the close-out to the board it is unlocking. check_assembly writes the
     # graded board's path into the payload and this gate never compared it, so
@@ -830,7 +1073,8 @@ def l2(a):
                 f'  handing to route: {os.path.abspath(a.board)}\n\n'
                 f'A stale close-out is not evidence about this board. Re-grade '
                 f'the board you are actually routing:\n'
-                f'  python3 -X utf8 py_tools/check_assembly.py {a.board} --json '
+                f'  python3 -X utf8 py_tools/check_assembly.py {a.board} '
+                f'--baseline <the board the run started from> --json '
                 f'wk/assembly_close.json')
 
     # SHAPE, BEFORE CONTENT. `blocking` exists in BOTH check_assembly's report
@@ -937,7 +1181,8 @@ def l2(a):
             'not say whether the placement is assembly-clean -- and a missing '
             'measurement is not a passing one. Produce the close-out from the '
             'instrument that measures it:\n'
-            '  python3 -X utf8 py_tools/check_assembly.py <board> --json '
+            '  python3 -X utf8 py_tools/check_assembly.py <board> '
+            '--baseline <the board the run started from> --json '
             'wk/assembly_close.json\n\nAn EMPTY or unrelated JSON satisfies a '
             'file-exists check and tells you nothing; that is the failure this '
             'refusal exists to stop.')
@@ -959,14 +1204,92 @@ def l2(a):
     oob, _ooberr = _count('oob_pad_count')
     if _ooberr:
         return err(_ooberr)
+    # PREFER the per-pad channel when a render is on hand. `oob_pad_count` is
+    # the COARSE measure and check_assembly's own `oob_pad_basis` string says so
+    # verbatim: it is a part pad AABB -- pads PLUS NPTH drill circles -- against
+    # an outline inflated by the GRADING CLEARANCE, so it moves when
+    # `--clearance` moves and a hit is not necessarily copper off the outline.
+    # The precise, margin-0 measure is render_placement's
+    # `checklist.a_off_outline.pad_copper`, and this gate was already being
+    # handed it.
+    #
+    # Measured on run 20, on the same board: coarse said [R4 0.2328,
+    # SW2 2.0172], per-pad said [SW2 1.5672]. R4's copper was on the board the
+    # whole time, and that single false positive is why --accept-residue
+    # oob_pad_count had to be used in BOTH cycles -- a waiver that also covers
+    # the real SW2 finding it was not meant to cover.
+    _oob_basis, _oob_refs = 'oob_pad_count (coarse, from check_assembly)', None
+    _pc = None
+    if getattr(a, 'render_json', None):
+        _rj, _rjerr = _load(a.render_json, 'The render (--render-json)')
+        if _rjerr:
+            # Not a refusal -- L3 is where a render is a gate. But the basis
+            # line must not claim a precision this gate did not get.
+            _oob_basis += f' -- {_rjerr}'
+        elif not isinstance(_rj, dict):
+            _oob_basis += ' -- the render is not a JSON object'
+        else:
+            # BOARD-BIND IT, exactly as _guard_route_render does for L3. This
+            # channel REPLACES the coarse count rather than max()ing it, so
+            # every way of getting the wrong document fails OPEN: a render of
+            # another board with an empty `pad_copper` turned a refusal into a
+            # pass on a board with three parts hanging off the outline. L2 was
+            # the only stage reading a document it did not bind.
+            _shown = ((_rj.get('instrument') or {}).get('board')
+                      if isinstance(_rj.get('instrument'), dict) else None)
+            if not _shown:
+                _oob_basis += (' -- the render carries no instrument.board, so '
+                               'it cannot say WHICH board it looked at '
+                               '(re-render with --json-out, not bare --json)')
+            elif os.path.normcase(os.path.abspath(_shown)) !=                     os.path.normcase(os.path.abspath(a.board)):
+                _oob_basis += (f' -- the render is of a DIFFERENT board '
+                               f'({_shown}), so it says nothing about this one')
+            else:
+                _chk = _rj.get('checklist')
+                _off = _chk.get('a_off_outline') if isinstance(_chk, dict) else None
+                _pc = _off.get('pad_copper') if isinstance(_off, dict) else None
+                if not isinstance(_pc, list):
+                    _oob_basis += (' -- the render carries no '
+                                   'checklist.a_off_outline.pad_copper')
+    if isinstance(_pc, list):
+        _oob_refs = [r[0] if isinstance(r, (list, tuple)) and r else r
+                     for r in _pc]
+        oob = len(_pc)
+        _oob_basis = ('checklist.a_off_outline.pad_copper (per-pad, margin 0, '
+                      'from the render)')
     if oob and oob > 0 and not _accept(a, 'oob_pad_count'):
+        _named = (f' Named: {", ".join(str(r) for r in _oob_refs)}.'
+                  if _oob_refs else '')
+        _corr = ''
+        if _oob_refs is not None:
+            _coarse, _ = _count('oob_pad_count')
+            if _coarse is not None and _coarse != oob:
+                # NOT "the coarse one is a phantom". The two measure DIFFERENT
+                # things and the extra parts in the coarse count are usually
+                # real -- just a different finding. Measured on run 20: the
+                # coarse channel named R4 as well as SW2, and R4's copper is
+                # indeed on the outline (so `pad_copper` is right to omit it)
+                # while `check_drc --check-pad-edge` reports R4.1 and R4.2 in
+                # CONTACT with the board edge. Calling that a false positive,
+                # as this message first did, discards a genuine violation.
+                _corr = (f'\n\ncheck_assembly\'s coarse `oob_pad_count` says '
+                         f'{_coarse}. They differ because the coarse measure '
+                         f'tests the pad AABB against an outline INFLATED by '
+                         f'the grading clearance -- so it also catches copper '
+                         f'that is ON the board but too close to its edge. '
+                         f'That is a real requirement, not noise: the extra '
+                         f'parts are a BOARD-EDGE CLEARANCE finding, and\n'
+                         f'  python3 -X utf8 py_router/check_drc.py {a.board} '
+                         f'--check-pad-edge\n'
+                         f'names them. Fix the per-pad count here; do not read '
+                         f'the difference as a false positive.')
         return err(
-            f'The placement close-out reports blocking = 0, but '
-            f'oob_pad_count = {oob}: {oob} part(s) carry pad copper OFF the '
-            f'board. Those parts are assembly-clean precisely because nothing '
+            f'The placement close-out reports blocking = 0, but {oob} part(s) '
+            f'carry pad copper OFF the board, measured by {_oob_basis}.{_named} '
+            f'Those parts are assembly-clean precisely because nothing '
             f'is out there to collide with, and their nets cannot be routed at '
-            f'all.\n\nThis is placement-shaped damage, and it is cheaper to '
-            f'fix now than to discover it as a routing failure and re-enter. '
+            f'all.{_corr}\n\nThis is placement-shaped damage, and it is cheaper '
+            f'to fix now than to discover it as a routing failure and re-enter. '
             f'Go back to the placement half.\n\nIf the overhang is BY DESIGN '
             f'-- a card edge, a switch actuator, a castellated module -- '
             f'declare it in the floorplan intent (edge_connectors), which '
@@ -985,14 +1308,60 @@ def l2(a):
             f'the board changed after the last lap was recorded -- and both '
             f'are the same problem for everything downstream, because the '
             f'ledger is what step-back, the film and the staleness list all '
-            f'read.\n\nRecord it:\n  python3 -X utf8 py_placer/converge.py record '
+            f'read.\n\nRecord it -- WITH a score, or the lap is invisible to '
+            f'the L5 plateau read (run-23: 17 score-less placement laps made '
+            f'the plateau NOT ANSWERABLE):\n'
+            f'  python3 -X utf8 .claude/skills/plan-pcb-routing/scripts/'
+            f'board_score.py \\\n      {a.board} --json {_work(a)}/score_place.json\n'
+            f'  python3 -X utf8 py_placer/converge.py record '
             f'--ledger {a.ledger} \\\n      --board {a.board} --kind placement '
-            f'--argv <the command that produced it>')
+            f'\\\n      --score-file {_work(a)}/score_place.json '
+            f'\\\n      --argv <the command that produced it>')
     # Deliberately NOT refusing on an empty or absent ledger. `_recorded`
     # returns None there, and this gate's own refusal text documents the case:
     # a board placed by someone else, handed straight to routing, has no
     # placement lap to record and never will. "I could not check" must not
     # become "you failed", or the legitimate path stops working.
+    # run-23: the BLIND-FIRST VISUAL REVIEW gate. Every numeric gate below
+    # passed run 23's board while it carried 15 courtyard interpenetrations
+    # and four mid-board connectors -- things a human saw in the render in
+    # seconds. The orchestrator viewed ONE image in 4.7 hours, after the
+    # failure, because no stage ever asked for eyes. This one does: the
+    # handoff is the last copper-free moment, so it is the cheapest one.
+    _rv = os.path.join(work, 'review_handoff.md')
+    if not (os.path.isfile(_rv) and os.path.getsize(_rv) >= 200):
+        return err(
+            f'No boundary review at {_rv} (missing or trivially small).\n\n'
+            f'Before the handoff, VIEW the board and write down what you saw '
+            f'-- BLIND-FIRST: open the renders and write your observations '
+            f'BEFORE reading any checklist key or banner metric. Run 23 '
+            f'measured why that ordering matters: the reviewer had "overlap '
+            f'26.30mm2" printed in the image banner and read past it, because '
+            f'the keys had already said clean and a closed question stays '
+            f'closed.\n\n'
+            f'  python3 -X utf8 py_tools/render_placement.py {a.board} \\\n'
+            f'      --clearance <the board\'s own floor> '
+            f'--review-sheet {work}/review_sheet.png \\\n'
+            f'      --json-out {work}/review_render.json --quiet -o {work}/review.png\n\n'
+            f'(--quiet keeps the keys off your screen -- the render used to echo '
+            f'JSON_SUMMARY in this very command, defeating the ordering '
+            f'this gate exists for. View the sheet BEFORE opening the '
+            f'JSON file.)\n\n'
+            f'Open {work}/review_sheet.png and write {_rv} with:\n'
+            f'  1. OBSERVATIONS (written before reading any JSON): connectors '
+            f'vs edges with distances; density pockets vs empty regions; '
+            f'orientation coherence; decap proximity; anything wrong that no '
+            f'key names.\n'
+            f'  2. RECONCILIATION (written after): every observation either '
+            f'dispositioned against a named key/number, or converted into a '
+            f'refusal of this handoff.\n'
+            f'  3. The check_pockets windows, each dispositioned:\n'
+            f'     python3 -X utf8 py_tools/check_pockets.py {a.board} '
+            f'--json {work}/pockets.json\n\n'
+            f'Observations must carry distances/mm2 the keys alone cannot '
+            f'produce -- that is what makes the review real rather than '
+            f'theater. ~2 images; run 23 spent 1.5M tokens NOT looking.')
+
     delegate, why = _delegation(a, half='routing')
     cyc, P = _paths(a)
     _frozen, _routed = P['frozen.kicad_pcb'], P['routed.kicad_pcb']
@@ -1024,8 +1393,11 @@ half wrote; do not re-derive it by diffing poses.
 
   python3 -X utf8 py_router/copy_board.py {a.board} {_frozen}
   ... stamp (locked yes) on the refs that file names ...
+  python3 -X utf8 .claude/skills/plan-pcb-routing/scripts/board_score.py \\
+      {_frozen} --json {work}/score_freeze.json
   python3 -X utf8 py_placer/converge.py record --ledger {a.ledger} \\
       --board {_frozen} --kind placement \\
+      --score-file {work}/score_freeze.json \\
       --lever "L2 freeze: <n> refs the placement half named as decisions"
 
 A later step that moves a decided pose silently undoes the placement work, and
@@ -1086,12 +1458,13 @@ hole-conflicting will still be there after the route, and no router setting
 removes it. Keep that board: it is the baseline `check_channels --baseline`
 needs, and you return its path below.
 
-No step has a wall-clock budget -- `--deadline` was removed everywhere (no
-result may depend on timing), so passing it is an argparse error. A harness
-timeout SIGTERMs the tool, its own shutdown never runs, and you get exit 143
-with no partial board and no summary. 143 and 124 are the SHELL's codes, not a
-tool's. Run long steps DETACHED, and bound them by SCOPE -- fewer nets, a
-tighter --max-ripup, a smaller violator set -- rather than by a clock.
+Only route.py and place_seed take a wall-clock budget
+(`--deadline`); the other mains lost the flag to #621, and passing it there is
+an argparse error. A harness timeout SIGTERMs a budget-less tool, its own
+shutdown never runs, and you get exit 143 with no partial board and no
+summary. 143 and 124 are the SHELL's codes, not a tool's. Run long steps
+DETACHED; pass `--deadline` where the tool has one, and bound the rest by
+SCOPE -- fewer nets, a tighter --max-ripup, a smaller violator set.
 
 Record EVERY accepted iteration into the ledger above with converge.py, and
 every rejected one with --rejected before stepping back. The stage after this
@@ -1136,6 +1509,26 @@ Return, and return ONLY:
   5. anything left UNGRADED, named as unexamined rather than clean.
 
 Do not summarise the process, and do not retype the numbers.
+
+IF A STEP RUNS LONG, HAND BACK -- do not wait on it. You cannot: a teammate has
+no way to sit on a backgrounded process and be woken when it exits, and both
+routing halves in run 20 returned "still working, I'll wait" for exactly that
+reason. Launch it detached (WITH --deadline when the tool takes one), then return three things and stop:
+  LOG=<where it is writing>   MARKER=<the file whose appearance means done>
+  NEXT=<what consumes it>
+This loop arms the wait and resumes you. That is a correct hand-back, not a
+failure -- report it as one and it will be read as one. The marker must be
+written by the STEP, never by you: a "done" file you write before returning says
+the work finished when it has not started. Run steps through
+tests/stress/tee_cmd.py and the marker is free: it writes
+logs/<label>.done containing the exit code at child exit -- wait on THAT
+file, never on a log line (run 23 lost 25 minutes to a completion line that
+goes to stdout while the waiter grepped the log).
+
+READ ROUTE RESULTS FROM THE `JSON_SUMMARY_MIN:` LINE -- one per run,
+authoritative-last, the MERGED tally in <1KB (run-23). The big JSON_SUMMARY
+lines are 6-20KB each, several per log, with scope semantics the log itself
+warns about; they are forensics, not your read.
 </subagent_prompt>
 
 When it returns, continue here with the paths it named. Do not retype its
@@ -1164,12 +1557,13 @@ only ones in front of you:
 Its Step 0 placement gate will pass: you just did that work, and the close-out
 is the evidence -- so it drops straight through to the routing stages.
 
-No step has a wall-clock budget -- `--deadline` was removed everywhere (no
-result may depend on timing), so passing it is an argparse error. A harness
-timeout SIGTERMs the tool, its own shutdown never runs, and you get exit 143
-with no partial board and no summary. 143 and 124 are the SHELL's codes, not a
-tool's. Run long steps DETACHED, and bound them by SCOPE -- fewer nets, a
-tighter --max-ripup, a smaller violator set -- rather than by a clock.
+Only route.py and place_seed take a wall-clock budget
+(`--deadline`); the other mains lost the flag to #621, and passing it there is
+an argparse error. A harness timeout SIGTERMs a budget-less tool, its own
+shutdown never runs, and you get exit 143 with no partial board and no
+summary. 143 and 124 are the SHELL's codes, not a tool's. Run long steps
+DETACHED; pass `--deadline` where the tool has one, and bound the rest by
+SCOPE -- fewer nets, a tighter --max-ripup, a smaller violator set.
 
 Two rules that are only true HERE, where the halves meet:
   - copper is not evidence about placement. A route that completed does not
@@ -1355,11 +1749,195 @@ check_reachability answers about ONE pad per run -- give it a pad on a failing
 net (or --net <id> --at <x,y>). A single genuine CAGED (exit 1) on the
 copper-free board is enough to make the shape placement.
 
+{_propose_shape(a)}
 Then re-run this stage with the shape you measured:
   --stage L4 --shape <parameter|placement|floorplan> --board {a.board} \\
       --score {a.score} --ledger {a.ledger} \\
+      [--defect-json <the record(s) that classified it>] \\
       [--congestion-json wk/cong_now.json --congestion-baseline wk/cong_base.json]
 </stage_instructions>'''
+
+
+def _propose_shape(a):
+    """Derive a shape from the evidence already in hand, and PRINT the derivation.
+
+    L3 prints four measurement commands and asks the operator to run
+    check_channels, check_reachability and two renders, read the exit codes and
+    decide. Every one of those measurements is exactly what a defect record and
+    a route summary contain -- so the loop was asking for work it was already
+    holding.
+
+    It PROPOSES; it does not decide and it does not refuse. `--shape` on L4
+    stays the operator's assertion -- this driver's own text calls that "the
+    guard that matters most", and it must keep costing a deliberate act. What
+    changes is that the assertion is now made against a printed derivation
+    instead of from memory.
+
+    Absent both inputs, returns '' and L3 reads exactly as it did before.
+    """
+    defects, notes = [], []
+    # `read` counts documents that PARSED, so "a record was given and it found
+    # nothing" stays distinguishable from "no record was given". They are
+    # different evidence: the first is a measurement that came back clean.
+    read = 0
+    for path in (getattr(a, 'defect_json', None) or []):
+        try:
+            with open(path, encoding='utf-8') as fh:
+                doc = json.load(fh)
+            if doc.get('kind') != 'defect-record':
+                notes.append(f'{path}: not a defect-record')
+                continue
+            read += 1
+            defects += list(doc.get('defects') or [])
+        except Exception as exc:                            # noqa: BLE001
+            notes.append(f'{path}: unreadable ({exc})')
+    summary = None
+    if getattr(a, 'route_summary', None):
+        summary, _serr = _load_route_summary(a.route_summary)
+        if _serr:
+            notes.append(_serr)
+    if not read and summary is None and not notes:
+        return ''
+
+    rows, shapes = [], set()
+    caged = [d for d in defects if d.get('verdict') == 'CAGED']
+    if caged:
+        d = caged[0]
+        m = d.get('measure') or {}
+        rows.append(
+            f'  CAGED on {d.get("net")} -- throat {m.get("gap_mm")}mm vs '
+            f'{m.get("gap_need_mm")}mm needed, margin '
+            f'{-1000.0 * (m.get("short_mm") or 0):+.2f} um'
+            + (f', between {", ".join(d.get("pads") or [])}'
+               if d.get('pads') else '')
+            + f'   -> placement')
+        # THE PRECONDITION, stated with the proposal rather than assumed: a
+        # CAGED verdict measured on ROUTED copper is rip-up depth, not
+        # placement, because the field it measured includes the router's own
+        # tracks. Three genuine cages once became three PASSABLE once the
+        # copper was removed.
+        rows.append('     (only if that was measured on the COPPER-FREE '
+                    'board -- on a routed one, CAGED is rip-up depth)')
+        shapes.add('placement')
+    blockers = (summary or {}).get('blockers') or []
+    if blockers:
+        rows.append(f'  summary["blockers"] names {len(blockers)} net(s) with '
+                    f'rippable copper in the way   -> parameter (congestion)')
+        shapes.add('parameter')
+    boxed = (summary or {}).get('boxed_in') or []
+    if boxed:
+        g = (boxed[0].get('geometry') or {})
+        rows.append(
+            f'  summary["boxed_in"] names {len(boxed)} net(s) walled in by '
+            f'STATIC obstacles, at grid {g.get("grid_step")}, clearance '
+            f'{g.get("clearance")}, track {g.get("track_width")}')
+        rows.append('     -> parameter (geometry) IF that geometry still has '
+                    'travel above the board\'s declared floor;')
+        rows.append('     -> placement    IF it is already AT the floor -- the '
+                    'parameter family is spent, and a finer grid alone has no '
+                    'geometry to pair with. L4 refuses the grid lever there.')
+        shapes.add('boxed')
+    if not rows:
+        rows.append('  the documents given carry no CAGED defect, no blockers '
+                    'and no box-in verdict -- nothing to derive from')
+    if shapes == {'placement'}:
+        verdict = 'proposed shape: placement'
+    elif shapes == {'parameter'}:
+        verdict = 'proposed shape: parameter'
+    elif shapes == {'boxed'}:
+        verdict = ('proposed shape: parameter OR placement -- decided by '
+                   'whether the geometry above is at the board floor')
+    elif shapes:
+        verdict = ('proposed shape: NONE -- the evidence DISAGREES across '
+                   'nets. Both readings are printed above; classify per net or '
+                   'measure again, do not average them.')
+    else:
+        verdict = 'proposed shape: none derivable from what was given'
+    return ('\nDERIVED FROM THE EVIDENCE YOU ALREADY HAVE:\n'
+            + '\n'.join(rows)
+            + (('\n  NOTE ' + '\n  NOTE '.join(notes)) if notes else '')
+            + f'\n\n  {verdict}\n  This is a PROPOSAL. --shape on L4 is still '
+              f'your assertion, and a disagreement between the two is printed '
+              f'there.\n')
+
+
+def _shape_disagreement(a):
+    """A LOUD note when --shape contradicts what the evidence derives, or ''.
+
+    Reports, never refuses. The evidence can be partial (reachability answers
+    about one pad) and the operator may know something the documents do not --
+    but a contradiction should never pass silently, because the whole cost of
+    this stage is that the wrong shape is expensive in both directions.
+    """
+    txt = _propose_shape(a)
+    if not txt:
+        return ''
+    for want, line in (('placement', 'proposed shape: placement'),
+                       ('parameter', 'proposed shape: parameter')):
+        if line in txt and a.shape != want:
+            return (f'loop_driver NOTE: you asserted --shape {a.shape}, but '
+                    f'the evidence you passed derives {want}:\n' + txt
+                    + f'  Proceeding with {a.shape} -- the assertion is '
+                      f'yours. Say in the ledger why the derivation is wrong.')
+    return ''
+
+
+def _defect_brief(paths):
+    """The defect records, as a TARGET line -- or '' when there are none.
+
+    Run 20 measured a cage at U4.54 (throat 0.409 mm against 0.450 needed,
+    blocking pads U4.53 and R7.2, relief ~0.042 mm) and then had to hand-write
+    that into an English paragraph in a ledger `lever` string and again into a
+    subagent prompt. The measurement existed; nothing could carry it.
+
+    NEVER a gate. L3 already refuses without `--render-json`; a second mandatory
+    document on the stage the loop turns on doubles the ways a real run stalls,
+    and producers are inherently partial (reachability answers about one pad).
+    """
+    out = []
+    for path in (paths or []):
+        try:
+            with open(path, encoding='utf-8') as fh:
+                doc = json.load(fh)
+        except Exception as exc:                            # noqa: BLE001
+            out.append(f'  --defect-json {path}: unreadable ({exc})')
+            continue
+        if doc.get('kind') != 'defect-record':
+            out.append(f'  --defect-json {path}: not a defect-record '
+                       f'({doc.get("kind")!r})')
+            continue
+        for d in (doc.get('defects') or []):
+            m = d.get('measure') or {}
+            at = d.get('at') or {}
+            who = ', '.join(d.get('pads') or d.get('refs') or [])
+            out.append(
+                f"  {d.get('verdict', '?')} {d.get('kind', '?')} on "
+                f"{d.get('net', '?')}"
+                + (f" at ({at['x']}, {at['y']}) {at.get('layer', '')}"
+                   if at.get('x') is not None else '')
+                + (f", between {who}" if who else ''))
+            if m.get('gap_mm') is not None:
+                # BOTH SPACES, each labelled. `bottleneck_mm` is slack space
+                # (2*(dist - clearance)); the physical gap is that plus
+                # 2*clearance. Run 20's ledger put one of each in one sentence
+                # as though they were the same number.
+                out.append(
+                    f"      gap {m['gap_mm']:.4f} / {m['gap_need_mm']:.4f} mm "
+                    f"needed (gap space); track {m.get('have_mm')} / "
+                    f"{m.get('need_mm')} (track space); short "
+                    f"{1000.0 * (m.get('short_mm') or 0):.1f} um at "
+                    f"{m.get('resolution_mm')} mm resolution")
+            for rel in (d.get('relief') or [])[:2]:
+                out.append(
+                    f"      TARGET: move {rel.get('ref')} >= "
+                    f"{rel.get('min_mm')} mm {rel.get('dir')} "
+                    f"(away from {rel.get('against')}) -- "
+                    f"{rel.get('bound', 'lower')} bound: this clears THIS pair "
+                    f"and may create another")
+    if not out:
+        return ''
+    return ('\nWHAT THIS RE-ENTRY IS AIMED AT (from --defect-json):\n'
+            + '\n'.join(out) + '\n')
 
 
 def l4(a):
@@ -1372,13 +1950,27 @@ def l4(a):
             'parameters spends iterations on a board no parameter can fix; '
             'sending a parameter-shaped failure back to placement throws away '
             'a routed board for nothing. L3 tells you how to measure it.')
+    # The assertion is still the operator's, and still costs a deliberate act.
+    # What is new is that it is now made against a DERIVATION L3 printed, so a
+    # disagreement between the two is a thing that can be seen rather than a
+    # thing that has to be remembered.
+    _disagree = _shape_disagreement(a)
+    if _disagree:
+        print(_disagree, file=sys.stderr)
     if a.shape == 'parameter':
         # Refuses only when the congestion evidence is MISSING. The numbers
         # themselves report and never refuse -- see _guard_congestion.
+        # BOTH preconditions, and the boxin one FIRST: a grid lever the router
+        # has already said cannot help is futile whether or not the congestion
+        # evidence exists, so asking for that evidence first would send the
+        # operator off to render two boards for a lap that is refused anyway.
+        _bok, _bwhy = _guard_static_boxin(a)
+        if not _bok:
+            return err(_bwhy)
         _cok, _cwhy = _guard_congestion(a)
         if not _cok:
             return err(_cwhy)
-        _cread = f'\n{_cwhy}\n' if _cwhy else ''
+        _cread = ''.join(f'\n{x}\n' for x in (_bwhy, _cwhy) if x)
         return f'''<stage_instructions stage="L4" name="re-enter: parameter" of="5">
 {_cread}
 Re-enter the FAILING ROUTING STEP with the parameter changed. Nothing before it
@@ -1445,10 +2037,11 @@ Next: --stage L1 --board <the adopted arrangement> --ledger {a.ledger}
             f'{a.ledger} \\\n'
             '          --board <the routed board> --kind completion \\\n'
             '          --score-file <the score json> --argv <the command>')
+    _dbrief = _defect_brief(getattr(a, 'defect_json', None))
     return f'''<stage_instructions stage="L4" name="re-enter: placement" of="5">
 This is the expensive one, and the cost is the point: no router setting adds a
 lane, so every routed board produced from this placement is now stale.
-
+{_dbrief}
 Routed boards this ledger recorded, which must not be reused:
 {stale}
 
@@ -1701,7 +2294,8 @@ check_complete is the one that fails CLOSED: board_score exits 0 with four of
 nine components ungraded, and it has no component at all for orphan stubs,
 weird copper or pad overlaps. --authored-from is what lets it see whether this
 board grades itself against floors it rewrote -- the writeback only ever
-loosens, so without the original project there is nothing left to compare to.
+loosens. Without it the check falls back to the project's own fab_floor_origin,
+which is narrower (only the keys declared at the first writeback), so pass it.
 
 Connectivity is orthogonal to DRC: a DRC-clean board can be entirely
 disconnected, because isolated copper has no clearance conflicts.
@@ -1995,10 +2589,14 @@ def _close_out(a, name):
                 f'  python3 -X utf8 check_complete.py {a.board} \\\n'
                 f'      --authored-from <the board this chain STARTED from> \\\n'
                 f'      --json wk/routing_close.json\n\n'
-                f'--authored-from is not optional bookkeeping: without it the '
-                f'floor check cannot run at all, and UNSOUND becomes '
-                f'unreachable. The chain rewrites the floors in place, so the '
-                f'original project is the only thing left to compare against.')
+                f'--authored-from is not optional bookkeeping. Without it the '
+                f'floor check falls back to the project\'s own '
+                f'fab_floor_origin, which is NARROWER: it holds only the keys '
+                f'the project declared at the FIRST writeback, so a floor the '
+                f'human never wrote down has no baseline and lands in '
+                f'`unmeasured` instead of `relaxed`. Pass it anyway -- the '
+                f'chain rewrites the floors in place, and the original project '
+                f'is the only complete record of what they were.')
 
     _missing = [k for k in CLOSE_KEYS if k not in doc]
     if _missing or doc.get('verdict') not in CLOSE_VERDICTS:
@@ -2081,7 +2679,35 @@ def _close_out(a, name):
     # STUCK/BUDGET alongside INCOMPLETE is a CONSISTENT pair and passes. It
     # lives in _cross_check now because it also has to run on the CONTINUE
     # branch -- see there for the run where it never ran at all.
-    return _cross_check(a, name, doc)
+    _disagree = _cross_check(a, name, doc)
+    if _disagree:
+        return _disagree
+    # run-23: the LAST guard, deliberately -- every evidence check above
+    # has passed, and the remaining question is whether anyone LOOKED.
+    # Same blind-first protocol as L2's handoff review, on the board
+    # being SHIPPED; not waivable by --accept-unclosed (that flag accepts
+    # a named CHECK's residue; this is not a check, it is eyes).
+    _work_dir = _work(a)
+    _rvc = os.path.join(_work_dir, 'review_close.md')
+    if not (os.path.isfile(_rvc) and os.path.getsize(_rvc) >= 200):
+        return err(
+            f'Every close-out number passed -- and nobody has LOOKED at '
+            f'the board being shipped ({_rvc} is missing or trivially '
+            f'small).\n\nRun 23 shipped a board a human rejected at a '
+            f'glance -- 15 courtyard interpenetrations, connectors '
+            f'mid-board -- while every terminal number read clean. '
+            f'Produce the sheet, view it BLIND-FIRST (observations '
+            f'written before reading any key), then reconcile each '
+            f'observation against a named number or refuse this close:\n'
+            f'  python3 -X utf8 py_tools/render_placement.py {a.board} \\\n'
+            f'      --clearance <the board\'s own floor> '
+            f'--review-sheet {_work_dir}/review_close_sheet.png \\\n'
+            f'      --json-out {_work_dir}/review_close_render.json --quiet '
+            f'-o {_work_dir}/review_close.png\n'
+            f'(--quiet keeps the keys off your screen; view the sheet BEFORE '
+            f'opening the JSON file.)\n'
+            f'Write the review to {_rvc}, then re-run this stage.')
+    return None
 
 
 STAGES = {'L1': l1, 'L2': l2, 'L3': l3, 'L4': l4, 'L5': l5}
@@ -2097,7 +2723,13 @@ def _args(argv=None):
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument('--stage', choices=sorted(STAGES))
     ap.add_argument('--board', default='board.kicad_pcb')
-    ap.add_argument('--ledger', default='wk/ledger.jsonl')
+    ap.add_argument('--workdir', default='wk',
+                    help="the work dir the emitted instructions should point at. Default 'wk' leaves them exactly as before. Set it and every wk/ path in the printed stage text is retargeted, so the artifacts land where run_watch/fence_audit/provenance_audit actually look -- they walk only the dir they are given, and a relative wk/ resolves against the process CWD instead")
+    # None, then filled from --workdir after parse: a hardcoded
+    # 'wk/ledger.jsonl' is the one path this driver resolves ITSELF,
+    # so leaving it fixed would put the ledger outside the work dir
+    # even when every emitted instruction pointed inside it.
+    ap.add_argument('--ledger', default=None)
     ap.add_argument('--placement-report', default=None)
     ap.add_argument('--score', default=None)
     ap.add_argument('--congestion-json', default=None, metavar='PATH',
@@ -2110,6 +2742,13 @@ def _args(argv=None):
     ap.add_argument('--congestion-baseline', default=None, metavar='PATH',
                     help='render_placement --json-out of the pre-placement '
                          'board, to compare --congestion-json against.')
+    ap.add_argument('--accept-boxin', default=None, metavar='REASON',
+                    help="proceed with a `parameter` re-entry even though the "
+                         "route summary reports the failing nets boxed in by "
+                         "STATIC obstacles at the board's declared floor. Takes "
+                         "the REASON, echoed into the stage body so it reaches "
+                         "the ledger. Run 20 spent three grid laps (~40 min) "
+                         "against exactly this verdict.")
     ap.add_argument('--accept-congestion', default=None, metavar='REASON',
                     help='Proceed with --shape parameter even though the '
                          'congestion read says the failure may be '
@@ -2121,6 +2760,18 @@ def _args(argv=None):
                          'speaks the L2 placement gate\'s vocabulary, and a '
                          'waiver that covers two gates at once waives the one '
                          'that was working.')
+    ap.add_argument('--route-summary', default=None, metavar='PATH',
+                    help="the route step's JSON_SUMMARY. L3 reads `blockers` "
+                         "and `boxed_in` from it to propose a shape, and L4 "
+                         "reads `boxed_in` to refuse a grid lever the router "
+                         "has already said will not help.")
+    ap.add_argument('--defect-json', action='append', default=None,
+                    metavar='PATH',
+                    help='defect-record document(s) -- check_reachability '
+                         '--defect-json. L3 derives a proposed shape from them '
+                         'and L4-placement prints the TARGET they name. Never '
+                         'a gate: a second mandatory document on the stage the '
+                         'loop turns on doubles the ways a real run stalls.')
     ap.add_argument('--render-json', default=None, metavar='PATH',
                     help='render_placement --json-out document. L3 requires '
                          'one when there is a failure to classify: "one pocket '
@@ -2174,7 +2825,61 @@ def _args(argv=None):
     ap.add_argument('--list', action='store_true')
     ap.add_argument('--dump-all', action='store_true')
     ap.add_argument('--self-test', action='store_true')
-    return ap.parse_args(argv)
+    ap.add_argument('--status', action='store_true',
+                    help='the NOW view (run-23): print RUN_STATE.json '
+                         '(refreshing it from the ledger first), the last 5 '
+                         'driver stages and the last 5 timed commands. One '
+                         'command to reorient instead of tailing three logs.')
+    ns = ap.parse_args(argv)
+    # Fill the ledger from the work dir, preserving the old default exactly
+    # when --workdir is not given.
+    if ns.ledger is None:
+        wd = (getattr(ns, 'workdir', None) or 'wk').replace(chr(92), '/')
+        ns.ledger = wd.rstrip('/') + '/ledger.jsonl'
+    return ns
+
+
+#: Paths in the emitted instructions are written against `wk/`. When the caller
+#: names a real work dir, retarget them -- otherwise the agent executing those
+#: instructions writes to a literal relative `wk/...`, which resolves against
+#: the process CWD and lands OUTSIDE the directory every audit walks.
+#:
+#: Measured, run 22: `run_watch --workdir`, `fence_audit --workdir` and
+#: `provenance_audit --workdir` all walk only the directory they are given, so
+#: a driver that tells the agent to write `wk/locks.json` puts that artifact
+#: where all three are blind. That is a hole in the EVIDENCE, not a cosmetic
+#: path issue: the watchers reported a clean run over a directory half the
+#: run's artifacts never entered.
+#:
+#: One substitution at the single emission point, rather than rewriting ~70
+#: string literals across two 3000-line files -- that diff would be large,
+#: risky, and would touch text an agent executes verbatim.
+_WK_RE = _re_wk.compile(r'(?<![\w./-])wk/')
+
+#: Real repo artifacts that live under `wk/` and must NOT be retargeted: they
+#: are prose references to things that exist, not work paths the caller owns.
+_WK_KEEP_RE = _re_wk.compile(r'wk/(?:calibration|run\d+)/')
+
+
+def _retarget(text, workdir):
+    """Point the emitted instructions at the caller's work dir.
+
+    The default `wk` short-circuits and returns the text unchanged, so every
+    existing caller -- and both embedded self-test suites, which construct
+    args without --workdir -- sees byte-identical output.
+    """
+    if not text or not workdir:
+        return text
+    wd = str(workdir).replace('\\', '/').rstrip('/')
+    if wd in ('', 'wk'):
+        return text
+    out, last = [], 0
+    for m in _WK_KEEP_RE.finditer(text):
+        out.append(_WK_RE.sub(wd + '/', text[last:m.start()]))
+        out.append(m.group(0))
+        last = m.end()
+    out.append(_WK_RE.sub(wd + '/', text[last:]))
+    return ''.join(out)
 
 
 def main(argv=None):
@@ -2183,6 +2888,8 @@ def main(argv=None):
         for k in ('L1', 'L2', 'L3', 'L4', 'L5'):
             print(f'  {k}  {TITLES[k]}')
         return 0
+    if a.status:
+        return _status(a)
     if a.self_test:
         return _self_test()
     if a.dump_all:
@@ -2205,6 +2912,9 @@ def main(argv=None):
             # opposite of what a dump is for.
             _bd = os.path.join(tmp, 'b.kicad_pcb')
             open(_bd, 'w', encoding='utf-8').close()
+            # run-23: the review gates read files beside the ledger.
+            _stage_review(tmp, 'review_handoff.md')
+            _stage_review(tmp, 'review_close.md')
             # ...and a LEDGER carrying that board's sha. L5 now refuses without
             # one, because its verdict is computed from the ledger and an empty
             # history reads as "still improving".
@@ -2314,7 +3024,7 @@ def main(argv=None):
     if not a.stage:
         print('loop_driver: --stage is required (see --list)', file=sys.stderr)
         return 2
-    out = STAGES[a.stage](a)
+    out = _retarget(STAGES[a.stage](a), getattr(a, 'workdir', None))
     code = 4 if out.startswith('<error>') else 0
     # BEFORE the print, so a stage that dies printing still leaves its trace,
     # and on stdout NOTHING changes -- existing callers tee exactly what they
@@ -2322,6 +3032,24 @@ def main(argv=None):
     _log_invocation(a, a.stage, out, code)
     print(out)
     return code
+
+
+def _stage_review(d, name):
+    """A non-trivial review fixture, for tests exercising the OTHER guards.
+
+    run-23 added the blind-first review gates (L2 handoff, close-out); every
+    self-test case that expects a stage to EMIT must carry one, exactly as
+    the close-out fixtures carry every key their gates read.
+    """
+    p = os.path.join(d, name)
+    with open(p, 'w', encoding='utf-8') as fh:
+        fh.write('# boundary review (self-test fixture)\n\n'
+                 'OBSERVATIONS (blind-first): fixture board, no panels to '
+                 'view in a unit test; nothing off-outline, no pockets, no '
+                 'interior connectors observed.\n\n'
+                 'RECONCILIATION: nothing observed, nothing to disposition; '
+                 'the numeric gates carry this fixture.\n')
+    return p
 
 
 def _self_test():
@@ -2343,7 +3071,10 @@ def _self_test():
         # 74, not 70: run-19 A2 grew FENCE_CLAUSE by four lines (the
         # hand-script disclosure duty). L1 sits exactly AT the cap, as it
         # did at 70 -- any further growth is a deliberate decision, here.
-        want(len(out.splitlines()) <= 74, f'{key} stays under 74 lines')
+        # 76, not 74: run-23 grew L1's close-out command by --baseline plus a
+        # two-line note (it ARMS the courtyard gate; omitting it is how J4
+        # shipped 0.90mm inside U6). Deliberate, decided here.
+        want(len(out.splitlines()) <= 76, f'{key} stays under 76 lines')
 
     want(STAGES['L2'](_args(base)).startswith('<error>'),
          'routing refuses to start without a placement close-out')
@@ -2359,6 +3090,11 @@ def _self_test():
         # detector: run 10 fed this gate `board_score`'s JSON, which shares the
         # field name `blocking` and means a six-component total by it, and
         # three of the four checks silently did not run.
+        # run-23: pass-through cases also need the review gate satisfied, in
+        # THIS tmp (never the repo's wk/), so the ledger is scoped here too.
+        base = ['--board', 'b.kicad_pcb',
+                '--ledger', os.path.join(tmp, 'ledger.jsonl')]
+        _stage_review(tmp, 'review_handoff.md')
         _asm = {'buildable': True, 'verdict': 'buildable (blocking 0)',
                 'locked_contacts': 0, 'oob_pad_count': 0}
         p = os.path.join(tmp, 'p.json')
@@ -2378,8 +3114,10 @@ def _self_test():
         json.dump({**_asm, 'blocking': 0, 'oob_pad_count': 4},
                   open(oob, 'w', encoding='utf-8'))
         out = STAGES['L2'](_args(base + ['--placement-report', oob]))
-        want(out.startswith('<error>') and 'oob_pad_count = 4' in out,
-             'routing refuses a blocking-0 placement with pads off the board')
+        want(out.startswith('<error>') and '4 part(s) carry pad copper OFF'
+              in out and 'coarse' in out,
+             'routing refuses a blocking-0 placement with pads off the board, '
+             'and names the count and the measure it used')
         want('edge_connectors' in out,
              '...and names how a BY-DESIGN overhang is declared instead')
         out = STAGES['L2'](_args(base + ['--placement-report', oob,
@@ -2393,7 +3131,8 @@ def _self_test():
         # oob_pad_count gate went with it.
         out = STAGES['L2'](_args(base + ['--placement-report', oob,
                                          '--accept-residue', 'blocking']))
-        want(out.startswith('<error>') and 'oob_pad_count = 4' in out,
+        want(out.startswith('<error>') and '4 part(s) carry pad copper OFF'
+              in out,
              'accepting `blocking` does NOT waive the oob_pad_count gate')
         out = STAGES['L2'](_args(base + ['--placement-report', oob,
                                          '--accept-residue']))
@@ -2437,6 +3176,7 @@ def _self_test():
         want('nothing to classify' in out,
              'a clean score has no failure to classify')
 
+    base = ['--board', 'b.kicad_pcb']
     with tempfile.TemporaryDirectory() as _ct:
         def _cong(name, hpwl, crossings=500.0):
             p = os.path.join(_ct, name)
@@ -2552,7 +3292,9 @@ def _self_test():
             n = _part_count(small)
             want(isinstance(n, int) and n > 0,
                  'the board can be sized at all')
-            auto = ['--board', small, '--placement-report', rep]
+            _stage_review(_t, 'review_handoff.md')     # run-23 gate fixture
+            auto = ['--board', small, '--placement-report', rep,
+                    '--ledger', os.path.join(_t, 'ledger.jsonl')]
             for k in ('L1', 'L2'):
                 out = STAGES[k](_args(auto))
                 want('DELEGATING:' in out and '<subagent_prompt' in out,
@@ -2586,7 +3328,8 @@ def _self_test():
         # An unreadable board no longer changes the decision -- it only changes
         # what can be SAID about it.
         out = STAGES['L1'](_args(['--board', os.path.join(_t, 'nope.kicad_pcb'),
-                                  '--placement-report', rep]))
+                                  '--placement-report', rep,
+                                  '--ledger', os.path.join(_t, 'l2.jsonl')]))
         want('could not be read' in out and '<subagent_prompt' in out,
              'an unreadable board still delegates, and says it could not size it')
 
@@ -2598,6 +3341,8 @@ def _self_test():
         # close-out commands, and the close-out is the run's terminal artifact.
         _bf = os.path.join(tmp, 'b.kicad_pcb')
         open(_bf, 'w', encoding='utf-8').close()
+        _stage_review(tmp, 'review_handoff.md')      # run-23 gate fixtures
+        _stage_review(tmp, 'review_close.md')
         ok_rep = os.path.join(tmp, 'p.json')
         # The close-out must also carry the keys the L2 gate now reads --
         # `buildable`, `locked_contacts` and the board it graded -- because a
@@ -2683,6 +3428,8 @@ def _self_test():
         # fixtures were relying on that.
         _b5 = os.path.join(tmp, 'b.kicad_pcb')
         open(_b5, 'w', encoding='utf-8').close()
+        _stage_review(tmp, 'review_handoff.md')      # run-23 gate fixtures
+        _stage_review(tmp, 'review_close.md')
         base = ['--board', _b5]
 
         want(STAGES['L5'](_args(base)).startswith('<error>'),
@@ -2991,6 +3738,8 @@ def _self_test():
     with tempfile.TemporaryDirectory() as tmp:
         _b = os.path.join(tmp, 'b.kicad_pcb')
         open(_b, 'w', encoding='utf-8').write('(kicad_pcb)')
+        _stage_review(tmp, 'review_handoff.md')      # run-23 gate fixtures
+        _stage_review(tmp, 'review_close.md')
         sys.path.insert(0, ROOT)
         from board_store import sha256_file as _shaf2
         _rep = os.path.join(tmp, 'p.json')
@@ -3294,6 +4043,7 @@ def _self_test():
         # the freeze itself writes the _cN name.
         _c2 = os.path.join(tmp, 'c2')
         os.makedirs(_c2)
+        _stage_review(_c2, 'review_handoff.md')      # run-23 gate fixture
         open(os.path.join(_c2, 'frozen_c2.kicad_pcb'), 'w',
              encoding='utf-8').close()
         _c2fwd = _c2.replace('\\', '/')

--- a/.claude/skills/plan-pcb-placement/scripts/placement_driver.py
+++ b/.claude/skills/plan-pcb-placement/scripts/placement_driver.py
@@ -27,11 +27,12 @@ Exit: 0 emitted, 2 usage, 4 a guard refused.
 import argparse
 import json
 import os
+import re as _re_wk
 import sys
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 SKILL_DIR = os.path.dirname(HERE)
-REFS = os.path.join(os.path.dirname(SKILL_DIR), 'plan-pcb-routing', 'references')
+REFS = os.path.join(os.path.dirname(SKILL_DIR), 'plan-pcb-placement-and-routing', 'references')
 
 
 # --------------------------------------------------------------------------
@@ -136,8 +137,36 @@ Walk the ladder in order and say which rung applies:
        python3 -X utf8 py_placer/place_seed.py {a.board} seed.kicad_pcb --intent fp.json
    The seeder grades its own output against the same intent; exit 4 means the
    seed does not satisfy the intent it was built from, and says which rule broke.
-3. Neither -> say so and STOP. This toolchain does not invent a placement, and
-   inventing mechanical geometry is what every rule here forbids.
+   A part it cannot seat is no longer a dead end: it censuses the seated
+   neighbours, evicts the one that frees the most poses, seats the part, then
+   puts the blocker back -- gated and reverted whole if the board does not
+   improve. READ `no_pose_blockers` in its JSON_SUMMARY -- it maps each
+   unseated ref to each blocker and the poses lifting that blocker frees,
+   which IS the next move where a bare "no legal pose" was a dead end.
+   `--evict-depth 0` censuses and moves nothing, if you want the call.
+3. The arrangement is STRUCTURAL and an intent cannot hold it -- a key matrix,
+   a mirrored pair of halves, a row at a pitch, a part whose ROTATION is the
+   decision. An intent has no pitch, no mirror, no rotation and no origin you
+   can measure off the outline. Treat those poses as MECHANICAL FACTS (P2):
+   compute each one off the outline, write it, lock the ref, and let the
+   seeder and the quench work around the locked set:
+       python3 -X utf8 py_placer/place_seed.py {a.board} seed.kicad_pcb --intent fp.json
+       python3 -X utf8 py_placer/place_optimize.py seed.kicad_pcb out.kicad_pcb --lock <REFS>
+   READ THE BOARD FIRST -- render it and read the JSON beside the picture
+   (part extents, free regions, the blocking pairs at the fab floor), so the
+   poses you assert are measured rather than guessed:
+       python3 -X utf8 py_tools/render_placement.py {a.board} --json-out view.json -o view/
+       python3 -X utf8 py_tools/check_assembly.py {a.board} --clearance <C> --json asm.json
+4. Neither, and the board may simply be too small -- MEASURE that rather than
+   asserting it: compare the parts' courtyard area against the usable area
+   inside the outline (render_placement's JSON carries both), and count the
+   blocking pairs check_assembly reports at the fab floor. Hand back the
+   numbers and the options -- a larger outline, more layers, a tighter
+   clearance the fab supports. NEVER act on them: the outline and the stackup
+   are mechanical decisions the user owns.
+5. Still neither -> say so and STOP. This toolchain does not invent mechanical
+   geometry. But do not reach rung 5 without having run rung 4: "too small"
+   with a number is a finding, and "too small" without one is a guess.
 
 Next: --stage P4 (legalize the seed) or --stage P6 (declare the intent first).
 </stage_instructions>'''
@@ -259,8 +288,8 @@ R2  Does the BOARD determine a position? A family whose pattern is
 R3  Apply with the repair tools, never the from-scratch seeder:
       python3 -X utf8 py_placer/place_seed.py {a.board} r.kicad_pcb --intent fp.json --repair
       python3 -X utf8 py_placer/place_reconstruct.py {a.board} r.kicad_pcb [--intent fp.json]
-    Both take --dry-run and report what they WOULD do, and both take
-    NO STEP HAS A WALL-CLOCK BUDGET -- `--deadline` was removed everywhere (no result may depend on timing), so passing it is an argparse error. A harness timeout SIGTERMs the tool, its shutdown never runs, and you get exit 143 with no partial board and no summary. 143 and 124 are the SHELL's codes, not a tool's. Run long steps DETACHED, and bound them by scope rather than by a clock.
+    Both take --dry-run and report what they WOULD do. place_seed also takes
+    --deadline SECONDS -- BELOW THE SMALLEST CAP IN THE STACK, your harness's included (a 2400s deadline inside a 600s window can never fire). place_reconstruct has NO wall-clock budget (#621 removed its --deadline; passing it is an argparse error) -- bound it by scope and run it DETACHED. A harness timeout SIGTERMs a budget-less tool, its shutdown never runs, and you get exit 143 with no partial board and no summary. 143 and 124 are the SHELL's codes, not a tool's.
 R3b A part whose pad CENTRES are off the outline is not repairable by a
     minimal-move sweep, whatever cap you give it: every repair search starts
     from the part's current pose, and that pose carries no information once
@@ -367,9 +396,16 @@ you which one worked.
 VERIFY: re-run all four. A lap is ACCEPTED only if the finding it aimed at is
 gone and nothing above it got worse.
 
-Then record it, before starting the next lap:
+Then record it, before starting the next lap -- WITH a score, or the lap is
+invisible to every plateau read downstream (run-23: seventeen placement laps
+recorded score-less; converge's window dropped them all as 'unjudged', L5's
+plateau question came back NOT ANSWERABLE, and run_watch's lap comparison
+reset on every one):
+  python3 -X utf8 .claude/skills/plan-pcb-routing/scripts/board_score.py \\
+      {a.board} --json wk/score_lap<N>.json
   python3 -X utf8 py_placer/converge.py record --ledger wk/ledger.jsonl \\
       --board {a.board} --kind placement --lever "<what you changed and why>" \\
+      --score-file wk/score_lap<N>.json \\
       --argv <the real command that produced this board, as BARE TOKENS>
 
 --argv takes the rest of the line, unquoted, and it must REPLAY: converge
@@ -439,9 +475,15 @@ def p6(a):
     return f'''<stage_instructions stage="P6" name="declare the intent" of="7">
 An intent turns "it looks right" into something gradable.
 
-  python3 -X utf8 py_tools/check_floorplan.py {a.board} --emit-intent wk/intent.json
+  python3 -X utf8 py_tools/check_floorplan.py {a.board} --emit-intent wk/intent.json \\
+      --declare-classes
   # then EDIT it down: the emit describes the board as it is, including its
   # damage. Keep what the SPEC requires; delete what is merely observed.
+  # --declare-classes is what puts CONNECTORS in the intent (run-23): without
+  # it only parts already overhanging get an entry, so a header seated
+  # mid-board is invisible to every rule -- run 23 shipped J2/J5/J6/J7 that
+  # way. Receptacles get an edge; generic connectors get the weak
+  # connector_affinity class (INTERIOR flagged at advisory, never an error).
 
   python3 -X utf8 py_tools/check_floorplan.py {a.board} --intent wk/intent.json --health
 
@@ -487,7 +529,7 @@ def p_close(a):
             '`rules_run: 0`, which constrained two laps with nothing, then a '
             'second covering 0 of 266 parts. Nothing objected either time.\n\n'
             '  python3 -X utf8 py_tools/check_floorplan.py <board> '
-            '--emit-intent wk/intent.json\n'
+            '--emit-intent wk/intent.json --declare-classes\n'
             '  # then EDIT IT DOWN -- the emit describes the board AS IT IS, '
             'damage included\n'
             '  python3 -X utf8 py_tools/check_floorplan.py <board> '
@@ -1060,6 +1102,8 @@ def _args(argv=None):
     ap = argparse.ArgumentParser(add_help=True, description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument('--stage', choices=sorted(STAGES))
+    ap.add_argument('--workdir', default='wk',
+                    help="the work dir the emitted instructions should point at. Default 'wk' leaves them exactly as before. Set it and every wk/ path in the printed stage text is retargeted, so the artifacts land where run_watch/fence_audit/provenance_audit actually look -- they walk only the dir they are given, and a relative wk/ resolves against the process CWD instead")
     ap.add_argument('--board', default='board.kicad_pcb')
     ap.add_argument('--before', default=None,
                     help='the board this one was derived from (the delta gates '
@@ -1112,6 +1156,97 @@ def _args(argv=None):
     return ap.parse_args(argv)
 
 
+#: Paths in the emitted instructions are written against `wk/`. When the caller
+#: names a real work dir, retarget them -- otherwise the agent executing those
+#: instructions writes to a literal relative `wk/...`, which resolves against
+#: the process CWD and lands OUTSIDE the directory every audit walks.
+#:
+#: Measured, run 22: `run_watch --workdir`, `fence_audit --workdir` and
+#: `provenance_audit --workdir` all walk only the directory they are given, so
+#: a driver that tells the agent to write `wk/locks.json` puts that artifact
+#: where all three are blind. That is a hole in the EVIDENCE, not a cosmetic
+#: path issue: the watchers reported a clean run over a directory half the
+#: run's artifacts never entered.
+#:
+#: One substitution at the single emission point, rather than rewriting ~70
+#: string literals across two 3000-line files -- that diff would be large,
+#: risky, and would touch text an agent executes verbatim.
+_WK_RE = _re_wk.compile(r'(?<![\w./-])wk/')
+
+#: Real repo artifacts that live under `wk/` and must NOT be retargeted: they
+#: are prose references to things that exist, not work paths the caller owns.
+_WK_KEEP_RE = _re_wk.compile(r'wk/(?:calibration|run\d+)/')
+
+
+def _retarget(text, workdir):
+    """Point the emitted instructions at the caller's work dir.
+
+    The default `wk` short-circuits and returns the text unchanged, so every
+    existing caller -- and both embedded self-test suites, which construct
+    args without --workdir -- sees byte-identical output.
+    """
+    if not text or not workdir:
+        return text
+    wd = str(workdir).replace('\\', '/').rstrip('/')
+    if wd in ('', 'wk'):
+        return text
+    out, last = [], 0
+    for m in _WK_KEEP_RE.finditer(text):
+        out.append(_WK_RE.sub(wd + '/', text[last:m.start()]))
+        out.append(m.group(0))
+        last = m.end()
+    out.append(_WK_RE.sub(wd + '/', text[last:]))
+    return ''.join(out)
+
+
+def _log_invocation(a, stage, out, code):
+    """Append this invocation to <workdir>/placement_driver.log (run-23).
+
+    loop_driver has journalled itself since run 15; this driver never did,
+    so a placement stage that ran, refused and was worked around left no
+    trace the audit could find. Same row shape, same never-breaks-a-stage
+    contract; also stamps the stage onto the workdir's RUN_STATE.json (the
+    ledger-derived body of that file is converge.write_run_state's).
+    """
+    import hashlib
+    import json as _json
+    import time as _time
+    try:
+        d = getattr(a, 'workdir', None) or 'wk'
+        if not os.path.isdir(d):
+            return None
+        row = {'t': round(_time.time(), 3),
+               'iso': _time.strftime('%Y-%m-%dT%H:%M:%S'),
+               'stage': stage, 'exit': code, 'refused': bool(code == 4),
+               'board': getattr(a, 'board', None),
+               'cwd': os.getcwd(), 'argv': list(sys.argv),
+               'out_sha': hashlib.sha256(
+                   (out or '').encode('utf-8')).hexdigest()[:16],
+               'out_lines': len((out or '').splitlines())}
+        with open(os.path.join(d, 'placement_driver.log'), 'a',
+                  encoding='utf-8') as fh:
+            fh.write(_json.dumps(row, sort_keys=True) + '\n')
+        try:
+            sp = os.path.join(d, 'RUN_STATE.json')
+            st = {}
+            if os.path.exists(sp):
+                with open(sp, encoding='utf-8') as sf:
+                    st = _json.load(sf)
+            st.update({'last_stage': f'placement:{stage}',
+                       'stage_exit': code,
+                       'stage_refused': bool(code == 4),
+                       'stage_written_at': row['iso']})
+            tmp = sp + '.tmp'
+            with open(tmp, 'w', encoding='utf-8') as sf:
+                _json.dump(st, sf, indent=1, sort_keys=True)
+            os.replace(tmp, sp)
+        except Exception:                                    # noqa: BLE001
+            pass
+        return d
+    except Exception:                                       # noqa: BLE001
+        return None
+
+
 def main(argv=None):
     a = _args(argv)
     if a.list:
@@ -1126,9 +1261,11 @@ def main(argv=None):
         print('placement_driver: --stage is required (see --list)',
               file=sys.stderr)
         return 2
-    out = STAGES[a.stage](a)
+    out = _retarget(STAGES[a.stage](a), getattr(a, 'workdir', None))
+    code = 4 if out.startswith('<error>') else 0
+    _log_invocation(a, a.stage, out, code)
     print(out)
-    return 4 if out.startswith('<error>') else 0
+    return code
 
 
 def _fake_render(board, halo=100.0, crossings=100.0, hpwl=1000.0, moved=3):

--- a/check_complete.py
+++ b/check_complete.py
@@ -207,6 +207,12 @@ def _grade(a, doc):
     doc['board_sha'] = score.get('board_sha')
     blocking = score.get('blocking')
     ungraded = sorted(score.get('ungraded') or [])
+    # NOT the same as ungraded, and it must not block: the board declares no
+    # such requirement, so there is nothing to grade and passing the flag would
+    # invent one. Run 20 closed with `--accept-unclosed ungraded` covering both
+    # a real gap and a non-question, and a standing false waiver on every simple
+    # board is how a real one stops being read.
+    not_applicable = sorted(score.get('not_applicable') or [])
     unknown = sorted(score.get('unknown') or [])
     score_failed = (code == TIMED_OUT or not score)
 
@@ -330,6 +336,12 @@ def _grade(a, doc):
         why += ('. UNEXAMINED, and not passed: ' + ', '.join(ungraded)
                 + ' -- nothing was asked to grade them, so they are unknown '
                   'rather than clean')
+    if not_applicable:
+        # Printed, never blocking. Visible so a reader can tell "no such
+        # requirement" from "nobody looked" without opening the JSON.
+        why += ('. NOT APPLICABLE (this board declares no such requirement): '
+                + ', '.join(not_applicable))
+    doc['not_applicable'] = not_applicable
     doc['verdict'] = verdict
     doc['reason'] = why
     doc['ungraded'] = ungraded

--- a/kicad_files/watchy.kicad_pro
+++ b/kicad_files/watchy.kicad_pro
@@ -1,0 +1,645 @@
+{
+  "board": {
+    "3dviewports": [],
+    "design_settings": {
+      "defaults": {
+        "apply_defaults_to_fp_fields": false,
+        "apply_defaults_to_fp_shapes": false,
+        "apply_defaults_to_fp_text": false,
+        "board_outline_line_width": 0.15,
+        "copper_line_width": 0.2,
+        "copper_text_italic": false,
+        "copper_text_size_h": 1.5,
+        "copper_text_size_v": 1.5,
+        "copper_text_thickness": 0.3,
+        "copper_text_upright": false,
+        "courtyard_line_width": 0.05,
+        "dimension_precision": 4,
+        "dimension_units": 3,
+        "dimensions": {
+          "arrow_length": 1270000,
+          "extension_offset": 500000,
+          "keep_text_aligned": true,
+          "suppress_zeroes": false,
+          "text_position": 0,
+          "units_format": 1
+        },
+        "fab_line_width": 0.1,
+        "fab_text_italic": false,
+        "fab_text_size_h": 1.0,
+        "fab_text_size_v": 1.0,
+        "fab_text_thickness": 0.15,
+        "fab_text_upright": false,
+        "other_line_width": 0.1,
+        "other_text_italic": false,
+        "other_text_size_h": 1.0,
+        "other_text_size_v": 1.0,
+        "other_text_thickness": 0.15,
+        "other_text_upright": false,
+        "pads": {
+          "drill": 0.0,
+          "height": 1.0,
+          "width": 1.4
+        },
+        "silk_line_width": 0.15,
+        "silk_text_italic": false,
+        "silk_text_size_h": 1.0,
+        "silk_text_size_v": 1.0,
+        "silk_text_thickness": 0.15,
+        "silk_text_upright": false,
+        "zones": {
+          "45_degree_only": false,
+          "min_clearance": 0.2032
+        }
+      },
+      "diff_pair_dimensions": [
+        {
+          "gap": 0.0,
+          "via_gap": 0.0,
+          "width": 0.0
+        }
+      ],
+      "drc_exclusions": [],
+      "meta": {
+        "filename": "board_design_settings.json",
+        "version": 2
+      },
+      "rule_severities": {
+        "annular_width": "error",
+        "clearance": "error",
+        "connection_width": "warning",
+        "copper_edge_clearance": "error",
+        "copper_sliver": "warning",
+        "courtyards_overlap": "error",
+        "creepage": "error",
+        "diff_pair_gap_out_of_range": "error",
+        "diff_pair_uncoupled_length_too_long": "error",
+        "drill_out_of_range": "error",
+        "duplicate_footprints": "warning",
+        "extra_footprint": "warning",
+        "footprint": "error",
+        "footprint_filters_mismatch": "ignore",
+        "footprint_symbol_mismatch": "warning",
+        "footprint_type_mismatch": "error",
+        "hole_clearance": "error",
+        "hole_near_hole": "error",
+        "hole_to_hole": "error",
+        "holes_co_located": "warning",
+        "invalid_outline": "error",
+        "isolated_copper": "warning",
+        "item_on_disabled_layer": "error",
+        "items_not_allowed": "error",
+        "length_out_of_range": "error",
+        "lib_footprint_issues": "warning",
+        "lib_footprint_mismatch": "warning",
+        "malformed_courtyard": "error",
+        "microvia_drill_out_of_range": "error",
+        "mirrored_text_on_front_layer": "warning",
+        "missing_courtyard": "ignore",
+        "missing_footprint": "warning",
+        "net_conflict": "warning",
+        "nonmirrored_text_on_back_layer": "warning",
+        "npth_inside_courtyard": "ignore",
+        "padstack": "error",
+        "pth_inside_courtyard": "ignore",
+        "shorting_items": "error",
+        "silk_edge_clearance": "warning",
+        "silk_over_copper": "warning",
+        "silk_overlap": "warning",
+        "skew_out_of_range": "error",
+        "solder_mask_bridge": "warning",
+        "starved_thermal": "error",
+        "text_height": "warning",
+        "text_on_edge_cuts": "error",
+        "text_thickness": "warning",
+        "through_hole_pad_without_hole": "error",
+        "too_many_vias": "error",
+        "track_angle": "error",
+        "track_dangling": "warning",
+        "track_segment_length": "error",
+        "track_width": "error",
+        "tracks_crossing": "error",
+        "unconnected_items": "error",
+        "unresolved_variable": "error",
+        "via_dangling": "warning",
+        "zones_intersect": "error"
+      },
+      "rule_severitieslegacy_courtyards_overlap": true,
+      "rule_severitieslegacy_no_courtyard_defined": false,
+      "rules": {
+        "allow_blind_buried_vias": false,
+        "allow_microvias": false,
+        "max_error": 0.005,
+        "min_clearance": 0.15,
+        "min_connection": 0.0,
+        "min_copper_edge_clearance": 0.254,
+        "min_groove_width": 0.0,
+        "min_hole_clearance": 0.254,
+        "min_hole_to_hole": 0.254,
+        "min_microvia_diameter": 0.2,
+        "min_microvia_drill": 0.1,
+        "min_resolved_spokes": 2,
+        "min_silk_clearance": 0.0,
+        "min_text_height": 0.8,
+        "min_text_thickness": 0.08,
+        "min_through_hole_diameter": 0.3,
+        "min_track_width": 0.15,
+        "min_via_annular_width": 0.05,
+        "min_via_diameter": 0.3,
+        "solder_mask_to_copper_clearance": 0.0,
+        "use_height_for_length_calcs": true
+      },
+      "teardrop_options": [
+        {
+          "td_onpthpad": true,
+          "td_onroundshapesonly": false,
+          "td_onsmdpad": true,
+          "td_ontrackend": false,
+          "td_onvia": true
+        }
+      ],
+      "teardrop_parameters": [
+        {
+          "td_allow_use_two_tracks": true,
+          "td_curve_segcount": 1,
+          "td_height_ratio": 1.0,
+          "td_length_ratio": 0.5,
+          "td_maxheight": 2.0,
+          "td_maxlen": 1.0,
+          "td_on_pad_in_zone": false,
+          "td_target_name": "td_round_shape",
+          "td_width_to_size_filter_ratio": 0.9
+        },
+        {
+          "td_allow_use_two_tracks": true,
+          "td_curve_segcount": 1,
+          "td_height_ratio": 1.0,
+          "td_length_ratio": 0.5,
+          "td_maxheight": 2.0,
+          "td_maxlen": 1.0,
+          "td_on_pad_in_zone": false,
+          "td_target_name": "td_rect_shape",
+          "td_width_to_size_filter_ratio": 0.9
+        },
+        {
+          "td_allow_use_two_tracks": true,
+          "td_curve_segcount": 1,
+          "td_height_ratio": 1.0,
+          "td_length_ratio": 0.5,
+          "td_maxheight": 2.0,
+          "td_maxlen": 1.0,
+          "td_on_pad_in_zone": false,
+          "td_target_name": "td_track_end",
+          "td_width_to_size_filter_ratio": 0.9
+        }
+      ],
+      "track_widths": [
+        0.0,
+        0.15,
+        0.5
+      ],
+      "tuning_pattern_settings": {
+        "diff_pair_defaults": {
+          "corner_radius_percentage": 80,
+          "corner_style": 1,
+          "max_amplitude": 1.0,
+          "min_amplitude": 0.2,
+          "single_sided": false,
+          "spacing": 1.0
+        },
+        "diff_pair_skew_defaults": {
+          "corner_radius_percentage": 80,
+          "corner_style": 1,
+          "max_amplitude": 1.0,
+          "min_amplitude": 0.2,
+          "single_sided": false,
+          "spacing": 0.6
+        },
+        "single_track_defaults": {
+          "corner_radius_percentage": 80,
+          "corner_style": 1,
+          "max_amplitude": 1.0,
+          "min_amplitude": 0.2,
+          "single_sided": false,
+          "spacing": 0.6
+        }
+      },
+      "via_dimensions": [
+        {
+          "diameter": 0.0,
+          "drill": 0.0
+        },
+        {
+          "diameter": 0.45,
+          "drill": 0.3
+        }
+      ],
+      "zones_allow_external_fillets": false,
+      "zones_use_no_outline": true
+    },
+    "ipc2581": {
+      "dist": "",
+      "distpn": "",
+      "internal_id": "",
+      "mfg": "",
+      "mpn": ""
+    },
+    "layer_pairs": [],
+    "layer_presets": [],
+    "viewports": []
+  },
+  "boards": [],
+  "cvpcb": {
+    "equivalence_files": []
+  },
+  "erc": {
+    "erc_exclusions": [],
+    "meta": {
+      "version": 0
+    },
+    "pin_map": [
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      [
+        0,
+        2,
+        0,
+        1,
+        0,
+        0,
+        1,
+        0,
+        2,
+        2,
+        2,
+        2
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        1,
+        0,
+        1,
+        2
+      ],
+      [
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        1,
+        1,
+        2,
+        1,
+        1,
+        2
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      [
+        1,
+        1,
+        1,
+        1,
+        1,
+        0,
+        1,
+        1,
+        1,
+        1,
+        1,
+        2
+      ],
+      [
+        0,
+        0,
+        0,
+        1,
+        0,
+        0,
+        1,
+        0,
+        0,
+        0,
+        0,
+        2
+      ],
+      [
+        0,
+        2,
+        1,
+        2,
+        0,
+        0,
+        1,
+        0,
+        2,
+        2,
+        2,
+        2
+      ],
+      [
+        0,
+        2,
+        0,
+        1,
+        0,
+        0,
+        1,
+        0,
+        2,
+        0,
+        0,
+        2
+      ],
+      [
+        0,
+        2,
+        1,
+        1,
+        0,
+        0,
+        1,
+        0,
+        2,
+        0,
+        0,
+        2
+      ],
+      [
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2,
+        2
+      ]
+    ],
+    "rule_severities": {
+      "bus_definition_conflict": "error",
+      "bus_entry_needed": "error",
+      "bus_to_bus_conflict": "error",
+      "bus_to_net_conflict": "error",
+      "conflicting_netclasses": "error",
+      "different_unit_footprint": "error",
+      "different_unit_net": "error",
+      "duplicate_reference": "error",
+      "duplicate_sheet_names": "error",
+      "endpoint_off_grid": "warning",
+      "extra_units": "error",
+      "footprint_filter": "ignore",
+      "footprint_link_issues": "warning",
+      "four_way_junction": "ignore",
+      "global_label_dangling": "warning",
+      "hier_label_mismatch": "error",
+      "label_dangling": "error",
+      "label_multiple_wires": "warning",
+      "lib_symbol_issues": "warning",
+      "lib_symbol_mismatch": "warning",
+      "missing_bidi_pin": "warning",
+      "missing_input_pin": "warning",
+      "missing_power_pin": "error",
+      "missing_unit": "warning",
+      "multiple_net_names": "warning",
+      "net_not_bus_member": "warning",
+      "no_connect_connected": "warning",
+      "no_connect_dangling": "warning",
+      "pin_not_connected": "error",
+      "pin_not_driven": "error",
+      "pin_to_pin": "warning",
+      "power_pin_not_driven": "error",
+      "same_local_global_label": "warning",
+      "similar_label_and_power": "warning",
+      "similar_labels": "warning",
+      "similar_power": "warning",
+      "simulation_model_issue": "ignore",
+      "single_global_label": "ignore",
+      "unannotated": "error",
+      "unconnected_wire_endpoint": "warning",
+      "undefined_netclass": "error",
+      "unit_value_mismatch": "error",
+      "unresolved_variable": "error",
+      "wire_dangling": "error"
+    }
+  },
+  "libraries": {
+    "pinned_footprint_libs": [],
+    "pinned_symbol_libs": []
+  },
+  "meta": {
+    "filename": "watchy.kicad_pro",
+    "version": 3
+  },
+  "net_settings": {
+    "classes": [
+      {
+        "bus_width": 12,
+        "clearance": 0.15,
+        "diff_pair_gap": 0.25,
+        "diff_pair_via_gap": 0.25,
+        "diff_pair_width": 0.2,
+        "line_style": 0,
+        "microvia_diameter": 0.3,
+        "microvia_drill": 0.1,
+        "name": "Default",
+        "pcb_color": "rgba(0, 0, 0, 0.000)",
+        "priority": 2147483647,
+        "schematic_color": "rgba(0, 0, 0, 0.000)",
+        "track_width": 0.25,
+        "via_diameter": 0.6,
+        "via_drill": 0.4,
+        "wire_width": 6
+      }
+    ],
+    "meta": {
+      "version": 4
+    },
+    "net_colors": null,
+    "netclass_assignments": null,
+    "netclass_patterns": []
+  },
+  "pcbnew": {
+    "last_paths": {
+      "gencad": "",
+      "idf": "",
+      "netlist": "Watchy.net",
+      "plot": "",
+      "pos_files": "",
+      "specctra_dsn": "",
+      "step": "",
+      "svg": "",
+      "vrml": ""
+    },
+    "page_layout_descr_file": ""
+  },
+  "schematic": {
+    "annotate_start_num": 0,
+    "bom_export_filename": "",
+    "bom_fmt_presets": [],
+    "bom_fmt_settings": {
+      "field_delimiter": ",",
+      "keep_line_breaks": false,
+      "keep_tabs": false,
+      "name": "CSV",
+      "ref_delimiter": ",",
+      "ref_range_delimiter": "",
+      "string_delimiter": "\""
+    },
+    "bom_presets": [],
+    "bom_settings": {
+      "exclude_dnp": false,
+      "fields_ordered": [
+        {
+          "group_by": false,
+          "label": "Reference",
+          "name": "Reference",
+          "show": true
+        },
+        {
+          "group_by": true,
+          "label": "Value",
+          "name": "Value",
+          "show": true
+        },
+        {
+          "group_by": false,
+          "label": "Datasheet",
+          "name": "Datasheet",
+          "show": true
+        },
+        {
+          "group_by": false,
+          "label": "Footprint",
+          "name": "Footprint",
+          "show": true
+        },
+        {
+          "group_by": false,
+          "label": "Qty",
+          "name": "${QUANTITY}",
+          "show": true
+        },
+        {
+          "group_by": true,
+          "label": "DNP",
+          "name": "${DNP}",
+          "show": true
+        }
+      ],
+      "filter_string": "",
+      "group_symbols": true,
+      "include_excluded_from_bom": false,
+      "name": "Grouped By Value",
+      "sort_asc": true,
+      "sort_field": "Reference"
+    },
+    "connection_grid_size": 50.0,
+    "drawing": {
+      "dashed_lines_dash_length_ratio": 12.0,
+      "dashed_lines_gap_length_ratio": 3.0,
+      "default_line_thickness": 6.0,
+      "default_text_size": 50.0,
+      "field_names": [],
+      "intersheets_ref_own_page": false,
+      "intersheets_ref_prefix": "",
+      "intersheets_ref_short": false,
+      "intersheets_ref_show": false,
+      "intersheets_ref_suffix": "",
+      "junction_size_choice": 3,
+      "label_size_ratio": 0.25,
+      "operating_point_overlay_i_precision": 3,
+      "operating_point_overlay_i_range": "~A",
+      "operating_point_overlay_v_precision": 3,
+      "operating_point_overlay_v_range": "~V",
+      "overbar_offset_ratio": 1.23,
+      "pin_symbol_size": 0.0,
+      "text_offset_ratio": 0.08
+    },
+    "legacy_lib_dir": "",
+    "legacy_lib_list": [],
+    "meta": {
+      "version": 1
+    },
+    "net_format_name": "Pcbnew",
+    "ngspice": {
+      "fix_include_paths": true,
+      "fix_passive_vals": false,
+      "meta": {
+        "version": 0
+      },
+      "model_mode": 0,
+      "workbook_filename": ""
+    },
+    "page_layout_descr_file": "",
+    "plot_directory": "./",
+    "space_save_all_events": true,
+    "spice_adjust_passive_values": false,
+    "spice_current_sheet_as_root": false,
+    "spice_external_command": "spice \"%I\"",
+    "spice_model_current_sheet_as_root": true,
+    "spice_save_all_currents": false,
+    "spice_save_all_dissipations": false,
+    "spice_save_all_voltages": false,
+    "subpart_first_id": 65,
+    "subpart_id_separator": 0
+  },
+  "sheets": [
+    [
+      "27fd5905-3b71-4bec-9bad-46976b157c31",
+      "Root"
+    ]
+  ],
+  "text_variables": {}
+}

--- a/py_placer/converge.py
+++ b/py_placer/converge.py
@@ -767,6 +767,15 @@ def cmd_record(a):
              'lever_argv': list(a.argv) if a.argv else None,
              'score': json.loads(a.score) if a.score else None,
              'renders': list(a.render_json) if a.render_json else None,
+             # The MEASUREMENT the next lap is aimed at, not a paragraph about
+             # it. Run 20 recorded "throat 0.409mm vs 0.450 needed, blocked by
+             # U4.53/R7.2" as English inside `lever`, so the re-entry could be
+             # read by a person and by nothing else.
+             'defects': list(a.defect_json) if a.defect_json else None,
+             # L4 requires a --shape and the ledger has never kept it, so
+             # "which shape did we re-enter at, and did it work" was not a
+             # question the record could answer.
+             'shape': a.shape,
              'lenses': list(a.lens) if a.lens else None,
              # Split on whitespace and commas so `--scope-refs "$(cat locks.txt)"`
              # records 45 refs rather than one 45-ref string.
@@ -820,6 +829,12 @@ def cmd_record(a):
                   f"add 'failed_nets' to the score JSON so the ledger stays "
                   f"readable without re-deriving the open set.",
                   file=sys.stderr)
+    # run-23: every record refreshes the NOW view. Best-effort -- the ledger
+    # append above is the authority and already succeeded.
+    try:
+        write_run_state(a.ledger)
+    except Exception as exc:                                    # noqa: BLE001
+        print(f"RUN_STATE not refreshed: {exc}", file=sys.stderr)
     return 0
 
 
@@ -868,9 +883,10 @@ def cmd_replay(a):
 
 CONTINUE, DONE, STUCK, BUDGET = 4, 0, 5, 6
 
-#: Which half of the loop a ledger row belongs to. `systemic` is neither -- it
-#: changes how the chain measures itself, not the board -- so it can never make
-#: a half look like it is still improving.
+#: Which half of the loop a ledger row belongs to. `systemic` and
+#: `classification` are neither -- one changes how the chain measures itself,
+#: the other decides where to re-enter -- and neither changes the board, so
+#: neither can make a half look like it is still improving.
 _HALF = {'placement': 'placement', 'completion': 'routing'}
 
 
@@ -1252,11 +1268,101 @@ def cmd_verdict(a):
     return code
 
 
+def write_run_state(ledger_path):
+    """Write <workdir>/RUN_STATE.json -- the machine-readable NOW view.
+
+    Run 23 measured 74% of its wall clock as agent context work, a large
+    share of it re-deriving "where are we" from ledger + journal + logs,
+    because only HISTORY existed on disk. This is the snapshot: written on
+    every `record` (and stage-stamped by the drivers), atomically. The
+    LEDGER stays the authority -- `source_ledger_row` + `written_at` let any
+    reader detect a stale snapshot after a crash and fall back to it.
+    """
+    out = {'written_at': time.strftime('%Y-%m-%dT%H:%M:%S'),
+           'ledger': ledger_path, 'source_ledger_row': 0}
+    try:
+        with open(ledger_path, encoding='utf-8') as f:
+            rows = [json.loads(ln) for ln in f if ln.strip()]
+    except (OSError, ValueError):
+        rows = []
+    out['source_ledger_row'] = len(rows)
+    if rows:
+        last = rows[-1]
+        out['lap'] = last.get('iteration')
+        out['last_kind'] = last.get('kind')
+        out['last_accepted'] = last.get('accepted')
+        out['last_lever'] = (last.get('lever') or '')[:240]
+        out['board_sha'] = last.get('result_sha')
+        for r in reversed(rows):
+            sc = r.get('score')
+            if r.get('accepted') and isinstance(sc, dict) and 'blocking' in sc:
+                out['blocking'] = sc.get('blocking')
+                out['blocking_by'] = sc.get('blocking_by')
+                out['quality'] = sc.get('quality')
+                out['score_lap'] = r.get('iteration')
+                break
+        for r in reversed(rows):
+            if r.get('lenses'):
+                out['last_lens_verdicts'] = r['lenses']
+                break
+        out['final_recorded'] = any(r.get('final') for r in rows)
+        # Exhaustion declarations, honouring the supersession rule the
+        # `record --exhausted` output promises: a later recorded lap of that
+        # half clears it.
+        _KINDS = {'placement': ('placement',),
+                  'routing': ('completion', 'routing')}
+        ex = {}
+        for half in ('placement', 'routing'):
+            decl = [r for r in rows
+                    if (r.get('exhausted') or {}).get('half') == half]
+            if not decl:
+                continue
+            t_decl = max(r.get('t', 0) for r in decl)
+            if not any(r.get('t', 0) > t_decl
+                       and r.get('kind') in _KINDS[half] for r in rows):
+                ex[half] = (decl[-1]['exhausted'].get('reason') or '')[:160]
+        out['exhausted'] = ex
+        out['phase'] = ('closeout' if out['final_recorded'] else
+                        {'placement': 'placement',
+                         'completion': 'routing'}.get(last.get('kind'),
+                                                      last.get('kind')))
+    wd = os.path.dirname(ledger_path) or '.'
+    ct = os.path.join(wd, 'cmd_timing.jsonl')
+    if os.path.exists(ct):
+        try:
+            with open(ct, encoding='utf-8') as f:
+                tail = [json.loads(ln) for ln in f.read().splitlines()[-5:]
+                        if ln.strip()]
+            out['last_commands'] = [
+                {'label': r.get('label'), 'exit': r.get('exit'),
+                 'wall_s': r.get('wall_s')} for r in tail]
+        except (OSError, ValueError):
+            pass
+    path = os.path.join(wd, 'RUN_STATE.json')
+    tmp = path + '.tmp'
+    with open(tmp, 'w', encoding='utf-8') as f:
+        json.dump(out, f, indent=1, sort_keys=True)
+    os.replace(tmp, path)
+    return path
+
+
 def cmd_status(a):
     from board_store import Ledger
     lg = Ledger(a.ledger)
     c = lg.counts()
-    print(json.dumps(c, indent=1, sort_keys=True))
+    # run-23: `status` is also the snapshot RENDERER -- refresh RUN_STATE.json
+    # and fold it into the ONE json doc this command prints. One doc, not
+    # two: this is a bare-JSON-stdout command and its consumers json.loads
+    # the whole stream (the cli_banner lesson, relearned live when a second
+    # doc broke test_converge's status test on the first try).
+    doc = dict(c)
+    try:
+        path = write_run_state(a.ledger)
+        with open(path, encoding='utf-8') as f:
+            doc['run_state'] = json.load(f)
+    except Exception as exc:                                    # noqa: BLE001
+        print(f"RUN_STATE not written: {exc}", file=sys.stderr)
+    print(json.dumps(doc, indent=1, sort_keys=True))
     if c['total'] and c['systemic'] * 2 >= c['total']:
         print("NOTE: at least half of this budget went to SYSTEMIC iterations -- "
               "changes to how the chain measures or grades itself, not to the "
@@ -1312,8 +1418,16 @@ def build_parser():
     r.add_argument('--ledger', required=True)
     r.add_argument('--board', required=True)
     r.add_argument('--store', default=None)
-    r.add_argument('--kind', choices=('completion', 'placement', 'systemic'),
-                   default='completion')
+    r.add_argument('--kind',
+                   choices=('completion', 'placement', 'systemic',
+                            'classification'),
+                   default='completion',
+                   help="which half of the loop this lap belongs to. "
+                        "`classification` is the L3 lap that DECIDES the shape "
+                        "of the next re-entry; it changes no board, so like "
+                        "`systemic` it belongs to neither half. It had to be "
+                        "filed as `systemic` before, which made a decision "
+                        "look like a tool change.")
     r.add_argument('--lever', default=None)
     r.add_argument('--score', default=None, help='JSON')
     r.add_argument('--score-file', default=None, metavar='PATH',
@@ -1322,6 +1436,17 @@ def build_parser():
                         '~32kB and the shell then exits 126 BEFORE record '
                         'runs, so the lap is lost with no error. Mutually '
                         'exclusive with --score.')
+    r.add_argument('--defect-json', action='append', default=None,
+                   metavar='PATH',
+                   help='defect-record document(s) this lap was aimed at; '
+                        'repeatable. Stored as entry["defects"]. A ledger that '
+                        'keeps the MEASUREMENT can tell a later reader what '
+                        'the lap was for; a ledger that keeps a paragraph '
+                        'about it cannot.')
+    r.add_argument('--shape', choices=('parameter', 'placement', 'floorplan'),
+                   default=None,
+                   help='the re-entry shape this lap acted on (the same word '
+                        'L4 demands). Stored as entry["shape"].')
     r.add_argument('--render-json', action='append', default=None,
                    metavar='PATH',
                    help='render_placement --json-out document(s) that were '
@@ -1425,7 +1550,13 @@ def main(argv=None):
 
 
 if __name__ == '__main__':
-    # NO cli_banner here (deliberate): converge's stdout is a JSON API --
-    # `record` and `status` print documents that callers json.loads() whole
-    # (tests/test_converge.py does). The other instruments' stdout is a log.
-    sys.exit(main())
+    # Declare the lever for the WHOLE run, so every pose this CLI
+    # writes carries its name. Nothing called declare_lever outside
+    # tests, so the unaided instrument had no armed state at all:
+    # unarmed it is silent, and armed by hand it refused the engine.
+    from placement.provenance import declare_lever
+    with declare_lever('converge.py', sys.argv):
+        # NO cli_banner here (deliberate): converge's stdout is a JSON API --
+        # `record` and `status` print documents that callers json.loads() whole
+        # (tests/test_converge.py does). The other instruments' stdout is a log.
+        sys.exit(main())

--- a/py_placer/place_fanout_clearance.py
+++ b/py_placer/place_fanout_clearance.py
@@ -25,6 +25,8 @@ vias, route)
 import _path  # noqa: F401  (py_placer -> py_router/py_tools on sys.path)
 
 import os
+import sys  # declare_lever() below reads sys.argv -- without this the module
+             # raised NameError on EVERY invocation, --help included (run 20)
 
 from kicad_parser import parse_kicad_pcb
 import routing_defaults as defaults
@@ -179,6 +181,11 @@ Examples:
 
 
 if __name__ == "__main__":
-    from console_encoding import enable_utf8_console
-    enable_utf8_console()  # cp1252-safe non-ASCII prints (issue #152)
-    main()
+    # In LEVER_REGISTRY, so it must DECLARE -- an entry that writes
+    # poses without declaring makes an armed regime refuse the engine
+    # itself, which is the failure the registry exists to prevent.
+    from placement.provenance import declare_lever
+    with declare_lever('place_fanout_clearance.py', sys.argv):
+        from console_encoding import enable_utf8_console
+        enable_utf8_console()  # cp1252-safe non-ASCII prints (issue #152)
+        main()

--- a/py_placer/place_optimize.py
+++ b/py_placer/place_optimize.py
@@ -315,8 +315,14 @@ Examples:
 
 
 if __name__ == "__main__":
-    import cli_banner; cli_banner.install()  # CMD/EXIT self-echo (run-3 B1)
-    # main() already returns 0 from the --suggest-locks branch; that value was
-    # dropped here, so the process exited 0 regardless of what main() decided
-    # (the #551 family). Propagate it so a future refusal is visible to a caller.
-    sys.exit(main() or 0)
+    # Declare the lever for the WHOLE run, so every pose this CLI
+    # writes carries its name. Nothing called declare_lever outside
+    # tests, so the unaided instrument had no armed state at all:
+    # unarmed it is silent, and armed by hand it refused the engine.
+    from placement.provenance import declare_lever
+    with declare_lever('place_optimize.py', sys.argv):
+        import cli_banner; cli_banner.install()  # CMD/EXIT self-echo (run-3 B1)
+        # main() already returns 0 from the --suggest-locks branch; that value was
+        # dropped here, so the process exited 0 regardless of what main() decided
+        # (the #551 family). Propagate it so a future refusal is visible to a caller.
+        sys.exit(main() or 0)

--- a/py_placer/place_portfolio.py
+++ b/py_placer/place_portfolio.py
@@ -710,4 +710,10 @@ def main():
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    # Declare the lever for the WHOLE run, so every pose this CLI
+    # writes carries its name. Nothing called declare_lever outside
+    # tests, so the unaided instrument had no armed state at all:
+    # unarmed it is silent, and armed by hand it refused the engine.
+    from placement.provenance import declare_lever
+    with declare_lever('place_portfolio.py', sys.argv):
+        sys.exit(main())

--- a/py_placer/place_reconstruct.py
+++ b/py_placer/place_reconstruct.py
@@ -692,5 +692,11 @@ Examples:
 
 
 if __name__ == "__main__":
-    import cli_banner; cli_banner.install()  # CMD/EXIT self-echo (run-3 B1)
-    sys.exit(main())
+    # Declare the lever for the WHOLE run, so every pose this CLI
+    # writes carries its name. Nothing called declare_lever outside
+    # tests, so the unaided instrument had no armed state at all:
+    # unarmed it is silent, and armed by hand it refused the engine.
+    from placement.provenance import declare_lever
+    with declare_lever('place_reconstruct.py', sys.argv):
+        import cli_banner; cli_banner.install()  # CMD/EXIT self-echo (run-3 B1)
+        sys.exit(main())

--- a/py_placer/place_route_loop.py
+++ b/py_placer/place_route_loop.py
@@ -793,6 +793,12 @@ def main():
 
 
 if __name__ == "__main__":
-    # The return value used to be dropped here, so a refusal deeper in main()
-    # still exited 0 (the #551 family). Propagate it.
-    sys.exit(main() or 0)
+    # Declare the lever for the WHOLE run, so every pose this CLI
+    # writes carries its name. Nothing called declare_lever outside
+    # tests, so the unaided instrument had no armed state at all:
+    # unarmed it is silent, and armed by hand it refused the engine.
+    from placement.provenance import declare_lever
+    with declare_lever('place_route_loop.py', sys.argv):
+        # The return value used to be dropped here, so a refusal deeper in main()
+        # still exited 0 (the #551 family). Propagate it.
+        sys.exit(main() or 0)

--- a/py_placer/place_seed.py
+++ b/py_placer/place_seed.py
@@ -79,6 +79,17 @@ Examples:
                         "non-obstacles either way (the existing exclude "
                         "mechanism); this changes only WHO goes first "
                         "(run-4 C)")
+    p.add_argument("--evict-depth", type=int, default=1, metavar="N",
+                   help="When a part has NO legal pose, census the seated "
+                        "neighbours, evict the one that frees the most poses, "
+                        "seat the part, then put the blocker back with it in "
+                        "place -- gated by the same reconstruct measure the "
+                        "anchor rounds use, and reverted whole if it does not "
+                        "improve (#630). 0 disables it and restores the bare "
+                        "'no legal pose' verdict. Only ever fires on a part "
+                        "that was already going to be reported unseated, so "
+                        "a run that seats everything is unaffected. Depth is "
+                        "1: a blocker's own blocker is not chased")
     p.add_argument("--anchor-rounds", type=int, default=1,
                    help="With --anchors-first: gated re-seat passes after "
                         "the first full placement (default 1 = none). Each "
@@ -109,6 +120,17 @@ Examples:
                         "pose being discarded). Composes with --repair and "
                         "runs BEFORE it. Judge it on witnesses_after, not on "
                         "how far anything moved")
+    p.add_argument("--deadline", type=float, default=None, metavar="SECONDS",
+                   help="Wall-clock budget for --repair/--reseat. The repair "
+                        "sweep has no internal bound (violators x caps x 36 "
+                        "ring sweeps x O(parts)); with a budget it stops "
+                        "between violators, keeps the seats it made, reports "
+                        "the rest in deadline_skipped and exits 7. Default: "
+                        "no budget (a wall-clock default would break replay "
+                        "determinism). ANY harness with an external timeout "
+                        "should pass this at ~0.8x its own -- on Windows an "
+                        "external kill is TerminateProcess and leaves NO "
+                        "output at all. Env: KRT_DEADLINE_S")
     p.add_argument("--dry-run", action="store_true",
                    help="With --repair/--reseat: print the move list and "
                         "grades, write nothing")
@@ -171,12 +193,19 @@ Examples:
     if args.repair or args.reseat is not None:
         import math as _math
         import tempfile
+        import krt_deadline
         if st.unplaced:
             print("place_seed: --repair/--reseat need a PLACED board (this "
                   "one is unplaced -- seed it instead).", file=sys.stderr)
             return UNPLACED_EXIT
         summary = {'dry_run': args.dry_run,
                    'output': None if args.dry_run else args.output_file}
+        # Armed BEFORE the passes, so the flush hook covers every return
+        # below -- the refusals above print no summary at all today, which is
+        # how a killed run and a refused one look identical to a scraper.
+        _dl = krt_deadline.arm(args.deadline, tool='place_seed',
+                               on_partial=lambda: summary)
+        _prog = krt_deadline.stdout_progress(deadline=_dl)
 
         # Both passes stage into a temp dir and the finished board is copied
         # to the output path once, at the end. That keeps --dry-run honest
@@ -207,7 +236,8 @@ Examples:
                 refs=(args.reseat or None), group_sources=sources,
                 clearance=args.clearance,
                 board_edge_clearance=args.board_edge_clearance,
-                grid_step=args.grid_step, seed=args.seed)
+                grid_step=args.grid_step, seed=args.seed,
+                deadline=_dl, progress=_prog)
             for note in reseat['notes']:
                 print(f"  NOTE: {note}")
             _rmax = 0.0
@@ -265,7 +295,7 @@ Examples:
                 cur_pcb, cur, intent, group_sources=sources,
                 clearance=args.clearance,
                 board_edge_clearance=args.board_edge_clearance,
-                grid_step=args.grid_step)
+                grid_step=args.grid_step, deadline=_dl, progress=_prog)
             for note in result['notes']:
                 print(f"  NOTE: {note}")
             max_move = 0.0
@@ -284,6 +314,7 @@ Examples:
                 'unrepairable': len(result['unrepairable']),
                 'moved_refs': [m['reference'] for m in result['moves']],
                 'max_move_mm': round(max_move, 3),
+                'deadline_skipped': result.get('deadline_skipped') or [],
             })
             summary.update({f'{k}_before': v
                             for k, v in result['pad_report_before'].items()})
@@ -291,6 +322,19 @@ Examples:
             if result['unrepairable']:
                 exit_rc = 4
 
+        summary['complete'] = ((result or {}).get('complete', True)
+                               and (reseat or {}).get('complete', True))
+        if not summary['complete'] and _dl is not None:
+            # Unlike place_reconstruct, the output IS written on expiry: the
+            # partial is coherent by construction here (a part is either fully
+            # seated, with every seat legality-checked before it was taken, or
+            # untouched), so there is no pre-legalize staging step whose result
+            # would be invalid to hand on.
+            krt_deadline.mark(
+                summary, _dl,
+                reseat_skipped=(reseat or {}).get('deadline_skipped') or [],
+                repair_skipped=(result or {}).get('deadline_skipped') or [],
+                output=None if args.dry_run else args.output_file)
         if not args.dry_run:
             # A no-op still writes a board: the next step in a chain is handed
             # a path, and "nothing needed doing" must not look like "the tool
@@ -313,10 +357,9 @@ Examples:
             if graded.errors:
                 exit_rc = 4
         _stage.cleanup()
-        summary.setdefault('complete', True)
-        summary.setdefault('status', 'ok')
-        print('JSON_SUMMARY: ' + json.dumps(summary, sort_keys=True,
-                                            default=str), flush=True)
+        krt_deadline.emit(summary, deadline=_dl)
+        if not summary['complete']:
+            return krt_deadline.DEADLINE_EXIT
         return exit_rc
 
     if not st.unplaced and not st.partially_unplaced and not args.force:
@@ -378,13 +421,24 @@ Examples:
             return UNPLACED_EXIT
 
     rng = random.Random(f"{args.seed}")
+    # A CLOCK ON THE PLAIN SEED PATH. `--deadline` was accepted here and
+    # threaded only into the --repair/--reseat branch, so a plain seed ran
+    # unbounded while its own help text promised otherwise -- measured: a
+    # 2400s budget on an 85-part pile ran past 50 minutes without firing.
+    # The eviction rung makes that worse, not better: it adds a census sweep
+    # per unseated part to the one path with no budget at all.
+    import krt_deadline
+    _seed_dl = krt_deadline.arm(args.deadline, tool='place_seed')
+    _seed_prog = krt_deadline.stdout_progress(deadline=_seed_dl)
     result = seeder.seed_from_intent(
         pcb, args.input_file, intent, rng, group_sources=sources,
         clearance=args.clearance,
         board_edge_clearance=args.board_edge_clearance,
         grid_step=args.grid_step, seed_refs=seed_refs,
         anchors_first=args.anchors_first,
-        anchor_rounds=args.anchor_rounds)
+        anchor_rounds=args.anchor_rounds,
+        evict_depth=args.evict_depth,
+        deadline=_seed_dl, progress=_seed_prog)
     for note in result['notes']:
         print(f"  NOTE: {note}")
     print(f"Seeded {len(result['placements'])} part(s); "
@@ -490,6 +544,11 @@ Examples:
     after = ratsnest.get('after', {})
     summary = {'placed': len(result['placements']),
                'unseated': len(result['unseated']),
+               # NAMES, not just a count. #629's complaint is that a verdict
+               # you cannot act on is a dead end, and a count names nobody.
+               'unseated_refs': list(result['unseated']),
+               'no_pose_blockers': result.get('no_pose_blockers') or {},
+               'evictions': len(result.get('evictions') or []),
                'locked': n_locked,
                'grade_errors': len(graded.errors),
                'grade_warnings': len(graded.warnings),
@@ -498,6 +557,15 @@ Examples:
                         if after.get('hpwl') is not None else None),
                'output': args.output_file}
     print("JSON_SUMMARY: " + json.dumps(summary, sort_keys=True))
+    if not result.get('complete', True):
+        # A budget that ran out is NOT a graded failure: the parts in
+        # `deadline_skipped` were never tried, and reporting them as unseated
+        # would be a measurement nobody made.
+        print(f"place_seed: the deadline expired with "
+              f"{len(result.get('deadline_skipped') or [])} part(s) never "
+              f"tried -- they are in deadline_skipped, NOT unseated. The "
+              f"partial seed was written.", file=sys.stderr)
+        return krt_deadline.DEADLINE_EXIT
     if result['unseated'] or graded.errors:
         print("place_seed: the seed does NOT satisfy its intent -- see the "
               "errors above. It was still written, for inspection.",
@@ -507,5 +575,11 @@ Examples:
 
 
 if __name__ == "__main__":
-    import cli_banner; cli_banner.install()  # CMD/EXIT self-echo (run-3 B1)
-    sys.exit(main())
+    # Declare the lever for the WHOLE run, so every pose this CLI
+    # writes carries its name. Nothing called declare_lever outside
+    # tests, so the unaided instrument had no armed state at all:
+    # unarmed it is silent, and armed by hand it refused the engine.
+    from placement.provenance import declare_lever
+    with declare_lever('place_seed.py', sys.argv):
+        import cli_banner; cli_banner.install()  # CMD/EXIT self-echo (run-3 B1)
+        sys.exit(main())

--- a/py_placer/placement/README.md
+++ b/py_placer/placement/README.md
@@ -139,6 +139,34 @@ rotation, and an unlocked load-bearing rotation was never protected from the
 quench either. Explore rotations deliberately with
 `place_portfolio.py --strategy poses`.
 
+### The eviction rung (`--evict-depth`, #630/#629)
+
+A part with no legal pose is not necessarily a part with no **room**. Run 19
+measured the difference: three sweeps returned a bare *"no legal pose anywhere
+on the board"* for two switches, and when the question was finally asked in
+scoped form the engine answered precisely — with D14 in place **0** poses,
+with D14 lifted **46**; with D31, **0** then **32**. One eviction each and both
+seated. That verdict was reachable the whole time and nothing asked for it.
+
+So when a part cannot be seated, the seeder now counts its poses with each
+nearby seated incumbent lifted in turn, evicts the one that frees the most,
+seats the blocked part **first** against the lifted board, and puts the blocker
+back afterwards with it in place. That ordering is the point: `reseat_scope`
+re-seats its scope at their net centroids, which is back into the pockets they
+block, and returned a null three times on exactly this case.
+
+Bounded on every axis — depth 1 (a blocker's own blocker is not chased), at
+most 8 candidates per part (a geometric superset, so a part outside the box
+frees zero poses by construction), and the census counts to a cap. Gated by the
+same `reconstruct.measure` tuple the anchor rounds use, with a snapshot revert,
+and every eviction recorded with both gate tuples so the trade can be checked
+rather than trusted. Locked parts are never candidates.
+
+The JSON_SUMMARY gains `no_pose_blockers` (`{ref: {blocker: poses_freed}}`),
+`unseated_refs` (names, not just a count) and `evictions`. **The census runs
+whenever anything is unseated; only the eviction is gated on depth**, so
+`--evict-depth 0` means *"tell me what is in the way, move nothing"*.
+
 Requires an Edge.Cuts outline (exit 3 without one — the outline is spec-owned
 and will not be invented) and refuses a board that already looks placed
 (use `place_portfolio.py` to explore around an existing placement, or

--- a/py_placer/placement/floorplan.py
+++ b/py_placer/placement/floorplan.py
@@ -878,19 +878,32 @@ def rule_edge_connector(ctx) -> Iterator[Violation]:
         # a violation -- which is also what makes a misplaced edge part
         # CHARGEABLE by place_seed --repair.
         setback = c.get('max_setback_mm')
+        _sev = ctx.sev('edge_connector')
         if setback is None and c.get('class') == 'edge_receptacle':
             from .part_class import SEAT_TOL_MM
             setback = SEAT_TOL_MM
+        if setback is None and c.get('class') == 'connector_affinity':
+            # run-23: the weak class. An INTERIOR generic connector is a flag
+            # for the boundary review, never an error -- legitimately-interior
+            # connectors exist (tigard J7), so this fires at WARN whatever the
+            # rule's configured severity. An author upgrades by writing
+            # max_setback_mm (then the configured severity applies) or edge.
+            from .part_class import INTERIOR_AFFINITY_MM
+            setback = INTERIOR_AFFINITY_MM
+            _sev = WARN
         if setback is not None and amount <= legality.EPS:
             clr = ctx.gate.edge_clearance(part.rect)
             if clr > float(setback) + legality.EPS:
                 yield Violation(
-                    rule='edge_connector', severity=ctx.sev('edge_connector'),
+                    rule='edge_connector', severity=_sev,
                     ref=ref,
                     message=(f"{ref} is an edge part seated {clr:.2f}mm from "
                              f"the nearest edge with no overhang (seat "
-                             f"tolerance {float(setback):.2f}mm) -- the "
-                             f"mating face cannot reach the edge"),
+                             f"tolerance {float(setback):.2f}mm) -- "
+                             + ("a plug may not reach it; disposition in the "
+                                "boundary review or declare max_setback_mm"
+                                if _sev == WARN else
+                                "the mating face cannot reach the edge")),
                     measured={'edge_clearance_mm': round(clr, 4)},
                     expected={'max_setback_mm': float(setback)})
 
@@ -1428,6 +1441,21 @@ def emit_intent(pcb_data, pcb_file: str, *,
             if fp is None:
                 continue
             pc = classify_part(fp, ref)
+            if pc.name == 'connector_affinity':
+                # run-23: generic connectors (headers, JST, terminal blocks)
+                # had NO class, so J2/J5/J6/J7 seated mid-board and no
+                # instrument could say so. Declared WITHOUT an edge (the
+                # run-4 rule stands: naming one would be an invention) and
+                # with no band ceiling; the grade flags an INTERIOR pose at
+                # ADVISORY severity only. A human upgrades by adding `edge`
+                # or `max_setback_mm` to the entry.
+                clr = state.edge_gate.edge_clearance(parts[ref].rect)
+                conns.append({
+                    'ref': ref, 'class': pc.name, 'source': 'auto-class',
+                    'overhang_mm': {'min': 0.0},
+                    'note': (f'connector-family part, no edge claim; '
+                             f'measured {clr:.2f}mm from the nearest edge')})
+                continue
             if pc.name != 'edge_receptacle':
                 # actuators make no claim unless they actually overhang
                 # (handled above); nothing else is an edge class.
@@ -1453,15 +1481,37 @@ def emit_intent(pcb_data, pcb_file: str, *,
     # (the emitted 6.112 budget graded the C14-on-R14 board clean). The
     # repaired board re-emits the honest number; meanwhile board_score's
     # `assembly` component grades independently of any budget.
+    # Run-23 extends the same withholding to unwaived COURTYARD interpene-
+    # trations past the blocking floors: run 23's intent was emitted from a
+    # mid-repair board carrying J4 0.90mm inside U6, baked overlap_area
+    # 30.1085, and the final board's 26.302 then graded PASS -- the budget
+    # blessed the board it was emitted from. A board with such pairs gets no
+    # auto overlap budget; declare one by hand (visibly) if the overlap is
+    # by design. Cost, measured: 5 of 34 corpus boards carry by-design
+    # censuses and lose the auto-budget too -- the legality rule then
+    # ABSTAINS (not-derivable) on them, which is honest degradation; their
+    # independent coverage is check_assembly's moved-vs-baseline gate.
     try:
         from placement.legality import grade_body_overlap
-        _body_blocking = grade_body_overlap(
-            pcb_data, state.clearance, pcb_file=pcb_file)['blocking']
+        _g_overlap = grade_body_overlap(
+            pcb_data, state.clearance, pcb_file=pcb_file)
+        _body_blocking = _g_overlap['blocking']
+        _courtyard_blocking = _g_overlap.get('courtyard_blocking', 0)
     except Exception:
         _body_blocking = 0
+        _courtyard_blocking = 0
     _suspects = any('SUSPECT' in (c.get('note') or '') for c in conns)
     _budget = {}
-    if not _body_blocking:
+    _withheld = {}
+    if _body_blocking:
+        _withheld['overlap_area'] = (f'{_body_blocking} blocking body '
+                                     f'pair(s) on the emitting board (run-6)')
+    elif _courtyard_blocking:
+        _withheld['overlap_area'] = (
+            f'{_courtyard_blocking} unwaived courtyard interpenetration(s) '
+            f'past the blocking floors on the emitting board (run-23): an '
+            f'auto-budget would bless them')
+    else:
         _budget['overlap_area'] = _ceil4(float(leg['overlap_area']))
     if not _suspects:
         _budget['oob_count'] = int(leg['oob_count'])
@@ -1499,6 +1549,10 @@ def emit_intent(pcb_data, pcb_file: str, *,
             'note': ('read-only, describing the board as it is. The outline is '
                      'not editable by this toolchain: size, cutouts and slots '
                      'are mechanical decisions the user owns'),
+            # Budget keys deliberately NOT baked, and why -- so a reader of
+            # the intent can tell "withheld" from "forgot" (empty when
+            # nothing was withheld).
+            'budget_withheld': _withheld,
             'cutouts': [[[round(x, 3), round(y, 3)] for x, y in ring]
                         for ring in (pcb_data.board_info.board_cutouts or [])],
             'edge_contours': len(

--- a/py_placer/placement/legality.py
+++ b/py_placer/placement/legality.py
@@ -96,6 +96,66 @@ def rect_area(rect):
     return max(0.0, rect[2] - rect[0]) * max(0.0, rect[3] - rect[1])
 
 
+#: A body overlap at or above this fraction of the SMALLER body is a
+#: CONTAINMENT rather than a kiss. Corpus-calibrated on the 33 boards in
+#: kicad_files/, measured (not assumed), in the FAB currency:
+#:
+#:     FID2 / J5   (orangecrab_ext_pll)  frac 1.000  2.25 mm2  marker-exempt
+#:     FID1 / J4   (orangecrab_ext_pll)  frac 0.867  1.95 mm2  marker-exempt
+#:     GPDI1 / J5  (ulx3s)               frac 0.011  0.22 mm2  non-exempt
+#:     GPDI1 / SW1 (ulx3s)               frac 0.001  0.085 mm2 non-exempt
+#:
+#: Those 4 pairs are the entire fab census. NON-EXEMPT fab containment at
+#: frac >= 0.5 is ZERO on all 33 healthy boards, and the worst healthy
+#: non-exempt fab frac is 0.011 against a measured defect of 1.000 -- a ~90x
+#: separation, the same standard that licensed `stacks` to gate.
+CONTAINMENT_FRAC = 0.5
+
+#: Courtyard BLOCKING policy (run-23). The courtyard channel stayed advisory
+#: because area alone cannot tell a by-design kiss from an interpenetration:
+#: run-23's final board shipped D3<->SW1 at 0.059 mm2 / depth 0.02 (a sliver a
+#: healthy board carries) NEXT TO J4<->U6 at 5.56 mm2 / depth 0.90 (two parts
+#: in the same space) and every gate passed both. A pair gates only when BOTH
+#: exceed these floors -- area says the overlap is substantial, depth says it
+#: is an interpenetration rather than an edge graze -- and the pair is
+#: unwaived (marker/edge/container/intent ladders still apply) and both
+#: courtyards are REAL geometry (see GradedPart.synthetic: a zero-pad
+#: footprint's fictional +/-0.5mm box manufactures phantom pairs).
+COURTYARD_BLOCKING_MIN_MM2 = 0.5
+COURTYARD_BLOCKING_MIN_DEPTH_MM = 0.3
+#: The RELATIVE floor (run-23, user finding #2): an absolute area floor is
+#: blind to small parts -- J4<->R21 measured 0.445mm2 (11% under the area
+#: floor) while a QUARTER of R21's courtyard sat inside J4's. A pair also
+#: gates when the overlap consumes this fraction of the SMALLER courtyard,
+#: the same denominator containment_frac uses and for the same reason: area
+#: is everything to a 0402 and nothing to a connector.
+COURTYARD_BLOCKING_MIN_FRAC = 0.25
+
+
+def containment_frac(area, ra, rb):
+    """How much of the SMALLER of two bodies the overlap `area` consumes.
+
+    The number `area_mm2` alone cannot supply, and the reason run-22 shipped a
+    board every gate called buildable: a connector shell KISSING a neighbour
+    and a part sitting WHOLLY INSIDE another part produce the same
+    `area_mm2` on different-sized parts, so a reader could not tell an
+    intended overhang from an assembly impossibility without re-deriving the
+    geometry by hand (the run wrote a throwaway probe to do exactly that).
+
+    Measured on that board: RN3 inside U5 and RN7 inside U6 both reported
+    `fab 2.0 mm2` -- identical to a large shell's legitimate graze -- while
+    being 1.000 of the smaller body.
+
+    Smaller-body denominator, because containment is asymmetric: a 2 mm2
+    overlap is everything to a 0402 and nothing to a connector. Returns
+    0.0..1.0, or None when either body has no area (nothing to be inside of).
+    """
+    small = min(rect_area(ra), rect_area(rb))
+    if small <= EPS:
+        return None
+    return round(min(1.0, area / small), 4)
+
+
 def point_to_seg_dist(px, py, x1, y1, x2, y2):
     """Distance from a point to a line segment."""
     dx, dy = x2 - x1, y2 - y1
@@ -280,6 +340,44 @@ class BoardOutlineGate:
             self._edges = out
         return self._edges
 
+    def _ring_edge_set(self, skip_rings) -> frozenset:
+        """The EDGES belonging to `skip_rings`, as a set for exact filtering.
+
+        Ring ids index `cutouts + milled` (the `_swallow_pts` convention), which
+        is NOT the ordering of `self.rings` -- so the mapping is done from the
+        source lists rather than by index into `edges()`. Edges are built from
+        the same vertex tuples in both places, so equality is exact; both
+        orientations are stored because `edges()` walks each ring in one
+        direction only and a future caller might not.
+
+        Cached: `rect_blocked` is called in the innermost candidate loop.
+        """
+        if not skip_rings:
+            return frozenset()
+        key = frozenset(skip_rings)
+        cache = getattr(self, '_ring_edge_cache', None)
+        if cache is None:
+            cache = self._ring_edge_cache = {}
+        hit = cache.get(key)
+        if hit is not None:
+            return hit
+        out = set()
+        for rid in key:
+            if rid < len(self.cutouts):
+                ring = self.cutouts[rid]
+            elif rid - len(self.cutouts) < len(self.milled):
+                ring = self.milled[rid - len(self.cutouts)]
+            else:
+                continue
+            n = len(ring)
+            for i in range(n):
+                a, b = ring[i], ring[(i + 1) % n]
+                out.add((a[0], a[1], b[0], b[1]))
+                out.add((b[0], b[1], a[0], a[1]))
+        hit = frozenset(out)
+        cache[key] = hit
+        return hit
+
     # -- level 2: cached reachability prune
     def edges_near(self, key, seed_rect, travel: float, center=None) -> list:
         """Cached: the ring edges a part seeded at `seed_rect` could ever bring
@@ -353,6 +451,53 @@ class BoardOutlineGate:
                     break
         return frozenset(owned)
 
+    # -- level 2b: per-rect bbox prefilter, exact
+    def _edges_touching(self, rect, edges):
+        """The subset of `edges` that can possibly come within `margin` of
+        `rect`.
+
+        EXACT, not a heuristic, and that is the whole reason it is safe to put
+        in front of the threshold tests: if an edge's bounding box is
+        separated from the rect's bbox by more than `margin` on EITHER axis,
+        then every point of that edge differs from every point of the rect by
+        more than `margin` on that axis alone, so their distance exceeds
+        `margin` and the edge cannot contribute.
+
+        It is not usable in front of `edge_clearance`, which reports the true
+        minimum distance rather than testing it against a threshold -- the
+        nearest edge there may be arbitrarily far away.
+
+        Why it matters: `edges_near` prunes per PART, sized by a displacement
+        budget, and the seeder's state has no budget at all (pose_score builds
+        its QuenchState without `build_neighbor_lists`, so `_travel_budget` is
+        infinite and `edges_near` returns every edge). `_try_place` calls
+        `rect_outside_amount` once per candidate offset, and `_offsets(16,
+        0.25)` alone is 16,641 offsets.
+
+        Measured on run 19's urchin, a 638-edge outline with one milled ring:
+        7x to 14x depending on machine load and on which rect population is
+        swept (a sweep near an edge keeps more edges than one over open
+        board). The conservative end is the number to quote. An independent
+        measurement that neutralised this method by monkeypatching it to the
+        identity -- so the ONLY difference between arms was the prefilter --
+        put it at 11.98x on two separate runs.
+        """
+        m = self.margin
+        lo_x, lo_y, hi_x, hi_y = rect[0] - m, rect[1] - m, rect[2] + m, rect[3] + m
+        out = []
+        for e in edges:
+            ax, ay, bx, by = e
+            if (ax if ax > bx else bx) < lo_x:
+                continue
+            if (ax if ax < bx else bx) > hi_x:
+                continue
+            if (ay if ay > by else by) < lo_y:
+                continue
+            if (ay if ay < by else by) > hi_y:
+                continue
+            out.append(e)
+        return out
+
     # -- level 3: the exact tests
     def rect_blocked(self, rect, edges=None, skip_rings=None) -> bool:
         """True when a rect leaves the real outline, enters a cutout, or comes
@@ -362,18 +507,40 @@ class BoardOutlineGate:
         `edges_near`; omitted, every ring edge is measured.
 
         `skip_rings` (from `rings_enclosing`) exempts the tested part's OWN
-        milled rings from the swallow probe -- a connector over its own milled
-        relief may swallow it, and without this it is judged board-violating at
-        its own hand-placed pose.
+        milled rings -- a connector over its own milled relief may swallow it,
+        and without this it is judged board-violating at its own hand-placed
+        pose.
+
+        THE EXEMPTION COVERS THE EDGE-MARGIN TEST TOO, not only the swallow
+        probe. It did not, and the omission made the exemption almost useless:
+        a part whose own pads caused a contour to be reclassified as an inner
+        milled edge still had every pose within `margin` of that contour
+        vetoed -- which, for a part sitting INSIDE its own relief, is every
+        pose there is. Measured on run 20's SW2, which owns the strap slot its
+        two NPTH posts sit in: 0 legal poses of 14884 at the board's own
+        floors, and at margin 0, 508 of 9604 -- all at rot 0/180, none at SW2's
+        own rot 270. `place_optimize` with SW2 free and 83 refs locked moved it
+        0 mm with the edge term as the entire objective; `place_reconstruct`
+        reported "no legal pose within any cap". The run had to declare SW2 an
+        `edge_actuator` and waive it permanently.
+
+        PER-PART, never global: the ring stays a hard edge for every other
+        part, and `rings_enclosing` only ever returns MILLED ids, so the outer
+        outline and the genuine cutouts can never be exempted by this path.
         """
         from check_drc import _point_on_board, _seg_seg_dist_coords
         x0, y0, x1, y1 = rect
         for (px, py) in ((x0, y0), (x1, y0), (x1, y1), (x0, y1)):
             if not _point_on_board(px, py, self.outer, self.cutouts):
                 return True
+        near = self._edges_touching(
+            rect, self.edges() if edges is None else edges)
+        _own = self._ring_edge_set(skip_rings)
+        if _own:
+            near = [e for e in near if e not in _own]
         for (ax, ay, bx, by) in ((x0, y0, x1, y0), (x1, y0, x1, y1),
                                  (x1, y1, x0, y1), (x0, y1, x0, y0)):
-            for (ex1, ey1, ex2, ey2) in (self.edges() if edges is None else edges):
+            for (ex1, ey1, ex2, ey2) in near:
                 if _seg_seg_dist_coords(ax, ay, bx, by,
                                         ex1, ey1, ex2, ey2) < self.margin:
                     return True
@@ -428,9 +595,21 @@ class BoardOutlineGate:
                 # so an off-board corner always outweighs a mere margin graze.
                 amt += max(self.margin,
                            _point_to_rings_distance(px, py, self.rings))
+        # Only edges that can come within `margin` can contribute a term, and
+        # `_edges_touching` selects exactly those -- so this stays the same
+        # number while measuring against a short list. See its docstring.
+        near = self._edges_touching(rect, use)
+        # Same exemption as rect_blocked's, and it MUST be the same: the two
+        # functions' agreement is what makes `violation() == 0` imply `not
+        # rect_blocked()`. Exempting the owned ring in one and not the other
+        # would give a part a legal verdict and a non-zero cost at the same
+        # pose, which every acceptance rule downstream reads as a regression.
+        _own = self._ring_edge_set(skip_rings)
+        if _own:
+            near = [e for e in near if e not in _own]
         for (ax, ay, bx, by) in ((x0, y0, x1, y0), (x1, y0, x1, y1),
                                  (x1, y1, x0, y1), (x0, y1, x0, y0)):
-            d = min((_seg_seg_dist_coords(ax, ay, bx, by, *e) for e in use),
+            d = min((_seg_seg_dist_coords(ax, ay, bx, by, *e) for e in near),
                     default=float('inf'))
             if d < self.margin:
                 amt += self.margin - d
@@ -490,6 +669,13 @@ class GradedPart(NamedTuple):
     rect: Tuple[float, float, float, float]      # courtyard, own side
     tht_rect: Optional[Tuple[float, float, float, float]] = None
     has_tht: bool = False
+    # True when `rect` is the +/-0.5mm FICTION compute_footprint_bbox_local
+    # returns for a footprint with no courtyard AND no pads (logos, graphics).
+    # Such a rect is not geometry anyone drew, so overlap against it must
+    # never gate -- run-23's G***<->J5 "0.537 mm2" pair was exactly this
+    # artifact. A pad-bbox fallback (pads exist, courtyard missing) stays
+    # False: those bounds are real copper.
+    synthetic: bool = False
 
     @property
     def sides(self) -> frozenset:
@@ -569,7 +755,7 @@ def placement_out_of_board(parts: Sequence[GradedPart], board_info,
 class BodyOverlapPair(NamedTuple):
     a: str
     b: str
-    kind: str            # 'pad_intersection' | 'courtyard'
+    kind: str            # 'pad_intersection' | 'courtyard' | 'fab'
     area_mm2: float      # intersection area on the worst shared side
     side: str            # the shared side it occurs on ('F'/'B'; worst side)
     waived: bool
@@ -595,6 +781,44 @@ class BodyOverlapPair(NamedTuple):
     # a decision somebody made; copper landing on it is never dispositionable
     # by a placement search (run-8 E6).
     locked_ref: str = ''
+    # How much of the SMALLER body this overlap consumes, 0..1 -- see
+    # `containment_frac`. THE field `area_mm2` alone cannot supply: run-22
+    # shipped RN3-in-U5 and RN7-in-U6 at `fab 2.0 mm2`, which is also what a
+    # large connector's by-design graze measures. Area cannot tell a KISS from
+    # a part WHOLLY INSIDE another; this can.
+    #
+    # None = NOT MEASURED, not "no containment". The pad_intersection channel
+    # has no body rect in scope, so it reports None rather than a 0.0 that
+    # would read as a measurement someone took.
+    contained_frac: Optional[float] = None
+    # Penetration depth: the SHORTER axis extent of the intersection rect, mm
+    # (0.0 = not measured; the pad_intersection channel has no body rects).
+    # Area cannot tell a long thin kiss from a real interpenetration --
+    # run-23: D3<->SW1 0.059mm2 at depth 0.02 vs J4<->U6 5.56mm2 at depth
+    # 0.90 -- and the courtyard blocking policy keys on this axis.
+    depth_mm: float = 0.0
+    # WHERE the overlap is: the intersection rect (x0, y0, x1, y1), None =
+    # not measured. run-23 user finding #1: the edge-class waiver needs the
+    # REGION, not only the pair -- J1's mating overhang legitimately covers
+    # the strip at/over the outline, and nothing else, yet R5 sat 45.7%
+    # inside J1's INTERIOR courtyard (under the connector body, 1.5mm inside
+    # the board) behind the same waiver.
+    overlap_rect: Optional[Tuple[float, float, float, float]] = None
+    # `contained_frac >= CONTAINMENT_FRAC`, **on the fab channel only**.
+    #
+    # Why fab-only, measured on the same 33 boards: the COURTYARD currency
+    # ships frac-1.0 containment on four healthy boards -- esp_prog (a part
+    # inside USB1), orangecrab_ext_pll (R9, R12 inside J5),
+    # rp2350_fpga_eensy_prePlane (U3 inside J2), ulx3s (R24, R22, C18 inside
+    # GPDI1, OSHW inside U9). A courtyard is body PLUS margin PLUS shell
+    # overhang volume, so a small part living under a connector's courtyard is
+    # ordinary and correct. The .Fab outline is the real body, and there a
+    # non-exempt containment is unknown on the corpus.
+    #
+    # So `contained_frac` is measured on both body channels because it is free
+    # and true, while `contained` -- the flag anything downstream acts on --
+    # is asserted only where the corpus says it discriminates.
+    contained: bool = False
 
 
 def body_overlap_pairs(parts: Sequence[GradedPart]) -> List[BodyOverlapPair]:
@@ -612,6 +836,7 @@ def body_overlap_pairs(parts: Sequence[GradedPart]) -> List[BodyOverlapPair]:
         for b in items[i + 1:]:
             worst = 0.0
             worst_side = ''
+            worst_rects = None
             for s in (a.sides & b.sides):
                 ra = rect_on(s, a.side, a.rect, a.tht_rect)
                 rb = rect_on(s, b.side, b.rect, b.tht_rect)
@@ -621,11 +846,19 @@ def body_overlap_pairs(parts: Sequence[GradedPart]) -> List[BodyOverlapPair]:
                 if area > worst:
                     worst = area
                     worst_side = s
+                    worst_rects = (ra, rb)
             if worst > EPS:
+                ra, rb = worst_rects
+                ix = (max(ra[0], rb[0]), max(ra[1], rb[1]),
+                      min(ra[2], rb[2]), min(ra[3], rb[3]))
+                _dx, _dy = ix[2] - ix[0], ix[3] - ix[1]
                 out.append(BodyOverlapPair(
                     a=min(a.ref, b.ref), b=max(a.ref, b.ref),
                     kind='courtyard', area_mm2=round(worst, 4),
-                    side=worst_side, waived=False, waiver=''))
+                    side=worst_side, waived=False, waiver='',
+                    contained_frac=containment_frac(worst, *worst_rects),
+                    depth_mm=round(max(0.0, min(_dx, _dy)), 4),
+                    overlap_rect=tuple(round(v, 4) for v in ix)))
     out.sort(key=lambda p: (-p.area_mm2, p.a, p.b))
     return out
 
@@ -655,11 +888,14 @@ def graded_parts_from_file(pcb_data, pcb_file: Optional[str] = None
     for ref, fp in sorted((pcb_data.footprints or {}).items()):
         own = footprint_side(fp)
         local = None
+        synthetic = False
         if sides.get(ref):
             local = courtyard_for_side(sides[ref], own)
         if local is None:
             try:
                 local = compute_footprint_bbox_local(fp)
+                # No courtyard AND no pads: the +/-0.5mm fiction, not geometry.
+                synthetic = not (fp.pads or ())
             except Exception:
                 local = None
         if local is None:
@@ -675,7 +911,8 @@ def graded_parts_from_file(pcb_data, pcb_file: Optional[str] = None
                 tx0, ty0, tx1, ty1 = rotate_local_bounds(*tlb, rot)
                 tht = (fp.x + tx0, fp.y + ty0, fp.x + tx1, fp.y + ty1)
         out.append(GradedPart(ref=ref, side=own, rect=rect,
-                              tht_rect=tht, has_tht=has_tht))
+                              tht_rect=tht, has_tht=has_tht,
+                              synthetic=synthetic))
     return out
 
 
@@ -708,11 +945,15 @@ def grade_body_overlap(pcb_data, clearance: float,
         except Exception:
             return None
 
+    _graded = graded_parts_from_file(pcb_data, pcb_file)
+    # Refs whose courtyard rect is the zero-pad +/-0.5mm fiction: their pairs
+    # may inform but must never gate (run-23's phantom G***<->J5).
+    _synthetic_refs = {g.ref for g in _graded if g.synthetic}
     _containers: set = set()
     bb = getattr(getattr(pcb_data, 'board_info', None), 'board_bounds', None)
     if bb:
         _barea = max(1e-9, (bb[2] - bb[0]) * (bb[3] - bb[1]))
-        for g in graded_parts_from_file(pcb_data, pcb_file):
+        for g in _graded:
             if rect_area(g.rect) >= CONTAINER_RATIO * _barea:
                 _containers.add(g.ref)
 
@@ -729,9 +970,13 @@ def grade_body_overlap(pcb_data, clearance: float,
         return ''
 
     pairs: List[BodyOverlapPair] = []
+    # Refs the fab channel could not judge (no .Fab geometry). A board with no
+    # readable source path leaves this empty AND judges nothing -- both are
+    # reported rather than silently conflated with "clean".
+    fab_unjudged: set = set()
 
-    # -- courtyard channel (advisory) -----------------------------------------
-    for p in body_overlap_pairs(graded_parts_from_file(pcb_data, pcb_file)):
+    # -- courtyard channel (advisory + the run-23 blocking policy below) ------
+    for p in body_overlap_pairs(_graded):
         waiver = _waiver_for(p.a, p.b)
         pairs.append(p._replace(waived=bool(waiver), waiver=waiver))
 
@@ -747,6 +992,7 @@ def grade_body_overlap(pcb_data, clearance: float,
         for ref, fp in sorted(fps.items()):
             sides = fab.get(ref)
             if not sides:
+                fab_unjudged.add(ref)
                 continue
             own = footprint_side(fp)
             lb = sides.get(own) or next(iter(sides.values()))
@@ -761,10 +1007,16 @@ def grade_body_overlap(pcb_data, clearance: float,
                 ov = rect_overlap_area(rca, rcb)
                 if ov > EPS:
                     waiver = _waiver_for(ra, rb)
+                    _cf = containment_frac(ov, rca, rcb)
+                    _dx = min(rca[2], rcb[2]) - max(rca[0], rcb[0])
+                    _dy = min(rca[3], rcb[3]) - max(rca[1], rcb[1])
                     pairs.append(BodyOverlapPair(
                         a=min(ra, rb), b=max(ra, rb), kind='fab',
                         area_mm2=round(ov, 4), side=sa,
-                        waived=bool(waiver), waiver=waiver))
+                        waived=bool(waiver), waiver=waiver,
+                        contained_frac=_cf, contained=_cf is not None
+                        and _cf >= CONTAINMENT_FRAC,
+                        depth_mm=round(max(0.0, min(_dx, _dy)), 4)))
 
     # -- pad_intersection channel (never waivable) ----------------------------
     # AABB broad phase in the gate currency, then exact re-verification at
@@ -881,12 +1133,186 @@ def grade_body_overlap(pcb_data, clearance: float,
     blocking = [p for p in pairs if p.kind == 'pad_intersection']
     advisory = [p for p in pairs
                 if p.kind != 'pad_intersection' and not p.waived]
+    contained = [p for p in pairs if p.contained]
+    # The subset that GATES. A containment is by-design when a MARKER
+    # (mount_hole/fiducial/testpoint) or a CONTAINER (courtyard >= half the
+    # board) is involved -- orangecrab ships FID2 wholly inside J5 at frac
+    # 1.000 and FID1 inside J4 at 0.867, and both are correct -- or when an
+    # operator has named the pair in the intent's `overlap_waivers`, which is
+    # AUTHORED and recorded.
+    #
+    # `edge_class` is deliberately NOT an exemption, and that is the whole
+    # point. It is a pure part-class lookup with no geometry in it, and it is
+    # the waiver that hid run-22's D4-wholly-inside-SW2 (SW2 is a declared
+    # edge_actuator) and C26/FB3/R1 inside J1's 65mm2 USB-C body on the board
+    # that run shipped as `buildable`. An operator may still accept those --
+    # by writing the pair into the intent, where the acceptance is visible --
+    # but never by inheriting a class waiver nobody authored.
+    #
+    # Corpus effect, measured: ZERO boards gate on this.
+    _GATE_EXEMPT = ('marker_class', 'container_class', 'intent_declared')
+    containment_blocking = [p for p in contained
+                            if p.waiver not in _GATE_EXEMPT]
+    # Courtyard BLOCKING (run-23): the subset of courtyard pairs that gates.
+    # Both floors must trip -- area >= COURTYARD_BLOCKING_MIN_MM2 and depth
+    # >= COURTYARD_BLOCKING_MIN_DEPTH_MM -- so by-design slivers a healthy
+    # board carries stay advisory, and a synthetic (+/-0.5mm fiction)
+    # courtyard never gates anything.
+    #
+    # The waiver ladder applies WITH ONE GEOMETRY CONDITION on edge_class
+    # (the run-22 containment lesson, in its courtyard form): an edge-class
+    # waiver is a claim that the part's shell/actuator legitimately overhangs
+    # -- which is only TRUE of a part that is actually AT an edge. Run-23's
+    # board waived every SW1/SW2 collision this way (SW1<->U1 1.74mm2,
+    # FB1<->SW2 0.70mm2 with real body contact) while SW2 sat 8.33mm
+    # INTERIOR, where the overhang story is geometrically dead. The waiver
+    # now stands only for a member whose pose is edge-LIVE: overhanging the
+    # outline, or within SEAT_TOL_MM of an edge. J1<->SW1 stays waived (J1
+    # is a receptacle overhanging at the edge; its courtyard includes the
+    # mating volume); marker/container/intent waivers are untouched --
+    # geometry cannot invalidate "this is a fiducial" or an authored intent.
+    _EDGE_W = ('edge_receptacle', 'edge_actuator')
+    _edge_live_cache: Dict[str, bool] = {}
+
+    def _edge_waiver_live(ref: str) -> bool:
+        if ref in _edge_live_cache:
+            return _edge_live_cache[ref]
+        live = False
+        if _class_of(ref) in _EDGE_W and bb:
+            g = next((x for x in _graded if x.ref == ref), None)
+            if g is not None:
+                try:
+                    from .part_class import SEAT_TOL_MM
+                    _og = BoardOutlineGate(pcb_data.board_info, 0.0)
+                    live = (_og.rect_outside_amount(g.rect) > EPS
+                            or _og.edge_clearance(g.rect) <= SEAT_TOL_MM)
+                except Exception:                            # noqa: BLE001
+                    live = True     # unmeasurable geometry never UN-waives
+        _edge_live_cache[ref] = live
+        return live
+
+    # Marker classes whose courtyard is NON-PHYSICAL and may keep the blanket
+    # blocking exemption. A mount_hole is deliberately absent (run-23, user
+    # finding #3): its courtyard is the SCREW-HEAD/standoff keepout -- J3's
+    # header sat 1.47mm inside locked H2's courtyard behind the same
+    # 'marker_class' label a fiducial gets, and a screw in H2 lands on J3's
+    # pin row. Fiducials and testpoints have nothing above board level;
+    # mounting holes do.
+    _MARKER_NONPHYSICAL = ('fiducial', 'testpoint')
+
+    def _blocking_waived(p) -> bool:
+        if not p.waived:
+            return False
+        # An AUTHORED waiver outranks everything below: it is a recorded
+        # human decision about this exact pair.
+        if p.waiver == 'intent_declared':
+            return True
+        # No CLASS waiver blesses contact with a KiCad-LOCKED part (the
+        # run-8 E6 principle, extended to the courtyard channel): a locked
+        # pose is a decision somebody made, and a class label chosen for
+        # unlocked parts does not apply to copper or courtyards landing on
+        # it. The pair still faces the floors + the moved gate like any
+        # unwaived pair.
+        if p.a in locked_refs or p.b in locked_refs:
+            return False
+        if p.waiver == 'marker_class':
+            return (_class_of(p.a) in _MARKER_NONPHYSICAL
+                    or _class_of(p.b) in _MARKER_NONPHYSICAL)
+        if p.waiver != 'edge_class':
+            return True
+        if not (_edge_waiver_live(p.a) or _edge_waiver_live(p.b)):
+            return False
+        # run-23 user finding #1: an edge-LIVE part's waiver covers its
+        # MATING ZONE, never its whole courtyard. The overhang story is
+        # about the strip at/over the outline; an overlap sitting INSIDE
+        # the board is under the part's BODY, whoever is at the edge --
+        # R5 sat 45.7% inside J1's interior courtyard behind this waiver.
+        # The overlap region must leave the outline or hug the edge
+        # (within SEAT_TOL_MM); unmeasurable geometry never UN-waives.
+        r = p.overlap_rect
+        if r is None or not bb:
+            return True
+        try:
+            from .part_class import SEAT_TOL_MM
+            _og = BoardOutlineGate(pcb_data.board_info, 0.0)
+            return (_og.rect_outside_amount(r) > EPS
+                    or _og.edge_clearance(r) <= SEAT_TOL_MM)
+        except Exception:                                    # noqa: BLE001
+            return True
+
+    courtyard_blocking = [
+        p for p in pairs
+        if p.kind == 'courtyard' and not _blocking_waived(p)
+        # ABSOLUTE floor or RELATIVE floor (user finding #2: 0.445mm2 was
+        # 25.5% of R21's courtyard and slid under the absolute floor).
+        and (p.area_mm2 >= COURTYARD_BLOCKING_MIN_MM2
+             or (p.contained_frac or 0.0) >= COURTYARD_BLOCKING_MIN_FRAC)
+        and p.depth_mm >= COURTYARD_BLOCKING_MIN_DEPTH_MM
+        and p.a not in _synthetic_refs and p.b not in _synthetic_refs]
     return {'blocking': len(blocking),
             'advisory': len(advisory),
             'waived': sum(1 for p in pairs if p.waived),
             'pairs': pairs,
             'blocking_pairs': blocking,
             'advisory_pairs': advisory,
+            # Body containment: one part's .Fab outline (near-)wholly inside
+            # another's. DISCLOSURE ONLY -- deliberately NOT folded into
+            # `blocking`, because the corpus ships legitimate frac-1.0
+            # containments (fiducials under connector bodies, measured on
+            # orangecrab_ext_pll: FID2/J5 at 1.000, FID1/J4 at 0.867).
+            #
+            # NOT filtered by `waived`, and that one omission is the whole
+            # point. `_waiver_for` is pure class membership and geometry-blind,
+            # so a part sitting WHOLLY inside an `edge_actuator` gets the same
+            # `edge_class` label as a 0.01 mm2 graze and then leaves
+            # `advisory`, `advisory_pairs` AND `new_advisory_pairs` in one
+            # step. Run-22 lost D4-inside-SW2 exactly that way, twice, and
+            # nothing in the chain could report it. This is the list a waiver
+            # cannot empty.
+            'contained': len(contained),
+            'containment_pairs': contained,
+            'containment_blocking': len(containment_blocking),
+            'containment_blocking_pairs': containment_blocking,
+            # Parts whose footprint draws no .Fab outline at all, so the fab
+            # channel CANNOT judge them (parser.extract_fab_sides skips them
+            # and the loop above continues past them). An unjudged part is not
+            # a clean part, and saying nothing would claim it was.
+            #
+            # MEASURED across all 33 corpus boards, so nobody has to re-derive
+            # it: 144 of 1583 footprints are unjudged, and 144 of 144 draw ZERO
+            # .Fab geometric primitives. They are mounting holes, testpoints,
+            # logos, fiducials and panel tabs. There is NO footprint anywhere
+            # in the corpus whose .Fab geometry the parser fails to read --
+            # every primitive kind used on that layer (fp_line, fp_arc,
+            # fp_circle, fp_poly, fp_rect) is already handled, and there are no
+            # degenerate bboxes.
+            #
+            # So a parser tolerance or polygon-closure fix moves ZERO
+            # footprints out of this set. (313 footprints do have non-closing
+            # .Fab line chains -- tigard Q1's left edge stops 0.02mm short --
+            # and every one of them is judged correctly, because a bbox is a
+            # min/max over points and the gap is interior to it.)
+            #
+            # And the one change that WOULD close the hole is measured
+            # dangerous: giving a bodyless part a fallback body (its courtyard,
+            # else its pad bbox) adds 77 new fab pairs corpus-wide, 65 of them
+            # above CONTAINMENT_FRAC -- dominated by rp2350's Teensy40, a
+            # bodyless module whose courtyard swallows 56 neighbours at frac
+            # 1.0. It would also break the 4-pair calibration gate outright.
+            #
+            # DISCLOSURE IS THE ANSWER HERE, not a fix. Report the count and
+            # let a reader judge.
+            'fab_unjudged': len(fab_unjudged),
+            'fab_unjudged_refs': sorted(fab_unjudged),
+            # Run-23 courtyard blocking channel -- see the selection above.
+            # NOTE these pairs also remain in `advisory`/`advisory_pairs`
+            # (that count's meaning is unchanged for its existing consumers);
+            # a pair can be both advisory-listed and courtyard-blocking.
+            'courtyard_blocking': len(courtyard_blocking),
+            'courtyard_blocking_pairs': courtyard_blocking,
+            # Refs graded on the zero-pad +/-0.5mm fictional box: their pairs
+            # are disclosure, never gates (run-23's phantom G***<->J5).
+            'courtyard_synthetic_refs': sorted(_synthetic_refs),
             # E6: pairs where copper lands on a part KiCad marks (locked yes),
             # of ANY channel including waived ones. A locked pose is a decision
             # somebody made -- a mounting hole against an enclosure, a

--- a/py_placer/placement/part_class.py
+++ b/py_placer/placement/part_class.py
@@ -86,6 +86,14 @@ _PREFIX_RE = re.compile(r'^([A-Za-z]+)')
 
 SEAT_TOL_MM = 0.5      # default; callers pass max(0.5, 2*grid_step)
 
+#: run-23: past this distance from every edge, a `connector_affinity` part is
+#: flagged INTERIOR -- by the intent grade (advisory) and the review sheet,
+#: the SAME constant so the two never disagree. 3.0mm is a cable-clearance
+#: scale, not a board-derived number: within it a plug can usually still
+#: reach over the edge parts; run 23's J4 sat 6.03mm interior (flagged),
+#: J2/J5/J6/J7 sat 0.7-2.9mm from their edges (declared, not flagged).
+INTERIOR_AFFINITY_MM = 3.0
+
 
 @dataclass(frozen=True)
 class PartClass:
@@ -146,7 +154,73 @@ def classify_part(fp, ref: str) -> PartClass:
               else f"reference prefix {pref!r} (convention only)"]
         return PartClass('edge_actuator', 'medium' if fp_act else 'low',
                          tuple(ev))
+    # run-23: the WEAK connector class. Generic connectors (headers, JST,
+    # molex, terminal blocks) deliberately make NO edge claim -- a JST
+    # wire-to-board part is legitimately interior (the guard above stands) --
+    # but they are still where a human plugs something in, and run 23 seated
+    # J2/J5/J6/J7 mid-board with NO instrument able to say so, because a part
+    # with no class is invisible to every intent rule. `connector_affinity`
+    # exists to be DECLARED and graded at ADVISORY severity: a mid-board pose
+    # is a flag for the boundary review, never an error, and pose_plausible
+    # makes no claim for it.
+    if any(k in name for k in CONNECTOR_FP) and not is_ic_pkg:
+        return PartClass('connector_affinity', 'low',
+                         ('connector-family footprint name; no edge claim',))
     return PartClass(None, None)
+
+
+# Part classes whose POSITION is a mechanical fact rather than a placement
+# decision. `testpoint` is deliberately absent: a test point is placed to suit
+# the layout, not the enclosure.
+MECHANICAL_CLASSES = ('mount_hole', 'fiducial', 'edge_receptacle',
+                      'edge_actuator')
+
+
+def mechanical_parts(pcb_data) -> Dict[str, Dict]:
+    """The parts whose position a real new board would already know.
+
+    Lives here, beside `classify_part`, because it is the ONLY pose-derived
+    answer in the toolchain that survives an unplaced board: `classify_part`
+    reads footprint name, reference prefix and pin function and never a
+    coordinate, so a pile classifies exactly as the placed board does. Every
+    other channel that could name the mechanically-fixed parts is geometric
+    and collapses -- `lock_advisor`'s high-confidence list measured 7 refs on
+    a placed watchy and 1 on the same board piled, and 10 -> 0 on ulx3s,
+    because its two-channel promotion needs a geometric rule to fire.
+
+    It was `tests/stress/stage_unaided.classify_exempt`, which is a stress
+    harness -- so the one artifact naming a board's mechanical parts was
+    something no product path could read. Both callers project from this:
+    the stager wants `(x, y, rot)` and a reason, the brief wants the class
+    and its evidence.
+
+    `at` is REPORTED, never asserted. On a pile it is the pile coordinate,
+    which is the honest answer -- the caller decides what that is worth.
+    """
+    out: Dict[str, Dict] = {}
+    for ref, fp in sorted((getattr(pcb_data, 'footprints', None) or {}).items()):
+        cls = classify_part(fp, ref)
+        name = getattr(cls, 'name', None) if cls else None
+        locked = bool(getattr(fp, 'locked', False))
+        if name in MECHANICAL_CLASSES:
+            why = (f"{name} (confidence {getattr(cls, 'confidence', '?')}): "
+                   f"its position is a mechanical fact a real new board would "
+                   f"already know")
+        elif locked:
+            why = ("(locked yes) in the source: the board's author pinned it, "
+                   "and a run that may not move it must know where it is")
+        else:
+            continue
+        out[ref] = {
+            'class': name,
+            'confidence': getattr(cls, 'confidence', None) if cls else None,
+            'evidence': list(getattr(cls, 'evidence', ()) or ()),
+            'locked_in_source': locked,
+            'reason': why,
+            'at': [round(fp.x, 6), round(fp.y, 6),
+                   round(fp.rotation or 0.0, 6)],
+        }
+    return out
 
 
 def pose_plausible(cls: Optional[str], outside_amount: Optional[float],

--- a/py_placer/placement/portfolio.py
+++ b/py_placer/placement/portfolio.py
@@ -156,16 +156,38 @@ def _restore(state, snap: Dict[str, Tuple[float, float, float]]) -> None:
             state.apply_move(ref, x, y, rot)
 
 
-def copy_siblings(src_board: str, dst_board: str) -> None:
+def copy_siblings(src_board: str, dst_board: str, quiet: bool = False) -> None:
     """Carry the project/rules siblings (#441): a board without its .kicad_pro
     grades at the stock netclass, so every written candidate gets the input's
-    siblings -- the probe routes and any later adoption read them."""
+    siblings -- the probe routes and any later adoption read them.
+
+    THE EXTENSION LIST IS `copy_board.SIBLING_EXTS`, not a local copy. Eight
+    sites in this tree spelled it out by hand and three had already drifted:
+    `stage_blind`, `fixture_boards` and `redo_diff_stage` carry
+    `.kicad_pro` + `.kicad_prl` and drop `.kicad_dru` -- the per-layer
+    clearance rules that, per CLAUDE.md #498, OUTRANK `--clearance`. Dropping
+    them is silent by construction: `kicad_dru.read_board_layer_clearances`
+    returns `({}, [])` for an absent file, so the run routes an inner layer
+    at the wrong value with no diagnostic anywhere.
+
+    A missing project is DISCLOSED, never refused. Most of the corpus has no
+    `.kicad_pro` -- a pristine never-routed board legitimately has none -- so
+    refusing would make them unstageable. But staging one used to print
+    nothing at all, and the floor that silently became `fixed default 0.25`
+    is the number every later step grades against.
+    """
+    from copy_board import SIBLING_EXTS
     src_base = os.path.splitext(src_board)[0]
     dst_base = os.path.splitext(dst_board)[0]
-    for ext in ('.kicad_pro', '.kicad_dru', '.kicad_prl'):
+    for ext in SIBLING_EXTS:
         s = src_base + ext
         if os.path.isfile(s):
             shutil.copyfile(s, dst_base + ext)
+    if not quiet and not os.path.isfile(src_base + '.kicad_pro'):
+        print(f"WARNING: '{os.path.basename(src_board)}' has no sibling "
+              f".kicad_pro, so no DRC floor travelled with it. Every later "
+              f"step will resolve its floor from the board's own netclass if "
+              f"it has one, else a fixed default -- grade accordingly.")
 
 
 # --------------------------------------------------------------------------

--- a/py_placer/placement/provenance.py
+++ b/py_placer/placement/provenance.py
@@ -1,0 +1,257 @@
+"""Was every pose in this board produced by a registered engine lever?
+
+`fence_audit` asks a different question, correctly, and answers it every time:
+*does any file in this work dir carry the control's poses?* That is the BLIND
+question. Run 19 passed it -- `VERDICT: CLEAN, exit 0` -- on a run whose
+placement came from a 221-line hand script, because a hand-arranged board
+matches the control at ~0.0, nowhere near `MATCH_FRAC = 0.98`. There was
+nothing for it to find.
+
+The claim being made was a different one: *the engine placed this board*.
+Nothing in the repo measured that. `FENCE_CLAUSE` gestures at it behaviourally
+and concedes the limit in its own text ("nothing downstream can detect that it
+happened"), and it says DISCLOSE, not refrain.
+
+So this is an orthogonal sibling, not a replacement. Two questions, two
+instruments, two manifests.
+
+THIS IS AN ACCOUNTING BOUNDARY, NOT A SECURITY BOUNDARY, and saying so is the
+honest register (`fence_audit.py:84-113` does the same for its own allow-list).
+A determined author can call `declare_lever` from a hand script. What changes
+is that doing so is an affirmative falsification rather than an omission -- and
+because `provenance_audit` reconciles the DELIVERED BOARD's moved poses against
+the ledger rather than reading the log alone, a forger must fabricate a
+consistent `refs_moved` chain, which is a much larger act than skipping a
+disclosure.
+
+Registration is by explicit call, never by sniffing `sys.argv[0]`: sniffing is
+defeated by one assignment, and a boundary that looks stronger than it is, is
+worse than one that states its own limit.
+"""
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import inspect
+import json
+import os
+import time
+from typing import Dict, List, Optional, Sequence
+
+SCHEMA = 1
+LEDGER_NAME = '.pose-provenance.jsonl'
+REGIME_NAME = '.unaided-manifest.json'
+
+# The CLI entry points allowed to author poses. A tool absent from this list
+# is not forbidden -- it simply cannot claim the run was engine-authored.
+LEVER_REGISTRY = (
+    'place_seed.py', 'place_optimize.py',
+    'place_reconstruct.py', 'place_portfolio.py', 'place_route_loop.py',
+    'place_fanout_clearance.py', 'converge.py',
+    # Staging tools author poses BY DESIGN -- that is what staging is.
+    # `perturb.py` is a LIBRARY with no __main__; it is reached through
+    # stage_blind, whose declaration covers it by the innermost-wins rule.
+    'perturb.py', 'stage_blind.py',
+)
+
+# Registered but NOT pose writers. `beautify_labels.py` moves reference-
+# designator silkscreen through `write_label_output`, which is not the pose
+# funnel -- it never records and never raises, so listing it here would be a
+# decorative entry that implies a coverage this instrument does not have.
+# Named rather than silently omitted, because "why is it missing" is a
+# question someone will ask.
+NOT_POSE_WRITERS = ('beautify_labels.py',)
+
+_active: List[Dict] = []
+
+
+class UnaidedViolation(RuntimeError):
+    """A pose write with no registered lever, under an unaided regime."""
+
+
+@contextlib.contextmanager
+def declare_lever(file: str, argv: Optional[Sequence[str]] = None):
+    """Declare that the poses written inside this block come from `file`.
+
+    Called explicitly by each CLI. The innermost declaration wins, so a tool
+    that shells out to another still attributes to the one doing the writing.
+    """
+    _active.append({'lever': os.path.basename(file),
+                    'lever_argv': list(argv) if argv else None})
+    try:
+        yield
+    finally:
+        _active.pop()
+
+
+def active_lever() -> Optional[Dict]:
+    return dict(_active[-1]) if _active else None
+
+
+def _caller() -> str:
+    """The outermost frame outside the placement PACKAGE -- the run-19 detector.
+
+    A hand script that imports `placement.writer` and writes poses records
+    ITSELF here, whatever it does or does not declare.
+
+    It used to skip every frame under `/py_placer/`, which is where all the
+    lever CLIs live (`place_seed.py`, `place_optimize.py`, ...) -- so the field
+    documented as the detector recorded `<unknown>` for exactly the tools it
+    exists to identify, and `<frozen runpy>` under `python -m`. Only the
+    package internals are uninteresting; the CLI that called them is the
+    answer.
+    """
+    try:
+        for fr in inspect.stack()[1:]:
+            fn = fr.filename.replace('\\', '/')
+            if '/py_placer/placement/' in fn or fn.endswith('provenance.py'):
+                continue
+            if fn.startswith('<'):               # <frozen runpy>, <string>
+                continue
+            return f"{os.path.basename(fr.filename)}:{fr.lineno} in {fr.function}"
+    except Exception:                            # noqa: BLE001
+        pass
+    return '<unknown>'
+
+
+def regime_for(path: str) -> Optional[str]:
+    """The work dir governing `path`, or None. Walks up for the manifest."""
+    d = os.path.dirname(os.path.abspath(path)) or os.getcwd()
+    seen = 0
+    while d and seen < 24:
+        if os.path.isfile(os.path.join(d, REGIME_NAME)):
+            return d
+        parent = os.path.dirname(d)
+        if parent == d:
+            break
+        d, seen = parent, seen + 1
+    return None
+
+
+def sha256_file(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, 'rb') as f:
+        for chunk in iter(lambda: f.read(1 << 20), b''):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+_PENDING: Dict[str, Dict] = {}
+
+
+def commit_write(output_file: str) -> Optional[Dict]:
+    """Finish the row `record_write(pending=True)` started, now the file exists.
+
+    Split in two so the REFUSAL can happen before the write. The gate used to
+    run after it, which made refusing decorative -- the poses were already on
+    disk and the exception only described a file it had helped produce.
+    """
+    row = _PENDING.pop(os.path.abspath(output_file), None)
+    if row is None:
+        return None
+    root = row.pop('_root')
+    row['board_sha256'] = (sha256_file(output_file)
+                           if os.path.isfile(output_file) else None)
+    with open(os.path.join(root, LEDGER_NAME), 'a', encoding='utf-8') as f:
+        f.write(json.dumps(row, sort_keys=True) + '\n')
+    return row
+
+
+def record_write(input_file: str, output_file: str,
+                 placements: Sequence[Dict],
+                 pending: bool = False) -> Optional[Dict]:
+    """Append one row for a pose write. Returns it, or None outside a regime.
+
+    Raises `UnaidedViolation` when a regime is in force and no lever is
+    declared. With `pending=True` the row is held until `commit_write`, so a
+    refusal can precede the write rather than follow it.
+    """
+    root = regime_for(output_file)
+    lever = active_lever()
+    if root is None:
+        return None
+    if lever is None:
+        raise UnaidedViolation(
+            f"{os.path.basename(output_file)}: poses were written with no "
+            f"registered lever, under the unaided regime at {root}. The "
+            f"caller was {_caller()}. A run that claims the engine placed "
+            f"this board cannot contain a pose this tool did not author -- "
+            f"see placement/provenance.py.")
+    if lever['lever'] not in LEVER_REGISTRY:
+        raise UnaidedViolation(
+            f"{os.path.basename(output_file)}: {lever['lever']!r} is not in "
+            f"LEVER_REGISTRY, so it cannot author poses under the unaided "
+            f"regime at {root}. Register it deliberately or run outside the "
+            f"regime.")
+
+    # refs_moved is SEPARATE from refs_written on purpose. `perturb.
+    # _all_at_current` hands the writer EVERY part so that six-decimal `(at)`
+    # reformatting cannot fingerprint the moved block; without the split every
+    # row would claim the whole board and the audit would be vacuous.
+    moved = []
+    try:
+        from kicad_parser import parse_kicad_pcb
+        before = parse_kicad_pcb(input_file).footprints
+        for p in placements:
+            ref = p.get('reference')
+            fp = before.get(ref)
+            if fp is None:
+                moved.append(ref)
+                continue
+            if (abs(fp.x - p.get('new_x', fp.x)) > 1e-6
+                    or abs(fp.y - p.get('new_y', fp.y)) > 1e-6
+                    or abs(((fp.rotation or 0.0)
+                            - (p.get('new_rotation') or 0.0) + 180.0) % 360.0
+                           - 180.0) > 1e-6):
+                moved.append(ref)
+    except Exception:                            # noqa: BLE001
+        moved = [p.get('reference') for p in placements]
+
+    row = {'t': time.time(), 'schema': SCHEMA,
+           'path': os.path.abspath(output_file),
+           'parent_sha256': (sha256_file(input_file)
+                             if os.path.isfile(input_file) else None),
+           'lever': lever['lever'], 'lever_argv': lever['lever_argv'],
+           'declared': True, 'caller': _caller(),
+           'refs_written': sorted(p.get('reference') for p in placements),
+           'refs_moved': sorted(r for r in moved if r)}
+    if pending:
+        row['_root'] = root
+        _PENDING[os.path.abspath(output_file)] = row
+        return row
+    row['board_sha256'] = (sha256_file(output_file)
+                           if os.path.isfile(output_file) else None)
+    with open(os.path.join(root, LEDGER_NAME), 'a', encoding='utf-8') as f:
+        f.write(json.dumps(row, sort_keys=True) + '\n')
+    return row
+
+
+def read_ledger(root: str) -> List[Dict]:
+    """Every row, tolerating a torn last line (board_store.Ledger's rule)."""
+    path = os.path.join(root, LEDGER_NAME)
+    out: List[Dict] = []
+    if not os.path.isfile(path):
+        return out
+    with open(path, encoding='utf-8') as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                out.append(json.loads(line))
+            except ValueError:
+                pass
+    return out
+
+
+def start_regime(workdir: str, staged_board: str, **extra) -> str:
+    """Mark a work dir unaided and seed the chain with the staged board."""
+    os.makedirs(workdir, exist_ok=True)
+    doc = {'schema': SCHEMA, 'kind': 'unaided-regime',
+           'staged_board': os.path.abspath(staged_board),
+           'staged_sha256': sha256_file(staged_board),
+           'lever_registry': list(LEVER_REGISTRY), **extra}
+    path = os.path.join(workdir, REGIME_NAME)
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(doc, f, indent=1, sort_keys=True)
+    return path

--- a/py_placer/placement/quench.py
+++ b/py_placer/placement/quench.py
@@ -34,6 +34,7 @@ untouched, since max(1, 1) = 1.
 """
 from __future__ import annotations
 
+import os
 import math
 from typing import Dict, List, NamedTuple, Sequence, Tuple, Set, Optional
 
@@ -45,12 +46,20 @@ from placement.parser import (courtyard_for_side, extract_courtyard_sides,
                               extract_locked_refs, warn_missing_courtyards)
 from placement.utility import compute_footprint_bbox_local, snap_to_grid
 from placement import legality
-from placement.legality import (CONTAINER_RATIO, BoardOutlineGate,
+from placement.legality import (CONTAINER_RATIO, CONTAINMENT_FRAC,
+                                BoardOutlineGate, containment_frac,
                                 footprint_has_through_pads,
                                 footprint_side, pair_min_gap, rect_gap,
+                                rect_overlap_area,
                                 rotate_local_bounds, sides_occupied)
 
 ROTATIONS = [0.0, 90.0, 180.0, 270.0]
+
+#: Kill switch for the body-containment conjunct in `candidate_valid`. It is a
+#: HARD gate on real boards, so a way to isolate it without a git stash is
+#: worth the one line -- `KRT_NO_CONTAINMENT_GATE=1` restores the pre-2026-08
+#: behaviour exactly. Not a supported flag; a debugging lever.
+_CONTAINMENT_GATE = os.environ.get('KRT_NO_CONTAINMENT_GATE', '') != '1'
 EPS_IMPROVE = 1e-6
 
 # Both helpers now live in placement/legality.py, the single home shared with
@@ -430,6 +439,13 @@ class QuenchState:
         self.edge_halo = edge_halo
         self.edge_weight = edge_weight
         self.grid_step = grid_step
+
+        # Kept so the FAB body channel can be resolved lazily -- see
+        # `fab_rect`. Nothing is parsed unless something asks.
+        self.pcb_file = pcb_file
+        self.pcb_data = pcb_data
+        self._fab_local = None
+        self._fab_cache = {}
 
         courtyards = extract_courtyard_sides(pcb_file)
         locked_refs = set(extract_locked_refs(pcb_file))
@@ -1083,6 +1099,27 @@ class QuenchState:
                 if rect_gap(rect, r) < clr:
                     legal = False
                     break
+        if legal:
+            # BODY layer. A pose that buries this part inside another part's
+            # .Fab body is not a trade-off to be priced -- it is illegal, the
+            # same verdict reconstruct._pair_conflicts already returns for the
+            # assign/exchange ILP. Without it here, `legalize` and every
+            # quench pass could re-seat a charged part straight back inside
+            # the body it was charged for, and _try_place's clearance ladder
+            # (full, full/2, 0.02) makes such a seat MORE reachable, not less.
+            #
+            # FAB currency, and only fab. The courtyard would be a false-veto
+            # machine: four healthy corpus boards ship frac-1.0 COURTYARD
+            # containment (esp_prog, orangecrab, rp2350, ulx3s). The docstring
+            # above warns that on watchy 81 of 82 parts start in violation of
+            # the courtyard clearance -- that warning is about the courtyard
+            # currency and about RELAXING the gate, and it does not transfer:
+            # on the fab currency the whole 33-board corpus carries 4 pairs
+            # with a maximum non-exempt frac of 0.011.
+            #
+            # Same marker/container exemption as the prevention gate, or a
+            # displaced fiducial could never come home under a connector.
+            legal = not self._body_contained_at(ref, x, y, rot, exclude)
         if legal and self.legality_ctx is not None:
             # Pad+drill layer: courtyard-clear does not imply pad-clear (pads
             # overhanging courtyards, exchanged nets, NPTH holes). Baseline-
@@ -1097,9 +1134,8 @@ class QuenchState:
         # candidate of this part until something moves. Without the cache this
         # branch runs a full neighbour sweep per rejected candidate, which on a
         # dense board is most of them.
-        cur_board, cur_overlap = (
-            self.violation_parts(ref, exclude=exclude) if exclude
-            else self._incumbent_violation(ref))
+        cur_board, cur_overlap = self._incumbent_violation(ref,
+                                                           exclude=exclude)
         if cur_overlap > EPS_IMPROVE or cur_board <= EPS_IMPROVE:
             # Overlapping, or already legal: original rule, legal poses only.
             return False
@@ -1153,11 +1189,29 @@ class QuenchState:
             return False
         return cur.hole <= base.hole + EPS_IMPROVE
 
-    def _incumbent_violation(self, ref):
-        v = self._inc_violation.get(ref)
+    def _incumbent_violation(self, ref, exclude=None):
+        """The incumbent pose's violation, cached per (ref, exclude).
+
+        The `exclude` half is why this exists. `candidate_valid`'s rejection
+        path guarded the cache with `if exclude:` and fell through to an
+        uncached `violation_parts` whenever one was supplied -- and the seeder
+        ALWAYS supplies one (the unplaced pile), so on the path that matters
+        the cache never ran. Measured over 30s of a real seeding run: 61,119
+        incumbent-pose calls, of which 61,092 (99.96%) were exact repeats of
+        the same (ref, clearance, exclude). Each one walks the neighbours and
+        the outline; the comment three lines above the guard already said this
+        must not happen.
+
+        The key is a frozenset, so it costs O(|exclude|) hashing against a
+        full neighbour-and-outline sweep -- cheap by a wide margin. The whole
+        cache is cleared on every move (see apply_move), which is what makes
+        an incumbent answer safe to hold at all.
+        """
+        key = (ref, frozenset(exclude) if exclude else None)
+        v = self._inc_violation.get(key)
         if v is None:
-            v = self.violation_parts(ref)
-            self._inc_violation[ref] = v
+            v = self.violation_parts(ref, exclude=exclude)
+            self._inc_violation[key] = v
         return v
 
     def _edges_near(self, ref) -> list:
@@ -1246,6 +1300,113 @@ class QuenchState:
         return cost, n_out + n_in
 
     # ----- full cost (for reporting) ---------------------------------------
+
+    def fab_rect(self, ref, x=None, y=None, rot=None):
+        """The part's .Fab BODY rect at a pose, or None when its footprint
+        draws no .Fab geometry.
+
+        The body currency for CONTAINMENT tests. It must never fall back to
+        the courtyard: a courtyard is body + margin + shell-overhang volume,
+        and the 33-board corpus ships frac-1.0 COURTYARD containment on four
+        healthy boards (esp_prog, orangecrab_ext_pll,
+        rp2350_fpga_eensy_prePlane, ulx3s) against ZERO non-exempt fab
+        containment. A courtyard-based containment test is a false-veto
+        machine; this one is not.
+
+        None means UNJUDGED, not clear -- a pose inside a bodyless part
+        cannot be refused, and callers disclose that rather than assuming
+        coverage they do not have.
+
+        Lazy: nothing is parsed until the first call, so every existing
+        quench/seeder path pays nothing.
+        """
+        if self._fab_local is None:
+            try:
+                from placement.parser import extract_fab_sides
+                self._fab_local = extract_fab_sides(self.pcb_file) or {}
+            except Exception:
+                self._fab_local = {}
+        p = self.parts.get(ref)
+        if p is None:
+            return None
+        sides = self._fab_local.get(ref)
+        if not sides:
+            return None
+        x = p.x if x is None else x
+        y = p.y if y is None else y
+        rot = p.rot if rot is None else rot
+        key = (ref, rot % 360)
+        local = self._fab_cache.get(key)
+        if local is None:
+            own = 'B' if str(getattr(p, 'side', 'F')).upper().startswith('B')                 else 'F'
+            lb = sides.get(own) or next(iter(sides.values()))
+            local = rotate_local_bounds(*lb, rot)
+            self._fab_cache[key] = local
+        return (x + local[0], y + local[1], x + local[2], y + local[3])
+
+    def body_exempt_refs(self):
+        """Refs whose body may legitimately swallow or be swallowed.
+
+        MARKER (mount_hole/fiducial/testpoint) and CONTAINER only -- the same
+        set reconstruct._body_exempt_refs builds, and deliberately NOT the
+        edge classes. Measured: orangecrab ships FID2 wholly inside J5 at frac
+        1.000 and FID1 inside J4 at 0.867, so without the marker exemption a
+        displaced fiducial could never come home under a connector.
+        """
+        cached = getattr(self, '_body_exempt', None)
+        if cached is not None:
+            return cached
+        exempt = set(getattr(self, 'container_refs', ()) or ())
+        try:
+            from placement.part_class import classify_part
+            fps = getattr(getattr(self, 'pcb_data', None), 'footprints', {})
+            for ref in self.parts:
+                fp = (fps or {}).get(ref)
+                if fp is None:
+                    continue
+                try:
+                    if classify_part(fp, ref).name in ('mount_hole', 'fiducial',
+                                                       'testpoint'):
+                        exempt.add(ref)
+                except Exception:
+                    continue
+        except Exception:
+            pass
+        self._body_exempt = exempt
+        return exempt
+
+    def _body_contained_at(self, ref, x, y, rot, exclude=None):
+        """Would this pose put `ref`'s body inside a neighbour's, or vice
+        versa? Fab currency; `None` from fab_rect means UNJUDGED, never clear.
+        """
+        if not _CONTAINMENT_GATE:
+            return False
+        exempt = self.body_exempt_refs()
+        if ref in exempt:
+            return False
+        ra = self.fab_rect(ref, x, y, rot)
+        if ra is None:
+            return False
+        part = self.parts[ref]
+        if self._neighbors is not None and ref in self._neighbors:
+            others = [(o, self.parts[o]) for o in self._neighbors[ref]]
+        else:
+            others = list(self.parts.items())
+        for other_ref, other in others:
+            if other_ref == ref or (exclude and other_ref in exclude):
+                continue
+            if other_ref in exempt or other.side != part.side:
+                continue
+            rb = self.fab_rect(other_ref)
+            if rb is None:
+                continue
+            area = rect_overlap_area(ra, rb)
+            if area <= 1e-9:
+                continue
+            frac = containment_frac(area, ra, rb)
+            if frac is not None and frac >= CONTAINMENT_FRAC:
+                return True
+        return False
 
     def total_cost(self):
         all_aw = _aw_array([aw for lst in self.net_airwires.values() for aw in lst])

--- a/py_placer/placement/reachability.py
+++ b/py_placer/placement/reachability.py
@@ -44,6 +44,7 @@ because a silently-degraded reachability answer is worse than none.
 from __future__ import annotations
 
 import math
+import os
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Sequence, Tuple
 
@@ -212,7 +213,8 @@ def slack_field(pcb, target_net_id, layer, view, base_clearance,
 # widest path
 # --------------------------------------------------------------------------
 
-def widest_path(slacks, targets, via_ok, seed_xy, seed_layer, view, step):
+def widest_path(slacks, targets, via_ok, seed_xy, seed_layer, view, step,
+                return_throat=False):
     """Kruskal widest path over a multi-layer grid; returns mm or None.
 
     Nodes are (cell, layer). In-layer edges join adjacent ACTIVE cells; a via
@@ -223,6 +225,13 @@ def widest_path(slacks, targets, via_ok, seed_xy, seed_layer, view, step):
     Returns the largest t such that a path exists using only cells of slack
     >= t. Exact for the raster: no search order, no grid alignment, no
     heuristic. None means no positive-slack path exists at any width.
+
+    `return_throat=True` returns `(value, (layer, x_mm, y_mm))` instead. The
+    cell that CLOSED the path is the throat -- the narrowest point on the widest
+    route -- and it was already in hand here (`lay`, `x`, `y` at the moment the
+    seed joins the target) and thrown away at the bare `return float(val)`.
+    Every consumer that wanted to say WHERE the bottleneck was had to go and
+    find it again by eye. `None` throat when there is no path.
     """
     L = len(slacks)
     h, w = slacks[0].shape
@@ -274,8 +283,13 @@ def widest_path(slacks, targets, via_ok, seed_xy, seed_layer, view, step):
                 if other != lay and active[other * n + cell]:
                     union(idx, other * n + cell)
         if active[seed] and find(seed) == find(TARGET):
-            return float(val)
-    return None
+            if not return_throat:
+                return float(val)
+            # `lay`, `y`, `x` are this cell -- the LAST one activated, i.e. the
+            # narrowest on the widest path. Cell centre, not corner.
+            return float(val), (lay, view[0] + (x + 0.5) * step,
+                                view[1] + (y + 0.5) * step)
+    return (None, None) if return_throat else None
 
 
 @dataclass
@@ -295,6 +309,17 @@ class Reachability:
     grid: Tuple[int, int]
     note: str = ''
     open_room_mm: float = 0.0     # the cap free space was clamped to
+    # WHERE the bottleneck is: (layer_index, x_mm, y_mm), or None when there is
+    # no path. Everything below exists because run 20 measured a throat, printed
+    # the number, and then had to hand-assemble the coordinates, the blocking
+    # refs and the relief distance into an English paragraph in a ledger string
+    # -- three tools' stdout, none of it consumable by anything downstream.
+    throat_cell: Optional[Tuple[int, float, float]] = None
+    #: The base clearance the field was built at. Needed to convert between the
+    #: two SPACES this class reports in -- see `gap_mm`.
+    clearance_mm: float = 0.0
+    #: Foreign copper nearest the throat: [{ref, pad, kind, x, y, layer, dist}].
+    near: Tuple[dict, ...] = ()
 
     @property
     def wide_open(self) -> bool:
@@ -333,6 +358,34 @@ class Reachability:
             return None
         return 1000.0 * (self.bottleneck_mm - self.track_mm)
 
+    @property
+    def gap_mm(self) -> Optional[float]:
+        """The bottleneck in GAP space -- the physical edge-to-edge distance.
+
+        `bottleneck_mm` is in SLACK space: `slack = 2 * (dist - clearance)`
+        (see `slack_field`), which is the widest TRACK that fits. The physical
+        gap between the two pieces of copper is `bottleneck + 2 * clearance`.
+
+        The two are different numbers for the same throat and mixing them is
+        easy: run 20's ledger recorded `0.409/0.450mm` (gap space) beside
+        `-37.69um` (track space) in one sentence, as if they described the same
+        measurement. Publishing both, each labelled, is why this property
+        exists.
+        """
+        if self.bottleneck_mm is None:
+            return None
+        return self.bottleneck_mm + 2.0 * self.clearance_mm
+
+    @property
+    def throat(self) -> Optional[dict]:
+        """The throat in world coordinates, or None."""
+        if not self.throat_cell:
+            return None
+        lay, x, y = self.throat_cell
+        return {'x': round(x, 4), 'y': round(y, 4),
+                'layer': self.layers[lay] if lay < len(self.layers)
+                else str(lay)}
+
     def to_dict(self):
         return {'net': self.net, 'seed': list(self.seed),
                 'layers': list(self.layers), 'step_mm': self.step_mm,
@@ -353,7 +406,69 @@ class Reachability:
                 'via_legal_fraction': round(self.via_legal_fraction, 4),
                 'grid': list(self.grid), 'view': [round(v, 3)
                                                   for v in self.view],
-                'note': self.note}
+                'note': self.note,
+                # ADDITIVE. Every key above is unchanged, and a test pins that
+                # -- consumers of this payload predate the defect record.
+                'throat': self.throat,
+                'clearance_mm': self.clearance_mm,
+                'gap_mm': (None if self.gap_mm is None
+                           else round(self.gap_mm, 5)),
+                'near': [dict(n) for n in self.near]}
+
+    def defect_record(self, board=None, board_sha=None, relief=(),
+                      instrument='check_reachability', floors=None):
+        """This measurement as a `defect-record` document -- the shared shape.
+
+        One document, produced by any tool, read by the render, the ledger and
+        the driver. Everything in it was already computed here and thrown away
+        at the point of formatting; this is plumbing, not new measurement.
+
+        Returns None when there is nothing to report (no verdict, or PASSABLE).
+        """
+        if not self.measured or not self.caged:
+            return None
+        thr = self.throat
+        # The two spaces, both stated, both labelled, with what converts them.
+        measure = {'space': 'track_width',
+                   'have_mm': (None if self.bottleneck_mm is None
+                               else round(self.bottleneck_mm, 5)),
+                   'need_mm': self.track_mm,
+                   'short_mm': (None if self.bottleneck_mm is None else
+                                round(self.track_mm - self.bottleneck_mm, 5)),
+                   'resolution_mm': self.step_mm,
+                   'gap_mm': (None if self.gap_mm is None
+                              else round(self.gap_mm, 5)),
+                   'gap_need_mm': round(self.track_mm
+                                        + 2.0 * self.clearance_mm, 5),
+                   'derived_from': 'have_mm + 2 * instrument.floors.'
+                                   'clearance.value'}
+        refs, pads = [], []
+        for n in self.near:
+            if n.get('ref') and n['ref'] not in refs:
+                refs.append(n['ref'])
+            if n.get('pad') and n['pad'] not in pads:
+                pads.append(n['pad'])
+        d = {'kind': 'throat', 'verdict': 'CAGED', 'net': self.net,
+             'seed': {'x': round(self.seed[0], 4), 'y': round(self.seed[1], 4),
+                      'layer': self.layers[0] if self.layers else None},
+             'at': thr, 'refs': refs, 'pads': pads, 'measure': measure,
+             'view': [round(v, 4) for v in self.view],
+             'relief': [dict(r) for r in relief],
+             'instrument': {'source': instrument, 'floors': dict(floors or {}),
+                            'step_mm': self.step_mm,
+                            'search_view': [round(v, 4) for v in self.view]}}
+        if len(self.near) >= 2:
+            d['span'] = {'a': {k: self.near[0].get(k)
+                               for k in ('x', 'y', 'layer', 'kind')},
+                         'b': {k: self.near[1].get(k)
+                               for k in ('x', 'y', 'layer', 'kind')}}
+        doc = {'kind': 'defect-record', 'version': 1, 'count': 1,
+               'defects': [d]}
+        if board:
+            doc['board'] = os.path.abspath(board)
+        if board_sha:
+            doc['board_sha'] = board_sha
+        return doc
 
     def format_text(self):
         lines = [f"net        {self.net} from ({self.seed[0]}, "
@@ -389,6 +504,66 @@ class Reachability:
                 f"VERDICT    {'CAGED' if self.caged else 'PASSABLE'} at track "
                 f"{self.track_mm}mm  (margin {self.margin_um:+.1f} um)")
         return '\n'.join(lines)
+
+
+def nearest_foreign(pcb, x, y, net_id, layers=None, k=2, radius_mm=2.0):
+    """The k nearest pieces of FOREIGN copper to (x, y), nearest first.
+
+    "Which two things form this throat" is the question every reader asks
+    immediately after "how wide is it", and answering it took a second tool and
+    a hand-assembled sentence. Modelled on `net_forensics`' wall inventory,
+    which already does exactly this inventory with `REF.PAD` naming -- this is
+    the same walk with a k-nearest cut instead of a printed table.
+
+    Each entry: {kind, ref, pad, net, x, y, layer, dist}. Distances are to the
+    OBJECT CENTRE (a pad's copper centre, a segment's nearer endpoint), not to
+    its edge: the edge-to-edge number is what `gap_mm` reports, and conflating
+    the two is the error this module keeps trying to make impossible.
+    """
+    lay = set(layers or ())
+    out = []
+    for fp in pcb.footprints.values():
+        for p in fp.pads:
+            if p.net_id == net_id:
+                continue
+            if getattr(p, 'pad_type', '') == 'np_thru_hole':
+                continue
+            if lay and not (p.drill or set(p.layers or ()) & lay):
+                continue
+            d = math.hypot(p.global_x - x, p.global_y - y)
+            if d <= radius_mm:
+                out.append({'kind': 'pad', 'ref': fp.reference,
+                            'pad': f'{fp.reference}.{p.pad_number}',
+                            'net': (pcb.nets[p.net_id].name
+                                    if p.net_id in pcb.nets else None),
+                            'x': round(p.global_x, 4), 'y': round(p.global_y, 4),
+                            'layer': (p.layers or [None])[0],
+                            'dist': round(d, 5)})
+    for v in pcb.vias:
+        if v.net_id == net_id:
+            continue
+        d = math.hypot(v.x - x, v.y - y)
+        if d <= radius_mm:
+            out.append({'kind': 'via', 'ref': None, 'pad': None,
+                        'net': (pcb.nets[v.net_id].name
+                                if v.net_id in pcb.nets else None),
+                        'x': round(v.x, 4), 'y': round(v.y, 4),
+                        'layer': None, 'dist': round(d, 5)})
+    for s in pcb.segments:
+        if s.net_id == net_id:
+            continue
+        if lay and s.layer not in lay:
+            continue
+        d = min(math.hypot(s.start_x - x, s.start_y - y),
+                math.hypot(s.end_x - x, s.end_y - y))
+        if d <= radius_mm:
+            out.append({'kind': 'segment', 'ref': None, 'pad': None,
+                        'net': (pcb.nets[s.net_id].name
+                                if s.net_id in pcb.nets else None),
+                        'x': round(s.start_x, 4), 'y': round(s.start_y, 4),
+                        'layer': s.layer, 'dist': round(d, 5)})
+    out.sort(key=lambda e: e['dist'])
+    return tuple(out[:k])
 
 
 def pad_reachability(pcb, seed_xy, net_name=None, net_id=None, *,
@@ -492,12 +667,17 @@ def pad_reachability(pcb, seed_xy, net_name=None, net_id=None, *,
         note = ("no other island of this net is inside the view -- the pad is "
                 "already joined to everything nearby. Widen --margin, or this "
                 "is not a reachability question")
-    b = (None if n_t == 0
-         else widest_path(slacks, targets, via_ok, seed_xy, 0, view, step))
+    b, throat = ((None, None) if n_t == 0
+                 else widest_path(slacks, targets, via_ok, seed_xy, 0, view,
+                                  step, return_throat=True))
+    near = ()
+    if throat:
+        near = nearest_foreign(pcb, throat[1], throat[2], net_id, layers)
     return Reachability(
         net=name, net_id=net_id, seed=(seed_xy[0], seed_xy[1]), layers=layers,
         step_mm=step, track_mm=track_mm, via_mm=via_mm, view=view,
         bottleneck_mm=b, target_cells=n_t,
         via_legal_fraction=float(via_ok.mean()),
         grid=(slacks[0].shape[1], slacks[0].shape[0]), note=note,
-        open_room_mm=_open_room(view))
+        open_room_mm=_open_room(view),
+        throat_cell=throat, clearance_mm=base_clearance, near=near)

--- a/py_placer/placement/reconstruct.py
+++ b/py_placer/placement/reconstruct.py
@@ -1559,6 +1559,96 @@ def solve_assignment(state, candidates: Dict[str, List[Tuple[float, float]]],
                                edge_pref=edge_pref or {})
 
 
+def _body_exempt_refs(state):
+    """Refs whose body may legitimately swallow, or be swallowed by, another.
+
+    Cached on the state. Two classes only, and both are MEASURED necessary on
+    the 33-board corpus, not assumed:
+
+      marker  (mount_hole / fiducial / testpoint) -- orangecrab_ext_pll ships
+              FID2 wholly inside J5 (frac 1.000) and FID1 inside J4 (0.867).
+              Without this exemption a displaced fiducial or mounting hole
+              could never come home under a connector, which is where they
+              belong.
+      container (courtyard >= CONTAINER_RATIO of the board) -- a part that
+              covers half the board contains things by construction.
+
+    EDGE classes (edge_receptacle / edge_actuator) are deliberately NOT
+    exempt here, although `legality._waiver_for` waives them for REPORTING.
+    That difference is the point: run-22's D4 landed wholly inside SW2, and
+    SW2 is a declared `edge_actuator`, so an edge exemption would re-permit
+    the exact defect this predicate exists to stop. It is safe by
+    measurement -- the only non-exempt fab pairs on the whole corpus are
+    ulx3s GPDI1/J5 at frac 0.011 and GPDI1/SW1 at 0.001, both far under
+    CONTAINMENT_FRAC.
+    """
+    cached = getattr(state, '_body_exempt', None)
+    if cached is not None:
+        return cached
+    exempt = set(getattr(state, 'container_refs', ()) or ())
+    try:
+        from placement.part_class import classify_part
+        fps = getattr(getattr(state, 'pcb_data', None), 'footprints', None)
+        if fps is None:
+            fps = {}
+        for ref in state.parts:
+            fp = fps.get(ref)
+            if fp is None:
+                continue
+            try:
+                if classify_part(fp, ref).name in ('mount_hole', 'fiducial',
+                                                   'testpoint'):
+                    exempt.add(ref)
+            except Exception:
+                continue
+    except Exception:
+        pass
+    state._body_exempt = exempt
+    return exempt
+
+
+def _body_contained(state, a: str, pos_a, b: str, pos_b) -> bool:
+    """Would one of these two poses put a part's BODY inside the other's?
+
+    The run-22 defect, verbatim: `assign`/`exchange` moved parts by a derived
+    +/-v with only pad legality and hpwl in the objective, so a teleport could
+    land a part wholly inside another part's body and score clean. It did,
+    twice, on two different pairs -- and every gate downstream reported
+    `blocking 0`, because no pad copper intersects.
+
+    FAB currency, never the courtyard. Measured on the corpus: the courtyard
+    ships frac-1.0 containment on four healthy boards, so a courtyard test
+    would veto legal poses on 12% of the corpus -- the run-4 lesson in a new
+    costume. `.Fab` is the drawn body, and non-exempt fab containment is
+    unknown on the corpus.
+
+    This charges CONTAINMENT, not a kiss. Two courtyards touching is not a
+    defect and is not priced here; that ordering decision (run-4, r=+0.72 of
+    courtyard overlap with distance-to-truth) is untouched, and `measure()`
+    still carries `overlap` as its last tiebreak below hpwl.
+
+    A part whose footprint draws no `.Fab` outline is UNJUDGED: this returns
+    False for it, and `place_reconstruct` discloses the count rather than
+    implying coverage it does not have.
+    """
+    if a in _body_exempt_refs(state) or b in _body_exempt_refs(state):
+        return False
+    pa, pb = state.parts[a], state.parts[b]
+    if pa.side != pb.side:          # same rule as legality's fab channel
+        return False
+    ra = state.fab_rect(a, pos_a[0], pos_a[1], pa.rot)
+    if ra is None:
+        return False
+    rb = state.fab_rect(b, pos_b[0], pos_b[1], pb.rot)
+    if rb is None:
+        return False
+    area = legality.rect_overlap_area(ra, rb)
+    if area <= legality.EPS:
+        return False
+    frac = legality.containment_frac(area, ra, rb)
+    return frac is not None and frac >= legality.CONTAINMENT_FRAC
+
+
 def _pair_conflicts(state, a: str, pos_a, b: str, pos_b) -> bool:
     """Do these two candidate poses conflict, ABSOLUTELY? Repair semantics:
     unlike the quench's baseline-relative gate, the assign stage exists to
@@ -1566,6 +1656,11 @@ def _pair_conflicts(state, a: str, pos_a, b: str, pos_b) -> bool:
     damaged status quo feasible at zero cost (measured: the ILP chose
     all-stay on the swap corpus). The outer stage gate still reverts any
     application that worsens the board."""
+    # Body containment first: two memoized rect lookups against
+    # pair_shortfall's full pad-set geometry, so a contained pair now costs
+    # LESS to reject than it used to cost to wrongly accept.
+    if _body_contained(state, a, pos_a, b, pos_b):
+        return True
     ctx = state.legality_ctx
     pa, pb = state.parts[a], state.parts[b]
     cur = ctx.pair_shortfall(a, b, pose_a=(pos_a[0], pos_a[1], pa.rot),
@@ -1578,7 +1673,16 @@ def _pair_conflicts(state, a: str, pos_a, b: str, pos_b) -> bool:
 
 
 def _interacting_pairs(state, candidates):
-    """Part pairs whose candidate extents can come near each other."""
+    """Part pairs whose candidate extents can come near each other.
+
+    Reach is the union of the PAD extent and the .Fab BODY, because a row
+    only exists for a pair this yields, and `_pair_conflicts` now refuses
+    body containment as well as pad contact. A part whose body is far larger
+    than its pad reach -- a shield can with four corner pads, a connector
+    whose shell overhangs its own pins -- would otherwise never be paired
+    with the small part sitting inside it, and the containment predicate
+    would never be asked.
+    """
     ctx = state.legality_ctx
     reach: Dict[str, Tuple[float, float, float, float]] = {}
     for ref, cands in candidates.items():
@@ -1590,6 +1694,9 @@ def _interacting_pairs(state, candidates):
             e = pp.extent(x, y, state.parts[ref].rot)
             if e is not None:
                 boxes.append(e)
+            fb = state.fab_rect(ref, x, y, state.parts[ref].rot)
+            if fb is not None:
+                boxes.append(fb)
         if boxes:
             reach[ref] = (min(b[0] for b in boxes), min(b[1] for b in boxes),
                           max(b[2] for b in boxes), max(b[3] for b in boxes))

--- a/py_placer/placement/routability.py
+++ b/py_placer/placement/routability.py
@@ -1007,3 +1007,49 @@ def pair_channel_widths(pcb_data, *, clearance: float,
                          'parts_in_channel': sorted(inside)[:12]})
     rows.sort(key=lambda r: r['channel_mm'])
     return rows
+
+
+def relief_move(rect_a, rect_b, need_mm, limit_mm=5.0, tol_mm=1e-6):
+    """How far must B move, per axis direction, for the A-B gap to reach need_mm?
+
+    Answers the question a throat measurement leaves open: "so what do I DO?".
+    Run 20 measured a 0.409 mm gap against a 0.450 mm need and then had to work
+    out by hand that moving R7 east by ~0.042 mm would clear it.
+
+    Bisection on `rect_gap`, which already returns the diagonal corner distance
+    for rects that miss on both axes -- i.e. exactly the geometry being measured.
+    Four axis directions; a direction that cannot reach `need_mm` within
+    `limit_mm` is omitted rather than reported as a large number.
+
+    Every result is stamped `bound: "lower"` and that is not decoration. This is
+    a TWO-BODY answer on a board with hundreds of bodies: moving B by this much
+    clears THIS pair and may create another. It is the smallest move that could
+    possibly work, never a solution.
+    """
+    from placement.legality import rect_gap
+
+    def shifted(d, t):
+        dx, dy = {'east': (t, 0.0), 'west': (-t, 0.0),
+                  'north': (0.0, -t), 'south': (0.0, t)}[d]
+        return (rect_b[0] + dx, rect_b[1] + dy,
+                rect_b[2] + dx, rect_b[3] + dy)
+
+    out = []
+    for d in ('east', 'west', 'north', 'south'):
+        if rect_gap(rect_a, shifted(d, limit_mm)) < need_mm - tol_mm:
+            continue                       # unreachable within the cap: say nothing
+        lo, hi = 0.0, limit_mm
+        if rect_gap(rect_a, rect_b) >= need_mm - tol_mm:
+            out.append({'dir': d, 'min_mm': 0.0, 'bound': 'lower'})
+            continue
+        for _ in range(60):
+            mid = (lo + hi) / 2.0
+            if rect_gap(rect_a, shifted(d, mid)) >= need_mm:
+                hi = mid
+            else:
+                lo = mid
+            if hi - lo < tol_mm:
+                break
+        out.append({'dir': d, 'min_mm': round(hi, 6), 'bound': 'lower'})
+    out.sort(key=lambda r: r['min_mm'])
+    return out

--- a/py_placer/placement/seeder.py
+++ b/py_placer/placement/seeder.py
@@ -42,7 +42,7 @@ import fnmatch
 import math
 import random
 import re
-from typing import Dict, List, Optional, Sequence, Set, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
 
 # Ring-search enumeration: nearest-first out to this radius, then a FINE ring
 # near the target, then a coarse whole-board sweep. The fine pass exists
@@ -67,10 +67,518 @@ def _rect_inside(rect, outer, tol: float) -> bool:
             and rect[2] <= outer[2] + tol and rect[3] <= outer[3] + tol)
 
 
+def _keepout_entry(entry):
+    """(rect, sides, allow) from either a bare rect or a full declaration.
+
+    A bare 4-tuple stays legal because that is what a plan writes in the
+    common case, and requiring the long form everywhere would make the
+    simple keepout the awkward one.
+    """
+    if isinstance(entry, dict):
+        return (tuple(entry['rect']), entry.get('sides') or None,
+                entry.get('allow') or ())
+    if len(entry) == 4 and all(isinstance(v, (int, float)) for v in entry):
+        return tuple(entry), None, ()
+    rect, sides, allow = entry
+    return tuple(rect), (tuple(sides) if sides else None), tuple(allow or ())
+
+
+def pose_ok(state, ref: str, x: float, y: float, rot: float,
+            exclude: Set[str], forbid: Sequence = ()) -> bool:
+    """THE seat predicate: fully contained, and clear of everything not in
+    `exclude`.
+
+    Lifted out of `_try_place` so a POSE COUNTER can use the identical test.
+    `count_legal_poses` below answers "how many seats would lifting X free",
+    and that answer is only worth anything if a positive count implies the
+    seat would really have been taken -- which needs the same predicate, not
+    a second copy of it that drifts.
+
+    Note `candidate_valid` alone is not enough: for a part whose incumbent
+    pose is off the board, its #456 branch accepts poses that move strictly
+    TOWARD the board while still outside it. Placement from scratch has no
+    incumbent worth improving on, so full containment is demanded explicitly.
+    """
+    part = state.parts[ref]
+    r = part.rect(x, y, rot)
+    if state.edge_gate.rect_outside_amount(r) > 1e-9:
+        return False
+    # DECLARED KEEPOUTS. The intent schema has had a `keepouts` rule since
+    # #549 and it is GRADED and honoured by nothing: `keepout` appears in
+    # floorplan.py's rule and in no seeding module, so a reserved strip could
+    # only ever be reported after the fact. Checked here, in the one predicate
+    # every seat goes through, so it cannot be honoured by some ops and not
+    # others. Default empty, so every existing path is byte-identical.
+    #
+    # Each entry is (rect, sides, allow) with the same meaning the intent's
+    # `keepouts` rule gives them: `sides` limits it to one face, and `allow`
+    # names the refs it does NOT apply to -- a mounting-hole keepout exists
+    # so the mounting hole can sit there, and one that excluded MH1 would be
+    # the wrong shape of correct.
+    for entry in forbid:
+        k, sides, allow = _keepout_entry(entry)
+        if allow and any(fnmatch.fnmatch(ref, pat) for pat in allow):
+            continue
+        if sides and getattr(part, 'side', None) not in sides:
+            continue
+        if not (r[2] <= k[0] or k[2] <= r[0] or r[3] <= k[1] or k[3] <= r[1]):
+            return False
+    return state.candidate_valid(ref, x, y, rot, exclude=exclude)
+
+
+# A pose census is a DIAGNOSTIC, not a search: it answers "is there room"
+# and must cost a fraction of the seat attempt that already failed. The cap
+# is what bounds it -- run 19's measured answers were 46 and 32 poses freed,
+# so a cap well above those still distinguishes "none" from "plenty".
+CENSUS_RADIUS_MM = 16.0
+CENSUS_STEP_MM = 1.0
+CENSUS_CAP = 64
+def zone_gate(part, constraint, tol: float):
+    """`(predicate, anchor_zone)` for "is this pose inside the zone".
+
+    ONE definition, shared by the seat search and the pose census. It used to
+    live as a closure inside `_try_place`, which meant the census -- the
+    thing that tells a plan author WHY a part could not be seated -- had no
+    zone concept at all. Measured on splitflap_driver: three parts packed
+    into a 2x2mm zone parked, and the census answered over an unconstrained
+    3mm disc, so one park read `baseline_poses: 64` ("64 legal poses with
+    nothing lifted") about a part the same op had just refused to seat, and
+    two more advised lifting U1 when the zone was the problem.
+
+    The ANCHOR relaxation is the half that must not be dropped when copying.
+    A zone smaller than the courtyard cannot contain it at any rotation --
+    the spec-COORDINATE pattern -- so containment relaxes to
+    anchor-point-in-zone, which makes such zones satisfiable by
+    construction; `floorplan.rule_zone_containment` grades them the same
+    way. A census that mirrors only the strict branch under-counts exactly
+    where the relaxation applies: C1 into a 0.4mm zone at its own pose
+    censuses 0 with the strict rule and 294 with this one, while
+    `_try_place` seats it either way. That is a confident zero, which is the
+    one census answer worse than no census -- so this returns the same pair
+    of branches to both callers rather than letting a second copy drift.
+    """
+    if constraint is None:
+        return (lambda x, y, rot: True), False
+    from placement.floorplan import zone_fits_courtyard
+    anchor = not any(
+        zone_fits_courtyard(constraint, part.rect(0.0, 0.0, r), tol)
+        for r in (part.rot % 360, (part.rot + 90) % 360))
+
+    if anchor:
+        def _in(x, y, rot):
+            return (constraint[0] - tol <= x <= constraint[2] + tol
+                    and constraint[1] - tol <= y <= constraint[3] + tol)
+    else:
+        def _in(x, y, rot):
+            return _rect_inside(part.rect(x, y, rot), constraint, tol)
+    return _in, anchor
+
+
+# A census sweep never exceeds this many locations. It is the ONLY bound on
+# the cost, so it is stated as a count rather than left to fall out of a
+# radius: (2*25+1)^2 = 2601 locations, x4 rotations = ~10k `pose_ok` calls
+# worst case, for the blocked part that has to exhaust the ladder.
+CENSUS_MAX_LOCATIONS = 2601
+
+
+def census_window(within, grid_step=0.1):
+    """The `(radius, step)` a pose census should sample a budget at.
+
+    Lives here, beside `_try_place`, because it encodes what `_try_place`
+    actually searches and must move with it.
+
+    **Take the FINEST lattice whose sweep fits the budget of locations, and
+    never a lattice coarser than `SEARCH_FINE_STEP_MM`.** The rule this
+    replaces was `within / 8`, which lands on no lattice `_try_place` visits
+    (0.1125 at `within=0.9`, 0.1875 at 1.5, 0.4875 at 3.9), so a park could
+    report "lifting X frees 34 poses" and the retry find not one of them.
+
+    The 1.0mm ring is deliberately excluded even though `_try_place` sweeps
+    it. That ring exists to cross 30mm cheaply, not to decide whether a part
+    fits, and a census that renders a verdict on it produces the one output
+    worse than no census: a confident zero. Measured on splitflap_driver
+    with an earlier "coarsest lattice with >= 6 samples" rule -- which chose
+    1.0mm the moment the budget reached 6.0 -- a part that `_try_place`
+    seats at FULL clearance censused `baseline 0, every blocker 0,
+    censused: true` at `within=6.0`, while `within=5.99` counted 44. The
+    cliff was not removed by that rule, only moved from 4.0 to 6.0.
+
+    **The radius is the budget, clamped twice**: to `SEARCH_RADIUS_MM`,
+    beyond which `_try_place` does not look at all once `max_disp` is set
+    (so counting there is counting poses the retry can never visit); and to
+    whatever `CENSUS_MAX_LOCATIONS` affords. `count_legal_poses` applies
+    `max_disp` as a `continue` AFTER `_offsets` materialises the disc, so an
+    unclamped radius is a list-building cost with nothing to show for it --
+    a fixed 16mm built 103,041 offsets to hand back 81 at `within=0.5`, and
+    an unclamped `within=500` built 1,002,001 (~72MB, 28s) before probing a
+    single pose.
+
+    **A TRUNCATED radius is not an error but it is not the whole answer** --
+    `radius < within` means the census looked at the near field only, and
+    the caller must say so rather than report the count bare.
+
+    A census is not comparable ACROSS budgets -- a coarser lattice counts
+    fewer poses over more ground -- which is why the window is reported with
+    the count. What must be commensurate is baseline vs each blocker, and
+    that holds because one census uses one window throughout.
+
+    **THIS COSTS MORE THAN THE RULE IT REPLACES, AND THAT IS THE TRADE.**
+    Measured, ten censused parks on splitflap_driver, before -> after:
+    `within` 0.5 3.19s -> 1.41s (the radius clamp; 2.3x FASTER), 1.4 3.99 ->
+    5.72, 2.0 5.36 -> 10.99 (the worst, 2.05x), 3.0 10.28 -> 11.16, 5.0
+    16.85 -> 22.52. Total 40.9s -> 53.0s, **1.30x**. The extra time buys a
+    lattice the seat search actually visits and the removal of the confident
+    zero; `CENSUS_CAP` still short-circuits the case where poses exist, so
+    the full price is only paid by the genuinely blocked part -- which is
+    the one whose answer matters.
+    """
+    grid = max(0.05, float(grid_step or 0.1))
+    if within is None:
+        return CENSUS_RADIUS_MM, CENSUS_STEP_MM
+    try:
+        budget = float(within)
+    except (TypeError, ValueError):          # noqa: BLE001
+        budget = 0.0
+    # NaN before the clamp: `min(nan, x)` is nan, and `math.ceil(inf)` raises
+    # OverflowError straight out of `op_place_lift`, which has no census
+    # guard. `plan_ops` validates `within > 0` and json.loads accepts
+    # `Infinity`, so both are plan-reachable.
+    if math.isnan(budget) or budget < 0.0:
+        budget = 0.0
+    budget = min(budget, SEARCH_RADIUS_MM)
+
+    # Finest first. `grid` is what `_try_place` reaches inside
+    # SEARCH_XFINE_RADIUS_MM; SEARCH_FINE_STEP_MM is the floor on coarseness.
+    cands = sorted({s for s in (grid, SEARCH_FINE_STEP_MM) if s >= grid - 1e-9})
+    max_rings = max(1, (math.isqrt(CENSUS_MAX_LOCATIONS) - 1) // 2)
+    step = cands[-1]
+    for s in cands:
+        if max(1, int(math.ceil(budget / s - 1e-9))) <= max_rings:
+            step = s
+            break
+    rings = min(max(1, int(math.ceil(budget / step - 1e-9))), max_rings)
+    return round(rings * step, 6), step
+
+
+def _feasible_centre_box(part, constraint, tol, anchor):
+    """Where `part`'s CENTRE may sit for the zone to hold it, over rotations.
+
+    Derived, not approximated. Containment at rotation r is
+    `zone[0]-tol <= x + b_r[0]` and `x + b_r[2] <= zone[2]+tol`, so
+    `x` in `[zone[0]-tol-b_r[0], zone[2]+tol-b_r[2]]`, and the UNION over
+    rotations is `[zone[0]-tol-max_r(b_r[0]), zone[2]+tol-min_r(b_r[2])]`.
+
+    THE COURTYARD IS NOT CENTRED ON THE FOOTPRINT ORIGIN -- `part.rect` is
+    `(x+b[0], y+b[1], x+b[2], y+b[3])` with `b` the raw local bounds, and 17
+    of 65 parts on splitflap_driver and 6 of 89 on tigard have an offset
+    centre (up to 10.15mm on tigard J3). A symmetric half-extent deflation
+    therefore SHIFTS the box: measured, J18/J19/J20 censused 0 while
+    `_try_place` seated them at full clearance. Two earlier forms of this
+    function were wrong here in opposite directions (max half-extent = a
+    subset, min half-extent = a shifted box), which is why this is now the
+    algebra rather than a bound.
+    """
+    x0, y0, x1, y1 = (float(v) for v in constraint)
+    if anchor:
+        # Anchor zones constrain the ANCHOR POINT, so the centre box is the
+        # zone itself; no courtyard term enters.
+        return x0 - tol, y0 - tol, x1 + tol, y1 + tol
+    max_b0x = max_b0y = -float('inf')
+    min_b2x = min_b2y = float('inf')
+    for rot in (part.rot, part.rot + 90.0, part.rot + 180.0, part.rot + 270.0):
+        b = part.rect(0.0, 0.0, rot % 360)
+        max_b0x = max(max_b0x, b[0])
+        max_b0y = max(max_b0y, b[1])
+        min_b2x = min(min_b2x, b[2])
+        min_b2y = min(min_b2y, b[3])
+    return (x0 - tol - max_b0x, y0 - tol - max_b0y,
+            x1 + tol - min_b2x, y1 + tol - min_b2y)
+
+
+def zone_census_offsets(part, constraint, tol, tx, ty, grid_step=0.1,
+                        max_disp=None):
+    """`(step, [(dx, dy), ...], reach_mm)` for a census under a ZONE.
+
+    A disc of `within` is the wrong sample set once a constraint applies:
+    the reachable poses are bounded by the zone, not by the budget, so
+    `census_window` spends its whole location cap on ground the zone
+    excludes and then has to coarsen the step to afford it. Measured on
+    splitflap_driver, R1 packed into a 2x2mm zone: `census_window(3.0, 0.1)`
+    picks step 0.25, and the zone leaves a feasible x-window for R1's centre
+    **0.07mm wide** -- so a census that filters that disc by the zone counts
+    ZERO with the blocker lifted, while `_try_place` reaches the window on
+    its 0.1mm ring and seats. Threading the constraint without this moves
+    the confident zero from the relaxation axis to the lattice axis instead
+    of removing it.
+
+    So: enumerate the feasible-CENTRE box instead, on the lattices
+    `_try_place` sweeps AT EACH DISTANCE. That last clause is the half an
+    earlier version got wrong: it chose one step by location count alone, so
+    a large zone fell to the 1.0mm ring (the verdict `census_window` refuses
+    to render) and a distant zone was sampled at 0.1mm where the search only
+    reaches 0.25mm -- 4 of 8 parks in one ordinary `place_pack` then promised
+    poses the retry could never collect.
+
+    `reach_mm` is how far from the target the sweep actually got. Smaller
+    than the budget means the near field only, and the caller must say so:
+    `_try_place` skips its whole-board fallback whenever `max_disp` is set,
+    so nothing beyond `SEARCH_FINE_RADIUS_MM` is reachable anyway, and the
+    location cap can bite before even that.
+    """
+    grid = max(0.05, float(grid_step or 0.1))
+    _in, anchor = zone_gate(part, constraint, tol)
+    lo_x, lo_y, hi_x, hi_y = _feasible_centre_box(part, constraint, tol,
+                                                 anchor)
+    # Nothing past the fine ring is reachable once `max_disp` is set, so the
+    # box is clipped there BEFORE it is materialised -- that is also the
+    # guard against a hostile zone (a 2000mm rect used to build a 4,004,001
+    # entry list, ten times per park, uncached).
+    reach = SEARCH_FINE_RADIUS_MM if max_disp is None \
+        else min(float(max_disp), SEARCH_FINE_RADIUS_MM)
+    lo_x, hi_x = max(lo_x, tx - reach), min(hi_x, tx + reach)
+    lo_y, hi_y = max(lo_y, ty - reach), min(hi_y, ty + reach)
+    if hi_x < lo_x or hi_y < lo_y:
+        # The zone cannot hold this part at all, or the budget cannot reach
+        # it. ONE offset, so the caller still evaluates the target itself and
+        # the answer is a measured zero rather than an empty sweep that never
+        # ran -- and `reach_mm` 0.0 says the sweep never left the target.
+        return grid, [(0.0, 0.0)], 0.0
+
+    def _lattice(step, rmax):
+        """Target-aligned points of `step` inside the box and within `rmax`."""
+        i0 = int(math.ceil((lo_x - tx) / step - 1e-9))
+        i1 = int(math.floor((hi_x - tx) / step + 1e-9))
+        j0 = int(math.ceil((lo_y - ty) / step - 1e-9))
+        j1 = int(math.floor((hi_y - ty) / step + 1e-9))
+        pts = []
+        for i in range(i0, i1 + 1):
+            dx = i * step
+            if abs(dx) > rmax + 1e-9:
+                continue
+            for j in range(j0, j1 + 1):
+                dy = j * step
+                if dx * dx + dy * dy <= rmax * rmax + 1e-9:
+                    pts.append((round(dx, 6), round(dy, 6)))
+        return pts
+
+    # TWO lattices, exactly as `_try_place` does it: `grid_step` out to
+    # SEARCH_XFINE_RADIUS_MM, then SEARCH_FINE_STEP_MM out to the reach.
+    # The 1.0mm ring is deliberately excluded -- a census must not render a
+    # verdict on it (see `census_window`).
+    seen, out = set(), []
+    for step, rmax in ((grid, min(reach, SEARCH_XFINE_RADIUS_MM)),
+                       (max(grid, SEARCH_FINE_STEP_MM), reach)):
+        for d in _lattice(step, rmax):
+            if d not in seen:
+                seen.add(d)
+                out.append(d)
+    if not out:
+        return grid, [(0.0, 0.0)], 0.0
+    out.sort(key=lambda d: (d[0] * d[0] + d[1] * d[1]))
+    if len(out) > CENSUS_MAX_LOCATIONS:
+        out = out[:CENSUS_MAX_LOCATIONS]
+    reach = math.sqrt(max(d[0] * d[0] + d[1] * d[1] for d in out))
+    step_used = grid if any(
+        abs(d[0]) <= SEARCH_XFINE_RADIUS_MM
+        and abs(d[1]) <= SEARCH_XFINE_RADIUS_MM for d in out) else \
+        max(grid, SEARCH_FINE_STEP_MM)
+    return step_used, out, round(reach, 6)
+
+
+# How many incumbents one stuck part may censused against. Bounded because
+# each candidate costs a census sweep, and because a part is blocked by its
+# NEIGHBOURS -- a part on the far side of the board cannot be in the way, and
+# the geometry below proves it rather than assuming it.
+EVICT_MAX_BLOCKERS = 8
+
+
+def _evict_candidates(state, ref: str, tx: float, ty: float,
+                      placed: Set[str], lock_refs: Sequence[str],
+                      constraint=None, tol: float = 0.5) -> List[str]:
+    """Seated, movable parts that could possibly be in `ref`'s way at (tx,ty).
+
+    A superset, not a heuristic: the box is every pose `ref` can take within
+    the census radius, inflated by its own reach and the clearance, so a part
+    whose own inflated extent misses it cannot be within clearance of ANY
+    candidate pose and would free exactly zero poses by construction. That is
+    `build_neighbor_lists`' pruning argument (quench.py) with the travel
+    budget replaced by the census radius.
+
+    Then nearest-first, capped: the cap is the only approximation, and it is
+    reported by the caller rather than hidden.
+    """
+    part = state.parts.get(ref)
+    if part is None:
+        return []
+    r = part.rect(tx, ty, part.rot)
+    reach = max(r[2] - r[0], r[3] - r[1]) / 2.0 + CENSUS_RADIUS_MM
+    clr = state.clearance
+    locked = set(lock_refs or ())
+    # UNDER A ZONE THE TARGET IS NOT THE CENTRE OF THE QUESTION. `place_pack`
+    # lays its members out on their own stride, so a member's target can sit
+    # wholly outside the zone (measured: 3.3mm out on a 2x2 zone), and both
+    # the box and the nearest-first cap were keyed on it -- so the 8 chosen
+    # need not be the 8 that overlap the zone the part must actually reach.
+    # Box on the union, rank by distance to the region being contested.
+    bx0, by0, bx1, by1 = tx - reach, ty - reach, tx + reach, ty + reach
+    cx, cy = tx, ty
+    if constraint is not None:
+        bx0 = min(bx0, constraint[0] - tol - reach)
+        by0 = min(by0, constraint[1] - tol - reach)
+        bx1 = max(bx1, constraint[2] + tol + reach)
+        by1 = max(by1, constraint[3] + tol + reach)
+        cx = min(max(tx, constraint[0]), constraint[2])
+        cy = min(max(ty, constraint[1]), constraint[3])
+    out: List[Tuple[float, str]] = []
+    for other in sorted(placed):
+        if other == ref or other not in state.parts:
+            continue
+        op = state.parts[other]
+        if op.locked or other in locked:
+            continue          # not this tool's to move -- see reseat_scope
+        orect = op.rect(op.x, op.y, op.rot)
+        if (orect[2] + clr < bx0 or orect[0] - clr > bx1
+                or orect[3] + clr < by0 or orect[1] - clr > by1):
+            continue
+        out.append((math.hypot(op.x - cx, op.y - cy), other))
+    out.sort()
+    return [b for _d, b in out[:EVICT_MAX_BLOCKERS]]
+
+
+def count_legal_poses(state, ref: str, tx: float, ty: float,
+                      exclude: Set[str], *,
+                      radius: float = CENSUS_RADIUS_MM,
+                      step: float = CENSUS_STEP_MM,
+                      cap: int = CENSUS_CAP,
+                      max_disp: Optional[float] = None,
+                      rotations: Optional[Sequence[float]] = None,
+                      forbid: Sequence = (),
+                      constraint=None, tol: float = 0.5) -> int:
+    """How many legal poses `ref` has near (tx, ty), counting at most `cap`.
+
+    This is issue #629's measurement. Three consecutive sweeps in run 19
+    returned a bare "no legal pose anywhere on the board" for SW17/SW34, and
+    when the same question was finally asked in scoped form the engine
+    answered precisely: with D14 in place 0 poses, with D14 lifted 46; with
+    D31, 0 then 32. A verdict that names its blockers is the next move; a
+    bare verdict is a dead end.
+
+    Counts only -- no `apply_move`, no cost evaluation. It uses `pose_ok`,
+    the same predicate `_try_place` seats on, at the state's own clearance
+    (NOT the relaxed ladder): a count is meant to say whether there is room,
+    and counting poses that only exist at a 0.02mm floor would promise seats
+    the ordinary search does not take. Measured cost of that divergence on
+    splitflap_driver: 4 of 65 movable parts census 0 while `_try_place`
+    seats them on a relaxed rung, 6 of 65 with a zone. Reported, not fixed --
+    see the paragraph above.
+
+    **With a `constraint`, the zone is honoured and the SAMPLE SET comes
+    from the zone too** (`zone_census_offsets`). Both halves are needed: the
+    predicate alone leaves the census answering over a disc the zone
+    excludes, and the disc alone leaves it counting poses that are outside
+    the zone the seat had to satisfy. `radius`/`step` are ignored when a
+    constraint is given -- the zone supersedes them.
+    """
+    from pose_score import _offsets
+    part = state.parts[ref]
+    rots = list(rotations) if rotations is not None \
+        else [part.rot] + [(part.rot + d) % 360 for d in (90.0, 180.0, 270.0)]
+    in_zone, _anchor = zone_gate(part, constraint, tol)
+    if constraint is None:
+        offsets = _offsets(radius, step)
+    else:
+        _step, offsets, _reach = zone_census_offsets(
+            part, constraint, tol, tx, ty,
+            getattr(state, 'grid_step', 0.1), max_disp)
+    n = 0
+    for dx, dy in offsets:
+        if max_disp is not None and math.hypot(dx, dy) > max_disp + 1e-9:
+            continue
+        x, y = round(tx + dx, 3), round(ty + dy, 3)
+        for rot in rots:
+            # Zone first: it is four float compares, where `pose_ok` ends in
+            # `candidate_valid`. Measured 19x faster on a small zone.
+            if not in_zone(x, y, rot):
+                continue
+            if pose_ok(state, ref, x, y, rot, exclude, forbid):
+                n += 1
+                if n >= cap:
+                    return n
+    return n
+
+
+def near_miss_poses(state, ref: str, tx: float, ty: float,
+                    exclude: Set[str], *,
+                    radius: float = CENSUS_RADIUS_MM,
+                    step: float = CENSUS_STEP_MM,
+                    max_disp: Optional[float] = None,
+                    rotations: Optional[Sequence[float]] = None,
+                    forbid: Sequence = (), k: int = 3) -> List[Dict]:
+    """The K nearest-to-legal poses, for a census that just counted ZERO.
+
+    run-23: `count_legal_poses` == 0 was a dead end three times (J5 "0 legal
+    poses in a 20mm disc", U6, J1), and each dead end was resolved by an
+    UNCHECKED place_fixed assert that shipped an overlap. The information
+    that would have resolved it honestly -- "the best pose in budget overlaps
+    only SW1, by 0.8mm2; move SW1 and the seat exists" -- was never computed.
+
+    Report-only: never applies a move. One entry per DISTINCT blocker set
+    (three poses all blocked by the same part teach nothing extra), ranked by
+    residual overlap area, side-aware, off-outline poses skipped (an
+    off-board pose is a different problem, not a near-miss). Same lattice
+    family as count_legal_poses; runs only on its zero path, which is
+    already the slow case.
+    """
+    part = state.parts[ref]
+    from pose_score import _offsets
+    rots = list(rotations) if rotations is not None \
+        else [part.rot] + [(part.rot + d) % 360 for d in (90.0, 180.0, 270.0)]
+    obstacles = []
+    for other, p2 in state.parts.items():
+        if other == ref or other in exclude:
+            continue
+        if not (part.sides & p2.sides):
+            continue
+        obstacles.append((other, p2.rect(p2.x, p2.y, p2.rot)))
+    best = []
+    for dx, dy in _offsets(radius, step):
+        if max_disp is not None and math.hypot(dx, dy) > max_disp + 1e-9:
+            continue
+        x, y = round(tx + dx, 3), round(ty + dy, 3)
+        for rot in rots:
+            r = part.rect(x, y, rot)
+            if state.edge_gate.rect_outside_amount(r) > 1e-9:
+                continue
+            ov = 0.0
+            hits = set()
+            for other, r2 in obstacles:
+                w = min(r[2], r2[2]) - max(r[0], r2[0])
+                h = min(r[3], r2[3]) - max(r[1], r2[1])
+                if w > 0 and h > 0:
+                    ov += w * h
+                    hits.add(other)
+            if ov <= 1e-9:
+                continue      # legal: count_legal_poses' business, not ours
+            best.append((ov, x, y, rot, tuple(sorted(hits))))
+    best.sort(key=lambda t: (t[0], t[1], t[2]))
+    seen = set()
+    out: List[Dict] = []
+    for ov, x, y, rot, hits in best:
+        if hits in seen:
+            continue
+        seen.add(hits)
+        out.append({'pose': [x, y, rot], 'overlap_mm2': round(ov, 3),
+                    'hits': list(hits)})
+        if len(out) >= k:
+            break
+    return out
+
+
 def _try_place(state, ref: str, tx: float, ty: float, exclude: Set[str],
                constraint=None, tol: float = 0.5,
                max_disp: Optional[float] = None,
-               info: Optional[Dict] = None) -> Optional[float]:
+               info: Optional[Dict] = None,
+               deadline=None, forbid: Sequence = ()) -> Optional[float]:
     """Nearest FULLY-CONTAINED legal pose to (tx, ty); applies the move and
     returns True.
 
@@ -108,30 +616,11 @@ def _try_place(state, ref: str, tx: float, ty: float, exclude: Set[str],
     part = state.parts[ref]
 
     def _ok(x, y, rot):
-        if state.edge_gate.rect_outside_amount(part.rect(x, y, rot)) > 1e-9:
-            return False
-        return state.candidate_valid(ref, x, y, rot, exclude=exclude)
+        return pose_ok(state, ref, x, y, rot, exclude, forbid)
 
-    # A zone smaller than the courtyard cannot contain it at any rotation --
-    # the spec-COORDINATE pattern. Containment then relaxes to anchor-point-
-    # in-zone, which makes such zones satisfiable by construction; the grader
-    # (floorplan.rule_zone_containment) applies the same relaxation.
-    anchor_zone = False
-    if constraint is not None:
-        from placement.floorplan import zone_fits_courtyard
-        anchor_zone = not any(
-            zone_fits_courtyard(constraint, part.rect(0.0, 0.0, r), tol)
-            for r in (part.rot % 360, (part.rot + 90) % 360))
-        if anchor_zone and info is not None:
-            info['anchor_zone'] = True
-
-    def _in_zone(x, y, rot):
-        if constraint is None:
-            return True
-        if anchor_zone:
-            return (constraint[0] - tol <= x <= constraint[2] + tol
-                    and constraint[1] - tol <= y <= constraint[3] + tol)
-        return _rect_inside(part.rect(x, y, rot), constraint, tol)
+    _in_zone, anchor_zone = zone_gate(part, constraint, tol)
+    if anchor_zone and info is not None:
+        info['anchor_zone'] = True
 
     full = state.clearance
     try:
@@ -158,6 +647,15 @@ def _try_place(state, ref: str, tx: float, ty: float, exclude: Set[str],
                     # the `for dx, dy in _offsets(...)` loop below: that is the
                     # innermost loop and _offsets already materialises ~3700
                     # tuples per call, so the band check bounds it adequately.
+                    # Returns None rather than raising, so the caller's existing
+                    # "no legal pose" path handles it with no new control flow --
+                    # but `info` records WHY, because reporting an unfinished
+                    # search as a measured failure is the same silent lie this
+                    # whole change exists to remove.
+                    if deadline is not None and deadline.expired():
+                        if info is not None:
+                            info['deadline'] = True
+                        return None
                     for dx, dy in _offsets(radius, step):
                         if (max_disp is not None
                                 and math.hypot(dx, dy) > max_disp + 1e-9):
@@ -211,18 +709,30 @@ def _edge_pose(part, bounds, edge: str, frac: float, overhang: float
 
 
 def _edge_correct(state, ref: str, edge: str, x: float, y: float,
-                  target: float) -> Tuple[float, float]:
+                  target: float) -> Tuple[float, float, bool]:
     """Walk the pose along the edge normal until the MEASURED overhang hits
     `target`. The analytic pose measures against the bounding box, but the
     grade's rule_edge_connector measures rect_outside_amount against the real
     Edge.Cuts rings -- on a non-rectangular outline the two differ by the
     local inset, and a seed placed by the bbox grades over its declared band
-    (measured on splitflap: 4 connectors 0.1-0.2mm past their max)."""
+    (measured on splitflap: 4 connectors 0.1-0.2mm past their max).
+
+    Returns (x, y, converged). **The third element is not decoration.** This
+    walk moves along ONE axis while `rect_outside_amount` is a SUM over all
+    four sides (`legality.py:438-448`), so any along-edge overshoot is a
+    constant term the walk cannot cancel -- it subtracts it again every
+    iteration and marches the part inland past the far edge. Measured on a
+    41.16mm connector on a 50.8mm edge: frac 0.70 -> y 88.767 (off the
+    opposite side), frac 0.90 -> y -2.443. It used to return that pose
+    indistinguishably from a converged one, and the caller seated it.
+    """
     part = state.parts[ref]
+    converged = False
     for _ in range(4):
         amt = state.edge_gate.rect_outside_amount(part.rect(x, y, part.rot))
         err = target - amt
         if abs(err) < 0.02:
+            converged = True
             break
         if edge == 'north':
             y -= err
@@ -232,11 +742,81 @@ def _edge_correct(state, ref: str, edge: str, x: float, y: float,
             x -= err
         else:
             x += err
-    return x, y
+    else:
+        # Ran out of iterations. One last measurement decides it -- a walk
+        # that happened to land on its target on the final step is converged.
+        amt = state.edge_gate.rect_outside_amount(part.rect(x, y, part.rot))
+        converged = abs(target - amt) < 0.02
+    return x, y, converged
+
+
+def edge_seat_ok(state, part, x: float, y: float, edge: str,
+                 lo: float, hi: float) -> bool:
+    """Is this edge pose a seat, or is the part off the board?
+
+    An edge seat is the one seat in the system that cannot use `pose_ok` --
+    it overhangs by design, so full containment is the wrong predicate. This
+    is the predicate it uses instead, and it has TWO parts because either
+    alone was measured to accept an off-board part:
+
+    * the measured overhang lies in the DECLARED band. Same quantity
+      `floorplan.rule_edge_connector` grades on, so a seat accepted here is
+      not a violation there.
+    * EVERY PAD lands on the board. That is the invariant that actually
+      matters -- CLAUDE.md calls pad copper outside the outline the
+      top-priority placement defect, because it converts 1:1 into unrouted
+      nets -- and it is the one a band cannot argue with. A band is an
+      author's declaration and a wrong one is not rare: `{min: 3, max: 4}` on
+      a 3.0mm-deep connector seated it with 1.7% of its courtyard on the
+      board, and `{min: 20, max: 21}` was accepted on the east and west edges
+      with 8 of 16 pads off.
+
+    The pad test uses the gate's own containment, so a board with cutouts or
+    milled rings is measured properly. A bounding-box test is not enough and
+    was measured dropping 24 of 26 pads into a milled slot while reporting a
+    seat: the pads were inside the bbox and inside a hole.
+
+    An edge connector's BODY overhangs by design; its PADS do not. That
+    asymmetry is what makes this checkable at all.
+    """
+    r = part.rect(x, y, part.rot)
+    amt = state.edge_gate.rect_outside_amount(r)
+    if not ((lo - 0.02) <= amt <= (hi + 0.02)):
+        return False
+    gate = state.edge_gate
+    for px, py, _sz in part.pad_globals(x, y, part.rot):
+        # A zero-size rect at the pad centre: "is this point on the board",
+        # asked through the gate so cutouts and milled rings count.
+        if gate.rect_outside_amount((px, py, px, py)) > 1e-9:
+            return False
+    return True
+
+
+def _edge_frac_bounds(part, bounds, edge: str) -> Tuple[float, float]:
+    """The fractions along `edge` at which the part is still ON the board.
+
+    `_edge_pose` places the part's CENTRE at `frac` along the edge's own span,
+    and the old clamp was a bare [0.05, 0.95] that knew nothing of the part's
+    width -- so a 41.16mm connector on a 50.80mm edge was slid to frac 0.70
+    and hung 5.34mm past the end while reporting a seat. Only
+    **[0.405, 0.595]** keeps that part on the board: the centre may range over
+    span - width = 9.64mm, i.e. (width/2)/span = 0.405 in from each end.
+
+    Returns (lo, hi); lo > hi means the part is wider than the edge, which is
+    a real answer and the caller must treat it as "no legal fraction".
+    """
+    lx0, ly0, lx1, ly1 = part.rect(0.0, 0.0, part.rot)
+    x0, y0, x1, y1 = bounds
+    if edge in ('north', 'south'):
+        span, a, b = (x1 - x0), lx0, lx1
+    else:
+        span, a, b = (y1 - y0), ly0, ly1
+    span = max(1e-9, span)
+    return (-a) / span, 1.0 - (b / span)
 
 
 def _seat_edge(state, ref: str, entry: Dict, must_lock: Set[str],
-               notes: List[str], target=None) -> bool:
+               notes: List[str], target=None, exclude=None) -> bool:
     """Seat a DECLARED edge part on its edge band, minimal-move (run-4 B-6).
 
     Repair could never do this: `_try_place._ok` demands full containment,
@@ -262,26 +842,52 @@ def _seat_edge(state, ref: str, entry: Dict, must_lock: Set[str],
         cur = (ax - x0) / max(1e-9, (x1 - x0))
     else:
         cur = (ay - y0) / max(1e-9, (y1 - y0))
-    cur = min(0.95, max(0.05, cur))
+
+    # Clamp by the part's OWN half-extent, not a bare [0.05, 0.95]. A part
+    # wider than its edge has no legal fraction at all; say so rather than
+    # sliding it off the end and reporting a seat.
+    f_lo, f_hi = _edge_frac_bounds(part, state.board, edge)
+    if f_lo > f_hi:
+        notes.append(f"{ref}: is wider than the {edge} edge "
+                     f"({f_lo:.2f} > {f_hi:.2f} of its span), so no along-edge "
+                     f"position keeps it on the board")
+        return False
+    cur = min(f_hi, max(f_lo, cur))
+
+    # The declared band. `hi` None means "no stated maximum" -- allow twice the
+    # midpoint target, which is what `overhang` was derived from, rather than
+    # allowing anything.
+    hi_eff = float(hi) if hi is not None else max(2.0 * overhang, lo + 1.0)
 
     ctx = state.legality_ctx
+    ex = set(exclude or ())
 
     def conflict_free(px, py):
         if ctx is None:
             return True
         for other in ctx.parts:
-            if other == ref or other not in state.parts:
+            # `ex` is the pile: parts whose input coordinates are meaningless.
+            # Without it a pile at the board centre vetoes the honest edge
+            # poses and the loop SLIDES the part along the edge until one is
+            # "free" -- measured, that is how a connector reached frac 0.70
+            # and hung off the end.
+            if other == ref or other in ex or other not in state.parts:
                 continue
             sf = ctx.pair_shortfall(ref, other, pose_a=(px, py, part.rot))
             if sf.pad > 1e-6 or sf.hole > 1e-6:
                 return False
         return True
 
+    def on_board(px, py):
+        return edge_seat_ok(state, part, px, py, edge, lo, hi_eff)
+
     for df in (0.0, 0.05, -0.05, 0.1, -0.1, 0.15, -0.15,
                0.2, -0.2, 0.3, -0.3, 0.4, -0.4):
-        frac = min(0.95, max(0.05, cur + df))
+        frac = min(f_hi, max(f_lo, cur + df))
         x, y = _edge_pose(part, state.board, edge, frac, overhang)
-        x, y = _edge_correct(state, ref, edge, x, y, overhang)
+        x, y, converged = _edge_correct(state, ref, edge, x, y, overhang)
+        if not converged or not on_board(x, y):
+            continue
         if conflict_free(x, y):
             state.apply_move(ref, round(x, 3), round(y, 3), part.rot)
             return True
@@ -332,7 +938,9 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
                      grid_step: float = 0.1,
                      seed_refs: Optional[Set[str]] = None,
                      anchors_first: bool = False,
-                     anchor_rounds: int = 1) -> Dict:
+                     anchor_rounds: int = 1,
+                     evict_depth: int = 1,
+                     deadline=None, progress=None) -> Dict:
     """Compute a full placement for an unplaced board from its intent.
 
     Returns {'placements': [...], 'lock_refs': [...], 'unseated': [...],
@@ -346,6 +954,13 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
     re-deriving the placed parts would discard someone's work, and the
     LIFT-AND-RE-SEAT case -- see `reseat_scope`).
 
+    `deadline` is an optional `krt_deadline.Deadline`, checked between parts in
+    the connectivity-centroid stage (the only unbounded one -- stages 1/1.5/2
+    are O(declared entries)). The partial is coherent by construction: a part
+    is either fully seated, and in `placements`, or untouched. Untouched parts
+    are named in `deadline_skipped` and are NOT `unseated` -- a search that ran
+    out of clock has measured nothing. `progress` is an optional
+    `(current, total, label)` callback.
     """
     import pose_score
     from placement import floorplan
@@ -369,6 +984,18 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
     placed: Set[str] = set()
     unplaced: Set[str] = {r for r, p in state.parts.items()}
     unseated: List[str] = []
+    # Parts a budget ran out before REACHING. Never `unseated`: a search that
+    # never ran has measured nothing, and reporting it as a failure is a
+    # verdict nobody earned. Declared here because the zone stage can fill it
+    # too, long before stage 3.
+    deadline_skipped: List[str] = []
+    # ref -> (target_x, target_y, constraint_rect, tol) for the seat that
+    # failed. The eviction rung (3c) retries at exactly the target the part
+    # was refused at; a rung that re-derived one would be answering a
+    # different question from the one that failed.
+    unseated_ctx: Dict[str, Tuple[float, float, Any, float]] = {}
+    evictions: List[Dict] = []
+    no_pose_blockers: Dict[str, Dict[str, int]] = {}
     # A part locked IN THE FILE is already authoritatively placed -- a caller
     # that pre-placed its spec-fixed parts and stamped them (locked yes) must
     # not have the seeder re-derive them. Treated as placed from the start:
@@ -418,9 +1045,41 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
             lo = float(band.get('min', 0.0))
             hi = band.get('max')
             overhang = (lo + float(hi)) / 2.0 if hi is not None else max(lo, 0.5)
+            # Even distribution, but clamped by the part's own half-extent:
+            # 3 connectors on one edge get fracs 0.25/0.5/0.75, and a wide
+            # part at 0.25 hangs off the end. This stage runs no legality
+            # gate at all (by design), so nothing downstream would catch it.
+            f_lo, f_hi = _edge_frac_bounds(part, bounds, edge)
             frac = (k + 1) / (len(specs) + 1)
+            if f_lo > f_hi:
+                notes.append(f"edge connector {ref}: wider than the {edge} "
+                             f"edge, so stage 1 leaves it to the later stages")
+                continue
+            frac = min(f_hi, max(f_lo, frac))
             x, y = _edge_pose(part, bounds, edge, frac, overhang)
-            x, y = _edge_correct(state, ref, edge, x, y, overhang)
+            x, y, converged = _edge_correct(state, ref, edge, x, y, overhang)
+            if not converged:
+                # The walk diverged (it drives a scalar SUM along one axis, so
+                # an along-edge overshoot never cancels). It used to
+                # apply_move unconditionally, which is how a diverged stage-1
+                # seat reached the board silently.
+                notes.append(f"edge connector {ref}: the overhang walk did "
+                             f"not converge on the {edge} edge, so stage 1 "
+                             f"left it for the later stages")
+                continue
+            # The SAME containment predicate _seat_edge uses. Stage 1 got the
+            # fraction clamp and the convergence skip but not this, and was
+            # measured still seating a connector at (159.909, 132.830) with
+            # 16 of 16 pads 18.45mm off a board ending at 114.38 -- the exact
+            # pose the fix elsewhere refuses. Stage 1 runs no legality gate at
+            # all by design, so nothing downstream catches it.
+            hi_eff = float(hi) if hi is not None else max(2.0 * overhang,
+                                                          lo + 1.0)
+            if not edge_seat_ok(state, part, x, y, edge, lo, hi_eff):
+                notes.append(f"edge connector {ref}: the {edge} band would "
+                             f"put it off the board, so stage 1 left it for "
+                             f"the later stages")
+                continue
             state.apply_move(ref, round(x, 3), round(y, 3), part.rot)
             placed.add(ref)
             unplaced.discard(ref)
@@ -445,12 +1104,14 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
         tol = intent.zone_tolerance(z) if z is not None else 0.5
         info: Dict = {}
         clr = _try_place(state, ref, part.x, part.y, unplaced - {ref},
-                         constraint=rect, tol=tol, info=info)
+                         constraint=rect, tol=tol, info=info,
+                         deadline=deadline)
         if clr is None and z is not None:
             zx = (z.rect[0] + z.rect[2]) / 2.0
             zy = (z.rect[1] + z.rect[3]) / 2.0
             clr = _try_place(state, ref, zx, zy, unplaced - {ref},
-                             constraint=rect, tol=tol, info=info)
+                             constraint=rect, tol=tol, info=info,
+                             deadline=deadline)
         if clr is not None:
             placed.add(ref)
             unplaced.discard(ref)
@@ -510,11 +1171,30 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
         cy = (z.rect[1] + z.rect[3]) / 2.0
         tol = intent.zone_tolerance(z)
         for ref in members:
+            # The zone stage was UNBOUNDED. `seed_from_intent`'s contract says
+            # the deadline is checked "between parts in the connectivity-
+            # centroid stage (the only unbounded one -- stages 1/1.5/2 are
+            # O(declared entries))", and the entry COUNT is indeed bounded --
+            # but each entry pays a full `_try_place` ladder, so on a board
+            # whose intent zones every part (run 19's urchin: 85 refs in two
+            # half-blocks) the whole run is stage 2 and the clock never got a
+            # chance to fire. Measured: a 30s budget ran past 200s.
+            if deadline is not None and deadline.expired():
+                for r in members[members.index(ref):]:
+                    if r in unplaced and r not in deadline_skipped:
+                        deadline_skipped.append(r)
+                notes.append(
+                    f"deadline reached in zone {name!r}; "
+                    f"{len(deadline_skipped)} part(s) left at their input "
+                    f"poses and reported in deadline_skipped (NOT unseated -- "
+                    f"they were never tried)")
+                break
             jx, jy = (0.0, 0.0) if len(members) == 1 else _jitter()
             rot_before = state.parts[ref].rot
             zinfo: Dict = {}
             clr = _try_place(state, ref, cx + jx, cy + jy, unplaced - {ref},
-                             constraint=z.rect, tol=tol, info=zinfo)
+                             constraint=z.rect, tol=tol, info=zinfo,
+                             deadline=deadline)
             if clr is not None:
                 placed.add(ref)
                 unplaced.discard(ref)
@@ -531,6 +1211,7 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
                                  f"{state.clearance:g})")
             else:
                 unseated.append(ref)
+                unseated_ctx[ref] = (cx + jx, cy + jy, z.rect, tol)
                 notes.append(f"{ref}: no legal pose inside zone {name!r}")
 
     # ---- 2.5 decap-governed caps: one cap per supply PIN -------------------
@@ -664,7 +1345,21 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
                      f"{thr:.2f}mm) seed before {len(unplaced) - len(anchors)}"
                      f" small(s): {', '.join(anchors)}")
         queue = anchors + [r for r in queue if r not in set(anchors)]
-    for ref in queue:
+    for _qi, ref in enumerate(queue):
+        if deadline is not None and deadline.check('seed'):
+            deadline_skipped.extend(r for r in queue[_qi:]
+                                    if r not in deadline_skipped)
+            notes.append(
+                f"deadline reached after {_qi}/{len(queue)} part(s); "
+                f"{len(deadline_skipped)} left at their input poses and "
+                f"reported in deadline_skipped (NOT unseated -- they were "
+                f"never tried)")
+            break
+        if progress is not None:
+            try:
+                progress(_qi, len(queue), f'seat {ref}')
+            except Exception:                                   # noqa: BLE001
+                pass
         target = _partner_centroid(state, ref, placed) or center
         jx, jy = _jitter()
         rot_before = state.parts[ref].rot
@@ -682,7 +1377,146 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
                              f"{clr:g} (none at {state.clearance:g})")
         else:
             unseated.append(ref)
+            unseated_ctx[ref] = (target[0] + jx, target[1] + jy, None, 0.5)
             notes.append(f"{ref}: no legal pose anywhere on the board")
+
+    # ---- 3c. eviction rung (#630): census the blockers, evict, retry --------
+    # A part with no legal pose is not necessarily a part with no ROOM. Run 19
+    # measured the difference: three sweeps returned a bare "no legal pose
+    # anywhere on the board" for SW17/SW34, and when the question was finally
+    # asked in scoped form the engine answered precisely -- with D14 in place
+    # 0 poses, with D14 lifted 46; with D31, 0 then 32. One eviction each and
+    # both seated. That verdict was reachable the whole time; nothing asked.
+    #
+    # So: for each part this seed could not seat, count its poses with each
+    # nearby incumbent lifted in turn, evict the one that frees the most, and
+    # retry. THE ORDERING IS LOAD-BEARING -- the blocked part is seated FIRST,
+    # against a board the blocker is lifted out of, and the blocker is
+    # re-seated afterwards with it as an obstacle. Run 19's one-call reseat
+    # got a null three times precisely because its queue re-seated the
+    # blockers first, back into the pockets they block.
+    #
+    # Bounded on every axis: depth 1 (a blocker's own blocker is not chased),
+    # at most EVICT_MAX_BLOCKERS candidates per part, and the census counts to
+    # a cap. Gated exactly like the anchor rounds -- `measure` before and
+    # after, with a snapshot revert -- so a trade that does not improve the
+    # board leaves it byte-identical.
+    # The CENSUS runs whenever anything is unseated; only the EVICTION is
+    # gated on depth. #629 asks for a verdict that names its blockers, and
+    # that is worth having on its own -- `--evict-depth 0` means "tell me
+    # what is in the way, move nothing", which is the honest default for
+    # anyone who wants to make the call themselves.
+    if unseated:
+        from placement.reconstruct import measure
+        still: List[str] = []
+        # DEDUPED, and placed-aware. A zone member that fails its zone stage
+        # stays in `unplaced`, so stage 3 tries it again and appends it a
+        # SECOND time -- `unseated` can name one part twice. Iterating that
+        # raw ran the rung again on a part the first pass had just seated,
+        # where the trade is now a pure loss, and the revert put it back in
+        # `unseated`: a success undone by a duplicate.
+        seen: Set[str] = set()
+        for ref in list(unseated):
+            if ref in seen:
+                continue
+            seen.add(ref)
+            if ref in placed:
+                continue          # an earlier pass of this rung seated it
+            if ref not in unseated_ctx or ref not in state.parts:
+                still.append(ref)
+                continue
+            # Checked between PARTS, like the stage-3 queue: one census is
+            # `1 + candidates` bounded sweeps, so the grain is fine enough,
+            # and a rung that overran its budget would be adding unbounded
+            # work to the one path that had none.
+            if deadline is not None and deadline.expired():
+                still.extend(r for r in list(unseated)
+                             if r not in seen and r not in placed)
+                notes.append(
+                    f"eviction rung: deadline reached; {len(still)} part(s) "
+                    f"left uncensused (their bare verdict stands)")
+                break
+            tx, ty, constraint, tol = unseated_ctx[ref]
+            base_excl = unplaced - {ref}
+            # The constraint has been unpacked here since this rung was
+            # written and was then dropped on the next two lines, so a part
+            # that failed to seat INSIDE A ZONE was censused over the open
+            # board. The retry below already passes it (`constraint=
+            # constraint` at the `_try_place` call), so the measurement and
+            # the retry were answering different questions -- and this one
+            # reaches `place_seed`'s JSON_SUMMARY, which the placement skill
+            # tells an agent to read.
+            zkw = dict(constraint=constraint, tol=tol)
+            baseline = count_legal_poses(state, ref, tx, ty, base_excl, **zkw)
+            cands = _evict_candidates(state, ref, tx, ty, placed, lock_refs,
+                                      constraint=constraint, tol=tol)
+            freed = {b: count_legal_poses(state, ref, tx, ty,
+                                          base_excl | {b}, **zkw)
+                     for b in cands}
+            no_pose_blockers[ref] = dict(freed)
+            useful = sorted((n, b) for b, n in freed.items() if n > baseline)
+            if not evict_depth:
+                still.append(ref)
+                if useful:
+                    notes.append(
+                        f"{ref}: no legal pose, and lifting {useful[-1][1]} "
+                        f"would free {useful[-1][0]} -- not evicted "
+                        f"(--evict-depth 0)")
+                continue
+            if not useful:
+                still.append(ref)
+                if cands:
+                    notes.append(
+                        f"{ref}: censused {len(cands)} neighbour(s); lifting "
+                        f"none of them frees a pose, so they are not what is "
+                        f"in the way")
+                continue
+            best = useful[-1][1]
+            snapshot = {r: (state.parts[r].x, state.parts[r].y,
+                            state.parts[r].rot) for r in (ref, best)}
+            before = measure(state)
+            # Lift, seat the blocked part, then put the blocker back with it
+            # in place.
+            unplaced.add(best)
+            placed.discard(best)
+            ok = _try_place(state, ref, tx, ty, (unplaced - {ref}) | {best},
+                            constraint=constraint, tol=tol) is not None
+            bx, by, brot = snapshot[best]
+            ok = ok and _try_place(state, best, bx, by,
+                                   unplaced - {best}) is not None
+            after = measure(state) if ok else None
+            if ok and after <= before:
+                placed.add(ref)
+                placed.add(best)
+                unplaced.discard(ref)
+                unplaced.discard(best)
+                evictions.append({
+                    'ref': ref, 'blocker': best, 'poses_freed': freed[best],
+                    'poses_before': baseline, 'depth': 1, 'accepted': True,
+                    'gate_before': list(before), 'gate_after': list(after)})
+                notes.append(
+                    f"{ref}: seated after evicting {best} (poses at its "
+                    f"target: {baseline} before, {freed[best]} with {best} "
+                    f"lifted); gate {list(before)} -> {list(after)}")
+            else:
+                for r, pose in snapshot.items():
+                    state.apply_move(r, *pose)
+                placed.add(best)
+                unplaced.discard(best)
+                still.append(ref)
+                evictions.append({
+                    'ref': ref, 'blocker': best, 'poses_freed': freed[best],
+                    'poses_before': baseline, 'depth': 1, 'accepted': False,
+                    'gate_before': list(before),
+                    'gate_after': None if after is None else list(after),
+                    'reason': ('the blocker had nowhere to go' if not ok
+                               else 'the trade did not improve the board')})
+                notes.append(
+                    f"{ref}: evicting {best} REVERTED -- "
+                    + ('it had no legal pose to return to'
+                       if not ok else
+                       f"gate worsened {list(before)} -> {list(after)}"))
+        unseated = still
 
     # ---- 3b. anchor rounds (run-4 C): gated re-seat passes ------------------
     # Round 1 seeded anchors against anchors only; now that the smalls
@@ -731,8 +1565,19 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
                    'new_x': state.parts[ref].x, 'new_y': state.parts[ref].y,
                    'new_rotation': state.parts[ref].rot}
                   for ref in sorted(placed)]
+    # Deduped: a zone member that also fails stage 3 is appended twice, and
+    # `unseated: 2` for one part is a miscount every consumer inherits --
+    # place_seed's summary, its exit code, and any gate reading the number.
     return {'placements': placements, 'lock_refs': lock_refs,
-            'unseated': sorted(unseated), 'notes': notes}
+            'unseated': sorted(set(unseated)), 'notes': notes,
+            # #629: a no-pose verdict that NAMES its blockers, with the count
+            # each one frees. An empty dict for a ref means the census ran and
+            # found no movable neighbour; a ref absent from the dict was never
+            # censused (the rung was off, or it had no recorded target).
+            'no_pose_blockers': no_pose_blockers,
+            'evictions': evictions,
+            'deadline_skipped': deadline_skipped,
+            'complete': not deadline_skipped}
 
 
 def stamp_locked(board_file: str, refs: Sequence[str]) -> int:
@@ -770,6 +1615,13 @@ def stamp_locked(board_file: str, refs: Sequence[str]) -> int:
     return count
 
 
+#: What a containment charges. Flat, not area-scaled: a 0402 wholly
+#: inside a TSSOP measures 0.5mm2 and an area charge would floor it to
+#: the 1.0mm budget, while a large part half-swallowed would outrank
+#: it. Containment is a yes/no fact about whether a part can be built.
+#: 2.0 buys the full cap ladder (budget = max(1.0, 8.0 * charge)).
+CONTAINMENT_CHARGE_MM = 2.0
+
 REPAIR_CAPS_MM = (0.5, 1.0, 2.0, 5.0)
 # A repair move must be PROPORTIONATE to the violation it clears. The cap
 # ladder escalates 0.5 -> 5.0mm hunting any legal seat, and on a board damaged
@@ -788,7 +1640,8 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
                      clearance: float = 0.25,
                      board_edge_clearance: float = 0.55,
                      grid_step: float = 0.1,
-                     caps: Sequence[float] = REPAIR_CAPS_MM) -> Dict:
+                     caps: Sequence[float] = REPAIR_CAPS_MM,
+                     deadline=None, progress=None) -> Dict:
     """Violation-driven minimal-move repair of a PLACED board (#place_seed
     --repair). Everything clean freezes; only violators move, worst first,
     each seated by the seeder's own search targeted at its CURRENT pose with
@@ -805,9 +1658,17 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
     re-stamping is needed). A file-locked ref OUTSIDE must_lock is not this
     tool's to move: reported in `unrepairable`.
 
-    NOTE this sweep has no internal bound -- its cost is violators x caps x 36
-    ring sweeps x O(parts) per candidate, and on a 217-part board it ran 46
-    minutes (run 9). Scope it with the violator set, not with a clock.
+    `deadline` is an optional `krt_deadline.Deadline`. This sweep has no
+    internal bound -- its cost is violators x caps x 36 ring sweeps x O(parts)
+    per candidate -- and on a 217-part board it ran 46 minutes without
+    terminating (run 9). When a budget is supplied the loop stops between
+    violators, keeps every seat it already made, and reports the untouched ones
+    in `deadline_skipped`. Those are NOT `unrepairable`: a search that ran out
+    of clock has measured nothing, and filing it as a failure is the same class
+    of lie as the silent hang.
+
+    `progress` is an optional `(current, total, label)` callback -- the sweep is
+    otherwise completely silent between its census line and its final line.
     """
     import pose_score
     from placement import floorplan, legality as _leg
@@ -939,6 +1800,50 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
         for partner in ordered[1:]:
             partner_of.setdefault(ordered[0], []).append(partner)
 
+    # CONTAINMENT census (run-22). The body census above reads
+    # `blocking_pairs`, which is pad_intersection ONLY -- so a part sitting
+    # WHOLLY INSIDE another part's .Fab body produces no pad-intersection area,
+    # is never charged, and legalize leaves it there. Prevention shipped
+    # (reconstruct._pair_conflicts refuses such a pose, candidate_valid refuses
+    # such a seat); this is the repair half, which did not.
+    #
+    # EXEMPTION: the engine's set, not the pair's `waiver` field.
+    # `containment_pairs` is deliberately unfiltered by `waived` -- that is the
+    # point of that list -- so iterating it raw would try to move orangecrab's
+    # FID2 out from under J5 (frac 1.000, by design). And filtering by
+    # `p.waived` instead would exempt `edge_class`, silently re-admitting the
+    # very defect the channel exists to catch (run 22's D4 wholly inside SW2,
+    # a declared edge_actuator).
+    _cont_exempt = set()
+    try:
+        from placement import reconstruct as _recon
+        _cont_exempt = _recon._body_exempt_refs(state)
+    except Exception:
+        _cont_exempt = set(getattr(state, 'container_refs', ()) or ())
+    _cont = [q for q in body.get('containment_pairs', ())
+             if q.a not in _cont_exempt and q.b not in _cont_exempt]
+    if _cont:
+        print(f"  Containment census: {len(_cont)} part(s) inside another "
+              f"part's body, all listed")
+    for q in _cont:
+        free = [r for r in (q.a, q.b)
+                if r in state.parts and not state.parts[r].locked]
+        if not free:
+            notes.append(f"containment {q.a}<->{q.b} "
+                         f"({q.contained_frac:.0%} of the smaller body): "
+                         f"both file-locked -- not repairable here")
+            continue
+        ordered = sorted(free, key=_mover_key)
+        # CHARGE: the same mm-equivalent scale the body stack above uses, so a
+        # containment buys at least the full cap ladder. Deliberately NOT
+        # area_mm2 -- a 0402 wholly inside a TSSOP measures 0.5mm2 and would
+        # be floored to a 1.0mm budget, while a large part half-swallowed
+        # would outrank it. Containment is a yes/no fact about whether a part
+        # can be built, so it charges a flat strong value rather than a size.
+        _charge(ordered[0], CONTAINMENT_CHARGE_MM)
+        for partner in ordered[1:]:
+            partner_of.setdefault(ordered[0], []).append(partner)
+
     # Off-board census on PAD/HOLE extents at ZERO margin -- copper or drill
     # off the outline is a fab defect; a COURTYARD poking past the edge is
     # cosmetic and common on legitimate boards (tigard's own corner mounting
@@ -1014,7 +1919,24 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
     failed: List[str] = []
     zero_move: List[str] = []   # run-7 A2: honesty re-grade candidates
     moves: List[Dict] = []
-    for ref in violators:
+    deadline_skipped: List[str] = []
+    for _vi, ref in enumerate(violators):
+        # Budget check at the VIOLATOR head: one monotonic read per violator,
+        # and each violator costs seconds (caps x 36 ring sweeps x O(parts)).
+        # The partial is coherent by construction -- a violator is either fully
+        # seated, with its move in `moves`, or untouched.
+        if deadline is not None and deadline.check('legalize'):
+            deadline_skipped = list(violators[_vi:])
+            notes.append(
+                f"deadline reached after {_vi}/{len(violators)} violator(s); "
+                f"{len(deadline_skipped)} left untouched and reported in "
+                f"deadline_skipped (NOT unrepairable -- they were never tried)")
+            break
+        if progress is not None:
+            try:
+                progress(_vi, len(violators), f'repair {ref}')
+            except Exception:                                  # noqa: BLE001
+                pass
         part = state.parts[ref]
         was_locked = part.locked      # always False here: locked refs are
                                       # already in `unrepairable` (see above)
@@ -1062,7 +1984,8 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
         for cap in caps:
             info: Dict = {}
             clr = _try_place(state, ref, ox, oy, set(), constraint=rect,
-                             tol=tol, max_disp=cap, info=info)
+                             tol=tol, max_disp=cap, info=info,
+                             deadline=deadline)
             if clr is not None:
                 placed_at = cap
                 if info.get('anchor_zone'):
@@ -1074,7 +1997,7 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
             zx = (z.rect[0] + z.rect[2]) / 2.0
             zy = (z.rect[1] + z.rect[3]) / 2.0
             clr = _try_place(state, ref, zx, zy, set(), constraint=rect,
-                             tol=tol)
+                             tol=tol, deadline=deadline)
             if clr is not None:
                 placed_at = 'zone'
         part.locked = was_locked
@@ -1090,7 +2013,8 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
                 pox, poy, porot = pp.x, pp.y, pp.rot
                 for cap in caps:
                     if _try_place(state, partner, pox, poy, set(),
-                                  max_disp=cap) is not None:
+                                  max_disp=cap,
+                                  deadline=deadline) is not None:
                         pd = math.hypot(pp.x - pox, pp.y - poy)
                         if pd > 1e-9:
                             seated_partner = (partner, pd)
@@ -1150,14 +2074,44 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
     # board whose pad/body census did not move are UNRESOLVED, so the fix
     # loop can see it stalled instead of believing "repaired" forever.
     unresolved = []
-    if zero_move and state.legality_ctx is not None:
+    if deadline_skipped:
+        # Skip the honesty re-grade on a partial run. It is O(zero_move x parts)
+        # with pair_shortfall, it can only DOWNGRADE `repaired`, and a partial
+        # run's `repaired` is already qualified by complete:false -- so paying
+        # for it here would just spend the clock we already ran out of.
+        notes.append("unresolved re-grade skipped: run stopped on its deadline")
+    elif zero_move and state.legality_ctx is not None:
         # Post-repair poses live on the STATE (pcb_data still holds the
         # file's input poses), so the re-grade uses the state's own pair
         # machinery in the gate currency.
         ctx = state.legality_ctx
         for ref in zero_move:
             still = False
+            # CONTAINMENT is checked FIRST, and it has to be: PairShortfall
+            # carries pad/hole/stack and no body term, so a part charged for
+            # sitting inside another body, which then could not move, would
+            # pass this loop and be reported `repaired`. That is the exact
+            # metric mismatch this re-grade was written to stop, one channel
+            # later.
+            #
+            # It FAILS LOUD. `state` is always a QuenchState (it comes from
+            # pose_score.make_state), so the method always exists, and
+            # fab_rect already swallows its own parse failure and returns None
+            # = UNJUDGED. Anything still raising here is a real bug -- and
+            # swallowing it would convert that bug into exactly the false
+            # `repaired` this check exists to prevent. So an error means NOT
+            # repaired, said out loud, rather than a silent pass.
+            try:
+                if state._body_contained_at(ref, None, None, None):
+                    still = True
+            except Exception as exc:
+                still = True
+                notes.append(f'{ref}: could not verify containment after the '
+                             f'repair ({exc.__class__.__name__}: {exc}) -- '
+                             f'NOT reported repaired')
             for other in sorted(state.parts):
+                if still:
+                    break
                 if other == ref:
                     continue
                 sf = ctx.pair_shortfall(ref, other)
@@ -1174,6 +2128,8 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
     return {'moves': moves, 'repaired': repaired, 'unrepairable':
             unrepairable + failed, 'unresolved': unresolved,
             'violators': violators, 'notes': notes,
+            'deadline_skipped': deadline_skipped,
+            'complete': not deadline_skipped,
             'pad_report_before': {k: pads[k] for k in
                                   ('pad_conflicts', 'hole_conflicts',
                                    'oob_pad_count')},
@@ -1188,7 +2144,8 @@ def reseat_scope(pcb_data, pcb_file: str, intent, *,
                  board_edge_clearance: float = 0.55,
                  grid_step: float = 0.1,
                  seed: int = 0,
-                 edge_bands: Optional[Dict[str, float]] = None) -> Dict:
+                 edge_bands: Optional[Dict[str, float]] = None,
+                 deadline=None, progress=None) -> Dict:
     """LIFT a subset of parts and re-seat them FROM SCRATCH at their net
     centroids, holding every other part fixed as an obstacle.
 
@@ -1253,7 +2210,8 @@ def reseat_scope(pcb_data, pcb_file: str, intent, *,
 
     Returns `{'moves', 'reseated', 'refused', 'unseated', 'scope',
     'scope_source', 'notes', 'gate_before', 'gate_after', 'accepted',
-    'witnesses_before', 'witnesses_after', 'edge_bands_dropped', 'pruned'}`.
+    'witnesses_before', 'witnesses_after', 'edge_bands_dropped', 'pruned',
+    'deadline_skipped', 'complete'}`.
 
     NOT `placement/reseat.py`, which is a different mechanism for a different
     problem (Hungarian re-assignment of a proximity-tethered decap cluster onto
@@ -1330,7 +2288,8 @@ def reseat_scope(pcb_data, pcb_file: str, intent, *,
                 'accepted': True, 'pruned': [],
                 'witnesses_before': sorted(witnesses_before),
                 'witnesses_after': sorted(witnesses_before),
-                'edge_bands_dropped': {}}
+                'edge_bands_dropped': {}, 'deadline_skipped': [],
+                'complete': True}
 
     if not scope:
         # A no-op is a RESULT. On a healthy board the auto scope is empty by
@@ -1383,7 +2342,7 @@ def reseat_scope(pcb_data, pcb_file: str, intent, *,
         pcb_data, pcb_file, intent2, random.Random(f"{seed}"),
         group_sources=group_sources, clearance=clearance,
         board_edge_clearance=board_edge_clearance, grid_step=grid_step,
-        seed_refs=set(scope))
+        seed_refs=set(scope), deadline=deadline, progress=progress)
     notes.extend(res['notes'])
 
     # `placements` covers every PLACED ref -- 101 of 107 on the measured board
@@ -1447,4 +2406,8 @@ def reseat_scope(pcb_data, pcb_file: str, intent, *,
             'accepted': accepted, 'pruned': sorted(pruned),
             'witnesses_before': sorted(witnesses_before),
             'witnesses_after': sorted(witnesses_after),
-            'edge_bands_dropped': {r: m for r, m in sorted(dropped.items())}}
+            'edge_bands_dropped': {r: m for r, m in sorted(dropped.items())},
+            'deadline_skipped': sorted(r for r in
+                                       res.get('deadline_skipped') or ()
+                                       if r in scope),
+            'complete': res.get('complete', True)}

--- a/py_placer/placement/writer.py
+++ b/py_placer/placement/writer.py
@@ -276,8 +276,29 @@ def write_placed_output(input_file: str, output_file: str,
             close = content.rindex(')')
             content = content[:close] + '\n'.join(elements) + '\n)' + content[close+1:]
 
+    # THE SINGLE POSE FUNNEL, and it must run BEFORE the write. Every
+    # footprint `(at ...)` rewrite in py_placer comes through here, so this is
+    # the one place that can answer "was every pose in this board produced by
+    # a registered engine lever?". Outside an unaided regime it is a no-op and
+    # the behaviour is byte-identical; inside one, an undeclared write raises.
+    #
+    # It used to raise AFTER `f.write(content)`, which made the refusal
+    # decorative: the poses were already on disk, so the "gate" reported a
+    # violation about a file it had just helped produce. Refusing means not
+    # writing.
+    #
+    # NOTE the qualifier -- "in py_placer". The GUI writes poses through
+    # pcbnew (`ai_plan._run_place_plan`, `fanout_gui`, `placement_gui`) and
+    # does NOT come through here, so a GUI-driven placement leaves no row.
+    # See provenance.record_write for what that means for a verdict.
+    from placement import provenance
+    provenance.record_write(input_file, output_file, placements,
+                            pending=True)
+
     with open(output_file, 'w', encoding='utf-8') as f:
         f.write(content)
+
+    provenance.commit_write(output_file)
 
     print(f"Modified {modified_count} footprint positions")
     print(f"Successfully wrote {output_file}")

--- a/py_placer/pose_score.py
+++ b/py_placer/pose_score.py
@@ -31,12 +31,40 @@ from typing import Dict, List, Optional, Sequence
 ROTATIONS: Sequence[float] = (0.0, 90.0, 180.0, 270.0)
 
 
+_OFFSETS_CACHE = {}
+# The cache was unbounded and keyed on raw floats, which was harmless while
+# the key set was the four fixed (radius, step) pairs `_try_place` uses. A
+# pose census derives its step from the caller's `within`, so every distinct
+# budget in a plan minted a new permanent entry -- and the entries are not
+# small (a 16mm radius at 0.1 is 103,041 tuples, ~0.45s to build). LRU rather
+# than a clear-on-full, because the hot fixed pairs are inserted first and a
+# FIFO would evict exactly those.
+_OFFSETS_CACHE_MAX = 64
+_OFFSETS_ORDER: List = []
+
+
 def _offsets(radius: float, step: float):
     """Concentric ring offsets out to `radius`, nearest first.
 
     Nearest-first matters: a tie between two equally-costed poses should go to
     the one that disturbs the board least, and the caller usually stops early.
+
+    CACHED, because the result depends only on (radius, step) and the caller
+    asks for the same few pairs relentlessly: `_try_place` runs 3 clearance
+    levels x 4 rotations, and each pass rebuilt the same lists -- the middle
+    band alone is 16,641 tuples, materialised 12 times per seat attempt and
+    then again for the next part. The returned list is treated as read-only by
+    every caller (they iterate it), so one shared copy is safe.
     """
+    key = (radius, step)
+    hit = _OFFSETS_CACHE.get(key)
+    if hit is not None:
+        try:                                  # keep it hot
+            _OFFSETS_ORDER.remove(key)
+        except ValueError:
+            pass
+        _OFFSETS_ORDER.append(key)
+        return hit
     out = [(0.0, 0.0)]
     n = max(1, int(round(radius / step)))
     for ring in range(1, n + 1):
@@ -50,6 +78,10 @@ def _offsets(radius: float, step: float):
                 ring_pts.append((i * step, j * step))
         ring_pts.sort(key=lambda d: (d[0] * d[0] + d[1] * d[1]))
         out.extend(ring_pts)
+    _OFFSETS_CACHE[key] = out
+    _OFFSETS_ORDER.append(key)
+    while len(_OFFSETS_ORDER) > _OFFSETS_CACHE_MAX:
+        _OFFSETS_CACHE.pop(_OFFSETS_ORDER.pop(0), None)
     return out
 
 

--- a/py_router/congestion_field.py
+++ b/py_router/congestion_field.py
@@ -167,22 +167,26 @@ def congestion2_knobs():
     return dict(env_knobs.CONGESTION2)
 
 
-def build_congestion2(pcb_data, config, net_ids_to_route,
-                      extra_demand_points=None):
-    """Precompute bins {(bx,by): (free_area_mm2, owners frozenset)} plus
-    per-net terminal coords. Returns None when disabled.
+def congestion_bins(pcb_data, net_ids, num_layers, bin_mm,
+                    extra_demand_points=None):
+    """THE demand/capacity census: {(bx,by): (free_area_mm2, owners)} plus
+    per-net terminal coords.
+
+    One definition, two consumers (run-23): `build_congestion2` attaches it
+    as an A* cost (env-gated), and `check_pockets.py` reports it PRE-ROUTE
+    at the placement->routing handoff -- because every per-net gate
+    (check_channels, check_reachability) passed run 23's board while two
+    nets died in one bin whose demand/free-area no instrument ever printed.
 
     extra_demand_points (#589): optional {net_id: [(x_mm, y_mm), ...]} of
     predicted-corridor samples (the global plan's rough paths) folded into
     each net's terminal set -- the net then claims demand along its whole
     predicted path instead of only at its endpoints, and its own exemption
-    disks follow the corridor (owner-exempt by construction)."""
-    k = congestion2_knobs()
-    if k['cost'] <= 0:
-        return None
-    bin_mm = max(0.25, k['bin'])
-    num_layers = max(1, len(config.layers))
-    to_route = set(net_ids_to_route)
+    disks follow the corridor (owner-exempt by construction).
+    """
+    bin_mm = max(0.25, bin_mm)
+    num_layers = max(1, num_layers)
+    to_route = set(net_ids)
 
     copper = {}
     for s in pcb_data.segments:
@@ -211,8 +215,6 @@ def build_congestion2(pcb_data, config, net_ids_to_route,
         terminals[nid] = pts
         for (x, y) in pts:
             owners.setdefault((int(x // bin_mm), int(y // bin_mm)), set()).add(nid)
-    for p in getattr(pcb_data, 'pads', []) or []:
-        pass  # pad copper folded via per-net pads below
     for nid, plist in getattr(pcb_data, 'pads_by_net', {}).items():
         for p in plist:
             b = (int(p.global_x // bin_mm), int(p.global_y // bin_mm))
@@ -223,6 +225,22 @@ def build_congestion2(pcb_data, config, net_ids_to_route,
         used = copper.get(b, 0.0)
         free = max(bin_area_total * 0.05, bin_area_total - used)
         bins[b] = (free, frozenset(own))
+    return bins, terminals
+
+
+def build_congestion2(pcb_data, config, net_ids_to_route,
+                      extra_demand_points=None):
+    """Precompute bins {(bx,by): (free_area_mm2, owners frozenset)} plus
+    per-net terminal coords. Returns None when disabled.
+
+    extra_demand_points (#589): see `congestion_bins` -- forwarded through."""
+    k = congestion2_knobs()
+    if k['cost'] <= 0:
+        return None
+    bin_mm = max(0.25, k['bin'])
+    bins, terminals = congestion_bins(
+        pcb_data, net_ids_to_route, len(config.layers), bin_mm,
+        extra_demand_points=extra_demand_points)
     n_hot = sum(1 for b, (fa, ow) in bins.items()
                 if len(ow) / fa > k['thresh'])
     print(f"Congestion2 field: {len(bins)} demand bins, {n_hot} above "

--- a/py_router/krt_deadline.py
+++ b/py_router/krt_deadline.py
@@ -1,0 +1,486 @@
+"""Wall-clock deadlines and a guaranteed JSON_SUMMARY for long-running stages.
+
+Run 9 lost two stages to the same shape: `place_reconstruct --stages legalize`
+and `route_disconnected_planes` each ran to an external `timeout(1)`, wrote no
+output file, printed no `JSON_SUMMARY`, and exited with **the shell's** 124
+rather than any code the tool chose. From the log they were indistinguishable
+from a hang, and because both stage their output and promote it only at the end,
+a kill left nothing at the output path either.
+
+The family is wider than those two -- `EXACT_FILL_TIMEOUT` (300 s) and
+`ORACLE_DRC_TIMEOUT` (240 s) both degrade to a fallback with no failure signal,
+and `converge record` can fail before it execs at all. What they share:
+
+    a long silent phase after a complete-looking report, an exit code that
+    belongs to the shell rather than the tool, and staged output that leaves
+    nothing behind on a kill.
+
+This module fixes the part that is fixable from inside the process: a stage that
+knows its own budget stops ITSELF, keeps the work it has done, says so in the
+summary, and exits with a code it chose.
+
+Usage -- `arm()` once, then a cooperative check in the hot loop::
+
+    import krt_deadline
+    dl = krt_deadline.arm(args.deadline, tool='place_reconstruct',
+                          on_partial=lambda: report)     # None == no budget
+    ...
+    for violator in violators:
+        if dl and dl.check('legalize'):
+            break
+    ...
+    finally:
+        krt_deadline.emit(report, deadline=dl)
+
+`emit()` is the single print site and fires at most once per process, so calling
+it from the success path AND a `finally` AND the atexit hook is safe.
+
+WHY THIS IS NOT PART OF `cli_banner`
+------------------------------------
+1. `cli_banner.install()` returns early when `KRT_NO_BANNER` is set
+   (`cli_banner.py:59`), and `board_score.run_tool` sets `KRT_NO_BANNER='1'` for
+   every checker it shells (`board_score.py:108-119`). A summary emitter
+   suppressed the same way would go dark exactly where `board_score` reads.
+   Nothing here consults `KRT_NO_BANNER`.
+2. The tools that NEED a deadline are largely the ones that deliberately do NOT
+   carry the banner (`route_disconnected_planes.py`, `route.py`,
+   `place_route_loop.py`). Folding the deadline into `cli_banner` would make
+   adopting it mean adopting `CMD:`/`EXIT=` on their stdout -- a separate and
+   riskier decision this repo takes seriously (`converge.py:692`: "converge's
+   stdout is a JSON API").
+
+`atexit` runs LIFO, so a hook registered by `arm()` AFTER `cli_banner.install()`
+fires BEFORE the banner's `EXIT=` hook. That gives `JSON_SUMMARY:` then `EXIT=`,
+which is the order every consumer wants. **That ordering is load-bearing.**
+
+WHAT THIS CANNOT DO
+-------------------
+Measured on Windows, so nobody expects more than this delivers::
+
+    external `timeout 1`, tool has NO deadline   -> shell rc 124,
+                                                    0 JSON_SUMMARY lines,
+                                                    0 EXIT lines
+    external `timeout 5`, tool deadline 0.4s     -> rc 7, status "deadline",
+                                                    partial result intact,
+                                                    EXIT=7
+
+The first row is run 9's actual case and it stays **unfixable from inside the
+process**: a native win32 process cannot receive a POSIX SIGTERM, and under Git
+Bash the kill resolves to `TerminateProcess`, which is uncatchable -- no handler,
+no `atexit`, no flush. Anyone designing around a SIGTERM handler here is
+designing for a platform that did not produce the bug.
+
+So: **setting a budget BELOW whatever the harness allows is the whole
+mechanism.** The signal handlers below only help for a polite SIGINT/SIGTERM
+(interactive Ctrl+C, POSIX CI). The remaining defence for the uncatchable case is
+line buffering (already done, `cli_banner.py:69-74`), the `DEADLINE:` breadcrumb
+this module prints at arm time, and a progress heartbeat -- which is why
+`stdout_progress` is here and not cosmetic.
+
+DELIBERATELY NOT DONE
+---------------------
+* **A watchdog thread that prints and calls `os._exit`.** It fires even when the
+  main thread is inside a C call, which is seductive -- and it emits state the
+  main thread is mid-mutation of, skips `atexit` (losing `EXIT=`, the exact
+  defect being fixed), and can interleave a partial line into stdout. Both hot
+  loops here are pure Python and reach a cooperative check.
+* **A `DeadlineExceeded` exception.** `route_disconnected_planes.py` is full of
+  `except Exception` swallowers -- `:2474` sits directly on the hot path -- so an
+  exception-based deadline would be caught and converted into a printed note,
+  which is precisely the silent failure being removed. Cooperative flag checks
+  and `return None` only.
+* **A generous default budget.** A wall clock default would make the same board
+  produce a different output on a slower machine, which this repo cares about
+  specifically (`tests/test_457_determinism.py`, `redo_commands.sh` replays). The
+  default is None; the budget belongs to the harness that already owns a clock.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from typing import Any, Callable, Dict, Optional
+
+#: Exit code a stage returns when its OWN budget stopped it.
+#:
+#: Not 124 -- that is the shell's, and erasing the tool/shell distinction is the
+#: confusion being removed. Not 4 -- in these tools 4 asserts a MEASURED defect
+#: class (`route_disconnected_planes.py:3616-3623` advises "reconnect them, or
+#: re-run without --rip-blocker-nets", which presumes a completed run), and a
+#: run that never finished has measured nothing. Not 5 -- already spoken for
+#: repo-wide: `converge.py:446` STUCK and `check_complete.py` UNSOUND. 7 is
+#: unused anywhere, which is what a harness needs.
+DEADLINE_EXIT = 7
+
+_emitted = False
+_summary_fn: Optional[Callable[[], Dict[str, Any]]] = None
+_installed = False
+_signalled = False
+_current: Optional['Deadline'] = None
+
+
+def current() -> Optional['Deadline']:
+    """The budget armed for this process, if any.
+
+    A deliberate global, for the one case threading cannot reach: work buried
+    under a shared engine that no caller in the chain can pass a parameter to.
+    The motivating case is `plane_fragility.register_plane_fragility`, invoked
+    from `route.py:batch_route` -- so EVERY batch_route on a board KiCad cannot
+    fill pays the full 300s EXACT_FILL_TIMEOUT, and the plane repair calls
+    batch_route many times. That is the root cause of both non-terminations
+    measured in run 9, and no signature between the CLI and that call site
+    carries a budget.
+
+    Use it only where a parameter genuinely cannot reach; everywhere else pass
+    the Deadline explicitly.
+    """
+    return _current
+
+
+class Deadline:
+    """A wall-clock budget. Never construct with 0 meaning "no budget" -- use
+    `arm(None)`; `--deadline 0` is a legitimate "stop immediately", which the
+    tests rely on.
+
+    `expired()` is a subtraction and a comparison -- cheap enough for a loop that
+    runs once per violator or once per pad. Do NOT call it per candidate pose;
+    the granularity that matters is "can the partial be described coherently",
+    not "how soon do we notice".
+    """
+
+    __slots__ = ('seconds', 'started', 'tool', 'stopped_in')
+
+    def __init__(self, seconds: Optional[float], tool: str = ''):
+        self.seconds = None if seconds is None else float(seconds)
+        self.started = time.monotonic()
+        self.tool = tool
+        self.stopped_in: Optional[str] = None
+
+    def expired(self, reserve: float = 0.0) -> bool:
+        """True once the budget (minus `reserve`) is spent, or on a signal.
+
+        `reserve` carves a band off the end so a caller can stop its main work
+        early and still have clock left for a mandatory tail step. See
+        `cancel_check`.
+        """
+        if _signalled:
+            return True
+        if self.seconds is None:
+            return False
+        return (time.monotonic() - self.started) >= max(0.0,
+                                                        self.seconds - reserve)
+
+    def check(self, label: str, reserve: float = 0.0) -> bool:
+        """`expired()`, recording WHICH phase owned the clock when it went.
+
+        The label lands in the summary as `stopped_in`, which is the difference
+        between "it timed out" and "it timed out in the legalize sweep with 88
+        violators left".
+        """
+        if self.expired(reserve):
+            if self.stopped_in is None:
+                self.stopped_in = label
+            return True
+        return False
+
+    def cancel_check(self, label: str = '', reserve: float = 0.0):
+        """A zero-arg closure for engines that already take a `cancel_check`.
+
+        `route_disconnected_planes` (`:762`) and `route.py` (`:370`) both accept
+        one and honour it at every loop head -- so a deadline there is this
+        closure, not new machinery.
+        """
+        def _cancel() -> bool:
+            return self.check(label, reserve) if label else self.expired(reserve)
+        return _cancel
+
+    def remaining(self) -> Optional[float]:
+        if self.seconds is None:
+            return None
+        return max(0.0, self.seconds - (time.monotonic() - self.started))
+
+    def elapsed(self) -> float:
+        return time.monotonic() - self.started
+
+    def __repr__(self) -> str:  # pragma: no cover - diagnostics only
+        cap = 'none' if self.seconds is None else f'{self.seconds:g}s'
+        return f'<Deadline {self.tool} cap={cap} elapsed={self.elapsed():.1f}s>'
+
+
+def arm(seconds: Optional[float], *, tool: str,
+        on_partial: Optional[Callable[[], Dict[str, Any]]] = None
+        ) -> Optional[Deadline]:
+    """Start a budget, announce it, and arrange a partial flush if interrupted.
+
+    Precedence: the `seconds` argument, else `$KRT_DEADLINE_S` (so a harness can
+    set one budget for a whole chain with one export), else None.
+
+    Returns None when there is no budget, so callers can write `if dl and
+    dl.check(...)` and pay nothing when the feature is off.
+
+    The `DEADLINE:` line it prints is deliberate: a log WITHOUT it is proof no
+    budget was set, which is the standing diagnosis for the next 46-minute run.
+    """
+    if seconds is None:
+        env = os.environ.get('KRT_DEADLINE_S')
+        if env:
+            try:
+                seconds = float(env)
+            except ValueError:
+                print(f"krt_deadline: ignoring unparseable KRT_DEADLINE_S="
+                      f"{env!r}", file=sys.stderr)
+    global _current
+    dl = None if seconds is None else Deadline(seconds, tool=tool)
+    _current = dl
+    if dl is not None:
+        print(f"DEADLINE: {dl.seconds:g}s ({tool})", flush=True)
+    # Install the flush hook even with NO budget. The atexit hook is what makes
+    # "a JSON_SUMMARY on every path" true -- it covers early returns, argparse
+    # errors and unhandled exceptions, which is why the callers need no
+    # try/finally around a main() with a dozen return statements. Without this,
+    # the guarantee would only exist for runs that happened to set a budget.
+    if on_partial is not None:
+        _install(on_partial, dl)
+    return dl
+
+
+def emit(report: Optional[Dict[str, Any]], *, complete: bool = True,
+         status: str = 'ok', deadline: Optional[Deadline] = None) -> bool:
+    """The ONE `JSON_SUMMARY:` print site. Fires at most once per process.
+
+    Returns True if this call did the printing. A payload that will not
+    serialise is reported rather than swallowed -- a summary that vanished is the
+    defect this module exists to remove, so it must not reappear as an exception.
+    """
+    global _emitted
+    if _emitted or report is None:
+        return False
+    _emitted = True
+    doc = dict(report)
+    doc.setdefault('complete', complete)
+    doc.setdefault('status', status)
+    if deadline is not None:
+        doc.setdefault('deadline_s', deadline.seconds)
+        doc.setdefault('elapsed_s', round(deadline.elapsed(), 1))
+        if deadline.stopped_in:
+            doc.setdefault('stopped_in', deadline.stopped_in)
+    try:
+        print('JSON_SUMMARY: ' + json.dumps(doc, sort_keys=True, default=str),
+              flush=True)
+    except Exception as exc:                                   # noqa: BLE001
+        try:
+            print('JSON_SUMMARY: ' + json.dumps(
+                {'complete': False, 'status': 'error',
+                 'error': f'summary unserialisable: {exc}'}), flush=True)
+        except Exception:                                      # pragma: no cover
+            pass
+    return True
+
+
+def seal() -> bool:
+    """Declare the JSON_SUMMARY already published, WITHOUT printing one.
+
+    For a tool whose engine prints its own summary. `route.py` and
+    `route_diff.py` are the cases: `batch_route` builds a large summary and
+    `print`s it directly, and it does so once per pass (the reconciliation
+    self-invoke prints a second), so routing them through `emit()` -- which
+    fires at most once -- would swallow every summary after the first.
+
+    Without this the atexit flush would see `_emitted` still False on a
+    perfectly successful run and publish the contentless partial report armed
+    at `--deadline` time, printing a SECOND, contradicting
+    `{"complete": false, "status": "incomplete"}` line after the real one. That
+    is a measured defect, not a hypothetical: it shipped in
+    `route_disconnected_planes` (run 11, v6_r7) and any consumer keying on the
+    LAST JSON_SUMMARY read a good run as a failed one.
+
+    Returns True if this call did the sealing.
+    """
+    global _emitted
+    if _emitted:
+        return False
+    _emitted = True
+    return True
+
+
+def stamp(report: Dict[str, Any]) -> Dict[str, Any]:
+    """Stamp THIS PROCESS's spent budget onto a summary someone else prints.
+
+    The companion to `seal()`, and the reason neither is a new engine kwarg:
+    `batch_route`'s summary is the only one `route.py` emits, and
+    `place_route_loop` already refuses a `complete: false` tally
+    (`place_route_loop.py:162`) while `route_summary.merge_summaries` already
+    makes incompleteness sticky across passes. The one missing piece was the
+    stamp itself, and it is read through `current()` rather than threaded
+    through the signature -- so the GUI, which never arms a budget, is inert
+    here and no parity gate is involved.
+
+    A no-op unless a budget was armed AND actually cut the work short, so a
+    summary from a run that finished inside its budget is byte-identical to
+    before.
+
+    "Cut short" is `stopped_in or expired()`, not `expired()` alone. A caller
+    using a RESERVE band (`cancel_check(label, reserve=...)`, which
+    route_planes and route_disconnected_planes both need so the bounded tail
+    still has clock) trips its loops at `deadline - reserve` -- and if that
+    tail then finishes before the wall clock runs out, the run is past its
+    cancel and NOT past its deadline. Testing `expired()` alone would report
+    that partial board as complete, which is precisely the confusion this
+    module exists to remove. `stopped_in` is set by `Deadline.check` at the
+    moment the cancel fires, so it is the durable record.
+    """
+    dl = _current
+    if dl is None or not (dl.stopped_in or dl.expired()):
+        return report
+    report['complete'] = False
+    report['status'] = 'deadline'
+    report['deadline_s'] = dl.seconds
+    report['elapsed_s'] = round(dl.elapsed(), 1)
+    report['stopped_in'] = dl.stopped_in
+    return report
+
+
+def mark(report: Dict[str, Any], dl: Deadline, **partial: Any
+         ) -> Dict[str, Any]:
+    """Stamp `report` as a partial result, in the shape consumers rely on.
+
+    `complete` is the machine gate -- read it as `.get('complete', True)` so
+    pre-change logs degrade correctly. `status` is the branching discriminator:
+    a cancel is not a deadline is not a crash, and encoding the reason only as a
+    bool loses that.
+
+    `status` is `"deadline"`, not `"timeout"` -- `timeout` already means
+    something else in these summaries (`max_iterations`, A* budgets).
+    """
+    report['complete'] = False
+    report['status'] = 'deadline'
+    report['deadline_s'] = dl.seconds
+    report['elapsed_s'] = round(dl.elapsed(), 1)
+    report['stopped_in'] = dl.stopped_in
+    if partial:
+        report.setdefault('partial', {}).update(partial)
+    return report
+
+
+def stdout_progress(min_interval: float = 15.0,
+                    deadline: Optional[Deadline] = None,
+                    heartbeat_file: Optional[str] = None):
+    """A throttled `(current, total, label)` callback for CLI progress.
+
+    `route_disconnected_planes` already invokes `progress_callback` at ~9 sites;
+    it is None on the CLI path only because it was built for the GUI. Passing
+    this lights all of them up with no new print statements.
+
+    Throttling matters: one of those sites fires per pad and would otherwise
+    flood a 96-pad board's log. `PROGRESS:` is a distinct prefix that cannot
+    match `route_summary.SUMMARY_RE`.
+
+    run-23: `heartbeat_file` (default $KRT_PROGRESS_FILE) additionally
+    rewrites one small JSON doc per tick, atomically -- a waiter or a
+    RUN_STATE reader polls one file for liveness instead of tailing a log
+    that only grows when something prints.
+    """
+    state = {'last': 0.0}
+    hb = heartbeat_file or os.environ.get('KRT_PROGRESS_FILE') or None
+
+    def _progress(current=0, total=0, label='') -> None:
+        now = time.monotonic()
+        if now - state['last'] < min_interval:
+            return
+        state['last'] = now
+        frac = f"{current}/{total}  " if total else ''
+        clock = ''
+        if deadline is not None and deadline.seconds is not None:
+            clock = f"  [t={deadline.elapsed():.0f}s/{deadline.seconds:g}s]"
+        try:
+            print(f"PROGRESS: {frac}{label}{clock}", flush=True)
+        except Exception:                                      # noqa: BLE001
+            pass
+        if hb:
+            try:
+                doc = {'t': time.time(), 'current': current, 'total': total,
+                       'label': label,
+                       'elapsed_s': (round(deadline.elapsed(), 1)
+                                     if deadline is not None else None),
+                       'deadline_s': (deadline.seconds
+                                      if deadline is not None else None)}
+                tmp = hb + '.tmp'
+                with open(tmp, 'w', encoding='utf-8') as f:
+                    json.dump(doc, f)
+                os.replace(tmp, hb)
+            except Exception:                                  # noqa: BLE001
+                pass
+    return _progress
+
+
+def _install(on_partial: Callable[[], Dict[str, Any]],
+             dl: Optional[Deadline]) -> None:
+    """atexit + signal wiring. Every registration is defensive: a missing signal
+    must not stop the tool from running."""
+    global _installed, _summary_fn
+    _summary_fn = on_partial
+    if _installed:
+        return
+    _installed = True
+
+    import atexit
+
+    @atexit.register
+    def _flush() -> None:                                      # pragma: no cover
+        if _emitted or _summary_fn is None:
+            return
+        try:
+            rep = _summary_fn()
+        except Exception as exc:                               # noqa: BLE001
+            emit({'error': f'partial summary unavailable: {exc}'},
+                 complete=False, status='error')
+            return
+        # Name the reason accurately: a run that died on an early return is
+        # `incomplete`, not `deadline`. Conflating them would put the wrong
+        # diagnosis in the one artefact that survives.
+        if _signalled:
+            status = 'cancelled'
+        elif dl is not None and dl.expired():
+            status = 'deadline'
+            mark(rep, dl)
+        else:
+            status = 'incomplete'
+        emit(rep, complete=False, status=status, deadline=dl)
+
+    try:
+        import signal
+
+        def _on_signal(signum, _frame):                        # noqa: ANN001
+            # Set a flag ONLY. Printing from a handler can interleave into a
+            # half-written stdout line and corrupt the very JSON_SUMMARY a
+            # scraper reads; the atexit hook does the I/O instead. A second
+            # identical signal restores the default so Ctrl+C twice always
+            # kills.
+            global _signalled
+            if _signalled:
+                signal.signal(signum, signal.SIG_DFL)
+                return
+            _signalled = True
+            sys.exit(130 if signum == getattr(signal, 'SIGINT', None)
+                     else DEADLINE_EXIT)
+
+        for _name in ('SIGTERM', 'SIGINT', 'SIGBREAK'):
+            _sig = getattr(signal, _name, None)
+            if _sig is None:
+                continue
+            try:
+                signal.signal(_sig, _on_signal)
+            except (ValueError, OSError, RuntimeError):
+                pass          # not the main thread, or platform refuses it
+    except Exception:                                          # noqa: BLE001
+        pass
+
+
+def reset_for_test() -> None:
+    """Test hook: forget that a summary was emitted."""
+    global _emitted, _installed, _summary_fn, _signalled
+    _emitted = False
+    _installed = False
+    _summary_fn = None
+    _signalled = False

--- a/py_router/routing_diagnostics.py
+++ b/py_router/routing_diagnostics.py
@@ -540,7 +540,7 @@ def preexisting_blocker_hint(blocked_cells, config, pcb_data, net_id,
             f"cannot be), then bisect if you want a minimal rip." + prot_txt, names)
 
 
-def static_boxin_hint(result, config, pcb_data=None) -> str:
+def static_boxin_hint(result, config, pcb_data=None, *, return_verdict=False):
     """One-line hint when a route died immediately with nothing rippable.
 
     A failure with almost no A* iterations and no rippable blockers means the
@@ -548,12 +548,22 @@ def static_boxin_hint(result, config, pcb_data=None) -> str:
     clearance expansion) - typical for fine-pitch (0.4-0.65 mm) packages at
     coarse grid/clearance settings - not by other nets' routes (issue #95).
     Returns '' when the failure doesn't match that signature.
+
+    `return_verdict=True` returns `(hint, verdict_or_None)` -- the same shape
+    `preexisting_blocker_hint`'s `return_names=True` already uses. The verdict
+    is the whole static-vs-congestion decision, which this function computes in
+    two lines and then FORMATS INTO A STRING. Run 20 printed that string on
+    every residual failure while three grid refinements were spent against it,
+    because nothing downstream could read a sentence.
     """
+    def _ret(hint, verdict=None):
+        return (hint, verdict) if return_verdict else hint
+
     if result is None:
-        return ""
+        return _ret("")
     iters = result.get('iterations_forward', 0) + result.get('iterations_backward', 0)
     if iters >= 20000:
-        return ""
+        return _ret("")
     finer = config.grid_step / 2
     # Don't steer users into an OOM (issue #105): halving the grid step
     # quadruples cell count. Above ~4M cells per layer, suggest scoping the
@@ -566,10 +576,90 @@ def static_boxin_hint(result, config, pcb_data=None) -> str:
             grid_advice = (f"--grid-step {finer:g} scoped to just the failing nets "
                            f"via --nets (board-global it is ~{cells / 1e6:.0f}M "
                            f"cells/layer and may exhaust memory)")
-    return (f"Hint: search exhausted after only {iters} iterations with no rippable "
-            f"blockers - the start/target pads are boxed in by static obstacles "
-            f"(neighboring pads + clearance), not by congestion. For fine-pitch "
-            f"parts try a finer grid and/or smaller clearance/track, e.g. "
-            f"{grid_advice} --clearance 0.15 --track-width 0.15 "
-            f"(current: grid {config.grid_step:g}, clearance {config.clearance:g}, "
-            f"track {config.track_width:g} mm)")
+    # WHAT TO ADVISE depends on whether the geometry has anywhere left to go.
+    # The old text hardcoded `--clearance 0.15 --track-width 0.15` regardless of
+    # `config`, so on run 20 -- routing at exactly 0.15/0.15 -- it advised the
+    # values already in force, and the only novel token in the whole hint was
+    # the grid. Three grid refinements followed, ~40 minutes, with the same
+    # three nets failing at every resolution.
+    #
+    # The floor is the BOARD's own declaration, not the fab minimum. Going
+    # below what the board declares is the ratchet this repo keeps
+    # rediscovering -- a run that "finds travel" by routing under the board's
+    # own class has not found travel, it has moved the goalposts and every
+    # later grader then reads clean. Measured on run 20: at the fab rung
+    # (0.0762 track) there is apparent room; at the board's declared 0.15 there
+    # is none, and none was the truth.
+    _floor_c = _floor_t = None
+    _src = getattr(pcb_data, 'source_path', None) if pcb_data is not None else None
+    if _src:
+        try:
+            from list_nets import board_floor, read_design_rules
+            _dr = read_design_rules(_src)
+            _floor_c = board_floor(_src, 'clearance', design_rules=_dr)[0]
+            _floor_t = board_floor(_src, 'track_width', design_rules=_dr)[0]
+        except Exception:                                   # noqa: BLE001
+            _floor_c = _floor_t = None
+    _has_c = _floor_c is not None and config.clearance > _floor_c + 1e-9
+    _has_t = _floor_t is not None and config.track_width > _floor_t + 1e-9
+    # BOTH axes, not either. `or` here asserted "at the floor" from ONE readable
+    # floor -- so a board declaring min_track_width but no netclass (clearance
+    # has no board-constraint fallback in list_nets._FLOOR_SOURCES) reported
+    # at_floor TRUE while running at clearance 0.90 against a 0.15 track floor,
+    # and L4 REFUSED the parameter lever on it. Dropping `--clearance 0.9` was
+    # precisely the working move. An axis whose floor cannot be read may have
+    # travel; the honest answer there is UNKNOWN, which refuses nothing.
+    _both_read = _floor_c is not None and _floor_t is not None
+    if _both_read and not (_has_c or _has_t):
+        _at = ', '.join(
+            f'{k} {v:g}' for k, v in (('clearance', _floor_c),
+                                      ('track', _floor_t)) if v is not None)
+        _advice = (
+            f"the geometry is ALREADY at this board's declared floor ({_at}), "
+            + f"so there is nothing left to pair a finer grid with. A finer "
+              f"grid alone resolves the SAME obstacles more precisely -- it "
+              f"does not make the gap wider. THIS IS A PLACEMENT/FLOORPLAN "
+              f"FINDING, NOT A PARAMETER ONE: measure it with "
+              f"check_reachability on the COPPER-FREE board and re-enter "
+              f"placement")
+    else:
+        _room = []
+        if _has_c:
+            _room.append(f"--clearance {_floor_c:g}")
+        if _has_t:
+            _room.append(f"--track-width {_floor_t:g}")
+        _advice = (
+            f"for fine-pitch parts try a finer grid PAIRED with the geometry "
+            f"that still has travel, e.g. {grid_advice}"
+            + (' ' + ' '.join(_room) if _room else '')
+            + (" (the grid is the COMPLEMENT, never the lever on its own)"
+               if _room else
+               " -- no declared floor was readable here, so whether the "
+               "geometry has travel is unknown; check the board's netclass "
+               "before spending a grid lap"))
+    return _ret(
+        f"Hint: search exhausted after only {iters} iterations with no rippable "
+        f"blockers - the start/target pads are boxed in by static obstacles "
+        f"(neighboring pads + clearance), not by congestion. {_advice} "
+        f"(current: grid {config.grid_step:g}, clearance {config.clearance:g}, "
+        f"track {config.track_width:g} mm)",
+        # The verdict, as data. `geometry` is what was IN FORCE -- whether that
+        # is at the board's floor is a question this function cannot answer
+        # (it holds a config, not a project), so it publishes the numbers and
+        # lets the guard that does hold the floors decide.
+        {'verdict': 'boxed_in_static', 'iterations': iters,
+         'geometry': {'grid_step': config.grid_step,
+                      'clearance': config.clearance,
+                      'track_width': config.track_width,
+                      'via_diameter': getattr(config, 'via_diameter', None)},
+         # The floors the geometry was compared against, and the ANSWER. The
+         # guard at L4 must not re-derive this: two instruments deriving one
+         # verdict two ways is how the same board gets classified twice.
+         # `at_floor` is None when no floor could be read -- unknown, never a
+         # silent False.
+         'floors': {'clearance': _floor_c, 'track_width': _floor_t},
+         # False when SOME axis provably has travel; True only when BOTH floors
+         # were read and neither does; None when an unread floor leaves it
+         # genuinely unknown. The guard at L4 refuses only on True.
+         'at_floor': (False if (_has_c or _has_t)
+                      else (True if _both_read else None))})

--- a/py_tools/check_assembly.py
+++ b/py_tools/check_assembly.py
@@ -14,10 +14,16 @@ authored overlap waivers only.
 to the baseline board (dense real boards ship hundreds of by-design
 courtyard kisses -- the corpus measured 235 -- so the placement fix loop
 targets the pairs OUR moves introduced, never a shipped design's own).
+--baseline also ARMS the courtyard gate (run-23): an unwaived courtyard
+interpenetration past the area+depth floors flips the verdict when a member
+MOVED relative to the baseline. Without a baseline the courtyard census is
+report-only -- healthy human boards ship such pairs by design (measured:
+5 of 34 corpus boards), so an absolute gate would be unshippable.
 
 Exit codes: 0 = clean, 2 = usage/load error, 4 = a blocking pair OR copper
 landing on a KiCad-locked part (see LOCKED-PART CONTACT) OR a coincident-
-origin stack (see COINCIDENT ORIGINS).
+origin stack (see COINCIDENT ORIGINS) OR a containment OR a moved-vs-
+baseline courtyard interpenetration (see COURTYARD BLOCKING).
 """
 import _path  # noqa: F401  (py_tools -> py_router/py_placer on sys.path)
 
@@ -46,6 +52,7 @@ def main():
 
     import routing_defaults as defaults
     from kicad_parser import parse_kicad_pcb
+    from placement import legality
     from placement.legality import grade_body_overlap, grade_pad_legality
 
     # GRADE AT THE BOARD'S OWN FLOOR, and say where that came from.
@@ -171,11 +178,18 @@ def main():
             continue
         _buckets.setdefault((round(_fp.x, 3), round(_fp.y, 3)),
                             []).append(_ref)
+    # NOTE this iterates DISTINCT REFERENCES. `pcb.footprints` is a dict keyed
+    # by reference, so two footprint blocks sharing one reference are ONE entry
+    # here and cannot form a coincident pair -- the check that exists to catch
+    # two parts at one point is structurally blind to two parts with one name.
+    # `duplicate_references` below is that case, reported separately.
     stack_groups = [{'point': [pt[0], pt[1]], 'refs': refs}
                     for pt, refs in sorted(_buckets.items())
                     if sum(1 for r in refs if not _marker(r)) >= 2]
+    dup_refs = dict(getattr(pcb, 'duplicate_references', None) or {})
 
     new_advisory = None
+    moved_refs = None
     if args.baseline:
         try:
             base_pcb = parse_kicad_pcb(args.baseline)
@@ -188,20 +202,60 @@ def main():
         base_keys = {(q.a, q.b, q.kind) for q in gb['pairs']}
         new_advisory = [q for q in g['advisory_pairs']
                         if (q.a, q.b, q.kind) not in base_keys]
+        # Refs whose POSE differs from the baseline (position, rotation mod
+        # 360, or layer). This is the courtyard gate's currency: a pair is
+        # chargeable only when OUR moves put a member there. Pair-membership
+        # ("new vs baseline") is NOT enough -- run-23's RN3<->U5 existed in
+        # the damaged baseline (the staged containment), the repair moved RN3
+        # 3.28mm and left the pair blocking, and a membership test would have
+        # called it pre-existing. A ref absent from the baseline counts as
+        # moved: something put it there.
+        moved_refs = set()
+        for _ref, _fp in pcb.footprints.items():
+            _bp = base_pcb.footprints.get(_ref)
+            if _bp is None:
+                moved_refs.add(_ref)
+                continue
+            _drot = ((_fp.rotation or 0.0) - (_bp.rotation or 0.0)) % 360.0
+            if (abs(_fp.x - _bp.x) > 1e-3 or abs(_fp.y - _bp.y) > 1e-3
+                    or min(_drot, 360.0 - _drot) > 1e-3
+                    or (_fp.layer or '') != (_bp.layer or '')):
+                moved_refs.add(_ref)
 
     print(f"Assembly audit of {args.board} (clearance {clearance}):")
+    if dup_refs:
+        # ADVISORY, never blocking: a duplicate reference is legal in KiCad and
+        # can be deliberate. But it must not be silent -- on run 20's board
+        # `coincident_origins` read 0 while TWO pairs sat at exactly coincident
+        # positions, because each pair was one dict entry.
+        _n = sum(dup_refs.values())
+        print(f"  DUPLICATE REFERENCES (advisory): {_n} footprint block(s) "
+              f"share {len(dup_refs)} reference(s) -- "
+              + ', '.join(f'{r} x{c}' for r, c in sorted(dup_refs.items())))
+        print(f"    Only the LAST block of each is parsed, so this audit sees "
+              f"{len(pcb.footprints)} parts and `coincident_origins` cannot "
+              f"compare the dropped ones. Legal, but rename them if they are "
+              f"meant to be distinct parts.")
     print(f"  blocking {g['blocking']}  advisory {g['advisory']}"
-          f"  waived {g['waived']}"
+          f"  waived {g['waived']}  contained {g['contained']}"
+          f"  courtyard_blocking {g['courtyard_blocking']}"
           + (f"  new-vs-baseline {len(new_advisory)}"
              if new_advisory is not None else ""))
+    _cb_keys = {(q.a, q.b) for q in g['courtyard_blocking_pairs']}
     for q in g['pairs']:
         label = ('BLOCKING' if q.kind == 'pad_intersection'
-                 else (f'waived:{q.waiver}' if q.waived else 'advisory'))
+                 else ('COURTYARD-BLOCKING'
+                       if q.kind == 'courtyard' and (q.a, q.b) in _cb_keys
+                       else (f'waived:{q.waiver}' if q.waived
+                             else 'advisory')))
         star = ''
         if new_advisory is not None and q in new_advisory:
             star = '  <-- NEW vs baseline'
+        cont = ''
+        if q.contained:
+            cont = f"  CONTAINED {q.contained_frac:.0%}"
         print(f"    {q.a} <-> {q.b}  {q.kind}  {q.area_mm2}mm2 "
-              f"side {q.side}  {label}{star}")
+              f"side {q.side}  {label}{cont}{star}")
         # Different-net pads touching is a short on top of the overlap. Say so
         # here rather than making a reader re-derive it from the board.
         for sh in getattr(q, 'shorts', ()) or ():
@@ -237,7 +291,92 @@ def main():
     # `buildable`, exit code). Three re-derivations of `blocking or
     # locked_contact` is how the coincident-origin channel would have reached
     # two of them and silently missed the third.
-    not_buildable = bool(g['blocking'] or locked_contact or stack_groups)
+    if g['contained']:
+        print(f"  CONTAINMENT ({g['contained']}): a part's .Fab body lies "
+              f"wholly or mostly inside another part's.")
+        for q in g['containment_pairs']:
+            tag = f"  [waived:{q.waiver}]" if q.waived else ''
+            print(f"    {q.a} <-> {q.b}  {q.area_mm2}mm2  "
+                  f"{q.contained_frac:.0%} of the smaller body{tag}")
+        if g['containment_blocking']:
+            print(f"    {g['containment_blocking']} of these BLOCK: a "
+                  f"containment gates unless a mount-hole/fiducial/testpoint "
+                  f"or a board-sized container is involved, or the pair is "
+                  f"named in the intent's `overlap_waivers`. An `edge_class` "
+                  f"waiver does NOT exempt -- it is a part-class lookup with "
+                  f"no geometry in it, and it is what hid a part wholly "
+                  f"inside a switch body in run 22.")
+            print(f"    To accept one deliberately, name the pair in the "
+                  f"intent rather than relying on its class.")
+        else:
+            print(f"    None of these BLOCK: each is a by-design containment "
+                  f"(a marker or a board-sized container), which the corpus "
+                  f"ships legitimately -- orangecrab FID2/J5 at 100%.")
+    if g['fab_unjudged']:
+        _u = g['fab_unjudged_refs']
+        print(f"  BODY COVERAGE: {g['fab_unjudged']} of "
+              f"{len(pcb.footprints)} part(s) draw no .Fab outline, so the "
+              f"containment channel cannot judge them: "
+              + ', '.join(_u[:8]) + (' ...' if len(_u) > 8 else ''))
+
+    # Courtyard gate currency (run-23): the census below is ABSOLUTE, but the
+    # GATE is moved-vs-baseline. Measured on this repo's own corpus: 5 healthy
+    # human boards ship unwaived courtyard interpenetrations past any sane
+    # floor (ulx3s GPDI1<->U11 at 38.5mm2 depth 5.1; rp2350 U3 frac-1.0 inside
+    # J2 -- both documented by-design), so an absolute conjunct flips 5 of 34
+    # corpus boards NOT BUILDABLE and is unshippable. A pair gates only when a
+    # MEMBER MOVED relative to --baseline: a pristine board graded against
+    # itself can never flip, while a repair run owns every pair its moves
+    # created or failed to clear (run-23: J4/J3/RN3 all moved; all three
+    # defects gate).
+    #
+    # The currency's ONE blind spot, named rather than papered over: a pair
+    # the DAMAGE created and the repair never touched (neither member moved)
+    # reads as the baseline's own -- run-23's FB1<->SW2 (0.70mm2, real body
+    # contact) is exactly that. It stays in the census and the review-sheet
+    # facts, and the boundary review must disposition it; no movement test
+    # can charge it without also flipping pristine boards.
+    courtyard_gating = []
+    if g['courtyard_blocking'] and moved_refs is not None:
+        courtyard_gating = [q for q in g['courtyard_blocking_pairs']
+                            if q.a in moved_refs or q.b in moved_refs]
+    if g['courtyard_blocking']:
+        _gate_note = (
+            f"{len(courtyard_gating)} of {g['courtyard_blocking']} GATE "
+            f"(a member moved vs the baseline)" if moved_refs is not None
+            else f"REPORT-ONLY: pass --baseline <the board the run started "
+                 f"from> to gate the pairs your moves created")
+        print(f"  COURTYARD BLOCKING ({g['courtyard_blocking']}): unwaived "
+              f"courtyard interpenetration past the floors (area >= "
+              f"{legality.COURTYARD_BLOCKING_MIN_MM2}mm2 OR >= "
+              f"{legality.COURTYARD_BLOCKING_MIN_FRAC:.0%} of the smaller "
+              f"courtyard, AND depth >= "
+              f"{legality.COURTYARD_BLOCKING_MIN_DEPTH_MM}mm) -- {_gate_note}")
+        for q in g['courtyard_blocking_pairs']:
+            _mv = ''
+            if moved_refs is not None:
+                _who = [r for r in (q.a, q.b) if r in moved_refs]
+                _mv = ('  GATES (moved: ' + ' '.join(_who) + ')' if _who
+                       else '  baseline\'s own (no member moved)')
+            print(f"    {q.a} <-> {q.b}  {q.area_mm2}mm2  depth "
+                  f"{q.depth_mm}mm  side {q.side}{_mv}")
+        print(f"    Run-23 shipped J4 0.90mm inside U6 as `buildable` "
+              f"because courtyard overlap was advisory everywhere. A "
+              f"deliberate overlap is accepted by naming the pair in the "
+              f"intent's `overlap_waivers`, where the acceptance is visible.")
+
+    # A FOURTH conjunct, and `g['blocking']` is deliberately NOT touched.
+    # `blocking` means "pad intersections" to board_score, to the seeder's
+    # repair census, and -- with INVERTED polarity -- to placement_driver's
+    # _guard_damage, which refuses to run the repair stages when `not
+    # blocking`. Folding containment into that count would change all three.
+    # This is the same shape the coincident-origin channel used.
+    # `courtyard_gating` is the FIFTH conjunct (run-23): the moved-vs-baseline
+    # subset of the courtyard census -- see the currency comment above for
+    # why the absolute census must not gate.
+    not_buildable = bool(g['blocking'] or locked_contact or stack_groups
+                         or g['containment_blocking']
+                         or courtyard_gating)
     verdict = 'NOT BUILDABLE' if not_buildable else 'buildable (blocking 0)'
     print(f"  VERDICT: {verdict}")
 
@@ -267,6 +406,35 @@ def main():
             'advisory': g['advisory'],
             'waived': g['waived'],
             'pairs': [q._asdict() for q in g['pairs']],
+            'contained': g['contained'],
+            'containments': [q._asdict() for q in g['containment_pairs']],
+            'fab_unjudged': g['fab_unjudged'],
+            'fab_unjudged_refs': g['fab_unjudged_refs'],
+            # Run-23 courtyard channel. `courtyard_pairs` is EVERY
+            # courtyard-kind pair (waived included, so a reader never
+            # re-derives the census); `courtyard_blocking*` is the gated
+            # subset; `courtyard_advisory` the unwaived-but-not-gating rest.
+            # NOTE `b_body_overlap_pairs` in render_placement's checklist is
+            # PAD INTERSECTIONS, not this -- the name predates this channel.
+            'courtyard_blocking': g['courtyard_blocking'],
+            'courtyard_blocking_pairs': [q._asdict()
+                                         for q in g['courtyard_blocking_pairs']],
+            # The subset that actually GATES buildable: census pairs where a
+            # member MOVED vs --baseline. None (not 0) without a baseline --
+            # "not measured" must never read as "measured clean".
+            'courtyard_blocking_gating': (len(courtyard_gating)
+                                          if moved_refs is not None else None),
+            'courtyard_blocking_gating_pairs': [q._asdict()
+                                                for q in courtyard_gating],
+            'courtyard_gating_basis': ('moved-vs-baseline'
+                                       if moved_refs is not None
+                                       else 'no-baseline: report-only'),
+            'courtyard_pairs': [q._asdict() for q in g['pairs']
+                                if q.kind == 'courtyard'],
+            'courtyard_advisory': sum(
+                1 for q in g['advisory_pairs'] if q.kind == 'courtyard'
+                and q not in g['courtyard_blocking_pairs']),
+            'courtyard_synthetic_refs': g['courtyard_synthetic_refs'],
             'blocking_pairs': [q._asdict() for q in g['blocking_pairs']],
             'advisory_pairs': [q._asdict() for q in g['advisory_pairs']],
             'pad_conflicts': leg['pad_conflicts'],
@@ -287,6 +455,13 @@ def main():
             # finding about one point, and the fix is one re-seat per part.
             'coincident_origin_groups': stack_groups,
             'coincident_origins': len(stack_groups),
+            'coincident_origins_basis': (
+                'distinct references only -- footprints are keyed by '
+                'reference, so blocks sharing one reference are a single '
+                'entry here and cannot form a pair. See duplicate_references.'),
+            'duplicate_references': dup_refs,
+            'footprint_blocks': len(pcb.footprints) + sum(dup_refs.values())
+                                - len(dup_refs),
         }
         if new_advisory is not None:
             doc['baseline'] = args.baseline

--- a/py_tools/check_pockets.py
+++ b/py_tools/check_pockets.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Pocket census: windowed routing demand vs free copper area (run-23).
+
+Every per-net handoff instrument passed run 23's board -- check_channels: 0
+starved faces; check_reachability: every failing pad PASSABLE copper-free;
+crossings below the damaged baseline -- and two nets then died across ~20
+route laps in ONE pocket (the RN7/U6/J2 region), where committed copper
+finally wrapped RN7 at 0.095mm against a 0.45mm corridor need. Per-net tests
+are blind to SIMULTANEOUS routability by construction; this tool reports the
+aggregate: the board binned at --bin mm, each bin's distinct demanding nets
+against its free area, top offenders named with their nets and parts.
+
+REPORT-ONLY, deliberately: a new metric mis-thresholded is noise, so nothing
+gates on it this sprint. The boundary review (the blind-first visual gate)
+must DISPOSITION every window this prints -- in writing, against a named
+plan -- or refuse the handoff itself.
+
+    python3 -X utf8 py_tools/check_pockets.py <board> [--nets GLOB...]
+        [--bin MM] [--top N] [--threshold NETS_PER_MM2] [--json PATH]
+
+Exit codes: 0 always (report), 2 usage/load error.
+"""
+import _path  # noqa: F401  (py_tools -> py_router/py_placer on sys.path)
+
+import argparse
+import json
+import sys
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description="Windowed demand/free-area census of a board.")
+    p.add_argument("board")
+    p.add_argument("--nets", nargs='+', default=['*'], metavar='GLOB',
+                   help="the DEMAND set (route.py glob syntax, '!' excludes). "
+                        "Default: every net. Pass the set the route step will "
+                        "carry so the census asks the same question")
+    p.add_argument("--bin", type=float, default=2.0, metavar='MM',
+                   help="window size (default 2.0mm -- about three 0.15/0.15 "
+                        "lanes plus a via, the scale run 23's pocket failed "
+                        "at; the router's own congestion cost uses 1.0)")
+    p.add_argument("--top", type=int, default=8, metavar='N',
+                   help="how many windows to print (default 8)")
+    p.add_argument("--threshold", type=float, default=None,
+                   metavar='NETS_PER_MM2',
+                   help="report only windows above this demand/free-area "
+                        "ratio. Default: none -- print the top N whatever "
+                        "their ratio, because an absolute threshold is "
+                        "exactly what this tool is too young to own")
+    p.add_argument("--json", default=None, metavar='PATH',
+                   help="write the full census as JSON")
+    args = p.parse_args()
+
+    from congestion_field import congestion_bins
+    from kicad_parser import parse_kicad_pcb
+    from net_queries import expand_net_patterns
+
+    try:
+        pcb = parse_kicad_pcb(args.board)
+    except Exception as exc:
+        print(f"cannot parse {args.board}: {exc}", file=sys.stderr)
+        return 2
+
+    names = expand_net_patterns(pcb, args.nets)
+    name_by_id = {n.net_id: n.name for n in pcb.nets.values()}
+    ids = [nid for nid, n in pcb.nets.items() if n.name in set(names)]
+    layers = list(getattr(pcb.board_info, 'copper_layers', []) or []) or ['F.Cu']
+
+    # The corridor arithmetic a reader needs beside the ratios: one lane =
+    # track + 2*clearance at the board's own floors (the 0.45mm number run
+    # 23's forensics measured RN7's cage against).
+    try:
+        from list_nets import board_floor
+        import routing_defaults as defaults
+        clr, _s1 = board_floor(args.board, 'clearance', None,
+                               defaults.CLEARANCE)
+        trk, _s2 = board_floor(args.board, 'track_width', None,
+                               defaults.TRACK_WIDTH)
+    except Exception:                                           # noqa: BLE001
+        clr = trk = None
+
+    bins, _terminals = congestion_bins(pcb, ids, len(layers), args.bin)
+    rows = []
+    for (bx, by), (free, owners) in bins.items():
+        ratio = len(owners) / free if free > 0 else float('inf')
+        rows.append({
+            'window': [round(bx * args.bin, 2), round(by * args.bin, 2),
+                       round((bx + 1) * args.bin, 2),
+                       round((by + 1) * args.bin, 2)],
+            'demand_nets': len(owners),
+            'free_area_mm2': round(free, 3),
+            'ratio': round(ratio, 4),
+            'nets': sorted(name_by_id.get(n, str(n)) for n in owners)[:12],
+        })
+    rows.sort(key=lambda r: -r['ratio'])
+    # Simultaneous routability needs >= 2 nets by definition: a single-net
+    # sliver (a bin inside one part's own pad field) tops any ratio ranking
+    # and means nothing here. Reported in the JSON, never in the ranking.
+    hot = [r for r in rows if r['demand_nets'] >= 2
+           and (args.threshold is None or r['ratio'] > args.threshold)]
+
+    # Parts per window, for the top rows only (the fix target is a ref).
+    pads = [(pad.global_x, pad.global_y, pad.component_ref)
+            for fp in pcb.footprints.values() for pad in fp.pads]
+    for r in hot[:args.top]:
+        w = r['window']
+        r['refs'] = sorted({ref for x, y, ref in pads
+                            if w[0] <= x < w[2] and w[1] <= y < w[3] and ref})
+
+    lane = (f"one lane = track {trk:g} + 2 x clearance {clr:g} = "
+            f"{trk + 2 * clr:g}mm" if clr is not None and trk is not None
+            else "board floors unreadable")
+    print(f"Pocket census of {args.board}: {len(ids)} demand net(s), "
+          f"{len(bins)} window(s) at {args.bin}mm, {len(layers)} layer(s); "
+          f"{lane}")
+    print(f"REPORT-ONLY: nothing gates on these numbers. The boundary review "
+          f"dispositions each window below, in writing.")
+    for r in hot[:args.top]:
+        w = r['window']
+        print(f"  [{w[0]:g},{w[1]:g}]-[{w[2]:g},{w[3]:g}]  demand "
+              f"{r['demand_nets']:>3} net(s) / free {r['free_area_mm2']:g}mm2 "
+              f"= {r['ratio']:g}/mm2")
+        print(f"      nets: {', '.join(r['nets'])}"
+              + (" ..." if r['demand_nets'] > len(r['nets']) else ""))
+        if r.get('refs'):
+            print(f"      refs: {', '.join(r['refs'][:14])}"
+                  + (" ..." if len(r['refs']) > 14 else ""))
+
+    if args.json:
+        doc = {'board': args.board, 'bin_mm': args.bin,
+               'demand_nets': len(ids), 'layers': len(layers),
+               'lane_mm': (round(trk + 2 * clr, 4)
+                           if clr is not None and trk is not None else None),
+               'threshold': args.threshold,
+               'windows': rows[:max(args.top, 32)]}
+        with open(args.json, 'w', encoding='utf-8') as f:
+            json.dump(doc, f, indent=1, sort_keys=True)
+        print(f"  JSON -> {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    import cli_banner
+    cli_banner.install()   # CMD/EXIT self-echo (run-3 B1)
+    sys.exit(main())

--- a/py_tools/check_reachability.py
+++ b/py_tools/check_reachability.py
@@ -113,6 +113,58 @@ def _resolve_pad(pcb, spec):
     return p.global_x, p.global_y, p.net_id, layer
 
 
+def _relief_for(pcb, r, track_mm, clearance):
+    """"So what do I DO?" -- how far the blocking part must move, or nothing.
+
+    Deliberately narrow. It answers only when the two nearest things at the
+    throat are pads belonging to two DIFFERENT footprints, because that is the
+    only case where "move this part" is the shape of the answer. A throat formed
+    by a segment, a via, or two pads of the same part is a different question
+    (rip that copper, re-fan that part) and returning a plausible-looking
+    distance for it would be a wrong instruction, which is worse than none.
+
+    The distance is between the two FOOTPRINT pad bounding boxes, and the need
+    is in GAP space: `track + 2*clearance`, not the track width. Reporting a
+    track-space number here would ask for a move roughly 2*clearance too small.
+    """
+    near = getattr(r, 'near', ()) or ()
+    if len(near) < 2:
+        return []
+    a, b = near[0], near[1]
+    if a.get('kind') != 'pad' or b.get('kind') != 'pad':
+        return []
+    if not a.get('ref') or not b.get('ref') or a['ref'] == b['ref']:
+        return []
+
+    def _bbox(ref):
+        fp = pcb.footprints.get(ref)
+        if not fp or not fp.pads:
+            return None
+        xs0 = [p.global_x - p.size_x / 2.0 for p in fp.pads]
+        ys0 = [p.global_y - p.size_y / 2.0 for p in fp.pads]
+        xs1 = [p.global_x + p.size_x / 2.0 for p in fp.pads]
+        ys1 = [p.global_y + p.size_y / 2.0 for p in fp.pads]
+        return (min(xs0), min(ys0), max(xs1), max(ys1))
+
+    ra, rb = _bbox(a['ref']), _bbox(b['ref'])
+    if not ra or not rb:
+        return []
+    from placement.routability import relief_move
+    need = track_mm + 2.0 * clearance
+    # BOTH movers, not one. The pair is symmetric as geometry but not as a
+    # decision: these are whole-footprint bounding boxes, so a 100-pin QFN and
+    # the 0402 beside it give different distances for the same throat, and
+    # naming only the first-listed one hands the operator "move the QFN" when
+    # nudging the resistor is the cheap answer. Sorted so the smallest move
+    # leads, and each entry says WHICH part it is asking to move.
+    out = [dict(m, ref=b['ref'], against=a['ref'], need_mm=round(need, 5))
+           for m in relief_move(ra, rb, need)]
+    out += [dict(m, ref=a['ref'], against=b['ref'], need_mm=round(need, 5))
+            for m in relief_move(rb, ra, need)]
+    out.sort(key=lambda m: m['min_mm'])
+    return out
+
+
 def main(argv=None):
     p = argparse.ArgumentParser(
         description=__doc__,
@@ -144,7 +196,25 @@ def main(argv=None):
                         "(default 4.0). Reachability is LOCAL; a whole board "
                         "at 10um costs memory for nothing")
     p.add_argument('--view', default=None, help="x0,y0,x1,y1 to override")
-    p.add_argument('--json', action='store_true')
+    p.add_argument('--json', action='store_true',
+                   help="dump the result dict to STDOUT. NOTE stdout also "
+                        "carries this tool's CMD: banner and any parser "
+                        "warning, so `json.load(stdout)` fails at char 0 -- "
+                        "use --json-out for a machine-readable answer.")
+    p.add_argument('--defect-json', metavar='PATH', default=None,
+                   help="write a `defect-record` document here when the "
+                        "verdict is CAGED: the throat coordinates, the "
+                        "blocking refs, the shortfall in BOTH spaces, and a "
+                        "relief distance. render_placement --defect-json draws "
+                        "it; converge record --defect-json carries it; "
+                        "loop_driver L3/L4 read it. Nothing is written for a "
+                        "PASSABLE or NO-TARGET measurement -- a record "
+                        "describes a defect.")
+    p.add_argument('--json-out', metavar='PATH', default=None,
+                   help="write the result dict to PATH. This is the "
+                        "machine-readable channel (the convention every other "
+                        "tool here uses); stdout stays human. Combines with "
+                        "the text output rather than replacing it.")
     args = p.parse_args(argv)
 
     from kicad_parser import parse_kicad_pcb  # _path put py_router on sys.path
@@ -197,14 +267,21 @@ def main(argv=None):
         dr = list_nets.read_design_rules(args.board)
     except Exception:                             # noqa: BLE001
         dr = None
-    def _board(key, fallback):
-        v = list_nets.board_default_netclass_param(args.board, key, dr)
-        return float(v) if v else fallback
-    clearance = args.clearance if args.clearance is not None else _board(
-        'clearance', 0.2)
-    track = args.track if args.track is not None else _board('track_width',
-                                                             0.15)
-    via = args.via if args.via is not None else _board('via_diameter', 0.6)
+    # `board_floor` rather than a local closure: it returns the SOURCE beside
+    # the value ('cli' | 'board netclass' | 'board constraint' | 'fixed
+    # default'), which is what lets the defect record say where each floor came
+    # from instead of publishing three bare numbers a reader cannot audit.
+    floors = {}
+
+    def _board(key, explicit, fallback, label=None):
+        v, src = list_nets.board_floor(args.board, key, explicit=explicit,
+                                       fallback=fallback, design_rules=dr)
+        floors[label or key] = {'value': v, 'source': src}
+        return v
+
+    clearance = _board('clearance', args.clearance, 0.2)
+    track = _board('track_width', args.track, 0.15)
+    via = _board('via_diameter', args.via, 0.6)
     try:
         net_clearances = list_nets.net_clearance_map_by_id(
             args.board, {i: n.name for i, n in pcb.nets.items()}, dr)
@@ -237,12 +314,69 @@ def main(argv=None):
                   f"{args.view!r}", file=sys.stderr)
             return 2
 
+    auto_widened = None
     try:
         r = reachability.pad_reachability(
             pcb, seed, net_name=args.net, net_id=net_id, layers=layers,
             view=view, track_mm=track, via_mm=via, base_clearance=clearance,
             net_clearances=net_clearances, step=args.step,
             margin_mm=args.margin)
+        # run-23: NO-TARGET at the default view means the net's other island
+        # sits beyond --margin, NOT that the question is unanswerable -- and
+        # the manual retry ladder measured badly (--margin 12 took 128s,
+        # --margin 18 306s, --margin 25 timed out at 10 minutes with NO
+        # data, because cells scale as (span/step)^2 at the fixed step).
+        # Locate the nearest other island by VECTOR union-find (no raster),
+        # widen the view to hold seed + its closest point, and coarsen the
+        # step so the grid stays ~1200^2 whatever the span. Coarse-locate;
+        # the step used rides in the result so readings stay comparable --
+        # re-measure a found throat on a small box at native step.
+        if (r.target_cells == 0 and view is None
+                and net_id is not None):
+            import math as _math
+            from net_forensics import _components
+            sx, sy = seed
+            best = None
+            own_d, own_i = None, None
+            comp_pts = []
+            for comp in _components(pcb, net_id):
+                pts = [p for _k, _o, ps in comp for p in ps]
+                if not pts:
+                    continue
+                d = min(_math.hypot(px - sx, py - sy) for px, py in pts)
+                comp_pts.append((d, pts))
+                if own_d is None or d < own_d:
+                    own_d, own_i = d, len(comp_pts) - 1
+            for i, (_d, pts) in enumerate(comp_pts):
+                if i == own_i:
+                    continue
+                for px, py in pts:
+                    dd = _math.hypot(px - sx, py - sy)
+                    if best is None or dd < best[0]:
+                        best = (dd, px, py)
+            if best is not None:
+                _d, px, py = best
+                x0 = min(sx, px) - args.margin
+                x1 = max(sx, px) + args.margin
+                y0 = min(sy, py) - args.margin
+                y1 = max(sy, py) + args.margin
+                span = max(x1 - x0, y1 - y0)
+                step2 = max(args.step, span / 1200.0)
+                print(f"  NO-TARGET at the default +/-{args.margin:g}mm "
+                      f"view; nearest other island of this net is "
+                      f"{best[0]:.2f}mm away -- auto-widening to "
+                      f"[{x0:.1f},{y0:.1f},{x1:.1f},{y1:.1f}] at step "
+                      f"{step2:g}mm")
+                r = reachability.pad_reachability(
+                    pcb, seed, net_name=args.net, net_id=net_id,
+                    layers=layers, view=[x0, y0, x1, y1], track_mm=track,
+                    via_mm=via, base_clearance=clearance,
+                    net_clearances=net_clearances, step=step2,
+                    margin_mm=args.margin)
+                auto_widened = {
+                    'view': [round(v, 2) for v in (x0, y0, x1, y1)],
+                    'step_mm': round(step2, 4),
+                    'nearest_island_mm': round(best[0], 2)}
     except reachability.ScipyRequired as exc:
         print(str(exc), file=sys.stderr)
         return 2
@@ -251,13 +385,77 @@ def main(argv=None):
         return 2
 
     source = 'from --flags' if args.clearance is not None else 'from the board'
+    if args.defect_json:
+        _sha = None
+        try:
+            import hashlib
+            with open(args.board, 'rb') as _fh:
+                _sha = hashlib.sha256(_fh.read()).hexdigest()
+        except OSError:
+            pass
+        _relief = []
+        # A relief distance needs two RECTS, and this tool measures a raster
+        # throat -- so it is offered only when the two nearest things are pads
+        # whose footprints we can bound. Absent rather than guessed: a wrong
+        # "move R7 east by X" is worse than no instruction.
+        try:
+            _relief = _relief_for(pcb, r, track_mm=track, clearance=clearance)
+        except Exception:                                   # noqa: BLE001
+            _relief = []
+        doc = r.defect_record(board=args.board, board_sha=_sha,
+                              relief=_relief, floors=floors)
+        if doc is None:
+            print(f"  no defect record written to {args.defect_json}: this "
+                  f"measurement is {r.to_dict()['verdict']}, and a record "
+                  f"describes a DEFECT")
+        else:
+            try:
+                with open(args.defect_json, 'w', encoding='utf-8') as fh:
+                    json.dump(doc, fh, indent=1)
+                print(f"  DEFECT RECORD -> {args.defect_json}")
+            except OSError as exc:
+                print(f"  could not write {args.defect_json}: {exc}",
+                      file=sys.stderr)
+    _doc = r.to_dict()
+    if auto_widened:
+        # The reading is only comparable at its own step -- say which.
+        _doc['auto_widened'] = auto_widened
+    if args.json_out:
+        try:
+            with open(args.json_out, 'w', encoding='utf-8') as fh:
+                json.dump(_doc, fh, indent=2)
+            print(f"  JSON -> {args.json_out}")
+        except OSError as exc:
+            print(f"  could not write {args.json_out}: {exc}", file=sys.stderr)
     if args.json:
-        print(json.dumps(r.to_dict(), indent=2))
+        print(json.dumps(_doc, indent=2))
     else:
         print(f"board      {os.path.basename(args.board)}")
         print(f"knobs      clearance {clearance}mm, track {track}mm, "
               f"via {via}mm ({source})")
         print(r.format_text())
+        # WHERE, beside how much. The number alone sent run 20 to two more
+        # tools and a hand-assembled paragraph.
+        _t = r.throat
+        if _t:
+            _who = ', '.join(n.get('pad') or f"{n['kind']}@{n['net']}"
+                             for n in (r.near or ()))
+            print(f"throat     ({_t['x']}, {_t['y']}) on {_t['layer']}"
+                  + (f"  between {_who}" if _who else ''))
+            if r.gap_mm is not None:
+                print(f"           gap {r.gap_mm:.4f}mm vs "
+                      f"{r.track_mm + 2 * r.clearance_mm:.4f}mm needed "
+                      f"(gap space); track {r.bottleneck_mm:.4f} vs "
+                      f"{r.track_mm:.4f} (track space) -- same throat, two "
+                      f"spaces, related by 2 x clearance {r.clearance_mm}")
+            if r.caged:
+                _side = max(0.5, 4.0 * (r.track_mm - (r.bottleneck_mm or 0.0)))
+                print(f"look at it:\n"
+                      f"  python3 -X utf8 py_tools/render_placement.py "
+                      f"{os.path.basename(args.board)} --focus \\\n"
+                      f"      --view {_t['x'] - _side / 2:.3f},"
+                      f"{_t['y'] - _side / 2:.3f},{_t['x'] + _side / 2:.3f},"
+                      f"{_t['y'] + _side / 2:.3f} --size 1600")
         if r.target_cells and not r.caged:
             print("\nPASSABLE means a route EXISTS at this width. If the "
                   "router failed here, that is a finding about the router "

--- a/py_tools/net_forensics.py
+++ b/py_tools/net_forensics.py
@@ -161,6 +161,38 @@ def _history(net_name, log_path, out):
         out(f"  (log unreadable: {e})")
 
 
+def net_data(pcb, net):
+    """The islands-and-gap facts as DATA (run-23): what _describe prints.
+
+    Exists because this tool was text-only, so run 23's teammates re-derived
+    the island gap by hand to feed their rip-set decisions -- the number
+    (/TXLED's 20.27mm span) lived in a paragraph nothing could consume.
+    """
+    comps = _components(pcb, net.net_id)
+    doc = {'net': net.name, 'net_id': net.net_id, 'islands': [], 'gap': None}
+    for c in comps:
+        doc['islands'].append({
+            'segs': sum(1 for k, _, _ in c if k == 'seg'),
+            'vias': sum(1 for k, _, _ in c if k == 'via'),
+            'pads': [f"{o.component_ref}.{o.pad_number}"
+                     for k, o, _ in c if k == 'pad'],
+            'layers': sorted({o.layer for k, o, _ in c if k == 'seg'})})
+    if len(comps) >= 2:
+        best = (9e9, None, None)
+        for _k, _o, ps in comps[0]:
+            for p1 in ps:
+                for _k2, _o2, ps2 in comps[1]:
+                    for p2 in ps2:
+                        d = math.hypot(p1[0] - p2[0], p1[1] - p2[1])
+                        if d < best[0]:
+                            best = (d, p1, p2)
+        d, p1, p2 = best
+        doc['gap'] = {'mm': round(d, 3),
+                      'from': [round(p1[0], 3), round(p1[1], 3)],
+                      'to': [round(p2[0], 3), round(p2[1], 3)]}
+    return doc
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__.split('\n')[0])
     ap.add_argument('board')
@@ -168,6 +200,10 @@ def main():
     ap.add_argument('--radius', type=float, default=1.0)
     ap.add_argument('--route-log', action='append', default=[])
     ap.add_argument('--log', help='also append the report to this file')
+    ap.add_argument('--json', metavar='PATH', default=None,
+                    help='also write {nets: [islands+gap docs]} here '
+                         '(run-23: the gap number was text-only and had to '
+                         'be re-derived by hand to feed rip-set decisions)')
     args = ap.parse_args()
 
     from kicad_parser import parse_kicad_pcb
@@ -179,15 +215,24 @@ def main():
         if sink:
             sink.write(line + '\n')
 
+    docs = []
     out(f"# net_forensics: {args.board}")
     for nm in args.nets:
         net = next((x for x in pcb.nets.values() if x.name == nm), None)
         if net is None:
             out(f"\n=== {nm}: NOT FOUND ===")
+            docs.append({'net': nm, 'error': 'not found'})
             continue
         _describe(pcb, net, args.radius, out)
+        docs.append(net_data(pcb, net))
         for lp in args.route_log:
             _history(nm, lp, out)
+    if args.json:
+        import json as _json
+        with open(args.json, 'w', encoding='utf-8') as f:
+            _json.dump({'board': args.board, 'nets': docs}, f, indent=1,
+                       sort_keys=True)
+        out(f"  JSON -> {args.json}")
     if sink:
         sink.close()
 

--- a/py_tools/render_placement.py
+++ b/py_tools/render_placement.py
@@ -235,6 +235,10 @@ def legality_findings(model) -> Dict[str, object]:
     out = {'oob_refs_pad_copper': [], 'oob_refs_courtyard': [],
            'pad_conflict_pairs_refs': [], 'hole_conflict_pairs_refs': [],
            'body_overlap_pairs_refs': [],
+           'courtyard_overlap_pairs_refs': [],
+           'courtyard_blocking_pairs_refs': [],
+           'courtyard_overlap_mm2': 0.0,
+           'cross_side_stacks': [],
            'locked_refs': sorted(r for r, p in model.parts().items()
                                  if getattr(p, 'locked', False))}
     state = getattr(model, 'state', None)
@@ -332,6 +336,52 @@ def legality_findings(model) -> Dict[str, object]:
                     continue
                 if amt > 1e-6:
                     out['oob_refs_courtyard'].append([ref, round(amt, 4)])
+    # run-23: the COURTYARD census, from the one definition in legality
+    # (grade_body_overlap), never a re-derivation. `body_overlap_pairs_refs`
+    # above is PAD intersections -- the name predates this channel -- and the
+    # gap between the two is exactly how a board with J4 0.90mm inside U6
+    # rendered "clean": the checklist had no key for what the picture showed,
+    # so a reader pairing the render with its keys read past it.
+    pcb = getattr(model, 'pcb', None)
+    if pcb is not None:
+        try:
+            from placement.legality import grade_body_overlap
+            _clr = getattr(state, 'clearance', None) or 0.15
+            _g = grade_body_overlap(pcb, _clr,
+                                    pcb_file=getattr(model, 'pcb_file', None))
+            out['courtyard_overlap_pairs_refs'] = [
+                [q.a, q.b, q.area_mm2, q.depth_mm]
+                for q in _g['advisory_pairs'] if q.kind == 'courtyard']
+            out['courtyard_blocking_pairs_refs'] = [
+                [q.a, q.b, q.area_mm2, q.depth_mm]
+                for q in _g['courtyard_blocking_pairs']]
+            out['courtyard_overlap_mm2'] = round(sum(
+                q.area_mm2 for q in _g['pairs'] if q.kind == 'courtyard'), 4)
+            # run-23 (ulx3s review): FRONT<->BACK stacks. Panels draw both
+            # faces' outlines with only a ghost tint, so a battery holder
+            # behind the buttons (BAT1/B4: 68.7mm2 of XY overlap, ZERO
+            # shared-side overlap) is visually indistinguishable from a
+            # collision, and a reviewer's honest eye reports a defect the
+            # census correctly refused to pair. Named here so the sheet can
+            # PRE-ANSWER the question instead of looking blind.
+            from placement.legality import (graded_parts_from_file,
+                                            rect_overlap_area)
+            _gp = [g for g in graded_parts_from_file(
+                       pcb, getattr(model, 'pcb_file', None))
+                   if not g.synthetic]
+            stacks = []
+            for i, ga in enumerate(_gp):
+                for gb in _gp[i + 1:]:
+                    if ga.sides & gb.sides:
+                        continue          # shared face: the census owns it
+                    raw = rect_overlap_area(ga.rect, gb.rect)
+                    if raw >= 1.0:
+                        stacks.append([min(ga.ref, gb.ref),
+                                       max(ga.ref, gb.ref), round(raw, 2)])
+            stacks.sort(key=lambda r: -r[2])
+            out['cross_side_stacks'] = stacks
+        except Exception:
+            pass
     model._legality_findings = out
     return out
 
@@ -417,6 +467,152 @@ def _rect_pts(r, rect):
     return [min(x0, x1), min(y0, y1), max(x0, x1), max(y0, y1)]
 
 
+#: How many device pixels the SHORTFALL must span for a defect panel to be
+#: worth calling a picture of that defect. Below this the two spans -- measured
+#: and required -- are indistinguishable and the panel is a picture of the
+#: neighbourhood, not of the finding.
+DEFECT_MIN_PX = 16
+
+
+def _board_sha(path):
+    """sha256 of a board file, or None. The same binding board_score uses."""
+    try:
+        import hashlib
+        with open(path, 'rb') as fh:
+            return hashlib.sha256(fh.read()).hexdigest()
+    except OSError:
+        return None
+
+
+def load_defect_records(paths, board_sha=None):
+    """Read `defect-record` documents; return (defects, notes).
+
+    Each defect is stamped with the file it came from and the record's board
+    binding. A record whose `board_sha` does not match the board being rendered
+    is DROPPED with a loud note: drawing it would put a measurement from one
+    board on top of another, at coordinates that happen to be valid.
+    """
+    out, notes = [], []
+    for path in (paths or []):
+        try:
+            with open(path, encoding='utf-8') as fh:
+                doc = json.load(fh)
+        except Exception as exc:                            # noqa: BLE001
+            notes.append(f'--defect-json {path}: unreadable ({exc})')
+            continue
+        if doc.get('kind') != 'defect-record':
+            notes.append(f"--defect-json {path}: kind is "
+                         f"{doc.get('kind')!r}, not 'defect-record'")
+            continue
+        sha = doc.get('board_sha')
+        if board_sha and sha and sha != board_sha:
+            notes.append(
+                f'--defect-json {path}: board_sha {sha[:12]} does NOT match '
+                f'this board ({board_sha[:12]}) -- SKIPPED. Drawing it would '
+                f'put one board\'s measurement on another at coordinates that '
+                f'happen to be valid.')
+            continue
+        if board_sha and not sha:
+            notes.append(f'--defect-json {path}: no board_sha, so it cannot be '
+                         f'proven to describe this board -- drawn anyway')
+        for d in (doc.get('defects') or []):
+            out.append(dict(d, _source=path))
+    return out, notes
+
+
+def defect_view(defect, size_px, min_px=DEFECT_MIN_PX):
+    """(view, px_per_mm, shortfall_px) for one defect -- or (None, ...).
+
+    NOT A NEW ZOOM. `--view`, `--zoom-group` and `--focus` have all been here
+    for a long time and are good; the whole board at --size 1600 is ~35 px/mm,
+    where a 41 um defect is 1.4 px, and `--view` around the throat fixes that
+    in one flag. What was missing was the TARGET and the AMOUNT:
+
+      * the target -- the throat coordinate was computed inside `widest_path`
+        and thrown away at `return float(val)`, so nothing could tell you where
+        to point `--view`. The only coordinate `check_reachability` printed was
+        the SEED pad, and on run 20 the throat was 0.66 mm from it.
+      * the amount -- there was no rule for how tight to crop, and no feedback
+        on whether the finding was resolvable in the box you chose.
+
+    So this derives the view from the MEASUREMENT: tighten until `short_mm`
+    spans `min_px`. At size 1600 and short 0.0405 mm that is a 4.05 mm box,
+    which still frames both blocking pads. The caller can always override it
+    with `--view`; this only removes the guesswork.
+    """
+    at = defect.get('at') or {}
+    if at.get('x') is None or at.get('y') is None:
+        return None, None, None
+    short = ((defect.get('measure') or {}).get('short_mm')) or 0.0
+    if short <= 0:
+        # No shortfall to size against (a defect kind that does not carry one).
+        # Fall back to the record's own view rather than inventing a scale.
+        v = defect.get('view')
+        if not v:
+            return None, None, None
+        side = max(v[2] - v[0], v[3] - v[1])
+    else:
+        side = min(short * size_px / float(min_px),
+                   max((defect.get('view') or [0, 0, 4, 4])[2]
+                       - (defect.get('view') or [0, 0, 4, 4])[0], 0.5))
+        side = max(side, 4.0 * short)      # never so tight the span leaves frame
+    half = side / 2.0
+    view = (at['x'] - half, at['y'] - half, at['x'] + half, at['y'] + half)
+    ppmm = size_px / side if side else 0.0
+    return view, ppmm, (short * ppmm if short else 0.0)
+
+
+def draw_defects(d, r, defects):
+    """A ring at the throat, the MEASURED span solid, the REQUIRED span dashed.
+
+    At the scale `defect_view` picks, those two differ by >= DEFECT_MIN_PX --
+    which is the whole reason the crop is sized from the measurement instead of
+    from the parts.
+    """
+    for x in defects:
+        at = x.get('at') or {}
+        if at.get('x') is None:
+            continue
+        cx, cy = r.tf.pt(at['x'], at['y'])
+        rad = max(6, _w(r, ((x.get('measure') or {}).get('gap_mm') or 0.2) / 2.0))
+        d.ellipse([cx - rad, cy - rad, cx + rad, cy + rad],
+                  outline=(255, 64, 64), width=max(2, _w(r, 0.01)))
+        span = x.get('span') or {}
+        a, b = span.get('a') or {}, span.get('b') or {}
+        if a.get('x') is None or b.get('x') is None:
+            continue
+        p0, p1 = r.tf.pt(a['x'], a['y']), r.tf.pt(b['x'], b['y'])
+        d.line([p0[0], p0[1], p1[0], p1[1]], fill=(255, 64, 64),
+               width=max(2, _w(r, 0.012)))
+        # The REQUIRED span: the same direction, scaled to what was needed.
+        m = x.get('measure') or {}
+        have, need = m.get('gap_mm'), m.get('gap_need_mm')
+        if not have or not need or have <= 0:
+            continue
+        k = float(need) / float(have)
+        mx, my = (p0[0] + p1[0]) / 2.0, (p0[1] + p1[1]) / 2.0
+        q0 = (mx + (p0[0] - mx) * k, my + (p0[1] - my) * k)
+        q1 = (mx + (p1[0] - mx) * k, my + (p1[1] - my) * k)
+        # ALONGSIDE, not on top. `need/have` here is 1.09, so the required span
+        # drawn from the same midpoint lies almost entirely over the measured
+        # one and the reader sees dashes with a little red at the ends -- the
+        # comparison the panel exists to make, hidden by the drawing order.
+        # Offset perpendicular by a few pixels and the two are two lines.
+        dx, dy = q1[0] - q0[0], q1[1] - q0[1]
+        _L = math.hypot(dx, dy) or 1.0
+        _off = max(5, _w(r, 0.02) * 3)
+        nx, ny = -dy / _L * _off, dx / _L * _off
+        _dash(d, (q0[0] + nx, q0[1] + ny), (q1[0] + nx, q1[1] + ny),
+              max(6, _w(r, 0.05)), max(4, _w(r, 0.03)),
+              (255, 200, 64), max(2, _w(r, 0.012)))
+        # End caps, so the two lengths can be compared at their ends rather
+        # than eyeballed along their middles.
+        for _q in (q0, q1):
+            d.line([_q[0] + nx * 0.2, _q[1] + ny * 0.2,
+                    _q[0] + nx * 1.8, _q[1] + ny * 1.8],
+                   fill=(255, 200, 64), width=max(2, _w(r, 0.012)))
+
+
 def _dash(d, p0, p1, on_px, off_px, fill, width):
     """PIL has no dashed line."""
     x0, y0 = p0
@@ -460,6 +656,7 @@ def draw_courtyards(d, r, model, refs, *, side=None, color=None, dim=False,
 
 C_CONFLICT = (255, 64, 64)      # pad/hole legality conflicts
 C_HOLE = (255, 160, 64)         # NPTH keepout circles
+C_COURT_OVL = (255, 120, 40)    # run-23: courtyard-blocking interpenetration
 
 
 def draw_legality(d, r, model, *, side=None):
@@ -536,6 +733,29 @@ def draw_legality(d, r, model, *, side=None):
                   min(ea[2], eb[2]), min(ea[3], eb[3]))
             if ix[2] > ix[0] and ix[3] > ix[1]:
                 d.rectangle(_rect_pts(r, ix), fill=C_CONFLICT)
+    # run-23: courtyard-BLOCKING pairs (unwaived interpenetration past the
+    # area+depth floors). Courtyards render as thin gray outlines, which
+    # makes real overlap visually indistinguishable from legal tight packing
+    # -- run-23's board WAS viewed (at L3, with the census in the banner) and
+    # still read clean. Filled intersection + the pair named ON the image, so
+    # the defect lives in pixels, not only in a key.
+    for a, bb, _mm2, _dep in fnd.get('courtyard_blocking_pairs_refs', ()):
+        ra = model.rect(a)
+        rb = model.rect(bb)
+        if ra is None or rb is None:
+            continue
+        for rect in (ra, rb):
+            d.rectangle(_rect_pts(r, rect), outline=C_COURT_OVL,
+                        width=_w(r, 0.16))
+        ix = (max(ra[0], rb[0]), max(ra[1], rb[1]),
+              min(ra[2], rb[2]), min(ra[3], rb[3]))
+        if ix[2] > ix[0] and ix[3] > ix[1]:
+            box = _rect_pts(r, ix)
+            d.rectangle(box, fill=C_COURT_OVL)
+            _size = max(10, _w(r, 1.0, floor=10))
+            d.text((min(box[0], box[2]), max(0, min(box[1], box[3]) - _size - 2)),
+                   f"{a}<->{bb} {_mm2}mm2", fill=C_COURT_OVL,
+                   font=load_font(_size))
 
 
 def draw_ghosts(d, r, model, moves, *, width_mm=0.1):
@@ -634,7 +854,7 @@ class PanelSpec:
 
     def __init__(self, model, *, view=None, side=None, prominent=(), moves=(),
                  hot_nets=(), blocker_nets=(), pick_nets=(), label='',
-                 opts=None):
+                 opts=None, defects=()):
         self.model = model
         self.view = view
         self.side = side
@@ -643,6 +863,7 @@ class PanelSpec:
         self.hot_nets = set(hot_nets)
         self.blocker_nets = set(blocker_nets)
         self.pick_nets = set(pick_nets)     # ids, from --ratsnest-nets
+        self.defects = list(defects)        # from --defect-json
         self.label = label
         self.o = opts or {}
 
@@ -704,9 +925,137 @@ def overlay_for(spec: PanelSpec):
             draw_arrows(d, r, spec.moves)
         if o.get('labels', True):
             draw_ref_labels(d, r, m, prom)
+        if spec.defects:
+            # LAST. A defect panel exists to show one thing; a ratsnest or a
+            # ref label drawn over it would be the picture failing at its only
+            # job.
+            draw_defects(d, r, spec.defects)
         if o.get('legend', True):
             draw_legend(d, r, spec)
     return _draw
+
+
+def connector_edge_facts(model) -> List[list]:
+    """[ref, class, nearest_edge, dist_mm] for every connector-family part.
+
+    Presentation-only (the review sheet's facts strip) -- a heuristic by
+    footprint name plus the part_class edge classes, deliberately broader
+    than part_class's gating classes: run 23 seated J2/J5/J6/J7 mid-board
+    and NO instrument said so, because generic connectors carry no class.
+    Nothing gates on this list; it exists so a reviewer sees the distances
+    without deriving them.
+    """
+    from placement.part_class import INTERIOR_AFFINITY_MM, classify_part
+    pcb = getattr(model, 'pcb', None)
+    bounds = getattr(getattr(pcb, 'board_info', None), 'board_bounds', None)
+    if pcb is None or not bounds:
+        return []
+    _NAME_TOKENS = ('conn', 'pinheader', 'header', 'socket', 'jst', 'molex',
+                    'terminal', 'usb', 'jack', 'receptacle')
+    out = []
+    for ref, fp in sorted((pcb.footprints or {}).items()):
+        name = (getattr(fp, 'footprint_name', '') or '').lower()
+        cls = None
+        try:
+            cls = classify_part(fp, ref).name
+        except Exception:
+            cls = None
+        if not (cls in ('edge_receptacle', 'edge_actuator')
+                or any(t in name for t in _NAME_TOKENS)):
+            continue
+        rect = model.rect(ref)
+        if rect is None:
+            continue
+        dists = {'W': rect[0] - bounds[0], 'N': rect[1] - bounds[1],
+                 'E': bounds[2] - rect[2], 'S': bounds[3] - rect[3]}
+        edge, dist = min(dists.items(), key=lambda kv: kv[1])
+        d = round(max(0.0, dist), 2)
+        out.append([ref, cls or 'connector', edge, d,
+                    bool(d > INTERIOR_AFFINITY_MM)])
+    return out
+
+
+def write_review_sheet(path, panel_paths, fnd, conn_facts) -> None:
+    """ONE image for the boundary review: F+B panels over a facts strip.
+
+    The panels already carry the courtyard-interpenetration overlay; the
+    strip adds what no panel can show spatially -- the census with numbers,
+    and each connector's distance to its nearest edge (INTERIOR flagged at
+    > 3mm). Run 23's reviewer had these facts spread over two panels and a
+    JSON, and the looking stopped at the spread.
+    """
+    from PIL import Image
+    imgs = [Image.open(p).convert('RGB') for p in panel_paths if p]
+    if not imgs:
+        raise ValueError('no panels to compose')
+    h = max(i.height for i in imgs)
+    imgs = [i if i.height == h
+            else i.resize((max(1, int(i.width * h / i.height)), h))
+            for i in imgs]
+    W = sum(i.width for i in imgs)
+
+    lines = []
+    cb = fnd.get('courtyard_blocking_pairs_refs') or []
+    cs = fnd.get('courtyard_overlap_pairs_refs') or []
+    # Count the BLOCKING list, not "unwaived": waiver-voided pairs (dead
+    # edge waivers, locked members) gate while staying labeled waived, so
+    # the two counts legitimately differ and the blocking one is the
+    # headline.
+    lines.append(
+        f"courtyard census {fnd.get('courtyard_overlap_mm2', 0)}mm2 "
+        f"({len(cs)} unwaived advisory)"
+        # '  |  '-separated, not comma: the strip wrapper breaks lines at
+        # that separator, and a comma-joined blocking list ran off the sheet
+        # unwrappable (found on the 10-pair run-23 board).
+        + (f"  |  BLOCKING ({len(cb)}): " + '  |  '.join(
+            f"{a}<->{b} {m}mm2/depth {dp}mm" for a, b, m, dp in cb)
+           if cb else "  |  blocking: none"))
+    if conn_facts:
+        chunk = []
+        for ref, _cls, edge, dist, interior in conn_facts:
+            tag = 'INTERIOR ' if interior else ''
+            chunk.append(f"{ref} {tag}{dist}mm {edge}")
+        lines.append("connectors, dist to nearest edge: " + '  |  '.join(chunk))
+    else:
+        lines.append("connectors: none recognised (name heuristic)")
+    xs = fnd.get('cross_side_stacks') or []
+    if xs:
+        # Pre-answer the reviewer's eye: these LOOK like collisions in the
+        # panels (both faces' outlines share the picture) and are not.
+        lines.append(
+            "front<->back stacks (opposite faces, NOT a conflict): "
+            + '  |  '.join(f"{a} over {b} {m}mm2" for a, b, m in xs[:14])
+            + (f"  |  +{len(xs) - 14} more" if len(xs) > 14 else ""))
+
+    font = load_font(max(14, h // 60))
+    lh = int(font.size * 1.5)
+    # crude width wrap: split any line the strip cannot hold
+    probe = ImageDraw.Draw(imgs[0])
+    wrapped = []
+    for ln in lines:
+        while probe.textlength(ln, font=font) > W - 20 and '  |  ' in ln:
+            # cut at the separator nearest the width limit
+            parts = ln.split('  |  ')
+            keep, rest = [parts[0]], parts[1:]
+            while rest and probe.textlength(
+                    '  |  '.join(keep + rest[:1]), font=font) <= W - 20:
+                keep.append(rest.pop(0))
+            wrapped.append('  |  '.join(keep))
+            ln = '  |  '.join(rest)
+            if not rest:
+                ln = ''
+        if ln:
+            wrapped.append(ln)
+    strip_h = lh * len(wrapped) + 16
+    sheet = Image.new('RGB', (W, h + strip_h), (10, 10, 10))
+    x = 0
+    for i in imgs:
+        sheet.paste(i, (x, 0))
+        x += i.width
+    d = ImageDraw.Draw(sheet)
+    for i, ln in enumerate(wrapped):
+        d.text((10, h + 8 + i * lh), ln, fill=(235, 235, 235), font=font)
+    sheet.save(path)
 
 
 def draw_legend(d, r, spec) -> None:
@@ -722,15 +1071,24 @@ def draw_legend(d, r, spec) -> None:
     Only the keys this panel can actually show are drawn -- a legend listing
     arrows on a panel with no --before is itself misinformation.
     """
-    rows = [(C_CONFLICT, 'dashed', 'pad copper off-board'),
-            (C_CONFLICT, 'ring', 'pad/hole clearance short'),
-            (C_CONFLICT, 'solid', 'BODY STACK - parts overlap'),
-            (C_HOLE, 'ring', 'NPTH keepout'),
-            (C_LOCKED, 'hatch', 'KiCad-locked (never moved)')]
-    if spec.moves:
-        rows.append((C_ARROW, 'arrow', 'moved since --before'))
-    if spec.hot_nets:
-        rows.append((C_AIR_FAIL, 'line', 'failed net'))
+    if getattr(spec, 'defects', None):
+        # A defect panel's marks are its whole point, so they are the ONLY
+        # legend on it. Listing the legality key beside them would invite the
+        # reader to hunt for findings the crop was not sized to show.
+        rows = [(C_CONFLICT, 'solid', 'MEASURED gap (the throat)'),
+                ((255, 200, 64), 'dashed', 'REQUIRED gap (what would fit)'),
+                (C_CONFLICT, 'ring', 'throat location')]
+    else:
+        rows = [(C_CONFLICT, 'dashed', 'pad copper off-board'),
+                (C_CONFLICT, 'ring', 'pad/hole clearance short'),
+                (C_CONFLICT, 'solid', 'BODY STACK - parts overlap'),
+                (C_COURT_OVL, 'solid', 'courtyard interpenetration'),
+                (C_HOLE, 'ring', 'NPTH keepout'),
+                (C_LOCKED, 'hatch', 'KiCad-locked (never moved)')]
+        if spec.moves:
+            rows.append((C_ARROW, 'arrow', 'moved since --before'))
+        if spec.hot_nets:
+            rows.append((C_AIR_FAIL, 'line', 'failed net'))
     try:
         # Overlays draw on the SUPERSAMPLED canvas, which is `ss` times the
         # output size -- so `r.H` (the output height) put the legend at 1/ss of
@@ -1139,6 +1497,20 @@ Examples:
                    help='how blocks are derived (default: auto = kicad,sheet)')
     p.add_argument('--list-groups', action='store_true',
                    help='list the blocks --group-by would derive, and exit')
+    p.add_argument('--defect-json', action='append', default=None,
+                   metavar='PATH',
+                   help='a `defect-record` document (check_reachability '
+                        '--defect-json). Repeatable. This is --view with the '
+                        'guesswork removed, NOT a new zoom: it takes the '
+                        'throat COORDINATE from the record (nothing else '
+                        'publishes it) and derives the box size from the '
+                        'measured shortfall. Each defect gets its own '
+                        'panel, cropped tight enough that the SHORTFALL is at '
+                        'least 16 px -- a 41um throat on a 34mm board at the '
+                        'default scale is 1.2 px, which is why run 20 had '
+                        'renders of the right board that could not show the '
+                        'defect. Records whose board_sha does not match are '
+                        'reported and skipped.')
     p.add_argument('--focus', action='store_true',
                    help='also emit one cropped panel per failed-net cluster')
     p.add_argument('--focus-gap', type=float, default=10.0, metavar='MM')
@@ -1148,6 +1520,12 @@ Examples:
                    help='force an F and a B panel (run-6: boards with '
                         'back-side parts get per-side panels by DEFAULT; '
                         'this flag only matters with --flat semantics)')
+    p.add_argument('--side', choices=('F', 'B'), default=None,
+                   help='render ONLY this side\'s panel (run-23: there was '
+                        'no way to ask for one face -- the choices were both '
+                        'panels or --flat, which mixes the faces into one '
+                        'image). Overrides --per-side/--flat; the review '
+                        'sheet then carries the one panel.')
     p.add_argument('--flat', action='store_true',
                    help='one flattened panel even when the board has '
                         'back-side parts (the pre-run-6 default; a B part '
@@ -1231,7 +1609,25 @@ Examples:
                         "JSON checklist then carries d={moved, expected, "
                         "match} -- mandate 8's question (d), quotable instead "
                         'of recalled (run-4 G5)')
-    p.add_argument('--quiet', action='store_true')
+    p.add_argument('--quiet', action='store_true',
+                   help='suppress narration. With --json-out it now also '
+                        'suppresses the stdout JSON_SUMMARY echo and the '
+                        'describe text (the file carries both): blind-first '
+                        'reviews depend on the IMAGE preceding the keys, and '
+                        'the unconditional echo defeated that in the very '
+                        'command the review gates prescribe (run 24, A-1). '
+                        'Without --json-out the summary line still prints -- '
+                        'data is never silenced into nowhere.')
+    p.add_argument('--review-sheet', metavar='PATH', default=None,
+                   help='run-23: ALSO write ONE composite image built for the '
+                        'boundary review -- F and B side by side (with the '
+                        'courtyard-interpenetration overlay both panels '
+                        'already carry) over a facts strip: the courtyard '
+                        'census with mm2/depth, and every connector-family '
+                        'part with its distance-to-nearest-edge (INTERIOR '
+                        'flagged). Exists because the facts a reviewer needs '
+                        'were spread over two panels and a JSON, and run 23 '
+                        'proved that spread is where the looking stops.')
     return p
 
 
@@ -1469,6 +1865,9 @@ def main(argv=None):
         sides = (None,)
         if not args.quiet:
             print("  (no back-side footprints and no B.Cu: skipping the B panel)")
+    if args.side:
+        # ONE face, explicitly asked for: overrides the split heuristics.
+        sides = (args.side,)
 
     panels = []
     if before_model is not None:
@@ -1489,8 +1888,58 @@ def main(argv=None):
                                 label=(f"AFTER {tag}" if before_model is not None
                                        else tag),
                                 opts=opts))
+    # DEFECT PANELS FIRST, and before either --focus branch. A defect record
+    # carries an AUTHORITATIVE coordinate -- the instrument that measured the
+    # throat says where it is -- where `cluster_points` derives a view from pad
+    # positions and its own docstring apologises for exactly that. When both
+    # are available the measured one wins.
+    _defects, _dnotes = load_defect_records(
+        getattr(args, 'defect_json', None), board_sha=_board_sha(args.board))
+    for _n in _dnotes:
+        print(f'  {_n}', file=sys.stderr)
+    _defect_panels = []
+    for i, _dx in enumerate(_defects):
+        _dv, _ppmm, _spx = defect_view(_dx, args.size)
+        if _dv is None:
+            print(f'  --defect-json: defect {i + 1} carries no `at` coordinate '
+                  f'and no view -- no panel', file=sys.stderr)
+            continue
+        _m = _dx.get('measure') or {}
+        _who = '<->'.join((_dx.get('pads') or _dx.get('refs') or ['?'])[:2])
+        # The HONESTY LINE. If the shortfall still does not span the threshold
+        # the caption says so instead of shipping a picture that implies it does.
+        _scale = (f'{_ppmm:.0f} px/mm -> {_spx:.0f} px'
+                  if _spx >= DEFECT_MIN_PX - 0.5
+                  else f'{_ppmm:.0f} px/mm -> {_spx:.1f} px INVISIBLE AT THIS '
+                       f'SCALE')
+        _lbl = (f"defect {i + 1}/{len(_defects)} {_dx.get('kind', '?')} {_who}"
+                + (f" | {_m['gap_mm']:.4f}/{_m['gap_need_mm']:.4f}mm short "
+                   f"{1000.0 * _m['short_mm']:.1f}um"
+                   if _m.get('gap_mm') is not None
+                   and _m.get('short_mm') is not None else '')
+                + f' | {_scale}')
+        # The record names a COPPER LAYER; this tool's `side` vocabulary is
+        # 'F'/'B'/None. Passing 'F.Cu' through compared unequal to every part's
+        # side and dimmed the whole crop. An inner-layer throat has no side, so
+        # both are drawn at full brightness -- which is the honest answer.
+        _lay = ((_dx.get('at') or {}).get('layer') or '')
+        _side = {'F.Cu': 'F', 'B.Cu': 'B'}.get(_lay)
+        _defect_panels.append(PanelSpec(
+            model, view=_dv, side=_side,
+            prominent=set(_dx.get('refs') or ()) or prominent, moves=moves,
+            hot_nets=failed, blocker_nets=blockers, pick_nets=pick,
+            defects=[_dx],
+            # Airwires OFF on a defect panel. They are the biggest source of
+            # visual noise on a dense board and here they cross the finding
+            # itself -- on the run-20 crop, a dozen grey lines through the one
+            # 16-px measurement the panel exists to show. The label already
+            # names the net, which is what the ratsnest would have told you.
+            opts=dict(opts, ratsnest=False),
+            label=_lbl))
+    panels.extend(_defect_panels)
+
     _leg_pockets = []
-    if args.focus and not args.summary_json:
+    if args.focus and not args.summary_json and not _defect_panels:
         # Run-4 G7 made --focus warn here, because its clusters came from the
         # route summary's failed nets and without one it emitted a single panel
         # and said nothing. But the same question -- one pocket or scattered --
@@ -1603,6 +2052,26 @@ def main(argv=None):
             'moved_refs': [{'reference': m['reference'],
                             'dist': round(m['dist'], 4)} for m in moves],
             'failed_nets': sorted(failed), 'blocker_nets': sorted(blockers),
+            # The defects this render was ASKED to show, and what it managed
+            # to show them at. `shortfall_px` is the honesty figure: a reader
+            # (or `_guard_route_render`) can tell a picture OF the defect from
+            # a picture of its neighbourhood without opening the png.
+            'defects': [{'kind': dx.get('kind'), 'net': dx.get('net'),
+                         'refs': dx.get('refs'), 'pads': dx.get('pads'),
+                         'at': dx.get('at'),
+                         'short_mm': (dx.get('measure') or {}).get('short_mm'),
+                         'source': dx.get('_source')} for dx in _defects],
+            'defect_panels': [
+                {'label': sp.label, 'view': sp.view,
+                 'px_per_mm': (round(args.size / (sp.view[2] - sp.view[0]), 2)
+                               if sp.view and sp.view[2] > sp.view[0] else None),
+                 'shortfall_px': (round(
+                     ((sp.defects[0].get('measure') or {}).get('short_mm') or 0)
+                     * args.size / (sp.view[2] - sp.view[0]), 2)
+                     if sp.view and sp.view[2] > sp.view[0] and sp.defects
+                     else None),
+                 'min_px': DEFECT_MIN_PX}
+                for sp in _defect_panels],
             'metrics': dict(model.metrics),
             # The instrument block (run-4 G2): two renders of the SAME board
             # differing only in --ignore-nets read 632 vs 412 crossings in
@@ -1614,6 +2083,13 @@ def main(argv=None):
                 'before': os.path.abspath(args.before) if args.before else None,
                 'summary_json': (os.path.abspath(args.summary_json)
                                  if args.summary_json else None),
+                # Mirrors summary_json, so a gate can assert a defect render
+                # was made from a record the same way _guard_route_render
+                # already asserts a focus render was made from a route log.
+                'defect_json': [os.path.abspath(x)
+                                for x in (getattr(args, 'defect_json', None)
+                                          or [])],
+                'defect_notes': _dnotes,
                 # `clearance` used to record args.clearance, i.e. None on
                 # every run that did not pass the flag -- so the document
                 # named no clearance at all for the runs most likely to be
@@ -1646,6 +2122,23 @@ def main(argv=None):
                 # reports what the old name promised.
                 'b_pad_clearance_pairs': fnd['pad_conflict_pairs_refs'],
                 'b_body_overlap_pairs': fnd['body_overlap_pairs_refs'],
+                # run-23 key honesty, same lesson again: b_body_overlap_pairs
+                # is PAD intersections (see the run-6 note above), so a reader
+                # auditing "overlap" against it concluded there was none while
+                # J4 stood 0.90mm inside U6's courtyard. The courtyard channel
+                # now has its own keys: [a, b, area_mm2, depth_mm] rows, the
+                # census unwaived (advisory) and the blocking subset (past the
+                # legality.COURTYARD_BLOCKING_* floors, synthetic excluded).
+                'b_courtyard_overlap_pairs':
+                    fnd['courtyard_overlap_pairs_refs'],
+                'b_courtyard_blocking_pairs':
+                    fnd['courtyard_blocking_pairs_refs'],
+                'b_courtyard_overlap_mm2': fnd['courtyard_overlap_mm2'],
+                # FRONT<->BACK stacks: XY overlap with NO shared face --
+                # deliberate on real boards (ulx3s: the battery holder
+                # behind the buttons), never a conflict, listed so a reader
+                # of the render does not mistake them for one.
+                'b_cross_side_stacks': fnd['cross_side_stacks'],
                 'c_hole_conflicts': fnd['hole_conflict_pairs_refs'],
                 'c_locked_refs': fnd['locked_refs'],
                 'd_moved': {'moved': len(moves),
@@ -1655,20 +2148,38 @@ def main(argv=None):
             },
             'unplaced': state.unplaced, 'no_outline': model.no_outline,
         }
+        if args.review_sheet:
+            _full = [pp['path'] for pp in doc['panels']
+                     if pp.get('view') is None][:2]
+            try:
+                write_review_sheet(args.review_sheet, _full, fnd,
+                                   connector_edge_facts(model))
+                doc['review_sheet'] = args.review_sheet
+                print(f"  review sheet -> {args.review_sheet}")
+            except Exception as exc:                            # noqa: BLE001
+                # The sheet is an aid, never the render's own gate -- but a
+                # silent miss would read as "no sheet requested".
+                doc['review_sheet'] = None
+                print(f"  review sheet FAILED: {exc}", file=sys.stderr)
+        _quiet = bool(args.quiet and args.json_out)
         if not args.no_describe:
             _txt, _dj = describe(model, legality_findings(model), moves, args,
                                  [p['path'] for p in doc['panels']])
             doc['describe'] = _dj
-            print()
-            print(_txt)
+            if not _quiet:
+                print()
+                print(_txt)
             if before_model is not None:
                 _ptxt, _pj = describe_pair(before_model, model, args)
                 doc['pair'] = _pj
-                print(_ptxt)
+                if not _quiet:
+                    print(_ptxt)
         if args.json_out:
             with open(args.json_out, 'w', encoding='utf-8') as f:
                 json.dump(doc, f, indent=2, sort_keys=True, default=str)
-        print("JSON_SUMMARY: " + json.dumps(doc, sort_keys=True, default=str))
+        if not _quiet:
+            print("JSON_SUMMARY: " + json.dumps(doc, sort_keys=True,
+                                                default=str))
         if args.gate:
             # Opt-in verdict. The default stays 0 on purpose -- SEEING an
             # unplaced or broken board is this tool's job, and a renderer that
@@ -1688,6 +2199,17 @@ def main(argv=None):
                 'c_hole_conflicts':
                     len(doc['checklist']['c_hole_conflicts']),
             }
+            # run-23: courtyard blocking gates MOVED-relative, mirroring
+            # check_assembly's currency -- healthy boards ship by-design
+            # interpenetrations (measured: 5 of 34 corpus boards), so the
+            # census gates only where --before shows a member moved. Without
+            # --before the census stays report-only in the checklist.
+            if before_model is not None:
+                _mv = {m['reference'] for m in moves}
+                _cb = [row for row in
+                       doc['checklist']['b_courtyard_blocking_pairs']
+                       if row[0] in _mv or row[1] in _mv]
+                _fail['b_courtyard_blocking_pairs(moved)'] = len(_cb)
             _hit = {k: v for k, v in _fail.items() if v}
             _moved = doc['checklist']['d_moved']
             if _moved.get('match') is False:

--- a/tests/TEST_HEALTH.md
+++ b/tests/TEST_HEALTH.md
@@ -1,0 +1,253 @@
+# Test health
+
+What was red, why, and what was done about it. Written so the next reader can
+tell a genuinely-skipped test from an abandoned one — and can disagree with a
+judgement call without re-deriving it.
+
+**The rule every entry here was held to:** a test that stops failing must stop
+failing because the thing it tests got fixed, or because the test was asserting
+something untrue. Deleting it, loosening an assertion, or blanket-skipping a
+class are all ways of making the suite lie.
+
+---
+
+## Prerequisites this suite needs
+
+| what | why | if missing |
+|---|---|---|
+| `rust_router/grid_router.pyd` | every routing test imports it via `py_router/route.py` | `python3 build_router.py` — downloads the published binary, no cargo needed. **It is `.gitignore`d**, so a fresh clone has none and ~110 tests fail until it is built. This is the single biggest difference between a fresh clone and a working tree. |
+| `pcbnew`, `wx` | `tests/gui_parity/` only | those gates cannot run; they are the legitimate `SKIP_EXIT` candidates. Nothing outside `gui_parity/` needs them. |
+| `scipy`, `numpy`, `shapely`, `PIL`, `matplotlib` | assorted | present in a normal dev env |
+
+Untracked artifacts also matter: `.gitignore` excludes `wk/` and most generated
+`kicad_files/*`, so a fresh worktree fails tests a working tree passes. That is
+environment, not regression — check it before diagnosing anything.
+
+## How to skip honestly
+
+`tests/run_all.py` defines `SKIP_EXIT = 77`. A test that **cannot** run prints
+`SKIP: <reason>` and exits 77. It then lands in its own bucket, is reported
+under *"SELF-SKIPPED (n) — these asserted NOTHING; they are not passes"*, and
+**still forces a non-zero exit**. Use it only when a prerequisite is genuinely
+absent.
+
+Do **not** use `--fast` exclusion as a skip: those land in the `skipped` bucket,
+which prints no reason and never appears under that banner.
+
+## How to declare a long runtime
+
+`RUN_ALL_TIMEOUT = <seconds>` at module scope. Read from the source (never by
+importing — importing a test runs it), and it can only raise the budget, never
+lower it below the global `--timeout`. Put the measurement in the comment beside
+it.
+
+---
+
+## The 2026-08-19 sweep: 22 failures + 3 timeouts, all pre-existing
+
+None was introduced by `run22-honesty-fixes`. Established by running four at
+base `798b11a3` in the same working tree and getting identical exit codes *and*
+identical failure text, and by diffing the product module each test exercises
+against base.
+
+### Class 1 — the #522 reorg (18 tests, one bug)
+
+`ee860796` (2026-08-04) moved the CLIs out of the repo root into `py_router/`,
+`py_placer/`, `py_tools/`. These tests kept spawning
+`os.path.join(ROOT, 'route.py')`. Python exits **2** with `can't open file …:
+[Errno 2]` on **stderr**, and they all assert on **stdout** — so the class
+surfaced as a bare `AssertionError` with an empty message that reads exactly
+like a product failure.
+
+**Fixed** by `run_utils.tool()` / `tool_env()`, delegating to the resolver the
+repo already ships (`krt_capabilities._tool_path`). `tool()` **raises**, naming
+what it looked for and where — a moved tool must fail at the call site, not
+three frames away inside a subprocess. A static lint cannot do this job:
+`test_431_board_gates` builds `os.path.join(ROOT, script)` with `script` a
+variable, so the bad path is only knowable at runtime. **The raising resolver is
+the gate.**
+
+**What it uncovered — the actual value:**
+
+- `test_soft_joint` — four checks expecting `n == 0` passed only because the
+  subprocess produced no output at all. Five of ten were vacuous; all ten now
+  run and pass.
+- `test_457_startup_checks` — asserted `returncode == 1`, which a
+  `ModuleNotFoundError` also satisfies. Exactly the false-clean that
+  `run_utils._ACCIDENTS` exists to catch, in a file that never used it.
+- `test_protect_nets_flag`'s surviving unit test was **doubly stale underneath
+  the dead one**: its fake pcb lacked `segments`/`vias` (added by #521) and set
+  `_protection_map_cache` after that memo was renamed `_protection_map_memo`, so
+  it silently supplied *no* protection and every net read as rippable. It could
+  not have passed for a long time and nobody could see it, because the
+  `--protect-nets` function beside it crashed first.
+
+**Latent, not churned:** eight files still use `PYTHONPATH=ROOT`
+(`test_place_reconstruct`, `test_run4_anchors_first`, `test_run4_reconstruct`,
+`test_run5_emit_guard` and others). All currently green, so they are recorded
+here rather than changed while they pass.
+
+### Class 2 — stale fixtures
+
+`11f6d48f` (2026-08-16) gave tigard a `.kicad_pro`; `ada4ca87` corrected
+`list_nets`' docstring but not the two tests still using tigard as their
+"declares nothing" example — the 8-check failure in `test_run12_tools` and one
+in `test_board_floors`.
+
+Repointed to `splitflap_driver` (no `.kicad_pro` tracked **or** on disk; only
+four are tracked at all: `flat_hierarchy`, `routed_output`, `tigard`, `watchy`,
+so a fresh clone agrees).
+
+**The first repoint was too broad and the tests caught it.** `NO_FLOOR_BOARD`
+was doing double duty and the channel/stack cases depend on tigard's actual refs
+(`KeyError: 'J2'`). Split into `NO_FLOOR_BOARD` (declares nothing) and
+`GEOM_BOARD` (real geometry). Changing a fixture used for two purposes to fix
+one of them is a goalpost move; the split is not.
+
+`assert_still_undeclared` is the anti-rot guard, and it is **mutation-tested**:
+pointed at tigard it fails with *"FIXTURE ROT … now DECLARES (1 class(es), 3
+constraint(s))"*, and passes on the replacement. A guard nobody has seen fail is
+a guard nobody knows works.
+
+### Class 3 — the product improved and the test didn't hear
+
+`test_549_floorplan_grade` asserted a `gr_circle`-only board is refused with
+`bounds is None`. `outline_state` now tessellates a circular outline into 64
+segments and derives correct bounds — the defect it guarded is **fixed**.
+
+The refusal property still matters, so it keeps a test, on the fixture that
+still cannot yield bounds. I probed four candidates (circle-only, no geometry,
+one stray segment, two disjoint segments); only **no Edge.Cuts geometry at all**
+still refuses. And the capability that retired the old fixture gets its own
+test — 64 segments, bounds `(30,30,70,70)`, `emit_intent` does not raise.
+Without that second test the first starts passing for the *wrong* reason if
+tessellation regresses, which is how the stale version survived.
+
+### Class 4 — doc lint
+
+`test_run8_skills_generic`: three `wk/runNN` strings genericised to
+`<workdir>/<board>`. Aligned with the `--workdir` work rather than incidental to
+it: the run directory is a parameter now, so a hardcoded `wk/run17` in the
+driver's own emitted text is actively wrong.
+
+Its "the combined skill is thin (< 200 lines)" check was **re-baselined to 230,
+not satisfied by trimming**, with the reason at the assertion. `ee6c3ad1`
+(2026-08-12) took that skill 103 → 204 lines in one commit, so it had been red
+for a week — and the content added is the L2/L3/L5 board-binding gates and the
+delegation rule, which the combined skill alone owns. The sibling check that
+*directly* measures restatement passes; line count is the proxy, and the proxy
+was stale.
+
+Moving a threshold to make a test pass is normally the failure mode this work
+removes. What makes this one legitimate: the direct measure is green, the growth
+is auditable to one commit, and the reason is recorded where the next reader can
+disagree with it.
+
+### Class 5 — timeouts
+
+Three tests exceeded the runner's 600 s cap while carrying **larger internal
+budgets**. Measured: `test_obstacle_map_balance` passes **alone in 681 s** with
+all 18 checks green, including its two self-checks that it did real work.
+
+Fixed by `RUN_ALL_TIMEOUT` (above), declared at 1200 / 3600 / 1800 with the
+measurement beside each.
+
+**Still worth doing:** `test_obstacle_map_balance` is four independent stages
+(`route.py`, `route_diff`, `route_planes`, `repair`) and would be better as four
+files — each inside the default budget, and a future leak attributed to one
+front-end instead of one opaque timeout. The budget makes it honest; the split
+would make it diagnosable.
+
+---
+
+## Corrections I had to make during this sweep
+
+Recorded because the method looked rigorous in both cases and was not.
+
+1. **"The router is missing."** It is not. `rust_router/grid_router.pyd` is
+   built and version-matched; my import test put `py_router` on `sys.path`
+   instead of `rust_router`. Building it would have been wasted work, and the
+   claim would have sent the next reader after the wrong prerequisite.
+
+2. **"`test_run5_exchange` is the one genuine failure left."** It was the #522
+   path class, in a file I had left out of the batch. I "verified" it against
+   the base engine *with the path fix already in place* — except the fix was
+   never applied to that file, so both arms of the comparison carried the same
+   broken invocation. Identical failures on both sides proved only that the bug
+   predated the branch: true, and useless. The `2 != 0` was the tell — exit 2 is
+   a usage error, not a placement verdict.
+
+3. **`test_457_determinism` listed as green without being run.** The patch
+   script had silently no-opped (its pattern did not match this file's
+   `PYTHONHASHSEED=seed, PYTHONPATH=ROOT`) and reported success anyway. I took
+   the claim from the script's output instead of a test run. Verified means run.
+
+---
+
+## A third of the corpus no-op baseline is untracked (2026-08-19)
+
+`tests/stress/corpus_noop_sweep.py` is the standing gate for placement-engine
+changes, and its own docstring says *"A baseline nobody can reproduce is not a
+baseline."* **11 of the 33 boards it pins are not tracked by git** — they are
+generated tool outputs (`fanout_output1/2`, `fanout_starting_point`,
+`flat_hierarchy_routed`, `interf_u_connected/fanout/plane/routed`,
+`qfn_fanned_out`, `sonde_u_routed`, `sonde_u_routed_routed`), matched by
+`.gitignore` patterns such as `/kicad_files/interf_u_*.kicad_pcb`.
+
+So a row's recorded value depends on which generation of the file the developer
+happens to have on disk. Measured while landing the containment census:
+
+```
+CHANGED interf_u_plane:reconstruct: refused:carries copper  ->  quiet
+CHANGED interf_u_plane:repair:      refused:board state     ->  quiet
+```
+
+Nothing moved on either arm — only the *reason* changed, because the copy on
+disk had been regenerated copper-free by an earlier sweep. **Reproduced with the
+engine change stashed out**, so it is fixture state, not a regression. Both rows
+were left as they were rather than re-recorded: pinning them to `quiet` would
+freeze a state that only exists on a machine that regenerated the file, and
+would hide this finding.
+
+A fresh clone does not see it. Those boards are absent, so they land in
+`skipped` ("outside this run's scope") rather than `gone` — a deliberate branch
+with its reasoning in the source. That is why the gate can be green on CI and
+red on a working tree, which is the confusing part.
+
+**Not fixed here**, because the fix changes what the gate covers and that is a
+decision, not a cleanup. The options are to drop the untracked boards from the
+baseline (22 boards, all reproducible), or to regenerate them deterministically
+as part of the sweep. Until then, read a changed row against `git
+check-ignore` before believing it.
+
+---
+
+## The bodyless-footprint hole is DISCLOSED, not fixed (2026-08-19)
+
+The body-containment channel cannot judge a part that draws no `.Fab` outline,
+and `grade_body_overlap` reports that as `fab_unjudged`. It looks like a gap to
+close. It is not, and the measurement is recorded here so nobody spends a day
+rediscovering it:
+
+- **144 of 1583 footprints across 33 boards are unjudged, and 144 of 144 draw
+  ZERO `.Fab` geometric primitives.** The classes "primitive type not handled"
+  and "degenerate bbox" are both empty; every kind used on that layer
+  (`fp_line`, `fp_arc`, `fp_circle`, `fp_poly`, `fp_rect`) is already read.
+- **313 footprints DO have non-closing `.Fab` chains** — tigard's `Q1` stops
+  0.02 mm short on its left edge — and every one is judged correctly, because a
+  bbox is a min/max over points and the gap is interior to it. A closure or
+  tolerance fix therefore moves **0 footprints and 0 pairs**.
+- The unjudged parts are mounting holes, testpoints, logos, fiducials and panel
+  tabs — parts that genuinely draw no body.
+- **The one change that would close the hole is measured dangerous.** Giving a
+  bodyless part a fallback body (courtyard, else pad bbox) adds **77 new fab
+  pairs, 65 above the containment threshold**, dominated by rp2350's `Teensy40`
+  — a bodyless module whose courtyard swallows 56 neighbours at frac 1.0. It
+  also breaks the 4-pair calibration gate outright.
+
+Two tests hold this. `test_the_bodyless_hole_is_exactly_what_was_measured` pins
+the count at 144 so a "helpful" parser change has to argue with the number, and
+`test_no_unjudged_part_has_fab_geometry_to_read` pins the **invariant** — no
+unjudged part has readable `.Fab` geometry — which is the claim that actually
+licenses "no parser fix helps", and which survives the corpus-membership drift
+described in the section above.

--- a/tests/fixtures/run23/tigard_damaged.kicad_pcb
+++ b/tests/fixtures/run23/tigard_damaged.kicad_pcb
@@ -1,0 +1,26040 @@
+(kicad_pcb
+	(version 20260206)
+	(generator "pcbnew")
+	(generator_version "10.0")
+	(general
+		(thickness 1.6)
+		(legacy_teardrops no)
+	)
+	(paper "A4")
+	(title_block
+		(title "Tigard")
+		(date "2020-10-27")
+		(rev "v1.1")
+		(comment 1 "Copyright Franklin Harding 2020")
+		(comment 2 "Licensed under CC-BY-SA 4.0")
+	)
+	(layers
+		(0 "F.Cu" signal)
+		(4 "In1.Cu" signal "GND")
+		(6 "In2.Cu" signal "PWR")
+		(2 "B.Cu" signal)
+		(9 "F.Adhes" user)
+		(11 "B.Adhes" user)
+		(13 "F.Paste" user)
+		(15 "B.Paste" user)
+		(5 "F.SilkS" user)
+		(7 "B.SilkS" user)
+		(1 "F.Mask" user)
+		(3 "B.Mask" user)
+		(17 "Dwgs.User" user)
+		(19 "Cmts.User" user)
+		(21 "Eco1.User" user)
+		(23 "Eco2.User" user)
+		(25 "Edge.Cuts" user)
+		(27 "Margin" user)
+		(31 "F.CrtYd" user)
+		(29 "B.CrtYd" user)
+		(35 "F.Fab" user)
+		(33 "B.Fab" user)
+	)
+	(setup
+		(pad_to_mask_clearance 0.05)
+		(allow_soldermask_bridges_in_footprints no)
+		(tenting
+			(front yes)
+			(back yes)
+		)
+		(covering
+			(front no)
+			(back no)
+		)
+		(plugging
+			(front no)
+			(back no)
+		)
+		(capping no)
+		(filling no)
+		(aux_axis_origin 76 76)
+		(grid_origin 1 -0.05)
+		(pcbplotparams
+			(layerselection 0x00000000_00000000_5555555f_5755f5ff)
+			(plot_on_all_layers_selection 0x00000000_00000000_00000000_00000000)
+			(disableapertmacros no)
+			(usegerberextensions yes)
+			(usegerberattributes no)
+			(usegerberadvancedattributes no)
+			(creategerberjobfile no)
+			(dashed_line_dash_ratio 12)
+			(dashed_line_gap_ratio 3)
+			(svgprecision 4)
+			(plotframeref no)
+			(mode 1)
+			(useauxorigin no)
+			(pdf_front_fp_property_popups yes)
+			(pdf_back_fp_property_popups yes)
+			(pdf_metadata yes)
+			(pdf_single_document no)
+			(dxfpolygonmode yes)
+			(dxfimperialunits yes)
+			(dxfusepcbnewfont yes)
+			(psnegative no)
+			(psa4output no)
+			(plot_black_and_white yes)
+			(sketchpadsonfab no)
+			(plotpadnumbers no)
+			(hidednponfab no)
+			(sketchdnponfab yes)
+			(crossoutdnponfab yes)
+			(subtractmaskfromsilk yes)
+			(outputformat 1)
+			(mirror no)
+			(drillshape 0)
+			(scaleselection 1)
+			(outputdirectory "gerber")
+		)
+	)
+	(footprint "MountingHole:MountingHole_3.2mm_M3_ISO7380"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec7649")
+		(at 73.000000 73.000000)
+		(descr "Mounting Hole 3.2mm, no annular, M3, ISO7380")
+		(tags "mounting hole 3.2mm no annular m3 iso7380")
+		(property "Reference" "H4"
+			(at 0 -3.85 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "bb472e54-fd10-4c0b-92a2-80874be40e6f")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "MountingHole"
+			(at 0 3.85 0)
+			(layer "F.Fab")
+			(uuid "b811a12a-b8a4-4dfd-863a-7cd1242b4961")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "c2a5032f-c8ed-45c5-b6c9-3833f3b0682a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "c4f3be3c-c194-437b-9c2a-408085256870")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-000060460663")
+		(attr exclude_from_pos_files exclude_from_bom)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_circle
+			(center 0 0)
+			(end 2.85 0)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(fill no)
+			(layer "Cmts.User")
+			(uuid "17faf555-61e9-4432-9afa-c7a11473e588")
+		)
+		(fp_circle
+			(center 0 0)
+			(end 3.1 0)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+			(uuid "61536813-4b3d-4d37-9660-53ce8d20e5bc")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0.3 0 0)
+			(layer "F.Fab")
+			(uuid "d6ed0199-2206-4540-8260-02dd5473837d")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "" np_thru_hole circle
+			(at 0 0)
+			(size 3.2 3.2)
+			(drill 3.2)
+			(layers "*.Cu" "*.Mask")
+			(uuid "3f43b813-3251-40d4-b8f7-11bd902f95b8")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "MountingHole:MountingHole_3.2mm_M3_ISO7380"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec765e")
+		(at 51.500000 58.000000)
+		(descr "Mounting Hole 3.2mm, no annular, M3, ISO7380")
+		(tags "mounting hole 3.2mm no annular m3 iso7380")
+		(property "Reference" "H3"
+			(at 0 -3.85 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "d1c79839-1057-4c2a-9c2e-671730b6a388")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "MountingHole"
+			(at 0 3.85 0)
+			(layer "F.Fab")
+			(uuid "e19c304d-5421-440d-b61a-4bef38441490")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b3c4e055-d45f-47b1-a243-e2c74370f4bf")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "1bb2094b-5ddf-4a1b-89fc-743ee86216bd")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-0000604604af")
+		(attr exclude_from_pos_files exclude_from_bom)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_circle
+			(center 0 0)
+			(end 2.85 0)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(fill no)
+			(layer "Cmts.User")
+			(uuid "f1b9e333-5a46-47d5-ad30-dbdbdb6dc252")
+		)
+		(fp_circle
+			(center 0 0)
+			(end 3.1 0)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+			(uuid "138b6e46-5d7a-493f-a618-841a176d2474")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0.3 0 0)
+			(layer "F.Fab")
+			(uuid "448a3cd4-1249-4a18-b0c7-f8304a24a0b4")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "" np_thru_hole circle
+			(at 0 0)
+			(size 3.2 3.2)
+			(drill 3.2)
+			(layers "*.Cu" "*.Mask")
+			(uuid "ee675091-231f-45f0-a898-cd8406e73f7d")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "MountingHole:MountingHole_3.2mm_M3_ISO7380"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec7673")
+		(at 54.500000 48.000000)
+		(descr "Mounting Hole 3.2mm, no annular, M3, ISO7380")
+		(tags "mounting hole 3.2mm no annular m3 iso7380")
+		(property "Reference" "H2"
+			(at 0 -3.85 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "336e738b-0f6e-427a-a043-135ff781a2d0")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "MountingHole"
+			(at 0 3.85 0)
+			(layer "F.Fab")
+			(uuid "18933cbc-600e-4731-86fd-56e44c290e7e")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "93f7aaa4-a81f-4357-9f7b-2e3c4991df16")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "8351bfe3-443d-48e9-8972-261c93757cf2")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-000060460323")
+		(attr exclude_from_pos_files exclude_from_bom)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_circle
+			(center 0 0)
+			(end 2.85 0)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(fill no)
+			(layer "Cmts.User")
+			(uuid "e0937eb3-7f6a-44e3-ae53-54b602fc57b8")
+		)
+		(fp_circle
+			(center 0 0)
+			(end 3.1 0)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+			(uuid "edc7901a-69fe-4363-a0c2-58562621a4cb")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0.3 0 0)
+			(layer "F.Fab")
+			(uuid "e30451b7-2702-4e37-8137-c0f96349aed9")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "" np_thru_hole circle
+			(at 0 0)
+			(size 3.2 3.2)
+			(drill 3.2)
+			(layers "*.Cu" "*.Mask")
+			(uuid "26ae4158-88ad-4be9-9ab4-942cefa82064")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "MountingHole:MountingHole_3.2mm_M3_ISO7380"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec7688")
+		(at 33.000000 33.000000)
+		(descr "Mounting Hole 3.2mm, no annular, M3, ISO7380")
+		(tags "mounting hole 3.2mm no annular m3 iso7380")
+		(property "Reference" "H1"
+			(at 0 -3.85 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "45ce1eed-0809-4401-8ec0-cc7e4594fe4a")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "MountingHole"
+			(at 0 3.85 0)
+			(layer "F.Fab")
+			(uuid "ea5cb08e-a9e5-40ad-ada2-722f36053e9d")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "7d2b2b1a-6ff4-4e26-955c-0e656884ff04")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "ea6647de-8ab3-4a37-b019-8abac40cef18")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00006045fa6c")
+		(attr exclude_from_pos_files exclude_from_bom)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_circle
+			(center 0 0)
+			(end 2.85 0)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(fill no)
+			(layer "Cmts.User")
+			(uuid "1c7b7aae-1c22-4ff6-9390-4954f9b665ae")
+		)
+		(fp_circle
+			(center 0 0)
+			(end 3.1 0)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+			(uuid "d88477d2-5176-4cb1-898b-3b1836d866cc")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0.3 0 0)
+			(layer "F.Fab")
+			(uuid "55d8c1d2-0254-4a5b-848e-89e21c116002")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "" np_thru_hole circle
+			(at 0 0)
+			(size 3.2 3.2)
+			(drill 3.2)
+			(layers "*.Cu" "*.Mask")
+			(uuid "5c2d81d1-739e-4af6-99ff-7c6cfbda65b3")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Package_SO:TSSOP-24_4.4x7.8mm_P0.65mm"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec76ef")
+		(at 67.770000 56.900000)
+		(descr "TSSOP, 24 Pin (JEDEC MO-153 Var AD https://www.jedec.org/document_search?search_api_views_fulltext=MO-153), generated with kicad-footprint-generator ipc_gullwing_generator.py")
+		(tags "TSSOP SO")
+		(property "Reference" "U5"
+			(at -0.02 5 0)
+			(layer "F.Fab")
+			(uuid "2fd158ee-f886-4452-9f8e-683b6b2b31b1")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "SN74LVC8T245"
+			(at 0 4.85 0)
+			(layer "F.Fab")
+			(uuid "9576fa93-5ffb-45e9-a9cf-1ea1b5696703")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "34a07708-433a-42c1-a046-d06db04c01f7")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "d2579827-8f05-4df1-b6d8-ced33e185d8c")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005fa83347")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0 -4.035)
+			(end -3.6 -4.035)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "427aeda2-9679-4a57-9f62-6e8ac850d8da")
+		)
+		(fp_line
+			(start 0 -4.035)
+			(end 2.2 -4.035)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "97f4e32c-29cb-4350-858a-ec2a77a702ac")
+		)
+		(fp_line
+			(start 0 4.035)
+			(end -2.2 4.035)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "15a81af1-dc65-4f30-bb9a-c30fa17f7148")
+		)
+		(fp_line
+			(start 0 4.035)
+			(end 2.2 4.035)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "e9be521f-bed1-4747-b5b1-f6f6dc236ee2")
+		)
+		(fp_line
+			(start -3.85 -4.15)
+			(end -3.85 4.15)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "3cec8fdb-d33e-4e71-afb4-7b7293c54ef2")
+		)
+		(fp_line
+			(start -3.85 4.15)
+			(end 3.85 4.15)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "faa9b931-b3b2-4593-a365-b7f759fe7561")
+		)
+		(fp_line
+			(start 3.85 -4.15)
+			(end -3.85 -4.15)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "92f458ae-1d77-4868-95ef-877005dac8e3")
+		)
+		(fp_line
+			(start 3.85 4.15)
+			(end 3.85 -4.15)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "8b5bda34-2e4c-4a4f-b8ba-3a6899ca6084")
+		)
+		(fp_line
+			(start -2.2 -2.9)
+			(end -1.2 -3.9)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a531cb94-6813-453b-bd9c-b0f2dfdc66a3")
+		)
+		(fp_line
+			(start -2.2 3.9)
+			(end -2.2 -2.9)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "2fc5f121-3fb3-41f9-89d2-9f08df02f4dd")
+		)
+		(fp_line
+			(start -1.2 -3.9)
+			(end 2.2 -3.9)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b7f6ac8a-3a57-4f03-a866-7d393489b1cf")
+		)
+		(fp_line
+			(start 2.2 -3.9)
+			(end 2.2 3.9)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "60746b1b-5bb0-4586-b171-3d8944108767")
+		)
+		(fp_line
+			(start 2.2 3.9)
+			(end -2.2 3.9)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "56d1e94c-bde2-4218-8397-9a60bc69e332")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "5f5c4dda-5cf3-4ffb-bb54-de1264e5feaf")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -2.8625 -3.575)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "f21779ed-7530-41a1-8d43-d7da0c8c2f4d")
+		)
+		(pad "2" smd roundrect
+			(at -2.8625 -2.925)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(R18-Pad2)")
+			(uuid "9c53374f-e059-4565-bee5-5d27fab6eb33")
+		)
+		(pad "3" smd roundrect
+			(at -2.8625 -2.275)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD0")
+			(uuid "01ce541e-3ec7-4536-9046-26367551bbb2")
+		)
+		(pad "4" smd roundrect
+			(at -2.8625 -1.625)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD1")
+			(uuid "e3e519eb-05df-454a-b3be-b72c0e674a08")
+		)
+		(pad "5" smd roundrect
+			(at -2.8625 -0.975)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD3")
+			(uuid "deb364fe-bd91-441f-bcd6-c30eb4711af6")
+		)
+		(pad "6" smd roundrect
+			(at -2.8625 -0.325)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD4")
+			(uuid "b8ec131e-a20f-44b8-a226-62dae079f0c7")
+		)
+		(pad "7" smd roundrect
+			(at -2.8625 0.325)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD5")
+			(uuid "db63eb4d-54f1-46e0-94ee-cf331071a5ed")
+		)
+		(pad "8" smd roundrect
+			(at -2.8625 0.975)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD4")
+			(uuid "ed633d17-4016-4b66-907c-6717b3f7ba1a")
+		)
+		(pad "9" smd roundrect
+			(at -2.8625 1.625)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD2")
+			(uuid "be182461-208c-4164-ab28-2e40cca9a35d")
+		)
+		(pad "10" smd roundrect
+			(at -2.8625 2.275)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD0")
+			(uuid "fb3d9a57-1a82-4124-a984-886279762258")
+		)
+		(pad "11" smd roundrect
+			(at -2.8625 2.925)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "dfa3babc-ea25-4ced-bcac-7cea1389378c")
+		)
+		(pad "12" smd roundrect
+			(at -2.8625 3.575)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "90227bc2-c24a-417b-8e3e-ffc52fb27af9")
+		)
+		(pad "13" smd roundrect
+			(at 2.8625 3.575)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "3c400a81-4432-484d-84b1-217f37f12fd9")
+		)
+		(pad "14" smd roundrect
+			(at 2.8625 2.925)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN4-Pad4)")
+			(uuid "47de9221-895a-42b9-ab4c-3139500afb26")
+		)
+		(pad "15" smd roundrect
+			(at 2.8625 2.275)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN4-Pad3)")
+			(uuid "a3261d0e-72ab-44eb-8077-a4ef1b676630")
+		)
+		(pad "16" smd roundrect
+			(at 2.8625 1.625)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN4-Pad2)")
+			(uuid "f0a204b2-e667-4a5f-b23e-3dc83d79b8d6")
+		)
+		(pad "17" smd roundrect
+			(at 2.8625 0.975)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN4-Pad1)")
+			(uuid "f0d837e0-7120-47df-8fec-e509e1acd091")
+		)
+		(pad "18" smd roundrect
+			(at 2.8625 0.325)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN3-Pad4)")
+			(uuid "52a1dc99-b41f-4661-b635-f72fe534efe7")
+		)
+		(pad "19" smd roundrect
+			(at 2.8625 -0.325)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN3-Pad3)")
+			(uuid "a59be271-9076-4679-a96d-78409b8feed5")
+		)
+		(pad "20" smd roundrect
+			(at 2.8625 -0.975)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN3-Pad2)")
+			(uuid "0fb611d7-c4d8-4088-9f89-8f6a58e8f712")
+		)
+		(pad "21" smd roundrect
+			(at 2.8625 -1.625)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN3-Pad1)")
+			(uuid "ad04213e-26c8-4d7e-a39c-925aae88e2f7")
+		)
+		(pad "22" smd roundrect
+			(at 2.8625 -2.275)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/~{ENABLE}")
+			(uuid "a93e73ab-a050-499e-a318-3b6251235dd9")
+		)
+		(pad "23" smd roundrect
+			(at 2.8625 -2.925)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "4fdad313-1767-42f7-8ac9-a1d8b96b7818")
+		)
+		(pad "24" smd roundrect
+			(at 2.8625 -3.575)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "104c0dfb-cb3d-4350-85ae-937144677f66")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Package_SO.3dshapes/TSSOP-24_4.4x7.8mm_P0.65mm.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:PinHeader_2x07_P1.27mm_Vertical_SMD"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec7791")
+		(at 67.450000 55.510000 270)
+		(descr "surface-mounted straight pin header, 2x07, 1.27mm pitch, double rows")
+		(tags "Surface mounted pin header SMD 2x07 1.27mm double row")
+		(property "Reference" "J6"
+			(at 0 -5.505 90)
+			(layer "F.Fab")
+			(uuid "d625164b-c7f1-41ca-8ea1-27e499304f41")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "LA"
+			(at -0.03 -5.59 270)
+			(layer "F.SilkS")
+			(uuid "77034dd8-1f69-4863-a45d-b36685522085")
+			(effects
+				(font
+					(size 0.8 0.8)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "d6ffa26e-6832-4a6e-b648-1cce2fc072f1")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "923945a5-5c62-4d98-9d92-298d94d0d7a4")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005fd77da4")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -1.765 4.505)
+			(end 1.765 4.505)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "bfa54926-b969-4fc6-86b8-c2e293699a64")
+		)
+		(fp_line
+			(start -1.765 4.44)
+			(end -1.765 4.505)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "9e38cb1b-0bff-41f1-aeb3-0d4234aeebd2")
+		)
+		(fp_line
+			(start 1.765 4.44)
+			(end 1.765 4.505)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "edbb8f13-a96b-48b9-b363-ccd4e1e7389f")
+		)
+		(fp_line
+			(start -3.09 -4.44)
+			(end -1.765 -4.44)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "37d62227-2229-4f8c-9fcb-39221e66f652")
+		)
+		(fp_line
+			(start -1.765 -4.505)
+			(end -1.765 -4.44)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "cfa03998-d85e-4ac0-9b61-647e3671f4dd")
+		)
+		(fp_line
+			(start -1.765 -4.505)
+			(end 1.765 -4.505)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "615a1e1b-cde2-4f86-8c60-afdcfba61605")
+		)
+		(fp_line
+			(start 1.765 -4.505)
+			(end 1.765 -4.44)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "6a4b565d-2a01-450f-be10-5832b19981aa")
+		)
+		(fp_line
+			(start -2.794 -4.826)
+			(end -3.15321 -5.18521)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "e2a99714-0473-4498-ae30-89b4fc2911a5")
+		)
+		(fp_line
+			(start -2.794 -4.826)
+			(end -2.43479 -5.18521)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "81482fc1-5a38-4b18-a61e-439561c2a1cf")
+		)
+		(fp_line
+			(start -2.794 -4.826)
+			(end -2.794 -5.90363)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "fef54523-4fdb-406d-87b1-ee06224c7a9f")
+		)
+		(fp_line
+			(start -3.15321 -5.18521)
+			(end -2.794 -4.826)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "64d26242-d63f-4ef9-be5f-bfabff2c5a6f")
+		)
+		(fp_line
+			(start -1.5 6.5)
+			(end 1.5 6.5)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Eco1.User")
+			(uuid "1f715f6f-7c7f-427e-af39-62bf2727da99")
+		)
+		(fp_line
+			(start 1.5 6.5)
+			(end 1.5 -6.5)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Eco1.User")
+			(uuid "d285e246-cc51-4dd7-abf1-9738261882a5")
+		)
+		(fp_line
+			(start -1.5 -6.5)
+			(end -1.5 6.5)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Eco1.User")
+			(uuid "34cfb8c0-5203-49c6-9611-ebb03c5d8d60")
+		)
+		(fp_line
+			(start 1.5 -6.5)
+			(end -1.5 -6.5)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Eco1.User")
+			(uuid "3f17bf57-b3be-41c3-b20b-6ee191754466")
+		)
+		(fp_line
+			(start -4.3 4.95)
+			(end 4.3 4.95)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "37299d2c-d979-488a-99aa-a6b793a5e32e")
+		)
+		(fp_line
+			(start 4.3 4.95)
+			(end 4.3 -4.95)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "fd64ccde-4289-4314-bf62-f0bdc6e98da1")
+		)
+		(fp_line
+			(start -4.3 -4.95)
+			(end -4.3 4.95)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "60c87124-6292-4372-9302-c32fc35e6493")
+		)
+		(fp_line
+			(start 4.3 -4.95)
+			(end -4.3 -4.95)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "cdd2b6f1-7df8-4539-84a9-16bbbe1ec275")
+		)
+		(fp_line
+			(start -1.705 4.445)
+			(end -1.705 -4.01)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9ad26181-c779-4bd4-9558-855ced060644")
+		)
+		(fp_line
+			(start 1.705 4.445)
+			(end -1.705 4.445)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "94eb7b79-37ee-4d2d-9b10-d25d94564336")
+		)
+		(fp_line
+			(start -2.75 4.01)
+			(end -1.705 4.01)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "35164ec9-8bff-4232-97b6-309bbd2dc087")
+		)
+		(fp_line
+			(start 2.75 4.01)
+			(end 1.705 4.01)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f761717b-1599-43db-aedc-cdb40bc4ee05")
+		)
+		(fp_line
+			(start -2.75 3.61)
+			(end -2.75 4.01)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "6d272ff7-324b-4996-bbb3-831200990737")
+		)
+		(fp_line
+			(start -1.705 3.61)
+			(end -2.75 3.61)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "739708c1-11fd-4fd2-8f3d-3093a39851a9")
+		)
+		(fp_line
+			(start 1.705 3.61)
+			(end 2.75 3.61)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c877b2ce-6f23-49ab-9f08-e9521597ca63")
+		)
+		(fp_line
+			(start 2.75 3.61)
+			(end 2.75 4.01)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "0691132d-2f3e-4c26-bac8-eef70fad4f08")
+		)
+		(fp_line
+			(start -2.75 2.74)
+			(end -1.705 2.74)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "12d81a95-8a63-4191-8af9-179f6e29b697")
+		)
+		(fp_line
+			(start 2.75 2.74)
+			(end 1.705 2.74)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "474160ac-5e3f-458e-8c8b-9ba4df543395")
+		)
+		(fp_line
+			(start -2.75 2.34)
+			(end -2.75 2.74)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a6d453a1-d6cd-47f4-bb83-392c09f7158b")
+		)
+		(fp_line
+			(start -1.705 2.34)
+			(end -2.75 2.34)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "72a4c876-55d8-4770-958c-5903b113b4c0")
+		)
+		(fp_line
+			(start 1.705 2.34)
+			(end 2.75 2.34)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "886ff9ba-1157-4b7d-b389-81fd93fc76f7")
+		)
+		(fp_line
+			(start 2.75 2.34)
+			(end 2.75 2.74)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e53d0028-7c67-4848-9119-a9a366dab571")
+		)
+		(fp_line
+			(start -2.75 1.47)
+			(end -1.705 1.47)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "07de0936-6634-409f-8fe6-c12a7151c380")
+		)
+		(fp_line
+			(start 2.75 1.47)
+			(end 1.705 1.47)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c7497da9-7187-4e5b-bc9c-9cbc0a280484")
+		)
+		(fp_line
+			(start -2.75 1.07)
+			(end -2.75 1.47)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ff09dcbd-9929-4720-b535-f06a5dc13bc4")
+		)
+		(fp_line
+			(start -1.705 1.07)
+			(end -2.75 1.07)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "5ec94d10-2cf1-4b5d-80cc-f081b925edb3")
+		)
+		(fp_line
+			(start 1.705 1.07)
+			(end 2.75 1.07)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "0e1a0f5c-629f-403e-bd93-c6f239b71ac7")
+		)
+		(fp_line
+			(start 2.75 1.07)
+			(end 2.75 1.47)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "991bf058-d26f-430c-a4a9-4778555fc1d3")
+		)
+		(fp_line
+			(start -2.75 0.2)
+			(end -1.705 0.2)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "de470dfa-e3d8-45c1-bade-f44948950f13")
+		)
+		(fp_line
+			(start 2.75 0.2)
+			(end 1.705 0.2)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "eb9008e0-9c83-41b7-ad1d-1645282e1c6f")
+		)
+		(fp_line
+			(start -2.75 -0.2)
+			(end -2.75 0.2)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "8559b712-fe46-4d92-a9a1-6a46482d64c4")
+		)
+		(fp_line
+			(start -1.705 -0.2)
+			(end -2.75 -0.2)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "da22d81b-24b9-4e68-a019-274584e36c26")
+		)
+		(fp_line
+			(start 1.705 -0.2)
+			(end 2.75 -0.2)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "3ea19346-7b8d-42a3-a39d-7e5e28590c99")
+		)
+		(fp_line
+			(start 2.75 -0.2)
+			(end 2.75 0.2)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f49a56cf-906b-44b7-ad12-96c05add2d3b")
+		)
+		(fp_line
+			(start -2.75 -1.07)
+			(end -1.705 -1.07)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "7c89cbfe-e6e9-4200-bbf4-20f1797e1c87")
+		)
+		(fp_line
+			(start 2.75 -1.07)
+			(end 1.705 -1.07)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "921ca45c-1d20-49af-a4d6-3b0a0a9b3279")
+		)
+		(fp_line
+			(start -2.75 -1.47)
+			(end -2.75 -1.07)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "25c2b5bc-8342-4b8a-a9b8-f5212784c518")
+		)
+		(fp_line
+			(start -1.705 -1.47)
+			(end -2.75 -1.47)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b9f71b86-b34a-44ae-90fb-f5b749f93da7")
+		)
+		(fp_line
+			(start 1.705 -1.47)
+			(end 2.75 -1.47)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "4f7bc2ea-9db3-4f38-ba32-f1ad56c1bc06")
+		)
+		(fp_line
+			(start 2.75 -1.47)
+			(end 2.75 -1.07)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ef3b9207-f8b0-4d5c-8a42-c797c809258b")
+		)
+		(fp_line
+			(start -2.75 -2.34)
+			(end -1.705 -2.34)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "21cc06b5-9755-433f-8b2d-1ff07aa69699")
+		)
+		(fp_line
+			(start 2.75 -2.34)
+			(end 1.705 -2.34)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "314028b1-e414-403b-bf68-3170ad41dabe")
+		)
+		(fp_line
+			(start -2.75 -2.74)
+			(end -2.75 -2.34)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "0acd16ef-5927-42d5-9cb5-589fc5893738")
+		)
+		(fp_line
+			(start -1.705 -2.74)
+			(end -2.75 -2.74)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "4ae3988a-08c2-4357-856f-468037ffa8d5")
+		)
+		(fp_line
+			(start 1.705 -2.74)
+			(end 2.75 -2.74)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "7559f03f-a6e7-46a6-9930-697229a5adab")
+		)
+		(fp_line
+			(start 2.75 -2.74)
+			(end 2.75 -2.34)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "39d75b7c-ff1b-4f5e-9524-3f6b8556885d")
+		)
+		(fp_line
+			(start -2.75 -3.61)
+			(end -1.705 -3.61)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d26ce950-d518-421b-a7c7-57fe8e9b11df")
+		)
+		(fp_line
+			(start 2.75 -3.61)
+			(end 1.705 -3.61)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "df28e62d-8364-45bf-b615-e2e32a9be590")
+		)
+		(fp_line
+			(start -2.75 -4.01)
+			(end -2.75 -3.61)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "89506f5a-e797-450e-91d7-07fb464e0fb1")
+		)
+		(fp_line
+			(start -1.705 -4.01)
+			(end -2.75 -4.01)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e10dd986-5cc2-4592-9210-1836c786395d")
+		)
+		(fp_line
+			(start -1.705 -4.01)
+			(end -1.27 -4.445)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "39954b92-dbe1-43ae-959e-5c029cd2ad2b")
+		)
+		(fp_line
+			(start 1.705 -4.01)
+			(end 2.75 -4.01)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f836d23a-a5c0-42a4-b301-f42da6719b3a")
+		)
+		(fp_line
+			(start 2.75 -4.01)
+			(end 2.75 -3.61)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "65897f26-7b38-47c4-b769-cf3e6f6a9f6e")
+		)
+		(fp_line
+			(start -1.27 -4.445)
+			(end 1.705 -4.445)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c0da5228-89e1-4dc7-87c8-de2879e1a898")
+		)
+		(fp_line
+			(start 1.705 -4.445)
+			(end 1.705 4.445)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "8bbbf9aa-b422-43e0-8cbe-1817143beb62")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "a72c7183-f02a-4a4e-9921-1929f4ba07b0")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -1.95 -3.81 270)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/CLK")
+			(uuid "0ae5c117-45bc-497d-9bf5-18a7a78fdc48")
+		)
+		(pad "2" smd roundrect
+			(at 1.95 -3.81 270)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/COPI")
+			(uuid "bf3c07f9-b3d2-4ed4-aea1-079627f4e7cb")
+		)
+		(pad "3" smd roundrect
+			(at -1.95 -2.54 270)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/DI")
+			(uuid "9954170a-605c-46c2-a6f4-99dcb7f1a603")
+		)
+		(pad "4" smd roundrect
+			(at 1.95 -2.54 270)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/CS")
+			(uuid "888c2463-89fb-4471-8aee-7477da4b44ad")
+		)
+		(pad "5" smd roundrect
+			(at -1.95 -1.27 270)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/xPB4")
+			(uuid "89e6b1e5-b271-4ae7-9c14-93ba074fd87f")
+		)
+		(pad "6" smd roundrect
+			(at 1.95 -1.27 270)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/xPB5")
+			(uuid "eff6a024-c51a-46d1-9605-306842970a29")
+		)
+		(pad "7" smd roundrect
+			(at -1.95 0 270)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/UART_TX")
+			(uuid "b13185ad-b5b9-4f09-b1b4-0002e89a98fc")
+		)
+		(pad "8" smd roundrect
+			(at 1.95 0 270)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/ICE_CDONE")
+			(uuid "a99ea99d-f2c9-4b71-be8f-e4a755bb4a36")
+		)
+		(pad "9" smd roundrect
+			(at -1.95 1.27 270)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "d7140a76-24c6-4002-9fde-4a862f392e58")
+		)
+		(pad "10" smd roundrect
+			(at 1.95 1.27 270)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "091e028e-27b4-4088-b7da-5a3b9cf0b237")
+		)
+		(pad "11" smd roundrect
+			(at -1.95 2.54 270)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "99a2ea20-0e55-42b6-ac90-37ee79accfe1")
+		)
+		(pad "12" smd roundrect
+			(at 1.95 2.54 270)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "8df0a0a5-adc6-4491-b1d4-ae0a7e1ba2b8")
+		)
+		(pad "13" smd roundrect
+			(at -1.95 3.81 270)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "a38f6be0-19cc-4b3f-a9d6-4394ef76b762")
+		)
+		(pad "14" smd roundrect
+			(at 1.95 3.81 270)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "d4a30846-c800-4e22-a559-f2c8c4c3d595")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Connector_PinHeader_1.27mm.3dshapes/PinHeader_2x07_P1.27mm_Vertical_SMD.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "LED_SMD:LED_0603_1608Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec7843")
+		(at 41.000000 49.526000 270)
+		(descr "LED SMD 0603 (1608 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "diode")
+		(property "Reference" "D3"
+			(at 0 -1.43 90)
+			(layer "F.Fab")
+			(uuid "ea8d8f5f-cd72-46a6-8c9c-33caec9c91b8")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "GREEN"
+			(at 0 1.43 90)
+			(layer "F.Fab")
+			(uuid "0d8ccabb-c585-4cea-94cf-1c667ec1ff0d")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "adbe2f89-0306-4fd5-bf2a-3d72e201dd3b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "da5d6e73-941f-4fff-9cfa-b8db642df460")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f225d89")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -1.485 0.735)
+			(end 0.8 0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "173be5b0-84de-4566-86da-f3c0e92b2a0d")
+		)
+		(fp_line
+			(start -1.485 -0.735)
+			(end -1.485 0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "a1b1e199-c930-470e-9491-b77b5dd5f6a5")
+		)
+		(fp_line
+			(start 0.8 -0.735)
+			(end -1.485 -0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "6c9fd50d-0c53-48dc-9390-148e7cdd4f54")
+		)
+		(fp_line
+			(start -1.48 0.73)
+			(end -1.48 -0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "57093d38-314e-4e39-8d66-7c5135119c5c")
+		)
+		(fp_line
+			(start 1.48 0.73)
+			(end -1.48 0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "7b7d899d-e3af-4149-bdcc-1a658e284921")
+		)
+		(fp_line
+			(start -1.48 -0.73)
+			(end 1.48 -0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "0223cc1d-da7c-4397-a03a-e244d87bedd9")
+		)
+		(fp_line
+			(start 1.48 -0.73)
+			(end 1.48 0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "0390ff7f-df7c-4dd5-91b3-7b6effd8ffa9")
+		)
+		(fp_line
+			(start -0.8 0.4)
+			(end 0.8 0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "5bc6d7b6-e614-4e63-92fb-50aad2d05933")
+		)
+		(fp_line
+			(start 0.8 0.4)
+			(end 0.8 -0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9d51c0ff-1178-4f8c-aad0-3fe9f6035bc3")
+		)
+		(fp_line
+			(start -0.8 -0.1)
+			(end -0.8 0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "da5f7b6d-7109-452c-8be7-d8a66a39dab2")
+		)
+		(fp_line
+			(start -0.5 -0.4)
+			(end -0.8 -0.1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "3b146f5c-e496-477e-88cf-71eeead3436d")
+		)
+		(fp_line
+			(start 0.8 -0.4)
+			(end -0.5 -0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "05a3b01d-d3ec-4738-9af6-dd491b7dcad2")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "cb430395-5ec9-49ec-ba29-f8778494306b")
+			(effects
+				(font
+					(size 0.4 0.4)
+					(thickness 0.06)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.7875 0 270)
+			(size 0.875 0.95)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/RXLED")
+			(uuid "ba25650e-e056-4d75-bc2a-90b28c6d17e9")
+		)
+		(pad "2" smd roundrect
+			(at 0.7875 0 270)
+			(size 0.875 0.95)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(D3-Pad2)")
+			(uuid "47889d70-9192-4832-afcb-fee29ce7ce30")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/LED_SMD.3dshapes/LED_0603_1608Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec7881")
+		(at 39.750000 48.650000 90)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C2"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "25910469-5804-4723-91df-e0860b033ce8")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "2u2"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "9474ad25-b9fc-43a9-9d67-94e535889953")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "122c6b2b-1635-4d0d-af4c-bb7561db34bb")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "dcceedf0-e910-4cd3-98f6-0f2182bddf3a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ee3e5c7")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "749c7708-8527-457c-9983-fa17ff9c1c5d")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "6667d55d-0210-4eac-b590-5d1691f7bfdf")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "c8224116-5391-4a3d-bb27-9b7fa714792e")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "212072e5-bfcf-424e-82fd-6ff721571bdf")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "251a1d6f-874e-4f99-9338-10267ab6818b")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "8ce1572a-87ae-4945-b10c-28661026277b")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "983e422f-66ca-4ab4-9d72-02c7fae277c0")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "480b2cc1-9886-432a-b822-9b7c3e941a0c")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "9feb1dd4-73f2-4142-8089-d6b89de1d924")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+1V8")
+			(uuid "8f7e1a99-48d2-4dec-9e4d-4e06da81a046")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "465514b3-f200-44bc-babe-5cdf641c98ab")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec78ab")
+		(at 58.750000 41.150000 270)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C26"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "82d90949-d6bf-4762-8432-b75212d3b471")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100n"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "ef5c9372-6d38-4a6d-ad3c-2c70df5fa296")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "cd0115e5-ff69-4c79-8306-e833ceb68979")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "e1dd155e-22c8-4639-807d-3f331f264ac6")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005fa89fd4")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "02e23e0a-42d2-46ae-ab6a-15e5dc7db19f")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "86f9ec1d-943a-4129-a741-2494f9983b17")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "57352f42-3e22-42f7-a814-2b8b0d30c36e")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "81d9bed1-4a8d-4ed2-9f28-fed2ff192d7b")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "60f9b7e1-ef8d-4029-aa47-d450c7d036bf")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "8923f6ff-087c-48e4-8ce9-030f2e69c644")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "bba1cc02-98aa-4843-8a99-c45503942149")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e7a6ec74-7b5d-492d-b630-1d7922c95144")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "9d020299-2f23-4aca-be97-b3363f0fe086")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+5V")
+			(uuid "a21689b9-e060-499c-a822-e322fb170382")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "39411482-b0f0-48c5-8b90-39483004b030")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec78d5")
+		(at 51.015000 53.150000 180)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C25"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "704c6386-5c54-4d97-9ddd-d76bf23e59e1")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "NF"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "b8aa696c-43c1-4134-b7b0-befe74fb37a0")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "df0fdb8d-e4bd-4701-845f-ab184e895a19")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "0976e7b9-de09-4946-b8b8-53b8a63188f7")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f3a982f")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2f71c11f-55be-4432-bde7-20eb6a1178a8")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "be0ffe6c-c197-4618-bd57-a69671f82333")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "541d8dd0-a6d2-42d9-9c06-069181adee7d")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "7940e504-38b8-4ec9-a4bc-63a3bb951050")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "5be24d94-a0ee-4320-bd3a-b1c4f0a63d89")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9b313482-b0c2-4494-a2b2-031300f91087")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "116465a7-6e09-47d4-a2bf-283e5928fbc9")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e1a51331-55f6-4c08-b2c3-7b9a4911b3aa")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "fbaa71ca-2180-4a23-b612-c0b97cc1c026")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "cdf1c7a3-8803-46b1-9359-b675b7349168")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(C25-Pad2)")
+			(uuid "72e0e9f5-e1b3-4fe2-a61e-5ce3c60bbdaf")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:PinHeader_1x09_P2.54mm_Vertical"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec791d")
+		(at 46.380000 33.700000 90)
+		(descr "Through hole straight pin header, 1x09, 2.54mm pitch, single row")
+		(tags "Through hole pin header THT 1x09 2.54mm single row")
+		(property "Reference" "J3"
+			(at 0 -2.33 90)
+			(layer "F.Fab")
+			(uuid "9f4f97c7-0cc3-4133-9d1b-3dc70e5afb57")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "UART"
+			(at 0.05 -2.59 90)
+			(layer "F.SilkS")
+			(uuid "cf751067-4ba2-4519-86a8-73d1e2a53b6f")
+			(effects
+				(font
+					(size 0.8 0.8)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "526798a6-743b-4e15-b366-3dbdb2711f18")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "d68c5c2b-2c15-4784-b8c1-20ff859f4070")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ebeac72")
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -2.032 -2.032)
+			(end -2.794 -2.794)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "073f5afe-5703-4ef0-aa50-9b818fe47898")
+		)
+		(fp_line
+			(start -2.032 -2.032)
+			(end -2.032 -2.54)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "4bed77dd-b38b-47b1-9e13-66cc0c883dbb")
+		)
+		(fp_line
+			(start -2.032 -2.032)
+			(end -2.54 -2.032)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "321006a3-2c21-47a8-876d-d1a5c7d497df")
+		)
+		(fp_line
+			(start -2.54 -2.032)
+			(end -2.032 -2.032)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "86c18958-e128-4365-8df1-5f8bff5504ba")
+		)
+		(fp_line
+			(start -1.33 -1.33)
+			(end 0 -1.33)
+			(stroke
+				(width 0.5)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d7007dba-20f3-4356-8954-bf55f435c5de")
+		)
+		(fp_line
+			(start -1.33 0)
+			(end -1.33 -1.33)
+			(stroke
+				(width 0.5)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b3ccb2ed-d307-47f9-9d34-18b13a98deb0")
+		)
+		(fp_line
+			(start 1.33 1.27)
+			(end 1.33 21.65)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "69ecc4dc-e138-4204-9cbf-a9f4d61514fd")
+		)
+		(fp_line
+			(start -1.33 1.27)
+			(end 1.33 1.27)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "821337a2-f4ff-41f2-98e2-2cf2ef2bd110")
+		)
+		(fp_line
+			(start -1.33 1.27)
+			(end -1.33 21.65)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "161deb74-5028-42c4-b7be-c749d0509e1e")
+		)
+		(fp_line
+			(start -1.33 21.65)
+			(end 1.33 21.65)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "e949c2b2-6833-4678-aa58-07eb1cbd2a00")
+		)
+		(fp_line
+			(start -2.032 -2.032)
+			(end -2.794 -2.794)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "57cf0db6-18f9-4ed1-8a32-c5d7c9f8cc25")
+		)
+		(fp_line
+			(start -2.032 -2.032)
+			(end -2.032 -2.54)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "c55065fc-568c-41ca-90b4-37fb6423a713")
+		)
+		(fp_line
+			(start -2.54 -2.032)
+			(end -2.032 -2.032)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "77ee8248-1834-484d-b660-cdcef514f577")
+		)
+		(fp_line
+			(start -1.33 -1.33)
+			(end 0 -1.33)
+			(stroke
+				(width 0.5)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "35090b4c-f372-42d6-8089-4eed6faa6788")
+		)
+		(fp_line
+			(start -1.33 0)
+			(end -1.33 -1.33)
+			(stroke
+				(width 0.5)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "415228c0-b1a1-4f85-b99f-08471e5dfa8b")
+		)
+		(fp_line
+			(start 1.33 1.27)
+			(end 1.33 21.65)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "16506d47-e3ec-4287-962b-fb61e6cba28a")
+		)
+		(fp_line
+			(start -1.33 1.27)
+			(end 1.33 1.27)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "ea40e2da-f95d-4eda-90b7-b93c23abb518")
+		)
+		(fp_line
+			(start -1.33 1.27)
+			(end -1.33 21.65)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "7a986731-ce52-4820-82e0-ed982f103aba")
+		)
+		(fp_line
+			(start -1.33 21.65)
+			(end 1.33 21.65)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "f86808f1-299c-4154-b838-002fbac6d388")
+		)
+		(fp_line
+			(start 1.8 -1.8)
+			(end -1.8 -1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "0039fbb6-d233-4726-acce-bfc4970c5eba")
+		)
+		(fp_line
+			(start -1.8 -1.8)
+			(end -1.8 22.1)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "3a428086-a284-4d6e-b1d9-715b017e83b5")
+		)
+		(fp_line
+			(start 1.8 22.1)
+			(end 1.8 -1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "e0501b2c-48d8-4fcd-bc36-72d78711a53e")
+		)
+		(fp_line
+			(start -1.8 22.1)
+			(end 1.8 22.1)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "581f5308-46d7-4a0e-aa46-b99834ab1dd5")
+		)
+		(fp_line
+			(start 1.27 -1.27)
+			(end 1.27 21.59)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9189025a-7d94-499b-8798-5e2fbc97f193")
+		)
+		(fp_line
+			(start -0.635 -1.27)
+			(end 1.27 -1.27)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "03de0dbe-d2cf-445b-b7d4-4789edc4a7e5")
+		)
+		(fp_line
+			(start -1.27 -0.635)
+			(end -0.635 -1.27)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "fd51427d-aa7e-4423-bc64-45a3ca33f6f4")
+		)
+		(fp_line
+			(start 1.27 21.59)
+			(end -1.27 21.59)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b477aa68-dbd5-46f6-97e4-46191ebe2075")
+		)
+		(fp_line
+			(start -1.27 21.59)
+			(end -1.27 -0.635)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "6fd6cd92-4b2b-440c-9601-74fe46cf9ab7")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 10.16 0)
+			(layer "F.Fab")
+			(uuid "14a9017e-7851-4e5b-9d1c-ae4e4f747c7c")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "1" thru_hole roundrect
+			(at 0 0 90)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(roundrect_rratio 0.25)
+			(net "VTARGET")
+			(uuid "b515c753-19cc-424b-ae5c-c585809a9523")
+		)
+		(pad "2" thru_hole oval
+			(at 0 2.54 90)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "GND")
+			(uuid "0e43c46c-35d9-4e07-b389-098fbdd3a8da")
+		)
+		(pad "3" thru_hole oval
+			(at 0 5.08 90)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/UART_TX")
+			(uuid "71485f84-345b-4a31-9bb1-2af9379f5310")
+		)
+		(pad "4" thru_hole oval
+			(at 0 7.62 90)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/ICE_CDONE")
+			(uuid "89b8c3de-eb46-4f9d-ad57-ed6c168a558d")
+		)
+		(pad "5" thru_hole oval
+			(at 0 10.16 90)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/~{UART_RTS}")
+			(uuid "f845d2ef-0ca4-4c08-8bfd-f24adceba287")
+		)
+		(pad "6" thru_hole oval
+			(at 0 12.7 90)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/~{UART_CTS}")
+			(uuid "6a513bb7-f104-4e50-ab31-e413fc4ad3cb")
+		)
+		(pad "7" thru_hole oval
+			(at 0 15.24 90)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/~{UART_DTR}")
+			(uuid "20361235-c047-4c8e-9ad8-9a2a66015ea0")
+		)
+		(pad "8" thru_hole oval
+			(at 0 17.78 90)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/~{UART_DSR}")
+			(uuid "d9557eeb-5773-499b-88e5-5dd2c4a09bee")
+		)
+		(pad "9" thru_hole oval
+			(at 0 20.32 90)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/~{UART_DCD}")
+			(uuid "55610ac5-d772-42b7-8a64-86b7467ed836")
+		)
+		(embedded_fonts no)
+		(model "${KIPRJMOD}/tigard.3dshapes/PinHeader_1x09_P2.54mm_Vertical_orange.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "LED_SMD:LED_0603_1608Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec7993")
+		(at 35.500000 59.622000 270)
+		(descr "LED SMD 0603 (1608 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "diode")
+		(property "Reference" "D2"
+			(at 0 -1.43 90)
+			(layer "F.Fab")
+			(uuid "0e330aec-4a32-4435-865d-eb8c04a5197f")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "BLUE"
+			(at 0 1.43 90)
+			(layer "F.Fab")
+			(uuid "51ba8085-cccf-40a9-80be-0c279e967a51")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "87eb2975-bb6e-4d55-9ea0-73208b275cf6")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "9f6465c8-3d54-40c9-b30c-bf094272b61d")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ebfe192")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -1.485 0.735)
+			(end 0.8 0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "8ea205f1-5c0a-4a74-961a-d8007fb46fbc")
+		)
+		(fp_line
+			(start -1.485 -0.735)
+			(end -1.485 0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "5b0ab053-5937-4348-8a0c-da892064b5d5")
+		)
+		(fp_line
+			(start 0.8 -0.735)
+			(end -1.485 -0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "973e5975-85a3-4280-b713-0678e3e4d01e")
+		)
+		(fp_line
+			(start -1.48 0.73)
+			(end -1.48 -0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "031155b0-6a5e-49f4-a4f8-5f2b423668b1")
+		)
+		(fp_line
+			(start 1.48 0.73)
+			(end -1.48 0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "992fbf16-6f65-4dbe-94f6-09b799de2602")
+		)
+		(fp_line
+			(start -1.48 -0.73)
+			(end 1.48 -0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "9dee232a-18d6-4916-8d19-34df99bcaa96")
+		)
+		(fp_line
+			(start 1.48 -0.73)
+			(end 1.48 0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "ec2d9441-686a-438e-9fb5-91e084b7d825")
+		)
+		(fp_line
+			(start -0.8 0.4)
+			(end 0.8 0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b74f5d05-126d-4e5d-84e2-13e56d8282be")
+		)
+		(fp_line
+			(start 0.8 0.4)
+			(end 0.8 -0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "8a98fb42-d184-4f43-9b36-259c75f59767")
+		)
+		(fp_line
+			(start -0.8 -0.1)
+			(end -0.8 0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "1655b101-b0db-44f8-8bc5-7350b1bfe8c2")
+		)
+		(fp_line
+			(start -0.5 -0.4)
+			(end -0.8 -0.1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9e1288b7-76cc-4bd6-b7d5-9edd494c9121")
+		)
+		(fp_line
+			(start 0.8 -0.4)
+			(end -0.5 -0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "527c8b86-8926-4274-98a7-1dc628e5b2b6")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "a0a28a06-0933-4643-8ece-79243cc01472")
+			(effects
+				(font
+					(size 0.4 0.4)
+					(thickness 0.06)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.7875 0 270)
+			(size 0.875 0.95)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(D2-Pad1)")
+			(uuid "825f9ef5-2754-44e7-bc3a-89abb1e137e6")
+		)
+		(pad "2" smd roundrect
+			(at 0.7875 0 270)
+			(size 0.875 0.95)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(D2-Pad2)")
+			(uuid "063e1de3-33b4-48ec-bec0-2d575b042030")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/LED_SMD.3dshapes/LED_0603_1608Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec79c5")
+		(at 62.515000 60.150000)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C12"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "03ce7138-dc36-405e-a700-3ac0258b9650")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100n"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "0e072391-6710-4829-bdc5-766f131cb2b8")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "84d7fd23-6467-4994-89d1-2d2f76d28f89")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "93a99c6c-f19e-46ad-b086-d8f4e9950e4e")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f77777a")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "6297af99-cf6c-4fca-bdae-007b0e7d36e2")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "b7cb5692-9dfb-4fd9-8464-b32edef52fc4")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "13db2cf9-716e-46b0-8baa-0c185eab7b74")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "1de2f827-33e6-4f8c-b139-33591cfa0a04")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "cc77af1f-eee4-4e1d-b2cf-81cf78e55c46")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "11b8490f-440f-4bd0-b217-7ef583a235f4")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b612cbda-eddb-4e96-91be-93c154a671e8")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "4bb0f707-4926-4119-a2f2-8b2982ce540f")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "c64e042c-8b4d-4e5b-98be-6170f510edba")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREG")
+			(uuid "0d1222a7-6df7-477e-b342-d71d4fded446")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "5dacd878-fb5b-441f-9111-b92d1e8d8fcf")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:SW_ALPS_SSSS224100_DP4T"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec7a8e")
+		(at 33.200000 40.400000 -90)
+		(property "Reference" "SW1"
+			(at 13.5 1.6 0)
+			(layer "F.Fab")
+			(uuid "bace793c-bcea-4151-a965-6800fea780b9")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "TARGET"
+			(at -3.75 -1.65 180)
+			(layer "F.SilkS")
+			(uuid "215d02be-136f-4be4-a247-c7fbdddb4963")
+			(effects
+				(font
+					(size 0.8 0.8)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "f6c55119-f08d-4c0f-88dc-0c66ff239a18")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "dba7ba0b-336c-4cf1-93b1-5a8a7bede58f")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f1c3bd3")
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -2.8 0.3)
+			(end -1.6 0.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "1962e738-7fe6-4353-a753-c2cb5e6c7dfe")
+		)
+		(fp_line
+			(start -2.5 0)
+			(end -1 0)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b8df8d7c-80a7-44a2-8ab9-cfa6fe4afa8a")
+		)
+		(fp_line
+			(start 3 0)
+			(end 5 0)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "e30ec1df-1d6a-42d2-9188-6e254d41cb5e")
+		)
+		(fp_line
+			(start 12.5 0)
+			(end 11 0)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "8c477517-4713-47a6-baad-a62e87490dd1")
+		)
+		(fp_line
+			(start 12.5 0)
+			(end 12.5 -3.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "303f2208-4f37-409f-8ba8-a1513af678f5")
+		)
+		(fp_line
+			(start -2.8 -0.9)
+			(end -2.8 0.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "3ec6719b-db60-4385-bf76-48108cd166a0")
+		)
+		(fp_line
+			(start -2.5 -3.3)
+			(end -2.5 0)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "be996f75-cf7c-4b80-a048-f3d250b5db47")
+		)
+		(fp_line
+			(start -2.5 -3.3)
+			(end -1 -3.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d280f38d-2a8b-4acc-a047-cb52f8142350")
+		)
+		(fp_line
+			(start 3 -3.3)
+			(end 5 -3.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "7145c2a5-23df-4633-b49d-bbfd05824e11")
+		)
+		(fp_line
+			(start 12.5 -3.3)
+			(end 11 -3.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "bc4dd372-f3fb-4b6f-baf1-6858cdef644a")
+		)
+		(fp_line
+			(start 1 2)
+			(end 1 0)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "baf56839-d26f-41d5-ae1a-971904889aed")
+		)
+		(fp_line
+			(start 3 2)
+			(end 1 2)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "3c4c3ce9-f5be-4e37-b6e9-21556e473b3b")
+		)
+		(fp_line
+			(start 3 2)
+			(end 5 2)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d9bc0413-8b7f-4b48-a666-506016a752ae")
+		)
+		(fp_line
+			(start 5 2)
+			(end 7 2)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "11bece95-62b6-4257-a4a9-96634074d4aa")
+		)
+		(fp_line
+			(start 5 2)
+			(end 5 0)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "14e5ea2e-edf1-442e-aabb-2caa373c6d04")
+		)
+		(fp_line
+			(start 7 2)
+			(end 9 2)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c025c0db-72a1-4f9d-af89-460527427077")
+		)
+		(fp_line
+			(start 7 2)
+			(end 7 0)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c51ab8e8-9dac-4d58-94ba-232a7ed45590")
+		)
+		(fp_line
+			(start 9 2)
+			(end 9 0)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "856f0670-a50c-4f43-85c7-28db6a2c8bd9")
+		)
+		(fp_line
+			(start 1 0)
+			(end 3 0)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "22610238-ad5d-4faa-92ca-acae7112c1e6")
+		)
+		(fp_line
+			(start 3 0)
+			(end 3 2)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6c2a86c6-5be4-43de-b994-a82f70143826")
+		)
+		(fp_line
+			(start 5 0)
+			(end 3 0)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "9654d1e7-4c23-4551-a9e5-65f86e5f003f")
+		)
+		(fp_line
+			(start 7 0)
+			(end 5 0)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5795b981-5c32-4c48-b8ea-84a365c9af44")
+		)
+		(fp_line
+			(start 9 0)
+			(end 7 0)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "20c9020f-f2f7-4b10-9813-98b970106937")
+		)
+		(fp_line
+			(start -3 1.2)
+			(end 13 1.2)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2ec56a81-a915-43c4-82c4-adc3222f864a")
+		)
+		(fp_line
+			(start 13 1.2)
+			(end 13 -4.55)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "45f481ef-1c73-431e-9d0d-3db653467dcd")
+		)
+		(fp_line
+			(start -3 -4.55)
+			(end -3 1.2)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "3edc1bb7-c965-4704-a284-0700f28410fd")
+		)
+		(fp_line
+			(start 13 -4.55)
+			(end -3 -4.55)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "bcd2bf0a-32e5-459a-a5ef-4a8d61c7d68e")
+		)
+		(fp_line
+			(start -2 0)
+			(end -1.5 0)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ae60572e-cf5c-4c1a-a96d-375574bcdaf7")
+		)
+		(fp_line
+			(start -2 0)
+			(end -2.5 -0.5)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b62a42f5-c15f-40a2-9927-1fb439321260")
+		)
+		(fp_line
+			(start 12.5 0)
+			(end -1.5 0)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ce084e10-047d-45bd-b1ee-27f8622f22f0")
+		)
+		(fp_line
+			(start 12.5 0)
+			(end 12.5 -3.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e14751a4-06a6-4dc5-ae48-1b2d13c133ef")
+		)
+		(fp_line
+			(start -2.5 -0.5)
+			(end -2.5 -3.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c4d35189-6e8e-4e93-95e8-d1246e2ea812")
+		)
+		(fp_line
+			(start -2 -3.3)
+			(end -2.5 -3.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "10d439cd-05e4-4244-9276-277d122aae0c")
+		)
+		(fp_line
+			(start 12.5 -3.3)
+			(end -2 -3.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f556c60e-f918-46f0-9b99-79373233fa29")
+		)
+		(pad "1" thru_hole roundrect
+			(at 0 0 270)
+			(size 1.4 1.4)
+			(drill 0.9)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(roundrect_rratio 0.25)
+			(uuid "e7316f8c-7694-419a-a9dc-3a9bbedccfeb")
+		)
+		(pad "2" thru_hole circle
+			(at 2 0 270)
+			(size 1.4 1.4)
+			(drill 0.9)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(uuid "99dd64ef-e3c5-42b6-8fd4-0439cb14461d")
+		)
+		(pad "3" thru_hole circle
+			(at 6 0 270)
+			(size 1.4 1.4)
+			(drill 0.9)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(uuid "678f3924-e8c6-4d36-b9c6-3dc1f2ca5d4d")
+		)
+		(pad "4" thru_hole circle
+			(at 8 0 270)
+			(size 1.4 1.4)
+			(drill 0.9)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(uuid "8aad8c4b-5c1d-4fc0-a643-55c20883421f")
+		)
+		(pad "5" thru_hole circle
+			(at 10 0 270)
+			(size 1.4 1.4)
+			(drill 0.9)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(uuid "c93ea350-28a5-405c-99ad-0abbc5e468ff")
+		)
+		(pad "6" thru_hole circle
+			(at 0 -3.3 270)
+			(size 1.4 1.4)
+			(drill 0.9)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "+5V")
+			(uuid "d40ba12e-c7a2-4c07-847a-fc811ae44747")
+		)
+		(pad "7" thru_hole circle
+			(at 2 -3.3 270)
+			(size 1.4 1.4)
+			(drill 0.9)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "+3V3")
+			(uuid "e616ce7f-1ae5-4c0f-a12c-1eceb6a4bf5b")
+		)
+		(pad "8" thru_hole circle
+			(at 6 -3.3 270)
+			(size 1.4 1.4)
+			(drill 0.9)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "VREF")
+			(uuid "ecf07b84-59ad-4a57-a2a8-c9e1ab240777")
+		)
+		(pad "9" thru_hole circle
+			(at 8 -3.3 270)
+			(size 1.4 1.4)
+			(drill 0.9)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "+1V8")
+			(uuid "7396ff9e-c0be-4d31-8767-972c3ba6f04a")
+		)
+		(pad "10" thru_hole circle
+			(at 10 -3.3 270)
+			(size 1.4 1.4)
+			(drill 0.9)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "VTARGET")
+			(uuid "581ab6c2-8255-4f30-a9a3-4adb697e8bb5")
+		)
+		(embedded_fonts no)
+		(model "${KIPRJMOD}/tigard.3dshapes/SSSS224100.step"
+			(offset
+				(xyz 5 1.65 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:PinHeader_2x05_P1.27mm_Vertical_SMD"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec7b2c")
+		(at 53.280000 56.320000)
+		(descr "surface-mounted straight pin header, 2x05, 1.27mm pitch, double rows")
+		(tags "Surface mounted pin header SMD 2x05 1.27mm double row")
+		(property "Reference" "J5"
+			(at 0 -4.235 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "7097a562-f886-425f-8ba4-a7d093934f9b")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "CORTEX"
+			(at -0.03 -4.42 0)
+			(layer "F.SilkS")
+			(uuid "1f1224aa-d2ae-412c-b395-28e3a9a4efa6")
+			(effects
+				(font
+					(size 0.8 0.8)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "73db39bc-e5d4-44ef-97b0-9720fd69c689")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "98a5393e-11dc-4040-9e17-cf1f8fdec050")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ebe7f5a")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -3.15321 -3.91521)
+			(end -2.794 -3.556)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d3699612-a441-4f79-9514-ba019da55f39")
+		)
+		(fp_line
+			(start -3.09 -3.17)
+			(end -1.765 -3.17)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "97368cc0-02b9-4690-ab90-66718688e4a4")
+		)
+		(fp_line
+			(start -2.794 -3.556)
+			(end -3.15321 -3.91521)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "21daa393-2812-4aba-9363-d30177de9a4f")
+		)
+		(fp_line
+			(start -2.794 -3.556)
+			(end -2.794 -4.63363)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "746e5c06-0179-406a-84a1-9dfddb169fb9")
+		)
+		(fp_line
+			(start -2.794 -3.556)
+			(end -2.43479 -3.91521)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "c18dbb45-2473-4444-9081-cdbf71859bd1")
+		)
+		(fp_line
+			(start -1.765 -3.235)
+			(end -1.765 -3.17)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "dd5edfe8-bda7-4ad7-89a3-18099473c8d6")
+		)
+		(fp_line
+			(start -1.765 -3.235)
+			(end 1.765 -3.235)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b55638eb-8408-419b-87b4-681934f08c18")
+		)
+		(fp_line
+			(start -1.765 3.17)
+			(end -1.765 3.235)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "13af60b2-d1f2-4f4c-b359-b3aa5fbb9a63")
+		)
+		(fp_line
+			(start -1.765 3.235)
+			(end 1.765 3.235)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "736cb6bb-1b07-400b-b8b1-d81f84290eba")
+		)
+		(fp_line
+			(start 1.765 -3.235)
+			(end 1.765 -3.17)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "bf03bae6-df65-4bde-bf30-0c18b5648da2")
+		)
+		(fp_line
+			(start 1.765 3.17)
+			(end 1.765 3.235)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "8ec523b3-ef42-4184-b228-c8249e203d39")
+		)
+		(fp_line
+			(start -4.3 -3.7)
+			(end -4.3 3.7)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "80ec5cb9-7bed-46fc-af7b-eeaa5ff08d8b")
+		)
+		(fp_line
+			(start -4.3 3.7)
+			(end 4.3 3.7)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "8fa3052a-5e8e-4263-acc4-1e47bb484020")
+		)
+		(fp_line
+			(start 4.3 -3.7)
+			(end -4.3 -3.7)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "98521784-3572-4b6e-a237-843b51b29136")
+		)
+		(fp_line
+			(start 4.3 3.7)
+			(end 4.3 -3.7)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "4acab31e-01f1-4e49-bea2-c46c35392b03")
+		)
+		(fp_line
+			(start -2.75 -2.74)
+			(end -2.75 -2.34)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "41c509d8-c91a-45b2-9b5b-adeb9f5de12a")
+		)
+		(fp_line
+			(start -2.75 -2.34)
+			(end -1.705 -2.34)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c8ac6f2c-dac9-4dc9-bc36-882f637164c3")
+		)
+		(fp_line
+			(start -2.75 -1.47)
+			(end -2.75 -1.07)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "949e111c-8335-4f13-bd39-3cb4bb8744b4")
+		)
+		(fp_line
+			(start -2.75 -1.07)
+			(end -1.705 -1.07)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "6a0bd6ce-54c7-4d1c-92b0-e5dc9eb71d38")
+		)
+		(fp_line
+			(start -2.75 -0.2)
+			(end -2.75 0.2)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f1b1c2ab-d8ee-445a-bf54-f26b18fbfdff")
+		)
+		(fp_line
+			(start -2.75 0.2)
+			(end -1.705 0.2)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "439e6418-cbcf-4f87-90fc-23e3a1cc0c63")
+		)
+		(fp_line
+			(start -2.75 1.07)
+			(end -2.75 1.47)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c9e1c4d8-44e1-41bd-bd66-c94c84331414")
+		)
+		(fp_line
+			(start -2.75 1.47)
+			(end -1.705 1.47)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "02ae2a43-5941-4bfc-b470-834c5e11eeb3")
+		)
+		(fp_line
+			(start -2.75 2.34)
+			(end -2.75 2.74)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "808cfbc4-25c8-420c-9beb-94d45b156f96")
+		)
+		(fp_line
+			(start -2.75 2.74)
+			(end -1.705 2.74)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "04da7e0c-b31b-4da9-bebf-4bf5fc7dcb9d")
+		)
+		(fp_line
+			(start -1.705 -2.74)
+			(end -2.75 -2.74)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d25d81e3-750e-42a0-a4a8-b067a6bdbef9")
+		)
+		(fp_line
+			(start -1.705 -2.74)
+			(end -1.27 -3.175)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "edc6864c-f83a-421e-834c-c8cd2ca26e1f")
+		)
+		(fp_line
+			(start -1.705 -1.47)
+			(end -2.75 -1.47)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e09bed96-4323-4829-8aad-9bac83194b38")
+		)
+		(fp_line
+			(start -1.705 -0.2)
+			(end -2.75 -0.2)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "10e1ba3b-d6b2-4531-b3d8-b3629c533435")
+		)
+		(fp_line
+			(start -1.705 1.07)
+			(end -2.75 1.07)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "0178ab99-5621-4475-a8da-f76ae7e35e57")
+		)
+		(fp_line
+			(start -1.705 2.34)
+			(end -2.75 2.34)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e4410a1b-43ac-406e-9c33-3d737742fedd")
+		)
+		(fp_line
+			(start -1.705 3.175)
+			(end -1.705 -2.74)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "35937651-4aa1-4c8a-88cb-9753f6330b98")
+		)
+		(fp_line
+			(start -1.27 -3.175)
+			(end 1.705 -3.175)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "23e1bc37-9f44-4fc3-8e39-058810929824")
+		)
+		(fp_line
+			(start 1.705 -3.175)
+			(end 1.705 3.175)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "6493db1b-121f-4ad1-9ecf-6e4fc3b12ea5")
+		)
+		(fp_line
+			(start 1.705 -2.74)
+			(end 2.75 -2.74)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "47f698c7-746e-4204-892e-85daf8033d0e")
+		)
+		(fp_line
+			(start 1.705 -1.47)
+			(end 2.75 -1.47)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "09665dd1-239f-46a8-9368-272ee284e34f")
+		)
+		(fp_line
+			(start 1.705 -0.2)
+			(end 2.75 -0.2)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "24698cb5-2739-4000-9c9c-bde00e9a800c")
+		)
+		(fp_line
+			(start 1.705 1.07)
+			(end 2.75 1.07)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b7afe8e0-a662-4fd8-a2c0-0cca81b8419d")
+		)
+		(fp_line
+			(start 1.705 2.34)
+			(end 2.75 2.34)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f48a7ad1-4626-45ff-8d6f-2335272728bc")
+		)
+		(fp_line
+			(start 1.705 3.175)
+			(end -1.705 3.175)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "559befd6-eb78-4004-97c2-b7ca81e39a08")
+		)
+		(fp_line
+			(start 2.75 -2.74)
+			(end 2.75 -2.34)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "7f0b2703-f35a-4e07-b701-aa1365993aa5")
+		)
+		(fp_line
+			(start 2.75 -2.34)
+			(end 1.705 -2.34)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ed432557-e727-4373-bddf-1b1ce6cdcae4")
+		)
+		(fp_line
+			(start 2.75 -1.47)
+			(end 2.75 -1.07)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "1681f093-18a5-4bad-8135-5bb0d9061020")
+		)
+		(fp_line
+			(start 2.75 -1.07)
+			(end 1.705 -1.07)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e515b37e-6e42-4aea-93e3-5feda8cb37ff")
+		)
+		(fp_line
+			(start 2.75 -0.2)
+			(end 2.75 0.2)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "8b34ac11-f3f3-46b5-93ae-2df79cd4b2dc")
+		)
+		(fp_line
+			(start 2.75 0.2)
+			(end 1.705 0.2)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9d1e637a-b555-4909-ab02-c71867a13866")
+		)
+		(fp_line
+			(start 2.75 1.07)
+			(end 2.75 1.47)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "fa2b965e-0394-4495-a218-8d84e8307c6c")
+		)
+		(fp_line
+			(start 2.75 1.47)
+			(end 1.705 1.47)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d6454e1a-1256-4b34-abfa-190eea938102")
+		)
+		(fp_line
+			(start 2.75 2.34)
+			(end 2.75 2.74)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e30a78ea-0671-43d7-a02f-c12130bdc4cc")
+		)
+		(fp_line
+			(start 2.75 2.74)
+			(end 1.705 2.74)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ec3eafbf-719e-4352-b11a-6536c653546c")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "f4de8b2d-bbcf-498f-92e4-615676b1d9ba")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -1.95 -2.54)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VTARGET")
+			(uuid "0b92c6dc-7fc1-4157-8d60-3eb1d2cd54e9")
+		)
+		(pad "2" smd roundrect
+			(at 1.95 -2.54)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/CORTEX_PIN2")
+			(uuid "34a0bebf-3549-43c3-a195-95357eb4382b")
+		)
+		(pad "3" smd roundrect
+			(at -1.95 -1.27)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "a76df55d-ecbc-44e7-adda-b807c870a395")
+		)
+		(pad "4" smd roundrect
+			(at 1.95 -1.27)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/CLK")
+			(uuid "6798e648-1589-4006-939c-d49d9417bfb5")
+		)
+		(pad "5" smd roundrect
+			(at -1.95 0)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "b8cb8fd2-2f28-4a19-a529-71d4fb3cfcec")
+		)
+		(pad "6" smd roundrect
+			(at 1.95 0)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/CIPO")
+			(uuid "325e1233-c7af-462b-92a8-6820c95ed089")
+		)
+		(pad "7" smd roundrect
+			(at -1.95 1.27)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "e0e8b091-ed89-4240-a9e3-231a1b8e9899")
+		)
+		(pad "8" smd roundrect
+			(at 1.95 1.27)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/COPI")
+			(uuid "6b200b18-a577-49b6-8276-7462a03582a1")
+		)
+		(pad "9" smd roundrect
+			(at -1.95 2.54)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "14dc5d4c-a9d6-48fc-bc32-53d53a374ad6")
+		)
+		(pad "10" smd roundrect
+			(at 1.95 2.54)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/xPB5")
+			(uuid "883e4674-570b-40a4-a62a-027f6b849dd1")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Connector_PinHeader_1.27mm.3dshapes/PinHeader_2x05_P1.27mm_Vertical_SMD.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec7cd1")
+		(at 44.750000 48.650000 90)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C1"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "79c22dea-dd87-4dd4-8201-de39ac87e5c2")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "2u2"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "7cbe176a-4664-494b-92aa-d739a58e21ea")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "136a90ba-9605-44d8-86f6-a21820480b5d")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "32066274-470a-42fc-be70-c97aa5dc7e0b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ee3ddb8")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "6d93e7c0-86b6-4dcf-929e-fc8ec411b9d4")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "405b7d95-8848-45b2-a9b2-40015ced495b")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "8f570cea-1b7b-487c-919e-c8d6aa01b288")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "3682645a-ceb9-4115-ae52-1da9ceddb695")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f03ce8e2-449f-41b2-81d5-cb9828408d67")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f8ad9c27-1f1c-4b74-83ea-7644546f9809")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "696f5bdf-bc43-45ba-a9e7-671980d3e51b")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d5295ec7-fb99-4999-b7c1-a7301c0d1ac1")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "7e600654-cfae-4aa1-9fbe-cf0c23b81160")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+5V")
+			(uuid "32f40528-1aad-4eda-a099-9520ca38d821")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "e6736db0-59c7-4f9a-9425-d6a98b37c8d2")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:Crystal_SMD_3225-4Pin_3.2x2.5mm_RoundRect"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec7f91")
+		(at 47.250000 49.250000 180)
+		(descr "SMD Crystal SERIES SMD3225/4 http://www.txccrystal.com/images/pdf/7m-accuracy.pdf, 3.2x2.5mm^2 package")
+		(tags "SMD SMT crystal")
+		(property "Reference" "Y1"
+			(at 0 -2.45 0)
+			(layer "F.Fab")
+			(uuid "758a30fa-7f43-4867-814a-5b4f392c4f12")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "12MHz"
+			(at 0 2.45 0)
+			(layer "F.Fab")
+			(uuid "31abad22-380b-4fec-a991-18a532e021dd")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "00dc83d7-798c-46c3-b9e6-419c8fb6cf97")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "840afdc4-6236-49ad-b5ab-47f5fabd5db0")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ee8326f")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -2 1.65)
+			(end 2 1.65)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "f1c63cc9-d26d-47b8-893b-61d458e61b73")
+		)
+		(fp_line
+			(start -2 -1.65)
+			(end -2 1.65)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "21d93c0f-1a8b-453f-b7a6-7d03c31a4746")
+		)
+		(fp_line
+			(start 2.1 1.7)
+			(end 2.1 -1.7)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "14e05e93-769a-45de-a156-a944a3811f5d")
+		)
+		(fp_line
+			(start 2.1 -1.7)
+			(end -2.1 -1.7)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "cf155659-ae81-4a56-8207-84dea7dbbc3d")
+		)
+		(fp_line
+			(start -2.1 1.7)
+			(end 2.1 1.7)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "4ba1b27f-bcfe-40f0-8f2d-2189d323626d")
+		)
+		(fp_line
+			(start -2.1 -1.7)
+			(end -2.1 1.7)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "c5459575-026e-459f-a3ae-a784a5bb8be9")
+		)
+		(fp_line
+			(start 1.6 1.25)
+			(end 1.6 -1.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e964a623-dbad-4841-bc4a-a7af18d6f326")
+		)
+		(fp_line
+			(start 1.6 -1.25)
+			(end -1.6 -1.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "958c3730-7ce1-4276-8e41-4d424712589c")
+		)
+		(fp_line
+			(start -1.6 1.25)
+			(end 1.6 1.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f36ae5cb-1771-4260-887e-bcd6a10b686b")
+		)
+		(fp_line
+			(start -1.6 0.25)
+			(end -0.6 1.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "774d561d-96d4-4ac4-b6d2-913d8641a79d")
+		)
+		(fp_line
+			(start -1.6 -1.25)
+			(end -1.6 1.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "4bb909f0-0bb8-4bc2-8fdc-b1acb0341311")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "6f406be3-2983-411b-9d40-105ea79be03c")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.105)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -1.1 0.85 180)
+			(size 1.4 1.2)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(C23-Pad1)")
+			(uuid "b75ade58-7002-492e-883e-f9590150d9f8")
+		)
+		(pad "2" smd roundrect
+			(at 1.1 0.85 180)
+			(size 1.4 1.2)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "7475f053-7f2b-4ce4-a9c2-52eeb0805407")
+		)
+		(pad "3" smd roundrect
+			(at 1.1 -0.85 180)
+			(size 1.4 1.2)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(C24-Pad1)")
+			(uuid "54aa79d3-a16e-4d1d-9e60-68fb7c4f0e51")
+		)
+		(pad "4" smd roundrect
+			(at -1.1 -0.85 180)
+			(size 1.4 1.2)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "7b7d292c-5a54-4852-abff-c1aa8356e5fc")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Crystal.3dshapes/Crystal_SMD_3225-4Pin_3.2x2.5mm.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec7fc5")
+		(at 56.500000 57.015000 90)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C16"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "3dc6f090-b3e9-4bb1-bcd0-7bfecc5dcb88")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100n"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "e0bb4644-ec7e-47d4-a9cc-29e63a9bb5ef")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "f8232fe5-fc5f-446f-8706-cbe0b9c506ea")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "edaeda6c-b238-4b62-a368-8f90b0bc0518")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f8a4b5c")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "6c4a4275-2c88-4be2-97fc-437b3f18286a")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "acd4d0df-ff51-47d0-8fc4-5aa7685ef7eb")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "0dfb4019-5d87-4bf1-b9d2-554d2dd2e968")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "32ff14e0-29e1-487f-9719-fd18f11ff19b")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a0d361f2-72c8-43d1-9a68-7d57ff0506f3")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "51228778-957f-4c0f-a938-c86fa4fa604b")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "407fcbdd-7ba3-4197-8c68-807270c96848")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "1fb4ebeb-a79f-4cc4-bce8-124ba858b7a4")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "9fdd75cc-829e-4850-9216-223737c44cd3")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "d564b245-b180-4cbe-862b-f75aaaf9459d")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "2869c505-fdc0-4351-8e1b-21b90d33ea8d")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:R_Array_Convex_4x0402_RoundRect"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec7ff7")
+		(at 62.500000 58.200000)
+		(descr "Chip Resistor Network, ROHM MNR04 (see mnr_g.pdf)")
+		(tags "resistor array")
+		(property "Reference" "RN2"
+			(at 0 -2.1 0)
+			(layer "F.Fab")
+			(uuid "5e81c52d-f742-4f6a-939a-49de4eb1491c")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100k"
+			(at 0 2.1 0)
+			(layer "F.Fab")
+			(uuid "ba264274-0db4-4918-a9a2-040d3c3b9d2a")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "4faaf7d9-e733-43c7-9eef-297b1fca389a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "5b4e3f88-bf6f-4b1f-931e-01f92166e772")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ee3079f")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.25 -1.18)
+			(end -0.25 -1.18)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "2e1129a8-4e83-4f69-91e7-9506f4297540")
+		)
+		(fp_line
+			(start 0.25 1.18)
+			(end -0.25 1.18)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "769dd7d1-3636-4f6f-8332-946b0cf405b2")
+		)
+		(fp_line
+			(start -1 -1.25)
+			(end -1 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "28420b1a-9304-4f34-b248-cddd7bad7a62")
+		)
+		(fp_line
+			(start -1 -1.25)
+			(end 1 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "b8a2bdf3-19bc-4563-9a0d-0a5d2f71a0cd")
+		)
+		(fp_line
+			(start 1 1.25)
+			(end -1 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "1205d770-1cb0-4811-8645-2ce8b884c513")
+		)
+		(fp_line
+			(start 1 1.25)
+			(end 1 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "b7b29aa5-6dfd-4e05-8466-63f660c4f542")
+		)
+		(fp_line
+			(start -0.5 -1)
+			(end 0.5 -1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c8dd9b54-e4a3-46c2-b195-bc0b07ac0859")
+		)
+		(fp_line
+			(start -0.5 1)
+			(end -0.5 -1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "896d484f-a06f-4ff2-8fd5-033a726f455b")
+		)
+		(fp_line
+			(start 0.5 -1)
+			(end 0.5 1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b537abe3-2263-4d0b-acea-9ab05f753100")
+		)
+		(fp_line
+			(start 0.5 1)
+			(end -0.5 1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "1ff9b6d3-ad32-4a77-8f25-2842be5534e2")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "75a4a348-2b07-4a85-bd48-edfec09c0e96")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.075)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.5 -0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "137e162f-1e23-46a8-961e-be50f2635748")
+		)
+		(pad "2" smd roundrect
+			(at -0.5 -0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "0e683dcc-793e-415f-a1af-87ab0fa470c2")
+		)
+		(pad "3" smd roundrect
+			(at -0.5 0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "9a6af302-83c9-448b-91df-b8bf301c2565")
+		)
+		(pad "4" smd roundrect
+			(at -0.5 0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "c4d03475-1877-4794-8d33-3db68641c52f")
+		)
+		(pad "5" smd roundrect
+			(at 0.5 0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD0")
+			(uuid "7b8243ca-ec3e-4f5d-ac6d-67bd47038637")
+		)
+		(pad "6" smd roundrect
+			(at 0.5 0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD2")
+			(uuid "9e3b8009-fc89-4e3a-bfe1-cd12ccdff0c9")
+		)
+		(pad "7" smd roundrect
+			(at 0.5 -0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD4")
+			(uuid "c1c62aef-4633-45ee-a8e9-818dbadbe5df")
+		)
+		(pad "8" smd roundrect
+			(at 0.5 -0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD5")
+			(uuid "e33fb8a2-5d4a-436f-aa7a-ca1197a6aba1")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_Array_Convex_4x0402.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:R_Array_Convex_4x0402_RoundRect"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8039")
+		(at 67.500000 62.850000)
+		(descr "Chip Resistor Network, ROHM MNR04 (see mnr_g.pdf)")
+		(tags "resistor array")
+		(property "Reference" "RN4"
+			(at 0 -2.1 0)
+			(layer "F.Fab")
+			(uuid "b0017a08-ffbd-40d3-8f0c-e5bdb003f628")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100"
+			(at 0 2.1 0)
+			(layer "F.Fab")
+			(uuid "ad635fb2-8e2d-41fd-961a-58580422fae4")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "4181703f-e47a-44af-803b-85316cf05707")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "dd345dc8-2a97-4505-86f7-08a82e0f5977")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ed37960")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.25 -1.18)
+			(end -0.25 -1.18)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "5ed75a97-f87d-4e03-aa40-43f90dea4a85")
+		)
+		(fp_line
+			(start 0.25 1.18)
+			(end -0.25 1.18)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "55b7c542-b272-49fd-8dbc-0d4ac10a142e")
+		)
+		(fp_line
+			(start -1 -1.25)
+			(end -1 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "73557a9a-ba4b-4994-b0b1-8ba1f3fca203")
+		)
+		(fp_line
+			(start -1 -1.25)
+			(end 1 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2edb470d-6f4e-4ad8-9e2d-93012a7f56dd")
+		)
+		(fp_line
+			(start 1 1.25)
+			(end -1 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "b713169e-c08e-4574-9acf-f2bb79b5746f")
+		)
+		(fp_line
+			(start 1 1.25)
+			(end 1 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "30cb840f-2fc8-402e-aeb5-62f3dc673177")
+		)
+		(fp_line
+			(start -0.5 -1)
+			(end 0.5 -1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ed177c45-9b86-4f16-84fb-40c51cc260d1")
+		)
+		(fp_line
+			(start -0.5 1)
+			(end -0.5 -1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "8433ce38-5e6f-48e5-8b32-e0af3bfa3eef")
+		)
+		(fp_line
+			(start 0.5 -1)
+			(end 0.5 1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "bec166e2-841c-42e7-b143-845b458534fc")
+		)
+		(fp_line
+			(start 0.5 1)
+			(end -0.5 1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a94cf72e-a02b-4a1e-8266-27b4d8e9fe77")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "3d77ad12-91c4-4ad4-86bb-70d2c46b8a05")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.075)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.5 -0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN4-Pad1)")
+			(uuid "4a11bc81-cf50-4526-9d32-2d32715229a5")
+		)
+		(pad "2" smd roundrect
+			(at -0.5 -0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN4-Pad2)")
+			(uuid "8f373570-d9ba-4a03-b11f-4b687ffb585e")
+		)
+		(pad "3" smd roundrect
+			(at -0.5 0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN4-Pad3)")
+			(uuid "64304a7e-6ef9-405e-bb36-95b7524ea858")
+		)
+		(pad "4" smd roundrect
+			(at -0.5 0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN4-Pad4)")
+			(uuid "e950bb96-b1cd-4bd2-ac7b-d447a2c853ef")
+		)
+		(pad "5" smd roundrect
+			(at 0.5 0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/UART_TX")
+			(uuid "c8979ee8-d00d-4feb-b4de-c1572d157b6b")
+		)
+		(pad "6" smd roundrect
+			(at 0.5 0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/~{UART_RTS}")
+			(uuid "5b3ba8d5-cb7f-4cec-9b81-a34fec75ef0b")
+		)
+		(pad "7" smd roundrect
+			(at 0.5 -0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/~{UART_DTR}")
+			(uuid "c4a44988-3921-4c15-9bc7-33c5492a0a0c")
+		)
+		(pad "8" smd roundrect
+			(at 0.5 -0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/xPB5")
+			(uuid "47f845cd-eba8-4e1c-9f49-25d72cf73263")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_Array_Convex_4x0402.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8109")
+		(at 50.500000 48.150000)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R12"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "f33cc1da-75af-483c-9fcd-e0760447896e")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "38cd2c81-e295-4cc6-a973-e63b0e245287")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "0bb8e5e9-c85e-4fcf-8247-c789456fd341")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "811c0a84-114c-4d73-acb4-49931ca58414")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f33b0f5")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "a43ecebd-2287-4c59-9b5b-236143460b76")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "5b1a7c6c-11a6-4d73-b6f4-2853bf576a3a")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "67c6ccf6-ad42-48fd-9849-57588b4c7ae1")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "32ece7e5-7386-44af-a09f-71a574ebcc6c")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "13fc50a9-fba0-4d10-b3d4-6ba0fc4bb3a0")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "8c4dbaf0-7965-412d-a7b1-02bc41f30f05")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "0cb79354-54a9-498a-b6e0-44e6b2cbf265")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "7e687b9f-c736-4534-953b-40deca74daeb")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "f8bd20b5-d2c4-4062-9f0e-c19e227b82f7")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "61f40a00-410d-4380-87be-3c46f7c09368")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/EECS")
+			(uuid "78a6f3f0-f051-43b3-9e47-7f317752e41b")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8136")
+		(at 61.015000 50.900000 180)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C14"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "873eca4f-e31d-4419-9595-34392475f3e5")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100n"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "59106cc4-c482-4ab0-8eb6-bbd510c0143f")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b2581a5b-606d-40e7-8be8-cb8683105c60")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "c3d3aeb6-fc59-4264-87e9-be3559952dae")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f8a4454")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "403db22b-d711-44ff-addb-d917639a0116")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "18914abe-e784-4c36-a5d7-b82cd425c0d6")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "68a507f5-fc4e-4e26-99a9-fba35c64f04e")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "c08c10b6-06a8-403d-bba6-9b3652dabdd4")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c03a1d99-74cd-42c8-aa39-7e2c014034f1")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f1377eab-d959-467b-ac80-251c8d7c07b8")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "fbf00c76-fa50-4d6c-81b2-fef3d677b7af")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c5449e23-aa87-45c0-a65f-77f27adaddc8")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "585d958c-ae1b-4766-a9ce-d0a990750bed")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "8a07deaa-2638-459c-9ef6-14c322de1aa9")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "75a5ce28-3eb1-4eed-b89b-4b8760ad05d1")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "LED_SMD:LED_0603_1608Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8164")
+		(at 48.920000 44.622000 -90)
+		(descr "LED SMD 0603 (1608 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "diode")
+		(property "Reference" "D1"
+			(at 0 -1.43 90)
+			(layer "F.Fab")
+			(uuid "98459e9f-e99a-4437-829b-b7ec00a9e9f4")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "YELLOW"
+			(at 0 1.43 90)
+			(layer "F.Fab")
+			(uuid "f7c3aa98-dbb1-440a-995b-d097b2a5bc5f")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "f3e25ce6-c10a-4558-b34a-656855dbb916")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "863b86af-e60e-4d59-b6a5-ee8d9c002a75")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f292e89")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -1.485 0.735)
+			(end 0.8 0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "900cc357-3d38-4e0e-aa8c-84613cbf4092")
+		)
+		(fp_line
+			(start -1.485 -0.735)
+			(end -1.485 0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "0fa7df76-983d-4952-b36f-681fb71c5b88")
+		)
+		(fp_line
+			(start 0.8 -0.735)
+			(end -1.485 -0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "99436eed-50af-4809-8680-8c61a1fa7bfe")
+		)
+		(fp_line
+			(start -1.48 0.73)
+			(end -1.48 -0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "e4e13b89-0c12-4c85-84ee-154671cde1b3")
+		)
+		(fp_line
+			(start 1.48 0.73)
+			(end -1.48 0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "73720a44-23d3-410a-8338-7cf2e00d9b3c")
+		)
+		(fp_line
+			(start -1.48 -0.73)
+			(end 1.48 -0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "60dfeead-a55c-4188-a2e8-a6a6c840f8bb")
+		)
+		(fp_line
+			(start 1.48 -0.73)
+			(end 1.48 0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "74f4d13c-377a-49da-be76-c368a7da3ce8")
+		)
+		(fp_line
+			(start -0.8 0.4)
+			(end 0.8 0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c45d079e-ae6d-49a4-908f-dbfc117e2a4a")
+		)
+		(fp_line
+			(start 0.8 0.4)
+			(end 0.8 -0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "1a6d886b-7dde-4137-984f-5ab41ff3ea82")
+		)
+		(fp_line
+			(start -0.8 -0.1)
+			(end -0.8 0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ede9a986-9f71-458d-b63b-639fcc3ddad2")
+		)
+		(fp_line
+			(start -0.5 -0.4)
+			(end -0.8 -0.1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d76365d9-a585-446e-9a4e-69c2569506bb")
+		)
+		(fp_line
+			(start 0.8 -0.4)
+			(end -0.5 -0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "5b43165b-7b1c-4e8e-a406-e9cf327db0fa")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "742ca2d2-43fd-429e-bc86-f8c35aa1bbd7")
+			(effects
+				(font
+					(size 0.4 0.4)
+					(thickness 0.06)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.7875 0 270)
+			(size 0.875 0.95)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "f126e847-221e-4c61-be3d-1e9dfe06a58d")
+		)
+		(pad "2" smd roundrect
+			(at 0.7875 0 270)
+			(size 0.875 0.95)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(D1-Pad2)")
+			(uuid "93fbba88-a01b-4d80-8d20-856529bc32b6")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/LED_SMD.3dshapes/LED_0603_1608Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec82b6")
+		(at 66.515000 44.900000 180)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C11"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "b16a175f-b593-432f-9a67-98b971f25031")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100n"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "5236577f-a9b1-4190-a720-6bc5a3222de4")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "f777cac8-c525-46b2-83f4-63591104d0fa")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "011bd6e9-91fb-49b5-ba74-05b17246aaa7")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f7771f1")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "fdaf2c03-84f2-4e69-87a0-7ace7630d4d8")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "1eab2155-285c-476e-8bcc-c6bf1343b3c0")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "630353c3-9e80-48d1-9ad9-b58c00bcc6f0")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "421f9fcb-8d63-4dc7-8fdd-899dcd94055b")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "073a17ea-e2a4-41f2-a091-da07122dc3d4")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "bd777317-9392-406c-9a40-2c3440f7b8b0")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "1b86ed77-88a8-4d4e-bfb7-e392a71d0905")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "49eb451d-2785-4647-9a54-e65e8606be4d")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "9edf8a9b-5b0f-4658-a4b6-81977eaeabb6")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREG")
+			(uuid "3669394d-aa8d-4651-b87b-bd528f3ab0cb")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "36b3eec4-51ab-4630-a7d6-a06b724e8a24")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec82e0")
+		(at 43.120000 58.150000)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R16"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "ae7cd424-6162-4a2a-9c2c-379a40f05723")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "330"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "cc33c862-2e8b-49d8-a523-cdc8319ef910")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "1845ff0f-1676-44d1-ad89-7268e76f796a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "1c1a5485-d98e-4384-8d14-d444ea591bad")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005eec3913")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "8d5ccbfb-d3c4-465f-ac0a-a5c20017f99b")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "287ec7b7-09dc-490f-addf-406ba906c815")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "73e4cded-7459-478b-b162-d25b923de97b")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "80e0eb86-3e58-445e-ad66-2ef32963466a")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a17c8d37-2195-420c-ae05-2174f09a5f17")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "fef5b3a8-595f-4c1e-bedf-4decb7bf318c")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "7e050dd1-9a01-4e74-a39b-cf3cbf22a9e7")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "5bc2fa60-a969-47e5-87a4-22dfbd0df49c")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "02977e7c-15e3-4ca0-8926-74f077ca68f7")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/SWDIO")
+			(uuid "81a68ea5-16fb-4c65-8e34-195f81312718")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/COPI")
+			(uuid "ed7ff3cb-ec01-4323-a46a-f87a72beb4b8")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8394")
+		(at 34.015000 61.650000)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R14"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "fee8b951-e6d5-4e13-910e-a55a16745641")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "5c29e3f3-f73f-4887-991d-47e077e3e3c0")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "1516236f-ee78-4b35-998f-658f33a2812a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "cd3dfbfa-2bdd-4bf1-8d25-9841f805c850")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f34c029")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "80424990-5aeb-4fb4-9295-54d480063197")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "5d6a0bb7-00dc-44bc-b50b-c57283d2c87d")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "b322925e-536b-4f25-a17d-31fdd859d6cd")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "5380f92f-8f11-40ab-944b-0899431443de")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "fa374c1b-4b78-435f-a9c9-6c43989ede85")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "eff2e8cc-3f19-4096-9cbc-7c7ee44313b5")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a92e49f1-f927-472b-b5e8-aca863791565")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e60bd223-94b4-4bdf-b545-8d455a596ed6")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "6a5bdbb7-f428-44ae-81fb-28abda4ae3a3")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "e54db2b5-6b78-41bb-bb7a-7a2cf1c8106e")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/EECLK")
+			(uuid "439c90b1-cdb5-4244-a7f8-c12e08f50bfd")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec83be")
+		(at 51.000000 51.900000 180)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R3"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "c0aa8caa-b2ea-422a-ac4e-8c10790c4393")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "1M"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "a91a9329-7a9f-425a-a677-f9ad61d2e8c3")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "1729fb67-06cd-46bd-9ae8-5b3d1ea9e6c5")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "c0786536-efb9-40f6-b872-36f7bf9c8cf9")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f3a89c1")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "65fcbdaa-307f-48c6-a6d6-b7b0173e023a")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "f60c043d-8d09-46d3-8d37-d98857a7e39f")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "e6e0494d-b3ab-4803-abae-7375e7625179")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "8ebf9d9f-aff5-41f9-9783-39e7bbf8099b")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e5deea1e-e328-45c8-86fd-3bb62b926a89")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "4544c1cc-7959-4a0d-8c6a-184c674f55a7")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "03dbcccd-3745-468a-a907-3cad35c40921")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "791cfcd5-0b73-4354-86a3-40ce90e0c99f")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "a6f4e27e-d19a-48c1-915f-e5cd065bc87d")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "8ba6b89f-ad15-4427-903a-84b0f912b9ed")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(C25-Pad2)")
+			(uuid "04b95793-6925-42f1-a885-ba003d2c323c")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Inductor_SMD:L_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec83e8")
+		(at 57.500000 41.135000 270)
+		(descr "Inductor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "inductor")
+		(property "Reference" "FB3"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "62caf72d-87a1-43ed-996c-0312cd6543a6")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "600R, 0.5A"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "d2fff713-c8bd-4300-b09e-ce750f1cf4bd")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "687c4c7f-0a36-452c-83cd-8c5bfac390bb")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "2db3aab7-ba6e-4b50-bc41-db487461d897")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005fa24965")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2965eee7-b7e1-464a-9bed-f37f6a00c5b4")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "6e8bfb4e-fc1e-48d5-8ba2-b079e8e6918c")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "b88dc8b1-f75b-445b-9f61-40afa271fb80")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "b55560e6-7ebe-4e22-abd5-7cef53ccedbc")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "95140cf7-32fa-4ced-9fd3-e4d1bc294d53")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b6fd31a9-d77f-4c01-bb45-f069572ec02e")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e7fad558-b717-47b9-9a2a-f7c3e990be3e")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "96e350a1-7a5b-4cb5-99cd-8ead4d7576de")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "1ac799a4-ab52-442e-905f-19ba5f52f5b5")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+5V")
+			(uuid "71fe107f-00c0-414b-9012-8436d6199f20")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/VBUS")
+			(uuid "4cabdd9b-d2f6-4479-9b91-1c9c75e0f129")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Inductor_SMD.3dshapes/L_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:OSHW-Symbol_4.4x4mm_SilkScreen"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec840b")
+		(at 35.95 68.01)
+		(descr "Open Source Hardware Symbol")
+		(tags "Logo Symbol OSHW")
+		(property "Reference" "LOGO1"
+			(at 0 0 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "a0285014-d6cf-4a2d-a4ea-19d3dfcd91d5")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "Logo_Open_Hardware_Small"
+			(at 0.75 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "3eac44fd-b589-41cc-9f82-f0418de73732")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "7b319ea8-790c-4a55-80c9-24e85cf3e290")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "4c5e4ad0-aaba-40e2-9938-4f09c3c4fcfa")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ed57cd6")
+		(attr exclude_from_pos_files exclude_from_bom)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_poly
+			(pts
+				(xy 0.050687 -1.999998) (xy 0.09016 -1.999886) (xy 0.128144 -1.999707) (xy 0.163966 -1.999461) (xy 0.196955 -1.99915)
+				(xy 0.226436 -1.998772) (xy 0.251738 -1.998329) (xy 0.272186 -1.997819) (xy 0.287109 -1.997243)
+				(xy 0.295834 -1.996601) (xy 0.297783 -1.996202) (xy 0.3052 -1.99012) (xy 0.308164 -1.986054) (xy 0.309353 -1.981551)
+				(xy 0.311752 -1.97046) (xy 0.315253 -1.953333) (xy 0.31975 -1.930721) (xy 0.325135 -1.903175) (xy 0.331302 -1.871246)
+				(xy 0.338145 -1.835486) (xy 0.345555 -1.796447) (xy 0.353427 -1.754678) (xy 0.361653 -1.710732)
+				(xy 0.36461 -1.694861) (xy 0.372912 -1.650305) (xy 0.380859 -1.607745) (xy 0.388346 -1.567732) (xy 0.395271 -1.530815)
+				(xy 0.40153 -1.497544) (xy 0.407018 -1.468468) (xy 0.411633 -1.444136) (xy 0.415272 -1.425097) (xy 0.417829 -1.411902)
+				(xy 0.419203 -1.4051) (xy 0.419386 -1.404325) (xy 0.423218 -1.397756) (xy 0.429385 -1.39082) (xy 0.434706 -1.387613)
+				(xy 0.446043 -1.382076) (xy 0.462656 -1.374511) (xy 0.483807 -1.365218) (xy 0.508757 -1.354498)
+				(xy 0.536766 -1.342652) (xy 0.567095 -1.329983) (xy 0.599005 -1.31679) (xy 0.631757 -1.303376) (xy 0.664611 -1.29004)
+				(xy 0.696828 -1.277085) (xy 0.72767 -1.264812) (xy 0.756397 -1.253521) (xy 0.78227 -1.243514) (xy 0.804549 -1.235091)
+				(xy 0.822496 -1.228555) (xy 0.835372 -1.224206) (xy 0.842436 -1.222346) (xy 0.843021 -1.222299)
+				(xy 0.853723 -1.223797) (xy 0.865604 -1.229044) (xy 0.877502 -1.236622) (xy 0.884781 -1.241643)
+				(xy 0.897341 -1.250279) (xy 0.914471 -1.262044) (xy 0.935463 -1.276449) (xy 0.959606 -1.29301) (xy 0.986193 -1.311239)
+				(xy 1.014512 -1.330649) (xy 1.038068 -1.34679) (xy 1.070357 -1.368915) (xy 1.104069 -1.392025) (xy 1.138044 -1.415323)
+				(xy 1.171123 -1.438015) (xy 1.202145 -1.459303) (xy 1.229952 -1.478393) (xy 1.253384 -1.49449) (xy 1.261128 -1.499813)
+				(xy 1.287962 -1.518115) (xy 1.309511 -1.532454) (xy 1.326334 -1.54317) (xy 1.338992 -1.550605) (xy 1.348045 -1.555098)
+				(xy 1.354053 -1.556991) (xy 1.355423 -1.557102) (xy 1.357894 -1.556644) (xy 1.361238 -1.555055)
+				(xy 1.365795 -1.552014) (xy 1.371904 -1.547199) (xy 1.379904 -1.540288) (xy 1.390133 -1.530959)
+				(xy 1.402931 -1.518892) (xy 1.418637 -1.503763) (xy 1.43759 -1.485252) (xy 1.460129 -1.463038) (xy 1.486592 -1.436797)
+				(xy 1.51732 -1.406209) (xy 1.55265 -1.370951) (xy 1.572327 -1.351291) (xy 1.614787 -1.308775) (xy 1.652141 -1.271197)
+				(xy 1.684498 -1.238447) (xy 1.711964 -1.210412) (xy 1.734648 -1.18698) (xy 1.752659 -1.168039) (xy 1.766103 -1.153477)
+				(xy 1.77509 -1.143183) (xy 1.779727 -1.137044) (xy 1.780438 -1.135543) (xy 1.780737 -1.125462) (xy 1.778751 -1.118373)
+				(xy 1.776123 -1.114295) (xy 1.769704 -1.104707) (xy 1.759816 -1.090083) (xy 1.746781 -1.070894)
+				(xy 1.73092 -1.047612) (xy 1.712556 -1.02071) (xy 1.692011 -0.99066) (xy 1.669608 -0.957934) (xy 1.645667 -0.923004)
+				(xy 1.620512 -0.886343) (xy 1.614639 -0.877789) (xy 1.584506 -0.833867) (xy 1.558261 -0.795512)
+				(xy 1.535649 -0.762332) (xy 1.516413 -0.733933) (xy 1.500297 -0.709923) (xy 1.487045 -0.689909)
+				(xy 1.476402 -0.673498) (xy 1.46811 -0.660297) (xy 1.461915 -0.649914) (xy 1.45756 -0.641956) (xy 1.454789 -0.63603)
+				(xy 1.453346 -0.631744) (xy 1.453014 -0.629828) (xy 1.453034 -0.626059) (xy 1.453853 -0.620987)
+				(xy 1.455673 -0.614102) (xy 1.458694 -0.604896) (xy 1.463119 -0.592861) (xy 1.469149 -0.577487)
+				(xy 1.476987 -0.558267) (xy 1.486834 -0.534691) (xy 1.498892 -0.506253) (xy 1.513362 -0.472442)
+				(xy 1.530447 -0.432751) (xy 1.540169 -0.410229) (xy 1.560473 -0.363376) (xy 1.578131 -0.32297) (xy 1.593267 -0.288748)
+				(xy 1.605999 -0.260446) (xy 1.616451 -0.237801) (xy 1.624742 -0.220547) (xy 1.630995 -0.208423)
+				(xy 1.63533 -0.201163) (xy 1.637375 -0.198767) (xy 1.642559 -0.196515) (xy 1.653301 -0.193441) (xy 1.669857 -0.18949)
+				(xy 1.692482 -0.184607) (xy 1.721432 -0.178739) (xy 1.756961 -0.171829) (xy 1.799327 -0.163825)
+				(xy 1.812997 -0.161278) (xy 1.874571 -0.149841) (xy 1.929408 -0.139653) (xy 1.977904 -0.130634)
+				(xy 2.02046 -0.122699) (xy 2.057473 -0.115769) (xy 2.089342 -0.109759) (xy 2.116464 -0.104589) (xy 2.139237 -0.100176)
+				(xy 2.158062 -0.096437) (xy 2.173334 -0.093291) (xy 2.185454 -0.090655) (xy 2.194818 -0.088448)
+				(xy 2.201826 -0.086587) (xy 2.206876 -0.084989) (xy 2.210365 -0.083574) (xy 2.212692 -0.082257)
+				(xy 2.214256 -0.080959) (xy 2.215455 -0.079595) (xy 2.216686 -0.078085) (xy 2.216783 -0.077972)
+				(xy 2.22495 -0.068558) (xy 2.22495 0.512333) (xy 2.214968 0.522044) (xy 2.212789 0.523934) (xy 2.209957 0.525743)
+				(xy 2.205975 0.527578) (xy 2.200346 0.529544) (xy 2.192571 0.531747) (xy 2.182153 0.534293) (xy 2.168594 0.537288)
+				(xy 2.151397 0.540836) (xy 2.130063 0.545045) (xy 2.104096 0.55002) (xy 2.072997 0.555867) (xy 2.036269 0.56269)
+				(xy 1.993413 0.570597) (xy 1.943933 0.579692) (xy 1.94184 0.580077) (xy 1.898721 0.58803) (xy 1.857394 0.59572)
+				(xy 1.81846 0.603031) (xy 1.78252 0.609848) (xy 1.750173 0.616054) (xy 1.72202 0.621533) (xy 1.698663 0.62617)
+				(xy 1.6807 0.629849) (xy 1.668734 0.632454) (xy 1.663562 0.633792) (xy 1.652924 0.638957) (xy 1.644817 0.645275)
+				(xy 1.643319 0.647165) (xy 1.641109 0.651859) (xy 1.636459 0.662707) (xy 1.62961 0.679119) (xy 1.620804 0.700502)
+				(xy 1.610283 0.726266) (xy 1.598286 0.755818) (xy 1.585056 0.788568) (xy 1.570834 0.823924) (xy 1.555861 0.861294)
+				(xy 1.551653 0.871823) (xy 1.534258 0.915386) (xy 1.519379 0.952726) (xy 1.506829 0.984362) (xy 1.496425 1.010809)
+				(xy 1.487982 1.032584) (xy 1.481317 1.050204) (xy 1.476244 1.064186) (xy 1.472578 1.075048) (xy 1.470137 1.083304)
+				(xy 1.468735 1.089473) (xy 1.468188 1.094072) (xy 1.468311 1.097616) (xy 1.468921 1.100623) (xy 1.469418 1.102303)
+				(xy 1.472149 1.107504) (xy 1.478678 1.118167) (xy 1.488667 1.133785) (xy 1.501781 1.153854) (xy 1.517683 1.177867)
+				(xy 1.536037 1.20532) (xy 1.556506 1.235705) (xy 1.578755 1.268519) (xy 1.602445 1.303254) (xy 1.624577 1.335529)
+				(xy 1.6492 1.371368) (xy 1.67267 1.405567) (xy 1.694654 1.43764) (xy 1.714821 1.4671) (xy 1.732839 1.493462)
+				(xy 1.748375 1.516238) (xy 1.761096 1.534941) (xy 1.770671 1.549087) (xy 1.776767 1.558187) (xy 1.779018 1.561685)
+				(xy 1.780985 1.570233) (xy 1.780438 1.578354) (xy 1.777849 1.582539) (xy 1.770963 1.590824) (xy 1.759672 1.603322)
+				(xy 1.743868 1.620144) (xy 1.723444 1.641403) (xy 1.698291 1.667211) (xy 1.668301 1.697679) (xy 1.633367 1.732919)
+				(xy 1.59338 1.773043) (xy 1.571884 1.794546) (xy 1.534488 1.831911) (xy 1.501872 1.864468) (xy 1.473684 1.892543)
+				(xy 1.449576 1.916466) (xy 1.429196 1.936563) (xy 1.412195 1.953163) (xy 1.398223 1.966594) (xy 1.386929 1.977185)
+				(xy 1.377964 1.985261) (xy 1.370977 1.991153) (xy 1.365619 1.995187) (xy 1.361539 1.997692) (xy 1.358387 1.998996)
+				(xy 1.355814 1.999426) (xy 1.353468 1.999311) (xy 1.353326 1.999294) (xy 1.348204 1.997428) (xy 1.338982 1.992501)
+				(xy 1.32541 1.984352) (xy 1.30724 1.97282) (xy 1.284222 1.957741) (xy 1.256107 1.938955) (xy 1.222644 1.9163)
+				(xy 1.183586 1.889615) (xy 1.174178 1.88316) (xy 1.140944 1.860343) (xy 1.107778 1.837572) (xy 1.075483 1.815399)
+				(xy 1.044866 1.794378) (xy 1.016731 1.775061) (xy 0.991885 1.758001) (xy 0.971132 1.743752) (xy 0.955278 1.732866)
+				(xy 0.951053 1.729965) (xy 0.929644 1.715469) (xy 0.91319 1.704859) (xy 0.900845 1.697655) (xy 0.891763 1.693378)
+				(xy 0.885098 1.69155) (xy 0.882881 1.691397) (xy 0.876698 1.692684) (xy 0.866232 1.696669) (xy 0.851095 1.703536)
+				(xy 0.830899 1.713471) (xy 0.805256 1.726661) (xy 0.77378 1.743289) (xy 0.768998 1.745841) (xy 0.743875 1.759166)
+				(xy 0.720616 1.77131) (xy 0.700038 1.781861) (xy 0.68296 1.790406) (xy 0.670201 1.796532) (xy 0.662581 1.799828)
+				(xy 0.66092 1.800286) (xy 0.652878 1.798206) (xy 0.648531 1.795749) (xy 0.646582 1.792031) (xy 0.642057 1.78206)
+				(xy 0.635147 1.766293) (xy 0.626043 1.74519) (xy 0.614936 1.719208) (xy 0.602016 1.688805) (xy 0.587474 1.65444)
+				(xy 0.571501 1.616569) (xy 0.554288 1.575653) (xy 0.536025 1.532148) (xy 0.516904 1.486513) (xy 0.497115 1.439206)
+				(xy 0.476848 1.390685) (xy 0.456296 1.341408) (xy 0.435648 1.291834) (xy 0.415095 1.24242) (xy 0.394828 1.193625)
+				(xy 0.375037 1.145906) (xy 0.355915 1.099722) (xy 0.337651 1.055531) (xy 0.320435 1.013791) (xy 0.30446 0.97496)
+				(xy 0.289916 0.939497) (xy 0.276993 0.907859) (xy 0.265882 0.880504) (xy 0.256774 0.857891) (xy 0.249861 0.840478)
+				(xy 0.245331 0.828723) (xy 0.243377 0.823084) (xy 0.243312 0.822703) (xy 0.245719 0.814414) (xy 0.252883 0.805363)
+				(xy 0.265461 0.794903) (xy 0.284111 0.782385) (xy 0.284257 0.782294) (xy 0.347287 0.739467) (xy 0.403501 0.694367)
+				(xy 0.453024 0.646846) (xy 0.495982 0.596757) (xy 0.532499 0.54395) (xy 0.5627 0.488277) (xy 0.586711 0.429591)
+				(xy 0.589743 0.420652) (xy 0.598441 0.393521) (xy 0.605214 0.370001) (xy 0.610296 0.34849) (xy 0.613919 0.327389)
+				(xy 0.616316 0.305097) (xy 0.61772 0.280014) (xy 0.618364 0.250538) (xy 0.618489 0.223221) (xy 0.618418 0.194467)
+				(xy 0.618149 0.171681) (xy 0.617598 0.15357) (xy 0.61668 0.138844) (xy 0.615312 0.12621) (xy 0.61341 0.114379)
+				(xy 0.610889 0.102057) (xy 0.610476 0.100197) (xy 0.592154 0.033237) (xy 0.567957 -0.029527) (xy 0.537762 -0.088329)
+				(xy 0.501444 -0.143401) (xy 0.458881 -0.194977) (xy 0.448257 -0.206306) (xy 0.399575 -0.25187) (xy 0.346668 -0.291701)
+				(xy 0.290042 -0.325545) (xy 0.230206 -0.353146) (xy 0.167667 -0.37425) (xy 0.102932 -0.3886) (xy 0.078676 -0.392127)
+				(xy 0.053089 -0.394308) (xy 0.022882 -0.395241) (xy -0.0099 -0.395002) (xy -0.043211 -0.393667)
+				(xy -0.075007 -0.391309) (xy -0.103241 -0.388004) (xy -0.121592 -0.384792) (xy -0.186624 -0.367375)
+				(xy -0.248597 -0.343647) (xy -0.307131 -0.31395) (xy -0.361843 -0.278626) (xy -0.412352 -0.238018)
+				(xy -0.458276 -0.192468) (xy -0.499234 -0.142317) (xy -0.534843 -0.08791) (xy -0.564722 -0.029586)
+				(xy -0.58849 0.03231) (xy -0.589189 0.034481) (xy -0.605547 0.09727) (xy -0.615227 0.161806) (xy -0.61823 0.227158)
+				(xy -0.614561 0.292395) (xy -0.604223 0.356588) (xy -0.587685 0.417405) (xy -0.565004 0.476061)
+				(xy -0.536818 0.531279) (xy -0.502876 0.583358) (xy -0.462928 0.632594) (xy -0.416726 0.679284)
+				(xy -0.364018 0.723726) (xy -0.304554 0.766218) (xy -0.282409 0.78049) (xy -0.266043 0.79112) (xy -0.254959 0.799305)
+				(xy -0.248037 0.806018) (xy -0.244156 0.812231) (xy -0.243332 0.814399) (xy -0.242912 0.816314)
+				(xy -0.24287 0.818857) (xy -0.243334 0.822357) (xy -0.244436 0.827145) (xy -0.246306 0.833549) (xy -0.249074 0.841899)
+				(xy -0.25287 0.852522) (xy -0.257825 0.865749) (xy -0.26407 0.881908) (xy -0.271734 0.901329) (xy -0.280949 0.92434)
+				(xy -0.291844 0.951272) (xy -0.304549 0.982452) (xy -0.319196 1.01821) (xy -0.335914 1.058875) (xy -0.354835 1.104776)
+				(xy -0.376087 1.156243) (xy -0.399802 1.213603) (xy -0.426111 1.277188) (xy -0.439157 1.308709)
+				(xy -0.462542 1.365134) (xy -0.485233 1.419749) (xy -0.50707 1.472173) (xy -0.527892 1.522028) (xy -0.54754 1.568934)
+				(xy -0.565852 1.612511) (xy -0.582668 1.65238) (xy -0.597828 1.688162) (xy -0.611172 1.719477) (xy -0.622539 1.745946)
+				(xy -0.631769 1.767189) (xy -0.638702 1.782827) (xy -0.643177 1.79248) (xy -0.644983 1.795749) (xy -0.653124 1.799575)
+				(xy -0.65753 1.800286) (xy -0.662214 1.798617) (xy -0.672449 1.793889) (xy -0.687413 1.786517) (xy -0.706283 1.776917)
+				(xy -0.728238 1.765504) (xy -0.752454 1.752693) (xy -0.765251 1.745841) (xy -0.796788 1.729026)
+				(xy -0.822522 1.715622) (xy -0.84293 1.705403) (xy -0.85849 1.69814) (xy -0.869678 1.693603) (xy -0.876971 1.691564)
+				(xy -0.878858 1.691397) (xy -0.882024 1.691949) (xy -0.886733 1.693773) (xy -0.89338 1.697126) (xy -0.902356 1.702263)
+				(xy -0.914055 1.70944) (xy -0.92887 1.718912) (xy -0.947193 1.730935) (xy -0.969417 1.745765) (xy -0.995935 1.763658)
+				(xy -1.02714 1.784868) (xy -1.063426 1.809652) (xy -1.105184 1.838265) (xy -1.115955 1.845656) (xy -1.160217 1.87599)
+				(xy -1.198876 1.902386) (xy -1.232276 1.92507) (xy -1.260761 1.944267) (xy -1.284675 1.960201) (xy -1.304363 1.973098)
+				(xy -1.320168 1.983182) (xy -1.332435 1.99068) (xy -1.341507 1.995815) (xy -1.347729 1.998814) (xy -1.351445 1.999901)
+				(xy -1.351747 1.999914) (xy -1.354216 1.999464) (xy -1.357543 1.997899) (xy -1.362067 1.994898)
+				(xy -1.368127 1.990138) (xy -1.376062 1.983298) (xy -1.386212 1.974056) (xy -1.398916 1.96209) (xy -1.414513 1.947078)
+				(xy -1.433344 1.928699) (xy -1.455746 1.90663) (xy -1.48206 1.88055) (xy -1.512625 1.850137) (xy -1.547781 1.815069)
+				(xy -1.568942 1.793934) (xy -1.601098 1.761731) (xy -1.63177 1.730867) (xy -1.660565 1.701742) (xy -1.687094 1.67476)
+				(xy -1.710965 1.650323) (xy -1.731787 1.628834) (xy -1.74917 1.610695) (xy -1.762722 1.596307) (xy -1.772052 1.586075)
+				(xy -1.77677 1.580399) (xy -1.777273 1.579519) (xy -1.777471 1.569553) (xy -1.775555 1.562581) (xy -1.772908 1.558262)
+				(xy -1.766475 1.548455) (xy -1.756589 1.533651) (xy -1.743582 1.514338) (xy -1.727786 1.491007)
+				(xy -1.709534 1.464149) (xy -1.689157 1.434252) (xy -1.66699 1.401808) (xy -1.643363 1.367306) (xy -1.62014 1.333464)
+				(xy -1.59496 1.2967) (xy -1.571076 1.26162) (xy -1.548808 1.228707) (xy -1.528478 1.198445) (xy -1.510408 1.17132)
+				(xy -1.494918 1.147816) (xy -1.482331 1.128416) (xy -1.472966 1.113605) (xy -1.467146 1.103868)
+				(xy -1.46523 1.099959) (xy -1.464696 1.096931) (xy -1.464704 1.093184) (xy -1.465443 1.088197) (xy -1.4671 1.081451)
+				(xy -1.469864 1.072426) (xy -1.473923 1.060602) (xy -1.479464 1.04546) (xy -1.486676 1.026481) (xy -1.495747 1.003143)
+				(xy -1.506866 0.974928) (xy -1.520219 0.941316) (xy -1.535996 0.901787) (xy -1.546088 0.87655) (xy -1.564157 0.831384)
+				(xy -1.57973 0.792474) (xy -1.593015 0.75934) (xy -1.60422 0.731501) (xy -1.613554 0.708476) (xy -1.621223 0.689786)
+				(xy -1.627436 0.674949) (xy -1.632401 0.663484) (xy -1.636327 0.654913) (xy -1.63942 0.648753) (xy -1.641889 0.644524)
+				(xy -1.643943 0.641746) (xy -1.645788 0.639938) (xy -1.647634 0.638619) (xy -1.649618 0.637355)
+				(xy -1.654586 0.635758) (xy -1.666208 0.632969) (xy -1.683994 0.629084) (xy -1.707457 0.624203)
+				(xy -1.736106 0.618421) (xy -1.769452 0.611839) (xy -1.807005 0.604552) (xy -1.848277 0.59666) (xy -1.892778 0.588259)
+				(xy -1.931507 0.581027) (xy -1.982253 0.57159) (xy -2.026343 0.563364) (xy -2.064263 0.556247) (xy -2.096495 0.550134)
+				(xy -2.123525 0.544922) (xy -2.145835 0.540508) (xy -2.163911 0.536788) (xy -2.178236 0.533658)
+				(xy -2.189294 0.531016) (xy -2.197569 0.528757) (xy -2.203545 0.526778) (xy -2.207707 0.524976)
+				(xy -2.210538 0.523247) (xy -2.212522 0.521487) (xy -2.213154 0.52079) (xy -2.22132 0.51137) (xy -2.22132 -0.068558)
+				(xy -2.213064 -0.078157) (xy -2.21131 -0.079962) (xy -2.208965 -0.081684) (xy -2.20555 -0.083426)
+				(xy -2.200587 -0.085289) (xy -2.193596 -0.087377) (xy -2.184099 -0.089791) (xy -2.171617 -0.092633)
+				(xy -2.155671 -0.096006) (xy -2.135784 -0.100013) (xy -2.111476 -0.104754) (xy -2.082268 -0.110334)
+				(xy -2.047682 -0.116853) (xy -2.007239 -0.124415) (xy -1.96046 -0.133121) (xy -1.924894 -0.139728)
+				(xy -1.869256 -0.150114) (xy -1.819003 -0.159609) (xy -1.77435 -0.16817) (xy -1.735516 -0.175755)
+				(xy -1.702715 -0.182318) (xy -1.676167 -0.187816) (xy -1.656086 -0.192207) (xy -1.642692 -0.195447)
+				(xy -1.636199 -0.197491) (xy -1.635835 -0.197691) (xy -1.633768 -0.198958) (xy -1.631972 -0.200098)
+				(xy -1.630221 -0.201598) (xy -1.628291 -0.203944) (xy -1.625956 -0.207623) (xy -1.622992 -0.213122)
+				(xy -1.619172 -0.220927) (xy -1.614272 -0.231526) (xy -1.608066 -0.245403) (xy -1.60033 -0.263047)
+				(xy -1.590838 -0.284944) (xy -1.579365 -0.31158) (xy -1.565686 -0.343442) (xy -1.549576 -0.381016)
+				(xy -1.531604 -0.422936) (xy -1.51355 -0.465115) (xy -1.498209 -0.501149) (xy -1.485381 -0.531544)
+				(xy -1.474867 -0.556804) (xy -1.466469 -0.577435) (xy -1.459988 -0.593941) (xy -1.455223 -0.606828)
+				(xy -1.451977 -0.616601) (xy -1.450051 -0.623765) (xy -1.449245 -0.628825) (xy -1.449288 -0.631826)
+				(xy -1.450733 -0.636009) (xy -1.454481 -0.643284) (xy -1.460728 -0.653947) (xy -1.469668 -0.668293)
+				(xy -1.481494 -0.686619) (xy -1.496402 -0.709219) (xy -1.514585 -0.736389) (xy -1.536239 -0.768425)
+				(xy -1.561557 -0.805622) (xy -1.590733 -0.848276) (xy -1.611152 -0.878037) (xy -1.636532 -0.915016)
+				(xy -1.660771 -0.950369) (xy -1.683545 -0.983625) (xy -1.704533 -1.014311) (xy -1.723413 -1.041955)
+				(xy -1.739862 -1.066085) (xy -1.753558 -1.08623) (xy -1.76418 -1.101916) (xy -1.771406 -1.112672)
+				(xy -1.774912 -1.118025) (xy -1.775156 -1.118438) (xy -1.777301 -1.127358) (xy -1.776809 -1.135543)
+				(xy -1.774218 -1.13973) (xy -1.767329 -1.14802) (xy -1.756034 -1.160523) (xy -1.740225 -1.177351)
+				(xy -1.719793 -1.198618) (xy -1.694631 -1.224434) (xy -1.664631 -1.254911) (xy -1.629685 -1.290162)
+				(xy -1.589684 -1.330298) (xy -1.568698 -1.351291) (xy -1.53095 -1.388993) (xy -1.497977 -1.421866)
+				(xy -1.469437 -1.450231) (xy -1.44499 -1.474411) (xy -1.424296 -1.49473) (xy -1.407015 -1.511509)
+				(xy -1.392807 -1.525072) (xy -1.381332 -1.53574) (xy -1.372249 -1.543837) (xy -1.365219 -1.549685)
+				(xy -1.359901 -1.553607) (xy -1.355955 -1.555925) (xy -1.353041 -1.556961) (xy -1.351685 -1.557102)
+				(xy -1.348363 -1.556265) (xy -1.342654 -1.553608) (xy -1.334222 -1.548909) (xy -1.322732 -1.541949)
+				(xy -1.307849 -1.532508) (xy -1.289236 -1.520365) (xy -1.266558 -1.5053) (xy -1.239481 -1.487093)
+				(xy -1.207668 -1.465523) (xy -1.170783 -1.44037) (xy -1.128493 -1.411414) (xy -1.099501 -1.391517)
+				(xy -1.061836 -1.365689) (xy -1.025731 -1.341009) (xy -0.991657 -1.317794) (xy -0.960085 -1.296362)
+				(xy -0.931484 -1.277028) (xy -0.906325 -1.260109) (xy -0.885077 -1.245922) (xy -0.868212 -1.234784)
+				(xy -0.856198 -1.227012) (xy -0.849506 -1.222921) (xy -0.848441 -1.222392) (xy -0.84596 -1.221489)
+				(xy -0.843576 -1.220821) (xy -0.840779 -1.220579) (xy -0.837056 -1.220949) (xy -0.831898 -1.22212)
+				(xy -0.824793 -1.224279) (xy -0.815229 -1.227616) (xy -0.802697 -1.232317) (xy -0.786685 -1.238572)
+				(xy -0.766681 -1.246567) (xy -0.742176 -1.256492) (xy -0.712657 -1.268534) (xy -0.677614 -1.28288)
+				(xy -0.636536 -1.29972) (xy -0.621099 -1.30605) (xy -0.58605 -1.320498) (xy -0.552844 -1.334341)
+				(xy -0.522122 -1.347301) (xy -0.494527 -1.359098) (xy -0.470703 -1.369456) (xy -0.45129 -1.378095)
+				(xy -0.436933 -1.384737) (xy -0.428273 -1.389104) (xy -0.426069 -1.390525) (xy -0.419476 -1.397952)
+				(xy -0.415775 -1.404325) (xy -0.41485 -1.408723) (xy -0.412705 -1.419709) (xy -0.409442 -1.436733)
+				(xy -0.405166 -1.459246) (xy -0.39998 -1.486698) (xy -0.393987 -1.51854) (xy -0.387291 -1.554222)
+				(xy -0.379996 -1.593195) (xy -0.372204 -1.634909) (xy -0.364021 -1.678815) (xy -0.361052 -1.694762)
+				(xy -0.35273 -1.739339) (xy -0.344723 -1.781933) (xy -0.337138 -1.821995) (xy -0.330083 -1.858972)
+				(xy -0.323665 -1.892312) (xy -0.31799 -1.921464) (xy -0.313165 -1.945877) (xy -0.309297 -1.964998)
+				(xy -0.306494 -1.978276) (xy -0.304862 -1.98516) (xy -0.304588 -1.985955) (xy -0.298445 -1.993166)
+				(xy -0.294154 -1.996202) (xy -0.289304 -1.996882) (xy -0.277869 -1.997496) (xy -0.26052 -1.998043)
+				(xy -0.237931 -1.998525) (xy -0.210774 -1.998941) (xy -0.179723 -1.99929) (xy -0.145451 -1.999573)
+				(xy -0.108629 -1.999791) (xy -0.069932 -1.999941) (xy -0.030031 -2.000026) (xy 0.010399 -2.000045)
+				(xy 0.050687 -1.999998)
+			)
+			(stroke
+				(width 0.01)
+				(type solid)
+			)
+			(fill yes)
+			(layer "F.SilkS")
+			(uuid "24a4f09c-bcf2-4d37-b069-f9016865e628")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8955")
+		(at 38.515000 62.400000 180)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R19"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "10923be2-ad37-4cfa-9777-2abce06655aa")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "4f0df729-8c6a-45e5-86a8-8b570e92236b")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "1531b616-4636-4693-902d-c828b930d7ce")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "7bb9038b-811c-4c92-8155-bb145c8856e3")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-0000601ada37")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "918c34dc-c621-4597-825d-6af99fcf702c")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "b48a6284-32ec-469c-8a01-386e429f4aab")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "e7541b12-027e-42e1-b51d-4eead07d0470")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "d8748be3-b036-4f61-8e12-1edf818a019c")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "04727b06-cf1d-47b9-ae86-c7640f9df266")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "0302117d-9be2-4b99-9ae0-9846971cf660")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "147c7a62-9e83-4a23-8bd3-ffcbc09f2b3c")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "82ca9151-06bc-425f-a883-d8df30ab77af")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "afa72659-0673-4785-af47-969a4491d48e")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(R19-Pad1)")
+			(uuid "40b11841-6fc5-4cb4-9f6e-7bedf9010380")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "666e4edc-04a7-49b9-bb6e-671f60d95d81")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec897f")
+		(at 35.500000 61.908000 180)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R5"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "ffe15749-d196-48ed-b96d-2753b30855bf")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "330"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "78342dae-943e-4c4d-a6c6-03168173060d")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "22e6cdf1-ab78-4cb2-b524-13b083924334")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "d8c1eb00-0a03-43c0-ad29-b517cfd703f8")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-0000601afbaf")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "b6c2f6fb-44a3-4ae9-84d3-c7b4be8834d8")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "0bf56e37-13e9-4c77-b0e0-b3b4e68df491")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2576df56-b9ae-4fd3-8219-8c7e7b814c6f")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "da8db2bc-5fba-4662-9d74-4683cdb5698d")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "05735906-a1ac-4c3d-b0df-7d490c4e69c9")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "42697b25-b7d4-4751-bba6-9c4b625f20fb")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "7c0b186d-dbec-492c-8741-4b35e8e07bb1")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ef754388-28d5-445a-be11-cfb380da3e8a")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "9376e41b-84bf-45f3-aa58-c31ea68afe59")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "16a20b31-b1c9-4e32-9b63-84142756fb8c")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(D2-Pad2)")
+			(uuid "08eb4d54-e333-4edb-b4ca-de35916e0e8a")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec89a9")
+		(at 41.000000 64.635000 90)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C9"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "ca3e7e69-3a97-42b6-9eb3-b7024d0fa283")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "2u2"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "f09669c3-4675-4f75-ab6a-8326d13c1093")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "1ada1a63-154e-4416-a87f-aa0b9fa87e83")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "7df42cd3-13ae-4850-9376-44204a7b9222")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005eec8444")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "7d8b566a-7e4c-48b2-8525-6853a2624186")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "43f5c3b6-a258-4894-8f19-b939ad17c509")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "afcd4454-99d7-41a3-b347-8fe1ede081a1")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "4a484c54-0a9a-4f69-af74-ef74c67d71b7")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "38e9c1e9-247b-41ef-a592-49f042f6c2b2")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c1dddc5a-5606-4ddb-aa0f-f888d25273de")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f051d52a-3c4a-42d8-b0e6-9a160a4641ee")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b5999448-5837-447e-8426-d0502bcdd60b")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "caffa770-7669-4613-b681-affa8efbc985")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREG")
+			(uuid "050b8ca2-52e1-4605-9d34-63d47c2e007c")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "50bea7b1-f701-4c39-bd3d-cdea28e17489")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Package_SO:TSSOP-24_4.4x7.8mm_P0.65mm"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec89ee")
+		(at 49.270000 61.900000)
+		(descr "TSSOP, 24 Pin (JEDEC MO-153 Var AD https://www.jedec.org/document_search?search_api_views_fulltext=MO-153), generated with kicad-footprint-generator ipc_gullwing_generator.py")
+		(tags "TSSOP SO")
+		(property "Reference" "U6"
+			(at 0 -4.85 0)
+			(layer "F.Fab")
+			(uuid "dc3357f4-8514-474d-a409-6c64a383593e")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "SN74LVC8T245"
+			(at 0 4.85 0)
+			(layer "F.Fab")
+			(uuid "0dc39160-b504-4859-85a3-b51f5bc58add")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "4c6784b9-3f2f-47ab-b0ad-412eee79c7e2")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "87eeab2b-8caa-4587-a080-cb580625d912")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005edc70fa")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0 -4.035)
+			(end -3.6 -4.035)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "8a6eb144-5f22-48fc-93e7-1d2a188e8d9a")
+		)
+		(fp_line
+			(start 0 -4.035)
+			(end 2.2 -4.035)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "7209b7d3-9af9-48e6-99dc-0f9249a525e3")
+		)
+		(fp_line
+			(start 0 4.035)
+			(end -2.2 4.035)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "1dd5edd3-37ab-4018-b568-ee45260d920e")
+		)
+		(fp_line
+			(start 0 4.035)
+			(end 2.2 4.035)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "27f56d80-36d5-48fe-b6ed-7b672573f7b5")
+		)
+		(fp_line
+			(start -3.85 -4.15)
+			(end -3.85 4.15)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "10e2e39f-e4ef-44e7-86b2-efb9995c5e2e")
+		)
+		(fp_line
+			(start -3.85 4.15)
+			(end 3.85 4.15)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "167bb9a4-2c7f-47bb-94ca-1ebf0673b701")
+		)
+		(fp_line
+			(start 3.85 -4.15)
+			(end -3.85 -4.15)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "847e6c15-c4cc-4fb0-8ed7-bbe6af0b9d27")
+		)
+		(fp_line
+			(start 3.85 4.15)
+			(end 3.85 -4.15)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "6f1782c9-3d56-4ffe-825d-e983d4a18125")
+		)
+		(fp_line
+			(start -2.2 -2.9)
+			(end -1.2 -3.9)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "5d1a1f9a-6d9f-46d4-bb6f-4789b2068311")
+		)
+		(fp_line
+			(start -2.2 3.9)
+			(end -2.2 -2.9)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "3a93bd1a-c007-48d6-a3d3-c7aa3a00e71c")
+		)
+		(fp_line
+			(start -1.2 -3.9)
+			(end 2.2 -3.9)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "483473b9-1283-4881-b4fa-8c83d8fee4e6")
+		)
+		(fp_line
+			(start 2.2 -3.9)
+			(end 2.2 3.9)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d16f3126-a1b7-4a65-b4fe-5e578100d3e9")
+		)
+		(fp_line
+			(start 2.2 3.9)
+			(end -2.2 3.9)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "cbbdfe46-14ad-4fd7-bf27-5da1be09c7b2")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "6bcd2d84-d9e4-42ba-8741-93fd9177bf5b")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -2.8625 -3.575)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "0fa6b909-3df7-47b3-a0cb-4954d4d8865a")
+		)
+		(pad "2" smd roundrect
+			(at -2.8625 -2.925)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(R19-Pad1)")
+			(uuid "c4ed339b-1513-4edf-807c-28c739effa57")
+		)
+		(pad "3" smd roundrect
+			(at -2.8625 -2.275)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN5-Pad8)")
+			(uuid "3b0b7e50-8b29-46f2-8ce2-dbdbf41af882")
+		)
+		(pad "4" smd roundrect
+			(at -2.8625 -1.625)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN5-Pad7)")
+			(uuid "7dd7cb20-2af4-44a1-8658-204ded849a66")
+		)
+		(pad "5" smd roundrect
+			(at -2.8625 -0.975)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN5-Pad6)")
+			(uuid "63a6dd5a-27db-44af-8169-291f728d697c")
+		)
+		(pad "6" smd roundrect
+			(at -2.8625 -0.325)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN5-Pad5)")
+			(uuid "31f21a2d-68dd-4e82-b808-6d8fa630719b")
+		)
+		(pad "7" smd roundrect
+			(at -2.8625 0.325)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN6-Pad8)")
+			(uuid "999a3082-c801-41b4-b63a-e539a7931043")
+		)
+		(pad "8" smd roundrect
+			(at -2.8625 0.975)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN6-Pad7)")
+			(uuid "b0ff7f43-1d6d-47ee-b3a3-1f10a2a29a31")
+		)
+		(pad "9" smd roundrect
+			(at -2.8625 1.625)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN6-Pad6)")
+			(uuid "de5eba7a-7a3a-43bc-bc4b-923c999775ba")
+		)
+		(pad "10" smd roundrect
+			(at -2.8625 2.275)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN6-Pad5)")
+			(uuid "43e176e5-7e7f-418a-bf13-46f77cb12bb1")
+		)
+		(pad "11" smd roundrect
+			(at -2.8625 2.925)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "a341416c-bf26-41f8-a013-213edfb17061")
+		)
+		(pad "12" smd roundrect
+			(at -2.8625 3.575)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "4653e73e-c4d0-4bf9-ab22-2da08d3b1145")
+		)
+		(pad "13" smd roundrect
+			(at 2.8625 3.575)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "46dad4c6-4d83-4b30-98d7-8c5b2a7f56e5")
+		)
+		(pad "14" smd roundrect
+			(at 2.8625 2.925)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN8-Pad4)")
+			(uuid "305a6464-1500-4734-a229-639452becee6")
+		)
+		(pad "15" smd roundrect
+			(at 2.8625 2.275)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN8-Pad3)")
+			(uuid "ea02d8fb-db9a-4f58-8279-ce7821d46ac9")
+		)
+		(pad "16" smd roundrect
+			(at 2.8625 1.625)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/ICE_CDONE")
+			(uuid "f6d871f8-d61e-4f45-98f7-119daa7b737c")
+		)
+		(pad "17" smd roundrect
+			(at 2.8625 0.975)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/DI")
+			(uuid "c6ae8299-31e7-4c03-b0da-6f239b47b59a")
+		)
+		(pad "18" smd roundrect
+			(at 2.8625 0.325)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/~{UART_DCD}")
+			(uuid "445420c2-99fa-40d6-8e95-247fd43b8beb")
+		)
+		(pad "19" smd roundrect
+			(at 2.8625 -0.325)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/~{UART_DSR}")
+			(uuid "8cf18b3d-6f29-4304-ae82-f0d2b16124f0")
+		)
+		(pad "20" smd roundrect
+			(at 2.8625 -0.975)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/~{UART_CTS}")
+			(uuid "43589fe4-2097-4d20-a182-0564ba5e50e8")
+		)
+		(pad "21" smd roundrect
+			(at 2.8625 -1.625)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/ICE_CDONE")
+			(uuid "6f7c8314-9154-4f5a-b662-19eea41a7398")
+		)
+		(pad "22" smd roundrect
+			(at 2.8625 -2.275)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/~{ENABLE}")
+			(uuid "54840450-cedc-4d66-83eb-9b587a9fa44b")
+		)
+		(pad "23" smd roundrect
+			(at 2.8625 -2.925)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "0fe3e084-edc4-4be7-ac0c-00dbca318a15")
+		)
+		(pad "24" smd roundrect
+			(at 2.8625 -3.575)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "b3b9bcda-45e8-4b31-b8b9-0ede9c190365")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Package_SO.3dshapes/TSSOP-24_4.4x7.8mm_P0.65mm.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8a84")
+		(at 48.943000 46.908000 180)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R4"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "8c4f401d-d616-4c4e-9ef0-a50582865f5d")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "330"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "be4d18fe-22e4-42db-bcb2-6ed2fa74bc5b")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "f18fd053-3d5a-47fd-85b1-5e324305f08b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "4e5a889f-628e-4c51-ae2f-6ed2990453fe")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ec7911b")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "1433eb8d-f188-45ae-a3bd-c2345282879d")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "4010cf6e-0a59-4f26-a9c7-f7b6751ba913")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "f999a0af-ce5d-4380-8446-d5a58ca9e85b")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "caff26d9-f99f-4249-ad4d-b1e7e5b5890e")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "8cce171d-2c43-4e50-b8d9-a15d7b579d0b")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "59cd8269-d1b0-4cc0-8cd0-486e94e6f6e3")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "3782645b-ecfc-464d-8424-f429007c8dfd")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "44da33a7-4b9a-42ff-bb4f-b5d5f5bf94fa")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "455073c0-5a88-4b5a-813f-b8f57d2367dc")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "9a39bac6-2dfd-4bc1-bc64-bf5c522b538c")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(D1-Pad2)")
+			(uuid "9ba14b8a-9687-4a78-9768-161c750ad733")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8ab1")
+		(at 47.735000 46.900000 180)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C23"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "5a20f3d2-4834-4c47-8721-590149e38f16")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "30pF"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "68b0120b-b578-4884-9de3-e22406a32036")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "fa90b151-0943-49a1-bef2-38af40ad14be")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "8c974ac8-7488-42dc-bc50-5f4561bac014")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ee9988b")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "4fce91ba-d548-49a6-b542-1175f3210be2")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "a9dcd031-e7fa-46c6-a5cc-b4aacfb9d977")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "eb988ec5-97e1-41eb-bfc1-6cc562ea4f0c")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "11a94ff2-e1b0-42f7-810e-541947fcc92f")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "8bd91719-9f08-4c3f-867f-9ba069df020f")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "75e08cca-fe77-4844-a22b-c82f34a666eb")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "edf25c1e-a1f1-49d9-bac8-691d9748b892")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "bf5cca5b-b9cb-444e-8122-b4a6ce891c27")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "7078e80d-e58b-470d-995c-f7f7363618d6")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(C23-Pad1)")
+			(uuid "655b0c5b-84e7-4e1c-ba55-a96cceb3c6b0")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "36d84aa4-22b3-4dd3-b709-77009d4e3d10")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:R_Array_Convex_4x0402_RoundRect"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8bb2")
+		(at 62.500000 55.600000)
+		(descr "Chip Resistor Network, ROHM MNR04 (see mnr_g.pdf)")
+		(tags "resistor array")
+		(property "Reference" "RN1"
+			(at 0 -2.1 0)
+			(layer "F.Fab")
+			(uuid "754f8d34-d47c-4b0e-a303-8c164f16077f")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100k"
+			(at 0 2.1 0)
+			(layer "F.Fab")
+			(uuid "636d5fc4-343b-4a98-943d-bdcee5a1d82c")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "bb436201-7d88-48f4-abb7-a24bd34fe7de")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "feed9315-a468-44d1-a171-191a3efcbd10")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ee2f88a")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.25 -1.18)
+			(end -0.25 -1.18)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "24a07ed9-10fd-4b75-bb0a-7653f4cd4c38")
+		)
+		(fp_line
+			(start 0.25 1.18)
+			(end -0.25 1.18)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "49a3771f-497d-4d37-9c36-ca61b243d7c0")
+		)
+		(fp_line
+			(start -1 -1.25)
+			(end -1 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "a0dafdba-c990-413e-a379-d374824927a6")
+		)
+		(fp_line
+			(start -1 -1.25)
+			(end 1 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "84d76322-4f33-4840-bf84-7c1de1b42cd0")
+		)
+		(fp_line
+			(start 1 1.25)
+			(end -1 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "fca51fc3-da12-4da9-bf35-5ee81019b77d")
+		)
+		(fp_line
+			(start 1 1.25)
+			(end 1 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "651d817a-abaa-47f6-8a18-ba25b0f14cb6")
+		)
+		(fp_line
+			(start -0.5 -1)
+			(end 0.5 -1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d6dd48b1-6283-4469-a84d-8ade8113553d")
+		)
+		(fp_line
+			(start -0.5 1)
+			(end -0.5 -1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "75f86ac8-ea2e-4d07-a31e-963df8139c8b")
+		)
+		(fp_line
+			(start 0.5 -1)
+			(end 0.5 1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c5568a4a-300d-40c5-b6c3-6f5789383ec7")
+		)
+		(fp_line
+			(start 0.5 1)
+			(end -0.5 1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "cc3f028b-8ab2-4397-ae4a-3f334476d4b7")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "a4ce06d8-656c-4c2a-a19d-49a92ca0332c")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.075)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.5 -0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "b8825e30-e091-4a01-b40e-febebc4cba15")
+		)
+		(pad "2" smd roundrect
+			(at -0.5 -0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "35fd670f-1e07-4691-9bce-54485016b6b7")
+		)
+		(pad "3" smd roundrect
+			(at -0.5 0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "375629d6-646a-4ddf-994b-f680a9e0f4a2")
+		)
+		(pad "4" smd roundrect
+			(at -0.5 0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "e788b78d-e33f-4f99-9356-2620f93f89fd")
+		)
+		(pad "5" smd roundrect
+			(at 0.5 0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD4")
+			(uuid "3371594e-8d68-4613-9de8-2b7d3aabf081")
+		)
+		(pad "6" smd roundrect
+			(at 0.5 0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD3")
+			(uuid "569dabef-433a-4979-b00a-8f52aaa8e1a6")
+		)
+		(pad "7" smd roundrect
+			(at 0.5 -0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD1")
+			(uuid "77a94cf1-d250-4380-b7b8-302c0d44e004")
+		)
+		(pad "8" smd roundrect
+			(at 0.5 -0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD0")
+			(uuid "fc010af3-6415-4ed9-986f-de458488686e")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_Array_Convex_4x0402.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Inductor_SMD:L_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8c9d")
+		(at 66.515000 43.900000)
+		(descr "Inductor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "inductor")
+		(property "Reference" "FB2"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "29129d35-9cd2-4da5-b16c-b8ad290b7b11")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "600R, 0.5A"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "63183969-6cfe-4430-b9fe-77c266b5a150")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "e7e007a3-7810-40a2-bb55-612a26247fe1")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "2eb3674c-d462-4a4b-a76f-2df159a5ac87")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f75562f")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "add0dd00-03c6-4b81-a9cd-3fe68b963af1")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "6de5a1d3-71bb-4454-aae4-79a850706e40")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "1ba1c34f-f87f-4890-ac40-7fae964f883f")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "f543b71f-0361-4392-9ff3-797604a0a0d4")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9b0c0c3c-75eb-41d4-9159-1dae2e8b192e")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c2db6faf-36c2-4370-be02-52aa19467bb5")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "eccc1ea8-5a06-498e-a970-a80e30850254")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f5c9395c-9b90-442e-a672-5a13cc6d3ae4")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "ffa29637-74cb-42e0-b7e2-d5925dffa566")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "dada4fa4-b366-43ba-9025-b31252c45441")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/VPLL")
+			(uuid "9f9a4283-c3de-4038-9344-ce03b5ead89e")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Inductor_SMD.3dshapes/L_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:SW_CuK_JS202011CQN_DPDT_Straight"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8cd7")
+		(at 40.580000 55.200000)
+		(descr "CuK sub miniature slide switch, JS series, DPDT, right angle, http://www.ckswitches.com/media/1422/js.pdf")
+		(tags "switch DPDT")
+		(property "Reference" "SW2"
+			(at 2.75 -1.6 0)
+			(layer "F.Fab")
+			(uuid "58ea607f-eb83-4a65-b15a-81389648bb83")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "MODE"
+			(at -3.33 -1.65 90)
+			(layer "F.SilkS")
+			(uuid "1b6f3c90-2a8f-4d07-8f1e-6b32df3b15ae")
+			(effects
+				(font
+					(size 0.8 0.8)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "bf21a75e-f61e-43a8-94e4-299faa83bac8")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "fa3c9ce2-1edf-4e9e-8274-c4d9e892649a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ffb28cb")
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -2.4 0.75)
+			(end -2.4 -0.45)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "86ecf18e-4d51-4df0-8b31-bcac40aeff9c")
+		)
+		(fp_line
+			(start -2.1 -3.75)
+			(end -0.9 -3.75)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "f6868bb1-42e5-4082-8c25-0e09e3bb8483")
+		)
+		(fp_line
+			(start -2.1 0.45)
+			(end -2.1 -3.75)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "39268507-2736-42dc-aaed-8ffe9b43c980")
+		)
+		(fp_line
+			(start -1.2 0.75)
+			(end -2.4 0.75)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "73d57e0d-0060-4969-94d5-17fe7556859a")
+		)
+		(fp_line
+			(start -0.9 0.45)
+			(end -2.1 0.45)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "bccfd025-91c6-418e-8eae-09b257cb78c0")
+		)
+		(fp_line
+			(start 5.9 -3.75)
+			(end 7.1 -3.75)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "356fdf04-d653-44ef-8fa9-af05f5a856ae")
+		)
+		(fp_line
+			(start 7.1 -3.75)
+			(end 7.1 0.45)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "bc8c2878-0ca1-4e7a-b61f-c19dc59eb26c")
+		)
+		(fp_line
+			(start 7.1 0.45)
+			(end 5.9 0.45)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "112f42d0-469c-44d0-aee6-cdfb2047bd71")
+		)
+		(fp_line
+			(start -2.25 -4.25)
+			(end -2.25 0.95)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "7ce50ae7-3959-41d6-bd76-857dec68bf83")
+		)
+		(fp_line
+			(start -2.25 -4.25)
+			(end 7.25 -4.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2ad616bb-7da1-40b9-9532-be02ddfccfe0")
+		)
+		(fp_line
+			(start 7.25 -4.25)
+			(end 7.25 0.95)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "4a0d61cd-8845-4eac-b4d5-10e7af5462ae")
+		)
+		(fp_line
+			(start 7.25 0.95)
+			(end -2.25 0.95)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "e2d247d1-d40b-4b8e-bde7-7a915acd08d6")
+		)
+		(fp_line
+			(start -2 -3.65)
+			(end -2 -0.65)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d3fec615-beda-4d9c-9824-524111678afe")
+		)
+		(fp_line
+			(start -2 -3.65)
+			(end 7 -3.65)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "af5ed991-dc18-4b27-a09e-5dc2107d8d77")
+		)
+		(fp_line
+			(start -1 0.35)
+			(end -2 -0.65)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9f036b34-aba8-4319-88a3-c263882afffd")
+		)
+		(fp_line
+			(start 7 -3.65)
+			(end 7 0.35)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "2cd1f182-66eb-4211-af41-fa6fccf79ce9")
+		)
+		(fp_line
+			(start 7 0.35)
+			(end -1 0.35)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "27226600-c935-47ca-88d3-e4577ff8a22d")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 2 -1.65 0)
+			(layer "F.Fab")
+			(uuid "a36f4ade-e832-4104-9b27-499fd75f2695")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "1" thru_hole roundrect
+			(at 0 0)
+			(size 1.4 1.4)
+			(drill 0.9)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(roundrect_rratio 0.25)
+			(net "/CS")
+			(uuid "bffb0d94-1fdd-463a-a71d-f11c38f93634")
+		)
+		(pad "2" thru_hole circle
+			(at 2.5 0)
+			(size 1.4 1.4)
+			(drill 0.9)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/CORTEX_PIN2")
+			(uuid "c1d543a4-142a-4506-a097-ed80cfece82c")
+		)
+		(pad "3" thru_hole circle
+			(at 5 0)
+			(size 1.4 1.4)
+			(drill 0.9)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/SWDIO")
+			(uuid "5c4d66ab-e904-44f0-a800-96b77ca9503a")
+		)
+		(pad "4" thru_hole circle
+			(at 0 -3.3 90)
+			(size 1.4 1.4)
+			(drill 0.9)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/CIPO")
+			(uuid "5593fa40-a577-4892-a80c-6211e0b5a089")
+		)
+		(pad "5" thru_hole circle
+			(at 2.5 -3.3)
+			(size 1.4 1.4)
+			(drill 0.9)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/DI")
+			(uuid "0b4b256e-1252-4009-b387-7b53f550963c")
+		)
+		(pad "6" thru_hole circle
+			(at 5 -3.3)
+			(size 1.4 1.4)
+			(drill 0.9)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/SWDIO")
+			(uuid "0a340971-1ffe-4f52-840e-b9307b164bc6")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Button_Switch_THT.3dshapes/SW_CuK_JS202011CQN_DPDT_Straight.wrl"
+			(offset
+				(xyz 0 3.3 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8d1e")
+		(at 69.250000 38.635000 270)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R13"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "0b818865-f1b0-40c4-94a9-ec9bb2302fa2")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "06eb3ba3-7deb-4b02-b901-a857f6c7c95d")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "ad5cf4d3-52f5-4089-b6d5-e9941108c839")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "869e69fc-d5db-4284-aa24-e9ccceeb8d1d")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f34b86f")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "7e015a22-ed12-46eb-ba73-e8b6a09774ad")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "75bfcfb1-7efa-4697-8f41-1da45b2400fc")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "eb1bb55f-f5b5-4eeb-8738-c81a45dfaf69")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "f42a583f-ee67-476e-aa8b-7c180c05dc94")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "0f2cba8c-4c15-412e-8cc8-830135434ea6")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "fc9c7bcd-2b13-4140-bff9-10b493af8fa3")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b41a3d66-841d-4b84-a601-70474499453b")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "29ecf637-f1e7-4728-b86b-12d0735d0198")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "6f3f9eb0-e00e-4030-8312-b8fd5388c2fa")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "2c07626c-b8fe-47eb-8197-fef574dd6f17")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(R13-Pad2)")
+			(uuid "890d897c-bf73-4350-8287-4e1a828dd7a8")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:R_Array_Convex_4x0402_RoundRect"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8d50")
+		(at 44.000000 60.600000)
+		(descr "Chip Resistor Network, ROHM MNR04 (see mnr_g.pdf)")
+		(tags "resistor array")
+		(property "Reference" "RN5"
+			(at 0 -2.1 0)
+			(layer "F.Fab")
+			(uuid "e9188aa5-1c43-4ed7-8b29-b65193e24939")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100"
+			(at 0 2.1 0)
+			(layer "F.Fab")
+			(uuid "d73099c6-2362-4626-a1e5-d9e632c549f9")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "aa55b962-b1f9-4030-9cc8-44ee30ba917f")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "54cc48cb-9e38-44a8-bb27-3ee7a990c9ea")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ed9a0e0")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.25 -1.18)
+			(end -0.25 -1.18)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "0db47c4c-ef1a-465a-aeed-87abbf42e300")
+		)
+		(fp_line
+			(start 0.25 1.18)
+			(end -0.25 1.18)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "573b9fb4-8b35-450e-af9a-6eccec561753")
+		)
+		(fp_line
+			(start -1 -1.25)
+			(end -1 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "b04d38d3-e181-47a6-a24e-f6df072ed366")
+		)
+		(fp_line
+			(start -1 -1.25)
+			(end 1 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "71ed6ba9-5133-4baf-831a-f99ce63af6bc")
+		)
+		(fp_line
+			(start 1 1.25)
+			(end -1 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "b1e6a942-a510-428d-9921-8be1a8abb54b")
+		)
+		(fp_line
+			(start 1 1.25)
+			(end 1 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "724507ea-80f6-4d0a-b90a-d7eb5de94f7d")
+		)
+		(fp_line
+			(start -0.5 -1)
+			(end 0.5 -1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a997acb1-0269-4e49-bb61-164f98c8ab70")
+		)
+		(fp_line
+			(start -0.5 1)
+			(end -0.5 -1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "86003e80-caef-4390-8626-17ff94917288")
+		)
+		(fp_line
+			(start 0.5 -1)
+			(end 0.5 1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "01fa7216-1f24-46c9-9a0f-34d3e49fe4b7")
+		)
+		(fp_line
+			(start 0.5 1)
+			(end -0.5 1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "eb3577c9-0d7f-4035-838a-0cd84402e1f3")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "0350a208-4291-463d-a856-ea53cc3bf827")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.075)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.5 -0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD1")
+			(uuid "cf0d05c7-5bf6-49c8-baef-d72e7cbf7546")
+		)
+		(pad "2" smd roundrect
+			(at -0.5 -0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD3")
+			(uuid "e41fe650-43fb-4823-99d4-48da504b75b3")
+		)
+		(pad "3" smd roundrect
+			(at -0.5 0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD5")
+			(uuid "7e8b164e-1ec9-4a03-84a2-76b9d5214806")
+		)
+		(pad "4" smd roundrect
+			(at -0.5 0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD6")
+			(uuid "0bb0d1a9-b781-4320-8d54-0a055cedc282")
+		)
+		(pad "5" smd roundrect
+			(at 0.5 0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN5-Pad5)")
+			(uuid "ecaf3f1a-e552-43d0-b5f4-dfc5c3826f69")
+		)
+		(pad "6" smd roundrect
+			(at 0.5 0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN5-Pad6)")
+			(uuid "aadde88c-0fa4-485a-9c79-cbf65e8fc6f1")
+		)
+		(pad "7" smd roundrect
+			(at 0.5 -0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN5-Pad7)")
+			(uuid "c0c8ca68-3e55-4603-ac66-99ed05cc6861")
+		)
+		(pad "8" smd roundrect
+			(at 0.5 -0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN5-Pad8)")
+			(uuid "0438f1ec-def2-4efd-bc40-5ba208958b6e")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_Array_Convex_4x0402.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:SOT-23-6_RoundRect"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8d91")
+		(at 35.100000 64.150000 180)
+		(descr "6-pin SOT-23 package")
+		(tags "SOT-23-6")
+		(property "Reference" "U4"
+			(at 0 -2.9 0)
+			(layer "F.Fab")
+			(uuid "29ea4e2a-1dca-4061-ae08-3a932ea1a262")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "93LC46BT-I/OT"
+			(at 0 2.9 0)
+			(layer "F.Fab")
+			(uuid "f22e316c-873b-485e-b873-040b5e49654e")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "d947a241-0f71-4379-8e9c-686d3d93dc15")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "3d7274b7-d64c-4982-93b6-e34a08738e4b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f75878e")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.9 -1.61)
+			(end -1.55 -1.61)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "daa7f720-17f3-4d51-9ac5-d0469bc234fb")
+		)
+		(fp_line
+			(start -0.9 1.61)
+			(end 0.9 1.61)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b83d0bfc-8533-421e-9449-d82e52d7ea1e")
+		)
+		(fp_line
+			(start 1.9 1.8)
+			(end 1.9 -1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "4e616958-dec0-4f0e-999e-3d506d1b7136")
+		)
+		(fp_line
+			(start 1.9 -1.8)
+			(end -1.9 -1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "bf2c3bf9-c593-4390-acd5-84c452977831")
+		)
+		(fp_line
+			(start -1.9 1.8)
+			(end 1.9 1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "19d628f2-231f-41a3-8e7e-8f207f9de3c4")
+		)
+		(fp_line
+			(start -1.9 -1.8)
+			(end -1.9 1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "33f418e8-0733-412f-afa5-e0c90f72f682")
+		)
+		(fp_line
+			(start 0.9 1.55)
+			(end -0.9 1.55)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9c3c794f-2891-4640-88a7-63193a1f0c6b")
+		)
+		(fp_line
+			(start 0.9 -1.55)
+			(end 0.9 1.55)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "38b673f2-8bb5-40b2-845c-0e2a4654aee9")
+		)
+		(fp_line
+			(start 0.9 -1.55)
+			(end -0.25 -1.55)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "7a85c93d-8036-454e-90e7-118f8fc58ec9")
+		)
+		(fp_line
+			(start -0.9 -0.9)
+			(end -0.25 -1.55)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "df4685c4-c767-47a5-aaf0-a3df119e6bff")
+		)
+		(fp_line
+			(start -0.9 -0.9)
+			(end -0.9 1.55)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a74149af-b7bb-41ef-9687-cd2c68cc51be")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "f8ef6595-ee4e-4316-b7ba-b8eebd927c63")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.075)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -1.1 -0.95 180)
+			(size 1.06 0.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(R13-Pad2)")
+			(uuid "b567ea79-38ae-42fa-8fab-9f82aa55f72c")
+		)
+		(pad "2" smd roundrect
+			(at -1.1 0 180)
+			(size 1.06 0.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "727d3781-5a29-473a-b462-92367b925c7f")
+		)
+		(pad "3" smd roundrect
+			(at -1.1 0.95 180)
+			(size 1.06 0.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/EEDATA")
+			(uuid "b73bf927-9d82-44aa-a2f5-69ecf95149d5")
+		)
+		(pad "4" smd roundrect
+			(at 1.1 0.95 180)
+			(size 1.06 0.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/EECLK")
+			(uuid "c9e1df02-9c1b-4ca7-9be6-cbfcde15f236")
+		)
+		(pad "5" smd roundrect
+			(at 1.1 0 180)
+			(size 1.06 0.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/EECS")
+			(uuid "c0383794-7f8d-4554-aff8-b2c01f79fcf6")
+		)
+		(pad "6" smd roundrect
+			(at 1.1 -0.95 180)
+			(size 1.06 0.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "70f34e51-2f81-4f64-b12c-892badfe335d")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Package_TO_SOT_SMD.3dshapes/SOT-23-6.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8dc9")
+		(at 56.500000 71.870000 -90)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R20"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "2acbfb27-e528-4fb9-b78e-e4f3c4e5c745")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "455457cf-2b9e-4aad-acaa-7cf665606619")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b7885587-a051-4587-94fe-b8c98324d2c4")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b07c752b-597d-42c6-99e1-15828522aa4a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005edd6c7c")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "4fcdf2cb-365f-4788-bead-46623f19f00b")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "3b7ce0b9-e2be-42e8-8171-3c570b5aaaab")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "c1db16c5-f7ee-4e18-8c24-8595f5380eec")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "62fca5ed-313f-4d70-9da5-2e7a1ca2d297")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "167bb99a-ed5a-4ec6-a122-35df677caa34")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "883b1317-4a93-4cab-b6c4-b6bddc7bba5e")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "eb3e49d7-142b-4bfe-b9d0-f50464eb3103")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "20a5b249-2c82-4c13-9127-e03f25545156")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "640016b0-3146-4423-aa8c-bc7bdd5c68c3")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(J4-Pad5)")
+			(uuid "fdc8e94f-64a9-40c7-9ad5-4556f2bfd50b")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VTARGET")
+			(uuid "27f0802e-c9e6-497d-bfce-7494e98f2542")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8df3")
+		(at 44.750000 44.400000 90)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C3"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "ac814bb2-45ab-43d9-a8e0-42100b5837df")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "2u2"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "2a862ef7-343c-49c3-8c9e-4c0bc240cd57")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "f1c6a71b-fa37-436c-90a1-64b0c8170afc")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "0cbae80d-64d4-406c-861a-7e4d591ff5bc")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ee3e93a")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "207f5941-e25f-4e52-8055-bfc66512d4dc")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "d5429629-c0b6-4c99-ac5e-9bdf49c8e2ea")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "9014d097-f099-491d-9978-c1a3e6fecad6")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "35b7d112-22a5-4a4e-952f-1e1cb45e56b3")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b25fbe12-099d-4b23-965f-e28612df4bfb")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9e96e875-f0c2-4495-85db-7b3d825e9b67")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "edc57bd9-7006-48ca-a1d0-9b7dd2d12234")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c36b7aee-fb9f-4de5-88d6-6e59a6342352")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "5b322a3c-5849-4077-85ac-9078c4c8e9aa")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+5V")
+			(uuid "ffdc2b70-e91d-4e21-b80a-eac2e6fd1451")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "ef47dfed-62a3-4b23-81fd-4eaecff1f00f")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8e1d")
+		(at 51.460000 46.908000)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R11"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "08712b82-e0bd-4f6b-b090-9b8e50d14d86")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "330"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "b8b24851-7f87-4a40-96d1-4bd7a87b7dc3")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "ba39d63e-dca1-4276-a891-ac0f24f2cf39")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "2d5d65a9-cd78-442c-ac6c-be77d953f810")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-000060280318")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "9e2e3732-b0c5-44fe-8976-bb0cdb524ae7")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "a5ed3400-e59c-4689-ae74-68b9396da016")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "73257495-0825-44e7-b499-02c2c6ccf69f")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "e2819ea9-5259-4315-bb32-e25dd584b5ff")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "4555197a-9d5e-4b0f-9054-d94c002dda6a")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e7739254-d7d5-43ec-983f-2e83e2ba823c")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "32133b22-5eae-4337-94ea-f1120331f77a")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "116d66cb-4580-41d6-a067-e99a587235f7")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "4502a198-3cdb-4dd2-89d7-917996c11a3c")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(D5-Pad2)")
+			(uuid "b2364b2a-49a0-4928-b959-628b653ed1e8")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "dd3b4672-38e7-4d5c-bb37-6403714a3d30")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8e47")
+		(at 40.985000 61.135000)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C19"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "9bacb73c-4de2-4ef8-92b2-a62dd3a75bf9")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100n"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "d8f20679-d310-48aa-b291-2cf6344ac39e")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "daa836e3-8a35-42af-b834-2793019e9f17")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "5d235090-aacb-4371-b58b-a953d1bddfe3")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-000060d35425")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "d5fae42b-ce6c-491c-85f4-5904eddff2b5")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "3d348103-cddf-4057-90a5-2e20f572f607")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "f182efd6-8db3-4a12-b5b5-6df5c5281ba6")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "c01b5b94-6d99-458a-ac9e-ce0d264ca8df")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ba4af50b-3aa8-4f71-871b-98a5749aacd6")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "50ffeb7a-56f0-4bda-ab43-570798c68358")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b08b0b42-7d8e-4d43-bf80-3883a2800d35")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "234a9d7f-4173-49c9-af21-5bac03644051")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "124421e6-ce62-4f36-89b0-e6e0f041c19c")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "0cc61a0c-2798-4768-a1cd-0acbaf0f07d3")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "83ec9f8d-0433-4159-9116-05b6213cd15d")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:SOT-23-5_RoundRect"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8e77")
+		(at 42.250000 48.150000 180)
+		(descr "5-pin SOT23 package")
+		(tags "SOT-23-5")
+		(property "Reference" "U1"
+			(at 0 -2.9 0)
+			(layer "F.Fab")
+			(uuid "6515e78b-830f-4b79-b28a-e9d7ad304e94")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "AP7365-18"
+			(at 0 2.9 0)
+			(layer "F.Fab")
+			(uuid "f36b37f5-3034-46db-8727-d64e2d2216bc")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "9b8f281b-5c02-46f2-ae11-f6447484f9a0")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "c59107c6-6f3d-4ad0-b211-c6d8f0354324")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ebde10a")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.9 -1.61)
+			(end -1.55 -1.61)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "7933deda-a0a1-428d-927b-c8cca1fd6c3a")
+		)
+		(fp_line
+			(start -0.9 1.61)
+			(end 0.9 1.61)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d70d798e-7c40-470a-8edd-3a173e00953b")
+		)
+		(fp_line
+			(start 1.9 1.8)
+			(end -1.9 1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "17a66e5e-65da-4a31-919d-22bb6fab449d")
+		)
+		(fp_line
+			(start 1.9 -1.8)
+			(end 1.9 1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "e11a121b-35b9-4fcf-8bd0-676ecd88987c")
+		)
+		(fp_line
+			(start -1.9 1.8)
+			(end -1.9 -1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2f71b17d-f216-4000-a28e-62cd29dbcf12")
+		)
+		(fp_line
+			(start -1.9 -1.8)
+			(end 1.9 -1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "e961c2c4-73e2-4b5c-8f9b-beab36c0adda")
+		)
+		(fp_line
+			(start 0.9 1.55)
+			(end -0.9 1.55)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "06de2af7-8db2-46ca-8a3b-bd2aedcb6b43")
+		)
+		(fp_line
+			(start 0.9 -1.55)
+			(end 0.9 1.55)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "5ad9a2da-f720-4257-8022-c00acbab2a5d")
+		)
+		(fp_line
+			(start 0.9 -1.55)
+			(end -0.25 -1.55)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "aee9129d-d0b7-4418-9e22-263f7de2c34a")
+		)
+		(fp_line
+			(start -0.9 -0.9)
+			(end -0.25 -1.55)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a2a92546-0f83-4fe3-97dd-691772304726")
+		)
+		(fp_line
+			(start -0.9 -0.9)
+			(end -0.9 1.55)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d2ff71e0-c601-4de8-af3c-4ada4fb935d4")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "5b582e5a-9551-4d9e-9d0e-7d2181901070")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.075)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -1.1 -0.95 180)
+			(size 1.06 0.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+5V")
+			(uuid "56d41e26-bdd4-4c64-8791-1c962a21500e")
+		)
+		(pad "2" smd roundrect
+			(at -1.1 0 180)
+			(size 1.06 0.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "87882041-3755-4539-b431-eb94c30719e2")
+		)
+		(pad "3" smd roundrect
+			(at -1.1 0.95 180)
+			(size 1.06 0.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+5V")
+			(uuid "9a1cb502-bf88-462b-965b-c9c24aacfd37")
+		)
+		(pad "4" smd roundrect
+			(at 1.1 0.95 180)
+			(size 1.06 0.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "9e12bba7-8d46-44d6-af69-c10896e3a124")
+		)
+		(pad "5" smd roundrect
+			(at 1.1 -0.95 180)
+			(size 1.06 0.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+1V8")
+			(uuid "95945aab-9ff9-4f91-9817-fe63be9ca42b")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Package_TO_SOT_SMD.3dshapes/SOT-23-5.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:R_Array_Convex_4x0402_RoundRect"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8eb5")
+		(at 67.500000 60.250000)
+		(descr "Chip Resistor Network, ROHM MNR04 (see mnr_g.pdf)")
+		(tags "resistor array")
+		(property "Reference" "RN3"
+			(at 0 -2.1 0)
+			(layer "F.Fab")
+			(uuid "23e6ec19-f98a-4da5-85fe-a88cdf76f107")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100"
+			(at 0 2.1 0)
+			(layer "F.Fab")
+			(uuid "513591f4-2781-4e83-96b7-c722e0d37253")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "736f1825-3a84-422f-8912-eea7fde4a18d")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "2f57ea13-cde9-4a40-b7e4-c0906dc72797")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00006123b61b")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.25 -1.18)
+			(end -0.25 -1.18)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "baf04716-e795-41b7-93d6-4375e5e4bd19")
+		)
+		(fp_line
+			(start 0.25 1.18)
+			(end -0.25 1.18)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "82e37d20-e3be-438c-b860-eedb68672221")
+		)
+		(fp_line
+			(start -1 -1.25)
+			(end -1 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "572fb178-fb2a-4ff8-9770-94a4b809c751")
+		)
+		(fp_line
+			(start -1 -1.25)
+			(end 1 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "a364a640-9cb4-490c-8a39-d025df090ad4")
+		)
+		(fp_line
+			(start 1 1.25)
+			(end -1 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "48b7f214-77a4-423d-833a-105387d22841")
+		)
+		(fp_line
+			(start 1 1.25)
+			(end 1 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "15585e91-e444-4231-915d-0b8438dc8bc6")
+		)
+		(fp_line
+			(start -0.5 -1)
+			(end 0.5 -1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "19629ce0-e17d-424a-b628-6059f8b81bec")
+		)
+		(fp_line
+			(start -0.5 1)
+			(end -0.5 -1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "0996fd95-103d-49c0-83a7-5608370ab52e")
+		)
+		(fp_line
+			(start 0.5 -1)
+			(end 0.5 1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "4f31ba79-2659-4976-9ede-faf435598d97")
+		)
+		(fp_line
+			(start 0.5 1)
+			(end -0.5 1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f7f981ae-555e-4a50-b2ca-601da7b10ad0")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "f2a48f77-7814-48de-a811-f577292e175d")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.075)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.5 -0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN3-Pad1)")
+			(uuid "35130f16-e578-460b-b05e-898523f195bc")
+		)
+		(pad "2" smd roundrect
+			(at -0.5 -0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN3-Pad2)")
+			(uuid "47b1afcf-38cc-4e70-96bf-63bd53ae2535")
+		)
+		(pad "3" smd roundrect
+			(at -0.5 0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN3-Pad3)")
+			(uuid "c24e27a5-202e-4d56-af65-288ded5f5aa6")
+		)
+		(pad "4" smd roundrect
+			(at -0.5 0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN3-Pad4)")
+			(uuid "1c0d3653-2701-4e0d-92a4-40ffa92a1d4f")
+		)
+		(pad "5" smd roundrect
+			(at 0.5 0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/xPB4")
+			(uuid "88c8e1ff-10ee-44ba-a44b-2791808a4e2d")
+		)
+		(pad "6" smd roundrect
+			(at 0.5 0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/CS")
+			(uuid "f1735bd3-0b00-4e1e-ac90-8bf88a7b2eb7")
+		)
+		(pad "7" smd roundrect
+			(at 0.5 -0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/COPI")
+			(uuid "6cf2cebe-215c-4e07-8b23-70625394f431")
+		)
+		(pad "8" smd roundrect
+			(at 0.5 -0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/CLK")
+			(uuid "29d41b39-ccc6-42a1-a095-e71442e1ddd5")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_Array_Convex_4x0402.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8f76")
+		(at 64.000000 38.650000 270)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C18"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "01e3d9c9-4d08-4b64-b8c7-c9b4418df795")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100n"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "8a6da369-a211-41dc-be22-316c83598940")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "35135a35-e430-41cc-898e-eb02bf14a36c")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "9a72fc63-9b95-4a22-9080-76a645b41eac")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005eec8e50")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "01198dba-aa14-43e8-a533-55480c228be3")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "28cc193d-260f-446c-b2f8-33f59477d038")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "b3c5b82f-2311-4181-8b21-a580f156f0ac")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "edeb8f83-6b5f-4859-a710-5cf8c73db544")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "da1cd01f-6506-41a3-8696-a141e62901b5")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "67f38907-afdf-4c38-beb3-5ff9569d23bc")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "1081a21f-bbf8-45fe-972c-c3a7fb2e15ec")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "def142c3-181c-4d43-bfb2-248c3636228b")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "f27240e6-8a22-454e-84b8-aeabbde29684")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "036dc83f-c484-4d5a-881d-03ae8d1caab5")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "057681bc-9066-409d-9e1a-56636f025cd0")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8fa0")
+		(at 57.500000 47.415000 270)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R2"
+			(at 0 -1.17 90)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "c6fef8b7-c394-4fd8-99f6-26f77c558389")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "5k1"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "8dc4d1f4-0e46-4550-acff-75b1db47ed87")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "68c5c131-34cb-43d3-b79a-91842ff8e372")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "f8fc8dec-ec3b-4318-b014-bc243e2d4b90")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ebd4231")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "e730b6a7-68ce-4ed1-b4a5-8a54c4486e26")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "db43f0a1-6b76-4ccd-84ea-124da908f87c")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "fbadf17e-f7cd-49ee-9bf9-9d95bb6f8883")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "03568ac3-3b47-43cd-83bb-01d5f1dc6351")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b6649bd2-250e-47c1-ad9c-7b888de6c0af")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a62b0e56-1a1d-41fc-89ef-fbf545ca7884")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "985761ae-23b4-4aee-bcad-24ce1d3b02a5")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "486c844b-5e38-4566-9a35-d687ac41f1a6")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "8eb5c672-87ef-4d54-b62c-47222db56cd6")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(J1-PadB5)")
+			(uuid "cef6bbe1-155c-4aee-a8ad-8847cf3605a4")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "e5191a60-4538-434b-a6a1-18248dc3330f")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8fca")
+		(at 66.515000 37.900000 180)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C6"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "dc3ccbb8-61dd-402a-8e9f-d16bb2f37de6")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "2u2"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "ca5f29c7-c4f6-457f-aff7-a321daf8da41")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "6c8fd564-2087-4a86-b6e4-60d0ddb76794")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "d0e4eaff-6aa7-48fc-82bd-b6e87afbf71b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ef8ce20")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2cd33f2a-b16c-474f-9893-bdf80309f721")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "a7c51852-9af8-434c-b42b-10434debf66b")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "0feece49-6dc3-4e58-9511-37b8ec807e1a")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "531830fd-a2be-4105-9ff2-19e9ff8e5946")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "686c3892-81eb-4d52-a635-fe0bab20f3b8")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "efbc0661-0f93-4314-9f3a-399e1aef406d")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "cd012935-767a-4c91-af7b-8b4e900c70c4")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "715b6334-9f34-4b18-898a-f676943674b2")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "45f44c50-e3a0-4f0c-bb87-5d4a51dcbd36")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/VPHY")
+			(uuid "83aa7d7d-61ef-48d5-a4f2-b1c7c2bfcd2d")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "3b37755c-c391-4019-9f42-de6641f83d94")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8ff4")
+		(at 70.500000 38.635000 90)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C17"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "139d369c-8046-4f61-a5cc-c99cb0014ee9")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100n"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "b4275406-d2d1-434e-88e5-b2e463f8a5b8")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "0844f8e2-7a15-4e80-b324-c1043f94158b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "972abab3-f690-48ec-a5a4-29a6266c3555")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f90af3d")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "c2fc1a83-47ac-4975-8cc8-0d792cd70323")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "4aadbc80-ef6d-47c9-a80b-913faeb98565")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "93e4ba4a-2676-46e5-add3-3ad091965d92")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "22874ac4-33ae-444d-ae91-d5189cfec88b")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "3b1547f5-b230-4ea4-bae3-b694f19c0b0c")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "5b37be9d-527a-4466-9237-0d7c7a14c3d4")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "5ee0ee6f-9ebf-475a-944d-c98410e3f55d")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "100af237-e4a4-4da7-badf-cf288dc2b365")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "c791a45f-b963-435d-8148-dc61ab5654f1")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "d7c031ed-7beb-4be5-84ec-5c5913cf7d4b")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "9618f62f-55e8-40c9-85bf-61c42a45cfe8")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:USB_C_Receptacle_HRO_TYPE-C-31-M-12"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec9037")
+		(at 57.000000 41.400000 270)
+		(descr "USB Type-C receptacle for USB 2.0 and PD, http://www.krhro.com/uploads/soft/180320/1-1P320120243.pdf")
+		(tags "usb usb-c 2.0 pd")
+		(property "Reference" "J1"
+			(at 0 -5.645 90)
+			(layer "F.Fab")
+			(uuid "92604a9c-37b0-425b-ad6c-efd66ff6066b")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "USB_C_Receptacle_USB2.0"
+			(at 0 5.1 90)
+			(layer "F.Fab")
+			(uuid "758e7920-a469-456c-9869-c412d60e61d4")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "9dffb0c9-d4d4-4b01-a76a-b06170369ded")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "a468e2b7-a559-47b9-9edf-32a3a61a3a8e")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ebcf27e")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -4.7 3.9)
+			(end 4.7 3.9)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "a2e1d508-c784-42fa-b4ee-72854b282323")
+		)
+		(fp_line
+			(start -4.7 2)
+			(end -4.7 3.9)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "e22bf71d-acdc-4c21-b614-449b2f92ac9b")
+		)
+		(fp_line
+			(start 4.7 2)
+			(end 4.7 3.9)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "c41039d3-fcbf-41a5-85e9-d22a317f7ed8")
+		)
+		(fp_line
+			(start -4.7 -1.9)
+			(end -4.7 0.1)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "11136eb9-9b33-42c6-95b2-cbbe54ddb1c6")
+		)
+		(fp_line
+			(start 4.7 -1.9)
+			(end 4.7 0.1)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "bf80831d-d258-4da2-b0be-bead7f196598")
+		)
+		(fp_line
+			(start -5.32 4.15)
+			(end 5.32 4.15)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "52c3b1a1-6a63-4509-b638-e1f82c02e014")
+		)
+		(fp_line
+			(start -5.32 -5.27)
+			(end -5.32 4.15)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "41ebd26c-b31f-4502-9fcd-763f8757333f")
+		)
+		(fp_line
+			(start -5.32 -5.27)
+			(end 5.32 -5.27)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "41f90907-8c7f-4079-bd40-cf7877de3939")
+		)
+		(fp_line
+			(start 5.32 -5.27)
+			(end 5.32 4.15)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "48a5d364-cf0c-4959-a539-970a3b2e5d81")
+		)
+		(fp_line
+			(start -4.47 3.65)
+			(end 4.47 3.65)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "01d89aae-3d54-4003-882b-047538419abc")
+		)
+		(fp_line
+			(start -4.47 -3.65)
+			(end -4.47 3.65)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "1fb3e514-78d6-4858-b920-7640dca5a97d")
+		)
+		(fp_line
+			(start -4.47 -3.65)
+			(end 4.47 -3.65)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "eaf56705-2872-4040-8cf2-74eb1bdf23de")
+		)
+		(fp_line
+			(start 4.47 -3.65)
+			(end 4.47 3.65)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "912e8d57-e18d-4613-882a-0c23c4a792c6")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "56d4e248-d08d-4b16-991c-198abfd932a2")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "" smd rect
+			(at -4.82 -3.13 270)
+			(size 1 2.1)
+			(layers "F.Paste")
+			(uuid "0bf2fa0e-47ea-40cb-9cab-e351d3a3606e")
+		)
+		(pad "" smd rect
+			(at -4.82 1.05 270)
+			(size 1 1.6)
+			(layers "F.Paste")
+			(uuid "3faaf992-ecf4-4235-843f-73168b43ebe5")
+		)
+		(pad "" smd oval
+			(at -4.32 -3.13 270)
+			(size 1 2.1)
+			(layers "F.Paste")
+			(uuid "2797777a-d673-467a-9816-6903278e8b78")
+		)
+		(pad "" smd oval
+			(at -4.32 1.05 270)
+			(size 1 1.6)
+			(layers "F.Paste")
+			(uuid "651ea73a-32fd-4401-a00c-81cc9d372df7")
+		)
+		(pad "" np_thru_hole circle
+			(at -2.89 -2.6 270)
+			(size 0.65 0.65)
+			(drill 0.65)
+			(layers "*.Cu" "*.Mask")
+			(uuid "dfca45f4-0db0-4562-bdb6-6cdfc528b101")
+		)
+		(pad "" np_thru_hole circle
+			(at 2.89 -2.6 270)
+			(size 0.65 0.65)
+			(drill 0.65)
+			(layers "*.Cu" "*.Mask")
+			(uuid "fe6b9179-7159-41e8-8f54-f20932159d37")
+		)
+		(pad "" smd oval
+			(at 4.32 -3.13 270)
+			(size 1 2.1)
+			(layers "F.Paste")
+			(uuid "b07c89b2-3fdf-4d59-9095-4ba6abcb0495")
+		)
+		(pad "" smd oval
+			(at 4.32 1.05 270)
+			(size 1 1.6)
+			(layers "F.Paste")
+			(uuid "ca217b3f-932e-4522-ac98-440e3a8213a2")
+		)
+		(pad "" smd rect
+			(at 4.82 -3.13 270)
+			(size 1 2.1)
+			(layers "F.Paste")
+			(uuid "01003b14-2fc6-4c5a-ab24-92b8c9ae6ca7")
+		)
+		(pad "" smd rect
+			(at 4.82 1.05 270)
+			(size 1 1.6)
+			(layers "F.Paste")
+			(uuid "e3536994-485c-4e0c-a9fd-f93e0e974755")
+		)
+		(pad "A1" smd rect
+			(at -3.25 -4.045 270)
+			(size 0.6 1.45)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(uuid "1a9df97e-5f5f-44ca-9ec2-4239e711e6a8")
+		)
+		(pad "A4" smd rect
+			(at -2.45 -4.045 270)
+			(size 0.6 1.45)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/VBUS")
+			(uuid "dd1a862c-c554-4765-bebc-c0804b39722e")
+		)
+		(pad "A5" smd rect
+			(at -1.25 -4.045 270)
+			(size 0.3 1.45)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(J1-PadA5)")
+			(uuid "f2fb061a-5052-4a37-9d58-777607d1e1da")
+		)
+		(pad "A6" smd rect
+			(at -0.25 -4.045 270)
+			(size 0.3 1.45)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/USB_DP")
+			(uuid "0744ece0-ec8d-4b80-9717-9df440758749")
+		)
+		(pad "A7" smd rect
+			(at 0.25 -4.045 270)
+			(size 0.3 1.45)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/USB_DN")
+			(uuid "d3f1f22f-edd7-433a-8137-5c4a29861696")
+		)
+		(pad "A8" smd rect
+			(at 1.25 -4.045 270)
+			(size 0.3 1.45)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(uuid "836a81cf-d342-4681-b188-5fb7c5e63931")
+		)
+		(pad "A9" smd rect
+			(at 2.45 -4.045 270)
+			(size 0.6 1.45)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/VBUS")
+			(uuid "70693b2e-8fe4-44d8-9a9a-ed381b07174f")
+		)
+		(pad "A12" smd rect
+			(at 3.25 -4.045 270)
+			(size 0.6 1.45)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(uuid "5698f424-29ea-4818-8f5c-cc6e905cec26")
+		)
+		(pad "B1" smd rect
+			(at 3.25 -4.045 270)
+			(size 0.6 1.45)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(uuid "faa501ff-830b-4e92-8791-4e26864e71c3")
+		)
+		(pad "B4" smd rect
+			(at 2.45 -4.045 270)
+			(size 0.6 1.45)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/VBUS")
+			(uuid "33298c4a-3ff6-49f6-8fb6-4a8cee4f6467")
+		)
+		(pad "B5" smd rect
+			(at 1.75 -4.045 270)
+			(size 0.3 1.45)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(J1-PadB5)")
+			(uuid "1466d844-84a8-46b3-a423-ab5eb5e81711")
+		)
+		(pad "B6" smd rect
+			(at 0.75 -4.045 270)
+			(size 0.3 1.45)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/USB_DP")
+			(uuid "3cae6199-476b-455d-8233-2a727f4f391f")
+		)
+		(pad "B7" smd rect
+			(at -0.75 -4.045 270)
+			(size 0.3 1.45)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/USB_DN")
+			(uuid "2766c1ee-adeb-43ff-8512-f02057c42510")
+		)
+		(pad "B8" smd rect
+			(at -1.75 -4.045 270)
+			(size 0.3 1.45)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(uuid "f65dba7c-91a4-441b-a3ec-6fe22e55e140")
+		)
+		(pad "B9" smd rect
+			(at -2.45 -4.045 270)
+			(size 0.6 1.45)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/VBUS")
+			(uuid "0b715c2f-9801-4150-8fe4-f51386f6fbfe")
+		)
+		(pad "B12" smd rect
+			(at -3.25 -4.045 270)
+			(size 0.6 1.45)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(uuid "a636b8de-5e43-4ff9-a3dc-4d026ceaaa9b")
+		)
+		(pad "S1" thru_hole oval
+			(at -4.32 -3.13 270)
+			(size 1 2.1)
+			(drill oval 0.6 1.7)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "Net-(C25-Pad2)")
+			(uuid "7ef9ef86-7a88-405c-9163-375f9799b3ef")
+		)
+		(pad "S1" thru_hole oval
+			(at -4.32 1.05 270)
+			(size 1 1.6)
+			(drill oval 0.6 1.2)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "Net-(C25-Pad2)")
+			(uuid "deb39570-11c3-44fc-a9e5-5d66f420f0e5")
+		)
+		(pad "S1" thru_hole oval
+			(at 4.32 -3.13 270)
+			(size 1 2.1)
+			(drill oval 0.6 1.7)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "Net-(C25-Pad2)")
+			(uuid "5cdd6bea-8971-40cc-b34c-be7c62b7cf73")
+		)
+		(pad "S1" thru_hole oval
+			(at 4.32 1.05 270)
+			(size 1 1.6)
+			(drill oval 0.6 1.2)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "Net-(C25-Pad2)")
+			(uuid "baee2d22-f976-41bd-90a2-96facadb085f")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Connector_USB.3dshapes/USB_C_Receptacle_HRO_TYPE-C-31-M-12.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+		(model "${KIPRJMOD}/tigard.3dshapes/HRO_TYPE-C-31-M-12.step"
+			(offset
+				(xyz -4.5 -3.7 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec9093")
+		(at 57.500000 43.400000 270)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R1"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "5bd87b55-95d7-4ef7-8af5-4aac5a4b0902")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "5k1"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "7245202e-7456-4006-8e43-a4996618019c")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "c2a86965-d4a9-46cd-a99b-6649d0507cd9")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "9711093a-8d70-4977-9bd2-70958ad5f3f7")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ebd3955")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "79ff1d45-3f6e-49b9-9465-0e811319cb34")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "89ab45ae-b0af-432c-a4aa-c02749d2d1eb")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "e3aa2590-fc1d-4363-92fb-5aedee5a9265")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "d2d3d1c3-8fe5-4295-b138-15021ea1c4ca")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "6fb20c2b-88f9-4e75-867d-42658d57d6e4")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "212ff279-ce6e-4bde-a030-dc3e1ee803b6")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "6e8e433f-11ec-4a74-83ae-dfbe87d7fc24")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e175eafd-1d9f-4dac-82ca-7f75c020742f")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "aa594fd8-ed27-4e88-b30a-b11966dd117d")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "e1ad4e50-49e5-4425-a8e6-da2628413b6e")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(J1-PadA5)")
+			(uuid "850054b9-615a-485a-a467-cab8ab670a08")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:PinHeader_2x04_P2.54mm_Vertical"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec90db")
+		(at 66.700000 69.260000 -90)
+		(descr "Through hole straight pin header, 2x04, 2.54mm pitch, double rows")
+		(tags "Through hole pin header THT 2x04 2.54mm double row")
+		(property "Reference" "J4"
+			(at 1.27 -2.33 90)
+			(unlocked yes)
+			(layer "F.Fab")
+			(uuid "30feb4dd-d60f-4776-8bea-cc3b34f5dd34")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "SPI"
+			(at 1.27 -2.55 270)
+			(unlocked yes)
+			(layer "F.SilkS")
+			(uuid "8128e921-fa35-4b3e-b924-49ff08f03c11")
+			(effects
+				(font
+					(size 0.8 0.8)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "f7d0abd1-2fba-4013-abb7-51dbc5d471cc")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "14bbf250-d777-4b59-b85d-a56302358cda")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ebdf705")
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -1.33 8.95)
+			(end 3.87 8.95)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "ab2bb5fc-09c8-4ed7-bfca-cea294815650")
+		)
+		(fp_line
+			(start -1.33 1.27)
+			(end -1.33 8.95)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "504cd5b3-9f59-431c-b46e-bc01b39545c0")
+		)
+		(fp_line
+			(start -1.33 1.27)
+			(end 1.27 1.27)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d17b18ae-d3df-471b-a656-ea6f956c61b7")
+		)
+		(fp_line
+			(start 1.27 1.27)
+			(end 1.27 -1.33)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "8980e2f1-147d-477e-b5ad-91de3a104ce0")
+		)
+		(fp_line
+			(start -1.33 0)
+			(end -1.33 -1.33)
+			(stroke
+				(width 0.5)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "65b95d13-3bd6-48c0-844f-ae0f776522e1")
+		)
+		(fp_line
+			(start -1.33 -1.33)
+			(end 0 -1.33)
+			(stroke
+				(width 0.5)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "2a125f29-8a0b-465b-a680-cf50254c3300")
+		)
+		(fp_line
+			(start 1.27 -1.33)
+			(end 3.87 -1.33)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "dbbb3947-7faf-4609-8725-5ff1df11cab9")
+		)
+		(fp_line
+			(start 3.87 -1.33)
+			(end 3.87 8.95)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "db8443cb-1b79-402b-9c22-95b76d3e5390")
+		)
+		(fp_line
+			(start -2.54 -2.032)
+			(end -2.032 -2.032)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "24c7c52d-1c7d-478e-b698-2d40d94b74ae")
+		)
+		(fp_line
+			(start -2.032 -2.032)
+			(end -2.54 -2.032)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "4283dfd0-bd13-424c-8e50-615f1b809053")
+		)
+		(fp_line
+			(start -2.032 -2.032)
+			(end -2.032 -2.54)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "4cf5a073-9a30-4d0b-9cdb-cbad54b47c9d")
+		)
+		(fp_line
+			(start -2.032 -2.032)
+			(end -2.794 -2.794)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "20488e7b-5b4b-44d1-b410-6cdfcabb29ff")
+		)
+		(fp_line
+			(start -1.33 8.95)
+			(end 3.87 8.95)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "d662bf1f-1bff-4024-807c-041f690eee77")
+		)
+		(fp_line
+			(start -1.33 1.27)
+			(end -1.33 8.95)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "f7a75936-bf6d-4a01-a9b0-be3f64706c4e")
+		)
+		(fp_line
+			(start -1.33 1.27)
+			(end 1.27 1.27)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "2de324fa-c2ee-4d8e-9d85-b29460e2a1c2")
+		)
+		(fp_line
+			(start 1.27 1.27)
+			(end 1.27 -1.33)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "89921d21-74f4-4d85-9dd6-007a1f98827a")
+		)
+		(fp_line
+			(start -1.33 0)
+			(end -1.33 -1.33)
+			(stroke
+				(width 0.5)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "4c760c36-2673-46eb-bf8d-bc7d1424c589")
+		)
+		(fp_line
+			(start -1.33 -1.33)
+			(end 0 -1.33)
+			(stroke
+				(width 0.5)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "b2501ae7-5a8f-41a8-b1c6-08ec985b1f62")
+		)
+		(fp_line
+			(start 1.27 -1.33)
+			(end 3.87 -1.33)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "322115ad-a1d9-4fdb-9fbb-70bd548722d2")
+		)
+		(fp_line
+			(start 3.87 -1.33)
+			(end 3.87 8.95)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "cf32d363-840d-4c90-afef-230461ba9775")
+		)
+		(fp_line
+			(start -2.54 -2.032)
+			(end -2.032 -2.032)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "1713ead6-9ded-466a-a73f-c08236664d45")
+		)
+		(fp_line
+			(start -2.032 -2.032)
+			(end -2.032 -2.54)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "985642fc-16c4-4805-a945-45fdf688f437")
+		)
+		(fp_line
+			(start -2.032 -2.032)
+			(end -2.794 -2.794)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "2953769a-8d76-4b0e-845b-ef6d21481333")
+		)
+		(fp_line
+			(start -1.8 9.4)
+			(end 4.35 9.4)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "4f6ad8dc-5ebe-42b9-b2f9-df6eff1e64b1")
+		)
+		(fp_line
+			(start 4.35 9.4)
+			(end 4.35 -1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "d529f96d-0743-49da-b125-f95d4f51e90a")
+		)
+		(fp_line
+			(start -1.8 -1.8)
+			(end -1.8 9.4)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "9b960fe2-c6ec-4842-afc9-2fce8057fab5")
+		)
+		(fp_line
+			(start 4.35 -1.8)
+			(end -1.8 -1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "202ddee6-7866-4102-a15a-a5a35f843e39")
+		)
+		(fp_line
+			(start -1.27 8.89)
+			(end -1.27 0)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "8e5a02cc-b4d0-4bd9-9f6d-892baab7c2b8")
+		)
+		(fp_line
+			(start 3.81 8.89)
+			(end -1.27 8.89)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "db3e4914-0fe0-49f7-9710-91bc70a8ec03")
+		)
+		(fp_line
+			(start -1.27 0)
+			(end 0 -1.27)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f12c0294-ba0d-4ca2-91ba-845de626eeaa")
+		)
+		(fp_line
+			(start 0 -1.27)
+			(end 3.81 -1.27)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "2e67008d-806f-4683-b36f-33cd0a743621")
+		)
+		(fp_line
+			(start 3.81 -1.27)
+			(end 3.81 8.89)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e3af3824-4c59-4002-a5f0-2072b24142e0")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 1.27 3.81 0)
+			(layer "F.Fab")
+			(uuid "39c52665-12ae-49ad-9506-d6ada8093ca9")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "1" thru_hole roundrect
+			(at 0 0 270)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(roundrect_rratio 0.25)
+			(net "/CS")
+			(uuid "e934e44c-6058-424a-8ea8-375149731999")
+		)
+		(pad "2" thru_hole oval
+			(at 2.54 0 270)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "VTARGET")
+			(uuid "7f7239ac-9306-4a5a-acfc-a493e9ef6349")
+		)
+		(pad "3" thru_hole oval
+			(at 0 2.54 270)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/CIPO")
+			(uuid "795d8ce5-fd32-42dd-aa01-725fad342063")
+		)
+		(pad "4" thru_hole oval
+			(at 2.54 2.54 270)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "Net-(J4-Pad4)")
+			(uuid "4ae2ff61-5967-43a1-9c33-212d7b4e7b82")
+		)
+		(pad "5" thru_hole oval
+			(at 0 5.08 270)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "Net-(J4-Pad5)")
+			(uuid "45a8b9c1-7226-40c4-9825-48c6e56f59d9")
+		)
+		(pad "6" thru_hole oval
+			(at 2.54 5.08 270)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/CLK")
+			(uuid "8872480d-a43c-4b12-8c0a-9f40ea9d53a9")
+		)
+		(pad "7" thru_hole oval
+			(at 0 7.62 270)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "GND")
+			(uuid "cc51cbf0-b07b-4f54-8334-95cfe68694dd")
+		)
+		(pad "8" thru_hole oval
+			(at 2.54 7.62 270)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/COPI")
+			(uuid "8b6bf79d-cd82-419d-904e-67beaabc6077")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_2x04_P2.54mm_Vertical.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec9141")
+		(at 57.500000 57.015000 -90)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R18"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "60c92b13-10c4-4c94-8f70-3df3311fe3be")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "1c499233-ee56-4945-8686-ae4541ce74bb")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "c3fe6508-6076-40bc-afef-8b2171e86152")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "7324f954-1b2a-431d-a92b-149ea2a91340")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005fb4f232")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "9006ec97-fa44-4213-9291-e5bf62328653")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2af5227a-dc4b-4593-ac5b-0e2987e72d93")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "16f237ec-afd2-4ca2-b98d-88f0d813524b")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "99e4a479-ab28-43e9-af91-d81fa11accd1")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "0c1e2f62-7c5e-4ec6-b14a-0a55ebe7b964")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "edd513d3-02eb-4087-a41a-9165a45dd3f6")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "61543b8d-9151-456c-8746-bd5c97a0491a")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9281e340-b650-4c18-b354-ddb06f6f9d41")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "ebfecfa0-8b47-4019-8bf3-f7241133e5af")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "2bb3428c-5646-4da3-8393-1d7bcdd5a114")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(R18-Pad2)")
+			(uuid "4d7b17e1-240c-461b-b035-cd1418b47685")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec916b")
+		(at 66.515000 39.900000)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R6"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "24af98ce-ccc6-4c4a-814c-dc93b2b1d06f")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "12k, 1%"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "ed79349e-d3e0-451a-9c29-4fa448a5dfef")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "93aecf30-2b56-40af-a7fd-94ed07fe86f6")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "68674b22-861e-4ad6-867c-e24b012d6a38")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ee10d01")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "f1c8e242-4601-44dd-ace7-2ff79b71e9a3")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "5e898769-f43b-47aa-850c-f502e016461d")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "47cf9027-dd80-483d-9535-717aba2525ce")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "c9989d23-097b-4346-8dc0-79b849fddc02")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d29384f1-0402-4ec8-a8b9-717d688fe998")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "8c1d7e80-fc33-4e76-8d4c-ea82b2c74f8c")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "39bfbbea-2f58-4a65-af11-75baf5fdf083")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "08f6bd15-8fc3-407b-9644-5c6956799b58")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "1f44e9e4-ade1-49da-a433-b198d759255b")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "81cfb9c9-af6b-4b75-ad7f-53959990e1c4")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(R6-Pad2)")
+			(uuid "615cde81-1ed4-41f9-ad69-0b695b97ea8d")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec9279")
+		(at 51.460000 40.812000)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R9"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "8ea6e346-df18-45af-9d28-74b12c19bdbc")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "330"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "bb0bbfdd-a0a5-4629-bc9e-d181aa3f3e77")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "09d15989-ec58-41d6-be3b-5ca777a40fc2")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "80bcb9db-419e-459f-a730-330cc104c252")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00006027fad3")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "5a83a743-1967-478e-bb9d-cd89d3b8b163")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "6a811f33-fb96-49f6-a35b-bf4b32e00420")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "fe59aa28-28fd-43f6-80f7-bbf55e0aa1e9")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "cf302d0d-fb57-41e7-86fc-ef0a714f769c")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "91ef6ff1-2949-4b83-9c60-ace0bbff49f9")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "6b035dc3-fbdc-40a8-b720-ef37df952745")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "278ce078-b9c3-43ee-8d8c-75932d88c57b")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "65fb1c18-bab5-4da7-a340-e4771bc6c0b3")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "bf632d6d-753e-4132-9f19-8b80ebdec45a")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(D4-Pad2)")
+			(uuid "1df0b6ce-6ed8-4424-8bdb-228a8bac65f1")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "ddd756c9-8d83-4949-aa85-022758c4ef60")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:SOT-23_RoundRect"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec92a9")
+		(at 52.750000 49.400000 90)
+		(descr "SOT-23, Standard")
+		(tags "SOT-23")
+		(property "Reference" "Q1"
+			(at 0 -2.5 90)
+			(layer "F.Fab")
+			(uuid "41d1956a-f73f-4a22-9114-de56bfceee20")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "BSH103"
+			(at 0 2.5 90)
+			(layer "F.Fab")
+			(uuid "8be97105-ce37-4c5c-ba8a-2e67a515ad12")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "9c33ee32-a15a-49b1-ac80-9d319be2b7e4")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "d257555a-f273-4e9a-bb0f-5419da60a89b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ec0037d")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.76 -1.58)
+			(end -1.4 -1.58)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d5dd7b7b-ab57-4d59-9763-d86dc6b00beb")
+		)
+		(fp_line
+			(start 0.76 -1.58)
+			(end 0.76 -0.65)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "bacddff0-1b91-4ed3-9d1b-1b51b57a1406")
+		)
+		(fp_line
+			(start 0.76 1.58)
+			(end 0.76 0.65)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "0a7da457-e28e-46cb-95be-3976da2260d9")
+		)
+		(fp_line
+			(start 0.76 1.58)
+			(end -0.7 1.58)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "14994f59-cc68-470a-a3be-0231a58da008")
+		)
+		(fp_line
+			(start 1.7 -1.75)
+			(end 1.7 1.75)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "7585c1b9-a82b-492a-bfd1-6d14c0cf0c64")
+		)
+		(fp_line
+			(start -1.7 -1.75)
+			(end 1.7 -1.75)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "41f734a9-f12c-4140-97a5-92efee9b9e3b")
+		)
+		(fp_line
+			(start 1.7 1.75)
+			(end -1.7 1.75)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "385b0d18-ee43-4fc6-bb9e-fcb7b2e2104c")
+		)
+		(fp_line
+			(start -1.7 1.75)
+			(end -1.7 -1.75)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2eaf35cc-96c0-441d-955e-bc52e86d6cc4")
+		)
+		(fp_line
+			(start 0.7 -1.52)
+			(end 0.7 1.52)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "8046bc54-96ee-4551-940b-135047b2e8cc")
+		)
+		(fp_line
+			(start -0.15 -1.52)
+			(end 0.7 -1.52)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "16729ffb-6621-44bb-9813-1b90b721f3c8")
+		)
+		(fp_line
+			(start -0.7 -0.95)
+			(end -0.15 -1.52)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "38b10064-ff8a-452c-b736-d1590a924793")
+		)
+		(fp_line
+			(start -0.7 -0.95)
+			(end -0.7 1.5)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d9bd41ba-6073-4cd3-a7d1-d0dc7bee7e7e")
+		)
+		(fp_line
+			(start -0.7 1.52)
+			(end 0.7 1.52)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "bd32726c-4cd4-401e-baa6-1090a1568b1b")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "1fc0ee16-abdd-48e7-968d-c3e6a57a39c6")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.075)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -1 -0.95 90)
+			(size 0.9 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "3b334221-b657-426b-bdf7-23111ed719bd")
+		)
+		(pad "2" smd roundrect
+			(at -1 0.95 90)
+			(size 0.9 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "2e923c35-9555-490a-a6c6-3295f9c92485")
+		)
+		(pad "3" smd roundrect
+			(at 1 0 90)
+			(size 0.9 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(D2-Pad1)")
+			(uuid "cc68bb2e-9eb1-4798-be90-3e0c35efad78")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Package_TO_SOT_SMD.3dshapes/SOT-23.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec92df")
+		(at 56.500000 69.385000 90)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R21"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "4b71d84a-d4e3-4d04-98f8-a346335f3ffe")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "616a0381-090c-423c-aef1-eacb49a37d7c")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "e9deb18c-b8e9-45e6-8756-ca2bed3dfa0d")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "c0de401b-fd54-4efd-a6ad-81224032fcaa")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005edd63f0")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "94891618-aec5-4ec0-a53c-91cf7a37e95f")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "0fd86333-3768-403f-bf2b-b6ac311975cc")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "06e50fb9-ac4c-4c90-a119-6fd42cbcacb2")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "5f66b7ea-4313-4fdb-abaf-d32a69f61397")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "57a0e8f9-8ffd-4091-b72a-7cdfba4fe38b")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a807eae4-1d4d-4048-9db5-d814e4d46e13")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "851e6796-9df5-41e8-afbc-bd51f03e38cf")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "42496899-4235-48c3-8721-f40a6ef31324")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "7633080a-fdea-4e5a-81a3-af10a750fdaf")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VTARGET")
+			(uuid "2be9c57b-719b-4a3e-8412-75f6aa9fac1a")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(J4-Pad4)")
+			(uuid "7fb447b6-f6c7-44b0-8a68-ff8533e1642d")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec9309")
+		(at 36.235000 61.650000)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R15"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "49e74603-7151-4cc2-8d27-0a5889464d29")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "2.2k"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "e7f3e9ed-ff27-4d85-a252-60908b9d254a")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "15412281-287f-4793-b868-0f445008de9a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "193e81c2-0b0d-46a1-965d-c17210455802")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f72cd39")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "c1953162-4a3d-45c7-b281-f8fa476f2c57")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "033741ac-a417-4f5f-b0ed-4143601dee34")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "990390b5-ce78-4664-ad7a-0e622c6e5c0d")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2faa715c-432a-4271-a4c5-34d35c3d1180")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "4357f83f-8344-490e-ad2f-5da177f666e6")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "634fce95-d1bb-480f-a764-5eb2071bf463")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c54d3d38-3efd-4cca-b335-77f0f8d63e4b")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "1e906826-faef-469a-af9c-b5e261731232")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "3e9af31b-94d5-412c-b22e-1a86b6424290")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/EEDATA")
+			(uuid "d07eadc8-2d62-465e-a848-383f388f0bad")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(R13-Pad2)")
+			(uuid "a18d8b08-cfad-44bd-98e3-fce091b412ab")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec9333")
+		(at 54.515000 58.900000 180)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R10"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "df982c89-cb67-40d6-b572-66fa0dbf7213")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "bf8cb901-0ab5-4bb9-b6a6-87d2145fa98d")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "32d5049e-344d-4538-9c68-bfa92c698de6")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "4d634a84-fdce-40a9-9ed2-a170b5549a04")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-000060387b05")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "d9b96e8a-e01c-4dbd-8ca8-4b920a3c5def")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "41610359-b6a2-40c9-9176-cb430a6970f5")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "3c2f9a81-733f-464c-9af2-3559eeb8d2a0")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "6f4ca5c7-a9d6-4c8d-b1be-f085a4eb9df8")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b219ac59-158b-4429-9fe4-24732afde678")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "cee8955c-6367-454d-bd55-038636ce4b8a")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d217deb7-dcfa-4f04-8475-b422af3c4672")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f811609a-5374-4d32-af2c-eb98191bd65c")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "23d92301-8e8a-40d7-b830-aba65aecd53c")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "536dfbd1-69fe-47f6-9e88-36fb3394302b")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/~{ENABLE}")
+			(uuid "24c6fb74-1e44-4971-9bfd-d7684d2f0113")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec935d")
+		(at 59.515000 56.135000)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C20"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "ddf62db0-329b-401e-98cf-d23852c05f08")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100n"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "9f96c9e4-9dfc-458b-8c9e-2477351666de")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "eac07145-2dce-4bcb-b81a-caef2bded2df")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "5ca1bd36-f90b-4a51-85be-5637cb377492")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-000060d35de8")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "9dff6ecf-577f-475c-9766-a910f6bd3a3e")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "c9dc03f0-6781-460f-a425-200740d0efc3")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "3d6867a2-fa1f-4699-8fd7-10f370e7ab9d")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "78599681-093b-4816-b69f-9a2325478558")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "42cdff92-6fcc-4332-bb06-97250b4f407b")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "136726d1-3064-439b-b5d5-8fa6298fc2fa")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "95df23bb-26ac-417e-8dc6-010681da6f41")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e0d76b0c-c0b7-48c9-8d16-6ea320b1dee2")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "4172afff-11f8-48bb-a1dd-2f3000d612c5")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "36135009-34ce-4a9a-97a7-73661696aa04")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "e598a256-e182-4a9d-9219-5fa1543bf78b")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec9444")
+		(at 66.515000 38.900000 180)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C5"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "da8fe7fd-ec98-48a4-912d-f56cbb292006")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100n"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "d8e4c202-fdc6-434f-a6ca-1c7771547621")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b613bed4-a29c-4410-a914-779a27569b50")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "12b28ff3-4905-4a41-ac86-a5015633b95a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ef8e430")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "747fb189-7f19-4312-9d22-85742324a423")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "06f73029-40d1-4daa-aaf1-4c8d84f53148")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "9c2b17a0-866b-44a0-a9e3-47c9da443ad1")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "5c3db4f5-b41f-438a-8306-235b4a667326")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c8f693e5-46d3-4212-8bce-253f929f94a9")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f41cc5a9-028c-4ed4-a6b8-3094732b20a6")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f7dcf4c8-15c3-4381-a6ac-05a97da29a3f")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "df58d99e-9371-4d04-aa53-96f28c0a1a3e")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "2db384f5-7d22-49ba-8ae1-894dbf1ecc42")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/VPHY")
+			(uuid "a002fddf-bd77-4d4b-8f38-855b8a601978")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "c05d14ce-3da7-4075-80f8-4ac2b902b908")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec9471")
+		(at 66.515000 45.900000)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R7"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "7d1eaff7-75e3-4e8b-922d-a20720e7baa0")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "f2e03c3b-9a53-455b-b75f-7f89064ccdf4")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "2f8fade8-a7b7-4df5-b742-1ee1afca81ea")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "48d05d25-0ef6-4c7a-993f-b6ff6a29dda7")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ee173e9")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "9c602f34-0151-48cd-a598-4859580fecfd")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "ce37fe65-96e8-445d-a354-f660d80f7166")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "0f555f29-6bc8-4515-8239-bd35064b5cab")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "22321f70-aac3-4b73-91f3-c913ff5400dc")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "46320f4a-4ccf-4a09-89d9-042c35fabacf")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ecebf158-50bd-4cf8-bb82-45fb725b460d")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c52a598d-b90f-4448-a50a-907a5a919ed2")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "2c417133-0f4a-47c9-85e5-b5b3185765d2")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "33d7a68f-d6d4-4b8e-af74-d2e23dabcb58")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "0d7b8f66-66cf-41bb-bc85-c09fa7319b61")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(R7-Pad2)")
+			(uuid "65995793-b83e-4b6c-a211-e6b5a7d8e120")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec94a1")
+		(at 35.523000 55.812000)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R8"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "f75257b9-4cdb-44be-a27c-75e53596af1d")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "330"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "ccc446c4-b9db-448b-9aa0-2d7007dc6d99")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "ccc9c6b7-45fd-48c5-8c9f-e1a4f52cb26c")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "a44e0c07-1761-4fc0-9b4b-bdd67a238f29")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00006027fe9c")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "33312c15-6457-4c0b-8fc8-9ac7b1e7f0e6")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "55021af7-4965-4cdd-9744-66dfc89cfe6f")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "281573fb-86b5-416c-b0fe-29373b620476")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "49e1bad8-ad04-4ea5-92a6-4e8b72be958d")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "70427058-3761-44e5-b705-bea6dc266ee0")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "817b3bf6-5f91-42c7-a55c-64907484f43d")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e135d182-5a65-462a-81da-181b14e01911")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c5189cda-deca-4491-8aea-7c4716fded72")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "9aec9e8a-0bde-45a8-a750-6532c065fb00")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(D3-Pad2)")
+			(uuid "7a00be39-b49b-4e8b-b73d-cb9f3d3fc3c7")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "ac4f10df-43f1-494a-9bf1-8153a441c4a5")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:SOT-23-5_RoundRect"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec94d1")
+		(at 42.250000 43.900000 180)
+		(descr "5-pin SOT23 package")
+		(tags "SOT-23-5")
+		(property "Reference" "U2"
+			(at 0 -2.9 0)
+			(layer "F.Fab")
+			(uuid "38ff575c-f78e-4b54-adda-03a6aedb9d4e")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "AP7365-33"
+			(at 0 2.9 0)
+			(layer "F.Fab")
+			(uuid "6cc11535-f161-4713-aa48-096f6ecb1f1e")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "7d577124-9be7-4619-8f38-7a84e7120431")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "11d766df-e614-464d-8f1d-2c5fb5941a4c")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ebe5652")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.9 -1.61)
+			(end -1.55 -1.61)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "c4bf0ba4-b3d3-4efa-a1a6-6414a011b09d")
+		)
+		(fp_line
+			(start -0.9 1.61)
+			(end 0.9 1.61)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d503be92-3daa-4941-9312-2e13d0b769ab")
+		)
+		(fp_line
+			(start 1.9 1.8)
+			(end -1.9 1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "ba02b310-6dcb-4e1b-8f11-448f6e4a7753")
+		)
+		(fp_line
+			(start 1.9 -1.8)
+			(end 1.9 1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "070f287b-e388-4370-9762-fccb0e4aeaed")
+		)
+		(fp_line
+			(start -1.9 1.8)
+			(end -1.9 -1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "7fbd40d4-882e-4a6c-928d-7d687e7f53c5")
+		)
+		(fp_line
+			(start -1.9 -1.8)
+			(end 1.9 -1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "913d158c-925d-44d0-b324-3f55763dd870")
+		)
+		(fp_line
+			(start 0.9 1.55)
+			(end -0.9 1.55)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "1171518d-cb75-42d0-8fce-88fe646e1fbc")
+		)
+		(fp_line
+			(start 0.9 -1.55)
+			(end 0.9 1.55)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c824b122-4f03-499e-8443-c85c0ed3599f")
+		)
+		(fp_line
+			(start 0.9 -1.55)
+			(end -0.25 -1.55)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e884c1db-c85a-453c-8552-aaa9df7ab66c")
+		)
+		(fp_line
+			(start -0.9 -0.9)
+			(end -0.25 -1.55)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "cbc32b0b-1ba3-4ee5-b2b2-291ec2fbe9ec")
+		)
+		(fp_line
+			(start -0.9 -0.9)
+			(end -0.9 1.55)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "4430e8f8-30cb-4818-888a-8ddc07b408b0")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "d232163c-697a-497a-b891-f3918b29af70")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.075)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -1.1 -0.95 180)
+			(size 1.06 0.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+5V")
+			(uuid "e99b8097-b10e-4038-89c1-ea65c792a8b9")
+		)
+		(pad "2" smd roundrect
+			(at -1.1 0 180)
+			(size 1.06 0.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "c7d0e909-1a9f-45d9-ba96-a732e5118f13")
+		)
+		(pad "3" smd roundrect
+			(at -1.1 0.95 180)
+			(size 1.06 0.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+5V")
+			(uuid "22931446-d779-42a4-8d5f-16b636c0ad81")
+		)
+		(pad "4" smd roundrect
+			(at 1.1 0.95 180)
+			(size 1.06 0.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "7828a9fb-2a58-46db-abc6-65c4680fc1b2")
+		)
+		(pad "5" smd roundrect
+			(at 1.1 -0.95 180)
+			(size 1.06 0.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "94f09866-f699-4e98-b9ac-82a6ac39b88a")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Package_TO_SOT_SMD.3dshapes/SOT-23-5.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:R_Array_Convex_4x0402_RoundRect"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec950f")
+		(at 49.000000 65.250000)
+		(descr "Chip Resistor Network, ROHM MNR04 (see mnr_g.pdf)")
+		(tags "resistor array")
+		(property "Reference" "RN7"
+			(at 0 -2.1 0)
+			(layer "F.Fab")
+			(uuid "017f920d-8cf0-4520-b64d-5b72c5e4576d")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100k"
+			(at 0 2.1 0)
+			(layer "F.Fab")
+			(uuid "7f9c6b71-e768-4feb-8b39-f096dbe9c7fe")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "c69f4400-678b-4eb3-b1e8-41f74cd05811")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "f98da903-2065-442b-958a-8827e470a8f6")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-0000612c4df4")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.25 -1.18)
+			(end -0.25 -1.18)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "2ff67bcb-c2d4-4b17-aac2-bb3a62397435")
+		)
+		(fp_line
+			(start 0.25 1.18)
+			(end -0.25 1.18)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "38455924-0b31-424c-b936-e3469dd29829")
+		)
+		(fp_line
+			(start -1 -1.25)
+			(end -1 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "08cc9866-d95e-4bda-83b2-db31c5c63f9a")
+		)
+		(fp_line
+			(start -1 -1.25)
+			(end 1 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "017d0fa3-942a-44b5-8f69-ca0da85db93a")
+		)
+		(fp_line
+			(start 1 1.25)
+			(end -1 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "9769f791-6b7c-4f5f-88f0-1b7e85f56244")
+		)
+		(fp_line
+			(start 1 1.25)
+			(end 1 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "a7d39629-f392-4630-b6dc-3da48c50a2df")
+		)
+		(fp_line
+			(start -0.5 -1)
+			(end 0.5 -1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "90e5c15c-a0a4-4260-ad29-4d2d1a624207")
+		)
+		(fp_line
+			(start -0.5 1)
+			(end -0.5 -1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "43deab0c-a886-4920-892c-6cdc3ce20abe")
+		)
+		(fp_line
+			(start 0.5 -1)
+			(end 0.5 1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "81bf3bf9-d5c2-403b-a76e-dc09b4bed57c")
+		)
+		(fp_line
+			(start 0.5 1)
+			(end -0.5 1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "626c2134-6262-4956-b64f-cd66572d5273")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "6c7a473f-3c21-4bab-8510-f6d2abfd79af")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.075)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.5 -0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/ICE_CDONE")
+			(uuid "bb07f5e9-db0b-427c-83af-e18ef4e9d845")
+		)
+		(pad "2" smd roundrect
+			(at -0.5 -0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/~{UART_CTS}")
+			(uuid "3b1f6c8c-ed96-48fc-8d7a-0edc79ad44ef")
+		)
+		(pad "3" smd roundrect
+			(at -0.5 0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/~{UART_DSR}")
+			(uuid "ab87a86f-b58f-45d3-aca7-9fce9d0938c5")
+		)
+		(pad "4" smd roundrect
+			(at -0.5 0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/~{UART_DCD}")
+			(uuid "fe06707c-6976-4ae4-a1ad-8b0f5f344e9a")
+		)
+		(pad "5" smd roundrect
+			(at 0.5 0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "590b3e5e-de6f-4bcc-8431-6808f2ca4fb2")
+		)
+		(pad "6" smd roundrect
+			(at 0.5 0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "c3480dde-54ae-4da6-b924-d286cb070d29")
+		)
+		(pad "7" smd roundrect
+			(at 0.5 -0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "85b980bc-81cd-4314-9e02-c67760cafe62")
+		)
+		(pad "8" smd roundrect
+			(at 0.5 -0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "bc43d391-21d8-45fd-baf4-d955e0ba6f1e")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_Array_Convex_4x0402.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec954c")
+		(at 66.515000 42.900000 180)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C7"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "5caba61b-8a89-47f1-8d0e-f1c55ccf21af")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "2u2"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "7a630f87-42d1-4b8a-aa2f-94ee0119cbbd")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "0ecff914-5312-44ee-a200-73e48aeb2b46")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "c7d97a47-16d3-4ca9-af48-d16e472c7077")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ed867b3")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "b4d5aeb1-5de0-425d-a1e0-1ec441884949")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "62ed8748-07e4-45b8-9d1e-8acfc8015570")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "e25cfbe1-81a4-4ebe-b452-24790510af31")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "e98d7c78-2e36-4788-986e-d74050b61fc0")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "dd3be009-1b83-4571-aa7e-60d8aa5015c2")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "69eccef5-a2b4-4f77-bc08-a110760ce8f0")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "1ac35f6d-9408-4eb2-9847-e23b11051fc5")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "86f69aa9-858e-4f68-b163-d82150101a23")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "f91d9c2a-4143-454c-8df7-f1753d72f98b")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/VPLL")
+			(uuid "e3baf949-20cf-4c31-bd30-add10720e1ac")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "dc553efe-1312-4dc0-aec5-5367fe84f871")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec96b4")
+		(at 66.515000 41.900000 180)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C8"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "c7f708ae-9205-4011-aa75-8fd80f92feac")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100n"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "305dc3a3-1cf9-4959-a977-1acba88eda33")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "5a2e8278-4c24-4ef5-908e-d6a9ca665fef")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "9bc3e915-9743-4d14-a9b7-a358feb2c14c")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f0d7ad7")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "d4ee2bf9-3da0-4017-af5b-0fda25fefcd6")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "d4f2dc26-68cd-4987-b6ed-99d0f9bab96c")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "e913d843-14b2-42a8-a521-50b030bb11cd")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "6d7a0fae-975a-46b2-b717-0ced09640e51")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "8a3a4830-0599-4815-9a02-8df69946f708")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "bdec6814-3c60-416f-9978-37a5e24564f2")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d5f29814-e222-492f-ade4-e925354747eb")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "0faa6fdd-4241-4a88-a842-0323ebecb0d8")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "3522beb0-e11d-4203-b8e8-322388e58fc8")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/VPLL")
+			(uuid "31a23ed8-c90c-4dbe-8eb3-6ed118de682c")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "5539cfde-c802-425b-ab4b-23a783fe63ef")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Inductor_SMD:L_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec96e1")
+		(at 48.015000 51.900000)
+		(descr "Inductor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "inductor")
+		(property "Reference" "FB1"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "95198cf2-5c83-47eb-94e8-9c67884a8906")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "600R, 0.5A"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "ccc02b2c-0a5c-42bb-be05-ba8d4a23f3a6")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "0207c0d1-faf8-40ed-b284-cd5c4eff9f41")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "6bf6bd1d-04f6-474e-bcdc-0817e9f29457")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005efb1073")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "e4204dc5-5a48-4fe5-bde9-8aa55d933c35")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "8b4121be-5b5d-4f50-868d-c5b17ef30514")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "d397ac98-3e6c-4e7d-9519-b4e92042e324")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "d6e39221-6380-4ea1-90c0-b06910e2aa40")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "3798ee8c-ce3f-453a-8c1a-034726994eb9")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "53d8c36a-6068-43e6-9ba6-92977300e6d4")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b8986638-a91a-4bf9-a6b9-a9f373f5385b")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "0c0e186e-ab5f-4921-8e8d-712e76f3565d")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "b5b4d340-52dd-4541-ad4b-7790dbc9f4aa")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "5b4e4a46-77f9-4041-80f1-a57ae3ea30f4")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/VPHY")
+			(uuid "90a99f77-f85d-4f69-b281-1aca2db0a20b")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Inductor_SMD.3dshapes/L_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec97c2")
+		(at 57.015000 65.900000)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C15"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "269e7704-505c-45ee-bad3-6a8b56aa2668")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100n"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "56fac5ab-4b37-47a9-a4cf-9fd8c890ac9b")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "e5ee0fbb-c809-4554-9fbe-2b9cb0e90e10")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "9e2eba8d-f497-4ef0-96bb-4f36874e3cda")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f8a478f")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "5b374205-de3b-441d-9f25-5a14682651cf")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "6e738067-87f6-468d-a64e-ed812587e872")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "d3300196-5e0d-4a41-a084-3e1d987489d7")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "93edbb3f-4f8a-4783-991d-b7f6e851f252")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "bff17869-d127-485b-9531-66e1e9d7cad9")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "362dd438-e33e-4f55-92d0-ecea4705bc30")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "1a00ea97-ea0a-4fec-a58e-2f11605c88ba")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a6ba7246-67b1-4559-b77b-14ae111b93a1")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "3e865886-7950-42a6-945c-d31d45ed1230")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "a109f825-fb43-417a-9efc-3d23a39f4171")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "e0690b0e-60f6-41d4-835f-9c1480c95ddf")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:R_Array_Convex_4x0402_RoundRect"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec97f4")
+		(at 49.000000 67.850000)
+		(descr "Chip Resistor Network, ROHM MNR04 (see mnr_g.pdf)")
+		(tags "resistor array")
+		(property "Reference" "RN8"
+			(at 0 -2.1 0)
+			(layer "F.Fab")
+			(uuid "b147a5bf-2a46-42e2-bd96-5132edafdf42")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100k"
+			(at 0 2.1 0)
+			(layer "F.Fab")
+			(uuid "e75b6ed5-6bbe-43ec-bd33-17e2c01a6d02")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "c801fba9-4ceb-482b-a476-e8f12013149e")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "ac7d1696-30d8-47ac-93b3-70ae19da300f")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005edcd172")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.25 -1.18)
+			(end -0.25 -1.18)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b0412022-8791-4233-96a4-728f4b13bac6")
+		)
+		(fp_line
+			(start 0.25 1.18)
+			(end -0.25 1.18)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "c8266556-25e2-4ba6-a157-854860b80106")
+		)
+		(fp_line
+			(start -1 -1.25)
+			(end -1 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "d03028c9-6e86-4e83-9377-5668c29f6434")
+		)
+		(fp_line
+			(start -1 -1.25)
+			(end 1 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "f36ecd1f-7b25-414c-b385-8beb5f506388")
+		)
+		(fp_line
+			(start 1 1.25)
+			(end -1 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "533e2866-3653-4e0c-8e17-e8778df1deaa")
+		)
+		(fp_line
+			(start 1 1.25)
+			(end 1 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "137a2f7b-6432-4a92-a2a5-f08e1ab4222f")
+		)
+		(fp_line
+			(start -0.5 -1)
+			(end 0.5 -1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "271fadba-fe13-4302-b86a-4da5319143b0")
+		)
+		(fp_line
+			(start -0.5 1)
+			(end -0.5 -1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f3314a50-b791-4171-b162-a4be8d33bf68")
+		)
+		(fp_line
+			(start 0.5 -1)
+			(end 0.5 1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "5a7ab889-df0d-4524-b1cc-e8ef0e5354e0")
+		)
+		(fp_line
+			(start 0.5 1)
+			(end -0.5 1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "5ee229b0-5811-4456-8bc1-d542889e8628")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "7af944f5-63e5-4b29-b0aa-b63f1698864c")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.075)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.5 -0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/DI")
+			(uuid "041a2884-5129-4ebe-b17b-833bd84e0771")
+		)
+		(pad "2" smd roundrect
+			(at -0.5 -0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/ICE_CDONE")
+			(uuid "46c63b8b-3c6b-4148-9847-c0139219e78e")
+		)
+		(pad "3" smd roundrect
+			(at -0.5 0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN8-Pad3)")
+			(uuid "69089371-944b-4347-afbe-e754e16d8f07")
+		)
+		(pad "4" smd roundrect
+			(at -0.5 0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN8-Pad4)")
+			(uuid "e5811467-ed70-49bd-9f41-556a97ca3bf4")
+		)
+		(pad "5" smd roundrect
+			(at 0.5 0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "407780a0-cc31-46a8-a1c9-ad34c8388b74")
+		)
+		(pad "6" smd roundrect
+			(at 0.5 0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "99163f66-7e55-4172-b2d8-72bd18f873d1")
+		)
+		(pad "7" smd roundrect
+			(at 0.5 -0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "f8899aeb-644a-465e-b0fa-b750fcb7e954")
+		)
+		(pad "8" smd roundrect
+			(at 0.5 -0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "98e0d86e-ead4-434e-803c-f3d8447d67cc")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_Array_Convex_4x0402.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:R_Array_Convex_4x0402_RoundRect"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec9836")
+		(at 44.000000 63.200000)
+		(descr "Chip Resistor Network, ROHM MNR04 (see mnr_g.pdf)")
+		(tags "resistor array")
+		(property "Reference" "RN6"
+			(at 0 -2.1 0)
+			(layer "F.Fab")
+			(uuid "9d01ef66-46c4-4567-9325-35e9e424fea5")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100"
+			(at 0 2.1 0)
+			(layer "F.Fab")
+			(uuid "cf951f6a-9b87-4cfd-a4aa-812b227c61b1")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "1c995596-6174-4daa-9665-4c833658dd23")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "3455c42d-1c9c-4b19-a0ad-e3d9415e2a84")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ed9af75")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.25 -1.18)
+			(end -0.25 -1.18)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "dc8a4d18-01c3-49b1-aeb5-d6595646339a")
+		)
+		(fp_line
+			(start 0.25 1.18)
+			(end -0.25 1.18)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d8503be9-422d-4fad-9cef-409391adf915")
+		)
+		(fp_line
+			(start -1 -1.25)
+			(end -1 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "3ab653cf-ebd9-4d37-83b0-c8f2062c98c6")
+		)
+		(fp_line
+			(start -1 -1.25)
+			(end 1 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "ecdbc9fb-bd55-4ecb-874d-f528e7b1b5fb")
+		)
+		(fp_line
+			(start 1 1.25)
+			(end -1 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "a97fe46c-e0d9-4ea6-a632-4a7475c61954")
+		)
+		(fp_line
+			(start 1 1.25)
+			(end 1 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "920d60a9-228a-4e20-8717-1e6f723aec82")
+		)
+		(fp_line
+			(start -0.5 -1)
+			(end 0.5 -1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "32961950-94c3-41e9-89ee-a036689f1265")
+		)
+		(fp_line
+			(start -0.5 1)
+			(end -0.5 -1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "01f45059-8b5a-4b1b-b22b-03b7f444fa0b")
+		)
+		(fp_line
+			(start 0.5 -1)
+			(end 0.5 1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "5d2c1e03-364c-4a10-886f-7a45c8a34a22")
+		)
+		(fp_line
+			(start 0.5 1)
+			(end -0.5 1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "0a78b53f-8bec-46c2-a0d4-9190b3ad9f7d")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "5e23bed3-d386-4f4e-9469-ceef9a6d207b")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.075)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.5 -0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD2")
+			(uuid "dd92535e-a64f-4d0a-9cd0-fc98e9a6de40")
+		)
+		(pad "2" smd roundrect
+			(at -0.5 -0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD6")
+			(uuid "e806e188-34cb-4ab8-937a-3b020616d9ab")
+		)
+		(pad "3" smd roundrect
+			(at -0.5 0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "96ef9955-2ba5-451c-8cda-ff02c006189b")
+		)
+		(pad "4" smd roundrect
+			(at -0.5 0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "8467dd8a-2600-4dff-8a27-0e52cc86d995")
+		)
+		(pad "5" smd roundrect
+			(at 0.5 0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN6-Pad5)")
+			(uuid "77b6b1d2-ada0-447e-ae26-dc5df3272ca6")
+		)
+		(pad "6" smd roundrect
+			(at 0.5 0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN6-Pad6)")
+			(uuid "96df956b-8dbd-4800-8721-135db90b3a5e")
+		)
+		(pad "7" smd roundrect
+			(at 0.5 -0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN6-Pad7)")
+			(uuid "a9cc2b83-3f51-49e7-a15b-8682eff37e59")
+		)
+		(pad "8" smd roundrect
+			(at 0.5 -0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN6-Pad8)")
+			(uuid "152c8af5-8f77-43e8-a770-c7ad7e53cf61")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_Array_Convex_4x0402.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec9870")
+		(at 46.515000 59.900000 180)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R17"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "e763c84a-dd02-46c4-8b20-01c367ed92db")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "1M"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "7b8892cc-b655-4eb3-bbf1-cafd88c5bbd3")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "077cfea0-84a7-4920-b126-ad91555b8f4c")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "251dc7d6-eca1-45ee-98e8-8e4f3f1a741a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-0000610cf3df")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "d2791bda-a44e-400f-869a-2dc0e2e37fca")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "95bd8822-c5d9-4c71-a543-4543e61f8d73")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "12201522-8760-42bb-96be-a90e2c93f8c6")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "031c1d3f-3071-4b74-90ef-d490f04a5afa")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "0d5b8162-c3ba-4cee-8ead-0efd8e9674b5")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "1c2b06d0-d66d-4307-af77-2b704eec031a")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "83c60164-268d-422c-ad42-b8227bc35768")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "31c01932-5eed-4b93-ac3d-38cf62680ad4")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "b5e1d5a8-1486-4f7d-977c-f9cc4f2d5cfb")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "c79262dd-d3b1-428b-9c73-344c661bf78e")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "23d57085-e988-432b-b24f-4c27fbd1fc40")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec989a")
+		(at 50.000000 49.650000 90)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C13"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "419a3076-2c4c-4df0-9c43-c8bbabffe901")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100n"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "32a56312-bb14-4346-8154-4837c6bc5912")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "15315da4-c0f3-4a5a-92bf-213b37362ce6")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b2c5d5f1-3d71-4f77-9ff4-0236ec923370")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f777983")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "9b7025bb-ba3d-46f5-a434-db058433b43d")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "8d667b74-e829-4e91-9119-f3e8176e569a")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "912a051f-bfbc-452c-aad4-8c5d2a1abdfb")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "484c4570-eef4-448e-ae95-b70eede3ae64")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a1757dec-d476-4011-b95f-78fb0787ad3b")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "49861cc6-d21a-44e0-8cf3-5b8625d680b5")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9ceb13ab-c0e9-4b3f-ba1e-4e3d361969e8")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b622bdbf-5f2d-4bc0-93e0-00a3ec05199c")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "ac479c65-a62d-4bc1-831b-00290d588420")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREG")
+			(uuid "ab2214a9-3023-42da-a008-fb9d63f345b4")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "2d05c1f5-4905-434d-ac7b-0b711d06e212")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "LED_SMD:LED_0603_1608Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec98c8")
+		(at 38.460000 49.526000 270)
+		(descr "LED SMD 0603 (1608 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "diode")
+		(property "Reference" "D4"
+			(at 0 -1.43 90)
+			(layer "F.Fab")
+			(uuid "8f1e8b75-dd21-4e73-9e32-f42b99c5cdba")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "YELLOW"
+			(at 0 1.43 90)
+			(layer "F.Fab")
+			(uuid "bd3b4988-efee-4544-9def-7ff1093dc025")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "7f12796d-a1db-459a-8aac-c95d3ac742f5")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "2dc7cd23-6375-45c1-bdc8-ad5f3756b337")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005fceb5af")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -1.485 0.735)
+			(end 0.8 0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "3808151b-83c8-4c77-ae1e-2903d6d31581")
+		)
+		(fp_line
+			(start -1.485 -0.735)
+			(end -1.485 0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "2c5b4a63-94f5-470b-8d26-67130b1151de")
+		)
+		(fp_line
+			(start 0.8 -0.735)
+			(end -1.485 -0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "026aa94b-463d-41ae-bb0d-906b3cfd3f48")
+		)
+		(fp_line
+			(start -1.48 0.73)
+			(end -1.48 -0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "cc6e82ea-7440-492f-bbf8-88c4d379ef9a")
+		)
+		(fp_line
+			(start 1.48 0.73)
+			(end -1.48 0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "6a27b7c0-ab83-4f70-8157-43604a0d4276")
+		)
+		(fp_line
+			(start -1.48 -0.73)
+			(end 1.48 -0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "7cc9dccd-577c-4e20-8676-2ce0a983f6d7")
+		)
+		(fp_line
+			(start 1.48 -0.73)
+			(end 1.48 0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2a27a921-5b90-4670-97ae-6e27d1eefb09")
+		)
+		(fp_line
+			(start -0.8 0.4)
+			(end 0.8 0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b04ffd40-da3e-4cd8-95c8-0cbc4222c859")
+		)
+		(fp_line
+			(start 0.8 0.4)
+			(end 0.8 -0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d5b287ce-373b-48c0-b7cd-e3cfcd407d5d")
+		)
+		(fp_line
+			(start -0.8 -0.1)
+			(end -0.8 0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ad5b86ea-39d6-46b7-8402-b4685643dc8e")
+		)
+		(fp_line
+			(start -0.5 -0.4)
+			(end -0.8 -0.1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a2c7a7d0-f568-4f7a-9238-c0dde4bc1792")
+		)
+		(fp_line
+			(start 0.8 -0.4)
+			(end -0.5 -0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9dab1394-94e6-4547-bfef-b9f5568e929d")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "f430230e-8f01-4521-a278-d4dc8b4c1f43")
+			(effects
+				(font
+					(size 0.4 0.4)
+					(thickness 0.06)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.7875 0 270)
+			(size 0.875 0.95)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/TXLED")
+			(uuid "88e0aaaf-fab9-4c02-81ba-966ca3f022d0")
+		)
+		(pad "2" smd roundrect
+			(at 0.7875 0 270)
+			(size 0.875 0.95)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(D4-Pad2)")
+			(uuid "0bcbd7bf-ab4c-4989-99a5-9ebb86998919")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/LED_SMD.3dshapes/LED_0603_1608Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "LED_SMD:LED_0603_1608Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec98fe")
+		(at 38.460000 55.622000 270)
+		(descr "LED SMD 0603 (1608 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "diode")
+		(property "Reference" "D5"
+			(at 0 -1.43 90)
+			(layer "F.Fab")
+			(uuid "27927f12-1d2f-439e-b966-6f38f1888f76")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "GREEN"
+			(at 0 1.43 90)
+			(layer "F.Fab")
+			(uuid "63b4cfab-5fb2-4386-8496-6fd577f9e5b7")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "cb8deb24-e099-435d-8c1b-451c553938d2")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "8a9ff24e-589d-40ec-9da3-42b9ee36f1a7")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005fcebabb")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -1.485 0.735)
+			(end 0.8 0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "3ea12638-5d17-4812-9074-f1bacf9a009f")
+		)
+		(fp_line
+			(start -1.485 -0.735)
+			(end -1.485 0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "ae240f6d-e57d-49d9-8eb4-d480499b04d4")
+		)
+		(fp_line
+			(start 0.8 -0.735)
+			(end -1.485 -0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "2fb12380-8577-4766-a591-2b3283b1a29d")
+		)
+		(fp_line
+			(start -1.48 0.73)
+			(end -1.48 -0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "24049293-a2cc-4dc6-9648-b77fe24c48e0")
+		)
+		(fp_line
+			(start 1.48 0.73)
+			(end -1.48 0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "a3098f5b-e247-4728-a1b5-118a8eea45ee")
+		)
+		(fp_line
+			(start -1.48 -0.73)
+			(end 1.48 -0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "29952af2-0545-4f0a-a4f5-63326387bf81")
+		)
+		(fp_line
+			(start 1.48 -0.73)
+			(end 1.48 0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "b497e6b5-5e45-4fab-bb72-526c257344f5")
+		)
+		(fp_line
+			(start -0.8 0.4)
+			(end 0.8 0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "36ae45a7-0437-462c-b92c-8a68abc99d6a")
+		)
+		(fp_line
+			(start 0.8 0.4)
+			(end 0.8 -0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "eac352f4-c414-4015-b92d-c9d00a109791")
+		)
+		(fp_line
+			(start -0.8 -0.1)
+			(end -0.8 0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "247dfcd5-e3d6-46a1-ba4e-ce95ca6c5fd3")
+		)
+		(fp_line
+			(start -0.5 -0.4)
+			(end -0.8 -0.1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b7ab9b93-d4ce-4f78-aac3-49065bcc77ec")
+		)
+		(fp_line
+			(start 0.8 -0.4)
+			(end -0.5 -0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "efb620da-4661-4846-8120-5e5cd0325a2f")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "e5d81d06-bbff-4ec3-ab9a-0c939411e1d2")
+			(effects
+				(font
+					(size 0.4 0.4)
+					(thickness 0.06)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.7875 0 270)
+			(size 0.875 0.95)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/~{ENABLE}")
+			(uuid "93e813fe-ddf4-4aa3-b5dc-b911e8af5f03")
+		)
+		(pad "2" smd roundrect
+			(at 0.7875 0 270)
+			(size 0.875 0.95)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(D5-Pad2)")
+			(uuid "92df106f-e0d0-4e7a-ba1d-5a7d24f4fd2e")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/LED_SMD.3dshapes/LED_0603_1608Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec9930")
+		(at 40.000000 64.635000 90)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C10"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "02fad32e-976a-41e9-8a58-218af1f794e8")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "2u2"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "4aed529c-a993-4326-9e2f-216f4367eb2b")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "11a4154e-bd67-40af-a95e-f51535a1bc71")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b28142b5-4069-492c-8cf0-ebdf10824b00")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005eec885d")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "cef0e661-8d31-49a6-9468-88d8089179bc")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "5e9da41c-4c32-41d5-afdf-41e20e1a9c57")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "0a9dcabd-9625-4b6a-8a3c-8d66458ece39")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "d31c6339-ce19-4f05-a47f-c82a84e471e3")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "81e9526c-e710-4e26-a56c-0e630178a54d")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "bdae627e-dbfd-4536-a9dc-e0862cfefb35")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ac274adc-6478-4d06-bedc-1440e2acdcba")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "44da51ba-2a8f-4f3e-8335-557171af8d41")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "7ff6ead7-47f1-4895-a39b-58cad9f059ad")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREG")
+			(uuid "415c59c7-b615-4f57-9d13-11ae25379779")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "4bfbabc9-76c4-4f6c-a2e6-76a2bf81d054")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec995a")
+		(at 39.750000 44.385000 90)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C4"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "3993be72-cc8c-4f5b-b5bc-827bd4e3f135")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "2u2"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "a1a45ef8-ab65-4333-9123-108194001646")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "ac366545-6785-4a0d-acdc-ea91b7ce0907")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "7c29b72b-a4e7-4bbc-abf1-85168f4a1d28")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ee3ec6b")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "8d7d681d-5da4-4515-905a-c37dafc9ab18")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "fdc69c24-5579-4447-b277-a3ebc7f6f74b")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "c7e041bb-0b3b-4737-b3c5-98da1b5df1ab")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "1cd2c82a-823f-4a75-ac0f-55c38331d945")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "62c2ef9f-4795-46f0-90fb-9ba775a3121e")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "cdd66f52-7e48-49a1-be14-cd471e370715")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "65518b25-1de7-41cb-b5be-0d812158eaa8")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "12d75ccd-3d47-4f7a-a016-46ab867ed6fb")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "2143b328-fa71-45e4-a699-1d3dc785fd74")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "f947296b-7504-48b2-b820-bbb4416cb791")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "30aa0563-df9c-430d-a95a-d0a04a74b6ae")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Package_DFN_QFN:QFN-64-1EP_9x9mm_P0.5mm_EP4.35x4.35mm_ThermalVias"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec99e5")
+		(at 54.500000 56.400000)
+		(descr "QFN, 64 Pin (https://www.ftdichip.com/Support/Documents/DataSheets/ICs/DS_FT2232H.pdf#page=57), generated with kicad-footprint-generator ipc_noLead_generator.py")
+		(tags "QFN NoLead")
+		(property "Reference" "U3"
+			(at 0 -5.8 0)
+			(layer "F.Fab")
+			(uuid "e79820b3-acf4-44b6-a259-40c5d8761ad5")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "FT2232HQ"
+			(at 0 5.8 0)
+			(layer "F.Fab")
+			(uuid "e9eae1fb-bf9f-4b91-844b-e42ac31af298")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b60c6693-fe98-4c04-ab58-e6f254f971df")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "d00d31ee-3544-4e36-82bd-7b45e94b6666")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005edde775")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -4.61 4.61)
+			(end -4.61 4.135)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d89287c2-8ea5-42e6-ab6f-46374bac47da")
+		)
+		(fp_line
+			(start -4.135 -4.61)
+			(end -4.61 -4.61)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "1aa95629-3ec9-4366-a9ee-fb8a5281a694")
+		)
+		(fp_line
+			(start -4.135 4.61)
+			(end -4.61 4.61)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "7d9eaaf6-a27f-40ef-969d-5087ebcce1ce")
+		)
+		(fp_line
+			(start 4.135 -4.61)
+			(end 4.61 -4.61)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "c918120c-5acd-4600-8262-9c53f7f48a5d")
+		)
+		(fp_line
+			(start 4.135 4.61)
+			(end 4.61 4.61)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "ec4913ce-f2c8-4657-826c-17e52bd07142")
+		)
+		(fp_line
+			(start 4.61 -4.61)
+			(end 4.61 -4.135)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "4ff138ab-4973-46e7-b718-9e6b6a04ad94")
+		)
+		(fp_line
+			(start 4.61 4.61)
+			(end 4.61 4.135)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "96936f4c-d8a1-466e-8a54-73246bdb4f20")
+		)
+		(fp_line
+			(start -5.1 -5.1)
+			(end -5.1 5.1)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "31bbe63a-a261-4929-9975-de48bf34beb2")
+		)
+		(fp_line
+			(start -5.1 5.1)
+			(end 5.1 5.1)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "4e3639df-181e-4efe-a27d-cd9dfe762ace")
+		)
+		(fp_line
+			(start 5.1 -5.1)
+			(end -5.1 -5.1)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "19d50738-a322-437e-8ee4-dd2b0f4298b8")
+		)
+		(fp_line
+			(start 5.1 5.1)
+			(end 5.1 -5.1)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "9e5d40fb-a1ff-41c8-af94-8b1d7f89c12e")
+		)
+		(fp_line
+			(start -4.5 -3.5)
+			(end -3.5 -4.5)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d1c001c6-fc53-44f0-af4d-228d13a2a3e8")
+		)
+		(fp_line
+			(start -4.5 4.5)
+			(end -4.5 -3.5)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "871d7d9c-7101-4012-b166-693f3ced12af")
+		)
+		(fp_line
+			(start -3.5 -4.5)
+			(end 4.5 -4.5)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ea89f07b-60c2-457b-83df-5fb62b666367")
+		)
+		(fp_line
+			(start 4.5 -4.5)
+			(end 4.5 4.5)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "731791c7-5a26-4e49-8d3d-c4ec266d0ca9")
+		)
+		(fp_line
+			(start 4.5 4.5)
+			(end -4.5 4.5)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "43e48220-8fdc-4c95-9b78-24d739b1b25e")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "6fef0575-efc2-4fcd-a7e1-a815a5810675")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "" smd roundrect
+			(at -1.283333 -1.283333)
+			(size 1.123165 1.123165)
+			(layers "F.Paste")
+			(roundrect_rratio 0.222585)
+			(uuid "1293d100-3f53-4093-8d1f-f6e2f8161a36")
+		)
+		(pad "" smd roundrect
+			(at -1.283333 0)
+			(size 1.123165 1.123165)
+			(layers "F.Paste")
+			(roundrect_rratio 0.222585)
+			(uuid "382d081a-d03b-47a4-8b53-8b9849681f3c")
+		)
+		(pad "" smd roundrect
+			(at -1.283333 1.283333)
+			(size 1.123165 1.123165)
+			(layers "F.Paste")
+			(roundrect_rratio 0.222585)
+			(uuid "574bb8f0-b761-4118-b514-775edca17d24")
+		)
+		(pad "" smd roundrect
+			(at 0 -1.283333)
+			(size 1.123165 1.123165)
+			(layers "F.Paste")
+			(roundrect_rratio 0.222585)
+			(uuid "04a9be9f-a88d-46f7-a7b8-621fb2c195dc")
+		)
+		(pad "" smd roundrect
+			(at 0 0)
+			(size 1.123165 1.123165)
+			(layers "F.Paste")
+			(roundrect_rratio 0.222585)
+			(uuid "fc551c16-6a0a-4597-a904-80297d71c9cd")
+		)
+		(pad "" smd roundrect
+			(at 0 1.283333)
+			(size 1.123165 1.123165)
+			(layers "F.Paste")
+			(roundrect_rratio 0.222585)
+			(uuid "c325f035-2ad8-4a90-b6d5-33447e570a10")
+		)
+		(pad "" smd roundrect
+			(at 1.283333 -1.283333)
+			(size 1.123165 1.123165)
+			(layers "F.Paste")
+			(roundrect_rratio 0.222585)
+			(uuid "bdbe83f5-8435-4360-bca4-8bff1bdcbe72")
+		)
+		(pad "" smd roundrect
+			(at 1.283333 0)
+			(size 1.123165 1.123165)
+			(layers "F.Paste")
+			(roundrect_rratio 0.222585)
+			(uuid "6d357c2e-0d06-44b4-8d99-a1604fb3802d")
+		)
+		(pad "" smd roundrect
+			(at 1.283333 1.283333)
+			(size 1.123165 1.123165)
+			(layers "F.Paste")
+			(roundrect_rratio 0.222585)
+			(uuid "9efa629c-f211-41fe-a48c-273efa8a0bce")
+		)
+		(pad "1" smd roundrect
+			(at -4.45 -3.75)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "8887296d-c58e-4de5-846b-99c01151a402")
+		)
+		(pad "2" smd roundrect
+			(at -4.45 -3.25)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(C23-Pad1)")
+			(uuid "35e9d339-9648-4cb0-b9b0-db4b41bcea46")
+		)
+		(pad "3" smd roundrect
+			(at -4.45 -2.75)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(C24-Pad1)")
+			(uuid "042419d3-8676-4c4a-9a74-ce578194028c")
+		)
+		(pad "4" smd roundrect
+			(at -4.45 -2.25)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/VPHY")
+			(uuid "23063d40-bc4b-4e4d-900e-dbc922ba91e5")
+		)
+		(pad "5" smd roundrect
+			(at -4.45 -1.75)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "96f7f591-0355-49e2-be1e-1f3290de264b")
+		)
+		(pad "6" smd roundrect
+			(at -4.45 -1.25)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(R6-Pad2)")
+			(uuid "1c5f7cd8-748f-4e04-a4b0-0a79ba478710")
+		)
+		(pad "7" smd roundrect
+			(at -4.45 -0.75)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/USB_DN")
+			(uuid "aa4f6e42-5344-4e5b-af8f-50979953cec0")
+		)
+		(pad "8" smd roundrect
+			(at -4.45 -0.25)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/USB_DP")
+			(uuid "6a079265-3399-439c-81d3-66ac014b2673")
+		)
+		(pad "9" smd roundrect
+			(at -4.45 0.25)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/VPLL")
+			(uuid "50bca8a7-49f8-470e-85e8-00569bb6f3aa")
+		)
+		(pad "10" smd roundrect
+			(at -4.45 0.75)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "675db17f-a635-407d-8b24-d5233838dfaa")
+		)
+		(pad "11" smd roundrect
+			(at -4.45 1.25)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "366b3f83-5736-4dde-8fad-6df0dbeeb610")
+		)
+		(pad "12" smd roundrect
+			(at -4.45 1.75)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREG")
+			(uuid "f2a70fe5-6c7f-4b20-a145-8f2e142cffbb")
+		)
+		(pad "13" smd roundrect
+			(at -4.45 2.25)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "dff74dd7-e6a5-48e3-8bf5-9853ce5adf66")
+		)
+		(pad "14" smd roundrect
+			(at -4.45 2.75)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(R7-Pad2)")
+			(uuid "25870d94-f1b5-41ba-a43f-3dc010f48be6")
+		)
+		(pad "15" smd roundrect
+			(at -4.45 3.25)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "3c1d842a-52fa-49c0-ada7-e7735d4edc34")
+		)
+		(pad "16" smd roundrect
+			(at -4.45 3.75)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD0")
+			(uuid "5e0883d7-4e02-4857-abb0-f4a2244fa7aa")
+		)
+		(pad "17" smd roundrect
+			(at -3.75 4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD1")
+			(uuid "d8804838-092a-4265-9bf3-8dcef664cb18")
+		)
+		(pad "18" smd roundrect
+			(at -3.25 4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD2")
+			(uuid "9a91f182-b114-48b5-a814-6aa117bcba40")
+		)
+		(pad "19" smd roundrect
+			(at -2.75 4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD3")
+			(uuid "49b6c91a-a7b2-4c93-8079-7fce77d3bc4f")
+		)
+		(pad "20" smd roundrect
+			(at -2.25 4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "d4df61bf-3d31-4465-89f2-78527948fc3e")
+		)
+		(pad "21" smd roundrect
+			(at -1.75 4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD4")
+			(uuid "1e34b810-5352-4b0d-b77c-74a71531ff6c")
+		)
+		(pad "22" smd roundrect
+			(at -1.25 4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD5")
+			(uuid "1bf49d27-52d6-46d9-a9a7-d1b5712a72b8")
+		)
+		(pad "23" smd roundrect
+			(at -0.75 4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD6")
+			(uuid "5e91665a-6a5e-49dd-b222-0407e66e5796")
+		)
+		(pad "24" smd roundrect
+			(at -0.25 4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "54eaa939-82aa-4304-a144-abfd0dfbbc19")
+		)
+		(pad "25" smd roundrect
+			(at 0.25 4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "6cf8da21-30f0-4152-83f2-8936d372d09b")
+		)
+		(pad "26" smd roundrect
+			(at 0.75 4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "aef53851-b295-4d3b-96b8-885bc90fc759")
+		)
+		(pad "27" smd roundrect
+			(at 1.25 4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "f71b1fe1-ccad-4786-9a4f-9e21bcfa74e0")
+		)
+		(pad "28" smd roundrect
+			(at 1.75 4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "86a4cadf-ca37-4514-961c-f22df89b8620")
+		)
+		(pad "29" smd roundrect
+			(at 2.25 4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/RXLED")
+			(uuid "669298ae-9104-44e8-8740-7ba9f248c7ee")
+		)
+		(pad "30" smd roundrect
+			(at 2.75 4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/TXLED")
+			(uuid "0c6aa260-a5ec-47b7-a333-0314ec55de7f")
+		)
+		(pad "31" smd roundrect
+			(at 3.25 4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "126a82fd-3a50-46b5-94fb-f79a74d0df95")
+		)
+		(pad "32" smd roundrect
+			(at 3.75 4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "28af905d-67a9-472d-a942-c0a3877acc57")
+		)
+		(pad "33" smd roundrect
+			(at 4.45 3.75)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "ea2791e2-5139-4924-a5b0-96aa9d30ff45")
+		)
+		(pad "34" smd roundrect
+			(at 4.45 3.25)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "0c0348dc-cd5f-4c18-8bbe-34feb2013440")
+		)
+		(pad "35" smd roundrect
+			(at 4.45 2.75)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "e22db05b-8dbe-490c-b1ec-fcaf81cdecc5")
+		)
+		(pad "36" smd roundrect
+			(at 4.45 2.25)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "0726635f-df45-4206-8690-11994693082b")
+		)
+		(pad "37" smd roundrect
+			(at 4.45 1.75)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREG")
+			(uuid "afbd182d-2c5b-417f-baa1-795058c80552")
+		)
+		(pad "38" smd roundrect
+			(at 4.45 1.25)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD0")
+			(uuid "ede26d58-dc21-4cc8-b7b4-15d7e11698a9")
+		)
+		(pad "39" smd roundrect
+			(at 4.45 0.75)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD1")
+			(uuid "fb5b9ea7-0318-4244-970d-06e282d38799")
+		)
+		(pad "40" smd roundrect
+			(at 4.45 0.25)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD2")
+			(uuid "7c9e9ef3-bf56-485f-80f1-661d282ede2c")
+		)
+		(pad "41" smd roundrect
+			(at 4.45 -0.25)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD3")
+			(uuid "167e4cea-e851-4221-8c7c-82f2f680fd84")
+		)
+		(pad "42" smd roundrect
+			(at 4.45 -0.75)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "cfd66c1a-532e-48e5-abb7-758d4bf8552c")
+		)
+		(pad "43" smd roundrect
+			(at 4.45 -1.25)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD4")
+			(uuid "ba283b13-9347-4651-8196-7b1152c45287")
+		)
+		(pad "44" smd roundrect
+			(at 4.45 -1.75)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD5")
+			(uuid "b8a3dc0e-b273-4029-b49a-30455284f0f1")
+		)
+		(pad "45" smd roundrect
+			(at 4.45 -2.25)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD6")
+			(uuid "4a06648d-8353-41c8-a148-ec00bc178ce1")
+		)
+		(pad "46" smd roundrect
+			(at 4.45 -2.75)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD7")
+			(uuid "5897a35e-7643-41b3-b1d2-c535319b5124")
+		)
+		(pad "47" smd roundrect
+			(at 4.45 -3.25)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "e1c7c18f-e2d4-4c1d-b476-e8f2eb897d38")
+		)
+		(pad "48" smd roundrect
+			(at 4.45 -3.75)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "0b1f59e1-2d8b-4010-9c3e-03cf2f0372e8")
+		)
+		(pad "49" smd roundrect
+			(at 3.75 -4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREG")
+			(uuid "42a9ebd2-9ca1-4857-9884-26947e2aefbf")
+		)
+		(pad "50" smd roundrect
+			(at 3.25 -4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "b724ebfc-e172-4503-9c12-680764e0688d")
+		)
+		(pad "51" smd roundrect
+			(at 2.75 -4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "079e93d5-afa7-4207-b015-7b83d3745e2f")
+		)
+		(pad "52" smd roundrect
+			(at 2.25 -4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "6c721b13-4208-4114-8dd5-ed0285fb8354")
+		)
+		(pad "53" smd roundrect
+			(at 1.75 -4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "cce4c9d5-f3a8-44b7-a315-d5aa47becbd1")
+		)
+		(pad "54" smd roundrect
+			(at 1.25 -4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "09068dc4-234b-434d-9f23-95cd79fd117b")
+		)
+		(pad "55" smd roundrect
+			(at 0.75 -4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "b4f669d4-7a7f-4ad5-8ca2-947d255ef91e")
+		)
+		(pad "56" smd roundrect
+			(at 0.25 -4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "e1606eeb-27a2-4e7c-904a-487583f8ce36")
+		)
+		(pad "57" smd roundrect
+			(at -0.25 -4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "2e571bbf-02d8-49a7-a056-1be2b70780ec")
+		)
+		(pad "58" smd roundrect
+			(at -0.75 -4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "13a38eea-59e3-4414-8c62-e765879f6dd5")
+		)
+		(pad "59" smd roundrect
+			(at -1.25 -4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "071747bd-0964-4b1d-98ee-88899a72b72c")
+		)
+		(pad "60" smd roundrect
+			(at -1.75 -4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/~{ENABLE}")
+			(uuid "cc45c115-61b7-4605-88aa-213811a7c0c5")
+		)
+		(pad "61" smd roundrect
+			(at -2.25 -4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/EEDATA")
+			(uuid "64254716-ff10-4382-8224-2ecf5ba921ef")
+		)
+		(pad "62" smd roundrect
+			(at -2.75 -4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/EECLK")
+			(uuid "aedf218a-44aa-40c8-b13c-2119f957af8e")
+		)
+		(pad "63" smd roundrect
+			(at -3.25 -4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/EECS")
+			(uuid "1940da76-8c12-43a1-b5fb-20237c93854c")
+		)
+		(pad "64" smd roundrect
+			(at -3.75 -4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREG")
+			(uuid "ca1537f9-15b4-432d-b33a-91e0c0564fb0")
+		)
+		(pad "65" thru_hole circle
+			(at -1.925 -1.925)
+			(size 0.5 0.5)
+			(drill 0.2)
+			(layers "*.Cu")
+			(remove_unused_layers no)
+			(net "GND")
+			(zone_connect 2)
+			(uuid "dd321821-8945-4601-b9b2-f15784bdf68a")
+		)
+		(pad "65" thru_hole circle
+			(at -1.925 -0.641667)
+			(size 0.5 0.5)
+			(drill 0.2)
+			(layers "*.Cu")
+			(remove_unused_layers no)
+			(net "GND")
+			(zone_connect 2)
+			(uuid "bfbb6bbc-df7d-4b09-9e55-a20f05e0dd59")
+		)
+		(pad "65" thru_hole circle
+			(at -1.925 0.641667)
+			(size 0.5 0.5)
+			(drill 0.2)
+			(layers "*.Cu")
+			(remove_unused_layers no)
+			(net "GND")
+			(zone_connect 2)
+			(uuid "f06cb80e-7a8c-4be9-a2c8-d04020ac591d")
+		)
+		(pad "65" thru_hole circle
+			(at -1.925 1.925)
+			(size 0.5 0.5)
+			(drill 0.2)
+			(layers "*.Cu")
+			(remove_unused_layers no)
+			(net "GND")
+			(zone_connect 2)
+			(uuid "8bbbf27e-962b-4d07-8124-520b0e0e4632")
+		)
+		(pad "65" thru_hole circle
+			(at -0.641667 -1.925)
+			(size 0.5 0.5)
+			(drill 0.2)
+			(layers "*.Cu")
+			(remove_unused_layers no)
+			(net "GND")
+			(zone_connect 2)
+			(uuid "75e7b327-9ad8-4028-8d98-6d9dccc77d7a")
+		)
+		(pad "65" thru_hole circle
+			(at -0.641667 -0.641667)
+			(size 0.5 0.5)
+			(drill 0.2)
+			(layers "*.Cu")
+			(remove_unused_layers no)
+			(net "GND")
+			(zone_connect 2)
+			(uuid "e0b958ec-da8c-4989-b058-3f63bdc20d87")
+		)
+		(pad "65" thru_hole circle
+			(at -0.641667 0.641667)
+			(size 0.5 0.5)
+			(drill 0.2)
+			(layers "*.Cu")
+			(remove_unused_layers no)
+			(net "GND")
+			(zone_connect 2)
+			(uuid "79db6368-2f7b-4b57-a472-f8acf3f4d63a")
+		)
+		(pad "65" thru_hole circle
+			(at -0.641667 1.925)
+			(size 0.5 0.5)
+			(drill 0.2)
+			(layers "*.Cu")
+			(remove_unused_layers no)
+			(net "GND")
+			(zone_connect 2)
+			(uuid "57ea4db0-eb85-40eb-861d-f9ce2742b762")
+		)
+		(pad "65" smd rect
+			(at 0 0)
+			(size 4.35 4.35)
+			(layers "F.Cu" "F.Mask")
+			(net "GND")
+			(zone_connect 2)
+			(uuid "3bdf743d-2646-4367-a19a-6ff1d06cbb63")
+		)
+		(pad "65" smd rect
+			(at 0 0)
+			(size 4.35 4.35)
+			(layers "B.Cu")
+			(net "GND")
+			(zone_connect 2)
+			(uuid "fda82e4e-ee87-4eeb-bf22-45d6be280583")
+		)
+		(pad "65" thru_hole circle
+			(at 0.641667 -1.925)
+			(size 0.5 0.5)
+			(drill 0.2)
+			(layers "*.Cu")
+			(remove_unused_layers no)
+			(net "GND")
+			(zone_connect 2)
+			(uuid "f1bec7e3-856d-4325-aab6-26b993242f3c")
+		)
+		(pad "65" thru_hole circle
+			(at 0.641667 -0.641667)
+			(size 0.5 0.5)
+			(drill 0.2)
+			(layers "*.Cu")
+			(remove_unused_layers no)
+			(net "GND")
+			(zone_connect 2)
+			(uuid "1339952a-a2ba-4f43-b1bc-6b63e1d2417e")
+		)
+		(pad "65" thru_hole circle
+			(at 0.641667 0.641667)
+			(size 0.5 0.5)
+			(drill 0.2)
+			(layers "*.Cu")
+			(remove_unused_layers no)
+			(net "GND")
+			(zone_connect 2)
+			(uuid "4b52bd06-1884-4af8-a50e-1e86a6e6bc11")
+		)
+		(pad "65" thru_hole circle
+			(at 0.641667 1.925)
+			(size 0.5 0.5)
+			(drill 0.2)
+			(layers "*.Cu")
+			(remove_unused_layers no)
+			(net "GND")
+			(zone_connect 2)
+			(uuid "30ae6fed-949c-40d4-bee6-75db2994bbd4")
+		)
+		(pad "65" thru_hole circle
+			(at 1.925 -1.925)
+			(size 0.5 0.5)
+			(drill 0.2)
+			(layers "*.Cu")
+			(remove_unused_layers no)
+			(net "GND")
+			(zone_connect 2)
+			(uuid "2ad30ee2-bef1-4b11-a8dd-b5c2161e3dfc")
+		)
+		(pad "65" thru_hole circle
+			(at 1.925 -0.641667)
+			(size 0.5 0.5)
+			(drill 0.2)
+			(layers "*.Cu")
+			(remove_unused_layers no)
+			(net "GND")
+			(zone_connect 2)
+			(uuid "e6b292f4-83bb-4eaa-b918-1dcdff3b941f")
+		)
+		(pad "65" thru_hole circle
+			(at 1.925 0.641667)
+			(size 0.5 0.5)
+			(drill 0.2)
+			(layers "*.Cu")
+			(remove_unused_layers no)
+			(net "GND")
+			(zone_connect 2)
+			(uuid "181e8a8b-4d58-428c-837a-a6438ffb3375")
+		)
+		(pad "65" thru_hole circle
+			(at 1.925 1.925)
+			(size 0.5 0.5)
+			(drill 0.2)
+			(layers "*.Cu")
+			(remove_unused_layers no)
+			(net "GND")
+			(zone_connect 2)
+			(uuid "da7061c6-0538-45e5-aa99-8202d9815e38")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Package_DFN_QFN.3dshapes/QFN-64-1EP_9x9mm_P0.5mm_EP6x6mm.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec9c33")
+		(at 64.985000 56.150000 180)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C22"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "b3ad07c6-dcb7-496a-afcf-a171025ce153")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100n"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "b5023181-ae03-46f8-ada3-1c81554ee54a")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "16ac2e2f-8b2c-4adc-bc70-7f6e9eef9bb9")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "324fe184-7998-48f7-be6a-4376ad6c2fa4")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-000060d3615e")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "9bcdeb59-7272-403c-a8b3-356f95a9d0e8")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "7a666a05-72f0-445b-a74d-5e594298ac2a")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "bdd3cadb-9cb1-4556-98c7-911c5ba89f4f")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "35444a90-a9c9-4233-90b6-4f926052e5bf")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "819dd2c8-6037-476f-8cc6-8c707e18f2b1")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "66f47885-cf18-4d3a-8c2b-3ec70464f2a9")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "0787b394-6107-4f93-beb5-cd2a863e99fb")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "dcd2c098-00bb-4345-a3a6-d6ba66d415e1")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "1459ee00-fffc-4660-aa47-51ed7e334ae0")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "3acbc4c2-4b6b-48b2-80be-a70eb7f90c8b")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "2dd7b01d-2442-446a-8446-a95e2665a17c")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec9c5d")
+		(at 44.500000 49.635000 90)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C24"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "696884bd-2566-4cab-a822-4fe32490dfa4")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "30pF"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "d896fad6-c853-436a-8e66-af289bc2977c")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "3587575e-aacf-4c78-b3cb-5c1d8ea3b78b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "0cd62acb-e9a3-4166-9cc8-2c0fd1522dc2")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f135a55")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "706e07ba-848f-459e-a588-c8dc8dcb2375")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "ae0c6a29-41cb-4009-9c18-02ea8e756d8d")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2a21b796-63bc-452b-82fb-39921d7993e2")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "38b1649e-c087-4fba-804b-bfaa0516e1cc")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c31cf128-49c3-4eed-bfb2-52190081e25e")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "8c168811-d8f5-4281-9857-1d2251cfbef3")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c9cfc2d7-3b44-4a09-940a-2698f3e30f84")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "301da222-25ec-44b8-9f6b-38068645a28d")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "84b028eb-5478-462a-b47b-aaefbced8602")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(C24-Pad1)")
+			(uuid "e4545f32-919b-4773-8598-cd53588862ae")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "771f7bd7-be52-463a-915b-f74ec9092a98")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec9cde")
+		(at 50.250000 48.635000 -90)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R24"
+			(at 0 -1.17 90)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "8573d26c-6fae-4ccb-8696-b84a8c890d6a")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "cb97a805-8d1a-4216-a2e2-39a82219d122")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "02f84efa-745e-4b17-ad32-0a6555f3b717")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "d13f89b7-d798-4d70-831b-137e60be1c18")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f0039b1")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "29d51469-f6be-4ce8-9a8a-396a6f48be28")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2da18d97-df70-4591-b342-5feebb9c2c4a")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "28554cd9-86db-4c3e-ba17-907bc0b0b1f0")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2e65a20d-627a-479b-b757-e09ae199798d")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "425c6f1a-94b3-45ac-a810-93c69599ba5d")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "084545a1-2e4e-4a59-80dc-5f38fc61552d")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "cb9052cf-e5d7-4f15-ba48-cf22f73fcbad")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a3bbd06c-ec33-4d5f-b5ef-daab3fcf39a7")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "54f88ffb-6301-4891-a3bc-284aec05617e")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "80eb0eea-60f7-487a-b26b-960263bc926b")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "c4c71006-af78-4b75-adf0-dbbddc7c91b6")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec9d08")
+		(at 46.515000 61.135000 180)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C21"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "559ebfe9-d75c-44b0-9e8b-1f47257c2c5d")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100n"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "c1008227-3869-4974-8c16-546f1df52da2")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "0cd71a18-806c-42d8-90e4-2a7d5c197a93")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b832ffa0-e50b-4a38-8d13-0b258a940cfd")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-000060d35f31")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "6bbed58b-9a24-4042-877c-cc3468d68e9c")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "c117c1cf-f528-4e74-977c-05dec5c5cce7")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "53a3e153-7475-4515-80a9-31386005d486")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "b9635ed5-26e9-4e3a-ba01-81e82a2faa9b")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ced39748-def3-42a7-9dfb-29d6f284a699")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "562670d5-94c6-4df5-a9a8-bf048ee371b1")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "578e118a-1f40-4c33-8328-268931328a60")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "dc3a1fa7-d1c3-49e0-a19e-1a4eeaff24e0")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "bc08af63-374a-449c-ae05-e8bb7a104b03")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "8c85b3e5-86b8-471b-8e05-280d038967b1")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "c4757275-6024-450e-8815-d617e27574bd")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Connector_JST:JST_SH_SM04B-SRSS-TB_1x04-1MP_P1.00mm_Horizontal"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005f2414b3")
+		(at 58.295000 57.825000)
+		(descr "JST SH series connector, SM04B-SRSS-TB (http://www.jst-mfg.com/product/pdf/eng/eSH.pdf), generated with kicad-footprint-generator")
+		(tags "connector JST SH top entry")
+		(property "Reference" "J7"
+			(at 0 -3.98 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "c443edd2-201a-4c73-a280-5cb5bd873dd6")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "I2C"
+			(at -0.045 -4.075 0)
+			(layer "F.SilkS")
+			(uuid "d48ac0c6-3dbf-4b17-a5da-41f94c929be3")
+			(effects
+				(font
+					(size 0.8 0.8)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "a1ce8e62-d8d7-4307-96f9-61e2f565fa40")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "437abbf3-156e-47e9-a90f-b790c0825d3e")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f2990ce")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -3.11 -1.785)
+			(end -2.06 -1.785)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "2d57665e-2d85-4911-9eb9-404ca9e0e1d6")
+		)
+		(fp_line
+			(start -3.11 0.715)
+			(end -3.11 -1.785)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "4cf43057-5f22-47a7-be55-f956404a9b39")
+		)
+		(fp_line
+			(start -2.06 -1.785)
+			(end -2.06 -2.775)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b084ab59-c7ae-4ed4-8707-bfebfdf80164")
+		)
+		(fp_line
+			(start -1.94 2.685)
+			(end 1.94 2.685)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b0a04087-eaaa-469d-b6b5-4838e543f86f")
+		)
+		(fp_line
+			(start 3.11 -1.785)
+			(end 2.06 -1.785)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "e736b274-12e4-4d8a-87ad-e2e71c7fc0e7")
+		)
+		(fp_line
+			(start 3.11 0.715)
+			(end 3.11 -1.785)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "21e295e4-fc6e-419c-92c0-51603fb084b1")
+		)
+		(fp_line
+			(start -3.9 -3.28)
+			(end -3.9 3.28)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "7067b2b9-33dd-4ea2-8b49-87f76e913009")
+		)
+		(fp_line
+			(start -3.9 3.28)
+			(end 3.9 3.28)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2649b79f-8ce7-4947-bb8b-6e495aa065f2")
+		)
+		(fp_line
+			(start 3.9 -3.28)
+			(end -3.9 -3.28)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "8234aad6-29e9-4d43-a68c-a5331a3add65")
+		)
+		(fp_line
+			(start 3.9 3.28)
+			(end 3.9 -3.28)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "da825e75-e31e-4407-acad-92b56cc18bdf")
+		)
+		(fp_line
+			(start -3 -1.675)
+			(end -3 2.575)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c96b6677-974d-4a9d-9cb9-421091613740")
+		)
+		(fp_line
+			(start -3 -1.675)
+			(end 3 -1.675)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e0fecb91-8c65-4f75-9c97-d43dfefa50f0")
+		)
+		(fp_line
+			(start -3 2.575)
+			(end 3 2.575)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "88035087-7c1e-4635-bbfe-d384089e1314")
+		)
+		(fp_line
+			(start -2 -1.675)
+			(end -1.5 -0.967893)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "4ea27b8f-31d4-4688-9a9c-ea3af7cd93ac")
+		)
+		(fp_line
+			(start -1.5 -0.967893)
+			(end -1 -1.675)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "01eb405b-3df7-4e2f-a59d-90cbbeaaba2b")
+		)
+		(fp_line
+			(start 3 -1.675)
+			(end 3 2.575)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "1cbb3321-eed3-4422-a9ac-bdf1424c89ef")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "448778d8-b1a4-4501-b1c2-98845e7a0b66")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -1.5 -2)
+			(size 0.6 1.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "4548f85f-d8d9-47d7-8d99-b25465502f09")
+		)
+		(pad "2" smd roundrect
+			(at -0.5 -2)
+			(size 0.6 1.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VTARGET")
+			(uuid "0b2e1d4b-9ffa-4d7d-91a3-98239455a8e1")
+		)
+		(pad "3" smd roundrect
+			(at 0.5 -2)
+			(size 0.6 1.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/COPI")
+			(uuid "891d718e-d344-4269-9e6d-2820ab2e7242")
+		)
+		(pad "4" smd roundrect
+			(at 1.5 -2)
+			(size 0.6 1.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/CLK")
+			(uuid "36555401-09fd-4bd9-a5a9-9f1b9df8086c")
+		)
+		(pad "MP" smd roundrect
+			(at -2.8 1.875)
+			(size 1.2 1.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.208333)
+			(net "GND")
+			(uuid "fe927404-9f44-4109-80c1-bbaf0cdbd99a")
+		)
+		(pad "MP" smd roundrect
+			(at 2.8 1.875)
+			(size 1.2 1.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.208333)
+			(net "GND")
+			(uuid "8b24b78d-bceb-443a-bec5-13127f44b32e")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Connector_JST.3dshapes/JST_SH_SM04B-SRSS-TB_1x04-1MP_P1.00mm_Horizontal.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "TestPoint:TestPoint_Keystone_5000-5004_Miniature"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005f2414c0")
+		(at 38.890000 33.700000 180)
+		(descr "Keystone Miniature THM Test Point 5000-5004, http://www.keyelco.com/product-pdf.cfm?p=1309")
+		(tags "Through Hole Mount Test Points")
+		(property "Reference" "TP1"
+			(at 0 -2.5 0)
+			(layer "F.Fab")
+			(uuid "db35b83a-6472-44d3-924b-e60f56fc11aa")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 0 2.45 0)
+			(layer "F.SilkS")
+			(uuid "43214cf9-2ef2-4cd7-9608-0d83d2357d0f")
+			(effects
+				(font
+					(size 0.8 0.8)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "bc2c8242-f01f-4668-882c-a779ddca6ba7")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "474d26a8-3ffe-4764-aaca-31fd573a6fe6")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-0000626de3cd")
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_circle
+			(center 0 0)
+			(end 1.4 0)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.SilkS")
+			(uuid "1c669a64-3143-4c27-b3ba-1cdd5a1e81e3")
+		)
+		(fp_circle
+			(center 0 0)
+			(end 1.65 0)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+			(uuid "60b67e17-91a7-4e54-bfa1-e0dd44d75d80")
+		)
+		(fp_line
+			(start 0.75 0.25)
+			(end -0.75 0.25)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c7a5873a-d003-4c88-b936-398afb4c294d")
+		)
+		(fp_line
+			(start 0.75 -0.25)
+			(end 0.75 0.25)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "5b88ac00-f5f1-40f5-8117-26a705b7e96e")
+		)
+		(fp_line
+			(start -0.75 0.25)
+			(end -0.75 -0.25)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c5370078-18e5-43ad-a5b6-25fbd762c305")
+		)
+		(fp_line
+			(start -0.75 -0.25)
+			(end 0.75 -0.25)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "89069555-ea6b-4a68-aeee-6479e0fbf484")
+		)
+		(fp_circle
+			(center 0 0)
+			(end 1.25 0)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.Fab")
+			(uuid "6377b212-0ac8-48ec-8adc-972238d67ea0")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 -2.5 0)
+			(layer "F.Fab")
+			(uuid "bab65854-dbec-443c-8f0b-686919275da2")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "1" thru_hole circle
+			(at 0 0 180)
+			(size 2 2)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "GND")
+			(uuid "671e1d10-fddd-4e35-be5a-169eab2d7c7a")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/TestPoint.3dshapes/TestPoint_Keystone_5000-5004_Miniature.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:PinHeader_1x09_P2.54mm_Vertical"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005f30e631")
+		(at 53.280000 63.940000)
+		(descr "Through hole straight pin header, 1x09, 2.54mm pitch, single row")
+		(tags "Through hole pin header THT 1x09 2.54mm single row")
+		(property "Reference" "J2"
+			(at 0 -2.33 0)
+			(layer "F.Fab")
+			(uuid "6c14b975-8bd4-48d5-b2eb-96428560dbd5")
+			(effects
+				(font
+					(size 0.8 0.8)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "JTAG"
+			(at 0 -2.54 0)
+			(layer "F.SilkS")
+			(uuid "94ddd0ab-09ac-460e-a5fe-5bc24dde3e21")
+			(effects
+				(font
+					(size 0.8 0.8)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "4f716169-475d-47b8-b6e3-99bc6445a338")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "f91b60da-4419-4b53-8bd5-69935970a1d4")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f7118a4")
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -2.54 -2.032)
+			(end -2.032 -2.032)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "90375929-d570-4e33-aca6-e72458258333")
+		)
+		(fp_line
+			(start -2.032 -2.032)
+			(end -2.794 -2.794)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "32f95764-3753-4534-8a9f-2034a26d9463")
+		)
+		(fp_line
+			(start -2.032 -2.032)
+			(end -2.54 -2.032)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d62696d0-7bde-411f-86a1-9d280c70fa90")
+		)
+		(fp_line
+			(start -2.032 -2.032)
+			(end -2.032 -2.54)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "78049808-0cd5-4c6b-a222-e2c97b81e9bc")
+		)
+		(fp_line
+			(start -1.33 -1.33)
+			(end 0 -1.33)
+			(stroke
+				(width 0.5)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "3921ef3e-2508-4658-9be3-c0ea56e62fe8")
+		)
+		(fp_line
+			(start -1.33 0)
+			(end -1.33 -1.33)
+			(stroke
+				(width 0.5)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "c7d86630-22a1-4056-a042-49b5fb340a84")
+		)
+		(fp_line
+			(start -1.33 1.27)
+			(end -1.33 21.65)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "6e7263f0-2776-4c06-a39a-0b4221884d65")
+		)
+		(fp_line
+			(start -1.33 1.27)
+			(end 1.33 1.27)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "cdfd8a8e-d14c-46f7-bd31-286fc5fd0100")
+		)
+		(fp_line
+			(start -1.33 21.65)
+			(end 1.33 21.65)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "a9873d31-e44c-4852-b22b-5097c72db391")
+		)
+		(fp_line
+			(start 1.33 1.27)
+			(end 1.33 21.65)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d9125b1e-d315-4bbd-b43e-c5204037bf05")
+		)
+		(fp_line
+			(start -2.54 -2.032)
+			(end -2.032 -2.032)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "8f1d91f8-25db-4fc5-b889-1976d7cd10c5")
+		)
+		(fp_line
+			(start -2.032 -2.032)
+			(end -2.794 -2.794)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "ea4fe10a-fdd0-499a-897b-e4fdfa17061e")
+		)
+		(fp_line
+			(start -2.032 -2.032)
+			(end -2.032 -2.54)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "365a3dcc-6995-4747-96b9-fbd1ebd30bc6")
+		)
+		(fp_line
+			(start -1.33 -1.33)
+			(end 0 -1.33)
+			(stroke
+				(width 0.5)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "4c5aebed-adac-42d6-af19-d34eef0bf5a4")
+		)
+		(fp_line
+			(start -1.33 0)
+			(end -1.33 -1.33)
+			(stroke
+				(width 0.5)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "a6ae3287-5c89-42bd-8e4d-9f7e6a2fc5bc")
+		)
+		(fp_line
+			(start -1.33 1.27)
+			(end -1.33 21.65)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "7a5b9684-8f4a-4c0a-8140-1e63178a4e44")
+		)
+		(fp_line
+			(start -1.33 1.27)
+			(end 1.33 1.27)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "4bed3966-7257-4d9d-8ae4-9cfe428c321e")
+		)
+		(fp_line
+			(start -1.33 21.65)
+			(end 1.33 21.65)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "605b9143-87f7-461c-bdec-cec5276ddde2")
+		)
+		(fp_line
+			(start 1.33 1.27)
+			(end 1.33 21.65)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "0a4385ef-59ae-4da3-b609-95e8607701c0")
+		)
+		(fp_line
+			(start -1.8 -1.8)
+			(end -1.8 22.1)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "e60f0cdf-5aa5-4f6a-b516-65ba40168d59")
+		)
+		(fp_line
+			(start -1.8 22.1)
+			(end 1.8 22.1)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "0a25cc6b-f51e-4616-9e5c-6da84d66ab49")
+		)
+		(fp_line
+			(start 1.8 -1.8)
+			(end -1.8 -1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "3c8347a5-3c80-42be-b7e0-2578d8b38a54")
+		)
+		(fp_line
+			(start 1.8 22.1)
+			(end 1.8 -1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "6895c90a-05cc-4e27-8736-072c7af5d399")
+		)
+		(fp_line
+			(start -1.27 -0.635)
+			(end -0.635 -1.27)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "cfd5452f-7497-4478-9979-eb1b22c7b0f3")
+		)
+		(fp_line
+			(start -1.27 21.59)
+			(end -1.27 -0.635)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "11252531-44ca-449c-934a-14b2fc83c363")
+		)
+		(fp_line
+			(start -0.635 -1.27)
+			(end 1.27 -1.27)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "44c0aa05-4969-4f42-a2b9-96c6dc08ae10")
+		)
+		(fp_line
+			(start 1.27 -1.27)
+			(end 1.27 21.59)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a3e74b57-b27f-498f-a58a-bcd9c4572d4f")
+		)
+		(fp_line
+			(start 1.27 21.59)
+			(end -1.27 21.59)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ae5c0f9b-14e9-4272-89db-adcb1a99ed44")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 10.16 90)
+			(layer "F.Fab")
+			(uuid "66dad8fa-4603-435a-8066-036bc05fa68c")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "1" thru_hole roundrect
+			(at 0 0)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(roundrect_rratio 0.25)
+			(net "VTARGET")
+			(uuid "59f31724-8a95-43a9-a5ac-6a835722d7ac")
+		)
+		(pad "2" thru_hole oval
+			(at 0 2.54)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "GND")
+			(uuid "350de13f-cbf2-4680-9560-c7ac780056c4")
+		)
+		(pad "3" thru_hole oval
+			(at 0 5.08)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/CLK")
+			(uuid "8ef546f8-6f3f-4e32-a783-504edfb18bcc")
+		)
+		(pad "4" thru_hole oval
+			(at 0 7.62)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/COPI")
+			(uuid "486ff49c-ed74-4853-8a7a-acce46384d65")
+		)
+		(pad "5" thru_hole oval
+			(at 0 10.16)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/CIPO")
+			(uuid "5ee1273c-9226-403f-885c-7121ba1eba24")
+		)
+		(pad "6" thru_hole oval
+			(at 0 12.7)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/CS")
+			(uuid "7c84fa3b-fbd6-4ef9-a2ba-087cd3d2ca9c")
+		)
+		(pad "7" thru_hole oval
+			(at 0 15.24)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/xPB4")
+			(uuid "799318b4-aaf7-4381-b99b-6f9d50cfe922")
+		)
+		(pad "8" thru_hole oval
+			(at 0 17.78)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/xPB5")
+			(uuid "6fbca3c9-77d3-43e5-8959-963f020aca78")
+		)
+		(pad "9" thru_hole oval
+			(at 0 20.32)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/ICE_CDONE")
+			(uuid "1390b3e4-8cf7-47a8-8078-498f42aefbe5")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_1x08_P2.54mm_Vertical.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005f30e668")
+		(at 42.000000 64.650000 270)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R22"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "c725f2de-fa04-4cd6-a6e0-2e763e29cd79")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "2k2"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "31a70917-e1f6-4a0e-9a9f-9d34d54106f1")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "c1dedcf0-b89a-4cc3-9c65-2f6aae6ddf0b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "6c1ff927-7103-46de-ac0b-3a4901355546")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f59250b")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "a54f5538-6369-47f4-a144-6376e9da27c7")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "3a5b2c97-40b5-4435-b526-4babb980e8d1")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "bbf1d4a2-64a7-46ce-81d5-f0eb2721609a")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "08d88cc9-f484-451c-ad2d-39ea8362f6b4")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9a70307f-d8f0-4af0-85e9-e73ba8c75003")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "3bd79036-88f0-4e8c-bbf5-85b401a9fe19")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "74164198-c170-44d0-bbe6-ed3805c2a9b6")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "7bf1b5c1-7a34-4f8f-a0c9-4215b82624ae")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "aa07b122-ffe8-4036-bacf-bf567878ba4c")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD5")
+			(uuid "b877b197-a204-4835-80d6-4d11aa1eab5d")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD7")
+			(uuid "e570d3ea-d2d8-4b1f-b127-83d7ddc4dc2f")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:Tigard_Logo"
+		(locked yes)
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005f37d5ad")
+		(at 43.84 38.9832)
+		(property "Reference" "G***"
+			(at 0 0 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "96f5c3e9-0651-4dcc-b8dc-44468f6d47ad")
+			(effects
+				(font
+					(size 1.524 1.524)
+					(thickness 0.3)
+				)
+			)
+		)
+		(property "Value" "LOGO"
+			(at 0.75 0 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "fac37eb9-027a-4177-922a-e9b9f6658014")
+			(effects
+				(font
+					(size 1.524 1.524)
+					(thickness 0.3)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "476cf4e7-c9f7-4926-a4ce-038806396921")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "dd45a066-474b-4cfb-bf1b-31510475dc6e")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_poly
+			(pts
+				(xy -2.647757 -1.27) (xy -3.271212 -1.27) (xy -3.271212 -1.762606) (xy -2.647757 -1.762606) (xy -2.647757 -1.27)
+			)
+			(stroke
+				(width 0.01)
+				(type solid)
+			)
+			(fill yes)
+			(layer "F.SilkS")
+			(uuid "c91577f7-3f0e-47d0-9646-de1988023881")
+		)
+		(fp_poly
+			(pts
+				(xy -2.647757 1.046788) (xy -3.271212 1.046788) (xy -3.271212 -1.046788) (xy -2.647757 -1.046788)
+				(xy -2.647757 1.046788)
+			)
+			(stroke
+				(width 0.01)
+				(type solid)
+			)
+			(fill yes)
+			(layer "F.SilkS")
+			(uuid "2d50bb30-cc35-47fe-9dfc-5b5837339827")
+		)
+		(fp_poly
+			(pts
+				(xy -3.47903 -1.270119) (xy -3.946621 -1.268135) (xy -4.414212 -1.266152) (xy -4.41811 1.046788)
+				(xy -5.133878 1.046788) (xy -5.133878 -1.27) (xy -6.072909 -1.27) (xy -6.072909 -1.893455) (xy -3.47903 -1.893455)
+				(xy -3.47903 -1.270119)
+			)
+			(stroke
+				(width 0.01)
+				(type solid)
+			)
+			(fill yes)
+			(layer "F.SilkS")
+			(uuid "e0b0d42b-78f8-429f-a429-722ede808049")
+		)
+		(fp_poly
+			(pts
+				(xy 2.849803 -1.054346) (xy 3.375122 -1.054208) (xy 3.452091 -1.035709) (xy 3.505195 -1.022047)
+				(xy 3.548265 -1.008492) (xy 3.586514 -0.993029) (xy 3.625154 -0.973644) (xy 3.652455 -0.958273)
+				(xy 3.691468 -0.93174) (xy 3.734955 -0.895773) (xy 3.779408 -0.853876) (xy 3.821322 -0.80955) (xy 3.857189 -0.766299)
+				(xy 3.883502 -0.727625) (xy 3.883653 -0.727364) (xy 3.907716 -0.683277) (xy 3.926671 -0.642187)
+				(xy 3.941189 -0.601179) (xy 3.951939 -0.557337) (xy 3.959592 -0.507747) (xy 3.964819 -0.449494)
+				(xy 3.96829 -0.379663) (xy 3.969091 -0.355985) (xy 3.973938 -0.200121) (xy 3.340485 -0.200121) (xy 3.340485 -0.290675)
+				(xy 3.340092 -0.331761) (xy 3.338591 -0.361109) (xy 3.335494 -0.382362) (xy 3.330316 -0.399164)
+				(xy 3.324321 -0.411902) (xy 3.29172 -0.458941) (xy 3.248163 -0.496118) (xy 3.218051 -0.513367) (xy 3.20033 -0.521776)
+				(xy 3.184552 -0.527637) (xy 3.167398 -0.531413) (xy 3.145548 -0.533563) (xy 3.115685 -0.53455) (xy 3.074489 -0.534833)
+				(xy 3.063394 -0.534847) (xy 2.951788 -0.534939) (xy 2.94794 0.254) (xy 2.944091 1.042939) (xy 2.634288 1.044951)
+				(xy 2.324485 1.046962) (xy 2.324485 -1.054485) (xy 2.849803 -1.054346)
+			)
+			(stroke
+				(width 0.01)
+				(type solid)
+			)
+			(fill yes)
+			(layer "F.SilkS")
+			(uuid "97b3a76c-0d90-4da1-bd85-889f511d07b0")
+		)
+		(fp_poly
+			(pts
+				(xy 6.119091 1.039091) (xy 5.747712 1.039114) (xy 5.66792 1.039191) (xy 5.588221 1.039403) (xy 5.510884 1.039733)
+				(xy 5.438175 1.040167) (xy 5.372362 1.040689) (xy 5.315711 1.041285) (xy 5.270491 1.04194) (xy 5.245485 1.042459)
+				(xy 5.195943 1.043207) (xy 5.145963 1.043071) (xy 5.100046 1.042123) (xy 5.062694 1.040434) (xy 5.048283 1.039301)
+				(xy 4.916633 1.020288) (xy 4.795181 0.990025) (xy 4.684074 0.948626) (xy 4.583459 0.896204) (xy 4.493482 0.832873)
+				(xy 4.414291 0.758745) (xy 4.346032 0.673933) (xy 4.288851 0.578552) (xy 4.242897 0.472713) (xy 4.219642 0.400242)
+				(xy 4.201197 0.323932) (xy 4.185597 0.238387) (xy 4.173674 0.149634) (xy 4.16626 0.0637) (xy 4.164329 0.004073)
+				(xy 4.819797 0.004073) (xy 4.821361 0.034547) (xy 4.825157 0.07128) (xy 4.828392 0.097665) (xy 4.845452 0.192098)
+				(xy 4.871465 0.274296) (xy 4.906692 0.34473) (xy 4.951398 0.403873) (xy 5.005845 0.452197) (xy 5.037577 0.472904)
+				(xy 5.065818 0.488262) (xy 5.093419 0.500154) (xy 5.122922 0.509009) (xy 5.156871 0.51526) (xy 5.19781 0.519337)
+				(xy 5.248281 0.52167) (xy 5.310828 0.522691) (xy 5.332129 0.522806) (xy 5.495743 0.523394) (xy 5.493765 -0.005773)
+				(xy 5.491788 -0.534939) (xy 5.337849 -0.53347) (xy 5.283248 -0.532778) (xy 5.241079 -0.531701) (xy 5.208383 -0.529965)
+				(xy 5.182197 -0.5273) (xy 5.159562 -0.523431) (xy 5.137516 -0.518087) (xy 5.121709 -0.513577) (xy 5.051028 -0.48605)
+				(xy 4.990381 -0.448075) (xy 4.939449 -0.399207) (xy 4.897914 -0.339002) (xy 4.865457 -0.267013)
+				(xy 4.84176 -0.182797) (xy 4.828544 -0.103517) (xy 4.823385 -0.059587) (xy 4.820471 -0.025514) (xy 4.819797 0.004073)
+				(xy 4.164329 0.004073) (xy 4.164124 -0.002228) (xy 4.165973 -0.060026) (xy 4.171343 -0.128346) (xy 4.179811 -0.202831)
+				(xy 4.190949 -0.279123) (xy 4.191419 -0.281993) (xy 4.218218 -0.404317) (xy 4.256726 -0.516678)
+				(xy 4.30678 -0.618914) (xy 4.368215 -0.710859) (xy 4.440868 -0.79235) (xy 4.524573 -0.863222) (xy 4.619168 -0.92331)
+				(xy 4.724487 -0.972451) (xy 4.840368 -1.01048) (xy 4.941455 -1.032952) (xy 4.971304 -1.037865) (xy 5.001886 -1.041815)
+				(xy 5.035572 -1.044945) (xy 5.074735 -1.047399) (xy 5.12175 -1.04932) (xy 5.178988 -1.050851) (xy 5.248823 -1.052135)
+				(xy 5.262803 -1.05235) (xy 5.495637 -1.055837) (xy 5.495637 -1.893455) (xy 6.119091 -1.893455) (xy 6.119091 1.039091)
+			)
+			(stroke
+				(width 0.01)
+				(type solid)
+			)
+			(fill yes)
+			(layer "F.SilkS")
+			(uuid "b26dfb72-1a1c-42e0-9c9f-06b8b30437df")
+		)
+		(fp_poly
+			(pts
+				(xy 1.147365 -1.05009) (xy 1.191261 -1.049782) (xy 1.227486 -1.049185) (xy 1.257328 -1.04827) (xy 1.282073 -1.047009)
+				(xy 1.303009 -1.045372) (xy 1.321422 -1.04333) (xy 1.338601 -1.040853) (xy 1.355831 -1.037913) (xy 1.373909 -1.034572)
+				(xy 1.459288 -1.015914) (xy 1.532699 -0.993658) (xy 1.597419 -0.966363) (xy 1.656722 -0.93259) (xy 1.713883 -0.890896)
+				(xy 1.728991 -0.878419) (xy 1.789811 -0.818535) (xy 1.844881 -0.747728) (xy 1.89147 -0.670168) (xy 1.926849 -0.590027)
+				(xy 1.936156 -0.561879) (xy 1.941653 -0.543091) (xy 1.946519 -0.524879) (xy 1.950792 -0.506225)
+				(xy 1.954512 -0.486113) (xy 1.957717 -0.463523) (xy 1.960446 -0.437439) (xy 1.962738 -0.406843)
+				(xy 1.964632 -0.370716) (xy 1.966167 -0.328042) (xy 1.967381 -0.277802) (xy 1.968313 -0.21898) (xy 1.969003 -0.150556)
+				(xy 1.969488 -0.071514) (xy 1.969808 0.019165) (xy 1.970002 0.122497) (xy 1.970109 0.239501) (xy 1.970152 0.329045)
+				(xy 1.970425 1.046788) (xy 1.325803 1.04585) (xy 1.201778 1.045609) (xy 1.092314 1.045263) (xy 0.996579 1.044797)
+				(xy 0.913741 1.044199) (xy 0.842968 1.043457) (xy 0.783426 1.042556) (xy 0.734285 1.041485) (xy 0.694712 1.04023)
+				(xy 0.663874 1.038779) (xy 0.640939 1.037118) (xy 0.625076 1.035235) (xy 0.623455 1.034968) (xy 0.537733 1.017121)
+				(xy 0.464358 0.994675) (xy 0.400636 0.966317) (xy 0.343875 0.930734) (xy 0.291382 0.886614) (xy 0.265462 0.860483)
+				(xy 0.211157 0.792056) (xy 0.166718 0.713545) (xy 0.133638 0.627788) (xy 0.123731 0.591303) (xy 0.113749 0.534118)
+				(xy 0.108064 0.467407) (xy 0.106664 0.397263) (xy 0.727974 0.397263) (xy 0.733539 0.447444) (xy 0.74959 0.486793)
+				(xy 0.776888 0.516411) (xy 0.816192 0.537399) (xy 0.827425 0.541252) (xy 0.849757 0.548046) (xy 0.869168 0.553028)
+				(xy 0.888503 0.556408) (xy 0.910609 0.558399) (xy 0.938332 0.559212) (xy 0.974519 0.559061) (xy 1.022015 0.558155)
+				(xy 1.046788 0.557583) (xy 1.099141 0.556455) (xy 1.152786 0.555486) (xy 1.20319 0.554745) (xy 1.245822 0.554301)
+				(xy 1.268076 0.554204) (xy 1.34697 0.554182) (xy 1.34697 0.221571) (xy 1.102591 0.227185) (xy 1.032797 0.228884)
+				(xy 0.976569 0.230522) (xy 0.932081 0.232229) (xy 0.897506 0.234134) (xy 0.871018 0.236368) (xy 0.850791 0.239059)
+				(xy 0.834998 0.242338) (xy 0.821812 0.246335) (xy 0.819071 0.247326) (xy 0.779371 0.267967) (xy 0.7515 0.296696)
+				(xy 0.734674 0.334804) (xy 0.728108 0.383584) (xy 0.727974 0.397263) (xy 0.106664 0.397263) (xy 0.106641 0.396152)
+				(xy 0.109451 0.325332) (xy 0.116459 0.259928) (xy 0.126197 0.210331) (xy 0.157248 0.116585) (xy 0.199499 0.033356)
+				(xy 0.25283 -0.039226) (xy 0.31712 -0.101034) (xy 0.392247 -0.151937) (xy 0.478092 -0.191809) (xy 0.516393 -0.204949)
+				(xy 0.533307 -0.210088) (xy 0.54898 -0.214311) (xy 0.565168 -0.217746) (xy 0.583629 -0.220521) (xy 0.606121 -0.222764)
+				(xy 0.6344 -0.224603) (xy 0.670225 -0.226166) (xy 0.715352 -0.227582) (xy 0.771539 -0.228978) (xy 0.840543 -0.230482)
+				(xy 0.877455 -0.231253) (xy 0.947821 -0.232683) (xy 1.017015 -0.234028) (xy 1.082656 -0.235246)
+				(xy 1.142361 -0.236295) (xy 1.193748 -0.237134) (xy 1.234436 -0.237721) (xy 1.261413 -0.238009)
+				(xy 1.349038 -0.238606) (xy 1.345122 -0.290561) (xy 1.333677 -0.360757) (xy 1.310621 -0.420896)
+				(xy 1.275847 -0.471151) (xy 1.22925 -0.511693) (xy 1.196237 -0.531091) (xy 1.143 -0.55803) (xy 0.6985 -0.56025)
+				(xy 0.254 -0.562469) (xy 0.254 -1.044769) (xy 0.767773 -1.048331) (xy 0.86933 -1.049026) (xy 0.956781 -1.049579)
+				(xy 1.031412 -1.04996) (xy 1.094511 -1.05014) (xy 1.147365 -1.05009)
+			)
+			(stroke
+				(width 0.01)
+				(type solid)
+			)
+			(fill yes)
+			(layer "F.SilkS")
+			(uuid "18ea6528-5bd4-45a4-b13a-bdc51702ccc4")
+		)
+		(fp_poly
+			(pts
+				(xy -0.153939 0.060088) (xy -0.153959 0.216643) (xy -0.154023 0.358555) (xy -0.154138 0.486572)
+				(xy -0.154311 0.601445) (xy -0.15455 0.703922) (xy -0.154862 0.794755) (xy -0.155253 0.874692) (xy -0.155731 0.944483)
+				(xy -0.156304 1.004879) (xy -0.156977 1.056628) (xy -0.157758 1.10048) (xy -0.158655 1.137186) (xy -0.159674 1.167495)
+				(xy -0.160823 1.192157) (xy -0.162108 1.211921) (xy -0.163537 1.227538) (xy -0.165118 1.239757)
+				(xy -0.165137 1.239883) (xy -0.189044 1.351721) (xy -0.224657 1.454268) (xy -0.271761 1.54714) (xy -0.330145 1.629953)
+				(xy -0.399595 1.702326) (xy -0.441214 1.73662) (xy -0.492717 1.770536) (xy -0.554953 1.80322) (xy -0.62329 1.832512)
+				(xy -0.693093 1.856252) (xy -0.705084 1.859666) (xy -0.781242 1.880679) (xy -1.935788 1.886166)
+				(xy -2.093593 1.88687) (xy -2.264384 1.88755) (xy -2.445755 1.8882) (xy -2.635297 1.888814) (xy -2.830604 1.889385)
+				(xy -3.029267 1.889909) (xy -3.22888 1.890379) (xy -3.427035 1.89079) (xy -3.621325 1.891136) (xy -3.809341 1.891411)
+				(xy -3.988678 1.891609) (xy -4.156926 1.891724) (xy -4.260272 1.891753) (xy -4.418034 1.891757)
+				(xy -4.561168 1.891737) (xy -4.690442 1.891683) (xy -4.806623 1.891588) (xy -4.910477 1.891443)
+				(xy -5.002771 1.89124) (xy -5.084273 1.89097) (xy -5.155748 1.890626) (xy -5.217965 1.890198) (xy -5.271689 1.889679)
+				(xy -5.317688 1.88906) (xy -5.356728 1.888333) (xy -5.389577 1.88749) (xy -5.417 1.886522) (xy -5.439766 1.885422)
+				(xy -5.45864 1.88418) (xy -5.47439 1.882788) (xy -5.487783 1.881239) (xy -5.499585 1.879523) (xy -5.507182 1.878241)
+				(xy -5.57071 1.865865) (xy -5.623481 1.852712) (xy -5.670122 1.837368) (xy -5.715256 1.818421) (xy -5.7369 1.808049)
+				(xy -5.82192 1.757533) (xy -5.8505 1.733977) (xy -5.570313 1.733977) (xy -5.562407 1.739348) (xy -5.55225 1.742669)
+				(xy -5.53776 1.743277) (xy -5.523153 1.734615) (xy -5.506268 1.714899) (xy -5.491012 1.692104) (xy -5.474245 1.670233)
+				(xy -5.461614 1.662561) (xy -5.454195 1.668203) (xy -5.453065 1.68627) (xy -5.459299 1.715878) (xy -5.45986 1.717767)
+				(xy -5.470578 1.753378) (xy -5.449646 1.757565) (xy -5.431679 1.760323) (xy -5.404115 1.763639)
+				(xy -5.372699 1.766825) (xy -5.370523 1.767024) (xy -5.312331 1.772297) (xy -5.267043 1.737449)
+				(xy -5.221974 1.699026) (xy -5.181914 1.656013) (xy -5.14215 1.603347) (xy -5.141963 1.603078) (xy -5.123143 1.578978)
+				(xy -5.103471 1.558505) (xy -5.085567 1.543827) (xy -5.07205 1.537115) (xy -5.065709 1.539933) (xy -5.067166 1.551924)
+				(xy -5.074377 1.574194) (xy -5.085849 1.603438) (xy -5.100091 1.636352) (xy -5.115612 1.669633)
+				(xy -5.130919 1.699976) (xy -5.144522 1.724077) (xy -5.154927 1.738632) (xy -5.155819 1.739515)
+				(xy -5.178497 1.761302) (xy -5.18921 1.774882) (xy -5.187578 1.782188) (xy -5.173223 1.785149) (xy -5.146736 1.785697)
+				(xy -5.096133 1.785697) (xy -5.091627 1.779054) (xy -5.010727 1.779054) (xy -5.00359 1.781913) (xy -4.98441 1.784155)
+				(xy -4.956537 1.785475) (xy -4.937877 1.785697) (xy -4.903684 1.78543) (xy -4.881612 1.784168) (xy -4.868391 1.781221)
+				(xy -4.860752 1.775899) (xy -4.855878 1.768379) (xy -4.843927 1.748804) (xy -4.827695 1.726048)
+				(xy -4.809786 1.703273) (xy -4.792801 1.683641) (xy -4.779346 1.670315) (xy -4.772022 1.666456)
+				(xy -4.771991 1.666474) (xy -4.7702 1.67555) (xy -4.773621 1.693501) (xy -4.776381 1.702198) (xy -4.784605 1.732303)
+				(xy -4.787456 1.758483) (xy -4.784958 1.777368) (xy -4.777135 1.785587) (xy -4.775797 1.785697)
+				(xy -4.763994 1.780793) (xy -4.745882 1.768149) (xy -4.73154 1.756002) (xy -4.700764 1.730324) (xy -4.6755 1.714127)
+				(xy -4.658302 1.708727) (xy -4.654942 1.715596) (xy -4.654068 1.733171) (xy -4.654927 1.747212)
+				(xy -4.658625 1.785697) (xy -4.480877 1.785697) (xy -4.486722 1.76453) (xy -4.441157 1.76453) (xy -4.441151 1.785697)
+				(xy -4.326446 1.785697) (xy -4.331002 1.721133) (xy -4.33268 1.683574) (xy -4.331115 1.655297) (xy -4.325759 1.63043)
+				(xy -4.321246 1.616769) (xy -4.309117 1.588281) (xy -4.297217 1.569517) (xy -4.287036 1.562522)
+				(xy -4.282945 1.564186) (xy -4.279627 1.572849) (xy -4.273727 1.593189) (xy -4.266168 1.621888)
+				(xy -4.260101 1.646341) (xy -4.250513 1.682657) (xy -4.240187 1.71648) (xy -4.230667 1.742969) (xy -4.226037 1.753225)
+				(xy -4.210922 1.781848) (xy -4.209815 1.754909) (xy -4.206598 1.724185) (xy -4.200375 1.700934)
+				(xy -4.192191 1.688817) (xy -4.190787 1.688162) (xy -4.183904 1.693268) (xy -4.172647 1.70902) (xy -4.159289 1.732179)
+				(xy -4.157448 1.735698) (xy -4.131593 1.785697) (xy -3.965811 1.785697) (xy -3.863878 1.785697)
+				(xy -3.778181 1.785697) (xy -3.805349 1.752543) (xy -3.824579 1.726058) (xy -3.842066 1.697082)
+				(xy -3.848028 1.685194) (xy -3.86354 1.651) (xy -3.863709 1.718348) (xy -3.863878 1.785697) (xy -3.965811 1.785697)
+				(xy -3.952625 1.733742) (xy -3.946782 1.705626) (xy -3.941735 1.671995) (xy -3.937713 1.636054)
+				(xy -3.934942 1.60101) (xy -3.933651 1.570068) (xy -3.934069 1.546436) (xy -3.936422 1.533318) (xy -3.938258 1.531697)
+				(xy -3.949595 1.535941) (xy -3.960544 1.542998) (xy -3.975789 1.552643) (xy -3.984432 1.550743)
+				(xy -3.989818 1.535656) (xy -3.991386 1.527848) (xy -3.99575 1.504582) (xy -3.856182 1.504582) (xy -3.853668 1.513113)
+				(xy -3.84708 1.531935) (xy -3.837906 1.556809) (xy -3.819894 1.601269) (xy -3.801629 1.640327) (xy -3.784584 1.671132)
+				(xy -3.770233 1.690832) (xy -3.767095 1.693808) (xy -3.755601 1.705699) (xy -3.739096 1.725514)
+				(xy -3.723918 1.745279) (xy -3.69406 1.785697) (xy -3.59809 1.785697) (xy -3.561692 1.785395) (xy -3.531632 1.784572)
+				(xy -3.510829 1.783349) (xy -3.502202 1.781849) (xy -3.502121 1.781683) (xy -3.505992 1.773395)
+				(xy -3.515755 1.757176) (xy -3.521064 1.748971) (xy -3.540763 1.713617) (xy -3.554437 1.67473) (xy -3.563408 1.62785)
+				(xy -3.567135 1.593412) (xy -3.571024 1.554386) (xy -3.575781 1.528196) (xy -3.58301 1.5123) (xy -3.594316 1.504157)
+				(xy -3.611303 1.501224) (xy -3.625543 1.500909) (xy -3.647054 1.501679) (xy -3.659268 1.505891)
+				(xy -3.663377 1.516395) (xy -3.660576 1.536043) (xy -3.652632 1.565657) (xy -3.639291 1.61386) (xy -3.629244 1.652778)
+				(xy -3.622858 1.68086) (xy -3.620502 1.696555) (xy -3.620928 1.699252) (xy -3.629968 1.698542) (xy -3.64643 1.690194)
+				(xy -3.666113 1.676662) (xy -3.680851 1.664228) (xy -3.696622 1.642878) (xy -3.712692 1.608897)
+				(xy -3.722288 1.582426) (xy -3.732566 1.552717) (xy -3.741984 1.528148) (xy -3.748936 1.512828)
+				(xy -3.750394 1.51053) (xy -3.760115 1.506495) (xy -3.779258 1.503264) (xy -3.803108 1.501101) (xy -3.826953 1.500272)
+				(xy -3.846082 1.501042) (xy -3.85578 1.503675) (xy -3.856182 1.504582) (xy -3.99575 1.504582) (xy -3.99644 1.500909)
+				(xy -4.045614 1.500909) (xy -4.070846 1.501876) (xy -4.088586 1.504401) (xy -4.094788 1.507684)
+				(xy -4.09245 1.518838) (xy -4.086181 1.541048) (xy -4.077098 1.570832) (xy -4.066319 1.604703) (xy -4.054962 1.639177)
+				(xy -4.044143 1.670768) (xy -4.03498 1.695992) (xy -4.031881 1.703881) (xy -4.024391 1.726095) (xy -4.021705 1.74255)
+				(xy -4.022978 1.74775) (xy -4.034979 1.749971) (xy -4.052795 1.742614) (xy -4.072679 1.728162) (xy -4.090884 1.709102)
+				(xy -4.09893 1.697375) (xy -4.112761 1.670495) (xy -4.126563 1.638617) (xy -4.132217 1.623453) (xy -4.147593 1.579724)
+				(xy -4.159395 1.548593) (xy -4.168713 1.527988) (xy -4.176639 1.515837) (xy -4.184262 1.510067)
+				(xy -4.19266 1.508606) (xy -4.204618 1.510958) (xy -4.209498 1.52095) (xy -4.210242 1.535545) (xy -4.211976 1.553354)
+				(xy -4.216238 1.562253) (xy -4.217142 1.562485) (xy -4.225923 1.55716) (xy -4.240229 1.54368) (xy -4.247694 1.535545)
+				(xy -4.262213 1.520408) (xy -4.27551 1.512343) (xy -4.293321 1.509145) (xy -4.317765 1.508606) (xy -4.346773 1.509934)
+				(xy -4.361636 1.514059) (xy -4.364201 1.518227) (xy -4.367965 1.529467) (xy -4.377754 1.549183)
+				(xy -4.389724 1.570182) (xy -4.404953 1.602147) (xy -4.419223 1.643752) (xy -4.431016 1.689251)
+				(xy -4.438811 1.7329) (xy -4.441157 1.76453) (xy -4.486722 1.76453) (xy -4.488848 1.756833) (xy -4.494264 1.71608)
+				(xy -4.49145 1.666988) (xy -4.48093 1.613879) (xy -4.465969 1.567908) (xy -4.442527 1.507907) (xy -4.489879 1.510181)
+				(xy -4.537232 1.512455) (xy -4.56937 1.561635) (xy -4.585603 1.585843) (xy -4.599084 1.6048) (xy -4.60726 1.614938)
+				(xy -4.607921 1.615514) (xy -4.615115 1.624807) (xy -4.625567 1.642566) (xy -4.629727 1.65048) (xy -4.644256 1.674199)
+				(xy -4.656391 1.682971) (xy -4.666629 1.676969) (xy -4.672493 1.665257) (xy -4.677087 1.63758) (xy -4.674642 1.602583)
+				(xy -4.66595 1.566196) (xy -4.655984 1.541904) (xy -4.646906 1.523621) (xy -4.641731 1.512277) (xy -4.641272 1.510827)
+				(xy -4.648433 1.509907) (xy -4.667768 1.509179) (xy -4.69606 1.50873) (xy -4.720166 1.508631) (xy -4.79906 1.508656)
+				(xy -4.821244 1.562747) (xy -4.83116 1.585306) (xy -4.841732 1.604405) (xy -4.855248 1.622894) (xy -4.873998 1.643628)
+				(xy -4.900271 1.669459) (xy -4.927077 1.694624) (xy -4.956454 1.722368) (xy -4.981319 1.746661)
+				(xy -4.999688 1.765501) (xy -5.009574 1.776883) (xy -5.010727 1.779054) (xy -5.091627 1.779054)
+				(xy -5.07133 1.749136) (xy -5.053879 1.724245) (xy -5.036677 1.701013) (xy -5.02883 1.691059) (xy -5.014999 1.669616)
+				(xy -5.004672 1.641822) (xy -4.999809 1.618318) (xy -4.94493 1.618318) (xy -4.942033 1.62026) (xy -4.934834 1.61694)
+				(xy -4.923841 1.606697) (xy -4.908705 1.58716) (xy -4.892682 1.562535) (xy -4.892508 1.562242) (xy -4.878722 1.538671)
+				(xy -4.868719 1.520749) (xy -4.864511 1.512089) (xy -4.864485 1.511903) (xy -4.871261 1.509722)
+				(xy -4.887921 1.508634) (xy -4.891424 1.508606) (xy -4.909657 1.510059) (xy -4.917118 1.516533)
+				(xy -4.918363 1.527564) (xy -4.921162 1.545532) (xy -4.92831 1.570524) (xy -4.93375 1.585558) (xy -4.942202 1.607676)
+				(xy -4.94493 1.618318) (xy -4.999809 1.618318) (xy -4.996963 1.604569) (xy -4.991523 1.560333) (xy -4.986362 1.50815)
+				(xy -5.088441 1.510302) (xy -5.19052 1.512455) (xy -5.196492 1.534824) (xy -5.204456 1.55176) (xy -5.21849 1.571874)
+				(xy -5.23495 1.590885) (xy -5.250194 1.604512) (xy -5.259321 1.608667) (xy -5.262199 1.601595) (xy -5.262751 1.582558)
+				(xy -5.260882 1.55482) (xy -5.260878 1.554788) (xy -5.25836 1.526664) (xy -5.258292 1.510523) (xy -5.261295 1.503062)
+				(xy -5.267991 1.500979) (xy -5.271013 1.500909) (xy -5.277821 1.500099) (xy -3.493607 1.500099)
+				(xy -3.489665 1.583246) (xy -3.485795 1.641838) (xy -3.480104 1.687627) (xy -3.472107 1.72315) (xy -3.46132 1.75094)
+				(xy -3.455591 1.761328) (xy -3.440771 1.785697) (xy -3.217333 1.785697) (xy -2.734217 1.785697)
+				(xy -2.663151 1.785697) (xy -2.663151 1.748626) (xy -2.667675 1.687707) (xy -2.68052 1.630838) (xy -2.700598 1.581751)
+				(xy -2.720847 1.550939) (xy -2.728625 1.542586) (xy -2.729221 1.544311) (xy -2.726545 1.557692)
+				(xy -2.7248 1.582657) (xy -2.724 1.61542) (xy -2.724161 1.652198) (xy -2.725296 1.689208) (xy -2.72742 1.722665)
+				(xy -2.728498 1.733742) (xy -2.734217 1.785697) (xy -3.217333 1.785697) (xy -3.217333 1.751061)
+				(xy -3.215812 1.726924) (xy -3.210999 1.717586) (xy -3.202522 1.722727) (xy -3.19556 1.732568) (xy -3.186269 1.744756)
+				(xy -3.182593 1.743528) (xy -3.18479 1.729902) (xy -3.190403 1.712281) (xy -3.19861 1.67559) (xy -3.201227 1.631994)
+				(xy -3.198089 1.588992) (xy -3.19359 1.567361) (xy -3.189314 1.543122) (xy -3.189431 1.523301) (xy -3.154252 1.523301)
+				(xy -3.150459 1.547928) (xy -3.145156 1.575647) (xy -3.125864 1.637009) (xy -3.091545 1.697147)
+				(xy -3.044981 1.753312) (xy -3.026427 1.771783) (xy -3.012169 1.781393) (xy -2.996149 1.784674)
+				(xy -2.972309 1.784155) (xy -2.97127 1.784099) (xy -2.929175 1.781848) (xy -2.907961 1.739515) (xy -2.896338 1.712011)
+				(xy -2.883985 1.675892) (xy -2.873065 1.637663) (xy -2.870213 1.625985) (xy -2.862502 1.595328)
+				(xy -2.855333 1.571294) (xy -2.849744 1.557159) (xy -2.847653 1.554788) (xy -2.840194 1.561872)
+				(xy -2.832531 1.58075) (xy -2.825516 1.607855) (xy -2.820005 1.639622) (xy -2.816852 1.672488) (xy -2.816442 1.685083)
+				(xy -2.815794 1.743364) (xy -2.800204 1.709385) (xy -2.793391 1.692821) (xy -2.789271 1.676605)
+				(xy -2.787523 1.656891) (xy -2.787825 1.629828) (xy -2.789855 1.59157) (xy -2.790067 1.588157) (xy -2.795518 1.500909)
+				(xy -2.679593 1.500909) (xy -2.661995 1.525924) (xy -2.648427 1.54401) (xy -2.628722 1.568846) (xy -2.606791 1.59552)
+				(xy -2.603392 1.599564) (xy -2.581235 1.627759) (xy -2.560926 1.656907) (xy -2.5465 1.681174) (xy -2.54542 1.683348)
+				(xy -2.528454 1.718507) (xy -2.525945 1.693069) (xy -2.526307 1.669408) (xy -2.530253 1.6411) (xy -2.532184 1.632376)
+				(xy -2.5474 1.592144) (xy -2.572489 1.549465) (xy -2.596758 1.518227) (xy -2.611844 1.506704) (xy -2.529508 1.506704)
+				(xy -2.526423 1.509896) (xy -2.52471 1.510819) (xy -2.509066 1.524745) (xy -2.491544 1.549647) (xy -2.474029 1.581574)
+				(xy -2.45841 1.616577) (xy -2.446574 1.650706) (xy -2.440408 1.68001) (xy -2.439939 1.688234) (xy -2.441576 1.713412)
+				(xy -2.448652 1.731453) (xy -2.464415 1.750116) (xy -2.466878 1.7526) (xy -2.482402 1.76869) (xy -2.492138 1.779871)
+				(xy -2.493818 1.782618) (xy -2.486829 1.784254) (xy -2.46869 1.785371) (xy -2.448413 1.785697) (xy -2.403009 1.785697)
+				(xy -2.385853 1.752985) (xy -2.359475 1.692666) (xy -2.3413 1.629946) (xy -2.33584 1.598264) (xy -2.329982 1.568446)
+				(xy -2.322172 1.552645) (xy -2.313113 1.549715) (xy -2.303503 1.55851) (xy -2.294045 1.577883) (xy -2.285439 1.606688)
+				(xy -2.278385 1.643779) (xy -2.273585 1.68801) (xy -2.272742 1.701479) (xy -2.2683 1.785697) (xy -2.195295 1.785697)
+				(xy -2.184494 1.741439) (xy -2.175702 1.71321) (xy -2.166664 1.698848) (xy -2.162497 1.697182) (xy -2.153517 1.704664)
+				(xy -2.144384 1.726289) (xy -2.140101 1.741439) (xy -2.128899 1.785697) (xy -2.095602 1.785697)
+				(xy -2.072455 1.783848) (xy -2.060725 1.777435) (xy -2.058045 1.772227) (xy -2.056287 1.767896)
+				(xy -1.977212 1.767896) (xy -1.974086 1.776025) (xy -1.962455 1.777962) (xy -1.957056 1.778) (xy -1.941554 1.77572)
+				(xy -1.930634 1.766326) (xy -1.919846 1.745997) (xy -1.905427 1.718258) (xy -1.888035 1.690169)
+				(xy -1.88435 1.684915) (xy -1.868164 1.659808) (xy -1.85417 1.633627) (xy -1.85154 1.627726) (xy -1.841605 1.610049)
+				(xy -1.831992 1.602798) (xy -1.830064 1.603007) (xy -1.825309 1.611917) (xy -1.822478 1.631759)
+				(xy -1.821522 1.658197) (xy -1.822392 1.686896) (xy -1.825038 1.713521) (xy -1.829411 1.733737)
+				(xy -1.831603 1.739) (xy -1.836042 1.751411) (xy -1.830062 1.753637) (xy -1.812937 1.745893) (xy -1.811358 1.745015)
+				(xy -1.782566 1.720573) (xy -1.763937 1.687036) (xy -1.756407 1.647634) (xy -1.760913 1.605597)
+				(xy -1.76613 1.589201) (xy -1.779712 1.563349) (xy -1.797741 1.541699) (xy -1.817513 1.525968) (xy -1.836326 1.517872)
+				(xy -1.851476 1.519124) (xy -1.859781 1.529773) (xy -1.872876 1.565272) (xy -1.888086 1.593167)
+				(xy -1.909641 1.621102) (xy -1.911542 1.623308) (xy -1.94865 1.676549) (xy -1.971058 1.733379) (xy -1.974521 1.749136)
+				(xy -1.977212 1.767896) (xy -2.056287 1.767896) (xy -2.038884 1.725039) (xy -2.011141 1.680898)
+				(xy -1.992586 1.657599) (xy -1.969044 1.626878) (xy -1.945617 1.59169) (xy -1.930054 1.564608) (xy -1.917251 1.538597)
+				(xy -1.9114 1.522655) (xy -1.911719 1.513537) (xy -1.916545 1.508544) (xy -1.933646 1.501855) (xy -1.948314 1.502637)
+				(xy -1.955004 1.510506) (xy -1.95503 1.511219) (xy -1.961436 1.523749) (xy -1.977193 1.530831) (xy -1.997109 1.532064)
+				(xy -2.015991 1.527046) (xy -2.027818 1.516842) (xy -2.03663 1.508335) (xy -2.04303 1.514405) (xy -2.046671 1.534372)
+				(xy -2.047394 1.555035) (xy -2.049352 1.585661) (xy -2.054382 1.614553) (xy -2.058794 1.628749)
+				(xy -2.069938 1.648323) (xy -2.081544 1.653775) (xy -2.094136 1.644812) (xy -2.10824 1.621144) (xy -2.119522 1.595093)
+				(xy -2.130749 1.568802) (xy -2.140635 1.549198) (xy -2.147384 1.539761) (xy -2.148295 1.539394)
+				(xy -2.153562 1.54619) (xy -2.158601 1.563168) (xy -2.159867 1.570021) (xy -2.167758 1.601172) (xy -2.179 1.61874)
+				(xy -2.193034 1.622019) (xy -2.198958 1.619387) (xy -2.211651 1.605766) (xy -2.21534 1.596296) (xy -2.220008 1.581575)
+				(xy -2.229442 1.558997) (xy -2.237765 1.541318) (xy -2.257729 1.500909) (xy -2.400789 1.501023)
+				(xy -2.451009 1.501203) (xy -2.487413 1.501737) (xy -2.51158 1.502749) (xy -2.525086 1.504362) (xy -2.529508 1.506704)
+				(xy -2.611844 1.506704) (xy -2.612843 1.505941) (xy -2.635659 1.501184) (xy -2.645775 1.500909)
+				(xy -2.679593 1.500909) (xy -2.795518 1.500909) (xy -2.940242 1.500909) (xy -2.940242 1.544274)
+				(xy -2.944799 1.597206) (xy -2.958919 1.639532) (xy -2.983278 1.673216) (xy -2.985318 1.675237)
+				(xy -3.008165 1.694744) (xy -3.023007 1.701106) (xy -3.029853 1.694324) (xy -3.028714 1.674397)
+				(xy -3.028264 1.672167) (xy -3.023614 1.633182) (xy -3.027644 1.595531) (xy -3.041077 1.553037)
+				(xy -3.042664 1.549034) (xy -3.060431 1.504758) (xy -3.108094 1.502466) (xy -3.131556 1.501402)
+				(xy -3.146162 1.502727) (xy -3.153274 1.509131) (xy -3.154252 1.523301) (xy -3.189431 1.523301)
+				(xy -3.18944 1.52181) (xy -3.190008 1.518947) (xy -3.193073 1.509812) (xy -3.198825 1.504434) (xy -3.210595 1.502009)
+				(xy -3.231714 1.50173) (xy -3.257966 1.502526) (xy -3.321242 1.504758) (xy -3.320324 1.549398) (xy -3.317097 1.580569)
+				(xy -3.309372 1.619122) (xy -3.298529 1.658211) (xy -3.298157 1.659361) (xy -3.289159 1.688783)
+				(xy -3.283032 1.712327) (xy -3.280649 1.726459) (xy -3.281041 1.728819) (xy -3.290839 1.728675)
+				(xy -3.308809 1.720478) (xy -3.331482 1.706246) (xy -3.355385 1.687995) (xy -3.363606 1.680845)
+				(xy -3.386312 1.655648) (xy -3.4019 1.625906) (xy -3.411942 1.587776) (xy -3.416823 1.550939) (xy -3.421303 1.504758)
+				(xy -3.457455 1.502428) (xy -3.493607 1.500099) (xy -5.277821 1.500099) (xy -5.290431 1.498599)
+				(xy -5.298734 1.496237) (xy -5.306419 1.496005) (xy -5.310064 1.505135) (xy -5.310968 1.525101)
+				(xy -5.313364 1.55119) (xy -5.319486 1.583432) (xy -5.32549 1.606195) (xy -5.335868 1.633664) (xy -5.349998 1.662529)
+				(xy -5.365736 1.689297) (xy -5.380937 1.710475) (xy -5.393459 1.722568) (xy -5.39786 1.724121) (xy -5.401598 1.717233)
+				(xy -5.401636 1.698701) (xy -5.398349 1.671729) (xy -5.392115 1.639517) (xy -5.384288 1.608667)
+				(xy -5.376275 1.576043) (xy -5.369671 1.541582) (xy -5.367627 1.527312) (xy -5.362994 1.488291)
+				(xy -5.398995 1.474543) (xy -5.420352 1.467371) (xy -5.435195 1.464218) (xy -5.438912 1.46471) (xy -5.44278 1.473717)
+				(xy -5.448837 1.493113) (xy -5.454438 1.513631) (xy -5.465514 1.54627) (xy -5.48294 1.586226) (xy -5.504143 1.628487)
+				(xy -5.526552 1.668042) (xy -5.547594 1.699878) (xy -5.554552 1.708736) (xy -5.567602 1.725136)
+				(xy -5.570313 1.733977) (xy -5.8505 1.733977) (xy -5.897703 1.695072) (xy -5.918597 1.671739) (xy -5.711151 1.671739)
+				(xy -5.705009 1.678279) (xy -5.69008 1.688173) (xy -5.67161 1.698447) (xy -5.654844 1.706123) (xy -5.646543 1.708387)
+				(xy -5.637846 1.703304) (xy -5.623256 1.689952) (xy -5.613738 1.679864) (xy -5.594558 1.656523)
+				(xy -5.578947 1.63392) (xy -5.568986 1.615465) (xy -5.566755 1.60457) (xy -5.567301 1.603709) (xy -5.575148 1.605524)
+				(xy -5.591676 1.613912) (xy -5.606666 1.622909) (xy -5.634777 1.638437) (xy -5.664783 1.651646)
+				(xy -5.676828 1.655772) (xy -5.697111 1.662895) (xy -5.709431 1.669411) (xy -5.711151 1.671739)
+				(xy -5.918597 1.671739) (xy -5.963573 1.621514) (xy -6.018853 1.537709) (xy -6.062868 1.444505)
+				(xy -6.088839 1.366212) (xy -6.092649 1.351763) (xy -6.095878 1.337361) (xy -6.098597 1.321563)
+				(xy -6.100878 1.302926) (xy -6.102793 1.280005) (xy -6.104412 1.251358) (xy -6.105807 1.215542)
+				(xy -6.10705 1.171113) (xy -6.10768 1.141522) (xy -5.972016 1.141522) (xy -5.971881 1.164247) (xy -5.971259 1.182253)
+				(xy -5.969886 1.212308) (xy -5.967674 1.230516) (xy -5.963269 1.240418) (xy -5.955315 1.245552)
+				(xy -5.945909 1.248487) (xy -5.928462 1.25051) (xy -5.899487 1.25075) (xy -5.862742 1.249257) (xy -5.831253 1.246937)
+				(xy -5.79537 1.244126) (xy -5.765396 1.242419) (xy -5.74447 1.24195) (xy -5.735736 1.24285) (xy -5.737691 1.250837)
+				(xy -5.747876 1.266709) (xy -5.763727 1.287374) (xy -5.782679 1.309742) (xy -5.802167 1.330722)
+				(xy -5.819627 1.347225) (xy -5.827278 1.353164) (xy -5.849654 1.365436) (xy -5.878972 1.377719)
+				(xy -5.897632 1.383952) (xy -5.921117 1.391765) (xy -5.937217 1.398865) (xy -5.94205 1.402992) (xy -5.938815 1.412456)
+				(xy -5.930337 1.431415) (xy -5.918859 1.454947) (xy -5.908199 1.475125) (xy -5.898159 1.489142)
+				(xy -5.88631 1.497225) (xy -5.870225 1.499598) (xy -5.847476 1.496489) (xy -5.815635 1.488123) (xy -5.772274 1.474726)
+				(xy -5.757333 1.469975) (xy -5.720651 1.458517) (xy -5.688874 1.449008) (xy -5.665075 1.442339)
+				(xy -5.65233 1.439399) (xy -5.6515 1.439334) (xy -5.6415 1.443201) (xy -5.642887 1.453762) (xy -5.654057 1.469454)
+				(xy -5.673406 1.488712) (xy -5.69933 1.509972) (xy -5.730224 1.53167) (xy -5.764485 1.552241) (xy -5.770795 1.555656)
+				(xy -5.798377 1.570817) (xy -5.819909 1.583589) (xy -5.832384 1.592139) (xy -5.834295 1.594353)
+				(xy -5.828371 1.599799) (xy -5.812995 1.611015) (xy -5.791765 1.625612) (xy -5.768284 1.641199)
+				(xy -5.74615 1.655388) (xy -5.728965 1.665787) (xy -5.720329 1.670008) (xy -5.720318 1.670009) (xy -5.721262 1.665138)
+				(xy -5.722996 1.66206) (xy -5.722076 1.649519) (xy -5.706982 1.632633) (xy -5.678178 1.611835) (xy -5.654147 1.597455)
+				(xy -5.626747 1.581076) (xy -5.601817 1.564734) (xy -5.586318 1.553207) (xy -5.570126 1.535895)
+				(xy -5.552021 1.511101) (xy -5.534596 1.483143) (xy -5.520445 1.45634) (xy -5.512161 1.435011) (xy -5.51103 1.427833)
+				(xy -5.515442 1.412364) (xy -5.526668 1.39124) (xy -5.534437 1.37975) (xy -5.557843 1.347922) (xy -5.595206 1.366688)
+				(xy -5.630348 1.380186) (xy -5.668578 1.385267) (xy -5.679557 1.385455) (xy -5.708111 1.384068)
+				(xy -5.722945 1.379553) (xy -5.723913 1.371379) (xy -5.710871 1.359014) (xy -5.683675 1.341925)
+				(xy -5.664901 1.331539) (xy -5.638401 1.316586) (xy -5.618633 1.304097) (xy -5.608363 1.295891)
+				(xy -5.607684 1.293932) (xy -5.617086 1.288717) (xy -5.635403 1.280908) (xy -5.643426 1.277827)
+				(xy -5.665927 1.26645) (xy -5.683237 1.252563) (xy -5.686187 1.248833) (xy -5.697635 1.231515) (xy -5.588 1.231515)
+				(xy -5.588 1.132529) (xy -5.612964 1.139689) (xy -5.638772 1.144098) (xy -5.676292 1.146645) (xy -5.721974 1.147459)
+				(xy -5.772266 1.146667) (xy -5.823615 1.144397) (xy -5.87247 1.140776) (xy -5.91528 1.135932) (xy -5.948492 1.129993)
+				(xy -5.958534 1.127263) (xy -5.966011 1.125917) (xy -5.970282 1.129707) (xy -5.972016 1.141522)
+				(xy -6.10768 1.141522) (xy -6.108211 1.116627) (xy -6.109363 1.050642) (xy -6.110577 0.971714) (xy -6.111498 0.908242)
+				(xy -6.112744 0.819707) (xy -6.113714 0.745177) (xy -6.114377 0.683264) (xy -6.114438 0.673795)
+				(xy -5.987523 0.673795) (xy -5.9865 0.700886) (xy -5.984465 0.738926) (xy -5.982097 0.778979) (xy -5.979769 0.806689)
+				(xy -5.976749 0.825088) (xy -5.972308 0.837206) (xy -5.965716 0.846075) (xy -5.956667 0.854364)
+				(xy -5.939152 0.873473) (xy -5.934465 0.888626) (xy -5.942577 0.898134) (xy -5.957454 0.900545)
+				(xy -5.973818 0.902464) (xy -5.979848 0.911433) (xy -5.980545 0.923277) (xy -5.974103 0.946684)
+				(xy -5.960892 0.959838) (xy -5.943236 0.972919) (xy -5.920522 0.990573) (xy -5.908937 0.999848)
+				(xy -5.869708 1.026888) (xy -5.826918 1.045957) (xy -5.775431 1.05921) (xy -5.761182 1.061768) (xy -5.729466 1.067343)
+				(xy -5.69984 1.07297) (xy -5.680363 1.07707) (xy -5.654195 1.081469) (xy -5.624975 1.084131) (xy -5.620712 1.0843)
+				(xy -5.588 1.085273) (xy -5.588 1.027545) (xy -5.588707 0.999926) (xy -5.590578 0.979461) (xy -5.593235 0.969927)
+				(xy -5.593772 0.969663) (xy -5.641733 0.964562) (xy -5.692422 0.95273) (xy -5.741206 0.935757) (xy -5.78345 0.915228)
+				(xy -5.812279 0.894817) (xy -5.830017 0.875404) (xy -5.846733 0.851485) (xy -5.860236 0.827058)
+				(xy -5.868334 0.806124) (xy -5.868835 0.792681) (xy -5.868543 0.792147) (xy -5.85997 0.79114) (xy -5.84257 0.794923)
+				(xy -5.821511 0.801868) (xy -5.801957 0.810345) (xy -5.791969 0.816292) (xy -5.781759 0.82107) (xy -5.760478 0.829357)
+				(xy -5.731668 0.83981) (xy -5.711151 0.846936) (xy -5.677481 0.858768) (xy -5.647224 0.869997) (xy -5.624761 0.878969)
+				(xy -5.617246 0.882378) (xy -5.601213 0.889819) (xy -5.59223 0.892848) (xy -5.590489 0.885683) (xy -5.589096 0.866314)
+				(xy -5.588219 0.837928) (xy -5.588 0.812467) (xy -5.588356 0.775388) (xy -5.589738 0.750657) (xy -5.592613 0.735239)
+				(xy -5.597449 0.726097) (xy -5.601941 0.722027) (xy -5.618385 0.706863) (xy -5.621897 0.691844)
+				(xy -5.612837 0.672836) (xy -5.606944 0.664713) (xy -5.597778 0.652) (xy -5.591937 0.640336) (xy -5.588851 0.626102)
+				(xy -5.587952 0.605677) (xy -5.588669 0.575439) (xy -5.589522 0.553903) (xy -5.591406 0.515967)
+				(xy -5.593922 0.489533) (xy -5.597926 0.470711) (xy -5.604276 0.45561) (xy -5.613827 0.440339) (xy -5.614852 0.438853)
+				(xy -5.62691 0.421566) (xy -5.636358 0.410238) (xy -5.647116 0.402167) (xy -5.663103 0.394652) (xy -5.68824 0.38499)
+				(xy -5.698655 0.381079) (xy -5.748638 0.362265) (xy -5.736917 0.390318) (xy -5.728267 0.408369)
+				(xy -5.713863 0.435656) (xy -5.695852 0.468204) (xy -5.679834 0.496133) (xy -5.661192 0.52947) (xy -5.645325 0.560411)
+				(xy -5.634078 0.585198) (xy -5.629516 0.598675) (xy -5.627432 0.615712) (xy -5.631914 0.622476)
+				(xy -5.640318 0.623455) (xy -5.653979 0.620058) (xy -5.677102 0.61098) (xy -5.705621 0.597884) (xy -5.718593 0.5914)
+				(xy -5.783974 0.549327) (xy -5.84038 0.495065) (xy -5.886782 0.429609) (xy -5.888227 0.427103) (xy -5.913006 0.383794)
+				(xy -5.932198 0.401639) (xy -5.948145 0.42018) (xy -5.958839 0.438727) (xy -5.966093 0.461861) (xy -5.971718 0.487585)
+				(xy -5.974858 0.510718) (xy -5.974659 0.526082) (xy -5.973668 0.52863) (xy -5.962064 0.539672) (xy -5.940258 0.556379)
+				(xy -5.911356 0.576678) (xy -5.878466 0.598498) (xy -5.844693 0.619765) (xy -5.813144 0.638409)
+				(xy -5.79188 0.649897) (xy -5.751485 0.671069) (xy -5.720152 0.68941) (xy -5.692779 0.708123) (xy -5.666336 0.728724)
+				(xy -5.653431 0.740304) (xy -5.651914 0.746602) (xy -5.659314 0.750759) (xy -5.681958 0.753839)
+				(xy -5.715269 0.751073) (xy -5.756102 0.743408) (xy -5.801311 0.731795) (xy -5.847753 0.717183)
+				(xy -5.892281 0.700521) (xy -5.93175 0.682759) (xy -5.963016 0.664847) (xy -5.975562 0.655287) (xy -5.98142 0.65076)
+				(xy -5.985213 0.650894) (xy -5.987171 0.657852) (xy -5.987523 0.673795) (xy -6.114438 0.673795)
+				(xy -6.114706 0.632582) (xy -6.11467 0.591743) (xy -6.114242 0.559361) (xy -6.113391 0.534047) (xy -6.112088 0.514416)
+				(xy -6.110305 0.499079) (xy -6.108013 0.48665) (xy -6.105182 0.475741) (xy -6.102224 0.466305) (xy -6.078637 0.411713)
+				(xy -6.044679 0.36278) (xy -6.003581 0.320836) (xy -5.951995 0.284265) (xy -5.892307 0.260286) (xy -5.823762 0.248602)
+				(xy -5.818255 0.248213) (xy -5.749516 0.251028) (xy -5.685531 0.267958) (xy -5.627504 0.298143)
+				(xy -5.57664 0.340719) (xy -5.534144 0.394823) (xy -5.50122 0.459593) (xy -5.493435 0.480841) (xy -5.49157 0.493784)
+				(xy -5.489686 0.520781) (xy -5.487828 0.560494) (xy -5.486039 0.611582) (xy -5.484363 0.672707)
+				(xy -5.482846 0.74253) (xy -5.48153 0.81971) (xy -5.480991 0.858382) (xy -5.476394 1.212612) (xy -5.451692 1.262473)
+				(xy -5.431609 1.297362) (xy -5.408118 1.325148) (xy -5.377446 1.349427) (xy -5.335819 1.373791)
+				(xy -5.333538 1.374995) (xy -5.291666 1.397) (xy -3.110852 1.395662) (xy -0.930037 1.394324) (xy -0.889964 1.374718)
+				(xy -0.852674 1.350978) (xy -0.823822 1.319574) (xy -0.80268 1.278946) (xy -0.78852 1.227537) (xy -0.780617 1.163787)
+				(xy -0.779151 1.137227) (xy -0.775496 1.046788) (xy -1.103196 1.046788) (xy -1.185962 1.046716)
+				(xy -1.25524 1.046456) (xy -1.312937 1.045938) (xy -1.360961 1.045094) (xy -1.401217 1.043856) (xy -1.435612 1.042154)
+				(xy -1.466052 1.039921) (xy -1.494444 1.037089) (xy -1.522694 1.033587) (xy -1.540948 1.031054)
+				(xy -1.630558 1.015935) (xy -1.70759 0.998075) (xy -1.770832 0.977766) (xy -1.781848 0.973383) (xy -1.80472 0.964584)
+				(xy -1.823483 0.958221) (xy -1.842544 0.950197) (xy -1.87075 0.93558) (xy -1.904545 0.91647) (xy -1.940372 0.89497)
+				(xy -1.974674 0.873182) (xy -2.003893 0.853208) (xy -2.014431 0.845375) (xy -2.094853 0.77371) (xy -2.164462 0.691136)
+				(xy -2.223269 0.597636) (xy -2.271284 0.493189) (xy -2.308515 0.377778) (xy -2.334974 0.251383)
+				(xy -2.340766 0.211667) (xy -2.345301 0.165101) (xy -2.34841 0.107538) (xy -2.350093 0.043113) (xy -2.35035 -0.024033)
+				(xy -2.350256 -0.029342) (xy -1.698796 -0.029342) (xy -1.698149 0.040328) (xy -1.693094 0.108822)
+				(xy -1.683974 0.171725) (xy -1.671137 0.224619) (xy -1.669103 0.230857) (xy -1.63762 0.304546) (xy -1.596587 0.369778)
+				(xy -1.547427 0.425088) (xy -1.491563 0.469012) (xy -1.430419 0.500087) (xy -1.397 0.510684) (xy -1.378298 0.515346)
+				(xy -1.361445 0.519132) (xy -1.344607 0.522142) (xy -1.325955 0.524475) (xy -1.303656 0.52623) (xy -1.275878 0.527505)
+				(xy -1.240792 0.5284) (xy -1.196564 0.529014) (xy -1.141364 0.529445) (xy -1.07336 0.529794) (xy -1.041015 0.529938)
+				(xy -0.777394 0.531091) (xy -0.777394 -0.531931) (xy -1.071803 -0.529293) (xy -1.147038 -0.528593)
+				(xy -1.208571 -0.527905) (xy -1.258091 -0.527125) (xy -1.297288 -0.526152) (xy -1.327854 -0.524883)
+				(xy -1.351479 -0.523216) (xy -1.369852 -0.521047) (xy -1.384665 -0.518274) (xy -1.397607 -0.514794)
+				(xy -1.41037 -0.510505) (xy -1.416242 -0.50838) (xy -1.487436 -0.475025) (xy -1.548184 -0.43071)
+				(xy -1.598593 -0.375277) (xy -1.638768 -0.308571) (xy -1.668815 -0.230436) (xy -1.688839 -0.140714)
+				(xy -1.694686 -0.095773) (xy -1.698796 -0.029342) (xy -2.350256 -0.029342) (xy -2.349181 -0.089765)
+				(xy -2.346587 -0.149943) (xy -2.342566 -0.200429) (xy -2.340759 -0.215515) (xy -2.317237 -0.344976)
+				(xy -2.282983 -0.463441) (xy -2.237922 -0.57102) (xy -2.181984 -0.667823) (xy -2.115097 -0.753959)
+				(xy -2.037187 -0.829537) (xy -1.948184 -0.894667) (xy -1.861117 -0.943187) (xy -1.77544 -0.979471)
+				(xy -1.678248 -1.010119) (xy -1.616363 -1.025454) (xy -1.60346 -1.0283) (xy -1.590764 -1.030806)
+				(xy -1.577239 -1.032997) (xy -1.561847 -1.034899) (xy -1.543551 -1.036538) (xy -1.521314 -1.03794)
+				(xy -1.494098 -1.03913) (xy -1.460868 -1.040136) (xy -1.420585 -1.040982) (xy -1.372213 -1.041694)
+				(xy -1.314714 -1.042299) (xy -1.247051 -1.042823) (xy -1.168188 -1.043291) (xy -1.077086 -1.043729)
+				(xy -0.972709 -1.044163) (xy -0.854021 -1.044619) (xy -0.848591 -1.044639) (xy -0.153939 -1.047257)
+				(xy -0.153939 0.060088)
+			)
+			(stroke
+				(width 0.01)
+				(type solid)
+			)
+			(fill yes)
+			(layer "F.SilkS")
+			(uuid "b05db981-a830-4310-a3b6-36abca3950bc")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "tigard:Securing_Hardware_Logo"
+		(layer "B.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec85cf")
+		(at 71.018 38.78 180)
+		(property "Reference" "LOGO2"
+			(at 0.21 -5.33 0)
+			(layer "B.Fab")
+			(uuid "47a8a532-e0f0-4321-9ce4-c544da20944d")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Value" "Logo_SH"
+			(at 0.21 -4.33 0)
+			(layer "B.Fab")
+			(uuid "3c681082-5145-4938-a00f-fe351a18ca9d")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "cb7db9f6-0eff-4a87-b93c-50299990051a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b1520d79-4c83-4fac-bc07-ce1a353b873b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f3191b2")
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 3.88 0.01)
+			(end 3.87 -0.05)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "5723d02c-4372-4c62-b412-d85462ef612b")
+		)
+		(fp_line
+			(start 3.87 0.07)
+			(end 3.88 0.01)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "faf3d93f-b176-44e4-ade4-679cb361fb38")
+		)
+		(fp_line
+			(start 3.87 -0.05)
+			(end 3.85 -0.13)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "c61583b8-11bc-4da5-b73b-1b8fe23eef7b")
+		)
+		(fp_line
+			(start 3.85 -0.13)
+			(end 3.8 -0.18)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "9f96f5a4-820d-4853-97d7-b834f399e13e")
+		)
+		(fp_line
+			(start 3.83 0.14)
+			(end 3.87 0.07)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "ee58b403-4c68-4243-beeb-4c64c83b152b")
+		)
+		(fp_line
+			(start 3.8 -0.18)
+			(end 3.74 -0.18)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "ef25a81e-bd54-43c0-b6e0-1d3e92e57890")
+		)
+		(fp_line
+			(start 3.74 -0.18)
+			(end 3.56 -0.18)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "2ce798cd-e99b-4191-bbda-1072b66df191")
+		)
+		(fp_line
+			(start 3.57 0.16)
+			(end 3.83 0.14)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "8636784e-ce5e-4395-b69f-468b3524b551")
+		)
+		(fp_line
+			(start 1.95 1.81)
+			(end 1.92 1.93)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "1a378621-f79f-48b0-a777-496550ddf716")
+		)
+		(fp_line
+			(start 1.95 1.35)
+			(end 1.95 1.81)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "32b8fd5f-fac9-4208-89d5-770f2a2eb57f")
+		)
+		(fp_line
+			(start 1.93 1.2)
+			(end 1.95 1.35)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "e74ca03b-d32c-4dcf-8fd2-056ea12ef34c")
+		)
+		(fp_line
+			(start 1.92 1.93)
+			(end 1.85 1.99)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "005d0050-2970-4706-b2fe-f9948d4ddb1d")
+		)
+		(fp_line
+			(start 1.92 1.13)
+			(end 1.93 1.2)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "16b926a7-e97e-49a4-9070-78a6321d6c38")
+		)
+		(fp_line
+			(start 1.9 -1.43)
+			(end 1.89 -1.29)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "387766dd-476f-4033-9669-4d66b79541de")
+		)
+		(fp_line
+			(start 1.9 -1.59)
+			(end 1.9 -1.43)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "e06fea39-f189-433d-8415-b730ff18cd99")
+		)
+		(fp_line
+			(start 1.89 1.06)
+			(end 1.92 1.13)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "9345fe59-0066-43d1-9b58-2e1cc7a86a02")
+		)
+		(fp_line
+			(start 1.89 -1.29)
+			(end 1.86 -1.16)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "36333b33-d016-4087-9f12-8a31aef56f73")
+		)
+		(fp_line
+			(start 1.89 -1.74)
+			(end 1.9 -1.59)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "60cbe5bd-64ee-407e-88e5-901dcde5e239")
+		)
+		(fp_line
+			(start 1.88 -1.83)
+			(end 1.89 -1.74)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "8f7056de-56e9-4117-a103-95e3209faaa2")
+		)
+		(fp_line
+			(start 1.86 -1.16)
+			(end 1.8 -1.11)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "2d6a3dc8-1291-4175-906f-b6ff4f3b9c39")
+		)
+		(fp_line
+			(start 1.85 1.99)
+			(end 1.73 2.05)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "12f2a62f-d0be-4983-bdc8-1740cb43a463")
+		)
+		(fp_line
+			(start 1.82 1.02)
+			(end 1.89 1.06)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "933792b0-4e4a-4b69-9987-85a068db7471")
+		)
+		(fp_line
+			(start 1.82 -1.93)
+			(end 1.88 -1.83)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "9abadb39-bb7a-4b2c-8b05-862b8f2e4b74")
+		)
+		(fp_line
+			(start 1.77 -1.99)
+			(end 1.82 -1.93)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "25169a8c-fdd8-4219-982b-2898ad434a26")
+		)
+		(fp_line
+			(start 1.73 2.05)
+			(end 1.61 2.05)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "382f5790-587f-4a33-b6da-4775175bb66e")
+		)
+		(fp_line
+			(start 1.68 -2.02)
+			(end 1.77 -1.99)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "9e637217-d8a5-4c5e-9c2b-0c2d5787fd64")
+		)
+		(fp_line
+			(start 1.61 2.05)
+			(end 0.84 2.04)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "e43a1acf-1ea5-4838-ac62-8373eef1d9cb")
+		)
+		(fp_line
+			(start 0.84 1.02)
+			(end 1.07 1.02)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "d45f8b72-d21a-4489-b885-6d5d4913e98c")
+		)
+		(fp_line
+			(start 0.84 -1.1)
+			(end 1.06 -1.1)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "11e9e27e-acb8-4c8f-a679-6f81405415dd")
+		)
+		(fp_line
+			(start 0.84 -2.02)
+			(end 1.68 -2.02)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "15a67936-f78c-446d-901b-7d3338c06922")
+		)
+		(fp_line
+			(start 0.8 2.31)
+			(end 0.79 -2.34)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "d373c930-e3c4-42e2-8099-f4d7727b7938")
+		)
+		(fp_line
+			(start 0.44 2.31)
+			(end 0.42 0.13)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "1e0cbd7e-efb2-4f61-aba0-8c0479fed999")
+		)
+		(fp_line
+			(start 0.44 -0.21)
+			(end 0.43 -2.34)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "01584aa6-fb65-451d-ace9-3c9b97634d6c")
+		)
+		(fp_line
+			(start 0.42 0.13)
+			(end -0.48 0.12)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "870a7fe2-42dd-4a01-8a55-eab407d42441")
+		)
+		(fp_line
+			(start 0.39 2.02)
+			(end 0.17 2.02)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "babfd7c7-f79a-41cc-bd33-71c7069dc3f5")
+		)
+		(fp_line
+			(start 0.17 -2.03)
+			(end 0.41 -2.03)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "a1aca244-9bf6-45cd-85ba-d1324c2d5b8b")
+		)
+		(fp_line
+			(start 0.12 -0.19)
+			(end 0.44 -0.21)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "d6aa3a6d-3772-4153-83d6-4352b434120c")
+		)
+		(fp_line
+			(start -0.02 -1.1)
+			(end 0.41 -1.11)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "d8a0f32f-9fe3-4640-a124-b1d2a96a8ba1")
+		)
+		(fp_line
+			(start -0.16 -1.11)
+			(end -0.02 -1.1)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "1691e865-014e-4ccf-b177-492edb5c90b7")
+		)
+		(fp_line
+			(start -0.17 2.02)
+			(end -1.34 2.01)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "19dda7d3-646f-4b19-b662-e3e922d3d087")
+		)
+		(fp_line
+			(start -0.17 -2.03)
+			(end -0.25 -1.96)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "ad7cc16d-41f0-4898-9a75-e0fefbf1ed59")
+		)
+		(fp_line
+			(start -0.25 -1.15)
+			(end -0.16 -1.11)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "389dec7c-1174-42ab-acd5-0c5605bac516")
+		)
+		(fp_line
+			(start -0.25 -1.96)
+			(end -0.32 -1.87)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "5fce5857-bbf0-45cc-9c2c-96fc20d2f5a6")
+		)
+		(fp_line
+			(start -0.3 -1.24)
+			(end -0.25 -1.15)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "dde0d367-28d0-476d-b2dd-a53ab3038efe")
+		)
+		(fp_line
+			(start -0.32 -1.87)
+			(end -0.34 -1.69)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "1b4452e0-3306-40e8-80f1-a9abdb23817f")
+		)
+		(fp_line
+			(start -0.33 -1.47)
+			(end -0.3 -1.24)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "66ba36a2-5ec3-48c0-9be0-8444ab322026")
+		)
+		(fp_line
+			(start -0.34 -1.69)
+			(end -0.33 -1.47)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "b2ea6bc0-cff7-44c4-84ec-32a433466918")
+		)
+		(fp_line
+			(start -0.46 -0.21)
+			(end 0.12 -0.19)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "39263420-6aa1-4032-9e21-701a9a46042a")
+		)
+		(fp_line
+			(start -1.24 -1.92)
+			(end -1.3 -1.96)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "4b0669fc-4979-4cd8-bfaa-5855d13e272c")
+		)
+		(fp_line
+			(start -1.33 1.06)
+			(end 0.39 1.04)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "4668ce9a-787e-427e-97ba-8da894be4cf3")
+		)
+		(fp_line
+			(start -1.37 -0.37)
+			(end -1.44 -0.69)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "d8ce0f64-c3fb-4af3-916c-018067881ee9")
+		)
+		(fp_line
+			(start -1.38 2.31)
+			(end -1.38 2.09)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "34dfcb39-2e4e-45d8-8c80-38744da74dc2")
+		)
+		(fp_line
+			(start -1.38 2.09)
+			(end -1.39 1.9)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "a80cc13a-af7c-4cac-a855-9f3d051ab96c")
+		)
+		(fp_line
+			(start -1.38 1.14)
+			(end -1.39 0.35)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "cd9d34a7-dbe1-40a1-b843-1476fb62617e")
+		)
+		(fp_line
+			(start -1.44 -0.69)
+			(end -1.8 -0.71)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "9336eb96-aa89-4c85-9956-c11a66ba2245")
+		)
+		(fp_line
+			(start -1.46 -1.11)
+			(end -1.25 -1.23)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "d1acde26-4fa9-4ec5-a8ba-70c363edfdd3")
+		)
+		(fp_line
+			(start -1.67 -2.02)
+			(end -1.3 -1.96)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "0ffc73bf-7b27-4afc-8ed4-b95a8acb799b")
+		)
+		(fp_line
+			(start -1.7 1.15)
+			(end -1.7 0.34)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "dedc5b21-94a4-44bb-889c-09b2ee1bbc89")
+		)
+		(fp_line
+			(start -1.72 2.31)
+			(end -1.72 2.11)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "f1120ff8-4a47-48b1-a5b1-6307fc915336")
+		)
+		(fp_line
+			(start -1.72 2.11)
+			(end -1.7 1.9)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "55b3e0d4-e431-4ef9-b8bf-ecb793b2e083")
+		)
+		(fp_line
+			(start -1.76 -1.09)
+			(end -1.46 -1.11)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "025d45af-e6ef-4fac-87c9-c4f95aed293b")
+		)
+		(fp_line
+			(start -1.8 -0.71)
+			(end -2.09 -0.71)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "260789a6-5203-437b-922b-00a0cf04e701")
+		)
+		(fp_line
+			(start -1.87 1.06)
+			(end -1.74 1.06)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "02014df3-9ffb-4d15-86af-6fc3a92ae6bc")
+		)
+		(fp_line
+			(start -2 2.01)
+			(end -1.76 2)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "2af3ea22-5e13-4f6a-b0cb-437253196940")
+		)
+		(fp_line
+			(start -2.04 -2.01)
+			(end -1.67 -2.02)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "d6adaf4d-bd20-4652-ba05-e9e810ade7d5")
+		)
+		(fp_line
+			(start -2.05 -1.09)
+			(end -1.76 -1.09)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "ae413e42-c946-403b-a0bc-c8d2f034e4af")
+		)
+		(fp_line
+			(start -2.09 -0.71)
+			(end -2.1 -1.19)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "ad018f9a-19ab-4a91-97a1-272b77d29b13")
+		)
+		(fp_line
+			(start -2.09 -2.01)
+			(end -2.1 -2.35)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "eba3f837-db0c-4351-864f-13decbe63995")
+		)
+		(fp_line
+			(start -2.1 -1.93)
+			(end -2.09 -2.01)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "640844da-d6aa-43c7-b1c9-afc8aa801a3a")
+		)
+		(fp_line
+			(start -2.39 2)
+			(end -2 2.01)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "1f3278e5-e8e5-41e0-bcd3-b6313e2c83de")
+		)
+		(fp_line
+			(start -2.45 -0.81)
+			(end -2.45 -0.97)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "05b0c912-6df6-4656-b632-26cb62118ec6")
+		)
+		(fp_line
+			(start -2.45 -0.97)
+			(end -2.45 -1.09)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "0bfbb66e-d935-4c79-b2b8-e59c4393bd12")
+		)
+		(fp_line
+			(start -2.45 -1.09)
+			(end -2.46 -1.21)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "202b017f-69eb-4ff8-98e5-f63802863f23")
+		)
+		(fp_line
+			(start -2.45 -2.06)
+			(end -2.45 -2.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "4f061582-d79e-4495-945b-924bbe17a79b")
+		)
+		(fp_line
+			(start -2.45 -2.25)
+			(end -2.45 -2.35)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "24de0d4f-7c1b-4960-a0ab-3fe93abcfda7")
+		)
+		(fp_line
+			(start -2.46 -1.9)
+			(end -2.45 -2.06)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "7ec83ff1-a49b-4bee-87af-b95896091ae7")
+		)
+		(fp_line
+			(start -2.47 -0.7)
+			(end -2.45 -0.81)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "5f173d93-c570-4692-a328-bb1a9f5b01fa")
+		)
+		(fp_line
+			(start -2.54 -0.37)
+			(end -2.48 -0.32)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "07e45fab-896b-4664-aa60-53d5ee8c0f00")
+		)
+		(fp_line
+			(start -2.54 -0.37)
+			(end -3.63 -0.38)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "e9f65f29-8d43-4081-9e2b-892ddf1fadb7")
+		)
+		(fp_line
+			(start -2.57 1.98)
+			(end -2.39 2)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "254e3875-1e9d-4c2b-88c7-df54e582de1a")
+		)
+		(fp_line
+			(start -2.59 -1.14)
+			(end -2.46 -1.13)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "e86d504a-9b02-4425-af8a-ce80d50984f1")
+		)
+		(fp_line
+			(start -2.64 1.07)
+			(end -2.7 1.12)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "613b8a66-3266-4f74-8c45-3fedb8725916")
+		)
+		(fp_line
+			(start -2.68 -1.13)
+			(end -2.59 -1.14)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "fed26813-109e-44f1-9594-40cb6758a031")
+		)
+		(fp_line
+			(start -2.7 1.12)
+			(end -2.74 1.2)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "a593ad6e-30ed-4667-b4bc-ec1179f88199")
+		)
+		(fp_line
+			(start -2.74 1.2)
+			(end -2.75 1.33)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "13e24e70-21b6-47e8-935c-a8bc5aad77a8")
+		)
+		(fp_line
+			(start -2.75 1.88)
+			(end -2.57 1.98)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "0e2bfec5-9490-48b9-a4d2-8d595f4b2ff2")
+		)
+		(fp_line
+			(start -2.75 1.51)
+			(end -2.76 1.72)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "945b3aa4-31a0-4588-b189-f978efeed00a")
+		)
+		(fp_line
+			(start -2.75 1.33)
+			(end -2.75 1.51)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "36a8d3c2-235a-4086-882f-d5bf201cf3a2")
+		)
+		(fp_line
+			(start -2.76 1.72)
+			(end -2.75 1.88)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "49a2cdb3-f688-4f59-9e92-b2e4b9eca41d")
+		)
+		(fp_line
+			(start -2.82 -1.13)
+			(end -2.68 -1.13)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "7317c533-977a-40dd-8a1b-2702a7e0d1ba")
+		)
+		(fp_line
+			(start -2.9 -2)
+			(end -2.49 -2)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "b9a75e6a-7f33-416a-b8e5-c0c720d381b2")
+		)
+		(fp_line
+			(start -3.01 -1.14)
+			(end -2.82 -1.13)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "5b7da91b-e690-41ef-96f6-c11c727bd094")
+		)
+		(fp_line
+			(start -3.14 -1.14)
+			(end -3.01 -1.14)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "fc02cfa7-8535-487c-a09e-41d4b38bee27")
+		)
+		(fp_line
+			(start -3.22 -1.14)
+			(end -3.14 -1.14)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "f801272d-73f8-43f4-80f8-80c9501ebc7d")
+		)
+		(fp_line
+			(start -3.3 -1.17)
+			(end -3.22 -1.14)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "2b853d96-5495-4e11-850d-db6d7e4f8a37")
+		)
+		(fp_line
+			(start -3.32 -1.96)
+			(end -3.27 -1.99)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "117e4517-7571-4edd-a744-9ba6dd7d5902")
+		)
+		(fp_line
+			(start -3.35 -1.21)
+			(end -3.3 -1.17)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "45b1bbea-108a-4de8-a13d-1ae2f5fa667e")
+		)
+		(fp_line
+			(start -3.36 -0.7)
+			(end -2.47 -0.7)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "eb3c9e43-ae34-4f0a-80e3-817c76ecd5b4")
+		)
+		(fp_line
+			(start -3.38 -1.9)
+			(end -3.32 -1.96)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "91edaa6e-73cf-4465-b94f-3da943d9059c")
+		)
+		(fp_line
+			(start -3.41 -1.3)
+			(end -3.35 -1.21)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "bff2e42c-1c41-4da0-9050-48c64791106f")
+		)
+		(fp_line
+			(start -3.41 -1.84)
+			(end -3.38 -1.9)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "68218afd-a492-475e-b39d-e50bf47b08c9")
+		)
+		(fp_line
+			(start -3.43 -1.76)
+			(end -3.41 -1.84)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "c7760dcb-c461-4c37-a2c0-aad664305e57")
+		)
+		(fp_line
+			(start -3.44 -1.41)
+			(end -3.41 -1.3)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "582cef67-c880-467e-a142-825de33e2ab4")
+		)
+		(fp_line
+			(start -3.44 -1.69)
+			(end -3.43 -1.76)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "fcbfc281-86a3-4b43-a111-3c0ab4e31931")
+		)
+		(fp_line
+			(start -3.44 -1.69)
+			(end -3.44 -1.41)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "5ee67e48-4c19-443b-b69d-89448b86a48a")
+		)
+		(fp_line
+			(start -3.51 -0.71)
+			(end -3.36 -0.7)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "10e1709b-72c6-41fc-84ed-88823d6e0a85")
+		)
+		(fp_line
+			(start -3.62 -0.7)
+			(end -3.51 -0.71)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "92e1790b-81a5-4452-bf3a-983f79a2d952")
+		)
+		(fp_line
+			(start -3.63 -0.38)
+			(end -3.76 -0.42)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "361307b1-1bea-49b2-a03c-f8ec09493d44")
+		)
+		(fp_line
+			(start -3.74 -0.66)
+			(end -3.62 -0.7)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "db7d51c6-1e9e-4da9-8772-ce2ec7d0f8ea")
+		)
+		(fp_line
+			(start -3.76 -0.42)
+			(end -3.8 -0.5)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "047c7238-7573-42fd-8588-a449086fbe22")
+		)
+		(fp_line
+			(start -3.78 -0.64)
+			(end -3.74 -0.66)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "32335e45-744a-4519-9aa5-e60e2de876b9")
+		)
+		(fp_line
+			(start -3.8 -0.5)
+			(end -3.8 -0.57)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "4e17ed71-f080-4950-bd71-4427b1f5cd16")
+		)
+		(fp_line
+			(start -3.8 -0.57)
+			(end -3.78 -0.64)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "2a5d6c5b-f2ca-4e48-84ba-fbf96548ba06")
+		)
+		(fp_poly
+			(pts
+				(xy -3.11 -0.39) (xy -3.25 -0.53) (xy -3.09 -0.69) (xy -2.95 -0.49) (xy -3.1 -0.39)
+			)
+			(stroke
+				(width 0.01)
+				(type solid)
+			)
+			(fill yes)
+			(layer "B.SilkS")
+			(uuid "91add528-e13a-4a84-930f-e3c936631b19")
+		)
+		(fp_poly
+			(pts
+				(xy -3.76 2.65) (xy 3.86 2.65) (xy 3.89 2.54) (xy 3.91 2.45) (xy 3.89 2.37) (xy 3.85 2.33) (xy 3.74 2.31)
+				(xy 3.38 2.31) (xy 1.62 2.32) (xy 0.17 2.31) (xy 0.17 1.68) (xy 0.17 1.37) (xy 0.13 1.36) (xy 0.07 1.35)
+				(xy 0 1.34) (xy 0 1.42) (xy 0.05 1.43) (xy 0.09 1.45) (xy 0.11 1.49) (xy 0.12 1.53) (xy 0.11 1.58)
+				(xy 0.09 1.61) (xy 0.06 1.64) (xy 0.02 1.66) (xy 0 1.66) (xy -0.05 1.65) (xy -0.08 1.63) (xy -0.11 1.6)
+				(xy -0.12 1.55) (xy -0.11 1.49) (xy -0.09 1.46) (xy -0.06 1.43) (xy -0.02 1.42) (xy 0 1.42) (xy 0 1.34)
+				(xy -0.15 1.36) (xy -0.17 1.37) (xy -0.17 2.31) (xy -3.52 2.31) (xy -3.75 2.32) (xy -3.79 2.37)
+				(xy -3.8 2.41) (xy -3.8 2.47)
+			)
+			(stroke
+				(width 0)
+				(type solid)
+			)
+			(fill yes)
+			(layer "B.SilkS")
+			(uuid "a74b40fd-5140-4c1f-aa96-3b3211149c16")
+		)
+		(fp_poly
+			(pts
+				(xy -3.77 -2.65) (xy 3.87 -2.65) (xy 3.87 -2.35) (xy 0.17 -2.34) (xy 0.17 -1.7) (xy 0.16 -1.47)
+				(xy 0.13 -1.36) (xy 0 -1.36) (xy 0 -1.45) (xy 0.04 -1.45) (xy 0.07 -1.47) (xy 0.1 -1.5) (xy 0.11 -1.53)
+				(xy 0.12 -1.57) (xy 0.11 -1.62) (xy 0.08 -1.66) (xy 0.04 -1.68) (xy 0 -1.69) (xy -0.05 -1.68) (xy -0.09 -1.65)
+				(xy -0.11 -1.61) (xy -0.12 -1.57) (xy -0.11 -1.51) (xy -0.09 -1.48) (xy -0.05 -1.46) (xy -0.02 -1.45)
+				(xy 0 -1.45) (xy 0 -1.36) (xy -0.13 -1.36) (xy -0.15 -1.44) (xy -0.17 -1.53) (xy -0.18 -1.79) (xy -0.17 -2.15)
+				(xy -0.17 -2.34) (xy -2.9 -2.35) (xy -2.9 -2.08) (xy -2.9 -1.83) (xy -2.9 -1.61) (xy -2.92 -1.37)
+				(xy -3.1 -1.37) (xy -3.1 -1.44) (xy -3.06 -1.45) (xy -3.02 -1.48) (xy -2.99 -1.53) (xy -2.98 -1.58)
+				(xy -2.99 -1.62) (xy -3.01 -1.65) (xy -3.05 -1.68) (xy -3.1 -1.69) (xy -3.14 -1.68) (xy -3.18 -1.65)
+				(xy -3.21 -1.61) (xy -3.22 -1.56) (xy -3.21 -1.51) (xy -3.17 -1.47) (xy -3.12 -1.45) (xy -3.1 -1.44)
+				(xy -3.1 -1.37) (xy -3.26 -1.37) (xy -3.27 -1.53) (xy -3.28 -1.78) (xy -3.27 -2.19) (xy -3.28 -2.34)
+				(xy -3.52 -2.34) (xy -3.77 -2.35)
+			)
+			(stroke
+				(width 0.01)
+				(type solid)
+			)
+			(fill yes)
+			(layer "B.SilkS")
+			(uuid "c3f95adc-63c5-44ec-bd61-594573e200c5")
+		)
+		(fp_poly
+			(pts
+				(xy 1.44 -1.85) (xy 1.44 -1.95) (xy 1.5 -1.95) (xy 1.58 -1.94) (xy 1.64 -1.92) (xy 1.69 -1.89) (xy 1.74 -1.85)
+				(xy 1.78 -1.8) (xy 1.8 -1.75) (xy 1.81 -1.72) (xy 1.82 -1.64) (xy 1.83 -1.43) (xy 1.82 -1.11) (xy 1.82 -0.39)
+				(xy 2.37 -0.39) (xy 2.85 -0.4) (xy 2.85 -1.72) (xy 2.85 -1.77) (xy 2.86 -1.8) (xy 2.89 -1.84) (xy 2.93 -1.87)
+				(xy 2.97 -1.89) (xy 3.03 -1.9) (xy 3.17 -1.9) (xy 3.33 -1.9) (xy 3.42 -1.89) (xy 3.46 -1.88) (xy 3.5 -1.85)
+				(xy 3.52 -1.83) (xy 3.54 -1.79) (xy 3.56 -1.75) (xy 3.58 -1.65) (xy 3.59 -1.53) (xy 3.59 -0.56)
+				(xy 3.58 -0.51) (xy 3.56 -0.31) (xy 3.56 0) (xy 3.49 0) (xy 3.48 -0.09) (xy 3.45 -0.15) (xy 3.41 -0.2)
+				(xy 3.37 -0.23) (xy 3.3 -0.27) (xy 3.21 -0.29) (xy 3.17 -0.29) (xy 3.11 -0.28) (xy 3.07 -0.26) (xy 3.02 -0.22)
+				(xy 2.98 -0.18) (xy 2.95 -0.13) (xy 2.93 -0.07) (xy 2.93 0.02) (xy 2.94 0.08) (xy 2.98 0.15) (xy 3.03 0.21)
+				(xy 3.08 0.24) (xy 3.15 0.26) (xy 3.2 0.26) (xy 3.26 0.25) (xy 3.3 0.24) (xy 3.36 0.21) (xy 3.41 0.17)
+				(xy 3.45 0.12) (xy 3.47 0.08) (xy 3.48 0.05) (xy 3.49 0) (xy 3.56 0) (xy 3.56 0.26) (xy 3.57 0.41)
+				(xy 3.58 0.5) (xy 3.59 0.55) (xy 3.59 1.56) (xy 3.58 1.65) (xy 3.56 1.74) (xy 3.54 1.79) (xy 3.51 1.82)
+				(xy 3.45 1.87) (xy 3.39 1.9) (xy 3.34 1.91) (xy 3.26 1.92) (xy 3.15 1.91) (xy 3.01 1.89) (xy 2.96 1.88)
+				(xy 2.92 1.86) (xy 2.88 1.82) (xy 2.85 1.77) (xy 2.83 1.71) (xy 2.82 1.62) (xy 2.83 1.55) (xy 2.83 0.37)
+				(xy 2.3 0.36) (xy 1.82 0.37) (xy 1.83 1.53) (xy 1.73 1.53) (xy 1.72 1.45) (xy 1.7 1.41) (xy 1.69 1.4)
+				(xy 1.67 1.37) (xy 1.61 1.33) (xy 1.54 1.3) (xy 1.49 1.29) (xy 1.4 1.29) (xy 1.35 1.3) (xy 1.28 1.33)
+				(xy 1.24 1.36) (xy 1.19 1.41) (xy 1.17 1.45) (xy 1.16 1.5) (xy 1.17 1.58) (xy 1.2 1.68) (xy 1.23 1.75)
+				(xy 1.39 1.81) (xy 1.43 1.82) (xy 1.52 1.81) (xy 1.61 1.77) (xy 1.67 1.71) (xy 1.71 1.64) (xy 1.72 1.6)
+				(xy 1.73 1.53) (xy 1.83 1.53) (xy 1.83 1.67) (xy 1.82 1.74) (xy 1.81 1.77) (xy 1.78 1.82) (xy 1.73 1.87)
+				(xy 1.68 1.9) (xy 1.62 1.92) (xy 1.41 1.93) (xy 1.37 1.93) (xy 1.27 1.92) (xy 1.22 1.9) (xy 1.15 1.86)
+				(xy 1.11 1.81) (xy 1.09 1.77) (xy 1.07 1.69) (xy 1.06 1.61) (xy 1.06 1.5) (xy 1.06 1.27) (xy 1.06 1.05)
+				(xy 1.06 -1.62) (xy 1.07 -1.75) (xy 1.09 -1.8) (xy 1.14 -1.86) (xy 1.18 -1.89) (xy 1.27 -1.93) (xy 1.39 -1.95)
+				(xy 1.44 -1.95) (xy 1.44 -1.85) (xy 1.37 -1.84) (xy 1.32 -1.82) (xy 1.26 -1.78) (xy 1.21 -1.72)
+				(xy 1.17 -1.63) (xy 1.16 -1.55) (xy 1.18 -1.45) (xy 1.23 -1.39) (xy 1.29 -1.35) (xy 1.38 -1.32)
+				(xy 1.46 -1.31) (xy 1.57 -1.34) (xy 1.63 -1.37) (xy 1.68 -1.41) (xy 1.71 -1.46) (xy 1.73 -1.53)
+				(xy 1.73 -1.56) (xy 1.72 -1.64) (xy 1.69 -1.71) (xy 1.64 -1.77) (xy 1.6 -1.8) (xy 1.54 -1.83) (xy 1.5 -1.84)
+			)
+			(stroke
+				(width 0.01)
+				(type solid)
+			)
+			(fill yes)
+			(layer "B.SilkS")
+			(uuid "aed4c667-c404-46da-9525-bed1f005139d")
+		)
+		(fp_poly
+			(pts
+				(xy -1.55 -1.95) (xy -0.87 -1.95) (xy -0.76 -1.94) (xy -0.68 -1.93) (xy -0.63 -1.92) (xy -0.61 -1.91)
+				(xy -0.56 -1.88) (xy -0.52 -1.84) (xy -0.47 -1.78) (xy -0.46 -1.71) (xy -0.44 -1.48) (xy -0.44 -0.73)
+				(xy -0.45 -0.58) (xy -0.46 -0.41) (xy -0.46 -0.02) (xy -0.45 0.13) (xy -0.47 0.18) (xy -0.5 0.23)
+				(xy -0.53 0.27) (xy -0.59 0.32) (xy -0.66 0.35) (xy -0.75 0.36) (xy -0.79 0.36) (xy -0.79 0.27)
+				(xy -0.73 0.26) (xy -0.68 0.23) (xy -0.64 0.19) (xy -0.59 0.12) (xy -0.56 0.02) (xy -0.56 -0.06)
+				(xy -0.58 -0.13) (xy -0.6 -0.16) (xy -0.64 -0.21) (xy -0.71 -0.25) (xy -0.76 -0.27) (xy -0.84 -0.28)
+				(xy -0.91 -0.27) (xy -0.97 -0.25) (xy -1.02 -0.21) (xy -1.07 -0.14) (xy -1.09 -0.09) (xy -1.09 0.01)
+				(xy -1.07 0.09) (xy -1.02 0.2) (xy -0.9 0.25) (xy -0.81 0.27) (xy -0.79 0.27) (xy -0.79 0.36) (xy -1.04 0.37)
+				(xy -1.29 0.36) (xy -1.65 0.34) (xy -1.88 0.35) (xy -1.88 0.59) (xy -1.89 0.84) (xy -1.86 1.12)
+				(xy -1.85 1.14) (xy -1.8 1.16) (xy -1.66 1.15) (xy -1.3 1.15) (xy -0.97 1.13) (xy -0.79 1.13) (xy -0.72 1.14)
+				(xy -0.62 1.17) (xy -0.58 1.19) (xy -0.51 1.26) (xy -0.47 1.33) (xy -0.45 1.4) (xy -0.44 1.45) (xy -0.43 1.55)
+				(xy -0.44 1.64) (xy -0.45 1.69) (xy -0.47 1.75) (xy -0.51 1.81) (xy -0.55 1.85) (xy -0.62 1.89)
+				(xy -0.7 1.91) (xy -0.84 1.92) (xy -1.08 1.92) (xy -1.35 1.9) (xy -1.56 1.89) (xy -1.77 1.9) (xy -1.92 1.91)
+				(xy -2.17 1.92) (xy -2.39 1.91) (xy -2.46 1.9) (xy -2.49 1.89) (xy -2.54 1.87) (xy -2.56 1.86) (xy -2.6 1.83)
+				(xy -2.64 1.77) (xy -2.65 1.72) (xy -2.66 1.55) (xy -2.54 1.55) (xy -2.53 1.63) (xy -2.5 1.69) (xy -2.46 1.74)
+				(xy -2.39 1.79) (xy -2.34 1.81) (xy -2.28 1.82) (xy -2.21 1.81) (xy -2.14 1.78) (xy -2.08 1.74)
+				(xy -2.03 1.67) (xy -2 1.61) (xy -1.99 1.56) (xy -1.99 1.49) (xy -2.01 1.42) (xy -2.06 1.35) (xy -2.11 1.3)
+				(xy -2.18 1.27) (xy -2.25 1.26) (xy -2.32 1.27) (xy -2.39 1.29) (xy -2.46 1.32) (xy -2.48 1.34)
+				(xy -2.5 1.39) (xy -2.53 1.46) (xy -2.54 1.51) (xy -2.54 1.55) (xy -2.66 1.55) (xy -2.65 1.34) (xy -2.64 1.09)
+				(xy -2.64 -0.16) (xy -2.62 -0.22) (xy -2.58 -0.29) (xy -2.53 -0.37) (xy -1.39 -0.37) (xy -1.25 -0.38)
+				(xy -1.2 -0.39) (xy -1.2 -0.49) (xy -1.2 -1.17) (xy -1.31 -1.15) (xy -1.52 -1.18) (xy -2.19 -1.19)
+				(xy -2.45 -1.17) (xy -2.58 -1.29) (xy -2.64 -1.36) (xy -2.67 -1.53) (xy -2.67 -1.59) (xy -2.66 -1.68)
+				(xy -2.64 -1.76) (xy -2.62 -1.8) (xy -2.55 -1.87) (xy -2.47 -1.94) (xy -2.39 -1.93) (xy -2.19 -1.92)
+				(xy -1.92 -1.94) (xy -1.58 -1.95) (xy -1.58 -1.85) (xy -1.63 -1.84) (xy -1.69 -1.81) (xy -1.72 -1.79)
+				(xy -1.77 -1.71) (xy -1.8 -1.64) (xy -1.81 -1.56) (xy -1.79 -1.47) (xy -1.75 -1.4) (xy -1.72 -1.36)
+				(xy -1.65 -1.31) (xy -1.6 -1.29) (xy -1.54 -1.28) (xy -1.45 -1.3) (xy -1.39 -1.34) (xy -1.34 -1.39)
+				(xy -1.3 -1.46) (xy -1.28 -1.53) (xy -1.28 -1.59) (xy -1.29 -1.65) (xy -1.32 -1.7) (xy -1.34 -1.73)
+				(xy -1.39 -1.79) (xy -1.45 -1.83) (xy -1.49 -1.84) (xy -1.55 -1.85) (xy -1.58 -1.85) (xy -1.58 -1.95)
+			)
+			(stroke
+				(width 0.01)
+				(type solid)
+			)
+			(fill yes)
+			(layer "B.SilkS")
+			(uuid "e7cd7f66-939a-4e7c-ba8b-2d42622dc787")
+		)
+		(fp_line
+			(start 3.560017 0.152958)
+			(end 3.560017 0.152958)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5adc2d5f-862b-4369-bb72-07f5e35bc65e")
+		)
+		(fp_line
+			(start 3.096466 0.245386)
+			(end 3.096466 0.245386)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d5032a0c-89ad-4952-9e85-cd37b232d8ac")
+		)
+		(fp_line
+			(start 1.330461 -1.336117)
+			(end 1.330461 -1.336117)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "588d68e2-a0bb-4412-84ea-265c20b19f77")
+		)
+		(fp_line
+			(start 1.330461 -1.336117)
+			(end 1.330461 -1.336117)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "959e19de-52b7-470b-b46d-a4a01768c9a0")
+		)
+		(fp_line
+			(start 1.234153 1.749983)
+			(end 1.234153 1.749983)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "1558524a-dc8a-41f9-a1b9-b02856579012")
+		)
+		(fp_line
+			(start 0.798472 2.0061)
+			(end 0.798472 2.0061)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "e39cf545-82e1-440e-a280-71cd9bf2667e")
+		)
+		(fp_line
+			(start 0.798472 -1.097639)
+			(end 0.798472 -1.097639)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0308bff9-b47b-4adf-8825-47d667ce35f1")
+		)
+		(fp_line
+			(start 0.435464 2.315133)
+			(end 0.435464 2.315133)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a771d686-0fb7-4cb5-b88b-03e8a5eb8803")
+		)
+		(fp_line
+			(start -0.040081 1.650147)
+			(end -0.040081 1.650147)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "23c119a9-3026-4666-9013-61cefd18f877")
+		)
+		(fp_line
+			(start -0.040081 1.650147)
+			(end -0.040081 1.650147)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a23e7684-12bd-4f97-95d1-b26f90bbbf97")
+		)
+		(fp_line
+			(start -0.040081 -1.45465)
+			(end -0.040081 -1.45465)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "4c555fef-659c-41cb-a328-f96f76d94d71")
+		)
+		(fp_line
+			(start -0.040081 -1.45465)
+			(end -0.040081 -1.45465)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "61320728-177e-49db-9423-79a67cace120")
+		)
+		(fp_line
+			(start -0.320539 -1.308953)
+			(end -0.320539 -1.308953)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "75fe45ac-f396-4b3e-a84f-997be499cdee")
+		)
+		(fp_line
+			(start -1.025036 0.19882)
+			(end -1.025036 0.19882)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "efa83280-3449-4b3c-bd4c-f47653310bef")
+		)
+		(fp_line
+			(start -1.385575 1.107928)
+			(end -1.386633 1.154847)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "99d81d1a-fbeb-4cb9-8a16-077e213e4247")
+		)
+		(fp_line
+			(start -1.385928 1.97435)
+			(end -1.385928 1.97435)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "eb50bc56-ef51-4335-8e21-b7363071b7be")
+		)
+		(fp_line
+			(start -1.386633 1.154847)
+			(end -1.385575 1.107928)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "854ab85c-bfbc-466f-8572-f358320ac191")
+		)
+		(fp_line
+			(start -1.633225 -1.301544)
+			(end -1.633225 -1.301544)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "3854bf45-0401-4421-b349-3606e799f5bd")
+		)
+		(fp_line
+			(start -1.633225 -1.301544)
+			(end -1.633225 -1.301544)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d7f1f373-e1dc-412a-955d-b5cc2da139e7")
+		)
+		(fp_line
+			(start -1.698842 1.132975)
+			(end -1.699195 1.154142)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d3999714-fbc3-4248-8bc9-5e2b5088de73")
+		)
+		(fp_line
+			(start -1.699195 1.154142)
+			(end -1.698842 1.132975)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5c041ad8-c3f4-42ea-9992-7d4647b1db8e")
+		)
+		(fp_line
+			(start -1.699195 1.154142)
+			(end -1.699195 1.154142)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c3739eb0-6e08-4dd9-9d66-8e6467e86847")
+		)
+		(fp_line
+			(start -1.717539 2.314075)
+			(end -1.717539 2.314075)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "157c31ad-6b5d-4e97-b4c0-45ee289a0341")
+		)
+		(fp_line
+			(start -1.861825 1.115689)
+			(end -1.861825 1.115689)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "db0ddff1-b578-446b-9ebd-23462f51c450")
+		)
+		(fp_line
+			(start -2.095364 -1.102578)
+			(end -2.095364 -1.102578)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "57aeea43-dfb5-40ed-8a4a-a71b878c3f69")
+		)
+		(fp_line
+			(start -2.09607 -1.925608)
+			(end -2.09607 -1.925608)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "db01c0aa-b5d7-4bae-8faa-4d853a52d06e")
+		)
+		(fp_line
+			(start -2.447083 -1.138208)
+			(end -2.456608 -1.172075)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5cd5b9a7-e0eb-482c-8122-e40155e5d278")
+		)
+		(fp_line
+			(start -2.456608 -1.172075)
+			(end -2.447083 -1.138208)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5875245a-62f3-468a-8821-6f18e29357c1")
+		)
+		(fp_line
+			(start -2.468956 -1.945011)
+			(end -2.468956 -1.945011)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ddcfee08-93f6-46d2-affe-57a8ae1c1fb2")
+		)
+		(fp_line
+			(start -2.541628 1.520678)
+			(end -2.541628 1.520678)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "22394566-24e2-418f-9fa9-597154ccaad2")
+		)
+		(fp_line
+			(start -2.719428 1.890389)
+			(end -2.719428 1.890389)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5d336ab9-0055-4ec9-becb-b198f99ab4b2")
+		)
+		(fp_line
+			(start -3.072911 -0.369153)
+			(end -3.072911 -0.369153)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "034c683c-0920-4609-9c64-8376eb8138f4")
+		)
+		(fp_line
+			(start -3.072911 -0.369153)
+			(end -3.098311 -0.387497)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "e62e01d6-7365-465f-b96b-daebe1c658b6")
+		)
+		(fp_line
+			(start -3.098311 -0.387497)
+			(end -3.072911 -0.369153)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c0ce068c-181a-4af3-a01e-c3d36caa3e1d")
+		)
+		(fp_line
+			(start -3.142761 -1.457825)
+			(end -3.142761 -1.457825)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0f9ebfa2-c9c1-411d-8ec3-73e83ebbe85b")
+		)
+		(fp_line
+			(start -3.254239 -0.526492)
+			(end -3.254239 -0.526492)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d56b3297-7565-425f-8d73-40d33f1173a7")
+		)
+		(fp_line
+			(start -3.42957 -1.342114)
+			(end -3.42957 -1.342114)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "15ce16fe-32a9-4a27-9eb8-9913f4f66b45")
+		)
+		(fp_line
+			(start -3.683922 -0.700764)
+			(end -3.683922 -0.700764)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "eb781c4a-b097-4ad6-918a-c27520785d99")
+		)
+		(fp_line
+			(start -4.075858 2.931083)
+			(end -4.069156 2.931083)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "8e15f6db-b6eb-4a19-9cb2-87ffe794c11d")
+		)
+		(fp_line
+			(start -4.075858 2.931083)
+			(end -4.075858 2.931083)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d090696d-bcd7-4de5-93d4-5ff8d198e88a")
+		)
+		(fp_line
+			(start -4.075858 2.928967)
+			(end -4.075858 2.931083)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "9feea498-6425-40ec-b12a-98fa6ba6fd2a")
+		)
+		(fp_curve
+			(pts
+				(xy 3.873283 -2.35) (xy 3.873989 -2.450542) (xy 3.873636 -2.55073) (xy 3.872225 -2.651272)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "2cf6062a-efd5-4d2f-aecb-999fc6c83026")
+		)
+		(fp_curve
+			(pts
+				(xy 3.872225 -2.651272) (xy 2.610692 -2.661503) (xy 1.348805 -2.652683) (xy 0.086919 -2.655505)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "8cb38348-dc6d-4941-a2f8-82e02b0ebf02")
+		)
+		(fp_curve
+			(pts
+				(xy 3.86658 -0.13385) (xy 3.794967 -0.224867) (xy 3.6595 -0.170186) (xy 3.560017 -0.18218)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "564e8464-eb4f-4118-9f99-74e6ee007120")
+		)
+		(fp_curve
+			(pts
+				(xy 3.865522 2.652742) (xy 3.87928 2.547614) (xy 3.9516 2.413206) (xy 3.856703 2.327128)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "9aecf125-0692-41a1-87a3-e7199d7057bc")
+		)
+		(fp_curve
+			(pts
+				(xy 3.856703 2.327128) (xy 3.812253 2.318661) (xy 3.76745 2.314075) (xy 3.722294 2.313722)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "06816702-30e8-4ab2-a20f-c05ce50a9c6c")
+		)
+		(fp_curve
+			(pts
+				(xy 3.821072 0.147667) (xy 3.911736 0.088047) (xy 3.877517 -0.042833) (xy 3.86658 -0.13385)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "2bdb641f-4250-4db9-933a-2274ee0ff383")
+		)
+		(fp_curve
+			(pts
+				(xy 3.722294 2.313722) (xy 2.746864 2.316192) (xy 1.77108 2.315839) (xy 0.79565 2.314075)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "db1e65f8-8cc2-4d89-a9a2-2679c5f642f3")
+		)
+		(fp_curve
+			(pts
+				(xy 3.586828 -1.514269) (xy 3.581536 -1.647267) (xy 3.585417 -1.809544) (xy 3.451714 -1.883275)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "33cc9aae-1746-4bc1-bc9d-b052411e78e6")
+		)
+		(fp_curve
+			(pts
+				(xy 3.586475 1.555603) (xy 3.583653 1.214467) (xy 3.586475 0.873331) (xy 3.585417 0.532194)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "8dad50af-b30d-4ee0-967a-eea311e064ce")
+		)
+		(fp_curve
+			(pts
+				(xy 3.585417 0.532194) (xy 3.567425 0.406606) (xy 3.558253 0.279958) (xy 3.560017 0.152958)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "7aad59c5-5af0-42e1-9f39-83d2c36eacc9")
+		)
+		(fp_curve
+			(pts
+				(xy 3.585064 -0.561417) (xy 3.58718 -0.878917) (xy 3.582947 -1.196417) (xy 3.586828 -1.514269)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "80b4067c-ba69-431d-8ad9-50299c6da5a5")
+		)
+		(fp_curve
+			(pts
+				(xy 3.560017 0.152958) (xy 3.6468 0.154722) (xy 3.734642 0.161425) (xy 3.821072 0.147667)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "649da55e-5d8b-43ce-8659-023ca42b2fcc")
+		)
+		(fp_curve
+			(pts
+				(xy 3.560017 0.152958) (xy 3.558605 0.041481) (xy 3.558605 -0.07035) (xy 3.560017 -0.18218)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a357ccab-6b03-4471-947b-b1c5d4cb0716")
+		)
+		(fp_curve
+			(pts
+				(xy 3.560017 -0.18218) (xy 3.558253 -0.30918) (xy 3.566719 -0.435828) (xy 3.585064 -0.561417)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "88810552-46ea-4c7e-a639-7053f4cab6c5")
+		)
+		(fp_curve
+			(pts
+				(xy 3.560017 -0.18218) (xy 3.558605 -0.07035) (xy 3.558605 0.041481) (xy 3.560017 0.152958)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "08634710-b45a-4b3e-8870-6275a71f2748")
+		)
+		(fp_curve
+			(pts
+				(xy 3.487344 1.844175) (xy 3.579772 1.780322) (xy 3.57695 1.656145) (xy 3.586475 1.555603)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "4fe0d1be-b6e9-4934-9588-2892bc5a8303")
+		)
+		(fp_curve
+			(pts
+				(xy 3.487344 0.002675) (xy 3.483817 0.182592) (xy 3.256275 0.303947) (xy 3.096466 0.245386)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "f28f5e94-1b36-434f-ab57-004ba76fe42f")
+		)
+		(fp_curve
+			(pts
+				(xy 3.487344 0.002675) (xy 3.516272 -0.2291) (xy 3.165964 -0.392789) (xy 3.010036 -0.213578)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "b71cf967-3036-43f2-b9c0-d1d659a4d7d3")
+		)
+		(fp_curve
+			(pts
+				(xy 3.451714 -1.883275) (xy 3.320128 -1.913261) (xy 3.182897 -1.894917) (xy 3.048842 -1.898444)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "922d5581-988d-45db-af6d-d8451d39f506")
+		)
+		(fp_curve
+			(pts
+				(xy 3.096466 0.245386) (xy 3.256275 0.303947) (xy 3.483817 0.182592) (xy 3.487344 0.002675)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "2ef3f25f-a090-4ef7-9fec-b45a2f716241")
+		)
+		(fp_curve
+			(pts
+				(xy 3.096466 0.245386) (xy 2.919019 0.174478) (xy 2.86328 -0.085167) (xy 3.010036 -0.213578)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a1be77ba-e49b-412f-959f-18b6d624eed0")
+		)
+		(fp_curve
+			(pts
+				(xy 3.048842 -1.898444) (xy 2.950769 -1.906911) (xy 2.833294 -1.831769) (xy 2.849522 -1.723467)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "e58064ba-70af-4595-ae61-7de59293e07d")
+		)
+		(fp_curve
+			(pts
+				(xy 3.010036 -0.213578) (xy 3.165964 -0.392789) (xy 3.516272 -0.2291) (xy 3.487344 0.002675)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "acad2b67-99be-43f6-b3a1-26069c98d301")
+		)
+		(fp_curve
+			(pts
+				(xy 3.010036 -0.213578) (xy 2.86328 -0.085167) (xy 2.919019 0.174478) (xy 3.096466 0.245386)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "93a02bc6-8906-4025-ada9-6e92899e8e45")
+		)
+		(fp_curve
+			(pts
+				(xy 2.972289 1.885097) (xy 3.141269 1.903795) (xy 3.341647 1.965178) (xy 3.487344 1.844175)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "8c757832-dd3d-47e8-a125-248dc1a152e5")
+		)
+		(fp_curve
+			(pts
+				(xy 2.849522 -1.723467) (xy 2.848464 -1.281789) (xy 2.853403 -0.840111) (xy 2.847758 -0.398786)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "bfa35b7c-b83a-436d-baff-df66b9183500")
+		)
+		(fp_curve
+			(pts
+				(xy 2.847758 -0.398786) (xy 2.506269 -0.388555) (xy 2.16478 -0.395964) (xy 1.823292 -0.3942)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "eacb197d-ca98-42d1-8b36-1a8d7f6e8f7a")
+		)
+		(fp_curve
+			(pts
+				(xy 2.82765 1.553133) (xy 2.807189 1.6759) (xy 2.841761 1.838883) (xy 2.972289 1.885097)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "44d8cd0e-8b58-487d-bf67-ce57763b36e8")
+		)
+		(fp_curve
+			(pts
+				(xy 2.826592 0.367447) (xy 2.828355 0.762558) (xy 2.82518 1.158022) (xy 2.82765 1.553133)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "f7ca421b-44e4-4888-8702-c0af413e5936")
+		)
+		(fp_curve
+			(pts
+				(xy 1.907605 1.342172) (xy 1.903725 1.241278) (xy 1.926303 1.118158) (xy 1.827525 1.052895)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ea54b43d-d8e0-4a2a-89d0-7657a040d297")
+		)
+		(fp_curve
+			(pts
+				(xy 1.900903 1.8283) (xy 1.914661 1.666728) (xy 1.903019 1.504097) (xy 1.907605 1.342172)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "481dbf23-3118-41e4-9ea9-ebc584295573")
+		)
+		(fp_curve
+			(pts
+				(xy 1.877267 -1.760508) (xy 1.882205 -1.887508) (xy 1.765436 -2.003219) (xy 1.638789 -1.999339)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ddcb4557-eb3c-46fa-9dc6-4a90658359c0")
+		)
+		(fp_curve
+			(pts
+				(xy 1.827525 1.692481) (xy 1.835992 1.479403) (xy 1.828936 1.265972) (xy 1.827525 1.052895)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "2780655d-e5ca-432e-8aab-55ffd2839abd")
+		)
+		(fp_curve
+			(pts
+				(xy 1.827525 1.692481) (xy 1.823644 1.823008) (xy 1.696292 1.929195) (xy 1.568233 1.92355)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "978445a4-0557-4c99-9f0d-8543a1605f34")
+		)
+		(fp_curve
+			(pts
+				(xy 1.827525 1.052895) (xy 1.828936 1.265972) (xy 1.835992 1.479403) (xy 1.827525 1.692481)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "16d1dc61-56b3-48f9-b9de-d4b27d14d0cd")
+		)
+		(fp_curve
+			(pts
+				(xy 1.827525 1.052895) (xy 1.82188 0.823942) (xy 1.822939 0.594989) (xy 1.824703 0.366036)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0348f91d-7458-4341-94a2-43d4b0b1c140")
+		)
+		(fp_curve
+			(pts
+				(xy 1.824703 0.366036) (xy 2.15843 0.36392) (xy 2.492511 0.361803) (xy 2.826592 0.367447)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0079b1f7-597b-41bb-9314-b125144afbca")
+		)
+		(fp_curve
+			(pts
+				(xy 1.823292 -0.3942) (xy 1.823292 -0.624211) (xy 1.825408 -0.853869) (xy 1.822939 -1.08388)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "264a35fa-76a7-49ad-a910-ccde1cc920e8")
+		)
+		(fp_curve
+			(pts
+				(xy 1.822939 -1.08388) (xy 1.916778 -1.296958) (xy 1.875503 -1.535436) (xy 1.877267 -1.760508)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "f16a2333-4f9f-4823-adf7-6189e7ff8eb3")
+		)
+		(fp_curve
+			(pts
+				(xy 1.822939 -1.08388) (xy 1.816589 -1.284964) (xy 1.839519 -1.487458) (xy 1.814119 -1.687836)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "18beaf1a-d8b4-4873-90b8-818319ddebd2")
+		)
+		(fp_curve
+			(pts
+				(xy 1.814119 -1.687836) (xy 1.839519 -1.487458) (xy 1.816589 -1.284964) (xy 1.822939 -1.08388)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "450d7683-6b91-40c6-947b-a3ca4af5a488")
+		)
+		(fp_curve
+			(pts
+				(xy 1.814119 -1.687836) (xy 1.801419 -1.842) (xy 1.647961 -1.951714) (xy 1.499089 -1.94748)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "9d95a6f2-fad4-43e9-a778-d99f02fbc915")
+		)
+		(fp_curve
+			(pts
+				(xy 1.725572 1.519267) (xy 1.739683 1.668492) (xy 1.613742 1.817364) (xy 1.461694 1.815953)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "3e4fd603-3b0b-47ba-bc6e-022d83eb7764")
+		)
+		(fp_curve
+			(pts
+				(xy 1.725572 1.519267) (xy 1.73933 1.366514) (xy 1.558355 1.279378) (xy 1.427122 1.286081)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c9d755d0-f481-4b2f-b9b9-15eb4af7bd92")
+		)
+		(fp_curve
+			(pts
+				(xy 1.724867 -1.583061) (xy 1.763319 -1.378097) (xy 1.493797 -1.263444) (xy 1.330461 -1.336117)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "79ac9d5b-7b02-4daf-b82a-d3f58edb40b2")
+		)
+		(fp_curve
+			(pts
+				(xy 1.724867 -1.583061) (xy 1.726983 -1.805311) (xy 1.426769 -1.932664) (xy 1.26555 -1.782733)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "2b54ea83-44d6-4456-b754-ab44552e3fa9")
+		)
+		(fp_curve
+			(pts
+				(xy 1.676183 1.998692) (xy 1.778842 2.006806) (xy 1.889614 1.934839) (xy 1.900903 1.8283)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ac0d1e61-7e2a-4b40-a15b-a2179af49376")
+		)
+		(fp_curve
+			(pts
+				(xy 1.638789 -1.999339) (xy 1.359036 -2.004631) (xy 1.079283 -1.999339) (xy 0.799178 -2.002867)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d8c16132-42a6-4857-ad9e-fed39085cee7")
+		)
+		(fp_curve
+			(pts
+				(xy 1.568233 1.92355) (xy 1.696292 1.929195) (xy 1.823644 1.823008) (xy 1.827525 1.692481)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0acfcc66-16e5-4af1-9c35-0ae552fa03cb")
+		)
+		(fp_curve
+			(pts
+				(xy 1.568233 1.92355) (xy 1.398547 1.929547) (xy 1.163597 1.960945) (xy 1.087044 1.764095)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "09bf51ab-af5c-4268-9d77-ac865736510a")
+		)
+		(fp_curve
+			(pts
+				(xy 1.499089 -1.94748) (xy 1.647961 -1.951714) (xy 1.801419 -1.842) (xy 1.814119 -1.687836)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "43ab5071-35ba-4cf0-b87d-3523ed8182c4")
+		)
+		(fp_curve
+			(pts
+				(xy 1.499089 -1.94748) (xy 1.338575 -1.959475) (xy 1.122675 -1.920669) (xy 1.0687 -1.744633)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "b3938513-97df-418c-86e9-c873466ef1e9")
+		)
+		(fp_curve
+			(pts
+				(xy 1.461694 1.815953) (xy 1.613742 1.817364) (xy 1.739683 1.668492) (xy 1.725572 1.519267)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "1fd9fc70-1919-40da-a5de-6d3817a385c6")
+		)
+		(fp_curve
+			(pts
+				(xy 1.461694 1.815953) (xy 1.378792 1.824772) (xy 1.31 1.773267) (xy 1.234153 1.749983)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "27544092-b3d3-46da-8c9c-fa51fbbfa4ed")
+		)
+		(fp_curve
+			(pts
+				(xy 1.427122 1.286081) (xy 1.558355 1.279378) (xy 1.73933 1.366514) (xy 1.725572 1.519267)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0b3ea0b9-7065-44fb-9c60-25f8d343f630")
+		)
+		(fp_curve
+			(pts
+				(xy 1.427122 1.286081) (xy 1.307178 1.295606) (xy 1.14878 1.378508) (xy 1.164303 1.519267)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "3ec2a957-6329-4f02-b646-0b95298243a1")
+		)
+		(fp_curve
+			(pts
+				(xy 1.330461 -1.336117) (xy 1.493797 -1.263444) (xy 1.763319 -1.378097) (xy 1.724867 -1.583061)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "b0c97deb-c463-4a16-8c0c-c677a005f90c")
+		)
+		(fp_curve
+			(pts
+				(xy 1.330461 -1.336117) (xy 1.126908 -1.387622) (xy 1.112444 -1.667022) (xy 1.26555 -1.782733)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "3daf76a3-34db-4734-b79e-ddea375f47d6")
+		)
+		(fp_curve
+			(pts
+				(xy 1.26555 -1.782733) (xy 1.426769 -1.932664) (xy 1.726983 -1.805311) (xy 1.724867 -1.583061)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0bfe98e5-9008-4851-b72f-a697f999fb4a")
+		)
+		(fp_curve
+			(pts
+				(xy 1.26555 -1.782733) (xy 1.112444 -1.667022) (xy 1.126908 -1.387622) (xy 1.330461 -1.336117)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "1a257069-c455-40e8-8158-964ed8055020")
+		)
+		(fp_curve
+			(pts
+				(xy 1.234153 1.749983) (xy 1.31 1.773267) (xy 1.378792 1.824772) (xy 1.461694 1.815953)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a89f6e18-1f26-40a4-a7c8-f926f7ee746e")
+		)
+		(fp_curve
+			(pts
+				(xy 1.234153 1.749983) (xy 1.200992 1.677311) (xy 1.163244 1.600758) (xy 1.164303 1.519267)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "90c0ba00-65f8-4ca1-8af8-0d65678ba9ec")
+		)
+		(fp_curve
+			(pts
+				(xy 1.164303 1.519267) (xy 1.14878 1.378508) (xy 1.307178 1.295606) (xy 1.427122 1.286081)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "12110caa-98f5-4d98-8efe-4b2616c18422")
+		)
+		(fp_curve
+			(pts
+				(xy 1.164303 1.519267) (xy 1.163244 1.600758) (xy 1.200992 1.677311) (xy 1.234153 1.749983)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "aefa1753-6a3c-4f43-a1f6-de8d73c60b6c")
+		)
+		(fp_curve
+			(pts
+				(xy 1.087044 1.764095) (xy 1.163597 1.960945) (xy 1.398547 1.929547) (xy 1.568233 1.92355)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ca83d6c8-f68b-4d54-8e41-9cca5e8de7dd")
+		)
+		(fp_curve
+			(pts
+				(xy 1.087044 1.764095) (xy 1.02813 1.539728) (xy 1.070111 1.300897) (xy 1.062703 1.070886)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "b393ce35-a70f-40e8-b46d-89339e11b237")
+		)
+		(fp_curve
+			(pts
+				(xy 1.0687 -1.744633) (xy 1.122675 -1.920669) (xy 1.338575 -1.959475) (xy 1.499089 -1.94748)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "b97f1b21-c64c-4e34-8f43-154e477eb611")
+		)
+		(fp_curve
+			(pts
+				(xy 1.0687 -1.744633) (xy 1.046122 -1.53085) (xy 1.062703 -1.314597) (xy 1.063055 -1.100108)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "835f8967-e05d-4c0d-9a8d-b5dda7d95d4d")
+		)
+		(fp_curve
+			(pts
+				(xy 1.063055 -1.100108) (xy 1.062703 -1.314597) (xy 1.046122 -1.53085) (xy 1.0687 -1.744633)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "de6159cc-aae5-4192-815d-3b6428a70758")
+		)
+		(fp_curve
+			(pts
+				(xy 1.063055 -1.100108) (xy 1.067994 -0.376561) (xy 1.068347 0.347339) (xy 1.062703 1.070886)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "86bb744c-4463-4b9e-bb47-f58ddd3c2cf7")
+		)
+		(fp_curve
+			(pts
+				(xy 1.062703 1.070886) (xy 1.070111 1.300897) (xy 1.02813 1.539728) (xy 1.087044 1.764095)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "3488991c-6055-46b2-b03d-ab8734fdbfde")
+		)
+		(fp_curve
+			(pts
+				(xy 1.062703 1.070886) (xy 0.974508 1.070533) (xy 0.886667 1.069828) (xy 0.798472 1.068417)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "abab44ad-0821-43ae-99d7-f95a35f3f247")
+		)
+		(fp_curve
+			(pts
+				(xy 0.799178 -2.002867) (xy 0.797061 -1.701242) (xy 0.798119 -1.399264) (xy 0.798472 -1.097639)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6b925535-7d3d-4015-bff2-49f96cf4aee7")
+		)
+		(fp_curve
+			(pts
+				(xy 0.799178 -2.002867) (xy 0.798825 -2.116461) (xy 0.796708 -2.229703) (xy 0.79565 -2.343297)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "f7fa6c92-db63-472f-84fe-23d2d38f4356")
+		)
+		(fp_curve
+			(pts
+				(xy 0.798472 2.0061) (xy 1.090925 1.994811) (xy 1.38373 1.997633) (xy 1.676183 1.998692)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0ae85f53-5b4e-4afd-bf2c-8b0db9bffd70")
+		)
+		(fp_curve
+			(pts
+				(xy 0.798472 2.0061) (xy 0.797767 1.693539) (xy 0.797767 1.380978) (xy 0.798472 1.068417)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "1ac4db04-a96a-464f-bdd0-1c5836fde173")
+		)
+		(fp_curve
+			(pts
+				(xy 0.798472 1.068417) (xy 0.797767 1.380978) (xy 0.797767 1.693539) (xy 0.798472 2.0061)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a08cd57f-dc09-4559-b619-34debdb01472")
+		)
+		(fp_curve
+			(pts
+				(xy 0.798472 1.068417) (xy 0.798472 0.346281) (xy 0.798472 -0.375503) (xy 0.798472 -1.097639)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d9ca188d-51d7-403c-8c5a-c42e673ff0ba")
+		)
+		(fp_curve
+			(pts
+				(xy 0.798472 -1.097639) (xy 0.886667 -1.09905) (xy 0.974861 -1.099755) (xy 1.063055 -1.100108)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "bd5ee997-e7f8-4015-bf82-90c7912ddb71")
+		)
+		(fp_curve
+			(pts
+				(xy 0.798472 -1.097639) (xy 0.798119 -1.399264) (xy 0.797061 -1.701242) (xy 0.799178 -2.002867)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c3999004-f6a6-4832-b568-93cb60f02804")
+		)
+		(fp_curve
+			(pts
+				(xy 0.79565 2.314075) (xy 0.796708 2.211417) (xy 0.797767 2.108758) (xy 0.798472 2.0061)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a305fcc8-5f1a-4478-9950-3064a5b465ef")
+		)
+		(fp_curve
+			(pts
+				(xy 0.79565 2.314075) (xy 0.675705 2.314075) (xy 0.555408 2.314428) (xy 0.435464 2.315133)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "fa94af41-c843-4315-9255-a14d9ce0716a")
+		)
+		(fp_curve
+			(pts
+				(xy 0.79565 -2.343297) (xy 1.821528 -2.349647) (xy 2.847758 -2.335889) (xy 3.873283 -2.35)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "7591c6b7-a0fb-4d2a-b5ec-49febabc9a7e")
+		)
+		(fp_curve
+			(pts
+				(xy 0.79565 -2.343297) (xy 0.675353 -2.343297) (xy 0.555408 -2.34365) (xy 0.435111 -2.344355)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0cb6e60b-e624-4ec0-9ab3-3c7af8d7f761")
+		)
+		(fp_curve
+			(pts
+				(xy 0.435817 -0.210403) (xy 0.137014 -0.170186) (xy -0.1632 -0.215342) (xy -0.462708 -0.212519)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "713464f9-47ef-4404-aa7e-20b98786a9bd")
+		)
+		(fp_curve
+			(pts
+				(xy 0.435464 2.315133) (xy 0.555408 2.314428) (xy 0.675705 2.314075) (xy 0.79565 2.314075)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "84616868-a678-4066-b8a2-3fca4fb13474")
+		)
+		(fp_curve
+			(pts
+				(xy 0.435464 2.315133) (xy 0.347269 2.315486) (xy 0.258722 2.315486) (xy 0.170528 2.315486)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "f060bcb5-ae1c-463d-96df-2aa84e327098")
+		)
+		(fp_curve
+			(pts
+				(xy 0.435464 -1.098344) (xy 0.43758 -0.802364) (xy 0.438639 -0.506383) (xy 0.435817 -0.210403)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "83f63420-f696-44fa-8a07-50e39965b802")
+		)
+		(fp_curve
+			(pts
+				(xy 0.435464 -1.098344) (xy 0.435464 -1.410553) (xy 0.435111 -1.723114) (xy 0.435464 -2.035675)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "e680c33f-58c8-48d2-9fef-c82dd23c2ebc")
+		)
+		(fp_curve
+			(pts
+				(xy 0.435464 -2.035675) (xy 0.435111 -1.723114) (xy 0.435464 -1.410553) (xy 0.435464 -1.098344)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "43c0b857-2b20-4b86-b3ee-10ebcc368c7c")
+		)
+		(fp_curve
+			(pts
+				(xy 0.435464 -2.035675) (xy 0.346211 -2.034617) (xy 0.256958 -2.034617) (xy 0.167705 -2.035675)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "2bb8240c-488a-4c4d-84af-95e037e1df35")
+		)
+		(fp_curve
+			(pts
+				(xy 0.435111 -2.344355) (xy 0.555408 -2.34365) (xy 0.675353 -2.343297) (xy 0.79565 -2.343297)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "4894e289-636e-4e1c-b604-885602d76350")
+		)
+		(fp_curve
+			(pts
+				(xy 0.435111 -2.344355) (xy 0.436169 -2.241344) (xy 0.436169 -2.138333) (xy 0.435464 -2.035675)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "69e7d637-bbb5-4bd1-87af-31d650a77ef1")
+		)
+		(fp_curve
+			(pts
+				(xy 0.434405 1.974703) (xy 0.435111 2.088297) (xy 0.436169 2.201539) (xy 0.435464 2.315133)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "18d1ad65-156f-4ac0-9a37-557726ee89d7")
+		)
+		(fp_curve
+			(pts
+				(xy 0.434405 1.974703) (xy 0.435817 1.683308) (xy 0.436169 1.391914) (xy 0.434405 1.100167)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5a3bc7c9-4265-47c4-afde-3b9ad776e9d0")
+		)
+		(fp_curve
+			(pts
+				(xy 0.434405 1.100167) (xy 0.436169 1.391914) (xy 0.435817 1.683308) (xy 0.434405 1.974703)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0760a5f2-a0f3-4272-91e7-7a39b7bf7582")
+		)
+		(fp_curve
+			(pts
+				(xy 0.434405 1.100167) (xy -0.172372 1.099461) (xy -0.778797 1.111103) (xy -1.385575 1.107928)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "b28496f2-0bd2-4270-a99e-aba05b1f16f7")
+		)
+		(fp_curve
+			(pts
+				(xy 0.429467 0.128264) (xy 0.444636 0.452114) (xy 0.435464 0.776317) (xy 0.434405 1.100167)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "3eeadef4-c4da-4557-9841-15418b222735")
+		)
+		(fp_curve
+			(pts
+				(xy 0.170528 2.315486) (xy 0.168058 2.201892) (xy 0.167705 2.088297) (xy 0.169117 1.975056)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "01e7dfbe-aad0-4722-b9b3-851b520cb6fa")
+		)
+		(fp_curve
+			(pts
+				(xy 0.170528 -2.344708) (xy 0.258722 -2.344708) (xy 0.346917 -2.344708) (xy 0.435111 -2.344355)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5f9b61b9-d237-4c28-acff-a0d9fff63078")
+		)
+		(fp_curve
+			(pts
+				(xy 0.169117 1.975056) (xy 0.257664 1.974703) (xy 0.345858 1.974703) (xy 0.434405 1.974703)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "357e5572-a919-4293-be68-ca3917213c99")
+		)
+		(fp_curve
+			(pts
+				(xy 0.169117 1.975056) (xy 0.171586 1.771856) (xy 0.172997 1.569008) (xy 0.165942 1.366161)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "f6a2d4b6-a546-4a96-aed8-8c3f822d7815")
+		)
+		(fp_curve
+			(pts
+				(xy 0.167705 -2.035675) (xy 0.166294 -2.138686) (xy 0.168411 -2.241697) (xy 0.170528 -2.344708)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "57fc5de3-db1d-4014-9634-1f1753f1891b")
+		)
+		(fp_curve
+			(pts
+				(xy 0.167705 -2.035675) (xy 0.175114 -1.810603) (xy 0.183228 -1.583061) (xy 0.131369 -1.362222)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c85d9674-c7ff-4d90-9598-608c5e05b84f")
+		)
+		(fp_curve
+			(pts
+				(xy 0.165942 1.366161) (xy 0.172997 1.569008) (xy 0.171586 1.771856) (xy 0.169117 1.975056)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "843abe7c-d1ee-419b-9ba4-962e8c4f3403")
+		)
+		(fp_curve
+			(pts
+				(xy 0.165942 1.366161) (xy 0.055875 1.339703) (xy -0.058425 1.338997) (xy -0.168492 1.366161)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "1ab890f7-903f-4f19-85d3-b4dac7f5b6c6")
+		)
+		(fp_curve
+			(pts
+				(xy 0.131369 -1.362222) (xy 0.183228 -1.583061) (xy 0.175114 -1.810603) (xy 0.167705 -2.035675)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a15b527e-65a0-4d4c-be18-a6d0b0737975")
+		)
+		(fp_curve
+			(pts
+				(xy 0.131369 -1.362222) (xy 0.042822 -1.361869) (xy -0.045725 -1.361869) (xy -0.13392 -1.362222)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "7cef0f57-5ad7-4784-b52d-5e81279d27f4")
+		)
+		(fp_curve
+			(pts
+				(xy 0.086919 -2.655505) (xy -1.19825 -2.652683) (xy -2.483772 -2.661503) (xy -3.768942 -2.651272)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "bdc28541-4d7d-4f41-9d2d-6572179e27b4")
+		)
+		(fp_curve
+			(pts
+				(xy 0.038236 -1.679722) (xy 0.184286 -1.638094) (xy 0.104911 -1.394678) (xy -0.040081 -1.45465)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "40fb8c0e-f737-4b68-a3bd-c1b8e95cc5d0")
+		)
+		(fp_curve
+			(pts
+				(xy 0.038236 -1.679722) (xy -0.104992 -1.735108) (xy -0.186484 -1.498042) (xy -0.040081 -1.45465)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "b0f64a43-02ed-42cb-9998-4600e6067f4b")
+		)
+		(fp_curve
+			(pts
+				(xy 0.037883 1.425075) (xy 0.184992 1.465292) (xy 0.104558 1.709414) (xy -0.040081 1.650147)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a2e9a1db-abce-4df0-ba4f-3776cfe070ac")
+		)
+		(fp_curve
+			(pts
+				(xy 0.037883 1.425075) (xy -0.105345 1.369336) (xy -0.186131 1.605697) (xy -0.040081 1.650147)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "3066d007-df35-4d03-80f1-59cb306bf8f5")
+		)
+		(fp_curve
+			(pts
+				(xy -0.040081 1.650147) (xy 0.104558 1.709414) (xy 0.184992 1.465292) (xy 0.037883 1.425075)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "22f177c4-1606-4fa3-b8ed-d4117b28e356")
+		)
+		(fp_curve
+			(pts
+				(xy -0.040081 1.650147) (xy -0.186131 1.605697) (xy -0.105345 1.369336) (xy 0.037883 1.425075)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "2d58a2e5-023d-470b-96ff-eaec2f0b90d8")
+		)
+		(fp_curve
+			(pts
+				(xy -0.040081 -1.45465) (xy 0.104911 -1.394678) (xy 0.184286 -1.638094) (xy 0.038236 -1.679722)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5928d939-b5bb-4a91-8f48-17bc4baf9e5a")
+		)
+		(fp_curve
+			(pts
+				(xy -0.040081 -1.45465) (xy -0.186484 -1.498042) (xy -0.104992 -1.735108) (xy 0.038236 -1.679722)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "dd6ae610-5973-4e60-a219-6a0267527d90")
+		)
+		(fp_curve
+			(pts
+				(xy -0.13392 -1.362222) (xy -0.045725 -1.361869) (xy 0.042822 -1.361869) (xy 0.131369 -1.362222)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "09d3909b-d4be-46ff-95fb-f6bc87100b2b")
+		)
+		(fp_curve
+			(pts
+				(xy -0.13392 -1.362222) (xy -0.181545 -1.579886) (xy -0.181192 -1.803547) (xy -0.175195 -2.025444)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "371d4170-f223-4e5a-8714-b7055f4924f2")
+		)
+		(fp_curve
+			(pts
+				(xy -0.168492 1.366161) (xy -0.058425 1.338997) (xy 0.055875 1.339703) (xy 0.165942 1.366161)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "1a268851-9285-40be-b2d0-b7c77becb638")
+		)
+		(fp_curve
+			(pts
+				(xy -0.168492 1.366161) (xy -0.175195 1.569008) (xy -0.173783 1.772208) (xy -0.171314 1.975408)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "736412f5-c9c2-46ce-9bef-12d5716d7a23")
+		)
+		(fp_curve
+			(pts
+				(xy -0.170961 -2.344355) (xy -0.170608 -2.238169) (xy -0.171667 -2.13163) (xy -0.175195 -2.025444)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "1ca1fb80-8255-49c2-a7b6-3309c9f7ad8c")
+		)
+		(fp_curve
+			(pts
+				(xy -0.171314 1.975408) (xy -0.173783 1.772208) (xy -0.175195 1.569008) (xy -0.168492 1.366161)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "97858d3f-af94-42c5-9b58-a886b4527b58")
+		)
+		(fp_curve
+			(pts
+				(xy -0.171314 1.975408) (xy -0.169903 2.08865) (xy -0.169903 2.201892) (xy -0.172372 2.315133)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "f1ea9eeb-48bc-439a-a569-c3e749378076")
+		)
+		(fp_curve
+			(pts
+				(xy -0.172372 2.315133) (xy -0.576656 2.316897) (xy -0.981292 2.314781) (xy -1.385575 2.314781)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "dcd8262d-ee92-4350-a3be-902d7bdcf05a")
+		)
+		(fp_curve
+			(pts
+				(xy -0.175195 -2.025444) (xy -0.181192 -1.803547) (xy -0.181545 -1.579886) (xy -0.13392 -1.362222)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "564fc606-b537-4866-bd19-64b4c855bbb1")
+		)
+		(fp_curve
+			(pts
+				(xy -0.175195 -2.025444) (xy -0.232345 -1.967589) (xy -0.316306 -1.917847) (xy -0.323361 -1.828594)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "320e43d5-80bd-4d3b-8bfc-1af8e0577add")
+		)
+		(fp_curve
+			(pts
+				(xy -0.180839 -1.114219) (xy 0.023067 -1.08635) (xy 0.230147 -1.108575) (xy 0.435464 -1.098344)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d09cf980-bf6d-4d18-b2f3-709058fd4ff0")
+		)
+		(fp_curve
+			(pts
+				(xy -0.320539 -1.308953) (xy -0.309956 -1.228519) (xy -0.273267 -1.127272) (xy -0.180839 -1.114219)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "bdb07c1c-e5d1-41b4-a296-ddfe0d147e20")
+		)
+		(fp_curve
+			(pts
+				(xy -0.323361 -1.828594) (xy -0.342411 -1.656439) (xy -0.339942 -1.481108) (xy -0.320539 -1.308953)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "e08d96f1-aed1-441b-9175-cf52cb058967")
+		)
+		(fp_curve
+			(pts
+				(xy -0.435897 -0.737805) (xy -0.444364 -1.083528) (xy -0.414731 -1.432072) (xy -0.470822 -1.775325)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "2c04f1b9-a831-45fc-97ad-9aa9cbaf1672")
+		)
+		(fp_curve
+			(pts
+				(xy -0.44507 1.659672) (xy -0.4172 1.492456) (xy -0.436956 1.281847) (xy -0.591825 1.1806)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ebdf4cf2-d700-424f-8457-1895cd32f15a")
+		)
+		(fp_curve
+			(pts
+				(xy -0.44507 1.659672) (xy -0.457417 1.785261) (xy -0.562545 1.896386) (xy -0.689545 1.907675)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "867282ed-0309-4d3a-8081-76d927a0b34b")
+		)
+		(fp_curve
+			(pts
+				(xy -0.452125 0.127206) (xy -0.158261 0.131086) (xy 0.135603 0.130028) (xy 0.429467 0.128264)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ab15d6b3-e3df-468f-b3be-f8f3c168f2e6")
+		)
+		(fp_curve
+			(pts
+				(xy -0.452125 0.127206) (xy -0.457064 0.013964) (xy -0.463414 -0.099278) (xy -0.462708 -0.212519)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "7c8452db-ab34-40be-a8aa-ed341af80702")
+		)
+		(fp_curve
+			(pts
+				(xy -0.462708 -0.212519) (xy -0.466236 -0.388203) (xy -0.453889 -0.56318) (xy -0.435897 -0.737805)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6501fa72-3e33-43f6-9d70-ea9fa8c0bc43")
+		)
+		(fp_curve
+			(pts
+				(xy -0.462708 -0.212519) (xy -0.463414 -0.099278) (xy -0.457064 0.013964) (xy -0.452125 0.127206)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "48ddf6c5-006f-44dc-b63f-6c44e0eeeb0d")
+		)
+		(fp_curve
+			(pts
+				(xy -0.470822 -1.775325) (xy -0.514214 -1.843764) (xy -0.576656 -1.914319) (xy -0.66097 -1.926667)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a9f8cce0-eb5a-45ed-b8d8-b780e2ffa1ba")
+		)
+		(fp_curve
+			(pts
+				(xy -0.580536 -0.129617) (xy -0.520564 0.011495) (xy -0.590414 0.19247) (xy -0.729056 0.257381)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ab91bb4b-2080-4235-8fd6-81ac2c5bfda6")
+		)
+		(fp_curve
+			(pts
+				(xy -0.580536 -0.129617) (xy -0.665203 -0.294364) (xy -0.936136 -0.340578) (xy -1.045497 -0.176536)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "7e24ac9e-dcc0-404e-8dd2-922ec5d1e286")
+		)
+		(fp_curve
+			(pts
+				(xy -0.591825 1.1806) (xy -0.436956 1.281847) (xy -0.4172 1.492456) (xy -0.44507 1.659672)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "43334e0b-d192-43f9-8825-b16bbb29076f")
+		)
+		(fp_curve
+			(pts
+				(xy -0.591825 1.1806) (xy -0.845472 1.069828) (xy -1.12205 1.166136) (xy -1.386633 1.154847)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c8ee67f6-ce7f-4a98-aed2-65c90d8d30c9")
+		)
+		(fp_curve
+			(pts
+				(xy -0.66097 -1.926667) (xy -0.863817 -1.964767) (xy -1.07125 -1.937603) (xy -1.276214 -1.946775)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "7862d73a-9250-4dc2-b7c4-a5587f3f3469")
+		)
+		(fp_curve
+			(pts
+				(xy -0.689545 1.907675) (xy -0.562545 1.896386) (xy -0.457417 1.785261) (xy -0.44507 1.659672)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5eca8a84-18da-4c1e-ba65-5e129f267f3a")
+		)
+		(fp_curve
+			(pts
+				(xy -0.689545 1.907675) (xy -0.921672 1.935897) (xy -1.155917 1.912967) (xy -1.388045 1.896739)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "24ba3f93-373c-4383-b571-481a3b1a4171")
+		)
+		(fp_curve
+			(pts
+				(xy -0.723058 0.357217) (xy -0.590414 0.357922) (xy -0.483522 0.251031) (xy -0.452125 0.127206)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0987526d-827b-4108-858c-86a6ecba7073")
+		)
+		(fp_curve
+			(pts
+				(xy -0.729056 0.257381) (xy -0.590414 0.19247) (xy -0.520564 0.011495) (xy -0.580536 -0.129617)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "407f1c69-64b3-471b-be33-cb316b83eaeb")
+		)
+		(fp_curve
+			(pts
+				(xy -0.729056 0.257381) (xy -0.833125 0.290189) (xy -0.931903 0.237978) (xy -1.025036 0.19882)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "1fab5236-ac00-4f6f-8a11-da7f5b891f2d")
+		)
+		(fp_curve
+			(pts
+				(xy -1.025036 0.19882) (xy -0.931903 0.237978) (xy -0.833125 0.290189) (xy -0.729056 0.257381)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6f879fd8-aeb7-4d1d-9856-378446d4af3a")
+		)
+		(fp_curve
+			(pts
+				(xy -1.025036 0.19882) (xy -1.075483 0.083108) (xy -1.1411 -0.064) (xy -1.045497 -0.176536)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "3b4b5469-02f7-46ad-837b-205f907d0807")
+		)
+		(fp_curve
+			(pts
+				(xy -1.045497 -0.176536) (xy -0.936136 -0.340578) (xy -0.665203 -0.294364) (xy -0.580536 -0.129617)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "058d1f4c-2cea-44e5-88ae-ce9e7dc0500e")
+		)
+		(fp_curve
+			(pts
+				(xy -1.045497 -0.176536) (xy -1.1411 -0.064) (xy -1.075483 0.083108) (xy -1.025036 0.19882)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c2b32662-d091-4ee2-a717-0b119cb1e182")
+		)
+		(fp_curve
+			(pts
+				(xy -1.196839 -1.169605) (xy -1.195781 -0.908197) (xy -1.190842 -0.646789) (xy -1.201072 -0.385733)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6a9a0fff-45ca-4e87-ae0b-a7f05148837f")
+		)
+		(fp_curve
+			(pts
+				(xy -1.201072 -0.385733) (xy -1.258928 -0.380089) (xy -1.316431 -0.374444) (xy -1.374286 -0.371622)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "884d0e5c-8e6a-43d0-84c1-7740de752281")
+		)
+		(fp_curve
+			(pts
+				(xy -1.276214 -1.946775) (xy -1.542561 -2.024386) (xy -1.820903 -2.000397) (xy -2.094658 -2.002514)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ce7eeed4-52e3-4561-b51c-d6c48c6a0cd4")
+		)
+		(fp_curve
+			(pts
+				(xy -1.276214 -1.946775) (xy -1.549617 -1.942894) (xy -1.823372 -1.955947) (xy -2.09607 -1.925608)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "9bd17b8c-87fb-41c4-b6d3-face583a53c3")
+		)
+		(fp_curve
+			(pts
+				(xy -1.304789 -1.152319) (xy -1.277978 -1.156553) (xy -1.224003 -1.165372) (xy -1.196839 -1.169605)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "546648c2-6fbe-498e-9e3b-b7fe2988f8f0")
+		)
+		(fp_curve
+			(pts
+				(xy -1.304789 -1.152319) (xy -1.565845 -1.202414) (xy -1.832545 -1.174897) (xy -2.096422 -1.185833)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a850b0f7-698a-43d1-af3d-d84c94be602c")
+		)
+		(fp_curve
+			(pts
+				(xy -1.330542 -1.716411) (xy -1.17285 -1.52838) (xy -1.399686 -1.196417) (xy -1.633225 -1.301544)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "452fdde9-0fcc-4567-a61e-722dd97f9779")
+		)
+		(fp_curve
+			(pts
+				(xy -1.330542 -1.716411) (xy -1.407095 -1.879747) (xy -1.680497 -1.905853) (xy -1.75705 -1.730875)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "601bd24a-4146-46be-bb98-6882a3b4d11c")
+		)
+		(fp_curve
+			(pts
+				(xy -1.374286 -0.371622) (xy -1.392983 -0.477455) (xy -1.414503 -0.582936) (xy -1.436022 -0.688417)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "3e31aa09-e586-46e1-8906-166031780ae6")
+		)
+		(fp_curve
+			(pts
+				(xy -1.374286 -0.371622) (xy -1.761636 -0.365978) (xy -2.149339 -0.373386) (xy -2.536689 -0.368094)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d99596ca-a1f3-4d4f-bc7b-e0e74ee55f43")
+		)
+		(fp_curve
+			(pts
+				(xy -1.38487 0.352983) (xy -1.165089 0.370975) (xy -0.943192 0.371328) (xy -0.723058 0.357217)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "57d89a2d-d6b2-4d69-902e-6a1bec82d274")
+		)
+		(fp_curve
+			(pts
+				(xy -1.38487 0.352983) (xy -1.486822 0.343106) (xy -1.589481 0.339931) (xy -1.691786 0.340989)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "34d0370c-0ba0-4552-80ce-bdbe296d6fec")
+		)
+		(fp_curve
+			(pts
+				(xy -1.385575 2.314781) (xy -1.383811 2.201186) (xy -1.382753 2.087945) (xy -1.385928 1.97435)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "7067e29d-47d9-46a1-8cc1-8ff3ce6de4af")
+		)
+		(fp_curve
+			(pts
+				(xy -1.385575 2.314781) (xy -1.496347 2.314428) (xy -1.606767 2.314075) (xy -1.717539 2.314075)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "aa5898a1-ea5e-4ad1-bcb2-507139fafe4f")
+		)
+		(fp_curve
+			(pts
+				(xy -1.385575 1.107928) (xy -1.380636 0.856045) (xy -1.383458 0.604514) (xy -1.38487 0.352983)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "7b802dfa-c6fd-4a61-bafb-70154f3fdfe1")
+		)
+		(fp_curve
+			(pts
+				(xy -1.385928 1.97435) (xy -0.980939 1.968706) (xy -0.57595 1.969411) (xy -0.171314 1.975408)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "8426fdd7-9e79-4d10-ad9e-2bdfc74923c4")
+		)
+		(fp_curve
+			(pts
+				(xy -1.385928 1.97435) (xy -1.386281 1.954947) (xy -1.387692 1.916142) (xy -1.388045 1.896739)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "4846ef46-0959-4101-a3ae-0833bca5441e")
+		)
+		(fp_curve
+			(pts
+				(xy -1.386633 1.154847) (xy -1.12205 1.166136) (xy -0.845472 1.069828) (xy -0.591825 1.1806)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "55fd7f7d-6e0f-417e-9057-a059c00299a2")
+		)
+		(fp_curve
+			(pts
+				(xy -1.386633 1.154847) (xy -1.490703 1.156258) (xy -1.595125 1.153436) (xy -1.699195 1.154142)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "7856d3a0-7895-4a0f-b0ee-4bfceecc5297")
+		)
+		(fp_curve
+			(pts
+				(xy -1.388045 1.896739) (xy -1.155917 1.912967) (xy -0.921672 1.935897) (xy -0.689545 1.907675)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "59de930b-f77b-4c9d-a5c3-e558d45f8697")
+		)
+		(fp_curve
+			(pts
+				(xy -1.388045 1.896739) (xy -1.387692 1.916142) (xy -1.386281 1.954947) (xy -1.385928 1.97435)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "630f2ec5-5f23-40ed-8000-b1fb43df395c")
+		)
+		(fp_curve
+			(pts
+				(xy -1.388045 1.896739) (xy -1.496347 1.892153) (xy -1.60465 1.892153) (xy -1.7126 1.896386)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "eef61362-7dc0-4f6c-b04b-6ca2b2b3e700")
+		)
+		(fp_curve
+			(pts
+				(xy -1.436022 -0.688417) (xy -1.654039 -0.712758) (xy -1.873114 -0.712053) (xy -2.092189 -0.709936)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "db16ab52-bded-4b25-9c89-d5223fc2191d")
+		)
+		(fp_curve
+			(pts
+				(xy -1.633225 -1.301544) (xy -1.399686 -1.196417) (xy -1.17285 -1.52838) (xy -1.330542 -1.716411)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "3ce8d9b1-da7d-4cab-bb83-8b5a1358c5e1")
+		)
+		(fp_curve
+			(pts
+				(xy -1.633225 -1.301544) (xy -1.794445 -1.371394) (xy -1.859003 -1.58553) (xy -1.75705 -1.730875)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a64ebdeb-c859-48aa-a54b-76c6dbad8f07")
+		)
+		(fp_curve
+			(pts
+				(xy -1.691786 0.340989) (xy -1.589481 0.339931) (xy -1.486822 0.343106) (xy -1.38487 0.352983)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c2e7d3f1-a81b-4199-86f9-4f290520d868")
+		)
+		(fp_curve
+			(pts
+				(xy -1.691786 0.340989) (xy -1.699547 0.60522) (xy -1.69355 0.869097) (xy -1.698842 1.132975)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "69074335-0dc1-48ec-9289-89d13afe1a96")
+		)
+		(fp_curve
+			(pts
+				(xy -1.698842 1.132975) (xy -1.747878 1.104047) (xy -1.808203 1.101578) (xy -1.861825 1.115689)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "11f3570a-2156-415c-a71b-94c43ee652e1")
+		)
+		(fp_curve
+			(pts
+				(xy -1.699195 1.154142) (xy -1.595125 1.153436) (xy -1.490703 1.156258) (xy -1.386633 1.154847)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "3ef8d790-4cef-4439-a88e-4d1b5a4585b7")
+		)
+		(fp_curve
+			(pts
+				(xy -1.699195 1.154142) (xy -1.750347 1.15132) (xy -1.840658 1.178131) (xy -1.861825 1.115689)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "e2ea0902-a755-4c13-b90e-44acb4e74596")
+		)
+		(fp_curve
+			(pts
+				(xy -1.7126 1.896386) (xy -1.60465 1.892153) (xy -1.496347 1.892153) (xy -1.388045 1.896739)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "753288da-39e9-4858-9ae8-08c403976508")
+		)
+		(fp_curve
+			(pts
+				(xy -1.7126 1.896386) (xy -1.714364 1.914731) (xy -1.717186 1.95142) (xy -1.71895 1.969764)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "32008281-ee7b-4988-bf44-46de3eb24ac5")
+		)
+		(fp_curve
+			(pts
+				(xy -1.7126 1.896386) (xy -1.946845 1.912967) (xy -2.183206 1.934839) (xy -2.41745 1.90697)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "2bbc2d57-2a13-4c4a-b84f-0064a65a6681")
+		)
+		(fp_curve
+			(pts
+				(xy -1.717539 2.314075) (xy -1.606767 2.314075) (xy -1.496347 2.314428) (xy -1.385575 2.314781)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ee11544a-e80d-4aa6-842d-d8c24f4ea67e")
+		)
+		(fp_curve
+			(pts
+				(xy -1.717539 2.314075) (xy -2.256583 2.315486) (xy -2.795981 2.315839) (xy -3.335025 2.314428)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "7ce4128b-819f-4637-9635-173f404b21d0")
+		)
+		(fp_curve
+			(pts
+				(xy -1.71895 1.969764) (xy -1.717186 1.95142) (xy -1.714364 1.914731) (xy -1.7126 1.896386)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c789dcee-968d-46ad-aaaf-6f89f0cc5510")
+		)
+		(fp_curve
+			(pts
+				(xy -1.71895 1.969764) (xy -1.725653 2.084417) (xy -1.721067 2.199422) (xy -1.717539 2.314075)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5fcc4549-9938-4a25-bd07-1f7e792c59a1")
+		)
+		(fp_curve
+			(pts
+				(xy -1.75705 -1.730875) (xy -1.680497 -1.905853) (xy -1.407095 -1.879747) (xy -1.330542 -1.716411)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "f4f57cab-3edf-46fa-ad0d-47e718edef36")
+		)
+		(fp_curve
+			(pts
+				(xy -1.75705 -1.730875) (xy -1.859003 -1.58553) (xy -1.794445 -1.371394) (xy -1.633225 -1.301544)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "260e9094-b9ae-4e6d-b5be-dad14fd11394")
+		)
+		(fp_curve
+			(pts
+				(xy -1.861825 1.115689) (xy -1.840658 1.178131) (xy -1.750347 1.15132) (xy -1.699195 1.154142)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "7eb2f309-f5c7-4279-b859-06cd0fc512cc")
+		)
+		(fp_curve
+			(pts
+				(xy -1.861825 1.115689) (xy -1.906628 0.862042) (xy -1.875936 0.601692) (xy -1.880875 0.345222)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "bba3f12d-24c5-439b-a3d9-6f8aa7b3c704")
+		)
+		(fp_curve
+			(pts
+				(xy -1.880875 0.345222) (xy -1.817728 0.343811) (xy -1.754933 0.342047) (xy -1.691786 0.340989)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "552e866a-aac3-45d1-8e6f-515376dacbe6")
+		)
+		(fp_curve
+			(pts
+				(xy -2.04915 1.365808) (xy -1.900278 1.529497) (xy -2.041389 1.790553) (xy -2.24212 1.814895)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a6440f3c-e6e0-4c93-b0f7-6a0339a9c93f")
+		)
+		(fp_curve
+			(pts
+				(xy -2.04915 1.365808) (xy -2.1444 1.21482) (xy -2.33737 1.253625) (xy -2.470014 1.326297)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "00b02bf7-0b75-47b1-9b06-a0a91aa46999")
+		)
+		(fp_curve
+			(pts
+				(xy -2.092189 -0.709936) (xy -2.093953 -0.840817) (xy -2.0936 -0.971697) (xy -2.095364 -1.102578)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "165d9cae-4f93-4954-9680-ec8f21c72943")
+		)
+		(fp_curve
+			(pts
+				(xy -2.093953 -2.343297) (xy -1.452956 -2.345414) (xy -0.811958 -2.344708) (xy -0.170961 -2.344355)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5ee89322-3179-489e-a6c8-19e5f60b259a")
+		)
+		(fp_curve
+			(pts
+				(xy -2.093953 -2.343297) (xy -2.214956 -2.342592) (xy -2.335606 -2.342944) (xy -2.456608 -2.34365)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "021501a4-fb72-42b7-9887-017bb6d98860")
+		)
+		(fp_curve
+			(pts
+				(xy -2.094658 -2.002514) (xy -2.093247 -2.116108) (xy -2.0936 -2.229703) (xy -2.093953 -2.343297)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "8955a629-8c7e-4254-8980-b5862322d8cd")
+		)
+		(fp_curve
+			(pts
+				(xy -2.094658 -2.002514) (xy -2.095011 -1.983111) (xy -2.095717 -1.944658) (xy -2.09607 -1.925608)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0c6e54ba-d529-4957-8f32-3ee35539d47c")
+		)
+		(fp_curve
+			(pts
+				(xy -2.095364 -1.102578) (xy -1.831486 -1.115983) (xy -1.561964 -1.072944) (xy -1.304789 -1.152319)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6c825885-ccaf-408b-9c86-9cf674ac1666")
+		)
+		(fp_curve
+			(pts
+				(xy -2.095364 -1.102578) (xy -2.095717 -1.123392) (xy -2.09607 -1.165019) (xy -2.096422 -1.185833)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "30464228-4d88-4aa7-bcc6-c96c7c4886ab")
+		)
+		(fp_curve
+			(pts
+				(xy -2.09607 -1.925608) (xy -1.823372 -1.955947) (xy -1.549617 -1.942894) (xy -1.276214 -1.946775)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c94436f3-11af-408c-8f4f-af3594d1b060")
+		)
+		(fp_curve
+			(pts
+				(xy -2.09607 -1.925608) (xy -2.095717 -1.944658) (xy -2.095011 -1.983111) (xy -2.094658 -2.002514)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "04371cc1-84ea-4dce-a65a-24259d3cc297")
+		)
+		(fp_curve
+			(pts
+				(xy -2.09607 -1.925608) (xy -2.2206 -1.918553) (xy -2.345836 -1.925608) (xy -2.468956 -1.945011)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "9cd77a79-03bd-4ad0-8785-54920891f97e")
+		)
+		(fp_curve
+			(pts
+				(xy -2.096422 -1.185833) (xy -1.832545 -1.174897) (xy -1.565845 -1.202414) (xy -1.304789 -1.152319)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ce875945-a18e-4e08-b71c-d2d8c69f420d")
+		)
+		(fp_curve
+			(pts
+				(xy -2.096422 -1.185833) (xy -2.09607 -1.165019) (xy -2.095717 -1.123392) (xy -2.095364 -1.102578)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "25d6435e-63fc-4bed-849a-bdbfd900bbfd")
+		)
+		(fp_curve
+			(pts
+				(xy -2.096422 -1.185833) (xy -2.21672 -1.187597) (xy -2.337017 -1.185128) (xy -2.456608 -1.172075)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5324509a-de52-40bb-82cc-95e7c5712c3d")
+		)
+		(fp_curve
+			(pts
+				(xy -2.24212 1.814895) (xy -2.041389 1.790553) (xy -1.900278 1.529497) (xy -2.04915 1.365808)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "9d37c65d-1d23-4e83-ab99-db8a24c8fa08")
+		)
+		(fp_curve
+			(pts
+				(xy -2.24212 1.814895) (xy -2.404397 1.839236) (xy -2.560678 1.681897) (xy -2.541628 1.520678)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "dee2841c-e1a4-4b73-bf56-d733dd65a8d1")
+		)
+		(fp_curve
+			(pts
+				(xy -2.384289 1.972586) (xy -2.162392 1.968) (xy -1.940495 1.979642) (xy -1.71895 1.969764)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "25030d27-3fd5-4b65-a576-19827b722188")
+		)
+		(fp_curve
+			(pts
+				(xy -2.41745 1.90697) (xy -2.183206 1.934839) (xy -1.946845 1.912967) (xy -1.7126 1.896386)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "9343186c-622a-4690-84d3-c0619a7c5092")
+		)
+		(fp_curve
+			(pts
+				(xy -2.41745 1.90697) (xy -2.515522 1.893564) (xy -2.638995 1.839589) (xy -2.648167 1.727406)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "3806401c-5264-41f6-89fe-cc6fcfc52dc1")
+		)
+		(fp_curve
+			(pts
+				(xy -2.447083 -1.138208) (xy -2.427328 -0.995686) (xy -2.456256 -0.852458) (xy -2.460489 -0.709936)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a0f544ed-fd6b-4a60-9e24-467767d8094a")
+		)
+		(fp_curve
+			(pts
+				(xy -2.456608 -1.172075) (xy -2.337017 -1.185128) (xy -2.21672 -1.187597) (xy -2.096422 -1.185833)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "486af24e-b215-4c76-9fbe-93eb8e02fb4a")
+		)
+		(fp_curve
+			(pts
+				(xy -2.456608 -1.172075) (xy -2.517639 -1.233106) (xy -2.589606 -1.285669) (xy -2.636172 -1.359047)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "60791dc0-788a-4c73-97d0-0a5d78b20065")
+		)
+		(fp_curve
+			(pts
+				(xy -2.456608 -2.34365) (xy -2.335606 -2.342944) (xy -2.214956 -2.342592) (xy -2.093953 -2.343297)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "901888e7-58e0-424d-84b5-b02c51862b71")
+		)
+		(fp_curve
+			(pts
+				(xy -2.456608 -2.34365) (xy -2.454845 -2.230761) (xy -2.452375 -2.117519) (xy -2.458725 -2.004983)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "f15640fc-a121-458c-a9cb-cdc69ea63ad8")
+		)
+		(fp_curve
+			(pts
+				(xy -2.458725 -2.004983) (xy -2.461195 -1.989814) (xy -2.466486 -1.96018) (xy -2.468956 -1.945011)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "29335e41-2995-49b3-9b93-b239330f0b70")
+		)
+		(fp_curve
+			(pts
+				(xy -2.458725 -2.004983) (xy -2.606892 -2.003219) (xy -2.755411 -2.002867) (xy -2.903578 -2.003219)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d637b275-ea93-4e0e-b97f-54347d14a6c2")
+		)
+		(fp_curve
+			(pts
+				(xy -2.460489 -0.709936) (xy -2.660514 -0.704997) (xy -2.860539 -0.714875) (xy -3.060211 -0.707819)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "8dd3d22e-040e-4b81-b35d-bb6a6e511d0a")
+		)
+		(fp_curve
+			(pts
+				(xy -2.468956 -1.945011) (xy -2.345836 -1.925608) (xy -2.2206 -1.918553) (xy -2.09607 -1.925608)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "04b1109d-e4cf-4701-82f2-4b0f62af9444")
+		)
+		(fp_curve
+			(pts
+				(xy -2.468956 -1.945011) (xy -2.466486 -1.96018) (xy -2.461195 -1.989814) (xy -2.458725 -2.004983)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ee632c72-72e4-4b43-befc-89627ce6967d")
+		)
+		(fp_curve
+			(pts
+				(xy -2.468956 -1.945011) (xy -2.523283 -1.887508) (xy -2.594545 -1.843764) (xy -2.635114 -1.774619)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "761df52a-7f08-45e3-b7e1-0fe0706f4d7c")
+		)
+		(fp_curve
+			(pts
+				(xy -2.470014 1.326297) (xy -2.33737 1.253625) (xy -2.1444 1.21482) (xy -2.04915 1.365808)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "b7cade27-1637-4047-be80-0c759a340d27")
+		)
+		(fp_curve
+			(pts
+				(xy -2.470014 1.326297) (xy -2.492945 1.391561) (xy -2.537747 1.44977) (xy -2.541628 1.520678)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "f951a94c-cfe4-407f-aa67-67b0d0c51f7c")
+		)
+		(fp_curve
+			(pts
+				(xy -2.536689 -0.368094) (xy -2.149339 -0.373386) (xy -1.761636 -0.365978) (xy -1.374286 -0.371622)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d332cd47-457a-4c87-9ec2-f63474efd436")
+		)
+		(fp_curve
+			(pts
+				(xy -2.536689 -0.368094) (xy -2.568792 -0.297892) (xy -2.623825 -0.236861) (xy -2.640758 -0.160308)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "9eb0aeb3-8616-454a-9230-69017f0183e2")
+		)
+		(fp_curve
+			(pts
+				(xy -2.541628 1.520678) (xy -2.560678 1.681897) (xy -2.404397 1.839236) (xy -2.24212 1.814895)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "de0c5f94-4476-4423-83ee-2f8e04647503")
+		)
+		(fp_curve
+			(pts
+				(xy -2.541628 1.520678) (xy -2.537747 1.44977) (xy -2.492945 1.391561) (xy -2.470014 1.326297)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "e59e17a5-b4df-4cc6-b8b2-f62652619bf3")
+		)
+		(fp_curve
+			(pts
+				(xy -2.635114 -1.774619) (xy -2.594545 -1.843764) (xy -2.523283 -1.887508) (xy -2.468956 -1.945011)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "8c03abf3-030c-4550-a9e2-94f9d2a95c07")
+		)
+		(fp_curve
+			(pts
+				(xy -2.635114 -1.774619) (xy -2.681681 -1.641622) (xy -2.679211 -1.49275) (xy -2.636172 -1.359047)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "821827f7-7639-4594-a40a-a6ab2b4bbab5")
+		)
+		(fp_curve
+			(pts
+				(xy -2.636172 -1.359047) (xy -2.589606 -1.285669) (xy -2.517639 -1.233106) (xy -2.456608 -1.172075)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a499e64c-db97-45bf-9a23-a9332025472a")
+		)
+		(fp_curve
+			(pts
+				(xy -2.636172 -1.359047) (xy -2.679211 -1.49275) (xy -2.681681 -1.641622) (xy -2.635114 -1.774619)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a62b8560-3943-43e7-b216-869c81087dbd")
+		)
+		(fp_curve
+			(pts
+				(xy -2.640758 -0.160308) (xy -2.643228 0.25597) (xy -2.639347 0.6726) (xy -2.642522 1.088878)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "9d3b9196-41f9-417e-be6e-cfb0a8d2bec2")
+		)
+		(fp_curve
+			(pts
+				(xy -2.642522 1.088878) (xy -2.638642 1.301956) (xy -2.677447 1.515386) (xy -2.648167 1.727406)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "4d6ce7c9-6dd7-4744-b4e4-b373751ccf43")
+		)
+		(fp_curve
+			(pts
+				(xy -2.642522 1.088878) (xy -2.679564 1.131917) (xy -2.724367 1.176367) (xy -2.720133 1.238103)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "bd071b2a-bbc0-4d29-b874-9a49067cb9f0")
+		)
+		(fp_curve
+			(pts
+				(xy -2.648167 1.727406) (xy -2.638995 1.839589) (xy -2.515522 1.893564) (xy -2.41745 1.90697)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "08f0f168-8b99-4f2f-84c2-b0055ce0fb7b")
+		)
+		(fp_curve
+			(pts
+				(xy -2.648167 1.727406) (xy -2.677447 1.515386) (xy -2.638642 1.301956) (xy -2.642522 1.088878)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ac009d4c-33a8-4967-baea-b23d0a392112")
+		)
+		(fp_curve
+			(pts
+				(xy -2.719428 1.890389) (xy -2.6143 1.939072) (xy -2.502117 1.978936) (xy -2.384289 1.972586)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "8914731f-6975-4654-9617-58a406de82f4")
+		)
+		(fp_curve
+			(pts
+				(xy -2.720133 1.238103) (xy -2.730364 1.455414) (xy -2.719781 1.673078) (xy -2.719428 1.890389)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "161fb023-1baa-4e08-a1fc-78f8dad549ff")
+		)
+		(fp_curve
+			(pts
+				(xy -2.903225 -2.345414) (xy -2.754353 -2.345414) (xy -2.605481 -2.345061) (xy -2.456608 -2.34365)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "596c314d-7d55-4752-9fdd-b0c69f68f73d")
+		)
+		(fp_curve
+			(pts
+				(xy -2.903578 -2.003219) (xy -2.906753 -2.117167) (xy -2.9064 -2.231114) (xy -2.903225 -2.345414)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6141d26d-ee37-4263-b19e-d8b73e930c3a")
+		)
+		(fp_curve
+			(pts
+				(xy -2.903578 -2.003219) (xy -2.89617 -1.791553) (xy -2.895817 -1.57918) (xy -2.915572 -1.367867)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "b9dfbd14-beaf-44c6-952f-aa86cf7d5751")
+		)
+		(fp_curve
+			(pts
+				(xy -2.915572 -1.367867) (xy -2.895817 -1.57918) (xy -2.89617 -1.791553) (xy -2.903578 -2.003219)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "841fb4d0-c7b5-4077-87ab-539e6356563d")
+		)
+		(fp_curve
+			(pts
+				(xy -2.915572 -1.367867) (xy -3.030931 -1.367161) (xy -3.146289 -1.367161) (xy -3.261647 -1.367867)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6ba2789c-ab21-4850-bbaa-45959e7c9da9")
+		)
+		(fp_curve
+			(pts
+				(xy -2.955436 -0.488392) (xy -2.994947 -0.55683) (xy -3.039397 -0.622094) (xy -3.090903 -0.682419)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "dc58cdde-381e-41ba-80d7-77ed6dd6da77")
+		)
+		(fp_curve
+			(pts
+				(xy -2.955436 -0.488392) (xy -3.002708 -0.453819) (xy -3.049981 -0.420305) (xy -3.098311 -0.387497)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "050e67df-d102-49a9-86e8-c8d4e5749e07")
+		)
+		(fp_curve
+			(pts
+				(xy -3.060211 -0.707819) (xy -3.06762 -0.701469) (xy -3.083142 -0.688769) (xy -3.090903 -0.682419)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "2166090d-1ec7-4dbc-9d44-81bfe5937093")
+		)
+		(fp_curve
+			(pts
+				(xy -3.060211 -0.707819) (xy -3.267997 -0.704644) (xy -3.476842 -0.722283) (xy -3.683922 -0.700764)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c71afe28-46f0-4642-8388-4fb2280adb1f")
+		)
+		(fp_curve
+			(pts
+				(xy -3.064445 -1.681839) (xy -2.917689 -1.648325) (xy -2.992478 -1.381625) (xy -3.142761 -1.457825)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5a97ba51-035b-45cb-826b-dd2b62ebfa74")
+		)
+		(fp_curve
+			(pts
+				(xy -3.064445 -1.681839) (xy -3.202028 -1.718528) (xy -3.286695 -1.510389) (xy -3.142761 -1.457825)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a3e724a9-988f-45c5-9c3d-279aca4899f5")
+		)
+		(fp_curve
+			(pts
+				(xy -3.072911 -0.369153) (xy -2.894053 -0.365625) (xy -2.715195 -0.374092) (xy -2.536689 -0.368094)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "b1bb1447-a890-4111-84e8-103949182902")
+		)
+		(fp_curve
+			(pts
+				(xy -3.090903 -0.682419) (xy -3.039397 -0.622094) (xy -2.994947 -0.55683) (xy -2.955436 -0.488392)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "1a3b833a-cbdb-4596-ab4a-787b76e16834")
+		)
+		(fp_curve
+			(pts
+				(xy -3.090903 -0.682419) (xy -3.083142 -0.688769) (xy -3.06762 -0.701469) (xy -3.060211 -0.707819)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0a3710c4-321f-4458-963b-46682c76c8cb")
+		)
+		(fp_curve
+			(pts
+				(xy -3.090903 -0.682419) (xy -3.149111 -0.634442) (xy -3.20097 -0.579761) (xy -3.254239 -0.526492)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6e7aef64-b598-4ed1-8a4b-80b601a36531")
+		)
+		(fp_curve
+			(pts
+				(xy -3.098311 -0.387497) (xy -3.049981 -0.420305) (xy -3.002708 -0.453819) (xy -2.955436 -0.488392)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "9240aa0e-e40b-4517-8b9d-301704015132")
+		)
+		(fp_curve
+			(pts
+				(xy -3.098311 -0.387497) (xy -3.150522 -0.433711) (xy -3.203439 -0.478867) (xy -3.254239 -0.526492)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "b743855f-c15a-4cea-b15f-592058e385f1")
+		)
+		(fp_curve
+			(pts
+				(xy -3.142761 -1.457825) (xy -2.992478 -1.381625) (xy -2.917689 -1.648325) (xy -3.064445 -1.681839)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "e4794da5-28c4-4d92-837e-f940408ec821")
+		)
+		(fp_curve
+			(pts
+				(xy -3.142761 -1.457825) (xy -3.286695 -1.510389) (xy -3.202028 -1.718528) (xy -3.064445 -1.681839)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ee52328b-6ed8-4f0c-98e6-32c5544c475b")
+		)
+		(fp_curve
+			(pts
+				(xy -3.193914 -1.132917) (xy -2.944853 -1.125155) (xy -2.695792 -1.129036) (xy -2.447083 -1.138208)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "3da60c95-8ef8-4d13-b1c8-893241d040eb")
+		)
+		(fp_curve
+			(pts
+				(xy -3.254239 -0.526492) (xy -3.20097 -0.579761) (xy -3.149111 -0.634442) (xy -3.090903 -0.682419)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "b1475af6-ac9b-4ab8-a2f9-96df0b18a2bd")
+		)
+		(fp_curve
+			(pts
+				(xy -3.254239 -0.526492) (xy -3.203439 -0.478867) (xy -3.150522 -0.433711) (xy -3.098311 -0.387497)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "00f21387-1cfb-4096-af78-0bd2e9848db4")
+		)
+		(fp_curve
+			(pts
+				(xy -3.261647 -1.367867) (xy -3.146289 -1.367161) (xy -3.030931 -1.367161) (xy -2.915572 -1.367867)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ea17deb3-8da6-4d92-9dd9-b17b99fcae97")
+		)
+		(fp_curve
+			(pts
+				(xy -3.261647 -1.367867) (xy -3.280345 -1.582355) (xy -3.281756 -1.797903) (xy -3.275758 -2.013097)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c3849ded-fe9b-47d3-b2e3-36ef20898f5d")
+		)
+		(fp_curve
+			(pts
+				(xy -3.2747 -2.345414) (xy -3.27082 -2.234642) (xy -3.271525 -2.123869) (xy -3.275758 -2.013097)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0d8dc067-7a07-4417-9864-2765ad2414a7")
+		)
+		(fp_curve
+			(pts
+				(xy -3.275758 -2.013097) (xy -3.281756 -1.797903) (xy -3.280345 -1.582355) (xy -3.261647 -1.367867)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6b5edbc7-394e-44a7-a4cc-0847a5a3d761")
+		)
+		(fp_curve
+			(pts
+				(xy -3.275758 -2.013097) (xy -3.337142 -1.948539) (xy -3.421103 -1.887508) (xy -3.428511 -1.7912)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "dcebb0bd-1059-4022-a70c-c71879adb63d")
+		)
+		(fp_curve
+			(pts
+				(xy -3.335025 2.314428) (xy -3.474372 2.315839) (xy -3.615483 2.302786) (xy -3.75342 2.326775)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "4eaa86db-492a-43fc-9cff-1c6af6078c56")
+		)
+		(fp_curve
+			(pts
+				(xy -3.428511 -1.7912) (xy -3.443681 -1.641975) (xy -3.442975 -1.490986) (xy -3.42957 -1.342114)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "072abe41-592c-4ba1-b07f-7cbf0859906d")
+		)
+		(fp_curve
+			(pts
+				(xy -3.42957 -1.342114) (xy -3.421103 -1.22605) (xy -3.309625 -1.129036) (xy -3.193914 -1.132917)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5dbf9791-e5c1-42e3-93f5-2ed09665c803")
+		)
+		(fp_curve
+			(pts
+				(xy -3.653936 -0.373386) (xy -3.460261 -0.364919) (xy -3.266586 -0.374092) (xy -3.072911 -0.369153)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "56450031-d497-4b1a-b3fc-9d96b6fe0808")
+		)
+		(fp_curve
+			(pts
+				(xy -3.683922 -0.700764) (xy -3.86137 -0.685242) (xy -3.834559 -0.357158) (xy -3.653936 -0.373386)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "fabe0506-2965-4495-86e9-2cfe0cf35e90")
+		)
+		(fp_curve
+			(pts
+				(xy -3.75342 2.326775) (xy -3.847258 2.414264) (xy -3.778114 2.547614) (xy -3.762239 2.652742)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a9d2b5d3-9231-47bb-a243-faa885cfbf9d")
+		)
+		(fp_curve
+			(pts
+				(xy -3.762239 2.652742) (xy -1.219417 2.653095) (xy 1.323053 2.6538) (xy 3.865522 2.652742)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "f5d75b5b-3eb8-4c6d-91d2-5fc184146905")
+		)
+		(fp_curve
+			(pts
+				(xy -3.768942 -2.651272) (xy -3.770353 -2.55073) (xy -3.771058 -2.450189) (xy -3.77 -2.35)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c8f7a0e0-f28f-4276-9efd-55d0d365c0f5")
+		)
+		(fp_curve
+			(pts
+				(xy -3.77 -2.35) (xy -3.605253 -2.343297) (xy -3.4398 -2.343297) (xy -3.2747 -2.345414)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "b8247daa-1ef6-45cd-9b69-55f07c39c84a")
+		)
+		(fp_curve
+			(pts
+				(xy -4.069156 2.931083) (xy -4.07092 2.930378) (xy -4.074095 2.92932) (xy -4.075858 2.928967)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "8b8e1c59-50ca-45e5-aea2-dbfd34dadd01")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Jumper:SolderJumper-2_P1.3mm_Bridged_RoundedPad1.0x1.5mm"
+		(layer "B.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8a52")
+		(at 54.350000 38.400000 180)
+		(descr "SMD Solder Jumper, 1x1.5mm, rounded Pads, 0.3mm gap, bridged with 1 copper strip")
+		(tags "solder jumper open")
+		(property "Reference" "JP1"
+			(at 0 1.8 0)
+			(layer "B.Fab")
+			(uuid "6619ae18-a2e0-419c-b564-060e048898ab")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Value" "ISO"
+			(at 2.35 0 90)
+			(layer "B.SilkS")
+			(uuid "db820133-fc12-4953-98d7-3ef8d0cfaea8")
+			(effects
+				(font
+					(size 0.8 0.8)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b6b40ad5-c287-4cd4-a5ab-3ba9a66fe464")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "80f49484-ff3c-440c-a603-d8c7a02361e1")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f174cc0")
+		(attr exclude_from_pos_files exclude_from_bom)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_poly
+			(pts
+				(xy 0.25 0.3) (xy -0.25 0.3) (xy -0.25 -0.3) (xy 0.25 -0.3)
+			)
+			(stroke
+				(width 0)
+				(type solid)
+			)
+			(fill yes)
+			(layer "B.Cu")
+			(uuid "135e579b-a407-4d1d-bb87-5c56faa2ce6f")
+		)
+		(fp_line
+			(start 1.4 0.3)
+			(end 1.4 -0.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "e62694a2-fbfe-4f3c-94bd-659ea5f07448")
+		)
+		(fp_line
+			(start 0.7 -1)
+			(end -0.7 -1)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "35ff873b-1c76-4276-8ad8-e85217819be2")
+		)
+		(fp_line
+			(start -0.7 1)
+			(end 0.7 1)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "4bca4a42-2f54-410f-9982-e486e5b6e4e1")
+		)
+		(fp_line
+			(start -1.4 -0.3)
+			(end -1.4 0.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "a6f399c9-8400-4d85-b17a-1a4d51d5c268")
+		)
+		(fp_arc
+			(start 1.4 0.3)
+			(mid 1.194975 0.794975)
+			(end 0.7 1)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "ae9c8e40-2cf4-43fc-9d93-8a88aea47f5b")
+		)
+		(fp_arc
+			(start 0.7 -1)
+			(mid 1.194975 -0.794975)
+			(end 1.4 -0.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "604069d0-b245-4e58-8309-92588ee45eca")
+		)
+		(fp_arc
+			(start -0.7 1)
+			(mid -1.194975 0.794975)
+			(end -1.4 0.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "9a3e6d9f-bdb8-4316-be98-b578160b9fb6")
+		)
+		(fp_arc
+			(start -1.4 -0.3)
+			(mid -1.194975 -0.794975)
+			(end -0.7 -1)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "412c20e3-6f9f-43aa-9499-864f61f18374")
+		)
+		(fp_line
+			(start 1.65 -1.25)
+			(end 1.65 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "B.CrtYd")
+			(uuid "edc21def-d39a-4d54-b0d9-5eafd01d45b5")
+		)
+		(fp_line
+			(start 1.65 -1.25)
+			(end -1.65 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "B.CrtYd")
+			(uuid "102dbe95-cb42-4279-b430-85ee09b4b958")
+		)
+		(fp_line
+			(start -1.65 1.25)
+			(end 1.65 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "B.CrtYd")
+			(uuid "b40e1adc-db91-4e98-8101-2f8bc5e7ace1")
+		)
+		(fp_line
+			(start -1.65 1.25)
+			(end -1.65 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "B.CrtYd")
+			(uuid "c4c0943f-90da-4bb6-90ce-65c164bd5b92")
+		)
+		(pad "1" smd custom
+			(at -0.65 0 180)
+			(size 1 0.5)
+			(layers "B.Cu" "B.Mask")
+			(net "VTARGET")
+			(zone_connect 2)
+			(options
+				(clearance outline)
+				(anchor rect)
+			)
+			(primitives
+				(gr_circle
+					(center 0 -0.25)
+					(end 0.5 -0.25)
+					(width 0)
+					(fill yes)
+				)
+				(gr_circle
+					(center 0 0.25)
+					(end 0.5 0.25)
+					(width 0)
+					(fill yes)
+				)
+				(gr_poly
+					(pts
+						(xy 0 0.75) (xy 0.5 0.75) (xy 0.5 -0.75) (xy 0 -0.75)
+					)
+					(width 0)
+					(fill yes)
+				)
+			)
+			(uuid "093aa1be-efc6-4b3c-aee6-b01c65d5af00")
+		)
+		(pad "2" smd custom
+			(at 0.65 0 180)
+			(size 1 0.5)
+			(layers "B.Cu" "B.Mask")
+			(net "VREF")
+			(zone_connect 2)
+			(options
+				(clearance outline)
+				(anchor rect)
+			)
+			(primitives
+				(gr_circle
+					(center 0 -0.25)
+					(end 0.5 -0.25)
+					(width 0)
+					(fill yes)
+				)
+				(gr_circle
+					(center 0 0.25)
+					(end 0.5 0.25)
+					(width 0)
+					(fill yes)
+				)
+				(gr_poly
+					(pts
+						(xy 0 0.75) (xy -0.5 0.75) (xy -0.5 -0.75) (xy 0 -0.75)
+					)
+					(width 0)
+					(fill yes)
+				)
+			)
+			(uuid "f71a041b-0da5-4501-91ff-8255b7324eb3")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Jumper:SolderJumper-2_P1.3mm_Open_RoundedPad1.0x1.5mm"
+		(layer "B.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec9c8a")
+		(at 45.750000 57.650000 180)
+		(descr "SMD Solder Jumper, 1x1.5mm, rounded Pads, 0.3mm gap, open")
+		(tags "solder jumper open")
+		(property "Reference" "JP2"
+			(at 0 1.8 0)
+			(layer "B.Fab")
+			(uuid "c331ffb5-09c7-42c7-9d8d-56dafb8057be")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Value" "HACK"
+			(at 0 -2 0)
+			(layer "B.SilkS")
+			(uuid "5ebb4efe-445e-452b-94ba-b7a78e30f111")
+			(effects
+				(font
+					(size 0.8 0.8)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "6461f297-7cf9-4281-84b7-43cf48772353")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "4b2d93fc-059e-4f55-8857-b2a92ff62fa3")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-0000617b0db5")
+		(attr exclude_from_pos_files exclude_from_bom)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 1.4 0.3)
+			(end 1.4 -0.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "1f3e5cdd-72bb-42b3-8c92-ae17e3becd0c")
+		)
+		(fp_line
+			(start 0.7 -1)
+			(end -0.7 -1)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "e06676da-fea3-4ea5-8bb9-8027fecbb3cc")
+		)
+		(fp_line
+			(start -0.7 1)
+			(end 0.7 1)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "f8e4998f-1c9c-4ee3-be29-2051c71b0036")
+		)
+		(fp_line
+			(start -1.4 -0.3)
+			(end -1.4 0.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "b4e5d1f3-3c27-411e-aba3-ddfb2dc2537f")
+		)
+		(fp_arc
+			(start 1.4 0.3)
+			(mid 1.194975 0.794975)
+			(end 0.7 1)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "c40cc05a-0210-4c59-9ace-322ce617633e")
+		)
+		(fp_arc
+			(start 0.7 -1)
+			(mid 1.194975 -0.794975)
+			(end 1.4 -0.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "57ef1809-990f-4421-9707-003f104f0129")
+		)
+		(fp_arc
+			(start -0.7 1)
+			(mid -1.194975 0.794975)
+			(end -1.4 0.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "1b6e810d-b089-4ea0-b771-08da357da4c7")
+		)
+		(fp_arc
+			(start -1.4 -0.3)
+			(mid -1.194975 -0.794975)
+			(end -0.7 -1)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "44f22ad3-b3c5-4cdb-8ae8-af431f32606c")
+		)
+		(fp_line
+			(start 1.65 -1.25)
+			(end 1.65 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "B.CrtYd")
+			(uuid "35ed4132-c024-46eb-85d7-8c818884ba83")
+		)
+		(fp_line
+			(start 1.65 -1.25)
+			(end -1.65 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "B.CrtYd")
+			(uuid "7b0d608d-f0d6-4af5-82b5-6e53193c2600")
+		)
+		(fp_line
+			(start -1.65 1.25)
+			(end 1.65 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "B.CrtYd")
+			(uuid "7698f274-bb49-4a03-8275-7dc67b7c13d3")
+		)
+		(fp_line
+			(start -1.65 1.25)
+			(end -1.65 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "B.CrtYd")
+			(uuid "71f74abb-5aba-4b40-a353-62a7ebd2a081")
+		)
+		(pad "1" smd custom
+			(at -0.65 0 180)
+			(size 1 0.5)
+			(layers "B.Cu" "B.Mask")
+			(net "/COPI")
+			(zone_connect 2)
+			(options
+				(clearance outline)
+				(anchor rect)
+			)
+			(primitives
+				(gr_circle
+					(center 0 -0.25)
+					(end 0.5 -0.25)
+					(width 0)
+					(fill yes)
+				)
+				(gr_circle
+					(center 0 0.25)
+					(end 0.5 0.25)
+					(width 0)
+					(fill yes)
+				)
+				(gr_poly
+					(pts
+						(xy 0 0.75) (xy 0.5 0.75) (xy 0.5 -0.75) (xy 0 -0.75)
+					)
+					(width 0)
+					(fill yes)
+				)
+			)
+			(uuid "e19882a6-91d3-40a9-b481-72d2ab10dc6c")
+		)
+		(pad "2" smd custom
+			(at 0.65 0 180)
+			(size 1 0.5)
+			(layers "B.Cu" "B.Mask")
+			(net "/SWDIO")
+			(zone_connect 2)
+			(options
+				(clearance outline)
+				(anchor rect)
+			)
+			(primitives
+				(gr_circle
+					(center 0 -0.25)
+					(end 0.5 -0.25)
+					(width 0)
+					(fill yes)
+				)
+				(gr_circle
+					(center 0 0.25)
+					(end 0.5 0.25)
+					(width 0)
+					(fill yes)
+				)
+				(gr_poly
+					(pts
+						(xy 0 0.75) (xy -0.5 0.75) (xy -0.5 -0.75) (xy 0 -0.75)
+					)
+					(width 0)
+					(fill yes)
+				)
+			)
+			(uuid "b60541fe-2e77-4cb4-b5d8-afd1f728e58d")
+		)
+		(embedded_fonts no)
+	)
+	(gr_line
+		(start 30 30.00236)
+		(end 75.99764 30.00236)
+		(stroke
+			(width 0.05)
+			(type default)
+		)
+		(layer "Edge.Cuts")
+		(uuid "b4ae0a91-b8aa-4a95-81f4-6b410cec069c")
+	)
+	(gr_line
+		(start 30 76)
+		(end 30 30.00236)
+		(stroke
+			(width 0.05)
+			(type default)
+		)
+		(layer "Edge.Cuts")
+		(uuid "7da3a505-70eb-4f94-8bc3-6d40dad8d5a1")
+	)
+	(gr_line
+		(start 75.99764 30.00236)
+		(end 75.99764 76)
+		(stroke
+			(width 0.05)
+			(type default)
+		)
+		(layer "Edge.Cuts")
+		(uuid "17c23777-360a-40a2-99ca-639848ab7c46")
+	)
+	(gr_line
+		(start 75.99764 76)
+		(end 30 76)
+		(stroke
+			(width 0.05)
+			(type default)
+		)
+		(layer "Edge.Cuts")
+		(uuid "cf2dc8b0-dfd6-4067-b900-5252aea5e0b4")
+	)
+	(zone
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec7979")
+		(hatch edge 0.508)
+		(connect_pads
+			(clearance 0)
+		)
+		(min_thickness 0.254)
+		(keepout
+			(tracks allowed)
+			(vias allowed)
+			(pads allowed)
+			(copperpour not_allowed)
+			(footprints allowed)
+		)
+		(placement
+			(enabled no)
+			(sheetname "")
+		)
+		(fill
+			(thermal_gap 0.508)
+			(thermal_bridge_width 0.508)
+			(island_removal_mode 0)
+		)
+		(polygon
+			(pts
+				(xy 39.75 53.65) (xy 39.5 53.65) (xy 39.5 52.9) (xy 39.75 52.9)
+			)
+		)
+	)
+	(zone
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec797c")
+		(hatch edge 0.508)
+		(connect_pads
+			(clearance 0)
+		)
+		(min_thickness 0.254)
+		(keepout
+			(tracks allowed)
+			(vias allowed)
+			(pads allowed)
+			(copperpour not_allowed)
+			(footprints allowed)
+		)
+		(placement
+			(enabled no)
+			(sheetname "")
+		)
+		(fill
+			(thermal_gap 0.508)
+			(thermal_bridge_width 0.508)
+			(island_removal_mode 0)
+		)
+		(polygon
+			(pts
+				(xy 42.5 54.9) (xy 41.5 54.9) (xy 41.5 51.4) (xy 42.5 51.4)
+			)
+		)
+	)
+	(zone
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec797f")
+		(hatch edge 0.508)
+		(connect_pads thru_hole_only
+			(clearance 0)
+		)
+		(min_thickness 0.15)
+		(keepout
+			(tracks allowed)
+			(vias allowed)
+			(pads allowed)
+			(copperpour not_allowed)
+			(footprints allowed)
+		)
+		(placement
+			(enabled no)
+			(sheetname "")
+		)
+		(fill
+			(thermal_gap 0.25)
+			(thermal_bridge_width 0.25)
+			(island_removal_mode 0)
+		)
+		(polygon
+			(pts
+				(xy 51.25 52.4) (xy 51.25 53.65) (xy 52.5 53.65) (xy 52.5 55.15) (xy 49 55.15) (xy 49 51.15) (xy 50 51.15)
+			)
+		)
+	)
+	(embedded_fonts no)
+)

--- a/tests/fixtures/run23/tigard_damaged.kicad_pro
+++ b/tests/fixtures/run23/tigard_damaged.kicad_pro
@@ -1,0 +1,88 @@
+{
+  "board": {
+    "design_settings": {
+      "defaults": {},
+      "diff_pair_dimensions": [],
+      "drc_exclusions": [],
+      "rules": {
+        "min_clearance": 0.15,
+        "min_track_width": 0.15,
+        "min_via_diameter": 0.5
+      },
+      "rule_severities": {},
+      "track_widths": [],
+      "via_dimensions": []
+    },
+    "layer_presets": [],
+    "viewports": []
+  },
+  "boards": [],
+  "cvpcb": {
+    "equivalence_files": []
+  },
+  "libraries": {
+    "pinned_footprint_libs": [],
+    "pinned_symbol_libs": []
+  },
+  "meta": {
+    "filename": "tigard.kicad_pro",
+    "version": 1
+  },
+  "net_settings": {
+    "classes": [
+      {
+        "bus_width": 12,
+        "clearance": 0.15,
+        "diff_pair_gap": 0.2032,
+        "diff_pair_width": 0.205232,
+        "line_style": 0,
+        "microvia_diameter": 0.3,
+        "microvia_drill": 0.1,
+        "name": "Default",
+        "pcb_color": "rgba(0, 0, 0, 0.000)",
+        "schematic_color": "rgba(0, 0, 0, 0.000)",
+        "track_width": 0.15,
+        "via_diameter": 0.5,
+        "via_drill": 0.25,
+        "wire_width": 6
+      }
+    ],
+    "meta": {
+      "version": 3
+    },
+    "net_colors": null,
+    "netclass_assignments": null,
+    "netclass_patterns": []
+  },
+  "pcbnew": {
+    "last_paths": {},
+    "page_layout_descr_file": ""
+  },
+  "schematic": {},
+  "sheets": [],
+  "text_variables": {},
+  "kicad_routing_tools": {
+    "floor_provenance": {
+      "_note": "MIGRATED, not authored and not guessed. tigard is a KiCad 5 design (board version 20171130) which stored its design rules INSIDE the .kicad_pcb, and KiCad 5 had no .kicad_pro at all -- so no project file exists upstream to copy. The board in kicad_files/ was re-saved through pcbnew 10.0 (version 20260206) during corpus staging, which dropped the (setup ...) constraints and every (net_class ...) stanza. The values below were read back out of the upstream board and are the author's own; none is a default, a fab tier, or an inference.",
+      "source": "https://raw.githubusercontent.com/tigard-tools/tigard/master/tigard.kicad_pcb",
+      "source_version": 20171130,
+      "verified": "85 net names upstream vs 85 parsed here, 79 identical; the 6 differences are the KiCad 5->9 overbar syntax change (/~ENABLE -> /~{ENABLE}), not a design difference",
+      "fields": {
+        "net_settings.classes[Default].clearance": "(net_class Default (clearance 0.15))",
+        "net_settings.classes[Default].track_width": "(net_class Default (trace_width 0.15))",
+        "net_settings.classes[Default].via_diameter": "(net_class Default (via_dia 0.5))",
+        "net_settings.classes[Default].via_drill": "(net_class Default (via_drill 0.25))",
+        "net_settings.classes[Default].diff_pair_width": "(net_class Default (diff_pair_width 0.205232))",
+        "net_settings.classes[Default].diff_pair_gap": "(net_class Default (diff_pair_gap 0.2032))",
+        "net_settings.classes[Default].microvia_diameter": "(net_class Default (uvia_dia 0.3))",
+        "net_settings.classes[Default].microvia_drill": "(net_class Default (uvia_drill 0.1))",
+        "board.design_settings.rules.min_clearance": "(setup (trace_clearance 0.15))",
+        "board.design_settings.rules.min_track_width": "(setup (trace_min 0.15))",
+        "board.design_settings.rules.min_via_diameter": "(setup (via_min_size 0.5))"
+      },
+      "deliberately_absent": {
+        "board.design_settings.rules.min_copper_edge_clearance": "KiCad 5 had no copper-to-edge constraint, so the author never declared one. Left absent so board_floor_knobs reports `fixed default` 0.55 with an honest source, rather than a number nobody chose wearing a board's name."
+      }
+    }
+  }
+}

--- a/tests/fixtures/run23/tigard_placed.kicad_pcb
+++ b/tests/fixtures/run23/tigard_placed.kicad_pcb
@@ -1,0 +1,26044 @@
+(kicad_pcb
+	(version 20260206)
+	(generator "pcbnew")
+	(generator_version "10.0")
+	(general
+		(thickness 1.6)
+		(legacy_teardrops no)
+	)
+	(paper "A4")
+	(title_block
+		(title "Tigard")
+		(date "2020-10-27")
+		(rev "v1.1")
+		(comment 1 "Copyright Franklin Harding 2020")
+		(comment 2 "Licensed under CC-BY-SA 4.0")
+	)
+	(layers
+		(0 "F.Cu" signal)
+		(4 "In1.Cu" signal "GND")
+		(6 "In2.Cu" signal "PWR")
+		(2 "B.Cu" signal)
+		(9 "F.Adhes" user)
+		(11 "B.Adhes" user)
+		(13 "F.Paste" user)
+		(15 "B.Paste" user)
+		(5 "F.SilkS" user)
+		(7 "B.SilkS" user)
+		(1 "F.Mask" user)
+		(3 "B.Mask" user)
+		(17 "Dwgs.User" user)
+		(19 "Cmts.User" user)
+		(21 "Eco1.User" user)
+		(23 "Eco2.User" user)
+		(25 "Edge.Cuts" user)
+		(27 "Margin" user)
+		(31 "F.CrtYd" user)
+		(29 "B.CrtYd" user)
+		(35 "F.Fab" user)
+		(33 "B.Fab" user)
+	)
+	(setup
+		(pad_to_mask_clearance 0.05)
+		(allow_soldermask_bridges_in_footprints no)
+		(tenting
+			(front yes)
+			(back yes)
+		)
+		(covering
+			(front no)
+			(back no)
+		)
+		(plugging
+			(front no)
+			(back no)
+		)
+		(capping no)
+		(filling no)
+		(aux_axis_origin 76 76)
+		(grid_origin 1 -0.05)
+		(pcbplotparams
+			(layerselection 0x00000000_00000000_5555555f_5755f5ff)
+			(plot_on_all_layers_selection 0x00000000_00000000_00000000_00000000)
+			(disableapertmacros no)
+			(usegerberextensions yes)
+			(usegerberattributes no)
+			(usegerberadvancedattributes no)
+			(creategerberjobfile no)
+			(dashed_line_dash_ratio 12)
+			(dashed_line_gap_ratio 3)
+			(svgprecision 4)
+			(plotframeref no)
+			(mode 1)
+			(useauxorigin no)
+			(pdf_front_fp_property_popups yes)
+			(pdf_back_fp_property_popups yes)
+			(pdf_metadata yes)
+			(pdf_single_document no)
+			(dxfpolygonmode yes)
+			(dxfimperialunits yes)
+			(dxfusepcbnewfont yes)
+			(psnegative no)
+			(psa4output no)
+			(plot_black_and_white yes)
+			(sketchpadsonfab no)
+			(plotpadnumbers no)
+			(hidednponfab no)
+			(sketchdnponfab yes)
+			(crossoutdnponfab yes)
+			(subtractmaskfromsilk yes)
+			(outputformat 1)
+			(mirror no)
+			(drillshape 0)
+			(scaleselection 1)
+			(outputdirectory "gerber")
+		)
+	)
+	(footprint "MountingHole:MountingHole_3.2mm_M3_ISO7380"
+		(locked yes)
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec7649")
+		(at 73.000000 73.000000)
+		(descr "Mounting Hole 3.2mm, no annular, M3, ISO7380")
+		(tags "mounting hole 3.2mm no annular m3 iso7380")
+		(property "Reference" "H4"
+			(at 0 -3.85 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "bb472e54-fd10-4c0b-92a2-80874be40e6f")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "MountingHole"
+			(at 0 3.85 0)
+			(layer "F.Fab")
+			(uuid "b811a12a-b8a4-4dfd-863a-7cd1242b4961")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "c2a5032f-c8ed-45c5-b6c9-3833f3b0682a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "c4f3be3c-c194-437b-9c2a-408085256870")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-000060460663")
+		(attr exclude_from_pos_files exclude_from_bom)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_circle
+			(center 0 0)
+			(end 2.85 0)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(fill no)
+			(layer "Cmts.User")
+			(uuid "17faf555-61e9-4432-9afa-c7a11473e588")
+		)
+		(fp_circle
+			(center 0 0)
+			(end 3.1 0)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+			(uuid "61536813-4b3d-4d37-9660-53ce8d20e5bc")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0.3 0 0)
+			(layer "F.Fab")
+			(uuid "d6ed0199-2206-4540-8260-02dd5473837d")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "" np_thru_hole circle
+			(at 0 0)
+			(size 3.2 3.2)
+			(drill 3.2)
+			(layers "*.Cu" "*.Mask")
+			(uuid "3f43b813-3251-40d4-b8f7-11bd902f95b8")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "MountingHole:MountingHole_3.2mm_M3_ISO7380"
+		(locked yes)
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec765e")
+		(at 33.000000 73.000000)
+		(descr "Mounting Hole 3.2mm, no annular, M3, ISO7380")
+		(tags "mounting hole 3.2mm no annular m3 iso7380")
+		(property "Reference" "H3"
+			(at 0 -3.85 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "d1c79839-1057-4c2a-9c2e-671730b6a388")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "MountingHole"
+			(at 0 3.85 0)
+			(layer "F.Fab")
+			(uuid "e19c304d-5421-440d-b61a-4bef38441490")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b3c4e055-d45f-47b1-a243-e2c74370f4bf")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "1bb2094b-5ddf-4a1b-89fc-743ee86216bd")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-0000604604af")
+		(attr exclude_from_pos_files exclude_from_bom)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_circle
+			(center 0 0)
+			(end 2.85 0)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(fill no)
+			(layer "Cmts.User")
+			(uuid "f1b9e333-5a46-47d5-ad30-dbdbdb6dc252")
+		)
+		(fp_circle
+			(center 0 0)
+			(end 3.1 0)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+			(uuid "138b6e46-5d7a-493f-a618-841a176d2474")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0.3 0 0)
+			(layer "F.Fab")
+			(uuid "448a3cd4-1249-4a18-b0c7-f8304a24a0b4")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "" np_thru_hole circle
+			(at 0 0)
+			(size 3.2 3.2)
+			(drill 3.2)
+			(layers "*.Cu" "*.Mask")
+			(uuid "ee675091-231f-45f0-a898-cd8406e73f7d")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "MountingHole:MountingHole_3.2mm_M3_ISO7380"
+		(locked yes)
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec7673")
+		(at 73.000000 33.000000)
+		(descr "Mounting Hole 3.2mm, no annular, M3, ISO7380")
+		(tags "mounting hole 3.2mm no annular m3 iso7380")
+		(property "Reference" "H2"
+			(at 0 -3.85 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "336e738b-0f6e-427a-a043-135ff781a2d0")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "MountingHole"
+			(at 0 3.85 0)
+			(layer "F.Fab")
+			(uuid "18933cbc-600e-4731-86fd-56e44c290e7e")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "93f7aaa4-a81f-4357-9f7b-2e3c4991df16")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "8351bfe3-443d-48e9-8972-261c93757cf2")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-000060460323")
+		(attr exclude_from_pos_files exclude_from_bom)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_circle
+			(center 0 0)
+			(end 2.85 0)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(fill no)
+			(layer "Cmts.User")
+			(uuid "e0937eb3-7f6a-44e3-ae53-54b602fc57b8")
+		)
+		(fp_circle
+			(center 0 0)
+			(end 3.1 0)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+			(uuid "edc7901a-69fe-4363-a0c2-58562621a4cb")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0.3 0 0)
+			(layer "F.Fab")
+			(uuid "e30451b7-2702-4e37-8137-c0f96349aed9")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "" np_thru_hole circle
+			(at 0 0)
+			(size 3.2 3.2)
+			(drill 3.2)
+			(layers "*.Cu" "*.Mask")
+			(uuid "26ae4158-88ad-4be9-9ab4-942cefa82064")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "MountingHole:MountingHole_3.2mm_M3_ISO7380"
+		(locked yes)
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec7688")
+		(at 33.000000 33.000000)
+		(descr "Mounting Hole 3.2mm, no annular, M3, ISO7380")
+		(tags "mounting hole 3.2mm no annular m3 iso7380")
+		(property "Reference" "H1"
+			(at 0 -3.85 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "45ce1eed-0809-4401-8ec0-cc7e4594fe4a")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "MountingHole"
+			(at 0 3.85 0)
+			(layer "F.Fab")
+			(uuid "ea5cb08e-a9e5-40ad-ada2-722f36053e9d")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "7d2b2b1a-6ff4-4e26-955c-0e656884ff04")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "ea6647de-8ab3-4a37-b019-8abac40cef18")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00006045fa6c")
+		(attr exclude_from_pos_files exclude_from_bom)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_circle
+			(center 0 0)
+			(end 2.85 0)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(fill no)
+			(layer "Cmts.User")
+			(uuid "1c7b7aae-1c22-4ff6-9390-4954f9b665ae")
+		)
+		(fp_circle
+			(center 0 0)
+			(end 3.1 0)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+			(uuid "d88477d2-5176-4cb1-898b-3b1836d866cc")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0.3 0 0)
+			(layer "F.Fab")
+			(uuid "55d8c1d2-0254-4a5b-848e-89e21c116002")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "" np_thru_hole circle
+			(at 0 0)
+			(size 3.2 3.2)
+			(drill 3.2)
+			(layers "*.Cu" "*.Mask")
+			(uuid "5c2d81d1-739e-4af6-99ff-7c6cfbda65b3")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Package_SO:TSSOP-24_4.4x7.8mm_P0.65mm"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec76ef")
+		(at 67.770000 56.900000)
+		(descr "TSSOP, 24 Pin (JEDEC MO-153 Var AD https://www.jedec.org/document_search?search_api_views_fulltext=MO-153), generated with kicad-footprint-generator ipc_gullwing_generator.py")
+		(tags "TSSOP SO")
+		(property "Reference" "U5"
+			(at -0.02 5 0)
+			(layer "F.Fab")
+			(uuid "2fd158ee-f886-4452-9f8e-683b6b2b31b1")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "SN74LVC8T245"
+			(at 0 4.85 0)
+			(layer "F.Fab")
+			(uuid "9576fa93-5ffb-45e9-a9cf-1ea1b5696703")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "34a07708-433a-42c1-a046-d06db04c01f7")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "d2579827-8f05-4df1-b6d8-ced33e185d8c")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005fa83347")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0 -4.035)
+			(end -3.6 -4.035)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "427aeda2-9679-4a57-9f62-6e8ac850d8da")
+		)
+		(fp_line
+			(start 0 -4.035)
+			(end 2.2 -4.035)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "97f4e32c-29cb-4350-858a-ec2a77a702ac")
+		)
+		(fp_line
+			(start 0 4.035)
+			(end -2.2 4.035)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "15a81af1-dc65-4f30-bb9a-c30fa17f7148")
+		)
+		(fp_line
+			(start 0 4.035)
+			(end 2.2 4.035)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "e9be521f-bed1-4747-b5b1-f6f6dc236ee2")
+		)
+		(fp_line
+			(start -3.85 -4.15)
+			(end -3.85 4.15)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "3cec8fdb-d33e-4e71-afb4-7b7293c54ef2")
+		)
+		(fp_line
+			(start -3.85 4.15)
+			(end 3.85 4.15)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "faa9b931-b3b2-4593-a365-b7f759fe7561")
+		)
+		(fp_line
+			(start 3.85 -4.15)
+			(end -3.85 -4.15)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "92f458ae-1d77-4868-95ef-877005dac8e3")
+		)
+		(fp_line
+			(start 3.85 4.15)
+			(end 3.85 -4.15)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "8b5bda34-2e4c-4a4f-b8ba-3a6899ca6084")
+		)
+		(fp_line
+			(start -2.2 -2.9)
+			(end -1.2 -3.9)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a531cb94-6813-453b-bd9c-b0f2dfdc66a3")
+		)
+		(fp_line
+			(start -2.2 3.9)
+			(end -2.2 -2.9)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "2fc5f121-3fb3-41f9-89d2-9f08df02f4dd")
+		)
+		(fp_line
+			(start -1.2 -3.9)
+			(end 2.2 -3.9)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b7f6ac8a-3a57-4f03-a866-7d393489b1cf")
+		)
+		(fp_line
+			(start 2.2 -3.9)
+			(end 2.2 3.9)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "60746b1b-5bb0-4586-b171-3d8944108767")
+		)
+		(fp_line
+			(start 2.2 3.9)
+			(end -2.2 3.9)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "56d1e94c-bde2-4218-8397-9a60bc69e332")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "5f5c4dda-5cf3-4ffb-bb54-de1264e5feaf")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -2.8625 -3.575)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "f21779ed-7530-41a1-8d43-d7da0c8c2f4d")
+		)
+		(pad "2" smd roundrect
+			(at -2.8625 -2.925)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(R18-Pad2)")
+			(uuid "9c53374f-e059-4565-bee5-5d27fab6eb33")
+		)
+		(pad "3" smd roundrect
+			(at -2.8625 -2.275)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD0")
+			(uuid "01ce541e-3ec7-4536-9046-26367551bbb2")
+		)
+		(pad "4" smd roundrect
+			(at -2.8625 -1.625)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD1")
+			(uuid "e3e519eb-05df-454a-b3be-b72c0e674a08")
+		)
+		(pad "5" smd roundrect
+			(at -2.8625 -0.975)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD3")
+			(uuid "deb364fe-bd91-441f-bcd6-c30eb4711af6")
+		)
+		(pad "6" smd roundrect
+			(at -2.8625 -0.325)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD4")
+			(uuid "b8ec131e-a20f-44b8-a226-62dae079f0c7")
+		)
+		(pad "7" smd roundrect
+			(at -2.8625 0.325)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD5")
+			(uuid "db63eb4d-54f1-46e0-94ee-cf331071a5ed")
+		)
+		(pad "8" smd roundrect
+			(at -2.8625 0.975)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD4")
+			(uuid "ed633d17-4016-4b66-907c-6717b3f7ba1a")
+		)
+		(pad "9" smd roundrect
+			(at -2.8625 1.625)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD2")
+			(uuid "be182461-208c-4164-ab28-2e40cca9a35d")
+		)
+		(pad "10" smd roundrect
+			(at -2.8625 2.275)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD0")
+			(uuid "fb3d9a57-1a82-4124-a984-886279762258")
+		)
+		(pad "11" smd roundrect
+			(at -2.8625 2.925)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "dfa3babc-ea25-4ced-bcac-7cea1389378c")
+		)
+		(pad "12" smd roundrect
+			(at -2.8625 3.575)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "90227bc2-c24a-417b-8e3e-ffc52fb27af9")
+		)
+		(pad "13" smd roundrect
+			(at 2.8625 3.575)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "3c400a81-4432-484d-84b1-217f37f12fd9")
+		)
+		(pad "14" smd roundrect
+			(at 2.8625 2.925)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN4-Pad4)")
+			(uuid "47de9221-895a-42b9-ab4c-3139500afb26")
+		)
+		(pad "15" smd roundrect
+			(at 2.8625 2.275)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN4-Pad3)")
+			(uuid "a3261d0e-72ab-44eb-8077-a4ef1b676630")
+		)
+		(pad "16" smd roundrect
+			(at 2.8625 1.625)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN4-Pad2)")
+			(uuid "f0a204b2-e667-4a5f-b23e-3dc83d79b8d6")
+		)
+		(pad "17" smd roundrect
+			(at 2.8625 0.975)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN4-Pad1)")
+			(uuid "f0d837e0-7120-47df-8fec-e509e1acd091")
+		)
+		(pad "18" smd roundrect
+			(at 2.8625 0.325)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN3-Pad4)")
+			(uuid "52a1dc99-b41f-4661-b635-f72fe534efe7")
+		)
+		(pad "19" smd roundrect
+			(at 2.8625 -0.325)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN3-Pad3)")
+			(uuid "a59be271-9076-4679-a96d-78409b8feed5")
+		)
+		(pad "20" smd roundrect
+			(at 2.8625 -0.975)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN3-Pad2)")
+			(uuid "0fb611d7-c4d8-4088-9f89-8f6a58e8f712")
+		)
+		(pad "21" smd roundrect
+			(at 2.8625 -1.625)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN3-Pad1)")
+			(uuid "ad04213e-26c8-4d7e-a39c-925aae88e2f7")
+		)
+		(pad "22" smd roundrect
+			(at 2.8625 -2.275)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/~{ENABLE}")
+			(uuid "a93e73ab-a050-499e-a318-3b6251235dd9")
+		)
+		(pad "23" smd roundrect
+			(at 2.8625 -2.925)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "4fdad313-1767-42f7-8ac9-a1d8b96b7818")
+		)
+		(pad "24" smd roundrect
+			(at 2.8625 -3.575)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "104c0dfb-cb3d-4350-85ae-937144677f66")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Package_SO.3dshapes/TSSOP-24_4.4x7.8mm_P0.65mm.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:PinHeader_2x07_P1.27mm_Vertical_SMD"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec7791")
+		(at 69.700000 48.260000 270)
+		(descr "surface-mounted straight pin header, 2x07, 1.27mm pitch, double rows")
+		(tags "Surface mounted pin header SMD 2x07 1.27mm double row")
+		(property "Reference" "J6"
+			(at 0 -5.505 90)
+			(layer "F.Fab")
+			(uuid "d625164b-c7f1-41ca-8ea1-27e499304f41")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "LA"
+			(at -0.03 -5.59 270)
+			(layer "F.SilkS")
+			(uuid "77034dd8-1f69-4863-a45d-b36685522085")
+			(effects
+				(font
+					(size 0.8 0.8)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "d6ffa26e-6832-4a6e-b648-1cce2fc072f1")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "923945a5-5c62-4d98-9d92-298d94d0d7a4")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005fd77da4")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -1.765 4.505)
+			(end 1.765 4.505)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "bfa54926-b969-4fc6-86b8-c2e293699a64")
+		)
+		(fp_line
+			(start -1.765 4.44)
+			(end -1.765 4.505)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "9e38cb1b-0bff-41f1-aeb3-0d4234aeebd2")
+		)
+		(fp_line
+			(start 1.765 4.44)
+			(end 1.765 4.505)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "edbb8f13-a96b-48b9-b363-ccd4e1e7389f")
+		)
+		(fp_line
+			(start -3.09 -4.44)
+			(end -1.765 -4.44)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "37d62227-2229-4f8c-9fcb-39221e66f652")
+		)
+		(fp_line
+			(start -1.765 -4.505)
+			(end -1.765 -4.44)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "cfa03998-d85e-4ac0-9b61-647e3671f4dd")
+		)
+		(fp_line
+			(start -1.765 -4.505)
+			(end 1.765 -4.505)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "615a1e1b-cde2-4f86-8c60-afdcfba61605")
+		)
+		(fp_line
+			(start 1.765 -4.505)
+			(end 1.765 -4.44)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "6a4b565d-2a01-450f-be10-5832b19981aa")
+		)
+		(fp_line
+			(start -2.794 -4.826)
+			(end -3.15321 -5.18521)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "e2a99714-0473-4498-ae30-89b4fc2911a5")
+		)
+		(fp_line
+			(start -2.794 -4.826)
+			(end -2.43479 -5.18521)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "81482fc1-5a38-4b18-a61e-439561c2a1cf")
+		)
+		(fp_line
+			(start -2.794 -4.826)
+			(end -2.794 -5.90363)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "fef54523-4fdb-406d-87b1-ee06224c7a9f")
+		)
+		(fp_line
+			(start -3.15321 -5.18521)
+			(end -2.794 -4.826)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "64d26242-d63f-4ef9-be5f-bfabff2c5a6f")
+		)
+		(fp_line
+			(start -1.5 6.5)
+			(end 1.5 6.5)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Eco1.User")
+			(uuid "1f715f6f-7c7f-427e-af39-62bf2727da99")
+		)
+		(fp_line
+			(start 1.5 6.5)
+			(end 1.5 -6.5)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Eco1.User")
+			(uuid "d285e246-cc51-4dd7-abf1-9738261882a5")
+		)
+		(fp_line
+			(start -1.5 -6.5)
+			(end -1.5 6.5)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Eco1.User")
+			(uuid "34cfb8c0-5203-49c6-9611-ebb03c5d8d60")
+		)
+		(fp_line
+			(start 1.5 -6.5)
+			(end -1.5 -6.5)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Eco1.User")
+			(uuid "3f17bf57-b3be-41c3-b20b-6ee191754466")
+		)
+		(fp_line
+			(start -4.3 4.95)
+			(end 4.3 4.95)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "37299d2c-d979-488a-99aa-a6b793a5e32e")
+		)
+		(fp_line
+			(start 4.3 4.95)
+			(end 4.3 -4.95)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "fd64ccde-4289-4314-bf62-f0bdc6e98da1")
+		)
+		(fp_line
+			(start -4.3 -4.95)
+			(end -4.3 4.95)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "60c87124-6292-4372-9302-c32fc35e6493")
+		)
+		(fp_line
+			(start 4.3 -4.95)
+			(end -4.3 -4.95)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "cdd2b6f1-7df8-4539-84a9-16bbbe1ec275")
+		)
+		(fp_line
+			(start -1.705 4.445)
+			(end -1.705 -4.01)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9ad26181-c779-4bd4-9558-855ced060644")
+		)
+		(fp_line
+			(start 1.705 4.445)
+			(end -1.705 4.445)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "94eb7b79-37ee-4d2d-9b10-d25d94564336")
+		)
+		(fp_line
+			(start -2.75 4.01)
+			(end -1.705 4.01)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "35164ec9-8bff-4232-97b6-309bbd2dc087")
+		)
+		(fp_line
+			(start 2.75 4.01)
+			(end 1.705 4.01)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f761717b-1599-43db-aedc-cdb40bc4ee05")
+		)
+		(fp_line
+			(start -2.75 3.61)
+			(end -2.75 4.01)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "6d272ff7-324b-4996-bbb3-831200990737")
+		)
+		(fp_line
+			(start -1.705 3.61)
+			(end -2.75 3.61)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "739708c1-11fd-4fd2-8f3d-3093a39851a9")
+		)
+		(fp_line
+			(start 1.705 3.61)
+			(end 2.75 3.61)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c877b2ce-6f23-49ab-9f08-e9521597ca63")
+		)
+		(fp_line
+			(start 2.75 3.61)
+			(end 2.75 4.01)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "0691132d-2f3e-4c26-bac8-eef70fad4f08")
+		)
+		(fp_line
+			(start -2.75 2.74)
+			(end -1.705 2.74)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "12d81a95-8a63-4191-8af9-179f6e29b697")
+		)
+		(fp_line
+			(start 2.75 2.74)
+			(end 1.705 2.74)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "474160ac-5e3f-458e-8c8b-9ba4df543395")
+		)
+		(fp_line
+			(start -2.75 2.34)
+			(end -2.75 2.74)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a6d453a1-d6cd-47f4-bb83-392c09f7158b")
+		)
+		(fp_line
+			(start -1.705 2.34)
+			(end -2.75 2.34)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "72a4c876-55d8-4770-958c-5903b113b4c0")
+		)
+		(fp_line
+			(start 1.705 2.34)
+			(end 2.75 2.34)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "886ff9ba-1157-4b7d-b389-81fd93fc76f7")
+		)
+		(fp_line
+			(start 2.75 2.34)
+			(end 2.75 2.74)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e53d0028-7c67-4848-9119-a9a366dab571")
+		)
+		(fp_line
+			(start -2.75 1.47)
+			(end -1.705 1.47)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "07de0936-6634-409f-8fe6-c12a7151c380")
+		)
+		(fp_line
+			(start 2.75 1.47)
+			(end 1.705 1.47)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c7497da9-7187-4e5b-bc9c-9cbc0a280484")
+		)
+		(fp_line
+			(start -2.75 1.07)
+			(end -2.75 1.47)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ff09dcbd-9929-4720-b535-f06a5dc13bc4")
+		)
+		(fp_line
+			(start -1.705 1.07)
+			(end -2.75 1.07)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "5ec94d10-2cf1-4b5d-80cc-f081b925edb3")
+		)
+		(fp_line
+			(start 1.705 1.07)
+			(end 2.75 1.07)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "0e1a0f5c-629f-403e-bd93-c6f239b71ac7")
+		)
+		(fp_line
+			(start 2.75 1.07)
+			(end 2.75 1.47)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "991bf058-d26f-430c-a4a9-4778555fc1d3")
+		)
+		(fp_line
+			(start -2.75 0.2)
+			(end -1.705 0.2)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "de470dfa-e3d8-45c1-bade-f44948950f13")
+		)
+		(fp_line
+			(start 2.75 0.2)
+			(end 1.705 0.2)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "eb9008e0-9c83-41b7-ad1d-1645282e1c6f")
+		)
+		(fp_line
+			(start -2.75 -0.2)
+			(end -2.75 0.2)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "8559b712-fe46-4d92-a9a1-6a46482d64c4")
+		)
+		(fp_line
+			(start -1.705 -0.2)
+			(end -2.75 -0.2)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "da22d81b-24b9-4e68-a019-274584e36c26")
+		)
+		(fp_line
+			(start 1.705 -0.2)
+			(end 2.75 -0.2)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "3ea19346-7b8d-42a3-a39d-7e5e28590c99")
+		)
+		(fp_line
+			(start 2.75 -0.2)
+			(end 2.75 0.2)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f49a56cf-906b-44b7-ad12-96c05add2d3b")
+		)
+		(fp_line
+			(start -2.75 -1.07)
+			(end -1.705 -1.07)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "7c89cbfe-e6e9-4200-bbf4-20f1797e1c87")
+		)
+		(fp_line
+			(start 2.75 -1.07)
+			(end 1.705 -1.07)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "921ca45c-1d20-49af-a4d6-3b0a0a9b3279")
+		)
+		(fp_line
+			(start -2.75 -1.47)
+			(end -2.75 -1.07)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "25c2b5bc-8342-4b8a-a9b8-f5212784c518")
+		)
+		(fp_line
+			(start -1.705 -1.47)
+			(end -2.75 -1.47)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b9f71b86-b34a-44ae-90fb-f5b749f93da7")
+		)
+		(fp_line
+			(start 1.705 -1.47)
+			(end 2.75 -1.47)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "4f7bc2ea-9db3-4f38-ba32-f1ad56c1bc06")
+		)
+		(fp_line
+			(start 2.75 -1.47)
+			(end 2.75 -1.07)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ef3b9207-f8b0-4d5c-8a42-c797c809258b")
+		)
+		(fp_line
+			(start -2.75 -2.34)
+			(end -1.705 -2.34)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "21cc06b5-9755-433f-8b2d-1ff07aa69699")
+		)
+		(fp_line
+			(start 2.75 -2.34)
+			(end 1.705 -2.34)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "314028b1-e414-403b-bf68-3170ad41dabe")
+		)
+		(fp_line
+			(start -2.75 -2.74)
+			(end -2.75 -2.34)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "0acd16ef-5927-42d5-9cb5-589fc5893738")
+		)
+		(fp_line
+			(start -1.705 -2.74)
+			(end -2.75 -2.74)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "4ae3988a-08c2-4357-856f-468037ffa8d5")
+		)
+		(fp_line
+			(start 1.705 -2.74)
+			(end 2.75 -2.74)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "7559f03f-a6e7-46a6-9930-697229a5adab")
+		)
+		(fp_line
+			(start 2.75 -2.74)
+			(end 2.75 -2.34)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "39d75b7c-ff1b-4f5e-9524-3f6b8556885d")
+		)
+		(fp_line
+			(start -2.75 -3.61)
+			(end -1.705 -3.61)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d26ce950-d518-421b-a7c7-57fe8e9b11df")
+		)
+		(fp_line
+			(start 2.75 -3.61)
+			(end 1.705 -3.61)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "df28e62d-8364-45bf-b615-e2e32a9be590")
+		)
+		(fp_line
+			(start -2.75 -4.01)
+			(end -2.75 -3.61)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "89506f5a-e797-450e-91d7-07fb464e0fb1")
+		)
+		(fp_line
+			(start -1.705 -4.01)
+			(end -2.75 -4.01)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e10dd986-5cc2-4592-9210-1836c786395d")
+		)
+		(fp_line
+			(start -1.705 -4.01)
+			(end -1.27 -4.445)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "39954b92-dbe1-43ae-959e-5c029cd2ad2b")
+		)
+		(fp_line
+			(start 1.705 -4.01)
+			(end 2.75 -4.01)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f836d23a-a5c0-42a4-b301-f42da6719b3a")
+		)
+		(fp_line
+			(start 2.75 -4.01)
+			(end 2.75 -3.61)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "65897f26-7b38-47c4-b769-cf3e6f6a9f6e")
+		)
+		(fp_line
+			(start -1.27 -4.445)
+			(end 1.705 -4.445)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c0da5228-89e1-4dc7-87c8-de2879e1a898")
+		)
+		(fp_line
+			(start 1.705 -4.445)
+			(end 1.705 4.445)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "8bbbf9aa-b422-43e0-8cbe-1817143beb62")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "a72c7183-f02a-4a4e-9921-1929f4ba07b0")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -1.95 -3.81 270)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/CLK")
+			(uuid "0ae5c117-45bc-497d-9bf5-18a7a78fdc48")
+		)
+		(pad "2" smd roundrect
+			(at 1.95 -3.81 270)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/COPI")
+			(uuid "bf3c07f9-b3d2-4ed4-aea1-079627f4e7cb")
+		)
+		(pad "3" smd roundrect
+			(at -1.95 -2.54 270)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/DI")
+			(uuid "9954170a-605c-46c2-a6f4-99dcb7f1a603")
+		)
+		(pad "4" smd roundrect
+			(at 1.95 -2.54 270)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/CS")
+			(uuid "888c2463-89fb-4471-8aee-7477da4b44ad")
+		)
+		(pad "5" smd roundrect
+			(at -1.95 -1.27 270)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/xPB4")
+			(uuid "89e6b1e5-b271-4ae7-9c14-93ba074fd87f")
+		)
+		(pad "6" smd roundrect
+			(at 1.95 -1.27 270)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/xPB5")
+			(uuid "eff6a024-c51a-46d1-9605-306842970a29")
+		)
+		(pad "7" smd roundrect
+			(at -1.95 0 270)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/UART_TX")
+			(uuid "b13185ad-b5b9-4f09-b1b4-0002e89a98fc")
+		)
+		(pad "8" smd roundrect
+			(at 1.95 0 270)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/ICE_CDONE")
+			(uuid "a99ea99d-f2c9-4b71-be8f-e4a755bb4a36")
+		)
+		(pad "9" smd roundrect
+			(at -1.95 1.27 270)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "d7140a76-24c6-4002-9fde-4a862f392e58")
+		)
+		(pad "10" smd roundrect
+			(at 1.95 1.27 270)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "091e028e-27b4-4088-b7da-5a3b9cf0b237")
+		)
+		(pad "11" smd roundrect
+			(at -1.95 2.54 270)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "99a2ea20-0e55-42b6-ac90-37ee79accfe1")
+		)
+		(pad "12" smd roundrect
+			(at 1.95 2.54 270)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "8df0a0a5-adc6-4491-b1d4-ae0a7e1ba2b8")
+		)
+		(pad "13" smd roundrect
+			(at -1.95 3.81 270)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "a38f6be0-19cc-4b3f-a9d6-4394ef76b762")
+		)
+		(pad "14" smd roundrect
+			(at 1.95 3.81 270)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "d4a30846-c800-4e22-a559-f2c8c4c3d595")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Connector_PinHeader_1.27mm.3dshapes/PinHeader_2x07_P1.27mm_Vertical_SMD.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "LED_SMD:LED_0603_1608Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec7843")
+		(at 38.460000 49.526000 270)
+		(descr "LED SMD 0603 (1608 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "diode")
+		(property "Reference" "D3"
+			(at 0 -1.43 90)
+			(layer "F.Fab")
+			(uuid "ea8d8f5f-cd72-46a6-8c9c-33caec9c91b8")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "GREEN"
+			(at 0 1.43 90)
+			(layer "F.Fab")
+			(uuid "0d8ccabb-c585-4cea-94cf-1c667ec1ff0d")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "adbe2f89-0306-4fd5-bf2a-3d72e201dd3b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "da5d6e73-941f-4fff-9cfa-b8db642df460")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f225d89")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -1.485 0.735)
+			(end 0.8 0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "173be5b0-84de-4566-86da-f3c0e92b2a0d")
+		)
+		(fp_line
+			(start -1.485 -0.735)
+			(end -1.485 0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "a1b1e199-c930-470e-9491-b77b5dd5f6a5")
+		)
+		(fp_line
+			(start 0.8 -0.735)
+			(end -1.485 -0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "6c9fd50d-0c53-48dc-9390-148e7cdd4f54")
+		)
+		(fp_line
+			(start -1.48 0.73)
+			(end -1.48 -0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "57093d38-314e-4e39-8d66-7c5135119c5c")
+		)
+		(fp_line
+			(start 1.48 0.73)
+			(end -1.48 0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "7b7d899d-e3af-4149-bdcc-1a658e284921")
+		)
+		(fp_line
+			(start -1.48 -0.73)
+			(end 1.48 -0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "0223cc1d-da7c-4397-a03a-e244d87bedd9")
+		)
+		(fp_line
+			(start 1.48 -0.73)
+			(end 1.48 0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "0390ff7f-df7c-4dd5-91b3-7b6effd8ffa9")
+		)
+		(fp_line
+			(start -0.8 0.4)
+			(end 0.8 0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "5bc6d7b6-e614-4e63-92fb-50aad2d05933")
+		)
+		(fp_line
+			(start 0.8 0.4)
+			(end 0.8 -0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9d51c0ff-1178-4f8c-aad0-3fe9f6035bc3")
+		)
+		(fp_line
+			(start -0.8 -0.1)
+			(end -0.8 0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "da5f7b6d-7109-452c-8be7-d8a66a39dab2")
+		)
+		(fp_line
+			(start -0.5 -0.4)
+			(end -0.8 -0.1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "3b146f5c-e496-477e-88cf-71eeead3436d")
+		)
+		(fp_line
+			(start 0.8 -0.4)
+			(end -0.5 -0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "05a3b01d-d3ec-4738-9af6-dd491b7dcad2")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "cb430395-5ec9-49ec-ba29-f8778494306b")
+			(effects
+				(font
+					(size 0.4 0.4)
+					(thickness 0.06)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.7875 0 270)
+			(size 0.875 0.95)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/RXLED")
+			(uuid "ba25650e-e056-4d75-bc2a-90b28c6d17e9")
+		)
+		(pad "2" smd roundrect
+			(at 0.7875 0 270)
+			(size 0.875 0.95)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(D3-Pad2)")
+			(uuid "47889d70-9192-4832-afcb-fee29ce7ce30")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/LED_SMD.3dshapes/LED_0603_1608Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec7881")
+		(at 41.800000 46.600000 270)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C2"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "25910469-5804-4723-91df-e0860b033ce8")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "2u2"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "9474ad25-b9fc-43a9-9d67-94e535889953")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "122c6b2b-1635-4d0d-af4c-bb7561db34bb")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "dcceedf0-e910-4cd3-98f6-0f2182bddf3a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ee3e5c7")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "749c7708-8527-457c-9983-fa17ff9c1c5d")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "6667d55d-0210-4eac-b590-5d1691f7bfdf")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "c8224116-5391-4a3d-bb27-9b7fa714792e")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "212072e5-bfcf-424e-82fd-6ff721571bdf")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "251a1d6f-874e-4f99-9338-10267ab6818b")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "8ce1572a-87ae-4945-b10c-28661026277b")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "983e422f-66ca-4ab4-9d72-02c7fae277c0")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "480b2cc1-9886-432a-b822-9b7c3e941a0c")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "9feb1dd4-73f2-4142-8089-d6b89de1d924")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+1V8")
+			(uuid "8f7e1a99-48d2-4dec-9e4d-4e06da81a046")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "465514b3-f200-44bc-babe-5cdf641c98ab")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec78ab")
+		(at 63.750000 47.150000 270)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C26"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "82d90949-d6bf-4762-8432-b75212d3b471")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100n"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "ef5c9372-6d38-4a6d-ad3c-2c70df5fa296")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "cd0115e5-ff69-4c79-8306-e833ceb68979")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "e1dd155e-22c8-4639-807d-3f331f264ac6")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005fa89fd4")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "02e23e0a-42d2-46ae-ab6a-15e5dc7db19f")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "86f9ec1d-943a-4129-a741-2494f9983b17")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "57352f42-3e22-42f7-a814-2b8b0d30c36e")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "81d9bed1-4a8d-4ed2-9f28-fed2ff192d7b")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "60f9b7e1-ef8d-4029-aa47-d450c7d036bf")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "8923f6ff-087c-48e4-8ce9-030f2e69c644")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "bba1cc02-98aa-4843-8a99-c45503942149")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e7a6ec74-7b5d-492d-b630-1d7922c95144")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "9d020299-2f23-4aca-be97-b3363f0fe086")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+5V")
+			(uuid "a21689b9-e060-499c-a822-e322fb170382")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "39411482-b0f0-48c5-8b90-39483004b030")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec78d5")
+		(at 46.800000 56.900000)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C25"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "704c6386-5c54-4d97-9ddd-d76bf23e59e1")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "NF"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "b8aa696c-43c1-4134-b7b0-befe74fb37a0")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "df0fdb8d-e4bd-4701-845f-ab184e895a19")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "0976e7b9-de09-4946-b8b8-53b8a63188f7")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f3a982f")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2f71c11f-55be-4432-bde7-20eb6a1178a8")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "be0ffe6c-c197-4618-bd57-a69671f82333")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "541d8dd0-a6d2-42d9-9c06-069181adee7d")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "7940e504-38b8-4ec9-a4bc-63a3bb951050")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "5be24d94-a0ee-4320-bd3a-b1c4f0a63d89")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9b313482-b0c2-4494-a2b2-031300f91087")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "116465a7-6e09-47d4-a2bf-283e5928fbc9")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e1a51331-55f6-4c08-b2c3-7b9a4911b3aa")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "fbaa71ca-2180-4a23-b612-c0b97cc1c026")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "cdf1c7a3-8803-46b1-9359-b675b7349168")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(C25-Pad2)")
+			(uuid "72e0e9f5-e1b3-4fe2-a61e-5ce3c60bbdaf")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:PinHeader_1x09_P2.54mm_Vertical"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec791d")
+		(at 49.265000 34.741700 90)
+		(descr "Through hole straight pin header, 1x09, 2.54mm pitch, single row")
+		(tags "Through hole pin header THT 1x09 2.54mm single row")
+		(property "Reference" "J3"
+			(at 0 -2.33 90)
+			(layer "F.Fab")
+			(uuid "9f4f97c7-0cc3-4133-9d1b-3dc70e5afb57")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "UART"
+			(at 0.05 -2.59 90)
+			(layer "F.SilkS")
+			(uuid "cf751067-4ba2-4519-86a8-73d1e2a53b6f")
+			(effects
+				(font
+					(size 0.8 0.8)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "526798a6-743b-4e15-b366-3dbdb2711f18")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "d68c5c2b-2c15-4784-b8c1-20ff859f4070")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ebeac72")
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -2.032 -2.032)
+			(end -2.794 -2.794)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "073f5afe-5703-4ef0-aa50-9b818fe47898")
+		)
+		(fp_line
+			(start -2.032 -2.032)
+			(end -2.032 -2.54)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "4bed77dd-b38b-47b1-9e13-66cc0c883dbb")
+		)
+		(fp_line
+			(start -2.032 -2.032)
+			(end -2.54 -2.032)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "321006a3-2c21-47a8-876d-d1a5c7d497df")
+		)
+		(fp_line
+			(start -2.54 -2.032)
+			(end -2.032 -2.032)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "86c18958-e128-4365-8df1-5f8bff5504ba")
+		)
+		(fp_line
+			(start -1.33 -1.33)
+			(end 0 -1.33)
+			(stroke
+				(width 0.5)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d7007dba-20f3-4356-8954-bf55f435c5de")
+		)
+		(fp_line
+			(start -1.33 0)
+			(end -1.33 -1.33)
+			(stroke
+				(width 0.5)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b3ccb2ed-d307-47f9-9d34-18b13a98deb0")
+		)
+		(fp_line
+			(start 1.33 1.27)
+			(end 1.33 21.65)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "69ecc4dc-e138-4204-9cbf-a9f4d61514fd")
+		)
+		(fp_line
+			(start -1.33 1.27)
+			(end 1.33 1.27)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "821337a2-f4ff-41f2-98e2-2cf2ef2bd110")
+		)
+		(fp_line
+			(start -1.33 1.27)
+			(end -1.33 21.65)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "161deb74-5028-42c4-b7be-c749d0509e1e")
+		)
+		(fp_line
+			(start -1.33 21.65)
+			(end 1.33 21.65)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "e949c2b2-6833-4678-aa58-07eb1cbd2a00")
+		)
+		(fp_line
+			(start -2.032 -2.032)
+			(end -2.794 -2.794)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "57cf0db6-18f9-4ed1-8a32-c5d7c9f8cc25")
+		)
+		(fp_line
+			(start -2.032 -2.032)
+			(end -2.032 -2.54)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "c55065fc-568c-41ca-90b4-37fb6423a713")
+		)
+		(fp_line
+			(start -2.54 -2.032)
+			(end -2.032 -2.032)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "77ee8248-1834-484d-b660-cdcef514f577")
+		)
+		(fp_line
+			(start -1.33 -1.33)
+			(end 0 -1.33)
+			(stroke
+				(width 0.5)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "35090b4c-f372-42d6-8089-4eed6faa6788")
+		)
+		(fp_line
+			(start -1.33 0)
+			(end -1.33 -1.33)
+			(stroke
+				(width 0.5)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "415228c0-b1a1-4f85-b99f-08471e5dfa8b")
+		)
+		(fp_line
+			(start 1.33 1.27)
+			(end 1.33 21.65)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "16506d47-e3ec-4287-962b-fb61e6cba28a")
+		)
+		(fp_line
+			(start -1.33 1.27)
+			(end 1.33 1.27)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "ea40e2da-f95d-4eda-90b7-b93c23abb518")
+		)
+		(fp_line
+			(start -1.33 1.27)
+			(end -1.33 21.65)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "7a986731-ce52-4820-82e0-ed982f103aba")
+		)
+		(fp_line
+			(start -1.33 21.65)
+			(end 1.33 21.65)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "f86808f1-299c-4154-b838-002fbac6d388")
+		)
+		(fp_line
+			(start 1.8 -1.8)
+			(end -1.8 -1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "0039fbb6-d233-4726-acce-bfc4970c5eba")
+		)
+		(fp_line
+			(start -1.8 -1.8)
+			(end -1.8 22.1)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "3a428086-a284-4d6e-b1d9-715b017e83b5")
+		)
+		(fp_line
+			(start 1.8 22.1)
+			(end 1.8 -1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "e0501b2c-48d8-4fcd-bc36-72d78711a53e")
+		)
+		(fp_line
+			(start -1.8 22.1)
+			(end 1.8 22.1)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "581f5308-46d7-4a0e-aa46-b99834ab1dd5")
+		)
+		(fp_line
+			(start 1.27 -1.27)
+			(end 1.27 21.59)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9189025a-7d94-499b-8798-5e2fbc97f193")
+		)
+		(fp_line
+			(start -0.635 -1.27)
+			(end 1.27 -1.27)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "03de0dbe-d2cf-445b-b7d4-4789edc4a7e5")
+		)
+		(fp_line
+			(start -1.27 -0.635)
+			(end -0.635 -1.27)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "fd51427d-aa7e-4423-bc64-45a3ca33f6f4")
+		)
+		(fp_line
+			(start 1.27 21.59)
+			(end -1.27 21.59)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b477aa68-dbd5-46f6-97e4-46191ebe2075")
+		)
+		(fp_line
+			(start -1.27 21.59)
+			(end -1.27 -0.635)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "6fd6cd92-4b2b-440c-9601-74fe46cf9ab7")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 10.16 0)
+			(layer "F.Fab")
+			(uuid "14a9017e-7851-4e5b-9d1c-ae4e4f747c7c")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "1" thru_hole roundrect
+			(at 0 0 90)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(roundrect_rratio 0.25)
+			(net "VTARGET")
+			(uuid "b515c753-19cc-424b-ae5c-c585809a9523")
+		)
+		(pad "2" thru_hole oval
+			(at 0 2.54 90)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "GND")
+			(uuid "0e43c46c-35d9-4e07-b389-098fbdd3a8da")
+		)
+		(pad "3" thru_hole oval
+			(at 0 5.08 90)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/UART_TX")
+			(uuid "71485f84-345b-4a31-9bb1-2af9379f5310")
+		)
+		(pad "4" thru_hole oval
+			(at 0 7.62 90)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/ICE_CDONE")
+			(uuid "89b8c3de-eb46-4f9d-ad57-ed6c168a558d")
+		)
+		(pad "5" thru_hole oval
+			(at 0 10.16 90)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/~{UART_RTS}")
+			(uuid "f845d2ef-0ca4-4c08-8bfd-f24adceba287")
+		)
+		(pad "6" thru_hole oval
+			(at 0 12.7 90)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/~{UART_CTS}")
+			(uuid "6a513bb7-f104-4e50-ab31-e413fc4ad3cb")
+		)
+		(pad "7" thru_hole oval
+			(at 0 15.24 90)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/~{UART_DTR}")
+			(uuid "20361235-c047-4c8e-9ad8-9a2a66015ea0")
+		)
+		(pad "8" thru_hole oval
+			(at 0 17.78 90)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/~{UART_DSR}")
+			(uuid "d9557eeb-5773-499b-88e5-5dd2c4a09bee")
+		)
+		(pad "9" thru_hole oval
+			(at 0 20.32 90)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/~{UART_DCD}")
+			(uuid "55610ac5-d772-42b7-8a64-86b7467ed836")
+		)
+		(embedded_fonts no)
+		(model "${KIPRJMOD}/tigard.3dshapes/PinHeader_1x09_P2.54mm_Vertical_orange.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "LED_SMD:LED_0603_1608Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec7993")
+		(at 41.000000 61.050000 180)
+		(descr "LED SMD 0603 (1608 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "diode")
+		(property "Reference" "D2"
+			(at 0 -1.43 90)
+			(layer "F.Fab")
+			(uuid "0e330aec-4a32-4435-865d-eb8c04a5197f")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "BLUE"
+			(at 0 1.43 90)
+			(layer "F.Fab")
+			(uuid "51ba8085-cccf-40a9-80be-0c279e967a51")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "87eb2975-bb6e-4d55-9ea0-73208b275cf6")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "9f6465c8-3d54-40c9-b30c-bf094272b61d")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ebfe192")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -1.485 0.735)
+			(end 0.8 0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "8ea205f1-5c0a-4a74-961a-d8007fb46fbc")
+		)
+		(fp_line
+			(start -1.485 -0.735)
+			(end -1.485 0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "5b0ab053-5937-4348-8a0c-da892064b5d5")
+		)
+		(fp_line
+			(start 0.8 -0.735)
+			(end -1.485 -0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "973e5975-85a3-4280-b713-0678e3e4d01e")
+		)
+		(fp_line
+			(start -1.48 0.73)
+			(end -1.48 -0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "031155b0-6a5e-49f4-a4f8-5f2b423668b1")
+		)
+		(fp_line
+			(start 1.48 0.73)
+			(end -1.48 0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "992fbf16-6f65-4dbe-94f6-09b799de2602")
+		)
+		(fp_line
+			(start -1.48 -0.73)
+			(end 1.48 -0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "9dee232a-18d6-4916-8d19-34df99bcaa96")
+		)
+		(fp_line
+			(start 1.48 -0.73)
+			(end 1.48 0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "ec2d9441-686a-438e-9fb5-91e084b7d825")
+		)
+		(fp_line
+			(start -0.8 0.4)
+			(end 0.8 0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b74f5d05-126d-4e5d-84e2-13e56d8282be")
+		)
+		(fp_line
+			(start 0.8 0.4)
+			(end 0.8 -0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "8a98fb42-d184-4f43-9b36-259c75f59767")
+		)
+		(fp_line
+			(start -0.8 -0.1)
+			(end -0.8 0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "1655b101-b0db-44f8-8bc5-7350b1bfe8c2")
+		)
+		(fp_line
+			(start -0.5 -0.4)
+			(end -0.8 -0.1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9e1288b7-76cc-4bd6-b7d5-9edd494c9121")
+		)
+		(fp_line
+			(start 0.8 -0.4)
+			(end -0.5 -0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "527c8b86-8926-4274-98a7-1dc628e5b2b6")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "a0a28a06-0933-4643-8ece-79243cc01472")
+			(effects
+				(font
+					(size 0.4 0.4)
+					(thickness 0.06)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.7875 0 180)
+			(size 0.875 0.95)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(D2-Pad1)")
+			(uuid "825f9ef5-2754-44e7-bc3a-89abb1e137e6")
+		)
+		(pad "2" smd roundrect
+			(at 0.7875 0 180)
+			(size 0.875 0.95)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(D2-Pad2)")
+			(uuid "063e1de3-33b4-48ec-bec0-2d575b042030")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/LED_SMD.3dshapes/LED_0603_1608Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec79c5")
+		(at 61.500000 58.200000 270)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C12"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "03ce7138-dc36-405e-a700-3ac0258b9650")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100n"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "0e072391-6710-4829-bdc5-766f131cb2b8")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "84d7fd23-6467-4994-89d1-2d2f76d28f89")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "93a99c6c-f19e-46ad-b086-d8f4e9950e4e")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f77777a")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "6297af99-cf6c-4fca-bdae-007b0e7d36e2")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "b7cb5692-9dfb-4fd9-8464-b32edef52fc4")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "13db2cf9-716e-46b0-8baa-0c185eab7b74")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "1de2f827-33e6-4f8c-b139-33591cfa0a04")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "cc77af1f-eee4-4e1d-b2cf-81cf78e55c46")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "11b8490f-440f-4bd0-b217-7ef583a235f4")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b612cbda-eddb-4e96-91be-93c154a671e8")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "4bb0f707-4926-4119-a2f2-8b2982ce540f")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "c64e042c-8b4d-4e5b-98be-6170f510edba")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREG")
+			(uuid "0d1222a7-6df7-477e-b342-d71d4fded446")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "5dacd878-fb5b-441f-9111-b92d1e8d8fcf")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:SW_ALPS_SSSS224100_DP4T"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec7a8e")
+		(at 33.200000 40.400000 -90)
+		(property "Reference" "SW1"
+			(at 13.5 1.6 0)
+			(layer "F.Fab")
+			(uuid "bace793c-bcea-4151-a965-6800fea780b9")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "TARGET"
+			(at -3.75 -1.65 180)
+			(layer "F.SilkS")
+			(uuid "215d02be-136f-4be4-a247-c7fbdddb4963")
+			(effects
+				(font
+					(size 0.8 0.8)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "f6c55119-f08d-4c0f-88dc-0c66ff239a18")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "dba7ba0b-336c-4cf1-93b1-5a8a7bede58f")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f1c3bd3")
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -2.8 0.3)
+			(end -1.6 0.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "1962e738-7fe6-4353-a753-c2cb5e6c7dfe")
+		)
+		(fp_line
+			(start -2.5 0)
+			(end -1 0)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b8df8d7c-80a7-44a2-8ab9-cfa6fe4afa8a")
+		)
+		(fp_line
+			(start 3 0)
+			(end 5 0)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "e30ec1df-1d6a-42d2-9188-6e254d41cb5e")
+		)
+		(fp_line
+			(start 12.5 0)
+			(end 11 0)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "8c477517-4713-47a6-baad-a62e87490dd1")
+		)
+		(fp_line
+			(start 12.5 0)
+			(end 12.5 -3.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "303f2208-4f37-409f-8ba8-a1513af678f5")
+		)
+		(fp_line
+			(start -2.8 -0.9)
+			(end -2.8 0.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "3ec6719b-db60-4385-bf76-48108cd166a0")
+		)
+		(fp_line
+			(start -2.5 -3.3)
+			(end -2.5 0)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "be996f75-cf7c-4b80-a048-f3d250b5db47")
+		)
+		(fp_line
+			(start -2.5 -3.3)
+			(end -1 -3.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d280f38d-2a8b-4acc-a047-cb52f8142350")
+		)
+		(fp_line
+			(start 3 -3.3)
+			(end 5 -3.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "7145c2a5-23df-4633-b49d-bbfd05824e11")
+		)
+		(fp_line
+			(start 12.5 -3.3)
+			(end 11 -3.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "bc4dd372-f3fb-4b6f-baf1-6858cdef644a")
+		)
+		(fp_line
+			(start 1 2)
+			(end 1 0)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "baf56839-d26f-41d5-ae1a-971904889aed")
+		)
+		(fp_line
+			(start 3 2)
+			(end 1 2)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "3c4c3ce9-f5be-4e37-b6e9-21556e473b3b")
+		)
+		(fp_line
+			(start 3 2)
+			(end 5 2)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d9bc0413-8b7f-4b48-a666-506016a752ae")
+		)
+		(fp_line
+			(start 5 2)
+			(end 7 2)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "11bece95-62b6-4257-a4a9-96634074d4aa")
+		)
+		(fp_line
+			(start 5 2)
+			(end 5 0)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "14e5ea2e-edf1-442e-aabb-2caa373c6d04")
+		)
+		(fp_line
+			(start 7 2)
+			(end 9 2)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c025c0db-72a1-4f9d-af89-460527427077")
+		)
+		(fp_line
+			(start 7 2)
+			(end 7 0)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c51ab8e8-9dac-4d58-94ba-232a7ed45590")
+		)
+		(fp_line
+			(start 9 2)
+			(end 9 0)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "856f0670-a50c-4f43-85c7-28db6a2c8bd9")
+		)
+		(fp_line
+			(start 1 0)
+			(end 3 0)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "22610238-ad5d-4faa-92ca-acae7112c1e6")
+		)
+		(fp_line
+			(start 3 0)
+			(end 3 2)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6c2a86c6-5be4-43de-b994-a82f70143826")
+		)
+		(fp_line
+			(start 5 0)
+			(end 3 0)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "9654d1e7-4c23-4551-a9e5-65f86e5f003f")
+		)
+		(fp_line
+			(start 7 0)
+			(end 5 0)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5795b981-5c32-4c48-b8ea-84a365c9af44")
+		)
+		(fp_line
+			(start 9 0)
+			(end 7 0)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "20c9020f-f2f7-4b10-9813-98b970106937")
+		)
+		(fp_line
+			(start -3 1.2)
+			(end 13 1.2)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2ec56a81-a915-43c4-82c4-adc3222f864a")
+		)
+		(fp_line
+			(start 13 1.2)
+			(end 13 -4.55)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "45f481ef-1c73-431e-9d0d-3db653467dcd")
+		)
+		(fp_line
+			(start -3 -4.55)
+			(end -3 1.2)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "3edc1bb7-c965-4704-a284-0700f28410fd")
+		)
+		(fp_line
+			(start 13 -4.55)
+			(end -3 -4.55)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "bcd2bf0a-32e5-459a-a5ef-4a8d61c7d68e")
+		)
+		(fp_line
+			(start -2 0)
+			(end -1.5 0)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ae60572e-cf5c-4c1a-a96d-375574bcdaf7")
+		)
+		(fp_line
+			(start -2 0)
+			(end -2.5 -0.5)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b62a42f5-c15f-40a2-9927-1fb439321260")
+		)
+		(fp_line
+			(start 12.5 0)
+			(end -1.5 0)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ce084e10-047d-45bd-b1ee-27f8622f22f0")
+		)
+		(fp_line
+			(start 12.5 0)
+			(end 12.5 -3.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e14751a4-06a6-4dc5-ae48-1b2d13c133ef")
+		)
+		(fp_line
+			(start -2.5 -0.5)
+			(end -2.5 -3.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c4d35189-6e8e-4e93-95e8-d1246e2ea812")
+		)
+		(fp_line
+			(start -2 -3.3)
+			(end -2.5 -3.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "10d439cd-05e4-4244-9276-277d122aae0c")
+		)
+		(fp_line
+			(start 12.5 -3.3)
+			(end -2 -3.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f556c60e-f918-46f0-9b99-79373233fa29")
+		)
+		(pad "1" thru_hole roundrect
+			(at 0 0 270)
+			(size 1.4 1.4)
+			(drill 0.9)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(roundrect_rratio 0.25)
+			(uuid "e7316f8c-7694-419a-a9dc-3a9bbedccfeb")
+		)
+		(pad "2" thru_hole circle
+			(at 2 0 270)
+			(size 1.4 1.4)
+			(drill 0.9)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(uuid "99dd64ef-e3c5-42b6-8fd4-0439cb14461d")
+		)
+		(pad "3" thru_hole circle
+			(at 6 0 270)
+			(size 1.4 1.4)
+			(drill 0.9)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(uuid "678f3924-e8c6-4d36-b9c6-3dc1f2ca5d4d")
+		)
+		(pad "4" thru_hole circle
+			(at 8 0 270)
+			(size 1.4 1.4)
+			(drill 0.9)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(uuid "8aad8c4b-5c1d-4fc0-a643-55c20883421f")
+		)
+		(pad "5" thru_hole circle
+			(at 10 0 270)
+			(size 1.4 1.4)
+			(drill 0.9)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(uuid "c93ea350-28a5-405c-99ad-0abbc5e468ff")
+		)
+		(pad "6" thru_hole circle
+			(at 0 -3.3 270)
+			(size 1.4 1.4)
+			(drill 0.9)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "+5V")
+			(uuid "d40ba12e-c7a2-4c07-847a-fc811ae44747")
+		)
+		(pad "7" thru_hole circle
+			(at 2 -3.3 270)
+			(size 1.4 1.4)
+			(drill 0.9)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "+3V3")
+			(uuid "e616ce7f-1ae5-4c0f-a12c-1eceb6a4bf5b")
+		)
+		(pad "8" thru_hole circle
+			(at 6 -3.3 270)
+			(size 1.4 1.4)
+			(drill 0.9)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "VREF")
+			(uuid "ecf07b84-59ad-4a57-a2a8-c9e1ab240777")
+		)
+		(pad "9" thru_hole circle
+			(at 8 -3.3 270)
+			(size 1.4 1.4)
+			(drill 0.9)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "+1V8")
+			(uuid "7396ff9e-c0be-4d31-8767-972c3ba6f04a")
+		)
+		(pad "10" thru_hole circle
+			(at 10 -3.3 270)
+			(size 1.4 1.4)
+			(drill 0.9)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "VTARGET")
+			(uuid "581ab6c2-8255-4f30-a9a3-4adb697e8bb5")
+		)
+		(embedded_fonts no)
+		(model "${KIPRJMOD}/tigard.3dshapes/SSSS224100.step"
+			(offset
+				(xyz 5 1.65 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:PinHeader_2x05_P1.27mm_Vertical_SMD"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec7b2c")
+		(at 42.280000 35.320000)
+		(descr "surface-mounted straight pin header, 2x05, 1.27mm pitch, double rows")
+		(tags "Surface mounted pin header SMD 2x05 1.27mm double row")
+		(property "Reference" "J5"
+			(at 0 -4.235 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "7097a562-f886-425f-8ba4-a7d093934f9b")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "CORTEX"
+			(at -0.03 -4.42 0)
+			(layer "F.SilkS")
+			(uuid "1f1224aa-d2ae-412c-b395-28e3a9a4efa6")
+			(effects
+				(font
+					(size 0.8 0.8)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "73db39bc-e5d4-44ef-97b0-9720fd69c689")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "98a5393e-11dc-4040-9e17-cf1f8fdec050")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ebe7f5a")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -3.15321 -3.91521)
+			(end -2.794 -3.556)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d3699612-a441-4f79-9514-ba019da55f39")
+		)
+		(fp_line
+			(start -3.09 -3.17)
+			(end -1.765 -3.17)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "97368cc0-02b9-4690-ab90-66718688e4a4")
+		)
+		(fp_line
+			(start -2.794 -3.556)
+			(end -3.15321 -3.91521)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "21daa393-2812-4aba-9363-d30177de9a4f")
+		)
+		(fp_line
+			(start -2.794 -3.556)
+			(end -2.794 -4.63363)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "746e5c06-0179-406a-84a1-9dfddb169fb9")
+		)
+		(fp_line
+			(start -2.794 -3.556)
+			(end -2.43479 -3.91521)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "c18dbb45-2473-4444-9081-cdbf71859bd1")
+		)
+		(fp_line
+			(start -1.765 -3.235)
+			(end -1.765 -3.17)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "dd5edfe8-bda7-4ad7-89a3-18099473c8d6")
+		)
+		(fp_line
+			(start -1.765 -3.235)
+			(end 1.765 -3.235)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b55638eb-8408-419b-87b4-681934f08c18")
+		)
+		(fp_line
+			(start -1.765 3.17)
+			(end -1.765 3.235)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "13af60b2-d1f2-4f4c-b359-b3aa5fbb9a63")
+		)
+		(fp_line
+			(start -1.765 3.235)
+			(end 1.765 3.235)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "736cb6bb-1b07-400b-b8b1-d81f84290eba")
+		)
+		(fp_line
+			(start 1.765 -3.235)
+			(end 1.765 -3.17)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "bf03bae6-df65-4bde-bf30-0c18b5648da2")
+		)
+		(fp_line
+			(start 1.765 3.17)
+			(end 1.765 3.235)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "8ec523b3-ef42-4184-b228-c8249e203d39")
+		)
+		(fp_line
+			(start -4.3 -3.7)
+			(end -4.3 3.7)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "80ec5cb9-7bed-46fc-af7b-eeaa5ff08d8b")
+		)
+		(fp_line
+			(start -4.3 3.7)
+			(end 4.3 3.7)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "8fa3052a-5e8e-4263-acc4-1e47bb484020")
+		)
+		(fp_line
+			(start 4.3 -3.7)
+			(end -4.3 -3.7)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "98521784-3572-4b6e-a237-843b51b29136")
+		)
+		(fp_line
+			(start 4.3 3.7)
+			(end 4.3 -3.7)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "4acab31e-01f1-4e49-bea2-c46c35392b03")
+		)
+		(fp_line
+			(start -2.75 -2.74)
+			(end -2.75 -2.34)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "41c509d8-c91a-45b2-9b5b-adeb9f5de12a")
+		)
+		(fp_line
+			(start -2.75 -2.34)
+			(end -1.705 -2.34)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c8ac6f2c-dac9-4dc9-bc36-882f637164c3")
+		)
+		(fp_line
+			(start -2.75 -1.47)
+			(end -2.75 -1.07)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "949e111c-8335-4f13-bd39-3cb4bb8744b4")
+		)
+		(fp_line
+			(start -2.75 -1.07)
+			(end -1.705 -1.07)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "6a0bd6ce-54c7-4d1c-92b0-e5dc9eb71d38")
+		)
+		(fp_line
+			(start -2.75 -0.2)
+			(end -2.75 0.2)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f1b1c2ab-d8ee-445a-bf54-f26b18fbfdff")
+		)
+		(fp_line
+			(start -2.75 0.2)
+			(end -1.705 0.2)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "439e6418-cbcf-4f87-90fc-23e3a1cc0c63")
+		)
+		(fp_line
+			(start -2.75 1.07)
+			(end -2.75 1.47)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c9e1c4d8-44e1-41bd-bd66-c94c84331414")
+		)
+		(fp_line
+			(start -2.75 1.47)
+			(end -1.705 1.47)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "02ae2a43-5941-4bfc-b470-834c5e11eeb3")
+		)
+		(fp_line
+			(start -2.75 2.34)
+			(end -2.75 2.74)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "808cfbc4-25c8-420c-9beb-94d45b156f96")
+		)
+		(fp_line
+			(start -2.75 2.74)
+			(end -1.705 2.74)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "04da7e0c-b31b-4da9-bebf-4bf5fc7dcb9d")
+		)
+		(fp_line
+			(start -1.705 -2.74)
+			(end -2.75 -2.74)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d25d81e3-750e-42a0-a4a8-b067a6bdbef9")
+		)
+		(fp_line
+			(start -1.705 -2.74)
+			(end -1.27 -3.175)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "edc6864c-f83a-421e-834c-c8cd2ca26e1f")
+		)
+		(fp_line
+			(start -1.705 -1.47)
+			(end -2.75 -1.47)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e09bed96-4323-4829-8aad-9bac83194b38")
+		)
+		(fp_line
+			(start -1.705 -0.2)
+			(end -2.75 -0.2)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "10e1ba3b-d6b2-4531-b3d8-b3629c533435")
+		)
+		(fp_line
+			(start -1.705 1.07)
+			(end -2.75 1.07)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "0178ab99-5621-4475-a8da-f76ae7e35e57")
+		)
+		(fp_line
+			(start -1.705 2.34)
+			(end -2.75 2.34)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e4410a1b-43ac-406e-9c33-3d737742fedd")
+		)
+		(fp_line
+			(start -1.705 3.175)
+			(end -1.705 -2.74)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "35937651-4aa1-4c8a-88cb-9753f6330b98")
+		)
+		(fp_line
+			(start -1.27 -3.175)
+			(end 1.705 -3.175)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "23e1bc37-9f44-4fc3-8e39-058810929824")
+		)
+		(fp_line
+			(start 1.705 -3.175)
+			(end 1.705 3.175)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "6493db1b-121f-4ad1-9ecf-6e4fc3b12ea5")
+		)
+		(fp_line
+			(start 1.705 -2.74)
+			(end 2.75 -2.74)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "47f698c7-746e-4204-892e-85daf8033d0e")
+		)
+		(fp_line
+			(start 1.705 -1.47)
+			(end 2.75 -1.47)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "09665dd1-239f-46a8-9368-272ee284e34f")
+		)
+		(fp_line
+			(start 1.705 -0.2)
+			(end 2.75 -0.2)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "24698cb5-2739-4000-9c9c-bde00e9a800c")
+		)
+		(fp_line
+			(start 1.705 1.07)
+			(end 2.75 1.07)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b7afe8e0-a662-4fd8-a2c0-0cca81b8419d")
+		)
+		(fp_line
+			(start 1.705 2.34)
+			(end 2.75 2.34)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f48a7ad1-4626-45ff-8d6f-2335272728bc")
+		)
+		(fp_line
+			(start 1.705 3.175)
+			(end -1.705 3.175)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "559befd6-eb78-4004-97c2-b7ca81e39a08")
+		)
+		(fp_line
+			(start 2.75 -2.74)
+			(end 2.75 -2.34)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "7f0b2703-f35a-4e07-b701-aa1365993aa5")
+		)
+		(fp_line
+			(start 2.75 -2.34)
+			(end 1.705 -2.34)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ed432557-e727-4373-bddf-1b1ce6cdcae4")
+		)
+		(fp_line
+			(start 2.75 -1.47)
+			(end 2.75 -1.07)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "1681f093-18a5-4bad-8135-5bb0d9061020")
+		)
+		(fp_line
+			(start 2.75 -1.07)
+			(end 1.705 -1.07)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e515b37e-6e42-4aea-93e3-5feda8cb37ff")
+		)
+		(fp_line
+			(start 2.75 -0.2)
+			(end 2.75 0.2)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "8b34ac11-f3f3-46b5-93ae-2df79cd4b2dc")
+		)
+		(fp_line
+			(start 2.75 0.2)
+			(end 1.705 0.2)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9d1e637a-b555-4909-ab02-c71867a13866")
+		)
+		(fp_line
+			(start 2.75 1.07)
+			(end 2.75 1.47)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "fa2b965e-0394-4495-a218-8d84e8307c6c")
+		)
+		(fp_line
+			(start 2.75 1.47)
+			(end 1.705 1.47)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d6454e1a-1256-4b34-abfa-190eea938102")
+		)
+		(fp_line
+			(start 2.75 2.34)
+			(end 2.75 2.74)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e30a78ea-0671-43d7-a02f-c12130bdc4cc")
+		)
+		(fp_line
+			(start 2.75 2.74)
+			(end 1.705 2.74)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ec3eafbf-719e-4352-b11a-6536c653546c")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "f4de8b2d-bbcf-498f-92e4-615676b1d9ba")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -1.95 -2.54)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VTARGET")
+			(uuid "0b92c6dc-7fc1-4157-8d60-3eb1d2cd54e9")
+		)
+		(pad "2" smd roundrect
+			(at 1.95 -2.54)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/CORTEX_PIN2")
+			(uuid "34a0bebf-3549-43c3-a195-95357eb4382b")
+		)
+		(pad "3" smd roundrect
+			(at -1.95 -1.27)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "a76df55d-ecbc-44e7-adda-b807c870a395")
+		)
+		(pad "4" smd roundrect
+			(at 1.95 -1.27)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/CLK")
+			(uuid "6798e648-1589-4006-939c-d49d9417bfb5")
+		)
+		(pad "5" smd roundrect
+			(at -1.95 0)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "b8cb8fd2-2f28-4a19-a529-71d4fb3cfcec")
+		)
+		(pad "6" smd roundrect
+			(at 1.95 0)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/CIPO")
+			(uuid "325e1233-c7af-462b-92a8-6820c95ed089")
+		)
+		(pad "7" smd roundrect
+			(at -1.95 1.27)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "e0e8b091-ed89-4240-a9e3-231a1b8e9899")
+		)
+		(pad "8" smd roundrect
+			(at 1.95 1.27)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/COPI")
+			(uuid "6b200b18-a577-49b6-8276-7462a03582a1")
+		)
+		(pad "9" smd roundrect
+			(at -1.95 2.54)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "14dc5d4c-a9d6-48fc-bc32-53d53a374ad6")
+		)
+		(pad "10" smd roundrect
+			(at 1.95 2.54)
+			(size 2.4 0.74)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/xPB5")
+			(uuid "883e4674-570b-40a4-a62a-027f6b849dd1")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Connector_PinHeader_1.27mm.3dshapes/PinHeader_2x05_P1.27mm_Vertical_SMD.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec7cd1")
+		(at 41.700000 43.000000 90)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C1"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "79c22dea-dd87-4dd4-8201-de39ac87e5c2")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "2u2"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "7cbe176a-4664-494b-92aa-d739a58e21ea")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "136a90ba-9605-44d8-86f6-a21820480b5d")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "32066274-470a-42fc-be70-c97aa5dc7e0b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ee3ddb8")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "6d93e7c0-86b6-4dcf-929e-fc8ec411b9d4")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "405b7d95-8848-45b2-a9b2-40015ced495b")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "8f570cea-1b7b-487c-919e-c8d6aa01b288")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "3682645a-ceb9-4115-ae52-1da9ceddb695")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f03ce8e2-449f-41b2-81d5-cb9828408d67")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f8ad9c27-1f1c-4b74-83ea-7644546f9809")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "696f5bdf-bc43-45ba-a9e7-671980d3e51b")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d5295ec7-fb99-4999-b7c1-a7301c0d1ac1")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "7e600654-cfae-4aa1-9fbe-cf0c23b81160")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+5V")
+			(uuid "32f40528-1aad-4eda-a099-9520ca38d821")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "e6736db0-59c7-4f9a-9425-d6a98b37c8d2")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:Crystal_SMD_3225-4Pin_3.2x2.5mm_RoundRect"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec7f91")
+		(at 47.250000 49.250000 180)
+		(descr "SMD Crystal SERIES SMD3225/4 http://www.txccrystal.com/images/pdf/7m-accuracy.pdf, 3.2x2.5mm^2 package")
+		(tags "SMD SMT crystal")
+		(property "Reference" "Y1"
+			(at 0 -2.45 0)
+			(layer "F.Fab")
+			(uuid "758a30fa-7f43-4867-814a-5b4f392c4f12")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "12MHz"
+			(at 0 2.45 0)
+			(layer "F.Fab")
+			(uuid "31abad22-380b-4fec-a991-18a532e021dd")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "00dc83d7-798c-46c3-b9e6-419c8fb6cf97")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "840afdc4-6236-49ad-b5ab-47f5fabd5db0")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ee8326f")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -2 1.65)
+			(end 2 1.65)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "f1c63cc9-d26d-47b8-893b-61d458e61b73")
+		)
+		(fp_line
+			(start -2 -1.65)
+			(end -2 1.65)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "21d93c0f-1a8b-453f-b7a6-7d03c31a4746")
+		)
+		(fp_line
+			(start 2.1 1.7)
+			(end 2.1 -1.7)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "14e05e93-769a-45de-a156-a944a3811f5d")
+		)
+		(fp_line
+			(start 2.1 -1.7)
+			(end -2.1 -1.7)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "cf155659-ae81-4a56-8207-84dea7dbbc3d")
+		)
+		(fp_line
+			(start -2.1 1.7)
+			(end 2.1 1.7)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "4ba1b27f-bcfe-40f0-8f2d-2189d323626d")
+		)
+		(fp_line
+			(start -2.1 -1.7)
+			(end -2.1 1.7)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "c5459575-026e-459f-a3ae-a784a5bb8be9")
+		)
+		(fp_line
+			(start 1.6 1.25)
+			(end 1.6 -1.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e964a623-dbad-4841-bc4a-a7af18d6f326")
+		)
+		(fp_line
+			(start 1.6 -1.25)
+			(end -1.6 -1.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "958c3730-7ce1-4276-8e41-4d424712589c")
+		)
+		(fp_line
+			(start -1.6 1.25)
+			(end 1.6 1.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f36ae5cb-1771-4260-887e-bcd6a10b686b")
+		)
+		(fp_line
+			(start -1.6 0.25)
+			(end -0.6 1.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "774d561d-96d4-4ac4-b6d2-913d8641a79d")
+		)
+		(fp_line
+			(start -1.6 -1.25)
+			(end -1.6 1.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "4bb909f0-0bb8-4bc2-8fdc-b1acb0341311")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "6f406be3-2983-411b-9d40-105ea79be03c")
+			(effects
+				(font
+					(size 0.7 0.7)
+					(thickness 0.105)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -1.1 0.85 180)
+			(size 1.4 1.2)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(C23-Pad1)")
+			(uuid "b75ade58-7002-492e-883e-f9590150d9f8")
+		)
+		(pad "2" smd roundrect
+			(at 1.1 0.85 180)
+			(size 1.4 1.2)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "7475f053-7f2b-4ce4-a9c2-52eeb0805407")
+		)
+		(pad "3" smd roundrect
+			(at 1.1 -0.85 180)
+			(size 1.4 1.2)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(C24-Pad1)")
+			(uuid "54aa79d3-a16e-4d1d-9e60-68fb7c4f0e51")
+		)
+		(pad "4" smd roundrect
+			(at -1.1 -0.85 180)
+			(size 1.4 1.2)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "7b7d292c-5a54-4852-abff-c1aa8356e5fc")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Crystal.3dshapes/Crystal_SMD_3225-4Pin_3.2x2.5mm.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec7fc5")
+		(at 58.500000 63.000000 180)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C16"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "3dc6f090-b3e9-4bb1-bcd0-7bfecc5dcb88")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100n"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "e0bb4644-ec7e-47d4-a9cc-29e63a9bb5ef")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "f8232fe5-fc5f-446f-8706-cbe0b9c506ea")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "edaeda6c-b238-4b62-a368-8f90b0bc0518")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f8a4b5c")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "6c4a4275-2c88-4be2-97fc-437b3f18286a")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "acd4d0df-ff51-47d0-8fc4-5aa7685ef7eb")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "0dfb4019-5d87-4bf1-b9d2-554d2dd2e968")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "32ff14e0-29e1-487f-9719-fd18f11ff19b")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a0d361f2-72c8-43d1-9a68-7d57ff0506f3")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "51228778-957f-4c0f-a938-c86fa4fa604b")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "407fcbdd-7ba3-4197-8c68-807270c96848")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "1fb4ebeb-a79f-4cc4-bce8-124ba858b7a4")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "9fdd75cc-829e-4850-9216-223737c44cd3")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "d564b245-b180-4cbe-862b-f75aaaf9459d")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "2869c505-fdc0-4351-8e1b-21b90d33ea8d")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:R_Array_Convex_4x0402_RoundRect"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec7ff7")
+		(at 62.000000 62.400000 180)
+		(descr "Chip Resistor Network, ROHM MNR04 (see mnr_g.pdf)")
+		(tags "resistor array")
+		(property "Reference" "RN2"
+			(at 0 -2.1 0)
+			(layer "F.Fab")
+			(uuid "5e81c52d-f742-4f6a-939a-49de4eb1491c")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100k"
+			(at 0 2.1 0)
+			(layer "F.Fab")
+			(uuid "ba264274-0db4-4918-a9a2-040d3c3b9d2a")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "4faaf7d9-e733-43c7-9eef-297b1fca389a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "5b4e3f88-bf6f-4b1f-931e-01f92166e772")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ee3079f")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.25 -1.18)
+			(end -0.25 -1.18)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "2e1129a8-4e83-4f69-91e7-9506f4297540")
+		)
+		(fp_line
+			(start 0.25 1.18)
+			(end -0.25 1.18)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "769dd7d1-3636-4f6f-8332-946b0cf405b2")
+		)
+		(fp_line
+			(start -1 -1.25)
+			(end -1 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "28420b1a-9304-4f34-b248-cddd7bad7a62")
+		)
+		(fp_line
+			(start -1 -1.25)
+			(end 1 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "b8a2bdf3-19bc-4563-9a0d-0a5d2f71a0cd")
+		)
+		(fp_line
+			(start 1 1.25)
+			(end -1 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "1205d770-1cb0-4811-8645-2ce8b884c513")
+		)
+		(fp_line
+			(start 1 1.25)
+			(end 1 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "b7b29aa5-6dfd-4e05-8466-63f660c4f542")
+		)
+		(fp_line
+			(start -0.5 -1)
+			(end 0.5 -1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c8dd9b54-e4a3-46c2-b195-bc0b07ac0859")
+		)
+		(fp_line
+			(start -0.5 1)
+			(end -0.5 -1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "896d484f-a06f-4ff2-8fd5-033a726f455b")
+		)
+		(fp_line
+			(start 0.5 -1)
+			(end 0.5 1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b537abe3-2263-4d0b-acea-9ab05f753100")
+		)
+		(fp_line
+			(start 0.5 1)
+			(end -0.5 1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "1ff9b6d3-ad32-4a77-8f25-2842be5534e2")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "75a4a348-2b07-4a85-bd48-edfec09c0e96")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.075)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.5 -0.75 180)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "137e162f-1e23-46a8-961e-be50f2635748")
+		)
+		(pad "2" smd roundrect
+			(at -0.5 -0.25 180)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "0e683dcc-793e-415f-a1af-87ab0fa470c2")
+		)
+		(pad "3" smd roundrect
+			(at -0.5 0.25 180)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "9a6af302-83c9-448b-91df-b8bf301c2565")
+		)
+		(pad "4" smd roundrect
+			(at -0.5 0.75 180)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "c4d03475-1877-4794-8d33-3db68641c52f")
+		)
+		(pad "5" smd roundrect
+			(at 0.5 0.75 180)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD0")
+			(uuid "7b8243ca-ec3e-4f5d-ac6d-67bd47038637")
+		)
+		(pad "6" smd roundrect
+			(at 0.5 0.25 180)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD2")
+			(uuid "9e3b8009-fc89-4e3a-bfe1-cd12ccdff0c9")
+		)
+		(pad "7" smd roundrect
+			(at 0.5 -0.25 180)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD4")
+			(uuid "c1c62aef-4633-45ee-a8e9-818dbadbe5df")
+		)
+		(pad "8" smd roundrect
+			(at 0.5 -0.75 180)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD5")
+			(uuid "e33fb8a2-5d4a-436f-aa7a-ca1197a6aba1")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_Array_Convex_4x0402.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:R_Array_Convex_4x0402_RoundRect"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8039")
+		(at 73.050000 61.800000 90)
+		(descr "Chip Resistor Network, ROHM MNR04 (see mnr_g.pdf)")
+		(tags "resistor array")
+		(property "Reference" "RN4"
+			(at 0 -2.1 0)
+			(layer "F.Fab")
+			(uuid "b0017a08-ffbd-40d3-8f0c-e5bdb003f628")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100"
+			(at 0 2.1 0)
+			(layer "F.Fab")
+			(uuid "ad635fb2-8e2d-41fd-961a-58580422fae4")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "4181703f-e47a-44af-803b-85316cf05707")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "dd345dc8-2a97-4505-86f7-08a82e0f5977")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ed37960")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.25 -1.18)
+			(end -0.25 -1.18)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "5ed75a97-f87d-4e03-aa40-43f90dea4a85")
+		)
+		(fp_line
+			(start 0.25 1.18)
+			(end -0.25 1.18)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "55b7c542-b272-49fd-8dbc-0d4ac10a142e")
+		)
+		(fp_line
+			(start -1 -1.25)
+			(end -1 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "73557a9a-ba4b-4994-b0b1-8ba1f3fca203")
+		)
+		(fp_line
+			(start -1 -1.25)
+			(end 1 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2edb470d-6f4e-4ad8-9e2d-93012a7f56dd")
+		)
+		(fp_line
+			(start 1 1.25)
+			(end -1 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "b713169e-c08e-4574-9acf-f2bb79b5746f")
+		)
+		(fp_line
+			(start 1 1.25)
+			(end 1 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "30cb840f-2fc8-402e-aeb5-62f3dc673177")
+		)
+		(fp_line
+			(start -0.5 -1)
+			(end 0.5 -1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ed177c45-9b86-4f16-84fb-40c51cc260d1")
+		)
+		(fp_line
+			(start -0.5 1)
+			(end -0.5 -1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "8433ce38-5e6f-48e5-8b32-e0af3bfa3eef")
+		)
+		(fp_line
+			(start 0.5 -1)
+			(end 0.5 1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "bec166e2-841c-42e7-b143-845b458534fc")
+		)
+		(fp_line
+			(start 0.5 1)
+			(end -0.5 1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a94cf72e-a02b-4a1e-8266-27b4d8e9fe77")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "3d77ad12-91c4-4ad4-86bb-70d2c46b8a05")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.075)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.5 -0.75 90)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN4-Pad1)")
+			(uuid "4a11bc81-cf50-4526-9d32-2d32715229a5")
+		)
+		(pad "2" smd roundrect
+			(at -0.5 -0.25 90)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN4-Pad2)")
+			(uuid "8f373570-d9ba-4a03-b11f-4b687ffb585e")
+		)
+		(pad "3" smd roundrect
+			(at -0.5 0.25 90)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN4-Pad3)")
+			(uuid "64304a7e-6ef9-405e-bb36-95b7524ea858")
+		)
+		(pad "4" smd roundrect
+			(at -0.5 0.75 90)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN4-Pad4)")
+			(uuid "e950bb96-b1cd-4bd2-ac7b-d447a2c853ef")
+		)
+		(pad "5" smd roundrect
+			(at 0.5 0.75 90)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/UART_TX")
+			(uuid "c8979ee8-d00d-4feb-b4de-c1572d157b6b")
+		)
+		(pad "6" smd roundrect
+			(at 0.5 0.25 90)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/~{UART_RTS}")
+			(uuid "5b3ba8d5-cb7f-4cec-9b81-a34fec75ef0b")
+		)
+		(pad "7" smd roundrect
+			(at 0.5 -0.25 90)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/~{UART_DTR}")
+			(uuid "c4a44988-3921-4c15-9bc7-33c5492a0a0c")
+		)
+		(pad "8" smd roundrect
+			(at 0.5 -0.75 90)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/xPB5")
+			(uuid "47f845cd-eba8-4e1c-9f49-25d72cf73263")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_Array_Convex_4x0402.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8109")
+		(at 51.500000 44.100000 270)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R12"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "f33cc1da-75af-483c-9fcd-e0760447896e")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "38cd2c81-e295-4cc6-a973-e63b0e245287")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "0bb8e5e9-c85e-4fcf-8247-c789456fd341")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "811c0a84-114c-4d73-acb4-49931ca58414")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f33b0f5")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "a43ecebd-2287-4c59-9b5b-236143460b76")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "5b1a7c6c-11a6-4d73-b6f4-2853bf576a3a")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "67c6ccf6-ad42-48fd-9849-57588b4c7ae1")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "32ece7e5-7386-44af-a09f-71a574ebcc6c")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "13fc50a9-fba0-4d10-b3d4-6ba0fc4bb3a0")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "8c4dbaf0-7965-412d-a7b1-02bc41f30f05")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "0cb79354-54a9-498a-b6e0-44e6b2cbf265")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "7e687b9f-c736-4534-953b-40deca74daeb")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "f8bd20b5-d2c4-4062-9f0e-c19e227b82f7")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "61f40a00-410d-4380-87be-3c46f7c09368")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/EECS")
+			(uuid "78a6f3f0-f051-43b3-9e47-7f317752e41b")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8136")
+		(at 59.100000 49.900000 180)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C14"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "873eca4f-e31d-4419-9595-34392475f3e5")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100n"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "59106cc4-c482-4ab0-8eb6-bbd510c0143f")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b2581a5b-606d-40e7-8be8-cb8683105c60")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "c3d3aeb6-fc59-4264-87e9-be3559952dae")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f8a4454")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "403db22b-d711-44ff-addb-d917639a0116")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "18914abe-e784-4c36-a5d7-b82cd425c0d6")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "68a507f5-fc4e-4e26-99a9-fba35c64f04e")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "c08c10b6-06a8-403d-bba6-9b3652dabdd4")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c03a1d99-74cd-42c8-aa39-7e2c014034f1")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f1377eab-d959-467b-ac80-251c8d7c07b8")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "fbf00c76-fa50-4d6c-81b2-fef3d677b7af")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c5449e23-aa87-45c0-a65f-77f27adaddc8")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "585d958c-ae1b-4766-a9ce-d0a990750bed")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "8a07deaa-2638-459c-9ef6-14c322de1aa9")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "75a5ce28-3eb1-4eed-b89b-4b8760ad05d1")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "LED_SMD:LED_0603_1608Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8164")
+		(at 48.920000 44.622000 -90)
+		(descr "LED SMD 0603 (1608 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "diode")
+		(property "Reference" "D1"
+			(at 0 -1.43 90)
+			(layer "F.Fab")
+			(uuid "98459e9f-e99a-4437-829b-b7ec00a9e9f4")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "YELLOW"
+			(at 0 1.43 90)
+			(layer "F.Fab")
+			(uuid "f7c3aa98-dbb1-440a-995b-d097b2a5bc5f")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "f3e25ce6-c10a-4558-b34a-656855dbb916")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "863b86af-e60e-4d59-b6a5-ee8d9c002a75")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f292e89")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -1.485 0.735)
+			(end 0.8 0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "900cc357-3d38-4e0e-aa8c-84613cbf4092")
+		)
+		(fp_line
+			(start -1.485 -0.735)
+			(end -1.485 0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "0fa7df76-983d-4952-b36f-681fb71c5b88")
+		)
+		(fp_line
+			(start 0.8 -0.735)
+			(end -1.485 -0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "99436eed-50af-4809-8680-8c61a1fa7bfe")
+		)
+		(fp_line
+			(start -1.48 0.73)
+			(end -1.48 -0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "e4e13b89-0c12-4c85-84ee-154671cde1b3")
+		)
+		(fp_line
+			(start 1.48 0.73)
+			(end -1.48 0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "73720a44-23d3-410a-8338-7cf2e00d9b3c")
+		)
+		(fp_line
+			(start -1.48 -0.73)
+			(end 1.48 -0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "60dfeead-a55c-4188-a2e8-a6a6c840f8bb")
+		)
+		(fp_line
+			(start 1.48 -0.73)
+			(end 1.48 0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "74f4d13c-377a-49da-be76-c368a7da3ce8")
+		)
+		(fp_line
+			(start -0.8 0.4)
+			(end 0.8 0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c45d079e-ae6d-49a4-908f-dbfc117e2a4a")
+		)
+		(fp_line
+			(start 0.8 0.4)
+			(end 0.8 -0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "1a6d886b-7dde-4137-984f-5ab41ff3ea82")
+		)
+		(fp_line
+			(start -0.8 -0.1)
+			(end -0.8 0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ede9a986-9f71-458d-b63b-639fcc3ddad2")
+		)
+		(fp_line
+			(start -0.5 -0.4)
+			(end -0.8 -0.1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d76365d9-a585-446e-9a4e-69c2569506bb")
+		)
+		(fp_line
+			(start 0.8 -0.4)
+			(end -0.5 -0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "5b43165b-7b1c-4e8e-a406-e9cf327db0fa")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "742ca2d2-43fd-429e-bc86-f8c35aa1bbd7")
+			(effects
+				(font
+					(size 0.4 0.4)
+					(thickness 0.06)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.7875 0 270)
+			(size 0.875 0.95)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "f126e847-221e-4c61-be3d-1e9dfe06a58d")
+		)
+		(pad "2" smd roundrect
+			(at 0.7875 0 270)
+			(size 0.875 0.95)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(D1-Pad2)")
+			(uuid "93fbba88-a01b-4d80-8d20-856529bc32b6")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/LED_SMD.3dshapes/LED_0603_1608Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec82b6")
+		(at 63.630000 43.858300 180)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C11"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "b16a175f-b593-432f-9a67-98b971f25031")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100n"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "5236577f-a9b1-4190-a720-6bc5a3222de4")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "f777cac8-c525-46b2-83f4-63591104d0fa")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "011bd6e9-91fb-49b5-ba74-05b17246aaa7")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f7771f1")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "fdaf2c03-84f2-4e69-87a0-7ace7630d4d8")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "1eab2155-285c-476e-8bcc-c6bf1343b3c0")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "630353c3-9e80-48d1-9ad9-b58c00bcc6f0")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "421f9fcb-8d63-4dc7-8fdd-899dcd94055b")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "073a17ea-e2a4-41f2-a091-da07122dc3d4")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "bd777317-9392-406c-9a40-2c3440f7b8b0")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "1b86ed77-88a8-4d4e-bfb7-e392a71d0905")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "49eb451d-2785-4647-9a54-e65e8606be4d")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "9edf8a9b-5b0f-4658-a4b6-81977eaeabb6")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREG")
+			(uuid "3669394d-aa8d-4651-b87b-bd528f3ab0cb")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "36b3eec4-51ab-4630-a7d6-a06b724e8a24")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec82e0")
+		(at 46.100000 58.200000)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R16"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "ae7cd424-6162-4a2a-9c2c-379a40f05723")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "330"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "cc33c862-2e8b-49d8-a523-cdc8319ef910")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "1845ff0f-1676-44d1-ad89-7268e76f796a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "1c1a5485-d98e-4384-8d14-d444ea591bad")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005eec3913")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "8d5ccbfb-d3c4-465f-ac0a-a5c20017f99b")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "287ec7b7-09dc-490f-addf-406ba906c815")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "73e4cded-7459-478b-b162-d25b923de97b")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "80e0eb86-3e58-445e-ad66-2ef32963466a")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a17c8d37-2195-420c-ae05-2174f09a5f17")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "fef5b3a8-595f-4c1e-bedf-4decb7bf318c")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "7e050dd1-9a01-4e74-a39b-cf3cbf22a9e7")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "5bc2fa60-a969-47e5-87a4-22dfbd0df49c")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "02977e7c-15e3-4ca0-8926-74f077ca68f7")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/SWDIO")
+			(uuid "81a68ea5-16fb-4c65-8e34-195f81312718")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/COPI")
+			(uuid "ed7ff3cb-ec01-4323-a46a-f87a72beb4b8")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8394")
+		(at 37.800000 65.700000)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R14"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "fee8b951-e6d5-4e13-910e-a55a16745641")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "5c29e3f3-f73f-4887-991d-47e077e3e3c0")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "1516236f-ee78-4b35-998f-658f33a2812a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "cd3dfbfa-2bdd-4bf1-8d25-9841f805c850")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f34c029")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "80424990-5aeb-4fb4-9295-54d480063197")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "5d6a0bb7-00dc-44bc-b50b-c57283d2c87d")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "b322925e-536b-4f25-a17d-31fdd859d6cd")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "5380f92f-8f11-40ab-944b-0899431443de")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "fa374c1b-4b78-435f-a9c9-6c43989ede85")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "eff2e8cc-3f19-4096-9cbc-7c7ee44313b5")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a92e49f1-f927-472b-b5e8-aca863791565")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e60bd223-94b4-4bdf-b545-8d455a596ed6")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "6a5bdbb7-f428-44ae-81fb-28abda4ae3a3")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "e54db2b5-6b78-41bb-bb7a-7a2cf1c8106e")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/EECLK")
+			(uuid "439c90b1-cdb5-4244-a7f8-c12e08f50bfd")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec83be")
+		(at 55.800000 48.600000 90)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R3"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "c0aa8caa-b2ea-422a-ac4e-8c10790c4393")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "1M"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "a91a9329-7a9f-425a-a677-f9ad61d2e8c3")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "1729fb67-06cd-46bd-9ae8-5b3d1ea9e6c5")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "c0786536-efb9-40f6-b872-36f7bf9c8cf9")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f3a89c1")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "65fcbdaa-307f-48c6-a6d6-b7b0173e023a")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "f60c043d-8d09-46d3-8d37-d98857a7e39f")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "e6e0494d-b3ab-4803-abae-7375e7625179")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "8ebf9d9f-aff5-41f9-9783-39e7bbf8099b")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e5deea1e-e328-45c8-86fd-3bb62b926a89")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "4544c1cc-7959-4a0d-8c6a-184c674f55a7")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "03dbcccd-3745-468a-a907-3cad35c40921")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "791cfcd5-0b73-4354-86a3-40ce90e0c99f")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "a6f4e27e-d19a-48c1-915f-e5cd065bc87d")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "8ba6b89f-ad15-4427-903a-84b0f912b9ed")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(C25-Pad2)")
+			(uuid "04b95793-6925-42f1-a885-ba003d2c323c")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Inductor_SMD:L_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec83e8")
+		(at 51.500000 41.135000 270)
+		(descr "Inductor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "inductor")
+		(property "Reference" "FB3"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "62caf72d-87a1-43ed-996c-0312cd6543a6")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "600R, 0.5A"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "d2fff713-c8bd-4300-b09e-ce750f1cf4bd")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "687c4c7f-0a36-452c-83cd-8c5bfac390bb")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "2db3aab7-ba6e-4b50-bc41-db487461d897")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005fa24965")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2965eee7-b7e1-464a-9bed-f37f6a00c5b4")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "6e8bfb4e-fc1e-48d5-8ba2-b079e8e6918c")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "b88dc8b1-f75b-445b-9f61-40afa271fb80")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "b55560e6-7ebe-4e22-abd5-7cef53ccedbc")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "95140cf7-32fa-4ced-9fd3-e4d1bc294d53")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b6fd31a9-d77f-4c01-bb45-f069572ec02e")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e7fad558-b717-47b9-9a2a-f7c3e990be3e")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "96e350a1-7a5b-4cb5-99cd-8ead4d7576de")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "1ac799a4-ab52-442e-905f-19ba5f52f5b5")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+5V")
+			(uuid "71fe107f-00c0-414b-9012-8436d6199f20")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/VBUS")
+			(uuid "4cabdd9b-d2f6-4479-9b91-1c9c75e0f129")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Inductor_SMD.3dshapes/L_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:OSHW-Symbol_4.4x4mm_SilkScreen"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec840b")
+		(at 35.95 68.01)
+		(descr "Open Source Hardware Symbol")
+		(tags "Logo Symbol OSHW")
+		(property "Reference" "LOGO1"
+			(at 0 0 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "a0285014-d6cf-4a2d-a4ea-19d3dfcd91d5")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "Logo_Open_Hardware_Small"
+			(at 0.75 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "3eac44fd-b589-41cc-9f82-f0418de73732")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "7b319ea8-790c-4a55-80c9-24e85cf3e290")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "4c5e4ad0-aaba-40e2-9938-4f09c3c4fcfa")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ed57cd6")
+		(attr exclude_from_pos_files exclude_from_bom)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_poly
+			(pts
+				(xy 0.050687 -1.999998) (xy 0.09016 -1.999886) (xy 0.128144 -1.999707) (xy 0.163966 -1.999461) (xy 0.196955 -1.99915)
+				(xy 0.226436 -1.998772) (xy 0.251738 -1.998329) (xy 0.272186 -1.997819) (xy 0.287109 -1.997243)
+				(xy 0.295834 -1.996601) (xy 0.297783 -1.996202) (xy 0.3052 -1.99012) (xy 0.308164 -1.986054) (xy 0.309353 -1.981551)
+				(xy 0.311752 -1.97046) (xy 0.315253 -1.953333) (xy 0.31975 -1.930721) (xy 0.325135 -1.903175) (xy 0.331302 -1.871246)
+				(xy 0.338145 -1.835486) (xy 0.345555 -1.796447) (xy 0.353427 -1.754678) (xy 0.361653 -1.710732)
+				(xy 0.36461 -1.694861) (xy 0.372912 -1.650305) (xy 0.380859 -1.607745) (xy 0.388346 -1.567732) (xy 0.395271 -1.530815)
+				(xy 0.40153 -1.497544) (xy 0.407018 -1.468468) (xy 0.411633 -1.444136) (xy 0.415272 -1.425097) (xy 0.417829 -1.411902)
+				(xy 0.419203 -1.4051) (xy 0.419386 -1.404325) (xy 0.423218 -1.397756) (xy 0.429385 -1.39082) (xy 0.434706 -1.387613)
+				(xy 0.446043 -1.382076) (xy 0.462656 -1.374511) (xy 0.483807 -1.365218) (xy 0.508757 -1.354498)
+				(xy 0.536766 -1.342652) (xy 0.567095 -1.329983) (xy 0.599005 -1.31679) (xy 0.631757 -1.303376) (xy 0.664611 -1.29004)
+				(xy 0.696828 -1.277085) (xy 0.72767 -1.264812) (xy 0.756397 -1.253521) (xy 0.78227 -1.243514) (xy 0.804549 -1.235091)
+				(xy 0.822496 -1.228555) (xy 0.835372 -1.224206) (xy 0.842436 -1.222346) (xy 0.843021 -1.222299)
+				(xy 0.853723 -1.223797) (xy 0.865604 -1.229044) (xy 0.877502 -1.236622) (xy 0.884781 -1.241643)
+				(xy 0.897341 -1.250279) (xy 0.914471 -1.262044) (xy 0.935463 -1.276449) (xy 0.959606 -1.29301) (xy 0.986193 -1.311239)
+				(xy 1.014512 -1.330649) (xy 1.038068 -1.34679) (xy 1.070357 -1.368915) (xy 1.104069 -1.392025) (xy 1.138044 -1.415323)
+				(xy 1.171123 -1.438015) (xy 1.202145 -1.459303) (xy 1.229952 -1.478393) (xy 1.253384 -1.49449) (xy 1.261128 -1.499813)
+				(xy 1.287962 -1.518115) (xy 1.309511 -1.532454) (xy 1.326334 -1.54317) (xy 1.338992 -1.550605) (xy 1.348045 -1.555098)
+				(xy 1.354053 -1.556991) (xy 1.355423 -1.557102) (xy 1.357894 -1.556644) (xy 1.361238 -1.555055)
+				(xy 1.365795 -1.552014) (xy 1.371904 -1.547199) (xy 1.379904 -1.540288) (xy 1.390133 -1.530959)
+				(xy 1.402931 -1.518892) (xy 1.418637 -1.503763) (xy 1.43759 -1.485252) (xy 1.460129 -1.463038) (xy 1.486592 -1.436797)
+				(xy 1.51732 -1.406209) (xy 1.55265 -1.370951) (xy 1.572327 -1.351291) (xy 1.614787 -1.308775) (xy 1.652141 -1.271197)
+				(xy 1.684498 -1.238447) (xy 1.711964 -1.210412) (xy 1.734648 -1.18698) (xy 1.752659 -1.168039) (xy 1.766103 -1.153477)
+				(xy 1.77509 -1.143183) (xy 1.779727 -1.137044) (xy 1.780438 -1.135543) (xy 1.780737 -1.125462) (xy 1.778751 -1.118373)
+				(xy 1.776123 -1.114295) (xy 1.769704 -1.104707) (xy 1.759816 -1.090083) (xy 1.746781 -1.070894)
+				(xy 1.73092 -1.047612) (xy 1.712556 -1.02071) (xy 1.692011 -0.99066) (xy 1.669608 -0.957934) (xy 1.645667 -0.923004)
+				(xy 1.620512 -0.886343) (xy 1.614639 -0.877789) (xy 1.584506 -0.833867) (xy 1.558261 -0.795512)
+				(xy 1.535649 -0.762332) (xy 1.516413 -0.733933) (xy 1.500297 -0.709923) (xy 1.487045 -0.689909)
+				(xy 1.476402 -0.673498) (xy 1.46811 -0.660297) (xy 1.461915 -0.649914) (xy 1.45756 -0.641956) (xy 1.454789 -0.63603)
+				(xy 1.453346 -0.631744) (xy 1.453014 -0.629828) (xy 1.453034 -0.626059) (xy 1.453853 -0.620987)
+				(xy 1.455673 -0.614102) (xy 1.458694 -0.604896) (xy 1.463119 -0.592861) (xy 1.469149 -0.577487)
+				(xy 1.476987 -0.558267) (xy 1.486834 -0.534691) (xy 1.498892 -0.506253) (xy 1.513362 -0.472442)
+				(xy 1.530447 -0.432751) (xy 1.540169 -0.410229) (xy 1.560473 -0.363376) (xy 1.578131 -0.32297) (xy 1.593267 -0.288748)
+				(xy 1.605999 -0.260446) (xy 1.616451 -0.237801) (xy 1.624742 -0.220547) (xy 1.630995 -0.208423)
+				(xy 1.63533 -0.201163) (xy 1.637375 -0.198767) (xy 1.642559 -0.196515) (xy 1.653301 -0.193441) (xy 1.669857 -0.18949)
+				(xy 1.692482 -0.184607) (xy 1.721432 -0.178739) (xy 1.756961 -0.171829) (xy 1.799327 -0.163825)
+				(xy 1.812997 -0.161278) (xy 1.874571 -0.149841) (xy 1.929408 -0.139653) (xy 1.977904 -0.130634)
+				(xy 2.02046 -0.122699) (xy 2.057473 -0.115769) (xy 2.089342 -0.109759) (xy 2.116464 -0.104589) (xy 2.139237 -0.100176)
+				(xy 2.158062 -0.096437) (xy 2.173334 -0.093291) (xy 2.185454 -0.090655) (xy 2.194818 -0.088448)
+				(xy 2.201826 -0.086587) (xy 2.206876 -0.084989) (xy 2.210365 -0.083574) (xy 2.212692 -0.082257)
+				(xy 2.214256 -0.080959) (xy 2.215455 -0.079595) (xy 2.216686 -0.078085) (xy 2.216783 -0.077972)
+				(xy 2.22495 -0.068558) (xy 2.22495 0.512333) (xy 2.214968 0.522044) (xy 2.212789 0.523934) (xy 2.209957 0.525743)
+				(xy 2.205975 0.527578) (xy 2.200346 0.529544) (xy 2.192571 0.531747) (xy 2.182153 0.534293) (xy 2.168594 0.537288)
+				(xy 2.151397 0.540836) (xy 2.130063 0.545045) (xy 2.104096 0.55002) (xy 2.072997 0.555867) (xy 2.036269 0.56269)
+				(xy 1.993413 0.570597) (xy 1.943933 0.579692) (xy 1.94184 0.580077) (xy 1.898721 0.58803) (xy 1.857394 0.59572)
+				(xy 1.81846 0.603031) (xy 1.78252 0.609848) (xy 1.750173 0.616054) (xy 1.72202 0.621533) (xy 1.698663 0.62617)
+				(xy 1.6807 0.629849) (xy 1.668734 0.632454) (xy 1.663562 0.633792) (xy 1.652924 0.638957) (xy 1.644817 0.645275)
+				(xy 1.643319 0.647165) (xy 1.641109 0.651859) (xy 1.636459 0.662707) (xy 1.62961 0.679119) (xy 1.620804 0.700502)
+				(xy 1.610283 0.726266) (xy 1.598286 0.755818) (xy 1.585056 0.788568) (xy 1.570834 0.823924) (xy 1.555861 0.861294)
+				(xy 1.551653 0.871823) (xy 1.534258 0.915386) (xy 1.519379 0.952726) (xy 1.506829 0.984362) (xy 1.496425 1.010809)
+				(xy 1.487982 1.032584) (xy 1.481317 1.050204) (xy 1.476244 1.064186) (xy 1.472578 1.075048) (xy 1.470137 1.083304)
+				(xy 1.468735 1.089473) (xy 1.468188 1.094072) (xy 1.468311 1.097616) (xy 1.468921 1.100623) (xy 1.469418 1.102303)
+				(xy 1.472149 1.107504) (xy 1.478678 1.118167) (xy 1.488667 1.133785) (xy 1.501781 1.153854) (xy 1.517683 1.177867)
+				(xy 1.536037 1.20532) (xy 1.556506 1.235705) (xy 1.578755 1.268519) (xy 1.602445 1.303254) (xy 1.624577 1.335529)
+				(xy 1.6492 1.371368) (xy 1.67267 1.405567) (xy 1.694654 1.43764) (xy 1.714821 1.4671) (xy 1.732839 1.493462)
+				(xy 1.748375 1.516238) (xy 1.761096 1.534941) (xy 1.770671 1.549087) (xy 1.776767 1.558187) (xy 1.779018 1.561685)
+				(xy 1.780985 1.570233) (xy 1.780438 1.578354) (xy 1.777849 1.582539) (xy 1.770963 1.590824) (xy 1.759672 1.603322)
+				(xy 1.743868 1.620144) (xy 1.723444 1.641403) (xy 1.698291 1.667211) (xy 1.668301 1.697679) (xy 1.633367 1.732919)
+				(xy 1.59338 1.773043) (xy 1.571884 1.794546) (xy 1.534488 1.831911) (xy 1.501872 1.864468) (xy 1.473684 1.892543)
+				(xy 1.449576 1.916466) (xy 1.429196 1.936563) (xy 1.412195 1.953163) (xy 1.398223 1.966594) (xy 1.386929 1.977185)
+				(xy 1.377964 1.985261) (xy 1.370977 1.991153) (xy 1.365619 1.995187) (xy 1.361539 1.997692) (xy 1.358387 1.998996)
+				(xy 1.355814 1.999426) (xy 1.353468 1.999311) (xy 1.353326 1.999294) (xy 1.348204 1.997428) (xy 1.338982 1.992501)
+				(xy 1.32541 1.984352) (xy 1.30724 1.97282) (xy 1.284222 1.957741) (xy 1.256107 1.938955) (xy 1.222644 1.9163)
+				(xy 1.183586 1.889615) (xy 1.174178 1.88316) (xy 1.140944 1.860343) (xy 1.107778 1.837572) (xy 1.075483 1.815399)
+				(xy 1.044866 1.794378) (xy 1.016731 1.775061) (xy 0.991885 1.758001) (xy 0.971132 1.743752) (xy 0.955278 1.732866)
+				(xy 0.951053 1.729965) (xy 0.929644 1.715469) (xy 0.91319 1.704859) (xy 0.900845 1.697655) (xy 0.891763 1.693378)
+				(xy 0.885098 1.69155) (xy 0.882881 1.691397) (xy 0.876698 1.692684) (xy 0.866232 1.696669) (xy 0.851095 1.703536)
+				(xy 0.830899 1.713471) (xy 0.805256 1.726661) (xy 0.77378 1.743289) (xy 0.768998 1.745841) (xy 0.743875 1.759166)
+				(xy 0.720616 1.77131) (xy 0.700038 1.781861) (xy 0.68296 1.790406) (xy 0.670201 1.796532) (xy 0.662581 1.799828)
+				(xy 0.66092 1.800286) (xy 0.652878 1.798206) (xy 0.648531 1.795749) (xy 0.646582 1.792031) (xy 0.642057 1.78206)
+				(xy 0.635147 1.766293) (xy 0.626043 1.74519) (xy 0.614936 1.719208) (xy 0.602016 1.688805) (xy 0.587474 1.65444)
+				(xy 0.571501 1.616569) (xy 0.554288 1.575653) (xy 0.536025 1.532148) (xy 0.516904 1.486513) (xy 0.497115 1.439206)
+				(xy 0.476848 1.390685) (xy 0.456296 1.341408) (xy 0.435648 1.291834) (xy 0.415095 1.24242) (xy 0.394828 1.193625)
+				(xy 0.375037 1.145906) (xy 0.355915 1.099722) (xy 0.337651 1.055531) (xy 0.320435 1.013791) (xy 0.30446 0.97496)
+				(xy 0.289916 0.939497) (xy 0.276993 0.907859) (xy 0.265882 0.880504) (xy 0.256774 0.857891) (xy 0.249861 0.840478)
+				(xy 0.245331 0.828723) (xy 0.243377 0.823084) (xy 0.243312 0.822703) (xy 0.245719 0.814414) (xy 0.252883 0.805363)
+				(xy 0.265461 0.794903) (xy 0.284111 0.782385) (xy 0.284257 0.782294) (xy 0.347287 0.739467) (xy 0.403501 0.694367)
+				(xy 0.453024 0.646846) (xy 0.495982 0.596757) (xy 0.532499 0.54395) (xy 0.5627 0.488277) (xy 0.586711 0.429591)
+				(xy 0.589743 0.420652) (xy 0.598441 0.393521) (xy 0.605214 0.370001) (xy 0.610296 0.34849) (xy 0.613919 0.327389)
+				(xy 0.616316 0.305097) (xy 0.61772 0.280014) (xy 0.618364 0.250538) (xy 0.618489 0.223221) (xy 0.618418 0.194467)
+				(xy 0.618149 0.171681) (xy 0.617598 0.15357) (xy 0.61668 0.138844) (xy 0.615312 0.12621) (xy 0.61341 0.114379)
+				(xy 0.610889 0.102057) (xy 0.610476 0.100197) (xy 0.592154 0.033237) (xy 0.567957 -0.029527) (xy 0.537762 -0.088329)
+				(xy 0.501444 -0.143401) (xy 0.458881 -0.194977) (xy 0.448257 -0.206306) (xy 0.399575 -0.25187) (xy 0.346668 -0.291701)
+				(xy 0.290042 -0.325545) (xy 0.230206 -0.353146) (xy 0.167667 -0.37425) (xy 0.102932 -0.3886) (xy 0.078676 -0.392127)
+				(xy 0.053089 -0.394308) (xy 0.022882 -0.395241) (xy -0.0099 -0.395002) (xy -0.043211 -0.393667)
+				(xy -0.075007 -0.391309) (xy -0.103241 -0.388004) (xy -0.121592 -0.384792) (xy -0.186624 -0.367375)
+				(xy -0.248597 -0.343647) (xy -0.307131 -0.31395) (xy -0.361843 -0.278626) (xy -0.412352 -0.238018)
+				(xy -0.458276 -0.192468) (xy -0.499234 -0.142317) (xy -0.534843 -0.08791) (xy -0.564722 -0.029586)
+				(xy -0.58849 0.03231) (xy -0.589189 0.034481) (xy -0.605547 0.09727) (xy -0.615227 0.161806) (xy -0.61823 0.227158)
+				(xy -0.614561 0.292395) (xy -0.604223 0.356588) (xy -0.587685 0.417405) (xy -0.565004 0.476061)
+				(xy -0.536818 0.531279) (xy -0.502876 0.583358) (xy -0.462928 0.632594) (xy -0.416726 0.679284)
+				(xy -0.364018 0.723726) (xy -0.304554 0.766218) (xy -0.282409 0.78049) (xy -0.266043 0.79112) (xy -0.254959 0.799305)
+				(xy -0.248037 0.806018) (xy -0.244156 0.812231) (xy -0.243332 0.814399) (xy -0.242912 0.816314)
+				(xy -0.24287 0.818857) (xy -0.243334 0.822357) (xy -0.244436 0.827145) (xy -0.246306 0.833549) (xy -0.249074 0.841899)
+				(xy -0.25287 0.852522) (xy -0.257825 0.865749) (xy -0.26407 0.881908) (xy -0.271734 0.901329) (xy -0.280949 0.92434)
+				(xy -0.291844 0.951272) (xy -0.304549 0.982452) (xy -0.319196 1.01821) (xy -0.335914 1.058875) (xy -0.354835 1.104776)
+				(xy -0.376087 1.156243) (xy -0.399802 1.213603) (xy -0.426111 1.277188) (xy -0.439157 1.308709)
+				(xy -0.462542 1.365134) (xy -0.485233 1.419749) (xy -0.50707 1.472173) (xy -0.527892 1.522028) (xy -0.54754 1.568934)
+				(xy -0.565852 1.612511) (xy -0.582668 1.65238) (xy -0.597828 1.688162) (xy -0.611172 1.719477) (xy -0.622539 1.745946)
+				(xy -0.631769 1.767189) (xy -0.638702 1.782827) (xy -0.643177 1.79248) (xy -0.644983 1.795749) (xy -0.653124 1.799575)
+				(xy -0.65753 1.800286) (xy -0.662214 1.798617) (xy -0.672449 1.793889) (xy -0.687413 1.786517) (xy -0.706283 1.776917)
+				(xy -0.728238 1.765504) (xy -0.752454 1.752693) (xy -0.765251 1.745841) (xy -0.796788 1.729026)
+				(xy -0.822522 1.715622) (xy -0.84293 1.705403) (xy -0.85849 1.69814) (xy -0.869678 1.693603) (xy -0.876971 1.691564)
+				(xy -0.878858 1.691397) (xy -0.882024 1.691949) (xy -0.886733 1.693773) (xy -0.89338 1.697126) (xy -0.902356 1.702263)
+				(xy -0.914055 1.70944) (xy -0.92887 1.718912) (xy -0.947193 1.730935) (xy -0.969417 1.745765) (xy -0.995935 1.763658)
+				(xy -1.02714 1.784868) (xy -1.063426 1.809652) (xy -1.105184 1.838265) (xy -1.115955 1.845656) (xy -1.160217 1.87599)
+				(xy -1.198876 1.902386) (xy -1.232276 1.92507) (xy -1.260761 1.944267) (xy -1.284675 1.960201) (xy -1.304363 1.973098)
+				(xy -1.320168 1.983182) (xy -1.332435 1.99068) (xy -1.341507 1.995815) (xy -1.347729 1.998814) (xy -1.351445 1.999901)
+				(xy -1.351747 1.999914) (xy -1.354216 1.999464) (xy -1.357543 1.997899) (xy -1.362067 1.994898)
+				(xy -1.368127 1.990138) (xy -1.376062 1.983298) (xy -1.386212 1.974056) (xy -1.398916 1.96209) (xy -1.414513 1.947078)
+				(xy -1.433344 1.928699) (xy -1.455746 1.90663) (xy -1.48206 1.88055) (xy -1.512625 1.850137) (xy -1.547781 1.815069)
+				(xy -1.568942 1.793934) (xy -1.601098 1.761731) (xy -1.63177 1.730867) (xy -1.660565 1.701742) (xy -1.687094 1.67476)
+				(xy -1.710965 1.650323) (xy -1.731787 1.628834) (xy -1.74917 1.610695) (xy -1.762722 1.596307) (xy -1.772052 1.586075)
+				(xy -1.77677 1.580399) (xy -1.777273 1.579519) (xy -1.777471 1.569553) (xy -1.775555 1.562581) (xy -1.772908 1.558262)
+				(xy -1.766475 1.548455) (xy -1.756589 1.533651) (xy -1.743582 1.514338) (xy -1.727786 1.491007)
+				(xy -1.709534 1.464149) (xy -1.689157 1.434252) (xy -1.66699 1.401808) (xy -1.643363 1.367306) (xy -1.62014 1.333464)
+				(xy -1.59496 1.2967) (xy -1.571076 1.26162) (xy -1.548808 1.228707) (xy -1.528478 1.198445) (xy -1.510408 1.17132)
+				(xy -1.494918 1.147816) (xy -1.482331 1.128416) (xy -1.472966 1.113605) (xy -1.467146 1.103868)
+				(xy -1.46523 1.099959) (xy -1.464696 1.096931) (xy -1.464704 1.093184) (xy -1.465443 1.088197) (xy -1.4671 1.081451)
+				(xy -1.469864 1.072426) (xy -1.473923 1.060602) (xy -1.479464 1.04546) (xy -1.486676 1.026481) (xy -1.495747 1.003143)
+				(xy -1.506866 0.974928) (xy -1.520219 0.941316) (xy -1.535996 0.901787) (xy -1.546088 0.87655) (xy -1.564157 0.831384)
+				(xy -1.57973 0.792474) (xy -1.593015 0.75934) (xy -1.60422 0.731501) (xy -1.613554 0.708476) (xy -1.621223 0.689786)
+				(xy -1.627436 0.674949) (xy -1.632401 0.663484) (xy -1.636327 0.654913) (xy -1.63942 0.648753) (xy -1.641889 0.644524)
+				(xy -1.643943 0.641746) (xy -1.645788 0.639938) (xy -1.647634 0.638619) (xy -1.649618 0.637355)
+				(xy -1.654586 0.635758) (xy -1.666208 0.632969) (xy -1.683994 0.629084) (xy -1.707457 0.624203)
+				(xy -1.736106 0.618421) (xy -1.769452 0.611839) (xy -1.807005 0.604552) (xy -1.848277 0.59666) (xy -1.892778 0.588259)
+				(xy -1.931507 0.581027) (xy -1.982253 0.57159) (xy -2.026343 0.563364) (xy -2.064263 0.556247) (xy -2.096495 0.550134)
+				(xy -2.123525 0.544922) (xy -2.145835 0.540508) (xy -2.163911 0.536788) (xy -2.178236 0.533658)
+				(xy -2.189294 0.531016) (xy -2.197569 0.528757) (xy -2.203545 0.526778) (xy -2.207707 0.524976)
+				(xy -2.210538 0.523247) (xy -2.212522 0.521487) (xy -2.213154 0.52079) (xy -2.22132 0.51137) (xy -2.22132 -0.068558)
+				(xy -2.213064 -0.078157) (xy -2.21131 -0.079962) (xy -2.208965 -0.081684) (xy -2.20555 -0.083426)
+				(xy -2.200587 -0.085289) (xy -2.193596 -0.087377) (xy -2.184099 -0.089791) (xy -2.171617 -0.092633)
+				(xy -2.155671 -0.096006) (xy -2.135784 -0.100013) (xy -2.111476 -0.104754) (xy -2.082268 -0.110334)
+				(xy -2.047682 -0.116853) (xy -2.007239 -0.124415) (xy -1.96046 -0.133121) (xy -1.924894 -0.139728)
+				(xy -1.869256 -0.150114) (xy -1.819003 -0.159609) (xy -1.77435 -0.16817) (xy -1.735516 -0.175755)
+				(xy -1.702715 -0.182318) (xy -1.676167 -0.187816) (xy -1.656086 -0.192207) (xy -1.642692 -0.195447)
+				(xy -1.636199 -0.197491) (xy -1.635835 -0.197691) (xy -1.633768 -0.198958) (xy -1.631972 -0.200098)
+				(xy -1.630221 -0.201598) (xy -1.628291 -0.203944) (xy -1.625956 -0.207623) (xy -1.622992 -0.213122)
+				(xy -1.619172 -0.220927) (xy -1.614272 -0.231526) (xy -1.608066 -0.245403) (xy -1.60033 -0.263047)
+				(xy -1.590838 -0.284944) (xy -1.579365 -0.31158) (xy -1.565686 -0.343442) (xy -1.549576 -0.381016)
+				(xy -1.531604 -0.422936) (xy -1.51355 -0.465115) (xy -1.498209 -0.501149) (xy -1.485381 -0.531544)
+				(xy -1.474867 -0.556804) (xy -1.466469 -0.577435) (xy -1.459988 -0.593941) (xy -1.455223 -0.606828)
+				(xy -1.451977 -0.616601) (xy -1.450051 -0.623765) (xy -1.449245 -0.628825) (xy -1.449288 -0.631826)
+				(xy -1.450733 -0.636009) (xy -1.454481 -0.643284) (xy -1.460728 -0.653947) (xy -1.469668 -0.668293)
+				(xy -1.481494 -0.686619) (xy -1.496402 -0.709219) (xy -1.514585 -0.736389) (xy -1.536239 -0.768425)
+				(xy -1.561557 -0.805622) (xy -1.590733 -0.848276) (xy -1.611152 -0.878037) (xy -1.636532 -0.915016)
+				(xy -1.660771 -0.950369) (xy -1.683545 -0.983625) (xy -1.704533 -1.014311) (xy -1.723413 -1.041955)
+				(xy -1.739862 -1.066085) (xy -1.753558 -1.08623) (xy -1.76418 -1.101916) (xy -1.771406 -1.112672)
+				(xy -1.774912 -1.118025) (xy -1.775156 -1.118438) (xy -1.777301 -1.127358) (xy -1.776809 -1.135543)
+				(xy -1.774218 -1.13973) (xy -1.767329 -1.14802) (xy -1.756034 -1.160523) (xy -1.740225 -1.177351)
+				(xy -1.719793 -1.198618) (xy -1.694631 -1.224434) (xy -1.664631 -1.254911) (xy -1.629685 -1.290162)
+				(xy -1.589684 -1.330298) (xy -1.568698 -1.351291) (xy -1.53095 -1.388993) (xy -1.497977 -1.421866)
+				(xy -1.469437 -1.450231) (xy -1.44499 -1.474411) (xy -1.424296 -1.49473) (xy -1.407015 -1.511509)
+				(xy -1.392807 -1.525072) (xy -1.381332 -1.53574) (xy -1.372249 -1.543837) (xy -1.365219 -1.549685)
+				(xy -1.359901 -1.553607) (xy -1.355955 -1.555925) (xy -1.353041 -1.556961) (xy -1.351685 -1.557102)
+				(xy -1.348363 -1.556265) (xy -1.342654 -1.553608) (xy -1.334222 -1.548909) (xy -1.322732 -1.541949)
+				(xy -1.307849 -1.532508) (xy -1.289236 -1.520365) (xy -1.266558 -1.5053) (xy -1.239481 -1.487093)
+				(xy -1.207668 -1.465523) (xy -1.170783 -1.44037) (xy -1.128493 -1.411414) (xy -1.099501 -1.391517)
+				(xy -1.061836 -1.365689) (xy -1.025731 -1.341009) (xy -0.991657 -1.317794) (xy -0.960085 -1.296362)
+				(xy -0.931484 -1.277028) (xy -0.906325 -1.260109) (xy -0.885077 -1.245922) (xy -0.868212 -1.234784)
+				(xy -0.856198 -1.227012) (xy -0.849506 -1.222921) (xy -0.848441 -1.222392) (xy -0.84596 -1.221489)
+				(xy -0.843576 -1.220821) (xy -0.840779 -1.220579) (xy -0.837056 -1.220949) (xy -0.831898 -1.22212)
+				(xy -0.824793 -1.224279) (xy -0.815229 -1.227616) (xy -0.802697 -1.232317) (xy -0.786685 -1.238572)
+				(xy -0.766681 -1.246567) (xy -0.742176 -1.256492) (xy -0.712657 -1.268534) (xy -0.677614 -1.28288)
+				(xy -0.636536 -1.29972) (xy -0.621099 -1.30605) (xy -0.58605 -1.320498) (xy -0.552844 -1.334341)
+				(xy -0.522122 -1.347301) (xy -0.494527 -1.359098) (xy -0.470703 -1.369456) (xy -0.45129 -1.378095)
+				(xy -0.436933 -1.384737) (xy -0.428273 -1.389104) (xy -0.426069 -1.390525) (xy -0.419476 -1.397952)
+				(xy -0.415775 -1.404325) (xy -0.41485 -1.408723) (xy -0.412705 -1.419709) (xy -0.409442 -1.436733)
+				(xy -0.405166 -1.459246) (xy -0.39998 -1.486698) (xy -0.393987 -1.51854) (xy -0.387291 -1.554222)
+				(xy -0.379996 -1.593195) (xy -0.372204 -1.634909) (xy -0.364021 -1.678815) (xy -0.361052 -1.694762)
+				(xy -0.35273 -1.739339) (xy -0.344723 -1.781933) (xy -0.337138 -1.821995) (xy -0.330083 -1.858972)
+				(xy -0.323665 -1.892312) (xy -0.31799 -1.921464) (xy -0.313165 -1.945877) (xy -0.309297 -1.964998)
+				(xy -0.306494 -1.978276) (xy -0.304862 -1.98516) (xy -0.304588 -1.985955) (xy -0.298445 -1.993166)
+				(xy -0.294154 -1.996202) (xy -0.289304 -1.996882) (xy -0.277869 -1.997496) (xy -0.26052 -1.998043)
+				(xy -0.237931 -1.998525) (xy -0.210774 -1.998941) (xy -0.179723 -1.99929) (xy -0.145451 -1.999573)
+				(xy -0.108629 -1.999791) (xy -0.069932 -1.999941) (xy -0.030031 -2.000026) (xy 0.010399 -2.000045)
+				(xy 0.050687 -1.999998)
+			)
+			(stroke
+				(width 0.01)
+				(type solid)
+			)
+			(fill yes)
+			(layer "F.SilkS")
+			(uuid "24a4f09c-bcf2-4d37-b069-f9016865e628")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8955")
+		(at 42.500000 65.100000 270)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R19"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "10923be2-ad37-4cfa-9777-2abce06655aa")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "4f0df729-8c6a-45e5-86a8-8b570e92236b")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "1531b616-4636-4693-902d-c828b930d7ce")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "7bb9038b-811c-4c92-8155-bb145c8856e3")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-0000601ada37")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "918c34dc-c621-4597-825d-6af99fcf702c")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "b48a6284-32ec-469c-8a01-386e429f4aab")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "e7541b12-027e-42e1-b51d-4eead07d0470")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "d8748be3-b036-4f61-8e12-1edf818a019c")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "04727b06-cf1d-47b9-ae86-c7640f9df266")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "0302117d-9be2-4b99-9ae0-9846971cf660")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "147c7a62-9e83-4a23-8bd3-ffcbc09f2b3c")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "82ca9151-06bc-425f-a883-d8df30ab77af")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "afa72659-0673-4785-af47-969a4491d48e")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(R19-Pad1)")
+			(uuid "40b11841-6fc5-4cb4-9f6e-7bedf9010380")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "666e4edc-04a7-49b9-bb6e-671f60d95d81")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec897f")
+		(at 35.400000 62.900000 90)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R5"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "ffe15749-d196-48ed-b96d-2753b30855bf")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "330"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "78342dae-943e-4c4d-a6c6-03168173060d")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "22e6cdf1-ab78-4cb2-b524-13b083924334")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "d8c1eb00-0a03-43c0-ad29-b517cfd703f8")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-0000601afbaf")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "b6c2f6fb-44a3-4ae9-84d3-c7b4be8834d8")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "0bf56e37-13e9-4c77-b0e0-b3b4e68df491")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2576df56-b9ae-4fd3-8219-8c7e7b814c6f")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "da8db2bc-5fba-4662-9d74-4683cdb5698d")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "05735906-a1ac-4c3d-b0df-7d490c4e69c9")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "42697b25-b7d4-4751-bba6-9c4b625f20fb")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "7c0b186d-dbec-492c-8741-4b35e8e07bb1")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ef754388-28d5-445a-be11-cfb380da3e8a")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "9376e41b-84bf-45f3-aa58-c31ea68afe59")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "16a20b31-b1c9-4e32-9b63-84142756fb8c")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(D2-Pad2)")
+			(uuid "08eb4d54-e333-4edb-b4ca-de35916e0e8a")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec89a9")
+		(at 44.265000 65.135000 180)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C9"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "ca3e7e69-3a97-42b6-9eb3-b7024d0fa283")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "2u2"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "f09669c3-4675-4f75-ab6a-8326d13c1093")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "1ada1a63-154e-4416-a87f-aa0b9fa87e83")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "7df42cd3-13ae-4850-9376-44204a7b9222")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005eec8444")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "7d8b566a-7e4c-48b2-8525-6853a2624186")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "43f5c3b6-a258-4894-8f19-b939ad17c509")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "afcd4454-99d7-41a3-b347-8fe1ede081a1")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "4a484c54-0a9a-4f69-af74-ef74c67d71b7")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "38e9c1e9-247b-41ef-a592-49f042f6c2b2")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c1dddc5a-5606-4ddb-aa0f-f888d25273de")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f051d52a-3c4a-42d8-b0e6-9a160a4641ee")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b5999448-5837-447e-8426-d0502bcdd60b")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "caffa770-7669-4613-b681-affa8efbc985")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREG")
+			(uuid "050b8ca2-52e1-4605-9d34-63d47c2e007c")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "50bea7b1-f701-4c39-bd3d-cdea28e17489")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Package_SO:TSSOP-24_4.4x7.8mm_P0.65mm"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec89ee")
+		(at 51.270000 66.900000)
+		(descr "TSSOP, 24 Pin (JEDEC MO-153 Var AD https://www.jedec.org/document_search?search_api_views_fulltext=MO-153), generated with kicad-footprint-generator ipc_gullwing_generator.py")
+		(tags "TSSOP SO")
+		(property "Reference" "U6"
+			(at 0 -4.85 0)
+			(layer "F.Fab")
+			(uuid "dc3357f4-8514-474d-a409-6c64a383593e")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "SN74LVC8T245"
+			(at 0 4.85 0)
+			(layer "F.Fab")
+			(uuid "0dc39160-b504-4859-85a3-b51f5bc58add")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "4c6784b9-3f2f-47ab-b0ad-412eee79c7e2")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "87eeab2b-8caa-4587-a080-cb580625d912")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005edc70fa")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0 -4.035)
+			(end -3.6 -4.035)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "8a6eb144-5f22-48fc-93e7-1d2a188e8d9a")
+		)
+		(fp_line
+			(start 0 -4.035)
+			(end 2.2 -4.035)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "7209b7d3-9af9-48e6-99dc-0f9249a525e3")
+		)
+		(fp_line
+			(start 0 4.035)
+			(end -2.2 4.035)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "1dd5edd3-37ab-4018-b568-ee45260d920e")
+		)
+		(fp_line
+			(start 0 4.035)
+			(end 2.2 4.035)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "27f56d80-36d5-48fe-b6ed-7b672573f7b5")
+		)
+		(fp_line
+			(start -3.85 -4.15)
+			(end -3.85 4.15)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "10e2e39f-e4ef-44e7-86b2-efb9995c5e2e")
+		)
+		(fp_line
+			(start -3.85 4.15)
+			(end 3.85 4.15)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "167bb9a4-2c7f-47bb-94ca-1ebf0673b701")
+		)
+		(fp_line
+			(start 3.85 -4.15)
+			(end -3.85 -4.15)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "847e6c15-c4cc-4fb0-8ed7-bbe6af0b9d27")
+		)
+		(fp_line
+			(start 3.85 4.15)
+			(end 3.85 -4.15)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "6f1782c9-3d56-4ffe-825d-e983d4a18125")
+		)
+		(fp_line
+			(start -2.2 -2.9)
+			(end -1.2 -3.9)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "5d1a1f9a-6d9f-46d4-bb6f-4789b2068311")
+		)
+		(fp_line
+			(start -2.2 3.9)
+			(end -2.2 -2.9)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "3a93bd1a-c007-48d6-a3d3-c7aa3a00e71c")
+		)
+		(fp_line
+			(start -1.2 -3.9)
+			(end 2.2 -3.9)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "483473b9-1283-4881-b4fa-8c83d8fee4e6")
+		)
+		(fp_line
+			(start 2.2 -3.9)
+			(end 2.2 3.9)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d16f3126-a1b7-4a65-b4fe-5e578100d3e9")
+		)
+		(fp_line
+			(start 2.2 3.9)
+			(end -2.2 3.9)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "cbbdfe46-14ad-4fd7-bf27-5da1be09c7b2")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "6bcd2d84-d9e4-42ba-8741-93fd9177bf5b")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -2.8625 -3.575)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "0fa6b909-3df7-47b3-a0cb-4954d4d8865a")
+		)
+		(pad "2" smd roundrect
+			(at -2.8625 -2.925)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(R19-Pad1)")
+			(uuid "c4ed339b-1513-4edf-807c-28c739effa57")
+		)
+		(pad "3" smd roundrect
+			(at -2.8625 -2.275)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN5-Pad8)")
+			(uuid "3b0b7e50-8b29-46f2-8ce2-dbdbf41af882")
+		)
+		(pad "4" smd roundrect
+			(at -2.8625 -1.625)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN5-Pad7)")
+			(uuid "7dd7cb20-2af4-44a1-8658-204ded849a66")
+		)
+		(pad "5" smd roundrect
+			(at -2.8625 -0.975)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN5-Pad6)")
+			(uuid "63a6dd5a-27db-44af-8169-291f728d697c")
+		)
+		(pad "6" smd roundrect
+			(at -2.8625 -0.325)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN5-Pad5)")
+			(uuid "31f21a2d-68dd-4e82-b808-6d8fa630719b")
+		)
+		(pad "7" smd roundrect
+			(at -2.8625 0.325)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN6-Pad8)")
+			(uuid "999a3082-c801-41b4-b63a-e539a7931043")
+		)
+		(pad "8" smd roundrect
+			(at -2.8625 0.975)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN6-Pad7)")
+			(uuid "b0ff7f43-1d6d-47ee-b3a3-1f10a2a29a31")
+		)
+		(pad "9" smd roundrect
+			(at -2.8625 1.625)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN6-Pad6)")
+			(uuid "de5eba7a-7a3a-43bc-bc4b-923c999775ba")
+		)
+		(pad "10" smd roundrect
+			(at -2.8625 2.275)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN6-Pad5)")
+			(uuid "43e176e5-7e7f-418a-bf13-46f77cb12bb1")
+		)
+		(pad "11" smd roundrect
+			(at -2.8625 2.925)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "a341416c-bf26-41f8-a013-213edfb17061")
+		)
+		(pad "12" smd roundrect
+			(at -2.8625 3.575)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "4653e73e-c4d0-4bf9-ab22-2da08d3b1145")
+		)
+		(pad "13" smd roundrect
+			(at 2.8625 3.575)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "46dad4c6-4d83-4b30-98d7-8c5b2a7f56e5")
+		)
+		(pad "14" smd roundrect
+			(at 2.8625 2.925)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN8-Pad4)")
+			(uuid "305a6464-1500-4734-a229-639452becee6")
+		)
+		(pad "15" smd roundrect
+			(at 2.8625 2.275)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN8-Pad3)")
+			(uuid "ea02d8fb-db9a-4f58-8279-ce7821d46ac9")
+		)
+		(pad "16" smd roundrect
+			(at 2.8625 1.625)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/ICE_CDONE")
+			(uuid "f6d871f8-d61e-4f45-98f7-119daa7b737c")
+		)
+		(pad "17" smd roundrect
+			(at 2.8625 0.975)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/DI")
+			(uuid "c6ae8299-31e7-4c03-b0da-6f239b47b59a")
+		)
+		(pad "18" smd roundrect
+			(at 2.8625 0.325)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/~{UART_DCD}")
+			(uuid "445420c2-99fa-40d6-8e95-247fd43b8beb")
+		)
+		(pad "19" smd roundrect
+			(at 2.8625 -0.325)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/~{UART_DSR}")
+			(uuid "8cf18b3d-6f29-4304-ae82-f0d2b16124f0")
+		)
+		(pad "20" smd roundrect
+			(at 2.8625 -0.975)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/~{UART_CTS}")
+			(uuid "43589fe4-2097-4d20-a182-0564ba5e50e8")
+		)
+		(pad "21" smd roundrect
+			(at 2.8625 -1.625)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/ICE_CDONE")
+			(uuid "6f7c8314-9154-4f5a-b662-19eea41a7398")
+		)
+		(pad "22" smd roundrect
+			(at 2.8625 -2.275)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/~{ENABLE}")
+			(uuid "54840450-cedc-4d66-83eb-9b587a9fa44b")
+		)
+		(pad "23" smd roundrect
+			(at 2.8625 -2.925)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "0fe3e084-edc4-4be7-ac0c-00dbca318a15")
+		)
+		(pad "24" smd roundrect
+			(at 2.8625 -3.575)
+			(size 1.475 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "b3b9bcda-45e8-4b31-b8b9-0ede9c190365")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Package_SO.3dshapes/TSSOP-24_4.4x7.8mm_P0.65mm.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8a84")
+		(at 48.943000 46.908000 180)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R4"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "8c4f401d-d616-4c4e-9ef0-a50582865f5d")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "330"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "be4d18fe-22e4-42db-bcb2-6ed2fa74bc5b")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "f18fd053-3d5a-47fd-85b1-5e324305f08b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "4e5a889f-628e-4c51-ae2f-6ed2990453fe")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ec7911b")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "1433eb8d-f188-45ae-a3bd-c2345282879d")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "4010cf6e-0a59-4f26-a9c7-f7b6751ba913")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "f999a0af-ce5d-4380-8446-d5a58ca9e85b")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "caff26d9-f99f-4249-ad4d-b1e7e5b5890e")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "8cce171d-2c43-4e50-b8d9-a15d7b579d0b")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "59cd8269-d1b0-4cc0-8cd0-486e94e6f6e3")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "3782645b-ecfc-464d-8424-f429007c8dfd")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "44da33a7-4b9a-42ff-bb4f-b5d5f5bf94fa")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "455073c0-5a88-4b5a-813f-b8f57d2367dc")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "9a39bac6-2dfd-4bc1-bc64-bf5c522b538c")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(D1-Pad2)")
+			(uuid "9ba14b8a-9687-4a78-9768-161c750ad733")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8ab1")
+		(at 43.700000 49.900000 180)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C23"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "5a20f3d2-4834-4c47-8721-590149e38f16")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "30pF"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "68b0120b-b578-4884-9de3-e22406a32036")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "fa90b151-0943-49a1-bef2-38af40ad14be")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "8c974ac8-7488-42dc-bc50-5f4561bac014")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ee9988b")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "4fce91ba-d548-49a6-b542-1175f3210be2")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "a9dcd031-e7fa-46c6-a5cc-b4aacfb9d977")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "eb988ec5-97e1-41eb-bfc1-6cc562ea4f0c")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "11a94ff2-e1b0-42f7-810e-541947fcc92f")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "8bd91719-9f08-4c3f-867f-9ba069df020f")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "75e08cca-fe77-4844-a22b-c82f34a666eb")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "edf25c1e-a1f1-49d9-bac8-691d9748b892")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "bf5cca5b-b9cb-444e-8122-b4a6ce891c27")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "7078e80d-e58b-470d-995c-f7f7363618d6")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(C23-Pad1)")
+			(uuid "655b0c5b-84e7-4e1c-ba55-a96cceb3c6b0")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "36d84aa4-22b3-4dd3-b709-77009d4e3d10")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:R_Array_Convex_4x0402_RoundRect"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8bb2")
+		(at 62.500000 53.600000 270)
+		(descr "Chip Resistor Network, ROHM MNR04 (see mnr_g.pdf)")
+		(tags "resistor array")
+		(property "Reference" "RN1"
+			(at 0 -2.1 0)
+			(layer "F.Fab")
+			(uuid "754f8d34-d47c-4b0e-a303-8c164f16077f")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100k"
+			(at 0 2.1 0)
+			(layer "F.Fab")
+			(uuid "636d5fc4-343b-4a98-943d-bdcee5a1d82c")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "bb436201-7d88-48f4-abb7-a24bd34fe7de")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "feed9315-a468-44d1-a171-191a3efcbd10")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ee2f88a")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.25 -1.18)
+			(end -0.25 -1.18)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "24a07ed9-10fd-4b75-bb0a-7653f4cd4c38")
+		)
+		(fp_line
+			(start 0.25 1.18)
+			(end -0.25 1.18)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "49a3771f-497d-4d37-9c36-ca61b243d7c0")
+		)
+		(fp_line
+			(start -1 -1.25)
+			(end -1 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "a0dafdba-c990-413e-a379-d374824927a6")
+		)
+		(fp_line
+			(start -1 -1.25)
+			(end 1 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "84d76322-4f33-4840-bf84-7c1de1b42cd0")
+		)
+		(fp_line
+			(start 1 1.25)
+			(end -1 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "fca51fc3-da12-4da9-bf35-5ee81019b77d")
+		)
+		(fp_line
+			(start 1 1.25)
+			(end 1 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "651d817a-abaa-47f6-8a18-ba25b0f14cb6")
+		)
+		(fp_line
+			(start -0.5 -1)
+			(end 0.5 -1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d6dd48b1-6283-4469-a84d-8ade8113553d")
+		)
+		(fp_line
+			(start -0.5 1)
+			(end -0.5 -1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "75f86ac8-ea2e-4d07-a31e-963df8139c8b")
+		)
+		(fp_line
+			(start 0.5 -1)
+			(end 0.5 1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c5568a4a-300d-40c5-b6c3-6f5789383ec7")
+		)
+		(fp_line
+			(start 0.5 1)
+			(end -0.5 1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "cc3f028b-8ab2-4397-ae4a-3f334476d4b7")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "a4ce06d8-656c-4c2a-a19d-49a92ca0332c")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.075)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.5 -0.75 270)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "b8825e30-e091-4a01-b40e-febebc4cba15")
+		)
+		(pad "2" smd roundrect
+			(at -0.5 -0.25 270)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "35fd670f-1e07-4691-9bce-54485016b6b7")
+		)
+		(pad "3" smd roundrect
+			(at -0.5 0.25 270)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "375629d6-646a-4ddf-994b-f680a9e0f4a2")
+		)
+		(pad "4" smd roundrect
+			(at -0.5 0.75 270)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "e788b78d-e33f-4f99-9356-2620f93f89fd")
+		)
+		(pad "5" smd roundrect
+			(at 0.5 0.75 270)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD4")
+			(uuid "3371594e-8d68-4613-9de8-2b7d3aabf081")
+		)
+		(pad "6" smd roundrect
+			(at 0.5 0.25 270)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD3")
+			(uuid "569dabef-433a-4979-b00a-8f52aaa8e1a6")
+		)
+		(pad "7" smd roundrect
+			(at 0.5 -0.25 270)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD1")
+			(uuid "77a94cf1-d250-4380-b7b8-302c0d44e004")
+		)
+		(pad "8" smd roundrect
+			(at 0.5 -0.75 270)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD0")
+			(uuid "fc010af3-6415-4ed9-986f-de458488686e")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_Array_Convex_4x0402.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Inductor_SMD:L_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8c9d")
+		(at 66.600000 42.900000 180)
+		(descr "Inductor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "inductor")
+		(property "Reference" "FB2"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "29129d35-9cd2-4da5-b16c-b8ad290b7b11")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "600R, 0.5A"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "63183969-6cfe-4430-b9fe-77c266b5a150")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "e7e007a3-7810-40a2-bb55-612a26247fe1")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "2eb3674c-d462-4a4b-a76f-2df159a5ac87")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f75562f")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "add0dd00-03c6-4b81-a9cd-3fe68b963af1")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "6de5a1d3-71bb-4454-aae4-79a850706e40")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "1ba1c34f-f87f-4890-ac40-7fae964f883f")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "f543b71f-0361-4392-9ff3-797604a0a0d4")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9b0c0c3c-75eb-41d4-9159-1dae2e8b192e")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c2db6faf-36c2-4370-be02-52aa19467bb5")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "eccc1ea8-5a06-498e-a970-a80e30850254")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f5c9395c-9b90-442e-a672-5a13cc6d3ae4")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "ffa29637-74cb-42e0-b7e2-d5925dffa566")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "dada4fa4-b366-43ba-9025-b31252c45441")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/VPLL")
+			(uuid "9f9a4283-c3de-4038-9344-ce03b5ead89e")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Inductor_SMD.3dshapes/L_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:SW_CuK_JS202011CQN_DPDT_Straight"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8cd7")
+		(at 40.580000 55.200000)
+		(descr "CuK sub miniature slide switch, JS series, DPDT, right angle, http://www.ckswitches.com/media/1422/js.pdf")
+		(tags "switch DPDT")
+		(property "Reference" "SW2"
+			(at 2.75 -1.6 0)
+			(layer "F.Fab")
+			(uuid "58ea607f-eb83-4a65-b15a-81389648bb83")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "MODE"
+			(at -3.33 -1.65 90)
+			(layer "F.SilkS")
+			(uuid "1b6f3c90-2a8f-4d07-8f1e-6b32df3b15ae")
+			(effects
+				(font
+					(size 0.8 0.8)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "bf21a75e-f61e-43a8-94e4-299faa83bac8")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "fa3c9ce2-1edf-4e9e-8274-c4d9e892649a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ffb28cb")
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -2.4 0.75)
+			(end -2.4 -0.45)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "86ecf18e-4d51-4df0-8b31-bcac40aeff9c")
+		)
+		(fp_line
+			(start -2.1 -3.75)
+			(end -0.9 -3.75)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "f6868bb1-42e5-4082-8c25-0e09e3bb8483")
+		)
+		(fp_line
+			(start -2.1 0.45)
+			(end -2.1 -3.75)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "39268507-2736-42dc-aaed-8ffe9b43c980")
+		)
+		(fp_line
+			(start -1.2 0.75)
+			(end -2.4 0.75)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "73d57e0d-0060-4969-94d5-17fe7556859a")
+		)
+		(fp_line
+			(start -0.9 0.45)
+			(end -2.1 0.45)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "bccfd025-91c6-418e-8eae-09b257cb78c0")
+		)
+		(fp_line
+			(start 5.9 -3.75)
+			(end 7.1 -3.75)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "356fdf04-d653-44ef-8fa9-af05f5a856ae")
+		)
+		(fp_line
+			(start 7.1 -3.75)
+			(end 7.1 0.45)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "bc8c2878-0ca1-4e7a-b61f-c19dc59eb26c")
+		)
+		(fp_line
+			(start 7.1 0.45)
+			(end 5.9 0.45)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "112f42d0-469c-44d0-aee6-cdfb2047bd71")
+		)
+		(fp_line
+			(start -2.25 -4.25)
+			(end -2.25 0.95)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "7ce50ae7-3959-41d6-bd76-857dec68bf83")
+		)
+		(fp_line
+			(start -2.25 -4.25)
+			(end 7.25 -4.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2ad616bb-7da1-40b9-9532-be02ddfccfe0")
+		)
+		(fp_line
+			(start 7.25 -4.25)
+			(end 7.25 0.95)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "4a0d61cd-8845-4eac-b4d5-10e7af5462ae")
+		)
+		(fp_line
+			(start 7.25 0.95)
+			(end -2.25 0.95)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "e2d247d1-d40b-4b8e-bde7-7a915acd08d6")
+		)
+		(fp_line
+			(start -2 -3.65)
+			(end -2 -0.65)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d3fec615-beda-4d9c-9824-524111678afe")
+		)
+		(fp_line
+			(start -2 -3.65)
+			(end 7 -3.65)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "af5ed991-dc18-4b27-a09e-5dc2107d8d77")
+		)
+		(fp_line
+			(start -1 0.35)
+			(end -2 -0.65)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9f036b34-aba8-4319-88a3-c263882afffd")
+		)
+		(fp_line
+			(start 7 -3.65)
+			(end 7 0.35)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "2cd1f182-66eb-4211-af41-fa6fccf79ce9")
+		)
+		(fp_line
+			(start 7 0.35)
+			(end -1 0.35)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "27226600-c935-47ca-88d3-e4577ff8a22d")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 2 -1.65 0)
+			(layer "F.Fab")
+			(uuid "a36f4ade-e832-4104-9b27-499fd75f2695")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "1" thru_hole roundrect
+			(at 0 0)
+			(size 1.4 1.4)
+			(drill 0.9)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(roundrect_rratio 0.25)
+			(net "/CS")
+			(uuid "bffb0d94-1fdd-463a-a71d-f11c38f93634")
+		)
+		(pad "2" thru_hole circle
+			(at 2.5 0)
+			(size 1.4 1.4)
+			(drill 0.9)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/CORTEX_PIN2")
+			(uuid "c1d543a4-142a-4506-a097-ed80cfece82c")
+		)
+		(pad "3" thru_hole circle
+			(at 5 0)
+			(size 1.4 1.4)
+			(drill 0.9)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/SWDIO")
+			(uuid "5c4d66ab-e904-44f0-a800-96b77ca9503a")
+		)
+		(pad "4" thru_hole circle
+			(at 0 -3.3 90)
+			(size 1.4 1.4)
+			(drill 0.9)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/CIPO")
+			(uuid "5593fa40-a577-4892-a80c-6211e0b5a089")
+		)
+		(pad "5" thru_hole circle
+			(at 2.5 -3.3)
+			(size 1.4 1.4)
+			(drill 0.9)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/DI")
+			(uuid "0b4b256e-1252-4009-b387-7b53f550963c")
+		)
+		(pad "6" thru_hole circle
+			(at 5 -3.3)
+			(size 1.4 1.4)
+			(drill 0.9)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/SWDIO")
+			(uuid "0a340971-1ffe-4f52-840e-b9307b164bc6")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Button_Switch_THT.3dshapes/SW_CuK_JS202011CQN_DPDT_Straight.wrl"
+			(offset
+				(xyz 0 3.3 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8d1e")
+		(at 63.480000 36.551600 270)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R13"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "0b818865-f1b0-40c4-94a9-ec9bb2302fa2")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "06eb3ba3-7deb-4b02-b901-a857f6c7c95d")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "ad5cf4d3-52f5-4089-b6d5-e9941108c839")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "869e69fc-d5db-4284-aa24-e9ccceeb8d1d")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f34b86f")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "7e015a22-ed12-46eb-ba73-e8b6a09774ad")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "75bfcfb1-7efa-4697-8f41-1da45b2400fc")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "eb1bb55f-f5b5-4eeb-8738-c81a45dfaf69")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "f42a583f-ee67-476e-aa8b-7c180c05dc94")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "0f2cba8c-4c15-412e-8cc8-830135434ea6")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "fc9c7bcd-2b13-4140-bff9-10b493af8fa3")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b41a3d66-841d-4b84-a601-70474499453b")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "29ecf637-f1e7-4728-b86b-12d0735d0198")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "6f3f9eb0-e00e-4030-8312-b8fd5388c2fa")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "2c07626c-b8fe-47eb-8197-fef574dd6f17")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(R13-Pad2)")
+			(uuid "890d897c-bf73-4350-8287-4e1a828dd7a8")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:R_Array_Convex_4x0402_RoundRect"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8d50")
+		(at 46.800000 60.800000)
+		(descr "Chip Resistor Network, ROHM MNR04 (see mnr_g.pdf)")
+		(tags "resistor array")
+		(property "Reference" "RN5"
+			(at 0 -2.1 0)
+			(layer "F.Fab")
+			(uuid "e9188aa5-1c43-4ed7-8b29-b65193e24939")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100"
+			(at 0 2.1 0)
+			(layer "F.Fab")
+			(uuid "d73099c6-2362-4626-a1e5-d9e632c549f9")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "aa55b962-b1f9-4030-9cc8-44ee30ba917f")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "54cc48cb-9e38-44a8-bb27-3ee7a990c9ea")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ed9a0e0")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.25 -1.18)
+			(end -0.25 -1.18)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "0db47c4c-ef1a-465a-aeed-87abbf42e300")
+		)
+		(fp_line
+			(start 0.25 1.18)
+			(end -0.25 1.18)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "573b9fb4-8b35-450e-af9a-6eccec561753")
+		)
+		(fp_line
+			(start -1 -1.25)
+			(end -1 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "b04d38d3-e181-47a6-a24e-f6df072ed366")
+		)
+		(fp_line
+			(start -1 -1.25)
+			(end 1 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "71ed6ba9-5133-4baf-831a-f99ce63af6bc")
+		)
+		(fp_line
+			(start 1 1.25)
+			(end -1 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "b1e6a942-a510-428d-9921-8be1a8abb54b")
+		)
+		(fp_line
+			(start 1 1.25)
+			(end 1 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "724507ea-80f6-4d0a-b90a-d7eb5de94f7d")
+		)
+		(fp_line
+			(start -0.5 -1)
+			(end 0.5 -1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a997acb1-0269-4e49-bb61-164f98c8ab70")
+		)
+		(fp_line
+			(start -0.5 1)
+			(end -0.5 -1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "86003e80-caef-4390-8626-17ff94917288")
+		)
+		(fp_line
+			(start 0.5 -1)
+			(end 0.5 1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "01fa7216-1f24-46c9-9a0f-34d3e49fe4b7")
+		)
+		(fp_line
+			(start 0.5 1)
+			(end -0.5 1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "eb3577c9-0d7f-4035-838a-0cd84402e1f3")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "0350a208-4291-463d-a856-ea53cc3bf827")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.075)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.5 -0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD1")
+			(uuid "cf0d05c7-5bf6-49c8-baef-d72e7cbf7546")
+		)
+		(pad "2" smd roundrect
+			(at -0.5 -0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD3")
+			(uuid "e41fe650-43fb-4823-99d4-48da504b75b3")
+		)
+		(pad "3" smd roundrect
+			(at -0.5 0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD5")
+			(uuid "7e8b164e-1ec9-4a03-84a2-76b9d5214806")
+		)
+		(pad "4" smd roundrect
+			(at -0.5 0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD6")
+			(uuid "0bb0d1a9-b781-4320-8d54-0a055cedc282")
+		)
+		(pad "5" smd roundrect
+			(at 0.5 0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN5-Pad5)")
+			(uuid "ecaf3f1a-e552-43d0-b5f4-dfc5c3826f69")
+		)
+		(pad "6" smd roundrect
+			(at 0.5 0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN5-Pad6)")
+			(uuid "aadde88c-0fa4-485a-9c79-cbf65e8fc6f1")
+		)
+		(pad "7" smd roundrect
+			(at 0.5 -0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN5-Pad7)")
+			(uuid "c0c8ca68-3e55-4603-ac66-99ed05cc6861")
+		)
+		(pad "8" smd roundrect
+			(at 0.5 -0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN5-Pad8)")
+			(uuid "0438f1ec-def2-4efd-bc40-5ba208958b6e")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_Array_Convex_4x0402.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:SOT-23-6_RoundRect"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8d91")
+		(at 38.900000 68.200000 180)
+		(descr "6-pin SOT-23 package")
+		(tags "SOT-23-6")
+		(property "Reference" "U4"
+			(at 0 -2.9 0)
+			(layer "F.Fab")
+			(uuid "29ea4e2a-1dca-4061-ae08-3a932ea1a262")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "93LC46BT-I/OT"
+			(at 0 2.9 0)
+			(layer "F.Fab")
+			(uuid "f22e316c-873b-485e-b873-040b5e49654e")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "d947a241-0f71-4379-8e9c-686d3d93dc15")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "3d7274b7-d64c-4982-93b6-e34a08738e4b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f75878e")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.9 -1.61)
+			(end -1.55 -1.61)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "daa7f720-17f3-4d51-9ac5-d0469bc234fb")
+		)
+		(fp_line
+			(start -0.9 1.61)
+			(end 0.9 1.61)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b83d0bfc-8533-421e-9449-d82e52d7ea1e")
+		)
+		(fp_line
+			(start 1.9 1.8)
+			(end 1.9 -1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "4e616958-dec0-4f0e-999e-3d506d1b7136")
+		)
+		(fp_line
+			(start 1.9 -1.8)
+			(end -1.9 -1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "bf2c3bf9-c593-4390-acd5-84c452977831")
+		)
+		(fp_line
+			(start -1.9 1.8)
+			(end 1.9 1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "19d628f2-231f-41a3-8e7e-8f207f9de3c4")
+		)
+		(fp_line
+			(start -1.9 -1.8)
+			(end -1.9 1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "33f418e8-0733-412f-afa5-e0c90f72f682")
+		)
+		(fp_line
+			(start 0.9 1.55)
+			(end -0.9 1.55)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9c3c794f-2891-4640-88a7-63193a1f0c6b")
+		)
+		(fp_line
+			(start 0.9 -1.55)
+			(end 0.9 1.55)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "38b673f2-8bb5-40b2-845c-0e2a4654aee9")
+		)
+		(fp_line
+			(start 0.9 -1.55)
+			(end -0.25 -1.55)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "7a85c93d-8036-454e-90e7-118f8fc58ec9")
+		)
+		(fp_line
+			(start -0.9 -0.9)
+			(end -0.25 -1.55)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "df4685c4-c767-47a5-aaf0-a3df119e6bff")
+		)
+		(fp_line
+			(start -0.9 -0.9)
+			(end -0.9 1.55)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a74149af-b7bb-41ef-9687-cd2c68cc51be")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "f8ef6595-ee4e-4316-b7ba-b8eebd927c63")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.075)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -1.1 -0.95 180)
+			(size 1.06 0.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(R13-Pad2)")
+			(uuid "b567ea79-38ae-42fa-8fab-9f82aa55f72c")
+		)
+		(pad "2" smd roundrect
+			(at -1.1 0 180)
+			(size 1.06 0.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "727d3781-5a29-473a-b462-92367b925c7f")
+		)
+		(pad "3" smd roundrect
+			(at -1.1 0.95 180)
+			(size 1.06 0.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/EEDATA")
+			(uuid "b73bf927-9d82-44aa-a2f5-69ecf95149d5")
+		)
+		(pad "4" smd roundrect
+			(at 1.1 0.95 180)
+			(size 1.06 0.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/EECLK")
+			(uuid "c9e1df02-9c1b-4ca7-9be6-cbfcde15f236")
+		)
+		(pad "5" smd roundrect
+			(at 1.1 0 180)
+			(size 1.06 0.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/EECS")
+			(uuid "c0383794-7f8d-4554-aff8-b2c01f79fcf6")
+		)
+		(pad "6" smd roundrect
+			(at 1.1 -0.95 180)
+			(size 1.06 0.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "70f34e51-2f81-4f64-b12c-892badfe335d")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Package_TO_SOT_SMD.3dshapes/SOT-23-6.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8dc9")
+		(at 56.500000 70.870000)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R20"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "2acbfb27-e528-4fb9-b78e-e4f3c4e5c745")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "455457cf-2b9e-4aad-acaa-7cf665606619")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b7885587-a051-4587-94fe-b8c98324d2c4")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b07c752b-597d-42c6-99e1-15828522aa4a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005edd6c7c")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "4fcdf2cb-365f-4788-bead-46623f19f00b")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "3b7ce0b9-e2be-42e8-8171-3c570b5aaaab")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "c1db16c5-f7ee-4e18-8c24-8595f5380eec")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "62fca5ed-313f-4d70-9da5-2e7a1ca2d297")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "167bb99a-ed5a-4ec6-a122-35df677caa34")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "883b1317-4a93-4cab-b6c4-b6bddc7bba5e")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "eb3e49d7-142b-4bfe-b9d0-f50464eb3103")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "20a5b249-2c82-4c13-9127-e03f25545156")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "640016b0-3146-4423-aa8c-bc7bdd5c68c3")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(J4-Pad5)")
+			(uuid "fdc8e94f-64a9-40c7-9ad5-4556f2bfd50b")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VTARGET")
+			(uuid "27f0802e-c9e6-497d-bfce-7494e98f2542")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8df3")
+		(at 47.635000 45.441700 90)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C3"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "ac814bb2-45ab-43d9-a8e0-42100b5837df")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "2u2"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "2a862ef7-343c-49c3-8c9e-4c0bc240cd57")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "f1c6a71b-fa37-436c-90a1-64b0c8170afc")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "0cbae80d-64d4-406c-861a-7e4d591ff5bc")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ee3e93a")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "207f5941-e25f-4e52-8055-bfc66512d4dc")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "d5429629-c0b6-4c99-ac5e-9bdf49c8e2ea")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "9014d097-f099-491d-9978-c1a3e6fecad6")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "35b7d112-22a5-4a4e-952f-1e1cb45e56b3")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b25fbe12-099d-4b23-965f-e28612df4bfb")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9e96e875-f0c2-4495-85db-7b3d825e9b67")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "edc57bd9-7006-48ca-a1d0-9b7dd2d12234")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c36b7aee-fb9f-4de5-88d6-6e59a6342352")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "5b322a3c-5849-4077-85ac-9078c4c8e9aa")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+5V")
+			(uuid "ffdc2b70-e91d-4e21-b80a-eac2e6fd1451")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "ef47dfed-62a3-4b23-81fd-4eaecff1f00f")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8e1d")
+		(at 51.460000 46.908000)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R11"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "08712b82-e0bd-4f6b-b090-9b8e50d14d86")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "330"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "b8b24851-7f87-4a40-96d1-4bd7a87b7dc3")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "ba39d63e-dca1-4276-a891-ac0f24f2cf39")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "2d5d65a9-cd78-442c-ac6c-be77d953f810")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-000060280318")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "9e2e3732-b0c5-44fe-8976-bb0cdb524ae7")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "a5ed3400-e59c-4689-ae74-68b9396da016")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "73257495-0825-44e7-b499-02c2c6ccf69f")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "e2819ea9-5259-4315-bb32-e25dd584b5ff")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "4555197a-9d5e-4b0f-9054-d94c002dda6a")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e7739254-d7d5-43ec-983f-2e83e2ba823c")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "32133b22-5eae-4337-94ea-f1120331f77a")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "116d66cb-4580-41d6-a067-e99a587235f7")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "4502a198-3cdb-4dd2-89d7-917996c11a3c")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(D5-Pad2)")
+			(uuid "b2364b2a-49a0-4928-b959-628b653ed1e8")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "dd3b4672-38e7-4d5c-bb37-6403714a3d30")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8e47")
+		(at 38.000000 64.100000)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C19"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "9bacb73c-4de2-4ef8-92b2-a62dd3a75bf9")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100n"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "d8f20679-d310-48aa-b291-2cf6344ac39e")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "daa836e3-8a35-42af-b834-2793019e9f17")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "5d235090-aacb-4371-b58b-a953d1bddfe3")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-000060d35425")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "d5fae42b-ce6c-491c-85f4-5904eddff2b5")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "3d348103-cddf-4057-90a5-2e20f572f607")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "f182efd6-8db3-4a12-b5b5-6df5c5281ba6")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "c01b5b94-6d99-458a-ac9e-ce0d264ca8df")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ba4af50b-3aa8-4f71-871b-98a5749aacd6")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "50ffeb7a-56f0-4bda-ab43-570798c68358")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b08b0b42-7d8e-4d43-bf80-3883a2800d35")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "234a9d7f-4173-49c9-af21-5bac03644051")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "124421e6-ce62-4f36-89b0-e6e0f041c19c")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "0cc61a0c-2798-4768-a1cd-0acbaf0f07d3")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "83ec9f8d-0433-4159-9116-05b6213cd15d")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:SOT-23-5_RoundRect"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8e77")
+		(at 39.166700 44.510000 180)
+		(descr "5-pin SOT23 package")
+		(tags "SOT-23-5")
+		(property "Reference" "U1"
+			(at 0 -2.9 0)
+			(layer "F.Fab")
+			(uuid "6515e78b-830f-4b79-b28a-e9d7ad304e94")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "AP7365-18"
+			(at 0 2.9 0)
+			(layer "F.Fab")
+			(uuid "f36b37f5-3034-46db-8727-d64e2d2216bc")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "9b8f281b-5c02-46f2-ae11-f6447484f9a0")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "c59107c6-6f3d-4ad0-b211-c6d8f0354324")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ebde10a")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.9 -1.61)
+			(end -1.55 -1.61)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "7933deda-a0a1-428d-927b-c8cca1fd6c3a")
+		)
+		(fp_line
+			(start -0.9 1.61)
+			(end 0.9 1.61)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d70d798e-7c40-470a-8edd-3a173e00953b")
+		)
+		(fp_line
+			(start 1.9 1.8)
+			(end -1.9 1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "17a66e5e-65da-4a31-919d-22bb6fab449d")
+		)
+		(fp_line
+			(start 1.9 -1.8)
+			(end 1.9 1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "e11a121b-35b9-4fcf-8bd0-676ecd88987c")
+		)
+		(fp_line
+			(start -1.9 1.8)
+			(end -1.9 -1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2f71b17d-f216-4000-a28e-62cd29dbcf12")
+		)
+		(fp_line
+			(start -1.9 -1.8)
+			(end 1.9 -1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "e961c2c4-73e2-4b5c-8f9b-beab36c0adda")
+		)
+		(fp_line
+			(start 0.9 1.55)
+			(end -0.9 1.55)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "06de2af7-8db2-46ca-8a3b-bd2aedcb6b43")
+		)
+		(fp_line
+			(start 0.9 -1.55)
+			(end 0.9 1.55)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "5ad9a2da-f720-4257-8022-c00acbab2a5d")
+		)
+		(fp_line
+			(start 0.9 -1.55)
+			(end -0.25 -1.55)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "aee9129d-d0b7-4418-9e22-263f7de2c34a")
+		)
+		(fp_line
+			(start -0.9 -0.9)
+			(end -0.25 -1.55)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a2a92546-0f83-4fe3-97dd-691772304726")
+		)
+		(fp_line
+			(start -0.9 -0.9)
+			(end -0.9 1.55)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d2ff71e0-c601-4de8-af3c-4ada4fb935d4")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "5b582e5a-9551-4d9e-9d0e-7d2181901070")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.075)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -1.1 -0.95 180)
+			(size 1.06 0.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+5V")
+			(uuid "56d41e26-bdd4-4c64-8791-1c962a21500e")
+		)
+		(pad "2" smd roundrect
+			(at -1.1 0 180)
+			(size 1.06 0.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "87882041-3755-4539-b431-eb94c30719e2")
+		)
+		(pad "3" smd roundrect
+			(at -1.1 0.95 180)
+			(size 1.06 0.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+5V")
+			(uuid "9a1cb502-bf88-462b-965b-c9c24aacfd37")
+		)
+		(pad "4" smd roundrect
+			(at 1.1 0.95 180)
+			(size 1.06 0.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "9e12bba7-8d46-44d6-af69-c10896e3a124")
+		)
+		(pad "5" smd roundrect
+			(at 1.1 -0.95 180)
+			(size 1.06 0.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+1V8")
+			(uuid "95945aab-9ff9-4f91-9817-fe63be9ca42b")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Package_TO_SOT_SMD.3dshapes/SOT-23-5.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:R_Array_Convex_4x0402_RoundRect"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8eb5")
+		(at 64.615000 61.808300)
+		(descr "Chip Resistor Network, ROHM MNR04 (see mnr_g.pdf)")
+		(tags "resistor array")
+		(property "Reference" "RN3"
+			(at 0 -2.1 0)
+			(layer "F.Fab")
+			(uuid "23e6ec19-f98a-4da5-85fe-a88cdf76f107")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100"
+			(at 0 2.1 0)
+			(layer "F.Fab")
+			(uuid "513591f4-2781-4e83-96b7-c722e0d37253")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "736f1825-3a84-422f-8912-eea7fde4a18d")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "2f57ea13-cde9-4a40-b7e4-c0906dc72797")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00006123b61b")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.25 -1.18)
+			(end -0.25 -1.18)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "baf04716-e795-41b7-93d6-4375e5e4bd19")
+		)
+		(fp_line
+			(start 0.25 1.18)
+			(end -0.25 1.18)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "82e37d20-e3be-438c-b860-eedb68672221")
+		)
+		(fp_line
+			(start -1 -1.25)
+			(end -1 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "572fb178-fb2a-4ff8-9770-94a4b809c751")
+		)
+		(fp_line
+			(start -1 -1.25)
+			(end 1 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "a364a640-9cb4-490c-8a39-d025df090ad4")
+		)
+		(fp_line
+			(start 1 1.25)
+			(end -1 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "48b7f214-77a4-423d-833a-105387d22841")
+		)
+		(fp_line
+			(start 1 1.25)
+			(end 1 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "15585e91-e444-4231-915d-0b8438dc8bc6")
+		)
+		(fp_line
+			(start -0.5 -1)
+			(end 0.5 -1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "19629ce0-e17d-424a-b628-6059f8b81bec")
+		)
+		(fp_line
+			(start -0.5 1)
+			(end -0.5 -1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "0996fd95-103d-49c0-83a7-5608370ab52e")
+		)
+		(fp_line
+			(start 0.5 -1)
+			(end 0.5 1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "4f31ba79-2659-4976-9ede-faf435598d97")
+		)
+		(fp_line
+			(start 0.5 1)
+			(end -0.5 1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f7f981ae-555e-4a50-b2ca-601da7b10ad0")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "f2a48f77-7814-48de-a811-f577292e175d")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.075)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.5 -0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN3-Pad1)")
+			(uuid "35130f16-e578-460b-b05e-898523f195bc")
+		)
+		(pad "2" smd roundrect
+			(at -0.5 -0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN3-Pad2)")
+			(uuid "47b1afcf-38cc-4e70-96bf-63bd53ae2535")
+		)
+		(pad "3" smd roundrect
+			(at -0.5 0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN3-Pad3)")
+			(uuid "c24e27a5-202e-4d56-af65-288ded5f5aa6")
+		)
+		(pad "4" smd roundrect
+			(at -0.5 0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN3-Pad4)")
+			(uuid "1c0d3653-2701-4e0d-92a4-40ffa92a1d4f")
+		)
+		(pad "5" smd roundrect
+			(at 0.5 0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/xPB4")
+			(uuid "88c8e1ff-10ee-44ba-a44b-2791808a4e2d")
+		)
+		(pad "6" smd roundrect
+			(at 0.5 0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/CS")
+			(uuid "f1735bd3-0b00-4e1e-ac90-8bf88a7b2eb7")
+		)
+		(pad "7" smd roundrect
+			(at 0.5 -0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/COPI")
+			(uuid "6cf2cebe-215c-4e07-8b23-70625394f431")
+		)
+		(pad "8" smd roundrect
+			(at 0.5 -0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/CLK")
+			(uuid "29d41b39-ccc6-42a1-a095-e71442e1ddd5")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_Array_Convex_4x0402.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8f76")
+		(at 69.100000 40.300000 90)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C18"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "01e3d9c9-4d08-4b64-b8c7-c9b4418df795")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100n"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "8a6da369-a211-41dc-be22-316c83598940")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "35135a35-e430-41cc-898e-eb02bf14a36c")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "9a72fc63-9b95-4a22-9080-76a645b41eac")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005eec8e50")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "01198dba-aa14-43e8-a533-55480c228be3")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "28cc193d-260f-446c-b2f8-33f59477d038")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "b3c5b82f-2311-4181-8b21-a580f156f0ac")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "edeb8f83-6b5f-4859-a710-5cf8c73db544")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "da1cd01f-6506-41a3-8696-a141e62901b5")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "67f38907-afdf-4c38-beb3-5ff9569d23bc")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "1081a21f-bbf8-45fe-972c-c3a7fb2e15ec")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "def142c3-181c-4d43-bfb2-248c3636228b")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "f27240e6-8a22-454e-84b8-aeabbde29684")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "036dc83f-c484-4d5a-881d-03ae8d1caab5")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "057681bc-9066-409d-9e1a-56636f025cd0")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8fa0")
+		(at 61.400000 47.500000)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R2"
+			(at 0 -1.17 90)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "c6fef8b7-c394-4fd8-99f6-26f77c558389")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "5k1"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "8dc4d1f4-0e46-4550-acff-75b1db47ed87")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "68c5c131-34cb-43d3-b79a-91842ff8e372")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "f8fc8dec-ec3b-4318-b014-bc243e2d4b90")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ebd4231")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "e730b6a7-68ce-4ed1-b4a5-8a54c4486e26")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "db43f0a1-6b76-4ccd-84ea-124da908f87c")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "fbadf17e-f7cd-49ee-9bf9-9d95bb6f8883")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "03568ac3-3b47-43cd-83bb-01d5f1dc6351")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b6649bd2-250e-47c1-ad9c-7b888de6c0af")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a62b0e56-1a1d-41fc-89ef-fbf545ca7884")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "985761ae-23b4-4aee-bcad-24ce1d3b02a5")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "486c844b-5e38-4566-9a35-d687ac41f1a6")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "8eb5c672-87ef-4d54-b62c-47222db56cd6")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(J1-PadB5)")
+			(uuid "cef6bbe1-155c-4aee-a8ad-8847cf3605a4")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "e5191a60-4538-434b-a6a1-18248dc3330f")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8fca")
+		(at 66.700000 41.500000)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C6"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "dc3ccbb8-61dd-402a-8e9f-d16bb2f37de6")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "2u2"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "ca5f29c7-c4f6-457f-aff7-a321daf8da41")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "6c8fd564-2087-4a86-b6e4-60d0ddb76794")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "d0e4eaff-6aa7-48fc-82bd-b6e87afbf71b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ef8ce20")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2cd33f2a-b16c-474f-9893-bdf80309f721")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "a7c51852-9af8-434c-b42b-10434debf66b")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "0feece49-6dc3-4e58-9511-37b8ec807e1a")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "531830fd-a2be-4105-9ff2-19e9ff8e5946")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "686c3892-81eb-4d52-a635-fe0bab20f3b8")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "efbc0661-0f93-4314-9f3a-399e1aef406d")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "cd012935-767a-4c91-af7b-8b4e900c70c4")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "715b6334-9f34-4b18-898a-f676943674b2")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "45f44c50-e3a0-4f0c-bb87-5d4a51dcbd36")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/VPHY")
+			(uuid "83aa7d7d-61ef-48d5-a4f2-b1c7c2bfcd2d")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "3b37755c-c391-4019-9f42-de6641f83d94")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8ff4")
+		(at 66.700000 37.600000)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C17"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "139d369c-8046-4f61-a5cc-c99cb0014ee9")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100n"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "b4275406-d2d1-434e-88e5-b2e463f8a5b8")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "0844f8e2-7a15-4e80-b324-c1043f94158b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "972abab3-f690-48ec-a5a4-29a6266c3555")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f90af3d")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "c2fc1a83-47ac-4975-8cc8-0d792cd70323")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "4aadbc80-ef6d-47c9-a80b-913faeb98565")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "93e4ba4a-2676-46e5-add3-3ad091965d92")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "22874ac4-33ae-444d-ae91-d5189cfec88b")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "3b1547f5-b230-4ea4-bae3-b694f19c0b0c")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "5b37be9d-527a-4466-9237-0d7c7a14c3d4")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "5ee0ee6f-9ebf-475a-944d-c98410e3f55d")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "100af237-e4a4-4da7-badf-cf288dc2b365")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "c791a45f-b963-435d-8148-dc61ab5654f1")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "d7c031ed-7beb-4be5-84ec-5c5913cf7d4b")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "9618f62f-55e8-40c9-85bf-61c42a45cfe8")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:USB_C_Receptacle_HRO_TYPE-C-31-M-12"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec9037")
+		(at 33.950000 57.500000 270)
+		(descr "USB Type-C receptacle for USB 2.0 and PD, http://www.krhro.com/uploads/soft/180320/1-1P320120243.pdf")
+		(tags "usb usb-c 2.0 pd")
+		(property "Reference" "J1"
+			(at 0 -5.645 90)
+			(layer "F.Fab")
+			(uuid "92604a9c-37b0-425b-ad6c-efd66ff6066b")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "USB_C_Receptacle_USB2.0"
+			(at 0 5.1 90)
+			(layer "F.Fab")
+			(uuid "758e7920-a469-456c-9869-c412d60e61d4")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "9dffb0c9-d4d4-4b01-a76a-b06170369ded")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "a468e2b7-a559-47b9-9edf-32a3a61a3a8e")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ebcf27e")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -4.7 3.9)
+			(end 4.7 3.9)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "a2e1d508-c784-42fa-b4ee-72854b282323")
+		)
+		(fp_line
+			(start -4.7 2)
+			(end -4.7 3.9)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "e22bf71d-acdc-4c21-b614-449b2f92ac9b")
+		)
+		(fp_line
+			(start 4.7 2)
+			(end 4.7 3.9)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "c41039d3-fcbf-41a5-85e9-d22a317f7ed8")
+		)
+		(fp_line
+			(start -4.7 -1.9)
+			(end -4.7 0.1)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "11136eb9-9b33-42c6-95b2-cbbe54ddb1c6")
+		)
+		(fp_line
+			(start 4.7 -1.9)
+			(end 4.7 0.1)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "bf80831d-d258-4da2-b0be-bead7f196598")
+		)
+		(fp_line
+			(start -5.32 4.15)
+			(end 5.32 4.15)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "52c3b1a1-6a63-4509-b638-e1f82c02e014")
+		)
+		(fp_line
+			(start -5.32 -5.27)
+			(end -5.32 4.15)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "41ebd26c-b31f-4502-9fcd-763f8757333f")
+		)
+		(fp_line
+			(start -5.32 -5.27)
+			(end 5.32 -5.27)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "41f90907-8c7f-4079-bd40-cf7877de3939")
+		)
+		(fp_line
+			(start 5.32 -5.27)
+			(end 5.32 4.15)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "48a5d364-cf0c-4959-a539-970a3b2e5d81")
+		)
+		(fp_line
+			(start -4.47 3.65)
+			(end 4.47 3.65)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "01d89aae-3d54-4003-882b-047538419abc")
+		)
+		(fp_line
+			(start -4.47 -3.65)
+			(end -4.47 3.65)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "1fb3e514-78d6-4858-b920-7640dca5a97d")
+		)
+		(fp_line
+			(start -4.47 -3.65)
+			(end 4.47 -3.65)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "eaf56705-2872-4040-8cf2-74eb1bdf23de")
+		)
+		(fp_line
+			(start 4.47 -3.65)
+			(end 4.47 3.65)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "912e8d57-e18d-4613-882a-0c23c4a792c6")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "56d4e248-d08d-4b16-991c-198abfd932a2")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "" smd rect
+			(at -4.82 -3.13 270)
+			(size 1 2.1)
+			(layers "F.Paste")
+			(uuid "0bf2fa0e-47ea-40cb-9cab-e351d3a3606e")
+		)
+		(pad "" smd rect
+			(at -4.82 1.05 270)
+			(size 1 1.6)
+			(layers "F.Paste")
+			(uuid "3faaf992-ecf4-4235-843f-73168b43ebe5")
+		)
+		(pad "" smd oval
+			(at -4.32 -3.13 270)
+			(size 1 2.1)
+			(layers "F.Paste")
+			(uuid "2797777a-d673-467a-9816-6903278e8b78")
+		)
+		(pad "" smd oval
+			(at -4.32 1.05 270)
+			(size 1 1.6)
+			(layers "F.Paste")
+			(uuid "651ea73a-32fd-4401-a00c-81cc9d372df7")
+		)
+		(pad "" np_thru_hole circle
+			(at -2.89 -2.6 270)
+			(size 0.65 0.65)
+			(drill 0.65)
+			(layers "*.Cu" "*.Mask")
+			(uuid "dfca45f4-0db0-4562-bdb6-6cdfc528b101")
+		)
+		(pad "" np_thru_hole circle
+			(at 2.89 -2.6 270)
+			(size 0.65 0.65)
+			(drill 0.65)
+			(layers "*.Cu" "*.Mask")
+			(uuid "fe6b9179-7159-41e8-8f54-f20932159d37")
+		)
+		(pad "" smd oval
+			(at 4.32 -3.13 270)
+			(size 1 2.1)
+			(layers "F.Paste")
+			(uuid "b07c89b2-3fdf-4d59-9095-4ba6abcb0495")
+		)
+		(pad "" smd oval
+			(at 4.32 1.05 270)
+			(size 1 1.6)
+			(layers "F.Paste")
+			(uuid "ca217b3f-932e-4522-ac98-440e3a8213a2")
+		)
+		(pad "" smd rect
+			(at 4.82 -3.13 270)
+			(size 1 2.1)
+			(layers "F.Paste")
+			(uuid "01003b14-2fc6-4c5a-ab24-92b8c9ae6ca7")
+		)
+		(pad "" smd rect
+			(at 4.82 1.05 270)
+			(size 1 1.6)
+			(layers "F.Paste")
+			(uuid "e3536994-485c-4e0c-a9fd-f93e0e974755")
+		)
+		(pad "A1" smd rect
+			(at -3.25 -4.045 270)
+			(size 0.6 1.45)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(uuid "1a9df97e-5f5f-44ca-9ec2-4239e711e6a8")
+		)
+		(pad "A4" smd rect
+			(at -2.45 -4.045 270)
+			(size 0.6 1.45)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/VBUS")
+			(uuid "dd1a862c-c554-4765-bebc-c0804b39722e")
+		)
+		(pad "A5" smd rect
+			(at -1.25 -4.045 270)
+			(size 0.3 1.45)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(J1-PadA5)")
+			(uuid "f2fb061a-5052-4a37-9d58-777607d1e1da")
+		)
+		(pad "A6" smd rect
+			(at -0.25 -4.045 270)
+			(size 0.3 1.45)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/USB_DP")
+			(uuid "0744ece0-ec8d-4b80-9717-9df440758749")
+		)
+		(pad "A7" smd rect
+			(at 0.25 -4.045 270)
+			(size 0.3 1.45)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/USB_DN")
+			(uuid "d3f1f22f-edd7-433a-8137-5c4a29861696")
+		)
+		(pad "A8" smd rect
+			(at 1.25 -4.045 270)
+			(size 0.3 1.45)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(uuid "836a81cf-d342-4681-b188-5fb7c5e63931")
+		)
+		(pad "A9" smd rect
+			(at 2.45 -4.045 270)
+			(size 0.6 1.45)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/VBUS")
+			(uuid "70693b2e-8fe4-44d8-9a9a-ed381b07174f")
+		)
+		(pad "A12" smd rect
+			(at 3.25 -4.045 270)
+			(size 0.6 1.45)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(uuid "5698f424-29ea-4818-8f5c-cc6e905cec26")
+		)
+		(pad "B1" smd rect
+			(at 3.25 -4.045 270)
+			(size 0.6 1.45)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(uuid "faa501ff-830b-4e92-8791-4e26864e71c3")
+		)
+		(pad "B4" smd rect
+			(at 2.45 -4.045 270)
+			(size 0.6 1.45)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/VBUS")
+			(uuid "33298c4a-3ff6-49f6-8fb6-4a8cee4f6467")
+		)
+		(pad "B5" smd rect
+			(at 1.75 -4.045 270)
+			(size 0.3 1.45)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "Net-(J1-PadB5)")
+			(uuid "1466d844-84a8-46b3-a423-ab5eb5e81711")
+		)
+		(pad "B6" smd rect
+			(at 0.75 -4.045 270)
+			(size 0.3 1.45)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/USB_DP")
+			(uuid "3cae6199-476b-455d-8233-2a727f4f391f")
+		)
+		(pad "B7" smd rect
+			(at -0.75 -4.045 270)
+			(size 0.3 1.45)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/USB_DN")
+			(uuid "2766c1ee-adeb-43ff-8512-f02057c42510")
+		)
+		(pad "B8" smd rect
+			(at -1.75 -4.045 270)
+			(size 0.3 1.45)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(uuid "f65dba7c-91a4-441b-a3ec-6fe22e55e140")
+		)
+		(pad "B9" smd rect
+			(at -2.45 -4.045 270)
+			(size 0.6 1.45)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "/VBUS")
+			(uuid "0b715c2f-9801-4150-8fe4-f51386f6fbfe")
+		)
+		(pad "B12" smd rect
+			(at -3.25 -4.045 270)
+			(size 0.6 1.45)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(net "GND")
+			(uuid "a636b8de-5e43-4ff9-a3dc-4d026ceaaa9b")
+		)
+		(pad "S1" thru_hole oval
+			(at -4.32 -3.13 270)
+			(size 1 2.1)
+			(drill oval 0.6 1.7)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "Net-(C25-Pad2)")
+			(uuid "7ef9ef86-7a88-405c-9163-375f9799b3ef")
+		)
+		(pad "S1" thru_hole oval
+			(at -4.32 1.05 270)
+			(size 1 1.6)
+			(drill oval 0.6 1.2)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "Net-(C25-Pad2)")
+			(uuid "deb39570-11c3-44fc-a9e5-5d66f420f0e5")
+		)
+		(pad "S1" thru_hole oval
+			(at 4.32 -3.13 270)
+			(size 1 2.1)
+			(drill oval 0.6 1.7)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "Net-(C25-Pad2)")
+			(uuid "5cdd6bea-8971-40cc-b34c-be7c62b7cf73")
+		)
+		(pad "S1" thru_hole oval
+			(at 4.32 1.05 270)
+			(size 1 1.6)
+			(drill oval 0.6 1.2)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "Net-(C25-Pad2)")
+			(uuid "baee2d22-f976-41bd-90a2-96facadb085f")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Connector_USB.3dshapes/USB_C_Receptacle_HRO_TYPE-C-31-M-12.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+		(model "${KIPRJMOD}/tigard.3dshapes/HRO_TYPE-C-31-M-12.step"
+			(offset
+				(xyz -4.5 -3.7 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec9093")
+		(at 58.200000 47.900000 180)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R1"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "5bd87b55-95d7-4ef7-8af5-4aac5a4b0902")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "5k1"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "7245202e-7456-4006-8e43-a4996618019c")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "c2a86965-d4a9-46cd-a99b-6649d0507cd9")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "9711093a-8d70-4977-9bd2-70958ad5f3f7")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ebd3955")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "79ff1d45-3f6e-49b9-9465-0e811319cb34")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "89ab45ae-b0af-432c-a4aa-c02749d2d1eb")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "e3aa2590-fc1d-4363-92fb-5aedee5a9265")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "d2d3d1c3-8fe5-4295-b138-15021ea1c4ca")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "6fb20c2b-88f9-4e75-867d-42658d57d6e4")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "212ff279-ce6e-4bde-a030-dc3e1ee803b6")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "6e8e433f-11ec-4a74-83ae-dfbe87d7fc24")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e175eafd-1d9f-4dac-82ca-7f75c020742f")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "aa594fd8-ed27-4e88-b30a-b11966dd117d")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "e1ad4e50-49e5-4425-a8e6-da2628413b6e")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(J1-PadA5)")
+			(uuid "850054b9-615a-485a-a467-cab8ab670a08")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:PinHeader_2x04_P2.54mm_Vertical"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec90db")
+		(at 63.616700 65.620000 270)
+		(descr "Through hole straight pin header, 2x04, 2.54mm pitch, double rows")
+		(tags "Through hole pin header THT 2x04 2.54mm double row")
+		(property "Reference" "J4"
+			(at 1.27 -2.33 90)
+			(unlocked yes)
+			(layer "F.Fab")
+			(uuid "30feb4dd-d60f-4776-8bea-cc3b34f5dd34")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "SPI"
+			(at 1.27 -2.55 270)
+			(unlocked yes)
+			(layer "F.SilkS")
+			(uuid "8128e921-fa35-4b3e-b924-49ff08f03c11")
+			(effects
+				(font
+					(size 0.8 0.8)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "f7d0abd1-2fba-4013-abb7-51dbc5d471cc")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "14bbf250-d777-4b59-b85d-a56302358cda")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ebdf705")
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -1.33 8.95)
+			(end 3.87 8.95)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "ab2bb5fc-09c8-4ed7-bfca-cea294815650")
+		)
+		(fp_line
+			(start -1.33 1.27)
+			(end -1.33 8.95)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "504cd5b3-9f59-431c-b46e-bc01b39545c0")
+		)
+		(fp_line
+			(start -1.33 1.27)
+			(end 1.27 1.27)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d17b18ae-d3df-471b-a656-ea6f956c61b7")
+		)
+		(fp_line
+			(start 1.27 1.27)
+			(end 1.27 -1.33)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "8980e2f1-147d-477e-b5ad-91de3a104ce0")
+		)
+		(fp_line
+			(start -1.33 0)
+			(end -1.33 -1.33)
+			(stroke
+				(width 0.5)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "65b95d13-3bd6-48c0-844f-ae0f776522e1")
+		)
+		(fp_line
+			(start -1.33 -1.33)
+			(end 0 -1.33)
+			(stroke
+				(width 0.5)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "2a125f29-8a0b-465b-a680-cf50254c3300")
+		)
+		(fp_line
+			(start 1.27 -1.33)
+			(end 3.87 -1.33)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "dbbb3947-7faf-4609-8725-5ff1df11cab9")
+		)
+		(fp_line
+			(start 3.87 -1.33)
+			(end 3.87 8.95)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "db8443cb-1b79-402b-9c22-95b76d3e5390")
+		)
+		(fp_line
+			(start -2.54 -2.032)
+			(end -2.032 -2.032)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "24c7c52d-1c7d-478e-b698-2d40d94b74ae")
+		)
+		(fp_line
+			(start -2.032 -2.032)
+			(end -2.54 -2.032)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "4283dfd0-bd13-424c-8e50-615f1b809053")
+		)
+		(fp_line
+			(start -2.032 -2.032)
+			(end -2.032 -2.54)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "4cf5a073-9a30-4d0b-9cdb-cbad54b47c9d")
+		)
+		(fp_line
+			(start -2.032 -2.032)
+			(end -2.794 -2.794)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "20488e7b-5b4b-44d1-b410-6cdfcabb29ff")
+		)
+		(fp_line
+			(start -1.33 8.95)
+			(end 3.87 8.95)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "d662bf1f-1bff-4024-807c-041f690eee77")
+		)
+		(fp_line
+			(start -1.33 1.27)
+			(end -1.33 8.95)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "f7a75936-bf6d-4a01-a9b0-be3f64706c4e")
+		)
+		(fp_line
+			(start -1.33 1.27)
+			(end 1.27 1.27)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "2de324fa-c2ee-4d8e-9d85-b29460e2a1c2")
+		)
+		(fp_line
+			(start 1.27 1.27)
+			(end 1.27 -1.33)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "89921d21-74f4-4d85-9dd6-007a1f98827a")
+		)
+		(fp_line
+			(start -1.33 0)
+			(end -1.33 -1.33)
+			(stroke
+				(width 0.5)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "4c760c36-2673-46eb-bf8d-bc7d1424c589")
+		)
+		(fp_line
+			(start -1.33 -1.33)
+			(end 0 -1.33)
+			(stroke
+				(width 0.5)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "b2501ae7-5a8f-41a8-b1c6-08ec985b1f62")
+		)
+		(fp_line
+			(start 1.27 -1.33)
+			(end 3.87 -1.33)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "322115ad-a1d9-4fdb-9fbb-70bd548722d2")
+		)
+		(fp_line
+			(start 3.87 -1.33)
+			(end 3.87 8.95)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "cf32d363-840d-4c90-afef-230461ba9775")
+		)
+		(fp_line
+			(start -2.54 -2.032)
+			(end -2.032 -2.032)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "1713ead6-9ded-466a-a73f-c08236664d45")
+		)
+		(fp_line
+			(start -2.032 -2.032)
+			(end -2.032 -2.54)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "985642fc-16c4-4805-a945-45fdf688f437")
+		)
+		(fp_line
+			(start -2.032 -2.032)
+			(end -2.794 -2.794)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "2953769a-8d76-4b0e-845b-ef6d21481333")
+		)
+		(fp_line
+			(start -1.8 9.4)
+			(end 4.35 9.4)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "4f6ad8dc-5ebe-42b9-b2f9-df6eff1e64b1")
+		)
+		(fp_line
+			(start 4.35 9.4)
+			(end 4.35 -1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "d529f96d-0743-49da-b125-f95d4f51e90a")
+		)
+		(fp_line
+			(start -1.8 -1.8)
+			(end -1.8 9.4)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "9b960fe2-c6ec-4842-afc9-2fce8057fab5")
+		)
+		(fp_line
+			(start 4.35 -1.8)
+			(end -1.8 -1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "202ddee6-7866-4102-a15a-a5a35f843e39")
+		)
+		(fp_line
+			(start -1.27 8.89)
+			(end -1.27 0)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "8e5a02cc-b4d0-4bd9-9f6d-892baab7c2b8")
+		)
+		(fp_line
+			(start 3.81 8.89)
+			(end -1.27 8.89)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "db3e4914-0fe0-49f7-9710-91bc70a8ec03")
+		)
+		(fp_line
+			(start -1.27 0)
+			(end 0 -1.27)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f12c0294-ba0d-4ca2-91ba-845de626eeaa")
+		)
+		(fp_line
+			(start 0 -1.27)
+			(end 3.81 -1.27)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "2e67008d-806f-4683-b36f-33cd0a743621")
+		)
+		(fp_line
+			(start 3.81 -1.27)
+			(end 3.81 8.89)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e3af3824-4c59-4002-a5f0-2072b24142e0")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 1.27 3.81 0)
+			(layer "F.Fab")
+			(uuid "39c52665-12ae-49ad-9506-d6ada8093ca9")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "1" thru_hole roundrect
+			(at 0 0 270)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(roundrect_rratio 0.25)
+			(net "/CS")
+			(uuid "e934e44c-6058-424a-8ea8-375149731999")
+		)
+		(pad "2" thru_hole oval
+			(at 2.54 0 270)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "VTARGET")
+			(uuid "7f7239ac-9306-4a5a-acfc-a493e9ef6349")
+		)
+		(pad "3" thru_hole oval
+			(at 0 2.54 270)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/CIPO")
+			(uuid "795d8ce5-fd32-42dd-aa01-725fad342063")
+		)
+		(pad "4" thru_hole oval
+			(at 2.54 2.54 270)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "Net-(J4-Pad4)")
+			(uuid "4ae2ff61-5967-43a1-9c33-212d7b4e7b82")
+		)
+		(pad "5" thru_hole oval
+			(at 0 5.08 270)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "Net-(J4-Pad5)")
+			(uuid "45a8b9c1-7226-40c4-9825-48c6e56f59d9")
+		)
+		(pad "6" thru_hole oval
+			(at 2.54 5.08 270)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/CLK")
+			(uuid "8872480d-a43c-4b12-8c0a-9f40ea9d53a9")
+		)
+		(pad "7" thru_hole oval
+			(at 0 7.62 270)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "GND")
+			(uuid "cc51cbf0-b07b-4f54-8334-95cfe68694dd")
+		)
+		(pad "8" thru_hole oval
+			(at 2.54 7.62 270)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/COPI")
+			(uuid "8b6bf79d-cd82-419d-904e-67beaabc6077")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_2x04_P2.54mm_Vertical.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec9141")
+		(at 60.500000 53.015000 270)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R18"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "60c92b13-10c4-4c94-8f70-3df3311fe3be")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "1c499233-ee56-4945-8686-ae4541ce74bb")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "c3fe6508-6076-40bc-afef-8b2171e86152")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "7324f954-1b2a-431d-a92b-149ea2a91340")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005fb4f232")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "9006ec97-fa44-4213-9291-e5bf62328653")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2af5227a-dc4b-4593-ac5b-0e2987e72d93")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "16f237ec-afd2-4ca2-b98d-88f0d813524b")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "99e4a479-ab28-43e9-af91-d81fa11accd1")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "0c1e2f62-7c5e-4ec6-b14a-0a55ebe7b964")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "edd513d3-02eb-4087-a41a-9165a45dd3f6")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "61543b8d-9151-456c-8746-bd5c97a0491a")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9281e340-b650-4c18-b354-ddb06f6f9d41")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "ebfecfa0-8b47-4019-8bf3-f7241133e5af")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "2bb3428c-5646-4da3-8393-1d7bcdd5a114")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(R18-Pad2)")
+			(uuid "4d7b17e1-240c-461b-b035-cd1418b47685")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec916b")
+		(at 64.600000 37.900000 90)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R6"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "24af98ce-ccc6-4c4a-814c-dc93b2b1d06f")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "12k, 1%"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "ed79349e-d3e0-451a-9c29-4fa448a5dfef")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "93aecf30-2b56-40af-a7fd-94ed07fe86f6")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "68674b22-861e-4ad6-867c-e24b012d6a38")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ee10d01")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "f1c8e242-4601-44dd-ace7-2ff79b71e9a3")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "5e898769-f43b-47aa-850c-f502e016461d")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "47cf9027-dd80-483d-9535-717aba2525ce")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "c9989d23-097b-4346-8dc0-79b849fddc02")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d29384f1-0402-4ec8-a8b9-717d688fe998")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "8c1d7e80-fc33-4e76-8d4c-ea82b2c74f8c")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "39bfbbea-2f58-4a65-af11-75baf5fdf083")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "08f6bd15-8fc3-407b-9644-5c6956799b58")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "1f44e9e4-ade1-49da-a433-b198d759255b")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "81cfb9c9-af6b-4b75-ad7f-53959990e1c4")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(R6-Pad2)")
+			(uuid "615cde81-1ed4-41f9-ad69-0b695b97ea8d")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec9279")
+		(at 49.700000 41.400000 270)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R9"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "8ea6e346-df18-45af-9d28-74b12c19bdbc")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "330"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "bb0bbfdd-a0a5-4629-bc9e-d181aa3f3e77")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "09d15989-ec58-41d6-be3b-5ca777a40fc2")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "80bcb9db-419e-459f-a730-330cc104c252")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00006027fad3")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "5a83a743-1967-478e-bb9d-cd89d3b8b163")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "6a811f33-fb96-49f6-a35b-bf4b32e00420")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "fe59aa28-28fd-43f6-80f7-bbf55e0aa1e9")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "cf302d0d-fb57-41e7-86fc-ef0a714f769c")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "91ef6ff1-2949-4b83-9c60-ace0bbff49f9")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "6b035dc3-fbdc-40a8-b720-ef37df952745")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "278ce078-b9c3-43ee-8d8c-75932d88c57b")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "65fb1c18-bab5-4da7-a340-e4771bc6c0b3")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "bf632d6d-753e-4132-9f19-8b80ebdec45a")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(D4-Pad2)")
+			(uuid "1df0b6ce-6ed8-4424-8bdb-228a8bac65f1")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "ddd756c9-8d83-4949-aa85-022758c4ef60")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:SOT-23_RoundRect"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec92a9")
+		(at 52.800000 49.400000 270)
+		(descr "SOT-23, Standard")
+		(tags "SOT-23")
+		(property "Reference" "Q1"
+			(at 0 -2.5 90)
+			(layer "F.Fab")
+			(uuid "41d1956a-f73f-4a22-9114-de56bfceee20")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "BSH103"
+			(at 0 2.5 90)
+			(layer "F.Fab")
+			(uuid "8be97105-ce37-4c5c-ba8a-2e67a515ad12")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "9c33ee32-a15a-49b1-ac80-9d319be2b7e4")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "d257555a-f273-4e9a-bb0f-5419da60a89b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ec0037d")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.76 -1.58)
+			(end -1.4 -1.58)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d5dd7b7b-ab57-4d59-9763-d86dc6b00beb")
+		)
+		(fp_line
+			(start 0.76 -1.58)
+			(end 0.76 -0.65)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "bacddff0-1b91-4ed3-9d1b-1b51b57a1406")
+		)
+		(fp_line
+			(start 0.76 1.58)
+			(end 0.76 0.65)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "0a7da457-e28e-46cb-95be-3976da2260d9")
+		)
+		(fp_line
+			(start 0.76 1.58)
+			(end -0.7 1.58)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "14994f59-cc68-470a-a3be-0231a58da008")
+		)
+		(fp_line
+			(start 1.7 -1.75)
+			(end 1.7 1.75)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "7585c1b9-a82b-492a-bfd1-6d14c0cf0c64")
+		)
+		(fp_line
+			(start -1.7 -1.75)
+			(end 1.7 -1.75)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "41f734a9-f12c-4140-97a5-92efee9b9e3b")
+		)
+		(fp_line
+			(start 1.7 1.75)
+			(end -1.7 1.75)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "385b0d18-ee43-4fc6-bb9e-fcb7b2e2104c")
+		)
+		(fp_line
+			(start -1.7 1.75)
+			(end -1.7 -1.75)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2eaf35cc-96c0-441d-955e-bc52e86d6cc4")
+		)
+		(fp_line
+			(start 0.7 -1.52)
+			(end 0.7 1.52)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "8046bc54-96ee-4551-940b-135047b2e8cc")
+		)
+		(fp_line
+			(start -0.15 -1.52)
+			(end 0.7 -1.52)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "16729ffb-6621-44bb-9813-1b90b721f3c8")
+		)
+		(fp_line
+			(start -0.7 -0.95)
+			(end -0.15 -1.52)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "38b10064-ff8a-452c-b736-d1590a924793")
+		)
+		(fp_line
+			(start -0.7 -0.95)
+			(end -0.7 1.5)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d9bd41ba-6073-4cd3-a7d1-d0dc7bee7e7e")
+		)
+		(fp_line
+			(start -0.7 1.52)
+			(end 0.7 1.52)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "bd32726c-4cd4-401e-baa6-1090a1568b1b")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "1fc0ee16-abdd-48e7-968d-c3e6a57a39c6")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.075)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -1 -0.95 270)
+			(size 0.9 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "3b334221-b657-426b-bdf7-23111ed719bd")
+		)
+		(pad "2" smd roundrect
+			(at -1 0.95 270)
+			(size 0.9 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "2e923c35-9555-490a-a6c6-3295f9c92485")
+		)
+		(pad "3" smd roundrect
+			(at 1 0 270)
+			(size 0.9 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(D2-Pad1)")
+			(uuid "cc68bb2e-9eb1-4798-be90-3e0c35efad78")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Package_TO_SOT_SMD.3dshapes/SOT-23.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec92df")
+		(at 59.385000 70.426700 90)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R21"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "4b71d84a-d4e3-4d04-98f8-a346335f3ffe")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "616a0381-090c-423c-aef1-eacb49a37d7c")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "e9deb18c-b8e9-45e6-8756-ca2bed3dfa0d")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "c0de401b-fd54-4efd-a6ad-81224032fcaa")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005edd63f0")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "94891618-aec5-4ec0-a53c-91cf7a37e95f")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "0fd86333-3768-403f-bf2b-b6ac311975cc")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "06e50fb9-ac4c-4c90-a119-6fd42cbcacb2")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "5f66b7ea-4313-4fdb-abaf-d32a69f61397")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "57a0e8f9-8ffd-4091-b72a-7cdfba4fe38b")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a807eae4-1d4d-4048-9db5-d814e4d46e13")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "851e6796-9df5-41e8-afbc-bd51f03e38cf")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "42496899-4235-48c3-8721-f40a6ef31324")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "7633080a-fdea-4e5a-81a3-af10a750fdaf")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VTARGET")
+			(uuid "2be9c57b-719b-4a3e-8412-75f6aa9fac1a")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(J4-Pad4)")
+			(uuid "7fb447b6-f6c7-44b0-8a68-ff8533e1642d")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec9309")
+		(at 40.000000 63.700000 90)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R15"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "49e74603-7151-4cc2-8d27-0a5889464d29")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "2.2k"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "e7f3e9ed-ff27-4d85-a252-60908b9d254a")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "15412281-287f-4793-b868-0f445008de9a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "193e81c2-0b0d-46a1-965d-c17210455802")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f72cd39")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "c1953162-4a3d-45c7-b281-f8fa476f2c57")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "033741ac-a417-4f5f-b0ed-4143601dee34")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "990390b5-ce78-4664-ad7a-0e622c6e5c0d")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2faa715c-432a-4271-a4c5-34d35c3d1180")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "4357f83f-8344-490e-ad2f-5da177f666e6")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "634fce95-d1bb-480f-a764-5eb2071bf463")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c54d3d38-3efd-4cca-b335-77f0f8d63e4b")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "1e906826-faef-469a-af9c-b5e261731232")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "3e9af31b-94d5-412c-b22e-1a86b6424290")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/EEDATA")
+			(uuid "d07eadc8-2d62-465e-a848-383f388f0bad")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(R13-Pad2)")
+			(uuid "a18d8b08-cfad-44bd-98e3-fce091b412ab")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec9333")
+		(at 56.300000 62.200000 180)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R10"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "df982c89-cb67-40d6-b572-66fa0dbf7213")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "bf8cb901-0ab5-4bb9-b6a6-87d2145fa98d")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "32d5049e-344d-4538-9c68-bfa92c698de6")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "4d634a84-fdce-40a9-9ed2-a170b5549a04")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-000060387b05")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "d9b96e8a-e01c-4dbd-8ca8-4b920a3c5def")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "41610359-b6a2-40c9-9176-cb430a6970f5")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "3c2f9a81-733f-464c-9af2-3559eeb8d2a0")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "6f4ca5c7-a9d6-4c8d-b1be-f085a4eb9df8")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b219ac59-158b-4429-9fe4-24732afde678")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "cee8955c-6367-454d-bd55-038636ce4b8a")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d217deb7-dcfa-4f04-8475-b422af3c4672")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f811609a-5374-4d32-af2c-eb98191bd65c")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "23d92301-8e8a-40d7-b830-aba65aecd53c")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "536dfbd1-69fe-47f6-9e88-36fb3394302b")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/~{ENABLE}")
+			(uuid "24c6fb74-1e44-4971-9bfd-d7684d2f0113")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec935d")
+		(at 61.800000 50.400000)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C20"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "ddf62db0-329b-401e-98cf-d23852c05f08")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100n"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "9f96c9e4-9dfc-458b-8c9e-2477351666de")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "eac07145-2dce-4bcb-b81a-caef2bded2df")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "5ca1bd36-f90b-4a51-85be-5637cb377492")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-000060d35de8")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "9dff6ecf-577f-475c-9766-a910f6bd3a3e")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "c9dc03f0-6781-460f-a425-200740d0efc3")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "3d6867a2-fa1f-4699-8fd7-10f370e7ab9d")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "78599681-093b-4816-b69f-9a2325478558")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "42cdff92-6fcc-4332-bb06-97250b4f407b")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "136726d1-3064-439b-b5d5-8fa6298fc2fa")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "95df23bb-26ac-417e-8dc6-010681da6f41")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e0d76b0c-c0b7-48c9-8d16-6ea320b1dee2")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "4172afff-11f8-48bb-a1dd-2f3000d612c5")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "36135009-34ce-4a9a-97a7-73661696aa04")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "e598a256-e182-4a9d-9219-5fa1543bf78b")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec9444")
+		(at 66.500000 39.900000)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C5"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "da8fe7fd-ec98-48a4-912d-f56cbb292006")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100n"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "d8e4c202-fdc6-434f-a6ca-1c7771547621")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b613bed4-a29c-4410-a914-779a27569b50")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "12b28ff3-4905-4a41-ac86-a5015633b95a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ef8e430")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "747fb189-7f19-4312-9d22-85742324a423")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "06f73029-40d1-4daa-aaf1-4c8d84f53148")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "9c2b17a0-866b-44a0-a9e3-47c9da443ad1")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "5c3db4f5-b41f-438a-8306-235b4a667326")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c8f693e5-46d3-4212-8bce-253f929f94a9")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f41cc5a9-028c-4ed4-a6b8-3094732b20a6")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f7dcf4c8-15c3-4381-a6ac-05a97da29a3f")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "df58d99e-9371-4d04-aa53-96f28c0a1a3e")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "2db384f5-7d22-49ba-8ae1-894dbf1ecc42")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/VPHY")
+			(uuid "a002fddf-bd77-4d4b-8f38-855b8a601978")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "c05d14ce-3da7-4075-80f8-4ac2b902b908")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec9471")
+		(at 63.630000 44.858300)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R7"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "7d1eaff7-75e3-4e8b-922d-a20720e7baa0")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "f2e03c3b-9a53-455b-b75f-7f89064ccdf4")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "2f8fade8-a7b7-4df5-b742-1ee1afca81ea")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "48d05d25-0ef6-4c7a-993f-b6ff6a29dda7")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ee173e9")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "9c602f34-0151-48cd-a598-4859580fecfd")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "ce37fe65-96e8-445d-a354-f660d80f7166")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "0f555f29-6bc8-4515-8239-bd35064b5cab")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "22321f70-aac3-4b73-91f3-c913ff5400dc")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "46320f4a-4ccf-4a09-89d9-042c35fabacf")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ecebf158-50bd-4cf8-bb82-45fb725b460d")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c52a598d-b90f-4448-a50a-907a5a919ed2")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "2c417133-0f4a-47c9-85e5-b5b3185765d2")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "33d7a68f-d6d4-4b8e-af74-d2e23dabcb58")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "0d7b8f66-66cf-41bb-bc85-c09fa7319b61")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(R7-Pad2)")
+			(uuid "65995793-b83e-4b6c-a211-e6b5a7d8e120")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec94a1")
+		(at 40.400000 57.900000 270)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R8"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "f75257b9-4cdb-44be-a27c-75e53596af1d")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "330"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "ccc446c4-b9db-448b-9aa0-2d7007dc6d99")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "ccc9c6b7-45fd-48c5-8c9f-e1a4f52cb26c")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "a44e0c07-1761-4fc0-9b4b-bdd67a238f29")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00006027fe9c")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "33312c15-6457-4c0b-8fc8-9ac7b1e7f0e6")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "55021af7-4965-4cdd-9744-66dfc89cfe6f")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "281573fb-86b5-416c-b0fe-29373b620476")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "49e1bad8-ad04-4ea5-92a6-4e8b72be958d")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "70427058-3761-44e5-b705-bea6dc266ee0")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "817b3bf6-5f91-42c7-a55c-64907484f43d")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e135d182-5a65-462a-81da-181b14e01911")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c5189cda-deca-4491-8aea-7c4716fded72")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "9aec9e8a-0bde-45a8-a750-6532c065fb00")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(D3-Pad2)")
+			(uuid "7a00be39-b49b-4e8b-b73d-cb9f3d3fc3c7")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "ac4f10df-43f1-494a-9bf1-8153a441c4a5")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:SOT-23-5_RoundRect"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec94d1")
+		(at 45.100000 44.900000 270)
+		(descr "5-pin SOT23 package")
+		(tags "SOT-23-5")
+		(property "Reference" "U2"
+			(at 0 -2.9 0)
+			(layer "F.Fab")
+			(uuid "38ff575c-f78e-4b54-adda-03a6aedb9d4e")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "AP7365-33"
+			(at 0 2.9 0)
+			(layer "F.Fab")
+			(uuid "6cc11535-f161-4713-aa48-096f6ecb1f1e")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "7d577124-9be7-4619-8f38-7a84e7120431")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "11d766df-e614-464d-8f1d-2c5fb5941a4c")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ebe5652")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.9 -1.61)
+			(end -1.55 -1.61)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "c4bf0ba4-b3d3-4efa-a1a6-6414a011b09d")
+		)
+		(fp_line
+			(start -0.9 1.61)
+			(end 0.9 1.61)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d503be92-3daa-4941-9312-2e13d0b769ab")
+		)
+		(fp_line
+			(start 1.9 1.8)
+			(end -1.9 1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "ba02b310-6dcb-4e1b-8f11-448f6e4a7753")
+		)
+		(fp_line
+			(start 1.9 -1.8)
+			(end 1.9 1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "070f287b-e388-4370-9762-fccb0e4aeaed")
+		)
+		(fp_line
+			(start -1.9 1.8)
+			(end -1.9 -1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "7fbd40d4-882e-4a6c-928d-7d687e7f53c5")
+		)
+		(fp_line
+			(start -1.9 -1.8)
+			(end 1.9 -1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "913d158c-925d-44d0-b324-3f55763dd870")
+		)
+		(fp_line
+			(start 0.9 1.55)
+			(end -0.9 1.55)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "1171518d-cb75-42d0-8fce-88fe646e1fbc")
+		)
+		(fp_line
+			(start 0.9 -1.55)
+			(end 0.9 1.55)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c824b122-4f03-499e-8443-c85c0ed3599f")
+		)
+		(fp_line
+			(start 0.9 -1.55)
+			(end -0.25 -1.55)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e884c1db-c85a-453c-8552-aaa9df7ab66c")
+		)
+		(fp_line
+			(start -0.9 -0.9)
+			(end -0.25 -1.55)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "cbc32b0b-1ba3-4ee5-b2b2-291ec2fbe9ec")
+		)
+		(fp_line
+			(start -0.9 -0.9)
+			(end -0.9 1.55)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "4430e8f8-30cb-4818-888a-8ddc07b408b0")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "d232163c-697a-497a-b891-f3918b29af70")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.075)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -1.1 -0.95 270)
+			(size 1.06 0.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+5V")
+			(uuid "e99b8097-b10e-4038-89c1-ea65c792a8b9")
+		)
+		(pad "2" smd roundrect
+			(at -1.1 0 270)
+			(size 1.06 0.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "c7d0e909-1a9f-45d9-ba96-a732e5118f13")
+		)
+		(pad "3" smd roundrect
+			(at -1.1 0.95 270)
+			(size 1.06 0.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+5V")
+			(uuid "22931446-d779-42a4-8d5f-16b636c0ad81")
+		)
+		(pad "4" smd roundrect
+			(at 1.1 0.95 270)
+			(size 1.06 0.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "7828a9fb-2a58-46db-abc6-65c4680fc1b2")
+		)
+		(pad "5" smd roundrect
+			(at 1.1 -0.95 270)
+			(size 1.06 0.65)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "94f09866-f699-4e98-b9ac-82a6ac39b88a")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Package_TO_SOT_SMD.3dshapes/SOT-23-5.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:R_Array_Convex_4x0402_RoundRect"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec950f")
+		(at 46.000000 70.200000 180)
+		(descr "Chip Resistor Network, ROHM MNR04 (see mnr_g.pdf)")
+		(tags "resistor array")
+		(property "Reference" "RN7"
+			(at 0 -2.1 0)
+			(layer "F.Fab")
+			(uuid "017f920d-8cf0-4520-b64d-5b72c5e4576d")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100k"
+			(at 0 2.1 0)
+			(layer "F.Fab")
+			(uuid "7f9c6b71-e768-4feb-8b39-f096dbe9c7fe")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "c69f4400-678b-4eb3-b1e8-41f74cd05811")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "f98da903-2065-442b-958a-8827e470a8f6")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-0000612c4df4")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.25 -1.18)
+			(end -0.25 -1.18)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "2ff67bcb-c2d4-4b17-aac2-bb3a62397435")
+		)
+		(fp_line
+			(start 0.25 1.18)
+			(end -0.25 1.18)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "38455924-0b31-424c-b936-e3469dd29829")
+		)
+		(fp_line
+			(start -1 -1.25)
+			(end -1 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "08cc9866-d95e-4bda-83b2-db31c5c63f9a")
+		)
+		(fp_line
+			(start -1 -1.25)
+			(end 1 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "017d0fa3-942a-44b5-8f69-ca0da85db93a")
+		)
+		(fp_line
+			(start 1 1.25)
+			(end -1 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "9769f791-6b7c-4f5f-88f0-1b7e85f56244")
+		)
+		(fp_line
+			(start 1 1.25)
+			(end 1 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "a7d39629-f392-4630-b6dc-3da48c50a2df")
+		)
+		(fp_line
+			(start -0.5 -1)
+			(end 0.5 -1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "90e5c15c-a0a4-4260-ad29-4d2d1a624207")
+		)
+		(fp_line
+			(start -0.5 1)
+			(end -0.5 -1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "43deab0c-a886-4920-892c-6cdc3ce20abe")
+		)
+		(fp_line
+			(start 0.5 -1)
+			(end 0.5 1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "81bf3bf9-d5c2-403b-a76e-dc09b4bed57c")
+		)
+		(fp_line
+			(start 0.5 1)
+			(end -0.5 1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "626c2134-6262-4956-b64f-cd66572d5273")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "6c7a473f-3c21-4bab-8510-f6d2abfd79af")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.075)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.5 -0.75 180)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/ICE_CDONE")
+			(uuid "bb07f5e9-db0b-427c-83af-e18ef4e9d845")
+		)
+		(pad "2" smd roundrect
+			(at -0.5 -0.25 180)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/~{UART_CTS}")
+			(uuid "3b1f6c8c-ed96-48fc-8d7a-0edc79ad44ef")
+		)
+		(pad "3" smd roundrect
+			(at -0.5 0.25 180)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/~{UART_DSR}")
+			(uuid "ab87a86f-b58f-45d3-aca7-9fce9d0938c5")
+		)
+		(pad "4" smd roundrect
+			(at -0.5 0.75 180)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/~{UART_DCD}")
+			(uuid "fe06707c-6976-4ae4-a1ad-8b0f5f344e9a")
+		)
+		(pad "5" smd roundrect
+			(at 0.5 0.75 180)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "590b3e5e-de6f-4bcc-8431-6808f2ca4fb2")
+		)
+		(pad "6" smd roundrect
+			(at 0.5 0.25 180)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "c3480dde-54ae-4da6-b924-d286cb070d29")
+		)
+		(pad "7" smd roundrect
+			(at 0.5 -0.25 180)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "85b980bc-81cd-4314-9e02-c67760cafe62")
+		)
+		(pad "8" smd roundrect
+			(at 0.5 -0.75 180)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "bc43d391-21d8-45fd-baf4-d955e0ba6f1e")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_Array_Convex_4x0402.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec954c")
+		(at 63.630000 41.858300 180)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C7"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "5caba61b-8a89-47f1-8d0e-f1c55ccf21af")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "2u2"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "7a630f87-42d1-4b8a-aa2f-94ee0119cbbd")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "0ecff914-5312-44ee-a200-73e48aeb2b46")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "c7d97a47-16d3-4ca9-af48-d16e472c7077")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ed867b3")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "b4d5aeb1-5de0-425d-a1e0-1ec441884949")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "62ed8748-07e4-45b8-9d1e-8acfc8015570")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "e25cfbe1-81a4-4ebe-b452-24790510af31")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "e98d7c78-2e36-4788-986e-d74050b61fc0")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "dd3be009-1b83-4571-aa7e-60d8aa5015c2")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "69eccef5-a2b4-4f77-bc08-a110760ce8f0")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "1ac35f6d-9408-4eb2-9847-e23b11051fc5")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "86f69aa9-858e-4f68-b163-d82150101a23")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "f91d9c2a-4143-454c-8df7-f1753d72f98b")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/VPLL")
+			(uuid "e3baf949-20cf-4c31-bd30-add10720e1ac")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "dc553efe-1312-4dc0-aec5-5367fe84f871")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec96b4")
+		(at 63.600000 39.900000 90)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C8"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "c7f708ae-9205-4011-aa75-8fd80f92feac")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100n"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "305dc3a3-1cf9-4959-a977-1acba88eda33")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "5a2e8278-4c24-4ef5-908e-d6a9ca665fef")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "9bc3e915-9743-4d14-a9b7-a358feb2c14c")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f0d7ad7")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "d4ee2bf9-3da0-4017-af5b-0fda25fefcd6")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "d4f2dc26-68cd-4987-b6ed-99d0f9bab96c")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "e913d843-14b2-42a8-a521-50b030bb11cd")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "6d7a0fae-975a-46b2-b717-0ced09640e51")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "8a3a4830-0599-4815-9a02-8df69946f708")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "bdec6814-3c60-416f-9978-37a5e24564f2")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d5f29814-e222-492f-ade4-e925354747eb")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "0faa6fdd-4241-4a88-a842-0323ebecb0d8")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "3522beb0-e11d-4203-b8e8-322388e58fc8")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/VPLL")
+			(uuid "31a23ed8-c90c-4dbe-8eb3-6ed118de682c")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "5539cfde-c802-425b-ab4b-23a783fe63ef")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Inductor_SMD:L_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec96e1")
+		(at 48.015000 51.900000)
+		(descr "Inductor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "inductor")
+		(property "Reference" "FB1"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "95198cf2-5c83-47eb-94e8-9c67884a8906")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "600R, 0.5A"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "ccc02b2c-0a5c-42bb-be05-ba8d4a23f3a6")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "0207c0d1-faf8-40ed-b284-cd5c4eff9f41")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "6bf6bd1d-04f6-474e-bcdc-0817e9f29457")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005efb1073")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "e4204dc5-5a48-4fe5-bde9-8aa55d933c35")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "8b4121be-5b5d-4f50-868d-c5b17ef30514")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "d397ac98-3e6c-4e7d-9519-b4e92042e324")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "d6e39221-6380-4ea1-90c0-b06910e2aa40")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "3798ee8c-ce3f-453a-8c1a-034726994eb9")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "53d8c36a-6068-43e6-9ba6-92977300e6d4")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b8986638-a91a-4bf9-a6b9-a9f373f5385b")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "0c0e186e-ab5f-4921-8e8d-712e76f3565d")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "b5b4d340-52dd-4541-ad4b-7790dbc9f4aa")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "5b4e4a46-77f9-4041-80f1-a57ae3ea30f4")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/VPHY")
+			(uuid "90a99f77-f85d-4f69-b281-1aca2db0a20b")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Inductor_SMD.3dshapes/L_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec97c2")
+		(at 53.931700 62.260000)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C15"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "269e7704-505c-45ee-bad3-6a8b56aa2668")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100n"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "56fac5ab-4b37-47a9-a4cf-9fd8c890ac9b")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "e5ee0fbb-c809-4554-9fbe-2b9cb0e90e10")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "9e2eba8d-f497-4ef0-96bb-4f36874e3cda")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f8a478f")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "5b374205-de3b-441d-9f25-5a14682651cf")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "6e738067-87f6-468d-a64e-ed812587e872")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "d3300196-5e0d-4a41-a084-3e1d987489d7")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "93edbb3f-4f8a-4783-991d-b7f6e851f252")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "bff17869-d127-485b-9531-66e1e9d7cad9")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "362dd438-e33e-4f55-92d0-ecea4705bc30")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "1a00ea97-ea0a-4fec-a58e-2f11605c88ba")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a6ba7246-67b1-4559-b77b-14ae111b93a1")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "3e865886-7950-42a6-945c-d31d45ed1230")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "a109f825-fb43-417a-9efc-3d23a39f4171")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "e0690b0e-60f6-41d4-835f-9c1480c95ddf")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:R_Array_Convex_4x0402_RoundRect"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec97f4")
+		(at 46.300000 64.450000)
+		(descr "Chip Resistor Network, ROHM MNR04 (see mnr_g.pdf)")
+		(tags "resistor array")
+		(property "Reference" "RN8"
+			(at 0 -2.1 0)
+			(layer "F.Fab")
+			(uuid "b147a5bf-2a46-42e2-bd96-5132edafdf42")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100k"
+			(at 0 2.1 0)
+			(layer "F.Fab")
+			(uuid "e75b6ed5-6bbe-43ec-bd33-17e2c01a6d02")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "c801fba9-4ceb-482b-a476-e8f12013149e")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "ac7d1696-30d8-47ac-93b3-70ae19da300f")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005edcd172")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.25 -1.18)
+			(end -0.25 -1.18)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b0412022-8791-4233-96a4-728f4b13bac6")
+		)
+		(fp_line
+			(start 0.25 1.18)
+			(end -0.25 1.18)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "c8266556-25e2-4ba6-a157-854860b80106")
+		)
+		(fp_line
+			(start -1 -1.25)
+			(end -1 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "d03028c9-6e86-4e83-9377-5668c29f6434")
+		)
+		(fp_line
+			(start -1 -1.25)
+			(end 1 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "f36ecd1f-7b25-414c-b385-8beb5f506388")
+		)
+		(fp_line
+			(start 1 1.25)
+			(end -1 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "533e2866-3653-4e0c-8e17-e8778df1deaa")
+		)
+		(fp_line
+			(start 1 1.25)
+			(end 1 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "137a2f7b-6432-4a92-a2a5-f08e1ab4222f")
+		)
+		(fp_line
+			(start -0.5 -1)
+			(end 0.5 -1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "271fadba-fe13-4302-b86a-4da5319143b0")
+		)
+		(fp_line
+			(start -0.5 1)
+			(end -0.5 -1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "f3314a50-b791-4171-b162-a4be8d33bf68")
+		)
+		(fp_line
+			(start 0.5 -1)
+			(end 0.5 1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "5a7ab889-df0d-4524-b1cc-e8ef0e5354e0")
+		)
+		(fp_line
+			(start 0.5 1)
+			(end -0.5 1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "5ee229b0-5811-4456-8bc1-d542889e8628")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "7af944f5-63e5-4b29-b0aa-b63f1698864c")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.075)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.5 -0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/DI")
+			(uuid "041a2884-5129-4ebe-b17b-833bd84e0771")
+		)
+		(pad "2" smd roundrect
+			(at -0.5 -0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/ICE_CDONE")
+			(uuid "46c63b8b-3c6b-4148-9847-c0139219e78e")
+		)
+		(pad "3" smd roundrect
+			(at -0.5 0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN8-Pad3)")
+			(uuid "69089371-944b-4347-afbe-e754e16d8f07")
+		)
+		(pad "4" smd roundrect
+			(at -0.5 0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN8-Pad4)")
+			(uuid "e5811467-ed70-49bd-9f41-556a97ca3bf4")
+		)
+		(pad "5" smd roundrect
+			(at 0.5 0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "407780a0-cc31-46a8-a1c9-ad34c8388b74")
+		)
+		(pad "6" smd roundrect
+			(at 0.5 0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "99163f66-7e55-4172-b2d8-72bd18f873d1")
+		)
+		(pad "7" smd roundrect
+			(at 0.5 -0.25)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "f8899aeb-644a-465e-b0fa-b750fcb7e954")
+		)
+		(pad "8" smd roundrect
+			(at 0.5 -0.75)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "98e0d86e-ead4-434e-803c-f3d8447d67cc")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_Array_Convex_4x0402.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:R_Array_Convex_4x0402_RoundRect"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec9836")
+		(at 44.000000 61.700000 270)
+		(descr "Chip Resistor Network, ROHM MNR04 (see mnr_g.pdf)")
+		(tags "resistor array")
+		(property "Reference" "RN6"
+			(at 0 -2.1 0)
+			(layer "F.Fab")
+			(uuid "9d01ef66-46c4-4567-9325-35e9e424fea5")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100"
+			(at 0 2.1 0)
+			(layer "F.Fab")
+			(uuid "cf951f6a-9b87-4cfd-a4aa-812b227c61b1")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "1c995596-6174-4daa-9665-4c833658dd23")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "3455c42d-1c9c-4b19-a0ad-e3d9415e2a84")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ed9af75")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.25 -1.18)
+			(end -0.25 -1.18)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "dc8a4d18-01c3-49b1-aeb5-d6595646339a")
+		)
+		(fp_line
+			(start 0.25 1.18)
+			(end -0.25 1.18)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d8503be9-422d-4fad-9cef-409391adf915")
+		)
+		(fp_line
+			(start -1 -1.25)
+			(end -1 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "3ab653cf-ebd9-4d37-83b0-c8f2062c98c6")
+		)
+		(fp_line
+			(start -1 -1.25)
+			(end 1 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "ecdbc9fb-bd55-4ecb-874d-f528e7b1b5fb")
+		)
+		(fp_line
+			(start 1 1.25)
+			(end -1 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "a97fe46c-e0d9-4ea6-a632-4a7475c61954")
+		)
+		(fp_line
+			(start 1 1.25)
+			(end 1 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "920d60a9-228a-4e20-8717-1e6f723aec82")
+		)
+		(fp_line
+			(start -0.5 -1)
+			(end 0.5 -1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "32961950-94c3-41e9-89ee-a036689f1265")
+		)
+		(fp_line
+			(start -0.5 1)
+			(end -0.5 -1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "01f45059-8b5a-4b1b-b22b-03b7f444fa0b")
+		)
+		(fp_line
+			(start 0.5 -1)
+			(end 0.5 1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "5d2c1e03-364c-4a10-886f-7a45c8a34a22")
+		)
+		(fp_line
+			(start 0.5 1)
+			(end -0.5 1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "0a78b53f-8bec-46c2-a0d4-9190b3ad9f7d")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "5e23bed3-d386-4f4e-9469-ceef9a6d207b")
+			(effects
+				(font
+					(size 0.5 0.5)
+					(thickness 0.075)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.5 -0.75 270)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD2")
+			(uuid "dd92535e-a64f-4d0a-9cd0-fc98e9a6de40")
+		)
+		(pad "2" smd roundrect
+			(at -0.5 -0.25 270)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD6")
+			(uuid "e806e188-34cb-4ab8-937a-3b020616d9ab")
+		)
+		(pad "3" smd roundrect
+			(at -0.5 0.25 270)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "96ef9955-2ba5-451c-8cda-ff02c006189b")
+		)
+		(pad "4" smd roundrect
+			(at -0.5 0.75 270)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "8467dd8a-2600-4dff-8a27-0e52cc86d995")
+		)
+		(pad "5" smd roundrect
+			(at 0.5 0.75 270)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN6-Pad5)")
+			(uuid "77b6b1d2-ada0-447e-ae26-dc5df3272ca6")
+		)
+		(pad "6" smd roundrect
+			(at 0.5 0.25 270)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN6-Pad6)")
+			(uuid "96df956b-8dbd-4800-8721-135db90b3a5e")
+		)
+		(pad "7" smd roundrect
+			(at 0.5 -0.25 270)
+			(size 0.5 0.3)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN6-Pad7)")
+			(uuid "a9cc2b83-3f51-49e7-a15b-8682eff37e59")
+		)
+		(pad "8" smd roundrect
+			(at 0.5 -0.75 270)
+			(size 0.5 0.4)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(RN6-Pad8)")
+			(uuid "152c8af5-8f77-43e8-a770-c7ad7e53cf61")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_Array_Convex_4x0402.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec9870")
+		(at 42.500000 56.900000)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R17"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "e763c84a-dd02-46c4-8b20-01c367ed92db")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "1M"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "7b8892cc-b655-4eb3-bbf1-cafd88c5bbd3")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "077cfea0-84a7-4920-b126-ad91555b8f4c")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "251dc7d6-eca1-45ee-98e8-8e4f3f1a741a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-0000610cf3df")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "d2791bda-a44e-400f-869a-2dc0e2e37fca")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "95bd8822-c5d9-4c71-a543-4543e61f8d73")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "12201522-8760-42bb-96be-a90e2c93f8c6")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "031c1d3f-3071-4b74-90ef-d490f04a5afa")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "0d5b8162-c3ba-4cee-8ead-0efd8e9674b5")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "1c2b06d0-d66d-4307-af77-2b704eec031a")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "83c60164-268d-422c-ad42-b8227bc35768")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "31c01932-5eed-4b93-ac3d-38cf62680ad4")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "b5e1d5a8-1486-4f7d-977c-f9cc4f2d5cfb")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "c79262dd-d3b1-428b-9c73-344c661bf78e")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "23d57085-e988-432b-b24f-4c27fbd1fc40")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec989a")
+		(at 50.000000 48.600000 90)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C13"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "419a3076-2c4c-4df0-9c43-c8bbabffe901")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100n"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "32a56312-bb14-4346-8154-4837c6bc5912")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "15315da4-c0f3-4a5a-92bf-213b37362ce6")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b2c5d5f1-3d71-4f77-9ff4-0236ec923370")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f777983")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "9b7025bb-ba3d-46f5-a434-db058433b43d")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "8d667b74-e829-4e91-9119-f3e8176e569a")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "912a051f-bfbc-452c-aad4-8c5d2a1abdfb")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "484c4570-eef4-448e-ae95-b70eede3ae64")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a1757dec-d476-4011-b95f-78fb0787ad3b")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "49861cc6-d21a-44e0-8cf3-5b8625d680b5")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9ceb13ab-c0e9-4b3f-ba1e-4e3d361969e8")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b622bdbf-5f2d-4bc0-93e0-00a3ec05199c")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "ac479c65-a62d-4bc1-831b-00290d588420")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREG")
+			(uuid "ab2214a9-3023-42da-a008-fb9d63f345b4")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 90)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "2d05c1f5-4905-434d-ac7b-0b711d06e212")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "LED_SMD:LED_0603_1608Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec98c8")
+		(at 41.000000 49.526000 270)
+		(descr "LED SMD 0603 (1608 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "diode")
+		(property "Reference" "D4"
+			(at 0 -1.43 90)
+			(layer "F.Fab")
+			(uuid "8f1e8b75-dd21-4e73-9e32-f42b99c5cdba")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "YELLOW"
+			(at 0 1.43 90)
+			(layer "F.Fab")
+			(uuid "bd3b4988-efee-4544-9def-7ff1093dc025")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "7f12796d-a1db-459a-8aac-c95d3ac742f5")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "2dc7cd23-6375-45c1-bdc8-ad5f3756b337")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005fceb5af")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -1.485 0.735)
+			(end 0.8 0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "3808151b-83c8-4c77-ae1e-2903d6d31581")
+		)
+		(fp_line
+			(start -1.485 -0.735)
+			(end -1.485 0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "2c5b4a63-94f5-470b-8d26-67130b1151de")
+		)
+		(fp_line
+			(start 0.8 -0.735)
+			(end -1.485 -0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "026aa94b-463d-41ae-bb0d-906b3cfd3f48")
+		)
+		(fp_line
+			(start -1.48 0.73)
+			(end -1.48 -0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "cc6e82ea-7440-492f-bbf8-88c4d379ef9a")
+		)
+		(fp_line
+			(start 1.48 0.73)
+			(end -1.48 0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "6a27b7c0-ab83-4f70-8157-43604a0d4276")
+		)
+		(fp_line
+			(start -1.48 -0.73)
+			(end 1.48 -0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "7cc9dccd-577c-4e20-8676-2ce0a983f6d7")
+		)
+		(fp_line
+			(start 1.48 -0.73)
+			(end 1.48 0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2a27a921-5b90-4670-97ae-6e27d1eefb09")
+		)
+		(fp_line
+			(start -0.8 0.4)
+			(end 0.8 0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b04ffd40-da3e-4cd8-95c8-0cbc4222c859")
+		)
+		(fp_line
+			(start 0.8 0.4)
+			(end 0.8 -0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d5b287ce-373b-48c0-b7cd-e3cfcd407d5d")
+		)
+		(fp_line
+			(start -0.8 -0.1)
+			(end -0.8 0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ad5b86ea-39d6-46b7-8402-b4685643dc8e")
+		)
+		(fp_line
+			(start -0.5 -0.4)
+			(end -0.8 -0.1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a2c7a7d0-f568-4f7a-9238-c0dde4bc1792")
+		)
+		(fp_line
+			(start 0.8 -0.4)
+			(end -0.5 -0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9dab1394-94e6-4547-bfef-b9f5568e929d")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "f430230e-8f01-4521-a278-d4dc8b4c1f43")
+			(effects
+				(font
+					(size 0.4 0.4)
+					(thickness 0.06)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.7875 0 270)
+			(size 0.875 0.95)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/TXLED")
+			(uuid "88e0aaaf-fab9-4c02-81ba-966ca3f022d0")
+		)
+		(pad "2" smd roundrect
+			(at 0.7875 0 270)
+			(size 0.875 0.95)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(D4-Pad2)")
+			(uuid "0bcbd7bf-ab4c-4989-99a5-9ebb86998919")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/LED_SMD.3dshapes/LED_0603_1608Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "LED_SMD:LED_0603_1608Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec98fe")
+		(at 43.500000 59.300000 180)
+		(descr "LED SMD 0603 (1608 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "diode")
+		(property "Reference" "D5"
+			(at 0 -1.43 90)
+			(layer "F.Fab")
+			(uuid "27927f12-1d2f-439e-b966-6f38f1888f76")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "GREEN"
+			(at 0 1.43 90)
+			(layer "F.Fab")
+			(uuid "63b4cfab-5fb2-4386-8496-6fd577f9e5b7")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "cb8deb24-e099-435d-8c1b-451c553938d2")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "8a9ff24e-589d-40ec-9da3-42b9ee36f1a7")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005fcebabb")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -1.485 0.735)
+			(end 0.8 0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "3ea12638-5d17-4812-9074-f1bacf9a009f")
+		)
+		(fp_line
+			(start -1.485 -0.735)
+			(end -1.485 0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "ae240f6d-e57d-49d9-8eb4-d480499b04d4")
+		)
+		(fp_line
+			(start 0.8 -0.735)
+			(end -1.485 -0.735)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "2fb12380-8577-4766-a591-2b3283b1a29d")
+		)
+		(fp_line
+			(start -1.48 0.73)
+			(end -1.48 -0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "24049293-a2cc-4dc6-9648-b77fe24c48e0")
+		)
+		(fp_line
+			(start 1.48 0.73)
+			(end -1.48 0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "a3098f5b-e247-4728-a1b5-118a8eea45ee")
+		)
+		(fp_line
+			(start -1.48 -0.73)
+			(end 1.48 -0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "29952af2-0545-4f0a-a4f5-63326387bf81")
+		)
+		(fp_line
+			(start 1.48 -0.73)
+			(end 1.48 0.73)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "b497e6b5-5e45-4fab-bb72-526c257344f5")
+		)
+		(fp_line
+			(start -0.8 0.4)
+			(end 0.8 0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "36ae45a7-0437-462c-b92c-8a68abc99d6a")
+		)
+		(fp_line
+			(start 0.8 0.4)
+			(end 0.8 -0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "eac352f4-c414-4015-b92d-c9d00a109791")
+		)
+		(fp_line
+			(start -0.8 -0.1)
+			(end -0.8 0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "247dfcd5-e3d6-46a1-ba4e-ce95ca6c5fd3")
+		)
+		(fp_line
+			(start -0.5 -0.4)
+			(end -0.8 -0.1)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "b7ab9b93-d4ce-4f78-aac3-49065bcc77ec")
+		)
+		(fp_line
+			(start 0.8 -0.4)
+			(end -0.5 -0.4)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "efb620da-4661-4846-8120-5e5cd0325a2f")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "e5d81d06-bbff-4ec3-ab9a-0c939411e1d2")
+			(effects
+				(font
+					(size 0.4 0.4)
+					(thickness 0.06)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.7875 0 180)
+			(size 0.875 0.95)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/~{ENABLE}")
+			(uuid "93e813fe-ddf4-4aa3-b5dc-b911e8af5f03")
+		)
+		(pad "2" smd roundrect
+			(at 0.7875 0 180)
+			(size 0.875 0.95)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(D5-Pad2)")
+			(uuid "92df106f-e0d0-4e7a-ba1d-5a7d24f4fd2e")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/LED_SMD.3dshapes/LED_0603_1608Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec9930")
+		(at 42.800000 66.700000 180)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C10"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "02fad32e-976a-41e9-8a58-218af1f794e8")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "2u2"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "4aed529c-a993-4326-9e2f-216f4367eb2b")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "11a4154e-bd67-40af-a95e-f51535a1bc71")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b28142b5-4069-492c-8cf0-ebdf10824b00")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005eec885d")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "cef0e661-8d31-49a6-9468-88d8089179bc")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "5e9da41c-4c32-41d5-afdf-41e20e1a9c57")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "0a9dcabd-9625-4b6a-8a3c-8d66458ece39")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "d31c6339-ce19-4f05-a47f-c82a84e471e3")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "81e9526c-e710-4e26-a56c-0e630178a54d")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "bdae627e-dbfd-4536-a9dc-e0862cfefb35")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ac274adc-6478-4d06-bedc-1440e2acdcba")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "44da51ba-2a8f-4f3e-8335-557171af8d41")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "7ff6ead7-47f1-4895-a39b-58cad9f059ad")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREG")
+			(uuid "415c59c7-b615-4f57-9d13-11ae25379779")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "4bfbabc9-76c4-4f6c-a2e6-76a2bf81d054")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec995a")
+		(at 43.800000 48.000000)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C4"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "3993be72-cc8c-4f5b-b5bc-827bd4e3f135")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "2u2"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "a1a45ef8-ab65-4333-9123-108194001646")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "ac366545-6785-4a0d-acdc-ea91b7ce0907")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "7c29b72b-a4e7-4bbc-abf1-85168f4a1d28")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005ee3ec6b")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "8d7d681d-5da4-4515-905a-c37dafc9ab18")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "fdc69c24-5579-4447-b277-a3ebc7f6f74b")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "c7e041bb-0b3b-4737-b3c5-98da1b5df1ab")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "1cd2c82a-823f-4a75-ac0f-55c38331d945")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "62c2ef9f-4795-46f0-90fb-9ba775a3121e")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "cdd66f52-7e48-49a1-be14-cd471e370715")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "65518b25-1de7-41cb-b5be-0d812158eaa8")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "12d75ccd-3d47-4f7a-a016-46ab867ed6fb")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "2143b328-fa71-45e4-a699-1d3dc785fd74")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "f947296b-7504-48b2-b820-bbb4416cb791")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "30aa0563-df9c-430d-a95a-d0a04a74b6ae")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Package_DFN_QFN:QFN-64-1EP_9x9mm_P0.5mm_EP4.35x4.35mm_ThermalVias"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec99e5")
+		(at 54.500000 56.400000)
+		(descr "QFN, 64 Pin (https://www.ftdichip.com/Support/Documents/DataSheets/ICs/DS_FT2232H.pdf#page=57), generated with kicad-footprint-generator ipc_noLead_generator.py")
+		(tags "QFN NoLead")
+		(property "Reference" "U3"
+			(at 0 -5.8 0)
+			(layer "F.Fab")
+			(uuid "e79820b3-acf4-44b6-a259-40c5d8761ad5")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "FT2232HQ"
+			(at 0 5.8 0)
+			(layer "F.Fab")
+			(uuid "e9eae1fb-bf9f-4b91-844b-e42ac31af298")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b60c6693-fe98-4c04-ab58-e6f254f971df")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "d00d31ee-3544-4e36-82bd-7b45e94b6666")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005edde775")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -4.61 4.61)
+			(end -4.61 4.135)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d89287c2-8ea5-42e6-ab6f-46374bac47da")
+		)
+		(fp_line
+			(start -4.135 -4.61)
+			(end -4.61 -4.61)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "1aa95629-3ec9-4366-a9ee-fb8a5281a694")
+		)
+		(fp_line
+			(start -4.135 4.61)
+			(end -4.61 4.61)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "7d9eaaf6-a27f-40ef-969d-5087ebcce1ce")
+		)
+		(fp_line
+			(start 4.135 -4.61)
+			(end 4.61 -4.61)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "c918120c-5acd-4600-8262-9c53f7f48a5d")
+		)
+		(fp_line
+			(start 4.135 4.61)
+			(end 4.61 4.61)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "ec4913ce-f2c8-4657-826c-17e52bd07142")
+		)
+		(fp_line
+			(start 4.61 -4.61)
+			(end 4.61 -4.135)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "4ff138ab-4973-46e7-b718-9e6b6a04ad94")
+		)
+		(fp_line
+			(start 4.61 4.61)
+			(end 4.61 4.135)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "96936f4c-d8a1-466e-8a54-73246bdb4f20")
+		)
+		(fp_line
+			(start -5.1 -5.1)
+			(end -5.1 5.1)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "31bbe63a-a261-4929-9975-de48bf34beb2")
+		)
+		(fp_line
+			(start -5.1 5.1)
+			(end 5.1 5.1)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "4e3639df-181e-4efe-a27d-cd9dfe762ace")
+		)
+		(fp_line
+			(start 5.1 -5.1)
+			(end -5.1 -5.1)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "19d50738-a322-437e-8ee4-dd2b0f4298b8")
+		)
+		(fp_line
+			(start 5.1 5.1)
+			(end 5.1 -5.1)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "9e5d40fb-a1ff-41c8-af94-8b1d7f89c12e")
+		)
+		(fp_line
+			(start -4.5 -3.5)
+			(end -3.5 -4.5)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "d1c001c6-fc53-44f0-af4d-228d13a2a3e8")
+		)
+		(fp_line
+			(start -4.5 4.5)
+			(end -4.5 -3.5)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "871d7d9c-7101-4012-b166-693f3ced12af")
+		)
+		(fp_line
+			(start -3.5 -4.5)
+			(end 4.5 -4.5)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ea89f07b-60c2-457b-83df-5fb62b666367")
+		)
+		(fp_line
+			(start 4.5 -4.5)
+			(end 4.5 4.5)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "731791c7-5a26-4e49-8d3d-c4ec266d0ca9")
+		)
+		(fp_line
+			(start 4.5 4.5)
+			(end -4.5 4.5)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "43e48220-8fdc-4c95-9b78-24d739b1b25e")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "6fef0575-efc2-4fcd-a7e1-a815a5810675")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "" smd roundrect
+			(at -1.283333 -1.283333)
+			(size 1.123165 1.123165)
+			(layers "F.Paste")
+			(roundrect_rratio 0.222585)
+			(uuid "1293d100-3f53-4093-8d1f-f6e2f8161a36")
+		)
+		(pad "" smd roundrect
+			(at -1.283333 0)
+			(size 1.123165 1.123165)
+			(layers "F.Paste")
+			(roundrect_rratio 0.222585)
+			(uuid "382d081a-d03b-47a4-8b53-8b9849681f3c")
+		)
+		(pad "" smd roundrect
+			(at -1.283333 1.283333)
+			(size 1.123165 1.123165)
+			(layers "F.Paste")
+			(roundrect_rratio 0.222585)
+			(uuid "574bb8f0-b761-4118-b514-775edca17d24")
+		)
+		(pad "" smd roundrect
+			(at 0 -1.283333)
+			(size 1.123165 1.123165)
+			(layers "F.Paste")
+			(roundrect_rratio 0.222585)
+			(uuid "04a9be9f-a88d-46f7-a7b8-621fb2c195dc")
+		)
+		(pad "" smd roundrect
+			(at 0 0)
+			(size 1.123165 1.123165)
+			(layers "F.Paste")
+			(roundrect_rratio 0.222585)
+			(uuid "fc551c16-6a0a-4597-a904-80297d71c9cd")
+		)
+		(pad "" smd roundrect
+			(at 0 1.283333)
+			(size 1.123165 1.123165)
+			(layers "F.Paste")
+			(roundrect_rratio 0.222585)
+			(uuid "c325f035-2ad8-4a90-b6d5-33447e570a10")
+		)
+		(pad "" smd roundrect
+			(at 1.283333 -1.283333)
+			(size 1.123165 1.123165)
+			(layers "F.Paste")
+			(roundrect_rratio 0.222585)
+			(uuid "bdbe83f5-8435-4360-bca4-8bff1bdcbe72")
+		)
+		(pad "" smd roundrect
+			(at 1.283333 0)
+			(size 1.123165 1.123165)
+			(layers "F.Paste")
+			(roundrect_rratio 0.222585)
+			(uuid "6d357c2e-0d06-44b4-8d99-a1604fb3802d")
+		)
+		(pad "" smd roundrect
+			(at 1.283333 1.283333)
+			(size 1.123165 1.123165)
+			(layers "F.Paste")
+			(roundrect_rratio 0.222585)
+			(uuid "9efa629c-f211-41fe-a48c-273efa8a0bce")
+		)
+		(pad "1" smd roundrect
+			(at -4.45 -3.75)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "8887296d-c58e-4de5-846b-99c01151a402")
+		)
+		(pad "2" smd roundrect
+			(at -4.45 -3.25)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(C23-Pad1)")
+			(uuid "35e9d339-9648-4cb0-b9b0-db4b41bcea46")
+		)
+		(pad "3" smd roundrect
+			(at -4.45 -2.75)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(C24-Pad1)")
+			(uuid "042419d3-8676-4c4a-9a74-ce578194028c")
+		)
+		(pad "4" smd roundrect
+			(at -4.45 -2.25)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/VPHY")
+			(uuid "23063d40-bc4b-4e4d-900e-dbc922ba91e5")
+		)
+		(pad "5" smd roundrect
+			(at -4.45 -1.75)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "96f7f591-0355-49e2-be1e-1f3290de264b")
+		)
+		(pad "6" smd roundrect
+			(at -4.45 -1.25)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(R6-Pad2)")
+			(uuid "1c5f7cd8-748f-4e04-a4b0-0a79ba478710")
+		)
+		(pad "7" smd roundrect
+			(at -4.45 -0.75)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/USB_DN")
+			(uuid "aa4f6e42-5344-4e5b-af8f-50979953cec0")
+		)
+		(pad "8" smd roundrect
+			(at -4.45 -0.25)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/USB_DP")
+			(uuid "6a079265-3399-439c-81d3-66ac014b2673")
+		)
+		(pad "9" smd roundrect
+			(at -4.45 0.25)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/VPLL")
+			(uuid "50bca8a7-49f8-470e-85e8-00569bb6f3aa")
+		)
+		(pad "10" smd roundrect
+			(at -4.45 0.75)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "675db17f-a635-407d-8b24-d5233838dfaa")
+		)
+		(pad "11" smd roundrect
+			(at -4.45 1.25)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "366b3f83-5736-4dde-8fad-6df0dbeeb610")
+		)
+		(pad "12" smd roundrect
+			(at -4.45 1.75)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREG")
+			(uuid "f2a70fe5-6c7f-4b20-a145-8f2e142cffbb")
+		)
+		(pad "13" smd roundrect
+			(at -4.45 2.25)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "dff74dd7-e6a5-48e3-8bf5-9853ce5adf66")
+		)
+		(pad "14" smd roundrect
+			(at -4.45 2.75)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(R7-Pad2)")
+			(uuid "25870d94-f1b5-41ba-a43f-3dc010f48be6")
+		)
+		(pad "15" smd roundrect
+			(at -4.45 3.25)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "3c1d842a-52fa-49c0-ada7-e7735d4edc34")
+		)
+		(pad "16" smd roundrect
+			(at -4.45 3.75)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD0")
+			(uuid "5e0883d7-4e02-4857-abb0-f4a2244fa7aa")
+		)
+		(pad "17" smd roundrect
+			(at -3.75 4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD1")
+			(uuid "d8804838-092a-4265-9bf3-8dcef664cb18")
+		)
+		(pad "18" smd roundrect
+			(at -3.25 4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD2")
+			(uuid "9a91f182-b114-48b5-a814-6aa117bcba40")
+		)
+		(pad "19" smd roundrect
+			(at -2.75 4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD3")
+			(uuid "49b6c91a-a7b2-4c93-8079-7fce77d3bc4f")
+		)
+		(pad "20" smd roundrect
+			(at -2.25 4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "d4df61bf-3d31-4465-89f2-78527948fc3e")
+		)
+		(pad "21" smd roundrect
+			(at -1.75 4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD4")
+			(uuid "1e34b810-5352-4b0d-b77c-74a71531ff6c")
+		)
+		(pad "22" smd roundrect
+			(at -1.25 4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD5")
+			(uuid "1bf49d27-52d6-46d9-a9a7-d1b5712a72b8")
+		)
+		(pad "23" smd roundrect
+			(at -0.75 4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/AD6")
+			(uuid "5e91665a-6a5e-49dd-b222-0407e66e5796")
+		)
+		(pad "24" smd roundrect
+			(at -0.25 4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "54eaa939-82aa-4304-a144-abfd0dfbbc19")
+		)
+		(pad "25" smd roundrect
+			(at 0.25 4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "6cf8da21-30f0-4152-83f2-8936d372d09b")
+		)
+		(pad "26" smd roundrect
+			(at 0.75 4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "aef53851-b295-4d3b-96b8-885bc90fc759")
+		)
+		(pad "27" smd roundrect
+			(at 1.25 4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "f71b1fe1-ccad-4786-9a4f-9e21bcfa74e0")
+		)
+		(pad "28" smd roundrect
+			(at 1.75 4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "86a4cadf-ca37-4514-961c-f22df89b8620")
+		)
+		(pad "29" smd roundrect
+			(at 2.25 4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/RXLED")
+			(uuid "669298ae-9104-44e8-8740-7ba9f248c7ee")
+		)
+		(pad "30" smd roundrect
+			(at 2.75 4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/TXLED")
+			(uuid "0c6aa260-a5ec-47b7-a333-0314ec55de7f")
+		)
+		(pad "31" smd roundrect
+			(at 3.25 4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "126a82fd-3a50-46b5-94fb-f79a74d0df95")
+		)
+		(pad "32" smd roundrect
+			(at 3.75 4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "28af905d-67a9-472d-a942-c0a3877acc57")
+		)
+		(pad "33" smd roundrect
+			(at 4.45 3.75)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "ea2791e2-5139-4924-a5b0-96aa9d30ff45")
+		)
+		(pad "34" smd roundrect
+			(at 4.45 3.25)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "0c0348dc-cd5f-4c18-8bbe-34feb2013440")
+		)
+		(pad "35" smd roundrect
+			(at 4.45 2.75)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "e22db05b-8dbe-490c-b1ec-fcaf81cdecc5")
+		)
+		(pad "36" smd roundrect
+			(at 4.45 2.25)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "0726635f-df45-4206-8690-11994693082b")
+		)
+		(pad "37" smd roundrect
+			(at 4.45 1.75)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREG")
+			(uuid "afbd182d-2c5b-417f-baa1-795058c80552")
+		)
+		(pad "38" smd roundrect
+			(at 4.45 1.25)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD0")
+			(uuid "ede26d58-dc21-4cc8-b7b4-15d7e11698a9")
+		)
+		(pad "39" smd roundrect
+			(at 4.45 0.75)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD1")
+			(uuid "fb5b9ea7-0318-4244-970d-06e282d38799")
+		)
+		(pad "40" smd roundrect
+			(at 4.45 0.25)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD2")
+			(uuid "7c9e9ef3-bf56-485f-80f1-661d282ede2c")
+		)
+		(pad "41" smd roundrect
+			(at 4.45 -0.25)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD3")
+			(uuid "167e4cea-e851-4221-8c7c-82f2f680fd84")
+		)
+		(pad "42" smd roundrect
+			(at 4.45 -0.75)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "cfd66c1a-532e-48e5-abb7-758d4bf8552c")
+		)
+		(pad "43" smd roundrect
+			(at 4.45 -1.25)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD4")
+			(uuid "ba283b13-9347-4651-8196-7b1152c45287")
+		)
+		(pad "44" smd roundrect
+			(at 4.45 -1.75)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD5")
+			(uuid "b8a3dc0e-b273-4029-b49a-30455284f0f1")
+		)
+		(pad "45" smd roundrect
+			(at 4.45 -2.25)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD6")
+			(uuid "4a06648d-8353-41c8-a148-ec00bc178ce1")
+		)
+		(pad "46" smd roundrect
+			(at 4.45 -2.75)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD7")
+			(uuid "5897a35e-7643-41b3-b1d2-c535319b5124")
+		)
+		(pad "47" smd roundrect
+			(at 4.45 -3.25)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "e1c7c18f-e2d4-4c1d-b476-e8f2eb897d38")
+		)
+		(pad "48" smd roundrect
+			(at 4.45 -3.75)
+			(size 0.8 0.25)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "0b1f59e1-2d8b-4010-9c3e-03cf2f0372e8")
+		)
+		(pad "49" smd roundrect
+			(at 3.75 -4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREG")
+			(uuid "42a9ebd2-9ca1-4857-9884-26947e2aefbf")
+		)
+		(pad "50" smd roundrect
+			(at 3.25 -4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "b724ebfc-e172-4503-9c12-680764e0688d")
+		)
+		(pad "51" smd roundrect
+			(at 2.75 -4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "079e93d5-afa7-4207-b015-7b83d3745e2f")
+		)
+		(pad "52" smd roundrect
+			(at 2.25 -4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "6c721b13-4208-4114-8dd5-ed0285fb8354")
+		)
+		(pad "53" smd roundrect
+			(at 1.75 -4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "cce4c9d5-f3a8-44b7-a315-d5aa47becbd1")
+		)
+		(pad "54" smd roundrect
+			(at 1.25 -4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "09068dc4-234b-434d-9f23-95cd79fd117b")
+		)
+		(pad "55" smd roundrect
+			(at 0.75 -4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "b4f669d4-7a7f-4ad5-8ca2-947d255ef91e")
+		)
+		(pad "56" smd roundrect
+			(at 0.25 -4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "+3V3")
+			(uuid "e1606eeb-27a2-4e7c-904a-487583f8ce36")
+		)
+		(pad "57" smd roundrect
+			(at -0.25 -4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "2e571bbf-02d8-49a7-a056-1be2b70780ec")
+		)
+		(pad "58" smd roundrect
+			(at -0.75 -4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "13a38eea-59e3-4414-8c62-e765879f6dd5")
+		)
+		(pad "59" smd roundrect
+			(at -1.25 -4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(uuid "071747bd-0964-4b1d-98ee-88899a72b72c")
+		)
+		(pad "60" smd roundrect
+			(at -1.75 -4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/~{ENABLE}")
+			(uuid "cc45c115-61b7-4605-88aa-213811a7c0c5")
+		)
+		(pad "61" smd roundrect
+			(at -2.25 -4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/EEDATA")
+			(uuid "64254716-ff10-4382-8224-2ecf5ba921ef")
+		)
+		(pad "62" smd roundrect
+			(at -2.75 -4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/EECLK")
+			(uuid "aedf218a-44aa-40c8-b13c-2119f957af8e")
+		)
+		(pad "63" smd roundrect
+			(at -3.25 -4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/EECS")
+			(uuid "1940da76-8c12-43a1-b5fb-20237c93854c")
+		)
+		(pad "64" smd roundrect
+			(at -3.75 -4.45)
+			(size 0.25 0.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREG")
+			(uuid "ca1537f9-15b4-432d-b33a-91e0c0564fb0")
+		)
+		(pad "65" thru_hole circle
+			(at -1.925 -1.925)
+			(size 0.5 0.5)
+			(drill 0.2)
+			(layers "*.Cu")
+			(remove_unused_layers no)
+			(net "GND")
+			(zone_connect 2)
+			(uuid "dd321821-8945-4601-b9b2-f15784bdf68a")
+		)
+		(pad "65" thru_hole circle
+			(at -1.925 -0.641667)
+			(size 0.5 0.5)
+			(drill 0.2)
+			(layers "*.Cu")
+			(remove_unused_layers no)
+			(net "GND")
+			(zone_connect 2)
+			(uuid "bfbb6bbc-df7d-4b09-9e55-a20f05e0dd59")
+		)
+		(pad "65" thru_hole circle
+			(at -1.925 0.641667)
+			(size 0.5 0.5)
+			(drill 0.2)
+			(layers "*.Cu")
+			(remove_unused_layers no)
+			(net "GND")
+			(zone_connect 2)
+			(uuid "f06cb80e-7a8c-4be9-a2c8-d04020ac591d")
+		)
+		(pad "65" thru_hole circle
+			(at -1.925 1.925)
+			(size 0.5 0.5)
+			(drill 0.2)
+			(layers "*.Cu")
+			(remove_unused_layers no)
+			(net "GND")
+			(zone_connect 2)
+			(uuid "8bbbf27e-962b-4d07-8124-520b0e0e4632")
+		)
+		(pad "65" thru_hole circle
+			(at -0.641667 -1.925)
+			(size 0.5 0.5)
+			(drill 0.2)
+			(layers "*.Cu")
+			(remove_unused_layers no)
+			(net "GND")
+			(zone_connect 2)
+			(uuid "75e7b327-9ad8-4028-8d98-6d9dccc77d7a")
+		)
+		(pad "65" thru_hole circle
+			(at -0.641667 -0.641667)
+			(size 0.5 0.5)
+			(drill 0.2)
+			(layers "*.Cu")
+			(remove_unused_layers no)
+			(net "GND")
+			(zone_connect 2)
+			(uuid "e0b958ec-da8c-4989-b058-3f63bdc20d87")
+		)
+		(pad "65" thru_hole circle
+			(at -0.641667 0.641667)
+			(size 0.5 0.5)
+			(drill 0.2)
+			(layers "*.Cu")
+			(remove_unused_layers no)
+			(net "GND")
+			(zone_connect 2)
+			(uuid "79db6368-2f7b-4b57-a472-f8acf3f4d63a")
+		)
+		(pad "65" thru_hole circle
+			(at -0.641667 1.925)
+			(size 0.5 0.5)
+			(drill 0.2)
+			(layers "*.Cu")
+			(remove_unused_layers no)
+			(net "GND")
+			(zone_connect 2)
+			(uuid "57ea4db0-eb85-40eb-861d-f9ce2742b762")
+		)
+		(pad "65" smd rect
+			(at 0 0)
+			(size 4.35 4.35)
+			(layers "F.Cu" "F.Mask")
+			(net "GND")
+			(zone_connect 2)
+			(uuid "3bdf743d-2646-4367-a19a-6ff1d06cbb63")
+		)
+		(pad "65" smd rect
+			(at 0 0)
+			(size 4.35 4.35)
+			(layers "B.Cu")
+			(net "GND")
+			(zone_connect 2)
+			(uuid "fda82e4e-ee87-4eeb-bf22-45d6be280583")
+		)
+		(pad "65" thru_hole circle
+			(at 0.641667 -1.925)
+			(size 0.5 0.5)
+			(drill 0.2)
+			(layers "*.Cu")
+			(remove_unused_layers no)
+			(net "GND")
+			(zone_connect 2)
+			(uuid "f1bec7e3-856d-4325-aab6-26b993242f3c")
+		)
+		(pad "65" thru_hole circle
+			(at 0.641667 -0.641667)
+			(size 0.5 0.5)
+			(drill 0.2)
+			(layers "*.Cu")
+			(remove_unused_layers no)
+			(net "GND")
+			(zone_connect 2)
+			(uuid "1339952a-a2ba-4f43-b1bc-6b63e1d2417e")
+		)
+		(pad "65" thru_hole circle
+			(at 0.641667 0.641667)
+			(size 0.5 0.5)
+			(drill 0.2)
+			(layers "*.Cu")
+			(remove_unused_layers no)
+			(net "GND")
+			(zone_connect 2)
+			(uuid "4b52bd06-1884-4af8-a50e-1e86a6e6bc11")
+		)
+		(pad "65" thru_hole circle
+			(at 0.641667 1.925)
+			(size 0.5 0.5)
+			(drill 0.2)
+			(layers "*.Cu")
+			(remove_unused_layers no)
+			(net "GND")
+			(zone_connect 2)
+			(uuid "30ae6fed-949c-40d4-bee6-75db2994bbd4")
+		)
+		(pad "65" thru_hole circle
+			(at 1.925 -1.925)
+			(size 0.5 0.5)
+			(drill 0.2)
+			(layers "*.Cu")
+			(remove_unused_layers no)
+			(net "GND")
+			(zone_connect 2)
+			(uuid "2ad30ee2-bef1-4b11-a8dd-b5c2161e3dfc")
+		)
+		(pad "65" thru_hole circle
+			(at 1.925 -0.641667)
+			(size 0.5 0.5)
+			(drill 0.2)
+			(layers "*.Cu")
+			(remove_unused_layers no)
+			(net "GND")
+			(zone_connect 2)
+			(uuid "e6b292f4-83bb-4eaa-b918-1dcdff3b941f")
+		)
+		(pad "65" thru_hole circle
+			(at 1.925 0.641667)
+			(size 0.5 0.5)
+			(drill 0.2)
+			(layers "*.Cu")
+			(remove_unused_layers no)
+			(net "GND")
+			(zone_connect 2)
+			(uuid "181e8a8b-4d58-428c-837a-a6438ffb3375")
+		)
+		(pad "65" thru_hole circle
+			(at 1.925 1.925)
+			(size 0.5 0.5)
+			(drill 0.2)
+			(layers "*.Cu")
+			(remove_unused_layers no)
+			(net "GND")
+			(zone_connect 2)
+			(uuid "da7061c6-0538-45e5-aa99-8202d9815e38")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Package_DFN_QFN.3dshapes/QFN-64-1EP_9x9mm_P0.5mm_EP6x6mm.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec9c33")
+		(at 61.800000 48.900000)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C22"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "b3ad07c6-dcb7-496a-afcf-a171025ce153")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100n"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "b5023181-ae03-46f8-ada3-1c81554ee54a")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "16ac2e2f-8b2c-4adc-bc70-7f6e9eef9bb9")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "324fe184-7998-48f7-be6a-4376ad6c2fa4")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-000060d3615e")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "9bcdeb59-7272-403c-a8b3-356f95a9d0e8")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "7a666a05-72f0-445b-a74d-5e594298ac2a")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "bdd3cadb-9cb1-4556-98c7-911c5ba89f4f")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "35444a90-a9c9-4233-90b6-4f926052e5bf")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "819dd2c8-6037-476f-8cc6-8c707e18f2b1")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "66f47885-cf18-4d3a-8c2b-3ec70464f2a9")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "0787b394-6107-4f93-beb5-cd2a863e99fb")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "dcd2c098-00bb-4345-a3a6-d6ba66d415e1")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "1459ee00-fffc-4660-aa47-51ed7e334ae0")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "3acbc4c2-4b6b-48b2-80be-a70eb7f90c8b")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "2dd7b01d-2442-446a-8446-a95e2665a17c")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec9c5d")
+		(at 48.600000 54.300000 270)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C24"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "696884bd-2566-4cab-a822-4fe32490dfa4")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "30pF"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "d896fad6-c853-436a-8e66-af289bc2977c")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "3587575e-aacf-4c78-b3cb-5c1d8ea3b78b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 90)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "0cd62acb-e9a3-4166-9cc8-2c0fd1522dc2")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f135a55")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "706e07ba-848f-459e-a588-c8dc8dcb2375")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "ae0c6a29-41cb-4009-9c18-02ea8e756d8d")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2a21b796-63bc-452b-82fb-39921d7993e2")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "38b1649e-c087-4fba-804b-bfaa0516e1cc")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c31cf128-49c3-4eed-bfb2-52190081e25e")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "8c168811-d8f5-4281-9857-1d2251cfbef3")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c9cfc2d7-3b44-4a09-940a-2698f3e30f84")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "301da222-25ec-44b8-9f6b-38068645a28d")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "84b028eb-5478-462a-b47b-aaefbced8602")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "Net-(C24-Pad1)")
+			(uuid "e4545f32-919b-4773-8598-cd53588862ae")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "771f7bd7-be52-463a-915b-f74ec9092a98")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec9cde")
+		(at 57.200000 49.600000 270)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R24"
+			(at 0 -1.17 90)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "8573d26c-6fae-4ccb-8696-b84a8c890d6a")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "10k"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "cb97a805-8d1a-4216-a2e2-39a82219d122")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "02f84efa-745e-4b17-ad32-0a6555f3b717")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "d13f89b7-d798-4d70-831b-137e60be1c18")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f0039b1")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "29d51469-f6be-4ce8-9a8a-396a6f48be28")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2da18d97-df70-4591-b342-5feebb9c2c4a")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "28554cd9-86db-4c3e-ba17-907bc0b0b1f0")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2e65a20d-627a-479b-b757-e09ae199798d")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "425c6f1a-94b3-45ac-a810-93c69599ba5d")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "084545a1-2e4e-4a59-80dc-5f38fc61552d")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "cb9052cf-e5d7-4f15-ba48-cf22f73fcbad")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a3bbd06c-ec33-4d5f-b5ef-daab3fcf39a7")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "54f88ffb-6301-4891-a3bc-284aec05617e")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "80eb0eea-60f7-487a-b26b-960263bc926b")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "c4c71006-af78-4b75-adf0-dbbddc7c91b6")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Capacitor_SMD:C_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec9d08")
+		(at 45.300000 67.100000 180)
+		(descr "Capacitor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "capacitor")
+		(property "Reference" "C21"
+			(at 0 -1.17 0)
+			(layer "F.Fab")
+			(uuid "559ebfe9-d75c-44b0-9e8b-1f47257c2c5d")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "100n"
+			(at 0 1.17 0)
+			(layer "F.Fab")
+			(uuid "c1008227-3869-4974-8c16-546f1df52da2")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "0cd71a18-806c-42d8-90e4-2a7d5c197a93")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b832ffa0-e50b-4a38-8d13-0b258a940cfd")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-000060d35f31")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "6bbed58b-9a24-4042-877c-cc3468d68e9c")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "c117c1cf-f528-4e74-977c-05dec5c5cce7")
+		)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "53a3e153-7475-4515-80a9-31386005d486")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "b9635ed5-26e9-4e3a-ba01-81e82a2faa9b")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ced39748-def3-42a7-9dfb-29d6f284a699")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "562670d5-94c6-4df5-a9a8-bf048ee371b1")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "578e118a-1f40-4c33-8328-268931328a60")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "dc3a1fa7-d1c3-49e0-a19e-1a4eeaff24e0")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "bc08af63-374a-449c-ae05-e8bb7a104b03")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VREF")
+			(uuid "8c85b3e5-86b8-471b-8e05-280d038967b1")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 180)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "c4757275-6024-450e-8815-d617e27574bd")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Capacitor_SMD.3dshapes/C_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Connector_JST:JST_SH_SM04B-SRSS-TB_1x04-1MP_P1.00mm_Horizontal"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005f2414b3")
+		(at 69.545000 66.575000)
+		(descr "JST SH series connector, SM04B-SRSS-TB (http://www.jst-mfg.com/product/pdf/eng/eSH.pdf), generated with kicad-footprint-generator")
+		(tags "connector JST SH top entry")
+		(property "Reference" "J7"
+			(at 0 -3.98 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "c443edd2-201a-4c73-a280-5cb5bd873dd6")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "I2C"
+			(at -0.045 -4.075 0)
+			(layer "F.SilkS")
+			(uuid "d48ac0c6-3dbf-4b17-a5da-41f94c929be3")
+			(effects
+				(font
+					(size 0.8 0.8)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "a1ce8e62-d8d7-4307-96f9-61e2f565fa40")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "437abbf3-156e-47e9-a90f-b790c0825d3e")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f2990ce")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -3.11 -1.785)
+			(end -2.06 -1.785)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "2d57665e-2d85-4911-9eb9-404ca9e0e1d6")
+		)
+		(fp_line
+			(start -3.11 0.715)
+			(end -3.11 -1.785)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "4cf43057-5f22-47a7-be55-f956404a9b39")
+		)
+		(fp_line
+			(start -2.06 -1.785)
+			(end -2.06 -2.775)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b084ab59-c7ae-4ed4-8707-bfebfdf80164")
+		)
+		(fp_line
+			(start -1.94 2.685)
+			(end 1.94 2.685)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "b0a04087-eaaa-469d-b6b5-4838e543f86f")
+		)
+		(fp_line
+			(start 3.11 -1.785)
+			(end 2.06 -1.785)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "e736b274-12e4-4d8a-87ad-e2e71c7fc0e7")
+		)
+		(fp_line
+			(start 3.11 0.715)
+			(end 3.11 -1.785)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "21e295e4-fc6e-419c-92c0-51603fb084b1")
+		)
+		(fp_line
+			(start -3.9 -3.28)
+			(end -3.9 3.28)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "7067b2b9-33dd-4ea2-8b49-87f76e913009")
+		)
+		(fp_line
+			(start -3.9 3.28)
+			(end 3.9 3.28)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "2649b79f-8ce7-4947-bb8b-6e495aa065f2")
+		)
+		(fp_line
+			(start 3.9 -3.28)
+			(end -3.9 -3.28)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "8234aad6-29e9-4d43-a68c-a5331a3add65")
+		)
+		(fp_line
+			(start 3.9 3.28)
+			(end 3.9 -3.28)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "da825e75-e31e-4407-acad-92b56cc18bdf")
+		)
+		(fp_line
+			(start -3 -1.675)
+			(end -3 2.575)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c96b6677-974d-4a9d-9cb9-421091613740")
+		)
+		(fp_line
+			(start -3 -1.675)
+			(end 3 -1.675)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "e0fecb91-8c65-4f75-9c97-d43dfefa50f0")
+		)
+		(fp_line
+			(start -3 2.575)
+			(end 3 2.575)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "88035087-7c1e-4635-bbfe-d384089e1314")
+		)
+		(fp_line
+			(start -2 -1.675)
+			(end -1.5 -0.967893)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "4ea27b8f-31d4-4688-9a9c-ea3af7cd93ac")
+		)
+		(fp_line
+			(start -1.5 -0.967893)
+			(end -1 -1.675)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "01eb405b-3df7-4e2f-a59d-90cbbeaaba2b")
+		)
+		(fp_line
+			(start 3 -1.675)
+			(end 3 2.575)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "1cbb3321-eed3-4422-a9ac-bdf1424c89ef")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 0)
+			(layer "F.Fab")
+			(uuid "448778d8-b1a4-4501-b1c2-98845e7a0b66")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -1.5 -2)
+			(size 0.6 1.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "GND")
+			(uuid "4548f85f-d8d9-47d7-8d99-b25465502f09")
+		)
+		(pad "2" smd roundrect
+			(at -0.5 -2)
+			(size 0.6 1.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "VTARGET")
+			(uuid "0b2e1d4b-9ffa-4d7d-91a3-98239455a8e1")
+		)
+		(pad "3" smd roundrect
+			(at 0.5 -2)
+			(size 0.6 1.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/COPI")
+			(uuid "891d718e-d344-4269-9e6d-2820ab2e7242")
+		)
+		(pad "4" smd roundrect
+			(at 1.5 -2)
+			(size 0.6 1.55)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/CLK")
+			(uuid "36555401-09fd-4bd9-a5a9-9f1b9df8086c")
+		)
+		(pad "MP" smd roundrect
+			(at -2.8 1.875)
+			(size 1.2 1.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.208333)
+			(net "GND")
+			(uuid "fe927404-9f44-4109-80c1-bbaf0cdbd99a")
+		)
+		(pad "MP" smd roundrect
+			(at 2.8 1.875)
+			(size 1.2 1.8)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.208333)
+			(net "GND")
+			(uuid "8b24b78d-bceb-443a-bec5-13127f44b32e")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Connector_JST.3dshapes/JST_SH_SM04B-SRSS-TB_1x04-1MP_P1.00mm_Horizontal.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "TestPoint:TestPoint_Keystone_5000-5004_Miniature"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005f2414c0")
+		(at 45.056600 40.980000 180)
+		(descr "Keystone Miniature THM Test Point 5000-5004, http://www.keyelco.com/product-pdf.cfm?p=1309")
+		(tags "Through Hole Mount Test Points")
+		(property "Reference" "TP1"
+			(at 0 -2.5 0)
+			(layer "F.Fab")
+			(uuid "db35b83a-6472-44d3-924b-e60f56fc11aa")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "GND"
+			(at 0 2.45 0)
+			(layer "F.SilkS")
+			(uuid "43214cf9-2ef2-4cd7-9608-0d83d2357d0f")
+			(effects
+				(font
+					(size 0.8 0.8)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "bc2c8242-f01f-4668-882c-a779ddca6ba7")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "474d26a8-3ffe-4764-aaca-31fd573a6fe6")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-0000626de3cd")
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_circle
+			(center 0 0)
+			(end 1.4 0)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.SilkS")
+			(uuid "1c669a64-3143-4c27-b3ba-1cdd5a1e81e3")
+		)
+		(fp_circle
+			(center 0 0)
+			(end 1.65 0)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.CrtYd")
+			(uuid "60b67e17-91a7-4e54-bfa1-e0dd44d75d80")
+		)
+		(fp_line
+			(start 0.75 0.25)
+			(end -0.75 0.25)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c7a5873a-d003-4c88-b936-398afb4c294d")
+		)
+		(fp_line
+			(start 0.75 -0.25)
+			(end 0.75 0.25)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "5b88ac00-f5f1-40f5-8117-26a705b7e96e")
+		)
+		(fp_line
+			(start -0.75 0.25)
+			(end -0.75 -0.25)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "c5370078-18e5-43ad-a5b6-25fbd762c305")
+		)
+		(fp_line
+			(start -0.75 -0.25)
+			(end 0.75 -0.25)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "89069555-ea6b-4a68-aeee-6479e0fbf484")
+		)
+		(fp_circle
+			(center 0 0)
+			(end 1.25 0)
+			(stroke
+				(width 0.15)
+				(type solid)
+			)
+			(fill no)
+			(layer "F.Fab")
+			(uuid "6377b212-0ac8-48ec-8adc-972238d67ea0")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 -2.5 0)
+			(layer "F.Fab")
+			(uuid "bab65854-dbec-443c-8f0b-686919275da2")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "1" thru_hole circle
+			(at 0 0 180)
+			(size 2 2)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "GND")
+			(uuid "671e1d10-fddd-4e35-be5a-169eab2d7c7a")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/TestPoint.3dshapes/TestPoint_Keystone_5000-5004_Miniature.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:PinHeader_1x09_P2.54mm_Vertical"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005f30e631")
+		(at 62.000000 73.500000 270)
+		(descr "Through hole straight pin header, 1x09, 2.54mm pitch, single row")
+		(tags "Through hole pin header THT 1x09 2.54mm single row")
+		(property "Reference" "J2"
+			(at 0 -2.33 0)
+			(layer "F.Fab")
+			(uuid "6c14b975-8bd4-48d5-b2eb-96428560dbd5")
+			(effects
+				(font
+					(size 0.8 0.8)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "JTAG"
+			(at 0 -2.54 0)
+			(layer "F.SilkS")
+			(uuid "94ddd0ab-09ac-460e-a5fe-5bc24dde3e21")
+			(effects
+				(font
+					(size 0.8 0.8)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "4f716169-475d-47b8-b6e3-99bc6445a338")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "f91b60da-4419-4b53-8bd5-69935970a1d4")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f7118a4")
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -2.54 -2.032)
+			(end -2.032 -2.032)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "90375929-d570-4e33-aca6-e72458258333")
+		)
+		(fp_line
+			(start -2.032 -2.032)
+			(end -2.794 -2.794)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "32f95764-3753-4534-8a9f-2034a26d9463")
+		)
+		(fp_line
+			(start -2.032 -2.032)
+			(end -2.54 -2.032)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d62696d0-7bde-411f-86a1-9d280c70fa90")
+		)
+		(fp_line
+			(start -2.032 -2.032)
+			(end -2.032 -2.54)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "78049808-0cd5-4c6b-a222-e2c97b81e9bc")
+		)
+		(fp_line
+			(start -1.33 -1.33)
+			(end 0 -1.33)
+			(stroke
+				(width 0.5)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "3921ef3e-2508-4658-9be3-c0ea56e62fe8")
+		)
+		(fp_line
+			(start -1.33 0)
+			(end -1.33 -1.33)
+			(stroke
+				(width 0.5)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "c7d86630-22a1-4056-a042-49b5fb340a84")
+		)
+		(fp_line
+			(start -1.33 1.27)
+			(end -1.33 21.65)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "6e7263f0-2776-4c06-a39a-0b4221884d65")
+		)
+		(fp_line
+			(start -1.33 1.27)
+			(end 1.33 1.27)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "cdfd8a8e-d14c-46f7-bd31-286fc5fd0100")
+		)
+		(fp_line
+			(start -1.33 21.65)
+			(end 1.33 21.65)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "a9873d31-e44c-4852-b22b-5097c72db391")
+		)
+		(fp_line
+			(start 1.33 1.27)
+			(end 1.33 21.65)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "F.SilkS")
+			(uuid "d9125b1e-d315-4bbd-b43e-c5204037bf05")
+		)
+		(fp_line
+			(start -2.54 -2.032)
+			(end -2.032 -2.032)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "8f1d91f8-25db-4fc5-b889-1976d7cd10c5")
+		)
+		(fp_line
+			(start -2.032 -2.032)
+			(end -2.794 -2.794)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "ea4fe10a-fdd0-499a-897b-e4fdfa17061e")
+		)
+		(fp_line
+			(start -2.032 -2.032)
+			(end -2.032 -2.54)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "365a3dcc-6995-4747-96b9-fbd1ebd30bc6")
+		)
+		(fp_line
+			(start -1.33 -1.33)
+			(end 0 -1.33)
+			(stroke
+				(width 0.5)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "4c5aebed-adac-42d6-af19-d34eef0bf5a4")
+		)
+		(fp_line
+			(start -1.33 0)
+			(end -1.33 -1.33)
+			(stroke
+				(width 0.5)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "a6ae3287-5c89-42bd-8e4d-9f7e6a2fc5bc")
+		)
+		(fp_line
+			(start -1.33 1.27)
+			(end -1.33 21.65)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "7a5b9684-8f4a-4c0a-8140-1e63178a4e44")
+		)
+		(fp_line
+			(start -1.33 1.27)
+			(end 1.33 1.27)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "4bed3966-7257-4d9d-8ae4-9cfe428c321e")
+		)
+		(fp_line
+			(start -1.33 21.65)
+			(end 1.33 21.65)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "605b9143-87f7-461c-bdec-cec5276ddde2")
+		)
+		(fp_line
+			(start 1.33 1.27)
+			(end 1.33 21.65)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "0a4385ef-59ae-4da3-b609-95e8607701c0")
+		)
+		(fp_line
+			(start -1.8 -1.8)
+			(end -1.8 22.1)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "e60f0cdf-5aa5-4f6a-b516-65ba40168d59")
+		)
+		(fp_line
+			(start -1.8 22.1)
+			(end 1.8 22.1)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "0a25cc6b-f51e-4616-9e5c-6da84d66ab49")
+		)
+		(fp_line
+			(start 1.8 -1.8)
+			(end -1.8 -1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "3c8347a5-3c80-42be-b7e0-2578d8b38a54")
+		)
+		(fp_line
+			(start 1.8 22.1)
+			(end 1.8 -1.8)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "6895c90a-05cc-4e27-8736-072c7af5d399")
+		)
+		(fp_line
+			(start -1.27 -0.635)
+			(end -0.635 -1.27)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "cfd5452f-7497-4478-9979-eb1b22c7b0f3")
+		)
+		(fp_line
+			(start -1.27 21.59)
+			(end -1.27 -0.635)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "11252531-44ca-449c-934a-14b2fc83c363")
+		)
+		(fp_line
+			(start -0.635 -1.27)
+			(end 1.27 -1.27)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "44c0aa05-4969-4f42-a2b9-96c6dc08ae10")
+		)
+		(fp_line
+			(start 1.27 -1.27)
+			(end 1.27 21.59)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "a3e74b57-b27f-498f-a58a-bcd9c4572d4f")
+		)
+		(fp_line
+			(start 1.27 21.59)
+			(end -1.27 21.59)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "ae5c0f9b-14e9-4272-89db-adcb1a99ed44")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 10.16 90)
+			(layer "F.Fab")
+			(uuid "66dad8fa-4603-435a-8066-036bc05fa68c")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(pad "1" thru_hole roundrect
+			(at 0 0 270)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(roundrect_rratio 0.25)
+			(net "VTARGET")
+			(uuid "59f31724-8a95-43a9-a5ac-6a835722d7ac")
+		)
+		(pad "2" thru_hole oval
+			(at 0 2.54 270)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "GND")
+			(uuid "350de13f-cbf2-4680-9560-c7ac780056c4")
+		)
+		(pad "3" thru_hole oval
+			(at 0 5.08 270)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/CLK")
+			(uuid "8ef546f8-6f3f-4e32-a783-504edfb18bcc")
+		)
+		(pad "4" thru_hole oval
+			(at 0 7.62 270)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/COPI")
+			(uuid "486ff49c-ed74-4853-8a7a-acce46384d65")
+		)
+		(pad "5" thru_hole oval
+			(at 0 10.16 270)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/CIPO")
+			(uuid "5ee1273c-9226-403f-885c-7121ba1eba24")
+		)
+		(pad "6" thru_hole oval
+			(at 0 12.7 270)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/CS")
+			(uuid "7c84fa3b-fbd6-4ef9-a2ba-087cd3d2ca9c")
+		)
+		(pad "7" thru_hole oval
+			(at 0 15.24 270)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/xPB4")
+			(uuid "799318b4-aaf7-4381-b99b-6f9d50cfe922")
+		)
+		(pad "8" thru_hole oval
+			(at 0 17.78 270)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/xPB5")
+			(uuid "6fbca3c9-77d3-43e5-8959-963f020aca78")
+		)
+		(pad "9" thru_hole oval
+			(at 0 20.32 270)
+			(size 1.7 1.7)
+			(drill 1)
+			(layers "*.Cu" "*.Mask")
+			(remove_unused_layers no)
+			(net "/ICE_CDONE")
+			(uuid "1390b3e4-8cf7-47a8-8078-498f42aefbe5")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Connector_PinHeader_2.54mm.3dshapes/PinHeader_1x08_P2.54mm_Vertical.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "Resistor_SMD:R_0402_1005Metric"
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005f30e668")
+		(at 43.770000 68.733000 270)
+		(descr "Resistor SMD 0402 (1005 Metric), square (rectangular) end terminal, IPC_7351 nominal, (Body size source: http://www.tortai-tech.com/upload/download/2011102023233369053.pdf), generated with kicad-footprint-generator")
+		(tags "resistor")
+		(property "Reference" "R22"
+			(at 0 -1.17 90)
+			(layer "F.Fab")
+			(uuid "c725f2de-fa04-4cd6-a6e0-2e763e29cd79")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Value" "2k2"
+			(at 0 1.17 90)
+			(layer "F.Fab")
+			(uuid "31a70917-e1f6-4a0e-9a9f-9d34d54106f1")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "c1dedcf0-b89a-4cc3-9c65-2f6aae6ddf0b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 270)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "6c1ff927-7103-46de-ac0b-3a4901355546")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f59250b")
+		(attr smd)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start -0.93 0.47)
+			(end -0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "a54f5538-6369-47f4-a144-6376e9da27c7")
+		)
+		(fp_line
+			(start 0.93 0.47)
+			(end -0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "3a5b2c97-40b5-4435-b526-4babb980e8d1")
+		)
+		(fp_line
+			(start -0.93 -0.47)
+			(end 0.93 -0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "bbf1d4a2-64a7-46ce-81d5-f0eb2721609a")
+		)
+		(fp_line
+			(start 0.93 -0.47)
+			(end 0.93 0.47)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "F.CrtYd")
+			(uuid "08d88cc9-f484-451c-ad2d-39ea8362f6b4")
+		)
+		(fp_line
+			(start -0.5 0.25)
+			(end -0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "9a70307f-d8f0-4af0-85e9-e73ba8c75003")
+		)
+		(fp_line
+			(start 0.5 0.25)
+			(end -0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "3bd79036-88f0-4e8c-bbf5-85b401a9fe19")
+		)
+		(fp_line
+			(start -0.5 -0.25)
+			(end 0.5 -0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "74164198-c170-44d0-bbe6-ed3805c2a9b6")
+		)
+		(fp_line
+			(start 0.5 -0.25)
+			(end 0.5 0.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "F.Fab")
+			(uuid "7bf1b5c1-7a34-4f8f-a0c9-4215b82624ae")
+		)
+		(fp_text user "${REFERENCE}"
+			(at 0 0 90)
+			(layer "F.Fab")
+			(uuid "aa07b122-ffe8-4036-bacf-bf567878ba4c")
+			(effects
+				(font
+					(size 0.25 0.25)
+					(thickness 0.04)
+				)
+			)
+		)
+		(pad "1" smd roundrect
+			(at -0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD5")
+			(uuid "b877b197-a204-4835-80d6-4d11aa1eab5d")
+		)
+		(pad "2" smd roundrect
+			(at 0.485 0 270)
+			(size 0.59 0.64)
+			(layers "F.Cu" "F.Mask" "F.Paste")
+			(roundrect_rratio 0.25)
+			(net "/BD7")
+			(uuid "e570d3ea-d2d8-4b1f-b127-83d7ddc4dc2f")
+		)
+		(embedded_fonts no)
+		(model "${KISYS3DMOD}/Resistor_SMD.3dshapes/R_0402_1005Metric.wrl"
+			(offset
+				(xyz 0 0 0)
+			)
+			(scale
+				(xyz 1 1 1)
+			)
+			(rotate
+				(xyz 0 0 0)
+			)
+		)
+	)
+	(footprint "tigard:Tigard_Logo"
+		(locked yes)
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005f37d5ad")
+		(at 43.84 38.9832)
+		(property "Reference" "G***"
+			(at 0 0 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "96f5c3e9-0651-4dcc-b8dc-44468f6d47ad")
+			(effects
+				(font
+					(size 1.524 1.524)
+					(thickness 0.3)
+				)
+			)
+		)
+		(property "Value" "LOGO"
+			(at 0.75 0 0)
+			(layer "F.SilkS")
+			(hide yes)
+			(uuid "fac37eb9-027a-4177-922a-e9b9f6658014")
+			(effects
+				(font
+					(size 1.524 1.524)
+					(thickness 0.3)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "476cf4e7-c9f7-4926-a4ce-038806396921")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "dd45a066-474b-4cfb-bf1b-31510475dc6e")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_poly
+			(pts
+				(xy -2.647757 -1.27) (xy -3.271212 -1.27) (xy -3.271212 -1.762606) (xy -2.647757 -1.762606) (xy -2.647757 -1.27)
+			)
+			(stroke
+				(width 0.01)
+				(type solid)
+			)
+			(fill yes)
+			(layer "F.SilkS")
+			(uuid "c91577f7-3f0e-47d0-9646-de1988023881")
+		)
+		(fp_poly
+			(pts
+				(xy -2.647757 1.046788) (xy -3.271212 1.046788) (xy -3.271212 -1.046788) (xy -2.647757 -1.046788)
+				(xy -2.647757 1.046788)
+			)
+			(stroke
+				(width 0.01)
+				(type solid)
+			)
+			(fill yes)
+			(layer "F.SilkS")
+			(uuid "2d50bb30-cc35-47fe-9dfc-5b5837339827")
+		)
+		(fp_poly
+			(pts
+				(xy -3.47903 -1.270119) (xy -3.946621 -1.268135) (xy -4.414212 -1.266152) (xy -4.41811 1.046788)
+				(xy -5.133878 1.046788) (xy -5.133878 -1.27) (xy -6.072909 -1.27) (xy -6.072909 -1.893455) (xy -3.47903 -1.893455)
+				(xy -3.47903 -1.270119)
+			)
+			(stroke
+				(width 0.01)
+				(type solid)
+			)
+			(fill yes)
+			(layer "F.SilkS")
+			(uuid "e0b0d42b-78f8-429f-a429-722ede808049")
+		)
+		(fp_poly
+			(pts
+				(xy 2.849803 -1.054346) (xy 3.375122 -1.054208) (xy 3.452091 -1.035709) (xy 3.505195 -1.022047)
+				(xy 3.548265 -1.008492) (xy 3.586514 -0.993029) (xy 3.625154 -0.973644) (xy 3.652455 -0.958273)
+				(xy 3.691468 -0.93174) (xy 3.734955 -0.895773) (xy 3.779408 -0.853876) (xy 3.821322 -0.80955) (xy 3.857189 -0.766299)
+				(xy 3.883502 -0.727625) (xy 3.883653 -0.727364) (xy 3.907716 -0.683277) (xy 3.926671 -0.642187)
+				(xy 3.941189 -0.601179) (xy 3.951939 -0.557337) (xy 3.959592 -0.507747) (xy 3.964819 -0.449494)
+				(xy 3.96829 -0.379663) (xy 3.969091 -0.355985) (xy 3.973938 -0.200121) (xy 3.340485 -0.200121) (xy 3.340485 -0.290675)
+				(xy 3.340092 -0.331761) (xy 3.338591 -0.361109) (xy 3.335494 -0.382362) (xy 3.330316 -0.399164)
+				(xy 3.324321 -0.411902) (xy 3.29172 -0.458941) (xy 3.248163 -0.496118) (xy 3.218051 -0.513367) (xy 3.20033 -0.521776)
+				(xy 3.184552 -0.527637) (xy 3.167398 -0.531413) (xy 3.145548 -0.533563) (xy 3.115685 -0.53455) (xy 3.074489 -0.534833)
+				(xy 3.063394 -0.534847) (xy 2.951788 -0.534939) (xy 2.94794 0.254) (xy 2.944091 1.042939) (xy 2.634288 1.044951)
+				(xy 2.324485 1.046962) (xy 2.324485 -1.054485) (xy 2.849803 -1.054346)
+			)
+			(stroke
+				(width 0.01)
+				(type solid)
+			)
+			(fill yes)
+			(layer "F.SilkS")
+			(uuid "97b3a76c-0d90-4da1-bd85-889f511d07b0")
+		)
+		(fp_poly
+			(pts
+				(xy 6.119091 1.039091) (xy 5.747712 1.039114) (xy 5.66792 1.039191) (xy 5.588221 1.039403) (xy 5.510884 1.039733)
+				(xy 5.438175 1.040167) (xy 5.372362 1.040689) (xy 5.315711 1.041285) (xy 5.270491 1.04194) (xy 5.245485 1.042459)
+				(xy 5.195943 1.043207) (xy 5.145963 1.043071) (xy 5.100046 1.042123) (xy 5.062694 1.040434) (xy 5.048283 1.039301)
+				(xy 4.916633 1.020288) (xy 4.795181 0.990025) (xy 4.684074 0.948626) (xy 4.583459 0.896204) (xy 4.493482 0.832873)
+				(xy 4.414291 0.758745) (xy 4.346032 0.673933) (xy 4.288851 0.578552) (xy 4.242897 0.472713) (xy 4.219642 0.400242)
+				(xy 4.201197 0.323932) (xy 4.185597 0.238387) (xy 4.173674 0.149634) (xy 4.16626 0.0637) (xy 4.164329 0.004073)
+				(xy 4.819797 0.004073) (xy 4.821361 0.034547) (xy 4.825157 0.07128) (xy 4.828392 0.097665) (xy 4.845452 0.192098)
+				(xy 4.871465 0.274296) (xy 4.906692 0.34473) (xy 4.951398 0.403873) (xy 5.005845 0.452197) (xy 5.037577 0.472904)
+				(xy 5.065818 0.488262) (xy 5.093419 0.500154) (xy 5.122922 0.509009) (xy 5.156871 0.51526) (xy 5.19781 0.519337)
+				(xy 5.248281 0.52167) (xy 5.310828 0.522691) (xy 5.332129 0.522806) (xy 5.495743 0.523394) (xy 5.493765 -0.005773)
+				(xy 5.491788 -0.534939) (xy 5.337849 -0.53347) (xy 5.283248 -0.532778) (xy 5.241079 -0.531701) (xy 5.208383 -0.529965)
+				(xy 5.182197 -0.5273) (xy 5.159562 -0.523431) (xy 5.137516 -0.518087) (xy 5.121709 -0.513577) (xy 5.051028 -0.48605)
+				(xy 4.990381 -0.448075) (xy 4.939449 -0.399207) (xy 4.897914 -0.339002) (xy 4.865457 -0.267013)
+				(xy 4.84176 -0.182797) (xy 4.828544 -0.103517) (xy 4.823385 -0.059587) (xy 4.820471 -0.025514) (xy 4.819797 0.004073)
+				(xy 4.164329 0.004073) (xy 4.164124 -0.002228) (xy 4.165973 -0.060026) (xy 4.171343 -0.128346) (xy 4.179811 -0.202831)
+				(xy 4.190949 -0.279123) (xy 4.191419 -0.281993) (xy 4.218218 -0.404317) (xy 4.256726 -0.516678)
+				(xy 4.30678 -0.618914) (xy 4.368215 -0.710859) (xy 4.440868 -0.79235) (xy 4.524573 -0.863222) (xy 4.619168 -0.92331)
+				(xy 4.724487 -0.972451) (xy 4.840368 -1.01048) (xy 4.941455 -1.032952) (xy 4.971304 -1.037865) (xy 5.001886 -1.041815)
+				(xy 5.035572 -1.044945) (xy 5.074735 -1.047399) (xy 5.12175 -1.04932) (xy 5.178988 -1.050851) (xy 5.248823 -1.052135)
+				(xy 5.262803 -1.05235) (xy 5.495637 -1.055837) (xy 5.495637 -1.893455) (xy 6.119091 -1.893455) (xy 6.119091 1.039091)
+			)
+			(stroke
+				(width 0.01)
+				(type solid)
+			)
+			(fill yes)
+			(layer "F.SilkS")
+			(uuid "b26dfb72-1a1c-42e0-9c9f-06b8b30437df")
+		)
+		(fp_poly
+			(pts
+				(xy 1.147365 -1.05009) (xy 1.191261 -1.049782) (xy 1.227486 -1.049185) (xy 1.257328 -1.04827) (xy 1.282073 -1.047009)
+				(xy 1.303009 -1.045372) (xy 1.321422 -1.04333) (xy 1.338601 -1.040853) (xy 1.355831 -1.037913) (xy 1.373909 -1.034572)
+				(xy 1.459288 -1.015914) (xy 1.532699 -0.993658) (xy 1.597419 -0.966363) (xy 1.656722 -0.93259) (xy 1.713883 -0.890896)
+				(xy 1.728991 -0.878419) (xy 1.789811 -0.818535) (xy 1.844881 -0.747728) (xy 1.89147 -0.670168) (xy 1.926849 -0.590027)
+				(xy 1.936156 -0.561879) (xy 1.941653 -0.543091) (xy 1.946519 -0.524879) (xy 1.950792 -0.506225)
+				(xy 1.954512 -0.486113) (xy 1.957717 -0.463523) (xy 1.960446 -0.437439) (xy 1.962738 -0.406843)
+				(xy 1.964632 -0.370716) (xy 1.966167 -0.328042) (xy 1.967381 -0.277802) (xy 1.968313 -0.21898) (xy 1.969003 -0.150556)
+				(xy 1.969488 -0.071514) (xy 1.969808 0.019165) (xy 1.970002 0.122497) (xy 1.970109 0.239501) (xy 1.970152 0.329045)
+				(xy 1.970425 1.046788) (xy 1.325803 1.04585) (xy 1.201778 1.045609) (xy 1.092314 1.045263) (xy 0.996579 1.044797)
+				(xy 0.913741 1.044199) (xy 0.842968 1.043457) (xy 0.783426 1.042556) (xy 0.734285 1.041485) (xy 0.694712 1.04023)
+				(xy 0.663874 1.038779) (xy 0.640939 1.037118) (xy 0.625076 1.035235) (xy 0.623455 1.034968) (xy 0.537733 1.017121)
+				(xy 0.464358 0.994675) (xy 0.400636 0.966317) (xy 0.343875 0.930734) (xy 0.291382 0.886614) (xy 0.265462 0.860483)
+				(xy 0.211157 0.792056) (xy 0.166718 0.713545) (xy 0.133638 0.627788) (xy 0.123731 0.591303) (xy 0.113749 0.534118)
+				(xy 0.108064 0.467407) (xy 0.106664 0.397263) (xy 0.727974 0.397263) (xy 0.733539 0.447444) (xy 0.74959 0.486793)
+				(xy 0.776888 0.516411) (xy 0.816192 0.537399) (xy 0.827425 0.541252) (xy 0.849757 0.548046) (xy 0.869168 0.553028)
+				(xy 0.888503 0.556408) (xy 0.910609 0.558399) (xy 0.938332 0.559212) (xy 0.974519 0.559061) (xy 1.022015 0.558155)
+				(xy 1.046788 0.557583) (xy 1.099141 0.556455) (xy 1.152786 0.555486) (xy 1.20319 0.554745) (xy 1.245822 0.554301)
+				(xy 1.268076 0.554204) (xy 1.34697 0.554182) (xy 1.34697 0.221571) (xy 1.102591 0.227185) (xy 1.032797 0.228884)
+				(xy 0.976569 0.230522) (xy 0.932081 0.232229) (xy 0.897506 0.234134) (xy 0.871018 0.236368) (xy 0.850791 0.239059)
+				(xy 0.834998 0.242338) (xy 0.821812 0.246335) (xy 0.819071 0.247326) (xy 0.779371 0.267967) (xy 0.7515 0.296696)
+				(xy 0.734674 0.334804) (xy 0.728108 0.383584) (xy 0.727974 0.397263) (xy 0.106664 0.397263) (xy 0.106641 0.396152)
+				(xy 0.109451 0.325332) (xy 0.116459 0.259928) (xy 0.126197 0.210331) (xy 0.157248 0.116585) (xy 0.199499 0.033356)
+				(xy 0.25283 -0.039226) (xy 0.31712 -0.101034) (xy 0.392247 -0.151937) (xy 0.478092 -0.191809) (xy 0.516393 -0.204949)
+				(xy 0.533307 -0.210088) (xy 0.54898 -0.214311) (xy 0.565168 -0.217746) (xy 0.583629 -0.220521) (xy 0.606121 -0.222764)
+				(xy 0.6344 -0.224603) (xy 0.670225 -0.226166) (xy 0.715352 -0.227582) (xy 0.771539 -0.228978) (xy 0.840543 -0.230482)
+				(xy 0.877455 -0.231253) (xy 0.947821 -0.232683) (xy 1.017015 -0.234028) (xy 1.082656 -0.235246)
+				(xy 1.142361 -0.236295) (xy 1.193748 -0.237134) (xy 1.234436 -0.237721) (xy 1.261413 -0.238009)
+				(xy 1.349038 -0.238606) (xy 1.345122 -0.290561) (xy 1.333677 -0.360757) (xy 1.310621 -0.420896)
+				(xy 1.275847 -0.471151) (xy 1.22925 -0.511693) (xy 1.196237 -0.531091) (xy 1.143 -0.55803) (xy 0.6985 -0.56025)
+				(xy 0.254 -0.562469) (xy 0.254 -1.044769) (xy 0.767773 -1.048331) (xy 0.86933 -1.049026) (xy 0.956781 -1.049579)
+				(xy 1.031412 -1.04996) (xy 1.094511 -1.05014) (xy 1.147365 -1.05009)
+			)
+			(stroke
+				(width 0.01)
+				(type solid)
+			)
+			(fill yes)
+			(layer "F.SilkS")
+			(uuid "18ea6528-5bd4-45a4-b13a-bdc51702ccc4")
+		)
+		(fp_poly
+			(pts
+				(xy -0.153939 0.060088) (xy -0.153959 0.216643) (xy -0.154023 0.358555) (xy -0.154138 0.486572)
+				(xy -0.154311 0.601445) (xy -0.15455 0.703922) (xy -0.154862 0.794755) (xy -0.155253 0.874692) (xy -0.155731 0.944483)
+				(xy -0.156304 1.004879) (xy -0.156977 1.056628) (xy -0.157758 1.10048) (xy -0.158655 1.137186) (xy -0.159674 1.167495)
+				(xy -0.160823 1.192157) (xy -0.162108 1.211921) (xy -0.163537 1.227538) (xy -0.165118 1.239757)
+				(xy -0.165137 1.239883) (xy -0.189044 1.351721) (xy -0.224657 1.454268) (xy -0.271761 1.54714) (xy -0.330145 1.629953)
+				(xy -0.399595 1.702326) (xy -0.441214 1.73662) (xy -0.492717 1.770536) (xy -0.554953 1.80322) (xy -0.62329 1.832512)
+				(xy -0.693093 1.856252) (xy -0.705084 1.859666) (xy -0.781242 1.880679) (xy -1.935788 1.886166)
+				(xy -2.093593 1.88687) (xy -2.264384 1.88755) (xy -2.445755 1.8882) (xy -2.635297 1.888814) (xy -2.830604 1.889385)
+				(xy -3.029267 1.889909) (xy -3.22888 1.890379) (xy -3.427035 1.89079) (xy -3.621325 1.891136) (xy -3.809341 1.891411)
+				(xy -3.988678 1.891609) (xy -4.156926 1.891724) (xy -4.260272 1.891753) (xy -4.418034 1.891757)
+				(xy -4.561168 1.891737) (xy -4.690442 1.891683) (xy -4.806623 1.891588) (xy -4.910477 1.891443)
+				(xy -5.002771 1.89124) (xy -5.084273 1.89097) (xy -5.155748 1.890626) (xy -5.217965 1.890198) (xy -5.271689 1.889679)
+				(xy -5.317688 1.88906) (xy -5.356728 1.888333) (xy -5.389577 1.88749) (xy -5.417 1.886522) (xy -5.439766 1.885422)
+				(xy -5.45864 1.88418) (xy -5.47439 1.882788) (xy -5.487783 1.881239) (xy -5.499585 1.879523) (xy -5.507182 1.878241)
+				(xy -5.57071 1.865865) (xy -5.623481 1.852712) (xy -5.670122 1.837368) (xy -5.715256 1.818421) (xy -5.7369 1.808049)
+				(xy -5.82192 1.757533) (xy -5.8505 1.733977) (xy -5.570313 1.733977) (xy -5.562407 1.739348) (xy -5.55225 1.742669)
+				(xy -5.53776 1.743277) (xy -5.523153 1.734615) (xy -5.506268 1.714899) (xy -5.491012 1.692104) (xy -5.474245 1.670233)
+				(xy -5.461614 1.662561) (xy -5.454195 1.668203) (xy -5.453065 1.68627) (xy -5.459299 1.715878) (xy -5.45986 1.717767)
+				(xy -5.470578 1.753378) (xy -5.449646 1.757565) (xy -5.431679 1.760323) (xy -5.404115 1.763639)
+				(xy -5.372699 1.766825) (xy -5.370523 1.767024) (xy -5.312331 1.772297) (xy -5.267043 1.737449)
+				(xy -5.221974 1.699026) (xy -5.181914 1.656013) (xy -5.14215 1.603347) (xy -5.141963 1.603078) (xy -5.123143 1.578978)
+				(xy -5.103471 1.558505) (xy -5.085567 1.543827) (xy -5.07205 1.537115) (xy -5.065709 1.539933) (xy -5.067166 1.551924)
+				(xy -5.074377 1.574194) (xy -5.085849 1.603438) (xy -5.100091 1.636352) (xy -5.115612 1.669633)
+				(xy -5.130919 1.699976) (xy -5.144522 1.724077) (xy -5.154927 1.738632) (xy -5.155819 1.739515)
+				(xy -5.178497 1.761302) (xy -5.18921 1.774882) (xy -5.187578 1.782188) (xy -5.173223 1.785149) (xy -5.146736 1.785697)
+				(xy -5.096133 1.785697) (xy -5.091627 1.779054) (xy -5.010727 1.779054) (xy -5.00359 1.781913) (xy -4.98441 1.784155)
+				(xy -4.956537 1.785475) (xy -4.937877 1.785697) (xy -4.903684 1.78543) (xy -4.881612 1.784168) (xy -4.868391 1.781221)
+				(xy -4.860752 1.775899) (xy -4.855878 1.768379) (xy -4.843927 1.748804) (xy -4.827695 1.726048)
+				(xy -4.809786 1.703273) (xy -4.792801 1.683641) (xy -4.779346 1.670315) (xy -4.772022 1.666456)
+				(xy -4.771991 1.666474) (xy -4.7702 1.67555) (xy -4.773621 1.693501) (xy -4.776381 1.702198) (xy -4.784605 1.732303)
+				(xy -4.787456 1.758483) (xy -4.784958 1.777368) (xy -4.777135 1.785587) (xy -4.775797 1.785697)
+				(xy -4.763994 1.780793) (xy -4.745882 1.768149) (xy -4.73154 1.756002) (xy -4.700764 1.730324) (xy -4.6755 1.714127)
+				(xy -4.658302 1.708727) (xy -4.654942 1.715596) (xy -4.654068 1.733171) (xy -4.654927 1.747212)
+				(xy -4.658625 1.785697) (xy -4.480877 1.785697) (xy -4.486722 1.76453) (xy -4.441157 1.76453) (xy -4.441151 1.785697)
+				(xy -4.326446 1.785697) (xy -4.331002 1.721133) (xy -4.33268 1.683574) (xy -4.331115 1.655297) (xy -4.325759 1.63043)
+				(xy -4.321246 1.616769) (xy -4.309117 1.588281) (xy -4.297217 1.569517) (xy -4.287036 1.562522)
+				(xy -4.282945 1.564186) (xy -4.279627 1.572849) (xy -4.273727 1.593189) (xy -4.266168 1.621888)
+				(xy -4.260101 1.646341) (xy -4.250513 1.682657) (xy -4.240187 1.71648) (xy -4.230667 1.742969) (xy -4.226037 1.753225)
+				(xy -4.210922 1.781848) (xy -4.209815 1.754909) (xy -4.206598 1.724185) (xy -4.200375 1.700934)
+				(xy -4.192191 1.688817) (xy -4.190787 1.688162) (xy -4.183904 1.693268) (xy -4.172647 1.70902) (xy -4.159289 1.732179)
+				(xy -4.157448 1.735698) (xy -4.131593 1.785697) (xy -3.965811 1.785697) (xy -3.863878 1.785697)
+				(xy -3.778181 1.785697) (xy -3.805349 1.752543) (xy -3.824579 1.726058) (xy -3.842066 1.697082)
+				(xy -3.848028 1.685194) (xy -3.86354 1.651) (xy -3.863709 1.718348) (xy -3.863878 1.785697) (xy -3.965811 1.785697)
+				(xy -3.952625 1.733742) (xy -3.946782 1.705626) (xy -3.941735 1.671995) (xy -3.937713 1.636054)
+				(xy -3.934942 1.60101) (xy -3.933651 1.570068) (xy -3.934069 1.546436) (xy -3.936422 1.533318) (xy -3.938258 1.531697)
+				(xy -3.949595 1.535941) (xy -3.960544 1.542998) (xy -3.975789 1.552643) (xy -3.984432 1.550743)
+				(xy -3.989818 1.535656) (xy -3.991386 1.527848) (xy -3.99575 1.504582) (xy -3.856182 1.504582) (xy -3.853668 1.513113)
+				(xy -3.84708 1.531935) (xy -3.837906 1.556809) (xy -3.819894 1.601269) (xy -3.801629 1.640327) (xy -3.784584 1.671132)
+				(xy -3.770233 1.690832) (xy -3.767095 1.693808) (xy -3.755601 1.705699) (xy -3.739096 1.725514)
+				(xy -3.723918 1.745279) (xy -3.69406 1.785697) (xy -3.59809 1.785697) (xy -3.561692 1.785395) (xy -3.531632 1.784572)
+				(xy -3.510829 1.783349) (xy -3.502202 1.781849) (xy -3.502121 1.781683) (xy -3.505992 1.773395)
+				(xy -3.515755 1.757176) (xy -3.521064 1.748971) (xy -3.540763 1.713617) (xy -3.554437 1.67473) (xy -3.563408 1.62785)
+				(xy -3.567135 1.593412) (xy -3.571024 1.554386) (xy -3.575781 1.528196) (xy -3.58301 1.5123) (xy -3.594316 1.504157)
+				(xy -3.611303 1.501224) (xy -3.625543 1.500909) (xy -3.647054 1.501679) (xy -3.659268 1.505891)
+				(xy -3.663377 1.516395) (xy -3.660576 1.536043) (xy -3.652632 1.565657) (xy -3.639291 1.61386) (xy -3.629244 1.652778)
+				(xy -3.622858 1.68086) (xy -3.620502 1.696555) (xy -3.620928 1.699252) (xy -3.629968 1.698542) (xy -3.64643 1.690194)
+				(xy -3.666113 1.676662) (xy -3.680851 1.664228) (xy -3.696622 1.642878) (xy -3.712692 1.608897)
+				(xy -3.722288 1.582426) (xy -3.732566 1.552717) (xy -3.741984 1.528148) (xy -3.748936 1.512828)
+				(xy -3.750394 1.51053) (xy -3.760115 1.506495) (xy -3.779258 1.503264) (xy -3.803108 1.501101) (xy -3.826953 1.500272)
+				(xy -3.846082 1.501042) (xy -3.85578 1.503675) (xy -3.856182 1.504582) (xy -3.99575 1.504582) (xy -3.99644 1.500909)
+				(xy -4.045614 1.500909) (xy -4.070846 1.501876) (xy -4.088586 1.504401) (xy -4.094788 1.507684)
+				(xy -4.09245 1.518838) (xy -4.086181 1.541048) (xy -4.077098 1.570832) (xy -4.066319 1.604703) (xy -4.054962 1.639177)
+				(xy -4.044143 1.670768) (xy -4.03498 1.695992) (xy -4.031881 1.703881) (xy -4.024391 1.726095) (xy -4.021705 1.74255)
+				(xy -4.022978 1.74775) (xy -4.034979 1.749971) (xy -4.052795 1.742614) (xy -4.072679 1.728162) (xy -4.090884 1.709102)
+				(xy -4.09893 1.697375) (xy -4.112761 1.670495) (xy -4.126563 1.638617) (xy -4.132217 1.623453) (xy -4.147593 1.579724)
+				(xy -4.159395 1.548593) (xy -4.168713 1.527988) (xy -4.176639 1.515837) (xy -4.184262 1.510067)
+				(xy -4.19266 1.508606) (xy -4.204618 1.510958) (xy -4.209498 1.52095) (xy -4.210242 1.535545) (xy -4.211976 1.553354)
+				(xy -4.216238 1.562253) (xy -4.217142 1.562485) (xy -4.225923 1.55716) (xy -4.240229 1.54368) (xy -4.247694 1.535545)
+				(xy -4.262213 1.520408) (xy -4.27551 1.512343) (xy -4.293321 1.509145) (xy -4.317765 1.508606) (xy -4.346773 1.509934)
+				(xy -4.361636 1.514059) (xy -4.364201 1.518227) (xy -4.367965 1.529467) (xy -4.377754 1.549183)
+				(xy -4.389724 1.570182) (xy -4.404953 1.602147) (xy -4.419223 1.643752) (xy -4.431016 1.689251)
+				(xy -4.438811 1.7329) (xy -4.441157 1.76453) (xy -4.486722 1.76453) (xy -4.488848 1.756833) (xy -4.494264 1.71608)
+				(xy -4.49145 1.666988) (xy -4.48093 1.613879) (xy -4.465969 1.567908) (xy -4.442527 1.507907) (xy -4.489879 1.510181)
+				(xy -4.537232 1.512455) (xy -4.56937 1.561635) (xy -4.585603 1.585843) (xy -4.599084 1.6048) (xy -4.60726 1.614938)
+				(xy -4.607921 1.615514) (xy -4.615115 1.624807) (xy -4.625567 1.642566) (xy -4.629727 1.65048) (xy -4.644256 1.674199)
+				(xy -4.656391 1.682971) (xy -4.666629 1.676969) (xy -4.672493 1.665257) (xy -4.677087 1.63758) (xy -4.674642 1.602583)
+				(xy -4.66595 1.566196) (xy -4.655984 1.541904) (xy -4.646906 1.523621) (xy -4.641731 1.512277) (xy -4.641272 1.510827)
+				(xy -4.648433 1.509907) (xy -4.667768 1.509179) (xy -4.69606 1.50873) (xy -4.720166 1.508631) (xy -4.79906 1.508656)
+				(xy -4.821244 1.562747) (xy -4.83116 1.585306) (xy -4.841732 1.604405) (xy -4.855248 1.622894) (xy -4.873998 1.643628)
+				(xy -4.900271 1.669459) (xy -4.927077 1.694624) (xy -4.956454 1.722368) (xy -4.981319 1.746661)
+				(xy -4.999688 1.765501) (xy -5.009574 1.776883) (xy -5.010727 1.779054) (xy -5.091627 1.779054)
+				(xy -5.07133 1.749136) (xy -5.053879 1.724245) (xy -5.036677 1.701013) (xy -5.02883 1.691059) (xy -5.014999 1.669616)
+				(xy -5.004672 1.641822) (xy -4.999809 1.618318) (xy -4.94493 1.618318) (xy -4.942033 1.62026) (xy -4.934834 1.61694)
+				(xy -4.923841 1.606697) (xy -4.908705 1.58716) (xy -4.892682 1.562535) (xy -4.892508 1.562242) (xy -4.878722 1.538671)
+				(xy -4.868719 1.520749) (xy -4.864511 1.512089) (xy -4.864485 1.511903) (xy -4.871261 1.509722)
+				(xy -4.887921 1.508634) (xy -4.891424 1.508606) (xy -4.909657 1.510059) (xy -4.917118 1.516533)
+				(xy -4.918363 1.527564) (xy -4.921162 1.545532) (xy -4.92831 1.570524) (xy -4.93375 1.585558) (xy -4.942202 1.607676)
+				(xy -4.94493 1.618318) (xy -4.999809 1.618318) (xy -4.996963 1.604569) (xy -4.991523 1.560333) (xy -4.986362 1.50815)
+				(xy -5.088441 1.510302) (xy -5.19052 1.512455) (xy -5.196492 1.534824) (xy -5.204456 1.55176) (xy -5.21849 1.571874)
+				(xy -5.23495 1.590885) (xy -5.250194 1.604512) (xy -5.259321 1.608667) (xy -5.262199 1.601595) (xy -5.262751 1.582558)
+				(xy -5.260882 1.55482) (xy -5.260878 1.554788) (xy -5.25836 1.526664) (xy -5.258292 1.510523) (xy -5.261295 1.503062)
+				(xy -5.267991 1.500979) (xy -5.271013 1.500909) (xy -5.277821 1.500099) (xy -3.493607 1.500099)
+				(xy -3.489665 1.583246) (xy -3.485795 1.641838) (xy -3.480104 1.687627) (xy -3.472107 1.72315) (xy -3.46132 1.75094)
+				(xy -3.455591 1.761328) (xy -3.440771 1.785697) (xy -3.217333 1.785697) (xy -2.734217 1.785697)
+				(xy -2.663151 1.785697) (xy -2.663151 1.748626) (xy -2.667675 1.687707) (xy -2.68052 1.630838) (xy -2.700598 1.581751)
+				(xy -2.720847 1.550939) (xy -2.728625 1.542586) (xy -2.729221 1.544311) (xy -2.726545 1.557692)
+				(xy -2.7248 1.582657) (xy -2.724 1.61542) (xy -2.724161 1.652198) (xy -2.725296 1.689208) (xy -2.72742 1.722665)
+				(xy -2.728498 1.733742) (xy -2.734217 1.785697) (xy -3.217333 1.785697) (xy -3.217333 1.751061)
+				(xy -3.215812 1.726924) (xy -3.210999 1.717586) (xy -3.202522 1.722727) (xy -3.19556 1.732568) (xy -3.186269 1.744756)
+				(xy -3.182593 1.743528) (xy -3.18479 1.729902) (xy -3.190403 1.712281) (xy -3.19861 1.67559) (xy -3.201227 1.631994)
+				(xy -3.198089 1.588992) (xy -3.19359 1.567361) (xy -3.189314 1.543122) (xy -3.189431 1.523301) (xy -3.154252 1.523301)
+				(xy -3.150459 1.547928) (xy -3.145156 1.575647) (xy -3.125864 1.637009) (xy -3.091545 1.697147)
+				(xy -3.044981 1.753312) (xy -3.026427 1.771783) (xy -3.012169 1.781393) (xy -2.996149 1.784674)
+				(xy -2.972309 1.784155) (xy -2.97127 1.784099) (xy -2.929175 1.781848) (xy -2.907961 1.739515) (xy -2.896338 1.712011)
+				(xy -2.883985 1.675892) (xy -2.873065 1.637663) (xy -2.870213 1.625985) (xy -2.862502 1.595328)
+				(xy -2.855333 1.571294) (xy -2.849744 1.557159) (xy -2.847653 1.554788) (xy -2.840194 1.561872)
+				(xy -2.832531 1.58075) (xy -2.825516 1.607855) (xy -2.820005 1.639622) (xy -2.816852 1.672488) (xy -2.816442 1.685083)
+				(xy -2.815794 1.743364) (xy -2.800204 1.709385) (xy -2.793391 1.692821) (xy -2.789271 1.676605)
+				(xy -2.787523 1.656891) (xy -2.787825 1.629828) (xy -2.789855 1.59157) (xy -2.790067 1.588157) (xy -2.795518 1.500909)
+				(xy -2.679593 1.500909) (xy -2.661995 1.525924) (xy -2.648427 1.54401) (xy -2.628722 1.568846) (xy -2.606791 1.59552)
+				(xy -2.603392 1.599564) (xy -2.581235 1.627759) (xy -2.560926 1.656907) (xy -2.5465 1.681174) (xy -2.54542 1.683348)
+				(xy -2.528454 1.718507) (xy -2.525945 1.693069) (xy -2.526307 1.669408) (xy -2.530253 1.6411) (xy -2.532184 1.632376)
+				(xy -2.5474 1.592144) (xy -2.572489 1.549465) (xy -2.596758 1.518227) (xy -2.611844 1.506704) (xy -2.529508 1.506704)
+				(xy -2.526423 1.509896) (xy -2.52471 1.510819) (xy -2.509066 1.524745) (xy -2.491544 1.549647) (xy -2.474029 1.581574)
+				(xy -2.45841 1.616577) (xy -2.446574 1.650706) (xy -2.440408 1.68001) (xy -2.439939 1.688234) (xy -2.441576 1.713412)
+				(xy -2.448652 1.731453) (xy -2.464415 1.750116) (xy -2.466878 1.7526) (xy -2.482402 1.76869) (xy -2.492138 1.779871)
+				(xy -2.493818 1.782618) (xy -2.486829 1.784254) (xy -2.46869 1.785371) (xy -2.448413 1.785697) (xy -2.403009 1.785697)
+				(xy -2.385853 1.752985) (xy -2.359475 1.692666) (xy -2.3413 1.629946) (xy -2.33584 1.598264) (xy -2.329982 1.568446)
+				(xy -2.322172 1.552645) (xy -2.313113 1.549715) (xy -2.303503 1.55851) (xy -2.294045 1.577883) (xy -2.285439 1.606688)
+				(xy -2.278385 1.643779) (xy -2.273585 1.68801) (xy -2.272742 1.701479) (xy -2.2683 1.785697) (xy -2.195295 1.785697)
+				(xy -2.184494 1.741439) (xy -2.175702 1.71321) (xy -2.166664 1.698848) (xy -2.162497 1.697182) (xy -2.153517 1.704664)
+				(xy -2.144384 1.726289) (xy -2.140101 1.741439) (xy -2.128899 1.785697) (xy -2.095602 1.785697)
+				(xy -2.072455 1.783848) (xy -2.060725 1.777435) (xy -2.058045 1.772227) (xy -2.056287 1.767896)
+				(xy -1.977212 1.767896) (xy -1.974086 1.776025) (xy -1.962455 1.777962) (xy -1.957056 1.778) (xy -1.941554 1.77572)
+				(xy -1.930634 1.766326) (xy -1.919846 1.745997) (xy -1.905427 1.718258) (xy -1.888035 1.690169)
+				(xy -1.88435 1.684915) (xy -1.868164 1.659808) (xy -1.85417 1.633627) (xy -1.85154 1.627726) (xy -1.841605 1.610049)
+				(xy -1.831992 1.602798) (xy -1.830064 1.603007) (xy -1.825309 1.611917) (xy -1.822478 1.631759)
+				(xy -1.821522 1.658197) (xy -1.822392 1.686896) (xy -1.825038 1.713521) (xy -1.829411 1.733737)
+				(xy -1.831603 1.739) (xy -1.836042 1.751411) (xy -1.830062 1.753637) (xy -1.812937 1.745893) (xy -1.811358 1.745015)
+				(xy -1.782566 1.720573) (xy -1.763937 1.687036) (xy -1.756407 1.647634) (xy -1.760913 1.605597)
+				(xy -1.76613 1.589201) (xy -1.779712 1.563349) (xy -1.797741 1.541699) (xy -1.817513 1.525968) (xy -1.836326 1.517872)
+				(xy -1.851476 1.519124) (xy -1.859781 1.529773) (xy -1.872876 1.565272) (xy -1.888086 1.593167)
+				(xy -1.909641 1.621102) (xy -1.911542 1.623308) (xy -1.94865 1.676549) (xy -1.971058 1.733379) (xy -1.974521 1.749136)
+				(xy -1.977212 1.767896) (xy -2.056287 1.767896) (xy -2.038884 1.725039) (xy -2.011141 1.680898)
+				(xy -1.992586 1.657599) (xy -1.969044 1.626878) (xy -1.945617 1.59169) (xy -1.930054 1.564608) (xy -1.917251 1.538597)
+				(xy -1.9114 1.522655) (xy -1.911719 1.513537) (xy -1.916545 1.508544) (xy -1.933646 1.501855) (xy -1.948314 1.502637)
+				(xy -1.955004 1.510506) (xy -1.95503 1.511219) (xy -1.961436 1.523749) (xy -1.977193 1.530831) (xy -1.997109 1.532064)
+				(xy -2.015991 1.527046) (xy -2.027818 1.516842) (xy -2.03663 1.508335) (xy -2.04303 1.514405) (xy -2.046671 1.534372)
+				(xy -2.047394 1.555035) (xy -2.049352 1.585661) (xy -2.054382 1.614553) (xy -2.058794 1.628749)
+				(xy -2.069938 1.648323) (xy -2.081544 1.653775) (xy -2.094136 1.644812) (xy -2.10824 1.621144) (xy -2.119522 1.595093)
+				(xy -2.130749 1.568802) (xy -2.140635 1.549198) (xy -2.147384 1.539761) (xy -2.148295 1.539394)
+				(xy -2.153562 1.54619) (xy -2.158601 1.563168) (xy -2.159867 1.570021) (xy -2.167758 1.601172) (xy -2.179 1.61874)
+				(xy -2.193034 1.622019) (xy -2.198958 1.619387) (xy -2.211651 1.605766) (xy -2.21534 1.596296) (xy -2.220008 1.581575)
+				(xy -2.229442 1.558997) (xy -2.237765 1.541318) (xy -2.257729 1.500909) (xy -2.400789 1.501023)
+				(xy -2.451009 1.501203) (xy -2.487413 1.501737) (xy -2.51158 1.502749) (xy -2.525086 1.504362) (xy -2.529508 1.506704)
+				(xy -2.611844 1.506704) (xy -2.612843 1.505941) (xy -2.635659 1.501184) (xy -2.645775 1.500909)
+				(xy -2.679593 1.500909) (xy -2.795518 1.500909) (xy -2.940242 1.500909) (xy -2.940242 1.544274)
+				(xy -2.944799 1.597206) (xy -2.958919 1.639532) (xy -2.983278 1.673216) (xy -2.985318 1.675237)
+				(xy -3.008165 1.694744) (xy -3.023007 1.701106) (xy -3.029853 1.694324) (xy -3.028714 1.674397)
+				(xy -3.028264 1.672167) (xy -3.023614 1.633182) (xy -3.027644 1.595531) (xy -3.041077 1.553037)
+				(xy -3.042664 1.549034) (xy -3.060431 1.504758) (xy -3.108094 1.502466) (xy -3.131556 1.501402)
+				(xy -3.146162 1.502727) (xy -3.153274 1.509131) (xy -3.154252 1.523301) (xy -3.189431 1.523301)
+				(xy -3.18944 1.52181) (xy -3.190008 1.518947) (xy -3.193073 1.509812) (xy -3.198825 1.504434) (xy -3.210595 1.502009)
+				(xy -3.231714 1.50173) (xy -3.257966 1.502526) (xy -3.321242 1.504758) (xy -3.320324 1.549398) (xy -3.317097 1.580569)
+				(xy -3.309372 1.619122) (xy -3.298529 1.658211) (xy -3.298157 1.659361) (xy -3.289159 1.688783)
+				(xy -3.283032 1.712327) (xy -3.280649 1.726459) (xy -3.281041 1.728819) (xy -3.290839 1.728675)
+				(xy -3.308809 1.720478) (xy -3.331482 1.706246) (xy -3.355385 1.687995) (xy -3.363606 1.680845)
+				(xy -3.386312 1.655648) (xy -3.4019 1.625906) (xy -3.411942 1.587776) (xy -3.416823 1.550939) (xy -3.421303 1.504758)
+				(xy -3.457455 1.502428) (xy -3.493607 1.500099) (xy -5.277821 1.500099) (xy -5.290431 1.498599)
+				(xy -5.298734 1.496237) (xy -5.306419 1.496005) (xy -5.310064 1.505135) (xy -5.310968 1.525101)
+				(xy -5.313364 1.55119) (xy -5.319486 1.583432) (xy -5.32549 1.606195) (xy -5.335868 1.633664) (xy -5.349998 1.662529)
+				(xy -5.365736 1.689297) (xy -5.380937 1.710475) (xy -5.393459 1.722568) (xy -5.39786 1.724121) (xy -5.401598 1.717233)
+				(xy -5.401636 1.698701) (xy -5.398349 1.671729) (xy -5.392115 1.639517) (xy -5.384288 1.608667)
+				(xy -5.376275 1.576043) (xy -5.369671 1.541582) (xy -5.367627 1.527312) (xy -5.362994 1.488291)
+				(xy -5.398995 1.474543) (xy -5.420352 1.467371) (xy -5.435195 1.464218) (xy -5.438912 1.46471) (xy -5.44278 1.473717)
+				(xy -5.448837 1.493113) (xy -5.454438 1.513631) (xy -5.465514 1.54627) (xy -5.48294 1.586226) (xy -5.504143 1.628487)
+				(xy -5.526552 1.668042) (xy -5.547594 1.699878) (xy -5.554552 1.708736) (xy -5.567602 1.725136)
+				(xy -5.570313 1.733977) (xy -5.8505 1.733977) (xy -5.897703 1.695072) (xy -5.918597 1.671739) (xy -5.711151 1.671739)
+				(xy -5.705009 1.678279) (xy -5.69008 1.688173) (xy -5.67161 1.698447) (xy -5.654844 1.706123) (xy -5.646543 1.708387)
+				(xy -5.637846 1.703304) (xy -5.623256 1.689952) (xy -5.613738 1.679864) (xy -5.594558 1.656523)
+				(xy -5.578947 1.63392) (xy -5.568986 1.615465) (xy -5.566755 1.60457) (xy -5.567301 1.603709) (xy -5.575148 1.605524)
+				(xy -5.591676 1.613912) (xy -5.606666 1.622909) (xy -5.634777 1.638437) (xy -5.664783 1.651646)
+				(xy -5.676828 1.655772) (xy -5.697111 1.662895) (xy -5.709431 1.669411) (xy -5.711151 1.671739)
+				(xy -5.918597 1.671739) (xy -5.963573 1.621514) (xy -6.018853 1.537709) (xy -6.062868 1.444505)
+				(xy -6.088839 1.366212) (xy -6.092649 1.351763) (xy -6.095878 1.337361) (xy -6.098597 1.321563)
+				(xy -6.100878 1.302926) (xy -6.102793 1.280005) (xy -6.104412 1.251358) (xy -6.105807 1.215542)
+				(xy -6.10705 1.171113) (xy -6.10768 1.141522) (xy -5.972016 1.141522) (xy -5.971881 1.164247) (xy -5.971259 1.182253)
+				(xy -5.969886 1.212308) (xy -5.967674 1.230516) (xy -5.963269 1.240418) (xy -5.955315 1.245552)
+				(xy -5.945909 1.248487) (xy -5.928462 1.25051) (xy -5.899487 1.25075) (xy -5.862742 1.249257) (xy -5.831253 1.246937)
+				(xy -5.79537 1.244126) (xy -5.765396 1.242419) (xy -5.74447 1.24195) (xy -5.735736 1.24285) (xy -5.737691 1.250837)
+				(xy -5.747876 1.266709) (xy -5.763727 1.287374) (xy -5.782679 1.309742) (xy -5.802167 1.330722)
+				(xy -5.819627 1.347225) (xy -5.827278 1.353164) (xy -5.849654 1.365436) (xy -5.878972 1.377719)
+				(xy -5.897632 1.383952) (xy -5.921117 1.391765) (xy -5.937217 1.398865) (xy -5.94205 1.402992) (xy -5.938815 1.412456)
+				(xy -5.930337 1.431415) (xy -5.918859 1.454947) (xy -5.908199 1.475125) (xy -5.898159 1.489142)
+				(xy -5.88631 1.497225) (xy -5.870225 1.499598) (xy -5.847476 1.496489) (xy -5.815635 1.488123) (xy -5.772274 1.474726)
+				(xy -5.757333 1.469975) (xy -5.720651 1.458517) (xy -5.688874 1.449008) (xy -5.665075 1.442339)
+				(xy -5.65233 1.439399) (xy -5.6515 1.439334) (xy -5.6415 1.443201) (xy -5.642887 1.453762) (xy -5.654057 1.469454)
+				(xy -5.673406 1.488712) (xy -5.69933 1.509972) (xy -5.730224 1.53167) (xy -5.764485 1.552241) (xy -5.770795 1.555656)
+				(xy -5.798377 1.570817) (xy -5.819909 1.583589) (xy -5.832384 1.592139) (xy -5.834295 1.594353)
+				(xy -5.828371 1.599799) (xy -5.812995 1.611015) (xy -5.791765 1.625612) (xy -5.768284 1.641199)
+				(xy -5.74615 1.655388) (xy -5.728965 1.665787) (xy -5.720329 1.670008) (xy -5.720318 1.670009) (xy -5.721262 1.665138)
+				(xy -5.722996 1.66206) (xy -5.722076 1.649519) (xy -5.706982 1.632633) (xy -5.678178 1.611835) (xy -5.654147 1.597455)
+				(xy -5.626747 1.581076) (xy -5.601817 1.564734) (xy -5.586318 1.553207) (xy -5.570126 1.535895)
+				(xy -5.552021 1.511101) (xy -5.534596 1.483143) (xy -5.520445 1.45634) (xy -5.512161 1.435011) (xy -5.51103 1.427833)
+				(xy -5.515442 1.412364) (xy -5.526668 1.39124) (xy -5.534437 1.37975) (xy -5.557843 1.347922) (xy -5.595206 1.366688)
+				(xy -5.630348 1.380186) (xy -5.668578 1.385267) (xy -5.679557 1.385455) (xy -5.708111 1.384068)
+				(xy -5.722945 1.379553) (xy -5.723913 1.371379) (xy -5.710871 1.359014) (xy -5.683675 1.341925)
+				(xy -5.664901 1.331539) (xy -5.638401 1.316586) (xy -5.618633 1.304097) (xy -5.608363 1.295891)
+				(xy -5.607684 1.293932) (xy -5.617086 1.288717) (xy -5.635403 1.280908) (xy -5.643426 1.277827)
+				(xy -5.665927 1.26645) (xy -5.683237 1.252563) (xy -5.686187 1.248833) (xy -5.697635 1.231515) (xy -5.588 1.231515)
+				(xy -5.588 1.132529) (xy -5.612964 1.139689) (xy -5.638772 1.144098) (xy -5.676292 1.146645) (xy -5.721974 1.147459)
+				(xy -5.772266 1.146667) (xy -5.823615 1.144397) (xy -5.87247 1.140776) (xy -5.91528 1.135932) (xy -5.948492 1.129993)
+				(xy -5.958534 1.127263) (xy -5.966011 1.125917) (xy -5.970282 1.129707) (xy -5.972016 1.141522)
+				(xy -6.10768 1.141522) (xy -6.108211 1.116627) (xy -6.109363 1.050642) (xy -6.110577 0.971714) (xy -6.111498 0.908242)
+				(xy -6.112744 0.819707) (xy -6.113714 0.745177) (xy -6.114377 0.683264) (xy -6.114438 0.673795)
+				(xy -5.987523 0.673795) (xy -5.9865 0.700886) (xy -5.984465 0.738926) (xy -5.982097 0.778979) (xy -5.979769 0.806689)
+				(xy -5.976749 0.825088) (xy -5.972308 0.837206) (xy -5.965716 0.846075) (xy -5.956667 0.854364)
+				(xy -5.939152 0.873473) (xy -5.934465 0.888626) (xy -5.942577 0.898134) (xy -5.957454 0.900545)
+				(xy -5.973818 0.902464) (xy -5.979848 0.911433) (xy -5.980545 0.923277) (xy -5.974103 0.946684)
+				(xy -5.960892 0.959838) (xy -5.943236 0.972919) (xy -5.920522 0.990573) (xy -5.908937 0.999848)
+				(xy -5.869708 1.026888) (xy -5.826918 1.045957) (xy -5.775431 1.05921) (xy -5.761182 1.061768) (xy -5.729466 1.067343)
+				(xy -5.69984 1.07297) (xy -5.680363 1.07707) (xy -5.654195 1.081469) (xy -5.624975 1.084131) (xy -5.620712 1.0843)
+				(xy -5.588 1.085273) (xy -5.588 1.027545) (xy -5.588707 0.999926) (xy -5.590578 0.979461) (xy -5.593235 0.969927)
+				(xy -5.593772 0.969663) (xy -5.641733 0.964562) (xy -5.692422 0.95273) (xy -5.741206 0.935757) (xy -5.78345 0.915228)
+				(xy -5.812279 0.894817) (xy -5.830017 0.875404) (xy -5.846733 0.851485) (xy -5.860236 0.827058)
+				(xy -5.868334 0.806124) (xy -5.868835 0.792681) (xy -5.868543 0.792147) (xy -5.85997 0.79114) (xy -5.84257 0.794923)
+				(xy -5.821511 0.801868) (xy -5.801957 0.810345) (xy -5.791969 0.816292) (xy -5.781759 0.82107) (xy -5.760478 0.829357)
+				(xy -5.731668 0.83981) (xy -5.711151 0.846936) (xy -5.677481 0.858768) (xy -5.647224 0.869997) (xy -5.624761 0.878969)
+				(xy -5.617246 0.882378) (xy -5.601213 0.889819) (xy -5.59223 0.892848) (xy -5.590489 0.885683) (xy -5.589096 0.866314)
+				(xy -5.588219 0.837928) (xy -5.588 0.812467) (xy -5.588356 0.775388) (xy -5.589738 0.750657) (xy -5.592613 0.735239)
+				(xy -5.597449 0.726097) (xy -5.601941 0.722027) (xy -5.618385 0.706863) (xy -5.621897 0.691844)
+				(xy -5.612837 0.672836) (xy -5.606944 0.664713) (xy -5.597778 0.652) (xy -5.591937 0.640336) (xy -5.588851 0.626102)
+				(xy -5.587952 0.605677) (xy -5.588669 0.575439) (xy -5.589522 0.553903) (xy -5.591406 0.515967)
+				(xy -5.593922 0.489533) (xy -5.597926 0.470711) (xy -5.604276 0.45561) (xy -5.613827 0.440339) (xy -5.614852 0.438853)
+				(xy -5.62691 0.421566) (xy -5.636358 0.410238) (xy -5.647116 0.402167) (xy -5.663103 0.394652) (xy -5.68824 0.38499)
+				(xy -5.698655 0.381079) (xy -5.748638 0.362265) (xy -5.736917 0.390318) (xy -5.728267 0.408369)
+				(xy -5.713863 0.435656) (xy -5.695852 0.468204) (xy -5.679834 0.496133) (xy -5.661192 0.52947) (xy -5.645325 0.560411)
+				(xy -5.634078 0.585198) (xy -5.629516 0.598675) (xy -5.627432 0.615712) (xy -5.631914 0.622476)
+				(xy -5.640318 0.623455) (xy -5.653979 0.620058) (xy -5.677102 0.61098) (xy -5.705621 0.597884) (xy -5.718593 0.5914)
+				(xy -5.783974 0.549327) (xy -5.84038 0.495065) (xy -5.886782 0.429609) (xy -5.888227 0.427103) (xy -5.913006 0.383794)
+				(xy -5.932198 0.401639) (xy -5.948145 0.42018) (xy -5.958839 0.438727) (xy -5.966093 0.461861) (xy -5.971718 0.487585)
+				(xy -5.974858 0.510718) (xy -5.974659 0.526082) (xy -5.973668 0.52863) (xy -5.962064 0.539672) (xy -5.940258 0.556379)
+				(xy -5.911356 0.576678) (xy -5.878466 0.598498) (xy -5.844693 0.619765) (xy -5.813144 0.638409)
+				(xy -5.79188 0.649897) (xy -5.751485 0.671069) (xy -5.720152 0.68941) (xy -5.692779 0.708123) (xy -5.666336 0.728724)
+				(xy -5.653431 0.740304) (xy -5.651914 0.746602) (xy -5.659314 0.750759) (xy -5.681958 0.753839)
+				(xy -5.715269 0.751073) (xy -5.756102 0.743408) (xy -5.801311 0.731795) (xy -5.847753 0.717183)
+				(xy -5.892281 0.700521) (xy -5.93175 0.682759) (xy -5.963016 0.664847) (xy -5.975562 0.655287) (xy -5.98142 0.65076)
+				(xy -5.985213 0.650894) (xy -5.987171 0.657852) (xy -5.987523 0.673795) (xy -6.114438 0.673795)
+				(xy -6.114706 0.632582) (xy -6.11467 0.591743) (xy -6.114242 0.559361) (xy -6.113391 0.534047) (xy -6.112088 0.514416)
+				(xy -6.110305 0.499079) (xy -6.108013 0.48665) (xy -6.105182 0.475741) (xy -6.102224 0.466305) (xy -6.078637 0.411713)
+				(xy -6.044679 0.36278) (xy -6.003581 0.320836) (xy -5.951995 0.284265) (xy -5.892307 0.260286) (xy -5.823762 0.248602)
+				(xy -5.818255 0.248213) (xy -5.749516 0.251028) (xy -5.685531 0.267958) (xy -5.627504 0.298143)
+				(xy -5.57664 0.340719) (xy -5.534144 0.394823) (xy -5.50122 0.459593) (xy -5.493435 0.480841) (xy -5.49157 0.493784)
+				(xy -5.489686 0.520781) (xy -5.487828 0.560494) (xy -5.486039 0.611582) (xy -5.484363 0.672707)
+				(xy -5.482846 0.74253) (xy -5.48153 0.81971) (xy -5.480991 0.858382) (xy -5.476394 1.212612) (xy -5.451692 1.262473)
+				(xy -5.431609 1.297362) (xy -5.408118 1.325148) (xy -5.377446 1.349427) (xy -5.335819 1.373791)
+				(xy -5.333538 1.374995) (xy -5.291666 1.397) (xy -3.110852 1.395662) (xy -0.930037 1.394324) (xy -0.889964 1.374718)
+				(xy -0.852674 1.350978) (xy -0.823822 1.319574) (xy -0.80268 1.278946) (xy -0.78852 1.227537) (xy -0.780617 1.163787)
+				(xy -0.779151 1.137227) (xy -0.775496 1.046788) (xy -1.103196 1.046788) (xy -1.185962 1.046716)
+				(xy -1.25524 1.046456) (xy -1.312937 1.045938) (xy -1.360961 1.045094) (xy -1.401217 1.043856) (xy -1.435612 1.042154)
+				(xy -1.466052 1.039921) (xy -1.494444 1.037089) (xy -1.522694 1.033587) (xy -1.540948 1.031054)
+				(xy -1.630558 1.015935) (xy -1.70759 0.998075) (xy -1.770832 0.977766) (xy -1.781848 0.973383) (xy -1.80472 0.964584)
+				(xy -1.823483 0.958221) (xy -1.842544 0.950197) (xy -1.87075 0.93558) (xy -1.904545 0.91647) (xy -1.940372 0.89497)
+				(xy -1.974674 0.873182) (xy -2.003893 0.853208) (xy -2.014431 0.845375) (xy -2.094853 0.77371) (xy -2.164462 0.691136)
+				(xy -2.223269 0.597636) (xy -2.271284 0.493189) (xy -2.308515 0.377778) (xy -2.334974 0.251383)
+				(xy -2.340766 0.211667) (xy -2.345301 0.165101) (xy -2.34841 0.107538) (xy -2.350093 0.043113) (xy -2.35035 -0.024033)
+				(xy -2.350256 -0.029342) (xy -1.698796 -0.029342) (xy -1.698149 0.040328) (xy -1.693094 0.108822)
+				(xy -1.683974 0.171725) (xy -1.671137 0.224619) (xy -1.669103 0.230857) (xy -1.63762 0.304546) (xy -1.596587 0.369778)
+				(xy -1.547427 0.425088) (xy -1.491563 0.469012) (xy -1.430419 0.500087) (xy -1.397 0.510684) (xy -1.378298 0.515346)
+				(xy -1.361445 0.519132) (xy -1.344607 0.522142) (xy -1.325955 0.524475) (xy -1.303656 0.52623) (xy -1.275878 0.527505)
+				(xy -1.240792 0.5284) (xy -1.196564 0.529014) (xy -1.141364 0.529445) (xy -1.07336 0.529794) (xy -1.041015 0.529938)
+				(xy -0.777394 0.531091) (xy -0.777394 -0.531931) (xy -1.071803 -0.529293) (xy -1.147038 -0.528593)
+				(xy -1.208571 -0.527905) (xy -1.258091 -0.527125) (xy -1.297288 -0.526152) (xy -1.327854 -0.524883)
+				(xy -1.351479 -0.523216) (xy -1.369852 -0.521047) (xy -1.384665 -0.518274) (xy -1.397607 -0.514794)
+				(xy -1.41037 -0.510505) (xy -1.416242 -0.50838) (xy -1.487436 -0.475025) (xy -1.548184 -0.43071)
+				(xy -1.598593 -0.375277) (xy -1.638768 -0.308571) (xy -1.668815 -0.230436) (xy -1.688839 -0.140714)
+				(xy -1.694686 -0.095773) (xy -1.698796 -0.029342) (xy -2.350256 -0.029342) (xy -2.349181 -0.089765)
+				(xy -2.346587 -0.149943) (xy -2.342566 -0.200429) (xy -2.340759 -0.215515) (xy -2.317237 -0.344976)
+				(xy -2.282983 -0.463441) (xy -2.237922 -0.57102) (xy -2.181984 -0.667823) (xy -2.115097 -0.753959)
+				(xy -2.037187 -0.829537) (xy -1.948184 -0.894667) (xy -1.861117 -0.943187) (xy -1.77544 -0.979471)
+				(xy -1.678248 -1.010119) (xy -1.616363 -1.025454) (xy -1.60346 -1.0283) (xy -1.590764 -1.030806)
+				(xy -1.577239 -1.032997) (xy -1.561847 -1.034899) (xy -1.543551 -1.036538) (xy -1.521314 -1.03794)
+				(xy -1.494098 -1.03913) (xy -1.460868 -1.040136) (xy -1.420585 -1.040982) (xy -1.372213 -1.041694)
+				(xy -1.314714 -1.042299) (xy -1.247051 -1.042823) (xy -1.168188 -1.043291) (xy -1.077086 -1.043729)
+				(xy -0.972709 -1.044163) (xy -0.854021 -1.044619) (xy -0.848591 -1.044639) (xy -0.153939 -1.047257)
+				(xy -0.153939 0.060088)
+			)
+			(stroke
+				(width 0.01)
+				(type solid)
+			)
+			(fill yes)
+			(layer "F.SilkS")
+			(uuid "b05db981-a830-4310-a3b6-36abca3950bc")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "tigard:Securing_Hardware_Logo"
+		(layer "B.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec85cf")
+		(at 71.018 38.78 180)
+		(property "Reference" "LOGO2"
+			(at 0.21 -5.33 0)
+			(layer "B.Fab")
+			(uuid "47a8a532-e0f0-4321-9ce4-c544da20944d")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Value" "Logo_SH"
+			(at 0.21 -4.33 0)
+			(layer "B.Fab")
+			(uuid "3c681082-5145-4938-a00f-fe351a18ca9d")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "cb7db9f6-0eff-4a87-b93c-50299990051a")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b1520d79-4c83-4fac-bc07-ce1a353b873b")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f3191b2")
+		(attr through_hole)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 3.88 0.01)
+			(end 3.87 -0.05)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "5723d02c-4372-4c62-b412-d85462ef612b")
+		)
+		(fp_line
+			(start 3.87 0.07)
+			(end 3.88 0.01)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "faf3d93f-b176-44e4-ade4-679cb361fb38")
+		)
+		(fp_line
+			(start 3.87 -0.05)
+			(end 3.85 -0.13)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "c61583b8-11bc-4da5-b73b-1b8fe23eef7b")
+		)
+		(fp_line
+			(start 3.85 -0.13)
+			(end 3.8 -0.18)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "9f96f5a4-820d-4853-97d7-b834f399e13e")
+		)
+		(fp_line
+			(start 3.83 0.14)
+			(end 3.87 0.07)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "ee58b403-4c68-4243-beeb-4c64c83b152b")
+		)
+		(fp_line
+			(start 3.8 -0.18)
+			(end 3.74 -0.18)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "ef25a81e-bd54-43c0-b6e0-1d3e92e57890")
+		)
+		(fp_line
+			(start 3.74 -0.18)
+			(end 3.56 -0.18)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "2ce798cd-e99b-4191-bbda-1072b66df191")
+		)
+		(fp_line
+			(start 3.57 0.16)
+			(end 3.83 0.14)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "8636784e-ce5e-4395-b69f-468b3524b551")
+		)
+		(fp_line
+			(start 1.95 1.81)
+			(end 1.92 1.93)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "1a378621-f79f-48b0-a777-496550ddf716")
+		)
+		(fp_line
+			(start 1.95 1.35)
+			(end 1.95 1.81)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "32b8fd5f-fac9-4208-89d5-770f2a2eb57f")
+		)
+		(fp_line
+			(start 1.93 1.2)
+			(end 1.95 1.35)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "e74ca03b-d32c-4dcf-8fd2-056ea12ef34c")
+		)
+		(fp_line
+			(start 1.92 1.93)
+			(end 1.85 1.99)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "005d0050-2970-4706-b2fe-f9948d4ddb1d")
+		)
+		(fp_line
+			(start 1.92 1.13)
+			(end 1.93 1.2)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "16b926a7-e97e-49a4-9070-78a6321d6c38")
+		)
+		(fp_line
+			(start 1.9 -1.43)
+			(end 1.89 -1.29)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "387766dd-476f-4033-9669-4d66b79541de")
+		)
+		(fp_line
+			(start 1.9 -1.59)
+			(end 1.9 -1.43)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "e06fea39-f189-433d-8415-b730ff18cd99")
+		)
+		(fp_line
+			(start 1.89 1.06)
+			(end 1.92 1.13)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "9345fe59-0066-43d1-9b58-2e1cc7a86a02")
+		)
+		(fp_line
+			(start 1.89 -1.29)
+			(end 1.86 -1.16)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "36333b33-d016-4087-9f12-8a31aef56f73")
+		)
+		(fp_line
+			(start 1.89 -1.74)
+			(end 1.9 -1.59)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "60cbe5bd-64ee-407e-88e5-901dcde5e239")
+		)
+		(fp_line
+			(start 1.88 -1.83)
+			(end 1.89 -1.74)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "8f7056de-56e9-4117-a103-95e3209faaa2")
+		)
+		(fp_line
+			(start 1.86 -1.16)
+			(end 1.8 -1.11)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "2d6a3dc8-1291-4175-906f-b6ff4f3b9c39")
+		)
+		(fp_line
+			(start 1.85 1.99)
+			(end 1.73 2.05)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "12f2a62f-d0be-4983-bdc8-1740cb43a463")
+		)
+		(fp_line
+			(start 1.82 1.02)
+			(end 1.89 1.06)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "933792b0-4e4a-4b69-9987-85a068db7471")
+		)
+		(fp_line
+			(start 1.82 -1.93)
+			(end 1.88 -1.83)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "9abadb39-bb7a-4b2c-8b05-862b8f2e4b74")
+		)
+		(fp_line
+			(start 1.77 -1.99)
+			(end 1.82 -1.93)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "25169a8c-fdd8-4219-982b-2898ad434a26")
+		)
+		(fp_line
+			(start 1.73 2.05)
+			(end 1.61 2.05)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "382f5790-587f-4a33-b6da-4775175bb66e")
+		)
+		(fp_line
+			(start 1.68 -2.02)
+			(end 1.77 -1.99)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "9e637217-d8a5-4c5e-9c2b-0c2d5787fd64")
+		)
+		(fp_line
+			(start 1.61 2.05)
+			(end 0.84 2.04)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "e43a1acf-1ea5-4838-ac62-8373eef1d9cb")
+		)
+		(fp_line
+			(start 0.84 1.02)
+			(end 1.07 1.02)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "d45f8b72-d21a-4489-b885-6d5d4913e98c")
+		)
+		(fp_line
+			(start 0.84 -1.1)
+			(end 1.06 -1.1)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "11e9e27e-acb8-4c8f-a679-6f81405415dd")
+		)
+		(fp_line
+			(start 0.84 -2.02)
+			(end 1.68 -2.02)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "15a67936-f78c-446d-901b-7d3338c06922")
+		)
+		(fp_line
+			(start 0.8 2.31)
+			(end 0.79 -2.34)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "d373c930-e3c4-42e2-8099-f4d7727b7938")
+		)
+		(fp_line
+			(start 0.44 2.31)
+			(end 0.42 0.13)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "1e0cbd7e-efb2-4f61-aba0-8c0479fed999")
+		)
+		(fp_line
+			(start 0.44 -0.21)
+			(end 0.43 -2.34)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "01584aa6-fb65-451d-ace9-3c9b97634d6c")
+		)
+		(fp_line
+			(start 0.42 0.13)
+			(end -0.48 0.12)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "870a7fe2-42dd-4a01-8a55-eab407d42441")
+		)
+		(fp_line
+			(start 0.39 2.02)
+			(end 0.17 2.02)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "babfd7c7-f79a-41cc-bd33-71c7069dc3f5")
+		)
+		(fp_line
+			(start 0.17 -2.03)
+			(end 0.41 -2.03)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "a1aca244-9bf6-45cd-85ba-d1324c2d5b8b")
+		)
+		(fp_line
+			(start 0.12 -0.19)
+			(end 0.44 -0.21)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "d6aa3a6d-3772-4153-83d6-4352b434120c")
+		)
+		(fp_line
+			(start -0.02 -1.1)
+			(end 0.41 -1.11)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "d8a0f32f-9fe3-4640-a124-b1d2a96a8ba1")
+		)
+		(fp_line
+			(start -0.16 -1.11)
+			(end -0.02 -1.1)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "1691e865-014e-4ccf-b177-492edb5c90b7")
+		)
+		(fp_line
+			(start -0.17 2.02)
+			(end -1.34 2.01)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "19dda7d3-646f-4b19-b662-e3e922d3d087")
+		)
+		(fp_line
+			(start -0.17 -2.03)
+			(end -0.25 -1.96)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "ad7cc16d-41f0-4898-9a75-e0fefbf1ed59")
+		)
+		(fp_line
+			(start -0.25 -1.15)
+			(end -0.16 -1.11)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "389dec7c-1174-42ab-acd5-0c5605bac516")
+		)
+		(fp_line
+			(start -0.25 -1.96)
+			(end -0.32 -1.87)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "5fce5857-bbf0-45cc-9c2c-96fc20d2f5a6")
+		)
+		(fp_line
+			(start -0.3 -1.24)
+			(end -0.25 -1.15)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "dde0d367-28d0-476d-b2dd-a53ab3038efe")
+		)
+		(fp_line
+			(start -0.32 -1.87)
+			(end -0.34 -1.69)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "1b4452e0-3306-40e8-80f1-a9abdb23817f")
+		)
+		(fp_line
+			(start -0.33 -1.47)
+			(end -0.3 -1.24)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "66ba36a2-5ec3-48c0-9be0-8444ab322026")
+		)
+		(fp_line
+			(start -0.34 -1.69)
+			(end -0.33 -1.47)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "b2ea6bc0-cff7-44c4-84ec-32a433466918")
+		)
+		(fp_line
+			(start -0.46 -0.21)
+			(end 0.12 -0.19)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "39263420-6aa1-4032-9e21-701a9a46042a")
+		)
+		(fp_line
+			(start -1.24 -1.92)
+			(end -1.3 -1.96)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "4b0669fc-4979-4cd8-bfaa-5855d13e272c")
+		)
+		(fp_line
+			(start -1.33 1.06)
+			(end 0.39 1.04)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "4668ce9a-787e-427e-97ba-8da894be4cf3")
+		)
+		(fp_line
+			(start -1.37 -0.37)
+			(end -1.44 -0.69)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "d8ce0f64-c3fb-4af3-916c-018067881ee9")
+		)
+		(fp_line
+			(start -1.38 2.31)
+			(end -1.38 2.09)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "34dfcb39-2e4e-45d8-8c80-38744da74dc2")
+		)
+		(fp_line
+			(start -1.38 2.09)
+			(end -1.39 1.9)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "a80cc13a-af7c-4cac-a855-9f3d051ab96c")
+		)
+		(fp_line
+			(start -1.38 1.14)
+			(end -1.39 0.35)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "cd9d34a7-dbe1-40a1-b843-1476fb62617e")
+		)
+		(fp_line
+			(start -1.44 -0.69)
+			(end -1.8 -0.71)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "9336eb96-aa89-4c85-9956-c11a66ba2245")
+		)
+		(fp_line
+			(start -1.46 -1.11)
+			(end -1.25 -1.23)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "d1acde26-4fa9-4ec5-a8ba-70c363edfdd3")
+		)
+		(fp_line
+			(start -1.67 -2.02)
+			(end -1.3 -1.96)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "0ffc73bf-7b27-4afc-8ed4-b95a8acb799b")
+		)
+		(fp_line
+			(start -1.7 1.15)
+			(end -1.7 0.34)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "dedc5b21-94a4-44bb-889c-09b2ee1bbc89")
+		)
+		(fp_line
+			(start -1.72 2.31)
+			(end -1.72 2.11)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "f1120ff8-4a47-48b1-a5b1-6307fc915336")
+		)
+		(fp_line
+			(start -1.72 2.11)
+			(end -1.7 1.9)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "55b3e0d4-e431-4ef9-b8bf-ecb793b2e083")
+		)
+		(fp_line
+			(start -1.76 -1.09)
+			(end -1.46 -1.11)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "025d45af-e6ef-4fac-87c9-c4f95aed293b")
+		)
+		(fp_line
+			(start -1.8 -0.71)
+			(end -2.09 -0.71)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "260789a6-5203-437b-922b-00a0cf04e701")
+		)
+		(fp_line
+			(start -1.87 1.06)
+			(end -1.74 1.06)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "02014df3-9ffb-4d15-86af-6fc3a92ae6bc")
+		)
+		(fp_line
+			(start -2 2.01)
+			(end -1.76 2)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "2af3ea22-5e13-4f6a-b0cb-437253196940")
+		)
+		(fp_line
+			(start -2.04 -2.01)
+			(end -1.67 -2.02)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "d6adaf4d-bd20-4652-ba05-e9e810ade7d5")
+		)
+		(fp_line
+			(start -2.05 -1.09)
+			(end -1.76 -1.09)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "ae413e42-c946-403b-a0bc-c8d2f034e4af")
+		)
+		(fp_line
+			(start -2.09 -0.71)
+			(end -2.1 -1.19)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "ad018f9a-19ab-4a91-97a1-272b77d29b13")
+		)
+		(fp_line
+			(start -2.09 -2.01)
+			(end -2.1 -2.35)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "eba3f837-db0c-4351-864f-13decbe63995")
+		)
+		(fp_line
+			(start -2.1 -1.93)
+			(end -2.09 -2.01)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "640844da-d6aa-43c7-b1c9-afc8aa801a3a")
+		)
+		(fp_line
+			(start -2.39 2)
+			(end -2 2.01)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "1f3278e5-e8e5-41e0-bcd3-b6313e2c83de")
+		)
+		(fp_line
+			(start -2.45 -0.81)
+			(end -2.45 -0.97)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "05b0c912-6df6-4656-b632-26cb62118ec6")
+		)
+		(fp_line
+			(start -2.45 -0.97)
+			(end -2.45 -1.09)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "0bfbb66e-d935-4c79-b2b8-e59c4393bd12")
+		)
+		(fp_line
+			(start -2.45 -1.09)
+			(end -2.46 -1.21)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "202b017f-69eb-4ff8-98e5-f63802863f23")
+		)
+		(fp_line
+			(start -2.45 -2.06)
+			(end -2.45 -2.25)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "4f061582-d79e-4495-945b-924bbe17a79b")
+		)
+		(fp_line
+			(start -2.45 -2.25)
+			(end -2.45 -2.35)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "24de0d4f-7c1b-4960-a0ab-3fe93abcfda7")
+		)
+		(fp_line
+			(start -2.46 -1.9)
+			(end -2.45 -2.06)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "7ec83ff1-a49b-4bee-87af-b95896091ae7")
+		)
+		(fp_line
+			(start -2.47 -0.7)
+			(end -2.45 -0.81)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "5f173d93-c570-4692-a328-bb1a9f5b01fa")
+		)
+		(fp_line
+			(start -2.54 -0.37)
+			(end -2.48 -0.32)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "07e45fab-896b-4664-aa60-53d5ee8c0f00")
+		)
+		(fp_line
+			(start -2.54 -0.37)
+			(end -3.63 -0.38)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "e9f65f29-8d43-4081-9e2b-892ddf1fadb7")
+		)
+		(fp_line
+			(start -2.57 1.98)
+			(end -2.39 2)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "254e3875-1e9d-4c2b-88c7-df54e582de1a")
+		)
+		(fp_line
+			(start -2.59 -1.14)
+			(end -2.46 -1.13)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "e86d504a-9b02-4425-af8a-ce80d50984f1")
+		)
+		(fp_line
+			(start -2.64 1.07)
+			(end -2.7 1.12)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "613b8a66-3266-4f74-8c45-3fedb8725916")
+		)
+		(fp_line
+			(start -2.68 -1.13)
+			(end -2.59 -1.14)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "fed26813-109e-44f1-9594-40cb6758a031")
+		)
+		(fp_line
+			(start -2.7 1.12)
+			(end -2.74 1.2)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "a593ad6e-30ed-4667-b4bc-ec1179f88199")
+		)
+		(fp_line
+			(start -2.74 1.2)
+			(end -2.75 1.33)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "13e24e70-21b6-47e8-935c-a8bc5aad77a8")
+		)
+		(fp_line
+			(start -2.75 1.88)
+			(end -2.57 1.98)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "0e2bfec5-9490-48b9-a4d2-8d595f4b2ff2")
+		)
+		(fp_line
+			(start -2.75 1.51)
+			(end -2.76 1.72)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "945b3aa4-31a0-4588-b189-f978efeed00a")
+		)
+		(fp_line
+			(start -2.75 1.33)
+			(end -2.75 1.51)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "36a8d3c2-235a-4086-882f-d5bf201cf3a2")
+		)
+		(fp_line
+			(start -2.76 1.72)
+			(end -2.75 1.88)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "49a2cdb3-f688-4f59-9e92-b2e4b9eca41d")
+		)
+		(fp_line
+			(start -2.82 -1.13)
+			(end -2.68 -1.13)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "7317c533-977a-40dd-8a1b-2702a7e0d1ba")
+		)
+		(fp_line
+			(start -2.9 -2)
+			(end -2.49 -2)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "b9a75e6a-7f33-416a-b8e5-c0c720d381b2")
+		)
+		(fp_line
+			(start -3.01 -1.14)
+			(end -2.82 -1.13)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "5b7da91b-e690-41ef-96f6-c11c727bd094")
+		)
+		(fp_line
+			(start -3.14 -1.14)
+			(end -3.01 -1.14)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "fc02cfa7-8535-487c-a09e-41d4b38bee27")
+		)
+		(fp_line
+			(start -3.22 -1.14)
+			(end -3.14 -1.14)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "f801272d-73f8-43f4-80f8-80c9501ebc7d")
+		)
+		(fp_line
+			(start -3.3 -1.17)
+			(end -3.22 -1.14)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "2b853d96-5495-4e11-850d-db6d7e4f8a37")
+		)
+		(fp_line
+			(start -3.32 -1.96)
+			(end -3.27 -1.99)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "117e4517-7571-4edd-a744-9ba6dd7d5902")
+		)
+		(fp_line
+			(start -3.35 -1.21)
+			(end -3.3 -1.17)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "45b1bbea-108a-4de8-a13d-1ae2f5fa667e")
+		)
+		(fp_line
+			(start -3.36 -0.7)
+			(end -2.47 -0.7)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "eb3c9e43-ae34-4f0a-80e3-817c76ecd5b4")
+		)
+		(fp_line
+			(start -3.38 -1.9)
+			(end -3.32 -1.96)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "91edaa6e-73cf-4465-b94f-3da943d9059c")
+		)
+		(fp_line
+			(start -3.41 -1.3)
+			(end -3.35 -1.21)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "bff2e42c-1c41-4da0-9050-48c64791106f")
+		)
+		(fp_line
+			(start -3.41 -1.84)
+			(end -3.38 -1.9)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "68218afd-a492-475e-b39d-e50bf47b08c9")
+		)
+		(fp_line
+			(start -3.43 -1.76)
+			(end -3.41 -1.84)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "c7760dcb-c461-4c37-a2c0-aad664305e57")
+		)
+		(fp_line
+			(start -3.44 -1.41)
+			(end -3.41 -1.3)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "582cef67-c880-467e-a142-825de33e2ab4")
+		)
+		(fp_line
+			(start -3.44 -1.69)
+			(end -3.43 -1.76)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "fcbfc281-86a3-4b43-a111-3c0ab4e31931")
+		)
+		(fp_line
+			(start -3.44 -1.69)
+			(end -3.44 -1.41)
+			(stroke
+				(width 0.075)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "5ee67e48-4c19-443b-b69d-89448b86a48a")
+		)
+		(fp_line
+			(start -3.51 -0.71)
+			(end -3.36 -0.7)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "10e1709b-72c6-41fc-84ed-88823d6e0a85")
+		)
+		(fp_line
+			(start -3.62 -0.7)
+			(end -3.51 -0.71)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "92e1790b-81a5-4452-bf3a-983f79a2d952")
+		)
+		(fp_line
+			(start -3.63 -0.38)
+			(end -3.76 -0.42)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "361307b1-1bea-49b2-a03c-f8ec09493d44")
+		)
+		(fp_line
+			(start -3.74 -0.66)
+			(end -3.62 -0.7)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "db7d51c6-1e9e-4da9-8772-ce2ec7d0f8ea")
+		)
+		(fp_line
+			(start -3.76 -0.42)
+			(end -3.8 -0.5)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "047c7238-7573-42fd-8588-a449086fbe22")
+		)
+		(fp_line
+			(start -3.78 -0.64)
+			(end -3.74 -0.66)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "32335e45-744a-4519-9aa5-e60e2de876b9")
+		)
+		(fp_line
+			(start -3.8 -0.5)
+			(end -3.8 -0.57)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "4e17ed71-f080-4950-bd71-4427b1f5cd16")
+		)
+		(fp_line
+			(start -3.8 -0.57)
+			(end -3.78 -0.64)
+			(stroke
+				(width 0.1)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "2a5d6c5b-f2ca-4e48-84ba-fbf96548ba06")
+		)
+		(fp_poly
+			(pts
+				(xy -3.11 -0.39) (xy -3.25 -0.53) (xy -3.09 -0.69) (xy -2.95 -0.49) (xy -3.1 -0.39)
+			)
+			(stroke
+				(width 0.01)
+				(type solid)
+			)
+			(fill yes)
+			(layer "B.SilkS")
+			(uuid "91add528-e13a-4a84-930f-e3c936631b19")
+		)
+		(fp_poly
+			(pts
+				(xy -3.76 2.65) (xy 3.86 2.65) (xy 3.89 2.54) (xy 3.91 2.45) (xy 3.89 2.37) (xy 3.85 2.33) (xy 3.74 2.31)
+				(xy 3.38 2.31) (xy 1.62 2.32) (xy 0.17 2.31) (xy 0.17 1.68) (xy 0.17 1.37) (xy 0.13 1.36) (xy 0.07 1.35)
+				(xy 0 1.34) (xy 0 1.42) (xy 0.05 1.43) (xy 0.09 1.45) (xy 0.11 1.49) (xy 0.12 1.53) (xy 0.11 1.58)
+				(xy 0.09 1.61) (xy 0.06 1.64) (xy 0.02 1.66) (xy 0 1.66) (xy -0.05 1.65) (xy -0.08 1.63) (xy -0.11 1.6)
+				(xy -0.12 1.55) (xy -0.11 1.49) (xy -0.09 1.46) (xy -0.06 1.43) (xy -0.02 1.42) (xy 0 1.42) (xy 0 1.34)
+				(xy -0.15 1.36) (xy -0.17 1.37) (xy -0.17 2.31) (xy -3.52 2.31) (xy -3.75 2.32) (xy -3.79 2.37)
+				(xy -3.8 2.41) (xy -3.8 2.47)
+			)
+			(stroke
+				(width 0)
+				(type solid)
+			)
+			(fill yes)
+			(layer "B.SilkS")
+			(uuid "a74b40fd-5140-4c1f-aa96-3b3211149c16")
+		)
+		(fp_poly
+			(pts
+				(xy -3.77 -2.65) (xy 3.87 -2.65) (xy 3.87 -2.35) (xy 0.17 -2.34) (xy 0.17 -1.7) (xy 0.16 -1.47)
+				(xy 0.13 -1.36) (xy 0 -1.36) (xy 0 -1.45) (xy 0.04 -1.45) (xy 0.07 -1.47) (xy 0.1 -1.5) (xy 0.11 -1.53)
+				(xy 0.12 -1.57) (xy 0.11 -1.62) (xy 0.08 -1.66) (xy 0.04 -1.68) (xy 0 -1.69) (xy -0.05 -1.68) (xy -0.09 -1.65)
+				(xy -0.11 -1.61) (xy -0.12 -1.57) (xy -0.11 -1.51) (xy -0.09 -1.48) (xy -0.05 -1.46) (xy -0.02 -1.45)
+				(xy 0 -1.45) (xy 0 -1.36) (xy -0.13 -1.36) (xy -0.15 -1.44) (xy -0.17 -1.53) (xy -0.18 -1.79) (xy -0.17 -2.15)
+				(xy -0.17 -2.34) (xy -2.9 -2.35) (xy -2.9 -2.08) (xy -2.9 -1.83) (xy -2.9 -1.61) (xy -2.92 -1.37)
+				(xy -3.1 -1.37) (xy -3.1 -1.44) (xy -3.06 -1.45) (xy -3.02 -1.48) (xy -2.99 -1.53) (xy -2.98 -1.58)
+				(xy -2.99 -1.62) (xy -3.01 -1.65) (xy -3.05 -1.68) (xy -3.1 -1.69) (xy -3.14 -1.68) (xy -3.18 -1.65)
+				(xy -3.21 -1.61) (xy -3.22 -1.56) (xy -3.21 -1.51) (xy -3.17 -1.47) (xy -3.12 -1.45) (xy -3.1 -1.44)
+				(xy -3.1 -1.37) (xy -3.26 -1.37) (xy -3.27 -1.53) (xy -3.28 -1.78) (xy -3.27 -2.19) (xy -3.28 -2.34)
+				(xy -3.52 -2.34) (xy -3.77 -2.35)
+			)
+			(stroke
+				(width 0.01)
+				(type solid)
+			)
+			(fill yes)
+			(layer "B.SilkS")
+			(uuid "c3f95adc-63c5-44ec-bd61-594573e200c5")
+		)
+		(fp_poly
+			(pts
+				(xy 1.44 -1.85) (xy 1.44 -1.95) (xy 1.5 -1.95) (xy 1.58 -1.94) (xy 1.64 -1.92) (xy 1.69 -1.89) (xy 1.74 -1.85)
+				(xy 1.78 -1.8) (xy 1.8 -1.75) (xy 1.81 -1.72) (xy 1.82 -1.64) (xy 1.83 -1.43) (xy 1.82 -1.11) (xy 1.82 -0.39)
+				(xy 2.37 -0.39) (xy 2.85 -0.4) (xy 2.85 -1.72) (xy 2.85 -1.77) (xy 2.86 -1.8) (xy 2.89 -1.84) (xy 2.93 -1.87)
+				(xy 2.97 -1.89) (xy 3.03 -1.9) (xy 3.17 -1.9) (xy 3.33 -1.9) (xy 3.42 -1.89) (xy 3.46 -1.88) (xy 3.5 -1.85)
+				(xy 3.52 -1.83) (xy 3.54 -1.79) (xy 3.56 -1.75) (xy 3.58 -1.65) (xy 3.59 -1.53) (xy 3.59 -0.56)
+				(xy 3.58 -0.51) (xy 3.56 -0.31) (xy 3.56 0) (xy 3.49 0) (xy 3.48 -0.09) (xy 3.45 -0.15) (xy 3.41 -0.2)
+				(xy 3.37 -0.23) (xy 3.3 -0.27) (xy 3.21 -0.29) (xy 3.17 -0.29) (xy 3.11 -0.28) (xy 3.07 -0.26) (xy 3.02 -0.22)
+				(xy 2.98 -0.18) (xy 2.95 -0.13) (xy 2.93 -0.07) (xy 2.93 0.02) (xy 2.94 0.08) (xy 2.98 0.15) (xy 3.03 0.21)
+				(xy 3.08 0.24) (xy 3.15 0.26) (xy 3.2 0.26) (xy 3.26 0.25) (xy 3.3 0.24) (xy 3.36 0.21) (xy 3.41 0.17)
+				(xy 3.45 0.12) (xy 3.47 0.08) (xy 3.48 0.05) (xy 3.49 0) (xy 3.56 0) (xy 3.56 0.26) (xy 3.57 0.41)
+				(xy 3.58 0.5) (xy 3.59 0.55) (xy 3.59 1.56) (xy 3.58 1.65) (xy 3.56 1.74) (xy 3.54 1.79) (xy 3.51 1.82)
+				(xy 3.45 1.87) (xy 3.39 1.9) (xy 3.34 1.91) (xy 3.26 1.92) (xy 3.15 1.91) (xy 3.01 1.89) (xy 2.96 1.88)
+				(xy 2.92 1.86) (xy 2.88 1.82) (xy 2.85 1.77) (xy 2.83 1.71) (xy 2.82 1.62) (xy 2.83 1.55) (xy 2.83 0.37)
+				(xy 2.3 0.36) (xy 1.82 0.37) (xy 1.83 1.53) (xy 1.73 1.53) (xy 1.72 1.45) (xy 1.7 1.41) (xy 1.69 1.4)
+				(xy 1.67 1.37) (xy 1.61 1.33) (xy 1.54 1.3) (xy 1.49 1.29) (xy 1.4 1.29) (xy 1.35 1.3) (xy 1.28 1.33)
+				(xy 1.24 1.36) (xy 1.19 1.41) (xy 1.17 1.45) (xy 1.16 1.5) (xy 1.17 1.58) (xy 1.2 1.68) (xy 1.23 1.75)
+				(xy 1.39 1.81) (xy 1.43 1.82) (xy 1.52 1.81) (xy 1.61 1.77) (xy 1.67 1.71) (xy 1.71 1.64) (xy 1.72 1.6)
+				(xy 1.73 1.53) (xy 1.83 1.53) (xy 1.83 1.67) (xy 1.82 1.74) (xy 1.81 1.77) (xy 1.78 1.82) (xy 1.73 1.87)
+				(xy 1.68 1.9) (xy 1.62 1.92) (xy 1.41 1.93) (xy 1.37 1.93) (xy 1.27 1.92) (xy 1.22 1.9) (xy 1.15 1.86)
+				(xy 1.11 1.81) (xy 1.09 1.77) (xy 1.07 1.69) (xy 1.06 1.61) (xy 1.06 1.5) (xy 1.06 1.27) (xy 1.06 1.05)
+				(xy 1.06 -1.62) (xy 1.07 -1.75) (xy 1.09 -1.8) (xy 1.14 -1.86) (xy 1.18 -1.89) (xy 1.27 -1.93) (xy 1.39 -1.95)
+				(xy 1.44 -1.95) (xy 1.44 -1.85) (xy 1.37 -1.84) (xy 1.32 -1.82) (xy 1.26 -1.78) (xy 1.21 -1.72)
+				(xy 1.17 -1.63) (xy 1.16 -1.55) (xy 1.18 -1.45) (xy 1.23 -1.39) (xy 1.29 -1.35) (xy 1.38 -1.32)
+				(xy 1.46 -1.31) (xy 1.57 -1.34) (xy 1.63 -1.37) (xy 1.68 -1.41) (xy 1.71 -1.46) (xy 1.73 -1.53)
+				(xy 1.73 -1.56) (xy 1.72 -1.64) (xy 1.69 -1.71) (xy 1.64 -1.77) (xy 1.6 -1.8) (xy 1.54 -1.83) (xy 1.5 -1.84)
+			)
+			(stroke
+				(width 0.01)
+				(type solid)
+			)
+			(fill yes)
+			(layer "B.SilkS")
+			(uuid "aed4c667-c404-46da-9525-bed1f005139d")
+		)
+		(fp_poly
+			(pts
+				(xy -1.55 -1.95) (xy -0.87 -1.95) (xy -0.76 -1.94) (xy -0.68 -1.93) (xy -0.63 -1.92) (xy -0.61 -1.91)
+				(xy -0.56 -1.88) (xy -0.52 -1.84) (xy -0.47 -1.78) (xy -0.46 -1.71) (xy -0.44 -1.48) (xy -0.44 -0.73)
+				(xy -0.45 -0.58) (xy -0.46 -0.41) (xy -0.46 -0.02) (xy -0.45 0.13) (xy -0.47 0.18) (xy -0.5 0.23)
+				(xy -0.53 0.27) (xy -0.59 0.32) (xy -0.66 0.35) (xy -0.75 0.36) (xy -0.79 0.36) (xy -0.79 0.27)
+				(xy -0.73 0.26) (xy -0.68 0.23) (xy -0.64 0.19) (xy -0.59 0.12) (xy -0.56 0.02) (xy -0.56 -0.06)
+				(xy -0.58 -0.13) (xy -0.6 -0.16) (xy -0.64 -0.21) (xy -0.71 -0.25) (xy -0.76 -0.27) (xy -0.84 -0.28)
+				(xy -0.91 -0.27) (xy -0.97 -0.25) (xy -1.02 -0.21) (xy -1.07 -0.14) (xy -1.09 -0.09) (xy -1.09 0.01)
+				(xy -1.07 0.09) (xy -1.02 0.2) (xy -0.9 0.25) (xy -0.81 0.27) (xy -0.79 0.27) (xy -0.79 0.36) (xy -1.04 0.37)
+				(xy -1.29 0.36) (xy -1.65 0.34) (xy -1.88 0.35) (xy -1.88 0.59) (xy -1.89 0.84) (xy -1.86 1.12)
+				(xy -1.85 1.14) (xy -1.8 1.16) (xy -1.66 1.15) (xy -1.3 1.15) (xy -0.97 1.13) (xy -0.79 1.13) (xy -0.72 1.14)
+				(xy -0.62 1.17) (xy -0.58 1.19) (xy -0.51 1.26) (xy -0.47 1.33) (xy -0.45 1.4) (xy -0.44 1.45) (xy -0.43 1.55)
+				(xy -0.44 1.64) (xy -0.45 1.69) (xy -0.47 1.75) (xy -0.51 1.81) (xy -0.55 1.85) (xy -0.62 1.89)
+				(xy -0.7 1.91) (xy -0.84 1.92) (xy -1.08 1.92) (xy -1.35 1.9) (xy -1.56 1.89) (xy -1.77 1.9) (xy -1.92 1.91)
+				(xy -2.17 1.92) (xy -2.39 1.91) (xy -2.46 1.9) (xy -2.49 1.89) (xy -2.54 1.87) (xy -2.56 1.86) (xy -2.6 1.83)
+				(xy -2.64 1.77) (xy -2.65 1.72) (xy -2.66 1.55) (xy -2.54 1.55) (xy -2.53 1.63) (xy -2.5 1.69) (xy -2.46 1.74)
+				(xy -2.39 1.79) (xy -2.34 1.81) (xy -2.28 1.82) (xy -2.21 1.81) (xy -2.14 1.78) (xy -2.08 1.74)
+				(xy -2.03 1.67) (xy -2 1.61) (xy -1.99 1.56) (xy -1.99 1.49) (xy -2.01 1.42) (xy -2.06 1.35) (xy -2.11 1.3)
+				(xy -2.18 1.27) (xy -2.25 1.26) (xy -2.32 1.27) (xy -2.39 1.29) (xy -2.46 1.32) (xy -2.48 1.34)
+				(xy -2.5 1.39) (xy -2.53 1.46) (xy -2.54 1.51) (xy -2.54 1.55) (xy -2.66 1.55) (xy -2.65 1.34) (xy -2.64 1.09)
+				(xy -2.64 -0.16) (xy -2.62 -0.22) (xy -2.58 -0.29) (xy -2.53 -0.37) (xy -1.39 -0.37) (xy -1.25 -0.38)
+				(xy -1.2 -0.39) (xy -1.2 -0.49) (xy -1.2 -1.17) (xy -1.31 -1.15) (xy -1.52 -1.18) (xy -2.19 -1.19)
+				(xy -2.45 -1.17) (xy -2.58 -1.29) (xy -2.64 -1.36) (xy -2.67 -1.53) (xy -2.67 -1.59) (xy -2.66 -1.68)
+				(xy -2.64 -1.76) (xy -2.62 -1.8) (xy -2.55 -1.87) (xy -2.47 -1.94) (xy -2.39 -1.93) (xy -2.19 -1.92)
+				(xy -1.92 -1.94) (xy -1.58 -1.95) (xy -1.58 -1.85) (xy -1.63 -1.84) (xy -1.69 -1.81) (xy -1.72 -1.79)
+				(xy -1.77 -1.71) (xy -1.8 -1.64) (xy -1.81 -1.56) (xy -1.79 -1.47) (xy -1.75 -1.4) (xy -1.72 -1.36)
+				(xy -1.65 -1.31) (xy -1.6 -1.29) (xy -1.54 -1.28) (xy -1.45 -1.3) (xy -1.39 -1.34) (xy -1.34 -1.39)
+				(xy -1.3 -1.46) (xy -1.28 -1.53) (xy -1.28 -1.59) (xy -1.29 -1.65) (xy -1.32 -1.7) (xy -1.34 -1.73)
+				(xy -1.39 -1.79) (xy -1.45 -1.83) (xy -1.49 -1.84) (xy -1.55 -1.85) (xy -1.58 -1.85) (xy -1.58 -1.95)
+			)
+			(stroke
+				(width 0.01)
+				(type solid)
+			)
+			(fill yes)
+			(layer "B.SilkS")
+			(uuid "e7cd7f66-939a-4e7c-ba8b-2d42622dc787")
+		)
+		(fp_line
+			(start 3.560017 0.152958)
+			(end 3.560017 0.152958)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5adc2d5f-862b-4369-bb72-07f5e35bc65e")
+		)
+		(fp_line
+			(start 3.096466 0.245386)
+			(end 3.096466 0.245386)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d5032a0c-89ad-4952-9e85-cd37b232d8ac")
+		)
+		(fp_line
+			(start 1.330461 -1.336117)
+			(end 1.330461 -1.336117)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "588d68e2-a0bb-4412-84ea-265c20b19f77")
+		)
+		(fp_line
+			(start 1.330461 -1.336117)
+			(end 1.330461 -1.336117)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "959e19de-52b7-470b-b46d-a4a01768c9a0")
+		)
+		(fp_line
+			(start 1.234153 1.749983)
+			(end 1.234153 1.749983)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "1558524a-dc8a-41f9-a1b9-b02856579012")
+		)
+		(fp_line
+			(start 0.798472 2.0061)
+			(end 0.798472 2.0061)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "e39cf545-82e1-440e-a280-71cd9bf2667e")
+		)
+		(fp_line
+			(start 0.798472 -1.097639)
+			(end 0.798472 -1.097639)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0308bff9-b47b-4adf-8825-47d667ce35f1")
+		)
+		(fp_line
+			(start 0.435464 2.315133)
+			(end 0.435464 2.315133)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a771d686-0fb7-4cb5-b88b-03e8a5eb8803")
+		)
+		(fp_line
+			(start -0.040081 1.650147)
+			(end -0.040081 1.650147)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "23c119a9-3026-4666-9013-61cefd18f877")
+		)
+		(fp_line
+			(start -0.040081 1.650147)
+			(end -0.040081 1.650147)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a23e7684-12bd-4f97-95d1-b26f90bbbf97")
+		)
+		(fp_line
+			(start -0.040081 -1.45465)
+			(end -0.040081 -1.45465)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "4c555fef-659c-41cb-a328-f96f76d94d71")
+		)
+		(fp_line
+			(start -0.040081 -1.45465)
+			(end -0.040081 -1.45465)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "61320728-177e-49db-9423-79a67cace120")
+		)
+		(fp_line
+			(start -0.320539 -1.308953)
+			(end -0.320539 -1.308953)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "75fe45ac-f396-4b3e-a84f-997be499cdee")
+		)
+		(fp_line
+			(start -1.025036 0.19882)
+			(end -1.025036 0.19882)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "efa83280-3449-4b3c-bd4c-f47653310bef")
+		)
+		(fp_line
+			(start -1.385575 1.107928)
+			(end -1.386633 1.154847)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "99d81d1a-fbeb-4cb9-8a16-077e213e4247")
+		)
+		(fp_line
+			(start -1.385928 1.97435)
+			(end -1.385928 1.97435)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "eb50bc56-ef51-4335-8e21-b7363071b7be")
+		)
+		(fp_line
+			(start -1.386633 1.154847)
+			(end -1.385575 1.107928)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "854ab85c-bfbc-466f-8572-f358320ac191")
+		)
+		(fp_line
+			(start -1.633225 -1.301544)
+			(end -1.633225 -1.301544)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "3854bf45-0401-4421-b349-3606e799f5bd")
+		)
+		(fp_line
+			(start -1.633225 -1.301544)
+			(end -1.633225 -1.301544)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d7f1f373-e1dc-412a-955d-b5cc2da139e7")
+		)
+		(fp_line
+			(start -1.698842 1.132975)
+			(end -1.699195 1.154142)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d3999714-fbc3-4248-8bc9-5e2b5088de73")
+		)
+		(fp_line
+			(start -1.699195 1.154142)
+			(end -1.698842 1.132975)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5c041ad8-c3f4-42ea-9992-7d4647b1db8e")
+		)
+		(fp_line
+			(start -1.699195 1.154142)
+			(end -1.699195 1.154142)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c3739eb0-6e08-4dd9-9d66-8e6467e86847")
+		)
+		(fp_line
+			(start -1.717539 2.314075)
+			(end -1.717539 2.314075)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "157c31ad-6b5d-4e97-b4c0-45ee289a0341")
+		)
+		(fp_line
+			(start -1.861825 1.115689)
+			(end -1.861825 1.115689)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "db0ddff1-b578-446b-9ebd-23462f51c450")
+		)
+		(fp_line
+			(start -2.095364 -1.102578)
+			(end -2.095364 -1.102578)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "57aeea43-dfb5-40ed-8a4a-a71b878c3f69")
+		)
+		(fp_line
+			(start -2.09607 -1.925608)
+			(end -2.09607 -1.925608)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "db01c0aa-b5d7-4bae-8faa-4d853a52d06e")
+		)
+		(fp_line
+			(start -2.447083 -1.138208)
+			(end -2.456608 -1.172075)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5cd5b9a7-e0eb-482c-8122-e40155e5d278")
+		)
+		(fp_line
+			(start -2.456608 -1.172075)
+			(end -2.447083 -1.138208)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5875245a-62f3-468a-8821-6f18e29357c1")
+		)
+		(fp_line
+			(start -2.468956 -1.945011)
+			(end -2.468956 -1.945011)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ddcfee08-93f6-46d2-affe-57a8ae1c1fb2")
+		)
+		(fp_line
+			(start -2.541628 1.520678)
+			(end -2.541628 1.520678)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "22394566-24e2-418f-9fa9-597154ccaad2")
+		)
+		(fp_line
+			(start -2.719428 1.890389)
+			(end -2.719428 1.890389)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5d336ab9-0055-4ec9-becb-b198f99ab4b2")
+		)
+		(fp_line
+			(start -3.072911 -0.369153)
+			(end -3.072911 -0.369153)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "034c683c-0920-4609-9c64-8376eb8138f4")
+		)
+		(fp_line
+			(start -3.072911 -0.369153)
+			(end -3.098311 -0.387497)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "e62e01d6-7365-465f-b96b-daebe1c658b6")
+		)
+		(fp_line
+			(start -3.098311 -0.387497)
+			(end -3.072911 -0.369153)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c0ce068c-181a-4af3-a01e-c3d36caa3e1d")
+		)
+		(fp_line
+			(start -3.142761 -1.457825)
+			(end -3.142761 -1.457825)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0f9ebfa2-c9c1-411d-8ec3-73e83ebbe85b")
+		)
+		(fp_line
+			(start -3.254239 -0.526492)
+			(end -3.254239 -0.526492)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d56b3297-7565-425f-8d73-40d33f1173a7")
+		)
+		(fp_line
+			(start -3.42957 -1.342114)
+			(end -3.42957 -1.342114)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "15ce16fe-32a9-4a27-9eb8-9913f4f66b45")
+		)
+		(fp_line
+			(start -3.683922 -0.700764)
+			(end -3.683922 -0.700764)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "eb781c4a-b097-4ad6-918a-c27520785d99")
+		)
+		(fp_line
+			(start -4.075858 2.931083)
+			(end -4.069156 2.931083)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "8e15f6db-b6eb-4a19-9cb2-87ffe794c11d")
+		)
+		(fp_line
+			(start -4.075858 2.931083)
+			(end -4.075858 2.931083)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d090696d-bcd7-4de5-93d4-5ff8d198e88a")
+		)
+		(fp_line
+			(start -4.075858 2.928967)
+			(end -4.075858 2.931083)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "9feea498-6425-40ec-b12a-98fa6ba6fd2a")
+		)
+		(fp_curve
+			(pts
+				(xy 3.873283 -2.35) (xy 3.873989 -2.450542) (xy 3.873636 -2.55073) (xy 3.872225 -2.651272)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "2cf6062a-efd5-4d2f-aecb-999fc6c83026")
+		)
+		(fp_curve
+			(pts
+				(xy 3.872225 -2.651272) (xy 2.610692 -2.661503) (xy 1.348805 -2.652683) (xy 0.086919 -2.655505)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "8cb38348-dc6d-4941-a2f8-82e02b0ebf02")
+		)
+		(fp_curve
+			(pts
+				(xy 3.86658 -0.13385) (xy 3.794967 -0.224867) (xy 3.6595 -0.170186) (xy 3.560017 -0.18218)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "564e8464-eb4f-4118-9f99-74e6ee007120")
+		)
+		(fp_curve
+			(pts
+				(xy 3.865522 2.652742) (xy 3.87928 2.547614) (xy 3.9516 2.413206) (xy 3.856703 2.327128)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "9aecf125-0692-41a1-87a3-e7199d7057bc")
+		)
+		(fp_curve
+			(pts
+				(xy 3.856703 2.327128) (xy 3.812253 2.318661) (xy 3.76745 2.314075) (xy 3.722294 2.313722)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "06816702-30e8-4ab2-a20f-c05ce50a9c6c")
+		)
+		(fp_curve
+			(pts
+				(xy 3.821072 0.147667) (xy 3.911736 0.088047) (xy 3.877517 -0.042833) (xy 3.86658 -0.13385)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "2bdb641f-4250-4db9-933a-2274ee0ff383")
+		)
+		(fp_curve
+			(pts
+				(xy 3.722294 2.313722) (xy 2.746864 2.316192) (xy 1.77108 2.315839) (xy 0.79565 2.314075)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "db1e65f8-8cc2-4d89-a9a2-2679c5f642f3")
+		)
+		(fp_curve
+			(pts
+				(xy 3.586828 -1.514269) (xy 3.581536 -1.647267) (xy 3.585417 -1.809544) (xy 3.451714 -1.883275)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "33cc9aae-1746-4bc1-bc9d-b052411e78e6")
+		)
+		(fp_curve
+			(pts
+				(xy 3.586475 1.555603) (xy 3.583653 1.214467) (xy 3.586475 0.873331) (xy 3.585417 0.532194)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "8dad50af-b30d-4ee0-967a-eea311e064ce")
+		)
+		(fp_curve
+			(pts
+				(xy 3.585417 0.532194) (xy 3.567425 0.406606) (xy 3.558253 0.279958) (xy 3.560017 0.152958)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "7aad59c5-5af0-42e1-9f39-83d2c36eacc9")
+		)
+		(fp_curve
+			(pts
+				(xy 3.585064 -0.561417) (xy 3.58718 -0.878917) (xy 3.582947 -1.196417) (xy 3.586828 -1.514269)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "80b4067c-ba69-431d-8ad9-50299c6da5a5")
+		)
+		(fp_curve
+			(pts
+				(xy 3.560017 0.152958) (xy 3.6468 0.154722) (xy 3.734642 0.161425) (xy 3.821072 0.147667)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "649da55e-5d8b-43ce-8659-023ca42b2fcc")
+		)
+		(fp_curve
+			(pts
+				(xy 3.560017 0.152958) (xy 3.558605 0.041481) (xy 3.558605 -0.07035) (xy 3.560017 -0.18218)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a357ccab-6b03-4471-947b-b1c5d4cb0716")
+		)
+		(fp_curve
+			(pts
+				(xy 3.560017 -0.18218) (xy 3.558253 -0.30918) (xy 3.566719 -0.435828) (xy 3.585064 -0.561417)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "88810552-46ea-4c7e-a639-7053f4cab6c5")
+		)
+		(fp_curve
+			(pts
+				(xy 3.560017 -0.18218) (xy 3.558605 -0.07035) (xy 3.558605 0.041481) (xy 3.560017 0.152958)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "08634710-b45a-4b3e-8870-6275a71f2748")
+		)
+		(fp_curve
+			(pts
+				(xy 3.487344 1.844175) (xy 3.579772 1.780322) (xy 3.57695 1.656145) (xy 3.586475 1.555603)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "4fe0d1be-b6e9-4934-9588-2892bc5a8303")
+		)
+		(fp_curve
+			(pts
+				(xy 3.487344 0.002675) (xy 3.483817 0.182592) (xy 3.256275 0.303947) (xy 3.096466 0.245386)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "f28f5e94-1b36-434f-ab57-004ba76fe42f")
+		)
+		(fp_curve
+			(pts
+				(xy 3.487344 0.002675) (xy 3.516272 -0.2291) (xy 3.165964 -0.392789) (xy 3.010036 -0.213578)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "b71cf967-3036-43f2-b9c0-d1d659a4d7d3")
+		)
+		(fp_curve
+			(pts
+				(xy 3.451714 -1.883275) (xy 3.320128 -1.913261) (xy 3.182897 -1.894917) (xy 3.048842 -1.898444)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "922d5581-988d-45db-af6d-d8451d39f506")
+		)
+		(fp_curve
+			(pts
+				(xy 3.096466 0.245386) (xy 3.256275 0.303947) (xy 3.483817 0.182592) (xy 3.487344 0.002675)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "2ef3f25f-a090-4ef7-9fec-b45a2f716241")
+		)
+		(fp_curve
+			(pts
+				(xy 3.096466 0.245386) (xy 2.919019 0.174478) (xy 2.86328 -0.085167) (xy 3.010036 -0.213578)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a1be77ba-e49b-412f-959f-18b6d624eed0")
+		)
+		(fp_curve
+			(pts
+				(xy 3.048842 -1.898444) (xy 2.950769 -1.906911) (xy 2.833294 -1.831769) (xy 2.849522 -1.723467)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "e58064ba-70af-4595-ae61-7de59293e07d")
+		)
+		(fp_curve
+			(pts
+				(xy 3.010036 -0.213578) (xy 3.165964 -0.392789) (xy 3.516272 -0.2291) (xy 3.487344 0.002675)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "acad2b67-99be-43f6-b3a1-26069c98d301")
+		)
+		(fp_curve
+			(pts
+				(xy 3.010036 -0.213578) (xy 2.86328 -0.085167) (xy 2.919019 0.174478) (xy 3.096466 0.245386)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "93a02bc6-8906-4025-ada9-6e92899e8e45")
+		)
+		(fp_curve
+			(pts
+				(xy 2.972289 1.885097) (xy 3.141269 1.903795) (xy 3.341647 1.965178) (xy 3.487344 1.844175)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "8c757832-dd3d-47e8-a125-248dc1a152e5")
+		)
+		(fp_curve
+			(pts
+				(xy 2.849522 -1.723467) (xy 2.848464 -1.281789) (xy 2.853403 -0.840111) (xy 2.847758 -0.398786)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "bfa35b7c-b83a-436d-baff-df66b9183500")
+		)
+		(fp_curve
+			(pts
+				(xy 2.847758 -0.398786) (xy 2.506269 -0.388555) (xy 2.16478 -0.395964) (xy 1.823292 -0.3942)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "eacb197d-ca98-42d1-8b36-1a8d7f6e8f7a")
+		)
+		(fp_curve
+			(pts
+				(xy 2.82765 1.553133) (xy 2.807189 1.6759) (xy 2.841761 1.838883) (xy 2.972289 1.885097)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "44d8cd0e-8b58-487d-bf67-ce57763b36e8")
+		)
+		(fp_curve
+			(pts
+				(xy 2.826592 0.367447) (xy 2.828355 0.762558) (xy 2.82518 1.158022) (xy 2.82765 1.553133)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "f7ca421b-44e4-4888-8702-c0af413e5936")
+		)
+		(fp_curve
+			(pts
+				(xy 1.907605 1.342172) (xy 1.903725 1.241278) (xy 1.926303 1.118158) (xy 1.827525 1.052895)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ea54b43d-d8e0-4a2a-89d0-7657a040d297")
+		)
+		(fp_curve
+			(pts
+				(xy 1.900903 1.8283) (xy 1.914661 1.666728) (xy 1.903019 1.504097) (xy 1.907605 1.342172)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "481dbf23-3118-41e4-9ea9-ebc584295573")
+		)
+		(fp_curve
+			(pts
+				(xy 1.877267 -1.760508) (xy 1.882205 -1.887508) (xy 1.765436 -2.003219) (xy 1.638789 -1.999339)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ddcb4557-eb3c-46fa-9dc6-4a90658359c0")
+		)
+		(fp_curve
+			(pts
+				(xy 1.827525 1.692481) (xy 1.835992 1.479403) (xy 1.828936 1.265972) (xy 1.827525 1.052895)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "2780655d-e5ca-432e-8aab-55ffd2839abd")
+		)
+		(fp_curve
+			(pts
+				(xy 1.827525 1.692481) (xy 1.823644 1.823008) (xy 1.696292 1.929195) (xy 1.568233 1.92355)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "978445a4-0557-4c99-9f0d-8543a1605f34")
+		)
+		(fp_curve
+			(pts
+				(xy 1.827525 1.052895) (xy 1.828936 1.265972) (xy 1.835992 1.479403) (xy 1.827525 1.692481)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "16d1dc61-56b3-48f9-b9de-d4b27d14d0cd")
+		)
+		(fp_curve
+			(pts
+				(xy 1.827525 1.052895) (xy 1.82188 0.823942) (xy 1.822939 0.594989) (xy 1.824703 0.366036)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0348f91d-7458-4341-94a2-43d4b0b1c140")
+		)
+		(fp_curve
+			(pts
+				(xy 1.824703 0.366036) (xy 2.15843 0.36392) (xy 2.492511 0.361803) (xy 2.826592 0.367447)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0079b1f7-597b-41bb-9314-b125144afbca")
+		)
+		(fp_curve
+			(pts
+				(xy 1.823292 -0.3942) (xy 1.823292 -0.624211) (xy 1.825408 -0.853869) (xy 1.822939 -1.08388)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "264a35fa-76a7-49ad-a910-ccde1cc920e8")
+		)
+		(fp_curve
+			(pts
+				(xy 1.822939 -1.08388) (xy 1.916778 -1.296958) (xy 1.875503 -1.535436) (xy 1.877267 -1.760508)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "f16a2333-4f9f-4823-adf7-6189e7ff8eb3")
+		)
+		(fp_curve
+			(pts
+				(xy 1.822939 -1.08388) (xy 1.816589 -1.284964) (xy 1.839519 -1.487458) (xy 1.814119 -1.687836)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "18beaf1a-d8b4-4873-90b8-818319ddebd2")
+		)
+		(fp_curve
+			(pts
+				(xy 1.814119 -1.687836) (xy 1.839519 -1.487458) (xy 1.816589 -1.284964) (xy 1.822939 -1.08388)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "450d7683-6b91-40c6-947b-a3ca4af5a488")
+		)
+		(fp_curve
+			(pts
+				(xy 1.814119 -1.687836) (xy 1.801419 -1.842) (xy 1.647961 -1.951714) (xy 1.499089 -1.94748)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "9d95a6f2-fad4-43e9-a778-d99f02fbc915")
+		)
+		(fp_curve
+			(pts
+				(xy 1.725572 1.519267) (xy 1.739683 1.668492) (xy 1.613742 1.817364) (xy 1.461694 1.815953)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "3e4fd603-3b0b-47ba-bc6e-022d83eb7764")
+		)
+		(fp_curve
+			(pts
+				(xy 1.725572 1.519267) (xy 1.73933 1.366514) (xy 1.558355 1.279378) (xy 1.427122 1.286081)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c9d755d0-f481-4b2f-b9b9-15eb4af7bd92")
+		)
+		(fp_curve
+			(pts
+				(xy 1.724867 -1.583061) (xy 1.763319 -1.378097) (xy 1.493797 -1.263444) (xy 1.330461 -1.336117)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "79ac9d5b-7b02-4daf-b82a-d3f58edb40b2")
+		)
+		(fp_curve
+			(pts
+				(xy 1.724867 -1.583061) (xy 1.726983 -1.805311) (xy 1.426769 -1.932664) (xy 1.26555 -1.782733)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "2b54ea83-44d6-4456-b754-ab44552e3fa9")
+		)
+		(fp_curve
+			(pts
+				(xy 1.676183 1.998692) (xy 1.778842 2.006806) (xy 1.889614 1.934839) (xy 1.900903 1.8283)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ac0d1e61-7e2a-4b40-a15b-a2179af49376")
+		)
+		(fp_curve
+			(pts
+				(xy 1.638789 -1.999339) (xy 1.359036 -2.004631) (xy 1.079283 -1.999339) (xy 0.799178 -2.002867)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d8c16132-42a6-4857-ad9e-fed39085cee7")
+		)
+		(fp_curve
+			(pts
+				(xy 1.568233 1.92355) (xy 1.696292 1.929195) (xy 1.823644 1.823008) (xy 1.827525 1.692481)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0acfcc66-16e5-4af1-9c35-0ae552fa03cb")
+		)
+		(fp_curve
+			(pts
+				(xy 1.568233 1.92355) (xy 1.398547 1.929547) (xy 1.163597 1.960945) (xy 1.087044 1.764095)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "09bf51ab-af5c-4268-9d77-ac865736510a")
+		)
+		(fp_curve
+			(pts
+				(xy 1.499089 -1.94748) (xy 1.647961 -1.951714) (xy 1.801419 -1.842) (xy 1.814119 -1.687836)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "43ab5071-35ba-4cf0-b87d-3523ed8182c4")
+		)
+		(fp_curve
+			(pts
+				(xy 1.499089 -1.94748) (xy 1.338575 -1.959475) (xy 1.122675 -1.920669) (xy 1.0687 -1.744633)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "b3938513-97df-418c-86e9-c873466ef1e9")
+		)
+		(fp_curve
+			(pts
+				(xy 1.461694 1.815953) (xy 1.613742 1.817364) (xy 1.739683 1.668492) (xy 1.725572 1.519267)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "1fd9fc70-1919-40da-a5de-6d3817a385c6")
+		)
+		(fp_curve
+			(pts
+				(xy 1.461694 1.815953) (xy 1.378792 1.824772) (xy 1.31 1.773267) (xy 1.234153 1.749983)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "27544092-b3d3-46da-8c9c-fa51fbbfa4ed")
+		)
+		(fp_curve
+			(pts
+				(xy 1.427122 1.286081) (xy 1.558355 1.279378) (xy 1.73933 1.366514) (xy 1.725572 1.519267)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0b3ea0b9-7065-44fb-9c60-25f8d343f630")
+		)
+		(fp_curve
+			(pts
+				(xy 1.427122 1.286081) (xy 1.307178 1.295606) (xy 1.14878 1.378508) (xy 1.164303 1.519267)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "3ec2a957-6329-4f02-b646-0b95298243a1")
+		)
+		(fp_curve
+			(pts
+				(xy 1.330461 -1.336117) (xy 1.493797 -1.263444) (xy 1.763319 -1.378097) (xy 1.724867 -1.583061)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "b0c97deb-c463-4a16-8c0c-c677a005f90c")
+		)
+		(fp_curve
+			(pts
+				(xy 1.330461 -1.336117) (xy 1.126908 -1.387622) (xy 1.112444 -1.667022) (xy 1.26555 -1.782733)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "3daf76a3-34db-4734-b79e-ddea375f47d6")
+		)
+		(fp_curve
+			(pts
+				(xy 1.26555 -1.782733) (xy 1.426769 -1.932664) (xy 1.726983 -1.805311) (xy 1.724867 -1.583061)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0bfe98e5-9008-4851-b72f-a697f999fb4a")
+		)
+		(fp_curve
+			(pts
+				(xy 1.26555 -1.782733) (xy 1.112444 -1.667022) (xy 1.126908 -1.387622) (xy 1.330461 -1.336117)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "1a257069-c455-40e8-8158-964ed8055020")
+		)
+		(fp_curve
+			(pts
+				(xy 1.234153 1.749983) (xy 1.31 1.773267) (xy 1.378792 1.824772) (xy 1.461694 1.815953)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a89f6e18-1f26-40a4-a7c8-f926f7ee746e")
+		)
+		(fp_curve
+			(pts
+				(xy 1.234153 1.749983) (xy 1.200992 1.677311) (xy 1.163244 1.600758) (xy 1.164303 1.519267)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "90c0ba00-65f8-4ca1-8af8-0d65678ba9ec")
+		)
+		(fp_curve
+			(pts
+				(xy 1.164303 1.519267) (xy 1.14878 1.378508) (xy 1.307178 1.295606) (xy 1.427122 1.286081)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "12110caa-98f5-4d98-8efe-4b2616c18422")
+		)
+		(fp_curve
+			(pts
+				(xy 1.164303 1.519267) (xy 1.163244 1.600758) (xy 1.200992 1.677311) (xy 1.234153 1.749983)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "aefa1753-6a3c-4f43-a1f6-de8d73c60b6c")
+		)
+		(fp_curve
+			(pts
+				(xy 1.087044 1.764095) (xy 1.163597 1.960945) (xy 1.398547 1.929547) (xy 1.568233 1.92355)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ca83d6c8-f68b-4d54-8e41-9cca5e8de7dd")
+		)
+		(fp_curve
+			(pts
+				(xy 1.087044 1.764095) (xy 1.02813 1.539728) (xy 1.070111 1.300897) (xy 1.062703 1.070886)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "b393ce35-a70f-40e8-b46d-89339e11b237")
+		)
+		(fp_curve
+			(pts
+				(xy 1.0687 -1.744633) (xy 1.122675 -1.920669) (xy 1.338575 -1.959475) (xy 1.499089 -1.94748)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "b97f1b21-c64c-4e34-8f43-154e477eb611")
+		)
+		(fp_curve
+			(pts
+				(xy 1.0687 -1.744633) (xy 1.046122 -1.53085) (xy 1.062703 -1.314597) (xy 1.063055 -1.100108)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "835f8967-e05d-4c0d-9a8d-b5dda7d95d4d")
+		)
+		(fp_curve
+			(pts
+				(xy 1.063055 -1.100108) (xy 1.062703 -1.314597) (xy 1.046122 -1.53085) (xy 1.0687 -1.744633)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "de6159cc-aae5-4192-815d-3b6428a70758")
+		)
+		(fp_curve
+			(pts
+				(xy 1.063055 -1.100108) (xy 1.067994 -0.376561) (xy 1.068347 0.347339) (xy 1.062703 1.070886)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "86bb744c-4463-4b9e-bb47-f58ddd3c2cf7")
+		)
+		(fp_curve
+			(pts
+				(xy 1.062703 1.070886) (xy 1.070111 1.300897) (xy 1.02813 1.539728) (xy 1.087044 1.764095)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "3488991c-6055-46b2-b03d-ab8734fdbfde")
+		)
+		(fp_curve
+			(pts
+				(xy 1.062703 1.070886) (xy 0.974508 1.070533) (xy 0.886667 1.069828) (xy 0.798472 1.068417)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "abab44ad-0821-43ae-99d7-f95a35f3f247")
+		)
+		(fp_curve
+			(pts
+				(xy 0.799178 -2.002867) (xy 0.797061 -1.701242) (xy 0.798119 -1.399264) (xy 0.798472 -1.097639)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6b925535-7d3d-4015-bff2-49f96cf4aee7")
+		)
+		(fp_curve
+			(pts
+				(xy 0.799178 -2.002867) (xy 0.798825 -2.116461) (xy 0.796708 -2.229703) (xy 0.79565 -2.343297)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "f7fa6c92-db63-472f-84fe-23d2d38f4356")
+		)
+		(fp_curve
+			(pts
+				(xy 0.798472 2.0061) (xy 1.090925 1.994811) (xy 1.38373 1.997633) (xy 1.676183 1.998692)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0ae85f53-5b4e-4afd-bf2c-8b0db9bffd70")
+		)
+		(fp_curve
+			(pts
+				(xy 0.798472 2.0061) (xy 0.797767 1.693539) (xy 0.797767 1.380978) (xy 0.798472 1.068417)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "1ac4db04-a96a-464f-bdd0-1c5836fde173")
+		)
+		(fp_curve
+			(pts
+				(xy 0.798472 1.068417) (xy 0.797767 1.380978) (xy 0.797767 1.693539) (xy 0.798472 2.0061)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a08cd57f-dc09-4559-b619-34debdb01472")
+		)
+		(fp_curve
+			(pts
+				(xy 0.798472 1.068417) (xy 0.798472 0.346281) (xy 0.798472 -0.375503) (xy 0.798472 -1.097639)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d9ca188d-51d7-403c-8c5a-c42e673ff0ba")
+		)
+		(fp_curve
+			(pts
+				(xy 0.798472 -1.097639) (xy 0.886667 -1.09905) (xy 0.974861 -1.099755) (xy 1.063055 -1.100108)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "bd5ee997-e7f8-4015-bf82-90c7912ddb71")
+		)
+		(fp_curve
+			(pts
+				(xy 0.798472 -1.097639) (xy 0.798119 -1.399264) (xy 0.797061 -1.701242) (xy 0.799178 -2.002867)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c3999004-f6a6-4832-b568-93cb60f02804")
+		)
+		(fp_curve
+			(pts
+				(xy 0.79565 2.314075) (xy 0.796708 2.211417) (xy 0.797767 2.108758) (xy 0.798472 2.0061)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a305fcc8-5f1a-4478-9950-3064a5b465ef")
+		)
+		(fp_curve
+			(pts
+				(xy 0.79565 2.314075) (xy 0.675705 2.314075) (xy 0.555408 2.314428) (xy 0.435464 2.315133)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "fa94af41-c843-4315-9255-a14d9ce0716a")
+		)
+		(fp_curve
+			(pts
+				(xy 0.79565 -2.343297) (xy 1.821528 -2.349647) (xy 2.847758 -2.335889) (xy 3.873283 -2.35)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "7591c6b7-a0fb-4d2a-b5ec-49febabc9a7e")
+		)
+		(fp_curve
+			(pts
+				(xy 0.79565 -2.343297) (xy 0.675353 -2.343297) (xy 0.555408 -2.34365) (xy 0.435111 -2.344355)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0cb6e60b-e624-4ec0-9ab3-3c7af8d7f761")
+		)
+		(fp_curve
+			(pts
+				(xy 0.435817 -0.210403) (xy 0.137014 -0.170186) (xy -0.1632 -0.215342) (xy -0.462708 -0.212519)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "713464f9-47ef-4404-aa7e-20b98786a9bd")
+		)
+		(fp_curve
+			(pts
+				(xy 0.435464 2.315133) (xy 0.555408 2.314428) (xy 0.675705 2.314075) (xy 0.79565 2.314075)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "84616868-a678-4066-b8a2-3fca4fb13474")
+		)
+		(fp_curve
+			(pts
+				(xy 0.435464 2.315133) (xy 0.347269 2.315486) (xy 0.258722 2.315486) (xy 0.170528 2.315486)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "f060bcb5-ae1c-463d-96df-2aa84e327098")
+		)
+		(fp_curve
+			(pts
+				(xy 0.435464 -1.098344) (xy 0.43758 -0.802364) (xy 0.438639 -0.506383) (xy 0.435817 -0.210403)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "83f63420-f696-44fa-8a07-50e39965b802")
+		)
+		(fp_curve
+			(pts
+				(xy 0.435464 -1.098344) (xy 0.435464 -1.410553) (xy 0.435111 -1.723114) (xy 0.435464 -2.035675)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "e680c33f-58c8-48d2-9fef-c82dd23c2ebc")
+		)
+		(fp_curve
+			(pts
+				(xy 0.435464 -2.035675) (xy 0.435111 -1.723114) (xy 0.435464 -1.410553) (xy 0.435464 -1.098344)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "43c0b857-2b20-4b86-b3ee-10ebcc368c7c")
+		)
+		(fp_curve
+			(pts
+				(xy 0.435464 -2.035675) (xy 0.346211 -2.034617) (xy 0.256958 -2.034617) (xy 0.167705 -2.035675)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "2bb8240c-488a-4c4d-84af-95e037e1df35")
+		)
+		(fp_curve
+			(pts
+				(xy 0.435111 -2.344355) (xy 0.555408 -2.34365) (xy 0.675353 -2.343297) (xy 0.79565 -2.343297)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "4894e289-636e-4e1c-b604-885602d76350")
+		)
+		(fp_curve
+			(pts
+				(xy 0.435111 -2.344355) (xy 0.436169 -2.241344) (xy 0.436169 -2.138333) (xy 0.435464 -2.035675)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "69e7d637-bbb5-4bd1-87af-31d650a77ef1")
+		)
+		(fp_curve
+			(pts
+				(xy 0.434405 1.974703) (xy 0.435111 2.088297) (xy 0.436169 2.201539) (xy 0.435464 2.315133)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "18d1ad65-156f-4ac0-9a37-557726ee89d7")
+		)
+		(fp_curve
+			(pts
+				(xy 0.434405 1.974703) (xy 0.435817 1.683308) (xy 0.436169 1.391914) (xy 0.434405 1.100167)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5a3bc7c9-4265-47c4-afde-3b9ad776e9d0")
+		)
+		(fp_curve
+			(pts
+				(xy 0.434405 1.100167) (xy 0.436169 1.391914) (xy 0.435817 1.683308) (xy 0.434405 1.974703)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0760a5f2-a0f3-4272-91e7-7a39b7bf7582")
+		)
+		(fp_curve
+			(pts
+				(xy 0.434405 1.100167) (xy -0.172372 1.099461) (xy -0.778797 1.111103) (xy -1.385575 1.107928)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "b28496f2-0bd2-4270-a99e-aba05b1f16f7")
+		)
+		(fp_curve
+			(pts
+				(xy 0.429467 0.128264) (xy 0.444636 0.452114) (xy 0.435464 0.776317) (xy 0.434405 1.100167)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "3eeadef4-c4da-4557-9841-15418b222735")
+		)
+		(fp_curve
+			(pts
+				(xy 0.170528 2.315486) (xy 0.168058 2.201892) (xy 0.167705 2.088297) (xy 0.169117 1.975056)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "01e7dfbe-aad0-4722-b9b3-851b520cb6fa")
+		)
+		(fp_curve
+			(pts
+				(xy 0.170528 -2.344708) (xy 0.258722 -2.344708) (xy 0.346917 -2.344708) (xy 0.435111 -2.344355)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5f9b61b9-d237-4c28-acff-a0d9fff63078")
+		)
+		(fp_curve
+			(pts
+				(xy 0.169117 1.975056) (xy 0.257664 1.974703) (xy 0.345858 1.974703) (xy 0.434405 1.974703)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "357e5572-a919-4293-be68-ca3917213c99")
+		)
+		(fp_curve
+			(pts
+				(xy 0.169117 1.975056) (xy 0.171586 1.771856) (xy 0.172997 1.569008) (xy 0.165942 1.366161)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "f6a2d4b6-a546-4a96-aed8-8c3f822d7815")
+		)
+		(fp_curve
+			(pts
+				(xy 0.167705 -2.035675) (xy 0.166294 -2.138686) (xy 0.168411 -2.241697) (xy 0.170528 -2.344708)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "57fc5de3-db1d-4014-9634-1f1753f1891b")
+		)
+		(fp_curve
+			(pts
+				(xy 0.167705 -2.035675) (xy 0.175114 -1.810603) (xy 0.183228 -1.583061) (xy 0.131369 -1.362222)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c85d9674-c7ff-4d90-9598-608c5e05b84f")
+		)
+		(fp_curve
+			(pts
+				(xy 0.165942 1.366161) (xy 0.172997 1.569008) (xy 0.171586 1.771856) (xy 0.169117 1.975056)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "843abe7c-d1ee-419b-9ba4-962e8c4f3403")
+		)
+		(fp_curve
+			(pts
+				(xy 0.165942 1.366161) (xy 0.055875 1.339703) (xy -0.058425 1.338997) (xy -0.168492 1.366161)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "1ab890f7-903f-4f19-85d3-b4dac7f5b6c6")
+		)
+		(fp_curve
+			(pts
+				(xy 0.131369 -1.362222) (xy 0.183228 -1.583061) (xy 0.175114 -1.810603) (xy 0.167705 -2.035675)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a15b527e-65a0-4d4c-be18-a6d0b0737975")
+		)
+		(fp_curve
+			(pts
+				(xy 0.131369 -1.362222) (xy 0.042822 -1.361869) (xy -0.045725 -1.361869) (xy -0.13392 -1.362222)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "7cef0f57-5ad7-4784-b52d-5e81279d27f4")
+		)
+		(fp_curve
+			(pts
+				(xy 0.086919 -2.655505) (xy -1.19825 -2.652683) (xy -2.483772 -2.661503) (xy -3.768942 -2.651272)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "bdc28541-4d7d-4f41-9d2d-6572179e27b4")
+		)
+		(fp_curve
+			(pts
+				(xy 0.038236 -1.679722) (xy 0.184286 -1.638094) (xy 0.104911 -1.394678) (xy -0.040081 -1.45465)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "40fb8c0e-f737-4b68-a3bd-c1b8e95cc5d0")
+		)
+		(fp_curve
+			(pts
+				(xy 0.038236 -1.679722) (xy -0.104992 -1.735108) (xy -0.186484 -1.498042) (xy -0.040081 -1.45465)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "b0f64a43-02ed-42cb-9998-4600e6067f4b")
+		)
+		(fp_curve
+			(pts
+				(xy 0.037883 1.425075) (xy 0.184992 1.465292) (xy 0.104558 1.709414) (xy -0.040081 1.650147)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a2e9a1db-abce-4df0-ba4f-3776cfe070ac")
+		)
+		(fp_curve
+			(pts
+				(xy 0.037883 1.425075) (xy -0.105345 1.369336) (xy -0.186131 1.605697) (xy -0.040081 1.650147)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "3066d007-df35-4d03-80f1-59cb306bf8f5")
+		)
+		(fp_curve
+			(pts
+				(xy -0.040081 1.650147) (xy 0.104558 1.709414) (xy 0.184992 1.465292) (xy 0.037883 1.425075)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "22f177c4-1606-4fa3-b8ed-d4117b28e356")
+		)
+		(fp_curve
+			(pts
+				(xy -0.040081 1.650147) (xy -0.186131 1.605697) (xy -0.105345 1.369336) (xy 0.037883 1.425075)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "2d58a2e5-023d-470b-96ff-eaec2f0b90d8")
+		)
+		(fp_curve
+			(pts
+				(xy -0.040081 -1.45465) (xy 0.104911 -1.394678) (xy 0.184286 -1.638094) (xy 0.038236 -1.679722)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5928d939-b5bb-4a91-8f48-17bc4baf9e5a")
+		)
+		(fp_curve
+			(pts
+				(xy -0.040081 -1.45465) (xy -0.186484 -1.498042) (xy -0.104992 -1.735108) (xy 0.038236 -1.679722)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "dd6ae610-5973-4e60-a219-6a0267527d90")
+		)
+		(fp_curve
+			(pts
+				(xy -0.13392 -1.362222) (xy -0.045725 -1.361869) (xy 0.042822 -1.361869) (xy 0.131369 -1.362222)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "09d3909b-d4be-46ff-95fb-f6bc87100b2b")
+		)
+		(fp_curve
+			(pts
+				(xy -0.13392 -1.362222) (xy -0.181545 -1.579886) (xy -0.181192 -1.803547) (xy -0.175195 -2.025444)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "371d4170-f223-4e5a-8714-b7055f4924f2")
+		)
+		(fp_curve
+			(pts
+				(xy -0.168492 1.366161) (xy -0.058425 1.338997) (xy 0.055875 1.339703) (xy 0.165942 1.366161)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "1a268851-9285-40be-b2d0-b7c77becb638")
+		)
+		(fp_curve
+			(pts
+				(xy -0.168492 1.366161) (xy -0.175195 1.569008) (xy -0.173783 1.772208) (xy -0.171314 1.975408)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "736412f5-c9c2-46ce-9bef-12d5716d7a23")
+		)
+		(fp_curve
+			(pts
+				(xy -0.170961 -2.344355) (xy -0.170608 -2.238169) (xy -0.171667 -2.13163) (xy -0.175195 -2.025444)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "1ca1fb80-8255-49c2-a7b6-3309c9f7ad8c")
+		)
+		(fp_curve
+			(pts
+				(xy -0.171314 1.975408) (xy -0.173783 1.772208) (xy -0.175195 1.569008) (xy -0.168492 1.366161)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "97858d3f-af94-42c5-9b58-a886b4527b58")
+		)
+		(fp_curve
+			(pts
+				(xy -0.171314 1.975408) (xy -0.169903 2.08865) (xy -0.169903 2.201892) (xy -0.172372 2.315133)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "f1ea9eeb-48bc-439a-a569-c3e749378076")
+		)
+		(fp_curve
+			(pts
+				(xy -0.172372 2.315133) (xy -0.576656 2.316897) (xy -0.981292 2.314781) (xy -1.385575 2.314781)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "dcd8262d-ee92-4350-a3be-902d7bdcf05a")
+		)
+		(fp_curve
+			(pts
+				(xy -0.175195 -2.025444) (xy -0.181192 -1.803547) (xy -0.181545 -1.579886) (xy -0.13392 -1.362222)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "564fc606-b537-4866-bd19-64b4c855bbb1")
+		)
+		(fp_curve
+			(pts
+				(xy -0.175195 -2.025444) (xy -0.232345 -1.967589) (xy -0.316306 -1.917847) (xy -0.323361 -1.828594)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "320e43d5-80bd-4d3b-8bfc-1af8e0577add")
+		)
+		(fp_curve
+			(pts
+				(xy -0.180839 -1.114219) (xy 0.023067 -1.08635) (xy 0.230147 -1.108575) (xy 0.435464 -1.098344)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d09cf980-bf6d-4d18-b2f3-709058fd4ff0")
+		)
+		(fp_curve
+			(pts
+				(xy -0.320539 -1.308953) (xy -0.309956 -1.228519) (xy -0.273267 -1.127272) (xy -0.180839 -1.114219)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "bdb07c1c-e5d1-41b4-a296-ddfe0d147e20")
+		)
+		(fp_curve
+			(pts
+				(xy -0.323361 -1.828594) (xy -0.342411 -1.656439) (xy -0.339942 -1.481108) (xy -0.320539 -1.308953)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "e08d96f1-aed1-441b-9175-cf52cb058967")
+		)
+		(fp_curve
+			(pts
+				(xy -0.435897 -0.737805) (xy -0.444364 -1.083528) (xy -0.414731 -1.432072) (xy -0.470822 -1.775325)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "2c04f1b9-a831-45fc-97ad-9aa9cbaf1672")
+		)
+		(fp_curve
+			(pts
+				(xy -0.44507 1.659672) (xy -0.4172 1.492456) (xy -0.436956 1.281847) (xy -0.591825 1.1806)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ebdf4cf2-d700-424f-8457-1895cd32f15a")
+		)
+		(fp_curve
+			(pts
+				(xy -0.44507 1.659672) (xy -0.457417 1.785261) (xy -0.562545 1.896386) (xy -0.689545 1.907675)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "867282ed-0309-4d3a-8081-76d927a0b34b")
+		)
+		(fp_curve
+			(pts
+				(xy -0.452125 0.127206) (xy -0.158261 0.131086) (xy 0.135603 0.130028) (xy 0.429467 0.128264)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ab15d6b3-e3df-468f-b3be-f8f3c168f2e6")
+		)
+		(fp_curve
+			(pts
+				(xy -0.452125 0.127206) (xy -0.457064 0.013964) (xy -0.463414 -0.099278) (xy -0.462708 -0.212519)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "7c8452db-ab34-40be-a8aa-ed341af80702")
+		)
+		(fp_curve
+			(pts
+				(xy -0.462708 -0.212519) (xy -0.466236 -0.388203) (xy -0.453889 -0.56318) (xy -0.435897 -0.737805)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6501fa72-3e33-43f6-9d70-ea9fa8c0bc43")
+		)
+		(fp_curve
+			(pts
+				(xy -0.462708 -0.212519) (xy -0.463414 -0.099278) (xy -0.457064 0.013964) (xy -0.452125 0.127206)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "48ddf6c5-006f-44dc-b63f-6c44e0eeeb0d")
+		)
+		(fp_curve
+			(pts
+				(xy -0.470822 -1.775325) (xy -0.514214 -1.843764) (xy -0.576656 -1.914319) (xy -0.66097 -1.926667)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a9f8cce0-eb5a-45ed-b8d8-b780e2ffa1ba")
+		)
+		(fp_curve
+			(pts
+				(xy -0.580536 -0.129617) (xy -0.520564 0.011495) (xy -0.590414 0.19247) (xy -0.729056 0.257381)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ab91bb4b-2080-4235-8fd6-81ac2c5bfda6")
+		)
+		(fp_curve
+			(pts
+				(xy -0.580536 -0.129617) (xy -0.665203 -0.294364) (xy -0.936136 -0.340578) (xy -1.045497 -0.176536)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "7e24ac9e-dcc0-404e-8dd2-922ec5d1e286")
+		)
+		(fp_curve
+			(pts
+				(xy -0.591825 1.1806) (xy -0.436956 1.281847) (xy -0.4172 1.492456) (xy -0.44507 1.659672)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "43334e0b-d192-43f9-8825-b16bbb29076f")
+		)
+		(fp_curve
+			(pts
+				(xy -0.591825 1.1806) (xy -0.845472 1.069828) (xy -1.12205 1.166136) (xy -1.386633 1.154847)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c8ee67f6-ce7f-4a98-aed2-65c90d8d30c9")
+		)
+		(fp_curve
+			(pts
+				(xy -0.66097 -1.926667) (xy -0.863817 -1.964767) (xy -1.07125 -1.937603) (xy -1.276214 -1.946775)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "7862d73a-9250-4dc2-b7c4-a5587f3f3469")
+		)
+		(fp_curve
+			(pts
+				(xy -0.689545 1.907675) (xy -0.562545 1.896386) (xy -0.457417 1.785261) (xy -0.44507 1.659672)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5eca8a84-18da-4c1e-ba65-5e129f267f3a")
+		)
+		(fp_curve
+			(pts
+				(xy -0.689545 1.907675) (xy -0.921672 1.935897) (xy -1.155917 1.912967) (xy -1.388045 1.896739)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "24ba3f93-373c-4383-b571-481a3b1a4171")
+		)
+		(fp_curve
+			(pts
+				(xy -0.723058 0.357217) (xy -0.590414 0.357922) (xy -0.483522 0.251031) (xy -0.452125 0.127206)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0987526d-827b-4108-858c-86a6ecba7073")
+		)
+		(fp_curve
+			(pts
+				(xy -0.729056 0.257381) (xy -0.590414 0.19247) (xy -0.520564 0.011495) (xy -0.580536 -0.129617)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "407f1c69-64b3-471b-be33-cb316b83eaeb")
+		)
+		(fp_curve
+			(pts
+				(xy -0.729056 0.257381) (xy -0.833125 0.290189) (xy -0.931903 0.237978) (xy -1.025036 0.19882)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "1fab5236-ac00-4f6f-8a11-da7f5b891f2d")
+		)
+		(fp_curve
+			(pts
+				(xy -1.025036 0.19882) (xy -0.931903 0.237978) (xy -0.833125 0.290189) (xy -0.729056 0.257381)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6f879fd8-aeb7-4d1d-9856-378446d4af3a")
+		)
+		(fp_curve
+			(pts
+				(xy -1.025036 0.19882) (xy -1.075483 0.083108) (xy -1.1411 -0.064) (xy -1.045497 -0.176536)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "3b4b5469-02f7-46ad-837b-205f907d0807")
+		)
+		(fp_curve
+			(pts
+				(xy -1.045497 -0.176536) (xy -0.936136 -0.340578) (xy -0.665203 -0.294364) (xy -0.580536 -0.129617)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "058d1f4c-2cea-44e5-88ae-ce9e7dc0500e")
+		)
+		(fp_curve
+			(pts
+				(xy -1.045497 -0.176536) (xy -1.1411 -0.064) (xy -1.075483 0.083108) (xy -1.025036 0.19882)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c2b32662-d091-4ee2-a717-0b119cb1e182")
+		)
+		(fp_curve
+			(pts
+				(xy -1.196839 -1.169605) (xy -1.195781 -0.908197) (xy -1.190842 -0.646789) (xy -1.201072 -0.385733)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6a9a0fff-45ca-4e87-ae0b-a7f05148837f")
+		)
+		(fp_curve
+			(pts
+				(xy -1.201072 -0.385733) (xy -1.258928 -0.380089) (xy -1.316431 -0.374444) (xy -1.374286 -0.371622)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "884d0e5c-8e6a-43d0-84c1-7740de752281")
+		)
+		(fp_curve
+			(pts
+				(xy -1.276214 -1.946775) (xy -1.542561 -2.024386) (xy -1.820903 -2.000397) (xy -2.094658 -2.002514)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ce7eeed4-52e3-4561-b51c-d6c48c6a0cd4")
+		)
+		(fp_curve
+			(pts
+				(xy -1.276214 -1.946775) (xy -1.549617 -1.942894) (xy -1.823372 -1.955947) (xy -2.09607 -1.925608)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "9bd17b8c-87fb-41c4-b6d3-face583a53c3")
+		)
+		(fp_curve
+			(pts
+				(xy -1.304789 -1.152319) (xy -1.277978 -1.156553) (xy -1.224003 -1.165372) (xy -1.196839 -1.169605)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "546648c2-6fbe-498e-9e3b-b7fe2988f8f0")
+		)
+		(fp_curve
+			(pts
+				(xy -1.304789 -1.152319) (xy -1.565845 -1.202414) (xy -1.832545 -1.174897) (xy -2.096422 -1.185833)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a850b0f7-698a-43d1-af3d-d84c94be602c")
+		)
+		(fp_curve
+			(pts
+				(xy -1.330542 -1.716411) (xy -1.17285 -1.52838) (xy -1.399686 -1.196417) (xy -1.633225 -1.301544)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "452fdde9-0fcc-4567-a61e-722dd97f9779")
+		)
+		(fp_curve
+			(pts
+				(xy -1.330542 -1.716411) (xy -1.407095 -1.879747) (xy -1.680497 -1.905853) (xy -1.75705 -1.730875)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "601bd24a-4146-46be-bb98-6882a3b4d11c")
+		)
+		(fp_curve
+			(pts
+				(xy -1.374286 -0.371622) (xy -1.392983 -0.477455) (xy -1.414503 -0.582936) (xy -1.436022 -0.688417)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "3e31aa09-e586-46e1-8906-166031780ae6")
+		)
+		(fp_curve
+			(pts
+				(xy -1.374286 -0.371622) (xy -1.761636 -0.365978) (xy -2.149339 -0.373386) (xy -2.536689 -0.368094)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d99596ca-a1f3-4d4f-bc7b-e0e74ee55f43")
+		)
+		(fp_curve
+			(pts
+				(xy -1.38487 0.352983) (xy -1.165089 0.370975) (xy -0.943192 0.371328) (xy -0.723058 0.357217)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "57d89a2d-d6b2-4d69-902e-6a1bec82d274")
+		)
+		(fp_curve
+			(pts
+				(xy -1.38487 0.352983) (xy -1.486822 0.343106) (xy -1.589481 0.339931) (xy -1.691786 0.340989)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "34d0370c-0ba0-4552-80ce-bdbe296d6fec")
+		)
+		(fp_curve
+			(pts
+				(xy -1.385575 2.314781) (xy -1.383811 2.201186) (xy -1.382753 2.087945) (xy -1.385928 1.97435)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "7067e29d-47d9-46a1-8cc1-8ff3ce6de4af")
+		)
+		(fp_curve
+			(pts
+				(xy -1.385575 2.314781) (xy -1.496347 2.314428) (xy -1.606767 2.314075) (xy -1.717539 2.314075)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "aa5898a1-ea5e-4ad1-bcb2-507139fafe4f")
+		)
+		(fp_curve
+			(pts
+				(xy -1.385575 1.107928) (xy -1.380636 0.856045) (xy -1.383458 0.604514) (xy -1.38487 0.352983)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "7b802dfa-c6fd-4a61-bafb-70154f3fdfe1")
+		)
+		(fp_curve
+			(pts
+				(xy -1.385928 1.97435) (xy -0.980939 1.968706) (xy -0.57595 1.969411) (xy -0.171314 1.975408)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "8426fdd7-9e79-4d10-ad9e-2bdfc74923c4")
+		)
+		(fp_curve
+			(pts
+				(xy -1.385928 1.97435) (xy -1.386281 1.954947) (xy -1.387692 1.916142) (xy -1.388045 1.896739)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "4846ef46-0959-4101-a3ae-0833bca5441e")
+		)
+		(fp_curve
+			(pts
+				(xy -1.386633 1.154847) (xy -1.12205 1.166136) (xy -0.845472 1.069828) (xy -0.591825 1.1806)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "55fd7f7d-6e0f-417e-9057-a059c00299a2")
+		)
+		(fp_curve
+			(pts
+				(xy -1.386633 1.154847) (xy -1.490703 1.156258) (xy -1.595125 1.153436) (xy -1.699195 1.154142)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "7856d3a0-7895-4a0f-b0ee-4bfceecc5297")
+		)
+		(fp_curve
+			(pts
+				(xy -1.388045 1.896739) (xy -1.155917 1.912967) (xy -0.921672 1.935897) (xy -0.689545 1.907675)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "59de930b-f77b-4c9d-a5c3-e558d45f8697")
+		)
+		(fp_curve
+			(pts
+				(xy -1.388045 1.896739) (xy -1.387692 1.916142) (xy -1.386281 1.954947) (xy -1.385928 1.97435)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "630f2ec5-5f23-40ed-8000-b1fb43df395c")
+		)
+		(fp_curve
+			(pts
+				(xy -1.388045 1.896739) (xy -1.496347 1.892153) (xy -1.60465 1.892153) (xy -1.7126 1.896386)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "eef61362-7dc0-4f6c-b04b-6ca2b2b3e700")
+		)
+		(fp_curve
+			(pts
+				(xy -1.436022 -0.688417) (xy -1.654039 -0.712758) (xy -1.873114 -0.712053) (xy -2.092189 -0.709936)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "db16ab52-bded-4b25-9c89-d5223fc2191d")
+		)
+		(fp_curve
+			(pts
+				(xy -1.633225 -1.301544) (xy -1.399686 -1.196417) (xy -1.17285 -1.52838) (xy -1.330542 -1.716411)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "3ce8d9b1-da7d-4cab-bb83-8b5a1358c5e1")
+		)
+		(fp_curve
+			(pts
+				(xy -1.633225 -1.301544) (xy -1.794445 -1.371394) (xy -1.859003 -1.58553) (xy -1.75705 -1.730875)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a64ebdeb-c859-48aa-a54b-76c6dbad8f07")
+		)
+		(fp_curve
+			(pts
+				(xy -1.691786 0.340989) (xy -1.589481 0.339931) (xy -1.486822 0.343106) (xy -1.38487 0.352983)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c2e7d3f1-a81b-4199-86f9-4f290520d868")
+		)
+		(fp_curve
+			(pts
+				(xy -1.691786 0.340989) (xy -1.699547 0.60522) (xy -1.69355 0.869097) (xy -1.698842 1.132975)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "69074335-0dc1-48ec-9289-89d13afe1a96")
+		)
+		(fp_curve
+			(pts
+				(xy -1.698842 1.132975) (xy -1.747878 1.104047) (xy -1.808203 1.101578) (xy -1.861825 1.115689)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "11f3570a-2156-415c-a71b-94c43ee652e1")
+		)
+		(fp_curve
+			(pts
+				(xy -1.699195 1.154142) (xy -1.595125 1.153436) (xy -1.490703 1.156258) (xy -1.386633 1.154847)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "3ef8d790-4cef-4439-a88e-4d1b5a4585b7")
+		)
+		(fp_curve
+			(pts
+				(xy -1.699195 1.154142) (xy -1.750347 1.15132) (xy -1.840658 1.178131) (xy -1.861825 1.115689)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "e2ea0902-a755-4c13-b90e-44acb4e74596")
+		)
+		(fp_curve
+			(pts
+				(xy -1.7126 1.896386) (xy -1.60465 1.892153) (xy -1.496347 1.892153) (xy -1.388045 1.896739)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "753288da-39e9-4858-9ae8-08c403976508")
+		)
+		(fp_curve
+			(pts
+				(xy -1.7126 1.896386) (xy -1.714364 1.914731) (xy -1.717186 1.95142) (xy -1.71895 1.969764)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "32008281-ee7b-4988-bf44-46de3eb24ac5")
+		)
+		(fp_curve
+			(pts
+				(xy -1.7126 1.896386) (xy -1.946845 1.912967) (xy -2.183206 1.934839) (xy -2.41745 1.90697)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "2bbc2d57-2a13-4c4a-b84f-0064a65a6681")
+		)
+		(fp_curve
+			(pts
+				(xy -1.717539 2.314075) (xy -1.606767 2.314075) (xy -1.496347 2.314428) (xy -1.385575 2.314781)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ee11544a-e80d-4aa6-842d-d8c24f4ea67e")
+		)
+		(fp_curve
+			(pts
+				(xy -1.717539 2.314075) (xy -2.256583 2.315486) (xy -2.795981 2.315839) (xy -3.335025 2.314428)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "7ce4128b-819f-4637-9635-173f404b21d0")
+		)
+		(fp_curve
+			(pts
+				(xy -1.71895 1.969764) (xy -1.717186 1.95142) (xy -1.714364 1.914731) (xy -1.7126 1.896386)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c789dcee-968d-46ad-aaaf-6f89f0cc5510")
+		)
+		(fp_curve
+			(pts
+				(xy -1.71895 1.969764) (xy -1.725653 2.084417) (xy -1.721067 2.199422) (xy -1.717539 2.314075)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5fcc4549-9938-4a25-bd07-1f7e792c59a1")
+		)
+		(fp_curve
+			(pts
+				(xy -1.75705 -1.730875) (xy -1.680497 -1.905853) (xy -1.407095 -1.879747) (xy -1.330542 -1.716411)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "f4f57cab-3edf-46fa-ad0d-47e718edef36")
+		)
+		(fp_curve
+			(pts
+				(xy -1.75705 -1.730875) (xy -1.859003 -1.58553) (xy -1.794445 -1.371394) (xy -1.633225 -1.301544)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "260e9094-b9ae-4e6d-b5be-dad14fd11394")
+		)
+		(fp_curve
+			(pts
+				(xy -1.861825 1.115689) (xy -1.840658 1.178131) (xy -1.750347 1.15132) (xy -1.699195 1.154142)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "7eb2f309-f5c7-4279-b859-06cd0fc512cc")
+		)
+		(fp_curve
+			(pts
+				(xy -1.861825 1.115689) (xy -1.906628 0.862042) (xy -1.875936 0.601692) (xy -1.880875 0.345222)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "bba3f12d-24c5-439b-a3d9-6f8aa7b3c704")
+		)
+		(fp_curve
+			(pts
+				(xy -1.880875 0.345222) (xy -1.817728 0.343811) (xy -1.754933 0.342047) (xy -1.691786 0.340989)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "552e866a-aac3-45d1-8e6f-515376dacbe6")
+		)
+		(fp_curve
+			(pts
+				(xy -2.04915 1.365808) (xy -1.900278 1.529497) (xy -2.041389 1.790553) (xy -2.24212 1.814895)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a6440f3c-e6e0-4c93-b0f7-6a0339a9c93f")
+		)
+		(fp_curve
+			(pts
+				(xy -2.04915 1.365808) (xy -2.1444 1.21482) (xy -2.33737 1.253625) (xy -2.470014 1.326297)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "00b02bf7-0b75-47b1-9b06-a0a91aa46999")
+		)
+		(fp_curve
+			(pts
+				(xy -2.092189 -0.709936) (xy -2.093953 -0.840817) (xy -2.0936 -0.971697) (xy -2.095364 -1.102578)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "165d9cae-4f93-4954-9680-ec8f21c72943")
+		)
+		(fp_curve
+			(pts
+				(xy -2.093953 -2.343297) (xy -1.452956 -2.345414) (xy -0.811958 -2.344708) (xy -0.170961 -2.344355)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5ee89322-3179-489e-a6c8-19e5f60b259a")
+		)
+		(fp_curve
+			(pts
+				(xy -2.093953 -2.343297) (xy -2.214956 -2.342592) (xy -2.335606 -2.342944) (xy -2.456608 -2.34365)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "021501a4-fb72-42b7-9887-017bb6d98860")
+		)
+		(fp_curve
+			(pts
+				(xy -2.094658 -2.002514) (xy -2.093247 -2.116108) (xy -2.0936 -2.229703) (xy -2.093953 -2.343297)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "8955a629-8c7e-4254-8980-b5862322d8cd")
+		)
+		(fp_curve
+			(pts
+				(xy -2.094658 -2.002514) (xy -2.095011 -1.983111) (xy -2.095717 -1.944658) (xy -2.09607 -1.925608)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0c6e54ba-d529-4957-8f32-3ee35539d47c")
+		)
+		(fp_curve
+			(pts
+				(xy -2.095364 -1.102578) (xy -1.831486 -1.115983) (xy -1.561964 -1.072944) (xy -1.304789 -1.152319)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6c825885-ccaf-408b-9c86-9cf674ac1666")
+		)
+		(fp_curve
+			(pts
+				(xy -2.095364 -1.102578) (xy -2.095717 -1.123392) (xy -2.09607 -1.165019) (xy -2.096422 -1.185833)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "30464228-4d88-4aa7-bcc6-c96c7c4886ab")
+		)
+		(fp_curve
+			(pts
+				(xy -2.09607 -1.925608) (xy -1.823372 -1.955947) (xy -1.549617 -1.942894) (xy -1.276214 -1.946775)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c94436f3-11af-408c-8f4f-af3594d1b060")
+		)
+		(fp_curve
+			(pts
+				(xy -2.09607 -1.925608) (xy -2.095717 -1.944658) (xy -2.095011 -1.983111) (xy -2.094658 -2.002514)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "04371cc1-84ea-4dce-a65a-24259d3cc297")
+		)
+		(fp_curve
+			(pts
+				(xy -2.09607 -1.925608) (xy -2.2206 -1.918553) (xy -2.345836 -1.925608) (xy -2.468956 -1.945011)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "9cd77a79-03bd-4ad0-8785-54920891f97e")
+		)
+		(fp_curve
+			(pts
+				(xy -2.096422 -1.185833) (xy -1.832545 -1.174897) (xy -1.565845 -1.202414) (xy -1.304789 -1.152319)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ce875945-a18e-4e08-b71c-d2d8c69f420d")
+		)
+		(fp_curve
+			(pts
+				(xy -2.096422 -1.185833) (xy -2.09607 -1.165019) (xy -2.095717 -1.123392) (xy -2.095364 -1.102578)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "25d6435e-63fc-4bed-849a-bdbfd900bbfd")
+		)
+		(fp_curve
+			(pts
+				(xy -2.096422 -1.185833) (xy -2.21672 -1.187597) (xy -2.337017 -1.185128) (xy -2.456608 -1.172075)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5324509a-de52-40bb-82cc-95e7c5712c3d")
+		)
+		(fp_curve
+			(pts
+				(xy -2.24212 1.814895) (xy -2.041389 1.790553) (xy -1.900278 1.529497) (xy -2.04915 1.365808)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "9d37c65d-1d23-4e83-ab99-db8a24c8fa08")
+		)
+		(fp_curve
+			(pts
+				(xy -2.24212 1.814895) (xy -2.404397 1.839236) (xy -2.560678 1.681897) (xy -2.541628 1.520678)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "dee2841c-e1a4-4b73-bf56-d733dd65a8d1")
+		)
+		(fp_curve
+			(pts
+				(xy -2.384289 1.972586) (xy -2.162392 1.968) (xy -1.940495 1.979642) (xy -1.71895 1.969764)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "25030d27-3fd5-4b65-a576-19827b722188")
+		)
+		(fp_curve
+			(pts
+				(xy -2.41745 1.90697) (xy -2.183206 1.934839) (xy -1.946845 1.912967) (xy -1.7126 1.896386)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "9343186c-622a-4690-84d3-c0619a7c5092")
+		)
+		(fp_curve
+			(pts
+				(xy -2.41745 1.90697) (xy -2.515522 1.893564) (xy -2.638995 1.839589) (xy -2.648167 1.727406)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "3806401c-5264-41f6-89fe-cc6fcfc52dc1")
+		)
+		(fp_curve
+			(pts
+				(xy -2.447083 -1.138208) (xy -2.427328 -0.995686) (xy -2.456256 -0.852458) (xy -2.460489 -0.709936)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a0f544ed-fd6b-4a60-9e24-467767d8094a")
+		)
+		(fp_curve
+			(pts
+				(xy -2.456608 -1.172075) (xy -2.337017 -1.185128) (xy -2.21672 -1.187597) (xy -2.096422 -1.185833)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "486af24e-b215-4c76-9fbe-93eb8e02fb4a")
+		)
+		(fp_curve
+			(pts
+				(xy -2.456608 -1.172075) (xy -2.517639 -1.233106) (xy -2.589606 -1.285669) (xy -2.636172 -1.359047)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "60791dc0-788a-4c73-97d0-0a5d78b20065")
+		)
+		(fp_curve
+			(pts
+				(xy -2.456608 -2.34365) (xy -2.335606 -2.342944) (xy -2.214956 -2.342592) (xy -2.093953 -2.343297)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "901888e7-58e0-424d-84b5-b02c51862b71")
+		)
+		(fp_curve
+			(pts
+				(xy -2.456608 -2.34365) (xy -2.454845 -2.230761) (xy -2.452375 -2.117519) (xy -2.458725 -2.004983)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "f15640fc-a121-458c-a9cb-cdc69ea63ad8")
+		)
+		(fp_curve
+			(pts
+				(xy -2.458725 -2.004983) (xy -2.461195 -1.989814) (xy -2.466486 -1.96018) (xy -2.468956 -1.945011)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "29335e41-2995-49b3-9b93-b239330f0b70")
+		)
+		(fp_curve
+			(pts
+				(xy -2.458725 -2.004983) (xy -2.606892 -2.003219) (xy -2.755411 -2.002867) (xy -2.903578 -2.003219)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d637b275-ea93-4e0e-b97f-54347d14a6c2")
+		)
+		(fp_curve
+			(pts
+				(xy -2.460489 -0.709936) (xy -2.660514 -0.704997) (xy -2.860539 -0.714875) (xy -3.060211 -0.707819)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "8dd3d22e-040e-4b81-b35d-bb6a6e511d0a")
+		)
+		(fp_curve
+			(pts
+				(xy -2.468956 -1.945011) (xy -2.345836 -1.925608) (xy -2.2206 -1.918553) (xy -2.09607 -1.925608)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "04b1109d-e4cf-4701-82f2-4b0f62af9444")
+		)
+		(fp_curve
+			(pts
+				(xy -2.468956 -1.945011) (xy -2.466486 -1.96018) (xy -2.461195 -1.989814) (xy -2.458725 -2.004983)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ee632c72-72e4-4b43-befc-89627ce6967d")
+		)
+		(fp_curve
+			(pts
+				(xy -2.468956 -1.945011) (xy -2.523283 -1.887508) (xy -2.594545 -1.843764) (xy -2.635114 -1.774619)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "761df52a-7f08-45e3-b7e1-0fe0706f4d7c")
+		)
+		(fp_curve
+			(pts
+				(xy -2.470014 1.326297) (xy -2.33737 1.253625) (xy -2.1444 1.21482) (xy -2.04915 1.365808)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "b7cade27-1637-4047-be80-0c759a340d27")
+		)
+		(fp_curve
+			(pts
+				(xy -2.470014 1.326297) (xy -2.492945 1.391561) (xy -2.537747 1.44977) (xy -2.541628 1.520678)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "f951a94c-cfe4-407f-aa67-67b0d0c51f7c")
+		)
+		(fp_curve
+			(pts
+				(xy -2.536689 -0.368094) (xy -2.149339 -0.373386) (xy -1.761636 -0.365978) (xy -1.374286 -0.371622)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "d332cd47-457a-4c87-9ec2-f63474efd436")
+		)
+		(fp_curve
+			(pts
+				(xy -2.536689 -0.368094) (xy -2.568792 -0.297892) (xy -2.623825 -0.236861) (xy -2.640758 -0.160308)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "9eb0aeb3-8616-454a-9230-69017f0183e2")
+		)
+		(fp_curve
+			(pts
+				(xy -2.541628 1.520678) (xy -2.560678 1.681897) (xy -2.404397 1.839236) (xy -2.24212 1.814895)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "de0c5f94-4476-4423-83ee-2f8e04647503")
+		)
+		(fp_curve
+			(pts
+				(xy -2.541628 1.520678) (xy -2.537747 1.44977) (xy -2.492945 1.391561) (xy -2.470014 1.326297)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "e59e17a5-b4df-4cc6-b8b2-f62652619bf3")
+		)
+		(fp_curve
+			(pts
+				(xy -2.635114 -1.774619) (xy -2.594545 -1.843764) (xy -2.523283 -1.887508) (xy -2.468956 -1.945011)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "8c03abf3-030c-4550-a9e2-94f9d2a95c07")
+		)
+		(fp_curve
+			(pts
+				(xy -2.635114 -1.774619) (xy -2.681681 -1.641622) (xy -2.679211 -1.49275) (xy -2.636172 -1.359047)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "821827f7-7639-4594-a40a-a6ab2b4bbab5")
+		)
+		(fp_curve
+			(pts
+				(xy -2.636172 -1.359047) (xy -2.589606 -1.285669) (xy -2.517639 -1.233106) (xy -2.456608 -1.172075)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a499e64c-db97-45bf-9a23-a9332025472a")
+		)
+		(fp_curve
+			(pts
+				(xy -2.636172 -1.359047) (xy -2.679211 -1.49275) (xy -2.681681 -1.641622) (xy -2.635114 -1.774619)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a62b8560-3943-43e7-b216-869c81087dbd")
+		)
+		(fp_curve
+			(pts
+				(xy -2.640758 -0.160308) (xy -2.643228 0.25597) (xy -2.639347 0.6726) (xy -2.642522 1.088878)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "9d3b9196-41f9-417e-be6e-cfb0a8d2bec2")
+		)
+		(fp_curve
+			(pts
+				(xy -2.642522 1.088878) (xy -2.638642 1.301956) (xy -2.677447 1.515386) (xy -2.648167 1.727406)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "4d6ce7c9-6dd7-4744-b4e4-b373751ccf43")
+		)
+		(fp_curve
+			(pts
+				(xy -2.642522 1.088878) (xy -2.679564 1.131917) (xy -2.724367 1.176367) (xy -2.720133 1.238103)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "bd071b2a-bbc0-4d29-b874-9a49067cb9f0")
+		)
+		(fp_curve
+			(pts
+				(xy -2.648167 1.727406) (xy -2.638995 1.839589) (xy -2.515522 1.893564) (xy -2.41745 1.90697)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "08f0f168-8b99-4f2f-84c2-b0055ce0fb7b")
+		)
+		(fp_curve
+			(pts
+				(xy -2.648167 1.727406) (xy -2.677447 1.515386) (xy -2.638642 1.301956) (xy -2.642522 1.088878)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ac009d4c-33a8-4967-baea-b23d0a392112")
+		)
+		(fp_curve
+			(pts
+				(xy -2.719428 1.890389) (xy -2.6143 1.939072) (xy -2.502117 1.978936) (xy -2.384289 1.972586)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "8914731f-6975-4654-9617-58a406de82f4")
+		)
+		(fp_curve
+			(pts
+				(xy -2.720133 1.238103) (xy -2.730364 1.455414) (xy -2.719781 1.673078) (xy -2.719428 1.890389)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "161fb023-1baa-4e08-a1fc-78f8dad549ff")
+		)
+		(fp_curve
+			(pts
+				(xy -2.903225 -2.345414) (xy -2.754353 -2.345414) (xy -2.605481 -2.345061) (xy -2.456608 -2.34365)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "596c314d-7d55-4752-9fdd-b0c69f68f73d")
+		)
+		(fp_curve
+			(pts
+				(xy -2.903578 -2.003219) (xy -2.906753 -2.117167) (xy -2.9064 -2.231114) (xy -2.903225 -2.345414)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6141d26d-ee37-4263-b19e-d8b73e930c3a")
+		)
+		(fp_curve
+			(pts
+				(xy -2.903578 -2.003219) (xy -2.89617 -1.791553) (xy -2.895817 -1.57918) (xy -2.915572 -1.367867)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "b9dfbd14-beaf-44c6-952f-aa86cf7d5751")
+		)
+		(fp_curve
+			(pts
+				(xy -2.915572 -1.367867) (xy -2.895817 -1.57918) (xy -2.89617 -1.791553) (xy -2.903578 -2.003219)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "841fb4d0-c7b5-4077-87ab-539e6356563d")
+		)
+		(fp_curve
+			(pts
+				(xy -2.915572 -1.367867) (xy -3.030931 -1.367161) (xy -3.146289 -1.367161) (xy -3.261647 -1.367867)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6ba2789c-ab21-4850-bbaa-45959e7c9da9")
+		)
+		(fp_curve
+			(pts
+				(xy -2.955436 -0.488392) (xy -2.994947 -0.55683) (xy -3.039397 -0.622094) (xy -3.090903 -0.682419)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "dc58cdde-381e-41ba-80d7-77ed6dd6da77")
+		)
+		(fp_curve
+			(pts
+				(xy -2.955436 -0.488392) (xy -3.002708 -0.453819) (xy -3.049981 -0.420305) (xy -3.098311 -0.387497)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "050e67df-d102-49a9-86e8-c8d4e5749e07")
+		)
+		(fp_curve
+			(pts
+				(xy -3.060211 -0.707819) (xy -3.06762 -0.701469) (xy -3.083142 -0.688769) (xy -3.090903 -0.682419)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "2166090d-1ec7-4dbc-9d44-81bfe5937093")
+		)
+		(fp_curve
+			(pts
+				(xy -3.060211 -0.707819) (xy -3.267997 -0.704644) (xy -3.476842 -0.722283) (xy -3.683922 -0.700764)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c71afe28-46f0-4642-8388-4fb2280adb1f")
+		)
+		(fp_curve
+			(pts
+				(xy -3.064445 -1.681839) (xy -2.917689 -1.648325) (xy -2.992478 -1.381625) (xy -3.142761 -1.457825)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5a97ba51-035b-45cb-826b-dd2b62ebfa74")
+		)
+		(fp_curve
+			(pts
+				(xy -3.064445 -1.681839) (xy -3.202028 -1.718528) (xy -3.286695 -1.510389) (xy -3.142761 -1.457825)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a3e724a9-988f-45c5-9c3d-279aca4899f5")
+		)
+		(fp_curve
+			(pts
+				(xy -3.072911 -0.369153) (xy -2.894053 -0.365625) (xy -2.715195 -0.374092) (xy -2.536689 -0.368094)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "b1bb1447-a890-4111-84e8-103949182902")
+		)
+		(fp_curve
+			(pts
+				(xy -3.090903 -0.682419) (xy -3.039397 -0.622094) (xy -2.994947 -0.55683) (xy -2.955436 -0.488392)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "1a3b833a-cbdb-4596-ab4a-787b76e16834")
+		)
+		(fp_curve
+			(pts
+				(xy -3.090903 -0.682419) (xy -3.083142 -0.688769) (xy -3.06762 -0.701469) (xy -3.060211 -0.707819)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0a3710c4-321f-4458-963b-46682c76c8cb")
+		)
+		(fp_curve
+			(pts
+				(xy -3.090903 -0.682419) (xy -3.149111 -0.634442) (xy -3.20097 -0.579761) (xy -3.254239 -0.526492)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6e7aef64-b598-4ed1-8a4b-80b601a36531")
+		)
+		(fp_curve
+			(pts
+				(xy -3.098311 -0.387497) (xy -3.049981 -0.420305) (xy -3.002708 -0.453819) (xy -2.955436 -0.488392)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "9240aa0e-e40b-4517-8b9d-301704015132")
+		)
+		(fp_curve
+			(pts
+				(xy -3.098311 -0.387497) (xy -3.150522 -0.433711) (xy -3.203439 -0.478867) (xy -3.254239 -0.526492)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "b743855f-c15a-4cea-b15f-592058e385f1")
+		)
+		(fp_curve
+			(pts
+				(xy -3.142761 -1.457825) (xy -2.992478 -1.381625) (xy -2.917689 -1.648325) (xy -3.064445 -1.681839)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "e4794da5-28c4-4d92-837e-f940408ec821")
+		)
+		(fp_curve
+			(pts
+				(xy -3.142761 -1.457825) (xy -3.286695 -1.510389) (xy -3.202028 -1.718528) (xy -3.064445 -1.681839)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ee52328b-6ed8-4f0c-98e6-32c5544c475b")
+		)
+		(fp_curve
+			(pts
+				(xy -3.193914 -1.132917) (xy -2.944853 -1.125155) (xy -2.695792 -1.129036) (xy -2.447083 -1.138208)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "3da60c95-8ef8-4d13-b1c8-893241d040eb")
+		)
+		(fp_curve
+			(pts
+				(xy -3.254239 -0.526492) (xy -3.20097 -0.579761) (xy -3.149111 -0.634442) (xy -3.090903 -0.682419)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "b1475af6-ac9b-4ab8-a2f9-96df0b18a2bd")
+		)
+		(fp_curve
+			(pts
+				(xy -3.254239 -0.526492) (xy -3.203439 -0.478867) (xy -3.150522 -0.433711) (xy -3.098311 -0.387497)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "00f21387-1cfb-4096-af78-0bd2e9848db4")
+		)
+		(fp_curve
+			(pts
+				(xy -3.261647 -1.367867) (xy -3.146289 -1.367161) (xy -3.030931 -1.367161) (xy -2.915572 -1.367867)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "ea17deb3-8da6-4d92-9dd9-b17b99fcae97")
+		)
+		(fp_curve
+			(pts
+				(xy -3.261647 -1.367867) (xy -3.280345 -1.582355) (xy -3.281756 -1.797903) (xy -3.275758 -2.013097)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c3849ded-fe9b-47d3-b2e3-36ef20898f5d")
+		)
+		(fp_curve
+			(pts
+				(xy -3.2747 -2.345414) (xy -3.27082 -2.234642) (xy -3.271525 -2.123869) (xy -3.275758 -2.013097)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "0d8dc067-7a07-4417-9864-2765ad2414a7")
+		)
+		(fp_curve
+			(pts
+				(xy -3.275758 -2.013097) (xy -3.281756 -1.797903) (xy -3.280345 -1.582355) (xy -3.261647 -1.367867)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "6b5edbc7-394e-44a7-a4cc-0847a5a3d761")
+		)
+		(fp_curve
+			(pts
+				(xy -3.275758 -2.013097) (xy -3.337142 -1.948539) (xy -3.421103 -1.887508) (xy -3.428511 -1.7912)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "dcebb0bd-1059-4022-a70c-c71879adb63d")
+		)
+		(fp_curve
+			(pts
+				(xy -3.335025 2.314428) (xy -3.474372 2.315839) (xy -3.615483 2.302786) (xy -3.75342 2.326775)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "4eaa86db-492a-43fc-9cff-1c6af6078c56")
+		)
+		(fp_curve
+			(pts
+				(xy -3.428511 -1.7912) (xy -3.443681 -1.641975) (xy -3.442975 -1.490986) (xy -3.42957 -1.342114)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "072abe41-592c-4ba1-b07f-7cbf0859906d")
+		)
+		(fp_curve
+			(pts
+				(xy -3.42957 -1.342114) (xy -3.421103 -1.22605) (xy -3.309625 -1.129036) (xy -3.193914 -1.132917)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "5dbf9791-e5c1-42e3-93f5-2ed09665c803")
+		)
+		(fp_curve
+			(pts
+				(xy -3.653936 -0.373386) (xy -3.460261 -0.364919) (xy -3.266586 -0.374092) (xy -3.072911 -0.369153)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "56450031-d497-4b1a-b3fc-9d96b6fe0808")
+		)
+		(fp_curve
+			(pts
+				(xy -3.683922 -0.700764) (xy -3.86137 -0.685242) (xy -3.834559 -0.357158) (xy -3.653936 -0.373386)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "fabe0506-2965-4495-86e9-2cfe0cf35e90")
+		)
+		(fp_curve
+			(pts
+				(xy -3.75342 2.326775) (xy -3.847258 2.414264) (xy -3.778114 2.547614) (xy -3.762239 2.652742)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "a9d2b5d3-9231-47bb-a243-faa885cfbf9d")
+		)
+		(fp_curve
+			(pts
+				(xy -3.762239 2.652742) (xy -1.219417 2.653095) (xy 1.323053 2.6538) (xy 3.865522 2.652742)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "f5d75b5b-3eb8-4c6d-91d2-5fc184146905")
+		)
+		(fp_curve
+			(pts
+				(xy -3.768942 -2.651272) (xy -3.770353 -2.55073) (xy -3.771058 -2.450189) (xy -3.77 -2.35)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "c8f7a0e0-f28f-4276-9efd-55d0d365c0f5")
+		)
+		(fp_curve
+			(pts
+				(xy -3.77 -2.35) (xy -3.605253 -2.343297) (xy -3.4398 -2.343297) (xy -3.2747 -2.345414)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "b8247daa-1ef6-45cd-9b69-55f07c39c84a")
+		)
+		(fp_curve
+			(pts
+				(xy -4.069156 2.931083) (xy -4.07092 2.930378) (xy -4.074095 2.92932) (xy -4.075858 2.928967)
+			)
+			(stroke
+				(width 0.001)
+				(type solid)
+			)
+			(layer "Dwgs.User")
+			(uuid "8b8e1c59-50ca-45e5-aea2-dbfd34dadd01")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Jumper:SolderJumper-2_P1.3mm_Bridged_RoundedPad1.0x1.5mm"
+		(layer "B.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec8a52")
+		(at 57.433300 42.040000 180)
+		(descr "SMD Solder Jumper, 1x1.5mm, rounded Pads, 0.3mm gap, bridged with 1 copper strip")
+		(tags "solder jumper open")
+		(property "Reference" "JP1"
+			(at 0 1.8 0)
+			(layer "B.Fab")
+			(uuid "6619ae18-a2e0-419c-b564-060e048898ab")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Value" "ISO"
+			(at 2.35 0 90)
+			(layer "B.SilkS")
+			(uuid "db820133-fc12-4953-98d7-3ef8d0cfaea8")
+			(effects
+				(font
+					(size 0.8 0.8)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "b6b40ad5-c287-4cd4-a5ab-3ba9a66fe464")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "80f49484-ff3c-440c-a603-d8c7a02361e1")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-00005f174cc0")
+		(attr exclude_from_pos_files exclude_from_bom)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_poly
+			(pts
+				(xy 0.25 0.3) (xy -0.25 0.3) (xy -0.25 -0.3) (xy 0.25 -0.3)
+			)
+			(stroke
+				(width 0)
+				(type solid)
+			)
+			(fill yes)
+			(layer "B.Cu")
+			(uuid "135e579b-a407-4d1d-bb87-5c56faa2ce6f")
+		)
+		(fp_line
+			(start 1.4 0.3)
+			(end 1.4 -0.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "e62694a2-fbfe-4f3c-94bd-659ea5f07448")
+		)
+		(fp_line
+			(start 0.7 -1)
+			(end -0.7 -1)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "35ff873b-1c76-4276-8ad8-e85217819be2")
+		)
+		(fp_line
+			(start -0.7 1)
+			(end 0.7 1)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "4bca4a42-2f54-410f-9982-e486e5b6e4e1")
+		)
+		(fp_line
+			(start -1.4 -0.3)
+			(end -1.4 0.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "a6f399c9-8400-4d85-b17a-1a4d51d5c268")
+		)
+		(fp_arc
+			(start 1.4 0.3)
+			(mid 1.194975 0.794975)
+			(end 0.7 1)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "ae9c8e40-2cf4-43fc-9d93-8a88aea47f5b")
+		)
+		(fp_arc
+			(start 0.7 -1)
+			(mid 1.194975 -0.794975)
+			(end 1.4 -0.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "604069d0-b245-4e58-8309-92588ee45eca")
+		)
+		(fp_arc
+			(start -0.7 1)
+			(mid -1.194975 0.794975)
+			(end -1.4 0.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "9a3e6d9f-bdb8-4316-be98-b578160b9fb6")
+		)
+		(fp_arc
+			(start -1.4 -0.3)
+			(mid -1.194975 -0.794975)
+			(end -0.7 -1)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "412c20e3-6f9f-43aa-9499-864f61f18374")
+		)
+		(fp_line
+			(start 1.65 -1.25)
+			(end 1.65 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "B.CrtYd")
+			(uuid "edc21def-d39a-4d54-b0d9-5eafd01d45b5")
+		)
+		(fp_line
+			(start 1.65 -1.25)
+			(end -1.65 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "B.CrtYd")
+			(uuid "102dbe95-cb42-4279-b430-85ee09b4b958")
+		)
+		(fp_line
+			(start -1.65 1.25)
+			(end 1.65 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "B.CrtYd")
+			(uuid "b40e1adc-db91-4e98-8101-2f8bc5e7ace1")
+		)
+		(fp_line
+			(start -1.65 1.25)
+			(end -1.65 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "B.CrtYd")
+			(uuid "c4c0943f-90da-4bb6-90ce-65c164bd5b92")
+		)
+		(pad "1" smd custom
+			(at -0.65 0 180)
+			(size 1 0.5)
+			(layers "B.Cu" "B.Mask")
+			(net "VTARGET")
+			(zone_connect 2)
+			(options
+				(clearance outline)
+				(anchor rect)
+			)
+			(primitives
+				(gr_circle
+					(center 0 -0.25)
+					(end 0.5 -0.25)
+					(width 0)
+					(fill yes)
+				)
+				(gr_circle
+					(center 0 0.25)
+					(end 0.5 0.25)
+					(width 0)
+					(fill yes)
+				)
+				(gr_poly
+					(pts
+						(xy 0 0.75) (xy 0.5 0.75) (xy 0.5 -0.75) (xy 0 -0.75)
+					)
+					(width 0)
+					(fill yes)
+				)
+			)
+			(uuid "093aa1be-efc6-4b3c-aee6-b01c65d5af00")
+		)
+		(pad "2" smd custom
+			(at 0.65 0 180)
+			(size 1 0.5)
+			(layers "B.Cu" "B.Mask")
+			(net "VREF")
+			(zone_connect 2)
+			(options
+				(clearance outline)
+				(anchor rect)
+			)
+			(primitives
+				(gr_circle
+					(center 0 -0.25)
+					(end 0.5 -0.25)
+					(width 0)
+					(fill yes)
+				)
+				(gr_circle
+					(center 0 0.25)
+					(end 0.5 0.25)
+					(width 0)
+					(fill yes)
+				)
+				(gr_poly
+					(pts
+						(xy 0 0.75) (xy -0.5 0.75) (xy -0.5 -0.75) (xy 0 -0.75)
+					)
+					(width 0)
+					(fill yes)
+				)
+			)
+			(uuid "f71a041b-0da5-4501-91ff-8255b7324eb3")
+		)
+		(embedded_fonts no)
+	)
+	(footprint "Jumper:SolderJumper-2_P1.3mm_Open_RoundedPad1.0x1.5mm"
+		(layer "B.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec9c8a")
+		(at 45.750000 57.650000 180)
+		(descr "SMD Solder Jumper, 1x1.5mm, rounded Pads, 0.3mm gap, open")
+		(tags "solder jumper open")
+		(property "Reference" "JP2"
+			(at 0 1.8 0)
+			(layer "B.Fab")
+			(uuid "c331ffb5-09c7-42c7-9d8d-56dafb8057be")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Value" "HACK"
+			(at 0 -2 0)
+			(layer "B.SilkS")
+			(uuid "5ebb4efe-445e-452b-94ba-b7a78e30f111")
+			(effects
+				(font
+					(size 0.8 0.8)
+					(thickness 0.15)
+				)
+				(justify mirror)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "6461f297-7cf9-4281-84b7-43cf48772353")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 180)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "4b2d93fc-059e-4f55-8857-b2a92ff62fa3")
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(path "/00000000-0000-0000-0000-0000617b0db5")
+		(attr exclude_from_pos_files exclude_from_bom)
+		(duplicate_pad_numbers_are_jumpers no)
+		(fp_line
+			(start 1.4 0.3)
+			(end 1.4 -0.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "1f3e5cdd-72bb-42b3-8c92-ae17e3becd0c")
+		)
+		(fp_line
+			(start 0.7 -1)
+			(end -0.7 -1)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "e06676da-fea3-4ea5-8bb9-8027fecbb3cc")
+		)
+		(fp_line
+			(start -0.7 1)
+			(end 0.7 1)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "f8e4998f-1c9c-4ee3-be29-2051c71b0036")
+		)
+		(fp_line
+			(start -1.4 -0.3)
+			(end -1.4 0.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "b4e5d1f3-3c27-411e-aba3-ddfb2dc2537f")
+		)
+		(fp_arc
+			(start 1.4 0.3)
+			(mid 1.194975 0.794975)
+			(end 0.7 1)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "c40cc05a-0210-4c59-9ace-322ce617633e")
+		)
+		(fp_arc
+			(start 0.7 -1)
+			(mid 1.194975 -0.794975)
+			(end 1.4 -0.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "57ef1809-990f-4421-9707-003f104f0129")
+		)
+		(fp_arc
+			(start -0.7 1)
+			(mid -1.194975 0.794975)
+			(end -1.4 0.3)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "1b6e810d-b089-4ea0-b771-08da357da4c7")
+		)
+		(fp_arc
+			(start -1.4 -0.3)
+			(mid -1.194975 -0.794975)
+			(end -0.7 -1)
+			(stroke
+				(width 0.12)
+				(type solid)
+			)
+			(layer "B.SilkS")
+			(uuid "44f22ad3-b3c5-4cdb-8ae8-af431f32606c")
+		)
+		(fp_line
+			(start 1.65 -1.25)
+			(end 1.65 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "B.CrtYd")
+			(uuid "35ed4132-c024-46eb-85d7-8c818884ba83")
+		)
+		(fp_line
+			(start 1.65 -1.25)
+			(end -1.65 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "B.CrtYd")
+			(uuid "7b0d608d-f0d6-4af5-82b5-6e53193c2600")
+		)
+		(fp_line
+			(start -1.65 1.25)
+			(end 1.65 1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "B.CrtYd")
+			(uuid "7698f274-bb49-4a03-8275-7dc67b7c13d3")
+		)
+		(fp_line
+			(start -1.65 1.25)
+			(end -1.65 -1.25)
+			(stroke
+				(width 0.05)
+				(type solid)
+			)
+			(layer "B.CrtYd")
+			(uuid "71f74abb-5aba-4b40-a353-62a7ebd2a081")
+		)
+		(pad "1" smd custom
+			(at -0.65 0 180)
+			(size 1 0.5)
+			(layers "B.Cu" "B.Mask")
+			(net "/COPI")
+			(zone_connect 2)
+			(options
+				(clearance outline)
+				(anchor rect)
+			)
+			(primitives
+				(gr_circle
+					(center 0 -0.25)
+					(end 0.5 -0.25)
+					(width 0)
+					(fill yes)
+				)
+				(gr_circle
+					(center 0 0.25)
+					(end 0.5 0.25)
+					(width 0)
+					(fill yes)
+				)
+				(gr_poly
+					(pts
+						(xy 0 0.75) (xy 0.5 0.75) (xy 0.5 -0.75) (xy 0 -0.75)
+					)
+					(width 0)
+					(fill yes)
+				)
+			)
+			(uuid "e19882a6-91d3-40a9-b481-72d2ab10dc6c")
+		)
+		(pad "2" smd custom
+			(at 0.65 0 180)
+			(size 1 0.5)
+			(layers "B.Cu" "B.Mask")
+			(net "/SWDIO")
+			(zone_connect 2)
+			(options
+				(clearance outline)
+				(anchor rect)
+			)
+			(primitives
+				(gr_circle
+					(center 0 -0.25)
+					(end 0.5 -0.25)
+					(width 0)
+					(fill yes)
+				)
+				(gr_circle
+					(center 0 0.25)
+					(end 0.5 0.25)
+					(width 0)
+					(fill yes)
+				)
+				(gr_poly
+					(pts
+						(xy 0 0.75) (xy -0.5 0.75) (xy -0.5 -0.75) (xy 0 -0.75)
+					)
+					(width 0)
+					(fill yes)
+				)
+			)
+			(uuid "b60541fe-2e77-4cb4-b5d8-afd1f728e58d")
+		)
+		(embedded_fonts no)
+	)
+	(gr_line
+		(start 30 30.00236)
+		(end 75.99764 30.00236)
+		(stroke
+			(width 0.05)
+			(type default)
+		)
+		(layer "Edge.Cuts")
+		(uuid "b4ae0a91-b8aa-4a95-81f4-6b410cec069c")
+	)
+	(gr_line
+		(start 30 76)
+		(end 30 30.00236)
+		(stroke
+			(width 0.05)
+			(type default)
+		)
+		(layer "Edge.Cuts")
+		(uuid "7da3a505-70eb-4f94-8bc3-6d40dad8d5a1")
+	)
+	(gr_line
+		(start 75.99764 30.00236)
+		(end 75.99764 76)
+		(stroke
+			(width 0.05)
+			(type default)
+		)
+		(layer "Edge.Cuts")
+		(uuid "17c23777-360a-40a2-99ca-639848ab7c46")
+	)
+	(gr_line
+		(start 75.99764 76)
+		(end 30 76)
+		(stroke
+			(width 0.05)
+			(type default)
+		)
+		(layer "Edge.Cuts")
+		(uuid "cf2dc8b0-dfd6-4067-b900-5252aea5e0b4")
+	)
+	(zone
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec7979")
+		(hatch edge 0.508)
+		(connect_pads
+			(clearance 0)
+		)
+		(min_thickness 0.254)
+		(keepout
+			(tracks allowed)
+			(vias allowed)
+			(pads allowed)
+			(copperpour not_allowed)
+			(footprints allowed)
+		)
+		(placement
+			(enabled no)
+			(sheetname "")
+		)
+		(fill
+			(thermal_gap 0.508)
+			(thermal_bridge_width 0.508)
+			(island_removal_mode 0)
+		)
+		(polygon
+			(pts
+				(xy 39.75 53.65) (xy 39.5 53.65) (xy 39.5 52.9) (xy 39.75 52.9)
+			)
+		)
+	)
+	(zone
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec797c")
+		(hatch edge 0.508)
+		(connect_pads
+			(clearance 0)
+		)
+		(min_thickness 0.254)
+		(keepout
+			(tracks allowed)
+			(vias allowed)
+			(pads allowed)
+			(copperpour not_allowed)
+			(footprints allowed)
+		)
+		(placement
+			(enabled no)
+			(sheetname "")
+		)
+		(fill
+			(thermal_gap 0.508)
+			(thermal_bridge_width 0.508)
+			(island_removal_mode 0)
+		)
+		(polygon
+			(pts
+				(xy 42.5 54.9) (xy 41.5 54.9) (xy 41.5 51.4) (xy 42.5 51.4)
+			)
+		)
+	)
+	(zone
+		(layer "F.Cu")
+		(uuid "00000000-0000-0000-0000-00005eec797f")
+		(hatch edge 0.508)
+		(connect_pads thru_hole_only
+			(clearance 0)
+		)
+		(min_thickness 0.15)
+		(keepout
+			(tracks allowed)
+			(vias allowed)
+			(pads allowed)
+			(copperpour not_allowed)
+			(footprints allowed)
+		)
+		(placement
+			(enabled no)
+			(sheetname "")
+		)
+		(fill
+			(thermal_gap 0.25)
+			(thermal_bridge_width 0.25)
+			(island_removal_mode 0)
+		)
+		(polygon
+			(pts
+				(xy 51.25 52.4) (xy 51.25 53.65) (xy 52.5 53.65) (xy 52.5 55.15) (xy 49 55.15) (xy 49 51.15) (xy 50 51.15)
+			)
+		)
+	)
+	(embedded_fonts no)
+)

--- a/tests/fixtures/run23/tigard_placed.kicad_pro
+++ b/tests/fixtures/run23/tigard_placed.kicad_pro
@@ -1,0 +1,88 @@
+{
+  "board": {
+    "design_settings": {
+      "defaults": {},
+      "diff_pair_dimensions": [],
+      "drc_exclusions": [],
+      "rules": {
+        "min_clearance": 0.15,
+        "min_track_width": 0.15,
+        "min_via_diameter": 0.5
+      },
+      "rule_severities": {},
+      "track_widths": [],
+      "via_dimensions": []
+    },
+    "layer_presets": [],
+    "viewports": []
+  },
+  "boards": [],
+  "cvpcb": {
+    "equivalence_files": []
+  },
+  "libraries": {
+    "pinned_footprint_libs": [],
+    "pinned_symbol_libs": []
+  },
+  "meta": {
+    "filename": "tigard.kicad_pro",
+    "version": 1
+  },
+  "net_settings": {
+    "classes": [
+      {
+        "bus_width": 12,
+        "clearance": 0.15,
+        "diff_pair_gap": 0.2032,
+        "diff_pair_width": 0.205232,
+        "line_style": 0,
+        "microvia_diameter": 0.3,
+        "microvia_drill": 0.1,
+        "name": "Default",
+        "pcb_color": "rgba(0, 0, 0, 0.000)",
+        "schematic_color": "rgba(0, 0, 0, 0.000)",
+        "track_width": 0.15,
+        "via_diameter": 0.5,
+        "via_drill": 0.25,
+        "wire_width": 6
+      }
+    ],
+    "meta": {
+      "version": 3
+    },
+    "net_colors": null,
+    "netclass_assignments": null,
+    "netclass_patterns": []
+  },
+  "pcbnew": {
+    "last_paths": {},
+    "page_layout_descr_file": ""
+  },
+  "schematic": {},
+  "sheets": [],
+  "text_variables": {},
+  "kicad_routing_tools": {
+    "floor_provenance": {
+      "_note": "MIGRATED, not authored and not guessed. tigard is a KiCad 5 design (board version 20171130) which stored its design rules INSIDE the .kicad_pcb, and KiCad 5 had no .kicad_pro at all -- so no project file exists upstream to copy. The board in kicad_files/ was re-saved through pcbnew 10.0 (version 20260206) during corpus staging, which dropped the (setup ...) constraints and every (net_class ...) stanza. The values below were read back out of the upstream board and are the author's own; none is a default, a fab tier, or an inference.",
+      "source": "https://raw.githubusercontent.com/tigard-tools/tigard/master/tigard.kicad_pcb",
+      "source_version": 20171130,
+      "verified": "85 net names upstream vs 85 parsed here, 79 identical; the 6 differences are the KiCad 5->9 overbar syntax change (/~ENABLE -> /~{ENABLE}), not a design difference",
+      "fields": {
+        "net_settings.classes[Default].clearance": "(net_class Default (clearance 0.15))",
+        "net_settings.classes[Default].track_width": "(net_class Default (trace_width 0.15))",
+        "net_settings.classes[Default].via_diameter": "(net_class Default (via_dia 0.5))",
+        "net_settings.classes[Default].via_drill": "(net_class Default (via_drill 0.25))",
+        "net_settings.classes[Default].diff_pair_width": "(net_class Default (diff_pair_width 0.205232))",
+        "net_settings.classes[Default].diff_pair_gap": "(net_class Default (diff_pair_gap 0.2032))",
+        "net_settings.classes[Default].microvia_diameter": "(net_class Default (uvia_dia 0.3))",
+        "net_settings.classes[Default].microvia_drill": "(net_class Default (uvia_drill 0.1))",
+        "board.design_settings.rules.min_clearance": "(setup (trace_clearance 0.15))",
+        "board.design_settings.rules.min_track_width": "(setup (trace_min 0.15))",
+        "board.design_settings.rules.min_via_diameter": "(setup (via_min_size 0.5))"
+      },
+      "deliberately_absent": {
+        "board.design_settings.rules.min_copper_edge_clearance": "KiCad 5 had no copper-to-edge constraint, so the author never declared one. Left absent so board_floor_knobs reports `fixed default` 0.55 with an honest source, rather than a number nobody chose wearing a board's name."
+      }
+    }
+  }
+}

--- a/tests/run_all.py
+++ b/tests/run_all.py
@@ -22,6 +22,7 @@ maintained list; a new pytest-style test can instead use @pytest.mark.integratio
 import argparse
 import glob
 import os
+import re
 import subprocess
 import sys
 import time
@@ -33,6 +34,39 @@ ROOT = os.path.dirname(TESTS_DIR)
 _EXCLUDE = {'run_all.py', 'run_utils.py', 'run_doc_examples.py', 'conftest.py', 'synth.py'}
 
 _INTEGRATION_MARKERS = ('import run_utils', 'from run_utils', 'subprocess')
+
+# A test exits with this when it CANNOT run -- a fixture it needs is absent --
+# as distinct from passing. 77 is the autotools convention. Before this, a test
+# that printed "SKIP: ..." and exited 0 was indistinguishable from a green one,
+# which is how a headline acceptance test reported PASS on every clone while
+# asserting nothing. A self-skip gets its own bucket and never counts as a pass.
+SKIP_EXIT = 77
+
+#: A test may declare its own budget with a module-level
+#: `RUN_ALL_TIMEOUT = <seconds>`. Read from the SOURCE, not by importing --
+#: importing a test runs it.
+#:
+#: Why this exists: three tests carried internal budgets ABOVE this runner's
+#: cap (test_compare_seeds sets timeout=3600 on its own subprocess,
+#: test_obstacle_map_balance 1200) and were killed at 600 s before their own
+#: deadline could fire -- so they produced no partial result and no
+#: diagnosis, and a machine-speed fact was reported as a code fact. Measured:
+#: test_obstacle_map_balance passes ALONE in 681 s with all 18 checks green.
+#:
+#: A declared budget is a claim the test makes about itself, in the test,
+#: where the next reader will look. Raising the GLOBAL --timeout instead
+#: would hide a genuinely hung test behind the slow ones.
+_BUDGET_RE = re.compile(r'^RUN_ALL_TIMEOUT\s*=\s*([0-9.]+)', re.M)
+
+
+def _declared_budget(path, default):
+    try:
+        m = _BUDGET_RE.search(open(path, encoding='utf-8',
+                                   errors='replace').read())
+    except OSError:
+        return default
+    return max(float(m.group(1)), default) if m else default
+
 
 
 def is_integration(path: str) -> bool:
@@ -105,6 +139,7 @@ def main():
 
     def run_one(f):
         name = os.path.basename(f)
+        budget = _declared_budget(f, args.timeout)
         try:
             # `text=True` alone decodes with the LOCALE default (cp1252 on
             # Windows) and raises UnicodeDecodeError in the reader thread the
@@ -116,22 +151,45 @@ def main():
             r = subprocess.run([sys.executable, '-X', 'utf8', f], cwd=ROOT,
                                capture_output=True, text=True,
                                encoding='utf-8', errors='replace',
-                               timeout=args.timeout)
+                               timeout=budget)
         except subprocess.TimeoutExpired:
-            return name, None, (f'TIME  {name}  (timeout after '
-                                f'{args.timeout:.0f}s -- NOT a failed '
+            return name, ('timeout', budget), (f'TIME  {name}  (timeout after '
+                                f'{budget:.0f}s -- NOT a failed '
                                 f'assertion; re-run it alone before treating '
                                 f'it as one)')
+        if r.returncode == SKIP_EXIT:
+            # A test that cannot run (a fixture it needs is absent) must not
+            # report PASS. Before this existed, `sys.exit(0)` after printing
+            # "SKIP: ..." was indistinguishable from a green run -- which is
+            # how the placement branch's headline acceptance test reported
+            # PASS on every clone while asserting nothing, for weeks.
+            why = ''
+            for line in (r.stdout or '').splitlines():
+                if line.strip().upper().startswith('SKIP'):
+                    why = line.strip()
+                    break
+            return name, 'skip', f'SKIP  {name}  ({why or "self-skipped"})'
         if r.returncode == 0:
             return name, True, f'PASS  {name}'
         tail = (r.stdout or '')[-800:] + (r.stderr or '')[-800:]
         return name, False, f'FAIL  {name}  (exit {r.returncode})\n{tail}'
 
     timed_out = []
+    self_skipped = []
 
     def record(name, ok, line):
-        if ok is None:
-            timed_out.append(name)
+        if ok == 'skip':
+            # NOT a pass and NOT a timeout: the test declined to run. Kept in
+            # its own bucket so the summary cannot read as green.
+            self_skipped.append(name)
+        elif isinstance(ok, tuple) and ok and ok[0] == 'timeout':
+            # Carry the budget this test ACTUALLY got. The summary used to
+            # print the global --timeout for every row, so a test killed at
+            # its own declared 1800s was reported as "Timed out at 600s" --
+            # which sends the reader to raise a cap the test had already been
+            # given 3x of. The per-test TIME line was right all along; only
+            # the line people read was wrong.
+            timed_out.append((name, ok[1]))
         elif ok:
             passed.append(name)
         else:
@@ -154,12 +212,20 @@ def main():
     # gets its own bucket and never joins the exit-deciding `failed` count on
     # its own -- but the exit code still goes non-zero, because an unfinished
     # suite is not a green one.
+    if self_skipped:
+        print(f'\nSELF-SKIPPED ({len(self_skipped)}) -- these asserted '
+              f'NOTHING; they are not passes:')
+        for n in self_skipped:
+            print(f'  {n}')
     print(f'\n{len(passed)} passed, {len(failed)} failed, '
-          f'{len(timed_out)} timed out, {len(skipped)} skipped in {dt:.1f}s')
+          f'{len(timed_out)} timed out, {len(skipped)} skipped '
+          f'(+{len(self_skipped)} self-skipped) in {dt:.1f}s')
     if failed:
         print('Failed: ' + ', '.join(failed))
     if timed_out:
-        print(f'Timed out at {args.timeout:.0f}s: ' + ', '.join(timed_out))
+        print('Timed out: ' + ', '.join(
+            f'{n} (at its own {b:.0f}s budget)' if b > args.timeout
+            else f'{n} (at {b:.0f}s)' for n, b in timed_out))
         print('  A timeout is not evidence of a broken test. Re-run each one '
               'alone (or raise --timeout) before recording it as a failure.')
     return 1 if (failed or timed_out) else 0

--- a/tests/run_utils.py
+++ b/tests/run_utils.py
@@ -6,10 +6,71 @@ from __future__ import annotations
 import os
 import shlex
 import subprocess
+import sys
 
 # Get the root directory (parent of tests/)
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
 ROOT_DIR = os.path.dirname(TESTS_DIR)
+
+#: Where the #522 reorg put the CLIs. Same order as krt_capabilities._TOOL_DIRS,
+#: which is the resolver this delegates to.
+_TOOL_DIRS = ('', 'py_router', 'py_tools', 'py_placer')
+
+
+def tool(name):
+    """Absolute path to a shipped CLI, wherever the #522 reorg put it.
+
+    RAISES when the tool is absent, and that is the whole point.
+
+    Commit ee860796 moved route.py, check_drc.py, place_optimize.py and the
+    rest out of the repo root into py_router/ py_tools/ py_placer/. EIGHTEEN
+    tests kept spawning `os.path.join(ROOT, 'route.py')`. Python exits 2 with
+    `can't open file ...: [Errno 2]` on STDERR, and those tests all assert on
+    STDOUT -- so the whole class surfaced as a bare AssertionError with an
+    empty message that reads exactly like a product failure. They sat red long
+    enough that several of them rotted into FALSE PASSES underneath: five of
+    test_soft_joint's ten checks "passed" only because the subprocess produced
+    no output at all, and test_457_startup_checks' `returncode == 1` passed
+    because ModuleNotFoundError also exits 1.
+
+    So a missing tool must fail HERE, naming what it looked for and where,
+    rather than three frames away inside a subprocess. A static lint cannot do
+    this job: test_431_board_gates builds `os.path.join(ROOT, script)` with
+    `script` a variable, so the bad path is only knowable at runtime. This
+    function is the gate.
+    """
+    try:
+        sys.path.insert(0, ROOT_DIR)
+        from krt_capabilities import _tool_path       # the shipped resolver
+        p = _tool_path(ROOT_DIR, name)
+    except Exception:                                  # pragma: no cover
+        p = os.path.join(ROOT_DIR, name)
+    if not os.path.isfile(p):
+        raise FileNotFoundError(
+            f'{name!r} is not in this checkout. Looked in: '
+            + ', '.join(repr(os.path.join(d, name) or name)
+                        for d in _TOOL_DIRS)
+            + '. If a tool moved, fix the caller -- do not hardcode a new path.')
+    return p
+
+
+def tool_env(env=None):
+    """An environment whose PYTHONPATH reaches every package the reorg made.
+
+    The sibling defect to `tool`: a subprocess probe launched with
+    `PYTHONPATH=ROOT` alone cannot `import kicad_parser` or `import
+    startup_checks` any more, because both moved into py_router/. The child
+    dies with ModuleNotFoundError and the parent reports whatever that exit
+    code happens to collide with.
+    """
+    env = dict(os.environ if env is None else env)
+    parts = [os.path.join(ROOT_DIR, d) if d else ROOT_DIR
+             for d in _TOOL_DIRS]
+    prev = env.get('PYTHONPATH')
+    if prev:
+        parts.append(prev)
+    env['PYTHONPATH'] = os.pathsep.join(parts)
+    return env
 
 
 def run(cmd: str, unbuffered: bool = False) -> None:

--- a/tests/stress/arm_report.py
+++ b/tests/stress/arm_report.py
@@ -46,8 +46,8 @@ sys.path.insert(0, os.path.join(ROOT, 'py_placer'))  # #522/py_placer layout
 sys.path.insert(0, os.path.join(ROOT, 'py_tools'))  # #522/py_placer layout
 os.environ.setdefault('KRT_NO_BANNER', '1')
 
-SKILL_SCRIPTS = os.path.join(ROOT, '.claude', 'skills', 'plan-pcb-routing',
-                             'scripts')
+SKILL_SCRIPTS = os.path.join(ROOT, '.claude', 'skills',
+                             'plan-pcb-placement-and-routing', 'scripts')
 PY = [sys.executable, '-X', 'utf8']
 
 

--- a/tests/stress/fence_audit.py
+++ b/tests/stress/fence_audit.py
@@ -198,7 +198,15 @@ def _json_poses(path):
 #: Extensions the scan opens. This module's thesis -- "the next carrier will
 #: have a different name" -- applies to EXTENSIONS exactly as it does to stems,
 #: and the scan used to stop at `.kicad_pcb`.
-SCANNED_EXT = ('.kicad_pcb', '.json')
+#:
+#: `.kicad_pro` earns its place the same way. The project MUST travel with a
+#: staged board or it grades at the stock netclass (#441), but KiCad stores
+#: `meta.filename` and `pcbnew.last_paths` inside it -- so a verbatim copy
+#: put the SOURCE'S NAME and the author's directories in the work dir, and
+#: this scan opened one file and returned CLEAN. A `.kicad_pro` carries no
+#: poses, so it is checked for IDENTITY rather than placement: see
+#: `_names_control`.
+SCANNED_EXT = ('.kicad_pcb', '.json', '.kicad_pro')
 
 
 #: A pad centre and a track end are "the same point" within this. Run 14
@@ -298,7 +306,32 @@ def copper_carries_poses(pcb, control_pads):
     return len(displaced), hits, rate, base
 
 
-def scan(workdir, control_poses, allow, control_pads=None):
+def _names_control(path, control_stem):
+    """Strings in this project that name the control's board.
+
+    A `.kicad_pro` carries no poses, so the leak it can commit is IDENTITY:
+    KiCad writes `meta.filename`, and `pcbnew.last_paths` holds the author's
+    own directories. Either one is a path back to the original placement,
+    which is exactly what "the source is recorded by HASH, not by path"
+    exists to prevent. Substring, not equality: `last_paths` embeds the stem
+    inside a longer path.
+    """
+    if not control_stem:
+        return []
+    try:
+        with open(path, encoding='utf-8') as f:
+            raw = f.read()
+    except Exception:                                # noqa: BLE001
+        return []
+    hits = []
+    for line in raw.splitlines():
+        if control_stem in line:
+            hits.append(line.strip()[:120])
+    return hits[:6]
+
+
+def scan(workdir, control_poses, allow, control_pads=None,
+         control_stem=None):
     """Every scannable file in workdir, scored against the control's poses."""
     rows = []
     for root, _dirs, files in os.walk(workdir):
@@ -312,6 +345,22 @@ def scan(workdir, control_poses, allow, control_pads=None):
                 continue
             _copper = None
             try:
+                if name.endswith('.kicad_pro'):
+                    # Identity, not poses: does this project name the board
+                    # the control came from? The stem is what a Read would
+                    # follow back to the original placement.
+                    hit = _names_control(path, control_stem)
+                    if hit:
+                        rows.append({
+                            'file': rel, 'kind': 'project',
+                            'match_frac': 1.0, 'refs_shared': 0,
+                            'worst_mm': None,
+                            'carries_truth': True,
+                            'truth_channel': 'identity',
+                            'names_source': hit,
+                            'sha256': _sha256(path),
+                            'mtime': os.path.getmtime(path)})
+                    continue
                 if name.endswith('.json'):
                     poses = _json_poses(path)
                     if poses is None:
@@ -383,7 +432,33 @@ def main(argv=None):
     # report the audit's own reference as a leak.
     control_real = os.path.realpath(args.control)
 
-    rows = [r for r in scan(args.workdir, control_poses, allow, control_pads)
+    # WHICH name is the leak: the SOURCE's, not the control's. Both stagers
+    # write the control as `control.kicad_pcb`, so its own stem names
+    # nothing; the source basename is recorded in `stage.json` beside it,
+    # which is the whole point of recording the source by hash and name
+    # THERE (outside the fence) rather than in the work dir.
+    # BOTH stagers, because they record it under different names and a check
+    # that knows only one is inert for the other: `stage_unaided` writes
+    # stage.json/source_basename, `stage_blind` writes draw.json/source. The
+    # first version read stage.json alone and returned CLEAN on a blind work
+    # dir whose project said "watchy.kicad_pro".
+    _stem = None
+    _truth = os.path.dirname(os.path.abspath(args.control))
+    for _name, _key in (('stage.json', 'source_basename'),
+                        ('draw.json', 'source')):
+        _p = os.path.join(_truth, _name)
+        if _stem or not os.path.isfile(_p):
+            continue
+        try:
+            with open(_p, encoding='utf-8') as _f:
+                _raw = json.load(_f).get(_key) or ''
+            _stem = os.path.splitext(os.path.basename(_raw))[0] or None
+        except Exception:                            # noqa: BLE001
+            _stem = None
+    if not _stem:
+        _stem = os.path.splitext(os.path.basename(args.control))[0]
+    rows = [r for r in scan(args.workdir, control_poses, allow, control_pads,
+                            control_stem=_stem)
             if os.path.realpath(os.path.join(args.workdir, r['file'])) != control_real]
 
     manifest_path = os.path.join(args.workdir, MANIFEST_NAME)
@@ -527,6 +602,14 @@ def main(argv=None):
                         f'stripped -- the tracks point at where each part '
                         f'belongs. Strip it with '
                         f'tests/stress/strip_copper_only.py')
+            elif row.get('truth_channel') == 'identity':
+                # A project carries no poses; what it can leak is the SOURCE'S
+                # NAME, which is one Read away from the original placement.
+                _how = ('NAMES THE SOURCE: '
+                        + '; '.join(row.get('names_source') or [])
+                        + '. A project must travel (#441) but KiCad stores '
+                          'meta.filename and pcbnew.last_paths inside it -- '
+                          'sanitise those before it enters the work dir')
             else:
                 _how = (f'carries the control\'s placement '
                         f'({row["match_frac"]:.3f} of {row["refs_shared"]} '

--- a/tests/stress/provenance_audit.py
+++ b/tests/stress/provenance_audit.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Was every pose in this board produced by a registered engine lever?
+
+    python3 -X utf8 tests/stress/provenance_audit.py --workdir DIR --mode audit
+
+The orthogonal sibling of `fence_audit`, which asks a DIFFERENT question --
+"does any file in this work dir carry the control's poses?" -- and answers it
+correctly every time. Run 19 passed it (`VERDICT: CLEAN, exit 0`) on a run
+whose placement came from a 221-line hand script, because a hand-arranged
+board matches the control at ~0.0. There was nothing for it to find. Nothing
+in the repo asked the other question.
+
+THE AUDIT IS A POSE RECONCILIATION, NOT A LOG READ, and that is what makes it
+worth having. It computes which refs actually MOVED between the staged board
+and the delivered one, then requires every one of them to be claimed by a row
+in the ledger's parent-chain with a registered lever. A hand script that edits
+`(at ...)` as raw text appears in no row, so bypassing the instrument does not
+bypass the check -- the board's own geometry is the anchor.
+
+Exit codes:
+
+    0  CLEAN     every moved pose traces to a registered lever
+    2  usage / IO
+    4  VIOLATION a moved pose has no lever, or a row says declared: false
+    5  UNPROVEN  the chain is broken, not violated -- no ledger, unreadable,
+                 or a sha appearing nowhere
+
+5 is load-bearing. `fence_audit` collapses "no manifest" into LEAK and warns
+about it in its own text; doing that here would retroactively accuse every run
+that predates this instrument, which did nothing wrong. "I cannot prove it"
+and "I proved it false" must be different numbers, and only an affirmative
+finding produces 4.
+"""
+import argparse
+import json
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(os.path.dirname(_HERE))
+for _p in (ROOT, os.path.join(ROOT, 'py_router'),
+           os.path.join(ROOT, 'py_tools'), os.path.join(ROOT, 'py_placer')):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+CLEAN, USAGE, VIOLATION, UNPROVEN = 0, 2, 4, 5
+POSE_TOL_MM = 1e-6
+POSE_TOL_DEG = 1e-3
+
+
+def poses(path):
+    from kicad_parser import parse_kicad_pcb
+    pcb = parse_kicad_pcb(path)
+    return {r: (f.x, f.y, f.rotation or 0.0)
+            for r, f in pcb.footprints.items()}
+
+
+def added_refs(a, b):
+    """Refs present in the delivered board and absent from the staged one."""
+    return sorted(r for r in b if r not in a)
+
+
+def moved_refs(a, b):
+    """Refs whose pose differs. Rotation compared MODULO 360, because the
+    writer normalises -90 to 270 and a raw float compare would report an
+    untouched part as moved."""
+    out = []
+    for ref, pb in sorted(b.items()):
+        pa = a.get(ref)
+        if pa is None:
+            # ADDED, not moved. A ref absent from the staged board has no
+            # pose to differ from, and counting it as moved made "someone
+            # dropped a test point into the work dir" an unaided VIOLATION.
+            # Adding a part is a real thing to disclose, so it is reported --
+            # under its own name, by the caller.
+            continue
+        drot = abs(((pa[2] - pb[2]) + 180.0) % 360.0 - 180.0)
+        if (abs(pa[0] - pb[0]) > POSE_TOL_MM or abs(pa[1] - pb[1]) > POSE_TOL_MM
+                or drot > POSE_TOL_DEG):
+            out.append(ref)
+    return out
+
+
+def audit(workdir, delivered=None):
+    from placement import provenance as PV
+    manifest = os.path.join(workdir, PV.REGIME_NAME)
+    if not os.path.isfile(manifest):
+        return UNPROVEN, {'verdict': 'UNPROVEN',
+                          'reason': f'no {PV.REGIME_NAME}: this work dir was '
+                                    f'not staged for an unaided run, so there '
+                                    f'is no claim to check'}
+    with open(manifest, encoding='utf-8') as f:
+        regime = json.load(f)
+    staged = regime.get('staged_board')
+    if not staged or not os.path.isfile(staged):
+        return UNPROVEN, {'verdict': 'UNPROVEN',
+                          'reason': f'the staged board named by the manifest '
+                                    f'is not readable: {staged!r}'}
+
+    if delivered is None:
+        # Newest .kicad_pcb, EXCLUDING intermediates. The chain routinely
+        # drops `*.staging.kicad_pcb` and `*.polish` next to a board, and
+        # picking one used to yield a soft UNPROVEN -- harmless. Now that a
+        # ledger-less moved pose is a VIOLATION, a mis-picked artifact is an
+        # affirmative accusation, so the guess has to be narrower.
+        ARTIFACTS = ('.staging.kicad_pcb', '.polish.kicad_pcb',
+                     '_before.kicad_pcb', '_control.kicad_pcb')
+        cands = [os.path.join(workdir, n) for n in sorted(os.listdir(workdir))
+                 if n.endswith('.kicad_pcb')
+                 and not any(n.endswith(a) for a in ARTIFACTS)
+                 and os.path.abspath(os.path.join(workdir, n))
+                 != os.path.abspath(staged)]
+        if not cands:
+            return UNPROVEN, {'verdict': 'UNPROVEN',
+                              'reason': 'no delivered board in the work dir '
+                                        '(staging artifacts are not one)'}
+        delivered = max(cands, key=os.path.getmtime)
+
+    rows = PV.read_ledger(workdir)
+    _sp, _dp = poses(staged), poses(delivered)
+    moved = moved_refs(_sp, _dp)
+    added = added_refs(_sp, _dp)
+    if not rows:
+        # COMPUTE `moved` FIRST. This returned UNPROVEN before looking at the
+        # board, which swallowed the exact case the instrument was built for:
+        # a purely hand-placed board has no ledger BECAUSE nothing engine-side
+        # ran, and it came back 5 ("I cannot prove it") instead of 4 ("I
+        # proved it false"). Those two must be different numbers -- it is the
+        # reason this file has four exit codes -- and the board itself
+        # distinguishes them. No ledger AND no movement is genuinely
+        # unproven; no ledger and 65 moved parts is a violation with a
+        # witness.
+        if moved:
+            return VIOLATION, {
+                'verdict': 'UNAIDED VIOLATION', 'delivered': delivered,
+                'staged': staged, 'ledger_rows': 0, 'moved': len(moved),
+                'claimed': 0, 'unclaimed_refs': moved[:40],
+                'added_refs': added[:40],
+                'undeclared_refs': {}, 'levers': [], 'callers': [],
+                'reason': (
+                    f"{len(moved)} pose(s) differ from the staged board and "
+                    f"there is NO ledger at all -- nothing engine-side wrote "
+                    f"them. This is the hand-placed case, not an unmeasured "
+                    f"one: the board is the witness.")}
+        return UNPROVEN, {
+            'verdict': 'UNPROVEN', 'delivered': delivered,
+            'moved': 0,
+            'reason': 'no pose-provenance ledger AND no pose differs from the '
+                      'staged board: this run predates the instrument, or '
+                      'nothing wrote a pose. Not a violation -- nothing was '
+                      'measured and nothing moved.'}
+    claimed, undeclared = {}, {}
+    for row in rows:
+        lever = row.get('lever')
+        ok = bool(row.get('declared')) and lever in PV.LEVER_REGISTRY
+        for ref in row.get('refs_moved') or ():
+            (claimed if ok else undeclared).setdefault(ref, lever or row.get(
+                'caller', '<unknown>'))
+
+    unclaimed = sorted(r for r in moved if r not in claimed)
+    bad = sorted(r for r in moved if r in undeclared and r not in claimed)
+    doc = {'workdir': os.path.abspath(workdir), 'staged': staged,
+           'delivered': delivered, 'ledger_rows': len(rows),
+           'moved': len(moved), 'added_refs': added[:40],
+           'claimed': len(claimed),
+           'unclaimed_refs': unclaimed[:40],
+           'undeclared_refs': {r: undeclared[r] for r in bad[:40]},
+           'levers': sorted({r.get('lever') for r in rows if r.get('lever')}),
+           'callers': sorted({r.get('caller') for r in rows
+                              if r.get('caller')})[:10]}
+    if unclaimed:
+        doc.update(verdict='UNAIDED VIOLATION', reason=(
+            f"{len(unclaimed)} moved pose(s) trace to no registered lever. "
+            f"A hand-authored pose reaches the board without a ledger row "
+            f"whatever tool it bypassed, because this compares the BOARD, "
+            f"not the log."))
+        return VIOLATION, doc
+    doc.update(verdict='CLEAN', reason=(
+        f"all {len(moved)} moved pose(s) trace to "
+        f"{', '.join(doc['levers']) or 'no lever (nothing moved)'}"))
+    return CLEAN, doc
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(
+        description="Audit that every pose in a delivered board came from a "
+                    "registered engine lever.")
+    p.add_argument("--workdir", required=True)
+    p.add_argument("--delivered", default=None,
+                   help="The board to audit (default: newest .kicad_pcb in "
+                        "the work dir that is not the staged one)")
+    p.add_argument("--mode", choices=('audit',), default='audit')
+    p.add_argument("--json", metavar="PATH")
+    a = p.parse_args(argv)
+
+    if not os.path.isdir(a.workdir):
+        print(f"provenance_audit: no such work dir: {a.workdir}",
+              file=sys.stderr)
+        return USAGE
+    try:
+        code, doc = audit(a.workdir, a.delivered)
+    except Exception as e:                       # noqa: BLE001
+        print(f"provenance_audit: {type(e).__name__}: {e}", file=sys.stderr)
+        return UNPROVEN
+
+    print(f"VERDICT: {doc['verdict']}")
+    print(f"  {doc['reason']}")
+    if doc.get('unclaimed_refs'):
+        print(f"  unclaimed: {', '.join(doc['unclaimed_refs'][:12])}")
+    for ref, who in (doc.get('undeclared_refs') or {}).items():
+        print(f"    {ref}: written by {who}, undeclared")
+    if a.json:
+        with open(a.json, 'w', encoding='utf-8') as f:
+            json.dump(doc, f, indent=1, sort_keys=True)
+    print("JSON_SUMMARY: " + json.dumps(
+        {k: doc.get(k) for k in
+         ('verdict', 'moved', 'claimed', 'ledger_rows', 'levers')},
+        sort_keys=True))
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/stress/run_watch.py
+++ b/tests/stress/run_watch.py
@@ -1,0 +1,998 @@
+#!/usr/bin/env python3
+"""Two watchers for a long run: what went wrong, and how long it took.
+
+Both are written for the Monitor contract -- ONE STDOUT LINE PER EVENT, exit
+ends the watch -- so they can be armed once and left alone while the run
+works.
+
+WHY A SCRIPT AND NOT A GREP. A watcher that matches only the happy path is
+silent through a crash, and silence is indistinguishable from "still
+running". That is the failure this file exists to avoid, so `bugs` matches
+the signatures you would ACT on -- tracebacks, refusals, leaks, rejected
+laps, a `blocking` that went UP -- and `timer` emits on every terminal state
+it can reach, including the one nobody wants: timed out. If it cannot tell you
+the run finished, it tells you it stopped being able to tell.
+
+The timer's contract is ONE START, ONE TERMINAL EVENT (DONE or TIMEOUT), and
+ZERO OR MORE STALL NOTICES between them. A stall is a SYMPTOM, not an outcome --
+a quiet work dir means the run may have died or may be thinking, and the watcher
+cannot tell which. It used to END the watch there, so run 20's timer exited on a
+20-minute stall while the run was still working, and from that point the absence
+of events (the timer's whole signal) meant nothing. `--stall-exit` restores that
+if a caller depended on it.
+
+    # every new problem, as it appears (many events, until you stop it)
+    python3 -X utf8 tests/stress/run_watch.py bugs --workdir wk/run20
+
+    # one event at the start, stall notices as they happen, one when it ends
+    python3 -X utf8 tests/stress/run_watch.py timer --workdir wk/run20 \
+        --done wk/run20/DONE
+
+Exit codes: 0 normal, 2 usage. `bugs` never exits on its own.
+"""
+import argparse
+import hashlib
+import json
+import os
+import re
+import shlex
+import sys
+import time
+
+#: Substrings that mean something went wrong, in any text the run leaves
+#: behind. Deliberately broad: a false positive costs one line, a missed
+#: crash costs the whole run's credibility. Ordered roughly by severity so
+#: the emitted label is the most specific one that matched.
+SIGNATURES = (
+    ('TRACEBACK', 'Traceback (most recent call last)'),
+    ('LEAK', 'VERDICT: LEAK'),
+    ('UNAIDED-VIOLATION', 'UnaidedViolation'),
+    ('PROVENANCE', 'UNAIDED VIOLATION'),
+    ('NOT-BUILDABLE', 'NOT BUILDABLE'),
+    ('REFUSED', 'refusing'),
+    ('REFUSED', 'REFUSED'),
+    ('ERROR', 'Error:'),
+    ('ERROR', 'ERROR'),
+    ('FAILED', 'FAILED'),
+    ('ASSERT', 'AssertionError'),
+    ('DID-NOT-RUN', 'did not run'),
+    ('UNAVAILABLE', 'unavailable'),
+)
+
+#: Files SCANNED for those signatures: tool output only. The run tees its own
+#: output to `*.log`; the tools write `*.json` reports whose `skipped` blocks say
+#: what could not be measured.
+#:
+#: `.md` is deliberately NOT here. The journal's job is to QUOTE tool output, so
+#: every signature appears in it legitimately -- measured on run 20, scanning it
+#: reported `NOT BUILDABLE` three times from a journal line reading
+#: "NOT BUILDABLE -> buildable", i.e. the sentence recording that the defect was
+#: FIXED. Narration is not an incident, and the incident it narrates was already
+#: reported from the log it quotes.
+SCAN_EXT = ('.log', '.txt', '.json', '.jsonl')
+
+#: Files that count as the run being ALIVE. This is where `.md` belongs and the
+#: real run-20 finding: `watch_timer`'s stall signature walked SCAN_EXT, so a
+#: stretch whose only output was the journal -- the artifact the run is REQUIRED
+#: to write as it goes -- read as a dead run. Measured: TIMER STALLED fired
+#: during L3/L4 while the journal was being written every few minutes.
+WATCHED_EXT = SCAN_EXT + ('.md',)
+
+#: Ledger `kind`s whose scores form ONE comparable sequence. `converge record`
+#: writes completion|placement|systemic (and classification, once added); a
+#: routing score and a placement score grade different things, and a lap of any
+#: other kind sits at the boundary between two routing sequences. 'routing' is
+#: accepted defensively -- it is not a current choice, but the field is free text
+#: on older ledgers.
+ROUTING_KINDS = frozenset({'completion', 'routing'})
+
+POLL_SEC = 5.0
+
+
+def _self_output_ids():
+    """(dev, ino) of whatever this watcher's own stdout/stderr point at.
+
+    A watcher must not scan its own output, and this one did. Measured on run
+    21, which armed `bugs` with `*> wk/run21/tigard/watch_bugs.log` -- inside
+    --workdir, because that is where the run tees everything so the watchers
+    can see it. Every line the watcher emitted then matched a signature on the
+    next poll, so hit N quoted hit N-1 verbatim:
+
+        NOT-BUILDABLE assembly0.json:1934: "verdict": "NOT BUILDABLE",
+        NOT-BUILDABLE watch_bugs.log:2: NOT-BUILDABLE assembly0.json:1934: ...
+        NOT-BUILDABLE watch_bugs.log:3: NOT-BUILDABLE watch_bugs.log:2: ...
+
+    Two hits become four, four become eight, and the ONE real finding is buried
+    under nesting copies of itself. This is the same class as the `.md`
+    exclusion above -- narration is not an incident -- except self-amplifying,
+    so it destroys the log rather than padding it.
+
+    Identified by inode rather than by name because the redirect target is
+    chosen by whoever arms the watcher, not by this file; a name list would
+    only cover the convention this repo happens to use today. `_is_self_output`
+    keeps that convention as the fallback for platforms reporting st_ino 0.
+    """
+    ids = set()
+    for fd in (1, 2):
+        try:
+            st = os.fstat(fd)
+        except OSError:
+            continue
+        if st.st_ino:
+            ids.add((st.st_dev, st.st_ino))
+    return ids
+
+
+#: Computed once, at import: the redirect cannot change under a running watcher.
+_SELF_OUTPUT_IDS = _self_output_ids()
+
+
+def _is_self_output(path):
+    """Is this file a WATCHER's output rather than a tool's?
+
+    Own stdout/stderr by inode, and any sibling watcher's log by the
+    `watch_*.log` convention. The sibling half matters for liveness too: three
+    watchers polling each other's logs are activity that never came from the
+    run, so a stalled run would keep reporting as alive.
+    """
+    try:
+        st = os.stat(path)
+    except OSError:
+        return False
+    if st.st_ino and (st.st_dev, st.st_ino) in _SELF_OUTPUT_IDS:
+        return True
+    name = os.path.basename(path)
+    return name.startswith('watch_') and name.endswith('.log')
+
+
+def _walk(workdir, exts=SCAN_EXT):
+    """Files under `workdir` with one of `exts`, never a watcher's own output.
+
+    Default is SCAN_EXT (tool output). `watch_timer` passes WATCHED_EXT, which
+    adds the journal: liveness and scanning are different questions and want
+    different file sets.
+    """
+    for root, dirs, files in os.walk(workdir):
+        dirs[:] = [d for d in dirs if not d.startswith('.')]
+        for name in sorted(files):
+            if not name.endswith(exts):
+                continue
+            path = os.path.join(root, name)
+            if _is_self_output(path):
+                continue
+            yield path
+
+
+def _unchanged(path, stamps):
+    """True when `path` has not changed since the last poll.
+
+    Purely a cost guard: `seen` already stops re-emission, but every poll re-read
+    every watched file end to end, and adding `.md` puts the journal -- the
+    largest text file in a long run -- on that path. Same (mtime, size) tuple
+    `watch_timer` already computes.
+    """
+    try:
+        st = os.stat(path)
+        now = (st.st_mtime, st.st_size)
+    except OSError:
+        return False
+    if stamps.get(path) == now:
+        return True
+    stamps[path] = now
+    return False
+
+
+def _scan_text(path, seen, rel):
+    """Emit one line per NEW signature hit in this file."""
+    out = []
+    try:
+        with open(path, encoding='utf-8', errors='replace') as f:
+            lines = f.readlines()
+    except OSError:
+        return out
+    for i, line in enumerate(lines):
+        for label, needle in SIGNATURES:
+            if needle in line:
+                key = (rel, label, line.strip()[:160])
+                if key in seen:
+                    break
+                seen.add(key)
+                out.append(f'{label} {rel}:{i + 1}: {line.strip()[:200]}')
+                break
+    return out
+
+
+def _scan_ledger(path, seen, rel):
+    """A rejected lap, or a `blocking` that went UP, is a finding too.
+
+    The ledger is the run's own record of what it decided, so a regression
+    here is more trustworthy than any log line -- it is what the loop acted
+    on, not what a tool printed.
+
+    BLOCKING-UP compares CONSECUTIVE KEPT ROUTING LAPS, and both qualifiers were
+    learned from a false positive. Run 20 emitted
+
+        BLOCKING-UP ledger.jsonl: iteration 35 blocking 10 -> 82
+
+    which compared cycle 2's FIRST scored lap against cycle 1's FINAL one. Two
+    local rules fix it without teaching this watcher what a cycle is:
+
+      * advance `prev` only on `accepted is True`. A rejected lap's score is the
+        measurement that got it rejected; the loop already reverted it, and
+        REJECTED-LAP reports it. Feeding it to `prev` reports the revert as a
+        regression.
+      * reset `prev` at any row whose `kind` is not a routing kind. A placement,
+        systemic or classification lap sits BETWEEN two routing sequences and is
+        the boundary -- scores either side of it grade different boards.
+
+    Measured on run 20's ledger: zero BLOCKING-UP, against one false positive
+    today. Deliberately NOT done by importing `loop_driver._cycle_index`: a
+    cross-tree import from tests/stress into .claude/skills/.../scripts would tie
+    a watcher to a driver that ships independently.
+    """
+    out, prev = [], None
+    try:
+        with open(path, encoding='utf-8') as f:
+            rows = [json.loads(x) for x in f if x.strip()]
+    except (OSError, ValueError):
+        return out
+    for r in rows:
+        if not isinstance(r, dict):
+            continue
+        it = r.get('iteration')
+        if r.get('accepted') is False:
+            key = (rel, 'rejected', it)
+            if key not in seen:
+                seen.add(key)
+                out.append(f'REJECTED-LAP {rel}: iteration {it} '
+                           f'lever={r.get("lever")} was not accepted')
+        sc = r.get('score') if isinstance(r.get('score'), dict) else {}
+        blk = sc.get('blocking')
+
+        # A lap that recorded `blocking: null` is a finding about the
+        # MEASUREMENT, not about the sequence, so it is reported for every lap --
+        # rejected and non-routing ones included. Keep it outside the
+        # comparison rules below.
+        if not isinstance(blk, (int, float)) and 'blocking' in sc:
+            key = (rel, 'blocking-none', it)
+            if key not in seen:
+                seen.add(key)
+                out.append(f'BLOCKING-NULL {rel}: iteration {it} reports '
+                           f'blocking=None -- "0 violations" and "0 rules '
+                           f'ran" are different answers')
+
+        if (r.get('kind') or 'completion') not in ROUTING_KINDS:
+            prev = None            # a half boundary: the next score grades a
+            continue               # different board than the last one did
+        if r.get('accepted') is not True:
+            continue               # a reverted lap is not a step in the sequence
+        if not isinstance(blk, (int, float)):
+            continue               # unmeasured: evidence in neither direction
+        if prev is not None and blk > prev:
+            key = (rel, 'regress', it)
+            if key not in seen:
+                seen.add(key)
+                out.append(f'BLOCKING-UP {rel}: iteration {it} '
+                           f'blocking {prev} -> {blk}')
+        prev = blk
+    return out
+
+
+def watch_bugs(workdir, poll):
+    seen, stamps = set(), {}
+    print(f'WATCHING {os.path.abspath(workdir)} for problems '
+          f'({len(SIGNATURES)} signatures + the ledger), '
+          f'scanning {" ".join(SCAN_EXT)}', flush=True)
+    while True:
+        if os.path.isdir(workdir):
+            for path in _walk(workdir):
+                if _unchanged(path, stamps):
+                    continue
+                rel = os.path.relpath(path, workdir).replace('\\', '/')
+                if path.endswith('.jsonl'):
+                    for line in _scan_ledger(path, seen, rel):
+                        print(line, flush=True)
+                else:
+                    for line in _scan_text(path, seen, rel):
+                        print(line, flush=True)
+        time.sleep(poll)
+
+
+#: Tool groups a flag is scoped to. `()` means "any tool".
+GRADERS = ('check_drc.py', 'board_score.py', 'check_complete.py')
+ROUTERS = ('route.py', 'route_diff.py', 'route_planes.py', 'repair_planes.py')
+#: `route_diff.py --nets DP DN` and `route_planes.py --nets GND +3V3` are what
+#: those tools ARE -- naming the pair or the pour is the invocation, not a
+#: narrowing. Only the general router can narrow its own scope.
+NET_SCOPED = ('route.py',)
+
+#: Flags that make a run report success by lowering the bar rather than
+#: clearing it. Each is legitimate SOMEWHERE -- that is why they exist -- so
+#: this reports the observation and the reason it matters, never a verdict.
+#: The run is answerable for them; the watcher only makes them visible.
+#:
+#: Fourth field: the tools on which the flag lowers a bar. Measured on run 20 --
+#: 683 raw substring hits, 24 once anchored to a real command line, 6 once
+#: scoped to the tools where the flag means what the `why` says.
+#: The two skill drivers. They install no cli_banner, so their invocations are
+#: only ever seen through a teed `cmd_timing.jsonl` row -- see _scan_ledger_argv.
+DRIVERS = ('placement_driver.py', 'loop_driver.py')
+
+CHEAT_FLAGS = (
+    ('WAIVER', '--accept-residue', 'accepts placement residue the close-out '
+                                   'refused', ()),
+    ('WAIVER', '--accept-unclosed', 'closes a half that did not close', ()),
+    ('WAIVER', '--accept-congestion', 'accepts a congestion regression', ()),
+    ('WAIVER', '--allow-unplaced', 'proceeds on a board the gate called '
+                                   'unplaced', ()),
+    ('WAIVER', '--allow-routed', 'places onto existing copper', ()),
+    ('WAIVER', '--force', 'overrides a refusal', ()),
+    ('WAIVER', '--no-verify', 'skips a hook', ()),
+    ('FLOOR', '--clearance', 'overrides the clearance the BOARD declares. A '
+                             'looser value makes DRC pass by grading what was '
+                             'not routed', GRADERS + ROUTERS),
+    ('FLOOR', '--board-edge-clearance', 'overrides the board edge floor',
+     GRADERS + ROUTERS),
+    ('FLOOR', '--clearance-margin', 'filters DRC hits by distance', GRADERS),
+    ('SCOPE', '--nets', 'routes a SUBSET -- "0 unrouted" over 6 of 84 nets '
+                        'is not the same claim', NET_SCOPED),
+    # Scoped to tools that produce a VERDICT. On `render_placement.py` and
+    # `place_optimize.py` this flag scopes AIRWIRE SCORING -- it is how you tell
+    # the panel not to draw 80 GND stubs -- and reporting it there buried the
+    # real uses in run 20.
+    ('SCOPE', '--ignore-nets', 'excludes nets from the verdict',
+     GRADERS + ROUTERS),
+    ('SCOPE', '--rip-existing-nets', 'rips copper an earlier step placed',
+     ROUTERS),
+    ('DELEGATION', '--no-delegate', 'runs an inner half inline; an inline '
+                                    'loop can silently do the outer loop\'s '
+                                    'job and never report it (run 14)', ()),
+    # --- run-22 additions ---------------------------------------------------
+    # Gaps in an already-covered family, not a category decision: the three
+    # sibling `--accept-*` flags were listed and these were not. Measured: run
+    # 22 used --waive FIVE times and this watcher emitted ZERO events.
+    ('WAIVER', '--waive', 'waives a lock advisory the P3 gate raised, per ref',
+     DRIVERS),
+    ('WAIVER', '--accept-boxin', 'accepts a boxed-in part the gate refused',
+     DRIVERS),
+    # The fab floor is a CEILING on what the router may emit. Lowering it lets
+    # copper reach 0.0889/0.25 AND grade clean there -- the run-22 ratchet: a
+    # board reported unrouted 0 / broken 0 while carrying 39 objects below its
+    # own declared floors.
+    ('FLOOR', '--fab-tier', 'routes and grades at a LOOSER fab tier '
+                            '(advanced reaches 0.0762 track, 0.25/0.15 via)',
+     GRADERS + ROUTERS),
+    ('FLOOR', '--fab-overrides', 'pins the fab floor to a file, which may sit '
+                                 'under the standard tier', GRADERS + ROUTERS),
+    # Without the writeback there is no `fab_floor_origin` in the output
+    # project, so check_complete.fab_floor_integrity reports ran: False and
+    # the ratchet check goes dark.
+    ('WAIVER', '--no-fix-drc-settings', 'leaves the output with no '
+                                        'fab_floor_origin, so the fab-floor '
+                                        'integrity check cannot run at all',
+     ROUTERS),
+)
+
+def _parse_cmd(line):
+    """`CMD: python3 -X utf8 route.py b.kicad_pcb --nets '*'` -> ('route.py', [tokens]).
+
+    The anchor is `py_router/cli_banner.py`, which prints exactly one
+    `CMD: <argv>` line per tool run, built from `sys.orig_argv`, and one
+    `EXIT=<rc>`. 27 tools install it and two tests pin that there is exactly one
+    of each per log. Anchoring here is what separates a flag that was PASSED from
+    a flag that was merely MENTIONED -- in help text, in a tool's own
+    "--clearance not given" disclosure, in a driver's refusal telling you to pass
+    it, or in a ledger `lever` sentence. Returns None for any other line.
+    """
+    if not line.startswith('CMD: '):
+        return None
+    try:
+        toks = shlex.split(line[5:].strip(), posix=False)
+    except ValueError:
+        toks = line[5:].strip().split()
+    tool = ''
+    for t in toks:
+        low = t.strip('"\'').lower()
+        if low.endswith('.py'):
+            tool = os.path.basename(low)
+            break
+    return tool, toks
+
+
+def _flag_in(toks, flag):
+    """Token-exact flag match, including the `--flag=value` form.
+
+    Substring matching is what made `--clearance` fire on `--clearance-margin`
+    and `--nets` fire on `--ignore-nets`.
+    """
+    for t in toks:
+        if t == flag or t.startswith(flag + '='):
+            return True
+    return False
+
+
+def _flag_value(toks, flag):
+    """First value after `flag` (or after `flag=`), stripped of quotes."""
+    for i, t in enumerate(toks):
+        if t.startswith(flag + '='):
+            return t.split('=', 1)[1].strip('"\'')
+        if t == flag and i + 1 < len(toks):
+            return toks[i + 1].strip('"\'')
+    return ''
+
+
+def _flag_values(toks, flag):
+    """Every value belonging to `flag`, up to the next option. List-taking flags
+    (`--nets A B C`) are the norm here, so one value is not enough."""
+    vals, grabbing = [], False
+    for t in toks:
+        if t.startswith(flag + '='):
+            vals.append(t.split('=', 1)[1].strip('"\''))
+            continue
+        if t == flag:
+            grabbing = True
+            continue
+        if grabbing:
+            if t.startswith('--'):
+                grabbing = False
+                continue
+            vals.append(t.strip('"\''))
+    return vals
+
+
+def _use_key(label, flag, tool, toks):
+    """Identity of a bar-lowering USE: which tool, which flag, applied to what.
+
+    Deliberately NOT the whole argv. The same lever reaches this watcher spelled
+    two ways -- a log's `CMD:` line carries absolute board paths and shell
+    quoting, the ledger's `lever_argv` carries the relative form the run recorded
+    -- and on run 20 those two differed in token count and quoting while naming
+    the identical tool, flags and nets. Keying on the argv reported one lever
+    twice; keying on what the flag was applied to reports it once, and still
+    separates two genuinely different scopes of the same flag.
+    """
+    vals = _flag_values(toks, flag)
+    payload = f'{tool}|{flag}|' + '\x1f'.join(sorted(vals))
+    return (label, flag, tool,
+            hashlib.sha1(payload.encode('utf-8', 'replace')).hexdigest()[:16])
+
+
+def _argv_key(toks):
+    """Stable identity for one executed command, independent of where it was seen.
+
+    The old dedupe key carried the LINE NUMBER, so a log rewritten between polls
+    re-fired every hit in it.
+
+    Normalisation matters as much as hashing: the SAME command reaches us spelled
+    two ways -- a log's `CMD:` line records `python3.exe -X utf8
+    C:/.../py_router/route.py`, while the ledger's `lever_argv` records
+    `python3 -X utf8 py_router/route.py`. Keying on the raw string reported both.
+    So: drop everything up to and including the interpreter, reduce the script to
+    its basename, and normalise separators and quotes.
+    """
+    norm, seen_py = [], False
+    for t in toks:
+        t = t.strip('"\'').replace('\\', '/')
+        if not seen_py:
+            if t.lower().endswith('.py'):
+                seen_py = True
+                norm.append(os.path.basename(t).lower())
+            continue                      # interpreter, -X, utf8, ...
+        norm.append(os.path.basename(t) if '/' in t else t)
+    if not seen_py:
+        norm = [t.strip('"\'') for t in toks]
+    return hashlib.sha1(' '.join(norm).encode('utf-8', 'replace')).hexdigest()[:16]
+
+
+#: JSONL keys that carry a REAL argv, in priority order. `lever_argv` is a
+#: converge lever; `argv` / `cmdline` are what tests/stress/tee_cmd.py records
+#: for EVERY invocation a timed run makes. Run 22 wrote 203 such rows and this
+#: watcher extracted nothing from any of them, because it looked only for
+#: `lever_argv` -- so every driver invocation was invisible (the drivers
+#: install no cli_banner, so they print no CMD: line of their own either).
+_ARGV_KEYS = ('lever_argv', 'argv', 'cmdline')
+
+
+def _scan_ledger_argv(path, seen, rel):
+    """Cheat flags in a ledger row's `lever_argv` -- the second source of truth.
+
+    `lever_argv` is a real command the run executed (converge refuses one whose
+    argv[0] could never replay). `lever` beside it is free prose and is NEVER
+    matched: run 20's levers narrate the flags they used, which is exactly the
+    disclosure the run is supposed to make, and reporting it as a finding
+    punishes the disclosure.
+    """
+    out = []
+    try:
+        with open(path, encoding='utf-8') as f:
+            rows = [json.loads(x) for x in f if x.strip()]
+    except (OSError, ValueError):
+        return out
+    for r in rows:
+        if not isinstance(r, dict):
+            continue
+        argv = src = None
+        for _k in _ARGV_KEYS:
+            if r.get(_k) is not None:
+                argv, src = r[_k], _k
+                break
+        if isinstance(argv, str):
+            try:
+                argv = shlex.split(argv, posix=False)
+            except ValueError:
+                argv = argv.split()
+        if not isinstance(argv, list) or not argv:
+            continue
+        toks = [str(t) for t in argv]
+        tool = ''
+        for t in toks:
+            if t.lower().endswith('.py'):
+                tool = os.path.basename(t.lower())
+                break
+        for label, flag, why in _cheat_hits(tool, toks):
+            key = _use_key(label, flag, tool, toks)
+            if key in seen:
+                continue
+            seen.add(key)
+            where = (f'iteration {r.get("iteration")}'
+                     if src == 'lever_argv' else f'label {r.get("label")!r}')
+            out.append(f'{label} {flag} in {rel} {src} {where} '
+                       f'({tool}) -- {why}')
+    return out
+
+
+def _cheat_hits(tool, toks):
+    """The (label, flag, why) triples this command line genuinely earns."""
+    out = []
+    for label, flag, why, tools in CHEAT_FLAGS:
+        if tools and tool not in tools:
+            continue
+        if not _flag_in(toks, flag):
+            continue
+        # `--nets '*'` is the whole board: the opposite of a narrowing, and the
+        # form #562 requires so the plane finalize keeps the pours in scope.
+        if flag == '--nets' and _flag_value(toks, flag) in ('*', '"*"', "'*'"):
+            continue
+        out.append((label, flag, why))
+    return out
+
+#: Directories whose tracked contents a RUN has no business changing. Editing
+#: the toolchain to make a gate pass is the cheat that leaves the most
+#: convincing evidence of success.
+GUARDED_DIRS = ('py_router', 'py_placer', 'py_tools', 'tests', '.claude',
+                'kicad_files')
+
+
+def _sha(path):
+    import hashlib
+    h = hashlib.sha256()
+    try:
+        with open(path, 'rb') as f:
+            for chunk in iter(lambda: f.read(1 << 20), b''):
+                h.update(chunk)
+    except OSError:
+        return None
+    return h.hexdigest()
+
+
+def _repo_root():
+    here = os.path.dirname(os.path.abspath(__file__))
+    return os.path.dirname(os.path.dirname(here))
+
+
+def _git_dirty(root):
+    """Tracked files changed under the guarded dirs, via git."""
+    import subprocess
+    try:
+        r = subprocess.run(['git', '-C', root, 'status', '--porcelain'],
+                           capture_output=True, text=True, timeout=60)
+    except Exception:                                  # noqa: BLE001
+        return None                                    # cannot tell -- say so
+    out = []
+    for line in (r.stdout or '').splitlines():
+        path = line[3:].strip().strip('"')
+        if path.split('/')[0] in GUARDED_DIRS:
+            out.append(f'{line[:2].strip()} {path}')
+    return out
+
+
+def watch_cheats(workdir, truthdir, done_path, poll):
+    """Ways this run could report success without earning it.
+
+    NOT an accusation channel. Every flag below is legitimate somewhere, and
+    a run may have a good reason; what it may not do is use one silently. So
+    each line states what was seen and why it matters, and the run answers.
+
+    What this CANNOT see, stated so nobody reads silence as proof: it cannot
+    tell that a file was read. Blindness to the control is enforced after the
+    fact by `fence_audit` -- which compares the DELIVERED BOARD's poses, so
+    bypassing the tool does not bypass the check -- and that is run here when
+    the run declares itself done.
+    """
+    root = _repo_root()
+    seen = set()
+    truth0 = {}
+    if truthdir and os.path.isdir(truthdir):
+        for r, _d, fs in os.walk(truthdir):
+            for n in fs:
+                p = os.path.join(r, n)
+                truth0[os.path.relpath(p, truthdir)] = _sha(p)
+    dirty0 = _git_dirty(root)
+    print(f'WATCHING for shortcuts: {len(CHEAT_FLAGS)} flags, '
+          f'{len(truth0)} truth file(s) fingerprinted, '
+          + ('git baseline clean'
+             if dirty0 == [] else
+             f'git baseline has {len(dirty0)} pre-existing change(s)'
+             if dirty0 else 'git unavailable -- toolchain edits INVISIBLE'),
+          flush=True)
+
+    while True:
+        # 1. the truth dir must not move. It is the answer key.
+        if truthdir and os.path.isdir(truthdir):
+            for r, _d, fs in os.walk(truthdir):
+                for n in fs:
+                    p = os.path.join(r, n)
+                    rel = os.path.relpath(p, truthdir)
+                    now = _sha(p)
+                    was = truth0.get(rel)
+                    if was is None and rel not in truth0:
+                        key = ('truth-new', rel)
+                        if key not in seen:
+                            seen.add(key)
+                            print(f'TRUTH-CHANGED a file appeared in the '
+                                  f'truth dir after staging: {rel}',
+                                  flush=True)
+                    elif now != was:
+                        key = ('truth-mod', rel)
+                        if key not in seen:
+                            seen.add(key)
+                            print(f'TRUTH-CHANGED {rel} was modified after '
+                                  f'staging -- the control is the thing the '
+                                  f'fence compares against', flush=True)
+
+        # 2. the toolchain must not move either.
+        dirty = _git_dirty(root)
+        if dirty is not None and dirty0 is not None:
+            for row in dirty:
+                if row in dirty0:
+                    continue
+                key = ('git', row)
+                if key not in seen:
+                    seen.add(key)
+                    print(f'TOOLCHAIN-EDIT {row} -- a gate that passes '
+                          f'because the gate changed has measured nothing',
+                          flush=True)
+
+        # 3. flags that lower the bar, and repeat staging.
+        #
+        # Two sources of truth, and only two. A flag that appears anywhere else
+        # was MENTIONED, not passed:
+        #   * a `CMD:` line, written by cli_banner from sys.orig_argv (27 tools)
+        #   * a ledger row's `lever_argv`, which IS an executed command --
+        #     never its `lever`, which is prose. converge.py deliberately does
+        #     not install cli_banner ("converge's stdout is a JSON API"), so its
+        #     invocations reach us only this way.
+        stages = 0
+        unanchored = 0
+        for path in _walk(workdir):
+            if not path.endswith(('.log', '.txt', '.jsonl')):
+                continue
+            rel = os.path.relpath(path, workdir).replace('\\', '/')
+            try:
+                with open(path, encoding='utf-8', errors='replace') as f:
+                    lines = f.readlines()
+            except OSError:
+                continue
+            for i, line in enumerate(lines):
+                parsed = _parse_cmd(line)
+                if parsed is None:
+                    # Count, do not report. Without this the redesign is
+                    # unfalsifiable -- a reader cannot tell "precise" from
+                    # "blind", and a tool that stops printing CMD: would go
+                    # silent instead of announcing itself.
+                    if any(f in line for _l, f, _w, _t in CHEAT_FLAGS):
+                        unanchored += 1
+                    continue
+                tool, toks = parsed
+                if any(t.endswith(('stage_blind.py', 'stage_unaided.py'))
+                       for t in toks):
+                    stages += 1
+                for label, flag, why in _cheat_hits(tool, toks):
+                    key = _use_key(label, flag, tool, toks)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    print(f'{label} {flag} in {rel}:{i + 1} ({tool}) -- {why} '
+                          f':: {line.strip()[:140]}', flush=True)
+            if path.endswith('.jsonl'):
+                for out in _scan_ledger_argv(path, seen, rel):
+                    print(out, flush=True)
+        # Key on the FACT, not the count. The running count was in the key,
+        # so every increment was a fresh event: the line promised "counted,
+        # not reported individually" and then reported every increment.
+        if unanchored and ('unanchored',) not in seen:
+            seen.add(('unanchored',))
+            print(f'NOTE {unanchored} flag mention(s) outside a CMD: line '
+                  f'(prose, help text, a tool disclosing "--clearance not '
+                  f'given", a driver refusal naming the flag, a ledger lever) '
+                  f'-- counted, not reported individually. If this number is '
+                  f'0 while a run is clearly using tools, a tool has stopped '
+                  f'printing its CMD: banner and this watcher has gone blind.',
+                  flush=True)
+        if stages > 1 and ('restage',) not in seen:
+            seen.add(('restage',))
+            print(f'RESTAGE the log shows {stages} staging invocations -- a '
+                  f'second draw is a different (possibly easier) damage, and '
+                  f'the run must say which one it reports', flush=True)
+
+        # 4. done: run the two audits that check the board rather than the log.
+        if os.path.exists(done_path):
+            print('DONE declared -- running the audits that read the BOARD, '
+                  'not the log', flush=True)
+            import subprocess
+            control = os.path.join(truthdir or '', 'control.kicad_pcb')
+            if truthdir and os.path.isfile(control):
+                try:
+                    r = subprocess.run(
+                        [sys.executable, '-X', 'utf8',
+                         os.path.join(root, 'tests', 'stress',
+                                      'fence_audit.py'),
+                         '--control', control, '--workdir', workdir],
+                        capture_output=True, text=True, timeout=900)
+                    for line in (r.stdout or '').splitlines():
+                        if 'VERDICT' in line or line.startswith('  LEAK'):
+                            print(f'FENCE {line.strip()}', flush=True)
+                except Exception as e:                 # noqa: BLE001
+                    print(f'FENCE could not run ({type(e).__name__}: {e}) -- '
+                          f'that is not a pass', flush=True)
+            else:
+                print('FENCE no control board found, so blindness was NOT '
+                      'verified -- that is not a pass', flush=True)
+            try:
+                r = subprocess.run(
+                    [sys.executable, '-X', 'utf8',
+                     os.path.join(root, 'tests', 'stress',
+                                  'provenance_audit.py'),
+                     '--workdir', workdir],
+                    capture_output=True, text=True, timeout=900)
+                for line in (r.stdout or '').splitlines():
+                    if line.startswith('VERDICT') or 'unclaimed' in line:
+                        print(f'PROVENANCE {line.strip()}', flush=True)
+                if r.returncode == 4:
+                    print('PROVENANCE exit 4 -- a pose in the delivered board '
+                          'traces to no registered lever, i.e. something '
+                          'moved parts that was not the engine', flush=True)
+            except Exception as e:                     # noqa: BLE001
+                print(f'PROVENANCE could not run ({type(e).__name__}: {e})',
+                      flush=True)
+            return 0
+        time.sleep(poll)
+
+
+def _fmt(sec):
+    h, rem = divmod(int(sec), 3600)
+    m, s = divmod(rem, 60)
+    return f'{h:d}h{m:02d}m{s:02d}s' if h else f'{m:d}m{s:02d}s'
+
+
+#: Escalating stall thresholds, as MULTIPLES of --stall-min. A run that goes
+#: quiet for 20 minutes and comes back is normal; one that has been quiet for 80
+#: is a different claim, and repeating the 20-minute sentence four times does not
+#: make it.
+_STALL_LADDER = (1.0, 2.0, 4.0)
+
+
+def watch_timer(workdir, done_path, poll, stall_min, max_min,
+                stall_exit=False):
+    """START now; STALL notices as they happen; ONE event at a terminal state.
+
+    Two terminal states -- DONE and TIMEOUT -- and zero or more STALL notices
+    between them. STALLED used to END the watch, which is wrong for the thing it
+    reports: a quiet work dir is a SYMPTOM, not an outcome. Run 20's watcher
+    exited on a 20-minute stall while the run was thinking, and from then on the
+    absence of events -- the timer's whole signal -- meant nothing, because
+    nothing was watching. A watcher that stops watching when it sees something
+    worrying is the opposite of a watcher.
+
+    So: emit once per stall EPISODE, re-arm when activity resumes, and escalate
+    the reported threshold on repeat (--stall-min x 1, x2, x4) so a long silence
+    reads differently from a short one. `--stall-exit` restores the old
+    behaviour for a caller that depended on it.
+    """
+    t0 = time.time()
+    stamp = os.path.join(workdir, '.run_watch_started')
+    os.makedirs(workdir, exist_ok=True)
+    if os.path.isfile(stamp):
+        try:
+            with open(stamp, encoding='utf-8') as f:
+                t0 = float(json.load(f)['started'])
+        except Exception:                              # noqa: BLE001
+            pass
+    else:
+        with open(stamp, 'w', encoding='utf-8') as f:
+            json.dump({'started': t0,
+                       'started_iso': time.strftime('%Y-%m-%dT%H:%M:%S')}, f)
+    print(f'TIMER START {time.strftime("%H:%M:%S")} -- watching '
+          f'{os.path.abspath(workdir)}, done marker '
+          f'{os.path.relpath(done_path, workdir)}', flush=True)
+
+    last_change, last_sig = time.time(), None
+    # Which rung of the ladder has been announced for THIS episode. Reset the
+    # moment anything changes, so a run that goes quiet, comes back and goes
+    # quiet again gets a fresh notice rather than silence.
+    rung = 0
+    while True:
+        if os.path.exists(done_path):
+            print(f'TIMER STOP after {_fmt(time.time() - t0)} -- done marker '
+                  f'appeared', flush=True)
+            return 0
+        sig = []
+        if os.path.isdir(workdir):
+            # Liveness, not scanning: WATCHED_EXT so the journal counts as
+            # activity. Run 20 stalled at 20m while the journal was being
+            # written, because this walk only saw tool output.
+            for p in _walk(workdir, WATCHED_EXT):
+                try:
+                    sig.append((p, os.path.getmtime(p), os.path.getsize(p)))
+                except OSError:
+                    pass
+        sig = tuple(sorted(sig))
+        if sig != last_sig:
+            if rung:
+                print(f'TIMER RESUMED after {_fmt(time.time() - t0)} -- the '
+                      f'work dir changed again; the stall notice above did not '
+                      f'mean the run was over', flush=True)
+            last_sig, last_change, rung = sig, time.time(), 0
+        idle = time.time() - last_change
+        if stall_min and rung < len(_STALL_LADDER)                 and idle > stall_min * 60 * _STALL_LADDER[rung]:
+            _mult = _STALL_LADDER[rung]
+            rung += 1
+            _last = rung >= len(_STALL_LADDER)
+            print(f'TIMER STALLED after {_fmt(time.time() - t0)} -- nothing '
+                  f'in the work dir changed for {_fmt(idle)} '
+                  f'(threshold {stall_min * _mult:g}m'
+                  + (', the last stall notice for this episode' if _last
+                     else f', next at {stall_min * _STALL_LADDER[rung]:g}m')
+                  + '). The run may have died, or it is thinking; check before '
+                    'assuming either. NOT a terminal state -- this watch '
+                    'continues.', flush=True)
+            if stall_exit:
+                return 0
+        if max_min and (time.time() - t0) > max_min * 60:
+            print(f'TIMER TIMEOUT at {_fmt(time.time() - t0)} -- the deadline '
+                  f'passed with no done marker', flush=True)
+            return 0
+        time.sleep(poll)
+
+
+def _self_test():
+    """Checkable in the field, where the harness runs and pytest does not.
+
+    Mirrors `loop_driver.py --self-test`. The full fixtures live in
+    tests/test_run20_run_watch.py; this is the subset that needs no files.
+    """
+    bad = []
+
+    def want(cond, label):
+        if not cond:
+            bad.append(label)
+
+    # The anchor: only a real CMD: line is a use.
+    want(_parse_cmd('CMD: python3 -X utf8 py_router/check_drc.py b.kicad_pcb '
+                    '--clearance 0.2')[0] == 'check_drc.py',
+         'CMD: line should yield its tool')
+    for prose in ('  --clearance not given; honoring net classes',
+                  'retry with --rip-existing-nets to authorize',
+                  'usage: route.py [-h] [--nets NETS [NETS ...]]',
+                  '   python3 $D --stage L2 --accept-residue oob_pad_count'):
+        want(_parse_cmd(prose) is None, f'prose must not parse: {prose[:40]}')
+
+    # Token-exact: the substrings that made 683 hits.
+    want(not _flag_in(['--clearance-margin', '0.1'], '--clearance'),
+         '--clearance must not match inside --clearance-margin')
+    want(not _flag_in(['--ignore-nets', 'GND'], '--nets'),
+         '--nets must not match inside --ignore-nets')
+    want(_flag_in(['--nets=A'], '--nets'), '--flag=value form must match')
+
+    # Tool scoping.
+    want(not _cheat_hits('route_diff.py', ['--nets', 'DP', 'DN']),
+         'naming the pair is what route_diff IS')
+    want(_cheat_hits('route.py', ['--nets', 'BUSY', 'SCK']),
+         'route.py narrowing its own scope is a real disclosure')
+    want(not _cheat_hits('route.py', ['--nets', '*']),
+         '--nets * is the whole board, the opposite of a narrowing')
+    want(_cheat_hits('check_drc.py', ['--clearance', '0.2']),
+         'a grader clearance is a floor override')
+
+    # One lever recorded two ways is one event.
+    log = ['python3.exe', '-X', 'utf8', 'C:/r/py_router/route.py',
+           'C:/r/wk/a.kicad_pcb', '--nets', 'CS', '/40M_N']
+    led = ['python3', '-X', 'utf8', 'py_router/route.py',
+           'wk/a.kicad_pcb', '--nets', '/40M_N', 'CS']
+    want(_use_key('SCOPE', '--nets', 'route.py', log)
+         == _use_key('SCOPE', '--nets', 'route.py', led),
+         'the same lever spelled two ways must dedupe to one event')
+    want(_use_key('SCOPE', '--nets', 'route.py', log)
+         != _use_key('SCOPE', '--nets', 'route.py',
+                     ['route.py', '--nets', 'BUSY']),
+         'a different scope must remain a separate event')
+
+    # Prose files: narration is not an incident.
+    want('.md' not in SCAN_EXT,
+         'the journal QUOTES tool output; scanning it re-reports fixed defects')
+    want('.md' in WATCHED_EXT,
+         'the journal must count as liveness, or a writing run reads as dead')
+
+    print('FAIL: ' + '; '.join(bad) if bad else 'OK')
+    return 1 if bad else 0
+
+
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv[1:]
+    if '--self-test' in list(argv):
+        return _self_test()
+    p = argparse.ArgumentParser(description=__doc__.split('\n')[0])
+    sub = p.add_subparsers(dest='mode', required=True)
+
+    b = sub.add_parser('bugs', help='one event per new problem, forever')
+    b.add_argument('--workdir', required=True)
+    b.add_argument('--poll', type=float, default=POLL_SEC)
+
+    c = sub.add_parser('cheats', help='ways the run could pass without '
+                                      'earning it; ends at DONE')
+    c.add_argument('--workdir', required=True)
+    c.add_argument('--truthdir', help='the answer key, fingerprinted at arm '
+                                      'time and re-checked (default: '
+                                      'WORKDIR + "_truth")')
+    c.add_argument('--done', help='path whose existence triggers the final '
+                                  'audits (default: WORKDIR/DONE)')
+    c.add_argument('--poll', type=float, default=POLL_SEC)
+
+    t = sub.add_parser('timer', help='one event at start, one at the end')
+    t.add_argument('--workdir', required=True)
+    t.add_argument('--done', help='path whose existence means finished '
+                                  '(default: WORKDIR/DONE)')
+    t.add_argument('--poll', type=float, default=POLL_SEC)
+    t.add_argument('--stall-min', type=float, default=20.0,
+                   help='emit STALLED after this many idle minutes, then again '
+                        'at 2x and 4x that (0 = off). NOT terminal: the watch '
+                        'continues and re-arms when activity resumes.')
+    t.add_argument('--stall-exit', action='store_true',
+                   help='restore the old behaviour: END the watch on the first '
+                        'stall. A watcher that stops watching when it sees '
+                        'something worrying reports nothing thereafter, which '
+                        'is why this is no longer the default.')
+    t.add_argument('--max-min', type=float, default=0.0,
+                   help='emit TIMEOUT after this many minutes (0 = off)')
+
+    a = p.parse_args(argv)
+    # An empty WORKDIR is what an unset shell variable looks like, and it used
+    # to reach os.makedirs('') and traceback -- which in a watcher reads as
+    # "the thing I am watching crashed", not "you passed nothing".
+    if not (a.workdir or '').strip():
+        p.error('--workdir is empty (an unset shell variable?), so there is '
+                'nothing to watch')
+    if a.mode == 'bugs':
+        try:
+            watch_bugs(a.workdir, a.poll)
+        except KeyboardInterrupt:
+            return 0
+        return 0
+    if a.mode == 'cheats':
+        truth = a.truthdir or (a.workdir.rstrip('/\\') + '_truth')
+        done = a.done or os.path.join(a.workdir, 'DONE')
+        try:
+            return watch_cheats(a.workdir, truth, done, a.poll)
+        except KeyboardInterrupt:
+            return 0
+    done = a.done or os.path.join(a.workdir, 'DONE')
+    try:
+        return watch_timer(a.workdir, done, a.poll, a.stall_min, a.max_min,
+                           stall_exit=a.stall_exit)
+    except KeyboardInterrupt:
+        return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/stress/stage_blind.py
+++ b/tests/stress/stage_blind.py
@@ -59,6 +59,7 @@ redraw happened, with no count, no kind, no block and no dose.
 """
 import contextlib
 import io
+import hashlib
 import json
 import os
 import random
@@ -96,6 +97,127 @@ MIN_MATERIAL_MM = 1.0      #: absolute floor; 10x the 0.1 mm legalize grid step
 MATERIAL_FRAC = 0.35       #: ...and at least this much of what was asked for
 MAX_DRAWS = 12             #: redraw budget before refusing outright
 
+
+
+#: Project keys that are the AUTHOR'S, not the board's spec. Every one is
+#: empty on all 13 in-repo projects and read by nothing in this tree, so
+#: dropping them is lossless for every consumer -- but a hand-placed source
+#: fills them with board coordinates (`drc_exclusions` carries the offending
+#: items' positions; the viewports are named views like "MCU corner"), and
+#: `last_paths` carries the author's directories.
+_LEAKY_PROJECT_KEYS = (
+    ('board', 'design_settings', 'drc_exclusions'),
+    ('board', 'viewports'),
+    ('board', '3dviewports'),
+    ('board', 'layer_presets'),
+    ('pcbnew', 'last_paths'),
+)
+
+#: What replaces a string that names the source. Not deletion: a run reading
+#: the staged project should see that something was withheld, rather than a
+#: project that looks like it never carried provenance at all.
+_REDACTED = '[redacted: named the source board]'
+
+
+def sha256_file(path):
+    h = hashlib.sha256()
+    with open(path, 'rb') as f:
+        for chunk in iter(lambda: f.read(1 << 20), b''):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _redact_source_stem(node, stem, path=(), hits=None):
+    """Replace every string ANYWHERE in the project that names `stem`.
+
+    The key list above is a list of carriers known to leak, and the next
+    carrier will have a different name. It did: measured on tigard, the leak
+    was `kicad_routing_tools.floor_provenance._note` ("tigard is a KiCad 5
+    design...") and `.source` (a raw.githubusercontent URL serving the
+    original board) -- an annotation this repo writes itself, in a node no
+    key list contained. `fence_audit` caught it; the stager did not.
+
+    So the backstop is content-shaped rather than key-shaped: whatever key it
+    lives under, a string that spells the source's stem is a path back to the
+    original poses. Numbers are untouched, which is what keeps the #441 floor
+    intact -- every value the floor is graded at is numeric.
+    """
+    if hits is None:
+        hits = []
+    if isinstance(node, dict):
+        for k, v in list(node.items()):
+            if isinstance(v, str) and stem in v.lower():
+                node[k] = _REDACTED
+                hits.append('.'.join(path + (str(k),)))
+            else:
+                _redact_source_stem(v, stem, path + (str(k),), hits)
+    elif isinstance(node, list):
+        for i, v in enumerate(node):
+            if isinstance(v, str) and stem in v.lower():
+                node[i] = _REDACTED
+                hits.append('.'.join(path + (str(i),)))
+            else:
+                _redact_source_stem(v, stem, path + (str(i),), hits)
+    return hits
+
+
+def sanitize_staged_project(out_board, source_stem=None):
+    """Strip the source's IDENTITY from the carried project; declare the rest.
+
+    `source_stem` is the SOURCE board's stem (e.g. `tigard`). Pass it: the
+    key list is a list of known carriers, and the stem sweep is what catches
+    the ones nobody has met yet.
+
+    The project must travel -- without it the staged board grades at the
+    stock netclass (#441). But KiCad stores `meta.filename` inside it, so a
+    verbatim copy puts the SOURCE'S NAME in the work dir, which is the one
+    thing this stager exists to withhold. `.kicad_prl` does not enter the
+    work dir at all: nothing in this repo reads it and it carries the
+    source's name the same way `meta.filename` does.
+
+    Returns a declaration: what travelled, what was sanitized, and the floors
+    the run will actually be graded at.
+    """
+    stem = os.path.splitext(out_board)[0]
+    prl = stem + '.kicad_prl'
+    dropped_prl = os.path.isfile(prl)
+    if dropped_prl:
+        os.remove(prl)
+    pro = stem + '.kicad_pro'
+    out = {'carried': os.path.isfile(pro), 'sanitized_keys': [],
+           'dropped_prl': dropped_prl}
+    if out['carried']:
+        with open(pro, encoding='utf-8') as f:
+            doc = json.load(f)
+        meta = doc.get('meta')
+        if isinstance(meta, dict) and meta.get('filename'):
+            meta['filename'] = os.path.basename(pro)
+            out['sanitized_keys'].append('meta.filename')
+        for path in _LEAKY_PROJECT_KEYS:
+            node = doc
+            for k in path[:-1]:
+                node = node.get(k) if isinstance(node, dict) else None
+                if node is None:
+                    break
+            if isinstance(node, dict) and node.get(path[-1]):
+                node[path[-1]] = [] if path[-1] != 'last_paths' else {}
+                out['sanitized_keys'].append('.'.join(path))
+        if source_stem:
+            hits = _redact_source_stem(doc, source_stem.lower())
+            out['redacted_source_strings'] = hits
+            out['sanitized_keys'].extend(hits)
+        with open(pro, 'w', encoding='utf-8') as f:
+            json.dump(doc, f, indent=2)
+        out['sha256'] = sha256_file(pro)
+    # The numbers the run is graded at, whether or not a project travelled.
+    try:
+        from list_nets import board_floor_knobs
+        out['floors'] = board_floor_knobs(out_board)[2]
+    except Exception as e:                                   # noqa: BLE001
+        out['floors'] = f'unavailable: {type(e).__name__}: {e}'
+    for ext in ('.kicad_dru', '.kicad_prl'):
+        out[ext.lstrip('.')] = os.path.isfile(stem + ext)
+    return out
 
 def board_scale_mm(pcb):
     """The board's smaller outline span, or None when it declares no outline.
@@ -139,7 +261,12 @@ def main(src, workdir, truthdir, kinds=None):
     # the work dir in the first place (run-12 Tier 0).
     control = os.path.join(truthdir, 'control.kicad_pcb')
     shutil.copyfile(src, control)
-    for ext in ('.kicad_pro', '.kicad_prl'):
+    # copy_board.SIBLING_EXTS, not a hand-written pair: this list said
+    # ('.kicad_pro', '.kicad_prl') and dropped `.kicad_dru`, so the per-layer
+    # clearance rules that OUTRANK --clearance (#498) did not reach the
+    # control -- silently, because an absent .kicad_dru reads as "no rules".
+    from copy_board import SIBLING_EXTS
+    for ext in SIBLING_EXTS:
         sib = os.path.splitext(src)[0] + ext
         if os.path.exists(sib):
             shutil.copyfile(sib, os.path.join(truthdir, 'control' + ext))
@@ -194,6 +321,19 @@ def main(src, workdir, truthdir, kinds=None):
             'than emitting a board whose damage is at the grid step -- that '
             'is what voided run 14.' % MAX_DRAWS)
 
+    # The work-dir project must not name the source. `perturb` copies the
+    # siblings so the damaged board still grades at the real floor (#441),
+    # but KiCad stores `meta.filename` inside the project -- measured, the
+    # blind work dir's board.kicad_pro read "watchy.kicad_pro", which is the
+    # one thing this stager exists to withhold. `.kicad_prl` does not
+    # enter the work dir at all.
+    # The stem is passed so the sweep can run: tigard's project carried
+    # `kicad_routing_tools.floor_provenance` -- prose this repo authored, in a
+    # node no key list contained, naming the upstream board AND linking the
+    # URL that serves its original placement. `fence_audit --mode create`
+    # refused the staged work dir over it; the stager had reported success.
+    sanitize_staged_project(out, os.path.splitext(os.path.basename(src))[0])
+
     with open(os.path.join(truthdir, 'draw.json'), 'w', encoding='utf-8') as f:
         json.dump({'kind': kind, 'dose_mm': dose, 'seed': seed,
                    'dose_mm_applied': rec.get('dose_mm_applied'),
@@ -234,19 +374,24 @@ def main(src, workdir, truthdir, kinds=None):
 
 
 if __name__ == '__main__':
-    import argparse
-    ap = argparse.ArgumentParser(
-        description=__doc__.strip().splitlines()[0],
-        formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument('src'); ap.add_argument('workdir'); ap.add_argument('truthdir')
-    ap.add_argument('--kind', action='append', metavar='KIND',
-                    help='narrow the draw to this perturbation kind '
-                         '(repeatable). Valid: ' + ' '.join(P.KINDS) + '. The '
-                         'kinds displace very different fractions of a board '
-                         '(measured: pile 67%%, translate 27%%), so a run that '
-                         'wants the PLACEMENT half exercised has a reason to '
-                         'ask. It costs one bit of the fence -- still blind to '
-                         'block, dose and seed, but not to kind -- so SAY SO '
-                         'in the report.')
-    _a = ap.parse_args()
-    main(_a.src, _a.workdir, _a.truthdir, _a.kind)
+    # In LEVER_REGISTRY, so it must DECLARE -- an entry that writes
+    # poses without declaring makes an armed regime refuse the engine
+    # itself, which is the failure the registry exists to prevent.
+    from placement.provenance import declare_lever
+    with declare_lever('stage_blind.py', sys.argv):
+        import argparse
+        ap = argparse.ArgumentParser(
+            description=__doc__.strip().splitlines()[0],
+            formatter_class=argparse.RawDescriptionHelpFormatter)
+        ap.add_argument('src'); ap.add_argument('workdir'); ap.add_argument('truthdir')
+        ap.add_argument('--kind', action='append', metavar='KIND',
+                        help='narrow the draw to this perturbation kind '
+                             '(repeatable). Valid: ' + ' '.join(P.KINDS) + '. The '
+                             'kinds displace very different fractions of a board '
+                             '(measured: pile 67%%, translate 27%%), so a run that '
+                             'wants the PLACEMENT half exercised has a reason to '
+                             'ask. It costs one bit of the fence -- still blind to '
+                             'block, dose and seed, but not to kind -- so SAY SO '
+                             'in the report.')
+        _a = ap.parse_args()
+        main(_a.src, _a.workdir, _a.truthdir, _a.kind)

--- a/tests/stress/tee_cmd.py
+++ b/tests/stress/tee_cmd.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Instrumentation ONLY: run a command, tee it, record start/end/exit.
+
+This exists because per-command timings are NOT recoverable after the fact.
+`loop_driver.log` writes its `t` AFTER the stage function returns, so it
+timestamps completions rather than start/end pairs -- and it logs only the
+driver's own advisory invocations, never the placement/routing tool
+subprocesses run in response to that advice. Without a record kept at call
+time, "the three slowest individual tool invocations with their commands" has
+no honest answer but "not recoverable". Run 21 hit exactly that and wrote this
+wrapper into its work dir mid-run; it is promoted here so the next run can
+just use it.
+
+It writes NO poses and NO copper, reads no board, and takes no decisions. Say
+so in the journal and to the cheat watcher anyway: a wrapper around the tools
+is the shape a hand-rolled pose writer would take, so what it does is bounded
+here and every argv it ever ran is in `cmd_timing.jsonl`.
+
+    python3 -X utf8 tests/stress/tee_cmd.py [--workdir DIR] <label> -- <cmd> [args ...]
+
+Appends one JSON row per invocation to `<workdir>/cmd_timing.jsonl` and tees
+combined output to `<workdir>/logs/<label>.log` (also echoed to this process's
+stdout so the caller sees it live). `--workdir` defaults to this file's own
+directory, which is what a copy dropped into the work dir wants.
+"""
+import json
+import os
+import subprocess
+import sys
+import time
+
+
+def main(argv):
+    if '--' not in argv:
+        raise SystemExit(
+            'usage: tee_cmd.py [--workdir DIR] <label> -- <command> [args ...]')
+    cut = argv.index('--')
+    head, cmd = argv[:cut], argv[cut + 1:]
+    if not cmd:
+        raise SystemExit('tee_cmd: no command given after --')
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    if '--workdir' in head:
+        i = head.index('--workdir')
+        if i + 1 >= len(head):
+            raise SystemExit('tee_cmd: --workdir needs a value')
+        here, head = os.path.abspath(head[i + 1]), head[:i] + head[i + 2:]
+    label = '_'.join(head) or 'unlabelled'
+
+    ledger = os.path.join(here, 'cmd_timing.jsonl')
+    logdir = os.path.join(here, 'logs')
+    os.makedirs(logdir, exist_ok=True)
+    # A label reused across laps must not overwrite the earlier lap's log --
+    # the timing table needs both rows, and an overwritten log is a stage that
+    # silently cannot be timed.
+    path = os.path.join(logdir, label + '.log')
+    n = 1
+    while os.path.exists(path):
+        n += 1
+        path = os.path.join(logdir, '%s.%d.log' % (label, n))
+
+    # Run 24 (finding A-10): on a reused label the unsuffixed `<label>.done`
+    # kept the OLDEST attempt's exit forever, while the stage advice says
+    # "wait on logs/<label>.done" -- so a waiter armed during a retry
+    # returned instantly with a stale verdict. The canonical marker now
+    # DISAPPEARS while a retry runs and reappears with the newest code:
+    # absent == in flight, present == the latest attempt's exit. The
+    # numbered `<label>.N.done` files still pair 1:1 with their logs for
+    # the timing table.
+    canonical_done = os.path.join(logdir, label + '.done')
+    if n > 1:
+        try:
+            os.remove(canonical_done)
+        except OSError:
+            pass
+
+    t0 = time.time()
+    with open(path, 'w', encoding='utf-8', errors='replace') as log:
+        log.write('CMD: %s\n' % ' '.join(cmd))
+        log.flush()
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                                stderr=subprocess.STDOUT)
+        for raw in proc.stdout:
+            line = raw.decode('utf-8', 'replace')
+            log.write(line)
+            log.flush()
+            sys.stdout.write(line)
+            sys.stdout.flush()
+        code = proc.wait()
+        # The anchor contract run_watch documents is "one CMD: and one EXIT=
+        # per log". We write the CMD: line above because the two skill drivers
+        # install no cli_banner and would otherwise be unanchored -- but we
+        # never wrote the EXIT= half, so a teed log of a banner-less tool
+        # satisfied only one side of it. `[tee_cmd] ... exit=N` below is for
+        # humans and does not carry the EXIT= prefix any parser looks for.
+        log.write('EXIT=%d' % code + chr(10))
+        log.flush()
+    # run-23: ONE canonical completion signal. The exit line above lives in
+    # the log; the `[tee_cmd] ... exit=` line goes to stdout only -- and a
+    # waiter grepping the log for the stdout line cost 25 measured minutes.
+    # `<label>.done` holds the exit code and appears exactly when the child
+    # has exited; wait on os.path.exists of THIS, nothing else.
+    with open(path[:-4] + '.done' if path.endswith('.log')
+              else path + '.done', 'w', encoding='utf-8') as f:
+        f.write('%d\n' % code)
+    if n > 1:
+        # last-attempt-wins: the canonical marker always carries the NEWEST
+        # attempt's exit, so "wait on logs/<label>.done" is correct across
+        # retries (it was removed above while this attempt ran).
+        with open(canonical_done, 'w', encoding='utf-8') as f:
+            f.write('%d\n' % code)
+    t1 = time.time()
+
+    with open(ledger, 'a', encoding='utf-8') as f:
+        f.write(json.dumps({
+            'label': label, 'log': os.path.relpath(path, here),
+            't_start': round(t0, 3), 't_end': round(t1, 3),
+            'iso_start': time.strftime('%Y-%m-%dT%H:%M:%S',
+                                       time.localtime(t0)),
+            'wall_s': round(t1 - t0, 3), 'exit': code,
+            'argv': cmd, 'cmdline': ' '.join(cmd),
+        }) + '\n')
+    print('[tee_cmd] %s exit=%d wall=%.1fs -> %s'
+          % (label, code, t1 - t0, os.path.relpath(path, here)))
+    return code
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv[1:]))

--- a/tests/test_431_board_gates.py
+++ b/tests/test_431_board_gates.py
@@ -25,6 +25,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'py_placer'))  # placement split
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'py_router'))  # placement split
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'py_tools'))  # placement split
+from run_utils import tool as _tool  # #522: resolve a moved CLI, loudly
 
 # #522 reorg + skill merge: engine -> py_router/, placer -> py_placer/,
 # board_score.py -> the placement-and-routing skill. Without these roots the
@@ -43,6 +44,14 @@ from kicad_parser import parse_kicad_pcb  # noqa: E402
 from placement.lock_advisor import advise_locks, to_json  # noqa: E402
 from placement.placement_state import (UNPLACED_EXIT, assess_placement)  # noqa: E402
 from placement.writer import write_placed_output  # noqa: E402
+
+#: Measured 516 s ALONE (2026-08-19, exit 0, all checks pass) -- UNDER the
+#: 600 s default, yet it times out in-suite. run_all defaults to -j 4, so
+#: it competes for CPU with three other processes while that clock runs.
+#: A budget for the contended case, not for a hung test: the standalone
+#: number is the evidence that it finishes.
+RUN_ALL_TIMEOUT = 1200
+
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 KF = os.path.join(ROOT, 'kicad_files')

--- a/tests/test_457_determinism.py
+++ b/tests/test_457_determinism.py
@@ -33,6 +33,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'py_router'))  # #522
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'py_placer'))  # placement split
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'py_tools'))  # #522
+from run_utils import tool_env as _tool_env  # #522 PYTHONPATH
 
 # #522 reorg + skill merge: engine -> py_router/, placer -> py_placer/,
 # board_score.py -> the placement-and-routing skill. Without these roots the
@@ -83,17 +84,10 @@ sys.stdout.write("RESULT" + json.dumps({
 
 
 def _run(board, seed):
-    # #522: kicad_parser/placement live under py_router/ now; the probe
-    # subprocess needs them on ITS path too (rust_router for grid_router).
-    env = dict(os.environ, PYTHONHASHSEED=seed,
-               PYTHONPATH=os.pathsep.join(
-                   (os.path.join(ROOT, 'py_router'),
-                    # the placer split out of py_router; _PROBE imports
-                    # placement.quench from here, and without it the probe
-                    # died before running and the test reported a failure
-                    # while asserting nothing.
-                    os.path.join(ROOT, 'py_placer'),
-                    os.path.join(ROOT, 'rust_router'), ROOT)))
+    # PYTHONPATH must reach py_router/ py_tools/ py_placer/ (and rust_router
+    # for grid_router) -- the probe imports kicad_parser, which #522 moved
+    # out of the repo root. run_utils.tool_env covers them all.
+    env = dict(_tool_env(), PYTHONHASHSEED=seed)
     r = subprocess.run([sys.executable, '-c', _PROBE,
                         os.path.join(ROOT, 'kicad_files', board)],
                        capture_output=True, text=True, cwd=ROOT, env=env)

--- a/tests/test_504_ratsnest_metrics.py
+++ b/tests/test_504_ratsnest_metrics.py
@@ -25,7 +25,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'py_router'))  # #522
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'py_tools'))  # #522
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), 'py_placer'))  # placement split
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'py_placer'))  # placement split (was tests/py_placer, which does not exist)
 
 # #522 reorg + skill merge: engine -> py_router/, placer -> py_placer/,
 # board_score.py -> the placement-and-routing skill. Without these roots the

--- a/tests/test_630_seeder_eviction.py
+++ b/tests/test_630_seeder_eviction.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Issue #630's own pin test, against the tool the issue names.
+
+    "`place_seed` on a pile fixture must seat a part whose only pocket is
+     blocked by one movable incumbent, without hand intervention."
+
+Not `place_plan`, not a library call -- `place_seed`, because that is the
+tool run 19 was using when it returned "no legal pose anywhere on the board"
+three times and a teammate went off and wrote 221 lines of arithmetic.
+
+The block is a THEOREM, not an observation. On a 16 x 14 board at 0.5mm edge
+clearance, BIG's 10x10 courtyard confines its centre to x in [5.5, 10.5] and
+y in [5.5, 8.5]. Clearing SMALL's 1x1 courtyard at the zone centre by 0.2mm
+needs |cx - 8| >= 5.7 or |cy - 7| >= 5.7, and neither interval intersects
+BIG's legal range. So while SMALL sits there BIG has exactly zero legal
+poses, and a full rim of them once it moves.
+
+Both parts are declared into the SAME zone, so the seeder packs them by
+descending pin count -- SMALL first, because it has more pads. That is not a
+contrivance: it is the ordering that produced run 19's failure (34 six-pad
+diodes seated before 34 fifteen-millimetre switches, and the smalls took the
+centre).
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for p in (REPO,):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+        sys.path.insert(0, os.path.join(p, 'py_router'))
+        sys.path.insert(0, os.path.join(p, 'py_tools'))
+        sys.path.insert(0, os.path.join(p, 'py_placer'))
+
+passed = failed = 0
+
+
+def check(name, ok, detail=""):
+    global passed, failed
+    passed += bool(ok)
+    failed += not ok
+    print(f"  {'OK  ' if ok else 'FAIL'} {name}{(' -- ' + detail) if detail else ''}")
+
+
+def _part(ref, x, y, cy, npads):
+    pads = ''.join(
+        f'\t\t(pad "{i + 1}" smd rect\n\t\t\t(at {i * 0.2 - 0.2} 0)\n'
+        f'\t\t\t(size 0.3 0.3)\n\t\t\t(layers "F.Cu")\n'
+        f'\t\t\t(net {1 if i == 0 else 2} "N{1 if i == 0 else 2}")\n'
+        f'\t\t\t(uuid "p{i}-{ref}")\n\t\t)\n' for i in range(npads))
+    return f'''\t(footprint "test:P{ref}"
+\t\t(layer "F.Cu")
+\t\t(uuid "fp-{ref}")
+\t\t(at {x} {y})
+\t\t(property "Reference" "{ref}"
+\t\t\t(at 0 0)
+\t\t)
+\t\t(fp_rect
+\t\t\t(start {-cy} {-cy})
+\t\t\t(end {cy} {cy})
+\t\t\t(layer "F.CrtYd")
+\t\t\t(uuid "cy-{ref}")
+\t\t)
+{pads}\t)
+'''
+
+
+def pile_board(path):
+    """Every part stacked at one coordinate: the place-from-scratch task."""
+    # SMALL has MORE pads than BIG, so the zone packer seats it first.
+    fps = (_part('BIG', 8, 7, 5.0, 2) + _part('SMALL', 8, 7, 0.5, 4))
+    body = ('(kicad_pcb\n\t(version 20241229)\n'
+            '\t(net 0 "")\n\t(net 1 "N1")\n\t(net 2 "N2")\n'
+            '\t(gr_rect\n\t\t(start 0 0)\n\t\t(end 16 14)\n'
+            '\t\t(layer "Edge.Cuts")\n\t\t(uuid "e1")\n\t)\n' + fps + ')\n')
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(body)
+
+
+INTENT = {
+    "schema": 1, "kind": "floorplan-intent", "units": "mm",
+    "envelope": {"rect": [0.0, 0.0, 16.0, 14.0], "tolerance_mm": 0.5},
+    "blocks": [{"name": "everything", "refs": ["BIG", "SMALL"],
+                "zone": [0.5, 0.5, 15.5, 13.5], "tolerance_mm": 0.5}],
+}
+
+
+def run(workdir, *extra):
+    board = os.path.join(workdir, 'pile.kicad_pcb')
+    intent = os.path.join(workdir, 'fp.json')
+    out = os.path.join(workdir, 'seed.kicad_pcb')
+    pile_board(board)
+    with open(intent, 'w', encoding='utf-8') as f:
+        json.dump(INTENT, f)
+    r = subprocess.run(
+        [sys.executable, '-X', 'utf8',
+         os.path.join('py_placer', 'place_seed.py'), board, out,
+         '--intent', intent, '--clearance', '0.2',
+         '--board-edge-clearance', '0.5', '--no-polish', *extra],
+        capture_output=True, text=True, encoding='utf-8', errors='replace',
+        cwd=REPO, timeout=900,
+        env=dict(os.environ, PYTHONHASHSEED='0', PYTHONIOENCODING='utf-8'))
+    summary = None
+    for line in r.stdout.splitlines():
+        if line.startswith('JSON_SUMMARY:'):
+            summary = json.loads(line.split(':', 1)[1])
+    return r, summary, out
+
+
+# --------------------------------------------------------------------------
+# THE PIN TEST
+# --------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as wd:
+    proc, s, out = run(wd)
+    check("place_seed runs", s is not None,
+          (proc.stdout[-600:] + proc.stderr[-600:]))
+    if s:
+        check("#630: it seats BOTH parts, with no hand intervention",
+              s['unseated'] == 0 and s['placed'] == 2,
+              f"placed {s['placed']}, unseated {s['unseated']} "
+              f"{s.get('unseated_refs')}")
+        check("and exits 0 rather than 4", proc.returncode == 0,
+              f"rc={proc.returncode}")
+    check("the run says which part it evicted, and what that freed",
+          'evicting' in proc.stdout and 'poses at its target' in proc.stdout,
+          str([l for l in proc.stdout.splitlines() if "evict" in l][:2]))
+
+# --------------------------------------------------------------------------
+# #629: the verdict NAMES its blockers, in the JSON, with the counts
+# --------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as wd:
+    proc, s, out = run(wd, '--evict-depth', '0')
+    check("with the rung off, the seed fails the way it always did",
+          s and s['unseated'] == 1 and proc.returncode == 4,
+          f"unseated {s and s['unseated']}, rc={proc.returncode}")
+    check("#629: the JSON_SUMMARY names the unseated ref, not just a count",
+          s and s.get('unseated_refs') == ['BIG'],
+          str(s and s.get('unseated_refs')))
+    check("#629: `no_pose_blockers` is in the JSON_SUMMARY",
+          s and 'no_pose_blockers' in s, str(sorted(s or {})))
+    check("#629: it names the blocker and the poses that blocker frees",
+          s and s.get('no_pose_blockers', {}).get('BIG', {}).get('SMALL', 0)
+          > 0,
+          str(s and s.get('no_pose_blockers')))
+    check("the bare verdict is still printed, now with the census beside it",
+          'no legal pose' in proc.stdout, proc.stdout[-300:])
+
+# --------------------------------------------------------------------------
+# The gate: a trade that does not improve the board must not ship
+# --------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as wd:
+    proc, s, out = run(wd)
+    # Every eviction is recorded with the gate tuple either side, so a reader
+    # can check the trade rather than trust it.
+    ev = [l for l in proc.stdout.splitlines() if 'gate' in l and 'evict' in l]
+    check("the eviction is RECORDED with the gate either side of it",
+          bool(ev), str([l for l in proc.stdout.splitlines()
+                         if 'evict' in l][:3]))
+
+# --------------------------------------------------------------------------
+# A locked incumbent is never evicted -- it is not this tool's to move
+# --------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as wd:
+    board = os.path.join(wd, 'pile.kicad_pcb')
+    pile_board(board)
+    src = open(board, encoding='utf-8').read().replace(
+        '(footprint "test:PSMALL"\n\t\t(layer "F.Cu")',
+        '(footprint "test:PSMALL"\n\t\t(layer "F.Cu")\n\t\t(locked yes)')
+    open(board, 'w', encoding='utf-8').write(src)
+    intent = os.path.join(wd, 'fp.json')
+    with open(intent, 'w', encoding='utf-8') as f:
+        json.dump(INTENT, f)
+    r = subprocess.run(
+        [sys.executable, '-X', 'utf8',
+         os.path.join('py_placer', 'place_seed.py'), board,
+         os.path.join(wd, 'o.kicad_pcb'), '--intent', intent,
+         '--clearance', '0.2', '--board-edge-clearance', '0.5', '--no-polish'],
+        capture_output=True, text=True, encoding='utf-8', errors='replace',
+        cwd=REPO, timeout=900,
+        env=dict(os.environ, PYTHONIOENCODING='utf-8'))
+    moved = 'SMALL' in r.stdout and 'evicting SMALL' in r.stdout
+    check("a file-locked incumbent is never evicted",
+          not moved, "the rung moved a part the file locked")
+
+print(f"\n{passed} passed, {failed} failed")
+sys.exit(1 if failed else 0)

--- a/tests/test_board_score_vacuity.py
+++ b/tests/test_board_score_vacuity.py
@@ -21,15 +21,7 @@ import tempfile
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, ROOT)
-# #522 reorg + skill merge: the engine moved to py_router/, the placer to
-# py_placer/, and board_score.py into the placement-and-routing skill. Tests
-# that shell out to or import them need those roots on sys.path.
-for _p in ('py_router', 'py_placer',
-           os.path.join('.claude', 'skills', 'plan-pcb-placement-and-routing',
-                        'scripts')):
-    _d = os.path.join(ROOT, _p)
-    if _d not in sys.path:
-        sys.path.insert(0, _d)
+from run_utils import tool as _tool  # #522: resolve a moved CLI, loudly
 BOARD = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
 SCORE = os.path.join(ROOT, '.claude', 'skills', 'plan-pcb-placement-and-routing',
                      'scripts', 'board_score.py')
@@ -49,7 +41,7 @@ def _routed_board(td):
     """Route two nets of the fixture so the impedance component has copper."""
     out = os.path.join(td, 'routed.kicad_pcb')
     r = subprocess.run([sys.executable, '-X', 'utf8',
-                        os.path.join(ROOT, 'py_router', 'route.py'), BOARD, out,
+                        _tool('route.py'), BOARD, out,
                         '--nets', '/OUT_A_PHASE_A', '/OUT_A_PHASE_B'],
                        capture_output=True, text=True, encoding='utf-8',
                        errors='replace', cwd=ROOT)

--- a/tests/test_compare_seeds.py
+++ b/tests/test_compare_seeds.py
@@ -17,6 +17,11 @@ import subprocess
 import sys
 import tempfile
 
+#: Self-budgets its inner subprocess at 3600 s, so the runner's 600 s cap
+#: killed it before its own deadline could fire -- no partial result, no
+#: diagnosis. Still doing real work at 900 s when measured.
+RUN_ALL_TIMEOUT = 3600
+
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, ROOT)
 sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # placement split

--- a/tests/test_defect_record_reachability.py
+++ b/tests/test_defect_record_reachability.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""The defect record: what the chain measured, in a shape something can read.
+
+Run 20 measured a cage at pad U4.54 -- throat 0.409 mm against 0.450 needed,
+blocked by U4.53 and R7.2 -- and that finding lived in three tools' stdout and
+had to be hand-assembled into an English paragraph inside a ledger `lever`
+string and a subagent prompt. Nothing downstream could consume it.
+
+Every number in the record was ALREADY COMPUTED and thrown away at the point of
+formatting. `widest_path` held the throat cell in a local and returned a bare
+float; `pad_reachability` knew the clearance the field was built at and did not
+publish it. This is plumbing, not new measurement, and the tests say so by
+checking the values against the geometry rather than against each other.
+
+Two traps this file exists to pin:
+
+  * `bottleneck_mm` is in SLACK space (`slack = 2*(dist - clearance)`), so the
+    physical gap is `bottleneck + 2*clearance`. Run 20's ledger put a gap-space
+    pair (0.409/0.450) beside a track-space margin (-37.69 um) in one sentence
+    as if they were the same measurement. The record carries both, labelled.
+  * `to_dict()` is PURELY ADDITIVE. Its consumers predate the record.
+"""
+import os
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for _p in (REPO, os.path.join(REPO, 'py_router'), os.path.join(REPO, 'py_placer'),
+           os.path.join(REPO, 'py_tools'), os.path.join(REPO, 'tests')):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+SKIP_EXIT = 77
+try:
+    import numpy  # noqa: F401
+    import scipy  # noqa: F401
+except ImportError as exc:
+    print(f'SKIP: reachability needs numpy+scipy ({exc})')
+    sys.exit(SKIP_EXIT)
+
+from placement import reachability as RE                          # noqa: E402
+from kicad_parser import BoardInfo, Footprint                     # noqa: E402
+import synth                                                      # noqa: E402
+
+
+def _fp(ref, pads):
+    return Footprint(reference=ref, footprint_name='t:x',
+                     x=pads[0].global_x, y=pads[0].global_y, rotation=0.0,
+                     layer='F.Cu', pads=pads)
+
+
+def _bi(layers):
+    return BoardInfo(layers={i * 2: n for i, n in enumerate(layers)},
+                     copper_layers=list(layers), board_bounds=(0, 0, 10, 10),
+                     stackup=[], board_outline=[], board_cutouts=[],
+                     board_outlines=[], board_edge_contours=[])
+
+passed = failed = 0
+
+
+def check(label, cond, detail=''):
+    global passed, failed
+    if cond:
+        passed += 1
+        print(f'  OK   {label}')
+    else:
+        failed += 1
+        print(f'  FAIL {label} -- {detail}')
+
+
+# A throat with KNOWN geometry, and it has to be a real WALL: two tall foreign
+# pads spanning the whole view with a 0.40 mm slot between them, so the only way
+# from the seed island to the target island is through the slot. A wall of two
+# small pads is not a throat -- the path simply goes around it, the bottleneck
+# is the view's own size, and every assertion below passes vacuously. (The first
+# version of this fixture did exactly that, and `caged` was True only because
+# the target island was outside the view: a NO-TARGET reported as a cage.)
+GAP = 0.40
+TALL = 3.0                              # each wall pad's height
+PITCH = TALL + GAP                      # centre-to-centre, vertically
+SEED = (4.0, 5.0)
+
+
+def _board():
+    own_a = synth.make_pad(1, SEED[0], SEED[1], ref='U1', num='1',
+                           net_name='SIG', size_x=0.6, size_y=0.6)
+    own_b = synth.make_pad(1, 6.0, 5.0, ref='U2', num='1', net_name='SIG',
+                           size_x=0.6, size_y=0.6)
+    wall_a = synth.make_pad(2, 5.0, 5.0 - PITCH / 2.0, ref='R7', num='2',
+                            net_name='GND', size_x=0.6, size_y=TALL)
+    wall_b = synth.make_pad(3, 5.0, 5.0 + PITCH / 2.0, ref='U4', num='3',
+                            net_name='VCC', size_x=0.6, size_y=TALL)
+    fps = {'U1': _fp('U1', [own_a]), 'U2': _fp('U2', [own_b]),
+           'R7': _fp('R7', [wall_a]), 'U4': _fp('U4', [wall_b])}
+    nets = {1: synth.make_net(1, 'SIG'), 2: synth.make_net(2, 'GND'),
+            3: synth.make_net(3, 'VCC')}
+    return synth.make_pcb(nets=nets, footprints=fps,
+                          board_info=_bi(['F.Cu']))
+
+
+CLR = 0.05
+TRACK = 0.40                            # deliberately wider than fits
+pcb = _board()
+r = RE.pad_reachability(pcb, SEED, net_id=1, layers=('F.Cu',),
+                        track_mm=TRACK, via_mm=0.6, base_clearance=CLR,
+                        step=0.01, margin_mm=2.0)
+
+print('--- the throat is WHERE the geometry says it is ---')
+# `measured` FIRST. `caged` is True whenever `bottleneck_mm` is None, which
+# includes "nothing of this net to reach inside the view" -- so asserting
+# `caged` alone passes on a fixture that measured nothing at all.
+check('the question was answerable (there IS a target island in the view)',
+      r.measured, f'target_cells={r.target_cells} note={r.note!r}')
+check('a path exists, so the bottleneck is a real number not a None',
+      r.bottleneck_mm is not None,
+      'None means no positive-slack path at any width -- a walled-in seed, '
+      'not a throat, and there is nothing to point at')
+check('the measurement is CAGED (0.40mm track will not fit a 0.40mm slot '
+      'at 0.05 clearance)', r.caged, r.to_dict()['verdict'])
+_t = r.throat
+check('a throat is reported at all', _t is not None,
+      'widest_path held this cell in a local and returned a bare float')
+if _t:
+    check('and it lies INSIDE the gap, not on either pad',
+          abs(_t['x'] - 5.0) < 0.35 and abs(_t['y'] - 5.0) < GAP,
+          f"{_t} -- the gap runs through (5.0, 5.0)")
+    check('on the layer the field was built on', _t['layer'] == 'F.Cu', str(_t))
+
+print('--- the two SPACES, both published, and convertible ---')
+check('gap_mm is the physical gap, within one raster step of the truth',
+      r.gap_mm is not None and abs(r.gap_mm - GAP) <= r.step_mm + 1e-9,
+      f'{r.gap_mm} vs an analytic {GAP} at step {r.step_mm}')
+check('and it is exactly bottleneck + 2*clearance, not a second measurement',
+      abs(r.gap_mm - (r.bottleneck_mm + 2 * r.clearance_mm)) < 1e-12,
+      f'{r.gap_mm} vs {r.bottleneck_mm} + 2*{r.clearance_mm}')
+check('the clearance the field was built at is published',
+      abs(r.clearance_mm - CLR) < 1e-12, str(r.clearance_mm))
+
+print('--- who is forming the throat ---')
+_refs = {n.get('ref') for n in r.near}
+check('the two nearest foreign objects are named, by REF.PAD',
+      _refs == {'R7', 'U4'}, str(r.near))
+check('and their distances are sorted nearest-first',
+      all(r.near[i]['dist'] <= r.near[i + 1]['dist']
+          for i in range(len(r.near) - 1)), str([n['dist'] for n in r.near]))
+
+print('--- to_dict stays additive ---')
+_LEGACY = {'net', 'seed', 'layers', 'step_mm', 'track_mm', 'via_mm',
+           'bottleneck_mm', 'wide_open', 'verdict', 'measured', 'margin_um',
+           'target_cells', 'via_legal_fraction', 'grid', 'view', 'note'}
+d = r.to_dict()
+check('every pre-existing key survives',
+      _LEGACY <= set(d),
+      f'missing {sorted(_LEGACY - set(d))} -- consumers of this payload '
+      f'predate the defect record and must not be broken by it')
+check('and the new keys are there beside them',
+      {'throat', 'clearance_mm', 'gap_mm', 'near'} <= set(d),
+      sorted(set(d) - _LEGACY))
+
+print('--- the record itself ---')
+rec = r.defect_record(board='/tmp/x.kicad_pcb', board_sha='deadbeef',
+                      floors={'clearance': {'value': CLR,
+                                            'source': 'board netclass'}})
+check('a CAGED measurement produces a record', isinstance(rec, dict), str(rec))
+_d0 = (rec or {}).get('defects', [{}])[0]
+check('it is a defect-record v1 with one defect',
+      rec.get('kind') == 'defect-record' and rec.get('version') == 1
+      and rec.get('count') == 1 and len(rec.get('defects') or []) == 1,
+      str(rec)[:200])
+check('the defect is a throat with the CAGED verdict',
+      _d0.get('kind') == 'throat' and _d0.get('verdict') == 'CAGED', str(_d0)[:200])
+_m = _d0.get('measure') or {}
+check('short_mm is exactly need - have, not a separate measurement',
+      abs(_m.get('short_mm', 0) - (_m['need_mm'] - _m['have_mm'])) < 1e-9,
+      str(_m))
+check('the measure names its SPACE and its resolution',
+      _m.get('space') == 'track_width' and _m.get('resolution_mm') == r.step_mm,
+      str(_m))
+check('gap space is carried alongside, with what converts them',
+      _m.get('gap_mm') is not None and _m.get('gap_need_mm') is not None
+      and 'clearance' in (_m.get('derived_from') or ''), str(_m))
+check('the blocking refs and pads are named',
+      set(_d0.get('refs') or ()) == {'R7', 'U4'}
+      and len(_d0.get('pads') or ()) == 2, str(_d0.get('pads')))
+check('the record is BOUND to the board it was measured on',
+      _d0 and rec.get('board_sha') == 'deadbeef' and rec.get('board'),
+      'a record without a sha can be drawn over a board it does not describe')
+check('the floors it graded at travel with it, with their sources',
+      (_d0.get('instrument') or {}).get('floors', {})
+      .get('clearance', {}).get('source') == 'board netclass',
+      str(_d0.get('instrument')))
+
+print('--- and NOT produced when there is no defect ---')
+r2 = RE.pad_reachability(pcb, SEED, net_id=1, layers=('F.Cu',),
+                         track_mm=0.05, via_mm=0.6, base_clearance=CLR,
+                         step=0.01, margin_mm=2.0)
+check('a PASSABLE measurement makes no record',
+      not r2.caged and r2.defect_record() is None,
+      f'caged={r2.caged} record={r2.defect_record()}')
+
+# A seed with nothing to reach is NO-TARGET, a third state -- and it must not
+# produce a record either, or the loop re-enters placement over a question
+# nobody answered (run 15: 7 CAGED reported where 3 was the truth).
+r3 = RE.pad_reachability(pcb, SEED, net_id=1, layers=('F.Cu',),
+                         track_mm=TRACK, via_mm=0.6, base_clearance=CLR,
+                         step=0.01, margin_mm=0.5)
+check('a NO-TARGET measurement makes no record either',
+      not r3.measured and r3.defect_record() is None,
+      f'measured={r3.measured} record={r3.defect_record()}')
+
+print('--- relief_move, the "so what do I do" half ---')
+from placement.routability import relief_move                     # noqa: E402
+from placement.legality import rect_gap                           # noqa: E402
+
+# The run-20 fixture, from the plan: dx=0.3915, dy=0.12, need=0.45.
+_a = (0.0, 0.0, 1.0, 1.0)
+_b = (1.0 + 0.3915, 1.0 + 0.12, 2.0, 2.0)
+check('the fixture gap is the hand-measured 0.409478',
+      abs(rect_gap(_a, _b) - 0.409478) < 1e-6, str(rect_gap(_a, _b)))
+_mv = relief_move(_a, _b, 0.45)
+_east = next((m for m in _mv if m['dir'] == 'east'), None)
+check('and the eastward relief is 0.0422mm',
+      _east and abs(_east['min_mm'] - 0.0422) < 1e-4, str(_mv))
+check('every result is stamped as a LOWER bound',
+      all(m['bound'] == 'lower' for m in _mv),
+      'moving a part changes the whole field; this clears THIS pair only')
+_moved = (_b[0] + _east['min_mm'], _b[1], _b[2] + _east['min_mm'], _b[3])
+check('and the bound is real -- applying it reaches the need',
+      rect_gap(_a, _moved) >= 0.45 - 1e-9, str(rect_gap(_a, _moved)))
+
+# Overlapping rects: the gap is negative, so every direction needs a real move.
+_ov = relief_move((0.0, 0.0, 2.0, 2.0), (1.0, 1.0, 3.0, 3.0), 0.45)
+check('overlapping rects still get an answer', bool(_ov), str(_ov))
+check('and none of those answers is zero',
+      all(m['min_mm'] > 0 for m in _ov), str(_ov))
+
+# Infeasible within the cap: omitted, never reported as a large number.
+_inf = relief_move((0.0, 0.0, 100.0, 1.0), (0.0, 1.05, 100.0, 2.0), 0.45,
+                   limit_mm=0.1)
+check('a direction that cannot reach the need within the cap is omitted',
+      not any(m['dir'] in ('north', 'south') for m in _inf), str(_inf))
+
+# Already clear: zero, not a bisection artefact.
+_clear = relief_move((0.0, 0.0, 1.0, 1.0), (2.0, 0.0, 3.0, 1.0), 0.45)
+check('a pair already at the need reports 0.0',
+      _clear and all(m['min_mm'] == 0.0 for m in _clear), str(_clear))
+
+print(f'\n{passed} passed, {failed} failed')
+sys.exit(1 if failed else 0)

--- a/tests/test_defect_render_scale.py
+++ b/tests/test_defect_render_scale.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""The picture is cropped from the MEASUREMENT, not from the parts.
+
+Run 20's board is 33.8 x 46.0 mm. At `--size 1600` that is ~35 px/mm, and the
+defect it was trying to show was 41 um -- about 1.2 px. Every render was of the
+right board at a scale where the finding could not exist as an image. No mandate
+in the chain ever asked for a crop AT a routing failure; crops were reserved for
+legality findings and stop-condition claims.
+
+So the defect panel derives its own view: tighten until the SHORTFALL spans
+`DEFECT_MIN_PX`. That is the difference between a picture of the neighbourhood
+and a picture of the finding, and when even that is not enough the caption says
+INVISIBLE AT THIS SCALE rather than shipping a lie.
+
+    python3 tests/test_defect_render_scale.py
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for _p in (REPO, os.path.join(REPO, 'py_router'), os.path.join(REPO, 'py_tools'),
+           os.path.join(REPO, 'py_placer')):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+SKIP_EXIT = 77
+try:
+    from PIL import ImageChops                                     # noqa: F401
+except ImportError as exc:
+    print(f'SKIP: needs Pillow ({exc})')
+    sys.exit(SKIP_EXIT)
+
+import render_placement as RP                                      # noqa: E402
+
+passed = failed = 0
+
+
+def check(label, cond, detail=''):
+    global passed, failed
+    if cond:
+        passed += 1
+        print(f'  OK   {label}')
+    else:
+        failed += 1
+        print(f'  FAIL {label} -- {detail}')
+
+
+_D = tempfile.mkdtemp()
+
+# The run-20 measurement, verbatim from what check_reachability produces.
+_DEFECT = {
+    'kind': 'throat', 'verdict': 'CAGED', 'net': 'Net-(U4-XTAL_P)',
+    'seed': {'x': 86.8575, 'y': 91.01, 'layer': 'F.Cu'},
+    'at': {'x': 87.4825, 'y': 91.235, 'layer': 'F.Cu'},
+    'refs': ['R7', 'U4'], 'pads': ['R7.2', 'U4.53'],
+    'measure': {'space': 'track_width', 'have_mm': 0.11231, 'need_mm': 0.15,
+                'short_mm': 0.03769, 'resolution_mm': 0.01,
+                'gap_mm': 0.41231, 'gap_need_mm': 0.45,
+                'derived_from': 'have_mm + 2 * instrument.floors.clearance.value'},
+    'view': [82.8575, 87.01, 90.8575, 95.01],
+    'span': {'a': {'x': 88.0067, 'y': 90.92, 'layer': 'F.Cu', 'kind': 'pad'},
+             'b': {'x': 86.8575, 'y': 91.41, 'layer': 'F.Cu', 'kind': 'pad'}},
+    'relief': [], 'instrument': {'source': 'check_reachability', 'floors': {}},
+}
+
+
+def _rec(path, sha=None, defect=None):
+    doc = {'kind': 'defect-record', 'version': 1, 'count': 1,
+           'defects': [defect or _DEFECT]}
+    if sha:
+        doc['board_sha'] = sha
+    p = os.path.join(_D, path)
+    with open(p, 'w', encoding='utf-8') as fh:
+        json.dump(doc, fh)
+    return p
+
+
+print('--- the crop is sized from the shortfall, not from the parts ---')
+
+for size in (800, 1600, 3200):
+    view, ppmm, spx = RP.defect_view(_DEFECT, size)
+    side = view[2] - view[0]
+    check(f'at --size {size} the shortfall spans >= {RP.DEFECT_MIN_PX} px',
+          spx >= RP.DEFECT_MIN_PX - 0.5,
+          f'{spx:.2f} px over a {side:.3f}mm crop -- at the board\'s own '
+          f'extent this defect is about 1.2 px')
+    check(f'...and the throat is centred in it (--size {size})',
+          abs((view[0] + view[2]) / 2 - _DEFECT['at']['x']) < 1e-9
+          and abs((view[1] + view[3]) / 2 - _DEFECT['at']['y']) < 1e-9,
+          str(view))
+
+view, ppmm, spx = RP.defect_view(_DEFECT, 1600)
+check('the crop still frames both blocking pads',
+      view[0] <= min(_DEFECT['span']['a']['x'], _DEFECT['span']['b']['x'])
+      and view[2] >= max(_DEFECT['span']['a']['x'], _DEFECT['span']['b']['x']),
+      f'{view} vs span x '
+      f"{_DEFECT['span']['a']['x']}, {_DEFECT['span']['b']['x']} -- a crop so "
+      f"tight the two pieces of copper leave frame answers 'how much' and "
+      f"loses 'between what'")
+check('and it is far tighter than the record\'s own search view',
+      (view[2] - view[0]) < (_DEFECT['view'][2] - _DEFECT['view'][0]) / 2,
+      f"{view[2] - view[0]:.3f}mm vs "
+      f"{_DEFECT['view'][2] - _DEFECT['view'][0]:.3f}mm")
+
+# A defect carrying no shortfall must not have a scale invented for it.
+_nos = dict(_DEFECT, measure={'space': 'track_width'})
+v2, _, _ = RP.defect_view(_nos, 1600)
+check('a defect with no shortfall falls back to its own view, not a guess',
+      v2 is not None and abs((v2[2] - v2[0])
+                             - (_DEFECT['view'][2] - _DEFECT['view'][0])) < 1e-6,
+      str(v2))
+v3, _, _ = RP.defect_view({'kind': 'throat'}, 1600)
+check('and a defect with neither gets no panel at all',
+      v3 is None, str(v3))
+
+print('--- a record is BOUND to its board ---')
+
+_board = os.path.join(REPO, 'wk', 'run20', 'frozen.kicad_pcb')
+if not os.path.isfile(_board):
+    _board = os.path.join(REPO, 'kicad_files', 'splitflap_driver.kicad_pcb')
+_sha = RP._board_sha(_board)
+check('the board hashes', bool(_sha), _board)
+
+d, notes = RP.load_defect_records([_rec('good.json', sha=_sha)], board_sha=_sha)
+check('a matching record loads', len(d) == 1 and not notes, str(notes))
+check('and remembers which file it came from',
+      d[0].get('_source', '').endswith('good.json'), str(d[0].get('_source')))
+
+d, notes = RP.load_defect_records([_rec('other.json', sha='0' * 64)],
+                                  board_sha=_sha)
+check('a record from a DIFFERENT board is dropped',
+      not d and notes, f'{len(d)} defects, notes={notes}')
+check('...loudly, naming both hashes',
+      notes and 'SKIPPED' in notes[0] and '000000000000' in notes[0],
+      str(notes))
+
+d, notes = RP.load_defect_records([_rec('nosha.json')], board_sha=_sha)
+check('a record with NO sha is drawn, but the doubt is recorded',
+      len(d) == 1 and notes and 'cannot be proven' in notes[0], str(notes))
+
+d, notes = RP.load_defect_records([os.path.join(_D, 'nope.json')],
+                                  board_sha=_sha)
+check('an unreadable record is a note, not a crash', not d and notes, str(notes))
+
+_wrong = os.path.join(_D, 'wrongkind.json')
+with open(_wrong, 'w', encoding='utf-8') as fh:
+    json.dump({'kind': 'board-score', 'blocking': 3}, fh)
+d, notes = RP.load_defect_records([_wrong], board_sha=_sha)
+check('another tool\'s JSON is refused BY KIND',
+      not d and notes and 'board-score' in notes[0], str(notes))
+
+print('--- and the panel actually draws it ---')
+
+if os.path.isfile(_board):
+    _out = os.path.join(_D, 'panels')
+    _js = os.path.join(_D, 'r.json')
+    p = subprocess.run(
+        [sys.executable, '-X', 'utf8',
+         os.path.join(REPO, 'py_tools', 'render_placement.py'), _board,
+         '--defect-json', _rec('live.json', sha=_sha), '--size', '1600',
+         '-o', _out + os.sep, '--json-out', _js],
+        capture_output=True, text=True, timeout=900)
+    ok = os.path.isfile(_js)
+    check('the render runs and writes its JSON', ok,
+          (p.stdout or '')[-300:] + (p.stderr or '')[-300:])
+    if ok:
+        doc = json.load(open(_js, encoding='utf-8'))
+        check("doc['defects'] carries what it was asked to show",
+              len(doc.get('defects') or []) == 1
+              and doc['defects'][0]['pads'] == ['R7.2', 'U4.53'],
+              str(doc.get('defects'))[:200])
+        check("instrument.defect_json mirrors instrument.summary_json",
+              isinstance(doc['instrument'].get('defect_json'), list)
+              and doc['instrument']['defect_json'],
+              str(doc['instrument'].get('defect_json'))
+              + ' -- a gate asserts a defect render the same way '
+                '_guard_route_render asserts a focus render')
+        dp = (doc.get('defect_panels') or [])
+        check('a defect panel was produced', len(dp) == 1, str(dp)[:200])
+        if dp:
+            check('and it reports the px figure it achieved, not a promise',
+                  dp[0]['shortfall_px'] >= RP.DEFECT_MIN_PX - 0.5,
+                  str(dp[0]))
+            check('the caption carries the scale so a reader can audit it',
+                  'px/mm ->' in dp[0]['label'], dp[0]['label'])
+            check('and names the two pads forming the throat',
+                  'R7.2' in dp[0]['label'] and 'U4.53' in dp[0]['label'],
+                  dp[0]['label'])
+        _pngs = [x['path'] for x in doc['panels'] if x.get('view')]
+        check('the panel was written to disk', _pngs and
+              all(os.path.isfile(x) for x in _pngs), str(_pngs))
+
+    # ImageChops: prove `draw_defects` actually drew, rather than trusting a
+    # code path that ran. Same panel, same view, defects on vs off.
+    from kicad_parser import parse_kicad_pcb                        # noqa: E402
+    _pcb = parse_kicad_pcb(_board)
+    m = RP.PlacementModel(_pcb, _board)
+    if m is not None:
+        # The record's coordinates are from the run-20 board; on the tracked
+        # fallback they can land OUTSIDE the outline, where a drawn mark
+        # cannot appear and this check fails for a reason that is not
+        # draw_defects. Rebase the whole record onto the loaded board's
+        # center so the mark is drawable wherever the fixture came from.
+        import copy as _copy
+        _bb = _pcb.board_info.board_bounds
+        _dx = (_bb[0] + _bb[2]) / 2.0 - _DEFECT['at']['x']
+        _dy = (_bb[1] + _bb[3]) / 2.0 - _DEFECT['at']['y']
+        _DX = _copy.deepcopy(_DEFECT)
+        for _pt in (_DX['seed'], _DX['at'], _DX['span']['a'], _DX['span']['b']):
+            _pt['x'] += _dx
+            _pt['y'] += _dy
+        _DX['view'] = [_DX['view'][0] + _dx, _DX['view'][1] + _dy,
+                       _DX['view'][2] + _dx, _DX['view'][3] + _dy]
+        _v, _, _ = RP.defect_view(_DX, 420)
+        _o = dict(borders=False, labels=False, ratsnest=False, pads=True,
+                  legality=False, legend=False)
+        # Assert the DRAWING PRIMITIVE against the real renderer transform.
+        # KNOWN GAP, disclosed rather than hidden: the composed
+        # render_panel(overlays=...) path shows no mark for a standalone
+        # caller on the tracked fallback board (reproduced identically on
+        # every branch this test has lived on -- it is not a regression, and
+        # the CLI defect-panel path exercised above IS the shipped path and
+        # is asserted green). Until that compositing gap is root-caused,
+        # this check proves draw_defects marks pixels where tf.pt puts them.
+        from PIL import ImageDraw                                   # noqa: E402
+        from route_render import BoardRenderer as _BR         # noqa: E402
+        _r = _BR(_pcb, size=420, supersample=1, show_pads=False)
+        a = _r.frame(overlays=[])
+        b = a.copy()
+        RP.draw_defects(ImageDraw.Draw(b), _r, [_DX])
+        check('drawing the defect measurably changes the image',
+              ImageChops.difference(a, b).getbbox() is not None,
+              'a code path that runs is not a mark that appears')
+else:
+    check('a board fixture is available', False, _board)
+
+print(f'\n{passed} passed, {failed} failed')
+sys.exit(1 if failed else 0)

--- a/tests/test_doc_flag_liveness.py
+++ b/tests/test_doc_flag_liveness.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Every `--flag` the routing docs tell you to pass must actually exist.
+
+Run 22 lost a routing lap to `--track-width-floor`. The flag was DELETED in
+53a5a16e (with `--protect-nets` and `--net-layers`), but the routing skill
+still told the reader to pass it in nine places, `docs/api-routing-config.md`
+still documented the config field as live, and `krt_capabilities.py`'s own
+usage example still used it. The run followed the documentation, `route.py`
+answered `error: unrecognized arguments`, and a lap was spent finding out why.
+
+Nothing caught it, and the near-miss is instructive: `test_krt_capabilities.py`
+asserts `--track-width-floor` is absent on `route_planes.py` and
+`route_diff.py` -- but never on `route.py`, the one CLI it had actually been
+removed from. The removal passed CI because the only assertions about the flag
+were about the two tools that never had it.
+
+The gate is UNION-shaped on purpose: a flag is live if ANY routing CLI defines
+it. A per-tool gate would drown in false positives, because the prose
+legitimately discusses one tool's flag while describing another's step, and a
+gate that cries wolf gets deleted.
+
+Run: python3 -X utf8 tests/test_doc_flag_liveness.py
+"""
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+os.environ.setdefault('KRT_NO_BANNER', '1')
+
+import krt_capabilities as K                                   # noqa: E402
+
+#: The docs this gate holds to the engine's actual surface.
+DOCS = (
+    os.path.join('.claude', 'skills', 'plan-pcb-routing', 'SKILL.md'),
+    os.path.join('docs', 'api-routing-config.md'),
+)
+
+#: What counts as LIVE: any non-test source file that registers the flag with
+#: argparse. Deliberately a text scan over the whole engine rather than a
+#: per-CLI parser walk -- `krt_capabilities.script_flags` follows a registrar
+#: only when it sits BESIDE the script (the rule that stops it handing
+#: route_planes the whole of route.py's vocabulary), so flags registered from
+#: a sub-package (`py_placer/placement/cli_gates.py` supplies --suggest-locks
+#: and --allow-routed) read as dead and the gate cries wolf. A gate that cries
+#: wolf gets deleted, which would be worse than no gate.
+SKIP_DIRS = ('.git', 'wk', 'kicad_files', 'docs', 'node_modules',
+             '__pycache__', 'rust_router')
+
+#: ANY quoted long-flag literal in non-test source, not only `add_argument`
+#: calls. Deliberately over-broad, because the two error directions are not
+#: symmetric here:
+#:
+#:   a false POSITIVE (calling a live flag dead) fails the build on correct
+#:   documentation, and a gate that cries wolf gets deleted -- taking the
+#:   real finding with it.
+#:   a false NEGATIVE (missing a dead flag) just leaves one stale doc line.
+#:
+#: And the over-approximation costs almost nothing for the class this gate
+#: exists to catch: a flag that was genuinely REMOVED disappears from the
+#: source entirely -- help text, error strings and all -- which is exactly
+#: what happened to --track-width-floor in 53a5a16e.
+#:
+#: Narrower rules were tried and each produced false positives: flags
+#: registered from a sibling sub-package (--suggest-locks via
+#: placement/cli_gates.py) and generated boolean pairs (--no-ratsnest, whose
+#: positive half never appears in an add_argument call either).
+_ADD_ARG = re.compile(r"(?<![\w-])(--[a-z][a-z0-9-]{2,})")
+
+
+def live_flags():
+    """Every long flag any non-test source registers with argparse."""
+    out = set()
+    for base, dirs, files in os.walk(ROOT):
+        dirs[:] = [d for d in dirs
+                   if d not in SKIP_DIRS and not d.startswith('.')
+                   or d in ('.claude',)]
+        for name in files:
+            # Skip TEST files, not the tests/ tree: tests/stress carries real
+            # tools the docs legitimately tell you to run (run_watch.py,
+            # fence_audit.py, tee_cmd.py).
+            if not name.endswith('.py') or name.startswith('test_'):
+                continue
+            try:
+                text = open(os.path.join(base, name), encoding='utf-8',
+                            errors='replace').read()
+            except OSError:
+                continue
+            out |= set(_ADD_ARG.findall(text))
+    # Paired boolean flags: several tools register `--x` and get `--no-x`
+    # from a helper, so `--no-ratsnest` is real on render_placement.py while
+    # appearing in no add_argument call anywhere. A text scan cannot see the
+    # generated half, so derive it.
+    out |= {'--no-' + f[2:] for f in list(out)}
+    return out
+
+
+#: Flags that belong to something other than this repo's CLIs. Seeded by
+#: running the gate once and reading what it found; keep it short, and add to
+#: it only for a genuinely foreign tool.
+EXTERNAL = {
+    # git / shell / kicad-cli / pytest / gh, quoted in worked examples
+    '--oneline', '--json', '--format', '--output', '--help', '--version',
+    '--no-verify', '--hard', '--force', '--from-source', '--stat',
+    '--exclude-all', '--define-var', '--drc', '--severity-all', '--units',
+    '--schematic-parity', '--all', '--quiet', '--verbose', '--dry-run',
+    '--name-only', '--porcelain', '--short', '--set-upstream', '--amend',
+    '--no-pager', '--follow', '--patch', '--word-diff', '--color',
+    '--recurse-submodules', '--depth', '--branch', '--tags',
+    # Prose placeholders, not flags: "`--flag`" in a worked example, and
+    # "`--stitch-`" as the prefix of a family.
+    '--flag', '--stitch-',
+}
+
+FAILURES = []
+
+
+def check(name, cond, detail=''):
+    print(f'  {"PASS" if cond else "FAIL"}  {name}'
+          + (f'\n        {detail}' if not cond and detail else ''))
+    if not cond:
+        FAILURES.append(name)
+
+
+#: A mention sitting in one of these sentences is the doc DOING ITS JOB --
+#: telling the reader a flag is gone. Counting those as errors would punish
+#: the very correction this gate exists to produce, and would leave the gate
+#: permanently unfixable: every honest "--x was REMOVED" note would fail it.
+_ABSENT = re.compile(
+    r'REMOVED|does not exist|do NOT exist|there is no|no such flag|'
+    r'was removed|were removed|deleted in|not a flag|do not emit|'
+    r'no longer exists|has been removed',
+    re.IGNORECASE)
+
+
+def documented_flags(rel):
+    """Long flags a doc tells the reader to PASS, as `--flag` in backticks.
+
+    Bare prose mentions are not matched: the point is the instruction, not
+    every incidental word. And a mention whose sentence says the flag is
+    ABSENT is not an instruction either -- see `_ABSENT`.
+    """
+    lines = open(os.path.join(ROOT, rel), encoding='utf-8').read().splitlines()
+    found = {}
+    for n, line in enumerate(lines):
+        # The sentence, generously: this line plus its neighbours, because a
+        # "REMOVED" verdict often lands a line away from the flag it names.
+        if _ABSENT.search(' '.join(lines[max(0, n - 2):n + 3])):
+            continue
+        for m in re.finditer(r'`([^`\n]*?)`', line):
+            for f in re.findall(r'(?<![\w-])(--[a-z][a-z0-9-]{2,})',
+                                m.group(1)):
+                found[f] = found.get(f, 0) + 1
+    return found
+
+
+def main():
+    live = live_flags()
+    check('the capability scan found a plausible flag surface',
+          len(live) > 100, f'only {len(live)} flags found by the add_argument scan')
+
+    for rel in DOCS:
+        if not os.path.exists(os.path.join(ROOT, rel)):
+            continue
+        print(f'{rel}')
+        documented = documented_flags(rel)
+        dead = sorted(f for f in documented
+                      if f not in live and f not in EXTERNAL)
+        check(f'{os.path.basename(rel)} names no flag the engine dropped',
+              not dead,
+              'these are documented but exist on NO tool: '
+              + ', '.join(f'{f} (x{documented[f]})' for f in dead))
+
+    print('the near-miss that let 53a5a16e through')
+    caps = K.capabilities()
+    # test_krt_capabilities asserted this flag's absence on the two tools that
+    # never had it, and not on the one it was removed from.
+    for token in ('route.py:--track-width-floor',
+                  'route.py:--net-layers',
+                  'route.py:--protect-nets'):
+        check(f'{token} is reported missing',
+              bool(K.missing(caps, [token])),
+              'either the flag came back, or the capability scan is lying')
+
+    print()
+    if FAILURES:
+        print(f'FAIL: {len(FAILURES)} check(s): {", ".join(FAILURES)}')
+        return 1
+    print('OK')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_outline_prefilter.py
+++ b/tests/test_outline_prefilter.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""The outline-gate bbox prefilter changes speed and never an answer.
+
+The oracle below re-implements the CURRENT probe bodies verbatim, including
+the #628 `_swallow_pts` loop (cutouts AND reclassified milled contours). An
+oracle that mirrors an older body tests a version of the code that no longer
+exists -- it went stale exactly once, on the rebase that brought #628 in, and
+reported a 0.5mm "mismatch" that was the oracle being wrong.
+
+`BoardOutlineGate.rect_blocked` and `rect_outside_amount` measured every ring
+edge of the board against all four sides of the rect. `edges_near` is supposed
+to shorten that list, but it prunes per PART, sized by a displacement budget --
+and the seeding path has no budget: `pose_score.make_state` builds its
+QuenchState without `build_neighbor_lists`, so `_travel_budget` is infinite,
+`reach` is infinite, and `edges_near` hands back every edge there is.
+
+Measured on run 19's urchin (638 edges, one milled ring): 9-24 ms per
+`rect_outside_amount` depending on machine load. `_try_place` calls it once
+per candidate offset, and `_offsets(16, 0.25)` alone is 16,641 offsets --
+which is why a single failed seat on that board cost minutes.
+
+The speedup this file prints is load- and population-dependent (7x to 14x
+observed). It asserts only `> 3.0` on a many-edge outline, because pinning a
+specific multiple would make the test a machine detector.
+
+The prefilter drops edges whose bounding box is separated from the rect's by
+more than the margin. That is exact rather than approximate, so the only thing
+worth testing is that claim, hard: this compares against a re-implementation of
+the ORIGINAL unfiltered loops, over thousands of rects, on every real outline
+available -- including rects deliberately straddling, containing and sitting
+just off each edge, where an off-by-epsilon filter would show.
+"""
+import math
+import os
+import random
+import sys
+import time
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for p in (REPO,):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+        sys.path.insert(0, os.path.join(p, 'py_router'))
+        sys.path.insert(0, os.path.join(p, 'py_tools'))
+        sys.path.insert(0, os.path.join(p, 'py_placer'))
+
+from kicad_parser import parse_kicad_pcb
+from placement.legality import BoardOutlineGate
+
+passed = failed = 0
+
+
+def check(name, ok, detail=""):
+    global passed, failed
+    passed += bool(ok)
+    failed += not ok
+    print(f"  {'OK  ' if ok else 'FAIL'} {name}{(' -- ' + detail) if detail else ''}")
+
+
+# --- the ORIGINAL implementations, verbatim, as the oracle -------------------
+def ref_rect_blocked(g, rect):
+    from check_drc import _point_on_board, _seg_seg_dist_coords
+    x0, y0, x1, y1 = rect
+    for (px, py) in ((x0, y0), (x1, y0), (x1, y1), (x0, y1)):
+        if not _point_on_board(px, py, g.outer, g.cutouts):
+            return True
+    for (ax, ay, bx, by) in ((x0, y0, x1, y0), (x1, y0, x1, y1),
+                             (x1, y1, x0, y1), (x0, y1, x0, y0)):
+        for (ex1, ey1, ex2, ey2) in g.edges():
+            if _seg_seg_dist_coords(ax, ay, bx, by,
+                                    ex1, ey1, ex2, ey2) < g.margin:
+                return True
+    for (_rid, cx, cy) in g._swallow_pts:
+        if x0 <= cx <= x1 and y0 <= cy <= y1:
+            return True
+    return False
+
+
+def ref_outside_amount(g, rect):
+    from check_drc import (_point_on_board, _point_to_rings_distance,
+                           _seg_seg_dist_coords)
+    amt = g.bbox_outside_amount(rect)
+    if not g.active:
+        return amt
+    x0, y0, x1, y1 = rect
+    for (px, py) in ((x0, y0), (x1, y0), (x1, y1), (x0, y1)):
+        if not _point_on_board(px, py, g.outer, g.cutouts):
+            amt += max(g.margin, _point_to_rings_distance(px, py, g.rings))
+    for (ax, ay, bx, by) in ((x0, y0, x1, y0), (x1, y0, x1, y1),
+                             (x1, y1, x0, y1), (x0, y1, x0, y0)):
+        d = min((_seg_seg_dist_coords(ax, ay, bx, by, *e) for e in g.edges()),
+                default=float('inf'))
+        if d < g.margin:
+            amt += g.margin - d
+    for (_rid, cx, cy) in g._swallow_pts:
+        if x0 <= cx <= x1 and y0 <= cy <= y1:
+            amt += g.margin
+    return amt
+
+
+# --- rect generators ---------------------------------------------------------
+def rects_for(g, bounds, rng, n):
+    """Random rects, plus adversarial ones pinned to the outline itself: a
+    filter that is wrong by an epsilon shows up on a rect sitting exactly at
+    the margin from an edge, not on a random one in open space."""
+    x0, y0, x1, y1 = bounds
+    out = []
+    for _ in range(n):
+        w = rng.uniform(0.2, 12.0)
+        h = rng.uniform(0.2, 12.0)
+        cx = rng.uniform(x0 - 5, x1 + 5)
+        cy = rng.uniform(y0 - 5, y1 + 5)
+        out.append((cx - w / 2, cy - h / 2, cx + w / 2, cy + h / 2))
+    m = g.margin
+    for (ax, ay, bx, by) in g.edges()[:400]:
+        mx, my = (ax + bx) / 2.0, (ay + by) / 2.0
+        for pad in (0.0, m * 0.5, m, m * 1.001, m * 2, 1.0):
+            out.append((mx - pad, my - pad, mx + pad, my + pad))
+        # a rect straddling the edge, and one just clear of each end
+        out.append((min(ax, bx) - 0.3, min(ay, by) - 0.3,
+                    max(ax, bx) + 0.3, max(ay, by) + 0.3))
+        out.append((ax - m * 0.999, ay - m * 0.999, ax + m * 0.999,
+                    ay + m * 0.999))
+    return out
+
+
+BOARDS = [os.path.join(REPO, 'kicad_files', n) for n in (
+    'glasgow_revC.kicad_pcb', 'tigard.kicad_pcb', 'splitflap_driver.kicad_pcb',
+    'watchy.kicad_pcb')]
+URCHIN = os.path.join(REPO, 'wk', 'run19', 'urchin', 'base.kicad_pcb')
+if os.path.isfile(URCHIN):
+    BOARDS.append(URCHIN)
+
+rng = random.Random(20260815)
+tested = 0
+timed = []
+
+for path in BOARDS:
+    if not os.path.isfile(path):
+        continue
+    name = os.path.basename(path)
+    pcb = parse_kicad_pcb(path)
+    if pcb.board_info.board_bounds is None:
+        continue
+    g = BoardOutlineGate(pcb.board_info, 0.5)
+    if not g.active:
+        check(f"{name}: skipped (outline IS its bounding box)", True)
+        continue
+    rects = rects_for(g, pcb.board_info.board_bounds, rng, 300)
+    bad_blocked = bad_amount = 0
+    worst = 0.0
+    for r in rects:
+        if g.rect_blocked(r) != ref_rect_blocked(g, r):
+            bad_blocked += 1
+        a, b = g.rect_outside_amount(r), ref_outside_amount(g, r)
+        if not (math.isclose(a, b, rel_tol=0.0, abs_tol=1e-12)):
+            bad_amount += 1
+            worst = max(worst, abs(a - b))
+    tested += len(rects)
+    check(f"{name} ({len(g.edges())} edges): rect_blocked identical on "
+          f"{len(rects)} rects", bad_blocked == 0, f"{bad_blocked} differed")
+    check(f"{name}: rect_outside_amount identical, to the bit",
+          bad_amount == 0, f"{bad_amount} differed, worst {worst:g}")
+
+    # speed, on the rects a candidate loop actually asks about (near the board)
+    sample = rects[:200]
+    t0 = time.perf_counter()
+    for r in sample:
+        g.rect_outside_amount(r)
+    fast = time.perf_counter() - t0
+    t0 = time.perf_counter()
+    for r in sample:
+        ref_outside_amount(g, r)
+    slow = time.perf_counter() - t0
+    timed.append((name, len(g.edges()), slow / max(fast, 1e-9)))
+    print(f"       {name}: {len(g.edges())} edges, "
+          f"{slow / len(sample) * 1e3:.2f}ms -> {fast / len(sample) * 1e3:.2f}ms "
+          f"({slow / max(fast, 1e-9):.1f}x)")
+
+check("something was actually tested", tested > 0, f"{tested} rects")
+# The prefilter must never be a slowdown on a board with a real outline.
+check("no board got slower", all(sp > 0.9 for _, _, sp in timed),
+      str([(n, round(sp, 2)) for n, _, sp in timed]))
+# On a board with many edges it must be a large win, or it is not worth having.
+big = [(n, e, sp) for n, e, sp in timed if e >= 200]
+if big:
+    check("a many-edge outline gets a big speedup",
+          all(sp > 3.0 for _, _, sp in big),
+          str([(n, e, round(sp, 1)) for n, e, sp in big]))
+else:
+    print("  NOTE no >=200-edge outline available; speedup claim untested")
+
+print(f"\n{passed} passed, {failed} failed")
+sys.exit(1 if failed else 0)

--- a/tests/test_part_class.py
+++ b/tests/test_part_class.py
@@ -22,6 +22,7 @@ sys.path.insert(0, ROOT)
 sys.path.insert(0, os.path.join(ROOT, 'py_placer'))  # placement split
 sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # placement split
 sys.path.insert(0, os.path.join(ROOT, 'py_tools'))  # placement split
+from run_utils import tool as _tool, tool_env as _tool_env  # #522: resolve a moved CLI, loudly
 from placement.part_class import (classify_part, default_band,  # noqa: E402
                                   pose_plausible)
 
@@ -111,9 +112,9 @@ class TestPlausibility(unittest.TestCase):
 
 
 def _run(tool, *argv):
-    env = dict(os.environ, PYTHONPATH=ROOT, PYTHONIOENCODING='utf-8')
+    env = dict(_tool_env(), PYTHONPATH=_tool_env()["PYTHONPATH"], PYTHONIOENCODING='utf-8')
     return subprocess.run(
-        [sys.executable, '-X', 'utf8', os.path.join(ROOT, tool)] + list(argv),
+        [sys.executable, '-X', 'utf8', _tool(tool)] + list(argv),
         capture_output=True, text=True, env=env, cwd=ROOT)
 
 
@@ -167,7 +168,15 @@ class TestDeclareClasses(unittest.TestCase):
             by_ref = {c['ref']: c for c in doc['edge_connectors']}
             self.assertIn('J1', by_ref)
             self.assertIn('SW1', by_ref)
-            self.assertNotIn('J7', by_ref)
+            # The original pin here was `J7 not declared at all` -- written
+            # when generic connectors produced NO entry. The invariant it
+            # protected was narrower: J7 (a JST wire-to-board part,
+            # legitimately interior) must never be given an EDGE. run-23's
+            # connector_affinity class declares it -- weakly, no edge, no
+            # implausibility claim -- so mid-board connectors stop being
+            # invisible to every rule. The protected invariant stands:
+            self.assertEqual(by_ref['J7'].get('class'), 'connector_affinity')
+            self.assertNotIn('edge', by_ref['J7'])
             # J1's pose is implausible: class-default band, NO edge invented
             self.assertEqual(by_ref['J1'].get('class'), 'edge_receptacle')
             self.assertNotIn('edge', by_ref['J1'])

--- a/tests/test_place_edge_containment.py
+++ b/tests/test_place_edge_containment.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""An edge seat must land ON the board, or not be a seat.
+
+`place_edge` is the one seat in the system that runs neither `pose_ok` (an edge
+part overhangs by design, so full containment is the wrong predicate) nor a
+clearance ladder. That left it with no containment check of any kind, and three
+defects that compounded into a connector placed entirely off the far side of
+the board and reported as seated, exit 0:
+
+  A. `_seat_edge` took no exclude set, so an unplaced PILE at the board centre
+     vetoed the honest edge poses and the slide loop walked the part along the
+     edge until one was "conflict free".
+  B. `_edge_correct` drives a SCALAR SUM (`rect_outside_amount` sums all four
+     sides) with a SINGLE-AXIS walk, so an along-edge overshoot is a constant
+     it can never cancel -- it subtracts it again every iteration and marches
+     the part inland past the opposite edge. It ran a fixed `range(4)` with no
+     convergence test, returning a diverged pose indistinguishably from a
+     converged one.
+  C. The along-edge fraction was clamped to a bare [0.05, 0.95], which knows
+     nothing of the part's own width.
+
+Measured before the fix, on a staged pile of orangecrab_ext_pll:
+`place_edge J2 south` -> pose (170.068, 88.767), `moved_mm 26.17`, seated,
+exit 0 -- on a board spanning y 91.52..114.38, i.e. entirely off the NORTH
+edge. The same op on the placed board gave (159.909, 112.33), moved 0.55mm.
+The fix makes the pile case return that same correct answer.
+
+The fixture is the tracked `kicad_files/orangecrab_ext_pll.kicad_pcb`, driven
+through the seeder helpers IN MEMORY -- no CLI, so the routed/unplaced gates
+and the board's existing copper are irrelevant to what is being measured here.
+It is used because it genuinely reproduces: J2's courtyard is 41.16mm on a
+50.80mm edge, so the part is 81% of its own edge and the fraction clamp is
+load-bearing. `flat_hierarchy` (the acceptance fixture) does NOT reproduce any
+of this -- its connectors are small and far from the pile -- which is exactly
+why this file exists separately.
+"""
+import os
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for p in (REPO, os.path.join(REPO, 'py_router'), os.path.join(REPO, 'py_tools'),
+          os.path.join(REPO, 'py_placer')):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+BOARD = os.path.join(REPO, 'kicad_files', 'orangecrab_ext_pll.kicad_pcb')
+passed = failed = 0
+
+
+def check(name, ok, detail=""):
+    global passed, failed
+    passed += bool(ok)
+    failed += not ok
+    print(f"  {'OK  ' if ok else 'FAIL'} {name}{(' -- ' + detail) if detail else ''}")
+
+
+if not os.path.isfile(BOARD):
+    print(f"FAIL fixture missing: {BOARD} (it is tracked; a skip here would "
+          f"hide the whole file)")
+    print("\n0 passed, 1 failed")
+    sys.exit(1)
+
+import pose_score
+from kicad_parser import parse_kicad_pcb
+from placement import seeder
+
+pcb = parse_kicad_pcb(BOARD)
+
+
+def fresh_state():
+    return pose_score.make_state(pcb, BOARD, clearance=0.25,
+                                 board_edge_clearance=0.55, grid_step=0.1)
+
+
+def pile(state, keep=('J2',)):
+    """Stack every movable part at the board centre, as staging does."""
+    x0, y0, x1, y1 = state.board
+    cx, cy = (x0 + x1) / 2.0, (y0 + y1) / 2.0
+    piled = []
+    for ref, p in state.parts.items():
+        if ref in keep or getattr(p, 'locked', False):
+            continue
+        state.apply_move(ref, cx, cy, 0.0)
+        piled.append(ref)
+    return set(piled)
+
+
+def pads_on_board(state, ref):
+    """Does this part's PAD COPPER lie inside the outline bbox?"""
+    p = state.parts[ref]
+    fp = pcb.footprints[ref]
+    dx, dy = p.x - fp.x, p.y - fp.y
+    xs = [q.global_x + dx for q in fp.pads]
+    ys = [q.global_y + dy for q in fp.pads]
+    x0, y0, x1, y1 = state.board
+    return (min(xs) >= x0 - 0.01 and max(xs) <= x1 + 0.01
+            and min(ys) >= y0 - 0.01 and max(ys) <= y1 + 0.01)
+
+
+# --------------------------------------------------------------------------
+# C. the fraction clamp knows the part's own width
+# --------------------------------------------------------------------------
+st = fresh_state()
+j2 = st.parts['J2']
+r = j2.rect(0.0, 0.0, j2.rot)
+width, span = r[2] - r[0], st.board[2] - st.board[0]
+lo, hi = seeder._edge_frac_bounds(j2, st.board, 'south')
+# centre may range over (span - width); as a fraction that is width/2/span in
+# from each end. 41.16 on 50.80 -> 0.405 .. 0.595.
+want_lo = (width / 2.0) / span
+check("the fraction clamp is derived from the part's own half-extent",
+      abs(lo - want_lo) < 1e-6 and abs(hi - (1.0 - want_lo)) < 1e-6,
+      f"{lo:.3f}..{hi:.3f}, part {width:.2f}mm on a {span:.2f}mm edge")
+check("and it is far tighter than the old bare [0.05, 0.95]",
+      lo > 0.05 and hi < 0.95, f"{lo:.3f}..{hi:.3f}")
+
+# a part wider than its edge has NO legal fraction, and says so
+wide_lo, wide_hi = seeder._edge_frac_bounds(j2, (0.0, 0.0, 10.0, 10.0), 'south')
+check("a part wider than the edge yields lo > hi (no legal fraction)",
+      wide_lo > wide_hi, f"{wide_lo:.3f}..{wide_hi:.3f}")
+
+# --------------------------------------------------------------------------
+# B. the correction walk reports divergence instead of hiding it
+# --------------------------------------------------------------------------
+st = fresh_state()
+# Start it where the agent measured divergence: far along the edge, so the
+# along-edge overshoot is a constant the single-axis walk cannot cancel.
+x_bad, y_bad = seeder._edge_pose(st.parts['J2'], st.board, 'south', 0.90, 0.0)
+_x, _y, converged = seeder._edge_correct(st, 'J2', 'south', x_bad, y_bad, 0.0)
+check("a diverging overhang walk reports converged=False",
+      converged is False, f"landed at ({_x:.3f}, {_y:.3f})")
+check("and it really did march off the board (the case is not hypothetical)",
+      _y < st.board[1] or _y > st.board[3],
+      f"y={_y:.3f} vs board y {st.board[1]:.2f}..{st.board[3]:.2f}")
+
+# a centred start converges
+x_ok, y_ok = seeder._edge_pose(st.parts['J2'], st.board, 'south', 0.5, 0.0)
+_x2, _y2, conv2 = seeder._edge_correct(st, 'J2', 'south', x_ok, y_ok, 0.0)
+check("a well-posed walk still converges (the flag is not always False)",
+      conv2 is True, f"({_x2:.3f}, {_y2:.3f})")
+
+# --------------------------------------------------------------------------
+# A + the whole thing: seat against a pile, land on the board
+# --------------------------------------------------------------------------
+st = fresh_state()
+piled = pile(st)
+entry = {'edge': 'south', 'overhang_mm': {'min': 0.0, 'max': 1.0}}
+notes = []
+ok = seeder._seat_edge(st, 'J2', entry, set(), notes, exclude=piled)
+check("it seats against a pile", ok, str(notes[-2:]))
+check("and the seat is ON the board -- the whole point",
+      pads_on_board(st, 'J2'),
+      f"pose ({st.parts['J2'].x:.3f}, {st.parts['J2'].y:.3f}), "
+      f"board {[round(v, 2) for v in st.board]}")
+check("it lands on the SOUTH edge it was asked for",
+      abs(st.parts['J2'].y - st.board[3]) < 3.0,
+      f"y={st.parts['J2'].y:.3f} vs south edge {st.board[3]:.2f}")
+
+# The measured pre-fix pose, asserted absent by name.
+check("it is not the pre-fix pose (170.068, 88.767)",
+      not (abs(st.parts['J2'].x - 170.068) < 0.01
+           and abs(st.parts['J2'].y - 88.767) < 0.01),
+      "that pose is 26.17mm away and entirely off the north edge")
+
+# A NONSENSE BAND must not buy an off-board seat. This is what makes the
+# containment gate load-bearing rather than decorative: with only the fraction
+# clamp in place, `converged`/`on_board` are never reached on a well-posed
+# call, so removing them changes nothing observable. Here the declared band is
+# satisfiable ONLY by a part sitting entirely off the board -- a 20mm overhang
+# on a 3.0mm-tall connector -- and the overlap invariant is the thing that
+# refuses it. Fault-injecting the gate away turns this red.
+# ALL FOUR EDGES. Testing only `south` is how the first version of this file
+# passed while the same nonsense band was accepted on east and west with 8 of
+# 16 pads off the board: on south, J2's 3.00mm dimension is normal to the edge
+# so a bare overlap test collapses to zero and refuses by accident; on east and
+# west its 41.16mm dimension keeps half the courtyard over the bbox and the
+# "invariant" held. One edge is not a test of an edge predicate.
+for _edge in ('south', 'north', 'east', 'west'):
+    st3 = fresh_state()
+    piled3 = pile(st3)
+    silly = {'edge': _edge, 'overhang_mm': {'min': 20.0, 'max': 21.0}}
+    ok3 = seeder._seat_edge(st3, 'J2', silly, set(), [], exclude=piled3)
+    check(f"[{_edge}] a band only an off-board pose could satisfy is refused",
+          (not ok3) or pads_on_board(st3, 'J2'),
+          f"ok={ok3} pose ({st3.parts['J2'].x:.3f}, {st3.parts['J2'].y:.3f})")
+
+# A merely WRONG band, not a nonsense one. The overlap test only refuses a part
+# that is 100% off, so `{3,4}` on a 3.00mm-deep connector seated it with 1.7%
+# of its courtyard on the board. The depth bound is what refuses this.
+for _band in ({'min': 3.0, 'max': 4.0}, {'min': 2.0, 'max': 3.0}):
+    st4 = fresh_state()
+    piled4 = pile(st4)
+    ok4 = seeder._seat_edge(st4, 'J2',
+                            {'edge': 'south', 'overhang_mm': _band},
+                            set(), [], exclude=piled4)
+    check(f"a band of {_band['min']:g}-{_band['max']:g}mm on a 3.0mm-deep part "
+          f"does not seat it off the board",
+          (not ok4) or pads_on_board(st4, 'J2'),
+          f"ok={ok4} pose ({st4.parts['J2'].x:.3f}, {st4.parts['J2'].y:.3f})")
+
+# A LEGITIMATE band must still seat -- otherwise the bound above is just a
+# refusal machine and place_edge stops working.
+st5 = fresh_state()
+piled5 = pile(st5)
+ok5 = seeder._seat_edge(st5, 'J2',
+                        {'edge': 'south', 'overhang_mm': {'min': 0.0,
+                                                          'max': 1.0}},
+                        set(), [], exclude=piled5)
+check("a sane band still seats (the bound is not a blanket refusal)",
+      ok5 and pads_on_board(st5, 'J2'),
+      f"ok={ok5} pose ({st5.parts['J2'].x:.3f}, {st5.parts['J2'].y:.3f})")
+
+# WITHOUT the exclude set the pile is a full obstacle set -- that is defect A.
+# The seat must then either refuse or still be on-board; what it must never do
+# is slide off the end and report success.
+st2 = fresh_state()
+pile(st2)
+notes2 = []
+ok2 = seeder._seat_edge(st2, 'J2', entry, set(), notes2)     # no exclude
+check("even with NO exclude set it never seats off the board",
+      (not ok2) or pads_on_board(st2, 'J2'),
+      f"ok={ok2} pose ({st2.parts['J2'].x:.3f}, {st2.parts['J2'].y:.3f})")
+
+print(f"\n{passed} passed, {failed} failed")
+sys.exit(1 if failed else 0)

--- a/tests/test_portfolio_determinism.py
+++ b/tests/test_portfolio_determinism.py
@@ -7,6 +7,12 @@ move), a different --seed must actually change the portfolio, and --only N
 must regenerate candidate N byte-identically -- that is the property the
 ledger's replay command rests on.
 """
+
+#: Measured ALONE at 366 s. It was killed at the runner's 600 s
+#: default under -j contention and reported as a timeout, which reads
+#: exactly like a hang; it passes 11/11 every time it is given room.
+RUN_ALL_TIMEOUT = 1200
+
 import json
 import os
 import subprocess

--- a/tests/test_provenance_audit.py
+++ b/tests/test_provenance_audit.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+"""The provenance audit, attacked the way a hand script would attack it.
+
+The case that matters is the one run 19 produced: a board whose poses are
+genuinely BLIND -- nothing read the control -- and genuinely NOT the engine's.
+`fence_audit` says CLEAN on that, correctly, because it asks a different
+question. This must not.
+
+Five cases, and the third is the load-bearing one:
+
+  1. a run through a registered lever            -> CLEAN (0)
+  2. a write through the funnel with no lever    -> refused BEFORE the write
+  3. a hand edit of `(at ...)` as RAW TEXT       -> VIOLATION (4)
+  4. no ledger, and poses MOVED                  -> VIOLATION (4)
+  5. no ledger, and nothing moved                -> UNPROVEN (5)
+
+Case 3 is why the audit reconciles the BOARD rather than reading the log: a
+script that never imports the writer leaves no row to be missing, and an audit
+that trusted the ledger would report CLEAN on a board it never authored.
+
+Cases 4 and 5 are the same check split on the board's own evidence, and an
+audit found them merged the wrong way: `audit()` returned UNPROVEN whenever
+there were no rows, WITHOUT looking at the poses, which swallowed exactly the
+run-19 case the instrument was built for -- a purely hand-placed board has no
+ledger BECAUSE nothing engine-side ran, and it came back "I cannot prove it"
+instead of "I proved it false". Runs predating the instrument are still
+protected, by the earlier manifest check: a work dir nobody staged returns
+UNPROVEN before the ledger is consulted at all.
+
+The last block is the one that would have caught the whole thing being inert:
+it ARMS a regime and runs a real CLI. Nothing called `declare_lever` outside
+this file, so every real run was UNPROVEN, and arming a regime by hand made
+`place_optimize.py` raise -- it is in LEVER_REGISTRY but declared nothing, so
+the gate refused the engine itself.
+"""
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for p in (REPO,):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+        sys.path.insert(0, os.path.join(p, 'py_router'))
+        sys.path.insert(0, os.path.join(p, 'py_tools'))
+        sys.path.insert(0, os.path.join(p, 'py_placer'))
+        sys.path.insert(0, os.path.join(p, 'tests', 'stress'))
+
+BOARD = os.path.join(REPO, 'kicad_files', 'splitflap_driver.kicad_pcb')
+
+passed = failed = 0
+
+
+def check(name, ok, detail=""):
+    global passed, failed
+    passed += bool(ok)
+    failed += not ok
+    print(f"  {'OK  ' if ok else 'FAIL'} {name}{(' -- ' + detail) if detail else ''}")
+
+
+if not os.path.isfile(BOARD):
+    print("SKIP: fixture missing")
+    sys.exit(0)
+
+from kicad_parser import parse_kicad_pcb
+from placement import provenance as PV
+from placement.writer import write_placed_output
+import provenance_audit as PA
+
+
+def _stage(src, dst):
+    """Copy the board and its siblings into the work dir (#441).
+
+    The audit needs exactly two things: a staged board and a regime
+    manifest naming it. Nothing here perturbs or piles the board.
+    """
+    shutil.copy2(src, dst)
+    for ext in ('.kicad_pro', '.kicad_dru'):
+        sib = os.path.splitext(src)[0] + ext
+        if os.path.isfile(sib):
+            shutil.copy2(sib, os.path.splitext(dst)[0] + ext)
+
+
+def fresh():
+    d = tempfile.mkdtemp()
+    wd = os.path.join(d, 'wk')
+    os.makedirs(wd)
+    staged = os.path.join(wd, 'board.kicad_pcb')
+    _stage(BOARD, staged)
+    PV.start_regime(wd, staged)
+    return wd, staged
+
+
+def some_moves(staged, n=3):
+    pcb = parse_kicad_pcb(staged)
+    refs = sorted(pcb.footprints)[:n]
+    return [{'reference': r, 'new_x': 12.0 + i, 'new_y': 34.0,
+             'new_rotation': 0.0} for i, r in enumerate(refs)]
+
+
+# --------------------------------------------------------------------------
+# 1. a registered lever
+# --------------------------------------------------------------------------
+wd, staged = fresh()
+out = os.path.join(wd, 'seeded.kicad_pcb')
+with PV.declare_lever('place_optimize.py', ['place_optimize.py', staged]):
+    write_placed_output(staged, out, some_moves(staged))
+code, doc = PA.audit(wd, out)
+check("a run through a registered lever is CLEAN",
+      code == PA.CLEAN, f"{code} {doc.get('reason')}")
+check("and it says which lever", doc.get('levers') == ['place_optimize.py'],
+      str(doc.get('levers')))
+check("it reconciles the moved refs, not merely the row count",
+      doc['moved'] == 3 and doc['claimed'] >= 3, str(doc))
+
+# --------------------------------------------------------------------------
+# 2. the funnel with no lever declared
+# --------------------------------------------------------------------------
+wd, staged = fresh()
+try:
+    write_placed_output(staged, os.path.join(wd, 'x.kicad_pcb'),
+                        some_moves(staged))
+    check("an undeclared write through the funnel is refused", False,
+          "it wrote anyway")
+except PV.UnaidedViolation as e:
+    check("an undeclared write through the funnel is refused at write time",
+          'no registered lever' in str(e), str(e)[:120])
+    check("and the refusal names the CALLER, which is the run-19 detector",
+          'test_provenance_audit.py' in str(e), str(e)[:200])
+
+# an unregistered lever is refused too
+wd, staged = fresh()
+try:
+    with PV.declare_lever('arrange.py', ['arrange.py']):
+        write_placed_output(staged, os.path.join(wd, 'y.kicad_pcb'),
+                            some_moves(staged))
+    check("an UNREGISTERED lever is refused", False, "it wrote anyway")
+except PV.UnaidedViolation as e:
+    check("an unregistered lever is refused, naming itself",
+          'arrange.py' in str(e) and 'LEVER_REGISTRY' in str(e), str(e)[:140])
+
+# --------------------------------------------------------------------------
+# 3. THE ONE THAT MATTERS: a raw-text hand edit, bypassing the funnel entirely
+# --------------------------------------------------------------------------
+wd, staged = fresh()
+out = os.path.join(wd, 'seeded.kicad_pcb')
+with PV.declare_lever('place_optimize.py', ['place_optimize.py']):
+    write_placed_output(staged, out, some_moves(staged))
+# Now a hand script edits the file directly -- no import, no funnel, no row.
+src = open(out, encoding='utf-8').read()
+hand = os.path.join(wd, 'hand.kicad_pcb')
+pcb = parse_kicad_pcb(out)
+moved_already = {m['reference'] for m in some_moves(staged)}
+victim = next(r for r in sorted(pcb.footprints) if r not in moved_already)
+
+# Edit the VICTIM'S OWN footprint block. A non-greedy regex spanning from
+# `(footprint` to the Reference property silently matches the FIRST
+# footprint's `(at` and the victim's name, so it moves the wrong part -- and
+# then the audit is being asked about a ref that was already moved legally,
+# which is not the case this test exists for.
+from kicad_parser import find_matching_paren
+starts = [m.start() for m in re.finditer(r'\(footprint\s+"', src)]
+edited, n = src, 0
+for st in reversed(starts):
+    end = find_matching_paren(src, st)
+    block = src[st:end]
+    if not re.search(r'\(property\s+"Reference"\s+"' + re.escape(victim)
+                     + r'"', block):
+        continue
+    new_block, k = re.subn(r'\(at\s+[\d.-]+\s+[\d.-]+',
+                           '(at 77.5 88.5', block, count=1)
+    if k:
+        edited = src[:st] + new_block + src[end:]
+        n = 1
+    break
+open(hand, 'w', encoding='utf-8').write(edited)
+hand_moved = PA.moved_refs(PA.poses(out), PA.poses(hand))
+check("the hand edit moved exactly the victim (else the case proves nothing)",
+      n == 1 and hand_moved == [victim],
+      f"substitutions {n}, moved {hand_moved}, victim {victim}")
+
+code, doc = PA.audit(wd, hand)
+check("a raw-text hand edit is a VIOLATION, not CLEAN",
+      code == PA.VIOLATION, f"{code} {doc.get('verdict')}")
+check("and it names the ref nothing authored",
+      victim in (doc.get('unclaimed_refs') or []),
+      f"{victim} vs {doc.get('unclaimed_refs')}")
+check("the reason says why the log could not have caught it",
+      'compares the BOARD' in doc.get('reason', ''), doc.get('reason'))
+
+# --------------------------------------------------------------------------
+# 4. no ledger -> UNPROVEN, never VIOLATION
+# --------------------------------------------------------------------------
+wd, staged = fresh()
+out = os.path.join(wd, 'seeded.kicad_pcb')
+with PV.declare_lever('place_optimize.py', ['place_optimize.py']):
+    write_placed_output(staged, out, some_moves(staged))
+os.unlink(os.path.join(wd, PV.LEDGER_NAME))
+code, doc = PA.audit(wd, out)
+# Deleting the ledger of a run that MOVED parts is indistinguishable from
+# never having had one, and the board still shows the movement -- so this is
+# a violation with a witness, not an unmeasured run. The audit used to return
+# UNPROVEN here because it checked `if not rows` BEFORE computing `moved`,
+# which swallowed the purely hand-placed case (run 19's) the whole instrument
+# was built for: it came back 5 instead of 4.
+check("a missing ledger with MOVED poses is a VIOLATION, not merely unproven",
+      code == PA.VIOLATION, f"{code} {doc.get('verdict')}")
+check("and it says the board is the witness",
+      'the board is the witness' in doc.get('reason', ''), doc.get('reason'))
+check("it names the refs nothing accounts for",
+      len(doc.get('unclaimed_refs') or []) == 3,
+      str(doc.get('unclaimed_refs')))
+
+# ...but a staged run where NOTHING moved is genuinely unproven, not accused.
+wd2, staged2 = fresh()
+out2 = os.path.join(wd2, 'copy.kicad_pcb')
+import shutil as _sh
+_sh.copy(staged2, out2)
+code2, doc2 = PA.audit(wd2, out2)
+check("a staged run with no ledger and NO movement stays UNPROVEN",
+      code2 == PA.UNPROVEN, f"{code2} {doc2.get('verdict')}")
+check("and that branch says nothing was measured, rather than accusing",
+      'Not a violation' in doc2.get('reason', ''), doc2.get('reason'))
+
+# a work dir that was never staged is UNPROVEN too
+d = tempfile.mkdtemp()
+code, doc = PA.audit(d)
+check("an unstaged work dir is UNPROVEN, not a violation",
+      code == PA.UNPROVEN, f"{code} {doc.get('verdict')}")
+
+# --------------------------------------------------------------------------
+# Outside a regime the gate is INERT -- no ledger, no refusal, no change
+# --------------------------------------------------------------------------
+d = tempfile.mkdtemp()
+plain = os.path.join(d, 'plain.kicad_pcb')
+write_placed_output(BOARD, plain, [])
+check("outside a regime the writer is unchanged and writes no ledger",
+      os.path.isfile(plain)
+      and not os.path.exists(os.path.join(d, PV.LEDGER_NAME)))
+
+# --------------------------------------------------------------------------
+# The CLI
+# --------------------------------------------------------------------------
+wd, staged = fresh()
+out = os.path.join(wd, 'seeded.kicad_pcb')
+with PV.declare_lever('place_seed.py', ['place_seed.py']):
+    write_placed_output(staged, out, some_moves(staged))
+r = subprocess.run(
+    [sys.executable, '-X', 'utf8',
+     os.path.join('tests', 'stress', 'provenance_audit.py'),
+     '--workdir', wd, '--mode', 'audit'],
+    capture_output=True, text=True, cwd=REPO, timeout=600,
+    env=dict(os.environ, PYTHONIOENCODING='utf-8'))
+check("the CLI exits 0 on a clean chain", r.returncode == 0,
+      f"rc={r.returncode} {r.stderr[-200:]}")
+check("the CLI prints a VERDICT and a JSON_SUMMARY",
+      'VERDICT: CLEAN' in r.stdout and 'JSON_SUMMARY:' in r.stdout,
+      r.stdout[-200:])
+
+# --------------------------------------------------------------------------
+# ARMED, END TO END, through a real CLI
+#
+# The instrument had no working armed state at all: nothing called
+# declare_lever outside this file, so every real run was UNPROVEN, and arming
+# a regime by hand made place_optimize.py RAISE -- it is in LEVER_REGISTRY but
+# declared nothing, so the gate refused the engine itself. Both halves are
+# asserted here, because "it works if you call it right" was already true and
+# was useless.
+# --------------------------------------------------------------------------
+fh = os.path.join(REPO, 'kicad_files', 'flat_hierarchy.kicad_pcb')
+if os.path.isfile(fh):
+    # A board with a sibling project, staged explicitly so the quench grades
+    # at the board's own floor; the lever is the quench CLI, whose __main__
+    # declares itself for the whole run.
+    _d = tempfile.mkdtemp()
+    wd = os.path.join(_d, 'wk')
+    os.makedirs(wd)
+    staged = os.path.join(wd, 'board.kicad_pcb')
+    _stage(fh, staged)
+    PV.start_regime(wd, staged)
+    out = os.path.join(wd, 'placed.kicad_pcb')
+    r = subprocess.run(
+        [sys.executable, '-X', 'utf8',
+         os.path.join('py_placer', 'place_optimize.py'),
+         staged, out, '--max-passes', '2', '--max-displacement', '3'],
+        capture_output=True, text=True, cwd=REPO, timeout=900,
+        env=dict(os.environ, PYTHONIOENCODING='utf-8'))
+    check("a real CLI runs INSIDE an armed regime without raising",
+          r.returncode == 0 and os.path.isfile(out),
+          f"rc={r.returncode} {(r.stdout + r.stderr)[-300:]}")
+    code, doc = PA.audit(wd, out)
+    check("and the run audits CLEAN, with the lever named",
+          code == PA.CLEAN and doc.get('levers') == ['place_optimize.py'],
+          f"{code} {doc.get('verdict')} {doc.get('levers')}")
+    check("every moved pose is claimed -- not a subset",
+          doc['moved'] > 0 and doc['claimed'] >= doc['moved'],
+          f"moved {doc['moved']} claimed {doc['claimed']}")
+    check("the ledger records the CALLER as the CLI, not <unknown>",
+          any('place_optimize' in (row.get('caller') or '')
+              for row in PV.read_ledger(wd)),
+          str([row.get('caller') for row in PV.read_ledger(wd)]))
+else:
+    check("the flat_hierarchy fixture exists", False, fh)
+
+# The refusal must precede the write. It used to raise AFTER f.write(), so the
+# poses were already on disk and the "gate" described a file it had helped
+# produce.
+wd, staged = fresh()
+victim = os.path.join(wd, 'never.kicad_pcb')
+try:
+    write_placed_output(staged, victim, some_moves(staged))
+    check("an undeclared write is refused BEFORE the file is written", False,
+          "it wrote anyway")
+except PV.UnaidedViolation:
+    check("an undeclared write is refused BEFORE the file is written",
+          not os.path.exists(victim),
+          "the board must not exist -- refusing means not writing")
+
+# --------------------------------------------------------------------------
+# EVERY registered lever must actually declare one
+#
+# An audit found 5 of 12 registry entries declaring nothing, three of which
+# write poses through the funnel -- so under an armed regime they raised
+# `UnaidedViolation` and the gate refused the engine itself. That is the exact
+# failure the registry exists to prevent, and it survived the commit that
+# claimed to fix it because only seven CLIs were armed.
+# --------------------------------------------------------------------------
+import glob as _glob
+
+_missing = []
+for _lever in PV.LEVER_REGISTRY:
+    _hits = (_glob.glob(os.path.join(REPO, 'py_placer', _lever))
+             + _glob.glob(os.path.join(REPO, 'tests', 'stress', _lever))
+             + _glob.glob(os.path.join(REPO, 'py_placer', 'placement', _lever)))
+    if not _hits:
+        continue
+    _src = open(_hits[0], encoding='utf-8').read()
+    # A library with no __main__ is reached through a declaring CLI; the
+    # innermost-wins rule covers it.
+    if 'declare_lever' not in _src and '__main__' in _src:
+        _missing.append(_lever)
+check("every registered lever with a __main__ actually declares one",
+      not _missing,
+      f"{_missing} -- these raise UnaidedViolation under an armed regime, "
+      f"refusing the engine")
+check("and the registry is not empty (else the check is vacuous)",
+      len(PV.LEVER_REGISTRY) >= 8, str(len(PV.LEVER_REGISTRY)))
+check("a tool that does NOT write poses is named, not silently registered",
+      hasattr(PV, 'NOT_POSE_WRITERS')
+      and 'beautify_labels.py' in PV.NOT_POSE_WRITERS,
+      "beautify_labels writes silkscreen through write_label_output, not the "
+      "pose funnel -- registering it would imply coverage that does not exist")
+
+# The check above reads the SOURCE for `declare_lever`. That is not enough, and
+# run 20 measured the gap: `place_fanout_clearance.py` contained the call, so
+# the static check passed, while the module raised
+#   NameError: name 'sys' is not defined
+# on EVERY invocation including --help -- because the `declare_lever(...,
+# sys.argv)` line was the file's only use of `sys` and nothing imported it. A
+# registered lever that cannot start is a lever that cannot author anything, so
+# the registry was describing a capability the repo did not have.
+#
+# --help is the cheapest possible execution: it exercises import, module-level
+# code and the argparse build without touching a board.
+_dead, _unresolved = [], []
+for _lever in PV.LEVER_REGISTRY:
+    # Same three legs as the static check above. Dropping one made the two loops
+    # disagree about which levers they cover.
+    _hits = (_glob.glob(os.path.join(REPO, 'py_placer', _lever))
+             + _glob.glob(os.path.join(REPO, 'tests', 'stress', _lever))
+             + _glob.glob(os.path.join(REPO, 'py_placer', 'placement', _lever)))
+    if not _hits:
+        # NOT a silent pass. A lever renamed without updating LEVER_REGISTRY
+        # degrades every check in this file to vacuous, and `len(REGISTRY) >= 8`
+        # guards a vacuous registry, not vacuous resolution.
+        _unresolved.append(_lever)
+        continue
+    _src = open(_hits[0], encoding='utf-8').read()
+    if '__main__' not in _src:
+        continue                       # a library, reached through a CLI
+    try:
+        _r = subprocess.run([sys.executable, '-X', 'utf8', _hits[0], '--help'],
+                            capture_output=True, text=True, timeout=120,
+                            cwd=REPO)
+    except subprocess.TimeoutExpired:
+        # Unwrapped, this escaped the file: no named failure and no
+        # "N passed, M failed" summary at all.
+        _dead.append(f'{_lever}: hung for 120s on --help')
+        continue
+    if _r.returncode != 0:
+        _tail = ((_r.stderr or _r.stdout or '').strip().splitlines() or [''])[-1]
+        _dead.append(f'{_lever}: rc={_r.returncode} {_tail[:110]}')
+check("every registered lever actually STARTS (--help exits 0)",
+      not _dead,
+      ' | '.join(_dead) + "  -- a lever that cannot start cannot author poses, "
+      "and the source-text check above cannot see this")
+check("every registered lever RESOLVES to a file",
+      not _unresolved,
+      f"{_unresolved} -- an entry that resolves to nothing makes both the "
+      f"static and the runtime check above vacuous for it")
+
+# The --help loop covers LEVER_REGISTRY, which is ~10 files. The same bug class
+# -- a module-level name used but never imported -- is repo-wide and kills any
+# CLI it touches. Measured while fixing place_fanout_clearance.py:
+# tests/stress/fix_mixed_net_refs.py, a step the stress RUNBOOK tells you to
+# run, had been dead 129 commits with `NameError: name 'os' is not defined`.
+# A static sweep costs ~0.4s and covers every file, not just the registry.
+_TOOL_DIRS = ('tests/stress', 'py_placer', 'py_tools')
+try:
+    _ruff = subprocess.run(['ruff', 'check', '--select', 'F821',
+                            '--output-format=concise'] + list(_TOOL_DIRS),
+                           capture_output=True, text=True, timeout=300, cwd=REPO)
+    _f821 = [ln for ln in (_ruff.stdout or '').splitlines() if 'F821' in ln]
+    check("no CLI directory uses a name it never imported (ruff F821)",
+          not _f821,
+          ' | '.join(_f821[:6]) + f"  ({len(_f821)} total) -- this is the "
+          f"place_fanout_clearance / fix_mixed_net_refs bug class; each one is "
+          f"a tool that dies on every invocation")
+except (OSError, subprocess.TimeoutExpired):
+    print('  SKIP no ruff on PATH -- the F821 sweep did not run, so the '
+          'undefined-name bug class is UNCHECKED here (the --help loop still '
+          'covers LEVER_REGISTRY)')
+
+print(f"\n{passed} passed, {failed} failed")
+sys.exit(1 if failed else 0)

--- a/tests/test_render_view_and_drc_panels.py
+++ b/tests/test_render_view_and_drc_panels.py
@@ -14,9 +14,12 @@ import tempfile
 
 _TESTS = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(_TESTS)
-for p in (ROOT, _TESTS, os.path.join(ROOT, 'rust_router')):
+for p in (ROOT, _TESTS, os.path.join(ROOT, 'rust_router'),
+          os.path.join(ROOT, 'py_router'), os.path.join(ROOT, 'py_tools'),
+          os.path.join(ROOT, 'py_placer')):   # #522: the CLIs moved into packages
     if p not in sys.path:
         sys.path.insert(0, p)
+from run_utils import tool as _tool  # #522: resolve a moved CLI, loudly
 
 # #522 reorg + skill merge: engine -> py_router/, placer -> py_placer/,
 # board_score.py -> the placement-and-routing skill. Without these roots the
@@ -82,7 +85,7 @@ def test_route_render_view_cli():
     with tempfile.TemporaryDirectory() as td:
         out = os.path.join(td, 'crop.png')
         r = subprocess.run([sys.executable, '-X', 'utf8',
-                            os.path.join(ROOT, 'py_router', 'route_render.py'), BOARD,
+                            _tool('route_render.py'), BOARD,
                             '-o', out, '--view', '60,30,80,45'],
                            capture_output=True, text=True, cwd=ROOT)
         assert r.returncode == 0, r.stderr[-500:]
@@ -132,6 +135,35 @@ def test_drc_panels_cluster_mark_and_cap():
         assert len(paths2) == 1
         assert 'NOT rendered' in buf.getvalue()
     print("  PASS: 2 clusters -> 2 panels, waived skipped, cap reported")
+
+
+def test_quiet_keeps_keys_off_stdout_when_json_out_carries_them():
+    """Run 24, finding A-1: the review gates order 'view the image BEFORE the
+    keys', then prescribe a render command whose unconditional JSON_SUMMARY
+    echo put the keys on screen first. --quiet with --json-out now suppresses
+    the echo and the describe text (the file carries both); --quiet WITHOUT
+    --json-out must still print the summary -- data is never silenced into
+    nowhere."""
+    rp = _tool('render_placement.py')
+    board = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
+    with tempfile.TemporaryDirectory() as td:
+        out = os.path.join(td, 'r.json')
+        r = subprocess.run(
+            [sys.executable, '-X', 'utf8', rp, board, '--clearance', '0.15',
+             '--json-out', out, '--quiet', '-o', os.path.join(td, 'r.png')],
+            capture_output=True, text=True, cwd=ROOT)
+        assert r.returncode == 0, r.stdout[-400:]
+        assert 'JSON_SUMMARY' not in r.stdout, 'the echo defeats blind-first'
+        assert 'WHAT THIS PANEL SHOWS' not in r.stdout
+        assert os.path.getsize(out) > 100, 'the file must still carry the doc'
+        r2 = subprocess.run(
+            [sys.executable, '-X', 'utf8', rp, board, '--clearance', '0.15',
+             '--json', '--quiet'],
+            capture_output=True, text=True, cwd=ROOT)
+        assert 'JSON_SUMMARY' in r2.stdout, \
+            'without --json-out the summary must still print somewhere'
+    print("  PASS: --quiet + --json-out is blind; --quiet alone never "
+          "silences data into nowhere")
 
 
 if __name__ == '__main__':

--- a/tests/test_run20_not_applicable.py
+++ b/tests/test_run20_not_applicable.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""`ungraded` conflated "not applicable" with "not measured".
+
+L5 refused to close run 20 because `length` and `net_widths` were "never
+examined", and closing needed `--accept-unclosed ungraded`. But the two are
+different facts. That board has no length-matched group AT ALL, so there is
+nothing to grade and passing `--length-groups` would INVENT a requirement --
+whereas `net_widths` was genuinely measurable and simply unasked-for.
+
+One waiver covered both. A standing false waiver on every simple board is how a
+real one stops being read.
+
+`board_score.skipped(reason)` already carried a reason string; nothing
+downstream read it. It now carries the distinction as data, and only `ungraded`
+blocks a close-out. Both lists stay in the payload and on the printed line --
+"not applicable" must be VISIBLE, not silently dropped, or a reader cannot tell
+it from a gap.
+
+The applicability test is the chain's OWN record (#521): matched groups and
+routed diff pairs live under `protected_nets`, impedance specs under
+`net_impedance`, in the sibling project. Conservative in the right direction --
+anything unreadable answers "applicable", so a component stays `ungraded`
+(blocking) rather than being silently excused.
+
+    python3 tests/test_run20_not_applicable.py
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BS = os.path.join(REPO, '.claude', 'skills', 'plan-pcb-placement-and-routing', 'scripts',
+                  'board_score.py')
+CC = os.path.join(REPO, 'check_complete.py')
+
+passed = failed = 0
+
+
+def check(label, cond, detail=''):
+    global passed, failed
+    if cond:
+        passed += 1
+        print(f'  OK   {label}')
+    else:
+        failed += 1
+        print(f'  FAIL {label} -- {detail}')
+
+
+_D = tempfile.mkdtemp()
+_BOARD_TXT = '''(kicad_pcb (version 20260206) (generator t)
+ (layers (0 "F.Cu" signal) (2 "B.Cu" signal) (44 "Edge.Cuts" user))
+ (gr_rect (start 0 0) (end 40 30) (layer "Edge.Cuts") (width 0.1))
+ (net 0 "") (net 1 "N1")
+ (footprint "t:r" (layer "F.Cu") (at 10 15)
+  (property "Reference" "R1" (at 0 0) (layer "F.SilkS"))
+  (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 1 "N1")))
+ (footprint "t:r" (layer "F.Cu") (at 30 15)
+  (property "Reference" "R2" (at 0 0) (layer "F.SilkS"))
+  (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 1 "N1")))
+ (segment (start 10 15) (end 30 15) (width 0.2) (layer "F.Cu") (net 1))
+)'''
+
+
+def _stage(name, krt=None):
+    d = os.path.join(_D, name)
+    os.makedirs(d, exist_ok=True)
+    b = os.path.join(d, 'b.kicad_pcb')
+    with open(b, 'w', encoding='utf-8') as fh:
+        fh.write(_BOARD_TXT)
+    pro = {'board': {'design_settings': {'rules': {'min_track_width': 0.15}}}}
+    if krt:
+        pro['kicad_routing_tools'] = krt
+    with open(os.path.join(d, 'b.kicad_pro'), 'w', encoding='utf-8') as fh:
+        json.dump(pro, fh)
+    return b
+
+
+def _score(board):
+    p = subprocess.run([sys.executable, BS, board, '--quiet'],
+                       capture_output=True, text=True, timeout=900)
+    out = (p.stdout or '')
+    ln = [x for x in out.splitlines() if x.startswith('SCORE_JSON=')]
+    return (json.loads(ln[0][len('SCORE_JSON='):]) if ln else {}), out
+
+
+print('--- a board with no such requirement ---')
+_plain = _stage('plain')
+sc, out = _score(_plain)
+check('length is NOT APPLICABLE, not ungraded',
+      'length' in (sc.get('not_applicable') or [])
+      and 'length' not in (sc.get('ungraded') or []),
+      f"ungraded={sc.get('ungraded')} n/a={sc.get('not_applicable')}")
+check('and so is impedance',
+      'impedance' in (sc.get('not_applicable') or []), str(sc.get('not_applicable')))
+check('but net_widths stays UNGRADED -- it was measurable and unasked',
+      'net_widths' in (sc.get('ungraded') or []),
+      f"{sc.get('ungraded')} -- there is no board-side declaration for per-net "
+      f"widths, so 'nobody asked' is the whole truth about it")
+check('the distinction is PRINTED, not only in the JSON',
+      'NOT APPLICABLE' in out and 'UNGRADED' in out, out[-500:])
+check('and it reaches the identity line, where a comparison is made',
+      any(x.startswith('BLOCKING=') and 'n/a:' in x
+          for x in out.splitlines()),
+      [x for x in out.splitlines() if x.startswith('BLOCKING=')])
+
+print('--- a board that DOES declare one ---')
+_decl = _stage('declared', krt={'protected_nets': ['N1'],
+                                'net_impedance': {'N1': {'ohms': 50}}})
+sc2, out2 = _score(_decl)
+check('a declared match group makes length UNGRADED again',
+      'length' in (sc2.get('ungraded') or [])
+      and 'length' not in (sc2.get('not_applicable') or []),
+      f"ungraded={sc2.get('ungraded')} n/a={sc2.get('not_applicable')}")
+check('and a declared impedance net makes impedance UNGRADED again',
+      'impedance' in (sc2.get('ungraded') or []), str(sc2.get('ungraded')))
+
+print('--- the fallback is conservative in the right direction ---')
+_noproj = os.path.join(_D, 'noproj.kicad_pcb')
+with open(_noproj, 'w', encoding='utf-8') as fh:
+    fh.write(_BOARD_TXT)
+sc3, _ = _score(_noproj)
+check('a project-less board does not silently excuse anything it cannot read',
+      'net_widths' in (sc3.get('ungraded') or []), str(sc3.get('ungraded')))
+
+_bad = _stage('badproj')
+with open(os.path.join(os.path.dirname(_bad), 'b.kicad_pro'), 'w',
+          encoding='utf-8') as fh:
+    fh.write('{ this is not json')
+sc4, _ = _score(_bad)
+check('an UNREADABLE project leaves both blocking, never excused',
+      'length' in (sc4.get('ungraded') or [])
+      and 'impedance' in (sc4.get('ungraded') or []),
+      f"{sc4.get('ungraded')} / {sc4.get('not_applicable')} -- unreadable must "
+      f"mean 'still applicable', or a corrupt file waives a real requirement")
+
+print('--- and the close-out stops demanding a waiver for a non-question ---')
+p = subprocess.run([sys.executable, '-X', 'utf8', CC, _plain, '--skip-slow'],
+                   capture_output=True, text=True, timeout=900)
+o = (p.stdout or '') + (p.stderr or '')
+_v = [x for x in o.splitlines() if x.startswith('VERDICT:')]
+check('check_complete prints NOT APPLICABLE beside UNEXAMINED',
+      _v and 'NOT APPLICABLE' in _v[0], (_v[0] if _v else o[-400:]))
+check('and does not list length among the unexamined',
+      _v and ('UNEXAMINED' not in _v[0]
+              or 'length' not in _v[0].split('UNEXAMINED')[1].split('.')[0]),
+      (_v[0] if _v else o[-400:]) + ' -- run 20 needed --accept-unclosed '
+      'ungraded to close, covering a real gap and a non-question at once')
+
+print(f'\n{passed} passed, {failed} failed')
+sys.exit(1 if failed else 0)

--- a/tests/test_run20_oob_channel.py
+++ b/tests/test_run20_oob_channel.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""L2's off-board gate reads the coarse channel while holding the precise one.
+
+`check_assembly`'s `oob_pad_count` is a part pad AABB -- pads PLUS NPTH drill
+circles -- tested against an outline INFLATED by the grading clearance. Its own
+`oob_pad_basis` string says so, and adds that the per-pad, margin-0 measure is
+`render_placement`'s `checklist.a_off_outline.pad_copper`.
+
+L2 refused on the coarse number while already being handed the render that
+carries the precise one. On run 20 they disagreed -- coarse [R4, SW2], per-pad
+[SW2] -- which is why `--accept-residue oob_pad_count` had to be used in BOTH
+cycles, and a waiver raised for one part also covers the other.
+
+R4 IS NOT A PHANTOM, and an earlier version of this file said it was. Its copper
+is on the outline, so `pad_copper` is right to omit it -- but
+`check_drc --check-pad-edge` reports R4.1 and R4.2 in CONTACT with the board
+edge. The two channels measure different requirements: copper OFF the outline
+at margin 0, versus the pad AABB against an outline inflated by the grading
+clearance, which is board-edge clearance. Reading their difference as a false
+positive discards a real violation, so the gate names it as an edge finding and
+prints the command that lists it.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DRIVER = os.path.join(REPO, '.claude', 'skills',
+                      'plan-pcb-placement-and-routing', 'scripts',
+                      'loop_driver.py')
+
+passed = failed = 0
+
+
+def check(label, cond, detail=''):
+    global passed, failed
+    if cond:
+        passed += 1
+        print(f'  OK   {label}')
+    else:
+        failed += 1
+        print(f'  FAIL {label} -- {detail}')
+
+
+_D = tempfile.mkdtemp()
+
+
+def _w(name, doc):
+    p = os.path.join(_D, name)
+    with open(p, 'w', encoding='utf-8') as fh:
+        json.dump(doc, fh)
+    return p
+
+
+# A board file the driver can stat. L2 board-binds its documents, so the paths
+# have to agree; content does not matter to this gate.
+_BOARD = os.path.join(_D, 'placed.kicad_pcb')
+with open(_BOARD, 'w', encoding='utf-8') as fh:
+    fh.write('(kicad_pcb (version 20260206) (generator test)\n'
+             ' (layers (0 "F.Cu" signal) (2 "B.Cu" signal) (44 "Edge.Cuts" user))\n'
+             ' (gr_rect (start 0 0) (end 40 30) (layer "Edge.Cuts") (width 0.1))\n'
+             ' (net 0 "")\n)')
+
+# The run-20 disagreement, reduced: two parts by the coarse measure, one by the
+# precise one.
+_ASSEMBLY = _w('assembly.json', {
+    'board': os.path.abspath(_BOARD), 'blocking': 0, 'buildable': True,
+    'verdict': 'buildable', 'locked_contacts': 0, 'oob_pad_count': 2,
+    'oob_pad_basis': 'part pad AABB against an outline inflated by the '
+                     'GRADING CLEARANCE'})
+_RENDER = _w('render.json', {
+    'instrument': {'board': os.path.abspath(_BOARD), 'summary_json': 'x.log'},
+    'checklist': {'a_off_outline': {
+        'courtyard': [['J2', 5.1492], ['R4', 0.6897], ['SW2', 2.3292]],
+        'pad_copper': [['SW2', 1.5672]]}},
+    'moved_refs': []})
+_RENDER_CLEAN = _w('render_clean.json', {
+    'instrument': {'board': os.path.abspath(_BOARD), 'summary_json': 'x.log'},
+    'checklist': {'a_off_outline': {'courtyard': [['R4', 0.6897]],
+                                    'pad_copper': []}},
+    'moved_refs': []})
+_LEDGER = os.path.join(_D, 'ledger.jsonl')
+open(_LEDGER, 'w').close()
+
+
+def _l2(*extra):
+    p = subprocess.run(
+        [sys.executable, '-X', 'utf8', DRIVER, '--stage', 'L2',
+         '--board', _BOARD, '--ledger', _LEDGER,
+         '--placement-report', _ASSEMBLY, '--no-delegate'] + list(extra),
+        capture_output=True, text=True, timeout=300)
+    return (p.stdout or '') + (p.stderr or '')
+
+
+print('--- with the render, the gate names the part whose copper is off ---')
+out = _l2('--render-json', _RENDER)
+check('it still refuses -- there IS a real off-board part',
+      '<error>' in out and 'pad copper OFF the board' in out, out[:400])
+check('and it names SW2',
+      'SW2' in out, out[:600])
+check('but NOT R4, whose copper was on the board the whole time',
+      'R4' not in out.split('Named:')[-1].split('.')[0] if 'Named:' in out
+      else 'R4' not in out,
+      'the coarse channel inflates the outline by the grading clearance, so a '
+      'part near the edge reads as off it; the waiver that answer forces also '
+      'covers the real finding')
+check('the refusal says WHICH measure it used',
+      'a_off_outline.pad_copper' in out and 'per-pad' in out, out[:600])
+check('and discloses the coarse number as corroboration, named as coarse',
+      'coarse' in out and '2' in out, out[:800])
+# The coarse channel is NOT a phantom, and the message must not say it is. On
+# run 20 the difference was R4, whose copper IS on the outline -- and which
+# `check_drc --check-pad-edge` reports in CONTACT with the board edge. The two
+# channels measure different requirements; calling the difference a false
+# positive discards a real violation.
+check('the difference is named as a BOARD-EDGE finding, not dismissed',
+      'BOARD-EDGE CLEARANCE' in out and '--check-pad-edge' in out,
+      out[:900] + ' -- the coarse measure inflates the outline by the grading '
+      'clearance, so it also catches copper that is on the board but too close '
+      'to its edge')
+
+print('--- when the precise channel says zero, the gate does not fire ---')
+out = _l2('--render-json', _RENDER_CLEAN)
+check('a board whose pad copper is all on the outline passes this gate',
+      'pad copper OFF the board' not in out,
+      out[:500] + ' -- the coarse count is 2 here and must not be believed '
+      'over the margin-0 per-pad measure')
+
+print('--- with no render, behaviour is exactly what it was ---')
+out = _l2()
+check('the coarse count still refuses when no render is available',
+      '<error>' in out and 'pad copper OFF the board' in out, out[:400])
+check('and the basis line says it is the coarse one',
+      'coarse' in out and 'check_assembly' in out, out[:600])
+
+print('--- a render it cannot use does not silently claim precision ---')
+_BAD = os.path.join(_D, 'nope.json')
+out = _l2('--render-json', _BAD)
+check('a missing render falls back and SAYS the fallback happened',
+      'coarse' in out and 'no such file' in out, out[:600])
+_NOCHK = _w('nochk.json', {'instrument': {'board': os.path.abspath(_BOARD)}})
+out = _l2('--render-json', _NOCHK)
+check('a render without the checklist key does too',
+      'coarse' in out and 'a_off_outline.pad_copper' in out, out[:600])
+
+print('--- the render must be OF THIS BOARD, or it does not count ---')
+# THE FAIL-OPEN DIRECTION. This channel REPLACES the coarse count rather than
+# max()ing it, so every way of getting the wrong document turns a refusal into
+# a pass. L3 board-binds its render; L2 did not, and was the only stage reading
+# a document it never checked the identity of.
+_OTHER = os.path.join(_D, 'other.kicad_pcb')
+with open(_OTHER, 'w', encoding='utf-8') as fh:
+    fh.write('(kicad_pcb (version 20260206) (generator test) (net 0 ""))')
+_FOREIGN = _w('foreign.json', {
+    'instrument': {'board': os.path.abspath(_OTHER), 'summary_json': 'x.log'},
+    'checklist': {'a_off_outline': {'pad_copper': []}}, 'moved_refs': []})
+out = _l2('--render-json', _FOREIGN)
+check('a render of a DIFFERENT board does not silence the gate',
+      '<error>' in out and 'pad copper OFF the board' in out,
+      out[:400] + ' -- an empty pad_copper from another board would otherwise '
+      'read as "this board is clean"')
+check('and the basis line says WHY it was not used',
+      'DIFFERENT board' in out, out[:600])
+check('...falling back to the coarse count, which is still a real measurement',
+      'coarse' in out, out[:600])
+
+_NOINST = _w('noinst.json', {
+    'checklist': {'a_off_outline': {'pad_copper': []}}})
+out = _l2('--render-json', _NOINST)
+check('a render with no instrument.board is refused the same way',
+      '<error>' in out and 'no instrument.board' in out, out[:600])
+
+print('--- and a malformed render is a fallback, never a crash ---')
+for _name, _doc in (('list_top.json', [1, 2, 3]),
+                    ('list_checklist.json',
+                     {'instrument': {'board': os.path.abspath(_BOARD)},
+                      'checklist': ['not', 'a', 'dict']}),
+                    ('str_off.json',
+                     {'instrument': {'board': os.path.abspath(_BOARD)},
+                      'checklist': {'a_off_outline': 'nope'}}),
+                    ('inst_list.json',
+                     {'instrument': ['x'], 'checklist': {}})):
+    out = _l2('--render-json', _w(_name, _doc))
+    check(f'{_name} does not crash the stage',
+          'Traceback' not in out and 'coarse' in out, out[:300])
+
+print('--- the waiver still works, and still covers only what it names ---')
+out = _l2('--render-json', _RENDER, '--accept-residue', 'oob_pad_count')
+check('--accept-residue oob_pad_count still waives this gate',
+      'pad copper OFF the board' not in out, out[:400])
+
+print(f'\n{passed} passed, {failed} failed')
+sys.exit(1 if failed else 0)

--- a/tests/test_run20_ring_ownership.py
+++ b/tests/test_run20_ring_ownership.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""A part that owns a milled ring may sit ON it, not merely swallow it.
+
+An Edge.Cuts contour enclosing >= 2 pad centres is reclassified by the parser
+from board CUTOUT to inner milled edge (#291/#628) -- otherwise the enclosed
+pads would be marked off-board and the run breaks. `rings_enclosing` /
+`skip_rings` then exempt the OWNING part, so a connector over its own milled
+relief is not judged board-violating at its own hand-placed pose.
+
+That exemption covered only the SWALLOW probe. The EDGE-MARGIN test -- which
+vetoes any rect within `max(clearance, edge)` of any ring edge -- had no
+exemption at all, so a part sitting inside its own relief had every pose vetoed,
+which for such a part is every pose there is.
+
+Measured on run 20's SW2, which owns the strap slot its two NPTH posts sit
+inside: 0 legal poses of 14884 at the board's own floors; at margin 0, 508 of
+9604, all at rot 0/180 and none at SW2's own rot 270. `place_optimize` with SW2
+free and 83 refs locked moved it 0 mm with the edge term as the entire
+objective (86024 of 86024). `place_reconstruct --stages classify,legalize`
+reported "no legal pose within any cap". The run declared SW2 an
+`edge_actuator` and waived it permanently.
+
+PER-PART, never global. The ring stays a hard edge for every other part, and
+`rings_enclosing` returns MILLED ids only -- the outer outline and the genuine
+cutouts can never be exempted through this path.
+
+    python3 tests/test_run20_ring_ownership.py
+"""
+import contextlib
+import io
+import os
+import sys
+import tempfile
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for _p in (REPO, os.path.join(REPO, 'py_router'), os.path.join(REPO, 'py_tools'),
+           os.path.join(REPO, 'py_placer')):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from kicad_parser import parse_kicad_pcb                           # noqa: E402
+from placement.legality import BoardOutlineGate                    # noqa: E402
+
+passed = failed = 0
+
+
+def check(label, cond, detail=''):
+    global passed, failed
+    if cond:
+        passed += 1
+        print(f'  OK   {label}')
+    else:
+        failed += 1
+        print(f'  FAIL {label} -- {detail}')
+
+
+# 40x30 board with an interior milled ring (a strap slot) at 18..22 x 12..18.
+# SW2's two THROUGH-HOLE posts sit INSIDE it, which is what makes the contour a
+# milled edge rather than a cutout. R9 sits outside, in the same band.
+_BOARD = '''(kicad_pcb (version 20260206) (generator t)
+ (layers (0 "F.Cu" signal) (2 "B.Cu" signal) (44 "Edge.Cuts" user))
+ (gr_rect (start 0 0) (end 40 30) (layer "Edge.Cuts") (width 0.1))
+ (gr_rect (start 18 12) (end 22 18) (layer "Edge.Cuts") (width 0.1))
+ (net 0 "") (net 1 "N1")
+ (footprint "t:sw" (layer "F.Cu") (at 20 15)
+  (property "Reference" "SW2" (at 0 0) (layer "F.SilkS"))
+  (pad "1" thru_hole circle (at -1 0) (size 1 1) (drill 0.8) (layers "*.Cu")
+   (net 1 "N1"))
+  (pad "2" thru_hole circle (at 1 0) (size 1 1) (drill 0.8) (layers "*.Cu")
+   (net 1 "N1")))
+ (footprint "t:r" (layer "F.Cu") (at 30 15)
+  (property "Reference" "R9" (at 0 0) (layer "F.SilkS"))
+  (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu") (net 1 "N1")))
+)'''
+
+_D = tempfile.mkdtemp()
+_B = os.path.join(_D, 'ring.kicad_pcb')
+with open(_B, 'w', encoding='utf-8') as fh:
+    fh.write(_BOARD)
+with contextlib.redirect_stdout(io.StringIO()):
+    pcb = parse_kicad_pcb(_B)
+
+MARGIN = 0.254
+gate = BoardOutlineGate(pcb.board_info, MARGIN)
+
+print('--- the fixture is the shape under test ---')
+check('the pad-enclosing contour was reclassified to a MILLED edge',
+      len(pcb.board_info.board_edge_contours or []) == 1
+      and not (pcb.board_info.board_cutouts or []),
+      f'{len(pcb.board_info.board_edge_contours or [])} milled / '
+      f'{len(pcb.board_info.board_cutouts or [])} cutouts -- if it stayed a '
+      f'cutout the enclosed pads would be off-board and this tests nothing')
+check('the outline gate is active (a rect board with one ring is exact '
+      'without it)', gate.active and len(gate.milled) == 1,
+      f'active={gate.active} milled={len(gate.milled)}')
+
+_sw = pcb.footprints['SW2']
+_own = gate.rings_enclosing([(p.global_x, p.global_y) for p in _sw.pads])
+check('SW2 OWNS the ring its posts sit in', bool(_own), str(_own))
+_r9 = pcb.footprints['R9']
+_foreign = gate.rings_enclosing([(p.global_x, p.global_y) for p in _r9.pads])
+check('R9 owns nothing', not _foreign, str(_foreign))
+
+print('--- the pose that was vetoed: a body SPANNING its own slot ---')
+# Edges cross the ring, so the margin test measures a distance of 0.
+_span = (17.9, 13.5, 22.1, 16.5)
+check('without an exemption the owner is BLOCKED at its own pose',
+      gate.rect_blocked(_span),
+      'if this is False the fixture is not exercising the margin test')
+check('WITH ownership the owner is legal there',
+      not gate.rect_blocked(_span, skip_rings=_own),
+      'the fix: the exemption now covers the edge-margin test, not only the '
+      'swallow probe')
+check('and the cost function agrees -- 0, not a residual graze',
+      gate.rect_outside_amount(_span, skip_rings=_own) == 0.0,
+      f'{gate.rect_outside_amount(_span, skip_rings=_own)} -- the two must '
+      f'agree or `violation() == 0` stops implying `not rect_blocked()`, and '
+      f'every acceptance rule downstream reads the disagreement as a regression')
+check('the unexempted cost is non-zero, so the pair really does discriminate',
+      gate.rect_outside_amount(_span) > 0.0,
+      str(gate.rect_outside_amount(_span)))
+
+print('--- and it is PER-PART ---')
+check('a FOREIGN part is still blocked at the same rect',
+      gate.rect_blocked(_span, skip_rings=_foreign),
+      'the ring is a hard edge for everyone who does not own it; a global '
+      'exemption would let any part sit in the slot')
+check('...and still charged for it',
+      gate.rect_outside_amount(_span, skip_rings=_foreign) > 0.0,
+      str(gate.rect_outside_amount(_span, skip_rings=_foreign)))
+
+print('--- the outer outline is NOT exemptible through this path ---')
+# A rect hanging off the real board edge must stay blocked no matter what is
+# claimed as owned. `rings_enclosing` cannot return the outer ring, but a
+# caller could pass any id, so the guard is tested rather than assumed.
+_off = (-1.0, 13.0, 3.0, 17.0)
+check('a rect off the real board edge is blocked with ownership claimed',
+      gate.rect_blocked(_off, skip_rings=frozenset(range(8))),
+      'the corner test reads the OUTER ring and the cutouts, which this '
+      'exemption never touches')
+
+print('--- a pose clear of the ring is unaffected either way ---')
+_clear = (18.6, 13.6, 21.4, 16.4)      # >0.254 from every ring edge
+check('an owner well inside its slot was never blocked',
+      not gate.rect_blocked(_clear) and not gate.rect_blocked(
+          _clear, skip_rings=_own), '')
+check('and its cost is 0 both ways -- the exemption adds nothing here',
+      gate.rect_outside_amount(_clear) == 0.0
+      and gate.rect_outside_amount(_clear, skip_rings=_own) == 0.0, '')
+
+print('--- rotation: the owner is legal at ITS OWN orientation ---')
+# The run-20 tell was that the only legal poses were rot 0/180 -- never SW2's
+# own 270. A slot-spanning body at 90 degrees is the same test rotated.
+_span90 = (18.5, 11.9, 21.5, 18.1)
+check('the owner spans its slot the OTHER way and is still legal',
+      gate.rect_blocked(_span90)
+      and not gate.rect_blocked(_span90, skip_rings=_own),
+      f'plain={gate.rect_blocked(_span90)} '
+      f'owned={gate.rect_blocked(_span90, skip_rings=_own)}')
+
+print('--- caching does not leak between parts ---')
+# The edge set is cached per skip-set; a cache keyed carelessly would hand one
+# part another's exemption.
+for _ in range(3):
+    check_a = gate.rect_blocked(_span, skip_rings=_own)
+    check_b = gate.rect_blocked(_span, skip_rings=_foreign)
+check('repeated interleaved queries keep their own answers',
+      not check_a and check_b, f'owner={check_a} foreign={check_b}')
+
+print(f'\n{passed} passed, {failed} failed')
+sys.exit(1 if failed else 0)

--- a/tests/test_run20_run_watch.py
+++ b/tests/test_run20_run_watch.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+"""The watcher that cried wolf 683 times.
+
+Run 20 armed `run_watch cheats` over a 5h43m run. It emitted ~683 lines from a
+bare case-sensitive substring scan; **6** were flags the run actually passed.
+Everything else was the flag being MENTIONED: a driver's own refusal telling you
+to pass `--accept-residue`, a tool disclosing "`--clearance` not given", an
+argparse help dump, a ledger `lever` sentence narrating the lever it used. A
+watcher wrong that often trains its reader to skim it, which is the same as not
+having one.
+
+The anchor is `py_router/cli_banner.py`: exactly one `CMD: <argv>` line per tool
+run, built from `sys.orig_argv`, installed by 27 tools and pinned by
+`tests/test_run4_instruments.py` and `tests/test_run12_tools.py`. A flag on that
+line was passed; a flag anywhere else was typed about.
+
+Three other findings from the same run are pinned here:
+
+  * BLOCKING-UP compared cycle 2's FIRST scored lap against cycle 1's FINAL one
+    and reported `blocking 10 -> 82` as a regression.
+  * the JOURNAL -- the artifact the run is REQUIRED to write as it goes -- was
+    invisible to the stall timer, so a stretch whose only output was the journal
+    read as a dead run. It must count as LIVENESS but must not be SCANNED: it
+    quotes tool output, and scanning it reported `NOT BUILDABLE` from a line
+    reading "NOT BUILDABLE -> buildable", i.e. the record of the fix.
+  * `run_watch.py` had no test file and no `--self-test` at all.
+"""
+import json
+import os
+import sys
+import tempfile
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(REPO, 'tests', 'stress'))
+
+import run_watch as RW  # noqa: E402
+
+SKIP_EXIT = 77
+passed = failed = 0
+
+
+def check(label, cond, detail=''):
+    global passed, failed
+    if cond:
+        passed += 1
+        print(f'  OK   {label}')
+    else:
+        failed += 1
+        print(f'  FAIL {label} -- {detail}')
+
+
+def scan_cheats(workdir):
+    """What `watch_cheats` would report on one pass over `workdir`."""
+    seen, out = set(), []
+    for path in RW._walk(workdir):
+        rel = os.path.relpath(path, workdir).replace('\\', '/')
+        try:
+            lines = open(path, encoding='utf-8', errors='replace').readlines()
+        except OSError:
+            continue
+        for line in lines:
+            parsed = RW._parse_cmd(line)
+            if parsed is None:
+                continue
+            tool, toks = parsed
+            for label, flag, _why in RW._cheat_hits(tool, toks):
+                key = RW._use_key(label, flag, tool, toks)
+                if key in seen:
+                    continue
+                seen.add(key)
+                out.append(f'{label} {flag} {tool}')
+        if path.endswith('.jsonl'):
+            for line in RW._scan_ledger_argv(path, seen, rel):
+                out.append(line.split(' -- ')[0])
+    return out
+
+
+print('--- the precision fixture: shapes that fired 683 times ---')
+
+d = tempfile.mkdtemp()
+with open(os.path.join(d, 'run.log'), 'w', encoding='utf-8') as fh:
+    fh.write(
+        # a driver refusal that NAMES the flag it wants you to pass
+        'If the overhang is BY DESIGN, declare it in the intent and re-run\n'
+        'with --accept-residue oob_pad_count.\n'
+        # a tool disclosing that it did NOT get the flag
+        '  --clearance not given; honoring net classes with base = 0.15mm.\n'
+        '  --board-edge-clearance not given; using 0.254mm [board constraint].\n'
+        # an argparse help dump
+        'usage: route.py [-h] [--nets NETS [NETS ...]] [--force-reroute]\n'
+        '                [--rip-existing-nets PATTERN [PATTERN ...]]\n'
+        # a router hint suggesting a flag
+        "Hint: retry with --rip-existing-nets to authorize\n"
+        # the driver naming the escape hatch it did NOT take
+        'DELEGATING: this half goes to a TEAMMATE. --no-delegate runs it here.\n')
+with open(os.path.join(d, 'ledger.jsonl'), 'w', encoding='utf-8') as fh:
+    fh.write(json.dumps({
+        'iteration': 0, 'kind': 'completion', 'accepted': True,
+        # prose that narrates the flags -- exactly the disclosure the run is
+        # SUPPOSED to make. Reporting it punishes the disclosure.
+        'lever': 'rip lever AUTHORIZED AND DISCLOSED -- --rip-existing-nets '
+                 'over 17 nets, at the board floors, no --clearance passed',
+    }) + '\n')
+
+hits = scan_cheats(d)
+check('zero events from prose, help, hints, refusals and ledger levers',
+      hits == [], f'{hits}')
+
+with open(os.path.join(d, 'real.log'), 'w', encoding='utf-8') as fh:
+    fh.write('CMD: python3.exe -X utf8 py_router/check_drc.py b.kicad_pcb '
+             '--clearance 0.2\nEXIT=0\n')
+hits = scan_cheats(d)
+check('exactly one event once a real CMD: line appears',
+      len(hits) == 1 and '--clearance' in hits[0], f'{hits}')
+
+print('--- token-exactness ---')
+check('--clearance does not match inside --clearance-margin',
+      not RW._flag_in(['--clearance-margin', '0.1'], '--clearance'))
+check('--nets does not match inside --ignore-nets',
+      not RW._flag_in(['--ignore-nets', 'GND'], '--nets'))
+check('the --flag=value form still matches',
+      RW._flag_in(['--nets=BUSY'], '--nets'))
+
+print('--- tool scoping ---')
+check('route_diff.py --nets DP DN is silent (naming the pair IS the tool)',
+      not RW._cheat_hits('route_diff.py', ['--nets', 'DP', 'DN']))
+check('route_planes.py --nets GND +3V3 is silent (naming the pour IS the tool)',
+      not RW._cheat_hits('route_planes.py', ['--nets', 'GND', '+3V3']))
+check('route.py --nets "*" is silent (the whole board, not a narrowing)',
+      not RW._cheat_hits('route.py', ['--nets', '*']))
+check('route.py --nets <subset> is reported',
+      RW._cheat_hits('route.py', ['--nets', 'BUSY', 'SCK']))
+check('check_drc.py --clearance is reported (a grader floor override)',
+      RW._cheat_hits('check_drc.py', ['--clearance', '0.2']))
+check('place_optimize.py --ignore-nets is silent (airwire scoring, no verdict)',
+      not RW._cheat_hits('place_optimize.py', ['--ignore-nets', 'GND']))
+
+print('--- one lever recorded twice is one event ---')
+log = ['python3.exe', '-X', 'utf8', 'C:/r/py_router/route.py',
+       'C:/r/wk/a.kicad_pcb', '--nets', 'CS', '/40M_N']
+led = ['python3', '-X', 'utf8', 'py_router/route.py', 'wk/a.kicad_pcb',
+       '--nets', '/40M_N', 'CS']
+check('log spelling and ledger spelling collapse to one key',
+      RW._use_key('SCOPE', '--nets', 'route.py', log)
+      == RW._use_key('SCOPE', '--nets', 'route.py', led))
+check('a different scope stays a separate event',
+      RW._use_key('SCOPE', '--nets', 'route.py', log)
+      != RW._use_key('SCOPE', '--nets', 'route.py',
+                     ['route.py', '--nets', 'BUSY']))
+
+print('--- BLOCKING-UP: kept routing laps only ---')
+
+
+def ledger_events(rows):
+    p = os.path.join(tempfile.mkdtemp(), 'ledger.jsonl')
+    with open(p, 'w', encoding='utf-8') as fh:
+        for r in rows:
+            fh.write(json.dumps(r) + '\n')
+    return RW._scan_ledger(p, set(), 'ledger.jsonl')
+
+
+ev = ledger_events([
+    {'iteration': 1, 'kind': 'completion', 'accepted': True,
+     'score': {'blocking': 10}},
+    {'iteration': 2, 'kind': 'completion', 'accepted': False,
+     'score': {'blocking': 82}},          # rejected: the loop already reverted it
+    {'iteration': 3, 'kind': 'completion', 'accepted': True,
+     'score': {'blocking': 12}},
+])
+# This is the DISCRIMINATING direction, and my first version of this test had it
+# backwards. If the rejected 82 became the baseline, 12 < 82 and the watcher goes
+# SILENT -- a real regression hidden by a lap the loop already threw away. With
+# the rejected lap skipped, 12 is compared against 10 and fires. So the correct
+# assertion is that it DOES fire, naming 10 -> 12.
+up = [e for e in ev if e.startswith('BLOCKING-UP')]
+check('a rejected lap is skipped, so the next kept lap compares against the '
+      'last KEPT one (10 -> 12, not 82 -> 12 which would be silent)',
+      len(up) == 1 and 'blocking 10 -> 12' in up[0],
+      f'{[e[:70] for e in ev]}')
+check('and it is still reported as a rejected lap',
+      len([e for e in ev if e.startswith('REJECTED-LAP')]) == 1)
+
+ev = ledger_events([
+    {'iteration': 1, 'kind': 'completion', 'accepted': True,
+     'score': {'blocking': 10}},
+    {'iteration': 2, 'kind': 'placement', 'accepted': True},   # a half boundary
+    {'iteration': 3, 'kind': 'completion', 'accepted': True,
+     'score': {'blocking': 82}},          # a NEW board's first score
+])
+check('a placement lap resets the sequence (run 20: 10 -> 82 was cross-cycle)',
+      not [e for e in ev if e.startswith('BLOCKING-UP')],
+      f'{[e[:70] for e in ev]}')
+
+ev = ledger_events([
+    {'iteration': 1, 'kind': 'completion', 'accepted': True,
+     'score': {'blocking': 10}},
+    {'iteration': 2, 'kind': 'completion', 'accepted': True,
+     'score': {'blocking': 15}},
+])
+check('a REAL regression between two kept routing laps is still reported',
+      len([e for e in ev if e.startswith('BLOCKING-UP')]) == 1,
+      f'{[e[:70] for e in ev]}')
+
+ev = ledger_events([{'iteration': 1, 'kind': 'placement', 'accepted': True,
+                     'score': {'blocking': None}}])
+check('BLOCKING-NULL is reported on ANY lap, not only routing ones',
+      len([e for e in ev if e.startswith('BLOCKING-NULL')]) == 1,
+      f'{[e[:70] for e in ev]}')
+
+print('--- the journal: liveness yes, scanning no ---')
+jd = tempfile.mkdtemp()
+with open(os.path.join(jd, 'JOURNAL.md'), 'w', encoding='utf-8') as fh:
+    fh.write('## 9. the damage repaired\n'
+             'assembly verdict NOT BUILDABLE -> buildable, and the ERROR the\n'
+             'router printed is quoted here so the record carries it.\n')
+check('the journal is NOT scanned for signatures',
+      RW._scan_text(os.path.join(jd, 'JOURNAL.md'), set(), 'JOURNAL.md') == []
+      or '.md' not in RW.SCAN_EXT,
+      'a journal narrating "NOT BUILDABLE -> buildable" is not an incident')
+check('and it is not in the scan walk at all',
+      list(RW._walk(jd)) == [], str(list(RW._walk(jd))))
+check('but it IS in the liveness walk',
+      len(list(RW._walk(jd, RW.WATCHED_EXT))) == 1)
+
+print('--- the real run-20 work dir, if it is still here ---')
+wk = os.path.join(REPO, 'wk', 'run20')
+if os.path.isdir(wk):
+    raw = 0
+    for p in RW._walk(wk):
+        try:
+            txt = open(p, encoding='utf-8', errors='replace').read()
+        except OSError:
+            continue
+        for _l, f, _w, _t in RW.CHEAT_FLAGS:
+            raw += txt.count(f)
+    hits = scan_cheats(wk)
+    print(f'       raw substring hits {raw} -> reported {len(hits)}')
+    check('the real run reports far fewer than the raw substring count',
+          len(hits) < raw / 20, f'{len(hits)} of {raw}')
+    led = os.path.join(wk, 'ledger.jsonl')
+    ev = RW._scan_ledger(led, set(), 'ledger.jsonl')
+    check('and its ledger produces no BLOCKING-UP at all',
+          not [e for e in ev if e.startswith('BLOCKING-UP')],
+          f'{[e[:80] for e in ev if e.startswith("BLOCKING-UP")]}')
+else:
+    print('       (wk/run20 absent -- skipping the real-corpus checks)')
+
+print('--- a stall is a SYMPTOM, not an outcome ---')
+# Run 20's timer exited on a 20-minute stall while the run was still working,
+# and from that point the absence of events -- the timer's entire signal --
+# meant nothing, because nothing was watching. A watcher that stops watching
+# when it sees something worrying is the opposite of a watcher.
+#
+# Driven on a FAKE CLOCK: a real one would make this a 20-minute test, and a
+# test nobody runs pins nothing.
+import io                                                          # noqa: E402
+import contextlib                                                  # noqa: E402
+
+check('the escalation ladder is multiplicative and rises',
+      RW._STALL_LADDER == (1.0, 2.0, 4.0)
+      and list(RW._STALL_LADDER) == sorted(RW._STALL_LADDER),
+      str(RW._STALL_LADDER) + ' -- repeating the same sentence four times does '
+      'not make an 80-minute silence read differently from a 20-minute one')
+
+
+def _fake_run(events, stall_min=20.0, max_min=0, stall_exit=False):
+    """Drive watch_timer over a scripted timeline.
+
+    `events` is [(minute, touch_or_not), ...]; the clock and the work-dir
+    signature are both faked, so the whole run is instantaneous.
+    """
+    d = tempfile.mkdtemp()
+    state = {'t': 0.0, 'i': 0, 'sig': 0}
+    _t0 = 1_000_000.0
+
+    def _time():
+        return _t0 + state['t'] * 60.0
+
+    def _walk(_wd, _exts=None):
+        return []
+
+    def _sleep(_s):
+        if state['i'] >= len(events):
+            raise SystemExit
+        state['t'], touched = events[state['i']]
+        state['i'] += 1
+        if touched:
+            state['sig'] += 1
+
+    # The signature comes from _walk; fake it by returning a changing list.
+    def _walk2(_wd, _exts=None):
+        return [os.path.join(d, f'f{state["sig"]}.log')]
+
+    buf = io.StringIO()
+    old = (RW.time.time, RW.time.sleep, RW._walk, RW.os.path.getmtime,
+           RW.os.path.getsize)
+    RW.time.time, RW.time.sleep, RW._walk = _time, _sleep, _walk2
+    RW.os.path.getmtime = lambda p: 0.0
+    RW.os.path.getsize = lambda p: 0
+    try:
+        with contextlib.redirect_stdout(buf):
+            try:
+                RW.watch_timer(d, os.path.join(d, 'NEVER'), 1.0, stall_min,
+                               max_min, stall_exit=stall_exit)
+            except SystemExit:
+                pass
+    finally:
+        (RW.time.time, RW.time.sleep, RW._walk, RW.os.path.getmtime,
+         RW.os.path.getsize) = old
+    return [ln for ln in buf.getvalue().splitlines() if ln.strip()]
+
+
+# Quiet for 25 minutes: one notice, and the watch does NOT end.
+out = _fake_run([(m, False) for m in range(1, 30)])
+_st = [ln for ln in out if 'STALLED' in ln]
+check('a quiet stretch emits ONE stall notice, not one per poll',
+      len(_st) == 1, f'{len(_st)}: {_st[:3]}')
+check('and the notice says it is not terminal',
+      _st and 'NOT a terminal state' in _st[0], str(_st))
+# "It continues" is only demonstrable by PAIRING: the same timeline with and
+# without --stall-exit. A single run's output cannot distinguish "kept polling
+# and had nothing more to say" from "returned".
+_pair_on = _fake_run([(m, False) for m in range(1, 50)], stall_exit=False)
+_pair_off = _fake_run([(m, False) for m in range(1, 50)], stall_exit=True)
+check('the watch CONTINUES past a stall, where --stall-exit ends it',
+      len([x for x in _pair_on if 'STALLED' in x]) == 2
+      and len([x for x in _pair_off if 'STALLED' in x]) == 1,
+      f'{len([x for x in _pair_on if "STALLED" in x])} vs '
+      f'{len([x for x in _pair_off if "STALLED" in x])} on the same timeline '
+      f'-- the second notice can only exist if the first did not return')
+
+# Quiet, then activity, then quiet again: TWO episodes, with a RESUMED between.
+out = _fake_run([(m, False) for m in range(1, 26)]
+                + [(26, True)]
+                + [(m, False) for m in range(27, 55)])
+_st = [ln for ln in out if 'STALLED' in ln]
+check('activity RE-ARMS the notice: a second episode is reported',
+      len(_st) >= 2, f'{len(_st)}: {[x[:60] for x in _st]}')
+check('and the resumption is announced, so the first notice is not left '
+      'reading as the end',
+      any('RESUMED' in ln for ln in out), str(out[:4]))
+
+# Sustained silence: escalating thresholds, each named, then it stops repeating.
+out = _fake_run([(m, False) for m in range(1, 130)])
+_st = [ln for ln in out if 'STALLED' in ln]
+check('a sustained silence escalates through the ladder',
+      len(_st) == len(RW._STALL_LADDER),
+      f'{len(_st)} notices for {len(RW._STALL_LADDER)} rungs: '
+      f'{[x[:70] for x in _st]}')
+check('each notice names the threshold it fired at',
+      all('threshold' in ln for ln in _st), str(_st[:1]))
+check('and the last one says it is the last',
+      _st and 'last stall notice' in _st[-1], str(_st[-1:]))
+
+out = _fake_run([(m, False) for m in range(1, 30)], stall_exit=True)
+check('--stall-exit restores the old behaviour exactly',
+      len([ln for ln in out if 'STALLED' in ln]) == 1
+      and not [ln for ln in out if 'RESUMED' in ln], str(out))
+
+out = _fake_run([(m, False) for m in range(1, 30)], stall_min=0)
+check('--stall-min 0 emits nothing at all',
+      not [ln for ln in out if 'STALLED' in ln], str(out))
+
+out = _fake_run([(m, False) for m in range(1, 40)], max_min=30)
+check('TIMEOUT is still terminal, and still reached through a stall',
+      any('TIMEOUT' in ln for ln in out)
+      and any('STALLED' in ln for ln in out), str(out))
+
+check('the contract in the docstring says so too',
+      'ZERO OR MORE STALL NOTICES' in (RW.__doc__ or ''),
+      'a contract change that only lives in the code is one the next reader '
+      'will undo')
+
+print('--- run-22: a teed cmd_timing.jsonl is a source of truth ---')
+
+# tee_cmd.py records argv for EVERY invocation a timed run makes. Run 22 wrote
+# 203 such rows carrying five --waive uses, one --fab-overrides and a --nets
+# narrowing, and this watcher reported ZERO of them: it only ever read
+# `lever_argv`. The two skill drivers install no cli_banner either, so a teed
+# row is the ONLY place their invocations are ever visible.
+d22 = tempfile.mkdtemp()
+with open(os.path.join(d22, 'cmd_timing.jsonl'), 'w', encoding='utf-8') as f:
+    f.write(json.dumps({
+        'label': 'place_driver_p3b',
+        'argv': ['python3', '-X', 'utf8',
+                 '.claude/skills/plan-pcb-placement/scripts/placement_driver.py',
+                 '--stage', 'P3', '--waive', 'H1:mechanically pinned'],
+        'cmdline': 'x', 'exit': 0}) + chr(10))
+    f.write(json.dumps({
+        'label': 'rt_route4_pinned',
+        'argv': ['python3', 'py_router/route.py', 'in.kicad_pcb',
+                 'out.kicad_pcb', '--fab-overrides', 'fab_floor.txt'],
+        'cmdline': 'x', 'exit': 0}) + chr(10))
+out22 = scan_cheats(d22)
+check('--waive on a driver in a teed row is reported',
+      any('--waive' in ln for ln in out22), str(out22))
+check('--fab-overrides on a router in a teed row is reported',
+      any('--fab-overrides' in ln for ln in out22), str(out22))
+
+_flags = {f for _lab, f, _why, _tools in RW.CHEAT_FLAGS}
+for _f in ('--waive', '--accept-boxin', '--fab-tier', '--fab-overrides',
+           '--no-fix-drc-settings'):
+    check(f'{_f} is a known cheat flag', _f in _flags)
+
+# `lever` PROSE must still never be matched -- reporting a run's own
+# disclosure is the mistake the scanner's docstring exists to prevent.
+d23 = tempfile.mkdtemp()
+with open(os.path.join(d23, 'ledger.jsonl'), 'w', encoding='utf-8') as f:
+    f.write(json.dumps({
+        'iteration': 1,
+        'lever': 'I passed --waive H1:mechanical and said so in the journal',
+    }) + chr(10))
+check('a flag named in ledger PROSE is still not a finding',
+      scan_cheats(d23) == [], str(scan_cheats(d23)))
+
+print(f'\n{passed} passed, {failed} failed')
+sys.exit(1 if failed else 0)

--- a/tests/test_run21_watcher_self_scan.py
+++ b/tests/test_run21_watcher_self_scan.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""A watcher must not scan its own output.
+
+Run 21 armed the bug watcher the way the brief says to -- output teed into the
+work dir, so the watchers can see everything -- and `watch_bugs` scanned the
+file it was writing. Every line it emitted matched a signature on the next
+poll, so each hit quoted the previous one verbatim:
+
+    NOT-BUILDABLE assembly0.json:1934: "verdict": "NOT BUILDABLE",
+    NOT-BUILDABLE watch_bugs.log:2: NOT-BUILDABLE assembly0.json:1934: ...
+    NOT-BUILDABLE watch_bugs.log:3: NOT-BUILDABLE watch_bugs.log:2: ...
+    NOT-BUILDABLE watch_bugs.log:4: NOT-BUILDABLE logs/p0_assembly.log:288: ...
+
+Eight lines in, ONE real finding had become six nested copies of itself. That
+is the same class as the `.md` exclusion this module already documents --
+narration is not an incident -- except self-amplifying, so it does not pad the
+log, it destroys it. The run's report is REQUIRED to quote every line each
+watcher emitted, so this defect attacks the deliverable directly.
+
+Two halves are pinned here: the exclusion works, and it is narrow enough that
+a tool log is still scanned. An over-broad fix would be worse than the bug --
+a watcher that scans nothing reports nothing, and reports it quietly.
+"""
+import os
+import sys
+import tempfile
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for p in (REPO, os.path.join(REPO, 'tests', 'stress')):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+import run_watch as RW
+
+passed = failed = 0
+
+
+def check(name, ok, detail=""):
+    global passed, failed
+    passed += bool(ok)
+    failed += not ok
+    print(f"  {'OK  ' if ok else 'FAIL'} {name}{(' -- ' + detail) if detail else ''}")
+
+
+d = tempfile.mkdtemp()
+os.makedirs(os.path.join(d, 'logs'), exist_ok=True)
+
+
+def w(rel, text):
+    path = os.path.join(d, rel)
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(text)
+    return path
+
+
+# A real tool log, a real tool report, and the watcher's own output quoting it.
+tool = w(os.path.join('logs', 'p0_assembly.log'), 'VERDICT: NOT BUILDABLE\n')
+report = w('assembly0.json', '{"verdict": "NOT BUILDABLE"}\n')
+selflog = w('watch_bugs.log',
+            'WATCHING for problems\n'
+            'NOT-BUILDABLE assembly0.json:1: "verdict": "NOT BUILDABLE",\n')
+cheatlog = w('watch_cheats.log', 'FLOOR --clearance in logs/x.log:1\n')
+timerlog = w('watch_timer.log', 'TIMER START 13:29:59\n')
+journal = w('JOURNAL.md', 'the board went NOT BUILDABLE -> buildable\n')
+
+walked = {os.path.relpath(p, d).replace('\\', '/') for p in RW._walk(d)}
+
+check("the tool's log is still scanned", 'logs/p0_assembly.log' in walked,
+      str(sorted(walked)))
+check("the tool's JSON report is still scanned", 'assembly0.json' in walked,
+      str(sorted(walked)))
+check("the bug watcher's OWN log is not scanned",
+      'watch_bugs.log' not in walked, str(sorted(walked)))
+check("nor a SIBLING watcher's log (three watchers, one work dir)",
+      'watch_cheats.log' not in walked and 'watch_timer.log' not in walked,
+      str(sorted(walked)))
+check("the journal is still excluded by extension, as before",
+      'JOURNAL.md' not in walked, str(sorted(walked)))
+
+# Liveness (WATCHED_EXT) adds the journal back and must ALSO drop the watcher
+# logs -- three watchers polling each other is activity that never came from
+# the run, so a stalled run would report as alive forever.
+live = {os.path.relpath(p, d).replace('\\', '/')
+        for p in RW._walk(d, RW.WATCHED_EXT)}
+check("liveness counts the journal", 'JOURNAL.md' in live, str(sorted(live)))
+check("liveness does NOT count watcher chatter as run activity",
+      not [n for n in live if n.startswith('watch_')], str(sorted(live)))
+
+# --------------------------------------------------------------------------
+# The inode path, which is the one that does not depend on the naming
+# convention. A watcher redirected to a file called anything at all must still
+# skip it.
+# --------------------------------------------------------------------------
+odd = w('run-output-2026.log', 'NOT BUILDABLE\n')
+check("a differently-named file is scanned by default",
+      'run-output-2026.log' in walked or os.path.isfile(odd),
+      "sanity: it exists and the convention does not cover it")
+
+st = os.stat(odd)
+if not st.st_ino:
+    print("       NOTE st_ino is 0 on this platform; the inode half of the "
+          "check cannot be exercised here and the name convention is the "
+          "only guard. Reported rather than skipped silently.")
+else:
+    saved = RW._SELF_OUTPUT_IDS
+    try:
+        RW._SELF_OUTPUT_IDS = {(st.st_dev, st.st_ino)}
+        check("a watcher's output is skipped by INODE, whatever it is called",
+              RW._is_self_output(odd), odd)
+        check("...and that does not spill onto other files",
+              not RW._is_self_output(tool), tool)
+        walked2 = {os.path.relpath(p, d).replace('\\', '/')
+                   for p in RW._walk(d)}
+        check("so _walk drops it too", 'run-output-2026.log' not in walked2,
+              str(sorted(walked2)))
+    finally:
+        RW._SELF_OUTPUT_IDS = saved
+
+check("_self_output_ids returns a set of (dev, ino) pairs, or empty",
+      isinstance(RW._self_output_ids(), set)
+      and all(isinstance(x, tuple) and len(x) == 2
+              for x in RW._self_output_ids()),
+      str(RW._self_output_ids()))
+
+# --------------------------------------------------------------------------
+# The feedback loop itself: scanning a watcher log finds hits, which is WHY
+# excluding it matters. If this ever stops finding hits, the exclusion has
+# become untested rather than unnecessary.
+# --------------------------------------------------------------------------
+hits = RW._scan_text(selflog, set(), 'watch_bugs.log')
+check("a watcher log DOES match the signatures (the loop was real)",
+      hits, f"{len(hits)} hit(s): {hits[:1]}")
+
+print(f"\n{passed} passed, {failed} failed")
+sys.exit(1 if failed else 0)

--- a/tests/test_run22_containment_repair.py
+++ b/tests/test_run22_containment_repair.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""A part buried inside another part's body is DISCLOSED, GATED and REPAIRED.
+
+Run 22 shipped a board every gate called buildable while RN3 sat wholly inside
+U5's body and RN7 inside U6's. Prevention landed first
+(`reconstruct._pair_conflicts` refuses such a candidate pose); this file covers
+the rest of the loop end to end on a real board.
+
+**The fixture is the delicate part, and two obvious ones are vacuous.** A
+containment planted anywhere that also produces a PAD INTERSECTION proves
+nothing: `repair_placement` already charged pad conflicts, so `legalize` moves
+the part for the other reason and the containment clears as a side effect --
+measured, such a fixture passes identically with the containment census
+stashed out. And a marker planted inside a body proves nothing if the marker
+has no `.Fab` geometry (tigard's H1..H4 are all `fab_unjudged`), because no
+pair is formed at all.
+
+So the subject here is **D3 inside U5** -- `contained 1, gating 1,
+blocking_pairs []`, a containment and nothing else, which is run 22's exact
+shape. A/B against the stashed census:
+
+    with census      Containment census: 1 part(s) ... -> 1 repaired, contained 0
+    without census   (silent)                          -> 0 repaired, 0 unrepairable
+
+The control is **TP1 at the same coordinates**: same board, same host, same
+geometry, only the part class differs -- contained, but `marker_class`, so it
+neither gates nor moves.
+
+Run: python3 -X utf8 tests/test_run22_containment_repair.py
+"""
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+for _p in ('py_router', 'py_tools', 'py_placer'):
+    sys.path.insert(0, os.path.join(ROOT, _p))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+os.environ.setdefault('KRT_NO_BANNER', '1')
+
+from run_utils import tool as _tool                            # noqa: E402
+from kicad_parser import parse_kicad_pcb                       # noqa: E402
+from placement.legality import grade_body_overlap              # noqa: E402
+from placement.writer import write_placed_output               # noqa: E402
+from copy_board import SIBLING_EXTS                            # noqa: E402
+
+SKIP_EXIT = 77
+BOARD = os.path.join(ROOT, 'kicad_files', 'tigard.kicad_pcb')
+MARKER_BOARD = os.path.join(ROOT, 'kicad_files',
+                            'orangecrab_ext_pll.kicad_pcb')
+
+# U5's fab body centre. D3 (0.8x1.6) sits wholly inside it at frac 1.0 with no
+# pad of any other part within reach -- found by sweeping every (small, host)
+# pair on the board for a containment with zero pad clash.
+U5_CENTRE = (62.27, 60.90)
+
+FAILURES = []
+
+
+def check(name, cond, detail=''):
+    print(f'  {"PASS" if cond else "FAIL"}  {name}'
+          + (f'\n        {detail}' if not cond and detail else ''))
+    if not cond:
+        FAILURES.append(name)
+
+
+def _run(script, *argv):
+    return subprocess.run([sys.executable, '-X', 'utf8', _tool(script), *argv],
+                          capture_output=True, text=True, encoding='utf-8',
+                          errors='replace', cwd=ROOT, timeout=1800)
+
+
+def _grade(path):
+    return grade_body_overlap(parse_kicad_pcb(path), 0.15, pcb_file=path)
+
+
+def _summary(stdout):
+    for line in stdout.splitlines():
+        if line.startswith('JSON_SUMMARY:'):
+            try:
+                return json.loads(line.split(':', 1)[1])
+            except Exception:
+                return None
+    return None
+
+
+def plant_at(src, dst, ref, x, y, td):
+    """Put `ref` at an EXACT board position, deterministically.
+
+    The pose is ASSERTED through `placement.writer.write_placed_output` -- no
+    search, no plan -- which is what makes this a fixture rather than a hope:
+    a perturbation might or might not land inside a body, and a test that only
+    sometimes builds its own subject is not a test. The siblings travel with
+    the board (#441) so every later step grades at the floor it was staged at.
+    Returns an object with `.returncode` (0 = planted), like the subprocess
+    result the callers were written against.
+    """
+    from types import SimpleNamespace
+    try:
+        fp = parse_kicad_pcb(src).footprints[ref]
+        ok = write_placed_output(src, dst, [
+            {'reference': ref, 'new_x': float(x), 'new_y': float(y),
+             'new_rotation': float(fp.rotation)}])
+        for ext in SIBLING_EXTS:
+            sib = os.path.splitext(src)[0] + ext
+            if os.path.isfile(sib):
+                shutil.copy2(sib, os.path.splitext(dst)[0] + ext)
+    except Exception as exc:                                 # noqa: BLE001
+        print(f'  plant_at({ref}) failed: {type(exc).__name__}: {exc}')
+        return SimpleNamespace(returncode=1)
+    return SimpleNamespace(returncode=0 if ok and os.path.exists(dst) else 1)
+
+
+def pose_of(path, ref):
+    fp = parse_kicad_pcb(path).footprints[ref]
+    return (round(fp.x, 3), round(fp.y, 3))
+
+
+def main():
+    if not os.path.exists(BOARD):
+        print('SKIP: tigard not present')
+        return SKIP_EXIT
+    td = tempfile.mkdtemp()
+    try:
+        base = os.path.join(td, 'base.kicad_pcb')
+        if _run('copy_board.py', BOARD, base).returncode != 0:
+            print('SKIP: could not stage the board')
+            return SKIP_EXIT
+        check('the fixture board starts with no containment',
+              _grade(base)['contained'] == 0)
+
+        print('a PURE containment (no pad conflict) is disclosed and GATES')
+        dmg = os.path.join(td, 'contained.kicad_pcb')
+        if plant_at(base, dmg, 'D3', U5_CENTRE[0], U5_CENTRE[1],
+                    td).returncode != 0 or not os.path.exists(dmg):
+            print('SKIP: could not plant the fixture')
+            return SKIP_EXIT
+        g = _grade(dmg)
+        check('D3 is wholly inside U5', g['contained'] == 1,
+              str([(q.a, q.b, q.contained_frac)
+                   for q in g['containment_pairs']]))
+        # THE anti-vacuity assertion. If this ever fails, the fixture has
+        # drifted into a pad conflict and every `repaired` check below would
+        # pass with the census removed.
+        check('...and it is the ONLY thing wrong -- no pad conflict',
+              g['blocking'] == 0 and not g['blocking_pairs'],
+              str([(q.a, q.b, q.kind) for q in g['blocking_pairs']]))
+        check('...so it gates on containment alone',
+              g['containment_blocking'] == 1)
+
+        asm = _run('check_assembly.py', dmg, '--clearance', '0.15')
+        check('check_assembly refuses the board', asm.returncode == 4,
+              f'exit {asm.returncode}')
+        check('...and says why', 'CONTAINMENT' in asm.stdout, asm.stdout[-300:])
+
+        print('legalize REPAIRS it -- the census is what makes this pass')
+        out = os.path.join(td, 'fixed.kicad_pcb')
+        r = _run('place_reconstruct.py', dmg, out,
+                 '--stages', 'classify,legalize', '--clearance', '0.15')
+        check('the containment census fires',
+              'Containment census' in r.stdout, r.stdout[-300:])
+        leg = (_summary(r.stdout) or {}).get('legalize') or {}
+        check('legalize repairs D3', 'D3' in set(leg.get('repaired') or []),
+              str(leg))
+        if os.path.exists(out):
+            after = _grade(out)
+            check('...and the containment is GONE from the output',
+                  after['containment_blocking'] == 0,
+                  str([(q.a, q.b) for q in after['containment_blocking_pairs']]))
+            check('...and check_assembly now accepts it',
+                  _run('check_assembly.py', out,
+                       '--clearance', '0.15').returncode == 0)
+        else:
+            check('the output board was written', False, r.stdout[-300:])
+
+        print('the paired control: a MARKER at the SAME pose is exempt')
+        # Only the part class differs from the case above. tigard's H1..H4 draw
+        # no .Fab geometry and would form no pair at all, so the marker has to
+        # be TP1 -- a testpoint WITH a body -- or this proves nothing.
+        mk = os.path.join(td, 'marker.kicad_pcb')
+        if plant_at(base, mk, 'TP1', U5_CENTRE[0], U5_CENTRE[1],
+                    td).returncode == 0 and os.path.exists(mk):
+            gm = _grade(mk)
+            check('TP1 is equally contained', gm['contained'] == 1,
+                  str([(q.a, q.b, q.contained_frac)
+                       for q in gm['containment_pairs']]))
+            check('...but does NOT gate', gm['containment_blocking'] == 0,
+                  str([(q.a, q.b, q.waiver) for q in gm['containment_pairs']]))
+            mo = os.path.join(td, 'marker_out.kicad_pcb')
+            _run('place_reconstruct.py', mk, mo,
+                 '--stages', 'classify,legalize', '--clearance', '0.15')
+            if os.path.exists(mo):
+                check('...and legalize does not move it',
+                      pose_of(mo, 'TP1') == pose_of(mk, 'TP1'),
+                      f'{pose_of(mk, "TP1")} -> {pose_of(mo, "TP1")}')
+        else:
+            check('the marker case could be planted', False)
+
+        print('a containment it CANNOT reach is named, never faked')
+        # R18 at U3's centre needs 9.15mm to come home and the cap ladder tops
+        # out at 5.0mm on a board where every other part is at its healthy
+        # pose. Unlike the case above this one ALSO carries a pad conflict, so
+        # it is a contract check on `repair_placement`'s honesty re-grade
+        # rather than a test of the census -- it passes with the census
+        # stashed out, and is kept because reporting an unmoved part as
+        # `repaired` is the failure this whole channel exists to prevent.
+        u3 = parse_kicad_pcb(base).footprints['U3']
+        deep = os.path.join(td, 'deep.kicad_pcb')
+        if plant_at(base, deep, 'R18', u3.x, u3.y, td).returncode == 0 \
+                and os.path.exists(deep):
+            r = _run('place_reconstruct.py', deep,
+                     os.path.join(td, 'deep_out.kicad_pcb'),
+                     '--stages', 'classify,legalize', '--clearance', '0.15')
+            leg = (_summary(r.stdout) or {}).get('legalize') or {}
+            check('it is NOT reported repaired',
+                  'R18' not in set(leg.get('repaired') or []), str(leg))
+            check('...it is named unrepairable',
+                  'R18' in set(leg.get('unrepairable') or []), str(leg))
+            check('...and the run does not exit clean', r.returncode != 0,
+                  f'exit {r.returncode}')
+
+        print('the corpus case the exemption was written for')
+        if os.path.exists(MARKER_BOARD):
+            go = _grade(MARKER_BOARD)
+            check('orangecrab_ext_pll ships 2 real containments',
+                  go['contained'] == 2, str(go['contained']))
+            check('...both marker_class, so none gates',
+                  go['containment_blocking'] == 0,
+                  str([(q.a, q.b, q.waiver) for q in go['containment_pairs']]))
+        else:
+            print('  (absent)')
+    finally:
+        shutil.rmtree(td, ignore_errors=True)
+
+    print()
+    if FAILURES:
+        print(f'FAIL: {len(FAILURES)} check(s): {", ".join(FAILURES)}')
+        return 1
+    print('OK')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_run22_driver_workdir.py
+++ b/tests/test_run22_driver_workdir.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""The skill drivers must be able to point at the work dir being audited.
+
+Run 22 ran three watchers over `wk/run22/tigard` and they reported a clean
+run. They could not have reported otherwise: `run_watch --workdir`,
+`fence_audit --workdir` and `provenance_audit --workdir` each walk ONLY the
+directory they are given, and both drivers emitted instructions hardcoding a
+relative `wk/locks.json`, `wk/drc0.json`, `wk/score.json` and ~70 more. Those
+resolve against the process CWD, so the artifacts landed outside every audit.
+
+That is a hole in the EVIDENCE rather than a cosmetic path problem: the
+watchers were not wrong, they were pointed at a directory that half the run's
+artifacts never entered.
+
+Run: python3 -X utf8 tests/test_run22_driver_workdir.py
+"""
+import os
+import re
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+os.environ.setdefault('KRT_NO_BANNER', '1')
+
+PLACE = os.path.join(ROOT, '.claude', 'skills', 'plan-pcb-placement',
+                     'scripts', 'placement_driver.py')
+LOOP = os.path.join(ROOT, '.claude', 'skills',
+                    'plan-pcb-placement-and-routing', 'scripts',
+                    'loop_driver.py')
+
+FAILURES = []
+
+
+def check(name, cond, detail=''):
+    print(f'  {"PASS" if cond else "FAIL"}  {name}'
+          + (f'\n        {detail}' if not cond and detail else ''))
+    if not cond:
+        FAILURES.append(name)
+
+
+def run(script, *argv):
+    env = dict(os.environ, PYTHONIOENCODING='utf-8', KRT_NO_BANNER='1')
+    r = subprocess.run([sys.executable, '-X', 'utf8', script, *argv],
+                       capture_output=True, text=True, env=env, cwd=ROOT)
+    return r.stdout + r.stderr
+
+
+#: The self-tests build boards in a fresh TemporaryDirectory each run, so two
+#: invocations legitimately differ by that name and nothing else.
+_TMP = re.compile(r'tmp[a-z0-9_]{6,}')
+
+
+def main():
+    print('the emitted instructions follow --workdir')
+    out = run(PLACE, '--stage', 'P0', '--board', 'b.kicad_pcb',
+              '--workdir', 'wk/run23/tigard')
+    check('a retargeted stage names the caller\'s dir',
+          'wk/run23/tigard/drc0.json' in out, out[:300])
+    check('...and no bare wk/ path survives',
+          not re.search(r'(?<![\w./-])wk/(?!run23)', out),
+          [m for m in re.findall(r'(?<![\w./-])wk/[\w./-]*', out)][:6])
+
+    print('the default is byte-identical -- the compatibility gate')
+    # Both drivers carry large embedded self-test suites that construct args
+    # WITHOUT --workdir. The default short-circuits so their expectations do
+    # not have to be rewritten, which is the whole reason the default is 'wk'
+    # rather than None.
+    for name, script in (('placement_driver', PLACE), ('loop_driver', LOOP)):
+        a = _TMP.sub('TMP', run(script, '--dump-all'))
+        b = _TMP.sub('TMP', run(script, '--dump-all', '--workdir', 'wk'))
+        check(f'{name} --dump-all is unchanged by an explicit default',
+              a == b, 'the short-circuit is broken')
+
+    print('the ledger the loop driver resolves ITSELF follows too')
+    sys.path.insert(0, os.path.dirname(LOOP))
+    import loop_driver as L
+    check('the old default is preserved exactly',
+          L._args(['--stage', 'L1', '--board', 'b']).ledger
+          == 'wk/ledger.jsonl')
+    check('and a named work dir carries the ledger into it',
+          L._args(['--stage', 'L1', '--board', 'b',
+                   '--workdir', 'wk/run23/x']).ledger
+          == 'wk/run23/x/ledger.jsonl',
+          'the ledger would sit outside the audited dir')
+
+    print('real repo artifacts under wk/ are NOT retargeted')
+    # `wk/calibration/RESULT.md` and `wk/run11/...` are prose references to
+    # things that exist in the repo, not work paths the caller owns.
+    keep = L._retarget('see wk/calibration/RESULT.md and write wk/score.json',
+                       'wk/run23/x')
+    check('a calibration reference survives',
+          'wk/calibration/RESULT.md' in keep, keep)
+    check('...while a work path beside it is retargeted',
+          'wk/run23/x/score.json' in keep, keep)
+
+    print('both self-test suites still pass')
+    for name, script in (('placement_driver', PLACE), ('loop_driver', LOOP)):
+        env = dict(os.environ, PYTHONIOENCODING='utf-8', KRT_NO_BANNER='1')
+        rc = subprocess.run([sys.executable, '-X', 'utf8', script,
+                             '--self-test'], capture_output=True, text=True,
+                            env=env, cwd=ROOT).returncode
+        check(f'{name} --self-test exits 0', rc == 0, f'exit {rc}')
+
+    print()
+    if FAILURES:
+        print(f'FAIL: {len(FAILURES)} check(s): {", ".join(FAILURES)}')
+        return 1
+    print('OK')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_run22_seat_containment_gate.py
+++ b/tests/test_run22_seat_containment_gate.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""`candidate_valid` refuses a seat that buries a part in another part's body.
+
+`reconstruct._pair_conflicts` refuses an assign/exchange CANDIDATE, but
+`candidate_valid` is what `pose_ok`, `_try_place`, `legalize` and every quench
+pass actually accept a pose with -- and it was body-blind. A part could be
+re-seated straight back into the body it had just been charged for, and
+`_try_place`'s clearance ladder (full, full/2, 0.02) makes that seat MORE
+reachable, not less.
+
+**The fixture had to be hunted, because the obvious ones prove nothing.** On
+tigard and watchy the term blocks NOTHING: a courtyard contains its own body,
+so the courtyard and pad conjuncts already reject every containment pose there.
+Measured, same-side non-exempt containment poses accepted by `candidate_valid`:
+
+    board                gate ON   gate OFF   blocked by this term
+    tigard                     0          0     0   (already rejected)
+    watchy                     0          0     0   (already rejected)
+    esp_prog                   0          0     0   (already rejected)
+    orangecrab_ext_pll         0        696   696
+    ulx3s                    114      27132   27018
+
+(The zero rows are NOT "no such pose exists" -- tigard sweeps 139183 such
+poses, esp_prog 1776. Every one is already refused by the courtyard or pad
+conjunct, which is the whole reason this term looks inert until you find a
+board where it is not.)
+
+So the subject is **ulx3s**, where the term is load-bearing, and the pose is one
+found by sweeping for `gate ON rejects AND gate OFF accepts` -- the only
+definition of a non-vacuous fixture here. Two earlier candidates were rejected
+during development because BOTH arms said False: another conjunct was doing the
+work and the test would have passed with the term deleted.
+
+(ulx3s's 114 residue is not a hole: every one sits at exactly frac 0.500, the
+`CONTAINMENT_FRAC` boundary, where the sweep's file-parsed rect and the state's
+own `fab_rect` disagree in the last bit.)
+
+Run: python3 -X utf8 tests/test_run22_seat_containment_gate.py
+"""
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+for _p in ('py_router', 'py_tools', 'py_placer'):
+    sys.path.insert(0, os.path.join(ROOT, _p))
+os.environ.setdefault('KRT_NO_BANNER', '1')
+
+from kicad_parser import parse_kicad_pcb                       # noqa: E402
+from placement import quench as Q                              # noqa: E402
+from placement.quench import QuenchState                       # noqa: E402
+from placement.legality import CONTAINMENT_FRAC                # noqa: E402
+import routing_defaults as defaults                            # noqa: E402
+
+SKIP_EXIT = 77
+ULX3S = os.path.join(ROOT, 'kicad_files', 'ulx3s.kicad_pcb')
+TIGARD = os.path.join(ROOT, 'kicad_files', 'tigard.kicad_pcb')
+
+# C2 wholly inside U9's body (U9 spans x 108.300..126.300, y 87.015..118.415).
+BURIED = (109.3, 87.515)
+# Walking C2 out of U9's right edge: 0.500 is the last contained step, 0.375
+# the first free one. The threshold is `>=`, so both sides are asserted.
+AT_THRESHOLD = (126.3, 87.515)     # frac exactly 0.500
+KISS = (126.7, 87.515)             # frac 0.250
+# tigard: U5's body centre. D3 buried there is the run-22 defect shape; TP1 at
+# the SAME point is the paired control -- a testpoint, so marker_class.
+U5_CENTRE = (62.27, 60.90)
+
+FAILURES = []
+
+
+def check(name, cond, detail=''):
+    print(f'  {"PASS" if cond else "FAIL"}  {name}'
+          + (f'\n        {detail}' if not cond and detail else ''))
+    if not cond:
+        FAILURES.append(name)
+
+
+def state(path):
+    return QuenchState(parse_kicad_pcb(path), path, clearance=0.15,
+                       board_edge_clearance=0.55, crossing_penalty=10.0,
+                       halo_base=0.5, halo_coef=0.25, halo_weight=2.0,
+                       edge_halo=2.0, edge_weight=2.0,
+                       grid_step=defaults.GRID_STEP, length_weight=1.0)
+
+
+def main():
+    if not os.path.exists(ULX3S) or not os.path.exists(TIGARD):
+        print('SKIP: corpus boards not present')
+        return SKIP_EXIT
+
+    was = Q._CONTAINMENT_GATE
+    try:
+        st = state(ULX3S)
+
+        print('the seat gate refuses a buried pose -- and ONLY it does')
+        Q._CONTAINMENT_GATE = True
+        check('the pose IS a containment by the engine s own term',
+              st._body_contained_at('C2', BURIED[0], BURIED[1], 0.0))
+        check('candidate_valid refuses it',
+              not st.candidate_valid('C2', BURIED[0], BURIED[1], 0.0))
+        # THE anti-vacuity assertion, and the reason this file names ulx3s
+        # rather than tigard. If another conjunct also rejected this pose, the
+        # test would pass with the term deleted and prove nothing.
+        Q._CONTAINMENT_GATE = False
+        check('...and with the term disabled it is ACCEPTED, so the term is '
+              'what rejected it',
+              st.candidate_valid('C2', BURIED[0], BURIED[1], 0.0),
+              'another conjunct now rejects this pose too -- the fixture has '
+              'gone vacuous and must be re-hunted, not relaxed')
+        Q._CONTAINMENT_GATE = True
+
+        print('it does not over-refuse: a KISS is not a containment')
+        check('a 0.25-frac overlap is not charged',
+              not st._body_contained_at('C2', KISS[0], KISS[1], 0.0))
+        check('...while the threshold step itself is',
+              st._body_contained_at('C2', AT_THRESHOLD[0], AT_THRESHOLD[1],
+                                    0.0),
+              f'CONTAINMENT_FRAC is {CONTAINMENT_FRAC} and the comparison is '
+              f'>=, so frac 0.500 must count')
+
+        print('the exemption reaches the SEAT path too')
+        # Or a displaced fiducial could never come home under a connector --
+        # orangecrab ships FID2 inside J5 at frac 1.000 by design.
+        tg = state(TIGARD)
+        check('D3 buried in U5 is charged',
+              tg._body_contained_at('D3', U5_CENTRE[0], U5_CENTRE[1], 0.0))
+        check('...but TP1 at the SAME point is not (marker_class)',
+              not tg._body_contained_at('TP1', U5_CENTRE[0], U5_CENTRE[1],
+                                        0.0),
+              'only the part CLASS differs between these two calls')
+
+        print('a healthy board is undisturbed')
+        d3 = parse_kicad_pcb(TIGARD).footprints['D3']
+        check('a part at its own shipped pose is not contained',
+              not tg._body_contained_at('D3', d3.x, d3.y, d3.rotation or 0.0))
+        check('...and its own pose is still a valid candidate',
+              tg.candidate_valid('D3', d3.x, d3.y, d3.rotation or 0.0))
+    finally:
+        Q._CONTAINMENT_GATE = was
+
+    print()
+    if FAILURES:
+        print(f'FAIL: {len(FAILURES)} check(s): {", ".join(FAILURES)}')
+        return 1
+    print('OK')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_run23_budget_honesty.py
+++ b/tests/test_run23_budget_honesty.py
@@ -1,0 +1,73 @@
+"""emit-intent must not bake a budget that blesses the board it came from.
+
+Run 23: the intent was emitted mid-repair from a board carrying J4 0.90mm
+inside U6's courtyard. It baked legality_budget.overlap_area = 30.1085 (the
+board's own number, ceil'd), and the final board's 26.302 then graded PASS --
+the budget blessed the defect it was emitted over. The run-6 withholding
+(body-blocking pairs freeze overlap_area) did not fire because no PAD pair
+blocked.
+
+The extension pinned here: unwaived courtyard interpenetrations past the
+blocking floors (legality.COURTYARD_BLOCKING_MIN_*) also withhold
+overlap_area, and the reason is recorded in context.budget_withheld so a
+reader can tell "withheld" from "forgot". Healthy boards without such pairs
+bake budgets exactly as before.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+
+PLACED = os.path.join(ROOT, 'tests', 'fixtures', 'run23',
+                      'tigard_placed.kicad_pcb')
+SPLITFLAP = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
+RUN5 = os.path.join(ROOT, 'wk', 'run5', 'final5.kicad_pcb')
+
+
+def _emit(board):
+    env = dict(os.environ, PYTHONPATH=ROOT, PYTHONIOENCODING='utf-8',
+               KRT_NO_BANNER='1')
+    with tempfile.TemporaryDirectory() as td:
+        jp = os.path.join(td, 'intent.json')
+        r = subprocess.run(
+            [sys.executable, '-X', 'utf8',
+             os.path.join(ROOT, 'py_tools', 'check_floorplan.py'),
+             board, '--emit-intent', jp],
+            capture_output=True, text=True, env=env, cwd=ROOT)
+        assert r.returncode == 0, r.stdout[-400:] + r.stderr[-400:]
+        return json.load(open(jp, encoding='utf-8'))
+
+
+class TestBudgetWithholding(unittest.TestCase):
+    def test_courtyard_blocking_board_gets_no_overlap_budget(self):
+        doc = _emit(PLACED)
+        self.assertNotIn('overlap_area', doc['legality_budget'])
+        withheld = doc['context']['budget_withheld']
+        self.assertIn('overlap_area', withheld)
+        self.assertIn('courtyard', withheld['overlap_area'])
+        # The rest of the budget survives: oob is independently judged.
+        self.assertIn('oob_count', doc['legality_budget'])
+
+    def test_healthy_board_bakes_budget_unchanged(self):
+        doc = _emit(SPLITFLAP)
+        self.assertIn('overlap_area', doc['legality_budget'])
+        self.assertEqual(doc['context']['budget_withheld'], {})
+
+    def test_run6_body_blocking_withholding_still_fires_first(self):
+        """The older, stronger reason must not be shadowed by the new one."""
+        if not os.path.exists(RUN5):
+            self.skipTest('run-5 deliverable not present')
+        doc = _emit(RUN5)
+        self.assertNotIn('overlap_area', doc['legality_budget'])
+        withheld = doc['context']['budget_withheld']
+        self.assertIn('blocking body', withheld['overlap_area'])
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=1)

--- a/tests/test_run23_connector_affinity.py
+++ b/tests/test_run23_connector_affinity.py
@@ -1,0 +1,114 @@
+"""connector_affinity: generic connectors get a WEAK class (run-23).
+
+Run 23 seated J2/J5/J6/J7 mid-board and no instrument could say so: generic
+connector keywords deliberately map to NO edge class (a JST wire-to-board
+part is legitimately interior -- that guard stands), and a part with no
+class is invisible to every intent rule. The weak class exists to be
+DECLARED (--declare-classes) and graded at ADVISORY severity: an INTERIOR
+pose (past part_class.INTERIOR_AFFINITY_MM from every edge) is a warning for
+the boundary review, never an error, and `pass` never flips on it.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for p in (ROOT, os.path.join(ROOT, 'py_router'), os.path.join(ROOT, 'py_placer')):
+    sys.path.insert(0, p)
+
+PLACED = os.path.join(ROOT, 'tests', 'fixtures', 'run23',
+                      'tigard_placed.kicad_pcb')
+SPLITFLAP = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
+
+
+def _cf(*argv):
+    env = dict(os.environ, PYTHONPATH=ROOT, PYTHONIOENCODING='utf-8',
+               KRT_NO_BANNER='1')
+    return subprocess.run(
+        [sys.executable, '-X', 'utf8',
+         os.path.join(ROOT, 'py_tools', 'check_floorplan.py'), *argv],
+        capture_output=True, text=True, env=env, cwd=ROOT)
+
+
+class TestClass(unittest.TestCase):
+    def test_generic_connectors_classify_weak_not_edge(self):
+        from kicad_parser import parse_kicad_pcb
+        from placement.part_class import (MECHANICAL_CLASSES, classify_part,
+                                          pose_plausible)
+        pcb = parse_kicad_pcb(PLACED)
+        for ref in ('J2', 'J4', 'J5', 'J6', 'J7'):
+            cls = classify_part(pcb.footprints[ref], ref)
+            self.assertEqual(cls.name, 'connector_affinity', ref)
+            self.assertEqual(cls.confidence, 'low', ref)
+        # The class makes NO pose claim and is NOT mechanically pinned --
+        # both would change reconstruct/stager behavior, which this class
+        # must never do.
+        self.assertNotIn('connector_affinity', MECHANICAL_CLASSES)
+        self.assertTrue(pose_plausible('connector_affinity', 0.0, 99.0))
+        # The receptacle guard stands: J1 (USB-C) is still edge_receptacle.
+        self.assertEqual(classify_part(pcb.footprints['J1'], 'J1').name,
+                         'edge_receptacle')
+
+
+class TestDeclareAndGrade(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.td = tempfile.TemporaryDirectory()
+        cls.intent = os.path.join(cls.td.name, 'intent.json')
+        r = _cf(PLACED, '--emit-intent', cls.intent, '--declare-classes')
+        assert r.returncode == 0, r.stdout[-400:]
+        cls.grade = os.path.join(cls.td.name, 'grade.json')
+        cls.gr = _cf(PLACED, '--intent', cls.intent, '--json', cls.grade)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.td.cleanup()
+
+    def test_declare_classes_declares_the_connector_family(self):
+        doc = json.load(open(self.intent, encoding='utf-8'))
+        by_ref = {c['ref']: c for c in doc['edge_connectors']}
+        for ref in ('J2', 'J4', 'J5', 'J6', 'J7'):
+            self.assertIn(ref, by_ref, 'connector not declared')
+            self.assertEqual(by_ref[ref]['class'], 'connector_affinity')
+            # NO invented edge (the run-4 rule): the note carries the
+            # measured distance instead.
+            self.assertNotIn('edge', by_ref[ref])
+            self.assertIn('measured', by_ref[ref]['note'])
+        self.assertEqual(by_ref['J1']['class'], 'edge_receptacle')
+
+    def test_interior_connector_flags_advisory_pass_survives(self):
+        self.assertEqual(self.gr.returncode, 0, self.gr.stdout[-400:])
+        doc = json.load(open(self.grade, encoding='utf-8'))
+        self.assertTrue(doc['pass'])
+        sev = [v['severity'] for v in doc['violations']]
+        self.assertNotIn('error', sev)
+        # J4 sits 6.03mm interior: flagged, as a WARNING.
+        j4 = [v for v in doc['violations'] if v['ref'] == 'J4']
+        self.assertEqual([v['severity'] for v in j4], ['warn'])
+        self.assertEqual(j4[0]['expected'], {'max_setback_mm': 3.0})
+        self.assertIn('J4 is an edge part seated', self.gr.stdout)
+        self.assertIn('[warn ]', self.gr.stdout)
+        # J7 (2.55mm, inside the affinity band) must NOT be flagged --
+        # legitimately-interior connectors are the false-positive guard.
+        self.assertNotIn('J7 is an edge part seated', self.gr.stdout)
+
+    def test_healthy_board_gains_no_errors(self):
+        with tempfile.TemporaryDirectory() as td:
+            intent = os.path.join(td, 'i.json')
+            r = _cf(SPLITFLAP, '--emit-intent', intent, '--declare-classes')
+            self.assertEqual(r.returncode, 0, r.stdout[-400:])
+            g = os.path.join(td, 'g.json')
+            r2 = _cf(SPLITFLAP, '--intent', intent, '--json', g)
+            self.assertEqual(r2.returncode, 0, r2.stdout[-400:])
+            doc = json.load(open(g, encoding='utf-8'))
+            self.assertTrue(doc['pass'])
+            self.assertNotIn(
+                'error', [v['severity'] for v in doc['violations']])
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=1)

--- a/tests/test_run23_courtyard_channel.py
+++ b/tests/test_run23_courtyard_channel.py
@@ -1,0 +1,302 @@
+"""The run-23 courtyard channel: census absolute, gate moved-vs-baseline.
+
+Run 23 shipped a board every gate called buildable while J4 stood 0.90mm
+inside U6's courtyard (5.56mm2), J3 interpenetrated R13 and RN3 still sat
+0.83mm2 into U5 -- residue of the staged damage the repair moved but never
+cleared. The courtyard channel existed and was advisory everywhere.
+
+Why the gate is moved-vs-baseline and NOT absolute, measured on this repo's
+own corpus before this landed: 5 of 34 healthy human boards (glasgow_revC,
+orangecrab_ext_pll, rp2350_fpga_eensy_prePlane, ulx3s, watchy) ship unwaived
+courtyard interpenetrations past any sane area/depth floor -- ulx3s GPDI1<->
+U11 at 38.5mm2 / depth 5.1, rp2350 U3 frac-1.0 inside J2 -- all by design
+(parts under connector shells). An absolute conjunct flips them all NOT
+BUILDABLE. A pair therefore gates only when a MEMBER MOVED relative to
+--baseline: a pristine board graded against itself can never flip, while a
+repair run owns every pair its moves created or failed to clear.
+
+And why moved-MEMBER rather than new-PAIR: RN3<->U5 exists in the damaged
+baseline too (the staged containment). A membership test calls it
+pre-existing and misses it; the repair moved RN3 3.28mm, so the moved test
+charges it. That distinction is pinned here because it is exactly the kind
+of clause a cleanup would simplify away.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+
+PLACED = os.path.join(ROOT, 'tests', 'fixtures', 'run23',
+                      'tigard_placed.kicad_pcb')
+DAMAGED = os.path.join(ROOT, 'tests', 'fixtures', 'run23',
+                       'tigard_damaged.kicad_pcb')
+ULX3S = os.path.join(ROOT, 'kicad_files', 'ulx3s.kicad_pcb')
+
+
+def _run(*argv):
+    env = dict(os.environ, PYTHONPATH=ROOT, PYTHONIOENCODING='utf-8',
+               KRT_NO_BANNER='1')
+    return subprocess.run(
+        [sys.executable, '-X', 'utf8',
+         os.path.join(ROOT, 'py_tools', 'check_assembly.py'), *argv],
+        capture_output=True, text=True, env=env, cwd=ROOT)
+
+
+def _grade(board, *extra):
+    with tempfile.TemporaryDirectory() as td:
+        jp = os.path.join(td, 'a.json')
+        r = _run(board, '--json', jp, *extra)
+        return r, json.load(open(jp, encoding='utf-8'))
+
+
+class TestRun23Board(unittest.TestCase):
+    """The board run 23 actually shipped, graded the way the run should."""
+
+    def test_gates_against_the_damaged_baseline(self):
+        r, doc = _grade(PLACED, '--baseline', DAMAGED)
+        self.assertEqual(r.returncode, 4, r.stdout[-600:])
+        self.assertFalse(doc['buildable'])
+        self.assertIn('NOT BUILDABLE', r.stdout)
+        self.assertEqual(doc['courtyard_blocking_gating'], 9)
+        self.assertEqual(doc['courtyard_gating_basis'], 'moved-vs-baseline')
+        gating = {(q['a'], q['b'])
+                  for q in doc['courtyard_blocking_gating_pairs']}
+        self.assertEqual(gating, {('J4', 'U6'), ('J3', 'R13'),
+                                  ('RN3', 'U5'), ('SW1', 'U1'),
+                                  ('J1', 'SW1'), ('J1', 'SW2'),
+                                  ('J1', 'R5'), ('J4', 'R21'),
+                                  ('H2', 'J3')})
+        # `blocking` (pad intersections) must NOT have moved -- it has three
+        # consumers and this board has none.
+        self.assertEqual(doc['blocking'], 0)
+
+    def test_moved_member_charges_a_baseline_resident_pair(self):
+        """RN3<->U5 is IN the damaged baseline; a new-pair test misses it."""
+        r, doc = _grade(PLACED, '--baseline', DAMAGED)
+        gating = {(q['a'], q['b'])
+                  for q in doc['courtyard_blocking_gating_pairs']}
+        self.assertIn(('RN3', 'U5'), gating)
+        # And the stdout names WHO moved (RN3; U5 stood still).
+        self.assertIn('GATES (moved: RN3)', r.stdout)
+
+    def test_without_baseline_census_reports_but_never_gates(self):
+        r, doc = _grade(PLACED)
+        self.assertEqual(r.returncode, 0, r.stdout[-600:])
+        self.assertTrue(doc['buildable'])
+        self.assertEqual(doc['courtyard_blocking'], 10)
+        self.assertIsNone(doc['courtyard_blocking_gating'])
+        self.assertEqual(doc['courtyard_gating_basis'],
+                         'no-baseline: report-only')
+        self.assertIn('REPORT-ONLY', r.stdout)
+
+    def test_synthetic_courtyards_never_block(self):
+        """G***'s +/-0.5mm fictional box manufactured a 0.537mm2 'pair'."""
+        _r, doc = _grade(PLACED, '--baseline', DAMAGED)
+        self.assertIn('G***', doc['courtyard_synthetic_refs'])
+        blocked = {(q['a'], q['b']) for q in doc['courtyard_blocking_pairs']}
+        self.assertNotIn(('G***', 'J5'), blocked)
+        # ...but the pair stays VISIBLE in the census (disclosure, not gate).
+        census = {(q['a'], q['b']) for q in doc['courtyard_pairs']}
+        self.assertIn(('G***', 'J5'), census)
+
+    def test_floors_hold_the_true_slivers_out(self):
+        """The RELATIVE floor (user finding): J4<->R21's 0.445mm2 slid
+        under the 0.5mm2 absolute floor while consuming 25.5% of R21's
+        courtyard -- it blocks now. The true slivers (D3<->SW1 0.059mm2 at
+        depth 0.02, frac 0.014) stay advisory: every floor must hold
+        SOMETHING out or it is not a floor."""
+        _r, doc = _grade(PLACED, '--baseline', DAMAGED)
+        blocked = {(q['a'], q['b']) for q in doc['courtyard_blocking_pairs']}
+        self.assertIn(('J4', 'R21'), blocked)
+        self.assertNotIn(('D3', 'SW1'), blocked)
+        self.assertNotIn(('D4', 'SW2'), blocked)
+        census = {(q['a'], q['b']) for q in doc['courtyard_pairs']}
+        self.assertIn(('D3', 'SW1'), census)
+
+    def test_dead_edge_waiver_does_not_hide_the_switches(self):
+        """The user's own finding, pinned: SW1/SW2 collided with parts and
+        NOTHING said so, because edge_class -- a class lookup with no
+        geometry -- waived every pair. The waiver now stands only for a
+        member whose pose is edge-LIVE (overhanging, or within seat
+        tolerance): SW1 sat 2.0mm interior, SW2 8.33mm, so SW1<->U1 and
+        FB1<->SW2 join the blocking census. And a LIVE waiver covers only
+        the MATING ZONE (second user finding): J1 is legitimately at the
+        edge, but R5 sat 45.7% inside J1's INTERIOR courtyard -- under the
+        connector body, 1.5mm inside the outline -- so J1<->R5, J1<->SW1
+        and J1<->SW2 block too; only an overlap that leaves or hugs the
+        outline is mating volume."""
+        _r, doc = _grade(PLACED, '--baseline', DAMAGED)
+        blocked = {(q['a'], q['b']) for q in doc['courtyard_blocking_pairs']}
+        self.assertIn(('SW1', 'U1'), blocked)
+        self.assertIn(('FB1', 'SW2'), blocked)
+        self.assertIn(('J1', 'R5'), blocked)
+        self.assertIn(('J1', 'SW1'), blocked)
+        # FB1<->SW2 is the moved-currency's NAMED blind spot: the damage
+        # placed both and the repair never touched either, so no movement
+        # test can charge it without flipping pristine boards. It must stay
+        # visible in the census while NOT gating.
+        gating = {(q['a'], q['b'])
+                  for q in doc['courtyard_blocking_gating_pairs']}
+        self.assertNotIn(('FB1', 'SW2'), gating)
+
+    def test_locked_and_mount_hole_pairs_face_the_floors(self):
+        """User finding #3, two rules in one pair: H2<->J3 (4.63mm2, depth
+        1.47) hid behind the blanket marker_class waiver. A mounting hole's
+        courtyard is the SCREW-HEAD keepout -- physical, unlike a fiducial's
+        -- and H2 is KiCad-LOCKED, and no class waiver blesses contact with
+        a locked part (the run-8 E6 principle, extended here). Both rules
+        route the pair to the ordinary floors; J3 moved 3.07mm, so it
+        gates. Fiducial/testpoint markers keep the blanket exemption
+        (G***<->TP1 stays out of blocking)."""
+        _r, doc = _grade(PLACED, '--baseline', DAMAGED)
+        blocked = {(q['a'], q['b']) for q in doc['courtyard_blocking_pairs']}
+        self.assertIn(('H2', 'J3'), blocked)
+        self.assertNotIn(('G***', 'TP1'), blocked)
+        gating = {(q['a'], q['b'])
+                  for q in doc['courtyard_blocking_gating_pairs']}
+        self.assertIn(('H2', 'J3'), gating)
+
+    def test_opposite_side_xy_overlap_is_not_a_pair(self):
+        """User question, answered by measurement and pinned: JP2 (a
+        B-side SMD jumper) sits exactly over F-side R16/C25 in XY -- pad
+        gap 0.000mm -- and that is NOT a conflict: opposite faces. The
+        side-aware census must never pair them."""
+        _r, doc = _grade(PLACED)
+        census = {(q['a'], q['b']) for q in doc['courtyard_pairs']}
+        self.assertNotIn(('JP2', 'R16'), census)
+        self.assertNotIn(('C25', 'JP2'), census)
+
+    def test_full_census_is_carried(self):
+        """The 15-pair census the user SAW must be in the JSON, waivers and
+        all -- J1<->SW1 (7.0mm2, edge-waived) is the one a reader asks about
+        first."""
+        _r, doc = _grade(PLACED)
+        census = {(q['a'], q['b']) for q in doc['courtyard_pairs']}
+        self.assertIn(('J1', 'SW1'), census)
+        self.assertGreaterEqual(len(census), 15)
+
+
+class TestRenderCourtyardTruth(unittest.TestCase):
+    """render_placement must SHOW the courtyard channel, not only key it.
+
+    Run 23's board was viewed at L3 with 'overlap 26.30mm2' in the banner and
+    still read clean: courtyards drew as thin gray outlines (overlap looks
+    like tight packing) and the checklist had no key for the courtyard
+    census -- b_body_overlap_pairs is PAD intersections.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.td = tempfile.TemporaryDirectory()
+        jp = os.path.join(cls.td.name, 'r.json')
+        png = os.path.join(cls.td.name, 'r.png')
+        sheet = os.path.join(cls.td.name, 'sheet.png')
+        env = dict(os.environ, PYTHONPATH=ROOT, PYTHONIOENCODING='utf-8',
+                   KRT_NO_BANNER='1')
+        r = subprocess.run(
+            [sys.executable, '-X', 'utf8',
+             os.path.join(ROOT, 'py_tools', 'render_placement.py'),
+             PLACED, '--clearance', '0.15', '--json-out', jp, '-o', png,
+             '--review-sheet', sheet],
+            capture_output=True, text=True, env=env, cwd=ROOT)
+        assert r.returncode == 0, r.stdout[-600:] + r.stderr[-600:]
+        cls.doc = json.load(open(jp, encoding='utf-8'))
+        cls.png_f = png.replace('.png', '_F.png')
+        cls.sheet = sheet
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.td.cleanup()
+
+    def test_checklist_carries_the_courtyard_keys(self):
+        cl = self.doc['checklist']
+        blocked = {(a, b) for a, b, _m, _d in
+                   cl['b_courtyard_blocking_pairs']}
+        self.assertEqual(blocked, {('J4', 'U6'), ('J3', 'R13'),
+                                   ('RN3', 'U5'), ('SW1', 'U1'),
+                                   ('FB1', 'SW2'), ('J1', 'SW1'),
+                                   ('J1', 'SW2'), ('J1', 'R5'),
+                                   ('J4', 'R21'), ('H2', 'J3')})
+        census = {(a, b) for a, b, _m, _d in cl['b_courtyard_overlap_pairs']}
+        # J4<->R21 blocks via the RELATIVE floor (25.5% of R21's courtyard);
+        # the true slivers stay out of the blocking list.
+        self.assertIn(('J4', 'R21'), census)
+        self.assertNotIn(('D3', 'SW1'), blocked)
+        self.assertGreater(cl['b_courtyard_overlap_mm2'], 20.0)
+
+    def test_the_defect_is_in_the_pixels(self):
+        """The C_COURT_OVL fill must be present INSIDE the J4<->U6
+        intersection region -- the picture, not only the key."""
+        from PIL import Image
+        img = Image.open(self.png_f).convert('RGB')
+        w, h = img.size
+        hits = sum(1 for _x in range(0, w, 7) for _y in range(0, h, 7)
+                   if img.getpixel((_x, _y)) == (255, 120, 40))
+        self.assertGreater(
+            hits, 20, 'no courtyard-interpenetration fill in the render')
+
+    def test_review_sheet_exists_and_is_wide(self):
+        from PIL import Image
+        self.assertTrue(os.path.exists(self.sheet))
+        img = Image.open(self.sheet)
+        # F+B side by side over a facts strip: wider than tall, and taller
+        # than either bare panel (the strip).
+        self.assertGreater(img.width, img.height)
+        self.assertEqual(self.doc.get('review_sheet'), self.sheet)
+
+
+class TestPristineBoards(unittest.TestCase):
+    """The corpus lesson: healthy boards carry big by-design censuses."""
+
+    def test_pristine_board_vs_itself_never_flips(self):
+        r, doc = _grade(ULX3S, '--baseline', ULX3S)
+        self.assertEqual(r.returncode, 0, r.stdout[-600:])
+        self.assertTrue(doc['buildable'])
+        # The census is large and REAL (GPDI1's shell over its passives) --
+        # pin that it exists, so a future "fix" that empties the census to
+        # make the gate quiet is caught here.
+        self.assertGreaterEqual(doc['courtyard_blocking'], 10)
+        self.assertEqual(doc['courtyard_blocking_gating'], 0)
+
+    def test_pristine_board_without_baseline_stays_buildable(self):
+        r, doc = _grade(ULX3S)
+        self.assertEqual(r.returncode, 0, r.stdout[-600:])
+        self.assertTrue(doc['buildable'])
+
+    def test_cross_side_stacks_are_named_not_paired(self):
+        """User finding on the ulx3s review: BAT1 sits BEHIND the buttons
+        (B4: 68.7mm2 of XY overlap, opposite faces) and the panels make that
+        visually indistinguishable from a collision. The census correctly
+        refuses to pair opposite faces; the render's checklist now NAMES the
+        stacks so the sheet pre-answers the eye instead of looking blind."""
+        import subprocess as _sp
+        env = dict(os.environ, PYTHONPATH=ROOT, PYTHONIOENCODING='utf-8',
+                   KRT_NO_BANNER='1')
+        with tempfile.TemporaryDirectory() as td:
+            jp = os.path.join(td, 'r.json')
+            r = _sp.run([sys.executable, '-X', 'utf8',
+                         os.path.join(ROOT, 'py_tools',
+                                      'render_placement.py'),
+                         ULX3S, '--json-out', jp,
+                         '-o', os.path.join(td, 'r.png')],
+                        capture_output=True, text=True, env=env, cwd=ROOT)
+            self.assertEqual(r.returncode, 0, r.stdout[-400:])
+            doc = json.load(open(jp, encoding='utf-8'))
+            stacks = {(a, b) for a, b, _m in
+                      doc['checklist']['b_cross_side_stacks']}
+            self.assertIn(('B4', 'BAT1'), stacks)
+            # ...and the same pair is NOT in the courtyard census: opposite
+            # faces never pair.
+            census = {(a, b) for a, b, *_ in
+                      doc['checklist']['b_courtyard_overlap_pairs']}
+            self.assertNotIn(('B4', 'BAT1'), census)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=1)

--- a/tests/test_run23_pockets.py
+++ b/tests/test_run23_pockets.py
@@ -1,0 +1,70 @@
+"""check_pockets: the aggregate handoff census per-net gates cannot give.
+
+Run 23: check_channels said 0 starved faces, check_reachability said every
+failing pad PASSABLE, crossings sat below the damaged baseline -- and two
+nets then died across ~20 route laps in one pocket (RN7/U6/J4/RN8, where
+committed copper wrapped RN7 at 0.095mm against the 0.45mm lane need). The
+census here must NAME that geography pre-route, and must stay REPORT-ONLY
+(exit 0): an absolute threshold on a young metric is how phantom gates get
+born.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PLACED = os.path.join(ROOT, 'tests', 'fixtures', 'run23',
+                      'tigard_placed.kicad_pcb')
+SPLITFLAP = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
+
+
+def _run(*argv):
+    env = dict(os.environ, PYTHONPATH=ROOT, PYTHONIOENCODING='utf-8',
+               KRT_NO_BANNER='1')
+    return subprocess.run(
+        [sys.executable, '-X', 'utf8',
+         os.path.join(ROOT, 'py_tools', 'check_pockets.py'), *argv],
+        capture_output=True, text=True, env=env, cwd=ROOT)
+
+
+class TestPocketCensus(unittest.TestCase):
+    def test_names_the_run23_pocket(self):
+        with tempfile.TemporaryDirectory() as td:
+            jp = os.path.join(td, 'p.json')
+            r = _run(PLACED, '--json', jp, '--top', '8')
+            self.assertEqual(r.returncode, 0, r.stdout[-400:])
+            # The failure geography by name: the top windows must carry the
+            # nets that ate run 23's endgame and the parts that cage them.
+            self.assertIn('/ICE_CDONE', r.stdout)
+            self.assertIn('RN8', r.stdout)
+            self.assertIn('U6', r.stdout)
+            # The lane arithmetic the forensics measured the cage against.
+            self.assertIn('0.45', r.stdout)
+            doc = json.load(open(jp, encoding='utf-8'))
+            self.assertEqual(doc['lane_mm'], 0.45)
+            self.assertGreater(len(doc['windows']), 10)
+
+    def test_report_only_and_multi_net_ranking(self):
+        r = _run(PLACED, '--top', '5')
+        self.assertEqual(r.returncode, 0)
+        self.assertIn('REPORT-ONLY', r.stdout)
+        # Every RANKED row is a >=2-net window -- a single-net sliver inside
+        # one part's own pad field means nothing for simultaneous
+        # routability and must not top the list.
+        for ln in r.stdout.splitlines():
+            ln = ln.strip()
+            if ln.startswith('[') and 'demand' in ln:
+                n = int(ln.split('demand')[1].split('net(s)')[0].strip())
+                self.assertGreaterEqual(n, 2, ln)
+
+    def test_exit_zero_on_a_healthy_board(self):
+        r = _run(SPLITFLAP, '--top', '3')
+        self.assertEqual(r.returncode, 0, r.stdout[-400:])
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=1)

--- a/tests/test_run23_reachability_widen.py
+++ b/tests/test_run23_reachability_widen.py
@@ -1,0 +1,79 @@
+"""check_reachability auto-widens NO-TARGET; net_forensics emits JSON.
+
+Run 23, measured: U3.30 (/TXLED, partner D4.1 20.27mm away) returned exit 2
+NO-TARGET at the default +/-4mm view; the manual retry ladder cost 128s at
+--margin 12, 306s at 18, and a 10-minute timeout WITH NO DATA at 25, because
+cells scale as (span/step)^2 at the fixed 0.01 step. The auto-widen locates
+the nearest other island by vector union-find, widens the view to hold it,
+and coarsens the step so the grid stays ~1200^2 -- one bounded invocation.
+And the island gap itself (the number rip-set decisions need) was text-only
+in net_forensics; --json makes it consumable.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PLACED = os.path.join(ROOT, 'tests', 'fixtures', 'run23',
+                      'tigard_placed.kicad_pcb')
+
+
+def _run(tool, *argv):
+    env = dict(os.environ, PYTHONPATH=ROOT, PYTHONIOENCODING='utf-8',
+               KRT_NO_BANNER='1')
+    return subprocess.run(
+        [sys.executable, '-X', 'utf8',
+         os.path.join(ROOT, 'py_tools', tool), *argv],
+        capture_output=True, text=True, env=env, cwd=ROOT)
+
+
+class TestAutoWiden(unittest.TestCase):
+    def test_u3_30_answers_in_one_bounded_invocation(self):
+        t0 = time.time()
+        with tempfile.TemporaryDirectory() as td:
+            jp = os.path.join(td, 'r.json')
+            r = _run('check_reachability.py', PLACED, '--pad', 'U3.30',
+                     '--json-out', jp)
+            wall = time.time() - t0
+            # Exit 0 = PASSABLE, the true verdict run 23 needed three manual
+            # retries to reach. Bounded: well under the 10-minute timeout
+            # the fixed-step ladder hit (CI slack included).
+            self.assertEqual(r.returncode, 0, r.stdout[-500:])
+            self.assertLess(wall, 240)
+            self.assertIn('auto-widening', r.stdout)
+            doc = json.load(open(jp, encoding='utf-8'))
+            self.assertEqual(doc['verdict'], 'PASSABLE')
+            aw = doc['auto_widened']
+            self.assertAlmostEqual(aw['nearest_island_mm'], 20.27, delta=0.1)
+            # The coarsened step is DISCLOSED (readings are only comparable
+            # at their own step).
+            self.assertGreater(aw['step_mm'], 0.01)
+            self.assertGreater(doc['margin_um'], 0)
+
+    def test_explicit_view_is_never_overridden(self):
+        r = _run('check_reachability.py', PLACED, '--pad', 'U3.30',
+                 '--view', '55,58,60,63')
+        self.assertNotIn('auto-widening', r.stdout)
+
+
+class TestForensicsJson(unittest.TestCase):
+    def test_gap_is_machine_readable(self):
+        with tempfile.TemporaryDirectory() as td:
+            jp = os.path.join(td, 'nf.json')
+            r = _run('net_forensics.py', PLACED, '--nets', '/TXLED',
+                     '--json', jp)
+            self.assertEqual(r.returncode, 0, r.stdout[-400:])
+            doc = json.load(open(jp, encoding='utf-8'))
+            net = doc['nets'][0]
+            self.assertEqual(net['net'], '/TXLED')
+            self.assertEqual(len(net['islands']), 2)
+            self.assertAlmostEqual(net['gap']['mm'], 20.267, delta=0.05)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=1)

--- a/tests/test_run23_run_state.py
+++ b/tests/test_run23_run_state.py
@@ -1,0 +1,129 @@
+"""RUN_STATE.json: the machine-readable NOW view of a run (run-23).
+
+Run 23 measured 74% of its wall clock as agent context work, much of it
+re-deriving "where are we" from ledger + journal + logs -- history existed,
+a snapshot did not. Pinned here: converge.record refreshes RUN_STATE.json;
+both drivers stamp their stage onto it; `loop_driver --status` renders it
+and degrades honestly on an empty workdir; and the placement-lap record
+templates now carry --score-file (the run-23 L5 "plateau NOT ANSWERABLE"
+fix -- a score-less lap is invisible to every comparison downstream).
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+
+LOOP = os.path.join(ROOT, '.claude', 'skills',
+                    'plan-pcb-placement-and-routing', 'scripts',
+                    'loop_driver.py')
+PLACE = os.path.join(ROOT, '.claude', 'skills', 'plan-pcb-placement',
+                     'scripts', 'placement_driver.py')
+BOARD = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
+
+
+def _run(*argv, cwd=ROOT):
+    env = dict(os.environ, PYTHONPATH=ROOT, PYTHONIOENCODING='utf-8',
+               KRT_NO_BANNER='1')
+    return subprocess.run([sys.executable, '-X', 'utf8', *argv],
+                          capture_output=True, text=True, env=env, cwd=cwd)
+
+
+class TestRunState(unittest.TestCase):
+    def test_record_refreshes_run_state(self):
+        with tempfile.TemporaryDirectory() as td:
+            ledger = os.path.join(td, 'ledger.jsonl')
+            score = os.path.join(td, 'score.json')
+            json.dump({'blocking': 7, 'blocking_by': {'unrouted': 7},
+                       'quality': {'vias': 0}, 'board_sha': 'x'},
+                      open(score, 'w'))
+            r = _run(os.path.join(ROOT, 'py_placer', 'converge.py'),
+                     'record', '--ledger', ledger, '--board', BOARD,
+                     '--kind', 'placement', '--lever', 'test lap',
+                     '--score-file', score)
+            self.assertEqual(r.returncode, 0, r.stderr[-400:])
+            sp = os.path.join(td, 'RUN_STATE.json')
+            self.assertTrue(os.path.exists(sp), 'record did not write state')
+            st = json.load(open(sp, encoding='utf-8'))
+            self.assertEqual(st['source_ledger_row'], 1)
+            self.assertEqual(st['blocking'], 7)
+            self.assertEqual(st['phase'], 'placement')
+            self.assertIn('written_at', st)
+
+    def test_driver_stage_stamps_the_state(self):
+        with tempfile.TemporaryDirectory() as td:
+            ledger = os.path.join(td, 'ledger.jsonl')
+            # L1 on a real board: emits the delegation prompt and must stamp.
+            r = _run(LOOP, '--stage', 'L1', '--board', BOARD,
+                     '--ledger', ledger, '--workdir', td)
+            self.assertEqual(r.returncode, 0, r.stdout[-400:])
+            st = json.load(open(os.path.join(td, 'RUN_STATE.json'),
+                                encoding='utf-8'))
+            self.assertEqual(st['last_stage'], 'L1')
+            self.assertFalse(st['stage_refused'])
+            # placement_driver stamps with its own namespace.
+            r2 = _run(PLACE, '--stage', 'P0', '--board', BOARD,
+                      '--workdir', td)
+            self.assertIn(r2.returncode, (0, 4), r2.stdout[-400:])
+            st2 = json.load(open(os.path.join(td, 'RUN_STATE.json'),
+                                 encoding='utf-8'))
+            self.assertEqual(st2['last_stage'], 'placement:P0')
+            # ...and journals itself (the loop_driver asymmetry, closed).
+            self.assertTrue(os.path.exists(
+                os.path.join(td, 'placement_driver.log')))
+
+    def test_status_renders_on_an_empty_workdir(self):
+        with tempfile.TemporaryDirectory() as td:
+            r = _run(LOOP, '--status',
+                     '--ledger', os.path.join(td, 'ledger.jsonl'))
+            self.assertEqual(r.returncode, 0, r.stdout[-400:])
+            self.assertIn('nothing recorded yet', r.stdout)
+
+    def test_status_renders_a_real_ledger(self):
+        with tempfile.TemporaryDirectory() as td:
+            ledger = os.path.join(td, 'ledger.jsonl')
+            score = os.path.join(td, 'score.json')
+            json.dump({'blocking': 2, 'quality': {}}, open(score, 'w'))
+            _run(os.path.join(ROOT, 'py_placer', 'converge.py'),
+                 'record', '--ledger', ledger, '--board', BOARD,
+                 '--kind', 'placement', '--lever', 'lap', '--score-file',
+                 score)
+            r = _run(LOOP, '--status', '--ledger', ledger)
+            self.assertEqual(r.returncode, 0, r.stdout[-400:])
+            self.assertIn('"blocking": 2', r.stdout)
+
+
+class TestScoreFileTemplates(unittest.TestCase):
+    """T3: the placement record templates the drivers PRINT carry a score.
+
+    Run 23's 17 score-less placement laps made L5's plateau question NOT
+    ANSWERABLE. The engine change is nothing; the templates are the surface
+    agents actually follow, so the templates are what is pinned.
+    """
+
+    def test_placement_driver_lap_template_carries_score_file(self):
+        src = open(PLACE, encoding='utf-8').read()
+        i = src.find('Then record it, before starting the next lap')
+        self.assertGreater(i, 0)
+        block = src[i:i + 900]
+        self.assertIn('--score-file', block)
+        self.assertIn('board_score.py', block)
+
+    def test_loop_driver_templates_carry_score_file(self):
+        src = open(LOOP, encoding='utf-8').read()
+        # The L2 freeze record and the L2 not-in-ledger refusal both must.
+        i = src.find('L2 freeze: <n> refs')
+        self.assertGreater(i, 0)
+        self.assertIn('--score-file', src[max(0, i - 900):i])
+        j = src.find('is not in {a.ledger}')
+        self.assertGreater(j, 0)
+        self.assertIn('--score-file', src[j:j + 1600])
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=1)

--- a/tests/test_run23_tee_done.py
+++ b/tests/test_run23_tee_done.py
@@ -1,0 +1,97 @@
+"""tee_cmd writes logs/<label>.done -- ONE canonical completion signal.
+
+Run 23's orchestrator waited on `[tee_cmd] <label> exit=` -- a line tee_cmd
+prints to STDOUT only -- by grepping the LOG, which carries `EXIT=N`
+instead. The waiter timed out; ~25 minutes of wall were lost to a completion
+signal split across two streams. The `.done` file holds the exit code and
+appears exactly when the child exits; a waiter polls os.path.exists of it
+and nothing else.
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TEE = os.path.join(ROOT, 'tests', 'stress', 'tee_cmd.py')
+
+
+def _tee(td, label, *cmd):
+    return subprocess.run(
+        [sys.executable, '-X', 'utf8', TEE, '--workdir', td, label,
+         '--', sys.executable, '-c', *cmd],
+        capture_output=True, text=True, cwd=ROOT)
+
+
+class TestTeeDone(unittest.TestCase):
+    def test_done_carries_the_exit_code(self):
+        with tempfile.TemporaryDirectory() as td:
+            _tee(td, 'ok', 'print("hi")')
+            _tee(td, 'bad', 'import sys; sys.exit(3)')
+            self.assertEqual(
+                open(os.path.join(td, 'logs', 'ok.done')).read().strip(), '0')
+            self.assertEqual(
+                open(os.path.join(td, 'logs', 'bad.done')).read().strip(),
+                '3')
+
+    def test_reused_label_gets_its_own_done(self):
+        """Reused labels get numbered logs (lap semantics); the .done files
+        must pair 1:1 with them or a waiter watches lap 1's marker while
+        lap 2 runs. Run 24 (finding A-10) sharpened the canonical marker:
+        the stage advice says "wait on logs/<label>.done", and the unsuffixed
+        file used to keep the OLDEST attempt's exit forever -- a waiter armed
+        during a retry returned instantly with a stale verdict. It is now
+        last-attempt-wins: absent while a retry runs, then the newest code."""
+        with tempfile.TemporaryDirectory() as td:
+            _tee(td, 'lap', 'pass')
+            self.assertEqual(
+                open(os.path.join(td, 'logs', 'lap.done')).read().strip(),
+                '0')
+            _tee(td, 'lap', 'import sys; sys.exit(2)')
+            self.assertEqual(
+                open(os.path.join(td, 'logs', 'lap.done')).read().strip(),
+                '2', 'canonical marker must carry the NEWEST attempt')
+            self.assertEqual(
+                open(os.path.join(td, 'logs', 'lap.2.done')).read().strip(),
+                '2')
+
+    def test_canonical_marker_absent_while_a_retry_runs(self):
+        """The stale-read hazard itself: while attempt 2 is in flight the
+        canonical marker must be GONE, or a waiter reads attempt 1's exit."""
+        import threading
+        import time as _time
+        with tempfile.TemporaryDirectory() as td:
+            _tee(td, 'lap', 'pass')
+            marker = os.path.join(td, 'logs', 'lap.done')
+            timeline = []
+
+            def watch():
+                # Sample across the retry. The retry's own process startup
+                # is allowed to still show the old marker (tee_cmd cannot
+                # delete it before it runs); the contract is that the marker
+                # then VANISHES for the duration and never returns stale.
+                for _ in range(300):
+                    timeline.append(
+                        open(marker).read().strip()
+                        if os.path.exists(marker) else None)
+                    _time.sleep(0.01)
+
+            t = threading.Thread(target=watch)
+            t.start()
+            _tee(td, 'lap',
+                 'import time, sys; time.sleep(1.0); sys.exit(5)')
+            t.join()
+            self.assertIn(None, timeline,
+                          'the canonical marker never vanished during the '
+                          'retry -- a waiter would read the stale exit')
+            after_gone = timeline[timeline.index(None):]
+            self.assertNotIn('0', after_gone,
+                             'the stale attempt-1 exit reappeared after the '
+                             'marker vanished')
+            self.assertEqual(open(marker).read().strip(), '5')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=1)

--- a/tests/test_run6_body_overlap.py
+++ b/tests/test_run6_body_overlap.py
@@ -36,7 +36,10 @@ class TestCorpusCalibration(unittest.TestCase):
         board, or the channel may not gate anywhere (run-6 invariant)."""
         boards = sorted(glob.glob(os.path.join(ROOT, 'kicad_files',
                                                '*.kicad_pcb')))
-        self.assertGreaterEqual(len(boards), 30)
+        # The TRACKED corpus is 22 boards; generated fixture chains add more on a
+        # developed tree. Guard against an empty or half-checked-out corpus, not
+        # against the generated surplus (a fresh clone has exactly 22).
+        self.assertGreaterEqual(len(boards), 22)
         bad = []
         for b in boards:
             try:
@@ -170,3 +173,213 @@ class TestIntentKey(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class TestContainment(unittest.TestCase):
+    """The containment channel: run-22's defect, and why it may not gate.
+
+    Run 22 shipped a board every gate called buildable while RN3 sat wholly
+    inside U5's body and RN7 inside U6's -- reported as `fab 2.0mm2`, which is
+    also what a large connector's by-design graze measures. `area_mm2` cannot
+    tell a KISS from a part WHOLLY INSIDE another; `contained_frac` can.
+    """
+
+    #: A big part with a .Fab body, and a small one whose body sits inside it.
+    #: The pads are deliberately clear of each other, so NOTHING in the
+    #: pad_intersection channel fires -- that is the whole point. This is the
+    #: defect shape that reported blocking 0.
+    BOARD = '''(kicad_pcb (version 20221018) (generator pcbnew)
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal) (44 "Edge.Cuts" user))
+  (net 0 "") (net 1 "VCC") (net 2 "GND")
+  (gr_rect (start 0 0) (end 30 30) (stroke (width 0.1) (type default)) (layer "Edge.Cuts"))
+  (footprint "t:BIG" (layer "F.Cu") (at 10 10)
+    (property "Reference" "{big}" (at 0 0) (layer "F.SilkS"))
+    (fp_rect (start -4 -4) (end 4 4) (stroke (width 0.05) (type default)) (layer "F.Fab"))
+    (fp_rect (start -4.2 -4.2) (end 4.2 4.2) (stroke (width 0.05) (type default)) (layer "F.CrtYd"))
+    (pad "1" smd rect (at -3.7 0) (size 0.4 0.4) (layers "F.Cu") (net 1 "VCC"))
+    (pad "2" smd rect (at 3.7 0) (size 0.4 0.4) (layers "F.Cu") (net 1 "VCC")))
+  (footprint "t:SMALL" (layer "F.Cu") (at {sx} 10)
+    (property "Reference" "{small}" (at 0 0) (layer "F.SilkS"))
+    (fp_rect (start -0.5 -0.3) (end 0.5 0.3) (stroke (width 0.05) (type default)) (layer "F.Fab"))
+    (fp_rect (start -0.7 -0.5) (end 0.7 0.5) (stroke (width 0.05) (type default)) (layer "F.CrtYd"))
+    (pad "1" smd rect (at 0 0) (size 0.2 0.2) (layers "F.Cu") (net 2 "GND")))
+)
+'''
+
+    def _board(self, sx, big='U1', small='RN1'):
+        text = self.BOARD.format(sx=sx, big=big, small=small)
+        td = tempfile.mkdtemp()
+        path = os.path.join(td, 'b.kicad_pcb')
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write(text)
+        return path
+
+    def _fab(self, g):
+        return [p for p in g['pairs'] if p.kind == 'fab']
+
+    def test_containment_is_measured(self):
+        """The small part's body wholly inside the big one's."""
+        g = _grade(self._board(sx=10.0))
+        fab = self._fab(g)
+        self.assertEqual(len(fab), 1)
+        self.assertEqual(fab[0].contained_frac, 1.0)
+        self.assertTrue(fab[0].contained)
+        self.assertEqual(g['contained'], 1)
+        self.assertEqual([(p.a, p.b) for p in g['containment_pairs']],
+                         [('RN1', 'U1')])
+
+    def test_a_kiss_is_not_a_containment(self):
+        """The run-4 lesson pinned into the new channel: two bodies meeting at
+        their edges is not a part inside a part, and must not report as one."""
+        g = _grade(self._board(sx=14.4))
+        fab = self._fab(g)
+        self.assertEqual(len(fab), 1)
+        self.assertLess(fab[0].contained_frac, 0.5)
+        self.assertFalse(fab[0].contained)
+        self.assertEqual(g['contained'], 0)
+
+    def test_a_waived_containment_is_still_disclosed(self):
+        """THE run-22 hole. `_waiver_for` is a part-class lookup with no
+        geometry in it, so a part sitting WHOLLY inside an edge_actuator gets
+        the same label as a 0.01mm2 graze and then leaves `advisory`,
+        `advisory_pairs` AND `new_advisory_pairs` in one step. D4-inside-SW2
+        vanished exactly that way, twice, and nothing in the chain reported it.
+        `containment_pairs` is the one list a waiver cannot empty."""
+        g = _grade(self._board(sx=10.0), intent_waivers=[('U1', 'RN1')])
+        self.assertEqual(g['advisory'], 0)
+        self.assertTrue(all(p.waived for p in self._fab(g)))
+        self.assertEqual(g['contained'], 1)
+        self.assertTrue(g['containment_pairs'][0].waived)
+
+    def test_containment_does_not_change_the_verdict(self):
+        """Zero blast radius, pinned. The corpus ships legitimate frac-1.0
+        containments (orangecrab FID2/J5), so this channel may not gate."""
+        g = _grade(self._board(sx=10.0))
+        self.assertEqual(g['contained'], 1)
+        self.assertEqual(g['blocking'], 0)
+        self.assertEqual(g['blocking_pairs'], [])
+
+    def test_a_nonexempt_containment_GATES(self):
+        """The verdict change: a part wholly inside another part's body makes
+        the board NOT BUILDABLE, unless something says it is by design."""
+        g = _grade(self._board(sx=10.0))
+        self.assertEqual(g['containment_blocking'], 1, g['containment_pairs'])
+        # ...and `blocking` is UNTOUCHED. Three consumers read that count --
+        # board_score, the seeder's repair census, and placement_driver's
+        # _guard_damage with INVERTED polarity ("run repair only if blocking").
+        # Folding containment in would change all three.
+        self.assertEqual(g['blocking'], 0)
+
+    def test_an_AUTHORED_waiver_lifts_the_gate(self):
+        """The escape hatch, and the only one: name the pair in the intent.
+        That is written down by a person; a class waiver is inherited."""
+        g = _grade(self._board(sx=10.0), intent_waivers=[('U1', 'RN1')])
+        self.assertEqual(g['contained'], 1)          # still DISCLOSED
+        self.assertEqual(g['containment_blocking'], 0)   # but not blocking
+
+    def test_the_corpus_still_grades_buildable(self):
+        """0 boards may gate. The only corpus containments are orangecrab's
+        FID2/J5 (frac 1.000) and FID1/J4 (0.867), both marker_class and both
+        correct -- fiducials under a connector body."""
+        boards = sorted(glob.glob(os.path.join(ROOT, 'kicad_files',
+                                               '*.kicad_pcb')))
+        self.assertGreaterEqual(len(boards), 30)
+        gating = {os.path.basename(b): [(q.a, q.b, q.waiver)
+                                        for q in _grade(b)['containment_blocking_pairs']]
+                  for b in boards}
+        offenders = {k: v for k, v in gating.items() if v}
+        self.assertEqual(offenders, {}, offenders)
+
+    def test_bodyless_footprints_are_disclosed(self):
+        """A part drawing no .Fab outline cannot be judged by this channel.
+        Measured 10-25 per corpus board, so it is a large limit rather than a
+        corner case -- and an unjudged part is not a clean part."""
+        g = _grade(os.path.join(ROOT, 'kicad_files', 'tigard.kicad_pcb'))
+        self.assertGreater(g['fab_unjudged'], 0)
+        self.assertEqual(len(g['fab_unjudged_refs']), g['fab_unjudged'])
+
+    def test_the_bodyless_hole_is_exactly_what_was_measured(self):
+        """144 of 1583 footprints draw no .Fab body, and that is the FINAL
+        answer, not a TODO.
+
+        Measured over all 33 boards: every one of those 144 draws ZERO .Fab
+        geometric primitives -- there is no footprint whose .Fab geometry the
+        parser fails to read. So a tolerance or polygon-closure fix moves
+        nothing (313 footprints DO have non-closing .Fab chains, tigard Q1
+        among them, and all 313 are judged correctly because a bbox is a
+        min/max over points).
+
+        This test exists so a future "helpful" parser change that alters the
+        count has to come and argue with the number. The dangerous direction
+        is a FALLBACK body for bodyless parts: measured, that adds 77 fab
+        pairs, 65 above the threshold, and breaks the calibration gate below.
+        """
+        boards = sorted(glob.glob(os.path.join(ROOT, 'kicad_files',
+                                               '*.kicad_pcb')))
+        self.assertGreaterEqual(len(boards), 30)
+        total_unjudged = sum(_grade(b)['fab_unjudged'] for b in boards)
+        self.assertEqual(total_unjudged, 144,
+                         f'corpus fab_unjudged moved to {total_unjudged}; if '
+                         f'that was deliberate, re-measure the 4-pair census '
+                         f'below and this number together')
+
+    def test_no_unjudged_part_has_fab_geometry_to_read(self):
+        """The INVARIANT behind the count above, and the stronger claim.
+
+        `fab_unjudged == 144` is a census of THIS corpus, and 11 of the 33
+        boards it sweeps are untracked generated fixtures, so the number moves
+        when someone regenerates one. This assertion does not depend on corpus
+        membership: whatever the set is, every unjudged part must draw NO .Fab
+        geometry at all.
+
+        That is what licenses "a parser tolerance or polygon-closure fix moves
+        zero footprints" -- not the 144. If this ever fails, the parser really
+        is failing to read a body it was handed, and the disclosure-not-a-fix
+        conclusion has to be revisited.
+        """
+        from placement.parser import extract_fab_sides
+        boards = sorted(glob.glob(os.path.join(ROOT, 'kicad_files',
+                                               '*.kicad_pcb')))
+        self.assertGreaterEqual(len(boards), 30)
+        readable, checked = [], 0
+        for b in boards:
+            sides = extract_fab_sides(b)
+            for ref in _grade(b)['fab_unjudged_refs']:
+                checked += 1
+                if sides.get(ref):
+                    readable.append((os.path.basename(b), ref))
+        self.assertGreater(checked, 0, 'nothing was checked')
+        self.assertEqual(readable, [], f'{len(readable)} part(s) are reported '
+                                       f'unjudged while their .Fab geometry '
+                                       f'parses fine: {readable[:5]}')
+
+    def test_corpus_carries_no_nonexempt_body_containment(self):
+        """THE calibration gate for the threshold, sibling of
+        test_all_healthy_boards_grade_zero_blocking.
+
+        Measured over all 33 boards: the fab census is exactly 4 pairs, and
+        every non-exempt one is a shell KISS three orders of magnitude below
+        the threshold (GPDI1/J5 at 0.011, GPDI1/SW1 at 0.001) against a
+        measured defect of 1.000. That ~90x separation is what licenses
+        CONTAINMENT_FRAC.
+
+        It is also why the ENGINE predicate may use the fab currency and never
+        the courtyard: the courtyard ships frac-1.0 containment on four healthy
+        boards (esp_prog, orangecrab_ext_pll, rp2350_fpga_eensy_prePlane,
+        ulx3s), so a courtyard-based predicate would false-veto legitimate
+        poses on 12% of the corpus -- the run-4 lesson in a new costume.
+        """
+        from placement.legality import CONTAINMENT_FRAC
+        boards = sorted(glob.glob(os.path.join(ROOT, 'kicad_files',
+                                               '*.kicad_pcb')))
+        self.assertGreaterEqual(len(boards), 30)
+        census = []
+        for b in boards:
+            for p in _grade(b)['pairs']:
+                if p.kind == 'fab':
+                    census.append((os.path.basename(b), p.a, p.b,
+                                   p.contained_frac, bool(p.waiver)))
+        self.assertEqual(len(census), 4, census)
+        offenders = [c for c in census
+                     if c[3] >= CONTAINMENT_FRAC and not c[4]]
+        self.assertEqual(offenders, [], offenders)

--- a/tests/test_run6_check_assembly.py
+++ b/tests/test_run6_check_assembly.py
@@ -94,3 +94,48 @@ class TestRenderBodyChannel(unittest.TestCase):
             cl = doc['checklist']
             self.assertIn(['C14', 'R14'], cl['b_body_overlap_pairs'])
             self.assertIn('b_pad_clearance_pairs', cl)
+
+
+class TestContainmentDisclosure(unittest.TestCase):
+    """Run 22: a board with two parts wholly inside two other parts' bodies
+    printed `VERDICT: buildable`. The containment must be visible in stdout
+    AND in the JSON, and the verdict must be untouched -- the corpus ships
+    legitimate frac-1.0 containments (fiducials under connector bodies), so
+    this channel discloses and never gates."""
+
+    BOARD = os.path.join(ROOT, 'kicad_files', 'orangecrab_ext_pll.kicad_pcb')
+
+    def test_containment_prints_and_lands_in_json(self):
+        if not os.path.exists(self.BOARD):
+            self.skipTest('corpus board not present')
+        with tempfile.TemporaryDirectory() as td:
+            jp = os.path.join(td, 'a.json')
+            r = _run(self.BOARD, '--json', jp)
+            # The verdict is NOT changed by containment.
+            self.assertEqual(r.returncode, 0, r.stdout[-400:])
+            self.assertIn('buildable (blocking 0)', r.stdout)
+            # ...but the containment can no longer hide.
+            self.assertIn('CONTAINMENT', r.stdout)
+            doc = json.load(open(jp, encoding='utf-8'))
+            self.assertEqual(doc['buildable'], True)
+            self.assertEqual(doc['blocking'], 0)
+            self.assertEqual(doc['contained'], 2)
+            pairs = {(c['a'], c['b']) for c in doc['containments']}
+            self.assertEqual(pairs, {('FID2', 'J5'), ('FID1', 'J4')})
+            # Both are WAIVED by part class, and both are still reported --
+            # that omission is the whole fix (run-22 lost D4-inside-SW2 to an
+            # edge_class waiver that no geometry ever tested).
+            self.assertTrue(all(c['waived'] for c in doc['containments']))
+
+    def test_body_coverage_is_disclosed(self):
+        """An unjudged part is not a clean part."""
+        if not os.path.exists(self.BOARD):
+            self.skipTest('corpus board not present')
+        with tempfile.TemporaryDirectory() as td:
+            jp = os.path.join(td, 'a.json')
+            r = _run(self.BOARD, '--json', jp)
+            self.assertIn('BODY COVERAGE', r.stdout)
+            doc = json.load(open(jp, encoding='utf-8'))
+            self.assertGreater(doc['fab_unjudged'], 0)
+            self.assertEqual(len(doc['fab_unjudged_refs']),
+                             doc['fab_unjudged'])

--- a/tests/test_run8_gate_conjuncts.py
+++ b/tests/test_run8_gate_conjuncts.py
@@ -38,6 +38,32 @@ from placement import reconstruct                              # noqa: E402
 import pose_score                                              # noqa: E402
 
 BOARD = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
+
+#: A big part with a .Fab body, a small part, and a fiducial. The pads never
+#: touch, so NOTHING in the pad_intersection channel fires -- that is the
+#: defect shape: it reported blocking 0.
+BODY_BOARD = """(kicad_pcb (version 20221018) (generator pcbnew)
+  (layers (0 "F.Cu" signal) (31 "B.Cu" signal) (44 "Edge.Cuts" user))
+  (net 0 "") (net 1 "VCC") (net 2 "GND")
+  (gr_rect (start 0 0) (end 40 40) (stroke (width 0.1) (type default)) (layer "Edge.Cuts"))
+  (footprint "t:BIG" (layer "F.Cu") (at 20 20)
+    (property "Reference" "U1" (at 0 0) (layer "F.SilkS"))
+    (fp_rect (start -4 -4) (end 4 4) (stroke (width 0.05) (type default)) (layer "F.Fab"))
+    (fp_rect (start -4.2 -4.2) (end 4.2 4.2) (stroke (width 0.05) (type default)) (layer "F.CrtYd"))
+    (pad "1" smd rect (at -3.7 0) (size 0.4 0.4) (layers "F.Cu") (net 1 "VCC"))
+    (pad "2" smd rect (at 3.7 0) (size 0.4 0.4) (layers "F.Cu") (net 1 "VCC")))
+  (footprint "t:SMALL" (layer "F.Cu") (at 32 20)
+    (property "Reference" "RN1" (at 0 0) (layer "F.SilkS"))
+    (fp_rect (start -0.5 -0.3) (end 0.5 0.3) (stroke (width 0.05) (type default)) (layer "F.Fab"))
+    (fp_rect (start -0.7 -0.5) (end 0.7 0.5) (stroke (width 0.05) (type default)) (layer "F.CrtYd"))
+    (pad "1" smd rect (at 0 0) (size 0.2 0.2) (layers "F.Cu") (net 2 "GND")))
+  (footprint "MountingHole:MountingHole_3.2mm_M3" (layer "F.Cu") (at 32 30)
+    (property "Reference" "FID1" (at 0 0) (layer "F.SilkS"))
+    (fp_rect (start -0.5 -0.5) (end 0.5 0.5) (stroke (width 0.05) (type default)) (layer "F.Fab"))
+    (fp_rect (start -0.7 -0.7) (end 0.7 0.7) (stroke (width 0.05) (type default)) (layer "F.CrtYd"))
+    (pad "1" smd circle (at 0 0) (size 0.3 0.3) (layers "F.Cu") (net 0 "")))
+)
+"""
 FAILURES = []
 
 
@@ -134,6 +160,54 @@ def main():
           'and not cross_group_hit' in src)
     check('a refusal is reported, not silent',
           'REJECTED an assignment' in src)
+
+    print("E8: a candidate pose INSIDE another part's body is refused")
+    # Run 22's defect, verbatim. assign/exchange moved parts by a derived
+    # +/-v with only pad legality and hpwl in the objective, so a teleport
+    # landed a part wholly inside another part's body and scored clean --
+    # twice, on two different pairs, both reporting `blocking 0` because no
+    # pad copper intersects.
+    with tempfile.TemporaryDirectory() as td:
+        bp = os.path.join(td, 'body.kicad_pcb')
+        with open(bp, 'w', encoding='utf-8') as f:
+            f.write(BODY_BOARD)
+        bst = state_for(bp)
+        big, small, fid = bst.parts['U1'], bst.parts['RN1'], bst.parts['FID1']
+        inside = (big.x, big.y)          # dead centre of U1's body
+        clear = (big.x + 12.0, big.y)    # well away from it
+
+        check("a pose inside another part's body conflicts",
+              reconstruct._pair_conflicts(bst, 'RN1', inside, 'U1',
+                                          (big.x, big.y)),
+              'the teleport that shipped twice in run 22 is still accepted')
+        check("a pose clear of it does not",
+              not reconstruct._pair_conflicts(bst, 'RN1', clear, 'U1',
+                                              (big.x, big.y)))
+        # The marker exemption is load-bearing and measured: orangecrab ships
+        # FID2 wholly inside J5 (frac 1.000) and FID1 inside J4 (0.867).
+        # Without it a displaced fiducial could never come home.
+        check('a fiducial inside a body is EXEMPT, not a conflict',
+              not reconstruct._pair_conflicts(bst, 'FID1', inside, 'U1',
+                                              (big.x, big.y)),
+              'the marker exemption was dropped; orangecrab FID1/FID2 break')
+        # The run-4 lesson, pinned into the predicate: a kiss is not a
+        # containment and must not be charged as one.
+        kiss = (big.x + 4.4, big.y)
+        check('a body KISS is not charged as containment',
+              not reconstruct._pair_conflicts(bst, 'RN1', kiss, 'U1',
+                                              (big.x, big.y)),
+              'courtyard/body kisses are being charged -- run-4 regression')
+
+    print('the containment fix did NOT re-promote courtyard in the gate')
+    # run-4 measured courtyard overlap at r=+0.72 with distance-to-truth and
+    # demoted it below hpwl deliberately. Containment is a hard predicate,
+    # not a gate term, so the tuple must be untouched.
+    check('the gate tuple is still 7 terms ending hpwl, overlap',
+          len(reconstruct.GATE_TERMS) == 7
+          and reconstruct.GATE_TERMS[5:] == ('hpwl', 'overlap'),
+          str(reconstruct.GATE_TERMS))
+    check('the engine wires containment into the pair predicate',
+          '_body_contained(state, a, pos_a, b, pos_b)' in src)
 
     print()
     if FAILURES:


### PR DESCRIPTION
The recovery-run harness and loop gates. Fourth in the placement stack, on top of #683 (its diff here includes the three below it until they merge). This is the part that serves #411 (manufacture known-bad placements by perturbing the corpus, then measure recovery) and the agent loop around it; say so if you would rather it lived in the fork.

## What is in it

- Staging with the control board fenced OUTSIDE the work dir and a content-based leak audit: a pose record is caught by its content whatever it is named.
- `tee_cmd`: per-command timing ledger and a `.done` completion marker that is last-attempt-wins (absent while a retry runs).
- `run_watch` and a lever-provenance audit: every tool that writes poses declares itself, so a hand-written pose can be told from an engine's.
- Loop driver gates: the handoff and the close refuse until someone has LOOKED at a render and written observations before reading the numbers; `RUN_STATE.json` as the machine-readable NOW view. (Upstream already has `converge --exhausted`; this adds only RUN_STATE.) `check_complete` prints the components it found NOT APPLICABLE instead of folding them into the verdict silently.

`routing_diagnostics` is an identical copy of the routing PR's module; one test here reads its verdict.

## Testing

On top of the instruments PR: compiles; `loop_driver --self-test` green; green: `test_431_board_gates`, `test_run23_tee_done`, `test_run23_run_state`, `test_run20_not_applicable`, `test_provenance_audit`, `test_board_score_vacuity`, `test_run20_oob_channel`, `test_run23_budget_honesty`, `test_run22_driver_workdir`, `test_run21_watcher_self_scan`, `test_run8_gate_conjuncts`, `test_doc_flag_liveness`, `test_run20_run_watch`.
