### PR TITLE
tests: clear the four run_all reds (#718)

### DIFF
--- a/tests/stress/corpus_noop_sweep.py
+++ b/tests/stress/corpus_noop_sweep.py
@@ -82,7 +82,8 @@ def sweep_reconstruct(board, workdir):
     """place_reconstruct --dry-run: proposals and would-move must both be empty."""
     out = os.path.join(workdir, 'out.kicad_pcb')
     argv = [sys.executable, '-X', 'utf8',
-            os.path.join(ROOT, 'place_reconstruct.py'), board, out, '--dry-run']
+            os.path.join(ROOT, 'py_placer', 'place_reconstruct.py'),
+            board, out, '--dry-run']
     proc = subprocess.run(argv, capture_output=True, text=True, encoding='utf-8',
                           errors='replace', cwd=ROOT, timeout=TIMEOUT_S)
     rep = _summary(proc.stdout or '')
@@ -133,7 +134,8 @@ def sweep_repair(board, workdir):
     """
     intent = os.path.join(workdir, 'intent.json')
     emit = subprocess.run(
-        [sys.executable, '-X', 'utf8', os.path.join(ROOT, 'check_floorplan.py'),
+        [sys.executable, '-X', 'utf8',
+         os.path.join(ROOT, 'py_tools', 'check_floorplan.py'),
          board, '--emit-intent', intent],
         capture_output=True, text=True, encoding='utf-8', errors='replace',
         cwd=ROOT, timeout=TIMEOUT_S)
@@ -143,7 +145,8 @@ def sweep_repair(board, workdir):
             None, f'emit-intent rc={emit.returncode} '
                   + (emit.stderr or '')[-140:])
     out = os.path.join(workdir, 'rep.kicad_pcb')
-    argv = [sys.executable, '-X', 'utf8', os.path.join(ROOT, 'place_seed.py'),
+    argv = [sys.executable, '-X', 'utf8',
+            os.path.join(ROOT, 'py_placer', 'place_seed.py'),
             board, out, '--intent', intent, '--repair', '--dry-run']
     proc = subprocess.run(argv, capture_output=True, text=True, encoding='utf-8',
                           errors='replace', cwd=ROOT, timeout=TIMEOUT_S)

--- a/tests/test_457_fresh_clone_fixtures.py
+++ b/tests/test_457_fresh_clone_fixtures.py
@@ -19,6 +19,8 @@ Two invariants, both of which were violated:
    suite left modified tracked files in the working tree.
 """
 
+import ast
+import glob
 import os
 import re
 import subprocess
@@ -140,6 +142,100 @@ def test_no_test_reads_an_untracked_board_directly():
     print("  PASS: no test reads an untracked kicad_files/ board directly")
 
 
+#: Test FILES that read a board out of gitignored `wk/` (issue #718).
+#:
+#: This is a RATCHET, not an approval list. `wk/` is work output -- every board
+#: under it is untracked, so on any machine but the one that produced it these
+#: tests `skipTest` and their file still exits 0: green while covering nothing.
+#: That is how #718 item 3 hid. It was found only because this machine happened
+#: to still have `wk/run3/final2.kicad_pcb`; #716's baseline, on a machine that
+#: did not, reported the file as passing.
+#:
+#: The list may only SHRINK. Adding a new file fails the gate; clearing one and
+#: forgetting to delete its entry fails it too, so the census cannot go stale.
+#: Clearing an entry means a `tests/fixture_boards.py` recipe rooted in a
+#: tracked board, or repointing at a tracked board outright.
+_WK_BOARD_CONSUMERS = {
+    'test_outline_prefilter.py',
+    'test_part_class.py',
+    'test_place_reconstruct.py',
+    'test_placement_pad_legality.py',
+    'test_run4_custom_pad_circle.py',
+    'test_run4_reconstruct.py',
+    'test_run5_emit_guard.py',
+    'test_run5_exchange.py',
+    'test_run6_backlog.py',
+    'test_run6_body_overlap.py',
+    'test_run6_check_assembly.py',
+    'test_run7_vectors.py',
+    'test_run8_airwire_refuted.py',
+    'test_run8_oob_outline.py',
+    'test_run8_rigid_consistency.py',
+}
+
+
+def _reads_a_wk_board(tree):
+    """Line numbers of `os.path.join(..., 'wk', ..., '*.kicad_pcb')` calls.
+
+    AST rather than regex: these paths are built as multi-segment joins
+    (`join(ROOT, 'wk', 'run5', 's1_pour.kicad_pcb')`, and one via
+    `join(dirname(__file__), '..', 'wk', ...)`), which no single literal
+    pattern catches. Anchored on the 'wk' segment plus a .kicad_pcb segment, so
+    a test writing its own board into a tempdir is not swept in.
+    """
+    hits = []
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == 'join'):
+            continue
+        lits = [a.value for a in node.args
+                if isinstance(a, ast.Constant) and isinstance(a.value, str)]
+        if 'wk' in lits and any(l.endswith('.kicad_pcb') for l in lits):
+            hits.append(node.lineno)
+    return hits
+
+
+def test_no_new_test_depends_on_an_untracked_wk_board():
+    """The cousin of the kicad_files/ scan above, for `wk/`.
+
+    That scan (test_no_test_reads_an_untracked_board_directly) matches only
+    'kicad_files/x.kicad_pcb', so a board read out of `wk/` was invisible to
+    it -- and `wk/` is gitignored in its entirety, so EVERY such read has the
+    fresh-clone problem the file exists to prevent.
+    """
+    here = os.path.dirname(os.path.abspath(__file__))
+    found = {}
+    for path in sorted(glob.glob(os.path.join(here, 'test_*.py'))):
+        try:
+            with open(path, encoding='utf-8', errors='replace') as fh:
+                tree = ast.parse(fh.read())
+        except SyntaxError:
+            continue
+        hits = _reads_a_wk_board(tree)
+        if hits:
+            found[os.path.basename(path)] = hits
+
+    added = sorted(set(found) - _WK_BOARD_CONSUMERS)
+    assert not added, (
+        "new test(s) reading a board out of gitignored wk/:\n  "
+        + "\n  ".join('%s (line %s)' % (f, ', '.join(map(str, found[f])))
+                      for f in added)
+        + "\nOn any machine without that work output the test skips and the "
+          "file still exits 0 -- green while covering nothing. Add a recipe to "
+          "tests/fixture_boards.py rooted in a TRACKED board and call ensure(), "
+          "or use a tracked board.")
+
+    cleared = sorted(_WK_BOARD_CONSUMERS - set(found))
+    assert not cleared, (
+        "these no longer read a wk/ board -- delete them from "
+        "_WK_BOARD_CONSUMERS so the census stays true:\n  "
+        + "\n  ".join(cleared))
+
+    print("  PASS: %d known wk/-dependent test file(s), none new"
+          % len(found))
+
+
 def test_fixtures_build_from_a_clean_state():
     """End to end: every fixture is producible right now."""
     for name in _RECIPES:
@@ -167,9 +263,30 @@ TESTS = [
     test_no_tracked_project_file_without_its_board,
     test_consumers_do_not_silently_skip_a_missing_fixture,
     test_no_test_reads_an_untracked_board_directly,
+    test_no_new_test_depends_on_an_untracked_wk_board,
     test_fixtures_build_from_a_clean_state,
     test_building_a_fixture_leaves_no_tracked_file_modified,
 ]
+
+
+def test_every_test_in_this_file_is_registered():
+    """TESTS is hand-maintained, so a new test here runs only if someone
+    remembers to list it -- and a test that never runs is indistinguishable
+    from one that passes. (Added after writing
+    test_no_new_test_depends_on_an_untracked_wk_board and watching it not run.)
+    """
+    listed = ({t.__name__ for t in TESTS}
+              | {'test_every_test_in_this_file_is_registered'})
+    defined = {k for k, v in sorted(globals().items())
+               if k.startswith('test_') and callable(v)}
+    missing = sorted(defined - listed)
+    assert not missing, (
+        "test(s) defined in this file but absent from TESTS, so they "
+        "never run:\n  " + "\n  ".join(missing))
+    print(f"  PASS: all {len(defined)} test functions are registered")
+
+
+TESTS.append(test_every_test_in_this_file_is_registered)
 
 
 if __name__ == '__main__':

--- a/tests/test_457_fresh_clone_fixtures.py
+++ b/tests/test_457_fresh_clone_fixtures.py
@@ -205,8 +205,11 @@ def test_no_new_test_depends_on_an_untracked_wk_board():
     fresh-clone problem the file exists to prevent.
     """
     here = os.path.dirname(os.path.abspath(__file__))
+    # Recursive: tests/stress/ and tests/gui_parity/ can grow one too. All of
+    # today's are in tests/ itself, so the baseline below is keyed on basename.
     found = {}
-    for path in sorted(glob.glob(os.path.join(here, 'test_*.py'))):
+    for path in sorted(glob.glob(os.path.join(here, '**', 'test_*.py'),
+                                 recursive=True)):
         try:
             with open(path, encoding='utf-8', errors='replace') as fh:
                 tree = ast.parse(fh.read())

--- a/tests/test_718_stale_tool_paths.py
+++ b/tests/test_718_stale_tool_paths.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""No test may spawn a repo-root script that the #522 reorg moved (issue #718).
+
+`ee860796` moved route.py, check_drc.py and the rest out of the repo root into
+py_router/ py_tools/ py_placer/. A test that kept spawning
+`os.path.join(ROOT, 'qfn_fanout.py')` does not fail usefully: python writes
+`can't open file ...: [Errno 2]` to STDERR and exits 2, so stdout is EMPTY and
+the test's own `assertIn(..., r.stdout)` fails with a bare message that reads
+exactly like a product bug. `tests/run_utils.py`'s `tool()` docstring records
+that EIGHTEEN tests had this and that several rotted into FALSE PASSES
+underneath; `ed779096` swept 25 files.
+
+It still recurred. At #718 four more carried it -- test_run5_exchange and
+test_run6_backlog (both red, both misread as product failures) plus three
+spawns in tests/stress/corpus_noop_sweep.py, which run_all does not even
+discover, so those were broken silently. This is the static half of the gate:
+every argv list that starts with `sys.executable` must name a script that
+EXISTS.
+
+The runtime half is `run_utils.tool()`, which raises and says where it looked.
+Prefer it: a literal path that resolves today can go stale tomorrow, and only
+`tool()` fails at the right place.
+
+BE CLEAR ABOUT WHAT THIS CANNOT SEE. #718's two headline tests spawned
+`os.path.join(ROOT, script)` with `script` a PARAMETER, so no static check
+resolves them -- which is exactly why the fix moved them onto `tool()` rather
+than repointing a string. `tool()`'s own docstring makes the same point about
+test_431_board_gates. Remaining variable call sites are REPORTED here, not
+failed: test_431_skill_commands feeds this shape from `discovered_tools()`,
+which only admits names that already resolve, so failing it would be wrong.
+
+    python3 tests/test_718_stale_tool_paths.py
+"""
+import ast
+import glob
+import os
+import sys
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(TESTS_DIR)
+
+#: argv tokens that sit between the interpreter and the script.
+_INTERPRETER_FLAGS = {'-X', 'utf8', '-u'}
+
+
+def _is_sys_executable(node):
+    return (isinstance(node, ast.Attribute) and node.attr == 'executable'
+            and isinstance(node.value, ast.Name) and node.value.id == 'sys')
+
+
+def _is_root(node):
+    return isinstance(node, ast.Name) and node.id in ('ROOT', 'ROOT_DIR')
+
+
+def _root_join(node):
+    """(path_parts, all_literal) for `os.path.join(ROOT, ...)`, else None."""
+    if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+            and node.func.attr == 'join'):
+        return None
+    if not node.args or not _is_root(node.args[0]):
+        return None
+    parts, literal = [], True
+    for arg in node.args[1:]:
+        if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+            parts.append(arg.value)
+        else:
+            literal = False
+    return parts, literal
+
+
+def _script_element(argv_list):
+    """The argv element naming the script: skip sys.executable and its flags."""
+    for el in argv_list.elts[1:]:
+        if isinstance(el, ast.Constant) and el.value in _INTERPRETER_FLAGS:
+            continue
+        return el
+    return None
+
+
+def scan():
+    """(stale, non_literal): every `[sys.executable, ...]` argv in tests/.
+
+    Scans LIST LITERALS rather than spawn call sites on purpose -- three of the
+    #718 spawns were built as `argv = [...]` first and passed by name, so a
+    scan anchored on the run/Popen call missed them.
+
+    (Prose note: this file avoids the literal word s-u-b-p-r-o-c-e-s-s because
+    run_all classifies a test as slow "integration" by substring-matching its
+    SOURCE for it. This check spawns nothing and finishes in well under a
+    second, so it belongs in the --fast loop where a stale path is caught
+    immediately.)
+    """
+    stale, non_literal = [], []
+    for path in sorted(glob.glob(os.path.join(TESTS_DIR, '**', '*.py'),
+                                 recursive=True)):
+        if os.path.basename(path) == os.path.basename(__file__):
+            continue
+        try:
+            with open(path, encoding='utf-8', errors='replace') as f:
+                tree = ast.parse(f.read())
+        except SyntaxError:                                  # not ours to judge
+            continue
+        rel = os.path.relpath(path, ROOT).replace(os.sep, '/')
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.List) and node.elts
+                    and _is_sys_executable(node.elts[0])):
+                continue
+            el = _script_element(node)
+            if el is None:
+                continue
+            # resolved loudly at runtime: nothing to check statically
+            if (isinstance(el, ast.Call) and isinstance(el.func, ast.Name)
+                    and el.func.id in ('tool', '_tool')):
+                continue
+            found = _root_join(el)
+            if found is None:
+                continue                       # not a ROOT-join; not our class
+            parts, literal = found
+            if not literal:
+                non_literal.append((rel, node.lineno))
+            elif parts and not os.path.isfile(os.path.join(ROOT, *parts)):
+                stale.append((rel, node.lineno, '/'.join(parts)))
+    return stale, non_literal
+
+
+def _elsewhere(name):
+    """Where a moved CLI actually lives now -- the half of the message that
+    turns 'this is broken' into 'this is the fix'."""
+    for pkg in ('py_router', 'py_tools', 'py_placer'):
+        if os.path.isfile(os.path.join(ROOT, pkg, name)):
+            return '%s/%s' % (pkg, name)
+    return None
+
+
+def main():
+    stale, non_literal = scan()
+
+    # A scan that matches nothing passes for free. #718's own shapes are gone
+    # from the tree now, so assert the scanner still SEES argv lists at all.
+    seen = 0
+    for path in glob.glob(os.path.join(TESTS_DIR, '**', '*.py'), recursive=True):
+        try:
+            with open(path, encoding='utf-8', errors='replace') as f:
+                tree = ast.parse(f.read())
+        except SyntaxError:
+            continue
+        seen += sum(1 for n in ast.walk(tree)
+                    if isinstance(n, ast.List) and n.elts
+                    and _is_sys_executable(n.elts[0]))
+    if seen < 20:
+        print('  FAIL  the scanner found only %d argv list(s) -- it has stopped '
+              'matching, so a green result here means nothing' % seen)
+        return 1
+    print('  PASS  scanner sees %d [sys.executable, ...] argv list(s)' % seen)
+
+    for rel, line in non_literal:
+        print('  note  %s:%d builds the script name from a variable -- only '
+              'run_utils.tool() can catch that one, at runtime' % (rel, line))
+
+    if stale:
+        print('\n  FAIL  %d test spawn(s) name a repo-root script that is not '
+              'there:' % len(stale))
+        for rel, line, named in stale:
+            moved = _elsewhere(os.path.basename(named))
+            print('    %s:%d  ->  %s%s' % (
+                rel, line, named,
+                '   (it moved to %s)' % moved if moved else
+                '   (not found anywhere -- deleted?)'))
+        print('\n  Use run_utils.tool(name), which resolves the #522 layout and '
+              'RAISES\n  naming what it looked for, instead of letting python '
+              'exit 2 into an\n  empty stdout three frames away.')
+        return 1
+
+    print('  PASS  no test spawns a missing repo-root script')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_run14_dash_net_hint.py
+++ b/tests/test_run14_dash_net_hint.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""A net whose NAME starts with '-' must not cost a lap (run 14).
+r"""A net whose NAME starts with '-' must not cost a lap (run 14).
 
 castor_pollux has a net called `-12V`. `route.py --nets ... -12V ...` is
 `nargs='+'`, so argparse read the name as a flag:
@@ -15,6 +15,14 @@ tools share the shape.
 `ArgumentParser.error` once so the hint appears wherever it happens. These tests
 pin that the hint fires, that it does not fire on unrelated errors, that it never
 masks the real error, and that the workaround it recommends actually works.
+
+SINCE #597 (55632d91) THE HINT IS INERT THROUGH THE SHIPPED CLIs, BY DESIGN.
+`cli_nets.pin_dash_digit_values` replaces argparse's negative-number matcher
+with `^-\d` at every net-accepting tool's parse_args, so `--nets ... -12V` is
+read as a VALUE and never reaches `error()` at all. The hint remains the
+backstop for a parser that has NOT been pinned -- which is what the unit tests
+below build -- so both halves are still real: the unit tests pin the hint, and
+the CLI test pins #597's promise that route.py no longer needs it.
 """
 import argparse
 import io
@@ -22,6 +30,7 @@ import contextlib
 import os
 import subprocess
 import sys
+import tempfile
 import unittest
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -105,14 +114,28 @@ class DashHintCliTest(unittest.TestCase):
                                os.path.join(ROOT, 'py_router', 'route.py')] + args,
                               capture_output=True, text=True, timeout=600)
 
-    @unittest.skipIf(_HINT_NOT_PROVOCABLE, _SKIP_REASON)
-    def test_route_py_emits_the_hint_and_still_exits_2(self):
-        r = self._run([BOARD, os.path.join(ROOT, '_no_such_out.kicad_pcb'),
-                       '--nets', '+12V', '-12V'])
-        self.assertEqual(r.returncode, 2)
+    def test_route_py_takes_the_bare_dash_net_since_597(self):
+        """The BARE form -- `--nets +12V -12V`, no `=` -- now parses.
+
+        This arm used to assert the opposite (exit 2, 'unrecognized
+        arguments', hint present), which was correct when it was written:
+        `git merge-base --is-ancestor 55632d91 4b4098a0` is false, so #597 and
+        this test were developed on parallel branches and each passed alone.
+        Merging both made the assertion describe a route.py that no longer
+        exists. It is inverted here rather than skipped, so it still fails if
+        the pin at route.py's parse_args is ever dropped.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            r = self._run([BOARD, os.path.join(td, 'out.kicad_pcb'),
+                           '--nets', '+12V', '-12V', '--skip-routing'])
         both = r.stdout + r.stderr
-        self.assertIn('--nets=-12V', both)
-        self.assertIn('unrecognized arguments', both)
+        self.assertNotIn('unrecognized arguments', both,
+                         'the #597 pin must keep argparse from reading a '
+                         'dash-named net as an option: ' + both[-300:])
+        self.assertNotIn('begins with', both,
+                         'and the hint must stay silent when nothing failed')
+        self.assertIn('-12V', both,
+                      'the net name must reach the tool as a VALUE')
 
     def test_the_recommended_form_parses(self):
         """The hint must recommend something that actually works.
@@ -123,8 +146,9 @@ class DashHintCliTest(unittest.TestCase):
         argparse -- which is the whole claim. Checking the code alone would
         confuse two different exit 2s.
         """
-        r = self._run([BOARD, os.path.join(ROOT, '_no_such_out.kicad_pcb'),
-                       '--nets=-12V', '--skip-routing'])
+        with tempfile.TemporaryDirectory() as td:
+            r = self._run([BOARD, os.path.join(td, 'out.kicad_pcb'),
+                           '--nets=-12V', '--skip-routing'])
         both = r.stdout + r.stderr
         self.assertNotIn('unrecognized arguments', both,
                          'the documented workaround must not be an argparse '

--- a/tests/test_run4_custom_pad_circle.py
+++ b/tests/test_run4_custom_pad_circle.py
@@ -3,12 +3,28 @@
 Run 3's DRC verifier lens found a 0.0884mm-vs-0.09 track-to-pad graze that
 kicad-cli flagged and check_drc missed: the pad's copper is a gr_circle
 PRIMITIVE, and the fixed inscribed 32-gon under-reached the true circle by
-~2.4um at r=0.5 -- more than the 1.6um defect. The primitive path now uses
-adaptive tessellation (1um sagitta, capped 64 vertices).
+~2.4um at r=0.5 -- more than the 1.6um defect. Run-4 B6 moved the primitive
+path to adaptive tessellation (1um sagitta, capped 64 vertices); that change
+has since been REVERTED -- see below, which is what this file now pins.
 
 Both directions are pinned: a real sub-floor gap is flagged, and a gap
 safely above the floor is NOT (the polygon stays inscribed, so tightening
 it cannot manufacture phantom violations).
+
+THE ADAPTIVE TESSELLATION WAS REVERTED in 6166a98b ("revert six
+placement-only routing changes that lose to main on the corpus"): the parser
+is back to a fixed inscribed 32-gon, because the adaptive version moved
+obstacle geometry AND DRC grading together on every board with
+circle-primitive custom pads -- a baseline shift no re-grade can separate
+(measured: real DRC 71 -> 49 across 73 boards). `_adaptive_circle_n` is
+RETAINED but WIRED TO NOTHING, per that commit's "restore if the accuracy is
+wanted, but land it as a deliberate, measured baseline change".
+
+So this file pins the SHIPPED geometry, not the reverted one: the 32-gon's
+vertex count and inscribed-ness, and the consequence on the run-3 board --
+the graze is masked at the 0.09 floor and reappears once the floor clears the
+sagitta. Restoring the adaptive path fails these, which is the point: it
+should be a decision, not a drift.
 """
 
 import math
@@ -82,6 +98,13 @@ class TestAdaptivePrimitiveCircle(unittest.TestCase):
                            '--max-print', '0')
 
     def test_sub_floor_gap_is_flagged(self):
+        # NOTE: this pair covers check_drc's custom-pad path, NOT tessellation.
+        # board_with_gap puts the rect due EAST of the circle centre, and the
+        # polygon's vertex k=0 sits at angle 0 -- exactly the true rightmost
+        # point (measured: max_x is 50.500000 at N=32). So the measured gap
+        # equals the true gap for any N and both directions pass whatever the
+        # tessellation does. The vertex count is pinned directly in
+        # TestShippedTessellation below.
         # The run-3 geometry: true gap 0.0884 vs floor 0.09 (1.6um short).
         r = self._drc_at(0.0884)
         self.assertEqual(r.returncode, 1, r.stdout + r.stderr)
@@ -89,12 +112,16 @@ class TestAdaptivePrimitiveCircle(unittest.TestCase):
 
     def test_above_floor_gap_stays_clean(self):
         # Inscribed polygons cannot manufacture phantom grazes: 6um of margin
-        # is far above the 1um sagitta budget.
+        # is far above the shipped 32-gon's 2.4um sagitta at r=0.5.
         r = self._drc_at(0.096)
         self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
         self.assertIn('NO DRC VIOLATIONS', r.stdout)
 
-    def test_polygon_radial_error_budget(self):
+    def test_retained_adaptive_helper_still_computes_its_budget(self):
+        """`_adaptive_circle_n` is dead code since 6166a98b -- retained on
+        purpose, called by nothing (asserted in TestShippedTessellation). Its
+        arithmetic is kept under test so restoring it stays a one-line change
+        to a working helper rather than a rewrite."""
         from kicad_parser import _adaptive_circle_n
         # 1um sagitta wherever the 64-vertex cap does not bite (r <= ~0.9)...
         for r in (0.2, 0.5, 0.8):
@@ -108,17 +135,77 @@ class TestAdaptivePrimitiveCircle(unittest.TestCase):
         self.assertLessEqual(s1, 0.0013)
 
 
+class TestShippedTessellation(unittest.TestCase):
+    """The fixed 32-gon 6166a98b went back to, pinned where it is decided."""
+
+    PAD_TEXT = ('(pad "1" smd custom (at 0 0) (size 0.1 0.1) (layers "F.Cu")'
+                ' (net 1 "A")\n'
+                '  (options (clearance outline) (anchor circle))\n'
+                '  (primitives (gr_circle (center 0 0) (end 0.45 0)'
+                ' (width 0.1) (fill yes))))')
+
+    def _outer(self):
+        from kicad_parser import _custom_pad_global_polygons
+        polys = _custom_pad_global_polygons(self.PAD_TEXT, 50.0, 50.0, 0.0)
+        return max(polys, key=len)
+
+    def test_circle_primitive_is_a_fixed_32gon(self):
+        self.assertEqual(len(self._outer()), 32,
+                         'the parser must use the fixed inscribed 32-gon '
+                         'restored by 6166a98b, not the adaptive count')
+
+    def test_the_polygon_is_inscribed(self):
+        """Inscribed = never outside the true copper, so the model can only
+        UNDER-report a graze, never manufacture one."""
+        r_max = max(math.hypot(x - 50.0, y - 50.0) for x, y in self._outer())
+        self.assertLessEqual(r_max, 0.5 + 1e-9, 'polygon escapes the circle')
+        self.assertAlmostEqual(r_max, 0.5, places=6,
+                               msg='vertices must sit ON the circle')
+
+    def test_the_adaptive_helper_is_wired_to_nothing(self):
+        """The revert is only real if nothing calls it."""
+        with open(os.path.join(ROOT, 'py_router', 'kicad_parser.py'),
+                  encoding='utf-8') as f:
+            src = f.read()
+        calls = (src.count('_adaptive_circle_n(')
+                 - src.count('def _adaptive_circle_n('))
+        self.assertEqual(calls, 0,
+                         'kicad_parser calls _adaptive_circle_n again -- that '
+                         'reverses 6166a98b and shifts DRC grading on every '
+                         'circle-primitive board; update this file first')
+
+
 class TestRun3ArchivedBoard(unittest.TestCase):
-    def test_the_shipped_graze_is_now_visible(self):
-        """wk/run3/final2.kicad_pcb is the archived pre-fix board carrying the
-        /ICE_CDONE-vs-JP2.2 0.0884mm graze only kicad-cli saw. It is the
-        regression artifact: check_drc at margin 0 must now report it."""
+    """wk/run3/final2.kicad_pcb is the archived pre-fix board carrying the
+    /ICE_CDONE-vs-JP2.2 0.0884mm graze only kicad-cli saw."""
+
+    def test_the_graze_is_masked_at_the_floor_and_visible_above_it(self):
+        """The defect is still in the copper; the 32-gon cannot see it at 0.09.
+
+        Measured: the true gap is 0.0884 (0.0016 short of the floor) and the
+        32-gon's sagitta at r=0.5 is 0.002408 -- LARGER than the shortfall, so
+        the modelled gap lands at 0.0908 and grades clean. Raise the floor past
+        the sagitta and the same pair reappears.
+
+        This arm asserted exit 1 at 0.09, which was true while the adaptive
+        tessellation shipped. It is re-pinned rather than skipped, so it still
+        fails if either the tessellation or check_drc moves."""
         if not os.path.exists(RUN3_BOARD):
             self.skipTest('run-3 archive board not present')
-        r = run_drc(RUN3_BOARD, '-c', '0.09', '--clearance-margin', '0',
-                    '--max-print', '0')
-        self.assertEqual(r.returncode, 1, r.stdout[-800:])
-        self.assertRegex(r.stdout, r'ICE_CDONE.*SWDIO|SWDIO.*ICE_CDONE')
+        masked = run_drc(RUN3_BOARD, '-c', '0.09', '--clearance-margin', '0',
+                         '--max-print', '0')
+        self.assertEqual(masked.returncode, 0, masked.stdout[-800:])
+        self.assertIn('NO DRC VIOLATIONS', masked.stdout)
+
+        sagitta = 0.5 * (1 - math.cos(math.pi / 32))
+        self.assertGreater(sagitta, 0.09 - 0.0884,
+                           'the masking claim only holds while the sagitta '
+                           'exceeds the shortfall')
+
+        seen = run_drc(RUN3_BOARD, '-c', '0.095', '--clearance-margin', '0',
+                       '--max-print', '0')
+        self.assertEqual(seen.returncode, 1, seen.stdout[-800:])
+        self.assertRegex(seen.stdout, r'ICE_CDONE.*SWDIO|SWDIO.*ICE_CDONE')
 
 
 if __name__ == '__main__':

--- a/tests/test_run5_exchange.py
+++ b/tests/test_run5_exchange.py
@@ -18,6 +18,8 @@ sys.path.insert(0, ROOT)
 sys.path.insert(0, os.path.join(ROOT, 'py_placer'))  # placement split
 sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # placement split
 sys.path.insert(0, os.path.join(ROOT, 'py_tools'))  # placement split
+from run_utils import tool as _tool, tool_env as _tool_env  # #522: resolve a moved CLI, loudly
+
 SWAP = os.path.join(ROOT, 'wk', 'b2', 'tigard__swap', 'd0',
                     'perturbed.kicad_pcb')
 HEALTHY = os.path.join(ROOT, 'kicad_files', 'tigard.kicad_pcb')
@@ -30,10 +32,15 @@ def _state(board):
 
 
 def _run(script, *argv):
-    env = dict(os.environ, PYTHONPATH=ROOT, PYTHONIOENCODING='utf-8',
-               KRT_NO_BANNER='1')
+    # `_tool` resolves the a241b5ac split (check_floorplan.py -> py_tools/,
+    # place_reconstruct.py -> py_placer/) and RAISES when a tool is missing.
+    # Spawning os.path.join(ROOT, script) directly made python exit 2 with
+    # "can't open file" -- read here as a tool exit code, so the end-to-end
+    # body below never ran at all. `_tool_env` is the sibling fix: a child
+    # launched with PYTHONPATH=ROOT alone can no longer import kicad_parser.
+    env = dict(_tool_env(), PYTHONIOENCODING='utf-8', KRT_NO_BANNER='1')
     return subprocess.run(
-        [sys.executable, '-X', 'utf8', os.path.join(ROOT, script), *argv],
+        [sys.executable, '-X', 'utf8', _tool(script), *argv],
         capture_output=True, text=True, env=env, cwd=ROOT)
 
 

--- a/tests/test_run6_backlog.py
+++ b/tests/test_run6_backlog.py
@@ -7,15 +7,21 @@ import unittest
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.insert(0, ROOT)
+from run_utils import tool as _tool, tool_env as _tool_env  # #522: resolve a moved CLI, loudly
 
 POUR = os.path.join(ROOT, 'wk', 'run5', 's1_pour.kicad_pcb')
 
 
 def _run(script, *argv):
-    env = dict(os.environ, PYTHONPATH=ROOT, PYTHONIOENCODING='utf-8',
-               KRT_NO_BANNER='1')
+    # `_tool` resolves the #522 reorg (these CLIs live in py_router/ now) and
+    # RAISES when a tool is missing. Spawning os.path.join(ROOT, script)
+    # directly made python exit 2 with "can't open file" on stderr and an
+    # EMPTY stdout, so every assertIn below failed with a bare message that
+    # read like a product bug. `_tool_env` is the sibling fix: PYTHONPATH=ROOT
+    # alone can no longer import kicad_parser/startup_checks.
+    env = dict(_tool_env(), PYTHONIOENCODING='utf-8', KRT_NO_BANNER='1')
     return subprocess.run(
-        [sys.executable, '-X', 'utf8', os.path.join(ROOT, script), *argv],
+        [sys.executable, '-X', 'utf8', _tool(script), *argv],
         capture_output=True, text=True, env=env, cwd=ROOT)
 
 
@@ -25,8 +31,11 @@ class TestQfnAutoDetect(unittest.TestCase):
         fallback classifies QFN) over the 64-pin U3."""
         if not os.path.exists(POUR):
             self.skipTest('run-5 chain board not present')
-        r = _run('qfn_fanout.py', POUR, '-o', os.devnull,
-                 '--clearance', '0.09', '--width', '0.127')
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            r = _run('qfn_fanout.py', POUR, '-o',
+                     os.path.join(td, 'x.kicad_pcb'),
+                     '--clearance', '0.09', '--width', '0.127')
         self.assertIn('Auto-detected QFN/QFP component: U3', r.stdout)
 
 


### PR DESCRIPTION
Closes #718

Four independent causes, none of them a routing regression. Each is separable — take any one and leave the rest if you disagree with it. Item 3 is the judgement call.

## 1. Two `#522` reorg stragglers the `ed779096` sweep missed

`test_run6_backlog` spawned `ROOT/qfn_fanout.py` and `ROOT/bga_fanout.py`; `test_run5_exchange` spawned `ROOT/check_floorplan.py` and `ROOT/place_reconstruct.py`. Python writes `can't open file ...: [Errno 2]` to **stderr** and exits 2, so stdout is `''` and the assertions fail with bare messages that read like product bugs — precisely the class `run_utils.tool()`'s docstring records for eighteen tests.

Both now use `run_utils.tool()` / `tool_env()`, matching `test_part_class.py:25,114-118`. `tool()` raises naming what it looked for; `tool_env()` fixes the sibling defect both files also had (a child launched with `PYTHONPATH=ROOT` alone can no longer `import kicad_parser`).

**`tests/stress/corpus_noop_sweep.py` carried three more of the same shape** (lines 85/136/146). `run_all` does not discover that file, so those were broken silently — found by the new guard, not by hand.

**`test_run5_exchange`'s `TestLadderEndToEnd` had therefore never executed since `a241b5ac`.** It passes.

## 2. `test_run14_dash_net_hint` — a semantic merge conflict with #597

The arm asserted `route.py --nets +12V -12V` exits 2 with `unrecognized arguments`. Since #597 (`55632d91`) `cli_nets.pin_dash_digit_values` swaps argparse's negative-number matcher for `^-\d`, so `-12V` is read as a **value** and the run succeeds.

```
plain matcher  ^-\d+$|^-\d*\.\d+$   ->  SystemExit 2 ("unrecognized arguments: -12V")
pinned matcher ^-\d                 ->  Namespace(nets=['+12V', '-12V'])
```

`git merge-base --is-ancestor 55632d91 4b4098a0` is **false** — the two were built on parallel branches and each passed alone. The test's own guard, `_argparse_takes_dash_values()`, probes a **bare** `ArgumentParser`, one `route.py` no longer builds, so it never skipped.

**Inverted rather than skipped**, so it still fails if the pin is ever dropped. The four unit tests of the hint machinery are untouched and still pass — the hint is inert *through the shipped CLIs*, which is #597's stated goal, and the module docstring now says so.

Its output also goes to a tempdir now. It had been passing `ROOT/_no_such_out.kicad_pcb` on the assumption route.py dies in argparse first; since #597 it really routes and writes, leaving `_no_such_out.kicad_pcb` (~350 KB) and `.kicad_pro` in the repo root after every suite run.

## 3. `test_run4_custom_pad_circle` — the judgement call

It pins the adaptive tessellation `6166a98b` deliberately reverted to a fixed 32-gon. **I did not restore it** — that was a measured corpus decision (real DRC 71 → 49 across 73 boards) and reversing it silently is not mine to make. The graze is still physically in the copper:

| quantity | value |
| --- | --- |
| true gap | 0.0884 mm — 0.0016 short of the 0.09 floor |
| 32-gon sagitta at r=0.5 | **0.002408 mm** — *exceeds* the shortfall |
| modelled gap | 0.0908 mm → grades clean |
| at `-c 0.095` | exit 1, `Pad:/SWDIO (JP2.2) <-> Seg:/ICE_CDONE` |

So the arm is re-pinned on what ships: **masked at 0.09, the same pair visible at 0.095**, with the sagitta-vs-shortfall arithmetic asserted so the claim cannot rot silently. If you would rather restore the adaptive path, this is the one to send back.

While there — the file's other three checks did not cover tessellation at all, which is why this sat unnoticed:

- `test_sub_floor_gap_is_flagged` / `test_above_floor_gap_stays_clean` are insensitive by construction: `board_with_gap` puts the rect due east of the circle centre and polygon vertex `k=0` sits at angle 0, so `max_x` is 50.500000 at N=32 and the measured gap equals the true gap for **any** N.
- `test_polygon_radial_error_budget` calls `_adaptive_circle_n`, which now has **1 definition and 0 call sites**.

Added direct checks of the shipped geometry — vertex count, inscribed-ness, and zero call sites — so restoring the adaptive path is a decision rather than a drift. The insensitivity is documented in place rather than papered over.

## Two guards, because cause 1 is now its third occurrence

**`tests/test_718_stale_tool_paths.py`** — every `[sys.executable, ...]` argv in `tests/` must name a script that exists, and the failure says where it moved. It scans **list literals**, not spawn call sites, because three of these were built as `argv = [...]` and passed by name.

It is explicit about what it cannot see: the two headline tests used `os.path.join(ROOT, script)` with `script` a **parameter**, which no static check resolves — that is exactly why they were moved onto `tool()` rather than repointed. Remaining variable call sites are reported, not failed (`test_431_skill_commands` feeds that shape from `discovered_tools()`, which only admits names that already resolve, so failing it would be wrong).

**`test_457_fresh_clone_fixtures`** gains the `wk/` half of its scan. Its regexes only matched `kicad_files/` (`:120-121`), and **15 test files read boards out of gitignored `wk/`**. On any machine without that work output they `skipTest` and the file still exits 0 — green while covering nothing. That is why cause 3 was invisible to #716's baseline and visible here.

Recorded as a **ratchet**, not an approval list: a new file fails the gate, and clearing one without deleting its entry *also* fails, so the census cannot go stale. Fixing the 15 is a separate job and I did not fold it in — say if you would rather have recipes than a baseline.

It also now registers the new test in `TESTS` and asserts every `test_*` in that file is registered — the new one silently did not run until I noticed, which is the same hand-maintained-registry bug as #696.

## The two timeouts are not defects

Both pass run alone on this machine, so nothing is changed for them:

| test | in `run_all -j 4` | alone |
| --- | --- | --- |
| `test_obstacle_map_balance` | timed out at its own 1200 s budget | **PASS**, including `repair: repairs actually performed` — the check #716 item 2 flagged as possibly real |
| `test_459_group_routing` | timed out at the 600 s cap | **PASS** (declares no `RUN_ALL_TIMEOUT`; may deserve one) |

## Verification

| run | before | after |
| --- | --- | --- |
| `run_all.py --fast` | 282 passed, 0 failed | **283 passed, 0 failed** (+1: the new static guard) |
| `run_all.py` (all 404) | 397 passed, **4 failed**, 2 timed out | **403 passed, 0 failed**, 1 timed out, 2771 s |

The remaining timeout is `test_obstacle_map_balance` at its own 1200 s budget under `-j 4`; it passes run alone (above). No stray `_no_such_out.*` in the working tree after the full run.

Both new guards were **mutation-tested** — they must fail on the pre-fix tree, not merely pass after it:

| mutation | result |
| --- | --- |
| put one `corpus_noop_sweep` path back | `test_718` FAILS, naming `corpus_noop_sweep.py:136 -> check_floorplan.py (it moved to py_tools/check_floorplan.py)` |
| a new test file reads a `wk/` board | `test_457` FAILS: `new test(s) reading a board out of gitignored wk/` |
| a baselined file stops reading `wk/` | `test_457` FAILS: `delete them from _WK_BOARD_CONSUMERS so the census stays true` |
| a `test_*` defined but not in `TESTS` | `test_457` FAILS: `absent from TESTS, so they never run` |

One note on the new guard file: it deliberately avoids the literal word for a spawned child process in its prose, because `run_all` classifies a test as slow "integration" by substring-matching its **source** for it. This check spawns nothing and runs in well under a second, so it belongs in the `--fast` loop where a stale path is caught immediately. That is stated in the file.
