### PR TITLE
#722: the soft-joint anchor, in all four copies -- and the layer guard the cap credit needed

### DIFF
--- a/py_router/check_drc.py
+++ b/py_router/check_drc.py
@@ -61,7 +61,8 @@ _EXPAND_ROUTING = None
 from routing_constants import SOFT_JOINT_MIN_GAP as _SOFT_JOINT_MIN_GAP
 
 # The one endpoint-coincidence radius (same value everywhere: 0.02mm / 20um).
-from connectivity import COINCIDENCE_TOL
+from connectivity import (COINCIDENCE_TOL, endpoint_reaches_pad,
+                          endpoint_reaches_via)
 
 
 def pad_copper_layers(pad, board_copper) -> set:
@@ -2279,15 +2280,25 @@ def run_drc(pcb_file: str, clearance: float = 0.1, net_patterns: Optional[List[s
             continue
         _ep_count[(s.net_id, s.layer, _rk(s.start_x, s.start_y))] += 1
         _ep_count[(s.net_id, s.layer, _rk(s.end_x, s.end_y))] += 1
-    _via_by_net = _dd(list)
+    _vias_by_net = _dd(list)
     for v in pcb_data.vias:
-        _via_by_net[v.net_id].append((v.x, v.y, (getattr(v, 'size', 0) or 0) / 2.0))
-    def _at_anchor(nid, x, y):
-        for vx, vy, vr in _via_by_net.get(nid, []):
-            if math.hypot(x - vx, y - vy) <= vr + 0.01:
+        _vias_by_net[v.net_id].append(v)
+    _copper = list(getattr(pcb_data.board_info, 'copper_layers', None) or ())
+    def _at_anchor(nid, x, y, layer, width):
+        """Does this end's own COPPER reach a same-net via barrel or pad?
+
+        Shared predicate (connectivity.endpoint_reaches_*), so this stays
+        byte-identical to check_weird's soft-joint anchor and to the repair
+        pass. The cap is what physically touches, so the cap radius is the
+        credit -- for the pad exactly as for the via (#722) -- and the pad
+        must actually carry copper on this layer, as check_connected requires.
+        """
+        r = (width or 0.0) / 2.0
+        for v in _vias_by_net.get(nid, []):
+            if endpoint_reaches_via(x, y, r, v, (layer,), _copper):
                 return True
         for p in pcb_data.pads_by_net.get(nid, []):
-            if point_to_pad_distance(x, y, p) <= COINCIDENCE_TOL:
+            if endpoint_reaches_pad(x, y, r, (layer,), p):
                 return True
         return False
     _dangles = _dd(list)  # (net_id, layer) -> [(x, y, width)]
@@ -2297,17 +2308,25 @@ def run_drc(pcb_file: str, clearance: float = 0.1, net_patterns: Optional[List[s
         for (x, y) in ((s.start_x, s.start_y), (s.end_x, s.end_y)):
             if _ep_count[(s.net_id, s.layer, _rk(x, y))] != 1:
                 continue  # shared vertex = clean joint
-            if _at_anchor(s.net_id, x, y):
+            if _at_anchor(s.net_id, x, y, s.layer, s.width):
                 continue  # terminates on a via / own pad = legitimate
-            _dangles[(s.net_id, s.layer)].append((x, y, s.width))
+            # A soft joint is a PAIR: a graphic is carried as a flag so
+            # only an art-MEETS-art pair is dropped, never the actionable
+            # TRACK end paired with art (#337, #722).
+            _dangles[(s.net_id, s.layer)].append(
+                (x, y, s.width, getattr(s, 'graphic', False)))
     for (net_id, layer), ends in _dangles.items():
         for i in range(len(ends)):
-            xi, yi, wi = ends[i]
+            xi, yi, wi, gi = ends[i]
             for j in range(i + 1, len(ends)):
-                xj, yj, wj = ends[j]
+                xj, yj, wj, gj = ends[j]
                 gap = math.hypot(xi - xj, yi - yj)
                 cap = (wi + wj) / 2.0
+                if gi and gj:
+                    continue  # art meets art: nothing anyone can act on
                 if _SOFT_JOINT_MIN_GAP < gap < cap - 1e-6:
+                    if gi:  # report where the fix goes: the TRACK end
+                        xi, yi, xj, yj = xj, yj, xi, yi
                     net_name = pcb_data.nets.get(net_id, None)
                     net_str = net_name.name if net_name else f"net_{net_id}"
                     violations.append({

--- a/py_router/check_weird.py
+++ b/py_router/check_weird.py
@@ -16,7 +16,14 @@ Categories:
                      An end is ANCHORED -- and so not a free end at all -- by
                      a via barrel or by a pad its own cap overlaps, both by
                      RADIUS (#695); crediting a pad by centre containment made
-                     this contradict check_connected's endpoint-cap rule.
+                     this contradict check_connected's endpoint-cap rule. The
+                     anchor is the SHARED predicate (connectivity.
+                     endpoint_reaches_pad/_via), so this test, _check_dangles,
+                     check_drc's soft-joint detector and the close_soft_joints
+                     repair pass cannot drift apart again (#722) -- and it is
+                     layer- and NPTH-aware, because a pad that carries no
+                     copper on the end's layer anchors nothing. Copper-layer
+                     GRAPHICS are not candidates (#337: immutable input art).
   redundant-cycle    same-net loop edges whose removal leaves connectivity
                      identical (pcb_modification._prune_net_cycles machinery,
                      report-only; zoned nets skipped -- planes are meshes).
@@ -78,7 +85,8 @@ from check_connected import (matches_any_pattern, check_net_connectivity,
                              analyze_conn_excluding, point_in_polygon,
                              _point_in_pad)
 from check_drc import point_to_pad_distance
-from connectivity import COINCIDENCE_TOL
+from connectivity import (COINCIDENCE_TOL, endpoint_reaches_pad,
+                          endpoint_reaches_via)
 from routing_constants import SOFT_JOINT_MIN_GAP
 from pcb_modification import _point_anchored, _prune_net_cycles, _pt_seg_dist
 
@@ -123,37 +131,42 @@ def _via_span(via, copper_layers) -> set:
     return set(copper_layers)
 
 
-def _check_soft_joints(net_id, name, net_segs, net_vias, net_pads, findings):
+def _check_soft_joints(net_id, name, net_segs, net_vias, net_pads,
+                       findings, copper_layers=()):
     """check_drc's 'segment-endpoint-gap' detection (same constants/approach):
     dangling free ends (degree 1, not on a via/own pad) whose caps overlap
     but whose endpoints are not coincident. Returns the set of participating
     endpoint keys (layer, rx, ry) so the dangle check can defer to this,
     more specific, category."""
-    via_r = [(v.x, v.y, (getattr(v, 'size', 0) or 0) / 2.0) for v in net_vias]
+    def at_anchor(x, y, layer, width):
+        """Does this end's own COPPER reach a same-net via barrel or pad?
 
-    def at_anchor(x, y, width):
-        for vx, vy, vr in via_r:
-            if math.hypot(x - vx, y - vy) <= vr + 0.01:
+        The cap is what physically touches, so the cap radius is the credit
+        -- for the pad exactly as for the via. Both answers now come from the
+        SHARED predicates in connectivity, so the four copies of this test
+        (here, _check_dangles, check_drc._at_anchor and
+        pcb_modification.at_anchor) cannot drift apart again -- which is how
+        #695 and #722 shipped four lines from each other.
+
+        Three things the cap credit alone did not fix (#722):
+          * LAYER. This test credited ANY same-net pad whatever layer it sat
+            on, and widening the reach from 0.02mm to width/2 widened that
+            hole with it. check_connected iterates the pad's OWN copper
+            layers, so a B.Cu end near an F.Cu-only pad is genuinely SPLIT
+            there while this called it anchored -- a false NEGATIVE, the
+            direction that ships broken copper.
+          * NPTH. A plated hole is copper; an unplated one is not, whatever
+            its layer list says.
+          * The VIA branch is cap-blind in the same way the pad branch was:
+            `vr + 0.01` credits the barrel but not the cap, where the
+            authority credits (via_size + track_width)/2.
+        """
+        r = (width or 0.0) / 2.0
+        for v in net_vias:
+            if endpoint_reaches_via(x, y, r, v, (layer,), copper_layers):
                 return True
-        # The endpoint's round cap has a RADIUS (width/2), exactly as the via
-        # barrel two lines above has one -- so a stub ending just short of a
-        # pad outline can still have its cap physically overlapping the pad
-        # copper. Crediting the CENTRE only (COINCIDENCE_TOL, 0.02mm) made
-        # this branch contradict the authoritative model on copper KiCad
-        # grades joined: check_connected.py unions a track end into a pad at
-        # `_m = max(ewidth/2 - 1e-6, tolerance)` (the #285 endpoint-cap rule),
-        # so two 0.25mm stubs ending 0.05mm outside a 1.0x0.6 pad are ONE
-        # component there and a `soft-joint` here. That is the same
-        # centre-vs-barrel asymmetry #695 fixed for the via/pad credit, four
-        # lines apart from it, and it bites harder: `soft-joint` carries
-        # size=None, so --tolerance never filters it, and check_weird's exit
-        # code is chain-blocking through check_complete.
-        #
-        # `width` is REQUIRED rather than defaulted: a caller that forgot it
-        # would silently get the centre-only credit back, which is the defect.
-        _m = max(width / 2 - 1e-6, COINCIDENCE_TOL)
-        for p in net_pads:
-            if point_to_pad_distance(x, y, p) <= _m:
+        for pd in net_pads:
+            if endpoint_reaches_pad(x, y, r, (layer,), pd):
                 return True
         return False
 
@@ -170,24 +183,37 @@ def _check_soft_joints(net_id, name, net_segs, net_vias, net_pads, findings):
         for (x, y) in ((s.start_x, s.start_y), (s.end_x, s.end_y)):
             if ep_count[(s.layer, rk(x, y))] != 1:
                 continue  # shared vertex = clean joint
-            if at_anchor(x, y, s.width):
-                continue  # terminates on a via / own pad = legitimate
-            dangles[s.layer].append((x, y, s.width))
+            if at_anchor(x, y, s.layer, s.width):
+            # A soft joint is a PAIR. Dropping a copper-layer GRAPHIC as a
+            # candidate drops the TRACK end paired with it, and nothing
+            # else picks that end up -- measured, a genuinely open net
+            # (check_connected: 2 components, 1 disconnected pad) went
+            # from exit 1 to exit 0, and check_complete gates DONE on that
+            # exit code. The ART end is the unactionable half (#337 forbids
+            # touching it); the TRACK end is entirely actionable (extend it,
+            # or make the art real copper). So a graphic is carried as a
+            # flag and only an art-MEETS-art pair is dropped.
+                continue  # its copper reaches a via / own pad = legitimate
+            dangles[s.layer].append((x, y, s.width, getattr(s, 'graphic', False)))
 
     soft_pts = set()
     for layer, ends in dangles.items():
         for i in range(len(ends)):
-            xi, yi, wi = ends[i]
+            xi, yi, wi, gi = ends[i]
             for j in range(i + 1, len(ends)):
-                xj, yj, wj = ends[j]
+                xj, yj, wj, gj = ends[j]
                 gap = math.hypot(xi - xj, yi - yj)
                 cap = (wi + wj) / 2.0
+                if gi and gj:
+                    continue  # art meets art: nothing anyone can act on
                 if SOFT_JOINT_MIN_GAP < gap < cap - 1e-6:
                     # size=None: soft joints bypass the --tolerance filter.
                     # Filtering by GAP inverted the severity metric (small
                     # gap = still fragile) and on <=0.1mm-width routing every
                     # representable soft joint has gap < 0.1 -- the whole
                     # category silently vanished at the default tolerance.
+                    if gi:  # report where the fix goes: the TRACK end
+                        xi, yi, xj, yj = xj, yj, xi, yi
                     findings.append(_finding(
                         'soft-joint', name, layer, xi, yi,
                         f"endpoint gap {gap:.3f}mm to ({xj:.3f}, {yj:.3f}), "
@@ -255,16 +281,15 @@ def _check_dangles(net_id, name, net_segs, net_vias, net_pads, net_zones,
             # max half-dimension) and misses rectangular pad corners: a stub
             # ending exactly on a 1.4x1.2 crystal pad's corner copper read
             # as a dangle. Exact outline test (glasgow XTALOUT/C11).
-            def _pad_carries(p):
-                # NPTH pads have no copper even when layers lists *.Cu; an
-                # other-layer SMD pad can't anchor this layer's free end.
-                if getattr(p, 'pad_type', '') == 'np_thru_hole':
-                    return False
-                if p.drill <= 0 and s.layer not in p.layers \
-                        and '*.Cu' not in p.layers:
-                    return False
-                return point_to_pad_distance(fx, fy, p) <= s.width / 2
-            if any(_pad_carries(p) for p in net_pads):
+            # The exact outline test is the SHARED predicate now --
+            # byte-identical to the one _check_soft_joints asks. Two
+            # spellings changed, both measured over kicad_files/:
+            # COINCIDENCE_TOL became a floor under the cap credit (it bites
+            # below 0.04mm track width; the corpus floor is 0.0762) and
+            # `'*.Cu' not in p.layers` became `any('*' in L)`, the form every
+            # other site already used.
+            if any(endpoint_reaches_pad(fx, fy, s.width / 2.0, (s.layer,), p)
+                   for p in net_pads):
                 continue
             if any(point_in_polygon(fx, fy, z.polygon)
                    for z in zones_by_layer.get(s.layer, ())):
@@ -731,7 +756,7 @@ def check_weird(pcb_data: PCBData, net_patterns: Optional[List[str]] = None,
         has_zone = bool(net_zones)
 
         soft_pts = _check_soft_joints(net_id, name, net_segs, net_vias,
-                                      net_pads, findings)
+                                      net_pads, findings, copper_layers)
         _check_dangles(net_id, name, net_segs, net_vias, net_pads, net_zones,
                        soft_pts, findings, join_tol=tolerance or 0.0)
         _check_orphan_islands(net_id, name, net_segs, net_vias, net_pads,

--- a/py_router/check_weird.py
+++ b/py_router/check_weird.py
@@ -235,12 +235,18 @@ def _check_dangles(net_id, name, net_segs, net_vias, net_pads, net_zones,
     if not track_segs:
         return
     via_pts = [(v.x, v.y, getattr(v, 'size', 0.6) or 0.6) for v in net_vias]
+    # NO pads are handed to _point_anchored. Its pad test is a bounding CIRCLE
+    # of radius max(size_x, size_y)/2, which over-credits every non-square pad
+    # -- and because it runs FIRST it can only ADD credit, so the exact test
+    # below never gets to refuse. Measured over kicad_files/: it anchors 2
+    # endpoints the exact predicate refuses, both a 0.3mm track ending 0.575mm
+    # from a 1.8x0.45 pad's copper on lvds_converter_dualclk_gnd -- a board
+    # that reports zero findings today, so those are two masked dangling-ends.
+    # _point_anchored keeps the VIA and T-junction halves, which this function
+    # has no other source for; pads are answered by endpoint_reaches_pad alone.
+    # (The bounding circle is left alone in pcb_modification, where the pruner
+    # shares it and over-crediting is the safe direction for a REMOVAL gate.)
     pad_pts = []
-    for p in net_pads:
-        px = getattr(p, 'global_x', getattr(p, 'x', 0.0))
-        py = getattr(p, 'global_y', getattr(p, 'y', 0.0))
-        psize = max(getattr(p, 'size_x', 0.5), getattr(p, 'size_y', 0.5))
-        pad_pts.append((px, py, psize, getattr(p, 'layers', [])))
 
     def key(x, y, layer):
         return (round(x, 3), round(y, 3), layer)
@@ -646,7 +652,8 @@ def _check_terminal_web(pcb_data, net_id, name, net_segs, net_pads, floor,
     if floor <= 0 or not net_pads or not net_segs:
         return
     from pcb_modification import (terminal_pad_web_shortfall,
-                                  terminal_web_neck_exact)
+                                  terminal_web_neck_exact,
+                                  circular_pad_web_shortfall, _is_round_pad)
     from routing_utils import _to_pad_frame
     e = floor / 2.0
 
@@ -671,8 +678,9 @@ def _check_terminal_web(pcb_data, net_id, name, net_segs, net_pads, floor,
                 continue  # not a free end
             target = None
             for pad in net_pads:
-                if getattr(pad, 'shape', None) not in ('rect', 'roundrect', 'oval'):
-                    continue
+                if getattr(pad, 'shape', None) not in ('rect', 'roundrect',
+                                                       'oval', 'circle'):
+                    continue  # custom-polygon pads have no closed-form web
                 if not pad.size_x or not pad.size_y:
                     continue
                 if not (s.layer in pad.layers or any('*' in L for L in pad.layers)):
@@ -684,8 +692,17 @@ def _check_terminal_web(pcb_data, net_id, name, net_segs, net_pads, floor,
                 continue
             elx, ely = _to_pad_frame(ex, ey, target)
             nlx, nly = _to_pad_frame(nx, ny, target)
-            is_neck, _ = terminal_pad_web_shortfall(
-                nlx, nly, elx, ely, target.size_x / 2.0, target.size_y / 2.0, r, e)
+            if _is_round_pad(target):
+                # A round pad has no corner, but it has a RIM: a cap landing
+                # near the edge joins through a lens chord that can be far
+                # below the floor. Skipping circles here reported NOTHING on
+                # the same hazard the rect model catches (#416/#722).
+                is_neck, _ = circular_pad_web_shortfall(
+                    elx, ely, target.size_x / 2.0, r, e)
+            else:
+                is_neck, _ = terminal_pad_web_shortfall(
+                    nlx, nly, elx, ely, target.size_x / 2.0,
+                    target.size_y / 2.0, r, e)
             if is_neck and terminal_web_neck_exact(
                     pcb_data, net_id, s.layer, ex, ey, floor) is not False:
                 # size=None: narrow pad joints bypass the --tolerance

--- a/py_router/connectivity.py
+++ b/py_router/connectivity.py
@@ -184,6 +184,116 @@ def is_edge_stub(pad_x: float, pad_y: float, bga_zones: List) -> bool:
 COINCIDENCE_TOL = 0.02
 
 
+def endpoint_reaches_pad(x, y, radius, layers, pad) -> set:
+    """Which of `layers` a disc of copper -- centre (x, y), radius `radius` --
+    both SHARES with `pad`'s copper and physically OVERLAPS. Empty set = no
+    contact.
+
+    THE one predicate for "does this copper reach this pad". A track
+    endpoint's round cap and a via barrel are the SAME question with a
+    different radius; answering them separately is how #695 and #722 shipped
+    four lines apart, in four copies across three modules.
+
+    GEOMETRY mirrors check_connected's endpoint-in-pad rule exactly --
+    ``_m = max(ewidth / 2 - 1e-6, tolerance)`` -- and its via twin,
+    ``_m = max(vsize / 2 - 1e-6, tolerance)``, whose `tolerance` default IS
+    COINCIDENCE_TOL. `margin` inflates the EXACT pad outline (custom-pad
+    polygons, roundrect corners and rect_rotation all hold), so this reads
+    "the copper overlaps the pad copper", not "the centre is inside it".
+    COINCIDENCE_TOL is a FLOOR under the credit, never a replacement for it,
+    exactly as it is there.
+
+    Note the role split this file documents above: COINCIDENCE_TOL grades
+    geometric INTENT. Asking a copper-reaches-copper question with it is a
+    category error -- it made these checkers contradict check_net_connectivity
+    on copper KiCad grades joined, and their exit codes are chain-blocking.
+
+    LAYERS come from `net_queries.expand_pad_layers`, the SAME expansion
+    check_connected uses, rather than a local reading of `pad.layers`:
+
+      * `*.Cu` means every copper layer; `*.Mask` and `*.Paste` mean NO copper
+        layer. A local `any('*' in L)` test reads a mask wildcard as an
+        all-layer copper pad -- and 641 pads in kicad_files/ carry `*.Mask`.
+      * a drilled pad occupies the layers it DECLARES. `drill > 0 -> every
+        layer` over-credits a PTH pad declared ("F.Cu" "B.Cu") on a 4-layer
+        board, which the authority grades as not reaching In1.Cu at all.
+      * an NPTH pad is a hole with no copper whatever its layer list says
+        (#328). `pad_is_plated_through` is the spelling for the neighbouring
+        question ("does this barrel tie copper layers"); here the pad simply
+        has no copper to land on.
+
+    Crediting the cap WITHOUT the layer guard trades one contradiction for
+    another: B.Cu ends near an F.Cu-only pad are genuinely split, and a
+    layer-blind widening silences that -- the direction that ships broken
+    copper.
+    """
+    if getattr(pad, 'pad_type', '') == 'np_thru_hole':
+        return set()                        # a hole, not copper (#328)
+    # Local import: net_queries imports this module, so a module-level import
+    # would cycle -- the same reason check_net_connectivity is imported below.
+    from net_queries import expand_pad_layers
+    want = list(layers)
+    on = set(want) & set(expand_pad_layers(list(getattr(pad, 'layers', None)
+                                                or ()), want))
+    if not on:
+        return set()                        # cheap test first; geometry is the cost
+    from check_connected import _point_in_pad
+    if _point_in_pad(x, y, pad, margin=max(radius - 1e-6, COINCIDENCE_TOL)):
+        return on
+    return set()
+
+
+def via_copper_layers(via, copper_layers=None) -> set:
+    """The copper layers `via`'s barrel actually occupies.
+
+    check_connected's rule: a via listing both F.Cu and B.Cu (or listing
+    nothing) spans every copper layer; otherwise it spans what it declares.
+    When `copper_layers` is supplied, a blind/buried via also gets the layers
+    BETWEEN its endpoints -- a buried F.Cu-In2.Cu via touches In1.Cu, and
+    treating the span as the two endpoints alone manufactured phantom
+    unsupported-via findings (check_weird._via_span, same rule).
+    """
+    declared = [L for L in (getattr(via, 'layers', None) or ()) if L.endswith('.Cu')]
+    if not declared or ('F.Cu' in declared and 'B.Cu' in declared):
+        return set(copper_layers or declared or ())
+    if copper_layers:
+        order = list(copper_layers)
+        idx = [order.index(L) for L in declared if L in order]
+        if len(idx) >= 2:
+            return set(order[min(idx):max(idx) + 1])
+    return set(declared)
+
+
+def endpoint_reaches_via(x, y, radius, via, layers, copper_layers=None) -> bool:
+    """Does a disc of copper -- centre (x, y), radius `radius`, living on
+    `layers` -- overlap `via`'s barrel?
+
+    The via twin of `endpoint_reaches_pad`, and the same mirror of the
+    authority: check_connected credits a via against a segment at
+    ``max((psize + seg.width) / 2 - eps, tolerance)`` -- barrel radius PLUS
+    the copper's own radius -- and creates via points ONLY on the via's own
+    copper layers.
+
+    Both halves matter, and only together. The soft-joint anchors used a flat
+    ``vr + 0.01``: barrel-aware but CAP-BLIND, the very defect #722 reports on
+    the pad branch. Widening that to `vr + radius` WITHOUT the layer test just
+    makes a layer-blind credit ~37% wider -- on a 0.6mm via and a 0.25mm track,
+    0.310mm becomes 0.425mm -- so a blind F.Cu/In1.Cu via would anchor B.Cu
+    track ends it carries no copper for, silencing a real open.
+
+    A via with no declared size claims the 0.6 default, matching
+    ``getattr(via, 'size', 0.6)`` in check_connected. A via whose size IS zero
+    keeps zero there, so it keeps zero here.
+    """
+    if not (set(layers) & via_copper_layers(via, copper_layers)):
+        return False
+    vr = (getattr(via, 'size', 0.6) if getattr(via, 'size', None) is not None
+          else 0.6) / 2.0
+    return math.hypot(x - via.x, y - via.y) <= max(vr + radius - 1e-6,
+                                                   COINCIDENCE_TOL)
+
+
+
 _CLUSTER_MEMO: "OrderedDict[tuple, tuple]" = OrderedDict()
 _CLUSTER_MEMO_CAP = 4096
 

--- a/py_router/pcb_modification.py
+++ b/py_router/pcb_modification.py
@@ -199,7 +199,8 @@ def prune_dead_end_segments(prunable: List[Segment], anchor_segments: List[Segme
 # is deliberately asymmetric (measure reality physically; refuse to ship
 # fragility). See issue #322 (smartknob +5V: mid-chain removals each passed
 # the overlap gate until 5 pads were genuinely disconnected).
-from connectivity import COINCIDENCE_TOL
+from connectivity import (COINCIDENCE_TOL, endpoint_reaches_pad,
+                          endpoint_reaches_via)
 _STRICT_GATE_WIDTH = COINCIDENCE_TOL  # one constant (#320): strict twin gate width
 
 
@@ -503,16 +504,34 @@ def close_soft_joints(results, pcb_data: PCBData, scope_net_ids, config,
             continue  # #337: immutable art -- its termini are not dangles
         ep_count[(s.net_id, s.layer, rk(s.start_x, s.start_y))] += 1
         ep_count[(s.net_id, s.layer, rk(s.end_x, s.end_y))] += 1
+    vias_by_net = defaultdict(list)
     via_by_net = defaultdict(list)
     for v in pcb_data.vias:
-        via_by_net[v.net_id].append((v.x, v.y, (getattr(v, 'size', 0) or 0) / 2.0))
+        vias_by_net[v.net_id].append(v)
+        # (x, y, radius) tuples for the via->pad GRAZE bridge below and the
+        # terminal-web via-terminal skip: those ask a DIFFERENT question (a
+        # graze band, a "is this a via terminal" test), not "does this end's
+        # own copper reach the barrel", so they keep their own geometry.
+        via_by_net[v.net_id].append((v.x, v.y,
+                                     (getattr(v, "size", 0) or 0) / 2.0))
 
-    def at_anchor(nid, x, y):
-        for vx, vy, vr in via_by_net.get(nid, []):
-            if math.hypot(x - vx, y - vy) <= vr + 0.01:
+    _copper = list(getattr(pcb_data.board_info, 'copper_layers', None) or ())
+    def at_anchor(nid, x, y, layer, width):
+        """Does this end's own COPPER reach a same-net via barrel or pad?
+
+        Shared predicate (connectivity.endpoint_reaches_*). This function and
+        check_drc's soft-joint detector MUST agree -- this pass repairs what
+        that one reports -- and they did not: a pad was credited by its CENTRE
+        while a via was credited by its RADIUS, so two ordinary stubs landing
+        on one pad were "dangling" and this pass bridged them with a segment
+        laid across copper both ends already touched (#722).
+        """
+        r = (width or 0.0) / 2.0
+        for v in vias_by_net.get(nid, []):
+            if endpoint_reaches_via(x, y, r, v, (layer,), _copper):
                 return True
         for p in pcb_data.pads_by_net.get(nid, []):
-            if point_to_pad_distance(x, y, p) <= COINCIDENCE_TOL:
+            if endpoint_reaches_pad(x, y, r, (layer,), p):
                 return True
         return False
 
@@ -523,7 +542,7 @@ def close_soft_joints(results, pcb_data: PCBData, scope_net_ids, config,
         for (x, y) in ((s.start_x, s.start_y), (s.end_x, s.end_y)):
             if ep_count[(s.net_id, s.layer, rk(x, y))] != 1:
                 continue
-            if at_anchor(s.net_id, x, y):
+            if at_anchor(s.net_id, x, y, s.layer, s.width):
                 continue
             dangles[(s.net_id, s.layer)].append((x, y, s.width))
 
@@ -1383,14 +1402,22 @@ def _soft_joint_pairs(segs, vias, pads):
     from routing_constants import SOFT_JOINT_MIN_GAP
     from check_drc import point_to_pad_distance
 
-    via_pts = [(v.x, v.y, (getattr(v, 'size', 0) or 0) / 2.0) for v in (vias or [])]
+    def anchored(x, y, layer, width):
+        """Does this end's own COPPER reach a same-net via barrel or pad?
 
-    def anchored(x, y):
-        for vx, vy, vr in via_pts:
-            if math.hypot(x - vx, y - vy) <= vr + 0.01:
+        Shared predicate (connectivity.endpoint_reaches_*). This function and
+        check_drc's soft-joint detector MUST agree -- this pass repairs what
+        that one reports -- and they did not: a pad was credited by its CENTRE
+        while a via was credited by its RADIUS, so two ordinary stubs landing
+        on one pad were "dangling" and this pass bridged them with a segment
+        laid across copper both ends already touched (#722).
+        """
+        r = (width or 0.0) / 2.0
+        for v in (vias or []):
+            if endpoint_reaches_via(x, y, r, v, (layer,)):
                 return True
         for p in (pads or []):
-            if point_to_pad_distance(x, y, p) <= COINCIDENCE_TOL:
+            if endpoint_reaches_pad(x, y, r, (layer,), p):
                 return True
         return False
 
@@ -1398,23 +1425,29 @@ def _soft_joint_pairs(segs, vias, pads):
     for s in segs:
         deg[(s.layer, _rk3(s.start_x, s.start_y))] += 1
         deg[(s.layer, _rk3(s.end_x, s.end_y))] += 1
-    dangles = defaultdict(list)  # layer -> [(key, x, y, width)]
+    dangles = defaultdict(list)  # layer -> [(key, x, y, width, is_graphic)]
     seen = set()
     for s in segs:
         for (x, y) in ((s.start_x, s.start_y), (s.end_x, s.end_y)):
             key = (s.layer, _rk3(x, y))
             if deg[key] != 1 or key in seen:
                 continue
-            if anchored(x, y):
+            if anchored(x, y, s.layer, s.width):
                 continue
             seen.add(key)
-            dangles[s.layer].append((key, x, y, s.width))
+            dangles[s.layer].append((key, x, y, s.width,
+                                     getattr(s, 'graphic', False)))
     pairs = set()
     for layer, ends in dangles.items():
         for i in range(len(ends)):
-            ki, xi, yi, wi = ends[i]
+            ki, xi, yi, wi, gi = ends[i]
             for j in range(i + 1, len(ends)):
-                kj, xj, yj, wj = ends[j]
+                kj, xj, yj, wj, gj = ends[j]
+                if gi and gj:
+                    # Art meets art: nothing anyone can act on (#337 forbids
+                    # touching it), and check_weird/check_drc drop the same
+                    # pair. A MIXED pair is kept -- the track end is real.
+                    continue
                 gap = math.hypot(xi - xj, yi - yj)
                 if SOFT_JOINT_MIN_GAP < gap < (wi + wj) / 2.0 - 1e-6:
                     pairs.add(frozenset((ki, kj)))

--- a/py_router/pcb_modification.py
+++ b/py_router/pcb_modification.py
@@ -453,6 +453,31 @@ def _duplicate_connector(px: float, py: float, tx: float, ty: float,
     return False
 
 
+def _own_net_npth_hole_dist(pcb_data, net_id, x1, y1, x2, y2) -> float:
+    """Distance from segment (x1,y1)-(x2,y2) to the drill of any SAME-net
+    UNPLATED pad. inf when there is none.
+
+    The foreign-hole scan deliberately skips own-net holes, because a plated
+    own-net barrel IS this net's copper. An unplated one is not copper at all
+    (#328) -- it is a hole, and a track crossing it is a fab defect no
+    clearance check was looking at."""
+    from kicad_parser import pad_drill_circles
+    best = float('inf')
+    for pads in pcb_data.pads_by_net.values():
+        for pad in pads:
+            if getattr(pad, 'pad_type', '') != 'np_thru_hole':
+                continue
+            if getattr(pad, 'net_id', 0) != net_id:
+                continue          # foreign NPTH holes: the foreign scan has them
+            # pad_drill_circles yields (x, y, DIAMETER), and a slot yields
+            # several circles along its axis -- so this follows a slotted
+            # mounting hole rather than treating it as one disc.
+            for (hx, hy, hdia) in pad_drill_circles(pad):
+                best = min(best,
+                           _pt_seg_dist(hx, hy, x1, y1, x2, y2) - hdia / 2.0)
+    return best
+
+
 def close_soft_joints(results, pcb_data: PCBData, scope_net_ids, config,
                       clearance: float = None) -> int:
     """Bridge same-net SOFT JOINTS with a TINY coincident segment (#soft-joint).
@@ -500,8 +525,14 @@ def close_soft_joints(results, pcb_data: PCBData, scope_net_ids, config,
     for s in pcb_data.segments:
         if scope_net_ids is not None and s.net_id not in scope_net_ids:
             continue
-        if getattr(s, 'graphic', False):
-            continue  # #337: immutable art -- its termini are not dangles
+        # Copper-layer GRAPHICS COUNT toward the degree, exactly as they do
+        # in check_drc's detector and check_weird's -- they were skipped here,
+        # so a track end sharing a vertex with copper art was degree 1 in this
+        # pass and degree 2 there: check_drc reported nothing while this pass
+        # wrote a bridge. This function's contract is "check_drc's exact
+        # soft-joint definition, so detection and repair agree"; that only
+        # holds if the degree is counted the same way. Graphics are still not
+        # CANDIDATES (below) -- #337 keeps the art itself untouchable.
         ep_count[(s.net_id, s.layer, rk(s.start_x, s.start_y))] += 1
         ep_count[(s.net_id, s.layer, rk(s.end_x, s.end_y))] += 1
     vias_by_net = defaultdict(list)
@@ -535,7 +566,7 @@ def close_soft_joints(results, pcb_data: PCBData, scope_net_ids, config,
                 return True
         return False
 
-    dangles = defaultdict(list)  # (net_id, layer) -> [(x, y, width)]
+    dangles = defaultdict(list)  # (net_id, layer) -> [(x, y, width, graphic)]
     for s in pcb_data.segments:
         if scope_net_ids is not None and s.net_id not in scope_net_ids:
             continue
@@ -544,7 +575,8 @@ def close_soft_joints(results, pcb_data: PCBData, scope_net_ids, config,
                 continue
             if at_anchor(s.net_id, x, y, s.layer, s.width):
                 continue
-            dangles[(s.net_id, s.layer)].append((x, y, s.width))
+            dangles[(s.net_id, s.layer)].append(
+                (x, y, s.width, getattr(s, 'graphic', False)))
 
     def clears(nid, x1, y1, x2, y2, layer, w):
         d = min(_seg_foreign_pad_dist(pcb_data, nid, x1, y1, x2, y2, layer,
@@ -552,6 +584,14 @@ def close_soft_joints(results, pcb_data: PCBData, scope_net_ids, config,
                 _seg_foreign_seg_dist(pcb_data, nid, x1, y1, x2, y2, layer),
                 _seg_foreign_via_dist(pcb_data, nid, x1, y1, x2, y2, layer))
         hd = _seg_foreign_hole_dist(pcb_data, nid, x1, y1, x2, y2)
+        # _seg_foreign_hole_dist filters `nid != net_id` ("own-net holes are
+        # excluded"), which is right for a PLATED barrel -- that copper is the
+        # net. It is wrong for an UNPLATED one: an NPTH pad has no copper
+        # whatever net it is tagged with (#328), so a net-tied mounting hole is
+        # a hole this bridge must clear like any other. Without this the gate
+        # was structurally blind to the one hole a same-net bridge is most
+        # likely to cross.
+        hd = min(hd, _own_net_npth_hole_dist(pcb_data, nid, x1, y1, x2, y2))
         return (d >= clr + w / 2.0 - 1e-4 and
                 hd >= npth_clr + w / 2.0 - 1e-4)
 
@@ -561,11 +601,13 @@ def close_soft_joints(results, pcb_data: PCBData, scope_net_ids, config,
         for i in range(len(ends)):
             if i in used:
                 continue
-            xi, yi, wi = ends[i]
+            xi, yi, wi, gi = ends[i]
             for j in range(i + 1, len(ends)):
                 if j in used:
                     continue
-                xj, yj, wj = ends[j]
+                xj, yj, wj, gj = ends[j]
+                if gi and gj:
+                    continue  # art meets art: #337 forbids touching either end
                 gap = math.hypot(xi - xj, yi - yj)
                 cap = (wi + wj) / 2.0
                 if SOFT_JOINT_MIN_GAP < gap < cap - 1e-6:
@@ -673,8 +715,9 @@ def close_soft_joints(results, pcb_data: PCBData, scope_net_ids, config,
                 continue  # anchored on a same-net via: a via terminal, not this
             target = None
             for pad in pcb_data.pads_by_net.get(s.net_id, []):
-                if getattr(pad, 'shape', None) not in ('rect', 'roundrect', 'oval'):
-                    continue  # sharp-corner necks: skip circle/custom pads
+                if getattr(pad, 'shape', None) not in ('rect', 'roundrect',
+                                                       'oval', 'circle'):
+                    continue  # custom-polygon pads have no closed-form web
                 if not pad.size_x or not pad.size_y:
                     continue
                 if not (s.layer in pad.layers or any('*' in L for L in pad.layers)):
@@ -686,9 +729,13 @@ def close_soft_joints(results, pcb_data: PCBData, scope_net_ids, config,
                 continue
             elx, ely = _to_pad_frame(ex, ey, target)
             nlx, nly = _to_pad_frame(nx, ny, target)
-            is_neck, tloc = terminal_pad_web_shortfall(
-                nlx, nly, elx, ely, target.size_x / 2.0, target.size_y / 2.0,
-                r, e416)
+            if _is_round_pad(target):
+                is_neck, tloc = circular_pad_web_shortfall(
+                    elx, ely, target.size_x / 2.0, r, e416)
+            else:
+                is_neck, tloc = terminal_pad_web_shortfall(
+                    nlx, nly, elx, ely, target.size_x / 2.0,
+                    target.size_y / 2.0, r, e416)
             if not is_neck:
                 continue
             # Confirm the cheap (over-reporting) pre-filter with KiCad's exact
@@ -829,6 +876,53 @@ def _pad_web_polygon(pad):
     if rot:
         shp = aff.rotate(shp, rot, origin=(pad.global_x, pad.global_y))
     return shp
+
+
+def _is_round_pad(pad) -> bool:
+    """A true circle: `circle`, or an `oval` whose axes are equal (KiCad writes
+    a round pad either way). Only these have the rotationally-symmetric web
+    circular_pad_web_shortfall solves; an elongated oval is a stadium and stays
+    on the conservative rectangular pre-filter."""
+    if not pad.size_x or not pad.size_y:
+        return False
+    return (getattr(pad, 'shape', None) in ('circle', 'oval')
+            and abs(pad.size_x - pad.size_y) < 1e-9)
+
+
+def circular_pad_web_shortfall(elx, ely, R, r, e, target_margin=0.0):
+    """The terminal-web pre-filter for a ROUND pad, in the pad's local frame.
+
+    terminal_pad_web_shortfall models the pad as a rectangle, so both callers
+    skipped circle pads entirely -- "a circle has no corner to graze". It has no
+    corner, but it still has a RIM: a cap landing near the edge of a round pad
+    joins it through a lens whose chord can be far thinner than the floor, which
+    is the same connection_width hazard (#416) the rect model catches. The
+    exact confirm (terminal_web_neck_exact -> _pad_web_polygon) has handled
+    circles all along; only this pre-filter and the shape gate did not.
+
+    Two circles, radii R (pad) and r (cap), centres d apart, intersect in a lens
+    whose chord half-width is h = sqrt(R^2 - a^2), a = (d^2 - r^2 + R^2) / 2d.
+    The joint is sub-floor when 2h < 2e. This is exact for the pair, and the
+    caller still confirms with KiCad's own erosion.
+
+    Returns ``(maybe_neck, target_local_or_None)`` like its rectangular twin.
+    """
+    d = math.hypot(elx, ely)
+    if R <= e + 1e-6:
+        return False, None      # pad narrower than the floor: unfixable
+    if d + r <= R + 1e-9:
+        return False, None      # cap fully inside: the web is the full cap
+    if d <= 1e-9 or d >= R + r:
+        return False, None      # concentric, or no contact at all
+    a = (d * d - r * r + R * R) / (2.0 * d)
+    h = math.sqrt(max(0.0, R * R - a * a))
+    if h >= e - 1e-9:
+        return False, None      # the chord already clears the floor
+    reach = R - e - target_margin
+    if reach <= 1e-6:
+        return False, None      # no floor-width band exists inside this pad
+    t = min(d, reach) / d
+    return True, (elx * t, ely * t)
 
 
 def terminal_web_neck_exact(pcb_data, net_id, layer, ex, ey, floor,

--- a/tests/test_check_weird.py
+++ b/tests/test_check_weird.py
@@ -26,6 +26,7 @@ Plus two guards on the REPORTER, which is what #696 actually broke:
 """
 import ast
 import io
+import math
 import os
 import re
 import sys
@@ -103,6 +104,29 @@ def _pcb(segments, vias=(), pads=(), zones=()):
 
 def _cats(findings):
     return Counter(f['category'] for f in findings)
+
+
+def _pad_geometry_askers():
+    """Functions in check_weird.py that ask pad/via CONTACT geometry directly
+    instead of through the shared predicate.
+
+    #722's thesis is that ONE question answered several ways is the defect,
+    not any single coordinate -- so the guard has to be STRUCTURAL. Nothing
+    that merely RUNS the checker can notice a fifth spelling appearing; this
+    can, the same way _emitted_categories() catches an unregistered category.
+    Nested functions are attributed to their parent, so an offender inside a
+    closure fails this too."""
+    tree = ast.parse(io.open(check_weird_mod.__file__, encoding='utf-8').read())
+    out = set()
+    for fn in ast.walk(tree):
+        if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for node in ast.walk(fn):
+            if (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+                    and node.func.id in ('point_to_pad_distance',
+                                         '_point_in_pad')):
+                out.add(fn.name)
+    return out
 
 
 def main():
@@ -403,6 +427,267 @@ def main():
         results.append((f"check_weird agrees with it ({_label}): "
                         f"soft-joint must be {not _want_joined}",
                         _soft is (not _want_joined)))
+
+    # 14. The three things the cap credit alone did NOT fix (#722). Each is a
+    #     way this anchor still disagreed with check_connected after the cap
+    #     radius landed, and each row carries its own control.
+    #
+    #     (a) LAYER. at_anchor credited ANY same-net pad whatever layer it sat
+    #         on, and widening the reach from 0.02mm to width/2 WIDENED that
+    #         hole rather than closing it. check_connected iterates the pad's
+    #         OWN copper layers, so B.Cu ends near an F.Cu-only pad are
+    #         genuinely SPLIT there while this called them anchored -- a false
+    #         NEGATIVE, the direction that ships broken copper.
+    def _land(pad_layer='F.Cu', seg_layer='F.Cu', ex=-0.55, w=0.25, pad=None):
+        lp = pad if pad is not None else _rect_pad(
+            0, 0, 1.0, 0.6, layers=(pad_layer,), num='1')
+        pads = [lp, _rect_pad(-3, 0, 1.0, 0.6, layers=(seg_layer,), num='2',
+                              ref='U2')]
+        segs = [_seg(-3, -0.06, ex, -0.06, layer=seg_layer, width=w),
+                _seg(-3, 0.06, ex, 0.06, layer=seg_layer, width=w)]
+        return _pcb(segs, pads=pads), segs, pads
+
+    def _sj(board):
+        return len([x for x in check_weird(board, tolerance=0)[0]
+                    if x['category'] == 'soft-joint'])
+
+    pcb, segs, pads = _land(pad_layer='F.Cu', seg_layer='B.Cu')
+    conn = check_net_connectivity(NET, segs, [], pads, [])
+    results.append(("an other-layer pad anchors nothing: check_connected "
+                    "calls this net SPLIT",
+                    conn['num_components'] == 2
+                    and len(conn['disconnected_pads']) == 1))
+    results.append(("...and check_weird agrees: still a soft joint",
+                    _sj(pcb) == 1))
+    #     Control: the SAME pad on the ends' own layer anchors both and the
+    #     board is clean -- so the row above is the LAYER test firing, not the
+    #     predicate refusing everything.
+    results.append(("the same pad on the ends' own layer anchors them: clean",
+                    _sj(_land(pad_layer='F.Cu', seg_layer='F.Cu')[0]) == 0))
+
+    #     (b) NPTH. An unplated hole has no copper even when its layer list
+    #         says *.Cu, so it anchors nothing. Its PLATED twin -- identical
+    #         geometry -- must still anchor, or the row would be passing
+    #         because the predicate refuses everything.
+    _npth = _rect_pad(0, 0, 1.0, 0.6, layers=('*.Cu',), num='1')
+    _npth.drill, _npth.pad_type = 0.8, 'np_thru_hole'
+    _plated = _rect_pad(0, 0, 1.0, 0.6, layers=('*.Cu',), num='1')
+    _plated.drill, _plated.pad_type = 0.8, 'thru_hole'
+    results.append(("a PLATED through pad anchors the ends (control)",
+                    _sj(_land(pad=_plated)[0]) == 0))
+    results.append(("an NPTH pad has no copper and anchors nothing",
+                    _sj(_land(pad=_npth)[0]) == 1))
+
+    #     (c) The VIA branch was cap-blind in exactly the way the pad branch
+    #         was: `vr + 0.01` credits the barrel but not the end's own cap,
+    #         where check_connected credits (via_size + track_width)/2. On a
+    #         0.6mm via and a 0.25mm track that is 0.310mm against 0.425mm.
+    def _via_land(dx, w=0.25):
+        pads = [_pad(-3, 0, num='1'),
+                _pad(3, 0, layers=('B.Cu',), num='2', ref='U2')]
+        segs = [_seg(-3, 0, -dx, -0.06, width=w),
+                _seg(-dx, 0.06, -3, 0, width=w),
+                _seg(0, 0, 3, 0, layer='B.Cu', width=w)]
+        v = _via(0, 0)
+        return _pcb(segs, vias=[v], pads=pads), segs, [v], pads
+
+    _d_band = math.hypot(0.35, 0.06)
+    results.append(("the via row is ON the cap band (clears barrel+0.01, "
+                    "inside barrel+cap)",
+                    0.3 + 0.01 < _d_band <= 0.3 + 0.125))
+    pcb_v, segs_v, vias_v, pads_v = _via_land(0.35)
+    conn_v = check_net_connectivity(NET, segs_v, vias_v, pads_v, [])
+    results.append(("check_connected joins through the barrel+cap overlap",
+                    conn_v['num_components'] == 1
+                    and not conn_v['disconnected_pads']))
+    results.append(("...and check_weird agrees: not a soft joint",
+                    _sj(pcb_v) == 0))
+    pcb_f, segs_f, vias_f, pads_f = _via_land(0.50)
+    conn_f = check_net_connectivity(NET, segs_f, vias_f, pads_f, [])
+    results.append(("an end beyond barrel+cap is genuinely split "
+                    "(check_connected)",
+                    conn_f['num_components'] > 1
+                    or bool(conn_f['disconnected_pads'])))
+    results.append(("...and check_weird agrees: still a soft joint",
+                    _sj(pcb_f) == 1))
+
+    # 15. Copper-layer GRAPHICS (#337) are immutable input art. They were
+    #     soft-joint CANDIDATES here and nowhere else -- _check_dangles refuses
+    #     them and check_connected refuses them outright ("graphics never
+    #     conduct") -- so a graphic pair produced an unactionable finding in a
+    #     size=None category that --tolerance can never drop.
+    _gpads = [_pad(-5, 0, num='1'), _pad(-6, 0, num='2', ref='U2')]
+    _real = [_seg(-6, 0, -5, 0), _seg(3, 0, 5, 0), _seg(3.12, 0, 6, 0.5)]
+    _art = [_real[0]] + [Segment(start_x=s.start_x, start_y=s.start_y,
+                                 end_x=s.end_x, end_y=s.end_y, width=s.width,
+                                 layer=s.layer, net_id=NET, graphic=True)
+                         for s in _real[1:]]
+    _w_art = check_net_connectivity(NET, _art, [], _gpads, [])
+    _wo_art = check_net_connectivity(NET, [_real[0]], [], _gpads, [])
+    results.append(("graphics are invisible to check_connected (identical "
+                    "verdict with and without them)",
+                    (_w_art['num_components'], _w_art['disconnected_pads'])
+                    == (_wo_art['num_components'],
+                        _wo_art['disconnected_pads'])))
+    results.append(("a graphic near-open is NOT a soft joint",
+                    _sj(_pcb(_art, pads=_gpads)) == 0))
+    #     Control: the SAME coordinates as real track copper still are one, so
+    #     the graphic flag is the only difference between these two rows.
+    results.append(("the same pair as TRACK copper still is a soft joint",
+                    _sj(_pcb(_real, pads=_gpads)) == 1))
+
+    #     (d) A size-less via claims the 0.6 default, as every other consumer
+    #         already does; `or 0` gave it radius ZERO, so it anchored nothing
+    #         at all. Not reachable through check_weird() -- a size=None via
+    #         raises in check_net_connectivity long before at_anchor sees it --
+    #         so this is a DIRECT row on the predicate, and the change is a
+    #         consistency fix rather than a behaviour one. The control pins
+    #         that a genuinely tiny barrel still does not reach.
+    from connectivity import endpoint_reaches_via
+    _sizeless = _via(0, 0)
+    _sizeless.size = None
+    results.append(("a size-less via claims the 0.6 default's radius, not 0",
+                    endpoint_reaches_via(0.29, 0, 0.0, _sizeless,
+                                         ('F.Cu',)) is True))
+    results.append(("a genuinely 0.02mm barrel still does not reach 0.29mm "
+                    "away (control)",
+                    endpoint_reaches_via(0.29, 0, 0.0,
+                                         _via(0, 0, size=0.02),
+                                         ('F.Cu',)) is False))
+
+    # 16. STRUCTURAL: only the shared predicate may ask pad-contact geometry.
+    #     This is the row that makes #722 a CLASS fix rather than a coordinate
+    #     fix -- nothing that merely runs the checker can see a fifth spelling
+    #     appear, which is exactly how #695 and #722 shipped four lines apart.
+    _ALLOWED = {
+        # _check_terminal_web is a deliberate exception, and it is NOT asking
+        # this question: it selects the pad an EROSION model runs against, and
+        # that model is undefined unless the cap strictly overlaps the pad body
+        # (`< r - 1e-6`, with NO COINCIDENCE_TOL floor -- a floor would turn a
+        # sub-0.04mm cap that does not touch into a target). Measured while
+        # fixing #722: routing it through the shared predicate flips 0 of the
+        # terminal ends in kicad_files/, so this is a recorded scope choice.
+        '_check_terminal_web',
+        # _check_unsupported_vias asks the same question about a BARREL and is
+        # the next site to fold in; #695 fixed its margin in place.
+        '_check_unsupported_vias',
+    }
+    results.append(("the pad-geometry guard is not vacuous",
+                    len(_pad_geometry_askers()) >= 1))
+    results.append(("only the shared predicate asks pad-contact geometry "
+                    "(#722)", _pad_geometry_askers() == _ALLOWED))
+
+    # 17. Two under-reports this branch introduced and a review caught. Both
+    #     are the SAME mistake the fix exists to correct, made while making it:
+    #     a credit widened without the guard that keeps it honest.
+    #
+    #     (a) VIA LAYERS. Crediting the endpoint's cap against a via barrel
+    #         (correct) while ignoring which layers that barrel occupies
+    #         (wrong) makes a layer-blind credit ~37% WIDER than the
+    #         `vr + 0.01` it replaced. A blind F.Cu/In1.Cu via then anchors
+    #         B.Cu track ends it carries no copper for, silencing a real open.
+    def _blind_via_board(seg_layer):
+        pads = [_pad(-3, 0, layers=(seg_layer,), num='1'),
+                _pad(3, 0, layers=(seg_layer,), num='2', ref='U2')]
+        segs = [_seg(-3, 0, -0.35, -0.06, layer=seg_layer, width=0.25),
+                _seg(-0.35, 0.06, -3, 0, layer=seg_layer, width=0.25)]
+        v = Via(x=0, y=0, size=0.6, drill=0.3, layers=['F.Cu', 'In1.Cu'],
+                net_id=NET)
+        pcb = _pcb(segs, vias=[v], pads=pads)
+        pcb.board_info.copper_layers = ['F.Cu', 'In1.Cu', 'In2.Cu', 'B.Cu']
+        return pcb, segs, [v], pads
+
+    pcb_b, segs_b, vias_b, pads_b = _blind_via_board('B.Cu')
+    conn_b = check_net_connectivity(NET, segs_b, vias_b, pads_b, [])
+    results.append(("a blind F.Cu/In1.Cu via carries no B.Cu copper: "
+                    "check_connected calls this net SPLIT",
+                    conn_b['num_components'] > 1
+                    or bool(conn_b['disconnected_pads'])))
+    results.append(("...and check_weird agrees: still a soft joint",
+                    _sj(pcb_b) == 1))
+    #     Control: the same via and the same geometry on a layer the barrel
+    #     DOES occupy anchors the ends, so the row above is the LAYER test
+    #     firing and not the predicate refusing every via.
+    results.append(("the same ends on a layer the barrel occupies are "
+                    "anchored: clean", _sj(_blind_via_board('F.Cu')[0]) == 0))
+
+    #     (b) A soft joint is a PAIR. Excluding a copper-layer GRAPHIC as a
+    #         CANDIDATE drops the TRACK end paired with it, and nothing else
+    #         picks that end up -- so a genuinely open net went from exit 1 to
+    #         exit 0, which is what check_complete gates DONE on. The art half
+    #         is unactionable (#337); the track half is not.
+    _gp = [_pad(-6, 0, num='1'), _pad(6, 0, num='2', ref='U2')]
+    _track = _seg(-6, 0, -0.05, 0, width=0.25)
+    _artseg = Segment(start_x=0.05, start_y=0, end_x=6, end_y=0, width=0.25,
+                      layer='F.Cu', net_id=NET, graphic=True)
+    _mixed = _pcb([_track, _artseg], pads=_gp)
+    _cm = check_net_connectivity(NET, [_track, _artseg], [], _gp, [])
+    results.append(("a track ending short of ART is a real open "
+                    "(check_connected)",
+                    _cm['num_components'] > 1 or bool(_cm['disconnected_pads'])))
+    results.append(("...and the track-vs-art pair is still reported",
+                    _sj(_mixed) == 1))
+    _rep = [x for x in check_weird(_mixed, tolerance=0)[0]
+            if x['category'] == 'soft-joint']
+    results.append(("...reported at the TRACK end, where the fix goes",
+                    len(_rep) == 1 and abs(_rep[0]['x'] - (-0.05)) < 1e-6))
+    #     Control: art meeting art has no actionable end, and is dropped.
+    _art2 = Segment(start_x=-6, start_y=0, end_x=-0.05, end_y=0, width=0.25,
+                    layer='F.Cu', net_id=NET, graphic=True)
+    results.append(("art meeting art is NOT reported (nothing to act on)",
+                    _sj(_pcb([_art2, _artseg], pads=_gp)) == 0))
+
+    # 18. The pad LAYER SET comes from net_queries.expand_pad_layers -- the
+    #     same expansion check_connected uses -- not from a local reading of
+    #     pad.layers. Two ways a local reading goes wrong, both caught by
+    #     review rather than by any board in kicad_files/.
+    from connectivity import endpoint_reaches_pad
+    from check_connected import check_net_connectivity as _cnc
+
+    #     (a) `*.Mask` is not copper. A pad carrying it is an ordinary
+    #         single-layer SMD pad, and 641 pads in kicad_files/ carry one --
+    #         but `any('*' in L)` reads the wildcard as "every copper layer"
+    #         and hands a B.Cu end an F.Cu-only pad.
+    _mask = _rect_pad(0, 0, 1.0, 0.6, layers=('F.Cu', '*.Mask', '*.Paste'),
+                      num='1')
+    results.append(("a mask wildcard is not copper: the pad reaches F.Cu",
+                    endpoint_reaches_pad(0, 0, 0.125, ('F.Cu',), _mask)
+                    == {'F.Cu'}))
+    results.append(("...and reaches NO other layer (a mask wildcard is not "
+                    "an all-copper pad)",
+                    endpoint_reaches_pad(0, 0, 0.125, ('B.Cu',), _mask)
+                    == set()
+                    and endpoint_reaches_pad(0, 0, 0.125, ('In1.Cu',), _mask)
+                    == set()))
+    #         Control: the copper wildcard DOES span every layer asked about,
+    #         so the row above is the *.Cu/*.Mask distinction firing and not
+    #         the predicate refusing wildcards outright.
+    _cuwild = _rect_pad(0, 0, 1.0, 0.6, layers=('*.Cu', '*.Mask'), num='1')
+    results.append(("a *.Cu wildcard spans every layer asked about (control)",
+                    endpoint_reaches_pad(0, 0, 0.125,
+                                         ('F.Cu', 'In1.Cu', 'B.Cu'), _cuwild)
+                    == {'F.Cu', 'In1.Cu', 'B.Cu'}))
+
+    #     (b) A DRILLED pad occupies the layers it declares, not every layer.
+    #         `drill > 0 -> all layers` over-credits a PTH pad declared
+    #         ("F.Cu" "B.Cu") on a 4-layer board; check_connected grades an
+    #         In1.Cu end as not reaching it, and the agreement row pins that
+    #         absolutely rather than merely asserting the two differ.
+    _pth = _rect_pad(0, 0, 1.0, 0.6, layers=('F.Cu', 'B.Cu', '*.Mask'),
+                     num='1')
+    _pth.drill, _pth.pad_type = 0.4, 'thru_hole'
+    results.append(("a drilled pad declared F.Cu/B.Cu reaches B.Cu",
+                    endpoint_reaches_pad(0, 0, 0.125, ('B.Cu',), _pth)
+                    == {'B.Cu'}))
+    results.append(("...and does NOT reach In1.Cu, which it never declared",
+                    endpoint_reaches_pad(0, 0, 0.125, ('In1.Cu',), _pth)
+                    == set()))
+    _far = _rect_pad(-3, 0, 1.0, 0.6, layers=('In1.Cu',), num='2', ref='U2')
+    _in1 = [_seg(-3, 0, 0, 0, layer='In1.Cu', width=0.25)]
+    _c = _cnc(NET, _in1, [], [_pth, _far], [])
+    results.append(("check_connected agrees the In1.Cu end does not reach it: "
+                    "the net is SPLIT",
+                    _c['num_components'] > 1 or bool(_c['disconnected_pads'])))
 
     # 11. The reporter, which is what #696 actually broke: a finding whose
     #     category is missing from CATEGORIES counted toward the headline and

--- a/tests/test_check_weird.py
+++ b/tests/test_check_weird.py
@@ -689,6 +689,58 @@ def main():
                     "the net is SPLIT",
                     _c['num_components'] > 1 or bool(_c['disconnected_pads'])))
 
+    # 19. _point_anchored's pad test is a bounding CIRCLE of radius
+    #     max(size_x, size_y)/2, and in _check_dangles it ran BEFORE the exact
+    #     one -- so it could only ADD credit and the exact test never got to
+    #     refuse. A 0.3mm track ending 0.575mm from a 1.8x0.45 pad's copper is
+    #     0.9mm from its centre, inside the bounding circle and nowhere near
+    #     the copper. Pads are answered by endpoint_reaches_pad alone now.
+    _long = _rect_pad(0, 0, 1.8, 0.45, num='1')
+    _lp2 = [_long, _rect_pad(-6, 0, 1.8, 0.45, num='2', ref='U2')]
+    _lseg = [_seg(-6, 0, -0.9, 0.42, width=0.3)]
+    results.append(("the long-pad row is ON its branch: inside the bounding "
+                    "circle, outside the copper",
+                    point_to_pad_distance(-0.9, 0.42, _long) > 0.15
+                    and math.hypot(-0.9, 0.42) < 1.8 / 2 + 0.15))
+    _lc = check_net_connectivity(NET, _lseg, [], _lp2, [])
+    results.append(("check_connected calls that end unconnected to the pad",
+                    _lc['num_components'] > 1 or bool(_lc['disconnected_pads'])))
+    results.append(("...and check_weird no longer credits it by the bounding "
+                    "circle: a dangling end",
+                    len([x for x in check_weird(_pcb(_lseg, pads=_lp2),
+                                                tolerance=0)[0]
+                         if x['category'] == 'dangling-end']) >= 1))
+    #     Control: an end genuinely ON that pad's copper is still anchored, so
+    #     the row above is the exact test firing and not a blanket refusal.
+    results.append(("an end on the long pad's real copper is still anchored",
+                    not [x for x in check_weird(
+                        _pcb([_seg(-6, 0, -0.5, 0, width=0.3)], pads=_lp2),
+                        tolerance=0)[0]
+                        if x['category'] == 'dangling-end']))
+
+    # 20. narrow-pad-joint on a ROUND pad (#416 follow-through). The shape gate
+    #     skipped circles -- "a circle has no corner to graze". It has no
+    #     corner, but it has a RIM, and the same connection_width hazard lives
+    #     there: a cap landing just outside the rim joins through a lens whose
+    #     chord is far below the floor. _pad_web_polygon has handled circles all
+    #     along; only the pre-filter and the gate did not.
+    def _rim(d, shape='circle', w=0.2, R=0.5, floor=0.1):
+        pad = _pad(0, 0, size=2 * R, num='1')
+        pad.shape = shape
+        far = _pad(6, 0, size=2 * R, num='2', ref='U2')
+        far.shape = shape
+        segs = [_seg(6, 0, d, 0, width=w),
+                _seg(-9, -9, -8, -9, width=floor)]   # sets the min-track floor
+        return _pcb(segs, pads=[pad, far])
+
+    results.append(("a cap grazing a ROUND pad's rim is a narrow-pad-joint",
+                    len([x for x in check_weird(_rim(0.59), tolerance=0)[0]
+                         if x['category'] == 'narrow-pad-joint']) == 1))
+    #     Control: the same cap biting deeper joins through full copper.
+    results.append(("the same cap deeper into the round pad is NOT flagged",
+                    not [x for x in check_weird(_rim(0.52), tolerance=0)[0]
+                         if x['category'] == 'narrow-pad-joint']))
+
     # 11. The reporter, which is what #696 actually broke: a finding whose
     #     category is missing from CATEGORIES counted toward the headline and
     #     the exit code but printed nothing, so the board was blocked by a

--- a/tests/test_soft_joint.py
+++ b/tests/test_soft_joint.py
@@ -229,6 +229,77 @@ def run():
     check("close_soft_joints still bridges it (the layer guard holds)",
           close_soft_joints([], _pcb, None, _cfg()) == 1)
 
+
+    # --- graphic DEGREE parity between detection and repair ------------------
+    # close_soft_joints skipped graphics when counting endpoint DEGREE while
+    # check_drc counted them, so a track end sharing a vertex with copper art
+    # was degree 1 here and degree 2 there: check_drc reported nothing and this
+    # pass wrote a bridge anyway. The contract is "check_drc's exact soft-joint
+    # definition, so detection and repair agree" -- which needs the same degree.
+    _gsegs = [Segment(start_x=0.0, start_y=0.0, end_x=1.0, end_y=0.0,
+                      width=0.1, layer='F.Cu', net_id=1),
+              Segment(start_x=1.0, start_y=0.0, end_x=1.5, end_y=0.5,
+                      width=0.1, layer='F.Cu', net_id=1, graphic=True),
+              Segment(start_x=1.05, start_y=0.05, end_x=2.0, end_y=0.05,
+                      width=0.1, layer='F.Cu', net_id=1)]
+    _gpcb = PCBData(footprints={}, nets={1: Net(1, '/A')}, segments=_gsegs,
+                    vias=[], board_info=BoardInfo(
+                        layers={}, copper_layers=['F.Cu', 'B.Cu']),
+                    pads_by_net={})
+    check("a track end sharing a vertex with copper ART is not a free end",
+          close_soft_joints([], _gpcb, None, _cfg()) == 0,
+          "bridges written")
+    # Control: the identical geometry with the art absent IS a soft joint, so
+    # the row above is the degree count and not a blanket refusal.
+    _ngpcb = PCBData(footprints={}, nets={1: Net(1, '/A')},
+                     segments=[_gsegs[0], _gsegs[2]], vias=[],
+                     board_info=BoardInfo(layers={},
+                                          copper_layers=['F.Cu', 'B.Cu']),
+                     pads_by_net={})
+    check("without the art the same pair IS bridged (control)",
+          close_soft_joints([], _ngpcb, None, _cfg()) == 1)
+
+    # --- the bridge must clear a same-net UNPLATED hole -----------------------
+    # _seg_foreign_hole_dist skips own-net holes -- right for a PLATED barrel
+    # (that copper IS the net), wrong for an unplated one, which has no copper
+    # whatever net it is tagged with (#328). A net-tied M3 mounting hole is the
+    # hole a same-net bridge is most likely to cross, and nothing was looking.
+    _npth = Pad(component_ref='H1', pad_number='1', global_x=1.025,
+                global_y=0.025, local_x=0, local_y=0, size_x=3.2, size_y=3.2,
+                shape='circle', layers=['*.Cu'], net_id=1, net_name='/A',
+                rotation=0.0, drill=3.2)
+    _npth.pad_type = 'np_thru_hole'
+    _hsegs = [Segment(start_x=-4.0, start_y=0.0, end_x=1.0, end_y=0.0,
+                      width=0.1, layer='F.Cu', net_id=1),
+              Segment(start_x=1.05, start_y=0.05, end_x=6.0, end_y=0.05,
+                      width=0.1, layer='F.Cu', net_id=1)]
+    _hpcb = PCBData(footprints={}, nets={1: Net(1, '/A')}, segments=_hsegs,
+                    vias=[], board_info=BoardInfo(
+                        layers={}, copper_layers=['F.Cu', 'B.Cu']),
+                    pads_by_net={1: [_npth]})
+    check("a bridge is refused across a same-net UNPLATED drill",
+          close_soft_joints([], _hpcb, None, _cfg()) == 0, "bridges written")
+    # Control: the SAME unplated hole moved away from the joint does not
+    # block it -- so the row above is a distance test, not a blanket refusal
+    # whenever an NPTH pad exists on the net.
+    _far_npth = Pad(component_ref='H1', pad_number='1', global_x=1.025,
+                    global_y=9.0, local_x=0, local_y=0, size_x=3.2,
+                    size_y=3.2, shape='circle', layers=['*.Cu'], net_id=1,
+                    net_name='/A', rotation=0.0, drill=3.2)
+    _far_npth.pad_type = 'np_thru_hole'
+    _fpcb = PCBData(footprints={}, nets={1: Net(1, '/A')},
+                    segments=[Segment(start_x=-4.0, start_y=0.0, end_x=1.0,
+                                      end_y=0.0, width=0.1, layer='F.Cu',
+                                      net_id=1),
+                              Segment(start_x=1.05, start_y=0.05, end_x=6.0,
+                                      end_y=0.05, width=0.1, layer='F.Cu',
+                                      net_id=1)],
+                    vias=[], board_info=BoardInfo(
+                        layers={}, copper_layers=['F.Cu', 'B.Cu']),
+                    pads_by_net={1: [_far_npth]})
+    check("the same hole far from the joint does NOT block it (control)",
+          close_soft_joints([], _fpcb, None, _cfg()) == 1, "bridges written")
+
     print()
     if fails:
         print(f"FAIL: {len(fails)} check(s): {fails}")

--- a/tests/test_soft_joint.py
+++ b/tests/test_soft_joint.py
@@ -58,6 +58,19 @@ def _seg(x1, y1, x2, y2, w=0.1, net=1):
     return generate_segment_sexpr((x1, y1), (x2, y2), w, 'F.Cu', net)
 
 
+def _pad_fp(cx, cy, w=1.0, h=0.6, layer='F.Cu', ref='U1', net=1):
+    """A one-pad SMD footprint, so a board can carry a real landing pad."""
+    return (f'(footprint "lp:P" (layer "F.Cu") (at {cx} {cy}) (attr smd)'
+            f' (pad "1" smd rect (at 0 0) (size {w} {h}) (layers "{layer}")'
+            f' (net {net} "/A")))')
+
+
+def _run_pcb(body):
+    """(counted segment-endpoint-gap violations, sub-coincidence warnings) for a
+    board carrying footprints as well as copper."""
+    return _run(body)
+
+
 def run():
     fails = []
 
@@ -123,6 +136,98 @@ def run():
     # idempotent: re-running adds nothing (the joint is now coincident, count 2).
     n2 = close_soft_joints([], pcb, None, _cfg())
     check("close_soft_joints is idempotent", n2 == 0, f"added {n2}")
+
+
+    # --- #722: an end whose CAP lands on pad copper is ANCHORED -------------
+    # check_weird's soft-joint anchor was fixed for this (#695/#722) but
+    # check_drc's copy and the close_soft_joints repair pass kept crediting a
+    # pad by its CENTRE, so the three deliberately-coupled copies disagreed:
+    # check_weird called the board clean while check_drc counted a violation
+    # on it and the repair pass wrote a bridge across copper both ends already
+    # touched. close_soft_joints' own docstring says it uses check_drc's exact
+    # definition "so detection and repair agree" -- that is the invariant.
+    #
+    # Two 0.25mm stubs stopping 0.05mm outside a 1.0x0.6 pad: both caps
+    # (r=0.125) physically overlap its copper, and check_connected -- the
+    # authority -- grades the net JOINED.
+    from check_connected import check_net_connectivity
+    from kicad_parser import Pad
+
+    def _land(ex):
+        return (_seg(-3, -0.06, ex, -0.06, w=0.25)
+                + _seg(-3, 0.06, ex, 0.06, w=0.25)
+                + _pad_fp(0, 0) + _pad_fp(-3, 0, ref='U2'))
+
+    # BRANCH GUARD: the fixture must sit on the CAP branch, not the centre one
+    # it retires -- outside the pad copper by more than COINCIDENCE_TOL, and
+    # inside the end's own cap radius. Otherwise it passes for the wrong reason.
+    from check_drc import point_to_pad_distance
+    from connectivity import COINCIDENCE_TOL
+    _lp = Pad(component_ref='U1', pad_number='1', global_x=0.0, global_y=0.0,
+              local_x=0, local_y=0, size_x=1.0, size_y=0.6, shape='rect',
+              layers=['F.Cu'], net_id=1, net_name='/A', rotation=0.0, drill=0.0)
+    _g_land = point_to_pad_distance(-0.55, -0.06, _lp)
+    _g_clear = point_to_pad_distance(-0.70, -0.06, _lp)
+    check("#722 fixture is ON the cap branch (outside COINCIDENCE_TOL, inside "
+          "the cap)", COINCIDENCE_TOL < _g_land < 0.125, f"gap {_g_land:.4f}")
+    check("#722 control is OFF the cap branch (beyond the cap)",
+          _g_clear > 0.125, f"gap {_g_clear:.4f}")
+
+    n, _w = _run(_land(-0.55))
+    check("check_drc: stubs landing on pad copper -> NOT a soft joint (#722)",
+          n == 0, f"got {n}")
+    # NEGATIVE CONTROL: push the ends out until the caps CLEAR the copper.
+    # Still a real fragile near-open -- without this row the one above also
+    # passes on a checker that anchors on anything.
+    n, _w = _run(_land(-0.70))
+    check("check_drc: stubs whose caps CLEAR the pad -> still a soft joint",
+          n == 1, f"got {n}")
+
+    # ABSOLUTE agreement with the authority, both arms. Assert what EACH model
+    # must say absolutely, never merely that the two differ: a `differ` form
+    # passes when both are wrong, which is what a correlated revert of the two
+    # mirrored margins produces.
+    def _pcb_land(ex, pad_layer='F.Cu', seg_layer='F.Cu'):
+        pads = [Pad(component_ref='U1', pad_number='1', global_x=0.0,
+                    global_y=0.0, local_x=0, local_y=0, size_x=1.0, size_y=0.6,
+                    shape='rect', layers=[pad_layer], net_id=1, net_name='/A',
+                    rotation=0.0, drill=0.0),
+                Pad(component_ref='U2', pad_number='1', global_x=-3.0,
+                    global_y=0.0, local_x=0, local_y=0, size_x=1.0, size_y=0.6,
+                    shape='rect', layers=[seg_layer], net_id=1, net_name='/A',
+                    rotation=0.0, drill=0.0)]
+        segs = [Segment(start_x=-3, start_y=-0.06, end_x=ex, end_y=-0.06,
+                        width=0.25, layer=seg_layer, net_id=1),
+                Segment(start_x=-3, start_y=0.06, end_x=ex, end_y=0.06,
+                        width=0.25, layer=seg_layer, net_id=1)]
+        pcb = PCBData(footprints={}, nets={1: Net(1, '/A')}, segments=segs,
+                      vias=[], board_info=BoardInfo(
+                          layers={}, copper_layers=['F.Cu', 'B.Cu']),
+                      pads_by_net={1: pads})
+        return pcb, segs, pads
+
+    for _label, _ex, _want_joined in (('caps overlap the pad', -0.55, True),
+                                      ('caps clear the pad', -0.70, False)):
+        _pcb, _segs, _pads = _pcb_land(_ex)
+        _c = check_net_connectivity(1, _segs, [], _pads, [])
+        _joined = _c['num_components'] == 1 and not _c['disconnected_pads']
+        check(f"check_connected joins the landing pad ({_label}): expected "
+              f"{_want_joined}", _joined is _want_joined)
+        _n = close_soft_joints([], _pcb, None, _cfg())
+        check(f"close_soft_joints writes {0 if _want_joined else 1} bridge "
+              f"({_label})", _n == (0 if _want_joined else 1), f"added {_n}")
+
+    # LAYER guard: crediting a pad by CAP RADIUS without checking the pad
+    # actually carries copper on the end's layer buys a new UNDER-report --
+    # the direction that ships broken copper. B.Cu ends 0.05mm from an
+    # F.Cu-ONLY pad are genuinely split (check_connected iterates the pad's own
+    # copper layers) and must stay flagged.
+    _pcb, _segs, _pads = _pcb_land(-0.55, pad_layer='F.Cu', seg_layer='B.Cu')
+    _c = check_net_connectivity(1, _segs, [], _pads, [])
+    check("an other-layer pad anchors nothing: check_connected calls it SPLIT",
+          _c['num_components'] == 2 and len(_c['disconnected_pads']) == 1)
+    check("close_soft_joints still bridges it (the layer guard holds)",
+          close_soft_joints([], _pcb, None, _cfg()) == 1)
 
     print()
     if fails:


### PR DESCRIPTION
Closes #722.

`27e49114` landed #722's cap credit in `check_weird`. The same anchor exists in
**three more places**, and `close_soft_joints`' own docstring states the
invariant the one-site fix broke — it uses "check_drc's exact soft-joint
definition/tolerance **so detection and repair agree**."

After that commit, they did not agree.

## The two checkers now contradicted each other

The issue's own reproduction: two 0.25 mm stubs ending 0.05 mm outside a
1.0 × 0.6 mm pad. Both caps (r = 0.125) physically overlap its copper, and
`check_connected` — the authority — grades the net **joined, 0 disconnected
pads**.

| | on `27e49114` | after this PR |
|---|---|---|
| `check_connected` (authority) | joined | joined |
| `check_weird` | clean | clean |
| `check_drc` | **1 `SEGMENT-ENDPOINT-GAP`** | clean |
| `close_soft_joints` | **writes 1 bridge** | writes 0 |

So DONE was still blocked — through `board_score` rather than through
`check_complete`, because `segment-endpoint-gap` is a **counted** violation
above the sub-coincidence band (`check_drc.py:3267`). And the repair pass was
laying a segment across copper both ends already touched.

The negative control moves in lockstep: push the ends to a 0.20 mm gap so the
caps clear the copper, and `check_connected` says split while all three report
it. The four now cross over at the same point.

## Three things the cap credit alone did not fix

Each is a way the anchor still disagreed with `check_connected`, and each has
its own test row and its own control.

- **LAYER.** The anchor credited *any* same-net pad whatever layer it sat on —
  and widening the reach from 0.02 mm to `width/2` **widened that hole** rather
  than closing it. `check_connected` iterates the pad's own copper layers, so
  B.Cu ends 0.05 mm from an **F.Cu-only** pad are genuinely split there.
  Measured: a layer-blind widening silences that finding — a false *negative*,
  the direction that ships broken copper.
- **NPTH.** An unplated hole has no copper even when its layer list says `*.Cu`.
- **The VIA branch**, cap-blind in exactly the way the pad branch was:
  `vr + 0.01` credits the barrel but not the end's own cap, where
  `check_connected` credits `(via_size + track_width)/2` — 0.310 mm against
  0.425 mm on a 0.6 mm via and a 0.25 mm track.

Also: copper-layer **graphics** stop being soft-joint candidates here and in
`check_drc`, as `_check_dangles` and `check_connected` already refuse them
("graphics never conduct", #337). Their endpoints still count toward the degree,
so a track ending on a graphic keeps degree 2 and is not a dangle. A finding on
immutable input art is unactionable, and `soft-joint` carries `size=None` so
`--tolerance` can never drop it.

## One predicate, and a guard that keeps it that way

`connectivity.endpoint_reaches_pad` / `endpoint_reaches_via` are now the single
answer, called by all four sites. `connectivity.py` is the right home: it
already owns `COINCIDENCE_TOL` and the note assigning the roles —
`COINCIDENCE_TOL` grades geometric **intent**, and asking a
copper-reaches-copper question with it is the category error both #695 and #722
are instances of. It is already a module-level import for all three consumers
and already uses function-local imports to break exactly these cycles.

`COINCIDENCE_TOL` is a **floor** under the credit, never a replacement for it,
so the credit can only ever widen relative to the centre test.

The structural row is the point of the PR: `_pad_geometry_askers()` parses
`check_weird`'s own AST and asserts that only the shared predicate asks
pad-contact geometry — the same way `_emitted_categories()` catches an
unregistered category. **Nothing that merely runs the checker can see a fifth
spelling appear**, which is exactly how #695 and #722 shipped four lines apart.

## Scope, stated rather than assumed

Left alone deliberately, and recorded in the guard's allow-list with the
measurement rather than silently:

- `_check_terminal_web` selects the pad an **erosion** model runs against and
  needs its strict `< r - 1e-6` with no floor. Measured: routing it through the
  shared predicate flips **0 of 33,340** candidate pairs in `kicad_files/`.
- The via→pad **graze bridge** and the terminal-web via-terminal skip keep their
  own tuple geometry — they ask a different question (a graze band, a
  "is this a via terminal" test).
- `_check_unsupported_vias` is #695's site; its margin was fixed in place.

No GUI work: `grep -rni weird kicad_routing_plugin/` is empty. `route.py` and
`check_join.py` import only `stacked_copper_over_model`. Python-only, no flag,
no parameter, no dialog control, no version bump.

## What an adversarial review of this branch caught

Two of the fixes here exist because a review found this branch making **the
same mistake it was written to correct** — a credit widened without the guard
that keeps it honest. Both were under-reports that flipped a chain-blocking
exit code from 1 to 0 on nets `check_connected` grades **open**:

- **A layer-blind via credit.** Crediting the endpoint's cap against a barrel
  (right) while ignoring which layers that barrel occupies (wrong) made the
  credit ~37% *wider* than the `vr + 0.01` it replaced. A blind F.Cu/In1.Cu via
  then anchored B.Cu track ends it carries no copper for.
- **The graphic filter dropped the actionable half.** A soft joint is a pair;
  excluding a copper graphic as a *candidate* dropped the **track** end paired
  with it, and nothing else picked it up.

Two more were latent: `any('*' in L)` reading `*.Mask` as an all-copper pad,
and `drill > 0` granting a pad every layer instead of the ones it declares.
Both now come from `expand_pad_layers`, the authority's own expansion.

The review also surfaced four defects that were **not** mine, and those are
fixed here too rather than filed:

| | |
|---|---|
| `_point_anchored`'s bounding-**circle** pad credit ran ahead of the exact test, so the exact one could never refuse | pads are answered by `endpoint_reaches_pad` alone now |
| `close_soft_joints` counted endpoint **degree** differently from the detector it repairs (it skipped graphics; `check_drc` counts them) | same degree on both sides — that is what "detection and repair agree" requires |
| the bridge's clearance gate could not see a **same-net unplated hole** (`_seg_foreign_hole_dist` skips own-net holes, right for a plated barrel, wrong for a drill) | measured: a 0.1 mm bridge 0.15 mm from a 1.6 mm drill, now refused |
| `narrow-pad-joint` was blind to **round pads** ("a circle has no corner to graze" — it has no corner, but it has a rim) | a closed-form two-circle lens test, confirmed by the same exact erosion; **this found the two real hazards above** |

One review claim did **not** survive checking: it inferred the bounding-circle
credit was masking two dangling-ends on `lvds_converter_dualclk_gnd`. That
board's only copper net carries a **zone**, and both endpoints land inside the
pour outline — a legitimate anchor. The fix is still right; the harm alleged
for it was not real, and the corpus is unchanged by that fix.

## Verification

- `tests/test_check_weird.py` **80/80** (was 44); `tests/test_soft_joint.py`
  **25/25** (was 11).
- `tests/run_all.py`: full suite green.
- **`check_drc`: 33/33 boards identical.**
- **`check_weird`: 31/33 identical; 2 boards gain findings, and they are real.**
  `interf_u_connected` and `interf_u_routed` each gain `narrow-pad-joint: 2` —
  0.2 mm tracks ending 0.0038 mm and 0.0026 mm outside a 1.4 mm and a 1.6 mm
  **round** pad, i.e. clipping the rim. Both are confirmed by KiCad's own
  erosion (`terminal_web_neck_exact` → True), and neither board's exit code
  changes (both already exit 1). That is the circle blind spot below being
  closed, not a regression.
- **A real route is unperturbed.** `close_soft_joints` runs as step 10 of
  `cleanup_pipeline`, so this touches a routing hot path. Routing
  `kicad_files/splitflap_driver.kicad_pcb` end to end on both sides gives
  identical graded outcomes: DRC clean, all nets connected, and the same
  per-category `check_weird` counts (`removable-segment: 155`,
  `redundant-cycle: 1`, every other category 0). Graded rather than diffed,
  since outputs carry per-run UUIDs.

**That corpus result is a no-regression result, not a reproduction, and it
cannot be anything else.** `soft-joint` and `segment-endpoint-gap` are **0 on
every corpus board**; 18 of the 33 carry any track copper or vias (17 carry track
segments), and none carries this geometry. (Worth knowing when reading any corpus claim about this checker: 11 of
those 33 boards are untracked local artifacts, so a fresh clone grades 22.) The
reproduction is the contradiction above.

Every row is mutation-tested; each mutation kills only rows that name it:

| mutation | rows killed |
|---|---|
| revert the pad cap credit to `COINCIDENCE_TOL` | 6 |
| over-credit the pad 10× | 5 (the controls) |
| drop the pad LAYER intersection | 4 |
| drop the NPTH guard | 1 |
| revert the via to `vr + 0.01` | 2 |
| revert the via 0.6 default to 0 | 1 |
| drop the via LAYER test | 1 |
| drop the art-vs-art pair rule | 2 |
| **correlated: revert BOTH mirrored margins** | **8** |
| **structural: a fifth spelling reappears** | **1** |
| pad wildcard: `any('*' in L)` instead of `*.Cu` | 2 |
| plated pad spans EVERY layer | 1 |
| repair skips graphics in the degree count | 1 |
| drop the own-net NPTH hole gate | 1 |
| circles back out of the terminal-web gate | 1 |
| restore the bounding-circle pad credit | 1 |

The correlated revert is the one that matters for the assertion form: it kills
`check_connected joins the landing pad: expected True`, which a
`joined != soft` row would have survived — both models are wrong together. The
structural mutation is caught by nothing that runs the checker.

The via-0.6-default rows are direct calls on the predicate, not board rows: a
size-less via raises inside `check_net_connectivity` long before `at_anchor`
sees it, so that change is a consistency fix rather than a reachable behaviour
one. Written that way only after the mutation was measured killing nothing.
