### PR TITLE
machine-readable run output: JSON_SUMMARY_MIN, boxed-in and finalize verdicts

### DIFF
--- a/docs/rip-up-reroute.md
+++ b/docs/rip-up-reroute.md
@@ -151,9 +151,9 @@ does: the file front rewrites the output as the input board; the GUI front
 returns an empty change-set, which is a true rollback rather than an un-apply
 because the plugin's applier runs *after* `batch_route` returns and therefore
 never touches the live board. The GUI also receives the verdict as
-`results_data['improvement_gate']`; diagnostics (`blockers`, `pad_pairs_open`)
-survive a rejection, since they are what the caller needs in order to try
-something different.
+`results_data['improvement_gate']`; diagnostics (`blockers`, `pad_pairs_open`,
+`boxed_in`) survive a rejection, since they are what the caller needs in order
+to try something different.
 
 The gate is skipped when it cannot mean anything: a run whose input board has
 no copper at all (nothing to regress), an in-place run (`output == input`,

--- a/py_router/reroute_loop.py
+++ b/py_router/reroute_loop.py
@@ -588,9 +588,14 @@ def run_reroute_loop(
                     if not ripped_items:
                         print(f"  {RED}ROUTE FAILED - no rippable blockers found{RESET}")
                         from routing_diagnostics import static_boxin_hint, condense_hint
-                        hint = condense_hint(static_boxin_hint(result, config, pcb_data))
+                        hint, _boxin = static_boxin_hint(
+                            result, config, pcb_data, return_verdict=True)
+                        hint = condense_hint(hint)
                         if hint:
                             print(f"  {hint}")
+                        if _boxin:
+                            record_net_event(state, ripped_net_id,
+                                             "boxed_in_static", _boxin)
                     # Remove from pending_multipoint_nets to prevent Phase 3 from
                     # trying to route taps for a net with no main route.
                     if ripped_net_id in state.pending_multipoint_nets:

--- a/py_router/route.py
+++ b/py_router/route.py
@@ -266,6 +266,7 @@ def _empty_results_data() -> dict:
         'segments_to_remove': [],
         'vias_to_remove': [],
         'blockers': [],
+        'boxed_in': [],
         'pad_pairs_open': [],
     }
 
@@ -530,7 +531,14 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
     # previous board in the same (GUI) process.
     from routing_diagnostics import reset_hint_condenser
     reset_hint_condenser()
-    if json_out:
+    # Every OUTERMOST entry starts the summary sink clean, not only a
+    # --json-out one: the GUI calls batch_route once per click in ONE
+    # process with no json_out, and a sink that survived the previous
+    # click would merge the next run's JSON_SUMMARY_MIN onto the previous
+    # run's summaries (effort keys summed, pad-pair attribution from the
+    # old run) and stamp its summaries 'reconciliation-subset'. Nested
+    # sub-runs pass final_reconcile=False and so keep the live sink.
+    if json_out or final_reconcile:
         _SUMMARY_SINK.clear()
         _RECONCILE_RAISED[0] = False
     if not _SUMMARY_SINK:
@@ -3376,6 +3384,7 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
     # a net that failed early but was later rescued/rerouted is filtered out
     # here because the final failed sets are authoritative.
     blockers_report = []
+    boxed_in_report = []
     try:
         _final_failed_ids = list(dict.fromkeys(
             failed_single_ids + [m['net_id'] for m in failed_multipoint]))
@@ -3406,8 +3415,21 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
                     'net': _name, 'stage': 'preexisting',
                     'blocked_by': [{'net': _bn, 'preexisting': True}
                                    for _bn in _pre103]})
+            # The static-vs-congestion verdict (the "boxed in by static
+            # obstacles" hint, #95) as its OWN key, beside `blockers` rather
+            # than inside it: `blockers` names WHICH routed copper is in the
+            # way, `boxed_in` says whether anything rippable is in the way at
+            # all, and a consumer reads both.
+            _bx = None
+            for _ev in (state.net_history.get(_nid) or []):
+                if _ev.get('event') == 'boxed_in_static':
+                    _bx = _ev.get('details') or _bx
+            if _bx:
+                boxed_in_report.append(dict(_bx, net=_name))
         if blockers_report:
             summary['blockers'] = blockers_report
+        if boxed_in_report:
+            summary['boxed_in'] = boxed_in_report
     except Exception:
         blockers_report = []
     # #409 follow-up: pad-pair routability tallies (PRR ingredients: connected
@@ -3548,6 +3570,11 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
             'vias_to_remove': stale_input_vias,
             # #409: same data as JSON_SUMMARY['blockers'] (may be empty).
             'blockers': blockers_report,
+            # ...and the static-vs-congestion verdict beside it, same data as
+            # JSON_SUMMARY['boxed_in']. The GUI reads results_data, not the
+            # printed summary, so a key that only reaches stdout does not
+            # reach the plugin (CLAUDE.md's Class-1 CLI/GUI gap).
+            'boxed_in': boxed_in_report,
             # #409 follow-up: same data as JSON_SUMMARY['pad_pairs_open']
             # (may be empty).
             'pad_pairs_open': pad_pairs_open_report,
@@ -3862,6 +3889,14 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
                           f"PLAN. Since #562 a pour alone connects nothing: "
                           f"unless a later route step covers these nets, "
                           f"their pads ship disconnected.{RESET}")
+                    # ...and in the SUMMARY, not only in the log, so a later
+                    # grade can tell a step that declined to weld these pads
+                    # BY PLAN from one that failed to. The printed
+                    # `JSON_SUMMARY:` line predates the finalize, so it does
+                    # NOT carry this key; `summary` sits in `_SUMMARY_SINK` by
+                    # reference, so `--json-out`, the returned dict and the
+                    # JSON_SUMMARY_MIN line (printed last) do.
+                    summary['finalize_excluded_nets'] = _excluded9
             # PRE-GATE for the MODEL-BASED legs (engine taps/joins +
             # cleanup): run them only for zone nets the fill-aware checker
             # says are incomplete on THIS run's board (pcb_data == file
@@ -5091,7 +5126,8 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
                 # the diagnostics (blockers / open pad pairs) -- they are
                 # why the caller asked -- and the gate report itself.
                 _keep6 = {k: results_data.get(k) or []
-                          for k in ('blockers', 'pad_pairs_open')}
+                          for k in ('blockers', 'pad_pairs_open',
+                                    'boxed_in')}
                 results_data = _empty_results_data()
                 results_data.update(_keep6)
                 _action = ("DISCARDED this run's changes (nothing is applied "
@@ -5131,6 +5167,28 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
         except Exception as _ge:
             # A gate that crashes must not take the run's board with it.
             print(f"  (improvement gate skipped: {_ge})")
+
+    # ONE compact authoritative line per outermost run, CLI and GUI alike.
+    # The big JSON_SUMMARY lines are 6-20KB each with scope semantics the log
+    # itself has to warn about; this one is the merged tally in <1KB.
+    # `final_reconcile` is True only on the outermost call (every sub-run --
+    # plane finalize, end-of-run reconcile -- passes False, the #562 recursion
+    # guard), so nested passes never emit a second MIN line. Deliberately the
+    # LAST thing printed: after the reconcile block, so it carries the merged
+    # tally, and after the improvement gate, so it describes the copper that
+    # is actually on the board -- a rejected run says so here, because its
+    # tallies describe a board that was reverted.
+    if final_reconcile:
+        try:
+            from route_summary import merge_summaries as _ms, summary_min
+            _m = _ms(list(_SUMMARY_SINK), _RECONCILE_RAISED[0])
+            if _m:
+                _min = summary_min(_m)
+                if _gate_report and _gate_report.get('verdict') == 'reject':
+                    _min['improvement_gate'] = 'reverted'
+                print("JSON_SUMMARY_MIN: " + json.dumps(_min, sort_keys=True))
+        except Exception as _e:                                 # noqa: BLE001
+            print(f"  WARNING: could not emit JSON_SUMMARY_MIN: {_e}")
 
     if return_results:
         return successful, failed, total_time, results_data

--- a/py_router/route.py
+++ b/py_router/route.py
@@ -295,6 +295,41 @@ def _plane_finalize_active() -> bool:
     return _PLANE_FINALIZE_DEPTH > 0
 
 
+def _emit_summary_min(gate_report: Optional[dict] = None,
+                      status: Optional[str] = None) -> None:
+    """Print the ONE compact verdict line for an outermost run.
+
+    Shared by the normal end-of-run path and the two "nothing to route" early
+    returns. The contract a consumer relies on is "exactly one
+    JSON_SUMMARY_MIN per outermost run", and a step that legitimately did
+    nothing -- "All nets are already fully connected", the routine state a
+    replay or a retry step lands in -- must still satisfy it. A missing line
+    there is indistinguishable from a crash, which is the one reading that
+    would make an agent do the wrong thing.
+
+    `status` names WHY the tally is empty on those paths; it is absent on an
+    ordinary run.
+    """
+    try:
+        from route_summary import merge_summaries as _ms, summary_min
+        _m = _ms(list(_SUMMARY_SINK), _RECONCILE_RAISED[0])
+        if _m is None and status is not None:
+            # The early returns fire before any summary is built, so there is
+            # nothing in the sink to merge: synthesize the empty tally rather
+            # than print nothing.
+            _m = {'successful': 0, 'failed': 0}
+        if not _m:
+            return
+        _min = summary_min(_m)
+        if status is not None:
+            _min['status'] = status
+        if gate_report and gate_report.get('verdict') == 'reject':
+            _min['improvement_gate'] = 'reverted'
+        print("JSON_SUMMARY_MIN: " + json.dumps(_min, sort_keys=True))
+    except Exception as _e:                                     # noqa: BLE001
+        print(f"  WARNING: could not emit JSON_SUMMARY_MIN: {_e}")
+
+
 def batch_route(input_file: str, output_file: str, net_names: List[str],
                 layers: List[str] = None,
                 bga_exclusion_zones: Optional[List[Tuple[float, float, float, float]]] = None,
@@ -1104,6 +1139,8 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
                 f"a trailing carriage return) or a stale net list. "
                 f"First few: {', '.join(repr(n) for n in list(net_names)[:5])}")
         print("No valid nets to route!")
+        if final_reconcile:
+            _emit_summary_min(status='no_valid_nets')
         if return_results:
             return 0, 0, 0.0, _empty_results_data()
         _write_passthrough_output(input_file, output_file)
@@ -1210,6 +1247,8 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
                   f"from scratch (#515).")
     if not net_ids:
         print("All nets are already fully connected - nothing to route!")
+        if final_reconcile:
+            _emit_summary_min(status='already_connected')
         if return_results:
             return 0, 0, 0.0, _empty_results_data()
         _write_passthrough_output(input_file, output_file)
@@ -5177,18 +5216,12 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
     # LAST thing printed: after the reconcile block, so it carries the merged
     # tally, and after the improvement gate, so it describes the copper that
     # is actually on the board -- a rejected run says so here, because its
-    # tallies describe a board that was reverted.
+    # tallies describe a board that was reverted. It is the last line
+    # batch_route prints, NOT the last line of a run: main()'s .kicad_pro
+    # DRC-floor writeback reports after this, so read the log for the line,
+    # do not tail it.
     if final_reconcile:
-        try:
-            from route_summary import merge_summaries as _ms, summary_min
-            _m = _ms(list(_SUMMARY_SINK), _RECONCILE_RAISED[0])
-            if _m:
-                _min = summary_min(_m)
-                if _gate_report and _gate_report.get('verdict') == 'reject':
-                    _min['improvement_gate'] = 'reverted'
-                print("JSON_SUMMARY_MIN: " + json.dumps(_min, sort_keys=True))
-        except Exception as _e:                                 # noqa: BLE001
-            print(f"  WARNING: could not emit JSON_SUMMARY_MIN: {_e}")
+        _emit_summary_min(_gate_report)
 
     if return_results:
         return successful, failed, total_time, results_data

--- a/py_router/route_summary.py
+++ b/py_router/route_summary.py
@@ -153,6 +153,17 @@ def merge_summaries(summaries: List[Dict], aborted: bool = False) -> Optional[Di
                     _failed |= {d.get('net_name') if isinstance(d, dict) else d
                                 for d in (merged.get('failed_multipoint') or [])}
                 merged[_k] = [e for e in first[_k] if e.get('net') in _failed]
+        # `finalize_excluded_nets` carries WHOLE, not through the
+        # still-failing filter: it is a list of net NAMES rather than per-net
+        # records, and it states what the finalize declined to do BY PLAN --
+        # something the reconcile sub-run neither repeats nor revokes. It is
+        # stamped on the summary AFTER the JSON_SUMMARY line printed, so it
+        # exists only on `first`; without this carry, last-wins drops it on
+        # exactly the runs that reconciled -- i.e. the failing ones, where
+        # telling "declined by plan" from "failed to" is the whole point.
+        if ('finalize_excluded_nets' in first
+                and 'finalize_excluded_nets' not in merged):
+            merged['finalize_excluded_nets'] = first['finalize_excluded_nets']
 
     # Coverage-gate nets have NO routed result, so their pads never reach
     # multipoint_pads_total and a caller's
@@ -231,7 +242,15 @@ def summary_min(merged: Dict, name_cap: int = 20) -> Dict:
         'terminal_restores_broken': _names(broken_restores),
         'min_clearance_used': merged.get('min_clearance_used'),
         'vias': merged.get('total_vias'),
-        'duration_s': merged.get('total_time'),
+        # NOT wall clock, and named for what it actually counts. `total_time`
+        # is the single-ended loop plus the reroute loop and nothing else --
+        # phase-3 taps, rescues, the plane finalize, and parse/write all sit
+        # outside it. Measured on splitflap_driver: 0.35 against 20.72 s of
+        # real wall time, a 59x under-report. The big summary can afford to
+        # call it `total_time` among thirty other keys; a one-line verdict an
+        # agent reads INSTEAD of those cannot call it `duration_s` without
+        # asserting the run took that long.
+        'main_loop_time_s': merged.get('total_time'),
     }
     if merged.get('finalize_excluded_nets'):
         out['finalize_excluded_nets'] = _names(

--- a/py_router/route_summary.py
+++ b/py_router/route_summary.py
@@ -21,10 +21,17 @@ import json
 import re
 from typing import Dict, List, Optional
 
-__all__ = ['merge_summaries', 'merge_route_summaries',
-           'SUMMARY_RE', 'RECONCILE_ABORTED', 'EFFORT_KEYS']
+__all__ = ['merge_summaries', 'merge_route_summaries', 'summary_min',
+           'SUMMARY_RE', 'SUMMARY_MIN_RE', 'RECONCILE_ABORTED', 'EFFORT_KEYS']
 
 SUMMARY_RE = re.compile(r'JSON_SUMMARY: (\{.*\})')
+
+# The one-line compact tally route.py prints at the end of every OUTERMOST
+# run (CLI and GUI alike): the merged verdict in <1KB, where the big
+# JSON_SUMMARY lines run 6-20KB each with scope semantics the log has to warn
+# about. The trailing colon-space differs from SUMMARY_RE's subject, so
+# neither regex can eat the other.
+SUMMARY_MIN_RE = re.compile(r'JSON_SUMMARY_MIN: (\{.*\})')
 
 # route.py prints this from the except around its reconciliation self-invoke.
 # The sub-run prints its JSON_SUMMARY BEFORE the board is written, so a summary
@@ -133,12 +140,19 @@ def merge_summaries(summaries: List[Dict], aborted: bool = False) -> Optional[Di
                 merged['pad_pairs_connected'] = first.get('pad_pairs_connected', 0)
                 if 'pad_pairs_open' in first:
                     merged['pad_pairs_open'] = first['pad_pairs_open']
-        if 'blockers' in first and 'blockers' not in merged:
-            _failed = set(merged.get('failed_single') or [])
-            _failed |= {d.get('net_name') if isinstance(d, dict) else d
-                        for d in (merged.get('failed_multipoint') or [])}
-            merged['blockers'] = [e for e in first['blockers']
-                                  if e.get('net') in _failed]
+        # `blockers` and `boxed_in` are both first-pass attribution: the
+        # reconcile sub-run re-routes a SUBSET and its summary carries neither,
+        # so without this a merged summary loses the evidence for nets that are
+        # still failing. Filtered to the nets that ARE still failing, so a net
+        # the reconcile fixed does not carry a stale accusation.
+        _failed = None
+        for _k in ('blockers', 'boxed_in'):
+            if _k in first and _k not in merged:
+                if _failed is None:
+                    _failed = set(merged.get('failed_single') or [])
+                    _failed |= {d.get('net_name') if isinstance(d, dict) else d
+                                for d in (merged.get('failed_multipoint') or [])}
+                merged[_k] = [e for e in first[_k] if e.get('net') in _failed]
 
     # Coverage-gate nets have NO routed result, so their pads never reach
     # multipoint_pads_total and a caller's
@@ -168,3 +182,58 @@ def merge_route_summaries(log: str) -> Optional[Dict]:
     summaries = [json.loads(s) for s in raw]
     aborted = log.rfind(RECONCILE_ABORTED) > log.rfind(raw[-1])
     return merge_summaries(summaries, aborted)
+
+
+def summary_min(merged: Dict, name_cap: int = 20) -> Dict:
+    """The <1KB verdict an agent reads INSTEAD of the big summaries.
+
+    Every value here is derived from the MERGED tally, so it carries the
+    "run-scope plus recoveries" semantics automatically -- the trap the log
+    warns about ("never scrape the LAST JSON_SUMMARY") cannot be re-imported
+    through this line. Name lists are capped at `name_cap` with an explicit
+    '+N more' marker, never silently truncated.
+
+    `finalize_excluded_nets` (plane nets outside the route's --nets scope,
+    excluded from the finalize by plan) is set on the summary AFTER the
+    `JSON_SUMMARY:` line was printed, so it reaches `--json-out`, the dict
+    `batch_route` returns, and this line -- not the printed big summary. It
+    is included here only when present.
+
+    Deliberately ABSENT: power_widths, ampacity, stacked copper --
+    forensics that stay in the big summaries / --json-out. And the DRC-floor
+    writeback verdict, which does not exist yet when this prints: the
+    writeback runs afterwards and reports on its own, so a consumer must
+    read both -- this line says nothing about whether the floors held.
+    """
+    def _names(vals) -> List[str]:
+        names = [str(v) for v in (vals or [])]
+        if len(names) > name_cap:
+            return names[:name_cap] + [f'+{len(names) - name_cap} more']
+        return names
+
+    pairs = merged.get('pad_pairs_open') or []
+    tr = merged.get('terminal_restores') or {}
+    broken_restores = sorted(n for n, v in tr.items()
+                             if v in ('full_open', 'stub'))
+    total = merged.get('multipoint_pads_total') or 0
+    conn = merged.get('multipoint_pads_connected') or 0
+    out = {
+        'scope': 'merged',
+        'routed': merged.get('successful'),
+        'failed': merged.get('failed'),
+        'failed_single': _names(merged.get('failed_single')),
+        'open_single': _names(merged.get('open_single')),
+        'multipoint_deficit': max(0, total - conn),
+        'pad_pairs_open': {
+            'count': len(pairs),
+            'nets': _names(sorted({p.get('net') for p in pairs
+                                   if p.get('net')}))},
+        'terminal_restores_broken': _names(broken_restores),
+        'min_clearance_used': merged.get('min_clearance_used'),
+        'vias': merged.get('total_vias'),
+        'duration_s': merged.get('total_time'),
+    }
+    if merged.get('finalize_excluded_nets'):
+        out['finalize_excluded_nets'] = _names(
+            merged['finalize_excluded_nets'])
+    return out

--- a/py_router/routing_diagnostics.py
+++ b/py_router/routing_diagnostics.py
@@ -540,7 +540,7 @@ def preexisting_blocker_hint(blocked_cells, config, pcb_data, net_id,
             f"cannot be), then bisect if you want a minimal rip." + prot_txt, names)
 
 
-def static_boxin_hint(result, config, pcb_data=None) -> str:
+def static_boxin_hint(result, config, pcb_data=None, *, return_verdict=False):
     """One-line hint when a route died immediately with nothing rippable.
 
     A failure with almost no A* iterations and no rippable blockers means the
@@ -548,12 +548,20 @@ def static_boxin_hint(result, config, pcb_data=None) -> str:
     clearance expansion) - typical for fine-pitch (0.4-0.65 mm) packages at
     coarse grid/clearance settings - not by other nets' routes (issue #95).
     Returns '' when the failure doesn't match that signature.
+
+    `return_verdict=True` returns `(hint, verdict_or_None)` -- the same shape
+    `preexisting_blocker_hint`'s `return_names=True` uses -- so callers can
+    record the static-vs-congestion decision as data (`boxed_in` in the
+    summary) instead of only printing it.
     """
+    def _ret(hint, verdict=None):
+        return (hint, verdict) if return_verdict else hint
+
     if result is None:
-        return ""
+        return _ret("")
     iters = result.get('iterations_forward', 0) + result.get('iterations_backward', 0)
     if iters >= 20000:
-        return ""
+        return _ret("")
     finer = config.grid_step / 2
     # Don't steer users into an OOM (issue #105): halving the grid step
     # quadruples cell count. Above ~4M cells per layer, suggest scoping the
@@ -566,10 +574,18 @@ def static_boxin_hint(result, config, pcb_data=None) -> str:
             grid_advice = (f"--grid-step {finer:g} scoped to just the failing nets "
                            f"via --nets (board-global it is ~{cells / 1e6:.0f}M "
                            f"cells/layer and may exhaust memory)")
-    return (f"Hint: search exhausted after only {iters} iterations with no rippable "
-            f"blockers - the start/target pads are boxed in by static obstacles "
-            f"(neighboring pads + clearance), not by congestion. For fine-pitch "
-            f"parts try a finer grid and/or smaller clearance/track, e.g. "
-            f"{grid_advice} --clearance 0.15 --track-width 0.15 "
-            f"(current: grid {config.grid_step:g}, clearance {config.clearance:g}, "
-            f"track {config.track_width:g} mm)")
+    return _ret(
+        f"Hint: search exhausted after only {iters} iterations with no rippable "
+        f"blockers - the start/target pads are boxed in by static obstacles "
+        f"(neighboring pads + clearance), not by congestion. For fine-pitch "
+        f"parts try a finer grid and/or smaller clearance/track, e.g. "
+        f"{grid_advice} --clearance 0.15 --track-width 0.15 "
+        f"(current: grid {config.grid_step:g}, clearance {config.clearance:g}, "
+        f"track {config.track_width:g} mm)",
+        # The same decision as data: the iteration count it was made on and
+        # the geometry that was in force.
+        {'verdict': 'boxed_in_static', 'iterations': iters,
+         'geometry': {'grid_step': config.grid_step,
+                      'clearance': config.clearance,
+                      'track_width': config.track_width,
+                      'via_diameter': getattr(config, 'via_diameter', None)}})

--- a/py_router/single_ended_loop.py
+++ b/py_router/single_ended_loop.py
@@ -1457,11 +1457,18 @@ def route_single_ended_nets(
                 from routing_diagnostics import (static_boxin_hint,
                                                  preexisting_blocker_hint,
                                                  condense_hint)
-                hint = static_boxin_hint(result, config, pcb_data)
+                hint, _boxin = static_boxin_hint(result, config, pcb_data,
+                                                 return_verdict=True)
                 if hint:
                     hint = condense_hint(hint)
                     if hint:
                         print(f"  {hint}")
+                if _boxin:
+                    # The verdict, not just the sentence. `preexisting_blockers`
+                    # below has been recorded and serialized since #301; this
+                    # one -- the static-vs-congestion decision the whole retry
+                    # ladder turns on -- was print-only.
+                    record_net_event(state, net_id, "boxed_in_static", _boxin)
                 # #301: the blockers may be PRE-EXISTING copper (earlier run/
                 # step) the rip-up attribution cannot see -- name them and the
                 # --rip-existing-nets retry. Cells were popped into

--- a/tests/test_boxed_in_summary.py
+++ b/tests/test_boxed_in_summary.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""The static-vs-congestion verdict stops being a sentence.
+
+The router has printed "boxed in by static obstacles (neighboring pads +
+clearance), not by congestion" on this failure shape since #95. Run 20 spent
+three grid refinements against exactly that sentence -- 0.05 -> 0.025 -> 0.0125,
+about 40 minutes, with the same three nets failing at every resolution -- because
+a sentence is not something a gate can read. Its sibling
+`preexisting_blocker_hint` has been recorded via `record_net_event` and
+serialized since #301; this one, the decision the whole retry ladder turns on,
+was print-only.
+
+THE INVARIANT THIS FILE EXISTS FOR: `summary['boxed_in']` is a SEPARATE key that
+adds NOTHING to `summary['blockers']`. The routing skill's classifier row is
+"`blockers` empty; the log says boxed in", so a verdict that leaked into
+`blockers` would silently turn every box-in into a congestion finding -- breaking
+the very clause being fixed. The row can then read "`blockers` empty AND
+`boxed_in` names the net": one JSON test, no regex.
+
+Note the invariant is NOT "`blockers` is empty on this fixture". It is not: the
+frontier analysis legitimately attributes the static WALL, because since e2ffa29
+pre-existing copper is rip-candidate and therefore attributable. The two keys
+answer different questions -- WHICH copper is in the way, versus whether anything
+RIPPABLE is in the way at all -- and the test asserts they keep their own schemas.
+
+    python3 tests/test_boxed_in_summary.py
+"""
+import io
+import json
+import os
+import re
+import sys
+from contextlib import redirect_stdout
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+_R = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for _p in (_R, os.path.join(_R, 'py_router'), os.path.join(_R, 'py_tools')):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from kicad_parser import BoardInfo                                # noqa: E402
+from synth import make_net, make_pad, make_pcb, make_seg          # noqa: E402
+
+X, WALL = 1, 2
+CHECKS = []
+
+
+def check(name, ok, detail=''):
+    CHECKS.append((name, ok))
+    print(f"  {'PASS' if ok else 'FAIL'}: {name}" + (f' -- {detail}' if not ok else ''))
+
+
+def _board():
+    """X's source pad sealed inside a box of STATIC copper.
+
+    Static on purpose: the wall is pre-existing and out of scope, and with
+    `max_rip_up_count=0` nothing is rippable at all. That is the exact
+    signature -- a search that dies in almost no iterations with no rippable
+    blockers -- and it is a geometry fact, not a congestion one.
+    """
+    bi = BoardInfo(layers={0: 'F.Cu', 31: 'B.Cu'},
+                   copper_layers=['F.Cu', 'B.Cu'],
+                   board_bounds=(0.0, 0.0, 10.0, 10.0))
+    pads = {X: [make_pad(X, 2.0, 5.0, ref='U1', num='1', net_name='X',
+                         size_x=0.3, size_y=0.3),
+                make_pad(X, 8.0, 5.0, ref='U2', num='1', net_name='X',
+                         size_x=0.3, size_y=0.3)],
+            WALL: []}
+    # A sealed box around the source pad, on BOTH layers so a via cannot
+    # escape either.
+    segs = []
+    for lay in ('F.Cu', 'B.Cu'):
+        segs += [make_seg(1.4, 4.4, 2.6, 4.4, net_id=WALL, width=0.4, layer=lay),
+                 make_seg(1.4, 5.6, 2.6, 5.6, net_id=WALL, width=0.4, layer=lay),
+                 make_seg(1.4, 4.4, 1.4, 5.6, net_id=WALL, width=0.4, layer=lay),
+                 make_seg(2.6, 4.4, 2.6, 5.6, net_id=WALL, width=0.4, layer=lay)]
+    return make_pcb(nets={X: make_net(X, 'X'), WALL: make_net(WALL, 'WALL')},
+                    segments=segs, pads_by_net=pads, board_info=bi)
+
+
+def case_static_cage():
+    """First-pass failure: the single_ended_loop records the verdict."""
+    from route import batch_route
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        _ok, _fail, _t, results_data = batch_route(
+                    'synthetic', '', ['X'], layers=['F.Cu', 'B.Cu'],
+                    clearance=0.2, track_width=0.2, via_size=0.5,
+                    via_drill=0.3, grid_step=0.1,
+                    ordering_strategy='original', final_reconcile=False,
+                    max_rip_up_count=0, return_results=True, pcb_data=_board())
+    out = buf.getvalue()
+    m = re.findall(r'JSON_SUMMARY: (\{.*\})', out)
+    check('JSON_SUMMARY present', bool(m))
+    summary = json.loads(m[-1]) if m else {}
+
+    check('X failed to route (the fixture is a cage, not a routable board)',
+          'X' in (summary.get('failed_single') or []),
+          str(summary.get('failed_single')))
+
+    boxed = summary.get('boxed_in')
+    if not isinstance(boxed, list):
+        check("summary carries a 'boxed_in' key", False,
+              f'{boxed!r} -- the hint printed: '
+              + ('yes' if 'boxed in by static obstacles' in out else 'NO, so '
+                 'this fixture no longer reproduces the signature and the test '
+                 'is measuring nothing'))
+    else:
+        check("summary carries a 'boxed_in' key", True)
+        check('it names the failing net',
+              [e.get('net') for e in boxed] == ['X'], str(boxed))
+        e = boxed[0]
+        check("the verdict is 'boxed_in_static'",
+              e.get('verdict') == 'boxed_in_static', str(e))
+        check('it carries the iteration count the decision was made on',
+              isinstance(e.get('iterations'), int) and e['iterations'] < 20000,
+              str(e.get('iterations')))
+        g = e.get('geometry') or {}
+        check('and the geometry that was IN FORCE, so a guard can ask whether '
+              'it is at the board floor',
+              abs((g.get('grid_step') or 0) - 0.1) < 1e-9
+              and abs((g.get('clearance') or 0) - 0.2) < 1e-9
+              and abs((g.get('track_width') or 0) - 0.2) < 1e-9, str(g))
+
+    # THE INVARIANT, stated correctly. It is NOT "`blockers` is empty" -- on
+    # this fixture the frontier analysis legitimately attributes the WALL, and
+    # since e2ffa29 pre-existing copper is rip-candidate and so attributable.
+    # The invariant is that `boxed_in` is a SEPARATE key that adds nothing to
+    # `blockers`: the skill's classifier row reads both, and a verdict that
+    # leaked into `blockers` would silently turn every box-in into a
+    # congestion finding -- breaking the clause this key exists to make
+    # readable.
+    _bl = summary.get('blockers') or []
+    check("no `blockers` entry carries a boxed-in verdict",
+          all(set(b) <= {'net', 'stage', 'blocked_by'} for b in _bl),
+          f'{[sorted(b) for b in _bl]} -- `blockers` entries must keep exactly '
+          f'their #409/#301 schema')
+    check('and no `boxed_in` entry carries blocker attribution',
+          all('blocked_by' not in e for e in (boxed if isinstance(boxed, list)
+                                              else [])),
+          str(boxed) + ' -- the two answer different questions: WHICH copper '
+          'is in the way, versus whether anything rippable is in the way at all')
+
+    # GUI parity: the plugin reads results_data, never the printed summary.
+    check('results_data carries the same boxed_in (GUI parity)',
+          results_data.get('boxed_in') == summary.get('boxed_in'),
+          f'{results_data.get("boxed_in")!r} vs {summary.get("boxed_in")!r}')
+
+    # And the prose is still printed, because a human reading a log is still a
+    # consumer -- the key is additive, not a replacement.
+    check('the human-readable hint is still printed',
+          'boxed in by static obstacles' in out, out[-400:])
+
+
+A, B = 3, 4   # WALL is 2 above; a locked wall keeps the same net id here
+
+
+def _rip_victim_board():
+    """Two in-scope nets share a one-track gap in a LOCKED wall.
+
+    A and B start inside a box of KiCad-locked copper (never rippable, no
+    override) whose only exit is a gap on F.Cu wide enough for one track;
+    B.Cu is sealed. A routes first and takes the gap. B's only way out is
+    through A, so B rips A and routes. A then comes back through the REROUTE
+    queue, finds the gap full of B -- which its rip ancestry forbids it to
+    rip -- and the locked wall everywhere else: a search that dies in a few
+    thousand iterations with nothing rippable, i.e. the boxed-in signature,
+    reached from `reroute_loop` rather than the first-pass loop. (Plain
+    pre-existing copper would not do: since e2ffa29 it is a rip candidate,
+    and with max_rip_up_count>0 the router rips the wall itself.)
+    """
+    bi = BoardInfo(layers={0: 'F.Cu', 31: 'B.Cu'},
+                   copper_layers=['F.Cu', 'B.Cu'],
+                   board_bounds=(0.0, 0.0, 10.0, 10.0))
+    pads = {A: [make_pad(A, 1.5, 4.6, ref='U1', num='1', net_name='A',
+                         size_x=0.3, size_y=0.3),
+                make_pad(A, 8.0, 4.6, ref='U2', num='1', net_name='A',
+                         size_x=0.3, size_y=0.3)],
+            B: [make_pad(B, 1.5, 5.4, ref='U1', num='2', net_name='B',
+                         size_x=0.3, size_y=0.3),
+                make_pad(B, 8.0, 5.4, ref='U2', num='2', net_name='B',
+                         size_x=0.3, size_y=0.3)],
+            WALL: []}
+    segs = []
+    for lay in ('F.Cu', 'B.Cu'):
+        segs += [make_seg(0.6, 3.6, 3.4, 3.6, net_id=WALL, width=0.4,
+                          layer=lay, locked=True),
+                 make_seg(0.6, 6.4, 3.4, 6.4, net_id=WALL, width=0.4,
+                          layer=lay, locked=True),
+                 make_seg(0.6, 3.6, 0.6, 6.4, net_id=WALL, width=0.4,
+                          layer=lay, locked=True)]
+    # Right wall: a one-track gap (copper edges 4.6..5.4) on F.Cu; sealed on
+    # B.Cu so a via cannot escape either.
+    segs += [make_seg(3.4, 3.6, 3.4, 4.4, net_id=WALL, width=0.4,
+                      layer='F.Cu', locked=True),
+             make_seg(3.4, 5.6, 3.4, 6.4, net_id=WALL, width=0.4,
+                      layer='F.Cu', locked=True),
+             make_seg(3.4, 3.6, 3.4, 6.4, net_id=WALL, width=0.4,
+                      layer='B.Cu', locked=True)]
+    return make_pcb(nets={A: make_net(A, 'A'), B: make_net(B, 'B'),
+                          WALL: make_net(WALL, 'WALL')},
+                    segments=segs, pads_by_net=pads, board_info=bi)
+
+
+def case_rip_victim_reroute():
+    """Reroute-path failure: `reroute_loop` records the verdict too.
+
+    The recording call in reroute_loop.py sits on the rip-victim reroute path,
+    which the first-pass cage above never reaches (its single net fails before
+    anything is ripped). This fixture was run under `coverage` while writing
+    the test: the reroute_loop call executed and the single_ended_loop one did
+    not. Without a coverage run the test still pins the path causally: A
+    ROUTED on its first pass (it is not in the failed set until after B ripped
+    it), so the only place A can have acquired a boxed-in verdict is its
+    reroute.
+    """
+    from route import batch_route
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        _ok, _fail, _t, results_data = batch_route(
+                    'synthetic', '', ['A', 'B'], layers=['F.Cu', 'B.Cu'],
+                    clearance=0.2, track_width=0.2, via_size=0.5,
+                    via_drill=0.3, grid_step=0.1,
+                    ordering_strategy='original', final_reconcile=False,
+                    max_rip_up_count=1, return_results=True,
+                    pcb_data=_rip_victim_board())
+    out = buf.getvalue()
+    m = re.findall(r'JSON_SUMMARY: (\{.*\})', out)
+    check('JSON_SUMMARY present (rip victim)', bool(m))
+    summary = json.loads(m[-1]) if m else {}
+
+    i_rip = out.find('Ripping up A')
+    i_rer = out.find('Re-routing ripped net A')
+    i_box = out.find('no rippable blockers found')
+    check('B ripped A and A was re-queued (the fixture exercises the reroute '
+          'path, not the first-pass loop)',
+          0 <= i_rip < i_rer < i_box,
+          f'rip@{i_rip} reroute@{i_rer} boxed@{i_box}')
+    check('B routed through the gap, A failed',
+          summary.get('failed_single') == ['A']
+          and summary.get('successful') == 1,
+          f"{summary.get('failed_single')} successful="
+          f"{summary.get('successful')}")
+    boxed = summary.get('boxed_in')
+    check("summary carries 'boxed_in' for the rip victim",
+          isinstance(boxed, list) and [e.get('net') for e in boxed] == ['A'],
+          f'{boxed!r}; hint printed: '
+          + str('boxed in by static obstacles' in out))
+    if isinstance(boxed, list) and boxed:
+        e = boxed[0]
+        check("rip victim's verdict is 'boxed_in_static' with an iteration "
+              "count below the static threshold",
+              e.get('verdict') == 'boxed_in_static'
+              and isinstance(e.get('iterations'), int)
+              and e['iterations'] < 20000, str(e))
+    check("and `blockers` is empty for it -- the classifier row "
+          "\"`blockers` empty AND `boxed_in` names the net\"",
+          not [b for b in (summary.get('blockers') or [])
+               if b.get('net') == 'A'],
+          str(summary.get('blockers')))
+    check('results_data carries the same boxed_in (GUI parity, rip victim)',
+          results_data.get('boxed_in') == summary.get('boxed_in'),
+          f'{results_data.get("boxed_in")!r} vs {summary.get("boxed_in")!r}')
+
+
+def case_merge_keeps_boxed_in():
+    """`boxed_in` merges like `blockers`: first-pass evidence, filtered to
+    the nets the reconcile sub-run left failing."""
+    from route_summary import merge_summaries
+    first = {'scope': 'run', 'successful': 0, 'failed': 2,
+             'failed_single': ['X', 'Y'],
+             'blockers': [{'net': 'X', 'stage': 'initial', 'blocked_by': []},
+                          {'net': 'Y', 'stage': 'initial', 'blocked_by': []}],
+             'boxed_in': [{'net': 'X', 'verdict': 'boxed_in_static',
+                           'iterations': 10},
+                          {'net': 'Y', 'verdict': 'boxed_in_static',
+                           'iterations': 12}]}
+    second = {'scope': 'reconciliation-subset', 'successful': 1, 'failed': 1,
+              'failed_single': ['Y']}
+    merged = merge_summaries([first, second])
+    check('merged boxed_in keeps only the net still failing (Y), clears X',
+          [e.get('net') for e in (merged or {}).get('boxed_in') or []] == ['Y'],
+          str((merged or {}).get('boxed_in')))
+    check('and blockers filter the same way (unchanged behaviour)',
+          [e.get('net') for e in (merged or {}).get('blockers') or []] == ['Y'],
+          str((merged or {}).get('blockers')))
+    check('a summary with no boxed_in at all gains no key',
+          'boxed_in' not in (merge_summaries([second]) or {}),
+          str(merge_summaries([second])))
+
+
+def _open_board():
+    """A routable two-pad net whose pads sit on OPPOSITE layers, so every
+    run places exactly one via -- a countable effort the sink bug doubles."""
+    bi = BoardInfo(layers={0: 'F.Cu', 31: 'B.Cu'},
+                   copper_layers=['F.Cu', 'B.Cu'],
+                   board_bounds=(0.0, 0.0, 10.0, 10.0))
+    pads = {A: [make_pad(A, 2.0, 5.0, ref='U1', num='1', net_name='A',
+                         size_x=0.5, size_y=0.5, layers=('F.Cu',)),
+                make_pad(A, 8.0, 5.0, ref='U2', num='1', net_name='A',
+                         size_x=0.5, size_y=0.5, layers=('B.Cu',))]}
+    return make_pcb(nets={A: make_net(A, 'A')}, pads_by_net=pads,
+                    board_info=bi)
+
+
+def case_gui_front_second_run():
+    """Two outermost calls in ONE process, the GUI's shape (no --json-out,
+    default final_reconcile): the second run's JSON_SUMMARY_MIN must describe
+    the second run only. Before the sink reset on every outermost entry the
+    merge summed effort keys across both runs and stamped the second run's
+    summaries 'reconciliation-subset'."""
+    from route import batch_route
+    outs = []
+    for _ in range(2):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            batch_route('synthetic', '', ['A'], layers=['F.Cu', 'B.Cu'],
+                        clearance=0.2, track_width=0.2, via_size=0.5,
+                        via_drill=0.3, grid_step=0.1,
+                        ordering_strategy='original', max_rip_up_count=0,
+                        return_results=True, pcb_data=_open_board())
+        outs.append(buf.getvalue())
+    big = re.findall(r'JSON_SUMMARY: (\{.*\})', outs[1])
+    mins = re.findall(r'JSON_SUMMARY_MIN: (\{.*\})', outs[1])
+    check('second run prints its own JSON_SUMMARY', bool(big))
+    check('second run prints exactly one JSON_SUMMARY_MIN', len(mins) == 1,
+          str(len(mins)))
+    if not (big and mins):
+        return
+    s = json.loads(big[-1]); m = json.loads(mins[0])
+    check('the fixture routes with a via (or the effort check is vacuous)',
+          s.get('successful') == 1 and (s.get('total_vias') or 0) >= 1,
+          f"successful={s.get('successful')} total_vias={s.get('total_vias')}")
+    check("second run's summary is scoped 'run', not 'reconciliation-subset'",
+          s.get('scope') == 'run', str(s.get('scope')))
+    check("MIN vias equal the second run's own total_vias (not both runs summed)",
+          m.get('vias') == s.get('total_vias'),
+          f"MIN {m.get('vias')} vs own {s.get('total_vias')}")
+    check("MIN routed equals the second run's own count",
+          m.get('routed') == s.get('successful'),
+          f"MIN {m.get('routed')} vs own {s.get('successful')}")
+
+
+def main():
+    print('-- first-pass cage (single_ended_loop)')
+    case_static_cage()
+    print('-- rip victim rerouted into a cage (reroute_loop)')
+    case_rip_victim_reroute()
+    print('-- merge_summaries keeps boxed_in for nets still failing')
+    case_merge_keeps_boxed_in()
+    print('-- GUI front: second outermost run in one process')
+    case_gui_front_second_run()
+
+    bad = [n for n, ok in CHECKS if not ok]
+    print(f"\n{len(CHECKS) - len(bad)} passed, {len(bad)} failed")
+    return 1 if bad else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_run23_summary_min.py
+++ b/tests/test_run23_summary_min.py
@@ -1,0 +1,123 @@
+"""JSON_SUMMARY_MIN: one compact authoritative line per outermost run.
+
+Run 23's route logs carried 53 JSON_SUMMARY lines, the longest 19.8KB, with
+scope semantics the log itself warns about ("never scrape the LAST
+JSON_SUMMARY") -- and every agent consuming them paid that in context, per
+lap. The MIN line is the merged verdict in <1KB, printed exactly once per
+outermost batch_route (final_reconcile gates it, so plane-finalize and
+reconcile sub-runs can never emit a second one).
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))
+
+BOARD = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
+
+
+class TestSummaryMin(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.td = tempfile.TemporaryDirectory()
+        out = os.path.join(cls.td.name, 'routed.kicad_pcb')
+        cls.json_out = os.path.join(cls.td.name, 'sum.json')
+        env = dict(os.environ, PYTHONPATH=ROOT, PYTHONIOENCODING='utf-8',
+                   KRT_NO_BANNER='1')
+        r = subprocess.run(
+            [sys.executable, '-X', 'utf8',
+             os.path.join(ROOT, 'py_router', 'route.py'),
+             BOARD, out, '--json-out', cls.json_out],
+            capture_output=True, text=True, env=env, cwd=ROOT)
+        assert r.returncode == 0, r.stdout[-800:]
+        cls.log = r.stdout
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.td.cleanup()
+
+    def test_exactly_one_min_line_and_it_is_last(self):
+        from route_summary import SUMMARY_MIN_RE, SUMMARY_RE
+        mins = SUMMARY_MIN_RE.findall(self.log)
+        self.assertEqual(len(mins), 1, f'{len(mins)} MIN lines')
+        # Authoritative-last: the MIN line must come after every big summary,
+        # or a tail-reader can still scrape a subset-scope line by accident.
+        self.assertGreater(self.log.rfind('JSON_SUMMARY_MIN: '),
+                           max((self.log.rfind('JSON_SUMMARY: '), -1)))
+        # And the two regexes must not eat each other.
+        for big in SUMMARY_RE.findall(self.log):
+            json.loads(big)   # every big match is still valid standalone JSON
+
+    def test_min_matches_the_merged_json_out(self):
+        # Content, not `summary_min(merged)` compared with itself: the
+        # counts on the line must be the MERGED tally's, read two
+        # independent ways -- the --json-out file and the printed
+        # JSON_SUMMARY lines merged by the same reader a consumer uses.
+        from route_summary import SUMMARY_MIN_RE, merge_route_summaries
+        got = json.loads(SUMMARY_MIN_RE.findall(self.log)[0])
+        with open(self.json_out, encoding='utf-8') as f:
+            merged = json.load(f)
+        from_log = merge_route_summaries(self.log)
+        self.assertEqual(got['scope'], 'merged')
+        self.assertGreater(merged['successful'], 0)
+        self.assertEqual(got['routed'], merged['successful'])
+        self.assertEqual(got['routed'], from_log['successful'])
+        self.assertEqual(got['failed'], merged['failed'])
+        self.assertEqual(got['failed'], from_log['failed'])
+        self.assertEqual(got['failed_single'],
+                         merged.get('failed_single') or [])
+        self.assertEqual(got['open_single'], merged.get('open_single') or [])
+        self.assertEqual(got['vias'], merged['total_vias'])
+        self.assertEqual(got['min_clearance_used'],
+                         merged.get('min_clearance_used'))
+        # A first route onto a copper-free board is not gated, so the gate
+        # key must be absent (it appears only when the gate reverted).
+        self.assertNotIn('improvement_gate', got)
+        self.assertNotIn('finalize_excluded_nets', got)
+
+    def test_min_is_small(self):
+        from route_summary import SUMMARY_MIN_RE
+        line = SUMMARY_MIN_RE.findall(self.log)[0]
+        self.assertLess(len(line), 2048, f'{len(line)} bytes')
+
+
+class TestSummaryMinShape(unittest.TestCase):
+    """Pure-function checks on `summary_min` (no routing)."""
+
+    def test_counts_and_caps(self):
+        from route_summary import summary_min
+        merged = {'successful': 7, 'failed': 3, 'total_vias': 4,
+                  'total_time': 1.5, 'min_clearance_used': 0.2,
+                  'failed_single': [f'N{i}' for i in range(25)],
+                  'pad_pairs_open': [{'net': 'P'}, {'net': 'P'}, {'net': 'Q'}],
+                  'multipoint_pads_total': 10, 'multipoint_pads_connected': 8,
+                  'terminal_restores': {'R': 'full', 'S': 'stub',
+                                        'T': 'full_open'}}
+        got = summary_min(merged)
+        self.assertEqual((got['routed'], got['failed']), (7, 3))
+        self.assertEqual(got['failed_single'][-1], '+5 more')
+        self.assertEqual(len(got['failed_single']), 21)
+        self.assertEqual(got['pad_pairs_open'], {'count': 3, 'nets': ['P', 'Q']})
+        self.assertEqual(got['multipoint_deficit'], 2)
+        self.assertEqual(got['terminal_restores_broken'], ['S', 'T'])
+        self.assertNotIn('finalize_excluded_nets', got)
+        self.assertNotIn('improvement_gate', got)
+
+    def test_finalize_excluded_nets_only_when_present(self):
+        from route_summary import summary_min
+        got = summary_min({'successful': 1, 'failed': 0,
+                           'finalize_excluded_nets': ['GND', 'VCC']})
+        self.assertEqual(got['finalize_excluded_nets'], ['GND', 'VCC'])
+        self.assertNotIn('finalize_excluded_nets',
+                         summary_min({'successful': 1, 'failed': 0,
+                                      'finalize_excluded_nets': []}))
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=1)

--- a/tests/test_run23_summary_min.py
+++ b/tests/test_run23_summary_min.py
@@ -108,6 +108,12 @@ class TestSummaryMinShape(unittest.TestCase):
         self.assertEqual(got['terminal_restores_broken'], ['S', 'T'])
         self.assertNotIn('finalize_excluded_nets', got)
         self.assertNotIn('improvement_gate', got)
+        # The time key is named for what `total_time` counts (single-ended
+        # loop + reroute loop), not for wall clock. Measured 0.35 against
+        # 20.72 s of real time on splitflap_driver, so a key called
+        # `duration_s` on a verdict line is a false claim, not a shorter one.
+        self.assertEqual(got['main_loop_time_s'], 1.5)
+        self.assertNotIn('duration_s', got)
 
     def test_finalize_excluded_nets_only_when_present(self):
         from route_summary import summary_min
@@ -117,6 +123,93 @@ class TestSummaryMinShape(unittest.TestCase):
         self.assertNotIn('finalize_excluded_nets',
                          summary_min({'successful': 1, 'failed': 0,
                                       'finalize_excluded_nets': []}))
+
+
+class TestMergeCarriesFinalizeExcluded(unittest.TestCase):
+    """`finalize_excluded_nets` must survive a reconcile sub-run.
+
+    merge_summaries is last-wins on summaries[-1]. The key is stamped on the
+    parent summary AFTER its JSON_SUMMARY printed, so it lives only on
+    summaries[0]; without an explicit carry it vanished from the merged tally
+    -- and therefore from --json-out and from this line -- on exactly the runs
+    that reconciled, i.e. the ones with failures, where "the finalize declined
+    these BY PLAN" is the thing a grader needs to know.
+    """
+
+    FIRST = {'successful': 5, 'failed': 2, 'failed_single': ['/A', '/B'],
+             'scope': 'run', 'finalize_excluded_nets': ['/GND', '/VCC']}
+    SUB = {'successful': 1, 'failed': 1, 'failed_single': ['/A'],
+           'scope': 'reconciliation-subset'}
+
+    def test_carried_across_the_sub_run(self):
+        from route_summary import merge_summaries, summary_min
+        merged = merge_summaries([self.FIRST, self.SUB])
+        self.assertEqual(merged['finalize_excluded_nets'], ['/GND', '/VCC'])
+        self.assertEqual(summary_min(merged)['finalize_excluded_nets'],
+                         ['/GND', '/VCC'])
+
+    def test_single_summary_unchanged(self):
+        from route_summary import merge_summaries
+        self.assertEqual(
+            merge_summaries([self.FIRST])['finalize_excluded_nets'],
+            ['/GND', '/VCC'])
+
+    def test_absent_stays_absent(self):
+        from route_summary import merge_summaries
+        first = {k: v for k, v in self.FIRST.items()
+                 if k != 'finalize_excluded_nets'}
+        self.assertNotIn('finalize_excluded_nets',
+                         merge_summaries([first, self.SUB]))
+
+
+class TestNoOpRunStillEmits(unittest.TestCase):
+    """A step that legitimately routed nothing still emits its MIN line.
+
+    "All nets are already fully connected" is a routine chain state -- a
+    replay, a retry, a re-run of a finished step. That path returns from
+    batch_route long before the end-of-run emit, so the line was missing
+    exactly there, and a consumer holding the "one MIN line per run" contract
+    reads a missing line as a crashed run.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.td = tempfile.TemporaryDirectory()
+        first = os.path.join(cls.td.name, 'routed.kicad_pcb')
+        again = os.path.join(cls.td.name, 'again.kicad_pcb')
+        env = dict(os.environ, PYTHONPATH=ROOT, PYTHONIOENCODING='utf-8',
+                   KRT_NO_BANNER='1')
+
+        def _run(src, dst):
+            r = subprocess.run(
+                [sys.executable, '-X', 'utf8',
+                 os.path.join(ROOT, 'py_router', 'route.py'), src, dst],
+                capture_output=True, text=True, env=env, cwd=ROOT)
+            assert r.returncode == 0, r.stdout[-800:]
+            return r.stdout
+
+        _run(BOARD, first)
+        # Re-route the finished board: every net is already connected.
+        cls.log = _run(first, again)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.td.cleanup()
+
+    def test_no_op_run_emits_exactly_one_min_line_with_status(self):
+        from route_summary import SUMMARY_MIN_RE
+        self.assertIn('nothing to route', self.log)
+        mins = SUMMARY_MIN_RE.findall(self.log)
+        self.assertEqual(len(mins), 1, f'{len(mins)} MIN lines on a no-op run')
+        got = json.loads(mins[0])
+        self.assertEqual(got['status'], 'already_connected')
+        self.assertEqual(got['routed'], 0)
+        self.assertEqual(got['failed'], 0)
+
+    def test_ordinary_run_carries_no_status_key(self):
+        """`status` marks the no-op paths only, so it stays a signal."""
+        from route_summary import summary_min
+        self.assertNotIn('status', summary_min({'successful': 1, 'failed': 0}))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Machine-readable run output, standalone on current main. Nothing here reads a clock, and no verdict is bound to a `.kicad_pro` floor. The reachability / net_forensics JSON expansion that was in the first version of this PR has been removed; it is a separate feature and will come as its own PR with its own tests.

## What changes for a user

- `route.py` prints one `JSON_SUMMARY_MIN:` line per outermost run (CLI and GUI alike; nested reconcile and plane-finalize sub-runs print none). It is the merged tally from `route_summary.summary_min`, kept under 2KB by the test: routed / failed counts, failed and open net names (capped at 20 with a `+N more` marker), multipoint deficit, open pad pairs, broken terminal restores, min clearance, vias, and `main_loop_time_s` (the single-ended plus reroute loop time that `total_time` counts, named for what it is rather than `duration_s`, which under-reported real wall time 59x on splitflap). It is the last line `batch_route` prints (main()'s DRC-floor writeback reports after it, so read the log for the line rather than tailing it): after the reconcile block, so it carries the merged numbers, and after the improvement gate, so it describes the copper that is actually on the board. A run that legitimately routed nothing (`already_connected`, `no_valid_nets`) still prints its one line, with a `status` key naming why the tally is empty; ordinary runs carry no `status`. When the gate reverted the run the line carries `"improvement_gate": "reverted"`; otherwise that key is absent. The big `JSON_SUMMARY:` lines are unchanged. One fix this needed: `batch_route` now resets its summary sink on every outermost entry, not only on `--json-out`. Before, a second run in the same process (the GUI's second click) merged onto the previous run's summaries, which summed the effort keys and stamped the new run's summaries `reconciliation-subset`; the test runs two outermost calls in one process and checks the second MIN line against that run's own summary.
- The "boxed in by static obstacles, not by congestion" hint becomes data: `static_boxin_hint(..., return_verdict=True)` returns `(hint, {verdict, iterations, geometry})`, both the first-pass loop and the reroute loop record it as a `boxed_in_static` net event, and `batch_route` publishes it as `summary['boxed_in']` (beside `blockers`, never inside it) and as `results_data['boxed_in']` for the GUI. `merge_summaries` carries it across the reconcile sub-run the same way it carries `blockers`, filtered to nets still failing, and the improvement gate keeps it on a rejected run like the other diagnostics. The printed hint text is unchanged.
- Plane nets outside a route step's `--nets` scope, which the finalize excludes by plan, are recorded as `summary['finalize_excluded_nets']`. That is set after the `JSON_SUMMARY:` line has printed, so it reaches `--json-out`, the dict `batch_route` returns, and the `JSON_SUMMARY_MIN:` line (only when non-empty), not the printed big summary. `merge_summaries` carries it whole across a reconcile sub-run (it is a list of names, not per-net records), so it survives on exactly the runs that reconciled. The log line itself is unchanged.

## Files

`py_router/route_summary.py` (`SUMMARY_MIN_RE`, `summary_min`, `boxed_in` in `merge_summaries`; the sticky-`complete` block is untouched), `py_router/route.py` (the `boxed_in` report and `results_data` key, `finalize_excluded_nets`, the MIN line, `boxed_in` in the gate's kept keys), `py_router/routing_diagnostics.py` (`return_verdict`), `py_router/reroute_loop.py` and `py_router/single_ended_loop.py` (record the verdict), `docs/rip-up-reroute.md` (one sentence), and two new tests: `tests/test_boxed_in_summary.py` (first-pass cage, a rip victim rerouted into a cage so the reroute-loop path is exercised, and the merge case) and `tests/test_run23_summary_min.py` (exactly one MIN line, printed last, counts equal to the merged tally read from both `--json-out` and the printed summaries, plus pure-function shape checks).

Run on this branch: `py_compile` on every changed file; `tests/test_boxed_in_summary.py`, `tests/test_run23_summary_min.py`, `tests/test_json_out_summary.py`, `tests/test_run12_tools.py`, `tests/gui_parity/test_manifest_plan_parity.py`, `tests/gui_parity/test_cli_postpass_coverage.py`, all passing, plus `tests/test_run5_emit_guard.py` and `tests/test_409_blockers_json.py` after the second commit. The reroute-loop recording line was confirmed executed under `coverage` from the new fixture, and a `routed: 0` mutation in `summary_min` fails the MIN test.

The second commit on this branch is the maintainer's review fix (the time key rename, the `finalize_excluded_nets` carry, and the no-op MIN line); the body above describes the branch with it included.
