### PR TITLE
review instruments: the review sheet, defect panels, pocket census, connector class (replaces #683)

### DIFF
--- a/docs/floorplan-intent.md
+++ b/docs/floorplan-intent.md
@@ -129,7 +129,7 @@ for it, and the reason is printed:
 | `zone_side` | a member is on the other face | `legality.footprint_side` |
 | `zone_exclusive` | a non-member intrudes on a reserved zone | `rect_overlap_area` |
 | `keepout` | any part enters a keep-out, unless in `allow` | courtyard **and** through-hole rect |
-| `edge_connector` | overhang outside `[min,max]`, or the wrong edge | `BoardOutlineGate.rect_outside_amount` |
+| `edge_connector` | overhang outside `[min,max]`, or the wrong edge; a `connector_affinity` entry seated more than 3 mm from every edge fires at **warn** whatever the configured severity | `BoardOutlineGate.rect_outside_amount`, `edge_clearance` |
 | `decap_distance` | a decoupling cap is too far from its own IC | `groups.decap_tethers` |
 | `must_lock` | a declared-critical part is not locked in the file | `parser.extract_locked_refs` |
 | `legality` | overlap or off-board parts exceed a budget | `QuenchState.legality_metrics` |
@@ -324,3 +324,39 @@ This is the same spatial incoherence that makes sheet blocks useless for
 Parts already overhanging the outline are recorded as `edge_connectors` by
 observation, which is what stops `oob_count` reporting a card edge or USB shell
 as a defect forever.
+
+With `--declare-classes`, connector-family parts that claim no edge (headers,
+JST, terminal blocks; `part_class` calls them `connector_affinity`) are also
+recorded, with `"class": "connector_affinity"` and **no `edge`** (naming one
+would be an invention). The grade then flags such a part seated more than
+3 mm from every edge at `warn` only, because legitimately interior connectors
+exist; write `max_setback_mm` or `edge` on the entry to make it a real claim
+at the configured severity.
+
+These entries are **declarations, not seat claims**, and the placement engines
+do not act on them. `edge_connectors` therefore holds two populations, and
+`Intent.edge_claims()` is the split: it drops `connector_affinity` and is what
+`place_seed` (which LOCKS edge refs for its polish quench), `place_reconstruct`
+(banded off-outline allowance, exchange-stage exclusion) and
+`reconstruct.classify` (the anchor tier) read. The `edge_connector` **rule**
+reads the whole key, because flagging an interior pose is the entry's only
+purpose. Writing `max_setback_mm` or `edge` on an entry changes its class-based
+severity, not its membership -- to hand a part the edge-part treatment in the
+engines, declare it with an edge class.
+
+The `overlap_area` budget is **withheld** when the emitting board carries a
+blocking body pair, or an unwaived courtyard interpenetration past the
+blocking floors: baking the number would bless the board it was measured on.
+`context.budget_withheld` names each withheld key and why, so a reader can tell
+"withheld" from "forgot"; declare the budget by hand if the overlap is by
+design.
+
+A withheld key is **abstained at grade time, not passed**. `check_floorplan
+--intent` reads `context.budget_withheld`, reports every withheld key that the
+intent does not also declare under `N legality budget key(s) NOT DERIVABLE --
+not graded, not passed`, and carries them as `budget_abstained` in `--json` and
+as `budget_abstained` / `budget_abstained_keys` in `JSON_SUMMARY`. When the
+whole budget is empty the `legality` rule does not run at all, and its skip
+reason names the withholding rather than saying only "the intent declares no
+legality_budget". Declaring the key by hand overrides the note: a declared
+budget is graded.

--- a/py_placer/place_reconstruct.py
+++ b/py_placer/place_reconstruct.py
@@ -219,7 +219,11 @@ Examples:
     # set is part of the run's record.
     edge_bands = {}
     if intent is not None:
-        for c in intent.edge_connectors:
+        # edge_claims(): a connector_affinity entry declares a class, not a
+        # band. Reading the raw key gave every generic header the 2.0mm
+        # default allowance below, which is an off-outline licence nobody
+        # asked for.
+        for c in intent.edge_claims():
             if c['ref'] not in state.parts:
                 continue
             # EVERY banded entry keeps its allowance, suspect or not: with
@@ -317,7 +321,10 @@ Examples:
     # proxy would anchor them to their possibly-misplaced partners).
     edge_pref = {}
     if intent is not None:
-        for c in intent.edge_connectors:
+        # edge_claims(): the receptacle filter below already excluded the
+        # weak class, but every engine read goes through the one split so a
+        # future edit to this filter cannot re-open it.
+        for c in intent.edge_claims():
             # Receptacles ONLY (run-5): the edge metric is the right
             # objective for a part whose class says the mating face must
             # reach the edge. An edge-less ACTUATOR entry (a suspect
@@ -341,7 +348,7 @@ Examples:
     # under investigation, not a seat.
     excl_x = set(tiers.locked) | set(tiers.zero_net)
     if intent is not None:
-        for c in intent.edge_connectors:
+        for c in intent.edge_claims():   # seat claims only; see edge_claims
             ref = c['ref']
             if ref not in state.parts:
                 continue

--- a/py_placer/place_seed.py
+++ b/py_placer/place_seed.py
@@ -426,7 +426,9 @@ Examples:
         # polished by the objective the later steps rank with. Locks ride in
         # from the file (must_lock was just stamped); edge connectors are
         # locked per-call so the polish cannot walk them off their band.
-        edge_refs = [c['ref'] for c in intent.edge_connectors]
+        # edge_claims(), not edge_connectors: a connector_affinity entry
+        # makes no seat claim and must not be locked out of the polish.
+        edge_refs = [c['ref'] for c in intent.edge_claims()]
         placements = quench(
             pcb_seeded, pcb_file=args.output_file,
             max_displacement=args.max_displacement,

--- a/py_placer/placement/floorplan.py
+++ b/py_placer/placement/floorplan.py
@@ -161,6 +161,39 @@ class Intent:
     # NEVER auto-emitted (a waiver derived from the board under repair would
     # be the budget self-bless bug again); consumed by grade_body_overlap.
     overlap_waivers: Tuple[Dict[str, object], ...] = ()
+    # Run-23: budget keys `emit_intent` deliberately did NOT bake, and why
+    # ({key: reason}). Emitted into `context.budget_withheld`; carried here so
+    # the GRADE can say "not derivable" instead of grading nothing and
+    # printing 0 errors. Hand-written intents leave it empty, which is the
+    # honest answer for a budget a human simply chose not to declare.
+    budget_withheld: Dict[str, str] = field(default_factory=dict)
+
+    def edge_claims(self) -> Tuple[Dict[str, object], ...]:
+        """The `edge_connectors` entries that actually CLAIM AN EDGE.
+
+        The wire key holds two populations. An `edge_receptacle` /
+        `edge_actuator` entry says "this part's mating face belongs at the
+        boundary", and the placement engines act on that: place_seed LOCKS it
+        during the polish quench, place_reconstruct grants it a banded
+        out-of-outline allowance and excludes it from the exchange stage, and
+        reconstruct.classify forces it into the anchor tier. A
+        `connector_affinity` entry (run-23) says only "this is a
+        connector-family part with NO edge claim" -- it exists so a mid-board
+        header stops being invisible to `rule_edge_connector`, which flags an
+        interior pose at WARN.
+
+        Handing the second population to the first's consumers would silently
+        change placement: on tigard_placed that is 6 extra refs locked in the
+        seed quench, given a 2.0mm off-outline allowance each and pinned as
+        anchors -- for parts nobody said anything about. So the engines read
+        THIS, and the rule reads `edge_connectors`.
+
+        The split lives here, in one place, rather than as a filter repeated
+        at every consumer: a filter that must be remembered is a filter that
+        will be forgotten at the next call site.
+        """
+        return tuple(c for c in self.edge_connectors
+                     if c.get('class') != 'connector_affinity')
 
     def waiver_pairs(self) -> Tuple[Tuple[str, str], ...]:
         out = []
@@ -390,6 +423,9 @@ def intent_from_dict(raw: Dict, source_path: str = '') -> Intent:
         severity={str(k): str(v) for k, v in severity.items()},
         source_path=source_path,
         overlap_waivers=tuple(waivers),
+        budget_withheld={
+            str(k): str(v) for k, v in
+            ((raw.get('context') or {}).get('budget_withheld') or {}).items()},
     )
 
 
@@ -878,19 +914,32 @@ def rule_edge_connector(ctx) -> Iterator[Violation]:
         # a violation -- which is also what makes a misplaced edge part
         # CHARGEABLE by place_seed --repair.
         setback = c.get('max_setback_mm')
+        _sev = ctx.sev('edge_connector')
         if setback is None and c.get('class') == 'edge_receptacle':
             from .part_class import SEAT_TOL_MM
             setback = SEAT_TOL_MM
+        if setback is None and c.get('class') == 'connector_affinity':
+            # run-23: the weak class. An INTERIOR generic connector is a flag
+            # for the boundary review, never an error -- legitimately-interior
+            # connectors exist (tigard J7), so this fires at WARN whatever the
+            # rule's configured severity. An author upgrades by writing
+            # max_setback_mm (then the configured severity applies) or edge.
+            from .part_class import INTERIOR_AFFINITY_MM
+            setback = INTERIOR_AFFINITY_MM
+            _sev = WARN
         if setback is not None and amount <= legality.EPS:
             clr = ctx.gate.edge_clearance(part.rect)
             if clr > float(setback) + legality.EPS:
                 yield Violation(
-                    rule='edge_connector', severity=ctx.sev('edge_connector'),
+                    rule='edge_connector', severity=_sev,
                     ref=ref,
                     message=(f"{ref} is an edge part seated {clr:.2f}mm from "
                              f"the nearest edge with no overhang (seat "
-                             f"tolerance {float(setback):.2f}mm) -- the "
-                             f"mating face cannot reach the edge"),
+                             f"tolerance {float(setback):.2f}mm) -- "
+                             + ("a plug may not reach it; disposition in the "
+                                "boundary review or declare max_setback_mm"
+                                if _sev == WARN else
+                                "the mating face cannot reach the edge")),
                     measured={'edge_clearance_mm': round(clr, 4)},
                     expected={'max_setback_mm': float(setback)})
 
@@ -964,6 +1013,11 @@ def rule_legality(ctx) -> Iterator[Violation]:
                        ('oob_count', 'parts leaving the board outline'),
                        ('oob_amount', 'total off-board overhang (mm)')):
         if key not in budget:
+            # Not graded. When the emitter WITHHELD it (a blocking body pair
+            # or an unwaived courtyard interpenetration on the board it was
+            # emitted from), the run must not look like a pass on this
+            # channel: `budget_abstained` on the result carries it, and both
+            # the report and the summary print it. See grade().
             continue
         got = ctx.legality.get(key)
         if got is None:
@@ -1043,6 +1097,11 @@ class GradeResult:
     rules_run: Tuple[str, ...]
     rules_skipped: Dict[str, str]
     n_footprints: int
+    # Run-23: budget keys the intent could NOT derive, {key: reason}. An
+    # abstention, not a pass -- the channel was never graded. Before this the
+    # withheld key was a bare `continue` in rule_legality and the run printed
+    # "PASS: N rules ran, no violations" with overlap unmeasured.
+    budget_abstained: Dict[str, str] = field(default_factory=dict)
 
     @property
     def errors(self) -> List[Violation]:
@@ -1106,9 +1165,21 @@ def grade(intent: Intent, pcb_data, pcb_file: str, *,
     violations = list(validate_intent(intent)) + list(block_problems)
     ran: List[str] = []
     skipped: Dict[str, str] = {}
+    # Budget keys the emitter withheld and that are therefore NOT graded.
+    # A key present in the budget was declared (by hand, deliberately) and
+    # overrides its withholding note.
+    abstained = {str(k): str(v)
+                 for k, v in (intent.budget_withheld or {}).items()
+                 if k not in (intent.legality_budget or {})}
     for name, fn in RULES:
         if not _wants(intent, name):
-            skipped[name] = _SKIP_REASON.get(name, 'not requested')
+            reason = _SKIP_REASON.get(name, 'not requested')
+            if name == 'legality' and abstained:
+                # "declares no legality_budget" is true but reads as "nobody
+                # wanted one". Say that the emitter refused to derive it.
+                reason += ('; the emitter WITHHELD ' + ', '.join(
+                    f'{k} ({v})' for k, v in sorted(abstained.items())))
+            skipped[name] = reason
             continue
         ran.append(name)
         violations.extend(fn(ctx))
@@ -1158,6 +1229,7 @@ def grade(intent: Intent, pcb_data, pcb_file: str, *,
                'segments': st.segments, 'vias': st.vias},
         health=health_out,
         rules_run=tuple(ran), rules_skipped=skipped,
+        budget_abstained=abstained,
         n_footprints=len(pcb_data.footprints))
 
 
@@ -1428,6 +1500,21 @@ def emit_intent(pcb_data, pcb_file: str, *,
             if fp is None:
                 continue
             pc = classify_part(fp, ref)
+            if pc.name == 'connector_affinity':
+                # run-23: generic connectors (headers, JST, terminal blocks)
+                # had NO class, so J2/J5/J6/J7 seated mid-board and no
+                # instrument could say so. Declared WITHOUT an edge (the
+                # run-4 rule stands: naming one would be an invention) and
+                # with no band ceiling; the grade flags an INTERIOR pose at
+                # ADVISORY severity only. A human upgrades by adding `edge`
+                # or `max_setback_mm` to the entry.
+                clr = state.edge_gate.edge_clearance(parts[ref].rect)
+                conns.append({
+                    'ref': ref, 'class': pc.name, 'source': 'auto-class',
+                    'overhang_mm': {'min': 0.0},
+                    'note': (f'connector-family part, no edge claim; '
+                             f'measured {clr:.2f}mm from the nearest edge')})
+                continue
             if pc.name != 'edge_receptacle':
                 # actuators make no claim unless they actually overhang
                 # (handled above); nothing else is an edge class.
@@ -1453,15 +1540,37 @@ def emit_intent(pcb_data, pcb_file: str, *,
     # (the emitted 6.112 budget graded the C14-on-R14 board clean). The
     # repaired board re-emits the honest number; meanwhile board_score's
     # `assembly` component grades independently of any budget.
+    # Run-23 extends the same withholding to unwaived COURTYARD interpene-
+    # trations past the blocking floors: run 23's intent was emitted from a
+    # mid-repair board carrying J4 0.90mm inside U6, baked overlap_area
+    # 30.1085, and the final board's 26.302 then graded PASS -- the budget
+    # blessed the board it was emitted from. A board with such pairs gets no
+    # auto overlap budget; declare one by hand (visibly) if the overlap is
+    # by design. Cost, measured: 5 of 34 corpus boards carry by-design
+    # censuses and lose the auto-budget too -- the legality rule then
+    # ABSTAINS (not-derivable) on them, which is honest degradation; their
+    # independent coverage is check_assembly's moved-vs-baseline gate.
     try:
         from placement.legality import grade_body_overlap
-        _body_blocking = grade_body_overlap(
-            pcb_data, state.clearance, pcb_file=pcb_file)['blocking']
+        _g_overlap = grade_body_overlap(
+            pcb_data, state.clearance, pcb_file=pcb_file)
+        _body_blocking = _g_overlap['blocking']
+        _courtyard_blocking = _g_overlap.get('courtyard_blocking', 0)
     except Exception:
         _body_blocking = 0
+        _courtyard_blocking = 0
     _suspects = any('SUSPECT' in (c.get('note') or '') for c in conns)
     _budget = {}
-    if not _body_blocking:
+    _withheld = {}
+    if _body_blocking:
+        _withheld['overlap_area'] = (f'{_body_blocking} blocking body '
+                                     f'pair(s) on the emitting board (run-6)')
+    elif _courtyard_blocking:
+        _withheld['overlap_area'] = (
+            f'{_courtyard_blocking} unwaived courtyard interpenetration(s) '
+            f'past the blocking floors on the emitting board (run-23): an '
+            f'auto-budget would bless them')
+    else:
         _budget['overlap_area'] = _ceil4(float(leg['overlap_area']))
     if not _suspects:
         _budget['oob_count'] = int(leg['oob_count'])
@@ -1499,6 +1608,10 @@ def emit_intent(pcb_data, pcb_file: str, *,
             'note': ('read-only, describing the board as it is. The outline is '
                      'not editable by this toolchain: size, cutouts and slots '
                      'are mechanical decisions the user owns'),
+            # Budget keys deliberately NOT baked, and why -- so a reader of
+            # the intent can tell "withheld" from "forgot" (empty when
+            # nothing was withheld).
+            'budget_withheld': _withheld,
             'cutouts': [[[round(x, 3), round(y, 3)] for x, y in ring]
                         for ring in (pcb_data.board_info.board_cutouts or [])],
             'edge_contours': len(
@@ -1542,6 +1655,11 @@ def format_text(r: GradeResult) -> str:
         for v in r.violations:
             tag = 'ERROR' if v.severity == ERROR else 'warn '
             lines.append(f"    [{tag}] {v.rule}: {v.message}")
+    if r.budget_abstained:
+        lines.append(f"  {len(r.budget_abstained)} legality budget key(s) NOT "
+                     f"DERIVABLE -- not graded, not passed:")
+        for key in sorted(r.budget_abstained):
+            lines.append(f"    - {key}: {r.budget_abstained[key]}")
     if r.rules_skipped:
         lines.append(f"  {len(r.rules_skipped)} rule(s) did not run:")
         for name in sorted(r.rules_skipped):
@@ -1641,6 +1759,7 @@ def to_json(r: GradeResult) -> Dict:
         'health': r.health,
         'rules_run': list(r.rules_run),
         'rules_skipped': r.rules_skipped,
+        'budget_abstained': r.budget_abstained,
         'n_footprints': r.n_footprints,
     }
 
@@ -1660,6 +1779,9 @@ def summary(r: GradeResult) -> Dict:
         'violations_by_rule': by_rule,
         'rules_run': len(r.rules_run),
         'rules_skipped': len(r.rules_skipped),
+        # Not a violation count and not a pass: channels nothing graded.
+        'budget_abstained': len(r.budget_abstained),
+        'budget_abstained_keys': sorted(r.budget_abstained),
         'blocks': len(r.blocks),
         'blocks_resolved': sum(1 for v in r.blocks.values() if v),
         'parts_covered': len({ref for v in r.blocks.values() for ref in v}),

--- a/py_placer/placement/reconstruct.py
+++ b/py_placer/placement/reconstruct.py
@@ -306,7 +306,9 @@ def classify(state, intent=None, anchor_extent='auto') -> Tiers:
     else:
         thr = float(anchor_extent)
     t.threshold = round(thr, 3)
-    edge_refs = ({c['ref'] for c in intent.edge_connectors}
+    # edge_claims(): forcing a connector_affinity part into the anchor tier
+    # would let a class declaration reshape the reconstruction.
+    edge_refs = ({c['ref'] for c in intent.edge_claims()}
                  if intent is not None else set())
     t.edge = edge_refs & set(state.parts)   # run-4 F2: kept, not discarded
     t.anchors = {r for r in free

--- a/py_placer/placement/seeder.py
+++ b/py_placer/placement/seeder.py
@@ -988,8 +988,12 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
                 rng.uniform(-TARGET_JITTER_MM, TARGET_JITTER_MM))
 
     # ---- 1. edge connectors: spec geometry, no legality gate ---------------
+    # edge_claims(), not the raw key: a connector_affinity entry declares a
+    # class and makes no seat claim, so stage 1 has nothing to seat it from.
+    # Reading the raw key printed "edge connector J7: no edge declared" at a
+    # part that never claimed one.
     by_edge: Dict[str, List[Dict]] = {}
-    for c in intent.edge_connectors:
+    for c in intent.edge_claims():
         if c['ref'] not in state.parts:
             notes.append(f"edge connector {c['ref']} is not on this board")
         elif c['ref'] in unplaced:
@@ -1346,7 +1350,7 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
         # no `edge` key is not protected, consistent with stage 1: it seats
         # no such entry ("no edge, no seat") and leaves it to the ordinary
         # stages, so it is an ordinary part here too.
-        immovable = set(lock_refs) | {c['ref'] for c in intent.edge_connectors
+        immovable = set(lock_refs) | {c['ref'] for c in intent.edge_claims()
                                       if c.get('edge')}
         still: List[str] = []
         # DEDUPED, and placed-aware. A zone member that fails its zone stage
@@ -1587,7 +1591,7 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
     # EXCESS past the band, not nothing at all -- see the note there.
     edge_band: Dict[str, float] = {}
     if intent:
-        for _c in intent.edge_connectors:
+        for _c in intent.edge_claims():   # seat claims only; see edge_claims
             edge_band[_c['ref']] = float(
                 (_c.get('overhang_mm') or {}).get('max') or 0.0)
 
@@ -1807,7 +1811,18 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
                  if r not in unrepairable]
 
     # ---- seat violators, worst first, escalating cap -----------------------
-    edge_entry = ({c['ref']: c for c in intent.edge_connectors}
+    # edge_claims(), and this one is a REGRESSION FIX, not tidiness. The
+    # dispatch below short-circuits every entry in this map that carries no
+    # `edge` into a refusal, so reading the raw key took the run-23
+    # connector_affinity declarations -- which never carry an edge, by
+    # design -- straight out of the ordinary `_try_place` loop. Measured on
+    # tests/fixtures/run23/tigard_damaged.kicad_pcb with its own
+    # --declare-classes intent: J5, J6 and J7 were refused with "declared
+    # edge part misplaced, but no edge is declared" (which also mislabels
+    # them), where upstream main tries them like any other violator and
+    # reports the honest "no legal pose within any cap". A declaration must
+    # not remove a part from repair.
+    edge_entry = ({c['ref']: c for c in intent.edge_claims()}
                   if intent else {})
     repaired: List[str] = []
     failed: List[str] = []
@@ -2174,7 +2189,13 @@ def reseat_scope(pcb_data, pcb_file: str, intent, *,
     # ---- edge bands: the scope forfeits its own ----------------------------
     if edge_bands is None:
         edge_bands = {}
-        for c in intent.edge_connectors:
+        # edge_claims(): the `or 2.0` default below is an off-outline
+        # allowance for a part whose seat overhangs by design. A
+        # connector_affinity entry carries `overhang_mm` with only a `min`,
+        # so the raw key handed every generic header 2.0mm of licence in the
+        # gate tuple -- the exact trap test_run23_connector_affinity's
+        # edge-band test names.
+        for c in intent.edge_claims():
             if c['ref'] in state.parts:
                 band = c.get('overhang_mm') or {}
                 edge_bands[c['ref']] = float(band.get('max') or 2.0)
@@ -2182,8 +2203,21 @@ def reseat_scope(pcb_data, pcb_file: str, intent, *,
 
     dropped = {}
     keep = []
-    for c in intent.edge_connectors:
-        if c['ref'] in scope:
+    # Only an edge CLAIM has a band to forfeit, and only a claim is seated by
+    # stage 1 without a legality gate (the 30km probe below). A
+    # connector_affinity entry declares a class and no band, so it rides
+    # through into `intent2` untouched rather than being reported as a
+    # dropped declaration it never made.
+    _claims = {c['ref'] for c in intent.edge_claims()}
+    # The raw key here is deliberate: `intent2` below must stay a faithful
+    # copy of the declaration list minus only the bands the scope forfeits,
+    # and filtering it would silently strip every connector_affinity entry
+    # from the sub-intent. Every OTHER engine read goes through
+    # edge_claims(); the marker on the next line is what the source guard in
+    # tests/test_run23_connector_affinity.py accepts, and it asserts this is
+    # the ONLY one in the tree.
+    for c in intent.edge_connectors:   # edge-claims-exempt: faithful copy
+        if c['ref'] in scope and c['ref'] in _claims:
             dropped[c['ref']] = float((c.get('overhang_mm') or {}).get('max')
                                       or 0.0)
         else:

--- a/py_router/congestion_field.py
+++ b/py_router/congestion_field.py
@@ -167,22 +167,31 @@ def congestion2_knobs():
     return dict(env_knobs.CONGESTION2)
 
 
-def build_congestion2(pcb_data, config, net_ids_to_route,
-                      extra_demand_points=None):
-    """Precompute bins {(bx,by): (free_area_mm2, owners frozenset)} plus
-    per-net terminal coords. Returns None when disabled.
+def congestion_bins(pcb_data, net_ids, num_layers, bin_mm,
+                    extra_demand_points=None):
+    """THE demand/capacity census: {(bx,by): (free_area_mm2, owners)} plus
+    per-net terminal coords, and the BIN IT ACTUALLY USED.
+
+    That third return value is not decoration: `bin_mm` is floored at 0.25,
+    and a caller that builds coordinates from its own requested value puts
+    the report on the wrong part of the board (check_pockets at --bin 0.1
+    named windows ~39mm from the ones it measured). Ask, do not assume.
+
+    One definition, two consumers (run-23): `build_congestion2` attaches it
+    as an A* cost (env-gated), and `check_pockets.py` reports it PRE-ROUTE
+    at the placement->routing handoff -- because every per-net gate
+    (check_channels, check_reachability) passed run 23's board while two
+    nets died in one bin whose demand/free-area no instrument ever printed.
 
     extra_demand_points (#589): optional {net_id: [(x_mm, y_mm), ...]} of
     predicted-corridor samples (the global plan's rough paths) folded into
     each net's terminal set -- the net then claims demand along its whole
     predicted path instead of only at its endpoints, and its own exemption
-    disks follow the corridor (owner-exempt by construction)."""
-    k = congestion2_knobs()
-    if k['cost'] <= 0:
-        return None
-    bin_mm = max(0.25, k['bin'])
-    num_layers = max(1, len(config.layers))
-    to_route = set(net_ids_to_route)
+    disks follow the corridor (owner-exempt by construction).
+    """
+    bin_mm = max(0.25, bin_mm)
+    num_layers = max(1, num_layers)
+    to_route = set(net_ids)
 
     copper = {}
     for s in pcb_data.segments:
@@ -211,8 +220,6 @@ def build_congestion2(pcb_data, config, net_ids_to_route,
         terminals[nid] = pts
         for (x, y) in pts:
             owners.setdefault((int(x // bin_mm), int(y // bin_mm)), set()).add(nid)
-    for p in getattr(pcb_data, 'pads', []) or []:
-        pass  # pad copper folded via per-net pads below
     for nid, plist in getattr(pcb_data, 'pads_by_net', {}).items():
         for p in plist:
             b = (int(p.global_x // bin_mm), int(p.global_y // bin_mm))
@@ -223,6 +230,22 @@ def build_congestion2(pcb_data, config, net_ids_to_route,
         used = copper.get(b, 0.0)
         free = max(bin_area_total * 0.05, bin_area_total - used)
         bins[b] = (free, frozenset(own))
+    return bins, terminals, bin_mm
+
+
+def build_congestion2(pcb_data, config, net_ids_to_route,
+                      extra_demand_points=None):
+    """Precompute bins {(bx,by): (free_area_mm2, owners frozenset)} plus
+    per-net terminal coords. Returns None when disabled.
+
+    extra_demand_points (#589): see `congestion_bins` -- forwarded through."""
+    k = congestion2_knobs()
+    if k['cost'] <= 0:
+        return None
+    bin_mm = max(0.25, k['bin'])
+    bins, terminals, bin_mm = congestion_bins(
+        pcb_data, net_ids_to_route, len(config.layers), bin_mm,
+        extra_demand_points=extra_demand_points)
     n_hot = sum(1 for b, (fa, ow) in bins.items()
                 if len(ow) / fa > k['thresh'])
     print(f"Congestion2 field: {len(bins)} demand bins, {n_hot} above "

--- a/py_tools/check_pockets.py
+++ b/py_tools/check_pockets.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Pocket census: windowed routing demand vs free copper area (run-23).
+
+Every per-net handoff instrument passed run 23's board -- check_channels: 0
+starved faces; check_reachability: every failing pad PASSABLE copper-free;
+crossings below the damaged baseline -- and two nets then died across ~20
+route laps in ONE pocket (the RN7/U6/J2 region), where committed copper
+finally wrapped RN7 at 0.095mm against a 0.45mm corridor need. Per-net tests
+are blind to SIMULTANEOUS routability by construction; this tool reports the
+aggregate: the board binned at --bin mm, each bin's distinct demanding nets
+against its free area, top offenders named with their nets and parts.
+
+REPORT-ONLY, deliberately: a new metric mis-thresholded is noise, so nothing
+gates on it this sprint. The boundary review (the blind-first visual gate)
+must DISPOSITION every window this prints -- in writing, against a named
+plan -- or refuse the handoff itself.
+
+    python3 -X utf8 py_tools/check_pockets.py <board> [--nets GLOB...]
+        [--bin MM] [--top N] [--threshold NETS_PER_MM2] [--json PATH]
+
+Exit codes: 0 always (report), 2 usage/load error.
+"""
+import _path  # noqa: F401  (py_tools -> py_router/py_placer on sys.path)
+
+import argparse
+import json
+import sys
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description="Windowed demand/free-area census of a board.")
+    p.add_argument("board")
+    p.add_argument("--nets", nargs='+', default=['*'], metavar='GLOB',
+                   help="the DEMAND set (route.py glob syntax, '!' excludes). "
+                        "Default: every net. Pass the set the route step will "
+                        "carry so the census asks the same question")
+    p.add_argument("--bin", type=float, default=2.0, metavar='MM',
+                   help="window size (default 2.0mm -- about three 0.15/0.15 "
+                        "lanes plus a via, the scale run 23's pocket failed "
+                        "at; the router's own congestion cost uses 1.0). "
+                        "FLOORED AT 0.25mm, which is the census's own floor; "
+                        "a smaller value is reported as the floor it was "
+                        "raised to, never silently accepted")
+    p.add_argument("--top", type=int, default=8, metavar='N',
+                   help="how many windows to print (default 8)")
+    p.add_argument("--threshold", type=float, default=None,
+                   metavar='NETS_PER_MM2',
+                   help="report only windows above this demand/free-area "
+                        "ratio. Default: none -- print the top N whatever "
+                        "their ratio, because an absolute threshold is "
+                        "exactly what this tool is too young to own")
+    p.add_argument("--json", default=None, metavar='PATH',
+                   help="write the full census as JSON")
+    args = p.parse_args()
+
+    from congestion_field import congestion_bins
+    from kicad_parser import parse_kicad_pcb
+    from net_queries import expand_net_patterns
+
+    try:
+        pcb = parse_kicad_pcb(args.board)
+    except Exception as exc:
+        print(f"cannot parse {args.board}: {exc}", file=sys.stderr)
+        return 2
+
+    names = set(expand_net_patterns(pcb, args.nets))
+    name_by_id = {n.net_id: n.name for n in pcb.nets.values()}
+    ids = [nid for nid, n in pcb.nets.items() if n.name in names]
+    layers = list(getattr(pcb.board_info, 'copper_layers', []) or []) or ['F.Cu']
+
+    # The corridor arithmetic a reader needs beside the ratios: one lane =
+    # track + 2*clearance at the board's own floors (the 0.45mm number run
+    # 23's forensics measured RN7's cage against).
+    try:
+        from list_nets import board_floor
+        import routing_defaults as defaults
+        clr, _s1 = board_floor(args.board, 'clearance', None,
+                               defaults.CLEARANCE)
+        trk, _s2 = board_floor(args.board, 'track_width', None,
+                               defaults.TRACK_WIDTH)
+    except Exception:                                           # noqa: BLE001
+        clr = trk = None
+
+    # THE EFFECTIVE BIN, not the requested one. `congestion_bins` floors its
+    # bin at 0.25mm, so a smaller --bin binned at 0.25 while this tool built
+    # its window rectangles from the requested value: at --bin 0.1 the rows
+    # read [25.9,21.3]-[26.0,21.4] for a window whose true left edge is
+    # 64.75mm. Every coordinate in the report -- printed and JSON -- named a
+    # place on the board where nothing was measured. Ask the census what it
+    # actually used and build the rectangles from that.
+    bins, _terminals, bin_mm = congestion_bins(pcb, ids, len(layers), args.bin)
+    if abs(bin_mm - args.bin) > 1e-9:
+        print(f"  --bin {args.bin:g}mm is below the census floor; binned at "
+              f"{bin_mm:g}mm and reported at {bin_mm:g}mm", file=sys.stderr)
+    rows = []
+    for (bx, by), (free, owners) in bins.items():
+        rows.append({
+            'window': [round(bx * bin_mm, 2), round(by * bin_mm, 2),
+                       round((bx + 1) * bin_mm, 2),
+                       round((by + 1) * bin_mm, 2)],
+            'demand_nets': len(owners),
+            'free_area_mm2': round(free, 3),
+            # `free` is floored at 5% of the bin area by congestion_bins, so
+            # it is never 0 and the ratio is always finite. The old
+            # `float('inf')` guard was unreachable AND would have written a
+            # bare `Infinity` token into the JSON, which is not standard JSON
+            # and which strict parsers refuse.
+            'ratio': round(len(owners) / free, 4),
+            'nets': sorted(name_by_id.get(n, str(n)) for n in owners)[:12],
+        })
+    rows.sort(key=lambda r: -r['ratio'])
+    # Simultaneous routability needs >= 2 nets by definition: a single-net
+    # sliver (a bin inside one part's own pad field) tops any ratio ranking
+    # and means nothing here. Reported in the JSON, never in the ranking.
+    hot = [r for r in rows if r['demand_nets'] >= 2
+           and (args.threshold is None or r['ratio'] > args.threshold)]
+
+    # Parts per window, for the top rows only (the fix target is a ref).
+    pads = [(pad.global_x, pad.global_y, pad.component_ref)
+            for fp in pcb.footprints.values() for pad in fp.pads]
+    for r in hot[:args.top]:
+        w = r['window']
+        r['refs'] = sorted({ref for x, y, ref in pads
+                            if w[0] <= x < w[2] and w[1] <= y < w[3] and ref})
+
+    lane = (f"one lane = track {trk:g} + 2 x clearance {clr:g} = "
+            f"{trk + 2 * clr:g}mm" if clr is not None and trk is not None
+            else "board floors unreadable")
+    print(f"Pocket census of {args.board}: {len(ids)} demand net(s), "
+          f"{len(bins)} window(s) at {bin_mm:g}mm, {len(layers)} layer(s); "
+          f"{lane}")
+    print("REPORT-ONLY: nothing gates on these numbers. The boundary review "
+          "dispositions each window below, in writing.")
+    for r in hot[:args.top]:
+        w = r['window']
+        print(f"  [{w[0]:g},{w[1]:g}]-[{w[2]:g},{w[3]:g}]  demand "
+              f"{r['demand_nets']:>3} net(s) / free {r['free_area_mm2']:g}mm2 "
+              f"= {r['ratio']:g}/mm2")
+        print(f"      nets: {', '.join(r['nets'])}"
+              + (" ..." if r['demand_nets'] > len(r['nets']) else ""))
+        if r.get('refs'):
+            print(f"      refs: {', '.join(r['refs'][:14])}"
+                  + (" ..." if len(r['refs']) > 14 else ""))
+
+    if args.json:
+        doc = {'board': args.board,
+               # The bin the census USED. `bin_requested` is what the caller
+               # asked for; they differ when --bin is under the floor, and a
+               # reader plotting `window` needs the one the rectangles came
+               # from.
+               'bin_mm': bin_mm, 'bin_requested_mm': args.bin,
+               'demand_nets': len(ids), 'layers': len(layers),
+               'lane_mm': (round(trk + 2 * clr, 4)
+                           if clr is not None and trk is not None else None),
+               'threshold': args.threshold,
+               'windows': rows[:max(args.top, 32)]}
+        with open(args.json, 'w', encoding='utf-8') as f:
+            json.dump(doc, f, indent=1, sort_keys=True)
+        print(f"  JSON -> {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    import cli_banner
+    cli_banner.install()   # CMD/EXIT self-echo (run-3 B1)
+    sys.exit(main())

--- a/py_tools/render_placement.py
+++ b/py_tools/render_placement.py
@@ -235,6 +235,14 @@ def legality_findings(model) -> Dict[str, object]:
     out = {'oob_refs_pad_copper': [], 'oob_refs_courtyard': [],
            'pad_conflict_pairs_refs': [], 'hole_conflict_pairs_refs': [],
            'body_overlap_pairs_refs': [],
+           'courtyard_overlap_pairs_refs': [],
+           'courtyard_blocking_pairs_refs': [],
+           'courtyard_overlap_mm2': 0.0,
+           'cross_side_stacks': [],
+           # None = the census ran. A string = it could NOT be built, and the
+           # sheet/gate say NOT MEASURED rather than reporting "blocking: none"
+           # on a board nothing looked at.
+           'courtyard_census_error': None,
            'locked_refs': sorted(r for r, p in model.parts().items()
                                  if getattr(p, 'locked', False))}
     state = getattr(model, 'state', None)
@@ -332,12 +340,97 @@ def legality_findings(model) -> Dict[str, object]:
                     continue
                 if amt > 1e-6:
                     out['oob_refs_courtyard'].append([ref, round(amt, 4)])
+    # run-23: the COURTYARD census, from the same FUNCTION legality uses
+    # (grade_body_overlap), never a re-derivation. `body_overlap_pairs_refs`
+    # above is PAD intersections -- the name predates this channel -- and the
+    # gap between the two is exactly how a board with J4 0.90mm inside U6
+    # rendered "clean": the checklist had no key for what the picture showed,
+    # so a reader pairing the render with its keys read past it.
+    #
+    # SAME FUNCTION, NOT THE SAME CENSUS as check_assembly's. Two differences,
+    # named here rather than glossed:
+    #   * check_assembly passes `intent_waivers` (check_assembly.py, its
+    #     --intent path); this renderer reads no intent, so an operator-waived
+    #     pair is UNWAIVED here and will appear in the advisory list and can
+    #     reach the gate below. A render is not a substitute for the assembly
+    #     grade on a board carrying waivers.
+    #   * `moved_parts` below (the gate's currency) compares poses for refs
+    #     present in BOTH boards only, and ignores a layer flip;
+    #     check_assembly's moved set also counts refs absent from the baseline
+    #     and side changes. The two moved sets therefore differ on a board
+    #     whose parts were added, removed or flipped.
+    pcb = getattr(model, 'pcb', None)
+    if pcb is not None:
+        try:
+            from placement.legality import grade_body_overlap
+            # The board's OWN resolved clearance floor -- what the instrument
+            # block reports and what --clearance sets -- rather than a magic
+            # constant. `state.clearance` is the quench's copy; floor_knobs is
+            # the model's resolution of it; routing_defaults.CLEARANCE is the
+            # last resort for a model built without either.
+            _clr = (getattr(state, 'clearance', None)
+                    or (model.floor_knobs.get('clearance') or {}).get('value')
+                    or defaults.CLEARANCE)
+            _g = grade_body_overlap(pcb, _clr,
+                                    pcb_file=getattr(model, 'pcb_file', None))
+            # UNWAIVED courtyard pairs only -- the advisory population. It is
+            # NOT a superset of the blocking list below (a waiver-voided pair
+            # blocks while staying labelled waived), which is why this key is
+            # named `advisory` and not `overlap`.
+            out['courtyard_overlap_pairs_refs'] = [
+                [q.a, q.b, q.area_mm2, q.depth_mm]
+                for q in _g['advisory_pairs'] if q.kind == 'courtyard']
+            out['courtyard_blocking_pairs_refs'] = [
+                [q.a, q.b, q.area_mm2, q.depth_mm]
+                for q in _g['courtyard_blocking_pairs']]
+            # EVERY courtyard pair, waived and unwaived, blocking and not:
+            # the complete census area. It is deliberately not the sum of
+            # either list above.
+            out['courtyard_overlap_mm2'] = round(sum(
+                q.area_mm2 for q in _g['pairs'] if q.kind == 'courtyard'), 4)
+            # run-23 (ulx3s review): FRONT<->BACK stacks. Panels draw both
+            # faces' outlines with only a ghost tint, so a battery holder
+            # behind the buttons (BAT1/B4: 68.7mm2 of XY overlap, ZERO
+            # shared-side overlap) is visually indistinguishable from a
+            # collision, and a reviewer's honest eye reports a defect the
+            # census correctly refused to pair. Named here so the sheet can
+            # PRE-ANSWER the question instead of looking blind.
+            from placement.legality import (graded_parts_from_file,
+                                            rect_overlap_area)
+            _gp = [g for g in graded_parts_from_file(
+                       pcb, getattr(model, 'pcb_file', None))
+                   if not g.synthetic]
+            stacks = []
+            for i, ga in enumerate(_gp):
+                for gb in _gp[i + 1:]:
+                    if ga.sides & gb.sides:
+                        continue          # shared face: the census owns it
+                    raw = rect_overlap_area(ga.rect, gb.rect)
+                    if raw >= 1.0:
+                        stacks.append([min(ga.ref, gb.ref),
+                                       max(ga.ref, gb.ref), round(raw, 2)])
+            stacks.sort(key=lambda r: -r[2])
+            out['cross_side_stacks'] = stacks
+        except Exception as exc:                             # noqa: BLE001
+            # Was a bare `pass`, which left every courtyard key at its empty
+            # default -- so the sheet headlined "blocking: none" and the
+            # checklist read clean on a board whose census never ran. Record
+            # WHY; the sheet and --gate both read this.
+            out['courtyard_census_error'] = f'{type(exc).__name__}: {exc}'
     model._legality_findings = out
     return out
 
 
 def moved_parts(before_pcb, after_pcb, tol: float = 1e-4) -> List[Dict]:
-    """Refs whose position changed, with both poses. Sorted (#457)."""
+    """Refs whose position changed, with both poses. Sorted (#457).
+
+    Position and rotation ONLY, over refs present in BOTH boards. A ref the
+    after board added or dropped is not "moved" here, and neither is a part
+    that changed side at the same x/y. check_assembly's moved set answers a
+    wider question (it counts appearances, disappearances and layer flips),
+    so the two lists legitimately differ on a board whose parts were added,
+    removed or flipped -- do not read one as the other.
+    """
     out = []
     for ref, a in sorted((before_pcb.footprints or {}).items()):
         b = (after_pcb.footprints or {}).get(ref)
@@ -417,6 +510,198 @@ def _rect_pts(r, rect):
     return [min(x0, x1), min(y0, y1), max(x0, x1), max(y0, y1)]
 
 
+#: How many device pixels the SHORTFALL must span for a defect panel to be
+#: worth calling a picture of that defect. Below this the two spans -- measured
+#: and required -- are indistinguishable and the panel is a picture of the
+#: neighbourhood, not of the finding.
+DEFECT_MIN_PX = 16
+# Schema versions `load_defect_records` will read. A document carrying any
+# other `version` is refused with a note: the docstring calls this reader the
+# schema's consumer contract, and a contract that accepts every version is not
+# one. A document with NO `version` is read (the key is optional) -- absence is
+# an old writer, a wrong number is a different schema.
+DEFECT_SCHEMA_VERSIONS = frozenset({1})
+
+
+def _board_sha(path):
+    """sha256 of a board file, or None. The same binding board_score uses."""
+    try:
+        import hashlib
+        with open(path, 'rb') as fh:
+            return hashlib.sha256(fh.read()).hexdigest()
+    except OSError:
+        return None
+
+
+def load_defect_records(paths, board_sha=None):
+    """Read `defect-record` documents; return (defects, notes).
+
+    A defect record is a plain JSON file. This reader is the schema's consumer
+    contract; nothing is imported from the instrument that writes one. Shape
+    (version 1), the keys this renderer uses marked with *::
+
+        {kind*: 'defect-record', version: 1, count: N,
+         board: <abs path>, board_sha*: <sha256 of the .kicad_pcb>,
+         defects*: [{kind*: 'throat', verdict: 'CAGED', net*: <name>,
+                     seed{x,y,layer}, at*{x*,y*,layer*}, refs*[], pads*[],
+                     measure*{space, have_mm, need_mm, short_mm*,
+                              resolution_mm, gap_mm*, gap_need_mm*,
+                              derived_from},
+                     span*{a*{x,y,layer,kind}, b*{x,y,layer,kind}},
+                     view*[x0,y0,x1,y1], relief[], instrument{...}}]}
+
+    `at` is the throat coordinate, `short_mm` the track-width shortfall the
+    panel is scaled from, `gap_mm`/`gap_need_mm` the measured and required
+    edge-to-edge spans drawn on it, `span` the two pieces of copper forming the
+    throat, `view` the fallback box when no shortfall is given.
+
+    The contract is ENFORCED, not merely described: a document that is not a
+    JSON object, whose `kind` is not `defect-record`, or whose `version` this
+    reader does not know is refused with a note rather than read hopefully. A
+    top-level JSON array used to reach `doc.get` and kill the whole render
+    with an AttributeError, and an unknown `version` used to be accepted in
+    silence -- which is not a schema contract, it is a shape guess.
+
+    Each defect is stamped with the file it came from and the record's board
+    binding. A record whose `board_sha` does not match the board being rendered
+    is DROPPED with a loud note: drawing it would put a measurement from one
+    board on top of another, at coordinates that happen to be valid.
+    """
+    out, notes = [], []
+    for path in (paths or []):
+        try:
+            with open(path, encoding='utf-8') as fh:
+                doc = json.load(fh)
+        except Exception as exc:                            # noqa: BLE001
+            notes.append(f'--defect-json {path}: unreadable ({exc})')
+            continue
+        if not isinstance(doc, dict):
+            notes.append(f'--defect-json {path}: top-level JSON is a '
+                         f'{type(doc).__name__}, not an object -- a '
+                         f'defect-record document is a JSON object with '
+                         f'`kind`, `version` and `defects`. SKIPPED')
+            continue
+        if doc.get('kind') != 'defect-record':
+            notes.append(f"--defect-json {path}: kind is "
+                         f"{doc.get('kind')!r}, not 'defect-record'")
+            continue
+        ver = doc.get('version')
+        if ver is not None and ver not in DEFECT_SCHEMA_VERSIONS:
+            _known = ', '.join(str(v) for v in sorted(DEFECT_SCHEMA_VERSIONS))
+            notes.append(
+                f'--defect-json {path}: version {ver!r} is not one this '
+                f'reader knows ({_known}) -- SKIPPED. Reading a future schema '
+                f'as if it were version 1 would draw whatever the keys '
+                f'happened to still mean.')
+            continue
+        sha = doc.get('board_sha')
+        if board_sha and sha and sha != board_sha:
+            notes.append(
+                f'--defect-json {path}: board_sha {sha[:12]} does NOT match '
+                f'this board ({board_sha[:12]}) -- SKIPPED. Drawing it would '
+                f'put one board\'s measurement on another at coordinates that '
+                f'happen to be valid.')
+            continue
+        if board_sha and not sha:
+            notes.append(f'--defect-json {path}: no board_sha, so it cannot be '
+                         f'proven to describe this board -- drawn anyway')
+        for d in (doc.get('defects') or []):
+            out.append(dict(d, _source=path))
+    return out, notes
+
+
+def defect_view(defect, size_px, min_px=DEFECT_MIN_PX):
+    """(view, px_per_mm, shortfall_px) for one defect -- or (None, ...).
+
+    NOT A NEW ZOOM. `--view`, `--zoom-group` and `--focus` have all been here
+    for a long time and are good; the whole board at --size 1600 is ~35 px/mm,
+    where a 41 um defect is 1.4 px, and `--view` around the throat fixes that
+    in one flag. What was missing was the TARGET and the AMOUNT:
+
+      * the target -- the record's `at` is the throat coordinate, measured by
+        the instrument that found it. A seed-pad coordinate is not a
+        substitute: on run 20 the throat was 0.66 mm from the seed pad.
+      * the amount -- there was no rule for how tight to crop, and no feedback
+        on whether the finding was resolvable in the box you chose.
+
+    So this derives the view from the MEASUREMENT: tighten until `short_mm`
+    spans `min_px`. At size 1600 and short 0.0405 mm that is a 4.05 mm box,
+    which still frames both blocking pads. The caller can always override it
+    with `--view`; this only removes the guesswork.
+    """
+    at = defect.get('at') or {}
+    if at.get('x') is None or at.get('y') is None:
+        return None, None, None
+    short = ((defect.get('measure') or {}).get('short_mm')) or 0.0
+    if short <= 0:
+        # No shortfall to size against (a defect kind that does not carry one).
+        # Fall back to the record's own view rather than inventing a scale.
+        v = defect.get('view')
+        if not v:
+            return None, None, None
+        side = max(v[2] - v[0], v[3] - v[1])
+    else:
+        side = min(short * size_px / float(min_px),
+                   max((defect.get('view') or [0, 0, 4, 4])[2]
+                       - (defect.get('view') or [0, 0, 4, 4])[0], 0.5))
+        side = max(side, 4.0 * short)      # never so tight the span leaves frame
+    half = side / 2.0
+    view = (at['x'] - half, at['y'] - half, at['x'] + half, at['y'] + half)
+    ppmm = size_px / side if side else 0.0
+    return view, ppmm, (short * ppmm if short else 0.0)
+
+
+def draw_defects(d, r, defects):
+    """A ring at the throat, the MEASURED span solid, the REQUIRED span dashed.
+
+    At the scale `defect_view` picks, those two differ by >= DEFECT_MIN_PX --
+    which is the whole reason the crop is sized from the measurement instead of
+    from the parts.
+    """
+    for x in defects:
+        at = x.get('at') or {}
+        if at.get('x') is None:
+            continue
+        cx, cy = r.tf.pt(at['x'], at['y'])
+        rad = max(6, _w(r, ((x.get('measure') or {}).get('gap_mm') or 0.2) / 2.0))
+        d.ellipse([cx - rad, cy - rad, cx + rad, cy + rad],
+                  outline=(255, 64, 64), width=max(2, _w(r, 0.01)))
+        span = x.get('span') or {}
+        a, b = span.get('a') or {}, span.get('b') or {}
+        if a.get('x') is None or b.get('x') is None:
+            continue
+        p0, p1 = r.tf.pt(a['x'], a['y']), r.tf.pt(b['x'], b['y'])
+        d.line([p0[0], p0[1], p1[0], p1[1]], fill=(255, 64, 64),
+               width=max(2, _w(r, 0.012)))
+        # The REQUIRED span: the same direction, scaled to what was needed.
+        m = x.get('measure') or {}
+        have, need = m.get('gap_mm'), m.get('gap_need_mm')
+        if not have or not need or have <= 0:
+            continue
+        k = float(need) / float(have)
+        mx, my = (p0[0] + p1[0]) / 2.0, (p0[1] + p1[1]) / 2.0
+        q0 = (mx + (p0[0] - mx) * k, my + (p0[1] - my) * k)
+        q1 = (mx + (p1[0] - mx) * k, my + (p1[1] - my) * k)
+        # ALONGSIDE, not on top. `need/have` here is 1.09, so the required span
+        # drawn from the same midpoint lies almost entirely over the measured
+        # one and the reader sees dashes with a little red at the ends -- the
+        # comparison the panel exists to make, hidden by the drawing order.
+        # Offset perpendicular by a few pixels and the two are two lines.
+        dx, dy = q1[0] - q0[0], q1[1] - q0[1]
+        _L = math.hypot(dx, dy) or 1.0
+        _off = max(5, _w(r, 0.02) * 3)
+        nx, ny = -dy / _L * _off, dx / _L * _off
+        _dash(d, (q0[0] + nx, q0[1] + ny), (q1[0] + nx, q1[1] + ny),
+              max(6, _w(r, 0.05)), max(4, _w(r, 0.03)),
+              (255, 200, 64), max(2, _w(r, 0.012)))
+        # End caps, so the two lengths can be compared at their ends rather
+        # than eyeballed along their middles.
+        for _q in (q0, q1):
+            d.line([_q[0] + nx * 0.2, _q[1] + ny * 0.2,
+                    _q[0] + nx * 1.8, _q[1] + ny * 1.8],
+                   fill=(255, 200, 64), width=max(2, _w(r, 0.012)))
+
+
 def _dash(d, p0, p1, on_px, off_px, fill, width):
     """PIL has no dashed line."""
     x0, y0 = p0
@@ -460,6 +745,7 @@ def draw_courtyards(d, r, model, refs, *, side=None, color=None, dim=False,
 
 C_CONFLICT = (255, 64, 64)      # pad/hole legality conflicts
 C_HOLE = (255, 160, 64)         # NPTH keepout circles
+C_COURT_OVL = (255, 120, 40)    # run-23: courtyard-blocking interpenetration
 
 
 def draw_legality(d, r, model, *, side=None):
@@ -536,6 +822,29 @@ def draw_legality(d, r, model, *, side=None):
                   min(ea[2], eb[2]), min(ea[3], eb[3]))
             if ix[2] > ix[0] and ix[3] > ix[1]:
                 d.rectangle(_rect_pts(r, ix), fill=C_CONFLICT)
+    # run-23: courtyard-BLOCKING pairs (unwaived interpenetration past the
+    # area+depth floors). Courtyards render as thin gray outlines, which
+    # makes real overlap visually indistinguishable from legal tight packing
+    # -- run-23's board WAS viewed (at L3, with the census in the banner) and
+    # still read clean. Filled intersection + the pair named ON the image, so
+    # the defect lives in pixels, not only in a key.
+    for a, bb, _mm2, _dep in fnd.get('courtyard_blocking_pairs_refs', ()):
+        ra = model.rect(a)
+        rb = model.rect(bb)
+        if ra is None or rb is None:
+            continue
+        for rect in (ra, rb):
+            d.rectangle(_rect_pts(r, rect), outline=C_COURT_OVL,
+                        width=_w(r, 0.16))
+        ix = (max(ra[0], rb[0]), max(ra[1], rb[1]),
+              min(ra[2], rb[2]), min(ra[3], rb[3]))
+        if ix[2] > ix[0] and ix[3] > ix[1]:
+            box = _rect_pts(r, ix)
+            d.rectangle(box, fill=C_COURT_OVL)
+            _size = max(10, _w(r, 1.0, floor=10))
+            d.text((min(box[0], box[2]), max(0, min(box[1], box[3]) - _size - 2)),
+                   f"{a}<->{bb} {_mm2}mm2", fill=C_COURT_OVL,
+                   font=load_font(_size))
 
 
 def draw_ghosts(d, r, model, moves, *, width_mm=0.1):
@@ -634,7 +943,7 @@ class PanelSpec:
 
     def __init__(self, model, *, view=None, side=None, prominent=(), moves=(),
                  hot_nets=(), blocker_nets=(), pick_nets=(), label='',
-                 opts=None):
+                 opts=None, defects=()):
         self.model = model
         self.view = view
         self.side = side
@@ -643,6 +952,7 @@ class PanelSpec:
         self.hot_nets = set(hot_nets)
         self.blocker_nets = set(blocker_nets)
         self.pick_nets = set(pick_nets)     # ids, from --ratsnest-nets
+        self.defects = list(defects)        # from --defect-json
         self.label = label
         self.o = opts or {}
 
@@ -704,9 +1014,148 @@ def overlay_for(spec: PanelSpec):
             draw_arrows(d, r, spec.moves)
         if o.get('labels', True):
             draw_ref_labels(d, r, m, prom)
+        if spec.defects:
+            # LAST. A defect panel exists to show one thing; a ratsnest or a
+            # ref label drawn over it would be the picture failing at its only
+            # job.
+            draw_defects(d, r, spec.defects)
         if o.get('legend', True):
             draw_legend(d, r, spec)
     return _draw
+
+
+def connector_edge_facts(model) -> List[list]:
+    """[ref, class, nearest_edge, dist_mm] for every connector-family part.
+
+    Presentation-only (the review sheet's facts strip) -- a heuristic by
+    footprint name plus the part_class edge classes, deliberately broader
+    than part_class's gating classes: run 23 seated J2/J5/J6/J7 mid-board
+    and NO instrument said so, because generic connectors carry no class.
+    Nothing gates on this list; it exists so a reviewer sees the distances
+    without deriving them.
+    """
+    from placement.part_class import INTERIOR_AFFINITY_MM, classify_part
+    pcb = getattr(model, 'pcb', None)
+    bounds = getattr(getattr(pcb, 'board_info', None), 'board_bounds', None)
+    if pcb is None or not bounds:
+        return []
+    _NAME_TOKENS = ('conn', 'pinheader', 'header', 'socket', 'jst', 'molex',
+                    'terminal', 'usb', 'jack', 'receptacle')
+    out = []
+    for ref, fp in sorted((pcb.footprints or {}).items()):
+        name = (getattr(fp, 'footprint_name', '') or '').lower()
+        cls = None
+        try:
+            cls = classify_part(fp, ref).name
+        except Exception:
+            cls = None
+        if not (cls in ('edge_receptacle', 'edge_actuator')
+                or any(t in name for t in _NAME_TOKENS)):
+            continue
+        rect = model.rect(ref)
+        if rect is None:
+            continue
+        dists = {'W': rect[0] - bounds[0], 'N': rect[1] - bounds[1],
+                 'E': bounds[2] - rect[2], 'S': bounds[3] - rect[3]}
+        edge, dist = min(dists.items(), key=lambda kv: kv[1])
+        d = round(max(0.0, dist), 2)
+        out.append([ref, cls or 'connector', edge, d,
+                    bool(d > INTERIOR_AFFINITY_MM)])
+    return out
+
+
+def write_review_sheet(path, panel_paths, fnd, conn_facts) -> None:
+    """ONE image for the boundary review: F+B panels over a facts strip.
+
+    The panels already carry the courtyard-interpenetration overlay; the
+    strip adds what no panel can show spatially -- the census with numbers,
+    and each connector's distance to its nearest edge (INTERIOR flagged at
+    > 3mm). Run 23's reviewer had these facts spread over two panels and a
+    JSON, and the looking stopped at the spread.
+    """
+    from PIL import Image
+    imgs = [Image.open(p).convert('RGB') for p in panel_paths if p]
+    if not imgs:
+        raise ValueError('no panels to compose')
+    h = max(i.height for i in imgs)
+    imgs = [i if i.height == h
+            else i.resize((max(1, int(i.width * h / i.height)), h))
+            for i in imgs]
+    W = sum(i.width for i in imgs)
+
+    lines = []
+    cb = fnd.get('courtyard_blocking_pairs_refs') or []
+    cs = fnd.get('courtyard_overlap_pairs_refs') or []
+    err = fnd.get('courtyard_census_error')
+    # THREE POPULATIONS, three names, because they are not nested: the mm2
+    # figure sums EVERY courtyard pair (waived included); `advisory` is the
+    # unwaived subset; `blocking` is the past-the-floors subset and is NOT
+    # inside advisory, because a waiver-voided pair (dead edge waiver, locked
+    # member) blocks while staying labelled waived. Measured on run 23's
+    # board: 26.98mm2 over all pairs, 5 advisory, 10 blocking, 6 of the
+    # blocking absent from advisory. A strip saying only "overlap" invited
+    # the reader to treat them as one number.
+    if err:
+        lines.append(f"courtyard census NOT MEASURED ({err}) -- this strip "
+                     f"cannot say whether the board is clean")
+    else:
+        lines.append(
+            f"courtyard: {fnd.get('courtyard_overlap_mm2', 0)}mm2 over ALL "
+            f"pairs (waived included)  |  {len(cs)} unwaived advisory"
+            # '  |  '-separated, not comma: the strip wrapper breaks lines at
+            # that separator, and a comma-joined blocking list ran off the
+            # sheet unwrappable (found on the 10-pair run-23 board).
+            + (f"  |  BLOCKING, past the floors ({len(cb)}): " + '  |  '.join(
+                f"{a}<->{b} {m}mm2/depth {dp}mm" for a, b, m, dp in cb)
+               if cb else "  |  blocking, past the floors: none"))
+    if conn_facts:
+        chunk = []
+        for ref, _cls, edge, dist, interior in conn_facts:
+            tag = 'INTERIOR ' if interior else ''
+            chunk.append(f"{ref} {tag}{dist}mm {edge}")
+        lines.append("connectors (footprint-NAME heuristic), dist to nearest "
+                     "edge: " + '  |  '.join(chunk))
+    else:
+        lines.append("connectors: none recognised (footprint-NAME heuristic, "
+                     "so a connector named otherwise is missing from this row)")
+    xs = fnd.get('cross_side_stacks') or []
+    if xs:
+        # Pre-answer the reviewer's eye: these LOOK like collisions in the
+        # panels (both faces' outlines share the picture) and are not.
+        lines.append(
+            "front<->back stacks (opposite faces, NOT a conflict): "
+            + '  |  '.join(f"{a} over {b} {m}mm2" for a, b, m in xs[:14])
+            + (f"  |  +{len(xs) - 14} more" if len(xs) > 14 else ""))
+
+    font = load_font(max(14, h // 60))
+    lh = int(font.size * 1.5)
+    # crude width wrap: split any line the strip cannot hold
+    probe = ImageDraw.Draw(imgs[0])
+    wrapped = []
+    for ln in lines:
+        while probe.textlength(ln, font=font) > W - 20 and '  |  ' in ln:
+            # cut at the separator nearest the width limit
+            parts = ln.split('  |  ')
+            keep, rest = [parts[0]], parts[1:]
+            while rest and probe.textlength(
+                    '  |  '.join(keep + rest[:1]), font=font) <= W - 20:
+                keep.append(rest.pop(0))
+            wrapped.append('  |  '.join(keep))
+            ln = '  |  '.join(rest)
+            if not rest:
+                ln = ''
+        if ln:
+            wrapped.append(ln)
+    strip_h = lh * len(wrapped) + 16
+    sheet = Image.new('RGB', (W, h + strip_h), (10, 10, 10))
+    x = 0
+    for i in imgs:
+        sheet.paste(i, (x, 0))
+        x += i.width
+    d = ImageDraw.Draw(sheet)
+    for i, ln in enumerate(wrapped):
+        d.text((10, h + 8 + i * lh), ln, fill=(235, 235, 235), font=font)
+    sheet.save(path)
 
 
 def draw_legend(d, r, spec) -> None:
@@ -722,15 +1171,24 @@ def draw_legend(d, r, spec) -> None:
     Only the keys this panel can actually show are drawn -- a legend listing
     arrows on a panel with no --before is itself misinformation.
     """
-    rows = [(C_CONFLICT, 'dashed', 'pad copper off-board'),
-            (C_CONFLICT, 'ring', 'pad/hole clearance short'),
-            (C_CONFLICT, 'solid', 'BODY STACK - parts overlap'),
-            (C_HOLE, 'ring', 'NPTH keepout'),
-            (C_LOCKED, 'hatch', 'KiCad-locked (never moved)')]
-    if spec.moves:
-        rows.append((C_ARROW, 'arrow', 'moved since --before'))
-    if spec.hot_nets:
-        rows.append((C_AIR_FAIL, 'line', 'failed net'))
+    if getattr(spec, 'defects', None):
+        # A defect panel's marks are its whole point, so they are the ONLY
+        # legend on it. Listing the legality key beside them would invite the
+        # reader to hunt for findings the crop was not sized to show.
+        rows = [(C_CONFLICT, 'solid', 'MEASURED gap (the throat)'),
+                ((255, 200, 64), 'dashed', 'REQUIRED gap (what would fit)'),
+                (C_CONFLICT, 'ring', 'throat location')]
+    else:
+        rows = [(C_CONFLICT, 'dashed', 'pad copper off-board'),
+                (C_CONFLICT, 'ring', 'pad/hole clearance short'),
+                (C_CONFLICT, 'solid', 'BODY STACK - parts overlap'),
+                (C_COURT_OVL, 'solid', 'courtyard interpenetration'),
+                (C_HOLE, 'ring', 'NPTH keepout'),
+                (C_LOCKED, 'hatch', 'KiCad-locked (never moved)')]
+        if spec.moves:
+            rows.append((C_ARROW, 'arrow', 'moved since --before'))
+        if spec.hot_nets:
+            rows.append((C_AIR_FAIL, 'line', 'failed net'))
     try:
         # Overlays draw on the SUPERSAMPLED canvas, which is `ss` times the
         # output size -- so `r.H` (the output height) put the legend at 1/ss of
@@ -1139,8 +1597,31 @@ Examples:
                    help='how blocks are derived (default: auto = kicad,sheet)')
     p.add_argument('--list-groups', action='store_true',
                    help='list the blocks --group-by would derive, and exit')
+    p.add_argument('--defect-json', action='append', default=None,
+                   metavar='PATH',
+                   help='a `defect-record` JSON document (schema: see '
+                        'load_defect_records; written by a reachability '
+                        'instrument, not by this tool). Repeatable. This is '
+                        '--view with the guesswork removed, NOT a new zoom: '
+                        'it takes the throat COORDINATE from the record and '
+                        'derives the box size from the measured shortfall. '
+                        'Each defect gets its own '
+                        'panel, cropped tight enough that the SHORTFALL is at '
+                        'least 16 px -- a 41um throat on a 34mm board at the '
+                        'default scale is 1.2 px, which is why run 20 had '
+                        'renders of the right board that could not show the '
+                        'defect. Records whose board_sha does not match are '
+                        'reported and skipped. NOTE: giving this SUPPRESSES '
+                        'the --focus legality-pocket panels -- a measured '
+                        'coordinate beats a cluster derived from pad '
+                        'positions, and emitting both puts two answers to the '
+                        'same question in one document. --focus panels for '
+                        'FAILED NETS (with --summary-json) are unaffected.')
     p.add_argument('--focus', action='store_true',
-                   help='also emit one cropped panel per failed-net cluster')
+                   help='also emit one cropped panel per failed-net cluster. '
+                        'With --defect-json the LEGALITY-pocket fallback is '
+                        'suppressed (the record carries a measured '
+                        'coordinate); the failed-net clusters still render')
     p.add_argument('--focus-gap', type=float, default=10.0, metavar='MM')
     p.add_argument('--max-focus', type=int, default=6)
     p.add_argument('--zoom-pad', type=float, default=2.0, metavar='MM')
@@ -1148,6 +1629,12 @@ Examples:
                    help='force an F and a B panel (run-6: boards with '
                         'back-side parts get per-side panels by DEFAULT; '
                         'this flag only matters with --flat semantics)')
+    p.add_argument('--side', choices=('F', 'B'), default=None,
+                   help='render ONLY this side\'s panel (run-23: there was '
+                        'no way to ask for one face -- the choices were both '
+                        'panels or --flat, which mixes the faces into one '
+                        'image). Overrides --per-side/--flat; the review '
+                        'sheet then carries the one panel.')
     p.add_argument('--flat', action='store_true',
                    help='one flattened panel even when the board has '
                         'back-side parts (the pre-run-6 default; a B part '
@@ -1231,7 +1718,25 @@ Examples:
                         "JSON checklist then carries d={moved, expected, "
                         "match} -- mandate 8's question (d), quotable instead "
                         'of recalled (run-4 G5)')
-    p.add_argument('--quiet', action='store_true')
+    p.add_argument('--quiet', action='store_true',
+                   help='suppress narration. With --json-out it now also '
+                        'suppresses the stdout JSON_SUMMARY echo and the '
+                        'describe text (the file carries both): blind-first '
+                        'reviews depend on the IMAGE preceding the keys, and '
+                        'the unconditional echo defeated that in the very '
+                        'command the review gates prescribe (run 24, A-1). '
+                        'Without --json-out the summary line still prints -- '
+                        'data is never silenced into nowhere.')
+    p.add_argument('--review-sheet', metavar='PATH', default=None,
+                   help='run-23: ALSO write ONE composite image built for the '
+                        'boundary review -- F and B side by side (with the '
+                        'courtyard-interpenetration overlay both panels '
+                        'already carry) over a facts strip: the courtyard '
+                        'census with mm2/depth, and every connector-family '
+                        'part with its distance-to-nearest-edge (INTERIOR '
+                        'flagged). Exists because the facts a reviewer needs '
+                        'were spread over two panels and a JSON, and run 23 '
+                        'proved that spread is where the looking stops.')
     return p
 
 
@@ -1469,6 +1974,9 @@ def main(argv=None):
         sides = (None,)
         if not args.quiet:
             print("  (no back-side footprints and no B.Cu: skipping the B panel)")
+    if args.side:
+        # ONE face, explicitly asked for: overrides the split heuristics.
+        sides = (args.side,)
 
     panels = []
     if before_model is not None:
@@ -1482,15 +1990,74 @@ def main(argv=None):
                                     pick_nets=pick,
                                     label=f"BEFORE {os.path.basename(args.before)}",
                                     opts=_bopts))
+    # Tracked, because the review sheet composes THESE. Selecting them by a
+    # property instead is how the sheet came to show the BEFORE board under
+    # the AFTER facts strip: with --pair the panel list is [BEFORE F, BEFORE
+    # B, AFTER F, AFTER B] and all four carry view=None, so "the first two
+    # full-board panels" is the before pair -- measured pixel-identical to
+    # the before render and 170480 px different from the after one.
+    _after_specs = []
     for side in sides:
-        panels.append(PanelSpec(model, view=view, side=side, prominent=prominent,
-                                moves=moves, hot_nets=failed,
-                                blocker_nets=blockers, pick_nets=pick,
-                                label=(f"AFTER {tag}" if before_model is not None
-                                       else tag),
-                                opts=opts))
+        _aspec = PanelSpec(model, view=view, side=side, prominent=prominent,
+                           moves=moves, hot_nets=failed,
+                           blocker_nets=blockers, pick_nets=pick,
+                           label=(f"AFTER {tag}" if before_model is not None
+                                  else tag),
+                           opts=opts)
+        panels.append(_aspec)
+        _after_specs.append(_aspec)
+    # DEFECT PANELS FIRST, and before either --focus branch. A defect record
+    # carries an AUTHORITATIVE coordinate -- the instrument that measured the
+    # throat says where it is -- where `cluster_points` derives a view from pad
+    # positions and its own docstring apologises for exactly that. When both
+    # are available the measured one wins.
+    _defects, _dnotes = load_defect_records(
+        getattr(args, 'defect_json', None), board_sha=_board_sha(args.board))
+    for _n in _dnotes:
+        print(f'  {_n}', file=sys.stderr)
+    _defect_panels = []
+    for i, _dx in enumerate(_defects):
+        _dv, _ppmm, _spx = defect_view(_dx, args.size)
+        if _dv is None:
+            print(f'  --defect-json: defect {i + 1} carries no `at` coordinate '
+                  f'and no view -- no panel', file=sys.stderr)
+            continue
+        _m = _dx.get('measure') or {}
+        _who = '<->'.join((_dx.get('pads') or _dx.get('refs') or ['?'])[:2])
+        # The HONESTY LINE. If the shortfall still does not span the threshold
+        # the caption says so instead of shipping a picture that implies it does.
+        _scale = (f'{_ppmm:.0f} px/mm -> {_spx:.0f} px'
+                  if _spx >= DEFECT_MIN_PX - 0.5
+                  else f'{_ppmm:.0f} px/mm -> {_spx:.1f} px INVISIBLE AT THIS '
+                       f'SCALE')
+        _lbl = (f"defect {i + 1}/{len(_defects)} {_dx.get('kind', '?')} {_who}"
+                + (f" | {_m['gap_mm']:.4f}/{_m['gap_need_mm']:.4f}mm short "
+                   f"{1000.0 * _m['short_mm']:.1f}um"
+                   if _m.get('gap_mm') is not None
+                   and _m.get('short_mm') is not None else '')
+                + f' | {_scale}')
+        # The record names a COPPER LAYER; this tool's `side` vocabulary is
+        # 'F'/'B'/None. Passing 'F.Cu' through compared unequal to every part's
+        # side and dimmed the whole crop. An inner-layer throat has no side, so
+        # both are drawn at full brightness -- which is the honest answer.
+        _lay = ((_dx.get('at') or {}).get('layer') or '')
+        _side = {'F.Cu': 'F', 'B.Cu': 'B'}.get(_lay)
+        _defect_panels.append(PanelSpec(
+            model, view=_dv, side=_side,
+            prominent=set(_dx.get('refs') or ()) or prominent, moves=moves,
+            hot_nets=failed, blocker_nets=blockers, pick_nets=pick,
+            defects=[_dx],
+            # Airwires OFF on a defect panel. They are the biggest source of
+            # visual noise on a dense board and here they cross the finding
+            # itself -- on the run-20 crop, a dozen grey lines through the one
+            # 16-px measurement the panel exists to show. The label already
+            # names the net, which is what the ratsnest would have told you.
+            opts=dict(opts, ratsnest=False),
+            label=_lbl))
+    panels.extend(_defect_panels)
+
     _leg_pockets = []
-    if args.focus and not args.summary_json:
+    if args.focus and not args.summary_json and not _defect_panels:
         # Run-4 G7 made --focus warn here, because its clusters came from the
         # route summary's failed nets and without one it emitted a single panel
         # and said nothing. But the same question -- one pocket or scattered --
@@ -1603,6 +2170,32 @@ def main(argv=None):
             'moved_refs': [{'reference': m['reference'],
                             'dist': round(m['dist'], 4)} for m in moves],
             'failed_nets': sorted(failed), 'blocker_nets': sorted(blockers),
+            # The defects this render was ASKED to show, and what it managed
+            # to show them at. `shortfall_px` is the honesty figure: it tells
+            # a picture OF the defect from a picture of its neighbourhood
+            # without opening the png. Both keys are READ, not merely
+            # written: --gate below compares `defects` against
+            # `defect_panels` and checks each panel's shortfall against
+            # `min_px`. (An earlier comment here credited loop_driver's
+            # `_guard_route_render` with reading them. It does not -- it
+            # checks instrument.board, checklist, summary_json and
+            # moved_refs, and nothing about defects.)
+            'defects': [{'kind': dx.get('kind'), 'net': dx.get('net'),
+                         'refs': dx.get('refs'), 'pads': dx.get('pads'),
+                         'at': dx.get('at'),
+                         'short_mm': (dx.get('measure') or {}).get('short_mm'),
+                         'source': dx.get('_source')} for dx in _defects],
+            'defect_panels': [
+                {'label': sp.label, 'view': sp.view,
+                 'px_per_mm': (round(args.size / (sp.view[2] - sp.view[0]), 2)
+                               if sp.view and sp.view[2] > sp.view[0] else None),
+                 'shortfall_px': (round(
+                     ((sp.defects[0].get('measure') or {}).get('short_mm') or 0)
+                     * args.size / (sp.view[2] - sp.view[0]), 2)
+                     if sp.view and sp.view[2] > sp.view[0] and sp.defects
+                     else None),
+                 'min_px': DEFECT_MIN_PX}
+                for sp in _defect_panels],
             'metrics': dict(model.metrics),
             # The instrument block (run-4 G2): two renders of the SAME board
             # differing only in --ignore-nets read 632 vs 412 crossings in
@@ -1614,6 +2207,13 @@ def main(argv=None):
                 'before': os.path.abspath(args.before) if args.before else None,
                 'summary_json': (os.path.abspath(args.summary_json)
                                  if args.summary_json else None),
+                # Mirrors summary_json, so a gate can assert a defect render
+                # was made from a record the same way _guard_route_render
+                # already asserts a focus render was made from a route log.
+                'defect_json': [os.path.abspath(x)
+                                for x in (getattr(args, 'defect_json', None)
+                                          or [])],
+                'defect_notes': _dnotes,
                 # `clearance` used to record args.clearance, i.e. None on
                 # every run that did not pass the flag -- so the document
                 # named no clearance at all for the runs most likely to be
@@ -1646,6 +2246,46 @@ def main(argv=None):
                 # reports what the old name promised.
                 'b_pad_clearance_pairs': fnd['pad_conflict_pairs_refs'],
                 'b_body_overlap_pairs': fnd['body_overlap_pairs_refs'],
+                # run-23 key honesty, same lesson again: b_body_overlap_pairs
+                # is PAD intersections (see the run-6 note above), so a reader
+                # auditing "overlap" against it concluded there was none while
+                # J4 stood 0.90mm inside U6's courtyard. The courtyard channel
+                # now has its own keys, [a, b, area_mm2, depth_mm] rows -- and
+                # each one NAMES ITS POPULATION, because the three are not
+                # nested and the first name here ('overlap') implied they
+                # were. Measured on run 23's board: 26.98mm2 over all pairs,
+                # 5 advisory, 10 blocking, and 6 of the blocking absent from
+                # the advisory list.
+                #
+                #   b_courtyard_advisory_pairs -- UNWAIVED courtyard pairs.
+                #   b_courtyard_blocking_pairs -- past the
+                #     legality.COURTYARD_BLOCKING_* floors, synthetic refs
+                #     excluded. NOT a subset of the advisory list: a
+                #     waiver-VOIDED pair (dead edge waiver, locked member)
+                #     blocks while staying labelled waived.
+                #   b_courtyard_overlap_mm2 -- area over EVERY courtyard
+                #     pair, waived included; not the sum of either list.
+                #
+                # This render reads no --intent, so operator waivers do not
+                # reach it: on a board carrying them, check_assembly is the
+                # authority and these keys are its unwaived-by-construction
+                # shadow.
+                'b_courtyard_advisory_pairs':
+                    fnd['courtyard_overlap_pairs_refs'],
+                'b_courtyard_blocking_pairs':
+                    fnd['courtyard_blocking_pairs_refs'],
+                'b_courtyard_overlap_mm2': fnd['courtyard_overlap_mm2'],
+                # None when the census ran. --gate reads it: a render that
+                # could not build the census must not report "blocking: none".
+                'b_courtyard_census_error': fnd['courtyard_census_error'],
+                # FRONT<->BACK stacks: XY overlap with NO shared face --
+                # deliberate on real boards (ulx3s: the battery holder
+                # behind the buttons), never a conflict, listed so a reader
+                # of the render does not mistake them for one. Never gates;
+                # --gate DISCLOSES the count on its verdict line, so the
+                # reviewer's eye is pre-answered by the same output that
+                # gives the verdict rather than only by the sheet.
+                'b_cross_side_stacks': fnd['cross_side_stacks'],
                 'c_hole_conflicts': fnd['hole_conflict_pairs_refs'],
                 'c_locked_refs': fnd['locked_refs'],
                 'd_moved': {'moved': len(moves),
@@ -1655,20 +2295,43 @@ def main(argv=None):
             },
             'unplaced': state.unplaced, 'no_outline': model.no_outline,
         }
+        if args.review_sheet:
+            # The AFTER panels, by IDENTITY. `view is None` alone selects the
+            # BEFORE pair under --pair (they are first in the list and share
+            # the property), which is how the sheet came to compose the before
+            # board under the after facts strip.
+            _after_ids = {id(s) for s in _after_specs}
+            _full = [w for s, w in zip(panels, written)
+                     if id(s) in _after_ids and s.view is None][:2]
+            try:
+                write_review_sheet(args.review_sheet, _full, fnd,
+                                   connector_edge_facts(model))
+                doc['review_sheet'] = args.review_sheet
+                print(f"  review sheet -> {args.review_sheet}")
+            except Exception as exc:                            # noqa: BLE001
+                # The sheet is an aid, never the render's own gate -- but a
+                # silent miss would read as "no sheet requested".
+                doc['review_sheet'] = None
+                print(f"  review sheet FAILED: {exc}", file=sys.stderr)
+        _quiet = bool(args.quiet and args.json_out)
         if not args.no_describe:
             _txt, _dj = describe(model, legality_findings(model), moves, args,
                                  [p['path'] for p in doc['panels']])
             doc['describe'] = _dj
-            print()
-            print(_txt)
+            if not _quiet:
+                print()
+                print(_txt)
             if before_model is not None:
                 _ptxt, _pj = describe_pair(before_model, model, args)
                 doc['pair'] = _pj
-                print(_ptxt)
+                if not _quiet:
+                    print(_ptxt)
         if args.json_out:
             with open(args.json_out, 'w', encoding='utf-8') as f:
                 json.dump(doc, f, indent=2, sort_keys=True, default=str)
-        print("JSON_SUMMARY: " + json.dumps(doc, sort_keys=True, default=str))
+        if not _quiet:
+            print("JSON_SUMMARY: " + json.dumps(doc, sort_keys=True,
+                                                default=str))
         if args.gate:
             # Opt-in verdict. The default stays 0 on purpose -- SEEING an
             # unplaced or broken board is this tool's job, and a renderer that
@@ -1688,19 +2351,82 @@ def main(argv=None):
                 'c_hole_conflicts':
                     len(doc['checklist']['c_hole_conflicts']),
             }
+            # A census that could not be built is a FAILED gate, not a clean
+            # one: every courtyard key sits at its empty default and the
+            # verdict would otherwise read "a/b/c clear" about a board
+            # nothing measured.
+            if doc['checklist']['b_courtyard_census_error']:
+                _fail['b_courtyard_census_error'] = (
+                    doc['checklist']['b_courtyard_census_error'])
+            # run-23: courtyard blocking gates MOVED-relative -- healthy
+            # boards ship by-design interpenetrations (measured: 5 of 34
+            # corpus boards), so the census gates only where --before shows a
+            # member moved. Without --before the census stays report-only in
+            # the checklist.
+            #
+            # The guard is `args.before`, which is where `moves` comes from.
+            # It used to be `before_model is not None`, i.e. --pair, and
+            # --pair is a SECOND MODEL for the before panels -- a different
+            # question. Measured: `--before --gate` on tigard_placed never
+            # produced this key at all, and adding --pair to the same command
+            # produced b_courtyard_blocking_pairs(moved)=9. The whole block
+            # was deletable without a red test.
+            #
+            # This is NOT check_assembly's gate, and must not be read as it:
+            # `moves` here is position/rotation over refs in both boards (see
+            # moved_parts), while check_assembly also counts added, removed
+            # and side-flipped refs; and this renderer reads no --intent, so
+            # an operator-waived pair is unwaived here. Where they disagree,
+            # check_assembly is the authority.
+            if args.before:
+                _mv = {m['reference'] for m in moves}
+                _cb = [row for row in
+                       doc['checklist']['b_courtyard_blocking_pairs']
+                       if row[0] in _mv or row[1] in _mv]
+                _fail['b_courtyard_blocking_pairs(moved)'] = len(_cb)
+            # THE DEFECT RECORDS, read rather than merely written. A gate on
+            # a render made from --defect-json is asking "does this picture
+            # show the finding", and there are three ways it does not:
+            # a record refused or doubted by the reader (defect_notes -- a
+            # board_sha mismatch, an unknown schema version, an unreadable
+            # file), a defect that produced no panel (no `at` coordinate),
+            # and a panel whose shortfall came out under DEFECT_MIN_PX
+            # despite the crop (the caption's INVISIBLE AT THIS SCALE, as a
+            # number nobody has to parse out of a label).
+            if getattr(args, 'defect_json', None):
+                if _dnotes:
+                    _fail['defect_records(refused or unproven)'] = '; '.join(
+                        _dnotes)[:300]
+                _missing = len(doc['defects']) - len(doc['defect_panels'])
+                if _missing > 0:
+                    _fail['defects(no panel)'] = _missing
+                _blind = [p for p in doc['defect_panels']
+                          if p.get('shortfall_px')
+                          and p['shortfall_px'] < p['min_px'] - 0.5]
+                if _blind:
+                    _fail['defect_panels(below min_px)'] = len(_blind)
             _hit = {k: v for k, v in _fail.items() if v}
             _moved = doc['checklist']['d_moved']
             if _moved.get('match') is False:
                 _hit['d_moved'] = (f"moved {_moved.get('moved')} != expected "
                                    f"{_moved.get('expected')}")
             if _hit:
+                _xs = len(doc['checklist']['b_cross_side_stacks'])
                 print("GATE: FAIL -- " + '; '.join(f'{k}={v}'
-                                                   for k, v in _hit.items()),
+                                                   for k, v in _hit.items())
+                      + (f" [{_xs} front<->back stack(s) also present -- "
+                         f"opposite faces, NOT conflicts]" if _xs else ""),
                       file=sys.stderr)
                 return 4
+            # The cross-side stacks ride on BOTH verdicts: they look like
+            # collisions in the panels and are not, so the line that says
+            # "clear" must say how many of them the reader is about to see.
+            _xs = len(doc['checklist']['b_cross_side_stacks'])
             print("GATE: PASS -- checklist a/b/c clear"
                   + ("" if _moved.get('match') is None
-                     else f", moved {_moved.get('moved')} as expected"),
+                     else f", moved {_moved.get('moved')} as expected")
+                  + (f" ({_xs} front<->back stack(s), opposite faces, not "
+                     f"conflicts)" if _xs else ""),
                   file=sys.stderr)
     return 0
 

--- a/tests/test_defect_render_scale.py
+++ b/tests/test_defect_render_scale.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""The picture is cropped from the MEASUREMENT, not from the parts.
+
+Run 20's board is 33.8 x 46.0 mm. At `--size 1600` that is ~35 px/mm, and the
+defect it was trying to show was 41 um -- about 1.2 px. Every render was of the
+right board at a scale where the finding could not exist as an image. No mandate
+in the chain ever asked for a crop AT a routing failure; crops were reserved for
+legality findings and stop-condition claims.
+
+So the defect panel derives its own view: tighten until the SHORTFALL spans
+`DEFECT_MIN_PX`. That is the difference between a picture of the neighbourhood
+and a picture of the finding, and when even that is not enough the caption says
+INVISIBLE AT THIS SCALE rather than shipping a lie.
+
+    python3 tests/test_defect_render_scale.py
+"""
+import atexit
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for _p in (REPO, os.path.join(REPO, 'py_router'), os.path.join(REPO, 'py_tools'),
+           os.path.join(REPO, 'py_placer')):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+SKIP_EXIT = 77
+try:
+    from PIL import ImageChops                                     # noqa: F401
+except ImportError as exc:
+    print(f'SKIP: needs Pillow ({exc})')
+    sys.exit(SKIP_EXIT)
+
+import render_placement as RP                                      # noqa: E402
+
+passed = failed = 0
+
+
+def check(label, cond, detail=''):
+    global passed, failed
+    if cond:
+        passed += 1
+        print(f'  OK   {label}')
+    else:
+        failed += 1
+        print(f'  FAIL {label} -- {detail}')
+
+
+_D = tempfile.mkdtemp()
+# mkdtemp does NOT clean up after itself, and this file writes records and
+# PNGs into it on every run. Registered rather than wrapped in a `with`,
+# because the module body IS the test and half of it runs at import time.
+atexit.register(shutil.rmtree, _D, ignore_errors=True)
+
+# The run-20 measurement, in the `defect-record` shape documented on
+# render_placement.load_defect_records (the reader is the schema contract).
+_DEFECT = {
+    'kind': 'throat', 'verdict': 'CAGED', 'net': 'Net-(U4-XTAL_P)',
+    'seed': {'x': 86.8575, 'y': 91.01, 'layer': 'F.Cu'},
+    'at': {'x': 87.4825, 'y': 91.235, 'layer': 'F.Cu'},
+    'refs': ['R7', 'U4'], 'pads': ['R7.2', 'U4.53'],
+    'measure': {'space': 'track_width', 'have_mm': 0.11231, 'need_mm': 0.15,
+                'short_mm': 0.03769, 'resolution_mm': 0.01,
+                'gap_mm': 0.41231, 'gap_need_mm': 0.45,
+                'derived_from': 'have_mm + 2 * instrument.floors.clearance.value'},
+    'view': [82.8575, 87.01, 90.8575, 95.01],
+    'span': {'a': {'x': 88.0067, 'y': 90.92, 'layer': 'F.Cu', 'kind': 'pad'},
+             'b': {'x': 86.8575, 'y': 91.41, 'layer': 'F.Cu', 'kind': 'pad'}},
+    'relief': [], 'instrument': {'source': 'check_reachability', 'floors': {}},
+}
+
+
+def _rec(path, sha=None, defect=None):
+    doc = {'kind': 'defect-record', 'version': 1, 'count': 1,
+           'defects': [defect or _DEFECT]}
+    if sha:
+        doc['board_sha'] = sha
+    p = os.path.join(_D, path)
+    with open(p, 'w', encoding='utf-8') as fh:
+        json.dump(doc, fh)
+    return p
+
+
+print('--- the crop is sized from the shortfall, not from the parts ---')
+
+for size in (800, 1600, 3200):
+    view, ppmm, spx = RP.defect_view(_DEFECT, size)
+    side = view[2] - view[0]
+    check(f'at --size {size} the shortfall spans >= {RP.DEFECT_MIN_PX} px',
+          spx >= RP.DEFECT_MIN_PX - 0.5,
+          f'{spx:.2f} px over a {side:.3f}mm crop -- at the board\'s own '
+          f'extent this defect is about 1.2 px')
+    check(f'...and the throat is centred in it (--size {size})',
+          abs((view[0] + view[2]) / 2 - _DEFECT['at']['x']) < 1e-9
+          and abs((view[1] + view[3]) / 2 - _DEFECT['at']['y']) < 1e-9,
+          str(view))
+
+view, ppmm, spx = RP.defect_view(_DEFECT, 1600)
+check('the crop still frames both blocking pads',
+      view[0] <= min(_DEFECT['span']['a']['x'], _DEFECT['span']['b']['x'])
+      and view[2] >= max(_DEFECT['span']['a']['x'], _DEFECT['span']['b']['x']),
+      f'{view} vs span x '
+      f"{_DEFECT['span']['a']['x']}, {_DEFECT['span']['b']['x']} -- a crop so "
+      f"tight the two pieces of copper leave frame answers 'how much' and "
+      f"loses 'between what'")
+check('and it is far tighter than the record\'s own search view',
+      (view[2] - view[0]) < (_DEFECT['view'][2] - _DEFECT['view'][0]) / 2,
+      f"{view[2] - view[0]:.3f}mm vs "
+      f"{_DEFECT['view'][2] - _DEFECT['view'][0]:.3f}mm")
+
+# A defect carrying no shortfall must not have a scale invented for it.
+_nos = dict(_DEFECT, measure={'space': 'track_width'})
+v2, _, _ = RP.defect_view(_nos, 1600)
+check('a defect with no shortfall falls back to its own view, not a guess',
+      v2 is not None and abs((v2[2] - v2[0])
+                             - (_DEFECT['view'][2] - _DEFECT['view'][0])) < 1e-6,
+      str(v2))
+v3, _, _ = RP.defect_view({'kind': 'throat'}, 1600)
+check('and a defect with neither gets no panel at all',
+      v3 is None, str(v3))
+
+print('--- a record is BOUND to its board ---')
+
+# A tracked board: the record's coordinates come from run 20's board, which
+# is not in the repo, so the live-render checks below rebase them.
+_board = os.path.join(REPO, 'kicad_files', 'splitflap_driver.kicad_pcb')
+_sha = RP._board_sha(_board)
+check('the board hashes', bool(_sha), _board)
+
+d, notes = RP.load_defect_records([_rec('good.json', sha=_sha)], board_sha=_sha)
+check('a matching record loads', len(d) == 1 and not notes, str(notes))
+check('and remembers which file it came from',
+      d[0].get('_source', '').endswith('good.json'), str(d[0].get('_source')))
+
+d, notes = RP.load_defect_records([_rec('other.json', sha='0' * 64)],
+                                  board_sha=_sha)
+check('a record from a DIFFERENT board is dropped',
+      not d and notes, f'{len(d)} defects, notes={notes}')
+check('...loudly, naming both hashes',
+      notes and 'SKIPPED' in notes[0] and '000000000000' in notes[0],
+      str(notes))
+
+d, notes = RP.load_defect_records([_rec('nosha.json')], board_sha=_sha)
+check('a record with NO sha is drawn, but the doubt is recorded',
+      len(d) == 1 and notes and 'cannot be proven' in notes[0], str(notes))
+
+d, notes = RP.load_defect_records([os.path.join(_D, 'nope.json')],
+                                  board_sha=_sha)
+check('an unreadable record is a note, not a crash', not d and notes, str(notes))
+
+_wrong = os.path.join(_D, 'wrongkind.json')
+with open(_wrong, 'w', encoding='utf-8') as fh:
+    json.dump({'kind': 'board-score', 'blocking': 3}, fh)
+d, notes = RP.load_defect_records([_wrong], board_sha=_sha)
+check('another tool\'s JSON is refused BY KIND',
+      not d and notes and 'board-score' in notes[0], str(notes))
+
+# The reader's docstring calls itself the schema's consumer contract, so the
+# two ways a document can be off-contract have to be REFUSED, not survived.
+_arr = os.path.join(_D, 'toplevel_array.json')
+with open(_arr, 'w', encoding='utf-8') as fh:
+    json.dump([{'kind': 'defect-record', 'version': 1, 'defects': []}], fh)
+d, notes = RP.load_defect_records([_arr], board_sha=_sha)
+check('a top-level JSON ARRAY is a note, not an AttributeError',
+      not d and notes and 'not an object' in notes[0], str(notes))
+
+_v99 = os.path.join(_D, 'v99.json')
+with open(_v99, 'w', encoding='utf-8') as fh:
+    json.dump({'kind': 'defect-record', 'version': 99, 'board_sha': _sha,
+               'defects': [_DEFECT]}, fh)
+d, notes = RP.load_defect_records([_v99], board_sha=_sha)
+check('an UNKNOWN schema version is refused, not read hopefully',
+      not d and notes and 'version 99' in notes[0], str(notes))
+
+_nov = os.path.join(_D, 'nover.json')
+with open(_nov, 'w', encoding='utf-8') as fh:
+    json.dump({'kind': 'defect-record', 'board_sha': _sha,
+               'defects': [_DEFECT]}, fh)
+d, notes = RP.load_defect_records([_nov], board_sha=_sha)
+check('...but a MISSING version still loads (the key is optional)',
+      len(d) == 1, str(notes))
+check('and the known set is the documented one',
+      RP.DEFECT_SCHEMA_VERSIONS == frozenset({1}),
+      str(RP.DEFECT_SCHEMA_VERSIONS))
+
+print('--- and the panel actually draws it ---')
+
+if os.path.isfile(_board):
+    _out = os.path.join(_D, 'panels')
+    _js = os.path.join(_D, 'r.json')
+    p = subprocess.run(
+        [sys.executable, '-X', 'utf8',
+         os.path.join(REPO, 'py_tools', 'render_placement.py'), _board,
+         '--defect-json', _rec('live.json', sha=_sha), '--size', '1600',
+         '-o', _out + os.sep, '--json-out', _js],
+        capture_output=True, text=True, timeout=900)
+    ok = os.path.isfile(_js)
+    check('the render runs and writes its JSON', ok,
+          (p.stdout or '')[-300:] + (p.stderr or '')[-300:])
+    if ok:
+        doc = json.load(open(_js, encoding='utf-8'))
+        check("doc['defects'] carries what it was asked to show",
+              len(doc.get('defects') or []) == 1
+              and doc['defects'][0]['pads'] == ['R7.2', 'U4.53'],
+              str(doc.get('defects'))[:200])
+        check("instrument.defect_json mirrors instrument.summary_json",
+              isinstance(doc['instrument'].get('defect_json'), list)
+              and doc['instrument']['defect_json'],
+              str(doc['instrument'].get('defect_json'))
+              + ' -- a gate asserts a defect render the same way '
+                '_guard_route_render asserts a focus render')
+        dp = (doc.get('defect_panels') or [])
+        check('a defect panel was produced', len(dp) == 1, str(dp)[:200])
+        if dp:
+            check('and it reports the px figure it achieved, not a promise',
+                  dp[0]['shortfall_px'] >= RP.DEFECT_MIN_PX - 0.5,
+                  str(dp[0]))
+            check('the caption carries the scale so a reader can audit it',
+                  'px/mm ->' in dp[0]['label'], dp[0]['label'])
+            check('and names the two pads forming the throat',
+                  'R7.2' in dp[0]['label'] and 'U4.53' in dp[0]['label'],
+                  dp[0]['label'])
+        _pngs = [x['path'] for x in doc['panels'] if x.get('view')]
+        check('the panel was written to disk', _pngs and
+              all(os.path.isfile(x) for x in _pngs), str(_pngs))
+
+    # ImageChops: prove `draw_defects` actually drew, rather than trusting a
+    # code path that ran. Same panel, same view, defects on vs off.
+    from kicad_parser import parse_kicad_pcb                        # noqa: E402
+    _pcb = parse_kicad_pcb(_board)
+    m = RP.PlacementModel(_pcb, _board)
+    if m is not None:
+        # The record's coordinates are from the run-20 board; on the tracked
+        # board they can land OUTSIDE the outline, where a drawn mark cannot
+        # appear and this check fails for a reason that is not draw_defects.
+        # Rebase the whole record onto the loaded board's center so the mark
+        # is drawable.
+        import copy as _copy
+        _bb = _pcb.board_info.board_bounds
+        _dx = (_bb[0] + _bb[2]) / 2.0 - _DEFECT['at']['x']
+        _dy = (_bb[1] + _bb[3]) / 2.0 - _DEFECT['at']['y']
+        _DX = _copy.deepcopy(_DEFECT)
+        for _pt in (_DX['seed'], _DX['at'], _DX['span']['a'], _DX['span']['b']):
+            _pt['x'] += _dx
+            _pt['y'] += _dy
+        _DX['view'] = [_DX['view'][0] + _dx, _DX['view'][1] + _dy,
+                       _DX['view'][2] + _dx, _DX['view'][3] + _dy]
+        _v, _, _ = RP.defect_view(_DX, 420)
+        _o = dict(borders=False, labels=False, ratsnest=False, pads=True,
+                  legality=False, legend=False)
+        # Assert the DRAWING PRIMITIVE against the real renderer transform.
+        # KNOWN GAP, disclosed rather than hidden: the composed
+        # render_panel(overlays=...) path shows no mark for a standalone
+        # caller on this board (reproduced identically on every branch this
+        # test has lived on -- it is not a regression, and the CLI
+        # defect-panel path exercised above IS the shipped path and is
+        # asserted green). Until that compositing gap is root-caused, this
+        # check proves draw_defects marks pixels where tf.pt puts them.
+        from PIL import ImageDraw                                   # noqa: E402
+        from route_render import BoardRenderer as _BR         # noqa: E402
+        _r = _BR(_pcb, size=420, supersample=1, show_pads=False)
+        a = _r.frame(overlays=[])
+        b = a.copy()
+        RP.draw_defects(ImageDraw.Draw(b), _r, [_DX])
+        check('drawing the defect measurably changes the image',
+              ImageChops.difference(a, b).getbbox() is not None,
+              'a code path that runs is not a mark that appears')
+else:
+    check('a board fixture is available', False, _board)
+
+# --- the two defect keys have a READER, not just a writer ---------------
+# `defects` and `defect_panels` were write-only, and the comment beside them
+# credited loop_driver._guard_route_render with reading `shortfall_px`. It
+# reads instrument.board, checklist, summary_json and moved_refs, and nothing
+# about defects. --gate now compares the two lists and the reader's notes,
+# which is the question a gate on a defect render is actually asking.
+if os.path.isfile(_board):
+    print()
+    print('--- --gate READS the defect keys ---')
+
+    def _gate(*extra):
+        js = os.path.join(_D, 'g.json')
+        pr = subprocess.run(
+            [sys.executable, '-X', 'utf8',
+             os.path.join(REPO, 'py_tools', 'render_placement.py'), _board,
+             '--quiet', '--gate', '--json-out', js,
+             '-o', os.path.join(_D, 'gate_panels') + os.sep, *extra],
+            capture_output=True, text=True, timeout=900,
+            env=dict(os.environ, PYTHONPATH=REPO, KRT_NO_BANNER='1'))
+        return pr, json.load(open(js, encoding='utf-8'))
+
+    # This board has its own legality findings, so the gate's VERDICT is
+    # not the signal -- the KEYS are. The baseline names no defect key at
+    # all, which is the control every claim below is measured against.
+    _base, _bdoc = _gate()
+    check('without a record the gate names no defect key',
+          'defect' not in _base.stderr, _base.stderr[-300:])
+
+    _ok, _okdoc = _gate('--defect-json', _rec('gate_ok.json', sha=_sha))
+    check('a matching record adds no defect key either',
+          'defect' not in _ok.stderr, _ok.stderr[-300:])
+    check('...and the verdict is unchanged by giving one',
+          _ok.returncode == _base.returncode,
+          f'{_ok.returncode} vs {_base.returncode}')
+    check('...and the render produced the panel it was asked for',
+          len(_okdoc['defect_panels']) == len(_okdoc['defects']) == 1,
+          str(_okdoc['defect_panels'])[:200])
+
+    _bad, _ = _gate('--defect-json', _rec('gate_other.json', sha='0' * 64))
+    check('a record from ANOTHER board FAILS the gate instead of vanishing',
+          _bad.returncode == 4
+          and 'defect_records(refused or unproven)' in _bad.stderr,
+          _bad.stderr[-400:])
+
+    _noat = dict(_DEFECT)
+    _noat.pop('at')
+    _noat.pop('view')
+    _np, _npdoc = _gate('--defect-json',
+                        _rec('gate_noat.json', sha=_sha, defect=_noat))
+    check('a defect that got NO panel fails the gate',
+          _np.returncode == 4 and 'defects(no panel)=1' in _np.stderr,
+          _np.stderr[-400:])
+    check('...and the two lists disagree in the document, which is how',
+          len(_npdoc['defects']) == 1 and not _npdoc['defect_panels'],
+          str(_npdoc['defect_panels'])[:200])
+
+print(f'\n{passed} passed, {failed} failed')
+sys.exit(1 if failed else 0)

--- a/tests/test_render_view_and_drc_panels.py
+++ b/tests/test_render_view_and_drc_panels.py
@@ -134,6 +134,35 @@ def test_drc_panels_cluster_mark_and_cap():
     print("  PASS: 2 clusters -> 2 panels, waived skipped, cap reported")
 
 
+def test_quiet_keeps_keys_off_stdout_when_json_out_carries_them():
+    """Run 24, finding A-1: the review gates order 'view the image BEFORE the
+    keys', then prescribe a render command whose unconditional JSON_SUMMARY
+    echo put the keys on screen first. --quiet with --json-out now suppresses
+    the echo and the describe text (the file carries both); --quiet WITHOUT
+    --json-out must still print the summary -- data is never silenced into
+    nowhere."""
+    rp = os.path.join(ROOT, 'py_tools', 'render_placement.py')
+    board = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
+    with tempfile.TemporaryDirectory() as td:
+        out = os.path.join(td, 'r.json')
+        r = subprocess.run(
+            [sys.executable, '-X', 'utf8', rp, board, '--clearance', '0.15',
+             '--json-out', out, '--quiet', '-o', os.path.join(td, 'r.png')],
+            capture_output=True, text=True, cwd=ROOT)
+        assert r.returncode == 0, r.stdout[-400:]
+        assert 'JSON_SUMMARY' not in r.stdout, 'the echo defeats blind-first'
+        assert 'WHAT THIS PANEL SHOWS' not in r.stdout
+        assert os.path.getsize(out) > 100, 'the file must still carry the doc'
+        r2 = subprocess.run(
+            [sys.executable, '-X', 'utf8', rp, board, '--clearance', '0.15',
+             '--json', '--quiet', '-o', os.path.join(td, 'r2.png')],
+            capture_output=True, text=True, cwd=ROOT)
+        assert 'JSON_SUMMARY' in r2.stdout, \
+            'without --json-out the summary must still print somewhere'
+    print("  PASS: --quiet + --json-out is blind; --quiet alone never "
+          "silences data into nowhere")
+
+
 if __name__ == '__main__':
     for k, fn in sorted(globals().items()):
         if k.startswith('test_'):

--- a/tests/test_run23_connector_affinity.py
+++ b/tests/test_run23_connector_affinity.py
@@ -1,0 +1,499 @@
+"""connector_affinity: generic connectors get a WEAK class (run-23).
+
+Run 23 seated J2/J5/J6/J7 mid-board and no instrument could say so: generic
+connector keywords deliberately map to NO edge class (a JST wire-to-board
+part is legitimately interior -- that guard stands), and a part with no
+class is invisible to every intent rule. The weak class exists to be
+DECLARED (--declare-classes) and graded at ADVISORY severity: an INTERIOR
+pose (past part_class.INTERIOR_AFFINITY_MM from every edge) is a warning for
+the boundary review, never an error, and `pass` never flips on it.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for p in (ROOT, os.path.join(ROOT, 'py_router'), os.path.join(ROOT, 'py_placer')):
+    sys.path.insert(0, p)
+
+PLACED = os.path.join(ROOT, 'tests', 'fixtures', 'run23',
+                      'tigard_placed.kicad_pcb')
+SPLITFLAP = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
+
+
+def _cf(*argv):
+    env = dict(os.environ, PYTHONPATH=ROOT, PYTHONIOENCODING='utf-8',
+               KRT_NO_BANNER='1')
+    return subprocess.run(
+        [sys.executable, '-X', 'utf8',
+         os.path.join(ROOT, 'py_tools', 'check_floorplan.py'), *argv],
+        capture_output=True, text=True, env=env, cwd=ROOT)
+
+
+class TestClass(unittest.TestCase):
+    def test_generic_connectors_classify_weak_not_edge(self):
+        from kicad_parser import parse_kicad_pcb
+        from placement.part_class import (MECHANICAL_CLASSES, classify_part,
+                                          pose_plausible)
+        pcb = parse_kicad_pcb(PLACED)
+        for ref in ('J2', 'J4', 'J5', 'J6', 'J7'):
+            cls = classify_part(pcb.footprints[ref], ref)
+            self.assertEqual(cls.name, 'connector_affinity', ref)
+            self.assertEqual(cls.confidence, 'low', ref)
+        # The class makes NO pose claim and is NOT mechanically pinned --
+        # both would change reconstruct/stager behavior, which this class
+        # must never do.
+        self.assertNotIn('connector_affinity', MECHANICAL_CLASSES)
+        self.assertTrue(pose_plausible('connector_affinity', 0.0, 99.0))
+        # The receptacle guard stands: J1 (USB-C) is still edge_receptacle.
+        self.assertEqual(classify_part(pcb.footprints['J1'], 'J1').name,
+                         'edge_receptacle')
+
+
+class TestDeclareAndGrade(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.td = tempfile.TemporaryDirectory()
+        cls.intent = os.path.join(cls.td.name, 'intent.json')
+        r = _cf(PLACED, '--emit-intent', cls.intent, '--declare-classes')
+        assert r.returncode == 0, r.stdout[-400:]
+        cls.grade = os.path.join(cls.td.name, 'grade.json')
+        cls.gr = _cf(PLACED, '--intent', cls.intent, '--json', cls.grade)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.td.cleanup()
+
+    def test_declare_classes_declares_the_connector_family(self):
+        doc = json.load(open(self.intent, encoding='utf-8'))
+        by_ref = {c['ref']: c for c in doc['edge_connectors']}
+        for ref in ('J2', 'J4', 'J5', 'J6', 'J7'):
+            self.assertIn(ref, by_ref, 'connector not declared')
+            self.assertEqual(by_ref[ref]['class'], 'connector_affinity')
+            # NO invented edge (the run-4 rule): the note carries the
+            # measured distance instead.
+            self.assertNotIn('edge', by_ref[ref])
+            self.assertIn('measured', by_ref[ref]['note'])
+        self.assertEqual(by_ref['J1']['class'], 'edge_receptacle')
+
+    def test_interior_connector_flags_advisory_pass_survives(self):
+        self.assertEqual(self.gr.returncode, 0, self.gr.stdout[-400:])
+        doc = json.load(open(self.grade, encoding='utf-8'))
+        self.assertTrue(doc['pass'])
+        sev = [v['severity'] for v in doc['violations']]
+        self.assertNotIn('error', sev)
+        # J4 sits 6.03mm interior: flagged, as a WARNING.
+        j4 = [v for v in doc['violations'] if v['ref'] == 'J4']
+        self.assertEqual([v['severity'] for v in j4], ['warn'])
+        self.assertEqual(j4[0]['expected'], {'max_setback_mm': 3.0})
+        self.assertIn('J4 is an edge part seated', self.gr.stdout)
+        self.assertIn('[warn ]', self.gr.stdout)
+        # J7 (2.55mm, inside the affinity band) must NOT be flagged --
+        # legitimately-interior connectors are the false-positive guard.
+        self.assertNotIn('J7 is an edge part seated', self.gr.stdout)
+
+    def test_healthy_board_gains_no_errors(self):
+        with tempfile.TemporaryDirectory() as td:
+            intent = os.path.join(td, 'i.json')
+            r = _cf(SPLITFLAP, '--emit-intent', intent, '--declare-classes')
+            self.assertEqual(r.returncode, 0, r.stdout[-400:])
+            g = os.path.join(td, 'g.json')
+            r2 = _cf(SPLITFLAP, '--intent', intent, '--json', g)
+            self.assertEqual(r2.returncode, 0, r2.stdout[-400:])
+            doc = json.load(open(g, encoding='utf-8'))
+            self.assertTrue(doc['pass'])
+            self.assertNotIn(
+                'error', [v['severity'] for v in doc['violations']])
+
+
+class TestInertToThePlacementEngines(unittest.TestCase):
+    """The class DECLARES; it must not reach the placement search.
+
+    `edge_connectors` is one wire key holding two populations. The engines
+    act on an edge claim -- place_seed LOCKS those refs for the polish
+    quench, place_reconstruct grants each a banded off-outline allowance and
+    excludes it from the exchange stage, and reconstruct.classify forces them
+    into the anchor tier. Handing them the connector_affinity entries would
+    put 6 more tigard refs through all four on the strength of a class
+    nobody acted on before. `Intent.edge_claims()` is the split, in one
+    place; this pins both halves.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        from placement import floorplan
+        cls.td = tempfile.TemporaryDirectory()
+        cls.path = os.path.join(cls.td.name, 'intent.json')
+        r = _cf(PLACED, '--emit-intent', cls.path, '--declare-classes')
+        assert r.returncode == 0, r.stdout[-400:]
+        cls.doc = json.load(open(cls.path, encoding='utf-8'))
+        cls.intent = floorplan.load_intent(cls.path)
+        # The same intent with the weak class removed -- what upstream main
+        # emits, and the control every "inert" claim is measured against.
+        stripped = dict(cls.doc)
+        stripped['edge_connectors'] = [
+            c for c in cls.doc['edge_connectors']
+            if c.get('class') != 'connector_affinity']
+        cls.stripped_path = os.path.join(cls.td.name, 'stripped.json')
+        with open(cls.stripped_path, 'w', encoding='utf-8') as fh:
+            json.dump(stripped, fh)
+        cls.stripped = floorplan.load_intent(cls.stripped_path)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.td.cleanup()
+
+    def test_the_wire_key_carries_both_populations(self):
+        """upstream/main's tests/test_part_class.py reads the declaration out
+        of doc['edge_connectors'] by ref, so the entries stay there."""
+        refs = {c['ref'] for c in self.doc['edge_connectors']}
+        self.assertEqual(refs, {'J1', 'J2', 'J3', 'J4', 'J5', 'J6', 'J7'})
+
+    def test_edge_claims_is_exactly_upstream_mains_population(self):
+        claimed = {c['ref'] for c in self.intent.edge_claims()}
+        self.assertEqual(claimed, {'J1'})
+        self.assertEqual(claimed,
+                         {c['ref'] for c in self.stripped.edge_claims()})
+        self.assertEqual(len(self.intent.edge_claims()),
+                         len(self.stripped.edge_connectors))
+
+    def test_edge_claims_is_what_a_band_map_would_be_built_from(self):
+        """The shape of the trap, stated once: every consumer's band map
+        defaults a missing `max` to 2.0mm, and a connector_affinity entry
+        carries `overhang_mm` with only a `min`. The real-call-path proofs
+        are in TestSeederDrivesTheSplitForReal below; this pins WHY."""
+        bands = {c['ref']: float((c.get('overhang_mm') or {}).get('max') or 2.0)
+                 for c in self.intent.edge_claims()}
+        self.assertEqual(sorted(bands), ['J1'])
+        raw = {c['ref']: float((c.get('overhang_mm') or {}).get('max') or 2.0)
+               for c in self.intent.edge_connectors}
+        self.assertEqual(raw.get('J7'), 2.0)
+
+    def test_reconstruct_tiers_are_byte_identical_either_way(self):
+        """The real function, not a re-derivation: classify() forces edge
+        refs into the anchor tier."""
+        from kicad_parser import parse_kicad_pcb
+        import pose_score
+        from placement import reconstruct
+        pcb = parse_kicad_pcb(PLACED)
+        st = pose_score.make_state(pcb, PLACED, clearance=0.15,
+                                   board_edge_clearance=0.55, grid_step=0.1)
+        with_cls = reconstruct.classify(st, self.intent)
+        without = reconstruct.classify(st, self.stripped)
+        self.assertEqual(with_cls.edge, without.edge)
+        self.assertEqual(with_cls.edge & {'J7'}, set(),
+                         'a connector_affinity ref reached the edge tier')
+        self.assertEqual(with_cls.anchors, without.anchors)
+        self.assertEqual(with_cls.smalls, without.smalls)
+
+    def test_the_grade_still_reads_the_whole_key(self):
+        """Inert to the SEARCH, live to the RULE -- otherwise the class
+        declares nothing and J4's interior seat goes back to being
+        invisible."""
+        from placement import floorplan
+        self.assertTrue(floorplan._wants(self.intent, 'edge_connector'))
+        only_weak = dict(self.doc)
+        only_weak['edge_connectors'] = [
+            c for c in self.doc['edge_connectors']
+            if c.get('class') == 'connector_affinity']
+        p = os.path.join(self.td.name, 'weak.json')
+        with open(p, 'w', encoding='utf-8') as fh:
+            json.dump(only_weak, fh)
+        weak = floorplan.load_intent(p)
+        self.assertEqual(weak.edge_claims(), ())
+        # An intent of nothing BUT weak entries still runs the rule.
+        self.assertTrue(floorplan._wants(weak, 'edge_connector'))
+
+    ENGINES = ('py_placer/place_seed.py',
+               'py_placer/place_reconstruct.py',
+               'py_placer/placement/reconstruct.py',
+               # seeder.py is driven straight from place_seed (reseat_scope
+               # at :222, repair_placement at :284) and had SIX raw reads,
+               # two of them acting on entries as parts. It was missing from
+               # this list, which is how they survived the first pass.
+               'py_placer/placement/seeder.py')
+    # A raw read is allowed only where the entry is being copied, not acted
+    # on, and only with this marker on the line. One exists (seeder's
+    # intent2 rebuild); a second one has to be argued for.
+    EXEMPT = 'edge-claims-exempt'
+
+    def _raw_reads(self, rel):
+        import re
+        src = open(os.path.join(ROOT, rel), encoding='utf-8').read()
+        pat = r'^(?!\s*#).*[.]edge_connectors[^_a-zA-Z0-9].*$'
+        return [m.group(0).strip() for m in re.finditer(pat, src, re.M)]
+
+    def test_no_engine_reads_the_raw_key(self):
+        """A filter that must be remembered is a filter that gets forgotten.
+        Every engine read goes through edge_claims(); floorplan.py owns the
+        raw key (the rule and the applicability test read it on purpose)."""
+        waived = []
+        for rel in self.ENGINES:
+            for line in self._raw_reads(rel):
+                if self.EXEMPT in line:
+                    waived.append((rel, line))
+                    continue
+                self.fail(f'{rel} reads intent.edge_connectors directly -- '
+                          f'use edge_claims(): {line}')
+        # Exactly one exemption in the tree, and it is the one argued for in
+        # seeder.reseat_scope. A new one is a decision, not a default.
+        self.assertEqual(len(waived), 1, str(waived))
+        self.assertEqual(waived[0][0], 'py_placer/placement/seeder.py')
+
+    def test_the_guard_actually_looks_at_seeder(self):
+        """The guard is the only mechanism protecting the converted call
+        sites, so its FILE LIST has to be pinned: it passed the first review
+        while missing the engine carrying the regression."""
+        self.assertIn('py_placer/placement/seeder.py', self.ENGINES)
+        # ...and the regex really does find reads in that file (the one
+        # exempted copy), so a silently-empty scan cannot look like a pass.
+        self.assertTrue(self._raw_reads('py_placer/placement/seeder.py'))
+
+
+class TestSeederDrivesTheSplitForReal(unittest.TestCase):
+    """The engines `place_seed` actually calls, called.
+
+    The first pass at this fix converted four call sites and pinned them with
+    comprehensions re-derived in the test, which proved nothing about the
+    code: reverting `place_seed.py:429` alone left every behavioural test
+    green. Worse, it MISSED `placement/seeder.py` -- the engine
+    `place_seed.py` drives at :222 (`reseat_scope`) and :284
+    (`repair_placement`) -- where the raw key was doing real damage.
+
+    Every test here calls the engine entry point and compares the FULL
+    intent against the same intent with the connector_affinity entries
+    stripped, which is exactly what upstream main emits. Equal is the whole
+    claim: the declaration must change nothing.
+    """
+
+    # The fixture is OWNED here, and small on purpose: the same proof on
+    # tests/fixtures/run23/tigard_damaged.kicad_pcb costs 160 s per
+    # repair_placement call and this class makes four. One connector_affinity
+    # part pushed off the south edge of the tracked splitflap board makes it
+    # the sole violator, which is all the dispatch below needs.
+    DY = 55.5
+    # A ref that is NOT the damaged one, for the gate-band test: `gate_bands`
+    # is `edge_bands` minus the scope, so a band is only visible to the gate
+    # when its owner sits OUTSIDE the scope.
+    SPARE = 'R8'
+
+    @classmethod
+    def setUpClass(cls):
+        for p in (ROOT, os.path.join(ROOT, 'py_router'),
+                  os.path.join(ROOT, 'py_placer'),
+                  os.path.join(ROOT, 'py_tools')):
+            if p not in sys.path:
+                sys.path.insert(0, p)
+        from kicad_parser import parse_kicad_pcb
+        from placement import floorplan
+        from placement.writer import write_placed_output
+        cls.td = tempfile.TemporaryDirectory()
+        pcb = parse_kicad_pcb(SPLITFLAP)
+        cls.doc = floorplan.emit_intent(pcb, SPLITFLAP, declare_classes=True)
+        cls.weak = sorted(c['ref'] for c in cls.doc['edge_connectors']
+                          if c.get('class') == 'connector_affinity')
+        assert cls.weak, 'fixture declares no connector_affinity part'
+        cls.victim = cls.weak[0]
+        cls.spare = cls.SPARE
+
+        fp = pcb.footprints[cls.victim]
+        cls.board = os.path.join(cls.td.name, 'damaged.kicad_pcb')
+        write_placed_output(SPLITFLAP, cls.board, [
+            {'reference': cls.victim, 'new_x': fp.x, 'new_y': cls.DY,
+             'new_rotation': fp.rotation or 0.0}])
+
+        full = os.path.join(cls.td.name, 'full.json')
+        with open(full, 'w', encoding='utf-8') as fh:
+            json.dump(cls.doc, fh)
+        cls.full = floorplan.load_intent(full)
+        stripped = dict(cls.doc)
+        stripped['edge_connectors'] = [
+            c for c in cls.doc['edge_connectors']
+            if c.get('class') != 'connector_affinity']
+        sp = os.path.join(cls.td.name, 'stripped.json')
+        with open(sp, 'w', encoding='utf-8') as fh:
+            json.dump(stripped, fh)
+        cls.stripped = floorplan.load_intent(sp)
+
+        cls.rep_full = cls._repair(cls.full)
+        cls.rep_strip = cls._repair(cls.stripped)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.td.cleanup()
+
+    @classmethod
+    def _repair(cls, intent):
+        from kicad_parser import parse_kicad_pcb
+        from placement import seeder
+        return seeder.repair_placement(
+            parse_kicad_pcb(cls.board), cls.board, intent, group_sources=(),
+            clearance=0.15, board_edge_clearance=0.55, grid_step=0.1)
+
+    def test_the_weak_violator_reaches_the_ordinary_repair_loop(self):
+        """THE REGRESSION. `repair_placement` dispatches every entry in its
+        edge map that carries no `edge` into a refusal BEFORE the ordinary
+        _try_place loop, so reading the raw key took the connector_affinity
+        declarations -- which never carry an edge, by design -- out of repair
+        entirely, and mislabelled them 'declared edge part' on the way out.
+        Measured on tigard_damaged: J5, J6 and J7 refused that way, where
+        upstream main tries them and reports 'no legal pose within any cap'."""
+        rep = self.rep_full
+        self.assertIn(self.victim, rep['violators'],
+                      'the fixture no longer makes the weak part a violator, '
+                      'so this test proves nothing')
+        bad = [n for n in rep['notes']
+               if 'declared edge part misplaced' in n
+               and any(n.startswith(w + ':') for w in self.weak)]
+        self.assertEqual(bad, [], 'a connector_affinity part was refused as a '
+                                  'declared edge part instead of repaired')
+        mine = [n for n in rep['notes'] if n.startswith(self.victim + ':')]
+        self.assertTrue(mine, 'the weak violator produced no note at all, so '
+                              'it never reached the loop')
+        # Whatever the loop decides is fine -- what matters is that the loop
+        # decided it. These are the verdicts only the ordinary path emits.
+        self.assertTrue(
+            any(k in mine[0] for k in ('re-seated', 'no legal pose',
+                                       'disproportionate', 'seated its pair')),
+            mine[0])
+
+    def test_repair_is_identical_with_and_without_the_declaration(self):
+        """The strongest form: same engine, same board, two intents that
+        differ only by the weak entries. Every output must match."""
+        a, b = self.rep_full, self.rep_strip
+        self.assertEqual(sorted(a['violators']), sorted(b['violators']))
+        self.assertEqual(sorted(a['repaired']), sorted(b['repaired']))
+        self.assertEqual(sorted(a['unrepairable']), sorted(b['unrepairable']))
+        self.assertEqual(sorted(n['reference'] for n in a['moves']),
+                         sorted(n['reference'] for n in b['moves']))
+        self.assertEqual(sorted(a['notes']), sorted(b['notes']))
+
+    def _reseat(self, intent, refs):
+        from kicad_parser import parse_kicad_pcb
+        from placement import seeder
+        return seeder.reseat_scope(
+            parse_kicad_pcb(self.board), self.board, intent, refs=refs,
+            group_sources=(), clearance=0.15, board_edge_clearance=0.55,
+            grid_step=0.1, seed=0)
+
+    def test_reseat_gate_bands_are_identical_either_way(self):
+        """`reseat_scope` builds {ref: band} from the entries and defaults a
+        missing `max` to 2.0mm -- an off-outline licence charged in the gate
+        tuple. The tuples it reports are measured against that map, so equal
+        tuples is the proof the weak entries bought no band.
+
+        THE SCOPE MUST EXCLUDE THE OFF-BOARD WEAK PART, and that is the whole
+        trick of this test rather than an accident: `gate_bands` is
+        `edge_bands` minus the scope, so a scope containing the damaged part
+        drops its band before the gate ever sees it and the raw key looks
+        innocent. Measured with the raw key restored and the victim OUT of
+        scope, the oob term reads 0.882 against 1.902 -- 1.02mm of off-board
+        copper forgiven on the strength of a declaration nobody made. With
+        the victim IN scope both read 1.902 and the mutation survives."""
+        refs = [self.spare]
+        self.assertNotIn(self.victim, refs)
+        a = self._reseat(self.full, refs)
+        b = self._reseat(self.stripped, refs)
+        # Ask the module for the column rather than hardcoding 3: a new
+        # gate term inserted before 'oob' would move it, and this
+        # assertion would then quietly measure something else.
+        from placement import reconstruct as _recon_mod
+        _oob = _recon_mod.GATE_TERMS.index('oob')
+        self.assertGreater(a['gate_before'][_oob], 0.0,
+                           'the fixture charges no off-board amount, so this '
+                           'test cannot see a band either way')
+        self.assertEqual(a['gate_before'], b['gate_before'])
+        self.assertEqual(a['gate_after'], b['gate_after'])
+        self.assertEqual(a['accepted'], b['accepted'])
+        self.assertEqual(a['reseated'], b['reseated'])
+        self.assertEqual(sorted(a['notes']), sorted(b['notes']))
+
+    def test_reseat_drops_no_declaration_it_never_made(self):
+        """A weak entry has no band to forfeit, so it must not be reported
+        as a dropped edge declaration -- and it must survive into the
+        sub-intent the pass seeds from (the one raw read left in seeder.py,
+        which exists so intent2 stays a faithful copy)."""
+        a = self._reseat(self.full, [self.victim])
+        self.assertNotIn(self.victim, a['edge_bands_dropped'])
+        kept = {c['ref'] for c in a['intent_used'].edge_connectors}
+        self.assertTrue(set(self.weak) <= kept,
+                        'the sub-intent lost the class declarations')
+        # ...and the sub-intent's CLAIMS are still only the real ones.
+        self.assertNotIn(self.victim,
+                         {c['ref'] for c in a['intent_used'].edge_claims()})
+
+
+class TestPlaceSeedLocksOnlyClaims(unittest.TestCase):
+    """place_seed:429 passes `edge_refs` to the polish quench as `lock_refs`.
+
+    Driven through `place_seed.main()` with the real argv, capturing the
+    kwargs the quench is actually called with. A comprehension re-derived in
+    the test would pass with the line reverted, which is how this one got
+    through the first review.
+    """
+
+    def test_lock_refs_are_the_edge_claims(self):
+        for p in (ROOT, os.path.join(ROOT, 'py_router'),
+                  os.path.join(ROOT, 'py_placer'),
+                  os.path.join(ROOT, 'py_tools')):
+            if p not in sys.path:
+                sys.path.insert(0, p)
+        from kicad_parser import parse_kicad_pcb
+        from placement import quench as quench_mod
+        from placement.floorplan import emit_intent
+        from placement.writer import write_placed_output
+        import place_seed
+
+        board = SPLITFLAP
+        pcb = parse_kicad_pcb(board)
+        with tempfile.TemporaryDirectory() as td:
+            pile = os.path.join(td, 'pile.kicad_pcb')
+            write_placed_output(board, pile, [
+                {'reference': r, 'new_x': 10.0, 'new_y': 10.0,
+                 'new_rotation': 0.0} for r in sorted(pcb.footprints)])
+            ip = os.path.join(td, 'i.json')
+            with open(ip, 'w', encoding='utf-8') as fh:
+                json.dump(emit_intent(pcb, board, declare_classes=True), fh)
+            doc = json.load(open(ip, encoding='utf-8'))
+            weak = {c['ref'] for c in doc['edge_connectors']
+                    if c.get('class') == 'connector_affinity'}
+            claims = {c['ref'] for c in doc['edge_connectors']
+                      if c.get('class') != 'connector_affinity'}
+            self.assertTrue(weak and claims, str(doc['edge_connectors'])[:200])
+
+            seen = {}
+
+            class _Stop(RuntimeError):
+                pass
+
+            def _spy(*a, **kw):
+                seen['lock_refs'] = kw.get('lock_refs')
+                raise _Stop()
+
+            real, quench_mod.quench = quench_mod.quench, _spy
+            argv = sys.argv
+            sys.argv = ['place_seed.py', pile,
+                        os.path.join(td, 'out.kicad_pcb'), '--intent', ip]
+            try:
+                try:
+                    place_seed.main()
+                except _Stop:
+                    pass
+            finally:
+                quench_mod.quench = real
+                sys.argv = argv
+
+        self.assertIn('lock_refs', seen, 'the polish quench was never reached')
+        got = set(seen['lock_refs'] or ())
+        self.assertEqual(got & weak, set(),
+                         f'connector_affinity refs locked in the polish: '
+                         f'{sorted(got & weak)}')
+        self.assertEqual(got, claims)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=1)

--- a/tests/test_run23_courtyard_channel.py
+++ b/tests/test_run23_courtyard_channel.py
@@ -1,0 +1,605 @@
+"""The run-23 courtyard channel: census absolute, gate moved-vs-baseline.
+
+Run 23 shipped a board every gate called buildable while J4 stood 0.90mm
+inside U6's courtyard (5.56mm2), J3 interpenetrated R13 and RN3 still sat
+0.83mm2 into U5 -- residue of the staged damage the repair moved but never
+cleared. The courtyard channel existed and was advisory everywhere.
+
+Why the gate is moved-vs-baseline and NOT absolute, measured on this repo's
+own corpus before this landed: 5 of 34 healthy human boards (glasgow_revC,
+orangecrab_ext_pll, rp2350_fpga_eensy_prePlane, ulx3s, watchy) ship unwaived
+courtyard interpenetrations past any sane area/depth floor -- ulx3s GPDI1<->
+U11 at 38.5mm2 / depth 5.1, rp2350 U3 frac-1.0 inside J2 -- all by design
+(parts under connector shells). An absolute conjunct flips them all NOT
+BUILDABLE. A pair therefore gates only when a MEMBER MOVED relative to
+--baseline: a pristine board graded against itself can never flip, while a
+repair run owns every pair its moves created or failed to clear.
+
+And why moved-MEMBER rather than new-PAIR: RN3<->U5 exists in the damaged
+baseline too (the staged containment). A membership test calls it
+pre-existing and misses it; the repair moved RN3 3.28mm, so the moved test
+charges it. That distinction is pinned here because it is exactly the kind
+of clause a cleanup would simplify away.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+
+PLACED = os.path.join(ROOT, 'tests', 'fixtures', 'run23',
+                      'tigard_placed.kicad_pcb')
+DAMAGED = os.path.join(ROOT, 'tests', 'fixtures', 'run23',
+                       'tigard_damaged.kicad_pcb')
+ULX3S = os.path.join(ROOT, 'kicad_files', 'ulx3s.kicad_pcb')
+
+
+def _run(*argv):
+    env = dict(os.environ, PYTHONPATH=ROOT, PYTHONIOENCODING='utf-8',
+               KRT_NO_BANNER='1')
+    return subprocess.run(
+        [sys.executable, '-X', 'utf8',
+         os.path.join(ROOT, 'py_tools', 'check_assembly.py'), *argv],
+        capture_output=True, text=True, env=env, cwd=ROOT)
+
+
+def _grade(board, *extra):
+    with tempfile.TemporaryDirectory() as td:
+        jp = os.path.join(td, 'a.json')
+        r = _run(board, '--json', jp, *extra)
+        return r, json.load(open(jp, encoding='utf-8'))
+
+
+class TestRun23Board(unittest.TestCase):
+    """The board run 23 actually shipped, graded the way the run should."""
+
+    def test_gates_against_the_damaged_baseline(self):
+        r, doc = _grade(PLACED, '--baseline', DAMAGED)
+        self.assertEqual(r.returncode, 4, r.stdout[-600:])
+        self.assertFalse(doc['buildable'])
+        self.assertIn('NOT BUILDABLE', r.stdout)
+        self.assertEqual(doc['courtyard_blocking_gating'], 9)
+        self.assertEqual(doc['courtyard_gating_basis'], 'moved-vs-baseline')
+        gating = {(q['a'], q['b'])
+                  for q in doc['courtyard_blocking_gating_pairs']}
+        self.assertEqual(gating, {('J4', 'U6'), ('J3', 'R13'),
+                                  ('RN3', 'U5'), ('SW1', 'U1'),
+                                  ('J1', 'SW1'), ('J1', 'SW2'),
+                                  ('J1', 'R5'), ('J4', 'R21'),
+                                  ('H2', 'J3')})
+        # `blocking` (pad intersections) must NOT have moved -- it has three
+        # consumers and this board has none.
+        self.assertEqual(doc['blocking'], 0)
+
+    def test_moved_member_charges_a_baseline_resident_pair(self):
+        """RN3<->U5 is IN the damaged baseline; a new-pair test misses it."""
+        r, doc = _grade(PLACED, '--baseline', DAMAGED)
+        gating = {(q['a'], q['b'])
+                  for q in doc['courtyard_blocking_gating_pairs']}
+        self.assertIn(('RN3', 'U5'), gating)
+        # And the stdout names WHO moved (RN3; U5 stood still).
+        self.assertIn('GATES (moved: RN3)', r.stdout)
+
+    def test_without_baseline_census_reports_but_never_gates(self):
+        r, doc = _grade(PLACED)
+        self.assertEqual(r.returncode, 0, r.stdout[-600:])
+        self.assertTrue(doc['buildable'])
+        self.assertEqual(doc['courtyard_blocking'], 10)
+        self.assertIsNone(doc['courtyard_blocking_gating'])
+        self.assertEqual(doc['courtyard_gating_basis'],
+                         'no-baseline: report-only')
+        self.assertIn('REPORT-ONLY', r.stdout)
+
+    def test_synthetic_courtyards_never_block(self):
+        """G***'s +/-0.5mm fictional box manufactured a 0.537mm2 'pair'."""
+        _r, doc = _grade(PLACED, '--baseline', DAMAGED)
+        self.assertIn('G***', doc['courtyard_synthetic_refs'])
+        blocked = {(q['a'], q['b']) for q in doc['courtyard_blocking_pairs']}
+        self.assertNotIn(('G***', 'J5'), blocked)
+        # ...but the pair stays VISIBLE in the census (disclosure, not gate).
+        census = {(q['a'], q['b']) for q in doc['courtyard_pairs']}
+        self.assertIn(('G***', 'J5'), census)
+
+    def test_floors_hold_the_true_slivers_out(self):
+        """The RELATIVE floor (user finding): J4<->R21's 0.445mm2 slid
+        under the 0.5mm2 absolute floor while consuming 25.5% of R21's
+        courtyard -- it blocks now. The true slivers (D3<->SW1 0.059mm2 at
+        depth 0.02, frac 0.014) stay advisory: every floor must hold
+        SOMETHING out or it is not a floor."""
+        _r, doc = _grade(PLACED, '--baseline', DAMAGED)
+        blocked = {(q['a'], q['b']) for q in doc['courtyard_blocking_pairs']}
+        self.assertIn(('J4', 'R21'), blocked)
+        self.assertNotIn(('D3', 'SW1'), blocked)
+        self.assertNotIn(('D4', 'SW2'), blocked)
+        census = {(q['a'], q['b']) for q in doc['courtyard_pairs']}
+        self.assertIn(('D3', 'SW1'), census)
+
+    def test_dead_edge_waiver_does_not_hide_the_switches(self):
+        """The user's own finding, pinned: SW1/SW2 collided with parts and
+        NOTHING said so, because edge_class -- a class lookup with no
+        geometry -- waived every pair. The waiver now stands only for a
+        member whose pose is edge-LIVE (overhanging, or within seat
+        tolerance): SW1 sat 2.0mm interior, SW2 8.33mm, so SW1<->U1 and
+        FB1<->SW2 join the blocking census. And a LIVE waiver covers only
+        the MATING ZONE (second user finding): J1 is legitimately at the
+        edge, but R5 sat 45.7% inside J1's INTERIOR courtyard -- under the
+        connector body, 1.5mm inside the outline -- so J1<->R5, J1<->SW1
+        and J1<->SW2 block too; only an overlap that leaves or hugs the
+        outline is mating volume."""
+        _r, doc = _grade(PLACED, '--baseline', DAMAGED)
+        blocked = {(q['a'], q['b']) for q in doc['courtyard_blocking_pairs']}
+        self.assertIn(('SW1', 'U1'), blocked)
+        self.assertIn(('FB1', 'SW2'), blocked)
+        self.assertIn(('J1', 'R5'), blocked)
+        self.assertIn(('J1', 'SW1'), blocked)
+        # FB1<->SW2 is the moved-currency's NAMED blind spot: the damage
+        # placed both and the repair never touched either, so no movement
+        # test can charge it without flipping pristine boards. It must stay
+        # visible in the census while NOT gating.
+        gating = {(q['a'], q['b'])
+                  for q in doc['courtyard_blocking_gating_pairs']}
+        self.assertNotIn(('FB1', 'SW2'), gating)
+
+    def test_locked_and_mount_hole_pairs_face_the_floors(self):
+        """User finding #3, two rules in one pair: H2<->J3 (4.63mm2, depth
+        1.47) hid behind the blanket marker_class waiver. A mounting hole's
+        courtyard is the SCREW-HEAD keepout -- physical, unlike a fiducial's
+        -- and H2 is KiCad-LOCKED, and no class waiver blesses contact with
+        a locked part (the run-8 E6 principle, extended here). Both rules
+        route the pair to the ordinary floors; J3 moved 3.07mm, so it
+        gates. Fiducial/testpoint markers keep the blanket exemption
+        (G***<->TP1 stays out of blocking)."""
+        _r, doc = _grade(PLACED, '--baseline', DAMAGED)
+        blocked = {(q['a'], q['b']) for q in doc['courtyard_blocking_pairs']}
+        self.assertIn(('H2', 'J3'), blocked)
+        self.assertNotIn(('G***', 'TP1'), blocked)
+        gating = {(q['a'], q['b'])
+                  for q in doc['courtyard_blocking_gating_pairs']}
+        self.assertIn(('H2', 'J3'), gating)
+
+    def test_opposite_side_xy_overlap_is_not_a_pair(self):
+        """User question, answered by measurement and pinned: JP2 (a
+        B-side SMD jumper) sits exactly over F-side R16/C25 in XY -- pad
+        gap 0.000mm -- and that is NOT a conflict: opposite faces. The
+        side-aware census must never pair them."""
+        _r, doc = _grade(PLACED)
+        census = {(q['a'], q['b']) for q in doc['courtyard_pairs']}
+        self.assertNotIn(('JP2', 'R16'), census)
+        self.assertNotIn(('C25', 'JP2'), census)
+
+    def test_full_census_is_carried(self):
+        """The 15-pair census the user SAW must be in the JSON, waivers and
+        all -- J1<->SW1 (7.0mm2, edge-waived) is the one a reader asks about
+        first."""
+        _r, doc = _grade(PLACED)
+        census = {(q['a'], q['b']) for q in doc['courtyard_pairs']}
+        self.assertIn(('J1', 'SW1'), census)
+        self.assertGreaterEqual(len(census), 15)
+
+
+class TestRenderCourtyardTruth(unittest.TestCase):
+    """render_placement must SHOW the courtyard channel, not only key it.
+
+    Run 23's board was viewed at L3 with 'overlap 26.30mm2' in the banner and
+    still read clean: courtyards drew as thin gray outlines (overlap looks
+    like tight packing) and the checklist had no key for the courtyard
+    census -- b_body_overlap_pairs is PAD intersections.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.td = tempfile.TemporaryDirectory()
+        jp = os.path.join(cls.td.name, 'r.json')
+        png = os.path.join(cls.td.name, 'r.png')
+        sheet = os.path.join(cls.td.name, 'sheet.png')
+        env = dict(os.environ, PYTHONPATH=ROOT, PYTHONIOENCODING='utf-8',
+                   KRT_NO_BANNER='1')
+        r = subprocess.run(
+            [sys.executable, '-X', 'utf8',
+             os.path.join(ROOT, 'py_tools', 'render_placement.py'),
+             PLACED, '--clearance', '0.15', '--json-out', jp, '-o', png,
+             '--review-sheet', sheet],
+            capture_output=True, text=True, env=env, cwd=ROOT)
+        assert r.returncode == 0, r.stdout[-600:] + r.stderr[-600:]
+        cls.doc = json.load(open(jp, encoding='utf-8'))
+        cls.png_f = png.replace('.png', '_F.png')
+        cls.sheet = sheet
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.td.cleanup()
+
+    def test_checklist_carries_the_courtyard_keys(self):
+        cl = self.doc['checklist']
+        blocked = {(a, b) for a, b, _m, _d in
+                   cl['b_courtyard_blocking_pairs']}
+        self.assertEqual(blocked, {('J4', 'U6'), ('J3', 'R13'),
+                                   ('RN3', 'U5'), ('SW1', 'U1'),
+                                   ('FB1', 'SW2'), ('J1', 'SW1'),
+                                   ('J1', 'SW2'), ('J1', 'R5'),
+                                   ('J4', 'R21'), ('H2', 'J3')})
+        # THREE POPULATIONS, and they are not nested -- the key names say
+        # which is which (run-23 review: 'overlap' implied a superset).
+        adv = {(a, b) for a, b, _m, _d in cl['b_courtyard_advisory_pairs']}
+        self.assertNotIn('b_courtyard_overlap_pairs', cl,
+                         'the ambiguous name must not come back')
+        # J4<->R21 blocks via the RELATIVE floor (25.5% of R21's courtyard);
+        # the true slivers stay out of the blocking list.
+        self.assertIn(('J4', 'R21'), adv)
+        # `blocking` is NOT inside `advisory`: a waiver-VOIDED pair blocks
+        # while staying labelled waived, so the advisory list is smaller and
+        # misses some blockers. Pinned, because a reader who assumes nesting
+        # audits the wrong list.
+        self.assertTrue(blocked - adv,
+                        'blocking pairs absent from advisory: '
+                        f'{sorted(blocked - adv)}')
+        # And the mm2 figure sums EVERY courtyard pair, waived included --
+        # not the sum of either list.
+        self.assertIsNone(cl['b_courtyard_census_error'])
+        self.assertNotIn(('D3', 'SW1'), blocked)
+        self.assertGreater(cl['b_courtyard_overlap_mm2'], 20.0)
+
+    def test_the_defect_is_in_the_pixels(self):
+        """The C_COURT_OVL fill must be present INSIDE the J4<->U6
+        intersection region -- the picture, not only the key."""
+        from PIL import Image
+        img = Image.open(self.png_f).convert('RGB')
+        w, h = img.size
+        hits = sum(1 for _x in range(0, w, 7) for _y in range(0, h, 7)
+                   if img.getpixel((_x, _y)) == (255, 120, 40))
+        self.assertGreater(
+            hits, 20, 'no courtyard-interpenetration fill in the render')
+
+    def test_review_sheet_exists_and_is_wide(self):
+        from PIL import Image
+        self.assertTrue(os.path.exists(self.sheet))
+        img = Image.open(self.sheet)
+        # F+B side by side over a facts strip: wider than tall, and taller
+        # than either bare panel (the strip).
+        self.assertGreater(img.width, img.height)
+        self.assertEqual(self.doc.get('review_sheet'), self.sheet)
+
+
+class TestPristineBoards(unittest.TestCase):
+    """The corpus lesson: healthy boards carry big by-design censuses."""
+
+    def test_pristine_board_vs_itself_never_flips(self):
+        r, doc = _grade(ULX3S, '--baseline', ULX3S)
+        self.assertEqual(r.returncode, 0, r.stdout[-600:])
+        self.assertTrue(doc['buildable'])
+        # The census is large and REAL (GPDI1's shell over its passives) --
+        # pin that it exists, so a future "fix" that empties the census to
+        # make the gate quiet is caught here.
+        self.assertGreaterEqual(doc['courtyard_blocking'], 10)
+        self.assertEqual(doc['courtyard_blocking_gating'], 0)
+
+    def test_pristine_board_without_baseline_stays_buildable(self):
+        r, doc = _grade(ULX3S)
+        self.assertEqual(r.returncode, 0, r.stdout[-600:])
+        self.assertTrue(doc['buildable'])
+
+    def test_cross_side_stacks_are_named_not_paired(self):
+        """User finding on the ulx3s review: BAT1 sits BEHIND the buttons
+        (B4: 68.7mm2 of XY overlap, opposite faces) and the panels make that
+        visually indistinguishable from a collision. The census correctly
+        refuses to pair opposite faces; the render's checklist now NAMES the
+        stacks so the sheet pre-answers the eye instead of looking blind."""
+        import subprocess as _sp
+        env = dict(os.environ, PYTHONPATH=ROOT, PYTHONIOENCODING='utf-8',
+                   KRT_NO_BANNER='1')
+        with tempfile.TemporaryDirectory() as td:
+            jp = os.path.join(td, 'r.json')
+            r = _sp.run([sys.executable, '-X', 'utf8',
+                         os.path.join(ROOT, 'py_tools',
+                                      'render_placement.py'),
+                         ULX3S, '--json-out', jp,
+                         '-o', os.path.join(td, 'r.png')],
+                        capture_output=True, text=True, env=env, cwd=ROOT)
+            self.assertEqual(r.returncode, 0, r.stdout[-400:])
+            doc = json.load(open(jp, encoding='utf-8'))
+            stacks = {(a, b) for a, b, _m in
+                      doc['checklist']['b_cross_side_stacks']}
+            self.assertIn(('B4', 'BAT1'), stacks)
+            # ...and the same pair is NOT in the courtyard census: opposite
+            # faces never pair.
+            census = {(a, b) for a, b, *_ in
+                      doc['checklist']['b_courtyard_advisory_pairs']}
+            self.assertNotIn(('B4', 'BAT1'), census)
+
+
+def _render(*argv):
+    env = dict(os.environ, PYTHONPATH=ROOT, PYTHONIOENCODING='utf-8',
+               KRT_NO_BANNER='1')
+    return subprocess.run(
+        [sys.executable, '-X', 'utf8',
+         os.path.join(ROOT, 'py_tools', 'render_placement.py'), *argv],
+        capture_output=True, text=True, env=env, cwd=ROOT)
+
+
+class TestReviewSheetShowsTheAfterBoard(unittest.TestCase):
+    """The sheet must compose the board the facts strip describes.
+
+    Found by review: the sheet picked "the first two panels with no view",
+    and under --pair the panel list is [BEFORE F, BEFORE B, AFTER F, AFTER B]
+    with view=None on all four -- so the strip's AFTER census sat under the
+    BEFORE picture. Measured then: the sheet's top-left 600x600 was
+    pixel-identical to the BEFORE render and differed from the AFTER render
+    in 170480 px. A reviewer reading that sheet dispositions defects against
+    the wrong copper.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        from PIL import Image                                    # noqa: F401
+        cls.td = tempfile.TemporaryDirectory()
+        d = cls.td.name
+        cls.sheet = os.path.join(d, 'sheet.png')
+        r = _render(PLACED, '--before', DAMAGED, '--pair',
+                    '--clearance', '0.15', '--quiet',
+                    '--json-out', os.path.join(d, 'r.json'),
+                    '-o', os.path.join(d, 'r.png'),
+                    '--review-sheet', cls.sheet)
+        assert r.returncode == 0, r.stdout[-600:] + r.stderr[-600:]
+        cls.doc = json.load(open(os.path.join(d, 'r.json'), encoding='utf-8'))
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.td.cleanup()
+
+    def _panel(self, label_prefix, side):
+        hits = [p['path'] for p in self.doc['panels']
+                if (p.get('label') or '').startswith(label_prefix)
+                and p.get('side') == side]
+        self.assertEqual(len(hits), 1, str(self.doc['panels']))
+        return hits[0]
+
+    def test_pair_really_wrote_four_full_board_panels(self):
+        """The precondition that made the bug possible, pinned: all four
+        panels carry view=None, so `view is None` cannot select the AFTER
+        pair and a future 'simplification' back to it is caught here."""
+        full = [p for p in self.doc['panels'] if p.get('view') is None]
+        self.assertEqual(len(full), 4, str(self.doc['panels']))
+        self.assertTrue((full[0].get('label') or '').startswith('BEFORE'))
+
+    def test_sheet_region_is_the_after_panel_not_the_before(self):
+        from PIL import Image, ImageChops
+        sheet = Image.open(self.sheet).convert('RGB')
+        before = Image.open(self._panel('BEFORE', 'F')).convert('RGB')
+        after = Image.open(self._panel('AFTER', 'F')).convert('RGB')
+        box = (0, 0, 600, 600)
+        reg = sheet.crop(box)
+
+        def ndiff(a, b):
+            # Non-black pixels of the difference: histogram bucket 0 is
+            # "identical", everything above it is a changed pixel.
+            return sum(ImageChops.difference(a, b).convert('L')
+                       .histogram()[1:])
+
+        d_after = ndiff(reg, after.crop(box))
+        d_before = ndiff(reg, before.crop(box))
+        self.assertEqual(d_after, 0,
+                         f'sheet region differs from the AFTER panel in '
+                         f'{d_after} px')
+        self.assertGreater(d_before, 1000,
+                           'the AFTER and BEFORE panels are indistinguishable '
+                           'here, so this test proves nothing -- pick a '
+                           'region that changed')
+
+
+class TestMovedCourtyardGateArmsOnBefore(unittest.TestCase):
+    """--gate's moved-relative courtyard key must arm on --before ALONE.
+
+    It guarded on the --pair model instead, so `--before --gate` (the way
+    every driver in this repo calls it) never produced the key: the whole
+    block was deletable with the suite green. Measured: adding --pair to the
+    same command yielded b_courtyard_blocking_pairs(moved)=9.
+    """
+
+    def _gate(self, *extra):
+        with tempfile.TemporaryDirectory() as td:
+            jp = os.path.join(td, 'r.json')
+            r = _render(PLACED, '--clearance', '0.15', '--quiet', '--gate',
+                        '--json-out', jp, '-o', os.path.join(td, 'r.png'),
+                        *extra)
+            return r, json.load(open(jp, encoding='utf-8'))
+
+    def test_before_alone_arms_the_moved_key(self):
+        r, _doc = self._gate('--before', DAMAGED)
+        self.assertEqual(r.returncode, 4, r.stderr[-400:])
+        self.assertIn('b_courtyard_blocking_pairs(moved)=9', r.stderr)
+
+    def test_pair_and_before_agree(self):
+        """--pair changes the PANELS, not the gate: same key, same count."""
+        r, _doc = self._gate('--before', DAMAGED, '--pair')
+        self.assertIn('b_courtyard_blocking_pairs(moved)=9', r.stderr)
+
+    def test_without_before_the_key_is_absent(self):
+        """No baseline, no moved-relative verdict -- report-only, as the
+        corpus census demands (5 of 34 healthy boards would flip)."""
+        r, doc = self._gate()
+        self.assertNotIn('b_courtyard_blocking_pairs(moved)', r.stderr)
+        # ...but the census is still in the checklist, unarmed.
+        self.assertTrue(doc['checklist']['b_courtyard_blocking_pairs'])
+
+    def test_gate_line_discloses_the_cross_side_stacks(self):
+        """b_cross_side_stacks had no reader anywhere. The verdict line is
+        the one place a reader is guaranteed to look, and these are exactly
+        the pairs that read as collisions in the panels."""
+        r, doc = self._gate('--before', DAMAGED)
+        self.assertTrue(doc['checklist']['b_cross_side_stacks'])
+        self.assertIn('front<->back stack(s)', r.stderr)
+
+
+def _floorplan(*argv):
+    env = dict(os.environ, PYTHONPATH=ROOT, PYTHONIOENCODING='utf-8',
+               KRT_NO_BANNER='1')
+    return subprocess.run(
+        [sys.executable, '-X', 'utf8',
+         os.path.join(ROOT, 'py_tools', 'check_floorplan.py'), *argv],
+        capture_output=True, text=True, env=env, cwd=ROOT)
+
+
+class TestWithheldBudgetIsVisibleAtGradeTime(unittest.TestCase):
+    """A withheld budget must ABSTAIN, out loud, not vanish.
+
+    emit_intent withholds `overlap_area` when the emitting board carries
+    unwaived courtyard interpenetrations past the blocking floors -- baking
+    it would bless the board it was measured on. But the grade then had a
+    bare `continue` on the missing key and the run printed "0 error(s)" with
+    the overlap channel never measured. The withholding note lived only in
+    the emitted file, where the grade never looked.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.td = tempfile.TemporaryDirectory()
+        cls.intent = os.path.join(cls.td.name, 'i.json')
+        r = _floorplan(PLACED, '--emit-intent', cls.intent,
+                       '--declare-classes')
+        assert r.returncode == 0, r.stdout[-400:]
+        cls.doc = json.load(open(cls.intent, encoding='utf-8'))
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.td.cleanup()
+
+    def test_the_emitter_withheld_overlap_area(self):
+        # The key is on `context`, which is where emit_intent writes it.
+        self.assertIn('overlap_area', self.doc['context']['budget_withheld'])
+        self.assertNotIn('overlap_area', self.doc['legality_budget'])
+
+    def test_grade_reports_it_as_not_derivable(self):
+        g = os.path.join(self.td.name, 'g.json')
+        r = _floorplan(PLACED, '--intent', self.intent, '--json', g)
+        self.assertIn('NOT DERIVABLE', r.stdout)
+        self.assertIn('overlap_area', r.stdout)
+        # --json carries the full report: {key: reason}.
+        doc = json.load(open(g, encoding='utf-8'))
+        self.assertEqual(sorted(doc['budget_abstained']), ['overlap_area'])
+        self.assertIn('courtyard', doc['budget_abstained']['overlap_area'])
+        # ...and the flat JSON_SUMMARY carries the machine-readable count.
+        s = json.loads(r.stdout.split('JSON_SUMMARY: ', 1)[1].splitlines()[0])
+        self.assertEqual(s['budget_abstained'], 1)
+        self.assertEqual(s['budget_abstained_keys'], ['overlap_area'])
+        # An abstention is NOT a violation and must not inflate one.
+        self.assertEqual(s['errors'], 0)
+
+    def test_a_hand_declared_budget_overrides_the_withholding(self):
+        """Declaring the number by hand is the documented escape hatch, and
+        a declared key is graded, not abstained."""
+        hand = json.loads(json.dumps(self.doc))
+        hand['legality_budget']['overlap_area'] = 999.0
+        p = os.path.join(self.td.name, 'hand.json')
+        with open(p, 'w', encoding='utf-8') as fh:
+            json.dump(hand, fh)
+        g = os.path.join(self.td.name, 'g2.json')
+        r = _floorplan(PLACED, '--intent', p, '--json', g)
+        self.assertNotIn('NOT DERIVABLE', r.stdout)
+        doc = json.load(open(g, encoding='utf-8'))
+        self.assertEqual(doc['budget_abstained'], {})
+
+    def test_an_empty_budget_names_the_withholding_in_the_skip_reason(self):
+        """When NOTHING was derivable the legality rule does not run at all,
+        and "the intent declares no legality_budget" reads as "nobody wanted
+        one". It must say the emitter refused."""
+        none = json.loads(json.dumps(self.doc))
+        none['legality_budget'] = {}
+        p = os.path.join(self.td.name, 'none.json')
+        with open(p, 'w', encoding='utf-8') as fh:
+            json.dump(none, fh)
+        r = _floorplan(PLACED, '--intent', p)
+        self.assertIn('WITHHELD', r.stdout)
+        self.assertIn('- legality:', r.stdout)
+
+
+class TestCensusFailureIsNotCleanliness(unittest.TestCase):
+    """A census that could not be built must say so, not read as clean.
+
+    The whole courtyard block sat under a bare `except Exception: pass`, so
+    an exception anywhere in it left every key at its empty default: the
+    checklist read clean, the review sheet headlined "blocking: none", and
+    --gate said "checklist a/b/c clear" about a board nothing had measured.
+    """
+
+    def setUp(self):
+        for p in (ROOT, os.path.join(ROOT, 'py_router'),
+                  os.path.join(ROOT, 'py_placer'),
+                  os.path.join(ROOT, 'py_tools')):
+            if p not in sys.path:
+                sys.path.insert(0, p)
+
+    def _findings(self, broken):
+        import render_placement as RP
+        from kicad_parser import parse_kicad_pcb
+        from placement import legality as LEG
+        pcb = parse_kicad_pcb(PLACED)
+        model = RP.PlacementModel(pcb, PLACED, quench_kwargs={
+            'clearance': 0.15, 'board_edge_clearance': 0.55})
+        orig = LEG.grade_body_overlap
+        if broken:
+            def boom(*_a, **_k):
+                raise RuntimeError('census unavailable')
+            LEG.grade_body_overlap = boom
+        try:
+            return RP.legality_findings(model)
+        finally:
+            LEG.grade_body_overlap = orig
+
+    def test_a_broken_census_is_recorded_not_swallowed(self):
+        fnd = self._findings(broken=True)
+        self.assertIn('census unavailable',
+                      fnd['courtyard_census_error'] or '')
+        # ...and the keys really are at their empty defaults, which is
+        # exactly why silence was unsafe.
+        self.assertEqual(fnd['courtyard_blocking_pairs_refs'], [])
+        self.assertEqual(fnd['courtyard_overlap_mm2'], 0.0)
+
+    def test_the_sheet_says_not_measured_instead_of_blocking_none(self):
+        import render_placement as RP
+        from PIL import Image
+        fnd = self._findings(broken=True)
+        lines = []
+        with tempfile.TemporaryDirectory() as td:
+            panel = os.path.join(td, 'p.png')
+            Image.new('RGB', (400, 400), (0, 0, 0)).save(panel)
+            sheet = os.path.join(td, 's.png')
+
+            class _Spy:
+                def __init__(self, inner):
+                    self._inner = inner
+
+                def __getattr__(self, name):
+                    return getattr(self._inner, name)
+
+                def text(self, xy, s, **kw):
+                    lines.append(s)
+                    return self._inner.text(xy, s, **kw)
+
+            _orig = RP.ImageDraw.Draw
+
+            def _draw(img, *a, **k):
+                return _Spy(_orig(img, *a, **k))
+
+            RP.ImageDraw.Draw = _draw
+            try:
+                RP.write_review_sheet(sheet, [panel], fnd, [])
+            finally:
+                RP.ImageDraw.Draw = _orig
+            self.assertTrue(os.path.isfile(sheet))
+        joined = ' '.join(lines)
+        self.assertIn('NOT MEASURED', joined)
+        self.assertNotIn('blocking: none', joined)
+
+    def test_a_working_census_reports_no_error(self):
+        fnd = self._findings(broken=False)
+        self.assertIsNone(fnd['courtyard_census_error'])
+        self.assertTrue(fnd['courtyard_blocking_pairs_refs'])
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=1)

--- a/tests/test_run23_pockets.py
+++ b/tests/test_run23_pockets.py
@@ -1,0 +1,126 @@
+"""check_pockets: the aggregate handoff census per-net gates cannot give.
+
+Run 23: check_channels said 0 starved faces, check_reachability said every
+failing pad PASSABLE, crossings sat below the damaged baseline -- and two
+nets then died across ~20 route laps in one pocket (RN7/U6/J4/RN8, where
+committed copper wrapped RN7 at 0.095mm against the 0.45mm lane need). The
+census here must NAME that geography pre-route, and must stay REPORT-ONLY
+(exit 0): an absolute threshold on a young metric is how phantom gates get
+born.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+PLACED = os.path.join(ROOT, 'tests', 'fixtures', 'run23',
+                      'tigard_placed.kicad_pcb')
+SPLITFLAP = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
+
+
+def _run(*argv):
+    env = dict(os.environ, PYTHONPATH=ROOT, PYTHONIOENCODING='utf-8',
+               KRT_NO_BANNER='1')
+    return subprocess.run(
+        [sys.executable, '-X', 'utf8',
+         os.path.join(ROOT, 'py_tools', 'check_pockets.py'), *argv],
+        capture_output=True, text=True, env=env, cwd=ROOT)
+
+
+class TestPocketCensus(unittest.TestCase):
+    def test_names_the_run23_pocket(self):
+        with tempfile.TemporaryDirectory() as td:
+            jp = os.path.join(td, 'p.json')
+            r = _run(PLACED, '--json', jp, '--top', '8')
+            self.assertEqual(r.returncode, 0, r.stdout[-400:])
+            # The failure geography by name: the top windows must carry the
+            # nets that ate run 23's endgame and the parts that cage them.
+            self.assertIn('/ICE_CDONE', r.stdout)
+            self.assertIn('RN8', r.stdout)
+            self.assertIn('U6', r.stdout)
+            # The lane arithmetic the forensics measured the cage against.
+            self.assertIn('0.45', r.stdout)
+            doc = json.load(open(jp, encoding='utf-8'))
+            self.assertEqual(doc['lane_mm'], 0.45)
+            self.assertGreater(len(doc['windows']), 10)
+
+    def test_report_only_and_multi_net_ranking(self):
+        r = _run(PLACED, '--top', '5')
+        self.assertEqual(r.returncode, 0)
+        self.assertIn('REPORT-ONLY', r.stdout)
+        # Every RANKED row is a >=2-net window -- a single-net sliver inside
+        # one part's own pad field means nothing for simultaneous
+        # routability and must not top the list.
+        for ln in r.stdout.splitlines():
+            ln = ln.strip()
+            if ln.startswith('[') and 'demand' in ln:
+                n = int(ln.split('demand')[1].split('net(s)')[0].strip())
+                self.assertGreaterEqual(n, 2, ln)
+
+    def test_exit_zero_on_a_healthy_board(self):
+        r = _run(SPLITFLAP, '--top', '3')
+        self.assertEqual(r.returncode, 0, r.stdout[-400:])
+
+
+class TestBinBelowTheCensusFloor(unittest.TestCase):
+    """A --bin under the census floor must not mislocate the windows.
+
+    congestion_bins floors its bin at 0.25mm; this tool built its window
+    rectangles from the REQUESTED value, so at --bin 0.1 a window whose true
+    left edge is 64.75mm was reported at 25.9mm -- roughly 39mm away, on a
+    part of the board where nothing had been measured. The whole point of
+    this instrument is to name a geography.
+    """
+
+    def _census(self, *extra):
+        with tempfile.TemporaryDirectory() as td:
+            jp = os.path.join(td, 'p.json')
+            r = _run(PLACED, '--json', jp, '--top', '4', *extra)
+            self.assertEqual(r.returncode, 0, r.stdout[-400:])
+            return r, json.load(open(jp, encoding='utf-8'))
+
+    def test_windows_match_the_effective_bin_not_the_requested_one(self):
+        r_small, small = self._census('--bin', '0.1')
+        _r_floor, floor = self._census('--bin', '0.25')
+        self.assertEqual(small['bin_mm'], 0.25)
+        self.assertEqual(small['bin_requested_mm'], 0.1)
+        # Same census, therefore the SAME geography -- this is the assertion
+        # the bug broke.
+        self.assertEqual([w['window'] for w in small['windows']],
+                         [w['window'] for w in floor['windows']])
+        # Every window is exactly one effective bin wide, so a rectangle
+        # cannot silently be a tenth of the cell it describes.
+        for w in small['windows']:
+            self.assertAlmostEqual(w['window'][2] - w['window'][0], 0.25, 6)
+        # ...and the clamp is announced, not silent.
+        self.assertIn('below the census floor', r_small.stderr)
+        self.assertIn('0.25mm', r_small.stdout)
+
+    def test_a_bin_at_or_above_the_floor_is_untouched(self):
+        r, doc = self._census('--bin', '2.0')
+        self.assertEqual(doc['bin_mm'], 2.0)
+        self.assertEqual(doc['bin_requested_mm'], 2.0)
+        self.assertNotIn('below the census floor', r.stderr)
+        for w in doc['windows']:
+            self.assertAlmostEqual(w['window'][2] - w['window'][0], 2.0, 6)
+
+    def test_the_json_is_strict_json(self):
+        """`ratio` used to have a float('inf') branch, which json.dump
+        writes as a bare `Infinity` token that strict parsers refuse."""
+        with tempfile.TemporaryDirectory() as td:
+            jp = os.path.join(td, 'p.json')
+            _run(PLACED, '--json', jp, '--bin', '0.25')
+            raw = open(jp, encoding='utf-8').read()
+            json.loads(raw, parse_constant=_no_constants)
+
+
+def _no_constants(tok):
+    raise AssertionError(f'non-standard JSON token {tok!r} in the census')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=1)


### PR DESCRIPTION
Review instruments, rebuilt on current main. This replaces #683 (closed while it was stacked on #680 and #682). It now carries only its own files on top of the merged legality (#680), run-output (#686) and seeder (#687) work, so every hunk here is new against main. The reachability instrument that writes defect records is a separate PR; this one reads a plain JSON file and imports nothing from it.

## What changes for a user

- `render_placement --review-sheet PATH` writes one composite image for the boundary review: the F and B panels side by side over a facts strip carrying the courtyard census, every connector-family part's distance to its nearest edge (INTERIOR flagged past 3 mm), and the front/back stacks that look like collisions in the panels but sit on opposite faces. Long lines wrap at the `  |  ` separator so a ten-pair blocking list stays on the sheet. With `--pair` the sheet composes the AFTER panels, which is the board the facts strip describes. The path it wrote is echoed back as `review_sheet` in the JSON, or `null` when the compose failed.
- The courtyard channel reaches the render. Courtyard pairs come from `legality.grade_body_overlap`, the same function `check_assembly` calls, and are drawn as a filled intersection with the pair named on the image. The JSON checklist gains `b_courtyard_advisory_pairs`, `b_courtyard_blocking_pairs`, `b_courtyard_overlap_mm2`, `b_courtyard_census_error` and `b_cross_side_stacks`. `b_body_overlap_pairs` was pad intersections all along, which is how a board with one part 0.90 mm inside another's courtyard rendered "clean". With `--gate` and `--before`, a blocking pair with a moved member fails the gate; without `--before` the census is report-only.
- `render_placement --defect-json PATH` (repeatable) draws defect panels. A defect record is a plain JSON file; the schema is documented on `load_defect_records`, which is the consumer contract and now enforces it: a document that is not a JSON object, or whose `version` is not one this reader knows, is refused with a note instead of read hopefully. Each defect gets its own panel, cropped so the measured shortfall spans at least 16 px (`DEFECT_MIN_PX`), the measured gap drawn solid and the required gap dashed alongside it. Records whose `board_sha` does not match the board are skipped with a note, and every note is carried in the document as `instrument.defect_notes`. The caption and `defect_panels[].shortfall_px` report the scale actually achieved and say INVISIBLE AT THIS SCALE when it is not enough. Giving `--defect-json` SUPPRESSES the `--focus` legality-pocket panels (a measured coordinate beats a cluster derived from pad positions); `--focus` panels for failed nets, which need `--summary-json`, are unaffected. With `--gate`, a defect render now also FAILS (exit 4) when a record was refused or cannot be proven to describe this board -- including one that merely lacks `board_sha` -- when a defect produced no panel, or when a panel could not reach `DEFECT_MIN_PX`. That is a new verdict channel, and it fixes the contract before its writer exists: a gate asked to judge a defect render should not pass one that could not show the defect. Nothing in this tree writes such a record yet; the reachability PR does.
- `render_placement --side F|B` renders one face only. `--quiet` together with `--json-out` now also suppresses the stdout JSON_SUMMARY echo and the describe text (the file carries both), so a reviewer can look at the image before reading the keys; without `--json-out` the summary still prints.
- `check_pockets.py` is new: routing demand against free copper area per window, before routing. The board is binned at `--bin` mm, each bin's distinct demanding nets are set against its free area, and the top windows are printed with their nets and parts, plus the lane arithmetic (track + 2 x clearance at the board's own floors). Report-only, exit 0 always; there is no threshold by default because the metric is too young to own one. `--bin` is floored at 0.25 mm, which is the census's own floor, and the effective value is announced and recorded rather than silently accepted. It uses the router's own census: `congestion_field.build_congestion2` is split so that `congestion_bins` holds the bin computation and both consumers share one definition. The A* cost path is unchanged; a dead loop in the moved body (`for p in pads: pass`) is dropped.
- `connector_affinity` becomes an intent class. `check_floorplan --emit-intent --declare-classes` records connector-family parts that claim no edge with `"class": "connector_affinity"` and no `edge`, and the `edge_connector` rule flags such a part seated more than 3 mm from every edge at warn only, whatever the configured severity; `pass` never flips on it. An author upgrades the entry by writing `max_setback_mm` or `edge`.
- `--emit-intent` withholds the `overlap_area` budget when the emitting board carries unwaived courtyard interpenetrations past the blocking floors (it already did for blocking body pairs), and `context.budget_withheld` names what was withheld and why. A withheld key is now ABSTAINED at grade time rather than silently ungraded: `check_floorplan --intent` prints `N legality budget key(s) NOT DERIVABLE -- not graded, not passed` and carries `budget_abstained` in `--json` and `budget_abstained` / `budget_abstained_keys` in JSON_SUMMARY.

There is no wall-clock budget in any engine or tool path. (`tests/test_defect_render_scale.py` passes `timeout=900` to `subprocess.run`, which is a test-harness guard against a hung child, not a budget any shipped code observes.)

## Two populations, named

Three courtyard numbers reach the render and they are not nested, so each key names its own population. Measured on `tests/fixtures/run23/tigard_placed.kicad_pcb`: `b_courtyard_overlap_mm2` = 26.98, summing EVERY courtyard pair including waived ones; `b_courtyard_advisory_pairs` = 5, the unwaived ones; `b_courtyard_blocking_pairs` = 10, the ones past the blocking floors, of which 6 are absent from the advisory list because a waiver-voided pair (dead edge waiver, locked member) blocks while staying labelled waived. The first of those keys was called `b_courtyard_overlap_pairs`, which invited a reader to treat the advisory list as a superset. The sheet's headline now says which population each number is.

`edge_connectors` in an emitted intent also holds two populations, and that one is a real hazard rather than a naming problem. An `edge_receptacle` entry is a seat claim the placement engines act on: `place_seed` LOCKS those refs for its polish quench, `place_reconstruct` and `seeder.reseat_scope` give each a banded off-outline allowance, `place_reconstruct` excludes them from the exchange stage, `reconstruct.classify` forces them into the anchor tier, and `seeder.repair_placement` routes them to an edge seat instead of the ordinary repair loop. A `connector_affinity` entry is a declaration with no claim. `Intent.edge_claims()` is the split, in one place rather than as a filter repeated at eleven call sites, and it is what every engine read goes through; the `edge_connector` rule reads the whole key, because flagging an interior pose is the entry's only purpose. On tigard_placed the emitted `edge_connectors` is 7 entries and `edge_claims()` is 1, which is exactly what upstream main emits.

The `repair_placement` site was a measured regression, caught in review and fixed here rather than shipped. Its dispatch refuses every entry in its edge map that carries no `edge`, before the ordinary `_try_place` loop, so reading the raw key took the declarations out of repair entirely. On `tests/fixtures/run23/tigard_damaged.kicad_pcb` with its own `--declare-classes` intent, J5, J6 and J7 came back as "declared edge part misplaced, but no edge is declared" -- a label they had not earned -- where upstream main tries them like any other violator and reports "no legal pose within any cap". With the split in place the run is note-for-note identical to main's (29 notes each) and the output board is pose-identical. One raw read is left in `seeder.reseat_scope`, marked `edge-claims-exempt`, because the sub-intent it builds must stay a faithful copy of the declaration list; the source guard in the tests accepts exactly that one and fails on any other.

## What the render's census is NOT

It calls the same function as `check_assembly`, and it is not the same census. Two differences, in the code comments and here:

- `check_assembly` passes `intent_waivers`; `render_placement` reads no intent, so an operator-waived pair is unwaived here and can reach `--gate`.
- `moved_parts` (the gate's currency) compares position and rotation over refs present in BOTH boards. `check_assembly`'s moved set also counts refs the baseline does not have, and side flips. On a board whose parts were added, removed or flipped the two lists differ.

Where they disagree, `check_assembly` is the authority. `--gate` here is a render's own verdict about its own picture.

`connector_edge_facts`, which feeds the sheet's connector row, is a footprint-NAME heuristic (`conn`, `header`, `jst`, `usb`, ...) plus the two `part_class` edge classes. It is deliberately broader than `part_class`'s gating classes and it is presentation only: nothing gates on it, and a connector whose footprint is named otherwise is missing from that row. The sheet says so on its face.

## Files

- `py_tools/render_placement.py`: courtyard, cross-side and census-error keys in `legality_findings`; `load_defect_records` (with the schema refusals), `defect_view`, `draw_defects`, `DEFECT_MIN_PX`, `DEFECT_SCHEMA_VERSIONS`; the courtyard overlay in `draw_legality` and its legend row; `connector_edge_facts` and `write_review_sheet`; the `--defect-json`, `--side`, `--review-sheet` flags and the `--quiet` change; the defect panels, the `defects` / `defect_panels` / `instrument.defect_json` / `instrument.defect_notes` / `review_sheet` keys, the review-sheet write and the moved-member courtyard gate in `main`.
- `py_tools/check_pockets.py`: new.
- `py_router/congestion_field.py`: `congestion_bins` extracted from `build_congestion2` so the pocket census and the router's A* cost share one definition, returning the bin it actually used alongside the bins. The extraction is behaviour preserving: the `max(0.25, bin)` and `max(1, layers)` clamps moved inside the new function and the caller still applies its own, and the env gate stays in `build_congestion2`. It also drops a `for p in pads: pass` no-op loop that folded nothing (the per-net pad loop below it does the work).
- `py_placer/placement/floorplan.py`: the `connector_affinity` branch of `rule_edge_connector`, its declaration in `emit_intent`, `Intent.edge_claims()`, `Intent.budget_withheld` and the `budget_abstained` reporting, and the courtyard budget withholding.
- `py_placer/place_seed.py`, `py_placer/place_reconstruct.py`, `py_placer/placement/reconstruct.py`, `py_placer/placement/seeder.py`: the engine reads go through `edge_claims()`.
- `docs/floorplan-intent.md`: the rule row, the class declaration, the two populations, and the withheld budget (`context.budget_withheld`, and what the grade does with it).
- Tests: `tests/test_run23_courtyard_channel.py`, `tests/test_defect_render_scale.py`, `tests/test_run23_pockets.py`, `tests/test_run23_connector_affinity.py` (new); `tests/test_render_view_and_drc_panels.py` gains the `--quiet` test.

Scope note: `test_run23_courtyard_channel.py` also pins `check_assembly`'s moved-vs-baseline courtyard gate and the courtyard floors, which #680 merged without a test; that code is not touched here.

A point in this PR's favour that is easy to miss: `upstream/main:tests/test_part_class.py:178` already asserts `by_ref['J7']['class'] == 'connector_affinity'` against an EMITTED intent. It is green on main only because its fixture (`wk/b2/tigard__swap/d0/perturbed.kicad_pcb`) is untracked and the test skips. Staged with that fixture present, main fails it with `KeyError: 'J7'` and this branch passes it. The emitter this PR adds is the one main's test was written for.

## Testing

Against upstream main at 0ba0226f, each run in the foreground with `python3 -X utf8`:

- `tests/test_defect_render_scale.py`: 38 passed, 0 failed.
- `tests/test_render_view_and_drc_panels.py`: ALL PASS (includes the new `--quiet` test).
- `tests/test_run23_pockets.py`: 6 tests OK.
- `tests/test_run23_connector_affinity.py`: 16 tests OK.
- `tests/test_run23_courtyard_channel.py`: 28 tests OK.
- `tests/test_504_ratsnest_metrics.py`: ALL PASS (unchanged; #683 listed it, and it still passes on its upstream version, so its one-line sys.path edit from #683 is not carried).
- `tests/test_run6_check_assembly.py`: OK.
- `tests/gui_parity/test_manifest_plan_parity.py` and `tests/gui_parity/test_cli_postpass_coverage.py`: 0 mismatches, 0 failures. `render_placement.py` stays in the converter's refused-tools map (it changes no board); `check_pockets.py` is a read-only checker like the other `check_*` tools, which the map does not list.

The tests use tracked boards only (`tests/fixtures/run23/`, `kicad_files/splitflap_driver.kicad_pcb`, `kicad_files/ulx3s.kicad_pcb`). No placement objective term changes, so `tests/test_placement_ab.py` is not affected: `edge_claims()` restores the pre-existing seeding and reconstruction inputs rather than altering them. That is asserted through the real call paths, not re-derived in the test: `TestSeederDrivesTheSplitForReal` calls `seeder.repair_placement` and `seeder.reseat_scope` with the full intent and with the same intent stripped of its `connector_affinity` entries and requires every output to match, `TestPlaceSeedLocksOnlyClaims` drives `place_seed.main()` and captures the `lock_refs` the polish quench is actually called with, and `TestInertToThePlacementEngines` calls `reconstruct.classify` on both intents and compares the tiers.
