### PR TITLE
seeder: gated eviction rung, blockers named on a no-legal-pose verdict (replaces #682)

### DIFF
--- a/py_placer/place_seed.py
+++ b/py_placer/place_seed.py
@@ -79,6 +79,23 @@ Examples:
                         "non-obstacles either way (the existing exclude "
                         "mechanism); this changes only WHO goes first "
                         "(run-4 C)")
+    p.add_argument("--evict-depth", type=int, default=0, choices=(0, 1),
+                   metavar="N",
+                   help="Eviction rung (#630). At every depth a part with NO "
+                        "legal pose gets a census of its seated neighbours "
+                        "(JSON_SUMMARY no_pose_blockers: how many poses "
+                        "lifting each one would free). 0 (default) moves "
+                        "nothing. 1 evicts the neighbour that frees the most, "
+                        "seats the part, then re-seats the neighbour (inside "
+                        "its own zone) with the part in place; the trade is "
+                        "kept only if both seats are legal against every "
+                        "seated part and the seated board's overlap count "
+                        "did not rise, else both parts are put back and the "
+                        "revert is recorded. Locked parts and declared edge "
+                        "connectors are never evicted; a blocker's own "
+                        "blocker is not chased. Only fires on a part that "
+                        "was going to be reported unseated. Opt-in until an "
+                        "A/B row on three boards exists")
     p.add_argument("--anchor-rounds", type=int, default=1,
                    help="With --anchors-first: gated re-seat passes after "
                         "the first full placement (default 1 = none). Each "
@@ -232,6 +249,9 @@ Examples:
                 'reseated': len(reseat['reseated']),
                 'reseated_refs': reseat['reseated'],
                 'unseated': reseat['unseated'],
+                'no_pose_blockers': reseat.get('no_pose_blockers') or {},
+                'evictions': reseat.get('evictions', 0),
+                'evictions_reverted': reseat.get('evictions_reverted', 0),
                 'refused': reseat['refused'],
                 'edge_bands_dropped': reseat['edge_bands_dropped'],
                 # THE load-bearing number: it is the one that predicts
@@ -384,7 +404,8 @@ Examples:
         board_edge_clearance=args.board_edge_clearance,
         grid_step=args.grid_step, seed_refs=seed_refs,
         anchors_first=args.anchors_first,
-        anchor_rounds=args.anchor_rounds)
+        anchor_rounds=args.anchor_rounds,
+        evict_depth=args.evict_depth)
     for note in result['notes']:
         print(f"  NOTE: {note}")
     print(f"Seeded {len(result['placements'])} part(s); "
@@ -490,6 +511,18 @@ Examples:
     after = ratsnest.get('after', {})
     summary = {'placed': len(result['placements']),
                'unseated': len(result['unseated']),
+               # NAMES, not just a count. #629's complaint is that a verdict
+               # you cannot act on is a dead end, and a count names nobody.
+               'unseated_refs': list(result['unseated']),
+               'no_pose_blockers': result.get('no_pose_blockers') or {},
+               # Trades KEPT, and trades REVERTED, separately: a reader who
+               # sees `evictions: 1` must not have to guess whether the board
+               # changed. The records themselves are in the NOTE lines.
+               'evictions': sum(1 for e in (result.get('evictions') or [])
+                                if e.get('accepted')),
+               'evictions_reverted': sum(
+                   1 for e in (result.get('evictions') or [])
+                   if not e.get('accepted')),
                'locked': n_locked,
                'grade_errors': len(graded.errors),
                'grade_warnings': len(graded.warnings),
@@ -507,5 +540,11 @@ Examples:
 
 
 if __name__ == "__main__":
-    import cli_banner; cli_banner.install()  # CMD/EXIT self-echo (run-3 B1)
-    sys.exit(main())
+    # Declare the lever for the WHOLE run, so every pose this CLI writes
+    # carries its name in the provenance record -- place_reconstruct.py
+    # does the same. Without it a seeded board carries no lever at all, and
+    # the provenance instrument is silent about where its poses came from.
+    from placement.provenance import declare_lever
+    with declare_lever('place_seed.py', sys.argv):
+        import cli_banner; cli_banner.install()  # CMD/EXIT self-echo (run-3 B1)
+        sys.exit(main())

--- a/py_placer/placement/README.md
+++ b/py_placer/placement/README.md
@@ -139,6 +139,45 @@ rotation, and an unlocked load-bearing rotation was never protected from the
 quench either. Explore rotations deliberately with
 `place_portfolio.py --strategy poses`.
 
+### The eviction rung (`--evict-depth`, #630)
+
+A part with no legal pose is not necessarily a part with no **room**. Run 19
+measured the difference: three sweeps returned a bare *"no legal pose anywhere
+on the board"* for two switches, and when the question was finally asked in
+scoped form the engine answered precisely: with D14 in place **0** poses,
+with D14 lifted **46**; with D31, **0** then **32**. One eviction each and both
+seated. That verdict was reachable the whole time and nothing asked for it.
+
+So when a part cannot be seated, the seeder counts its poses with each nearby
+seated incumbent lifted in turn. That census runs at every depth and is what
+the JSON_SUMMARY's `no_pose_blockers` (`{ref: {blocker: poses_freed}}`)
+reports, next to `unseated_refs` (names, not just a count). `--evict-depth 0`,
+the default, stops there: *tell me what is in the way, move nothing*. The
+`--reseat` path carries the same keys (`no_pose_blockers`, `evictions`,
+`evictions_reverted`) for its scope; it runs at depth 0, so the counts are 0.
+
+`--evict-depth 1` also trades: evict the incumbent that frees the most, seat
+the blocked part **first** against the lifted board, then put the blocker back
+(inside its own zone, searching out from its old pose) with the part in place.
+That ordering is the point: `reseat_scope` re-seats its scope at their net
+centroids, which is back into the pockets they block, and returned a null
+three times on exactly this case. The trade is kept only if, in this order,
+both seats were found, both are legal against **every** seated part (re-checked
+with the seat predicate, not read off the search's return value; the two parts
+are obstacles to each other), and the seated board's violation count and
+overlap area did not rise. HPWL is recorded and never consulted: a part in the
+pile has an artificially short HPWL, so any gate that ranks it refuses every
+legal seat. A trade that fails puts both parts back and is recorded as
+reverted (`evictions` counts kept trades, `evictions_reverted` the others).
+
+Bounded on every axis: depth 1 (a blocker's own blocker is not chased), at
+most 8 candidates per part (a geometric superset, so a part outside the box
+frees zero poses by construction), one trade per part, and the census counts
+to a cap. Locked parts and declared edge connectors are never candidates. The
+rung only fires on a part that was going to be reported unseated, so a run
+that seats everything is unaffected at either depth. It is opt-in until an
+A/B row on three boards exists (`tests/test_placement_ab.py`).
+
 Requires an Edge.Cuts outline (exit 3 without one — the outline is spec-owned
 and will not be invented) and refuses a board that already looks placed
 (use `place_portfolio.py` to explore around an existing placement, or

--- a/py_placer/placement/seeder.py
+++ b/py_placer/placement/seeder.py
@@ -42,7 +42,7 @@ import fnmatch
 import math
 import random
 import re
-from typing import Dict, List, Optional, Sequence, Set, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
 
 # Ring-search enumeration: nearest-first out to this radius, then a FINE ring
 # near the target, then a coarse whole-board sweep. The fine pass exists
@@ -65,6 +65,496 @@ TARGET_JITTER_MM = 1.5
 def _rect_inside(rect, outer, tol: float) -> bool:
     return (rect[0] >= outer[0] - tol and rect[1] >= outer[1] - tol
             and rect[2] <= outer[2] + tol and rect[3] <= outer[3] + tol)
+
+
+def pose_ok(state, ref: str, x: float, y: float, rot: float,
+            exclude: Set[str]) -> bool:
+    """THE seat predicate: fully contained, and clear of everything not in
+    `exclude`.
+
+    Lifted out of `_try_place` so a POSE COUNTER can use the identical test.
+    `count_legal_poses` below answers "how many seats would lifting X free",
+    and that answer is only worth anything if a positive count implies the
+    seat would really have been taken -- which needs the same predicate, not
+    a second copy of it that drifts.
+
+    Note `candidate_valid` alone is not enough: for a part whose incumbent
+    pose is off the board, its #456 branch accepts poses that move strictly
+    TOWARD the board while still outside it. Placement from scratch has no
+    incumbent worth improving on, so full containment is demanded explicitly.
+    """
+    part = state.parts[ref]
+    r = part.rect(x, y, rot)
+    if state.edge_gate.rect_outside_amount(r) > 1e-9:
+        return False
+    return state.candidate_valid(ref, x, y, rot, exclude=exclude)
+
+
+# A pose census is a DIAGNOSTIC, not a search: it answers "is there room"
+# and must cost a fraction of the seat attempt that already failed. The cap
+# is what bounds it -- run 19's measured answers were 46 and 32 poses freed,
+# so a cap well above those still distinguishes "none" from "plenty".
+CENSUS_RADIUS_MM = 16.0
+CENSUS_STEP_MM = 1.0
+CENSUS_CAP = 64
+
+
+def zone_gate(part, constraint, tol: float):
+    """`(predicate, anchor_zone)` for "is this pose inside the zone".
+
+    ONE definition, shared by the seat search and the pose census. It used to
+    live as a closure inside `_try_place`, which meant the census -- the
+    thing that tells a plan author WHY a part could not be seated -- had no
+    zone concept at all. Measured on splitflap_driver: three parts packed
+    into a 2x2mm zone were refused, and the census answered over an
+    unconstrained 3mm disc, so one verdict read "64 legal poses with nothing
+    lifted" about a part the same pass had just refused to seat, and two
+    more advised lifting U1 when the zone was the problem.
+
+    The ANCHOR relaxation is the half that must not be dropped when copying.
+    A zone smaller than the courtyard cannot contain it at any rotation --
+    the spec-COORDINATE pattern -- so containment relaxes to
+    anchor-point-in-zone, which makes such zones satisfiable by
+    construction; `floorplan.rule_zone_containment` grades them the same
+    way. A census that mirrors only the strict branch under-counts exactly
+    where the relaxation applies: C1 into a 0.4mm zone at its own pose
+    censuses 0 with the strict rule and 294 with this one, while
+    `_try_place` seats it either way. That is a confident zero, which is the
+    one census answer worse than no census -- so this returns the same pair
+    of branches to both callers rather than letting a second copy drift.
+    """
+    if constraint is None:
+        return (lambda x, y, rot: True), False
+    from placement.floorplan import zone_fits_courtyard
+    anchor = not any(
+        zone_fits_courtyard(constraint, part.rect(0.0, 0.0, r), tol)
+        for r in (part.rot % 360, (part.rot + 90) % 360))
+
+    if anchor:
+        def _in(x, y, rot):
+            return (constraint[0] - tol <= x <= constraint[2] + tol
+                    and constraint[1] - tol <= y <= constraint[3] + tol)
+    else:
+        def _in(x, y, rot):
+            return _rect_inside(part.rect(x, y, rot), constraint, tol)
+    return _in, anchor
+
+
+# A census sweep never exceeds this many locations. It is the ONLY bound on
+# the cost, so it is stated as a count rather than left to fall out of a
+# radius: (2*25+1)^2 = 2601 locations, x4 rotations = ~10k `pose_ok` calls
+# worst case, for the blocked part that has to exhaust the ladder.
+CENSUS_MAX_LOCATIONS = 2601
+
+
+def _feasible_centre_box(part, constraint, tol, anchor):
+    """Where `part`'s CENTRE may sit for the zone to hold it, over rotations.
+
+    Derived, not approximated. Containment at rotation r is
+    `zone[0]-tol <= x + b_r[0]` and `x + b_r[2] <= zone[2]+tol`, so
+    `x` in `[zone[0]-tol-b_r[0], zone[2]+tol-b_r[2]]`, and the UNION over
+    rotations is `[zone[0]-tol-max_r(b_r[0]), zone[2]+tol-min_r(b_r[2])]`.
+
+    THE COURTYARD IS NOT CENTRED ON THE FOOTPRINT ORIGIN -- `part.rect` is
+    `(x+b[0], y+b[1], x+b[2], y+b[3])` with `b` the raw local bounds, and 17
+    of 65 parts on splitflap_driver and 6 of 89 on tigard have an offset
+    centre (up to 10.15mm on tigard J3). A symmetric half-extent deflation
+    therefore SHIFTS the box: measured, J18/J19/J20 censused 0 while
+    `_try_place` seated them at full clearance. Two earlier forms of this
+    function were wrong here in opposite directions (max half-extent = a
+    subset, min half-extent = a shifted box), which is why this is now the
+    algebra rather than a bound.
+    """
+    x0, y0, x1, y1 = (float(v) for v in constraint)
+    if anchor:
+        # Anchor zones constrain the ANCHOR POINT, so the centre box is the
+        # zone itself; no courtyard term enters.
+        return x0 - tol, y0 - tol, x1 + tol, y1 + tol
+    max_b0x = max_b0y = -float('inf')
+    min_b2x = min_b2y = float('inf')
+    for rot in (part.rot, part.rot + 90.0, part.rot + 180.0, part.rot + 270.0):
+        b = part.rect(0.0, 0.0, rot % 360)
+        max_b0x = max(max_b0x, b[0])
+        max_b0y = max(max_b0y, b[1])
+        min_b2x = min(min_b2x, b[2])
+        min_b2y = min(min_b2y, b[3])
+    return (x0 - tol - max_b0x, y0 - tol - max_b0y,
+            x1 + tol - min_b2x, y1 + tol - min_b2y)
+
+
+def zone_census_offsets(part, constraint, tol, tx, ty, grid_step=0.1,
+                        max_disp=None):
+    """`(step, [(dx, dy), ...], reach_mm)` for a census under a ZONE.
+
+    A disc around the target is the wrong sample set once a constraint
+    applies: the reachable poses are bounded by the zone, so a disc census
+    spends its whole location cap on ground the zone excludes and has to
+    coarsen its step to afford it. Measured on splitflap_driver, R1 packed
+    into a 2x2mm zone: a 0.25mm disc lattice counts ZERO with the blocker
+    lifted, because the zone leaves a feasible x-window for R1's centre
+    **0.07mm wide**, while `_try_place` reaches that window on its 0.1mm
+    ring and seats. Threading the constraint without this moves the
+    confident zero from the relaxation axis to the lattice axis instead of
+    removing it.
+
+    So: enumerate the feasible-CENTRE box instead, on the lattices
+    `_try_place` sweeps AT EACH DISTANCE. That last clause is the half an
+    earlier version got wrong: it chose one step by location count alone, so
+    a large zone fell to the 1.0mm ring (a ring that exists to cross the
+    board cheaply, not to decide whether a part fits, so a verdict rendered
+    on it is a confident zero) and a distant zone was sampled at 0.1mm where
+    the search only reaches 0.25mm -- 4 of 8 censused parts in one ordinary
+    zone pack then promised poses the retry could never collect.
+
+    `reach_mm` is how far from the target the sweep actually got:
+    `_try_place` skips its whole-board fallback whenever `max_disp` is set,
+    so nothing beyond `SEARCH_FINE_RADIUS_MM` is reachable anyway, and the
+    location cap can bite before even that.
+    """
+    grid = max(0.05, float(grid_step or 0.1))
+    _in, anchor = zone_gate(part, constraint, tol)
+    lo_x, lo_y, hi_x, hi_y = _feasible_centre_box(part, constraint, tol,
+                                                 anchor)
+    # Nothing past the fine ring is reachable once `max_disp` is set, so the
+    # box is clipped there BEFORE it is materialised -- that is also the
+    # guard against a hostile zone (a 2000mm rect used to build a 4,004,001
+    # entry list, once per censused part, uncached).
+    reach = SEARCH_FINE_RADIUS_MM if max_disp is None \
+        else min(float(max_disp), SEARCH_FINE_RADIUS_MM)
+    lo_x, hi_x = max(lo_x, tx - reach), min(hi_x, tx + reach)
+    lo_y, hi_y = max(lo_y, ty - reach), min(hi_y, ty + reach)
+    if hi_x < lo_x or hi_y < lo_y:
+        # The zone cannot hold this part at all, or the budget cannot reach
+        # it. ONE offset, so the caller still evaluates the target itself and
+        # the answer is a measured zero rather than an empty sweep that never
+        # ran -- and `reach_mm` 0.0 says the sweep never left the target.
+        return grid, [(0.0, 0.0)], 0.0
+
+    def _lattice(step, rmax):
+        """Target-aligned points of `step` inside the box and within `rmax`."""
+        i0 = int(math.ceil((lo_x - tx) / step - 1e-9))
+        i1 = int(math.floor((hi_x - tx) / step + 1e-9))
+        j0 = int(math.ceil((lo_y - ty) / step - 1e-9))
+        j1 = int(math.floor((hi_y - ty) / step + 1e-9))
+        pts = []
+        for i in range(i0, i1 + 1):
+            dx = i * step
+            if abs(dx) > rmax + 1e-9:
+                continue
+            for j in range(j0, j1 + 1):
+                dy = j * step
+                if dx * dx + dy * dy <= rmax * rmax + 1e-9:
+                    pts.append((round(dx, 6), round(dy, 6)))
+        return pts
+
+    # TWO lattices, exactly as `_try_place` does it: `grid_step` out to
+    # SEARCH_XFINE_RADIUS_MM, then SEARCH_FINE_STEP_MM out to the reach.
+    # The 1.0mm ring is deliberately excluded -- a census must not render a
+    # verdict on it (see the docstring).
+    seen, out = set(), []
+    for step, rmax in ((grid, min(reach, SEARCH_XFINE_RADIUS_MM)),
+                       (max(grid, SEARCH_FINE_STEP_MM), reach)):
+        for d in _lattice(step, rmax):
+            if d not in seen:
+                seen.add(d)
+                out.append(d)
+    if not out:
+        return grid, [(0.0, 0.0)], 0.0
+    out.sort(key=lambda d: (d[0] * d[0] + d[1] * d[1]))
+    if len(out) > CENSUS_MAX_LOCATIONS:
+        out = out[:CENSUS_MAX_LOCATIONS]
+    reach = math.sqrt(max(d[0] * d[0] + d[1] * d[1] for d in out))
+    step_used = grid if any(
+        abs(d[0]) <= SEARCH_XFINE_RADIUS_MM
+        and abs(d[1]) <= SEARCH_XFINE_RADIUS_MM for d in out) else \
+        max(grid, SEARCH_FINE_STEP_MM)
+    return step_used, out, round(reach, 6)
+
+
+# How many incumbents one stuck part may censused against. Bounded because
+# each candidate costs a census sweep, and because a part is blocked by its
+# NEIGHBOURS -- a part on the far side of the board cannot be in the way, and
+# the geometry below proves it rather than assuming it.
+EVICT_MAX_BLOCKERS = 8
+
+
+def _evict_candidates(state, ref: str, tx: float, ty: float,
+                      placed: Set[str], immovable: Set[str],
+                      constraint=None, tol: float = 0.5) -> List[str]:
+    """Seated, movable parts that could possibly be in `ref`'s way at (tx,ty).
+
+    `immovable` is every seated ref the rung may not lift: the intent's
+    `must_lock` set and its DECLARED EDGE CONNECTORS. A file-locked part is
+    skipped here as well. The edge connectors are excluded because the rung
+    re-seats a blocker through `_try_place`, which demands full containment
+    -- measured, it lifted a stage-1 connector off its edge band and seated
+    it inland, on top of another part. An edge seat is `_seat_edge`'s to
+    make, and sliding a connector along its edge to free a pocket is not
+    what this rung does.
+
+    A superset, not a heuristic: the box is every pose `ref` can take within
+    the census radius, inflated by its own reach and the clearance, so a part
+    whose own inflated extent misses it cannot be within clearance of ANY
+    candidate pose and would free exactly zero poses by construction. That is
+    `build_neighbor_lists`' pruning argument (quench.py) with the travel
+    budget replaced by the census radius.
+
+    Then nearest-first, capped: the cap is the only approximation, and it is
+    reported by the caller rather than hidden.
+    """
+    part = state.parts.get(ref)
+    if part is None:
+        return []
+    r = part.rect(tx, ty, part.rot)
+    reach = max(r[2] - r[0], r[3] - r[1]) / 2.0 + CENSUS_RADIUS_MM
+    clr = state.clearance
+    locked = set(immovable or ())
+    # UNDER A ZONE THE TARGET IS NOT THE CENTRE OF THE QUESTION. The zone
+    # stage jitters each member's target, so a target can sit wholly outside
+    # a small zone (measured: 3.3mm out on a 2x2 zone), and both the box and
+    # the nearest-first cap were keyed on it -- so the 8 chosen
+    # need not be the 8 that overlap the zone the part must actually reach.
+    # Box on the union, rank by distance to the region being contested.
+    bx0, by0, bx1, by1 = tx - reach, ty - reach, tx + reach, ty + reach
+    cx, cy = tx, ty
+    if constraint is not None:
+        bx0 = min(bx0, constraint[0] - tol - reach)
+        by0 = min(by0, constraint[1] - tol - reach)
+        bx1 = max(bx1, constraint[2] + tol + reach)
+        by1 = max(by1, constraint[3] + tol + reach)
+        cx = min(max(tx, constraint[0]), constraint[2])
+        cy = min(max(ty, constraint[1]), constraint[3])
+    out: List[Tuple[float, str]] = []
+    for other in sorted(placed):
+        if other == ref or other not in state.parts:
+            continue
+        op = state.parts[other]
+        if op.locked or other in locked:
+            continue          # not this tool's to move -- see reseat_scope
+        orect = op.rect(op.x, op.y, op.rot)
+        if (orect[2] + clr < bx0 or orect[0] - clr > bx1
+                or orect[3] + clr < by0 or orect[1] - clr > by1):
+            continue
+        out.append((math.hypot(op.x - cx, op.y - cy), other))
+    out.sort()
+    return [b for _d, b in out[:EVICT_MAX_BLOCKERS]]
+
+
+def count_legal_poses(state, ref: str, tx: float, ty: float,
+                      exclude: Set[str], *,
+                      radius: float = CENSUS_RADIUS_MM,
+                      step: float = CENSUS_STEP_MM,
+                      cap: int = CENSUS_CAP,
+                      max_disp: Optional[float] = None,
+                      rotations: Optional[Sequence[float]] = None,
+                      constraint=None, tol: float = 0.5) -> int:
+    """How many legal poses `ref` has near (tx, ty), counting at most `cap`.
+
+    This is issue #629's measurement. Three consecutive sweeps in run 19
+    returned a bare "no legal pose anywhere on the board" for SW17/SW34, and
+    when the same question was finally asked in scoped form the engine
+    answered precisely: with D14 in place 0 poses, with D14 lifted 46; with
+    D31, 0 then 32. A verdict that names its blockers is the next move; a
+    bare verdict is a dead end.
+
+    Counts only -- no `apply_move`, no cost evaluation. It uses `pose_ok`,
+    the same predicate `_try_place` seats on, at the state's own clearance
+    (NOT the relaxed ladder): a count is meant to say whether there is room,
+    and counting poses that only exist at a 0.02mm floor would promise seats
+    the ordinary search does not take. Measured cost of that divergence on
+    splitflap_driver: 4 of 65 movable parts census 0 while `_try_place`
+    seats them on a relaxed rung, 6 of 65 with a zone. Reported, not fixed --
+    see the paragraph above.
+
+    **With a `constraint`, the zone is honoured and the SAMPLE SET comes
+    from the zone too** (`zone_census_offsets`). Both halves are needed: the
+    predicate alone leaves the census answering over a disc the zone
+    excludes, and the disc alone leaves it counting poses that are outside
+    the zone the seat had to satisfy. `radius`/`step` are ignored when a
+    constraint is given -- the zone supersedes them.
+    """
+    from pose_score import _offsets
+    part = state.parts[ref]
+    rots = list(rotations) if rotations is not None \
+        else [part.rot] + [(part.rot + d) % 360 for d in (90.0, 180.0, 270.0)]
+    in_zone, _anchor = zone_gate(part, constraint, tol)
+    if constraint is None:
+        offsets = _offsets(radius, step)
+    else:
+        _step, offsets, _reach = zone_census_offsets(
+            part, constraint, tol, tx, ty,
+            getattr(state, 'grid_step', 0.1), max_disp)
+    n = 0
+    for dx, dy in offsets:
+        if max_disp is not None and math.hypot(dx, dy) > max_disp + 1e-9:
+            continue
+        x, y = round(tx + dx, 3), round(ty + dy, 3)
+        for rot in rots:
+            # Zone first: it is four float compares, where `pose_ok` ends in
+            # `candidate_valid`. Measured 19x faster on a small zone.
+            if not in_zone(x, y, rot):
+                continue
+            if pose_ok(state, ref, x, y, rot, exclude):
+                n += 1
+                if n >= cap:
+                    return n
+    return n
+
+
+def _seated_violations(state, seated: Set[str]) -> Tuple[int, float]:
+    """`(violating parts-or-pairs, courtyard overlap mm2)` over the SEATED
+    parts only.
+
+    The pile is not measured. An unseated part sits at a coordinate that
+    means nothing, and a measure that includes it is wrong in whichever
+    direction it is read: counting its overlaps makes any move out of the
+    pile look like a repair, while `reconstruct.measure`, which ranks HPWL
+    above overlap area, makes every legal seat look like a loss because the
+    pile's HPWL is artificially short. The first version of the eviction
+    rung gated on that tuple and refused every legal trade (measured:
+    `[.. 3.502, 1.0] -> [.. 12.706, 0.0]` rejected) while accepting the one
+    that stacked the blocker on the part it had just seated.
+
+    A pair counts when its courtyards intersect on a shared side, or, when
+    the pad layer is on, when pads or holes intersect; a part counts when
+    its body is contained in another's (#680's fab-currency test, with its
+    marker/container exemptions). Container parts are skipped as obstacles,
+    as `candidate_valid` skips them. Clearance SHORTFALL is deliberately not
+    counted: `_try_place` seats at a relaxed clearance by design when
+    nothing else fits, and a rung that refused what the ordinary stages
+    accept would trade a seated part for an unseated one.
+    """
+    refs = sorted(r for r in seated if r in state.parts)
+    containers = set(getattr(state, 'container_refs', ()) or ())
+    ctx = state.legality_ctx
+    others = set(state.parts) - set(refs)
+    count = 0
+    area = 0.0
+    for i, a in enumerate(refs):
+        pa = state.parts[a]
+        if a not in containers:
+            try:
+                if state._body_contained_at(a, None, None, None,
+                                            exclude=others):
+                    count += 1
+            except Exception:          # noqa: BLE001 -- unjudged, not clear
+                count += 1
+        ra = pa.rects()
+        for b in refs[i + 1:]:
+            if a in containers or b in containers:
+                continue
+            pb = state.parts[b]
+            gap = pa.gap_to(pb, ra)
+            bad = gap is not None and gap < -1e-9
+            if bad and pa.side == pb.side:
+                r1, r2 = ra[0], pb.rect()
+                area += (max(0.0, min(r1[2], r2[2]) - max(r1[0], r2[0]))
+                         * max(0.0, min(r1[3], r2[3]) - max(r1[1], r2[1])))
+            if not bad and ctx is not None:
+                sf = ctx.pair_shortfall(a, b)
+                bad = bool(sf.pad_overlap or sf.stack or sf.hole > 1e-6)
+            if bad:
+                count += 1
+    return count, round(area, 4)
+
+
+def _evict_trade(state, ref: str, best: str, tx: float, ty: float,
+                 constraint, tol: float, best_constraint, best_tol: float,
+                 placed: Set[str], unplaced: Set[str]) -> Dict:
+    """Lift `best`, seat `ref` at the target it was refused at, put `best`
+    back; keep the trade only under the rule below, else restore both.
+
+    THE ACCEPTANCE RULE, in this order, every conjunct required:
+
+      1. both seats were found -- `_try_place` seated `ref` (under its own
+         zone) against the board with `best` lifted, then seated `best`
+         (under ITS own zone, searching out from its old pose) against the
+         board with `ref` in it;
+      2. both are legal against the FULL seated set, re-checked here with
+         `pose_ok` at the clearance the seats were found at. The only parts
+         excluded are the ones still in the pile, so `ref` and `best` are
+         obstacles to each other. This is the conjunct that does not trust
+         the bookkeeping: the first version of this rung re-seated the
+         blocker with `ref` still in its exclude set and landed it on top
+         of `ref`, 100% inside its courtyard, and reported `unseated 0`;
+      3. `_seated_violations` over the seated parts, `ref` now among them,
+         has not increased against the board before the trade. This is the
+         only ABSOLUTE pad-layer check in the rule: conjunct 2's pad test
+         (`candidate_valid` -> `pads_ok`) is baseline-relative, "no worse
+         than the SEED pose", and two parts that started stacked have a seed
+         baseline that already contains a pad intersection -- so a re-seat
+         whose courtyards are clear but whose pads intersect passes 2 and is
+         refused here.
+
+    HPWL is NOT a conjunct and is not a tie-break between anything, because
+    there is one trade per part: it is recorded in the returned record for
+    the reader. A gate that ranks it vetoes every legal seat over an
+    unseated pile (see `_seated_violations`).
+
+    Returns the eviction record. `accepted` says which branch ran; on the
+    reverted branch both parts are back at their snapshot poses and `reason`
+    names the conjunct that failed. The caller owns `placed`/`unplaced`; this
+    function reads them and restores `best` to `placed` either way.
+    """
+    snapshot = {r: (state.parts[r].x, state.parts[r].y, state.parts[r].rot)
+                for r in (ref, best)}
+    seated_before = set(placed) - {ref}
+    viol_before = _seated_violations(state, seated_before)
+    hpwl_before = round(state.hpwl(), 3)
+    pile = set(unplaced) - {ref, best}
+    # 1. lift, seat the blocked part, put the blocker back with it in place.
+    unplaced.add(best)
+    placed.discard(best)
+    clr_ref = _try_place(state, ref, tx, ty, pile | {best},
+                         constraint=constraint, tol=tol)
+    clr_best = None
+    if clr_ref is not None:
+        bx, by, _brot = snapshot[best]
+        clr_best = _try_place(state, best, bx, by, pile,
+                              constraint=best_constraint, tol=best_tol)
+    ok = clr_ref is not None and clr_best is not None
+    # 2. legal against the full seated set, independently of (1).
+    legal = False
+    if ok:
+        full = state.clearance
+        try:
+            state.clearance = min(clr_ref, clr_best)
+            state._inc_violation.clear()
+            pr, pb = state.parts[ref], state.parts[best]
+            legal = (pose_ok(state, ref, pr.x, pr.y, pr.rot, pile)
+                     and pose_ok(state, best, pb.x, pb.y, pb.rot, pile))
+        finally:
+            state.clearance = full
+            state._inc_violation.clear()
+    # 3. the seated board did not get worse.
+    viol_after = (_seated_violations(state, seated_before | {ref})
+                  if ok else None)
+    accepted = bool(ok and legal and viol_after <= viol_before)
+    if not accepted:
+        for r, pose in snapshot.items():
+            state.apply_move(r, *pose)
+    placed.add(best)
+    unplaced.discard(best)
+    if not ok:
+        reason = ('the blocked part still had no legal pose with the blocker '
+                  'lifted' if clr_ref is None else
+                  'the blocker had no legal pose to return to with the part '
+                  'in place')
+    elif not legal:
+        reason = 'a seat was not legal against the full seated set'
+    elif not accepted:
+        reason = (f'violations rose {list(viol_before)} -> '
+                  f'{list(viol_after)}')
+    else:
+        reason = ''
+    return {'ref': ref, 'blocker': best, 'accepted': accepted,
+            'clearance': [clr_ref, clr_best],
+            'violations_before': list(viol_before),
+            'violations_after': (None if viol_after is None
+                                 else list(viol_after)),
+            'hpwl_before': hpwl_before,
+            'hpwl_after': round(state.hpwl(), 3),
+            'reason': reason}
 
 
 def _try_place(state, ref: str, tx: float, ty: float, exclude: Set[str],
@@ -108,30 +598,11 @@ def _try_place(state, ref: str, tx: float, ty: float, exclude: Set[str],
     part = state.parts[ref]
 
     def _ok(x, y, rot):
-        if state.edge_gate.rect_outside_amount(part.rect(x, y, rot)) > 1e-9:
-            return False
-        return state.candidate_valid(ref, x, y, rot, exclude=exclude)
+        return pose_ok(state, ref, x, y, rot, exclude)
 
-    # A zone smaller than the courtyard cannot contain it at any rotation --
-    # the spec-COORDINATE pattern. Containment then relaxes to anchor-point-
-    # in-zone, which makes such zones satisfiable by construction; the grader
-    # (floorplan.rule_zone_containment) applies the same relaxation.
-    anchor_zone = False
-    if constraint is not None:
-        from placement.floorplan import zone_fits_courtyard
-        anchor_zone = not any(
-            zone_fits_courtyard(constraint, part.rect(0.0, 0.0, r), tol)
-            for r in (part.rot % 360, (part.rot + 90) % 360))
-        if anchor_zone and info is not None:
-            info['anchor_zone'] = True
-
-    def _in_zone(x, y, rot):
-        if constraint is None:
-            return True
-        if anchor_zone:
-            return (constraint[0] - tol <= x <= constraint[2] + tol
-                    and constraint[1] - tol <= y <= constraint[3] + tol)
-        return _rect_inside(part.rect(x, y, rot), constraint, tol)
+    _in_zone, anchor_zone = zone_gate(part, constraint, tol)
+    if anchor_zone and info is not None:
+        info['anchor_zone'] = True
 
     full = state.clearance
     try:
@@ -211,18 +682,31 @@ def _edge_pose(part, bounds, edge: str, frac: float, overhang: float
 
 
 def _edge_correct(state, ref: str, edge: str, x: float, y: float,
-                  target: float) -> Tuple[float, float]:
+                  target: float) -> Tuple[float, float, bool]:
     """Walk the pose along the edge normal until the MEASURED overhang hits
     `target`. The analytic pose measures against the bounding box, but the
     grade's rule_edge_connector measures rect_outside_amount against the real
     Edge.Cuts rings -- on a non-rectangular outline the two differ by the
     local inset, and a seed placed by the bbox grades over its declared band
-    (measured on splitflap: 4 connectors 0.1-0.2mm past their max)."""
+    (measured on splitflap: 4 connectors 0.1-0.2mm past their max).
+
+    Returns (x, y, converged). **The third element is not decoration.** This
+    walk moves along ONE axis while `rect_outside_amount` is a SUM over all
+    four sides (`legality.EdgeGate.rect_outside_amount`), so any along-edge
+    overshoot is a
+    constant term the walk cannot cancel -- it subtracts it again every
+    iteration and marches the part inland past the far edge. Measured on a
+    41.16mm connector on a 50.8mm edge: frac 0.70 -> y 88.767 (off the
+    opposite side), frac 0.90 -> y -2.443. It used to return that pose
+    indistinguishably from a converged one, and the caller seated it.
+    """
     part = state.parts[ref]
+    converged = False
     for _ in range(4):
         amt = state.edge_gate.rect_outside_amount(part.rect(x, y, part.rot))
         err = target - amt
         if abs(err) < 0.02:
+            converged = True
             break
         if edge == 'north':
             y -= err
@@ -232,11 +716,81 @@ def _edge_correct(state, ref: str, edge: str, x: float, y: float,
             x -= err
         else:
             x += err
-    return x, y
+    else:
+        # Ran out of iterations. One last measurement decides it -- a walk
+        # that happened to land on its target on the final step is converged.
+        amt = state.edge_gate.rect_outside_amount(part.rect(x, y, part.rot))
+        converged = abs(target - amt) < 0.02
+    return x, y, converged
+
+
+def edge_seat_ok(state, part, x: float, y: float, edge: str,
+                 lo: float, hi: float) -> bool:
+    """Is this edge pose a seat, or is the part off the board?
+
+    An edge seat is the one seat in the system that cannot use `pose_ok` --
+    it overhangs by design, so full containment is the wrong predicate. This
+    is the predicate it uses instead, and it has TWO parts because either
+    alone was measured to accept an off-board part:
+
+    * the measured overhang lies in the DECLARED band. Same quantity
+      `floorplan.rule_edge_connector` grades on, so a seat accepted here is
+      not a violation there.
+    * EVERY PAD lands on the board. That is the invariant that actually
+      matters -- CLAUDE.md calls pad copper outside the outline the
+      top-priority placement defect, because it converts 1:1 into unrouted
+      nets -- and it is the one a band cannot argue with. A band is an
+      author's declaration and a wrong one is not rare: `{min: 3, max: 4}` on
+      a 3.0mm-deep connector seated it with 1.7% of its courtyard on the
+      board, and `{min: 20, max: 21}` was accepted on the east and west edges
+      with 8 of 16 pads off.
+
+    The pad test uses the gate's own containment, so a board with cutouts or
+    milled rings is measured properly. A bounding-box test is not enough and
+    was measured dropping 24 of 26 pads into a milled slot while reporting a
+    seat: the pads were inside the bbox and inside a hole.
+
+    An edge connector's BODY overhangs by design; its PADS do not. That
+    asymmetry is what makes this checkable at all.
+    """
+    r = part.rect(x, y, part.rot)
+    amt = state.edge_gate.rect_outside_amount(r)
+    if not ((lo - 0.02) <= amt <= (hi + 0.02)):
+        return False
+    gate = state.edge_gate
+    for px, py, _sz in part.pad_globals(x, y, part.rot):
+        # A zero-size rect at the pad centre: "is this point on the board",
+        # asked through the gate so cutouts and milled rings count.
+        if gate.rect_outside_amount((px, py, px, py)) > 1e-9:
+            return False
+    return True
+
+
+def _edge_frac_bounds(part, bounds, edge: str) -> Tuple[float, float]:
+    """The fractions along `edge` at which the part is still ON the board.
+
+    `_edge_pose` places the part's CENTRE at `frac` along the edge's own span,
+    and the old clamp was a bare [0.05, 0.95] that knew nothing of the part's
+    width -- so a 41.16mm connector on a 50.80mm edge was slid to frac 0.70
+    and hung 5.34mm past the end while reporting a seat. Only
+    **[0.405, 0.595]** keeps that part on the board: the centre may range over
+    span - width = 9.64mm, i.e. (width/2)/span = 0.405 in from each end.
+
+    Returns (lo, hi); lo > hi means the part is wider than the edge, which is
+    a real answer and the caller must treat it as "no legal fraction".
+    """
+    lx0, ly0, lx1, ly1 = part.rect(0.0, 0.0, part.rot)
+    x0, y0, x1, y1 = bounds
+    if edge in ('north', 'south'):
+        span, a, b = (x1 - x0), lx0, lx1
+    else:
+        span, a, b = (y1 - y0), ly0, ly1
+    span = max(1e-9, span)
+    return (-a) / span, 1.0 - (b / span)
 
 
 def _seat_edge(state, ref: str, entry: Dict, must_lock: Set[str],
-               notes: List[str], target=None) -> bool:
+               notes: List[str], target=None, exclude=None) -> bool:
     """Seat a DECLARED edge part on its edge band, minimal-move (run-4 B-6).
 
     Repair could never do this: `_try_place._ok` demands full containment,
@@ -262,26 +816,52 @@ def _seat_edge(state, ref: str, entry: Dict, must_lock: Set[str],
         cur = (ax - x0) / max(1e-9, (x1 - x0))
     else:
         cur = (ay - y0) / max(1e-9, (y1 - y0))
-    cur = min(0.95, max(0.05, cur))
+
+    # Clamp by the part's OWN half-extent, not a bare [0.05, 0.95]. A part
+    # wider than its edge has no legal fraction at all; say so rather than
+    # sliding it off the end and reporting a seat.
+    f_lo, f_hi = _edge_frac_bounds(part, state.board, edge)
+    if f_lo > f_hi:
+        notes.append(f"{ref}: is wider than the {edge} edge "
+                     f"({f_lo:.2f} > {f_hi:.2f} of its span), so no along-edge "
+                     f"position keeps it on the board")
+        return False
+    cur = min(f_hi, max(f_lo, cur))
+
+    # The declared band. `hi` None means "no stated maximum" -- allow twice the
+    # midpoint target, which is what `overhang` was derived from, rather than
+    # allowing anything.
+    hi_eff = float(hi) if hi is not None else max(2.0 * overhang, lo + 1.0)
 
     ctx = state.legality_ctx
+    ex = set(exclude or ())
 
     def conflict_free(px, py):
         if ctx is None:
             return True
         for other in ctx.parts:
-            if other == ref or other not in state.parts:
+            # `ex` is the pile: parts whose input coordinates are meaningless.
+            # Without it a pile at the board centre vetoes the honest edge
+            # poses and the loop SLIDES the part along the edge until one is
+            # "free" -- measured, that is how a connector reached frac 0.70
+            # and hung off the end.
+            if other == ref or other in ex or other not in state.parts:
                 continue
             sf = ctx.pair_shortfall(ref, other, pose_a=(px, py, part.rot))
             if sf.pad > 1e-6 or sf.hole > 1e-6:
                 return False
         return True
 
+    def on_board(px, py):
+        return edge_seat_ok(state, part, px, py, edge, lo, hi_eff)
+
     for df in (0.0, 0.05, -0.05, 0.1, -0.1, 0.15, -0.15,
                0.2, -0.2, 0.3, -0.3, 0.4, -0.4):
-        frac = min(0.95, max(0.05, cur + df))
+        frac = min(f_hi, max(f_lo, cur + df))
         x, y = _edge_pose(part, state.board, edge, frac, overhang)
-        x, y = _edge_correct(state, ref, edge, x, y, overhang)
+        x, y, converged = _edge_correct(state, ref, edge, x, y, overhang)
+        if not converged or not on_board(x, y):
+            continue
         if conflict_free(x, y):
             state.apply_move(ref, round(x, 3), round(y, 3), part.rot)
             return True
@@ -332,7 +912,8 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
                      grid_step: float = 0.1,
                      seed_refs: Optional[Set[str]] = None,
                      anchors_first: bool = False,
-                     anchor_rounds: int = 1) -> Dict:
+                     anchor_rounds: int = 1,
+                     evict_depth: int = 0) -> Dict:
     """Compute a full placement for an unplaced board from its intent.
 
     Returns {'placements': [...], 'lock_refs': [...], 'unseated': [...],
@@ -346,7 +927,14 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
     re-deriving the placed parts would discard someone's work, and the
     LIFT-AND-RE-SEAT case -- see `reseat_scope`).
 
+    `evict_depth` arms the eviction rung (stage 3c, #630): 0 (the default)
+    censuses the blockers of every unseated part and moves nothing; 1 also
+    trades the best blocker out and back under `_evict_trade`'s acceptance
+    rule. Opt-in until an A/B row on three boards exists (CLAUDE.md, "A new
+    PLACEMENT objective term"). Nothing deeper is defined.
     """
+    if evict_depth not in (0, 1):
+        raise ValueError(f"evict_depth must be 0 or 1, got {evict_depth!r}")
     import pose_score
     from placement import floorplan
 
@@ -369,6 +957,13 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
     placed: Set[str] = set()
     unplaced: Set[str] = {r for r, p in state.parts.items()}
     unseated: List[str] = []
+    # ref -> (target_x, target_y, constraint_rect, tol) for the seat that
+    # failed. The eviction rung (3c) retries at exactly the target the part
+    # was refused at; a rung that re-derived one would be answering a
+    # different question from the one that failed.
+    unseated_ctx: Dict[str, Tuple[float, float, Any, float]] = {}
+    evictions: List[Dict] = []
+    no_pose_blockers: Dict[str, Dict[str, int]] = {}
     # A part locked IN THE FILE is already authoritatively placed -- a caller
     # that pre-placed its spec-fixed parts and stamped them (locked yes) must
     # not have the seeder re-derive them. Treated as placed from the start:
@@ -418,9 +1013,41 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
             lo = float(band.get('min', 0.0))
             hi = band.get('max')
             overhang = (lo + float(hi)) / 2.0 if hi is not None else max(lo, 0.5)
+            # Even distribution, but clamped by the part's own half-extent:
+            # 3 connectors on one edge get fracs 0.25/0.5/0.75, and a wide
+            # part at 0.25 hangs off the end. This stage runs no legality
+            # gate at all (by design), so nothing downstream would catch it.
+            f_lo, f_hi = _edge_frac_bounds(part, bounds, edge)
             frac = (k + 1) / (len(specs) + 1)
+            if f_lo > f_hi:
+                notes.append(f"edge connector {ref}: wider than the {edge} "
+                             f"edge, so stage 1 leaves it to the later stages")
+                continue
+            frac = min(f_hi, max(f_lo, frac))
             x, y = _edge_pose(part, bounds, edge, frac, overhang)
-            x, y = _edge_correct(state, ref, edge, x, y, overhang)
+            x, y, converged = _edge_correct(state, ref, edge, x, y, overhang)
+            if not converged:
+                # The walk diverged (it drives a scalar SUM along one axis, so
+                # an along-edge overshoot never cancels). It used to
+                # apply_move unconditionally, which is how a diverged stage-1
+                # seat reached the board silently.
+                notes.append(f"edge connector {ref}: the overhang walk did "
+                             f"not converge on the {edge} edge, so stage 1 "
+                             f"left it for the later stages")
+                continue
+            # The SAME containment predicate _seat_edge uses. Stage 1 got the
+            # fraction clamp and the convergence skip but not this, and was
+            # measured still seating a connector at (159.909, 132.830) with
+            # 16 of 16 pads 18.45mm off a board ending at 114.38 -- the exact
+            # pose the fix elsewhere refuses. Stage 1 runs no legality gate at
+            # all by design, so nothing downstream catches it.
+            hi_eff = float(hi) if hi is not None else max(2.0 * overhang,
+                                                          lo + 1.0)
+            if not edge_seat_ok(state, part, x, y, edge, lo, hi_eff):
+                notes.append(f"edge connector {ref}: the {edge} band would "
+                             f"put it off the board, so stage 1 left it for "
+                             f"the later stages")
+                continue
             state.apply_move(ref, round(x, 3), round(y, 3), part.rot)
             placed.add(ref)
             unplaced.discard(ref)
@@ -531,6 +1158,7 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
                                  f"{state.clearance:g})")
             else:
                 unseated.append(ref)
+                unseated_ctx[ref] = (cx + jx, cy + jy, z.rect, tol)
                 notes.append(f"{ref}: no legal pose inside zone {name!r}")
 
     # ---- 2.5 decap-governed caps: one cap per supply PIN -------------------
@@ -682,7 +1310,116 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
                              f"{clr:g} (none at {state.clearance:g})")
         else:
             unseated.append(ref)
+            # setdefault: a zone member that failed its zone stage keeps THAT
+            # context, so the rung retries it inside its zone rather than at
+            # this unconstrained centroid (a seat outside the zone would fail
+            # the grade anyway).
+            unseated_ctx.setdefault(
+                ref, (target[0] + jx, target[1] + jy, None, 0.5))
             notes.append(f"{ref}: no legal pose anywhere on the board")
+
+    # ---- 3c. eviction rung (#630): census the blockers, evict, retry --------
+    # A part with no legal pose is not necessarily a part with no ROOM. Run 19
+    # measured the difference: three sweeps returned a bare "no legal pose
+    # anywhere on the board" for SW17/SW34, and when the question was finally
+    # asked in scoped form the engine answered precisely -- with D14 in place
+    # 0 poses, with D14 lifted 46; with D31, 0 then 32. One eviction each and
+    # both seated. That verdict was reachable the whole time; nothing asked.
+    #
+    # So: for each part this seed could not seat, count its poses with each
+    # nearby incumbent lifted in turn (the CENSUS, which runs at every depth
+    # and is what `no_pose_blockers` reports), and at depth 1 evict the one
+    # that frees the most and retry. THE ORDERING IS LOAD-BEARING -- the
+    # blocked part is seated FIRST, against a board the blocker is lifted
+    # out of, and the blocker is re-seated afterwards with it as an
+    # obstacle. Run 19's one-call reseat got a null three times precisely
+    # because its queue re-seated the blockers first, back into the pockets
+    # they block. The trade itself, and the rule that accepts or reverts
+    # it, is `_evict_trade`.
+    #
+    # Bounded on every axis: depth 1 (a blocker's own blocker is not
+    # chased), at most EVICT_MAX_BLOCKERS candidates per part, one trade per
+    # part, and the census counts to a cap.
+    if unseated:
+        # Not this rung's to lift: the intent's locks, and its declared edge
+        # connectors (see `_evict_candidates`). An edge_connector entry with
+        # no `edge` key is not protected, consistent with stage 1: it seats
+        # no such entry ("no edge, no seat") and leaves it to the ordinary
+        # stages, so it is an ordinary part here too.
+        immovable = set(lock_refs) | {c['ref'] for c in intent.edge_connectors
+                                      if c.get('edge')}
+        still: List[str] = []
+        # DEDUPED, and placed-aware. A zone member that fails its zone stage
+        # stays in `unplaced`, so stage 3 tries it again and appends it a
+        # SECOND time -- `unseated` can name one part twice. Iterating that
+        # raw ran the rung again on a part the first pass had just seated,
+        # where the trade is now a pure loss, and the revert put it back in
+        # `unseated`: a success undone by a duplicate.
+        seen: Set[str] = set()
+        for ref in list(unseated):
+            if ref in seen:
+                continue
+            seen.add(ref)
+            if ref in placed:
+                continue          # an earlier pass of this rung seated it
+            if ref not in unseated_ctx or ref not in state.parts:
+                still.append(ref)
+                continue
+            tx, ty, constraint, tol = unseated_ctx[ref]
+            base_excl = unplaced - {ref}
+            # The census and the retry answer the SAME question: both carry
+            # the zone the part was refused in. A census over the open board
+            # about a part that must land in a zone is a different question,
+            # and this one reaches `place_seed`'s JSON_SUMMARY.
+            zkw = dict(constraint=constraint, tol=tol)
+            baseline = count_legal_poses(state, ref, tx, ty, base_excl, **zkw)
+            cands = _evict_candidates(state, ref, tx, ty, placed, immovable,
+                                      constraint=constraint, tol=tol)
+            freed = {b: count_legal_poses(state, ref, tx, ty,
+                                          base_excl | {b}, **zkw)
+                     for b in cands}
+            no_pose_blockers[ref] = dict(freed)
+            useful = sorted((n, b) for b, n in freed.items() if n > baseline)
+            if not evict_depth:
+                still.append(ref)
+                if useful:
+                    notes.append(
+                        f"{ref}: no legal pose, and lifting {useful[-1][1]} "
+                        f"would free {useful[-1][0]} -- not evicted "
+                        f"(--evict-depth 0)")
+                continue
+            if not useful:
+                still.append(ref)
+                if cands:
+                    notes.append(
+                        f"{ref}: censused {len(cands)} neighbour(s); lifting "
+                        f"none of them frees a pose, so they are not what is "
+                        f"in the way")
+                continue
+            best = useful[-1][1]
+            bz = ref_zone.get(best)
+            rec = _evict_trade(
+                state, ref, best, tx, ty, constraint, tol,
+                bz.rect if bz is not None else None,
+                intent.zone_tolerance(bz) if bz is not None else 0.5,
+                placed, unplaced)
+            rec.update({'poses_freed': freed[best], 'poses_before': baseline,
+                        'depth': 1})
+            evictions.append(rec)
+            if rec['accepted']:
+                placed.add(ref)
+                unplaced.discard(ref)
+                notes.append(
+                    f"{ref}: seated after evicting {best} (poses at its "
+                    f"target: {baseline} before, {freed[best]} with {best} "
+                    f"lifted); violations {rec['violations_before']} -> "
+                    f"{rec['violations_after']}, hpwl {rec['hpwl_before']} "
+                    f"-> {rec['hpwl_after']}")
+            else:
+                still.append(ref)
+                notes.append(f"{ref}: evicting {best} REVERTED -- "
+                             f"{rec['reason']}")
+        unseated = still
 
     # ---- 3b. anchor rounds (run-4 C): gated re-seat passes ------------------
     # Round 1 seeded anchors against anchors only; now that the smalls
@@ -731,8 +1468,19 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
                    'new_x': state.parts[ref].x, 'new_y': state.parts[ref].y,
                    'new_rotation': state.parts[ref].rot}
                   for ref in sorted(placed)]
+    # Deduped: a zone member that also fails stage 3 is appended twice, and
+    # `unseated: 2` for one part is a miscount every consumer inherits --
+    # place_seed's summary, its exit code, and any gate reading the number.
     return {'placements': placements, 'lock_refs': lock_refs,
-            'unseated': sorted(unseated), 'notes': notes}
+            'unseated': sorted(set(unseated)), 'notes': notes,
+            # #629: a no-pose verdict that NAMES its blockers, with the count
+            # each one frees. Present at every evict_depth. An empty dict for
+            # a ref means the census ran and found no movable neighbour; a
+            # ref absent from the dict had no recorded target.
+            'no_pose_blockers': no_pose_blockers,
+            # One record per attempted trade (depth 1 only), accepted or
+            # reverted -- see `_evict_trade`.
+            'evictions': evictions}
 
 
 def stamp_locked(board_file: str, refs: Sequence[str]) -> int:
@@ -769,6 +1517,13 @@ def stamp_locked(board_file: str, refs: Sequence[str]) -> int:
         f.write(content)
     return count
 
+
+#: What a containment charges. Flat, not area-scaled: a 0402 wholly
+#: inside a TSSOP measures 0.5mm2 and an area charge would floor it to
+#: the 1.0mm budget, while a large part half-swallowed would outrank
+#: it. Containment is a yes/no fact about whether a part can be built.
+#: 2.0 buys the full cap ladder (budget = max(1.0, 8.0 * charge)).
+CONTAINMENT_CHARGE_MM = 2.0
 
 REPAIR_CAPS_MM = (0.5, 1.0, 2.0, 5.0)
 # A repair move must be PROPORTIONATE to the violation it clears. The cap
@@ -936,6 +1691,50 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
         ordered = sorted(free, key=_mover_key)
         # mm2 -> a strong mm-equivalent charge: a stack is never cosmetic
         _charge(ordered[0], max(1.0, bp.area_mm2))
+        for partner in ordered[1:]:
+            partner_of.setdefault(ordered[0], []).append(partner)
+
+    # CONTAINMENT census (run-22). The body census above reads
+    # `blocking_pairs`, which is pad_intersection ONLY -- so a part sitting
+    # WHOLLY INSIDE another part's .Fab body produces no pad-intersection area,
+    # is never charged, and legalize leaves it there. Prevention shipped
+    # (reconstruct._pair_conflicts refuses such a pose, candidate_valid refuses
+    # such a seat); this is the repair half, which did not.
+    #
+    # EXEMPTION: the engine's set, not the pair's `waiver` field.
+    # `containment_pairs` is deliberately unfiltered by `waived` -- that is the
+    # point of that list -- so iterating it raw would try to move orangecrab's
+    # FID2 out from under J5 (frac 1.000, by design). And filtering by
+    # `p.waived` instead would exempt `edge_class`, silently re-admitting the
+    # very defect the channel exists to catch (run 22's D4 wholly inside SW2,
+    # a declared edge_actuator).
+    _cont_exempt = set()
+    try:
+        from placement import reconstruct as _recon
+        _cont_exempt = _recon._body_exempt_refs(state)
+    except Exception:
+        _cont_exempt = set(getattr(state, 'container_refs', ()) or ())
+    _cont = [q for q in body.get('containment_pairs', ())
+             if q.a not in _cont_exempt and q.b not in _cont_exempt]
+    if _cont:
+        print(f"  Containment census: {len(_cont)} part(s) inside another "
+              f"part's body, all listed")
+    for q in _cont:
+        free = [r for r in (q.a, q.b)
+                if r in state.parts and not state.parts[r].locked]
+        if not free:
+            notes.append(f"containment {q.a}<->{q.b} "
+                         f"({q.contained_frac:.0%} of the smaller body): "
+                         f"both file-locked -- not repairable here")
+            continue
+        ordered = sorted(free, key=_mover_key)
+        # CHARGE: the same mm-equivalent scale the body stack above uses, so a
+        # containment buys at least the full cap ladder. Deliberately NOT
+        # area_mm2 -- a 0402 wholly inside a TSSOP measures 0.5mm2 and would
+        # be floored to a 1.0mm budget, while a large part half-swallowed
+        # would outrank it. Containment is a yes/no fact about whether a part
+        # can be built, so it charges a flat strong value rather than a size.
+        _charge(ordered[0], CONTAINMENT_CHARGE_MM)
         for partner in ordered[1:]:
             partner_of.setdefault(ordered[0], []).append(partner)
 
@@ -1157,7 +1956,31 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
         ctx = state.legality_ctx
         for ref in zero_move:
             still = False
+            # CONTAINMENT is checked FIRST, and it has to be: PairShortfall
+            # carries pad/hole/stack and no body term, so a part charged for
+            # sitting inside another body, which then could not move, would
+            # pass this loop and be reported `repaired`. That is the exact
+            # metric mismatch this re-grade was written to stop, one channel
+            # later.
+            #
+            # It FAILS LOUD. `state` is always a QuenchState (it comes from
+            # pose_score.make_state), so the method always exists, and
+            # fab_rect already swallows its own parse failure and returns None
+            # = UNJUDGED. Anything still raising here is a real bug -- and
+            # swallowing it would convert that bug into exactly the false
+            # `repaired` this check exists to prevent. So an error means NOT
+            # repaired, said out loud, rather than a silent pass.
+            try:
+                if state._body_contained_at(ref, None, None, None):
+                    still = True
+            except Exception as exc:
+                still = True
+                notes.append(f'{ref}: could not verify containment after the '
+                             f'repair ({exc.__class__.__name__}: {exc}) -- '
+                             f'NOT reported repaired')
             for other in sorted(state.parts):
+                if still:
+                    break
                 if other == ref:
                     continue
                 sf = ctx.pair_shortfall(ref, other)
@@ -1441,6 +2264,18 @@ def reseat_scope(pcb_data, pcb_file: str, intent, *,
             'reseated': sorted(m['reference'] for m in moves),
             'refused': sorted(refused),
             'unseated': sorted(r for r in res['unseated'] if r in scope),
+            # The census travels with the verdict here too (#630): a scope
+            # ref with no legal pose names what is in its way. This pass
+            # runs the seeder at its default evict_depth (0), so the two
+            # eviction counts are 0 by construction; they are carried so a
+            # reader sees the same keys on both paths.
+            'no_pose_blockers': {r: v for r, v in
+                                 (res.get('no_pose_blockers') or {}).items()
+                                 if r in scope},
+            'evictions': sum(1 for e in (res.get('evictions') or [])
+                             if e.get('accepted')),
+            'evictions_reverted': sum(1 for e in (res.get('evictions') or [])
+                                      if not e.get('accepted')),
             'scope': sorted(scope), 'scope_source': scope_source,
             'notes': notes,
             'gate_before': list(before), 'gate_after': list(after),

--- a/tests/test_630_seeder_eviction.py
+++ b/tests/test_630_seeder_eviction.py
@@ -1,0 +1,548 @@
+#!/usr/bin/env python3
+"""Issue #630's own pin test, against the tool the issue names.
+
+    "`place_seed` on a pile fixture must seat a part whose only pocket is
+     blocked by one movable incumbent, without hand intervention."
+
+Not `place_plan`, not a library call -- `place_seed`, because that is the
+tool run 19 was using when it returned "no legal pose anywhere on the board"
+three times and a teammate went off and wrote 221 lines of arithmetic.
+
+The block is a THEOREM, not an observation. On a 16 x 14 board at 0.5mm edge
+clearance, BIG's 10x10 courtyard confines its centre to x in [5.5, 10.5] and
+y in [5.5, 8.5]. Clearing SMALL's 1x1 courtyard at the zone centre by 0.2mm
+needs |cx - 8| >= 5.7 or |cy - 7| >= 5.7, and neither interval intersects
+BIG's legal range. So while SMALL sits there BIG has exactly zero legal
+poses, and a full rim of them once it moves.
+
+Both parts are declared into the SAME zone, so the seeder packs them by
+descending pin count -- SMALL first, because it has more pads. That is not a
+contrivance: it is the ordering that produced run 19's failure (34 six-pad
+diodes seated before 34 fifteen-millimetre switches, and the smalls took the
+centre).
+
+WHAT IS ASSERTED, AND WHY IT IS THE OUTPUT FILE. The first version of this
+file checked `unseated == 0 and placed == 2` and passed while SMALL sat 100%
+inside BIG's courtyard: the rung had re-seated the blocker with the part it
+had just seated still in its exclude set. A count of seated parts is not a
+board. So every accepting case here parses the WRITTEN board and proves
+pairwise legality with the legality module and `candidate_valid`, never the
+JSON. The JSON is checked too, for what it claims.
+
+Two of the checks below are MUTATION KILLS, kept because the gate they
+guard is cheap to weaken silently:
+  * "the gate does not trust `_try_place`" injects the fault that shipped
+    (the blocker returned on top of the part, reported as a seat) and
+    demands a revert -- dropping the legality conjunct from
+    `_evict_trade`'s acceptance turns it red;
+  * the pin test's pairwise-legality check turns red if the blocker is
+    re-seated with the part excluded again.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for p in (REPO,):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+        sys.path.insert(0, os.path.join(p, 'py_router'))
+        sys.path.insert(0, os.path.join(p, 'py_tools'))
+        sys.path.insert(0, os.path.join(p, 'py_placer'))
+
+from kicad_parser import parse_kicad_pcb                        # noqa: E402
+from placement import legality, seeder                          # noqa: E402
+import pose_score                                               # noqa: E402
+
+passed = failed = 0
+
+
+def check(name, ok, detail=""):
+    global passed, failed
+    passed += bool(ok)
+    failed += not ok
+    print(f"  {'OK  ' if ok else 'FAIL'} {name}{(' -- ' + detail) if detail else ''}")
+
+
+def _part(ref, x, y, half_w, half_h, npads, pad_y=0.0):
+    """A footprint with a (2*half_w x 2*half_h) courtyard and `npads` pads in
+    a row at local y=`pad_y`. Pad 1 is on N1, the rest on N2."""
+    pads = ''.join(
+        f'\t\t(pad "{i + 1}" smd rect\n\t\t\t(at {i * 0.2 - 0.2} {pad_y})\n'
+        f'\t\t\t(size 0.3 0.3)\n\t\t\t(layers "F.Cu")\n'
+        f'\t\t\t(net {1 if i == 0 else 2} "N{1 if i == 0 else 2}")\n'
+        f'\t\t\t(uuid "p{i}-{ref}")\n\t\t)\n' for i in range(npads))
+    return f'''\t(footprint "test:P{ref}"
+\t\t(layer "F.Cu")
+\t\t(uuid "fp-{ref}")
+\t\t(at {x} {y})
+\t\t(property "Reference" "{ref}"
+\t\t\t(at 0 0)
+\t\t)
+\t\t(fp_rect
+\t\t\t(start {-half_w} {-half_h})
+\t\t\t(end {half_w} {half_h})
+\t\t\t(layer "F.CrtYd")
+\t\t\t(uuid "cy-{ref}")
+\t\t)
+{pads}\t)
+'''
+
+
+def board(path, parts, size=(16, 14)):
+    """Every part stacked at one coordinate: the place-from-scratch task."""
+    body = ('(kicad_pcb\n\t(version 20241229)\n'
+            '\t(net 0 "")\n\t(net 1 "N1")\n\t(net 2 "N2")\n'
+            '\t(gr_rect\n\t\t(start 0 0)\n\t\t(end {} {})\n'
+            '\t\t(layer "Edge.Cuts")\n\t\t(uuid "e1")\n\t)\n'.format(*size)
+            + ''.join(parts) + ')\n')
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(body)
+
+
+def pile_board(path):
+    # SMALL has MORE pads than BIG, so the zone packer seats it first.
+    board(path, [_part('BIG', 8, 7, 5.0, 5.0, 2),
+                 _part('SMALL', 8, 7, 0.5, 0.5, 4)])
+
+
+def two_bigs_board(path):
+    """Two 10x10 courtyards on a 16x14 board: whichever seats first leaves
+    the other no pose, and lifting it frees plenty -- but there is no pose
+    to put it BACK to with the other in place (20.2mm of courtyard on a
+    15mm usable span, either axis). The only trade must revert."""
+    board(path, [_part('BIG1', 8, 7, 5.0, 5.0, 2),
+                 _part('BIG2', 8, 7, 5.0, 5.0, 4)])
+
+
+EDGE_SIZE = (20, 14)
+
+
+def _big_pad_part(ref, x, y, half_cy, pads):
+    """A courtyard of +/-half_cy with ARBITRARY pads: (num, net, px, py, sx, sy)."""
+    body = ''.join(
+        f'\t\t(pad "{n}" smd rect\n\t\t\t(at {px} {py})\n'
+        f'\t\t\t(size {sx} {sy})\n\t\t\t(layers "F.Cu")\n'
+        f'\t\t\t(net {net} "N{net}")\n\t\t\t(uuid "p{n}-{ref}")\n\t\t)\n'
+        for n, net, px, py, sx, sy in pads)
+    return f'''	(footprint "test:P{ref}"
+		(layer "F.Cu")
+		(uuid "fp-{ref}")
+		(at {x} {y})
+		(property "Reference" "{ref}"
+			(at 0 0)
+		)
+		(fp_rect
+			(start {-half_cy} {-half_cy})
+			(end {half_cy} {half_cy})
+			(layer "F.CrtYd")
+			(uuid "cy-{ref}")
+		)
+{body}	)
+'''
+
+
+def pad_overhang_board(path):
+    """The pin geometry (BIG 10x10, SMALL 1x1, SMALL seats first), but the
+    COPPER overhangs both courtyards by 1.0mm on every side: BIG carries one
+    12x12 pad on N1, SMALL two 1.5x3 pads (N1 | N2). The courtyards are what
+    the seat search clears, so SMALL's nearest re-seat sits 0.2mm outside
+    BIG's courtyard with 1.8mm of its copper over BIG's pad -- a pad-only
+    intersection, no courtyard overlap. `candidate_valid` tolerates it: both
+    parts start stacked at one coordinate, which is a bucket of TWO (not the
+    three that make a seed degenerate), so the pair's SEED baseline already
+    holds a larger pad intersection and `pads_ok` is "no worse than the
+    seed". Conjunct 2 therefore passes; only conjunct 3's absolute census
+    refuses the trade."""
+    board(path, [_big_pad_part('BIG', 8, 7, 5.0,
+                               [(1, 1, 0, 0, 12.0, 12.0)]),
+                 _big_pad_part('SMALL', 8, 7, 0.5,
+                               [(1, 1, -0.75, 0, 1.5, 3.0),
+                                (2, 2, 0.75, 0, 1.5, 3.0)])])
+
+
+def edge_board(path):
+    """J1 is a declared south-edge connector (4 x 3 courtyard, pads 0.5mm
+    inside its inner edge). With a 0..1mm band the overhang walk puts it
+    0.5mm past the edge-clearance inset, i.e. flush with the outline: centre
+    y=12.5, courtyard y 11.0..14.0. BIG is 11 x 11 on a 20 x 14 board: its
+    centre must lie in y [6.0, 8.0] at either rotation, and clearing J1 needs
+    y + 5.5 <= 10.8. No pose -- and lifting J1 frees one. The board is 20 wide so BIG (121mm2)
+    stays under the 50% container threshold (a container is skipped as an
+    obstacle, which is what made a 16 x 14 version of this fixture vacuous)
+    AND so that J1, rotated, WOULD fit inland beside BIG: an eviction of J1
+    would succeed here, which is what makes the pose assertion below
+    load-bearing rather than a revert dressed up as a refusal."""
+    board(path, [_part('BIG', 10, 7, 5.5, 5.5, 2),
+                 _part('J1', 10, 7, 2.0, 1.5, 2, pad_y=-1.0)],
+          size=EDGE_SIZE)
+
+
+def intent_for(refs, edge=None, size=(16, 14)):
+    w, h = float(size[0]), float(size[1])
+    it = {"schema": 1, "kind": "floorplan-intent", "units": "mm",
+          "envelope": {"rect": [0.0, 0.0, w, h], "tolerance_mm": 0.5},
+          "blocks": [{"name": "everything", "refs": list(refs),
+                      "zone": [0.5, 0.5, w - 0.5, h - 0.5],
+                      "tolerance_mm": 0.5}]}
+    if edge:
+        it["edge_connectors"] = [edge]
+    return it
+
+
+def run(workdir, make_board, intent, *extra, tag='seed'):
+    bpath = os.path.join(workdir, f'{tag}-in.kicad_pcb')
+    ipath = os.path.join(workdir, f'{tag}-fp.json')
+    out = os.path.join(workdir, f'{tag}-out.kicad_pcb')
+    make_board(bpath)
+    with open(ipath, 'w', encoding='utf-8') as f:
+        json.dump(intent, f)
+    r = subprocess.run(
+        [sys.executable, '-X', 'utf8',
+         os.path.join('py_placer', 'place_seed.py'), bpath, out,
+         '--intent', ipath, '--clearance', '0.2',
+         '--board-edge-clearance', '0.5', '--no-polish', *extra],
+        capture_output=True, text=True, encoding='utf-8', errors='replace',
+        cwd=REPO, timeout=900,
+        env=dict(os.environ, PYTHONHASHSEED='0', PYTHONIOENCODING='utf-8'))
+    summary = None
+    for line in r.stdout.splitlines():
+        if line.startswith('JSON_SUMMARY:'):
+            summary = json.loads(line.split(':', 1)[1])
+    return r, summary, out
+
+
+def poses(path):
+    pcb = parse_kicad_pcb(path)
+    return {ref: (round(fp.x, 3), round(fp.y, 3), round(fp.rotation, 1))
+            for ref, fp in sorted(pcb.footprints.items())}
+
+
+def pairwise_legal(path):
+    """(ok, detail) -- every pair of the WRITTEN board clear of every other,
+    by the legality module's courtyard census AND by `candidate_valid`
+    against the full part set (no exclude) at the run's own floors."""
+    pcb = parse_kicad_pcb(path)
+    pairs = legality.body_overlap_pairs(
+        legality.graded_parts_from_file(pcb, path))
+    st = pose_score.make_state(pcb, path, clearance=0.2,
+                               board_edge_clearance=0.5, grid_step=0.1)
+    bad = []
+    for ref in sorted(st.parts):
+        p = st.parts[ref]
+        if not st.candidate_valid(ref, p.x, p.y, p.rot, exclude=set()):
+            bad.append(ref)
+    detail = (f"courtyard overlaps {[(q.a, q.b, q.area_mm2) for q in pairs]}, "
+              f"candidate_valid rejects {bad}")
+    return (not pairs and not bad), detail
+
+
+# --------------------------------------------------------------------------
+# THE PIN TEST (depth 1, opt-in)
+# --------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as wd:
+    proc, s, out = run(wd, pile_board, intent_for(['BIG', 'SMALL']),
+                       '--evict-depth', '1')
+    check("place_seed runs", s is not None,
+          (proc.stdout[-600:] + proc.stderr[-600:]))
+    if s:
+        check("#630: it seats BOTH parts, with no hand intervention",
+              s['unseated'] == 0 and s['placed'] == 2,
+              f"placed {s['placed']}, unseated {s['unseated']} "
+              f"{s.get('unseated_refs')}")
+        check("and exits 0 rather than 4", proc.returncode == 0,
+              f"rc={proc.returncode}")
+        check("the JSON counts one KEPT eviction and no reverted one",
+              s.get('evictions') == 1 and s.get('evictions_reverted') == 0,
+              f"evictions {s.get('evictions')} reverted "
+              f"{s.get('evictions_reverted')}")
+    ok, detail = pairwise_legal(out)
+    check("THE BOARD: every pair of the written output is legal (the first "
+          "version shipped SMALL 100% inside BIG and said unseated 0)",
+          ok, detail)
+    check("the run says which part it evicted, and what that freed",
+          'evicting' in proc.stdout and 'poses at its target' in proc.stdout,
+          str([l for l in proc.stdout.splitlines() if "evict" in l][:2]))
+    check("the eviction is RECORDED with the violation measure either side",
+          any('evict' in l and 'violations' in l and 'hpwl' in l
+              for l in proc.stdout.splitlines()),
+          str([l for l in proc.stdout.splitlines() if 'evict' in l][:3]))
+
+# --------------------------------------------------------------------------
+# The default is OFF: census only, nothing moves (opt-in per CLAUDE.md until
+# an A/B row exists)
+# --------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as wd:
+    proc, s, out = run(wd, pile_board, intent_for(['BIG', 'SMALL']))
+    check("with no flag, the seed fails the way it always did (default 0)",
+          s and s['unseated'] == 1 and proc.returncode == 4,
+          f"unseated {s and s['unseated']}, rc={proc.returncode}")
+    check("and nothing was evicted",
+          s and s.get('evictions') == 0 and 'evicting' not in proc.stdout,
+          str(s and s.get('evictions')))
+    check("#629: the JSON_SUMMARY names the unseated ref, not just a count",
+          s and s.get('unseated_refs') == ['BIG'],
+          str(s and s.get('unseated_refs')))
+    check("#629: `no_pose_blockers` is in the JSON_SUMMARY",
+          s and 'no_pose_blockers' in s, str(sorted(s or {})))
+    check("#629: it names the blocker and the poses that blocker frees",
+          s and s.get('no_pose_blockers', {}).get('BIG', {}).get('SMALL', 0)
+          > 0,
+          str(s and s.get('no_pose_blockers')))
+    check("the bare verdict is still printed, now with the census beside it",
+          'no legal pose' in proc.stdout and 'would free' in proc.stdout,
+          proc.stdout[-300:])
+    proc2, s2, out2 = run(wd, pile_board, intent_for(['BIG', 'SMALL']),
+                          '--evict-depth', '0', tag='d0')
+    check("--evict-depth 0 is the same as the default",
+          s2 and s2['unseated'] == 1 and poses(out2) == poses(out),
+          f"{s2 and s2['unseated']} {poses(out2)} vs {poses(out)}")
+    proc3, s3, out3 = run(wd, pile_board, intent_for(['BIG', 'SMALL']),
+                          '--evict-depth', '2', tag='d2')
+    check("--evict-depth 2 is refused (nothing deeper is defined)",
+          proc3.returncode == 2 and s3 is None,
+          f"rc={proc3.returncode}")
+
+# --------------------------------------------------------------------------
+# A trade that cannot be completed REVERTS, says so, and leaves the board as
+# it was
+# --------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as wd:
+    proc, s, out = run(wd, two_bigs_board, intent_for(['BIG1', 'BIG2']),
+                       '--evict-depth', '1')
+    proc0, s0, out0 = run(wd, two_bigs_board, intent_for(['BIG1', 'BIG2']),
+                          '--evict-depth', '0', tag='ctrl')
+    check("the reverted case runs (both depths)",
+          s is not None and s0 is not None,
+          (proc.stdout[-400:] + proc.stderr[-400:]))
+    if s and s0:
+        check("the census found the blocker (so the trade was attempted)",
+              s['no_pose_blockers'].get('BIG1', {}).get('BIG2', 0) > 0,
+              str(s['no_pose_blockers']))
+        check("the trade REVERTED: JSON says evictions 0, reverted 1",
+              s.get('evictions') == 0 and s.get('evictions_reverted') == 1,
+              f"evictions {s.get('evictions')} reverted "
+              f"{s.get('evictions_reverted')}")
+        check("the part stays unseated and the exit code is 4",
+              s['unseated_refs'] == ['BIG1'] and proc.returncode == 4,
+              f"{s['unseated_refs']} rc={proc.returncode}")
+        check("the NOTE names the revert and the conjunct that failed",
+              any('REVERTED' in l and 'no legal pose to return' in l
+                  for l in proc.stdout.splitlines()),
+              str([l for l in proc.stdout.splitlines() if 'REVERT' in l]))
+        check("THE BOARD equals the pre-eviction poses (depth 0 output)",
+              poses(out) == poses(out0),
+              f"{poses(out)} vs {poses(out0)}")
+
+# --------------------------------------------------------------------------
+# CONJUNCT 3 IS THE DECIDING ONE: a re-seat that is courtyard-clear but
+# pad-intersecting, which the baseline-relative pad gate tolerates
+# --------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as wd:
+    proc, s, out = run(wd, pad_overhang_board, intent_for(['BIG', 'SMALL']),
+                       '--evict-depth', '1')
+    proc0, s0, out0 = run(wd, pad_overhang_board,
+                          intent_for(['BIG', 'SMALL']),
+                          '--evict-depth', '0', tag='ctrl')
+    check("the pad-overhang case runs (both depths)",
+          s is not None and s0 is not None,
+          (proc.stdout[-400:] + proc.stderr[-400:]))
+    if s and s0:
+        check("the fixture reproduces: BIG blocked by SMALL, census names it",
+              s0['unseated_refs'] == ['BIG']
+              and s['no_pose_blockers'].get('BIG', {}).get('SMALL', 0) > 0,
+              f"{s0['unseated_refs']} {s['no_pose_blockers']}")
+        check("the trade was REVERTED by conjunct 3 (violations rose), "
+              "having passed both seats and the legality re-check",
+              s.get('evictions') == 0 and s.get('evictions_reverted') == 1
+              and any('REVERTED' in l and 'violations rose' in l
+                      for l in proc.stdout.splitlines()),
+              str([l for l in proc.stdout.splitlines() if 'REVERT' in l]))
+        check("the board equals the depth-0 poses",
+              poses(out) == poses(out0), f"{poses(out)} vs {poses(out0)}")
+        # Absolute, on the written file: no pad of BIG intersects a pad of
+        # SMALL. This is what the mutation `accepted = bool(ok and legal)`
+        # ships, and the JSON above would not be the only thing to say so.
+        pcb_o = parse_kicad_pcb(out)
+        st_o = pose_score.make_state(pcb_o, out, clearance=0.2,
+                                     board_edge_clearance=0.5, grid_step=0.1)
+        sf = st_o.legality_ctx.pair_shortfall('BIG', 'SMALL')
+        claims_seated = not s.get('unseated_refs')
+        check("and if the JSON claims both seated, no BIG pad intersects a "
+              "SMALL pad in the written board",
+              (not claims_seated) or not (sf.pad_overlap or sf.stack),
+              f"unseated_refs={s.get('unseated_refs')} "
+              f"pad_overlap={sf.pad_overlap} stack={sf.stack} {poses(out)}")
+
+# --------------------------------------------------------------------------
+# A declared edge connector is never evicted inland
+# --------------------------------------------------------------------------
+EDGE = {"ref": "J1", "edge": "south",
+        "overhang_mm": {"min": 0.0, "max": 1.0}}
+with tempfile.TemporaryDirectory() as wd:
+    proc, s, out = run(wd, edge_board,
+                       intent_for(['BIG'], edge=EDGE, size=EDGE_SIZE),
+                       '--evict-depth', '1')
+    check("the edge case runs", s is not None,
+          (proc.stdout[-400:] + proc.stderr[-400:]))
+    if s:
+        pz = poses(out)
+        check("J1 was seated on its south edge by stage 1",
+              abs(pz['J1'][0] - 10.0) < 1e-6
+              and abs(pz['J1'][1] - 12.5) < 0.05,
+              str(pz))
+        check("BIG has no pose while J1 sits there (the fixture reproduces)",
+              s['unseated_refs'] == ['BIG'], str(s['unseated_refs']))
+        check("the census does NOT name J1 as a blocker: a declared edge "
+              "connector is not this rung's to lift",
+              'J1' not in s['no_pose_blockers'].get('BIG', {'J1': 1}),
+              str(s['no_pose_blockers']))
+        check("J1 was never evicted (no trade attempted, kept or reverted)",
+              'evicting J1' not in proc.stdout
+              and s.get('evictions') == 0
+              and s.get('evictions_reverted') == 0,
+              str([l for l in proc.stdout.splitlines() if 'evict' in l]))
+        check("and J1 is still ON ITS EDGE in the written board, not inland",
+              abs(pz['J1'][1] - 12.5) < 0.05 and pz['J1'][2] == 0.0,
+              str(pz))
+
+# --------------------------------------------------------------------------
+# The --reseat path carries the census too: a scope ref with no legal pose
+# names what is in its way in ITS JSON_SUMMARY, not only in a NOTE line
+# --------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as wd:
+    def placed_blocked(path):
+        # A PLACED board (distinct coordinates, so assess_placement does not
+        # call it a pile): SMALL seated at the centre, BIG beside it,
+        # overlapping. --reseat BIG lifts BIG and re-seats it at its net
+        # centroid, which is SMALL's pads -- no legal pose while SMALL sits
+        # there.
+        board(path, [_part('BIG', 8, 7, 5.0, 5.0, 2),
+                     _part('SMALL', 9.5, 8.5, 0.5, 0.5, 4)])
+    bpath = os.path.join(wd, 'placed.kicad_pcb')
+    ipath = os.path.join(wd, 'placed-fp.json')
+    outp = os.path.join(wd, 'placed-out.kicad_pcb')
+    placed_blocked(bpath)
+    with open(ipath, 'w', encoding='utf-8') as f:
+        json.dump(intent_for(['BIG', 'SMALL']), f)
+    r = subprocess.run(
+        [sys.executable, '-X', 'utf8',
+         os.path.join('py_placer', 'place_seed.py'), bpath, outp,
+         '--intent', ipath, '--clearance', '0.2',
+         '--board-edge-clearance', '0.5', '--reseat', 'BIG'],
+        capture_output=True, text=True, encoding='utf-8', errors='replace',
+        cwd=REPO, timeout=900,
+        env=dict(os.environ, PYTHONHASHSEED='0', PYTHONIOENCODING='utf-8'))
+    sr = None
+    for line in r.stdout.splitlines():
+        if line.startswith('JSON_SUMMARY:'):
+            sr = json.loads(line.split(':', 1)[1])
+    check("--reseat runs on the placed fixture and emits a summary",
+          sr is not None and sr.get('reseat') is True,
+          (r.stdout[-500:] + r.stderr[-500:]))
+    if sr:
+        check("--reseat: BIG is in scope and unseated (the fixture reproduces)",
+              sr.get('scope') == ['BIG'] and sr.get('unseated') == ['BIG'],
+              f"scope {sr.get('scope')} unseated {sr.get('unseated')}")
+        check("--reseat: the JSON_SUMMARY carries no_pose_blockers naming "
+              "SMALL, not only a NOTE line",
+              sr.get('no_pose_blockers', {}).get('BIG', {}).get('SMALL', 0)
+              > 0,
+              str(sr.get('no_pose_blockers')))
+        check("--reseat: the eviction counts are present and 0 (depth 0)",
+              sr.get('evictions') == 0 and sr.get('evictions_reverted') == 0,
+              f"{sr.get('evictions')} {sr.get('evictions_reverted')}")
+
+# --------------------------------------------------------------------------
+# A locked incumbent is never evicted -- it is not this tool's to move
+# --------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as wd:
+    def locked_pile(path):
+        pile_board(path)
+        src = open(path, encoding='utf-8').read().replace(
+            '(footprint "test:PSMALL"\n\t\t(layer "F.Cu")',
+            '(footprint "test:PSMALL"\n\t\t(layer "F.Cu")\n\t\t(locked yes)')
+        open(path, 'w', encoding='utf-8').write(src)
+    proc, s, out = run(wd, locked_pile, intent_for(['BIG', 'SMALL']),
+                       '--evict-depth', '1')
+    check("a file-locked incumbent is never evicted",
+          'evicting SMALL' not in proc.stdout
+          and s is not None and s.get('evictions') == 0,
+          "the rung moved a part the file locked")
+
+# --------------------------------------------------------------------------
+# THE GATE DOES NOT TRUST `_try_place`. Inject the fault that shipped: the
+# blocker's re-seat "succeeds" by landing it on the part just seated. The
+# acceptance rule's legality conjunct must refuse it and restore both.
+# --------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as wd:
+    import random
+    from placement import floorplan
+    bpath = os.path.join(wd, 'inj.kicad_pcb')
+    pile_board(bpath)
+    ipath = os.path.join(wd, 'inj.json')
+    with open(ipath, 'w', encoding='utf-8') as f:
+        json.dump(intent_for(['BIG', 'SMALL']), f)
+    intent = floorplan.load_intent(ipath)
+    pcb = parse_kicad_pcb(bpath)
+    real_try_place = seeder._try_place
+    injected = {'n': 0}
+
+    def faulty_try_place(state, ref, tx, ty, exclude, *a, **kw):
+        # Only the rung calls _try_place for SMALL with BIG seated and NOT
+        # excluded; that is the re-seat of the blocker. Stack it on BIG.
+        if ref == 'SMALL' and 'BIG' not in exclude \
+                and 'BIG' in state.parts and injected['n'] == 0:
+            injected['n'] += 1
+            b = state.parts['BIG']
+            state.apply_move('SMALL', b.x, b.y, state.parts['SMALL'].rot)
+            return state.clearance
+        return real_try_place(state, ref, tx, ty, exclude, *a, **kw)
+
+    # The control: the same seed at depth 0 gives SMALL's pre-trade seat.
+    res0 = seeder.seed_from_intent(
+        pcb, bpath, intent, random.Random("0"), clearance=0.2,
+        board_edge_clearance=0.5, grid_step=0.1, evict_depth=0)
+    seeder._try_place = faulty_try_place
+    try:
+        res = seeder.seed_from_intent(
+            pcb, bpath, intent, random.Random("0"), clearance=0.2,
+            board_edge_clearance=0.5, grid_step=0.1, evict_depth=1)
+    finally:
+        seeder._try_place = real_try_place
+    ev = res.get('evictions') or []
+    check("the fault was injected (the blocker was 'seated' on the part)",
+          injected['n'] == 1, str(injected))
+    check("the trade was REVERTED by the legality conjunct, not accepted",
+          len(ev) == 1 and ev[0]['accepted'] is False
+          and 'not legal' in ev[0]['reason'],
+          str(ev))
+    check("BIG is reported unseated again, not placed on top of SMALL",
+          res['unseated'] == ['BIG']
+          and all(p['reference'] != 'BIG' for p in res['placements']),
+          f"unseated {res['unseated']}")
+    placed = {p['reference']: (p['new_x'], p['new_y'], p['new_rotation'])
+              for p in res['placements']}
+    placed0 = {p['reference']: (p['new_x'], p['new_y'], p['new_rotation'])
+               for p in res0['placements']}
+    check("SMALL is back at its pre-trade seat (the snapshot restore)",
+          placed.get('SMALL') is not None
+          and placed.get('SMALL') == placed0.get('SMALL'),
+          f"{placed} vs depth-0 {placed0}")
+
+# --------------------------------------------------------------------------
+# The seeder refuses an undefined depth too (the CLI's choices= is not the
+# only guard)
+# --------------------------------------------------------------------------
+try:
+    seeder.seed_from_intent(pcb, bpath, intent, random.Random("0"),
+                            evict_depth=2)
+    check("seed_from_intent(evict_depth=2) raises", False, "no error")
+except ValueError as exc:
+    check("seed_from_intent(evict_depth=2) raises", 'evict_depth' in str(exc),
+          str(exc))
+
+print(f"\n{passed} passed, {failed} failed")
+sys.exit(1 if failed else 0)

--- a/tests/test_place_edge_containment.py
+++ b/tests/test_place_edge_containment.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""An edge seat must land ON the board, or not be a seat.
+
+`_seat_edge` is the one seat in the system that runs neither `pose_ok` (an edge
+part overhangs by design, so full containment is the wrong predicate) nor a
+clearance ladder. That left it with no containment check of any kind, and three
+defects that compounded into a connector placed entirely off the far side of
+the board and reported as seated, exit 0:
+
+  A. `_seat_edge` took no exclude set, so an unplaced PILE at the board centre
+     vetoed the honest edge poses and the slide loop walked the part along the
+     edge until one was "conflict free".
+  B. `_edge_correct` drives a SCALAR SUM (`rect_outside_amount` sums all four
+     sides) with a SINGLE-AXIS walk, so an along-edge overshoot is a constant
+     it can never cancel -- it subtracts it again every iteration and marches
+     the part inland past the opposite edge. It ran a fixed `range(4)` with no
+     convergence test, returning a diverged pose indistinguishably from a
+     converged one.
+  C. The along-edge fraction was clamped to a bare [0.05, 0.95], which knows
+     nothing of the part's own width.
+
+Measured before the fix, on a staged pile of orangecrab_ext_pll:
+`_seat_edge(J2, south)` against the pile returned pose (170.068, 88.767) and
+reported a seat -- on a board spanning y 91.52..114.38, i.e. entirely off
+the NORTH edge, 26.17mm from where the same call lands on the placed board
+((159.909, 112.33)). The fix makes the pile case return that same correct
+answer.
+
+The fixture is the tracked `kicad_files/orangecrab_ext_pll.kicad_pcb`, driven
+through the seeder helpers IN MEMORY -- no CLI, so the routed/unplaced gates
+and the board's existing copper are irrelevant to what is being measured here.
+It is used because it genuinely reproduces: J2's courtyard is 41.16mm on a
+50.80mm edge, so the part is 81% of its own edge and the fraction clamp is
+load-bearing. `flat_hierarchy` (the acceptance fixture) does NOT reproduce any
+of this -- its connectors are small and far from the pile -- which is exactly
+why this file exists separately.
+"""
+import os
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for p in (REPO, os.path.join(REPO, 'py_router'), os.path.join(REPO, 'py_tools'),
+          os.path.join(REPO, 'py_placer')):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+BOARD = os.path.join(REPO, 'kicad_files', 'orangecrab_ext_pll.kicad_pcb')
+passed = failed = 0
+
+
+def check(name, ok, detail=""):
+    global passed, failed
+    passed += bool(ok)
+    failed += not ok
+    print(f"  {'OK  ' if ok else 'FAIL'} {name}{(' -- ' + detail) if detail else ''}")
+
+
+if not os.path.isfile(BOARD):
+    print(f"FAIL fixture missing: {BOARD} (it is tracked; a skip here would "
+          f"hide the whole file)")
+    print("\n0 passed, 1 failed")
+    sys.exit(1)
+
+import pose_score
+from kicad_parser import parse_kicad_pcb
+from placement import seeder
+
+pcb = parse_kicad_pcb(BOARD)
+
+
+def fresh_state():
+    return pose_score.make_state(pcb, BOARD, clearance=0.25,
+                                 board_edge_clearance=0.55, grid_step=0.1)
+
+
+def pile(state, keep=('J2',)):
+    """Stack every movable part at the board centre, as staging does."""
+    x0, y0, x1, y1 = state.board
+    cx, cy = (x0 + x1) / 2.0, (y0 + y1) / 2.0
+    piled = []
+    for ref, p in state.parts.items():
+        if ref in keep or getattr(p, 'locked', False):
+            continue
+        state.apply_move(ref, cx, cy, 0.0)
+        piled.append(ref)
+    return set(piled)
+
+
+def pads_on_board(state, ref):
+    """Does this part's PAD COPPER lie inside the outline bbox?"""
+    p = state.parts[ref]
+    fp = pcb.footprints[ref]
+    dx, dy = p.x - fp.x, p.y - fp.y
+    xs = [q.global_x + dx for q in fp.pads]
+    ys = [q.global_y + dy for q in fp.pads]
+    x0, y0, x1, y1 = state.board
+    return (min(xs) >= x0 - 0.01 and max(xs) <= x1 + 0.01
+            and min(ys) >= y0 - 0.01 and max(ys) <= y1 + 0.01)
+
+
+# --------------------------------------------------------------------------
+# C. the fraction clamp knows the part's own width
+# --------------------------------------------------------------------------
+st = fresh_state()
+j2 = st.parts['J2']
+r = j2.rect(0.0, 0.0, j2.rot)
+width, span = r[2] - r[0], st.board[2] - st.board[0]
+lo, hi = seeder._edge_frac_bounds(j2, st.board, 'south')
+# centre may range over (span - width); as a fraction that is width/2/span in
+# from each end. 41.16 on 50.80 -> 0.405 .. 0.595.
+want_lo = (width / 2.0) / span
+check("the fraction clamp is derived from the part's own half-extent",
+      abs(lo - want_lo) < 1e-6 and abs(hi - (1.0 - want_lo)) < 1e-6,
+      f"{lo:.3f}..{hi:.3f}, part {width:.2f}mm on a {span:.2f}mm edge")
+check("and it is far tighter than the old bare [0.05, 0.95]",
+      lo > 0.05 and hi < 0.95, f"{lo:.3f}..{hi:.3f}")
+
+# a part wider than its edge has NO legal fraction, and says so
+wide_lo, wide_hi = seeder._edge_frac_bounds(j2, (0.0, 0.0, 10.0, 10.0), 'south')
+check("a part wider than the edge yields lo > hi (no legal fraction)",
+      wide_lo > wide_hi, f"{wide_lo:.3f}..{wide_hi:.3f}")
+
+# --------------------------------------------------------------------------
+# B. the correction walk reports divergence instead of hiding it
+# --------------------------------------------------------------------------
+st = fresh_state()
+# Start it where the agent measured divergence: far along the edge, so the
+# along-edge overshoot is a constant the single-axis walk cannot cancel.
+x_bad, y_bad = seeder._edge_pose(st.parts['J2'], st.board, 'south', 0.90, 0.0)
+_x, _y, converged = seeder._edge_correct(st, 'J2', 'south', x_bad, y_bad, 0.0)
+check("a diverging overhang walk reports converged=False",
+      converged is False, f"landed at ({_x:.3f}, {_y:.3f})")
+check("and it really did march off the board (the case is not hypothetical)",
+      _y < st.board[1] or _y > st.board[3],
+      f"y={_y:.3f} vs board y {st.board[1]:.2f}..{st.board[3]:.2f}")
+
+# a centred start converges
+x_ok, y_ok = seeder._edge_pose(st.parts['J2'], st.board, 'south', 0.5, 0.0)
+_x2, _y2, conv2 = seeder._edge_correct(st, 'J2', 'south', x_ok, y_ok, 0.0)
+check("a well-posed walk still converges (the flag is not always False)",
+      conv2 is True, f"({_x2:.3f}, {_y2:.3f})")
+
+# --------------------------------------------------------------------------
+# A + the whole thing: seat against a pile, land on the board
+# --------------------------------------------------------------------------
+st = fresh_state()
+piled = pile(st)
+entry = {'edge': 'south', 'overhang_mm': {'min': 0.0, 'max': 1.0}}
+notes = []
+ok = seeder._seat_edge(st, 'J2', entry, set(), notes, exclude=piled)
+check("it seats against a pile", ok, str(notes[-2:]))
+check("and the seat is ON the board -- the whole point",
+      pads_on_board(st, 'J2'),
+      f"pose ({st.parts['J2'].x:.3f}, {st.parts['J2'].y:.3f}), "
+      f"board {[round(v, 2) for v in st.board]}")
+check("it lands on the SOUTH edge it was asked for",
+      abs(st.parts['J2'].y - st.board[3]) < 3.0,
+      f"y={st.parts['J2'].y:.3f} vs south edge {st.board[3]:.2f}")
+
+# The measured pre-fix pose, asserted absent by name.
+check("it is not the pre-fix pose (170.068, 88.767)",
+      not (abs(st.parts['J2'].x - 170.068) < 0.01
+           and abs(st.parts['J2'].y - 88.767) < 0.01),
+      "that pose is 26.17mm away and entirely off the north edge")
+
+# A NONSENSE BAND must not buy an off-board seat. This is what makes the
+# containment gate load-bearing rather than decorative: with only the fraction
+# clamp in place, `converged`/`on_board` are never reached on a well-posed
+# call, so removing them changes nothing observable. Here the declared band is
+# satisfiable ONLY by a part sitting entirely off the board -- a 20mm overhang
+# on a 3.0mm-tall connector -- and the overlap invariant is the thing that
+# refuses it. Fault-injecting the gate away turns this red.
+# ALL FOUR EDGES. Testing only `south` is how the first version of this file
+# passed while the same nonsense band was accepted on east and west with 8 of
+# 16 pads off the board: on south, J2's 3.00mm dimension is normal to the edge
+# so a bare overlap test collapses to zero and refuses by accident; on east and
+# west its 41.16mm dimension keeps half the courtyard over the bbox and the
+# "invariant" held. One edge is not a test of an edge predicate.
+for _edge in ('south', 'north', 'east', 'west'):
+    st3 = fresh_state()
+    piled3 = pile(st3)
+    silly = {'edge': _edge, 'overhang_mm': {'min': 20.0, 'max': 21.0}}
+    ok3 = seeder._seat_edge(st3, 'J2', silly, set(), [], exclude=piled3)
+    check(f"[{_edge}] a band only an off-board pose could satisfy is refused",
+          (not ok3) or pads_on_board(st3, 'J2'),
+          f"ok={ok3} pose ({st3.parts['J2'].x:.3f}, {st3.parts['J2'].y:.3f})")
+
+# A merely WRONG band, not a nonsense one. The overlap test only refuses a part
+# that is 100% off, so `{3,4}` on a 3.00mm-deep connector seated it with 1.7%
+# of its courtyard on the board. The depth bound is what refuses this.
+for _band in ({'min': 3.0, 'max': 4.0}, {'min': 2.0, 'max': 3.0}):
+    st4 = fresh_state()
+    piled4 = pile(st4)
+    ok4 = seeder._seat_edge(st4, 'J2',
+                            {'edge': 'south', 'overhang_mm': _band},
+                            set(), [], exclude=piled4)
+    check(f"a band of {_band['min']:g}-{_band['max']:g}mm on a 3.0mm-deep part "
+          f"does not seat it off the board",
+          (not ok4) or pads_on_board(st4, 'J2'),
+          f"ok={ok4} pose ({st4.parts['J2'].x:.3f}, {st4.parts['J2'].y:.3f})")
+
+# A LEGITIMATE band must still seat -- otherwise the bound above is just a
+# refusal machine and the edge seat stops working.
+st5 = fresh_state()
+piled5 = pile(st5)
+ok5 = seeder._seat_edge(st5, 'J2',
+                        {'edge': 'south', 'overhang_mm': {'min': 0.0,
+                                                          'max': 1.0}},
+                        set(), [], exclude=piled5)
+check("a sane band still seats (the bound is not a blanket refusal)",
+      ok5 and pads_on_board(st5, 'J2'),
+      f"ok={ok5} pose ({st5.parts['J2'].x:.3f}, {st5.parts['J2'].y:.3f})")
+
+# WITHOUT the exclude set the pile is a full obstacle set -- that is defect A.
+# The seat must then either refuse or still be on-board; what it must never do
+# is slide off the end and report success.
+st2 = fresh_state()
+pile(st2)
+notes2 = []
+ok2 = seeder._seat_edge(st2, 'J2', entry, set(), notes2)     # no exclude
+check("even with NO exclude set it never seats off the board",
+      (not ok2) or pads_on_board(st2, 'J2'),
+      f"ok={ok2} pose ({st2.parts['J2'].x:.3f}, {st2.parts['J2'].y:.3f})")
+
+print(f"\n{passed} passed, {failed} failed")
+sys.exit(1 if failed else 0)

--- a/tests/test_run22_containment_repair.py
+++ b/tests/test_run22_containment_repair.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""A part buried inside another part's body is DISCLOSED, GATED and REPAIRED.
+
+Run 22 shipped a board every gate called buildable while RN3 sat wholly inside
+U5's body and RN7 inside U6's. Prevention landed first
+(`reconstruct._pair_conflicts` refuses such a candidate pose); this file covers
+the rest of the loop end to end on a real board.
+
+**The fixture is the delicate part, and two obvious ones are vacuous.** A
+containment planted anywhere that also produces a PAD INTERSECTION proves
+nothing: `repair_placement` already charged pad conflicts, so `legalize` moves
+the part for the other reason and the containment clears as a side effect --
+measured, such a fixture passes identically with the containment census
+stashed out. And a marker planted inside a body proves nothing if the marker
+has no `.Fab` geometry (tigard's H1..H4 are all `fab_unjudged`), because no
+pair is formed at all.
+
+So the subject here is **D3 inside U5** -- `contained 1, gating 1,
+blocking_pairs []`, a containment and nothing else, which is run 22's exact
+shape. A/B against the stashed census:
+
+    with census      Containment census: 1 part(s) ... -> 1 repaired, contained 0
+    without census   (silent)                          -> 0 repaired, 0 unrepairable
+
+The control is **TP1 at the same coordinates**: same board, same host, same
+geometry, only the part class differs -- contained, but `marker_class`, so it
+neither gates nor moves.
+
+Run: python3 -X utf8 tests/test_run22_containment_repair.py
+"""
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+for _p in ('py_router', 'py_tools', 'py_placer'):
+    sys.path.insert(0, os.path.join(ROOT, _p))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+os.environ.setdefault('KRT_NO_BANNER', '1')
+
+from run_utils import tool as _tool                            # noqa: E402
+from kicad_parser import parse_kicad_pcb                       # noqa: E402
+from placement.legality import grade_body_overlap              # noqa: E402
+from placement.writer import write_placed_output               # noqa: E402
+from copy_board import SIBLING_EXTS                            # noqa: E402
+
+SKIP_EXIT = 77
+BOARD = os.path.join(ROOT, 'kicad_files', 'tigard.kicad_pcb')
+MARKER_BOARD = os.path.join(ROOT, 'kicad_files',
+                            'orangecrab_ext_pll.kicad_pcb')
+
+# U5's fab body centre. D3 (0.8x1.6) sits wholly inside it at frac 1.0 with no
+# pad of any other part within reach -- found by sweeping every (small, host)
+# pair on the board for a containment with zero pad clash.
+U5_CENTRE = (62.27, 60.90)
+
+FAILURES = []
+
+
+def check(name, cond, detail=''):
+    print(f'  {"PASS" if cond else "FAIL"}  {name}'
+          + (f'\n        {detail}' if not cond and detail else ''))
+    if not cond:
+        FAILURES.append(name)
+
+
+def _run(script, *argv):
+    return subprocess.run([sys.executable, '-X', 'utf8', _tool(script), *argv],
+                          capture_output=True, text=True, encoding='utf-8',
+                          errors='replace', cwd=ROOT, timeout=1800)
+
+
+def _grade(path):
+    return grade_body_overlap(parse_kicad_pcb(path), 0.15, pcb_file=path)
+
+
+def _summary(stdout):
+    for line in stdout.splitlines():
+        if line.startswith('JSON_SUMMARY:'):
+            try:
+                return json.loads(line.split(':', 1)[1])
+            except Exception:
+                return None
+    return None
+
+
+def plant_at(src, dst, ref, x, y, td):
+    """Put `ref` at an EXACT board position, deterministically.
+
+    The pose is ASSERTED through `placement.writer.write_placed_output` -- no
+    search, no plan -- which is what makes this a fixture rather than a hope:
+    a perturbation might or might not land inside a body, and a test that only
+    sometimes builds its own subject is not a test. The siblings travel with
+    the board (#441) so every later step grades at the floor it was staged at.
+    Returns an object with `.returncode` (0 = planted), like the subprocess
+    result the callers were written against.
+    """
+    from types import SimpleNamespace
+    try:
+        fp = parse_kicad_pcb(src).footprints[ref]
+        ok = write_placed_output(src, dst, [
+            {'reference': ref, 'new_x': float(x), 'new_y': float(y),
+             'new_rotation': float(fp.rotation)}])
+        for ext in SIBLING_EXTS:
+            sib = os.path.splitext(src)[0] + ext
+            if os.path.isfile(sib):
+                shutil.copy2(sib, os.path.splitext(dst)[0] + ext)
+    except Exception as exc:                                 # noqa: BLE001
+        print(f'  plant_at({ref}) failed: {type(exc).__name__}: {exc}')
+        return SimpleNamespace(returncode=1)
+    return SimpleNamespace(returncode=0 if ok and os.path.exists(dst) else 1)
+
+
+def pose_of(path, ref):
+    fp = parse_kicad_pcb(path).footprints[ref]
+    return (round(fp.x, 3), round(fp.y, 3))
+
+
+def main():
+    if not os.path.exists(BOARD):
+        print('SKIP: tigard not present')
+        return SKIP_EXIT
+    td = tempfile.mkdtemp()
+    try:
+        base = os.path.join(td, 'base.kicad_pcb')
+        if _run('copy_board.py', BOARD, base).returncode != 0:
+            print('SKIP: could not stage the board')
+            return SKIP_EXIT
+        check('the fixture board starts with no containment',
+              _grade(base)['contained'] == 0)
+
+        print('a PURE containment (no pad conflict) is disclosed and GATES')
+        dmg = os.path.join(td, 'contained.kicad_pcb')
+        if plant_at(base, dmg, 'D3', U5_CENTRE[0], U5_CENTRE[1],
+                    td).returncode != 0 or not os.path.exists(dmg):
+            print('SKIP: could not plant the fixture')
+            return SKIP_EXIT
+        g = _grade(dmg)
+        check('D3 is wholly inside U5', g['contained'] == 1,
+              str([(q.a, q.b, q.contained_frac)
+                   for q in g['containment_pairs']]))
+        # THE anti-vacuity assertion. If this ever fails, the fixture has
+        # drifted into a pad conflict and every `repaired` check below would
+        # pass with the census removed.
+        check('...and it is the ONLY thing wrong -- no pad conflict',
+              g['blocking'] == 0 and not g['blocking_pairs'],
+              str([(q.a, q.b, q.kind) for q in g['blocking_pairs']]))
+        check('...so it gates on containment alone',
+              g['containment_blocking'] == 1)
+
+        asm = _run('check_assembly.py', dmg, '--clearance', '0.15')
+        check('check_assembly refuses the board', asm.returncode == 4,
+              f'exit {asm.returncode}')
+        check('...and says why', 'CONTAINMENT' in asm.stdout, asm.stdout[-300:])
+
+        print('legalize REPAIRS it -- the census is what makes this pass')
+        out = os.path.join(td, 'fixed.kicad_pcb')
+        r = _run('place_reconstruct.py', dmg, out,
+                 '--stages', 'classify,legalize', '--clearance', '0.15')
+        check('the containment census fires',
+              'Containment census' in r.stdout, r.stdout[-300:])
+        leg = (_summary(r.stdout) or {}).get('legalize') or {}
+        check('legalize repairs D3', 'D3' in set(leg.get('repaired') or []),
+              str(leg))
+        if os.path.exists(out):
+            after = _grade(out)
+            check('...and the containment is GONE from the output',
+                  after['containment_blocking'] == 0,
+                  str([(q.a, q.b) for q in after['containment_blocking_pairs']]))
+            check('...and check_assembly now accepts it',
+                  _run('check_assembly.py', out,
+                       '--clearance', '0.15').returncode == 0)
+        else:
+            check('the output board was written', False, r.stdout[-300:])
+
+        print('the paired control: a MARKER at the SAME pose is exempt')
+        # Only the part class differs from the case above. tigard's H1..H4 draw
+        # no .Fab geometry and would form no pair at all, so the marker has to
+        # be TP1 -- a testpoint WITH a body -- or this proves nothing.
+        mk = os.path.join(td, 'marker.kicad_pcb')
+        if plant_at(base, mk, 'TP1', U5_CENTRE[0], U5_CENTRE[1],
+                    td).returncode == 0 and os.path.exists(mk):
+            gm = _grade(mk)
+            check('TP1 is equally contained', gm['contained'] == 1,
+                  str([(q.a, q.b, q.contained_frac)
+                       for q in gm['containment_pairs']]))
+            check('...but does NOT gate', gm['containment_blocking'] == 0,
+                  str([(q.a, q.b, q.waiver) for q in gm['containment_pairs']]))
+            mo = os.path.join(td, 'marker_out.kicad_pcb')
+            _run('place_reconstruct.py', mk, mo,
+                 '--stages', 'classify,legalize', '--clearance', '0.15')
+            if os.path.exists(mo):
+                check('...and legalize does not move it',
+                      pose_of(mo, 'TP1') == pose_of(mk, 'TP1'),
+                      f'{pose_of(mk, "TP1")} -> {pose_of(mo, "TP1")}')
+        else:
+            check('the marker case could be planted', False)
+
+        print('a containment it CANNOT reach is named, never faked')
+        # R18 at U3's centre needs 9.15mm to come home and the cap ladder tops
+        # out at 5.0mm on a board where every other part is at its healthy
+        # pose. Unlike the case above this one ALSO carries a pad conflict, so
+        # it is a contract check on `repair_placement`'s honesty re-grade
+        # rather than a test of the census -- it passes with the census
+        # stashed out, and is kept because reporting an unmoved part as
+        # `repaired` is the failure this whole channel exists to prevent.
+        u3 = parse_kicad_pcb(base).footprints['U3']
+        deep = os.path.join(td, 'deep.kicad_pcb')
+        if plant_at(base, deep, 'R18', u3.x, u3.y, td).returncode == 0 \
+                and os.path.exists(deep):
+            r = _run('place_reconstruct.py', deep,
+                     os.path.join(td, 'deep_out.kicad_pcb'),
+                     '--stages', 'classify,legalize', '--clearance', '0.15')
+            leg = (_summary(r.stdout) or {}).get('legalize') or {}
+            check('it is NOT reported repaired',
+                  'R18' not in set(leg.get('repaired') or []), str(leg))
+            check('...it is named unrepairable',
+                  'R18' in set(leg.get('unrepairable') or []), str(leg))
+            check('...and the run does not exit clean', r.returncode != 0,
+                  f'exit {r.returncode}')
+
+        print('the corpus case the exemption was written for')
+        if os.path.exists(MARKER_BOARD):
+            go = _grade(MARKER_BOARD)
+            check('orangecrab_ext_pll ships 2 real containments',
+                  go['contained'] == 2, str(go['contained']))
+            check('...both marker_class, so none gates',
+                  go['containment_blocking'] == 0,
+                  str([(q.a, q.b, q.waiver) for q in go['containment_pairs']]))
+        else:
+            print('  (absent)')
+    finally:
+        shutil.rmtree(td, ignore_errors=True)
+
+    print()
+    if FAILURES:
+        print(f'FAIL: {len(FAILURES)} check(s): {", ".join(FAILURES)}')
+        return 1
+    print('OK')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Seeder: a gated eviction rung, and a no-legal-pose verdict that names its blockers. Rebased on current main on top of the merged #680 (it uses `reconstruct._body_exempt_refs` and `QuenchState._body_contained_at` from there). No clock anywhere.

The previous head of this branch shipped overlapping parts: the rung re-seated the evicted blocker with the part it had just seated still in its exclude set, so on its own fixture SMALL ended 100% inside BIG's courtyard while the run reported `unseated 0, grade_errors 0`. That is fixed here, and the acceptance rule no longer trusts the search's return value at all, so the same class of bug cannot ship again: a trade is kept only if both parts re-check legal against every seated part, with each other as obstacles.

## What changes for a user

**The census (`no_pose_blockers`), at every depth.** When `place_seed` cannot seat a part, it now counts that part's legal poses with each nearby seated neighbour lifted in turn (same seat predicate as the search, same zone, capped) and puts `{ref: {blocker: poses_freed}}` in the JSON_SUMMARY as `no_pose_blockers`, next to `unseated_refs` (names, not just a count). Locked parts and declared edge connectors are never censused as candidates. This is the "name the blockers" half of issue 629, which #680's body text already took care of; the census here serves that request without reopening it.

**The eviction rung, `--evict-depth 1` (default 0, opt-in).** At depth 1 the seeder evicts the neighbour that frees the most poses, seats the blocked part first against the lifted board, then re-seats the blocker inside its own zone, searching out from its old pose, with the part in place. The trade is accepted only if, in this order:

1. both seats were found;
2. both are legal against the full seated set, re-checked with the seat predicate (`pose_ok`, which includes #680's body containment) at the clearance the seats were found at, with only the still-unplaced pile excluded, so the two parts are obstacles to each other;
3. the seated board's violation measure (intersecting pairs and overlap area over the seated parts, `_seated_violations`) did not increase. This is the only absolute pad-layer check in the rule: conjunct 2's pad test is baseline-relative ("no worse than the seed pose"), and two parts that started stacked already have a pad intersection in their seed baseline, so a re-seat whose courtyards are clear but whose pads intersect passes 2 and is refused here.

HPWL is recorded in the eviction record and never consulted. The earlier gate used the reconstruct tuple, which ranks HPWL above overlap area; a part in the pile has an artificially short HPWL, so that gate refused every legal trade and accepted only the illegal one. A rejected trade restores both poses from the snapshot and is recorded: `evictions` counts kept trades, `evictions_reverted` counts the rest, and the NOTE line names the conjunct that failed. The `--reseat` path carries the same three keys for its scope (it runs at depth 0, so the counts there are 0; the census is the point). One trade per part, depth 1 only; `--evict-depth` takes `choices=(0, 1)` and `seed_from_intent` raises on anything else. Default 0 because a new placement term goes through `tests/test_placement_ab.py` on three boards before it ships on (CLAUDE.md), and that row does not exist yet.

**Edge seats land on the board or are not seats.** `_seat_edge` took no exclude set (a pile at the board centre vetoed honest edge poses and the slide loop walked the part off the end), `_edge_correct` drove a four-sided sum with a single-axis walk and returned a diverged pose as if converged, and the along-edge fraction clamp was a bare [0.05, 0.95] that knew nothing of the part's width. Measured on orangecrab_ext_pll: J2 seated at (170.068, 88.767), entirely off the north edge, reported as a seat. Now `_edge_correct` returns a converged flag, `_edge_frac_bounds` derives the clamp from the part's own half-extent, `edge_seat_ok` requires the measured overhang inside the declared band and every pad on the board (through the edge gate, so cutouts count), and both `_seat_edge` and stage 1 refuse a pose that fails it. This is separate from the rung; it is in this PR because the rung's edge-connector probe is what exposed it, and `tests/test_place_edge_containment.py` pins it.

**`legalize` repairs a body containment it did not create.** `repair_placement`'s census read `blocking_pairs` (pad intersections only), so a part sitting wholly inside another part's .Fab body was never charged and never moved. It now runs a containment census on `containment_pairs`, exempting the engine's marker/container set (`reconstruct._body_exempt_refs`), charges a flat `CONTAINMENT_CHARGE_MM`, and re-grades containment before reporting a part repaired. `tests/test_run22_containment_repair.py` pins it on tigard (D3 inside U5, a containment with no pad clash, so the pad channel cannot clear it by accident).

`zone_gate` (the zone predicate with its anchor relaxation) and `zone_census_offsets` are shared between the search and the census, so the census cannot count poses the search would not take. `place_seed.py` declares its provenance lever like `place_reconstruct.py` already does. The unseated list is deduplicated (a zone member that also failed stage 3 used to be counted twice).

## What was removed from the earlier head

Dead code: `census_window`, `near_miss_poses`, the `forbid`/keepout parameter threaded through `pose_ok`, `count_legal_poses` and `_try_place` (no caller), `copy_siblings(quiet=)`, and the `RUN_ALL_TIMEOUT` constants (nothing reads them). Separable changes that are not needed by the rung were dropped back to main: the `pose_score._offsets` cache and the `copy_siblings` warning. Comments that referred to an unshipped plan-op branch were scrubbed.

Closes #630.

## Testing

`python3 -X utf8` on Windows, from this branch on current main:

- `tests/test_630_seeder_eviction.py` 42/42: the pin test asserts pairwise legality of the written board (legality module courtyard census plus `candidate_valid` with no exclude, never the JSON), the default-off path, a reverted-trade fixture (two 10x10 parts on a 16x14 board: the blocker has nowhere to return to; JSON says reverted, exit 4, board equals the depth-0 poses), a pad-overhang fixture where conjunct 3 is the deciding one (copper overhangs both courtyards by 1mm, so the blocker's nearest re-seat is courtyard-clear with pads intersecting, which the baseline-relative pad gate tolerates; the NOTE reads `violations rose [0, 0.0] -> [1, 0.0]`), a declared edge connector that is never censused or evicted, a `--reseat` run whose JSON_SUMMARY carries `no_pose_blockers`, a file-locked incumbent, a fault injection that returns the blocker on top of the part and must be reverted by conjunct 2, and the depth validation at both the CLI and the library.
- Mutation kills, applied to the committed tree and reverted: dropping conjuncts 2 and 3 (`accepted = bool(ok)`) fails the injection case; dropping conjunct 3 alone (`accepted = bool(ok and legal)`) fails the pad-overhang case; excluding the part again when re-seating the blocker fails the pin test's board check.
- `tests/test_place_edge_containment.py` 18/18, `tests/test_run22_containment_repair.py` pass, `tests/test_portfolio_determinism.py` 11/11, `tests/gui_parity/test_manifest_plan_parity.py` and `tests/gui_parity/test_cli_postpass_coverage.py` pass.
- `tests/test_compare_seeds.py` self-budgets an hour and was not run; it is unchanged from main.
