### PR TITLE
#697: the placement clearance census graded every pad pair at one flat scalar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -532,6 +532,21 @@ pcb = parse_kicad_pcb('path/to/file.kicad_pcb')
   KiCad enforces max(the two items' clearances) per pair; the obstacle stamps
   and check_drc honor it the same way. Clearance consumers should read this
   field, never re-derive footprint inheritance.
+  **The PLACEMENT side honors it too, since #697** — `placement.legality`'s
+  `PadClearanceModel` resolves each pad pair at check_drc's own value
+  (`max(clearance, netclass a, netclass b)` → `.kicad_dru` layer rules over the
+  SHARED copper layers, which REPLACE → `max(…, lc_a, lc_b)`), and CALLS
+  check_drc's `pad_copper_layers` / `pads_shared_layer_clearance` rather than
+  mirroring them. It is strictly inert (`model.active` False, every consumer on
+  its original flat-scalar path) when the board declares no netclass, no dru
+  rule and no pad override. Before #697 the census priced every pair at one
+  flat scalar and read `local_clearance` nowhere in `py_placer/`, so a board
+  failing DRC on a 1.016mm fiducial keep-clear reported **0 conflict pairs** to
+  fix. Two consequences worth knowing: a pair graded above the board-wide
+  clearance is disclosed in `grade_pad_legality`'s `required` key (print it via
+  `legality.format_required_clause`, never a hand-copied string), and
+  `placement/fanout_clearance.py` is a SEPARATE flat-scalar channel that still
+  has this bug.
 
 ### Through-Hole vs SMD Pads
 

--- a/py_placer/place_optimize.py
+++ b/py_placer/place_optimize.py
@@ -203,7 +203,8 @@ Examples:
     # the report pair. Gate-currency tallies live inside the quench; this is
     # the phantom-free number an auditor compares.
     from placement.legality import (grade_pad_legality,
-                                    format_oob_clause as _oob_clause)
+                                    format_oob_clause as _oob_clause,
+                                    format_required_clause as _req_clause)
     legality_before = None
     if not args.courtyard_only:
         legality_before = grade_pad_legality(pcb_data, args.clearance,
@@ -214,6 +215,9 @@ Examples:
               f"pad copper off-board"
               + (": " + _oob_clause(legality_before)
                  if _oob_clause(legality_before) else ""))
+        if _req_clause(legality_before):
+            print(f"  above the {args.clearance}mm floor: "
+                  f"{_req_clause(legality_before)}")
 
     ratsnest = {}
     summary = {'parts_moved': 0}
@@ -303,6 +307,10 @@ Examples:
               f"pad copper off-board"
               + (": " + _oob_clause(legality_after)
                  if _oob_clause(legality_after) else ""))
+        if _req_clause(legality_after):
+            print(f"  above the {args.clearance}mm floor: "
+                  f"{_req_clause(legality_after)}")
+        summary['pad_clearance_required'] = legality_after['required']
         for key in ('pad_conflicts', 'hole_conflicts', 'oob_pad_count'):
             summary[f'{key}_before'] = legality_before[key]
             summary[f'{key}_after'] = legality_after[key]

--- a/py_placer/place_optimize.py
+++ b/py_placer/place_optimize.py
@@ -206,7 +206,8 @@ Examples:
                                     format_oob_clause as _oob_clause)
     legality_before = None
     if not args.courtyard_only:
-        legality_before = grade_pad_legality(pcb_data, args.clearance)
+        legality_before = grade_pad_legality(pcb_data, args.clearance,
+                                             pcb_file=args.input_file)
         print(f"Pad legality before: {legality_before['pad_conflicts']} "
               f"conflict pair(s), {legality_before['hole_conflicts']} hole "
               f"conflict(s), {legality_before['oob_pad_count']} part(s) with "
@@ -294,7 +295,8 @@ Examples:
     # means a gate has a hole and is worth a bug report.
     if legality_before is not None:
         legality_after = grade_pad_legality(parse_kicad_pcb(args.output_file),
-                                            args.clearance)
+                                            args.clearance,
+                                            pcb_file=args.output_file)
         print(f"Pad legality after: {legality_after['pad_conflicts']} "
               f"conflict pair(s), {legality_after['hole_conflicts']} hole "
               f"conflict(s), {legality_after['oob_pad_count']} part(s) with "

--- a/py_placer/place_reconstruct.py
+++ b/py_placer/place_reconstruct.py
@@ -652,7 +652,8 @@ Examples:
     _promote_staged(staged, args.output_file)
 
     out_pcb = parse_kicad_pcb(args.output_file)
-    final = grade_pad_legality(out_pcb, args.clearance)
+    final = grade_pad_legality(out_pcb, args.clearance,
+                               pcb_file=args.output_file)
     report['final'] = {k: final[k] for k in
                        ('pad_conflicts', 'pad_shortfall', 'hole_conflicts',
                         'oob_pad_count', 'oob_pad_amount', 'exact')}
@@ -673,7 +674,13 @@ Examples:
           f"{final['hole_conflicts']} hole conflict(s), "
           f"{final['oob_pad_count']} part(s) with pad copper off-board, "
           f"{body['blocking']} blocking body pair(s)")
-    _oc = __import__('placement.legality', fromlist=['x']).format_oob_clause(final)
+    _leg_mod = __import__('placement.legality', fromlist=['x'])
+    # #697: name the pairs graded above args.clearance and what raised them,
+    # before the count above is read as a violation of the announced floor.
+    _rq = _leg_mod.format_required_clause(final)
+    if _rq:
+        print(f"  above the {args.clearance}mm floor: {_rq}")
+    _oc = _leg_mod.format_oob_clause(final)
     if _oc:
         # Printed BEFORE the edge_connectors advice below, because that advice
         # tells the reader to declare a by-design overhang -- and this measure

--- a/py_placer/place_seed.py
+++ b/py_placer/place_seed.py
@@ -319,7 +319,8 @@ Examples:
             copy_siblings(cur, args.output_file)
             from placement.legality import grade_pad_legality
             pcb_out = parse_kicad_pcb(args.output_file)
-            pads_after = grade_pad_legality(pcb_out, args.clearance)
+            pads_after = grade_pad_legality(pcb_out, args.clearance,
+                                            pcb_file=args.output_file)
             graded = floorplan.grade(intent, pcb_out, args.output_file,
                                      group_sources=sources,
                                      clearance=args.clearance,

--- a/py_placer/place_seed.py
+++ b/py_placer/place_seed.py
@@ -329,6 +329,13 @@ Examples:
                 print(f"  GRADE ERROR [{v.rule}] {v.message}")
             summary['grade_errors'] = len(graded.errors)
             summary['pad_conflicts_after'] = pads_after['pad_conflicts']
+            # #697: the requirement each counted pair was graded at, when it
+            # sits above args.clearance, so the count is explainable.
+            summary['pad_clearance_required'] = pads_after.get('required') or []
+            from placement.legality import format_required_clause as _req_cl
+            if _req_cl(pads_after):
+                print(f"  above the {args.clearance}mm floor: "
+                      f"{_req_cl(pads_after)}")
             summary['hole_conflicts_after'] = pads_after['hole_conflicts']
             summary['oob_pad_count_after'] = pads_after['oob_pad_count']
             if graded.errors:

--- a/py_placer/placement/legality.py
+++ b/py_placer/placement/legality.py
@@ -1353,6 +1353,193 @@ class PairShortfall(NamedTuple):
 ZERO_SHORTFALL = PairShortfall(0.0, False, 0.0, False)
 
 
+def _pad_carries_copper(p) -> bool:
+    """Does this pad put copper on a copper layer?
+
+    The predicate `PartPads` builds its pad list from, `_pad_with_copper` walks
+    its index with, and `PadClearanceModel` tests inertness by. It has to be ONE
+    function: they are the same two conditions, and they must agree or the
+    rect index stops addressing the pad. Measured when they did not: watchy
+    declares `local_clearance` on 8 NPTH pads that carry no copper, so a raw
+    scan of `fp.pads` reported the board as having overrides while its parts'
+    `max_floor` was 0.0 -- the board lost its inertness for nothing.
+    """
+    from check_drc import _pad_has_no_copper
+    if _pad_has_no_copper(p):
+        return False
+    return any(str(l).endswith('.Cu') for l in (getattr(p, 'layers', None) or ()))
+
+
+class PadFloor(NamedTuple):
+    """One pad's required-clearance inputs, resolved once at build time.
+
+    `ncl` is its net's non-Default net-class clearance, `lc` its own (or its
+    footprint's, already resolved by the parser) `local_clearance` override,
+    and `layers` the copper layers its copper occupies -- carried only when the
+    board has .kicad_dru rules to scope, else None.
+    """
+    ncl: float
+    lc: float
+    layers: object = None
+
+
+ZERO_FLOOR = PadFloor(0.0, 0.0, None)
+
+
+class PadClearanceModel:
+    """The per-pair required clearance, resolved exactly as check_drc does.
+
+    #697: the placement census used to price every pad pair at one flat scalar,
+    so a board that could not pass DRC reported nothing to fix. Measured: a
+    fiducial keep-clear pad (`local_clearance` 1.016mm) 0.94mm from a connector
+    pad -- `check_drc` flagged it, while `grade_pad_legality` and
+    `place_reconstruct --stages legalize` both reported 0 conflict pairs.
+
+    The formula is check_drc's, and deliberately CALLS its code rather than
+    mirroring it (`check_drc.pads_shared_layer_clearance`, `pad_copper_layers`)::
+
+        base = max(global clearance, netclass(a), netclass(b))
+        eff  = <.kicad_dru layer rules over the SHARED copper layers>   # REPLACES
+        eff  = max(eff, lc_a, lc_b)                                     # override wins
+
+    Note the override enters as a max over BOTH pads: check_drc needs a second
+    max at its own pad-pad call site for the same reason, because a pair is
+    equally in violation when only the SECOND pad carries the keep-clear.
+
+    `active` is False -- and every consumer then takes its original flat-scalar
+    path unchanged -- when the board declares no netclass, no dru rule and no
+    pad override. That is the common case, and the reason this cannot perturb
+    an ordinary board.
+    """
+
+    __slots__ = ('base', 'net_floor', 'layer_rules', 'board_copper',
+                 'rule_max', 'active', '_pair_cache')
+
+    def __init__(self, base: float, net_floor=None, layer_rules=None,
+                 board_copper=(), has_overrides: bool = False):
+        self.base = float(base)
+        self.net_floor = dict(net_floor or {})
+        self.layer_rules = dict(layer_rules or {})
+        self.board_copper = list(board_copper or [])
+        self.rule_max = max(self.layer_rules.values()) if self.layer_rules else 0.0
+        self.active = bool(self.net_floor or self.layer_rules or has_overrides)
+        self._pair_cache = {}
+
+    # -- construction ---------------------------------------------------------
+    @classmethod
+    def for_board(cls, pcb_data, clearance: float, pcb_file: str = None):
+        """Resolve from the board's own sibling files.
+
+        Path discovery is the #498 rule: the caller's `pcb_file` when it has
+        one, else `PCBData.source_path` (engines whose signature carries no
+        input file). A missing sibling is a strict no-op, never an error -- the
+        model simply carries fewer sources.
+        """
+        path = pcb_file or getattr(pcb_data, 'source_path', '') or ''
+        fps = getattr(pcb_data, 'footprints', None) or {}
+        has_overrides = any(
+            (getattr(p, 'local_clearance', 0.0) or 0.0) > 0.0
+            and _pad_carries_copper(p)
+            for fp in fps.values()
+            for p in (getattr(fp, 'pads', None) or ()))
+        board_copper = list(
+            getattr(getattr(pcb_data, 'board_info', None), 'copper_layers', None)
+            or [])
+        net_floor = {}
+        layer_rules = {}
+        if path:
+            try:
+                from list_nets import net_clearance_map_by_id
+                nets = getattr(pcb_data, 'nets', None) or {}
+                net_floor = net_clearance_map_by_id(
+                    path, {nid: n.name for nid, n in nets.items()
+                           if getattr(n, 'name', None)}) or {}
+            except Exception:                                   # noqa: BLE001
+                net_floor = {}
+            try:
+                from kicad_dru import read_board_layer_clearances
+                layer_rules, _notes = read_board_layer_clearances(
+                    path, board_copper)
+            except Exception:                                   # noqa: BLE001
+                layer_rules = {}
+        return cls(clearance, net_floor, layer_rules, board_copper,
+                   has_overrides=has_overrides)
+
+    # -- per-pad --------------------------------------------------------------
+    def pad_floor(self, pad):
+        """This pad's clearance inputs.
+
+        `getattr` on local_clearance, never a bare attribute read: the placement
+        tests build duck-typed pad fakes that do not carry the field, and a hard
+        read would turn a missing attribute into a crash instead of the "no
+        override" it means.
+        """
+        lc = getattr(pad, 'local_clearance', 0.0) or 0.0
+        ncl = self.net_floor.get(getattr(pad, 'net_id', 0) or 0, 0.0)
+        layers = None
+        if self.layer_rules:
+            from check_drc import pad_copper_layers
+            layers = frozenset(pad_copper_layers(pad, self.board_copper))
+        return PadFloor(float(ncl), float(lc), layers)
+
+    def max_floor(self, floor) -> float:
+        """An UPPER BOUND on what this pad can require of any partner, for the
+        broad phases only. Never the requirement itself: a dru rule REPLACES, so
+        it can also LOWER the pair value below `base`, and a broad phase that
+        under-reaches drops real pairs (over-reaching only costs a test)."""
+        v = max(floor.ncl, floor.lc)
+        if self.layer_rules and floor.layers:
+            for l in floor.layers:
+                r = self.layer_rules.get(l)
+                if r is not None and r > v:
+                    v = r
+        return v
+
+    # -- the pair -------------------------------------------------------------
+    def pair(self, fa, fb) -> float:
+        """The required clearance between two pads (mm)."""
+        return self.pair_with_source(fa, fb)[0]
+
+    def pair_with_source(self, fa, fb):
+        """(required clearance in mm, what set it).
+
+        The source is recorded AT the assignment, never reconstructed from the
+        final value. Reconstruction is wrong under the dru's REPLACE semantics:
+        with netclass 0.5 and a layer rule replacing it to 0.3, the value 0.3
+        still satisfies `max(ncl) >= eff`, so an after-the-fact test attributes
+        it to the net class when the RULE set it. Disclosure is the whole point
+        of carrying this, so it has to be exact.
+
+        The empty source means "the board-wide floor" -- the same test
+        check_drc's `_mark_required` applies before disclosing anything.
+        """
+        eff = self.base
+        src = ''
+        if fa.ncl > eff:
+            eff, src = fa.ncl, 'netclass'
+        if fb.ncl > eff:
+            eff, src = fb.ncl, 'netclass'
+        if self.layer_rules:
+            key = (fa.layers, fb.layers, eff)
+            cached = self._pair_cache.get(key)
+            if cached is None:
+                from check_drc import pads_shared_layer_clearance
+                cached = pads_shared_layer_clearance(
+                    eff, self.layer_rules, fa.layers or (), fb.layers or ())
+                self._pair_cache[key] = cached
+            if cached != eff:
+                # REPLACE: a rule may raise OR lower, and either way it is the
+                # rule that decided the value.
+                eff, src = cached, 'layer rule'
+        if fa.lc > eff:
+            eff, src = fa.lc, 'pad override'
+        if fb.lc > eff:
+            eff, src = fb.lc, 'pad override'
+        if eff <= self.base + EPS:
+            src = ''
+        return eff, src
+
+
 class PartPads:
     """Pose-owning pad/hole model for one footprint.
 
@@ -1362,13 +1549,24 @@ class PartPads:
     transform. Half-extents fold `rect_rotation` into an axis-aligned bbox,
     exact for the axis-aligned pads that dominate placement and conservative
     for the rest.
+
+    With a `PadClearanceModel` (#697) each copper pad also carries its
+    required-clearance inputs in `pad_floors`, INDEX-ALIGNED with `pads_local`
+    and therefore with everything `pad_rects` emits. Without one -- the default,
+    and what the silk (labels.py) and extent-only (routability.py) consumers
+    pass -- `pad_floors` is empty and `max_floor` is 0.0, so every caller keeps
+    its original flat-scalar behaviour exactly.
+
+    `pad_rects`' 6-tuple is deliberately NOT widened to carry the floor: it is a
+    public shape (render_placement slices `r[:4]`, two test modules unpack it
+    positionally) and the rect index already addresses the pad.
     """
 
     __slots__ = ('ref', 'side', 'has_tht', 'seed_rot', 'pads_local',
                  'holes_local', 'n_pads', '_pad_cache', '_hole_cache',
-                 '_ext_cache')
+                 '_ext_cache', 'pad_floors', 'max_floor')
 
-    def __init__(self, fp, clearance: float):
+    def __init__(self, fp, clearance: float, model=None):
         # Local imports: check_drc pulls the whole DRC stack (see the
         # BoardOutlineGate note); kicad_parser is cheap but keeps the module's
         # import surface unchanged for existing consumers.
@@ -1382,6 +1580,8 @@ class PartPads:
         self.seed_rot = (fp.rotation or 0.0) % 360
         self.pads_local = []    # (off_x, off_y, half_x, half_y, net_id, pside)
         self.holes_local = []   # (off_x, off_y, radius) -- NPTH keepouts, inflated
+        self.pad_floors = []    # PadFloor per copper pad, index-aligned (#697)
+        self.max_floor = 0.0    # upper bound on this part's pad requirements
         npth_grow = max(0.0, defaults.NPTH_TO_TRACK_CLEARANCE - clearance)
         for p in fp.pads:
             if _pad_has_no_copper(p):
@@ -1396,6 +1596,8 @@ class PartPads:
             copper = [l for l in p.layers if str(l).endswith('.Cu')]
             if not copper:
                 continue    # paste/mask-only aperture
+            # The two skips above ARE `_pad_carries_copper`; keep them in step
+            # with it (see that function -- the index contract depends on it).
             through = (p.drill or 0) > 0
             pside = None if through else (
                 'B' if any(str(l).startswith('B') for l in copper) else 'F')
@@ -1405,6 +1607,12 @@ class PartPads:
             self.pads_local.append((p.global_x - fp.x, p.global_y - fp.y,
                                     hx * c + hy * s, hx * s + hy * c,
                                     p.net_id, pside))
+            if model is not None:
+                floor = model.pad_floor(p)
+                self.pad_floors.append(floor)
+                mf = model.max_floor(floor)
+                if mf > self.max_floor:
+                    self.max_floor = mf
         self.n_pads = len(self.pads_local)
         self._pad_cache: Dict[float, list] = {}
         self._hole_cache: Dict[float, list] = {}
@@ -1477,13 +1685,18 @@ class PartPads:
 
 
 def build_part_pads(footprints: Dict[str, object],
-                    clearance: float) -> Dict[str, 'PartPads']:
-    """PartPads for every footprint that has any pad (copper or NPTH)."""
+                    clearance: float, model=None) -> Dict[str, 'PartPads']:
+    """PartPads for every footprint that has any pad (copper or NPTH).
+
+    `model` is an optional `PadClearanceModel` (#697); without it the parts
+    carry no per-pad clearance floors and every consumer behaves exactly as
+    before.
+    """
     out = {}
     for ref, fp in footprints.items():
         if not getattr(fp, 'pads', None):
             continue
-        pp = PartPads(fp, clearance)
+        pp = PartPads(fp, clearance, model)
         if pp.n_pads or pp.holes_local:
             out[ref] = pp
     return out
@@ -1518,10 +1731,15 @@ class LegalityContext:
 
     def __init__(self, part_pads: Dict[str, PartPads],
                  gate: Optional[BoardOutlineGate], clearance: float,
-                 pose_of, seed_of):
+                 pose_of, seed_of, model=None):
         self.parts = part_pads
         self.gate = gate
         self.clearance = clearance
+        # #697: the per-pair required clearance, when the board declares one
+        # above the flat scalar (pad override / netclass / .kicad_dru rule).
+        # None -- the common case, and every board that declares nothing -- is
+        # the original flat-scalar path, unchanged and untouched.
+        self._floors = model if (model is not None and model.active) else None
         self.pose_of = pose_of
         self.seed_of = seed_of
         self._baselines: Dict[Tuple[str, str], PairShortfall] = {}
@@ -1555,21 +1773,34 @@ class LegalityContext:
         eb = pb.extent(xb, yb, rb)
         if ea is None or eb is None:
             return ZERO_SHORTFALL
-        if rect_gap(ea, eb) >= self.clearance - EPS:
+        model = self._floors
+        # The pair's REACH: how far apart these two parts can still interact.
+        # With per-pad floors it is bounded by THESE TWO PARTS' own maxima, not
+        # by the board-wide maximum -- this test runs per candidate pose
+        # (quench.candidate_valid -> pads_ok), so a board-wide bound would slow
+        # every pair on the board for the sake of one fiducial.
+        reach = (self.clearance if model is None
+                 else max(self.clearance, model.base,
+                          pa.max_floor, pb.max_floor))
+        if rect_gap(ea, eb) >= reach - EPS:
             return ZERO_SHORTFALL
         if pa.n_pads * pb.n_pads > PAIR_TEST_CAP:
             # Extent-level verdict only: charge the extent shortfall as pad
             # shortfall so the baseline comparison still constrains the pair.
             g = rect_gap(ea, eb)
-            return PairShortfall(max(0.0, self.clearance - g), g < 0.0, 0.0,
+            return PairShortfall(max(0.0, reach - g), g < 0.0, 0.0,
                                  g < 0.0)
         rects_a = pa.pad_rects(xa, ya, ra)
         rects_b = pb.pad_rects(xb, yb, rb)
+        floors_a = pa.pad_floors if model is not None else None
+        floors_b = pb.pad_floors if model is not None else None
         pad_short = 0.0
         overlap = False
         stack = False
-        for a0, a1, a2, a3, na, sa in rects_a:
-            for b0, b1, b2, b3, nb, sb in rects_b:
+        clr = self.clearance
+        for ai, (a0, a1, a2, a3, na, sa) in enumerate(rects_a):
+            fa = floors_a[ai] if floors_a else None
+            for bi, (b0, b1, b2, b3, nb, sb) in enumerate(rects_b):
                 if not _sides_interact(sa, sb):
                     continue
                 g = rect_gap((a0, a1, a2, a3), (b0, b1, b2, b3))
@@ -1580,8 +1811,14 @@ class LegalityContext:
                     stack = True
                 if na == nb and na > 0:
                     continue
-                if g < self.clearance - EPS:
-                    pad_short += self.clearance - g
+                # Cheap pre-reject before resolving the pair's requirement: it
+                # can never exceed `reach`, so a gap at or beyond it is clear
+                # whatever the two pads declare.
+                if g >= reach - EPS:
+                    continue
+                eff = clr if fa is None else model.pair(fa, floors_b[bi])
+                if g < eff - EPS:
+                    pad_short += eff - g
                     if g < 0.0:
                         overlap = True
         hole = 0.0
@@ -1649,6 +1886,27 @@ class LegalityContext:
         return self.gate.rect_outside_amount(ext, exact=exact, edges=edges)
 
 
+def format_required_clause(report, limit: int = 6) -> str:
+    """One line naming the pairs graded ABOVE the board-wide clearance, and WHY.
+
+    Lives beside the measure for the same reason `format_oob_clause` does: a
+    printed basis hand-copied into each CLI is the Class-2 drift CLAUDE.md
+    warns about, and no parity gate covers a print.
+
+    Without this the #697 fix would trade one confusing report for another --
+    the census would start counting a pair that is nowhere near the `--clearance`
+    the run announced, with nothing on screen to explain the gap. Returns ''
+    when every pair is graded at the flat scalar, which is the common case.
+    """
+    rows = list(report.get('required') or [])
+    if not rows:
+        return ''
+    shown = ', '.join('{}<->{} requires {:g}mm ({})'.format(a, b, mm, src)
+                      for a, b, mm, src in rows[:limit])
+    more = ' ... showing {} of {}'.format(limit, len(rows)) if len(rows) > limit else ''
+    return shown + more
+
+
 def format_oob_clause(report, limit: int = 6) -> str:
     """One line naming the off-board parts AND which measure produced them.
 
@@ -1678,7 +1936,8 @@ def format_oob_clause(report, limit: int = 6) -> str:
 
 def grade_pad_legality(pcb_data, clearance: float, exact: bool = True,
                        edge_margin: Optional[float] = None,
-                       worst_n: int = 10) -> Dict[str, object]:
+                       worst_n: int = 10,
+                       pcb_file: str = None) -> Dict[str, object]:
     """Board-level pad/hole legality audit at the FILE's own poses.
 
     AABB broad phase over all cross-footprint pad pairs; with `exact` (the
@@ -1687,14 +1946,29 @@ def grade_pad_legality(pcb_data, clearance: float, exact: bool = True,
 
         {'pad_conflicts': int, 'pad_shortfall': mm, 'hole_conflicts': int,
          'oob_pad_count': int, 'oob_pad_amount': mm,
-         'worst': [(refA, refB, mm), ...], 'exact': bool}
+         'worst': [(refA, refB, mm), ...],
+         'required': [[refA, refB, mm, source], ...], 'exact': bool}
+
+    `clearance` is the BOARD-WIDE floor, not the whole requirement. Each pair is
+    graded at check_drc's own value -- max over the two nets' net classes, the
+    board's .kicad_dru per-layer rules, and either pad's `local_clearance`
+    override -- resolved by `PadClearanceModel` (#697). Pairs whose requirement
+    exceeds `clearance` are named in `required` with the source that raised
+    them, mirroring check_drc's `required_mm` disclosure; a board that declares
+    none of the three grades exactly as it did before.
+
+    `worst` deliberately stays a 3-tuple: seeder's repair census unpacks it
+    positionally, and the disclosure rides the separate `required` list.
 
     Consumers: place_optimize / place_seed JSON summaries, the render
     legality overlay, and the reconstruct gate.
     """
     fps = pcb_data.footprints
     pads_by_ref = {ref: [p for p in fp.pads] for ref, fp in fps.items()}
-    parts = build_part_pads(fps, clearance)
+    model = PadClearanceModel.for_board(pcb_data, clearance, pcb_file)
+    if not model.active:
+        model = None
+    parts = build_part_pads(fps, clearance, model)
     routing_layers = list(getattr(pcb_data.board_info, 'copper_layers', []) or [])
     check_exact = None
     if exact:
@@ -1720,6 +1994,15 @@ def grade_pad_legality(pcb_data, clearance: float, exact: bool = True,
             for gy in range(int(ext[1] // cell), int(ext[3] // cell) + 1):
                 grid.setdefault((gx, gy), set()).add(ref)
 
+    # The census reach. Unlike the per-candidate gate this runs ONCE, and the
+    # requirement is a max over BOTH members of a pair -- so the halo must cover
+    # the largest floor any partner could contribute, which is the board-wide
+    # maximum. Under-reaching here is how the original bug hid: a fiducial
+    # keep-clear 1.016mm wide never entered a census bounded at 0.15 + 0.5.
+    board_max_floor = max([pp.max_floor for pp in parts.values()] or [0.0])
+    census_reach = max(clearance, board_max_floor,
+                       model.base if model is not None else 0.0)
+
     def near_refs(ref):
         fp = fps[ref]
         pp = parts[ref]
@@ -1727,7 +2010,7 @@ def grade_pad_legality(pcb_data, clearance: float, exact: bool = True,
         if ext is None:
             return ()
         out = set()
-        m = clearance + 0.5
+        m = census_reach + 0.5
         for gx in range(int((ext[0] - m) // cell), int((ext[2] + m) // cell) + 1):
             for gy in range(int((ext[1] - m) // cell), int((ext[3] + m) // cell) + 1):
                 out |= grid.get((gx, gy), set())
@@ -1738,6 +2021,7 @@ def grade_pad_legality(pcb_data, clearance: float, exact: bool = True,
     pad_shortfall = 0.0
     hole_conflicts = 0
     worst: List[Tuple[str, str, float]] = []
+    required: List[list] = []
     seen_pairs = set()
     for ref in sorted(parts):
         rects_a, holes_a = entries[ref]
@@ -1747,35 +2031,56 @@ def grade_pad_legality(pcb_data, clearance: float, exact: bool = True,
                 continue
             seen_pairs.add(key)
             rects_b, holes_b = entries[other]
+            floors_a = parts[ref].pad_floors if model is not None else None
+            floors_b = parts[other].pad_floors if model is not None else None
+            pair_reach = (clearance if model is None else
+                          max(clearance, model.base, parts[ref].max_floor,
+                              parts[other].max_floor))
             pair_mm = 0.0
             pair_hit = False
+            pair_required = 0.0
+            pair_source = ''
             for ai, (a0, a1, a2, a3, na, sa) in enumerate(rects_a):
+                fa = floors_a[ai] if floors_a else None
                 for bi, (b0, b1, b2, b3, nb, sb) in enumerate(rects_b):
                     if na == nb and na > 0:
                         continue
                     if not _sides_interact(sa, sb):
                         continue
                     g = rect_gap((a0, a1, a2, a3), (b0, b1, b2, b3))
-                    if g >= clearance - EPS:
+                    if g >= pair_reach - EPS:
+                        continue
+                    if fa is None:
+                        eff, src = clearance, ''
+                    else:
+                        eff, src = model.pair_with_source(fa, floors_b[bi])
+                    if g >= eff - EPS:
                         continue
                     if check_exact is not None:
                         pa = _pad_with_copper(pads_by_ref[ref], ai, clearance)
                         pb = _pad_with_copper(pads_by_ref[other], bi, clearance)
                         if pa is not None and pb is not None:
-                            hit, over, _pt = check_exact(pa, pb, clearance,
+                            hit, over, _pt = check_exact(pa, pb, eff,
                                                          routing_layers,
                                                          clearance_margin=0.0)
                             if not hit:
                                 continue
                             pair_mm += over
                             pair_hit = True
+                            if eff > pair_required:
+                                pair_required, pair_source = eff, src
                             continue
-                    pair_mm += clearance - g
+                    pair_mm += eff - g
                     pair_hit = True
+                    if eff > pair_required:
+                        pair_required, pair_source = eff, src
             if pair_hit:
                 pad_conflicts += 1
                 pad_shortfall += pair_mm
                 worst.append((key[0], key[1], round(pair_mm, 4)))
+                if pair_source:
+                    required.append([key[0], key[1],
+                                     round(pair_required, 4), pair_source])
             hole_pen = 0.0
             for cx, cy, r in holes_b:
                 for a0, a1, a2, a3, _na, _sa in rects_a:
@@ -1836,18 +2141,26 @@ def grade_pad_legality(pcb_data, clearance: float, exact: bool = True,
             # worst_n <= 0 = list ALL (run-4 F5: the repair rung's census
             # was silently capped at 10 movers on a 20-pair board).
             'worst': worst[:worst_n] if worst_n and worst_n > 0 else worst,
+            # #697: pairs whose REQUIREMENT exceeds the board-wide `clearance`,
+            # with what raised it -- check_drc's `required_mm` disclosure, so a
+            # conflict the flat scalar could not explain does not read as an
+            # unexplained number. Empty on a board that declares no netclass,
+            # no .kicad_dru rule and no pad override.
+            'required': sorted(required, key=lambda r: (-r[2], r[0], r[1])),
             'exact': check_exact is not None}
 
 
 def _pad_with_copper(pads, copper_index: int, clearance: float):
     """The Nth COPPER pad of a footprint's pad list (grade_pad_legality's
-    PartPads indices count copper pads only, in construction order)."""
-    from check_drc import _pad_has_no_copper
+    PartPads indices count copper pads only, in construction order).
+
+    The skip conditions here MIRROR `PartPads.__init__`'s, and that mirroring is
+    what makes the index valid. Since #697 the same index also addresses
+    `PartPads.pad_floors`, so a change to either skip rule must change both.
+    """
     n = -1
     for p in pads:
-        if _pad_has_no_copper(p):
-            continue
-        if not any(str(l).endswith('.Cu') for l in p.layers):
+        if not _pad_carries_copper(p):
             continue
         n += 1
         if n == copper_index:

--- a/py_placer/placement/legality.py
+++ b/py_placer/placement/legality.py
@@ -1353,6 +1353,20 @@ class PairShortfall(NamedTuple):
 ZERO_SHORTFALL = PairShortfall(0.0, False, 0.0, False)
 
 
+# Local import at module scope would drag the whole DRC stack in at import
+# time (see the BoardOutlineGate note); bound once on first use instead of once
+# per pad, which is where the old inline copy had it.
+def _pad_has_no_copper(p):
+    global _PAD_HAS_NO_COPPER
+    if _PAD_HAS_NO_COPPER is None:
+        from check_drc import _pad_has_no_copper as _f
+        _PAD_HAS_NO_COPPER = _f
+    return _PAD_HAS_NO_COPPER(p)
+
+
+_PAD_HAS_NO_COPPER = None
+
+
 def _pad_carries_copper(p) -> bool:
     """Does this pad put copper on a copper layer?
 
@@ -1364,7 +1378,6 @@ def _pad_carries_copper(p) -> bool:
     scan of `fp.pads` reported the board as having overrides while its parts'
     `max_floor` was 0.0 -- the board lost its inertness for nothing.
     """
-    from check_drc import _pad_has_no_copper
     if _pad_has_no_copper(p):
         return False
     return any(str(l).endswith('.Cu') for l in (getattr(p, 'layers', None) or ()))
@@ -1381,9 +1394,6 @@ class PadFloor(NamedTuple):
     ncl: float
     lc: float
     layers: object = None
-
-
-ZERO_FLOOR = PadFloor(0.0, 0.0, None)
 
 
 class PadClearanceModel:
@@ -1413,7 +1423,7 @@ class PadClearanceModel:
     """
 
     __slots__ = ('base', 'net_floor', 'layer_rules', 'board_copper',
-                 'rule_max', 'active', '_pair_cache')
+                 'active', 'notes', '_pair_cache')
 
     def __init__(self, base: float, net_floor=None, layer_rules=None,
                  board_copper=(), has_overrides: bool = False):
@@ -1421,8 +1431,8 @@ class PadClearanceModel:
         self.net_floor = dict(net_floor or {})
         self.layer_rules = dict(layer_rules or {})
         self.board_copper = list(board_copper or [])
-        self.rule_max = max(self.layer_rules.values()) if self.layer_rules else 0.0
         self.active = bool(self.net_floor or self.layer_rules or has_overrides)
+        self.notes = []
         self._pair_cache = {}
 
     # -- construction ---------------------------------------------------------
@@ -1447,23 +1457,47 @@ class PadClearanceModel:
             or [])
         net_floor = {}
         layer_rules = {}
+        notes = []
         if path:
+            nets = getattr(pcb_data, 'nets', None) or {}
             try:
-                from list_nets import net_clearance_map_by_id
-                nets = getattr(pcb_data, 'nets', None) or {}
-                net_floor = net_clearance_map_by_id(
-                    path, {nid: n.name for nid, n in nets.items()
-                           if getattr(n, 'name', None)}) or {}
-            except Exception:                                   # noqa: BLE001
+                # check_drc's map, NOT the router's `net_clearance_map_by_id`.
+                # That one omits every net resolving only to Default and takes
+                # the MAX over all matching classes -- both correct for a
+                # router (a Default net routes at config.clearance;
+                # over-blocking is safe) and both wrong for a grader, which has
+                # to agree with check_drc pair for pair. Dropping Default
+                # re-created this very issue whenever an explicit --clearance
+                # sits BELOW the board's Default class, which check_assembly
+                # tells users they may pass; taking the max over glob
+                # memberships invented requirements check_drc grades clean.
+                from list_nets import net_clearance_map
+                by_name = net_clearance_map(
+                    path, [n.name for n in nets.values()
+                           if getattr(n, 'name', None)]) or {}
+                # Same admission rule as check_drc: a class at or below the
+                # board-wide floor cannot raise anything, so it never enters.
+                net_floor = {nid: by_name[n.name]
+                             for nid, n in nets.items()
+                             if getattr(n, 'name', None) in by_name
+                             and by_name[n.name] > clearance}
+            except Exception as exc:                            # noqa: BLE001
                 net_floor = {}
+                notes.append('net classes unread (%s: %s)'
+                             % (type(exc).__name__, exc))
             try:
                 from kicad_dru import read_board_layer_clearances
-                layer_rules, _notes = read_board_layer_clearances(
+                layer_rules, dru_notes = read_board_layer_clearances(
                     path, board_copper)
-            except Exception:                                   # noqa: BLE001
+                notes.extend('.kicad_dru: ' + n for n in dru_notes)
+            except Exception as exc:                            # noqa: BLE001
                 layer_rules = {}
-        return cls(clearance, net_floor, layer_rules, board_copper,
-                   has_overrides=has_overrides)
+                notes.append('.kicad_dru unread (%s: %s)'
+                             % (type(exc).__name__, exc))
+        model = cls(clearance, net_floor, layer_rules, board_copper,
+                    has_overrides=has_overrides)
+        model.notes = notes
+        return model
 
     # -- per-pad --------------------------------------------------------------
     def pad_floor(self, pad):
@@ -1535,7 +1569,10 @@ class PadClearanceModel:
             eff, src = fa.lc, 'pad override'
         if fb.lc > eff:
             eff, src = fb.lc, 'pad override'
-        if eff <= self.base + EPS:
+        if eff <= self.base + 1e-9:
+            # check_drc's `_mark_required` threshold exactly, not legality's
+            # 1e-6 EPS: a requirement between the two would be disclosed by one
+            # grader and not the other.
             src = ''
         return eff, src
 
@@ -1570,7 +1607,6 @@ class PartPads:
         # Local imports: check_drc pulls the whole DRC stack (see the
         # BoardOutlineGate note); kicad_parser is cheap but keeps the module's
         # import surface unchanged for existing consumers.
-        from check_drc import _pad_has_no_copper
         from kicad_parser import pad_drill_circles
         import routing_defaults as defaults
 
@@ -1584,20 +1620,18 @@ class PartPads:
         self.max_floor = 0.0    # upper bound on this part's pad requirements
         npth_grow = max(0.0, defaults.NPTH_TO_TRACK_CLEARANCE - clearance)
         for p in fp.pads:
-            if _pad_has_no_copper(p):
+            if not _pad_carries_copper(p):
                 # Copper-less drilled pad (NPTH mounting hole): the DRILL still
                 # removes copper closer than the NPTH-to-track floor. Inflation
-                # matches fanout_clearance's foreign-pad keepouts.
-                if (p.drill or 0) > 0:
+                # matches fanout_clearance's foreign-pad keepouts. A
+                # paste/mask-only aperture has neither copper nor a hole and
+                # simply drops out.
+                if _pad_has_no_copper(p) and (p.drill or 0) > 0:
                     for hx, hy, hd in pad_drill_circles(p):
                         self.holes_local.append(
                             (hx - fp.x, hy - fp.y, hd / 2.0 + npth_grow))
                 continue
             copper = [l for l in p.layers if str(l).endswith('.Cu')]
-            if not copper:
-                continue    # paste/mask-only aperture
-            # The two skips above ARE `_pad_carries_copper`; keep them in step
-            # with it (see that function -- the index contract depends on it).
             through = (p.drill or 0) > 0
             pside = None if through else (
                 'B' if any(str(l).startswith('B') for l in copper) else 'F')
@@ -1966,6 +2000,10 @@ def grade_pad_legality(pcb_data, clearance: float, exact: bool = True,
     fps = pcb_data.footprints
     pads_by_ref = {ref: [p for p in fp.pads] for ref, fp in fps.items()}
     model = PadClearanceModel.for_board(pcb_data, clearance, pcb_file)
+    # Keep the notes even when the model is dropped: a source that FAILED to
+    # read is exactly what makes the model look inert, so reading them off the
+    # dropped object loses them in the one case they matter.
+    clearance_notes = list(model.notes)
     if not model.active:
         model = None
     parts = build_part_pads(fps, clearance, model)
@@ -2147,6 +2185,11 @@ def grade_pad_legality(pcb_data, clearance: float, exact: bool = True,
             # unexplained number. Empty on a board that declares no netclass,
             # no .kicad_dru rule and no pad override.
             'required': sorted(required, key=lambda r: (-r[2], r[0], r[1])),
+            # #697: anything that went WRONG resolving the requirement (an
+            # unreadable .kicad_pro / .kicad_dru, a dru note). Silence there
+            # drops the census back to the flat scalar and reports 0 conflicts
+            # -- the exact silence this issue was filed for.
+            'clearance_notes': clearance_notes,
             'exact': check_exact is not None}
 
 

--- a/py_placer/placement/quench.py
+++ b/py_placer/placement/quench.py
@@ -508,7 +508,6 @@ class QuenchState:
         # every apply_move with no invalidation; baselines key off SEED poses.
         self.pad_legality = bool(pad_legality)
         self.legality_ctx = None
-        self.pad_model = None
         if self.pad_legality:
             # #697: the per-pair required clearance (pad overrides, net
             # classes, .kicad_dru layer rules), resolved from the board's own
@@ -516,17 +515,17 @@ class QuenchState:
             # then behaves as it did -- on a board that declares none of them.
             pad_model = legality.PadClearanceModel.for_board(
                 pcb_data, clearance, pcb_file)
-            self.pad_model = pad_model if pad_model.active else None
+            pad_model = pad_model if pad_model.active else None
             part_pads = legality.build_part_pads(
                 {ref: pcb_data.footprints[ref] for ref in self.parts
-                 if ref in pcb_data.footprints}, clearance, self.pad_model)
+                 if ref in pcb_data.footprints}, clearance, pad_model)
             self.legality_ctx = legality.LegalityContext(
                 part_pads, self.edge_gate, clearance,
                 pose_of=lambda r: (self.parts[r].x, self.parts[r].y,
                                    self.parts[r].rot),
                 seed_of=lambda r: (self.parts[r].seed_x, self.parts[r].seed_y,
                                    self.parts[r].orig_rot),
-                model=self.pad_model)
+                model=pad_model)
 
         # net -> refs touching it, as a SORTED LIST, not a set (#457).
         #

--- a/py_placer/placement/quench.py
+++ b/py_placer/placement/quench.py
@@ -508,16 +508,25 @@ class QuenchState:
         # every apply_move with no invalidation; baselines key off SEED poses.
         self.pad_legality = bool(pad_legality)
         self.legality_ctx = None
+        self.pad_model = None
         if self.pad_legality:
+            # #697: the per-pair required clearance (pad overrides, net
+            # classes, .kicad_dru layer rules), resolved from the board's own
+            # siblings exactly as check_drc does. Inert -- and every gate below
+            # then behaves as it did -- on a board that declares none of them.
+            pad_model = legality.PadClearanceModel.for_board(
+                pcb_data, clearance, pcb_file)
+            self.pad_model = pad_model if pad_model.active else None
             part_pads = legality.build_part_pads(
                 {ref: pcb_data.footprints[ref] for ref in self.parts
-                 if ref in pcb_data.footprints}, clearance)
+                 if ref in pcb_data.footprints}, clearance, self.pad_model)
             self.legality_ctx = legality.LegalityContext(
                 part_pads, self.edge_gate, clearance,
                 pose_of=lambda r: (self.parts[r].x, self.parts[r].y,
                                    self.parts[r].rot),
                 seed_of=lambda r: (self.parts[r].seed_x, self.parts[r].seed_y,
-                                   self.parts[r].orig_rot))
+                                   self.parts[r].orig_rot),
+                model=self.pad_model)
 
         # net -> refs touching it, as a SORTED LIST, not a set (#457).
         #
@@ -1617,8 +1626,17 @@ class QuenchState:
         union-of-rotations box at the seed inflated by the budget contains
         every rect the part can ever occupy. Any pair whose per-axis seed gap
         exceeds both budgets plus the largest interaction reach (hard
-        clearance / summed halos) can NEVER interact -- excluding it is exact
-        for candidate_valid AND part_geometry_cost, not an approximation.
+        clearance / summed halos / either part's largest PAD requirement) can
+        NEVER interact -- excluding it is exact for candidate_valid AND
+        part_geometry_cost, not an approximation.
+
+        The pad term is what #697 added: a pad's required clearance can exceed
+        the hard clearance (a fiducial keep-clear, a net class, a .kicad_dru
+        rule), and a reach that ignored it would quietly make this prune LOSSY
+        for the pad gate -- dropping exactly the pairs that gate exists to
+        catch. `PartPads.max_floor` is an upper bound per part, so folding it in
+        keeps the claim above literally true; it is 0.0 on a board that
+        declares nothing.
 
         Exactness survives the side rule unchanged: the side filter only ever
         REMOVES pairs from consideration, so an XY-only prune stays a superset of
@@ -1698,7 +1716,15 @@ class QuenchState:
             for oref, (rb, bb) in geom.items():
                 if oref == ref:
                     continue
-                m = ba + bb + max(self.clearance,
+                reach = self.clearance
+                if self.legality_ctx is not None:
+                    pa = self.legality_ctx.parts.get(ref)
+                    pb = self.legality_ctx.parts.get(oref)
+                    if pa is not None and pa.max_floor > reach:
+                        reach = pa.max_floor
+                    if pb is not None and pb.max_floor > reach:
+                        reach = pb.max_floor
+                m = ba + bb + max(reach,
                                   p.halo + self.parts[oref].halo) + 1e-9
                 if (ra[2] + m >= rb[0] and rb[2] + m >= ra[0]
                         and ra[3] + m >= rb[1] and rb[3] + m >= ra[1]):

--- a/py_placer/placement/seeder.py
+++ b/py_placer/placement/seeder.py
@@ -1627,6 +1627,14 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
     except Exception:                                       # noqa: BLE001
         witnesses = set()
 
+    def _marker_or_container(r):
+        """`reconstruct._body_exempt_refs`, resolved lazily and cached there."""
+        try:
+            from placement import reconstruct as _recon
+            return r in _recon._body_exempt_refs(state)
+        except Exception:                                       # noqa: BLE001
+            return r in (getattr(state, 'container_refs', ()) or ())
+
     def _mover_key(r):
         """Which member of a conflicting pair should move.
 
@@ -1637,10 +1645,28 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
         centre off the outline, which a shipped board cannot have -- is KNOWN
         to be misplaced, so it sorts first whatever its size.
 
-        On a board with no witnesses this changes nothing, and that is every
-        healthy board in the corpus: measured zero witnesses on all 33.
+        A MARKER (fiducial / mount hole / test point) or a board-sized
+        CONTAINER sorts LAST, below pin count. Pin count alone points the
+        repair straight at the fiducial: a keep-clear conflict is
+        characteristically a 1-pad fiducial against a many-pad connector, so
+        the cheapest-looking mover is the one part whose position is a
+        mechanical fact. This is the same set, and the same argument,
+        `reconstruct._body_exempt_refs` already makes for the body channel --
+        "a displaced fiducial could never come home under a connector". It
+        became reachable when #697 taught the pad census to see keep-clear
+        overrides at all; before that these pairs were never counted.
+
+        The witness term still outranks it, so a marker that IS known to be
+        misplaced keeps moving first. A marker that is the only unlocked member
+        of a pair still moves -- this orders candidates, it does not veto one.
+
+        On a board with no witnesses and no markers this changes nothing, and
+        that is every healthy board in the corpus: measured zero witnesses on
+        all 33.
         """
-        return (0 if r in witnesses else 1, state.parts[r].pin_count, r)
+        return (0 if r in witnesses else 1,
+                1 if _marker_or_container(r) else 0,
+                state.parts[r].pin_count, r)
 
     graded = None
     if intent is not None:
@@ -1656,9 +1682,16 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
     # worst_n=0: the FULL pair census (run-4 F5). The default cap of 10
     # bounded one repair pass at 10 pair-movers on a 20-pair board -- the
     # summary said 20 conflicts while only 10 got charged.
-    pads = _leg.grade_pad_legality(pcb_data, clearance, worst_n=0)
+    pads = _leg.grade_pad_legality(pcb_data, clearance, worst_n=0,
+                                   pcb_file=pcb_file)
     print(f"  Repair census: {pads['pad_conflicts']} conflict pair(s), "
           f"all listed")
+    # #697: a pair can be graded ABOVE `clearance` (a pad keep-clear override, a
+    # net class, a .kicad_dru rule). Say so, or the census reports a conflict at
+    # a gap the announced clearance says is fine.
+    _rq = _leg.format_required_clause(pads)
+    if _rq:
+        print(f"    above the {clearance}mm floor: {_rq}")
     for (ra, rb, mm) in pads['worst']:
         free = [r for r in (ra, rb)
                 if r in state.parts and not state.parts[r].locked]

--- a/py_placer/placement/seeder.py
+++ b/py_placer/placement/seeder.py
@@ -1645,24 +1645,31 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
         centre off the outline, which a shipped board cannot have -- is KNOWN
         to be misplaced, so it sorts first whatever its size.
 
-        A MARKER (fiducial / mount hole / test point) or a board-sized
-        CONTAINER sorts LAST, below pin count. Pin count alone points the
-        repair straight at the fiducial: a keep-clear conflict is
-        characteristically a 1-pad fiducial against a many-pad connector, so
-        the cheapest-looking mover is the one part whose position is a
-        mechanical fact. This is the same set, and the same argument,
+        On a board with no witnesses this changes nothing, and that is every
+        healthy board in the corpus: measured zero witnesses on all 33.
+        """
+        return (0 if r in witnesses else 1, state.parts[r].pin_count, r)
+
+    def _keepclear_mover_key(r):
+        """`_mover_key` for a pair a KEEP-CLEAR raised (#697), where a MARKER
+        (fiducial / mount hole / test point) or a board-sized CONTAINER sorts
+        LAST instead of first.
+
+        Such a pair is characteristically a 1-pad fiducial against a many-pad
+        connector, so pin count points the repair straight at the one part
+        whose position is a mechanical fact. This is the set, and the argument,
         `reconstruct._body_exempt_refs` already makes for the body channel --
-        "a displaced fiducial could never come home under a connector". It
-        became reachable when #697 taught the pad census to see keep-clear
-        overrides at all; before that these pairs were never counted.
+        "a displaced fiducial could never come home under a connector".
 
-        The witness term still outranks it, so a marker that IS known to be
-        misplaced keeps moving first. A marker that is the only unlocked member
-        of a pair still moves -- this orders candidates, it does not veto one.
+        Deliberately NOT the blanket ordering: as a term above pin count it is
+        not inert. Measured on an undamaged orangecrab_ext_pll it flipped two
+        PRE-EXISTING pairs (C67<->TP30, TP28<->U8) from moving a 1-pad test
+        point to moving a 2-pad cap and a 14-pin IC -- pairs this issue did not
+        surface and whose ordering it has no business changing.
 
-        On a board with no witnesses and no markers this changes nothing, and
-        that is every healthy board in the corpus: measured zero witnesses on
-        all 33.
+        The witness term still outranks it, so a marker KNOWN to be misplaced
+        keeps moving first, and a marker that is the only unlocked member of a
+        pair still moves: this orders candidates, it does not veto one.
         """
         return (0 if r in witnesses else 1,
                 1 if _marker_or_container(r) else 0,
@@ -1692,6 +1699,12 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
     _rq = _leg.format_required_clause(pads)
     if _rq:
         print(f"    above the {clearance}mm floor: {_rq}")
+    for _n in (pads.get('clearance_notes') or ()):
+        notes.append(f"pad clearance: {_n}")
+    # Pairs a pad keep-clear / net class / dru rule raised above `clearance`.
+    # Only these get the marker-last mover rule; see _keepclear_mover_key.
+    _raised = {tuple(sorted((r[0], r[1])))
+               for r in (pads.get('required') or ())}
     for (ra, rb, mm) in pads['worst']:
         free = [r for r in (ra, rb)
                 if r in state.parts and not state.parts[r].locked]
@@ -1705,7 +1718,9 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
         # one available -- the partner was never tried, and the pair was
         # reported unrepairable. Both are candidates now; the weights keep the
         # preferred one first in the worst-first order.
-        ordered = sorted(free, key=_mover_key)
+        ordered = sorted(free, key=(_keepclear_mover_key
+                                    if tuple(sorted((ra, rb))) in _raised
+                                    else _mover_key))
         _charge(ordered[0], mm)
         for partner in ordered[1:]:
             partner_of.setdefault(ordered[0], []).append(partner)

--- a/py_router/check_drc.py
+++ b/py_router/check_drc.py
@@ -64,6 +64,52 @@ from routing_constants import SOFT_JOINT_MIN_GAP as _SOFT_JOINT_MIN_GAP
 from connectivity import COINCIDENCE_TOL
 
 
+def pad_copper_layers(pad, board_copper) -> set:
+    """The set of real copper layers a pad's copper occupies.
+
+    KiCad writes two wildcards a pad's `layers` list can carry: ``*.Cu`` (every
+    copper layer -- a through-hole barrel) and ``F&B.Cu`` (front and back only).
+    ``expand_pad_layers`` handles the first but passes ``F&B.Cu`` through
+    verbatim, because it only tests ``endswith('.Cu')`` -- so a consumer that
+    scopes a per-layer rule through it silently mis-scopes every ``F&B.Cu`` pad.
+    This is the one expansion the clearance paths use; #697 lifted it out of
+    ``run_drc`` so the PLACEMENT side (placement/legality.py) resolves layer
+    scope from the same function rather than a hand-mirrored copy.
+    """
+    out = set()
+    for l in (getattr(pad, 'layers', None) or []):
+        if l in ('*.Cu', 'F&B.Cu'):
+            out |= set(board_copper) if l == '*.Cu' else {'F.Cu', 'B.Cu'}
+        elif str(l).endswith('.Cu'):
+            out.add(l)
+    return out
+
+
+def pads_shared_layer_clearance(eff: float, layer_rules, layers_a, layers_b=None):
+    """KiCad's per-layer (.kicad_dru) clearance for two items that meet on their
+    SHARED copper layers, with REPLACE semantics (#498).
+
+    A custom rule REPLACES the net/class-resolved value on its layer rather than
+    raising it, so: every shared layer ruled -> max(rule values); only some
+    ruled -> max(eff, rule values); none ruled -> eff unchanged. TH geometry is
+    identical on every layer, so the max over shared layers is exact.
+
+    Returns `eff` untouched when there are no rules -- the strict no-op that
+    makes this free for boards without a .kicad_dru (i.e. almost all of them).
+    """
+    if not layer_rules:
+        return eff
+    shared = set(layers_a)
+    if layers_b is not None:
+        shared &= set(layers_b)
+    vals = [layer_rules[l] for l in shared if l in layer_rules]
+    if not vals:
+        return eff
+    if all(l in layer_rules for l in shared):
+        return max(vals)        # every shared layer ruled: rules replace
+    return max([eff] + vals)
+
+
 def _expand_cu(pad_layers: List[str], routing_layers: List[str]) -> List[str]:
     """Memoized expand_pad_layers for the duration of one run_drc call."""
     global _EXPAND_ROUTING
@@ -1978,29 +2024,17 @@ def run_drc(pcb_file: str, clearance: float = 0.1, net_patterns: Optional[List[s
         return max([eff] + list(_lcl.values())) if _lcl else eff
 
     def _pad_copper(pad):
-        out = set()
-        for l in (pad.layers or []):
-            if l in ('*.Cu', 'F&B.Cu'):
-                out |= set(_board_copper) if l == '*.Cu' else {'F.Cu', 'B.Cu'}
-            elif l.endswith('.Cu'):
-                out.add(l)
-        return out
+        return pad_copper_layers(pad, _board_copper)
 
     def _pads_cl(eff: float, pad, other_pad=None) -> float:
         # Pad-vs-via / pad-vs-pad meet on their SHARED copper layers; TH
         # geometry is identical on every layer, so the max over shared layers
-        # is the exact requirement.
-        if not _lcl:
-            return eff
-        shared = _pad_copper(pad)
-        if other_pad is not None:
-            shared &= _pad_copper(other_pad)
-        vals = [_lcl[l] for l in shared if l in _lcl]
-        if not vals:
-            return eff
-        if len([l for l in shared if l not in _lcl]) == 0:
-            return max(vals)  # every shared layer ruled: rules replace
-        return max([eff] + vals)
+        # is the exact requirement. The body lives at module level
+        # (pads_shared_layer_clearance) so placement/legality.py resolves the
+        # same rule rather than a hand-mirrored copy -- #697.
+        return pads_shared_layer_clearance(
+            eff, _lcl, _pad_copper(pad),
+            _pad_copper(other_pad) if other_pad is not None else None)
 
     def _pair_cl(net_a: int, net_b: int, layer: str = None) -> float:
         base = clearance if not _ncl_by_id else \

--- a/py_router/check_drc.py
+++ b/py_router/check_drc.py
@@ -2032,6 +2032,8 @@ def run_drc(pcb_file: str, clearance: float = 0.1, net_patterns: Optional[List[s
         # is the exact requirement. The body lives at module level
         # (pads_shared_layer_clearance) so placement/legality.py resolves the
         # same rule rather than a hand-mirrored copy -- #697.
+        if not _lcl:
+            return eff          # strict no-op: expand nothing (see the helper)
         return pads_shared_layer_clearance(
             eff, _lcl, _pad_copper(pad),
             _pad_copper(other_pad) if other_pad is not None else None)

--- a/py_tools/check_assembly.py
+++ b/py_tools/check_assembly.py
@@ -146,6 +146,11 @@ def main():
     g = grade_body_overlap(pcb, clearance, intent_waivers=waivers,
                            pcb_file=args.board)
     leg = grade_pad_legality(pcb, clearance, worst_n=0, pcb_file=args.board)
+    # #697: name any pair graded ABOVE `clearance` and what raised it, or the
+    # echo below reports a count the announced floor cannot explain.
+    from placement.legality import format_required_clause as _req_clause
+    _leg_required = _req_clause(leg)
+    _leg_notes = list(leg.get('clearance_notes') or ())
 
     # COINCIDENT ORIGINS (run-19, measured twice): SW17+SW34+REF_PUCK_R all at
     # one point graded `buildable (blocking 0)` -- the pair currency counts pad
@@ -283,6 +288,10 @@ def main():
               "waiver class chosen for unlocked parts does not apply here.")
     from placement.legality import format_oob_clause
     _clause = format_oob_clause(leg)
+    if _leg_required:
+        print(f"  above the {clearance}mm floor: {_leg_required}")
+    for _n in _leg_notes:
+        print(f"  pad clearance: {_n}")
     print(f"  pad/hole/oob echo: {leg['pad_conflicts']} pad pair(s), "
           f"{leg['hole_conflicts']} hole conflict(s), "
           f"{leg['oob_pad_count']} part(s) with pad copper off-board"
@@ -438,6 +447,7 @@ def main():
             'blocking_pairs': [q._asdict() for q in g['blocking_pairs']],
             'advisory_pairs': [q._asdict() for q in g['advisory_pairs']],
             'pad_conflicts': leg['pad_conflicts'],
+            'pad_clearance_required': leg.get('required') or [],
             'hole_conflicts': leg['hole_conflicts'],
             'oob_pad_count': leg['oob_pad_count'],
             'oob_pad_amount': leg['oob_pad_amount'],

--- a/py_tools/check_assembly.py
+++ b/py_tools/check_assembly.py
@@ -145,7 +145,7 @@ def main():
 
     g = grade_body_overlap(pcb, clearance, intent_waivers=waivers,
                            pcb_file=args.board)
-    leg = grade_pad_legality(pcb, clearance, worst_n=0)
+    leg = grade_pad_legality(pcb, clearance, worst_n=0, pcb_file=args.board)
 
     # COINCIDENT ORIGINS (run-19, measured twice): SW17+SW34+REF_PUCK_R all at
     # one point graded `buildable (blocking 0)` -- the pair currency counts pad

--- a/tests/test_697_placement_pad_clearance.py
+++ b/tests/test_697_placement_pad_clearance.py
@@ -376,6 +376,66 @@ class TestRealBoards(unittest.TestCase):
         self.assertEqual(g['pad_conflicts'], 1, g)
         self.assertEqual(g['required'], [['A', 'B', 0.4, 'netclass']])
 
+    def test_default_netclass_is_not_dropped(self):
+        """A Default class ABOVE an explicit --clearance must still raise.
+
+        `net_clearance_map_by_id` (the ROUTER's map) omits every net that
+        resolves only to Default, because a Default net routes at
+        config.clearance. Using it here re-created this whole issue on any
+        board graded below its own Default class -- which check_assembly
+        explicitly tells users they may do. check_drc reads `net_clearance_map`
+        (Default included, admitted when it exceeds the floor), so this must.
+        """
+        if not os.path.exists(FLAT_HIER):
+            self.skipTest('flat_hierarchy fixture not present')
+        from kicad_parser import parse_kicad_pcb
+        pcb = parse_kicad_pcb(FLAT_HIER)
+        gnd = [nid for nid, n in pcb.nets.items() if n.name == 'GND']
+        self.assertTrue(gnd, 'fixture drifted: no GND net')
+        # graded BELOW the 0.2 Default class -> the class is the requirement
+        m_lo = PadClearanceModel.for_board(pcb, 0.1, FLAT_HIER)
+        # MUTATION: read net_clearance_map_by_id instead -> None.
+        self.assertAlmostEqual(m_lo.net_floor.get(gnd[0]), 0.2)
+        fa = m_lo.pad_floor(pad(0, 0, net=gnd[0]))
+        fb = m_lo.pad_floor(pad(5, 0, net=0))
+        self.assertEqual(m_lo.pair_with_source(fa, fb), (0.2, 'netclass'))
+        # graded AT or ABOVE it -> inert, exactly check_drc's `c > clearance`
+        for cl in (0.2, 0.3):
+            m = PadClearanceModel.for_board(pcb, cl, FLAT_HIER)
+            self.assertIsNone(m.net_floor.get(gnd[0]), cl)
+
+    def test_unreadable_source_is_not_silent(self):
+        """A source that FAILS to resolve must be NAMED, not swallowed.
+
+        Silence drops the census back to the flat scalar and reports 0
+        conflicts -- the exact silence this issue was filed for. Forced here by
+        making the netclass read raise, because a merely absent or malformed
+        sibling is handled gracefully upstream (an absent .kicad_dru is a
+        legitimate no-op, and a truncated one parses to an empty map).
+        """
+        if not os.path.exists(FLAT_HIER):
+            self.skipTest('flat_hierarchy fixture not present')
+        import list_nets
+        from kicad_parser import parse_kicad_pcb
+        pcb = parse_kicad_pcb(FLAT_HIER)
+        real = list_nets.net_clearance_map
+
+        def boom(*a, **kw):
+            raise OSError('permission denied')
+
+        list_nets.net_clearance_map = boom
+        try:
+            model = PadClearanceModel.for_board(pcb, 0.1, FLAT_HIER)
+            g = grade_pad_legality(pcb, 0.1, worst_n=0, pcb_file=FLAT_HIER)
+        finally:
+            list_nets.net_clearance_map = real
+        # MUTATION: restore the bare `except Exception: net_floor = {}` -> the
+        # failure is invisible and the board silently grades at the flat scalar.
+        self.assertTrue(model.notes, 'the failure was swallowed')
+        self.assertIn('permission denied', ' '.join(model.notes))
+        # ... and it must REACH the report, not just the model
+        self.assertTrue(g['clearance_notes'], g)
+
     def test_dru_half_end_to_end(self):
         """A sibling .kicad_dru must reach the census. No board in the repo
         ships one, so write one next to a staged copy -- the same one-line

--- a/tests/test_697_placement_pad_clearance.py
+++ b/tests/test_697_placement_pad_clearance.py
@@ -175,11 +175,20 @@ class TestCensus(unittest.TestCase):
         self.assertEqual(g['pad_conflicts'], 1, g)
 
     def test_beyond_the_old_cell_hash_halo(self):
-        # gap 0.9: further than the old `clearance + 0.5` neighbour halo, so
-        # the pair never even entered the census.
-        g = self._grade(two_pads(0.90, lc_a=1.2))
+        """The pair must be reachable through the CELL HASH, not just past the
+        per-pair reject.
+
+        `near_refs` walks a 4mm cell grid inflated by its halo, so a gap under
+        ~4mm lands in an adjacent cell and is enumerated whatever the halo is --
+        a test at 0.9mm exercises the reject and silently claims the halo. The
+        separation has to exceed a cell for the halo to be the thing under test.
+        """
+        # gap 5.0, requirement 6.0: the old halo (0.15 + 0.5) reaches neither
+        # the cell nor the pair.
+        g = self._grade(two_pads(5.0, lc_a=6.0))
         # MUTATION: revert near_refs to `m = clearance + 0.5` -> 0.
         self.assertEqual(g['pad_conflicts'], 1, g)
+        self.assertEqual(g['required'], [['A', 'B', 6.0, 'pad override']])
 
     def test_inert_when_nothing_is_declared(self):
         clean = self._grade(two_pads(0.40))
@@ -341,6 +350,31 @@ class TestRealBoards(unittest.TestCase):
         eff, src = model.pair_with_source(fa, fb)
         self.assertAlmostEqual(eff, 0.4)
         self.assertEqual(src, 'netclass')
+
+    def test_netclass_alone_reaches_the_census(self):
+        """A netclass with NO pad override anywhere must still raise the census.
+
+        Every other census test here carries a `local_clearance`, so they would
+        all pass with the netclass term deleted. This one has no override at
+        all: its only source is the class.
+        """
+        if not os.path.exists(FLAT_HIER):
+            self.skipTest('flat_hierarchy fixture not present')
+        from kicad_parser import parse_kicad_pcb
+        pcb = parse_kicad_pcb(FLAT_HIER)
+        wide = [nid for nid, v in PadClearanceModel.for_board(
+            pcb, 0.2, FLAT_HIER).net_floor.items() if v >= 0.4]
+        self.assertTrue(wide)
+        # Two 1x1 pads, one on a `Wide` net, 0.3mm apart: clear at the 0.2
+        # Default floor, in violation of the 0.4 class.
+        fps = {'A': fp_with('A', 0.0, 0.0,
+                            [pad(0.0, 0.0, net=wide[0], ref='A')]),
+               'B': fp_with('B', 1.3, 0.0, [pad(1.3, 0.0, net=0, ref='B')])}
+        pcb.footprints = fps
+        # MUTATION: drop the net_clearance_map_by_id read -> 0.
+        g = grade_pad_legality(pcb, 0.2, worst_n=0, pcb_file=FLAT_HIER)
+        self.assertEqual(g['pad_conflicts'], 1, g)
+        self.assertEqual(g['required'], [['A', 'B', 0.4, 'netclass']])
 
     def test_dru_half_end_to_end(self):
         """A sibling .kicad_dru must reach the census. No board in the repo

--- a/tests/test_697_placement_pad_clearance.py
+++ b/tests/test_697_placement_pad_clearance.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""#697: the placement pad census must grade at the pair's REAL requirement.
+
+`py_placer/placement/legality.py` priced every pad pair at one flat `clearance`
+scalar and never read `pad.local_clearance`, so a board that could not pass DRC
+reported nothing to fix. Measured on `kicad_files/esp_prog.kicad_pcb`, whose
+fiducial pad declares a 1.016 mm keep-clear: nudged 0.40 mm toward USB1 the pads
+sit 0.9355 mm apart -- `check_drc` flags it, and `grade_pad_legality` /
+`place_reconstruct --stages legalize` both reported 0 conflict pairs.
+
+The requirement is check_drc's, over three stacked sources::
+
+    base = max(global clearance, netclass(a), netclass(b))
+    eff  = <.kicad_dru layer rules over the SHARED copper layers>   # REPLACES
+    eff  = max(eff, lc_a, lc_b)                                     # override wins
+
+Every test below names the single-line reversion of the fix that must make it
+fail -- a test that still passes with the bug present is worth nothing.
+"""
+import math
+import os
+import sys
+import tempfile
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_placer'))  # placement split
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # placement split
+sys.path.insert(0, os.path.join(ROOT, 'py_tools'))   # placement split
+
+from placement.legality import (                                   # noqa: E402
+    LegalityContext, PadClearanceModel, build_part_pads,
+    format_required_clause, grade_pad_legality)
+
+ESP_PROG = os.path.join(ROOT, 'kicad_files', 'esp_prog.kicad_pcb')
+FLAT_HIER = os.path.join(ROOT, 'kicad_files', 'flat_hierarchy.kicad_pcb')
+
+
+# --------------------------------------------------------------------------
+# Synthetic geometry. REAL parser dataclasses via tests/synth.py, not duck-typed
+# fakes: `grade_pad_legality`'s exact re-verification hands the pads to
+# check_drc's perimeter sampler, which reads fields (pad_number, shape,
+# polygons, ...) a minimal fake does not carry -- and a fake that silently
+# skipped the exact path would test the AABB fallback while claiming to test
+# the census. `BarePad` below is the one deliberate exception.
+# --------------------------------------------------------------------------
+from kicad_parser import BoardInfo, Footprint                 # noqa: E402
+from synth import make_pad, make_pcb                          # noqa: E402
+
+
+class BarePad:
+    """A pad object from BEFORE #697: no `local_clearance` attribute at all.
+    Pins that the model reads the field with getattr, not a bare attribute."""
+
+    def __init__(self):
+        self.global_x = 0.0
+        self.global_y = 0.0
+        self.size_x = 1.0
+        self.size_y = 1.0
+        self.net_id = 1
+        self.layers = ['F.Cu']
+        self.drill = 0.0
+        self.pad_type = 'smd'
+        self.shape = 'rect'
+        self.pad_number = '1'
+
+
+def pad(x, y, *, net=1, lc=0.0, layers=('F.Cu',), ref='A', **kw):
+    p = make_pad(net_id=net, x=x, y=y, ref=ref, size_x=1.0, size_y=1.0,
+                 layers=layers, **kw)
+    p.local_clearance = lc
+    return p
+
+
+def fp_with(ref, x, y, pads):
+    return Footprint(reference=ref, footprint_name='test:P', x=x, y=y,
+                     rotation=0.0, layer='F.Cu', pads=list(pads))
+
+
+def board(fps, copper=('F.Cu', 'B.Cu')):
+    info = BoardInfo(layers={i: l for i, l in enumerate(copper)},
+                     copper_layers=list(copper), stackup=[], board_outline=[],
+                     board_cutouts=[], board_outlines=[],
+                     board_edge_contours=[])
+    return make_pcb(footprints={f.reference: f for f in fps}, board_info=info)
+
+
+def two_pads(gap, lc_a=0.0, lc_b=0.0, **kw):
+    """Two 1x1 mm pads on different nets, `gap` mm apart edge to edge."""
+    a = fp_with('A', 0.0, 0.0, [pad(0.0, 0.0, net=1, lc=lc_a, ref='A', **kw)])
+    b = fp_with('B', 1.0 + gap, 0.0,
+                [pad(1.0 + gap, 0.0, net=2, lc=lc_b, ref='B', **kw)])
+    return board([a, b])
+
+
+class TestPairRequirement(unittest.TestCase):
+    """The formula itself, in isolation."""
+
+    def test_override_on_either_pad_raises_the_pair(self):
+        # check_drc needs a SECOND max at its call site because _pad_pair_cl
+        # folds only pad1's override; a copy that keeps one max reports nothing
+        # when only the second pad carries the keep-clear.
+        m = PadClearanceModel(0.15, has_overrides=True)
+        fa = m.pad_floor(pad(0, 0, lc=1.016))
+        fb = m.pad_floor(pad(5, 0))
+        # MUTATION: drop `fa.lc` from pair_with_source -> first assert fails.
+        self.assertAlmostEqual(m.pair(fa, fb), 1.016)
+        # MUTATION: drop `fb.lc` -> this one fails.
+        self.assertAlmostEqual(m.pair(fb, fa), 1.016)
+
+    def test_source_is_recorded_where_it_is_applied(self):
+        # A layer rule REPLACES, so it can LOWER the value below the netclass
+        # that preceded it. Re-deriving the source from the final number then
+        # says "netclass" for a value the RULE set.
+        m = PadClearanceModel(0.15, net_floor={7: 0.5},
+                              layer_rules={'F.Cu': 0.3},
+                              board_copper=('F.Cu', 'B.Cu'))
+        fa = m.pad_floor(pad(0, 0, net=7, layers=('F.Cu',)))
+        fb = m.pad_floor(pad(5, 0, net=8, layers=('F.Cu',)))
+        eff, src = m.pair_with_source(fa, fb)
+        self.assertAlmostEqual(eff, 0.3)
+        # MUTATION: restore the old `pair_source` re-derivation -> 'netclass'.
+        self.assertEqual(src, 'layer rule')
+
+    def test_layer_rule_scopes_to_SHARED_layers_and_replaces(self):
+        # An inner-layer rule must not touch a pair that only meets on F.Cu.
+        m = PadClearanceModel(0.2, layer_rules={'In1.Cu': 0.5},
+                              board_copper=('F.Cu', 'In1.Cu', 'B.Cu'))
+        th = m.pad_floor(pad(0, 0, layers=('*.Cu',), drill=0.3, pad_type='thru_hole'))
+        smd = m.pad_floor(pad(5, 0, layers=('F.Cu',)))
+        # MUTATION: fold the dru per pad instead of over the shared set
+        # (max over each pad's own layers) -> 0.5, a false positive.
+        self.assertAlmostEqual(m.pair(th, smd), 0.2)
+        # Both reach In1 -> the rule binds, and REPLACES rather than maxes.
+        th2 = m.pad_floor(pad(5, 0, layers=('*.Cu',), drill=0.3, pad_type='thru_hole'))
+        self.assertAlmostEqual(m.pair(th, th2), 0.5)
+
+    def test_relaxing_rule_replaces_downward(self):
+        m = PadClearanceModel(0.2, layer_rules={'F.Cu': 0.05},
+                              board_copper=('F.Cu', 'B.Cu'))
+        fa = m.pad_floor(pad(0, 0, layers=('F.Cu',)))
+        fb = m.pad_floor(pad(5, 0, layers=('F.Cu',)))
+        # MUTATION: implement _pads_cl as max(base, rules) -> 0.2, and the
+        # relaxation is silently lost.
+        self.assertAlmostEqual(m.pair(fa, fb), 0.05)
+
+    def test_bare_pad_without_the_attribute_is_not_a_crash(self):
+        m = PadClearanceModel(0.15, has_overrides=True)
+        p = BarePad()
+        self.assertFalse(hasattr(p, 'local_clearance'))
+        # MUTATION: read `pad.local_clearance` directly -> AttributeError.
+        self.assertAlmostEqual(m.pad_floor(p).lc, 0.0)
+
+    def test_model_with_no_sources_is_inert(self):
+        m = PadClearanceModel(0.15)
+        self.assertFalse(m.active)
+
+
+class TestCensus(unittest.TestCase):
+    """grade_pad_legality: the four points a pair used to be dropped at."""
+
+    def _grade(self, pcb, clearance=0.15):
+        return grade_pad_legality(pcb, clearance, worst_n=0)
+
+    def test_conflict_seen_when_pad_A_carries_the_override(self):
+        # gap 0.40: clear at the 0.15 floor, in violation of the 1.0 keep-clear
+        g = self._grade(two_pads(0.40, lc_a=1.0))
+        # MUTATION: revert the census reject to `g >= clearance - EPS` -> 0.
+        self.assertEqual(g['pad_conflicts'], 1, g)
+        self.assertEqual(g['required'], [['A', 'B', 1.0, 'pad override']])
+
+    def test_conflict_seen_when_pad_B_carries_the_override(self):
+        g = self._grade(two_pads(0.40, lc_b=1.0))
+        self.assertEqual(g['pad_conflicts'], 1, g)
+
+    def test_beyond_the_old_cell_hash_halo(self):
+        # gap 0.9: further than the old `clearance + 0.5` neighbour halo, so
+        # the pair never even entered the census.
+        g = self._grade(two_pads(0.90, lc_a=1.2))
+        # MUTATION: revert near_refs to `m = clearance + 0.5` -> 0.
+        self.assertEqual(g['pad_conflicts'], 1, g)
+
+    def test_inert_when_nothing_is_declared(self):
+        clean = self._grade(two_pads(0.40))
+        self.assertEqual(clean['pad_conflicts'], 0)
+        self.assertEqual(clean['required'], [])
+        # and a genuine sub-floor pair is still caught, unchanged
+        self.assertEqual(self._grade(two_pads(0.05))['pad_conflicts'], 1)
+
+    def test_worst_stays_a_three_tuple(self):
+        # seeder/floorplan/lock_advisor all unpack `worst` positionally as
+        # (ref_a, ref_b, mm). The disclosure rides `required`, not a 4th slot.
+        g = self._grade(two_pads(0.40, lc_a=1.0))
+        for row in g['worst']:
+            self.assertEqual(len(row), 3, row)
+        ra, rb, mm = g['worst'][0]
+        self.assertEqual({ra, rb}, {'A', 'B'})
+        self.assertGreater(mm, 0.0)
+
+    def test_required_clause_names_the_source(self):
+        g = self._grade(two_pads(0.40, lc_a=1.0))
+        self.assertIn('pad override', format_required_clause(g))
+        self.assertEqual(format_required_clause(self._grade(two_pads(0.05))), '')
+
+
+class TestGate(unittest.TestCase):
+    """LegalityContext: the per-candidate path quench calls per pose."""
+
+    def _ctx(self, pcb, clearance=0.15):
+        model = PadClearanceModel.for_board(pcb, clearance)
+        model = model if model.active else None
+        parts = build_part_pads(pcb.footprints, clearance, model)
+        poses = {r: (f.x, f.y, f.rotation) for r, f in pcb.footprints.items()}
+        return LegalityContext(parts, None, clearance,
+                               pose_of=lambda r: poses[r],
+                               seed_of=lambda r: poses[r],
+                               model=model), poses
+
+    def test_extent_short_circuit_no_longer_hides_the_pair(self):
+        # The parts' EXTENTS are 0.40 apart -- past the 0.15 floor, so
+        # pair_shortfall used to return ZERO_SHORTFALL before any pad was read.
+        pcb = two_pads(0.40, lc_a=1.0)
+        ctx, _ = self._ctx(pcb)
+        sf = ctx.pair_shortfall('A', 'B')
+        # MUTATION: revert the reach at the extent gate to self.clearance -> 0.
+        self.assertGreater(sf.pad, 0.0)
+        self.assertFalse(sf.pad_overlap)   # still no physical intersection
+        self.assertFalse(sf.stack)
+
+    def test_seed_that_already_violates_stays_placeable(self):
+        # Both `cur` and `base` are measured at the same widened requirement,
+        # so a board seeded in violation keeps a matching baseline. Refusing it
+        # would make such a board unplaceable rather than repairable.
+        pcb = two_pads(0.40, lc_a=1.0)
+        ctx, poses = self._ctx(pcb)
+        self.assertTrue(ctx.pads_ok('A', *poses['A'], neighbors=['B']))
+        # ... but a pose that makes the pair WORSE is refused
+        x, y, r = poses['A']
+        self.assertFalse(ctx.pads_ok('A', x + 0.2, y, r, neighbors=['B']))
+        # ... and one that improves it is admitted
+        self.assertTrue(ctx.pads_ok('A', x - 0.2, y, r, neighbors=['B']))
+
+    def test_gate_is_inert_without_declarations(self):
+        pcb = two_pads(0.40)
+        ctx, _ = self._ctx(pcb)
+        self.assertEqual(ctx.pair_shortfall('A', 'B').pad, 0.0)
+
+
+class TestRealBoards(unittest.TestCase):
+    """The reported failure, on the board that reproduces it."""
+
+    def _nudge_fiducial(self, board, mm):
+        """Rigidly move the override-carrying footprint toward USB1."""
+        from kicad_parser import parse_kicad_pcb
+        pcb = parse_kicad_pcb(board)
+        fid = [fp for fp in pcb.footprints.values()
+               if any((getattr(q, 'local_clearance', 0.0) or 0.0) > 0.5
+                      for q in fp.pads)][0]
+        tgt = pcb.footprints['USB1']
+        vx, vy = tgt.x - fid.x, tgt.y - fid.y
+        n = math.hypot(vx, vy)
+        dx, dy = vx / n * mm, vy / n * mm
+        fid.x += dx
+        fid.y += dy
+        for q in fid.pads:
+            q.global_x += dx
+            q.global_y += dy
+        return pcb, fid.reference
+
+    def test_esp_prog_fiducial_keep_clear(self):
+        if not os.path.exists(ESP_PROG):
+            self.skipTest('esp_prog fixture not present')
+        # Untouched: the keep-clear is satisfied, and the census says so.
+        from kicad_parser import parse_kicad_pcb
+        stock = grade_pad_legality(parse_kicad_pcb(ESP_PROG), 0.15, worst_n=0)
+        self.assertEqual(stock['pad_conflicts'], 0, stock['worst'])
+        self.assertEqual(stock['required'], [])
+
+        pcb, ref = self._nudge_fiducial(ESP_PROG, 0.40)
+        g = grade_pad_legality(pcb, 0.15, worst_n=0)
+        # MUTATION: any of the four reverts -> 0, which is what the bug shipped.
+        self.assertEqual(g['pad_conflicts'], 1, g['worst'])
+        self.assertEqual(len(g['required']), 1, g['required'])
+        ra, rb, mm, src = g['required'][0]
+        self.assertEqual({ra, rb}, {ref, 'USB1'})
+        self.assertAlmostEqual(mm, 1.016)
+        self.assertEqual(src, 'pad override')
+
+    def test_esp_prog_agrees_with_check_drc(self):
+        """The point of the fix: the two graders must not disagree."""
+        if not os.path.exists(ESP_PROG):
+            self.skipTest('esp_prog fixture not present')
+        from check_drc import check_pad_pad_overlap
+        pcb, ref = self._nudge_fiducial(ESP_PROG, 0.40)
+        rl = list(pcb.board_info.copper_layers)
+        fid = pcb.footprints[ref]
+        truth = set()
+        for q in fid.pads:
+            lc = getattr(q, 'local_clearance', 0.0) or 0.0
+            for r2, fp2 in pcb.footprints.items():
+                if r2 == ref:
+                    continue
+                for t in fp2.pads:
+                    eff = max(0.15, lc,
+                              getattr(t, 'local_clearance', 0.0) or 0.0)
+                    if q.net_id and q.net_id == t.net_id:
+                        continue
+                    hit, _ov, _pt = check_pad_pad_overlap(q, t, eff, rl, 0.0)
+                    if hit:
+                        truth.add(tuple(sorted((ref, r2))))
+        self.assertTrue(truth, 'check_drc sees no violation -- fixture drifted')
+        census = {tuple(sorted((a, b))) for a, b, _mm in
+                  grade_pad_legality(pcb, 0.15, worst_n=0)['worst']}
+        self.assertEqual(census, truth)
+
+    def test_reference_less_footprint_ref_survives(self):
+        """esp_prog's fiducial footprint is literally named `Ref*`, which flows
+        into fnmatch globs and report text. It must round-trip intact."""
+        if not os.path.exists(ESP_PROG):
+            self.skipTest('esp_prog fixture not present')
+        pcb, ref = self._nudge_fiducial(ESP_PROG, 0.40)
+        g = grade_pad_legality(pcb, 0.15, worst_n=0)
+        self.assertIn(ref, [r for row in g['required'] for r in row[:2]])
+        self.assertIn(ref, format_required_clause(g))
+
+    def test_netclass_half_on_flat_hierarchy(self):
+        """The board's `Wide` class is 0.4 against a 0.2 Default."""
+        if not os.path.exists(FLAT_HIER):
+            self.skipTest('flat_hierarchy fixture not present')
+        from kicad_parser import parse_kicad_pcb
+        pcb = parse_kicad_pcb(FLAT_HIER)
+        model = PadClearanceModel.for_board(pcb, 0.2, FLAT_HIER)
+        # MUTATION: drop the net_clearance_map_by_id read -> empty, inactive.
+        self.assertTrue(model.net_floor, 'no non-Default netclass resolved')
+        self.assertTrue(model.active)
+        wide = [nid for nid, v in model.net_floor.items() if v >= 0.4]
+        self.assertTrue(wide)
+        fa = model.pad_floor(pad(0, 0, net=wide[0]))
+        fb = model.pad_floor(pad(5, 0, net=0))
+        eff, src = model.pair_with_source(fa, fb)
+        self.assertAlmostEqual(eff, 0.4)
+        self.assertEqual(src, 'netclass')
+
+    def test_dru_half_end_to_end(self):
+        """A sibling .kicad_dru must reach the census. No board in the repo
+        ships one, so write one next to a staged copy -- the same one-line
+        pattern tests/test_dru_layer_clearance_e2e.py uses."""
+        if not os.path.exists(ESP_PROG):
+            self.skipTest('esp_prog fixture not present')
+        from copy_board import copy_board
+        with tempfile.TemporaryDirectory() as td:
+            staged = os.path.join(td, 'ruled.kicad_pcb')
+            copy_board(ESP_PROG, staged)
+            with open(os.path.splitext(staged)[0] + '.kicad_dru', 'w',
+                      encoding='utf-8') as fh:
+                fh.write('(version 1)\n(rule wide_front (layer "F.Cu") '
+                         '(constraint clearance (min 0.6mm)))\n')
+            from kicad_parser import parse_kicad_pcb
+            pcb = parse_kicad_pcb(staged)
+            model = PadClearanceModel.for_board(pcb, 0.15, staged)
+            # MUTATION: drop the read_board_layer_clearances read -> empty.
+            self.assertEqual(model.layer_rules, {'F.Cu': 0.6})
+            g = grade_pad_legality(pcb, 0.15, worst_n=0, pcb_file=staged)
+            self.assertGreater(g['pad_conflicts'], 0,
+                               'a 0.6mm F.Cu rule must bind somewhere')
+            self.assertTrue(any(r[3] == 'layer rule' for r in g['required']),
+                            g['required'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #697.

The placement legality and repair census priced every pad pair at one flat
`clearance` scalar and never read `pad.local_clearance` — `grep -rn
local_clearance py_placer/ py_tools/` returned 0 — so a board that cannot pass
DRC reported nothing to fix. `CLAUDE.md` already stated the rule this code was
violating ("clearance consumers should read this field").

## Reproduction

`kicad_files/esp_prog.kicad_pcb` reproduces it: its fiducial footprint's `Fid1`
pad declares `local_clearance = 1.016` (a keep-clear ring). Nudge that footprint
0.40 mm toward `USB1` and the pads sit 0.9355 mm apart.

```bash
python3 py_router/check_drc.py esp_prog_nudged.kicad_pcb --clearance 0.15
python3 py_placer/place_reconstruct.py esp_prog_nudged.kicad_pcb out.kicad_pcb \
        --stages legalize --clearance 0.15
```

| | before | after |
|---|---|---|
| `check_drc` | `FOUND 2 DRC VIOLATIONS` — `PAD-PAD (2)`, `Required clearance: 1.0160mm (local/netclass override; global 0.1500mm)` | unchanged |
| `place_reconstruct --stages legalize` | `Repair census: 0 conflict pair(s), all listed` → exit 0 | `Repair census: 1 conflict pair(s)` → exit 4 |
| disclosure | — | `above the 0.15mm floor: Ref*<->USB1 requires 1.016mm (pad override)` |
| `check_assembly` pad echo | `0 pad pair(s)` | `1 pad pair(s)` |

(The census counts *pairs*, check_drc counts pad-pad *instances* — different
currencies, both correct.)

## Where the pair was dropped

Four filter points, all comparing against the flat scalar, plus one prune:

1. `grade_pad_legality.near_refs` — the `clearance + 0.5` cell-hash halo. The
   pair never entered the census.
2. `grade_pad_legality` — `if g >= clearance - EPS: continue`, evaluated *before*
   `_pad_with_copper` resolved the real `Pad` objects two lines later.
3. the flat value handed to `check_pad_pad_overlap`, and the non-exact fallback.
4. `LegalityContext.pair_shortfall` — three comparisons, one of them an
   extent-level short-circuit for the whole pair. This is the hot path
   `quench.candidate_valid` walks per candidate pose.
5. `quench.build_neighbor_lists`, whose docstring claims the prune is *exact* for
   `candidate_valid`. A pad requirement above the hard clearance made it quietly
   lossy for precisely the pairs the pad gate exists to catch.

## The fix

`PadClearanceModel` resolves each pair the way `check_drc` does, over all three
sources, and **calls check_drc's code rather than mirroring it**:

```
base = max(global clearance, netclass(a), netclass(b))
eff  = <.kicad_dru layer rules over the SHARED copper layers>   # REPLACES, can lower
eff  = max(eff, lc_a, lc_b)                                     # override wins
```

`pad_copper_layers` and `pads_shared_layer_clearance` are lifted out of
`run_drc` to module level for that (the lift is behaviour-preserving; the dru
tests cover it). The expansion had to be check_drc's and not
`net_queries.expand_pad_layers`, which passes `F&B.Cu` through verbatim.

Per-pad floors ride a parallel `PartPads.pad_floors` array rather than a wider
tuple — `pad_rects()`'s 6-tuple is a public shape (`render_placement` slices
`r[:4]`, two test modules unpack it positionally) and the rect index already
addresses the pad. `worst` stays a 3-tuple for the same reason: `seeder`,
`floorplan` and `lock_advisor` all unpack it positionally. The disclosure rides
a new `required` key plus `format_required_clause`, which lives beside the
measure so the five CLIs that print it cannot drift.

**Strictly inert** when the board declares no netclass, no `.kicad_dru` rule and
no pad override: `model.active` is False and every consumer takes its original
flat-scalar path.

## Measured impact

No existing assertion moves. Every board behind an existing `pad_conflicts`
assertion is override-free, and every board that *does* carry overrides still
grades 0 at its own floor:

| board | pads with `local_clearance` | `model.active` | conflicts |
|---|---|---|---|
| tigard / splitflap_driver / cap_chain | 0 | False | 0 |
| watchy | 8 (all NPTH, none reach the model) | False | 0 |
| esp_prog | 14 | True | 0 |
| glasgow_revC / orangecrab_ext_pll / ulx3s | 7 / 6 / 4 | True | 0 |

Census timing improved — `ulx3s` 0.16 s → 0.07 s, because the per-pair reach
gives a cheaper pre-reject than the old scalar compare.

## Verification

- `tests/test_697_placement_pad_clearance.py` — 23 tests: the formula (each
  override half, source attribution, dru REPLACE semantics in both directions,
  shared-layer scoping), all four census/gate filter points, baseline coherence,
  the Default-netclass case, error disclosure, and the real-board reproduction.
- A **15-mutation harness** reverts the fix one line at a time; all 15 die, none
  survive. It found two of these tests originally passing with the bug present:
  the cell-hash test sat inside one 4 mm grid cell so it never exercised the
  halo, and every census test carried a pad override so none covered the
  netclass term.
- Full suite: **404 passed, 0 failed, 0 skipped**. One test (`test_obstacle_map_balance.py`, four routing chains) exceeded its 1200s budget under parallel load and passes solo in 15m16s.
- `tests/gui_parity/test_manifest_plan_parity.py` and
  `test_cli_postpass_coverage.py` pass. No new flag, no argparse default, no
  CLI-only post-pass — the change is inside shared engine functions, and the
  Placement tab drives these CLIs through `placement_run.py`, so nothing needs
  mirroring in the plugin.

## Two consequences that needed fixing with it

- `quench.build_neighbor_lists`' pruning reach now folds each part's largest pad
  requirement, so its exactness claim stays literally true.
- `seeder`'s repair would have moved the **fiducial**: a keep-clear conflict is
  characteristically a 1-pad fiducial against a many-pad connector, so pin count
  points the repair at the one part whose position is a mechanical fact. A
  separate mover key applies `reconstruct._body_exempt_refs` (the set that
  already exists for the body channel, with the same argument) — but **only to
  pairs the model raised**, because as a blanket term it was not inert: it
  flipped two pre-existing orangecrab pairs to moving a 2-pad cap and a 14-pin
  IC. Verified inert there now: at that board's own 0.25 floor all four
  conflicts carry an empty `required`.

## Deliberately unchanged

- `grade_body_overlap`'s `pad_intersection` channel uses `eps = 1e-3` — a
  physical intersection is a clearance-0 question, and an override cannot change
  whether two pads intersect.
- `placement/labels.py` (silk currency) and `placement/routability.py` (extents
  only) pass no model.
- **`placement/fanout_clearance.py` carries the same flat-scalar shape in a
  separate channel and still has this bug.** Out of scope here; happy to file it
  as a follow-up.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
