### PR TITLE
floorplan intent: refuse unknown keys in every nested object (#710)

### DIFF
--- a/.claude/skills/plan-pcb-placement/SKILL.md
+++ b/.claude/skills/plan-pcb-placement/SKILL.md
@@ -1078,6 +1078,13 @@ area**. Schematic sheets usually are not: on one 4-layer corpus board all ten sh
 bounding boxes overlap each other, so `--emit-intent` claims a zone for only 4 of 10 and
 says why for the rest.
 
+A misspelled key is **refused**, at every level of the file and including
+`severity` keys — you will be told the key that was wrong and the ones that
+were accepted, so fix the spelling rather than assuming the claim landed.
+Reasoning about *why* a claim is what it is goes in `context`, which every
+entry accepts and nothing grades; do not put it in `note`, which is read for
+the substring `SUSPECT`.
+
 `--health` adds the routability signals: how far each block sits from the parts
 it connects to, and what crosses each declared bus corridor. Advisory — they say
 the floorplan will fight the router, not that it breaks your intent.

--- a/docs/floorplan-intent.md
+++ b/docs/floorplan-intent.md
@@ -116,7 +116,7 @@ source, suspect, suspect_reason
 | `edge_connectors[].overhang_mm` | `min`, `max` |
 | `decaps` | `max_distance_mm`, `exempt`, `search_radius_mm` |
 | `legality_budget` | `overlap_area`, `oob_count`, `oob_amount` (`oob_area` refused — see below) |
-| `health` | `bus_corridors`, `classes`, `block_displacement_mm`, `ignore_net_ids`, `max_fanout`, `zoned_blocks`, `affinity_exempt_nets` |
+| `health` | `bus_corridors`, `classes`, `block_displacement_mm`, `ignore_net_ids`, `max_fanout`, `zoned_blocks`, `affinity_exempt_nets`, `affinity_exempt_net_ids` |
 | `health.bus_corridors[]` | `name`, `nets`, `width_mm` |
 | `severity` | any of the 12 rule names below |
 | `overlap_waivers[]` | `pair`, `reason`, `context` |
@@ -169,9 +169,20 @@ grading it halfway is the same wrong answer as grading it fully. A build older
 than the field itself refuses `min_reader` as an unknown top-level key, which
 is the same answer.
 
-The policy: an additive nested field is inert on an older build and needs no
-`min_reader`. A field whose ABSENCE changes the verdict carries one, and
-`READER_VERSION` bumps in the commit that adds it.
+The policy, and what each half is for. Refusing unknown keys already covers
+**new** fields: an older build does not know the key, so it refuses the file
+outright and says which key it did not understand. That is loud, automatic,
+and needs no `min_reader`.
+
+What refusal cannot see is a key an older build *does* know:
+
+- its accepted **values** widened (a new `edge` direction, a new `class`);
+- its **meaning** changed, so an old build acts on it differently;
+- a **default** changed, so the same file grades differently than intended.
+
+Those are what `min_reader` is for, and the file's author is the only one who
+can know it applies. `READER_VERSION` bumps in the commit that makes such a
+change, and files depending on it declare `min_reader`.
 
 ### `refs` is the primitive, not `group`
 

--- a/docs/floorplan-intent.md
+++ b/docs/floorplan-intent.md
@@ -91,6 +91,88 @@ knowingly.)
 }
 ```
 
+### Every key, and what happens to one you misspell
+
+An unknown key is **refused at load time, at every level** — not dropped. A
+typo'd key that is silently ignored is a constraint the author believes they
+set and the grader never checks, which is the same failure `block_unresolved`
+exists to prevent, one level down. The message names the key that was wrong and
+lists the ones that were accepted:
+
+```
+edge_connectors[0]: unknown key(s) max_setback. Known: class, context, edge,
+max_setback_mm, note, observed_overhang_mm, overhang_capped, overhang_mm, ref,
+source, suspect, suspect_reason
+```
+
+| object | keys |
+|---|---|
+| top level | `schema`, `kind`, `board`, `units`, `min_reader`, `envelope`, `defaults`, `blocks`, `keepouts`, `edge_connectors`, `decaps`, `must_lock`, `legality_budget`, `health`, `severity`, `overlap_waivers`, `context` |
+| `envelope` | `rect`, `tolerance_mm` |
+| `defaults` | `zone_tolerance_mm` |
+| `blocks[]` | `name`, `group`, `refs`, `zone`, `side`, `exclusive`, `tolerance_mm`, `note`, `context` |
+| `keepouts[]` | `name`, `rect`, `circle`, `sides`, `allow`, `note`, `context` |
+| `edge_connectors[]` | `ref`, `edge`, `overhang_mm`, `max_setback_mm`, `class`, `note`, `context`, and the emitter-written `source`, `suspect`, `suspect_reason`, `overhang_capped`, `observed_overhang_mm` |
+| `edge_connectors[].overhang_mm` | `min`, `max` |
+| `decaps` | `max_distance_mm`, `exempt`, `search_radius_mm` |
+| `legality_budget` | `overlap_area`, `oob_count`, `oob_amount` (`oob_area` refused — see below) |
+| `health` | `bus_corridors`, `classes`, `block_displacement_mm`, `ignore_net_ids`, `max_fanout`, `zoned_blocks`, `affinity_exempt_nets` |
+| `health.bus_corridors[]` | `name`, `nets`, `width_mm` |
+| `severity` | any of the 12 rule names below |
+| `overlap_waivers[]` | `pair`, `reason`, `context` |
+| `must_lock` | a list of reference globs (no nested keys) |
+
+`severity` keys are checked too. The settable names are the nine rules —
+`envelope`, `zone_containment`, `zone_side`, `zone_exclusive`, `keepout`,
+`edge_connector`, `decap_distance`, `must_lock`, `legality` — plus the three
+findings raised outside the rule loop: `intent_zone_outside_envelope`,
+`intent_zone_overlap`, `block_unresolved`. `{"decap_distanc": "warn"}` is a
+demotion that never happens, so it is refused rather than accepted.
+
+### `context` is the slot for everything that is not a claim
+
+`context` is **deliberately open** — free-form keys, at the top level and on
+every `blocks[]`, `keepouts[]`, `edge_connectors[]` and `overlap_waivers[]`
+entry. Nothing reads it and no rule grades it; it is where a run records why a
+claim is what it is:
+
+```jsonc
+{ "ref": "J1", "edge": "east",
+  "context": { "why": "the mating face is on the east wall of the enclosure",
+               "rejected_alternative": "north, blocked by the display window" } }
+```
+
+It is open for the same reason everything else is strict. With nowhere to put
+reasoning, it drifts into the graded keys — a recorded run had
+`edge_connectors[]` entries carrying `band_basis`, `why`, `why_not_repaired`
+and `rejected_alternative`, which every consumer ignored. `note` is not the
+place either: it is grepped for the substring `SUSPECT`, so appending prose to
+it can change behaviour. A `context` value must still be an object; the keys
+inside it are yours.
+
+### Versioning: `schema` is the format, `min_reader` is the vocabulary
+
+`schema` is matched **exactly**, so bumping it invalidates every existing
+intent file at once — far too blunt for "this build learned a new field".
+
+So field-level compatibility is a second number. `READER_VERSION` (currently
+`1`) is what this build can act on, and an intent sets `min_reader` when a
+claim must not be silently ignored:
+
+```jsonc
+{ "schema": 1, "kind": "floorplan-intent", "min_reader": 2, ... }
+```
+
+A build whose `READER_VERSION` is lower **refuses the file** rather than
+grading it without the claim — checked before anything else is read, because
+grading it halfway is the same wrong answer as grading it fully. A build older
+than the field itself refuses `min_reader` as an unknown top-level key, which
+is the same answer.
+
+The policy: an additive nested field is inert on an older build and needs no
+`min_reader`. A field whose ABSENCE changes the verdict carries one, and
+`READER_VERSION` bumps in the commit that adds it.
+
 ### `refs` is the primitive, not `group`
 
 Sheet group keys are opaque uuid paths — KiCad's `Sheetname` property is absent

--- a/py_placer/placement/README.md
+++ b/py_placer/placement/README.md
@@ -585,6 +585,16 @@ parts worth knowing from here:
 - **`oob_area` cannot be budgeted.** It is measured against the bbox inset, so a
   part sitting entirely inside a cutout scores `0.0`. Refused at load time with
   that reason; use `oob_count` / `oob_amount`.
+- **An unknown key is refused at every level of the intent** (#710), and so is a
+  `severity` key that is not a rule name. Same reason as `block_unresolved`, one
+  level down: a typo'd key that is silently dropped is a constraint the author
+  believes they set and the grader never checks. `context` is the one exception,
+  open by design at the top level and on every entry, because provenance with
+  nowhere to go ends up in a key that IS graded.
+- **`schema` is the format number; `min_reader` is the field vocabulary.** An
+  intent sets `min_reader` when a claim must not be silently ignored, and a
+  build whose `READER_VERSION` is lower refuses the file instead of grading it
+  without the claim.
 
 One thing `--emit-intent` will not do: claim a `zone` for a sheet block. A
 schematic sheet is a *functional* grouping, so its members scatter and all ten of

--- a/py_placer/placement/floorplan.py
+++ b/py_placer/placement/floorplan.py
@@ -133,8 +133,10 @@ _EDGE_CONNECTOR_KEYS = {'ref', 'edge', 'overhang_mm', 'max_setback_mm',
 _OVERHANG_KEYS = {'min', 'max'}
 _DECAP_KEYS = {'max_distance_mm', 'exempt', 'search_radius_mm'}
 _DEFAULTS_KEYS = {'zone_tolerance_mm'}
-#: `zoned_blocks` and `affinity_exempt_net_ids` are setdefault-injected into
-#: this same dict by `grade` after load, so an author may also set them.
+#: `zoned_blocks` is setdefault-injected into this same dict by `grade` after
+#: load, and `affinity_exempt_net_ids` is derived there from
+#: `affinity_exempt_nets` -- but only when that key is present, so an author
+#: may also set the ids directly. Both are accepted for that reason.
 _HEALTH_KEYS = {'bus_corridors', 'classes', 'zoned_blocks',
                 'affinity_exempt_nets', 'affinity_exempt_net_ids',
                 'ignore_net_ids', 'max_fanout', 'block_displacement_mm'}
@@ -143,7 +145,11 @@ _BUDGET_KEYS = {'overlap_area', 'oob_count', 'oob_amount'}
 _WAIVER_KEYS = {'pair', 'reason', 'context'}
 # `context` deliberately has NO key set of its own, at the top level or on an
 # entry: it is the read-only slot where a run records provenance no rule will
-# ever grade. Every object above accepts one, because the alternative is worse.
+# ever grade. The four objects a human AUTHORS entry-by-entry accept one --
+# _BLOCK_KEYS, _KEEPOUT_KEYS, _EDGE_CONNECTOR_KEYS, _WAIVER_KEYS -- because the
+# alternative is worse; the settings objects (envelope, defaults, decaps,
+# health, legality_budget, overhang_mm) do not, since prose about a setting
+# belongs on the claim that uses it or at the top level.
 # Refusing prose outright pushes it into a key that IS graded -- the recorded
 # runs show exactly that drift, an `edge_connectors[]` entry that grew
 # `band_basis`, `why`, `why_not_repaired` and `rejected_alternative` because
@@ -200,6 +206,13 @@ class Zone:
     exclusive: bool = False
     tolerance_mm: Optional[float] = None
     note: str = ''
+    #: Free-form provenance, read by nothing (see `_BLOCK_KEYS`). Carried on
+    #: the Zone rather than dropped: `keepouts`/`edge_connectors`/
+    #: `overlap_waivers` keep their raw dict and so keep theirs, and a slot
+    #: that silently vanishes for ONE of the four is the #710 defect itself.
+    #: (Zone is frozen, so this makes it unhashable -- nothing hashes a Zone,
+    #: only iterates them.)
+    context: Dict[str, object] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -311,10 +324,15 @@ def _reject_unknown(obj, allowed, where: str) -> None:
     `health.bus_corridors[0]` all read alike. The `Known:` list is what turns
     a typo into a fix -- `keepout` only looks wrong next to `keepouts`.
     """
-    bad = sorted(set(obj) - set(allowed))
+    # str() BEFORE sorting, not at join time: a dict handed to
+    # `intent_from_dict` directly (it is public, and the place_* mains catch
+    # only ValueError) can carry a non-string key, and both `sorted` over
+    # mixed types and `join` over non-strings raise TypeError -- which would
+    # traceback past the callers instead of becoming their exit 2.
+    bad = sorted(str(k) for k in set(obj) - set(allowed))
     if bad:
         raise IntentError(f"{where}: unknown key(s) {', '.join(bad)}. "
-                          f"Known: {', '.join(sorted(allowed))}")
+                          f"Known: {', '.join(sorted(map(str, allowed)))}")
 
 
 def _entry_context(entry, where: str) -> None:
@@ -370,19 +388,14 @@ def load_intent(path: str) -> Intent:
 
 
 def intent_from_dict(raw: Dict, source_path: str = '') -> Intent:
-    _reject_unknown(raw, _TOP_LEVEL_KEYS, 'top level')
-
-    schema = raw.get('schema')
-    if schema != SCHEMA_VERSION:
-        raise IntentError(
-            f"schema {schema!r}: this build reads schema {SCHEMA_VERSION}")
-    # Refused BEFORE anything else is read: the point of the field is that a
-    # build which cannot act on the file must not grade it, and grading it
-    # halfway is the same wrong answer as grading it fully.
+    # FIRST, ahead of the unknown-key and schema checks. A build that declares
+    # a new field almost always declares a new TOP-LEVEL one, so checking the
+    # key set first means the actionable "this build is too old, upgrade"
+    # message is exactly the one an author never sees -- they get "unknown
+    # key(s) zones" and go looking for a typo that is not there.
     #
-    # Note the field works in the backwards direction from the day it lands:
-    # a build older than this one refuses `min_reader` as an unknown
-    # top-level key, which is exactly the intended answer.
+    # Grading such a file halfway is the same wrong answer as grading it
+    # fully, so nothing else is read until this passes.
     min_reader = raw.get('min_reader')
     if min_reader is not None:
         if not isinstance(min_reader, int) or isinstance(min_reader, bool):
@@ -394,6 +407,13 @@ def intent_from_dict(raw: Dict, source_path: str = '') -> Intent:
                 f"{READER_VERSION}. The intent declares a claim this build "
                 f"would not act on, and grading it would report clean on a "
                 f"constraint that was never checked -- upgrade instead")
+
+    _reject_unknown(raw, _TOP_LEVEL_KEYS, 'top level')
+
+    schema = raw.get('schema')
+    if schema != SCHEMA_VERSION:
+        raise IntentError(
+            f"schema {schema!r}: this build reads schema {SCHEMA_VERSION}")
 
     kind = raw.get('kind')
     if kind != KIND:
@@ -437,6 +457,7 @@ def intent_from_dict(raw: Dict, source_path: str = '') -> Intent:
             exclusive=bool(b.get('exclusive', False)),
             tolerance_mm=b.get('tolerance_mm'),
             note=b.get('note', '') or '',
+            context=b.get('context') or {},
         ))
         if not blocks[-1].refs and not blocks[-1].group:
             raise IntentError(

--- a/py_placer/placement/floorplan.py
+++ b/py_placer/placement/floorplan.py
@@ -449,6 +449,10 @@ def intent_from_dict(raw: Dict, source_path: str = '') -> Intent:
     if any(v not in (ERROR, WARN) for v in severity.values()):
         raise IntentError(
             f"severity: expected {{rule: 'error'|'warn'}}, got {severity!r}")
+    # Keys too, not only values (#710). `{"decap_distanc": "warn"}` used to
+    # load clean and leave the rule at its default -- a demotion the author
+    # believes they made and the exit code never reflects.
+    _reject_unknown(severity, _SEVERITY_KEYS, 'severity')
 
     budget = _obj(raw.get('legality_budget'), 'legality_budget')
     if 'oob_area' in budget:
@@ -1131,6 +1135,19 @@ RULES = (
     ('must_lock', rule_must_lock),
     ('legality', rule_legality),
 )
+
+#: Rules whose violations are raised OUTSIDE the `RULES` loop, and so have no
+#: rule function to be enumerated from: the two self-contradiction findings in
+#: `validate_intent` and the unresolved-block finding in `resolve_blocks`.
+#: Kept as a named set rather than folded into `_SEVERITY_KEYS` by hand, so the
+#: next reader can see which names are the exception and why.
+_NON_RULE_SEVERITIES = frozenset({
+    'intent_zone_outside_envelope', 'intent_zone_overlap', 'block_unresolved'})
+
+#: Every rule name an intent may set a severity for. Derived from `RULES`, so a
+#: new rule is settable the moment it is registered -- a hand-listed set would
+#: silently refuse the newest rule's own name.
+_SEVERITY_KEYS = frozenset(name for name, _ in RULES) | _NON_RULE_SEVERITIES
 
 # Why a rule did not run. Reported so that "0 violations" and "0 rules ran"
 # cannot look the same to a reader or to a machine.

--- a/py_placer/placement/floorplan.py
+++ b/py_placer/placement/floorplan.py
@@ -99,7 +99,7 @@ _TOP_LEVEL_KEYS = {
     'health', 'severity', 'context', 'overlap_waivers', 'min_reader',
 }
 _BLOCK_KEYS = {'name', 'group', 'refs', 'zone', 'side', 'exclusive',
-               'tolerance_mm', 'note'}
+               'tolerance_mm', 'note', 'context'}
 
 # The principle `_BLOCK_KEYS` already encodes, applied one level down (#710).
 # Before this the loader was strict at exactly two levels -- top-level and
@@ -121,14 +121,15 @@ _BLOCK_KEYS = {'name', 'group', 'refs', 'zone', 'side', 'exclusive',
 # pinned against them by tests/test_549_floorplan_grade.py -- so a new emitted
 # key fails there, rather than as an artifact that stops loading months later.
 _ENVELOPE_KEYS = {'rect', 'tolerance_mm'}
-_KEEPOUT_KEYS = {'name', 'rect', 'circle', 'sides', 'allow', 'note'}
+_KEEPOUT_KEYS = {'name', 'rect', 'circle', 'sides', 'allow', 'note',
+                 'context'}
 #: `source`, `suspect`, `suspect_reason`, `overhang_capped` and
 #: `observed_overhang_mm` are emitter-written and read by nothing today; they
 #: are accepted because `emit_intent` writes them and the round trip must
 #: survive, not because anything acts on them.
 _EDGE_CONNECTOR_KEYS = {'ref', 'edge', 'overhang_mm', 'max_setback_mm',
                         'class', 'source', 'note', 'suspect', 'suspect_reason',
-                        'overhang_capped', 'observed_overhang_mm'}
+                        'overhang_capped', 'observed_overhang_mm', 'context'}
 _OVERHANG_KEYS = {'min', 'max'}
 _DECAP_KEYS = {'max_distance_mm', 'exempt', 'search_radius_mm'}
 _DEFAULTS_KEYS = {'zone_tolerance_mm'}
@@ -139,9 +140,16 @@ _HEALTH_KEYS = {'bus_corridors', 'classes', 'zoned_blocks',
                 'ignore_net_ids', 'max_fanout', 'block_displacement_mm'}
 _CORRIDOR_KEYS = {'name', 'nets', 'width_mm'}
 _BUDGET_KEYS = {'overlap_area', 'oob_count', 'oob_amount'}
-_WAIVER_KEYS = {'pair', 'reason'}
-# `context` deliberately has NO key set: it is the documented read-only slot
-# where a run records provenance no rule will ever grade. See where it is read.
+_WAIVER_KEYS = {'pair', 'reason', 'context'}
+# `context` deliberately has NO key set of its own, at the top level or on an
+# entry: it is the read-only slot where a run records provenance no rule will
+# ever grade. Every object above accepts one, because the alternative is worse.
+# Refusing prose outright pushes it into a key that IS graded -- the recorded
+# runs show exactly that drift, an `edge_connectors[]` entry that grew
+# `band_basis`, `why`, `why_not_repaired` and `rejected_alternative` because
+# there was nowhere else for the reasoning to go. Folding it into `note`
+# instead would be worse still: `note` is load-bearing, grepped for the
+# substring SUSPECT by emit_intent and place_reconstruct.
 _EDGES = ('north', 'south', 'east', 'west')
 
 
@@ -309,6 +317,16 @@ def _reject_unknown(obj, allowed, where: str) -> None:
                           f"Known: {', '.join(sorted(allowed))}")
 
 
+def _entry_context(entry, where: str) -> None:
+    """An entry's `context` is free-form, but it is still an OBJECT.
+
+    Type-checked and otherwise untouched: a list here means the author meant
+    something else, while an unknown key inside means nothing at all.
+    """
+    if 'context' in entry:
+        _obj(entry['context'], f"{where}.context")
+
+
 def _obj(value, where: str) -> Dict:
     """An intent object, or `{}` when absent.
 
@@ -400,6 +418,7 @@ def intent_from_dict(raw: Dict, source_path: str = '') -> Intent:
         if not isinstance(b, dict):
             raise IntentError(f"blocks[{i}]: expected an object")
         _reject_unknown(b, _BLOCK_KEYS, f"blocks[{i}]")
+        _entry_context(b, f"blocks[{i}]")
         name = b.get('name') or f"block{i}"
         if name in seen_names:
             raise IntentError(f"blocks[{i}]: duplicate block name {name!r}")
@@ -430,6 +449,7 @@ def intent_from_dict(raw: Dict, source_path: str = '') -> Intent:
         if not isinstance(k, dict):
             raise IntentError(f"keepouts[{i}]: expected an object")
         _reject_unknown(k, _KEEPOUT_KEYS, f"keepouts[{i}]")
+        _entry_context(k, f"keepouts[{i}]")
         k = dict(k)
         k.setdefault('name', f"keepout{i}")
         if 'rect' in k and k['rect'] is not None:
@@ -457,6 +477,7 @@ def intent_from_dict(raw: Dict, source_path: str = '') -> Intent:
         # it is unknown, not reported as a missing `ref` while the author
         # stares at the key they did write.
         _reject_unknown(c, _EDGE_CONNECTOR_KEYS, f"edge_connectors[{i}]")
+        _entry_context(c, f"edge_connectors[{i}]")
         if not c.get('ref'):
             raise IntentError(f"edge_connectors[{i}]: expected an object with "
                               f"a `ref`")
@@ -532,6 +553,7 @@ def intent_from_dict(raw: Dict, source_path: str = '') -> Intent:
                 "overlap_waivers: each entry needs 'pair': [refA, refB] "
                 "(and should carry a 'reason')")
         _reject_unknown(w, _WAIVER_KEYS, f"overlap_waivers[{i}]")
+        _entry_context(w, f"overlap_waivers[{i}]")
 
     return Intent(
         schema=schema, kind=kind, board=raw.get('board', '') or '',

--- a/py_placer/placement/floorplan.py
+++ b/py_placer/placement/floorplan.py
@@ -88,6 +88,48 @@ _TOP_LEVEL_KEYS = {
 }
 _BLOCK_KEYS = {'name', 'group', 'refs', 'zone', 'side', 'exclusive',
                'tolerance_mm', 'note'}
+
+# The principle `_BLOCK_KEYS` already encodes, applied one level down (#710).
+# Before this the loader was strict at exactly two levels -- top-level and
+# `blocks[]` -- and permissive everywhere else, so `{"ref": "J1",
+# "max_setback": 2.0}` and `{"severity": {"decap_distanc": "warn"}}` loaded
+# clean and did nothing. That is the failure `block_unresolved` exists to
+# prevent, one level down: a constraint the author thinks they set and the
+# grader never checks.
+#
+# The compatibility half matters as much. Because unknown nested keys were
+# IGNORED rather than refused, every field added below the top level was
+# automatically backward compatible AND silently inert on an older build --
+# for a constraint the worst possible pair, because the older reader answers
+# "clean" instead of "I do not understand this". Refusing makes it say so;
+# `min_reader` is the explicit, author-set form of the same guarantee.
+#
+# Every name below is either read by code or written by `emit_intent`. The
+# sets were enumerated from both directions, and the emitter's own output is
+# pinned against them by tests/test_549_floorplan_grade.py -- so a new emitted
+# key fails there, rather than as an artifact that stops loading months later.
+_ENVELOPE_KEYS = {'rect', 'tolerance_mm'}
+_KEEPOUT_KEYS = {'name', 'rect', 'circle', 'sides', 'allow', 'note'}
+#: `source`, `suspect`, `suspect_reason`, `overhang_capped` and
+#: `observed_overhang_mm` are emitter-written and read by nothing today; they
+#: are accepted because `emit_intent` writes them and the round trip must
+#: survive, not because anything acts on them.
+_EDGE_CONNECTOR_KEYS = {'ref', 'edge', 'overhang_mm', 'max_setback_mm',
+                        'class', 'source', 'note', 'suspect', 'suspect_reason',
+                        'overhang_capped', 'observed_overhang_mm'}
+_OVERHANG_KEYS = {'min', 'max'}
+_DECAP_KEYS = {'max_distance_mm', 'exempt', 'search_radius_mm'}
+_DEFAULTS_KEYS = {'zone_tolerance_mm'}
+#: `zoned_blocks` and `affinity_exempt_net_ids` are setdefault-injected into
+#: this same dict by `grade` after load, so an author may also set them.
+_HEALTH_KEYS = {'bus_corridors', 'classes', 'zoned_blocks',
+                'affinity_exempt_nets', 'affinity_exempt_net_ids',
+                'ignore_net_ids', 'max_fanout', 'block_displacement_mm'}
+_CORRIDOR_KEYS = {'name', 'nets', 'width_mm'}
+_BUDGET_KEYS = {'overlap_area', 'oob_count', 'oob_amount'}
+_WAIVER_KEYS = {'pair', 'reason'}
+# `context` deliberately has NO key set: it is the documented read-only slot
+# where a run records provenance no rule will ever grade. See where it is read.
 _EDGES = ('north', 'south', 'east', 'west')
 
 
@@ -242,6 +284,33 @@ def _rect(value, where: str) -> Tuple[float, float, float, float]:
     return (min(x0, x1), min(y0, y1), max(x0, x1), max(y0, y1))
 
 
+def _reject_unknown(obj, allowed, where: str) -> None:
+    """Refuse an unknown key rather than dropping it (#710).
+
+    One message shape for every level, so `blocks[3]`, `severity` and
+    `health.bus_corridors[0]` all read alike. The `Known:` list is what turns
+    a typo into a fix -- `keepout` only looks wrong next to `keepouts`.
+    """
+    bad = sorted(set(obj) - set(allowed))
+    if bad:
+        raise IntentError(f"{where}: unknown key(s) {', '.join(bad)}. "
+                          f"Known: {', '.join(sorted(allowed))}")
+
+
+def _obj(value, where: str) -> Dict:
+    """An intent object, or `{}` when absent.
+
+    `raw.get(k) or {}` handed a list or a string straight on, so a schema
+    error surfaced as an AttributeError inside a rule three call frames later
+    -- or, for a key nothing reads yet, not at all.
+    """
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise IntentError(f"{where}: expected an object, got {value!r}")
+    return value
+
+
 def _str_tuple(value, where: str) -> Tuple[str, ...]:
     if value is None:
         return ()
@@ -271,11 +340,7 @@ def load_intent(path: str) -> Intent:
 
 
 def intent_from_dict(raw: Dict, source_path: str = '') -> Intent:
-    unknown = sorted(set(raw) - _TOP_LEVEL_KEYS)
-    if unknown:
-        raise IntentError(
-            f"unknown top-level key(s): {', '.join(unknown)}. Known keys: "
-            f"{', '.join(sorted(_TOP_LEVEL_KEYS))}")
+    _reject_unknown(raw, _TOP_LEVEL_KEYS, 'top level')
 
     schema = raw.get('schema')
     if schema != SCHEMA_VERSION:
@@ -292,9 +357,8 @@ def intent_from_dict(raw: Dict, source_path: str = '') -> Intent:
     if units != 'mm':
         raise IntentError(f"units {units!r}: only 'mm' is supported")
 
-    envelope = raw.get('envelope') or {}
-    if not isinstance(envelope, dict):
-        raise IntentError("envelope: expected an object")
+    envelope = _obj(raw.get('envelope'), 'envelope')
+    _reject_unknown(envelope, _ENVELOPE_KEYS, 'envelope')
     if 'rect' in envelope and envelope['rect'] is not None:
         envelope = dict(envelope)
         envelope['rect'] = _rect(envelope['rect'], 'envelope.rect')
@@ -304,9 +368,7 @@ def intent_from_dict(raw: Dict, source_path: str = '') -> Intent:
     for i, b in enumerate(raw.get('blocks') or []):
         if not isinstance(b, dict):
             raise IntentError(f"blocks[{i}]: expected an object")
-        bad = sorted(set(b) - _BLOCK_KEYS)
-        if bad:
-            raise IntentError(f"blocks[{i}]: unknown key(s) {', '.join(bad)}")
+        _reject_unknown(b, _BLOCK_KEYS, f"blocks[{i}]")
         name = b.get('name') or f"block{i}"
         if name in seen_names:
             raise IntentError(f"blocks[{i}]: duplicate block name {name!r}")
@@ -336,6 +398,7 @@ def intent_from_dict(raw: Dict, source_path: str = '') -> Intent:
     for i, k in enumerate(raw.get('keepouts') or []):
         if not isinstance(k, dict):
             raise IntentError(f"keepouts[{i}]: expected an object")
+        _reject_unknown(k, _KEEPOUT_KEYS, f"keepouts[{i}]")
         k = dict(k)
         k.setdefault('name', f"keepout{i}")
         if 'rect' in k and k['rect'] is not None:
@@ -356,7 +419,14 @@ def intent_from_dict(raw: Dict, source_path: str = '') -> Intent:
 
     conns = []
     for i, c in enumerate(raw.get('edge_connectors') or []):
-        if not isinstance(c, dict) or not c.get('ref'):
+        if not isinstance(c, dict):
+            raise IntentError(f"edge_connectors[{i}]: expected an object with "
+                              f"a `ref`")
+        # Unknown keys BEFORE the `ref` check: a typo'd `reff` should be told
+        # it is unknown, not reported as a missing `ref` while the author
+        # stares at the key they did write.
+        _reject_unknown(c, _EDGE_CONNECTOR_KEYS, f"edge_connectors[{i}]")
+        if not c.get('ref'):
             raise IntentError(f"edge_connectors[{i}]: expected an object with "
                               f"a `ref`")
         c = dict(c)
@@ -366,20 +436,21 @@ def intent_from_dict(raw: Dict, source_path: str = '') -> Intent:
                 f"edge_connectors[{i}] ({c['ref']}): edge {edge!r}, expected "
                 f"one of {', '.join(_EDGES)}")
         oh = c.get('overhang_mm')
-        if oh is not None and not isinstance(oh, dict):
-            raise IntentError(f"edge_connectors[{i}] ({c['ref']}): "
-                              f"overhang_mm expects {{'min': .., 'max': ..}}")
+        if oh is not None:
+            if not isinstance(oh, dict):
+                raise IntentError(f"edge_connectors[{i}] ({c['ref']}): "
+                                  f"overhang_mm expects "
+                                  f"{{'min': .., 'max': ..}}")
+            _reject_unknown(oh, _OVERHANG_KEYS,
+                            f"edge_connectors[{i}] ({c['ref']}).overhang_mm")
         conns.append(c)
 
-    severity = raw.get('severity') or {}
-    if not isinstance(severity, dict) or any(
-            v not in (ERROR, WARN) for v in severity.values()):
+    severity = _obj(raw.get('severity'), 'severity')
+    if any(v not in (ERROR, WARN) for v in severity.values()):
         raise IntentError(
             f"severity: expected {{rule: 'error'|'warn'}}, got {severity!r}")
 
-    budget = raw.get('legality_budget') or {}
-    if not isinstance(budget, dict):
-        raise IntentError("legality_budget: expected an object")
+    budget = _obj(raw.get('legality_budget'), 'legality_budget')
     if 'oob_area' in budget:
         # Refused loudly rather than ignored, because it is the ONE legality
         # number that lies about cutouts. `out_of_board_area` measures against
@@ -392,40 +463,58 @@ def intent_from_dict(raw: Dict, source_path: str = '') -> Intent:
             "measured against the bounding-box inset, so a part sitting inside "
             "a CUTOUT scores 0.0 area and would grade clean. Use oob_count or "
             "oob_amount, which both see the real Edge.Cuts rings")
-    unknown_budget = sorted(set(budget) - {'overlap_area', 'oob_count',
-                                           'oob_amount'})
-    if unknown_budget:
-        raise IntentError(
-            f"legality_budget: unknown key(s) {', '.join(unknown_budget)}. "
-            f"Known: overlap_area, oob_count, oob_amount")
+    _reject_unknown(budget, _BUDGET_KEYS, 'legality_budget')
+
+    defaults = _obj(raw.get('defaults'), 'defaults')
+    _reject_unknown(defaults, _DEFAULTS_KEYS, 'defaults')
+
+    decaps = _obj(raw.get('decaps'), 'decaps')
+    _reject_unknown(decaps, _DECAP_KEYS, 'decaps')
+
+    health = _obj(raw.get('health'), 'health')
+    _reject_unknown(health, _HEALTH_KEYS, 'health')
+    for i, spec in enumerate(health.get('bus_corridors') or []):
+        if not isinstance(spec, dict):
+            raise IntentError(f"health.bus_corridors[{i}]: expected an object")
+        _reject_unknown(spec, _CORRIDOR_KEYS, f"health.bus_corridors[{i}]")
+
+    # `context` is deliberately OPEN -- the documented read-only slot, where a
+    # run records provenance no rule will ever grade (`emit_intent` writes
+    # `cutouts`, `file_locked`, `budget_withheld`; run artifacts add their own
+    # prose). Type-checked so a list cannot reach `.get('budget_withheld')`,
+    # but its KEYS are the author's business: refusing them would only push
+    # provenance into a key that IS graded, which is the worse failure.
+    context = _obj(raw.get('context'), 'context')
 
     waivers = raw.get('overlap_waivers') or []
     if not isinstance(waivers, list):
         raise IntentError("overlap_waivers: expected a list of "
                           "{'pair': [refA, refB], 'reason': ...} objects")
-    for w in waivers:
+    for i, w in enumerate(waivers):
         if (not isinstance(w, dict) or not isinstance(w.get('pair'), list)
                 or len(w['pair']) != 2):
             raise IntentError(
                 "overlap_waivers: each entry needs 'pair': [refA, refB] "
                 "(and should carry a 'reason')")
+        _reject_unknown(w, _WAIVER_KEYS, f"overlap_waivers[{i}]")
 
     return Intent(
         schema=schema, kind=kind, board=raw.get('board', '') or '',
         units=units, envelope=envelope,
-        defaults=raw.get('defaults') or {},
+        defaults=defaults,
         blocks=tuple(blocks), keepouts=tuple(keepouts),
         edge_connectors=tuple(conns),
-        decaps=raw.get('decaps') or {},
+        decaps=decaps,
         must_lock=_str_tuple(raw.get('must_lock'), 'must_lock'),
-        legality_budget=raw.get('legality_budget') or {},
-        health=raw.get('health') or {},
+        legality_budget=budget,
+        health=health,
         severity={str(k): str(v) for k, v in severity.items()},
         source_path=source_path,
         overlap_waivers=tuple(waivers),
         budget_withheld={
             str(k): str(v) for k, v in
-            ((raw.get('context') or {}).get('budget_withheld') or {}).items()},
+            _obj(context.get('budget_withheld'),
+                 'context.budget_withheld').items()},
     )
 
 

--- a/py_placer/placement/floorplan.py
+++ b/py_placer/placement/floorplan.py
@@ -81,10 +81,22 @@ DEFAULT_ENVELOPE_TOLERANCE_MM = 0.5
 #: which already knows this failure mode for one part class.
 EDGE_BAND_SANITY_MM = 5.0
 
+#: What this build can ACT on, as distinct from what it can parse (#710).
+#: `schema` is the format number and is matched exactly; bumping it invalidates
+#: every existing intent file at once, which is far too blunt for "this build
+#: learned a new field". `READER_VERSION` is the field-vocabulary number, and an
+#: intent whose claim would be MEANINGLESS to an older build says so by setting
+#: `min_reader` to the version that introduced the field.
+#:
+#: Bump this whenever the loader learns a declarable field that changes a
+#: verdict, and say in docs/floorplan-intent.md which field arrived. Do NOT
+#: bump it for a field nothing grades.
+READER_VERSION = 1
+
 _TOP_LEVEL_KEYS = {
     'schema', 'kind', 'board', 'units', 'envelope', 'defaults', 'blocks',
     'keepouts', 'edge_connectors', 'decaps', 'must_lock', 'legality_budget',
-    'health', 'severity', 'context', 'overlap_waivers',
+    'health', 'severity', 'context', 'overlap_waivers', 'min_reader',
 }
 _BLOCK_KEYS = {'name', 'group', 'refs', 'zone', 'side', 'exclusive',
                'tolerance_mm', 'note'}
@@ -346,6 +358,25 @@ def intent_from_dict(raw: Dict, source_path: str = '') -> Intent:
     if schema != SCHEMA_VERSION:
         raise IntentError(
             f"schema {schema!r}: this build reads schema {SCHEMA_VERSION}")
+    # Refused BEFORE anything else is read: the point of the field is that a
+    # build which cannot act on the file must not grade it, and grading it
+    # halfway is the same wrong answer as grading it fully.
+    #
+    # Note the field works in the backwards direction from the day it lands:
+    # a build older than this one refuses `min_reader` as an unknown
+    # top-level key, which is exactly the intended answer.
+    min_reader = raw.get('min_reader')
+    if min_reader is not None:
+        if not isinstance(min_reader, int) or isinstance(min_reader, bool):
+            raise IntentError(
+                f"min_reader {min_reader!r}: expected an integer")
+        if min_reader > READER_VERSION:
+            raise IntentError(
+                f"min_reader {min_reader}: this build is reader "
+                f"{READER_VERSION}. The intent declares a claim this build "
+                f"would not act on, and grading it would report clean on a "
+                f"constraint that was never checked -- upgrade instead")
+
     kind = raw.get('kind')
     if kind != KIND:
         # A round sidecar or a lock-advisor dump handed in by mistake reads as

--- a/tests/test_549_floorplan_grade.py
+++ b/tests/test_549_floorplan_grade.py
@@ -169,14 +169,20 @@ def _emitted_connector_keys():
                 keys |= dict_keys(node.value)
         elif isinstance(node, ast.AugAssign) and is_entry(node.target):
             keys.add(node.target.slice.value)
-        # conns.append({...})
-        elif (isinstance(node, ast.Call)
-              and isinstance(node.func, ast.Attribute)
-              and node.func.attr == 'append'
-              and isinstance(node.func.value, ast.Name)
-              and node.func.value.id == 'conns'
-              and node.args and isinstance(node.args[0], ast.Dict)):
-            keys |= dict_keys(node.args[0])
+        # conns.append({...}), entry.update({...}), entry.setdefault('k', ..)
+        elif isinstance(node, ast.Call) and isinstance(node.func,
+                                                       ast.Attribute):
+            recv = node.func.value
+            named = isinstance(recv, ast.Name) and recv.id in ('conns', 'entry')
+            if not named or not node.args:
+                continue
+            if node.func.attr in ('append', 'update') and isinstance(
+                    node.args[0], ast.Dict):
+                keys |= dict_keys(node.args[0])
+            elif node.func.attr == 'setdefault' and isinstance(
+                    node.args[0], ast.Constant) and isinstance(
+                    node.args[0].value, str):
+                keys.add(node.args[0].value)
     return keys
 
 

--- a/tests/test_549_floorplan_grade.py
+++ b/tests/test_549_floorplan_grade.py
@@ -88,6 +88,173 @@ def test_an_emitted_intent_grades_clean_on_every_tracked_board():
     print(f"  PASS: {checked} boards emit -> grade with zero errors")
 
 
+def _stray_keys(doc):
+    """Every key an emitted intent writes that the loader would now refuse.
+
+    The emitter and the loader's key sets (#710) are two halves of one
+    contract with nothing else holding them together: `emit_intent` writes
+    `suspect`, `overhang_capped`, `class` and friends that no rule reads, so
+    a set that forgot one would not fail any rule -- it would fail months
+    later, on an artifact that used to load.
+    """
+    from placement.floorplan import (_BLOCK_KEYS, _BUDGET_KEYS, _CORRIDOR_KEYS,
+                                     _DECAP_KEYS, _DEFAULTS_KEYS,
+                                     _EDGE_CONNECTOR_KEYS, _ENVELOPE_KEYS,
+                                     _HEALTH_KEYS, _KEEPOUT_KEYS,
+                                     _OVERHANG_KEYS, _TOP_LEVEL_KEYS)
+    out = []
+
+    def chk(obj, allowed, where):
+        if isinstance(obj, dict):
+            out.extend(f"{where}.{k}" for k in sorted(set(obj) - set(allowed)))
+
+    chk(doc, _TOP_LEVEL_KEYS, 'top')
+    chk(doc.get('envelope'), _ENVELOPE_KEYS, 'envelope')
+    chk(doc.get('defaults'), _DEFAULTS_KEYS, 'defaults')
+    chk(doc.get('decaps'), _DECAP_KEYS, 'decaps')
+    chk(doc.get('legality_budget'), _BUDGET_KEYS, 'legality_budget')
+    chk(doc.get('health'), _HEALTH_KEYS, 'health')
+    for i, spec in enumerate((doc.get('health') or {}).get('bus_corridors')
+                             or []):
+        chk(spec, _CORRIDOR_KEYS, f'health.bus_corridors[{i}]')
+    for i, b in enumerate(doc.get('blocks') or []):
+        chk(b, _BLOCK_KEYS, f'blocks[{i}]')
+    for i, k in enumerate(doc.get('keepouts') or []):
+        chk(k, _KEEPOUT_KEYS, f'keepouts[{i}]')
+    for i, c in enumerate(doc.get('edge_connectors') or []):
+        chk(c, _EDGE_CONNECTOR_KEYS, f'edge_connectors[{i}]')
+        chk(c.get('overhang_mm'), _OVERHANG_KEYS,
+            f'edge_connectors[{i}].overhang_mm')
+    return out
+
+
+def _emitted_connector_keys():
+    """Every key `emit_intent` can write on an `edge_connectors[]` entry, read
+    from the SOURCE rather than from a run.
+
+    The dynamic check below only sees branches a test board reaches, and
+    `suspect` / `suspect_reason` need rigid pattern vectors -- which is a
+    property of a DAMAGED corpus board, not of anything tracked here. A source
+    scan sees every branch; the dynamic half proves the keys are the ones a
+    real emission actually produces. Neither alone is the guard.
+    """
+    import ast
+    import inspect
+    import textwrap
+    from placement import floorplan as fp
+    tree = ast.parse(textwrap.dedent(inspect.getsource(fp.emit_intent)))
+
+    def dict_keys(node):
+        return {k.value for k in node.keys
+                if isinstance(k, ast.Constant) and isinstance(k.value, str)}
+
+    def is_entry(node):
+        return (isinstance(node, ast.Subscript)
+                and isinstance(node.value, ast.Name)
+                and node.value.id == 'entry'
+                and isinstance(node.slice, ast.Constant)
+                and isinstance(node.slice.value, str))
+
+    keys = set()
+    for node in ast.walk(tree):
+        # entry['k'] = ...   and   entry['k'] += ...
+        if isinstance(node, ast.Assign):
+            for t in node.targets:
+                if is_entry(t):
+                    keys.add(t.slice.value)
+            # entry = {...}
+            if (len(node.targets) == 1 and isinstance(node.targets[0], ast.Name)
+                    and node.targets[0].id == 'entry'
+                    and isinstance(node.value, ast.Dict)):
+                keys |= dict_keys(node.value)
+        elif isinstance(node, ast.AugAssign) and is_entry(node.target):
+            keys.add(node.target.slice.value)
+        # conns.append({...})
+        elif (isinstance(node, ast.Call)
+              and isinstance(node.func, ast.Attribute)
+              and node.func.attr == 'append'
+              and isinstance(node.func.value, ast.Name)
+              and node.func.value.id == 'conns'
+              and node.args and isinstance(node.args[0], ast.Dict)):
+            keys |= dict_keys(node.args[0])
+    return keys
+
+
+def _damaged_board(td):
+    """A board with two parts stacked well outside the outline.
+
+    That is what drives `emit_intent` down its capped-overhang branch --
+    the one that writes `overhang_capped` and `observed_overhang_mm`, keys
+    no healthy tracked board ever emits.
+    """
+    from placement.writer import write_placed_output
+    src = _board('splitflap_driver')
+    pcb = parse_kicad_pcb(src)
+    b = pcb.board_info.board_bounds
+    small = sorted(r for r, f in pcb.footprints.items()
+                   if r[0] in 'RC' and len(f.pads) == 2)[:2]
+    assert len(small) == 2, small
+    x, y = b[2] + 6.0, (b[1] + b[3]) / 2.0
+    dst = os.path.join(td, 'damaged.kicad_pcb')
+    assert write_placed_output(src, dst, [
+        {'reference': r, 'new_x': x, 'new_y': y, 'new_rotation': 0.0}
+        for r in small], pcb_data=pcb)
+    return dst
+
+
+def test_what_emit_writes_is_what_the_loader_accepts():
+    """The #710 drift detector.
+
+    `emit_intent` and the loader's key sets are two halves of one contract
+    with nothing else holding them together: the emitter writes `suspect`,
+    `overhang_capped`, `class` and friends that no RULE reads, so a set that
+    forgot one would fail no rule here -- it would fail months later, on an
+    artifact that used to load.
+    """
+    checked, rare = 0, set()
+    for name in ROUND_TRIP:
+        p = _board(name)
+        if not os.path.exists(p):
+            continue
+        pcb = parse_kicad_pcb(p)
+        for classes in (False, True):
+            doc = emit_intent(pcb, p, declare_classes=classes)
+            assert not _stray_keys(doc), (name, classes, _stray_keys(doc))
+            intent_from_dict(doc)          # and the loader itself agrees
+            for c in doc.get('edge_connectors') or []:
+                rare |= set(c) - {'ref', 'edge', 'overhang_mm'}
+            checked += 1
+    assert checked >= 10, f"only {checked} emissions checked"
+
+    # The capped branch, which no healthy board reaches.
+    with tempfile.TemporaryDirectory() as td:
+        dmg = _damaged_board(td)
+        doc = emit_intent(parse_kicad_pcb(dmg), dmg, declare_classes=True)
+        assert not _stray_keys(doc), _stray_keys(doc)
+        intent_from_dict(doc)
+        for c in doc.get('edge_connectors') or []:
+            rare |= set(c) - {'ref', 'edge', 'overhang_mm'}
+
+    # Anti-vacuity: without this, a run that emitted only `ref`/`edge` would
+    # pass while checking none of the keys the test exists for.
+    assert {'class', 'source', 'overhang_capped',
+            'observed_overhang_mm'} <= rare, sorted(rare)
+
+    # And the branches no board here can reach, from the source. `emit_intent`
+    # builds its BLOCK entries with the same local name, so the scan sees both
+    # vocabularies and is checked against both; which key belongs to which
+    # level is what the dynamic half above pins, on every level a board
+    # reaches.
+    from placement.floorplan import _BLOCK_KEYS, _EDGE_CONNECTOR_KEYS
+    written = _emitted_connector_keys()
+    known = _EDGE_CONNECTOR_KEYS | _BLOCK_KEYS
+    assert {'suspect', 'suspect_reason'} <= written, sorted(written)
+    assert written <= known, sorted(written - known)
+    print(f"  PASS: {checked + 1} emissions carry only accepted keys; "
+          f"{len(written)} emitter-source keys all known "
+          f"(seen live: {', '.join(sorted(rare))})")
+
+
 def test_the_round_trip_is_not_vacuous():
     """Guards the failure the round trip cannot see: every rule skipped."""
     raw = _emit()
@@ -485,6 +652,7 @@ def test_state_signals_reach_the_summary():
 
 TESTS = [
     test_an_emitted_intent_grades_clean_on_every_tracked_board,
+    test_what_emit_writes_is_what_the_loader_accepts,
     test_the_round_trip_is_not_vacuous,
     test_a_part_pushed_out_of_its_zone_is_caught_with_the_distance,
     test_an_unresolved_block_is_an_error_not_a_silent_pass,

--- a/tests/test_549_floorplan_schema.py
+++ b/tests/test_549_floorplan_schema.py
@@ -24,6 +24,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'py_router'))  # placement split
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'py_tools'))  # placement split
 
+from placement import floorplan as fp
 from placement.floorplan import (ERROR, KIND, READER_VERSION, RULES,
                                  SCHEMA_VERSION, WARN, Intent, IntentError,
                                  _SEVERITY_KEYS, intent_from_dict, load_intent,
@@ -103,6 +104,132 @@ def test_unknown_keys_are_refused_not_ignored():
     print("  PASS: unknown top-level and per-block keys both refused")
 
 
+#: Matches `rule='x'` and `rule="x"` alike. Built here rather than inline so
+#: the pattern's own quoting stays readable.
+RULE_LITERAL = "rule=[" + chr(39) + chr(34) + "](" + chr(92) + "w+)[" \
+    + chr(39) + chr(34) + "]"
+
+#: The intent vocabulary, stated here rather than derived from the module, so
+#: that GROWING a key set is as loud as shrinking one. Both directions are
+#: defects: a shrunk set refuses a key real intent files carry, and a grown one
+#: re-admits a key nothing reads -- which is #710 itself. The emitter-driven
+#: detector in test_549_floorplan_grade.py cannot see either, because
+#: `emit_intent` never writes a `health`, `decaps` or `keepouts` object at all.
+KEY_SETS = {
+    '_TOP_LEVEL_KEYS': {
+        'schema', 'kind', 'board', 'units', 'min_reader', 'envelope',
+        'defaults', 'blocks', 'keepouts', 'edge_connectors', 'decaps',
+        'must_lock', 'legality_budget', 'health', 'severity', 'context',
+        'overlap_waivers'},
+    '_ENVELOPE_KEYS': {'rect', 'tolerance_mm'},
+    '_DEFAULTS_KEYS': {'zone_tolerance_mm'},
+    '_BLOCK_KEYS': {'name', 'group', 'refs', 'zone', 'side', 'exclusive',
+                    'tolerance_mm', 'note', 'context'},
+    '_KEEPOUT_KEYS': {'name', 'rect', 'circle', 'sides', 'allow', 'note',
+                      'context'},
+    '_EDGE_CONNECTOR_KEYS': {
+        'ref', 'edge', 'overhang_mm', 'max_setback_mm', 'class', 'source',
+        'note', 'suspect', 'suspect_reason', 'overhang_capped',
+        'observed_overhang_mm', 'context'},
+    '_OVERHANG_KEYS': {'min', 'max'},
+    '_DECAP_KEYS': {'max_distance_mm', 'exempt', 'search_radius_mm'},
+    '_HEALTH_KEYS': {'bus_corridors', 'classes', 'zoned_blocks',
+                     'affinity_exempt_nets', 'affinity_exempt_net_ids',
+                     'ignore_net_ids', 'max_fanout', 'block_displacement_mm'},
+    '_CORRIDOR_KEYS': {'name', 'nets', 'width_mm'},
+    '_BUDGET_KEYS': {'overlap_area', 'oob_count', 'oob_amount'},
+    '_WAIVER_KEYS': {'pair', 'reason', 'context'},
+}
+
+
+def test_the_key_sets_are_exactly_what_is_documented():
+    """A change detector on the vocabulary itself, in BOTH directions.
+
+    Shrinking a set is the regression this whole change risks -- it refuses a
+    key that real intent files carry. Growing one silently re-admits a key
+    nothing reads, which is #710 over again. Neither is visible to the
+    emitter-driven detector in the grade test, which only sees keys
+    `emit_intent` writes.
+    """
+    for name, expected in sorted(KEY_SETS.items()):
+        actual = set(getattr(fp, name))
+        assert actual == expected, (name, sorted(actual ^ expected))
+    doc = os.path.join(os.path.dirname(os.path.dirname(
+        os.path.abspath(__file__))), 'docs', 'floorplan-intent.md')
+    with open(doc, encoding='utf-8') as fh:
+        text = fh.read()
+    undocumented = sorted({k for keys in KEY_SETS.values() for k in keys
+                           if f'`{k}`' not in text})
+    assert not undocumented, undocumented
+    print(f"  PASS: {len(KEY_SETS)} key sets pinned exactly; "
+          f"{sum(len(v) for v in KEY_SETS.values())} names all documented")
+
+
+def test_an_intent_using_every_known_key_loads():
+    """The other half: every key in every set is ACCEPTED.
+
+    Pinning the sets catches a set that changed; this catches a set that was
+    right while the code around it refused the key anyway -- and it is the
+    only test that exercises `health`, `decaps` and `keepouts` keys through
+    the loader at all, since `emit_intent` never writes those objects.
+    """
+    raw = {
+        'schema': SCHEMA_VERSION, 'kind': KIND, 'units': 'mm',
+        'board': 'b.kicad_pcb', 'min_reader': READER_VERSION,
+        'envelope': {'rect': [0, 0, 100, 80], 'tolerance_mm': 0.4},
+        'defaults': {'zone_tolerance_mm': 0.6},
+        'blocks': [{'name': 'power', 'group': 'sheet:1', 'refs': ['U3'],
+                    'zone': [2, 2, 40, 30], 'side': 'F', 'exclusive': True,
+                    'tolerance_mm': 0.7, 'note': 'n', 'context': {'why': 'w'}}],
+        'keepouts': [{'name': 'k', 'rect': [0, 0, 6, 6], 'sides': ['F'],
+                      'allow': ['MH1'], 'note': 'n', 'context': {'why': 'w'}},
+                     {'name': 'k2', 'circle': [50, 5, 8], 'sides': ['F', 'B'],
+                      'allow': [], 'note': '', 'context': {}}],
+        'edge_connectors': [{
+            'ref': 'J1', 'edge': 'east',
+            'overhang_mm': {'min': 0.0, 'max': 1.5}, 'max_setback_mm': 2.0,
+            'class': 'edge_receptacle', 'source': 'auto-class', 'note': 'n',
+            'suspect': True, 'suspect_reason': 'r', 'overhang_capped': True,
+            'observed_overhang_mm': 9.0, 'context': {'why': 'w'}}],
+        'decaps': {'max_distance_mm': 2.5, 'exempt': ['C99'],
+                   'search_radius_mm': 6.0},
+        'must_lock': ['MH*'],
+        'legality_budget': {'overlap_area': 1.0, 'oob_count': 2,
+                            'oob_amount': 3.0},
+        'health': {'bus_corridors': [{'name': 'c', 'nets': ['/D*'],
+                                      'width_mm': 8.0}],
+                   'classes': {'critical': ['/D*']}, 'zoned_blocks': ['power'],
+                   'affinity_exempt_nets': ['/GND'],
+                   'affinity_exempt_net_ids': [3], 'ignore_net_ids': [1, 2],
+                   'max_fanout': 30, 'block_displacement_mm': 4.0},
+        'severity': {name: WARN for name in sorted(_SEVERITY_KEYS)},
+        'context': {'note': 'read-only'},
+        'overlap_waivers': [{'pair': ['U1', 'U2'], 'reason': 'net tie',
+                             'context': {'why': 'w'}}],
+    }
+    # Every key of every set must appear above, or this proves less than it
+    # claims -- the point is coverage of the vocabulary, not of a sample.
+    seen = set(raw) | set(raw['envelope']) | set(raw['defaults'])
+    seen |= set(raw['blocks'][0]) | set(raw['decaps']) | set(raw['health'])
+    seen |= set(raw['legality_budget']) | set(raw['edge_connectors'][0])
+    seen |= set(raw['edge_connectors'][0]['overhang_mm'])
+    seen |= set(raw['health']['bus_corridors'][0])
+    seen |= set(raw['overlap_waivers'][0])
+    for k in raw['keepouts']:
+        seen |= set(k)
+    missing = sorted({k for keys in KEY_SETS.values() for k in keys} - seen)
+    assert not missing, missing
+
+    i = intent_from_dict(raw)
+    assert i.blocks[0].tolerance_mm == 0.7 and i.blocks[0].exclusive
+    assert i.decaps['search_radius_mm'] == 6.0
+    assert i.health['max_fanout'] == 30
+    assert i.legality_budget['oob_amount'] == 3.0
+    assert i.keepouts[0]['allow'] == ('MH1',)
+    assert i.edge_connectors[0]['max_setback_mm'] == 2.0
+    print(f"  PASS: an intent using all {len(seen)} known keys loads")
+
+
 def test_min_reader_refuses_a_build_that_would_ignore_the_claim():
     """#710, the compatibility half.
 
@@ -116,19 +243,54 @@ def test_min_reader_refuses_a_build_that_would_ignore_the_claim():
     assert intent_from_dict(_base(min_reader=READER_VERSION))
     assert intent_from_dict(_base(min_reader=1))
     msg = _rejects(_base(min_reader=READER_VERSION + 1), "a future reader")
-    assert str(READER_VERSION + 1) in msg and str(READER_VERSION) in msg, msg
-    for bad in ('2', 2.5, True, [2]):
-        assert 'min_reader' in _rejects(_base(min_reader=bad),
-                                        f"min_reader={bad!r}")
-    # It is refused BEFORE the rest of the file is read: a build that cannot
-    # act on the claim must not report on the board at all.
-    msg = _rejects({'schema': SCHEMA_VERSION, 'kind': KIND,
-                    'min_reader': READER_VERSION + 1,
-                    'blocks': [{'name': 'x', 'zone': [0, 0, 1, 1]}]},
-                   "a future reader with a malformed block")
-    assert 'min_reader' in msg, msg
+    # Phrases, not digits. `str(RV+1) in msg and str(RV) in msg` is
+    # `'2' in msg and '1' in msg` at RV=1, which a message with the two
+    # numbers SWAPPED satisfies exactly as well. (It did.)
+    assert f"min_reader {READER_VERSION + 1}" in msg, msg
+    assert f"reader {READER_VERSION}" in msg, msg
+    # Refused for its TYPE, distinctly from being too new: a gate that leaked
+    # floats still refuses 2.5 as a future reader, and a test that only looks
+    # for 'min_reader' cannot tell the two apart. (It could not.)
+    for bad in ('2', 2.5, True, [2], 0.5):
+        assert 'expected an integer' in _rejects(
+            _base(min_reader=bad), f"min_reader={bad!r}")
+    # It outranks EVERY other check, including the unknown-key and schema
+    # ones. This is the case that matters and the one that was wrong first: a
+    # build declaring a new field almost always declares a new TOP-LEVEL one,
+    # so if the key set is checked first the author gets "unknown key(s)
+    # zones" and goes hunting for a typo instead of upgrading.
+    for extra, why in (
+            ({'blocks': [{'name': 'x', 'zone': [0, 0, 1, 1]}]},
+             "a malformed block"),
+            ({'zones': []}, "a future top-level key"),
+            ({'schema': SCHEMA_VERSION + 1}, "a future schema"),
+            ({'kind': 'lock-advice'}, "the wrong kind")):
+        raw = {'schema': SCHEMA_VERSION, 'kind': KIND,
+               'min_reader': READER_VERSION + 1}
+        raw.update(extra)
+        msg = _rejects(raw, f"a future reader with {why}")
+        # The upgrade PHRASE, not the word `min_reader`: that word is in the
+        # Known: list of every top-level unknown-key message, so asserting it
+        # passed even when the key gate ran first and won. (It did.)
+        assert f"min_reader {READER_VERSION + 1}" in msg, (why, msg)
+        assert 'upgrade' in msg, (why, msg)
     print(f"  PASS: reader {READER_VERSION} loads min_reader<={READER_VERSION}"
           f", refuses {READER_VERSION + 1} before reading further")
+
+
+def test_a_non_string_key_is_an_intent_error_not_a_TypeError():
+    """`intent_from_dict` is public and takes a dict, not JSON.
+
+    The place_* mains catch ValueError (IntentError is one) and turn it into
+    exit 2; a TypeError from sorting or joining a non-string key would
+    traceback straight past them.
+    """
+    for raw, where in (({'severity': {1: WARN}}, 'severity'),
+                       ({'decaps': {2: 3}}, 'decaps'),
+                       ({'envelope': {None: 1}}, 'envelope')):
+        msg = _rejects(_base(**raw), f"a non-string key in {where}")
+        assert where in msg, (where, msg)
+    print("  PASS: a non-string key refuses as an IntentError, not TypeError")
 
 
 def test_unknown_nested_keys_are_refused_not_ignored():
@@ -145,35 +307,47 @@ def test_unknown_nested_keys_are_refused_not_ignored():
     """
     cases = [
         (_base(keepouts=[{'name': 'k', 'rect': [0, 0, 1, 1], 'sids': ['F']}]),
-         'sids', 'sides'),
+         'sids', 'sides', 'keepouts[0]'),
         (_base(edge_connectors=[{'ref': 'J1', 'max_setback': 2.0}]),
-         'max_setback', 'max_setback_mm'),
+         'max_setback', 'max_setback_mm', 'edge_connectors[0]'),
         (_base(edge_connectors=[{'ref': 'J1',
                                  'overhang_mm': {'min': 0.0, 'maximum': 1.0}}]),
-         'maximum', 'max'),
+         'maximum', 'max', 'overhang_mm'),
         (_base(decaps={'max_distance_mm': 2.5, 'exempts': ['C9']}),
-         'exempts', 'exempt'),
+         'exempts', 'exempt', 'decaps'),
         (_base(defaults={'zone_tolerance': 0.5}),
-         'zone_tolerance', 'zone_tolerance_mm'),
+         'zone_tolerance', 'zone_tolerance_mm', 'defaults'),
         (_base(health={'bus_corridor': []}),
-         'bus_corridor', 'bus_corridors'),
+         'bus_corridor', 'bus_corridors', 'health'),
         (_base(health={'bus_corridors': [{'nets': ['/D*'], 'width': 8.0}]}),
-         'width', 'width_mm'),
+         'width', 'width_mm', 'health.bus_corridors[0]'),
         (_base(envelope={'rect': [0, 0, 100, 80], 'tolerance': 0.5}),
-         'tolerance', 'tolerance_mm'),
+         'tolerance', 'tolerance_mm', 'envelope'),
         (_base(overlap_waivers=[{'pair': ['U1', 'U2'], 'because': 'by design'}]),
-         'because', 'reason'),
+         'because', 'reason', 'overlap_waivers[0]'),
+        (_base(blocks=[{'name': 'b', 'refs': ['U1'], 'exclusiv': True}]),
+         'exclusiv', 'exclusive', 'blocks[0]'),
+        (_base(legality_budget={'oob_counts': 1}),
+         'oob_counts', 'oob_count', 'legality_budget'),
     ]
     # Split on `Known:` before asserting. Checking both halves of the raw
     # message would pass vacuously on every pair here -- `width` is a
     # substring of `width_mm`, `ref` of `reff` -- so the typo has to appear
     # in the REFUSAL half and the correction in the KNOWN half.
-    for raw, typo, meant in cases:
+    for raw, typo, meant, where in cases:
         msg = _rejects(raw, f"{typo} instead of {meant}")
         refused, _, known = msg.partition('Known:')
         assert known, f"message carries no `Known:` list: {msg}"
         assert typo in refused, (typo, msg)
         assert meant in known.replace(',', ' ').split(), (meant, msg)
+        # WHICH object. Without this the path can name a different object
+        # entirely and every case still passes -- which defeats the point of
+        # the message. (It did: relabelling the corridor check `blocks[9]`
+        # survived all of them.)
+        assert where in refused, (where, msg)
+        # ...and ONLY the typo is refused, so a set that had lost a
+        # legitimate key would not hide behind the same assertions.
+        assert refused.count(',') == 0, ("more than one key refused", msg)
     # A typo'd `ref` reports the unknown key, not a missing `ref` -- the
     # author is looking at the key they DID write.
     msg = _rejects(_base(edge_connectors=[{'reff': 'J1'}]), "reff")
@@ -194,8 +368,23 @@ def test_a_nested_object_must_be_an_object():
         msg = _rejects(_base(**{key: value}), f"{key}={value!r}")
         assert key in msg, (key, msg)
         assert 'object' in msg, (key, msg)
-    print("  PASS: 7 nested objects refuse a list/scalar instead of crashing "
-          "later")
+    # Entries in a LIST get the same treatment, named by index. These guards
+    # are separate code from `_obj` -- the bus_corridors one is new here and
+    # had no coverage at all.
+    for raw, where in (
+            (_base(blocks=['U1']), 'blocks[0]'),
+            (_base(keepouts=['k']), 'keepouts[0]'),
+            (_base(edge_connectors=['J1']), 'edge_connectors[0]'),
+            (_base(health={'bus_corridors': ['/D*']}),
+             'health.bus_corridors[0]')):
+        msg = _rejects(raw, f"{where} as a non-object")
+        assert where in msg and 'object' in msg, (where, msg)
+    # And the one nested object inside `context`, which IS read back.
+    msg = _rejects(_base(context={'budget_withheld': []}),
+                   'context.budget_withheld as a list')
+    assert 'budget_withheld' in msg and 'object' in msg, msg
+    print("  PASS: 7 objects + 4 list entries + context.budget_withheld all "
+          "refuse a list/scalar instead of crashing later")
 
 
 def test_context_is_deliberately_open():
@@ -231,6 +420,12 @@ def test_an_entry_carries_its_own_context_slot():
                           'context': ctx}]))
     assert i.keepouts[0]['context'] == ctx
     assert i.edge_connectors[0]['context'] == ctx
+    # blocks[] too. It is the one entry kind rebuilt into a dataclass rather
+    # than kept as its raw dict, so accepting the key and dropping it was
+    # exactly the #710 defect one level down -- and the earlier version of
+    # this test passed a block context and never looked at it.
+    assert i.blocks[0].context == ctx
+    assert i.overlap_waivers[0]['context'] == ctx
     # Free-form, but still an object -- a list means the author meant
     # something else, while an unknown key inside means nothing at all.
     for raw, where in (
@@ -260,9 +455,12 @@ def test_severity_keys_are_checked_against_the_rule_names():
     asserts every name in the real vocabulary still loads, not just that a
     typo is refused.
     """
-    msg = _rejects(_base(severity={'decap_distanc': WARN}), "a typo'd rule")
+    # A non-PREFIX typo. `decap_distanc` is a prefix of `decap_distance`, so
+    # asserting it appears in the refused half also matched a message that
+    # only ever printed the suggestion. (It did.)
+    msg = _rejects(_base(severity={'decap_distanse': WARN}), "a typo'd rule")
     refused, _, known = msg.partition('Known:')
-    assert 'decap_distanc' in refused, msg
+    assert 'decap_distanse' in refused, msg
     assert 'decap_distance' in known.replace(',', ' ').split(), msg
     # Stated here as a literal, NOT iterated off _SEVERITY_KEYS: a test that
     # loops over the set under test just tests fewer names when the set
@@ -291,9 +489,13 @@ def test_every_violation_rule_name_is_settable():
     src = os.path.join(os.path.dirname(os.path.dirname(
         os.path.abspath(__file__))), 'py_placer', 'placement', 'floorplan.py')
     with open(src, encoding='utf-8') as fh:
-        names = set(re.findall(r"rule='([a-z_]+)'", fh.read()))
-    assert len(names) >= 10, names
-    assert names <= _SEVERITY_KEYS, sorted(names - _SEVERITY_KEYS)
+        # BOTH quote styles, and any identifier: scanning only single-quoted
+        # `rule=` missed a rule written with double quotes, and the
+        # `len >= 10` floor let two of the twelve go missing without a word.
+        names = set(re.findall(RULE_LITERAL, fh.read()))
+    # Exact equality, not a floor and not a subset: every settable name must
+    # be raised somewhere, and every name raised must be settable.
+    assert names == set(_SEVERITY_KEYS), sorted(names ^ set(_SEVERITY_KEYS))
     print(f"  PASS: all {len(names)} violation rule names are settable")
 
 
@@ -440,7 +642,10 @@ TESTS = [
     test_the_wrong_file_is_refused_by_kind,
     test_schema_version_is_enforced,
     test_unknown_keys_are_refused_not_ignored,
+    test_the_key_sets_are_exactly_what_is_documented,
+    test_an_intent_using_every_known_key_loads,
     test_min_reader_refuses_a_build_that_would_ignore_the_claim,
+    test_a_non_string_key_is_an_intent_error_not_a_TypeError,
     test_unknown_nested_keys_are_refused_not_ignored,
     test_a_nested_object_must_be_an_object,
     test_context_is_deliberately_open,

--- a/tests/test_549_floorplan_schema.py
+++ b/tests/test_549_floorplan_schema.py
@@ -24,9 +24,9 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'py_router'))  # placement split
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'py_tools'))  # placement split
 
-from placement.floorplan import (ERROR, KIND, RULES, SCHEMA_VERSION, WARN,
-                                 Intent, IntentError, _SEVERITY_KEYS,
-                                 intent_from_dict, load_intent,
+from placement.floorplan import (ERROR, KIND, READER_VERSION, RULES,
+                                 SCHEMA_VERSION, WARN, Intent, IntentError,
+                                 _SEVERITY_KEYS, intent_from_dict, load_intent,
                                  validate_intent)
 
 
@@ -101,6 +101,34 @@ def test_unknown_keys_are_refused_not_ignored():
                    "zones instead of zone")
     assert 'zones' in msg, msg
     print("  PASS: unknown top-level and per-block keys both refused")
+
+
+def test_min_reader_refuses_a_build_that_would_ignore_the_claim():
+    """#710, the compatibility half.
+
+    Refusing unknown nested keys makes an older build fail on a field it does
+    not know -- but only if the field is NEW. `min_reader` covers the other
+    case: a field whose spelling an old build accepts while its MEANING
+    changed, and any file whose author wants "refuse" rather than "grade it
+    without this". `schema` cannot do that job: it is matched exactly, so
+    bumping it invalidates every existing intent at once.
+    """
+    assert intent_from_dict(_base(min_reader=READER_VERSION))
+    assert intent_from_dict(_base(min_reader=1))
+    msg = _rejects(_base(min_reader=READER_VERSION + 1), "a future reader")
+    assert str(READER_VERSION + 1) in msg and str(READER_VERSION) in msg, msg
+    for bad in ('2', 2.5, True, [2]):
+        assert 'min_reader' in _rejects(_base(min_reader=bad),
+                                        f"min_reader={bad!r}")
+    # It is refused BEFORE the rest of the file is read: a build that cannot
+    # act on the claim must not report on the board at all.
+    msg = _rejects({'schema': SCHEMA_VERSION, 'kind': KIND,
+                    'min_reader': READER_VERSION + 1,
+                    'blocks': [{'name': 'x', 'zone': [0, 0, 1, 1]}]},
+                   "a future reader with a malformed block")
+    assert 'min_reader' in msg, msg
+    print(f"  PASS: reader {READER_VERSION} loads min_reader<={READER_VERSION}"
+          f", refuses {READER_VERSION + 1} before reading further")
 
 
 def test_unknown_nested_keys_are_refused_not_ignored():
@@ -375,6 +403,7 @@ TESTS = [
     test_the_wrong_file_is_refused_by_kind,
     test_schema_version_is_enforced,
     test_unknown_keys_are_refused_not_ignored,
+    test_min_reader_refuses_a_build_that_would_ignore_the_claim,
     test_unknown_nested_keys_are_refused_not_ignored,
     test_a_nested_object_must_be_an_object,
     test_context_is_deliberately_open,

--- a/tests/test_549_floorplan_schema.py
+++ b/tests/test_549_floorplan_schema.py
@@ -24,8 +24,9 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'py_router'))  # placement split
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'py_tools'))  # placement split
 
-from placement.floorplan import (ERROR, KIND, SCHEMA_VERSION, WARN, Intent,
-                                 IntentError, intent_from_dict, load_intent,
+from placement.floorplan import (ERROR, KIND, RULES, SCHEMA_VERSION, WARN,
+                                 Intent, IntentError, _SEVERITY_KEYS,
+                                 intent_from_dict, load_intent,
                                  validate_intent)
 
 
@@ -183,6 +184,54 @@ def test_context_is_deliberately_open():
     print("  PASS: context accepts arbitrary keys; budget_withheld still read")
 
 
+def test_severity_keys_are_checked_against_the_rule_names():
+    """#710: `severity` validated its VALUES and never its keys.
+
+    The vocabulary is 12 names, not the 9 in `RULES`: three findings are
+    raised outside the rules loop (`validate_intent` raises two,
+    `resolve_blocks` one) and an intent has always been allowed to set their
+    severity. Validating against `RULES` alone would refuse
+    `{"block_unresolved": "warn"}`, which is legal today -- so the test
+    asserts every name in the real vocabulary still loads, not just that a
+    typo is refused.
+    """
+    msg = _rejects(_base(severity={'decap_distanc': WARN}), "a typo'd rule")
+    refused, _, known = msg.partition('Known:')
+    assert 'decap_distanc' in refused, msg
+    assert 'decap_distance' in known.replace(',', ' ').split(), msg
+    # Stated here as a literal, NOT iterated off _SEVERITY_KEYS: a test that
+    # loops over the set under test just tests fewer names when the set
+    # shrinks, and passes. (It did.)
+    expected = {n for n, _ in RULES} | {'intent_zone_outside_envelope',
+                                        'intent_zone_overlap',
+                                        'block_unresolved'}
+    assert _SEVERITY_KEYS == expected, sorted(_SEVERITY_KEYS ^ expected)
+    for name in sorted(expected):
+        i = intent_from_dict(_base(severity={name: WARN}))
+        assert i.severity_of(name) == WARN, name
+    print(f"  PASS: {len(expected)} settable rule names accepted, "
+          f"a typo refused (RULES has {len(RULES)})")
+
+
+def test_every_violation_rule_name_is_settable():
+    """A change detector for the next rule.
+
+    A rule whose name is not in `_SEVERITY_KEYS` cannot be demoted to warn --
+    and, now that severity keys are refused, an intent trying to would be
+    told the name does not exist. Read off the SOURCE so a new
+    `Violation(rule='...')` is caught wherever it is raised, including the
+    paths that never reach the RULES loop.
+    """
+    import re
+    src = os.path.join(os.path.dirname(os.path.dirname(
+        os.path.abspath(__file__))), 'py_placer', 'placement', 'floorplan.py')
+    with open(src, encoding='utf-8') as fh:
+        names = set(re.findall(r"rule='([a-z_]+)'", fh.read()))
+    assert len(names) >= 10, names
+    assert names <= _SEVERITY_KEYS, sorted(names - _SEVERITY_KEYS)
+    print(f"  PASS: all {len(names)} violation rule names are settable")
+
+
 def test_a_block_needs_refs_or_group():
     msg = _rejects(_base(blocks=[{'name': 'x', 'zone': [0, 0, 1, 1]}]),
                    "a block naming no members")
@@ -329,6 +378,8 @@ TESTS = [
     test_unknown_nested_keys_are_refused_not_ignored,
     test_a_nested_object_must_be_an_object,
     test_context_is_deliberately_open,
+    test_severity_keys_are_checked_against_the_rule_names,
+    test_every_violation_rule_name_is_settable,
     test_a_block_needs_refs_or_group,
     test_refs_as_a_bare_string_is_refused,
     test_enumerations_are_checked,

--- a/tests/test_549_floorplan_schema.py
+++ b/tests/test_549_floorplan_schema.py
@@ -102,6 +102,87 @@ def test_unknown_keys_are_refused_not_ignored():
     print("  PASS: unknown top-level and per-block keys both refused")
 
 
+def test_unknown_nested_keys_are_refused_not_ignored():
+    """#710: the same principle, one level down.
+
+    The loader used to be strict at exactly two levels -- top-level and
+    `blocks[]` -- and permissive everywhere else, so a typo'd key inside a
+    keepout, an edge connector or `health` loaded clean and constrained
+    nothing. Every case below is a REAL near-miss: `max_setback` for
+    `max_setback_mm`, `bus_corridor` for `bus_corridors`, `exempts` for
+    `exempt`. Each message must name the key that was wrong AND the one that
+    was meant -- a bare "unknown key" leaves the author reading their own
+    typo back.
+    """
+    cases = [
+        (_base(keepouts=[{'name': 'k', 'rect': [0, 0, 1, 1], 'sids': ['F']}]),
+         'sids', 'sides'),
+        (_base(edge_connectors=[{'ref': 'J1', 'max_setback': 2.0}]),
+         'max_setback', 'max_setback_mm'),
+        (_base(edge_connectors=[{'ref': 'J1',
+                                 'overhang_mm': {'min': 0.0, 'maximum': 1.0}}]),
+         'maximum', 'max'),
+        (_base(decaps={'max_distance_mm': 2.5, 'exempts': ['C9']}),
+         'exempts', 'exempt'),
+        (_base(defaults={'zone_tolerance': 0.5}),
+         'zone_tolerance', 'zone_tolerance_mm'),
+        (_base(health={'bus_corridor': []}),
+         'bus_corridor', 'bus_corridors'),
+        (_base(health={'bus_corridors': [{'nets': ['/D*'], 'width': 8.0}]}),
+         'width', 'width_mm'),
+        (_base(envelope={'rect': [0, 0, 100, 80], 'tolerance': 0.5}),
+         'tolerance', 'tolerance_mm'),
+        (_base(overlap_waivers=[{'pair': ['U1', 'U2'], 'because': 'by design'}]),
+         'because', 'reason'),
+    ]
+    # Split on `Known:` before asserting. Checking both halves of the raw
+    # message would pass vacuously on every pair here -- `width` is a
+    # substring of `width_mm`, `ref` of `reff` -- so the typo has to appear
+    # in the REFUSAL half and the correction in the KNOWN half.
+    for raw, typo, meant in cases:
+        msg = _rejects(raw, f"{typo} instead of {meant}")
+        refused, _, known = msg.partition('Known:')
+        assert known, f"message carries no `Known:` list: {msg}"
+        assert typo in refused, (typo, msg)
+        assert meant in known.replace(',', ' ').split(), (meant, msg)
+    # A typo'd `ref` reports the unknown key, not a missing `ref` -- the
+    # author is looking at the key they DID write.
+    msg = _rejects(_base(edge_connectors=[{'reff': 'J1'}]), "reff")
+    refused, _, known = msg.partition('Known:')
+    assert 'reff' in refused, msg
+    assert 'ref' in known.replace(',', ' ').split(), msg
+    print(f"  PASS: {len(cases) + 1} nested typos refused, each naming the "
+          f"key that was meant")
+
+
+def test_a_nested_object_must_be_an_object():
+    """`raw.get(k) or {}` handed a list straight on, so the schema error
+    surfaced as an AttributeError inside a rule three frames later -- or, for
+    a key nothing reads yet, not at all."""
+    for key, value in (('envelope', []), ('defaults', []), ('decaps', 'none'),
+                       ('health', []), ('context', 3), ('severity', []),
+                       ('legality_budget', [])):
+        msg = _rejects(_base(**{key: value}), f"{key}={value!r}")
+        assert key in msg, (key, msg)
+        assert 'object' in msg, (key, msg)
+    print("  PASS: 7 nested objects refuse a list/scalar instead of crashing "
+          "later")
+
+
+def test_context_is_deliberately_open():
+    """The read-only slot. `emit_intent` writes `cutouts` / `file_locked` /
+    `budget_withheld` there, and run artifacts add their own provenance prose
+    (17 distinct keys across the recorded runs). Nothing grades it, so
+    refusing a key here would only push provenance into a key that IS
+    graded -- the worse failure."""
+    i = intent_from_dict(_base(context={
+        'note': 'read-only', 'authored_by': 'run-20',
+        'j7_evidence': 'six of seven pins interior',
+        'budget_withheld': {'overlap_area': 'a blocking body pair'}}))
+    assert i.budget_withheld == {'overlap_area': 'a blocking body pair'}
+    print("  PASS: context accepts arbitrary keys; budget_withheld still read")
+
+
 def test_a_block_needs_refs_or_group():
     msg = _rejects(_base(blocks=[{'name': 'x', 'zone': [0, 0, 1, 1]}]),
                    "a block naming no members")
@@ -245,6 +326,9 @@ TESTS = [
     test_the_wrong_file_is_refused_by_kind,
     test_schema_version_is_enforced,
     test_unknown_keys_are_refused_not_ignored,
+    test_unknown_nested_keys_are_refused_not_ignored,
+    test_a_nested_object_must_be_an_object,
+    test_context_is_deliberately_open,
     test_a_block_needs_refs_or_group,
     test_refs_as_a_bare_string_is_refused,
     test_enumerations_are_checked,

--- a/tests/test_549_floorplan_schema.py
+++ b/tests/test_549_floorplan_schema.py
@@ -212,6 +212,43 @@ def test_context_is_deliberately_open():
     print("  PASS: context accepts arbitrary keys; budget_withheld still read")
 
 
+def test_an_entry_carries_its_own_context_slot():
+    """Provenance needs somewhere to go that is not a constraint.
+
+    Without a slot the reasoning drifts into the graded keys -- the recorded
+    runs show one intent whose edge_connectors entries grew `band_basis`,
+    `why`, `why_not_repaired` and `rejected_alternative`, which every consumer
+    then ignored. `note` is not the answer either: it is grepped for the
+    substring SUSPECT, so appending prose to it can change behaviour.
+    """
+    ctx = {'why': 'the mating face is on the east wall of the enclosure',
+           'rejected_alternative': 'north, blocked by the display window'}
+    i = intent_from_dict(_base(
+        blocks=[{'name': 'p', 'refs': ['U1'], 'context': ctx}],
+        keepouts=[{'name': 'k', 'rect': [0, 0, 6, 6], 'context': ctx}],
+        edge_connectors=[{'ref': 'J1', 'edge': 'east', 'context': ctx}],
+        overlap_waivers=[{'pair': ['U1', 'U2'], 'reason': 'net tie',
+                          'context': ctx}]))
+    assert i.keepouts[0]['context'] == ctx
+    assert i.edge_connectors[0]['context'] == ctx
+    # Free-form, but still an object -- a list means the author meant
+    # something else, while an unknown key inside means nothing at all.
+    for raw, where in (
+            (_base(blocks=[{'name': 'p', 'refs': ['U1'], 'context': []}]),
+             'blocks[0].context'),
+            (_base(edge_connectors=[{'ref': 'J1', 'context': 'why'}]),
+             'edge_connectors[0].context'),
+            (_base(keepouts=[{'name': 'k', 'rect': [0, 0, 6, 6],
+                              'context': 1}]), 'keepouts[0].context'),
+            (_base(overlap_waivers=[{'pair': ['U1', 'U2'],
+                                     'context': []}]),
+             'overlap_waivers[0].context')):
+        msg = _rejects(raw, f"{where} as a non-object")
+        assert where in msg, (where, msg)
+    print("  PASS: 4 entry kinds carry a free-form context; a non-object is "
+          "refused by path")
+
+
 def test_severity_keys_are_checked_against_the_rule_names():
     """#710: `severity` validated its VALUES and never its keys.
 
@@ -407,6 +444,7 @@ TESTS = [
     test_unknown_nested_keys_are_refused_not_ignored,
     test_a_nested_object_must_be_an_object,
     test_context_is_deliberately_open,
+    test_an_entry_carries_its_own_context_slot,
     test_severity_keys_are_checked_against_the_rule_names,
     test_every_violation_rule_name_is_settable,
     test_a_block_needs_refs_or_group,


### PR DESCRIPTION
Closes #710.

The intent loader was strict at exactly two levels and permissive everywhere else. Unknown top-level keys raised, unknown `blocks[]` keys raised, and one level down these all loaded clean and did nothing:

```json
{"ref": "J1", "edge": "east", "max_setback": 2.0}
{"severity": {"decap_distanc": "warn"}}
{"decaps": {"max_distance_mm": 2.5, "exempts": ["C9"]}}
```

That is the failure `block_unresolved` exists to prevent, one level down: a constraint the author thinks they set and the grader never checks.

## What changed

Each nested object gets a key set validated the way `_BLOCK_KEYS` already was — `_ENVELOPE_KEYS`, `_KEEPOUT_KEYS`, `_EDGE_CONNECTOR_KEYS`, `_OVERHANG_KEYS`, `_DECAP_KEYS`, `_DEFAULTS_KEYS`, `_HEALTH_KEYS`, `_CORRIDOR_KEYS`, `_BUDGET_KEYS`, `_WAIVER_KEYS`. Two helpers (`_reject_unknown`, `_obj`) replace three hand-rolled copies of the same check and give one message shape at every level, including the `Known:` list — which is what turns a typo into a fix, since `keepout` only looks wrong next to `keepouts`.

`envelope` and `overlap_waivers[]` are covered too. The issue doesn't name them; they were the same hole.

`_obj` also closes a gap nothing had noticed: `defaults`, `decaps`, `health` and `context` were never *type*-checked, so `"defaults": []` sailed through the loader and died later at `.get()` — or, for a key nothing reads yet, not at all.

**`severity` keys.** The vocabulary is **12 names, not the 9 in `RULES`**. Three findings are raised outside the rules loop — `intent_zone_outside_envelope` and `intent_zone_overlap` from `validate_intent`, `block_unresolved` from `resolve_blocks` — and an intent has always been allowed to set their severity. Validating against `RULES` alone, as the issue suggests, would have refused `{"block_unresolved": "warn"}`, which is legal today. So `_SEVERITY_KEYS` is derived from `RULES` (a new rule is settable the moment it is registered) unioned with a named `_NON_RULE_SEVERITIES`.

**`min_reader`.** Refusing unknown keys already covers *new* fields — an older build does not know the key, refuses the file, and says which key. What refusal cannot see is a key an older build *does* know whose accepted values widened, whose meaning changed, or whose default moved. That is `min_reader`'s job, against a new `READER_VERSION`. `schema` stays the format number: it is matched exactly, so bumping it would invalidate every existing intent file at once. The gate is checked first, before the unknown-key and schema checks, because a build declaring a new field almost always adds a top-level one — and in exactly that case the author would otherwise get "unknown key(s) zones" and go hunting for a typo instead of upgrading.

**A `context` slot per entry** (separate commit, droppable). Strictness without somewhere to put reasoning pushes prose into keys that *are* graded: one recorded run had `edge_connectors[]` entries carrying `band_basis`, `why`, `why_not_repaired`, `rejected_alternative`, which every consumer ignored — #710 arrived at from the authoring side. `blocks[]`, `keepouts[]`, `edge_connectors[]` and `overlap_waivers[]` each accept a free-form `context` object, same contract as the top-level one. Not `note`: that is grepped for the substring `SUSPECT` by `emit_intent` and `place_reconstruct`, so appending to it can change behaviour.

## Migration, measured

The issue warns that emitter-written keys must all land in the allowed sets or existing artifacts stop loading. I swept every floorplan-intent file on disk (73 of them, all under `wk/`, none tracked):

| | |
|---|---|
| before the `context` slot | **72 / 73 load** |
| after | **73 / 73** |

The single holdout was the file carrying those four prose keys; migrating it moved them one level down into `context`, every value preserved. `envelope`, `defaults`, `decaps`, `keepouts[]`, `legality_budget` and `blocks[]` were already clean across the whole corpus.

## Tests

`emit_intent` writes `suspect`, `overhang_capped`, `class` and friends that no rule reads, so a key set that forgot one would fail no rule — it would fail months later, on an artifact that used to load. The drift detector runs every tracked board with `--declare-classes` both ways, plus a board damaged in-test for the capped branch, and reads the branches no tracked board can reach (`suspect` needs rigid pattern vectors) off the emitter's own source.

The vocabulary is also pinned as a literal in **both** directions and cross-checked against the doc's key table, and an intent using all 60 known keys must load. That second one matters more than it looks: `emit_intent` never writes a `health`, `decaps` or `keepouts` object at all, so an emitter-driven check alone cannot see a set that *shrinks* — which is the regression this change actually risks, since a shrunk set refuses a key real files carry.

## On the review

Two adversarial reviews, one on the engine and one on the tests. Both found real defects in the first four commits, fixed in the last one. Worth flagging three for reviewers:

- `min_reader` was checked *after* the gates it needed to outrank, so the one case it exists for never reached it.
- `blocks[].context` was accepted and then silently dropped — `blocks[]` is the one entry kind rebuilt into a dataclass rather than kept as its raw dict. An authored key that loads clean and does nothing: **#710, introduced by the commit fixing #710.**
- The stated versioning policy was contradicted by this very change (it claimed an additive nested field stays inert on an older build; after this, it is refused). Rewritten.

The test review found six assertions that were substring-vacuous or self-referential, each proven by a mutation that survived them — e.g. `min_reader`'s check was `'2' in msg and '1' in msg`, which a message with the two numbers *swapped* satisfies exactly as well. 19 mutations now, 19 caught.

## Verification

- `tests/run_all.py` — full suite, compared against `upstream/main`
- the two contract tests, plus `test_549_floorplan_cli`, `test_run5_emit_guard`, `test_run23_connector_affinity`, `test_run6_body_overlap` (the only `overlap_waivers` coverage), `test_630_seeder_eviction`, `test_run4_reconstruct`, `test_placement_ab` (the only test exercising `health` through the loader), `test_part_class`, `test_portfolio`, `test_431_skill_commands`, `test_457_fresh_clone_fixtures`
- both runners: the bare scripts and `pytest`, since `pytest.ini` collects the same files
- `check_floorplan.py --emit-intent … --declare-classes` then `--intent` on real boards

Not fixed here, worth its own issue: `emit_intent` writes `suspect` / `suspect_reason` / `overhang_capped` / `observed_overhang_mm` / `source` that **nothing reads**, while the same condition is consumed by grepping `SUSPECT` out of the free-text `note` — the exact asymmetry the code comment there claims to have fixed.
