### PR TITLE
capacity options and board_brief: say what a board cannot hold, with the number

### DIFF
--- a/py_placer/placement/options.py
+++ b/py_placer/placement/options.py
@@ -1,0 +1,686 @@
+"""When a board cannot hold its parts, say so WITH THE NUMBER and the options.
+
+The prohibition this serves is written down in six places -- docs/floorplan-
+intent.md:29-40, floorplan.py:14-19, check_floorplan.py:19-24,
+rule_envelope:692, and both placement skills -- and every one of them says the
+same sentence:
+
+    the honest response to a board that is genuinely too small is to say so
+    with the measured number and stop
+
+The number was never computed. `out_of_board_area` is the nearest quantity and
+`floorplan.py:347-360` explicitly DISQUALIFIES it as a budget key, because a
+part sitting inside a cutout scores 0.0 area. Nothing sums a required area,
+nothing re-runs a lane ledger at another layer count, and nothing converts a
+face deficit into the millimetres of span that would clear it. So a run that
+hits a genuinely too-small board can only stop, and the person reading it has
+to go and measure by hand what to change.
+
+THIS REPORTS; IT NEVER REFUSES AND NEVER ACTS. That is the house pattern from
+`placement_driver._guard_congestion:779-823` -- "ok is False ONLY when the
+evidence is missing; the numbers themselves never refuse... The executor
+decides" -- and from `lock_advisor`, which prints a paste-ready `--lock` and
+locks nothing, because a wrong auto-action fails invisibly.
+
+Nothing here writes Edge.Cuts or a stackup. The only two things in the tree
+that write an outline stay `kicad_writer.strip_zero_length_edge_cuts` and the
+corpus tool `fix_outline_gaps.py`. This proposes with a number, exactly as
+`recommend-stackup/SKILL.md:44` already does: "propose the nearest workable
+option... Do not modify the board file directly -- stackup is a fab-facing
+decision the user must own."
+
+Every option carries the house shape:
+
+    ran        bool -- False means NOT MEASURED, never "fine"
+    reason     why it did not run
+    measured   what this board is
+    expected   what it would have to be
+    action     the sentence or argv a human would act on, never run here
+"""
+from __future__ import annotations
+
+import math
+from typing import Dict, List, Optional, Sequence
+
+# A board packed tighter than this by courtyard area is worth remarking on even
+# when every part currently fits: the parts have to be ROUTED between, and the
+# corpus's own comfortable boards sit far below it. Deliberately advisory --
+# see the module docstring on why nothing here refuses.
+CROWDED_UTILISATION = 0.55
+
+
+def _skip(reason: str) -> Dict:
+    return {'ran': False, 'reason': reason}
+
+
+def deficit_totals(ledgers) -> Dict[str, int]:
+    """(lanes short in total, parts with any short face, parts examined).
+
+    Read off `FaceLedger.deficit` directly. `PartEscape` exposes `worst` (a
+    FaceLedger or None) and NO `worst_deficit` attribute -- that name exists
+    only as a key in its `to_dict()`. A `getattr(p, 'worst_deficit', 0)`
+    therefore always returns the default, silently, and turns "38 faces are
+    short" into "0", which is the exact shape of failure this repo names
+    elsewhere: a component nothing examined reported as clean.
+    """
+    lanes = parts = 0
+    for p in ledgers:
+        worst = getattr(p, 'worst', None)
+        if worst is not None and worst.deficit > 0:
+            parts += 1
+        lanes += sum(f.deficit for f in (getattr(p, 'faces', ()) or ()))
+    return {'lanes': lanes, 'parts': parts, 'examined': len(ledgers)}
+
+
+# A container must HOST this fraction of the other parts to count as one.
+HOSTS_FRACTION = 0.30
+
+
+def _hosts_the_design(ref, gx0, gy0, gx1, gy1, fp, footprints) -> bool:
+    """Is this big footprint a frame around the design, or just a big part?
+
+    Area alone is not enough, and getting that wrong is worse than not
+    excluding at all. `CONTAINER_RATIO` is relative to the BOARD, so on a
+    genuinely too-small board ordinary connectors cross it -- measured on a
+    synthetically shrunk splitflap, 12 plain connectors were classed as
+    containers, which would have suppressed the very parts causing the
+    shortfall and understated the answer this option exists to give.
+
+    A real container hosts the design: other parts sit INSIDE it. rp2350's U8
+    contains most of the board; a big connector on a small board contains
+    nothing.
+
+    Two conditions beyond that, each added because the first version of this
+    guard failed the same way it was written to prevent:
+
+    * **SAME SIDE ONLY.** Utilisation is per-side, so a part on F.Cu cannot
+      host one on B.Cu. Layer-blind, an 18x25.5mm module on F.Cu was
+      "hosting" twenty 0402s underneath it on B.Cu and got excluded, and a
+      board whose true F.Cu utilisation was 1.10 reported `fits` at 0.55.
+    * **NOT A PILE.** On an unplaced board every part shares one coordinate,
+      so ANY part covering that point hosts 100% of the design. Measured on a
+      shrunk, piled haasoscope: a BGA-256 and a BGA-529 were classed as
+      containers and a real 524.86mm2 shortfall was reported as no shortfall
+      at all. Two BGAs are not "a frame, not a body". Require the hosted
+      parts to occupy several DISTINCT positions, which a pile cannot.
+    """
+    x0 = fp.x + gx0
+    y0 = fp.y + gy0
+    x1 = fp.x + gx1
+    y1 = fp.y + gy1
+    side = getattr(fp, 'layer', None) or 'F.Cu'
+    others = [o for r, o in footprints.items()
+              if r != ref and (getattr(o, 'layer', None) or 'F.Cu') == side]
+    if len(others) < 4:
+        return False
+    hosted = [o for o in others if x0 <= o.x <= x1 and y0 <= o.y <= y1]
+    if len(hosted) < HOSTS_FRACTION * len(others):
+        return False
+    # A frame hosts a LAYOUT, not a stack. Distinct positions is what
+    # separates the two, and it is exactly what a pile does not have.
+    spots = {(round(o.x, 3), round(o.y, 3)) for o in hosted}
+    return len(spots) >= max(4, 0.5 * len(hosted))
+
+
+def grow_board(pcb_data, pcb_file: str, *, clearance: float,
+               board_edge_clearance: float) -> Dict:
+    """Does the total part area fit inside the outline, and by how much not?
+
+    This is the number the prohibition asks for and nobody computes. It is
+    deliberately a NECESSARY-condition test, not a sufficient one: parts whose
+    courtyards sum to more than the usable area certainly do not fit, while
+    parts that sum to less may still not fit for shape reasons. Reporting it
+    as "at least this much more" rather than "this much more" is the honest
+    reading, and the field is named so.
+
+    Courtyard area is used where a footprint has one and the pad bounding box
+    where it does not, and the count of each is reported: a pad bbox carries
+    no courtyard margin, so a board made of them reads smaller than it builds.
+    """
+    from placement.parser import extract_courtyard_bboxes
+    bi = pcb_data.board_info
+    if bi.board_bounds is None:
+        return _skip('the board has no outline to measure against')
+    x0, y0, x1, y1 = bi.board_bounds
+    usable_w = max(0.0, (x1 - x0) - 2 * board_edge_clearance)
+    usable_h = max(0.0, (y1 - y0) - 2 * board_edge_clearance)
+    usable = usable_w * usable_h
+
+    try:
+        cy = extract_courtyard_bboxes(pcb_file) or {}
+    except Exception as e:                       # noqa: BLE001
+        return _skip(f'courtyards unreadable: {type(e).__name__}: {e}')
+
+    total = 0.0
+    from_courtyard = from_pads = no_geometry = 0
+    biggest = []
+    from placement.legality import CONTAINER_RATIO, rotate_local_bounds
+    from placement.utility import compute_footprint_bbox_local
+    per_side = {'F.Cu': 0.0, 'B.Cu': 0.0}
+    containers = []
+    outline_area = (x1 - x0) * (y1 - y0)
+    for ref, fp in sorted(pcb_data.footprints.items()):
+        box = cy.get(ref)
+        if box:
+            from_courtyard += 1
+        elif fp.pads:
+            # NOT max(global_x) - min(global_x): the pad-CENTRE span omits the
+            # pads' own size, so a two-pad part measures ZERO width along its
+            # pad axis (esp_prog C1: [0.0, 1.778] against a real 2.794x1.016)
+            # and the sum understated total part area by 51% on that board.
+            box = compute_footprint_bbox_local(fp)
+            from_pads += 1
+        else:
+            no_geometry += 1
+            continue
+        # Both sources are footprint-LOCAL; rotate into board space or every
+        # 90/270 part is transposed.
+        gx0, gy0, gx1, gy1 = rotate_local_bounds(*box, fp.rotation or 0.0)
+        w, h = gx1 - gx0, gy1 - gy0
+        # A CONTAINER is a module-outline footprint hosting the design -- a
+        # frame, not a body -- and charging its area against the board is how
+        # this option told a SHIPPING board it does not fit. Measured on
+        # rp2350_fpga_eensy: U8's bbox is 1.15x the whole board and 66% of the
+        # busiest side, giving utilisation 1.91 and a demand for 526.67 mm2
+        # more area; without it the board reads 0.64 and fits. Same ratio and
+        # the same calibration part as legality.CONTAINER_RATIO, which exists
+        # for exactly this and which this function was not consulting.
+        if (outline_area > 0 and (w * h) >= CONTAINER_RATIO * outline_area
+                and _hosts_the_design(ref, gx0, gy0, gx1, gy1, fp,
+                                      pcb_data.footprints)):
+            containers.append((round(w * h, 2), ref))
+            continue
+        # Each part also needs clearance around it; charging half the
+        # clearance per side is what makes the sum comparable to the usable
+        # area rather than to the parts' bare footprints.
+        a = (w + clearance) * (h + clearance)
+        total += a
+        layer = getattr(fp, 'layer', None) or 'F.Cu'
+        per_side[layer] = per_side.get(layer, 0.0) + a
+        biggest.append((round(a, 2), ref))
+    biggest.sort(reverse=True)
+
+    # Utilisation is PER SIDE. Summing both sides against one side's usable
+    # area is why this told the shipping OrangeCrab it does not fit and
+    # recommended shrinking a working board: F.Cu 999.94mm2 and B.Cu 364.17
+    # against 1088.58 usable -- each side fits, their sum (1364.11, util
+    # 1.2531) does not. A part on B.Cu does not compete for F.Cu area.
+    # (ulx3s flips the same way, 1.3373 -> 0.9018.)
+    busiest = max(per_side.values()) if per_side else 0.0
+    util = (busiest / usable) if usable > 0 else float('inf')
+    fits = busiest <= usable
+    out = {
+        'ran': True,
+        'measured': {
+            'part_area_mm2': round(total, 2),
+            # Both sides, and the one utilisation is computed from. Reported
+            # because `part_area_mm2` alone cannot be checked against
+            # `utilisation` on a two-sided board, and a reader who tries will
+            # conclude the number is wrong.
+            'part_area_by_side_mm2': {k: round(v, 2)
+                                      for k, v in sorted(per_side.items())},
+            'busiest_side_area_mm2': round(busiest, 2),
+            'usable_area_mm2': round(usable, 2),
+            'outline_area_mm2': round((x1 - x0) * (y1 - y0), 2),
+            'utilisation': round(util, 4),
+            'parts': len(pcb_data.footprints),
+            # Named, never silently dropped: a reader must be able to see
+            # WHY a 731mm2 part is absent from the sum.
+            'containers_excluded': [r for _a, r in sorted(containers,
+                                                          reverse=True)],
+            'container_area_mm2': round(sum(a for a, _r in containers), 2),
+            'extent_from_courtyard': from_courtyard,
+            'extent_from_pad_bbox': from_pads,
+            'parts_without_geometry': no_geometry,
+            'largest_parts_mm2': biggest[:5],
+        },
+        'expected': {'utilisation': f'<= 1.0 to fit at all, and typically '
+                                    f'<= {CROWDED_UTILISATION} to route'},
+        'fits_by_area': fits,
+    }
+    if not fits:
+        need = busiest - usable
+        # Square-ish growth is the cheapest way to state it; a real outline
+        # change is a mechanical decision and this does not pretend otherwise.
+        #
+        # The side must be solved for USABLE area, not outline area. It was
+        # sqrt(outline_area + need), where `need` is a usable-area shortfall --
+        # so the proposed board's usable area, (side - 2*edge)^2, was still
+        # short. Measured: it proposed 55.1mm square for parts needing
+        # 2971.0mm2 usable, which yields 2920.3 -- still 50.7mm2 under. A
+        # square whose USABLE area holds the parts has side sqrt(busiest)
+        # plus the edge clearance it loses on each side.
+        # ROUND UP to the published precision, then keep a hair of margin.
+        # sqrt(busiest) + 2*edge makes (side - 2*edge)^2 == busiest EXACTLY,
+        # and the action string publishes `{side:.1f}` -- so any downward
+        # rounding ships a proposal that is short. Measured across the corpus:
+        # 8 of 22 boards were short by 0.9-3.1 mm2, and the test that checks
+        # this passed only because splitflap's 55.1897 happens to round up.
+        exact = math.sqrt(max(0.0, busiest)) + 2.0 * board_edge_clearance
+        side = math.ceil(exact * 10.0) / 10.0
+        out['measured']['shortfall_mm2_at_least'] = round(need, 2)
+        # The number, not just the prose. The proposal was reachable only by
+        # parsing the action string, which is also what the test audited -- so
+        # the audit read the same rounded text it was meant to check.
+        out['measured']['proposed_square_side_mm'] = side
+        out['action'] = (
+            f"the parts need AT LEAST {need:.1f} mm2 more usable area than "
+            f"this outline has ({busiest:.1f} vs {usable:.1f} mm2 on the "
+            f"busiest side). A square "
+            f"board holding them would be about {side:.1f} x {side:.1f} mm "
+            f"against today's {x1 - x0:.1f} x {y1 - y0:.1f}. The outline is a "
+            f"mechanical decision: this reports it and changes nothing.")
+    elif util >= CROWDED_UTILISATION:
+        out['action'] = (
+            f"the parts fit by area ({util:.0%} of usable) but leave little "
+            f"room to route between them. Consider a larger outline or a "
+            f"denser layer stack before blaming the placement.")
+    return out
+
+
+def add_layers(pcb_data, pcb_file: str, *, clearance: float,
+               track_width: Optional[float] = None,
+               step: int = 2) -> Dict:
+    """Would more copper layers clear the escape-lane deficits?
+
+    Two effects, and only one of them is modelled here honestly:
+
+    * a finer FAB FLOOR at a higher layer count narrows the lane pitch, so a
+      face supplies more lanes. That is computable, and it is what this
+      reports -- `fab_tiers.fab_floor_min` already indexes on layer count and
+      `check_channels.py:160-170` ran exactly this experiment by hand at three
+      clearances (supply 29 -> 120 -> 242).
+    * nets escaping on OTHER layers relieve a face entirely. That needs a
+      routing attempt, so it is named as not modelled rather than guessed.
+    """
+    from placement.escape import escape_ledger, lane_pitch  # noqa: F401
+    try:
+        from fab_tiers import count_copper_layers_in_file, fab_floor_min
+    except ImportError as e:
+        return _skip(f'fab_tiers unavailable: {e}')
+
+    n = count_copper_layers_in_file(pcb_file)
+    if not n:
+        return _skip('could not count this board\'s copper layers')
+    try:
+        now = fab_floor_min(n)
+        more = fab_floor_min(n + step)
+    except Exception as e:                       # noqa: BLE001
+        return _skip(f'no fab floor for {n} or {n + step} layers: {e}')
+
+    def _deficit(clr, tw):
+        return deficit_totals(escape_ledger(pcb_data, pcb_file=pcb_file,
+                                            clearance=clr, track_width=tw))
+
+    # BOTH sides must be measured at their own fab floor, or the comparison
+    # is not about layers at all. Measuring "now" at the board's clearance
+    # and "more" at the n+2 fab floor reported 43 -> 12 lanes on a board
+    # where the two floors are IDENTICAL -- the whole apparent gain was the
+    # clearance change, credited to the layer count.
+    same_floor = (now.get('clearance') == more.get('clearance')
+                  and now.get('track_width') == more.get('track_width'))
+    try:
+        d_now = _deficit(now.get('clearance', clearance),
+                         now.get('track_width', track_width))
+        d_more = _deficit(more.get('clearance', clearance),
+                          more.get('track_width', track_width))
+        d_board = _deficit(clearance, track_width)
+    except Exception as e:                       # noqa: BLE001
+        return _skip(f'the escape ledger did not run: {type(e).__name__}: {e}')
+
+    if d_now['examined'] == 0:
+        return _skip('this board has no fine-pitch part, so there is no '
+                     'escape-lane question to answer')
+
+    out = {
+        'ran': True,
+        'measured': {
+            'copper_layers': n,
+            'floor_now': {k: now.get(k) for k in ('track_width', 'clearance')},
+            'floor_at_more': {k: more.get(k)
+                              for k in ('track_width', 'clearance')},
+            # `_now` means AT THIS BOARD'S CLEARANCE -- what the board is
+            # actually short of today. It used to mean "at the fab floor for
+            # this layer count", which reported tigard as 0 while
+            # move_blocker, in the same document, named 41 deficit lanes.
+            # Two different questions cannot share the word "now".
+            'deficit_lanes_now': d_board['lanes'],
+            'deficit_parts_now': d_board['parts'],
+            'deficit_lanes_at_fab_floor': d_now['lanes'],
+            'deficit_parts_at_fab_floor': d_now['parts'],
+            'deficit_lanes_at_more': d_more['lanes'],
+            'deficit_parts_at_more': d_more['parts'],
+            'deficit_lanes_at_board_clearance': d_board['lanes'],
+            'floors_differ': not same_floor,
+            'fine_pitch_parts': d_now['examined'],
+        },
+        'expected': {'deficit_lanes': 0},
+        'not_modelled': 'nets that would escape on the new layers instead of '
+                        'through a face -- that needs a routing attempt',
+    }
+    # The BRANCHES moved to the board clearance; the prose must move with
+    # them. Quoting d_now (the fab floor) inside a branch chosen by d_board
+    # reintroduces the same "two questions, one word" defect one level down:
+    # measured on esp_prog at clearance 0.6, the else-branch printed "0
+    # deficit lane(s) remain" while d_board['lanes'] was 1.
+    gain = d_now['lanes'] - d_more['lanes']
+    if same_floor:
+        out['action'] = (
+            f"the fab floor is identical at {n} and {n + step} copper layers "
+            f"({now.get('track_width')} / {now.get('clearance')} mm), so more "
+            f"layers buy NO extra lanes on a face. They would only help by "
+            f"letting nets escape on the new layers instead, which needs a "
+            f"routing attempt to measure.")
+    elif d_board['lanes'] == 0:
+        # Judged at the BOARD's clearance, not the fab floor. At the floor
+        # this read 0 on boards with 41 deficit lanes and printed the
+        # false-clean below.
+        out['action'] = ("no face is short of lanes at this board's "
+                         "clearance, so more layers would not fix an escape "
+                         "problem")
+    elif gain > 0:
+        out['action'] = (
+            f"going from {n} to {n + step} copper layers takes the fab floor "
+            f"finer and removes {gain} of {d_now['lanes']} deficit lane(s) at the fab floor (this board is short {d_board['lanes']} at its own clearance) on its "
+            f"own, before counting nets that would escape on the new layers. "
+            f"Stackup is a fab-facing decision: this reports it and changes "
+            f"nothing.")
+    else:
+        out['action'] = (
+            f"{d_board['lanes']} deficit lane(s) at this board's clearance, and "
+            f"{d_more['lanes']} still remain at the fab floor for {n + step} "
+            f"layers -- the finer floor does not supply them, so this is a "
+            f"geometry problem (move what ate the span) rather than a stackup "
+            f"one.")
+    return out
+
+
+def move_blocker(pcb_data, pcb_file: str, *, clearance: float,
+                 track_width: Optional[float] = None,
+                 limit: int = 5) -> Dict:
+    """Which neighbour to move, and by how many millimetres.
+
+    `escape.FaceLedger` already carries `deficit` and `blockers` -- its own
+    dataclass calls blockers "WHO ate it -- the actionable field". What it has
+    never carried is the CONVERSION: a face short by k lanes needs
+    k * lane_pitch mm of span freed, and that one multiplication is the
+    difference between "this face is short 3 lanes" and "move C14 1.4 mm".
+    """
+    from placement.escape import escape_ledger
+    try:
+        led = escape_ledger(pcb_data, pcb_file=pcb_file, clearance=clearance,
+                            track_width=track_width)
+    except Exception as e:                       # noqa: BLE001
+        return _skip(f'the escape ledger did not run: {type(e).__name__}: {e}')
+    if not led:
+        return _skip('this board has no fine-pitch part, so no face has a '
+                     'lane budget to be short of')
+
+    rows = []
+    for part in led:
+        for face in (getattr(part, 'faces', ()) or ()):
+            d = getattr(face, 'deficit', 0)
+            if d <= 0:
+                continue
+            pitch = getattr(face, 'lane_pitch_mm', None) or 0.0
+            rows.append({
+                'ref': getattr(part, 'ref', None),
+                'face': getattr(face, 'face', None),
+                'deficit_lanes': d,
+                'lane_pitch_mm': round(pitch, 4),
+                'span_needed_mm': round(d * pitch, 3),
+                'blocked_mm': round(getattr(face, 'blocked_mm', 0.0) or 0.0,
+                                    3),
+                'blockers': list(getattr(face, 'blockers', ()) or ()),
+            })
+    rows.sort(key=lambda r: (-r['span_needed_mm'], str(r['ref'])))
+    if not rows:
+        return {'ran': True, 'measured': {'faces_in_deficit': 0},
+                'expected': {'faces_in_deficit': 0},
+                'action': 'no face is short of lanes; nothing to move'}
+    worst = rows[0]
+    who = worst['blockers'][0] if worst['blockers'] else None
+    out = {'ran': True,
+           'measured': {'faces_in_deficit': len(rows), 'worst': rows[:limit]},
+           'expected': {'faces_in_deficit': 0}}
+    out['action'] = (
+        f"{worst['ref']}'s {worst['face']} face is short {worst['deficit_lanes']} "
+        f"lane(s); freeing {worst['span_needed_mm']:.2f} mm of span there "
+        + (f"means moving {who}, which ate {worst['blocked_mm']:.2f} mm of it."
+           if who else
+           "would clear it, though nothing was identified as eating the span.")
+        + " Net ordering cannot fix a face deficit -- it only chooses which "
+          "nets strand there.")
+    return out
+
+
+def relax_clearance(pcb_data, pcb_file: str, *, clearance: float,
+                    track_width: Optional[float] = None,
+                    factors: Sequence[float] = (0.75, 0.5)) -> Dict:
+    """What a tighter clearance would buy, and what the fab allows.
+
+    Reported as a LADDER rather than a single answer, and floored at the fab
+    minimum for this board's layer count, because a lane pitch below what any
+    fab can etch predicts capacity nobody can build -- `check_channels.py:
+    152-174` measured that trap directly (declared 0.02/0.02 reported supply
+    242 against 29 at 0.2/0.2).
+    """
+    from placement.escape import escape_ledger
+    floor_clr = None
+    try:
+        from fab_tiers import count_copper_layers_in_file, fab_floor_min
+        n = count_copper_layers_in_file(pcb_file)
+        if n:
+            floor_clr = fab_floor_min(n).get('clearance')
+    except Exception:                            # noqa: BLE001
+        floor_clr = None
+
+    def _deficit(clr):
+        led = escape_ledger(pcb_data, pcb_file=pcb_file, clearance=clr,
+                            track_width=track_width)
+        # Via deficit_totals, NOT `getattr(p, 'worst_deficit', 0)`. That name
+        # is a to_dict() key, never an attribute, so the getattr returned 0 on
+        # every board and this whole option reported "no face is short of
+        # lanes" while move_blocker, in the same report, named 23 faces in
+        # deficit on tigard. Same lane definition as move_blocker (all faces,
+        # not the worst per part) so the two cannot disagree again.
+        return deficit_totals(led)['lanes']
+
+    try:
+        base = _deficit(clearance)
+    except Exception as e:                       # noqa: BLE001
+        return _skip(f'the escape ledger did not run: {type(e).__name__}: {e}')
+    if base == 0:
+        return _skip('no face is short of lanes at the current clearance, so '
+                     'relaxing it buys nothing measurable here')
+
+    ladder = []
+    for f in factors:
+        clr = round(clearance * f, 4)
+        below = floor_clr is not None and clr < floor_clr
+        row = {'clearance': clr, 'below_fab_floor': bool(below),
+               'fab_floor': floor_clr}
+        if below:
+            row['deficit_lanes'] = None
+            row['note'] = ('below the fab floor for this layer count -- not '
+                           'measured, because capacity nobody can etch is '
+                           'not capacity')
+        else:
+            row['deficit_lanes'] = _deficit(clr)
+        ladder.append(row)
+    out = {'ran': True,
+           'measured': {'clearance': clearance, 'deficit_lanes': base,
+                        'ladder': ladder, 'fab_floor_clearance': floor_clr},
+           'expected': {'deficit_lanes': 0}}
+    usable = [r for r in ladder if r.get('deficit_lanes') is not None]
+    best = min(usable, key=lambda r: r['deficit_lanes']) if usable else None
+    if best and best['deficit_lanes'] < base:
+        out['action'] = (
+            f"tightening clearance from {clearance} to {best['clearance']} mm "
+            f"takes the deficit from {base} to {best['deficit_lanes']} lane(s) "
+            f"and stays at or above this board's fab floor. That is a DRC "
+            f"decision the board owner makes, not a placement one.")
+    else:
+        out['action'] = (
+            f"tightening clearance to the fab floor does not clear the "
+            f"{base} deficit lane(s) -- the span is taken by geometry, so "
+            f"move what ate it or add layers.")
+    return out
+
+
+def smaller_footprint(pcb_data, pcb_file: str, *, clearance: float,
+                      limit: int = 5) -> Dict:
+    """Which parts are big enough that their SIZE is the constraint.
+
+    Ranked by courtyard area against the board's usable area, because that is
+    the honest signal available without a parts database: this cannot know
+    that a 0805 has a 0402 equivalent, and says so rather than pretending.
+    """
+    g = grow_board(pcb_data, pcb_file, clearance=clearance,
+                   board_edge_clearance=0.0)
+    if not g.get('ran'):
+        return _skip(g.get('reason', 'the area measurement did not run'))
+    biggest = g['measured'].get('largest_parts_mm2') or []
+    usable = g['measured'].get('usable_area_mm2') or 0.0
+    if not biggest or usable <= 0:
+        return _skip('no part geometry to rank')
+    rows = [{'ref': ref, 'area_mm2': a,
+             'share_of_usable': round(a / usable, 4)}
+            for a, ref in biggest[:limit]]
+    out = {'ran': True,
+           'measured': {'largest': rows, 'usable_area_mm2': usable},
+           'expected': {'share_of_usable': 'no single part dominating'},
+           'not_modelled': 'whether a smaller equivalent part EXISTS -- that '
+                           'needs a parts database this toolchain does not '
+                           'have'}
+    top = rows[0]
+    out['action'] = (
+        f"{top['ref']} alone occupies {top['share_of_usable']:.1%} of the "
+        f"usable area ({top['area_mm2']} mm2). If the board is short of room, "
+        f"a smaller package for it buys the most; whether one exists is a "
+        f"parts decision this tool cannot make.")
+    return out
+
+
+OPTIONS = {
+    'grow_board': grow_board,
+    'add_layers': add_layers,
+    'move_blocker': move_blocker,
+    'relax_clearance': relax_clearance,
+    'smaller_footprint': smaller_footprint,
+}
+
+
+def capacity_options(pcb_data, pcb_file: str, *, clearance: float,
+                     board_edge_clearance: float,
+                     track_width: Optional[float] = None,
+                     only: Optional[Sequence[str]] = None) -> Dict:
+    """Every option, each either measured or explaining why it was not."""
+    out: Dict[str, Dict] = {}
+    for name, fn in OPTIONS.items():
+        if only and name not in only:
+            continue
+        kw = {'clearance': clearance}
+        if name == 'grow_board':
+            kw['board_edge_clearance'] = board_edge_clearance
+        if name in ('add_layers', 'move_blocker', 'relax_clearance'):
+            kw['track_width'] = track_width
+        try:
+            out[name] = fn(pcb_data, pcb_file, **kw)
+        except Exception as e:                   # noqa: BLE001 - disclosed
+            # A crash is NOT "this option does not apply here", and the two
+            # must not read alike: a leftover tuple index in add_layers once
+            # raised KeyError and arrived looking exactly like the honest
+            # "this board has no fine-pitch part" skip, on a board with 43
+            # deficit lanes. `error` is what tells them apart.
+            out[name] = dict(_skip(f'INTERNAL ERROR: {type(e).__name__}: {e}'),
+                             error=True)
+    return out
+
+
+def format_text(opts: Dict) -> str:
+    L = ["CAPACITY OPTIONS -- measured, never applied. Nothing here writes an "
+         "outline or a stackup."]
+    for name in OPTIONS:
+        o = opts.get(name)
+        if o is None:
+            continue
+        if not o.get('ran'):
+            tag = 'FAILED' if o.get('error') else 'not measured'
+            L.append(f"  {name}: {tag} -- {o.get('reason')}")
+            continue
+        # Always print what was MEASURED, not only what to do about it. An
+        # option whose numbers are comfortable still has numbers, and a line
+        # carrying only the option's name reads as "nothing found" when it
+        # actually means "measured, and fine".
+        L.append(f"  {name}: {_digest(o.get('measured') or {})}")
+        if o.get('action'):
+            for chunk in _wrap(o['action'], 74):
+                L.append(f"    {chunk}")
+        if o.get('not_modelled'):
+            L.append(f"    NOT MODELLED: {o['not_modelled']}")
+    ran = sum(1 for o in opts.values() if o.get('ran'))
+    L.append(f"  {ran} of {len(opts)} option(s) measured; "
+             f"{len(opts) - ran} could not be.")
+    return "\n".join(L)
+
+
+# Keys the text channel must never drop, whatever else is added beside them.
+# `_digest`'s positional `limit` silently truncated: adding the fab-floor pair
+# pushed `deficit_lanes_at_more` -- the "would more layers help" number the
+# whole option exists to answer -- off the end, and `parts=92` off grow_board.
+# A digest that drops the headline is not a digest.
+_DIGEST_ALWAYS = ('deficit_lanes_now', 'deficit_lanes_at_more',
+                  'deficit_lanes_at_fab_floor', 'utilisation',
+                  'busiest_side_area_mm2', 'usable_area_mm2',
+                  'parts', 'shortfall_mm2_at_least',
+                  'proposed_square_side_mm', 'faces_in_deficit',
+                  'deficit_lanes', 'containers_excluded')
+
+
+def _digest(measured: Dict, limit: int = 5) -> str:
+    """The scalar measurements, compactly. Nested rows are named, not dumped:
+    a text digest that inlined a findings list is how a summary stops being
+    one (the same trap board_brief's locks tally fell into).
+
+    `_DIGEST_ALWAYS` keys are emitted whether or not they fall inside `limit`,
+    and a non-empty dict is named with its size rather than skipped entirely --
+    `part_area_by_side_mm2` was added so a reader could check `utilisation`
+    against a number, and being a dict it never appeared in the text channel
+    it was added for.
+    """
+    bits, forced = [], []
+    for k, v in measured.items():
+        empty = isinstance(v, (list, tuple, dict)) and not v
+        if isinstance(v, bool):
+            bit = f"{k}={'yes' if v else 'no'}"
+        elif isinstance(v, (int, float)):
+            bit = f"{k}={v}"
+        elif isinstance(v, (list, tuple)):
+            bit = f"{k}[{len(v)}]"
+        elif isinstance(v, dict) and v:
+            bit = f"{k}{{{len(v)}}}"
+        else:
+            continue
+        # An EMPTY collection is never forced. Forcing `containers_excluded`
+        # unconditionally spent a slot on `[0]` and evicted
+        # usable_area_mm2/outline_area_mm2 -- the denominator `utilisation` is
+        # computed from -- on the 32 of 33 corpus boards that have no
+        # container. A digest that drops the denominator to report an empty
+        # list is worse than the truncation it was fixing.
+        (forced if (k in _DIGEST_ALWAYS and not empty) else bits).append(bit)
+    out = forced + [b for b in bits if b not in forced]
+    return ', '.join(out[:max(limit, len(forced))]) if out else 'measured'
+
+
+def _wrap(text: str, width: int) -> List[str]:
+    out, line = [], ''
+    for word in text.split():
+        if len(line) + len(word) + 1 > width:
+            out.append(line)
+            line = word
+        else:
+            line = f"{line} {word}".strip()
+    if line:
+        out.append(line)
+    return out

--- a/py_tools/board_brief.py
+++ b/py_tools/board_brief.py
@@ -1,0 +1,926 @@
+#!/usr/bin/env python3
+"""What a board looks like to something that has to place it, in one artifact.
+
+The placement toolchain already emits every number an author needs -- escape
+lane deficits and who ate them, block displacement, net affinity, part classes,
+groups, lock advice, the render checklist and the crop that frames each
+finding. What it has never had is one place to READ them from, so an author
+(human or model) reassembles the picture from a dozen commands every time, or
+does not, and places from a guess.
+
+THIS MODULE ASSEMBLES; IT DOES NOT COMPUTE. Every number comes from the
+function that already owns it, and `sources` names that function per section,
+so there is one source of truth per fact and the brief cannot drift away from
+the graders. The one exception is `fit`, which is opt-in and says so: it
+answers "where does a W x H part fit at all", the question
+`wk/run19/urchin/probe_space.py` was hand-written to answer and whose output
+became that run's X0 = 46.0.
+
+Two rules inherited from the evidence map
+(.claude/skills/plan-pcb-routing/references/evidence-map.md):
+
+    never read a picture on its own -- every render is paired with a number
+    that either confirms or contradicts it, and the number wins
+
+    keys are literal; if a key is not in the output you are looking at, you
+    are looking at the wrong artifact
+
+so `renders` is folded in only as a reference to a real `render_placement
+--json-out` document, never re-derived here.
+
+A section that cannot run says WHY, in `skipped`, and is absent from the body.
+A brief that silently omitted a measurement would read as "nothing to report".
+
+    python3 board_brief.py board.kicad_pcb
+    python3 board_brief.py board.kicad_pcb --json brief.json --fit 15.5x15.5
+    python3 board_brief.py board.kicad_pcb --requirements "USB on the north
+        edge; the two thumb clusters must stay reachable" --render-json r.json
+
+Exit codes: 0 = a brief was written, 2 = usage/load error, 3 = no outline
+(there is nothing to place against).
+"""
+import _path  # noqa: F401  (py_tools -> py_router/py_placer on sys.path)
+
+import argparse
+import json
+import math
+import os
+import sys
+
+SCHEMA = 1
+DEFAULT_FIT_STEP_MM = 2.0
+WORST_N = 10
+
+
+def _safe(section, fn, skipped, *a, **kw):
+    """Run an emitter; record WHY it did not run rather than dropping it."""
+    try:
+        return fn(*a, **kw)
+    except Exception as e:                       # noqa: BLE001 - reported
+        skipped[section] = f"{type(e).__name__}: {e}"
+        return None
+
+
+def _rings(raw):
+    """Ring vertices as JSON, at the parser's own precision."""
+    return [[[round(float(x), 6), round(float(y), 6)] for x, y in ring]
+            for ring in (raw or ()) if ring]
+
+
+def _shoelace(ring):
+    """The tree's own shoelace, with a local fallback.
+
+    `board_section` is the one section `build_brief` calls outside `_safe`
+    (its keys are structurally required, down to the JSON_SUMMARY line), so a
+    hard dependency on a PRIVATE cross-module name would put the whole
+    artifact behind someone else's rename.
+    """
+    try:
+        from kicad_writer import _polygon_area
+        return _polygon_area(ring)
+    except Exception:                            # noqa: BLE001
+        a = 0.0
+        for i in range(len(ring)):
+            x1, y1 = ring[i][0], ring[i][1]
+            x2, y2 = ring[(i + 1) % len(ring)][0], ring[(i + 1) % len(ring)][1]
+            a += x1 * y2 - x2 * y1
+        return abs(a) / 2.0
+
+
+def board_section(pcb, pcb_file, skipped):
+    from kicad_parser import parse_kicad_pcb  # noqa: F401  (documents origin)
+    bi = pcb.board_info
+    out = {
+        'path': os.path.abspath(pcb_file),
+        'bounds': list(bi.board_bounds) if bi.board_bounds else None,
+        'copper_layers': list(getattr(bi, 'copper_layers', []) or []),
+        'cutouts': len(getattr(bi, 'board_cutouts', []) or []),
+        'outlines': len(getattr(bi, 'board_outlines', []) or []),
+        # #505: an interior contour that is a milled edge, not a hole. A part
+        # whose pads land inside one is unroutable, and it is invisible to a
+        # bounding-box view of the board.
+        'milled_contours': len(getattr(bi, 'board_edge_contours', []) or []),
+        'stackup': [{'name': l.name, 'type': l.layer_type,
+                     'thickness': l.thickness}
+                    for l in (getattr(bi, 'stackup', []) or [])],
+        'footprints': len(pcb.footprints),
+        'nets': len(pcb.nets),
+    }
+    # WHERE, not just how many. These are already-parsed vertex lists and the
+    # brief used to call len() on all three, so an author was told a board has
+    # two cutouts and never where -- on watchy, two strap slots spanning
+    # nearly the full width at the north and south edges, which is exactly
+    # where `place_edge north|south` aims. They are also the only source in
+    # the brief for `place_keepout`'s required `rect`: the rings ARE the rects.
+    out['outline_rings'] = _rings(getattr(bi, 'board_outlines', None))
+    out['cutout_rings'] = _rings(getattr(bi, 'board_cutouts', None))
+    out['milled_contour_rings'] = _rings(getattr(bi, 'board_edge_contours',
+                                                 None))
+    out['outline_source'] = 'edge_cuts_contours'
+    if out['bounds']:
+        x0, y0, x1, y1 = out['bounds']
+        out['size_mm'] = [round(x1 - x0, 3), round(y1 - y0, 3)]
+        out['area_mm2'] = round((x1 - x0) * (y1 - y0), 2)
+        if not out['outline_rings']:
+            # `extract_board_contours` returns NOTHING for a simple
+            # axis-aligned rectangle -- "Simple rectangle, use bounding box"
+            # (kicad_parser.py:2228) -- which is 24 of the 33 corpus boards.
+            # Publishing only what it returns meant the rings, and the areas
+            # guarded on them, were absent from most briefs with nothing in
+            # `skipped` to say why, while this section's stated purpose is to
+            # be the source for `place_keepout`'s rect. On those boards the
+            # outline IS the bounding box, so it is stated rather than
+            # withheld -- and `outline_source` says which it came from.
+            out['outline_rings'] = [[[round(x0, 6), round(y0, 6)],
+                                     [round(x1, 6), round(y0, 6)],
+                                     [round(x1, 6), round(y1, 6)],
+                                     [round(x0, 6), round(y1, 6)]]]
+            out['outline_source'] = 'bounding_box'
+            # ...and the COUNT follows the geometry. A rectangular board has
+            # one outline; reporting 0 because the contour extractor
+            # short-circuits was the same under-report in scalar form.
+            out['outlines'] = 1
+    # Real copper, by shoelace. `area_mm2` stays the bounding box so nothing
+    # reading it changes meaning; this is the number a cutout can reduce
+    # (watchy: 1553.06 bbox against 1434.09 of copper, 8.3% of it not there).
+    # DELIBERATELY NOT called `usable_area_mm2`: `options.grow_board` already
+    # emits that name for the bbox minus the edge-clearance band, which is
+    # cutout-blind and not comparable -- one name, two quantities, across two
+    # artifacts an author reads together, is the drift this module exists to
+    # prevent.
+    if out['outline_rings']:
+        o_area = sum(_shoelace(r) for r in out['outline_rings'])
+        c_area = sum(_shoelace(r) for r in out['cutout_rings'])
+        out['outline_area_mm2'] = round(o_area, 2)
+        out['cutout_area_mm2'] = round(c_area, 2)
+        out['copper_area_mm2'] = round(max(0.0, o_area - c_area), 2)
+    floors = _safe('board.floors', _floors, skipped, pcb_file)
+    if floors is not None:
+        out['floors'] = floors
+    return out
+
+
+def _floors(pcb_file):
+    """The board's own floors, with each value's SOURCE.
+
+    `board_floor_knobs` returns `(clearance, board_edge_clearance, knobs)` --
+    a triple, not a mapping. Only `knobs` belongs in the brief: it is the
+    part that says whether a number came from the board's netclass, a board
+    constraint, or a fixed default, and a reader who cannot tell those apart
+    cannot tell a real floor from a guess.
+    """
+    from list_nets import board_floor_knobs
+    return board_floor_knobs(pcb_file)[2]
+
+
+# Brief keys a PLACEMENT produces and an unplaced board cannot. Each is nulled
+# rather than dropped, and named in `position_dependent.invalid`, because the
+# shape of the answer is the problem: on a pile these come back in the exact
+# schema a placed board yields, so a reader has no way to tell them apart.
+# Measured placed -> piled, same brief, no marking anywhere: ulx3s escape
+# 19 -> 109 deficit lanes and locks.high 10 -> 0; kit-dev-coldfire 0 -> 82
+# lanes on a board with no escape problem at all; splitflap_driver
+# locks.high 16 -> 2; watchy 25 -> 69 lanes, locks.high 7 -> 1, tethers 6 -> 4.
+#
+# Mechanisms, one per group:
+#   escape   `_blocked_span` charges every co-located neighbour against the
+#            band, so supply -> 0 and deficit == demand for every part but
+#            the largest. `deficit_lanes` becomes a netlist count wearing an
+#            escape verdict's clothes, and `blockers` names parts to move
+#            that are not anywhere.
+#   locks    the geometric rules (off_board, near_board_edge,
+#            family_orbit_seat) cannot fire at a centre pile, so the
+#            `geometric and lexical -> high` promotion is unreachable and the
+#            pad-conflict demotion fires on nearly everything.
+#   decap    every IC-to-cap distance is 0.0, so the strict `<` in the
+#            nearest-IC search is decided by FILE ORDER and every cap on a
+#            rail re-parents onto one chip.
+#   netprefix  fails the OTHER way: the 20mm spread gate is disarmed at
+#            spread 0, so it MANUFACTURES blocks the real board lacks.
+POSITION_DEPENDENT = (
+    'measurements.escape.deficit_parts',
+    'measurements.escape.deficit_lanes',
+    'measurements.escape.worst[].worst_face',
+    'measurements.escape.worst[].worst_deficit',
+    'measurements.escape.worst[].faces[].supply',
+    'measurements.escape.worst[].faces[].deficit',
+    'measurements.escape.worst[].faces[].blocked_mm',
+    'measurements.escape.worst[].faces[].blockers',
+    'measurements.locks.high',
+    'measurements.locks.lock_argv',
+    'measurements.locks.tally.findings_high',
+    'measurements.locks.tally.findings_medium',
+    'measurements.locks.tally.findings_low',
+    'measurements.locks.tally.findings_covered',
+    'measurements.locks.tally.unlocked_high',
+    'structure.decap_tethers',
+    'structure.groups.decap',
+    'structure.groups.netprefix',
+)
+
+# Fires the disclosure even when `assess_placement` stops short of `unplaced`.
+# Matches `placement_state.DUP_FRACTION`, the same threshold that module uses
+# for its own strong signal -- this is that signal WITHOUT the
+# distinct-positions conjunct the mechanical exemptions break.
+PILE_FRACTION = 0.5
+
+# KEPT, but derived from the part's pose rather than from the netlist -- so
+# they are correct for the board AS IT IS and not for the board as it will
+# be. Named rather than nulled because each is the best answer available and
+# an author needs it: `extent_mm` is what sizes a part, per-face `demand` is
+# what an escape budget is read from. What makes them treacherous on a
+# staged board is that `stage_unaided` writes ROTATION 0 for every part it
+# moves, and all of these follow rotation.
+#
+# Measured on boards staged by this repo's own stager: 130 of 234 ulx3s parts
+# have `extent_mm` with width and height SWAPPED against the placed board
+# (BAT1 [20.3, 14.1] at rot 90 -> [14.1, 20.3] at rot 0); watchy 43 of 84,
+# tigard 30 of 92, every one an exact swap. And U2's escape demand moves
+# north 21 -> 2 / east 1 -> 21 as the part turns, so the per-face table is
+# right about a rotation the author has not chosen yet.
+POSE_DERIVED_KEPT = (
+    ('parts[].rotation',
+     'on a staged board this is a generator default, not a decision'),
+    ('parts[].extent_mm',
+     'follows `rotation`: swap width and height when you rotate the part'),
+    ('parts[].rect / parts[].at',
+     'the pile coordinate for any part `mechanical.pose_shared_with` lists'),
+    ('measurements.escape.worst[].faces[].face / .demand / .span_mm',
+     'which face a net leaves through follows rotation, so the table is '
+     'right about the CURRENT angle only. Per-part totals are invariant'),
+    ('measurements.escape.worst[] membership and order',
+     'the ledger is sorted by a deficit that is now null and truncated to '
+     'the first 10, so on a board with more than 10 fine-pitch parts this '
+     'is a pile-selected SET, not just a pile-ordered one'),
+    ('renders.*',
+     'a render draws the poses in the file, so a render of this board shows '
+     'the pile'),
+)
+
+
+def _null_path(node, parts):
+    """Set one dotted path to None wherever it EXISTS; `a[]` walks a list.
+
+    Returns whether the path was present, so `position_dependent.invalid`
+    lists the paths this board actually had rather than the table's wish
+    list. Present-and-already-None counts: otherwise a key that is null for
+    its own reasons ships null with nothing in `invalid` explaining it, which
+    is the exact silence this block exists to break.
+    """
+    key, listy = parts[0], parts[0].endswith('[]')
+    if listy:
+        key = key[:-2]
+    if not isinstance(node, dict) or key not in node:
+        return False
+    if len(parts) == 1:
+        node[key] = None
+        return True
+    child = node[key]
+    if listy:
+        # A LIST COMPREHENSION, NOT A GENERATOR. `any()` short-circuits on
+        # the first True, so a generator would null element 0 and leave
+        # 1..N intact while still reporting the path as nulled.
+        if isinstance(child, (str, bytes)) or not isinstance(child, (list,
+                                                                    tuple)):
+            return False        # `a[]` over a non-list: nothing to walk
+        return any([_null_path(it, parts[1:]) for it in child])
+    return _null_path(child, parts[1:])
+
+
+def state_section(pcb, pcb_file, skipped):
+    from placement.placement_state import assess_placement
+    st = assess_placement(pcb, pcb_file)
+    return {'unplaced': st.unplaced,
+            # WHY, not just the verdict. Dropping these left a JSON reader
+            # with a bare boolean and no way to see what fired -- and they
+            # are what `position_dependent.because` quotes.
+            'reasons': list(st.reasons),
+            'signals': dict(st.signals),
+            'partially_unplaced': st.partially_unplaced,
+            'has_copper': st.has_copper,
+            'duplicate_fraction': round(st.duplicate_fraction, 4),
+            'spread_ratio': round(st.spread_ratio, 4),
+            'outside_fraction': round(st.outside_fraction, 4),
+            'stacked_suspect_refs': list(st.stacked_suspect_refs),
+            'segments': st.segments, 'vias': st.vias}
+
+
+def parts_section(pcb, pcb_file, skipped):
+    """Per part: what an author needs to decide where it goes.
+
+    Size comes from the courtyard where the footprint has one and the pad
+    bounding box where it does not -- and `courtyard` says which, because a
+    pad bbox carries NO courtyard margin and treating the two alike is how a
+    part gets seated tighter than its own footprint allows (the quench warns
+    about this on every board that needs it).
+    """
+    from placement.legality import rotate_local_bounds
+    from placement.parser import extract_courtyard_bboxes
+    from placement.utility import compute_footprint_bbox_local
+    from placement.part_class import classify_part
+    from placement.escape import lane_pitch  # noqa: F401 (documents origin)
+
+    cy = _safe('parts.courtyards', extract_courtyard_bboxes, skipped,
+               pcb_file) or {}
+    out = {}
+    for ref, fp in sorted(pcb.footprints.items()):
+        pads = fp.pads or []
+        box = cy.get(ref)
+        if box:
+            src = 'courtyard'
+        elif pads:
+            # compute_footprint_bbox_local, NOT max(global_x) - min(global_x).
+            # The pad-CENTRE span omits the pads' own size, so a two-pad part
+            # measures ZERO width along its pad axis: esp_prog C1 (an 0603)
+            # reported [0.0, 1.778] where its real extent is 2.794 x 1.016,
+            # and the understatement reached 51% of total part area on that
+            # board -- a number grow_board's utilisation is computed from.
+            box = compute_footprint_bbox_local(fp)
+            src = 'pad_bbox'
+        else:
+            box = None
+            src = 'none'
+        if box is None:
+            w = h = 0.0
+            rect = None
+        else:
+            # extract_courtyard_bboxes and compute_footprint_bbox_local BOTH
+            # return the footprint-LOCAL frame; the parser's own docstring
+            # says so ("must be transformed to global coordinates using the
+            # footprint's position and rotation"). Reporting them raw
+            # transposes every part on a 90/270 rotation -- 133 of 266 on
+            # glasgow_revC -- so `extent_mm` could not be fed to --fit WxH,
+            # whose `fit` section IS board-frame.
+            gx0, gy0, gx1, gy1 = rotate_local_bounds(*box, fp.rotation or 0.0)
+            w, h = gx1 - gx0, gy1 - gy0
+            # The same rect `legality.graded_parts_from_file` publishes
+            # (`rect = (fp.x + lx0, fp.y + ly0, ...)`). The rotation is
+            # applied one line up and the translation was thrown away, so
+            # this brief emitted `rotation` and no position while standing
+            # one addition away from the absolute pose.
+            rect = [round(fp.x + gx0, 6), round(fp.y + gy0, 6),
+                    round(fp.x + gx1, 6), round(fp.y + gy1, 6)]
+        cls = classify_part(fp, ref)
+        row = {'extent_mm': [round(w, 3), round(h, 3)],
+               'extent_source': src,
+               'pads': len(pads),
+               'side': getattr(fp, 'layer', None),
+               # WHERE THE PART IS, which this table has never carried. Six
+               # of the thirteen plan ops take a literal board coordinate
+               # (place_keepout.rect, place_fixed.at, place_at.at,
+               # place_array.origin, place_slots.slots, place_pack.zone), and
+               # `place_fixed` -- the op whose whole job is asserting a pose
+               # the mechanical drawing already fixed -- REQUIRES an `at` no
+               # section of this brief could supply. Reported as a fact: on
+               # an unplaced board it is the pile coordinate, which `state`
+               # already says is meaningless, and the two must be read
+               # together.
+               'at': [round(fp.x, 6), round(fp.y, 6)],
+               'rect': rect,
+               'rotation': getattr(fp, 'rotation', None),
+               'locked': bool(getattr(fp, 'locked', False)),
+               'dnp': bool(getattr(fp, 'dnp', False)),
+               'footprint': getattr(fp, 'footprint_name', None),
+               'value': getattr(fp, 'value', None),
+               'nets': sorted({p.net_name for p in pads
+                               if p.net_id and p.net_name})}
+        if cls is not None and getattr(cls, 'name', None):
+            row['class'] = cls.name
+            row['class_confidence'] = getattr(cls, 'confidence', None)
+            row['class_evidence'] = list(getattr(cls, 'evidence', ()) or ())
+        out[ref] = row
+    return out
+
+
+def mechanical_section(pcb, pcb_file, skipped):
+    """Which parts' positions are a mechanical fact, on what evidence.
+
+    INFERENCE, NEVER AUTHORITY -- `--requirements` is the channel for fact,
+    carried verbatim, because the constraints that fix a connector or a
+    mounting hole live in an enclosure drawing this tool cannot see. What
+    this section adds is the evidence an author would otherwise have to
+    reconstruct: the class, its confidence, what the classifier saw, and
+    whether the board's own author already pinned the part.
+
+    It exists because the brief's only other channel for the same question --
+    `measurements.locks.high` -- is GEOMETRIC and collapses on exactly the
+    input an unaided author has. Measured placed -> piled: watchy 7 -> 1,
+    ulx3s 10 -> 0, splitflap_driver 16 -> 2. `part_class.classify_part` reads
+    footprint name, reference prefix and pin function and never a coordinate,
+    so it answers the same on both.
+
+    `pose_shared_with` is the per-part honesty check, and it is per PART
+    rather than a whole-board verdict for the reason `plan_resolve` gives:
+    a part alone at its coordinate is where someone put it, whatever state
+    the rest of the board is in. A staged unaided board carries the real
+    poses of exactly these parts, so an empty list here is the difference
+    between `place_fixed` having a coordinate to assert and not.
+    """
+    from placement.part_class import mechanical_parts
+    found = mechanical_parts(pcb)
+    at_coord = {}
+    for ref, fp in (pcb.footprints or {}).items():
+        at_coord.setdefault((round(fp.x, 4), round(fp.y, 4)), []).append(ref)
+    out = {}
+    for ref, rec in found.items():
+        fp = pcb.footprints.get(ref)
+        shared = []
+        if fp is not None:
+            shared = sorted(r for r in at_coord.get(
+                (round(fp.x, 4), round(fp.y, 4)), ()) if r != ref)
+        row = dict(rec)
+        row['pose_shared_with'] = shared
+        out[ref] = row
+    return {'refs': out,
+            'note': 'INFERENCE from part class, not a mechanical drawing. '
+                    'These are the parts whose position a real new board '
+                    'would already know; `at` is [x, y, rotation] AS THE FILE '
+                    'HAS IT, so read `pose_shared_with` before treating one '
+                    'as a fact to assert with place_fixed. State real '
+                    'mechanical constraints with --requirements.'}
+
+
+def structure_section(pcb, pcb_file, skipped):
+    """The electrical structure a floorplan thinks in."""
+    from placement.groups import AUTO_SOURCES, SOURCES, derive_groups, \
+        decap_tethers
+    out = {}
+    by_source = {}
+    for src in SOURCES:
+        g = _safe(f'structure.groups.{src}', derive_groups, skipped, pcb,
+                  (src,))
+        if g:
+            by_source[src] = {k: sorted(v) for k, v in sorted(g.items())}
+    out['groups'] = by_source
+    out['groups_auto_sources'] = list(AUTO_SOURCES)
+    teth = _safe('structure.decap_tethers', decap_tethers, skipped, pcb)
+    if teth is not None:
+        out['decap_tethers'] = {a: [r for r, _d in sorted(v)]
+                                for a, v in sorted(teth.items())}
+
+    from list_nets import (find_differential_pairs, find_high_connection_nets,
+                           find_power_nets)
+    dp = _safe('structure.diff_pairs', find_differential_pairs, skipped, pcb)
+    if dp is not None:
+        out['diff_pairs'] = _jsonable(dp)
+    pw = _safe('structure.power_nets', find_power_nets, skipped, pcb)
+    if pw is not None:
+        gnd, vcc, cand = pw
+        out['power_nets'] = {'gnd': _jsonable(gnd), 'vcc': _jsonable(vcc),
+                             'candidates': _jsonable(cand)}
+    hi = _safe('structure.top_nets', find_high_connection_nets, skipped, pcb,
+               top_n=15)
+    if hi is not None:
+        out['top_nets'] = _jsonable(hi)
+    return out
+
+
+def _jsonable(v):
+    """Emitters return tuples/dataclasses; a brief has to be JSON."""
+    if isinstance(v, dict):
+        return {str(k): _jsonable(x) for k, x in v.items()}
+    if isinstance(v, (list, tuple, set)):
+        return [_jsonable(x) for x in (sorted(v) if isinstance(v, set) else v)]
+    if hasattr(v, 'to_dict'):
+        return _jsonable(v.to_dict())
+    if hasattr(v, '_asdict'):
+        return _jsonable(v._asdict())
+    if isinstance(v, (int, float, str, bool)) or v is None:
+        return v
+    return str(v)
+
+
+def measurements_section(pcb, pcb_file, skipped, clearance, edge):
+    """The numbers that say a placement will fight the router.
+
+    `escape` is the one that is a BINDING constraint rather than a
+    preference: a face short of lanes cannot pass its own nets at any net
+    ordering, and `blockers` names which neighbour ate the span -- that field
+    is the difference between a signal and an action.
+    """
+    out = {}
+    from placement.escape import escape_ledger
+    led = _safe('measurements.escape', escape_ledger, skipped, pcb,
+                pcb_file=pcb_file, clearance=clearance)
+    if led is not None:
+        # `PartEscape` exposes `worst` (a FaceLedger or None) and NO
+        # `worst_deficit` attribute -- that name exists only as a key in its
+        # to_dict(). A getattr(..., 'worst_deficit', 0) therefore always
+        # returns the default, silently reporting every board as having no
+        # face in deficit.
+        from placement.options import deficit_totals
+        tot = deficit_totals(led)
+        out['escape'] = {'parts': len(led),
+                         'worst': [_jsonable(p) for p in led[:WORST_N]],
+                         'deficit_parts': tot['parts'],
+                         'deficit_lanes': tot['lanes']}
+
+    from placement.lock_advisor import advise_locks, to_json as lock_json
+    adv = _safe('measurements.locks', advise_locks, skipped, pcb,
+                pcb_file=pcb_file, conflict_clearance=clearance)
+    if adv is not None:
+        doc = lock_json(adv)
+        # The advisor's own tally() keys, named explicitly. A
+        # startswith('findings') filter also matches `findings` itself and
+        # embeds the whole per-part findings list -- reasons, evidence and
+        # all -- under a key called "tally".
+        out['locks'] = {
+            'tally': {k: doc[k] for k in
+                      ('findings_high', 'findings_medium', 'findings_low',
+                       'findings_covered', 'unlocked_high', 'locked_in_file',
+                       'advisories') if k in doc},
+            'lock_argv': doc.get('lock_argv', []),
+            'high': [f['ref'] for f in doc.get('findings', [])
+                     if f.get('confidence') == 'high'],
+        }
+    return out
+
+
+def fit_section(pcb, pcb_file, extents, step, clearance, edge, skipped):
+    """Where does a W x H part fit at all?
+
+    Opt-in and COMPUTED here rather than assembled, which is why it is the
+    one section that names its own method. It is the question
+    `wk/run19/urchin/probe_space.py` was hand-written to answer, and whose
+    answer became that run's X0 = 46.0 and "U1 at (28, 60)" -- authored as
+    constants because nothing in the toolchain would say it.
+
+    Reports the legal-centre BOUNDS and count per extent, not a bitmap: an
+    author needs to know whether a 15.5mm part has anywhere to go and roughly
+    where, and a 60x40 grid of booleans in a JSON brief is unreadable.
+    """
+    from placement.legality import BoardOutlineGate
+    bi = pcb.board_info
+    if bi.board_bounds is None:
+        skipped['fit'] = 'the board has no outline to fit against'
+        return None
+    gate = BoardOutlineGate(bi, edge)
+    x0, y0, x1, y1 = bi.board_bounds
+    out = []
+    for (w, h) in extents:
+        hw, hh = w / 2.0, h / 2.0
+        pts = []
+        nx = max(1, int((x1 - x0) / step))
+        ny = max(1, int((y1 - y0) / step))
+        for i in range(nx + 1):
+            for j in range(ny + 1):
+                cx = round(x0 + i * step, 3)
+                cy = round(y0 + j * step, 3)
+                if gate.rect_outside_amount(
+                        (cx - hw, cy - hh, cx + hw, cy + hh)) <= 1e-9:
+                    pts.append((cx, cy))
+        row = {'extent_mm': [w, h], 'step_mm': step, 'legal_cells': len(pts),
+               'fits': bool(pts)}
+        if pts:
+            xs = [p[0] for p in pts]
+            ys = [p[1] for p in pts]
+            row['centre_bounds'] = [min(xs), min(ys), max(xs), max(ys)]
+        out.append(row)
+    return out
+
+
+# Each entry names the function that owns the section's numbers AND what the
+# section requires of the input. The second half is not decoration: a reader
+# who cannot tell "needs a placement" from "needs only the netlist" cannot
+# tell which half of a brief for an unplaced board to believe -- and every
+# section here used to read alike.
+SOURCES_NOTE = {
+    'board': 'kicad_parser.parse_kicad_pcb + list_nets.board_floor_knobs + '
+             'board_brief._shoelace '
+             '[requires: an outline. Independent of part positions]',
+    'state': 'placement.placement_state.assess_placement '
+             '[requires: nothing. This section IS the placement verdict '
+             'the others are read against]',
+    'parts': 'placement.parser.extract_courtyard_bboxes + '
+             'placement.utility.compute_footprint_bbox_local + '
+             'placement.legality.rotate_local_bounds + '
+             'placement.part_class.classify_part '
+             '[requires: nothing for extent/class/nets; `at` and `rect` are '
+             'reported from the file, so on an unplaced board they are the '
+             'pile coordinate]',
+    'mechanical': 'placement.part_class.mechanical_parts '
+                  '(classify_part; pose-independent, so it survives an '
+                  'unplaced board where measurements.locks does not) '
+                  '[requires: nothing. Read `pose_shared_with` before '
+                  'trusting an `at`]',
+    'structure': 'placement.groups.derive_groups / decap_tethers + '
+                 'list_nets.find_differential_pairs / find_power_nets / '
+                 'find_high_connection_nets '
+                 '[requires: a PLACEMENT for groups.decap, groups.netprefix '
+                 'and decap_tethers, which are distance-derived; nothing for '
+                 'groups.sheet/kicad, diff_pairs, power_nets, top_nets]',
+    'measurements': 'placement.escape.escape_ledger + '
+                    'placement.lock_advisor.advise_locks '
+                    '[requires: a PLACEMENT. escape supply and lock '
+                    'confidence are both measured between parts, so on an '
+                    'unplaced board most of this section is null -- see '
+                    'position_dependent]',
+    'fit': 'placement.legality.BoardOutlineGate.rect_outside_amount '
+           '(COMPUTED here, not assembled) '
+           '[requires: an outline only. It never reads another part, so it '
+           'is valid on an unplaced board]',
+    'renders': 'py_tools/render_placement.py --json-out (folded in verbatim) '
+               '[requires: whatever the render was made from -- it draws the '
+               'poses in the file]',
+}
+
+
+def build_brief(pcb, pcb_file, *, clearance=None, board_edge_clearance=None,
+                requirements=None, fit=(), fit_step=DEFAULT_FIT_STEP_MM,
+                render_doc=None):
+    skipped = {}
+    # Board-first: an unset knob resolves from this board's own Default
+    # netclass / min_copper_edge_clearance, and the returned `knobs` records
+    # which source each came from. `board_floor_knobs` returns a TRIPLE.
+    try:
+        from list_nets import board_floor_knobs
+        clr, edge, _knobs = board_floor_knobs(
+            pcb_file, clearance=clearance,
+            board_edge_clearance=board_edge_clearance)
+    except Exception as e:                       # noqa: BLE001 - disclosed
+        clr = 0.25 if clearance is None else clearance
+        edge = 0.55 if board_edge_clearance is None else board_edge_clearance
+        skipped['floors'] = f"{type(e).__name__}: {e}"
+
+    brief = {'schema': SCHEMA, 'kind': 'board-brief',
+             'clearance': clr, 'board_edge_clearance': edge}
+    brief['board'] = board_section(pcb, pcb_file, skipped)
+    brief['state'] = _safe('state', state_section, skipped, pcb, pcb_file,
+                           skipped)
+    brief['parts'] = _safe('parts', parts_section, skipped, pcb, pcb_file,
+                           skipped)
+    brief['mechanical'] = _safe('mechanical', mechanical_section, skipped, pcb,
+                                pcb_file, skipped)
+    brief['structure'] = _safe('structure', structure_section, skipped, pcb,
+                               pcb_file, skipped)
+    brief['measurements'] = _safe('measurements', measurements_section,
+                                  skipped, pcb, pcb_file, skipped, clr, edge)
+    if fit:
+        f = _safe('fit', fit_section, skipped, pcb, pcb_file, fit, fit_step,
+                  clr, edge, skipped)
+        if f is not None:
+            brief['fit'] = f
+    if render_doc is not None:
+        # Verbatim, and only the keys the evidence map names -- a brief that
+        # paraphrased a checklist would be a second source of truth for the
+        # same finding.
+        brief['renders'] = {
+            'instrument': render_doc.get('instrument'),
+            'checklist': render_doc.get('checklist'),
+            'panels': render_doc.get('panels'),
+            'describe': render_doc.get('describe'),
+        }
+    if requirements:
+        # Verbatim. These are the constraints that live nowhere in the board
+        # file -- enclosure fit, connector positions, thermal and EMI zoning,
+        # datasheet layout intent -- and paraphrasing them here would be this
+        # tool inventing mechanical geometry.
+        brief['requirements'] = requirements
+    # The board already told us it is a pile; act on it. This runs AFTER
+    # every section so there is one table of position-dependent paths rather
+    # than a scattering of `if unplaced` branches, and so `invalid` is
+    # derived from what was actually nulled instead of restated by hand.
+    st = brief.get('state') or {}
+    # NOT `st['unplaced']` alone. `assess_placement`'s verdict needs BOTH a
+    # high duplicate fraction AND `distinct_positions <= max(3, 0.1n)`, and
+    # this repo's own stager breaks the second conjunct with the very
+    # exemptions that make an unaided board usable: `stage_unaided` on
+    # splitflap_driver leaves 58 of 65 parts on one coordinate but 8 distinct
+    # positions (7 mechanical + the pile), so `unplaced` is False,
+    # `partially_unplaced` is True -- and this whole disclosure did not fire
+    # on the tool's own output. The brief's question is narrower than the
+    # stager's: "are these coordinates meaningful", and half the parts
+    # sharing one is enough to answer no. A netlist re-import dropping three
+    # new parts on a placed board is 3/65 = 0.046 and stays unmarked, which
+    # is the case `partially_unplaced` exists for.
+    dup = st.get('duplicate_fraction') or 0.0
+    piled = bool(st.get('unplaced')) or dup >= PILE_FRACTION
+    if piled:
+        nulled = [p for p in POSITION_DEPENDENT
+                  if _null_path(brief, p.split('.'))]
+        brief['position_dependent'] = {
+            'invalid': nulled,
+            'because': list(st.get('reasons') or ())
+            or [f"{dup:.0%} of footprints share a position with another"],
+            'also_pose_derived': [{'key': k, 'caveat': why}
+                                  for k, why in POSE_DERIVED_KEPT],
+            'note': (
+                'Keys in `invalid` are null because they are MEASURED FROM '
+                'PART POSITIONS and this board has none yet -- not because '
+                'they could not be computed. Keys in `also_pose_derived` are '
+                'KEPT: each is the best answer available and an author needs '
+                'it, but every one follows the part\'s pose, and a staged '
+                'board carries rotation 0 for everything it moved. '
+                'Everything named in NEITHER list is a netlist, footprint or '
+                'outline fact and holds. `fit` is unaffected -- it probes the '
+                'outline and never another part, so on this board it is the '
+                'section that still answers "where could this go".'),
+            'gate': ('state.unplaced' if st.get('unplaced')
+                     else f'duplicate_fraction {dup:.3f} >= {PILE_FRACTION}'),
+            'not_applied_to': (
+                'a board where only a few refs share a coordinate -- a '
+                'netlist re-import dropping new parts at one spot leaves the '
+                'rest of the numbers meaningful, and state.'
+                'stacked_suspect_refs names the affected refs'),
+        }
+    brief['sources'] = SOURCES_NOTE
+    brief['skipped'] = skipped
+    return brief
+
+
+def format_text(b):
+    L = []
+    bd = b.get('board') or {}
+    L.append(f"BOARD {os.path.basename(bd.get('path', '?'))}: "
+             f"{bd.get('footprints')} parts, {bd.get('nets')} nets, "
+             f"{len(bd.get('copper_layers') or [])} copper layers")
+    if bd.get('size_mm'):
+        L.append(f"  outline {bd['size_mm'][0]} x {bd['size_mm'][1]} mm "
+                 f"({bd.get('area_mm2')} mm2), cutouts {bd.get('cutouts')}, "
+                 f"milled contours {bd.get('milled_contours')}")
+        if bd.get('cutout_area_mm2'):
+            L.append(f"    copper {bd.get('copper_area_mm2')} mm2 -- "
+                     f"{bd['cutout_area_mm2']} mm2 of the outline is cut out")
+    st = b.get('state') or {}
+    if st:
+        what = ('UNPLACED' if st.get('unplaced') else
+                'partially unplaced' if st.get('partially_unplaced')
+                else 'placed')
+        copper = 'yes' if st.get('has_copper') else 'no'
+        L.append(f"  state: {what}; copper {copper} "
+                 f"({st.get('segments')} segs, {st.get('vias')} vias)")
+        for r in (st.get('reasons') or ())[:3]:
+            L.append(f"    - {r}")
+    # BEFORE the numbers, not after them and not only in the JSON. This
+    # printed `state: UNPLACED` and then, eleven lines later, an escape
+    # deficit and a lock tally measured on the pile, in the same words a
+    # placed board gets.
+    pd = b.get('position_dependent') or {}
+    if pd.get('invalid'):
+        L.append(f"  !! {len(pd['invalid'])} measurement(s) below are NULL: "
+                 f"they are measured from part positions and this board has "
+                 f"none yet")
+        L.append("     every part's input coordinate is meaningless, so an "
+                 "op that does not state a target has nothing to work from. "
+                 "State mechanical")
+        L.append("     poses with place_fixed and the rest with "
+                 "place_at/place_pack. `--fit WxH` still answers where a "
+                 "part can go at all.")
+    mech = ((b.get('mechanical') or {}).get('refs')) or {}
+    if mech:
+        _fixed = sorted(r for r, v in mech.items()
+                        if not v.get('pose_shared_with'))
+        L.append(f"  mechanical: {len(mech)} part(s) whose position is a "
+                 f"mechanical fact {sorted(mech)[:6]}"
+                 f"{'...' if len(mech) > 6 else ''}")
+        L.append(f"    {len(_fixed)} of them sit alone at their coordinate, "
+                 f"so `at` is assertable with place_fixed: {_fixed[:6]}"
+                 f"{'...' if len(_fixed) > 6 else ''}")
+    stx = b.get('structure') or {}
+    for src, groups in (stx.get('groups') or {}).items():
+        # A nulled source is named by position_dependent, not counted here --
+        # `len(None)` is how the caveat first shipped.
+        if groups is None:
+            L.append(f"  groups[{src}]: null (needs a placement)")
+            continue
+        L.append(f"  groups[{src}]: {len(groups)} block(s) "
+                 f"{sorted(groups)[:4]}{'...' if len(groups) > 4 else ''}")
+    pw = (stx.get('power_nets') or {})
+    if pw:
+        L.append(f"  power: gnd {pw.get('gnd')}, vcc {pw.get('vcc')}")
+    if stx.get('diff_pairs'):
+        L.append(f"  diff pairs: {len(stx['diff_pairs'])}")
+    ms = b.get('measurements') or {}
+    esc = ms.get('escape') or {}
+    if esc:
+        _dp = esc.get('deficit_parts')
+        L.append(f"  escape: {esc.get('parts')} fine-pitch part(s), "
+                 + (f"{_dp} in deficit" if _dp is not None
+                    else "deficit NOT MEASURED (needs a placement)"))
+        for row in (esc.get('worst') or [])[:3]:
+            if row.get('worst_deficit') is None:
+                continue
+            L.append(f"    {row.get('ref')}: worst face "
+                     f"{row.get('worst_face')} deficit "
+                     f"{row.get('worst_deficit')}")
+    lk = ms.get('locks') or {}
+    if lk:
+        t = lk.get('tally') or {}
+        _uh = t.get('unlocked_high')
+        L.append(f"  locks: "
+                 + (f"{_uh} high-confidence part(s) NOT locked" if _uh
+                    is not None else
+                    "confidence NOT MEASURED (needs a placement) -- see the "
+                    "`mechanical` section, which does not")
+                 + f"; {t.get('locked_in_file', 0)} already locked in the "
+                   f"file")
+        if lk.get('lock_argv'):
+            L.append(f"    {' '.join(lk['lock_argv'])}")
+    for row in (b.get('fit') or []):
+        w, h = row['extent_mm']
+        if row['fits']:
+            cb = row['centre_bounds']
+            L.append(f"  fit {w}x{h}mm: {row['legal_cells']} legal centre(s) "
+                     f"at {row['step_mm']}mm, x {cb[0]}..{cb[2]}, "
+                     f"y {cb[1]}..{cb[3]}")
+        else:
+            L.append(f"  fit {w}x{h}mm: NOWHERE on this board at "
+                     f"{row['step_mm']}mm")
+    if b.get('requirements'):
+        L.append(f"  requirements (verbatim): {b['requirements']}")
+    if b.get('skipped'):
+        L.append(f"  {len(b['skipped'])} section(s) did not run:")
+        for k, why in sorted(b['skipped'].items()):
+            L.append(f"    - {k}: {why}")
+    return "\n".join(L)
+
+
+def _parse_fit(values):
+    out = []
+    for v in values or ():
+        try:
+            w, h = v.lower().replace('*', 'x').split('x')
+            out.append((float(w), float(h)))
+        except ValueError:
+            raise SystemExit(f"board_brief: --fit wants WxH in mm, got {v!r}")
+    return out
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(
+        description="Assemble what a placement author needs to read.",
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("board")
+    p.add_argument("--json", metavar="PATH", help="Write the full brief here")
+    p.add_argument("--clearance", type=float, default=None)
+    p.add_argument("--board-edge-clearance", type=float, default=None)
+    p.add_argument("--requirements", default=None,
+                   help="The constraints that live nowhere in the board file "
+                        "(enclosure, connector edges, thermal, EMI). Carried "
+                        "VERBATIM")
+    p.add_argument("--requirements-file", default=None)
+    p.add_argument("--fit", action="append", metavar="WxH",
+                   help="Also report where a part of this extent fits at all "
+                        "(repeatable)")
+    p.add_argument("--fit-step", type=float, default=DEFAULT_FIT_STEP_MM,
+                   metavar="MM")
+    p.add_argument("--render-json", default=None, metavar="PATH",
+                   help="A render_placement --json-out document to fold in")
+    p.add_argument("-q", "--quiet", action="store_true")
+    a = p.parse_args(argv)
+
+    from kicad_parser import parse_kicad_pcb
+    try:
+        pcb = parse_kicad_pcb(a.board)
+    except Exception as e:                       # noqa: BLE001
+        print(f"board_brief: cannot read {a.board}: {e}", file=sys.stderr)
+        return 2
+    if pcb.board_info.board_bounds is None:
+        print("board_brief: this board has no Edge.Cuts outline, so there is "
+              "nothing to place against. The outline is spec-owned.",
+              file=sys.stderr)
+        return 3
+
+    req = a.requirements
+    if a.requirements_file:
+        try:
+            with open(a.requirements_file, encoding='utf-8') as f:
+                req = f.read().strip()
+        except OSError as e:
+            print(f"board_brief: cannot read requirements: {e}",
+                  file=sys.stderr)
+            return 2
+
+    render_doc = None
+    if a.render_json:
+        try:
+            with open(a.render_json, encoding='utf-8') as f:
+                render_doc = json.load(f)
+        except (OSError, ValueError) as e:
+            print(f"board_brief: cannot read the render doc: {e}",
+                  file=sys.stderr)
+            return 2
+
+    brief = build_brief(pcb, a.board, clearance=a.clearance,
+                        board_edge_clearance=a.board_edge_clearance,
+                        requirements=req, fit=_parse_fit(a.fit),
+                        fit_step=a.fit_step, render_doc=render_doc)
+    if not a.quiet:
+        print(format_text(brief))
+    if a.json:
+        with open(a.json, 'w', encoding='utf-8') as f:
+            json.dump(brief, f, indent=1, sort_keys=True, default=str)
+        print(f"Wrote {a.json}")
+    print("JSON_SUMMARY: " + json.dumps(
+        {'board': a.board, 'parts': brief['board'].get('footprints'),
+         'nets': brief['board'].get('nets'),
+         'unplaced': (brief.get('state') or {}).get('unplaced'),
+         'sections': sorted(k for k, v in brief.items()
+                            if isinstance(v, (dict, list))
+                            and k not in ('sources', 'skipped')),
+         'skipped': sorted(brief.get('skipped') or {})}, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/py_tools/check_capacity.py
+++ b/py_tools/check_capacity.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Can this board hold its parts -- and if not, what are the options?
+
+Six places in this toolchain promise the same sentence:
+
+    the honest response to a board that is genuinely too small is to say so
+    with the measured number and stop
+
+and the measured number is computed in none of them. This computes it, plus
+the other four levers a too-tight board actually has: more copper layers, a
+neighbour moved off a starved face, a tighter clearance (floored at what the
+fab can etch), and a smaller package.
+
+IT REPORTS. It never refuses and it never acts -- no outline is written, no
+stackup is edited, no part is moved. That is deliberate and it matches
+`recommend-stackup`, which proposes the nearest workable option and says
+"do not modify the board file directly -- stackup is a fab-facing decision
+the user must own".
+
+    python3 check_capacity.py board.kicad_pcb
+    python3 check_capacity.py board.kicad_pcb --json capacity.json
+    python3 check_capacity.py board.kicad_pcb --only grow_board add_layers
+
+Exit codes: 0 = measured (whatever the answer), 2 = usage/load error,
+3 = no outline, so there is no capacity question to ask.
+
+There is deliberately NO exit code for "the board is too small". A gate that
+refuses on this would refuse boards that route fine -- the area test is a
+necessary condition, not a sufficient one -- and the executor decides.
+"""
+import _path  # noqa: F401  (py_tools -> py_router/py_placer on sys.path)
+
+import argparse
+import json
+import sys
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(
+        description="Measured capacity options for a board that may be too "
+                    "small for its parts. Reports; never modifies.")
+    p.add_argument("board")
+    p.add_argument("--json", metavar="PATH", help="Write the full report here")
+    p.add_argument("--clearance", type=float, default=None,
+                   help="Default: this board's own Default netclass "
+                        "clearance, never a guessed round number")
+    p.add_argument("--board-edge-clearance", type=float, default=None)
+    p.add_argument("--track-width", type=float, default=None)
+    p.add_argument("--only", nargs="+", metavar="OPTION",
+                   help="Measure only these options")
+    p.add_argument("-q", "--quiet", action="store_true")
+    a = p.parse_args(argv)
+
+    from kicad_parser import parse_kicad_pcb
+    from placement.options import OPTIONS, capacity_options, format_text
+
+    if a.only:
+        bad = [o for o in a.only if o not in OPTIONS]
+        if bad:
+            p.error(f"unknown option(s) {bad}; known: {sorted(OPTIONS)}")
+
+    try:
+        pcb = parse_kicad_pcb(a.board)
+    except Exception as e:                       # noqa: BLE001
+        print(f"check_capacity: cannot read {a.board}: {e}", file=sys.stderr)
+        return 2
+    if pcb.board_info.board_bounds is None:
+        print("check_capacity: this board has no Edge.Cuts outline, so there "
+              "is no capacity question to ask. The outline is spec-owned.",
+              file=sys.stderr)
+        return 3
+
+    try:
+        from list_nets import board_floor_knobs
+        clearance, edge, floors = board_floor_knobs(
+            a.board, clearance=a.clearance,
+            board_edge_clearance=a.board_edge_clearance)
+    except Exception as e:                       # noqa: BLE001
+        clearance = 0.25 if a.clearance is None else a.clearance
+        edge = 0.55 if a.board_edge_clearance is None else a.board_edge_clearance
+        floors = {'error': f"{type(e).__name__}: {e}"}
+
+    opts = capacity_options(pcb, a.board, clearance=clearance,
+                            board_edge_clearance=edge,
+                            track_width=a.track_width, only=a.only)
+    if not a.quiet:
+        print(format_text(opts))
+
+    report = {'schema': 1, 'kind': 'capacity-options', 'board': a.board,
+              'clearance': clearance, 'board_edge_clearance': edge,
+              'floors': floors, 'options': opts}
+    if a.json:
+        with open(a.json, 'w', encoding='utf-8') as f:
+            json.dump(report, f, indent=1, sort_keys=True, default=str)
+        print(f"Wrote {a.json}")
+
+    grow = opts.get('grow_board') or {}
+    print("JSON_SUMMARY: " + json.dumps({
+        'board': a.board,
+        'fits_by_area': grow.get('fits_by_area'),
+        'utilisation': (grow.get('measured') or {}).get('utilisation'),
+        'shortfall_mm2_at_least':
+            (grow.get('measured') or {}).get('shortfall_mm2_at_least'),
+        'measured': sorted(k for k, v in opts.items() if v.get('ran')),
+        'not_measured': sorted(k for k, v in opts.items() if not v.get('ran')),
+    }, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/stress/stage_unaided.py
+++ b/tests/stress/stage_unaided.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""Stage a board for an UNAIDED placement run: netlist in, nothing else.
+
+    python3 -X utf8 tests/stress/stage_unaided.py SRC.kicad_pcb WORKDIR TRUTHDIR
+
+`--kind pile` was the closest thing to this and it is not close enough. Its
+own docstring says "this kind exists to produce the place-from-scratch task"
+(`placement/perturb.py:368-382`) and it hands over:
+
+  * EVERY free part's original rotation (`:389-391` writes
+    `'new_rotation': state.parts[r].rot`). Measured on splitflap_driver:
+    65 of 65 preserved, 32 of them non-zero.
+  * every pad-less and every `(locked yes)` ref at its true x, y AND rotation,
+    because `portfolio.free_refs` skips those and `_all_at_current` then
+    writes them where they were.
+
+And `fence_audit` cannot see any of it: `pose_match` counts a ref only when
+position AND rotation are inside tolerance, so on a pile the positions are all
+wrong, `match_frac` is 0.0000, and the verdict is CLEAN. Run 19's fence exited
+CLEAN, 0 on exactly this.
+
+So this stager does three things the pile kind does not:
+
+  1. **Rotation 0 for every non-exempt part.** An angle is a design decision
+     as much as a position; handing it over is handing over the answer.
+  2. **Exemptions are DECLARED, per ref, with a reason**, in a
+     `mechanical.json` the run may read. Some inheritance is legitimate -- a
+     mounting hole's position is a mechanical fact, not a placement choice --
+     but the difference between a benchmark input and a leak is whether it is
+     written down. Silent inheritance is what `--kind pile` does.
+  3. **The source is recorded by HASH, not by path.** `stage_blind.py:204`
+     writes `'source': src` into the truth dir, naming a file whose original
+     placement is one `Read` away. The mapping lives in the truth dir instead.
+
+Truth goes to a SIBLING directory, never a child of the work dir -- the fence
+audit recurses, and `perturb()`'s own default writes the control beside the
+damaged board, which is how a run gets fenced on paper and open in fact.
+
+Exit codes: 0 staged, 2 usage/IO, 3 the board cannot be staged (no outline).
+"""
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(os.path.dirname(_HERE))
+for _p in (ROOT, os.path.join(ROOT, 'py_router'),
+           os.path.join(ROOT, 'py_tools'), os.path.join(ROOT, 'py_placer')):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+SCHEMA = 1
+
+
+def sha256_file(path):
+    h = hashlib.sha256()
+    with open(path, 'rb') as f:
+        for chunk in iter(lambda: f.read(1 << 20), b''):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def classify_exempt(pcb_data, pcb_file=None):
+    """{ref: (x, y, rot)} plus {ref: reason} for the parts a real new board
+    would genuinely know the position of.
+
+    A PROJECTION of `placement.part_class.mechanical_parts`, not a second
+    taxonomy. It used to be the implementation, which meant the only thing in
+    the tree that could name a board's mechanical parts lived in a stress
+    harness -- so `board_brief` could not answer "where do the fixed parts
+    go?" and an unaided author had to read `mechanical.json`, an artifact no
+    product path emits. Same classifier, two readers.
+    """
+    from placement.part_class import mechanical_parts
+    found = mechanical_parts(pcb_data)
+    refs = {r: tuple(v['at']) for r, v in found.items()}
+    reasons = {r: v['reason'] for r, v in found.items()}
+    return refs, reasons
+
+
+#: Project keys that are the AUTHOR'S, not the board's spec. Every one is
+#: empty on all 13 in-repo projects and read by nothing in this tree, so
+#: dropping them is lossless for every consumer -- but a hand-placed source
+#: fills them with board coordinates (`drc_exclusions` carries the offending
+#: items' positions; the viewports are named views like "MCU corner"), and
+#: `last_paths` carries the author's directories.
+_LEAKY_PROJECT_KEYS = (
+    ('board', 'design_settings', 'drc_exclusions'),
+    ('board', 'viewports'),
+    ('board', '3dviewports'),
+    ('board', 'layer_presets'),
+    ('pcbnew', 'last_paths'),
+)
+
+
+#: What replaces a string that names the source. Not deletion: a run reading
+#: the staged project should see that something was withheld, rather than a
+#: project that looks like it never carried provenance at all.
+_REDACTED = '[redacted: named the source board]'
+
+
+def _redact_source_stem(node, stem, path=(), hits=None):
+    """Replace every string ANYWHERE in the project that names `stem`.
+
+    The key list above is a list of carriers known to leak, and this module's
+    own thesis is that the next carrier will have a different name. It does:
+    measured on tigard, the leak was
+    `kicad_routing_tools.floor_provenance._note` ("tigard is a KiCad 5
+    design...") and `.source`
+    (`https://raw.githubusercontent.com/tigard-tools/tigard/.../tigard.kicad_pcb`)
+    -- an annotation this repo writes itself, in a node no key list contained,
+    naming the upstream board and giving a URL that serves its original
+    placement. `fence_audit` caught it; the stager did not.
+
+    So the backstop is content-shaped rather than key-shaped: whatever key it
+    lives under, a string that spells the source's stem is a path back to the
+    original poses. Numbers are untouched, which is what keeps the #441 floor
+    intact -- every value the floor is graded at is numeric.
+    """
+    if hits is None:
+        hits = []
+    if isinstance(node, dict):
+        for k, v in list(node.items()):
+            if isinstance(v, str) and stem in v.lower():
+                node[k] = _REDACTED
+                hits.append('.'.join(path + (str(k),)))
+            else:
+                _redact_source_stem(v, stem, path + (str(k),), hits)
+    elif isinstance(node, list):
+        for i, v in enumerate(node):
+            if isinstance(v, str) and stem in v.lower():
+                node[i] = _REDACTED
+                hits.append('.'.join(path + (str(i),)))
+            else:
+                _redact_source_stem(v, stem, path + (str(i),), hits)
+    return hits
+
+
+def sanitize_staged_project(out_board, source_stem=None):
+    """Strip the source's IDENTITY from the carried project; declare the rest.
+
+    `source_stem` is the SOURCE board's stem (e.g. `tigard`). Pass it: the
+    key list is a list of known carriers, and the stem sweep is what catches
+    the ones nobody has met yet. Omitting it keeps the old key-only behaviour.
+
+    The project must travel -- without it the staged board grades at the
+    stock netclass (#441), and on flat_hierarchy that is 0.2 -> 0.25 with the
+    source flipping from `board netclass` to `fixed default`. But KiCad
+    stores `meta.filename` inside it, so a verbatim copy puts the SOURCE'S
+    NAME in the work dir: measured, the staged project read
+    `flat_hierarchy.kicad_pro`.
+
+    That defeats this module's own rule -- "the source is recorded by HASH,
+    not by path", because a path is one Read away from the original
+    placement -- and `fence_audit` could not see it: its `SCANNED_EXT` was
+    ('.kicad_pcb', '.json'), so it scanned one file and returned CLEAN.
+
+    Returns the declaration recorded in `mechanical.json`: what travelled,
+    and the floors the run will actually be graded at.
+    """
+    stem = os.path.splitext(out_board)[0]
+    # `.kicad_prl` does not enter the work dir. NOTHING in this repo reads it
+    # (grep: only copy-lists and a temp cleanup) -- it is KiCad's per-board
+    # view state, active layer and selection filter -- and it carries the
+    # source's name the same way `meta.filename` does. Measured: after
+    # sanitising the project, `board.kicad_prl` was the one remaining file in
+    # the work dir containing 'flat_hierarchy'. Carrying a file no consumer
+    # reads, at the cost of a second identity leak, is a bad trade. It still
+    # travels to the TRUTH dir, which is outside the fence.
+    prl = stem + '.kicad_prl'
+    dropped_prl = os.path.isfile(prl)
+    if dropped_prl:
+        os.remove(prl)
+    pro = stem + '.kicad_pro'
+    out = {'carried': os.path.isfile(pro), 'sanitized_keys': [],
+           'dropped_prl': dropped_prl}
+    if out['carried']:
+        with open(pro, encoding='utf-8') as f:
+            doc = json.load(f)
+        meta = doc.get('meta')
+        if isinstance(meta, dict) and meta.get('filename'):
+            meta['filename'] = os.path.basename(pro)
+            out['sanitized_keys'].append('meta.filename')
+        for path in _LEAKY_PROJECT_KEYS:
+            node = doc
+            for k in path[:-1]:
+                node = node.get(k) if isinstance(node, dict) else None
+                if node is None:
+                    break
+            if isinstance(node, dict) and node.get(path[-1]):
+                node[path[-1]] = [] if path[-1] != 'last_paths' else {}
+                out['sanitized_keys'].append('.'.join(path))
+        if source_stem:
+            hits = _redact_source_stem(doc, source_stem.lower())
+            out['redacted_source_strings'] = hits
+            out['sanitized_keys'].extend(hits)
+        with open(pro, 'w', encoding='utf-8') as f:
+            json.dump(doc, f, indent=2)
+        out['sha256'] = sha256_file(pro)
+    # The numbers the run is graded at, whether or not a project travelled.
+    try:
+        from list_nets import board_floor_knobs
+        out['floors'] = board_floor_knobs(out_board)[2]
+    except Exception as e:                                   # noqa: BLE001
+        out['floors'] = f'unavailable: {type(e).__name__}: {e}'
+    for ext in ('.kicad_dru', '.kicad_prl'):
+        out[ext.lstrip('.')] = os.path.isfile(stem + ext)
+    return out
+
+
+def read_mechanical(path):
+    with open(path, encoding='utf-8') as f:
+        return json.load(f)
+
+
+def stage(src, out_board, truth_dir=None, mechanical_out=None):
+    """Write the unaided board; return the mechanical declaration.
+
+    Everything free lands on ONE coordinate at ROTATION 0. The single
+    coordinate is what `placement_state.assess_placement` needs to call the
+    board unplaced (`duplicate_fraction >= 0.5` AND `distinct_positions <=
+    max(3, 0.1n)`), which is what makes the placement tools accept it as a
+    from-scratch task rather than refusing it as a damaged placement.
+    """
+    from kicad_parser import parse_kicad_pcb
+    from placement.writer import write_placed_output
+    from placement.portfolio import copy_siblings
+
+    pcb = parse_kicad_pcb(src)
+    bi = pcb.board_info
+    if bi.board_bounds is None:
+        raise ValueError("the board has no Edge.Cuts outline, so there is "
+                         "nothing to stage a placement against")
+    x0, y0, x1, y1 = bi.board_bounds
+    cx, cy = round((x0 + x1) / 2.0, 6), round((y0 + y1) / 2.0, 6)
+
+    exempt, reasons = classify_exempt(pcb, src)
+    placements = []
+    for ref, fp in sorted(pcb.footprints.items()):
+        if ref in exempt:
+            ex, ey, erot = exempt[ref]
+            placements.append({'reference': ref, 'new_x': ex, 'new_y': ey,
+                               'new_rotation': erot})
+        else:
+            placements.append({'reference': ref, 'new_x': cx, 'new_y': cy,
+                               'new_rotation': 0.0})
+    write_placed_output(src, out_board, placements)
+    copy_siblings(src, out_board)
+    project = sanitize_staged_project(
+        out_board, os.path.splitext(os.path.basename(src))[0])
+
+    doc = {'schema': SCHEMA, 'kind': 'mechanical-declaration',
+           'refs': exempt, 'reasons': reasons,
+           # The project is an input the run reads and it sets every
+           # clearance the placement is graded at -- and it was written down
+           # NOWHERE, while this file's own note claims the declaration is
+           # what makes an input legitimate. A project-less source is now a
+           # declared `carried: false` rather than silence.
+           'project': project,
+           'note': 'the ONLY poses carried over from the source. Everything '
+                   'else is at the board centre at rotation 0. A run may read '
+                   'this; it is an input, not a leak, BECAUSE it is written '
+                   'down. `project` names the floors the run will be graded '
+                   'at, for the same reason.'}
+    mech = mechanical_out or os.path.join(os.path.dirname(out_board),
+                                          'mechanical.json')
+    with open(mech, 'w', encoding='utf-8') as f:
+        json.dump(doc, f, indent=1, sort_keys=True)
+
+    if truth_dir:
+        os.makedirs(truth_dir, exist_ok=True)
+        control = os.path.join(truth_dir, 'control.kicad_pcb')
+        shutil.copyfile(src, control)
+        copy_siblings(src, control)
+        with open(os.path.join(truth_dir, 'stage.json'), 'w',
+                  encoding='utf-8') as f:
+            # The source by HASH. stage_blind records `'source': <path>`,
+            # which names a file whose original placement the run can simply
+            # open; the mapping belongs on this side of the fence.
+            json.dump({'schema': SCHEMA, 'kind': 'unaided-stage',
+                       'source_sha256': sha256_file(src),
+                       'source_basename': os.path.basename(src),
+                       'staged_sha256': sha256_file(out_board),
+                       'exempt_refs': sorted(exempt),
+                       'piled_at': [cx, cy],
+                       'note': 'source recorded by hash, not by path'},
+                      f, indent=1, sort_keys=True)
+    return doc
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(
+        description="Stage a board for an unaided placement run.")
+    p.add_argument("src")
+    p.add_argument("workdir")
+    p.add_argument("truthdir", nargs='?')
+    a = p.parse_args(argv)
+
+    # WORKDIR is a directory, not the output board. Passing `wk/board.kicad_pcb`
+    # -- the obvious guess, and what the output is actually called -- made a
+    # DIRECTORY of that name containing `board.kicad_pcb/board.kicad_pcb`, and
+    # the next command's "cannot read" pointed at the argument rather than the
+    # mistake.
+    if a.workdir.lower().endswith('.kicad_pcb'):
+        p.error(f"WORKDIR is a directory, not a board: {a.workdir!r} names the "
+                f"output file. Pass the directory; the staged board is always "
+                f"written to WORKDIR/board.kicad_pcb.")
+
+    if a.truthdir and os.path.abspath(a.truthdir).startswith(
+            os.path.abspath(a.workdir) + os.sep):
+        p.error("TRUTHDIR must be a SIBLING of WORKDIR, never a child -- the "
+                "fence audit recurses into the work dir, so truth inside it "
+                "is inside the fence")
+    os.makedirs(a.workdir, exist_ok=True)
+    out = os.path.join(a.workdir, 'board.kicad_pcb')
+    try:
+        doc = stage(a.src, out, truth_dir=a.truthdir)
+    except ValueError as e:
+        print(f"stage_unaided: {e}", file=sys.stderr)
+        return 3
+    except OSError as e:
+        print(f"stage_unaided: {e}", file=sys.stderr)
+        return 2
+
+    # Disclosure discipline, from stage_blind: say the SHAPE of the board and
+    # nothing about what was staged away.
+    print(f"Staged {out}")
+    print(f"  {len(doc['refs'])} ref(s) declared mechanical and carried at "
+          f"their source pose; everything else at the board centre, "
+          f"rotation 0")
+    for ref in sorted(doc['refs'])[:8]:
+        print(f"    {ref}: {doc['reasons'][ref]}")
+    if a.truthdir:
+        print(f"  truth in {a.truthdir} (a sibling; nothing in the work dir "
+              f"names the source)")
+    print("JSON_SUMMARY: " + json.dumps(
+        {'board': out, 'exempt': len(doc['refs']),
+         'mechanical': os.path.join(a.workdir, 'mechanical.json')},
+        sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    # In LEVER_REGISTRY, so it must DECLARE -- an entry that writes
+    # poses without declaring makes an armed regime refuse the engine
+    # itself, which is the failure the registry exists to prevent.
+    from placement.provenance import declare_lever
+    with declare_lever('stage_unaided.py', sys.argv):
+        sys.exit(main())

--- a/tests/test_board_brief.py
+++ b/tests/test_board_brief.py
@@ -1,0 +1,685 @@
+#!/usr/bin/env python3
+"""The board brief assembles; it does not compute.
+
+That is the whole claim, and it is the one worth testing: a brief that
+re-derived any number would become a SECOND source of truth for it, and the
+first time the two disagreed nobody would know which one the graders use. So
+each section here is compared against the emitter that owns it, called
+directly, and required to be equal -- not merely plausible.
+
+The other half is honesty about absence. A section that cannot run has to
+appear in `skipped` WITH A REASON and be absent from the body; a brief that
+silently omitted a measurement would read as "nothing to report", which is the
+failure `check_channels` names when it exits 3 rather than answering "clean"
+for a gate that examined nothing.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for p in (REPO,):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+        sys.path.insert(0, os.path.join(p, 'py_router'))
+        sys.path.insert(0, os.path.join(p, 'py_tools'))
+        sys.path.insert(0, os.path.join(p, 'py_placer'))
+
+BOARD = os.path.join(REPO, 'kicad_files', 'splitflap_driver.kicad_pcb')
+
+passed = failed = 0
+
+
+def check(name, ok, detail=""):
+    global passed, failed
+    passed += bool(ok)
+    failed += not ok
+    print(f"  {'OK  ' if ok else 'FAIL'} {name}{(' -- ' + detail) if detail else ''}")
+
+
+if not os.path.isfile(BOARD):
+    print("SKIP: fixture missing")
+    sys.exit(0)
+
+from kicad_parser import parse_kicad_pcb
+from board_brief import build_brief, format_text
+
+pcb = parse_kicad_pcb(BOARD)
+brief = build_brief(pcb, BOARD, requirements="USB on the north edge",
+                    fit=[(15.5, 15.5), (400.0, 400.0)])
+
+# --------------------------------------------------------------------------
+# shape
+# --------------------------------------------------------------------------
+check("the brief carries every section",
+      {'board', 'state', 'parts', 'structure', 'measurements', 'fit',
+       'sources', 'skipped'} <= set(brief), str(sorted(brief)))
+check("nothing was skipped on a healthy board", not brief['skipped'],
+      str(brief['skipped']))
+check("every section names the function that produced it",
+      all(k in brief['sources'] for k in
+          ('board', 'state', 'parts', 'structure', 'measurements', 'fit')),
+      str(sorted(brief['sources'])))
+check("the brief is JSON-serialisable",
+      isinstance(json.dumps(brief, default=str), str))
+check("format_text produces something to read",
+      len(format_text(brief).splitlines()) > 4)
+
+# --------------------------------------------------------------------------
+# ASSEMBLES, DOES NOT COMPUTE: each number equals its emitter's
+# --------------------------------------------------------------------------
+check("board.footprints == the parsed count",
+      brief['board']['footprints'] == len(pcb.footprints),
+      f"{brief['board']['footprints']} vs {len(pcb.footprints)}")
+check("board.bounds == board_info.board_bounds",
+      brief['board']['bounds'] == list(pcb.board_info.board_bounds))
+
+from placement.placement_state import assess_placement
+st = assess_placement(pcb, BOARD)
+check("state.unplaced == assess_placement's",
+      brief['state']['unplaced'] == st.unplaced)
+check("state.stacked_suspect_refs == assess_placement's",
+      brief['state']['stacked_suspect_refs'] == list(st.stacked_suspect_refs))
+
+from placement.groups import derive_groups
+for src in ('decap', 'sheet'):
+    want = derive_groups(pcb, (src,))
+    got = (brief['structure']['groups'] or {}).get(src)
+    if want:
+        check(f"structure.groups[{src}] == derive_groups'",
+              got == {k: sorted(v) for k, v in sorted(want.items())},
+              f"{len(got or {})} vs {len(want)}")
+    else:
+        check(f"structure.groups has no empty {src} bucket", got is None,
+              f"emitter returned nothing but the brief carries {got!r}")
+
+from placement.escape import escape_ledger
+led = escape_ledger(pcb, pcb_file=BOARD, clearance=brief['clearance'])
+esc = brief['measurements'].get('escape') or {}
+check("measurements.escape.parts == escape_ledger's length",
+      esc.get('parts') == len(led), f"{esc.get('parts')} vs {len(led)}")
+# `PartEscape` has no `worst_deficit` ATTRIBUTE -- only a to_dict() key -- so
+# a getattr with a 0 default silently reports every board as deficit-free.
+# Compare against the emitter's own dict, which is where the name is real.
+want_parts = sum(1 for p in led if p.to_dict()['worst_deficit'] > 0)
+check("measurements.escape.deficit_parts == the emitter's own worst_deficit",
+      esc.get('deficit_parts') == want_parts,
+      f"{esc.get('deficit_parts')} vs {want_parts}")
+
+from placement.lock_advisor import advise_locks, to_json as lock_json
+adv = lock_json(advise_locks(pcb, pcb_file=BOARD,
+                             conflict_clearance=brief['clearance']))
+check("measurements.locks.unlocked_high == the advisor's own tally",
+      (brief['measurements']['locks']['tally'].get('unlocked_high')
+       == adv.get('unlocked_high')),
+      f"{brief['measurements']['locks']['tally'].get('unlocked_high')} vs "
+      f"{adv.get('unlocked_high')}")
+check("measurements.locks.lock_argv is the advisor's paste-ready form",
+      brief['measurements']['locks']['lock_argv'] == adv.get('lock_argv'))
+
+# --------------------------------------------------------------------------
+# the parts table
+# --------------------------------------------------------------------------
+parts = brief['parts']
+check("every footprint appears in the parts table",
+      set(parts) == set(pcb.footprints), str(len(parts)))
+check("a part's extent says whether it came from a courtyard or a pad bbox",
+      all(p['extent_source'] in ('courtyard', 'pad_bbox', 'none')
+          for p in parts.values()),
+      str({p['extent_source'] for p in parts.values()}))
+check("at least one part fell back to its pad bbox, and says so",
+      any(p['extent_source'] == 'pad_bbox' for p in parts.values()),
+      "this board's H6/H7 have no courtyard, so the distinction must show")
+
+# --------------------------------------------------------------------------
+# fit: opt-in, and honest when the answer is nowhere
+# --------------------------------------------------------------------------
+fits = {tuple(r['extent_mm']): r for r in brief['fit']}
+check("a part that fits reports where", fits[(15.5, 15.5)]['fits']
+      and fits[(15.5, 15.5)]['legal_cells'] > 0, str(fits[(15.5, 15.5)]))
+check("a part larger than the board reports NOWHERE, not an empty success",
+      fits[(400.0, 400.0)]['fits'] is False
+      and fits[(400.0, 400.0)]['legal_cells'] == 0,
+      str(fits[(400.0, 400.0)]))
+check("fit names itself as computed rather than assembled",
+      'COMPUTED' in brief['sources']['fit'], brief['sources']['fit'])
+check("fit is absent unless asked for",
+      'fit' not in build_brief(pcb, BOARD))
+
+# --------------------------------------------------------------------------
+# requirements are carried VERBATIM -- they are the constraints that live
+# nowhere in the board file, and paraphrasing them would be this tool
+# inventing mechanical geometry
+# --------------------------------------------------------------------------
+check("requirements are carried verbatim",
+      brief['requirements'] == "USB on the north edge", brief['requirements'])
+check("no requirements key when none were given",
+      'requirements' not in build_brief(pcb, BOARD))
+
+# --------------------------------------------------------------------------
+# absence is disclosed, not silent
+# --------------------------------------------------------------------------
+import board_brief as bb
+real = bb.escape_ledger if hasattr(bb, 'escape_ledger') else None
+
+
+def _boom(*a, **kw):
+    raise RuntimeError("deliberate")
+
+
+import placement.escape as esc_mod
+_saved = esc_mod.escape_ledger
+esc_mod.escape_ledger = _boom
+try:
+    broken = build_brief(pcb, BOARD)
+finally:
+    esc_mod.escape_ledger = _saved
+check("a section that raises is reported in `skipped` with its reason",
+      any('escape' in k for k in broken['skipped'])
+      and 'deliberate' in ' '.join(broken['skipped'].values()),
+      str(broken['skipped']))
+check("and is absent from the body rather than present-and-empty",
+      'escape' not in (broken['measurements'] or {}),
+      str(sorted(broken['measurements'] or {})))
+
+# The advisor's tally is a TALLY: counts, not the whole findings list. A
+# `startswith('findings')` filter also matches `findings` itself, which
+# silently embedded every per-part reason and evidence blob under it.
+tally = brief['measurements']['locks']['tally']
+check("locks.tally carries counts only",
+      all(isinstance(v, int) for v in tally.values()),
+      str({k: type(v).__name__ for k, v in tally.items()}))
+check("locks.tally does not embed the findings list",
+      'findings' not in tally, str(sorted(tally)))
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as wd:
+    out = os.path.join(wd, 'brief.json')
+    r = subprocess.run(
+        [sys.executable, '-X', 'utf8', os.path.join('py_tools',
+                                                    'board_brief.py'),
+         BOARD, '--json', out, '--fit', '15.5x15.5'],
+        capture_output=True, text=True, encoding='utf-8', errors='replace',
+        cwd=REPO, timeout=900,
+        env=dict(os.environ, PYTHONIOENCODING='utf-8'))
+    check("the CLI exits 0 on a healthy board", r.returncode == 0,
+          r.stderr[-400:])
+    check("the CLI writes the JSON it says it wrote", os.path.isfile(out))
+    check("the CLI prints a JSON_SUMMARY",
+          any(l.startswith('JSON_SUMMARY:') for l in r.stdout.splitlines()))
+    # The floors path takes no --clearance here, which is the call shape that
+    # crashed while board_floor_knobs' TRIPLE return was read as a mapping.
+    check("the CLI resolves floors without an explicit --clearance",
+          'Traceback' not in r.stderr, r.stderr[-400:])
+
+# --------------------------------------------------------------------------
+# extent_mm is BOARD-FRAME and includes the pads' own size
+#
+# Two defects that shipped together, both silent:
+#   * the pad fallback measured max(global_x) - min(global_x), i.e. pad
+#     CENTRES, so a two-pad part had ZERO width along its pad axis;
+#   * both geometry sources return the footprint-LOCAL frame and nothing
+#     rotated them, so every 90/270 part was transposed.
+# The brief's own `fit` section IS board-frame, so `extent_mm` could not be
+# fed to --fit WxH for half a board -- and the understated area fed
+# grow_board's utilisation.
+# --------------------------------------------------------------------------
+from placement.legality import rotate_local_bounds
+from placement.parser import extract_courtyard_bboxes
+from placement.utility import compute_footprint_bbox_local
+
+for _bd in (BOARD, os.path.join(REPO, 'kicad_files', 'esp_prog.kicad_pcb')):
+    if not os.path.isfile(_bd):
+        continue
+    _pcb = parse_kicad_pcb(_bd)
+    _brief = build_brief(_pcb, _bd)
+    _cy = extract_courtyard_bboxes(_bd) or {}
+    bad, rotated, twopad = [], 0, 0
+    for _ref, _row in _brief['parts'].items():
+        _fp = _pcb.footprints.get(_ref)
+        if _fp is None or _row['extent_source'] == 'none':
+            continue
+        _box = _cy.get(_ref) or compute_footprint_bbox_local(_fp)
+        _g = rotate_local_bounds(*_box, _fp.rotation or 0.0)
+        want = [round(_g[2] - _g[0], 3), round(_g[3] - _g[1], 3)]
+        if want != _row['extent_mm']:
+            bad.append((_ref, _row['extent_mm'], want))
+        if (_fp.rotation or 0.0) % 180 not in (0.0,):
+            rotated += 1
+        if len(_fp.pads or ()) == 2 and _row['extent_source'] == 'pad_bbox':
+            twopad += 1
+            if min(_row['extent_mm']) <= 0.0:
+                bad.append((_ref, _row['extent_mm'], 'zero-width two-pad part'))
+    name = os.path.basename(_bd)
+    check(f"{name}: every extent matches the canonical board-frame bbox",
+          not bad, f"{len(bad)} mismatch(es): {bad[:3]}")
+    check(f"{name}: the fixture has rotated parts, so the frame check bites",
+          rotated > 0, f"{rotated} part(s) at a non-0/180 rotation")
+
+_ep = os.path.join(REPO, 'kicad_files', 'esp_prog.kicad_pcb')
+if os.path.isfile(_ep):
+    _b = build_brief(parse_kicad_pcb(_ep), _ep)
+    c1 = _b['parts'].get('C1', {}).get('extent_mm')
+    check("esp_prog C1 (an 0603) has real width on both axes",
+          c1 and min(c1) > 0.5, f"{c1} -- it used to read [0.0, 1.778]")
+
+# --------------------------------------------------------------------------
+# COORDINATES. The brief emitted `rotation` and no position, from the same
+# footprint, in the same dict literal -- while six of the thirteen plan ops
+# take a literal board coordinate and `place_fixed` REQUIRES one.
+# --------------------------------------------------------------------------
+from placement.legality import graded_parts_from_file
+
+for _bd in (BOARD, os.path.join(REPO, 'kicad_files', 'watchy.kicad_pcb')):
+    if not os.path.isfile(_bd):
+        continue
+    name = os.path.basename(_bd)
+    _pcb = parse_kicad_pcb(_bd)
+    _brief = build_brief(_pcb, _bd)
+
+    bad_at = [(r, row.get('at'), [round(_pcb.footprints[r].x, 6),
+                                 round(_pcb.footprints[r].y, 6)])
+              for r, row in _brief['parts'].items()
+              if r in _pcb.footprints
+              and row.get('at') != [round(_pcb.footprints[r].x, 6),
+                                    round(_pcb.footprints[r].y, 6)]]
+    check(f"{name}: every part row carries its own pose",
+          _brief['parts'] and not bad_at,
+          f"{len(bad_at)} wrong: {bad_at[:3]}")
+
+    # The absolute rect must be the one the LEGALITY GRADER uses, or the
+    # brief is publishing a second geometry an author would place against
+    # and a grader would then contradict.
+    #
+    # `extent_source: 'none'` is excluded and then checked separately: the
+    # two DO disagree there, deliberately. `compute_footprint_bbox_local`
+    # substitutes a 1x1mm placeholder for a part with no pads, so the grader
+    # has something to grade; the brief says it has no geometry instead.
+    # Asserting them equal would force the brief to publish the placeholder
+    # as if it were a measurement.
+    _graded = {p.ref: p.rect for p in graded_parts_from_file(_pcb, _bd)}
+    _cmp = {r: v for r, v in _graded.items()
+            if r in _brief['parts']
+            and _brief['parts'][r]['extent_source'] != 'none'}
+    bad_rect = [(r, _brief['parts'][r].get('rect'), list(_cmp[r]))
+                for r in _cmp
+                if (_brief['parts'][r].get('rect') is None
+                    or max(abs(a - b) for a, b in
+                           zip(_brief['parts'][r]['rect'], _cmp[r])) > 1e-6)]
+    check(f"{name}: parts[*].rect == graded_parts_from_file's rect",
+          _cmp and not bad_rect,
+          f"{len(bad_rect)} of {len(_cmp)} graded differ: {bad_rect[:2]}")
+    _nogeom = [r for r, row in _brief['parts'].items()
+               if row['extent_source'] == 'none']
+    check(f"{name}: a null rect means the part really has no pads",
+          all(not (_pcb.footprints[r].pads or ()) for r in _nogeom)
+          and all(_brief['parts'][r]['rect'] is None for r in _nogeom),
+          str([(r, len(_pcb.footprints[r].pads or ())) for r in _nogeom]))
+
+    # Rings, not counts. `place_keepout` takes a rect and nothing in the
+    # brief could supply one.
+    _bi = _pcb.board_info
+    check(f"{name}: cutout rings round-trip to the parser's own",
+          _brief['board']['cutout_rings'] ==
+          [[[round(float(x), 6), round(float(y), 6)] for x, y in ring]
+           for ring in (getattr(_bi, 'board_cutouts', None) or ()) if ring],
+          f"{len(_brief['board']['cutout_rings'])} ring(s) vs "
+          f"{len(getattr(_bi, 'board_cutouts', None) or ())} parsed")
+    check(f"{name}: the ring count still matches the published rings",
+          _brief['board']['cutouts'] == len(_brief['board']['cutout_rings'])
+          and _brief['board']['outlines'] ==
+          len(_brief['board']['outline_rings']))
+
+_w = os.path.join(REPO, 'kicad_files', 'watchy.kicad_pcb')
+if os.path.isfile(_w):
+    _b = build_brief(parse_kicad_pcb(_w), _w)
+    # watchy is the corpus's only board with cutouts: two strap slots worth
+    # 118.97mm2, which a bbox area reports as copper that is not there.
+    check("watchy: copper area subtracts the cutouts",
+          _b['board'].get('copper_area_mm2') == 1434.09,
+          f"copper {_b['board'].get('copper_area_mm2')}, "
+          f"bbox {_b['board'].get('area_mm2')} (must not be equal)")
+    check("watchy: the bbox area is UNCHANGED, so no reader silently moves",
+          _b['board'].get('area_mm2') == 1553.06,
+          str(_b['board'].get('area_mm2')))
+    check("watchy: the cutouts are the difference",
+          abs((_b['board']['outline_area_mm2']
+               - _b['board']['cutout_area_mm2'])
+              - _b['board']['copper_area_mm2']) < 0.01)
+
+# --------------------------------------------------------------------------
+# MECHANICAL. The one channel for "which parts' positions are fixed" that
+# survives a pile -- `measurements.locks.high` is geometric and does not.
+# --------------------------------------------------------------------------
+from placement.part_class import mechanical_parts
+
+for _bd in (BOARD, _w, os.path.join(REPO, 'kicad_files', 'tigard.kicad_pcb')):
+    if not os.path.isfile(_bd):
+        continue
+    name = os.path.basename(_bd)
+    _pcb = parse_kicad_pcb(_bd)
+    _brief = build_brief(_pcb, _bd)
+    _mech = (_brief.get('mechanical') or {}).get('refs') or {}
+    check(f"{name}: mechanical names the same refs as its own emitter",
+          set(_mech) == set(mechanical_parts(_pcb)),
+          f"{sorted(_mech)} vs {sorted(mechanical_parts(_pcb))}")
+    check(f"{name}: the fixture HAS mechanical parts, so the check bites",
+          len(_mech) > 0, f"{len(_mech)} found")
+    # Two grounds, two evidence shapes. A CLASSIFIED ref must carry the
+    # classifier's confidence and what it saw; a ref admitted only because
+    # the file locks it has no class evidence to give -- the lock IS the
+    # evidence -- so requiring one of it would have forced a fabricated
+    # value (tigard's G*** is exactly this case).
+    bad_ev = [(r, v.get('class'), v.get('confidence'), v.get('evidence'),
+               v.get('locked_in_source'))
+              for r, v in _mech.items()
+              if not v.get('reason')
+              or (v.get('class') and not (v.get('confidence')
+                                          and v.get('evidence')))
+              or (not v.get('class') and not v.get('locked_in_source'))]
+    check(f"{name}: every mechanical ref carries evidence for its own ground",
+          not bad_ev, str(bad_ev[:3]))
+    # The `at` is the field `place_fixed` consumes. Nothing validated it.
+    bad_mat = [(r, v['at'], [round(_pcb.footprints[r].x, 6),
+                             round(_pcb.footprints[r].y, 6),
+                             round(_pcb.footprints[r].rotation or 0.0, 6)])
+               for r, v in _mech.items()
+               if v['at'] != [round(_pcb.footprints[r].x, 6),
+                              round(_pcb.footprints[r].y, 6),
+                              round(_pcb.footprints[r].rotation or 0.0, 6)]]
+    check(f"{name}: mechanical `at` is the part's real pose, x/y AND rotation",
+          not bad_mat, str(bad_mat[:3]))
+    # On a PLACED board nothing shares a coordinate, so every `at` is
+    # assertable. That is the value this must report, and the piled arm
+    # below is the one that must report the opposite.
+    check(f"{name}: on a placed board every mechanical pose stands alone",
+          all(not v['pose_shared_with'] for v in _mech.values()),
+          str({r: v['pose_shared_with'] for r, v in _mech.items()
+               if v['pose_shared_with']}))
+
+# --------------------------------------------------------------------------
+# THE PILE. Graded on three boards, because this is not a property of one:
+# swept placed -> piled, ulx3s reports 19 -> 109 escape deficit lanes and
+# locks.high 10 -> 0, kit-dev-coldfire 0 -> 82 lanes on a board with no
+# escape problem at all, splitflap_driver locks.high 16 -> 2. Same schema,
+# no marking anywhere.
+#
+# The pile is built IN MEMORY -- moving every footprint to the board centre
+# and shifting its pads -- so this needs no new board file and cannot drift
+# from the boards the rest of the suite uses.
+# --------------------------------------------------------------------------
+from placement.placement_state import assess_placement
+from board_brief import POSITION_DEPENDENT, _null_path
+
+
+def piled(path):
+    """The board as `stage_unaided.stage()` leaves it, in memory.
+
+    ROTATION 0 is not a detail -- `stage_unaided.py:118` writes it for every
+    part it moves, and `extent_mm`, `rect` and the whole per-face escape
+    table follow rotation. An earlier version of this helper translated the
+    parts and KEPT their angles, so nothing rotation-derived could move and
+    the arm below could not see any of it: an injection that rotated every
+    face's demand by one face passed all 102 checks.
+    """
+    p = parse_kicad_pcb(path)
+    b = p.board_info.board_bounds
+    cx, cy = (b[0] + b[2]) / 2.0, (b[1] + b[3]) / 2.0
+    for _r, _f in p.footprints.items():
+        dx, dy = cx - _f.x, cy - _f.y
+        _f.x, _f.y = cx, cy
+        _f.rotation = 0.0
+        for _p in _f.pads:
+            _p.global_x += dx
+            _p.global_y += dy
+    return p
+
+
+def dig(doc, path):
+    """Follow one POSITION_DEPENDENT path to its value(s)."""
+    node, parts = doc, path.split('.')
+    for i, key in enumerate(parts):
+        listy = key.endswith('[]')
+        if listy:
+            key = key[:-2]
+        if not isinstance(node, dict) or key not in node:
+            return []
+        node = node[key]
+        if listy:
+            return [v for it in (node or ())
+                    for v in dig(it, '.'.join(parts[i + 1:]))]
+    return [node]
+
+
+_demand_boards = []
+for _bd in (BOARD, _w, os.path.join(REPO, 'kicad_files', 'tigard.kicad_pcb')):
+    if not os.path.isfile(_bd):
+        continue
+    name = os.path.basename(_bd)
+    _pcb = piled(_bd)
+    check(f"{name}: the in-memory pile really is unplaced",
+          assess_placement(_pcb, _bd).unplaced,
+          "if this is False the whole arm below proves nothing")
+    _pb = build_brief(_pcb, _bd, fit=[(5.0, 5.0)])
+    _pd = _pb.get('position_dependent') or {}
+
+    check(f"{name}: the brief discloses that it nulled things",
+          bool(_pd.get('invalid')) and bool(_pd.get('because')),
+          str(_pd)[:120])
+    # EVERY path it names is actually null ...
+    still = [p for p in _pd.get('invalid', ())
+             if any(v is not None for v in dig(_pb, p))]
+    check(f"{name}: every path named in `invalid` is really null",
+          not still, str(still))
+    # ... and nothing it did NOT name got nulled behind the reader's back.
+    # Scanned over the WHOLE measurements/structure subtree, not just over
+    # POSITION_DEPENDENT: ranging over the table made the "no others" half
+    # definitionally true, and an injection that nulled `structure.top_nets`
+    # without declaring it passed every check.
+    def null_leaves(node, path=''):
+        if isinstance(node, dict):
+            for k, v in node.items():
+                yield from null_leaves(v, f'{path}.{k}' if path else k)
+        elif isinstance(node, list):
+            for it in node:
+                yield from null_leaves(it, path + '[]')
+        elif node is None:
+            yield path
+
+    declared = set(_pd.get('invalid', ()))
+    unnamed = sorted({p for sub in ('measurements', 'structure')
+                      for p in null_leaves(_pb.get(sub), sub)
+                      if p not in declared})
+    check(f"{name}: `invalid` names every nulled path and no others",
+          not unnamed,
+          f"{unnamed} -- null with nothing in position_dependent explaining it")
+
+    # The valid half SURVIVES. A caveat that nulled the netlist facts too
+    # would be a refusal wearing a caveat's clothes.
+    esc = (_pb['measurements'].get('escape') or {})
+    check(f"{name}: the per-part escape numbers survive the pile",
+          esc.get('parts') is not None
+          and all(f.get('demand') is not None and f.get('span_mm') is not None
+                  for p in (esc.get('worst') or []) for f in p['faces']),
+          str({k: v for k, v in esc.items() if not isinstance(v, list)}))
+    # ...but the per-FACE split follows rotation and a staged board carries
+    # rotation 0, so it must be NAMED. It is kept, not nulled, because a
+    # deficit is read off it -- and an injection that rotated every face's
+    # demand by one face passed the check above, which is why this one is
+    # here: the value is not asserted, its DISCLOSURE is.
+    _named = {d['key'] for d in (_pd.get('also_pose_derived') or ())}
+    check(f"{name}: the per-face escape table is named as pose-derived",
+          any('faces[]' in k and 'demand' in k for k in _named), str(_named))
+    check(f"{name}: so is extent_mm, which swaps W/H with rotation",
+          any('extent_mm' in k for k in _named), str(_named))
+    check(f"{name}: and the render fold-in, which draws the pile",
+          any(k.startswith('renders') for k in _named), str(_named))
+    check(f"{name}: worst[] is named as pile-SELECTED, not merely reordered",
+          any('membership' in k for k in _named), str(_named))
+    # The invariant the per-face split is NOT: a part's total demand.
+    _tot = {p['ref']: sum(f['demand'] for f in p['faces'])
+            for p in (esc.get('worst') or [])}
+    _placed_esc = (build_brief(parse_kicad_pcb(_bd), _bd)['measurements']
+                   .get('escape') or {})
+    _ptot = {p['ref']: sum(f['demand'] for f in p['faces'])
+             for p in (_placed_esc.get('worst') or [])}
+    _shared = set(_tot) & set(_ptot)
+    if _shared:
+        _demand_boards.append(name)
+        check(f"{name}: total demand per part IS rotation-invariant",
+              all(_tot[r] == _ptot[r] for r in _shared),
+              str({r: (_tot[r], _ptot[r]) for r in _shared
+                   if _tot[r] != _ptot[r]}))
+    tal = (_pb['measurements'].get('locks') or {}).get('tally') or {}
+    check(f"{name}: locked_in_file is a FILE fact and survives",
+          tal.get('locked_in_file') is not None, str(tal))
+    check(f"{name}: the netlist structure survives",
+          _pb['structure'].get('power_nets') is not None
+          and _pb['structure'].get('diff_pairs') is not None)
+
+    # fit probes the OUTLINE and never another part, so it is the section
+    # that still answers "where could this go".
+    _placed = build_brief(parse_kicad_pcb(_bd), _bd, fit=[(5.0, 5.0)])
+    check(f"{name}: `fit` is identical placed and piled",
+          _pb['fit'] == _placed['fit'],
+          f"{_pb['fit']} vs {_placed['fit']}")
+
+    # And the section that answers "which parts are fixed" must survive too,
+    # while reporting honestly that the poses are now pile poses.
+    _pm = (_pb.get('mechanical') or {}).get('refs') or {}
+    _plm = (_placed.get('mechanical') or {}).get('refs') or {}
+    check(f"{name}: mechanical still names its refs on the pile",
+          _plm and set(_pm) == set(_plm),
+          f"{sorted(_pm)} vs {sorted(_plm)}")
+    check(f"{name}: and says every pose is now shared, so none is assertable",
+          all(v['pose_shared_with'] for v in _pm.values()),
+          str({r: v['pose_shared_with'] for r, v in _pm.items()
+               if not v['pose_shared_with']}))
+
+    check(f"{name}: format_text survives a nulled brief",
+          len(format_text(_pb).splitlines()) > 4)
+    # RELATIVE, not a fixed line window: a 12-line prefix happens to work on
+    # these three boards and would stop biting on a shorter one.
+    _lines = format_text(_pb).splitlines()
+    _warn = next((i for i, ln in enumerate(_lines) if 'NULL' in ln), None)
+    _num = next((i for i, ln in enumerate(_lines)
+                 if ln.lstrip().startswith(('escape:', 'locks:', 'groups['))),
+                None)
+    check(f"{name}: and warns BEFORE the numbers, not after",
+          _warn is not None and _num is not None and _warn < _num,
+          f"caveat at line {_warn}, first number at line {_num}")
+
+check("at least one board actually exercised the demand invariant",
+      bool(_demand_boards),
+      f"{_demand_boards} -- a board with no fine-pitch parts makes that "
+      f"check vacuous, so it is skipped there and must bite somewhere")
+
+# --------------------------------------------------------------------------
+# THE PRODUCT PATH. The in-memory pile above is a model; this is the thing
+# the toolchain actually produces, and the two disagree in the way that
+# matters. `stage_unaided` exempts the mechanical parts, which keeps their
+# real coordinates -- so `distinct_positions` is 8, not 1, on
+# splitflap_driver, `assess_placement` returns partially_unplaced rather than
+# unplaced, and a disclosure gated on `state.unplaced` alone DID NOT FIRE on
+# 58-of-65 parts stacked at one point. Gate on the pile fraction here.
+# --------------------------------------------------------------------------
+import shutil
+import tempfile
+
+sys.path.insert(0, os.path.join(REPO, 'tests', 'stress'))
+try:
+    from stage_unaided import stage as _stage
+except Exception as _e:                                      # noqa: BLE001
+    _stage = None
+    check("stage_unaided is importable (the product path arm needs it)",
+          False, str(_e))
+
+if _stage is not None:
+    for _bd in (BOARD, _w):
+        if not os.path.isfile(_bd):
+            continue
+        name = os.path.basename(_bd)
+        _tmp = tempfile.mkdtemp(prefix='brief_staged_')
+        try:
+            _out = os.path.join(_tmp, 'board.kicad_pcb')
+            _stage(_bd, _out, os.path.join(_tmp, 'truth'))
+            _spcb = parse_kicad_pcb(_out)
+            _sb = build_brief(_spcb, _out)
+            _st = _sb['state']
+            _spd = _sb.get('position_dependent') or {}
+            check(f"{name} STAGED: the disclosure fires on the real stager's "
+                  f"output", bool(_spd.get('invalid')),
+                  f"unplaced={_st['unplaced']} "
+                  f"partially={_st['partially_unplaced']} "
+                  f"dup={_st['duplicate_fraction']} "
+                  f"distinct={_st['signals'].get('distinct_positions')} -- "
+                  f"gating on state.unplaced alone misses this board")
+            check(f"{name} STAGED: and says which gate fired",
+                  bool(_spd.get('gate')), str(_spd.get('gate')))
+            check(f"{name} STAGED: the pile really is a pile "
+                  f"(else the check above is free)",
+                  (_st['duplicate_fraction'] or 0) >= 0.5,
+                  str(_st['duplicate_fraction']))
+            # The mechanical refs KEEP their real pose through staging --
+            # that is what makes `place_fixed` writable from the brief.
+            _sm = (_sb.get('mechanical') or {}).get('refs') or {}
+            _om = (build_brief(parse_kicad_pcb(_bd), _bd)
+                   .get('mechanical') or {}).get('refs') or {}
+            check(f"{name} STAGED: every mechanical pose survives staging",
+                  _sm and all(_sm[r]['at'] == _om[r]['at'] for r in _sm),
+                  str({r: (_sm[r]['at'], _om[r]['at']) for r in _sm
+                       if _sm[r]['at'] != _om[r]['at']}))
+            check(f"{name} STAGED: and each is alone, so `at` is assertable",
+                  all(not v['pose_shared_with'] for v in _sm.values()),
+                  str({r: v['pose_shared_with'] for r, v in _sm.items()
+                       if v['pose_shared_with']}))
+            # The rotation-derived keys the note now names: prove they really
+            # do move, so `also_pose_derived` is a live disclosure.
+            _ob = build_brief(parse_kicad_pcb(_bd), _bd)
+            swapped = [r for r, row in _sb['parts'].items()
+                       if r in _ob['parts'] and r not in _sm
+                       and row['extent_mm'] == list(
+                           reversed(_ob['parts'][r]['extent_mm']))
+                       and row['extent_mm'] != _ob['parts'][r]['extent_mm']]
+            check(f"{name} STAGED: extent_mm really does swap on staged parts",
+                  len(swapped) > 0,
+                  f"{len(swapped)} part(s) transposed -- if this is 0 the "
+                  f"`also_pose_derived` entry for extent_mm is not earning "
+                  f"its place")
+        finally:
+            shutil.rmtree(_tmp, ignore_errors=True)
+
+# A PLACED board must be untouched by all of this.
+_pl = build_brief(parse_kicad_pcb(BOARD), BOARD)
+check("a placed board gets no position_dependent block at all",
+      'position_dependent' not in _pl, str(_pl.get('position_dependent')))
+check("and its numbers are not nulled",
+      (_pl['measurements'].get('escape') or {}).get('deficit_lanes')
+      is not None)
+
+# DERIVED FROM THE BRIEF, not from a hand-written list. Both of these used
+# to enumerate section names, so they asserted that a dict literal contained
+# the keys of the same dict literal and could never notice a new section
+# that shipped unsourced -- which is exactly what `sources` exists to stop.
+_META = {'schema', 'kind', 'clearance', 'board_edge_clearance', 'sources',
+         'skipped', 'requirements', 'position_dependent'}
+_pl_full = build_brief(parse_kicad_pcb(BOARD), BOARD, fit=[(5.0, 5.0)],
+                       requirements='x')
+_sections = {k for k, v in _pl_full.items()
+             if k not in _META and isinstance(v, (dict, list))}
+check("every section the brief emits names the function that produced it",
+      _sections and _sections <= set(_pl_full['sources']),
+      f"unsourced: {sorted(_sections - set(_pl_full['sources']))}")
+check("and the fixture really has the sections worth checking",
+      {'board', 'state', 'parts', 'mechanical', 'structure', 'measurements',
+       'fit'} <= _sections, str(sorted(_sections)))
+check("and each source says what it REQUIRES of the input",
+      all('[requires:' in _pl_full['sources'][k] for k in _sections),
+      str([k for k in _sections if '[requires:' not in _pl_full['sources'][k]]))
+
+print(f"\n{passed} passed, {failed} failed")
+sys.exit(1 if failed else 0)

--- a/tests/test_capacity_options.py
+++ b/tests/test_capacity_options.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""The options channel: measured, and never a refusal.
+
+Six places in the toolchain promise "say so with the measured number and
+stop", and the number was computed in none of them. These are the tests that
+the number is now real, that it is honest about being a NECESSARY rather than
+a sufficient condition, and that nothing here ever refuses or acts.
+
+The trap this file exists to catch is the one that was already live in the
+first draft: `PartEscape` exposes `worst` (a FaceLedger or None) and no
+`worst_deficit` attribute -- that name is only a key in its `to_dict()`. A
+`getattr(p, 'worst_deficit', 0)` therefore returns the default forever, and
+two of these options reported "no face is short of lanes" on a board with 38
+of them. So every deficit number here is compared against the emitter's own
+dict rather than an attribute that may not exist.
+"""
+import glob
+import os
+import subprocess
+import sys
+import tempfile
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for p in (REPO,):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+        sys.path.insert(0, os.path.join(p, 'py_router'))
+        sys.path.insert(0, os.path.join(p, 'py_tools'))
+        sys.path.insert(0, os.path.join(p, 'py_placer'))
+
+SMALL = os.path.join(REPO, 'kicad_files', 'splitflap_driver.kicad_pcb')
+DENSE = os.path.join(REPO, 'kicad_files', 'glasgow_revC.kicad_pcb')
+
+passed = failed = 0
+
+
+def check(name, ok, detail=""):
+    global passed, failed
+    passed += bool(ok)
+    failed += not ok
+    print(f"  {'OK  ' if ok else 'FAIL'} {name}{(' -- ' + detail) if detail else ''}")
+
+
+if not os.path.isfile(SMALL):
+    print("SKIP: fixture missing")
+    sys.exit(0)
+
+from kicad_parser import parse_kicad_pcb
+from placement.escape import PartEscape, escape_ledger
+from placement.options import (OPTIONS, capacity_options, deficit_totals,
+                               format_text, grow_board)
+
+pcb = parse_kicad_pcb(SMALL)
+opts = capacity_options(pcb, SMALL, clearance=0.2, board_edge_clearance=0.5)
+
+# --------------------------------------------------------------------------
+# the house shape: ran / reason / measured / expected, and never a refusal
+# --------------------------------------------------------------------------
+check("every option is present in the report", set(opts) == set(OPTIONS),
+      str(sorted(set(OPTIONS) ^ set(opts))))
+check("every option either ran or says why it did not",
+      all(o.get('ran') or o.get('reason') for o in opts.values()),
+      str({k: sorted(v) for k, v in opts.items()}))
+check("an option that ran carries measured AND expected",
+      all({'measured', 'expected'} <= set(o)
+          for o in opts.values() if o.get('ran')),
+      str({k: sorted(v) for k, v in opts.items() if v.get('ran')}))
+check("`ran: False` never means clean -- it means NOT MEASURED",
+      all('measured' not in o for o in opts.values() if not o.get('ran')),
+      "a skipped option must not carry numbers")
+check("format_text says nothing is applied",
+      'never applied' in format_text(opts))
+check("a measured option shows its numbers even with no action to take",
+      all(any(line.strip().startswith(k + ':')
+              and len(line.split(':', 1)[1].strip()) > 0
+              for line in format_text(opts).splitlines())
+          for k in opts if opts[k].get('ran')),
+      format_text(opts))
+
+# --------------------------------------------------------------------------
+# grow_board: the number the prohibition asks for
+# --------------------------------------------------------------------------
+g = opts['grow_board']
+check("grow_board ran on a healthy board", g.get('ran'), str(g))
+m = g['measured']
+check("it measures part area against USABLE area, not the raw outline",
+      m['usable_area_mm2'] < m['outline_area_mm2'],
+      f"{m['usable_area_mm2']} vs {m['outline_area_mm2']}")
+check("it discloses how many extents came from a pad bbox",
+      'extent_from_pad_bbox' in m and 'extent_from_courtyard' in m, str(m))
+check("a board whose parts fit reports no shortfall",
+      g['fits_by_area'] and 'shortfall_mm2_at_least' not in m, str(m))
+check("the shortfall is named 'at_least' -- it is a NECESSARY condition",
+      'shortfall_mm2_at_least' in str(grow_board.__doc__)
+      or 'necessary' in grow_board.__doc__.lower(),
+      "the docstring must say the area test is not sufficient")
+
+# A board that cannot possibly hold its parts: same parts, tiny outline.
+#
+# This used to depend on the fixture's outline being a single `gr_rect`, and
+# splitflap's is gr_lines -- so the else-branch never ran and the if-branch
+# booked `check(..., True)` with a SKIPPED reason. A literal-True check with
+# an explanation is still a green tick on an examination nobody performed, and
+# it sat here for the entire life of the option it was meant to guard.
+# Overriding `board_bounds` needs no outline geometry at all.
+tp = parse_kicad_pcb(SMALL)
+_bx0, _by0, _bx1, _by1 = tp.board_info.board_bounds
+tp.board_info.board_bounds = (_bx0, _by0, _bx0 + (_bx1 - _bx0) / 6.0,
+                              _by0 + (_by1 - _by0) / 6.0)
+tg = grow_board(tp, SMALL, clearance=0.2, board_edge_clearance=0.5)
+check("a too-small board reports a shortfall in mm2",
+      tg['ran'] and tg['fits_by_area'] is False
+      and tg['measured']['shortfall_mm2_at_least'] > 0,
+      str(tg.get('measured')))
+check("and says the outline is a mechanical decision it will not make",
+      'mechanical decision' in tg.get('action', ''), tg.get('action'))
+
+# --------------------------------------------------------------------------
+# deficit_totals: the bug that made two options lie
+# --------------------------------------------------------------------------
+# Against the REAL class. This asserted `not hasattr(type('x', (), {}), ...)`
+# -- an anonymous empty class -- which is unconditionally true and never
+# touched PartEscape. It stayed green when a real worst_deficit property was
+# added, and, worse, it stood guard over a bug that was still live in
+# options.py's relax_clearance the whole time it was passing.
+check("PartEscape really has no worst_deficit ATTRIBUTE",
+      not hasattr(PartEscape, 'worst_deficit'),
+      "if this ever gains the attribute, the getattr form becomes safe and "
+      "this test should be deleted rather than inverted")
+if os.path.isfile(DENSE):
+    dp = parse_kicad_pcb(DENSE)
+    led = escape_ledger(dp, pcb_file=DENSE, clearance=0.2)
+    tot = deficit_totals(led)
+    want_parts = sum(1 for p in led if p.to_dict()['worst_deficit'] > 0)
+    want_lanes = sum(f['deficit'] for p in led for f in p.to_dict()['faces'])
+    check("deficit_totals.parts == the emitter's own worst_deficit",
+          tot['parts'] == want_parts, f"{tot['parts']} vs {want_parts}")
+    check("deficit_totals.lanes == the emitter's own per-face deficits",
+          tot['lanes'] == want_lanes, f"{tot['lanes']} vs {want_lanes}")
+    check("a dense board really does have faces in deficit (else this "
+          "fixture proves nothing)", want_lanes > 0, f"{want_lanes} lanes")
+
+    dopts = capacity_options(dp, DENSE, clearance=0.2,
+                             board_edge_clearance=0.5)
+    al = dopts['add_layers']
+    mb = dopts['move_blocker']
+    # A crash must never arrive looking like an honest skip. This board has
+    # fine-pitch parts and 43 deficit lanes, so BOTH of these must run --
+    # asserting only "they agree" lets a KeyError pass vacuously, which is
+    # exactly what happened.
+    check("no option FAILED on the dense board",
+          not any(o.get('error') for o in dopts.values()),
+          str({k: v.get('reason') for k, v in dopts.items()
+               if v.get('error')}))
+    check("add_layers RAN on a board with fine-pitch parts", al.get('ran'),
+          al.get('reason'))
+    check("move_blocker RAN on a board with faces in deficit", mb.get('ran'),
+          mb.get('reason'))
+    check("add_layers and move_blocker agree about the deficit",
+          (al.get('ran') and mb.get('ran')
+           and (al['measured']['deficit_lanes_now'] > 0)
+           == (mb['measured']['faces_in_deficit'] > 0)),
+          f"add_layers={al.get('measured', {}).get('deficit_lanes_now')} vs "
+          f"move_blocker={mb.get('measured', {}).get('faces_in_deficit')}")
+    # add_layers measures at the FAB FLOOR (both sides, so the comparison is
+    # about layers); the ledger above measured at the BOARD's clearance. Two
+    # different questions, and the option carries both so neither is mistaken
+    # for the other.
+    check("add_layers' board-clearance deficit == deficit_totals' lanes",
+          al.get('ran')
+          and al['measured']['deficit_lanes_at_board_clearance']
+          == tot['lanes'],
+          f"{al.get('measured', {}).get('deficit_lanes_at_board_clearance')} "
+          f"vs {tot['lanes']}")
+    check("and its fab-floor deficit is lower than at the board clearance",
+          al.get('ran')
+          and al['measured']['deficit_lanes_at_fab_floor']
+          <= al['measured']['deficit_lanes_at_board_clearance'],
+          str(al['measured']))
+    # `_now` must mean AT THIS BOARD'S CLEARANCE. It used to mean "at the fab
+    # floor", which reported tigard as 0 deficit lanes while move_blocker, in
+    # the same document, named 23 faces in deficit -- and the false-clean
+    # action string ("no face is short of lanes") was reachable on any board
+    # whose fab floor is finer than its netclass.
+    check("`_now` means the board's own clearance, not the fab floor",
+          al.get('ran')
+          and al['measured']['deficit_lanes_now']
+          == al['measured']['deficit_lanes_at_board_clearance'],
+          f"now={al.get('measured', {}).get('deficit_lanes_now')} "
+          f"board={al.get('measured', {}).get('deficit_lanes_at_board_clearance')} "
+          f"fab={al.get('measured', {}).get('deficit_lanes_at_fab_floor')}")
+    check("and on THIS board the two genuinely differ, so that check bites",
+          al.get('ran')
+          and al['measured']['deficit_lanes_at_fab_floor']
+          != al['measured']['deficit_lanes_at_board_clearance'],
+          "if they were equal the assertion above would pass either way")
+    if mb.get('ran') and mb['measured'].get('faces_in_deficit'):
+        worst = mb['measured']['worst'][0]
+        check("move_blocker converts lanes into MILLIMETRES of span",
+              worst['span_needed_mm'] > 0
+              and abs(worst['span_needed_mm']
+                      - worst['deficit_lanes'] * worst['lane_pitch_mm']) < 1e-6,
+              str(worst))
+        check("and names who to move", 'blockers' in worst, str(worst))
+    if al.get('ran'):
+        check("add_layers names what it does NOT model",
+              'not_modelled' in al, str(sorted(al)))
+        # BOTH sides must be measured at their own fab floor. Measuring
+        # "now" at the board's clearance and "more" at the n+2 floor
+        # reported 43 -> 12 lanes on a board whose two floors are IDENTICAL,
+        # crediting a clearance change to the layer count.
+        check("add_layers discloses whether the two floors even differ",
+              'floors_differ' in al['measured'], str(al['measured']))
+        if not al['measured']['floors_differ']:
+            # FAB FLOOR to FAB FLOOR. `_now` is the board's own clearance now,
+            # so comparing it to `_at_more` (a fab-floor number) compares two
+            # different questions and fails on a board where the floor is
+            # finer than the netclass -- which is most of them.
+            check("identical floors report NO lane gain from layers",
+                  al['measured']['deficit_lanes_at_fab_floor']
+                  == al['measured']['deficit_lanes_at_more']
+                  and 'buy NO extra lanes' in al['action'],
+                  f"{al['measured']['deficit_lanes_at_fab_floor']} -> "
+                  f"{al['measured']['deficit_lanes_at_more']}: {al['action']}")
+    rc = dopts['relax_clearance']
+    # NOT `if rc.get('ran'):`. That guard made this the only relax_clearance
+    # assertion in the suite AND made it dead code: `ran` was False on every
+    # board because of the worst_deficit getattr, so the option shipped a
+    # false "nothing to report" and no test could see it. Assert it RAN.
+    check("relax_clearance actually runs on a board with a lane deficit",
+          rc.get('ran'), f"ran={rc.get('ran')} reason={rc.get('reason')!r} -- "
+                         f"a deficit board must not report 'nothing to relax'")
+    check("and it measured a real base deficit, not 0",
+          (rc.get('measured') or {}).get('deficit_lanes', 0) > 0,
+          str(rc.get('measured')))
+    below = [r for r in (rc.get('measured') or {}).get('ladder', [])
+             if r.get('below_fab_floor')]
+    check("relax_clearance refuses to measure below the fab floor",
+          all(r['deficit_lanes'] is None for r in below),
+          "capacity nobody can etch is not capacity")
+else:
+    print("  NOTE glasgow_revC absent; the deficit half is untested")
+
+# --------------------------------------------------------------------------
+# the CLI reports and never refuses
+# --------------------------------------------------------------------------
+with tempfile.TemporaryDirectory() as wd:
+    out = os.path.join(wd, 'cap.json')
+    r = subprocess.run(
+        [sys.executable, '-X', 'utf8',
+         os.path.join('py_tools', 'check_capacity.py'), SMALL, '--json', out],
+        capture_output=True, text=True, encoding='utf-8', errors='replace',
+        cwd=REPO, timeout=900,
+        env=dict(os.environ, PYTHONIOENCODING='utf-8'))
+    check("the CLI exits 0 whatever the answer", r.returncode == 0,
+          f"rc={r.returncode} {r.stderr[-300:]}")
+    check("the CLI writes its JSON", os.path.isfile(out))
+    check("the CLI prints a JSON_SUMMARY",
+          any(l.startswith('JSON_SUMMARY:') for l in r.stdout.splitlines()))
+    check("the CLI names which options were NOT measured",
+          'not_measured' in r.stdout, r.stdout[-300:])
+    check("--only rejects an unknown option by name",
+          subprocess.run(
+              [sys.executable, '-X', 'utf8',
+               os.path.join('py_tools', 'check_capacity.py'), SMALL,
+               '--only', 'make_it_bigger'],
+              capture_output=True, text=True, cwd=REPO,
+              timeout=300).returncode == 2)
+
+# --------------------------------------------------------------------------
+# grow_board: per SIDE, and a proposal that actually holds the parts
+# --------------------------------------------------------------------------
+OC = os.path.join(REPO, 'kicad_files', 'orangecrab_ext_pll.kicad_pcb')
+if os.path.isfile(OC):
+    ocb = parse_kicad_pcb(OC)
+    g = grow_board(ocb, OC, clearance=0.2, board_edge_clearance=0.5)
+    m = g['measured']
+    sides = m['part_area_by_side_mm2']
+    check("grow_board splits part area by SIDE", len(sides) >= 2, str(sides))
+    check("and the fixture really is two-sided, or the split proves nothing",
+          min(sides.values()) > 0, str(sides))
+    check("utilisation is the BUSIEST side, not the sum",
+          abs(m['utilisation']
+              - m['busiest_side_area_mm2'] / m['usable_area_mm2']) < 1e-3,
+          f"util {m['utilisation']} vs busiest/usable "
+          f"{m['busiest_side_area_mm2'] / m['usable_area_mm2']:.4f}")
+    # The regression this fixes: a SHIPPING board told it does not fit, with a
+    # recommendation to shrink it. Summing both sides against one side's area
+    # is what produced that.
+    check("a shipping two-sided board is not told it fails to fit",
+          g['fits_by_area'] is True,
+          f"util {m['utilisation']}, sides {sides}, usable "
+          f"{m['usable_area_mm2']}")
+    check("and summing the sides WOULD have failed it (the bug was real)",
+          sum(sides.values()) > m['usable_area_mm2'],
+          f"sum {sum(sides.values()):.1f} vs usable {m['usable_area_mm2']}")
+
+# The proposed square must actually hold the parts. It was
+# sqrt(outline_area + need) where `need` is a USABLE-area shortfall, so the
+# proposal's own usable area was still short -- 55.1mm square for parts
+# needing 2971.0mm2 yields 2920.3.
+import re as _re
+
+# Shrink the OUTLINE only. Scaling the file's (xy ...) shrinks the footprints
+# with it, so utilisation is unchanged and the board is not too small at all --
+# measured, that fixture reported fits=True and this branch skipped itself.
+tp = parse_kicad_pcb(SMALL)
+bx0, by0, bx1, by1 = tp.board_info.board_bounds
+tp.board_info.board_bounds = (bx0, by0, bx0 + (bx1 - bx0) / 3.0,
+                              by0 + (by1 - by0) / 3.0)
+tg = grow_board(tp, SMALL, clearance=0.2, board_edge_clearance=0.5)
+# Audit the PUBLISHED number and the prose, and audit them ACROSS THE
+# CORPUS. Checking one board checked one rounding: `sqrt(busiest)+2*edge`
+# makes (side-2e)^2 == busiest exactly, so any downward rounding of the
+# `{side:.1f}` in the action string ships a proposal that is short.
+# Measured before the ceil: 8 of 22 corpus boards were short by 0.9-3.1
+# mm2, and this assertion passed only because splitflap's 55.1897 happens
+# to round UP. It also parsed the same rounded string it was auditing.
+boards = sorted(glob.glob(os.path.join(REPO, 'kicad_files', '*.kicad_pcb')))
+short, checked = [], 0
+for bd in boards:
+    try:
+        bp = parse_kicad_pcb(bd)
+        bb = bp.board_info.board_bounds
+        if not bb:
+            continue
+        bp.board_info.board_bounds = (bb[0], bb[1],
+                                      bb[0] + (bb[2] - bb[0]) / 3.0,
+                                      bb[1] + (bb[3] - bb[1]) / 3.0)
+        g = grow_board(bp, bd, clearance=0.2, board_edge_clearance=0.5)
+    except Exception:                            # noqa: BLE001
+        continue
+    if not g.get('ran') or g['fits_by_area']:
+        continue
+    checked += 1
+    side_mm = g['measured']['proposed_square_side_mm']
+    published = float(_re.search(r'about ([\d.]+) x',
+                                 g['action']).group(1))
+    need = g['measured']['busiest_side_area_mm2']
+    if (side_mm - 1.0) ** 2 < need - 1e-6 or published != side_mm:
+        short.append((os.path.basename(bd), side_mm, published,
+                      round((side_mm - 1.0) ** 2, 2), round(need, 2)))
+check("the proposed square holds the parts on EVERY corpus board",
+      not short, f"{len(short)} short of {checked}: {short[:4]}")
+check("and enough boards were exercised for that to mean something",
+      checked >= 8, f"only {checked} board(s) came back too-small")
+check("the proposal is a NUMBER, not only prose",
+      isinstance(tg['measured'].get('proposed_square_side_mm'), float),
+      str(tg['measured'].get('proposed_square_side_mm')))
+
+# A CONTAINER part -- a module-outline footprint hosting the design -- must not
+# be charged against the board. rp2350_fpga_eensy's U8 bbox is 1.15x the whole
+# board; charging it gave utilisation 1.91 and demanded 526.67mm2 more area on
+# a SHIPPING board, which is the same failure the per-side split cured.
+RP = os.path.join(REPO, 'kicad_files', 'rp2350_fpga_eensy_prePlane.kicad_pcb')
+if os.path.isfile(RP):
+    rp = parse_kicad_pcb(RP)
+    rg = grow_board(rp, RP, clearance=0.2, board_edge_clearance=0.5)
+    check("a container footprint is excluded and NAMED",
+          'U8' in rg['measured']['containers_excluded'],
+          str(rg['measured']['containers_excluded']))
+    check("and the shipping board is no longer told it does not fit",
+          rg['fits_by_area'] is True,
+          f"util {rg['measured']['utilisation']}")
+    check("the container is big enough that excluding it matters",
+          rg['measured']['container_area_mm2'] > 0.4 * rg['measured'][
+              'outline_area_mm2'],
+          str(rg['measured']['container_area_mm2']))
+
+else:
+    check("the rp2350 container fixture exists", False, RP)
+
+# ...but AREA ALONE must not classify. CONTAINER_RATIO is relative to the
+# board, so on a genuinely too-small board ordinary parts cross it -- and
+# excluding them would suppress the very parts causing the shortfall, making
+# this option understate the answer it exists to give. Measured on the shrunk
+# fixture before the hosting test: 12 plain connectors classed as containers
+# and the shortfall reported as 1262.39 instead of 2805.90.
+check("a big part on a SMALL board is not a container (it hosts nothing)",
+      tg['measured']['containers_excluded'] == [],
+      str(tg['measured']['containers_excluded']))
+check("so the too-small board reports the FULL shortfall",
+      tg['measured']['shortfall_mm2_at_least'] > 2000.0,
+      f"{tg['measured']['shortfall_mm2_at_least']} -- suppressing the big "
+      f"parts understates this to ~1262")
+
+# The options.py half of the pad-size and rotation fixes had NO coverage: an
+# audit reverted each in options.py alone and the suite stayed 43/43, while
+# esp_prog's utilisation moved 0.2475 -> 0.5156. Pin the numbers directly.
+EP = os.path.join(REPO, 'kicad_files', 'esp_prog.kicad_pcb')
+if os.path.isfile(EP):
+    ep = parse_kicad_pcb(EP)
+    eg = grow_board(ep, EP, clearance=0.25, board_edge_clearance=0.5)
+    check("grow_board uses pad SIZE, not pad centres",
+          eg['measured']['part_area_mm2'] > 200.0,
+          f"{eg['measured']['part_area_mm2']} -- the pad-centre form gives "
+          f"~106.7 on this board, understating by 51%")
+
+print(f"\n{passed} passed, {failed} failed")
+sys.exit(1 if failed else 0)


### PR DESCRIPTION
Two modules that were written during the recovery runs and never proposed. They ride together because the second reads the first.

## `placement/options.py` + `check_capacity.py`

The prohibition against resizing a board's outline is written in six places, and every one of them says the same sentence: the honest response to a board that is genuinely too small is to say so with the measured number and stop. The number was never computed. `out_of_board_area` is the nearest quantity and `floorplan.py` explicitly disqualifies it as a budget key, because a part sitting inside a cutout scores 0.0 area.

So a run that hit a genuinely too-small board could only stop, and the person reading it had to go and measure by hand what to change.

Five options, each reporting the house shape (`ran` / `reason` / `measured` / `expected` / `action`), where `ran: false` means NOT MEASURED and never "fine":

- `grow_board` sums per-side courtyard area against the usable outline, and proposes a square side
- `add_layers` re-runs the escape ledger at another layer count
- `move_blocker` converts a face deficit into the millimetres a named part must move
- `relax_clearance` and `smaller_footprint` do the same for their levers

It reports; it never refuses and never acts. That follows `lock_advisor`, which prints a paste-ready `--lock` and locks nothing, because a wrong auto-action fails invisibly. Nothing here writes Edge.Cuts or a stackup.

## `board_brief.py`

One artifact describing what a board looks like to something that has to place it. Seven sections: board, state, parts, mechanical, structure, measurements, and an opt-in `fit`.

The design rule is that it **assembles and does not compute**: every number comes from the function that already owns it, and a `sources` map names that function per section, so there is one source of truth per fact and the brief cannot drift away from the graders.

Its `measurements` section reads `placement/options.py`. Without it the section records the ImportError in `skipped` rather than reporting a number, which is the correct degradation but not a useful one, and it is why these are one PR rather than two.

`tests/stress/stage_unaided.py` (352 lines) is included because `test_board_brief`'s staged arm imports it. It stages a board for an unaided run, netlist in and nothing else, which `--kind pile` does not do: pile hands over every free part's original rotation, measured at 65 of 65 on splitflap_driver.

## Tests

185 assertions, run against this branch on current main: `test_capacity_options.py` 52 passed, `test_board_brief.py` 133 passed.

## Two things I would rather flag than quietly fix

**`CROWDED_UTILISATION = 0.55` fires on shipping boards.** Measured across the 22 in-repo boards with outlines: median utilisation 0.495, but 8 of 22 are at or above 0.55, and the three highest are human-designed and routed: orangecrab_ext_pll 0.946, ulx3s 0.913, glasgow_revC 0.821. On those the advisory prints "Consider a larger outline or a denser layer stack", which is the one action the toolchain forbids everywhere else.

I have not changed the constant in this PR. Picking a new one needs a corpus sweep deduplicated by distinct design, several in-repo entries being the same board at different chain stages, and doing that unreviewed inside the PR that introduces the tool seemed worse than saying so here. The band that would not fire on any clean-routing in-repo board is nearer 0.91 than 0.55.

**`usable_area_mm2` is a bounding box.** `(W - 2*edge) * (H - 2*edge)` from `board_bounds`, so cutouts, slots and L-shapes are invisible to the denominator and utilisation is optimistic on exactly the boards with mechanical constraints. Measured on watchy: bbox 1553.06 mm2, cutouts 118.97, true copper 1434.09, so the reported 0.4687 should be about 0.509. `board_brief` already computes the true shoelace area and deliberately refuses to reuse the name, which is the seam if you want it fixed.

Happy to do either or both in this PR if you would rather they land together.
