### PR TITLE
reachability and forensics: --json-out, auto-widen and the defect record (split from #686)

### DIFF
--- a/py_placer/placement/reachability.py
+++ b/py_placer/placement/reachability.py
@@ -44,6 +44,7 @@ because a silently-degraded reachability answer is worse than none.
 from __future__ import annotations
 
 import math
+import os
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Sequence, Tuple
 
@@ -212,7 +213,8 @@ def slack_field(pcb, target_net_id, layer, view, base_clearance,
 # widest path
 # --------------------------------------------------------------------------
 
-def widest_path(slacks, targets, via_ok, seed_xy, seed_layer, view, step):
+def widest_path(slacks, targets, via_ok, seed_xy, seed_layer, view, step,
+                return_throat=False):
     """Kruskal widest path over a multi-layer grid; returns mm or None.
 
     Nodes are (cell, layer). In-layer edges join adjacent ACTIVE cells; a via
@@ -223,6 +225,13 @@ def widest_path(slacks, targets, via_ok, seed_xy, seed_layer, view, step):
     Returns the largest t such that a path exists using only cells of slack
     >= t. Exact for the raster: no search order, no grid alignment, no
     heuristic. None means no positive-slack path exists at any width.
+
+    `return_throat=True` returns `(value, (layer, x_mm, y_mm))` instead. The
+    cell that CLOSED the path is the throat -- the narrowest point on the widest
+    route -- and it was already in hand here (`lay`, `x`, `y` at the moment the
+    seed joins the target) and thrown away at the bare `return float(val)`.
+    Every consumer that wanted to say WHERE the bottleneck was had to go and
+    find it again by eye. `None` throat when there is no path.
     """
     L = len(slacks)
     h, w = slacks[0].shape
@@ -274,8 +283,13 @@ def widest_path(slacks, targets, via_ok, seed_xy, seed_layer, view, step):
                 if other != lay and active[other * n + cell]:
                     union(idx, other * n + cell)
         if active[seed] and find(seed) == find(TARGET):
-            return float(val)
-    return None
+            if not return_throat:
+                return float(val)
+            # `lay`, `y`, `x` are this cell -- the LAST one activated, i.e. the
+            # narrowest on the widest path. Cell centre, not corner.
+            return float(val), (lay, view[0] + (x + 0.5) * step,
+                                view[1] + (y + 0.5) * step)
+    return (None, None) if return_throat else None
 
 
 @dataclass
@@ -295,6 +309,20 @@ class Reachability:
     grid: Tuple[int, int]
     note: str = ''
     open_room_mm: float = 0.0     # the cap free space was clamped to
+    # WHERE the bottleneck is: (layer_index, x_mm, y_mm), or None when there is
+    # no path. Everything below exists because run 20 measured a throat, printed
+    # the number, and then had to hand-assemble the coordinates, the blocking
+    # refs and the relief distance into an English paragraph in a ledger string
+    # -- three tools' stdout, none of it consumable by anything downstream.
+    throat_cell: Optional[Tuple[int, float, float]] = None
+    #: The base clearance the field was built at. Needed to convert between the
+    #: two SPACES this class reports in -- see `gap_mm`.
+    clearance_mm: float = 0.0
+    #: Foreign copper nearest the throat, on the throat's OWN layer:
+    #: [{ref, pad, kind, net, net_id, clearance, x, y, layer, dist}]. `dist` is
+    #: to the object's edge; `clearance` is what converts `bottleneck_mm` into
+    #: `gap_mm` for that blocker.
+    near: Tuple[dict, ...] = ()
 
     @property
     def wide_open(self) -> bool:
@@ -333,6 +361,109 @@ class Reachability:
             return None
         return 1000.0 * (self.bottleneck_mm - self.track_mm)
 
+    @property
+    def binding_clearances(self) -> Tuple[float, float]:
+        """The clearance in force at each of the two blockers forming the throat.
+
+        NOT `2 * clearance_mm`. Clearance here is PAIRWISE: `slack_field` builds
+        `D = min_k(dist_k - c_k)` from the per-net map the routing config
+        resolves, and `check_reachability` always passes one. So the number that
+        converts the bottleneck into a physical gap is the clearance of the
+        copper actually at the throat, which is only the base clearance when
+        every blocker happens to sit on the Default class.
+
+        Measured, on a synthetic 1.00 mm slot at base clearance 0.05: with no
+        net clearances the gap came out 1.00 (right); with the two wall nets on
+        a 0.3 class it came out 0.50 for the same unchanged geometry -- off by
+        `2 * (class - base)`, and in the pessimistic direction that turns a
+        passable slot into a reported cage.
+
+        Falls back to `clearance_mm` twice when no blocker is known (no `near`,
+        or a caller that passed no clearance map), which is the old behaviour
+        with the old assumption now stated out loud. With exactly ONE blocker
+        known it duplicates that blocker's clearance -- see `gap_blockers`,
+        which publishes the count so nobody reads such a `gap_mm` as an
+        edge-to-edge distance between two named objects.
+        """
+        cs = [n['clearance'] for n in self.near
+              if n.get('clearance') is not None][:2]
+        if not cs:
+            return (self.clearance_mm, self.clearance_mm)
+        if len(cs) == 1:
+            return (cs[0], cs[0])
+        return (cs[0], cs[1])
+
+    @property
+    def gap_blockers(self) -> int:
+        """How many blockers the gap conversion actually knew about (0, 1 or 2).
+
+        2 is the honest case: `gap_mm` is then the distance between two named
+        pieces of copper, each converted by its own clearance. With 1 the far
+        side of the throat is ASSUMED to sit at the same clearance as the near
+        one, and with 0 both sides are assumed at the base clearance -- the
+        number is still the widest room measured at the throat, but calling it
+        "the edge-to-edge distance between the two blockers" would name
+        objects that were never identified. Published so a consumer can tell
+        the three apart instead of trusting a label.
+        """
+        return min(2, sum(1 for n in self.near
+                          if n.get('clearance') is not None))
+
+    @property
+    def gap_mm(self) -> Optional[float]:
+        """The bottleneck in GAP space -- the physical edge-to-edge distance
+        when `gap_blockers == 2`, and twice the room on the known side when it
+        is less.
+
+        `bottleneck_mm` is in SLACK space: `slack = 2 * (dist - clearance)`
+        (see `slack_field`), which is the widest TRACK that fits. At the throat
+        the two blockers are each exactly their own clearance beyond the widest
+        track, so with `D = bottleneck / 2`::
+
+            dist_a - c_a = dist_b - c_b = D
+            gap = dist_a + dist_b = bottleneck + c_a + c_b
+
+        which is exact when the two classes differ and collapses to the
+        familiar `bottleneck + 2 * clearance` when they do not. See
+        `binding_clearances` for what went wrong with the fixed `2 * clearance`.
+
+        The two spaces are different numbers for the same throat and mixing them
+        is easy: run 20's ledger recorded `0.409/0.450mm` (gap space) beside
+        `-37.69um` (track space) in one sentence, as if they described the same
+        measurement. Publishing both, each labelled, is why this property
+        exists.
+
+        None when there is no path, and None when the result is `wide_open`:
+        there the bottleneck is the view's own size, not a distance between
+        two pieces of copper, so there is no gap to report.
+        """
+        if self.bottleneck_mm is None or self.wide_open:
+            return None
+        return self.bottleneck_mm + sum(self.binding_clearances)
+
+    @property
+    def gap_need_mm(self) -> Optional[float]:
+        """What the gap would have to BE for `track_mm` to fit through it.
+
+        The partner of `gap_mm`, in the same space and converted by the same
+        two clearances -- publishing one without the other leaves a reader to
+        re-derive the conversion, and re-deriving it with `2 * clearance_mm` is
+        exactly the bug `binding_clearances` fixes. None whenever `gap_mm` is.
+        """
+        if self.bottleneck_mm is None or self.wide_open:
+            return None
+        return self.track_mm + sum(self.binding_clearances)
+
+    @property
+    def throat(self) -> Optional[dict]:
+        """The throat in world coordinates, or None."""
+        if not self.throat_cell:
+            return None
+        lay, x, y = self.throat_cell
+        return {'x': round(x, 4), 'y': round(y, 4),
+                'layer': self.layers[lay] if lay < len(self.layers)
+                else str(lay)}
+
     def to_dict(self):
         return {'net': self.net, 'seed': list(self.seed),
                 'layers': list(self.layers), 'step_mm': self.step_mm,
@@ -353,7 +484,114 @@ class Reachability:
                 'via_legal_fraction': round(self.via_legal_fraction, 4),
                 'grid': list(self.grid), 'view': [round(v, 3)
                                                   for v in self.view],
-                'note': self.note}
+                'note': self.note,
+                # ADDITIVE. Every key above is unchanged
+                # (tests/test_defect_record_reachability.py pins the set) --
+                # consumers of this payload predate the defect record.
+                'throat': self.throat,
+                'clearance_mm': self.clearance_mm,
+                'gap_mm': (None if self.gap_mm is None
+                           else round(self.gap_mm, 5)),
+                # Beside `gap_mm`, because `gap_mm - gap_need_mm` is no longer
+                # derivable from `clearance_mm` alone: the conversion uses the
+                # clearance of each blocker at the throat, and each of those is
+                # published on its own entry in `near`.
+                'gap_need_mm': (None if self.gap_need_mm is None
+                                else round(self.gap_need_mm, 5)),
+                # How many blockers that conversion knew about. With fewer
+                # than 2 the far side is assumed, and `gap_mm` is NOT a
+                # distance between two named objects -- see `gap_blockers`.
+                'gap_blockers': self.gap_blockers,
+                'near': [dict(n) for n in self.near]}
+
+    def defect_record(self, board=None, board_sha=None, relief=(),
+                      instrument='check_reachability', floors=None):
+        """This measurement as a `defect-record` document.
+
+        Shape (version 1)::
+
+            {kind: 'defect-record', version: 1, count: 1,
+             board: <abs path, if given>, board_sha: <sha256, if given>,
+             defects: [{kind: 'throat', verdict: 'CAGED', net, seed{x,y,layer},
+                        at{x,y,layer}, refs[], pads[],
+                        measure{space: 'track_width', have_mm, need_mm,
+                                short_mm, resolution_mm, gap_mm, gap_need_mm,
+                                gap_blockers, derived_from},
+                        span{a, b}  (when two blockers are known; each is
+                                     {x, y, layer, kind, net, clearance}),
+                        view[], relief[], instrument{source, floors, step_mm,
+                                                     search_view}}]}
+
+        `measure` carries both spaces: `have_mm`/`need_mm` are track widths
+        (what `bottleneck_mm` and `track_mm` are), `gap_mm`/`gap_need_mm` are
+        the physical edge-to-edge distances, converted by the clearance in
+        force at EACH blocker (`span.a.clearance` + `span.b.clearance`, see
+        `binding_clearances`) rather than by twice the base clearance. `refs`
+        and `pads` are the foreign copper nearest the throat, from `near`;
+        `instrument`, `relief` and `floors` are whatever the caller passes
+        through (the check_reachability CLI fills them). Everything here was
+        already computed by `pad_reachability`; this only arranges it.
+
+        Returns None when there is nothing to report: NO-TARGET (no verdict)
+        or PASSABLE. The only writer at present is `check_reachability
+        --defect-json`, which writes this dict to the path it is given.
+        """
+        if not self.measured or not self.caged:
+            return None
+        thr = self.throat
+        # The two spaces, both stated, both labelled, with what converts them.
+        measure = {'space': 'track_width',
+                   'have_mm': (None if self.bottleneck_mm is None
+                               else round(self.bottleneck_mm, 5)),
+                   'need_mm': self.track_mm,
+                   'short_mm': (None if self.bottleneck_mm is None else
+                                round(self.track_mm - self.bottleneck_mm, 5)),
+                   'resolution_mm': self.step_mm,
+                   'gap_mm': (None if self.gap_mm is None
+                              else round(self.gap_mm, 5)),
+                   'gap_need_mm': (None if self.gap_need_mm is None
+                                   else round(self.gap_need_mm, 5)),
+                   'gap_blockers': self.gap_blockers,
+                   # None, not a sentence: with no blocker found there is no
+                   # gap to derive (`gap_mm` is null too). The severest CAGED
+                   # -- a seed ringed by copper, `bottleneck_mm` None -- lands
+                   # here, and a record that DESCRIBED a derivation nobody
+                   # made would be the phantom this instrument exists to stop.
+                   'derived_from': (
+                       None if self.gap_mm is None else
+                       'have_mm + span.a.clearance + span.b.clearance (the '
+                       'clearance in force at each blocker forming the '
+                       'throat, NOT 2 x the base clearance)'
+                       if self.gap_blockers >= 2 else
+                       'have_mm + 2 x the clearance of the ONE blocker found '
+                       '(gap_blockers < 2: the far side of the throat was not '
+                       'identified and is assumed at the same clearance)')}
+        refs, pads = [], []
+        for n in self.near:
+            if n.get('ref') and n['ref'] not in refs:
+                refs.append(n['ref'])
+            if n.get('pad') and n['pad'] not in pads:
+                pads.append(n['pad'])
+        d = {'kind': 'throat', 'verdict': 'CAGED', 'net': self.net,
+             'seed': {'x': round(self.seed[0], 4), 'y': round(self.seed[1], 4),
+                      'layer': self.layers[0] if self.layers else None},
+             'at': thr, 'refs': refs, 'pads': pads, 'measure': measure,
+             'view': [round(v, 4) for v in self.view],
+             'relief': [dict(r) for r in relief],
+             'instrument': {'source': instrument, 'floors': dict(floors or {}),
+                            'step_mm': self.step_mm,
+                            'search_view': [round(v, 4) for v in self.view]}}
+        if len(self.near) >= 2:
+            _span = ('x', 'y', 'layer', 'kind', 'net', 'clearance')
+            d['span'] = {'a': {k: self.near[0].get(k) for k in _span},
+                         'b': {k: self.near[1].get(k) for k in _span}}
+        doc = {'kind': 'defect-record', 'version': 1, 'count': 1,
+               'defects': [d]}
+        if board:
+            doc['board'] = os.path.abspath(board)
+        if board_sha:
+            doc['board_sha'] = board_sha
+        return doc
 
     def format_text(self):
         lines = [f"net        {self.net} from ({self.seed[0]}, "
@@ -389,6 +627,141 @@ class Reachability:
                 f"VERDICT    {'CAGED' if self.caged else 'PASSABLE'} at track "
                 f"{self.track_mm}mm  (margin {self.margin_um:+.1f} um)")
         return '\n'.join(lines)
+
+
+#: How many blockers `nearest_foreign` reports. TWO, and not a parameter: the
+#: record's `span` is a segment between two pieces of copper and the relief
+#: answer is a two-body one, so a third entry has nowhere to go. It was a
+#: never-varied `k=2` argument, which read as a knob and was not one.
+NEAR_K = 2
+#: Search radius, in EDGE-to-edge millimetres. Also not a parameter, and this
+#: one had teeth: as a never-varied `radius_mm=2.0` measured to object CENTRES
+#: it silently dropped every blocker bigger than about 4 mm. A 5 mm-tall wall
+#: pad 0.2 mm from the throat has its centre 2.7 mm away, so a CAGED verdict
+#: shipped `near: ()`, no refs, no pads, no span and no relief -- the whole
+#: point of the record. Measured edge-to-edge the same pad is 0.2 mm away and
+#: is named.
+NEAR_RADIUS_MM = 2.0
+
+
+def _point_rect_dist(px, py, cx, cy, sx, sy, rot_deg=0.0):
+    """Distance from a point to a pad RECTANGLE's edge; 0 inside.
+
+    A rectangle, including for a round pad, because that is what `_rect`
+    stamps into the field the bottleneck was measured from. Two models of the
+    same pad would put the naming and the number in different geometries.
+    """
+    dx, dy = px - cx, py - cy
+    if abs(rot_deg) > 1e-9:                       # same convention as `_rect`
+        th = math.radians(-rot_deg)
+        dx, dy = (dx * math.cos(th) - dy * math.sin(th),
+                  dx * math.sin(th) + dy * math.cos(th))
+    return math.hypot(max(abs(dx) - sx / 2.0, 0.0),
+                      max(abs(dy) - sy / 2.0, 0.0))
+
+
+def _point_seg_dist(px, py, x0, y0, x1, y1):
+    """Distance from a point to a line SEGMENT (its centreline)."""
+    dx, dy = x1 - x0, y1 - y0
+    L2 = dx * dx + dy * dy
+    if L2 < 1e-12:
+        return math.hypot(px - x0, py - y0)
+    t = max(0.0, min(1.0, ((px - x0) * dx + (py - y0) * dy) / L2))
+    return math.hypot(px - (x0 + t * dx), py - (y0 + t * dy))
+
+
+def nearest_foreign(pcb, x, y, net_id, layers=None, net_clearances=None,
+                    base_clearance=None):
+    """The two nearest pieces of FOREIGN copper to (x, y), nearest first.
+
+    "Which two things form this throat" is the question every reader asks
+    immediately after "how wide is it", and answering it took a second tool and
+    a hand-assembled sentence. Modelled on `net_forensics`' wall inventory,
+    which already does exactly this inventory with `REF.PAD` naming -- this is
+    the same walk with a two-nearest cut instead of a printed table.
+
+    Each entry: {kind, ref, pad, net, net_id, clearance, x, y, layer, dist}.
+
+    `dist` is to the object's EDGE -- the pad rectangle, the via barrel, the
+    segment capsule -- not to its centre. Centre distances were the first
+    version and they were wrong in the one direction that matters: a big
+    object beside the throat measured FAR and was dropped, so the record that
+    exists to name the blocker named nobody (see `NEAR_RADIUS_MM`).
+
+    `x`/`y` remain the object's CENTRE: that is where the thing is, and a
+    reader drawing it wants the object, not the closest point on it.
+
+    `layers` must be the ONE layer the throat is on, not the whole analysis
+    stack. Copper on another face cannot bound this throat, and naming it
+    produced advice to move a part on the other side of the board. Through-hole
+    pads and vias are barrels and are kept whatever the layer.
+
+    `net_clearances` / `base_clearance`, when given, stamp each entry with the
+    clearance in force for THAT blocker, which is what converts the bottleneck
+    into a physical gap (see `Reachability.gap_mm`). Published per blocker so
+    the conversion is auditable instead of assumed.
+    """
+    lay = set(layers or ())
+    nc = dict(net_clearances or {})
+
+    def _clr(nid):
+        if base_clearance is None:
+            return None
+        return float(nc.get(nid, base_clearance))
+
+    out = []
+    for fp in pcb.footprints.values():
+        for p in fp.pads:
+            if p.net_id == net_id:
+                continue
+            if getattr(p, 'pad_type', '') == 'np_thru_hole':
+                continue
+            # `_pad_on_layer`, the SAME predicate `slack_field` stamps
+            # with. A second, nearly-identical test re-created blocker 3
+            # through another door: a pad declared on `*.Cu` is stamped into
+            # the field and forms the throat, but `set(p.layers) & lay` does
+            # not match it, so a CAGED result shipped near=[] refs=[] again.
+            if lay and not any(_pad_on_layer(p, l) for l in lay):
+                continue
+            d = _point_rect_dist(x, y, p.global_x, p.global_y,
+                                 p.size_x, p.size_y,
+                                 getattr(p, 'rect_rotation', 0.0) or 0.0)
+            if d <= NEAR_RADIUS_MM:
+                out.append({'kind': 'pad', 'ref': fp.reference,
+                            'pad': f'{fp.reference}.{p.pad_number}',
+                            'net': (pcb.nets[p.net_id].name
+                                    if p.net_id in pcb.nets else None),
+                            'net_id': p.net_id, 'clearance': _clr(p.net_id),
+                            'x': round(p.global_x, 4), 'y': round(p.global_y, 4),
+                            'layer': (p.layers or [None])[0],
+                            'dist': round(d, 5)})
+    for v in pcb.vias:
+        if v.net_id == net_id:
+            continue
+        d = max(0.0, math.hypot(v.x - x, v.y - y) - (v.size or 0.0) / 2.0)
+        if d <= NEAR_RADIUS_MM:
+            out.append({'kind': 'via', 'ref': None, 'pad': None,
+                        'net': (pcb.nets[v.net_id].name
+                                if v.net_id in pcb.nets else None),
+                        'net_id': v.net_id, 'clearance': _clr(v.net_id),
+                        'x': round(v.x, 4), 'y': round(v.y, 4),
+                        'layer': None, 'dist': round(d, 5)})
+    for s in pcb.segments:
+        if s.net_id == net_id:
+            continue
+        if lay and s.layer not in lay:
+            continue
+        d = max(0.0, _point_seg_dist(x, y, s.start_x, s.start_y,
+                                     s.end_x, s.end_y) - (s.width or 0.0) / 2.0)
+        if d <= NEAR_RADIUS_MM:
+            out.append({'kind': 'segment', 'ref': None, 'pad': None,
+                        'net': (pcb.nets[s.net_id].name
+                                if s.net_id in pcb.nets else None),
+                        'net_id': s.net_id, 'clearance': _clr(s.net_id),
+                        'x': round(s.start_x, 4), 'y': round(s.start_y, 4),
+                        'layer': s.layer, 'dist': round(d, 5)})
+    out.sort(key=lambda e: e['dist'])
+    return tuple(out[:NEAR_K])
 
 
 def pad_reachability(pcb, seed_xy, net_name=None, net_id=None, *,
@@ -492,12 +865,32 @@ def pad_reachability(pcb, seed_xy, net_name=None, net_id=None, *,
         note = ("no other island of this net is inside the view -- the pad is "
                 "already joined to everything nearby. Widen --margin, or this "
                 "is not a reachability question")
-    b = (None if n_t == 0
-         else widest_path(slacks, targets, via_ok, seed_xy, 0, view, step))
-    return Reachability(
+    b, throat = ((None, None) if n_t == 0
+                 else widest_path(slacks, targets, via_ok, seed_xy, 0, view,
+                                  step, return_throat=True))
+    r = Reachability(
         net=name, net_id=net_id, seed=(seed_xy[0], seed_xy[1]), layers=layers,
         step_mm=step, track_mm=track_mm, via_mm=via_mm, view=view,
         bottleneck_mm=b, target_cells=n_t,
         via_legal_fraction=float(via_ok.mean()),
         grid=(slacks[0].shape[1], slacks[0].shape[0]), note=note,
-        open_room_mm=_open_room(view))
+        open_room_mm=_open_room(view),
+        throat_cell=throat, clearance_mm=base_clearance)
+    if r.wide_open:
+        # The path never came near foreign copper, so the cell that closed it
+        # is just the last free cell Kruskal happened to activate -- a point in
+        # open board, not a throat. Reporting it (and the copper "nearest" to
+        # it) would put a location and a 34 mm "gap" on a measurement that has
+        # neither; `wide_open` is the whole answer.
+        r.throat_cell = None
+    elif throat:
+        # The throat is on ONE layer. Handing `nearest_foreign` the whole
+        # analysis stack let it name copper on the other face -- probed: a
+        # B.Cu throat whose `near[0]` was an F.Cu SMD pad that cannot bound
+        # it, which `check_reachability._relief_for` then turned into advice
+        # to move a part on the other side of the board.
+        r.near = nearest_foreign(pcb, throat[1], throat[2], net_id,
+                                 (layers[throat[0]],),
+                                 net_clearances=net_clearances,
+                                 base_clearance=base_clearance)
+    return r

--- a/py_placer/placement/routability.py
+++ b/py_placer/placement/routability.py
@@ -1007,3 +1007,49 @@ def pair_channel_widths(pcb_data, *, clearance: float,
                          'parts_in_channel': sorted(inside)[:12]})
     rows.sort(key=lambda r: r['channel_mm'])
     return rows
+
+
+def relief_move(rect_a, rect_b, need_mm, limit_mm=5.0, tol_mm=1e-6):
+    """How far must B move, per axis direction, for the A-B gap to reach need_mm?
+
+    Answers the question a throat measurement leaves open: "so what do I DO?".
+    Run 20 measured a 0.409 mm gap against a 0.450 mm need and then had to work
+    out by hand that moving R7 east by ~0.042 mm would clear it.
+
+    Bisection on `rect_gap`, which already returns the diagonal corner distance
+    for rects that miss on both axes -- i.e. exactly the geometry being measured.
+    Four axis directions; a direction that cannot reach `need_mm` within
+    `limit_mm` is omitted rather than reported as a large number.
+
+    Every result is stamped `bound: "lower"` and that is not decoration. This is
+    a TWO-BODY answer on a board with hundreds of bodies: moving B by this much
+    clears THIS pair and may create another. It is the smallest move that could
+    possibly work, never a solution.
+    """
+    from placement.legality import rect_gap
+
+    def shifted(d, t):
+        dx, dy = {'east': (t, 0.0), 'west': (-t, 0.0),
+                  'north': (0.0, -t), 'south': (0.0, t)}[d]
+        return (rect_b[0] + dx, rect_b[1] + dy,
+                rect_b[2] + dx, rect_b[3] + dy)
+
+    out = []
+    for d in ('east', 'west', 'north', 'south'):
+        if rect_gap(rect_a, shifted(d, limit_mm)) < need_mm - tol_mm:
+            continue                       # unreachable within the cap: say nothing
+        lo, hi = 0.0, limit_mm
+        if rect_gap(rect_a, rect_b) >= need_mm - tol_mm:
+            out.append({'dir': d, 'min_mm': 0.0, 'bound': 'lower'})
+            continue
+        for _ in range(60):
+            mid = (lo + hi) / 2.0
+            if rect_gap(rect_a, shifted(d, mid)) >= need_mm:
+                hi = mid
+            else:
+                lo = mid
+            if hi - lo < tol_mm:
+                break
+        out.append({'dir': d, 'min_mm': round(hi, 6), 'bound': 'lower'})
+    out.sort(key=lambda r: r['min_mm'])
+    return out

--- a/py_router/list_nets.py
+++ b/py_router/list_nets.py
@@ -21,8 +21,10 @@ Examples:
 
 import argparse
 import json
+import math
 import os
 import re
+from collections import defaultdict
 from fnmatch import fnmatch, fnmatchcase
 from kicad_parser import parse_kicad_pcb, find_components_by_type
 
@@ -786,6 +788,104 @@ def print_design_rules(pcb_path):
           f"--clearance {eff['drc_clearance']} "
           f"--hole-to-hole-clearance {eff['drc_hole_to_hole']} "
           f"--board-edge-clearance {eff['drc_edge_clearance']}")
+
+
+def net_islands(pcb, net_id, tol=0.05):
+    """The net's copper as ISLANDS: union-find over coincident points.
+
+    Returns a list of components, largest first; each component is a list of
+    `(kind, obj, points)` where kind is 'seg' | 'via' | 'pad'. Two items join
+    when a point of one lies within `max(tol, radius_a, radius_b)` of a point
+    of the other -- a pad's radius is half its larger dimension, a via's half
+    its diameter, a track endpoint's a 60 um nub.
+
+    Lives HERE, not in a py_tools CLI, because two front-ends need it:
+    `net_forensics` (which is where it was written) and `check_reachability`'s
+    auto-widen, which has to find the nearest OTHER island of a net without
+    rasterising the board. The reachability tool used to reach across and
+    import `net_forensics._components` -- a sibling CLI's private name, from a
+    directory `_path` does not put on `sys.path`, so the ImportError would have
+    escaped as exit **1**, which in that tool is the CAGED geometry verdict.
+
+    The pair scan is bucketed by a uniform grid at the largest join radius, so
+    a net with thousands of endpoints does not pay the O(P^2) all-pairs walk
+    the first version did. The join rule is unchanged.
+    """
+    items = []
+    for s in pcb.segments:
+        if s.net_id == net_id:
+            items.append(('seg', s, [(s.start_x, s.start_y),
+                                     (s.end_x, s.end_y)]))
+    for v in pcb.vias:
+        if v.net_id == net_id:
+            items.append(('via', v, [(v.x, v.y)]))
+    for fp in pcb.footprints.values():
+        for p in fp.pads:
+            if p.net_id == net_id:
+                items.append(('pad', p, [(p.global_x, p.global_y)]))
+    parent = list(range(len(items)))
+
+    def find(i):
+        while parent[i] != i:
+            parent[i] = parent[parent[i]]
+            i = parent[i]
+        return i
+
+    def union(a, b):
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[rb] = ra
+
+    pts = []
+    for idx, (_, obj, ps) in enumerate(items):
+        r = (max(obj.size_x, obj.size_y) / 2 if hasattr(obj, 'size_x')
+             else getattr(obj, 'size', 0) / 2 or 0.06)
+        for (x, y) in ps:
+            pts.append((x, y, idx, r))
+    # Bucket at the largest join radius: two points can only join if they are
+    # within it, so only the 3x3 neighbourhood of a point's cell can hold a
+    # partner. Same answer as the all-pairs scan, without the P^2.
+    # `or tol` was not a guard: with tol=0 and every radius 0 (a caller
+    # asking for exact coincidence only) the fallback is 0 too, and the
+    # bucket index divides by it. Any positive cell is correct here -- the
+    # 3x3 neighbourhood still contains every point within `cell`.
+    cell = max([tol] + [p[3] for p in pts]) or 1e-6
+    buckets = defaultdict(list)
+    for i, (x, y, _a, _r) in enumerate(pts):
+        buckets[(int(math.floor(x / cell)), int(math.floor(y / cell)))].append(i)
+    for i, (x1, y1, a, r1) in enumerate(pts):
+        cx, cy = int(math.floor(x1 / cell)), int(math.floor(y1 / cell))
+        for gx in (cx - 1, cx, cx + 1):
+            for gy in (cy - 1, cy, cy + 1):
+                for j in buckets.get((gx, gy), ()):
+                    if j <= i:
+                        continue
+                    x2, y2, b, r2 = pts[j]
+                    if a != b and math.hypot(x1 - x2, y1 - y2) <= max(tol, r1, r2):
+                        union(a, b)
+    comps = defaultdict(list)
+    for idx in range(len(items)):
+        comps[find(idx)].append(items[idx])
+    return sorted(comps.values(), key=len, reverse=True)
+
+
+def island_gap(comp_a, comp_b):
+    """Closest approach between two islands: (mm, (x, y), (x, y)).
+
+    The unclosed MST edge between them, which is the number a rip-set decision
+    needs. `(None, None, None)` when either island has no points. One
+    implementation because there were two, in the same file, one printing and
+    one returning a dict, and they could drift.
+    """
+    best = (None, None, None)
+    for _k, _o, ps in comp_a:
+        for p1 in ps:
+            for _k2, _o2, ps2 in comp_b:
+                for p2 in ps2:
+                    d = math.hypot(p1[0] - p2[0], p1[1] - p2[1])
+                    if best[0] is None or d < best[0]:
+                        best = (d, p1, p2)
+    return best
 
 
 def find_differential_pairs(pcb_data):

--- a/py_tools/check_reachability.py
+++ b/py_tools/check_reachability.py
@@ -21,8 +21,10 @@ principle was wrong. The rule this tool enforces is simple -- **no impossibility
 claim without a numeric field.**
 
 Clearances are read from the BOARD (netclasses via the sibling `.kicad_pro`,
-then `--clearance` as the base), so the verdict is graded at what the board
-would actually route at rather than at a guessed round number.
+then `--clearance` as the base), so the verdict is measured at what the board
+would actually route at rather than at a guessed round number -- and then
+pinned UP to the fab floor, because this tool PREDICTS routability and a lane
+finer than any fab can etch is capacity nobody can build (see `_fab_wrap`).
 
 Exit codes: 0 PASSABLE, 1 CAGED, 2 usage/geometry error.
 
@@ -113,6 +115,118 @@ def _resolve_pad(pcb, spec):
     return p.global_x, p.global_y, p.net_id, layer
 
 
+def _relief_for(pcb, r, track_mm, clearance):
+    """"So what do I DO?" -- how far the blocking part must move, or nothing.
+
+    Deliberately narrow. It answers only when the two nearest things at the
+    throat are pads belonging to two DIFFERENT footprints, because that is the
+    only case where "move this part" is the shape of the answer. A throat formed
+    by a segment, a via, or two pads of the same part is a different question
+    (rip that copper, re-fan that part) and returning a plausible-looking
+    distance for it would be a wrong instruction, which is worse than none.
+
+    The distance is between the two FOOTPRINT pad bounding boxes, and the need
+    is in GAP space: `track + 2*clearance`, not the track width. Reporting a
+    track-space number here would ask for a move roughly 2*clearance too small.
+    """
+    near = getattr(r, 'near', ()) or ()
+    if len(near) < 2:
+        return []
+    a, b = near[0], near[1]
+    if a.get('kind') != 'pad' or b.get('kind') != 'pad':
+        return []
+    if not a.get('ref') or not b.get('ref') or a['ref'] == b['ref']:
+        return []
+
+    def _bbox(ref):
+        fp = pcb.footprints.get(ref)
+        if not fp or not fp.pads:
+            return None
+        xs0 = [p.global_x - p.size_x / 2.0 for p in fp.pads]
+        ys0 = [p.global_y - p.size_y / 2.0 for p in fp.pads]
+        xs1 = [p.global_x + p.size_x / 2.0 for p in fp.pads]
+        ys1 = [p.global_y + p.size_y / 2.0 for p in fp.pads]
+        return (min(xs0), min(ys0), max(xs1), max(ys1))
+
+    ra, rb = _bbox(a['ref']), _bbox(b['ref'])
+    if not ra or not rb:
+        return []
+    from placement.routability import relief_move
+    need = track_mm + 2.0 * clearance
+    # BOTH movers, not one. The pair is symmetric as geometry but not as a
+    # decision: these are whole-footprint bounding boxes, so a 100-pin QFN and
+    # the 0402 beside it give different distances for the same throat, and
+    # naming only the first-listed one hands the operator "move the QFN" when
+    # nudging the resistor is the cheap answer. Sorted so the smallest move
+    # leads, and each entry says WHICH part it is asking to move.
+    out = [dict(m, ref=b['ref'], against=a['ref'], need_mm=round(need, 5))
+           for m in relief_move(ra, rb, need)]
+    out += [dict(m, ref=a['ref'], against=b['ref'], need_mm=round(need, 5))
+            for m in relief_move(rb, ra, need)]
+    out.sort(key=lambda m: m['min_mm'])
+    return out
+
+
+#: floors key -> `fab_tiers` floor key. Via diameter is in here for the same
+#: reason as track width: a barrel narrower than the fab drills is capacity
+#: that cannot be built.
+_FAB_KEYS = {'clearance': 'clearance', 'track_width': 'track_width',
+             'via_diameter': 'via_diameter'}
+
+
+def _fab_wrap(board, floors, tier=None, overrides=None):
+    """Pin each resolved floor UP to what a fab can actually make.
+
+    `list_nets.board_floor` is board-authoritative, NOT raise-only, and its own
+    docstring says why that cuts both ways: a tool that GRADES existing copper
+    must measure at the board's own value or it manufactures phantom
+    violations, while a tool that PREDICTS routability must wrap at the fab
+    floor or it promises capacity nobody can etch. `check_channels` learned
+    this the expensive way -- on tigard --refs U3, a declared 0.05/0.05 took
+    its deficit faces from 3 to 1 and U3's supply from 29 to 120, hiding two
+    real deficits.
+
+    This tool predicts. Its whole output is a claim about whether a route
+    EXISTS, and its CAGED verdict is the most expensive answer in the loop, so
+    a sub-fab clearance here buys a confident PASSABLE for a lane no fab can
+    make -- the phantom-supply direction, which hides a defect rather than
+    wasting effort on one.
+
+    Pinned regardless of SOURCE, exactly as `enforce_fab_floors` treats an
+    explicit flag: a `--clearance 0.05` typed on the command line is as
+    unetchable as a declared one. The declared value is not discarded -- it is
+    kept under `declared` in the floors block, so the defect record shows both
+    what the board asked for and what the measurement actually used.
+
+    `tier` / `overrides` come from the shared `--fab-tier` / `--fab-overrides`
+    flags, and they are NOT decoration: a floor a tool enforces has to be one
+    the operator can tell it about. A board deliberately built at an advanced
+    tier, or with the documented `--fab-overrides` escape hatch, would
+    otherwise be measured against a floor its fab beats -- and the answer that
+    buys is CAGED, the most expensive verdict in the loop.
+
+    Returns `(values, fab)` -- the wrapped floors and the fab floor dict, which
+    the caller needs to wrap the PER-NET clearance map at the same minimum.
+    """
+    from fab_tiers import fab_floor_min, count_copper_layers_in_file
+    try:
+        fab = fab_floor_min(count_copper_layers_in_file(board), tier, overrides)
+    except Exception:                                          # noqa: BLE001
+        fab = {}
+    for name, key in _FAB_KEYS.items():
+        rec = floors.get(name)
+        f = fab.get(key)
+        if not rec or f is None or rec['value'] >= f - 1e-9:
+            continue
+        print(f"  {name.replace('_', ' ')} {rec['value']:g}mm "
+              f"[{rec['source']}] is below the {f:g}mm fab floor; measuring "
+              f"at {f:g}mm (no fab can make it narrower).", file=sys.stderr)
+        floors[name] = {'value': f, 'source': 'fab floor',
+                        'declared': {'value': rec['value'],
+                                     'source': rec['source']}}
+    return {n: floors[n]['value'] for n in _FAB_KEYS if n in floors}, fab
+
+
 def main(argv=None):
     p = argparse.ArgumentParser(
         description=__doc__,
@@ -144,8 +258,40 @@ def main(argv=None):
                         "(default 4.0). Reachability is LOCAL; a whole board "
                         "at 10um costs memory for nothing")
     p.add_argument('--view', default=None, help="x0,y0,x1,y1 to override")
-    p.add_argument('--json', action='store_true')
+    p.add_argument('--json', action='store_true',
+                   help="print the result as JSON on stdout, and nothing else "
+                        "-- notices go to stderr. --json-out writes the same "
+                        "document to a file and keeps the text report")
+    p.add_argument('--defect-json', metavar='PATH', default=None,
+                   help="when the verdict is CAGED, write a `defect-record` "
+                        "JSON document to PATH: the throat coordinates, the "
+                        "nearest foreign refs/pads, the shortfall in both "
+                        "track-width and gap space, the floors graded at (with "
+                        "their sources) and, when the two nearest blockers are "
+                        "pads of two different parts, a per-direction relief "
+                        "distance. Nothing is written for a PASSABLE or "
+                        "NO-TARGET measurement. Schema: "
+                        "placement.reachability.Reachability.defect_record")
+    p.add_argument('--json-out', metavar='PATH', default=None,
+                   help="also write the result dict to PATH (the same document "
+                        "--json prints); the text report is still printed")
+    # The same two flags every routing and DRC CLI carries, from the same
+    # helper, so the fab floor this tool measures against is the one the rest
+    # of the chain routed to.
+    from fab_tiers import (add_fab_tier_args, fab_tier_from_args,
+                           set_default_fab_tier)
+    add_fab_tier_args(p)
     args = p.parse_args(argv)
+    try:
+        _tier, _tier_over = fab_tier_from_args(args)
+    except SystemExit as exc:                     # a missing override FILE
+        print(f"cannot resolve: {exc}", file=sys.stderr)
+        return 2
+    # Set the PROCESS default too, as route.py:5713 and check_drc.py do.
+    # Nothing else in this tool's call graph reads a fab floor today, so this
+    # changes no number here -- it is so a future nested consumer cannot
+    # silently measure against the stock tier while this run was told another.
+    set_default_fab_tier(_tier, _tier_over)
 
     from kicad_parser import parse_kicad_pcb  # _path put py_router on sys.path
     from placement import reachability
@@ -197,19 +343,51 @@ def main(argv=None):
         dr = list_nets.read_design_rules(args.board)
     except Exception:                             # noqa: BLE001
         dr = None
-    def _board(key, fallback):
-        v = list_nets.board_default_netclass_param(args.board, key, dr)
-        return float(v) if v else fallback
-    clearance = args.clearance if args.clearance is not None else _board(
-        'clearance', 0.2)
-    track = args.track if args.track is not None else _board('track_width',
-                                                             0.15)
-    via = args.via if args.via is not None else _board('via_diameter', 0.6)
+    # `board_floor` rather than a local closure: it returns the SOURCE beside
+    # the value ('cli' | 'board netclass' | 'board constraint' | 'fixed
+    # default' | 'fab floor'), which is what lets the defect record say where
+    # each floor came from instead of publishing three bare numbers a reader
+    # cannot audit.
+    # One precedence step the old closure did not have: on a board with no
+    # Default-netclass value, track and via now fall through to the board's
+    # `min_track_width` / `min_via_diameter` constraint before the fixed
+    # default (clearance has no constraint key, so it is unchanged). And one
+    # step NEITHER had: the fab floor on top of all of it. The knobs line names
+    # each source so both differences are visible in the text.
+    floors = {}
+
+    def _board(key, explicit, fallback):
+        v, src = list_nets.board_floor(args.board, key, explicit=explicit,
+                                       fallback=fallback, design_rules=dr)
+        floors[key] = {'value': v, 'source': src}
+        return v
+
+    _board('clearance', args.clearance, 0.2)
+    _board('track_width', args.track, 0.15)
+    _board('via_diameter', args.via, 0.6)
+    # ...and then wrapped at the fab floor, because this tool PREDICTS.
+    _floors, _fab = _fab_wrap(args.board, floors, _tier, _tier_over)
+    clearance = _floors['clearance']
+    track = _floors['track_width']
+    via = _floors['via_diameter']
     try:
         net_clearances = list_nets.net_clearance_map_by_id(
             args.board, {i: n.name for i, n in pcb.nets.items()}, dr)
     except Exception:                             # noqa: BLE001
         net_clearances = {}
+    # The per-net map gets the same wrap as the base. Pinning only the base
+    # would leave the hole open on exactly the boards this map exists for: a
+    # net class declaring 0.05 would still build its part of the field at a
+    # spacing no fab can etch, and the field is a min() over the classes, so
+    # one unwrapped class sets the answer.
+    _fc = _fab.get('clearance')
+    if _fc is not None and net_clearances:
+        _pinned = sum(1 for c in net_clearances.values() if c < _fc - 1e-9)
+        if _pinned:
+            print(f"  {_pinned} net-class clearance(s) below the {_fc:g}mm "
+                  f"fab floor; measuring those nets at {_fc:g}mm.",
+                  file=sys.stderr)
+            net_clearances = {i: max(c, _fc) for i, c in net_clearances.items()}
 
     layers = (args.layers.split(',') if args.layers
               else list(pcb.board_info.copper_layers or ('F.Cu', 'B.Cu')))
@@ -237,12 +415,100 @@ def main(argv=None):
                   f"{args.view!r}", file=sys.stderr)
             return 2
 
+    auto_widened = None
     try:
         r = reachability.pad_reachability(
             pcb, seed, net_name=args.net, net_id=net_id, layers=layers,
             view=view, track_mm=track, via_mm=via, base_clearance=clearance,
             net_clearances=net_clearances, step=args.step,
             margin_mm=args.margin)
+        # run-23: NO-TARGET at the default view means the net's other island
+        # sits beyond --margin, NOT that the question is unanswerable -- and
+        # the manual retry ladder measured badly (--margin 12 took 128s,
+        # --margin 18 306s, --margin 25 timed out at 10 minutes with NO
+        # data, because cells scale as (span/step)^2 at the fixed step).
+        # Locate the nearest other island by VECTOR union-find (no raster),
+        # widen the view to hold seed + its closest point, and coarsen the
+        # step so the grid stays ~1200^2 whatever the span. Coarse-locate;
+        # the step used rides in the result so readings stay comparable --
+        # re-measure a found throat on a small box at native step.
+        if (r.target_cells == 0 and view is None
+                and net_id is not None):
+            import math as _math
+            # `list_nets.net_islands`, NOT `net_forensics._components`: that
+            # was a sibling CLI's private name imported from a directory
+            # `_path` does not put on sys.path, so the ImportError would have
+            # escaped as exit 1 -- the code this file reserves for the CAGED
+            # geometry verdict, and the most expensive answer it can give.
+            sx, sy = seed
+            best = None
+            own_d, own_i = None, None
+            comp_pts = []
+            for comp in list_nets.net_islands(pcb, net_id):
+                pts = [p for _k, _o, ps in comp for p in ps]
+                if not pts:
+                    continue
+                d = min(_math.hypot(px - sx, py - sy) for px, py in pts)
+                comp_pts.append((d, pts))
+                if own_d is None or d < own_d:
+                    own_d, own_i = d, len(comp_pts) - 1
+            for i, (_d, pts) in enumerate(comp_pts):
+                if i == own_i:
+                    continue
+                for px, py in pts:
+                    dd = _math.hypot(px - sx, py - sy)
+                    if best is None or dd < best[0]:
+                        best = (dd, px, py)
+            if best is not None:
+                _d, px, py = best
+                x0 = min(sx, px) - args.margin
+                x1 = max(sx, px) + args.margin
+                y0 = min(sy, py) - args.margin
+                y1 = max(sy, py) + args.margin
+                span = max(x1 - x0, y1 - y0)
+                # Rounded UP to 10 nm so the step the field is built at is
+                # the step the result discloses (one number, not a rounded
+                # copy beside a raw one), and the grid stays <= ~1200^2.
+                step2 = max(args.step,
+                            _math.ceil(span / 1200.0 * 1e5) / 1e5)
+                # stderr: --json makes stdout a machine channel (the loop
+                # driver documents it as one), and a notice on it is a
+                # JSONDecodeError at character 0.
+                print(f"  NO-TARGET at the default +/-{args.margin:g}mm "
+                      f"view; nearest other island of this net is "
+                      f"{best[0]:.2f}mm away -- auto-widening to "
+                      f"[{x0:.1f},{y0:.1f},{x1:.1f},{y1:.1f}] at step "
+                      f"{step2:g}mm", file=sys.stderr)
+                r = reachability.pad_reachability(
+                    pcb, seed, net_name=args.net, net_id=net_id,
+                    layers=layers, view=[x0, y0, x1, y1], track_mm=track,
+                    via_mm=via, base_clearance=clearance,
+                    net_clearances=net_clearances, step=step2,
+                    margin_mm=args.margin)
+                # The widened step grows with the ISLAND DISTANCE (span/1200),
+                # and nothing about that distance says the answer is still
+                # resolvable. A bottleneck is only resolved to +/- one step, so
+                # once a step is a large fraction of the track width the
+                # verdict is a coin toss dressed as a measurement. Measured,
+                # tigard U3.30 at one view: native step 0.01 gave bottleneck
+                # 0.4403, the widened 0.02021 gave 0.46904 -- 29 um
+                # OPTIMISTIC, more than one whole step, and optimistic is the
+                # direction that hides a cage.
+                coarse = step2 > track / 4.0 + 1e-12
+                auto_widened = {
+                    'view': [round(v, 2) for v in (x0, y0, x1, y1)],
+                    'step_mm': step2,
+                    'nearest_island_mm': round(best[0], 2),
+                    'coarse': coarse}
+                if coarse:
+                    _msg = (f"COARSE: the widened step {step2:g}mm is more "
+                            f"than a quarter of the {track:g}mm track, and a "
+                            f"bottleneck is resolved to +/- one step -- treat "
+                            f"this verdict as a locate, then re-measure the "
+                            f"throat on a small --view at --step {args.step:g}")
+                    auto_widened['coarse_note'] = _msg
+                    r.note = f"{r.note} | {_msg}" if r.note else _msg
+                    print(f"  {_msg}", file=sys.stderr)
     except reachability.ScipyRequired as exc:
         print(str(exc), file=sys.stderr)
         return 2
@@ -250,14 +516,100 @@ def main(argv=None):
         print(str(exc), file=sys.stderr)
         return 2
 
-    source = 'from --flags' if args.clearance is not None else 'from the board'
+    # `declared -> pinned` in the report, not only on the stderr notice: the
+    # record carries both numbers and the text should say the same thing, or a
+    # reader of the printed report cannot tell a wrapped floor from a declared
+    # one that happens to equal the fab minimum.
+    source = ', '.join(
+        f"{k.replace('_', ' ')}: {v['source']}"
+        + (f" ({v['declared']['value']:g} declared [{v['declared']['source']}]"
+           f" -> {v['value']:g})" if v.get('declared') else '')
+        for k, v in floors.items())
+    if args.defect_json:
+        _sha = None
+        try:
+            import hashlib
+            with open(args.board, 'rb') as _fh:
+                _sha = hashlib.sha256(_fh.read()).hexdigest()
+        except OSError:
+            pass
+        _relief = []
+        # A relief distance needs two RECTS, and this tool measures a raster
+        # throat -- so it is offered only when the two nearest things are pads
+        # whose footprints we can bound. Absent rather than guessed: a wrong
+        # "move R7 east by X" is worse than no instruction.
+        try:
+            _relief = _relief_for(pcb, r, track_mm=track, clearance=clearance)
+        except Exception:                                   # noqa: BLE001
+            _relief = []
+        doc = r.defect_record(board=args.board, board_sha=_sha,
+                              relief=_relief, floors=floors,
+                              instrument='check_reachability')
+        if doc is None:
+            print(f"  no defect record written to {args.defect_json}: this "
+                  f"measurement is {r.to_dict()['verdict']}, and a record "
+                  f"describes a DEFECT", file=sys.stderr)
+        else:
+            try:
+                with open(args.defect_json, 'w', encoding='utf-8') as fh:
+                    json.dump(doc, fh, indent=1)
+                print(f"  DEFECT RECORD -> {args.defect_json}",
+                      file=sys.stderr)
+            except OSError as exc:
+                print(f"  could not write {args.defect_json}: {exc}",
+                      file=sys.stderr)
+    _doc = r.to_dict()
+    if auto_widened:
+        # The reading is only comparable at its own step -- say which.
+        _doc['auto_widened'] = auto_widened
+    if args.json_out:
+        try:
+            with open(args.json_out, 'w', encoding='utf-8') as fh:
+                json.dump(_doc, fh, indent=2)
+            print(f"  JSON -> {args.json_out}", file=sys.stderr)
+        except OSError as exc:
+            print(f"  could not write {args.json_out}: {exc}", file=sys.stderr)
     if args.json:
-        print(json.dumps(r.to_dict(), indent=2))
+        print(json.dumps(_doc, indent=2))
     else:
         print(f"board      {os.path.basename(args.board)}")
         print(f"knobs      clearance {clearance}mm, track {track}mm, "
               f"via {via}mm ({source})")
         print(r.format_text())
+        # WHERE, beside how much. The number alone sent run 20 to two more
+        # tools and a hand-assembled paragraph. Not on a wide-open result:
+        # there is no throat to locate (`throat` is already None there, and
+        # this guard keeps it that way if that ever changes).
+        _t = None if r.wide_open else r.throat
+        if _t:
+            _who = ', '.join(n.get('pad') or f"{n['kind']}@{n['net']}"
+                             for n in (r.near or ()))
+            print(f"throat     ({_t['x']}, {_t['y']}) on {_t['layer']}"
+                  + (f"  between {_who}" if _who else ''))
+            if r.gap_mm is not None:
+                _ca, _cb = r.binding_clearances
+                print(f"           gap {r.gap_mm:.4f}mm vs "
+                      f"{r.gap_need_mm:.4f}mm needed "
+                      f"(gap space); track {r.bottleneck_mm:.4f} vs "
+                      f"{r.track_mm:.4f} (track space) -- same throat, two "
+                      f"spaces, related by the clearance at each blocker "
+                      f"({_ca:g} + {_cb:g}mm)")
+                if r.gap_blockers < 2:
+                    # Say it, rather than print a two-object number derived
+                    # from one object and let the label carry the lie.
+                    print(f"           NOTE only {r.gap_blockers} blocker(s) "
+                          f"identified at this throat, so the far side is "
+                          f"ASSUMED at the same clearance: the gap above is "
+                          f"twice the room on the known side, not a distance "
+                          f"between two named objects")
+            if r.caged:
+                _side = max(0.5, 4.0 * (r.track_mm - (r.bottleneck_mm or 0.0)))
+                print(f"look at it:\n"
+                      f"  python3 -X utf8 py_tools/render_placement.py "
+                      f"{os.path.basename(args.board)} --focus \\\n"
+                      f"      --view {_t['x'] - _side / 2:.3f},"
+                      f"{_t['y'] - _side / 2:.3f},{_t['x'] + _side / 2:.3f},"
+                      f"{_t['y'] + _side / 2:.3f} --size 1600")
         if r.target_cells and not r.caged:
             print("\nPASSABLE means a route EXISTS at this width. If the "
                   "router failed here, that is a finding about the router "

--- a/py_tools/net_forensics.py
+++ b/py_tools/net_forensics.py
@@ -16,7 +16,8 @@ For each requested net on a board, reports to stdout (and --log FILE):
 
 Usage:
   python3 net_forensics.py board.kicad_pcb --nets BT_PCM_SYNC USB_D_P \
-      [--radius 1.0] [--route-log step11.log] [--log forensics.txt]
+      [--radius 1.0] [--route-log step11.log] [--log forensics.txt] \
+      [--json-out forensics.json]
 
 Born from the 2026-07-21 ottercast pocket forensics: every residual
 failure traced to escape-stub tips boxed on all four layers by neighbors'
@@ -33,52 +34,21 @@ import sys
 from collections import defaultdict
 
 
-def _components(pcb, net_id, tol=0.05):
-    """Union-find over the net's segments/vias/pads by coincident points."""
-    items = []
-    for s in pcb.segments:
-        if s.net_id == net_id:
-            items.append(('seg', s, [(s.start_x, s.start_y), (s.end_x, s.end_y)]))
-    for v in pcb.vias:
-        if v.net_id == net_id:
-            items.append(('via', v, [(v.x, v.y)]))
-    for fp in pcb.footprints.values():
-        for p in fp.pads:
-            if p.net_id == net_id:
-                items.append(('pad', p, [(p.global_x, p.global_y)]))
-    parent = list(range(len(items)))
-
-    def find(i):
-        while parent[i] != i:
-            parent[i] = parent[parent[i]]
-            i = parent[i]
-        return i
-
-    def union(a, b):
-        ra, rb = find(a), find(b)
-        if ra != rb:
-            parent[rb] = ra
-
-    pts = []
-    for idx, (_, obj, ps) in enumerate(items):
-        r = (max(obj.size_x, obj.size_y) / 2 if hasattr(obj, 'size_x')
-             else getattr(obj, 'size', 0) / 2 or 0.06)
-        for (x, y) in ps:
-            pts.append((x, y, idx, r))
-    for i in range(len(pts)):
-        x1, y1, a, r1 = pts[i]
-        for j in range(i + 1, len(pts)):
-            x2, y2, b, r2 = pts[j]
-            if a != b and math.hypot(x1 - x2, y1 - y2) <= max(tol, r1, r2):
-                union(a, b)
-    comps = defaultdict(list)
-    for idx in range(len(items)):
-        comps[find(idx)].append(items[idx])
-    return sorted(comps.values(), key=len, reverse=True)
+# The island walk and the island-to-island gap now live in `list_nets`, where
+# `check_reachability`'s auto-widen can reach them: it used to import
+# `_components` out of THIS file, a sibling CLI's private name from a directory
+# `_path` does not put on sys.path.
+from list_nets import net_islands, island_gap    # noqa: E402
 
 
 def _describe(pcb, net, radius, out):
-    comps = _components(pcb, net.net_id)
+    """Print the islands/gap/walls report; RETURN the islands it walked.
+
+    Returned rather than re-walked: `net_data` wants the same components, and
+    calling `net_islands` again for it walked every net twice on a --json-out
+    run. The gap loop was de-duplicated first and this is the other half.
+    """
+    comps = net_islands(pcb, net.net_id)
     out(f"\n=== {net.name} (net {net.net_id}): {len(comps)} island(s) ===")
     for i, c in enumerate(comps):
         pads = [f"{o.component_ref}.{o.pad_number}" for k, o, _ in c if k == 'pad']
@@ -87,19 +57,11 @@ def _describe(pcb, net, radius, out):
             f"{sum(1 for k,_,_ in c if k=='via')} vias, pads={pads} layers={layers}")
     if len(comps) < 2:
         out("  (fully connected)")
-        return
-    # gap between the two largest islands
-    def points(c):
-        for k, o, ps in c:
-            for p in ps:
-                yield p
-    best = (9e9, None, None)
-    for p1 in points(comps[0]):
-        for p2 in points(comps[1]):
-            d = math.hypot(p1[0] - p2[0], p1[1] - p2[1])
-            if d < best[0]:
-                best = (d, p1, p2)
-    d, p1, p2 = best
+        return comps
+    # gap between the two largest islands -- ONE implementation, shared with
+    # net_data(), which had a byte-for-byte copy of this loop written as a dict
+    # builder. Two copies of a measurement drift, and only one of them prints.
+    d, p1, p2 = island_gap(comps[0], comps[1])
     out(f"  GAP island0<->island1: {d:.2f}mm  from ({p1[0]:.2f},{p1[1]:.2f}) "
         f"to ({p2[0]:.2f},{p2[1]:.2f})")
     for label, (gx, gy) in (('island0-end', p1), ('island1-end', p2)):
@@ -133,6 +95,7 @@ def _describe(pcb, net, radius, out):
         for nm in sorted(inv, key=lambda n: min(x[0] for x in inv[n]))[:8]:
             entries = sorted(inv[nm])[:3]
             out(f"    {nm}: " + ", ".join(f"{k}@{d}mm" for d, k in entries))
+    return comps
 
 
 def _history(net_name, log_path, out):
@@ -161,6 +124,33 @@ def _history(net_name, log_path, out):
         out(f"  (log unreadable: {e})")
 
 
+def net_data(pcb, net, comps=None):
+    """The islands-and-gap facts as DATA (run-23): what _describe prints.
+
+    Exists because this tool was text-only, so run 23's teammates re-derived
+    the island gap by hand to feed their rip-set decisions -- the number
+    (/TXLED's 20.27mm span) lived in a paragraph nothing could consume.
+
+    `comps` takes the islands `_describe` already walked. Without it this
+    walked every net a second time on the one kind of run that asks for it.
+    """
+    comps = net_islands(pcb, net.net_id) if comps is None else comps
+    doc = {'net': net.name, 'net_id': net.net_id, 'islands': [], 'gap': None}
+    for c in comps:
+        doc['islands'].append({
+            'segs': sum(1 for k, _, _ in c if k == 'seg'),
+            'vias': sum(1 for k, _, _ in c if k == 'via'),
+            'pads': [f"{o.component_ref}.{o.pad_number}"
+                     for k, o, _ in c if k == 'pad'],
+            'layers': sorted({o.layer for k, o, _ in c if k == 'seg'})})
+    if len(comps) >= 2:
+        d, p1, p2 = island_gap(comps[0], comps[1])
+        doc['gap'] = {'mm': round(d, 3),
+                      'from': [round(p1[0], 3), round(p1[1], 3)],
+                      'to': [round(p2[0], 3), round(p2[1], 3)]}
+    return doc
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__.split('\n')[0])
     ap.add_argument('board')
@@ -168,6 +158,15 @@ def main():
     ap.add_argument('--radius', type=float, default=1.0)
     ap.add_argument('--route-log', action='append', default=[])
     ap.add_argument('--log', help='also append the report to this file')
+    # --json-out, not --json: every other tool in this repo that writes a JSON
+    # document to a path spells it --json-out (route.py, converge.py,
+    # place_route_loop.py, pose_score.py), and in check_reachability --json
+    # means "print the document on stdout". Nothing in the tree called the
+    # flag by its old name, so there is no alias to keep.
+    ap.add_argument('--json-out', metavar='PATH', default=None,
+                    help='also write {nets: [islands+gap docs]} here '
+                         '(run-23: the gap number was text-only and had to '
+                         'be re-derived by hand to feed rip-set decisions)')
     args = ap.parse_args()
 
     from kicad_parser import parse_kicad_pcb
@@ -179,15 +178,30 @@ def main():
         if sink:
             sink.write(line + '\n')
 
+    docs = []
     out(f"# net_forensics: {args.board}")
     for nm in args.nets:
         net = next((x for x in pcb.nets.values() if x.name == nm), None)
         if net is None:
             out(f"\n=== {nm}: NOT FOUND ===")
+            if args.json_out:
+                docs.append({'net': nm, 'error': 'not found'})
             continue
-        _describe(pcb, net, args.radius, out)
+        # Only when someone is going to read it, and reusing the islands
+        # `_describe` just walked. Calling `net_data` unconditionally, on its
+        # own fresh walk, made every run pay twice -- and every text-only run,
+        # which is nearly all of them, threw the second walk away.
+        _comps = _describe(pcb, net, args.radius, out)
+        if args.json_out:
+            docs.append(net_data(pcb, net, _comps))
         for lp in args.route_log:
             _history(nm, lp, out)
+    if args.json_out:
+        import json as _json
+        with open(args.json_out, 'w', encoding='utf-8') as f:
+            _json.dump({'board': args.board, 'nets': docs}, f, indent=1,
+                       sort_keys=True)
+        out(f"  JSON -> {args.json_out}")
     if sink:
         sink.close()
 

--- a/tests/test_defect_record_reachability.py
+++ b/tests/test_defect_record_reachability.py
@@ -1,0 +1,591 @@
+#!/usr/bin/env python3
+"""The defect record: what the chain measured, in a shape something can read.
+
+Run 20 measured a cage at pad U4.54 -- throat 0.409 mm against 0.450 needed,
+blocked by U4.53 and R7.2 -- and that finding lived in three tools' stdout and
+had to be hand-assembled into an English paragraph inside a ledger `lever`
+string and a subagent prompt. Nothing downstream could consume it.
+
+Every number in the record was ALREADY COMPUTED and thrown away at the point of
+formatting. `widest_path` held the throat cell in a local and returned a bare
+float; `pad_reachability` knew the clearance the field was built at and did not
+publish it. This is plumbing, not new measurement, and the tests say so by
+checking the values against the geometry rather than against each other.
+
+Two traps this file exists to pin:
+
+  * `bottleneck_mm` is in SLACK space (`slack = 2*(dist - clearance)`), so the
+    physical gap is `bottleneck + 2*clearance`. Run 20's ledger put a gap-space
+    pair (0.409/0.450) beside a track-space margin (-37.69 um) in one sentence
+    as if they were the same measurement. The record carries both, labelled.
+  * `to_dict()` is PURELY ADDITIVE. Its consumers predate the record.
+"""
+import os
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for _p in (REPO, os.path.join(REPO, 'py_router'), os.path.join(REPO, 'py_placer'),
+           os.path.join(REPO, 'py_tools'), os.path.join(REPO, 'tests')):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+SKIP_EXIT = 77
+try:
+    import numpy  # noqa: F401
+    import scipy  # noqa: F401
+except ImportError as exc:
+    print(f'SKIP: reachability needs numpy+scipy ({exc})')
+    sys.exit(SKIP_EXIT)
+
+import math                                                       # noqa: E402
+import numpy as np                                                # noqa: E402
+from placement import reachability as RE                          # noqa: E402
+from kicad_parser import BoardInfo, Footprint                     # noqa: E402
+import synth                                                      # noqa: E402
+
+
+def _fp(ref, pads):
+    return Footprint(reference=ref, footprint_name='t:x',
+                     x=pads[0].global_x, y=pads[0].global_y, rotation=0.0,
+                     layer='F.Cu', pads=pads)
+
+
+def _bi(layers):
+    return BoardInfo(layers={i * 2: n for i, n in enumerate(layers)},
+                     copper_layers=list(layers), board_bounds=(0, 0, 10, 10),
+                     stackup=[], board_outline=[], board_cutouts=[],
+                     board_outlines=[], board_edge_contours=[])
+
+passed = failed = 0
+
+
+def check(label, cond, detail=''):
+    global passed, failed
+    if cond:
+        passed += 1
+        print(f'  OK   {label}')
+    else:
+        failed += 1
+        print(f'  FAIL {label} -- {detail}')
+
+
+# A throat with KNOWN geometry, and it has to be a real WALL: two tall foreign
+# pads spanning the whole view with a 0.40 mm slot between them, so the only way
+# from the seed island to the target island is through the slot. A wall of two
+# small pads is not a throat -- the path simply goes around it, the bottleneck
+# is the view's own size, and every assertion below passes vacuously. (The first
+# version of this fixture did exactly that, and `caged` was True only because
+# the target island was outside the view: a NO-TARGET reported as a cage.)
+GAP = 0.40
+TALL = 3.0                              # each wall pad's height
+PITCH = TALL + GAP                      # centre-to-centre, vertically
+SEED = (4.0, 5.0)
+
+
+def _board(walls=True, gap=GAP, tall=TALL, layer='F.Cu', layers=('F.Cu',),
+           extra=(), wall_layers=None, wall_rot=0.0):
+    """The two-wall fixture, with the knobs the later probes vary.
+
+    `gap`/`tall` size the slot and the walls, `layer` puts the whole thing on
+    one copper face, `wall_layers` overrides just the WALLS' layer list (a pad
+    declared `*.Cu` is a different thing to the layer predicate), `wall_rot`
+    gives them a residual rect tilt, and `extra` adds foreign footprints (used
+    to park copper on the OTHER face).
+    """
+    pitch = tall + gap
+    own_a = synth.make_pad(1, SEED[0], SEED[1], ref='U1', num='1',
+                           net_name='SIG', size_x=0.6, size_y=0.6,
+                           layers=(layer,))
+    own_b = synth.make_pad(1, 6.0, 5.0, ref='U2', num='1', net_name='SIG',
+                           size_x=0.6, size_y=0.6, layers=(layer,))
+    fps = {'U1': _fp('U1', [own_a]), 'U2': _fp('U2', [own_b])}
+    nets = {1: synth.make_net(1, 'SIG'), 2: synth.make_net(2, 'GND'),
+            3: synth.make_net(3, 'VCC')}
+    if walls:
+        _wl = tuple(wall_layers) if wall_layers else (layer,)
+        wall_a = synth.make_pad(2, 5.0, 5.0 - pitch / 2.0, ref='R7', num='2',
+                                net_name='GND', size_x=0.6, size_y=tall,
+                                layers=_wl, rect_rotation=wall_rot)
+        wall_b = synth.make_pad(3, 5.0, 5.0 + pitch / 2.0, ref='U4', num='3',
+                                net_name='VCC', size_x=0.6, size_y=tall,
+                                layers=_wl, rect_rotation=wall_rot)
+        fps['R7'] = _fp('R7', [wall_a])
+        fps['U4'] = _fp('U4', [wall_b])
+    for _ref, _pad in extra:
+        fps[_ref] = _fp(_ref, [_pad])
+    return synth.make_pcb(nets=nets, footprints=fps,
+                          board_info=_bi(list(layers)))
+
+
+CLR = 0.05
+TRACK = 0.40                            # deliberately wider than fits
+pcb = _board()
+r = RE.pad_reachability(pcb, SEED, net_id=1, layers=('F.Cu',),
+                        track_mm=TRACK, via_mm=0.6, base_clearance=CLR,
+                        step=0.01, margin_mm=2.0)
+
+print('--- the throat is WHERE the geometry says it is ---')
+# `measured` FIRST. `caged` is True whenever `bottleneck_mm` is None, which
+# includes "nothing of this net to reach inside the view" -- so asserting
+# `caged` alone passes on a fixture that measured nothing at all.
+check('the question was answerable (there IS a target island in the view)',
+      r.measured, f'target_cells={r.target_cells} note={r.note!r}')
+check('a path exists, so the bottleneck is a real number not a None',
+      r.bottleneck_mm is not None,
+      'None means no positive-slack path at any width -- a walled-in seed, '
+      'not a throat, and there is nothing to point at')
+check('the measurement is CAGED (0.40mm track will not fit a 0.40mm slot '
+      'at 0.05 clearance)', r.caged, r.to_dict()['verdict'])
+_t = r.throat
+check('a throat is reported at all', _t is not None,
+      'widest_path held this cell in a local and returned a bare float')
+if _t:
+    check('and it lies INSIDE the gap, not on either pad',
+          abs(_t['x'] - 5.0) < 0.35 and abs(_t['y'] - 5.0) < GAP,
+          f"{_t} -- the gap runs through (5.0, 5.0)")
+    check('on the layer the field was built on', _t['layer'] == 'F.Cu', str(_t))
+
+print('--- the two SPACES, both published, and convertible ---')
+check('gap_mm is the physical gap, within one raster step of the truth',
+      r.gap_mm is not None and abs(r.gap_mm - GAP) <= r.step_mm + 1e-9,
+      f'{r.gap_mm} vs an analytic {GAP} at step {r.step_mm}')
+check('and it is exactly bottleneck + the two blocking clearances, not a '
+      'second measurement',
+      abs(r.gap_mm - (r.bottleneck_mm + sum(r.binding_clearances))) < 1e-12,
+      f'{r.gap_mm} vs {r.bottleneck_mm} + {r.binding_clearances}')
+check('which here, with both walls on the base clearance, IS 2*clearance',
+      abs(r.gap_mm - (r.bottleneck_mm + 2 * r.clearance_mm)) < 1e-12,
+      f'{r.gap_mm} vs {r.bottleneck_mm} + 2*{r.clearance_mm}')
+check('the clearance the field was built at is published',
+      abs(r.clearance_mm - CLR) < 1e-12, str(r.clearance_mm))
+check('gap_need_mm is the same conversion applied to the track width',
+      r.gap_need_mm is not None
+      and abs(r.gap_need_mm - (TRACK + sum(r.binding_clearances))) < 1e-12,
+      f'{r.gap_need_mm} vs {TRACK} + {r.binding_clearances}')
+
+print('--- who is forming the throat ---')
+_refs = {n.get('ref') for n in r.near}
+check('the two nearest foreign objects are named, by REF.PAD',
+      _refs == {'R7', 'U4'}, str(r.near))
+check('and their distances are sorted nearest-first',
+      all(r.near[i]['dist'] <= r.near[i + 1]['dist']
+          for i in range(len(r.near) - 1)), str([n['dist'] for n in r.near]))
+
+print('--- to_dict stays additive ---')
+_LEGACY = {'net', 'seed', 'layers', 'step_mm', 'track_mm', 'via_mm',
+           'bottleneck_mm', 'wide_open', 'verdict', 'measured', 'margin_um',
+           'target_cells', 'via_legal_fraction', 'grid', 'view', 'note'}
+d = r.to_dict()
+check('every pre-existing key survives',
+      _LEGACY <= set(d),
+      f'missing {sorted(_LEGACY - set(d))} -- consumers of this payload '
+      f'predate the defect record and must not be broken by it')
+check('and the new keys are there beside them',
+      {'throat', 'clearance_mm', 'gap_mm', 'gap_need_mm', 'near'} <= set(d),
+      sorted(set(d) - _LEGACY))
+check('gap_need_mm rides beside gap_mm, because the conversion is no longer '
+      'derivable from clearance_mm alone',
+      d['gap_need_mm'] is not None and d['gap_mm'] is not None, str(d))
+
+print('--- the record itself ---')
+rec = r.defect_record(board='/tmp/x.kicad_pcb', board_sha='deadbeef',
+                      floors={'clearance': {'value': CLR,
+                                            'source': 'board netclass'}})
+check('a CAGED measurement produces a record', isinstance(rec, dict), str(rec))
+_d0 = (rec or {}).get('defects', [{}])[0]
+check('it is a defect-record v1 with one defect',
+      rec.get('kind') == 'defect-record' and rec.get('version') == 1
+      and rec.get('count') == 1 and len(rec.get('defects') or []) == 1,
+      str(rec)[:200])
+check('the defect is a throat with the CAGED verdict',
+      _d0.get('kind') == 'throat' and _d0.get('verdict') == 'CAGED', str(_d0)[:200])
+_m = _d0.get('measure') or {}
+check('short_mm is exactly need - have, not a separate measurement',
+      abs(_m.get('short_mm', 0) - (_m['need_mm'] - _m['have_mm'])) < 1e-9,
+      str(_m))
+check('the measure names its SPACE and its resolution',
+      _m.get('space') == 'track_width' and _m.get('resolution_mm') == r.step_mm,
+      str(_m))
+check('gap space is carried alongside, with what converts them',
+      _m.get('gap_mm') is not None and _m.get('gap_need_mm') is not None
+      and 'clearance' in (_m.get('derived_from') or ''), str(_m))
+check('the blocking refs and pads are named',
+      set(_d0.get('refs') or ()) == {'R7', 'U4'}
+      and len(_d0.get('pads') or ()) == 2, str(_d0.get('pads')))
+check('the record is BOUND to the board it was measured on',
+      _d0 and rec.get('board_sha') == 'deadbeef' and rec.get('board'),
+      'a record without a sha can be drawn over a board it does not describe')
+check('the floors it graded at travel with it, with their sources',
+      (_d0.get('instrument') or {}).get('floors', {})
+      .get('clearance', {}).get('source') == 'board netclass',
+      str(_d0.get('instrument')))
+# `instrument` is a real parameter, not a decorative default: the CLI passes
+# its own name. It was defaulted and never passed at any call site, which is
+# how a default becomes a hardcoded string nobody notices is wrong.
+check('the instrument name is what the caller passed, not a hardcoded default',
+      (r.defect_record(instrument='a-probe') or {})['defects'][0]
+      ['instrument']['source'] == 'a-probe',
+      str(r.defect_record(instrument='a-probe')))
+import inspect                                                     # noqa: E402
+_sig = set(inspect.signature(RE.nearest_foreign).parameters)
+check('nearest_foreign has no never-varied k / radius_mm knobs',
+      not (_sig & {'k', 'radius_mm'}),
+      f'{sorted(_sig)} -- radius_mm=2.0 read as a knob and was not one; it '
+      f'silently dropped every blocker bigger than about 4mm')
+_src = open(os.path.join(REPO, 'py_tools', 'check_reachability.py'),
+            encoding='utf-8').read()
+check('and the CLI passes instrument= at its call site',
+      "instrument='check_reachability'" in _src,
+      'the only writer of a record must name itself explicitly')
+check('and no longer imports a sibling CLI\'s private _components',
+      'from net_forensics import' not in _src,
+      'py_tools is not on sys.path via _path, so that ImportError left as '
+      'exit 1 -- the CAGED verdict')
+
+print('--- and NOT produced when there is no defect ---')
+r2 = RE.pad_reachability(pcb, SEED, net_id=1, layers=('F.Cu',),
+                         track_mm=0.05, via_mm=0.6, base_clearance=CLR,
+                         step=0.01, margin_mm=2.0)
+check('a PASSABLE measurement makes no record',
+      not r2.caged and r2.defect_record() is None,
+      f'caged={r2.caged} record={r2.defect_record()}')
+
+# A seed with nothing to reach is NO-TARGET, a third state -- and it must not
+# produce a record either, or the loop re-enters placement over a question
+# nobody answered (run 15: 7 CAGED reported where 3 was the truth).
+r3 = RE.pad_reachability(pcb, SEED, net_id=1, layers=('F.Cu',),
+                         track_mm=TRACK, via_mm=0.6, base_clearance=CLR,
+                         step=0.01, margin_mm=0.5)
+check('a NO-TARGET measurement makes no record either',
+      not r3.measured and r3.defect_record() is None,
+      f'measured={r3.measured} record={r3.defect_record()}')
+
+print('--- a WIDE-OPEN result has no throat at all ---')
+# The same two own pads with the walls removed: the widest path never nears
+# foreign copper, so the bottleneck is the view's own size. The cell that
+# closed the path is then just the last free cell Kruskal activated -- a point
+# in open board, not a throat -- and the first version reported it anyway,
+# with the copper "nearest" to it and a view-sized "gap": check_reachability
+# printed "There is no throat here to measure" and, two lines later,
+# "throat (...) gap 34.18mm vs 0.55mm needed".
+r4 = RE.pad_reachability(_board(walls=False), SEED, net_id=1,
+                         layers=('F.Cu',), track_mm=TRACK, via_mm=0.6,
+                         base_clearance=CLR, step=0.01, margin_mm=2.0)
+check('the fixture is measured, wide open and PASSABLE',
+      r4.measured and r4.wide_open and not r4.caged,
+      f'measured={r4.measured} wide_open={r4.wide_open} caged={r4.caged} '
+      f'bottleneck={r4.bottleneck_mm} open_room={r4.open_room_mm}')
+check('so there is no throat', r4.throat is None and r4.throat_cell is None,
+      str(r4.throat))
+check('no copper "nearest" to a point that is not a throat', r4.near == (),
+      str(r4.near))
+check('and no gap: a gap is between two pieces of copper, and there are none',
+      r4.gap_mm is None, str(r4.gap_mm))
+d4 = r4.to_dict()
+check('the dict says the same (throat/near/gap null, wide_open set)',
+      d4['throat'] is None and d4['near'] == [] and d4['gap_mm'] is None
+      and d4['wide_open'] and d4['verdict'] == 'PASSABLE', str(d4))
+check('bottleneck_mm still reports the view-bounded number it always did',
+      d4['bottleneck_mm'] is not None and d4['bottleneck_mm'] > 1.0,
+      str(d4['bottleneck_mm']))
+check('and no record', r4.defect_record() is None, str(r4.defect_record()))
+# The caged fixture, for contrast: it is NOT wide open, so the throat stays.
+check('the caged fixture is not wide open and keeps its throat',
+      not r.wide_open and r.throat is not None, f'wide_open={r.wide_open}')
+
+print('--- relief_move, the "so what do I do" half ---')
+from placement.routability import relief_move                     # noqa: E402
+from placement.legality import rect_gap                           # noqa: E402
+
+# The run-20 fixture, from the plan: dx=0.3915, dy=0.12, need=0.45.
+_a = (0.0, 0.0, 1.0, 1.0)
+_b = (1.0 + 0.3915, 1.0 + 0.12, 2.0, 2.0)
+check('the fixture gap is the hand-measured 0.409478',
+      abs(rect_gap(_a, _b) - 0.409478) < 1e-6, str(rect_gap(_a, _b)))
+_mv = relief_move(_a, _b, 0.45)
+_east = next((m for m in _mv if m['dir'] == 'east'), None)
+check('and the eastward relief is 0.0422mm',
+      _east and abs(_east['min_mm'] - 0.0422) < 1e-4, str(_mv))
+check('every result is stamped as a LOWER bound',
+      all(m['bound'] == 'lower' for m in _mv),
+      'moving a part changes the whole field; this clears THIS pair only')
+_moved = (_b[0] + _east['min_mm'], _b[1], _b[2] + _east['min_mm'], _b[3])
+check('and the bound is real -- applying it reaches the need',
+      rect_gap(_a, _moved) >= 0.45 - 1e-9, str(rect_gap(_a, _moved)))
+
+# Overlapping rects: the gap is negative, so every direction needs a real move.
+_ov = relief_move((0.0, 0.0, 2.0, 2.0), (1.0, 1.0, 3.0, 3.0), 0.45)
+check('overlapping rects still get an answer', bool(_ov), str(_ov))
+check('and none of those answers is zero',
+      all(m['min_mm'] > 0 for m in _ov), str(_ov))
+
+# Infeasible within the cap: omitted, never reported as a large number.
+_inf = relief_move((0.0, 0.0, 100.0, 1.0), (0.0, 1.05, 100.0, 2.0), 0.45,
+                   limit_mm=0.1)
+check('a direction that cannot reach the need within the cap is omitted',
+      not any(m['dir'] in ('north', 'south') for m in _inf), str(_inf))
+
+# Already clear: zero, not a bisection artefact.
+_clear = relief_move((0.0, 0.0, 1.0, 1.0), (2.0, 0.0, 3.0, 1.0), 0.45)
+check('a pair already at the need reports 0.0',
+      _clear and all(m['min_mm'] == 0.0 for m in _clear), str(_clear))
+
+print('--- the gap is in the clearance the BLOCKERS are on, not the base one ---')
+# The whole point of the per-net map `slack_field` already builds: clearance is
+# PAIRWISE. Same 1.00mm slot, same base clearance, twice -- once with the walls
+# on the Default class and once with them on a 0.3mm class. The GEOMETRY does
+# not change, so the physical gap must not either. The first version computed
+# `bottleneck + 2 * base_clearance` and reported 1.00 then 0.50: off by
+# 2 * (class - base), and in the direction that turns a passable slot into a
+# reported cage.
+WIDE = 1.00
+_pcbw = _board(gap=WIDE, tall=3.0)
+_g = {}
+for _label, _nc in (('base', None), ('class 0.3', {2: 0.3, 3: 0.3})):
+    _rw = RE.pad_reachability(_pcbw, SEED, net_id=1, layers=('F.Cu',),
+                              track_mm=0.2, via_mm=0.6, base_clearance=CLR,
+                              net_clearances=_nc, step=0.01, margin_mm=2.0)
+    _g[_label] = _rw
+    check(f'the {WIDE}mm slot measures {WIDE}mm edge-to-edge with the walls '
+          f'on the {_label} clearance',
+          _rw.gap_mm is not None and abs(_rw.gap_mm - WIDE) <= _rw.step_mm + 1e-9,
+          f'gap_mm={_rw.gap_mm} bottleneck={_rw.bottleneck_mm} '
+          f'binding={_rw.binding_clearances} -- the geometry is identical in '
+          f'both runs, so the physical gap must be too')
+check('the two runs agree on the gap to within a raster step',
+      abs(_g['base'].gap_mm - _g['class 0.3'].gap_mm) <= 0.01 + 1e-9,
+      f"{_g['base'].gap_mm} vs {_g['class 0.3'].gap_mm}")
+check('and they DISAGREE on the bottleneck, which is the point: a track has '
+      'less room on the wider class',
+      _g['class 0.3'].bottleneck_mm < _g['base'].bottleneck_mm - 0.4,
+      f"{_g['base'].bottleneck_mm} vs {_g['class 0.3'].bottleneck_mm}")
+check('the clearance in force at each blocker is published on the entry',
+      all(abs(n['clearance'] - 0.3) < 1e-12 for n in _g['class 0.3'].near),
+      str([n.get('clearance') for n in _g['class 0.3'].near]))
+check('binding_clearances reads them back',
+      _g['class 0.3'].binding_clearances == (0.3, 0.3),
+      str(_g['class 0.3'].binding_clearances))
+_recw = _g['class 0.3'].defect_record(board='/tmp/x.kicad_pcb')
+check('a PASSABLE wide slot still makes no record', _recw is None, str(_recw))
+# ...and the record's own conversion, on a CAGED reading of the same slot.
+_rwc = RE.pad_reachability(_pcbw, SEED, net_id=1, layers=('F.Cu',),
+                           track_mm=0.8, via_mm=0.6, base_clearance=CLR,
+                           net_clearances={2: 0.3, 3: 0.3}, step=0.01,
+                           margin_mm=2.0)
+_mw = (_rwc.defect_record(board='/tmp/x.kicad_pcb') or {}).get(
+    'defects', [{}])[0].get('measure', {})
+check('the record carries the same gap the property does',
+      _mw.get('gap_mm') is not None and abs(_mw['gap_mm'] - WIDE) <= 0.01 + 1e-9,
+      str(_mw))
+check('and its gap_need_mm converts the NEED with the same two clearances',
+      abs(_mw.get('gap_need_mm', 0) - (0.8 + 0.6)) < 1e-9, str(_mw))
+check('and derived_from names the two blockers, not twice the base clearance',
+      'span.a.clearance' in (_mw.get('derived_from') or ''), str(_mw))
+
+print('--- a blocker bigger than the search radius is still NAMED ---')
+# Centre distances dropped it. A 5mm-tall wall pad 0.2mm from the throat has
+# its centre 2.7mm away, so a CAGED verdict shipped `near: ()`, `refs: []`,
+# `pads: []`, no span and no relief -- the record's entire purpose. Any pad or
+# connector wider than about 4mm hit this.
+_pcbb = _board(gap=0.40, tall=5.0)
+_rb = RE.pad_reachability(_pcbb, SEED, net_id=1, layers=('F.Cu',),
+                          track_mm=TRACK, via_mm=0.6, base_clearance=CLR,
+                          step=0.01, margin_mm=3.0)
+check('the big-wall fixture is CAGED (that is what the record describes)',
+      _rb.measured and _rb.caged, _rb.to_dict()['verdict'])
+check('and the 5mm walls are named, at their EDGE distance',
+      {n.get('ref') for n in _rb.near} == {'R7', 'U4'},
+      f'{_rb.near} -- the wall centres are 2.7mm away; their edges are 0.2mm')
+check('the reported distances are edge distances, not centre distances',
+      all(n['dist'] < 0.5 for n in _rb.near),
+      str([n['dist'] for n in _rb.near]))
+_recb = (_rb.defect_record(board='/tmp/x.kicad_pcb') or {})
+_db = (_recb.get('defects') or [{}])[0]
+check('so the record names the refs, the pads and the span',
+      set(_db.get('refs') or ()) == {'R7', 'U4'}
+      and len(_db.get('pads') or ()) == 2 and _db.get('span'),
+      f"refs={_db.get('refs')} pads={_db.get('pads')} span={_db.get('span')}")
+
+print('--- only copper on the THROAT\'s own layer can bound it ---')
+# Probed on a two-layer board: a B.Cu throat whose near[0] was an F.Cu SMD pad.
+# `check_reachability._relief_for` consumes near[0]/near[1], so that became
+# advice to move a part on the other side of the board.
+_far = synth.make_pad(2, 5.0, 5.0, ref='F9', num='1', net_name='GND',
+                      size_x=6.0, size_y=6.0, layers=('F.Cu',))
+_pcbl = _board(gap=0.40, tall=3.0, layer='B.Cu', layers=('B.Cu', 'F.Cu'),
+               extra=[('F9', _far)])
+_rl = RE.pad_reachability(_pcbl, SEED, net_id=1, layers=('B.Cu', 'F.Cu'),
+                          track_mm=TRACK, via_mm=0.6, base_clearance=CLR,
+                          step=0.01, margin_mm=2.0)
+check('the throat is on B.Cu (F.Cu is covered, so the path must use the slot)',
+      (_rl.throat or {}).get('layer') == 'B.Cu', str(_rl.throat))
+check('and nothing on F.Cu is named as forming it',
+      _rl.near and all(n['layer'] == 'B.Cu' for n in _rl.near),
+      f"{_rl.near} -- F9 is a 6x6mm F.Cu pad centred ON the throat and cannot "
+      f"bound a B.Cu throat")
+check('the B.Cu walls are what is named',
+      {n.get('ref') for n in _rl.near} == {'R7', 'U4'}, str(_rl.near))
+
+print('--- a `*.Cu` pad forms the throat, so it must be NAMED as one ---')
+# Blocker 3 through a second door. The naming walk had its own layer test
+# (`set(p.layers) & lay`) instead of `_pad_on_layer`, the predicate the FIELD
+# stamps with. A pad declared on `*.Cu` is stamped, forms the throat, and was
+# then refused by the naming walk: same CAGED verdict, near=[] refs=[] again.
+_star = {}
+for _lbl, _wl in (('F.Cu', ('F.Cu',)), ('*.Cu', ('*.Cu',))):
+    _rs = RE.pad_reachability(_board(wall_layers=_wl), SEED, net_id=1,
+                              layers=('F.Cu',), track_mm=TRACK, via_mm=0.6,
+                              base_clearance=CLR, step=0.01, margin_mm=2.0)
+    _star[_lbl] = _rs
+    _ds = ((_rs.defect_record(board='/tmp/x.kicad_pcb') or {})
+           .get('defects') or [{}])[0]
+    check(f'walls declared on {_lbl}: the same walls are named',
+          {n.get('ref') for n in _rs.near} == {'R7', 'U4'}
+          and set(_ds.get('refs') or ()) == {'R7', 'U4'}
+          and bool(_ds.get('span')),
+          f"near={_rs.near} refs={_ds.get('refs')} span={bool(_ds.get('span'))}")
+check('and the two declarations measure the same bottleneck, because the '
+      'FIELD never disagreed -- only the naming walk did',
+      abs(_star['F.Cu'].bottleneck_mm - _star['*.Cu'].bottleneck_mm) < 1e-12,
+      f"{_star['F.Cu'].bottleneck_mm} vs {_star['*.Cu'].bottleneck_mm}")
+
+print('--- a pad\'s residual tilt is part of its geometry ---')
+# `_point_rect_dist` rotates the point into the pad frame with the SAME
+# convention `_rect` stamps with. Ignoring the tilt puts the blocker distance
+# (and therefore which two objects are named) on a different rectangle to the
+# one the bottleneck was measured from.
+_ANALYTIC = 0.9 * math.sqrt(0.5) - 0.1     # a 2.0 x 0.2 pad turned 45 degrees
+check('a point 0.9mm off centre is INSIDE an axis-aligned 2.0x0.2 pad',
+      RE._point_rect_dist(0.9, 0.0, 0.0, 0.0, 2.0, 0.2, 0.0) == 0.0,
+      str(RE._point_rect_dist(0.9, 0.0, 0.0, 0.0, 2.0, 0.2, 0.0)))
+check('and OUTSIDE the same pad turned 45 degrees, by the analytic amount',
+      abs(RE._point_rect_dist(0.9, 0.0, 0.0, 0.0, 2.0, 0.2, 45.0)
+          - _ANALYTIC) < 1e-9,
+      f'{RE._point_rect_dist(0.9, 0.0, 0.0, 0.0, 2.0, 0.2, 45.0)} vs '
+      f'{_ANALYTIC}')
+check('the tilt turns the same way for -45 (the distance is symmetric here)',
+      abs(RE._point_rect_dist(0.9, 0.0, 0.0, 0.0, 2.0, 0.2, -45.0)
+          - _ANALYTIC) < 1e-9,
+      str(RE._point_rect_dist(0.9, 0.0, 0.0, 0.0, 2.0, 0.2, -45.0)))
+# ...and the raster agrees, which is the property that matters: one geometry,
+# two consumers. Stamp a 45-degree pad and compare the occupancy against the
+# zero-set of `_point_rect_dist` over every cell.
+_occ = np.zeros((60, 60), dtype=bool)
+_view = (-1.5, -1.5, 1.5, 1.5)
+RE._rect(_occ, 0.0, 0.0, 2.0, 0.2, _view, 0.05, 45.0)
+_mismatch = 0
+for _iy in range(60):
+    for _ix in range(60):
+        _px = _view[0] + (_ix + 0.5) * 0.05
+        _py = _view[1] + (_iy + 0.5) * 0.05
+        _inside = RE._point_rect_dist(_px, _py, 0.0, 0.0, 2.0, 0.2, 45.0) <= 0.0
+        if bool(_occ[_iy, _ix]) != _inside:
+            _mismatch += 1
+check('the distance function and the rasteriser agree on the tilted pad, '
+      'cell for cell', _mismatch == 0,
+      f'{_mismatch} of 3600 cells disagree -- the naming walk and the field '
+      f'would be measuring two different rectangles')
+_rrot = RE.pad_reachability(_board(wall_rot=30.0), SEED, net_id=1,
+                            layers=('F.Cu',), track_mm=TRACK, via_mm=0.6,
+                            base_clearance=CLR, step=0.01, margin_mm=2.0)
+check('a tilted wall still names itself at a tilt-aware distance',
+      _rrot.near and all(
+          abs(n['dist'] - RE._point_rect_dist(
+              _rrot.throat['x'], _rrot.throat['y'], n['x'], n['y'],
+              0.6, TALL, 30.0)) < 2e-4 for n in _rrot.near),
+      str(_rrot.near))
+
+print('--- how many blockers the gap conversion actually knew about ---')
+check('the two-wall fixture knows both, so gap_mm IS an edge-to-edge distance',
+      r.gap_blockers == 2 and d['gap_blockers'] == 2,
+      f'{r.gap_blockers} / {d.get("gap_blockers")}')
+# One blocker: the only foreign copper in the view is a single small pad
+# between the seed and its partner, so the widest path detours round it and
+# the throat has exactly one named side. `gap_mm` is then twice the room on
+# that side, and the count says so rather than the label claiming two objects
+# that were never identified.
+_one_nets = {1: synth.make_net(1, 'SIG'), 2: synth.make_net(2, 'GND')}
+_one = synth.make_pcb(
+    nets=_one_nets, board_info=_bi(['F.Cu']),
+    footprints={
+        'U1': _fp('U1', [synth.make_pad(1, 4.0, 5.0, ref='U1', num='1',
+                                        net_name='SIG', size_x=0.6,
+                                        size_y=0.6)]),
+        'U2': _fp('U2', [synth.make_pad(1, 4.8, 5.0, ref='U2', num='1',
+                                        net_name='SIG', size_x=0.6,
+                                        size_y=0.6)]),
+        'R9': _fp('R9', [synth.make_pad(2, 4.4, 5.0, ref='R9', num='1',
+                                        net_name='GND', size_x=0.2,
+                                        size_y=0.2)])})
+_r1 = RE.pad_reachability(_one, SEED, net_id=1, layers=('F.Cu',),
+                          track_mm=1.2, via_mm=0.6, base_clearance=CLR,
+                          step=0.01, margin_mm=1.0)
+check('the single-blocker fixture is measured, not wide open, and CAGED',
+      _r1.measured and not _r1.wide_open and _r1.caged,
+      f'measured={_r1.measured} wide_open={_r1.wide_open} caged={_r1.caged}')
+check('a single-blocker throat reports gap_blockers 1, not 2',
+      _r1.gap_blockers == 1 and len(_r1.near) == 1,
+      f'gap_blockers={_r1.gap_blockers} near={_r1.near}')
+check('and to_dict publishes the count beside the gap',
+      _r1.to_dict()['gap_blockers'] == 1, str(_r1.to_dict()['gap_blockers']))
+_m1 = (((_r1.defect_record(board='/tmp/x.kicad_pcb') or {})
+        .get('defects') or [{}])[0].get('measure') or {})
+check('and the record says the far side was ASSUMED, not measured',
+      _m1.get('gap_blockers') == 1
+      and 'assumed' in (_m1.get('derived_from') or ''), str(_m1))
+check('while the two-wall record still names both blockers as the source',
+      (_d0.get('measure') or {}).get('gap_blockers') == 2
+      and 'span.a.clearance' in ((_d0.get('measure') or {})
+                                 .get('derived_from') or ''),
+      str(_d0.get('measure')))
+
+# ---------------------------------------------------------------------------
+# The SEVEREST caged result -- a seed ringed by copper, so the search never
+# gets out and there is no throat at all -- still writes a record, and that
+# record must not describe a derivation nobody made. `gap_mm` is null there,
+# so `derived_from` is null too: a sentence naming "the ONE blocker found"
+# beside `gap_blockers: 0` is exactly the phantom this instrument exists to
+# stop, and it is the reading a grader would act on.
+_ring_nets = {1: synth.make_net(1, 'SIG'), 2: synth.make_net(2, 'GND')}
+_ring_wall = []
+for _i, (_wx, _wy, _sx, _sy) in enumerate((
+        (5.0, 4.3, 2.0, 0.4), (5.0, 5.7, 2.0, 0.4),
+        (4.3, 5.0, 0.4, 2.0), (5.7, 5.0, 0.4, 2.0))):
+    _ring_wall.append(synth.make_pad(2, _wx, _wy, ref='W1', num=str(_i + 1),
+                                     net_name='GND', size_x=_sx, size_y=_sy))
+_ring = synth.make_pcb(
+    nets=_ring_nets, board_info=_bi(['F.Cu']),
+    footprints={
+        'U1': _fp('U1', [synth.make_pad(1, 5.0, 5.0, ref='U1', num='1',
+                                        net_name='SIG', size_x=0.3,
+                                        size_y=0.3)]),
+        # INSIDE the view, or this fixture is NO-TARGET rather than a ring,
+        # `defect_record` returns None, and every assertion below passes
+        # against an empty dict. That vacuity is the trap this file exists to
+        # avoid, so the target sits where the margin reaches it.
+        'U2': _fp('U2', [synth.make_pad(1, 6.8, 5.0, ref='U2', num='1',
+                                        net_name='SIG', size_x=0.3,
+                                        size_y=0.3)]),
+        'W1': _fp('W1', _ring_wall)})
+_rr = RE.pad_reachability(_ring, (5.0, 5.0), net_id=1, layers=('F.Cu',),
+                          track_mm=0.2, via_mm=0.4, base_clearance=CLR,
+                          step=0.02, margin_mm=2.5)
+check('the ringed seed is MEASURED and CAGED with no throat at all',
+      _rr.measured and _rr.caged and _rr.bottleneck_mm is None
+      and _rr.gap_mm is None and _rr.gap_blockers == 0,
+      f'measured={_rr.measured} caged={_rr.caged} '
+      f'bottleneck={_rr.bottleneck_mm} gap={_rr.gap_mm}')
+_dr = ((_rr.defect_record(board='/tmp/x.kicad_pcb') or {})
+       .get('defects') or [{}])[0]
+_mr = _dr.get('measure') or {}
+check('it still writes a record (the severest caged is the one worth having)',
+      bool(_dr) and bool(_mr), str(_dr)[:200])
+check('and derived_from is null, not a sentence about a blocker never found',
+      'derived_from' in _mr and _mr['derived_from'] is None,
+      f"gap_blockers={_mr.get('gap_blockers')} "
+      f"derived_from={_mr.get('derived_from')!r} -- with no gap derived, a "
+      f"sentence here would describe arithmetic that did not happen")
+
+
+print(f'\n{passed} passed, {failed} failed')
+sys.exit(1 if failed else 0)

--- a/tests/test_reachability.py
+++ b/tests/test_reachability.py
@@ -45,8 +45,14 @@ class _Pad:
 
 
 class _Fp:
-    def __init__(self, pads):
+    # `reference` because the real Footprint always has one and
+    # `nearest_foreign` names its blockers by REF.PAD. The stand-in got away
+    # without it only while blockers were measured to their CENTRES: nothing in
+    # this fixture was within 2 mm of the throat that way, so the naming walk
+    # never ran. Measured edge-to-edge the walls are 0.2 mm away and it does.
+    def __init__(self, pads, reference='?'):
         self.pads = pads
+        self.reference = reference
 
 
 class _Net:
@@ -61,7 +67,7 @@ class _Info:
 class _Pcb:
     """The slice of PCBData the field reads."""
     def __init__(self, pads_by_ref, nets):
-        self.footprints = {k: _Fp(v) for k, v in pads_by_ref.items()}
+        self.footprints = {k: _Fp(v, k) for k, v in pads_by_ref.items()}
         self.nets = {i: _Net(n) for i, n in nets.items()}
         self.segments, self.vias = [], []
         self.board_info = _Info()

--- a/tests/test_run23_reachability_widen.py
+++ b/tests/test_run23_reachability_widen.py
@@ -1,0 +1,586 @@
+"""check_reachability auto-widens NO-TARGET; net_forensics emits JSON.
+
+Run 23, measured: U3.30 (/TXLED, partner D4.1 20.27mm away) returned exit 2
+NO-TARGET at the default +/-4mm view; the manual retry ladder cost 128s at
+--margin 12, 306s at 18, and a 10-minute timeout WITH NO DATA at 25, because
+cells scale as (span/step)^2 at the fixed 0.01 step. The auto-widen locates
+the nearest other island by vector union-find, widens the view to hold it,
+and coarsens the step so the grid stays ~1200^2 -- one invocation whose cost
+is bounded by the grid cap, not by a clock. And the island gap itself (the
+number rip-set decisions need) was text-only in net_forensics; --json-out
+makes it consumable.
+
+The rest of this file is the review's list, each item pinned by a test that
+fails without its fix: stdout stays a machine channel under --json, a coarsened
+step is declared coarse instead of passed off as a measurement, the floors are
+wrapped at the fab floor because this tool PREDICTS, and the auto-widen no
+longer reaches into a sibling CLI for a private name.
+"""
+
+import contextlib
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PLACED = os.path.join(ROOT, 'tests', 'fixtures', 'run23',
+                      'tigard_placed.kicad_pcb')
+
+
+def _run(tool, *argv):
+    env = dict(os.environ, PYTHONPATH=ROOT, PYTHONIOENCODING='utf-8',
+               KRT_NO_BANNER='1')
+    return subprocess.run(
+        [sys.executable, '-X', 'utf8',
+         os.path.join(ROOT, 'py_tools', tool), *argv],
+        capture_output=True, text=True, env=env, cwd=ROOT)
+
+
+def _load(path):
+    with open(path, encoding='utf-8') as fh:
+        return json.load(fh)
+
+
+class TestAutoWiden(unittest.TestCase):
+    def test_u3_30_answers_in_one_bounded_invocation(self):
+        with tempfile.TemporaryDirectory() as td:
+            jp = os.path.join(td, 'r.json')
+            r = _run('check_reachability.py', PLACED, '--pad', 'U3.30',
+                     '--json-out', jp)
+            # Exit 0 = PASSABLE, the true verdict run 23 needed three manual
+            # retries to reach.
+            self.assertEqual(r.returncode, 0, r.stdout[-500:])
+            # STDERR. A notice on stdout is a JSONDecodeError at character 0
+            # for --json, which the loop driver documents as a machine channel.
+            self.assertIn('auto-widening', r.stderr)
+            self.assertNotIn('auto-widening', r.stdout)
+            self.assertIn('JSON ->', r.stderr)
+            self.assertNotIn('JSON ->', r.stdout)
+            doc = _load(jp)
+            self.assertEqual(doc['verdict'], 'PASSABLE')
+            aw = doc['auto_widened']
+            self.assertAlmostEqual(aw['nearest_island_mm'], 20.27, delta=0.1)
+            # The coarsened step is DISCLOSED (readings are only comparable
+            # at their own step), and it is the step the field was built at,
+            # not a rounded copy of it. The grid cap is what bounds the cost.
+            self.assertGreater(aw['step_mm'], 0.01)
+            self.assertEqual(aw['step_mm'], doc['step_mm'])
+            self.assertLessEqual(max(doc['grid']), 1201)
+            self.assertGreater(doc['margin_um'], 0)
+            # A throat is a place on the board; a wide-open result has none,
+            # and a result with no path has none. Never the last free cell the
+            # search happened to touch.
+            self.assertEqual(doc['throat'] is None,
+                             doc['wide_open'] or doc['bottleneck_mm'] is None)
+            if doc['wide_open']:
+                self.assertEqual(doc['near'], [])
+                self.assertIsNone(doc['gap_mm'])
+                self.assertNotIn('throat     (', r.stdout)
+
+            # A step this fine relative to the track is NOT coarse, and the
+            # verdict says so rather than staying silent about it.
+            self.assertFalse(aw['coarse'], aw)
+
+    def test_explicit_view_is_never_overridden(self):
+        r = _run('check_reachability.py', PLACED, '--pad', 'U3.30',
+                 '--view', '55,58,60,63')
+        self.assertNotIn('auto-widening', r.stdout)
+        self.assertNotIn('auto-widening', r.stderr)
+
+    def test_a_coarsened_step_is_declared_coarse(self):
+        """The widened step grows with the island distance; nothing refused it.
+
+        Measured A/B on this very pad at one view: the native 0.01 step gave
+        bottleneck 0.4403, the widened 0.02021 gave 0.46904 -- 29 um
+        OPTIMISTIC, more than one whole step, and optimistic is the direction
+        that hides a cage. At --track 0.05 (pinned up to the 0.0762 fab floor)
+        the step is more than a quarter of the track and the reading is a
+        locate, not a measurement.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            jp = os.path.join(td, 'r.json')
+            r = _run('check_reachability.py', PLACED, '--pad', 'U3.30',
+                     '--track', '0.05', '--json-out', jp)
+            self.assertEqual(r.returncode, 0, r.stdout[-500:])
+            aw = _load(jp)['auto_widened']
+            self.assertTrue(aw['coarse'], aw)
+            self.assertIn('coarse_note', aw)
+            self.assertIn('COARSE', r.stderr)
+            # ...and it reaches the reader of the document too, not only the
+            # operator watching the terminal.
+            self.assertIn('COARSE', _load(jp)['note'])
+            self.assertIn('COARSE', r.stdout)      # via the `note` line
+
+    def test_json_stdout_carries_nothing_but_json(self):
+        """--json prints the document and nothing else; notices go to stderr."""
+        r = _run('check_reachability.py', PLACED, '--pad', 'U3.30', '--json')
+        self.assertEqual(r.returncode, 0, r.stderr[-500:])
+        doc = json.loads(r.stdout)                 # char 0 must be `{`
+        self.assertEqual(doc['verdict'], 'PASSABLE')
+        self.assertIn('auto-widening', r.stderr)
+
+
+class TestFabFloorWrap(unittest.TestCase):
+    """A PREDICTIVE tool must not promise a lane no fab can etch.
+
+    `list_nets.board_floor` is board-authoritative, not raise-only, and its
+    docstring says a predictive consumer has to wrap at the fab floor the way
+    `check_channels._fab` does. This tool predicts: its verdict is a claim that
+    a route EXISTS. Two paths are covered here, and neither was exercised by
+    any board in the repo -- every tracked board already sits above its floors.
+    """
+    # A tight explicit --view: the floors are resolved and reported before any
+    # field is built, so the assertions do not need (or want) a whole widened
+    # raster. Exit 2 is NO-TARGET in that box, which is the honest answer and
+    # not what this test is about.
+    VIEW = '184,32,188,36'
+
+    def test_cli_values_below_the_floor_are_pinned(self):
+        board = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
+        r = _run('check_reachability.py', board, '--pad', 'U1.1',
+                 '--clearance', '0.02', '--track', '0.02', '--view', self.VIEW)
+        self.assertEqual(r.returncode, 2, r.stderr[-500:])
+        # 2-layer JLC floors: clearance 0.1, track 0.1. Pinned regardless of
+        # SOURCE -- a 0.02 typed on the command line is as unetchable as a
+        # declared one, which is how enforce_fab_floors treats a flag too.
+        self.assertIn('below the 0.1mm fab floor', r.stderr)
+        self.assertIn('[cli]', r.stderr)
+        self.assertIn('clearance 0.1mm, track 0.1mm', r.stdout)
+        self.assertIn('clearance: fab floor', r.stdout)
+        self.assertIn('track width: fab floor', r.stdout)
+
+    def test_board_constraint_fallback_is_read_and_then_wrapped(self):
+        """The .kicad_pro min_track_width / min_via_diameter fallback.
+
+        New in this PR and inert on every board in the tree, so it is staged: a
+        project declaring NO Default netclass, only the two Board Setup minima,
+        both below the fab floor. The notice has to name `board constraint` as
+        the source it read and then pin the value up.
+
+        The staged project also carries a sub-floor NET CLASS, because the
+        field is a min() over the classes: pinning the base while leaving one
+        class at 0.02 would still measure that net's part of the field at a
+        spacing no fab can etch.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            src = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
+            dst = os.path.join(td, 'staged.kicad_pcb')
+            with open(src, encoding='utf-8') as fh:
+                _txt = fh.read()
+            with open(dst, 'w', encoding='utf-8') as fh:
+                fh.write(_txt)
+            with open(os.path.join(td, 'staged.kicad_pro'), 'w',
+                      encoding='utf-8') as fh:
+                json.dump({'board': {'design_settings': {'rules': {
+                    'min_track_width': 0.05, 'min_via_diameter': 0.2}}},
+                    'net_settings': {
+                        'classes': [{'name': 'Fine', 'clearance': 0.02}],
+                        'netclass_assignments': {'GND': 'Fine'}}}, fh)
+            r = _run('check_reachability.py', dst, '--pad', 'U1.1',
+                     '--view', self.VIEW)
+            self.assertEqual(r.returncode, 2, r.stderr[-500:])
+            self.assertIn('track width 0.05mm [board constraint]', r.stderr)
+            self.assertIn('via diameter 0.2mm [board constraint]', r.stderr)
+            self.assertIn('track 0.1mm', r.stdout)
+            self.assertIn('via 0.25mm', r.stdout)
+            self.assertIn('net-class clearance(s) below the 0.1mm fab floor',
+                          r.stderr)
+            # The report carries both numbers, not just the stderr notice: a
+            # reader of the text cannot otherwise tell a wrapped floor from a
+            # declared one that happens to equal the fab minimum.
+            self.assertIn('0.05 declared [board constraint] -> 0.1', r.stdout)
+
+    def test_the_per_net_map_is_wrapped_in_EFFECT_not_just_in_the_notice(self):
+        """Assert the consequence, because the message is not the fix.
+
+        Deleting the per-net wrap and keeping its stderr line passed the
+        message-matching test. `via_legal_fraction` is computed from the same
+        field the verdict is, and it moves with the per-net clearances, so a
+        sub-floor class that was NOT wrapped shows up here.
+
+        Three staged projects, one pad, one explicit view: a `*` class at 0.02
+        (below tigard's 4-layer 0.09 fab clearance) must measure IDENTICALLY
+        to one declared at exactly 0.09, and both must differ from one at 0.30
+        so the equality cannot pass by measuring nothing. Measured: 0.3298 /
+        0.3298 / 0.2261, and 0.3707 for the 0.02 class with the wrap deleted.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            dst = os.path.join(td, 's.kicad_pcb')
+            with open(PLACED, encoding='utf-8') as fh:
+                _txt = fh.read()
+            with open(dst, 'w', encoding='utf-8') as fh:
+                fh.write(_txt)
+            frac = {}
+            for clr in (0.02, 0.09, 0.30):
+                with open(os.path.join(td, 's.kicad_pro'), 'w',
+                          encoding='utf-8') as fh:
+                    json.dump({'net_settings': {
+                        'classes': [{'name': 'Fine', 'clearance': clr}],
+                        'netclass_patterns': [{'pattern': '*',
+                                               'netclass': 'Fine'}]}}, fh)
+                jp = os.path.join(td, f'o{clr}.json')
+                r = _run('check_reachability.py', dst, '--pad', 'U3.30',
+                         '--view', '55,58,60,63', '--json-out', jp)
+                self.assertIn(r.returncode, (0, 1, 2), r.stderr[-400:])
+                frac[clr] = _load(jp)['via_legal_fraction']
+            self.assertEqual(
+                frac[0.02], frac[0.09],
+                f'a 0.02 net class measured {frac[0.02]} where the 0.09 fab '
+                f'floor measures {frac[0.09]}: the per-net map was not wrapped')
+            self.assertNotEqual(
+                frac[0.09], frac[0.30],
+                'the fixture measures nothing that depends on the per-net '
+                'clearances, so the equality above proves nothing')
+
+
+class TestFabTierIsTellable(unittest.TestCase):
+    """The floor this tool ENFORCES has to be one the operator can set.
+
+    `--fab-tier` / `--fab-overrides` come from `fab_tiers.add_fab_tier_args`,
+    the same helper every routing and DRC CLI uses, so the floor measured
+    against here is the floor the chain routed to. Without them a board built
+    with the documented override escape hatch is measured CAGED at a floor its
+    fab beats, and CAGED is the loop's most expensive verdict.
+    """
+    BOARD = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
+    VIEW = '184,32,188,36'
+
+    def test_an_override_moves_the_wrapped_floor(self):
+        with tempfile.TemporaryDirectory() as td:
+            ov = os.path.join(td, 'fab.txt')
+            with open(ov, 'w', encoding='utf-8') as fh:
+                fh.write('clearance = 0.05\ntrack_width = 0.05\n')
+            args = (self.BOARD, '--pad', 'U1.1', '--clearance', '0.06',
+                    '--track', '0.06', '--view', self.VIEW)
+            plain = _run('check_reachability.py', *args)
+            self.assertIn('below the 0.1mm fab floor', plain.stderr)
+            self.assertIn('clearance 0.1mm, track 0.1mm', plain.stdout)
+            over = _run('check_reachability.py', *args, '--fab-overrides', ov)
+            self.assertNotIn('fab floor', over.stderr)
+            self.assertIn('clearance 0.06mm, track 0.06mm', over.stdout)
+            self.assertIn('clearance: cli', over.stdout)
+
+    def test_a_missing_override_file_is_exit_2_not_the_CAGED_verdict(self):
+        r = _run('check_reachability.py', self.BOARD, '--pad', 'U1.1',
+                 '--fab-overrides', os.path.join(ROOT, 'no-such-fab.txt'))
+        self.assertEqual(r.returncode, 2, r.stderr[-300:])
+        self.assertIn('cannot resolve', r.stderr)
+
+
+class TestNoSiblingCliImport(unittest.TestCase):
+    """The auto-widen must not import `net_forensics._components`.
+
+    A sibling CLI's private name, from a directory `_path` does not put on
+    sys.path -- so the ImportError escaped as exit **1**, which in this tool is
+    the CAGED geometry verdict and re-enters placement, discarding every routed
+    board. The walk lives in `list_nets.net_islands` now.
+    """
+    def test_auto_widen_runs_with_net_forensics_unimportable(self):
+        import types
+        for _p in (os.path.join(ROOT, 'py_tools'),
+                   os.path.join(ROOT, 'py_router'),
+                   os.path.join(ROOT, 'py_placer')):
+            if _p not in sys.path:
+                sys.path.insert(0, _p)
+        try:
+            import scipy  # noqa: F401
+        except ImportError:
+            self.skipTest('reachability needs scipy')
+        import check_reachability
+        saved = sys.modules.get('net_forensics')
+        # A module object with no `_components`: `from net_forensics import
+        # _components` raises ImportError against it, exactly as it would if
+        # py_tools were not on the path.
+        sys.modules['net_forensics'] = types.ModuleType('net_forensics')
+        buf = io.StringIO()
+        try:
+            with contextlib.redirect_stdout(buf):
+                rc = check_reachability.main([PLACED, '--pad', 'U3.30'])
+        finally:
+            if saved is None:
+                sys.modules.pop('net_forensics', None)
+            else:
+                sys.modules['net_forensics'] = saved
+        self.assertEqual(rc, 0, buf.getvalue()[-400:])
+        self.assertIn('PASSABLE', buf.getvalue())
+
+    def test_help_does_not_promise_a_banner_it_never_prints(self):
+        r = _run('check_reachability.py', '--help')
+        self.assertEqual(r.returncode, 0, r.stderr[-300:])
+        self.assertNotIn('CMD:', r.stdout)
+        self.assertNotIn('banner', r.stdout)
+
+
+class TestWideOpenHasNoThroat(unittest.TestCase):
+    """A wide-open result carries no throat, in the JSON or the text.
+
+    The first version returned the last cell Kruskal activated as the throat
+    even when the path never neared copper, so this pad printed "There is no
+    throat here to measure" and then "throat (...) gap 34.18mm vs 0.55mm
+    needed" two lines later, and --json-out carried throat/near/gap_mm for a
+    PASSABLE verdict.
+    """
+    BOARD = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
+
+    def test_splitflap_u1_1(self):
+        with tempfile.TemporaryDirectory() as td:
+            jp = os.path.join(td, 'r.json')
+            dp = os.path.join(td, 'd.json')
+            r = _run('check_reachability.py', self.BOARD, '--pad', 'U1.1',
+                     '--json-out', jp, '--defect-json', dp)
+            self.assertEqual(r.returncode, 0, r.stdout[-500:])
+            doc = _load(jp)
+            self.assertEqual(doc['verdict'], 'PASSABLE')
+            self.assertTrue(doc['wide_open'], doc)
+            self.assertIsNone(doc['throat'])
+            self.assertEqual(doc['near'], [])
+            self.assertIsNone(doc['gap_mm'])
+            self.assertIn('There is no throat here to measure', r.stdout)
+            self.assertNotIn('throat     (', r.stdout)
+            self.assertNotIn('look at it', r.stdout)
+            self.assertFalse(os.path.exists(dp),
+                             'a record describes a defect; PASSABLE has none')
+
+
+def _islands_all_pairs(pcb, net_id, tol=0.05):
+    """`net_islands` written the obvious way: compare every point to every other.
+
+    The REFERENCE, kept deliberately dumb. `net_islands` buckets its pair scan
+    on a uniform grid, which is a separate optimisation riding in a shared
+    py_router module, and the review found that shrinking its neighbourhood
+    from 3x3 to the point's own cell passed every test in the tree. Nothing
+    pinned the bucketing to the thing it is meant to be equivalent to; this
+    does.
+    """
+    import math as _m
+    from collections import defaultdict as _dd
+    items = []
+    for s in pcb.segments:
+        if s.net_id == net_id:
+            items.append(('seg', s, [(s.start_x, s.start_y), (s.end_x, s.end_y)]))
+    for v in pcb.vias:
+        if v.net_id == net_id:
+            items.append(('via', v, [(v.x, v.y)]))
+    for fp in pcb.footprints.values():
+        for p in fp.pads:
+            if p.net_id == net_id:
+                items.append(('pad', p, [(p.global_x, p.global_y)]))
+    parent = list(range(len(items)))
+
+    def find(i):
+        while parent[i] != i:
+            parent[i] = parent[parent[i]]
+            i = parent[i]
+        return i
+
+    pts = []
+    for idx, (_k, obj, ps) in enumerate(items):
+        r = (max(obj.size_x, obj.size_y) / 2 if hasattr(obj, 'size_x')
+             else getattr(obj, 'size', 0) / 2 or 0.06)
+        for (x, y) in ps:
+            pts.append((x, y, idx, r))
+    for i in range(len(pts)):
+        x1, y1, a, r1 = pts[i]
+        for j in range(i + 1, len(pts)):
+            x2, y2, b, r2 = pts[j]
+            if a != b and _m.hypot(x1 - x2, y1 - y2) <= max(tol, r1, r2):
+                ra, rb = find(a), find(b)
+                if ra != rb:
+                    parent[rb] = ra
+    comps = _dd(list)
+    for idx in range(len(items)):
+        comps[find(idx)].append(items[idx])
+    return sorted(comps.values(), key=len, reverse=True)
+
+
+class TestNetIslandsMatchesAllPairs(unittest.TestCase):
+    """`net_islands`' bucketed pair scan must equal the all-pairs walk.
+
+    Every case here is a boundary the 3x3 neighbourhood exists to cover, so
+    each one fails if the neighbourhood shrinks. `cell` is the LARGEST join
+    radius on the net, which is why a single big pad among small ones is its
+    own case: it makes the cell wide and every small pair land in one bucket,
+    and it is also the case where a partner sits two cells away.
+    """
+    def setUp(self):
+        for _p in (ROOT, os.path.join(ROOT, 'py_router'),
+                   os.path.join(ROOT, 'tests')):
+            if _p not in sys.path:
+                sys.path.insert(0, _p)
+
+    @staticmethod
+    def _key(comps):
+        return sorted(tuple(sorted(o.pad_number for _k, o, _p in c))
+                      for c in comps)
+
+    def _pcb(self, pads):
+        import synth
+        from kicad_parser import Footprint
+        fps = {}
+        for i, (x, y, sx, sy) in enumerate(pads):
+            num = f'p{i}'
+            pad = synth.make_pad(1, x, y, ref='U1', num=num, net_name='N',
+                                 size_x=sx, size_y=sy)
+            fps[f'F{i}'] = Footprint(reference=f'F{i}', footprint_name='t:x',
+                                     x=x, y=y, rotation=0.0, layer='F.Cu',
+                                     pads=[pad])
+        return synth.make_pcb(nets={1: synth.make_net(1, 'N')},
+                              footprints=fps)
+
+    # (label, tol, [(x, y, size_x, size_y), ...])
+    CASES = [
+        # Exactly at the join radius, straddling a cell boundary at x=0.05.
+        ('exact radius across a cell boundary', 0.05,
+         [(0.03, 0.0, 0.0, 0.0), (0.08, 0.0, 0.0, 0.0)]),
+        # Both points sitting ON the boundary line.
+        ('both on the boundary', 0.05,
+         [(0.05, 0.05, 0.0, 0.0), (0.05, 0.09, 0.0, 0.0)]),
+        # Diagonal neighbours: the case a 4-neighbourhood would miss.
+        ('diagonal across a cell corner', 0.05,
+         [(0.049, 0.049, 0.0, 0.0), (0.051, 0.051, 0.0, 0.0)]),
+        # Two items at the very same coordinate.
+        ('coincident duplicates', 0.05,
+         [(1.0, 1.0, 0.2, 0.2), (1.0, 1.0, 0.2, 0.2), (1.0, 1.0, 0.2, 0.2)]),
+        ('a single item', 0.05, [(3.0, 3.0, 0.5, 0.5)]),
+        # Zero-size pads exactly at tol and just past it.
+        ('zero-size pads at tol', 0.05,
+         [(0.0, 0.0, 0.0, 0.0), (0.05, 0.0, 0.0, 0.0)]),
+        ('zero-size pads just past tol', 0.05,
+         [(0.0, 0.0, 0.0, 0.0), (0.050001, 0.0, 0.0, 0.0)]),
+        ('negative coordinates', 0.05,
+         [(-1.02, -1.0, 0.0, 0.0), (-0.98, -1.0, 0.0, 0.0),
+          (-1.0, -3.0, 0.0, 0.0)]),
+        # One big pad sets `cell`; its partners are 2 and 3 cells away.
+        ('one big pad spanning several cells', 0.05,
+         [(0.0, 0.0, 6.0, 6.0), (2.5, 0.0, 0.1, 0.1), (5.5, 0.0, 0.1, 0.1),
+          (9.0, 0.0, 0.1, 0.1)]),
+        ('mixed radii, chain of three', 0.05,
+         [(0.0, 0.0, 1.0, 1.0), (0.45, 0.0, 0.1, 0.1), (0.9, 0.0, 2.0, 0.2)]),
+        # tol=0 with every radius 0: `cell` is 0 and the bucket index divides
+        # by it. This used to raise ZeroDivisionError inside a shared module.
+        ('tol 0 and every radius 0', 0.0,
+         [(1.0, 1.0, 0.0, 0.0), (1.0, 1.0, 0.0, 0.0), (2.0, 2.0, 0.0, 0.0)]),
+    ]
+
+    def test_adversarial_points(self):
+        import list_nets
+        for label, tol, pads in self.CASES:
+            with self.subTest(label):
+                pcb = self._pcb(pads)
+                got = list_nets.net_islands(pcb, 1, tol=tol)
+                want = _islands_all_pairs(pcb, 1, tol=tol)
+                self.assertEqual(self._key(got), self._key(want), label)
+
+    def test_the_two_tracked_boards_every_net(self):
+        import list_nets
+        from kicad_parser import parse_kicad_pcb
+        for board in (PLACED, os.path.join(ROOT, 'kicad_files',
+                                           'splitflap_driver.kicad_pcb')):
+            pcb = parse_kicad_pcb(board)
+            for nid in pcb.nets:
+                got = list_nets.net_islands(pcb, nid)
+                want = _islands_all_pairs(pcb, nid)
+                self.assertEqual(self._key(got), self._key(want),
+                                 f'{board} net {nid}')
+
+
+class TestForensicsJson(unittest.TestCase):
+    def test_gap_is_machine_readable(self):
+        with tempfile.TemporaryDirectory() as td:
+            jp = os.path.join(td, 'nf.json')
+            # --json-out, the name every other tool in the repo uses for
+            # "write the document to this path".
+            r = _run('net_forensics.py', PLACED, '--nets', '/TXLED',
+                     '--json-out', jp)
+            self.assertEqual(r.returncode, 0, r.stdout[-400:])
+            doc = _load(jp)
+            net = doc['nets'][0]
+            self.assertEqual(net['net'], '/TXLED')
+            self.assertEqual(len(net['islands']), 2)
+            self.assertAlmostEqual(net['gap']['mm'], 20.267, delta=0.05)
+
+    def test_the_island_walk_is_paid_exactly_once_per_net(self):
+        """`net_data` repeated the walk `_describe` had just done.
+
+        It was called unconditionally, outside any --json guard, so every
+        text-only run -- which is nearly all of them -- paid for the island
+        walk twice and threw the second one away. Guarding it fixed the
+        text-only run; passing `_describe`'s components in fixes the
+        --json-out run, which still walked twice. Counted at `net_islands`,
+        the walk itself, so neither half can regress unseen.
+        """
+        for _p in (os.path.join(ROOT, 'py_tools'),
+                   os.path.join(ROOT, 'py_router')):
+            if _p not in sys.path:
+                sys.path.insert(0, _p)
+        import net_forensics
+        import list_nets
+        walks, data_calls = [], []
+        real_walk = list_nets.net_islands
+        real_data = net_forensics.net_data
+
+        def counted_walk(*a, **k):
+            walks.append(1)
+            return real_walk(*a, **k)
+
+        def counted_data(*a, **k):
+            data_calls.append(1)
+            return real_data(*a, **k)
+
+        # net_forensics imported the name, so both bindings have to move.
+        net_forensics.net_islands = counted_walk
+        list_nets.net_islands = counted_walk
+        net_forensics.net_data = counted_data
+        argv = sys.argv
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                buf = io.StringIO()
+                sys.argv = ['net_forensics.py', PLACED, '--nets', '/TXLED']
+                with contextlib.redirect_stdout(buf):
+                    net_forensics.main()
+                self.assertEqual(data_calls, [],
+                                 'a text-only run built the JSON document')
+                self.assertEqual(len(walks), 1,
+                                 f'a text-only run walked {len(walks)} times '
+                                 f'for one net')
+                walks.clear()
+                jp = os.path.join(td, 'nf.json')
+                sys.argv = ['net_forensics.py', PLACED, '--nets', '/TXLED',
+                            '--json-out', jp]
+                with contextlib.redirect_stdout(buf):
+                    net_forensics.main()
+                self.assertEqual(len(data_calls), 1)
+                self.assertEqual(len(walks), 1,
+                                 f'a --json-out run walked {len(walks)} times '
+                                 f'for one net; `_describe` returns the '
+                                 f'components so `net_data` need not re-walk')
+                self.assertTrue(os.path.exists(jp))
+                doc = _load(jp)
+                # ...and reusing them changed no number.
+                self.assertAlmostEqual(doc['nets'][0]['gap']['mm'], 20.267,
+                                       delta=0.05)
+                self.assertEqual(len(doc['nets'][0]['islands']), 2)
+        finally:
+            net_forensics.net_islands = real_walk
+            list_nets.net_islands = real_walk
+            net_forensics.net_data = real_data
+            sys.argv = argv
+
+    def test_a_single_island_net_and_a_missing_net_still_serialise(self):
+        """The two early-return paths through `_describe`, which now RETURNS."""
+        with tempfile.TemporaryDirectory() as td:
+            jp = os.path.join(td, 'nf.json')
+            r = _run('net_forensics.py', PLACED, '--nets', 'GND', 'NOPE',
+                     '--json-out', jp)
+            self.assertEqual(r.returncode, 0, r.stdout[-400:])
+            nets = {n['net']: n for n in _load(jp)['nets']}
+            self.assertEqual(nets['NOPE'].get('error'), 'not found')
+            self.assertGreater(len(nets['GND']['islands']), 1)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=1)


### PR DESCRIPTION
This is the reachability and net_forensics part of #686, split out at review. It carries its own tests, and it fixes a defect the review found in the #686 version: a wide-open result reported a "throat" that was not one (details below). One commit, no Rust, no wall-clock budgets anywhere.

Two review passes measured defects in the split itself. They are fixed here and each has a test that fails without the fix. Round one: the gap number was computed at the wrong clearance whenever a blocker sat on a non-Default net class, the blockers naming a throat could be copper on the other face of the board, and a blocker wider than about 4 mm was dropped entirely so a CAGED record named nobody. Round two: the naming walk used its own layer predicate instead of the field's, so a pad declared on `*.Cu` recreated the dropped-blocker defect through another door; the fab floor this tool now enforces could not be told about `--fab-tier` / `--fab-overrides`; a pad's residual rect tilt was covered by no test; and `gap_mm` was labelled an edge-to-edge distance even when only one blocker had been identified. The rest of both lists is addressed and described below.

## What changes for a user

`check_reachability.py`

- `--json-out PATH` writes the result dict to a file. The text report is still printed. `--json` prints the same dict on stdout and nothing else: every notice this tool emits now goes to stderr, so stdout stays a channel a caller can pipe into `json.load` (the loop driver documents it as one). The document itself gains `auto_widened` (see below) on a widened run, so `--json` is not unchanged in behaviour even though the flag spelling is.
- The result dict gains five keys, all additive: `throat` ({x, y, layer} of the narrowest point on the widest path, or null), `near` (the two nearest pieces of foreign copper to the throat, by REF.PAD for pads, with edge distances and the clearance in force at each), `clearance_mm` (the base clearance the field was built at), `gap_mm` (the physical edge-to-edge gap at the throat) and `gap_need_mm` (what that gap would have to be for the track to fit). Every pre-existing key is unchanged and a test pins the set.
- `gap_mm` is `bottleneck_mm + the clearance at each of the two blockers`, not `bottleneck_mm + 2 * clearance_mm`. Clearance is pairwise: the field is built from the per-net map the routing config resolves, which this tool always passes. Measured on a synthetic 1.00 mm slot at base clearance 0.05: with no net clearances the gap came out 1.00, and with the two wall nets on a 0.3 class it came out 0.50 for identical geometry. That is off by 2 x (class - base) and in the direction that turns a passable slot into a reported cage. Both blockers publish their own clearance in `near` and in the record's `span`, so the conversion is auditable rather than assumed.
- `near` uses `_pad_on_layer`, the same predicate the field itself stamps with, rather than a second nearly-identical test of its own. A pad declared on `*.Cu` is stamped into the field and forms the throat, but `set(p.layers) & lay` did not match it, so the naming walk refused it and a CAGED result shipped `near=[] refs=[] span=false` again. Measured on the same fixture: walls declared `F.Cu` named `['U4','R7']`, the identical walls declared `*.Cu` named nobody, at an identical bottleneck.
- `near` names only copper on the throat's own layer. It was handed the whole analysis stack, so a B.Cu throat could be reported as bounded by an F.Cu SMD pad, and the relief advice that follows would then ask for a part on the other side of the board to move.
- `gap_mm` publishes `gap_blockers`, the number of blockers the conversion actually knew about (0, 1 or 2). Only at 2 is it a distance between two named pieces of copper; at 1 the far side of the throat is assumed to sit at the same clearance and the number is twice the room on the known side. The old label said "the physical edge-to-edge distance" in every case. The count rides in `to_dict`, in the record's `measure`, in the record's `derived_from` sentence, and in a NOTE line in the text report.
- Blockers are measured to their edge, not their centre. A pad's residual rect tilt (`rect_rotation`) is honoured with the same convention the rasteriser uses; a test compares the two cell for cell over a 45-degree pad, because a naming walk and a field measuring two different rectangles is exactly how the dropped-blocker defect happened. A 5 mm tall wall pad 0.2 mm from the throat has its centre 2.7 mm away, which was outside the 2 mm search radius, so a CAGED verdict shipped `near: []`, no refs, no pads, no span and no relief. Any pad or connector wider than about 4 mm hit this. Pads are measured as rectangles because that is what the raster stamps, vias as barrels, tracks as capsules.
- A wide-open result (the path never came near foreign copper inside the view) has `throat`, `near`, `gap_mm` and `gap_need_mm` all null. The #686 version returned the last cell the search activated as the throat, so the text said "There is no throat here to measure" and then printed "throat (...) gap 34.18mm vs 0.55mm needed" two lines later, and `--json-out` carried a throat for a PASSABLE verdict. `bottleneck_mm` still reports the view-bounded number it always did.
- `--defect-json PATH` writes a `defect-record` document (version 1) when the verdict is CAGED: the throat coordinates, the nearest foreign refs and pads, the shortfall in both track-width space and gap space with the conversion stated, the floors the measurement was graded at with their sources, the board path and its sha256, and, only when the two nearest blockers are pads of two different parts, a per-direction relief distance for each part (smallest move first, each stamped as a lower bound because it clears this pair only). Nothing is written for a PASSABLE or NO-TARGET result. The schema is documented on `Reachability.defect_record`.

  **Nothing on main reads this document.** `--defect-json`, `auto_widened`, `nearest_foreign`, `relief_move` and `net_forensics --json-out` are all writer-only in this tree. A reader is being written on a separate unmerged branch and a record produced here loads into it cleanly, but an unmerged branch is not a consumer, and this PR should be judged as adding an output format nothing consumes yet. If the loop driver is not wired to it in the next PR, the 90-line record schema is fair to drop.
- The text report gains a `throat` line (location, which two objects form it, the gap in both spaces) for a measured result that is not wide open, and a ready-to-paste `render_placement.py --focus --view ...` line when it is CAGED.
- Auto-widen on NO-TARGET. When the default view has no other island of the net inside it and `--view` was not given, the tool finds the nearest other island by vector union-find, widens the view to hold the seed and that island plus `--margin`, coarsens the step so the grid stays at most about 1200 cells on a side, and measures once more. The step used is rounded up to 10 nm and disclosed twice, as `step_mm` and again under `auto_widened` (with the widened view and the island distance), because a reading is only comparable at its own step. Behaviour change: a pad whose partner sits beyond `--margin` used to exit 2 NO-TARGET at the default view; it now returns a verdict at a coarser step. An explicit `--view` is never widened. Motivation: on tigard U3.30 the manual retry ladder cost 128 s at `--margin 12`, 306 s at 18, and a 10 minute timeout with no data at 25, because cells scale as (span/step)^2 at the fixed 0.01 step; the widened run answers in one invocation. Note that the grid cap bounds the RETRY only. The first measurement, at plus or minus `--margin` at `--step`, is not capped, so `--margin 25 --step 0.01` still costs what it always did.
- A widened reading declares itself `coarse` when the coarsened step exceeds a quarter of the track width. The widened step grows with the island distance and nothing refused a coarse read before. Measured A/B on tigard U3.30 at one view: the native 0.01 step gave bottleneck 0.4403, the widened 0.02021 gave 0.46904, so 29 um optimistic, more than one whole step, and optimistic is the direction that hides a cage. `auto_widened.coarse` carries the flag, `auto_widened.coarse_note` and the result's `note` carry the sentence, and a line goes to stderr. The advice is to treat such a verdict as a locate and re-measure the found throat on a small `--view` at the native step.
- `--fab-tier` and `--fab-overrides`, from `fab_tiers.add_fab_tier_args`, the same helper every routing and DRC CLI uses. A floor this tool now ENFORCES has to be one the operator can set: a board built at an advanced tier, or with the documented `--fab-overrides` escape hatch, would otherwise be measured against a floor its fab beats, and the answer that buys is CAGED, the most expensive verdict in the loop. A missing override file exits 2, not 1.
- The `knobs` line prints `declared -> pinned` for any wrapped floor (`track width: fab floor (0.05 declared [board constraint] -> 0.1)`), so the text report carries both numbers the record does. Previously only the stderr notice did, and a reader of the printed report could not tell a wrapped floor from a declared one that happens to equal the fab minimum.
- Floors come from `list_nets.board_floor` instead of a local closure, so each floor carries its source for the defect record, and then they are pinned up to the fab floor. `board_floor` is board-authoritative, not raise-only, and its own docstring says a predictive consumer has to wrap the way `check_channels._fab` does. This tool predicts: its whole output is a claim that a route exists, so a clearance below what any fab can etch buys a confident PASSABLE for a lane nobody can build. The wrap applies regardless of source, which is how `enforce_fab_floors` treats an explicit flag, and the declared value is kept beside the pinned one under `declared` in the floors block. The per-net clearance map is wrapped at the same minimum, because the field is a min over the classes and one unwrapped class would set the answer.
- Behaviour change on boards with no Default netclass value: track and via now fall through to the board's `min_track_width` / `min_via_diameter` constraint before the fixed default. Clearance has no constraint key and is unchanged. That fallback changes no board in the tree, so the test stages a project that declares only those two Board Setup minima (and a sub-floor net class), both below the fab floor, and checks that the constraint is read and then pinned. The `knobs` line names each source (`clearance: board netclass, track width: fab floor, ...`) so both steps are visible in the text.

`net_forensics.py`

- `--json-out PATH` writes `{board, nets: [{net, net_id, islands: [{segs, vias, pads, layers}], gap: {mm, from, to}}]}` (a net that is not found gets `{net, error}`). The island gap was text-only before and had to be re-derived by hand to feed rip-set decisions. The flag is `--json-out` rather than `--json` because that is what every other tool in the repo calls "write the document to this path" (route.py, converge.py, place_route_loop.py, pose_score.py), and because in check_reachability `--json` means print on stdout. Nothing in the tree called it by the old name, so there is no alias; argparse's own prefix matching still accepts `--json PATH`.
- The island walk is paid exactly once per net, on any run. `net_data` was called unconditionally and did its own fresh walk, so a text-only run (nearly all of them) walked twice and threw the second away. It is now guarded by `--json-out` AND handed the components `_describe` already walked, so the `--json-out` run walks once too. A test counts calls to `net_islands` itself, so neither half can regress unseen.

`list_nets.py` (library)

- `net_islands(pcb, net_id)` and `island_gap(a, b)`: the island union-find and the closest approach between two islands. The bucketed pair scan is a separate optimisation riding in a shared module, so it is pinned by an all-pairs reference implementation in the test file: eleven adversarial point sets (exact radius across a cell boundary, both points on the boundary, diagonal across a corner, coincident duplicates, a single item, zero-size pads at and just past `tol`, negative coordinates, one big pad spanning several cells, mixed radii, and `tol=0` with every radius 0) plus every net of both tracked boards. Shrinking the neighbourhood from 3x3 to the point's own cell now fails five ways; before the reference test it passed everything in the tree. A degenerate `cell` of 0 used to raise ZeroDivisionError and is now guarded. Both were private to `net_forensics`, and check_reachability's auto-widen reached across and imported `net_forensics._components` by name. `_path` does not put py_tools on sys.path, so that ImportError would have left as exit 1, which in check_reachability is the CAGED geometry verdict and re-enters placement, discarding every routed board. The pair scan is now bucketed on a uniform grid at the largest join radius instead of an all-pairs walk over every endpoint; the join rule and the resulting islands are unchanged, verified identical for all 85 nets of tigard_placed and all 83 of splitflap_driver. `net_forensics` also had two copies of the island-to-island gap loop, one printing and one building a dict; there is one now.

`placement/reachability.py` (library)

- `widest_path(..., return_throat=True)` returns the throat cell beside the width; the default call is unchanged.
- `Reachability` gains `throat_cell`, `clearance_mm`, `near`, the `throat`, `gap_mm`, `gap_need_mm` and `binding_clearances` properties, and `defect_record()`. `pad_reachability` fills them, and clears the throat on a wide-open result.
- `nearest_foreign(pcb, x, y, net_id, layers, net_clearances, base_clearance)`: the two nearest foreign pads, vias and segments to a point, nearest first, by edge distance. The count and the radius are module constants (`NEAR_K`, `NEAR_RADIUS_MM`) rather than never-varied arguments; the old `radius_mm=2.0` read as a knob and was the cause of the dropped-blocker defect.
- `defect_record(..., instrument=...)` is passed by its caller instead of relying on its default, so the record names the tool that wrote it rather than a string that happens to still be right.

`placement/routability.py` (library)

- `relief_move(rect_a, rect_b, need_mm, limit_mm)`: how far rect B must move in each axis direction for the A-B gap to reach `need_mm`, by bisection on `rect_gap`. A direction that cannot reach the need within `limit_mm` is omitted.

## Files

- `py_tools/check_reachability.py` (+359/-13): `--json-out`, `--defect-json`, auto-widen with a coarse verdict, `board_floor` floors wrapped at the fab floor, throat text, `_relief_for`, notices on stderr.
- `py_tools/net_forensics.py` (+72/-58): `net_data`, `--json-out`, the shared island walk, one gap implementation.
- `py_router/list_nets.py` (+100): `net_islands`, `island_gap`.
- `py_placer/placement/reachability.py` (+395/-8): throat return, the new fields and properties, `defect_record`, `nearest_foreign`, wide-open clearing.
- `py_placer/placement/routability.py` (+46): `relief_move`.
- `tests/test_defect_record_reachability.py` (new, 570 lines, 81 checks): synthetic wall fixtures. The throat lies in the slot; `gap_mm` equals `bottleneck + the two blocking clearances` and is within one raster step of the analytic slot width whether the walls are on the base clearance or on a 0.3 class; the blockers are named by REF.PAD; every pre-existing `to_dict` key survives; the record's shape, and that it is not produced for PASSABLE or NO-TARGET; the wide-open case (no throat, no near, no gap, no record); a 5 mm wall is still named at its edge distance; a B.Cu throat names no F.Cu copper; and `relief_move` on the run-20 geometry (0.409478 mm gap, 0.0422 mm eastward relief) plus overlapping, infeasible and already-clear pairs. 64 checks. A seed ringed by copper is the severest caged result and still writes a record: there `gap_mm` is null, so `derived_from` is null too rather than a sentence about a blocker that was never found. The fixture keeps its partner pad inside the view on purpose, because a NO-TARGET result writes no record at all and every assertion would then pass against an empty dict.
- `tests/test_run23_reachability_widen.py` (new, 586 lines, 17 tests): subprocess and in-process tests on the tracked `tests/fixtures/run23/tigard_placed.kicad_pcb` and `kicad_files/splitflap_driver.kicad_pcb`. Auto-widen on U3.30 returns PASSABLE with the island at 20.27 mm and its notices on stderr; `--json` stdout parses as JSON at character 0; a coarsened step is declared coarse; an explicit `--view` is not widened; splitflap U1.1 (wide open) carries no throat in the JSON or the text and writes no defect record; sub-fab floors are pinned from both the CLI and a staged `.kicad_pro`; the auto-widen runs with `net_forensics` made unimportable; the help text no longer promises a banner this tool does not print; `net_forensics --json-out` reports /TXLED's two islands and the 20.267 mm gap, and does not walk the islands twice on a text-only run. 11 tests.
- `tests/test_reachability.py` (+8/-2): the fixture's stand-in footprint gains a `reference`, which the real `Footprint` always has. It got away without one only while blockers were measured to their centres, because nothing in that fixture was within 2 mm of the throat that way.

Both tests depend only on files already on main (`tests/synth.py`, `placement.legality.rect_gap`, `list_nets.board_floor`, `fab_tiers`, the two boards above).

## Testing

All run in the foreground on Windows, `python3 -X utf8`:

- `python3 -m py_compile` on all eight files: exit 0.
- `tests/test_defect_record_reachability.py`: 81 passed, 0 failed, exit 0.
- `tests/test_run23_reachability_widen.py` (with `-W error::ResourceWarning`): 17 tests OK in about 130 s, exit 0.
- `tests/test_reachability.py` (already on main): ALL PASS, exit 0.
- `tests/test_board_floors.py`, `tests/test_krt_capabilities.py`, `tests/test_run12_tools.py` (the other tests that touch `list_nets`): OK.

Every fix above was proved by applying the mutation that reverts it and watching the named test fail. Round one: the gap conversion (3 checks fail, gap 1.0 becomes 0.5), the throat layer (2 fail, F.Cu pad named at a B.Cu throat), edge distances (6 fail, `near` empty), the fab wrap (2 tests), stderr hygiene, the coarse flag, the banner sentence, the double island walk, the flag rename, the sibling import (ImportError out of `main`), and the unused parameters. Round two: the layer predicate (`*.Cu` walls name nobody), the bucket neighbourhood (5 failures against the all-pairs reference, where before it passed every test in the tree), the degenerate cell size (ZeroDivisionError), the fab tier flags, the per-net clearance wrap measured by its EFFECT rather than its message (via_legal_fraction 0.3707 against 0.3298), the rect tilt (262 of 3600 cells disagree with the rasteriser), `gap_blockers` (3 checks), the second island walk (2 walks for one net), and the `declared -> pinned` report line.

Smoke runs:

- `py_tools/check_reachability.py kicad_files/splitflap_driver.kicad_pcb --pad U1.1 --json-out r.json --defect-json d.json`: exit 0. Auto-widened (nearest island 10.18 mm, step 0.01408, grid 1200x920), verdict PASSABLE, `wide_open` true, `throat` null, `near` [], `gap_mm` null, `auto_widened.step_mm == step_mm`, `auto_widened.coarse` false; no d.json written, stderr says why.
- The same board with `--json`: stdout parses as JSON with nothing before it.
- `py_tools/net_forensics.py kicad_files/splitflap_driver.kicad_pcb --nets GND --json-out nf.json`: exit 0, well-formed JSON, 59 islands, gap 51.806 mm.

`git diff --numstat upstream/main` is hunks only (0 CR bytes in every committed blob). No `deadline`, `time.time` or `perf_counter` anywhere in the diff; the #686 test had a wall-clock assertion and it is gone.
