### PR TITLE
#696: narrow-pad-joint blocked DONE while printing nothing

### DIFF
--- a/py_router/check_weird.py
+++ b/py_router/check_weird.py
@@ -38,6 +38,14 @@ Categories:
                      Zone-connected copper counts as connected (the island
                      unions with everything in its zone outline). Size = the
                      island's total copper length.
+  narrow-pad-joint   a degree-1 terminal cap that overlaps a same-net pad only
+                     near a CORNER, so the two join through a copper web
+                     thinner than the board's min-track floor (issue #416).
+                     DRC-clean and connected, but the joint can etch open --
+                     KiCad's own `connection_width` class. Reported with NO
+                     size, so --tolerance never filters it (as for soft-joint:
+                     for a web, THINNER is worse, so a size filter would drop
+                     the severe findings and keep the marginal ones).
 
 This script NEVER modifies the board (read-only; nothing is written back).
 Net 0 (unconnected) copper is skipped -- "same-net" semantics do not apply.
@@ -65,7 +73,7 @@ from pcb_modification import _point_anchored, _prune_net_cycles, _pt_seg_dist
 
 CATEGORIES = ['dangling-end', 'soft-joint', 'redundant-cycle',
               'removable-segment', 'stacked-copper', 'unsupported-via',
-              'dangling-via', 'orphan-island']
+              'dangling-via', 'orphan-island', 'narrow-pad-joint']
 # Cost cap for the per-segment removable scan (spec: skip unless --thorough).
 MAX_SEGS_PER_NET = 500
 _CELL = 1.0  # spatial-grid cell (mm) fed to _point_anchored, as in the pruner
@@ -605,8 +613,14 @@ def _check_terminal_web(pcb_data, net_id, name, net_segs, net_pads, floor,
                 nlx, nly, elx, ely, target.size_x / 2.0, target.size_y / 2.0, r, e)
             if is_neck and terminal_web_neck_exact(
                     pcb_data, net_id, s.layer, ex, ey, floor) is not False:
+                # size=None: narrow pad joints bypass the --tolerance
+                # filter, for the same reason soft joints do (see the note in
+                # _check_soft_joints). Every magnitude available here is
+                # INVERTED against severity -- a THINNER web is a worse
+                # etch-open -- so a size filter would drop the severe findings
+                # and keep the marginal ones.
                 findings.append(_finding(
-                    'narrow_pad_joint', name, s.layer, ex, ey,
+                    'narrow-pad-joint', name, s.layer, ex, ey,
                     f"terminal cap joins pad {target.component_ref}."
                     f"{target.pad_number} through a copper web below the "
                     f"{floor:.3f}mm min-track floor (connection_width hazard)",
@@ -695,7 +709,13 @@ def print_report(findings: List[Dict], skipped_nets: List[Tuple[str, int]],
         by_cat[f['category']].append(f)
     if findings:
         print(f"\nFOUND {len(findings)} WEIRD THINGS:\n")
-        for cat in CATEGORIES:
+        # CATEGORIES is hand-maintained, so a check whose category was
+        # never registered would print NOTHING while still counting toward the
+        # headline and the exit code (#696: that shipped, and blocked DONE with
+        # nothing on screen to act on). Report the strays too, after the
+        # registered ones, so a future omission can only ever cost ordering.
+        unregistered = [c for c in sorted(by_cat) if c not in CATEGORIES]
+        for cat in CATEGORIES + unregistered:
             items = by_cat.get(cat, [])
             print(f"  {cat}: {len(items)}")
             limit = len(items) if (max_print is not None and max_print <= 0) \
@@ -722,7 +742,8 @@ def main():
     parser = argparse.ArgumentParser(
         description='Check PCB for weird copper hygiene issues '
                     '(dangles, soft joints, loops, removable/stacked copper, '
-                    'floating vias). Read-only: never modifies the board.')
+                    'floating vias, narrow pad joints). Read-only: never '
+                    'modifies the board.')
     parser.add_argument('pcb', help='Input PCB file')
     parser.add_argument('--nets', '-n', nargs='+', default=None,
                         help='Net name patterns to check (fnmatch wildcards '
@@ -734,7 +755,9 @@ def main():
                         help='Minimum finding size in mm (dangle/tail length, '
                              'gap, duplicated-copper length, via diameter); '
                              'smaller findings are dropped. Default 0.1; use '
-                             '0 to report everything.')
+                             '0 to report everything. soft-joint and '
+                             'narrow-pad-joint carry no size and are ALWAYS '
+                             'reported -- for those, smaller is worse.')
     parser.add_argument('--max-print', type=int, default=20,
                         help='Max findings printed per category '
                              '(<=0 prints all; default 20)')

--- a/tests/test_check_weird.py
+++ b/tests/test_check_weird.py
@@ -10,19 +10,31 @@ Synthetic Segment/Via/Pad cases:
   * a clean two-pad net            -> no findings at all
   * a half-segment tail past a mid-body via anchor -> dangling-end (tail)
   * a floating via                 -> unsupported-via flagged
+  * a corner-graze terminal cap    -> narrow-pad-joint flagged (#696/#416)
+  * the same cap landing in the pad body -> NOT flagged (clean)
+
+Plus two guards on the REPORTER, which is what #696 actually broke:
+  * every category any _finding(...) emits is registered in CATEGORIES
+  * print_report names a category that is NOT in CATEGORIES, and its headline
+    count equals the sum of the per-category counts
 
     python3 tests/test_check_weird.py
 """
+import ast
+import io
 import os
+import re
 import sys
 from collections import Counter
+from contextlib import redirect_stdout
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'py_router'))  # #522
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'py_tools'))  # #522
 
 from kicad_parser import Pad, Segment, Via, Zone, Net, BoardInfo, PCBData
-from check_weird import check_weird
+import check_weird as check_weird_mod
+from check_weird import check_weird, print_report, CATEGORIES
 
 NET = 1
 NAME = '/TEST'
@@ -33,6 +45,31 @@ def _pad(x, y, size=0.6, layers=('F.Cu',), drill=0.0, num='1', ref='U1'):
                local_x=0, local_y=0, size_x=size, size_y=size, shape='circle',
                layers=list(layers), net_id=NET, net_name=NAME,
                rotation=0.0, drill=drill)
+
+
+def _rect_pad(x, y, w, h, layers=('F.Cu',), num='1', ref='U1'):
+    # _check_terminal_web only considers rect/roundrect/oval pads -- a circle
+    # has no corner to graze, so _pad() above cannot exercise it.
+    return Pad(component_ref=ref, pad_number=num, global_x=x, global_y=y,
+               local_x=0, local_y=0, size_x=w, size_y=h, shape='rect',
+               layers=list(layers), net_id=NET, net_name=NAME,
+               rotation=0.0, drill=0.0)
+
+
+def _emitted_categories():
+    """Every category literal any `_finding(...)` call in check_weird.py emits,
+    read from the source. This is how #696 is caught at test time: the category
+    existed and the emission worked, and only the CATEGORIES entry was missing
+    -- so nothing that merely RUNS the checker could see the gap."""
+    tree = ast.parse(io.open(check_weird_mod.__file__, encoding='utf-8').read())
+    out = set()
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+                and node.func.id == '_finding' and node.args
+                and isinstance(node.args[0], ast.Constant)
+                and isinstance(node.args[0].value, str)):
+            out.add(node.args[0].value)
+    return out
 
 
 def _seg(x1, y1, x2, y2, layer='F.Cu', width=0.2):
@@ -159,10 +196,18 @@ def main():
     results.append(("coincident vias flagged as stacked-copper",
                     c['stacked-copper'] == 1))
 
-    # Default tolerance hides sub-0.1mm findings (the same 0.05mm soft joint).
-    f_tol, _ = check_weird(pcb)
-    results.append(("default 0.1mm tolerance hides the 0.05mm soft joint",
-                    len([x for x in f_tol if x['category'] == 'soft-joint']) == 0))
+    # Soft joints carry size=None deliberately (check_weird.py, the note in
+    # _check_soft_joints: a SMALLER gap is still fragile, so filtering by size
+    # would invert severity, and on <=0.1mm routing the whole category vanished
+    # at the default). So the default 0.1mm tolerance must NOT hide the 0.05mm
+    # joint of case 3. This assertion previously ran on the coincident-VIAS
+    # board above -- which has no soft joint at all -- so it passed vacuously
+    # while claiming the opposite of the shipped behavior.
+    soft_pcb = _pcb([_seg(0, 0, 5, 0), _seg(5.05, 0, 10, 0)],
+                    pads=[_pad(0, 0, num='1'), _pad(10, 0, num='2', ref='U2')])
+    f_tol, _ = check_weird(soft_pcb)
+    results.append(("0.05mm soft joint survives the default 0.1mm tolerance",
+                    len([x for x in f_tol if x['category'] == 'soft-joint']) == 1))
 
     # Orphan island: two joined segments + via, nowhere near any pad of the
     # net (pads at 0/10, island at 50) -> flagged with its total length; a
@@ -180,6 +225,57 @@ def main():
     f2, _ = check_weird(pcb2)
     results.append(("sub-tolerance orphan island hidden by default",
                     not [x for x in f2 if x['category'] == 'orphan-island']))
+
+    # 10. Narrow pad joint (#416): a 0.2mm track whose free cap overlaps a
+    #     1.0x1.0mm rect pad only at the CORNER. The floor is the board's
+    #     thinnest track (0.2), so erosion by 0.1 parts the cap from the pad:
+    #     a sub-floor web. Flagged, and NOT dropped by the default 0.1mm
+    #     tolerance (size=None is deliberate -- for a web, thinner is worse).
+    pads = [_rect_pad(0, 0, 1.0, 1.0, num='1'),
+            _rect_pad(10, 0, 1.0, 1.0, num='2', ref='U2')]
+    pcb = _pcb([_seg(0.55, 0.55, 2.0, 2.0)], pads=pads)
+    f, _ = check_weird(pcb)
+    necks = [x for x in f if x['category'] == 'narrow-pad-joint']
+    results.append(("corner-graze terminal cap flagged as narrow-pad-joint",
+                    len(necks) == 1))
+    results.append(("narrow-pad-joint reported at the cap (0.55, 0.55)",
+                    len(necks) == 1 and abs(necks[0]['x'] - 0.55) < 1e-6
+                    and abs(necks[0]['y'] - 0.55) < 1e-6))
+    results.append(("narrow-pad-joint survives the default 0.1mm tolerance",
+                    len(necks) == 1 and necks[0]['size'] is None))
+    #     Negative control, same pad and same track: a cap landing in the pad
+    #     BODY joins through full-width copper and is NOT flagged. Without it
+    #     the case above would also pass on a check that flagged everything.
+    pcb = _pcb([_seg(0.0, 0.0, 2.0, 2.0)], pads=pads)
+    f, _ = check_weird(pcb)
+    results.append(("cap landing in the pad body NOT flagged",
+                    not [x for x in f if x['category'] == 'narrow-pad-joint']))
+
+    # 11. The reporter, which is what #696 actually broke: a finding whose
+    #     category is missing from CATEGORIES counted toward the headline and
+    #     the exit code but printed nothing, so the board was blocked by a
+    #     defect that was never named. Both halves are pinned here.
+    emitted = _emitted_categories()
+    results.append(("the source emits categories at all (guard not vacuous)",
+                    len(emitted) >= 8))
+    results.append(("every emitted category is registered in CATEGORIES",
+                    bool(emitted) and emitted <= set(CATEGORIES)))
+
+    stray = [{'category': 'brand-new-category', 'net': NAME, 'layer': 'F.Cu',
+              'x': 1.0, 'y': 2.0, 'detail': 'a category nobody registered',
+              'size': None}]
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        print_report(stray, [])
+    out = buf.getvalue()
+    results.append(("print_report names a category missing from CATEGORIES",
+                    'brand-new-category: 1' in out
+                    and 'a category nobody registered' in out))
+    counts = [int(m) for m in re.findall('^  [^ ]+: ([0-9]+)$', out, re.M)]
+    head = re.search('FOUND ([0-9]+) WEIRD THINGS', out)
+    results.append(("the headline count equals the sum of printed counts",
+                    head is not None and bool(counts)
+                    and int(head.group(1)) == sum(counts) == 1))
 
     passed = 0
     for name, ok in results:

--- a/tests/test_check_weird.py
+++ b/tests/test_check_weird.py
@@ -14,7 +14,8 @@ Synthetic Segment/Via/Pad cases:
   * the same cap landing in the pad body -> NOT flagged (clean)
 
 Plus two guards on the REPORTER, which is what #696 actually broke:
-  * every category any _finding(...) emits is registered in CATEGORIES
+  * CATEGORIES is exactly the set of categories _finding(...) emits
+    (both directions: an unregistered emission AND a stale registration)
   * print_report names a category that is NOT in CATEGORIES, and its headline
     count equals the sum of the per-category counts
 
@@ -258,8 +259,12 @@ def main():
     emitted = _emitted_categories()
     results.append(("the source emits categories at all (guard not vacuous)",
                     len(emitted) >= 8))
-    results.append(("every emitted category is registered in CATEGORIES",
-                    bool(emitted) and emitted <= set(CATEGORIES)))
+    # Set EQUALITY, not containment, so the guard holds in both directions.
+    # A registered category nobody emits is the mirror defect: it prints a
+    # permanent `: 0` line that no board can ever produce, and it is exactly
+    # what a rename like this one leaves behind when only one side is edited.
+    results.append(("CATEGORIES is exactly the set of emitted categories",
+                    emitted == set(CATEGORIES)))
 
     stray = [{'category': 'brand-new-category', 'net': NAME, 'layer': 'F.Cu',
               'x': 1.0, 'y': 2.0, 'detail': 'a category nobody registered',


### PR DESCRIPTION
Closes #696

## The defect

`_check_terminal_web` emits a narrow pad joint (#416 — a terminal cap joining a same-net
pad only through a copper web below the min-track floor), but the category was never
added to `CATEGORIES`, and `print_report` iterates `CATEGORIES`. A board whose only
finding was one of these printed:

```
FOUND 1 WEIRD THINGS:

  dangling-end: 0
  soft-joint: 0
  ... all eight categories: 0
```

and exited 1. `check_complete.py:366-372` keeps only that exit code and discards the
report text, so `:414-415` reported `weird_copper: not clean (exit 1)` → `INCOMPLETE`,
DONE blocked, nothing on screen naming what to fix. Measured in run 24
(`wk/run24/esp_prog/logs/R4-complete.log:5,7`), where it forced a reroute lap.

## The fix

**Register the category, kebab-cased** to match the other eight. The string occurred
exactly **once** repo-wide (the emission site) — no test, doc, skill, or fixture keys on
it — so the rename costs nothing and removes the odd one out.

**Stop the class, not the instance.** `CATEGORIES` is hand-maintained, so *any* future
category left out of it prints nothing while still counting toward the headline and the
exit code. `print_report` now also prints categories present in the findings but absent
from the list, so a future omission can only ever cost ordering.

Report on a real board, headline now equal to the sum of the parts (92 = 1 + 90 + 1):

```
$ python3 py_router/check_weird.py kicad_files/interf_u_routed.kicad_pcb --max-print 1
FOUND 92 WEIRD THINGS:

  dangling-end: 1
    net /PE+ (F.Cu) at (175.300, 92.500): free end, dangling segment 0.273mm ...
  ...
  orphan-island: 0
  narrow-pad-joint: 0
```

## The `size=None` question, declined with precedent

The issue asks whether the finding should carry a `size` so `--tolerance` can filter it.
It should not — and `_check_soft_joints` already made this exact call, for this exact
reason:

> `size=None`: soft joints bypass the `--tolerance` filter. Filtering by GAP inverted the
> severity metric (small gap = still fragile) and on <=0.1mm-width routing every
> representable soft joint has gap < 0.1 — the whole category silently vanished at the
> default tolerance.

Same inversion here: a **thinner** web is a **worse** etch-open. The one naturally
increasing quantity available (the erosion shortfall inside `terminal_pad_web_shortfall`)
would, at the default `--tolerance 0.1`, hide most real necks. So `size=None` stays, with
the reasoning now recorded at the emission site, in the module docstring's category list,
and in `--tolerance`'s help.

**Scope note:** this makes the blocker *nameable*. It does not change whether hygiene
classes should block at all — that is the separate severity-tier / `--json` work, and the
exit code is untouched.

## A second finding, in the same file

`tests/test_check_weird.py`'s assertion *"default 0.1mm tolerance hides the 0.05mm soft
joint"* ran against the **coincident-vias** board (the `pcb` variable was rebound in the
case above it), which has no soft joint at all. It passed vacuously — while asserting the
**opposite** of the shipped behavior. Measured on the real soft-joint board:

```
tolerance=0:   soft-joint count = 1   sizes=[None]
tolerance=0.1: soft-joint count = 1   sizes=[None]
```

It is now pointed at the soft-joint board and asserts what the code does. Coverage of the
tolerance filter itself is retained by the existing sub-tolerance orphan-island case.

## Tests

| case | asserts |
|---|---|
| corner-graze terminal cap | a 0.2 mm track capping on a 1.0 × 1.0 mm rect pad corner is flagged, at the cap, with `size is None` |
| **negative control** | the *same* pad and track, cap landing in the pad **body**, is NOT flagged |
| AST guard | every category literal any `_finding(...)` call emits is registered in `CATEGORIES` |
| reporter guard | `print_report` names a category missing from `CATEGORIES`, and the headline count equals the sum of the per-category counts |

The AST guard is the one that catches this defect class at test time: the category existed
and the emission worked — only the list entry was missing, so nothing that merely *runs*
the checker could see the gap.

**Each guard was mutation-tested** — reverting one production change at a time must fail
exactly the guard written for it, and does:

| mutation | result |
|---|---|
| revert the `CATEGORIES` entry | 27/28 — `every emitted category is registered in CATEGORIES` FAILS |
| revert the emission string to `narrow_pad_joint` | 24/28 — the three narrow-pad-joint cases + the AST guard FAIL |
| revert the `print_report` change | 26/28 — both reporter assertions FAIL |
| none | 28/28 |

## Suite

`tests/test_check_weird.py` 28/28.

The full suite needed the local Rust router brought in line first: the binary on disk was
0.20.0 while `upstream/main`'s `Cargo.toml` declares 0.21.1, so
`startup_checks.check_rust_library()` raised on every test that touches the routing engine
and masked the real state. After `python3 build_router.py` (release v0.21.1 is published,
so no `--from-source` needed):

| run | result |
|---|---|
| `run_all.py --fast` (282 unit tests) | **282 passed, 0 failed** |
| `run_all.py` (all 403) | **397 passed, 4 failed, 2 timed out, 0 skipped** in 2916 s |

The 4 failures -- `test_run14_dash_net_hint`, `test_run4_custom_pad_circle`,
`test_run5_exchange`, `test_run6_backlog` -- are **pre-existing**: each fails identically
with this PR's two files reverted to `upstream/main` in the same tree. The 2 timeouts
(`test_459_group_routing` at the runner's 600 s cap, `test_obstacle_map_balance` at its own
declared 1200 s budget) are `-j 4` load artifacts; the runner itself prints that a timeout
is not evidence of a broken test, and `run_all.py`'s own comment records
`test_obstacle_map_balance` passing alone in 681 s.

Nothing in this PR touches the router or any of those paths.

No GUI parity work: `grep check_weird kicad_routing_plugin/` is empty — `check_weird` is a
standalone read-only checker with no plugin call site.

