### PR TITLE
#695: via-in-pad read as dangling because a pad was credited by its centre

### DIFF
--- a/py_router/check_weird.py
+++ b/py_router/check_weird.py
@@ -13,6 +13,10 @@ Categories:
   soft-joint         same-net endpoints whose caps overlap but are not
                      coincident (check_drc's 'segment-endpoint-gap' class;
                      reuses routing_constants.SOFT_JOINT_MIN_GAP and approach).
+                     An end is ANCHORED -- and so not a free end at all -- by
+                     a via barrel or by a pad its own cap overlaps, both by
+                     RADIUS (#695); crediting a pad by centre containment made
+                     this contradict check_connected's endpoint-cap rule.
   redundant-cycle    same-net loop edges whose removal leaves connectivity
                      identical (pcb_modification._prune_net_cycles machinery,
                      report-only; zoned nets skipped -- planes are meshes).
@@ -127,12 +131,29 @@ def _check_soft_joints(net_id, name, net_segs, net_vias, net_pads, findings):
     more specific, category."""
     via_r = [(v.x, v.y, (getattr(v, 'size', 0) or 0) / 2.0) for v in net_vias]
 
-    def at_anchor(x, y):
+    def at_anchor(x, y, width):
         for vx, vy, vr in via_r:
             if math.hypot(x - vx, y - vy) <= vr + 0.01:
                 return True
+        # The endpoint's round cap has a RADIUS (width/2), exactly as the via
+        # barrel two lines above has one -- so a stub ending just short of a
+        # pad outline can still have its cap physically overlapping the pad
+        # copper. Crediting the CENTRE only (COINCIDENCE_TOL, 0.02mm) made
+        # this branch contradict the authoritative model on copper KiCad
+        # grades joined: check_connected.py unions a track end into a pad at
+        # `_m = max(ewidth/2 - 1e-6, tolerance)` (the #285 endpoint-cap rule),
+        # so two 0.25mm stubs ending 0.05mm outside a 1.0x0.6 pad are ONE
+        # component there and a `soft-joint` here. That is the same
+        # centre-vs-barrel asymmetry #695 fixed for the via/pad credit, four
+        # lines apart from it, and it bites harder: `soft-joint` carries
+        # size=None, so --tolerance never filters it, and check_weird's exit
+        # code is chain-blocking through check_complete.
+        #
+        # `width` is REQUIRED rather than defaulted: a caller that forgot it
+        # would silently get the centre-only credit back, which is the defect.
+        _m = max(width / 2 - 1e-6, COINCIDENCE_TOL)
         for p in net_pads:
-            if point_to_pad_distance(x, y, p) <= COINCIDENCE_TOL:
+            if point_to_pad_distance(x, y, p) <= _m:
                 return True
         return False
 
@@ -149,7 +170,7 @@ def _check_soft_joints(net_id, name, net_segs, net_vias, net_pads, findings):
         for (x, y) in ((s.start_x, s.start_y), (s.end_x, s.end_y)):
             if ep_count[(s.layer, rk(x, y))] != 1:
                 continue  # shared vertex = clean joint
-            if at_anchor(x, y):
+            if at_anchor(x, y, s.width):
                 continue  # terminates on a via / own pad = legitimate
             dangles[s.layer].append((x, y, s.width))
 

--- a/py_router/check_weird.py
+++ b/py_router/check_weird.py
@@ -26,8 +26,15 @@ Categories:
                      within ~1um) and coincident same-net vias (centers
                      within 0.01mm) -- the duplicate-emission bug class.
   unsupported-via    a via with no same-net track copper reaching its barrel,
-                     not inside a same-net pad, and not inside a same-net
-                     zone polygon (a floating via).
+                     no same-net pad whose copper that barrel overlaps, and
+                     not inside a same-net zone polygon (a floating via).
+                     Track and pad are both judged by BARREL OVERLAP (#695);
+                     the zone test is centre-in-OUTLINE, which is looser than
+                     the authoritative model -- check_net_connectivity credits
+                     a zone through its FILL model when a caller hands it
+                     pcb_data, so a via in a clearance void inside the outline
+                     grades supported here and unsupported there. Pre-existing,
+                     and not what #695 asked about.
   dangling-via       a via whose same-net copper reaches it on exactly ONE of
                      the layers it spans, so the barrel joins nothing. This is
                      KiCad's own `via_dangling` rule; it is a strictly weaker
@@ -473,7 +480,9 @@ def stacked_copper_over_model(segs_by_net, vias_by_net, net_name):
 def _check_unsupported_vias(net_id, name, net_segs, net_vias, net_pads,
                             net_zones, copper_layers, findings):
     """Floating vias: no same-net track copper reaching the barrel, no
-    same-net pad containing the center, no same-net zone polygon around it."""
+    same-net pad whose copper the barrel OVERLAPS, no same-net zone polygon
+    around it. Pad credit is barrel-overlap, not centre-containment (#695) --
+    see the note at the pad loop below."""
     for v in net_vias:
         span = _via_span(v, copper_layers)
         r = (getattr(v, 'size', 0.6) or 0.6) / 2.0
@@ -499,8 +508,28 @@ def _check_unsupported_vias(net_id, name, net_segs, net_vias, net_pads,
             else:
                 pl = set(p.layers or [])
                 on = set(span) if any('*' in L for L in pl) else (span & pl)
+            # The barrel has a RADIUS against a track (above), so it has one
+            # against a pad too. `margin` inflates the EXACT pad outline, so
+            # this reads "the barrel copper overlaps the pad copper" -- the
+            # same GEOMETRY as check_connected.py's via-in-pad union and
+            # check_drc's via-in-edge-pad exemption, with COINCIDENCE_TOL kept
+            # as the floor exactly as it is there. Crediting the CENTRE only
+            # (COINCIDENCE_TOL, 0.02mm) made this checker contradict the
+            # authoritative connectivity model on copper KiCad grades joined,
+            # and check_weird's exit code is chain-blocking: an off-centre
+            # via-in-pad read as `dangling via` forced a reroute lap (#695).
+            #
+            # The LAYER model above is NOT the same, and this is only geometry
+            # parity: check_connected expands pad.layers (dropping *.Mask and
+            # friends) and unions only on a SHARED copper layer, while `on`
+            # here hands a drilled pad -- or one carrying any '*' layer -- the
+            # via's whole span. That predates #695 and no board in the corpus
+            # has a pad whose copper layers are a strict subset, but a plated
+            # pad declaring only F/B.Cu would let a buried via grazing its ring
+            # claim an inner layer. Left alone deliberately; fixing it is a
+            # different behaviour change from the one this comment describes.
             if on and not on <= sup and _point_in_pad(
-                    v.x, v.y, p, margin=COINCIDENCE_TOL):
+                    v.x, v.y, p, margin=max(r - 1e-6, COINCIDENCE_TOL)):
                 sup |= on
         for z in net_zones:
             if z.layer in span and z.layer not in sup and point_in_polygon(

--- a/py_router/fab_notes.py
+++ b/py_router/fab_notes.py
@@ -4,7 +4,9 @@ Right now: via-in-pad (#489 §8). The tool places it from three separate paths
 (qfn_fanout `allow_via_in_pad`, `route_planes --same-net-pad-clearance -1`,
 bga_fanout/underpad) and said nothing about the requirement it had just created.
 Via-in-pad needs IPC-4761 Type VII -- filled, capped and plated -- or solder
-wicks out of the joint into the barrel during reflow. The tool cannot enforce
+wicks out of the joint into the barrel during reflow. A site is counted when
+the via BARREL overlaps the pad copper, not merely when its centre is inside
+(#695) -- an off-centre tap wicks just the same. The tool cannot enforce
 that (it is a fab process, not board geometry), so the least it can do is COUNT
 the sites and say so in the run output.
 
@@ -13,6 +15,7 @@ can call it.
 """
 from __future__ import annotations
 
+import math
 from typing import Dict, List, Optional, Tuple
 
 # IPC-4761 Type VII is the protection class via-in-pad requires.
@@ -29,17 +32,71 @@ def _get(obj, name: str, default=None):
 
 
 def _pad_holds(pad, x: float, y: float, margin: float = 0.0) -> bool:
-    """Is (x, y) within the pad's copper extent? size_x/size_y are already
-    resolved to board space by the parser, so this is an axis-aligned test."""
-    hx = _get(pad, 'size_x', 0.0) / 2 + margin
-    hy = _get(pad, 'size_y', 0.0) / 2 + margin
-    return (abs(x - _get(pad, 'global_x', 0.0)) <= hx
-            and abs(y - _get(pad, 'global_y', 0.0)) <= hy)
+    """Is (x, y) within `margin` of the pad's COPPER?
+
+    Exact when check_drc is importable (custom-pad polygons, roundrect
+    corners, circle/oval, and rect_rotation), which is the same function --
+    and the same function-local-import trick -- check_connected._point_in_pad
+    uses. The import is inside the call so this module still IMPORTS as a
+    leaf: any front can `import fab_notes` without dragging a checker in at
+    module load, and only a point that survives the cheap reject pays for it.
+
+    The reject is the DIAGONAL one, copied from check_connected, not an
+    axis-aligned box. A box in board space clips a rotated pad's copper,
+    because size_x/size_y stay in the PAD's frame and the tilt rides in
+    rect_rotation -- a 1.0x0.2 pad at 45 degrees holds (0.35, 0.35) inside its
+    copper, and a box gate rejects it, losing a real Type VII site.
+
+    The box is not a safe credit either, in the other direction (#695):
+    inflating one by the barrel radius over-credits by up to a factor of
+    sqrt(2) along the diagonal, which is exactly where bga_fanout puts a
+    dog-bone via (the half-pitch diagonal). Measured on ulx3s's BGA-381: a box
+    named all 379 dog-bone vias as via-in-pad and the exact test named none,
+    the nearest copper being 0.37mm from a 0.225mm barrel. So the fallback
+    used when check_drc cannot be imported is the pad's circumscribed reach,
+    which kills that corner artifact -- still not exact, and deliberately
+    erring toward naming a site rather than missing one.
+    """
+    hx = _get(pad, 'size_x', 0.0) / 2
+    hy = _get(pad, 'size_y', 0.0) / 2
+    dx = x - _get(pad, 'global_x', 0.0)
+    dy = y - _get(pad, 'global_y', 0.0)
+    reach = max(hx, hy) + margin
+    if dx * dx + dy * dy > reach * reach * 2:   # bbox-DIAGONAL prefilter
+        return False
+    try:
+        from check_drc import point_to_pad_distance
+    except ImportError:                          # no checker on this path
+        # A point outside the pad's own circumscribed reach cannot be within
+        # `margin` of copper that lives inside it. Only an ImportError is
+        # caught: a geometry error must surface, not silently downgrade.
+        return math.hypot(dx, dy) <= math.hypot(hx, hy) + margin
+    return point_to_pad_distance(x, y, pad) <= margin
 
 
 def via_in_pad_sites(vias, pads_by_net: Dict[int, list],
                      margin: float = 0.0) -> List[Tuple[object, object]]:
-    """[(via, pad)] for every via whose centre lands inside a SAME-NET pad.
+    """[(via, pad)] for every via whose BARREL overlaps a SAME-NET pad.
+
+    Overlap, not centre-containment (#695): an off-centre via-in-pad can have
+    its centre just outside the pad outline while the barrel still overlaps
+    the copper -- and solder wicks through copper continuity, not through the
+    via's centre point, so that joint needs Type VII exactly as much. The
+    router places such vias on purpose (QFN allow_via_in_pad, plane taps
+    clamped to the pad edge, BGA underpad drops). Measured: the centre test
+    missed 6 real sites on rp2350_fpga_eensy_prePlane alone, every one a true
+    overlap against the exact pad shape.
+
+    The credit must be EXACT, not a box inflated by the radius -- see
+    _pad_holds. Over-counting here is not cheap: this note is a fab process
+    requirement (filled, capped, plated), so a false site costs money, and
+    bga_fanout hands this function its dog-bone vias, which sit on the
+    half-pitch diagonal where a box over-credits worst.
+
+    `margin` is a FLOOR on that credit, not a replacement for it: the barrel
+    radius applies even when the caller passes 0. That is a change of meaning
+    (#695) -- `margin` could once be used to ask for a credit TIGHTER than the
+    barrel, and can no longer. No in-repo caller passes it.
 
     Same-net only: a via inside a FOREIGN pad is a short, not via-in-pad, and is
     the DRC checkers' business. Accepts vias as dicts or objects.
@@ -52,10 +109,13 @@ def via_in_pad_sites(vias, pads_by_net: Dict[int, list],
         vx, vy = _get(via, 'x'), _get(via, 'y')
         if vx is None or vy is None:
             continue
+        # A via with no declared size claims the 0.6 default's radius, as
+        # every other consumer of a size-less via in this repo does.
+        vr = (_get(via, 'size', 0.6) or 0.6) / 2.0
         for pad in pads_by_net.get(net_id, ()) or ():
             if _get(pad, 'drill', 0.0) or 0.0:
                 continue  # a plated TH pad's own barrel is not via-in-pad
-            if _pad_holds(pad, vx, vy, margin):
+            if _pad_holds(pad, vx, vy, max(vr - 1e-6, margin)):
                 sites.append((via, pad))
                 break
     return sites
@@ -64,6 +124,8 @@ def via_in_pad_sites(vias, pads_by_net: Dict[int, list],
 def via_in_pad_summary(vias, pads_by_net: Dict[int, list],
                        margin: float = 0.0) -> Optional[Dict]:
     """Machine-readable via-in-pad record, or None when there is none.
+
+    Sites are barrel-overlap, not centre-in-pad -- see via_in_pad_sites.
 
     {'count', 'pads' (["U1.A1", ...]), 'note'} -- returned so a caller can put it
     in a run summary instead of only printing it.
@@ -82,7 +144,10 @@ def via_in_pad_summary(vias, pads_by_net: Dict[int, list],
 def print_via_in_pad_note(vias, pads_by_net: Dict[int, list],
                           context: str = "", margin: float = 0.0,
                           max_refs: int = 8) -> Optional[Dict]:
-    """Print one fab note when this run put vias in pads. Returns the record."""
+    """Print one fab note when this run put vias in pads. Returns the record.
+
+    `margin` floors the barrel-overlap credit; see via_in_pad_sites.
+    """
     record = via_in_pad_summary(vias, pads_by_net, margin)
     if not record:
         return None

--- a/tests/test_489_via_tenting.py
+++ b/tests/test_489_via_tenting.py
@@ -173,6 +173,80 @@ def run():
           "a via clear of every pad is not via-in-pad")
     check(via_in_pad_sites([foreign], pads_by_net) == [],
           "a via in a FOREIGN pad is a short, not via-in-pad -- not this report")
+    # #695: an OFF-CENTRE via-in-pad has its centre outside the pad outline
+    # while the barrel still overlaps the copper. Solder wicks through copper
+    # continuity, not through the centre point, so that joint needs Type VII
+    # too -- and the router places exactly this geometry on purpose (QFN
+    # allow_via_in_pad, plane taps clamped to the pad edge, BGA underpad).
+    # The pad is 0.5 wide (edge at x=10.25) and the barrel radius is 0.225.
+    grazing = {'x': 10.40, 'y': 10.0, 'size': 0.45, 'drill': 0.25, 'net_id': 7}
+    clear = {'x': 10.60, 'y': 10.0, 'size': 0.45, 'drill': 0.25, 'net_id': 7}
+    check(abs(grazing['x'] - 10.0) > pad.size_x / 2,
+          "the grazing via's CENTRE must be outside the pad, or this row "
+          "passes on the centre test it is meant to retire")
+    check(len(via_in_pad_sites([grazing], pads_by_net)) == 1,
+          "a via whose BARREL overlaps a same-net pad is via-in-pad (#695)")
+    check(via_in_pad_sites([clear], pads_by_net) == [],
+          "a via whose barrel clears the pad is NOT via-in-pad -- without "
+          "this control the row above passes on a check that credits all")
+    # The credit must follow the pad's SHAPE, not a box around it. bga_fanout
+    # hands this function its dog-bone vias, and those sit on the half-pitch
+    # DIAGONAL from a round BGA pad -- precisely where a box inflated by the
+    # barrel radius over-credits by sqrt(2). Measured on ulx3s's BGA-381 while
+    # fixing #695: the box named all 379 of them and the exact test named none,
+    # the nearest copper being 0.37mm from a 0.225mm barrel. A false site here
+    # is a fab process requirement (filled/capped/plated), not a stray line.
+    round_pad = Pad(component_ref='U2', pad_number='A2', global_x=0.0, global_y=0.0,
+                    local_x=0, local_y=0, size_x=0.4, size_y=0.4, shape='circle',
+                    layers=['F.Cu'], net_id=8, net_name='M', drill=0.0,
+                    pad_type='smd')
+    dogbone = {'x': 0.4, 'y': 0.4, 'size': 0.45, 'drill': 0.25, 'net_id': 8}
+    # On the branch: inside the inflated BOX (0.4 <= 0.2+0.225 on both axes),
+    # outside the real copper (radially 0.566 - 0.2 = 0.366 > 0.225).
+    check(abs(dogbone['x']) <= round_pad.size_x / 2 + dogbone['size'] / 2
+          and abs(dogbone['y']) <= round_pad.size_y / 2 + dogbone['size'] / 2,
+          "the dog-bone via must be inside the pad's inflated BOX, or this "
+          "row does not exercise the corner over-credit it names")
+    check(via_in_pad_sites([dogbone], {8: [round_pad]}) == [],
+          "a dog-bone via on the half-pitch diagonal of a ROUND pad is not "
+          "via-in-pad -- the credit follows the pad shape, not its box (#695)")
+    # The cheap reject must be the DIAGONAL one, not an axis-aligned box: a
+    # rotated pad keeps size_x/size_y in its OWN frame and carries the tilt in
+    # rect_rotation, so a board-space box clips its copper. This via's centre
+    # is literally INSIDE the copper and a box gate drops it -- a MISSED Type
+    # VII callout, the unsafe direction.
+    tilted = Pad(component_ref='U3', pad_number='1', global_x=0.0, global_y=0.0,
+                 local_x=0, local_y=0, size_x=1.0, size_y=0.2, shape='rect',
+                 layers=['F.Cu'], net_id=9, net_name='R', drill=0.0,
+                 pad_type='smd', rotation=45.0)
+    tilted.rect_rotation = 45.0
+    on_tilt = {'x': 0.35, 'y': 0.35, 'size': 0.45, 'drill': 0.25, 'net_id': 9}
+    check(abs(on_tilt['x']) > tilted.size_y / 2 + on_tilt['size'] / 2,
+          "the tilted-pad via must fall outside the axis-aligned box, or "
+          "this row does not exercise the gate it names")
+    check(len(via_in_pad_sites([on_tilt], {9: [tilted]})) == 1,
+          "a via inside a ROTATED pad's copper is via-in-pad -- the reject "
+          "must be the diagonal prefilter, not a board-space box (#695)")
+    # The no-checker fallback is a real branch and had no coverage: with
+    # check_drc unavailable _pad_holds falls back to the pad's circumscribed
+    # reach, which must still refuse the dog-bone corner artifact above.
+    import builtins
+    _real_import = builtins.__import__
+
+    def _no_check_drc(name, *a, **kw):
+        if name == 'check_drc':
+            raise ImportError('forced: exercising the fallback branch')
+        return _real_import(name, *a, **kw)
+
+    builtins.__import__ = _no_check_drc
+    try:
+        check(len(via_in_pad_sites([grazing], pads_by_net)) == 1,
+              "with no check_drc, the fallback still names a real overlap")
+        check(via_in_pad_sites([dogbone], {8: [round_pad]}) == [],
+              "with no check_drc, the fallback's circumscribed-reach guard "
+              "still refuses the dog-bone corner artifact")
+    finally:
+        builtins.__import__ = _real_import
     summary = via_in_pad_summary([in_pad, outside], pads_by_net)
     check(summary and summary['count'] == 1 and summary['pads'] == ['U1.A1'],
           f"summary should name the one hit pad, got {summary}")

--- a/tests/test_check_weird.py
+++ b/tests/test_check_weird.py
@@ -42,6 +42,7 @@ from check_weird import check_weird, print_report, CATEGORIES
 from check_connected import check_net_connectivity
 from check_drc import point_to_pad_distance
 from connectivity import COINCIDENCE_TOL
+from routing_constants import SOFT_JOINT_MIN_GAP
 
 NET = 1
 NAME = '/TEST'
@@ -328,6 +329,80 @@ def main():
         results.append((f"check_weird agrees with it ({_label}): "
                         f"dangling must be {not _want_joined}",
                         _dangling is (not _want_joined)))
+
+    # 13. The SAME centre-vs-barrel asymmetry, in the soft-joint anchor.
+    #     `at_anchor` credited a via by its BARREL radius and a pad by centre
+    #     containment, four lines apart -- so a stub whose round cap (r =
+    #     width/2) physically overlaps a pad, but whose endpoint sits outside
+    #     the outline, was counted as a free end. Two such ends facing each
+    #     other are then reported as `soft-joint` on copper check_connected
+    #     grades as ONE component (its #285 endpoint-cap rule unions a track
+    #     end into a pad at max(width/2 - 1e-6, tolerance)). `soft-joint`
+    #     carries size=None, so --tolerance cannot filter it away, and
+    #     check_weird's exit code is chain-blocking through check_complete.
+    #
+    #     1.0 x 0.6 pad at the origin; two 0.25mm stubs whose near ends sit
+    #     0.05mm outside its right edge, 0.12mm apart, each running away to
+    #     its own far pad so the FAR ends anchor and cannot confound the row.
+    def _soft_anchor_board(nx):
+        p1 = _rect_pad(0, 0, 1.0, 0.6, num='1', ref='U1')
+        p2 = _pad(3, 2, num='2', ref='U2')
+        p3 = _pad(3, -2, num='3', ref='U3')
+        segs = [_seg(nx, 0.06, 3, 2, width=0.25),
+                _seg(nx, -0.06, 3, -2, width=0.25)]
+        return _pcb(segs, pads=[p1, p2, p3]), segs, [p1, p2, p3]
+
+    _cap_r = 0.25 / 2.0
+    _p1 = _rect_pad(0, 0, 1.0, 0.6)
+    _near = point_to_pad_distance(0.55, 0.06, _p1)
+    _far = point_to_pad_distance(0.65, 0.06, _p1)
+    #     The rows must be ON the branch they name, in BOTH directions: the
+    #     near end outside the old centre credit but inside the cap (so the
+    #     centre test cannot pass it), the far end outside the cap too (so the
+    #     control is a real free end, not a fixture that merely moved).
+    results.append(("the soft-joint stub end is outside the pad copper but "
+                    "inside its own cap (guard is on the cap branch)",
+                    COINCIDENCE_TOL < _near < _cap_r))
+    results.append(("the control stub end is outside the cap as well",
+                    _far > _cap_r))
+    #     ...and that the PAIR condition itself is satisfied, or 'no
+    #     soft-joint' below would pass for the wrong reason.
+    _gap, _cap = 0.12, 0.25
+    results.append(("the two stub ends do form a soft-joint pair "
+                    "(gap within the overlapping caps)",
+                    SOFT_JOINT_MIN_GAP < _gap < _cap - 1e-6))
+
+    pcb_soft, segs_soft, pads_soft = _soft_anchor_board(0.55)
+    f_soft, _ = check_weird(pcb_soft)
+    results.append(("stub caps overlapping a pad NOT reported as soft-joint",
+                    not [x for x in f_soft if x['category'] == 'soft-joint']))
+    #     Negative control: same pair, moved until the caps clear the copper.
+    #     Still a genuine soft joint -- without this the row above would also
+    #     pass on a check that anchored every endpoint unconditionally.
+    pcb_gap, segs_gap, pads_gap = _soft_anchor_board(0.65)
+    f_gap, _ = check_weird(pcb_gap)
+    results.append(("stub caps clear of the pad still reported as soft-joint",
+                    len([x for x in f_gap
+                         if x['category'] == 'soft-joint']) == 1))
+
+    #     Same thesis as #695 above, and asserted the same way: what each
+    #     model must say ABSOLUTELY. In the overlapping case every pad is
+    #     joined through the centre pad; in the clear case that pad is
+    #     stranded, which is what makes the soft-joint report correct there.
+    for _label, (_pcb_, _segs_, _pads_), _want_joined in (
+            ('caps overlap the pad', (pcb_soft, segs_soft, pads_soft), True),
+            ('caps clear the pad', (pcb_gap, segs_gap, pads_gap), False)):
+        _conn = check_net_connectivity(NET, _segs_, [], _pads_, [])
+        _joined = (_conn['num_components'] == 1
+                   and not _conn['disconnected_pads'])
+        _soft = any(x['category'] == 'soft-joint'
+                    for x in check_weird(_pcb_)[0])
+        results.append((f"check_connected joins the stubs to the pad "
+                        f"({_label}): expected {_want_joined}",
+                        _joined is _want_joined))
+        results.append((f"check_weird agrees with it ({_label}): "
+                        f"soft-joint must be {not _want_joined}",
+                        _soft is (not _want_joined)))
 
     # 11. The reporter, which is what #696 actually broke: a finding whose
     #     category is missing from CATEGORIES counted toward the headline and

--- a/tests/test_check_weird.py
+++ b/tests/test_check_weird.py
@@ -12,6 +12,9 @@ Synthetic Segment/Via/Pad cases:
   * a floating via                 -> unsupported-via flagged
   * a corner-graze terminal cap    -> narrow-pad-joint flagged (#696/#416)
   * the same cap landing in the pad body -> NOT flagged (clean)
+  * an off-centre via-in-pad (centre outside the pad, barrel overlapping)
+    -> NOT flagged, and its verdict AGREES with check_net_connectivity (#695)
+  * the same via moved until the barrel clears the pad -> dangling-via
 
 Plus two guards on the REPORTER, which is what #696 actually broke:
   * CATEGORIES is exactly the set of categories _finding(...) emits
@@ -36,6 +39,9 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(
 from kicad_parser import Pad, Segment, Via, Zone, Net, BoardInfo, PCBData
 import check_weird as check_weird_mod
 from check_weird import check_weird, print_report, CATEGORIES
+from check_connected import check_net_connectivity
+from check_drc import point_to_pad_distance
+from connectivity import COINCIDENCE_TOL
 
 NET = 1
 NAME = '/TEST'
@@ -251,6 +257,77 @@ def main():
     f, _ = check_weird(pcb)
     results.append(("cap landing in the pad body NOT flagged",
                     not [x for x in f if x['category'] == 'narrow-pad-joint']))
+
+    # 12. Via-in-pad credited by the BARREL, not the centre (#695). The
+    #     router puts vias in pads on purpose (QFN allow_via_in_pad, plane
+    #     taps, BGA underpad), and an off-centre one has its centre just
+    #     OUTSIDE the pad outline while the barrel still overlaps the copper.
+    #     Crediting the centre only made this checker report `dangling-via`
+    #     on a joint check_net_connectivity -- the authoritative model, and
+    #     KiCad -- grades connected; check_weird's exit code is chain-blocking,
+    #     so that false positive cost a reroute lap.
+    #
+    #     Offset and pad are the kuchen case quoted in check_connected's own
+    #     comment (0.42mm circle pad, via centre 0.283mm away, so the centre
+    #     sits 0.073mm OUTSIDE the copper). The via here is _via()'s 0.6mm
+    #     default rather than kuchen's 0.42mm, so the barrel overlaps by
+    #     0.21 + 0.30 - 0.283 = 0.227mm, not kuchen's 0.137mm -- same class,
+    #     different number, and the guard below derives its bound from the
+    #     fixture instead of restating either. The via also carries a B.Cu run
+    #     to a second pad, so the pad is the only thing that can supply F.Cu.
+    def _via_in_pad_board(vx):
+        pads = [_pad(0, 0, size=0.42, num='1'),
+                _pad(5, 0, layers=('B.Cu',), num='2', ref='U2')]
+        segs = [_seg(vx, 0, 5, 0, layer='B.Cu')]
+        v = _via(vx, 0)
+        return _pcb(segs, vias=[v], pads=pads), segs, v, pads
+
+    # The row must be ON the branch it names: assert the via centre really is
+    # outside the pad copper by more than the old COINCIDENCE_TOL credit, or
+    # this passes for the wrong reason (the centre test would credit it too).
+    _gap = point_to_pad_distance(0.283, 0, _pad(0, 0, size=0.42))
+    _r = _via(0, 0).size / 2.0
+    results.append(("the #695 via centre is OUTSIDE the pad copper "
+                    "(guard is on the barrel branch, not the centre one)",
+                    COINCIDENCE_TOL < _gap < _r))
+
+    pcb, segs, v, pads = _via_in_pad_board(0.283)
+    f, _ = check_weird(pcb)
+    results.append(("via-in-pad whose barrel overlaps the pad NOT flagged",
+                    not [x for x in f if x['category']
+                         in ('dangling-via', 'unsupported-via')]))
+    #     Negative control: move the via until the barrel clears the copper
+    #     (0.55 -> 0.34mm gap > the 0.30 radius). Still a real dangling via.
+    #     Without this the row above would also pass on a check that credited
+    #     every pad unconditionally.
+    pcb_far, segs_far, v_far, pads_far = _via_in_pad_board(0.55)
+    f_far, _ = check_weird(pcb_far)
+    results.append(("via whose barrel does NOT reach the pad still flagged",
+                    len([x for x in f_far
+                         if x['category'] == 'dangling-via']) == 1))
+
+    #     The thesis of #695: this checker must not contradict the
+    #     AUTHORITATIVE connectivity model on the same geometry. Assert what
+    #     each model must say ABSOLUTELY, not merely that the two differ:
+    #     `joined != dangling` passes when BOTH are wrong (revert the margin
+    #     in check_weird AND check_connected -- the likely future edit, since
+    #     the fix mirrors them -- and it still holds), and it is not even the
+    #     right invariant, since it reads a whole-net verdict as a per-via one
+    #     and so goes red on any fixture that adds a third, unrouted pad.
+    for _label, (_pcb_, _segs_, _v_, _pads_), _want_joined in (
+            ('barrel overlaps', (pcb, segs, v, pads), True),
+            ('barrel clear', (pcb_far, segs_far, v_far, pads_far), False)):
+        _conn = check_net_connectivity(NET, _segs_, [_v_], _pads_, [])
+        _joined = (_conn['num_components'] == 1
+                   and not _conn['disconnected_pads'])
+        _dangling = any(x['category'] == 'dangling-via'
+                        for x in check_weird(_pcb_)[0])
+        results.append((f"check_connected joins this via to the pad "
+                        f"({_label}): expected {_want_joined}",
+                        _joined is _want_joined))
+        results.append((f"check_weird agrees with it ({_label}): "
+                        f"dangling must be {not _want_joined}",
+                        _dangling is (not _want_joined)))
 
     # 11. The reporter, which is what #696 actually broke: a finding whose
     #     category is missing from CATEGORIES counted toward the headline and


### PR DESCRIPTION
Closes #695.

`check_weird._check_unsupported_vias` asks one geometric question two ways, ten lines apart. Against a **track** the via barrel has a radius (`_pt_seg_dist(...) < r + s.width/2 - 1e-6`). Against a **pad** it did not: `margin=COINCIDENCE_TOL`, so the via *centre* had to land inside the pad outline within 0.02 mm. `r` was already in scope two lines above.

Three other places in this repo answer it the barrel way, and one carries the comment written to retire exactly this rule:

| site | predicate |
|---|---|
| `check_connected.py:1093` (authoritative) | `_m = max(vsize/2 - 1e-6, tolerance)`, under *"Center-containment is not enough"* — kuchen `/PWR1V2` U1, centre 0.283 mm from a 0.42 circle pad, 0.137 mm real overlap, kicad-cli reports 0 unconnected |
| `check_drc.py:2985` | `point_to_pad_distance(via.x, via.y, pad) <= via.size/2 + eps` |
| `check_weird.py:492` | its own track branch |

`connectivity.py:178-183` states the split explicitly: `COINCIDENCE_TOL` grades *geometric intent*, and the *physical overlap* definition is "deliberately" `check_net_connectivity`'s. Via support is a physical question that was wired to the intent constant.

It is not advisory. `check_weird` exits `1 if findings else 0`; `check_complete.py:300` keeps only that code and turns it into `weird_copper: not clean (exit 1)` → **INCOMPLETE**, DONE blocked, a reroute lap spent on copper KiCad grades joined.

## The two checkers contradicted each other

Kuchen geometry — 0.42 mm circle pad on F.Cu, 0.6 mm via, B.Cu run to a second pad — sweeping the via offset and grading with **both** checkers:

| via offset | gap to pad copper | `check_weird` before | after | `check_connected` |
|---|---|---|---|---|
| 0.283 mm | 0.073 | `dangling-via` | clean | 1 component, 0 disconnected |
| 0.500 mm | 0.290 | `dangling-via` | clean | 1 component, 0 disconnected |
| 0.550 mm | 0.340 | `dangling-via` | `dangling-via` | 2 components, 1 disconnected |
| 0.700 mm | 0.490 | `dangling-via` | `dangling-via` | 2 components, 1 disconnected |

They now cross over at the same point.

**No board in `kicad_files/` carries this geometry** — all 33 keep identical per-category finding counts — which is why it went unnoticed. That is a no-regression result, not a reproduction; the reproduction is the contradiction above.

## Second commit: the fab note under-counted, on a real board

`fab_notes.via_in_pad_sites` asked the same question the same wrong way, and it decides whether a run prints the IPC-4761 Type VII note. On the boards' own vias: **707 → 713 sites**, the six new ones all on `rp2350_fpga_eensy_prePlane`, each a genuine overlap against the exact pad shape (edge distances 0.027–0.200 mm against a 0.225 mm barrel).

The widening has to be **exact**. A box is wrong in both directions, and review caught both:

- **Too generous.** A box inflated by the barrel radius reaches `sqrt(2)*(h+r)` on its diagonal — exactly where `bga_fanout` puts a dog-bone via (the half-pitch site it tries *before* the centre tap, then hands to `print_via_in_pad_note`). Simulated on ulx3s's BGA-381: the box named **all 379** dog-bone vias and the exact test named **none**; nearest copper 0.37 mm from a 0.225 mm barrel. A false site here is a fab process that costs money, not a stray line.
- **Too mean.** An axis-aligned box in *board* space clips a rotated pad's copper, since `size_x/size_y` stay in the pad's frame and the tilt rides in `rect_rotation`. A 1.0×0.2 pad at 45° holds (0.35, 0.35) *inside* its copper and a box gate drops it — a missed Type VII callout. That one predates this PR.

So `_pad_holds` rejects with `check_connected`'s diagonal prefilter and answers with `check_drc`'s exact `point_to_pad_distance`, imported *inside* the call so the module still imports as a leaf — the same trick `check_connected._point_in_pad` uses. Only `ImportError` is caught, so a real geometry error surfaces rather than silently downgrading. Cost is bounded: on rp2350 only 27 of 251 via-pad pairs get past the reject.

## Scope, stated rather than assumed

- **Geometry parity only.** `check_connected` expands `pad.layers` and unions on a shared copper layer; `on` here still hands a drilled pad (or one carrying any `*` layer) the via's whole span. Pre-existing; no corpus board has a pad whose copper layers are a strict subset. Named in the code, not fixed here.
- **The zone branch is left alone**, and the header no longer claims it matches the authority: `check_net_connectivity` credits a zone through its *fill* model when given `pcb_data`, so a via in a clearance void inside the outline grades supported here and unsupported there. Also pre-existing.
- **No CLI/GUI parity work.** `check_weird` has no GUI call site; all three `fab_notes` call sites are inside shared engine functions (`route_planes.create_plane`, `qfn_fanout`'s underpad escape, `bga_fanout.generate_underpad_escape`), so the plugin gets this for free. No flag, no parameter, no dialog control. Python-only, no version bump.
- **`margin` changed meaning** — it is now a floor on the barrel credit rather than the whole of it, so it can no longer ask for a *tighter* credit. No in-repo caller passes it. Documented at the three public functions.

## Found while fixing this, NOT fixed here

`_check_soft_joints.at_anchor` has the **same asymmetry**: a via anchor by barrel radius at `check_weird.py:129`, a pad anchor by centre containment at `:131`, four lines apart, where `check_connected.py:1123` uses the cap radius (`_m = max(ewidth/2 - 1e-6, tolerance)`). Reproduced — two 0.25 mm stubs ending 0.05 mm outside a 1.0×0.6 pad, both caps (r = 0.125) physically overlapping the copper:

```
check_connected: num_components = 1, disconnected_pads = []
check_weird    : soft-joint  "endpoint gap 0.120mm ... caps overlap 0.130mm"
```

`soft-joint` carries `size=None`, so `--tolerance` never filters it and it blocks the chain the same way. Left out as a separate failure mode — happy to file it as its own issue if you'd like.

## Verification

- `tests/test_check_weird.py` 35/35, `tests/test_489_via_tenting.py` PASS
- `tests/run_all.py --fast`: **283 passed, 0 failed** (121 integration skipped by `--fast`)
- 29/29 across the via / fanout / fab / connectivity neighbourhood
- 33/33 boards unchanged for `check_weird`; fab sites 707 → 713 with 713/713 real overlaps; ulx3s dog-bone fan 379 → 0 false

Every new test row was mutation-tested and each fails only the rows that name it: reverting the `check_weird` margin, a 10× over-credit, a **correlated** revert of both mirrored margins (`check_weird` + `check_connected`), returning the box result, deleting the radial guard, and restoring the axis-aligned gate. The agreement rows assert what each model must say *absolutely* rather than that the two differ — the `joined != dangling` form passes when both are wrong, which is what the correlated revert produces.
