### PR TITLE
#736: the post-nudge re-grade sees the copper the pass drew

### DIFF
--- a/kicad_routing_plugin/fanout_gui.py
+++ b/kicad_routing_plugin/fanout_gui.py
@@ -1605,6 +1605,10 @@ class FanoutTab(wx.Panel):
                 # Advanced cap-placement knobs (#130) so the inline checkbox
                 # path honours them too, not just defaults.
                 **{k: v for k, v in config.items() if k.startswith('cap_')},
+                # #733: the cap repair's edge margin. AFTER the cap_* spread, so
+                # the shared Basic-tab override wins over any same-named panel
+                # key. None = the engine resolves it (CLI parity).
+                'cap_board_edge_clearance': shared.get('cap_board_edge_clearance'),
                 # Shared "Add teardrops" checkbox (#489 section 9).
                 'add_teardrops': shared.get('add_teardrops', False),
                 # #693: shared "Fix DRC settings after routing" checkbox --
@@ -1929,6 +1933,11 @@ class FanoutTab(wx.Panel):
                 pcb_file=self.board_filename,
                 clearance=fanout_config.get('clearance', defaults.BGA_CLEARANCE),
                 grid_step=fanout_config.get('grid_step', defaults.GRID_STEP),
+                # #733: the plugin used to pass NOTHING here, so it silently took
+                # the signature default whatever the board or the operator said,
+                # while the cap mover insets by max(clearance, this). None = the
+                # engine resolves it, which is what an omitted CLI flag does too.
+                board_edge_clearance=fanout_config.get('cap_board_edge_clearance'),
                 default_via_size=fanout_config.get('via_size', defaults.BGA_VIA_SIZE),
                 # Advanced cap-placement knobs from the BGA fanout tab (#130)
                 capture_radius=fanout_config.get('cap_capture_radius', 2.0),
@@ -2057,6 +2066,8 @@ class FanoutTab(wx.Panel):
             'clearance': shared.get('clearance', defaults.BGA_CLEARANCE),
             'grid_step': shared.get('grid_step', defaults.GRID_STEP),
             'via_size': shared.get('via_size', defaults.BGA_VIA_SIZE),
+            # #733, as in the inline path above.
+            'cap_board_edge_clearance': shared.get('cap_board_edge_clearance'),
         })
         from .gui_utils import redirect_prints_to_log, refill_all_zones
         with redirect_prints_to_log(self.append_log):

--- a/kicad_routing_plugin/swig_gui.py
+++ b/kicad_routing_plugin/swig_gui.py
@@ -737,6 +737,34 @@ class RoutingDialog(wx.Dialog):
         val = rule if (rule and rule > 1e-9) else defaults.PLANE_EDGE_CLEARANCE
         return self._fab_floored('board_edge_clearance', val)
 
+    def _effective_placement_edge_clearance(self):
+        """Cap-PLACEMENT edge margin for the #130 repair (#733), or None.
+
+        None means "the shared engine resolves it" -- exact parity with the CLI,
+        where an omitted --board-edge-clearance reaches
+        placement.fanout_clearance.resolve_cap_edge_clearance and a given one is
+        honoured as typed. Only the operator's OVERRIDE has to travel; that way
+        neither front carries its own copy of the default and they cannot drift,
+        which is the whole of #733.
+
+        NOT _effective_board_edge_clearance: that is the SIGNAL edge clearance,
+        which answers 0.0 on a board with no rule and is then fab-floored to 0.20
+        -- 0.35mm looser than this pass's own margin. _effective_plane_edge_clearance
+        above carries the same warning for the plane tab, for the same reason.
+        """
+        if self.edge_clearance_check.GetValue():
+            val = self.board_edge_clearance.GetValue()
+            # A ZERO in a ticked override is UNSET, not a margin of zero. The
+            # control is CREATED at defaults.BOARD_EDGE_CLEARANCE (0.0) with a
+            # range minimum of 0.0, so "ticked the box, typed nothing" is a
+            # reachable state -- and passing that on would inset caps at the bare
+            # clearance, LOOSER than the 0.55 this tab used before #733. Same
+            # `> 1e-9` rule as _effective_plane_edge_clearance above; the signal
+            # twin on this same control gets the equivalent guard from
+            # _fab_floored, which is why only this reading needed one.
+            return val if val > 1e-9 else None
+        return None
+
     def _effective_geometry_floor(self, name):
         """Geometry floor to route/grade with (#439 parity with the CLI):
         the dedicated control when its override checkbox is checked; otherwise
@@ -1754,6 +1782,11 @@ class RoutingDialog(wx.Dialog):
                 # Edge.Cuts keep-out for QFN escape stubs/vias (issue #288);
                 # 0 = fall back to the copper clearance inside generate_qfn_fanout.
                 'board_edge_clearance': self._effective_board_edge_clearance(),
+                # #733: the decoupling-cap repair's OWN edge margin, which is a
+                # placement margin rather than the signal keep-out above. None =
+                # let the shared engine resolve it, exactly as the CLI does when
+                # --board-edge-clearance is omitted.
+                'cap_board_edge_clearance': self._effective_placement_edge_clearance(),
                 # #489 section 9: the ONE shared "Add teardrops" checkbox now
                 # reaches fanout too -- it is the step where a track-to-via
                 # teardrop matters most.

--- a/py_placer/place_fanout_clearance.py
+++ b/py_placer/place_fanout_clearance.py
@@ -62,8 +62,12 @@ Examples:
                         help=f"DRC clearance in mm (default: {defaults.CLEARANCE})")
     parser.add_argument("--grid-step", type=float, default=defaults.GRID_STEP,
                         help=f"Position snap in mm (default: {defaults.GRID_STEP})")
-    parser.add_argument("--board-edge-clearance", type=float, default=0.55,
-                        help="Hard clearance from board edge in mm (default: 0.55)")
+    parser.add_argument("--board-edge-clearance", type=float, default=None,
+                        help="Hard clearance from board edge in mm (default: the "
+                             "board's own min_copper_edge_clearance when it asks "
+                             "for MORE than 0.55, else 0.55). #733: resolved by "
+                             "the shared engine, so the GUI plugin and "
+                             "animate_fanout_clearance.py get the same answer.")
     parser.add_argument("--capture-radius", type=float, default=2.0,
                         help="Max distance over which a same-net ball attracts "
                              "a cap pad in mm (default: 2.0)")

--- a/py_placer/placement/README.md
+++ b/py_placer/placement/README.md
@@ -286,7 +286,7 @@ python py_placer/place_fanout_clearance.py fanned.kicad_pcb capclean.kicad_pcb -
 | `--cap-prefix` | `C,R` | Comma-separated reference prefix(es) for movable passives near a BGA (caps **and** resistors by default). Only 2-copper-pad parts move, so RN-style arrays are auto-excluded; paste-only apertures are ignored when counting pads. |
 | `--capture-radius` | 2 mm | Max distance over which a same-net ball attracts a pad |
 | `--max-displacement` / `--max-displacement-cap` | 2 / 3 mm | Initial and grown move budget per cap |
-| `--default-via-size` | 0.3 mm | Fallback only, for vias with no readable size |
+| `--default-via-size` | 0.3 mm | Fallback only, for vias with no readable size. Honoured by the grader **and** the via-nudge since #732; before that the nudge priced such a via at a hard-coded 0.5 and the two disagreed. |
 | `--lock` | – | Extra reference patterns to pin in place |
 
 On ulx3s U1 (22×22, 0.8 mm) this took the fanned board from 4 PAD-VIA to

--- a/py_placer/placement/README.md
+++ b/py_placer/placement/README.md
@@ -287,6 +287,7 @@ python py_placer/place_fanout_clearance.py fanned.kicad_pcb capclean.kicad_pcb -
 | `--capture-radius` | 2 mm | Max distance over which a same-net ball attracts a pad |
 | `--max-displacement` / `--max-displacement-cap` | 2 / 3 mm | Initial and grown move budget per cap |
 | `--default-via-size` | 0.3 mm | Fallback only, for vias with no readable size. Honoured by the grader **and** the via-nudge since #732; before that the nudge priced such a via at a hard-coded 0.5 and the two disagreed. |
+| `--board-edge-clearance` | the board's own `min_copper_edge_clearance` when it asks for MORE, else 0.55 mm | Copper-to-Edge.Cuts margin for a moved cap **and** for a via the #313 nudge relocates -- one number since #733, where the nudger gated its own emitted copper at the bare `--clearance` and parked it 0.30 mm inside the band the cap mover reserves. Resolved by the shared engine, so the GUI plugin and `animate_fanout_clearance.py` get the same answer; TIGHTEN-only on an omitted flag, because `fix_project_for_output` pins this field up to the 0.20 fab floor on every board the chain writes. A given value is honoured as typed. |
 | `--lock` | – | Extra reference patterns to pin in place |
 
 On ulx3s U1 (22×22, 0.8 mm) this took the fanned board from 4 PAD-VIA to

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -50,6 +50,12 @@ from placement.legality import (BoardOutlineGate, PadClearanceModel, PadFloor,
 
 ROTATIONS = [0.0, 90.0, 180.0, 270.0]
 EPS = 1e-6
+# The keep-out written into an eff cell for a pair sharing NO copper layer
+# (#731). Large and NEGATIVE, so _seg_shortfalls' EXISTING cheap bbox reject
+# (min(x1, x2) > bx1 + halfw) fires on the first comparison: the layer gate
+# costs the innermost loop nothing -- no extra branch, no mask row. Finite
+# rather than -inf so nothing can produce a NaN if a caller sums a row.
+_OFF_LAYER = -1.0e9
 
 # These four moved to placement/legality.py, the shared home with quench.py
 # (which carried byte-identical copies of the first two). Aliased rather than
@@ -144,7 +150,7 @@ class _Cap:
     for decoupling caps).
     """
 
-    def __init__(self, fp, courtyard_local, model=None):
+    def __init__(self, fp, courtyard_local, model=None, board_copper=None):
         self.ref = fp.reference
         self.side = 'B' if (fp.layer or '').startswith('B') else 'F'
         self.seed_x, self.seed_y = fp.x, fp.y
@@ -170,16 +176,26 @@ class _Cap:
         # makes the alignment true by construction.
         self.pad_floors = []
         self.max_floor = 0.0
-        # Per-pad COPPER LAYER sets, index-aligned like pad_floors. Needed
-        # because self.segments records only an 'F'/'B' side and files an
-        # In1.Cu track under 'F' (a pre-existing model quirk), so an F-side cap
-        # pad is compared against inner-layer tracks it can never touch. That
-        # phantom is priced at the flat scalar today; without this set the
-        # NETCLASS term -- which is layer-blind -- would raise it too, and the
-        # pass would move caps to clear copper on a layer their pads do not
-        # occupy. Measured on orangecrab at --clearance 0.1 with a Default
-        # class of 0.3: R17/R18/R5's ENTIRE graze is that phantom, 0.082mm
-        # each flat and 0.70/0.70/0.57mm raised. See _seg_effs.
+        # Per-pad COPPER LAYER sets, index-aligned like self.pads. This is
+        # what scopes a cap pad to the tracks it can actually touch (#731):
+        # check_drc grades a pad-segment pair only on their SHARED copper, and
+        # the netclass term is layer-blind, so without this set the pass both
+        # charged phantom inner-layer pairs and missed the real B.Cu/inner
+        # pairs of a through-hole pad.
+        #
+        # Built from the BOARD STACKUP alone, never from the clearance model
+        # (#731). Which copper a pad occupies is a fact about the board, not
+        # about what it declares -- and PadClearanceModel is inert unless a
+        # netclass, a .kicad_dru rule or a pad override exists. Gated on the
+        # model, as pad_floors legitimately is, this would be inert on exactly
+        # the boards carrying the most phantom: rp2350 declares none of the
+        # three, is 6 copper layers, and 2342 of its 4331 pruned pad x track
+        # pairs are off-layer, carrying 4.6685mm of phantom graze against
+        # 0.0142mm of real. `board_copper` falls back to the model's copy only
+        # so a caller passing a model and nothing else still resolves layers.
+        _cu = list(board_copper if board_copper is not None
+                   else (getattr(model, 'board_copper', None) or ()))
+        from check_drc import pad_copper_layers
         self.pad_layers = []
         for p in fp.pads:
             if not any(str(l).endswith('.Cu') for l in p.layers):
@@ -192,31 +208,30 @@ class _Cap:
             half_x = hx * c + hy * s
             half_y = hx * s + hy * c
             self.pads.append((off_x, off_y, half_x, half_y, p.net_id))
+            # The GEOMETRY filter above stays loose on purpose (see the
+            # comment), but a FLOOR must not: PadClearanceModel.pad_floor
+            # reads local_clearance unconditionally, and an np_thru_hole
+            # pad lists *.Cu while carrying no copper at all. Charging its
+            # override would move a cap to clear copper that does not
+            # exist -- and would contradict the model's own inertness
+            # rule, which refuses to ACTIVATE for an NPTH-only override
+            # (legality._pad_carries_copper, the watchy measurement).
+            # A pad that carries no copper is graded FLAT, whole stop --
+            # not merely stripped of its own override. check_drc does not
+            # grade such a pad at all, so letting the PARTNER's netclass
+            # through pair() would charge a keep-out that does not exist,
+            # which is the same defect as the off-layer phantom #731 is
+            # about. The EMPTY layer set is the marker the eff builders
+            # key on; a real copper pad always resolves at least one layer.
+            carries = _pad_carries_copper(p)
+            # Appended ALWAYS, model or not (#731), and unconditionally
+            # within the loop so the index alignment the loose geometry
+            # filter buys is preserved.
+            self.pad_layers.append(
+                frozenset(pad_copper_layers(p, _cu)) if carries else frozenset())
             if model is not None:
-                # The GEOMETRY filter above stays loose on purpose (see the
-                # comment), but a FLOOR must not: PadClearanceModel.pad_floor
-                # reads local_clearance unconditionally, and an np_thru_hole
-                # pad lists *.Cu while carrying no copper at all. Charging its
-                # override would move a cap to clear copper that does not
-                # exist -- and would contradict the model's own inertness
-                # rule, which refuses to ACTIVATE for an NPTH-only override
-                # (legality._pad_carries_copper, the watchy measurement).
-                # Zero floor, appended unconditionally so the index alignment
-                # the loose filter buys is preserved.
-                # A pad that carries no copper is graded FLAT, whole stop --
-                # not merely stripped of its own override. check_drc does not
-                # grade such a pad at all, so letting the PARTNER's netclass
-                # through pair() would charge a keep-out that does not exist,
-                # which is the same defect as the off-layer phantom below.
-                # The empty layer set is the marker the eff builders key on;
-                # a real copper pad always resolves at least one layer.
-                carries = _pad_carries_copper(p)
                 fl = model.pad_floor(p) if carries else PadFloor(0.0, 0.0, None)
                 self.pad_floors.append(fl)
-                from check_drc import pad_copper_layers
-                self.pad_layers.append(
-                    frozenset(pad_copper_layers(p, model.board_copper))
-                    if carries else frozenset())
                 mf = model.max_floor(fl)
                 if mf > self.max_floor:
                     self.max_floor = mf
@@ -451,34 +466,40 @@ class _Repair:
             self.vias.append(t)
             self._via_radius_by_id[id(t)] = (t, size / 2.0)
 
-        # --- avoidance: foreign-net tracks on the cap's own side ---
+        # --- avoidance: foreign-net tracks the cap's pads can actually TOUCH ---
         # Fanout escapes can land on the bottom (cap) side; attraction could
         # then pull a cap onto an escape track -> a PAD-SEGMENT violation.
-        # Keyed by side so a B.Cu cap only avoids B.Cu tracks.
-        # #725: element 5 is the OVER-REACH, like self.vias[3] above. The
-        # segment's floor is keyed by its REAL layer, not by the F/B `side`
-        # collapse on the next line (which files an In1.Cu track under 'F') --
-        # a .kicad_dru rule is layer-scoped, and check_drc's pad-segment path
-        # resolves it as a single-layer REPLACE on seg.layer. The side collapse
-        # is pre-existing and deliberately left alone here.
+        # #725: element 5 is the OVER-REACH, like self.vias[3] above, and the
+        # segment's floor is keyed by its REAL layer.
+        # #731: so is element 6, which used to be the 'F'/'B' board SIDE. That
+        # collapse filed every non-B layer under 'F', so an In1.Cu track was
+        # compared against an F-side cap pad that can never touch it -- 928
+        # such pairs on orangecrab at --clearance 0.1, 0.2464mm of phantom
+        # graze at the seed, and the ENTIRE bill of R17/R18/R5. check_drc
+        # grades no such pair at all (check_pad_segment_overlap returns early
+        # when seg.layer is not in the pad's expanded copper layers). It was
+        # wrong in the other direction too: a THROUGH-HOLE cap pad's copper
+        # spans every layer, and the side test DROPPED the B.Cu and inner
+        # tracks it really does share copper with.
+        #
+        # The tuple WIDTH is unchanged (TestShapeContract pins it) and the
+        # side is now derived, in one place (_seg_side), only where a cap's
+        # real pad layers are unavailable.
         self.segments: List[Tuple[float, float, float, float, int, float, str]] = []
-        # The 7-tuple carries `side`, not the real layer, so the floor cannot be
-        # re-derived from it later -- keep it on the tuple's identity. The
-        # tuples live for this object's lifetime, so the id is stable; a tuple a
-        # test injects is simply absent and grades flat.
+        # The floor cannot be re-derived from the tuple, so keep it on the
+        # tuple's identity. The tuples live for this object's lifetime, so the
+        # id is stable; a tuple a test injects is simply absent and grades
+        # flat. (There is no companion layer map any more: the layer IS the
+        # tuple's element 6, so there is exactly one answer to "what layer is
+        # this track on". The old map was additionally gated on an ACTIVE
+        # clearance model, which is what made the layer truth vanish on the
+        # boards carrying the most phantom -- see _cap_seg_scope.)
         self._seg_floor_by_id: Dict[int, PadFloor] = {}
-        # ...and its REAL layer, for the same reason: the pruned list is built
-        # on the F/B side collapse, so _seg_effs needs the true layer to tell a
-        # pair that shares copper from one that cannot.
-        self._seg_layer_by_id: Dict[int, str] = {}
         for s in pcb_data.segments:
-            side = 'B' if (s.layer or '').startswith('B') else 'F'
             fl = self._seg_floor_for(s.net_id, s.layer)
             t = (s.start_x, s.start_y, s.end_x, s.end_y, s.net_id,
-                 s.width / 2.0 + self._item_reach(fl), side)
+                 s.width / 2.0 + self._item_reach(fl), s.layer)
             self.segments.append(t)
-            if self._floors is not None:
-                self._seg_layer_by_id[id(t)] = s.layer
             if fl is not None:
                 self._seg_floor_by_id[id(t)] = fl
 
@@ -556,7 +577,7 @@ class _Repair:
             is_cap = (ref.startswith(self._cap_prefixes) and n_copper <= 2
                       and ref not in locked)
             if is_cap:
-                cap = _Cap(fp, lb, self._floors)
+                cap = _Cap(fp, lb, self._floors, self._all_cu)
                 if self._near_any(cap.rect(), bga_bboxes, near_margin):
                     self.caps[ref] = cap
                     continue
@@ -649,7 +670,7 @@ class _Repair:
         self.cap_static: Dict[str, List[Tuple[int, Tuple]]] = {}
         # other movable caps (refs, same side) that could ever touch this one
         self.cap_caps: Dict[str, List[str]] = {}
-        # foreign-net tracks on the cap's side in reach
+        # foreign-net tracks this cap's pads SHARE COPPER WITH, in reach (#731)
         self.cap_segs: Dict[str, List[Tuple]] = {}
         # through-vias in reach (each (vx, vy, net, keepout))
         self.cap_vias: Dict[str, List[Tuple[float, float, int, float]]] = {}
@@ -700,8 +721,25 @@ class _Repair:
             # this cap's excess over the flat scalar bounds the pair.
             seg_reach = (max_displacement_cap + 2 * span + clearance
                          + max(0.0, cap_mf - clearance))
+            # #731: keep a track only if SOME pad of this cap shares its copper
+            # layer. The union is a superset of every per-pad set (see
+            # _seg_shares), so this can never drop a chargeable pair -- the
+            # list stays EXACT, as TestPruneRadiiStayExact requires. The
+            # per-pad half is applied in _seg_effs, and matters only for a cap
+            # whose pads differ (an SMD pad beside a through-hole one).
+            #
+            # When scoping is off, fall back to the OLD side collapse rather
+            # than keeping everything: check_drc still layer-scopes such a
+            # board (its routing_layers falls back to the segment-derived set,
+            # then to ['F.Cu','B.Cu']), so the placer must stay on the
+            # over-block side, not stop filtering altogether.
+            _pl, _union = self._cap_seg_scope(cap)
             for seg in self.segments:
-                if seg[6] != cap.side:
+                layer = seg[6]
+                if _union is None:
+                    if self._seg_side(layer) != cap.side:
+                        continue
+                elif layer in self._all_cu and layer not in _union:
                     continue
                 d = _point_to_seg_dist(ccx, ccy, seg[0], seg[1], seg[2], seg[3])
                 if d <= seg_reach + seg[5]:
@@ -931,7 +969,13 @@ class _Repair:
         because a board with no copper layers has no layer question to answer.
         """
         pl = getattr(cap, 'pad_layers', None)
-        if pl is None or len(pl) != len(getattr(cap, 'pad_floors', ())):
+        # #731: anchored on `pads`, NOT on `pad_floors`. pad_layers is built
+        # unconditionally and pad_floors only when the model is active, so a
+        # pad_floors-anchored check would return None on every INERT board --
+        # switching layer scoping off precisely where the phantom is largest.
+        # `pads` is the list pad_rects() is built from, so it is the alignment
+        # that actually matters.
+        if pl is None or len(pl) != len(getattr(cap, 'pads', ())):
             return None
         return pl if self._all_cu else None
 
@@ -939,6 +983,44 @@ class _Repair:
     def _flat_pad(cap_layers, i):
         """True when cap pad `i` carries no copper and must be graded flat."""
         return cap_layers is not None and not cap_layers[i]
+
+    @staticmethod
+    def _seg_side(layer):
+        """The 'F'/'B' collapse the track prune used to be keyed on, kept ONLY
+        as the fallback for a cap whose real pad layers are unavailable.
+        Byte-identical to what __init__ computed before #731."""
+        return 'B' if (layer or '').startswith('B') else 'F'
+
+    def _cap_seg_scope(self, cap):
+        """(per-pad copper layer sets, their union) for the TRACK channel, or
+        (None, None) when layer scoping is off for this cap -- a duck-typed
+        cap, a misaligned list, a board declaring no copper layers, or a cap
+        with no copper-carrying pad at all. ONE decision point, so the prune
+        and the eff matrix can never disagree about whether scoping is on."""
+        pl = self._cap_pad_layers(cap)
+        if not pl:
+            return None, None
+        u = frozenset().union(*pl)
+        return (pl, u) if u else (None, None)
+
+    def _seg_shares(self, layer, mine):
+        """True when a track on `layer` can touch a cap pad whose copper layer
+        set is `mine`. The ONE predicate the prune, the eff matrix and the
+        disclosure all resolve through, so they cannot drift (#731).
+
+          mine is None              -> scoping off for this cap; charge, as before
+          layer not in self._all_cu -> an UNKNOWN layer (including None, a
+                                       test-injected 'F'/'B', and every layer
+                                       on a board declaring no copper): charge.
+                                       Over-blocking is the only direction that
+                                       can never ship a violation.
+          mine empty                -> a copper-less pad, which check_drc grades
+                                       not at all (#725): shares nothing.
+
+        Exactness of the union prune follows: _seg_shares(L, mine[i]) implies
+        `L not in _all_cu or L in union`, so a pair the per-pad grader would
+        charge can never be pruned away."""
+        return mine is None or layer not in self._all_cu or layer in mine
 
     def _cap_floors_ok(self, cap):
         """True when this cap carries a usable, index-aligned floor list. A
@@ -966,10 +1048,21 @@ class _Repair:
 
     def _seg_effs(self, ref, cap):
         """[cap pad i][pruned segment j] final half-width KEEP-OUT -- the
-        track's half width plus that pair's required clearance -- or None."""
-        if not self._cap_floors_ok(cap):
-            return None
+        track's half width plus that pair's required clearance -- or
+        `_OFF_LAYER` for a pair that shares no copper layer (#731). None only
+        for a cap offering neither floors nor layers (the duck-typed path).
+
+        Built even when the clearance model is INERT: the layer gate is a fact
+        about the stackup, not about what the board declares. On that path
+        every on-layer cell is the tuple's own t[5] BIT-EXACTLY and pair() is
+        never called, so an inert board stays byte-identical."""
         src = self.cap_segs[ref]
+        n = len(getattr(cap, 'pads', None) or ())
+        floors_ok = self._cap_floors_ok(cap)
+        cap_layers, _union = self._cap_seg_scope(cap)
+        # Nothing to price AND nothing to gate -> the duck-typed flat path.
+        if n == 0 or (not floors_ok and cap_layers is None):
+            return None
         rec = self._cap_seg_eff.get(ref)
         if rec is not None and rec[0] is src:
             return rec[1]
@@ -977,27 +1070,30 @@ class _Repair:
         floors = [by_id.get(id(t)) for t in src]
         # t[5] is half width + the segment's own over-reach; strip it back.
         halves = [t[5] - self._item_reach(f) for t, f in zip(src, floors)]
-        # A pair that shares NO copper layer keeps the FLAT scalar. cap_segs is
-        # pruned on the 'F'/'B' side collapse, which files an In1.Cu track
-        # under 'F', so it contains F-pad/inner-track pairs that cannot touch.
-        # The dru term already scopes itself away from them (empty shared set),
-        # but the netclass term does not -- and raising a phantom is how this
-        # change would move caps for a non-violation. Charging it flat leaves
-        # the pre-existing phantom exactly as it was; removing it altogether is
-        # a separate fix to the side collapse, filed rather than folded in.
-        cap_layers = self._cap_pad_layers(cap)
-        seg_layers = [self._seg_layer_by_id.get(id(t)) for t in src]
-
-        def eff(fa, mine, j):
-            sl = seg_layers[j]
-            if mine is not None and sl is not None and sl not in mine:
-                return self.clearance
-            return self._pair_or_flat(fa, floors[j])
-
-        rows = [[halves[j] + eff(fa, None if cap_layers is None
-                                 else cap_layers[i], j)
-                 for j in range(len(src))]
-                for i, fa in enumerate(cap.pad_floors)]
+        rows = []
+        for i in range(n):
+            fa = cap.pad_floors[i] if floors_ok else None
+            mine = None if cap_layers is None else cap_layers[i]
+            flat_pad = self._flat_pad(cap_layers, i)
+            row = []
+            for j, t in enumerate(src):
+                if not self._seg_shares(t[6], mine):
+                    # #731: a pair sharing no copper layer is not repriced, it
+                    # is REMOVED. _OFF_LAYER makes _seg_shortfalls' existing
+                    # cheap bbox reject fire on its first comparison, so the
+                    # gate costs the innermost loop nothing at all.
+                    row.append(_OFF_LAYER)
+                elif fa is None and floors[j] is None:
+                    # Bit-exact: t[5] itself, not (t[5] - clearance) + clearance,
+                    # so an INERT board grades every surviving pair to the same
+                    # float it did before, and an injected tuple grades exactly
+                    # as injected. The model is never consulted on this arm.
+                    row.append(t[5])
+                elif flat_pad:
+                    row.append(halves[j] + self.clearance)
+                else:
+                    row.append(halves[j] + self._pair_or_flat(fa, floors[j]))
+            rows.append(row)
         self._cap_seg_eff[ref] = (src, rows)
         return rows
 
@@ -1111,9 +1207,15 @@ class _Repair:
                     # nothing and belongs in no row
                     if _Repair._flat_pad(cap_layers, i):
                         continue
-                    # ...and neither does a pair that shares no copper layer
-                    if (layer is not None and cap_layers is not None
-                            and layer not in cap_layers[i]):
+                    # ...and neither does a pair that shares no copper layer.
+                    # THE SAME predicate _seg_effs prices with (#731), not a
+                    # second derivation -- a report that re-derives reports
+                    # pairs the pass never charged. `layer` is None for the
+                    # pad/via kinds, and _seg_shares charges an unknown layer,
+                    # so this is a no-op for them.
+                    if not self._seg_shares(
+                            layer, None if cap_layers is None
+                            else cap_layers[i]):
                         continue
                     mm, src = pair_with_source(fa, fb)
                     if src and mm > out.get(net, (0.0, ''))[0]:
@@ -1150,7 +1252,7 @@ class _Repair:
                     ('track', self.cap_segs[ref],
                      lambda t: self._seg_floor_by_id.get(id(t)), lambda t: t[4],
                      both(self._seg_shortfalls),
-                     lambda t: self._seg_layer_by_id.get(id(t)), None)):
+                     lambda t: t[6], None)):
                 for net, (mm, src) in best(fls, items, floor_of, net_of,
                                            set(charged), cl, layer_of,
                                            side_of).items():
@@ -1278,7 +1380,8 @@ class _Repair:
         return by_net
 
     def _seg_shortfalls(self, ref, cap, x, y, rot):
-        """PER-FOREIGN-NET, same-side track clearance shortfall for a placement,
+        """PER-FOREIGN-NET track clearance shortfall for a placement, over the
+        tracks this cap's pads actually SHARE COPPER WITH (#731),
         keyed by the track's net_id (#441): {snet: sum of (halfw - dist) over that
         net's segments this cap penetrates}. A net absent from the dict is fully
         clear. halfw already includes the clearance, so a positive shortfall is a
@@ -1287,13 +1390,16 @@ class _Repair:
         shortfall drops -- the zynq_ad9364 GND<->NetR2_2 repair-pass short (a move
         that relieved a 260um DDR3_BA2 graze by dropping a GND pad 85um onto a
         previously-clear NetR2_2 track looked like a net improvement to the old
-        scalar baseline). Uses the per-cap pruned, same-side track list."""
+        scalar baseline). Uses the per-cap pruned, layer-scoped track list."""
         by_net: Dict[int, float] = {}
         segs = self.cap_segs[ref]
         effs = self._seg_effs(ref, cap)
         if effs is None:
+            # Duck-typed cap only (#731): a real _Cap always offers pads, so it
+            # always gets a matrix. There is no layer to gate on here, and an
+            # injected tuple grades exactly as injected.
             for (bx0, by0, bx1, by1, net) in cap.pad_rects(x, y, rot):
-                for x1, y1, x2, y2, snet, halfw, side in segs:
+                for x1, y1, x2, y2, snet, halfw, _layer in segs:
                     if snet == net:
                         continue
                     # cheap reject: the segment's bbox can't reach the pad rect
@@ -1307,10 +1413,12 @@ class _Repair:
             return by_net
         # #725 active path: effs[i][j] IS the pair's keep-out, and the cheap
         # bbox reject widens with it -- a reject left at the flat half width
-        # would silently drop the pairs this fix exists to charge.
+        # would silently drop the pairs this fix exists to charge. Since #731
+        # the row also carries the LAYER gate, as _OFF_LAYER; the same cheap
+        # reject is what makes that free.
         for i, (bx0, by0, bx1, by1, net) in enumerate(cap.pad_rects(x, y, rot)):
             row = effs[i]
-            for j, (x1, y1, x2, y2, snet, _hw, side) in enumerate(segs):
+            for j, (x1, y1, x2, y2, snet, _hw, _layer) in enumerate(segs):
                 if snet == net:
                     continue
                 halfw = row[j]

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -1084,10 +1084,16 @@ class _Repair:
                     # gate costs the innermost loop nothing at all.
                     row.append(_OFF_LAYER)
                 elif fa is None and floors[j] is None:
-                    # Bit-exact: t[5] itself, not (t[5] - clearance) + clearance,
-                    # so an INERT board grades every surviving pair to the same
-                    # float it did before, and an injected tuple grades exactly
-                    # as injected. The model is never consulted on this arm.
+                    # Neither side has a floor: the pair is worth exactly the
+                    # tuple's own over-reach. Taking t[5] directly rather than
+                    # rebuilding it as halves[j] + clearance keeps the
+                    # resolver OUT of the inert path entirely -- _pair_or_flat
+                    # is not called, so an inert board cannot start consulting
+                    # a model, and an injected tuple grades exactly as
+                    # injected. (The arithmetic round-trip happens to be
+                    # float-exact on every cell measured -- 0 of 1063 on
+                    # rp2350 -- so this is about the call, not about the
+                    # rounding.)
                     row.append(t[5])
                 elif flat_pad:
                     row.append(halves[j] + self.clearance)

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -1339,9 +1339,10 @@ def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
     print(f"BGAs: {', '.join(st.bga_refs) or '(none)'}  "
           f"fanout vias: {len(st.vias)}  "
           f"movable near-BGA caps: {len(st.caps)}")
-    # #725: the early returns carry the same key set as the full one, so a
-    # caller reading result['required'] / ['clearance_notes'] does not have to
-    # special-case a no-op board.
+    # #725: the early returns carry 'required' / 'clearance_notes' too, so a
+    # caller does not have to special-case a no-op board for them. (They still
+    # omit 'via_moves' / 'new_segments', as they always have -- every caller
+    # reads the dict with .get.)
     if not st.vias:
         print("No vias on the board - run this AFTER bga_fanout.py.")
         return {'placements': [], 'resolved': [], 'unresolved': [],

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -2431,10 +2431,24 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
         # then keeps the #130 pad-via graze this pass exists to remove. That is
         # exactly the failure obstacle_map.resolve_hole_clearance names for
         # this function by name -- an all-or-nothing repair whose one clearing
-        # candidate must not be refused -- and the same balance #617 struck for
-        # the connector gate. At --clearance >= 0.20 the two floors are equal,
-        # so this only ever differs below the fab floor; the CLI's own --help
-        # example is --clearance 0.1, and the GUI control's minimum is 0.05.
+        # candidate must not be refused.
+        #
+        # A board's DECLARED min_hole_clearance stays unread here, and the
+        # checkable reason is better than the #617 appeal it replaces: it
+        # changes nothing in check_drc's VIA arm either. The declared floor
+        # enters that arm only through the `req_clr > npth_clr` THRESHOLD, so
+        # with hole_clearance 0.5 and no pad override the requirement is still
+        # `clearance`. (#617 is about a different move -- it declined to RAISE
+        # the connector gate above the flat fab floor; this LOWERS the via gate
+        # below it, which #617 never measured. The principle is shared, the
+        # floor is not.)
+        #
+        # At --clearance >= 0.20 the two floors are equal, so this only ever
+        # differs below the fab floor. The CLI's own --help example is
+        # --clearance 0.1 and it applies no fab floor at all; the GUI's spin
+        # minimum is 0.05 but its value passes through _fab_floored, so the
+        # reachable minimum there is the fab tier's -- 0.127 standard 2-layer,
+        # 0.10 advanced 2-layer, 0.09 advanced multilayer.
         #
         # Same helper, same own-net exemption and the same 1e-4 as
         # connector_clear's gate below, so the two cannot disagree about which
@@ -2455,12 +2469,26 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
         # drill-to-drill is a machine constraint, this is an etch constraint,
         # and check_drc's via arm makes the same own-net exemption.
         #
-        # KNOWN GAP, deliberately not closed here, exactly as at the cap
-        # keep-out site above: this does not honour the hole pad's OWN
-        # `local_clearance`, which check_drc does honour, so it under-blocks by
-        # `lc - clearance` on such a pad. That is #730 -- a wrong VALUE where
-        # this was a missing GATE -- and closing it here would move a number
-        # #730 needs to move in one place.
+        # KNOWN GAP, deliberately not closed here. Like the cap keep-out site
+        # above, this does not honour the hole pad's OWN `local_clearance` --
+        # but the arithmetic is NOT the same, and saying "as above" inside a
+        # comment whose whole point is that the track and via arms differ would
+        # be wrong. check_drc's via arm is a STEP, not a max:
+        # `lc if lc > npth_clr else clearance`. So the shortfall here is
+        # `lc - clearance` ONLY when `lc > npth_clr`, and exactly ZERO for
+        # `clearance < lc <= npth_clr` (measured: clearance 0.10, lc 0.15 ->
+        # checker wants 0.100, this gate charges 0.100). Choosing `clearance`
+        # over `npth_clr` WIDENS that shortfall by `npth_clr - clearance`, i.e.
+        # by up to 0.10mm at --clearance 0.1 -- stated in magnitude, not merely
+        # in kind.
+        #
+        # That is #730 -- a wrong VALUE where this was a missing GATE. Two
+        # things for whoever closes it: the obvious `max(clearance, lc)` is
+        # measured WRONG in both directions (it over-blocks by 0.05 at
+        # clearance 0.10 / lc 0.15), and an exact mirror needs check_drc's
+        # `npth_clr`, which includes the BOARD's declared min_hole_clearance --
+        # dragging back in the very read this function and its own source guard
+        # forbid.
         if _seg_foreign_hole_dist(pcb_data, v.net_id, nx, ny, nx, ny) < \
                 clearance + vr - 1e-4:
             return False

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -43,8 +43,9 @@ import routing_defaults as defaults
 from bga_fanout.grid import analyze_bga_grid
 from placement.parser import extract_courtyard_bboxes, extract_locked_refs
 from placement.utility import compute_footprint_bbox_local, snap_to_grid
-from placement.legality import (BoardOutlineGate, point_to_seg_dist, rect_gap,
-                                ring_is_rect, rotate_local_bounds)
+from placement.legality import (BoardOutlineGate, PadClearanceModel, PadFloor,
+                                format_required_clause, point_to_seg_dist,
+                                rect_gap, ring_is_rect, rotate_local_bounds)
 
 ROTATIONS = [0.0, 90.0, 180.0, 270.0]
 EPS = 1e-6
@@ -74,18 +75,26 @@ def _point_to_rect_dist(px, py, rect):
     return math.hypot(dx, dy)
 
 
-def _pad_pair_shortfall(pads_a, pads_b, clearance):
+def _pad_pair_shortfall(pads_a, pads_b, clearance, effs=None):
     """Sum of different-net pad clearance shortfalls between two movable parts'
     pad rects (#275) -- the mover-vs-mover analogue of pad_penalty. Same-net
-    pad pairs are fine (shared rail copper may touch)."""
+    pad pairs are fine (shared rail copper may touch).
+
+    `effs` (#725) is the per-pair REQUIRED clearance, `effs[ia][ib]` aligned
+    with pads_a x pads_b -- a pad override / netclass / .kicad_dru layer rule
+    can put a pair's requirement above (or, for a relaxing rule, below) the
+    flat scalar. None keeps the flat path, which is what a board declaring
+    none of them takes."""
     pen = 0.0
-    for (ax0, ay0, ax1, ay1, anet) in pads_a:
-        for (bx0, by0, bx1, by1, bnet) in pads_b:
+    for ia, (ax0, ay0, ax1, ay1, anet) in enumerate(pads_a):
+        row = None if effs is None else effs[ia]
+        for ib, (bx0, by0, bx1, by1, bnet) in enumerate(pads_b):
             if anet == bnet:
                 continue
             gap = _rect_gap((ax0, ay0, ax1, ay1), (bx0, by0, bx1, by1))
-            if gap < clearance - EPS:
-                pen += (clearance - gap)
+            clr = clearance if row is None else row[ib]
+            if gap < clr - EPS:
+                pen += (clr - gap)
     return pen
 
 
@@ -134,7 +143,7 @@ class _Cap:
     for decoupling caps).
     """
 
-    def __init__(self, fp, courtyard_local):
+    def __init__(self, fp, courtyard_local, model=None):
         self.ref = fp.reference
         self.side = 'B' if (fp.layer or '').startswith('B') else 'F'
         self.seed_x, self.seed_y = fp.x, fp.y
@@ -145,6 +154,21 @@ class _Cap:
         # separate paste-only "pads" (e.g. gkl_misc C_0201_0603Metric), which are
         # not copper and must not enter the clearance/attraction geometry.
         self.pads = []
+        # #725, mirroring PartPads (legality.py): the per-pad clearance FLOOR
+        # rides in a parallel list index-aligned with self.pads, never widened
+        # into the pad tuple -- pad_rects()' 5-tuple is unpacked positionally by
+        # tests and by animate_fanout_clearance.py. `max_floor` is the
+        # over-reach a broad phase must use (a .kicad_dru rule REPLACES, so it
+        # can also LOWER a pair; a prune must never under-reach).
+        # NOTE the copper filter below stays _Cap's own `endswith('.Cu')` test
+        # and is deliberately NOT unified with legality._pad_carries_copper,
+        # which additionally rejects np_thru_hole. Unifying would change which
+        # pads enter pad_rects/pad_bbox/attraction and desynchronise the
+        # n_copper cap-detection test in _Repair.__init__ -- a placement change
+        # dressed as a clearance fix. Building the floors against THIS rule
+        # makes the alignment true by construction.
+        self.pad_floors = []
+        self.max_floor = 0.0
         for p in fp.pads:
             if not any(str(l).endswith('.Cu') for l in p.layers):
                 continue  # paste/mask-only aperture, not copper
@@ -156,6 +180,12 @@ class _Cap:
             half_x = hx * c + hy * s
             half_y = hx * s + hy * c
             self.pads.append((off_x, off_y, half_x, half_y, p.net_id))
+            if model is not None:
+                fl = model.pad_floor(p)
+                self.pad_floors.append(fl)
+                mf = model.max_floor(fl)
+                if mf > self.max_floor:
+                    self.max_floor = mf
         self.local_bounds = courtyard_local
         # Rotation-only geometry is reused across every candidate position
         # (millions of times on a dense board), so memoize it per angle and
@@ -298,6 +328,29 @@ class _Repair:
         self._edge_active = self.edge_gate.active
         self._max_disp_cap = max_displacement_cap
         self.clearance = clearance
+        # #725: `clearance` is ONE flat scalar, but KiCad's different-net
+        # requirement for a pair is max(clearance, netclass a, netclass b),
+        # then REPLACED by any .kicad_dru rule on the layers the two share,
+        # then raised by either item's own pad `(clearance ...)` override.
+        # This pass is the second channel of #697's defect: priced flat, a pair
+        # separated by more than `clearance` but less than its real requirement
+        # is never charged, so the repair reports nothing to fix on geometry
+        # check_drc flags. PadClearanceModel resolves it exactly as check_drc
+        # does and is STRICTLY INERT on a board declaring none of the three.
+        # `notes` must be read BEFORE the active-drop: a FAILED read (an
+        # unreadable sibling) is exactly what makes the model look inert.
+        _model = PadClearanceModel.for_board(pcb_data, clearance, pcb_file)
+        self.clearance_notes = list(_model.notes)
+        self._floors = _model if _model.active else None
+        # Pad-layer scope for the non-pad items below. A via spans copper, so
+        # it is scoped to ALL copper: check_drc's pad-via path passes
+        # layers_b=None meaning "scope to the pad's own layers", and
+        # intersecting with all-copper reproduces that exactly (blind vias
+        # included). Never None here -- PadClearanceModel.pair does
+        # `fb.layers or ()`, and an EMPTY shared set discards every dru rule.
+        self._all_cu = frozenset(pcb_data.board_info.copper_layers or ())
+        self._via_floor: Dict[int, PadFloor] = {}
+        self._seg_floor: Dict[Tuple[int, str], PadFloor] = {}
         # #617: KiCad's copper-to-hole rule is the BOARD's `min_hole_clearance`
         # whenever it declares one above the 0.20 NPTH fab floor -- the same
         # value check_drc grades at. The NPTH keep-out rects below were grown
@@ -326,20 +379,44 @@ class _Repair:
         # Each (x, y, net, keepout) where keepout = via_radius + clearance; a
         # cap pad must clear vias of a DIFFERENT net by this. Through-vias, so
         # they apply to caps on either board side.
+        # #725: `keepout` is the OVER-REACH -- radius + max(clearance, this
+        # via's own upper-bound floor). It feeds the prunes, the locked-part
+        # warning and the animator's drawn disk, all of which may over-reach.
+        # The EXACT per-(cap pad, via) value is resolved in the eff lists
+        # below, never from this slot. Byte-identical (radius + clearance) when
+        # the model is inert. The 4-tuple shape is pinned: tests assign
+        # st.vias wholesale and animate_fanout_clearance.py unpacks it.
         self.vias: List[Tuple[float, float, int, float]] = []
         for v in pcb_data.vias:
             size = v.size if v.size and v.size > 0 else default_via_size
-            self.vias.append((v.x, v.y, v.net_id, size / 2.0 + clearance))
+            self.vias.append((v.x, v.y, v.net_id,
+                              size / 2.0 + self._item_reach(
+                                  self._via_floor_for(v.net_id))))
 
         # --- avoidance: foreign-net tracks on the cap's own side ---
         # Fanout escapes can land on the bottom (cap) side; attraction could
         # then pull a cap onto an escape track -> a PAD-SEGMENT violation.
         # Keyed by side so a B.Cu cap only avoids B.Cu tracks.
+        # #725: element 5 is the OVER-REACH, like self.vias[3] above. The
+        # segment's floor is keyed by its REAL layer, not by the F/B `side`
+        # collapse on the next line (which files an In1.Cu track under 'F') --
+        # a .kicad_dru rule is layer-scoped, and check_drc's pad-segment path
+        # resolves it as a single-layer REPLACE on seg.layer. The side collapse
+        # is pre-existing and deliberately left alone here.
         self.segments: List[Tuple[float, float, float, float, int, float, str]] = []
+        # The 7-tuple carries `side`, not the real layer, so the floor cannot be
+        # re-derived from it later -- keep it on the tuple's identity. The
+        # tuples live for this object's lifetime, so the id is stable; a tuple a
+        # test injects is simply absent and grades flat.
+        self._seg_floor_by_id: Dict[int, PadFloor] = {}
         for s in pcb_data.segments:
             side = 'B' if (s.layer or '').startswith('B') else 'F'
-            self.segments.append((s.start_x, s.start_y, s.end_x, s.end_y,
-                                  s.net_id, s.width / 2.0 + clearance, side))
+            fl = self._seg_floor_for(s.net_id, s.layer)
+            t = (s.start_x, s.start_y, s.end_x, s.end_y, s.net_id,
+                 s.width / 2.0 + self._item_reach(fl), side)
+            self.segments.append(t)
+            if fl is not None:
+                self._seg_floor_by_id[id(t)] = fl
 
         # --- attraction: BGA balls grouped by net ---
         # A cap pad is pulled toward the nearest ball of its own net, so a via
@@ -378,6 +455,13 @@ class _Repair:
         # a through-hole pad that blocks both sides). Same-net pads are fine.
         self.foreign_pads: List[
             Tuple[float, float, float, float, int, Optional[str]]] = []
+        # #725: index-aligned with self.foreign_pads (the 6-tuple shape is
+        # pinned -- tests inject into cap_foreign_pads directly). An NPTH
+        # entry gets floor None / mf 0.0: its rect is already inflated to the
+        # hole floor, and the copper-to-HOLE rule is net-independent, so the
+        # new machinery must never raise it via a neighbouring pad's netclass.
+        self.foreign_pad_floors: List[Optional[PadFloor]] = []
+        self.foreign_pad_mf: List[float] = []
         self.caps: Dict[str, _Cap] = {}
         self.static_rects: List[Tuple[Tuple[float, float, float, float], str]] = []
         for ref, fp in pcb_data.footprints.items():
@@ -392,7 +476,7 @@ class _Repair:
             is_cap = (ref.startswith(self._cap_prefixes) and n_copper <= 2
                       and ref not in locked)
             if is_cap:
-                cap = _Cap(fp, lb)
+                cap = _Cap(fp, lb, self._floors)
                 if self._near_any(cap.rect(), bga_bboxes, near_margin):
                     self.caps[ref] = cap
                     continue
@@ -421,6 +505,8 @@ class _Repair:
                             hr = hd / 2.0 + grow
                             self.foreign_pads.append(
                                 (hx - hr, hy - hr, hx + hr, hy + hr, -1, None))
+                            self.foreign_pad_floors.append(None)
+                            self.foreign_pad_mf.append(0.0)
                     continue
                 if not copper:
                     continue  # paste/mask-only aperture
@@ -436,6 +522,10 @@ class _Repair:
                     (p.global_x - half_x, p.global_y - half_y,
                      p.global_x + half_x, p.global_y + half_y,
                      p.net_id, pside))
+                _fl = None if self._floors is None else self._floors.pad_floor(p)
+                self.foreign_pad_floors.append(_fl)
+                self.foreign_pad_mf.append(
+                    0.0 if _fl is None else self._floors.max_floor(_fl))
 
         # Per-cap spatially-pruned neighbour lists (perf). A cap moves at most
         # max_displacement_cap from its seed, so anything whose seed gap already
@@ -443,6 +533,26 @@ class _Repair:
         # it -- excluding it is exact, not an approximation. This turns the
         # per-candidate hard_blocked / penalty loops from O(all parts) into
         # O(handful), the dominant cost on dense boards (#213 profiling).
+        # #725: same identity-keyed map for foreign pads -- a pad's floor
+        # depends on its own `(clearance ...)` and its copper layers, neither of
+        # which the 6-tuple carries.
+        self._fp_floor_by_id: Dict[int, PadFloor] = {}
+        if self._floors is not None:
+            for _t, _f in zip(self.foreign_pads, self.foreign_pad_floors):
+                if _f is not None:
+                    self._fp_floor_by_id[id(_t)] = _f
+        # Per-(cap, neighbour) REQUIRED-clearance memos. model.pair() is
+        # pose-independent, so it is resolved ONCE per pair here and never
+        # inside the candidate sweep. Each memo is (source_list, rows) and is
+        # rebuilt when the source list identity changes -- which makes
+        # repair_fanout_clearance's wholesale `st.cap_vias = {...}` reassignment
+        # self-heal, and makes a test that injects into cap_foreign_pads grade
+        # flat rather than mis-index.
+        self._cap_pad_eff: Dict[str, Tuple[list, list]] = {}
+        self._cap_seg_eff: Dict[str, Tuple[list, list]] = {}
+        self._cap_via_eff: Dict[str, Tuple[list, list]] = {}
+        self._cap_pair_eff: Dict[Tuple[str, str], list] = {}
+
         cap_geom: Dict[str, Tuple[float, float, float, Tuple]] = {}
         for ref, cap in self.caps.items():
             r = cap.rect()
@@ -460,16 +570,25 @@ class _Repair:
         self.cap_segs: Dict[str, List[Tuple]] = {}
         # through-vias in reach (each (vx, vy, net, keepout))
         self.cap_vias: Dict[str, List[Tuple[float, float, int, float]]] = {}
+        # #725: every reach below is raised by THE TWO ITEMS' OWN maxima, never
+        # by a board-wide maximum -- these lists gate per-candidate loops, so a
+        # board-wide bound would slow every cap for the sake of one keep-clear
+        # pad. `cap.max_floor` and `foreign_pad_mf` are 0.0 on an inert board,
+        # so `max(clearance, 0.0, 0.0) == clearance` and the reaches are
+        # byte-identical. Left un-raised on purpose: cap_static below, which
+        # gates _overlap (courtyards, not copper).
         cap_refs = list(self.caps)
         for ref, cap in self.caps.items():
             ccx, ccy, span, crect = cap_geom[ref]
-            reach = max_displacement_cap + span + clearance
+            reach = max_displacement_cap + span
+            cap_mf = cap.max_floor
             near_pads = []
-            for fp_pad in self.foreign_pads:
+            for j, fp_pad in enumerate(self.foreign_pads):
                 px = (fp_pad[0] + fp_pad[2]) / 2.0
                 py = (fp_pad[1] + fp_pad[3]) / 2.0
                 phalf = math.hypot(fp_pad[2] - px, fp_pad[3] - py)
-                if math.hypot(px - ccx, py - ccy) <= reach + phalf:
+                req = max(clearance, cap_mf, self.foreign_pad_mf[j])
+                if math.hypot(px - ccx, py - ccy) <= reach + req + phalf:
                     near_pads.append(fp_pad)
             self.cap_foreign_pads[ref] = near_pads
 
@@ -487,12 +606,17 @@ class _Repair:
                     continue
                 # both caps can move, so the combined reach is 2x the budget
                 if (_rect_gap(crect, cap_geom[oref][3])
-                        <= 2 * max_displacement_cap + clearance + EPS):
+                        <= 2 * max_displacement_cap
+                        + max(clearance, cap_mf, self.caps[oref].max_floor)
+                        + EPS):
                     near_caps.append(oref)
             self.cap_caps[ref] = near_caps
 
             near_segs = []
-            seg_reach = max_displacement_cap + 2 * span + clearance
+            # seg[5] already carries the segment's own over-reach, so adding
+            # this cap's excess over the flat scalar bounds the pair.
+            seg_reach = (max_displacement_cap + 2 * span + clearance
+                         + max(0.0, cap_mf - clearance))
             for seg in self.segments:
                 if seg[6] != cap.side:
                     continue
@@ -502,11 +626,13 @@ class _Repair:
             self.cap_segs[ref] = near_segs
 
             near_vias = []
+            # v[3] = via_radius + its own keep-out; a via that can reach a pad
+            # must be within (move + span + keep-out) of the seed. #725: plus
+            # this cap's excess over the flat scalar, which bounds the pair.
+            via_slack = max(0.0, cap_mf - clearance)
             for v in self.vias:
-                # v[3] = via_radius + clearance keep-out; a via that can reach
-                # a pad must be within (move + span + keep-out) of the seed.
                 if math.hypot(v[0] - ccx, v[1] - ccy) <= (
-                        max_displacement_cap + span + v[3]):
+                        max_displacement_cap + span + v[3] + via_slack):
                     near_vias.append(v)
             self.cap_vias[ref] = near_vias
 
@@ -562,8 +688,15 @@ class _Repair:
             for oref in self.cap_caps[ref]:
                 key = frozenset((ref, oref))
                 if key not in self.base_cap_pad:
+                    # #725: the baseline must be in the SAME currency as the
+                    # candidate it gates. Priced flat while candidates are
+                    # priced at the requirement, _worsens_any_net fires on
+                    # every pose and the pass silently stops moving anything --
+                    # a failure whose symptom is FEWER placements, which reads
+                    # as conservative rather than broken.
                     self.base_cap_pad[key] = _pad_pair_shortfall(
-                        seed_pads, self.caps[oref].pad_rects(), self.clearance)
+                        seed_pads, self.caps[oref].pad_rects(), self.clearance,
+                        self._pair_effs(ref, cap, oref, self.caps[oref]))
 
     @staticmethod
     def _near_any(rect, bboxes, margin):
@@ -617,26 +750,282 @@ class _Repair:
         return self.edge_gate.rect_blocked(
             rect, skip_rings=self._owned_rings(ref) if ref is not None else None)
 
+    # ---- #725: per-pair required clearance -------------------------------
+    # A via or a track carries no pad `(clearance ...)` override, so its floor
+    # is a pure function of (net, layer scope) and is memoised on that key --
+    # never on a list position, because st.vias is reassigned wholesale by
+    # tests and rebuilt by nudge_vias_for_unresolved, which would desync any
+    # index-aligned parallel list.
+
+    def _via_floor_for(self, net_id):
+        """The PadFloor standing in for a via: its net's class floor, no pad
+        override, scoped to all copper (see self._all_cu). None when inert."""
+        if self._floors is None:
+            return None
+        f = self._via_floor.get(net_id)
+        if f is None:
+            f = PadFloor(self._floors.net_floor.get(net_id or 0, 0.0), 0.0,
+                         self._all_cu if self._floors.layer_rules else None)
+            self._via_floor[net_id] = f
+        return f
+
+    def _seg_floor_for(self, net_id, layer):
+        """The PadFloor standing in for a track: its net's class floor, no pad
+        override, scoped to its OWN layer -- which reproduces check_drc's
+        single-layer REPLACE for pad-segment, since with one shared layer
+        pads_shared_layer_clearance is all-or-nothing. None when inert."""
+        if self._floors is None:
+            return None
+        key = (net_id, layer)
+        f = self._seg_floor.get(key)
+        if f is None:
+            f = PadFloor(self._floors.net_floor.get(net_id or 0, 0.0), 0.0,
+                         frozenset({layer}) if self._floors.layer_rules else None)
+            self._seg_floor[key] = f
+        return f
+
+    def _item_reach(self, floor):
+        """The over-reach for a via/track keep-out: never below the flat
+        scalar, raised by that item's own upper bound. Exactly `clearance`
+        when the model is inert, so the keep-outs stay byte-identical."""
+        if floor is None:
+            return self.clearance
+        return max(self.clearance, self._floors.max_floor(floor))
+
+    # Public resolvers. nudge_vias_for_unresolved composes its requirements
+    # from these rather than re-deriving them, so there is ONE answer per pair
+    # kind in this module.
+
+    def required(self, fa, fb):
+        """Required clearance between two resolved floors (either may be None
+        -- an NPTH keep-out, a test-injected tuple -- which grades flat)."""
+        return self._pair_or_flat(fa, fb)
+
+    def pad_floor(self, pad):
+        """The floor for a real parser Pad; None when inert."""
+        return None if self._floors is None else self._floors.pad_floor(pad)
+
+    def via_floor(self, net_id):
+        """The floor standing in for a via of `net_id`; None when inert."""
+        return self._via_floor_for(net_id)
+
+    def seg_floor(self, net_id, layer):
+        """The floor standing in for a track on `layer`; None when inert."""
+        return self._seg_floor_for(net_id, layer)
+
+    def via_required(self, pad_floor, via_net):
+        """The required clearance for one (cap pad, via) pair.
+
+        The offender test in nudge_vias_for_unresolved and via_penalty's
+        grazing test MUST both resolve through here: if they diverge, the
+        nudger chases a via the grader no longer flags (or reports a cap
+        unresolved that its own nudger then refuses to see). The via eff rows
+        are built from this same call, so they cannot drift from it either."""
+        return self._pair_or_flat(pad_floor, self._via_floor_for(via_net))
+
+    def _pair_or_flat(self, fa, fb):
+        """model.pair for two floors, falling back to the flat scalar whenever
+        either side has none (an NPTH keep-out rect, a test-injected tuple)."""
+        if fa is None or fb is None:
+            return self.clearance
+        return self._floors.pair(fa, fb)
+
+    def _cap_floors_ok(self, cap):
+        """True when this cap carries a usable, index-aligned floor list. A
+        _Cap built without the model (or by a test) grades flat."""
+        pf = getattr(cap, 'pad_floors', None)
+        return (self._floors is not None and pf is not None
+                and len(pf) == len(getattr(cap, 'pads', ())))
+
+    def _pad_effs(self, ref, cap):
+        """[cap pad i][pruned foreign pad j] required clearance, or None for
+        the flat path."""
+        if not self._cap_floors_ok(cap):
+            return None
+        src = self.cap_foreign_pads[ref]
+        rec = self._cap_pad_eff.get(ref)
+        if rec is not None and rec[0] is src:
+            return rec[1]
+        by_id = self._fp_floor_by_id
+        rows = [[self._pair_or_flat(fa, by_id.get(id(t))) for t in src]
+                for fa in cap.pad_floors]
+        self._cap_pad_eff[ref] = (src, rows)
+        return rows
+
+    def _seg_effs(self, ref, cap):
+        """[cap pad i][pruned segment j] final half-width KEEP-OUT -- the
+        track's half width plus that pair's required clearance -- or None."""
+        if not self._cap_floors_ok(cap):
+            return None
+        src = self.cap_segs[ref]
+        rec = self._cap_seg_eff.get(ref)
+        if rec is not None and rec[0] is src:
+            return rec[1]
+        by_id = self._seg_floor_by_id
+        floors = [by_id.get(id(t)) for t in src]
+        # t[5] is half width + the segment's own over-reach; strip it back.
+        halves = [t[5] - self._item_reach(f) for t, f in zip(src, floors)]
+        rows = [[halves[j] + self._pair_or_flat(fa, floors[j])
+                 for j in range(len(src))] for fa in cap.pad_floors]
+        self._cap_seg_eff[ref] = (src, rows)
+        return rows
+
+    def _via_effs(self, ref, cap, vias):
+        """[cap pad i][via j] final KEEP-OUT for `vias` -- the via's radius plus
+        that pair's required clearance -- or None for the flat path. The
+        requirement is resolved through via_required, so this can never
+        disagree with the offender test in nudge_vias_for_unresolved."""
+        if not self._cap_floors_ok(cap):
+            return None
+        rec = self._cap_via_eff.get(ref)
+        if rec is not None and rec[0] is vias:
+            return rec[1]
+        # v[3] is radius + the via's own over-reach; strip it back to a radius.
+        radii = [v[3] - self._item_reach(self._via_floor_for(v[2])) for v in vias]
+        rows = [[radii[j] + self.via_required(fa, v[2])
+                 for j, v in enumerate(vias)] for fa in cap.pad_floors]
+        self._cap_via_eff[ref] = (vias, rows)
+        return rows
+
+    def _pair_effs(self, ref, cap, oref, other):
+        """[this cap's pad i][other mover's pad j] required clearance, or None.
+        Keyed on the ORDERED pair so the row index always addresses `cap`; the
+        summed shortfall itself is symmetric, so the seed baseline is not."""
+        if not (self._cap_floors_ok(cap) and self._cap_floors_ok(other)):
+            return None
+        key = (ref, oref)
+        rows = self._cap_pair_eff.get(key)
+        if rows is None:
+            rows = [[self._pair_or_flat(fa, fb) for fb in other.pad_floors]
+                    for fa in cap.pad_floors]
+            self._cap_pair_eff[key] = rows
+        return rows
+
+    def required_rows(self, net_names=None, limit=200):
+        """Rows `[cap_ref, '<kind> <partner>', mm, source]` for every pair this
+        pass actually CHARGED at a requirement above the flat scalar, at the
+        caps' current poses.
+
+        Same 4-column shape as legality.grade_pad_legality's 'required', so
+        legality.format_required_clause renders it unchanged. `[]` when inert.
+        Only charged pairs are listed -- an in-reach pair that happens to be
+        clear is not a finding, it is the normal case on a declaring board.
+        The partner is named by NET, not by reference: foreign_pads / vias /
+        segments carry no owning ref and their tuple shapes are pinned."""
+        if self._floors is None:
+            return []
+        names = net_names or {}
+        pair_with_source = self._floors.pair_with_source
+        rows = []
+
+        def net_label(net):
+            if net == 0:
+                return '<no net>'
+            if net == -1:
+                return '<hole>'
+            return names.get(net, str(net))
+
+        def best(floors_a, items, floor_of, net_of, only):
+            """Worst requirement, with its source, over the items on `only`."""
+            out = {}
+            for t in items:
+                net = net_of(t)
+                if net not in only:
+                    continue
+                fb = floor_of(t)
+                if fb is None:
+                    continue
+                for fa in floors_a:
+                    mm, src = pair_with_source(fa, fb)
+                    if src and mm > out.get(net, (0.0, ''))[0]:
+                        out[net] = (mm, src)
+            return out
+
+        for ref, cap in self.caps.items():
+            if not self._cap_floors_ok(cap):
+                continue
+            fls = cap.pad_floors
+            x, y, rot = cap.x, cap.y, cap.rot
+            for kind, items, floor_of, net_of, charged in (
+                    ('pad', self.cap_foreign_pads[ref],
+                     lambda t: self._fp_floor_by_id.get(id(t)), lambda t: t[4],
+                     self._pad_shortfalls(ref, cap, x, y, rot)),
+                    ('via', self.cap_vias[ref],
+                     lambda t: self._via_floor_for(t[2]), lambda t: t[2],
+                     self._via_shortfalls(ref, cap, x, y, rot)),
+                    ('track', self.cap_segs[ref],
+                     lambda t: self._seg_floor_by_id.get(id(t)), lambda t: t[4],
+                     self._seg_shortfalls(ref, cap, x, y, rot))):
+                for net, (mm, src) in best(fls, items, floor_of, net_of,
+                                           set(charged)).items():
+                    rows.append([ref, '{} {}'.format(kind, net_label(net)),
+                                 round(mm, 6), src])
+            # mover-vs-mover: the shortfall is a scalar per pair, so charge the
+            # pair as a whole and name it by the partner's reference.
+            cand = cap.pad_rects(x, y, rot)
+            for oref in self.cap_caps[ref]:
+                other = self.caps[oref]
+                if not self._cap_floors_ok(other):
+                    continue
+                effs = self._pair_effs(ref, cap, oref, other)
+                if _pad_pair_shortfall(cand, other.pad_rects(),
+                                       self.clearance, effs) <= EPS:
+                    continue
+                mm, src = 0.0, ''
+                for fa in fls:
+                    for fb in other.pad_floors:
+                        m, sc = pair_with_source(fa, fb)
+                        if sc and m > mm:
+                            mm, src = m, sc
+                if src:
+                    rows.append([ref, 'cap ' + oref, round(mm, 6), src])
+        rows.sort(key=lambda r: (-r[2], r[0], r[1]))
+        return rows[:limit]
+
     def _overlap(self, a, b):
-        """Courtyard-clearance shortfall between two rects (0 if clear)."""
+        """Courtyard-clearance shortfall between two rects (0 if clear).
+
+        Deliberately NOT #725-converted: a courtyard is a mechanical/assembly
+        extent, not copper, so charging a netclass or a pad override here would
+        move caps for a reason KiCad's DRC never raises. The cap_static prune
+        that gates it is therefore still exact at the flat scalar."""
         return max(0.0, self.clearance - _rect_gap(a, b))
 
-    def via_penalty(self, cap, x, y, rot, vias=None):
+    def via_penalty(self, cap, x, y, rot, vias=None, ref=None):
         """Sum of foreign-net via penetration depths for a cap placement
         (how far each pad intrudes inside a different-net via's keep-out).
 
         vias defaults to the full board list; callers with a ref pass the
         per-cap pruned list (self.cap_vias[ref]), which is exact -- a via that
-        can penetrate a pad is necessarily within the cap's reach."""
+        can penetrate a pad is necessarily within the cap's reach.
+
+        #725: `ref` keys the per-pair required-clearance memo. Without it (the
+        4-positional test/default path) the flat scalar is used, which is what
+        the whole-board `vias` default is for anyway."""
         vias = self.vias if vias is None else vias
+        effs = None if ref is None else self._via_effs(ref, cap, vias)
         pen = 0.0
-        for (bx0, by0, bx1, by1, net) in cap.pad_rects(x, y, rot):
-            for vx, vy, vnet, keepout in vias:
+        if effs is None:
+            for (bx0, by0, bx1, by1, net) in cap.pad_rects(x, y, rot):
+                for vx, vy, vnet, keepout in vias:
+                    if vnet == net:
+                        continue
+                    d = _point_to_rect_dist(vx, vy, (bx0, by0, bx1, by1))
+                    if d < keepout - EPS:
+                        pen += (keepout - d)
+            return pen
+        # #725 active path: effs[i][j] IS the pair's keep-out (via radius +
+        # required clearance), precomputed -- the tuple's own keepout slot is
+        # the prune over-reach and is not the requirement.
+        for i, (bx0, by0, bx1, by1, net) in enumerate(cap.pad_rects(x, y, rot)):
+            row = effs[i]
+            for j, (vx, vy, vnet, _ko) in enumerate(vias):
                 if vnet == net:
                     continue
+                ko = row[j]
                 d = _point_to_rect_dist(vx, vy, (bx0, by0, bx1, by1))
-                if d < keepout - EPS:
-                    pen += (keepout - d)
+                if d < ko - EPS:
+                    pen += (ko - d)
         return pen
 
     def _via_shortfalls(self, ref, cap, x, y, rot):
@@ -648,10 +1037,23 @@ class _Repair:
         much track graze it relieves elsewhere (zynq_ad9364 R2 onto the
         DDR3_VREF via)."""
         by_net: Dict[int, float] = {}
-        for (bx0, by0, bx1, by1, net) in cap.pad_rects(x, y, rot):
-            for vx, vy, vnet, keepout in self.cap_vias[ref]:
+        vias = self.cap_vias[ref]
+        effs = self._via_effs(ref, cap, vias)
+        if effs is None:
+            for (bx0, by0, bx1, by1, net) in cap.pad_rects(x, y, rot):
+                for vx, vy, vnet, keepout in vias:
+                    if vnet == net:
+                        continue
+                    d = _point_to_rect_dist(vx, vy, (bx0, by0, bx1, by1))
+                    if d < keepout - EPS:
+                        by_net[vnet] = by_net.get(vnet, 0.0) + (keepout - d)
+            return by_net
+        for i, (bx0, by0, bx1, by1, net) in enumerate(cap.pad_rects(x, y, rot)):
+            row = effs[i]
+            for j, (vx, vy, vnet, _ko) in enumerate(vias):
                 if vnet == net:
                     continue
+                keepout = row[j]
                 d = _point_to_rect_dist(vx, vy, (bx0, by0, bx1, by1))
                 if d < keepout - EPS:
                     by_net[vnet] = by_net.get(vnet, 0.0) + (keepout - d)
@@ -670,11 +1072,30 @@ class _Repair:
         scalar baseline). Uses the per-cap pruned, same-side track list."""
         by_net: Dict[int, float] = {}
         segs = self.cap_segs[ref]
-        for (bx0, by0, bx1, by1, net) in cap.pad_rects(x, y, rot):
-            for x1, y1, x2, y2, snet, halfw, side in segs:
+        effs = self._seg_effs(ref, cap)
+        if effs is None:
+            for (bx0, by0, bx1, by1, net) in cap.pad_rects(x, y, rot):
+                for x1, y1, x2, y2, snet, halfw, side in segs:
+                    if snet == net:
+                        continue
+                    # cheap reject: the segment's bbox can't reach the pad rect
+                    if (min(x1, x2) > bx1 + halfw or max(x1, x2) < bx0 - halfw
+                            or min(y1, y2) > by1 + halfw
+                            or max(y1, y2) < by0 - halfw):
+                        continue
+                    d = _seg_to_rect_dist(x1, y1, x2, y2, (bx0, by0, bx1, by1))
+                    if d < halfw - EPS:
+                        by_net[snet] = by_net.get(snet, 0.0) + (halfw - d)
+            return by_net
+        # #725 active path: effs[i][j] IS the pair's keep-out, and the cheap
+        # bbox reject widens with it -- a reject left at the flat half width
+        # would silently drop the pairs this fix exists to charge.
+        for i, (bx0, by0, bx1, by1, net) in enumerate(cap.pad_rects(x, y, rot)):
+            row = effs[i]
+            for j, (x1, y1, x2, y2, snet, _hw, side) in enumerate(segs):
                 if snet == net:
                     continue
-                # cheap reject: the segment's bbox can't reach the pad rect
+                halfw = row[j]
                 if (min(x1, x2) > bx1 + halfw or max(x1, x2) < bx0 - halfw or
                         min(y1, y2) > by1 + halfw or max(y1, y2) < by0 - halfw):
                     continue
@@ -697,15 +1118,30 @@ class _Repair:
         Same-net pads are ignored (a shared via / touching same-net copper is
         fine)."""
         by_net: Dict[int, float] = {}
-        for (bx0, by0, bx1, by1, net) in cap.pad_rects(x, y, rot):
-            for (px0, py0, px1, py1, pnet, pside) in self.cap_foreign_pads[ref]:
+        fpads = self.cap_foreign_pads[ref]
+        effs = self._pad_effs(ref, cap)
+        if effs is None:
+            for (bx0, by0, bx1, by1, net) in cap.pad_rects(x, y, rot):
+                for (px0, py0, px1, py1, pnet, pside) in fpads:
+                    if pnet == net:
+                        continue
+                    if pside is not None and pside != cap.side:
+                        continue  # SMD pad on the other side
+                    gap = _rect_gap((bx0, by0, bx1, by1), (px0, py0, px1, py1))
+                    if gap < self.clearance - EPS:
+                        by_net[pnet] = by_net.get(pnet, 0.0) + (self.clearance - gap)
+            return by_net
+        for i, (bx0, by0, bx1, by1, net) in enumerate(cap.pad_rects(x, y, rot)):
+            row = effs[i]
+            for j, (px0, py0, px1, py1, pnet, pside) in enumerate(fpads):
                 if pnet == net:
                     continue
                 if pside is not None and pside != cap.side:
                     continue  # SMD pad on the other side
+                eff = row[j]
                 gap = _rect_gap((bx0, by0, bx1, by1), (px0, py0, px1, py1))
-                if gap < self.clearance - EPS:
-                    by_net[pnet] = by_net.get(pnet, 0.0) + (self.clearance - gap)
+                if gap < eff - EPS:
+                    by_net[pnet] = by_net.get(pnet, 0.0) + (eff - gap)
         return by_net
 
     def pad_penalty(self, ref, cap, x, y, rot):
@@ -770,14 +1206,22 @@ class _Repair:
             # every pad-pair gap >= the bbox gap; bboxes >= clearance apart
             # means the shortfall is exactly 0 <= base + EPS -- skip the
             # pairwise scan (the dominant cost of the candidate sweep).
+            # #725: the prescreen is a SKIP, so it must widen with the pair's
+            # requirement -- left at the flat scalar it silently drops exactly
+            # the pairs a pad override / netclass / dru rule raises. Bounded by
+            # the two movers' OWN maxima, never a board-wide one: this runs per
+            # candidate pose.
             if cand_bbox is None:
                 cand_bbox = cap.pad_bbox(x, y, rot)
-            if _rect_gap(cand_bbox, other.pad_bbox()) >= self.clearance:
+            screen = self.clearance if self._floors is None else max(
+                self.clearance, cap.max_floor, other.max_floor)
+            if _rect_gap(cand_bbox, other.pad_bbox()) >= screen:
                 continue
             if cand_pads is None:
                 cand_pads = cap.pad_rects(x, y, rot)
             if _pad_pair_shortfall(cand_pads, other.pad_rects(),
-                                   self.clearance) > \
+                                   self.clearance,
+                                   self._pair_effs(ref, cap, other_ref, other)) > \
                     self.base_cap_pad.get(pair, 0.0) + EPS:
                 return True
         return False
@@ -812,7 +1256,7 @@ class _Repair:
         (#130) + same-side track (#278 PAD-SEGMENT) + component pad (#275
         PAD-PAD). Anything positive is a shipped DRC violation, so all three
         are violations to FIX, not just baselines to preserve."""
-        return (self.via_penalty(cap, x, y, rot, self.cap_vias[ref])
+        return (self.via_penalty(cap, x, y, rot, self.cap_vias[ref], ref=ref)
                 + self.seg_penalty(ref, cap, x, y, rot)
                 + self.pad_penalty(ref, cap, x, y, rot))
 
@@ -895,14 +1339,19 @@ def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
     print(f"BGAs: {', '.join(st.bga_refs) or '(none)'}  "
           f"fanout vias: {len(st.vias)}  "
           f"movable near-BGA caps: {len(st.caps)}")
+    # #725: the early returns carry the same key set as the full one, so a
+    # caller reading result['required'] / ['clearance_notes'] does not have to
+    # special-case a no-op board.
     if not st.vias:
         print("No vias on the board - run this AFTER bga_fanout.py.")
         return {'placements': [], 'resolved': [], 'unresolved': [],
-                'bga_refs': st.bga_refs}
+                'bga_refs': st.bga_refs, 'required': [],
+                'clearance_notes': list(st.clearance_notes)}
     if not st.caps:
         print("No movable caps near a BGA - nothing to do.")
         return {'placements': [], 'resolved': [], 'unresolved': [],
-                'bga_refs': st.bga_refs}
+                'bga_refs': st.bga_refs, 'required': [],
+                'clearance_notes': list(st.clearance_notes)}
 
     # Initial violators: any foreign-copper clearance shortfall (via #130,
     # track #278, pad #275) is a shipped DRC violation to fix.
@@ -927,10 +1376,18 @@ def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
                 continue
             rect = (p.global_x - p.size_x / 2, p.global_y - p.size_y / 2,
                     p.global_x + p.size_x / 2, p.global_y + p.size_y / 2)
+            # #725: graded at the pair's REAL requirement, like everything
+            # else. `keepout` is the prune over-reach, so re-form the pair's
+            # keep-out from the via's radius. A locked fiducial's keep-clear
+            # override is exactly the case this warning exists to surface, and
+            # priced flat it under-reported it.
+            pfl = st.pad_floor(p)
             for vx, vy, vnet, keepout in st.vias:
                 if vnet == p.net_id:
                     continue
-                if _point_to_rect_dist(vx, vy, rect) < keepout - EPS:
+                ko = (keepout - st._item_reach(st.via_floor(vnet))
+                      + st.via_required(pfl, vnet))
+                if _point_to_rect_dist(vx, vy, rect) < ko - EPS:
                     locked_hits.append((ref, p.pad_number, vx, vy))
     if locked_hits:
         print(f"WARNING: {len(locked_hits)} foreign via(s) inside LOCKED parts' pad "
@@ -1098,10 +1555,19 @@ def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
           f"{len(unresolved)} unresolved.")
     if unresolved:
         print(f"  Unresolved (need manual attention): {', '.join(sorted(unresolved))}")
+    # #725: disclose what was graded ABOVE the flat --clearance, and why.
+    # Printed from the ENGINE so the CLI and the GUI plugin both inherit it.
+    required = st.required_rows({n.net_id: n.name for n in pcb_data.nets.values()})
+    _clause = format_required_clause({'required': required})
+    if _clause:
+        print(f"  above the {clearance}mm floor: {_clause}")
+    for _note in st.clearance_notes:
+        print(f"  pad clearance: {_note}")
 
     return {'placements': placements, 'resolved': resolved,
             'unresolved': unresolved, 'bga_refs': st.bga_refs,
-            'via_moves': via_moves, 'new_segments': new_segs}
+            'via_moves': via_moves, 'new_segments': new_segs,
+            'required': required, 'clearance_notes': list(st.clearance_notes)}
 
 
 def _point_in_poly(px, py, poly) -> bool:
@@ -1195,57 +1661,109 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
     # missing layer gate rejected every candidate: the connector necessarily
     # starts at the old via position, inside the grazed cap's keep-out, but
     # only the VIA barrel -- not an inner-layer connector -- conflicts there).
+    # #725: every requirement below resolves through st's own resolvers, so the
+    # nudger and the grader cannot disagree. `getattr` throughout -- tests pass
+    # a duck-typed _FakeSt that carries none of this, and must grade flat.
+    _req = getattr(st, 'required', None)
+    _via_req = getattr(st, 'via_required', None)
+    _pad_fl = getattr(st, 'pad_floor', None)
+    _via_fl = getattr(st, 'via_floor', None)
+    _seg_fl = getattr(st, 'seg_floor', None)
+
+    def req(fa, fb):
+        return clearance if _req is None else _req(fa, fb)
+
+    def via_req(pad_floor, via_net):
+        return clearance if _via_req is None else _via_req(pad_floor, via_net)
+
+    def pad_fl(p):
+        return None if _pad_fl is None else _pad_fl(p)
+
+    def via_fl(net):
+        return None if _via_fl is None else _via_fl(net)
+
+    def seg_fl(net, layer):
+        return None if _seg_fl is None else _seg_fl(net, layer)
+
+    def cap_floors_of(cap, rects):
+        """This cap's per-pad floors, index-aligned with `rects` -- or None,
+        which grades flat. Tests drive this function with a duck-typed cap that
+        carries neither the attribute nor a matching length."""
+        pf = getattr(cap, 'pad_floors', None)
+        return pf if (pf is not None and len(pf) == len(rects)) else None
+
+    # `all_cap_rects` is function-local, so it CAN carry the pad's floor.
     all_cap_rects = []
     for ref, cap in st.caps.items():
         fp = pcb_data.footprints.get(ref)
         cl = getattr(fp, 'layer', 'F.Cu') if fp is not None else 'F.Cu'
-        for (bx0, by0, bx1, by1, net) in cap.pad_rects(cap.x, cap.y, cap.rot):
-            all_cap_rects.append((bx0, by0, bx1, by1, net, cl))
+        _rects = cap.pad_rects(cap.x, cap.y, cap.rot)
+        pf = cap_floors_of(cap, _rects)
+        for i, (bx0, by0, bx1, by1, net) in enumerate(_rects):
+            all_cap_rects.append((bx0, by0, bx1, by1, net, cl,
+                                  None if pf is None else pf[i]))
+
+    # Flatten the board's pads ONCE, in pads_by_net iteration order, resolving
+    # each pad's floor and drill capsule here instead of inside the 16-angle x
+    # 12-radius sweep below. Strictly cheaper than the previous per-call walk.
+    board_pads = []
+    for _pads in pcb_data.pads_by_net.values():
+        for p in _pads:
+            if getattr(p, 'component_ref', None) in st.caps:
+                continue  # movable caps handled by the final rects above
+            cap_ = pad_drill_capsule(p) if (p.drill and p.drill > 0) else None
+            board_pads.append((p, pad_fl(p), not _pad_has_no_copper(p), cap_))
 
     def valid_via_pos(v, nx, ny):
         vr = (v.size or 0.5) / 2.0
+        vfl = via_fl(v.net_id)
         # never off the board / into a cutout / inside the edge margin (#370 B3)
         if not edge_ok_point(nx, ny, vr):
             return False
-        for (bx0, by0, bx1, by1, net, _cl) in all_cap_rects:
+        for (bx0, by0, bx1, by1, net, _cl, pfl) in all_cap_rects:
             # via barrel spans all layers: no layer gate here
             if net != v.net_id and _point_to_rect_dist(
-                    nx, ny, (bx0, by0, bx1, by1)) < vr + clearance:
+                    nx, ny, (bx0, by0, bx1, by1)) < vr + via_req(pfl, v.net_id):
                 return False
-        for pads in pcb_data.pads_by_net.values():
-            for p in pads:
-                if getattr(p, 'component_ref', None) in st.caps:
-                    continue  # movable caps handled by final rects above
-                # rotation/shape-aware pad copper distance (#370 B3, #356
-                # class: the axis-aligned size_x/size_y rect under-blocked
-                # rotated pads). NPTH pads carry no copper -- drill-only.
-                if (p.net_id != v.net_id and not _pad_has_no_copper(p)
-                        and point_to_pad_distance(nx, ny, p) < vr + clearance):
+        for p, pfl, has_cu, cap_ in board_pads:
+            # rotation/shape-aware pad copper distance (#370 B3, #356
+            # class: the axis-aligned size_x/size_y rect under-blocked
+            # rotated pads). NPTH pads carry no copper -- drill-only.
+            if (p.net_id != v.net_id and has_cu
+                    and point_to_pad_distance(nx, ny, p) < vr + req(pfl, vfl)):
+                return False
+            if cap_ is not None:
+                # slot/offset-aware drill capsule (net-INDEPENDENT floor, so
+                # deliberately NOT #725-resolved -- see npth_clr above)
+                (c1x, c1y), (c2x, c2y), prad = cap_
+                if _point_to_seg_dist(nx, ny, c1x, c1y, c2x, c2y) < \
+                        (v.drill or 0.3) / 2.0 + prad + H2H_PAD:
                     return False
-                if p.drill and p.drill > 0:
-                    # slot/offset-aware drill capsule (net-INDEPENDENT floor)
-                    (c1x, c1y), (c2x, c2y), prad = pad_drill_capsule(p)
-                    if _point_to_seg_dist(nx, ny, c1x, c1y, c2x, c2y) < \
-                            (v.drill or 0.3) / 2.0 + prad + H2H_PAD:
-                        return False
         for ov in pcb_data.vias:
             if ov is v:
                 continue
             d = math.hypot(nx - ov.x, ny - ov.y)
-            if ov.net_id != v.net_id and d < vr + (ov.size or 0.5) / 2.0 + clearance:
+            if ov.net_id != v.net_id and d < vr + (ov.size or 0.5) / 2.0 + \
+                    req(vfl, via_fl(ov.net_id)):
                 return False
             if d < (v.drill or 0.3) / 2.0 + (ov.drill or 0.3) / 2.0 + H2H_VIA:
                 return False
         for s in pcb_data.segments:
             if s.net_id == v.net_id:
                 continue
-            if _point_to_seg_dist(nx, ny, s.start_x, s.start_y,
-                                  s.end_x, s.end_y) < vr + s.width / 2.0 + clearance:
+            if _point_to_seg_dist(nx, ny, s.start_x, s.start_y, s.end_x, s.end_y) \
+                    < vr + s.width / 2.0 + req(vfl, seg_fl(s.net_id, s.layer)):
                 return False
         return True
 
     def connector_clear(net_id, layer, width, sx, sy, ex, ey):
         hw = width / 2.0
+        # The connector is a TRACK on `layer`, so it resolves like one. Note
+        # this honours netclasses and .kicad_dru LAYER rules, but not #549
+        # track-scoped rules, which live in a channel PadClearanceModel does
+        # not carry (check_drc.read_board_track_clearances); under-blocking a
+        # geometric connector that is separately DRC'd is the safe direction.
+        cfl = seg_fl(net_id, layer)
         # board edge / cutouts + NPTH drill holes at their floor (#370 B3):
         # a connector is drawn geometrically, not routed, so it must gate
         # against Edge.Cuts and copper-less holes itself.
@@ -1254,33 +1772,33 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
         if _seg_foreign_hole_dist(pcb_data, net_id, sx, sy, ex, ey) < \
                 npth_clr + hw - 1e-4:
             return False
-        for (bx0, by0, bx1, by1, net, cl) in all_cap_rects:
+        for (bx0, by0, bx1, by1, net, cl, pfl) in all_cap_rects:
             if cl != layer:
                 continue  # cap pads only exist on the cap's own side
             if net != net_id and _seg_to_rect_dist(
-                    sx, sy, ex, ey, (bx0, by0, bx1, by1)) < hw + clearance:
+                    sx, sy, ex, ey, (bx0, by0, bx1, by1)) < hw + req(pfl, cfl):
                 return False
-        for pads in pcb_data.pads_by_net.values():
-            for p in pads:
-                if getattr(p, 'component_ref', None) in st.caps or p.net_id == net_id:
-                    continue
-                if not _pad_on_layer(p, layer):
-                    continue
-                if _pad_has_no_copper(p):
-                    continue  # NPTH: no copper; the hole check above covers it
-                # rotation-aware pad rect (#370 B3): rotate the segment into
-                # the pad's frame so a tilted pad is tested against its true
-                # rectangle (distance is rotation-invariant).
-                rx1, ry1 = into_pad_frame_point(sx, sy, p)
-                rx2, ry2 = into_pad_frame_point(ex, ey, p)
-                d, _ = segment_to_rect_distance(
-                    rx1, ry1, rx2, ry2, p.global_x, p.global_y,
-                    p.size_x / 2.0, p.size_y / 2.0)
-                if d < hw + clearance:
-                    return False
+        for p, pfl, has_cu, _cap in board_pads:
+            if p.net_id == net_id:
+                continue
+            if not _pad_on_layer(p, layer):
+                continue
+            if not has_cu:
+                continue  # NPTH: no copper; the hole check above covers it
+            # rotation-aware pad rect (#370 B3): rotate the segment into
+            # the pad's frame so a tilted pad is tested against its true
+            # rectangle (distance is rotation-invariant).
+            rx1, ry1 = into_pad_frame_point(sx, sy, p)
+            rx2, ry2 = into_pad_frame_point(ex, ey, p)
+            d, _ = segment_to_rect_distance(
+                rx1, ry1, rx2, ry2, p.global_x, p.global_y,
+                p.size_x / 2.0, p.size_y / 2.0)
+            if d < hw + req(pfl, cfl):
+                return False
         for ov in pcb_data.vias:
             if ov.net_id != net_id and _point_to_seg_dist(
-                    ov.x, ov.y, sx, sy, ex, ey) < (ov.size or 0.5) / 2.0 + hw + clearance:
+                    ov.x, ov.y, sx, sy, ex, ey) < (ov.size or 0.5) / 2.0 + hw \
+                    + req(cfl, via_fl(ov.net_id)):
                 return False
         for s2 in pcb_data.segments:
             if s2.net_id == net_id or s2.layer != layer:
@@ -1292,19 +1810,26 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
                     _point_to_seg_dist(ex, ey, s2.start_x, s2.start_y, s2.end_x, s2.end_y),
                     _point_to_seg_dist(s2.start_x, s2.start_y, sx, sy, ex, ey),
                     _point_to_seg_dist(s2.end_x, s2.end_y, sx, sy, ex, ey))
-            if d < hw + s2.width / 2.0 + clearance:
+            if d < hw + s2.width / 2.0 + req(cfl, seg_fl(s2.net_id, s2.layer)):
                 return False
         return True
 
     for ref in sorted(unresolved):
         cap = st.caps[ref]
         rects = cap.pad_rects(cap.x, cap.y, cap.rot)
+        # #725: this predicate MUST match via_penalty's, which is why both go
+        # through st.via_required. Left at the flat scalar while the grader
+        # resolves the requirement, a cap reported unresolved because of a
+        # raised via would yield an EMPTY offender list -- the pass would print
+        # nothing and report the cap unresolved forever.
+        pfls = cap_floors_of(cap, rects)
         offenders = []
         for v in pcb_data.vias:
             vr = (v.size or 0.5) / 2.0
-            for (bx0, by0, bx1, by1, net) in rects:
+            for i, (bx0, by0, bx1, by1, net) in enumerate(rects):
                 if v.net_id != net and _point_to_rect_dist(
-                        v.x, v.y, (bx0, by0, bx1, by1)) < vr + clearance - EPS:
+                        v.x, v.y, (bx0, by0, bx1, by1)) < vr + via_req(
+                            None if pfls is None else pfls[i], v.net_id) - EPS:
                     offenders.append(v)
                     break
         for v in offenders:
@@ -1380,6 +1905,10 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
                     start_x=old[0], start_y=old[1], end_x=nx, end_y=ny,
                     width=w, layer=layer, net_id=v.net_id))
             v.x, v.y = nx, ny
+            # w2[2]/w2[3] (net and keep-out) are carried through unchanged --
+            # a moved via keeps its requirement. #725: this rebuild gives the
+            # list a NEW identity, which is what makes _Repair's per-cap
+            # required-clearance memos rebuild instead of going stale.
             st.vias = [(nx, ny, w2[2], w2[3]) if (abs(w2[0] - old[0]) < 1e-6 and
                                                   abs(w2[1] - old[1]) < 1e-6) else w2
                        for w2 in st.vias]

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -203,12 +203,20 @@ class _Cap:
                 # (legality._pad_carries_copper, the watchy measurement).
                 # Zero floor, appended unconditionally so the index alignment
                 # the loose filter buys is preserved.
-                fl = (model.pad_floor(p) if _pad_carries_copper(p)
-                      else PadFloor(0.0, 0.0, None))
+                # A pad that carries no copper is graded FLAT, whole stop --
+                # not merely stripped of its own override. check_drc does not
+                # grade such a pad at all, so letting the PARTNER's netclass
+                # through pair() would charge a keep-out that does not exist,
+                # which is the same defect as the off-layer phantom below.
+                # The empty layer set is the marker the eff builders key on;
+                # a real copper pad always resolves at least one layer.
+                carries = _pad_carries_copper(p)
+                fl = model.pad_floor(p) if carries else PadFloor(0.0, 0.0, None)
                 self.pad_floors.append(fl)
                 from check_drc import pad_copper_layers
                 self.pad_layers.append(
-                    frozenset(pad_copper_layers(p, model.board_copper)))
+                    frozenset(pad_copper_layers(p, model.board_copper))
+                    if carries else frozenset())
                 mf = model.max_floor(fl)
                 if mf > self.max_floor:
                     self.max_floor = mf
@@ -469,7 +477,8 @@ class _Repair:
             t = (s.start_x, s.start_y, s.end_x, s.end_y, s.net_id,
                  s.width / 2.0 + self._item_reach(fl), side)
             self.segments.append(t)
-            self._seg_layer_by_id[id(t)] = s.layer
+            if self._floors is not None:
+                self._seg_layer_by_id[id(t)] = s.layer
             if fl is not None:
                 self._seg_floor_by_id[id(t)] = fl
 
@@ -901,6 +910,21 @@ class _Repair:
             return self.clearance
         return self._floors.pair(fa, fb)
 
+    def _cap_pad_layers(self, cap):
+        """This cap's per-pad copper layer sets, or None when unavailable (a
+        duck-typed cap, or a board that declares no copper layers at all -- in
+        which case NO pair may be scoped by layer, or every one of them would
+        fall back to the flat scalar and under-block)."""
+        pl = getattr(cap, 'pad_layers', None)
+        if pl is None or len(pl) != len(getattr(cap, 'pad_floors', ())):
+            return None
+        return pl if self._all_cu else None
+
+    @staticmethod
+    def _flat_pad(cap_layers, i):
+        """True when cap pad `i` carries no copper and must be graded flat."""
+        return cap_layers is not None and not cap_layers[i]
+
     def _cap_floors_ok(self, cap):
         """True when this cap carries a usable, index-aligned floor list. A
         _Cap built without the model (or by a test) grades flat."""
@@ -918,8 +942,10 @@ class _Repair:
         if rec is not None and rec[0] is src:
             return rec[1]
         by_id = self._fp_floor_by_id
-        rows = [[self._pair_or_flat(fa, by_id.get(id(t))) for t in src]
-                for fa in cap.pad_floors]
+        cl = self._cap_pad_layers(cap)
+        rows = [[self.clearance] * len(src) if self._flat_pad(cl, i)
+                else [self._pair_or_flat(fa, by_id.get(id(t))) for t in src]
+                for i, fa in enumerate(cap.pad_floors)]
         self._cap_pad_eff[ref] = (src, rows)
         return rows
 
@@ -944,9 +970,7 @@ class _Repair:
         # change would move caps for a non-violation. Charging it flat leaves
         # the pre-existing phantom exactly as it was; removing it altogether is
         # a separate fix to the side collapse, filed rather than folded in.
-        cap_layers = getattr(cap, 'pad_layers', None)
-        if cap_layers is not None and len(cap_layers) != len(cap.pad_floors):
-            cap_layers = None      # a duck-typed cap; grade flat
+        cap_layers = self._cap_pad_layers(cap)
         seg_layers = [self._seg_layer_by_id.get(id(t)) for t in src]
 
         def eff(fa, mine, j):
@@ -977,13 +1001,19 @@ class _Repair:
         # convention, and re-deriving would mis-price it silently. Absent ->
         # graded flat, i.e. v[3] is used as-is.
         by_id = self._via_radius_by_id
+        cl = self._cap_pad_layers(cap)
         rows = []
-        for fa in cap.pad_floors:
+        for i, fa in enumerate(cap.pad_floors):
+            flat = self._flat_pad(cl, i)
             row = []
             for v in vias:
                 rec = by_id.get(id(v))
-                row.append(v[3] if rec is None
-                           else rec[1] + self.via_required(fa, v[2]))
+                if rec is None:
+                    row.append(v[3])
+                elif flat:
+                    row.append(rec[1] + self.clearance)
+                else:
+                    row.append(rec[1] + self.via_required(fa, v[2]))
             rows.append(row)
         self._cap_via_eff[ref] = (vias, rows)
         return rows
@@ -1004,15 +1034,19 @@ class _Repair:
                                  or (rows and len(rows[0]) != len(other.pad_floors))):
             rows = None
         if rows is None:
-            rows = [[self._pair_or_flat(fa, fb) for fb in other.pad_floors]
-                    for fa in cap.pad_floors]
+            mine, theirs = self._cap_pad_layers(cap), self._cap_pad_layers(other)
+            rows = [[self.clearance
+                     if (self._flat_pad(mine, i) or self._flat_pad(theirs, j))
+                     else self._pair_or_flat(fa, fb)
+                     for j, fb in enumerate(other.pad_floors)]
+                    for i, fa in enumerate(cap.pad_floors)]
             self._cap_pair_eff[key] = rows
         return rows
 
     def required_rows(self, net_names=None, limit=200):
         """Rows `[cap_ref, '<kind> <partner>', mm, source]` for every pair this
         pass actually CHARGED at a requirement above the flat scalar, at the
-        caps' current poses.
+        SEED pose or the final one (see `both` below for why both).
 
         Same 4-column shape as legality.grade_pad_legality's 'required', so
         legality.format_required_clause renders it unchanged. `[]` when inert.

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -425,15 +425,23 @@ class _Repair:
         # The RADIUS, keyed on the tuple's identity. _via_effs has to strip the
         # over-reach back off element 3, and deriving the radius arithmetically
         # would silently mis-price a tuple a test assigned wholesale with a
-        # different keep-out convention. Absent from this map -> graded flat,
-        # which is the same fallback _pad_effs and _seg_effs already take.
-        self._via_radius_by_id: Dict[int, float] = {}
+        # different keep-out convention. Absent from this map -> graded at the
+        # tuple's own keep-out slot verbatim, i.e. exactly as injected.
+        #
+        # The VALUE holds the tuple as well as the radius, so the map itself
+        # keeps every registered tuple alive. Unlike the pad/segment floor maps
+        # -- which are filled only in __init__, where self.foreign_pads and
+        # self.segments hold their tuples -- this one gains entries later, when
+        # nudge_vias_for_unresolved relocates a via. A tuple that died while its
+        # id entry lived would hand a recycled id ANOTHER via's radius,
+        # silently.
+        self._via_radius_by_id: Dict[int, Tuple[tuple, float]] = {}
         for v in pcb_data.vias:
             size = v.size if v.size and v.size > 0 else default_via_size
             t = (v.x, v.y, v.net_id,
                  size / 2.0 + self._item_reach(self._via_floor_for(v.net_id)))
             self.vias.append(t)
-            self._via_radius_by_id[id(t)] = size / 2.0
+            self._via_radius_by_id[id(t)] = (t, size / 2.0)
 
         # --- avoidance: foreign-net tracks on the cap's own side ---
         # Fanout escapes can land on the bottom (cap) side; attraction could
@@ -973,8 +981,9 @@ class _Repair:
         for fa in cap.pad_floors:
             row = []
             for v in vias:
-                r = by_id.get(id(v))
-                row.append(v[3] if r is None else r + self.via_required(fa, v[2]))
+                rec = by_id.get(id(v))
+                row.append(v[3] if rec is None
+                           else rec[1] + self.via_required(fa, v[2]))
             rows.append(row)
         self._cap_via_eff[ref] = (vias, rows)
         return rows
@@ -2044,9 +2053,21 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
             # a moved via keeps its requirement. #725: this rebuild gives the
             # list a NEW identity, which is what makes _Repair's per-cap
             # required-clearance memos rebuild instead of going stale.
-            st.vias = [(nx, ny, w2[2], w2[3]) if (abs(w2[0] - old[0]) < 1e-6 and
-                                                  abs(w2[1] - old[1]) < 1e-6) else w2
-                       for w2 in st.vias]
+            _radii = getattr(st, '_via_radius_by_id', None)
+            _rebuilt = []
+            for w2 in st.vias:
+                if (abs(w2[0] - old[0]) < 1e-6 and abs(w2[1] - old[1]) < 1e-6):
+                    moved = (nx, ny, w2[2], w2[3])
+                    # A relocated via is a NEW tuple, so it would drop out of
+                    # the radius map and be graded at its keep-out slot -- the
+                    # prune OVER-reach -- instead of the pair's requirement.
+                    # Carry the radius across; the via did not change size.
+                    if _radii is not None and id(w2) in _radii:
+                        _radii[id(moved)] = (moved, _radii[id(w2)][1])
+                    _rebuilt.append(moved)
+                else:
+                    _rebuilt.append(w2)
+            st.vias = _rebuilt
             via_moves.append((old[0], old[1],
                               {'x': nx, 'y': ny, 'size': v.size, 'drill': v.drill,
                                'layers': v.layers, 'net_id': v.net_id}))

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -189,9 +189,10 @@ class _Cap:
         # netclass, a .kicad_dru rule or a pad override exists. Gated on the
         # model, as pad_floors legitimately is, this would be inert on exactly
         # the boards carrying the most phantom: rp2350 declares none of the
-        # three, is 6 copper layers, and 2342 of its 4331 pruned pad x track
+        # three, is 6 copper layers, and 2342 of its 4468 pruned pad x track
         # pairs are off-layer, carrying 4.6685mm of phantom graze against
-        # 0.0142mm of real. `board_copper` falls back to the model's copy only
+        # 0.0142mm of real. (Both figures count same-net pairs; excluding them
+        # it is 2238 of 4331. Mixing the two conventions is easy and wrong.) `board_copper` falls back to the model's copy only
         # so a caller passing a model and nothing else still resolves layers.
         _cu = list(board_copper if board_copper is not None
                    else (getattr(model, 'board_copper', None) or ()))
@@ -406,7 +407,35 @@ class _Repair:
         # intersecting with all-copper reproduces that exactly (blind vias
         # included). Never None here -- PadClearanceModel.pair does
         # `fb.layers or ()`, and an EMPTY shared set discards every dru rule.
-        self._all_cu = frozenset(pcb_data.board_info.copper_layers or ())
+        # #731: resolved through the SAME three-level fallback check_drc's
+        # run_drc uses (check_drc.py: filter to .Cu -> the layers segments
+        # actually sit on -> ['F.Cu','B.Cu']), because this set is what decides
+        # whether layer scoping is on at all. A board whose `(layers ...)`
+        # stanza yields no copper -- kicad_parser's regex has produced that in
+        # the field, see its `In1(GND).Cu` note -- would otherwise switch
+        # scoping off and fall back to the 'F'/'B' side collapse. That is NOT
+        # the safe direction it looks like: check_drc still expands a `*.Cu`
+        # pad over the segment-derived layers and grades it, while the side
+        # collapse DROPS every B.Cu and inner track a through-hole cap pad
+        # shares copper with -- an UNDER-block, and the very mirror bug #731
+        # exists to fix. Measured on rp2350 with the copper list cleared and
+        # cap pads made through-hole: 280 pairs check_drc grades that the
+        # side-collapse fallback ignores, byte-identical to the pre-#731 count.
+        # sorted(), not list(set(...)): string hashing is randomized per
+        # process and this list feeds pad-layer expansion (the same reason
+        # check_drc sorts it).
+        _cu = [l for l in (pcb_data.board_info.copper_layers or [])
+               if str(l).endswith('.Cu')]
+        if not _cu:
+            _cu = sorted({s.layer for s in pcb_data.segments
+                          if (s.layer or '').endswith('.Cu')})
+        if not _cu:
+            _cu = ['F.Cu', 'B.Cu']
+        self._all_cu = frozenset(_cu)
+        # The ORDERED list is what pad-layer expansion consumes; `_all_cu` is
+        # the membership test. Keeping both means `*.Cu` never resolves through
+        # a set whose iteration order varies run to run.
+        self._all_cu_ordered = list(_cu)
         self._via_floor: Dict[int, PadFloor] = {}
         self._seg_floor: Dict[Tuple[int, str], PadFloor] = {}
         # #617: KiCad's copper-to-hole rule is the BOARD's `min_hole_clearance`
@@ -577,7 +606,7 @@ class _Repair:
             is_cap = (ref.startswith(self._cap_prefixes) and n_copper <= 2
                       and ref not in locked)
             if is_cap:
-                cap = _Cap(fp, lb, self._floors, self._all_cu)
+                cap = _Cap(fp, lb, self._floors, self._all_cu_ordered)
                 if self._near_any(cap.rect(), bga_bboxes, near_margin):
                     self.caps[ref] = cap
                     continue
@@ -728,11 +757,17 @@ class _Repair:
             # per-pad half is applied in _seg_effs, and matters only for a cap
             # whose pads differ (an SMD pad beside a through-hole one).
             #
-            # When scoping is off, fall back to the OLD side collapse rather
-            # than keeping everything: check_drc still layer-scopes such a
-            # board (its routing_layers falls back to the segment-derived set,
-            # then to ['F.Cu','B.Cu']), so the placer must stay on the
-            # over-block side, not stop filtering altogether.
+            # The `_union is None` arm is a fallback for a cap that offers no
+            # copper pad at all -- cap detection admits n_copper == 0 (a
+            # paste-only C-prefixed part). Such a cap has an empty pad_rects,
+            # so NOTHING it keeps is ever graded and the arm cannot change an
+            # outcome; it keeps the old side filter purely so the pruned list
+            # stays the size it always was. It is NOT reachable for an empty
+            # copper list any more: `_all_cu` above resolves through
+            # check_drc's own three-level fallback and is never empty, which
+            # is deliberate -- falling back to the side collapse there would
+            # DROP the B.Cu and inner tracks a through-hole cap pad shares
+            # copper with, an under-block (measured: 280 pairs on rp2350).
             _pl, _union = self._cap_seg_scope(cap)
             for seg in self.segments:
                 layer = seg[6]
@@ -1000,8 +1035,16 @@ class _Repair:
         pl = self._cap_pad_layers(cap)
         if not pl:
             return None, None
-        u = frozenset().union(*pl)
-        return (pl, u) if u else (None, None)
+        # An EMPTY union means every pad of this cap is copper-LESS (an NPTH
+        # keep-out). It must NOT collapse to "scoping off" (#731 review): that
+        # switched the guard off for the TRACK channel alone, so `_flat_pad`
+        # read False and those pads were charged at the partner's netclass --
+        # reinstating, in one channel, exactly the phantom 4bbfa4de removed
+        # from every other. Measured on a staged orangecrab with R17's pads set
+        # to np_thru_hole at a Default class of 0.4: 52 track cells charged at
+        # 0.4 while the pad channel correctly charged the flat 0.1. check_drc
+        # grades none of them -- it skips a copper-less pad outright.
+        return pl, frozenset().union(*pl)
 
     def _seg_shares(self, layer, mine):
         """True when a track on `layer` can touch a cap pad whose copper layer
@@ -1090,10 +1133,12 @@ class _Repair:
                     # resolver OUT of the inert path entirely -- _pair_or_flat
                     # is not called, so an inert board cannot start consulting
                     # a model, and an injected tuple grades exactly as
-                    # injected. (The arithmetic round-trip happens to be
-                    # float-exact on every cell measured -- 0 of 1063 on
-                    # rp2350 -- so this is about the call, not about the
-                    # rounding.)
+                    # injected. NB this is about the CALL, not the
+                    # rounding: the arithmetic round-trip turns out to be
+                    # float-exact everywhere measured (0 of rp2350's 1063
+                    # segment round-trips DIFFER, and 0 of orangecrab's 618),
+                    # which is precisely why an equality assertion cannot tell
+                    # the two forms apart and the test spies the call instead.
                     row.append(t[5])
                 elif flat_pad:
                     row.append(halves[j] + self.clearance)
@@ -1401,8 +1446,10 @@ class _Repair:
         segs = self.cap_segs[ref]
         effs = self._seg_effs(ref, cap)
         if effs is None:
-            # Duck-typed cap only (#731): a real _Cap always offers pads, so it
-            # always gets a matrix. There is no layer to gate on here, and an
+            # No matrix: a duck-typed cap, or a real _Cap with no copper pad
+            # at all (cap detection admits n_copper == 0, e.g. a paste-only
+            # C-prefixed part -- whose pad_rects is empty, so this loop does
+            # nothing either way). There is no layer to gate on here, and an
             # injected tuple grades exactly as injected.
             for (bx0, by0, bx1, by1, net) in cap.pad_rects(x, y, rot):
                 for x1, y1, x2, y2, snet, halfw, _layer in segs:

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -2402,48 +2402,67 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
         if not edge_ok_point(nx, ny, vr):
             return False
         # #737: the relocated via's COPPER against copper-less (NPTH) holes.
-        # This function had no such test at all. Its only drilled-pad gate is
-        # the DRILL-to-drill one below, which measures the DRILL, so it covered
-        # the annular ring only while
+        # This function had no such test. Its only drilled-pad gate is the
+        # DRILL-to-drill one below, which measures the DRILL, so it covered the
+        # annular ring only while
         #
-        #     ring = (size - drill) / 2 <= H2H_PAD - npth_clr
+        #     ring = (size - drill) / 2 <= H2H_PAD - clearance
         #
-        # -- 0.25 at the fab floor, but only 0.20 at the shipped --clearance
-        # 0.25, and 0 at clearance >= 0.45. Past that the pass parked ring
-        # copper inside a mounting hole's keep-out, and this pass WRITES the
-        # via (placement/writer.py, and the plugin's pcbnew mirror). Measured
-        # on a rig at --clearance 0.1: a 1.4/0.3 via relocated to 0.05mm of
-        # copper-to-hole-wall gap, which check_drc reports as a via-hole
-        # violation of exactly that.
+        # -- 0.20 at the shipped --clearance 0.25, and 0 at clearance >= 0.45.
+        # Past that the pass parked ring copper inside a mounting hole's
+        # keep-out, and this pass WRITES the via (placement/writer.py, and the
+        # plugin's pcbnew mirror). Measured at --clearance 0.25: a 1.4/0.3 via
+        # relocated to 0.150mm of copper-to-hole-wall gap, which check_drc's
+        # own via arm of this rule reports as `via-hole ... 0.100mm`.
         #
-        # Same helper, same floor, same own-net exemption and the same 1e-4 as
-        # connector_clear's gate below, so the two sibling validators cannot
-        # disagree about which holes exist or what one costs -- and the gate
-        # order in the two now reads alike (edge, hole, cap rects, board pads,
-        # vias, segments). `board_pads` was the cheaper source and is the wrong
-        # one: it drops the pads of movable caps, which the helper keeps. That
-        # buys AGREEMENT between the siblings, not truth -- both read pre-move
-        # pad coordinates, so neither is right about a cap already relocated.
+        # THE FLOOR IS `clearance`, NOT `npth_clr` -- deliberately NOT the
+        # sibling's, and that asymmetry is the point rather than an oversight.
+        # `npth_clr` is `max(clearance, NPTH_TO_TRACK_CLEARANCE)`: a routing
+        # policy for TRACKS, which is what connector_clear gates. check_drc
+        # grades a VIA against a plain NPTH hole at `clearance`
+        # (`kicad_req = req_clr if req_clr > npth_clr else clearance`), and
+        # says why: charging a via the track floor "invents items kicad-cli
+        # never reports" (crkbd, 7 phantoms). obstacle_map stamps the same
+        # asymmetry -- a plain NPTH is a track keep-out, not a via-copper one.
+        #
+        # Charging `npth_clr` here was measured to COST THE REPAIR rather than
+        # merely cost search room: at --clearance 0.1 it refuses a landing
+        # 0.150mm off the hole wall that check_drc grades CLEAN, and the cap
+        # then keeps the #130 pad-via graze this pass exists to remove. That is
+        # exactly the failure obstacle_map.resolve_hole_clearance names for
+        # this function by name -- an all-or-nothing repair whose one clearing
+        # candidate must not be refused -- and the same balance #617 struck for
+        # the connector gate. At --clearance >= 0.20 the two floors are equal,
+        # so this only ever differs below the fab floor; the CLI's own --help
+        # example is --clearance 0.1, and the GUI control's minimum is 0.05.
+        #
+        # Same helper, same own-net exemption and the same 1e-4 as
+        # connector_clear's gate below, so the two cannot disagree about which
+        # holes EXIST -- only about what one costs a track versus a via. The
+        # gate order now reads alike in both (edge, hole, cap rects, board
+        # pads, vias, segments). `board_pads` was the cheaper source and the
+        # wrong one: it drops the pads of movable caps, which the helper keeps.
+        # That buys AGREEMENT between the siblings rather than truth -- both
+        # read pre-move pad coordinates, so neither is right about a cap this
+        # pass has already relocated, and `all_cap_rects` above is post-move
+        # while this hole set is pre-move.
+        #
         # A degenerate segment is the point case: _seg_capsule_axis_dist guards
         # L2 == 0 and its crossing test is strict, so a zero-length segment
         # cannot report a spurious crossing.
         #
-        # The drill test below stays net-INDEPENDENT and keeps its own floor:
+        # The drill test below keeps its own floor and its net-independence:
         # drill-to-drill is a machine constraint, this is an etch constraint,
-        # and check_drc's via-hole arm makes the same own-net exemption
-        # (check_drc.py, `if via.net_id == hnet: continue`).
+        # and check_drc's via arm makes the same own-net exemption.
         #
         # KNOWN GAP, deliberately not closed here, exactly as at the cap
-        # keep-out site above: neither this gate nor the sibling honours the
-        # hole pad's OWN `local_clearance`, which check_drc does honour, so
-        # both under-block by `lc - npth_clr` on such a pad. That is #730 --
-        # a wrong VALUE, where this is a missing GATE -- and closing it here
-        # would move a number #730 needs to move in one place.
-        #
-        # NOT a reversal of #617. #617 measured RAISING this pass's hole floor
-        # to a board's DECLARED min_hole_clearance and refused it; the floor
-        # here is still the flat npth_clr, deliberately NOT st.npth_floor.
-        if _seg_foreign_hole_dist(pcb_data, v.net_id, nx, ny, nx, ny) <                 npth_clr + vr - 1e-4:
+        # keep-out site above: this does not honour the hole pad's OWN
+        # `local_clearance`, which check_drc does honour, so it under-blocks by
+        # `lc - clearance` on such a pad. That is #730 -- a wrong VALUE where
+        # this was a missing GATE -- and closing it here would move a number
+        # #730 needs to move in one place.
+        if _seg_foreign_hole_dist(pcb_data, v.net_id, nx, ny, nx, ny) < \
+                clearance + vr - 1e-4:
             return False
         for (bx0, by0, bx1, by1, net, _cl, pfl) in all_cap_rects:
             # via barrel spans all layers: no layer gate here

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -643,13 +643,12 @@ class _Repair:
         # clearance model, which is what made the layer truth vanish on the
         # boards carrying the most phantom -- see _cap_seg_scope.)
         self._seg_floor_by_id: Dict[int, PadFloor] = {}
+        # #736: through _register_segment, which is also what the connector
+        # copper this pass DRAWS goes through -- so a track filed later cannot
+        # be priced or scoped differently from one present at construction.
         for s in pcb_data.segments:
-            fl = self._seg_floor_for(s.net_id, s.layer)
-            t = (s.start_x, s.start_y, s.end_x, s.end_y, s.net_id,
-                 s.width / 2.0 + self._item_reach(fl), s.layer)
-            self.segments.append(t)
-            if fl is not None:
-                self._seg_floor_by_id[id(t)] = fl
+            self._register_segment(s.start_x, s.start_y, s.end_x, s.end_y,
+                                   s.net_id, s.width, s.layer)
 
         # --- attraction: BGA balls grouped by net ---
         # A cap pad is pulled toward the nearest ball of its own net, so a via
@@ -709,6 +708,10 @@ class _Repair:
         # must NOT be deleted as dead: the id-keyed floor maps below depend on
         # those tuples staying alive, and a recycled id would return ANOTHER
         # item's floor, silently, with no error.
+        # #736: self.segments does GAIN entries after __init__ (the connector
+        # copper this pass draws, filed by register_new_segments). It is
+        # APPENDED to, never rebuilt -- precisely so the aliveness this note is
+        # about survives the gain. self.foreign_pads is unchanged.
         self.foreign_pad_floors: List[Optional[PadFloor]] = []
         self.foreign_pad_mf: List[float] = []
         self.caps: Dict[str, _Cap] = {}
@@ -811,6 +814,15 @@ class _Repair:
             cx, cy = (r[0] + r[2]) / 2.0, (r[1] + r[3]) / 2.0
             span = math.hypot(r[2] - cx, r[3] - cy)
             cap_geom[ref] = (cx, cy, span, r)
+        # #736: KEPT, not consumed and dropped with the frame. Every prune
+        # reach below is anchored on the cap's SEED pose -- which is what this
+        # dict holds, because a cap's x/y/rot still equal its seed_* here --
+        # and register_new_segments re-runs that same prune for copper that
+        # appears AFTER construction, by which time cap.rect() is no longer the
+        # seed. Stored rather than re-derived there for the reason _seg_shares
+        # and via_required exist: a second derivation is a second thing to keep
+        # in step.
+        self._cap_geom = cap_geom
 
         self.cap_foreign_pads: Dict[str, List[
             Tuple[float, float, float, float, int, Optional[str]]]] = {}
@@ -864,41 +876,12 @@ class _Repair:
                     near_caps.append(oref)
             self.cap_caps[ref] = near_caps
 
-            near_segs = []
-            # seg[5] already carries the segment's own over-reach, so adding
-            # this cap's excess over the flat scalar bounds the pair.
-            seg_reach = (max_displacement_cap + 2 * span + clearance
-                         + max(0.0, cap_mf - clearance))
-            # #731: keep a track only if SOME pad of this cap shares its copper
-            # layer. The union is a superset of every per-pad set (see
-            # _seg_shares), so this can never drop a chargeable pair -- the
-            # list stays EXACT, as TestPruneRadiiStayExact requires. The
-            # per-pad half is applied in _seg_effs, and matters only for a cap
-            # whose pads differ (an SMD pad beside a through-hole one).
-            #
-            # The `_union is None` arm is a fallback for a cap that offers no
-            # copper pad at all -- cap detection admits n_copper == 0 (a
-            # paste-only C-prefixed part). Such a cap has an empty pad_rects,
-            # so NOTHING it keeps is ever graded and the arm cannot change an
-            # outcome; it keeps the old side filter purely so the pruned list
-            # stays the size it always was. It is NOT reachable for an empty
-            # copper list any more: `_all_cu` above resolves through
-            # check_drc's own three-level fallback and is never empty, which
-            # is deliberate -- falling back to the side collapse there would
-            # DROP the B.Cu and inner tracks a through-hole cap pad shares
-            # copper with, an under-block (measured: 280 pairs on rp2350).
-            _pl, _union = self._cap_seg_scope(cap)
-            for seg in self.segments:
-                layer = seg[6]
-                if _union is None:
-                    if self._seg_side(layer) != cap.side:
-                        continue
-                elif layer in self._all_cu and layer not in _union:
-                    continue
-                d = _point_to_seg_dist(ccx, ccy, seg[0], seg[1], seg[2], seg[3])
-                if d <= seg_reach + seg[5]:
-                    near_segs.append(seg)
-            self.cap_segs[ref] = near_segs
+            # #736: through _prune_segs, the ONE spelling of this predicate.
+            # It carries the comment block that used to live here, including
+            # why the reach is anchored on the SEED pose and why the #731 layer
+            # union keeps the list exact.
+            self.cap_segs[ref] = self._prune_segs(cap, cap_geom[ref],
+                                                  self.segments)
 
             near_vias = []
             # v[3] = via_radius + its own keep-out; a via that can reach a pad
@@ -1262,6 +1245,170 @@ class _Repair:
         pf = getattr(cap, 'pad_floors', None)
         return (self._floors is not None and pf is not None
                 and len(pf) == len(getattr(cap, 'pads', ())))
+
+    # ---- #736: THE one way a track enters this grader --------------------
+    # Two private helpers plus one public registrar, and every track this
+    # module grades goes through them: the ones present at construction, and
+    # the connector copper nudge_vias_for_unresolved DRAWS afterwards. Before
+    # #736 both halves were inline in __init__ and existed nowhere else, so
+    # the post-nudge re-grade had no way to register what the pass had just
+    # created -- it re-graded against the construction-time snapshot and could
+    # report a cap RESOLVED while a connector this same run emitted grazed one
+    # of its pads. Same shape, and the same reason, as via_radius /
+    # via_required / edge_margin above: ONE answer per pair kind in this
+    # module.
+
+    def _register_segment(self, x1, y1, x2, y2, net_id, width, layer):
+        """Grade one track into the track view, and return its tuple.
+
+        THE only construction site for a track tuple, and the only writer of
+        the id-keyed floor map -- both pinned by the source guard in
+        tests/test_736_fanout_clearance_regrade_view.py, which reports
+        offending line numbers rather than dumping the module.
+
+        Takes PRIMITIVE fields rather than a parser Segment because its two
+        callers hold different things: __init__ has real Segments, and
+        register_new_segments has the writer-shaped dicts the nudger returns.
+        A builder that accepted only one of those would have left the other
+        re-deriving the tuple, which is the defect being fixed.
+
+        It files the tuple BEFORE returning, on purpose. The floor map is
+        keyed on the tuple's identity, so a tuple that died while its id entry
+        lived would hand a recycled id ANOTHER track's floor -- silently, with
+        no error. That is the hazard the NB above self.foreign_pad_floors
+        names, and a factory that only BUILT would let a caller drop the
+        reference and arm it. Build-and-file is one operation here because the
+        invariant says it is.
+
+        Element 5 is the OVER-REACH -- half width plus this track's own upper
+        bound (#725), which _seg_effs strips back with the same _item_reach.
+        Element 6 is the track's REAL layer, never an 'F'/'B' side collapse
+        (#731).
+        """
+        fl = self._seg_floor_for(net_id, layer)
+        t = (x1, y1, x2, y2, net_id,
+             width / 2.0 + self._item_reach(fl), layer)
+        self.segments.append(t)
+        if fl is not None:
+            self._seg_floor_by_id[id(t)] = fl
+        return t
+
+    def _prune_segs(self, cap, geom, source):
+        """The tracks in `source` this cap could EVER be charged against --
+        THE one spelling of the per-cap track prune.
+
+        `geom` is the cap's SEED-pose (cx, cy, span, rect) from self._cap_geom,
+        never its current rect. The bound below is the reachable-DISK argument:
+        a cap moves at most max_displacement_cap from its SEED, so anything
+        whose seed gap already exceeds that can never constrain it -- which is
+        what makes this prune EXACT rather than an approximation
+        (TestPruneRadiiStayExact). A MOVED pose would silently redefine what
+        "exact" means, and it would be wrong for required_rows, which grades
+        the seed pose as well as the final one.
+
+        seg[5] already carries the segment's own over-reach, so adding this
+        cap's excess over the flat scalar bounds the pair.
+
+        #731: keep a track only if SOME pad of this cap shares its copper
+        layer. The union is a superset of every per-pad set (see _seg_shares),
+        so this can never drop a chargeable pair -- the list stays EXACT, as
+        TestPruneRadiiStayExact requires. The per-pad half is applied in
+        _seg_effs, and matters only for a cap whose pads differ (an SMD pad
+        beside a through-hole one).
+
+        The `_union is None` arm is a fallback for a cap that offers no copper
+        pad at all -- cap detection admits n_copper == 0 (a paste-only
+        C-prefixed part). Such a cap has an empty pad_rects, so NOTHING it
+        keeps is ever graded and the arm cannot change an outcome; it keeps the
+        old side filter purely so the pruned list stays the size it always was.
+        It is NOT reachable for an empty copper list any more: `_all_cu`
+        resolves through check_drc's own three-level fallback and is never
+        empty, which is deliberate -- falling back to the side collapse there
+        would DROP the B.Cu and inner tracks a through-hole cap pad shares
+        copper with, an under-block (measured: 280 pairs on rp2350).
+
+        Returns a NEW list. A caller must ASSIGN it and must never extend a
+        cap's existing list in place: _seg_effs memoises on the source list's
+        IDENTITY, so an in-place append leaves a memo that still passes the
+        identity test while being one column short, and _seg_shortfalls then
+        indexes past the end of its row.
+        """
+        ccx, ccy, span, _crect = geom
+        seg_reach = (self._max_disp_cap + 2 * span + self.clearance
+                     + max(0.0, cap.max_floor - self.clearance))
+        _pl, _union = self._cap_seg_scope(cap)
+        near_segs = []
+        for seg in source:
+            layer = seg[6]
+            if _union is None:
+                if self._seg_side(layer) != cap.side:
+                    continue
+            elif layer in self._all_cu and layer not in _union:
+                continue
+            d = _point_to_seg_dist(ccx, ccy, seg[0], seg[1], seg[2], seg[3])
+            if d <= seg_reach + seg[5]:
+                near_segs.append(seg)
+        return near_segs
+
+    def register_new_segments(self, seg_dicts) -> int:
+        """Take copper that appeared AFTER construction into the PAD-SEGMENT
+        channel; return how many tracks were filed (#736).
+
+        The one caller is repair_fanout_clearance, with the `new_segments` list
+        nudge_vias_for_unresolved returns: the connectors that restore
+        continuity to each relocated via. That copper is drawn by the pass
+        itself, milliseconds before the pass grades its own work, and both
+        front ends WRITE it (placement/writer.py on the CLI, the plugin's
+        pcbnew mirror in the GUI). Without this the final `unresolved` list and
+        required_rows' disclosure are computed against the track snapshot
+        __init__ took, so a cap can be reported RESOLVED while a connector this
+        same run emitted grazes one of its pads.
+
+        Takes the writer-shaped dicts the nudger already returns
+        ({'start', 'end', 'width', 'layer', 'net_id'}) rather than a tail
+        slice of pcb_data.segments, so nothing here depends on that list being
+        append-only.
+
+        INCREMENTAL, not a rebuild from the board, and the reason is not only
+        cost. The nudger leaves the ORIGINAL attached segments exactly where
+        they are (its own docstring says so), so every tuple already filed
+        still describes real copper at the same coordinates and every pruned
+        membership is as valid as it was. A rebuild would additionally REPLACE
+        the tuples the floor map is keyed on: the originals die, their ids can
+        be recycled by the replacements, and a track is handed ANOTHER track's
+        floor -- the hazard __init__'s own NB names. Appending cannot.
+
+        Each cap that keeps new copper is REASSIGNED a new list; a cap that
+        keeps none is left alone, so it keeps its list identity and therefore
+        its _seg_effs memo. That is what makes this O(caps x new tracks)
+        instead of a second pass over the whole board.
+
+        Deliberately NOT called from nudge_vias_for_unresolved. That function
+        is duck-typed on `st` -- the #370/#617/#732/#733/#737 harnesses pass a
+        stand-in carrying only `caps`, `vias` and `graze_penalty` -- so every
+        `st` read there goes through getattr with a flat fallback. A RESOLVER
+        has an honest flat fallback; a MUTATION does not, because "silently do
+        nothing" is precisely the staleness this fixes. repair_fanout_clearance
+        holds a real _Repair, so the call needs no escape hatch at all.
+
+        A connector on a layer this board never declared is KEPT and CHARGED
+        rather than dropped: `_all_cu` was resolved at construction, so such a
+        layer reads as UNKNOWN and _seg_shares charges it. Over-blocking is the
+        only direction that can never ship a violation.
+
+        Not idempotent, and does not need to be: one caller, one call.
+        """
+        fresh = [self._register_segment(sd['start'][0], sd['start'][1],
+                                        sd['end'][0], sd['end'][1],
+                                        sd['net_id'], sd['width'], sd['layer'])
+                 for sd in seg_dicts]
+        if not fresh:
+            return 0
+        for ref, cap in self.caps.items():
+            kept = self._prune_segs(cap, self._cap_geom[ref], fresh)
+            if kept:
+                self.cap_segs[ref] = self.cap_segs[ref] + kept
+        return len(fresh)
 
     def _pad_effs(self, ref, cap):
         """[cap pad i][pruned foreign pad j] required clearance, or None for
@@ -2167,8 +2314,55 @@ def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
     if unresolved:
         via_moves, new_segs = nudge_vias_for_unresolved(st, pcb_data, clearance)
         if via_moves:
+            # #736: absorb the connector tracks the nudger just DREW. They went
+            # into pcb_data.segments, but st.segments / st.cap_segs /
+            # st._seg_floor_by_id were snapshotted in _Repair.__init__ before
+            # they existed -- so the re-grade below, and required_rows' seed +
+            # final disclosure, read a track view missing exactly the copper
+            # this pass is responsible for, and a cap could be reported
+            # RESOLVED with one of its pads inside a connector's keep-out.
+            #
+            # The nudger's own connector_clear gate does NOT already close
+            # this. On the connector's OWN layer the two agree exactly -- same
+            # two floors through the same resolver, and connector_clear is the
+            # stricter by EPS -- so an accepted same-layer connector can never
+            # be charged here. It is the OTHER layers that diverge, in two
+            # ways: connector_clear compares against the cap FOOTPRINT's side
+            # (#738), so an inner-layer or back-side connector is never tested
+            # against a THROUGH-HOLE cap pad whose copper spans every layer;
+            # and a connector on a layer this board never declared is skipped
+            # there while _seg_shares charges it here, which is a window #738's
+            # own proposed fix does not close. Either way the gate that drew
+            # the copper is not the gate that grades it, and the summary the
+            # operator reads comes from this one.
+            #
+            # THE GUARD STAYS `via_moves` and gains no `or new_segs`: a
+            # connector dict is appended only inside the same commit block that
+            # appends the via move, with no continue or break between, so a
+            # non-empty new_segs IMPLIES a non-empty via_moves and the disjunct
+            # could never fire. No inner `if new_segs:` either -- the empty
+            # case returns immediately inside register_new_segments.
+            # (writer.py does spell `if via_moves or new_segments:`, and that
+            # is right THERE: it wraps two independent text rewrites and is
+            # defending against a caller handing it lists it did not produce.)
+            st.register_new_segments(new_segs)
             # refresh the per-cap pruned via lists before re-grading
             st.cap_vias = {r: st.vias for r in st.caps}
+            # base_seg / base_pad / base_via are deliberately NOT re-seeded --
+            # exactly as base_via is left alone by the line above, though via
+            # positions changed there too. They are read only by cost() /
+            # hard_blocked, neither of which runs past this point; and a
+            # baseline means "the state at the SEED", which copper this pass
+            # CREATED is not part of. Folding it in would license a later move
+            # to sit on the pass's own connector for free -- the #441
+            # GND<->NetR2_2 failure in miniature, and silent. The consequence
+            # to know: from here st.base_seg and st.cap_segs describe different
+            # boards, which is what "baseline" means rather than a defect.
+            #
+            # KNOWN GAP, deliberately not closed here: `resolved` above is
+            # computed BEFORE the nudge and is not refreshed, so a cap the
+            # sweep cleaned and a connector then grazes can appear in both
+            # lists. That is older than #736 and a different failure mode.
             unresolved = [r for r in st.caps
                           if st.graze_penalty(r, st.caps[r], st.caps[r].x,
                                               st.caps[r].y, st.caps[r].rot) > EPS]

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -622,8 +622,11 @@ class _Repair:
                 if _f is not None:
                     self._fp_floor_by_id[id(_t)] = _f
         # Per-(cap, neighbour) REQUIRED-clearance memos. model.pair() is
-        # pose-independent, so it is resolved ONCE per pair here and never
-        # inside the candidate sweep. Each memo is (source_list, rows) and is
+        # pose-independent, so it is resolved ONCE per (cap, neighbour) pair
+        # and reused for every candidate pose. The memos are filled lazily, so
+        # the first fill for a pair does happen inside cost() -- measured on a
+        # 0.5-class board: 572 of 62,565 pair_with_source calls, against
+        # 251,477 cost() calls. Each memo is (source_list, rows) and is
         # rebuilt when the source list identity changes -- which makes
         # repair_fanout_clearance's wholesale `st.cap_vias = {...}` reassignment
         # self-heal, and makes a test that injects into cap_foreign_pads grade
@@ -770,10 +773,15 @@ class _Repair:
                 if key not in self.base_cap_pad:
                     # #725: the baseline must be in the SAME currency as the
                     # candidate it gates. Priced flat while candidates are
-                    # priced at the requirement, _worsens_any_net fires on
-                    # every pose and the pass silently stops moving anything --
-                    # a failure whose symptom is FEWER placements, which reads
-                    # as conservative rather than broken.
+                    # priced at the requirement, _worsens_any_net compares two
+                    # different units, so the accept gate reads a pose as
+                    # worse-than-seed on a pair that did not change.
+                    # Measured by reverting exactly this line at HEAD: the
+                    # placement count moves in a CLASS-DEPENDENT direction and
+                    # not by much (0.4 identical, 0.5 gives 50 vs 48 and one
+                    # more unresolved, 1.0 gives 31 vs 34) -- so the symptom is
+                    # a quietly wrong answer, not a visible seizure, which is
+                    # why the test asserts the CURRENCY and not a count.
                     self.base_cap_pad[key] = _pad_pair_shortfall(
                         seed_pads, self.caps[oref].pad_rects(), self.clearance,
                         self._pair_effs(ref, cap, oref, self.caps[oref]))
@@ -911,10 +919,17 @@ class _Repair:
         return self._floors.pair(fa, fb)
 
     def _cap_pad_layers(self, cap):
-        """This cap's per-pad copper layer sets, or None when unavailable (a
-        duck-typed cap, or a board that declares no copper layers at all -- in
-        which case NO pair may be scoped by layer, or every one of them would
-        fall back to the flat scalar and under-block)."""
+        """This cap's per-pad copper layer sets, or None when unavailable.
+
+        None for a duck-typed cap, and for a board that declares no copper
+        layers at all: `pad_copper_layers(p, [])` resolves nothing for a `*.Cu`
+        pad, so every such pad would read as copper-less and take the
+        off-layer fallback -- an UNDER-block. It hits only `*.Cu` pads (an
+        `F.Cu` / `B.Cu` / `F&B.Cu` pad still resolves), which is 0 of 308 cap
+        pads on orangecrab but 468 of 2186 across the tracked corpus, all
+        through-hole. Scoping switches off entirely rather than per-pad,
+        because a board with no copper layers has no layer question to answer.
+        """
         pl = getattr(cap, 'pad_layers', None)
         if pl is None or len(pl) != len(getattr(cap, 'pad_floors', ())):
             return None
@@ -1939,7 +1954,7 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
         # The connector is a TRACK on `layer`, so it resolves like one. Note
         # this honours netclasses and .kicad_dru LAYER rules, but not #549
         # track-scoped rules, which live in a channel PadClearanceModel does
-        # not carry (check_drc.read_board_track_clearances); under-blocking a
+        # not carry (kicad_dru.read_board_track_clearances); under-blocking a
         # geometric connector that is separately DRC'd is the safe direction.
         cfl = seg_fl(net_id, layer)
         # board edge / cutouts + NPTH drill holes at their floor (#370 B3):

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -2401,6 +2401,50 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
         # never off the board / into a cutout / inside the edge margin (#370 B3)
         if not edge_ok_point(nx, ny, vr):
             return False
+        # #737: the relocated via's COPPER against copper-less (NPTH) holes.
+        # This function had no such test at all. Its only drilled-pad gate is
+        # the DRILL-to-drill one below, which measures the DRILL, so it covered
+        # the annular ring only while
+        #
+        #     ring = (size - drill) / 2 <= H2H_PAD - npth_clr
+        #
+        # -- 0.25 at the fab floor, but only 0.20 at the shipped --clearance
+        # 0.25, and 0 at clearance >= 0.45. Past that the pass parked ring
+        # copper inside a mounting hole's keep-out, and this pass WRITES the
+        # via (placement/writer.py, and the plugin's pcbnew mirror). Measured
+        # on a rig at --clearance 0.1: a 1.4/0.3 via relocated to 0.05mm of
+        # copper-to-hole-wall gap, which check_drc reports as a via-hole
+        # violation of exactly that.
+        #
+        # Same helper, same floor, same own-net exemption and the same 1e-4 as
+        # connector_clear's gate below, so the two sibling validators cannot
+        # disagree about which holes exist or what one costs -- and the gate
+        # order in the two now reads alike (edge, hole, cap rects, board pads,
+        # vias, segments). `board_pads` was the cheaper source and is the wrong
+        # one: it drops the pads of movable caps, which the helper keeps. That
+        # buys AGREEMENT between the siblings, not truth -- both read pre-move
+        # pad coordinates, so neither is right about a cap already relocated.
+        # A degenerate segment is the point case: _seg_capsule_axis_dist guards
+        # L2 == 0 and its crossing test is strict, so a zero-length segment
+        # cannot report a spurious crossing.
+        #
+        # The drill test below stays net-INDEPENDENT and keeps its own floor:
+        # drill-to-drill is a machine constraint, this is an etch constraint,
+        # and check_drc's via-hole arm makes the same own-net exemption
+        # (check_drc.py, `if via.net_id == hnet: continue`).
+        #
+        # KNOWN GAP, deliberately not closed here, exactly as at the cap
+        # keep-out site above: neither this gate nor the sibling honours the
+        # hole pad's OWN `local_clearance`, which check_drc does honour, so
+        # both under-block by `lc - npth_clr` on such a pad. That is #730 --
+        # a wrong VALUE, where this is a missing GATE -- and closing it here
+        # would move a number #730 needs to move in one place.
+        #
+        # NOT a reversal of #617. #617 measured RAISING this pass's hole floor
+        # to a board's DECLARED min_hole_clearance and refused it; the floor
+        # here is still the flat npth_clr, deliberately NOT st.npth_floor.
+        if _seg_foreign_hole_dist(pcb_data, v.net_id, nx, ny, nx, ny) <                 npth_clr + vr - 1e-4:
+            return False
         for (bx0, by0, bx1, by1, net, _cl, pfl) in all_cap_rects:
             # via barrel spans all layers: no layer gate here
             if net != v.net_id and _point_to_rect_dist(

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -57,6 +57,38 @@ EPS = 1e-6
 # rather than -inf so nothing can produce a NaN if a caller sums a row.
 _OFF_LAYER = -1.0e9
 
+# The diameter to assume for a via whose size the board does not carry -- a
+# literal `(size 0)` token, or a padstack whose pcbnew GetFrontWidth() came back
+# 0. This is the value nudge_vias_for_unresolved hard-coded at four sites before
+# #732 named it, so nothing moves.
+#
+# Module-private on purpose. It governs how THIS pass prices a barrel it cannot
+# measure, which is an operator-facing placement decision; it is emphatically
+# not a number the DRC/connectivity graders should adopt. KiCad honours a
+# declared size literally: `(size 0)` is a hard `via_diameter` DRC error there
+# (min 0.5000mm, actual 0.0000mm) rather than a via KiCad silently sizes for
+# you, and such a barrel joins nothing -- so a grader that substituted a
+# diameter would report CONNECTED what KiCad reports OPEN. Measured; see
+# TestTheGradersStillReadTheBoard in tests/test_732_...py, which states the
+# geometry the experiment needs (perpendicular copper-to-barrel separation,
+# not stub endpoint offset) because the naive version shows nothing.
+_UNREADABLE_VIA_SIZE = 0.5  # mm
+
+
+def _via_radius(via, default_size=_UNREADABLE_VIA_SIZE) -> float:
+    """The copper radius of a via, in mm -- the ONE implementation of the rule.
+
+    #732: this was spelled `v.size if v.size and v.size > 0 else
+    default_via_size` in the grader and `(v.size or 0.5) / 2.0` at four nudger
+    sites, so the two halves of the pass priced the same barrel differently.
+    `getattr` because the nudger is public and its test harnesses pass
+    duck-typed via-likes.
+    """
+    size = getattr(via, 'size', None)
+    if not size or size <= 0:
+        size = default_size
+    return size / 2.0
+
 # These four moved to placement/legality.py, the shared home with quench.py
 # (which carried byte-identical copies of the first two). Aliased rather than
 # renamed: the names are used throughout this module and imported by tests.
@@ -487,13 +519,18 @@ class _Repair:
         # nudge_vias_for_unresolved relocates a via. A tuple that died while its
         # id entry lived would hand a recycled id ANOTHER via's radius,
         # silently.
+        #
+        # #732: the fallback is STORED rather than consumed inline and dropped,
+        # because nudge_vias_for_unresolved needs the same answer and had no way
+        # to reach it -- see via_radius() for what that cost.
+        self._default_via_size = default_via_size
         self._via_radius_by_id: Dict[int, Tuple[tuple, float]] = {}
         for v in pcb_data.vias:
-            size = v.size if v.size and v.size > 0 else default_via_size
+            r = self.via_radius(v)
             t = (v.x, v.y, v.net_id,
-                 size / 2.0 + self._item_reach(self._via_floor_for(v.net_id)))
+                 r + self._item_reach(self._via_floor_for(v.net_id)))
             self.vias.append(t)
-            self._via_radius_by_id[id(t)] = (t, size / 2.0)
+            self._via_radius_by_id[id(t)] = (t, r)
 
         # --- avoidance: foreign-net tracks the cap's pads can actually TOUCH ---
         # Fanout escapes can land on the bottom (cap) side; attraction could
@@ -983,6 +1020,34 @@ class _Repair:
         unresolved that its own nudger then refuses to see). The via eff rows
         are built from this same call, so they cannot drift from it either."""
         return self._pair_or_flat(pad_floor, self._via_floor_for(via_net))
+
+    def via_radius(self, via) -> float:
+        """The RADIUS of one parser Via -- the one answer in this module (#732).
+
+        The only place `--default-via-size` is applied. __init__ builds the
+        keep-out list from this, and nudge_vias_for_unresolved's offender test,
+        its candidate validation and its #313 connectivity tolerance all read it
+        back through the same call, for the same reason via_required exists.
+
+        Left divergent, a via whose size the board does not carry got the
+        grader's default_via_size/2 and the nudger's hard-coded 0.25 for the
+        SAME barrel. At the CLI's 0.3 default the nudger's is LARGER, so it
+        moves vias the grader never flagged and lays connector copper for
+        nothing; above 0.5 the sign flips and the grader flags a cap whose
+        offender list then comes back EMPTY -- the `for v in offenders:` body
+        never runs, so not even the "no clear spot" line prints and the cap is
+        reported unresolved forever with nothing on screen. Both signs are
+        reachable from the GUI too: its via size is the Basic tab's spin
+        control, not the 0.5 constant (fanout_gui.py:1529 -> swig_gui.py:1739).
+
+        NOT the same question as _via_radius_by_id, and deliberately a separate
+        mechanism. That map answers "what radius did THIS 4-tuple get", which
+        for a tuple a test assigned wholesale is its own convention and must
+        stay so. This answers "how wide is this barrel" -- a fact about the
+        parser object, and the only form that works for a via injected into
+        pcb_data.vias AFTER construction, which the tests do.
+        """
+        return _via_radius(via, self._default_via_size)
 
     def _pair_or_flat(self, fa, fb):
         """model.pair for two floors, falling back to the flat scalar whenever
@@ -2067,6 +2132,7 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
     _pad_fl = getattr(st, 'pad_floor', None)
     _via_fl = getattr(st, 'via_floor', None)
     _seg_fl = getattr(st, 'seg_floor', None)
+    _via_rad = getattr(st, 'via_radius', None)
 
     def req(fa, fb):
         return clearance if _req is None else _req(fa, fb)
@@ -2082,6 +2148,25 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
 
     def seg_fl(net, layer):
         return None if _seg_fl is None else _seg_fl(net, layer)
+
+    def via_rad(v):
+        """This via's RADIUS, resolved by st when it can (#732), so the offender
+        test, the candidate validation and the #313 connectivity tolerance below
+        cannot disagree with the keep-out list the grader was built from. Four
+        sites here spelled it `(x.size or 0.5) / 2.0` and a fifth `v.size / 2.0`
+        with no fallback at all, while the grader used --default-via-size.
+
+        The fallback is reached ONLY on the duck-typed path -- the _FakeSt the
+        #370 and #617 harnesses pass carries no resolver -- and only for a via
+        whose size is falsy. Every via those fixtures build carries a real 0.5,
+        so it is numerically unreachable there; the #732 test file pins that.
+        defaults.UNREADABLE_VIA_SIZE rather than a bare literal so the number
+        has ONE name across this module and the two checkers. Spelled with the
+        same `and ... > 0` guard as _Repair.via_radius, not `or`, so a negative
+        size cannot take a different branch in the two."""
+        if _via_rad is not None:
+            return _via_rad(v)
+        return _via_radius(v)
 
     def cap_floors_of(cap, rects):
         """This cap's per-pad floors, index-aligned with `rects` -- or None,
@@ -2125,7 +2210,7 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
             board_pads.append((p, pad_fl(p), not _pad_has_no_copper(p), cap_))
 
     def valid_via_pos(v, nx, ny):
-        vr = (v.size or 0.5) / 2.0
+        vr = via_rad(v)
         vfl = via_fl(v.net_id)
         # never off the board / into a cutout / inside the edge margin (#370 B3)
         if not edge_ok_point(nx, ny, vr):
@@ -2153,7 +2238,7 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
             if ov is v:
                 continue
             d = math.hypot(nx - ov.x, ny - ov.y)
-            if ov.net_id != v.net_id and d < vr + (ov.size or 0.5) / 2.0 + \
+            if ov.net_id != v.net_id and d < vr + via_rad(ov) + \
                     req(vfl, via_fl(ov.net_id)):
                 return False
             if d < (v.drill or 0.3) / 2.0 + (ov.drill or 0.3) / 2.0 + H2H_VIA:
@@ -2210,7 +2295,7 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
                 return False
         for ov in pcb_data.vias:
             if ov.net_id != net_id and _point_to_seg_dist(
-                    ov.x, ov.y, sx, sy, ex, ey) < (ov.size or 0.5) / 2.0 + hw \
+                    ov.x, ov.y, sx, sy, ex, ey) < via_rad(ov) + hw \
                     + req(cfl, via_fl(ov.net_id)):
                 return False
         for s2 in pcb_data.segments:
@@ -2238,7 +2323,7 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
         pfls = cap_floors_of(cap, rects)
         offenders = []
         for v in pcb_data.vias:
-            vr = (v.size or 0.5) / 2.0
+            vr = via_rad(v)
             for i, (bx0, by0, bx1, by1, net) in enumerate(rects):
                 if v.net_id != net and _point_to_rect_dist(
                         v.x, v.y, (bx0, by0, bx1, by1)) < vr + via_req(
@@ -2256,7 +2341,7 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
             # 1um match missed copper offset by grid quantization or a prior
             # #280 via-nudge; the via body radius is the correct connectivity
             # tolerance (a track end buried in the via is connected).
-            tol = max(1e-3, v.size / 2.0)
+            tol = max(1e-3, via_rad(v))
             for s in pcb_data.segments:
                 if s.net_id != v.net_id:
                     continue

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -74,6 +74,87 @@ _OFF_LAYER = -1.0e9
 # not stub endpoint offset) because the naive version shows nothing.
 _UNREADABLE_VIA_SIZE = 0.5  # mm
 
+# The cap-placement margin from Edge.Cuts when the operator names none and the
+# board declares none. A PLACEMENT margin (keep a decap off the rim so it can be
+# assembled and reworked), not a DRC floor -- which is why it is 0.55 and not one
+# of routing_defaults' two edge numbers: BOARD_EDGE_CLEARANCE is 0.0, the SIGNAL
+# sentinel meaning "no edge rule, use the copper-copper clearance" (list_nets.py
+# :507-511), and adopting it here would collapse this margin to `clearance`;
+# PLANE_EDGE_CLEARANCE 0.5 belongs to pours. list_nets.board_floor_knobs already
+# spells this same 0.55 as its `edge_default` for the sibling placement CLIs.
+CAP_EDGE_CLEARANCE = 0.55  # mm
+
+
+def resolve_cap_edge_clearance(pcb_file, explicit=None):
+    """The cap-placement edge margin, resolved ONCE. Returns ``(mm, source)``.
+
+    THE ONE ANSWER for every front end (#733). The CLI, the GUI plugin and the
+    animator each carried their own hard-coded 0.55 and only the CLI exposed a
+    flag, so a board declaring a real copper-to-edge rule reached three different
+    margins depending on which front invoked the same engine.
+
+    TIGHTEN-ONLY, and that is deliberate rather than a softer form of the
+    board-first rule `list_nets.board_floor` implements. `board_floor` is
+    explicitly NOT raise-only, which is correct for a routing floor and wrong
+    here, because the value it would read back is one THIS pipeline wrote:
+    `fix_project_for_output` PINS `min_copper_edge_clearance` UP to the fab
+    copper-to-edge floor 0.20 on every board it writes (fix_kicad_drc_settings.py
+    :608 -> :749-754, the one raise-allowed key), and `bga_fanout.py` calls it
+    (bga_fanout/__init__.py:4328) -- as does place_fanout_clearance.py itself.
+    The documented pipeline is `bga_fanout.py -> place_fanout_clearance.py`, so
+    EVERY board this pass is handed in a real chain declares >= 0.20 even when its
+    author declared nothing. Read plainly board-first, that 0.20 comes back tagged
+    "board constraint" -- our own default wearing the board's name -- and the cap
+    margin silently drops 0.55 -> max(clearance, 0.20). 80/184 corpus boards
+    declare below 0.20 (fix_kicad_drc_settings.py:356), so that is the common case,
+    not a corner. Raising only is immune to the pin and still honours a board that
+    genuinely wants MORE room than 0.55.
+
+    An EXPLICIT POSITIVE value is honoured as given, in both directions: that is
+    the operator overriding the pass, and --board-edge-clearance 0.2 must mean
+    0.2 even though it is below the default.
+
+    A NON-POSITIVE explicit value is UNSET, not a margin of zero. Cite the right
+    precedent for that, because there are two rules in this codebase and they
+    differ exactly here: `board_floor` / `board_floor_knobs` apply the
+    non-positive-is-unset rule to a DECLARED value only and honour an explicit
+    one unconditionally (`if explicit is not None: return float(explicit)`,
+    list_nets.py:450), while `effective_board_edge_clearance` applies it to the
+    CLI value too (`cli_value if (cli_value and cli_value > 0) else ...`,
+    fix_kicad_drc_settings.py:357). This follows the latter, and deliberately
+    diverges from `board_floor` on this one point. Not pedantry: the GUI's Min
+    Edge Clearance spin control is
+    CREATED at defaults.BOARD_EDGE_CLEARANCE, which is 0.0, with a range minimum
+    of 0.0 -- so an operator who ticks the override box and types nothing hands
+    this function a 0. Honoured literally that would drop the cap margin to
+    max(clearance, 0) = the bare clearance: the exact 0.30mm under-block #733
+    exists to close, re-opened through a different door and LOOSER than the
+    0.55 the plugin used before this change. Caught by the #733 review.
+
+    `source` is for disclosure only: 'cli' | 'board constraint, raised' |
+    'fixed default'. There is deliberately NO 'unreadable project' source, unlike
+    board_floor's -- `board_constraint` swallows its own read errors and
+    `read_design_rules` swallows JSONDecodeError/OSError (list_nets.py:199), so a
+    corrupt project is genuinely indistinguishable here from one that declares
+    nothing. Both report 'fixed default'. Stated rather than papered over with a
+    label that could never print; the VALUE is 0.55 either way, which is the safe
+    direction for a raise-only rule.
+    """
+    if explicit is not None and explicit > 0:
+        return float(explicit), 'cli'
+    try:
+        from list_nets import board_constraint
+        declared = board_constraint(pcb_file, 'min_copper_edge_clearance')
+    except Exception:                                          # noqa: BLE001
+        declared = None    # e.g. pcb_file is not a path at all (an unsaved GUI
+                           # board): no declaration to raise to, take the default
+    # A declaration below the default cannot LOWER this margin (see above), and a
+    # non-positive one is UNSET rather than a floor of zero -- KiCad writes 0 into
+    # these fields for "not configured". `> CAP_EDGE_CLEARANCE` subsumes both.
+    if declared is not None and declared > CAP_EDGE_CLEARANCE:
+        return float(declared), 'board constraint, raised'
+    return CAP_EDGE_CLEARANCE, 'fixed default'
+
 
 def _via_radius(via, default_size=_UNREADABLE_VIA_SIZE) -> float:
     """The copper radius of a via, in mm -- the ONE implementation of the rule.
@@ -387,13 +468,12 @@ class _Repair:
         self.board = bounds
         # Copper-to-EDGE, not a different-net pair requirement, so #725 leaves
         # it alone: it is KiCad's `min_copper_edge_clearance`, a separate rule
-        # a netclass cannot express. Two caveats worth stating rather than
-        # implying: `board_edge_clearance` is a plain CLI flag (default 0.55)
-        # and is NOT auto-read from the board the way the routing steps read
-        # their edge constraint, and the GUI never passes it, so the plugin
-        # always gets the 0.55 signature default. Separately,
-        # nudge_vias_for_unresolved's own edge tests use bare `clearance`
-        # instead of this margin -- both pre-existing, both filed.
+        # a netclass cannot express. #733 closed the three gaps this comment
+        # used to list as filed: `board_edge_clearance` now reaches every front
+        # end through resolve_cap_edge_clearance (the GUI passed nothing and got
+        # the signature default; the animator had its own copy), and
+        # nudge_vias_for_unresolved reads `self.edge_margin` below instead of
+        # gating its own emitted copper at bare `clearance`.
         margin = max(clearance, board_edge_clearance)
         self.usable = (bounds[0] + margin, bounds[1] + margin,
                        bounds[2] - margin, bounds[3] - margin)
@@ -406,7 +486,9 @@ class _Repair:
         # touch a ring pay for the exact test. The gate itself now lives in
         # placement/legality.py, shared with quench (#456 item 2).
         self.edge_gate = BoardOutlineGate(pcb_data.board_info, margin)
-        self._edge_margin = margin
+        # (the board-edge requirement is read back through the `edge_margin`
+        # property below, which delegates to the gate rather than keeping a
+        # second copy of `margin` -- see its docstring for why, #733)
         # ref -> the milled rings this mover's own pads sit inside (#628), the
         # same exemption quench takes. Needed HERE and not only at the margin-0
         # gates because this one runs at max(clearance, board_edge_clearance)
@@ -1020,6 +1102,50 @@ class _Repair:
         unresolved that its own nudger then refuses to see). The via eff rows
         are built from this same call, so they cannot drift from it either."""
         return self._pair_or_flat(pad_floor, self._via_floor_for(via_net))
+
+    @property
+    def edge_margin(self) -> float:
+        """THE copper-to-Edge.Cuts requirement of this run -- max(clearance,
+        board_edge_clearance) -- and the one answer in this module (#733).
+
+        Public, and read from OUTSIDE the class, for the same reason
+        via_radius and via_required are: nudge_vias_for_unresolved gates the
+        vias it RELOCATES and the connector segments it DRAWS, and those two
+        gates must not be weaker than the one a cap pad has to pass.
+
+        Left divergent, they were. The cap mover inset `usable` and built
+        `edge_gate` at max(clearance, board_edge_clearance) while the nudger's
+        edge_ok_point / edge_ok_seg spelled a bare `clearance`, so at the CLI
+        defaults (0.55 / 0.25) the pass parked a relocated via and its
+        connector 0.30mm closer to Edge.Cuts than any cap is allowed to sit --
+        an under-block on copper the pass itself created and the writer keeps
+        (place_fanout_clearance.py:138). Identically 0.30mm on the GUI path,
+        which passes no flag at all.
+
+        DELEGATES to the gate instead of storing the number a second time.
+        `edge_gate` is what the cap mover's real-outline rect tests actually
+        measure against, so a private duplicate here would be this very defect
+        in miniature -- two names for one requirement, one refactor from
+        drifting. (It replaces `_edge_margin`, which this module read nowhere.)
+
+        What is NOT shared with the gate is its #628 owned-milled-ring
+        exemption -- and read legality.py:512-525 before restoring it here,
+        because the obvious reading is wrong. That exemption is not a
+        rect-modelling workaround limited to the swallow probe; it covers the
+        EDGE-MARGIN test too, and exists because a part whose own PADS caused a
+        contour to be reclassified as an inner milled edge would otherwise have
+        every pose inside its own relief vetoed (run 20's SW2: 0 legal poses of
+        14884). Ownership is defined by pads, and a via has none -- it can never
+        be the part that owns a ring, so there is nothing here to exempt. A
+        barrel 0.30mm from a milled slot is a real copper-to-edge violation
+        whichever way the parser's slot-vs-inner-outline ambiguity resolves, so
+        the nudger should stand off. The cost is that it may decline a move near
+        such a ring; it prints "no clear spot", which is visible and recoverable,
+        unlike silent sub-margin copper. No tracked board carries a milled
+        contour at all -- tests/test_733_*.py asserts that, so the claim expires
+        loudly rather than quietly.
+        """
+        return self.edge_gate.margin
 
     def via_radius(self, via) -> float:
         """The RADIUS of one parser Via -- the one answer in this module (#732).
@@ -1729,7 +1855,7 @@ class _Repair:
 def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
                             clearance: float = 0.2,
                             grid_step: float = 0.1,
-                            board_edge_clearance: float = 0.55,
+                            board_edge_clearance: Optional[float] = None,
                             near_margin: float = 1.0,
                             capture_radius: float = 2.0,
                             default_via_size: float = 0.3,
@@ -1763,6 +1889,11 @@ def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
     deliberately NOT exposed on the CLI / GUI -- flip this argument in code to
     disable.
 
+    board_edge_clearance (#733) defaults to None meaning "resolve it" -- see
+    resolve_cap_edge_clearance: the board's own min_copper_edge_clearance when it
+    declares MORE room than CAP_EDGE_CLEARANCE, else that 0.55. A value passed in
+    is honoured exactly as given, in both directions.
+
     on_move, if given, is a callback invoked with the internal _Repair state
     once at the seed placement and again after every accepted cap move. It is
     used purely for visualization (animate_fanout_clearance.py) and has no
@@ -1774,6 +1905,23 @@ def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
         for ref in pcb_data.footprints:
             if any(fnmatch.fnmatch(ref, pat) for pat in lock_refs):
                 extra_locked.add(ref)
+
+    # #733: ONE board-edge margin for every front end. Resolved HERE, in the
+    # shared engine rather than in a CLI main(), because the GUI plugin
+    # re-implements the main() layer and would otherwise keep silently taking
+    # the signature default whatever the board declares. Printed for the same
+    # reason the #725 clearance disclosure is printed from the engine: both
+    # fronts inherit it.
+    #
+    # UNCONDITIONAL, including when the caller named a value. The number governs
+    # where cap copper may sit relative to Edge.Cuts, and an operator reading a
+    # transcript should never have to know which of three fronts invoked this to
+    # know which margin it used -- printing only the resolved case would disclose
+    # exactly the branch that needs no explaining.
+    board_edge_clearance, _edge_src = resolve_cap_edge_clearance(
+        pcb_file, board_edge_clearance)
+    print(f"  board-edge margin for caps: {board_edge_clearance}mm "
+          f"({_edge_src})")
 
     st = _Repair(pcb_data, pcb_file, clearance, grid_step,
                  board_edge_clearance, near_margin, capture_radius,
@@ -2107,7 +2255,7 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
     npth_clr = max(clearance, defaults.NPTH_TO_TRACK_CLEARANCE)
 
     def edge_ok_point(x, y, r):
-        need = r + clearance
+        need = r + edge_margin
         if edge_rings:
             if not _point_on_board(x, y, edge_outer, edge_cutouts):
                 return False
@@ -2118,7 +2266,7 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
         return True
 
     def edge_ok_seg(sx, sy, ex, ey, hw):
-        need = hw + clearance
+        need = hw + edge_margin
         if edge_rings:
             if not (_point_on_board(sx, sy, edge_outer, edge_cutouts) and
                     _point_on_board(ex, ey, edge_outer, edge_cutouts)):
@@ -2145,6 +2293,32 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
     _via_fl = getattr(st, 'via_floor', None)
     _seg_fl = getattr(st, 'seg_floor', None)
     _via_rad = getattr(st, 'via_radius', None)
+    # #733: the board-edge requirement comes from st, so the two edge helpers
+    # below cannot gate the copper this function EMITS more weakly than the cap
+    # mover gates a cap pad.
+    #
+    # max(), not a bare read, for the same reason _item_reach never returns below
+    # `self.clearance`: the flat argument is this function's own floor, and an st
+    # must never LOWER this test below the clearance the caller passed.
+    #
+    # Defensive, and say so precisely rather than overstate it: no LIVE caller
+    # can currently hand this a sub-clearance margin. `_Repair` is constructed at
+    # one site, its margin is already max(clearance, ...), and the margin-ZERO
+    # outline gate render_placement builds is a shallow COPY it keeps beside
+    # `state.edge_gate` rather than a `_Repair` -- the #733 review checked, after
+    # an earlier version of this comment claimed otherwise. A duck-typed st CAN,
+    # and the #733 test exercises exactly that.
+    #
+    # The fallback is EXACTLY `clearance`, not CAP_EDGE_CLEARANCE -- the duck-typed
+    # _FakeSt the #370/#617 harnesses pass carries no margin, and this function's
+    # own flat scalar is the honest stand-in for one. Worth stating plainly: those
+    # two harnesses do NOT in fact pin this. Every landing they exercise clears
+    # 0.80mm, so a 0.55 fallback passes all five of their arms unchanged. That is
+    # exactly why tests/test_733_*.py brackets the fallback to (0.20, 0.30] on a
+    # rig built for it -- the regression a later reader would introduce by
+    # "tidying" this line is one nothing else would catch.
+    _edge_m = getattr(st, 'edge_margin', None)
+    edge_margin = clearance if _edge_m is None else max(clearance, _edge_m)
 
     def req(fa, fb):
         return clearance if _req is None else _req(fa, fb)

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -44,8 +44,9 @@ from bga_fanout.grid import analyze_bga_grid
 from placement.parser import extract_courtyard_bboxes, extract_locked_refs
 from placement.utility import compute_footprint_bbox_local, snap_to_grid
 from placement.legality import (BoardOutlineGate, PadClearanceModel, PadFloor,
-                                format_required_clause, point_to_seg_dist,
-                                rect_gap, ring_is_rect, rotate_local_bounds)
+                                _pad_carries_copper, format_required_clause,
+                                point_to_seg_dist, rect_gap, ring_is_rect,
+                                rotate_local_bounds)
 
 ROTATIONS = [0.0, 90.0, 180.0, 270.0]
 EPS = 1e-6
@@ -181,7 +182,18 @@ class _Cap:
             half_y = hx * s + hy * c
             self.pads.append((off_x, off_y, half_x, half_y, p.net_id))
             if model is not None:
-                fl = model.pad_floor(p)
+                # The GEOMETRY filter above stays loose on purpose (see the
+                # comment), but a FLOOR must not: PadClearanceModel.pad_floor
+                # reads local_clearance unconditionally, and an np_thru_hole
+                # pad lists *.Cu while carrying no copper at all. Charging its
+                # override would move a cap to clear copper that does not
+                # exist -- and would contradict the model's own inertness
+                # rule, which refuses to ACTIVATE for an NPTH-only override
+                # (legality._pad_carries_copper, the watchy measurement).
+                # Zero floor, appended unconditionally so the index alignment
+                # the loose filter buys is preserved.
+                fl = (model.pad_floor(p) if _pad_carries_copper(p)
+                      else PadFloor(0.0, 0.0, None))
                 self.pad_floors.append(fl)
                 mf = model.max_floor(fl)
                 if mf > self.max_floor:
@@ -303,6 +315,15 @@ class _Repair:
         if bounds is None:
             raise ValueError("No board boundary (Edge.Cuts) found")
         self.board = bounds
+        # Copper-to-EDGE, not a different-net pair requirement, so #725 leaves
+        # it alone: it is KiCad's `min_copper_edge_clearance`, a separate rule
+        # a netclass cannot express. Two caveats worth stating rather than
+        # implying: `board_edge_clearance` is a plain CLI flag (default 0.55)
+        # and is NOT auto-read from the board the way the routing steps read
+        # their edge constraint, and the GUI never passes it, so the plugin
+        # always gets the 0.55 signature default. Separately,
+        # nudge_vias_for_unresolved's own edge tests use bare `clearance`
+        # instead of this margin -- both pre-existing, both filed.
         margin = max(clearance, board_edge_clearance)
         self.usable = (bounds[0] + margin, bounds[1] + margin,
                        bounds[2] - margin, bounds[3] - margin)
@@ -460,6 +481,17 @@ class _Repair:
         # entry gets floor None / mf 0.0: its rect is already inflated to the
         # hole floor, and the copper-to-HOLE rule is net-independent, so the
         # new machinery must never raise it via a neighbouring pad's netclass.
+        # KNOWN GAP, deliberately not closed here: check_drc DOES honour the
+        # hole pad's OWN `local_clearance` on that rule (check_drc.py, the
+        # `max(npth_clr, local_clearance)` in the copper-to-hole pass, #505),
+        # and `lc` is net-independent too -- so this under-blocks by
+        # `lc - max(npth_floor, clearance)` on such a pad. Measured on
+        # kicad_files/ulx3s.kicad_pcb, AUDIO1's two 1.7mm NPTH holes at
+        # lc=0.400: 1.050mm modelled vs 1.250mm required, a 0.200mm
+        # under-block. It is the HOLE rule, not the different-net copper rule
+        # #725 is about, and it interacts with the #617 balance below; filed
+        # separately. (watchy's 8 NPTH overrides are all 0.100, below the 0.20
+        # fab floor, so that board is numerically inert here.)
         self.foreign_pad_floors: List[Optional[PadFloor]] = []
         self.foreign_pad_mf: List[float] = []
         self.caps: Dict[str, _Cap] = {}
@@ -1373,15 +1405,29 @@ def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
         if fp is None:
             continue
         for p in fp.pads:
-            if not any(str(l).endswith('.Cu') for l in p.layers):
+            # #725: the copper predicate is the shared one. An np_thru_hole pad
+            # lists *.Cu and carries no copper, so the loose test named it here
+            # as a copper obstacle -- and would have charged its keep-clear
+            # override besides.
+            if not _pad_carries_copper(p):
                 continue
-            rect = (p.global_x - p.size_x / 2, p.global_y - p.size_y / 2,
-                    p.global_x + p.size_x / 2, p.global_y + p.size_y / 2)
-            # #725: graded at the pair's REAL requirement, like everything
-            # else. `keepout` is the prune over-reach, so re-form the pair's
-            # keep-out from the via's radius. A locked fiducial's keep-clear
-            # override is exactly the case this warning exists to surface, and
-            # priced flat it under-reported it.
+            # ...and the RECT gets the same rect_rotation inflation _Cap and
+            # foreign_pads use. This was the one pad-geometry site in the file
+            # built from raw size_x/size_y, so a tilted locked pad under-blocked
+            # by (sqrt(2)-1)*half along the board axes -- 0.14mm on glasgow's
+            # 45-degree R9. Converting the clearance term and leaving the shape
+            # would be exactly the half-conversion this change is about.
+            tilt = math.radians(getattr(p, 'rect_rotation', 0.0) or 0.0)
+            _c, _s = abs(math.cos(tilt)), abs(math.sin(tilt))
+            _hx, _hy = p.size_x / 2.0, p.size_y / 2.0
+            ex, ey = _hx * _c + _hy * _s, _hx * _s + _hy * _c
+            rect = (p.global_x - ex, p.global_y - ey,
+                    p.global_x + ex, p.global_y + ey)
+            # Graded at the pair's REAL requirement, like everything else.
+            # `keepout` is the prune over-reach, so re-form the pair's keep-out
+            # from the via's radius. A locked fiducial's keep-clear override is
+            # exactly the case this warning exists to surface, and priced flat
+            # it under-reported it.
             pfl = st.pad_floor(p)
             for vx, vy, vnet, keepout in st.vias:
                 if vnet == p.net_id:

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -832,6 +832,10 @@ class _Repair:
         self.cap_caps: Dict[str, List[str]] = {}
         # foreign-net tracks this cap's pads SHARE COPPER WITH, in reach (#731)
         self.cap_segs: Dict[str, List[Tuple]] = {}
+        # ...and how many LEADING entries of each are seed-era (#736). Copper
+        # register_new_segments appends is real on the final board and a
+        # fiction at the seed, so the two graded poses see different lists.
+        self._seed_seg_n: Dict[str, int] = {}
         # through-vias in reach (each (vx, vy, net, keepout))
         self.cap_vias: Dict[str, List[Tuple[float, float, int, float]]] = {}
         # #725: every reach below is raised by THE TWO ITEMS' OWN maxima, never
@@ -882,6 +886,13 @@ class _Repair:
             # union keeps the list exact.
             self.cap_segs[ref] = self._prune_segs(cap, cap_geom[ref],
                                                   self.segments)
+            # #736: how much of that list is SEED-ERA copper. required_rows
+            # grades the seed pose as well as the final one, and a connector
+            # this pass DREW did not exist at the seed -- charging it there
+            # invents a row describing a pair no board ever had. Recorded per
+            # cap rather than derived from a global count, because the pruned
+            # lists have different lengths.
+            self._seed_seg_n[ref] = len(self.cap_segs[ref])
 
             near_vias = []
             # v[3] = via_radius + its own keep-out; a via that can reach a pad
@@ -1301,10 +1312,22 @@ class _Repair:
         never its current rect. The bound below is the reachable-DISK argument:
         a cap moves at most max_displacement_cap from its SEED, so anything
         whose seed gap already exceeds that can never constrain it -- which is
-        what makes this prune EXACT rather than an approximation
-        (TestPruneRadiiStayExact). A MOVED pose would silently redefine what
-        "exact" means, and it would be wrong for required_rows, which grades
-        the seed pose as well as the final one.
+        what makes this prune EXACT rather than an approximation. A MOVED pose
+        would silently redefine what "exact" means.
+
+        The bound is stated rather than cited, because the obvious citation is
+        wrong: TestPruneRadiiStayExact checks that the lists never SHRINK when
+        a requirement is raised, not that the pruned grade equals the unpruned
+        one. Measured instead, over all 115 caps of every tracked board:
+        `2*span + clearance - grid_overshoot - R_max` has a minimum slack of
+        +1.009mm and never goes negative, where R_max is the largest
+        seed-centre-to-pad-corner distance across all four reachable
+        rotations. That figure is at --clearance 0.1; the bound carries a
+        `+ clearance` term, so it is +1.109 at the shipped 0.2 and larger
+        above. The grid overshoot is real and pre-existing --
+        _candidate_positions snaps AFTER its radius test, so a final pose can
+        sit up to grid_step*sqrt(2)/2 past max_displacement_cap -- and the
+        2*span term absorbs it with an order of magnitude to spare.
 
         seg[5] already carries the segment's own over-reach, so adding this
         cap's excess over the flat scalar bounds the pair.
@@ -1405,9 +1428,20 @@ class _Repair:
         if not fresh:
             return 0
         for ref, cap in self.caps.items():
-            kept = self._prune_segs(cap, self._cap_geom[ref], fresh)
+            # `.get` rather than a bare index, matching what _pair_effs and
+            # the eff builders already do: st.caps / st.cap_segs / st.segments
+            # are all assignable from a test on a REAL _Repair (test_725 and
+            # test_732 both do it), and a cap this object never pruned for has
+            # no seed geometry to measure a reach from. Skipping it leaves
+            # that cap exactly as the caller built it.
+            geom = self._cap_geom.get(ref)
+            if geom is None or ref not in self.cap_segs:
+                continue
+            kept = self._prune_segs(cap, geom, fresh)
             if kept:
                 self.cap_segs[ref] = self.cap_segs[ref] + kept
+                self._seed_seg_n.setdefault(
+                    ref, len(self.cap_segs[ref]) - len(kept))
         return len(fresh)
 
     def _pad_effs(self, ref, cap):
@@ -1618,15 +1652,22 @@ class _Repair:
             x, y, rot = cap.x, cap.y, cap.rot
             sx, sy, srot = cap.seed_x, cap.seed_y, cap.seed_rot
 
-            def both(fn):
+            def both(fn, seed_kw=None):
                 """Nets charged at the SEED pose or the final one.
 
                 The seed half is the point: the pass SUCCEEDS by leaving
                 nothing charged, so a final-pose-only report is empty exactly
                 when the raised requirement did its work -- and the operator
                 could not tell a run graded at --clearance from one graded at
-                five times it."""
-                out = set(fn(ref, cap, sx, sy, srot))
+                five times it.
+
+                #736: `seed_kw` scopes the SEED half to the copper that
+                existed at the seed. Only the TRACK kind needs it -- the pad
+                and via channels gain nothing after __init__ -- and without it
+                a connector the pass DREW is charged against the cap's seed
+                pads, a pair no board ever had. That is the same class of
+                phantom #731 removed from this very report."""
+                out = set(fn(ref, cap, sx, sy, srot, **(seed_kw or {})))
                 out |= set(fn(ref, cap, x, y, rot))
                 return out
 
@@ -1640,7 +1681,8 @@ class _Repair:
                      both(self._via_shortfalls), None, None),
                     ('track', self.cap_segs[ref],
                      lambda t: self._seg_floor_by_id.get(id(t)), lambda t: t[4],
-                     both(self._seg_shortfalls),
+                     both(self._seg_shortfalls,
+                          {'upto': self._seed_seg_n.get(ref)}),
                      lambda t: t[6], None)):
                 for net, (mm, src) in best(fls, items, floor_of, net_of,
                                            set(charged), cl, layer_of,
@@ -1768,7 +1810,7 @@ class _Repair:
                     by_net[vnet] = by_net.get(vnet, 0.0) + (keepout - d)
         return by_net
 
-    def _seg_shortfalls(self, ref, cap, x, y, rot):
+    def _seg_shortfalls(self, ref, cap, x, y, rot, upto=None):
         """PER-FOREIGN-NET track clearance shortfall for a placement, over the
         tracks this cap's pads actually SHARE COPPER WITH (#731),
         keyed by the track's net_id (#441): {snet: sum of (halfw - dist) over that
@@ -1782,6 +1824,13 @@ class _Repair:
         scalar baseline). Uses the per-cap pruned, layer-scoped track list."""
         by_net: Dict[int, float] = {}
         segs = self.cap_segs[ref]
+        # #736: `upto` grades only the first N entries -- the SEED-ERA ones,
+        # since register_new_segments APPENDS. Used by required_rows' seed
+        # half, which must not charge copper this pass itself drew. A PREFIX
+        # rather than a filtered subset on purpose: the eff rows below are
+        # index-aligned with this list, and a subset would mis-index them.
+        if upto is not None:
+            segs = segs[:upto]
         effs = self._seg_effs(ref, cap)
         if effs is None:
             # No matrix: a duck-typed cap, or a real _Cap with no copper pad
@@ -2342,6 +2391,13 @@ def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
             # non-empty new_segs IMPLIES a non-empty via_moves and the disjunct
             # could never fire. No inner `if new_segs:` either -- the empty
             # case returns immediately inside register_new_segments.
+            #
+            # The CONVERSE is false and this is not an equivalence: a via whose
+            # conn_layers is empty -- no same-net copper terminating in its
+            # body, no containing same-net pad, no same-net zone -- relocates
+            # with no connector at all (and, worth knowing separately, with no
+            # connector validation, since `all(...)` over an empty dict is
+            # vacuously True). That grows via_moves and not new_segs.
             # (writer.py does spell `if via_moves or new_segments:`, and that
             # is right THERE: it wraps two independent text rewrites and is
             # defending against a caller handing it lists it did not produce.)

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -1952,10 +1952,13 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
     def connector_clear(net_id, layer, width, sx, sy, ex, ey):
         hw = width / 2.0
         # The connector is a TRACK on `layer`, so it resolves like one. Note
-        # this honours netclasses and .kicad_dru LAYER rules, but not #549
-        # track-scoped rules, which live in a channel PadClearanceModel does
-        # not carry (kicad_dru.read_board_track_clearances); under-blocking a
+        # this honours netclasses and .kicad_dru LAYER rules, but not
+        # TRACK-SCOPED .kicad_dru rules, which live in a channel
+        # PadClearanceModel does not carry (kicad_dru.read_board_track_clearances,
+        # applied by check_drc at the seg-seg site only). Under-blocking a
         # geometric connector that is separately DRC'd is the safe direction.
+        # Filed as #735. (check_drc.py tags that channel `#549`; GitHub #549 is
+        # a closed, unrelated issue, so this cites the tracker instead.)
         cfl = seg_fl(net_id, layer)
         # board edge / cutouts + NPTH drill holes at their floor (#370 B3):
         # a connector is drawn geometrically, not routed, so it must gate

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -1845,11 +1845,23 @@ def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
             # exactly the case this warning exists to surface, and priced flat
             # it under-reported it.
             pfl = st.pad_floor(p) if _carries else None
-            for vx, vy, vnet, keepout in st.vias:
+            _radii = st._via_radius_by_id
+            for t in st.vias:
+                vx, vy, vnet, keepout = t
                 if vnet == p.net_id:
                     continue
-                ko = (keepout - st._item_reach(st.via_floor(vnet))
-                      + st.via_required(pfl, vnet))
+                # #732: the radius comes from the MAP, never from
+                # `keepout - _item_reach(...)`. That subtraction is the exact
+                # arithmetic re-derivation the map's own comment forbids, and
+                # it re-prices a tuple a test assigned wholesale with its own
+                # keep-out convention. Absent from the map -> the tuple's own
+                # keep-out slot verbatim, which is what via_penalty's flat path
+                # and _via_effs already do with such a tuple. Numerically
+                # identical for every via __init__ built, so this is inert on
+                # every real board (the #732 test file measures that).
+                _rec = _radii.get(id(t))
+                ko = (keepout if _rec is None
+                      else _rec[1] + st.via_required(pfl, vnet))
                 if _point_to_rect_dist(vx, vy, rect) < ko - EPS:
                     locked_hits.append((ref, p.pad_number, vx, vy))
     if locked_hits:

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -1082,8 +1082,16 @@ class _Repair:
                 return '<hole>'
             return names.get(net, str(net))
 
-        def best(floors_a, items, floor_of, net_of, only):
-            """Worst requirement, with its source, over the items on `only`."""
+        def best(floors_a, items, floor_of, net_of, only,
+                 cap_layers=None, layer_of=None, side_of=None):
+            """Worst requirement, with its source, over the items on `only`.
+
+            Takes the SAME two per-pad guards the eff builders take, because a
+            report that re-derives the price instead of mirroring it reports
+            pairs the pass never charged. Both were measured: without the
+            layer guard, up to 43% of the rows on rp2350 named a cap pad
+            against a track on a layer it does not occupy -- pairs check_drc
+            does not grade and `_seg_effs` prices at the flat scalar."""
             out = {}
             for t in items:
                 net = net_of(t)
@@ -1092,7 +1100,21 @@ class _Repair:
                 fb = floor_of(t)
                 if fb is None:
                     continue
-                for fa in floors_a:
+                # an SMD foreign pad on the other board side is skipped by
+                # _pad_shortfalls, so it charges nothing and belongs in no row
+                pside = None if side_of is None else side_of(t)
+                if pside is not None and pside != cap.side:
+                    continue
+                layer = None if layer_of is None else layer_of(t)
+                for i, fa in enumerate(floors_a):
+                    # a copper-less cap pad is graded flat, so it charges
+                    # nothing and belongs in no row
+                    if _Repair._flat_pad(cap_layers, i):
+                        continue
+                    # ...and neither does a pair that shares no copper layer
+                    if (layer is not None and cap_layers is not None
+                            and layer not in cap_layers[i]):
+                        continue
                     mm, src = pair_with_source(fa, fb)
                     if src and mm > out.get(net, (0.0, ''))[0]:
                         out[net] = (mm, src)
@@ -1117,18 +1139,21 @@ class _Repair:
                 out |= set(fn(ref, cap, x, y, rot))
                 return out
 
-            for kind, items, floor_of, net_of, charged in (
+            cl = self._cap_pad_layers(cap)
+            for kind, items, floor_of, net_of, charged, layer_of, side_of in (
                     ('pad', self.cap_foreign_pads[ref],
                      lambda t: self._fp_floor_by_id.get(id(t)), lambda t: t[4],
-                     both(self._pad_shortfalls)),
+                     both(self._pad_shortfalls), None, lambda t: t[5]),
                     ('via', self.cap_vias[ref],
                      lambda t: self._via_floor_for(t[2]), lambda t: t[2],
-                     both(self._via_shortfalls)),
+                     both(self._via_shortfalls), None, None),
                     ('track', self.cap_segs[ref],
                      lambda t: self._seg_floor_by_id.get(id(t)), lambda t: t[4],
-                     both(self._seg_shortfalls))):
+                     both(self._seg_shortfalls),
+                     lambda t: self._seg_layer_by_id.get(id(t)), None)):
                 for net, (mm, src) in best(fls, items, floor_of, net_of,
-                                           set(charged)).items():
+                                           set(charged), cl, layer_of,
+                                           side_of).items():
                     rows.append([ref, '{} {}'.format(kind, net_label(net)),
                                  round(mm, 6), src])
             # mover-vs-mover: the shortfall is a scalar per pair, so charge the
@@ -1150,8 +1175,13 @@ class _Repair:
                 if now <= EPS and was <= EPS:
                     continue
                 mm, src = 0.0, ''
-                for fa in fls:
-                    for fb in other.pad_floors:
+                theirs = self._cap_pad_layers(other)
+                for i, fa in enumerate(fls):
+                    if self._flat_pad(cl, i):
+                        continue
+                    for j, fb in enumerate(other.pad_floors):
+                        if self._flat_pad(theirs, j):
+                            continue
                         m, sc = pair_with_source(fa, fb)
                         if sc and m > mm:
                             mm, src = m, sc
@@ -1184,13 +1214,23 @@ class _Repair:
         effs = None if ref is None else self._via_effs(ref, cap, vias)
         pen = 0.0
         if effs is None:
+            # The tuple's slot is the prune OVER-reach, not a requirement, so
+            # grading it directly would charge more than any pair needs (and
+            # more than upstream's slot, which was radius + clearance). Recover
+            # the radius where we know it and grade at the flat scalar, which
+            # is what this path documents. A tuple absent from the map -- one a
+            # test assigned wholesale -- is graded exactly as injected.
+            by_id = self._via_radius_by_id
             for (bx0, by0, bx1, by1, net) in cap.pad_rects(x, y, rot):
-                for vx, vy, vnet, keepout in vias:
+                for v in vias:
+                    vx, vy, vnet, keepout = v
                     if vnet == net:
                         continue
+                    rec = by_id.get(id(v))
+                    ko = keepout if rec is None else rec[1] + self.clearance
                     d = _point_to_rect_dist(vx, vy, (bx0, by0, bx1, by1))
-                    if d < keepout - EPS:
-                        pen += (keepout - d)
+                    if d < ko - EPS:
+                        pen += (ko - d)
             return pen
         # #725 active path: effs[i][j] IS the pair's keep-out (via radius +
         # required clearance), precomputed -- the tuple's own keepout slot is
@@ -1551,12 +1591,16 @@ def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
         if fp is None:
             continue
         for p in fp.pads:
-            # #725: the copper predicate is the shared one. An np_thru_hole pad
-            # lists *.Cu and carries no copper, so the loose test named it here
-            # as a copper obstacle -- and would have charged its keep-clear
-            # override besides.
-            if not _pad_carries_copper(p):
+            # #725: an np_thru_hole pad lists *.Cu and carries no copper. It
+            # is still WARNED ABOUT -- upstream did, foreign_pads does, and a
+            # via inside a 1.7mm mounting hole is exactly what this warning is
+            # for -- but it is graded FLAT: its keep-clear override is not
+            # copper and must not raise the pair. Dropping it outright (the
+            # first version of this fix) removed real rows on boards that
+            # declare nothing at all.
+            if not any(str(l).endswith('.Cu') for l in p.layers):
                 continue
+            _carries = _pad_carries_copper(p)
             # ...and the RECT gets the same rect_rotation inflation _Cap and
             # foreign_pads use. This was the one pad-geometry site in the file
             # built from raw size_x/size_y, so a tilted locked pad under-blocked
@@ -1574,7 +1618,7 @@ def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
             # from the via's radius. A locked fiducial's keep-clear override is
             # exactly the case this warning exists to surface, and priced flat
             # it under-reported it.
-            pfl = st.pad_floor(p)
+            pfl = st.pad_floor(p) if _carries else None
             for vx, vy, vnet, keepout in st.vias:
                 if vnet == p.net_id:
                     continue
@@ -1881,9 +1925,21 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
     def cap_floors_of(cap, rects):
         """This cap's per-pad floors, index-aligned with `rects` -- or None,
         which grades flat. Tests drive this function with a duck-typed cap that
-        carries neither the attribute nor a matching length."""
+        carries neither the attribute nor a matching length.
+
+        A pad whose `pad_layers` entry is EMPTY carries no copper, and its
+        entry comes back None so it grades flat here too. The eff builders key
+        on that same marker; without it the nudger would charge a phantom the
+        grader does not, hand itself a via nothing flagged, and print an
+        operator-facing line naming a non-violation.
+        """
         pf = getattr(cap, 'pad_floors', None)
-        return pf if (pf is not None and len(pf) == len(rects)) else None
+        if pf is None or len(pf) != len(rects):
+            return None
+        pl = getattr(cap, 'pad_layers', None)
+        if pl is None or len(pl) != len(pf):
+            return list(pf)
+        return [f if pl[i] else None for i, f in enumerate(pf)]
 
     # `all_cap_rects` is function-local, so it CAN carry the pad's floor.
     all_cap_rects = []

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -170,6 +170,17 @@ class _Cap:
         # makes the alignment true by construction.
         self.pad_floors = []
         self.max_floor = 0.0
+        # Per-pad COPPER LAYER sets, index-aligned like pad_floors. Needed
+        # because self.segments records only an 'F'/'B' side and files an
+        # In1.Cu track under 'F' (a pre-existing model quirk), so an F-side cap
+        # pad is compared against inner-layer tracks it can never touch. That
+        # phantom is priced at the flat scalar today; without this set the
+        # NETCLASS term -- which is layer-blind -- would raise it too, and the
+        # pass would move caps to clear copper on a layer their pads do not
+        # occupy. Measured on orangecrab at --clearance 0.1 with a Default
+        # class of 0.3: R17/R18/R5's ENTIRE graze is that phantom, 0.082mm
+        # each flat and 0.70/0.70/0.57mm raised. See _seg_effs.
+        self.pad_layers = []
         for p in fp.pads:
             if not any(str(l).endswith('.Cu') for l in p.layers):
                 continue  # paste/mask-only aperture, not copper
@@ -195,6 +206,9 @@ class _Cap:
                 fl = (model.pad_floor(p) if _pad_carries_copper(p)
                       else PadFloor(0.0, 0.0, None))
                 self.pad_floors.append(fl)
+                from check_drc import pad_copper_layers
+                self.pad_layers.append(
+                    frozenset(pad_copper_layers(p, model.board_copper)))
                 mf = model.max_floor(fl)
                 if mf > self.max_floor:
                     self.max_floor = mf
@@ -408,11 +422,18 @@ class _Repair:
         # the model is inert. The 4-tuple shape is pinned: tests assign
         # st.vias wholesale and animate_fanout_clearance.py unpacks it.
         self.vias: List[Tuple[float, float, int, float]] = []
+        # The RADIUS, keyed on the tuple's identity. _via_effs has to strip the
+        # over-reach back off element 3, and deriving the radius arithmetically
+        # would silently mis-price a tuple a test assigned wholesale with a
+        # different keep-out convention. Absent from this map -> graded flat,
+        # which is the same fallback _pad_effs and _seg_effs already take.
+        self._via_radius_by_id: Dict[int, float] = {}
         for v in pcb_data.vias:
             size = v.size if v.size and v.size > 0 else default_via_size
-            self.vias.append((v.x, v.y, v.net_id,
-                              size / 2.0 + self._item_reach(
-                                  self._via_floor_for(v.net_id))))
+            t = (v.x, v.y, v.net_id,
+                 size / 2.0 + self._item_reach(self._via_floor_for(v.net_id)))
+            self.vias.append(t)
+            self._via_radius_by_id[id(t)] = size / 2.0
 
         # --- avoidance: foreign-net tracks on the cap's own side ---
         # Fanout escapes can land on the bottom (cap) side; attraction could
@@ -430,12 +451,17 @@ class _Repair:
         # tuples live for this object's lifetime, so the id is stable; a tuple a
         # test injects is simply absent and grades flat.
         self._seg_floor_by_id: Dict[int, PadFloor] = {}
+        # ...and its REAL layer, for the same reason: the pruned list is built
+        # on the F/B side collapse, so _seg_effs needs the true layer to tell a
+        # pair that shares copper from one that cannot.
+        self._seg_layer_by_id: Dict[int, str] = {}
         for s in pcb_data.segments:
             side = 'B' if (s.layer or '').startswith('B') else 'F'
             fl = self._seg_floor_for(s.net_id, s.layer)
             t = (s.start_x, s.start_y, s.end_x, s.end_y, s.net_id,
                  s.width / 2.0 + self._item_reach(fl), side)
             self.segments.append(t)
+            self._seg_layer_by_id[id(t)] = s.layer
             if fl is not None:
                 self._seg_floor_by_id[id(t)] = fl
 
@@ -492,6 +518,11 @@ class _Repair:
         # #725 is about, and it interacts with the #617 balance below; filed
         # separately. (watchy's 8 NPTH overrides are all 0.100, below the 0.20
         # fab floor, so that board is numerically inert here.)
+        # NB: self.foreign_pads (and self.segments) are read nowhere after
+        # __init__ -- the pruned per-cap lists are what the sweep uses. They
+        # must NOT be deleted as dead: the id-keyed floor maps below depend on
+        # those tuples staying alive, and a recycled id would return ANOTHER
+        # item's floor, silently, with no error.
         self.foreign_pad_floors: List[Optional[PadFloor]] = []
         self.foreign_pad_mf: List[float] = []
         self.caps: Dict[str, _Cap] = {}
@@ -897,8 +928,29 @@ class _Repair:
         floors = [by_id.get(id(t)) for t in src]
         # t[5] is half width + the segment's own over-reach; strip it back.
         halves = [t[5] - self._item_reach(f) for t, f in zip(src, floors)]
-        rows = [[halves[j] + self._pair_or_flat(fa, floors[j])
-                 for j in range(len(src))] for fa in cap.pad_floors]
+        # A pair that shares NO copper layer keeps the FLAT scalar. cap_segs is
+        # pruned on the 'F'/'B' side collapse, which files an In1.Cu track
+        # under 'F', so it contains F-pad/inner-track pairs that cannot touch.
+        # The dru term already scopes itself away from them (empty shared set),
+        # but the netclass term does not -- and raising a phantom is how this
+        # change would move caps for a non-violation. Charging it flat leaves
+        # the pre-existing phantom exactly as it was; removing it altogether is
+        # a separate fix to the side collapse, filed rather than folded in.
+        cap_layers = getattr(cap, 'pad_layers', None)
+        if cap_layers is not None and len(cap_layers) != len(cap.pad_floors):
+            cap_layers = None      # a duck-typed cap; grade flat
+        seg_layers = [self._seg_layer_by_id.get(id(t)) for t in src]
+
+        def eff(fa, mine, j):
+            sl = seg_layers[j]
+            if mine is not None and sl is not None and sl not in mine:
+                return self.clearance
+            return self._pair_or_flat(fa, floors[j])
+
+        rows = [[halves[j] + eff(fa, None if cap_layers is None
+                                 else cap_layers[i], j)
+                 for j in range(len(src))]
+                for i, fa in enumerate(cap.pad_floors)]
         self._cap_seg_eff[ref] = (src, rows)
         return rows
 
@@ -912,10 +964,18 @@ class _Repair:
         rec = self._cap_via_eff.get(ref)
         if rec is not None and rec[0] is vias:
             return rec[1]
-        # v[3] is radius + the via's own over-reach; strip it back to a radius.
-        radii = [v[3] - self._item_reach(self._via_floor_for(v[2])) for v in vias]
-        rows = [[radii[j] + self.via_required(fa, v[2])
-                 for j, v in enumerate(vias)] for fa in cap.pad_floors]
+        # The radius comes from the identity map, never from arithmetic on
+        # v[3]: a tuple a test assigned wholesale carries its own keep-out
+        # convention, and re-deriving would mis-price it silently. Absent ->
+        # graded flat, i.e. v[3] is used as-is.
+        by_id = self._via_radius_by_id
+        rows = []
+        for fa in cap.pad_floors:
+            row = []
+            for v in vias:
+                r = by_id.get(id(v))
+                row.append(v[3] if r is None else r + self.via_required(fa, v[2]))
+            rows.append(row)
         self._cap_via_eff[ref] = (vias, rows)
         return rows
 
@@ -927,6 +987,13 @@ class _Repair:
             return None
         key = (ref, oref)
         rows = self._cap_pair_eff.get(key)
+        # The other three memos guard on their source list's identity; this one
+        # has no list to key on, so it validates its own SHAPE instead. Both
+        # exist for the same reason: st.caps / st.cap_* are assignable from a
+        # test, and a stale memo here is an IndexError or a wrong requirement.
+        if rows is not None and (len(rows) != len(cap.pad_floors)
+                                 or (rows and len(rows[0]) != len(other.pad_floors))):
+            rows = None
         if rows is None:
             rows = [[self._pair_or_flat(fa, fb) for fb in other.pad_floors]
                     for fa in cap.pad_floors]
@@ -978,16 +1045,30 @@ class _Repair:
                 continue
             fls = cap.pad_floors
             x, y, rot = cap.x, cap.y, cap.rot
+            sx, sy, srot = cap.seed_x, cap.seed_y, cap.seed_rot
+
+            def both(fn):
+                """Nets charged at the SEED pose or the final one.
+
+                The seed half is the point: the pass SUCCEEDS by leaving
+                nothing charged, so a final-pose-only report is empty exactly
+                when the raised requirement did its work -- and the operator
+                could not tell a run graded at --clearance from one graded at
+                five times it."""
+                out = set(fn(ref, cap, sx, sy, srot))
+                out |= set(fn(ref, cap, x, y, rot))
+                return out
+
             for kind, items, floor_of, net_of, charged in (
                     ('pad', self.cap_foreign_pads[ref],
                      lambda t: self._fp_floor_by_id.get(id(t)), lambda t: t[4],
-                     self._pad_shortfalls(ref, cap, x, y, rot)),
+                     both(self._pad_shortfalls)),
                     ('via', self.cap_vias[ref],
                      lambda t: self._via_floor_for(t[2]), lambda t: t[2],
-                     self._via_shortfalls(ref, cap, x, y, rot)),
+                     both(self._via_shortfalls)),
                     ('track', self.cap_segs[ref],
                      lambda t: self._seg_floor_by_id.get(id(t)), lambda t: t[4],
-                     self._seg_shortfalls(ref, cap, x, y, rot))):
+                     both(self._seg_shortfalls))):
                 for net, (mm, src) in best(fls, items, floor_of, net_of,
                                            set(charged)).items():
                     rows.append([ref, '{} {}'.format(kind, net_label(net)),
@@ -995,13 +1076,20 @@ class _Repair:
             # mover-vs-mover: the shortfall is a scalar per pair, so charge the
             # pair as a whole and name it by the partner's reference.
             cand = cap.pad_rects(x, y, rot)
+            seed = cap.pad_rects(sx, sy, srot)
             for oref in self.cap_caps[ref]:
                 other = self.caps[oref]
                 if not self._cap_floors_ok(other):
                     continue
                 effs = self._pair_effs(ref, cap, oref, other)
-                if _pad_pair_shortfall(cand, other.pad_rects(),
-                                       self.clearance, effs) <= EPS:
+                # seed pose OR final pose, for the reason `both` gives above
+                now = _pad_pair_shortfall(cand, other.pad_rects(),
+                                          self.clearance, effs)
+                was = _pad_pair_shortfall(
+                    seed, other.pad_rects(other.seed_x, other.seed_y,
+                                          other.seed_rot),
+                    self.clearance, effs)
+                if now <= EPS and was <= EPS:
                     continue
                 mm, src = 0.0, ''
                 for fa in fls:

--- a/py_tools/animate_fanout_clearance.py
+++ b/py_tools/animate_fanout_clearance.py
@@ -230,7 +230,10 @@ def main():
                    "(default: input_capmove.gif)")
     p.add_argument("--clearance", type=float, default=defaults.CLEARANCE)
     p.add_argument("--grid-step", type=float, default=defaults.GRID_STEP)
-    p.add_argument("--board-edge-clearance", type=float, default=0.55)
+    # None, not 0.55 (#733): the engine resolves it, so the GIF frames the
+    # same usable box the run it visualises actually used. A private copy
+    # here would be a third notion of the margin -- the defect #733 closed.
+    p.add_argument("--board-edge-clearance", type=float, default=None)
     p.add_argument("--capture-radius", type=float, default=2.0)
     p.add_argument("--default-via-size", type=float, default=DEFAULT_VIA_SIZE)
     p.add_argument("--near-margin", type=float, default=1.0)

--- a/tests/gui_parity/test_733_cap_edge_clearance_gui.py
+++ b/tests/gui_parity/test_733_cap_edge_clearance_gui.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""#733: the cap-placement edge margin, read off the REAL headless dialog.
+
+`tests/test_733_fanout_clearance_edge_margin.py` covers the engine and greps
+`fanout_gui.py` for the kwarg, but the `swig_gui.py` half -- the resolver and
+the shared-params key -- was gated by NOTHING. Measured by the #733 review:
+deleting `'cap_board_edge_clearance': self._effective_placement_edge_clearance()`
+from `get_shared_params`, or making that method `return None` always, left every
+one of those tests green while the operator's override silently stopped
+travelling.
+
+The three states this asserts, and why each is load-bearing:
+
+  * UNCHECKED -> None, so the engine resolves (CLI parity with an omitted
+    --board-edge-clearance). Not `_effective_board_edge_clearance`, which is the
+    SIGNAL keep-out: it answers 0.0 on a board with no rule and is then
+    fab-floored to 0.20, so reusing it would inset caps at 0.20 instead of 0.55
+    -- a 0.35mm relaxation shipped inside the parity fix. The signal key is read
+    here too, as the negative control that proves the two are different numbers.
+  * CHECKED with a real value -> that value, honoured as typed.
+  * CHECKED with ZERO -> None. This is the footgun the review found: the control
+    is CREATED at defaults.BOARD_EDGE_CLEARANCE (0.0) with a range minimum of
+    0.0, so "ticked the box, typed nothing" is a reachable state, and passing it
+    on would inset caps at the bare clearance -- LOOSER than the 0.55 this tab
+    used before #733.
+
+Needs KiCad's python (wx + pcbnew); re-execs into it automatically, like its
+siblings. Constructs the dialog headless and reads dict values. No routing runs;
+seconds, not minutes.
+
+Run: python3 tests/gui_parity/test_733_cap_edge_clearance_gui.py
+"""
+import os
+import subprocess
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+
+KICAD_PYTHONS = [
+    '/Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/'
+    'Versions/Current/bin/python3',
+    '/usr/bin/python3',
+    r'C:\Program Files\KiCad\10.0\bin\python.exe',
+]
+
+
+def _reexec_into_kicad():
+    for cand in KICAD_PYTHONS:
+        if cand == sys.executable or not os.path.exists(cand):
+            continue
+        if subprocess.run([cand, '-c', 'import pcbnew, wx'],
+                          capture_output=True).returncode == 0:
+            argv = [cand, os.path.abspath(__file__)] + sys.argv[1:]
+            if os.name == 'nt':
+                sys.exit(subprocess.run(argv).returncode)
+            os.execv(cand, argv)
+    # Exit 0, like every sibling in this directory -- these gates are run by
+    # hand and by contributors who may not have KiCad installed, and a hard
+    # failure there is noise, not signal. But say plainly that the gate did NOT
+    # run: this file exists because the swig_gui half was covered by nothing,
+    # and a silent skip re-creates exactly that state on a machine without wx.
+    # CLAUDE.md: probe before recording it as not-run --
+    #   <kicad>/bin/python3 -c "import pcbnew, wx; print(wx.version())"
+    print("SKIP: no python with pcbnew+wx found -- THIS GATE DID NOT RUN, and "
+          "nothing else covers swig_gui._effective_placement_edge_clearance")
+    sys.exit(0)
+
+
+def main():
+    try:
+        import wx  # noqa: F401
+        import pcbnew  # noqa: F401
+    except ImportError:
+        _reexec_into_kicad()
+
+    os.environ.setdefault('WXSUPPRESS_SIZER_FLAGS_CHECK', '1')
+    import wx
+    sys.path.insert(0, REPO)
+    sys.path.insert(0, os.path.join(REPO, 'py_router'))
+    sys.path.insert(0, os.path.join(REPO, 'py_placer'))
+    sys.path.insert(0, os.path.join(REPO, 'py_tools'))
+    sys.path.insert(0, os.path.dirname(REPO))
+
+    app = wx.App(False)  # noqa: F841  (before any wx object)
+    board = os.path.join(REPO, 'kicad_files', 'splitflap_driver.kicad_pcb')
+    from kicad_parser import parse_kicad_pcb
+    from kicad_routing_plugin.swig_gui import RoutingDialog
+    from placement.fanout_clearance import (CAP_EDGE_CLEARANCE,
+                                            resolve_cap_edge_clearance)
+
+    dlg = RoutingDialog(None, parse_kicad_pcb(board), board)
+    failures = []
+
+    def check(what, ok, detail=''):
+        # `detail` is the FAILURE explanation, so print it only on failure --
+        # an OK line carrying "the key is absent" reads as a contradiction.
+        print(('  OK   ' if ok else '  FAIL ') + what
+              + ('' if ok or not detail else ' -- ' + detail))
+        if not ok:
+            failures.append(what)
+
+    def shared():
+        return dlg.fanout_tab.get_shared_params()
+
+    # ON THE GATE: the key must EXIST, or every assertion below reads None from
+    # a dict that simply never carried it and the file passes vacuously.
+    dlg.edge_clearance_check.SetValue(True)
+    dlg.board_edge_clearance.SetValue(0.8)
+    s = shared()
+    check('get_shared_params carries cap_board_edge_clearance',
+          'cap_board_edge_clearance' in s,
+          'the key is absent -- the operator override never reaches the engine')
+    check('checked 0.8 -> the typed value travels',
+          s.get('cap_board_edge_clearance') == 0.8,
+          repr(s.get('cap_board_edge_clearance')))
+
+    dlg.edge_clearance_check.SetValue(False)
+    s = shared()
+    cap, sig = s.get('cap_board_edge_clearance'), s.get('board_edge_clearance')
+    check('unchecked -> None, so the ENGINE resolves it', cap is None, repr(cap))
+    check('...and the engine then answers the placement default',
+          resolve_cap_edge_clearance(board, cap)
+          == (CAP_EDGE_CLEARANCE, 'fixed default'))
+    # NEGATIVE CONTROL: the SIGNAL twin on the same control answers something
+    # else entirely, and something SMALLER. Not `sig != cap` -- with cap None
+    # that is true of any float and would pass on a build that had wired the
+    # two together in the other direction.
+    check('the signal keep-out is a real number, not None',
+          isinstance(sig, (int, float)),
+          f'signal={sig!r} -- the control this compares against is gone')
+    check('...and it is BELOW the placement default, so reusing it would have '
+          'inset caps closer to the edge',
+          isinstance(sig, (int, float)) and sig < CAP_EDGE_CLEARANCE,
+          f'signal={sig!r} vs placement default {CAP_EDGE_CLEARANCE}')
+
+    # The footgun: ticked, but never typed in. SetValue(0.0) reproduces the
+    # control's own creation state (defaults.BOARD_EDGE_CLEARANCE, range min 0).
+    dlg.edge_clearance_check.SetValue(True)
+    dlg.board_edge_clearance.SetValue(0.0)
+    cap = shared().get('cap_board_edge_clearance')
+    check('checked but ZERO -> None (an empty override is UNSET)',
+          cap is None, repr(cap))
+    check('...so the margin does not fall below the placement default',
+          resolve_cap_edge_clearance(board, cap)[0] == CAP_EDGE_CLEARANCE)
+
+    dlg.Destroy()
+    print()
+    if failures:
+        print(f"VERDICT: {len(failures)} FAILURE(S): {', '.join(failures)}")
+        return 1
+    print("VERDICT: cap edge margin reaches the engine from the real dialog")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/gui_parity/test_cli_postpass_coverage.py
+++ b/tests/gui_parity/test_cli_postpass_coverage.py
@@ -40,10 +40,18 @@ PLUGIN = REPO / "kicad_routing_plugin"
 # post-passes (run_drc graze audit, fix_project_for_output) were a blind spot.
 # Point at the package __init__ where main() actually lives.
 # #522 layout: the CLI mains live under py_router/.
+# #725: place_fanout_clearance.py was absent, so this gate never scanned the
+# decoupling-cap repair CLI even though its main() runs two tracked post-passes
+# (warn_if_missing_project_floor, fix_project_for_output). That matters
+# specifically because the cap-repair engine now reads the sibling .kicad_pro
+# and .kicad_dru for its own arithmetic: dropping the project on the way out
+# does not just cost the next step its DRC floor, it silently changes what the
+# NEXT cap-repair run prices at.
 CLI_MAINS = ["py_router/route.py", "py_router/route_diff.py",
              "py_router/route_planes.py", "py_router/repair_planes.py",
              "py_router/bga_fanout/__init__.py",
-             "py_router/qfn_fanout/__init__.py"]
+             "py_router/qfn_fanout/__init__.py",
+             "py_placer/place_fanout_clearance.py"]
 
 # Known post-engine passes -> GUI counterpart symbol(s). A pass is "covered" if
 # ANY listed symbol appears anywhere under kicad_routing_plugin/. Keep the RHS

--- a/tests/gui_parity/test_manifest_plan_parity.py
+++ b/tests/gui_parity/test_manifest_plan_parity.py
@@ -282,6 +282,13 @@ _MUST_RESOLVE = {
     'impedance', 'ordering', 'direction', 'time_matching',
     'keepout', 'guide_corridor', 'length_match_groups', 'swappable_nets',
     'polarity_swap_nets', 'qfn_track_width', 'qfn_clearance',
+    # #733: place_fanout_clearance's --board-edge-clearance -> the SHARED
+    # Basic-tab edge control (not a cap_* one), which ai_plan's
+    # _GEOMETRY_OVERRIDE_CHECKS ticks by this exact name. This set gates the
+    # NAME (does it reach a control?); check_cap_flags below gates the
+    # converter ROW that produces it. Measured: deleting the CAP_FLAG_PARAMS
+    # row leaves this half green, which is why both exist.
+    'board_edge_clearance',
 }
 
 
@@ -342,6 +349,42 @@ def check_param_resolution():
             bad.append((p, f"alias -> {tgt!r}, but no such GUI control"))
         else:
             bad.append((p, "no control, no alias, not special -> would be ignored"))
+    return bad
+
+
+def check_cap_flags():
+    """#733: the optimize_caps step's flags survive conversion.
+
+    The pairs loop above deliberately `continue`s on place_fanout_clearance.py
+    ("optimize_caps: no routing flags to assert"), so nothing there looks at
+    CAP_FLAG_PARAMS at all. That was harmless while every row named a
+    bga_options control the plan executor ignores anyway; it stopped being
+    harmless when --board-edge-clearance joined the table, because that one
+    names a REAL dialog control and changes where cap copper may sit relative
+    to Edge.Cuts. Measured: deleting its row left the whole gate green.
+
+    Self-contained, like check_group_flags: no corpus needed.
+    """
+    bad = []
+    argv = ['python3', 'py_placer/place_fanout_clearance.py', 'in.kicad_pcb',
+            'out.kicad_pcb', '--board-edge-clearance', '0.85',
+            '--near-margin', '1.5', '--no-rotate']
+    step = m2p.cap_optimization_step(argv)
+    if step.get('action') != 'optimize_caps':
+        return [('(step)', f"action is {step.get('action')!r}")]
+    params = step.get('params') or {}
+    for flag, key, want in (('--board-edge-clearance', 'board_edge_clearance', 0.85),
+                            ('--near-margin', 'cap_near_margin', 1.5),
+                            ('--no-rotate', 'cap_allow_rotation', False)):
+        if params.get(key) != want:
+            bad.append((flag, f"-> {key}={params.get(key)!r}, expected {want!r}"))
+    # NEGATIVE CONTROL: an omitted flag must NOT be invented. An engine-resolved
+    # default that leaked into the plan would pin the margin at plan time and
+    # defeat the point of resolving it per board.
+    bare = m2p.cap_optimization_step(
+        ['python3', 'py_placer/place_fanout_clearance.py', 'in.kicad_pcb'])
+    if 'board_edge_clearance' in (bare.get('params') or {}):
+        bad.append(('(omitted)', 'an unset flag was materialised into the plan'))
     return bad
 
 
@@ -473,6 +516,13 @@ def main():
     for p, why in res_bad:
         print(f"    {p}: {why}")
 
+    # #733 optimize_caps flags (self-contained, no corpus needed).
+    cap_bad = check_cap_flags()
+    print(f"\nCap-optimization flags: {'OK' if not cap_bad else 'FAILED'} "
+          f"(--board-edge-clearance and the cap_* knobs survive).")
+    for f, why in cap_bad:
+        print(f"    {f}: {why}")
+
     # #459 placement-block flags (self-contained, no corpus needed).
     grp_bad = check_group_flags()
     print(f"\nPlacement-block flags: {'OK' if not grp_bad else 'FAILED'} "
@@ -486,7 +536,7 @@ def main():
     for f, why in ref_bad:
         print(f"    {f}: {why}")
 
-    return 1 if (total_bad or res_bad or grp_bad or ref_bad) else 0
+    return 1 if (total_bad or res_bad or cap_bad or grp_bad or ref_bad) else 0
 
 
 if __name__ == "__main__":

--- a/tests/stress/manifest_to_plan.py
+++ b/tests/stress/manifest_to_plan.py
@@ -440,6 +440,13 @@ CAP_FLAG_PARAMS = {
     '--displacement-growth': 'cap_displacement_growth',
     '--max-passes': 'cap_max_passes',
     '--cap-prefix': 'cap_prefix',
+    # #733. NOT a cap_* name: its GUI home is the SHARED Basic-tab edge control,
+    # which ai_plan._GEOMETRY_OVERRIDE_CHECKS already maps by this exact name
+    # ('board_edge_clearance' -> 'edge_clearance_check'), so a plan carrying it
+    # ticks the override box and the value reaches the engine. Only an EXPLICIT
+    # flag needs carrying: an omitted one now resolves to the same number on
+    # both fronts (placement/fanout_clearance.resolve_cap_edge_clearance).
+    '--board-edge-clearance': 'board_edge_clearance',
 }
 CAP_BOOL_FLAGS = {'--no-rotate': ('cap_allow_rotation', False)}  # inverted sense
 

--- a/tests/test_628_cap_owns_milled_ring.py
+++ b/tests/test_628_cap_owns_milled_ring.py
@@ -155,9 +155,9 @@ def main():
               'C1' in rep.caps)
         check("fixture: the edge gate is ACTIVE (else nothing is tested)",
               rep.edge_gate.active)
-        check(f"fixture: gate margin is non-zero ({rep._edge_margin}) -- the "
+        check(f"fixture: gate margin is non-zero ({rep.edge_margin}) -- the "
               f"'margin-0 is inert' argument does not cover this gate",
-              rep._edge_margin > 0.0)
+              rep.edge_margin > 0.0)
 
         # --- API surface (reported, not fatal -- see _owned/_blocked above)
         check("API: _Repair grows _owned_rings",

--- a/tests/test_725_fanout_clearance_pad_floors.py
+++ b/tests/test_725_fanout_clearance_pad_floors.py
@@ -620,9 +620,11 @@ class TestPruneRadiiStayExact(unittest.TestCase):
 
     def test_the_seed_baseline_is_in_the_SAME_currency(self):
         """A baseline priced flat while candidates price at the requirement
-        makes `_worsens_any_net` fire on every pose and the pass stops moving
-        anything -- a failure whose symptom is FEWER placements, which reads as
-        conservative rather than broken."""
+        makes `_worsens_any_net` compare two different units, so the accept
+        gate reads a pose as worse-than-seed on a pair that did not change.
+        Measured by reverting that line at HEAD, the placement count moves in a
+        CLASS-DEPENDENT direction and not by much -- which is exactly why this
+        asserts the CURRENCY rather than a placement count."""
         raised = [k for k, v in self.st.base_cap_pad.items() if v > 0.0]
         self.assertTrue(raised, 'no mover pair has a non-zero seed baseline')
         for key in raised:

--- a/tests/test_725_fanout_clearance_pad_floors.py
+++ b/tests/test_725_fanout_clearance_pad_floors.py
@@ -461,35 +461,50 @@ class TestChannels(unittest.TestCase):
     # is no longer 0. MUTATION: make `_seg_shares` return False always -> `on`
     # drops to 0 and the vacuity guard fires.
 
-    def test_a_board_with_NO_copper_layers_is_not_scoped_by_layer(self):
+    def test_a_board_with_NO_copper_layers_RESOLVES_one(self):
         """If `board_info.copper_layers` is empty, `pad_copper_layers` resolves
-        NOTHING for a `*.Cu` pad -- so every cap pad would look copper-less,
-        every pair would take the off-layer fallback, and the whole board would
-        be graded at the flat scalar. Before the layer scoping existed such a
-        board only ever OVER-blocked; the fallback flips the direction, and
-        under-blocking ships a violation. So the scoping switches itself off."""
+        NOTHING for a `*.Cu` pad -- so every such pad reads copper-less and the
+        scoping would grade the board at the flat scalar. #725 handled that by
+        switching scoping OFF entirely, on the reasoning that the board only
+        ever over-blocked before.
+
+        #731 corrected the reasoning. Switching off falls back to the 'F'/'B'
+        side collapse, and check_drc does NOT switch off: it resolves the same
+        situation with a three-level fallback (filter to `.Cu`, then the layers
+        segments sit on, then ['F.Cu','B.Cu']) and still expands and grades a
+        `*.Cu` pad over the result. The side collapse drops every B.Cu and
+        inner track a through-hole pad shares copper with -- an UNDER-block,
+        which is what actually ships a violation. Measured on rp2350 with the
+        copper list cleared and cap pads made through-hole: 280 pairs check_drc
+        grades that the old fallback ignored.
+
+        So `_Repair` now resolves a copper list the same way check_drc does,
+        and `_all_cu` is never empty on a board that has any copper at all."""
         with tempfile.TemporaryDirectory() as td:
             p = _stage(td, 'nocu', classes=_default_class(0.4))
             pcb = parse_kicad_pcb(p)
+            real = list(pcb.board_info.copper_layers)
             pcb.board_info.copper_layers = []
             st = _repair(p, pcb=pcb)
             # ON THE BRANCH: the model must still be active, or nothing is
             # scoped anyway and this passes for the wrong reason.
             self.assertIsNotNone(st._floors)
-            self.assertEqual(st._all_cu, frozenset())
+            self.assertEqual(pcb.board_info.copper_layers, [])
+            # ...and the fallback reconstructed a real list from the segments.
+            self.assertTrue(st._all_cu, 'the fallback resolved no copper')
+            self.assertTrue(st._all_cu <= set(real),
+                            'the fallback invented a layer: %r'
+                            % (st._all_cu - set(real),))
             cap = st.caps[ANCHOR_CAP]
-            self.assertIsNone(st._cap_pad_layers(cap),
-                              'layer scoping stayed on with no copper layers')
+            self.assertIsNotNone(st._cap_pad_layers(cap),
+                                 'layer scoping switched itself off')
             rows = st._pad_effs(ANCHOR_CAP, cap)
             self.assertTrue(rows)
             self.assertIn(0.4, {round(v, 6) for r in rows for v in r},
                           'every pair fell back to the flat scalar -- the '
                           'board is now UNDER-blocked')
-    # MUTATION: `return pl if self._all_cu else None` -> `return pl` -> the
-    # `assertIsNone` fails. NB the effs are 0.4 either way on this board: only
-    # a `*.Cu` pad resolves empty against an empty layer list, and orangecrab's
-    # cap pads are all concrete F.Cu/B.Cu, so the under-block this guards
-    # against needs a through-hole cap pad to appear at all.
+    # MUTATION: drop the segment-derived fallback for `_all_cu` -> it is empty,
+    # `_cap_pad_layers` returns None and the assertIsNotNone fires.
 
     def test_a_relaxing_rule_REPLACES_downward(self):
         """A dru rule REPLACES, so it can lower a pair below the netclass.

--- a/tests/test_725_fanout_clearance_pad_floors.py
+++ b/tests/test_725_fanout_clearance_pad_floors.py
@@ -1,0 +1,694 @@
+"""#725: the fanout-clearance repair pass must price each pair at its REAL
+required clearance -- netclass, `.kicad_dru` layer rule, pad `(clearance ...)`
+override -- exactly as check_drc grades it, and stay byte-identical on a board
+that declares none of them.
+
+Conventions this file follows (from #697's test file, and CLAUDE.md):
+
+  * REAL parser dataclasses and REAL boards. `_Repair.__init__` reads courtyards
+    and locked refs from the file on disk, so even a synthetic case needs a file.
+  * Every assertion names the single-line MUTATION that must kill it.
+  * Assert you are ON the branch before asserting about it -- each test spies the
+    value its branch keys on, with a detail string saying why.
+
+It deliberately imports neither `run_utils` nor `subprocess`: `run_all.py`
+classifies a test as integration by grepping its SOURCE for those, and `--fast`
+would then never run this file.
+"""
+from __future__ import annotations
+
+RUN_ALL_TIMEOUT = 900
+
+import json
+import math
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+_TESTS = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_TESTS)
+for _p in ('', 'py_router', 'py_placer', 'py_tools'):
+    _d = os.path.join(_ROOT, _p)
+    if _d not in sys.path:
+        sys.path.insert(0, _d)
+if _TESTS not in sys.path:
+    sys.path.insert(0, _TESTS)
+
+from kicad_parser import parse_kicad_pcb
+from copy_board import copy_board
+import placement.legality as L
+from placement.legality import PadClearanceModel
+from placement.fanout_clearance import (_Repair, _pad_pair_shortfall,
+                                        _point_to_rect_dist, _rect_gap,
+                                        nudge_vias_for_unresolved,
+                                        repair_fanout_clearance)
+
+BOARD = os.path.join(_ROOT, 'kicad_files', 'orangecrab_ext_pll.kicad_pcb')
+INERT = os.path.join(_ROOT, 'kicad_files',
+                     'rp2350_fpga_eensy_prePlane.kicad_pcb')
+CLEAR = 0.1
+
+# Measured anchors on the stock board at CLEAR (see the PR body). TP32.1 is a
+# B.Cu test point on net 69 sitting 0.1346mm from C20's pad -- above the flat
+# 0.1 and below anything a declaration raises it to, which is precisely the
+# band the flat scalar cannot see.
+ANCHOR_CAP = 'C20'
+ANCHOR_NET = 69
+ANCHOR_GAP = 0.1346
+MOVER_A, MOVER_B = 'C49', 'C62'
+
+# The inert board's recorded result, which #725 must not move.
+INERT_UNRESOLVED = ['C16', 'C17', 'C18', 'C19', 'C22', 'C23', 'C24']
+INERT_PLACEMENTS = 2
+
+
+def _repair(path, clearance=CLEAR, prefix='C,R,FB', pcb=None):
+    """The 10-POSITIONAL construction every other test in this family uses.
+    Calling it positionally is itself part of the #725 shape contract."""
+    return _Repair(pcb if pcb is not None else parse_kicad_pcb(path), path,
+                   clearance, 0.1, 0.55, 1.0, 2.0, 0.3, prefix, set())
+
+
+def _stage(tmp, name, classes=None, dru=None):
+    """A COPY of the in-repo board (siblings carried by copy_board), plus an
+    optional netclass project and/or an optional .kicad_dru."""
+    d = os.path.join(tmp, name)
+    os.makedirs(d, exist_ok=True)
+    dst = os.path.join(d, 'b.kicad_pcb')
+    copy_board(BOARD, dst)
+    pro = os.path.splitext(dst)[0] + '.kicad_pro'
+    if classes is not None:
+        with open(pro, 'w', encoding='utf-8') as f:
+            json.dump({'net_settings': {'classes': classes,
+                                        'netclass_assignments': {},
+                                        'netclass_patterns': []}}, f)
+    elif os.path.exists(pro):
+        os.remove(pro)
+    if dru is not None:
+        with open(os.path.splitext(dst)[0] + '.kicad_dru', 'w',
+                  encoding='utf-8') as f:
+            f.write(dru)
+    return dst
+
+
+def _default_class(clearance):
+    return [{'name': 'Default', 'clearance': clearance, 'track_width': 0.2,
+             'via_diameter': 0.6, 'via_drill': 0.4, 'priority': 2147483647}]
+
+
+def _dru(layer, mm):
+    return ('(version 1)\n(rule r (layer "%s") '
+            '(constraint clearance (min %gmm)))\n' % (layer, mm))
+
+
+def _pad_rect(p):
+    """The pad rect exactly as _Repair builds it (rect_rotation folded in)."""
+    t = math.radians(getattr(p, 'rect_rotation', 0.0) or 0.0)
+    c, s = abs(math.cos(t)), abs(math.sin(t))
+    hx, hy = p.size_x / 2.0, p.size_y / 2.0
+    ex, ey = hx * c + hy * s, hx * s + hy * c
+    return (p.global_x - ex, p.global_y - ey, p.global_x + ex, p.global_y + ey)
+
+
+def _anchor_pad(pcb):
+    """The parser Pad behind the ANCHOR_GAP tuple -- located by matching the
+    rect the module itself computes, so this cannot drift from the geometry."""
+    st = _repair(BOARD, pcb=pcb)
+    cap = st.caps[ANCHOR_CAP]
+    r = cap.pad_rects()[0]
+    for t in st.cap_foreign_pads[ANCHOR_CAP]:
+        if t[4] == r[4] or t[4] == -1:
+            continue
+        if t[5] is not None and t[5] != cap.side:
+            continue
+        gap = _rect_gap(r[:4], t[:4])
+        if abs(gap - ANCHOR_GAP) > 5e-3:
+            continue
+        for fref, fp in pcb.footprints.items():
+            for p in fp.pads:
+                if p.net_id != t[4]:
+                    continue
+                if max(abs(a - b) for a, b in zip(_pad_rect(p), t[:4])) < 1e-9:
+                    return fref, p, gap
+    raise AssertionError('the ANCHOR_GAP pair is gone -- the fixture moved')
+
+
+def _short(st, ref):
+    cap = st.caps[ref]
+    return st._pad_shortfalls(ref, cap, cap.x, cap.y, cap.rot)
+
+
+class TestSourcesReachTheEngine(unittest.TestCase):
+    """Each of the three declaration channels must arrive, and a board with
+    none of them must not build a model at all."""
+
+    def test_pad_override_raises_a_pad_pair(self):
+        pcb = parse_kicad_pcb(BOARD)
+        owner, pad, gap = _anchor_pad(pcb)
+        # ON THE BRANCH: the pair must sit in the band the flat scalar misses,
+        # or every assertion below passes for the wrong reason.
+        self.assertTrue(CLEAR < gap < 0.5,
+                        'gap %.4f is not in (%.2f, 0.5) -- this test would '
+                        'pass vacuously' % (gap, CLEAR))
+        self.assertEqual(_short(_repair(BOARD, pcb=pcb), ANCHOR_CAP), {},
+                         'the stock board must not charge this pair')
+        pad.local_clearance = 0.5
+        st = _repair(BOARD, pcb=pcb)
+        self.assertIsNotNone(st._floors, 'the override did not activate a model')
+        got = _short(st, ANCHOR_CAP)
+        self.assertIn(pad.net_id,
+                      got, 'the %s override never reached the shortfall' % owner)
+        self.assertAlmostEqual(got[pad.net_id], 0.5 - gap, places=4)
+    # MUTATION: `_pad_shortfalls` back to `if gap < self.clearance - EPS:`
+    # (with the matching `self.clearance - gap`) -> got == {}.
+
+    def test_netclass_from_a_sibling_project_raises_a_pad_pair(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = _stage(td, 'ncl', classes=_default_class(0.4))
+            pcb = parse_kicad_pcb(p)
+            m = PadClearanceModel.for_board(pcb, CLEAR, p)
+            named = sum(1 for n in pcb.nets.values() if n.name)
+            # ON THE BRANCH: every named net must have arrived, at 0.4.
+            self.assertEqual(len(m.net_floor), named,
+                             'the project reached %d of %d named nets'
+                             % (len(m.net_floor), named))
+            self.assertEqual({round(v, 6) for v in m.net_floor.values()}, {0.4})
+            self.assertIn(ANCHOR_NET, _short(_repair(p, pcb=pcb), ANCHOR_CAP),
+                          'the netclass never reached the shortfall')
+    # MUTATION: drop the `PadClearanceModel.for_board` call in
+    # `_Repair.__init__` -> the shortfall is empty.
+
+    def test_dru_layer_rule_raises_a_pad_pair(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = _stage(td, 'dru', dru=_dru('B.Cu', 0.5))
+            pcb = parse_kicad_pcb(p)
+            m = PadClearanceModel.for_board(pcb, CLEAR, p)
+            # ON THE BRANCH: the rule must have parsed, on the anchor's layer.
+            self.assertEqual({k: round(v, 6) for k, v in m.layer_rules.items()},
+                             {'B.Cu': 0.5}, 'the .kicad_dru did not parse')
+            self.assertIn(ANCHOR_NET, _short(_repair(p, pcb=pcb), ANCHOR_CAP),
+                          'the layer rule never reached the shortfall')
+    # MUTATION: drop `read_board_layer_clearances` from the model -> empty.
+
+    def test_a_board_declaring_nothing_builds_no_model(self):
+        pcb = parse_kicad_pcb(INERT)
+        self.assertFalse(PadClearanceModel.for_board(pcb, CLEAR, INERT).active)
+        self.assertIsNone(_repair(INERT, pcb=pcb)._floors,
+                          'an inert board must take the flat path')
+    # MUTATION: drop the `.active` gate -> `_floors` is a model.
+
+
+class TestChannels(unittest.TestCase):
+    """pad<->pad, via<->pad and track<->pad, each priced at the requirement."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.td = tempfile.mkdtemp()
+        cls.path = _stage(cls.td, 'chan', dru=_dru('B.Cu', 0.5))
+        cls.st = _repair(cls.path)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.td, ignore_errors=True)
+
+    def test_static_foreign_pad_is_charged(self):
+        got = _short(self.st, ANCHOR_CAP)
+        self.assertIn(ANCHOR_NET, got)
+        self.assertAlmostEqual(got[ANCHOR_NET], 0.5 - ANCHOR_GAP, places=3)
+    # MUTATION: `_pad_shortfalls` back to the flat scalar -> {}.
+
+    def test_mover_vs_mover_pad_is_charged(self):
+        a, b = self.st.caps[MOVER_A], self.st.caps[MOVER_B]
+        gap = min(_rect_gap(ra[:4], rb[:4]) for ra in a.pad_rects()
+                  for rb in b.pad_rects() if ra[4] != rb[4])
+        # ON THE BRANCH: the pair must sit in the uncharged band.
+        self.assertTrue(CLEAR < gap < 0.5,
+                        '%s<->%s gap %.4f is outside the band -- this test '
+                        'would pass vacuously' % (MOVER_A, MOVER_B, gap))
+        effs = self.st._pair_effs(MOVER_A, a, MOVER_B, b)
+        self.assertIsNotNone(effs, 'no per-pair requirements were resolved')
+        self.assertEqual(
+            _pad_pair_shortfall(a.pad_rects(), b.pad_rects(), CLEAR), 0.0,
+            'the flat scalar must see nothing here')
+        self.assertGreater(
+            _pad_pair_shortfall(a.pad_rects(), b.pad_rects(), CLEAR, effs), 0.0)
+    # MUTATION: `_pad_pair_shortfall` back to `if gap < clearance - EPS:` -> 0.0.
+
+    def test_via_dru_rule_binds_through_the_span(self):
+        """A via has no pad layers of its own, so its PadFloor must be scoped to
+        ALL copper. Built with `layers=None`, PadClearanceModel.pair does
+        `fb.layers or ()`, the shared set is empty, and EVERY dru rule is
+        silently discarded -- a wrong answer that passes every other test."""
+        fl = self.st.via_floor(0)
+        self.assertIsNotNone(fl)
+        self.assertTrue(fl.layers, 'the via floor carries no layer scope')
+        self.assertIn('B.Cu', fl.layers)
+        pf = self.st.caps[ANCHOR_CAP].pad_floors[0]
+        self.assertAlmostEqual(self.st.via_required(pf, 0), 0.5, places=6)
+    # MUTATION: build the via PadFloor with `layers=None` -> via_required
+    # returns the flat 0.1.
+
+    def test_track_is_scoped_to_the_SEGMENTS_own_layer(self):
+        """check_drc resolves pad-segment as a single-layer REPLACE on
+        `seg.layer`, NOT over the F/B `side` the tuple carries (which files an
+        In1.Cu track under 'F')."""
+        pf = self.st.caps[ANCHOR_CAP].pad_floors[0]      # a B-side cap pad
+        self.assertAlmostEqual(
+            self.st.required(pf, self.st.seg_floor(0, 'B.Cu')), 0.5, places=6)
+        self.assertAlmostEqual(
+            self.st.required(pf, self.st.seg_floor(0, 'F.Cu')), CLEAR, places=6)
+        self.assertAlmostEqual(
+            self.st.required(pf, self.st.seg_floor(0, 'In1.Cu')), CLEAR,
+            places=6)
+    # MUTATION: scope the segment floor to `self._all_cu` -> the F.Cu and
+    # In1.Cu arms return 0.5 too.
+
+    def test_a_relaxing_rule_REPLACES_downward(self):
+        """A dru rule REPLACES, so it can lower a pair below the netclass.
+        Pinning this is what proves the compare uses pair(), not max_floor()."""
+        with tempfile.TemporaryDirectory() as td:
+            p = _stage(td, 'relax', classes=_default_class(0.4),
+                       dru=_dru('B.Cu', 0.15))
+            st = _repair(p)
+            cap = st.caps[ANCHOR_CAP]
+            pf = cap.pad_floors[0]
+            # ON THE BRANCH: the pad's own netclass must be the 0.4 the rule is
+            # about to replace, or "replaced downward" is not what is tested.
+            self.assertAlmostEqual(pf.ncl, 0.4, places=6)
+            self.assertAlmostEqual(st.required(pf, st.seg_floor(0, 'B.Cu')),
+                                   0.15, places=6)
+            # ...while the BROAD-PHASE bound keeps the 0.4: a relaxing rule
+            # REPLACES a pair value but must never shrink a prune, which may
+            # over-reach and must never under-reach.
+            self.assertGreaterEqual(
+                cap.max_floor, 0.4,
+                'the broad-phase bound was lowered by a relaxing rule')
+    # MUTATION: use `max_floor` instead of `pair` in the eff precompute -> the
+    # first assertion reads 0.4.
+
+    def test_the_track_bbox_reject_widens_with_the_requirement(self):
+        """`_seg_shortfalls`' cheap bbox reject is a SKIP keyed on the same
+        half-width the compare uses; left flat it drops raised pairs."""
+        ref = ANCHOR_CAP
+        cap = self.st.caps[ref]
+        segs = self.st.cap_segs[ref]
+        self.assertTrue(segs, 'no tracks in reach of %s' % ref)
+        rows = self.st._seg_effs(ref, cap)
+        self.assertIsNotNone(rows)
+        widened = sum(1 for i in range(len(rows))
+                      for j, t in enumerate(segs)
+                      if rows[i][j] > t[5] - self.st._item_reach(
+                          self.st._seg_floor_by_id.get(id(t))) + CLEAR + 1e-9)
+        self.assertGreater(widened, 0,
+                           'no track keep-out was raised -- this test would '
+                           'pass vacuously')
+    # MUTATION: leave `_seg_shortfalls`' reject at the flat `halfw` -> the
+    # widened band is never scanned.
+
+
+class TestPruneRadiiStayExact(unittest.TestCase):
+    """The pruned neighbour lists are documented as EXACT, not approximate.
+    That claim dies the moment a requirement exceeds the flat scalar."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.td = tempfile.mkdtemp()
+        cls.path = _stage(cls.td, 'prune', classes=_default_class(0.6))
+        cls.st = _repair(cls.path)
+        cls.flat = _repair(BOARD)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.td, ignore_errors=True)
+
+    def test_no_pruned_list_shrinks_at_a_raised_requirement(self):
+        """Every list must grow, or stay equal where nothing sits in the band --
+        never shrink. A shrunk list is a pair the pass can no longer see."""
+        grew = {}
+        for ref in self.st.caps:
+            for name in ('cap_foreign_pads', 'cap_caps', 'cap_segs', 'cap_vias'):
+                a = len(getattr(self.flat, name)[ref])
+                b = len(getattr(self.st, name)[ref])
+                self.assertGreaterEqual(
+                    b, a, '%s[%s] SHRANK %d -> %d at a raised requirement'
+                          % (name, ref, a, b))
+                if b > a:
+                    grew[name] = grew.get(name, 0) + 1
+        # ON THE BRANCH: each reach must actually have been raised, or this
+        # passes on a no-op change.
+        for name in ('cap_foreign_pads', 'cap_caps', 'cap_segs', 'cap_vias'):
+            self.assertIn(name, grew,
+                          '%s never grew -- its reach was not raised' % name)
+    # MUTATION: revert any one of the four prune radii -> that list shrinks and
+    # its name is missing from `grew`.
+
+    def test_a_foreign_pad_beyond_the_OLD_reach_is_still_kept(self):
+        cap = self.st.caps[ANCHOR_CAP]
+        r = cap.rect()
+        cx, cy = (r[0] + r[2]) / 2.0, (r[1] + r[3]) / 2.0
+        span = math.hypot(r[2] - cx, r[3] - cy)
+        old = 3.0 + span + CLEAR          # max_displacement_cap + span + flat
+        beyond = 0
+        for t in self.st.cap_foreign_pads[ANCHOR_CAP]:
+            px, py = (t[0] + t[2]) / 2.0, (t[1] + t[3]) / 2.0
+            ph = math.hypot(t[2] - px, t[3] - py)
+            if math.hypot(px - cx, py - cy) > old + ph:
+                beyond += 1
+        self.assertGreater(beyond, 0,
+                           'no foreign pad sits beyond the old reach %.3f -- '
+                           'this test would pass vacuously' % old)
+    # MUTATION: `:466` back to `max_displacement_cap + span + clearance` ->
+    # nothing beyond the old reach survives.
+
+    def test_the_bbox_prescreen_widens_with_the_requirement(self):
+        """`_blocked_geom`'s pad-bbox prescreen is a SKIP: left at the flat
+        scalar it silently drops exactly the pairs a declaration raises."""
+        pairs = 0
+        for ref, cap in self.st.caps.items():
+            for oref in self.st.cap_caps[ref]:
+                other = self.st.caps[oref]
+                gap = _rect_gap(cap.pad_bbox(cap.x, cap.y, cap.rot),
+                                other.pad_bbox())
+                screen = max(self.st.clearance, cap.max_floor, other.max_floor)
+                if self.st.clearance <= gap < screen:
+                    pairs += 1
+        self.assertGreater(pairs, 0,
+                           'no mover pair sits between the flat scalar and the '
+                           'widened prescreen -- this test would pass vacuously')
+    # MUTATION: `_blocked_geom`'s prescreen back to `>= self.clearance` ->
+    # every one of those pairs is skipped before its shortfall is computed.
+
+    def test_the_seed_baseline_is_in_the_SAME_currency(self):
+        """A baseline priced flat while candidates price at the requirement
+        makes `_worsens_any_net` fire on every pose and the pass stops moving
+        anything -- a failure whose symptom is FEWER placements, which reads as
+        conservative rather than broken."""
+        raised = [k for k, v in self.st.base_cap_pad.items() if v > 0.0]
+        self.assertTrue(raised, 'no mover pair has a non-zero seed baseline')
+        for key in raised:
+            ref, oref = tuple(key) if len(key) == 2 else (tuple(key)[0],) * 2
+            cap, other = self.st.caps[ref], self.st.caps[oref]
+            self.assertAlmostEqual(
+                self.st.base_cap_pad[key],
+                _pad_pair_shortfall(cap.pad_rects(), other.pad_rects(),
+                                    self.st.clearance,
+                                    self.st._pair_effs(ref, cap, oref, other)),
+                places=9,
+                msg='%s<->%s baseline is not in the candidates currency'
+                    % (ref, oref))
+        # and the flat pricing must NOT reproduce them, or the two currencies
+        # are indistinguishable here.
+        flat_zero = sum(
+            1 for key in raised
+            for ref, oref in [tuple(key)]
+            if _pad_pair_shortfall(self.st.caps[ref].pad_rects(),
+                                   self.st.caps[oref].pad_rects(),
+                                   self.st.clearance) == 0.0)
+        self.assertGreater(flat_zero, 0,
+                           'every raised baseline is also non-zero flat -- this '
+                           'test would pass vacuously')
+    # MUTATION: `base_cap_pad` back to the 3-argument `_pad_pair_shortfall` ->
+    # the raised baselines read 0.0.
+
+
+class TestNudgerGraderConsistency(unittest.TestCase):
+    """`nudge_vias_for_unresolved`'s offender test and `via_penalty`'s grazing
+    test must resolve the SAME number for the same (cap pad, via) pair. If they
+    diverge, the nudger returns an empty offender list for a cap the grader
+    flagged and the cap stays unresolved forever with nothing printed."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.td = tempfile.mkdtemp()
+        cls.path = _stage(cls.td, 'nudge', classes=_default_class(0.4))
+        cls.st = _repair(cls.path)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.td, ignore_errors=True)
+
+    def test_the_grader_rows_are_built_from_via_required(self):
+        ref = ANCHOR_CAP
+        cap = self.st.caps[ref]
+        vias = self.st.cap_vias[ref]
+        self.assertTrue(vias, 'no vias in reach of %s' % ref)
+        rows = self.st._via_effs(ref, cap, vias)
+        self.assertIsNotNone(rows)
+        raised = 0
+        for i, fa in enumerate(cap.pad_floors):
+            for j, v in enumerate(vias):
+                radius = v[3] - self.st._item_reach(self.st.via_floor(v[2]))
+                want = self.st.via_required(fa, v[2])
+                self.assertAlmostEqual(rows[i][j], radius + want, places=9)
+                raised += (want > self.st.clearance + 1e-9)
+        # ON THE BRANCH: some pair must actually be raised, or the loop above
+        # compares the flat scalar with itself.
+        self.assertGreater(raised, 0, 'no (pad, via) pair was raised -- this '
+                                      'test would pass vacuously')
+    # MUTATION: build the via eff rows from anything but `via_required` -> the
+    # equality fails.
+
+    def test_the_offender_predicate_sees_what_the_grader_charges(self):
+        """The nudger's offender test, replayed here against the same helper.
+        A via that the grader charges must be an offender, and there must be at
+        least one that the FLAT predicate would have missed."""
+        only_raised = 0
+        for ref, cap in self.st.caps.items():
+            rects = cap.pad_rects(cap.x, cap.y, cap.rot)
+            for vx, vy, vnet, keepout in self.st.cap_vias[ref]:
+                radius = keepout - self.st._item_reach(self.st.via_floor(vnet))
+                for i, (bx0, by0, bx1, by1, net) in enumerate(rects):
+                    if vnet == net:
+                        continue
+                    d = _point_to_rect_dist(vx, vy, (bx0, by0, bx1, by1))
+                    want = self.st.via_required(cap.pad_floors[i], vnet)
+                    hit_now = d < radius + want - 1e-6
+                    hit_flat = d < radius + self.st.clearance - 1e-6
+                    self.assertFalse(hit_flat and not hit_now,
+                                     'the raised predicate LOST an offender '
+                                     'the flat one saw (%s, via %g,%g)'
+                                     % (ref, vx, vy))
+                    only_raised += (hit_now and not hit_flat)
+        self.assertGreater(only_raised, 0,
+                           'no via is an offender only under the raised '
+                           'requirement -- this test would pass vacuously')
+    # MUTATION: the offender test in `nudge_vias_for_unresolved` back to
+    # `vr + clearance` -> those `only_raised` vias become invisible to the
+    # nudger while the grader still reports their caps unresolved.
+
+    def test_a_duck_typed_state_grades_flat_instead_of_crashing(self):
+        """test_617 and test_370 drive the nudger with a _FakeSt/_FakeCap that
+        carries none of this machinery."""
+        class _FakeSt(object):
+            caps = {}
+            locked_refs = set()
+
+            def graze_penalty(self, *a):
+                return 0.0
+
+        self.assertEqual(
+            nudge_vias_for_unresolved(_FakeSt(), parse_kicad_pcb(INERT), CLEAR),
+            ([], []))
+    # MUTATION: read `st._floors` (or `cap.pad_floors`) directly instead of via
+    # getattr -> AttributeError, and two existing test files go red.
+
+
+class TestShapeContract(unittest.TestCase):
+    """Four tuple shapes are unpacked positionally outside this module. #725
+    carries floors in parallel lists and identity maps precisely so that none
+    of them had to widen."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.td = tempfile.mkdtemp()
+        cls.path = _stage(cls.td, 'shape', classes=_default_class(0.4))
+        cls.st = _repair(cls.path)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.td, ignore_errors=True)
+
+    def test_the_four_pinned_tuple_widths(self):
+        # ON THE BRANCH: grading the FLAT path proves nothing about the shapes.
+        self.assertIsNotNone(self.st._floors)
+        self.assertTrue(all(len(v) == 4 for v in self.st.vias))
+        self.assertTrue(all(len(s) == 7 for s in self.st.segments))
+        self.assertTrue(all(len(t) == 6 for t in self.st.foreign_pads))
+        for cap in self.st.caps.values():
+            self.assertTrue(all(len(r) == 5 for r in cap.pad_rects()))
+    # MUTATION: widen any of them -> animate_fanout_clearance.py and three
+    # existing test files stop unpacking.
+
+    def test_pad_floors_stay_index_aligned_through_every_rotation(self):
+        cap = self.st.caps[ANCHOR_CAP]
+        self.assertEqual(len(cap.pad_floors), len(cap.pads))
+        base = [r[4] for r in cap.pad_rects(cap.x, cap.y, 0.0)]
+        for rot in (0.0, 90.0, 180.0, 270.0):
+            rects = cap.pad_rects(cap.x, cap.y, rot)
+            self.assertEqual(len(rects), len(cap.pad_floors))
+            self.assertEqual([r[4] for r in rects], base,
+                             'pad order changed at rot %g -- floors would '
+                             'address the wrong pad' % rot)
+    # MUTATION: sort or filter inside `_pad_cache_for` -> the nets reorder.
+
+    def test_injecting_st_vias_wholesale_still_grades(self):
+        """`st.vias = [...]` is the idiom tests/test_fanout_clearance.py uses.
+        Any POSITIONAL parallel floor list would desync right here."""
+        st = _repair(self.path)
+        cap = st.caps[ANCHOR_CAP]
+        own = {p[4] for p in cap.pads}
+        foreign = next(n for n in range(1, 50) if n not in own)
+        r = cap.pad_rects()[0]
+        st.vias = [((r[0] + r[2]) / 2.0, (r[1] + r[3]) / 2.0, foreign,
+                    0.35 / 2 + CLEAR)]
+        st.cap_vias = {ref: st.vias for ref in st.caps}
+        self.assertGreater(
+            st.via_penalty(cap, cap.x, cap.y, cap.rot,
+                           st.cap_vias[ANCHOR_CAP], ref=ANCHOR_CAP), 0.0)
+    # MUTATION: key the via floors by list position -> IndexError, or a
+    # silently wrong requirement.
+
+    def test_injecting_cap_foreign_pads_grades_without_misindexing(self):
+        st = _repair(self.path)
+        cap = st.caps[ANCHOR_CAP]
+        own = {p[4] for p in cap.pads}
+        foreign = next(n for n in range(1, 50) if n not in own)
+        r = cap.pad_rects()[0]
+        st.cap_foreign_pads[ANCHOR_CAP] = [
+            (r[0] - 0.15, r[1], r[0] - 0.05, r[3], foreign, cap.side)]
+        self.assertIn(foreign, _short(st, ANCHOR_CAP))
+    # MUTATION: drop the source-list identity guard in `_pad_effs` -> stale
+    # rows index a list that no longer exists (IndexError).
+
+    def test_ten_positional_arguments_still_construct(self):
+        _Repair(parse_kicad_pcb(BOARD), BOARD, CLEAR, 0.1, 0.55, 1.0, 2.0, 0.3,
+                'C', set())
+    # MUTATION: insert a parameter before `max_displacement_cap` -> four
+    # existing test files break.
+
+
+class TestInertness(unittest.TestCase):
+    """A board declaring nothing must take the IDENTICAL flat path -- a
+    stronger claim than 'it gives the same answer'."""
+
+    @staticmethod
+    def _counting():
+        hits = [0]
+        orig = PadClearanceModel.pair
+
+        def counting(self, a, b):
+            hits[0] += 1
+            return orig(self, a, b)
+        return hits, orig, counting
+
+    def test_the_model_is_never_consulted_on_an_inert_board(self):
+        """A result comparison alone passes even if the model runs and returns
+        `base` every time, which would be a real (perf) regression hiding
+        behind a correct answer."""
+        hits, orig, counting = self._counting()
+        PadClearanceModel.pair = counting
+        try:
+            r = repair_fanout_clearance(parse_kicad_pcb(INERT), INERT,
+                                        clearance=CLEAR)
+        finally:
+            PadClearanceModel.pair = orig
+        self.assertEqual(hits[0], 0,
+                         'the model was consulted %d times on a board that '
+                         'declares nothing' % hits[0])
+        self.assertEqual(len(r['placements']), INERT_PLACEMENTS)
+        self.assertEqual(sorted(r['unresolved']), INERT_UNRESOLVED)
+        self.assertEqual(r['required'], [])
+        self.assertEqual(r['clearance_notes'], [])
+    # MUTATION: drop the `.active` gate in `_Repair.__init__` -> hits > 0.
+
+    def test_the_counter_itself_fires_on_a_declaring_board(self):
+        """Without this, the test above also passes if `pair` is simply never
+        the method the fix calls."""
+        hits, orig, counting = self._counting()
+        PadClearanceModel.pair = counting
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                _repair(_stage(td, 'ctr', classes=_default_class(0.4)))
+        finally:
+            PadClearanceModel.pair = orig
+        self.assertGreater(hits[0], 0)
+
+
+class TestReport(unittest.TestCase):
+    def test_required_rows_name_the_source_and_render(self):
+        with tempfile.TemporaryDirectory() as td:
+            st = _repair(_stage(td, 'rep', classes=_default_class(0.4)))
+            rows = st.required_rows()
+            self.assertTrue(rows, 'nothing was reported as raised')
+            for ref, who, mm, src in rows:
+                self.assertIn(src, ('netclass', 'layer rule', 'pad override'))
+                self.assertGreater(mm, st.clearance)
+            clause = L.format_required_clause({'required': rows})
+            self.assertIn('requires', clause)
+            self.assertIn('netclass', clause)
+
+    def test_only_CHARGED_pairs_are_reported(self):
+        """An in-reach pair that happens to be clear is not a finding, it is the
+        normal case on a declaring board. Reporting all of them buries the real
+        ones under hundreds of rows."""
+        with tempfile.TemporaryDirectory() as td:
+            st = _repair(_stage(td, 'rep2', classes=_default_class(0.4)))
+            in_reach = sum(len(st.cap_foreign_pads[r]) + len(st.cap_vias[r])
+                           + len(st.cap_segs[r]) for r in st.caps)
+            self.assertGreater(in_reach, 1000, 'the fixture got small')
+            self.assertLess(len(st.required_rows()), 100,
+                            'required_rows is reporting in-reach pairs rather '
+                            'than charged ones')
+    # MUTATION: drop the `charged` filter in `required_rows` -> hundreds of rows.
+
+    def test_an_unreadable_declaration_is_disclosed_not_silent(self):
+        """A FAILED read is exactly what makes a model look inert, so the notes
+        must be captured BEFORE the active-drop."""
+        import list_nets
+        orig = list_nets.net_clearance_map
+
+        def boom(*a, **k):
+            raise IOError('staged failure')
+        list_nets.net_clearance_map = boom
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                st = _repair(_stage(td, 'unread', classes=_default_class(0.4)))
+                self.assertTrue(st.clearance_notes,
+                                'the failed netclass read was silent')
+        finally:
+            list_nets.net_clearance_map = orig
+    # MUTATION: read `model.notes` after `if not model.active: model = None`
+    # -> AttributeError, or the notes are lost.
+
+
+class TestAnimatorRecorderStillUnpacks(unittest.TestCase):
+    """tests/test_431_animator_port.py drives render_gif with a SYNTHETIC
+    recorder and never touches the real `_Recorder`, so it passes even if a
+    shape change breaks the shipped animator. This is the only coverage."""
+
+    def test_the_real_on_move_recorder_survives(self):
+        import animate_fanout_clearance as AFC
+        rec = AFC._Recorder()
+        repair_fanout_clearance(parse_kicad_pcb(INERT), INERT, clearance=CLEAR,
+                                max_displacement=0.0, max_passes=1, on_move=rec)
+        self.assertTrue(rec.static['vias'], 'no vias were recorded')
+        self.assertTrue(all(len(v) == 4 for v in rec.static['vias']))
+    # MUTATION: widen st.vias to 5-tuples -> ValueError inside _Recorder.
+
+
+class TestParityGateRegistration(unittest.TestCase):
+    def test_place_fanout_clearance_is_a_scanned_CLI_main(self):
+        """tests/gui_parity/** is NOT collected by run_all.py's flat glob, so
+        nothing in the default suite runs that lint. Assert it here."""
+        with open(os.path.join(_TESTS, 'gui_parity',
+                               'test_cli_postpass_coverage.py'),
+                  encoding='utf-8') as fh:
+            self.assertIn('py_placer/place_fanout_clearance.py', fh.read())
+    # MUTATION: remove it from CLI_MAINS -> the cap-repair CLI's post-passes go
+    # unscanned again.
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/test_725_fanout_clearance_pad_floors.py
+++ b/tests/test_725_fanout_clearance_pad_floors.py
@@ -24,7 +24,9 @@ from __future__ import annotations
 RUN_ALL_FAST_OK = True
 RUN_ALL_TIMEOUT = 900
 
+import contextlib
 import copy
+import io
 import json
 import math
 import os
@@ -163,7 +165,14 @@ class TestSourcesReachTheEngine(unittest.TestCase):
                          'the stock board must not charge this pair')
         pad.local_clearance = 0.5
         st = _repair(BOARD, pcb=pcb)
-        self.assertIsNotNone(st._floors, 'the override did not activate a model')
+        # NB: NOT `assertIsNotNone(st._floors)` -- this board's 6 fiducials
+        # already carry local_clearance 0.375, so the model is active before
+        # this test writes anything, and that assertion would credit the setup
+        # for a state it did not create.
+        self.assertAlmostEqual(st.caps[ANCHOR_CAP].max_floor, 0.0, places=9,
+                               msg='the CAP carries a floor of its own -- the '
+                                   'shortfall below would not isolate the '
+                                   'foreign override')
         got = _short(st, ANCHOR_CAP)
         self.assertIn(pad.net_id,
                       got, 'the %s override never reached the shortfall' % owner)
@@ -443,8 +452,11 @@ class TestChannels(unittest.TestCase):
             self.assertIn(0.4, {round(v, 6) for r in rows for v in r},
                           'every pair fell back to the flat scalar -- the '
                           'board is now UNDER-blocked')
-    # MUTATION: `return pl if self._all_cu else None` -> `return pl` -> every
-    # pad reads as copper-less and the whole board grades flat.
+    # MUTATION: `return pl if self._all_cu else None` -> `return pl` -> the
+    # `assertIsNone` fails. NB the effs are 0.4 either way on this board: only
+    # a `*.Cu` pad resolves empty against an empty layer list, and orangecrab's
+    # cap pads are all concrete F.Cu/B.Cu, so the under-block this guards
+    # against needs a through-hole cap pad to appear at all.
 
     def test_a_relaxing_rule_REPLACES_downward(self):
         """A dru rule REPLACES, so it can lower a pair below the netclass.
@@ -466,8 +478,10 @@ class TestChannels(unittest.TestCase):
             self.assertGreaterEqual(
                 cap.max_floor, 0.4,
                 'the broad-phase bound was lowered by a relaxing rule')
-    # MUTATION: use `max_floor` instead of `pair` in the eff precompute -> the
-    # first assertion reads 0.4.
+    # MUTATION: `_pair_or_flat` -> `max(self.clearance, model.max_floor(fa),
+    # model.max_floor(fb))` -> the `required(...)` assertion reads 0.4 instead
+    # of the replaced-down 0.15. (A mutation confined to the eff builders does
+    # NOT reach this test -- it reads the resolver directly.)
 
     def test_the_track_bbox_reject_widens_with_the_requirement(self):
         """`_seg_shortfalls`' cheap bbox reject is a SKIP keyed on the same
@@ -485,8 +499,10 @@ class TestChannels(unittest.TestCase):
         self.assertGreater(widened, 0,
                            'no track keep-out was raised -- this test would '
                            'pass vacuously')
-    # MUTATION: leave `_seg_shortfalls`' reject at the flat `halfw` -> the
-    # widened band is never scanned.
+    # MUTATION: `_seg_effs`' `halves[j] + eff(...)` -> `halves[j] +
+    # self.clearance` -> no row exceeds the flat half-width.
+    # NB this reads the eff ROWS; `_seg_shortfalls`' own widened bbox reject is
+    # a separate site and is NOT what this test covers.
 
 
 class TestPruneRadiiStayExact(unittest.TestCase):
@@ -522,8 +538,12 @@ class TestPruneRadiiStayExact(unittest.TestCase):
         for name in ('cap_foreign_pads', 'cap_caps', 'cap_segs', 'cap_vias'):
             self.assertIn(name, grew,
                           '%s never grew -- its reach was not raised' % name)
-    # MUTATION: revert any one of the four prune radii -> that list shrinks and
-    # its name is missing from `grew`.
+    # MUTATION: revert the foreign-pad radius or the cap-cap radius -> that
+    # list shrinks and its name is missing from `grew`.
+    # NB the segment and via radii are NOT covered here: on a uniform-class
+    # fixture the ITEMS' own floors already grow those two lists, so removing
+    # the cap-side slack leaves `grew` intact. They are covered by
+    # test_the_cap_side_slack_raises_the_via_and_track_reaches.
 
     def test_a_foreign_pad_beyond_the_OLD_reach_is_still_kept(self):
         cap = self.st.caps[ANCHOR_CAP]
@@ -772,21 +792,79 @@ class TestNudgerGraderConsistency(unittest.TestCase):
     # MUTATION: drop the `_radii[id(moved)] = ...` carry-over in
     # `nudge_vias_for_unresolved` -> rec is None.
 
+    def test_the_nudger_grades_a_COPPERLESS_cap_pad_flat_too(self):
+        """The copper-less-pad rule must not stop at the eff builders. The
+        nudger resolves through the same helpers, so without the marker it
+        charges a phantom the grader does not -- handing itself a via nothing
+        flagged and printing an operator-facing line naming a non-violation."""
+        with tempfile.TemporaryDirectory() as td:
+            p = _stage(td, 'nudgeflat', classes=_default_class(0.4))
+            pcb = parse_kicad_pcb(p)
+            fp = pcb.footprints[ANCHOR_CAP]
+            real = [q for q in fp.pads if L._pad_carries_copper(q)]
+            hole = copy.deepcopy(real[1])
+            hole.pad_type = 'np_thru_hole'
+            hole.drill = 1.0
+            hole.layers = ['*.Cu', '*.Mask']
+            hole.local_clearance = 1.0
+            fp.pads[fp.pads.index(real[1])] = hole
+            st = _repair(p, pcb=pcb)
+            cap = st.caps[ANCHOR_CAP]
+            flat_i = [k for k in range(len(cap.pad_floors))
+                      if not cap.pad_layers[k]]
+            # ON THE BRANCH: there must be exactly one copper-less pad, and the
+            # board must be declaring, or the phantom cannot arise.
+            self.assertEqual(len(flat_i), 1)
+            self.assertIsNotNone(st._floors)
+            seen = []
+            real_req = st.via_required
+
+            def recording(pad_floor, via_net):
+                seen.append(pad_floor)
+                return real_req(pad_floor, via_net)
+            st.via_required = recording
+            nudge_vias_for_unresolved(st, pcb, CLEAR)
+            self.assertTrue(seen, 'the nudger never consulted via_required')
+            bad = [f for f in seen if f is cap.pad_floors[flat_i[0]]]
+            self.assertEqual(bad, [], 'the nudger priced the copper-less pad '
+                                      'at its own floor instead of flat')
+    # MUTATION: drop the `pad_layers` check in `cap_floors_of` -> the
+    # copper-less pad's floor reaches via_required.
+
     def test_a_duck_typed_state_grades_flat_instead_of_crashing(self):
         """test_617 and test_370 drive the nudger with a _FakeSt/_FakeCap that
-        carries none of this machinery."""
+        carries none of this machinery.
+
+        The cap and the UNRESOLVED verdict are both load-bearing: with no caps
+        the function returns at its pre-existing early return, 58 lines above
+        the first `getattr(st, ...)` this change added, and the test proves
+        nothing at all. It did exactly that until an audit measured the line
+        coverage."""
+        pcb = parse_kicad_pcb(INERT)
+
+        class _FakeCap(object):
+            pads = [(0.0, 0.0, 0.1, 0.1, 1)]
+            x = y = rot = 0.0
+            side = 'F'
+
+            def pad_rects(self, *a):
+                b = pcb.board_info.board_bounds
+                return [(b[0] + 1.0, b[1] + 1.0, b[0] + 1.2, b[1] + 1.2, 1)]
+
         class _FakeSt(object):
-            caps = {}
+            caps = {'C1': _FakeCap()}
             locked_refs = set()
 
             def graze_penalty(self, *a):
-                return 0.0
-
-        self.assertEqual(
-            nudge_vias_for_unresolved(_FakeSt(), parse_kicad_pcb(INERT), CLEAR),
-            ([], []))
-    # MUTATION: read `st._floors` (or `cap.pad_floors`) directly instead of via
-    # getattr -> AttributeError, and two existing test files go red.
+                return 1.0          # unresolved, so the offender loop RUNS
+        st = _FakeSt()
+        moves, segs = nudge_vias_for_unresolved(st, pcb, CLEAR)
+        self.assertEqual((moves, segs), ([], []))
+        # ON THE BRANCH: prove the guarded reads were reached, not skipped.
+        self.assertIsNone(getattr(st, '_floors', None))
+        self.assertFalse(hasattr(_FakeCap, 'pad_floors'))
+    # MUTATION: read `st.required` / `cap.pad_floors` directly instead of via
+    # getattr -> AttributeError here, and in test_617 / test_370.
 
 
 class TestShapeContract(unittest.TestCase):
@@ -807,11 +885,19 @@ class TestShapeContract(unittest.TestCase):
     def test_the_four_pinned_tuple_widths(self):
         # ON THE BRANCH: grading the FLAT path proves nothing about the shapes.
         self.assertIsNotNone(self.st._floors)
-        self.assertTrue(all(len(v) == 4 for v in self.st.vias))
-        self.assertTrue(all(len(s) == 7 for s in self.st.segments))
-        self.assertTrue(all(len(t) == 6 for t in self.st.foreign_pads))
+        # every all() below is vacuous on an empty collection, so gate each
+        for what, coll, width in (('vias', self.st.vias, 4),
+                                  ('segments', self.st.segments, 7),
+                                  ('foreign_pads', self.st.foreign_pads, 6)):
+            self.assertTrue(coll, 'no %s on this fixture -- the width '
+                                  'assertion would be vacuous' % what)
+            self.assertTrue(all(len(t) == width for t in coll),
+                            '%s is not %d wide' % (what, width))
+        self.assertTrue(self.st.caps)
         for cap in self.st.caps.values():
-            self.assertTrue(all(len(r) == 5 for r in cap.pad_rects()))
+            rects = cap.pad_rects()
+            self.assertTrue(rects)
+            self.assertTrue(all(len(r) == 5 for r in rects))
     # MUTATION: widen any of them -> animate_fanout_clearance.py and three
     # existing test files stop unpacking.
 
@@ -825,7 +911,9 @@ class TestShapeContract(unittest.TestCase):
             self.assertEqual([r[4] for r in rects], base,
                              'pad order changed at rot %g -- floors would '
                              'address the wrong pad' % rot)
-    # MUTATION: sort or filter inside `_pad_cache_for` -> the nets reorder.
+    # MUTATION: FILTER inside `_pad_cache_for` (drop a pad) -> the length
+    # assertions fail. NB a deterministic SORT is not covered: `base` comes
+    # from the same function, so both sides reorder together.
 
     def test_injecting_st_vias_wholesale_is_graded_AS_INJECTED(self):
         """`st.vias = [...]` is the idiom tests/test_fanout_clearance.py uses.
@@ -896,11 +984,64 @@ class TestShapeContract(unittest.TestCase):
     # MUTATION: drop the source-list identity guard in `_pad_effs` -> the
     # shortfall reads 0.35.
 
-    def test_ten_positional_arguments_still_construct(self):
-        _Repair(parse_kicad_pcb(BOARD), BOARD, CLEAR, 0.1, 0.55, 1.0, 2.0, 0.3,
-                'C', set())
-    # MUTATION: insert a parameter before `max_displacement_cap` -> four
-    # existing test files break.
+    def test_via_penalty_without_a_ref_grades_FLAT_as_documented(self):
+        """`via_penalty(cap, x, y, rot)` is a public 4-positional path existing
+        tests use. Its docstring says the flat scalar is used there. #725
+        redefined the tuple's keep-out slot as the prune OVER-reach, so grading
+        that slot directly charges more than any pair needs -- and more than
+        upstream's slot, which really was radius + clearance."""
+        with tempfile.TemporaryDirectory() as td:
+            p = _stage(td, 'noref', classes=_default_class(0.4),
+                       dru=_dru('In1.Cu', 0.9))
+            st = _repair(p)
+            ref = 'C7'          # C20's vias clear both ways; C7's do not
+            cap = st.caps[ref]
+            vias = st.cap_vias[ref]
+            self.assertTrue(vias)
+            flat = st.via_penalty(cap, cap.x, cap.y, cap.rot, vias)
+            expect = over = 0.0
+            for (bx0, by0, bx1, by1, net) in cap.pad_rects():
+                for v in vias:
+                    if v[2] == net:
+                        continue
+                    d = _point_to_rect_dist(v[0], v[1], (bx0, by0, bx1, by1))
+                    ko = st._via_radius_by_id[id(v)][1] + CLEAR
+                    if d < ko - 1e-6:
+                        expect += ko - d
+                    if d < v[3] - 1e-6:          # the tuple's over-reach slot
+                        over += v[3] - d
+            # ON THE BRANCH: the two must actually differ on this cap, or the
+            # assertion below holds whichever quantity is graded.
+            self.assertGreater(over, expect + 1.0,
+                               'flat and over-reach coincide here (%.4f vs '
+                               '%.4f) -- this would pass vacuously'
+                               % (expect, over))
+            self.assertAlmostEqual(flat, expect, places=9,
+                                   msg='the no-ref path graded at the prune '
+                                       'over-reach, not the flat scalar')
+    # MUTATION: grade `keepout` directly in via_penalty's flat branch -> the
+    # penalty comes out far above the flat scalar.
+
+    def test_ten_positional_arguments_bind_to_the_documented_params(self):
+        """Four existing test files construct _Repair with 10 positionals. A
+        bare construction asserts nothing -- inserting a DEFAULTED parameter
+        still constructs fine and binds every argument to the wrong name. Check
+        the signature, then check the values landed."""
+        import inspect
+        names = list(inspect.signature(_Repair.__init__).parameters)[1:11]
+        self.assertEqual(names, ['pcb_data', 'pcb_file', 'clearance',
+                                 'grid_step', 'board_edge_clearance',
+                                 'near_margin', 'capture_radius',
+                                 'default_via_size', 'cap_prefix',
+                                 'extra_locked'])
+        st = _Repair(parse_kicad_pcb(BOARD), BOARD, CLEAR, 0.1, 0.55, 1.0, 2.0,
+                     0.3, 'C', set())
+        self.assertEqual(st.clearance, CLEAR)
+        self.assertEqual(st.grid_step, 0.1)
+        self.assertEqual(st.capture_radius, 2.0)
+        self.assertEqual(st._cap_prefixes, ('C',))
+    # MUTATION: insert ANY parameter (defaulted or not) before `extra_locked`
+    # -> the name list differs, and the values land on the wrong attributes.
 
 
 class TestInertness(unittest.TestCase):
@@ -937,6 +1078,49 @@ class TestInertness(unittest.TestCase):
         self.assertEqual(r['clearance_notes'], [])
     # MUTATION: drop the `.active` gate in `_Repair.__init__` -> hits > 0.
 
+    def test_the_locked_warning_still_names_a_COPPERLESS_NPTH_pad(self):
+        """The locked-part warning exists to surface a foreign via inside a
+        locked pad's keep-out. A via inside a 1.7mm mounting hole is exactly
+        that, and upstream reported it. #725's copper predicate must decide how
+        the pair is PRICED, not whether it is seen -- dropping such pads removed
+        real rows on a board that declares nothing at all, which would break
+        the inertness claim in this channel."""
+        pcb = parse_kicad_pcb(INERT)
+        st = _repair(INERT, pcb=pcb)
+        # ON THE BRANCH: an inert board, and a locked part to convert.
+        self.assertIsNone(st._floors)
+        locked = sorted(st.locked_refs)
+        self.assertTrue(locked, 'no locked part on this fixture')
+
+        def warn_rows(board):
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                repair_fanout_clearance(board, INERT, clearance=CLEAR)
+            return [ln.strip() for ln in buf.getvalue().splitlines()
+                    if '<-> via at' in ln]
+
+        # ON THE BRANCH: convert the pad that actually HAS a via in its
+        # keep-out, or the row it should keep does not exist either way.
+        # (Match the ref token exactly -- 'U8.16'.startswith('U8.1') is True,
+        # and a prefix test silently passed on the wrong row while checking
+        # this fix.)
+        before = warn_rows(pcb)
+        self.assertTrue(before, 'no locked-pad warning at all on this fixture')
+        ref, pnum = before[0].split(' ')[0].split('.', 1)
+        fp = pcb.footprints[ref]
+        pad = next(q for q in fp.pads if str(q.pad_number) == pnum)
+        pad.pad_type = 'np_thru_hole'
+        pad.drill = 1.7
+        pad.layers = ['*.Cu', '*.Mask']
+        self.assertFalse(L._pad_carries_copper(pad))
+        after = warn_rows(pcb)
+        named = [r for r in after if r.split(' ')[0] == '%s.%s' % (ref, pnum)]
+        self.assertTrue(named,
+                        'the copper-less locked pad vanished from the warning: '
+                        '%r -> %r' % (before, after))
+    # MUTATION: `continue` on `not _pad_carries_copper(p)` in the locked
+    # warning -> those rows disappear, on an INERT board.
+
     def test_the_counter_itself_fires_on_a_declaring_board(self):
         """Without this, the test above also passes if `pair` is simply never
         the method the fix calls."""
@@ -948,6 +1132,9 @@ class TestInertness(unittest.TestCase):
         finally:
             PadClearanceModel.pair = orig
         self.assertGreater(hits[0], 0)
+    # MUTATION: make the counter patch a method the fix does not call (e.g.
+    # `pair_with_source`) -> this control goes red while the inertness test
+    # above still passes, which is the point of having it.
 
 
 class TestReport(unittest.TestCase):
@@ -959,9 +1146,18 @@ class TestReport(unittest.TestCase):
             for ref, who, mm, src in rows:
                 self.assertIn(src, ('netclass', 'layer rule', 'pad override'))
                 self.assertGreater(mm, st.clearance)
+            # every source this fixture can produce is 'netclass'; assert that
+            # rather than a 3-way `assertIn` that one value satisfies
+            self.assertEqual({r[3] for r in rows}, {'netclass'})
             clause = L.format_required_clause({'required': rows})
             self.assertIn('requires', clause)
             self.assertIn('netclass', clause)
+            # the mover-vs-mover leg must contribute, or deleting it passes
+            self.assertTrue([r for r in rows if r[1].startswith('cap ')],
+                            'no mover-vs-mover row -- deleting that leg would '
+                            'leave this test green')
+    # MUTATION: delete the mover-vs-mover leg of `required_rows` -> the last
+    # assertion fails (it left 59 of 77 rows and passed before this guard).
 
     def test_only_CHARGED_pairs_are_reported(self):
         """An in-reach pair that happens to be clear is not a finding, it is the
@@ -976,6 +1172,45 @@ class TestReport(unittest.TestCase):
                             'required_rows is reporting in-reach pairs rather '
                             'than charged ones')
     # MUTATION: drop the `charged` filter in `required_rows` -> hundreds of rows.
+
+    def test_the_report_never_names_an_OFF_LAYER_track_pair(self):
+        """`required_rows` must MIRROR what was charged, not re-derive it.
+        `_seg_effs` prices a cap-pad/track pair that shares no copper layer at
+        the flat scalar (the F/B side collapse puts such pairs in `cap_segs` at
+        all); a report that resolves the requirement independently names them
+        anyway, at the netclass. check_drc grades no such pair, so every one of
+        those rows sends the reader after a violation that does not exist --
+        measured at up to 43% of the disclosure on rp2350."""
+        with tempfile.TemporaryDirectory() as td:
+            p = _stage(td, 'offrep', classes=_default_class(0.4), src=INERT)
+            pcb = parse_kicad_pcb(p)
+            st = _repair(p, pcb=pcb)
+            names = {n.net_id: n.name for n in pcb.nets.values()}
+            by_name = {v: k for k, v in names.items()}
+            rows = st.required_rows(names)
+            tracks = [r for r in rows if r[1].startswith('track ')]
+            # ON THE BRANCH: there must BE track rows and there must be
+            # off-layer pairs in reach, or this proves nothing.
+            self.assertTrue(tracks, 'no track rows at all on this fixture')
+            off_pairs = sum(
+                1 for ref, cap in st.caps.items()
+                for t in st.cap_segs[ref]
+                if not any(st._seg_layer_by_id.get(id(t)) in pl
+                           for pl in cap.pad_layers))
+            self.assertGreater(off_pairs, 0, 'no off-layer pair in any pruned '
+                                             'list -- this would pass vacuously')
+            for ref, who, mm, src in tracks:
+                nid = by_name.get(who[6:])
+                cap = st.caps[ref]
+                shared = any(
+                    any(st._seg_layer_by_id.get(id(t)) in pl
+                        for pl in cap.pad_layers)
+                    for t in st.cap_segs[ref] if t[4] == nid)
+                self.assertTrue(shared,
+                                '%s <-> %s shares no copper layer, so it is '
+                                'priced flat and must not be reported' % (ref, who))
+    # MUTATION: drop the `layer not in cap_layers[i]` guard in
+    # `required_rows`' `best()` -> phantom rows come back.
 
     def test_an_unreadable_declaration_is_disclosed_not_silent(self):
         """A FAILED read is exactly what makes a model look INERT, so the notes

--- a/tests/test_725_fanout_clearance_pad_floors.py
+++ b/tests/test_725_fanout_clearance_pad_floors.py
@@ -240,8 +240,68 @@ class TestSourcesReachTheEngine(unittest.TestCase):
         self.assertAlmostEqual(cap.max_floor, 0.5, places=6,
                                msg='the NPTH override reached max_floor and '
                                    'would widen every prune and the prescreen')
+        # ...and the pad's LAYER SET is empty, which is the marker every eff
+        # builder keys "grade this pad flat" on.
+        self.assertEqual(cap.pad_layers[-1], frozenset())
+        self.assertTrue(cap.pad_layers[0], 'the copper pad lost its layers')
     # MUTATION: drop the `_pad_carries_copper` guard on `model.pad_floor(p)` in
     # `_Cap.__init__` -> max_floor becomes 3.0.
+
+    def test_a_COPPERLESS_pad_is_graded_flat_in_EVERY_channel(self):
+        """Zeroing the copper-less pad's own override is not enough: the
+        PARTNER's netclass still flows through `pair()`, charging a keep-out
+        against a pad check_drc does not grade at all. Same defect as the
+        off-layer phantom, in the pad / via / cap-cap channels.
+
+        Measured before this guard, with C20's second copper pad replaced by an
+        np_thru_hole at lc=1.0 on a Default-0.4 board: that pad was priced at
+        0.4 against every foreign pad, and C20's foreign-pad shortfall read
+        0.6950mm where the flat scalar sees 0.2450."""
+        with tempfile.TemporaryDirectory() as td:
+            p = _stage(td, 'npthflat', classes=_default_class(0.4))
+            pcb = parse_kicad_pcb(p)
+            fp = pcb.footprints[ANCHOR_CAP]
+            real = [q for q in fp.pads if L._pad_carries_copper(q)]
+            self.assertGreaterEqual(len(real), 2, 'need a 2-copper-pad cap')
+            hole = copy.deepcopy(real[1])
+            hole.pad_type = 'np_thru_hole'
+            hole.drill = 1.0
+            hole.layers = ['*.Cu', '*.Mask']
+            hole.local_clearance = 1.0
+            fp.pads[fp.pads.index(real[1])] = hole
+            st = _repair(p, pcb=pcb)
+            cap = st.caps[ANCHOR_CAP]
+            flat_i = [k for k in range(len(cap.pad_floors))
+                      if not cap.pad_layers[k]]
+            live_i = [k for k in range(len(cap.pad_floors))
+                      if cap.pad_layers[k]]
+            # ON THE BRANCH: one of each, or this proves nothing.
+            self.assertEqual(len(flat_i), 1)
+            self.assertTrue(live_i)
+            fi, li = flat_i[0], live_i[0]
+
+            pad_rows = st._pad_effs(ANCHOR_CAP, cap)
+            self.assertEqual({round(v, 6) for v in pad_rows[fi]}, {CLEAR})
+            self.assertEqual({round(v, 6) for v in pad_rows[li]}, {0.4},
+                             'the COPPER pad must still be charged at 0.4')
+
+            vias = st.cap_vias[ANCHOR_CAP]
+            self.assertTrue(vias)
+            via_rows = st._via_effs(ANCHOR_CAP, cap, vias)
+            for j, v in enumerate(vias):
+                radius = st._via_radius_by_id[id(v)][1]
+                self.assertAlmostEqual(via_rows[fi][j], radius + CLEAR,
+                                       places=9)
+                self.assertAlmostEqual(via_rows[li][j], radius + 0.4, places=9)
+
+            oref = next((o for o in st.cap_caps[ANCHOR_CAP]
+                         if st._cap_floors_ok(st.caps[o])), None)
+            self.assertIsNotNone(oref, 'no mover neighbour to pair with')
+            pair_rows = st._pair_effs(ANCHOR_CAP, cap, oref, st.caps[oref])
+            self.assertEqual({round(v, 6) for v in pair_rows[fi]}, {CLEAR})
+            self.assertEqual({round(v, 6) for v in pair_rows[li]}, {0.4})
+    # MUTATION: drop the `_flat_pad` test in `_pad_effs` / `_via_effs` /
+    # `_pair_effs` -> the copper-less row comes back at 0.4.
 
     def test_a_board_declaring_nothing_builds_no_model(self):
         pcb = parse_kicad_pcb(INERT)
@@ -358,6 +418,33 @@ class TestChannels(unittest.TestCase):
             self.assertGreater(on, 0, 'no on-layer pair was raised')
     # MUTATION: drop the off-layer test in `_seg_effs` -> the off-layer rows
     # come back at the netclass 0.4.
+
+    def test_a_board_with_NO_copper_layers_is_not_scoped_by_layer(self):
+        """If `board_info.copper_layers` is empty, `pad_copper_layers` resolves
+        NOTHING for a `*.Cu` pad -- so every cap pad would look copper-less,
+        every pair would take the off-layer fallback, and the whole board would
+        be graded at the flat scalar. Before the layer scoping existed such a
+        board only ever OVER-blocked; the fallback flips the direction, and
+        under-blocking ships a violation. So the scoping switches itself off."""
+        with tempfile.TemporaryDirectory() as td:
+            p = _stage(td, 'nocu', classes=_default_class(0.4))
+            pcb = parse_kicad_pcb(p)
+            pcb.board_info.copper_layers = []
+            st = _repair(p, pcb=pcb)
+            # ON THE BRANCH: the model must still be active, or nothing is
+            # scoped anyway and this passes for the wrong reason.
+            self.assertIsNotNone(st._floors)
+            self.assertEqual(st._all_cu, frozenset())
+            cap = st.caps[ANCHOR_CAP]
+            self.assertIsNone(st._cap_pad_layers(cap),
+                              'layer scoping stayed on with no copper layers')
+            rows = st._pad_effs(ANCHOR_CAP, cap)
+            self.assertTrue(rows)
+            self.assertIn(0.4, {round(v, 6) for r in rows for v in r},
+                          'every pair fell back to the flat scalar -- the '
+                          'board is now UNDER-blocked')
+    # MUTATION: `return pl if self._all_cu else None` -> `return pl` -> every
+    # pad reads as copper-less and the whole board grades flat.
 
     def test_a_relaxing_rule_REPLACES_downward(self):
         """A dru rule REPLACES, so it can lower a pair below the netclass.

--- a/tests/test_725_fanout_clearance_pad_floors.py
+++ b/tests/test_725_fanout_clearance_pad_floors.py
@@ -11,12 +11,17 @@ Conventions this file follows (from #697's test file, and CLAUDE.md):
   * Assert you are ON the branch before asserting about it -- each test spies the
     value its branch keys on, with a detail string saying why.
 
-It deliberately imports neither `run_utils` nor `subprocess`: `run_all.py`
-classifies a test as integration by grepping its SOURCE for those, and `--fast`
-would then never run this file.
+Nothing here shells out or drives a CLI: it runs entirely in-process in ~22 s.
+`run_all.is_integration` classifies by grepping the SOURCE for `run_utils` and
+the name of the standard sub-process module, and this file NAMES those markers
+in prose (including in this sentence) -- which is exactly how the first version
+of it got bucketed as integration and silently skipped under `--fast`, a test
+file that proves nothing being worse than no test file at all. Hence the
+explicit opt-out below.
 """
 from __future__ import annotations
 
+RUN_ALL_FAST_OK = True
 RUN_ALL_TIMEOUT = 900
 
 import json

--- a/tests/test_725_fanout_clearance_pad_floors.py
+++ b/tests/test_725_fanout_clearance_pad_floors.py
@@ -316,6 +316,49 @@ class TestChannels(unittest.TestCase):
     # MUTATION: scope the segment floor to `self._all_cu` -> the F.Cu and
     # In1.Cu arms return 0.5 too.
 
+    def test_an_OFF_LAYER_track_pair_keeps_the_flat_scalar(self):
+        """`cap_segs` is pruned on the F/B side collapse, which files an
+        In1.Cu track under 'F' -- so it contains cap-pad/inner-track pairs that
+        cannot touch and that check_drc never grades at all. The dru term
+        scopes itself away from them (empty shared set), but the NETCLASS term
+        is layer-blind, so charging it there would raise a PHANTOM and move
+        caps to clear copper on a layer their pads do not occupy.
+
+        Measured before this guard, on this board at a Default class of 0.3:
+        R17/R18/R5's entire graze WAS the phantom -- 0.0821mm each flat,
+        0.6991/0.6991/0.5686 raised."""
+        with tempfile.TemporaryDirectory() as td:
+            p = _stage(td, 'offlayer', classes=_default_class(0.4))
+            st = _repair(p)
+            checked = off = on = 0
+            for ref, cap in st.caps.items():
+                rows = st._seg_effs(ref, cap)
+                if rows is None:
+                    continue
+                for i in range(len(cap.pad_floors)):
+                    mine = cap.pad_layers[i]
+                    for j, t in enumerate(st.cap_segs[ref]):
+                        layer = st._seg_layer_by_id.get(id(t))
+                        if layer is None:
+                            continue
+                        half = t[5] - st._item_reach(
+                            st._seg_floor_by_id.get(id(t)))
+                        checked += 1
+                        if layer in mine:
+                            on += rows[i][j] > half + CLEAR + 1e-9
+                        else:
+                            off += 1
+                            self.assertAlmostEqual(
+                                rows[i][j], half + CLEAR, places=9,
+                                msg='%s pad %d vs an off-layer %s track was '
+                                    'charged above the flat scalar'
+                                    % (ref, i, layer))
+            # ON THE BRANCH: both kinds must be present, or this proves nothing
+            self.assertGreater(off, 0, 'no off-layer pair in any pruned list')
+            self.assertGreater(on, 0, 'no on-layer pair was raised')
+    # MUTATION: drop the off-layer test in `_seg_effs` -> the off-layer rows
+    # come back at the netclass 0.4.
+
     def test_a_relaxing_rule_REPLACES_downward(self):
         """A dru rule REPLACES, so it can lower a pair below the netclass.
         Pinning this is what proves the compare uses pair(), not max_floor()."""
@@ -653,22 +696,45 @@ class TestShapeContract(unittest.TestCase):
                              'address the wrong pad' % rot)
     # MUTATION: sort or filter inside `_pad_cache_for` -> the nets reorder.
 
-    def test_injecting_st_vias_wholesale_still_grades(self):
+    def test_injecting_st_vias_wholesale_is_graded_AS_INJECTED(self):
         """`st.vias = [...]` is the idiom tests/test_fanout_clearance.py uses.
-        Any POSITIONAL parallel floor list would desync right here."""
-        st = _repair(self.path)
-        cap = st.caps[ANCHOR_CAP]
-        own = {p[4] for p in cap.pads}
-        foreign = next(n for n in range(1, 50) if n not in own)
-        r = cap.pad_rects()[0]
-        st.vias = [((r[0] + r[2]) / 2.0, (r[1] + r[3]) / 2.0, foreign,
-                    0.35 / 2 + CLEAR)]
-        st.cap_vias = {ref: st.vias for ref in st.caps}
-        self.assertGreater(
-            st.via_penalty(cap, cap.x, cap.y, cap.rot,
-                           st.cap_vias[ANCHOR_CAP], ref=ANCHOR_CAP), 0.0)
-    # MUTATION: key the via floors by list position -> IndexError, or a
-    # silently wrong requirement.
+        The injected tuple carries its own keep-out convention, so it must be
+        used verbatim -- deriving the radius by subtracting `_item_reach` off
+        element 3 and adding the pair requirement back silently re-prices it.
+
+        Staged with a netclass AND an inner-layer dru rule on purpose: that is
+        what makes `_item_reach` (0.5, raised by the rule on the via's all-copper
+        scope) differ from `pair` (0.4, the netclass, since the cap pad does not
+        share the ruled layer). On a fixture where they coincide, a derived
+        radius round-trips by luck and this test would pass either way."""
+        with tempfile.TemporaryDirectory() as td:
+            p = _stage(td, 'inject', classes=_default_class(0.4),
+                       dru=_dru('In1.Cu', 0.5))
+            st = _repair(p)
+            cap = st.caps[ANCHOR_CAP]
+            own = {q[4] for q in cap.pads}
+            foreign = next(n for n in range(1, 50) if n not in own)
+            r = cap.pad_rects()[0]
+            injected = ((r[0] + r[2]) / 2.0, (r[1] + r[3]) / 2.0, foreign,
+                        0.35 / 2 + CLEAR)
+            st.vias = [injected]
+            st.cap_vias = {ref: st.vias for ref in st.caps}
+            # ON THE BRANCH: the two must actually differ here.
+            reach = st._item_reach(st.via_floor(foreign))
+            pair = st.via_required(cap.pad_floors[0], foreign)
+            self.assertNotAlmostEqual(
+                reach, pair, places=6,
+                msg='_item_reach == pair on this fixture -- a derived radius '
+                    'would round-trip by luck and this test would pass '
+                    'whether or not the identity map is used')
+            rows = st._via_effs(ANCHOR_CAP, cap, st.cap_vias[ANCHOR_CAP])
+            self.assertAlmostEqual(rows[0][0], injected[3], places=9,
+                                   msg='the injected keep-out was re-priced')
+            self.assertGreater(
+                st.via_penalty(cap, cap.x, cap.y, cap.rot,
+                               st.cap_vias[ANCHOR_CAP], ref=ANCHOR_CAP), 0.0)
+    # MUTATION: derive the radius from `v[3] - _item_reach(...)` instead of the
+    # identity map -> rows[0][0] comes out 0.1mm low.
 
     def test_injecting_cap_foreign_pads_grades_without_misindexing(self):
         """A tuple a test injected carries no registered floor, so it must be

--- a/tests/test_725_fanout_clearance_pad_floors.py
+++ b/tests/test_725_fanout_clearance_pad_floors.py
@@ -38,6 +38,7 @@ if _TESTS not in sys.path:
 
 from kicad_parser import parse_kicad_pcb
 from copy_board import copy_board
+from synth import make_via
 import placement.legality as L
 from placement.legality import PadClearanceModel
 from placement.fanout_clearance import (_Repair, _pad_pair_shortfall,
@@ -71,13 +72,13 @@ def _repair(path, clearance=CLEAR, prefix='C,R,FB', pcb=None):
                    clearance, 0.1, 0.55, 1.0, 2.0, 0.3, prefix, set())
 
 
-def _stage(tmp, name, classes=None, dru=None):
-    """A COPY of the in-repo board (siblings carried by copy_board), plus an
+def _stage(tmp, name, classes=None, dru=None, src=None):
+    """A COPY of an in-repo board (siblings carried by copy_board), plus an
     optional netclass project and/or an optional .kicad_dru."""
     d = os.path.join(tmp, name)
     os.makedirs(d, exist_ok=True)
     dst = os.path.join(d, 'b.kicad_pcb')
-    copy_board(BOARD, dst)
+    copy_board(src or BOARD, dst)
     pro = os.path.splitext(dst)[0] + '.kicad_pro'
     if classes is not None:
         with open(pro, 'w', encoding='utf-8') as f:
@@ -364,21 +365,78 @@ class TestPruneRadiiStayExact(unittest.TestCase):
 
     def test_the_bbox_prescreen_widens_with_the_requirement(self):
         """`_blocked_geom`'s pad-bbox prescreen is a SKIP: left at the flat
-        scalar it silently drops exactly the pairs a declaration raises."""
-        pairs = 0
-        for ref, cap in self.st.caps.items():
-            for oref in self.st.cap_caps[ref]:
-                other = self.st.caps[oref]
-                gap = _rect_gap(cap.pad_bbox(cap.x, cap.y, cap.rot),
-                                other.pad_bbox())
-                screen = max(self.st.clearance, cap.max_floor, other.max_floor)
-                if self.st.clearance <= gap < screen:
-                    pairs += 1
-        self.assertGreater(pairs, 0,
-                           'no mover pair sits between the flat scalar and the '
-                           'widened prescreen -- this test would pass vacuously')
-    # MUTATION: `_blocked_geom`'s prescreen back to `>= self.clearance` ->
-    # every one of those pairs is skipped before its shortfall is computed.
+        scalar it silently drops exactly the pairs a declaration raises.
+
+        Behavioural, not arithmetic: it walks a cap toward each neighbour until
+        the pair is charged beyond its seed baseline while the pad BBOXES are
+        still further apart than the flat scalar, then asserts _blocked_geom
+        actually vetoes that pose."""
+        pcb = parse_kicad_pcb(BOARD)
+        for p in pcb.footprints[ANCHOR_CAP].pads:
+            p.local_clearance = 1.2      # raise only this mover's own pads
+        st = _repair(BOARD, pcb=pcb)
+        cap = st.caps[ANCHOR_CAP]
+        found = None
+        for oref in st.cap_caps[ANCHOR_CAP]:
+            other = st.caps[oref]
+            base = st.base_cap_pad.get(frozenset((ANCHOR_CAP, oref)), 0.0)
+            effs = st._pair_effs(ANCHOR_CAP, cap, oref, other)
+            orect = other.rect()
+            ocx, ocy = (orect[0] + orect[2]) / 2.0, (orect[1] + orect[3]) / 2.0
+            d = math.hypot(ocx - cap.x, ocy - cap.y)
+            for k in range(1, 25):
+                step = k * 0.1
+                if step >= d:
+                    break
+                nx = cap.x + (ocx - cap.x) * step / d
+                ny = cap.y + (ocy - cap.y) * step / d
+                pads = cap.pad_rects(nx, ny, cap.rot)
+                bbox_gap = _rect_gap(cap.pad_bbox(nx, ny, cap.rot),
+                                     other.pad_bbox())
+                charged = _pad_pair_shortfall(pads, other.pad_rects(),
+                                              st.clearance, effs)
+                flat = _pad_pair_shortfall(pads, other.pad_rects(), st.clearance)
+                if (bbox_gap >= st.clearance and charged > base + 1e-6
+                        and flat == 0.0):
+                    found = (oref, nx, ny, bbox_gap, charged, base)
+                    break
+            if found:
+                break
+        # ON THE BRANCH: the pose must be one the OLD prescreen would skip, and
+        # one the flat pricing scores at exactly zero.
+        self.assertIsNotNone(found, 'no pose sits beyond the flat prescreen '
+                                    'while being charged -- this test would '
+                                    'pass vacuously')
+        oref, nx, ny, bbox_gap, charged, base = found
+        self.assertGreaterEqual(bbox_gap, st.clearance)
+        self.assertGreater(charged, base)
+        self.assertTrue(
+            st._blocked_geom(ANCHOR_CAP, cap, nx, ny, cap.rot),
+            '_blocked_geom let a charged %s<->%s pose through (bbox gap %.4f '
+            '>= the flat %.2f, so the prescreen skipped it)'
+            % (ANCHOR_CAP, oref, bbox_gap, st.clearance))
+    # MUTATION: `_blocked_geom`'s prescreen back to `>= self.clearance` -> the
+    # pair is skipped before its shortfall is computed and the pose is allowed.
+
+    def test_the_cap_side_slack_raises_the_via_and_track_reaches(self):
+        """`cap_segs`/`cap_vias` add the CAP's own excess over the flat scalar.
+        A uniform netclass hides this -- the item's own floor already grew the
+        list -- so raise one mover's pads and leave every via and track at the
+        flat value."""
+        pcb = parse_kicad_pcb(BOARD)
+        for p in pcb.footprints[ANCHOR_CAP].pads:
+            p.local_clearance = 1.2
+        st = _repair(BOARD, pcb=pcb)
+        # ON THE BRANCH: the cap is raised and the items are NOT.
+        self.assertAlmostEqual(st.caps[ANCHOR_CAP].max_floor, 1.2, places=6)
+        self.assertEqual(st._item_reach(st.via_floor(0)), CLEAR)
+        for name in ('cap_segs', 'cap_vias'):
+            a = len(getattr(self.flat, name)[ANCHOR_CAP])
+            b = len(getattr(st, name)[ANCHOR_CAP])
+            self.assertGreater(b, a, '%s did not grow with the cap-side slack '
+                                     '(%d -> %d)' % (name, a, b))
+    # MUTATION: `via_slack = 0.0`, or drop `max(0.0, cap_mf - clearance)` from
+    # `seg_reach` -> that list stops growing.
 
     def test_the_seed_baseline_is_in_the_SAME_currency(self):
         """A baseline priced flat while candidates price at the requirement
@@ -450,33 +508,45 @@ class TestNudgerGraderConsistency(unittest.TestCase):
     # MUTATION: build the via eff rows from anything but `via_required` -> the
     # equality fails.
 
-    def test_the_offender_predicate_sees_what_the_grader_charges(self):
-        """The nudger's offender test, replayed here against the same helper.
-        A via that the grader charges must be an offender, and there must be at
-        least one that the FLAT predicate would have missed."""
-        only_raised = 0
-        for ref, cap in self.st.caps.items():
-            rects = cap.pad_rects(cap.x, cap.y, cap.rot)
-            for vx, vy, vnet, keepout in self.st.cap_vias[ref]:
-                radius = keepout - self.st._item_reach(self.st.via_floor(vnet))
-                for i, (bx0, by0, bx1, by1, net) in enumerate(rects):
-                    if vnet == net:
-                        continue
-                    d = _point_to_rect_dist(vx, vy, (bx0, by0, bx1, by1))
-                    want = self.st.via_required(cap.pad_floors[i], vnet)
-                    hit_now = d < radius + want - 1e-6
-                    hit_flat = d < radius + self.st.clearance - 1e-6
-                    self.assertFalse(hit_flat and not hit_now,
-                                     'the raised predicate LOST an offender '
-                                     'the flat one saw (%s, via %g,%g)'
-                                     % (ref, vx, vy))
-                    only_raised += (hit_now and not hit_flat)
-        self.assertGreater(only_raised, 0,
-                           'no via is an offender only under the raised '
-                           'requirement -- this test would pass vacuously')
+    def test_the_offender_loop_RESOLVES_rather_than_assuming_the_scalar(self):
+        """Drives the real `nudge_vias_for_unresolved` and counts how often its
+        offender loop consults `via_required`.
+
+        Every via is parked far from every cap, so there are no offenders and
+        the function returns empty either way -- but the loop must still have
+        EVALUATED the predicate through the resolver. Priced at the flat scalar
+        instead, the resolver is never called at all, and a cap unresolved
+        because of a RAISED via requirement yields an empty offender list: the
+        pass then reports it unresolved forever and prints nothing."""
+        pcb = parse_kicad_pcb(self.path)
+        st = _repair(self.path, pcb=pcb)
+        bounds = pcb.board_info.board_bounds
+        far = make_via(bounds[0] + 2.0, bounds[1] + 2.0, net_id=1)
+        pcb.vias[:] = [far]
+        st.vias = [(far.x, far.y, 1, 0.25 + st._item_reach(st.via_floor(1)))]
+        st.cap_vias = {r: st.vias for r in st.caps}
+        unresolved = [r for r in st.caps
+                      if st.graze_penalty(r, st.caps[r], st.caps[r].x,
+                                          st.caps[r].y, st.caps[r].rot) > 1e-6]
+        # ON THE BRANCH: the loop only runs at all if some cap is unresolved,
+        # and only reaches the resolver if a via is in the list.
+        self.assertTrue(unresolved, 'no cap is unresolved -- the offender loop '
+                                    'never runs and this proves nothing')
+        calls = [0]
+        real = st.via_required
+
+        def counting(pad_floor, via_net):
+            calls[0] += 1
+            return real(pad_floor, via_net)
+        st.via_required = counting
+        moves, segs = nudge_vias_for_unresolved(st, pcb, CLEAR)
+        self.assertEqual((moves, segs), ([], []),
+                         'the far-away via should offend nobody')
+        self.assertGreater(calls[0], 0,
+                           'the offender loop never consulted via_required -- '
+                           'it is pricing at the flat scalar')
     # MUTATION: the offender test in `nudge_vias_for_unresolved` back to
-    # `vr + clearance` -> those `only_raised` vias become invisible to the
-    # nudger while the grader still reports their caps unresolved.
+    # `vr + clearance - EPS` -> calls[0] == 0.
 
     def test_a_duck_typed_state_grades_flat_instead_of_crashing(self):
         """test_617 and test_370 drive the nudger with a _FakeSt/_FakeCap that
@@ -551,6 +621,11 @@ class TestShapeContract(unittest.TestCase):
     # silently wrong requirement.
 
     def test_injecting_cap_foreign_pads_grades_without_misindexing(self):
+        """A tuple a test injected carries no registered floor, so it must be
+        graded at the FLAT scalar. Without the source-list identity guard the
+        memo built during __init__ is reused, and row[0] silently supplies the
+        requirement of a completely different pad -- a wrong number that raises
+        no error and looks entirely plausible."""
         st = _repair(self.path)
         cap = st.caps[ANCHOR_CAP]
         own = {p[4] for p in cap.pads}
@@ -558,9 +633,21 @@ class TestShapeContract(unittest.TestCase):
         r = cap.pad_rects()[0]
         st.cap_foreign_pads[ANCHOR_CAP] = [
             (r[0] - 0.15, r[1], r[0] - 0.05, r[3], foreign, cap.side)]
-        self.assertIn(foreign, _short(st, ANCHOR_CAP))
-    # MUTATION: drop the source-list identity guard in `_pad_effs` -> stale
-    # rows index a list that no longer exists (IndexError).
+        rect = st.cap_foreign_pads[ANCHOR_CAP][0][:4]
+        got = _short(st, ANCHOR_CAP)
+        self.assertIn(foreign, got)
+        # Summed over EVERY cap pad, at the FLAT scalar. Graded off a stale row
+        # it would come out at the board's declared 0.4 instead.
+        flat = sum(max(0.0, CLEAR - _rect_gap(p[:4], rect))
+                   for p in cap.pad_rects())
+        declared = sum(max(0.0, 0.4 - _rect_gap(p[:4], rect))
+                       for p in cap.pad_rects())
+        self.assertNotAlmostEqual(flat, declared, places=6)   # not vacuous
+        self.assertAlmostEqual(got[foreign], flat, places=6,
+                               msg='the injected pad was graded at a stale '
+                                   'row rather than the flat scalar')
+    # MUTATION: drop the source-list identity guard in `_pad_effs` -> the
+    # shortfall reads 0.35.
 
     def test_ten_positional_arguments_still_construct(self):
         _Repair(parse_kicad_pcb(BOARD), BOARD, CLEAR, 0.1, 0.55, 1.0, 2.0, 0.3,
@@ -644,8 +731,12 @@ class TestReport(unittest.TestCase):
     # MUTATION: drop the `charged` filter in `required_rows` -> hundreds of rows.
 
     def test_an_unreadable_declaration_is_disclosed_not_silent(self):
-        """A FAILED read is exactly what makes a model look inert, so the notes
-        must be captured BEFORE the active-drop."""
+        """A FAILED read is exactly what makes a model look INERT, so the notes
+        must be captured BEFORE the active-drop.
+
+        Staged on the board with NO pad overrides on purpose: on a board that
+        has some, the failed netclass read still leaves the model active and
+        the notes survive by accident, so the ordering is never tested."""
         import list_nets
         orig = list_nets.net_clearance_map
 
@@ -654,7 +745,13 @@ class TestReport(unittest.TestCase):
         list_nets.net_clearance_map = boom
         try:
             with tempfile.TemporaryDirectory() as td:
-                st = _repair(_stage(td, 'unread', classes=_default_class(0.4)))
+                p = _stage(td, 'unread', classes=_default_class(0.4), src=INERT)
+                st = _repair(p)
+                # ON THE BRANCH: the failure must leave the model INACTIVE, or
+                # the notes survive for the wrong reason.
+                self.assertIsNone(st._floors,
+                                  'the model stayed active -- the ordering is '
+                                  'not under test on this fixture')
                 self.assertTrue(st.clearance_notes,
                                 'the failed netclass read was silent')
         finally:

--- a/tests/test_725_fanout_clearance_pad_floors.py
+++ b/tests/test_725_fanout_clearance_pad_floors.py
@@ -68,9 +68,28 @@ ANCHOR_NET = 69
 ANCHOR_GAP = 0.1346
 MOVER_A, MOVER_B = 'C49', 'C62'
 
-# The inert board's recorded result, which #725 must not move.
-INERT_UNRESOLVED = ['C16', 'C17', 'C18', 'C19', 'C22', 'C23', 'C24']
-INERT_PLACEMENTS = 2
+# The inert board's recorded result. #725 did not move it; #731 did, on
+# purpose and by a lot -- 2 placements and 7 unresolved caps became 1 and 1.
+#
+# rp2350 declares no netclass, no .kicad_dru and no pad override, so the
+# clearance model is INERT and the pre-#731 layer side-channels were both
+# empty here. It is also 6 copper layers, and 2342 of its 4331 pruned
+# pad x track pairs were OFF-LAYER, carrying 4.6685mm of phantom seed graze
+# against 0.0142mm of real. Per-cap seed track graze, on-layer / off-layer:
+#
+#   C16  0.0000 / 0.7046      C20  0.0000 / 0.2900
+#   C17  0.0000 / 0.4913      C22  0.0000 / 0.9160
+#   C18  0.0106 / 0.0000      C23  0.0036 / 0.5836
+#   C19  0.0000 / 0.7851      C24  0.0000 / 0.8979
+#
+# So six of the eight caps were violators purely on phantom, and only C18 and
+# C23 have anything real. C18 is resolved; C23 is not, and is the one cap that
+# legitimately remains unresolved. The old run also SHIPPED a violation for
+# this: it moved C19 to clear a phantom and put its GND pad 0.145mm inside a
+# real F.Cu track, so check_drc flagged a PAD-SEGMENT on the output of a board
+# that is clean as it ships. It is clean again now.
+INERT_UNRESOLVED = ['C23']
+INERT_PLACEMENTS = 1
 
 
 def _repair(path, clearance=CLEAR, prefix='C,R,FB', pcb=None):
@@ -385,31 +404,46 @@ class TestChannels(unittest.TestCase):
     # MUTATION: scope the segment floor to `self._all_cu` -> the F.Cu and
     # In1.Cu arms return 0.5 too.
 
-    def test_an_OFF_LAYER_track_pair_keeps_the_flat_scalar(self):
-        """`cap_segs` is pruned on the F/B side collapse, which files an
-        In1.Cu track under 'F' -- so it contains cap-pad/inner-track pairs that
-        cannot touch and that check_drc never grades at all. The dru term
-        scopes itself away from them (empty shared set), but the NETCLASS term
-        is layer-blind, so charging it there would raise a PHANTOM and move
-        caps to clear copper on a layer their pads do not occupy.
+    def test_an_OFF_LAYER_track_pair_is_not_in_cap_segs_AT_ALL(self):
+        """#725 charged an off-layer pair the FLAT scalar so a netclass could
+        not amplify it; #731 removed the pair instead, which is what check_drc
+        does (check_pad_segment_overlap returns early off-layer).
 
-        Measured before this guard, on this board at a Default class of 0.3:
+        This test used to assert the flat price and to REQUIRE such a pair to
+        exist (`assertGreater(off, 0)`). Under #731 that is structurally
+        impossible, so the spy moved: it recomputes the OLD 'F'/'B' side prune
+        and asserts THAT still admits off-layer pairs, then asserts the real
+        `cap_segs` admits none. Without the recomputed spy this test would pass
+        just as well on a build that had deleted track grading outright, which
+        is why the on-layer arm below is kept unchanged.
+
+        Measured on this board at a Default class of 0.3 before #731:
         R17/R18/R5's entire graze WAS the phantom -- 0.0821mm each flat,
         0.6991/0.6991/0.5686 raised."""
         with tempfile.TemporaryDirectory() as td:
             p = _stage(td, 'offlayer', classes=_default_class(0.4))
             st = _repair(p)
+            # ON THE BRANCH: the OLD side prune really did admit off-layer
+            # pairs on this board, so "0 now" is a change, not a tautology.
+            old_off = 0
+            for ref, cap in st.caps.items():
+                for t in st.segments:
+                    if st._seg_side(t[6]) != cap.side:
+                        continue
+                    if not any(t[6] in pl for pl in cap.pad_layers):
+                        old_off += 1
+            self.assertGreater(old_off, 0,
+                               'the OLD side prune admitted no off-layer pair '
+                               'on this board -- the spy proves nothing')
             checked = off = on = 0
             for ref, cap in st.caps.items():
                 rows = st._seg_effs(ref, cap)
                 if rows is None:
                     continue
-                for i in range(len(cap.pad_floors)):
+                for i in range(len(cap.pad_layers)):
                     mine = cap.pad_layers[i]
                     for j, t in enumerate(st.cap_segs[ref]):
-                        layer = st._seg_layer_by_id.get(id(t))
-                        if layer is None:
-                            continue
+                        layer = t[6]
                         half = t[5] - st._item_reach(
                             st._seg_floor_by_id.get(id(t)))
                         checked += 1
@@ -417,16 +451,15 @@ class TestChannels(unittest.TestCase):
                             on += rows[i][j] > half + CLEAR + 1e-9
                         else:
                             off += 1
-                            self.assertAlmostEqual(
-                                rows[i][j], half + CLEAR, places=9,
-                                msg='%s pad %d vs an off-layer %s track was '
-                                    'charged above the flat scalar'
-                                    % (ref, i, layer))
-            # ON THE BRANCH: both kinds must be present, or this proves nothing
-            self.assertGreater(off, 0, 'no off-layer pair in any pruned list')
+            self.assertEqual(off, 0,
+                             '%d off-layer pair(s) survived the prune' % off)
+            # ON THE BRANCH: on-layer pairs must still be raised, or the whole
+            # track channel is simply gone and `off == 0` is vacuous.
             self.assertGreater(on, 0, 'no on-layer pair was raised')
-    # MUTATION: drop the off-layer test in `_seg_effs` -> the off-layer rows
-    # come back at the netclass 0.4.
+            self.assertGreater(checked, 0, 'no pair was examined at all')
+    # MUTATION: revert the prune to `if seg[6] != cap.side: continue` -> `off`
+    # is no longer 0. MUTATION: make `_seg_shares` return False always -> `on`
+    # drops to 0 and the vacuity guard fires.
 
     def test_a_board_with_NO_copper_layers_is_not_scoped_by_layer(self):
         """If `board_info.copper_layers` is empty, `pad_copper_layers` resolves
@@ -1175,12 +1208,19 @@ class TestReport(unittest.TestCase):
 
     def test_the_report_never_names_an_OFF_LAYER_track_pair(self):
         """`required_rows` must MIRROR what was charged, not re-derive it.
-        `_seg_effs` prices a cap-pad/track pair that shares no copper layer at
-        the flat scalar (the F/B side collapse puts such pairs in `cap_segs` at
-        all); a report that resolves the requirement independently names them
-        anyway, at the netclass. check_drc grades no such pair, so every one of
-        those rows sends the reader after a violation that does not exist --
-        measured at up to 43% of the disclosure on rp2350."""
+        Before #731 the F/B side collapse put pairs sharing no copper layer
+        into `cap_segs` at all, `_seg_effs` priced them at the flat scalar, and
+        a report resolving the requirement independently named them anyway, at
+        the netclass -- up to 43% of the disclosure on rp2350, every row
+        sending the reader after a violation check_drc does not grade.
+
+        #731 removes the pair rather than repricing it, so the guard in
+        `best()` is now belt-and-braces for the real prune and load-bearing
+        only for a MIXED-layer cap (an SMD pad beside a through-hole one),
+        where the union prune keeps a track only some pads share. The spy that
+        used to require an off-layer pair to exist therefore moved to the OLD
+        side prune; the per-row `shared` assertion below is unchanged and is
+        what still discriminates."""
         with tempfile.TemporaryDirectory() as td:
             p = _stage(td, 'offrep', classes=_default_class(0.4), src=INERT)
             pcb = parse_kicad_pcb(p)
@@ -1189,28 +1229,36 @@ class TestReport(unittest.TestCase):
             by_name = {v: k for k, v in names.items()}
             rows = st.required_rows(names)
             tracks = [r for r in rows if r[1].startswith('track ')]
-            # ON THE BRANCH: there must BE track rows and there must be
-            # off-layer pairs in reach, or this proves nothing.
+            # ON THE BRANCH: there must BE track rows, or this proves nothing.
             self.assertTrue(tracks, 'no track rows at all on this fixture')
+            # ...and the OLD prune must have admitted off-layer pairs here, or
+            # the phantom this guard is about never existed on this fixture.
+            old_off = sum(
+                1 for ref, cap in st.caps.items()
+                for t in st.segments
+                if st._seg_side(t[6]) == cap.side
+                and not any(t[6] in pl for pl in cap.pad_layers))
+            self.assertGreater(old_off, 0, 'the OLD side prune admitted no '
+                                           'off-layer pair -- spy proves nothing')
+            # ...and the NEW prune must admit none.
             off_pairs = sum(
                 1 for ref, cap in st.caps.items()
                 for t in st.cap_segs[ref]
-                if not any(st._seg_layer_by_id.get(id(t)) in pl
-                           for pl in cap.pad_layers))
-            self.assertGreater(off_pairs, 0, 'no off-layer pair in any pruned '
-                                             'list -- this would pass vacuously')
+                if not any(t[6] in pl for pl in cap.pad_layers))
+            self.assertEqual(off_pairs, 0,
+                             '%d off-layer pair(s) survived the prune' % off_pairs)
             for ref, who, mm, src in tracks:
                 nid = by_name.get(who[6:])
                 cap = st.caps[ref]
                 shared = any(
-                    any(st._seg_layer_by_id.get(id(t)) in pl
-                        for pl in cap.pad_layers)
+                    any(t[6] in pl for pl in cap.pad_layers)
                     for t in st.cap_segs[ref] if t[4] == nid)
                 self.assertTrue(shared,
                                 '%s <-> %s shares no copper layer, so it is '
-                                'priced flat and must not be reported' % (ref, who))
-    # MUTATION: drop the `layer not in cap_layers[i]` guard in
-    # `required_rows`' `best()` -> phantom rows come back.
+                                'not charged and must not be reported' % (ref, who))
+    # MUTATION: drop the `_seg_shares` guard in `required_rows`' `best()` ->
+    # a mixed-layer cap's phantom rows come back. MUTATION: revert the prune to
+    # the side collapse -> `off_pairs` is no longer 0.
 
     def test_an_unreadable_declaration_is_disclosed_not_silent(self):
         """A FAILED read is exactly what makes a model look INERT, so the notes

--- a/tests/test_725_fanout_clearance_pad_floors.py
+++ b/tests/test_725_fanout_clearance_pad_floors.py
@@ -641,6 +641,48 @@ class TestNudgerGraderConsistency(unittest.TestCase):
     # MUTATION: the offender test in `nudge_vias_for_unresolved` back to
     # `vr + clearance - EPS` -> calls[0] == 0.
 
+    def test_a_RELOCATED_via_keeps_its_radius(self):
+        """`nudge_vias_for_unresolved` rebuilds `st.vias`, so a moved via is a
+        NEW tuple. Without carrying its entry across, it drops out of the radius
+        map and is graded at its keep-out SLOT -- the prune over-reach -- rather
+        than at the pair's requirement. Conservative, but wrong, and it is the
+        one map that gains entries after __init__, so the entry must also hold
+        its tuple or a recycled id hands back another via's radius.
+
+        No tracked board relocates a via at the shipped 0.6mm budget, so this
+        rigs one: a single foreign via just outside a cap pad, a cleared
+        neighbourhood, and a wider `max_shift`."""
+        pcb = parse_kicad_pcb(BOARD)
+        st = _repair(BOARD, pcb=pcb)
+        cap = st.caps['C67']
+        r = cap.pad_rects()[0]
+        own = {q[4] for q in cap.pads}
+        fnet = next(n for n in pcb.nets if n and n not in own)
+        vx, vy = r[2] + 0.20, (r[1] + r[3]) / 2.0
+        pcb.vias[:] = [make_via(vx, vy, net_id=fnet, size=0.5, drill=0.3)]
+        pcb.segments[:] = []
+        t0 = (vx, vy, fnet, 0.25 + st._item_reach(st.via_floor(fnet)))
+        st.vias = [t0]
+        st._via_radius_by_id = {id(t0): (t0, 0.25)}
+        st.cap_vias = {k: st.vias for k in st.caps}
+        st.segments = []
+        st.cap_segs = {k: [] for k in st.caps}
+        moves, _segs = nudge_vias_for_unresolved(st, pcb, CLEAR, max_shift=4.0)
+        # ON THE BRANCH: the via must actually have moved, or the carry-over
+        # branch never ran and this test would pass vacuously.
+        self.assertEqual(len(moves), 1, 'no via was relocated')
+        self.assertEqual(len(st.vias), 1)
+        moved = st.vias[0]
+        self.assertNotEqual((moved[0], moved[1]), (t0[0], t0[1]))
+        rec = st._via_radius_by_id.get(id(moved))
+        self.assertIsNotNone(rec, 'the relocated via lost its radius')
+        self.assertAlmostEqual(rec[1], 0.25, places=9)
+        self.assertIs(rec[0], moved,
+                      'the map does not hold the tuple it keys on -- a '
+                      'recycled id would return another via\'s radius')
+    # MUTATION: drop the `_radii[id(moved)] = ...` carry-over in
+    # `nudge_vias_for_unresolved` -> rec is None.
+
     def test_a_duck_typed_state_grades_flat_instead_of_crashing(self):
         """test_617 and test_370 drive the nudger with a _FakeSt/_FakeCap that
         carries none of this machinery."""

--- a/tests/test_725_fanout_clearance_pad_floors.py
+++ b/tests/test_725_fanout_clearance_pad_floors.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 RUN_ALL_FAST_OK = True
 RUN_ALL_TIMEOUT = 900
 
+import copy
 import json
 import math
 import os
@@ -46,7 +47,7 @@ from copy_board import copy_board
 from synth import make_via
 import placement.legality as L
 from placement.legality import PadClearanceModel
-from placement.fanout_clearance import (_Repair, _pad_pair_shortfall,
+from placement.fanout_clearance import (_Cap, _Repair, _pad_pair_shortfall,
                                         _point_to_rect_dist, _rect_gap,
                                         nudge_vias_for_unresolved,
                                         repair_fanout_clearance)
@@ -197,6 +198,50 @@ class TestSourcesReachTheEngine(unittest.TestCase):
             self.assertIn(ANCHOR_NET, _short(_repair(p, pcb=pcb), ANCHOR_CAP),
                           'the layer rule never reached the shortfall')
     # MUTATION: drop `read_board_layer_clearances` from the model -> empty.
+
+    def test_an_override_on_a_COPPERLESS_pad_is_not_charged(self):
+        """`_Cap`'s pad filter is deliberately loose (`endswith('.Cu')`), which
+        admits an np_thru_hole pad -- it lists *.Cu and carries no copper. A
+        FLOOR must not be that loose: PadClearanceModel.pad_floor reads
+        local_clearance unconditionally, so charging it would move a cap to
+        clear copper that does not exist, and would contradict the model's own
+        inertness rule, which refuses to ACTIVATE for an NPTH-only override."""
+        pcb = parse_kicad_pcb(BOARD)
+        model = PadClearanceModel.for_board(pcb, CLEAR, BOARD)
+        self.assertTrue(model.active)
+        fp = copy.deepcopy(pcb.footprints[ANCHOR_CAP])
+        # the footprint carries paste-only apertures too; take a REAL copper pad
+        real = next(p for p in fp.pads if L._pad_carries_copper(p))
+        real.local_clearance = 0.5                # copper, must be charged
+        hole = copy.deepcopy(real)
+        hole.pad_number = 'H1'
+        hole.pad_type = 'np_thru_hole'
+        hole.drill = 1.0
+        hole.layers = ['*.Cu', '*.Mask']
+        hole.net_id = 0
+        hole.local_clearance = 3.0                # absurd, and must be ignored
+        fp.pads.append(hole)
+        # _Cap directly, not through _Repair: appending a pad would push this
+        # footprint past the `n_copper <= 2` cap test and it would stop being a
+        # mover at all -- the very coupling the loose filter's comment warns
+        # about.
+        cap = _Cap(fp, (-0.5, -0.5, 0.5, 0.5), model)
+        # ON THE BRANCH: the loose GEOMETRY filter must still admit the hole
+        # (it lists *.Cu), or this tests nothing. The footprint also carries
+        # paste-only apertures, which the filter correctly drops.
+        loose = [p for p in fp.pads
+                 if any(str(l).endswith('.Cu') for l in p.layers)]
+        self.assertIn(hole, loose, 'the hole was dropped by the geometry '
+                                   'filter -- this test would pass vacuously')
+        self.assertEqual(len(cap.pads), len(loose))
+        self.assertEqual(len(cap.pad_floors), len(cap.pads))
+        self.assertEqual(cap.pad_floors[-1].lc, 0.0,
+                         'the copper-less pad was given a clearance floor')
+        self.assertAlmostEqual(cap.max_floor, 0.5, places=6,
+                               msg='the NPTH override reached max_floor and '
+                                   'would widen every prune and the prescreen')
+    # MUTATION: drop the `_pad_carries_copper` guard on `model.pad_floor(p)` in
+    # `_Cap.__init__` -> max_floor becomes 3.0.
 
     def test_a_board_declaring_nothing_builds_no_model(self):
         pcb = parse_kicad_pcb(INERT)

--- a/tests/test_731_fanout_clearance_track_layer_scope.py
+++ b/tests/test_731_fanout_clearance_track_layer_scope.py
@@ -392,14 +392,37 @@ class TestTheInertPath(unittest.TestCase):
     # MUTATION: source `board_copper` from a `PadClearanceModel.for_board`
     # call instead of `self._all_cu` -> hits > 0.
 
-    def test_an_ON_layer_inert_cell_is_the_tuples_own_half_width_BIT_EXACTLY(self):
-        """`t[5] - clearance + clearance` is not float-identical to `t[5]`, and
-        this file's contract is that an inert board is BYTE-identical. Asserted
-        with assertEqual, not assertAlmostEqual."""
+    def test_an_ON_layer_inert_cell_NEVER_REACHES_THE_RESOLVER(self):
+        """On the inert path the eff cell is the tuple's own over-reach, taken
+        directly rather than rebuilt as `halves[j] + clearance`.
+
+        The point is the CALL, not the rounding. Rebuilding it routes every
+        inert cell through `_pair_or_flat`, which is the funnel the clearance
+        model hangs off -- a board that declares nothing would start consulting
+        the resolver once per pair. Spied directly, because the arithmetic
+        round-trip is float-exact on every cell measured (0 of 1063 on rp2350),
+        so an equality check alone cannot tell the two forms apart: a mutation
+        replacing this arm left the value assertion GREEN."""
         st = self.st
+        calls = []
+        orig = _Repair._pair_or_flat
+
+        def spy(self_, fa, fb):
+            calls.append((fa, fb))
+            return orig(self_, fa, fb)
+        _Repair._pair_or_flat = spy
+        try:
+            st._cap_seg_eff.clear()
+            rows_by_ref = {ref: st._seg_effs(ref, cap)
+                           for ref, cap in st.caps.items()}
+        finally:
+            _Repair._pair_or_flat = orig
+        self.assertEqual(calls, [],
+                         'the resolver was consulted %d time(s) building the '
+                         'TRACK eff matrix on an inert board' % len(calls))
         checked = 0
         for ref, cap in st.caps.items():
-            rows = st._seg_effs(ref, cap)
+            rows = rows_by_ref[ref]
             self.assertIsNotNone(rows, '%s got no eff matrix' % ref)
             for i in range(len(cap.pads)):
                 for j, t in enumerate(st.cap_segs[ref]):
@@ -410,9 +433,11 @@ class TestTheInertPath(unittest.TestCase):
                                      '%s pad %d vs track %d: %r != %r'
                                      % (ref, i, j, rows[i][j], t[5]))
                     checked += 1
+        # ON THE BRANCH: there must BE inert cells, or "0 calls" is vacuous.
         self.assertGreater(checked, 0, 'no inert pair was examined')
-    # MUTATION: replace the `t[5]` arm with `halves[j] + self.clearance` -> the
-    # assertEqual fails on the pairs where the float round-trip is lossy.
+    # MUTATION: replace the `fa is None and floors[j] is None` arm with `False`
+    # -> every inert cell falls through to `_pair_or_flat` and `calls` is no
+    # longer empty.
 
     def test_the_inert_boards_recorded_result_is_the_NEW_one(self):
         """Six of rp2350's eight caps were violators purely on phantom. Only
@@ -521,23 +546,45 @@ class TestTheOffSwitches(unittest.TestCase):
 class TestShapeAndClassification(unittest.TestCase):
 
     def test_the_Cap_constructor_takes_board_copper_POSITIONALLY(self):
-        """`board_copper` must be a real parameter, not a defaulted one that a
-        3-positional caller silently skips: with a default of `()`, every
-        `*.Cu` pad would resolve to the EMPTY set and read as copper-less --
-        the fix would look present and grade nothing."""
+        """`board_copper` must default to None, NOT to `()`.
+
+        With `()` the fallback to the model's own copper list never fires, so a
+        3-positional `_Cap(fp, lb, model)` -- which `test_725` uses -- resolves
+        `pad_copper_layers(p, [])`. That still resolves a CONCRETE `F.Cu` pad,
+        which is why a naive fixture cannot see it: only a `*.Cu` pad collapses
+        to the empty set, and an empty set is the "copper-less, grade flat"
+        marker. So the board would silently stop scoping its through-hole pads
+        while every visible signal looked fine. Measured: with a plain
+        signature check plus a 4-positional construction, that mutation
+        SURVIVED the whole suite."""
         names = list(inspect.signature(_Cap.__init__).parameters)
         self.assertEqual(names[1:5],
                          ['fp', 'courtyard_local', 'model', 'board_copper'])
+        self.assertIsNone(
+            inspect.signature(_Cap.__init__).parameters['board_copper'].default,
+            'board_copper defaults to something other than None, so the '
+            'fallback to model.board_copper cannot fire')
         pcb = parse_kicad_pcb(BOARD)
-        fp = pcb.footprints[CAP]
+        fp = copy.deepcopy(pcb.footprints[CAP])
+        for p in _copper_pads(fp):
+            _as_through(p)                      # now a `*.Cu` pad
         cu = pcb.board_info.copper_layers
+        # (a) 4-positional, no model at all: layers still resolve.
         cap = _Cap(fp, (-0.5, -0.5, 0.5, 0.5), None, cu)
-        # Built with NO model at all, and still resolves real layers.
         self.assertEqual(cap.pad_floors, [])
-        self.assertEqual(sorted(cap.pad_layers[0]), ['F.Cu'])
         self.assertEqual(len(cap.pad_layers), len(cap.pads))
-    # MUTATION: gate the pad_layers build on `model is not None` -> pad_layers
-    # is [] here. MUTATION: rename or reorder the parameter -> the name list
+        self.assertEqual(len(cap.pad_layers[0]), len(cu))
+        # (b) 3-positional with only a model, the shape test_725 uses: the
+        # fallback to model.board_copper must carry the layers.
+        model = PadClearanceModel.for_board(pcb, CLEAR, BOARD)
+        cap3 = _Cap(fp, (-0.5, -0.5, 0.5, 0.5), model)
+        self.assertEqual(len(cap3.pad_layers[0]), len(cu),
+                         'a 3-positional _Cap resolved %r for a *.Cu pad -- '
+                         'board_copper is shadowing the model fallback'
+                         % (cap3.pad_layers[0],))
+    # MUTATION: `board_copper=()` -> arm (b) resolves the empty set.
+    # MUTATION: gate the pad_layers build on `model is not None` -> arm (a) has
+    # no pad_layers. MUTATION: rename or reorder the parameter -> the name list
     # differs.
 
     def test_the_segment_tuple_is_still_SEVEN_wide_and_carries_a_LAYER(self):

--- a/tests/test_731_fanout_clearance_track_layer_scope.py
+++ b/tests/test_731_fanout_clearance_track_layer_scope.py
@@ -23,11 +23,14 @@ Conventions this file follows (from #697/#725 and CLAUDE.md):
     "and this one still is".
 
 Nothing here shells out or drives a CLI: it runs entirely in-process in ~25 s.
-`run_all.is_integration` classifies by grepping the SOURCE for `run_utils` and
-the name of the standard sub-process module, and this file NAMES those markers
-in prose (including in this sentence), which is how the first version of the
-#725 file got bucketed as integration and silently skipped under `--fast`.
-Hence the explicit opt-out below.
+`run_all.is_integration` classifies by grepping the SOURCE for the literal
+strings `import run_utils`, `from run_utils` and the name of the standard
+sub-process module. This file contains NONE of them as written -- the prose
+above is hyphenated and unqualified on purpose -- so the opt-out below is
+belt-and-braces, not load-bearing: it is here so that a later edit which does
+introduce one of those strings cannot silently reclassify the file and skip it
+under `--fast`. That is not hypothetical; it is what happened to the first
+version of the #725 file (6c2096c6).
 """
 from __future__ import annotations
 
@@ -35,6 +38,7 @@ RUN_ALL_FAST_OK = True
 
 import copy
 import inspect
+import io
 import os
 import sys
 import unittest
@@ -151,8 +155,12 @@ class TestTheTruthTable(unittest.TestCase):
             self.assertAlmostEqual(pen, 0.0, places=9,
                                    msg='%s track charged %.6f against an F.Cu '
                                        'pad' % (layer, pen))
-    # MUTATION: revert the prune to `if seg[6] != cap.side: continue` -> every
-    # arm charges BITE (0.05).
+    # MUTATION: `_seg_shares` -> `return True` -> every arm charges BITE
+    # (0.05). NB reverting the PRUNE alone does NOT kill this: the gate is
+    # two-layer (prune + `_seg_effs`), and with the grading half intact the
+    # pair is still priced `_OFF_LAYER` and billed nothing. Only
+    # `test_no_pruned_pair_is_one_check_drc_would_IGNORE` sees a prune-only
+    # revert -- it fires there at exactly 928.
 
     def test_the_SAME_geometry_on_F_Cu_IS_still_charged(self):
         """The negative control. Without it, a build that deleted track grading
@@ -311,7 +319,8 @@ class TestTheSeedPhantomIsGone(unittest.TestCase):
                                    0.0, places=9, msg='%s track graze' % ref)
             self.assertAlmostEqual(st.graze_penalty(ref, cap, x, y, rot),
                                    0.0, places=9, msg='%s total' % ref)
-    # MUTATION: revert the prune -> each reads 0.0821.
+    # MUTATION: `_seg_shares` -> `return True` -> each reads 0.0821. (A
+    # prune-only revert leaves these green; see the note above.)
 
     def test_the_boards_whole_seed_track_graze_is_zero_and_was_not(self):
         """0.246393mm before #731, every micron of it off-layer: this board has
@@ -326,7 +335,8 @@ class TestTheSeedPhantomIsGone(unittest.TestCase):
                                    % (total, PRE_FIX_PHANTOM_MM))
         # ON THE BRANCH: there must be tracks in the pruned lists at all.
         self.assertGreater(sum(len(v) for v in st.cap_segs.values()), 0)
-    # MUTATION: revert the prune -> the total reads 0.246393.
+    # MUTATION: `_seg_shares` -> `return True` -> the total reads 0.246393.
+    # (A prune-only revert leaves this green; see the note above.)
 
 
 class TestTheInertPath(unittest.TestCase):
@@ -449,8 +459,10 @@ class TestTheInertPath(unittest.TestCase):
         self.assertEqual(sorted(r['unresolved']), ['C23'])
         self.assertEqual(sorted(r['resolved']), ['C18'])
         self.assertEqual(r['required'], [], 'an inert board discloses nothing')
-    # MUTATION: any revert of the prune, the unconditional pad_layers, or the
-    # `_cap_pad_layers` anchor -> the 7-ref unresolved list comes back.
+    # MUTATION: `_seg_shares` -> `return True`, or reverting the
+    # unconditional pad_layers, or the `_cap_pad_layers` anchor -> the 7-ref
+    # unresolved list comes back. (A prune-only revert leaves this green: the
+    # grading half still zeroes the phantom.)
 
 
 class TestTheOffSwitches(unittest.TestCase):
@@ -513,34 +525,232 @@ class TestTheOffSwitches(unittest.TestCase):
     # MUTATION: delete the `_seg_shares` branch in `_seg_effs` -> this reads
     # BITE (0.05) while every board-level test stays green.
 
-    def test_a_board_with_NO_copper_layers_falls_back_to_the_SIDE_collapse(self):
-        """`pad_copper_layers(p, [])` resolves nothing for a `*.Cu` pad, so
-        every pad would read copper-less and every pair would take the
-        off-layer path -- an UNDER-block, which ships violations. Scoping
-        switches off wholesale. It must fall back to the OLD side test, NOT to
-        keeping every segment on the board: check_drc still layer-scopes such a
-        board (its routing_layers falls back to the segment-derived set), so
-        the placer must stay on the over-block side."""
+    def test_a_board_with_NO_copper_layers_RESOLVES_one_instead_of_giving_up(self):
+        """A board whose `(layers ...)` stanza yields no copper must NOT fall
+        back to the 'F'/'B' side collapse.
+
+        That looked like the safe direction and is not. check_drc resolves the
+        same situation with a THREE-level fallback -- filter to `.Cu`, then the
+        layers segments actually sit on, then ['F.Cu','B.Cu'] -- and still
+        expands a `*.Cu` pad over the result and grades it. The side collapse
+        DROPS every B.Cu and inner track a through-hole cap pad shares copper
+        with, which is an UNDER-block and the exact mirror bug #731 fixes.
+        Measured on rp2350 with the copper list cleared and cap pads made
+        through-hole: 280 pairs check_drc grades that the side-collapse
+        fallback ignored, byte-identical to the pre-#731 count."""
         pcb = parse_kicad_pcb(BOARD)
+        real = list(pcb.board_info.copper_layers)
         pcb.board_info.copper_layers = []
         st = _repair(BOARD, pcb=pcb)
-        self.assertEqual(st._all_cu, frozenset())
+        # ON THE BRANCH: the board really declares nothing, and the fallback
+        # really had to reconstruct the list from the segments.
+        self.assertEqual(pcb.board_info.copper_layers, [])
+        self.assertTrue(st._all_cu, 'the fallback resolved no copper at all')
+        self.assertTrue(st._all_cu <= set(real),
+                        'the fallback invented a layer the board lacks: %r'
+                        % (st._all_cu - set(real),))
+        # ...and scoping stays ON, so a through-hole pad keeps its inner and
+        # back-side copper.
         cap = st.caps[CAP]
-        self.assertIsNone(st._cap_pad_layers(cap),
-                          'layer scoping stayed on with no copper layers')
-        # ON THE BRANCH: the board must carry tracks on BOTH sides, or "did not
-        # keep everything" cannot be distinguished from "kept everything".
-        sides = {st._seg_side(t[6]) for t in st.segments}
-        self.assertEqual(sides, {'F', 'B'})
-        kept = st.cap_segs[CAP]
-        self.assertTrue(kept, 'the fallback dropped every track')
-        self.assertTrue(all(st._seg_side(t[6]) == cap.side for t in kept),
-                        'a track from the OTHER side survived: the fallback '
-                        'stopped filtering instead of using the side test')
-        self.assertLess(len(kept), len(st.segments),
-                        'the fallback kept every segment on the board')
-    # MUTATION: make the `_union is None` arm keep every segment -> the last
-    # two assertions fail.
+        self.assertIsNotNone(st._cap_pad_layers(cap),
+                             'layer scoping switched itself off')
+        for t in st.cap_segs[CAP]:
+            self.assertIn(t[6], st._all_cu)
+            self.assertTrue(any(t[6] in pl for pl in cap.pad_layers),
+                            'an off-layer track survived the fallback')
+        self.assertEqual(sorted(st._all_cu_ordered), sorted(st._all_cu))
+    # MUTATION: `self._all_cu = frozenset(board_info.copper_layers or ())`
+    # (drop the fallback) -> `_all_cu` is empty, `_cap_pad_layers` returns None
+    # and the assertIsNotNone fires.
+    #
+    # NB the prune's `_union is None` arm is deliberately NOT pinned by a
+    # mutation: with the fallback in place it is reachable only for a cap with
+    # zero copper pads, whose pad_rects is empty, so no assertion anywhere can
+    # observe what it keeps. Claiming a mutation for it would be an unearned
+    # MUTATION line -- the exact defect this file's review found elsewhere.
+
+    def test_EVERY_tracked_board_resolves_a_copper_list_and_stays_scoped(self):
+        """The invariant the prune's off-switch now rests on: `_all_cu` is
+        never empty, so layer scoping never silently degrades to the side
+        collapse on a real board."""
+        import subprocess
+        out = subprocess.run(['git', 'ls-files', '-z', 'kicad_files/*.kicad_pcb'],
+                             cwd=_ROOT, capture_output=True, text=True)
+        boards = [b for b in out.stdout.split(chr(0)) if b]
+        if not boards:
+            self.skipTest('git could not list the corpus')
+        checked = 0
+        for rel in boards:
+            path = os.path.join(_ROOT, rel)
+            pcb = parse_kicad_pcb(path)
+            st = _repair(path, pcb=pcb)
+            self.assertTrue(st._all_cu, '%s resolved no copper layers' % rel)
+            for ref, cap in st.caps.items():
+                self.assertIsNotNone(
+                    st._cap_pad_layers(cap),
+                    '%s %s: layer scoping switched off on a real board'
+                    % (rel, ref))
+                checked += 1
+        self.assertGreater(checked, 0, 'no cap on any tracked board')
+    # MUTATION: drop the segment-derived fallback for `_all_cu` -> a board
+    # whose (layers ...) stanza yields no copper fails the first assertion.
+
+    def test_a_cap_whose_pads_carry_NO_COPPER_is_graded_flat_in_the_TRACK_channel_too(self):
+        """4bbfa4de established that a copper-less pad is graded FLAT in every
+        channel: check_drc does not grade such a pad at all, so letting the
+        partner's netclass through would charge a keep-out that does not exist.
+
+        An empty per-pad union must therefore NOT read as 'scoping off'. It did
+        in the first version of #731, which switched the guard off for the
+        TRACK channel alone -- so `_flat_pad` read False and those pads were
+        charged at the partner's netclass, reinstating in one channel exactly
+        the phantom the previous commit removed from every other."""
+        import tempfile, json
+        with tempfile.TemporaryDirectory() as td:
+            from copy_board import copy_board
+            dst = os.path.join(td, 'b.kicad_pcb')
+            copy_board(BOARD, dst)
+            with open(os.path.splitext(dst)[0] + '.kicad_pro', 'w',
+                      encoding='utf-8') as f:
+                json.dump({'net_settings': {'classes': [
+                    {'name': 'Default', 'clearance': 0.4, 'track_width': 0.2,
+                     'via_diameter': 0.6, 'via_drill': 0.4,
+                     'priority': 2147483647}],
+                    'netclass_assignments': {}, 'netclass_patterns': []}}, f)
+            pcb = parse_kicad_pcb(dst)
+            for p in _copper_pads(pcb.footprints[CAP]):
+                p.layers = ['*.Cu', '*.Mask']
+                p.pad_type = 'np_thru_hole'
+                p.drill = 0.3
+            st = _repair(dst, pcb=pcb)
+            cap = st.caps[CAP]
+            # ON THE BRANCH: the model is active (0.4) and every pad of this
+            # cap really did resolve copper-less, or nothing is being tested.
+            self.assertIsNotNone(st._floors)
+            self.assertEqual(list(st._cap_pad_layers(cap)),
+                             [frozenset()] * len(cap.pads))
+            # The union is EMPTY but scoping stays ON -- that is the whole
+            # point. (None, None) here is what let the netclass through.
+            pl, union = st._cap_seg_scope(cap)
+            self.assertIsNotNone(pl, 'scoping switched off for the track '
+                                     'channel on a copper-less cap')
+            self.assertEqual(union, frozenset())
+            # A pad with no copper shares copper with nothing, so there is no
+            # track pair at all -- which is exactly what check_drc does with
+            # it (_pad_has_no_copper skips the pad outright). Charging such a
+            # pair, at ANY price, is the phantom.
+            self.assertEqual(st.cap_segs[CAP], [],
+                             '%d track pair(s) kept for a cap whose every pad '
+                             'is copper-less' % len(st.cap_segs[CAP]))
+            self.assertAlmostEqual(
+                st.seg_penalty(CAP, cap, cap.x, cap.y, cap.rot), 0.0, places=9)
+            # ON THE BRANCH / cross-channel: the PAD channel still grades these
+            # same pads, and grades them FLAT at 0.1 -- not at the 0.4 class.
+            # If the track channel disagreed with that, the two channels would
+            # be grading one cap two different ways, which is the defect.
+            prows = st._pad_effs(CAP, cap)
+            self.assertTrue(prows and prows[0], 'no foreign pad in reach')
+            self.assertEqual({round(v, 9) for r in prows for v in r}, {CLEAR})
+    # MUTATION: `return (pl, u) if u else (None, None)` in `_cap_seg_scope` ->
+    # `union` reads None, the track pairs come back and are charged at the 0.4
+    # netclass while the pad channel still says 0.1.
+
+
+    def test_the_PRUNE_keeps_a_track_on_a_layer_the_board_does_not_declare(self):
+        """The prune's `layer in self._all_cu` conjunct, tested where it lives.
+
+        `test_an_INJECTED_tuple_with_an_UNRECOGNISED_layer_is_still_graded`
+        pins the same invariant on the GRADING side, but it injects into
+        `cap_segs` AFTER the prune, so it never reaches this arm -- deleting
+        the conjunct survived that test. A track on a layer the board's copper
+        list omits must be KEPT (and charged): check_drc reaches such a segment
+        through its own segment-derived fallback, so dropping it under-blocks.
+        """
+        pcb = parse_kicad_pcb(BOARD)
+        pads = _copper_pads(pcb.footprints[CAP])
+        target = pads[0]
+        x0, x1 = target.global_x - target.size_x / 2, target.global_x + target.size_x / 2
+        keepout = TRACK_W / 2 + CLEAR
+        ty = target.global_y - target.size_y / 2 - keepout + BITE
+        seg = make_seg(x0 - 1.0, ty, x1 + 1.0, ty, layer='In9.Cu',
+                       net_id=FOREIGN_NET, width=TRACK_W)
+        pcb.segments = [seg]
+        pcb.vias = []
+        st = _repair(BOARD, pcb=pcb)
+        cap = st.caps[CAP]
+        # ON THE BRANCH: the layer really is absent from the board's list and
+        # from the pad's set, so only the `_all_cu` conjunct can save it.
+        self.assertNotIn('In9.Cu', st._all_cu)
+        self.assertNotIn('In9.Cu', cap.pad_layers[0])
+        self.assertTrue(st.cap_segs[CAP],
+                        'a track on an UNDECLARED layer was pruned away -- '
+                        'check_drc still reaches it, so this under-blocks')
+        self.assertAlmostEqual(
+            st.seg_penalty(CAP, cap, cap.x, cap.y, cap.rot), BITE, places=9)
+    # MUTATION: drop the `layer in self._all_cu` conjunct from the PRUNE
+    # (`elif layer not in _union: continue`) -> the track is dropped and the
+    # penalty reads 0.0.
+
+    def test_a_COPPERLESS_pad_meeting_an_UNKNOWN_layer_is_charged_FLAT(self):
+        """`_seg_effs`' `elif flat_pad:` arm.
+
+        Reaching it takes a precise combination, which is why a naive fixture
+        cannot pin it. A copper-less pad against a REAL layer is already
+        removed by `_seg_shares`; against an unknown layer whose segment has no
+        registered floor, the flat arm and the fallback both yield the same
+        number. The arm only bites for a copper-less pad meeting a segment that
+        is BOTH on a layer the board does not declare AND carries a resolved
+        netclass floor -- and then the difference is the whole netclass."""
+        import tempfile, json
+        from copy_board import copy_board
+        with tempfile.TemporaryDirectory() as td:
+            dst = os.path.join(td, 'b.kicad_pcb')
+            copy_board(BOARD, dst)
+            with open(os.path.splitext(dst)[0] + '.kicad_pro', 'w',
+                      encoding='utf-8') as f:
+                json.dump({'net_settings': {'classes': [
+                    {'name': 'Default', 'clearance': 0.4, 'track_width': 0.2,
+                     'via_diameter': 0.6, 'via_drill': 0.4,
+                     'priority': 2147483647}],
+                    'netclass_assignments': {}, 'netclass_patterns': []}}, f)
+            pcb = parse_kicad_pcb(dst)
+            pads = _copper_pads(pcb.footprints[CAP])
+            for pad in pads:
+                pad.layers = ['*.Cu', '*.Mask']
+                pad.pad_type = 'np_thru_hole'
+                pad.drill = 0.3
+            target = pads[0]
+            x0 = target.global_x - target.size_x / 2
+            x1 = target.global_x + target.size_x / 2
+            keepout = TRACK_W / 2 + CLEAR
+            ty = target.global_y - target.size_y / 2 - keepout + BITE
+            pcb.segments = [make_seg(x0 - 1.0, ty, x1 + 1.0, ty,
+                                     layer='In9.Cu', net_id=FOREIGN_NET,
+                                     width=TRACK_W)]
+            pcb.vias = []
+            st = _repair(dst, pcb=pcb)
+            cap = st.caps[CAP]
+            # ON THE BRANCH, all four conditions the arm needs:
+            self.assertIsNotNone(st._floors)                 # model active
+            self.assertEqual(cap.pad_layers[0], frozenset())  # copper-less pad
+            self.assertNotIn('In9.Cu', st._all_cu)            # unknown layer
+            t = st.segments[0]
+            floor = st._seg_floor_by_id.get(id(t))
+            self.assertIsNotNone(floor, 'the segment carries no floor, so the '
+                                        'flat arm and the fallback agree and '
+                                        'this test cannot discriminate')
+            self.assertAlmostEqual(floor.ncl, 0.4, places=6)
+            self.assertTrue(st.cap_segs[CAP], 'the unknown-layer track was '
+                                              'pruned away')
+            rows = st._seg_effs(CAP, cap)
+            half = t[5] - st._item_reach(floor)
+            self.assertAlmostEqual(rows[0][0], half + CLEAR, places=9,
+                                   msg='a copper-less pad was charged %r; the '
+                                       'flat price is %r and the netclass '
+                                       'price is %r'
+                                       % (rows[0][0], half + CLEAR, half + 0.4))
+    # MUTATION: delete the `elif flat_pad:` arm in `_seg_effs` -> the cell is
+    # priced at the 0.4 netclass instead of the flat 0.1.
 
 
 class TestShapeAndClassification(unittest.TestCase):
@@ -602,15 +812,29 @@ class TestShapeAndClassification(unittest.TestCase):
     # MUTATION: put `side` back in element 6 -> `assertIn(t[6], _all_cu)` fails.
 
     def test_this_file_is_collected_as_a_FAST_test(self):
-        """This file names the integration markers in its own prose, which is
-        exactly how the #725 file got bucketed as integration and skipped under
-        --fast (commit 6c2096c6)."""
+        """A file bucketed as integration is skipped under --fast, and a test
+        file that proves nothing is worse than none (6c2096c6).
+
+        Note what this does and does not pin. The opt-out marker is currently
+        INERT -- this file contains none of the literal strings the classifier
+        greps for, so deleting `RUN_ALL_FAST_OK = True` changes nothing today.
+        Asserting on the marker would therefore be asserting on a value the
+        branch does not key on. What is worth pinning is the OUTCOME: the file
+        is collected and it is fast. The second half below is the one that
+        would fail if a later edit introduced a marker string while the opt-out
+        had been dropped."""
         import run_all
-        self.assertFalse(run_all.is_integration(os.path.abspath(__file__)))
+        path = os.path.abspath(__file__)
+        self.assertFalse(run_all.is_integration(path))
         found = [os.path.basename(f) for f in run_all.discover(['731'])]
         self.assertIn(os.path.basename(__file__), found)
-    # MUTATION: delete the `RUN_ALL_FAST_OK = True` line -> is_integration
-    # returns True and the file is skipped under --fast.
+        # The opt-out must still be present, because it is the only thing that
+        # keeps the line above true if the source ever gains a marker string.
+        src = io.open(path, encoding='utf-8').read()
+        self.assertIn('RUN_ALL_FAST_OK = True', src)
+    # MUTATION: delete the `RUN_ALL_FAST_OK = True` line AND add `import
+    # subprocess` -> is_integration returns True. Deleting the marker alone is
+    # caught only by the last assertion, which is why it is written out.
 
 
 if __name__ == '__main__':

--- a/tests/test_731_fanout_clearance_track_layer_scope.py
+++ b/tests/test_731_fanout_clearance_track_layer_scope.py
@@ -1,0 +1,570 @@
+"""#731: the fanout-clearance repair pass must grade a cap pad against a track
+only when the two SHARE A REAL COPPER LAYER -- the same predicate check_drc
+gates on -- instead of against an 'F'/'B' board SIDE that files every
+non-B layer under 'F'.
+
+The collapse was wrong in both directions. It ADDED pairs an F-side cap pad can
+never touch (928 of them on orangecrab at --clearance 0.1, 0.2464mm of phantom
+seed graze against 0.0000mm of real; R17/R18/R5's entire bill), and it DROPPED
+the B.Cu and inner-layer tracks a THROUGH-HOLE cap pad really does share copper
+with. Neither is academic: on rp2350 -- a board that is DRC-clean as it ships --
+the old pass moved C19 to clear a phantom and put its GND pad 0.145mm inside a
+real F.Cu track, so the step introduced a PAD-SEGMENT violation.
+
+Conventions this file follows (from #697/#725 and CLAUDE.md):
+
+  * REAL parser dataclasses and REAL boards. `_Repair.__init__` reads courtyards
+    and locked refs from the file on disk, so even a synthetic case needs a file.
+  * Every assertion names the single-line MUTATION that must kill it.
+  * Assert you are ON the branch before asserting about it -- each test spies the
+    value its branch keys on, with a detail string saying why.
+  * A removal test needs a NEGATIVE CONTROL, or it passes just as well on a build
+    that deleted the whole channel. Every "is not charged" here is paired with an
+    "and this one still is".
+
+Nothing here shells out or drives a CLI: it runs entirely in-process in ~25 s.
+`run_all.is_integration` classifies by grepping the SOURCE for `run_utils` and
+the name of the standard sub-process module, and this file NAMES those markers
+in prose (including in this sentence), which is how the first version of the
+#725 file got bucketed as integration and silently skipped under `--fast`.
+Hence the explicit opt-out below.
+"""
+from __future__ import annotations
+
+RUN_ALL_FAST_OK = True
+
+import copy
+import inspect
+import os
+import sys
+import unittest
+
+_TESTS = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_TESTS)
+for _p in ('', 'py_router', 'py_placer', 'py_tools'):
+    _d = os.path.join(_ROOT, _p)
+    if _d not in sys.path:
+        sys.path.insert(0, _d)
+if _TESTS not in sys.path:
+    sys.path.insert(0, _TESTS)
+
+from kicad_parser import parse_kicad_pcb
+from synth import make_seg
+import check_drc
+from check_drc import check_pad_segment_overlap, pad_copper_layers
+from placement.legality import PadClearanceModel
+from placement.fanout_clearance import (_Cap, _OFF_LAYER, _Repair,
+                                        repair_fanout_clearance)
+
+BOARD = os.path.join(_ROOT, 'kicad_files', 'orangecrab_ext_pll.kicad_pcb')
+INERT = os.path.join(_ROOT, 'kicad_files',
+                     'rp2350_fpga_eensy_prePlane.kicad_pcb')
+CLEAR = 0.1
+
+# R17 is an F-side 0402 near a BGA with two copper pads (net 69 / net 70) and
+# two paste-only apertures that _Cap's copper filter drops. Its ENTIRE seed
+# graze before #731 was phantom In1.Cu track pairs.
+CAP = 'R17'
+PHANTOM_CAPS = ('R17', 'R18', 'R5')
+FOREIGN_NET = 2          # neither 69 nor 70
+TRACK_W = 0.1            # half width 0.05, so keep-out = 0.05 + CLEAR
+BITE = 0.05              # how far inside the keep-out band the track sits
+
+# The cap prefix the CLI defaults to. NOT 'C': with 'C' alone the movable set is
+# 51 caps and R17/R18/R5 -- the three this issue is about -- never appear.
+PREFIX = 'C,R,FB'
+
+# Measured on the stock boards at CLEAR, before #731 (see the PR body).
+PRE_FIX_OFF_LAYER_PAIRS = 928       # orangecrab, same-net pairs included
+PRE_FIX_PHANTOM_MM = 0.246393       # orangecrab seed graze, all of it phantom
+PRE_FIX_INERT_OFF_PAIRS = 2342      # rp2350
+BOTH_GRADED = 618                   # orangecrab pairs check_drc DOES grade
+
+
+def _repair(path, pcb=None, clearance=CLEAR, prefix=PREFIX):
+    """The 10-POSITIONAL construction every test in this family uses."""
+    return _Repair(pcb if pcb is not None else parse_kicad_pcb(path), path,
+                   clearance, 0.1, 0.55, 1.0, 2.0, 0.3, prefix, set())
+
+
+def _routing_layers(pcb):
+    """check_drc's own layer list for the overlap checks."""
+    return [l for l in (pcb.board_info.copper_layers or [])
+            if l.endswith('.Cu')]
+
+
+def _as_through(pad, layers=('*.Cu', '*.Mask')):
+    """Convert a copper pad in place into a plated through-hole pad."""
+    pad.layers = list(layers)
+    pad.pad_type = 'thru_hole'
+    pad.drill = 0.3
+    return pad
+
+
+def _copper_pads(fp):
+    """The pads _Cap keeps, in _Cap's own order (its loose endswith filter)."""
+    return [p for p in fp.pads
+            if any(str(l).endswith('.Cu') for l in p.layers)]
+
+
+class TestTheTruthTable(unittest.TestCase):
+    """One real cap, one synthetic track, every (pad kind, track layer) cell --
+    graded by the pass and by check_drc, and required to agree."""
+
+    def _case(self, layer, through=False, pad_index=0, net=FOREIGN_NET):
+        """Build R17 with exactly one foreign track biting `BITE` into the
+        keep-out band of `pad_index`, and return (seg_penalty, drc, st, pcb)."""
+        pcb = parse_kicad_pcb(BOARD)
+        fp = pcb.footprints[CAP]
+        pads = _copper_pads(fp)
+        if through:
+            for p in pads:
+                _as_through(p)
+        target = pads[pad_index]
+        x0, x1 = target.global_x - target.size_x / 2, target.global_x + target.size_x / 2
+        y0 = target.global_y - target.size_y / 2
+        # A horizontal track below the pad rect: distance = keepout - BITE.
+        keepout = TRACK_W / 2 + CLEAR
+        ty = y0 - keepout + BITE
+        seg = make_seg(x0 - 1.0, ty, x1 + 1.0, ty,
+                       layer=layer, net_id=net, width=TRACK_W)
+        pcb.segments = [seg]
+        pcb.vias = []
+        st = _repair(BOARD, pcb=pcb)
+        cap = st.caps[CAP]
+        pen = st.seg_penalty(CAP, cap, cap.x, cap.y, cap.rot)
+        drc = check_pad_segment_overlap(target, seg, CLEAR,
+                                        _routing_layers(pcb),
+                                        clearance_margin=0.0)
+        return pen, drc, st, pcb
+
+    def test_an_INNER_layer_track_is_not_charged_against_an_F_side_SMD_pad(self):
+        """The whole issue, on one cap: an In1.Cu track cannot touch an F.Cu
+        pad, and check_drc grades no such pair."""
+        for layer in ('In1.Cu', 'In2.Cu', 'In3.Cu', 'In4.Cu'):
+            pen, drc, st, _ = self._case(layer)
+            # ON THE BRANCH: the cap really is F-side and really is scoped,
+            # or "not charged" could be true for an unrelated reason.
+            self.assertEqual(st.caps[CAP].side, 'F')
+            self.assertIsNotNone(st._cap_pad_layers(st.caps[CAP]))
+            self.assertFalse(drc[0], '%s: check_drc changed its mind' % layer)
+            self.assertAlmostEqual(pen, 0.0, places=9,
+                                   msg='%s track charged %.6f against an F.Cu '
+                                       'pad' % (layer, pen))
+    # MUTATION: revert the prune to `if seg[6] != cap.side: continue` -> every
+    # arm charges BITE (0.05).
+
+    def test_the_SAME_geometry_on_F_Cu_IS_still_charged(self):
+        """The negative control. Without it, a build that deleted track grading
+        outright would satisfy the test above perfectly."""
+        pen, drc, st, _ = self._case('F.Cu')
+        # ON THE BRANCH: the track must actually be in the pruned list, or
+        # "charged" is being decided somewhere other than the layer gate.
+        self.assertTrue(st.cap_segs[CAP],
+                        'the F.Cu track was pruned away -- the layer gate is '
+                        'dropping copper the cap really does share')
+        self.assertTrue(drc[0])
+        self.assertAlmostEqual(pen, BITE, places=9)
+        self.assertAlmostEqual(pen, drc[1], places=6,
+                               msg='the pass and check_drc disagree on the '
+                                   'overlap of a pair they both grade')
+    # MUTATION: make `_seg_shares` return False always -> this goes red while
+    # the inner-layer test above stays green.
+
+    def test_a_THROUGH_HOLE_cap_pad_KEEPS_the_B_Cu_track(self):
+        """The mirror. A through-hole pad's copper spans every layer, so the
+        side collapse DROPPED the B.Cu track it really does share -- an
+        UNDER-block, which is the direction that ships a violation."""
+        pen, drc, st, _ = self._case('B.Cu', through=True)
+        cap = st.caps[CAP]
+        # ON THE BRANCH: the pad must span all copper and the cap must be
+        # F-side, or this is not the cross-side case at all.
+        self.assertEqual(cap.side, 'F')
+        self.assertEqual(len(cap.pad_layers[0]), 6,
+                         'the through-hole pad did not resolve every copper '
+                         'layer: %r' % (cap.pad_layers[0],))
+        self.assertTrue(drc[0], 'check_drc does not grade this pair either -- '
+                                'the fixture is wrong, not the engine')
+        self.assertAlmostEqual(pen, BITE, places=9,
+                               msg='the B.Cu track was dropped for a pad whose '
+                                   'copper spans it')
+    # MUTATION: keep the side test as an AND alongside the layer test
+    # (`if self._seg_side(layer) != cap.side or ...`) -> the B.Cu track is
+    # dropped again and this reads 0.0, while the two tests above stay green.
+
+    def test_every_cell_agrees_with_check_pad_segment_overlap(self):
+        """Parity with the authority, over the whole 2 x 4 table."""
+        seen_true = seen_false = 0
+        for through in (False, True):
+            for layer in ('F.Cu', 'In1.Cu', 'In2.Cu', 'B.Cu'):
+                pen, drc, _, _ = self._case(layer, through=through)
+                cell = '%s pad vs %s' % ('THT' if through else 'SMD', layer)
+                self.assertEqual(pen > 1e-9, bool(drc[0]),
+                                 '%s: pass says %.6f, check_drc says %r'
+                                 % (cell, pen, drc[0]))
+                if drc[0]:
+                    seen_true += 1
+                    self.assertAlmostEqual(pen, drc[1], places=6, msg=cell)
+                else:
+                    seen_false += 1
+        # ON THE BRANCH: the table must contain both verdicts, or agreement is
+        # trivial (all-clear agrees with all-clear).
+        self.assertGreater(seen_true, 0)
+        self.assertGreater(seen_false, 0)
+    # MUTATION: build `pad_layers` from `frozenset(p.layers)` instead of
+    # `pad_copper_layers(p, board_copper)` -> a `*.Cu` pad resolves to
+    # {'*.Cu'}, matches no seg.layer, and all four THT rows read 0.0.
+
+    def test_a_MIXED_pad_cap_scopes_PER_PAD_not_by_the_UNION(self):
+        """The prune keeps the UNION of a cap's pad layers (a superset, so it
+        can never drop a chargeable pair); the GRADING must then apply the
+        exact per-pad set. A cap with one through-hole pad beside one F.Cu SMD
+        pad is the only shape where the two answers differ."""
+        pcb = parse_kicad_pcb(BOARD)
+        pads = _copper_pads(pcb.footprints[CAP])
+        _as_through(pads[0])                      # pad 0 spans all copper
+        target = pads[1]                          # pad 1 stays F.Cu only
+        x0, x1 = target.global_x - target.size_x / 2, target.global_x + target.size_x / 2
+        keepout = TRACK_W / 2 + CLEAR
+        ty = target.global_y - target.size_y / 2 - keepout + BITE
+        seg = make_seg(x0 - 1.0, ty, x1 + 1.0, ty,
+                       layer='B.Cu', net_id=FOREIGN_NET, width=TRACK_W)
+        pcb.segments = [seg]
+        pcb.vias = []
+        st = _repair(BOARD, pcb=pcb)
+        cap = st.caps[CAP]
+        # ON THE BRANCH: the two pads must really differ, or per-pad and union
+        # are the same answer and this test cannot tell them apart.
+        self.assertEqual(len(cap.pad_layers[0]), 6)
+        self.assertEqual(sorted(cap.pad_layers[1]), ['F.Cu'])
+        rl = _routing_layers(pcb)
+        d_tht = check_pad_segment_overlap(pads[0], seg, CLEAR, rl,
+                                          clearance_margin=0.0)
+        d_smd = check_pad_segment_overlap(target, seg, CLEAR, rl,
+                                          clearance_margin=0.0)
+        # check_drc grades the THT pad and not the SMD one; the pass must bill
+        # exactly the same total.
+        self.assertTrue(d_tht[0])
+        self.assertFalse(d_smd[0])
+        pen = st.seg_penalty(CAP, cap, cap.x, cap.y, cap.rot)
+        self.assertAlmostEqual(pen, d_tht[1], places=6,
+                               msg='billed %.6f; the union would bill the SMD '
+                                   'pad too' % pen)
+        # ...and the off-layer cell really is the sentinel, not a small number.
+        rows = st._seg_effs(CAP, cap)
+        self.assertEqual(rows[1][0], _OFF_LAYER)
+        self.assertNotEqual(rows[0][0], _OFF_LAYER)
+    # MUTATION: grade with `union(cap.pad_layers)` instead of
+    # `cap.pad_layers[i]` -> the SMD pad is billed too and the total rises.
+
+
+class TestTheSeedPhantomIsGone(unittest.TestCase):
+    """The board-level claim, on the board the issue was measured on."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.pcb = parse_kicad_pcb(BOARD)
+        cls.st = _repair(BOARD, pcb=cls.pcb)
+        cls.rl = _routing_layers(cls.pcb)
+
+    def test_no_pruned_pair_is_one_check_drc_would_IGNORE(self):
+        """Every (cap pad, pruned track) pair must be one check_drc grades."""
+        st, pcb = self.st, self.pcb
+        both = ignored = 0
+        for ref, cap in st.caps.items():
+            pads = _copper_pads(pcb.footprints[ref])
+            self.assertEqual(len(pads), len(cap.pads),
+                             '%s: pad list misaligned with _Cap' % ref)
+            for p in pads:
+                expanded = pad_copper_layers(p, pcb.board_info.copper_layers)
+                for t in st.cap_segs[ref]:
+                    if t[6] in expanded:
+                        both += 1
+                    else:
+                        ignored += 1
+        self.assertEqual(ignored, 0,
+                         '%d pruned pair(s) are ones check_drc does not grade '
+                         '(was %d before #731)'
+                         % (ignored, PRE_FIX_OFF_LAYER_PAIRS))
+        # ON THE BRANCH: 0/0 would also satisfy the line above.
+        self.assertEqual(both, BOTH_GRADED,
+                         'the number of REAL pairs moved: %d, expected %d'
+                         % (both, BOTH_GRADED))
+    # MUTATION: revert the prune to the side collapse -> `ignored` returns to
+    # 928. MUTATION: make `_seg_shares` return False -> `both` collapses to 0.
+
+    def test_R17_R18_R5_have_NO_seed_graze_left_in_ANY_channel(self):
+        """Their entire bill was off-layer track graze -- 0.0821mm each -- so
+        they were violators, were moved, and were candidates for the via
+        nudger, which moves real vias and appends real segments."""
+        st = self.st
+        for ref in PHANTOM_CAPS:
+            cap = st.caps[ref]
+            x, y, rot = cap.x, cap.y, cap.rot
+            # Named per channel so the test says WHY, not just that it is 0.
+            self.assertAlmostEqual(
+                st.via_penalty(cap, x, y, rot, st.cap_vias[ref], ref=ref),
+                0.0, places=9, msg='%s via graze' % ref)
+            self.assertAlmostEqual(st.pad_penalty(ref, cap, x, y, rot),
+                                   0.0, places=9, msg='%s pad graze' % ref)
+            self.assertAlmostEqual(st.seg_penalty(ref, cap, x, y, rot),
+                                   0.0, places=9, msg='%s track graze' % ref)
+            self.assertAlmostEqual(st.graze_penalty(ref, cap, x, y, rot),
+                                   0.0, places=9, msg='%s total' % ref)
+    # MUTATION: revert the prune -> each reads 0.0821.
+
+    def test_the_boards_whole_seed_track_graze_is_zero_and_was_not(self):
+        """0.246393mm before #731, every micron of it off-layer: this board has
+        NO on-layer seed track graze at all, which is why check_drc reports
+        zero PAD-SEGMENT violations on it."""
+        st = self.st
+        total = sum(st.seg_penalty(r, c, c.x, c.y, c.rot)
+                    for r, c in st.caps.items())
+        self.assertAlmostEqual(total, 0.0, places=9,
+                               msg='%.6f mm of seed track graze remains (was '
+                                   '%.6f, all phantom)'
+                                   % (total, PRE_FIX_PHANTOM_MM))
+        # ON THE BRANCH: there must be tracks in the pruned lists at all.
+        self.assertGreater(sum(len(v) for v in st.cap_segs.values()), 0)
+    # MUTATION: revert the prune -> the total reads 0.246393.
+
+
+class TestTheInertPath(unittest.TestCase):
+    """The case a fix built on #725's side-channels would have MISSED.
+
+    rp2350 declares no netclass, no .kicad_dru and no pad override, so
+    PadClearanceModel is inert -- and before #731 both layer side-channels were
+    gated on it. It is also 6 copper layers and carried 4.6685mm of phantom
+    seed graze against 0.0142mm of real, the largest phantom measured anywhere.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.pcb = parse_kicad_pcb(INERT)
+        cls.st = _repair(INERT, pcb=cls.pcb)
+
+    def test_layer_scoping_SURVIVES_a_board_that_declares_nothing(self):
+        st = self.st
+        # ON THE BRANCH: the model really must be inert, or this passes for the
+        # wrong reason -- it would just be testing the active path again.
+        self.assertIsNone(st._floors,
+                          'rp2350 built a clearance model; this fixture no '
+                          'longer tests the inert path')
+        self.assertTrue(st._all_cu, 'no copper layers -> scoping switches off')
+        for ref, cap in st.caps.items():
+            self.assertTrue(cap.pad_layers,
+                            '%s has no pad_layers on an inert board' % ref)
+            self.assertIsNotNone(st._cap_pad_layers(cap),
+                                 '%s: layer scoping switched itself off' % ref)
+        off = sum(1 for ref, cap in st.caps.items()
+                  for t in st.cap_segs[ref]
+                  if not any(t[6] in pl for pl in cap.pad_layers))
+        self.assertEqual(off, 0,
+                         '%d off-layer pair(s) survived on the inert board '
+                         '(was %d)' % (off, PRE_FIX_INERT_OFF_PAIRS))
+    # MUTATION: move the `pad_layers` build back inside `if model is not None:`
+    # -> pad_layers is [] here and every assertion above fails.
+    # MUTATION: re-anchor `_cap_pad_layers` on `pad_floors` -> it returns None
+    # on this board and `off` returns to 2342.
+
+    def test_the_model_is_STILL_never_consulted_on_an_inert_board(self):
+        """The layer data must come from `board_info.copper_layers`, never from
+        `model.board_copper` -- sourcing it from the model would ACTIVATE the
+        model on a board that declares nothing."""
+        hits = [0]
+        orig = PadClearanceModel.pair
+
+        def counting(self, a, b):
+            hits[0] += 1
+            return orig(self, a, b)
+        PadClearanceModel.pair = counting
+        try:
+            r = repair_fanout_clearance(parse_kicad_pcb(INERT), INERT,
+                                        clearance=CLEAR)
+        finally:
+            PadClearanceModel.pair = orig
+        self.assertEqual(hits[0], 0,
+                         'the model was consulted %d times on a board that '
+                         'declares nothing' % hits[0])
+        # ON THE BRANCH: the run must have done something, or 0 calls is
+        # trivially true.
+        self.assertTrue(r['bga_refs'])
+    # MUTATION: source `board_copper` from a `PadClearanceModel.for_board`
+    # call instead of `self._all_cu` -> hits > 0.
+
+    def test_an_ON_layer_inert_cell_is_the_tuples_own_half_width_BIT_EXACTLY(self):
+        """`t[5] - clearance + clearance` is not float-identical to `t[5]`, and
+        this file's contract is that an inert board is BYTE-identical. Asserted
+        with assertEqual, not assertAlmostEqual."""
+        st = self.st
+        checked = 0
+        for ref, cap in st.caps.items():
+            rows = st._seg_effs(ref, cap)
+            self.assertIsNotNone(rows, '%s got no eff matrix' % ref)
+            for i in range(len(cap.pads)):
+                for j, t in enumerate(st.cap_segs[ref]):
+                    self.assertNotEqual(
+                        rows[i][j], _OFF_LAYER,
+                        '%s: an off-layer pair survived the prune' % ref)
+                    self.assertEqual(rows[i][j], t[5],
+                                     '%s pad %d vs track %d: %r != %r'
+                                     % (ref, i, j, rows[i][j], t[5]))
+                    checked += 1
+        self.assertGreater(checked, 0, 'no inert pair was examined')
+    # MUTATION: replace the `t[5]` arm with `halves[j] + self.clearance` -> the
+    # assertEqual fails on the pairs where the float round-trip is lossy.
+
+    def test_the_inert_boards_recorded_result_is_the_NEW_one(self):
+        """Six of rp2350's eight caps were violators purely on phantom. Only
+        C18 (0.0106mm on-layer) and C23 (0.0036mm) have anything real; C18 is
+        resolved and C23 is the one cap that legitimately remains unresolved."""
+        r = repair_fanout_clearance(parse_kicad_pcb(INERT), INERT,
+                                    clearance=CLEAR)
+        self.assertEqual(len(r['placements']), 1)
+        self.assertEqual(sorted(r['unresolved']), ['C23'])
+        self.assertEqual(sorted(r['resolved']), ['C18'])
+        self.assertEqual(r['required'], [], 'an inert board discloses nothing')
+    # MUTATION: any revert of the prune, the unconditional pad_layers, or the
+    # `_cap_pad_layers` anchor -> the 7-ref unresolved list comes back.
+
+
+class TestTheOffSwitches(unittest.TestCase):
+    """The three ways layer scoping must decline to act."""
+
+    def _one_track_board(self, layer, net=FOREIGN_NET):
+        pcb = parse_kicad_pcb(BOARD)
+        pads = _copper_pads(pcb.footprints[CAP])
+        target = pads[0]
+        x0, x1 = target.global_x - target.size_x / 2, target.global_x + target.size_x / 2
+        keepout = TRACK_W / 2 + CLEAR
+        ty = target.global_y - target.size_y / 2 - keepout + BITE
+        pcb.segments = [make_seg(x0 - 1.0, ty, x1 + 1.0, ty, layer=layer,
+                                 net_id=net, width=TRACK_W)]
+        pcb.vias = []
+        return pcb
+
+    def test_an_INJECTED_tuple_with_an_UNRECOGNISED_layer_is_still_graded(self):
+        """A tuple a test injects carries whatever it likes in the layer slot --
+        `tests/test_fanout_clearance.py` injects the cap's own 'F'/'B' side.
+        An UNKNOWN layer must be CHARGED: over-blocking is the only direction
+        that can never ship a violation, and this is the arm that replaced
+        #725's `sl is None` fallback."""
+        pcb = self._one_track_board('F.Cu')
+        st = _repair(BOARD, pcb=pcb)
+        cap = st.caps[CAP]
+        real = st.cap_segs[CAP][0]
+        for slot in ('F', 'B', None, 'Nonsense.Cu'):
+            injected = real[:6] + (slot,)
+            st.cap_segs[CAP] = [injected]
+            st._cap_seg_eff.pop(CAP, None)
+            # ON THE BRANCH: the slot really is not a board copper layer.
+            self.assertNotIn(slot, st._all_cu)
+            pen = st.seg_penalty(CAP, cap, cap.x, cap.y, cap.rot)
+            self.assertGreater(pen, 1e-6,
+                               'an injected tuple with layer slot %r was '
+                               'silently dropped' % (slot,))
+    # MUTATION: drop the `layer not in self._all_cu` arm of `_seg_shares` ->
+    # every injected tuple grades 0 and
+    # test_fanout_clearance::test_seed_track_graze_is_resolved goes red too.
+
+    def test_an_INJECTED_OFF_LAYER_tuple_is_NOT_charged(self):
+        """The GRADING skip, tested independently of the prune. With the prune
+        working, no real board can put an off-layer pair in front of
+        `_seg_shortfalls` -- so without this test a mutation that deletes the
+        per-pad gate is caught by nothing."""
+        pcb = self._one_track_board('F.Cu')
+        st = _repair(BOARD, pcb=pcb)
+        cap = st.caps[CAP]
+        real = st.cap_segs[CAP][0]
+        # ON THE BRANCH: the same tuple on its real layer IS charged.
+        self.assertGreater(st.seg_penalty(CAP, cap, cap.x, cap.y, cap.rot), 1e-6)
+        st.cap_segs[CAP] = [real[:6] + ('In1.Cu',)]
+        st._cap_seg_eff.pop(CAP, None)
+        self.assertIn('In1.Cu', st._all_cu)
+        self.assertNotIn('In1.Cu', cap.pad_layers[0])
+        pen = st.seg_penalty(CAP, cap, cap.x, cap.y, cap.rot)
+        self.assertAlmostEqual(pen, 0.0, places=9,
+                               msg='an off-layer tuple was charged %.6f' % pen)
+    # MUTATION: delete the `_seg_shares` branch in `_seg_effs` -> this reads
+    # BITE (0.05) while every board-level test stays green.
+
+    def test_a_board_with_NO_copper_layers_falls_back_to_the_SIDE_collapse(self):
+        """`pad_copper_layers(p, [])` resolves nothing for a `*.Cu` pad, so
+        every pad would read copper-less and every pair would take the
+        off-layer path -- an UNDER-block, which ships violations. Scoping
+        switches off wholesale. It must fall back to the OLD side test, NOT to
+        keeping every segment on the board: check_drc still layer-scopes such a
+        board (its routing_layers falls back to the segment-derived set), so
+        the placer must stay on the over-block side."""
+        pcb = parse_kicad_pcb(BOARD)
+        pcb.board_info.copper_layers = []
+        st = _repair(BOARD, pcb=pcb)
+        self.assertEqual(st._all_cu, frozenset())
+        cap = st.caps[CAP]
+        self.assertIsNone(st._cap_pad_layers(cap),
+                          'layer scoping stayed on with no copper layers')
+        # ON THE BRANCH: the board must carry tracks on BOTH sides, or "did not
+        # keep everything" cannot be distinguished from "kept everything".
+        sides = {st._seg_side(t[6]) for t in st.segments}
+        self.assertEqual(sides, {'F', 'B'})
+        kept = st.cap_segs[CAP]
+        self.assertTrue(kept, 'the fallback dropped every track')
+        self.assertTrue(all(st._seg_side(t[6]) == cap.side for t in kept),
+                        'a track from the OTHER side survived: the fallback '
+                        'stopped filtering instead of using the side test')
+        self.assertLess(len(kept), len(st.segments),
+                        'the fallback kept every segment on the board')
+    # MUTATION: make the `_union is None` arm keep every segment -> the last
+    # two assertions fail.
+
+
+class TestShapeAndClassification(unittest.TestCase):
+
+    def test_the_Cap_constructor_takes_board_copper_POSITIONALLY(self):
+        """`board_copper` must be a real parameter, not a defaulted one that a
+        3-positional caller silently skips: with a default of `()`, every
+        `*.Cu` pad would resolve to the EMPTY set and read as copper-less --
+        the fix would look present and grade nothing."""
+        names = list(inspect.signature(_Cap.__init__).parameters)
+        self.assertEqual(names[1:5],
+                         ['fp', 'courtyard_local', 'model', 'board_copper'])
+        pcb = parse_kicad_pcb(BOARD)
+        fp = pcb.footprints[CAP]
+        cu = pcb.board_info.copper_layers
+        cap = _Cap(fp, (-0.5, -0.5, 0.5, 0.5), None, cu)
+        # Built with NO model at all, and still resolves real layers.
+        self.assertEqual(cap.pad_floors, [])
+        self.assertEqual(sorted(cap.pad_layers[0]), ['F.Cu'])
+        self.assertEqual(len(cap.pad_layers), len(cap.pads))
+    # MUTATION: gate the pad_layers build on `model is not None` -> pad_layers
+    # is [] here. MUTATION: rename or reorder the parameter -> the name list
+    # differs.
+
+    def test_the_segment_tuple_is_still_SEVEN_wide_and_carries_a_LAYER(self):
+        """#731 replaced element 6 rather than widening the tuple, because
+        `_seg_shortfalls` unpacks it positionally in two places and
+        test_725's TestShapeContract pins the width."""
+        st = _repair(BOARD)
+        self.assertTrue(st.segments)
+        for t in st.segments[:50]:
+            self.assertEqual(len(t), 7)
+            self.assertIn(t[6], st._all_cu)
+        self.assertFalse(hasattr(st, '_seg_layer_by_id'),
+                         'the companion layer map is back -- there are two '
+                         'answers to "what layer is this track on" again')
+    # MUTATION: put `side` back in element 6 -> `assertIn(t[6], _all_cu)` fails.
+
+    def test_this_file_is_collected_as_a_FAST_test(self):
+        """This file names the integration markers in its own prose, which is
+        exactly how the #725 file got bucketed as integration and skipped under
+        --fast (commit 6c2096c6)."""
+        import run_all
+        self.assertFalse(run_all.is_integration(os.path.abspath(__file__)))
+        found = [os.path.basename(f) for f in run_all.discover(['731'])]
+        self.assertIn(os.path.basename(__file__), found)
+    # MUTATION: delete the `RUN_ALL_FAST_OK = True` line -> is_integration
+    # returns True and the file is skipped under --fast.
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/test_732_fanout_clearance_via_radius.py
+++ b/tests/test_732_fanout_clearance_via_radius.py
@@ -1,0 +1,613 @@
+"""#732: a via's RADIUS must have ONE resolver in the fanout-clearance pass.
+
+`_Repair.__init__` built its keep-out list from
+`v.size if v.size and v.size > 0 else default_via_size`, while
+`nudge_vias_for_unresolved` priced the SAME barrel at a hard-coded
+`(v.size or 0.5) / 2.0` in four places, and its #313 connectivity tolerance at
+`max(1e-3, v.size / 2.0)` with no fallback at all. For a via the board did not
+size, the grader and the nudger therefore resolved DIFFERENT keep-outs -- the
+divergence the module's own comments forbid for the clearance term (#725).
+
+Three failure modes, all measured at HEAD 0bfc0be0 before the fix:
+
+  * `--default-via-size` ABOVE 0.5: grader keep-out 0.500, nudger threshold
+    0.350. The grader reports the cap unresolved (penetration 0.080000) and the
+    offender list comes back EMPTY, so the `for v in offenders:` body never
+    runs -- not even the "no clear spot" line prints. Captured nudger stdout
+    was literally ''. The cap stays unresolved forever with nothing on screen.
+  * BELOW 0.5 -- which is the SHIPPED CLI DEFAULT of 0.3
+    (bga_fanout.constants.DEFAULT_VIA_SIZE): the nudger over-estimates and
+    relocates vias whose grader penetration is exactly 0.000000, recording them
+    for the writer and laying connector copper for nothing.
+  * The tolerance: a size-0 via collapses `tol` to 1e-3, so a same-net stub end
+    0.100mm off the via centre is not matched, `conn_layers` comes back EMPTY,
+    and `all([])` is True -- the via is relocated with ZERO connectors and the
+    stub is orphaned. That is the pre-#313 behaviour the comment above the line
+    says was fixed.
+
+WHY THE GRADERS ARE NOT TOUCHED, and why that is a finding rather than an
+omission. `--default-via-size` is an OPERATOR's belief about a board being
+placed. It is not licence for a DRC/connectivity grader to disagree with KiCad,
+and KiCad honours a declared size literally.
+
+Measured on KiCad 10 with two boards identical but for one via's size, graded
+through check_connected's KiCad refill cross-check. State the geometry
+precisely, because the naive version of this experiment shows NOTHING: what
+governs is the PERPENDICULAR distance from the same-net copper to the barrel
+centre, not the stub's endpoint offset, and a track wide enough to cover the
+barrel keeps the net connected at either size. With ~0.2mm of effective
+separation, KiCad reports 0 unconnected links at `(size 0.5)` and 1 at
+`(size 0)`; a first attempt at a 0.100mm endpoint offset with a 0.2mm track
+reported 0 in BOTH arms, because the track's own copper already reached the
+barrel.
+
+`(size 0)` is additionally a hard KiCad DRC error in its own right
+(`via_diameter (min 0.5000 mm; actual 0.0000 mm)`, plus `track_dangling`), which
+is the strongest form of the point: KiCad does not quietly assume a diameter
+for such a via, it rejects it. So a grader that invented one would report
+CONNECTED what KiCad reports OPEN -- the direction that hides an open.
+`TestTheGradersStillReadTheBoard` pins that decision behaviourally, on
+`connectivity.endpoint_reaches_via`, so a later reader does not "fix"
+check_drc / check_connected / connectivity into disagreeing with KiCad.
+
+Conventions this file follows (from #697/#725/#731 and CLAUDE.md):
+
+  * REAL parser dataclasses and REAL boards. `_Repair.__init__` reads
+    courtyards and locked refs from the file on disk.
+  * Every assertion names the single-line MUTATION that must kill it.
+  * Assert you are ON the branch before asserting about it -- each test spies
+    the value its branch keys on, with a detail string saying why.
+  * Every "is not charged" is paired with a NEGATIVE CONTROL that still is.
+
+Runs in-process in ~20 s; nothing here shells out.
+"""
+from __future__ import annotations
+
+RUN_ALL_FAST_OK = True
+RUN_ALL_TIMEOUT = 900
+
+import contextlib
+import inspect
+import io
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+
+_TESTS = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_TESTS)
+for _p in ('', 'py_router', 'py_placer', 'py_tools'):
+    _d = os.path.join(_ROOT, _p)
+    if _d not in sys.path:
+        sys.path.insert(0, _d)
+if _TESTS not in sys.path:
+    sys.path.insert(0, _TESTS)
+
+from kicad_parser import BoardInfo, parse_kicad_pcb
+from synth import make_pcb, make_seg, make_via
+from placement import fanout_clearance as FC
+from placement.fanout_clearance import _Repair, nudge_vias_for_unresolved
+
+# Declares no netclass, no .kicad_dru and no pad override, so the clearance
+# model is INERT: via_required == clearance and _item_reach == clearance on
+# BOTH sides. The radius is then the only variable that can differ, which is
+# the isolation this issue needs and which orangecrab (6 fiducials carrying
+# local_clearance 0.375) cannot give.
+BOARD = os.path.join(_ROOT, 'kicad_files', 'rp2350_fpga_eensy_prePlane.kicad_pcb')
+CLEAR = 0.1
+PREFIX = 'C,R,FB'          # the CLI default; with 'C' alone R-refs never appear
+CAP = 'C16'                # a decoupling cap with clear board on both sides
+FOREIGN = 5                # neither of C16's own nets (2 and 4)
+
+# The two working points. 0.5 is deliberately avoided: it is the constant the
+# nudger used to hard-code, so at 0.5 the two conventions AGREE and every test
+# here would pass vacuously.
+DVS_BIG = 0.8              # grader radius 0.40 vs the old nudger's 0.25
+DVS_SMALL = 0.3            # the shipped CLI default; 0.15 vs 0.25, sign flipped
+OLD_NUDGER_RADIUS = 0.5 / 2.0
+
+
+def _repair(pcb, dvs, path=BOARD):
+    """The 10-POSITIONAL construction every test in this family uses. `dvs` is
+    argument 8, `default_via_size` -- the knob this issue is about, and the one
+    #725's shape contract pins in that slot."""
+    return _Repair(pcb, path, CLEAR, 0.1, 0.55, 1.0, 2.0, dvs, PREFIX, set())
+
+
+def _rig(dvs, gaps, sizes=None, stubs=()):
+    """A REAL board whose vias are replaced by ones parked at EXACT distances
+    from a real cap pad's rect, so `_point_to_rect_dist` IS the requested gap
+    and every threshold below is closed-form rather than measured.
+
+    Returns (pcb, st, cap, rect). Vias sit on the pad rect's horizontal centre
+    line, outside its right edge, on a foreign net.
+    """
+    pcb = parse_kicad_pcb(BOARD)
+    probe = _repair(pcb, dvs)
+    rect = probe.caps[CAP].pad_rects()[1]        # the net-2 pad
+    cy = (rect[1] + rect[3]) / 2.0
+    if sizes is None:
+        sizes = [0.0] * len(gaps)
+    pcb.vias[:] = [make_via(rect[2] + g, cy, net_id=FOREIGN, size=sz)
+                   for g, sz in zip(gaps, sizes)]
+    pcb.segments[:] = list(stubs)
+    st = _repair(pcb, dvs)
+    # Isolate the via channel: no foreign tracks, and every cap sees every via.
+    st.cap_segs = {k: [] for k in st.caps}
+    st.cap_vias = {k: st.vias for k in st.caps}
+    return pcb, st, st.caps[CAP], rect
+
+
+def _nudge(st, pcb, **kw):
+    """Drive the real pass, capturing what it printed. The PRINTED OUTPUT is
+    half the evidence for #732: above 0.5 the old build printed nothing at all,
+    which is what made the failure silent."""
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        moves, segs = nudge_vias_for_unresolved(st, pcb, CLEAR, **kw)
+    return moves, segs, buf.getvalue()
+
+
+class TestOneRadiusRule(unittest.TestCase):
+    """There is exactly one implementation of "how wide is this via"."""
+
+    def test_a_size_zero_via_resolves_to_the_operators_default(self):
+        pcb = parse_kicad_pcb(BOARD)
+        pcb.vias[0].size = 0.0
+        st = _repair(pcb, DVS_BIG)
+        v, t = pcb.vias[0], st.vias[0]
+        # ON THE BRANCH, both halves:
+        self.assertFalse(v.size, 'the via carries a size -- the fallback branch '
+                                 'is not taken and this test is vacuous')
+        self.assertNotAlmostEqual(
+            DVS_BIG / 2.0, OLD_NUDGER_RADIUS, places=9,
+            msg='at default_via_size 0.5 the old hard-coded fallback EQUALS the '
+                'resolver, so this test could not fail')
+        self.assertAlmostEqual(st.via_radius(v), DVS_BIG / 2.0, places=12)
+        # the tuple and the identity map are built from that same number
+        self.assertAlmostEqual(t[3], st.via_radius(v) + CLEAR, places=12)
+        self.assertAlmostEqual(st._via_radius_by_id[id(t)][1], st.via_radius(v),
+                               places=12)
+    # MUTATION: `via_radius` back to `(via.size or 0.5) / 2.0` -> reads 0.25,
+    # not 0.40, and all three assertions fail.
+
+    def test_a_via_with_a_REAL_size_ignores_the_default(self):
+        """NEGATIVE CONTROL for the test above: the operator's belief must not
+        override a size the board actually carries."""
+        pcb = parse_kicad_pcb(BOARD)
+        pcb.vias[0].size = 0.4
+        for dvs in (DVS_SMALL, DVS_BIG):
+            st = _repair(pcb, dvs)
+            self.assertAlmostEqual(st.via_radius(pcb.vias[0]), 0.2, places=12,
+                                   msg='default_via_size %s leaked into a via '
+                                       'that declares its own size' % dvs)
+    # MUTATION: make `via_radius` return `default_size / 2` unconditionally.
+
+    def test_the_module_has_exactly_ONE_spelling_of_a_via_radius(self):
+        """A source guard. The bug was not a wrong number, it was N numbers."""
+        src = inspect.getsource(FC)
+        # ON THE BRANCH: the resolver exists at all.
+        self.assertIn('def via_radius', src)
+        lines = src.split(chr(10))
+        for gone, where in ((' (v.size or 0.5)', 'the nudger validation/offender sites'),
+                            ('(ov.size or 0.5)', 'the foreign-via sites'),
+                            ('max(1e-3, v.size / 2.0)', 'the #313 connectivity tolerance'),
+                            ('keepout - st._item_reach', 'the locked-part warning')):
+            # Report the offending LINES, not the whole 130KB module: an
+            # assertNotIn on a source-sized haystack prints the haystack, and
+            # one failure produced 393KB of output.
+            hits = ['%d: %s' % (i + 1, l.strip())
+                    for i, l in enumerate(lines) if gone in l]
+            self.assertEqual(
+                hits, [],
+                '%s still resolves a via radius its own way -- %s'
+                % (where, '; '.join(hits)))
+    # MUTATION: re-introduce any one of those spellings -> its assertNotIn fires.
+
+
+class TestNudgerSeesWhatTheGraderFlags(unittest.TestCase):
+    """The offender test and the grader must agree about WHICH via offends."""
+
+    def test_above_the_old_fallback_the_nudger_can_SEE_the_flagged_via(self):
+        """The silent failure. Grader keep-out 0.500, old nudger 0.350; a via
+        at 0.420 sits in the band only the resolved radius can see."""
+        pcb, st, cap, rect = _rig(DVS_BIG, [0.42, 1.50])
+        near = pcb.vias[0]
+        # ON THE BRANCH, both halves:
+        self.assertGreater(
+            st.graze_penalty(CAP, cap, cap.x, cap.y, cap.rot), FC.EPS,
+            'the grader does not flag this cap, so the offender loop never runs')
+        self.assertTrue(
+            OLD_NUDGER_RADIUS + CLEAR <= 0.42 < st.via_radius(near) + CLEAR,
+            'the via is not in the band that separates the two conventions '
+            '(old %.3f, resolved %.3f)' % (OLD_NUDGER_RADIUS + CLEAR,
+                                           st.via_radius(near) + CLEAR))
+        moves, _segs, out = _nudge(st, pcb, max_shift=4.0)
+        # The SILENCE is the headline symptom, so assert it first: asserting the
+        # move count first shadows this one, and then no mutation can ever make
+        # the printed output the reported failure.
+        self.assertIn('via-nudge:', out,
+                      'the pass printed NOTHING about a cap it reports '
+                      'unresolved -- the silent failure #732 is about')
+        self.assertEqual(len(moves), 1, 'expected exactly the 0.42 via to move')
+        self.assertAlmostEqual(moves[0][0], rect[2] + 0.42, places=6)
+        # Where it LANDED, not just which via moved. moves[0][0..1] is the OLD
+        # position, so without this nothing checks the destination -- and the
+        # destination is what `valid_via_pos` prices with its own `vr`.
+        gap = FC._point_to_rect_dist(near.x, near.y, rect[:4])
+        self.assertGreaterEqual(
+            gap, st.via_radius(near) + CLEAR - 1e-9,
+            'the via landed %.4fmm from the pad, inside its resolved keep-out '
+            '%.4fmm -- valid_via_pos is pricing the barrel at a constant'
+            % (gap, st.via_radius(near) + CLEAR))
+        self.assertLess(
+            gap, st.via_radius(near) + CLEAR + 0.30,
+            'the via was pushed far beyond its keep-out, so this assertion '
+            'would hold for a much smaller radius too and proves little')
+        # NEGATIVE CONTROL: the via at 1.50 is clear under BOTH conventions and
+        # is still left alone.
+        self.assertAlmostEqual(pcb.vias[1].x, rect[2] + 1.50, places=6,
+                               msg='a genuinely clear via was moved')
+    # MUTATION: the offender loop back to `(v.size or 0.5) / 2.0` -> moves == []
+    # and `out` is '' (measured at HEAD: exactly that).
+
+    def test_below_it_a_PHANTOM_via_is_no_longer_chased(self):
+        """The shipped CLI default. Grader keep-out 0.250, old nudger 0.350: a
+        via at 0.300 is a phantom the old build relocated anyway."""
+        pcb, st, cap, rect = _rig(DVS_SMALL, [0.30, 0.02])
+        phantom = pcb.vias[0]
+        # ON THE BRANCH, three guards:
+        self.assertGreater(
+            st.graze_penalty(CAP, cap, cap.x, cap.y, cap.rot), FC.EPS,
+            'no cap is unresolved, so the offender loop never runs')
+        self.assertTrue(
+            st.via_radius(phantom) + CLEAR <= 0.30 < OLD_NUDGER_RADIUS + CLEAR,
+            'the phantom is not in the band only the OLD fallback could see')
+        self.assertLessEqual(
+            st.via_penalty(cap, cap.x, cap.y, cap.rot,
+                           [st.vias[0]], ref=CAP), FC.EPS,
+            'the grader DOES charge the 0.30 via -- it is not a phantom, and '
+            'this test is measuring the wrong thing')
+        moves, _segs, _out = _nudge(st, pcb, max_shift=4.0)
+        # NEGATIVE CONTROL is the assertion itself: the real offender still moves.
+        self.assertEqual(len(moves), 1,
+                         'expected only the 0.02 via (the real offender) to move')
+        self.assertAlmostEqual(moves[0][0], rect[2] + 0.02, places=6,
+                               msg='the phantom moved instead of the real offender')
+    # MUTATION: the offender loop back to `(v.size or 0.5) / 2.0` -> len(moves)
+    # becomes 2 and the phantom is relocated (measured at HEAD).
+
+    def test_the_offender_loop_RESOLVES_the_radius_through_st(self):
+        """Isolate the OFFENDER LOOP specifically.
+
+        A foreign TRACK makes the cap unresolved, so the loop runs -- but the
+        only via is 40mm away, so it offends nobody and neither `valid_via_pos`
+        nor `connector_clear` is ever entered. Any call to the resolver
+        therefore came from the offender test itself. Priced at a constant, the
+        resolver is never called at all, and a cap unresolved because of a
+        RAISED via requirement would yield an empty offender list: the pass
+        reports it unresolved forever and prints nothing.
+        """
+        pcb = parse_kicad_pcb(BOARD)
+        probe = _repair(pcb, DVS_BIG)
+        rect = probe.caps[CAP].pad_rects()[1]
+        cy = (rect[1] + rect[3]) / 2.0
+        # A foreign track biting into the cap pad's keep-out band.
+        bite = make_seg(rect[2] + 0.05, cy - 2.0, rect[2] + 0.05, cy + 2.0,
+                        width=0.1, layer='F.Cu', net_id=FOREIGN)
+        pcb.segments[:] = [bite]
+        pcb.vias[:] = [make_via(rect[2] + 40.0, cy, net_id=FOREIGN, size=0.0)]
+        st = _repair(pcb, DVS_BIG)
+        st.cap_vias = {k: st.vias for k in st.caps}
+        cap = st.caps[CAP]
+        # ON THE BRANCH, three guards: the loop only runs on an unresolved cap,
+        # only reaches the resolver if a via is in the list, and the via must
+        # NOT be an offender or a validator would run and muddy the count.
+        unresolved = [r for r in st.caps
+                      if st.graze_penalty(r, st.caps[r], st.caps[r].x,
+                                          st.caps[r].y, st.caps[r].rot) > FC.EPS]
+        self.assertIn(CAP, unresolved,
+                      'the track does not make %s unresolved, so the offender '
+                      'loop never runs' % CAP)
+        self.assertTrue(pcb.vias, 'no vias -- the inner loop never executes')
+        self.assertLessEqual(
+            st.via_penalty(cap, cap.x, cap.y, cap.rot, st.vias, ref=CAP),
+            FC.EPS, 'the far via grazes the cap, so a validator will run and '
+                    'this test no longer isolates the offender loop')
+        calls, real = [0], st.via_radius
+
+        def counting(v):
+            calls[0] += 1
+            return real(v)
+        st.via_radius = counting
+        moves, segs, _out = _nudge(st, pcb)
+        self.assertEqual((moves, segs), ([], []),
+                         'a via 40mm away should offend nobody')
+        self.assertGreater(calls[0], 0,
+                           'the offender loop never consulted via_radius -- it '
+                           'is pricing the barrel at a constant')
+    # MUTATION: the offender loop back to a hard-coded fallback -> calls == 0.
+
+
+class TestTheConnectivityTolerance(unittest.TestCase):
+    """#313: copper terminating within the VIA BODY is joined through it and
+    needs a connector on its layer when the via moves."""
+
+    def _stub_rig(self, size):
+        pcb, st, cap, rect = _rig(DVS_BIG, [0.42], sizes=[size])
+        v = pcb.vias[0]
+        near = make_seg(v.x, v.y - 0.30, v.x, v.y - 0.10,
+                        width=0.2, layer='F.Cu', net_id=FOREIGN)
+        far = make_seg(v.x, v.y + 0.90, v.x, v.y + 1.40,
+                       width=0.2, layer='B.Cu', net_id=FOREIGN)
+        pcb.segments[:] = [near, far]
+        return pcb, st, v
+
+    def test_a_size_zero_vias_stub_still_gets_its_connector(self):
+        pcb, st, v = self._stub_rig(0.0)
+        # ON THE BRANCH: 0.10mm is inside the resolved body but far outside the
+        # 1e-3 the old expression collapsed to.
+        self.assertTrue(1e-3 < 0.10 < st.via_radius(v),
+                        'the stub end is not in the band that separates the two '
+                        'tolerances (resolved radius %.3f)' % st.via_radius(v))
+        moves, segs, _out = _nudge(st, pcb, max_shift=4.0)
+        self.assertEqual(len(moves), 1, 'the via did not move; nothing to prove')
+        layers = {s['layer'] for s in segs}
+        self.assertIn('F.Cu', layers,
+                      'the via was relocated with NO connector back to its stub '
+                      '-- the #313 open this tolerance exists to prevent')
+        # NEGATIVE CONTROL: a same-net stub 0.90mm away is genuinely out of
+        # reach of the barrel and must still get nothing.
+        self.assertNotIn('B.Cu', layers,
+                         'a stub far outside the via body was given a connector')
+    # MUTATION: `tol` back to `max(1e-3, v.size / 2.0)` -> conn_layers is EMPTY,
+    # `all([])` is True so the move still happens, and segs loses F.Cu.
+
+    # NOT COVERED BEHAVIOURALLY, and here is the full list rather than a silent
+    # gap. A mutation run reverted each converted site individually with a
+    # guard-evading spelling; these are the ones no test noticed:
+    #
+    #   * `connector_clear`'s foreign-via term
+    #   * `valid_via_pos`'s foreign-via term (`via_rad(ov)`)
+    #
+    # `valid_via_pos`'s OWN `vr` was in that list too and is now covered, by
+    # asserting where the via LANDS rather than only which via moved.
+    #
+    # For the two that remain: the foreign-via terms only bind when a FOREIGN
+    # via sits close enough to matter, and every fixture here parks its foreign
+    # vias against the cap pad rather than against each other. I tried to cover
+    # `connector_clear`'s and the rig was VACUOUS -- `segs` came back empty, so
+    # the assertion loop never iterated.
+    #
+    # The reason is structural, not laziness. For a foreign via of the same
+    # radius r, `valid_via_pos` requires centre-to-centre >= r + r + clearance
+    # while `connector_clear` requires point-to-segment >= r + hw + clearance.
+    # With r 0.4 and a 0.2mm connector that is 0.9mm versus 0.6mm, so
+    # valid_via_pos is STRICTLY stricter: any blocker close enough to trip the
+    # connector test has already rejected the candidate position. The term can
+    # only bind against the connector's MIDDLE, and a connector is at most
+    # max_shift long, so its midpoint sits within half a shift of the old via
+    # position -- where the moving via already was, i.e. somewhere that was
+    # legal by construction.
+    #
+    # It is therefore guarded by SPELLING only
+    # (test_the_module_has_exactly_ONE_spelling_of_a_via_radius). Filed rather
+    # than faked. The same holds for the locked-part warning's `_rec is None`
+    # branch, which is unreachable while every tuple comes from __init__.
+
+    def test_a_via_with_a_real_size_is_priced_exactly_as_before(self):
+        """The whole fix is gated on a falsy size. A real one must resolve to
+        exactly `size / 2`, before and after."""
+        pcb, st, v = self._stub_rig(0.5)
+        self.assertAlmostEqual(st.via_radius(v), 0.25, places=12)
+        self.assertAlmostEqual(st.via_radius(v), OLD_NUDGER_RADIUS, places=12,
+                               msg='a real-sized via must be priced identically '
+                                   'to the pre-#732 build')
+    # MUTATION: make via_radius apply the default even when size > 0.
+
+
+class TestTheDuckTypedPathStaysInert(unittest.TestCase):
+    """`nudge_vias_for_unresolved` is public and the #370/#617 harnesses drive
+    it with a stand-in `st` carrying no resolvers at all."""
+
+    class _FakeCap:
+        def __init__(self, rects):
+            self._rects = list(rects)
+            self.side = 'F'
+            self.x = self.y = self.rot = 0.0
+
+        def pad_rects(self, x=None, y=None, rot=None):
+            return self._rects
+
+    class _FakeSt:
+        def __init__(self, rects, cap_cls):
+            self.caps = {'C1': cap_cls(rects)}
+            self.vias = []
+
+        def graze_penalty(self, ref, cap, x, y, rot):
+            return 1.0
+
+    def test_the_fallback_is_the_value_the_nudger_always_used(self):
+        """DRIVES the real function with a duck-typed `st`, so the fallback
+        branch is actually executed. Asserting on `_via_radius` alone
+        would leave `via_rad`'s fallback dead code that a `raise` could replace
+        without any test noticing -- which is exactly what a mutation run found
+        the first version of this test doing."""
+        BAR = (0.2, 0.9, 1.8, 1.1, 2)      # cap pad bar; only +y escapes
+        st = self._FakeSt([BAR], self._FakeCap)
+        v = make_via(1.0, 1.4, net_id=3, size=0.0)
+        pcb = make_pcb(vias=[v], board_info=BoardInfo(
+            layers={}, board_bounds=(-5.0, -5.0, 15.0, 50.0),
+            copper_layers=['F.Cu', 'B.Cu']),
+            footprints={'C1': SimpleNamespace(layer='F.Cu', pads=[])})
+        # ON THE BRANCH, both halves:
+        self.assertIsNone(getattr(st, 'via_radius', None),
+                          'the fake grew a resolver -- the fallback is never '
+                          'exercised and this test is vacuous')
+        self.assertFalse(v.size, 'the via declares a size, so the fallback '
+                                 'branch is not taken')
+        self.assertEqual(FC._UNREADABLE_VIA_SIZE, 0.5,
+                         'the duck-typed fallback silently changed value; the '
+                         'nudger hard-coded 0.5 at four sites before #732 and '
+                         'this rename must not move it')
+        moves, _segs, _out = _nudge(st, pcb, max_shift=4.0)
+        self.assertEqual(len(moves), 1, 'the fake st did not drive a move, so '
+                                        'the fallback was never reached')
+        # The relocated via must clear the bar by the FALLBACK radius: the bar
+        # spans y in [0.9, 1.1], so a via at radius r must sit at least
+        # r + CLEAR above 1.1.
+        self.assertGreaterEqual(
+            v.y, BAR[3] + OLD_NUDGER_RADIUS + CLEAR - 1e-9,
+            'the nudger cleared the bar by %.3f, not by the fallback radius '
+            '%.3f' % (v.y - BAR[3] - CLEAR, OLD_NUDGER_RADIUS))
+        # NEGATIVE CONTROL: a via that DECLARES a size is priced off the via,
+        # not off the fallback -- a wider one must be pushed further.
+        st2 = self._FakeSt([BAR], self._FakeCap)
+        v2 = make_via(1.0, 1.4, net_id=3, size=1.0)
+        pcb2 = make_pcb(vias=[v2], board_info=BoardInfo(
+            layers={}, board_bounds=(-5.0, -5.0, 15.0, 50.0),
+            copper_layers=['F.Cu', 'B.Cu']),
+            footprints={'C1': SimpleNamespace(layer='F.Cu', pads=[])})
+        moves2, _s2, _o2 = _nudge(st2, pcb2, max_shift=4.0)
+        self.assertEqual(len(moves2), 1)
+        self.assertGreater(v2.y, v.y,
+                           'a 1.0mm via was not pushed further than a size-0 '
+                           'one, so the radius is not being read at all')
+    # MUTATION: change UNREADABLE_VIA_SIZE -> the fallback assertion fires.
+    # MUTATION: replace via_rad's fallback body with `raise` -> this test dies
+    # (it is the only one that reaches that branch).
+
+
+class TestTheLockedWarningReadsTheMap(unittest.TestCase):
+    """The last arithmetic re-derivation of a radius in the file. It agrees
+    with the map on every real via -- which is what licenses replacing it."""
+
+    def test_the_arithmetic_and_the_map_agree_on_every_real_via(self):
+        pcb = parse_kicad_pcb(BOARD)
+        st = _repair(pcb, DVS_SMALL)
+        # ON THE BRANCH:
+        self.assertTrue(st.vias, 'the board has no vias to compare')
+        self.assertEqual(len(st._via_radius_by_id), len(st.vias),
+                         'not every tuple is registered, so the map is not the '
+                         'authority this test claims it is')
+        for t in st.vias:
+            self.assertAlmostEqual(
+                t[3] - st._item_reach(st.via_floor(t[2])),
+                st._via_radius_by_id[id(t)][1], places=12,
+                msg='the old subtraction and the map disagree at %r' % (t,))
+    # MUTATION: none kills this one -- it is the MEASUREMENT that licenses the
+    # locked-warning change (the two forms are numerically identical on a real
+    # board, so the swap is inert). The source guard in TestOneRadiusRule is
+    # what stops the arithmetic coming back.
+
+
+class TestTheGradersStillReadTheBoard(unittest.TestCase):
+    """MEASURED DECISION, pinned so nobody "fixes" it later.
+
+    KiCad honours a declared via size literally. On two boards identical but
+    for one via's size, with a same-net stub end 0.100mm off its centre,
+    check_connected's KiCad refill cross-check reported 0 unconnected links at
+    `(size 0.5)` and 1 at `(size 0)`. A zero-diameter barrel joins nothing, so
+    a grader that substituted `--default-via-size` would report CONNECTED what
+    KiCad reports OPEN. The operator's belief governs PLACEMENT, not grading.
+    """
+
+    def test_the_grader_mirror_credits_a_size_zero_barrel_at_ZERO(self):
+        """BEHAVIOURAL, not a string match.
+
+        An earlier version of this test asserted only
+        `'defaults.via_radius' not in source`, which such a mutant defeats with
+        `from routing_defaults import via_radius as _vr`, and which would pass
+        just as well on a build that hard-coded 0.5 in the grader by hand. It
+        pinned a spelling, not the decision.
+
+        `connectivity.endpoint_reaches_via` is the right thing to pin: it is
+        public, its docstring explicitly documents itself as the mirror of
+        check_connected's via credit, and it is the function a well-meaning
+        reader would "fix". Its contract is that the credit is the BARREL
+        radius plus the copper's own radius -- so for a via the board sizes at
+        0, the barrel contributes nothing and only the copper's own reach and
+        the coincidence floor remain.
+        """
+        import connectivity
+        from connectivity import COINCIDENCE_TOL, endpoint_reaches_via
+        LAY = ['F.Cu', 'B.Cu']
+        big = make_via(0.0, 0.0, net_id=7, size=0.8)
+        zero = make_via(0.0, 0.0, net_id=7, size=0.0)
+        # A zero-radius probe: the credit is then the barrel alone.
+        # 0.25: inside the 0.8 barrel (0.40), far outside the 0.02 floor,
+        # and strictly inside a 0.6 invented diameter (0.30) so a mutant
+        # that substitutes one is caught. NOT 0.30 -- that equals such a
+        # mutant's radius exactly and the strict `<` lets it through.
+        d = 0.25
+        # ON THE BRANCH: the same probe IS credited against a real barrel, so a
+        # False below is the barrel's absence and not a broken fixture.
+        self.assertTrue(endpoint_reaches_via(d, 0.0, 0.0, big, LAY, LAY),
+                        'a 0.8mm barrel does not reach 0.25mm; the fixture is '
+                        'not measuring the barrel')
+        self.assertGreater(d, COINCIDENCE_TOL,
+                           'the probe is inside the coincidence floor, so this '
+                           'would pass whatever the radius is')
+        self.assertFalse(
+            endpoint_reaches_via(d, 0.0, 0.0, zero, LAY, LAY),
+            'a via the board sizes at 0 was credited with 0.25mm of barrel '
+            'reach. KiCad honours a declared size literally -- (size 0) is a '
+            'via_diameter DRC error there and that barrel joins nothing -- so '
+            'inventing a diameter here reports CONNECTED what KiCad reports '
+            'OPEN, the direction that hides an open. --default-via-size is an '
+            'operator belief about a board being PLACED; it is not licence for '
+            'a grader to disagree with KiCad.')
+        # And the source of that number is still the board, not a constant.
+        self.assertNotIn('_UNREADABLE_VIA_SIZE', inspect.getsource(connectivity),
+                         'connectivity now imports the placement pass fallback')
+    # MUTATION: give connectivity.endpoint_reaches_via a non-zero fallback for a
+    # size-0 via (e.g. restore `(getattr(via,'size',0.6) or 0.6)`) -> the
+    # assertFalse fires.
+
+
+class TestInertOnTheTrackedCorpus(unittest.TestCase):
+    """Every changed expression is gated on a falsy size, and no tracked board
+    has one -- so the whole change is provably inert on the corpus. Asserted
+    rather than narrated."""
+
+    def test_no_tracked_board_carries_a_via_the_fix_could_touch(self):
+        import re
+        import subprocess
+        # git ls-files, NOT a glob: eleven boards in kicad_files/ are gitignored
+        # build products (interf_u_*, sonde_u_*, fanout_output*, ...). Globbing
+        # made this test pass only on a machine that had run the examples and
+        # FAIL on a fresh clone -- measured, 602 tokens vs the 1520 a populated
+        # tree sees.
+        try:
+            out = subprocess.check_output(
+                ['git', 'ls-files', 'kicad_files/*.kicad_pcb'],
+                cwd=_ROOT, stderr=subprocess.DEVNULL).decode()
+        except Exception as exc:                       # no git, no answer
+            raise unittest.SkipTest('git ls-files unavailable: %s' % exc)
+        boards = [os.path.join(_ROOT, ln) for ln in out.splitlines()
+                  if ln.strip()]
+        pat = re.compile(r'\(size\s+([0-9.]+)\s*\)')
+        total = zero = 0
+        for path in boards:
+            with io.open(path, encoding='utf-8', errors='replace') as fh:
+                for m in pat.finditer(fh.read()):
+                    total += 1
+                    if float(m.group(1)) <= 0:
+                        zero += 1
+        # ON THE BRANCH: the scan actually read the tracked corpus.
+        self.assertGreater(len(boards), 15,
+                           'git listed only %d tracked boards' % len(boards))
+        self.assertGreater(total, 500,
+                           'the scan found only %d size tokens across %d tracked '
+                           'boards -- it is not reading the corpus'
+                           % (total, len(boards)))
+        self.assertEqual(zero, 0,
+                         '%d tracked via(s) now have size <= 0, so the "provably '
+                         'inert on the corpus" claim in the PR is no longer '
+                         'true and must be re-measured' % zero)
+    # MUTATION: add a `(size 0)` via to any tracked board -> this fails, which
+    # is the point: the inertness claim stops being true and must be restated.
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/test_733_fanout_clearance_edge_margin.py
+++ b/tests/test_733_fanout_clearance_edge_margin.py
@@ -1,0 +1,739 @@
+"""#733: the board-edge requirement must have ONE resolver in this pass.
+
+`_Repair.__init__` insets `usable` and builds `edge_gate` at
+`max(clearance, board_edge_clearance)`, and gates every candidate cap rect on
+that. `nudge_vias_for_unresolved` -- which RELOCATES real vias and DRAWS real
+connector segments, the only channel here that emits copper rather than moving
+parts -- gated its own `edge_ok_point` / `edge_ok_seg` at the bare flat
+`clearance`, and took no `board_edge_clearance` parameter at all, so it could
+not agree.
+
+Measured on the rig below at HEAD 0f62d190, at the shipped CLI defaults
+(`--clearance 0.25`, `--board-edge-clearance 0.55`):
+
+    board top 2.15, cap bar at y 0.9..1.1, one foreign 0.5mm via at (1.0, 1.4)
+
+  * before: the via is relocated to (1.0, 1.600) and the writer keeps it
+    (place_fanout_clearance.py:138). Its centre is 0.550mm from Edge.Cuts --
+    0.30mm inside the band the cap mover reserves, on copper this pass created.
+  * after: no candidate validates, the pass prints "no clear spot", and the
+    via stays put.
+
+The same 0.30mm on the GUI path, which passed NO value and silently took the
+signature default whatever the board or the operator said.
+
+TIGHTEN-ONLY, and that is the interesting half. `resolve_cap_edge_clearance`
+raises the 0.55 default to a board's declared `min_copper_edge_clearance` but
+never lowers it, because `fix_project_for_output` PINS that field UP to the fab
+copper-to-edge floor 0.20 on every board it writes
+(fix_kicad_drc_settings.py:608 -> :748-753, the one raise-allowed key) and
+`bga_fanout.py` calls it -- so in the documented pipeline
+`bga_fanout.py -> place_fanout_clearance.py` every board arrives declaring
+>= 0.20 even when its author declared nothing. Read plainly board-first, that
+0.20 comes back tagged "board constraint" -- this pipeline's own default
+wearing the board's name -- and the cap margin would silently drop to
+max(clearance, 0.20).
+
+A FINDING THIS FILE EXISTS FOR. The two harnesses that drive
+`nudge_vias_for_unresolved` with a duck-typed `st` --
+tests/test_370_tierb_fixes.py:377-383 and
+tests/test_617_placement_fanout_hole_clearance.py:243 -- do NOT pin the
+None-fallback at all. Every landing they exercise clears 0.80mm, so a fallback
+of 0.55 passes all five of their arms unchanged. `TestTheDuckTypedPathStaysInert`
+brackets the fallback to (0.20, 0.30] on a rig built for it, because the
+regression a later reader would introduce by "tidying" that line is one nothing
+else would catch.
+
+Conventions this file follows (from #697/#725/#731/#732 and CLAUDE.md):
+
+  * REAL parser dataclasses, and a REAL board wherever the outline matters.
+  * Every assertion names the single-line MUTATION that must kill it.
+  * Assert you are ON the branch before asserting about it.
+  * Every "is refused" is paired with a NEGATIVE CONTROL that still passes.
+  * No fixture sits ON a threshold. Measured: at clearance 0.1 the r=0.05
+    candidate lands 0.34999999999999987 from a 0.35 requirement and is
+    float-rejected, so every rig here keeps >= 0.05mm of headroom.
+
+Runs in-process in a few seconds; nothing here shells out.
+"""
+from __future__ import annotations
+
+RUN_ALL_FAST_OK = True
+RUN_ALL_TIMEOUT = 900
+
+import contextlib
+import inspect
+import io
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+_TESTS = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_TESTS)
+for _p in ('', 'py_router', 'py_placer', 'py_tools'):
+    _d = os.path.join(_ROOT, _p)
+    if _d not in sys.path:
+        sys.path.insert(0, _d)
+if _TESTS not in sys.path:
+    sys.path.insert(0, _TESTS)
+
+from kicad_parser import BoardInfo, PCBData, Segment, Via, parse_kicad_pcb
+from check_drc import (board_edge_geometry, _point_on_board,
+                       _point_to_rings_distance)
+from placement import fanout_clearance as FC
+from placement.fanout_clearance import (CAP_EDGE_CLEARANCE, _Repair,
+                                        nudge_vias_for_unresolved,
+                                        resolve_cap_edge_clearance)
+
+# The inert board (#732's, for the same reason): no netclass, no .kicad_dru, no
+# pad override and NO sibling .kicad_pro, so every pair requirement collapses to
+# `clearance` and the EDGE MARGIN is the only variable this file can move.
+BOARD = os.path.join(_ROOT, 'kicad_files', 'rp2350_fpga_eensy_prePlane.kicad_pcb')
+# The only tracked board with real interior Edge.Cuts rings that also carries no
+# vias of its own, so its outline can be borrowed without foreign copper.
+WATCHY = os.path.join(_ROOT, 'kicad_files', 'watchy.kicad_pcb')
+
+CLEAR = 0.25               # routing_defaults.CLEARANCE, the shipped --clearance
+BEC = 0.55                 # the shipped --board-edge-clearance == CAP_EDGE_CLEARANCE
+VIA_R = 0.25               # a 0.5mm via: needs 0.50 under the old convention and
+                           # 0.80 under the new one -- a 0.30mm band.
+PREFIX = 'C,R,FB'
+FOREIGN = 3
+
+HBAR = (0.2, 0.9, 1.8, 1.1, 2)   # cap pad bar on net 2; the only escape is +y
+
+
+class _FakeCap:
+    """Minimal stand-in for _Cap: fixed pad rects, never moves."""
+
+    def __init__(self, rects):
+        self._rects = rects
+        self.x = self.y = self.rot = 0.0
+
+    def pad_rects(self, x=None, y=None, rot=None):
+        return self._rects
+
+
+class _FakeSt:
+    """The duck-typed `st` the #370/#617 harnesses pass: no resolvers at all.
+
+    `edge_margin` is ABSENT, not None, so `getattr(st, 'edge_margin', None)`
+    takes its default -- the branch TestTheDuckTypedPathStaysInert pins.
+    """
+
+    def __init__(self, rects):
+        self.caps = {'C1': _FakeCap(rects)}
+        self.vias = []
+
+    def graze_penalty(self, ref, cap, x, y, rot):
+        return 1.0          # permanently unresolved, so the offender loop RUNS
+
+
+class _MarginSt(_FakeSt):
+    """...plus the one resolver this issue is about."""
+
+    def __init__(self, rects, margin):
+        super().__init__(rects)
+        self.edge_margin = margin
+
+
+class _SpySt(_FakeSt):
+    """Counts reads of `edge_margin`, so "the nudger READ st" is provable."""
+
+    def __init__(self, rects, margin):
+        super().__init__(rects)
+        self._margin = margin
+        self.reads = 0
+
+    @property
+    def edge_margin(self):
+        self.reads += 1
+        return self._margin
+
+
+def _repair(pcb, bec=BEC, clear=CLEAR, path=BOARD):
+    """The 10-POSITIONAL construction this family uses (#725's shape contract
+    pins the slots); `bec` is argument 5."""
+    return _Repair(pcb, path, clear, 0.1, bec, 1.0, 2.0, 0.8, PREFIX, set())
+
+
+def _bbox_board(top, vias, segments=()):
+    bi = BoardInfo(layers={}, board_bounds=(0.0, 0.0, 2.0, top),
+                   copper_layers=['F.Cu', 'B.Cu'])
+    return PCBData(board_info=bi, nets={},
+                   footprints={'C1': SimpleNamespace(layer='F.Cu', pads=[])},
+                   vias=list(vias), segments=list(segments), pads_by_net={})
+
+
+def _graze_via(x=1.0, y=1.4):
+    return Via(x=x, y=y, size=2 * VIA_R, drill=0.3,
+               layers=['F.Cu', 'B.Cu'], net_id=FOREIGN)
+
+
+def _nudge(st, pcb, clear=CLEAR, **kw):
+    """Drive the real pass, capturing what it printed. The PRINTED OUTPUT is
+    half the evidence: a refusal that prints nothing is indistinguishable from
+    a pass that never looked (the #732 silent-failure lesson)."""
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        moves, segs = nudge_vias_for_unresolved(st, pcb, clear, **kw)
+    return moves, segs, buf.getvalue()
+
+
+def _rig_a(top, st, clear=CLEAR, segments=()):
+    """Bbox rig: one foreign via boxed by a cap bar so its ONLY escape is +y,
+    straight at the top edge. Measured landing is (1.0, 1.600) whenever a move
+    happens at all, so `top - 1.6` IS the edge distance under test. A sideways
+    escape would need r >= 1.3, well past the 0.6mm search budget."""
+    v = _graze_via()
+    pcb = _bbox_board(top, [v], segments)
+    moves, segs, out = _nudge(st, pcb, clear)
+    return v, pcb, moves, segs, out
+
+
+class TestTheBoardEdgeRequirementHasOneResolver(unittest.TestCase):
+    """The invariant #733 is about, on a real board: one number, not two."""
+
+    def test_the_cap_mover_and_the_nudger_read_the_same_margin(self):
+        pcb = parse_kicad_pcb(BOARD)
+        st = _repair(pcb)
+        # ON THE BRANCH: if the two conventions coincided, this whole file
+        # would pass vacuously.
+        self.assertGreater(BEC, CLEAR,
+                           'board_edge_clearance does not exceed clearance, so '
+                           'max() is a no-op and nothing here is under test')
+        self.assertAlmostEqual(st.edge_margin, BEC, places=12,
+                               msg='edge_margin is not max(clearance, bec)')
+        self.assertAlmostEqual(st.edge_margin, st.edge_gate.margin, places=12,
+                               msg='the rect gate and the scalar disagree -- '
+                                   'there are two storages again')
+        b = pcb.board_info.board_bounds
+        self.assertAlmostEqual(st.usable[0] - b[0], st.edge_margin, places=12,
+                               msg='the bbox inset is not the same number')
+        self.assertAlmostEqual(b[2] - st.usable[2], st.edge_margin, places=12)
+    # MUTATION: `return self.edge_gate.margin` -> `return self.clearance`.
+
+    def test_a_clearance_above_the_edge_flag_wins_the_max(self):
+        pcb = parse_kicad_pcb(BOARD)
+        big = _repair(pcb, bec=0.55, clear=0.6)
+        self.assertAlmostEqual(big.edge_margin, 0.6, places=12,
+                               msg='a clearance above the edge flag must win')
+        self.assertAlmostEqual(big.edge_gate.margin, 0.6, places=12)
+        # NEGATIVE CONTROL: below it, the edge flag still governs.
+        small = _repair(pcb, bec=0.55, clear=0.1)
+        self.assertAlmostEqual(small.edge_margin, 0.55, places=12,
+                               msg='the edge flag stopped governing')
+    # MUTATION: `margin = max(clearance, board_edge_clearance)` ->
+    # `margin = board_edge_clearance` -- the first assertion reads 0.55.
+
+    def test_the_nudger_never_gates_below_the_clearance_it_was_called_with(self):
+        """The flat `clearance` argument is this function's own floor: an st
+        must never LOWER the edge test below it.
+
+        Defensive rather than load-bearing, and worth saying so: no LIVE caller
+        can hand the nudger a sub-clearance margin today. `_Repair` is built at
+        one site and its margin is already max(clearance, ...); the margin-ZERO
+        outline gate render_placement builds is a shallow COPY it keeps beside
+        `state.edge_gate` (render_placement.py:275-284), not a `_Repair`. An
+        earlier version of this docstring claimed otherwise and the #733
+        fact-check caught it. A duck-typed st CAN, and this is that."""
+        st = _MarginSt([HBAR], 0.0)
+        # 1.90 - 1.6 = 0.30 of room; max(0.25, 0.0) needs 0.25 + 0.25 = 0.50.
+        _v, _pcb, moves, _segs, out = _rig_a(1.90, st)
+        self.assertIn('no clear spot', out,
+                      'a margin-0 st silently lowered the edge gate below the '
+                      'clearance the caller passed')
+        self.assertEqual(moves, [], 'the via was relocated at a 0.0 margin')
+        # NEGATIVE CONTROL: the same st on a roomier board still moves it, so
+        # the rig is not simply dead.
+        st2 = _MarginSt([HBAR], 0.0)
+        _v2, _pcb2, moves2, _s2, _o2 = _rig_a(2.15, st2)
+        self.assertEqual(len(moves2), 1,
+                         'the margin-0 arm rejects everything; the first '
+                         'assertion proves nothing')
+    # MUTATION: `max(clearance, _edge_m)` -> `_edge_m` -- edge_margin becomes
+    # 0.0, need drops to 0.25 <= 0.30, and the via moves.
+
+
+class TestARelocatedViaHonoursTheBoardEdgeMargin(unittest.TestCase):
+    """edge_ok_point, both signs."""
+
+    def test_a_via_in_the_band_between_the_two_conventions_is_refused(self):
+        """The headline. At top 2.15 the only landing sits 0.550mm from
+        Edge.Cuts: clear under `clearance` (needs 0.500), inside the margin
+        (needs 0.800)."""
+        # ON THE BRANCH: the landing must be IN the band, or this test is a
+        # statement about some other geometry.
+        self.assertTrue(VIA_R + CLEAR <= 0.55 < VIA_R + BEC,
+                        'the landing is not in the band that separates the two '
+                        'conventions (old %.3f, new %.3f)'
+                        % (VIA_R + CLEAR, VIA_R + BEC))
+        v, _pcb, moves, segs, out = _rig_a(2.15, _MarginSt([HBAR], BEC))
+        # The PRINT first: assert the move count first and no mutation can ever
+        # make the silence the reported failure (#732's lesson).
+        self.assertIn('no clear spot', out,
+                      'the pass said nothing about a via it declined to move')
+        self.assertEqual(moves, [], 'the via was relocated into the edge band')
+        self.assertEqual(segs, [], 'connector copper was drawn for no move')
+        self.assertEqual((v.x, v.y), (1.0, 1.4), 'the via was mutated in place')
+        # NEGATIVE CONTROL, same board: without the resolver the old convention
+        # accepts exactly this landing -- which is what #733 reports.
+        v2, _p2, moves2, _s2, out2 = _rig_a(2.15, _FakeSt([HBAR]))
+        self.assertEqual(len(moves2), 1,
+                         'the permissive arm did not move either, so the two '
+                         'conventions are not being separated here')
+        self.assertAlmostEqual(v2.y, 1.6, places=4)
+        self.assertIn('moved', out2)
+    # MUTATION: `need = r + edge_margin` -> `need = r + clearance` -- the via
+    # moves and stdout says "moved" instead of "no clear spot".
+
+    def test_a_via_with_real_room_still_moves_at_the_raised_margin(self):
+        """The over-rejection guard: raising the margin must not simply stop
+        the pass working."""
+        v, _pcb, moves, _segs, out = _rig_a(2.60, _MarginSt([HBAR], BEC))
+        self.assertEqual(len(moves), 1,
+                         'a via with 1.00mm of room was refused at a 0.80mm '
+                         'requirement -- the gate over-rejects')
+        self.assertAlmostEqual(v.y, 1.6, places=4)
+        self.assertIn('moved', out)
+    # MUTATION: `need = r + edge_margin` -> `need = r + 2 * edge_margin`.
+
+
+class TestAConnectorSegmentHonoursTheBoardEdgeMargin(unittest.TestCase):
+    """edge_ok_seg. The connector is copper this pass DRAWS, so it is the half
+    that matters most -- and it is priced on its own half-width."""
+
+    def _rig_b(self, width, st):
+        """Rig A at top 2.60 plus a same-net stub on B.Cu, so the connector is
+        drawn there. B.Cu ON PURPOSE: connector_clear's cap-pad term is
+        layer-gated (cap pads exist only on the cap's own side), so a wide F.Cu
+        connector would be killed by the bar and the edge term never reached.
+        On B.Cu the ONLY live gate is edge_ok_seg -- no board pads, no foreign
+        vias (the moving via is same-net), no foreign segments, no NPTH."""
+        stub = Segment(start_x=1.0, start_y=1.6, end_x=1.0, end_y=1.4,
+                       width=width, layer='B.Cu', net_id=FOREIGN)
+        return _rig_a(2.60, st, segments=[stub])
+
+    def test_a_wide_connector_is_gated_on_its_own_half_width_plus_the_margin(self):
+        # ON THE BRANCH: the POINT test passes at this board size, so a refusal
+        # here is attributable to edge_ok_seg and to nothing else.
+        self.assertGreaterEqual(2.60 - 1.6, VIA_R + BEC,
+                                'the via itself does not clear the margin, so '
+                                'edge_ok_point could be doing the rejecting')
+        self.assertLess(2.60 - 1.6, 1.2 / 2.0 + BEC,
+                        'a 1.2mm connector already clears the margin; this rig '
+                        'separates nothing')
+        _v, _pcb, moves, segs, out = self._rig_b(1.2, _MarginSt([HBAR], BEC))
+        self.assertIn('no clear spot', out,
+                      'the pass said nothing about a connector it declined')
+        self.assertEqual(moves, [], 'the via moved despite an illegal connector')
+        self.assertEqual(segs, [])
+        # NEGATIVE CONTROL: the old convention draws exactly that connector.
+        _v2, _p2, moves2, segs2, _o2 = self._rig_b(1.2, _FakeSt([HBAR]))
+        self.assertEqual(len(moves2), 1)
+        self.assertEqual([(s['layer'], s['width']) for s in segs2],
+                         [('B.Cu', 1.2)],
+                         'the permissive arm did not draw the wide connector, '
+                         'so the two conventions are not being separated')
+    # MUTATION: `need = hw + edge_margin` -> `need = hw + clearance`.
+
+    def test_a_narrow_connector_on_the_same_board_still_moves(self):
+        """Isolates the half-width term: without this, a gate that ignored `hw`
+        entirely would still pass the test above."""
+        _v, _pcb, moves, segs, _out = self._rig_b(0.2, _MarginSt([HBAR], BEC))
+        self.assertEqual(len(moves), 1,
+                         'a 0.2mm connector with 1.00mm of room was refused')
+        self.assertEqual([(s['layer'], s['width']) for s in segs],
+                         [('B.Cu', 0.2)])
+    # MUTATION: `need = hw + edge_margin` -> `need = 2 * hw + edge_margin`
+    # over-rejects and this move disappears.
+
+
+class TestTheRealOutlineBranch(unittest.TestCase):
+    """Both helpers have a rings branch and a bbox branch. The tests above
+    exercise the bbox one; this exercises the rings one on real Edge.Cuts."""
+
+    def _watchy(self):
+        bi = parse_kicad_pcb(WATCHY).board_info
+        rings, outer, cutouts = board_edge_geometry(bi)
+        # Derived, never hard-coded: a watchy re-export must not silently
+        # un-calibrate this fixture.
+        cut_y = max(y for _x, y in cutouts[0])
+        return bi, rings, outer, cutouts, cut_y
+
+    def _run(self, st):
+        bi, rings, outer, cutouts, cut_y = self._watchy()
+        v = Via(x=85.0, y=cut_y + 0.95, size=2 * VIA_R, drill=0.3,
+                layers=['F.Cu', 'B.Cu'], net_id=FOREIGN)
+        bar = (84.2, cut_y + 1.25, 85.8, cut_y + 1.45, 2)
+        pcb = PCBData(board_info=bi, nets={},
+                      footprints={'C1': SimpleNamespace(layer='F.Cu', pads=[])},
+                      vias=[v], segments=[], pads_by_net={})
+        st = st([bar]) if st is _FakeSt else st([bar], BEC)
+        moves, segs, out = _nudge(st, pcb)
+        return v, moves, out, rings, outer, cutouts, bi
+
+    def test_a_via_beside_a_real_milled_slot_is_refused_at_the_board_margin(self):
+        # NEGATIVE CONTROL FIRST, because it establishes the geometry the
+        # positive assertion depends on.
+        v, moves, out, rings, outer, cutouts, bi = self._run(_FakeSt)
+        self.assertTrue(rings, 'watchy yielded no rings -- this is the bbox '
+                               'branch again, not the outline branch')
+        self.assertEqual(len(moves), 1,
+                         'the permissive arm did not move; nothing to compare')
+        d = _point_to_rings_distance(v.x, v.y, rings)
+        self.assertTrue(_point_on_board(v.x, v.y, outer, cutouts),
+                        'the permissive arm parked the via off the board, '
+                        'which is a different bug from the one under test')
+        # ON THE BRANCH, twice over: the landing is in the band, AND the bbox
+        # branch would happily accept it -- so the rings are what reject it.
+        self.assertTrue(VIA_R + CLEAR <= d < VIA_R + BEC,
+                        'the landing is %.4f from Edge.Cuts, not in the band '
+                        '(%.3f, %.3f)' % (d, VIA_R + CLEAR, VIA_R + BEC))
+        b = bi.board_bounds
+        self.assertGreater(min(v.x - b[0], b[2] - v.x, v.y - b[1], b[3] - v.y),
+                           VIA_R + BEC,
+                           'the bounding box alone would also reject this '
+                           'point, so the ring geometry proves nothing')
+        v2, moves2, out2, *_ = self._run(_MarginSt)
+        self.assertIn('no clear spot', out2)
+        self.assertEqual(moves2, [],
+                         'the via was parked %.4fmm from a real milled slot' % d)
+    # MUTATION: `need = r + edge_margin` -> `need = r + clearance` in the RING
+    # branch -- the via is parked 0.719mm from Edge.Cuts.
+
+
+class TestTheDuckTypedPathStaysInert(unittest.TestCase):
+    """#370/#617 pass an st with no resolvers. Their fixtures do NOT pin the
+    fallback -- every landing they exercise clears 0.80mm -- so it is pinned
+    here or nowhere."""
+
+    def test_the_fallback_is_exactly_the_clearance_argument(self):
+        st = _FakeSt([HBAR])
+        # ON THE BRANCH: the fake must not have grown a margin.
+        self.assertIsNone(getattr(st, 'edge_margin', None),
+                          'the fake carries a margin, so the fallback branch '
+                          'is never taken and this test is vacuous')
+        # Bracket it. 2.15 leaves 0.55 of room and needs fallback + 0.25 <= 0.55;
+        # 2.05 leaves 0.45 and must still refuse. Together the fallback is pinned
+        # to the OPEN interval (0.20, 0.30) -- open at BOTH ends, measured: 0.30
+        # itself fails the 2.15 arm, because the bbox branch has no -1e-6
+        # tolerance where the rings branch does. CLEAR is 0.25, comfortably
+        # inside. This BRACKETS the fallback; it does not prove it EQUALS
+        # `clearance`, and an earlier version of this docstring overclaimed
+        # that. What it rules out is the regression that matters: a 0.55
+        # fallback, which neither #370 nor #617 would notice.
+        _v, _p, moves_hi, _s, _o = _rig_a(2.15, _FakeSt([HBAR]))
+        self.assertEqual(len(moves_hi), 1,
+                         'the fallback is above 0.30 -- a 0.55 fallback lands '
+                         'here, and neither #370 nor #617 would notice')
+        _v2, _p2, moves_lo, _s2, _o2 = _rig_a(2.05, _FakeSt([HBAR]))
+        self.assertEqual(moves_lo, [],
+                         'the fallback is at or below 0.20 -- lower than the '
+                         'clearance the caller passed')
+        # ...and an st that declares exactly CLEAR is indistinguishable from an
+        # st with no margin at all, on every arm.
+        for top in (2.05, 2.15, 2.60):
+            a = _rig_a(top, _FakeSt([HBAR]))[2]
+            b = _rig_a(top, _MarginSt([HBAR], CLEAR))[2]
+            self.assertEqual(len(a), len(b),
+                             'the absent-margin path and an explicit %s '
+                             'diverge at top %s' % (CLEAR, top))
+    # MUTATION: `getattr(st, 'edge_margin', None)` -> `..., 0.55)` -- the 2.15
+    # arm gives 0 moves. Verified: NEITHER #370 NOR #617 catches this.
+
+    def test_the_nudger_reads_st_s_margin_rather_than_recomputing_it(self):
+        st = _SpySt([HBAR], BEC)
+        _v, _p, moves, _s, out = _rig_a(2.15, st)
+        self.assertEqual(st.reads, 1,
+                         'edge_margin was read %d times; the #725 shim block '
+                         'reads each resolver exactly once, outside the '
+                         'candidate sweep' % st.reads)
+        # Paired with the behavioural half, so a mutant that reads the value
+        # and then discards it is caught too.
+        self.assertEqual(moves, [], 'the value was read but not used')
+        self.assertIn('no clear spot', out)
+    # MUTATION: `edge_margin = clearance` (ignore st) -> reads == 0 AND the
+    # via moves.
+
+    def test_no_edge_test_in_the_nudger_spells_the_bare_clearance(self):
+        """Guards the two sites by spelling as well as behaviour, because a
+        third edge test could be added tomorrow with the old convention."""
+        src = inspect.getsource(FC.nudge_vias_for_unresolved).splitlines()
+        bad = [f'{i + 1}: {ln.strip()}' for i, ln in enumerate(src)
+               if 'need = ' in ln and 'edge_margin' not in ln]
+        self.assertEqual(bad, [],
+                         'an edge test still gates on something other than '
+                         'edge_margin: %s' % bad)
+        # ON THE BRANCH: the resolver is read at all.
+        self.assertTrue(any('edge_margin' in ln for ln in src),
+                        'the nudger does not mention edge_margin, so the guard '
+                        'above is vacuously satisfied')
+    # MUTATION: re-introduce `need = r + clearance` at either site.
+
+
+class TestTheEdgeMarginResolver(unittest.TestCase):
+    """resolve_cap_edge_clearance: tighten-only, and every branch reachable."""
+
+    def _board_declaring(self, tmp, value, name):
+        pcb = os.path.join(tmp, name + '.kicad_pcb')
+        shutil.copyfile(BOARD, pcb)
+        with open(os.path.splitext(pcb)[0] + '.kicad_pro', 'w',
+                  encoding='utf-8') as f:
+            json.dump({'board': {'design_settings': {
+                'rules': {'min_copper_edge_clearance': value}}}}, f)
+        return pcb
+
+    def test_an_explicit_positive_value_is_honoured_in_both_directions(self):
+        self.assertEqual(resolve_cap_edge_clearance(BOARD, 0.2),
+                         (0.2, 'cli'),
+                         'an operator asking for LESS was overridden')
+        self.assertEqual(resolve_cap_edge_clearance(BOARD, 0.9),
+                         (0.9, 'cli'))
+    # MUTATION: drop the `if explicit is not None and explicit > 0` early return.
+
+    def test_an_explicit_ZERO_is_unset_rather_than_a_margin_of_zero(self):
+        """The footgun the #733 review found in this change: the GUI's Min Edge
+        Clearance spin is CREATED at defaults.BOARD_EDGE_CLEARANCE (0.0) with a
+        range minimum of 0.0, so "ticked the override, typed nothing" hands this
+        a 0. Honoured literally, the cap margin would fall to max(clearance, 0)
+        -- the bare clearance -- which is the 0.30mm under-block #733 closes,
+        re-opened through a different door and LOOSER than the plugin's old
+        0.55. Same rule resolve_cli_floor applies to every routing floor."""
+        for zero in (0, 0.0, -0.1):
+            self.assertEqual(
+                resolve_cap_edge_clearance(BOARD, zero),
+                (CAP_EDGE_CLEARANCE, 'fixed default'),
+                'an explicit %r was taken as a real margin' % (zero,))
+        # NEGATIVE CONTROL: a small POSITIVE value is still honoured, so the
+        # guard has not swallowed the operator's override wholesale.
+        self.assertEqual(resolve_cap_edge_clearance(BOARD, 0.01),
+                         (0.01, 'cli'))
+    # MUTATION: `explicit is not None and explicit > 0` -> `explicit is not
+    # None` -- the 0 arms return (0.0, 'cli').
+
+    def test_a_board_asking_for_more_room_raises_the_margin(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            pcb = self._board_declaring(tmp, 0.9, 'roomy')
+            # ON THE BRANCH: the declaration must exceed the default, or this
+            # is the fixed-default branch wearing a different name.
+            self.assertGreater(0.9, CAP_EDGE_CLEARANCE)
+            self.assertEqual(resolve_cap_edge_clearance(pcb),
+                             (0.9, 'board constraint, raised'))
+    # MUTATION: `declared > CAP_EDGE_CLEARANCE` -> `declared is not None`
+    # still passes here; it is the NEXT test that kills that one.
+
+    def test_a_board_asking_for_less_can_never_lower_the_margin(self):
+        """The reason this is tighten-only. 0.20 is not hypothetical: it is the
+        fab copper-to-edge floor fix_project_for_output PINS into every board
+        this pipeline writes, so a plainly board-first read would take this
+        pipeline's own default back as the board's declaration."""
+        with tempfile.TemporaryDirectory() as tmp:
+            for value in (0.2, 0.5, 0.0):
+                pcb = self._board_declaring(tmp, value, 'tight%s' % value)
+                self.assertEqual(
+                    resolve_cap_edge_clearance(pcb),
+                    (CAP_EDGE_CLEARANCE, 'fixed default'),
+                    'a declared %s LOWERED the cap margin' % value)
+    # MUTATION: `declared > CAP_EDGE_CLEARANCE` -> `declared is not None and
+    # declared > 0` -- the 0.2 and 0.5 arms drop the margin.
+
+    def test_a_board_with_no_project_and_an_unreadable_one_take_the_default(self):
+        self.assertEqual(resolve_cap_edge_clearance(BOARD),
+                         (CAP_EDGE_CLEARANCE, 'fixed default'))
+        # ON THE BRANCH: BOARD really has no sibling project, or the assertion
+        # above is testing the wrong branch.
+        self.assertFalse(
+            os.path.exists(os.path.splitext(BOARD)[0] + '.kicad_pro'),
+            'the inert board grew a .kicad_pro; pick another')
+        # Not a path at all -- an unsaved GUI board reaches this.
+        self.assertEqual(resolve_cap_edge_clearance(None),
+                         (CAP_EDGE_CLEARANCE, 'fixed default'))
+    # MUTATION: remove the try/except -> the None case raises TypeError.
+
+    def test_the_engine_resolves_an_omitted_margin_and_says_so(self):
+        """The default is None, and the ENGINE resolves it -- which is what
+        makes the CLI, the plugin and the animator agree without any of them
+        carrying a copy."""
+        import placement.fanout_clearance as mod
+        sig = inspect.signature(mod.repair_fanout_clearance)
+        self.assertIsNone(sig.parameters['board_edge_clearance'].default,
+                          'the engine still carries a numeric default, so a '
+                          'front end that passes nothing gets it silently')
+        pcb = parse_kicad_pcb(BOARD)
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            mod.repair_fanout_clearance(pcb, BOARD, clearance=CLEAR,
+                                        max_displacement=0.0, max_passes=1)
+        self.assertIn('board-edge margin for caps: 0.55mm (fixed default)',
+                      buf.getvalue(),
+                      'the engine resolved the margin without disclosing it')
+        # ...and it discloses an EXPLICIT one too. Printing only the resolved
+        # case would disclose exactly the branch that needs no explaining, and
+        # an operator reading a transcript would have to know which of three
+        # fronts invoked this to know which margin it used.
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            mod.repair_fanout_clearance(pcb, BOARD, clearance=CLEAR,
+                                        board_edge_clearance=0.2,
+                                        max_displacement=0.0, max_passes=1)
+        self.assertIn('board-edge margin for caps: 0.2mm (cli)', buf.getvalue(),
+                      'a caller-supplied margin is applied silently')
+
+    def test_the_resolved_margin_actually_reaches_the_repair_state(self):
+        """The wire, not the report. Everything else here either constructs
+        _Repair directly with an explicit margin or reads the PRINTED line, so
+        a build that resolved the margin, printed it, and then handed _Repair
+        the UNRESOLVED value would pass the lot -- the "asserts a reported
+        value rather than the one used" hole the #733 fact-check went looking
+        for. Spy on the constructor and read what it was actually given."""
+        import placement.fanout_clearance as mod
+        seen = []
+        real = mod._Repair
+
+        class _Spy(real):
+            def __init__(self, pcb, path, clearance, grid_step, bec, *a, **kw):
+                seen.append(bec)
+                super().__init__(pcb, path, clearance, grid_step, bec, *a, **kw)
+
+        pcb = parse_kicad_pcb(BOARD)
+        mod._Repair = _Spy
+        try:
+            with contextlib.redirect_stdout(io.StringIO()):
+                mod.repair_fanout_clearance(pcb, BOARD, clearance=CLEAR,
+                                            max_displacement=0.0, max_passes=1)
+                mod.repair_fanout_clearance(parse_kicad_pcb(BOARD), BOARD,
+                                            clearance=CLEAR,
+                                            board_edge_clearance=0.9,
+                                            max_displacement=0.0, max_passes=1)
+        finally:
+            mod._Repair = real
+        # ON THE BRANCH: the spy must have run, or `seen` is empty and every
+        # assertion below is vacuously true.
+        self.assertEqual(len(seen), 2, 'the _Repair spy never ran')
+        self.assertEqual(seen[0], CAP_EDGE_CLEARANCE,
+                         'the omitted margin was RESOLVED and PRINTED but '
+                         '%r reached _Repair' % (seen[0],))
+        self.assertEqual(seen[1], 0.9,
+                         'an explicit margin did not reach _Repair')
+    # MUTATION: pass `board_edge_clearance` (the parameter) to _Repair instead
+    # of the resolved value -> seen[0] is None and this is the only test that
+    # notices.
+    # MUTATION: `board_edge_clearance: Optional[float] = None` -> `= 0.55`.
+
+
+class TestTheFrontEndsDoNotCarryTheirOwnCopy(unittest.TestCase):
+    """#733's other two facts: the CLI hardcoded 0.55 and the GUI passed
+    nothing at all. Both must now defer to the engine."""
+
+    def test_the_two_clis_default_to_none_so_the_engine_resolves(self):
+        # assertTrue on a computed boolean, never assertIn against a whole
+        # file: a failing assertIn prints the ENTIRE haystack, and a 100KB
+        # failure message buries the one line that matters (#732's lesson).
+        for script in ('py_placer/place_fanout_clearance.py',
+                       'py_tools/animate_fanout_clearance.py'):
+            with open(os.path.join(_ROOT, script), encoding='utf-8') as f:
+                src = f.read()
+            self.assertTrue(
+                '"--board-edge-clearance", type=float, default=None' in src,
+                '%s still carries its own numeric edge default' % script)
+    # MUTATION: put `default=0.55` back in either script.
+
+    def test_the_plugin_passes_the_margin_to_the_engine(self):
+        with open(os.path.join(_ROOT, 'kicad_routing_plugin', 'fanout_gui.py'),
+                  encoding='utf-8') as f:
+            src = f.read()
+        self.assertTrue(
+            "board_edge_clearance=fanout_config.get('cap_board_edge_clearance')"
+            in src,
+            'the plugin does not pass the cap edge margin, so it takes the '
+            'engine signature default whatever the operator asked for')
+        # ...and the key is actually populated, on BOTH entry points.
+        self.assertEqual(
+            src.count("'cap_board_edge_clearance': shared.get("), 2,
+            'only one of the two GUI entry points populates the key')
+        # NEGATIVE CONTROL, and the trap this design had to avoid: the QFN
+        # SIGNAL keep-out is a DIFFERENT key that answers 0.0 on a board with
+        # no edge rule (fab-floored to 0.20 by _effective_board_edge_clearance)
+        # and also feeds update_live_drc_floors. Reusing it would have inset
+        # caps at 0.20 instead of 0.55 -- a 0.35mm relaxation shipped inside
+        # the parity fix. Measured on the real headless dialog: unchecked, the
+        # signal key reads 0.2 and the cap key reads None.
+        self.assertTrue(
+            "board_edge_clearance=shared.get('board_edge_clearance', 0.0)"
+            in src,
+            'the QFN signal keep-out kwarg changed; the cap margin was meant '
+            'to be a SEPARATE key and this control no longer proves it is')
+    # MUTATION: drop the board_edge_clearance kwarg from the engine call.
+
+    def test_a_recorded_manifest_carries_an_explicit_flag_into_the_plan(self):
+        sys.path.insert(0, os.path.join(_TESTS, 'stress'))
+        import manifest_to_plan as M
+        step = M.cap_optimization_step(
+            ['py_placer/place_fanout_clearance.py', 'b.kicad_pcb',
+             '--board-edge-clearance', '0.3', '--near-margin', '1.5'])
+        self.assertEqual(step['params'].get('board_edge_clearance'), 0.3,
+                         'an explicit --board-edge-clearance is dropped on '
+                         'replay, so the GUI plan routes at a different margin')
+        # ON THE BRANCH: the converter is doing real work, not returning {}.
+        self.assertEqual(step['params'].get('cap_near_margin'), 1.5)
+        # ...and the param name is one the plan executor can apply.
+        with open(os.path.join(_ROOT, 'kicad_routing_plugin', 'ai_plan.py'),
+                  encoding='utf-8') as f:
+            src = f.read()
+        self.assertTrue("'board_edge_clearance': 'edge_clearance_check'" in src,
+                        'the plan executor has no override checkbox for this '
+                        'param, so a plan carrying it would set a disabled '
+                        'control and the value would be ignored')
+    # MUTATION: remove the CAP_FLAG_PARAMS row.
+
+
+class TestTheCorpusBound(unittest.TestCase):
+    """What the change can and cannot reach on boards this repo can measure."""
+
+    def _tracked(self):
+        # EVERY tracked board, not just kicad_files/ -- five more live under
+        # tests/fixtures/, and an earlier version of this scan missed them while
+        # the PR called its result "the tracked corpus".
+        out = subprocess.run(['git', 'ls-files', '*.kicad_pcb'],
+                             cwd=_ROOT, capture_output=True, text=True)
+        return [os.path.join(_ROOT, p) for p in out.stdout.split()
+                if p.endswith('.kicad_pcb')]
+
+    def test_no_tracked_board_carries_a_milled_ring_this_change_could_refuse(self):
+        """The cap mover exempts a milled ring a cap's own pads sit in (#628);
+        the nudger has no analogue, because that exemption exists for a
+        COURTYARD RECT artifact a via does not have. Bound the asymmetry: it is
+        unreachable on every tracked board. When that stops being true this
+        test fails, which is the point."""
+        boards = self._tracked()
+        self.assertGreater(len(boards), 25,
+                           'git ls-files returned %d boards -- never glob the '
+                           'directory, 11 boards in kicad_files/ alone are '
+                           'gitignored build products' % len(boards))
+        milled, ringed = [], []
+        for b in boards:
+            bi = parse_kicad_pcb(b).board_info
+            if [c for c in (getattr(bi, 'board_edge_contours', None) or [])
+                    if len(c) >= 3]:
+                milled.append(os.path.basename(b))
+            rings, _o, _c = board_edge_geometry(bi)
+            if rings:
+                ringed.append(os.path.basename(b))
+        self.assertEqual(milled, [],
+                         'a tracked board now carries a milled contour (%s) -- '
+                         'the "#628 asymmetry is unreachable" claim in the PR '
+                         'must be re-measured' % milled)
+        # ON THE BRANCH: some boards DO yield rings, so the scan is real.
+        self.assertTrue(ringed, 'no tracked board yielded any Edge.Cuts ring, '
+                                'so this scan proves nothing')
+    # MUTATION: add a milled Edge.Cuts contour to any tracked board.
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/test_736_fanout_clearance_regrade_view.py
+++ b/tests/test_736_fanout_clearance_regrade_view.py
@@ -104,13 +104,20 @@ Conventions this file follows (#697/#725/#731/#732/#733/#737 and CLAUDE.md):
         mutations -- dropping `_item_reach`, and omitting the floor map --
         cancel and both survive.
 
-MUTATION BATTERY: 18 single-line mutations of the fix, 18 killed, each named
+MUTATION BATTERY: 22 single-line mutations of the fix, 22 killed, each named
 by the arm that kills it under `TestOneConstructionSiteOnePrunePredicate`. Two
 false-positive probes -- a trailing comment naming a guarded literal, and a
 comment line naming the pricing spelling -- are correctly inert.
 
-Two of the eighteen exist because the FIRST run of that battery let them
-through, and both are recorded rather than quietly fixed:
+Four of the twenty-two (19-22) exist because an adversarial review of this
+branch found a defect the fix INTRODUCED: `required_rows` grades the seed pose
+as well as the final one, and a connector the pass DREW did not exist at the
+seed, so charging it there invented a `track <net>` row describing a pair no
+board ever had -- the same class of phantom #731 removed from that very report.
+`TestTheSeedHalfOfTheDisclosureIgnoresPassCreatedCopper` is that finding.
+
+Two more exist because the FIRST run of the battery let them through, and both
+are recorded rather than quietly fixed:
 
   * `if via_moves:` -> `if True:` changes no NUMBER, because the via prune is
     exact and de-pruning grades identically. The first version of
@@ -218,6 +225,15 @@ DECL_CLASS = [{'name': 'Default', 'clearance': 0.2, 'track_width': 0.2,
 DECL_LC = 0.5               # a pad override, so pair() != _item_reach()
 DECL_T5 = 0.35              # HW + _item_reach(seg floor)  = 0.15 + max(0.1,0.2)
 DECL_EFF = 0.65             # HW + pair(cap floor, seg floor) = 0.15 + 0.5
+
+# A connector hugging C1's SEED pads: 0.100 off pad 2's seed edge against the
+# 0.650 declared keep-out, so it IS charged there -- and 1.900 clear of the
+# pads once the cap has walked SEED_HUG_WALK away, so it is NOT charged at the
+# pose the pass left it in. That asymmetry is the whole of the seed-half
+# disclosure defect an adversarial review found in this branch.
+SEED_HUG = {'start': (10.90, CAP_XY[1]), 'end': (11.05, CAP_XY[1]),
+            'width': TRACK_W, 'layer': 'F.Cu', 'net_id': NET_V}
+SEED_HUG_WALK = 2.5
 
 
 def _bga():
@@ -665,6 +681,58 @@ class TestTheRefreshIsSkippedWhenNothingMoved(unittest.TestCase):
     # asserted only the track half and the mutation SURVIVED the battery.
 
 
+class TestTheSeedHalfOfTheDisclosureIgnoresPassCreatedCopper(unittest.TestCase):
+    """`required_rows` grades `_seg_shortfalls` at the SEED pose as well as the
+    final one -- deliberately, so that a pass which SUCCEEDS still discloses
+    the raised requirement that did the work.
+
+    A connector this pass DREW did not exist at the seed. Charging it there
+    invents a `track <net>` row describing a pair no board ever had, which is
+    exactly the class of phantom #731 removed from this very report. Measured
+    on the rig below before the scope was added: `{3: 0.550}` charged at the
+    seed against `{}` at the final pose -- 0.650 (the declared eff cell) minus
+    the 0.100 the connector sits off pad 2's SEED edge.
+
+    Found by an adversarial review of this branch, not by me.
+    """
+
+    def test_a_connector_hugging_the_SEED_pads_produces_no_track_row(self):
+        with _stub(DECL_CLASS) as path:
+            pcb, v = _board(VIA_CLEAR, 'F.Cu', lc=DECL_LC)
+            st = _Repair(pcb, path, CLEAR, 0.1, 0.55, 1.0, 2.0, 0.3, 'C',
+                         set())
+            self.assertIsNotNone(st._floors, 'an INERT board discloses '
+                                             'nothing, so this arm would pass '
+                                             'on an empty report')
+            cap = st.caps['C1']
+            seed_n = st._seed_seg_n['C1']
+            cap.x = cap.seed_x - SEED_HUG_WALK      # the pose the pass left
+            self.assertEqual(st.register_new_segments([SEED_HUG]), 1)
+            self.assertEqual(len(st.cap_segs['C1']), seed_n + 1)
+
+            # ON THE BRANCH: the fixture really does reach the phantom -- the
+            # connector is charged at the seed pose over ALL copper, and clear
+            # at the pose the cap is actually in.
+            self.assertEqual(
+                st._seg_shortfalls('C1', cap, cap.x, cap.y, cap.rot), {})
+            self.assertIn(
+                NET_V, st._seg_shortfalls('C1', cap, cap.seed_x, cap.seed_y,
+                                          cap.seed_rot))
+            # ...and scoped to the seed-era copper it is not
+            self.assertEqual(
+                st._seg_shortfalls('C1', cap, cap.seed_x, cap.seed_y,
+                                   cap.seed_rot, upto=seed_n), {})
+
+            tracks = [r for r in st.required_rows({})
+                      if str(r[1]).startswith('track ')]
+            self.assertEqual(tracks, [],
+                             'the disclosure names a track pair that exists '
+                             'on neither the seed board nor the final one')
+    # MUTATION: drop the `upto` slice from _seg_shortfalls; record
+    # _seed_seg_n AFTER the append instead of in __init__; pass no seed_kw to
+    # both() for the track kind.
+
+
 class TestThePruneIsAnchoredOnTheSEEDPose(unittest.TestCase):
     """By the time a connector is registered the caps have already moved, so
     `_prune_segs` is handed `self._cap_geom` -- the SEED-pose geometry -- and
@@ -722,7 +790,7 @@ class TestOneConstructionSiteOnePrunePredicate(unittest.TestCase):
     are REPORTED; never `assertIn` over the whole source (#732 measured a
     393KB failure message from that).
 
-    THE BATTERY, as RUN: 18 mutations, 18 killed, plus two inert probes.
+    THE BATTERY, as RUN: 22 mutations, 22 killed, plus two inert probes.
 
       1  delete the refresh call ............ graze_penalty_RISES + 3 others
       2  call it BEFORE the nudge ........... graze_penalty_RISES + 3 others
@@ -742,10 +810,16 @@ class TestOneConstructionSiteOnePrunePredicate(unittest.TestCase):
       16 drop the distance filter ........... prune_predicate_has_ONE_spelling
       17 make the refresh unconditional ..... RefreshIsSkippedWhenNothingMoved
       18 prune from the MOVED pose .......... PruneIsAnchoredOnTheSEEDPose
+      19 ignore the `upto` seed scope ....... SeedHalfIgnoresPassCreatedCopper
+      20 record `_seed_seg_n` after the append  same
+      21 grade the seed half over ALL copper .. same
+      22 registrar reports the wrong count ... same
 
-    10, 11, 15, 16, 17 and 18 have exactly ONE killer each; the module
-    docstring records that 17 and 18 SURVIVED the first run of this battery and
-    what was added to catch them.
+    TEN of them -- 10, 11, 15, 16, 17, 18 and each of 19-22 -- have exactly
+    ONE killer, which is why those arms exist at all; the
+    module docstring records that 17 and 18 SURVIVED the first run of this
+    battery, and that 19-22 exist because a review found a defect the fix
+    itself introduced.
 
     INERT PROBES, which must change nothing: a trailing comment naming
     `self._seg_floor_by_id[`, and a comment line naming the pricing spelling

--- a/tests/test_736_fanout_clearance_regrade_view.py
+++ b/tests/test_736_fanout_clearance_regrade_view.py
@@ -1,0 +1,954 @@
+"""#736: the post-nudge re-grade must see the copper the pass itself drew.
+
+`repair_fanout_clearance` ends by asking `nudge_vias_for_unresolved` to move
+offending vias, then re-grades to produce the final `unresolved` list. The
+nudger does TWO things to the board: it moves vias, and it APPENDS new
+connector `Segment`s to `pcb_data.segments` to restore continuity back to each
+moved via's stub start.
+
+The re-grade refreshed only the via view (`st.cap_vias = {r: st.vias ...}`).
+`st.segments`, `st.cap_segs` and `st._seg_floor_by_id` were snapshotted in
+`_Repair.__init__`, before those connectors existed, and nothing rebuilt them --
+so `_seg_shortfalls`, the PAD-SEGMENT channel of `graze_penalty`, and
+`required_rows`' disclosure both read a stale track view. Both front ends WRITE
+that copper (placement/writer.py on the CLI, the plugin's pcbnew mirror in the
+GUI), so the summary is a statement about a board that already carries it.
+
+THE HEADLINE, measured on the rig below at `--clearance 0.1` and graded by the
+AUTHORITATIVE checker rather than by the repair pass's own grader:
+
+    arm B  through-hole cap pads, connector on B.Cu
+      before   1 via move, 1 connector, `unresolved == []`      <- RESOLVED
+      after    same move, same connector, `unresolved == ['C1']`
+      check_drc.check_pad_segment_overlap(C1.2, the connector)
+               -> violation, overlap 0.1200mm
+
+That overlap IS the requirement: the connector's copper reaches 0.020mm INSIDE
+the pad (0.130 centre-gap minus its 0.150 half-width), and the repair's own
+grader charges the same 0.1200.
+
+WHICH WINDOW THIS RUNS THROUGH, stated precisely because the obvious reading is
+wrong. On the connector's OWN layer the draw gate and the accept gate are the
+same number -- `connector_clear` charges `hw + req(pfl, cfl)` and `_seg_effs`
+charges `halves[j] + _pair_or_flat(fa, floors[j])` with `halves[j] == hw`, the
+same two floors through the same resolver -- and `connector_clear` is the
+STRICTER of the two, by EPS. So an ACCEPTED same-layer connector can never be
+charged here, and `TestTheDrawGateAndTheGraderAgreeOnTheSameLayer` measures
+that rather than asserting it. Two windows remain:
+
+  * arm B, the #738 window: `connector_clear` scopes a cap pad by the
+    FOOTPRINT's side (`cl != layer`), so it never tests a back-side or
+    inner-layer connector against a THROUGH-HOLE cap pad, whose copper spans
+    every layer. This is a REAL violation -- check_drc agrees, above.
+  * arm C, a window #738's own proposed fix does NOT close: a connector on a
+    layer absent from `_all_cu` is charged by `_seg_shares` (which charges an
+    unknown layer on purpose) while `connector_clear` skips it. Measured
+    identical numbers to arm B with no through-hole pad anywhere -- BUT
+    check_drc grades that pair CLEAN. It is the module's documented
+    over-block, not a shipped violation, and its test says so.
+
+An earlier draft of this file had that backwards and called arm C the durable
+demonstration of a shipped violation. It is durable; it is not a violation.
+
+WHY THE RIG IS SYNTHETIC. Measured over the 22 boards `git ls-files
+kicad_files/*.kicad_pcb` returns, at `--clearance` 0.25 and 0.10: 2 run the
+full pass, 1 reaches the via-nudger, and **0 emit a connector**. The one in-repo
+configuration that does is the FALLBACK-OFF leg of the frozen sweep
+`test_fanout_clearance.py` uses -- orangecrab_ext_pll at 0.10, 9 via moves and
+17 connectors on B.Cu / F.Cu / In1.Cu / In2.Cu -- and after the fix all 17
+enter the grader's view and NOTHING changes (`unresolved` 10 -> 10, every
+per-cap shortfall `{}`). Both facts are asserted by
+`TestInertOnTheTrackedCorpus`, the second so the first cannot be a statement
+about unreachable code.
+
+Which leg, precisely, because the obvious answer is wrong: that test runs both,
+and `via_clear_fallback=False` is the load-bearing flag. With the fallback ON
+the same board reports 0 unresolved, so the nudger is never called at all -- 0
+moves, 0 connectors. `allow_rotations` makes no difference either way.
+Measured, all four combinations.
+
+THE ZONE IS THE TRICK. `conn_layers` can be fed by a same-net segment, a
+via-in-pad pad, or a ZONE. A stub `Segment` terminating at the via necessarily
+starts inside the cap's keep-out on its own layer and destroys the isolation; a
+via-in-pad `Pad` enters `foreign_pads` and charges the pad channel.
+`_Repair.__init__` reads `pcb_data.zones` NOWHERE -- the module's only read is
+inside `nudge_vias_for_unresolved`'s pour-tie loop -- so a zone carries the
+connector's LAYER in as a free parameter while leaving every keep-out channel
+empty. The board therefore has ZERO segments until the connector exists, and
+every arm's seed `seg_penalty` is exactly 0.0000.
+
+Conventions this file follows (#697/#725/#731/#732/#733/#737 and CLAUDE.md):
+
+  * REAL parser dataclasses, and a real file on disk -- `_Repair.__init__`
+    reads courtyards, locked refs and the clearance model from `pcb_file`.
+  * Every assertion names the single-line MUTATION that must kill it.
+  * Assert you are ON THE BRANCH before asserting about it.
+  * Every "is refused" is paired with a NEGATIVE CONTROL that still moves, and
+    every "is charged" with one that is drawn and correctly NOT charged.
+  * A refusal is asserted from the PRINTED OUTPUT before the counts -- a
+    refusal that prints nothing is indistinguishable from a pass that never
+    looked (#732's silent-failure lesson).
+  * No fixture sits within 0.05mm of the quantity its assertion measures. The
+    two gaps are 0.130 and 0.375 against a 0.250 keep-out, i.e. 0.120 and 0.125
+    of margin. THREE tighter boundaries exist and are named here rather than
+    left for a reviewer to find:
+      - the landing (11.330) clears the VIA keep-out (11.300) by 0.030. That is
+        the spiral's own 0.05mm radial quantum, and no assertion measures it --
+        the landings are asserted EXACTLY, so they are change detectors for
+        precisely that.
+      - C2's probe pose sits 0.100 past the plateau edge at dy = 1.70 (where
+        its pad's y-range starts covering the connector). Asserted on the
+        plateau, at dy = 1.80.
+      - the declaring arm's `t[5]` (0.350) and its `effs` cell (0.650) differ
+        by 0.300 ON PURPOSE: without that inequality the two likeliest
+        mutations -- dropping `_item_reach`, and omitting the floor map --
+        cancel and both survive.
+
+MUTATION BATTERY: 18 single-line mutations of the fix, 18 killed, each named
+by the arm that kills it under `TestOneConstructionSiteOnePrunePredicate`. Two
+false-positive probes -- a trailing comment naming a guarded literal, and a
+comment line naming the pricing spelling -- are correctly inert.
+
+Two of the eighteen exist because the FIRST run of that battery let them
+through, and both are recorded rather than quietly fixed:
+
+  * `if via_moves:` -> `if True:` changes no NUMBER, because the via prune is
+    exact and de-pruning grades identically. The first version of
+    `TestTheRefreshIsSkippedWhenNothingMoved` asserted only the track half and
+    the mutation survived. It is now caught on list IDENTITY -- `cap_vias[ref]
+    is not st.vias` -- which is the real consequence: an eff-matrix rebuild of
+    n_pads x n_ALL_vias per cap, on every board that reaches the nudger and
+    moves nothing, i.e. every tracked board at the shipped defaults.
+  * anchoring the prune on `cap.rect()` instead of `self._cap_geom` survived
+    because every arm here freezes the caps (`max_displacement=0.0`), so no
+    cap ever moves. `TestThePruneIsAnchoredOnTheSEEDPose` moves one by hand.
+
+ONE mutation is DECLARED unkillable rather than papered over: `if via_moves:`
+-> `if new_segs:`. A via move whose `conn_layers` is empty registers nothing
+either way, so no arm can separate them -- recorded as test_737 records its own
+surviving spelling.
+
+Runtime ~40s, in-process apart from one `git ls-files`.
+"""
+from __future__ import annotations
+
+RUN_ALL_FAST_OK = True
+RUN_ALL_TIMEOUT = 900
+
+import contextlib
+import inspect
+import io
+import json
+import os
+import re
+import sys
+import tempfile
+import unittest
+
+_TESTS = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_TESTS)
+for _p in ('', 'py_router', 'py_placer', 'py_tools'):
+    _d = os.path.join(_ROOT, _p)
+    if _d not in sys.path:
+        sys.path.insert(0, _d)
+if _TESTS not in sys.path:
+    sys.path.insert(0, _TESTS)
+
+import routing_defaults as defaults
+import run_utils
+from check_drc import check_pad_segment_overlap
+from kicad_parser import BoardInfo, Footprint, Zone, parse_kicad_pcb
+from placement import fanout_clearance as FC
+from placement.fanout_clearance import _Repair, repair_fanout_clearance
+from synth import make_net, make_pad, make_pcb, make_via
+
+# --- the rig, and every number it is worth ---------------------------------
+CLEAR = 0.1                 # place_fanout_clearance.py's own --help example
+CU = ['F.Cu', 'In1.Cu', 'In2.Cu', 'B.Cu']
+BOUNDS = (0.0, 0.0, 60.0, 20.0)
+TRACK_W = defaults.TRACK_WIDTH      # 0.3 -- the width the pour-tie path falls
+HW = TRACK_W / 2.0                  # back to; imported, never mirrored
+V_SIZE, V_DRILL = 0.8, 0.3
+VR = V_SIZE / 2.0                   # 0.40
+
+NET_V = 3                   # the foreign net the via and its connector carry
+NET_A, NET_B = 11, 12       # C1's two pads
+CAP_XY = (10.0, 10.0)
+CAP2_XY = (10.0, 8.0)
+BGA_XY = (7.6, 10.0)
+
+PAD_HALF = 0.3              # 0.6mm square pads at local +-0.5 ...
+PAD2_EDGE = CAP_XY[0] + 0.5 + PAD_HALF          # ... so pad 2's right edge
+
+SEG_KEEPOUT = HW + CLEAR                        # 0.25, what the GRADER charges
+VIA_KEEPOUT = VR + CLEAR                        # 0.40, what valid_via_pos needs
+
+VIA_DEEP = 10.930           # gap 0.130 -> charged SEG_KEEPOUT - 0.130
+VIA_CLEAR = 11.175          # gap 0.375 -> clear by 0.125
+GAP_DEEP = VIA_DEEP - PAD2_EDGE                 # 0.130
+CHARGE = SEG_KEEPOUT - GAP_DEEP                 # 0.1200
+
+LAND_DEEP = (11.330, 10.0)
+LAND_CLEAR = (11.325, 10.0)
+# The connector runs from the via's OLD position to its new one, so its
+# start is VIA_CLEAR itself. Spelled that way rather than as
+# `LAND_CLEAR[0] - 0.15` -- the same point in arithmetic, and one ULP
+# below it in float.
+CONN_CLEAR = (VIA_CLEAR, CAP_XY[1], LAND_CLEAR[0], CAP_XY[1])
+
+# The per-cap track prune keeps anything within
+#   max_displacement_cap + 2*span + clearance   (+ the track's own over-reach)
+# of the cap's SEED centre: 5.058801mm here (3.0 + 2*0.854400 + 0.1 + 0.25).
+# FAR_D is inside it and FAR_D - WALK_BACK is outside it, both by more than the
+# 0.05 this file allows itself, so a prune anchored on the MOVED pose drops a
+# track the seed-anchored one keeps.
+FAR_D = 4.90
+FAR_SEG = (CAP_XY[0] + FAR_D, CAP_XY[1],
+           CAP_XY[0] + FAR_D + 0.15, CAP_XY[1])
+WALK_BACK = -0.30
+
+# C1 walked +0.30 in x puts its pad edge 0.075 from the connector.
+PROBE_C1 = (0.30, 0.0)
+PROBE_C2 = (0.30, 1.80)
+PROBE_CHARGE = 0.1750
+
+DECL_CLASS = [{'name': 'Default', 'clearance': 0.2, 'track_width': 0.2,
+               'via_diameter': 0.6, 'via_drill': 0.4,
+               'priority': 2147483647}]
+DECL_LC = 0.5               # a pad override, so pair() != _item_reach()
+DECL_T5 = 0.35              # HW + _item_reach(seg floor)  = 0.15 + max(0.1,0.2)
+DECL_EFF = 0.65             # HW + pair(cap floor, seg floor) = 0.15 + 0.5
+
+
+def _bga():
+    """detect_package_type keys on the footprint NAME, so a 3x3 grid whose
+    name says BGA is enough to give _Repair a ball field to sit caps near."""
+    pads = []
+    for i, dx in enumerate((-0.8, 0.0, 0.8)):
+        for j, dy in enumerate((-0.8, 0.0, 0.8)):
+            pads.append(make_pad(net_id=100 + 3 * i + j,
+                                 x=BGA_XY[0] + dx, y=BGA_XY[1] + dy,
+                                 ref='U1', num='%d%d' % (i, j),
+                                 size_x=0.4, size_y=0.4, shape='circle',
+                                 layers=['F.Cu'], local_x=dx, local_y=dy))
+    return Footprint(reference='U1', footprint_name='lib:BGA-9_3x3_0.8mm',
+                     x=BGA_XY[0], y=BGA_XY[1], rotation=0.0, layer='F.Cu',
+                     pads=pads)
+
+
+def _cap(ref, cx, cy, through=False):
+    """A C-prefixed 2-copper-pad part -- what _Repair's cap detection admits.
+
+    `through` is the ONE variable that separates arm B from its control: the
+    pads become `*.Cu` plated through-hole, so their copper spans every layer
+    while the FOOTPRINT still sits on F.Cu. That is the whole of the #738
+    window, expressed as one keyword.
+    """
+    kw = dict(size_x=2 * PAD_HALF, size_y=2 * PAD_HALF, shape='rect')
+    if through:
+        kw.update(layers=['*.Cu', '*.Mask'], drill=0.3, pad_type='thru_hole')
+    else:
+        kw.update(layers=['F.Cu'])
+    pads = [make_pad(net_id=NET_A, x=cx - 0.5, y=cy, ref=ref, num='1',
+                     local_x=-0.5, local_y=0.0, **kw),
+            make_pad(net_id=NET_B, x=cx + 0.5, y=cy, ref=ref, num='2',
+                     local_x=0.5, local_y=0.0, **kw)]
+    return Footprint(reference=ref, footprint_name='lib:C_0402_1005Metric',
+                     x=cx, y=cy, rotation=0.0, layer='F.Cu', pads=pads)
+
+
+def _board(via_x, zone_layer, through=False, second_cap=False, lc=0.0):
+    bi = BoardInfo(layers={}, copper_layers=list(CU), board_bounds=BOUNDS)
+    v = make_via(via_x, CAP_XY[1], net_id=NET_V, size=V_SIZE, drill=V_DRILL)
+    fps = {'U1': _bga(), 'C1': _cap('C1', *CAP_XY, through=through)}
+    if second_cap:
+        fps['C2'] = _cap('C2', *CAP2_XY, through=through)
+    if lc:
+        for p in fps['C1'].pads:
+            p.local_clearance = lc
+    zone = Zone(net_id=NET_V, net_name='N3', layer=zone_layer,
+                polygon=[(via_x - 1.0, CAP_XY[1] - 1.0),
+                         (via_x + 1.0, CAP_XY[1] - 1.0),
+                         (via_x + 1.0, CAP_XY[1] + 1.0),
+                         (via_x - 1.0, CAP_XY[1] + 1.0)])
+    pads_by_net = {}
+    for fp in fps.values():
+        for p in fp.pads:
+            pads_by_net.setdefault(p.net_id, []).append(p)
+    nets = {0: make_net(0, '')}
+    for k in list(pads_by_net) + [NET_V]:
+        nets.setdefault(k, make_net(k, 'N%d' % k))
+    pcb = make_pcb(board_info=bi, nets=nets, vias=[v], segments=[],
+                   footprints=fps, pads_by_net=pads_by_net, zones=[zone])
+    return pcb, v
+
+
+@contextlib.contextmanager
+def _stub(classes=None):
+    """A bare board FILE so the path-reading collaborators degrade cleanly
+    (courtyards -> {}, locked refs -> set(), PadClearanceModel -> INERT unless
+    `classes` declares one). #617's idiom."""
+    with tempfile.TemporaryDirectory() as td:
+        path = os.path.join(td, 'b.kicad_pcb')
+        with io.open(path, 'w', encoding='utf-8') as f:
+            f.write('(kicad_pcb (version 20240108))\n')
+        if classes is not None:
+            with io.open(os.path.join(td, 'b.kicad_pro'), 'w',
+                         encoding='utf-8') as f:
+                json.dump({'net_settings': {'classes': classes,
+                                            'netclass_assignments': {},
+                                            'netclass_patterns': []}}, f)
+        yield path
+
+
+def _run(pcb, path, **kw):
+    """Drive the WHOLE pass, capturing stdout and the internal `_Repair`.
+
+    `on_move` is the supported hook the animator uses: it is handed the state
+    at the seed frame, and every frame is the SAME object, so it is the only
+    way to see cap_segs / segments / _seg_floor_by_id from outside without
+    monkeypatching.
+
+    max_displacement=0.0 with max_passes=1 is the BOXED cap of #313 expressed
+    as a budget rather than as a wall of obstacle geometry -- the same rig
+    tests/test_fanout_clearance.py's via-clear-fallback check uses.
+    """
+    seen, buf = [], io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        res = repair_fanout_clearance(
+            pcb, path, clearance=CLEAR, cap_prefix='C',
+            max_displacement=0.0, max_passes=1, allow_rotations=False,
+            via_clear_fallback=False, on_move=lambda st: seen.append(st), **kw)
+    return res, (seen[0] if seen else None), buf.getvalue()
+
+
+def _arm(via_x, zone_layer, **kw):
+    with _stub(kw.pop('classes', None)) as path:
+        pcb, v = _board(via_x, zone_layer, **kw)
+        pre = None
+
+        res, st, out = _run(pcb, path)
+        return pcb, v, res, st, out, pre
+
+
+class TestTheDrawGateAndTheGraderAgreeOnTheSameLayer(unittest.TestCase):
+    """The measurement that LICENSES this file's framing: on the connector's
+    own layer the two gates are the same number, so #736 cannot ship a false
+    RESOLVED there. Without this, every other arm reads as a lucky fixture."""
+
+    def test_a_same_layer_connector_in_the_keepout_is_REFUSED_at_draw_time(self):
+        pcb, v, res, st, out, _ = _arm(VIA_DEEP, 'F.Cu')
+        # ON THE BRANCH: the cap really is a violator, so the nudger really ran
+        self.assertIn('Caps initially grazing foreign copper', out)
+        self.assertEqual(sorted(st.caps), ['C1'],
+                         'U1 leaked into the cap set; cap_prefix is wrong')
+        self.assertLess(GAP_DEEP, SEG_KEEPOUT - 0.05,
+                        'the fixture no longer sits inside the keep-out')
+        # the PRINTED refusal first (#732): a refusal that prints nothing is
+        # indistinguishable from a pass that never looked
+        self.assertIn("via-nudge: no clear spot for C1's offending via", out)
+        self.assertEqual(res['via_moves'], [])
+        self.assertEqual(res['new_segments'], [])
+        self.assertEqual((v.x, v.y), (VIA_DEEP, CAP_XY[1]))
+        self.assertEqual(len(pcb.segments), 0)
+    # MUTATION: none -- this arm licenses the claim rather than testing the
+    # fix, and it fails loudly if the draw gate is ever weakened.
+
+    def test_the_NEGATIVE_control_with_room_still_moves(self):
+        pcb, v, res, st, out, _ = _arm(VIA_CLEAR, 'F.Cu')
+        self.assertIn('via-nudge: moved', out)
+        self.assertEqual(len(res['via_moves']), 1)
+        self.assertEqual((round(v.x, 4), round(v.y, 4)), LAND_CLEAR)
+    # MUTATION: none (control).
+
+    def test_the_two_gates_resolve_to_the_SAME_requirement(self):
+        """Arithmetic, not geometry: `connector_clear` charges
+        `hw + req(pfl, cfl)` and `_seg_effs` charges `halves + pair(fa, fb)`
+        from the same two floors. Compared on a DECLARING board, where both
+        are free to be wrong differently."""
+        with _stub(DECL_CLASS) as path:
+            pcb, v = _board(VIA_CLEAR, 'F.Cu', lc=DECL_LC)
+            st = _Repair(pcb, path, CLEAR, 0.1, 0.55, 1.0, 2.0, 0.3, 'C',
+                         set())
+            self.assertIsNotNone(st._floors, 'the model is INERT -- this arm '
+                                             'would compare 0.1 with 0.1')
+            cap = st.caps['C1']
+            st.register_new_segments([{'start': CONN_CLEAR[:2],
+                                       'end': CONN_CLEAR[2:],
+                                       'width': TRACK_W, 'layer': 'F.Cu',
+                                       'net_id': NET_V}])
+            cfl = st.seg_floor(NET_V, 'F.Cu')
+            drawn = HW + st.required(cap.pad_floors[1], cfl)
+            graded = st._seg_effs('C1', cap)[1][-1]
+            self.assertAlmostEqual(drawn, graded, places=12)
+            self.assertAlmostEqual(graded, DECL_EFF, places=9)
+    # MUTATION: price the tuple at `HW + self.clearance` -> graded 0.25 != drawn.
+
+
+class TestTheConnectorEntersTheGradersView(unittest.TestCase):
+    """LOAD-BEARING, and deliberately built on a connector the draw gate
+    genuinely ACCEPTS on the cap's own layer. Nothing here depends on #738 or
+    on any layer-scope divergence, so #738 landing cannot touch it."""
+
+    def setUp(self):
+        self.pcb, self.v, self.res, self.st, self.out, _ = _arm(
+            VIA_CLEAR, 'F.Cu', second_cap=True)
+        # ON THE BRANCH: the pass reached the nudger and really drew copper
+        self.assertEqual(len(self.res['via_moves']), 1, self.out)
+        self.assertEqual([(s['layer'], s['width'])
+                          for s in self.res['new_segments']],
+                         [('F.Cu', TRACK_W)])
+        self.assertIn('via-nudge: moved', self.out)
+        self.seg = self.pcb.segments[-1]
+
+    def test_the_track_view_gained_exactly_the_connector(self):
+        self.assertEqual(len(self.st.segments), len(self.pcb.segments))
+        self.assertEqual(len(self.st.segments), 1)
+    # MUTATION: drop the register_new_segments call -> 0 != 1.
+
+    def test_the_tuple_is_priced_and_layered_as_init_would_have(self):
+        t = self.st.cap_segs['C1'][-1]
+        self.assertEqual(t[:5], (CONN_CLEAR[0], CONN_CLEAR[1], CONN_CLEAR[2],
+                                 CONN_CLEAR[3], NET_V))
+        self.assertEqual(t[6], 'F.Cu',
+                         'element 6 is a board SIDE again -- the pre-#731 '
+                         'collapse')
+        self.assertAlmostEqual(
+            t[5], self.seg.width / 2.0 + self.st._item_reach(
+                self.st.seg_floor(self.seg.net_id, self.seg.layer)), places=12)
+        self.assertAlmostEqual(t[5], SEG_KEEPOUT, places=9)
+    # MUTATION: `t[6] = _seg_side(layer)`; drop `_item_reach`; drop the `/2`.
+
+    def test_the_floor_map_holds_no_orphan_id(self):
+        live = {id(t) for t in self.st.segments}
+        self.assertLessEqual(set(self.st._seg_floor_by_id), live,
+                             'an entry keys a tuple that is not in the live '
+                             'list -- a recycled id would return ANOTHER '
+                             "track's floor, silently")
+    # MUTATION: build the tuple without filing it in self.segments.
+
+    def test_every_cap_in_reach_was_refreshed_with_a_NEW_list(self):
+        for ref in ('C1', 'C2'):
+            self.assertEqual(len(self.st.cap_segs[ref]), 1,
+                             '%s did not keep the connector' % ref)
+        effs = self.st._seg_effs('C1', self.st.caps['C1'])
+        self.assertTrue(all(len(row) == len(self.st.cap_segs['C1'])
+                            for row in effs),
+                        'the _cap_seg_eff memo is one column short -- '
+                        'cap_segs was appended to IN PLACE, so its identity '
+                        'never changed and the memo was never rebuilt')
+    # MUTATION: `cap_segs[ref].append(t)`; refresh only the repaired cap.
+
+    def test_the_pass_did_not_INVENT_a_charge_for_clear_copper(self):
+        for ref in ('C1', 'C2'):
+            cap = self.st.caps[ref]
+            self.assertAlmostEqual(
+                self.st.seg_penalty(ref, cap, cap.x, cap.y, cap.rot), 0.0,
+                places=9, msg='%s is charged for a connector the draw gate '
+                              'accepted -- the fix OVER-blocks' % ref)
+        self.assertEqual(self.res['unresolved'], [])
+    # MUTATION: charge the tuple at the prune over-reach instead of the pair.
+
+    def test_graze_penalty_RISES_for_a_pose_inside_the_connectors_keepout(self):
+        """The behavioural half, with no layer-scope dependence at all: walk
+        each cap toward the connector and the charge must appear."""
+        for ref, (dx, dy) in (('C1', PROBE_C1), ('C2', PROBE_C2)):
+            cap = self.st.caps[ref]
+            self.assertAlmostEqual(
+                sum(self.st._seg_shortfalls(
+                    ref, cap, cap.x + dx, cap.y + dy, cap.rot).values()),
+                PROBE_CHARGE, places=4,
+                msg='%s: the connector is not in the view, or is priced wrong'
+                    % ref)
+    # MUTATION: any of the above; also "build from st.segments instead of the
+    # nudger's dicts" (nothing to build from) and "call it BEFORE the nudge".
+
+
+class TestTheStaleViewShipsAFalseRESOLVED(unittest.TestCase):
+    """THE HEADLINE. A through-hole cap pad and a back-side connector: the
+    draw gate never tests the pair (#738), the grader charges it, and
+    check_drc -- the authority -- agrees the copper really is in violation."""
+
+    def setUp(self):
+        self.pcb, self.v, self.res, self.st, self.out, _ = _arm(
+            VIA_DEEP, 'B.Cu', through=True)
+
+    def test_the_connector_is_DRAWN_and_now_CHARGED(self):
+        # draw side FIRST, and exactly -- see the CHANGE DETECTOR note below
+        self.assertEqual([(s['layer'], s['width'])
+                          for s in self.res['new_segments']],
+                         [('B.Cu', TRACK_W)],
+                         'the off-side connector was NOT drawn. If #738 has '
+                         'landed that is CORRECT: delete this class, keep '
+                         'TestTheConnectorEntersTheGradersView, and record in '
+                         'the #738 PR that #736\'s behavioural window closed.')
+        self.assertEqual((round(self.v.x, 4), round(self.v.y, 4)), LAND_DEEP)
+        cap = self.st.caps['C1']
+        self.assertAlmostEqual(
+            self.st.seg_penalty('C1', cap, cap.x, cap.y, cap.rot), CHARGE,
+            places=4)
+        self.assertEqual(self.res['unresolved'], ['C1'])
+    # MUTATION: delete the refresh -> unresolved == [] and the pass reports a
+    # cap RESOLVED with a connector 0.020mm INSIDE one of its pads.
+
+    def test_check_drc_agrees_it_is_a_real_violation(self):
+        """Not the repair pass's own arithmetic: the authoritative checker, at
+        margin 0 so the number is the requirement and not a tolerance band."""
+        pad2 = self.pcb.footprints['C1'].pads[1]
+        viol, overlap, _pt = check_pad_segment_overlap(
+            pad2, self.pcb.segments[-1], CLEAR, CU, clearance_margin=0.0)
+        self.assertTrue(viol, 'check_drc grades this pair clean -- the fix is '
+                              'reporting a phantom, not a violation')
+        self.assertAlmostEqual(overlap, CHARGE, places=4)
+    # MUTATION: none -- this is the arm that makes the headline a fact rather
+    # than a claim about one grader agreeing with itself.
+
+    def test_the_NEGATIVE_control_SMD_pads_is_drawn_and_NOT_charged(self):
+        """One variable away from the arm above: the same B.Cu connector
+        against SMD F.Cu pads, which share no copper with it."""
+        pcb, v, res, st, out, _ = _arm(VIA_DEEP, 'B.Cu', through=False)
+        self.assertEqual([(s['layer'], s['width'])
+                          for s in res['new_segments']], [('B.Cu', TRACK_W)])
+        cap = st.caps['C1']
+        self.assertAlmostEqual(st.seg_penalty('C1', cap, cap.x, cap.y,
+                                              cap.rot), 0.0, places=9)
+        self.assertEqual(res['unresolved'], [])
+        pad2 = pcb.footprints['C1'].pads[1]
+        viol, _ov, _pt = check_pad_segment_overlap(
+            pad2, pcb.segments[-1], CLEAR, CU, clearance_margin=0.0)
+        self.assertFalse(viol)
+    # MUTATION: drop the layer gate from the rebuilt prune -> charged, and
+    # check_drc says it should not be.
+
+
+class TestTheLayerScopeSurvivesTheRebuild(unittest.TestCase):
+    """#731's regression guard, and the ONLY arm that kills one mutation."""
+
+    def test_a_DECLARED_layer_the_cap_pads_do_not_share_is_excluded(self):
+        pcb, v, res, st, out, _ = _arm(VIA_DEEP, 'In1.Cu')
+        # the connector IS drawn and IS on the board ...
+        self.assertEqual([(s['layer'], s['width'])
+                          for s in res['new_segments']], [('In1.Cu', TRACK_W)])
+        self.assertEqual(len(st.segments), 1)
+        self.assertIn('In1.Cu', st._all_cu, 'the layer is UNKNOWN to the '
+                                            'board, so _seg_shares charges it '
+                                            'and this arm tests nothing')
+        # ... and the F.Cu SMD cap pads share no copper with it
+        self.assertEqual(len(st.cap_segs['C1']), 0)
+        cap = st.caps['C1']
+        self.assertAlmostEqual(st.seg_penalty('C1', cap, cap.x, cap.y,
+                                              cap.rot), 0.0, places=9)
+        self.assertEqual(res['unresolved'], [])
+    # MUTATION: `t[6] = _seg_side(s.layer)` -- the pre-#731 collapse. 'F' is
+    # not in _all_cu, so _seg_shares charges it and a PHANTOM appears. This is
+    # the only arm that catches it: on the F.Cu and B.Cu arms the collapse is
+    # numerically invisible.
+
+
+class TestTheUnknownLayerOverBlockIsDELIBERATE(unittest.TestCase):
+    """Arm C. A connector on a layer the board never declared is charged --
+    by policy, not by accident (`_seg_shares`: "over-blocking is the only
+    direction that can never ship a violation").
+
+    It is pinned HERE, apart from the headline, because check_drc grades the
+    pair CLEAN. Reading it as a violation is the mistake an earlier draft of
+    this file made."""
+
+    def test_it_is_charged_even_though_the_checker_calls_it_clean(self):
+        pcb, v, res, st, out, _ = _arm(VIA_DEEP, 'In3.Cu')
+        self.assertNotIn('In3.Cu', st._all_cu,
+                         'In3.Cu became a declared layer; this arm now tests '
+                         'the same thing as the In1.Cu one')
+        self.assertEqual([(s['layer'], s['width'])
+                          for s in res['new_segments']], [('In3.Cu', TRACK_W)])
+        cap = st.caps['C1']
+        self.assertAlmostEqual(st.seg_penalty('C1', cap, cap.x, cap.y,
+                                              cap.rot), CHARGE, places=4)
+        self.assertEqual(res['unresolved'], ['C1'])
+        # ... and the authority disagrees, which is the point of this class
+        pad2 = pcb.footprints['C1'].pads[1]
+        viol, _ov, _pt = check_pad_segment_overlap(
+            pad2, pcb.segments[-1], CLEAR, CU, clearance_margin=0.0)
+        self.assertFalse(viol, 'check_drc now flags this -- the over-block '
+                               'has become a real rule and this class should '
+                               'be re-read as a violation arm')
+    # MUTATION: drop the `_seg_shares` fallback from the rebuilt prune.
+
+
+class TestTheRebuildPricesTheConnectorCorrectly(unittest.TestCase):
+    """A DECLARING board, where `t[5]` and the eff cell are free to differ --
+    0.350 against 0.650 here. Without that inequality the two likeliest
+    mutations cancel exactly and both survive."""
+
+    def _st(self, path, pcb):
+        st = _Repair(pcb, path, CLEAR, 0.1, 0.55, 1.0, 2.0, 0.3, 'C', set())
+        st.register_new_segments([{'start': CONN_CLEAR[:2],
+                                   'end': CONN_CLEAR[2:], 'width': TRACK_W,
+                                   'layer': 'F.Cu', 'net_id': NET_V}])
+        return st
+
+    def test_the_two_prices_are_separated_and_both_correct(self):
+        with _stub(DECL_CLASS) as path:
+            pcb, v = _board(VIA_CLEAR, 'F.Cu', lc=DECL_LC)
+            st = self._st(path, pcb)
+            self.assertIsNotNone(st._floors, 'the model is INERT')
+            t = st.segments[-1]
+            self.assertAlmostEqual(t[5], DECL_T5, places=9)
+            self.assertAlmostEqual(st._seg_effs('C1', st.caps['C1'])[1][-1],
+                                   DECL_EFF, places=9)
+            self.assertGreater(abs(DECL_EFF - DECL_T5), 0.05,
+                               'the two prices coincide, so a mutation that '
+                               'swaps them survives')
+    # MUTATION: drop `_item_reach` -> t[5] 0.25; omit the floor map -> the eff
+    # cell moves.
+
+    def test_the_floor_filed_is_the_TRACK_floor_object_itself(self):
+        """Identity, not value: `_seg_floor_for` memoises per (net, layer), so
+        the right floor is the same OBJECT. A via floor is scoped to ALL
+        copper and would diverge only under a layer-scoped .kicad_dru rule --
+        which no behavioural arm here has, so this is the only killer."""
+        with _stub(DECL_CLASS) as path:
+            pcb, v = _board(VIA_CLEAR, 'F.Cu', lc=DECL_LC)
+            st = self._st(path, pcb)
+            t = st.segments[-1]
+            fl = st.seg_floor(NET_V, 'F.Cu')
+            self.assertIsNotNone(fl, 'an inert board makes this None is None')
+            self.assertIs(st._seg_floor_by_id.get(id(t)), fl)
+    # MUTATION: file `_via_floor_for(net)` instead of `_seg_floor_for(net,
+    # layer)` -- behaviourally invisible without a dru rule.
+
+    def test_an_INERT_board_files_no_floor_at_all(self):
+        with _stub() as path:
+            pcb, v = _board(VIA_CLEAR, 'F.Cu')
+            st = self._st(path, pcb)
+            self.assertIsNone(st._floors)
+            t = st.segments[-1]
+            self.assertNotIn(id(t), st._seg_floor_by_id)
+            self.assertAlmostEqual(t[5], SEG_KEEPOUT, places=9)
+    # MUTATION: file the floor unconditionally (drop `if fl is not None`).
+
+
+class TestTheRefreshIsSkippedWhenNothingMoved(unittest.TestCase):
+    """The refresh is guarded, and the guard is not decorative: EVERY tracked
+    board that reaches the nudger at the shipped defaults makes zero moves."""
+
+    def test_a_run_that_moved_no_via_leaves_the_track_view_alone(self):
+        with _stub() as path:
+            pcb, v = _board(VIA_DEEP, 'F.Cu')
+            st_probe = _Repair(pcb, path, CLEAR, 0.1, 0.55, 1.0, 2.0, 0.3,
+                               'C', set())
+            before = {r: st_probe.cap_segs[r] for r in st_probe.caps}
+            segs_before = st_probe.segments
+
+            res, st, out = _run(pcb, path)
+        self.assertIn('no clear spot', out)
+        self.assertEqual(res['via_moves'], [])
+        # the run built its OWN _Repair, so compare the live one's identities
+        self.assertEqual(len(st.segments), 0)
+        for ref in st.caps:
+            self.assertEqual(st.cap_segs[ref], [])
+            # ...and the VIA half of the refresh did not run either. This is
+            # the only observable consequence of an unguarded refresh: the
+            # `cap_vias` line DE-prunes every cap onto the whole-board list,
+            # which is numerically identical (the prune is exact) but pays an
+            # eff-matrix rebuild of n_pads x n_ALL_vias per cap on every board
+            # that reaches the nudger and moves nothing -- which is every
+            # tracked board at the shipped defaults.
+            self.assertIsNot(st.cap_vias[ref], st.vias,
+                             'the per-cap via lists were de-pruned on a run '
+                             'that moved NO via -- the refresh is unguarded')
+        self.assertEqual(len(segs_before), 0)
+        self.assertEqual(sorted(before), sorted(st.caps))
+    # MUTATION: `if via_moves:` -> `if True:`. It changes no number -- the
+    # via prune is exact, so de-pruning grades the same -- which is why the
+    # assertion above is on list IDENTITY. The first version of this class
+    # asserted only the track half and the mutation SURVIVED the battery.
+
+
+class TestThePruneIsAnchoredOnTheSEEDPose(unittest.TestCase):
+    """By the time a connector is registered the caps have already moved, so
+    `_prune_segs` is handed `self._cap_geom` -- the SEED-pose geometry -- and
+    not `cap.rect()`.
+
+    That is not a stylistic choice. The reach bound is the reachable-DISK
+    argument (a cap moves at most `max_displacement_cap` from its SEED), which
+    is what makes the prune EXACT rather than approximate; and
+    `required_rows` grades `_seg_shortfalls` at the SEED pose as well as the
+    final one, so a moved-pose radius is a superset for neither.
+    """
+
+    def test_a_track_in_reach_of_the_SEED_survives_a_cap_that_moved_away(self):
+        with _stub() as path:
+            pcb, v = _board(VIA_CLEAR, 'F.Cu')
+            st = _Repair(pcb, path, CLEAR, 0.1, 0.55, 1.0, 2.0, 0.3, 'C',
+                         set())
+            cap = st.caps['C1']
+            _cx, _cy, span, _r = st._cap_geom['C1']
+            thr = (st._max_disp_cap + 2 * span + st.clearance
+                   + max(0.0, cap.max_floor - st.clearance)
+                   + HW + st.clearance)
+            # ON THE BRANCH: the fixture straddles the real threshold, both
+            # ways, by more than the 0.05mm this file allows itself
+            self.assertGreater(thr - FAR_D, 0.05, 'the track is not in reach '
+                                                  'of the seed after all')
+            self.assertGreater((FAR_D - WALK_BACK) - thr, 0.05,
+                               'the moved pose still reaches it, so a '
+                               'moved-pose prune would keep it too')
+            cap.x += WALK_BACK              # the pose the sweep left it in
+            self.assertNotEqual(cap.x, cap.seed_x)
+
+            st.register_new_segments([{'start': FAR_SEG[:2],
+                                       'end': FAR_SEG[2:], 'width': TRACK_W,
+                                       'layer': 'F.Cu', 'net_id': NET_V}])
+            self.assertEqual(
+                len(st.cap_segs['C1']), 1,
+                'the connector was pruned away: the reach was measured from '
+                "the cap's CURRENT pose, not its seed, which silently "
+                'redefines what "exact" means for this prune')
+    # MUTATION: recompute (ccx, ccy, span) from cap.rect() in the registrar
+    # instead of reading self._cap_geom.
+
+
+class TestOneConstructionSiteOnePrunePredicate(unittest.TestCase):
+    """SOURCE GUARD. #736 exists because both halves of "how a track becomes a
+    graded tuple" were inline in `__init__` and existed nowhere else, so
+    nothing could register a track that appeared later. Adding a second
+    spelling is that defect again, and no fixture can catch it.
+
+    CODE only -- `l.split('#')[0]` drops a trailing comment as well as a
+    full-line one, because the engine's comment blocks name every one of these
+    symbols repeatedly. Reading raw lines both invents sites and lets a real
+    one hide behind a trailing comment (#737's lesson). Offending line numbers
+    are REPORTED; never `assertIn` over the whole source (#732 measured a
+    393KB failure message from that).
+
+    THE BATTERY, as RUN: 18 mutations, 18 killed, plus two inert probes.
+
+      1  delete the refresh call ............ graze_penalty_RISES + 3 others
+      2  call it BEFORE the nudge ........... graze_penalty_RISES + 3 others
+      3  hand the registrar an empty list ... graze_penalty_RISES + 3 others
+      4  register but never prune per cap ... every_cap_in_reach, SEEDPose
+      5  prune but never file the tuple ..... CONSTRUCTED_in_exactly_one_place
+      6  refresh AFTER the unresolved recompute  connector_is_DRAWN_and_CHARGED
+      7  drop `_item_reach` ................. two_prices_are_separated
+      8  drop the `/2` ...................... tuple_is_priced_and_layered
+      9  omit the floor map ................. floor_filed_is_the_TRACK_floor
+      10 file `_via_floor_for` instead ...... floor_filed_is_the_TRACK_floor
+      11 `t[6] = _seg_side(layer)` .......... LayerScopeSurvivesTheRebuild
+      12 extend `cap_segs[ref]` IN PLACE .... cap_segs_is_ASSIGNED + 3 others
+      13 file the floor under a stale id .... floor_filed_is_the_TRACK_floor
+      14 refresh only the first cap ......... every_cap_in_reach (C2)
+      15 drop the layer filter .............. LayerScopeSurvivesTheRebuild
+      16 drop the distance filter ........... prune_predicate_has_ONE_spelling
+      17 make the refresh unconditional ..... RefreshIsSkippedWhenNothingMoved
+      18 prune from the MOVED pose .......... PruneIsAnchoredOnTheSEEDPose
+
+    10, 11, 15, 16, 17 and 18 have exactly ONE killer each; the module
+    docstring records that 17 and 18 SURVIVED the first run of this battery and
+    what was added to catch them.
+
+    INERT PROBES, which must change nothing: a trailing comment naming
+    `self._seg_floor_by_id[`, and a comment line naming the pricing spelling
+    and an in-place `cap_segs[r] +=`. Both pass, so the comment stripper is
+    doing its job rather than the guard being loose.
+
+    DECLARED UNKILLABLE, rather than papered over: `if via_moves:` ->
+    `if new_segs:`. A via move whose `conn_layers` is empty registers nothing
+    either way, so no arm can separate them. Recorded as test_737 records its
+    own surviving spelling.
+    """
+
+    @staticmethod
+    def _code(obj):
+        return [l.split('#')[0] for l in inspect.getsource(obj).splitlines()]
+
+    def _sites(self, lines, literal):
+        return [i + 1 for i, l in enumerate(lines) if literal in l]
+
+    def setUp(self):
+        self.mod = self._code(FC)
+        self.rep = self._code(FC._Repair)
+        self.builder = self._code(FC._Repair._register_segment)
+        self.pruner = self._code(FC._Repair._prune_segs)
+        self.nudger = self._code(FC.nudge_vias_for_unresolved)
+
+    def test_a_track_tuple_is_CONSTRUCTED_in_exactly_one_place(self):
+        for lit, where in (('self.segments.append(', self.builder),
+                           ('self._seg_floor_by_id[', self.builder),
+                           ('width / 2.0 + self._item_reach(', self.builder)):
+            sites = self._sites(self.mod, lit)
+            self.assertEqual(
+                len(sites), 1,
+                '%r occurs at %d sites (module-relative line(s) %s). #736 '
+                'exists because the one in __init__ was the only one, so '
+                'nothing could register the connectors the pass draws. A '
+                'second is that defect again.' % (lit, len(sites), sites))
+            self.assertTrue(any(lit in l for l in where),
+                            '%r moved out of _register_segment' % lit)
+    # MUTATION: re-inline the tuple build in __init__ or in the registrar.
+
+    def test_the_prune_predicate_has_exactly_one_spelling(self):
+        sites = self._sites(self.rep, '_point_to_seg_dist(')
+        self.assertEqual(len(sites), 1,
+                         '_Repair measures a point-to-track distance at %d '
+                         'sites (class-relative line(s) %s); the prune must '
+                         'have one' % (len(sites), sites))
+        self.assertTrue(any('_point_to_seg_dist(' in l for l in self.pruner))
+        calls = self._sites(self.mod, 'self._prune_segs(')
+        self.assertEqual(len(calls), 2,
+                         'expected exactly two callers of the prune -- '
+                         '__init__ and the registrar; found %d at %s'
+                         % (len(calls), calls))
+    # MUTATION: re-inline the prune loop in either caller.
+
+    def test_cap_segs_is_ASSIGNED_and_never_mutated_in_place(self):
+        asg = re.compile(r'self\.cap_segs\[[^\]]+\]\s*=[^=]')
+        writes = [i + 1 for i, l in enumerate(self.mod) if asg.search(l)]
+        self.assertEqual(len(writes), 2,
+                         'expected two cap_segs assignments (__init__ and the '
+                         'registrar); found %d at %s' % (len(writes), writes))
+        inplace = re.compile(r'cap_segs\[[^\]]*\]\s*(?:\.append|\.extend|\+=)')
+        bad = [i + 1 for i, l in enumerate(self.mod) if inplace.search(l)]
+        self.assertEqual(bad, [],
+                         'cap_segs is mutated IN PLACE at line(s) %s -- the '
+                         '_cap_seg_eff memo revalidates on the list IDENTITY, '
+                         'so the rows are never rebuilt and _seg_shortfalls '
+                         'indexes past the end of its row' % bad)
+    # MUTATION: `cap_segs[ref].append(t)` / `.extend(kept)` / `+= kept`.
+
+    def test_the_registrar_is_not_reached_from_the_duck_typed_nudger(self):
+        """`nudge_vias_for_unresolved` takes a duck-typed `st` -- five test
+        files pass a stand-in carrying only caps / vias / graze_penalty. A
+        resolver there has an honest flat fallback; a MUTATION does not,
+        because "silently do nothing" IS this defect."""
+        self.assertEqual(self._sites(self.nudger, 'register_new_segments('), [])
+        calls = [i + 1 for i, l in enumerate(self.mod)
+                 if 'register_new_segments(' in l and 'def ' not in l]
+        self.assertEqual(len(calls), 1,
+                         'expected exactly one call site; found %d at %s'
+                         % (len(calls), calls))
+    # MUTATION: move the call inside the nudger -> five test files AttributeError.
+
+    def test_the_zero_count_arms_are_not_searching_for_dead_strings(self):
+        """Every `== 0` arm above passes after a rename. Assert the positive
+        controls exist, so a rename fails HERE rather than disarming them."""
+        for token, floor in (('cap_segs', 6), ('self.segments', 3),
+                             ('_seg_floor_by_id', 4),
+                             ('pcb_data.segments', 5)):
+            n = sum(1 for l in self.mod if token in l)
+            self.assertGreaterEqual(
+                n, floor, '%r appears %d times in CODE (expected >= %d) -- it '
+                          'was renamed, and the zero-count arms of this file '
+                          'are now vacuous' % (token, n, floor))
+    # MUTATION: rename any of those identifiers.
+
+    def test_a_trailing_comment_cannot_arm_or_disarm_the_guard(self):
+        """False-positive probe: the stripper must drop a trailing comment, so
+        a comment MENTIONING a guarded literal invents no site."""
+        probe = ['        x = 1  # self.segments.append( and cap_segs[r] += q',
+                 '        # width / 2.0 + self._item_reach(fl)']
+        stripped = [l.split('#')[0] for l in probe]
+        self.assertEqual(self._sites(stripped, 'self.segments.append('), [])
+        self.assertEqual(
+            self._sites(stripped, 'width / 2.0 + self._item_reach('), [])
+    # MUTATION: read raw lines instead of stripping comments.
+
+
+class TestInertOnTheTrackedCorpus(unittest.TestCase):
+    """Two arms. The first says no tracked board emits a connector at the
+    shipped defaults, so the change is inert there. The second is what stops
+    that from being a statement about unreachable code."""
+
+    @staticmethod
+    def _reaching():
+        """Boards carrying BOTH vias and a movable near-BGA cap -- the only
+        ones that get past repair_fanout_clearance's two early returns."""
+        boards = run_utils.corpus_boards()
+        if not boards:
+            return None
+        out = []
+        for b in boards:
+            try:
+                pcb = parse_kicad_pcb(b)
+            except Exception:                                    # noqa: BLE001
+                continue
+            if not pcb.vias:
+                continue
+            if not any('BGA' in (f.footprint_name or '').upper()
+                       for f in pcb.footprints.values()):
+                continue
+            out.append(b)
+        return out
+
+    def test_no_tracked_board_EMITS_a_connector_at_the_shipped_defaults(self):
+        reaching = self._reaching()
+        if reaching is None:
+            print('SKIP: git cannot identify the tracked corpus')
+            self.skipTest('no git')
+        self.assertGreaterEqual(len(reaching), 3,
+                                'the candidate set collapsed; the filter is '
+                                'wrong and this arm proves nothing')
+        emitters = []
+        for b in reaching:
+            for clr in (0.25, 0.10):
+                buf = io.StringIO()
+                with contextlib.redirect_stdout(buf):
+                    r = repair_fanout_clearance(parse_kicad_pcb(b), b,
+                                                clearance=clr)
+                if r.get('new_segments'):
+                    emitters.append((os.path.basename(b), clr,
+                                     len(r['new_segments'])))
+        self.assertEqual(emitters, [],
+                         'a tracked board now emits connector copper: %r. The '
+                         '"inert on the corpus" claim in the #736 PR has '
+                         'EXPIRED -- re-run the before/after and record the '
+                         'new unresolved lists.' % (emitters,))
+    # MUTATION: none -- a self-expiring corpus bound, not a fix assertion.
+
+    def test_the_one_configuration_that_DOES_emit_connectors_is_still_clean(self):
+        """The FALLBACK-OFF leg of tests/test_fanout_clearance.py's frozen
+        sweep, on the one board that reaches the nudger with it: 9 via moves
+        and 17 connectors on four different layers, all registered, and NOT
+        ONE of them lands in any cap's keep-out. This is the whole in-repo
+        real-board A/B for #736, and it is what makes the synthetic rig
+        necessary rather than lazy.
+
+        `via_clear_fallback=False` is not decoration: with the fallback ON the
+        same board reports 0 unresolved, so the nudger is never called and
+        this arm would assert about nothing."""
+        board = os.path.join(_ROOT, 'kicad_files',
+                             'orangecrab_ext_pll.kicad_pcb')
+        if not os.path.isfile(board):
+            print('SKIP: %s is absent' % board)
+            self.skipTest('fixture absent')
+        pcb = parse_kicad_pcb(board)
+        seen, buf = [], io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            r = repair_fanout_clearance(pcb, board, clearance=0.1,
+                                        max_displacement=0.0, max_passes=1,
+                                        via_clear_fallback=False,
+                                        on_move=lambda st: seen.append(st))
+        st = seen[0]
+        self.assertGreater(len(r['new_segments']), 10,
+                           'this configuration stopped emitting connectors, '
+                           'so the arm below is vacuous')
+        self.assertGreater(len({s['layer'] for s in r['new_segments']}), 2)
+        registered = {(round(s['start'][0], 6), round(s['start'][1], 6),
+                       round(s['end'][0], 6), round(s['end'][1], 6),
+                       s['net_id'], s['layer'])
+                      for s in r['new_segments']}
+        live = {(round(t[0], 6), round(t[1], 6), round(t[2], 6),
+                 round(t[3], 6), t[4], t[6]) for t in st.segments}
+        self.assertLessEqual(registered, live,
+                             'a connector the pass drew never reached the '
+                             'track view')
+        dirty = {ref: st._seg_shortfalls(ref, c, c.x, c.y, c.rot)
+                 for ref, c in st.caps.items()}
+        self.assertEqual({k: v for k, v in dirty.items() if v}, {},
+                         'a connector now grazes a cap on a REAL board -- '
+                         'grade it with check_drc before believing it')
+    # MUTATION: delete the refresh -> `registered <= live` fails.
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/test_737_fanout_clearance_via_hole.py
+++ b/tests/test_737_fanout_clearance_via_hole.py
@@ -87,28 +87,43 @@ Conventions this file follows (#697/#725/#731/#732/#733 and CLAUDE.md):
       - the corpus bound, where the widest tracked ring 0.1500 sits 0.0500
         under the 0.2000 threshold. That IS the finding, not a fixture.
 
-A 14-mutation run over the engine gate kills 13. The survivor is named rather
-than hidden: `<` -> `<=`. Its mechanism is worth stating correctly, because the
-obvious version is wrong: it is NOT that no candidate lands on an exact tie --
-this rig generates two (XH_MOVES at r = 0.50 gives a gap of exactly 0.2000, and
-XH_SEPARATES_THE_FLOORS at r = 0.50 exactly 0.1000), they are simply never
-reached because an earlier radius wins. The real reason is stronger: the gate
-compares against `floor + vr - 1e-4`, so a gap sitting on the FLOOR is 1e-4
-clear of the COMPARISON boundary, and `<` and `<=` are therefore behaviourally
-identical for every input -- not merely for every input this file tries.
+A 17-mutation run over the engine gate kills 17. Getting there took two wrong
+explanations of ONE mutation, `<` -> `<=`, and both are recorded because the
+second is the more seductive:
 
-Dropping the `- 1e-4` was likewise measured to leave the entire suite green (it
-was predicted to break test_732's DVS_BIG rig; it does not). It is therefore
-held by the source guard in `TestTheFloorIsTheVIARuleNotTheTRACKFloor` -- the two sibling
-gates must read as one expression, which is a source property.
+  1. "no candidate lands on an exact tie" -- false. This rig generates two
+     (XH_MOVES at r = 0.50 gives a gap of exactly 0.2000, and
+     XH_SEPARATES_THE_FLOORS at r = 0.50 exactly 0.1000); they are simply never
+     REACHED, because an earlier radius wins.
+  2. "the `- 1e-4` moves the comparison boundary off the floor, so the two
+     spellings are identical for EVERY input" -- also false, and it reasons
+     about the wrong quantity. The tie that matters is at the COMPARISON
+     boundary `floor + vr - 1e-4`, not at the floor, and that boundary is
+     reachable from ordinary 1um-grid KiCad geometry.
 
-Five of those fourteen were added after review found the first version of the
-source guard defeatable, and all five die: the epsilon hidden behind a trailing
-comment, the floor hidden behind one, the CONNECTOR gate unified onto this
-gate's floor, `H2H_PAD` moved, and the staged project's declaring key mistyped.
+`TestTheComparisonIsSTRICT` builds it: an NPTH hole of drill 0.500100 at
+x = 4.499950 makes the helper return exactly 0.7998999999999999, which IS
+`clearance + vr - 1e-4` in float. The shipped `<` accepts that candidate and
+the via relocates; `<=` refuses it and the repair is lost. So the survival was
+a FIXTURE GAP, not a proof of equivalence -- and the fixture now exists.
+
+This is the one place the file's "no fixture within 0.05mm of the quantity
+under test" convention is deliberately inverted: an exact tie IS the quantity
+under test there, and the arm asserts the tie before asserting about it.
+
+Eight of the seventeen were added by successive review rounds, and all eight
+die: the epsilon hidden behind a trailing comment, the floor hidden behind one,
+the CONNECTOR gate unified onto this gate's floor, `H2H_PAD` moved, the staged
+project's declaring key mistyped, the track floor SPELT as `clearance`
+(`max(clearance, 0.20)`, which the source guard alone cannot catch), the same
+via the named constant, and a board-aware `getattr(st, 'npth_floor', 0.0)`.
 Two FALSE-POSITIVE probes -- a comment mentioning `_seg_foreign_hole_dist(`,
 and one mentioning `st.npth_floor` -- correctly change nothing, which the
-earlier raw-line version of the guard did not manage.
+earlier raw-line version of the source guard did not manage.
+
+Dropping the `- 1e-4` is killed by the source guard only; it was measured to
+leave the entire suite green on behaviour alone (it was predicted to break
+test_732's DVS_BIG rig; it does not).
 
 Runs in-process in a couple of seconds; the corpus class shells out once for
 `git ls-files`.
@@ -169,10 +184,11 @@ LANDING = (3.45, 3.0)          # the FIRST landing the walls admit
 # admitted at r = 0.50 and 0.55, both also at k = 0 -- (3.50, 3.00) and
 # (3.55, 3.00). Naming LANDING "the only one" would be false, and the refusal
 # arms do not rest on it being the only one. They rest on something stronger:
-# the hole sits ON that single admissible ray, so the copper-to-hole gap grows
-# monotonically with r, and a hole close enough to refuse (3.45) refuses every
-# candidate BEYOND it too -- which is why a refusal arm ends with an empty
-# `moves` rather than with a different landing. ALL_CANDIDATES pins the set.
+# every admissible candidate lies on the +x ray and the hole is FURTHER along
+# it, so the copper-to-hole gap SHRINKS as r grows -- (3.45) is the roomiest of
+# the three, and refusing it refuses the other two a fortiori. That is why a
+# refusal arm ends with an empty `moves` rather than with a different landing.
+# ALL_CANDIDATES pins the set, and the arms assert every member.
 ALL_CANDIDATES = ((3.45, 3.0), (3.50, 3.0), (3.55, 3.0))
 WALL_L = (0.0, 0.0, 2.625, 8.0, 2)
 WALL_T = (0.0, 3.90, 8.0, 8.0, 2)
@@ -538,6 +554,58 @@ class TestTheFloorIsTheVIARuleNotTheTRACKFloor(unittest.TestCase):
     # any fixture that could catch it would sit on the threshold.
 
 
+class TestTheComparisonIsSTRICT(unittest.TestCase):
+    """`<`, not `<=`. The only mutation this file could not kill for two
+    rounds, because both explanations offered for its survival were wrong (see
+    the module docstring). A gap exactly ON the comparison boundary
+    `clearance + vr - 1e-4` is reachable from ordinary 1um-grid geometry, and
+    the two spellings disagree there."""
+
+    #: Chosen so `_seg_foreign_hole_dist` returns the boundary EXACTLY in
+    #: float. Both are 1um-grid values a real board could carry.
+    TIE_DRILL = 0.500100
+    TIE_X = 4.499950
+
+    def _tie_board(self):
+        bi = BoardInfo(layers={}, copper_layers=['F.Cu', 'B.Cu'],
+                       board_bounds=(0.0, 0.0, 8.0, 8.0))
+        v = make_via(VIA0[0], VIA0[1], net_id=3, size=V_SIZE, drill=V_DRILL)
+        stub = make_seg(2.0, 3.0, VIA0[0], VIA0[1], width=0.2, layer='F.Cu',
+                        net_id=3)
+        hole = make_pad(net_id=0, x=self.TIE_X, y=3.0, ref='H1REF', num='H1',
+                        size_x=self.TIE_DRILL, size_y=self.TIE_DRILL,
+                        shape='circle', layers=['F.Mask', 'B.Mask'],
+                        drill=self.TIE_DRILL, pad_type='np_thru_hole')
+        pcb = make_pcb(board_info=bi, vias=[v], segments=[stub],
+                       footprints={'C1': SimpleNamespace(layer='F.Cu',
+                                                         pads=[])},
+                       pads_by_net={0: [hole]}, zones=[])
+        return v, pcb
+
+    def test_a_candidate_exactly_ON_the_boundary_is_ACCEPTED(self):
+        """Deliberately inverts this file's own no-fixture-on-a-threshold rule:
+        an exact tie IS the quantity under test here."""
+        v, pcb = self._tie_board()
+        # ON THE BRANCH: assert the tie before asserting about it. Float
+        # equality is the point, so `assertEqual`, not assertAlmostEqual.
+        boundary = CLEAR + VR - 1e-4
+        self.assertEqual(
+            _seg_foreign_hole_dist(pcb, 3, LANDING[0], LANDING[1],
+                                   LANDING[0], LANDING[1]), boundary,
+            'the fixture no longer lands on the comparison boundary, so this '
+            'arm cannot tell `<` from `<=` and proves nothing')
+        moves, segs, out = _nudge(_FakeSt(WALLS), pcb, max_shift=MAX_SHIFT)
+        self.assertEqual(len(moves), 1,
+                         'a candidate exactly ON the boundary was refused -- '
+                         'the comparison is `<=`, and a gap equal to the '
+                         'requirement is legal, not a violation')
+        self.assertAlmostEqual(v.x, LANDING[0], places=4)
+        self.assertEqual(len(segs), 1)
+        self.assertIn('moved', out)
+    # MUTATION: `<` -> `<=` -- this candidate is refused, `no clear spot`
+    # prints, and the repair is lost. Nothing else in the file catches it.
+
+
 class TestTheTwoSiblingValidatorsSeeTheSameHoles(unittest.TestCase):
     """Why the gate calls the shared helper instead of reusing `board_pads`."""
 
@@ -550,7 +618,12 @@ class TestTheTwoSiblingValidatorsSeeTheSameHoles(unittest.TestCase):
 
     def test_an_NPTH_hole_on_a_MOVABLE_CAP_is_still_seen(self):
         """`board_pads` drops the pads of movable caps; the helper keeps them.
-        This is the ONE arm that separates the two implementations."""
+        This is the one arm that separates the two implementations on
+        BEHAVIOUR. The source guard co-kills that mutation for a structural
+        reason -- any inline version necessarily removes a
+        `_seg_foreign_hole_dist(` call site -- so "the only thing that catches
+        it" would be false; this is the only thing that catches it by running
+        the pass."""
         v, pcb, moves, segs, out = _rig(XH_REFUSED_BY_BOTH, hole_ref='C1')
         # ON THE BRANCH: the pad really is invisible to a board_pads-based
         # gate, and really is visible to the helper.
@@ -566,7 +639,8 @@ class TestTheTwoSiblingValidatorsSeeTheSameHoles(unittest.TestCase):
         self.assertEqual((moves, segs), ([], []))
         self.assertEqual((v.x, v.y), VIA0)
     # MUTATION: reimplement the gate inline over `board_pads` (reusing its
-    # `cap_` capsule) -- this arm moves while every other arm still passes.
+    # `cap_` capsule) -- this arm moves. The source guard also fires, on the
+    # missing call site; this is the only BEHAVIOURAL arm that does.
 
     def test_a_hole_on_the_VIAS_OWN_NET_is_exempt(self):
         """NEGATIVE CONTROL for the net filter. A via on the hole's own net

--- a/tests/test_737_fanout_clearance_via_hole.py
+++ b/tests/test_737_fanout_clearance_via_hole.py
@@ -1,0 +1,545 @@
+"""#737: the relocated via's COPPER must be tested against an NPTH hole.
+
+`nudge_vias_for_unresolved` has two sibling validators, written to mirror each
+other. `connector_clear` tests the connector TRACK's copper against copper-less
+drill holes; `valid_via_pos` had NO equivalent for the via it relocates. Its
+only drilled-pad gate is drill-to-drill at the JLC `H2H_PAD` floor, which
+measures the DRILL -- so it covered the annular ring only while
+
+    ring = (size - drill) / 2  <=  H2H_PAD - npth_clr
+
+That bound is NOT the constant 0.25 the issue quotes: `npth_clr` is
+`max(clearance, NPTH_TO_TRACK_CLEARANCE)`, so it is 0.25 only at clearance
+<= 0.20, **0.20 at the shipped `--clearance` 0.25**, and 0 at clearance >= 0.45.
+Past it the pass parks ring copper inside a mounting hole's keep-out -- and it
+WRITES that via (placement/writer.py on the CLI, the plugin's own pcbnew mirror
+in the GUI).
+
+Measured at HEAD before the fix, on the rig below (`--clearance 0.1`, a 1.4/0.3
+via boxed so its only escape is +x): the via relocates to (3.4500, 3.0000),
+0.0500mm of copper-to-hole-WALL gap where 0.2000 is required, and `check_drc`
+grades that board with its own via arm of the same rule:
+
+    VIA-HOLE violations (1):
+      Hole:net_0 (MH1.H1) <-> Via:net_1 (copper-to-hole)
+        Overlap: 0.050mm    Hole: (4.70,3.00)    Via: (3.45,3.00)
+
+After the fix no candidate validates, `via-nudge: no clear spot` prints, and the
+via stays put. A via with real room still relocates.
+
+WHY THE FLOOR IS `npth_clr` AND NOT A BARE `clearance`, decided by measurement
+rather than by argument. Both candidates were run over all 27 tracked boards at
+`--clearance` 0.25 AND 0.1, comparing placements with coordinates, the
+unresolved list, `via_moves`, `new_segments` and stdout: **0 boards differ, on
+either arm, at either clearance.** Both are inert everywhere this repo can
+measure, so the conservative one ships. Two facts make that cheap:
+
+  * At every shipped default they are the SAME NUMBER. `routing_defaults`
+    CLEARANCE is 0.25 and `npth_clr` is `max(clearance, 0.20)`, so on the CLI,
+    GUI and animator path `npth_clr == clearance` exactly and this gate IS
+    check_drc's `via-hole` arm. The choice bites only below clearance 0.20.
+  * `npth_clr >= clearance` always, so the pass can never emit a via its own
+    checker then flags -- a one-way invariant a bare `clearance` gives only as
+    equality.
+
+NOT A REVERSAL OF #617, and `TestTheFloorIsTheFlatFabFloor` pins that
+behaviourally. #617 measured that RAISING this pass's hole floor to a board's
+DECLARED `min_hole_clearance` turns 1 move / 1 connector into 0 / 0; #737 ADDS a
+missing gate at the flat fab floor and leaves the declared value unread.
+
+DELIBERATELY NOT CLOSED HERE: neither hole gate honours the hole pad's own
+`local_clearance`, which check_drc does honour -- that is #730, a wrong VALUE
+where this is a missing GATE.
+
+Conventions this file follows (#697/#725/#731/#732/#733 and CLAUDE.md):
+
+  * Every assertion names the single-line MUTATION that must kill it.
+  * Assert you are ON THE BRANCH before asserting about it.
+  * Every "is refused" is paired with a NEGATIVE CONTROL that still moves.
+  * No fixture sits within 0.05mm of the quantity under test. The ONE
+    sub-0.05 boundary in the rig is the CAP gate (0.025 either side of
+    nx = 3.425); that is the sweep's own 0.05mm radial quantum, it is stated
+    here rather than left for a reviewer to find, and it is not the quantity
+    any assertion below measures.
+
+A 9-mutation run over the engine gate kills 8. The survivor is named rather
+than hidden: `<` -> `<=`. It, and dropping the `- 1e-4`, were both measured to
+leave the ENTIRE suite green on behaviour alone -- they decide an exact tie, and
+the 0.05mm spiral produces no candidate that sits on one. The 1e-4 is therefore
+held by the SOURCE guard in `TestTheFloorIsTheFlatFabFloor` (the two sibling
+gates must read as one expression, which is a source property); `<=` is held by
+nothing, because any fixture that could catch it would have to sit on the
+threshold this file's own convention forbids.
+
+Runs in-process in a couple of seconds; the corpus class shells out once for
+`git ls-files`.
+
+    python3 tests/test_737_fanout_clearance_via_hole.py
+"""
+from __future__ import annotations
+
+RUN_ALL_FAST_OK = True
+RUN_ALL_TIMEOUT = 900
+
+import contextlib
+import inspect
+import io
+import json
+import math
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+_TESTS = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_TESTS)
+for _p in ('', 'py_router', 'py_placer', 'py_tools'):
+    _d = os.path.join(_ROOT, _p)
+    if _d not in sys.path:
+        sys.path.insert(0, _d)
+if _TESTS not in sys.path:
+    sys.path.insert(0, _TESTS)
+
+import routing_defaults as defaults
+from bga_fanout.constants import DEFAULT_VIA_SIZE
+from check_drc import _pad_has_no_copper
+from kicad_parser import BoardInfo, parse_kicad_pcb
+from single_ended_routing import _seg_foreign_hole_dist
+from synth import make_pad, make_pcb, make_seg, make_via
+from placement import fanout_clearance as FC
+from placement.fanout_clearance import nudge_vias_for_unresolved
+
+# --- the rig ---------------------------------------------------------------
+CLEAR = 0.1                    # -> npth_clr 0.20; every other requirement 0.10
+NPTH_FLOOR = defaults.NPTH_TO_TRACK_CLEARANCE       # 0.20
+H2H_PAD = 0.45                 # the function's own literal, mirrored here
+V_SIZE, V_DRILL = 1.4, 0.3     # vr 0.70, ring 0.55 -- past the masking bound
+VR = V_SIZE / 2.0
+H_DRILL = 1.0                  # hr 0.50
+HR = H_DRILL / 2.0
+MAX_SHIFT = 0.55
+VIA0 = (3.0, 3.0)              # the offending via, net 3
+LANDING = (3.45, 3.0)          # the ONLY landing the walls admit
+
+# Foreign-net (2) walls that box the search to +x, so the landing is
+# deterministic and one-dimensional: T/B admit only |dy| <= 0.10, and L needs
+# nx >= 3.425, so the first admissible ring is r = 0.45 -> (3.45, 3.00).
+WALL_L = (0.0, 0.0, 2.625, 8.0, 2)
+WALL_T = (0.0, 3.90, 8.0, 8.0, 2)
+WALL_B = (0.0, 0.0, 8.0, 2.10, 2)
+WALLS = [WALL_L, WALL_T, WALL_B]
+
+# Hole x positions. Distance from the landing is XH - 3.45; the gate measures
+# to the hole WALL, so the requirement is `floor + VR` on `XH - 3.45 - HR`.
+XH_REFUSED_BY_BOTH = 4.70      # wall gap 0.050 -- refused at either floor
+XH_SEPARATES_THE_FLOORS = 4.80  # wall gap 0.150 -- refused at 0.20, not at 0.10
+XH_MOVES = 4.90                # wall gap 0.250 -- moves at 0.20, not at 0.40
+
+
+class _FakeCap:
+    """Minimal stand-in for _Cap: fixed pad rects, never moves."""
+
+    def __init__(self, rects):
+        self._rects = list(rects)
+        self.x = self.y = self.rot = 0.0
+
+    def pad_rects(self, x=None, y=None, rot=None):
+        return self._rects
+
+
+class _FakeSt:
+    """The duck-typed `st` the #370/#617 harnesses pass: no resolvers at all,
+    so every requirement in the nudger falls back to the flat scalar."""
+
+    def __init__(self, rects):
+        self.caps = {'C1': _FakeCap(rects)}
+        self.vias = []
+
+    def graze_penalty(self, ref, cap, x, y, rot):
+        return 1.0          # permanently unresolved, so the offender loop RUNS
+
+
+def _board(xh, *, hole_net=0, hole_ref='H1REF', source_path=None,
+           v_size=V_SIZE, v_drill=V_DRILL, h_drill=H_DRILL):
+    bi = BoardInfo(layers={}, copper_layers=['F.Cu', 'B.Cu'],
+                   board_bounds=(0.0, 0.0, 8.0, 8.0))
+    v = make_via(VIA0[0], VIA0[1], net_id=3, size=v_size, drill=v_drill)
+    stub = make_seg(2.0, 3.0, VIA0[0], VIA0[1], width=0.2, layer='F.Cu',
+                    net_id=3)
+    hole = make_pad(net_id=hole_net, x=xh, y=3.0, ref=hole_ref, num='H1',
+                    size_x=h_drill, size_y=h_drill, shape='circle',
+                    layers=['F.Mask', 'B.Mask'], drill=h_drill,
+                    pad_type='np_thru_hole')
+    kw = {} if source_path is None else {'source_path': source_path}
+    pcb = make_pcb(board_info=bi, vias=[v], segments=[stub],
+                   footprints={'C1': SimpleNamespace(layer='F.Cu', pads=[])},
+                   pads_by_net={hole_net: [hole]}, zones=[], **kw)
+    return v, pcb
+
+
+def _nudge(st, pcb, clear=CLEAR, **kw):
+    """Drive the real pass, capturing what it printed. The PRINTED OUTPUT is
+    half the evidence: a refusal that prints nothing is indistinguishable from
+    a pass that never looked (the #732 silent-failure lesson)."""
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        moves, segs = nudge_vias_for_unresolved(st, pcb, clear, **kw)
+    return moves, segs, buf.getvalue()
+
+
+def _rig(xh, **kw):
+    v, pcb = _board(xh, **kw)
+    moves, segs, out = _nudge(_FakeSt(WALLS), pcb, max_shift=MAX_SHIFT)
+    return v, pcb, moves, segs, out
+
+
+def _wall_gap(xh, at=LANDING, hr=HR):
+    """The copper-edge-to-hole-WALL gap the new gate actually measures."""
+    return math.hypot(at[0] - xh, at[1] - 3.0) - hr - VR
+
+
+class TestARelocatedViaHonoursTheHoleFloor(unittest.TestCase):
+    """The headline, both signs."""
+
+    def test_a_via_whose_RING_reaches_into_a_mounting_hole_is_refused(self):
+        # ON THE BRANCH 1: the ring must be past the bound the DRILL test
+        # masks, or this rig is a statement about some other geometry.
+        self.assertGreater((V_SIZE - V_DRILL) / 2.0, H2H_PAD - NPTH_FLOOR,
+                           'the via ring does not exceed H2H_PAD - npth_clr, '
+                           'so the drill test would reject this landing on '
+                           'its own and the new gate is not what is measured')
+        # ON THE BRANCH 2: the landing is DRILL-test-legal, so the refusal
+        # below is attributable to the new gate and to nothing else.
+        d_axis = abs(LANDING[0] - XH_REFUSED_BY_BOTH)
+        self.assertGreaterEqual(d_axis, V_DRILL / 2.0 + HR + H2H_PAD + 0.05,
+                                'the landing is inside the drill-to-drill '
+                                'keep-out, so the drill test refuses it too')
+        self.assertLess(_wall_gap(XH_REFUSED_BY_BOTH), NPTH_FLOOR - 0.05,
+                        'the landing is not inside the copper-to-hole band')
+        v, _pcb, moves, segs, out = _rig(XH_REFUSED_BY_BOTH)
+        # The PRINT first: assert it before the counts and no mutation can
+        # make the silence be the reported failure.
+        self.assertIn('no clear spot', out,
+                      'the pass said nothing about a via it declined to move')
+        self.assertEqual(moves, [], 'the via was relocated into the hole band')
+        self.assertEqual(segs, [], 'connector copper was drawn for no move')
+        self.assertEqual((v.x, v.y), VIA0, 'the via was mutated in place')
+    # MUTATION: delete the `_seg_foreign_hole_dist` gate in valid_via_pos --
+    # the via is parked at (3.4500, 3.0000) with 0.0500mm of copper-to-hole
+    # gap and stdout says "moved" (check_drc: VIA-HOLE, overlap 0.050mm).
+
+    def test_a_via_with_real_room_still_moves(self):
+        """The over-rejection guard, and the negative control for every
+        refusal in this file: the same rig with the hole 0.20mm further off."""
+        self.assertGreaterEqual(_wall_gap(XH_MOVES), NPTH_FLOOR + 0.04,
+                                'the control landing is not clear of the gate')
+        v, _pcb, moves, segs, out = _rig(XH_MOVES)
+        self.assertEqual(len(moves), 1,
+                         'a via with 0.25mm of copper-to-hole gap was refused '
+                         'at a 0.20mm requirement -- the gate over-rejects')
+        self.assertAlmostEqual(v.x, LANDING[0], places=4)
+        self.assertAlmostEqual(v.y, LANDING[1], places=4)
+        self.assertEqual([(s['layer'], s['width']) for s in segs],
+                         [('F.Cu', 0.2)])
+        self.assertIn('moved', out)
+    # MUTATION: `npth_clr + vr` -> `npth_clr + 2 * vr` -- the gate
+    # over-rejects and this move disappears.
+
+    def test_the_gate_prices_the_BARREL_not_the_DRILL(self):
+        """What separates #737's gate from the drill test beside it."""
+        v, _pcb, moves, _segs, _out = _rig(XH_REFUSED_BY_BOTH)
+        self.assertGreater(VR, (v.drill or 0.3) / 2.0 + 0.05,
+                           'barrel and drill radius are too close for this '
+                           'rig to tell the two conventions apart')
+        # A drill-priced gate would need only 0.15 + 0.50 + 0.20 = 0.85 of
+        # centre distance; the landing has 1.25, so it would accept.
+        self.assertGreater(abs(LANDING[0] - XH_REFUSED_BY_BOTH),
+                           V_DRILL / 2.0 + HR + NPTH_FLOOR + 0.05,
+                           'a drill-priced gate would refuse this landing too')
+        self.assertEqual(moves, [])
+    # MUTATION: `npth_clr + vr` -> `npth_clr + (v.drill or 0.3) / 2.0` -- the
+    # requirement falls to 0.85 of centre distance and the via moves.
+
+
+class TestTheFloorIsTheFlatFabFloor(unittest.TestCase):
+    """Brackets the floor from BOTH sides: above a bare `clearance`, and not
+    raised by a board's declared `min_hole_clearance` (the #617 pin)."""
+
+    def test_the_floor_is_not_the_bare_clearance(self):
+        # ON THE BRANCH: above clearance 0.20 the two candidates coincide and
+        # this arm asserts nothing.
+        self.assertLess(CLEAR, NPTH_FLOOR,
+                        'at this clearance npth_clr == clearance, so this '
+                        'test cannot separate the two conventions')
+        gap = _wall_gap(XH_SEPARATES_THE_FLOORS)
+        self.assertGreater(gap, CLEAR + 0.04,
+                           'the landing is inside the bare-clearance band '
+                           'too, so a `clearance` floor would refuse it as '
+                           'well and this arm proves nothing')
+        self.assertLess(gap, NPTH_FLOOR - 0.04,
+                        'the landing is outside the npth_clr band')
+        _v, _pcb, moves, segs, out = _rig(XH_SEPARATES_THE_FLOORS)
+        self.assertIn('no clear spot', out)
+        self.assertEqual((moves, segs), ([], []))
+    # MUTATION: `npth_clr + vr` -> `clearance + vr` -- the requirement drops
+    # to a 0.10mm wall gap and the via moves to (3.4500, 3.0000).
+
+    def test_a_DECLARED_min_hole_clearance_changes_nothing(self):
+        """#617's balance, pinned behaviourally rather than by comment. A
+        board declaring 0.40 would refuse this landing if the gate read the
+        board; the flat floor accepts it, so the #130 repair is kept."""
+        self.assertGreater(_wall_gap(XH_MOVES), NPTH_FLOOR + 0.04,
+                           'the landing does not clear the flat floor')
+        self.assertLess(_wall_gap(XH_MOVES), 0.40 - 0.04,
+                        'the landing clears 0.40 as well, so a board-aware '
+                        'gate would accept it and this arm is vacuous')
+        with tempfile.TemporaryDirectory() as td:
+            pcb_path = os.path.join(td, 'b.kicad_pcb')
+            with open(pcb_path, 'w', encoding='utf-8') as f:
+                f.write('(kicad_pcb (version 20240108))\n')
+            with open(os.path.join(td, 'b.kicad_pro'), 'w',
+                      encoding='utf-8') as f:
+                json.dump({'board': {'design_settings':
+                                     {'rules': {'min_hole_clearance': 0.40}}}},
+                          f)
+            v, pcb = _board(XH_MOVES, source_path=pcb_path)
+            moves, segs, out = _nudge(_FakeSt(WALLS), pcb, max_shift=MAX_SHIFT)
+        self.assertEqual(len(moves), 1,
+                         'the declared 0.40 reached this gate -- #617 '
+                         'measured that raising it costs the repair entirely')
+        self.assertAlmostEqual(v.x, LANDING[0], places=4)
+        self.assertEqual(len(segs), 1)
+        self.assertIn('moved', out)
+    # MUTATION: `npth_clr` -> `st.npth_floor` (or a resolve_hole_clearance
+    # read) -- this arm refuses while the project-less arm above still moves.
+
+    def test_both_hole_gates_in_the_nudger_spell_the_same_floor(self):
+        """A source guard, because the two sibling validators drifting apart
+        IS this issue. Reports the offending LINES, never assertIn over the
+        whole source (test_732 measured a 393KB failure message)."""
+        src = inspect.getsource(FC.nudge_vias_for_unresolved).splitlines()
+        calls = [i for i, l in enumerate(src)
+                 if '_seg_foreign_hole_dist(' in l
+                 and not l.lstrip().startswith('#')]
+        self.assertEqual(len(calls), 2,
+                         'expected exactly two copper-to-hole gates (the via '
+                         'and the connector); found %d at function-relative '
+                         'line(s) %s' % (len(calls), [i + 1 for i in calls]))
+        bad = [i + 1 for i in calls
+               if 'npth_clr' not in ' '.join(src[i:i + 3])]
+        self.assertEqual(bad, [],
+                         'a hole gate does not spell npth_clr, at '
+                         'function-relative line(s) %s' % bad)
+        # The tolerance too. This one is pinned HERE and nowhere else, and
+        # deliberately so: measured, dropping `- 1e-4` from the via gate leaves
+        # the whole suite green, because it only decides an exact tie and no
+        # candidate the 0.05mm spiral produces lands on one. It is kept because
+        # the two sibling gates must read as one expression, which is a source
+        # property, so a source guard is the honest place to hold it.
+        eps = [i + 1 for i in calls
+               if '1e-4' not in ' '.join(src[i:i + 3])]
+        self.assertEqual(eps, [],
+                         'a hole gate dropped the 1e-4 the other one carries, '
+                         'at function-relative line(s) %s' % eps)
+        drift = [i + 1 for i, l in enumerate(src)
+                 if ('npth_floor' in l or 'resolve_hole_clearance' in l)
+                 and not l.lstrip().startswith('#')]
+        self.assertEqual(drift, [],
+                         'the nudger reads a BOARD-AWARE hole floor at '
+                         'function-relative line(s) %s -- #617 refused that'
+                         % drift)
+    # MUTATION: re-spell either gate's floor, drop either 1e-4, or add a third
+    # gate -- the count, the `bad` list or the `eps` list changes. This arm is
+    # the ONLY thing that kills the 1e-4 mutation; `<` -> `<=` is killed by
+    # nothing at all, and is left declared rather than papered over, because
+    # any fixture that could catch it would sit on the threshold.
+
+
+class TestTheTwoSiblingValidatorsSeeTheSameHoles(unittest.TestCase):
+    """Why the gate calls the shared helper instead of reusing `board_pads`."""
+
+    @staticmethod
+    def _board_pads_would_see(pcb, cap_refs):
+        """`board_pads`' own filter, rebuilt here so the claim below is
+        measured rather than asserted from reading the source."""
+        return [p for ps in pcb.pads_by_net.values() for p in ps
+                if getattr(p, 'component_ref', None) not in cap_refs]
+
+    def test_an_NPTH_hole_on_a_MOVABLE_CAP_is_still_seen(self):
+        """`board_pads` drops the pads of movable caps; the helper keeps them.
+        This is the ONE arm that separates the two implementations."""
+        v, pcb, moves, segs, out = _rig(XH_REFUSED_BY_BOTH, hole_ref='C1')
+        # ON THE BRANCH: the pad really is invisible to a board_pads-based
+        # gate, and really is visible to the helper.
+        self.assertEqual(self._board_pads_would_see(pcb, {'C1'}), [],
+                         'the hole pad is NOT filtered out of board_pads, so '
+                         'this rig does not exercise the scope difference')
+        self.assertAlmostEqual(
+            _seg_foreign_hole_dist(pcb, 3, LANDING[0], LANDING[1],
+                                   LANDING[0], LANDING[1]), 0.75, places=4,
+            msg='the helper does not see this hole either, so the outcome '
+                'below is not about the scope difference')
+        self.assertIn('no clear spot', out)
+        self.assertEqual((moves, segs), ([], []))
+        self.assertEqual((v.x, v.y), VIA0)
+    # MUTATION: reimplement the gate inline over `board_pads` (reusing its
+    # `cap_` capsule) -- this arm moves while every other arm still passes.
+
+    def test_a_hole_on_the_VIAS_OWN_NET_is_exempt(self):
+        """NEGATIVE CONTROL for the net filter. A via on the hole's own net
+        legitimately lands there; check_drc's via arm exempts it the same way
+        (`if via.net_id == hnet: continue`)."""
+        v, pcb, moves, segs, out = _rig(XH_REFUSED_BY_BOTH, hole_net=3)
+        self.assertEqual(
+            _seg_foreign_hole_dist(pcb, 3, LANDING[0], LANDING[1],
+                                   LANDING[0], LANDING[1]), 1e9,
+            'the helper still sees this hole, so the exemption under test is '
+            'not the reason for the outcome below')
+        self.assertEqual(len(moves), 1,
+                         'an OWN-NET mounting hole blocked its own net')
+        self.assertEqual(len(segs), 1)
+        self.assertAlmostEqual(v.x, LANDING[0], places=4)
+        self.assertIn('moved', out)
+        # POSITIVE CONTROL, identical geometry on a foreign net.
+        self.assertEqual(_rig(XH_REFUSED_BY_BOTH)[2], [],
+                         'the foreign-net arm moves too, so this rig does not '
+                         'separate own-net from foreign-net at all')
+    # MUTATION: pass `0` (or drop the net argument) instead of `v.net_id` --
+    # a net-tied mounting hole blocks its own net's via and this arm refuses.
+
+
+class TestTheDrillTestIsUnchanged(unittest.TestCase):
+    """#617's own rig, verbatim. The change detector that says the #130 repair
+    is kept -- and the measurement that licenses the change."""
+
+    NPTH = (1.0, 0.98)
+    ND = 0.2
+    BAR = (0.2, 0.9, 1.8, 1.1, 2)
+
+    def _rig617(self):
+        bi = BoardInfo(layers={}, copper_layers=['F.Cu', 'B.Cu'],
+                       board_bounds=(0.0, 0.0, 3.0, 3.0))
+        v = make_via(1.0, 1.4, net_id=3, size=0.5, drill=0.3)
+        stub = make_seg(1.0, 1.6, 1.0, 1.4, width=0.2, layer='F.Cu', net_id=3)
+        hole = make_pad(net_id=0, x=self.NPTH[0], y=self.NPTH[1], ref='BUS1',
+                        num='H1', size_x=self.ND, size_y=self.ND,
+                        shape='circle', layers=['F.Mask', 'B.Mask'],
+                        drill=self.ND, pad_type='np_thru_hole')
+        pcb = make_pcb(board_info=bi, vias=[v], segments=[stub],
+                       footprints={'C1': SimpleNamespace(layer='F.Cu',
+                                                         pads=[])},
+                       pads_by_net={0: [hole]}, zones=[])
+        return v, pcb
+
+    def test_the_617_rig_relocates_to_exactly_the_same_place(self):
+        v, pcb = self._rig617()
+        moves, segs, out = _nudge(_FakeSt([self.BAR]), pcb)
+        self.assertEqual((len(moves), len(segs)), (1, 1),
+                         'the #130 pad-via repair #617 measured was traded '
+                         'away by this change')
+        self.assertAlmostEqual(v.x, 1.1148, places=4)
+        self.assertAlmostEqual(v.y, 1.6772, places=4)
+        self.assertIn('moved', out)
+        gap = _seg_foreign_hole_dist(
+            pcb, segs[0]['net_id'], segs[0]['start'][0], segs[0]['start'][1],
+            segs[0]['end'][0], segs[0]['end'][1]) - segs[0]['width'] / 2.0
+        self.assertAlmostEqual(gap, 0.22, places=4,
+                               msg='#617 records this connector landing at '
+                                   '0.2200mm; it moved')
+    # MUTATION: any change to the gate that rejects this landing -- the counts
+    # go to (0, 0) and the refusal line appears instead.
+
+    def test_the_new_gate_is_numerically_unreachable_on_a_NORMAL_via(self):
+        """Why #617 stays green, as an inequality rather than a hope: on a
+        0.5/0.3 via the DRILL test is the stricter of the two, so the new gate
+        can never be the binding one there."""
+        drill_need = 0.3 / 2.0 + self.ND / 2.0 + H2H_PAD          # 0.70
+        gate_need = 0.5 / 2.0 + self.ND / 2.0 + NPTH_FLOOR        # 0.55
+        self.assertGreater(drill_need, gate_need + 0.10,
+                           'the two requirements are close enough that the '
+                           'new gate could become the binding one here')
+        v, pcb = self._rig617()
+        _nudge(_FakeSt([self.BAR]), pcb)
+        d = math.hypot(v.x - self.NPTH[0], v.y - self.NPTH[1])
+        self.assertGreater(d, gate_need + 0.10,
+                           'the achieved landing has less than 0.10mm of '
+                           'headroom on the new gate')
+        self.assertAlmostEqual(d, 0.706588, places=5)
+    # MUTATION: none kills these -- they are the measurement that licenses the
+    # change. Their job is to fail loudly if a later edit moves the landing.
+
+
+class TestInertOnTheTrackedCorpus(unittest.TestCase):
+    """A self-expiring bound. The gate is UNREACHABLE on every board this repo
+    tracks, which is why the demonstration above is synthetic on purpose."""
+
+    @staticmethod
+    def _tracked():
+        out = subprocess.run(['git', 'ls-files', '-z', '*.kicad_pcb'],
+                             cwd=_ROOT, capture_output=True, text=True)
+        return [os.path.join(_ROOT, p) for p in out.stdout.split('\0')
+                if p.endswith('.kicad_pcb')]
+
+    def test_no_tracked_via_is_fat_enough_for_the_gate_to_bind(self):
+        boards = self._tracked()
+        self.assertGreater(len(boards), 25,
+                           'git ls-files returned %d boards -- never glob the '
+                           'directory, 11 boards in kicad_files/ alone are '
+                           'gitignored build products' % len(boards))
+        widest, where, total, with_both = 0.0, None, 0, []
+        for b in boards:
+            pcb = parse_kicad_pcb(b)
+            vias = [v for v in pcb.vias if (v.size or 0) > 0]
+            holes = [p for ps in pcb.pads_by_net.values() for p in ps
+                     if (getattr(p, 'drill', 0) or 0) > 0
+                     and _pad_has_no_copper(p)]
+            total += len(vias)
+            if not vias:
+                continue
+            r = max((v.size - (v.drill or 0)) / 2.0 for v in vias)
+            if r > widest:
+                widest, where = r, os.path.basename(b)
+            if holes:
+                with_both.append(os.path.basename(b))
+        self.assertGreater(total, 500,
+                           'only %d sized vias across the corpus -- the bound '
+                           'below would be vacuous' % total)
+        bound = H2H_PAD - max(defaults.CLEARANCE, NPTH_FLOOR)      # 0.20
+        self.assertLess(widest, bound - 0.04,
+                        'a tracked board now carries a via ring of %.4f (%s), '
+                        'at or near the %.4f bound where this gate starts to '
+                        'bind at the shipped --clearance %.2f. The "provably '
+                        'inert on the corpus" claim in this PR must be '
+                        're-measured.' % (widest, where, bound,
+                                          defaults.CLEARANCE))
+        # The boards carrying BOTH vias and copper-less holes are the only
+        # ones where this gate could ever fire; name them, so a change there
+        # is visible rather than silent.
+        self.assertEqual(sorted(with_both),
+                         ['orangecrab_ext_pll.kicad_pcb',
+                          'rp2350_fpga_eensy_prePlane.kicad_pcb'],
+                         'the set of boards carrying both vias and '
+                         'copper-less holes changed; re-run the corpus A/B')
+    # MUTATION: add a via with size - drill > 0.32 to any tracked board -- the
+    # inertness claim stops being true and this fails with the board's name.
+
+    def test_every_via_this_pipeline_CREATES_is_below_the_bound(self):
+        """The corpus is a snapshot; these are the sizes the tool itself
+        emits, and they are what keep the gate inert on boards it produces."""
+        bound = H2H_PAD - max(defaults.CLEARANCE, NPTH_FLOOR)
+        for name, size, drill in (
+                ('BGA_VIA', defaults.BGA_VIA_SIZE, defaults.BGA_VIA_DRILL),
+                ('VIA', defaults.VIA_SIZE, defaults.VIA_DRILL),
+                ('DEFAULT_VIA_SIZE', DEFAULT_VIA_SIZE, defaults.VIA_DRILL)):
+            with self.subTest(name):
+                self.assertLess((size - drill) / 2.0, bound - 0.04,
+                                '%s (%s/%s) now has a ring at the %.4f bound'
+                                % (name, size, drill, bound))
+    # MUTATION: raise BGA_VIA_SIZE past 0.62 -- the fanout vias this pass
+    # moves start binding and the inertness claim must be restated.
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/test_737_fanout_clearance_via_hole.py
+++ b/tests/test_737_fanout_clearance_via_hole.py
@@ -6,46 +6,60 @@ drill holes; `valid_via_pos` had NO equivalent for the via it relocates. Its
 only drilled-pad gate is drill-to-drill at the JLC `H2H_PAD` floor, which
 measures the DRILL -- so it covered the annular ring only while
 
-    ring = (size - drill) / 2  <=  H2H_PAD - npth_clr
+    ring = (size - drill) / 2  <=  H2H_PAD - clearance
 
-That bound is NOT the constant 0.25 the issue quotes: `npth_clr` is
-`max(clearance, NPTH_TO_TRACK_CLEARANCE)`, so it is 0.25 only at clearance
-<= 0.20, **0.20 at the shipped `--clearance` 0.25**, and 0 at clearance >= 0.45.
-Past it the pass parks ring copper inside a mounting hole's keep-out -- and it
-WRITES that via (placement/writer.py on the CLI, the plugin's own pcbnew mirror
-in the GUI).
+which is **0.20 at the shipped `--clearance` 0.25** and 0 at clearance >= 0.45,
+where every via binds. (The issue quotes a constant 0.25; that is the value for
+the TRACK floor, and this gate is not charged at the track floor -- see below.)
+Past that bound the pass parks ring copper inside a mounting hole's keep-out --
+and it WRITES that via (placement/writer.py on the CLI, the plugin's own pcbnew
+mirror in the GUI).
 
 Measured at HEAD before the fix, on the rig below (`--clearance 0.1`, a 1.4/0.3
 via boxed so its only escape is +x): the via relocates to (3.4500, 3.0000),
-0.0500mm of copper-to-hole-WALL gap where 0.2000 is required, and `check_drc`
-grades that board with its own via arm of the same rule:
+0.0500mm of copper-to-hole-WALL gap where the graded requirement is 0.1000, and
+`check_drc` grades that board with its own via arm of the same rule:
 
     VIA-HOLE violations (1):
       Hole:net_0 (MH1.H1) <-> Via:net_1 (copper-to-hole)
         Overlap: 0.050mm    Hole: (4.70,3.00)    Via: (3.45,3.00)
 
-After the fix no candidate validates, `via-nudge: no clear spot` prints, and the
-via stays put. A via with real room still relocates.
+The overlap IS the proof of the requirement: 0.1000 - 0.0500. After the fix no
+candidate validates, `via-nudge: no clear spot` prints, and the via stays put. A
+via with real room still relocates.
 
-WHY THE FLOOR IS `npth_clr` AND NOT A BARE `clearance`, decided by measurement
-rather than by argument. Both candidates were run over all 27 tracked boards at
-`--clearance` 0.25 AND 0.1, comparing placements with coordinates, the
-unresolved list, `via_moves`, `new_segments` and stdout: **0 boards differ, on
-either arm, at either clearance.** Both are inert everywhere this repo can
-measure, so the conservative one ships. Two facts make that cheap:
+WHY THE FLOOR IS `clearance` AND NOT THE SIBLING'S `npth_clr`. The asymmetry is
+the point, not an oversight, and it was decided by measurement after a first
+version of this file shipped the sibling's floor.
 
-  * At every shipped default they are the SAME NUMBER. `routing_defaults`
-    CLEARANCE is 0.25 and `npth_clr` is `max(clearance, 0.20)`, so on the CLI,
-    GUI and animator path `npth_clr == clearance` exactly and this gate IS
-    check_drc's `via-hole` arm. The choice bites only below clearance 0.20.
-  * `npth_clr >= clearance` always, so the pass can never emit a via its own
-    checker then flags -- a one-way invariant a bare `clearance` gives only as
-    equality.
+`npth_clr` is `max(clearance, NPTH_TO_TRACK_CLEARANCE)` -- a routing policy for
+TRACKS, which is what `connector_clear` gates. `check_drc` grades a VIA against
+a plain NPTH hole at `clearance` instead
+(`kicad_req = req_clr if req_clr > npth_clr else clearance`) and records why:
+charging a via the track floor "invents items kicad-cli never reports" (crkbd,
+7 phantoms at 0.016-0.023mm). `obstacle_map` stamps the same asymmetry -- a
+plain NPTH is a track keep-out, not a via-copper one.
 
-NOT A REVERSAL OF #617, and `TestTheFloorIsTheFlatFabFloor` pins that
-behaviourally. #617 measured that RAISING this pass's hole floor to a board's
-DECLARED `min_hole_clearance` turns 1 move / 1 connector into 0 / 0; #737 ADDS a
-missing gate at the flat fab floor and leaves the declared value unread.
+Charging `npth_clr` here does not merely cost search room, it COSTS THE REPAIR.
+Measured, and pinned by `TestTheTrackFloorWouldAbandonARepair`: at
+`--clearance 0.1` a landing 0.1500mm off the hole wall is graded CLEAN by
+check_drc (`NO DRC VIOLATIONS FOUND`), the track floor refuses it, no other
+candidate validates, and the cap keeps the #130 pad-via graze this pass exists
+to remove. That is the exact failure `obstacle_map.resolve_hole_clearance`
+names for this function BY NAME -- an all-or-nothing repair whose one clearing
+candidate must not be refused -- and it is the same balance #617 struck for the
+connector gate.
+
+The two floors are EQUAL at `--clearance >= 0.20`, so this only ever differs
+below the fab floor. That is not hypothetical: `place_fanout_clearance.py`'s own
+`--help` example is `--clearance 0.1`, and the GUI control's minimum is 0.05.
+
+NOT A REVERSAL OF #617, and `TestTheFloorIsTheVIARuleNotTheTRACKFloor` pins it
+behaviourally: #617 measured that RAISING this pass's hole floor -- to a board's
+DECLARED `min_hole_clearance` -- turns 1 move / 1 connector into 0 / 0. The
+declared value is still unread here, and the floor charged is the LOWER of the
+two candidates, so this pass refuses strictly less than the version review
+rejected.
 
 DELIBERATELY NOT CLOSED HERE: neither hole gate honours the hole pad's own
 `local_clearance`, which check_drc does honour -- that is #730, a wrong VALUE
@@ -73,7 +87,7 @@ Conventions this file follows (#697/#725/#731/#732/#733 and CLAUDE.md):
       - the corpus bound, where the widest tracked ring 0.1500 sits 0.0500
         under the 0.2000 threshold. That IS the finding, not a fixture.
 
-A 9-mutation run over the engine gate kills 8. The survivor is named rather
+A 14-mutation run over the engine gate kills 13. The survivor is named rather
 than hidden: `<` -> `<=`. Its mechanism is worth stating correctly, because the
 obvious version is wrong: it is NOT that no candidate lands on an exact tie --
 this rig generates two (XH_MOVES at r = 0.50 gives a gap of exactly 0.2000, and
@@ -85,15 +99,16 @@ identical for every input -- not merely for every input this file tries.
 
 Dropping the `- 1e-4` was likewise measured to leave the entire suite green (it
 was predicted to break test_732's DVS_BIG rig; it does not). It is therefore
-held by the SOURCE guard in `TestTheFloorIsTheFlatFabFloor` -- the two sibling
+held by the source guard in `TestTheFloorIsTheVIARuleNotTheTRACKFloor` -- the two sibling
 gates must read as one expression, which is a source property.
 
-A second round of four mutations, added after a review found the first version
-of that guard defeatable, kills all four: the epsilon hidden behind a trailing
-comment, the floor hidden behind one, `H2H_PAD` moved, and the staged project's
-declaring key mistyped. Two FALSE-POSITIVE probes -- a comment mentioning
-`_seg_foreign_hole_dist(`, and one mentioning `st.npth_floor` -- correctly
-change nothing, which the earlier raw-line version of the guard did not manage.
+Five of those fourteen were added after review found the first version of the
+source guard defeatable, and all five die: the epsilon hidden behind a trailing
+comment, the floor hidden behind one, the CONNECTOR gate unified onto this
+gate's floor, `H2H_PAD` moved, and the staged project's declaring key mistyped.
+Two FALSE-POSITIVE probes -- a comment mentioning `_seg_foreign_hole_dist(`,
+and one mentioning `st.npth_floor` -- correctly change nothing, which the
+earlier raw-line version of the guard did not manage.
 
 Runs in-process in a couple of seconds; the corpus class shells out once for
 `git ls-files`.
@@ -136,7 +151,8 @@ from placement import fanout_clearance as FC
 from placement.fanout_clearance import nudge_vias_for_unresolved
 
 # --- the rig ---------------------------------------------------------------
-CLEAR = 0.1                    # -> npth_clr 0.20; every other requirement 0.10
+CLEAR = 0.1                    # the VIA gate's floor, and check_drc's
+                               # -> npth_clr 0.20, the SIBLING's floor
 NPTH_FLOOR = defaults.NPTH_TO_TRACK_CLEARANCE       # 0.20
 H2H_PAD = 0.45                 # the function's own literal, mirrored here
 V_SIZE, V_DRILL = 1.4, 0.3     # vr 0.70, ring 0.55 -- past the masking bound
@@ -166,7 +182,8 @@ WALLS = [WALL_L, WALL_T, WALL_B]
 # Hole x positions. Distance from the landing is XH - 3.45; the gate measures
 # to the hole WALL, so the requirement is `floor + VR` on `XH - 3.45 - HR`.
 XH_REFUSED_BY_BOTH = 4.70      # wall gap 0.050 -- refused at either floor
-XH_SEPARATES_THE_FLOORS = 4.80  # wall gap 0.150 -- refused at 0.20, not at 0.10
+XH_SEPARATES_THE_FLOORS = 4.80  # wall gap 0.150 -- MOVES at 0.10, refused at
+                               # 0.20; check_drc grades this landing CLEAN
 XH_MOVES = 4.90                # wall gap 0.250 -- moves at 0.20, not at 0.40
 
 
@@ -238,8 +255,8 @@ class TestARelocatedViaHonoursTheHoleFloor(unittest.TestCase):
     def test_a_via_whose_RING_reaches_into_a_mounting_hole_is_refused(self):
         # ON THE BRANCH 1: the ring must be past the bound the DRILL test
         # masks, or this rig is a statement about some other geometry.
-        self.assertGreater((V_SIZE - V_DRILL) / 2.0, H2H_PAD - NPTH_FLOOR,
-                           'the via ring does not exceed H2H_PAD - npth_clr, '
+        self.assertGreater((V_SIZE - V_DRILL) / 2.0, H2H_PAD - CLEAR,
+                           'the via ring does not exceed H2H_PAD - clearance, '
                            'so the drill test would reject this landing on '
                            'its own and the new gate is not what is measured')
         # ON THE BRANCH 2: the landing is DRILL-test-legal, so the refusal
@@ -248,7 +265,7 @@ class TestARelocatedViaHonoursTheHoleFloor(unittest.TestCase):
         self.assertGreaterEqual(d_axis, V_DRILL / 2.0 + HR + H2H_PAD + 0.05,
                                 'the landing is inside the drill-to-drill '
                                 'keep-out, so the drill test refuses it too')
-        self.assertLess(_wall_gap(XH_REFUSED_BY_BOTH), NPTH_FLOOR - 0.05,
+        self.assertLess(_wall_gap(XH_REFUSED_BY_BOTH), CLEAR - 0.04,
                         'the landing is not inside the copper-to-hole band')
         # ON THE BRANCH 3: an empty `moves` means EVERY admissible candidate was
         # refused, not just the first. The walls admit three, all on the +x ray,
@@ -257,7 +274,7 @@ class TestARelocatedViaHonoursTheHoleFloor(unittest.TestCase):
         # would silently become a statement about the search budget.
         for cand in ALL_CANDIDATES:
             self.assertLess(_wall_gap(XH_REFUSED_BY_BOTH, at=cand),
-                            NPTH_FLOOR - 0.04,
+                            CLEAR - 0.04,
                             'candidate %s clears the gate, so a refusal here '
                             'would be about the 0.55mm budget, not the gate'
                             % (cand,))
@@ -270,24 +287,28 @@ class TestARelocatedViaHonoursTheHoleFloor(unittest.TestCase):
         self.assertEqual(segs, [], 'connector copper was drawn for no move')
         self.assertEqual((v.x, v.y), VIA0, 'the via was mutated in place')
     # MUTATION: delete the `_seg_foreign_hole_dist` gate in valid_via_pos --
-    # the via is parked at (3.4500, 3.0000) with 0.0500mm of copper-to-hole
-    # gap and stdout says "moved" (check_drc: VIA-HOLE, overlap 0.050mm).
+    # the via is parked at (3.4500, 3.0000) with 0.0500mm of copper-to-hole gap
+    # against a 0.1000 requirement, and stdout says "moved" (check_drc:
+    # VIA-HOLE, overlap 0.050mm -- which IS 0.1000 - 0.0500).
 
     def test_a_via_with_real_room_still_moves(self):
         """The over-rejection guard, and the negative control for every
         refusal in this file: the same rig with the hole 0.20mm further off."""
-        self.assertGreaterEqual(_wall_gap(XH_MOVES), NPTH_FLOOR + 0.04,
+        # Clear of BOTH candidate floors, so it is a control whichever one
+        # the gate charges -- it cannot be quietly invalidated by that choice.
+        self.assertGreaterEqual(_wall_gap(XH_MOVES),
+                                max(CLEAR, NPTH_FLOOR) + 0.04,
                                 'the control landing is not clear of the gate')
         v, _pcb, moves, segs, out = _rig(XH_MOVES)
         self.assertEqual(len(moves), 1,
                          'a via with 0.25mm of copper-to-hole gap was refused '
-                         'at a 0.20mm requirement -- the gate over-rejects')
+                         'at a 0.10mm requirement -- the gate over-rejects')
         self.assertAlmostEqual(v.x, LANDING[0], places=4)
         self.assertAlmostEqual(v.y, LANDING[1], places=4)
         self.assertEqual([(s['layer'], s['width']) for s in segs],
                          [('F.Cu', 0.2)])
         self.assertIn('moved', out)
-    # MUTATION: `npth_clr + vr` -> `npth_clr + 2 * vr` -- the gate
+    # MUTATION: `clearance + vr` -> `clearance + 2 * vr` -- the gate
     # over-rejects and this move disappears.
 
     def test_the_gate_prices_the_BARREL_not_the_DRILL(self):
@@ -299,35 +320,78 @@ class TestARelocatedViaHonoursTheHoleFloor(unittest.TestCase):
         # A drill-priced gate would need only 0.15 + 0.50 + 0.20 = 0.85 of
         # centre distance; the landing has 1.25, so it would accept.
         self.assertGreater(abs(LANDING[0] - XH_REFUSED_BY_BOTH),
-                           V_DRILL / 2.0 + HR + NPTH_FLOOR + 0.05,
+                           V_DRILL / 2.0 + HR + CLEAR + 0.05,
                            'a drill-priced gate would refuse this landing too')
         self.assertEqual(moves, [])
-    # MUTATION: `npth_clr + vr` -> `npth_clr + (v.drill or 0.3) / 2.0` -- the
-    # requirement falls to 0.85 of centre distance and the via moves.
+    # MUTATION: `clearance + vr` -> `clearance + (v.drill or 0.3) / 2.0` -- the
+    # requirement falls to 0.75 of centre distance and the via moves.
 
 
-class TestTheFloorIsTheFlatFabFloor(unittest.TestCase):
-    """Brackets the floor from BOTH sides: above a bare `clearance`, and not
-    raised by a board's declared `min_hole_clearance` (the #617 pin)."""
+class TestTheFloorIsTheVIARuleNotTheTRACKFloor(unittest.TestCase):
+    """The via gate charges `clearance`; its sibling charges `npth_clr`. That
+    asymmetry is deliberate -- check_drc grades a track and a via against a
+    plain NPTH hole at different values, and so does obstacle_map -- and these
+    arms are what stop a later reader unifying the two."""
 
-    def test_the_floor_is_not_the_bare_clearance(self):
-        # ON THE BRANCH: above clearance 0.20 the two candidates coincide and
-        # this arm asserts nothing.
+    def test_the_floor_is_NOT_the_siblings_track_floor(self):
+        # ON THE BRANCH: at clearance >= 0.20 the two coincide and this arm
+        # asserts nothing at all.
         self.assertLess(CLEAR, NPTH_FLOOR,
                         'at this clearance npth_clr == clearance, so this '
                         'test cannot separate the two conventions')
         gap = _wall_gap(XH_SEPARATES_THE_FLOORS)
         self.assertGreater(gap, CLEAR + 0.04,
-                           'the landing is inside the bare-clearance band '
-                           'too, so a `clearance` floor would refuse it as '
-                           'well and this arm proves nothing')
+                           'the landing is inside the via floor too, so it '
+                           'would be refused either way and this arm proves '
+                           'nothing')
         self.assertLess(gap, NPTH_FLOOR - 0.04,
-                        'the landing is outside the npth_clr band')
-        _v, _pcb, moves, segs, out = _rig(XH_SEPARATES_THE_FLOORS)
-        self.assertIn('no clear spot', out)
-        self.assertEqual((moves, segs), ([], []))
-    # MUTATION: `npth_clr + vr` -> `clearance + vr` -- the requirement drops
-    # to a 0.10mm wall gap and the via moves to (3.4500, 3.0000).
+                        'the landing clears the track floor as well, so the '
+                        'two conventions are not being separated here')
+        v, _pcb, moves, segs, out = _rig(XH_SEPARATES_THE_FLOORS)
+        self.assertEqual(len(moves), 1,
+                         'the via gate is charging the TRACK floor: it '
+                         'refused a landing check_drc grades clean')
+        self.assertAlmostEqual(v.x, LANDING[0], places=4)
+        self.assertEqual(len(segs), 1)
+        self.assertIn('moved', out)
+    # MUTATION: `clearance + vr` -> `npth_clr + vr` -- the requirement rises to
+    # a 0.20mm wall gap, this landing is refused, and (see the next arm) the
+    # repair is abandoned rather than merely relocated.
+
+    def test_the_track_floor_would_ABANDON_a_repair_check_drc_calls_clean(self):
+        """Why the asymmetry is not pedantry. `nudge_vias_for_unresolved` is an
+        all-or-nothing repair -- obstacle_map.resolve_hole_clearance names this
+        function BY NAME as one whose single clearing candidate must not be
+        refused. On this rig the track floor refuses every candidate, so the
+        cap would keep the #130 pad-via graze the pass exists to remove.
+
+        check_drc's own requirement for a via against a plain NPTH hole is
+        `hr + via.size/2 + clearance`, i.e. a wall gap of `clearance`.
+        Reproduced with the real checker on the equivalent board:
+
+            python3 py_router/check_drc.py rig48.kicad_pcb --clearance 0.1
+            -> NO DRC VIOLATIONS FOUND
+        """
+        self.assertGreaterEqual(
+            _wall_gap(XH_SEPARATES_THE_FLOORS), CLEAR,
+            'this landing is NOT clean at check_drc s via requirement, so '
+            'refusing it costs nothing and this arm is not about what it says')
+        # EVERY candidate the walls admit is inside the TRACK floor, so
+        # charging it loses the repair outright rather than moving it.
+        for cand in ALL_CANDIDATES:
+            self.assertLess(_wall_gap(XH_SEPARATES_THE_FLOORS, at=cand),
+                            NPTH_FLOOR,
+                            'candidate %s clears the track floor, so charging '
+                            'it would relocate rather than abandon, and this '
+                            'arm overstates the cost' % (cand,))
+        moves = _rig(XH_SEPARATES_THE_FLOORS)[2]
+        self.assertEqual(len(moves), 1,
+                         'the repair was abandoned on a landing check_drc '
+                         'grades CLEAN -- the exact failure mode '
+                         'obstacle_map.resolve_hole_clearance warns about for '
+                         'this function by name')
+    # MUTATION: `clearance + vr` -> `npth_clr + vr` -- 0 moves, 0 connectors,
+    # and `no clear spot` printed, on geometry the checker calls clean.
 
     def test_a_DECLARED_min_hole_clearance_changes_nothing(self):
         """#617's balance, pinned behaviourally rather than by comment. A
@@ -369,10 +433,13 @@ class TestTheFloorIsTheFlatFabFloor(unittest.TestCase):
     # MUTATION: `npth_clr` -> `st.npth_floor` (or a resolve_hole_clearance
     # read) -- this arm refuses while the project-less arm above still moves.
 
-    def test_both_hole_gates_in_the_nudger_spell_the_same_floor(self):
-        """A source guard, because the two sibling validators drifting apart
-        IS this issue. Reports the offending LINES, never assertIn over the
-        whole source (test_732 measured a 393KB failure message)."""
+    def test_the_two_hole_gates_keep_their_DIFFERENT_floors(self):
+        """A source guard. The two sibling validators drifting apart IS
+        this issue -- but they must agree about which HOLES exist, not
+        about what one COSTS: a track is charged npth_clr and a via
+        clearance, and unifying them in either direction is a defect.
+        Reports the offending LINES, never assertIn over the whole source
+        (test_732 measured a 393KB failure message)."""
         # CODE only. `l.lstrip().startswith('#')` drops a full-line comment
         # but not a trailing one, and the engine's comment block around this
         # very gate names `_seg_foreign_hole_dist`, `npth_clr`, `st.npth_floor`
@@ -389,11 +456,28 @@ class TestTheFloorIsTheFlatFabFloor(unittest.TestCase):
                          'expected exactly two copper-to-hole gates (the via '
                          'and the connector); found %d at function-relative '
                          'line(s) %s' % (len(calls), [i + 1 for i in calls]))
-        bad = [i + 1 for i in calls
-               if 'npth_clr' not in ' '.join(src[i:i + 3])]
-        self.assertEqual(bad, [],
-                         'a hole gate does not spell npth_clr, at '
-                         'function-relative line(s) %s' % bad)
+        # The two gates must spell DIFFERENT floors, and this is the guard
+        # that stops a later reader "tidying" them into one. The via gate
+        # (`v.net_id`) charges `clearance`; the connector gate (`net_id`, `hw`)
+        # charges `npth_clr`.
+        via_gate = [i for i in calls if 'v.net_id' in src[i]]
+        conn_gate = [i for i in calls if i not in via_gate]
+        self.assertEqual((len(via_gate), len(conn_gate)), (1, 1),
+                         'could not tell the via gate from the connector gate '
+                         'at function-relative line(s) %s'
+                         % [i + 1 for i in calls])
+        vtxt = ' '.join(src[via_gate[0]:via_gate[0] + 3])
+        ctxt = ' '.join(src[conn_gate[0]:conn_gate[0] + 3])
+        self.assertNotIn('npth_clr', vtxt,
+                         'the VIA gate spells npth_clr -- that is the TRACK '
+                         'floor, and charging it abandons repairs check_drc '
+                         'grades clean')
+        self.assertIn('clearance', vtxt,
+                      'the VIA gate does not spell `clearance`, which is what '
+                      'check_drc s via-hole arm grades at')
+        self.assertIn('npth_clr', ctxt,
+                      'the CONNECTOR gate no longer spells npth_clr -- #617 '
+                      'set that floor deliberately')
         # The tolerance too. This one is pinned HERE and nowhere else, and
         # deliberately so: measured, dropping `- 1e-4` from the via gate leaves
         # the whole suite green, because it only decides an exact tie and no
@@ -525,15 +609,15 @@ class TestTheDrillTestIsUnchanged(unittest.TestCase):
         0.5/0.3 via the DRILL test is the stricter of the two, so the new gate
         can never be the binding one there."""
         drill_need = 0.3 / 2.0 + self.ND / 2.0 + H2H_PAD          # 0.70
-        gate_need = 0.5 / 2.0 + self.ND / 2.0 + NPTH_FLOOR        # 0.55
-        self.assertGreater(drill_need, gate_need + 0.10,
+        gate_need = 0.5 / 2.0 + self.ND / 2.0 + CLEAR             # 0.45
+        self.assertGreater(drill_need, gate_need + 0.20,
                            'the two requirements are close enough that the '
                            'new gate could become the binding one here')
         v, pcb = self._rig617()
         _nudge(_FakeSt([self.BAR]), pcb)
         d = math.hypot(v.x - self.NPTH[0], v.y - self.NPTH[1])
-        self.assertGreater(d, gate_need + 0.10,
-                           'the achieved landing has less than 0.10mm of '
+        self.assertGreater(d, gate_need + 0.20,
+                           'the achieved landing has less than 0.20mm of '
                            'headroom on the new gate')
         self.assertAlmostEqual(d, 0.706588, places=5)
     # MUTATION: none kills these -- they are the measurement that licenses the
@@ -588,7 +672,7 @@ class TestInertOnTheTrackedCorpus(unittest.TestCase):
         self.assertGreater(total, 500,
                            'only %d sized vias across the corpus -- the bound '
                            'below would be vacuous' % total)
-        bound = H2H_PAD - max(defaults.CLEARANCE, NPTH_FLOOR)      # 0.20
+        bound = H2H_PAD - defaults.CLEARANCE                       # 0.20
         # Compared against the bound ITSELF, with the margin reported. An
         # arbitrary safety subtraction here would be the tightest number in
         # the file (0.1500 against 0.1600) while LOOKING like the loosest --
@@ -619,7 +703,7 @@ class TestInertOnTheTrackedCorpus(unittest.TestCase):
     def test_every_via_this_pipeline_CREATES_is_below_the_bound(self):
         """The corpus is a snapshot; these are the sizes the tool itself
         emits, and they are what keep the gate inert on boards it produces."""
-        bound = H2H_PAD - max(defaults.CLEARANCE, NPTH_FLOOR)
+        bound = H2H_PAD - defaults.CLEARANCE
         for name, size, drill in (
                 ('BGA_VIA', defaults.BGA_VIA_SIZE, defaults.BGA_VIA_DRILL),
                 ('VIA', defaults.VIA_SIZE, defaults.VIA_DRILL),

--- a/tests/test_737_fanout_clearance_via_hole.py
+++ b/tests/test_737_fanout_clearance_via_hole.py
@@ -56,20 +56,44 @@ Conventions this file follows (#697/#725/#731/#732/#733 and CLAUDE.md):
   * Every assertion names the single-line MUTATION that must kill it.
   * Assert you are ON THE BRANCH before asserting about it.
   * Every "is refused" is paired with a NEGATIVE CONTROL that still moves.
-  * No fixture sits within 0.05mm of the quantity under test. The ONE
-    sub-0.05 boundary in the rig is the CAP gate (0.025 either side of
-    nx = 3.425); that is the sweep's own 0.05mm radial quantum, it is stated
-    here rather than left for a reviewer to find, and it is not the quantity
-    any assertion below measures.
+  * No fixture in the rig below sits within 0.05mm of the quantity its
+    assertion measures -- the three hole positions sit at gaps 0.050 / 0.150 /
+    0.250 against a 0.200 floor, i.e. exactly 0.05 clear on both sides. Four
+    tighter boundaries exist and are named here rather than left for a reviewer
+    to find, because a blanket claim that ignored them would be false:
+      - the CAP gate, 0.025 either side of nx = 3.425. That is the sweep's own
+        0.05mm radial quantum, and no assertion here measures it.
+      - #617's INHERITED rig, whose landing clears the drill gate by 0.006588
+        (0.706588 vs 0.700000) -- that margin is what CHOOSES the landing, and
+        it is #617's geometry, not a fixture this file picked. The arm that
+        reads it asserts the landing exactly, so it is a change detector for
+        precisely that.
+      - the same rig's connector, 0.0200 clear of the connector's own floor
+        (0.3200 vs 0.3000) -- again inherited, and asserted exactly (0.2200).
+      - the corpus bound, where the widest tracked ring 0.1500 sits 0.0500
+        under the 0.2000 threshold. That IS the finding, not a fixture.
 
 A 9-mutation run over the engine gate kills 8. The survivor is named rather
-than hidden: `<` -> `<=`. It, and dropping the `- 1e-4`, were both measured to
-leave the ENTIRE suite green on behaviour alone -- they decide an exact tie, and
-the 0.05mm spiral produces no candidate that sits on one. The 1e-4 is therefore
-held by the SOURCE guard in `TestTheFloorIsTheFlatFabFloor` (the two sibling
-gates must read as one expression, which is a source property); `<=` is held by
-nothing, because any fixture that could catch it would have to sit on the
-threshold this file's own convention forbids.
+than hidden: `<` -> `<=`. Its mechanism is worth stating correctly, because the
+obvious version is wrong: it is NOT that no candidate lands on an exact tie --
+this rig generates two (XH_MOVES at r = 0.50 gives a gap of exactly 0.2000, and
+XH_SEPARATES_THE_FLOORS at r = 0.50 exactly 0.1000), they are simply never
+reached because an earlier radius wins. The real reason is stronger: the gate
+compares against `floor + vr - 1e-4`, so a gap sitting on the FLOOR is 1e-4
+clear of the COMPARISON boundary, and `<` and `<=` are therefore behaviourally
+identical for every input -- not merely for every input this file tries.
+
+Dropping the `- 1e-4` was likewise measured to leave the entire suite green (it
+was predicted to break test_732's DVS_BIG rig; it does not). It is therefore
+held by the SOURCE guard in `TestTheFloorIsTheFlatFabFloor` -- the two sibling
+gates must read as one expression, which is a source property.
+
+A second round of four mutations, added after a review found the first version
+of that guard defeatable, kills all four: the epsilon hidden behind a trailing
+comment, the floor hidden behind one, `H2H_PAD` moved, and the staged project's
+declaring key mistyped. Two FALSE-POSITIVE probes -- a comment mentioning
+`_seg_foreign_hole_dist(`, and one mentioning `st.npth_floor` -- correctly
+change nothing, which the earlier raw-line version of the guard did not manage.
 
 Runs in-process in a couple of seconds; the corpus class shells out once for
 `git ls-files`.
@@ -121,11 +145,19 @@ H_DRILL = 1.0                  # hr 0.50
 HR = H_DRILL / 2.0
 MAX_SHIFT = 0.55
 VIA0 = (3.0, 3.0)              # the offending via, net 3
-LANDING = (3.45, 3.0)          # the ONLY landing the walls admit
+LANDING = (3.45, 3.0)          # the FIRST landing the walls admit
 
-# Foreign-net (2) walls that box the search to +x, so the landing is
-# deterministic and one-dimensional: T/B admit only |dy| <= 0.10, and L needs
-# nx >= 3.425, so the first admissible ring is r = 0.45 -> (3.45, 3.00).
+# Foreign-net (2) walls that box the search to +x, so the search is
+# one-dimensional: T/B admit only |dy| <= 0.10, and L needs nx >= 3.425, so the
+# first admissible ring is r = 0.45 -> (3.45, 3.00). Two further candidates are
+# admitted at r = 0.50 and 0.55, both also at k = 0 -- (3.50, 3.00) and
+# (3.55, 3.00). Naming LANDING "the only one" would be false, and the refusal
+# arms do not rest on it being the only one. They rest on something stronger:
+# the hole sits ON that single admissible ray, so the copper-to-hole gap grows
+# monotonically with r, and a hole close enough to refuse (3.45) refuses every
+# candidate BEYOND it too -- which is why a refusal arm ends with an empty
+# `moves` rather than with a different landing. ALL_CANDIDATES pins the set.
+ALL_CANDIDATES = ((3.45, 3.0), (3.50, 3.0), (3.55, 3.0))
 WALL_L = (0.0, 0.0, 2.625, 8.0, 2)
 WALL_T = (0.0, 3.90, 8.0, 8.0, 2)
 WALL_B = (0.0, 0.0, 8.0, 2.10, 2)
@@ -218,6 +250,17 @@ class TestARelocatedViaHonoursTheHoleFloor(unittest.TestCase):
                                 'keep-out, so the drill test refuses it too')
         self.assertLess(_wall_gap(XH_REFUSED_BY_BOTH), NPTH_FLOOR - 0.05,
                         'the landing is not inside the copper-to-hole band')
+        # ON THE BRANCH 3: an empty `moves` means EVERY admissible candidate was
+        # refused, not just the first. The walls admit three, all on the +x ray,
+        # so the gap grows monotonically with r and the far ones are the ones
+        # that could plausibly escape. Assert they do not -- otherwise this arm
+        # would silently become a statement about the search budget.
+        for cand in ALL_CANDIDATES:
+            self.assertLess(_wall_gap(XH_REFUSED_BY_BOTH, at=cand),
+                            NPTH_FLOOR - 0.04,
+                            'candidate %s clears the gate, so a refusal here '
+                            'would be about the 0.55mm budget, not the gate'
+                            % (cand,))
         v, _pcb, moves, segs, out = _rig(XH_REFUSED_BY_BOTH)
         # The PRINT first: assert it before the counts and no mutation can
         # make the silence be the reported failure.
@@ -305,6 +348,17 @@ class TestTheFloorIsTheFlatFabFloor(unittest.TestCase):
                                      {'rules': {'min_hole_clearance': 0.40}}}},
                           f)
             v, pcb = _board(XH_MOVES, source_path=pcb_path)
+            # VERIFY THE INPUT before trusting the output (CLAUDE.md's
+            # run_utils.evidence rule). The assertion below is an ABSENCE --
+            # "the declared value changed nothing" -- so a fixture that
+            # declares nothing passes it forever, for the wrong reason. Mistype
+            # the key and resolve_hole_clearance returns 0.0; this line is what
+            # makes that a failure instead of a green.
+            from obstacle_map import resolve_hole_clearance
+            self.assertAlmostEqual(
+                resolve_hole_clearance(pcb, None), 0.40, places=6,
+                msg='the staged project does not actually declare 0.40, so '
+                    'this arm would pass even if the gate DID read the board')
             moves, segs, out = _nudge(_FakeSt(WALLS), pcb, max_shift=MAX_SHIFT)
         self.assertEqual(len(moves), 1,
                          'the declared 0.40 reached this gate -- #617 '
@@ -319,10 +373,18 @@ class TestTheFloorIsTheFlatFabFloor(unittest.TestCase):
         """A source guard, because the two sibling validators drifting apart
         IS this issue. Reports the offending LINES, never assertIn over the
         whole source (test_732 measured a 393KB failure message)."""
-        src = inspect.getsource(FC.nudge_vias_for_unresolved).splitlines()
+        # CODE only. `l.lstrip().startswith('#')` drops a full-line comment
+        # but not a trailing one, and the engine's comment block around this
+        # very gate names `_seg_foreign_hole_dist`, `npth_clr`, `st.npth_floor`
+        # and `1e-4` repeatedly -- so reading raw lines both invented gates
+        # (measured: one `# see _seg_foreign_hole_dist(` line took the count to
+        # 3) and let a real one hide behind `npth_clr + vr:  # the 1e-4 was
+        # here`, which passed every arm of this file.
+        src = [l.split('#')[0]
+               for l in inspect.getsource(FC.nudge_vias_for_unresolved)
+               .splitlines()]
         calls = [i for i, l in enumerate(src)
-                 if '_seg_foreign_hole_dist(' in l
-                 and not l.lstrip().startswith('#')]
+                 if '_seg_foreign_hole_dist(' in l]
         self.assertEqual(len(calls), 2,
                          'expected exactly two copper-to-hole gates (the via '
                          'and the connector); found %d at function-relative '
@@ -344,12 +406,19 @@ class TestTheFloorIsTheFlatFabFloor(unittest.TestCase):
                          'a hole gate dropped the 1e-4 the other one carries, '
                          'at function-relative line(s) %s' % eps)
         drift = [i + 1 for i, l in enumerate(src)
-                 if ('npth_floor' in l or 'resolve_hole_clearance' in l)
-                 and not l.lstrip().startswith('#')]
+                 if 'npth_floor' in l or 'resolve_hole_clearance' in l]
         self.assertEqual(drift, [],
                          'the nudger reads a BOARD-AWARE hole floor at '
                          'function-relative line(s) %s -- #617 refused that'
                          % drift)
+        # And the one constant this file HAND-MIRRORS. `H2H_PAD` is a
+        # function-local literal, so it cannot be imported; three ON-THE-BRANCH
+        # guards above reason about the drill test using the mirror, and would
+        # silently reason about the wrong number if the engine's changed.
+        self.assertIn('H2H_PAD = %s' % H2H_PAD, ' '.join(src),
+                      "the engine's H2H_PAD is no longer %s, so this file's "
+                      'mirror -- and the drill-test arithmetic in every '
+                      'ON-THE-BRANCH guard here -- is stale' % H2H_PAD)
     # MUTATION: re-spell either gate's floor, drop either 1e-4, or add a third
     # gate -- the count, the `bad` list or the `eps` list changes. This arm is
     # the ONLY thing that kills the 1e-4 mutation; `<` -> `<=` is killed by
@@ -475,12 +544,25 @@ class TestInertOnTheTrackedCorpus(unittest.TestCase):
     """A self-expiring bound. The gate is UNREACHABLE on every board this repo
     tracks, which is why the demonstration above is synthetic on purpose."""
 
-    @staticmethod
-    def _tracked():
-        out = subprocess.run(['git', 'ls-files', '-z', '*.kicad_pcb'],
-                             cwd=_ROOT, capture_output=True, text=True)
-        return [os.path.join(_ROOT, p) for p in out.stdout.split('\0')
-                if p.endswith('.kicad_pcb')]
+    def _tracked(self):
+        """The boards git TRACKS. A checkout with no git, or a source export
+        outside a repo, cannot identify that set at all -- and must SKIP rather
+        than grade against a set it cannot name. Before this, a `git ls-files`
+        that exited 128 with empty output failed the count assertion below and
+        reported the gitignored-build-products reason, which is the WRONG
+        cause: `out.returncode` was captured and never read."""
+        try:
+            out = subprocess.run(['git', 'ls-files', '-z', '*.kicad_pcb'],
+                                 cwd=_ROOT, capture_output=True, text=True)
+        except OSError as e:
+            self.skipTest('SKIP: cannot run git to identify the tracked '
+                          'corpus: %s' % e)
+        if out.returncode != 0:
+            self.skipTest('SKIP: git ls-files exited %d (%s) -- the tracked '
+                          'corpus cannot be identified here'
+                          % (out.returncode, out.stderr.strip()[:120]))
+        return [os.path.join(_ROOT, q) for q in out.stdout.split(chr(0))
+                if q.endswith('.kicad_pcb')]
 
     def test_no_tracked_via_is_fat_enough_for_the_gate_to_bind(self):
         boards = self._tracked()
@@ -507,13 +589,22 @@ class TestInertOnTheTrackedCorpus(unittest.TestCase):
                            'only %d sized vias across the corpus -- the bound '
                            'below would be vacuous' % total)
         bound = H2H_PAD - max(defaults.CLEARANCE, NPTH_FLOOR)      # 0.20
-        self.assertLess(widest, bound - 0.04,
+        # Compared against the bound ITSELF, with the margin reported. An
+        # arbitrary safety subtraction here would be the tightest number in
+        # the file (0.1500 against 0.1600) while LOOKING like the loosest --
+        # and it is the bound, not a safety band, that the claim is about.
+        self.assertLess(widest, bound,
                         'a tracked board now carries a via ring of %.4f (%s), '
-                        'at or near the %.4f bound where this gate starts to '
+                        'at or over the %.4f bound where this gate starts to '
                         'bind at the shipped --clearance %.2f. The "provably '
                         'inert on the corpus" claim in this PR must be '
                         're-measured.' % (widest, where, bound,
                                           defaults.CLEARANCE))
+        self.assertGreater(bound - widest, 0.04,
+                           'the widest tracked ring %.4f is now within 0.04mm '
+                           'of the %.4f bound -- still inert, but the margin '
+                           'this PR reported as 0.0500 has shrunk'
+                           % (widest, bound))
         # The boards carrying BOTH vias and copper-less holes are the only
         # ones where this gate could ever fire; name them, so a change there
         # is visible rather than silent.

--- a/tests/test_737_fanout_clearance_via_hole.py
+++ b/tests/test_737_fanout_clearance_via_hole.py
@@ -202,6 +202,15 @@ class _FakeSt:
     """The duck-typed `st` the #370/#617 harnesses pass: no resolvers at all,
     so every requirement in the nudger falls back to the flat scalar."""
 
+    #: A REAL `st` is a `_Repair`, which carries `npth_floor` (the board-aware
+    #: hole floor). The duck type must carry one too, or the most likely wrong
+    #: floor -- `max(clearance, getattr(st, 'npth_floor', 0.0))` -- reads 0.0
+    #: here, behaves exactly like the right one, and is caught only by the
+    #: source guard. Measured: without this attribute that mutation survives
+    #: every behavioural arm in this file. 0.40 is above every gap the rig
+    #: uses, so a gate that reads it refuses landings the checker calls clean.
+    npth_floor = 0.40
+
     def __init__(self, rects):
         self.caps = {'C1': _FakeCap(rects)}
         self.vias = []
@@ -394,9 +403,21 @@ class TestTheFloorIsTheVIARuleNotTheTRACKFloor(unittest.TestCase):
     # and `no clear spot` printed, on geometry the checker calls clean.
 
     def test_a_DECLARED_min_hole_clearance_changes_nothing(self):
-        """#617's balance, pinned behaviourally rather than by comment. A
-        board declaring 0.40 would refuse this landing if the gate read the
-        board; the flat floor accepts it, so the #130 repair is kept."""
+        """A board declaring 0.40 would refuse this landing if the gate read
+        the board; it does not, so the #130 repair is kept.
+
+        The reason the declared value must stay unread is stronger than the
+        #617 appeal it used to rest on, and it is checkable: it changes
+        nothing in check_drc's VIA arm either. The declared floor enters that
+        arm only through the `req_clr > npth_clr` THRESHOLD, so with a
+        declared 0.40 and no pad override the graded requirement is still
+        `clearance`. A gate that read the board would therefore refuse copper
+        its own checker calls clean.
+
+        `_FakeSt.npth_floor` exists for this arm: without it the
+        `max(clearance, getattr(st, 'npth_floor', 0.0))` mutation reads 0.0
+        and slips through every behavioural test in this file.
+        """
         self.assertGreater(_wall_gap(XH_MOVES), NPTH_FLOOR + 0.04,
                            'the landing does not clear the flat floor')
         self.assertLess(_wall_gap(XH_MOVES), 0.40 - 0.04,
@@ -475,9 +496,16 @@ class TestTheFloorIsTheVIARuleNotTheTRACKFloor(unittest.TestCase):
         self.assertIn('clearance', vtxt,
                       'the VIA gate does not spell `clearance`, which is what '
                       'check_drc s via-hole arm grades at')
+        # This assertion is the ONLY thing in the tree that holds the
+        # connector floor. Measured: rewriting `npth_clr + hw` to
+        # `clearance + hw` passes test_617, test_370 and test_fanout_clearance
+        # (20 tests) -- including test_617's own "UNCHANGED site" arm, which
+        # exists to pin exactly that floor. Same position as the 1e-4 above,
+        # and worth the same disclosure rather than a silent reliance.
         self.assertIn('npth_clr', ctxt,
                       'the CONNECTOR gate no longer spells npth_clr -- #617 '
-                      'set that floor deliberately')
+                      'set that floor deliberately, and NOTHING else in the '
+                      'tree catches this')
         # The tolerance too. This one is pinned HERE and nowhere else, and
         # deliberately so: measured, dropping `- 1e-4` from the via gate leaves
         # the whole suite green, because it only decides an exact tie and no

--- a/tests/test_fanout_clearance.py
+++ b/tests/test_fanout_clearance.py
@@ -297,5 +297,4 @@ if __name__ == '__main__':
     test_seed_track_graze_is_resolved()
     test_seg_to_rect_dist_exact()
     test_mover_pad_short_is_hard_blocked()
-    test_mover_pad_short_is_hard_blocked()
     print("ALL PASS")


### PR DESCRIPTION
Closes #736.

> **Stacked on #744 (`fix/737-fanout-clearance-via-hole`) → #743 → #740 → #739 → #729.**
> Upstream `main` has none of them, so the diff below carries their commits too until
> they merge. The #736 commits are the top three: `6f4241f0`, `65531e3d`, `0cdafd7a`.
>
> #744's own description lists #736 under "deliberately not folded in".

## The bug

`repair_fanout_clearance` ends by asking `nudge_vias_for_unresolved` to move offending
vias, then re-grades to produce the final `unresolved` list. The nudger does **two**
things to the board: it moves vias, and it **appends new connector `Segment`s** to
`pcb_data.segments` to restore continuity back to each moved via's stub start.

The re-grade refreshed only the via view:

```python
via_moves, new_segs = nudge_vias_for_unresolved(st, pcb_data, clearance)
if via_moves:
    # refresh the per-cap pruned via lists before re-grading
    st.cap_vias = {r: st.vias for r in st.caps}
    unresolved = [r for r in st.caps if st.graze_penalty(...) > EPS]
```

`st.segments`, `st.cap_segs` and `st._seg_floor_by_id` were snapshotted in
`_Repair.__init__`, before those connectors existed, and **nothing anywhere rebuilt
them** — so `_seg_shortfalls` (the PAD-SEGMENT channel of `graze_penalty`) and
`required_rows`' disclosure read a stale track view. Both front ends **write** that copper
(`placement/writer.py` on the CLI, the plugin's pcbnew mirror in the GUI), so the summary
is a statement about a board that already carries the connectors.

**Measured**, on the rig in the new test file at `--clearance 0.1` — a boxed cap with
through-hole pads whose offending via is nudged, drawing one connector on `B.Cu`:

| | outcome | `check_drc` on the emitted connector |
|---|---|---|
| **before** | via moved, connector drawn, **`unresolved == []`** | **violation, overlap 0.1200 mm** |
| **after** | same move, same connector, `unresolved == ['C1']` | same violation, now reported |

Not the repair pass's own arithmetic — `check_drc.check_pad_segment_overlap(C1.2, the
connector, 0.1, …)` returns `(True, 0.1200, …)`, the same number its grader charges. The
connector's centreline passes **0.130 mm from the pad's copper edge** and it is 0.150 mm
wide to each side, so **0.020 mm of copper sits inside the pad**.

### Which window this runs through — and I had it backwards first

The obvious reading is that any connector can graze. It cannot. On the connector's **own
layer** the draw gate and the accept gate are the *same number*: `connector_clear` charges
`hw + req(pfl, cfl)` and `_seg_effs` charges `halves[j] + _pair_or_flat(fa, floors[j])`
with `halves[j] == hw` — the same two floors through the same resolver — and
`connector_clear` is the **stricter of the two, by EPS**. So an accepted same-layer
connector can never be charged, and a test *measures* that rather than asserting it. Two
windows remain:

* **The #738 window** — `connector_clear` scopes a cap pad by the **footprint's side**
  (`cl != layer`), so it never tests a back-side or inner-layer connector against a
  through-hole cap pad, whose copper spans every layer. **This is the real one**;
  check_drc agrees, above.
* **A connector on a layer the board never DECLARED** — `_seg_shares` charges an unknown
  layer on purpose ("over-blocking is the only direction that can never ship a
  violation") while `connector_clear` skips it. It gives *identical numbers* with no
  through-hole pad anywhere, and it survives the fix #738's own text proposes. But
  **check_drc grades that pair CLEAN.**

An earlier draft of this PR called the second one the durable demonstration of a *shipped
violation*. It is durable; it is not a violation — it pins the module's documented
over-block. Its test class says so and asserts the checker's verdict, so the distinction
cannot quietly rot.

## The fix — one construction site, one prune predicate

Not a patch at the call site, because the shape of the defect is the shape this module has
been fixing all year (#725, #731, #732, #733): two places that must agree, one of which
nobody could reach. Both halves of "how a track becomes a graded tuple" were **inline in
`__init__` and existed nowhere else**, so there was no way to register a track that
appeared later.

| new member | what it owns |
|---|---|
| `_Repair._register_segment` | THE construction site for a track tuple, and the only writer of the id-keyed floor map |
| `_Repair._prune_segs` | THE per-cap prune predicate (carrying the comment block that used to sit inline) |
| `_Repair.register_new_segments` | the public registrar, called from `repair_fanout_clearance` |
| `self._cap_geom` | `cap_geom` stops being a discarded `__init__` local, so the prune has one seed-geometry origin |
| `self._seed_seg_n` | how much of each pruned list is seed-era copper (added by the review round below) |

Three existing members change too: `__init__` adopts the two helpers, and
`required_rows` / `_seg_shortfalls` gain the seed scope the review round added.

Three decisions worth stating rather than burying:

**`_register_segment` takes PRIMITIVE fields, not a `Segment`.** Its two callers hold
different things — `__init__` has parser `Segment`s, the registrar has the writer-shaped
dicts the nudger already returns. A builder that accepted only one would have left the
other re-deriving the tuple, which is the defect being fixed. Taking the dicts also means
nothing depends on `pcb_data.segments` being append-only, so no source guard has to defend
that.

**It files the tuple BEFORE returning.** The floor map is keyed on `id(t)`, and a factory
that only *built* would let a caller drop the reference and hand a recycled id another
track's floor — silently, the hazard `__init__`'s own NB names.

**INCREMENTAL, not the rebuild the issue suggests**, and the reason is not only the
`O(caps × board segments)` cost it flags. A rebuild *replaces* the tuples the floor map is
keyed on, arming exactly that id-recycling hazard. Appending cannot.

Each cap that keeps new copper is reassigned a **new list**; `_seg_effs` memoises on the
source list's IDENTITY, so an in-place append leaves a memo one column short and
`_seg_shortfalls` indexes past its row. A cap that keeps nothing is left alone and keeps
its memo.

**The guard stays `if via_moves:`** and gains no `or new_segs`: a connector dict is
appended only inside the same commit block that appends the via move, with no `continue` or
`break` between, so a non-empty `new_segs` implies a non-empty `via_moves` and the disjunct
could never fire. The converse is false, and the comment now says so: a via whose
`conn_layers` is empty relocates with no connector — and, worth knowing separately, with no
connector *validation*, since `all(...)` over an empty dict is vacuously True.

**`base_seg` / `base_pad` / `base_via` are NOT re-seeded**, exactly as `base_via` is left
alone by the `cap_vias` line beside it. They are read only by `cost()` / `hard_blocked`,
neither of which runs past this point, and a baseline means "the state at the SEED" —
copper this pass *created* is not part of it. Folding it in would license a later move to
sit on the pass's own connector for free.

### Review found a defect this fix introduced

An adversarial review of the branch caught it, and the third commit is that finding.
`required_rows`' `both()` grades `_seg_shortfalls` at the **seed** pose as well as the
final one — deliberately, so a pass that SUCCEEDS still discloses the raised requirement
that did the work. Registering the connectors made that seed half see copper the pass
**drew**, which did not exist at the seed. So a connector could be charged against the
cap's seed pads and produce a `track <net>` row describing **a pair no board ever had** —
precisely the class of phantom #731 removed from that very report. Measured on a declaring
rig with a cap walked 2.5 mm off its seed: `{3: 0.550}` charged at the seed -- the 0.650
declared eff cell minus the 0.100 the connector sits off pad 2's seed edge -- against `{}`
at the pose the cap is actually in.

The irony is structural: `_prune_segs`' own docstring cited the seed-pose grading to
*justify* the seed anchor without noticing that seed-pose grading of pass-created copper is
itself wrong.

The fix scopes the seed half to seed-era copper — `__init__` records `self._seed_seg_n[ref]`
beside each pruned list, `_seg_shortfalls` gains an `upto=` that grades only the first N
entries, and `both()` passes it for the TRACK kind alone. A **prefix**, not a filtered
subset, because `_seg_effs`' rows are index-aligned with that list.

The same round found three smaller things, all fixed: `_prune_segs` cited
`TestPruneRadiiStayExact` for an exactness bound that test does not measure (the bound
*survives* — minimum slack **+1.009 mm** at `--clearance 0.1` over all 115 caps of every tracked board,
and +1.109 at the shipped 0.2 since the bound carries a `+ clearance` term — so the
docstring now states and measures it, and names the grid overshoot the citation hid); the
registrar indexed `_cap_geom` / `cap_segs` bare while every neighbour guards; and the
guard comment read as an equivalence.

## Verification

**88/88 A/B cells byte-identical.** Paired against the merge base over the 22 tracked
boards × {0.25, 0.10} × {shipped defaults, the frozen sweep `test_fanout_clearance.py`
uses}, comparing placements **with coordinates**, `resolved`, `unresolved`, `via_moves`,
`new_segments`, the `required` rows and full stdout: **zero cells differ**, before and
after the review round.

The honest shape of that number:

```
at the shipped defaults, both clearances:
  tracked boards                          22
    early return (no vias, or no caps)    20
    run the full pass                      2   orangecrab_ext_pll, rp2350_..._prePlane
    reach the via-nudger                   1   rp2350 at 0.25 (prints, moves nothing)
    EMIT A CONNECTOR                       0
```

`if via_moves:` never fires at the shipped defaults, so the change is inert corpus-wide —
**and that would be a statement about unreachable code if it stood alone.** It does not:

**One in-repo configuration genuinely enters the new path on a real board.** The
fallback-OFF leg of `test_fanout_clearance.py`'s frozen sweep, on `orangecrab_ext_pll` at
`--clearance 0.1`: **9 via moves and 17 connectors** — `F.Cu` 9, `In1.Cu` 5, `B.Cu` 2,
`In2.Cu` 1 — real copper drawn past the `cl != layer` gate. Stated precisely, because "all
17 reach the grader" would be false: **all 17 reach `st.segments`**, and the per-cap prune
then keeps **4 distinct connectors, in 8 caps' lists** (`C2`, `C6`, `C7`, `C15`, `R1`,
`R5`, `R13`, `R17`) — and `cap_segs` is what `_seg_shortfalls` / `graze_penalty` /
`required_rows` actually read. **None is charged**: every per-cap shortfall is `{}`,
`unresolved` 10 → 10. A test asserts both halves, so "inert" is measured rather than
assumed. (`via_clear_fallback=False` is load-bearing: with the fallback on, the same board
reports 0 unresolved and the nudger is never called. `allow_rotations` makes no difference
either way.) Said plainly rather than implied: that flag is deliberately not exposed on the
CLI or the GUI, so **no operator-reachable configuration on this corpus enters the new
path** -- the leg exists in a test, which is exactly why it is worth running.

One more caveat on that cell rather than letting a reader over-read it: its `required` list
is **empty on both sides**, so the byte-identical `required` comparison there is `[]` vs
`[]` — not evidence about the disclosure channel, which is the channel the review finding
above was in. The declaring rig in the test file is what covers that.

**The `__init__` refactor is separately audited, independently.** Paired against the merge
base over **248 configurations** — the 22 tracked boards × {0.25, 0.10} × {`C,R,FB`, `C`},
plus declaring copies (netclass and/or `.kicad_dru` layer rule), `max_displacement_cap` ∈
{0.0, 1.5, 3.0, 5.0}, a copper-less cap exercising the `_union is None` arm, both `_all_cu`
fallback levels, and the untracked routed boards — comparing **55 items per configuration
(13,640 cells)**: `st.segments` at **exact float equality**, `st.cap_segs` by value, order
**and object identity**, the id-keyed floor map re-keyed positionally, `base_seg` /
`base_pad` / `base_via`, `required_rows`, and **ordered call-traces** of `_item_reach` /
`_seg_floor_for`. **248/248 identical, 0 within-tree invariant violations**, byte
reproducible across two full passes. A deep whole-object comparison over 72 configurations
finds **all 47 shared instance attributes identical**, with `_cap_geom` the only addition.
(That run predates the review commit, which adds a second attribute, `_seed_seg_n`; the
88-cell A/B above was re-run after it and is still 0 differing.)
Ten injected mutants confirm the comparison detects a wrong `_max_disp_cap`, a wrong
`cap.max_floor`, a **1-ULP** element-5 change, a reordered or non-identical `cap_segs`, an
unwritten floor map and a moved prune centre.

And the one thing value comparison alone cannot settle, settled by AST: the executable body
of `__init__` differs in **exactly three places**, and the moved code is
**statement-for-statement identical** after the mechanical rename — so there is no float
re-association to detect. That matters, because `w/2.0 + r` and `(w + 2r)/2.0` happen to be
bit-identical on every distinct `(width, reach)` pair the audit's 248-configuration board
set contains (10 of them over the 22 tracked boards alone), and a value-only check would
have passed that mutation.

**New `tests/test_736_fanout_clearance_regrade_view.py` — 28 tests, ~25 s, in-process
apart from one `git ls-files`.**
The load-bearing class is deliberately built on a same-layer connector the draw gate
genuinely **accepts**, so it is immune to #738 landing: it pins the tuple's layer and price,
the rebuilt eff rows (which is how an in-place append is caught), the absence of orphan ids,
that **both** caps in reach were refreshed, and that the seed pose is still charged 0.0000
(the over-rejection guard) while each of the two caps walked onto the connector reads
0.1750.

The rig is synthetic because no tracked board can demonstrate this, and a **zone** carries
the connector's layer rather than a stub segment: `_Repair.__init__` reads `pcb_data.zones`
nowhere, so a zone feeds `conn_layers` while leaving every keep-out channel empty — the
board has **zero** segments until the connector exists and every arm's seed `seg_penalty`
is exactly 0.0000.

**A mutation battery of 22 kills 22**, with two false-positive probes correctly inert and
one spelling declared unkillable (`if via_moves:` → `if new_segs:` — a via move whose
`conn_layers` is empty registers nothing either way). Four of the twenty-two cover the
review finding above. **Two more survived the first run**, and both are recorded rather
than quietly fixed:

* `if via_moves:` → `if True:` changes no *number*, because the via prune is exact and
  de-pruning grades identically. The first version of that class asserted only the track
  half. It is now caught on list **identity** — the real consequence being an eff-matrix
  rebuild of `n_pads × n_ALL_vias` per cap, on every board that reaches the nudger and
  moves nothing, i.e. every tracked board at the shipped defaults.
* anchoring the prune on `cap.rect()` instead of `self._cap_geom` survived because every
  arm freezes the caps, so none ever moves. A new class moves one by hand, across a
  threshold it derives from `st` and asserts it straddles by more than 0.05 mm both ways.

Ten mutations have exactly **one** killer each, which is why those arms exist: swapping
the track floor for the via floor is invisible without a layer-scoped `.kicad_dru` rule and
dies only on object **identity**; the pre-#731 side collapse is numerically invisible except
on the declared-but-unshared-layer arm.

**A source guard** pins the invariant no fixture can reach — one construction site for a
track tuple, one writer of the floor map, one pricing spelling, one prune predicate inside
`_Repair`, two `cap_segs` assignments and **zero** in-place mutations of them, and the
registrar reachable from `repair_fanout_clearance` but **not** from the duck-typed nudger.
It reads CODE only (trailing comments stripped) and reports offending line numbers rather
than dumping the module (`test_732` measured a 393 KB failure message from the naive form).
An anti-vacuity arm asserts the positive controls still exist, so a rename fails there
instead of silently disarming the `== 0` rows.

**The full suite, paired against the merge base**, in two clean trees with the same
prebuilt router, so the number is a delta and not an absolute:

```
merge base b197f91e   415 passed, 0 failed, 0 skipped
this branch           416 passed, 0 failed, 0 timed out, 0 skipped   (2403s)
```

The +1 is the new file. The base leg's own run reported `414 passed, 1 timed out` --
`test_obstacle_map_balance.py` at its own 1200s budget, under CPU contention from work
running alongside it. Re-run alone on the merge base it passes in 15m50s, so the leg is
415/415 and the timeout was load, not a failure. Recorded rather than quietly rounded up,
because the runner itself says a timeout is not evidence.

**No CLI/GUI plumbing, and that is the point.** The change is wholly inside
`repair_fanout_clearance` plus five new `_Repair` members (the four tabled above and
`_seed_seg_n`) and three modified ones (`__init__`, `required_rows`, `_seg_shortfalls`) — the shared engine — so
`place_fanout_clearance.py`, `fanout_gui.py` and `animate_fanout_clearance.py` inherit it.
No flag, no engine parameter, no dialog control, no `manifest_to_plan` row, no README row.
Both wx-free parity gates -- `test_manifest_plan_parity.py` and
`test_cli_postpass_coverage.py`, the two CONTRIBUTING names -- run clean. Two consequences land identically on both fronts and are worth
stating: `unresolved` may grow, and the "above the Xmm floor" disclosure may gain
`track <net>` rows.

## Deliberately not folded in

Per CONTRIBUTING's one-failure-mode rule:

* **#738** — the draw gate scopes cap pads by the footprint's SIDE. This PR makes the pass
  **report** such a pair; it does not stop the nudger **drawing** it. Worth recording for
  whoever closes it: the `pad_layers`-scoped fix #738's own text proposes does **not** close
  the undeclared-layer window; mirroring `_seg_shares` does.
* **#735** — track-scoped `.kicad_dru` rules in `connector_clear`.
* **#730** — neither hole gate honours the hole pad's own `local_clearance`.

Two things noticed while here, both filed separately rather than ridden in:

* **#746 -- `resolved` is computed BEFORE the nudge and never refreshed**, so a cap the nudger frees
  is credited in neither list (measured: `violators0 = ['C1']`, `resolved = []`,
  `unresolved = []`). After this PR a cap could also appear in **both** lists -- a reasoned
  consequence rather than a measured one; no rig here produces it, because the via channel
  alone cannot create a new violator. Older than #736 and a different failure mode. The GUI's summary also renders `unresolved` as "could not clear a
  foreign **via**", which `graze_penalty` has never been.
* **#747 -- the via channel keeps a second copy of `__init__`'s knowledge** — the inline `st.vias`
  rebuild in the nudger, including its hand-written radius carry-over. Applying #736's
  pattern there needs the nudger to *report* which tuples moved rather than mutating `st`,
  which changes its `(via_moves, new_segments)` return contract that six test files unpack
  positionally.

One pre-existing thing the review surfaced and neither this PR nor those two issues covers,
recorded so it is not lost: `__init__`'s three-level `_all_cu` fallback guards the **empty**
copper-layer case explicitly and at length, but a **partial** `(layers …)` read on a
multi-layer board silently takes the massive over-block path — the inner tracks read as
UNKNOWN, `_seg_shares` charges them all, and the prune keeps every one. Measured on
rp2350_fpga_eensy_prePlane (6 copper layers) with the list forced to `F.Cu, B.Cu`: pruned
pad x track pairs go 2,126 -> 4,468, i.e. **2,342 extra**, every one of them on a layer
check_drc grades not at all. `_prune_segs` inherits that unchanged.
