### PR TITLE
#761: legality's NPTH keep-out is the inflation PLUS the clearance

### DIFF
--- a/.claude/skills/plan-pcb-routing/SKILL.md
+++ b/.claude/skills/plan-pcb-routing/SKILL.md
@@ -1146,9 +1146,13 @@ cap. **resolved** means "was grazing at the seed and is clean now", counted at
 the END of the pass, so it credits both the cap move and the via-nudge (#746).
 Any **unresolved** caps are still grazing foreign copper — a via, a track, or a
 component pad — and are not auto-fixed; note them for a manual nudge. A
-`Re-grazed by this pass's own connector copper:` line means the pass fixed
-those caps and then its own reconnect copper broke them again; treat it as a
-bug report, not as a board defect. By default (`--cap-prefix C,R`) it moves 2-pad
+`Re-grazed by this pass's own connector copper:` line names the subset that
+was **clean before the via-nudge and is grazing after it** — copper this pass
+drew, not copper the board arrived with. Those caps are in the unresolved list
+too, so treat them as you would any other; the extra line says where the
+copper came from. Grade with `check_drc.py` before acting: the repair pass
+deliberately over-blocks a track on a layer the board never declared, so some
+of these grade clean and some are real. By default (`--cap-prefix C,R`) it moves 2-pad
 **caps and resistors** near a BGA (RN-style arrays auto-excluded since only
 2-copper-pad parts move); it never overlaps parts, and is a no-op when nothing
 collides. Feed `board_step1c.kicad_pcb`

--- a/.claude/skills/plan-pcb-routing/SKILL.md
+++ b/.claude/skills/plan-pcb-routing/SKILL.md
@@ -1140,9 +1140,15 @@ setting that matters (it reads each via's real size from the board).
 python3 py_placer/place_fanout_clearance.py board_step1b.kicad_pcb board_step1c.kicad_pcb \
     --clearance 0.1
 
-It prints `Moved N cap(s); resolved R/M ... K unresolved`. Any **unresolved**
-caps had no clear spot within the displacement budget — note them for a manual
-nudge; they are not auto-fixed. By default (`--cap-prefix C,R`) it moves 2-pad
+It prints `Moved N cap(s); resolved R/V initial violations; K unresolved`, plus
+`(F freed by via-nudge)` when the #313 last resort moved a via to free a boxed
+cap. **resolved** means "was grazing at the seed and is clean now", counted at
+the END of the pass, so it credits both the cap move and the via-nudge (#746).
+Any **unresolved** caps are still grazing foreign copper — a via, a track, or a
+component pad — and are not auto-fixed; note them for a manual nudge. A
+`Re-grazed by this pass's own connector copper:` line means the pass fixed
+those caps and then its own reconnect copper broke them again; treat it as a
+bug report, not as a board defect. By default (`--cap-prefix C,R`) it moves 2-pad
 **caps and resistors** near a BGA (RN-style arrays auto-excluded since only
 2-copper-pad parts move); it never overlaps parts, and is a no-op when nothing
 collides. Feed `board_step1c.kicad_pcb`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -614,15 +614,22 @@ pcb = parse_kicad_pcb('path/to/file.kicad_pcb')
   loses its spec and is re-stamped with front+back tenting, which is wrong for
   via-in-pad (needs IPC-4761 Type VII filled+capped+plated). Vias the tool ADDS
   default to `kicad_writer.prevailing_via_protection(pcb.vias)` — the board's own
-  convention — instead of a hardcoded policy. When a re-placed via carried **no**
-  spec of its own, pass `kicad_writer.INHERIT_VIA_PROTECTION` rather than nothing
-  (#741). `None` **and `{}`** both mean "the caller has no opinion", which on
-  KiCad 10 output stamps front+back tenting (on a numeric-net board they emit
-  nothing) — and `{}` is exactly what `Via.tenting_attrs` holds for such a via,
-  so passing it back verbatim is the bug. The sentinel emits nothing, so the
-  via keeps inheriting the board's `(setup ...)` — what it had, and what the GUI
+  convention — instead of a hardcoded policy. When RE-PLACING a via, also pass
+  `inherit_when_unspecified=True` (#741). `None` **and `{}`** otherwise both mean
+  "the caller has no opinion", which on KiCad 10 output stamps front+back
+  tenting (on a numeric-net board they emit nothing) — and `{}` is exactly what
+  `Via.tenting_attrs` holds for a via that carries no spec, so handing it back
+  verbatim is the bug. With the flag an empty spec emits nothing, so the via
+  keeps inheriting the board's `(setup ...)` — what it had, and what the GUI
   side (`gui_utils.apply_via_protection`, early-return on an empty spec) has
-  always done. Spell it
-  `tenting_attrs=(v.tenting_attrs or INHERIT_VIA_PROTECTION)`. GUI side:
+  always done. Spell it `tenting_attrs=v.tenting_attrs,
+  inherit_when_unspecified=True` — a keyword rather than a sentinel VALUE,
+  because the repo's own idiom for carrying a spec is `dict(...)`, which would
+  turn any dict-shaped sentinel back into a plain `{}` and silently restore the
+  bug. **A re-placed via must also keep the board's net DIALECT**: emitting a
+  numeric `(net N)` token alongside a protection spec produces a via
+  `extract_vias` cannot read back at all, so the barrel vanishes from the model
+  (see `placement/writer._net_name`, and note `net_id_to_name` has no key 0 on
+  any board). GUI side:
   `gui_utils.apply_via_protection(pcb_via, attrs)`. `fab_notes.print_via_in_pad_note`
   emits the IPC-4761 note from the shared engines when a run puts vias in pads.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -614,6 +614,15 @@ pcb = parse_kicad_pcb('path/to/file.kicad_pcb')
   loses its spec and is re-stamped with front+back tenting, which is wrong for
   via-in-pad (needs IPC-4761 Type VII filled+capped+plated). Vias the tool ADDS
   default to `kicad_writer.prevailing_via_protection(pcb.vias)` — the board's own
-  convention — instead of a hardcoded policy. GUI side:
+  convention — instead of a hardcoded policy. When a re-placed via carried **no**
+  spec of its own, pass `kicad_writer.INHERIT_VIA_PROTECTION` rather than nothing
+  (#741). `None` **and `{}`** both mean "the caller has no opinion", which on
+  KiCad 10 output stamps front+back tenting (on a numeric-net board they emit
+  nothing) — and `{}` is exactly what `Via.tenting_attrs` holds for such a via,
+  so passing it back verbatim is the bug. The sentinel emits nothing, so the
+  via keeps inheriting the board's `(setup ...)` — what it had, and what the GUI
+  side (`gui_utils.apply_via_protection`, early-return on an empty spec) has
+  always done. Spell it
+  `tenting_attrs=(v.tenting_attrs or INHERIT_VIA_PROTECTION)`. GUI side:
   `gui_utils.apply_via_protection(pcb_via, attrs)`. `fab_notes.print_via_in_pad_note`
   emits the IPC-4761 note from the shared engines when a run puts vias in pads.

--- a/docs/api-kicad-writer.md
+++ b/docs/api-kicad-writer.md
@@ -122,7 +122,8 @@ yourself:
 ```python
 generate_segment_sexpr(start, end, width, layer, net_id, net_name=None) -> str
 generate_via_sexpr(x, y, size, drill, layers, net_id,
-                   free=False, net_name=None, tenting_attrs=None) -> str
+                   free=False, net_name=None, tenting_attrs=None,
+                   inherit_when_unspecified=False) -> str
 generate_gr_line_sexpr(start, end, width, layer) -> str      # debug graphics
 generate_gr_text_sexpr(text, x, y, layer, size=0.5, angle=0) -> str
 generate_zone_sexpr(net_id, net_name, layer, polygon_points,
@@ -147,35 +148,52 @@ print(generate_segment_sexpr((100.0, 100.0), (105.0, 100.0),
 `tenting_attrs` is a via's own protection spec -- `Via.tenting_attrs`, the
 `(tenting ...)` / `(covering ...)` / `(plugging ...)` / `(capping ...)` /
 `(filling ...)` family, see `docs/api-kicad-parser.md`. Which value you pass
-says which of **four** different things is true about the via, and they are not
-interchangeable (#489 s8, #741):
+is read together with `inherit_when_unspecified`, and the four combinations
+are not interchangeable (#489 s8, #741):
 
-| Pass | Meaning | Emitted |
+| `tenting_attrs` | `inherit_when_unspecified` | Emitted |
 |---|---|---|
-| a non-empty parsed spec | the board said this about this via | that spec, in canonical token order |
-| `INHERIT_VIA_PROTECTION` | the board said **nothing** about this via, and nothing is the answer | nothing -- the via keeps inheriting the board's `(setup ...)` |
-| `None` (the default) | the caller has no opinion | front+back tenting on KiCad 10 output (`net_name=` given); nothing on KiCad 9 |
-| `{}` | **indistinguishable from `None`** -- see below | same as `None` |
+| a non-empty parsed spec | either | that spec, in canonical token order |
+| `None` or `{}` | `True` | nothing -- the via keeps inheriting the board's `(setup ...)` |
+| `None` or `{}` | `False` (default) | front+back tenting on KiCad 10 output (`net_name=` given) |
+| `None` or `{}` | `False`, numeric net | nothing |
 
 `{}` is the trap, and it is worth stating plainly because it is exactly what
 `Via.tenting_attrs` holds for a via that carries no spec: passing it back
-verbatim reads as "no opinion" and stamps the default. That is why the sentinel
-exists. Re-placing a via is therefore
-`tenting_attrs=(v.tenting_attrs or INHERIT_VIA_PROTECTION)`, never
-`tenting_attrs=v.tenting_attrs` alone.
+verbatim, without the flag, reads as "no opinion" and stamps the default. So
+re-placing a via is `tenting_attrs=v.tenting_attrs,
+inherit_when_unspecified=True`, never `tenting_attrs=v.tenting_attrs` alone.
+
+The decision is a KEYWORD rather than a sentinel VALUE on purpose. A sentinel
+would have to survive being copied, and the copy idiom this repo actually uses
+for a spec is `dict(via.tenting_attrs or {})` -- which turns any dict-shaped
+sentinel straight back into a plain `{}` and silently restores the bug.
+Carrying the decision separately from the value cannot be undone by copying the
+value.
 
 **Pass the spec back for any via that already existed.** A via you re-place
 without it -- rip-up, sub-grid nudge, tap relocation -- is re-stamped with
 front+back tenting, which is wrong for via-in-pad (it needs IPC-4761 Type VII:
 filled + capped + plated).
 
-**Pass `INHERIT_VIA_PROTECTION` when such a via carried no spec of its own**,
-so the re-placement does not *gain* an attribute the board never gave it. This
-is what the GUI side has always done -- `gui_utils.apply_via_protection`
-returns early on an empty spec, because pcbnew's `*_MODE_FROM_BOARD` already
-means inherit. The sentinel is an empty `dict` subclass that compares truthy,
-so a copy or a re-import that breaks its identity still emits nothing rather
-than falling back to the default.
+**Pass `inherit_when_unspecified=True` for any via that already existed**, so
+the re-placement does not *gain* an attribute the board never gave it. This is
+what the GUI side has always done -- `gui_utils.apply_via_protection` returns
+early on an empty spec, because pcbnew's `*_MODE_FROM_BOARD` already means
+inherit.
+
+**And keep the board's net dialect.** `generate_via_sexpr` picks the dialect
+from `net_name` and the protection tokens from `tenting_attrs` independently,
+so a numeric `(net N)` token emitted alongside a spec is a shape
+`kicad_parser.extract_vias` cannot match -- the via vanishes from the model
+rather than merely losing its spec. Note `net_id_to_name` has no key `0` on any
+board, so a no-net via needs `net_name=''` spelled out; see
+`py_placer/placement/writer._net_name`.
+
+Only `py_placer/placement/writer.py` passes the flag today. The other emit
+sites (`output_writer`, `plane_io`, `repair_planes`, `kicad_oracle`) still have
+the residue and are tracked separately -- do not assume a site is correct
+because it passes `tenting_attrs`.
 
 For vias you **add**, `prevailing_via_protection(pcb.vias)` /
 `prevailing_via_protection_in_text(content)` gives the board's own convention,

--- a/docs/api-kicad-writer.md
+++ b/docs/api-kicad-writer.md
@@ -122,7 +122,7 @@ yourself:
 ```python
 generate_segment_sexpr(start, end, width, layer, net_id, net_name=None) -> str
 generate_via_sexpr(x, y, size, drill, layers, net_id,
-                   free=False, net_name=None) -> str
+                   free=False, net_name=None, tenting_attrs=None) -> str
 generate_gr_line_sexpr(start, end, width, layer) -> str      # debug graphics
 generate_gr_text_sexpr(text, x, y, layer, size=0.5, angle=0) -> str
 generate_zone_sexpr(net_id, net_name, layer, polygon_points,
@@ -141,6 +141,45 @@ from kicad_writer import generate_segment_sexpr
 print(generate_segment_sexpr((100.0, 100.0), (105.0, 100.0),
                              0.25, 'F.Cu', 42))
 ```
+
+### Via protection (`tenting_attrs`)
+
+`tenting_attrs` is a via's own protection spec -- `Via.tenting_attrs`, the
+`(tenting ...)` / `(covering ...)` / `(plugging ...)` / `(capping ...)` /
+`(filling ...)` family, see `docs/api-kicad-parser.md`. Which value you pass
+says which of **four** different things is true about the via, and they are not
+interchangeable (#489 s8, #741):
+
+| Pass | Meaning | Emitted |
+|---|---|---|
+| a non-empty parsed spec | the board said this about this via | that spec, in canonical token order |
+| `INHERIT_VIA_PROTECTION` | the board said **nothing** about this via, and nothing is the answer | nothing -- the via keeps inheriting the board's `(setup ...)` |
+| `None` (the default) | the caller has no opinion | front+back tenting on KiCad 10 output (`net_name=` given); nothing on KiCad 9 |
+| `{}` | **indistinguishable from `None`** -- see below | same as `None` |
+
+`{}` is the trap, and it is worth stating plainly because it is exactly what
+`Via.tenting_attrs` holds for a via that carries no spec: passing it back
+verbatim reads as "no opinion" and stamps the default. That is why the sentinel
+exists. Re-placing a via is therefore
+`tenting_attrs=(v.tenting_attrs or INHERIT_VIA_PROTECTION)`, never
+`tenting_attrs=v.tenting_attrs` alone.
+
+**Pass the spec back for any via that already existed.** A via you re-place
+without it -- rip-up, sub-grid nudge, tap relocation -- is re-stamped with
+front+back tenting, which is wrong for via-in-pad (it needs IPC-4761 Type VII:
+filled + capped + plated).
+
+**Pass `INHERIT_VIA_PROTECTION` when such a via carried no spec of its own**,
+so the re-placement does not *gain* an attribute the board never gave it. This
+is what the GUI side has always done -- `gui_utils.apply_via_protection`
+returns early on an empty spec, because pcbnew's `*_MODE_FROM_BOARD` already
+means inherit. The sentinel is an empty `dict` subclass that compares truthy,
+so a copy or a re-import that breaks its identity still emits nothing rather
+than falling back to the default.
+
+For vias you **add**, `prevailing_via_protection(pcb.vias)` /
+`prevailing_via_protection_in_text(content)` gives the board's own convention,
+which is the right default for new copper.
 
 ## Modifying existing copper
 

--- a/docs/api-kicad-writer.md
+++ b/docs/api-kicad-writer.md
@@ -192,8 +192,8 @@ board, so a no-net via needs `net_name=''` spelled out; see
 
 Only `py_placer/placement/writer.py` passes the flag today. The other emit
 sites (`output_writer`, `plane_io`, `repair_planes`, `kicad_oracle`) still have
-the residue and are tracked separately -- do not assume a site is correct
-because it passes `tenting_attrs`.
+the residue and are tracked in #749 -- do not assume a site is correct because
+it passes `tenting_attrs`. The numeric-dialect hazard above is #748.
 
 For vias you **add**, `prevailing_via_protection(pcb.vias)` /
 `prevailing_via_protection_in_text(content)` gives the board's own convention,

--- a/kicad_routing_plugin/fanout_gui.py
+++ b/kicad_routing_plugin/fanout_gui.py
@@ -96,6 +96,49 @@ def _get_net_classes_from_board():
         return {}, ['Default']
 
 
+def cap_optimization_summary(result):
+    """The one-line summary for a repair_fanout_clearance result (#130/#746).
+
+    A module-level function rather than a method body so it can be driven with
+    a plain dict: it needs no board, no dialog and no wx, and before #746 the
+    only way to reach it was a live pcbnew board, so nothing tested it and the
+    wording below went wrong unnoticed.
+
+    Reads every key with `.get` -- the engine's two early returns carry neither
+    'via_moves'/'new_segments' nor 'via_resolved'/'regrazed'.
+
+    #746: `resolved` is graded at the END of the pass, so it spans BOTH
+    mechanisms -- a cap the descent walked clear and a cap only the via-nudge
+    could free. `via_resolved` says which, so this line does too instead of
+    leaving the operator to infer it from the engine's stdout. `regrazed`
+    names the caps the pass itself broke after fixing them; silence is normal.
+    """
+    moved = len(result.get('placements') or [])
+    nudged = len(result.get('via_moves') or [])
+    unresolved = result.get('unresolved') or []
+    via_resolved = result.get('via_resolved') or []
+    regrazed = result.get('regrazed') or []
+    summary = f"Decoupling caps optimized: {moved} moved"
+    if nudged:
+        summary += f"; {nudged} via(s) nudged with reconnect (#313)"
+    if via_resolved:
+        summary += f"; {len(via_resolved)} cap(s) freed by that nudge"
+    if unresolved:
+        # The verdict has ALWAYS been via + track + pad (the engine's
+        # graze_penalty is via #130 + track #278 + pad #275). This line said
+        # "could not clear a foreign via", naming one of the three: wrong
+        # before #736 and more visibly wrong after it, which made the track
+        # channel reachable in this verdict for the first time. Worded to
+        # match the engine's own seed disclosure.
+        summary += (f"; {len(unresolved)} still grazing foreign copper "
+                    f"(via/track/pad) "
+                    f"(manual: {', '.join(sorted(unresolved))})")
+    if regrazed:
+        summary += (f"; {len(regrazed)} re-grazed by this pass's own "
+                    f"connector copper: {', '.join(sorted(regrazed))}")
+    return summary
+
+
 class NetSelectionPanel(wx.Panel):
     """Reusable net selection panel with filtering."""
 
@@ -2060,16 +2103,7 @@ class FanoutTab(wx.Panel):
                 from .gui_utils import refill_all_zones
                 refill_all_zones(board)
 
-            moved = len(result.get('placements', []))
-            nudged = len(via_moves)
-            unresolved = result.get('unresolved', [])
-            summary = f"Decoupling caps optimized: {moved} moved"
-            if nudged:
-                summary += f"; {nudged} via(s) nudged with reconnect (#313)"
-            if unresolved:
-                summary += (f"; {len(unresolved)} could not clear a foreign via "
-                            f"(manual: {', '.join(sorted(unresolved))})")
-            return summary
+            return cap_optimization_summary(result)
         except Exception as e:
             import traceback
             traceback.print_exc()

--- a/kicad_routing_plugin/fanout_gui.py
+++ b/kicad_routing_plugin/fanout_gui.py
@@ -111,7 +111,9 @@ def cap_optimization_summary(result):
     mechanisms -- a cap the descent walked clear and a cap only the via-nudge
     could free. `via_resolved` says which, so this line does too instead of
     leaving the operator to infer it from the engine's stdout. `regrazed`
-    names the caps the pass itself broke after fixing them; silence is normal.
+    names the caps that were clean before the nudge and are grazing after it
+    -- the pass broke them, whether or not it had fixed them first. Silence
+    there is the normal case.
     """
     moved = len(result.get('placements') or [])
     nudged = len(result.get('via_moves') or [])
@@ -127,9 +129,11 @@ def cap_optimization_summary(result):
         # The verdict has ALWAYS been via + track + pad (the engine's
         # graze_penalty is via #130 + track #278 + pad #275). This line said
         # "could not clear a foreign via", naming one of the three: wrong
-        # before #736 and more visibly wrong after it, which made the track
-        # channel reachable in this verdict for the first time. Worded to
-        # match the engine's own seed disclosure.
+        # before #736 and more visibly wrong after it -- not because the
+        # track channel was new (it has been in graze_penalty since the module
+        # landed) but because #736 made the pass's OWN connector tracks
+        # reachable in this verdict for the first time. Worded to match the
+        # engine's own seed disclosure.
         summary += (f"; {len(unresolved)} still grazing foreign copper "
                     f"(via/track/pad) "
                     f"(manual: {', '.join(sorted(unresolved))})")

--- a/kicad_routing_plugin/fanout_gui.py
+++ b/kicad_routing_plugin/fanout_gui.py
@@ -1605,6 +1605,10 @@ class FanoutTab(wx.Panel):
                 # Advanced cap-placement knobs (#130) so the inline checkbox
                 # path honours them too, not just defaults.
                 **{k: v for k, v in config.items() if k.startswith('cap_')},
+                # #733: the cap repair's edge margin. AFTER the cap_* spread, so
+                # the shared Basic-tab override wins over any same-named panel
+                # key. None = the engine resolves it (CLI parity).
+                'cap_board_edge_clearance': shared.get('cap_board_edge_clearance'),
                 # Shared "Add teardrops" checkbox (#489 section 9).
                 'add_teardrops': shared.get('add_teardrops', False),
                 # #693: shared "Fix DRC settings after routing" checkbox --
@@ -1929,6 +1933,11 @@ class FanoutTab(wx.Panel):
                 pcb_file=self.board_filename,
                 clearance=fanout_config.get('clearance', defaults.BGA_CLEARANCE),
                 grid_step=fanout_config.get('grid_step', defaults.GRID_STEP),
+                # #733: the plugin used to pass NOTHING here, so it silently took
+                # the signature default whatever the board or the operator said,
+                # while the cap mover insets by max(clearance, this). None = the
+                # engine resolves it, which is what an omitted CLI flag does too.
+                board_edge_clearance=fanout_config.get('cap_board_edge_clearance'),
                 default_via_size=fanout_config.get('via_size', defaults.BGA_VIA_SIZE),
                 # Advanced cap-placement knobs from the BGA fanout tab (#130)
                 capture_radius=fanout_config.get('cap_capture_radius', 2.0),
@@ -2057,6 +2066,8 @@ class FanoutTab(wx.Panel):
             'clearance': shared.get('clearance', defaults.BGA_CLEARANCE),
             'grid_step': shared.get('grid_step', defaults.GRID_STEP),
             'via_size': shared.get('via_size', defaults.BGA_VIA_SIZE),
+            # #733, as in the inline path above.
+            'cap_board_edge_clearance': shared.get('cap_board_edge_clearance'),
         })
         from .gui_utils import redirect_prints_to_log, refill_all_zones
         with redirect_prints_to_log(self.append_log):

--- a/kicad_routing_plugin/fanout_gui.py
+++ b/kicad_routing_plugin/fanout_gui.py
@@ -1991,15 +1991,25 @@ class FanoutTab(wx.Panel):
                 # inherits the board's `(setup (tenting ...))`, which
                 # apply_via_protection correctly leaves alone.
                 #
-                # Note the guard below is `if not moved_attrs`: TRUTHINESS, not
-                # presence, so it fires for that inheriting via too. Harmless --
-                # _pcbnew_via_protection_attrs returns {} for a track at
-                # *_MODE_FROM_BOARD, so the re-read agrees -- but it does mean
-                # this fallback is NOT the regression detector for either half
-                # of #741. It re-derives its answer from the same track via the
-                # same call that built pcb_data, so it would MASK an engine
-                # revert. tests/test_741_via_nudge_tenting.py asserts on the
-                # engine dict for exactly that reason.
+                # Note the guard below is `if not moved_attrs`: TRUTHINESS,
+                # not presence, so it fires for that inheriting via too. It
+                # cannot mis-stamp -- apply_via_protection returns early on an
+                # empty spec either way -- but it is NOT the regression
+                # detector for either half of #741: it re-derives its answer
+                # from the same track via the same call that built pcb_data,
+                # so it would MASK an engine revert.
+                # tests/test_741_via_nudge_tenting.py asserts on the engine
+                # dict for exactly that reason.
+                #
+                # And on KiCad 10.0.0 the re-read is inert for EVERY via, not
+                # just an inheriting one: pcbnew's SWIG wrapper does not export
+                # TENTING_MODE_TENTED and friends (measured -- the setters
+                # exist, the constants do not, and the getters hand back an
+                # opaque SwigPyObject), so _pcbnew_via_protection_attrs raises
+                # internally and returns {}. That is pre-existing #489
+                # behaviour and NOT this fix's doing, but it means the GUI half
+                # of the round trip does not currently carry a spec at all.
+                # Filed separately.
                 moved_attrs = vd.get('tenting_attrs')
                 for track in list(board.GetTracks()):
                     if track.GetClass() != 'PCB_VIA':

--- a/kicad_routing_plugin/fanout_gui.py
+++ b/kicad_routing_plugin/fanout_gui.py
@@ -1970,7 +1970,7 @@ class FanoutTab(wx.Panel):
             # segment(s) back to the stub start. The CLI applies these via
             # write_placed_output; on the live board we must mirror it (else the
             # via stays put and the graze the summary claims to have fixed
-            # persists). GUI parity for placement/writer.py:119-141.
+            # persists). GUI parity for placement/writer.py:250-302.
             name_to_id, _ = _build_layer_mappings()
 
             def _layer_id(layer_name):
@@ -1985,6 +1985,21 @@ class FanoutTab(wx.Panel):
                 # This is the via NUDGE: the old via is deleted and an identical
                 # one re-added a fraction of a mm away. Carry its protection spec
                 # across or the nudge silently re-tents it (#489 §8).
+                #
+                # #741: the ENGINE now populates this key, so on this path it
+                # is always present -- and legitimately {} for a via that
+                # inherits the board's `(setup (tenting ...))`, which
+                # apply_via_protection correctly leaves alone.
+                #
+                # Note the guard below is `if not moved_attrs`: TRUTHINESS, not
+                # presence, so it fires for that inheriting via too. Harmless --
+                # _pcbnew_via_protection_attrs returns {} for a track at
+                # *_MODE_FROM_BOARD, so the re-read agrees -- but it does mean
+                # this fallback is NOT the regression detector for either half
+                # of #741. It re-derives its answer from the same track via the
+                # same call that built pcb_data, so it would MASK an engine
+                # revert. tests/test_741_via_nudge_tenting.py asserts on the
+                # engine dict for exactly that reason.
                 moved_attrs = vd.get('tenting_attrs')
                 for track in list(board.GetTracks()):
                     if track.GetClass() != 'PCB_VIA':

--- a/kicad_routing_plugin/fanout_gui.py
+++ b/kicad_routing_plugin/fanout_gui.py
@@ -1970,7 +1970,10 @@ class FanoutTab(wx.Panel):
             # segment(s) back to the stub start. The CLI applies these via
             # write_placed_output; on the live board we must mirror it (else the
             # via stays put and the graze the summary claims to have fixed
-            # persists). GUI parity for placement/writer.py:250-302.
+            # persists). GUI parity for the via-nudge block in
+            # placement/writer.py (`# Via-nudge rewrites (#313)` to the
+            # splice) -- named by its marker comment rather than by line
+            # numbers, which this file has now got wrong twice.
             name_to_id, _ = _build_layer_mappings()
 
             def _layer_id(layer_name):
@@ -2009,7 +2012,7 @@ class FanoutTab(wx.Panel):
                 # internally and returns {}. That is pre-existing #489
                 # behaviour and NOT this fix's doing, but it means the GUI half
                 # of the round trip does not currently carry a spec at all.
-                # Filed separately.
+                # #751.
                 moved_attrs = vd.get('tenting_attrs')
                 for track in list(board.GetTracks()):
                     if track.GetClass() != 'PCB_VIA':

--- a/kicad_routing_plugin/swig_gui.py
+++ b/kicad_routing_plugin/swig_gui.py
@@ -737,6 +737,34 @@ class RoutingDialog(wx.Dialog):
         val = rule if (rule and rule > 1e-9) else defaults.PLANE_EDGE_CLEARANCE
         return self._fab_floored('board_edge_clearance', val)
 
+    def _effective_placement_edge_clearance(self):
+        """Cap-PLACEMENT edge margin for the #130 repair (#733), or None.
+
+        None means "the shared engine resolves it" -- exact parity with the CLI,
+        where an omitted --board-edge-clearance reaches
+        placement.fanout_clearance.resolve_cap_edge_clearance and a given one is
+        honoured as typed. Only the operator's OVERRIDE has to travel; that way
+        neither front carries its own copy of the default and they cannot drift,
+        which is the whole of #733.
+
+        NOT _effective_board_edge_clearance: that is the SIGNAL edge clearance,
+        which answers 0.0 on a board with no rule and is then fab-floored to 0.20
+        -- 0.35mm looser than this pass's own margin. _effective_plane_edge_clearance
+        above carries the same warning for the plane tab, for the same reason.
+        """
+        if self.edge_clearance_check.GetValue():
+            val = self.board_edge_clearance.GetValue()
+            # A ZERO in a ticked override is UNSET, not a margin of zero. The
+            # control is CREATED at defaults.BOARD_EDGE_CLEARANCE (0.0) with a
+            # range minimum of 0.0, so "ticked the box, typed nothing" is a
+            # reachable state -- and passing that on would inset caps at the bare
+            # clearance, LOOSER than the 0.55 this tab used before #733. Same
+            # `> 1e-9` rule as _effective_plane_edge_clearance above; the signal
+            # twin on this same control gets the equivalent guard from
+            # _fab_floored, which is why only this reading needed one.
+            return val if val > 1e-9 else None
+        return None
+
     def _effective_geometry_floor(self, name):
         """Geometry floor to route/grade with (#439 parity with the CLI):
         the dedicated control when its override checkbox is checked; otherwise
@@ -1754,6 +1782,11 @@ class RoutingDialog(wx.Dialog):
                 # Edge.Cuts keep-out for QFN escape stubs/vias (issue #288);
                 # 0 = fall back to the copper clearance inside generate_qfn_fanout.
                 'board_edge_clearance': self._effective_board_edge_clearance(),
+                # #733: the decoupling-cap repair's OWN edge margin, which is a
+                # placement margin rather than the signal keep-out above. None =
+                # let the shared engine resolve it, exactly as the CLI does when
+                # --board-edge-clearance is omitted.
+                'cap_board_edge_clearance': self._effective_placement_edge_clearance(),
                 # #489 section 9: the ONE shared "Add teardrops" checkbox now
                 # reaches fanout too -- it is the step where a track-to-via
                 # teardrop matters most.

--- a/py_placer/place_fanout_clearance.py
+++ b/py_placer/place_fanout_clearance.py
@@ -5,9 +5,16 @@ Run this AFTER bga_fanout.py. It nudges decoupling caps near a BGA so their
 pads clear every foreign-net fanout via by `clearance`, and pulls each cap
 pad toward the nearest same-net ball (so a GND/power via dropped there later
 also lands on the cap pad). Caps move as little as possible (90-degree
-rotations allowed) and never overlap each other; a cap that can't clear a
-foreign via grows its displacement budget until it fits or is reported
-unresolved.
+rotations allowed) and never overlap each other; a cap that can't clear
+foreign copper -- a via (#130), a track (#278) or a component pad (#275) --
+grows its displacement budget until it fits or is reported unresolved.
+
+The summary counts both mechanisms from ONE board state, at the end of the
+pass (#746): `resolved R/V initial violations` means "was grazing at the seed
+and is clean now", with `(F freed by via-nudge)` naming the share the #313
+last resort freed by moving a via rather than the cap. A `Re-grazed by this
+pass's own connector copper:` line means the pass fixed those caps and then
+its own reconnect copper broke them again.
 
 Usage:
   python place_fanout_clearance.py fanned.kicad_pcb [output.kicad_pcb] [options]

--- a/py_placer/place_fanout_clearance.py
+++ b/py_placer/place_fanout_clearance.py
@@ -62,8 +62,12 @@ Examples:
                         help=f"DRC clearance in mm (default: {defaults.CLEARANCE})")
     parser.add_argument("--grid-step", type=float, default=defaults.GRID_STEP,
                         help=f"Position snap in mm (default: {defaults.GRID_STEP})")
-    parser.add_argument("--board-edge-clearance", type=float, default=0.55,
-                        help="Hard clearance from board edge in mm (default: 0.55)")
+    parser.add_argument("--board-edge-clearance", type=float, default=None,
+                        help="Hard clearance from board edge in mm (default: the "
+                             "board's own min_copper_edge_clearance when it asks "
+                             "for MORE than 0.55, else 0.55). #733: resolved by "
+                             "the shared engine, so the GUI plugin and "
+                             "animate_fanout_clearance.py get the same answer.")
     parser.add_argument("--capture-radius", type=float, default=2.0,
                         help="Max distance over which a same-net ball attracts "
                              "a cap pad in mm (default: 2.0)")

--- a/py_placer/place_fanout_clearance.py
+++ b/py_placer/place_fanout_clearance.py
@@ -13,8 +13,10 @@ The summary counts both mechanisms from ONE board state, at the end of the
 pass (#746): `resolved R/V initial violations` means "was grazing at the seed
 and is clean now", with `(F freed by via-nudge)` naming the share the #313
 last resort freed by moving a via rather than the cap. A `Re-grazed by this
-pass's own connector copper:` line means the pass fixed those caps and then
-its own reconnect copper broke them again.
+pass's own connector copper:` line means those caps were CLEAN before the
+nudge and are grazing after it -- whether or not the pass had fixed them
+first, since copper this pass draws can also break a cap that arrived clean.
+They are in the unresolved list too; this line names the cause, which is us.
 
 Usage:
   python place_fanout_clearance.py fanned.kicad_pcb [output.kicad_pcb] [options]

--- a/py_placer/placement/README.md
+++ b/py_placer/placement/README.md
@@ -926,9 +926,20 @@ re-seating 85/92 while leaving its zone targets unmoved):
 - **`legality.PartPads` / `LegalityContext` / `grade_pad_legality`** — the
   pad+drill layer. Gate currency: rotation-inflated AABB pad rects (the
   `_Cap.pad_rects` pattern; conservative — can falsely reject, never falsely
-  accept), NPTH drills inflated per hole to `max(NPTH_TO_TRACK_CLEARANCE,
-  the hole pad's own local_clearance)` (#730; `copper_holes=False` opts a
-  SILK caller out, since that override is a copper rule), per-PAIR
+  accept), NPTH drills held off foreign copper at a STANDOFF FROM THE HOLE
+  WALL of `max(--clearance, NPTH_TO_TRACK_CLEARANCE, the board's declared
+  min_hole_clearance, the hole pad's own local_clearance)` — `check_drc`'s own
+  requirement (#730, #761). Resolved in ONE place, `PartPads.hole_keepouts`:
+  the stored `holes_local` radius is the growth ABOVE `--clearance` and the
+  consumer adds the clearance back, exactly as `fanout_clearance`'s cap gate
+  and `labels.py`'s silk test each do — before #761 legality added nothing, so
+  its modelled standoff collapsed to zero at and above the requirement.
+  `copper_holes=False` opts a SILK caller out of both copper terms (the pad
+  override and the board floor); the board floor arrives as a resolved FLOAT
+  (`resolve_npth_floor`), never a board pointer, and only at the two of six
+  `build_part_pads` call sites that read hole keep-outs. `holes_extent`
+  carries the same holes WITHOUT either copper term, so an author's keep-clear
+  can never push a part off the outline. Per-PAIR
   baselines from SEED poses ("never worse than the board you were handed"; a
   NEW different-net pad intersection is never admitted). Exact `check_drc`
   geometry runs once per CLI for reports, so summaries carry no AABB phantoms.
@@ -969,8 +980,10 @@ re-seating 85/92 while leaving its zone targets unmoved):
   individual mis-move smuggled inside a hugely-improving set (run 3's J7:
   31.6 mm from home, worse than its 15.8 mm input).
 - **`render_placement --legality`** (default ON) draws the defects the caption
-  used to only count: conflict rings/links, NPTH keepout circles, dashed-red
-  off-board pad extents; caption gains `pad-conflicts` / `hole-conflict`.
+  used to only count: conflict rings/links, NPTH keepout circles (the real
+  keep-out since #761 — it drew the bare drill at `--clearance >= 0.20`,
+  agreeing with the model's own blind spot), dashed-red off-board pad
+  extents; caption gains `pad-conflicts` / `hole-conflict`.
 
 Design lineage (see the session literature survey): Abacus/minimum-
 perturbation legalization (Spindler 2008; Brenner 2012; Kahng-Markov-Reda

--- a/py_placer/placement/README.md
+++ b/py_placer/placement/README.md
@@ -281,7 +281,8 @@ which is not a subset of the seed violators — copper the pass itself drew can
 break a cap that started clean, and when it does, a `Re-grazed by this pass's
 own connector copper:` line names those caps. Before #746 `resolved` was
 computed before the nudge and never refreshed, so a cap the nudge freed reached
-neither list and a cap the pass re-grazed reached both.
+neither list, and a cap the sweep had cleaned before the pass re-grazed it
+reached both.
 
 It reads each via's actual size from the board, so the only setting that
 matters is `--clearance`, which must match the fanout / DRC floor:

--- a/py_placer/placement/README.md
+++ b/py_placer/placement/README.md
@@ -272,6 +272,17 @@ shared via connects ball + cap + plane). Caps move as little as possible
 that can't clear within the (auto-grown) displacement budget is reported
 unresolved for a manual nudge.
 
+The summary line reads `Moved N cap(s); resolved R/V initial violations;
+K unresolved`. Since #746 both counts are graded from the **same** board state,
+at the end of the pass: `resolved` means "was grazing at the seed and is clean
+now" and therefore credits the #313 via-nudge as well as the cap move, with
+`(F freed by via-nudge)` naming that share. `unresolved` means "grazing now",
+which is not a subset of the seed violators — copper the pass itself drew can
+break a cap that started clean, and when it does, a `Re-grazed by this pass's
+own connector copper:` line names those caps. Before #746 `resolved` was
+computed before the nudge and never refreshed, so a cap the nudge freed reached
+neither list and a cap the pass re-grazed reached both.
+
 It reads each via's actual size from the board, so the only setting that
 matters is `--clearance`, which must match the fanout / DRC floor:
 

--- a/py_placer/placement/README.md
+++ b/py_placer/placement/README.md
@@ -286,7 +286,7 @@ python py_placer/place_fanout_clearance.py fanned.kicad_pcb capclean.kicad_pcb -
 | `--cap-prefix` | `C,R` | Comma-separated reference prefix(es) for movable passives near a BGA (caps **and** resistors by default). Only 2-copper-pad parts move, so RN-style arrays are auto-excluded; paste-only apertures are ignored when counting pads. |
 | `--capture-radius` | 2 mm | Max distance over which a same-net ball attracts a pad |
 | `--max-displacement` / `--max-displacement-cap` | 2 / 3 mm | Initial and grown move budget per cap |
-| `--default-via-size` | 0.3 mm | Fallback only, for vias with no readable size |
+| `--default-via-size` | 0.3 mm | Fallback only, for vias with no readable size. Honoured by the grader **and** the via-nudge since #732; before that the nudge priced such a via at a hard-coded 0.5 and the two disagreed. |
 | `--lock` | – | Extra reference patterns to pin in place |
 
 On ulx3s U1 (22×22, 0.8 mm) this took the fanned board from 4 PAD-VIA to

--- a/py_placer/placement/README.md
+++ b/py_placer/placement/README.md
@@ -287,6 +287,7 @@ python py_placer/place_fanout_clearance.py fanned.kicad_pcb capclean.kicad_pcb -
 | `--capture-radius` | 2 mm | Max distance over which a same-net ball attracts a pad |
 | `--max-displacement` / `--max-displacement-cap` | 2 / 3 mm | Initial and grown move budget per cap |
 | `--default-via-size` | 0.3 mm | Fallback only, for vias with no readable size. Honoured by the grader **and** the via-nudge since #732; before that the nudge priced such a via at a hard-coded 0.5 and the two disagreed. |
+| `--board-edge-clearance` | the board's own `min_copper_edge_clearance` when it asks for MORE, else 0.55 mm | Copper-to-Edge.Cuts margin for a moved cap **and** for a via the #313 nudge relocates -- one number since #733, where the nudger gated its own emitted copper at the bare `--clearance` and parked it 0.30 mm inside the band the cap mover reserves. Resolved by the shared engine, so the GUI plugin and `animate_fanout_clearance.py` get the same answer; TIGHTEN-only on an omitted flag, because `fix_project_for_output` pins this field up to the 0.20 fab floor on every board the chain writes. A given value is honoured as typed. |
 | `--lock` | – | Extra reference patterns to pin in place |
 
 On ulx3s U1 (22×22, 0.8 mm) this took the fanned board from 4 PAD-VIA to

--- a/py_placer/placement/README.md
+++ b/py_placer/placement/README.md
@@ -926,7 +926,9 @@ re-seating 85/92 while leaving its zone targets unmoved):
 - **`legality.PartPads` / `LegalityContext` / `grade_pad_legality`** — the
   pad+drill layer. Gate currency: rotation-inflated AABB pad rects (the
   `_Cap.pad_rects` pattern; conservative — can falsely reject, never falsely
-  accept), NPTH drills inflated to `NPTH_TO_TRACK_CLEARANCE`, per-PAIR
+  accept), NPTH drills inflated per hole to `max(NPTH_TO_TRACK_CLEARANCE,
+  the hole pad's own local_clearance)` (#730; `copper_holes=False` opts a
+  SILK caller out, since that override is a copper rule), per-PAIR
   baselines from SEED poses ("never worse than the board you were handed"; a
   NEW different-net pad intersection is never admitted). Exact `check_drc`
   geometry runs once per CLI for reports, so summaries carry no AABB phantoms.

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -50,6 +50,12 @@ from placement.legality import (BoardOutlineGate, PadClearanceModel, PadFloor,
 
 ROTATIONS = [0.0, 90.0, 180.0, 270.0]
 EPS = 1e-6
+# The keep-out written into an eff cell for a pair sharing NO copper layer
+# (#731). Large and NEGATIVE, so _seg_shortfalls' EXISTING cheap bbox reject
+# (min(x1, x2) > bx1 + halfw) fires on the first comparison: the layer gate
+# costs the innermost loop nothing -- no extra branch, no mask row. Finite
+# rather than -inf so nothing can produce a NaN if a caller sums a row.
+_OFF_LAYER = -1.0e9
 
 # These four moved to placement/legality.py, the shared home with quench.py
 # (which carried byte-identical copies of the first two). Aliased rather than
@@ -144,7 +150,7 @@ class _Cap:
     for decoupling caps).
     """
 
-    def __init__(self, fp, courtyard_local, model=None):
+    def __init__(self, fp, courtyard_local, model=None, board_copper=None):
         self.ref = fp.reference
         self.side = 'B' if (fp.layer or '').startswith('B') else 'F'
         self.seed_x, self.seed_y = fp.x, fp.y
@@ -170,16 +176,26 @@ class _Cap:
         # makes the alignment true by construction.
         self.pad_floors = []
         self.max_floor = 0.0
-        # Per-pad COPPER LAYER sets, index-aligned like pad_floors. Needed
-        # because self.segments records only an 'F'/'B' side and files an
-        # In1.Cu track under 'F' (a pre-existing model quirk), so an F-side cap
-        # pad is compared against inner-layer tracks it can never touch. That
-        # phantom is priced at the flat scalar today; without this set the
-        # NETCLASS term -- which is layer-blind -- would raise it too, and the
-        # pass would move caps to clear copper on a layer their pads do not
-        # occupy. Measured on orangecrab at --clearance 0.1 with a Default
-        # class of 0.3: R17/R18/R5's ENTIRE graze is that phantom, 0.082mm
-        # each flat and 0.70/0.70/0.57mm raised. See _seg_effs.
+        # Per-pad COPPER LAYER sets, index-aligned like self.pads. This is
+        # what scopes a cap pad to the tracks it can actually touch (#731):
+        # check_drc grades a pad-segment pair only on their SHARED copper, and
+        # the netclass term is layer-blind, so without this set the pass both
+        # charged phantom inner-layer pairs and missed the real B.Cu/inner
+        # pairs of a through-hole pad.
+        #
+        # Built from the BOARD STACKUP alone, never from the clearance model
+        # (#731). Which copper a pad occupies is a fact about the board, not
+        # about what it declares -- and PadClearanceModel is inert unless a
+        # netclass, a .kicad_dru rule or a pad override exists. Gated on the
+        # model, as pad_floors legitimately is, this would be inert on exactly
+        # the boards carrying the most phantom: rp2350 declares none of the
+        # three, is 6 copper layers, and 2342 of its 4331 pruned pad x track
+        # pairs are off-layer, carrying 4.6685mm of phantom graze against
+        # 0.0142mm of real. `board_copper` falls back to the model's copy only
+        # so a caller passing a model and nothing else still resolves layers.
+        _cu = list(board_copper if board_copper is not None
+                   else (getattr(model, 'board_copper', None) or ()))
+        from check_drc import pad_copper_layers
         self.pad_layers = []
         for p in fp.pads:
             if not any(str(l).endswith('.Cu') for l in p.layers):
@@ -192,31 +208,30 @@ class _Cap:
             half_x = hx * c + hy * s
             half_y = hx * s + hy * c
             self.pads.append((off_x, off_y, half_x, half_y, p.net_id))
+            # The GEOMETRY filter above stays loose on purpose (see the
+            # comment), but a FLOOR must not: PadClearanceModel.pad_floor
+            # reads local_clearance unconditionally, and an np_thru_hole
+            # pad lists *.Cu while carrying no copper at all. Charging its
+            # override would move a cap to clear copper that does not
+            # exist -- and would contradict the model's own inertness
+            # rule, which refuses to ACTIVATE for an NPTH-only override
+            # (legality._pad_carries_copper, the watchy measurement).
+            # A pad that carries no copper is graded FLAT, whole stop --
+            # not merely stripped of its own override. check_drc does not
+            # grade such a pad at all, so letting the PARTNER's netclass
+            # through pair() would charge a keep-out that does not exist,
+            # which is the same defect as the off-layer phantom #731 is
+            # about. The EMPTY layer set is the marker the eff builders
+            # key on; a real copper pad always resolves at least one layer.
+            carries = _pad_carries_copper(p)
+            # Appended ALWAYS, model or not (#731), and unconditionally
+            # within the loop so the index alignment the loose geometry
+            # filter buys is preserved.
+            self.pad_layers.append(
+                frozenset(pad_copper_layers(p, _cu)) if carries else frozenset())
             if model is not None:
-                # The GEOMETRY filter above stays loose on purpose (see the
-                # comment), but a FLOOR must not: PadClearanceModel.pad_floor
-                # reads local_clearance unconditionally, and an np_thru_hole
-                # pad lists *.Cu while carrying no copper at all. Charging its
-                # override would move a cap to clear copper that does not
-                # exist -- and would contradict the model's own inertness
-                # rule, which refuses to ACTIVATE for an NPTH-only override
-                # (legality._pad_carries_copper, the watchy measurement).
-                # Zero floor, appended unconditionally so the index alignment
-                # the loose filter buys is preserved.
-                # A pad that carries no copper is graded FLAT, whole stop --
-                # not merely stripped of its own override. check_drc does not
-                # grade such a pad at all, so letting the PARTNER's netclass
-                # through pair() would charge a keep-out that does not exist,
-                # which is the same defect as the off-layer phantom below.
-                # The empty layer set is the marker the eff builders key on;
-                # a real copper pad always resolves at least one layer.
-                carries = _pad_carries_copper(p)
                 fl = model.pad_floor(p) if carries else PadFloor(0.0, 0.0, None)
                 self.pad_floors.append(fl)
-                from check_drc import pad_copper_layers
-                self.pad_layers.append(
-                    frozenset(pad_copper_layers(p, model.board_copper))
-                    if carries else frozenset())
                 mf = model.max_floor(fl)
                 if mf > self.max_floor:
                     self.max_floor = mf
@@ -451,34 +466,40 @@ class _Repair:
             self.vias.append(t)
             self._via_radius_by_id[id(t)] = (t, size / 2.0)
 
-        # --- avoidance: foreign-net tracks on the cap's own side ---
+        # --- avoidance: foreign-net tracks the cap's pads can actually TOUCH ---
         # Fanout escapes can land on the bottom (cap) side; attraction could
         # then pull a cap onto an escape track -> a PAD-SEGMENT violation.
-        # Keyed by side so a B.Cu cap only avoids B.Cu tracks.
-        # #725: element 5 is the OVER-REACH, like self.vias[3] above. The
-        # segment's floor is keyed by its REAL layer, not by the F/B `side`
-        # collapse on the next line (which files an In1.Cu track under 'F') --
-        # a .kicad_dru rule is layer-scoped, and check_drc's pad-segment path
-        # resolves it as a single-layer REPLACE on seg.layer. The side collapse
-        # is pre-existing and deliberately left alone here.
+        # #725: element 5 is the OVER-REACH, like self.vias[3] above, and the
+        # segment's floor is keyed by its REAL layer.
+        # #731: so is element 6, which used to be the 'F'/'B' board SIDE. That
+        # collapse filed every non-B layer under 'F', so an In1.Cu track was
+        # compared against an F-side cap pad that can never touch it -- 928
+        # such pairs on orangecrab at --clearance 0.1, 0.2464mm of phantom
+        # graze at the seed, and the ENTIRE bill of R17/R18/R5. check_drc
+        # grades no such pair at all (check_pad_segment_overlap returns early
+        # when seg.layer is not in the pad's expanded copper layers). It was
+        # wrong in the other direction too: a THROUGH-HOLE cap pad's copper
+        # spans every layer, and the side test DROPPED the B.Cu and inner
+        # tracks it really does share copper with.
+        #
+        # The tuple WIDTH is unchanged (TestShapeContract pins it) and the
+        # side is now derived, in one place (_seg_side), only where a cap's
+        # real pad layers are unavailable.
         self.segments: List[Tuple[float, float, float, float, int, float, str]] = []
-        # The 7-tuple carries `side`, not the real layer, so the floor cannot be
-        # re-derived from it later -- keep it on the tuple's identity. The
-        # tuples live for this object's lifetime, so the id is stable; a tuple a
-        # test injects is simply absent and grades flat.
+        # The floor cannot be re-derived from the tuple, so keep it on the
+        # tuple's identity. The tuples live for this object's lifetime, so the
+        # id is stable; a tuple a test injects is simply absent and grades
+        # flat. (There is no companion layer map any more: the layer IS the
+        # tuple's element 6, so there is exactly one answer to "what layer is
+        # this track on". The old map was additionally gated on an ACTIVE
+        # clearance model, which is what made the layer truth vanish on the
+        # boards carrying the most phantom -- see _cap_seg_scope.)
         self._seg_floor_by_id: Dict[int, PadFloor] = {}
-        # ...and its REAL layer, for the same reason: the pruned list is built
-        # on the F/B side collapse, so _seg_effs needs the true layer to tell a
-        # pair that shares copper from one that cannot.
-        self._seg_layer_by_id: Dict[int, str] = {}
         for s in pcb_data.segments:
-            side = 'B' if (s.layer or '').startswith('B') else 'F'
             fl = self._seg_floor_for(s.net_id, s.layer)
             t = (s.start_x, s.start_y, s.end_x, s.end_y, s.net_id,
-                 s.width / 2.0 + self._item_reach(fl), side)
+                 s.width / 2.0 + self._item_reach(fl), s.layer)
             self.segments.append(t)
-            if self._floors is not None:
-                self._seg_layer_by_id[id(t)] = s.layer
             if fl is not None:
                 self._seg_floor_by_id[id(t)] = fl
 
@@ -556,7 +577,7 @@ class _Repair:
             is_cap = (ref.startswith(self._cap_prefixes) and n_copper <= 2
                       and ref not in locked)
             if is_cap:
-                cap = _Cap(fp, lb, self._floors)
+                cap = _Cap(fp, lb, self._floors, self._all_cu)
                 if self._near_any(cap.rect(), bga_bboxes, near_margin):
                     self.caps[ref] = cap
                     continue
@@ -649,7 +670,7 @@ class _Repair:
         self.cap_static: Dict[str, List[Tuple[int, Tuple]]] = {}
         # other movable caps (refs, same side) that could ever touch this one
         self.cap_caps: Dict[str, List[str]] = {}
-        # foreign-net tracks on the cap's side in reach
+        # foreign-net tracks this cap's pads SHARE COPPER WITH, in reach (#731)
         self.cap_segs: Dict[str, List[Tuple]] = {}
         # through-vias in reach (each (vx, vy, net, keepout))
         self.cap_vias: Dict[str, List[Tuple[float, float, int, float]]] = {}
@@ -700,8 +721,25 @@ class _Repair:
             # this cap's excess over the flat scalar bounds the pair.
             seg_reach = (max_displacement_cap + 2 * span + clearance
                          + max(0.0, cap_mf - clearance))
+            # #731: keep a track only if SOME pad of this cap shares its copper
+            # layer. The union is a superset of every per-pad set (see
+            # _seg_shares), so this can never drop a chargeable pair -- the
+            # list stays EXACT, as TestPruneRadiiStayExact requires. The
+            # per-pad half is applied in _seg_effs, and matters only for a cap
+            # whose pads differ (an SMD pad beside a through-hole one).
+            #
+            # When scoping is off, fall back to the OLD side collapse rather
+            # than keeping everything: check_drc still layer-scopes such a
+            # board (its routing_layers falls back to the segment-derived set,
+            # then to ['F.Cu','B.Cu']), so the placer must stay on the
+            # over-block side, not stop filtering altogether.
+            _pl, _union = self._cap_seg_scope(cap)
             for seg in self.segments:
-                if seg[6] != cap.side:
+                layer = seg[6]
+                if _union is None:
+                    if self._seg_side(layer) != cap.side:
+                        continue
+                elif layer in self._all_cu and layer not in _union:
                     continue
                 d = _point_to_seg_dist(ccx, ccy, seg[0], seg[1], seg[2], seg[3])
                 if d <= seg_reach + seg[5]:
@@ -931,7 +969,13 @@ class _Repair:
         because a board with no copper layers has no layer question to answer.
         """
         pl = getattr(cap, 'pad_layers', None)
-        if pl is None or len(pl) != len(getattr(cap, 'pad_floors', ())):
+        # #731: anchored on `pads`, NOT on `pad_floors`. pad_layers is built
+        # unconditionally and pad_floors only when the model is active, so a
+        # pad_floors-anchored check would return None on every INERT board --
+        # switching layer scoping off precisely where the phantom is largest.
+        # `pads` is the list pad_rects() is built from, so it is the alignment
+        # that actually matters.
+        if pl is None or len(pl) != len(getattr(cap, 'pads', ())):
             return None
         return pl if self._all_cu else None
 
@@ -939,6 +983,44 @@ class _Repair:
     def _flat_pad(cap_layers, i):
         """True when cap pad `i` carries no copper and must be graded flat."""
         return cap_layers is not None and not cap_layers[i]
+
+    @staticmethod
+    def _seg_side(layer):
+        """The 'F'/'B' collapse the track prune used to be keyed on, kept ONLY
+        as the fallback for a cap whose real pad layers are unavailable.
+        Byte-identical to what __init__ computed before #731."""
+        return 'B' if (layer or '').startswith('B') else 'F'
+
+    def _cap_seg_scope(self, cap):
+        """(per-pad copper layer sets, their union) for the TRACK channel, or
+        (None, None) when layer scoping is off for this cap -- a duck-typed
+        cap, a misaligned list, a board declaring no copper layers, or a cap
+        with no copper-carrying pad at all. ONE decision point, so the prune
+        and the eff matrix can never disagree about whether scoping is on."""
+        pl = self._cap_pad_layers(cap)
+        if not pl:
+            return None, None
+        u = frozenset().union(*pl)
+        return (pl, u) if u else (None, None)
+
+    def _seg_shares(self, layer, mine):
+        """True when a track on `layer` can touch a cap pad whose copper layer
+        set is `mine`. The ONE predicate the prune, the eff matrix and the
+        disclosure all resolve through, so they cannot drift (#731).
+
+          mine is None              -> scoping off for this cap; charge, as before
+          layer not in self._all_cu -> an UNKNOWN layer (including None, a
+                                       test-injected 'F'/'B', and every layer
+                                       on a board declaring no copper): charge.
+                                       Over-blocking is the only direction that
+                                       can never ship a violation.
+          mine empty                -> a copper-less pad, which check_drc grades
+                                       not at all (#725): shares nothing.
+
+        Exactness of the union prune follows: _seg_shares(L, mine[i]) implies
+        `L not in _all_cu or L in union`, so a pair the per-pad grader would
+        charge can never be pruned away."""
+        return mine is None or layer not in self._all_cu or layer in mine
 
     def _cap_floors_ok(self, cap):
         """True when this cap carries a usable, index-aligned floor list. A
@@ -966,10 +1048,21 @@ class _Repair:
 
     def _seg_effs(self, ref, cap):
         """[cap pad i][pruned segment j] final half-width KEEP-OUT -- the
-        track's half width plus that pair's required clearance -- or None."""
-        if not self._cap_floors_ok(cap):
-            return None
+        track's half width plus that pair's required clearance -- or
+        `_OFF_LAYER` for a pair that shares no copper layer (#731). None only
+        for a cap offering neither floors nor layers (the duck-typed path).
+
+        Built even when the clearance model is INERT: the layer gate is a fact
+        about the stackup, not about what the board declares. On that path
+        every on-layer cell is the tuple's own t[5] BIT-EXACTLY and pair() is
+        never called, so an inert board stays byte-identical."""
         src = self.cap_segs[ref]
+        n = len(getattr(cap, 'pads', None) or ())
+        floors_ok = self._cap_floors_ok(cap)
+        cap_layers, _union = self._cap_seg_scope(cap)
+        # Nothing to price AND nothing to gate -> the duck-typed flat path.
+        if n == 0 or (not floors_ok and cap_layers is None):
+            return None
         rec = self._cap_seg_eff.get(ref)
         if rec is not None and rec[0] is src:
             return rec[1]
@@ -977,27 +1070,30 @@ class _Repair:
         floors = [by_id.get(id(t)) for t in src]
         # t[5] is half width + the segment's own over-reach; strip it back.
         halves = [t[5] - self._item_reach(f) for t, f in zip(src, floors)]
-        # A pair that shares NO copper layer keeps the FLAT scalar. cap_segs is
-        # pruned on the 'F'/'B' side collapse, which files an In1.Cu track
-        # under 'F', so it contains F-pad/inner-track pairs that cannot touch.
-        # The dru term already scopes itself away from them (empty shared set),
-        # but the netclass term does not -- and raising a phantom is how this
-        # change would move caps for a non-violation. Charging it flat leaves
-        # the pre-existing phantom exactly as it was; removing it altogether is
-        # a separate fix to the side collapse, filed rather than folded in.
-        cap_layers = self._cap_pad_layers(cap)
-        seg_layers = [self._seg_layer_by_id.get(id(t)) for t in src]
-
-        def eff(fa, mine, j):
-            sl = seg_layers[j]
-            if mine is not None and sl is not None and sl not in mine:
-                return self.clearance
-            return self._pair_or_flat(fa, floors[j])
-
-        rows = [[halves[j] + eff(fa, None if cap_layers is None
-                                 else cap_layers[i], j)
-                 for j in range(len(src))]
-                for i, fa in enumerate(cap.pad_floors)]
+        rows = []
+        for i in range(n):
+            fa = cap.pad_floors[i] if floors_ok else None
+            mine = None if cap_layers is None else cap_layers[i]
+            flat_pad = self._flat_pad(cap_layers, i)
+            row = []
+            for j, t in enumerate(src):
+                if not self._seg_shares(t[6], mine):
+                    # #731: a pair sharing no copper layer is not repriced, it
+                    # is REMOVED. _OFF_LAYER makes _seg_shortfalls' existing
+                    # cheap bbox reject fire on its first comparison, so the
+                    # gate costs the innermost loop nothing at all.
+                    row.append(_OFF_LAYER)
+                elif fa is None and floors[j] is None:
+                    # Bit-exact: t[5] itself, not (t[5] - clearance) + clearance,
+                    # so an INERT board grades every surviving pair to the same
+                    # float it did before, and an injected tuple grades exactly
+                    # as injected. The model is never consulted on this arm.
+                    row.append(t[5])
+                elif flat_pad:
+                    row.append(halves[j] + self.clearance)
+                else:
+                    row.append(halves[j] + self._pair_or_flat(fa, floors[j]))
+            rows.append(row)
         self._cap_seg_eff[ref] = (src, rows)
         return rows
 
@@ -1111,9 +1207,15 @@ class _Repair:
                     # nothing and belongs in no row
                     if _Repair._flat_pad(cap_layers, i):
                         continue
-                    # ...and neither does a pair that shares no copper layer
-                    if (layer is not None and cap_layers is not None
-                            and layer not in cap_layers[i]):
+                    # ...and neither does a pair that shares no copper layer.
+                    # THE SAME predicate _seg_effs prices with (#731), not a
+                    # second derivation -- a report that re-derives reports
+                    # pairs the pass never charged. `layer` is None for the
+                    # pad/via kinds, and _seg_shares charges an unknown layer,
+                    # so this is a no-op for them.
+                    if not self._seg_shares(
+                            layer, None if cap_layers is None
+                            else cap_layers[i]):
                         continue
                     mm, src = pair_with_source(fa, fb)
                     if src and mm > out.get(net, (0.0, ''))[0]:
@@ -1150,7 +1252,7 @@ class _Repair:
                     ('track', self.cap_segs[ref],
                      lambda t: self._seg_floor_by_id.get(id(t)), lambda t: t[4],
                      both(self._seg_shortfalls),
-                     lambda t: self._seg_layer_by_id.get(id(t)), None)):
+                     lambda t: t[6], None)):
                 for net, (mm, src) in best(fls, items, floor_of, net_of,
                                            set(charged), cl, layer_of,
                                            side_of).items():
@@ -1278,7 +1380,8 @@ class _Repair:
         return by_net
 
     def _seg_shortfalls(self, ref, cap, x, y, rot):
-        """PER-FOREIGN-NET, same-side track clearance shortfall for a placement,
+        """PER-FOREIGN-NET track clearance shortfall for a placement, over the
+        tracks this cap's pads actually SHARE COPPER WITH (#731),
         keyed by the track's net_id (#441): {snet: sum of (halfw - dist) over that
         net's segments this cap penetrates}. A net absent from the dict is fully
         clear. halfw already includes the clearance, so a positive shortfall is a
@@ -1287,13 +1390,16 @@ class _Repair:
         shortfall drops -- the zynq_ad9364 GND<->NetR2_2 repair-pass short (a move
         that relieved a 260um DDR3_BA2 graze by dropping a GND pad 85um onto a
         previously-clear NetR2_2 track looked like a net improvement to the old
-        scalar baseline). Uses the per-cap pruned, same-side track list."""
+        scalar baseline). Uses the per-cap pruned, layer-scoped track list."""
         by_net: Dict[int, float] = {}
         segs = self.cap_segs[ref]
         effs = self._seg_effs(ref, cap)
         if effs is None:
+            # Duck-typed cap only (#731): a real _Cap always offers pads, so it
+            # always gets a matrix. There is no layer to gate on here, and an
+            # injected tuple grades exactly as injected.
             for (bx0, by0, bx1, by1, net) in cap.pad_rects(x, y, rot):
-                for x1, y1, x2, y2, snet, halfw, side in segs:
+                for x1, y1, x2, y2, snet, halfw, _layer in segs:
                     if snet == net:
                         continue
                     # cheap reject: the segment's bbox can't reach the pad rect
@@ -1307,10 +1413,12 @@ class _Repair:
             return by_net
         # #725 active path: effs[i][j] IS the pair's keep-out, and the cheap
         # bbox reject widens with it -- a reject left at the flat half width
-        # would silently drop the pairs this fix exists to charge.
+        # would silently drop the pairs this fix exists to charge. Since #731
+        # the row also carries the LAYER gate, as _OFF_LAYER; the same cheap
+        # reject is what makes that free.
         for i, (bx0, by0, bx1, by1, net) in enumerate(cap.pad_rects(x, y, rot)):
             row = effs[i]
-            for j, (x1, y1, x2, y2, snet, _hw, side) in enumerate(segs):
+            for j, (x1, y1, x2, y2, snet, _hw, _layer) in enumerate(segs):
                 if snet == net:
                     continue
                 halfw = row[j]

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -1084,10 +1084,16 @@ class _Repair:
                     # gate costs the innermost loop nothing at all.
                     row.append(_OFF_LAYER)
                 elif fa is None and floors[j] is None:
-                    # Bit-exact: t[5] itself, not (t[5] - clearance) + clearance,
-                    # so an INERT board grades every surviving pair to the same
-                    # float it did before, and an injected tuple grades exactly
-                    # as injected. The model is never consulted on this arm.
+                    # Neither side has a floor: the pair is worth exactly the
+                    # tuple's own over-reach. Taking t[5] directly rather than
+                    # rebuilding it as halves[j] + clearance keeps the
+                    # resolver OUT of the inert path entirely -- _pair_or_flat
+                    # is not called, so an inert board cannot start consulting
+                    # a model, and an injected tuple grades exactly as
+                    # injected. (The arithmetic round-trip happens to be
+                    # float-exact on every cell measured -- 0 of 1063 on
+                    # rp2350 -- so this is about the call, not about the
+                    # rounding.)
                     row.append(t[5])
                 elif flat_pad:
                     row.append(halves[j] + self.clearance)

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -1339,9 +1339,10 @@ def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
     print(f"BGAs: {', '.join(st.bga_refs) or '(none)'}  "
           f"fanout vias: {len(st.vias)}  "
           f"movable near-BGA caps: {len(st.caps)}")
-    # #725: the early returns carry the same key set as the full one, so a
-    # caller reading result['required'] / ['clearance_notes'] does not have to
-    # special-case a no-op board.
+    # #725: the early returns carry 'required' / 'clearance_notes' too, so a
+    # caller does not have to special-case a no-op board for them. (They still
+    # omit 'via_moves' / 'new_segments', as they always have -- every caller
+    # reads the dict with .get.)
     if not st.vias:
         print("No vias on the board - run this AFTER bga_fanout.py.")
         return {'placements': [], 'resolved': [], 'unresolved': [],

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -2431,10 +2431,24 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
         # then keeps the #130 pad-via graze this pass exists to remove. That is
         # exactly the failure obstacle_map.resolve_hole_clearance names for
         # this function by name -- an all-or-nothing repair whose one clearing
-        # candidate must not be refused -- and the same balance #617 struck for
-        # the connector gate. At --clearance >= 0.20 the two floors are equal,
-        # so this only ever differs below the fab floor; the CLI's own --help
-        # example is --clearance 0.1, and the GUI control's minimum is 0.05.
+        # candidate must not be refused.
+        #
+        # A board's DECLARED min_hole_clearance stays unread here, and the
+        # checkable reason is better than the #617 appeal it replaces: it
+        # changes nothing in check_drc's VIA arm either. The declared floor
+        # enters that arm only through the `req_clr > npth_clr` THRESHOLD, so
+        # with hole_clearance 0.5 and no pad override the requirement is still
+        # `clearance`. (#617 is about a different move -- it declined to RAISE
+        # the connector gate above the flat fab floor; this LOWERS the via gate
+        # below it, which #617 never measured. The principle is shared, the
+        # floor is not.)
+        #
+        # At --clearance >= 0.20 the two floors are equal, so this only ever
+        # differs below the fab floor. The CLI's own --help example is
+        # --clearance 0.1 and it applies no fab floor at all; the GUI's spin
+        # minimum is 0.05 but its value passes through _fab_floored, so the
+        # reachable minimum there is the fab tier's -- 0.127 standard 2-layer,
+        # 0.10 advanced 2-layer, 0.09 advanced multilayer.
         #
         # Same helper, same own-net exemption and the same 1e-4 as
         # connector_clear's gate below, so the two cannot disagree about which
@@ -2455,12 +2469,26 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
         # drill-to-drill is a machine constraint, this is an etch constraint,
         # and check_drc's via arm makes the same own-net exemption.
         #
-        # KNOWN GAP, deliberately not closed here, exactly as at the cap
-        # keep-out site above: this does not honour the hole pad's OWN
-        # `local_clearance`, which check_drc does honour, so it under-blocks by
-        # `lc - clearance` on such a pad. That is #730 -- a wrong VALUE where
-        # this was a missing GATE -- and closing it here would move a number
-        # #730 needs to move in one place.
+        # KNOWN GAP, deliberately not closed here. Like the cap keep-out site
+        # above, this does not honour the hole pad's OWN `local_clearance` --
+        # but the arithmetic is NOT the same, and saying "as above" inside a
+        # comment whose whole point is that the track and via arms differ would
+        # be wrong. check_drc's via arm is a STEP, not a max:
+        # `lc if lc > npth_clr else clearance`. So the shortfall here is
+        # `lc - clearance` ONLY when `lc > npth_clr`, and exactly ZERO for
+        # `clearance < lc <= npth_clr` (measured: clearance 0.10, lc 0.15 ->
+        # checker wants 0.100, this gate charges 0.100). Choosing `clearance`
+        # over `npth_clr` WIDENS that shortfall by `npth_clr - clearance`, i.e.
+        # by up to 0.10mm at --clearance 0.1 -- stated in magnitude, not merely
+        # in kind.
+        #
+        # That is #730 -- a wrong VALUE where this was a missing GATE. Two
+        # things for whoever closes it: the obvious `max(clearance, lc)` is
+        # measured WRONG in both directions (it over-blocks by 0.05 at
+        # clearance 0.10 / lc 0.15), and an exact mirror needs check_drc's
+        # `npth_clr`, which includes the BOARD's declared min_hole_clearance --
+        # dragging back in the very read this function and its own source guard
+        # forbid.
         if _seg_foreign_hole_dist(pcb_data, v.net_id, nx, ny, nx, ny) < \
                 clearance + vr - 1e-4:
             return False

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -43,8 +43,9 @@ import routing_defaults as defaults
 from bga_fanout.grid import analyze_bga_grid
 from placement.parser import extract_courtyard_bboxes, extract_locked_refs
 from placement.utility import compute_footprint_bbox_local, snap_to_grid
-from placement.legality import (BoardOutlineGate, point_to_seg_dist, rect_gap,
-                                ring_is_rect, rotate_local_bounds)
+from placement.legality import (BoardOutlineGate, PadClearanceModel, PadFloor,
+                                format_required_clause, point_to_seg_dist,
+                                rect_gap, ring_is_rect, rotate_local_bounds)
 
 ROTATIONS = [0.0, 90.0, 180.0, 270.0]
 EPS = 1e-6
@@ -74,18 +75,26 @@ def _point_to_rect_dist(px, py, rect):
     return math.hypot(dx, dy)
 
 
-def _pad_pair_shortfall(pads_a, pads_b, clearance):
+def _pad_pair_shortfall(pads_a, pads_b, clearance, effs=None):
     """Sum of different-net pad clearance shortfalls between two movable parts'
     pad rects (#275) -- the mover-vs-mover analogue of pad_penalty. Same-net
-    pad pairs are fine (shared rail copper may touch)."""
+    pad pairs are fine (shared rail copper may touch).
+
+    `effs` (#725) is the per-pair REQUIRED clearance, `effs[ia][ib]` aligned
+    with pads_a x pads_b -- a pad override / netclass / .kicad_dru layer rule
+    can put a pair's requirement above (or, for a relaxing rule, below) the
+    flat scalar. None keeps the flat path, which is what a board declaring
+    none of them takes."""
     pen = 0.0
-    for (ax0, ay0, ax1, ay1, anet) in pads_a:
-        for (bx0, by0, bx1, by1, bnet) in pads_b:
+    for ia, (ax0, ay0, ax1, ay1, anet) in enumerate(pads_a):
+        row = None if effs is None else effs[ia]
+        for ib, (bx0, by0, bx1, by1, bnet) in enumerate(pads_b):
             if anet == bnet:
                 continue
             gap = _rect_gap((ax0, ay0, ax1, ay1), (bx0, by0, bx1, by1))
-            if gap < clearance - EPS:
-                pen += (clearance - gap)
+            clr = clearance if row is None else row[ib]
+            if gap < clr - EPS:
+                pen += (clr - gap)
     return pen
 
 
@@ -134,7 +143,7 @@ class _Cap:
     for decoupling caps).
     """
 
-    def __init__(self, fp, courtyard_local):
+    def __init__(self, fp, courtyard_local, model=None):
         self.ref = fp.reference
         self.side = 'B' if (fp.layer or '').startswith('B') else 'F'
         self.seed_x, self.seed_y = fp.x, fp.y
@@ -145,6 +154,21 @@ class _Cap:
         # separate paste-only "pads" (e.g. gkl_misc C_0201_0603Metric), which are
         # not copper and must not enter the clearance/attraction geometry.
         self.pads = []
+        # #725, mirroring PartPads (legality.py): the per-pad clearance FLOOR
+        # rides in a parallel list index-aligned with self.pads, never widened
+        # into the pad tuple -- pad_rects()' 5-tuple is unpacked positionally by
+        # tests and by animate_fanout_clearance.py. `max_floor` is the
+        # over-reach a broad phase must use (a .kicad_dru rule REPLACES, so it
+        # can also LOWER a pair; a prune must never under-reach).
+        # NOTE the copper filter below stays _Cap's own `endswith('.Cu')` test
+        # and is deliberately NOT unified with legality._pad_carries_copper,
+        # which additionally rejects np_thru_hole. Unifying would change which
+        # pads enter pad_rects/pad_bbox/attraction and desynchronise the
+        # n_copper cap-detection test in _Repair.__init__ -- a placement change
+        # dressed as a clearance fix. Building the floors against THIS rule
+        # makes the alignment true by construction.
+        self.pad_floors = []
+        self.max_floor = 0.0
         for p in fp.pads:
             if not any(str(l).endswith('.Cu') for l in p.layers):
                 continue  # paste/mask-only aperture, not copper
@@ -156,6 +180,12 @@ class _Cap:
             half_x = hx * c + hy * s
             half_y = hx * s + hy * c
             self.pads.append((off_x, off_y, half_x, half_y, p.net_id))
+            if model is not None:
+                fl = model.pad_floor(p)
+                self.pad_floors.append(fl)
+                mf = model.max_floor(fl)
+                if mf > self.max_floor:
+                    self.max_floor = mf
         self.local_bounds = courtyard_local
         # Rotation-only geometry is reused across every candidate position
         # (millions of times on a dense board), so memoize it per angle and
@@ -298,6 +328,29 @@ class _Repair:
         self._edge_active = self.edge_gate.active
         self._max_disp_cap = max_displacement_cap
         self.clearance = clearance
+        # #725: `clearance` is ONE flat scalar, but KiCad's different-net
+        # requirement for a pair is max(clearance, netclass a, netclass b),
+        # then REPLACED by any .kicad_dru rule on the layers the two share,
+        # then raised by either item's own pad `(clearance ...)` override.
+        # This pass is the second channel of #697's defect: priced flat, a pair
+        # separated by more than `clearance` but less than its real requirement
+        # is never charged, so the repair reports nothing to fix on geometry
+        # check_drc flags. PadClearanceModel resolves it exactly as check_drc
+        # does and is STRICTLY INERT on a board declaring none of the three.
+        # `notes` must be read BEFORE the active-drop: a FAILED read (an
+        # unreadable sibling) is exactly what makes the model look inert.
+        _model = PadClearanceModel.for_board(pcb_data, clearance, pcb_file)
+        self.clearance_notes = list(_model.notes)
+        self._floors = _model if _model.active else None
+        # Pad-layer scope for the non-pad items below. A via spans copper, so
+        # it is scoped to ALL copper: check_drc's pad-via path passes
+        # layers_b=None meaning "scope to the pad's own layers", and
+        # intersecting with all-copper reproduces that exactly (blind vias
+        # included). Never None here -- PadClearanceModel.pair does
+        # `fb.layers or ()`, and an EMPTY shared set discards every dru rule.
+        self._all_cu = frozenset(pcb_data.board_info.copper_layers or ())
+        self._via_floor: Dict[int, PadFloor] = {}
+        self._seg_floor: Dict[Tuple[int, str], PadFloor] = {}
         # #617: KiCad's copper-to-hole rule is the BOARD's `min_hole_clearance`
         # whenever it declares one above the 0.20 NPTH fab floor -- the same
         # value check_drc grades at. The NPTH keep-out rects below were grown
@@ -326,20 +379,44 @@ class _Repair:
         # Each (x, y, net, keepout) where keepout = via_radius + clearance; a
         # cap pad must clear vias of a DIFFERENT net by this. Through-vias, so
         # they apply to caps on either board side.
+        # #725: `keepout` is the OVER-REACH -- radius + max(clearance, this
+        # via's own upper-bound floor). It feeds the prunes, the locked-part
+        # warning and the animator's drawn disk, all of which may over-reach.
+        # The EXACT per-(cap pad, via) value is resolved in the eff lists
+        # below, never from this slot. Byte-identical (radius + clearance) when
+        # the model is inert. The 4-tuple shape is pinned: tests assign
+        # st.vias wholesale and animate_fanout_clearance.py unpacks it.
         self.vias: List[Tuple[float, float, int, float]] = []
         for v in pcb_data.vias:
             size = v.size if v.size and v.size > 0 else default_via_size
-            self.vias.append((v.x, v.y, v.net_id, size / 2.0 + clearance))
+            self.vias.append((v.x, v.y, v.net_id,
+                              size / 2.0 + self._item_reach(
+                                  self._via_floor_for(v.net_id))))
 
         # --- avoidance: foreign-net tracks on the cap's own side ---
         # Fanout escapes can land on the bottom (cap) side; attraction could
         # then pull a cap onto an escape track -> a PAD-SEGMENT violation.
         # Keyed by side so a B.Cu cap only avoids B.Cu tracks.
+        # #725: element 5 is the OVER-REACH, like self.vias[3] above. The
+        # segment's floor is keyed by its REAL layer, not by the F/B `side`
+        # collapse on the next line (which files an In1.Cu track under 'F') --
+        # a .kicad_dru rule is layer-scoped, and check_drc's pad-segment path
+        # resolves it as a single-layer REPLACE on seg.layer. The side collapse
+        # is pre-existing and deliberately left alone here.
         self.segments: List[Tuple[float, float, float, float, int, float, str]] = []
+        # The 7-tuple carries `side`, not the real layer, so the floor cannot be
+        # re-derived from it later -- keep it on the tuple's identity. The
+        # tuples live for this object's lifetime, so the id is stable; a tuple a
+        # test injects is simply absent and grades flat.
+        self._seg_floor_by_id: Dict[int, PadFloor] = {}
         for s in pcb_data.segments:
             side = 'B' if (s.layer or '').startswith('B') else 'F'
-            self.segments.append((s.start_x, s.start_y, s.end_x, s.end_y,
-                                  s.net_id, s.width / 2.0 + clearance, side))
+            fl = self._seg_floor_for(s.net_id, s.layer)
+            t = (s.start_x, s.start_y, s.end_x, s.end_y, s.net_id,
+                 s.width / 2.0 + self._item_reach(fl), side)
+            self.segments.append(t)
+            if fl is not None:
+                self._seg_floor_by_id[id(t)] = fl
 
         # --- attraction: BGA balls grouped by net ---
         # A cap pad is pulled toward the nearest ball of its own net, so a via
@@ -378,6 +455,13 @@ class _Repair:
         # a through-hole pad that blocks both sides). Same-net pads are fine.
         self.foreign_pads: List[
             Tuple[float, float, float, float, int, Optional[str]]] = []
+        # #725: index-aligned with self.foreign_pads (the 6-tuple shape is
+        # pinned -- tests inject into cap_foreign_pads directly). An NPTH
+        # entry gets floor None / mf 0.0: its rect is already inflated to the
+        # hole floor, and the copper-to-HOLE rule is net-independent, so the
+        # new machinery must never raise it via a neighbouring pad's netclass.
+        self.foreign_pad_floors: List[Optional[PadFloor]] = []
+        self.foreign_pad_mf: List[float] = []
         self.caps: Dict[str, _Cap] = {}
         self.static_rects: List[Tuple[Tuple[float, float, float, float], str]] = []
         for ref, fp in pcb_data.footprints.items():
@@ -392,7 +476,7 @@ class _Repair:
             is_cap = (ref.startswith(self._cap_prefixes) and n_copper <= 2
                       and ref not in locked)
             if is_cap:
-                cap = _Cap(fp, lb)
+                cap = _Cap(fp, lb, self._floors)
                 if self._near_any(cap.rect(), bga_bboxes, near_margin):
                     self.caps[ref] = cap
                     continue
@@ -421,6 +505,8 @@ class _Repair:
                             hr = hd / 2.0 + grow
                             self.foreign_pads.append(
                                 (hx - hr, hy - hr, hx + hr, hy + hr, -1, None))
+                            self.foreign_pad_floors.append(None)
+                            self.foreign_pad_mf.append(0.0)
                     continue
                 if not copper:
                     continue  # paste/mask-only aperture
@@ -436,6 +522,10 @@ class _Repair:
                     (p.global_x - half_x, p.global_y - half_y,
                      p.global_x + half_x, p.global_y + half_y,
                      p.net_id, pside))
+                _fl = None if self._floors is None else self._floors.pad_floor(p)
+                self.foreign_pad_floors.append(_fl)
+                self.foreign_pad_mf.append(
+                    0.0 if _fl is None else self._floors.max_floor(_fl))
 
         # Per-cap spatially-pruned neighbour lists (perf). A cap moves at most
         # max_displacement_cap from its seed, so anything whose seed gap already
@@ -443,6 +533,26 @@ class _Repair:
         # it -- excluding it is exact, not an approximation. This turns the
         # per-candidate hard_blocked / penalty loops from O(all parts) into
         # O(handful), the dominant cost on dense boards (#213 profiling).
+        # #725: same identity-keyed map for foreign pads -- a pad's floor
+        # depends on its own `(clearance ...)` and its copper layers, neither of
+        # which the 6-tuple carries.
+        self._fp_floor_by_id: Dict[int, PadFloor] = {}
+        if self._floors is not None:
+            for _t, _f in zip(self.foreign_pads, self.foreign_pad_floors):
+                if _f is not None:
+                    self._fp_floor_by_id[id(_t)] = _f
+        # Per-(cap, neighbour) REQUIRED-clearance memos. model.pair() is
+        # pose-independent, so it is resolved ONCE per pair here and never
+        # inside the candidate sweep. Each memo is (source_list, rows) and is
+        # rebuilt when the source list identity changes -- which makes
+        # repair_fanout_clearance's wholesale `st.cap_vias = {...}` reassignment
+        # self-heal, and makes a test that injects into cap_foreign_pads grade
+        # flat rather than mis-index.
+        self._cap_pad_eff: Dict[str, Tuple[list, list]] = {}
+        self._cap_seg_eff: Dict[str, Tuple[list, list]] = {}
+        self._cap_via_eff: Dict[str, Tuple[list, list]] = {}
+        self._cap_pair_eff: Dict[Tuple[str, str], list] = {}
+
         cap_geom: Dict[str, Tuple[float, float, float, Tuple]] = {}
         for ref, cap in self.caps.items():
             r = cap.rect()
@@ -460,16 +570,25 @@ class _Repair:
         self.cap_segs: Dict[str, List[Tuple]] = {}
         # through-vias in reach (each (vx, vy, net, keepout))
         self.cap_vias: Dict[str, List[Tuple[float, float, int, float]]] = {}
+        # #725: every reach below is raised by THE TWO ITEMS' OWN maxima, never
+        # by a board-wide maximum -- these lists gate per-candidate loops, so a
+        # board-wide bound would slow every cap for the sake of one keep-clear
+        # pad. `cap.max_floor` and `foreign_pad_mf` are 0.0 on an inert board,
+        # so `max(clearance, 0.0, 0.0) == clearance` and the reaches are
+        # byte-identical. Left un-raised on purpose: cap_static below, which
+        # gates _overlap (courtyards, not copper).
         cap_refs = list(self.caps)
         for ref, cap in self.caps.items():
             ccx, ccy, span, crect = cap_geom[ref]
-            reach = max_displacement_cap + span + clearance
+            reach = max_displacement_cap + span
+            cap_mf = cap.max_floor
             near_pads = []
-            for fp_pad in self.foreign_pads:
+            for j, fp_pad in enumerate(self.foreign_pads):
                 px = (fp_pad[0] + fp_pad[2]) / 2.0
                 py = (fp_pad[1] + fp_pad[3]) / 2.0
                 phalf = math.hypot(fp_pad[2] - px, fp_pad[3] - py)
-                if math.hypot(px - ccx, py - ccy) <= reach + phalf:
+                req = max(clearance, cap_mf, self.foreign_pad_mf[j])
+                if math.hypot(px - ccx, py - ccy) <= reach + req + phalf:
                     near_pads.append(fp_pad)
             self.cap_foreign_pads[ref] = near_pads
 
@@ -487,12 +606,17 @@ class _Repair:
                     continue
                 # both caps can move, so the combined reach is 2x the budget
                 if (_rect_gap(crect, cap_geom[oref][3])
-                        <= 2 * max_displacement_cap + clearance + EPS):
+                        <= 2 * max_displacement_cap
+                        + max(clearance, cap_mf, self.caps[oref].max_floor)
+                        + EPS):
                     near_caps.append(oref)
             self.cap_caps[ref] = near_caps
 
             near_segs = []
-            seg_reach = max_displacement_cap + 2 * span + clearance
+            # seg[5] already carries the segment's own over-reach, so adding
+            # this cap's excess over the flat scalar bounds the pair.
+            seg_reach = (max_displacement_cap + 2 * span + clearance
+                         + max(0.0, cap_mf - clearance))
             for seg in self.segments:
                 if seg[6] != cap.side:
                     continue
@@ -502,11 +626,13 @@ class _Repair:
             self.cap_segs[ref] = near_segs
 
             near_vias = []
+            # v[3] = via_radius + its own keep-out; a via that can reach a pad
+            # must be within (move + span + keep-out) of the seed. #725: plus
+            # this cap's excess over the flat scalar, which bounds the pair.
+            via_slack = max(0.0, cap_mf - clearance)
             for v in self.vias:
-                # v[3] = via_radius + clearance keep-out; a via that can reach
-                # a pad must be within (move + span + keep-out) of the seed.
                 if math.hypot(v[0] - ccx, v[1] - ccy) <= (
-                        max_displacement_cap + span + v[3]):
+                        max_displacement_cap + span + v[3] + via_slack):
                     near_vias.append(v)
             self.cap_vias[ref] = near_vias
 
@@ -562,8 +688,15 @@ class _Repair:
             for oref in self.cap_caps[ref]:
                 key = frozenset((ref, oref))
                 if key not in self.base_cap_pad:
+                    # #725: the baseline must be in the SAME currency as the
+                    # candidate it gates. Priced flat while candidates are
+                    # priced at the requirement, _worsens_any_net fires on
+                    # every pose and the pass silently stops moving anything --
+                    # a failure whose symptom is FEWER placements, which reads
+                    # as conservative rather than broken.
                     self.base_cap_pad[key] = _pad_pair_shortfall(
-                        seed_pads, self.caps[oref].pad_rects(), self.clearance)
+                        seed_pads, self.caps[oref].pad_rects(), self.clearance,
+                        self._pair_effs(ref, cap, oref, self.caps[oref]))
 
     @staticmethod
     def _near_any(rect, bboxes, margin):
@@ -617,26 +750,282 @@ class _Repair:
         return self.edge_gate.rect_blocked(
             rect, skip_rings=self._owned_rings(ref) if ref is not None else None)
 
+    # ---- #725: per-pair required clearance -------------------------------
+    # A via or a track carries no pad `(clearance ...)` override, so its floor
+    # is a pure function of (net, layer scope) and is memoised on that key --
+    # never on a list position, because st.vias is reassigned wholesale by
+    # tests and rebuilt by nudge_vias_for_unresolved, which would desync any
+    # index-aligned parallel list.
+
+    def _via_floor_for(self, net_id):
+        """The PadFloor standing in for a via: its net's class floor, no pad
+        override, scoped to all copper (see self._all_cu). None when inert."""
+        if self._floors is None:
+            return None
+        f = self._via_floor.get(net_id)
+        if f is None:
+            f = PadFloor(self._floors.net_floor.get(net_id or 0, 0.0), 0.0,
+                         self._all_cu if self._floors.layer_rules else None)
+            self._via_floor[net_id] = f
+        return f
+
+    def _seg_floor_for(self, net_id, layer):
+        """The PadFloor standing in for a track: its net's class floor, no pad
+        override, scoped to its OWN layer -- which reproduces check_drc's
+        single-layer REPLACE for pad-segment, since with one shared layer
+        pads_shared_layer_clearance is all-or-nothing. None when inert."""
+        if self._floors is None:
+            return None
+        key = (net_id, layer)
+        f = self._seg_floor.get(key)
+        if f is None:
+            f = PadFloor(self._floors.net_floor.get(net_id or 0, 0.0), 0.0,
+                         frozenset({layer}) if self._floors.layer_rules else None)
+            self._seg_floor[key] = f
+        return f
+
+    def _item_reach(self, floor):
+        """The over-reach for a via/track keep-out: never below the flat
+        scalar, raised by that item's own upper bound. Exactly `clearance`
+        when the model is inert, so the keep-outs stay byte-identical."""
+        if floor is None:
+            return self.clearance
+        return max(self.clearance, self._floors.max_floor(floor))
+
+    # Public resolvers. nudge_vias_for_unresolved composes its requirements
+    # from these rather than re-deriving them, so there is ONE answer per pair
+    # kind in this module.
+
+    def required(self, fa, fb):
+        """Required clearance between two resolved floors (either may be None
+        -- an NPTH keep-out, a test-injected tuple -- which grades flat)."""
+        return self._pair_or_flat(fa, fb)
+
+    def pad_floor(self, pad):
+        """The floor for a real parser Pad; None when inert."""
+        return None if self._floors is None else self._floors.pad_floor(pad)
+
+    def via_floor(self, net_id):
+        """The floor standing in for a via of `net_id`; None when inert."""
+        return self._via_floor_for(net_id)
+
+    def seg_floor(self, net_id, layer):
+        """The floor standing in for a track on `layer`; None when inert."""
+        return self._seg_floor_for(net_id, layer)
+
+    def via_required(self, pad_floor, via_net):
+        """The required clearance for one (cap pad, via) pair.
+
+        The offender test in nudge_vias_for_unresolved and via_penalty's
+        grazing test MUST both resolve through here: if they diverge, the
+        nudger chases a via the grader no longer flags (or reports a cap
+        unresolved that its own nudger then refuses to see). The via eff rows
+        are built from this same call, so they cannot drift from it either."""
+        return self._pair_or_flat(pad_floor, self._via_floor_for(via_net))
+
+    def _pair_or_flat(self, fa, fb):
+        """model.pair for two floors, falling back to the flat scalar whenever
+        either side has none (an NPTH keep-out rect, a test-injected tuple)."""
+        if fa is None or fb is None:
+            return self.clearance
+        return self._floors.pair(fa, fb)
+
+    def _cap_floors_ok(self, cap):
+        """True when this cap carries a usable, index-aligned floor list. A
+        _Cap built without the model (or by a test) grades flat."""
+        pf = getattr(cap, 'pad_floors', None)
+        return (self._floors is not None and pf is not None
+                and len(pf) == len(getattr(cap, 'pads', ())))
+
+    def _pad_effs(self, ref, cap):
+        """[cap pad i][pruned foreign pad j] required clearance, or None for
+        the flat path."""
+        if not self._cap_floors_ok(cap):
+            return None
+        src = self.cap_foreign_pads[ref]
+        rec = self._cap_pad_eff.get(ref)
+        if rec is not None and rec[0] is src:
+            return rec[1]
+        by_id = self._fp_floor_by_id
+        rows = [[self._pair_or_flat(fa, by_id.get(id(t))) for t in src]
+                for fa in cap.pad_floors]
+        self._cap_pad_eff[ref] = (src, rows)
+        return rows
+
+    def _seg_effs(self, ref, cap):
+        """[cap pad i][pruned segment j] final half-width KEEP-OUT -- the
+        track's half width plus that pair's required clearance -- or None."""
+        if not self._cap_floors_ok(cap):
+            return None
+        src = self.cap_segs[ref]
+        rec = self._cap_seg_eff.get(ref)
+        if rec is not None and rec[0] is src:
+            return rec[1]
+        by_id = self._seg_floor_by_id
+        floors = [by_id.get(id(t)) for t in src]
+        # t[5] is half width + the segment's own over-reach; strip it back.
+        halves = [t[5] - self._item_reach(f) for t, f in zip(src, floors)]
+        rows = [[halves[j] + self._pair_or_flat(fa, floors[j])
+                 for j in range(len(src))] for fa in cap.pad_floors]
+        self._cap_seg_eff[ref] = (src, rows)
+        return rows
+
+    def _via_effs(self, ref, cap, vias):
+        """[cap pad i][via j] final KEEP-OUT for `vias` -- the via's radius plus
+        that pair's required clearance -- or None for the flat path. The
+        requirement is resolved through via_required, so this can never
+        disagree with the offender test in nudge_vias_for_unresolved."""
+        if not self._cap_floors_ok(cap):
+            return None
+        rec = self._cap_via_eff.get(ref)
+        if rec is not None and rec[0] is vias:
+            return rec[1]
+        # v[3] is radius + the via's own over-reach; strip it back to a radius.
+        radii = [v[3] - self._item_reach(self._via_floor_for(v[2])) for v in vias]
+        rows = [[radii[j] + self.via_required(fa, v[2])
+                 for j, v in enumerate(vias)] for fa in cap.pad_floors]
+        self._cap_via_eff[ref] = (vias, rows)
+        return rows
+
+    def _pair_effs(self, ref, cap, oref, other):
+        """[this cap's pad i][other mover's pad j] required clearance, or None.
+        Keyed on the ORDERED pair so the row index always addresses `cap`; the
+        summed shortfall itself is symmetric, so the seed baseline is not."""
+        if not (self._cap_floors_ok(cap) and self._cap_floors_ok(other)):
+            return None
+        key = (ref, oref)
+        rows = self._cap_pair_eff.get(key)
+        if rows is None:
+            rows = [[self._pair_or_flat(fa, fb) for fb in other.pad_floors]
+                    for fa in cap.pad_floors]
+            self._cap_pair_eff[key] = rows
+        return rows
+
+    def required_rows(self, net_names=None, limit=200):
+        """Rows `[cap_ref, '<kind> <partner>', mm, source]` for every pair this
+        pass actually CHARGED at a requirement above the flat scalar, at the
+        caps' current poses.
+
+        Same 4-column shape as legality.grade_pad_legality's 'required', so
+        legality.format_required_clause renders it unchanged. `[]` when inert.
+        Only charged pairs are listed -- an in-reach pair that happens to be
+        clear is not a finding, it is the normal case on a declaring board.
+        The partner is named by NET, not by reference: foreign_pads / vias /
+        segments carry no owning ref and their tuple shapes are pinned."""
+        if self._floors is None:
+            return []
+        names = net_names or {}
+        pair_with_source = self._floors.pair_with_source
+        rows = []
+
+        def net_label(net):
+            if net == 0:
+                return '<no net>'
+            if net == -1:
+                return '<hole>'
+            return names.get(net, str(net))
+
+        def best(floors_a, items, floor_of, net_of, only):
+            """Worst requirement, with its source, over the items on `only`."""
+            out = {}
+            for t in items:
+                net = net_of(t)
+                if net not in only:
+                    continue
+                fb = floor_of(t)
+                if fb is None:
+                    continue
+                for fa in floors_a:
+                    mm, src = pair_with_source(fa, fb)
+                    if src and mm > out.get(net, (0.0, ''))[0]:
+                        out[net] = (mm, src)
+            return out
+
+        for ref, cap in self.caps.items():
+            if not self._cap_floors_ok(cap):
+                continue
+            fls = cap.pad_floors
+            x, y, rot = cap.x, cap.y, cap.rot
+            for kind, items, floor_of, net_of, charged in (
+                    ('pad', self.cap_foreign_pads[ref],
+                     lambda t: self._fp_floor_by_id.get(id(t)), lambda t: t[4],
+                     self._pad_shortfalls(ref, cap, x, y, rot)),
+                    ('via', self.cap_vias[ref],
+                     lambda t: self._via_floor_for(t[2]), lambda t: t[2],
+                     self._via_shortfalls(ref, cap, x, y, rot)),
+                    ('track', self.cap_segs[ref],
+                     lambda t: self._seg_floor_by_id.get(id(t)), lambda t: t[4],
+                     self._seg_shortfalls(ref, cap, x, y, rot))):
+                for net, (mm, src) in best(fls, items, floor_of, net_of,
+                                           set(charged)).items():
+                    rows.append([ref, '{} {}'.format(kind, net_label(net)),
+                                 round(mm, 6), src])
+            # mover-vs-mover: the shortfall is a scalar per pair, so charge the
+            # pair as a whole and name it by the partner's reference.
+            cand = cap.pad_rects(x, y, rot)
+            for oref in self.cap_caps[ref]:
+                other = self.caps[oref]
+                if not self._cap_floors_ok(other):
+                    continue
+                effs = self._pair_effs(ref, cap, oref, other)
+                if _pad_pair_shortfall(cand, other.pad_rects(),
+                                       self.clearance, effs) <= EPS:
+                    continue
+                mm, src = 0.0, ''
+                for fa in fls:
+                    for fb in other.pad_floors:
+                        m, sc = pair_with_source(fa, fb)
+                        if sc and m > mm:
+                            mm, src = m, sc
+                if src:
+                    rows.append([ref, 'cap ' + oref, round(mm, 6), src])
+        rows.sort(key=lambda r: (-r[2], r[0], r[1]))
+        return rows[:limit]
+
     def _overlap(self, a, b):
-        """Courtyard-clearance shortfall between two rects (0 if clear)."""
+        """Courtyard-clearance shortfall between two rects (0 if clear).
+
+        Deliberately NOT #725-converted: a courtyard is a mechanical/assembly
+        extent, not copper, so charging a netclass or a pad override here would
+        move caps for a reason KiCad's DRC never raises. The cap_static prune
+        that gates it is therefore still exact at the flat scalar."""
         return max(0.0, self.clearance - _rect_gap(a, b))
 
-    def via_penalty(self, cap, x, y, rot, vias=None):
+    def via_penalty(self, cap, x, y, rot, vias=None, ref=None):
         """Sum of foreign-net via penetration depths for a cap placement
         (how far each pad intrudes inside a different-net via's keep-out).
 
         vias defaults to the full board list; callers with a ref pass the
         per-cap pruned list (self.cap_vias[ref]), which is exact -- a via that
-        can penetrate a pad is necessarily within the cap's reach."""
+        can penetrate a pad is necessarily within the cap's reach.
+
+        #725: `ref` keys the per-pair required-clearance memo. Without it (the
+        4-positional test/default path) the flat scalar is used, which is what
+        the whole-board `vias` default is for anyway."""
         vias = self.vias if vias is None else vias
+        effs = None if ref is None else self._via_effs(ref, cap, vias)
         pen = 0.0
-        for (bx0, by0, bx1, by1, net) in cap.pad_rects(x, y, rot):
-            for vx, vy, vnet, keepout in vias:
+        if effs is None:
+            for (bx0, by0, bx1, by1, net) in cap.pad_rects(x, y, rot):
+                for vx, vy, vnet, keepout in vias:
+                    if vnet == net:
+                        continue
+                    d = _point_to_rect_dist(vx, vy, (bx0, by0, bx1, by1))
+                    if d < keepout - EPS:
+                        pen += (keepout - d)
+            return pen
+        # #725 active path: effs[i][j] IS the pair's keep-out (via radius +
+        # required clearance), precomputed -- the tuple's own keepout slot is
+        # the prune over-reach and is not the requirement.
+        for i, (bx0, by0, bx1, by1, net) in enumerate(cap.pad_rects(x, y, rot)):
+            row = effs[i]
+            for j, (vx, vy, vnet, _ko) in enumerate(vias):
                 if vnet == net:
                     continue
+                ko = row[j]
                 d = _point_to_rect_dist(vx, vy, (bx0, by0, bx1, by1))
-                if d < keepout - EPS:
-                    pen += (keepout - d)
+                if d < ko - EPS:
+                    pen += (ko - d)
         return pen
 
     def _via_shortfalls(self, ref, cap, x, y, rot):
@@ -648,10 +1037,23 @@ class _Repair:
         much track graze it relieves elsewhere (zynq_ad9364 R2 onto the
         DDR3_VREF via)."""
         by_net: Dict[int, float] = {}
-        for (bx0, by0, bx1, by1, net) in cap.pad_rects(x, y, rot):
-            for vx, vy, vnet, keepout in self.cap_vias[ref]:
+        vias = self.cap_vias[ref]
+        effs = self._via_effs(ref, cap, vias)
+        if effs is None:
+            for (bx0, by0, bx1, by1, net) in cap.pad_rects(x, y, rot):
+                for vx, vy, vnet, keepout in vias:
+                    if vnet == net:
+                        continue
+                    d = _point_to_rect_dist(vx, vy, (bx0, by0, bx1, by1))
+                    if d < keepout - EPS:
+                        by_net[vnet] = by_net.get(vnet, 0.0) + (keepout - d)
+            return by_net
+        for i, (bx0, by0, bx1, by1, net) in enumerate(cap.pad_rects(x, y, rot)):
+            row = effs[i]
+            for j, (vx, vy, vnet, _ko) in enumerate(vias):
                 if vnet == net:
                     continue
+                keepout = row[j]
                 d = _point_to_rect_dist(vx, vy, (bx0, by0, bx1, by1))
                 if d < keepout - EPS:
                     by_net[vnet] = by_net.get(vnet, 0.0) + (keepout - d)
@@ -670,11 +1072,30 @@ class _Repair:
         scalar baseline). Uses the per-cap pruned, same-side track list."""
         by_net: Dict[int, float] = {}
         segs = self.cap_segs[ref]
-        for (bx0, by0, bx1, by1, net) in cap.pad_rects(x, y, rot):
-            for x1, y1, x2, y2, snet, halfw, side in segs:
+        effs = self._seg_effs(ref, cap)
+        if effs is None:
+            for (bx0, by0, bx1, by1, net) in cap.pad_rects(x, y, rot):
+                for x1, y1, x2, y2, snet, halfw, side in segs:
+                    if snet == net:
+                        continue
+                    # cheap reject: the segment's bbox can't reach the pad rect
+                    if (min(x1, x2) > bx1 + halfw or max(x1, x2) < bx0 - halfw
+                            or min(y1, y2) > by1 + halfw
+                            or max(y1, y2) < by0 - halfw):
+                        continue
+                    d = _seg_to_rect_dist(x1, y1, x2, y2, (bx0, by0, bx1, by1))
+                    if d < halfw - EPS:
+                        by_net[snet] = by_net.get(snet, 0.0) + (halfw - d)
+            return by_net
+        # #725 active path: effs[i][j] IS the pair's keep-out, and the cheap
+        # bbox reject widens with it -- a reject left at the flat half width
+        # would silently drop the pairs this fix exists to charge.
+        for i, (bx0, by0, bx1, by1, net) in enumerate(cap.pad_rects(x, y, rot)):
+            row = effs[i]
+            for j, (x1, y1, x2, y2, snet, _hw, side) in enumerate(segs):
                 if snet == net:
                     continue
-                # cheap reject: the segment's bbox can't reach the pad rect
+                halfw = row[j]
                 if (min(x1, x2) > bx1 + halfw or max(x1, x2) < bx0 - halfw or
                         min(y1, y2) > by1 + halfw or max(y1, y2) < by0 - halfw):
                     continue
@@ -697,15 +1118,30 @@ class _Repair:
         Same-net pads are ignored (a shared via / touching same-net copper is
         fine)."""
         by_net: Dict[int, float] = {}
-        for (bx0, by0, bx1, by1, net) in cap.pad_rects(x, y, rot):
-            for (px0, py0, px1, py1, pnet, pside) in self.cap_foreign_pads[ref]:
+        fpads = self.cap_foreign_pads[ref]
+        effs = self._pad_effs(ref, cap)
+        if effs is None:
+            for (bx0, by0, bx1, by1, net) in cap.pad_rects(x, y, rot):
+                for (px0, py0, px1, py1, pnet, pside) in fpads:
+                    if pnet == net:
+                        continue
+                    if pside is not None and pside != cap.side:
+                        continue  # SMD pad on the other side
+                    gap = _rect_gap((bx0, by0, bx1, by1), (px0, py0, px1, py1))
+                    if gap < self.clearance - EPS:
+                        by_net[pnet] = by_net.get(pnet, 0.0) + (self.clearance - gap)
+            return by_net
+        for i, (bx0, by0, bx1, by1, net) in enumerate(cap.pad_rects(x, y, rot)):
+            row = effs[i]
+            for j, (px0, py0, px1, py1, pnet, pside) in enumerate(fpads):
                 if pnet == net:
                     continue
                 if pside is not None and pside != cap.side:
                     continue  # SMD pad on the other side
+                eff = row[j]
                 gap = _rect_gap((bx0, by0, bx1, by1), (px0, py0, px1, py1))
-                if gap < self.clearance - EPS:
-                    by_net[pnet] = by_net.get(pnet, 0.0) + (self.clearance - gap)
+                if gap < eff - EPS:
+                    by_net[pnet] = by_net.get(pnet, 0.0) + (eff - gap)
         return by_net
 
     def pad_penalty(self, ref, cap, x, y, rot):
@@ -770,14 +1206,22 @@ class _Repair:
             # every pad-pair gap >= the bbox gap; bboxes >= clearance apart
             # means the shortfall is exactly 0 <= base + EPS -- skip the
             # pairwise scan (the dominant cost of the candidate sweep).
+            # #725: the prescreen is a SKIP, so it must widen with the pair's
+            # requirement -- left at the flat scalar it silently drops exactly
+            # the pairs a pad override / netclass / dru rule raises. Bounded by
+            # the two movers' OWN maxima, never a board-wide one: this runs per
+            # candidate pose.
             if cand_bbox is None:
                 cand_bbox = cap.pad_bbox(x, y, rot)
-            if _rect_gap(cand_bbox, other.pad_bbox()) >= self.clearance:
+            screen = self.clearance if self._floors is None else max(
+                self.clearance, cap.max_floor, other.max_floor)
+            if _rect_gap(cand_bbox, other.pad_bbox()) >= screen:
                 continue
             if cand_pads is None:
                 cand_pads = cap.pad_rects(x, y, rot)
             if _pad_pair_shortfall(cand_pads, other.pad_rects(),
-                                   self.clearance) > \
+                                   self.clearance,
+                                   self._pair_effs(ref, cap, other_ref, other)) > \
                     self.base_cap_pad.get(pair, 0.0) + EPS:
                 return True
         return False
@@ -812,7 +1256,7 @@ class _Repair:
         (#130) + same-side track (#278 PAD-SEGMENT) + component pad (#275
         PAD-PAD). Anything positive is a shipped DRC violation, so all three
         are violations to FIX, not just baselines to preserve."""
-        return (self.via_penalty(cap, x, y, rot, self.cap_vias[ref])
+        return (self.via_penalty(cap, x, y, rot, self.cap_vias[ref], ref=ref)
                 + self.seg_penalty(ref, cap, x, y, rot)
                 + self.pad_penalty(ref, cap, x, y, rot))
 
@@ -895,14 +1339,19 @@ def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
     print(f"BGAs: {', '.join(st.bga_refs) or '(none)'}  "
           f"fanout vias: {len(st.vias)}  "
           f"movable near-BGA caps: {len(st.caps)}")
+    # #725: the early returns carry the same key set as the full one, so a
+    # caller reading result['required'] / ['clearance_notes'] does not have to
+    # special-case a no-op board.
     if not st.vias:
         print("No vias on the board - run this AFTER bga_fanout.py.")
         return {'placements': [], 'resolved': [], 'unresolved': [],
-                'bga_refs': st.bga_refs}
+                'bga_refs': st.bga_refs, 'required': [],
+                'clearance_notes': list(st.clearance_notes)}
     if not st.caps:
         print("No movable caps near a BGA - nothing to do.")
         return {'placements': [], 'resolved': [], 'unresolved': [],
-                'bga_refs': st.bga_refs}
+                'bga_refs': st.bga_refs, 'required': [],
+                'clearance_notes': list(st.clearance_notes)}
 
     # Initial violators: any foreign-copper clearance shortfall (via #130,
     # track #278, pad #275) is a shipped DRC violation to fix.
@@ -927,10 +1376,18 @@ def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
                 continue
             rect = (p.global_x - p.size_x / 2, p.global_y - p.size_y / 2,
                     p.global_x + p.size_x / 2, p.global_y + p.size_y / 2)
+            # #725: graded at the pair's REAL requirement, like everything
+            # else. `keepout` is the prune over-reach, so re-form the pair's
+            # keep-out from the via's radius. A locked fiducial's keep-clear
+            # override is exactly the case this warning exists to surface, and
+            # priced flat it under-reported it.
+            pfl = st.pad_floor(p)
             for vx, vy, vnet, keepout in st.vias:
                 if vnet == p.net_id:
                     continue
-                if _point_to_rect_dist(vx, vy, rect) < keepout - EPS:
+                ko = (keepout - st._item_reach(st.via_floor(vnet))
+                      + st.via_required(pfl, vnet))
+                if _point_to_rect_dist(vx, vy, rect) < ko - EPS:
                     locked_hits.append((ref, p.pad_number, vx, vy))
     if locked_hits:
         print(f"WARNING: {len(locked_hits)} foreign via(s) inside LOCKED parts' pad "
@@ -1098,10 +1555,19 @@ def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
           f"{len(unresolved)} unresolved.")
     if unresolved:
         print(f"  Unresolved (need manual attention): {', '.join(sorted(unresolved))}")
+    # #725: disclose what was graded ABOVE the flat --clearance, and why.
+    # Printed from the ENGINE so the CLI and the GUI plugin both inherit it.
+    required = st.required_rows({n.net_id: n.name for n in pcb_data.nets.values()})
+    _clause = format_required_clause({'required': required})
+    if _clause:
+        print(f"  above the {clearance}mm floor: {_clause}")
+    for _note in st.clearance_notes:
+        print(f"  pad clearance: {_note}")
 
     return {'placements': placements, 'resolved': resolved,
             'unresolved': unresolved, 'bga_refs': st.bga_refs,
-            'via_moves': via_moves, 'new_segments': new_segs}
+            'via_moves': via_moves, 'new_segments': new_segs,
+            'required': required, 'clearance_notes': list(st.clearance_notes)}
 
 
 def _point_in_poly(px, py, poly) -> bool:
@@ -1195,57 +1661,109 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
     # missing layer gate rejected every candidate: the connector necessarily
     # starts at the old via position, inside the grazed cap's keep-out, but
     # only the VIA barrel -- not an inner-layer connector -- conflicts there).
+    # #725: every requirement below resolves through st's own resolvers, so the
+    # nudger and the grader cannot disagree. `getattr` throughout -- tests pass
+    # a duck-typed _FakeSt that carries none of this, and must grade flat.
+    _req = getattr(st, 'required', None)
+    _via_req = getattr(st, 'via_required', None)
+    _pad_fl = getattr(st, 'pad_floor', None)
+    _via_fl = getattr(st, 'via_floor', None)
+    _seg_fl = getattr(st, 'seg_floor', None)
+
+    def req(fa, fb):
+        return clearance if _req is None else _req(fa, fb)
+
+    def via_req(pad_floor, via_net):
+        return clearance if _via_req is None else _via_req(pad_floor, via_net)
+
+    def pad_fl(p):
+        return None if _pad_fl is None else _pad_fl(p)
+
+    def via_fl(net):
+        return None if _via_fl is None else _via_fl(net)
+
+    def seg_fl(net, layer):
+        return None if _seg_fl is None else _seg_fl(net, layer)
+
+    def cap_floors_of(cap, rects):
+        """This cap's per-pad floors, index-aligned with `rects` -- or None,
+        which grades flat. Tests drive this function with a duck-typed cap that
+        carries neither the attribute nor a matching length."""
+        pf = getattr(cap, 'pad_floors', None)
+        return pf if (pf is not None and len(pf) == len(rects)) else None
+
+    # `all_cap_rects` is function-local, so it CAN carry the pad's floor.
     all_cap_rects = []
     for ref, cap in st.caps.items():
         fp = pcb_data.footprints.get(ref)
         cl = getattr(fp, 'layer', 'F.Cu') if fp is not None else 'F.Cu'
-        for (bx0, by0, bx1, by1, net) in cap.pad_rects(cap.x, cap.y, cap.rot):
-            all_cap_rects.append((bx0, by0, bx1, by1, net, cl))
+        _rects = cap.pad_rects(cap.x, cap.y, cap.rot)
+        pf = cap_floors_of(cap, _rects)
+        for i, (bx0, by0, bx1, by1, net) in enumerate(_rects):
+            all_cap_rects.append((bx0, by0, bx1, by1, net, cl,
+                                  None if pf is None else pf[i]))
+
+    # Flatten the board's pads ONCE, in pads_by_net iteration order, resolving
+    # each pad's floor and drill capsule here instead of inside the 16-angle x
+    # 12-radius sweep below. Strictly cheaper than the previous per-call walk.
+    board_pads = []
+    for _pads in pcb_data.pads_by_net.values():
+        for p in _pads:
+            if getattr(p, 'component_ref', None) in st.caps:
+                continue  # movable caps handled by the final rects above
+            cap_ = pad_drill_capsule(p) if (p.drill and p.drill > 0) else None
+            board_pads.append((p, pad_fl(p), not _pad_has_no_copper(p), cap_))
 
     def valid_via_pos(v, nx, ny):
         vr = (v.size or 0.5) / 2.0
+        vfl = via_fl(v.net_id)
         # never off the board / into a cutout / inside the edge margin (#370 B3)
         if not edge_ok_point(nx, ny, vr):
             return False
-        for (bx0, by0, bx1, by1, net, _cl) in all_cap_rects:
+        for (bx0, by0, bx1, by1, net, _cl, pfl) in all_cap_rects:
             # via barrel spans all layers: no layer gate here
             if net != v.net_id and _point_to_rect_dist(
-                    nx, ny, (bx0, by0, bx1, by1)) < vr + clearance:
+                    nx, ny, (bx0, by0, bx1, by1)) < vr + via_req(pfl, v.net_id):
                 return False
-        for pads in pcb_data.pads_by_net.values():
-            for p in pads:
-                if getattr(p, 'component_ref', None) in st.caps:
-                    continue  # movable caps handled by final rects above
-                # rotation/shape-aware pad copper distance (#370 B3, #356
-                # class: the axis-aligned size_x/size_y rect under-blocked
-                # rotated pads). NPTH pads carry no copper -- drill-only.
-                if (p.net_id != v.net_id and not _pad_has_no_copper(p)
-                        and point_to_pad_distance(nx, ny, p) < vr + clearance):
+        for p, pfl, has_cu, cap_ in board_pads:
+            # rotation/shape-aware pad copper distance (#370 B3, #356
+            # class: the axis-aligned size_x/size_y rect under-blocked
+            # rotated pads). NPTH pads carry no copper -- drill-only.
+            if (p.net_id != v.net_id and has_cu
+                    and point_to_pad_distance(nx, ny, p) < vr + req(pfl, vfl)):
+                return False
+            if cap_ is not None:
+                # slot/offset-aware drill capsule (net-INDEPENDENT floor, so
+                # deliberately NOT #725-resolved -- see npth_clr above)
+                (c1x, c1y), (c2x, c2y), prad = cap_
+                if _point_to_seg_dist(nx, ny, c1x, c1y, c2x, c2y) < \
+                        (v.drill or 0.3) / 2.0 + prad + H2H_PAD:
                     return False
-                if p.drill and p.drill > 0:
-                    # slot/offset-aware drill capsule (net-INDEPENDENT floor)
-                    (c1x, c1y), (c2x, c2y), prad = pad_drill_capsule(p)
-                    if _point_to_seg_dist(nx, ny, c1x, c1y, c2x, c2y) < \
-                            (v.drill or 0.3) / 2.0 + prad + H2H_PAD:
-                        return False
         for ov in pcb_data.vias:
             if ov is v:
                 continue
             d = math.hypot(nx - ov.x, ny - ov.y)
-            if ov.net_id != v.net_id and d < vr + (ov.size or 0.5) / 2.0 + clearance:
+            if ov.net_id != v.net_id and d < vr + (ov.size or 0.5) / 2.0 + \
+                    req(vfl, via_fl(ov.net_id)):
                 return False
             if d < (v.drill or 0.3) / 2.0 + (ov.drill or 0.3) / 2.0 + H2H_VIA:
                 return False
         for s in pcb_data.segments:
             if s.net_id == v.net_id:
                 continue
-            if _point_to_seg_dist(nx, ny, s.start_x, s.start_y,
-                                  s.end_x, s.end_y) < vr + s.width / 2.0 + clearance:
+            if _point_to_seg_dist(nx, ny, s.start_x, s.start_y, s.end_x, s.end_y) \
+                    < vr + s.width / 2.0 + req(vfl, seg_fl(s.net_id, s.layer)):
                 return False
         return True
 
     def connector_clear(net_id, layer, width, sx, sy, ex, ey):
         hw = width / 2.0
+        # The connector is a TRACK on `layer`, so it resolves like one. Note
+        # this honours netclasses and .kicad_dru LAYER rules, but not #549
+        # track-scoped rules, which live in a channel PadClearanceModel does
+        # not carry (check_drc.read_board_track_clearances); under-blocking a
+        # geometric connector that is separately DRC'd is the safe direction.
+        cfl = seg_fl(net_id, layer)
         # board edge / cutouts + NPTH drill holes at their floor (#370 B3):
         # a connector is drawn geometrically, not routed, so it must gate
         # against Edge.Cuts and copper-less holes itself.
@@ -1254,33 +1772,33 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
         if _seg_foreign_hole_dist(pcb_data, net_id, sx, sy, ex, ey) < \
                 npth_clr + hw - 1e-4:
             return False
-        for (bx0, by0, bx1, by1, net, cl) in all_cap_rects:
+        for (bx0, by0, bx1, by1, net, cl, pfl) in all_cap_rects:
             if cl != layer:
                 continue  # cap pads only exist on the cap's own side
             if net != net_id and _seg_to_rect_dist(
-                    sx, sy, ex, ey, (bx0, by0, bx1, by1)) < hw + clearance:
+                    sx, sy, ex, ey, (bx0, by0, bx1, by1)) < hw + req(pfl, cfl):
                 return False
-        for pads in pcb_data.pads_by_net.values():
-            for p in pads:
-                if getattr(p, 'component_ref', None) in st.caps or p.net_id == net_id:
-                    continue
-                if not _pad_on_layer(p, layer):
-                    continue
-                if _pad_has_no_copper(p):
-                    continue  # NPTH: no copper; the hole check above covers it
-                # rotation-aware pad rect (#370 B3): rotate the segment into
-                # the pad's frame so a tilted pad is tested against its true
-                # rectangle (distance is rotation-invariant).
-                rx1, ry1 = into_pad_frame_point(sx, sy, p)
-                rx2, ry2 = into_pad_frame_point(ex, ey, p)
-                d, _ = segment_to_rect_distance(
-                    rx1, ry1, rx2, ry2, p.global_x, p.global_y,
-                    p.size_x / 2.0, p.size_y / 2.0)
-                if d < hw + clearance:
-                    return False
+        for p, pfl, has_cu, _cap in board_pads:
+            if p.net_id == net_id:
+                continue
+            if not _pad_on_layer(p, layer):
+                continue
+            if not has_cu:
+                continue  # NPTH: no copper; the hole check above covers it
+            # rotation-aware pad rect (#370 B3): rotate the segment into
+            # the pad's frame so a tilted pad is tested against its true
+            # rectangle (distance is rotation-invariant).
+            rx1, ry1 = into_pad_frame_point(sx, sy, p)
+            rx2, ry2 = into_pad_frame_point(ex, ey, p)
+            d, _ = segment_to_rect_distance(
+                rx1, ry1, rx2, ry2, p.global_x, p.global_y,
+                p.size_x / 2.0, p.size_y / 2.0)
+            if d < hw + req(pfl, cfl):
+                return False
         for ov in pcb_data.vias:
             if ov.net_id != net_id and _point_to_seg_dist(
-                    ov.x, ov.y, sx, sy, ex, ey) < (ov.size or 0.5) / 2.0 + hw + clearance:
+                    ov.x, ov.y, sx, sy, ex, ey) < (ov.size or 0.5) / 2.0 + hw \
+                    + req(cfl, via_fl(ov.net_id)):
                 return False
         for s2 in pcb_data.segments:
             if s2.net_id == net_id or s2.layer != layer:
@@ -1292,19 +1810,26 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
                     _point_to_seg_dist(ex, ey, s2.start_x, s2.start_y, s2.end_x, s2.end_y),
                     _point_to_seg_dist(s2.start_x, s2.start_y, sx, sy, ex, ey),
                     _point_to_seg_dist(s2.end_x, s2.end_y, sx, sy, ex, ey))
-            if d < hw + s2.width / 2.0 + clearance:
+            if d < hw + s2.width / 2.0 + req(cfl, seg_fl(s2.net_id, s2.layer)):
                 return False
         return True
 
     for ref in sorted(unresolved):
         cap = st.caps[ref]
         rects = cap.pad_rects(cap.x, cap.y, cap.rot)
+        # #725: this predicate MUST match via_penalty's, which is why both go
+        # through st.via_required. Left at the flat scalar while the grader
+        # resolves the requirement, a cap reported unresolved because of a
+        # raised via would yield an EMPTY offender list -- the pass would print
+        # nothing and report the cap unresolved forever.
+        pfls = cap_floors_of(cap, rects)
         offenders = []
         for v in pcb_data.vias:
             vr = (v.size or 0.5) / 2.0
-            for (bx0, by0, bx1, by1, net) in rects:
+            for i, (bx0, by0, bx1, by1, net) in enumerate(rects):
                 if v.net_id != net and _point_to_rect_dist(
-                        v.x, v.y, (bx0, by0, bx1, by1)) < vr + clearance - EPS:
+                        v.x, v.y, (bx0, by0, bx1, by1)) < vr + via_req(
+                            None if pfls is None else pfls[i], v.net_id) - EPS:
                     offenders.append(v)
                     break
         for v in offenders:
@@ -1380,6 +1905,10 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
                     start_x=old[0], start_y=old[1], end_x=nx, end_y=ny,
                     width=w, layer=layer, net_id=v.net_id))
             v.x, v.y = nx, ny
+            # w2[2]/w2[3] (net and keep-out) are carried through unchanged --
+            # a moved via keeps its requirement. #725: this rebuild gives the
+            # list a NEW identity, which is what makes _Repair's per-cap
+            # required-clearance memos rebuild instead of going stale.
             st.vias = [(nx, ny, w2[2], w2[3]) if (abs(w2[0] - old[0]) < 1e-6 and
                                                   abs(w2[1] - old[1]) < 1e-6) else w2
                        for w2 in st.vias]

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -203,12 +203,20 @@ class _Cap:
                 # (legality._pad_carries_copper, the watchy measurement).
                 # Zero floor, appended unconditionally so the index alignment
                 # the loose filter buys is preserved.
-                fl = (model.pad_floor(p) if _pad_carries_copper(p)
-                      else PadFloor(0.0, 0.0, None))
+                # A pad that carries no copper is graded FLAT, whole stop --
+                # not merely stripped of its own override. check_drc does not
+                # grade such a pad at all, so letting the PARTNER's netclass
+                # through pair() would charge a keep-out that does not exist,
+                # which is the same defect as the off-layer phantom below.
+                # The empty layer set is the marker the eff builders key on;
+                # a real copper pad always resolves at least one layer.
+                carries = _pad_carries_copper(p)
+                fl = model.pad_floor(p) if carries else PadFloor(0.0, 0.0, None)
                 self.pad_floors.append(fl)
                 from check_drc import pad_copper_layers
                 self.pad_layers.append(
-                    frozenset(pad_copper_layers(p, model.board_copper)))
+                    frozenset(pad_copper_layers(p, model.board_copper))
+                    if carries else frozenset())
                 mf = model.max_floor(fl)
                 if mf > self.max_floor:
                     self.max_floor = mf
@@ -469,7 +477,8 @@ class _Repair:
             t = (s.start_x, s.start_y, s.end_x, s.end_y, s.net_id,
                  s.width / 2.0 + self._item_reach(fl), side)
             self.segments.append(t)
-            self._seg_layer_by_id[id(t)] = s.layer
+            if self._floors is not None:
+                self._seg_layer_by_id[id(t)] = s.layer
             if fl is not None:
                 self._seg_floor_by_id[id(t)] = fl
 
@@ -901,6 +910,21 @@ class _Repair:
             return self.clearance
         return self._floors.pair(fa, fb)
 
+    def _cap_pad_layers(self, cap):
+        """This cap's per-pad copper layer sets, or None when unavailable (a
+        duck-typed cap, or a board that declares no copper layers at all -- in
+        which case NO pair may be scoped by layer, or every one of them would
+        fall back to the flat scalar and under-block)."""
+        pl = getattr(cap, 'pad_layers', None)
+        if pl is None or len(pl) != len(getattr(cap, 'pad_floors', ())):
+            return None
+        return pl if self._all_cu else None
+
+    @staticmethod
+    def _flat_pad(cap_layers, i):
+        """True when cap pad `i` carries no copper and must be graded flat."""
+        return cap_layers is not None and not cap_layers[i]
+
     def _cap_floors_ok(self, cap):
         """True when this cap carries a usable, index-aligned floor list. A
         _Cap built without the model (or by a test) grades flat."""
@@ -918,8 +942,10 @@ class _Repair:
         if rec is not None and rec[0] is src:
             return rec[1]
         by_id = self._fp_floor_by_id
-        rows = [[self._pair_or_flat(fa, by_id.get(id(t))) for t in src]
-                for fa in cap.pad_floors]
+        cl = self._cap_pad_layers(cap)
+        rows = [[self.clearance] * len(src) if self._flat_pad(cl, i)
+                else [self._pair_or_flat(fa, by_id.get(id(t))) for t in src]
+                for i, fa in enumerate(cap.pad_floors)]
         self._cap_pad_eff[ref] = (src, rows)
         return rows
 
@@ -944,9 +970,7 @@ class _Repair:
         # change would move caps for a non-violation. Charging it flat leaves
         # the pre-existing phantom exactly as it was; removing it altogether is
         # a separate fix to the side collapse, filed rather than folded in.
-        cap_layers = getattr(cap, 'pad_layers', None)
-        if cap_layers is not None and len(cap_layers) != len(cap.pad_floors):
-            cap_layers = None      # a duck-typed cap; grade flat
+        cap_layers = self._cap_pad_layers(cap)
         seg_layers = [self._seg_layer_by_id.get(id(t)) for t in src]
 
         def eff(fa, mine, j):
@@ -977,13 +1001,19 @@ class _Repair:
         # convention, and re-deriving would mis-price it silently. Absent ->
         # graded flat, i.e. v[3] is used as-is.
         by_id = self._via_radius_by_id
+        cl = self._cap_pad_layers(cap)
         rows = []
-        for fa in cap.pad_floors:
+        for i, fa in enumerate(cap.pad_floors):
+            flat = self._flat_pad(cl, i)
             row = []
             for v in vias:
                 rec = by_id.get(id(v))
-                row.append(v[3] if rec is None
-                           else rec[1] + self.via_required(fa, v[2]))
+                if rec is None:
+                    row.append(v[3])
+                elif flat:
+                    row.append(rec[1] + self.clearance)
+                else:
+                    row.append(rec[1] + self.via_required(fa, v[2]))
             rows.append(row)
         self._cap_via_eff[ref] = (vias, rows)
         return rows
@@ -1004,15 +1034,19 @@ class _Repair:
                                  or (rows and len(rows[0]) != len(other.pad_floors))):
             rows = None
         if rows is None:
-            rows = [[self._pair_or_flat(fa, fb) for fb in other.pad_floors]
-                    for fa in cap.pad_floors]
+            mine, theirs = self._cap_pad_layers(cap), self._cap_pad_layers(other)
+            rows = [[self.clearance
+                     if (self._flat_pad(mine, i) or self._flat_pad(theirs, j))
+                     else self._pair_or_flat(fa, fb)
+                     for j, fb in enumerate(other.pad_floors)]
+                    for i, fa in enumerate(cap.pad_floors)]
             self._cap_pair_eff[key] = rows
         return rows
 
     def required_rows(self, net_names=None, limit=200):
         """Rows `[cap_ref, '<kind> <partner>', mm, source]` for every pair this
         pass actually CHARGED at a requirement above the flat scalar, at the
-        caps' current poses.
+        SEED pose or the final one (see `both` below for why both).
 
         Same 4-column shape as legality.grade_pad_legality's 'required', so
         legality.format_required_clause renders it unchanged. `[]` when inert.

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -425,15 +425,23 @@ class _Repair:
         # The RADIUS, keyed on the tuple's identity. _via_effs has to strip the
         # over-reach back off element 3, and deriving the radius arithmetically
         # would silently mis-price a tuple a test assigned wholesale with a
-        # different keep-out convention. Absent from this map -> graded flat,
-        # which is the same fallback _pad_effs and _seg_effs already take.
-        self._via_radius_by_id: Dict[int, float] = {}
+        # different keep-out convention. Absent from this map -> graded at the
+        # tuple's own keep-out slot verbatim, i.e. exactly as injected.
+        #
+        # The VALUE holds the tuple as well as the radius, so the map itself
+        # keeps every registered tuple alive. Unlike the pad/segment floor maps
+        # -- which are filled only in __init__, where self.foreign_pads and
+        # self.segments hold their tuples -- this one gains entries later, when
+        # nudge_vias_for_unresolved relocates a via. A tuple that died while its
+        # id entry lived would hand a recycled id ANOTHER via's radius,
+        # silently.
+        self._via_radius_by_id: Dict[int, Tuple[tuple, float]] = {}
         for v in pcb_data.vias:
             size = v.size if v.size and v.size > 0 else default_via_size
             t = (v.x, v.y, v.net_id,
                  size / 2.0 + self._item_reach(self._via_floor_for(v.net_id)))
             self.vias.append(t)
-            self._via_radius_by_id[id(t)] = size / 2.0
+            self._via_radius_by_id[id(t)] = (t, size / 2.0)
 
         # --- avoidance: foreign-net tracks on the cap's own side ---
         # Fanout escapes can land on the bottom (cap) side; attraction could
@@ -973,8 +981,9 @@ class _Repair:
         for fa in cap.pad_floors:
             row = []
             for v in vias:
-                r = by_id.get(id(v))
-                row.append(v[3] if r is None else r + self.via_required(fa, v[2]))
+                rec = by_id.get(id(v))
+                row.append(v[3] if rec is None
+                           else rec[1] + self.via_required(fa, v[2]))
             rows.append(row)
         self._cap_via_eff[ref] = (vias, rows)
         return rows
@@ -2044,9 +2053,21 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
             # a moved via keeps its requirement. #725: this rebuild gives the
             # list a NEW identity, which is what makes _Repair's per-cap
             # required-clearance memos rebuild instead of going stale.
-            st.vias = [(nx, ny, w2[2], w2[3]) if (abs(w2[0] - old[0]) < 1e-6 and
-                                                  abs(w2[1] - old[1]) < 1e-6) else w2
-                       for w2 in st.vias]
+            _radii = getattr(st, '_via_radius_by_id', None)
+            _rebuilt = []
+            for w2 in st.vias:
+                if (abs(w2[0] - old[0]) < 1e-6 and abs(w2[1] - old[1]) < 1e-6):
+                    moved = (nx, ny, w2[2], w2[3])
+                    # A relocated via is a NEW tuple, so it would drop out of
+                    # the radius map and be graded at its keep-out slot -- the
+                    # prune OVER-reach -- instead of the pair's requirement.
+                    # Carry the radius across; the via did not change size.
+                    if _radii is not None and id(w2) in _radii:
+                        _radii[id(moved)] = (moved, _radii[id(w2)][1])
+                    _rebuilt.append(moved)
+                else:
+                    _rebuilt.append(w2)
+            st.vias = _rebuilt
             via_moves.append((old[0], old[1],
                               {'x': nx, 'y': ny, 'size': v.size, 'drill': v.drill,
                                'layers': v.layers, 'net_id': v.net_id}))

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -200,10 +200,14 @@ def _via_radius(via, default_size=_UNREADABLE_VIA_SIZE) -> float:
 def _via_drill_radius(via, default_drill=_UNREADABLE_VIA_DRILL) -> float:
     """The DRILL radius of a via, in mm -- the ONE implementation of the rule.
 
-    #750: this was spelled `(v.drill or 0.3) / 2.0` at three sites inside
-    valid_via_pos, while the copper radius on the SAME two lines already went
-    through _via_radius. Same shape as that function, deliberately, including
-    the two things that are easy to read as accidents:
+    #750: this was spelled `(x.drill or 0.3) / 2.0` at three sites inside
+    valid_via_pos -- twice on `v` and once on `ov` -- while the copper radius
+    in those same two gate BLOCKS already went through _via_radius. (Not on
+    the same LINES: neither drill line carried a copper term. The sharper
+    statement is that of the two radii summed at the capsule gate, `prad` is
+    measured from the board and this one was invented.) Same shape as
+    _via_radius, deliberately, including the two things that read as
+    accidents:
 
     `getattr`, because the nudger is public and its harnesses pass duck-typed
     via-likes. This DOES widen what the pass tolerates -- the old expression
@@ -216,9 +220,17 @@ def _via_drill_radius(via, default_drill=_UNREADABLE_VIA_DRILL) -> float:
     value, so the drill term goes NEGATIVE and weakens the gate it is summed
     into. With both drills negative the whole hole-to-hole threshold turns
     negative and the gate can never fire at all -- measured, the pass then
-    parks two 0.5mm barrels 0.05mm apart. Both parse paths admit it: the via
-    regex drill class carries a `-` and the float() that follows checks no
-    sign.
+    parks two 0.5mm barrels 0.05mm apart. BOTH parse paths admit a negative,
+    and for two different reasons worth stating separately: the text parser's
+    via-regex drill class carries a `-` and the `float()` after it checks no
+    sign, while build_pcb_data_from_board's `to_mm(track.GetDrill())` applies
+    no sign check either (verified on KiCad 10.0.0, which returns -0.3mm for
+    such a via rather than rejecting it).
+
+    NaN is the one remaining hole, and it is NOT closed here because it is
+    not this guard's question: both spellings propagate it, every `<`
+    against it is False, and the gate silently stops firing. Same before,
+    same after, and the same in _via_radius.
     """
     d = getattr(via, 'drill', None)
     if not d or d <= 0:
@@ -2793,10 +2805,26 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
 
     # #750: every OTHER via's drill radius, resolved ONCE, for the same reason
     # the pads above are flattened here -- the hole-to-hole gate below runs
-    # inside the 16-angle x 12-radius sweep, so resolving per candidate would
-    # cost one call per via per CANDIDATE (383 of them on routed_output).
-    # Safe to hoist: the sweep does not mutate pcb_data.vias. The nudger
-    # rebuilds st.vias when it commits a move, which is a different list.
+    # inside the candidate sweep (16 angles x up to 12 radii), so resolving
+    # there costs one call per via per candidate. Measured on
+    # orangecrab_ext_pll (136 vias, the one tracked board that actually nudges
+    # one): 6336 valid_via_pos calls, so this replaces ~862k resolutions
+    # with 136.
+    #
+    # WHAT MAKES THE HOIST SAFE is narrower than "nothing mutates
+    # pcb_data.vias", and the wider claim is the one that invites the bug:
+    # the nudger relocates vias IN PLACE (`v.x, v.y = nx, ny` below) and
+    # processes caps one after another, so a via's COORDINATES do change
+    # between iterations. This tuple caches only the DRILL RADIUS, which no
+    # path writes, and the gate still reads `ov.x`/`ov.y` live. Folding the
+    # coordinates in here -- the obvious tidy-up, since they are right there
+    # -- is a real defect: measured on a two-cap rig, the second via lands at
+    # (5.1061, 6.1061) instead of (5.0500, 6.0000).
+    #
+    # `via_rad(ov)` on the copper line below is deliberately NOT hoisted with
+    # it: that resolver takes the operator's --default-via-size through `st`,
+    # so caching it here would put a second copy of a knob-dependent answer
+    # beside the one _Repair already owns -- the shape #732 removed.
     board_via_drills = [(ov, _via_drill_radius(ov)) for ov in pcb_data.vias]
 
     def valid_via_pos(v, nx, ny):

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -189,9 +189,10 @@ class _Cap:
         # netclass, a .kicad_dru rule or a pad override exists. Gated on the
         # model, as pad_floors legitimately is, this would be inert on exactly
         # the boards carrying the most phantom: rp2350 declares none of the
-        # three, is 6 copper layers, and 2342 of its 4331 pruned pad x track
+        # three, is 6 copper layers, and 2342 of its 4468 pruned pad x track
         # pairs are off-layer, carrying 4.6685mm of phantom graze against
-        # 0.0142mm of real. `board_copper` falls back to the model's copy only
+        # 0.0142mm of real. (Both figures count same-net pairs; excluding them
+        # it is 2238 of 4331. Mixing the two conventions is easy and wrong.) `board_copper` falls back to the model's copy only
         # so a caller passing a model and nothing else still resolves layers.
         _cu = list(board_copper if board_copper is not None
                    else (getattr(model, 'board_copper', None) or ()))
@@ -406,7 +407,35 @@ class _Repair:
         # intersecting with all-copper reproduces that exactly (blind vias
         # included). Never None here -- PadClearanceModel.pair does
         # `fb.layers or ()`, and an EMPTY shared set discards every dru rule.
-        self._all_cu = frozenset(pcb_data.board_info.copper_layers or ())
+        # #731: resolved through the SAME three-level fallback check_drc's
+        # run_drc uses (check_drc.py: filter to .Cu -> the layers segments
+        # actually sit on -> ['F.Cu','B.Cu']), because this set is what decides
+        # whether layer scoping is on at all. A board whose `(layers ...)`
+        # stanza yields no copper -- kicad_parser's regex has produced that in
+        # the field, see its `In1(GND).Cu` note -- would otherwise switch
+        # scoping off and fall back to the 'F'/'B' side collapse. That is NOT
+        # the safe direction it looks like: check_drc still expands a `*.Cu`
+        # pad over the segment-derived layers and grades it, while the side
+        # collapse DROPS every B.Cu and inner track a through-hole cap pad
+        # shares copper with -- an UNDER-block, and the very mirror bug #731
+        # exists to fix. Measured on rp2350 with the copper list cleared and
+        # cap pads made through-hole: 280 pairs check_drc grades that the
+        # side-collapse fallback ignores, byte-identical to the pre-#731 count.
+        # sorted(), not list(set(...)): string hashing is randomized per
+        # process and this list feeds pad-layer expansion (the same reason
+        # check_drc sorts it).
+        _cu = [l for l in (pcb_data.board_info.copper_layers or [])
+               if str(l).endswith('.Cu')]
+        if not _cu:
+            _cu = sorted({s.layer for s in pcb_data.segments
+                          if (s.layer or '').endswith('.Cu')})
+        if not _cu:
+            _cu = ['F.Cu', 'B.Cu']
+        self._all_cu = frozenset(_cu)
+        # The ORDERED list is what pad-layer expansion consumes; `_all_cu` is
+        # the membership test. Keeping both means `*.Cu` never resolves through
+        # a set whose iteration order varies run to run.
+        self._all_cu_ordered = list(_cu)
         self._via_floor: Dict[int, PadFloor] = {}
         self._seg_floor: Dict[Tuple[int, str], PadFloor] = {}
         # #617: KiCad's copper-to-hole rule is the BOARD's `min_hole_clearance`
@@ -577,7 +606,7 @@ class _Repair:
             is_cap = (ref.startswith(self._cap_prefixes) and n_copper <= 2
                       and ref not in locked)
             if is_cap:
-                cap = _Cap(fp, lb, self._floors, self._all_cu)
+                cap = _Cap(fp, lb, self._floors, self._all_cu_ordered)
                 if self._near_any(cap.rect(), bga_bboxes, near_margin):
                     self.caps[ref] = cap
                     continue
@@ -728,11 +757,17 @@ class _Repair:
             # per-pad half is applied in _seg_effs, and matters only for a cap
             # whose pads differ (an SMD pad beside a through-hole one).
             #
-            # When scoping is off, fall back to the OLD side collapse rather
-            # than keeping everything: check_drc still layer-scopes such a
-            # board (its routing_layers falls back to the segment-derived set,
-            # then to ['F.Cu','B.Cu']), so the placer must stay on the
-            # over-block side, not stop filtering altogether.
+            # The `_union is None` arm is a fallback for a cap that offers no
+            # copper pad at all -- cap detection admits n_copper == 0 (a
+            # paste-only C-prefixed part). Such a cap has an empty pad_rects,
+            # so NOTHING it keeps is ever graded and the arm cannot change an
+            # outcome; it keeps the old side filter purely so the pruned list
+            # stays the size it always was. It is NOT reachable for an empty
+            # copper list any more: `_all_cu` above resolves through
+            # check_drc's own three-level fallback and is never empty, which
+            # is deliberate -- falling back to the side collapse there would
+            # DROP the B.Cu and inner tracks a through-hole cap pad shares
+            # copper with, an under-block (measured: 280 pairs on rp2350).
             _pl, _union = self._cap_seg_scope(cap)
             for seg in self.segments:
                 layer = seg[6]
@@ -1000,8 +1035,16 @@ class _Repair:
         pl = self._cap_pad_layers(cap)
         if not pl:
             return None, None
-        u = frozenset().union(*pl)
-        return (pl, u) if u else (None, None)
+        # An EMPTY union means every pad of this cap is copper-LESS (an NPTH
+        # keep-out). It must NOT collapse to "scoping off" (#731 review): that
+        # switched the guard off for the TRACK channel alone, so `_flat_pad`
+        # read False and those pads were charged at the partner's netclass --
+        # reinstating, in one channel, exactly the phantom 4bbfa4de removed
+        # from every other. Measured on a staged orangecrab with R17's pads set
+        # to np_thru_hole at a Default class of 0.4: 52 track cells charged at
+        # 0.4 while the pad channel correctly charged the flat 0.1. check_drc
+        # grades none of them -- it skips a copper-less pad outright.
+        return pl, frozenset().union(*pl)
 
     def _seg_shares(self, layer, mine):
         """True when a track on `layer` can touch a cap pad whose copper layer
@@ -1090,10 +1133,12 @@ class _Repair:
                     # resolver OUT of the inert path entirely -- _pair_or_flat
                     # is not called, so an inert board cannot start consulting
                     # a model, and an injected tuple grades exactly as
-                    # injected. (The arithmetic round-trip happens to be
-                    # float-exact on every cell measured -- 0 of 1063 on
-                    # rp2350 -- so this is about the call, not about the
-                    # rounding.)
+                    # injected. NB this is about the CALL, not the
+                    # rounding: the arithmetic round-trip turns out to be
+                    # float-exact everywhere measured (0 of rp2350's 1063
+                    # segment round-trips DIFFER, and 0 of orangecrab's 618),
+                    # which is precisely why an equality assertion cannot tell
+                    # the two forms apart and the test spies the call instead.
                     row.append(t[5])
                 elif flat_pad:
                     row.append(halves[j] + self.clearance)
@@ -1401,8 +1446,10 @@ class _Repair:
         segs = self.cap_segs[ref]
         effs = self._seg_effs(ref, cap)
         if effs is None:
-            # Duck-typed cap only (#731): a real _Cap always offers pads, so it
-            # always gets a matrix. There is no layer to gate on here, and an
+            # No matrix: a duck-typed cap, or a real _Cap with no copper pad
+            # at all (cap detection admits n_copper == 0, e.g. a paste-only
+            # C-prefixed part -- whose pad_rects is empty, so this loop does
+            # nothing either way). There is no layer to gate on here, and an
             # injected tuple grades exactly as injected.
             for (bx0, by0, bx1, by1, net) in cap.pad_rects(x, y, rot):
                 for x1, y1, x2, y2, snet, halfw, _layer in segs:

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -2076,24 +2076,43 @@ def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
     Run AFTER bga_fanout.py.
 
     Returns a dict with 'placements' (list of {reference,new_x,new_y,
-    new_rotation} for moved caps), 'resolved', 'unresolved', 'bga_refs',
-    'via_moves', 'new_segments', 'required' and 'clearance_notes'.
+    new_rotation} for moved caps), 'resolved', 'unresolved', 'via_resolved',
+    'regrazed', 'bga_refs', 'via_moves', 'new_segments', 'required' and
+    'clearance_notes'.
 
     'resolved' and 'unresolved' are graded together, from ONE board state, at
     the very END of the pass (#746) -- so they are disjoint, and 'resolved'
     credits the via-nudge for a cap only the nudge could free. Read them as:
 
       resolved     was grazing at the SEED and is clean now. A subset of the
-                   initial violators, so len(resolved) <= the V printed below.
+                   initial violators, so len(resolved) is at most the
+                   denominator of the "resolved R/V" count printed below.
       unresolved   is grazing NOW, whatever it was at the seed. NOT a subset
                    of the initial violators: copper this pass itself drew can
                    put a cap here that started clean.
       via_resolved the caps in 'resolved' that the cap-move descent could not
                    clean and the via-nudge did -- the last resort's credit,
                    which before #746 landed in neither list.
-      regrazed     the caps the descent DID clean and a connector this same
-                   pass then drew grazes. They are in 'unresolved' and not in
-                   'resolved'; this key names the cause, which is us.
+      regrazed     the caps that were CLEAN before the nudge and are grazing
+                   after it: this pass broke them. Keyed on the transition,
+                   NOT on membership of the seed violators -- a cap that was
+                   never broken at all is the case the 'unresolved' line above
+                   exists to describe, and it must not be the one case with no
+                   cause named. A subset of 'unresolved', disjoint from
+                   'resolved'.
+
+    Two things to know before treating 'regrazed' as a shipped DRC violation.
+    It is graded by THIS module, which deliberately over-blocks a track on a
+    layer the board never declared (see test_736's
+    TestTheUnknownLayerOverBlockIsDELIBERATE), so check_drc can grade the same
+    pair clean -- 'unresolved' has had that property since #736; what is new
+    is a line asserting a CAUSE, which can send an operator hunting a phantom.
+    And the cause it asserts is connector copper rather than the relocated via
+    because valid_via_pos's cap gate is strictly stronger than via_penalty's:
+    same rects, same radius, same resolver, both over post-descent poses, and
+    no layer gate on either -- so a landing that would newly graze a cap is
+    refused before it happens. The set difference below does not re-check
+    that, which is why it is written down here.
 
     The two early returns below carry neither 'via_resolved' nor 'regrazed',
     exactly as they carry no 'via_moves' / 'new_segments' -- see the note there.
@@ -2461,15 +2480,23 @@ def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
             # both lists, and a cap the SWEEP cleaned that a connector then
             # grazes now leaves `resolved` instead of sitting in both.
             #
-            # The two deltas are taken against `swept` -- the pre-nudge credit
-            # -- and NOT recomputed from a penalty, because "who fixed it" is
-            # a fact about the transition and not about either end state. Set
-            # semantics on lists: `st.caps` has one entry per ref, so `swept`
-            # and `resolved` carry no duplicates and `in` is exact.
+            # Both deltas are taken against the PRE-NUDGE lists and not
+            # recomputed from a penalty, because "who fixed it" and "who broke
+            # it" are facts about the transition, not about either end state.
+            # Set semantics on lists: `st.caps` has one entry per ref, so no
+            # list here carries duplicates and `in` is exact.
+            #
+            # `regrazed` keys on `was_grazing`, NOT on `swept`: a review of the
+            # first version caught that spelling it `[r for r in swept if r not
+            # in resolved]` can only ever name a cap that was ALSO a seed
+            # violator -- so a cap that started perfectly clean and was broken
+            # by this pass's own connector was the one case that got no cause
+            # named, which is exactly the case the docstring above says exists.
             swept = resolved
+            was_grazing = set(unresolved)
             resolved, unresolved = _grade()
             via_resolved = [r for r in resolved if r not in swept]
-            regrazed = [r for r in swept if r not in resolved]
+            regrazed = [r for r in unresolved if r not in was_grazing]
 
     # #746: the credit clause says WHO freed the cap, because `resolved` now
     # spans both mechanisms and a bare count cannot distinguish them. Both

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -2402,48 +2402,67 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
         if not edge_ok_point(nx, ny, vr):
             return False
         # #737: the relocated via's COPPER against copper-less (NPTH) holes.
-        # This function had no such test at all. Its only drilled-pad gate is
-        # the DRILL-to-drill one below, which measures the DRILL, so it covered
-        # the annular ring only while
+        # This function had no such test. Its only drilled-pad gate is the
+        # DRILL-to-drill one below, which measures the DRILL, so it covered the
+        # annular ring only while
         #
-        #     ring = (size - drill) / 2 <= H2H_PAD - npth_clr
+        #     ring = (size - drill) / 2 <= H2H_PAD - clearance
         #
-        # -- 0.25 at the fab floor, but only 0.20 at the shipped --clearance
-        # 0.25, and 0 at clearance >= 0.45. Past that the pass parked ring
-        # copper inside a mounting hole's keep-out, and this pass WRITES the
-        # via (placement/writer.py, and the plugin's pcbnew mirror). Measured
-        # on a rig at --clearance 0.1: a 1.4/0.3 via relocated to 0.05mm of
-        # copper-to-hole-wall gap, which check_drc reports as a via-hole
-        # violation of exactly that.
+        # -- 0.20 at the shipped --clearance 0.25, and 0 at clearance >= 0.45.
+        # Past that the pass parked ring copper inside a mounting hole's
+        # keep-out, and this pass WRITES the via (placement/writer.py, and the
+        # plugin's pcbnew mirror). Measured at --clearance 0.25: a 1.4/0.3 via
+        # relocated to 0.150mm of copper-to-hole-wall gap, which check_drc's
+        # own via arm of this rule reports as `via-hole ... 0.100mm`.
         #
-        # Same helper, same floor, same own-net exemption and the same 1e-4 as
-        # connector_clear's gate below, so the two sibling validators cannot
-        # disagree about which holes exist or what one costs -- and the gate
-        # order in the two now reads alike (edge, hole, cap rects, board pads,
-        # vias, segments). `board_pads` was the cheaper source and is the wrong
-        # one: it drops the pads of movable caps, which the helper keeps. That
-        # buys AGREEMENT between the siblings, not truth -- both read pre-move
-        # pad coordinates, so neither is right about a cap already relocated.
+        # THE FLOOR IS `clearance`, NOT `npth_clr` -- deliberately NOT the
+        # sibling's, and that asymmetry is the point rather than an oversight.
+        # `npth_clr` is `max(clearance, NPTH_TO_TRACK_CLEARANCE)`: a routing
+        # policy for TRACKS, which is what connector_clear gates. check_drc
+        # grades a VIA against a plain NPTH hole at `clearance`
+        # (`kicad_req = req_clr if req_clr > npth_clr else clearance`), and
+        # says why: charging a via the track floor "invents items kicad-cli
+        # never reports" (crkbd, 7 phantoms). obstacle_map stamps the same
+        # asymmetry -- a plain NPTH is a track keep-out, not a via-copper one.
+        #
+        # Charging `npth_clr` here was measured to COST THE REPAIR rather than
+        # merely cost search room: at --clearance 0.1 it refuses a landing
+        # 0.150mm off the hole wall that check_drc grades CLEAN, and the cap
+        # then keeps the #130 pad-via graze this pass exists to remove. That is
+        # exactly the failure obstacle_map.resolve_hole_clearance names for
+        # this function by name -- an all-or-nothing repair whose one clearing
+        # candidate must not be refused -- and the same balance #617 struck for
+        # the connector gate. At --clearance >= 0.20 the two floors are equal,
+        # so this only ever differs below the fab floor; the CLI's own --help
+        # example is --clearance 0.1, and the GUI control's minimum is 0.05.
+        #
+        # Same helper, same own-net exemption and the same 1e-4 as
+        # connector_clear's gate below, so the two cannot disagree about which
+        # holes EXIST -- only about what one costs a track versus a via. The
+        # gate order now reads alike in both (edge, hole, cap rects, board
+        # pads, vias, segments). `board_pads` was the cheaper source and the
+        # wrong one: it drops the pads of movable caps, which the helper keeps.
+        # That buys AGREEMENT between the siblings rather than truth -- both
+        # read pre-move pad coordinates, so neither is right about a cap this
+        # pass has already relocated, and `all_cap_rects` above is post-move
+        # while this hole set is pre-move.
+        #
         # A degenerate segment is the point case: _seg_capsule_axis_dist guards
         # L2 == 0 and its crossing test is strict, so a zero-length segment
         # cannot report a spurious crossing.
         #
-        # The drill test below stays net-INDEPENDENT and keeps its own floor:
+        # The drill test below keeps its own floor and its net-independence:
         # drill-to-drill is a machine constraint, this is an etch constraint,
-        # and check_drc's via-hole arm makes the same own-net exemption
-        # (check_drc.py, `if via.net_id == hnet: continue`).
+        # and check_drc's via arm makes the same own-net exemption.
         #
         # KNOWN GAP, deliberately not closed here, exactly as at the cap
-        # keep-out site above: neither this gate nor the sibling honours the
-        # hole pad's OWN `local_clearance`, which check_drc does honour, so
-        # both under-block by `lc - npth_clr` on such a pad. That is #730 --
-        # a wrong VALUE, where this is a missing GATE -- and closing it here
-        # would move a number #730 needs to move in one place.
-        #
-        # NOT a reversal of #617. #617 measured RAISING this pass's hole floor
-        # to a board's DECLARED min_hole_clearance and refused it; the floor
-        # here is still the flat npth_clr, deliberately NOT st.npth_floor.
-        if _seg_foreign_hole_dist(pcb_data, v.net_id, nx, ny, nx, ny) <                 npth_clr + vr - 1e-4:
+        # keep-out site above: this does not honour the hole pad's OWN
+        # `local_clearance`, which check_drc does honour, so it under-blocks by
+        # `lc - clearance` on such a pad. That is #730 -- a wrong VALUE where
+        # this was a missing GATE -- and closing it here would move a number
+        # #730 needs to move in one place.
+        if _seg_foreign_hole_dist(pcb_data, v.net_id, nx, ny, nx, ny) < \
+                clearance + vr - 1e-4:
             return False
         for (bx0, by0, bx1, by1, net, _cl, pfl) in all_cap_rects:
             # via barrel spans all layers: no layer gate here

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -841,10 +841,17 @@ class _Repair:
         # but on the one board that matters it is active anyway and still gives
         # the hole nothing: measured on ulx3s, BAT1's two SMD pads carry
         # lc 0.700 so `model.active` is True, while AUDIO1's two NPTH holes get
-        # no floor at all, because `pad_floor` is built for copper pads only
-        # and `_fp_floor_by_id` maps only copper-pad tuples -- so the NPTH
-        # tuple still resolves through `_pair_or_flat(fa, None)` to the flat
-        # scalar. The read has to be off the pad.
+        # no floor at all.
+        #
+        # And the REASON is not the one it looks like, which is worth stating
+        # because the plausible version is wrong. `pad_floor` is NOT gated on
+        # copper: called on that NPTH pad it hands back
+        # `PadFloor(ncl=0.0, lc=0.4, layers=None)` -- measured. What drops the
+        # override is the filing below: an NPTH entry gets floor `None`, and
+        # `_fp_floor_by_id` maps only tuples that carry one, so the tuple
+        # resolves through `_pair_or_flat(fa, None)` to the flat scalar and
+        # `pad_floor` is never consulted for it at all. The read has to be off
+        # the pad.
         # NB: self.foreign_pads (and self.segments) are read nowhere after
         # __init__ -- the pruned per-cap lists are what the sweep uses. They
         # must NOT be deleted as dead: the id-keyed floor maps below depend on
@@ -3145,12 +3152,17 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
         # the checker wants 0.100, this charges 0.100). Only an override ABOVE
         # `npth_clr` outranks it, and that is what `override_holes` carries.
         #
-        # Which is why the obvious `max(clearance, lc)` here is wrong in BOTH
-        # directions: at clearance 0.10 / lc 0.15 it over-blocks by 0.05 and
-        # invents a refusal kicad-cli never reports -- the crkbd phantom class
-        # the block above names. Splitting the step across two gates rather
-        # than folding it into one expression is what keeps this fix
-        # RAISE-ONLY and byte-identical on every board declaring no override.
+        # Which is why the obvious `max(clearance, lc)` here is wrong -- in ONE
+        # direction, and it is the direction that costs a repair. Against the
+        # step it can only ever charge MORE or the same: for `lc > npth_clr`
+        # the two agree, and for `lc <= npth_clr` the checker charges
+        # `clearance` while the max charges `lc`. At clearance 0.10 / lc 0.15
+        # that is an over-block of 0.05 and a refusal kicad-cli never reports
+        # -- the same invented-refusal class the crkbd phantoms belong to,
+        # though there the trigger was the fab floor and not an override.
+        # Splitting the step across two gates rather than folding it into one
+        # expression is what keeps this fix RAISE-ONLY and byte-identical on
+        # every board declaring no override.
         if _seg_foreign_hole_dist(pcb_data, v.net_id, nx, ny, nx, ny) < \
                 clearance + vr - 1e-4:
             return False

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -74,6 +74,32 @@ _OFF_LAYER = -1.0e9
 # not stub endpoint offset) because the naive version shows nothing.
 _UNREADABLE_VIA_SIZE = 0.5  # mm
 
+# The DRILL to assume for a via whose hole the board does not carry -- a literal
+# `(drill 0)` token, or a padstack whose pcbnew GetDrill() came back 0. This is
+# the value valid_via_pos hard-coded at three sites before #750 named it, so
+# nothing moves.
+#
+# Module-private for CAP_EDGE_CLEARANCE's reason below, NOT the one above it:
+# _UNREADABLE_VIA_SIZE argues privacy from what the GRADERS must not adopt,
+# which does not transfer -- KiCad rejects `(drill 0)` at the fab floor rather
+# than reporting a barrel connected that is not. The argument that does
+# transfer is CAP_EDGE_CLEARANCE's: a PLACEMENT number that happens to equal a
+# fab default and must not be wired to it.
+#
+# And it does equal several. 0.3 is routing_defaults.VIA_DRILL, BGA_VIA_DRILL,
+# and bga_fanout.constants.DEFAULT_VIA_SIZE -- that last one a SIZE, which is
+# the trap. Those are the hole this toolchain DRILLS when it creates a via;
+# this is a pricing assumption about a barrel this pass cannot MEASURE. They
+# agree today by accident of value, and wiring them would let a change to a fab
+# default silently move a hole-to-hole keep-out.
+#
+# What the pair prices, since the two constants are read on different paths:
+# through a real _Repair an unreadable size resolves to --default-via-size, so
+# at the CLI's 0.3 the assumed via is 0.3/0.3 -- a ZERO annular ring; on the
+# duck-typed path it is _UNREADABLE_VIA_SIZE/this, 0.5/0.3, a 0.1 ring, which
+# is exactly routing_defaults' standard via. #750 records both readings.
+_UNREADABLE_VIA_DRILL = 0.3  # mm
+
 # The cap-placement margin from Edge.Cuts when the operator names none and the
 # board declares none. A PLACEMENT margin (keep a decap off the rim so it can be
 # assembled and reworked), not a DRC floor -- which is why it is 0.55 and not one
@@ -169,6 +195,35 @@ def _via_radius(via, default_size=_UNREADABLE_VIA_SIZE) -> float:
     if not size or size <= 0:
         size = default_size
     return size / 2.0
+
+
+def _via_drill_radius(via, default_drill=_UNREADABLE_VIA_DRILL) -> float:
+    """The DRILL radius of a via, in mm -- the ONE implementation of the rule.
+
+    #750: this was spelled `(v.drill or 0.3) / 2.0` at three sites inside
+    valid_via_pos, while the copper radius on the SAME two lines already went
+    through _via_radius. Same shape as that function, deliberately, including
+    the two things that are easy to read as accidents:
+
+    `getattr`, because the nudger is public and its harnesses pass duck-typed
+    via-likes. This DOES widen what the pass tolerates -- the old expression
+    raised AttributeError on a via-like carrying no `drill` at all, and this
+    prices it at the fallback. Deliberate, and the only such object is a test
+    stand-in; no parse path produces one.
+
+    `not d or d <= 0` and NOT `or`, so a negative drill cannot take a different
+    branch in the two. That is not hypothetical here: `or` keeps a negative
+    value, so the drill term goes NEGATIVE and weakens the gate it is summed
+    into. With both drills negative the whole hole-to-hole threshold turns
+    negative and the gate can never fire at all -- measured, the pass then
+    parks two 0.5mm barrels 0.05mm apart. Both parse paths admit it: the via
+    regex drill class carries a `-` and the float() that follows checks no
+    sign.
+    """
+    d = getattr(via, 'drill', None)
+    if not d or d <= 0:
+        d = default_drill
+    return d / 2.0
 
 # These four moved to placement/legality.py, the shared home with quench.py
 # (which carried byte-identical copies of the first two). Aliased rather than
@@ -2682,10 +2737,15 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
         #370 and #617 harnesses pass carries no resolver -- and only for a via
         whose size is falsy. Every via those fixtures build carries a real 0.5,
         so it is numerically unreachable there; the #732 test file pins that.
-        defaults.UNREADABLE_VIA_SIZE rather than a bare literal so the number
-        has ONE name across this module and the two checkers. Spelled with the
-        same `and ... > 0` guard as _Repair.via_radius, not `or`, so a negative
-        size cannot take a different branch in the two."""
+        _UNREADABLE_VIA_SIZE rather than a bare literal so the number has ONE
+        name in this module. (#750 corrects two claims this docstring used to
+        make: it named `defaults.UNREADABLE_VIA_SIZE`, which exists nowhere in
+        the repo -- the constant is module-private here and reaches this call
+        as _via_radius's default argument -- and it described the guard as
+        `and ... > 0`, where _via_radius spells it `not size or size <= 0`.
+        Same semantics, and worth stating correctly because the SPELLING is the
+        rule: not `or`, so a negative size cannot take a different branch in
+        the two. #750 applies that same rule to the drill.)"""
         if _via_rad is not None:
             return _via_rad(v)
         return _via_radius(v)
@@ -2731,8 +2791,17 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
             cap_ = pad_drill_capsule(p) if (p.drill and p.drill > 0) else None
             board_pads.append((p, pad_fl(p), not _pad_has_no_copper(p), cap_))
 
+    # #750: every OTHER via's drill radius, resolved ONCE, for the same reason
+    # the pads above are flattened here -- the hole-to-hole gate below runs
+    # inside the 16-angle x 12-radius sweep, so resolving per candidate would
+    # cost one call per via per CANDIDATE (383 of them on routed_output).
+    # Safe to hoist: the sweep does not mutate pcb_data.vias. The nudger
+    # rebuilds st.vias when it commits a move, which is a different list.
+    board_via_drills = [(ov, _via_drill_radius(ov)) for ov in pcb_data.vias]
+
     def valid_via_pos(v, nx, ny):
         vr = via_rad(v)
+        vdr = _via_drill_radius(v)      # hoisted once, like vr (#750)
         vfl = via_fl(v.net_id)
         # never off the board / into a cutout / inside the edge margin (#370 B3)
         if not edge_ok_point(nx, ny, vr):
@@ -2845,16 +2914,17 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
                 # deliberately NOT #725-resolved -- see npth_clr above)
                 (c1x, c1y), (c2x, c2y), prad = cap_
                 if _point_to_seg_dist(nx, ny, c1x, c1y, c2x, c2y) < \
-                        (v.drill or 0.3) / 2.0 + prad + H2H_PAD:
+                        vdr + prad + H2H_PAD:
                     return False
-        for ov in pcb_data.vias:
+        for ov, ovdr in board_via_drills:
             if ov is v:
                 continue
             d = math.hypot(nx - ov.x, ny - ov.y)
             if ov.net_id != v.net_id and d < vr + via_rad(ov) + \
                     req(vfl, via_fl(ov.net_id)):
                 return False
-            if d < (v.drill or 0.3) / 2.0 + (ov.drill or 0.3) / 2.0 + H2H_VIA:
+            # net-INDEPENDENT: two holes collide whatever they carry
+            if d < vdr + ovdr + H2H_VIA:
                 return False
         for s in pcb_data.segments:
             if s.net_id == v.net_id:

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -643,13 +643,12 @@ class _Repair:
         # clearance model, which is what made the layer truth vanish on the
         # boards carrying the most phantom -- see _cap_seg_scope.)
         self._seg_floor_by_id: Dict[int, PadFloor] = {}
+        # #736: through _register_segment, which is also what the connector
+        # copper this pass DRAWS goes through -- so a track filed later cannot
+        # be priced or scoped differently from one present at construction.
         for s in pcb_data.segments:
-            fl = self._seg_floor_for(s.net_id, s.layer)
-            t = (s.start_x, s.start_y, s.end_x, s.end_y, s.net_id,
-                 s.width / 2.0 + self._item_reach(fl), s.layer)
-            self.segments.append(t)
-            if fl is not None:
-                self._seg_floor_by_id[id(t)] = fl
+            self._register_segment(s.start_x, s.start_y, s.end_x, s.end_y,
+                                   s.net_id, s.width, s.layer)
 
         # --- attraction: BGA balls grouped by net ---
         # A cap pad is pulled toward the nearest ball of its own net, so a via
@@ -709,6 +708,10 @@ class _Repair:
         # must NOT be deleted as dead: the id-keyed floor maps below depend on
         # those tuples staying alive, and a recycled id would return ANOTHER
         # item's floor, silently, with no error.
+        # #736: self.segments does GAIN entries after __init__ (the connector
+        # copper this pass draws, filed by register_new_segments). It is
+        # APPENDED to, never rebuilt -- precisely so the aliveness this note is
+        # about survives the gain. self.foreign_pads is unchanged.
         self.foreign_pad_floors: List[Optional[PadFloor]] = []
         self.foreign_pad_mf: List[float] = []
         self.caps: Dict[str, _Cap] = {}
@@ -811,6 +814,15 @@ class _Repair:
             cx, cy = (r[0] + r[2]) / 2.0, (r[1] + r[3]) / 2.0
             span = math.hypot(r[2] - cx, r[3] - cy)
             cap_geom[ref] = (cx, cy, span, r)
+        # #736: KEPT, not consumed and dropped with the frame. Every prune
+        # reach below is anchored on the cap's SEED pose -- which is what this
+        # dict holds, because a cap's x/y/rot still equal its seed_* here --
+        # and register_new_segments re-runs that same prune for copper that
+        # appears AFTER construction, by which time cap.rect() is no longer the
+        # seed. Stored rather than re-derived there for the reason _seg_shares
+        # and via_required exist: a second derivation is a second thing to keep
+        # in step.
+        self._cap_geom = cap_geom
 
         self.cap_foreign_pads: Dict[str, List[
             Tuple[float, float, float, float, int, Optional[str]]]] = {}
@@ -864,41 +876,12 @@ class _Repair:
                     near_caps.append(oref)
             self.cap_caps[ref] = near_caps
 
-            near_segs = []
-            # seg[5] already carries the segment's own over-reach, so adding
-            # this cap's excess over the flat scalar bounds the pair.
-            seg_reach = (max_displacement_cap + 2 * span + clearance
-                         + max(0.0, cap_mf - clearance))
-            # #731: keep a track only if SOME pad of this cap shares its copper
-            # layer. The union is a superset of every per-pad set (see
-            # _seg_shares), so this can never drop a chargeable pair -- the
-            # list stays EXACT, as TestPruneRadiiStayExact requires. The
-            # per-pad half is applied in _seg_effs, and matters only for a cap
-            # whose pads differ (an SMD pad beside a through-hole one).
-            #
-            # The `_union is None` arm is a fallback for a cap that offers no
-            # copper pad at all -- cap detection admits n_copper == 0 (a
-            # paste-only C-prefixed part). Such a cap has an empty pad_rects,
-            # so NOTHING it keeps is ever graded and the arm cannot change an
-            # outcome; it keeps the old side filter purely so the pruned list
-            # stays the size it always was. It is NOT reachable for an empty
-            # copper list any more: `_all_cu` above resolves through
-            # check_drc's own three-level fallback and is never empty, which
-            # is deliberate -- falling back to the side collapse there would
-            # DROP the B.Cu and inner tracks a through-hole cap pad shares
-            # copper with, an under-block (measured: 280 pairs on rp2350).
-            _pl, _union = self._cap_seg_scope(cap)
-            for seg in self.segments:
-                layer = seg[6]
-                if _union is None:
-                    if self._seg_side(layer) != cap.side:
-                        continue
-                elif layer in self._all_cu and layer not in _union:
-                    continue
-                d = _point_to_seg_dist(ccx, ccy, seg[0], seg[1], seg[2], seg[3])
-                if d <= seg_reach + seg[5]:
-                    near_segs.append(seg)
-            self.cap_segs[ref] = near_segs
+            # #736: through _prune_segs, the ONE spelling of this predicate.
+            # It carries the comment block that used to live here, including
+            # why the reach is anchored on the SEED pose and why the #731 layer
+            # union keeps the list exact.
+            self.cap_segs[ref] = self._prune_segs(cap, cap_geom[ref],
+                                                  self.segments)
 
             near_vias = []
             # v[3] = via_radius + its own keep-out; a via that can reach a pad
@@ -1262,6 +1245,170 @@ class _Repair:
         pf = getattr(cap, 'pad_floors', None)
         return (self._floors is not None and pf is not None
                 and len(pf) == len(getattr(cap, 'pads', ())))
+
+    # ---- #736: THE one way a track enters this grader --------------------
+    # Two private helpers plus one public registrar, and every track this
+    # module grades goes through them: the ones present at construction, and
+    # the connector copper nudge_vias_for_unresolved DRAWS afterwards. Before
+    # #736 both halves were inline in __init__ and existed nowhere else, so
+    # the post-nudge re-grade had no way to register what the pass had just
+    # created -- it re-graded against the construction-time snapshot and could
+    # report a cap RESOLVED while a connector this same run emitted grazed one
+    # of its pads. Same shape, and the same reason, as via_radius /
+    # via_required / edge_margin above: ONE answer per pair kind in this
+    # module.
+
+    def _register_segment(self, x1, y1, x2, y2, net_id, width, layer):
+        """Grade one track into the track view, and return its tuple.
+
+        THE only construction site for a track tuple, and the only writer of
+        the id-keyed floor map -- both pinned by the source guard in
+        tests/test_736_fanout_clearance_regrade_view.py, which reports
+        offending line numbers rather than dumping the module.
+
+        Takes PRIMITIVE fields rather than a parser Segment because its two
+        callers hold different things: __init__ has real Segments, and
+        register_new_segments has the writer-shaped dicts the nudger returns.
+        A builder that accepted only one of those would have left the other
+        re-deriving the tuple, which is the defect being fixed.
+
+        It files the tuple BEFORE returning, on purpose. The floor map is
+        keyed on the tuple's identity, so a tuple that died while its id entry
+        lived would hand a recycled id ANOTHER track's floor -- silently, with
+        no error. That is the hazard the NB above self.foreign_pad_floors
+        names, and a factory that only BUILT would let a caller drop the
+        reference and arm it. Build-and-file is one operation here because the
+        invariant says it is.
+
+        Element 5 is the OVER-REACH -- half width plus this track's own upper
+        bound (#725), which _seg_effs strips back with the same _item_reach.
+        Element 6 is the track's REAL layer, never an 'F'/'B' side collapse
+        (#731).
+        """
+        fl = self._seg_floor_for(net_id, layer)
+        t = (x1, y1, x2, y2, net_id,
+             width / 2.0 + self._item_reach(fl), layer)
+        self.segments.append(t)
+        if fl is not None:
+            self._seg_floor_by_id[id(t)] = fl
+        return t
+
+    def _prune_segs(self, cap, geom, source):
+        """The tracks in `source` this cap could EVER be charged against --
+        THE one spelling of the per-cap track prune.
+
+        `geom` is the cap's SEED-pose (cx, cy, span, rect) from self._cap_geom,
+        never its current rect. The bound below is the reachable-DISK argument:
+        a cap moves at most max_displacement_cap from its SEED, so anything
+        whose seed gap already exceeds that can never constrain it -- which is
+        what makes this prune EXACT rather than an approximation
+        (TestPruneRadiiStayExact). A MOVED pose would silently redefine what
+        "exact" means, and it would be wrong for required_rows, which grades
+        the seed pose as well as the final one.
+
+        seg[5] already carries the segment's own over-reach, so adding this
+        cap's excess over the flat scalar bounds the pair.
+
+        #731: keep a track only if SOME pad of this cap shares its copper
+        layer. The union is a superset of every per-pad set (see _seg_shares),
+        so this can never drop a chargeable pair -- the list stays EXACT, as
+        TestPruneRadiiStayExact requires. The per-pad half is applied in
+        _seg_effs, and matters only for a cap whose pads differ (an SMD pad
+        beside a through-hole one).
+
+        The `_union is None` arm is a fallback for a cap that offers no copper
+        pad at all -- cap detection admits n_copper == 0 (a paste-only
+        C-prefixed part). Such a cap has an empty pad_rects, so NOTHING it
+        keeps is ever graded and the arm cannot change an outcome; it keeps the
+        old side filter purely so the pruned list stays the size it always was.
+        It is NOT reachable for an empty copper list any more: `_all_cu`
+        resolves through check_drc's own three-level fallback and is never
+        empty, which is deliberate -- falling back to the side collapse there
+        would DROP the B.Cu and inner tracks a through-hole cap pad shares
+        copper with, an under-block (measured: 280 pairs on rp2350).
+
+        Returns a NEW list. A caller must ASSIGN it and must never extend a
+        cap's existing list in place: _seg_effs memoises on the source list's
+        IDENTITY, so an in-place append leaves a memo that still passes the
+        identity test while being one column short, and _seg_shortfalls then
+        indexes past the end of its row.
+        """
+        ccx, ccy, span, _crect = geom
+        seg_reach = (self._max_disp_cap + 2 * span + self.clearance
+                     + max(0.0, cap.max_floor - self.clearance))
+        _pl, _union = self._cap_seg_scope(cap)
+        near_segs = []
+        for seg in source:
+            layer = seg[6]
+            if _union is None:
+                if self._seg_side(layer) != cap.side:
+                    continue
+            elif layer in self._all_cu and layer not in _union:
+                continue
+            d = _point_to_seg_dist(ccx, ccy, seg[0], seg[1], seg[2], seg[3])
+            if d <= seg_reach + seg[5]:
+                near_segs.append(seg)
+        return near_segs
+
+    def register_new_segments(self, seg_dicts) -> int:
+        """Take copper that appeared AFTER construction into the PAD-SEGMENT
+        channel; return how many tracks were filed (#736).
+
+        The one caller is repair_fanout_clearance, with the `new_segments` list
+        nudge_vias_for_unresolved returns: the connectors that restore
+        continuity to each relocated via. That copper is drawn by the pass
+        itself, milliseconds before the pass grades its own work, and both
+        front ends WRITE it (placement/writer.py on the CLI, the plugin's
+        pcbnew mirror in the GUI). Without this the final `unresolved` list and
+        required_rows' disclosure are computed against the track snapshot
+        __init__ took, so a cap can be reported RESOLVED while a connector this
+        same run emitted grazes one of its pads.
+
+        Takes the writer-shaped dicts the nudger already returns
+        ({'start', 'end', 'width', 'layer', 'net_id'}) rather than a tail
+        slice of pcb_data.segments, so nothing here depends on that list being
+        append-only.
+
+        INCREMENTAL, not a rebuild from the board, and the reason is not only
+        cost. The nudger leaves the ORIGINAL attached segments exactly where
+        they are (its own docstring says so), so every tuple already filed
+        still describes real copper at the same coordinates and every pruned
+        membership is as valid as it was. A rebuild would additionally REPLACE
+        the tuples the floor map is keyed on: the originals die, their ids can
+        be recycled by the replacements, and a track is handed ANOTHER track's
+        floor -- the hazard __init__'s own NB names. Appending cannot.
+
+        Each cap that keeps new copper is REASSIGNED a new list; a cap that
+        keeps none is left alone, so it keeps its list identity and therefore
+        its _seg_effs memo. That is what makes this O(caps x new tracks)
+        instead of a second pass over the whole board.
+
+        Deliberately NOT called from nudge_vias_for_unresolved. That function
+        is duck-typed on `st` -- the #370/#617/#732/#733/#737 harnesses pass a
+        stand-in carrying only `caps`, `vias` and `graze_penalty` -- so every
+        `st` read there goes through getattr with a flat fallback. A RESOLVER
+        has an honest flat fallback; a MUTATION does not, because "silently do
+        nothing" is precisely the staleness this fixes. repair_fanout_clearance
+        holds a real _Repair, so the call needs no escape hatch at all.
+
+        A connector on a layer this board never declared is KEPT and CHARGED
+        rather than dropped: `_all_cu` was resolved at construction, so such a
+        layer reads as UNKNOWN and _seg_shares charges it. Over-blocking is the
+        only direction that can never ship a violation.
+
+        Not idempotent, and does not need to be: one caller, one call.
+        """
+        fresh = [self._register_segment(sd['start'][0], sd['start'][1],
+                                        sd['end'][0], sd['end'][1],
+                                        sd['net_id'], sd['width'], sd['layer'])
+                 for sd in seg_dicts]
+        if not fresh:
+            return 0
+        for ref, cap in self.caps.items():
+            kept = self._prune_segs(cap, self._cap_geom[ref], fresh)
+            if kept:
+                self.cap_segs[ref] = self.cap_segs[ref] + kept
+        return len(fresh)
 
     def _pad_effs(self, ref, cap):
         """[cap pad i][pruned foreign pad j] required clearance, or None for
@@ -2167,8 +2314,55 @@ def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
     if unresolved:
         via_moves, new_segs = nudge_vias_for_unresolved(st, pcb_data, clearance)
         if via_moves:
+            # #736: absorb the connector tracks the nudger just DREW. They went
+            # into pcb_data.segments, but st.segments / st.cap_segs /
+            # st._seg_floor_by_id were snapshotted in _Repair.__init__ before
+            # they existed -- so the re-grade below, and required_rows' seed +
+            # final disclosure, read a track view missing exactly the copper
+            # this pass is responsible for, and a cap could be reported
+            # RESOLVED with one of its pads inside a connector's keep-out.
+            #
+            # The nudger's own connector_clear gate does NOT already close
+            # this. On the connector's OWN layer the two agree exactly -- same
+            # two floors through the same resolver, and connector_clear is the
+            # stricter by EPS -- so an accepted same-layer connector can never
+            # be charged here. It is the OTHER layers that diverge, in two
+            # ways: connector_clear compares against the cap FOOTPRINT's side
+            # (#738), so an inner-layer or back-side connector is never tested
+            # against a THROUGH-HOLE cap pad whose copper spans every layer;
+            # and a connector on a layer this board never declared is skipped
+            # there while _seg_shares charges it here, which is a window #738's
+            # own proposed fix does not close. Either way the gate that drew
+            # the copper is not the gate that grades it, and the summary the
+            # operator reads comes from this one.
+            #
+            # THE GUARD STAYS `via_moves` and gains no `or new_segs`: a
+            # connector dict is appended only inside the same commit block that
+            # appends the via move, with no continue or break between, so a
+            # non-empty new_segs IMPLIES a non-empty via_moves and the disjunct
+            # could never fire. No inner `if new_segs:` either -- the empty
+            # case returns immediately inside register_new_segments.
+            # (writer.py does spell `if via_moves or new_segments:`, and that
+            # is right THERE: it wraps two independent text rewrites and is
+            # defending against a caller handing it lists it did not produce.)
+            st.register_new_segments(new_segs)
             # refresh the per-cap pruned via lists before re-grading
             st.cap_vias = {r: st.vias for r in st.caps}
+            # base_seg / base_pad / base_via are deliberately NOT re-seeded --
+            # exactly as base_via is left alone by the line above, though via
+            # positions changed there too. They are read only by cost() /
+            # hard_blocked, neither of which runs past this point; and a
+            # baseline means "the state at the SEED", which copper this pass
+            # CREATED is not part of. Folding it in would license a later move
+            # to sit on the pass's own connector for free -- the #441
+            # GND<->NetR2_2 failure in miniature, and silent. The consequence
+            # to know: from here st.base_seg and st.cap_segs describe different
+            # boards, which is what "baseline" means rather than a defect.
+            #
+            # KNOWN GAP, deliberately not closed here: `resolved` above is
+            # computed BEFORE the nudge and is not refreshed, so a cap the
+            # sweep cleaned and a connector then grazes can appear in both
+            # lists. That is older than #736 and a different failure mode.
             unresolved = [r for r in st.caps
                           if st.graze_penalty(r, st.caps[r], st.caps[r].x,
                                               st.caps[r].y, st.caps[r].rot) > EPS]

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -622,8 +622,11 @@ class _Repair:
                 if _f is not None:
                     self._fp_floor_by_id[id(_t)] = _f
         # Per-(cap, neighbour) REQUIRED-clearance memos. model.pair() is
-        # pose-independent, so it is resolved ONCE per pair here and never
-        # inside the candidate sweep. Each memo is (source_list, rows) and is
+        # pose-independent, so it is resolved ONCE per (cap, neighbour) pair
+        # and reused for every candidate pose. The memos are filled lazily, so
+        # the first fill for a pair does happen inside cost() -- measured on a
+        # 0.5-class board: 572 of 62,565 pair_with_source calls, against
+        # 251,477 cost() calls. Each memo is (source_list, rows) and is
         # rebuilt when the source list identity changes -- which makes
         # repair_fanout_clearance's wholesale `st.cap_vias = {...}` reassignment
         # self-heal, and makes a test that injects into cap_foreign_pads grade
@@ -770,10 +773,15 @@ class _Repair:
                 if key not in self.base_cap_pad:
                     # #725: the baseline must be in the SAME currency as the
                     # candidate it gates. Priced flat while candidates are
-                    # priced at the requirement, _worsens_any_net fires on
-                    # every pose and the pass silently stops moving anything --
-                    # a failure whose symptom is FEWER placements, which reads
-                    # as conservative rather than broken.
+                    # priced at the requirement, _worsens_any_net compares two
+                    # different units, so the accept gate reads a pose as
+                    # worse-than-seed on a pair that did not change.
+                    # Measured by reverting exactly this line at HEAD: the
+                    # placement count moves in a CLASS-DEPENDENT direction and
+                    # not by much (0.4 identical, 0.5 gives 50 vs 48 and one
+                    # more unresolved, 1.0 gives 31 vs 34) -- so the symptom is
+                    # a quietly wrong answer, not a visible seizure, which is
+                    # why the test asserts the CURRENCY and not a count.
                     self.base_cap_pad[key] = _pad_pair_shortfall(
                         seed_pads, self.caps[oref].pad_rects(), self.clearance,
                         self._pair_effs(ref, cap, oref, self.caps[oref]))
@@ -911,10 +919,17 @@ class _Repair:
         return self._floors.pair(fa, fb)
 
     def _cap_pad_layers(self, cap):
-        """This cap's per-pad copper layer sets, or None when unavailable (a
-        duck-typed cap, or a board that declares no copper layers at all -- in
-        which case NO pair may be scoped by layer, or every one of them would
-        fall back to the flat scalar and under-block)."""
+        """This cap's per-pad copper layer sets, or None when unavailable.
+
+        None for a duck-typed cap, and for a board that declares no copper
+        layers at all: `pad_copper_layers(p, [])` resolves nothing for a `*.Cu`
+        pad, so every such pad would read as copper-less and take the
+        off-layer fallback -- an UNDER-block. It hits only `*.Cu` pads (an
+        `F.Cu` / `B.Cu` / `F&B.Cu` pad still resolves), which is 0 of 308 cap
+        pads on orangecrab but 468 of 2186 across the tracked corpus, all
+        through-hole. Scoping switches off entirely rather than per-pad,
+        because a board with no copper layers has no layer question to answer.
+        """
         pl = getattr(cap, 'pad_layers', None)
         if pl is None or len(pl) != len(getattr(cap, 'pad_floors', ())):
             return None
@@ -1939,7 +1954,7 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
         # The connector is a TRACK on `layer`, so it resolves like one. Note
         # this honours netclasses and .kicad_dru LAYER rules, but not #549
         # track-scoped rules, which live in a channel PadClearanceModel does
-        # not carry (check_drc.read_board_track_clearances); under-blocking a
+        # not carry (kicad_dru.read_board_track_clearances); under-blocking a
         # geometric connector that is separately DRC'd is the safe direction.
         cfl = seg_fl(net_id, layer)
         # board edge / cutouts + NPTH drill holes at their floor (#370 B3):

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -2401,6 +2401,50 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
         # never off the board / into a cutout / inside the edge margin (#370 B3)
         if not edge_ok_point(nx, ny, vr):
             return False
+        # #737: the relocated via's COPPER against copper-less (NPTH) holes.
+        # This function had no such test at all. Its only drilled-pad gate is
+        # the DRILL-to-drill one below, which measures the DRILL, so it covered
+        # the annular ring only while
+        #
+        #     ring = (size - drill) / 2 <= H2H_PAD - npth_clr
+        #
+        # -- 0.25 at the fab floor, but only 0.20 at the shipped --clearance
+        # 0.25, and 0 at clearance >= 0.45. Past that the pass parked ring
+        # copper inside a mounting hole's keep-out, and this pass WRITES the
+        # via (placement/writer.py, and the plugin's pcbnew mirror). Measured
+        # on a rig at --clearance 0.1: a 1.4/0.3 via relocated to 0.05mm of
+        # copper-to-hole-wall gap, which check_drc reports as a via-hole
+        # violation of exactly that.
+        #
+        # Same helper, same floor, same own-net exemption and the same 1e-4 as
+        # connector_clear's gate below, so the two sibling validators cannot
+        # disagree about which holes exist or what one costs -- and the gate
+        # order in the two now reads alike (edge, hole, cap rects, board pads,
+        # vias, segments). `board_pads` was the cheaper source and is the wrong
+        # one: it drops the pads of movable caps, which the helper keeps. That
+        # buys AGREEMENT between the siblings, not truth -- both read pre-move
+        # pad coordinates, so neither is right about a cap already relocated.
+        # A degenerate segment is the point case: _seg_capsule_axis_dist guards
+        # L2 == 0 and its crossing test is strict, so a zero-length segment
+        # cannot report a spurious crossing.
+        #
+        # The drill test below stays net-INDEPENDENT and keeps its own floor:
+        # drill-to-drill is a machine constraint, this is an etch constraint,
+        # and check_drc's via-hole arm makes the same own-net exemption
+        # (check_drc.py, `if via.net_id == hnet: continue`).
+        #
+        # KNOWN GAP, deliberately not closed here, exactly as at the cap
+        # keep-out site above: neither this gate nor the sibling honours the
+        # hole pad's OWN `local_clearance`, which check_drc does honour, so
+        # both under-block by `lc - npth_clr` on such a pad. That is #730 --
+        # a wrong VALUE, where this is a missing GATE -- and closing it here
+        # would move a number #730 needs to move in one place.
+        #
+        # NOT a reversal of #617. #617 measured RAISING this pass's hole floor
+        # to a board's DECLARED min_hole_clearance and refused it; the floor
+        # here is still the flat npth_clr, deliberately NOT st.npth_floor.
+        if _seg_foreign_hole_dist(pcb_data, v.net_id, nx, ny, nx, ny) <                 npth_clr + vr - 1e-4:
+            return False
         for (bx0, by0, bx1, by1, net, _cl, pfl) in all_cap_rects:
             # via barrel spans all layers: no layer gate here
             if net != v.net_id and _point_to_rect_dist(

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -2821,6 +2821,12 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
     # -- is a real defect: measured on a two-cap rig, the second via lands at
     # (5.1061, 6.1061) instead of (5.0500, 6.0000).
     #
+    # It also snapshots MEMBERSHIP, not just the radius: the gate used to walk
+    # pcb_data.vias live. Inert today -- nothing in this function appends to,
+    # slices or rebinds that list -- but a future edit that adds a via
+    # mid-pass (a stitching barrel, a split) would be invisible to the
+    # hole-to-hole gate and to nothing else, so add it here too.
+    #
     # `via_rad(ov)` on the copper line below is deliberately NOT hoisted with
     # it: that resolver takes the operator's --default-via-size through `st`,
     # so caching it here would put a second copy of a knob-dependent answer

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -57,6 +57,38 @@ EPS = 1e-6
 # rather than -inf so nothing can produce a NaN if a caller sums a row.
 _OFF_LAYER = -1.0e9
 
+# The diameter to assume for a via whose size the board does not carry -- a
+# literal `(size 0)` token, or a padstack whose pcbnew GetFrontWidth() came back
+# 0. This is the value nudge_vias_for_unresolved hard-coded at four sites before
+# #732 named it, so nothing moves.
+#
+# Module-private on purpose. It governs how THIS pass prices a barrel it cannot
+# measure, which is an operator-facing placement decision; it is emphatically
+# not a number the DRC/connectivity graders should adopt. KiCad honours a
+# declared size literally: `(size 0)` is a hard `via_diameter` DRC error there
+# (min 0.5000mm, actual 0.0000mm) rather than a via KiCad silently sizes for
+# you, and such a barrel joins nothing -- so a grader that substituted a
+# diameter would report CONNECTED what KiCad reports OPEN. Measured; see
+# TestTheGradersStillReadTheBoard in tests/test_732_...py, which states the
+# geometry the experiment needs (perpendicular copper-to-barrel separation,
+# not stub endpoint offset) because the naive version shows nothing.
+_UNREADABLE_VIA_SIZE = 0.5  # mm
+
+
+def _via_radius(via, default_size=_UNREADABLE_VIA_SIZE) -> float:
+    """The copper radius of a via, in mm -- the ONE implementation of the rule.
+
+    #732: this was spelled `v.size if v.size and v.size > 0 else
+    default_via_size` in the grader and `(v.size or 0.5) / 2.0` at four nudger
+    sites, so the two halves of the pass priced the same barrel differently.
+    `getattr` because the nudger is public and its test harnesses pass
+    duck-typed via-likes.
+    """
+    size = getattr(via, 'size', None)
+    if not size or size <= 0:
+        size = default_size
+    return size / 2.0
+
 # These four moved to placement/legality.py, the shared home with quench.py
 # (which carried byte-identical copies of the first two). Aliased rather than
 # renamed: the names are used throughout this module and imported by tests.
@@ -487,13 +519,18 @@ class _Repair:
         # nudge_vias_for_unresolved relocates a via. A tuple that died while its
         # id entry lived would hand a recycled id ANOTHER via's radius,
         # silently.
+        #
+        # #732: the fallback is STORED rather than consumed inline and dropped,
+        # because nudge_vias_for_unresolved needs the same answer and had no way
+        # to reach it -- see via_radius() for what that cost.
+        self._default_via_size = default_via_size
         self._via_radius_by_id: Dict[int, Tuple[tuple, float]] = {}
         for v in pcb_data.vias:
-            size = v.size if v.size and v.size > 0 else default_via_size
+            r = self.via_radius(v)
             t = (v.x, v.y, v.net_id,
-                 size / 2.0 + self._item_reach(self._via_floor_for(v.net_id)))
+                 r + self._item_reach(self._via_floor_for(v.net_id)))
             self.vias.append(t)
-            self._via_radius_by_id[id(t)] = (t, size / 2.0)
+            self._via_radius_by_id[id(t)] = (t, r)
 
         # --- avoidance: foreign-net tracks the cap's pads can actually TOUCH ---
         # Fanout escapes can land on the bottom (cap) side; attraction could
@@ -983,6 +1020,34 @@ class _Repair:
         unresolved that its own nudger then refuses to see). The via eff rows
         are built from this same call, so they cannot drift from it either."""
         return self._pair_or_flat(pad_floor, self._via_floor_for(via_net))
+
+    def via_radius(self, via) -> float:
+        """The RADIUS of one parser Via -- the one answer in this module (#732).
+
+        The only place `--default-via-size` is applied. __init__ builds the
+        keep-out list from this, and nudge_vias_for_unresolved's offender test,
+        its candidate validation and its #313 connectivity tolerance all read it
+        back through the same call, for the same reason via_required exists.
+
+        Left divergent, a via whose size the board does not carry got the
+        grader's default_via_size/2 and the nudger's hard-coded 0.25 for the
+        SAME barrel. At the CLI's 0.3 default the nudger's is LARGER, so it
+        moves vias the grader never flagged and lays connector copper for
+        nothing; above 0.5 the sign flips and the grader flags a cap whose
+        offender list then comes back EMPTY -- the `for v in offenders:` body
+        never runs, so not even the "no clear spot" line prints and the cap is
+        reported unresolved forever with nothing on screen. Both signs are
+        reachable from the GUI too: its via size is the Basic tab's spin
+        control, not the 0.5 constant (fanout_gui.py:1529 -> swig_gui.py:1739).
+
+        NOT the same question as _via_radius_by_id, and deliberately a separate
+        mechanism. That map answers "what radius did THIS 4-tuple get", which
+        for a tuple a test assigned wholesale is its own convention and must
+        stay so. This answers "how wide is this barrel" -- a fact about the
+        parser object, and the only form that works for a via injected into
+        pcb_data.vias AFTER construction, which the tests do.
+        """
+        return _via_radius(via, self._default_via_size)
 
     def _pair_or_flat(self, fa, fb):
         """model.pair for two floors, falling back to the flat scalar whenever
@@ -2067,6 +2132,7 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
     _pad_fl = getattr(st, 'pad_floor', None)
     _via_fl = getattr(st, 'via_floor', None)
     _seg_fl = getattr(st, 'seg_floor', None)
+    _via_rad = getattr(st, 'via_radius', None)
 
     def req(fa, fb):
         return clearance if _req is None else _req(fa, fb)
@@ -2082,6 +2148,25 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
 
     def seg_fl(net, layer):
         return None if _seg_fl is None else _seg_fl(net, layer)
+
+    def via_rad(v):
+        """This via's RADIUS, resolved by st when it can (#732), so the offender
+        test, the candidate validation and the #313 connectivity tolerance below
+        cannot disagree with the keep-out list the grader was built from. Four
+        sites here spelled it `(x.size or 0.5) / 2.0` and a fifth `v.size / 2.0`
+        with no fallback at all, while the grader used --default-via-size.
+
+        The fallback is reached ONLY on the duck-typed path -- the _FakeSt the
+        #370 and #617 harnesses pass carries no resolver -- and only for a via
+        whose size is falsy. Every via those fixtures build carries a real 0.5,
+        so it is numerically unreachable there; the #732 test file pins that.
+        defaults.UNREADABLE_VIA_SIZE rather than a bare literal so the number
+        has ONE name across this module and the two checkers. Spelled with the
+        same `and ... > 0` guard as _Repair.via_radius, not `or`, so a negative
+        size cannot take a different branch in the two."""
+        if _via_rad is not None:
+            return _via_rad(v)
+        return _via_radius(v)
 
     def cap_floors_of(cap, rects):
         """This cap's per-pad floors, index-aligned with `rects` -- or None,
@@ -2125,7 +2210,7 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
             board_pads.append((p, pad_fl(p), not _pad_has_no_copper(p), cap_))
 
     def valid_via_pos(v, nx, ny):
-        vr = (v.size or 0.5) / 2.0
+        vr = via_rad(v)
         vfl = via_fl(v.net_id)
         # never off the board / into a cutout / inside the edge margin (#370 B3)
         if not edge_ok_point(nx, ny, vr):
@@ -2153,7 +2238,7 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
             if ov is v:
                 continue
             d = math.hypot(nx - ov.x, ny - ov.y)
-            if ov.net_id != v.net_id and d < vr + (ov.size or 0.5) / 2.0 + \
+            if ov.net_id != v.net_id and d < vr + via_rad(ov) + \
                     req(vfl, via_fl(ov.net_id)):
                 return False
             if d < (v.drill or 0.3) / 2.0 + (ov.drill or 0.3) / 2.0 + H2H_VIA:
@@ -2210,7 +2295,7 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
                 return False
         for ov in pcb_data.vias:
             if ov.net_id != net_id and _point_to_seg_dist(
-                    ov.x, ov.y, sx, sy, ex, ey) < (ov.size or 0.5) / 2.0 + hw \
+                    ov.x, ov.y, sx, sy, ex, ey) < via_rad(ov) + hw \
                     + req(cfl, via_fl(ov.net_id)):
                 return False
         for s2 in pcb_data.segments:
@@ -2238,7 +2323,7 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
         pfls = cap_floors_of(cap, rects)
         offenders = []
         for v in pcb_data.vias:
-            vr = (v.size or 0.5) / 2.0
+            vr = via_rad(v)
             for i, (bx0, by0, bx1, by1, net) in enumerate(rects):
                 if v.net_id != net and _point_to_rect_dist(
                         v.x, v.y, (bx0, by0, bx1, by1)) < vr + via_req(
@@ -2256,7 +2341,7 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
             # 1um match missed copper offset by grid quantization or a prior
             # #280 via-nudge; the via body radius is the correct connectivity
             # tolerance (a track end buried in the via is connected).
-            tol = max(1e-3, v.size / 2.0)
+            tol = max(1e-3, via_rad(v))
             for s in pcb_data.segments:
                 if s.net_id != v.net_id:
                     continue

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -74,6 +74,87 @@ _OFF_LAYER = -1.0e9
 # not stub endpoint offset) because the naive version shows nothing.
 _UNREADABLE_VIA_SIZE = 0.5  # mm
 
+# The cap-placement margin from Edge.Cuts when the operator names none and the
+# board declares none. A PLACEMENT margin (keep a decap off the rim so it can be
+# assembled and reworked), not a DRC floor -- which is why it is 0.55 and not one
+# of routing_defaults' two edge numbers: BOARD_EDGE_CLEARANCE is 0.0, the SIGNAL
+# sentinel meaning "no edge rule, use the copper-copper clearance" (list_nets.py
+# :507-511), and adopting it here would collapse this margin to `clearance`;
+# PLANE_EDGE_CLEARANCE 0.5 belongs to pours. list_nets.board_floor_knobs already
+# spells this same 0.55 as its `edge_default` for the sibling placement CLIs.
+CAP_EDGE_CLEARANCE = 0.55  # mm
+
+
+def resolve_cap_edge_clearance(pcb_file, explicit=None):
+    """The cap-placement edge margin, resolved ONCE. Returns ``(mm, source)``.
+
+    THE ONE ANSWER for every front end (#733). The CLI, the GUI plugin and the
+    animator each carried their own hard-coded 0.55 and only the CLI exposed a
+    flag, so a board declaring a real copper-to-edge rule reached three different
+    margins depending on which front invoked the same engine.
+
+    TIGHTEN-ONLY, and that is deliberate rather than a softer form of the
+    board-first rule `list_nets.board_floor` implements. `board_floor` is
+    explicitly NOT raise-only, which is correct for a routing floor and wrong
+    here, because the value it would read back is one THIS pipeline wrote:
+    `fix_project_for_output` PINS `min_copper_edge_clearance` UP to the fab
+    copper-to-edge floor 0.20 on every board it writes (fix_kicad_drc_settings.py
+    :608 -> :749-754, the one raise-allowed key), and `bga_fanout.py` calls it
+    (bga_fanout/__init__.py:4328) -- as does place_fanout_clearance.py itself.
+    The documented pipeline is `bga_fanout.py -> place_fanout_clearance.py`, so
+    EVERY board this pass is handed in a real chain declares >= 0.20 even when its
+    author declared nothing. Read plainly board-first, that 0.20 comes back tagged
+    "board constraint" -- our own default wearing the board's name -- and the cap
+    margin silently drops 0.55 -> max(clearance, 0.20). 80/184 corpus boards
+    declare below 0.20 (fix_kicad_drc_settings.py:356), so that is the common case,
+    not a corner. Raising only is immune to the pin and still honours a board that
+    genuinely wants MORE room than 0.55.
+
+    An EXPLICIT POSITIVE value is honoured as given, in both directions: that is
+    the operator overriding the pass, and --board-edge-clearance 0.2 must mean
+    0.2 even though it is below the default.
+
+    A NON-POSITIVE explicit value is UNSET, not a margin of zero. Cite the right
+    precedent for that, because there are two rules in this codebase and they
+    differ exactly here: `board_floor` / `board_floor_knobs` apply the
+    non-positive-is-unset rule to a DECLARED value only and honour an explicit
+    one unconditionally (`if explicit is not None: return float(explicit)`,
+    list_nets.py:450), while `effective_board_edge_clearance` applies it to the
+    CLI value too (`cli_value if (cli_value and cli_value > 0) else ...`,
+    fix_kicad_drc_settings.py:357). This follows the latter, and deliberately
+    diverges from `board_floor` on this one point. Not pedantry: the GUI's Min
+    Edge Clearance spin control is
+    CREATED at defaults.BOARD_EDGE_CLEARANCE, which is 0.0, with a range minimum
+    of 0.0 -- so an operator who ticks the override box and types nothing hands
+    this function a 0. Honoured literally that would drop the cap margin to
+    max(clearance, 0) = the bare clearance: the exact 0.30mm under-block #733
+    exists to close, re-opened through a different door and LOOSER than the
+    0.55 the plugin used before this change. Caught by the #733 review.
+
+    `source` is for disclosure only: 'cli' | 'board constraint, raised' |
+    'fixed default'. There is deliberately NO 'unreadable project' source, unlike
+    board_floor's -- `board_constraint` swallows its own read errors and
+    `read_design_rules` swallows JSONDecodeError/OSError (list_nets.py:199), so a
+    corrupt project is genuinely indistinguishable here from one that declares
+    nothing. Both report 'fixed default'. Stated rather than papered over with a
+    label that could never print; the VALUE is 0.55 either way, which is the safe
+    direction for a raise-only rule.
+    """
+    if explicit is not None and explicit > 0:
+        return float(explicit), 'cli'
+    try:
+        from list_nets import board_constraint
+        declared = board_constraint(pcb_file, 'min_copper_edge_clearance')
+    except Exception:                                          # noqa: BLE001
+        declared = None    # e.g. pcb_file is not a path at all (an unsaved GUI
+                           # board): no declaration to raise to, take the default
+    # A declaration below the default cannot LOWER this margin (see above), and a
+    # non-positive one is UNSET rather than a floor of zero -- KiCad writes 0 into
+    # these fields for "not configured". `> CAP_EDGE_CLEARANCE` subsumes both.
+    if declared is not None and declared > CAP_EDGE_CLEARANCE:
+        return float(declared), 'board constraint, raised'
+    return CAP_EDGE_CLEARANCE, 'fixed default'
+
 
 def _via_radius(via, default_size=_UNREADABLE_VIA_SIZE) -> float:
     """The copper radius of a via, in mm -- the ONE implementation of the rule.
@@ -387,13 +468,12 @@ class _Repair:
         self.board = bounds
         # Copper-to-EDGE, not a different-net pair requirement, so #725 leaves
         # it alone: it is KiCad's `min_copper_edge_clearance`, a separate rule
-        # a netclass cannot express. Two caveats worth stating rather than
-        # implying: `board_edge_clearance` is a plain CLI flag (default 0.55)
-        # and is NOT auto-read from the board the way the routing steps read
-        # their edge constraint, and the GUI never passes it, so the plugin
-        # always gets the 0.55 signature default. Separately,
-        # nudge_vias_for_unresolved's own edge tests use bare `clearance`
-        # instead of this margin -- both pre-existing, both filed.
+        # a netclass cannot express. #733 closed the three gaps this comment
+        # used to list as filed: `board_edge_clearance` now reaches every front
+        # end through resolve_cap_edge_clearance (the GUI passed nothing and got
+        # the signature default; the animator had its own copy), and
+        # nudge_vias_for_unresolved reads `self.edge_margin` below instead of
+        # gating its own emitted copper at bare `clearance`.
         margin = max(clearance, board_edge_clearance)
         self.usable = (bounds[0] + margin, bounds[1] + margin,
                        bounds[2] - margin, bounds[3] - margin)
@@ -406,7 +486,9 @@ class _Repair:
         # touch a ring pay for the exact test. The gate itself now lives in
         # placement/legality.py, shared with quench (#456 item 2).
         self.edge_gate = BoardOutlineGate(pcb_data.board_info, margin)
-        self._edge_margin = margin
+        # (the board-edge requirement is read back through the `edge_margin`
+        # property below, which delegates to the gate rather than keeping a
+        # second copy of `margin` -- see its docstring for why, #733)
         # ref -> the milled rings this mover's own pads sit inside (#628), the
         # same exemption quench takes. Needed HERE and not only at the margin-0
         # gates because this one runs at max(clearance, board_edge_clearance)
@@ -1020,6 +1102,50 @@ class _Repair:
         unresolved that its own nudger then refuses to see). The via eff rows
         are built from this same call, so they cannot drift from it either."""
         return self._pair_or_flat(pad_floor, self._via_floor_for(via_net))
+
+    @property
+    def edge_margin(self) -> float:
+        """THE copper-to-Edge.Cuts requirement of this run -- max(clearance,
+        board_edge_clearance) -- and the one answer in this module (#733).
+
+        Public, and read from OUTSIDE the class, for the same reason
+        via_radius and via_required are: nudge_vias_for_unresolved gates the
+        vias it RELOCATES and the connector segments it DRAWS, and those two
+        gates must not be weaker than the one a cap pad has to pass.
+
+        Left divergent, they were. The cap mover inset `usable` and built
+        `edge_gate` at max(clearance, board_edge_clearance) while the nudger's
+        edge_ok_point / edge_ok_seg spelled a bare `clearance`, so at the CLI
+        defaults (0.55 / 0.25) the pass parked a relocated via and its
+        connector 0.30mm closer to Edge.Cuts than any cap is allowed to sit --
+        an under-block on copper the pass itself created and the writer keeps
+        (place_fanout_clearance.py:138). Identically 0.30mm on the GUI path,
+        which passes no flag at all.
+
+        DELEGATES to the gate instead of storing the number a second time.
+        `edge_gate` is what the cap mover's real-outline rect tests actually
+        measure against, so a private duplicate here would be this very defect
+        in miniature -- two names for one requirement, one refactor from
+        drifting. (It replaces `_edge_margin`, which this module read nowhere.)
+
+        What is NOT shared with the gate is its #628 owned-milled-ring
+        exemption -- and read legality.py:512-525 before restoring it here,
+        because the obvious reading is wrong. That exemption is not a
+        rect-modelling workaround limited to the swallow probe; it covers the
+        EDGE-MARGIN test too, and exists because a part whose own PADS caused a
+        contour to be reclassified as an inner milled edge would otherwise have
+        every pose inside its own relief vetoed (run 20's SW2: 0 legal poses of
+        14884). Ownership is defined by pads, and a via has none -- it can never
+        be the part that owns a ring, so there is nothing here to exempt. A
+        barrel 0.30mm from a milled slot is a real copper-to-edge violation
+        whichever way the parser's slot-vs-inner-outline ambiguity resolves, so
+        the nudger should stand off. The cost is that it may decline a move near
+        such a ring; it prints "no clear spot", which is visible and recoverable,
+        unlike silent sub-margin copper. No tracked board carries a milled
+        contour at all -- tests/test_733_*.py asserts that, so the claim expires
+        loudly rather than quietly.
+        """
+        return self.edge_gate.margin
 
     def via_radius(self, via) -> float:
         """The RADIUS of one parser Via -- the one answer in this module (#732).
@@ -1729,7 +1855,7 @@ class _Repair:
 def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
                             clearance: float = 0.2,
                             grid_step: float = 0.1,
-                            board_edge_clearance: float = 0.55,
+                            board_edge_clearance: Optional[float] = None,
                             near_margin: float = 1.0,
                             capture_radius: float = 2.0,
                             default_via_size: float = 0.3,
@@ -1763,6 +1889,11 @@ def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
     deliberately NOT exposed on the CLI / GUI -- flip this argument in code to
     disable.
 
+    board_edge_clearance (#733) defaults to None meaning "resolve it" -- see
+    resolve_cap_edge_clearance: the board's own min_copper_edge_clearance when it
+    declares MORE room than CAP_EDGE_CLEARANCE, else that 0.55. A value passed in
+    is honoured exactly as given, in both directions.
+
     on_move, if given, is a callback invoked with the internal _Repair state
     once at the seed placement and again after every accepted cap move. It is
     used purely for visualization (animate_fanout_clearance.py) and has no
@@ -1774,6 +1905,23 @@ def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
         for ref in pcb_data.footprints:
             if any(fnmatch.fnmatch(ref, pat) for pat in lock_refs):
                 extra_locked.add(ref)
+
+    # #733: ONE board-edge margin for every front end. Resolved HERE, in the
+    # shared engine rather than in a CLI main(), because the GUI plugin
+    # re-implements the main() layer and would otherwise keep silently taking
+    # the signature default whatever the board declares. Printed for the same
+    # reason the #725 clearance disclosure is printed from the engine: both
+    # fronts inherit it.
+    #
+    # UNCONDITIONAL, including when the caller named a value. The number governs
+    # where cap copper may sit relative to Edge.Cuts, and an operator reading a
+    # transcript should never have to know which of three fronts invoked this to
+    # know which margin it used -- printing only the resolved case would disclose
+    # exactly the branch that needs no explaining.
+    board_edge_clearance, _edge_src = resolve_cap_edge_clearance(
+        pcb_file, board_edge_clearance)
+    print(f"  board-edge margin for caps: {board_edge_clearance}mm "
+          f"({_edge_src})")
 
     st = _Repair(pcb_data, pcb_file, clearance, grid_step,
                  board_edge_clearance, near_margin, capture_radius,
@@ -2107,7 +2255,7 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
     npth_clr = max(clearance, defaults.NPTH_TO_TRACK_CLEARANCE)
 
     def edge_ok_point(x, y, r):
-        need = r + clearance
+        need = r + edge_margin
         if edge_rings:
             if not _point_on_board(x, y, edge_outer, edge_cutouts):
                 return False
@@ -2118,7 +2266,7 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
         return True
 
     def edge_ok_seg(sx, sy, ex, ey, hw):
-        need = hw + clearance
+        need = hw + edge_margin
         if edge_rings:
             if not (_point_on_board(sx, sy, edge_outer, edge_cutouts) and
                     _point_on_board(ex, ey, edge_outer, edge_cutouts)):
@@ -2145,6 +2293,32 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
     _via_fl = getattr(st, 'via_floor', None)
     _seg_fl = getattr(st, 'seg_floor', None)
     _via_rad = getattr(st, 'via_radius', None)
+    # #733: the board-edge requirement comes from st, so the two edge helpers
+    # below cannot gate the copper this function EMITS more weakly than the cap
+    # mover gates a cap pad.
+    #
+    # max(), not a bare read, for the same reason _item_reach never returns below
+    # `self.clearance`: the flat argument is this function's own floor, and an st
+    # must never LOWER this test below the clearance the caller passed.
+    #
+    # Defensive, and say so precisely rather than overstate it: no LIVE caller
+    # can currently hand this a sub-clearance margin. `_Repair` is constructed at
+    # one site, its margin is already max(clearance, ...), and the margin-ZERO
+    # outline gate render_placement builds is a shallow COPY it keeps beside
+    # `state.edge_gate` rather than a `_Repair` -- the #733 review checked, after
+    # an earlier version of this comment claimed otherwise. A duck-typed st CAN,
+    # and the #733 test exercises exactly that.
+    #
+    # The fallback is EXACTLY `clearance`, not CAP_EDGE_CLEARANCE -- the duck-typed
+    # _FakeSt the #370/#617 harnesses pass carries no margin, and this function's
+    # own flat scalar is the honest stand-in for one. Worth stating plainly: those
+    # two harnesses do NOT in fact pin this. Every landing they exercise clears
+    # 0.80mm, so a 0.55 fallback passes all five of their arms unchanged. That is
+    # exactly why tests/test_733_*.py brackets the fallback to (0.20, 0.30] on a
+    # rig built for it -- the regression a later reader would introduce by
+    # "tidying" this line is one nothing else would catch.
+    _edge_m = getattr(st, 'edge_margin', None)
+    edge_margin = clearance if _edge_m is None else max(clearance, _edge_m)
 
     def req(fa, fb):
         return clearance if _req is None else _req(fa, fb)

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -2468,7 +2468,8 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
     same-net copper terminating there (plus the pad's copper layer for a
     via-in-pad). mm-exact validation throughout. Returns
     (via_moves, new_segments) for the writer:
-      via_moves    = [(old_x, old_y, via_dict_at_new_pos)]
+      via_moves    = [(old_x, old_y, via dict {'x','y','size',
+                       'drill','layers','net_id','tenting_attrs'})]
       new_segments = [segment dicts {'start','end','width','layer','net_id'}]
     """
     H2H_VIA = 0.2    # JLC via-hole to via-hole floor
@@ -2951,7 +2952,31 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
             st.vias = _rebuilt
             via_moves.append((old[0], old[1],
                               {'x': nx, 'y': ny, 'size': v.size, 'drill': v.drill,
-                               'layers': v.layers, 'net_id': v.net_id}))
+                               'layers': v.layers, 'net_id': v.net_id,
+                               # This via came OFF the board and goes back on:
+                               # the writer DELETES it at `old` and re-emits it
+                               # here, and the plugin's pcbnew twin does the
+                               # same. Carry its tenting/plugging spec across or
+                               # the nudge silently re-tents it (#489 s8) -- a
+                               # via-in-pad needing IPC-4761 Type VII ships
+                               # tented from a pass whose job is clearance.
+                               # Same reason and same spelling as the rip-up
+                               # restore dict, plane_io.py:777-783.
+                               # `dict(...)` copies the SPEC specifically: it is
+                               # the one value here a consumer could mutate back
+                               # into the parser Via this pass still holds live.
+                               # `layers` above is shared by reference and always
+                               # has been -- a pre-existing shape, not a claim
+                               # this line makes.
+                               # `getattr` is belt-and-braces only. Every harness
+                               # that drives this function builds a REAL Via, and
+                               # Via.tenting_attrs has a default_factory, so the
+                               # default is unreachable today. It is spelled this
+                               # way because the function is public and takes
+                               # whatever pcb_data.vias holds, which is the same
+                               # reason _via_radius reads its fields defensively.
+                               'tenting_attrs': dict(
+                                   getattr(v, 'tenting_attrs', {}) or {})}))
             nm = pcb_data.nets[v.net_id].name if v.net_id in pcb_data.nets else v.net_id
             print(f"  via-nudge: moved {nm} via ({old[0]:.3f},{old[1]:.3f}) -> "
                   f"({nx:.3f},{ny:.3f}) to free {ref}; {len(conn_layers)} "

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -666,6 +666,38 @@ class _Repair:
         # placement engine has no GridRouteConfig anywhere in this call chain
         # (repair_fanout_clearance takes scalars); the board read is driven by
         # pcb_data.source_path, so the declared floor arrives regardless.
+        #
+        # #730: THIS PASS CARRIES TWO NPTH FLOORS AND THAT IS DELIBERATE.
+        # `nudge_vias_for_unresolved` resolves its own,
+        # `npth_clr = max(clearance, NPTH_TO_TRACK_CLEARANCE)`, which omits the
+        # board read this one performs. A reader finding them apart will want
+        # to unify them; #617 already decided not to, and the decision is
+        # measured. Its harness (`_via_mover_stays_flat` in
+        # tests/test_617_placement_fanout_hole_clearance.py) stages a board
+        # declaring 0.25, and the mover's only validated connector landing sits
+        # 0.2200mm off the hole wall -- so ANY floor above 0.2200 refuses it.
+        # Re-measured on this tree while closing #730: flat -> "1 move(s),
+        # 1 connector(s); copper-to-hole gap 0.2200mm"; board-aware -> "no
+        # clear spot", 0 and 0, and the #130 pad-via graze the pass exists to
+        # remove simply persists.
+        #
+        # The asymmetry has a shape, not just a history. THIS site is a COST
+        # MODEL -- the whole cap search descends it, so raising it makes the
+        # pass SEE a shortfall and MOVE the cap out of the band. That site is
+        # an ALL-OR-NOTHING GATE on a 0.6mm search, where raising it does not
+        # find a better spot, it returns "no clear spot". Same rule, two
+        # positions, and only one of them can afford the strictness. The file
+        # already carries this shape once, for the via-vs-connector floor
+        # inside that function; this is the second instance and it is now
+        # written down at BOTH ends rather than only at the far one.
+        #
+        # One correction to how the divergence was first reported (#730's
+        # thread): the two do NOT differ in both directions.
+        # `max(clearance, NPTH_TO_TRACK_CLEARANCE)` can never exceed
+        # `max(clearance, NPTH_TO_TRACK_CLEARANCE, declared)`, which is what
+        # this floor resolves to at its use site once the graded `clearance`
+        # is added back. The nudger is the lower of the two, or equal, and
+        # never the higher.
         from obstacle_map import resolve_hole_clearance
         self.npth_floor = max(defaults.NPTH_TO_TRACK_CLEARANCE,
                               resolve_hole_clearance(pcb_data, None))

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -321,6 +321,43 @@ def _seg_to_rect_dist(x1, y1, x2, y2, rect):
     return best
 
 
+def _seg_seg_dist(x1, y1, x2, y2, ax, ay, bx, by) -> float:
+    """Distance between two segments -- a scalar mirror of
+    `single_ended_routing._seg_capsule_axis_dist` (#730).
+
+    Deliberately NOT `_seg_rect_dist`'s `_segs_cross`-based shape, and the
+    difference is the reason this exists rather than reusing what is already
+    here. The kernel this mirrors decides a crossing with a STRICT
+    `o1*o2 < 0`, so a segment whose endpoint lies exactly ON the other's line
+    is NOT a crossing and falls through to the endpoint minimum; `_segs_cross`
+    counts an orientation of 0 as a crossing and would return 0.0 for the same
+    geometry. The #730 override gate must agree with its two scalar siblings
+    about touching cases -- they all measure the same holes -- so it copies the
+    kernel term for term instead of approximating it. Pure Python because the
+    override list is empty on 20 of the 22 tracked boards and never long.
+    """
+    def pt_to_seg(px, py, qx1, qy1, qx2, qy2):
+        dx = qx2 - qx1
+        dy = qy2 - qy1
+        L2 = dx * dx + dy * dy
+        t = 0.0 if L2 <= 0 else min(1.0, max(
+            0.0, ((px - qx1) * dx + (py - qy1) * dy) / L2))
+        return math.hypot(px - (qx1 + t * dx), py - (qy1 + t * dy))
+
+    sdx, sdy = x2 - x1, y2 - y1
+    hdx, hdy = bx - ax, by - ay
+    o1 = sdx * (ay - y1) - sdy * (ax - x1)
+    o2 = sdx * (by - y1) - sdy * (bx - x1)
+    o3 = hdx * (y1 - ay) - hdy * (x1 - ax)
+    o4 = hdx * (y2 - ay) - hdy * (x2 - ax)
+    if o1 * o2 < 0 and o3 * o4 < 0:
+        return 0.0
+    return min(pt_to_seg(ax, ay, x1, y1, x2, y2),
+               pt_to_seg(bx, by, x1, y1, x2, y2),
+               pt_to_seg(x1, y1, ax, ay, bx, by),
+               pt_to_seg(x2, y2, ax, ay, bx, by))
+
+
 class _Cap:
     """A movable cap: pad offsets + courtyard bbox, in a seed-relative frame.
 
@@ -2683,7 +2720,138 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
     # clear spot" and the #130 pad-via graze the pass exists to fix persists.
     # Measured on the #370-B3 harness with a declared 0.25: raised -> 0 moves,
     # 0 connectors; flat -> 1 move, 1 connector.
+    #
+    # #730 RE-MEASURED that, because it is the reason a whole site was dropped
+    # rather than fixed, and a four-month-old number carrying that much weight
+    # deserves re-derivation rather than quotation. Same harness
+    # (tests/test_617_placement_fanout_hole_clearance.py's
+    # `_via_mover_stays_flat`), same declared 0.25, on this tree: flat -> "1
+    # move(s), 1 connector(s); copper-to-hole gap 0.2200mm"; raised -> "no
+    # clear spot", 0 and 0. The connector's only validated landing sits 0.2200
+    # off the wall, so ANY floor above 0.2200 kills it and 0.25 is above it.
+    # #617's choice stands, and `self.npth_floor` (which DOES read the board)
+    # deliberately differs from this. See the note beside that assignment.
     npth_clr = max(clearance, defaults.NPTH_TO_TRACK_CLEARANCE)
+
+    # ---- #730: the OVERRIDE hole gate ------------------------------------
+    #
+    # `_seg_foreign_hole_dist` returns a PURE minimum distance -- one number
+    # for the whole board, with no per-hole requirement in it. That is right
+    # for a flat floor and wrong for KiCad's copper-to-hole rule, which honours
+    # each hole pad's OWN `(clearance ...)`. So the holes that CARRY one are
+    # collected here and gated separately, ADDITIVELY: the two scalar gates
+    # below keep their floors and their spellings exactly, and this list only
+    # ever refuses more. That is what makes #730 raise-only.
+    #
+    # THE THRESHOLD READS THE BOARD, and that is the one board-derived value
+    # this function is allowed. check_drc's via arm is a STEP --
+    # `kicad_req = req_clr if req_clr > npth_clr + 1e-9 else clearance`
+    # (check_drc.py:2851) -- whose `npth_clr` is
+    # `max(clearance, NPTH_TO_TRACK_CLEARANCE, hole_clearance)`, the third term
+    # being the board's declared min_hole_clearance. A threshold WITHOUT that
+    # term charges `lc` on a board where the checker charges `clearance`, which
+    # is the invented-refusal class #737's own comment is about. Measured
+    # during review: declared 0.35, hole lc 0.30, a landing 0.200 off the wall
+    # -- shipped 1 move; flat threshold 0 moves (repair LOST); board-aware
+    # threshold 1 move; and check_drc grades that landing CLEAN
+    # (kicad_req 0.10, overlap -0.1000). So the flat spelling reproduces, by
+    # 0.10mm, exactly the failure #737 was written to avoid.
+    #
+    # This is NOT the read #617 refused, and the direction is the whole
+    # argument. #617 refused board-deriving a FLOOR, which raises what every
+    # candidate is charged. This is a THRESHOLD: raising it makes it HARDER for
+    # a pad override to outrank the fab floor, so a larger declared value can
+    # only ever charge LESS. Against what ships today -- no `lc` term at all --
+    # the gate is raise-only either way, and the thing that keeps it from
+    # costing repairs is not the monotonicity but that it fires ONLY for a
+    # hole whose pad carries an explicit, author-declared keep-clear above the
+    # fab floor. A per-pad declaration, not a board-wide floor: that is the
+    # distinction from #617, and it is why this one is safe to raise.
+    #
+    # DISCLOSED, not exact. `resolve_hole_clearance` returns
+    # `max(rules.min_hole_clearance, fab_floor_origin)` while check_drc's CLI
+    # pins `rules` alone, so on a mid-chain board whose recorded origin exceeds
+    # its current rule (the tigard 0.25 -> 0.15 chain that resolver's own
+    # docstring measures) this threshold sits ABOVE the checker's, and a pad
+    # with `lc` in that band is graded by the checker and not charged here.
+    # #730 narrowed, not closed. Filed rather than papered over with a third
+    # copper-to-hole resolver in this pass.
+    #
+    # Read through `pcb_data`, never off `st`: this function is public and its
+    # harnesses pass duck types carrying `caps` and `vias` and nothing else, so
+    # a `getattr(st, 'npth_floor', ...)` would silently take the default -- and
+    # the default is the LOW threshold, which is the direction that costs
+    # repairs. (`st.npth_floor` is also the wrong number: it omits `clearance`,
+    # so it is too low at --clearance 0.3.)
+    from obstacle_map import resolve_hole_clearance
+    npth_step = max(npth_clr, resolve_hole_clearance(pcb_data, None))
+
+    # The hole SET is selected with the same two predicates and the same
+    # capsule geometry `single_ended_routing._foreign_hole_capsules` uses, so
+    # the override gate and its two scalar siblings cannot disagree about which
+    # holes EXIST -- only about what one costs. That agreement is the property
+    # test_737's TestTheTwoSiblingValidatorsSeeTheSameHoles exists to hold, and
+    # a re-spelt predicate is how it would be lost, silently and by
+    # under-blocking. Built from `pads_by_net`, which KEEPS the pads of movable
+    # caps, and NOT from `board_pads`, which drops them.
+    #
+    # Almost always EMPTY: 20 of the 22 tracked boards carry no NPTH override
+    # at all, and watchy's 8 are 0.100, under the 0.20 fab floor. So the two
+    # gates below cost a zero-length loop on every board in the corpus, and
+    # the `if` in front of each is what keeps that true rather than an
+    # assertion about it.
+    override_holes = []
+    for _hnet, _hpads in getattr(pcb_data, 'pads_by_net', {}).items():
+        for _hp in _hpads:
+            if (getattr(_hp, 'drill', 0) or 0) <= 0 or not _pad_has_no_copper(_hp):
+                continue
+            _hlc = getattr(_hp, 'local_clearance', 0.0) or 0.0
+            if _hlc <= npth_step + 1e-9:
+                continue
+            (_h1, _h2, _hr) = pad_drill_capsule(_hp)
+            override_holes.append((_h1[0], _h1[1], _h2[0], _h2[1], _hr,
+                                   _hnet, _hlc))
+
+    # REACH FILTER, and it is why a board that DOES carry an override still
+    # pays almost nothing. Every point either gate tests lies within
+    # `max_shift` of an existing via, and the requirement is
+    # `hr + hlc + (vr | hw)`, so a hole further than
+    # `hr + hlc + max_shift + widest` from EVERY via can never bind. Dropping
+    # those is provably conservative -- it removes only holes no candidate can
+    # reach -- and it matters: measured during review, the unfiltered gate ran
+    # 104us per candidate against the existing gate's 37us, about 22% on top of
+    # valid_via_pos's per-candidate cost, paid on a board where the branch
+    # then fires on nothing. On the fanned ulx3s the nearest via to AUDIO1's
+    # two holes is 9.283mm and 15.055mm against a 0.6mm spiral, so the filter
+    # empties the list there and both gates cost one truth test.
+    if override_holes:
+        _widest = max([v.size / 2.0 for v in pcb_data.vias]
+                      + [sg.width / 2.0 for sg in pcb_data.segments] + [0.0])
+        override_holes = [
+            h for h in override_holes
+            if any(_point_to_seg_dist(v.x, v.y, h[0], h[1], h[2], h[3])
+                   <= h[4] + h[6] + max_shift + _widest
+                   for v in pcb_data.vias)]
+
+    def override_hole_gap(net_id, x1, y1, x2, y2):
+        """Worst `distance-to-hole-wall MINUS that hole's own requirement`
+        over the override holes, or 1e9 when there are none.
+
+        Reads like its two scalar siblings -- a distance the caller compares
+        against its own half-extent -- so all four hole gates in this function
+        are one expression shape. Same own-net exemption they make, and the
+        same measure: `_point_to_seg_dist` between the two axes, which is what
+        `_seg_capsule_axis_dist` reduces to for the endpoint cases, minus the
+        capsule radius. A round drill is a zero-length capsule, so the point
+        case falls out rather than being special-cased."""
+        best = 1e9
+        for hx1, hy1, hx2, hy2, hr, hnet, hlc in override_holes:
+            if hnet == net_id:
+                continue
+            d = _seg_seg_dist(x1, y1, x2, y2, hx1, hy1, hx2, hy2) - hr
+            if d - hlc < best:
+                best = d - hlc
+        return best
 
     def edge_ok_point(x, y, r):
         need = r + edge_margin
@@ -2936,28 +3104,30 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
         # drill-to-drill is a machine constraint, this is an etch constraint,
         # and check_drc's via arm makes the same own-net exemption.
         #
-        # KNOWN GAP, deliberately not closed here. Like the cap keep-out site
-        # above, this does not honour the hole pad's OWN `local_clearance` --
-        # but the arithmetic is NOT the same, and saying "as above" inside a
-        # comment whose whole point is that the track and via arms differ would
-        # be wrong. check_drc's via arm is a STEP, not a max:
-        # `lc if lc > npth_clr else clearance`. So the shortfall here is
-        # `lc - clearance` ONLY when `lc > npth_clr`, and exactly ZERO for
-        # `clearance < lc <= npth_clr` (measured: clearance 0.10, lc 0.15 ->
-        # checker wants 0.100, this gate charges 0.100). Choosing `clearance`
-        # over `npth_clr` WIDENS that shortfall by `npth_clr - clearance`, i.e.
-        # by up to 0.10mm at --clearance 0.1 -- stated in magnitude, not merely
-        # in kind.
+        # #730 is CLOSED, in the SECOND gate below rather than in this one, and
+        # the gate on the next line is deliberately unchanged -- floor,
+        # spelling and all. check_drc's via arm is a STEP, not a max:
+        # `kicad_req = lc if lc > npth_clr else clearance`. So for
+        # `clearance < lc <= npth_clr` the requirement is EXACTLY `clearance`
+        # and this gate was already right (measured: clearance 0.10, lc 0.15 ->
+        # the checker wants 0.100, this charges 0.100). Only an override ABOVE
+        # `npth_clr` outranks it, and that is what `override_holes` carries.
         #
-        # That is #730 -- a wrong VALUE where this was a missing GATE. Two
-        # things for whoever closes it: the obvious `max(clearance, lc)` is
-        # measured WRONG in both directions (it over-blocks by 0.05 at
-        # clearance 0.10 / lc 0.15), and an exact mirror needs check_drc's
-        # `npth_clr`, which includes the BOARD's declared min_hole_clearance --
-        # dragging back in the very read this function and its own source guard
-        # forbid.
+        # Which is why the obvious `max(clearance, lc)` here is wrong in BOTH
+        # directions: at clearance 0.10 / lc 0.15 it over-blocks by 0.05 and
+        # invents a refusal kicad-cli never reports -- the crkbd phantom class
+        # the block above names. Splitting the step across two gates rather
+        # than folding it into one expression is what keeps this fix
+        # RAISE-ONLY and byte-identical on every board declaring no override.
         if _seg_foreign_hole_dist(pcb_data, v.net_id, nx, ny, nx, ny) < \
                 clearance + vr - 1e-4:
+            return False
+        # ...and the step's OTHER branch: a hole whose pad declares more than
+        # `npth_step` charges that override instead of `clearance`.
+        # `override_holes` is empty on every tracked board, so this costs one
+        # truth test there.
+        if override_holes and override_hole_gap(
+                v.net_id, nx, ny, nx, ny) < vr - 1e-4:
             return False
         for (bx0, by0, bx1, by1, net, _cl, pfl) in all_cap_rects:
             # via barrel spans all layers: no layer gate here
@@ -3014,6 +3184,17 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
             return False
         if _seg_foreign_hole_dist(pcb_data, net_id, sx, sy, ex, ey) < \
                 npth_clr + hw - 1e-4:
+            return False
+        # #730, the TRACK arm: check_drc grades a track against an NPTH hole at
+        # `max(npth_clr, lc)` -- a MAX, where the via gate above takes a STEP --
+        # so an override above the floor this gate already charges raises it,
+        # and one below it changes nothing. `override_holes` is filtered to
+        # `lc > npth_step >= npth_clr`, so every member is above and the max
+        # collapses to `lc` for all of them: the FILTER carries this arm, not
+        # the charge. `npth_clr` itself stays the flat fab floor -- #617's
+        # decision, re-measured in the note beside it.
+        if override_holes and override_hole_gap(
+                net_id, sx, sy, ex, ey) < hw - 1e-4:
             return False
         for (bx0, by0, bx1, by1, net, cl, pfl) in all_cap_rects:
             if cl != layer:

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -44,8 +44,9 @@ from bga_fanout.grid import analyze_bga_grid
 from placement.parser import extract_courtyard_bboxes, extract_locked_refs
 from placement.utility import compute_footprint_bbox_local, snap_to_grid
 from placement.legality import (BoardOutlineGate, PadClearanceModel, PadFloor,
-                                format_required_clause, point_to_seg_dist,
-                                rect_gap, ring_is_rect, rotate_local_bounds)
+                                _pad_carries_copper, format_required_clause,
+                                point_to_seg_dist, rect_gap, ring_is_rect,
+                                rotate_local_bounds)
 
 ROTATIONS = [0.0, 90.0, 180.0, 270.0]
 EPS = 1e-6
@@ -181,7 +182,18 @@ class _Cap:
             half_y = hx * s + hy * c
             self.pads.append((off_x, off_y, half_x, half_y, p.net_id))
             if model is not None:
-                fl = model.pad_floor(p)
+                # The GEOMETRY filter above stays loose on purpose (see the
+                # comment), but a FLOOR must not: PadClearanceModel.pad_floor
+                # reads local_clearance unconditionally, and an np_thru_hole
+                # pad lists *.Cu while carrying no copper at all. Charging its
+                # override would move a cap to clear copper that does not
+                # exist -- and would contradict the model's own inertness
+                # rule, which refuses to ACTIVATE for an NPTH-only override
+                # (legality._pad_carries_copper, the watchy measurement).
+                # Zero floor, appended unconditionally so the index alignment
+                # the loose filter buys is preserved.
+                fl = (model.pad_floor(p) if _pad_carries_copper(p)
+                      else PadFloor(0.0, 0.0, None))
                 self.pad_floors.append(fl)
                 mf = model.max_floor(fl)
                 if mf > self.max_floor:
@@ -303,6 +315,15 @@ class _Repair:
         if bounds is None:
             raise ValueError("No board boundary (Edge.Cuts) found")
         self.board = bounds
+        # Copper-to-EDGE, not a different-net pair requirement, so #725 leaves
+        # it alone: it is KiCad's `min_copper_edge_clearance`, a separate rule
+        # a netclass cannot express. Two caveats worth stating rather than
+        # implying: `board_edge_clearance` is a plain CLI flag (default 0.55)
+        # and is NOT auto-read from the board the way the routing steps read
+        # their edge constraint, and the GUI never passes it, so the plugin
+        # always gets the 0.55 signature default. Separately,
+        # nudge_vias_for_unresolved's own edge tests use bare `clearance`
+        # instead of this margin -- both pre-existing, both filed.
         margin = max(clearance, board_edge_clearance)
         self.usable = (bounds[0] + margin, bounds[1] + margin,
                        bounds[2] - margin, bounds[3] - margin)
@@ -460,6 +481,17 @@ class _Repair:
         # entry gets floor None / mf 0.0: its rect is already inflated to the
         # hole floor, and the copper-to-HOLE rule is net-independent, so the
         # new machinery must never raise it via a neighbouring pad's netclass.
+        # KNOWN GAP, deliberately not closed here: check_drc DOES honour the
+        # hole pad's OWN `local_clearance` on that rule (check_drc.py, the
+        # `max(npth_clr, local_clearance)` in the copper-to-hole pass, #505),
+        # and `lc` is net-independent too -- so this under-blocks by
+        # `lc - max(npth_floor, clearance)` on such a pad. Measured on
+        # kicad_files/ulx3s.kicad_pcb, AUDIO1's two 1.7mm NPTH holes at
+        # lc=0.400: 1.050mm modelled vs 1.250mm required, a 0.200mm
+        # under-block. It is the HOLE rule, not the different-net copper rule
+        # #725 is about, and it interacts with the #617 balance below; filed
+        # separately. (watchy's 8 NPTH overrides are all 0.100, below the 0.20
+        # fab floor, so that board is numerically inert here.)
         self.foreign_pad_floors: List[Optional[PadFloor]] = []
         self.foreign_pad_mf: List[float] = []
         self.caps: Dict[str, _Cap] = {}
@@ -1373,15 +1405,29 @@ def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
         if fp is None:
             continue
         for p in fp.pads:
-            if not any(str(l).endswith('.Cu') for l in p.layers):
+            # #725: the copper predicate is the shared one. An np_thru_hole pad
+            # lists *.Cu and carries no copper, so the loose test named it here
+            # as a copper obstacle -- and would have charged its keep-clear
+            # override besides.
+            if not _pad_carries_copper(p):
                 continue
-            rect = (p.global_x - p.size_x / 2, p.global_y - p.size_y / 2,
-                    p.global_x + p.size_x / 2, p.global_y + p.size_y / 2)
-            # #725: graded at the pair's REAL requirement, like everything
-            # else. `keepout` is the prune over-reach, so re-form the pair's
-            # keep-out from the via's radius. A locked fiducial's keep-clear
-            # override is exactly the case this warning exists to surface, and
-            # priced flat it under-reported it.
+            # ...and the RECT gets the same rect_rotation inflation _Cap and
+            # foreign_pads use. This was the one pad-geometry site in the file
+            # built from raw size_x/size_y, so a tilted locked pad under-blocked
+            # by (sqrt(2)-1)*half along the board axes -- 0.14mm on glasgow's
+            # 45-degree R9. Converting the clearance term and leaving the shape
+            # would be exactly the half-conversion this change is about.
+            tilt = math.radians(getattr(p, 'rect_rotation', 0.0) or 0.0)
+            _c, _s = abs(math.cos(tilt)), abs(math.sin(tilt))
+            _hx, _hy = p.size_x / 2.0, p.size_y / 2.0
+            ex, ey = _hx * _c + _hy * _s, _hx * _s + _hy * _c
+            rect = (p.global_x - ex, p.global_y - ey,
+                    p.global_x + ex, p.global_y + ey)
+            # Graded at the pair's REAL requirement, like everything else.
+            # `keepout` is the prune over-reach, so re-form the pair's keep-out
+            # from the via's radius. A locked fiducial's keep-clear override is
+            # exactly the case this warning exists to surface, and priced flat
+            # it under-reported it.
             pfl = st.pad_floor(p)
             for vx, vy, vnet, keepout in st.vias:
                 if vnet == p.net_id:

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -321,43 +321,6 @@ def _seg_to_rect_dist(x1, y1, x2, y2, rect):
     return best
 
 
-def _seg_seg_dist(x1, y1, x2, y2, ax, ay, bx, by) -> float:
-    """Distance between two segments -- a scalar mirror of
-    `single_ended_routing._seg_capsule_axis_dist` (#730).
-
-    Deliberately NOT `_seg_rect_dist`'s `_segs_cross`-based shape, and the
-    difference is the reason this exists rather than reusing what is already
-    here. The kernel this mirrors decides a crossing with a STRICT
-    `o1*o2 < 0`, so a segment whose endpoint lies exactly ON the other's line
-    is NOT a crossing and falls through to the endpoint minimum; `_segs_cross`
-    counts an orientation of 0 as a crossing and would return 0.0 for the same
-    geometry. The #730 override gate must agree with its two scalar siblings
-    about touching cases -- they all measure the same holes -- so it copies the
-    kernel term for term instead of approximating it. Pure Python because the
-    override list is empty on 20 of the 22 tracked boards and never long.
-    """
-    def pt_to_seg(px, py, qx1, qy1, qx2, qy2):
-        dx = qx2 - qx1
-        dy = qy2 - qy1
-        L2 = dx * dx + dy * dy
-        t = 0.0 if L2 <= 0 else min(1.0, max(
-            0.0, ((px - qx1) * dx + (py - qy1) * dy) / L2))
-        return math.hypot(px - (qx1 + t * dx), py - (qy1 + t * dy))
-
-    sdx, sdy = x2 - x1, y2 - y1
-    hdx, hdy = bx - ax, by - ay
-    o1 = sdx * (ay - y1) - sdy * (ax - x1)
-    o2 = sdx * (by - y1) - sdy * (bx - x1)
-    o3 = hdx * (y1 - ay) - hdy * (x1 - ax)
-    o4 = hdx * (y2 - ay) - hdy * (x2 - ax)
-    if o1 * o2 < 0 and o3 * o4 < 0:
-        return 0.0
-    return min(pt_to_seg(ax, ay, x1, y1, x2, y2),
-               pt_to_seg(bx, by, x1, y1, x2, y2),
-               pt_to_seg(x1, y1, ax, ay, bx, by),
-               pt_to_seg(x2, y2, ax, ay, bx, by))
-
-
 class _Cap:
     """A movable cap: pad offsets + courtyard bbox, in a seed-relative frame.
 
@@ -2742,10 +2705,22 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
     # budget but validated candidates against copper only -- a via or its new
     # connector could be pushed off the board / into a cutout, and connectors
     # had no NPTH-hole test at all.
+    # `_seg_seg_dist_coords` (#730) is the segment-to-segment measure the two
+    # override gates use, and it is the SHARED helper -- geometry_utils',
+    # which check_drc re-exports and placement/legality.py already calls at
+    # three sites -- rather than a fifth copy. Emphatically NOT this module's
+    # own `_segs_cross` shape: that snaps an orientation of 0 to "crossing", so
+    # a segment whose endpoint lies exactly ON the other's line measures 0.0,
+    # where `_seg_capsule_axis_dist` -- the kernel the two SIBLING hole gates
+    # measure with -- uses a strict `o1*o2 < 0` and falls through to the
+    # endpoint minimum. All four hole gates must agree about touching cases.
+    # Measured equal to that kernel over ~800k fuzz cases: max |delta| 2.8e-14
+    # at board-scale magnitudes, 2.3e-10 at |coord| ~ 1e6 mm, both many orders
+    # below the gates' own 1e-4.
     from check_drc import (board_edge_geometry, _point_on_board,
                            _point_to_rings_distance, _segment_to_rings_distance,
                            point_to_pad_distance, _pad_has_no_copper,
-                           segment_to_rect_distance)
+                           segment_to_rect_distance, _seg_seg_dist_coords)
     from kicad_parser import pad_drill_capsule
     from routing_utils import into_pad_frame_point
     from single_ended_routing import _seg_foreign_hole_dist
@@ -2816,6 +2791,14 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
     # #730 narrowed, not closed. Filed rather than papered over with a third
     # copper-to-hole resolver in this pass.
     #
+    # The OTHER direction is reachable too, and only one way: `check_drc
+    # --hole-clearance X` given explicitly above the board's own rule makes the
+    # checker's npth_clr exceed this threshold, so a pad with `lc` in
+    # `(npth_step, X]` is charged `lc` here and `clearance` there -- an
+    # over-block. It needs a grader invoked with a floor the board does not
+    # declare, which is a deliberate act rather than a chain artefact, but it
+    # belongs in the disclosure beside its mirror image.
+    #
     # Read through `pcb_data`, never off `st`: this function is public and its
     # harnesses pass duck types carrying `caps` and `vias` and nothing else, so
     # a `getattr(st, 'npth_floor', ...)` would silently take the default -- and
@@ -2864,8 +2847,15 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
     # two holes is 9.283mm and 15.055mm against a 0.6mm spiral, so the filter
     # empties the list there and both gates cost one truth test.
     if override_holes:
-        _widest = max([v.size / 2.0 for v in pcb_data.vias]
-                      + [sg.width / 2.0 for sg in pcb_data.segments] + [0.0])
+        # `getattr`, like every other read of a via in this function: the
+        # nudger is public and its harnesses pass duck-typed via-likes. A bare
+        # `v.size` here would raise ONLY on a board that carries an override
+        # hole -- invisible on 20 of 22 tracked boards and on every existing
+        # harness, which is the worst possible place for a hard read.
+        _widest = max([(getattr(v, 'size', 0.0) or 0.0) / 2.0
+                       for v in pcb_data.vias]
+                      + [(getattr(sg, 'width', 0.0) or 0.0) / 2.0
+                         for sg in pcb_data.segments] + [0.0])
         override_holes = [
             h for h in override_holes
             if any(_point_to_seg_dist(v.x, v.y, h[0], h[1], h[2], h[3])
@@ -2879,15 +2869,18 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
         Reads like its two scalar siblings -- a distance the caller compares
         against its own half-extent -- so all four hole gates in this function
         are one expression shape. Same own-net exemption they make, and the
-        same measure: `_point_to_seg_dist` between the two axes, which is what
-        `_seg_capsule_axis_dist` reduces to for the endpoint cases, minus the
-        capsule radius. A round drill is a zero-length capsule, so the point
-        case falls out rather than being special-cased."""
+        same measure: a full SEGMENT-to-segment distance (crossing branch
+        included) to the hole's capsule axis, minus the capsule radius. Not an
+        endpoint test -- a connector whose MIDDLE grazes a hole must be caught,
+        and its endpoints can both be clear while it does. A round drill is a
+        zero-length capsule and the via gate passes a zero-length segment, so
+        the point cases fall out rather than being special-cased."""
         best = 1e9
         for hx1, hy1, hx2, hy2, hr, hnet, hlc in override_holes:
             if hnet == net_id:
                 continue
-            d = _seg_seg_dist(x1, y1, x2, y2, hx1, hy1, hx2, hy2) - hr
+            d = _seg_seg_dist_coords(x1, y1, x2, y2,
+                                     hx1, hy1, hx2, hy2) - hr
             if d - hlc < best:
                 best = d - hlc
         return best

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -832,6 +832,10 @@ class _Repair:
         self.cap_caps: Dict[str, List[str]] = {}
         # foreign-net tracks this cap's pads SHARE COPPER WITH, in reach (#731)
         self.cap_segs: Dict[str, List[Tuple]] = {}
+        # ...and how many LEADING entries of each are seed-era (#736). Copper
+        # register_new_segments appends is real on the final board and a
+        # fiction at the seed, so the two graded poses see different lists.
+        self._seed_seg_n: Dict[str, int] = {}
         # through-vias in reach (each (vx, vy, net, keepout))
         self.cap_vias: Dict[str, List[Tuple[float, float, int, float]]] = {}
         # #725: every reach below is raised by THE TWO ITEMS' OWN maxima, never
@@ -882,6 +886,13 @@ class _Repair:
             # union keeps the list exact.
             self.cap_segs[ref] = self._prune_segs(cap, cap_geom[ref],
                                                   self.segments)
+            # #736: how much of that list is SEED-ERA copper. required_rows
+            # grades the seed pose as well as the final one, and a connector
+            # this pass DREW did not exist at the seed -- charging it there
+            # invents a row describing a pair no board ever had. Recorded per
+            # cap rather than derived from a global count, because the pruned
+            # lists have different lengths.
+            self._seed_seg_n[ref] = len(self.cap_segs[ref])
 
             near_vias = []
             # v[3] = via_radius + its own keep-out; a via that can reach a pad
@@ -1301,10 +1312,22 @@ class _Repair:
         never its current rect. The bound below is the reachable-DISK argument:
         a cap moves at most max_displacement_cap from its SEED, so anything
         whose seed gap already exceeds that can never constrain it -- which is
-        what makes this prune EXACT rather than an approximation
-        (TestPruneRadiiStayExact). A MOVED pose would silently redefine what
-        "exact" means, and it would be wrong for required_rows, which grades
-        the seed pose as well as the final one.
+        what makes this prune EXACT rather than an approximation. A MOVED pose
+        would silently redefine what "exact" means.
+
+        The bound is stated rather than cited, because the obvious citation is
+        wrong: TestPruneRadiiStayExact checks that the lists never SHRINK when
+        a requirement is raised, not that the pruned grade equals the unpruned
+        one. Measured instead, over all 115 caps of every tracked board:
+        `2*span + clearance - grid_overshoot - R_max` has a minimum slack of
+        +1.009mm and never goes negative, where R_max is the largest
+        seed-centre-to-pad-corner distance across all four reachable
+        rotations. That figure is at --clearance 0.1; the bound carries a
+        `+ clearance` term, so it is +1.109 at the shipped 0.2 and larger
+        above. The grid overshoot is real and pre-existing --
+        _candidate_positions snaps AFTER its radius test, so a final pose can
+        sit up to grid_step*sqrt(2)/2 past max_displacement_cap -- and the
+        2*span term absorbs it with an order of magnitude to spare.
 
         seg[5] already carries the segment's own over-reach, so adding this
         cap's excess over the flat scalar bounds the pair.
@@ -1405,9 +1428,20 @@ class _Repair:
         if not fresh:
             return 0
         for ref, cap in self.caps.items():
-            kept = self._prune_segs(cap, self._cap_geom[ref], fresh)
+            # `.get` rather than a bare index, matching what _pair_effs and
+            # the eff builders already do: st.caps / st.cap_segs / st.segments
+            # are all assignable from a test on a REAL _Repair (test_725 and
+            # test_732 both do it), and a cap this object never pruned for has
+            # no seed geometry to measure a reach from. Skipping it leaves
+            # that cap exactly as the caller built it.
+            geom = self._cap_geom.get(ref)
+            if geom is None or ref not in self.cap_segs:
+                continue
+            kept = self._prune_segs(cap, geom, fresh)
             if kept:
                 self.cap_segs[ref] = self.cap_segs[ref] + kept
+                self._seed_seg_n.setdefault(
+                    ref, len(self.cap_segs[ref]) - len(kept))
         return len(fresh)
 
     def _pad_effs(self, ref, cap):
@@ -1618,15 +1652,22 @@ class _Repair:
             x, y, rot = cap.x, cap.y, cap.rot
             sx, sy, srot = cap.seed_x, cap.seed_y, cap.seed_rot
 
-            def both(fn):
+            def both(fn, seed_kw=None):
                 """Nets charged at the SEED pose or the final one.
 
                 The seed half is the point: the pass SUCCEEDS by leaving
                 nothing charged, so a final-pose-only report is empty exactly
                 when the raised requirement did its work -- and the operator
                 could not tell a run graded at --clearance from one graded at
-                five times it."""
-                out = set(fn(ref, cap, sx, sy, srot))
+                five times it.
+
+                #736: `seed_kw` scopes the SEED half to the copper that
+                existed at the seed. Only the TRACK kind needs it -- the pad
+                and via channels gain nothing after __init__ -- and without it
+                a connector the pass DREW is charged against the cap's seed
+                pads, a pair no board ever had. That is the same class of
+                phantom #731 removed from this very report."""
+                out = set(fn(ref, cap, sx, sy, srot, **(seed_kw or {})))
                 out |= set(fn(ref, cap, x, y, rot))
                 return out
 
@@ -1640,7 +1681,8 @@ class _Repair:
                      both(self._via_shortfalls), None, None),
                     ('track', self.cap_segs[ref],
                      lambda t: self._seg_floor_by_id.get(id(t)), lambda t: t[4],
-                     both(self._seg_shortfalls),
+                     both(self._seg_shortfalls,
+                          {'upto': self._seed_seg_n.get(ref)}),
                      lambda t: t[6], None)):
                 for net, (mm, src) in best(fls, items, floor_of, net_of,
                                            set(charged), cl, layer_of,
@@ -1768,7 +1810,7 @@ class _Repair:
                     by_net[vnet] = by_net.get(vnet, 0.0) + (keepout - d)
         return by_net
 
-    def _seg_shortfalls(self, ref, cap, x, y, rot):
+    def _seg_shortfalls(self, ref, cap, x, y, rot, upto=None):
         """PER-FOREIGN-NET track clearance shortfall for a placement, over the
         tracks this cap's pads actually SHARE COPPER WITH (#731),
         keyed by the track's net_id (#441): {snet: sum of (halfw - dist) over that
@@ -1782,6 +1824,13 @@ class _Repair:
         scalar baseline). Uses the per-cap pruned, layer-scoped track list."""
         by_net: Dict[int, float] = {}
         segs = self.cap_segs[ref]
+        # #736: `upto` grades only the first N entries -- the SEED-ERA ones,
+        # since register_new_segments APPENDS. Used by required_rows' seed
+        # half, which must not charge copper this pass itself drew. A PREFIX
+        # rather than a filtered subset on purpose: the eff rows below are
+        # index-aligned with this list, and a subset would mis-index them.
+        if upto is not None:
+            segs = segs[:upto]
         effs = self._seg_effs(ref, cap)
         if effs is None:
             # No matrix: a duck-typed cap, or a real _Cap with no copper pad
@@ -2342,6 +2391,13 @@ def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
             # non-empty new_segs IMPLIES a non-empty via_moves and the disjunct
             # could never fire. No inner `if new_segs:` either -- the empty
             # case returns immediately inside register_new_segments.
+            #
+            # The CONVERSE is false and this is not an equivalence: a via whose
+            # conn_layers is empty -- no same-net copper terminating in its
+            # body, no containing same-net pad, no same-net zone -- relocates
+            # with no connector at all (and, worth knowing separately, with no
+            # connector validation, since `all(...)` over an empty dict is
+            # vacuously True). That grows via_moves and not new_segs.
             # (writer.py does spell `if via_moves or new_segments:`, and that
             # is right THERE: it wraps two independent text rewrites and is
             # defending against a caller handing it lists it did not produce.)

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -1952,10 +1952,13 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
     def connector_clear(net_id, layer, width, sx, sy, ex, ey):
         hw = width / 2.0
         # The connector is a TRACK on `layer`, so it resolves like one. Note
-        # this honours netclasses and .kicad_dru LAYER rules, but not #549
-        # track-scoped rules, which live in a channel PadClearanceModel does
-        # not carry (kicad_dru.read_board_track_clearances); under-blocking a
+        # this honours netclasses and .kicad_dru LAYER rules, but not
+        # TRACK-SCOPED .kicad_dru rules, which live in a channel
+        # PadClearanceModel does not carry (kicad_dru.read_board_track_clearances,
+        # applied by check_drc at the seg-seg site only). Under-blocking a
         # geometric connector that is separately DRC'd is the safe direction.
+        # Filed as #735. (check_drc.py tags that channel `#549`; GitHub #549 is
+        # a closed, unrelated issue, so this cites the tracker instead.)
         cfl = seg_fl(net_id, layer)
         # board edge / cutouts + NPTH drill holes at their floor (#370 B3):
         # a connector is drawn geometrically, not routed, so it must gate

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -759,17 +759,23 @@ class _Repair:
         # entry gets floor None / mf 0.0: its rect is already inflated to the
         # hole floor, and the copper-to-HOLE rule is net-independent, so the
         # new machinery must never raise it via a neighbouring pad's netclass.
-        # KNOWN GAP, deliberately not closed here: check_drc DOES honour the
-        # hole pad's OWN `local_clearance` on that rule (check_drc.py, the
-        # `max(npth_clr, local_clearance)` in the copper-to-hole pass, #505),
-        # and `lc` is net-independent too -- so this under-blocks by
-        # `lc - max(npth_floor, clearance)` on such a pad. Measured on
-        # kicad_files/ulx3s.kicad_pcb, AUDIO1's two 1.7mm NPTH holes at
-        # lc=0.400: 1.050mm modelled vs 1.250mm required, a 0.200mm
-        # under-block. It is the HOLE rule, not the different-net copper rule
-        # #725 is about, and it interacts with the #617 balance below; filed
-        # separately. (watchy's 8 NPTH overrides are all 0.100, below the 0.20
-        # fab floor, so that board is numerically inert here.)
+        # #730: the rect inflation below DOES now carry the hole pad's OWN
+        # `local_clearance`, which is what makes floor None correct rather than
+        # merely convenient. check_drc grades this rule at
+        # `max(npth_clr, lc)` (check_drc.py:2733, #505) and `lc` on a hole pad
+        # is net-independent exactly like the floor beside it -- so it belongs
+        # in the GEOMETRY, with the fab floor, and not in the per-pair floor
+        # machinery, which resolves netclasses. Read straight off the pad, NOT
+        # through PadClearanceModel, and "is the model active?" is NOT a usable
+        # proxy either. The model refuses to activate for an NPTH-ONLY override
+        # (legality.py:1450-1454 gates has_overrides on _pad_carries_copper) --
+        # but on the one board that matters it is active anyway and still gives
+        # the hole nothing: measured on ulx3s, BAT1's two SMD pads carry
+        # lc 0.700 so `model.active` is True, while AUDIO1's two NPTH holes get
+        # no floor at all, because `pad_floor` is built for copper pads only
+        # and `_fp_floor_by_id` maps only copper-pad tuples -- so the NPTH
+        # tuple still resolves through `_pair_or_flat(fa, None)` to the flat
+        # scalar. The read has to be off the pad.
         # NB: self.foreign_pads (and self.segments) are read nowhere after
         # __init__ -- the pruned per-cap lists are what the sweep uses. They
         # must NOT be deleted as dead: the id-keyed floor maps below depend on
@@ -815,11 +821,33 @@ class _Repair:
                     # the DRILL still removes any copper closer than the
                     # NPTH-to-track floor, so a cap pad slid over it is a real
                     # fab violation regardless of net. Blocks BOTH sides
-                    # (through hole); graded at the NPTH floor by inflating
-                    # the rect; net -1 never matches a cap pad's net (even a
-                    # net-tied mounting hole is not connectable copper, #328).
+                    # (through hole); graded by inflating the rect so that
+                    # rect + the flat `clearance` charged downstream lands on
+                    # check_drc's own requirement; net -1 never matches a cap
+                    # pad's net (even a net-tied mounting hole is not
+                    # connectable copper, #328).
+                    #
+                    # #730: `max(self.npth_floor, lc)` is check_drc's
+                    # `max(npth_clr, local_clearance)` term for term.
+                    # `max(npth_floor, clearance)` -- what this resolved to
+                    # before -- is ALREADY exactly check_drc.py:2714's
+                    # `npth_clr = max(clearance, NPTH_TO_TRACK_CLEARANCE,
+                    # hole_clearance)`, because npth_floor carries the fab
+                    # floor and the board's declared min_hole_clearance and
+                    # the `clearance` comes back in downstream. So `lc` was
+                    # the only missing term, and this is one term added, not
+                    # a re-derivation. Measured on kicad_files/ulx3s.kicad_pcb,
+                    # AUDIO1's two 1.7mm NPTH holes at lc=0.400: 1.050mm
+                    # modelled vs 1.250mm required at --clearance 0.10, and
+                    # 1.100 vs 1.250 at 0.25. RAISE-ONLY -- `max` with a
+                    # non-negative term -- so a board with no NPTH override,
+                    # which is 21 of the 22 tracked ones, is byte-identical.
+                    # (watchy's 8 NPTH overrides are all 0.100, below the 0.20
+                    # fab floor, so that board stays inert and is this rule's
+                    # negative control rather than a second example.)
                     if (p.drill or 0) > 0:
-                        grow = max(0.0, self.npth_floor - clearance)
+                        lc = getattr(p, 'local_clearance', 0.0) or 0.0
+                        grow = max(0.0, max(self.npth_floor, lc) - clearance)
                         for hx, hy, hd in pad_drill_circles(p):
                             hr = hd / 2.0 + grow
                             self.foreign_pads.append(

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -1845,11 +1845,23 @@ def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
             # exactly the case this warning exists to surface, and priced flat
             # it under-reported it.
             pfl = st.pad_floor(p) if _carries else None
-            for vx, vy, vnet, keepout in st.vias:
+            _radii = st._via_radius_by_id
+            for t in st.vias:
+                vx, vy, vnet, keepout = t
                 if vnet == p.net_id:
                     continue
-                ko = (keepout - st._item_reach(st.via_floor(vnet))
-                      + st.via_required(pfl, vnet))
+                # #732: the radius comes from the MAP, never from
+                # `keepout - _item_reach(...)`. That subtraction is the exact
+                # arithmetic re-derivation the map's own comment forbids, and
+                # it re-prices a tuple a test assigned wholesale with its own
+                # keep-out convention. Absent from the map -> the tuple's own
+                # keep-out slot verbatim, which is what via_penalty's flat path
+                # and _via_effs already do with such a tuple. Numerically
+                # identical for every via __init__ built, so this is inert on
+                # every real board (the #732 test file measures that).
+                _rec = _radii.get(id(t))
+                ko = (keepout if _rec is None
+                      else _rec[1] + st.via_required(pfl, vnet))
                 if _point_to_rect_dist(vx, vy, rect) < ko - EPS:
                     locked_hits.append((ref, p.pad_number, vx, vy))
     if locked_hits:

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -1082,8 +1082,16 @@ class _Repair:
                 return '<hole>'
             return names.get(net, str(net))
 
-        def best(floors_a, items, floor_of, net_of, only):
-            """Worst requirement, with its source, over the items on `only`."""
+        def best(floors_a, items, floor_of, net_of, only,
+                 cap_layers=None, layer_of=None, side_of=None):
+            """Worst requirement, with its source, over the items on `only`.
+
+            Takes the SAME two per-pad guards the eff builders take, because a
+            report that re-derives the price instead of mirroring it reports
+            pairs the pass never charged. Both were measured: without the
+            layer guard, up to 43% of the rows on rp2350 named a cap pad
+            against a track on a layer it does not occupy -- pairs check_drc
+            does not grade and `_seg_effs` prices at the flat scalar."""
             out = {}
             for t in items:
                 net = net_of(t)
@@ -1092,7 +1100,21 @@ class _Repair:
                 fb = floor_of(t)
                 if fb is None:
                     continue
-                for fa in floors_a:
+                # an SMD foreign pad on the other board side is skipped by
+                # _pad_shortfalls, so it charges nothing and belongs in no row
+                pside = None if side_of is None else side_of(t)
+                if pside is not None and pside != cap.side:
+                    continue
+                layer = None if layer_of is None else layer_of(t)
+                for i, fa in enumerate(floors_a):
+                    # a copper-less cap pad is graded flat, so it charges
+                    # nothing and belongs in no row
+                    if _Repair._flat_pad(cap_layers, i):
+                        continue
+                    # ...and neither does a pair that shares no copper layer
+                    if (layer is not None and cap_layers is not None
+                            and layer not in cap_layers[i]):
+                        continue
                     mm, src = pair_with_source(fa, fb)
                     if src and mm > out.get(net, (0.0, ''))[0]:
                         out[net] = (mm, src)
@@ -1117,18 +1139,21 @@ class _Repair:
                 out |= set(fn(ref, cap, x, y, rot))
                 return out
 
-            for kind, items, floor_of, net_of, charged in (
+            cl = self._cap_pad_layers(cap)
+            for kind, items, floor_of, net_of, charged, layer_of, side_of in (
                     ('pad', self.cap_foreign_pads[ref],
                      lambda t: self._fp_floor_by_id.get(id(t)), lambda t: t[4],
-                     both(self._pad_shortfalls)),
+                     both(self._pad_shortfalls), None, lambda t: t[5]),
                     ('via', self.cap_vias[ref],
                      lambda t: self._via_floor_for(t[2]), lambda t: t[2],
-                     both(self._via_shortfalls)),
+                     both(self._via_shortfalls), None, None),
                     ('track', self.cap_segs[ref],
                      lambda t: self._seg_floor_by_id.get(id(t)), lambda t: t[4],
-                     both(self._seg_shortfalls))):
+                     both(self._seg_shortfalls),
+                     lambda t: self._seg_layer_by_id.get(id(t)), None)):
                 for net, (mm, src) in best(fls, items, floor_of, net_of,
-                                           set(charged)).items():
+                                           set(charged), cl, layer_of,
+                                           side_of).items():
                     rows.append([ref, '{} {}'.format(kind, net_label(net)),
                                  round(mm, 6), src])
             # mover-vs-mover: the shortfall is a scalar per pair, so charge the
@@ -1150,8 +1175,13 @@ class _Repair:
                 if now <= EPS and was <= EPS:
                     continue
                 mm, src = 0.0, ''
-                for fa in fls:
-                    for fb in other.pad_floors:
+                theirs = self._cap_pad_layers(other)
+                for i, fa in enumerate(fls):
+                    if self._flat_pad(cl, i):
+                        continue
+                    for j, fb in enumerate(other.pad_floors):
+                        if self._flat_pad(theirs, j):
+                            continue
                         m, sc = pair_with_source(fa, fb)
                         if sc and m > mm:
                             mm, src = m, sc
@@ -1184,13 +1214,23 @@ class _Repair:
         effs = None if ref is None else self._via_effs(ref, cap, vias)
         pen = 0.0
         if effs is None:
+            # The tuple's slot is the prune OVER-reach, not a requirement, so
+            # grading it directly would charge more than any pair needs (and
+            # more than upstream's slot, which was radius + clearance). Recover
+            # the radius where we know it and grade at the flat scalar, which
+            # is what this path documents. A tuple absent from the map -- one a
+            # test assigned wholesale -- is graded exactly as injected.
+            by_id = self._via_radius_by_id
             for (bx0, by0, bx1, by1, net) in cap.pad_rects(x, y, rot):
-                for vx, vy, vnet, keepout in vias:
+                for v in vias:
+                    vx, vy, vnet, keepout = v
                     if vnet == net:
                         continue
+                    rec = by_id.get(id(v))
+                    ko = keepout if rec is None else rec[1] + self.clearance
                     d = _point_to_rect_dist(vx, vy, (bx0, by0, bx1, by1))
-                    if d < keepout - EPS:
-                        pen += (keepout - d)
+                    if d < ko - EPS:
+                        pen += (ko - d)
             return pen
         # #725 active path: effs[i][j] IS the pair's keep-out (via radius +
         # required clearance), precomputed -- the tuple's own keepout slot is
@@ -1551,12 +1591,16 @@ def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
         if fp is None:
             continue
         for p in fp.pads:
-            # #725: the copper predicate is the shared one. An np_thru_hole pad
-            # lists *.Cu and carries no copper, so the loose test named it here
-            # as a copper obstacle -- and would have charged its keep-clear
-            # override besides.
-            if not _pad_carries_copper(p):
+            # #725: an np_thru_hole pad lists *.Cu and carries no copper. It
+            # is still WARNED ABOUT -- upstream did, foreign_pads does, and a
+            # via inside a 1.7mm mounting hole is exactly what this warning is
+            # for -- but it is graded FLAT: its keep-clear override is not
+            # copper and must not raise the pair. Dropping it outright (the
+            # first version of this fix) removed real rows on boards that
+            # declare nothing at all.
+            if not any(str(l).endswith('.Cu') for l in p.layers):
                 continue
+            _carries = _pad_carries_copper(p)
             # ...and the RECT gets the same rect_rotation inflation _Cap and
             # foreign_pads use. This was the one pad-geometry site in the file
             # built from raw size_x/size_y, so a tilted locked pad under-blocked
@@ -1574,7 +1618,7 @@ def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
             # from the via's radius. A locked fiducial's keep-clear override is
             # exactly the case this warning exists to surface, and priced flat
             # it under-reported it.
-            pfl = st.pad_floor(p)
+            pfl = st.pad_floor(p) if _carries else None
             for vx, vy, vnet, keepout in st.vias:
                 if vnet == p.net_id:
                     continue
@@ -1881,9 +1925,21 @@ def nudge_vias_for_unresolved(st, pcb_data, clearance: float,
     def cap_floors_of(cap, rects):
         """This cap's per-pad floors, index-aligned with `rects` -- or None,
         which grades flat. Tests drive this function with a duck-typed cap that
-        carries neither the attribute nor a matching length."""
+        carries neither the attribute nor a matching length.
+
+        A pad whose `pad_layers` entry is EMPTY carries no copper, and its
+        entry comes back None so it grades flat here too. The eff builders key
+        on that same marker; without it the nudger would charge a phantom the
+        grader does not, hand itself a via nothing flagged, and print an
+        operator-facing line naming a non-violation.
+        """
         pf = getattr(cap, 'pad_floors', None)
-        return pf if (pf is not None and len(pf) == len(rects)) else None
+        if pf is None or len(pf) != len(rects):
+            return None
+        pl = getattr(cap, 'pad_layers', None)
+        if pl is None or len(pl) != len(pf):
+            return list(pf)
+        return [f if pl[i] else None for i, f in enumerate(pf)]
 
     # `all_cap_rects` is function-local, so it CAN carry the pad's floor.
     all_cap_rects = []

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -2076,8 +2076,27 @@ def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
     Run AFTER bga_fanout.py.
 
     Returns a dict with 'placements' (list of {reference,new_x,new_y,
-    new_rotation} for moved caps), 'resolved', 'unresolved' (refs still
-    grazing foreign copper), and 'bga_refs'.
+    new_rotation} for moved caps), 'resolved', 'unresolved', 'bga_refs',
+    'via_moves', 'new_segments', 'required' and 'clearance_notes'.
+
+    'resolved' and 'unresolved' are graded together, from ONE board state, at
+    the very END of the pass (#746) -- so they are disjoint, and 'resolved'
+    credits the via-nudge for a cap only the nudge could free. Read them as:
+
+      resolved     was grazing at the SEED and is clean now. A subset of the
+                   initial violators, so len(resolved) <= the V printed below.
+      unresolved   is grazing NOW, whatever it was at the seed. NOT a subset
+                   of the initial violators: copper this pass itself drew can
+                   put a cap here that started clean.
+      via_resolved the caps in 'resolved' that the cap-move descent could not
+                   clean and the via-nudge did -- the last resort's credit,
+                   which before #746 landed in neither list.
+      regrazed     the caps the descent DID clean and a connector this same
+                   pass then drew grazes. They are in 'unresolved' and not in
+                   'resolved'; this key names the cause, which is us.
+
+    The two early returns below carry neither 'via_resolved' nor 'regrazed',
+    exactly as they carry no 'via_moves' / 'new_segments' -- see the note there.
 
     via_clear_fallback (#213): when True (default), any cap the normal cost
     descent leaves grazing foreign copper is jumped to the nearest position
@@ -2129,8 +2148,9 @@ def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
           f"movable near-BGA caps: {len(st.caps)}")
     # #725: the early returns carry 'required' / 'clearance_notes' too, so a
     # caller does not have to special-case a no-op board for them. (They still
-    # omit 'via_moves' / 'new_segments', as they always have -- every caller
-    # reads the dict with .get.)
+    # omit 'via_moves' / 'new_segments' -- and, since #746, 'via_resolved' /
+    # 'regrazed' -- as they always have: every caller reads the dict with .get,
+    # and all four describe a via-nudge that provably did not happen here.)
     if not st.vias:
         print("No vias on the board - run this AFTER bga_fanout.py.")
         return {'placements': [], 'resolved': [], 'unresolved': [],
@@ -2342,19 +2362,37 @@ def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
             gc.enable()
 
     placements = []
-    resolved = []
     for ref, cap in st.caps.items():
         moved = (abs(cap.x - cap.seed_x) > EPS or abs(cap.y - cap.seed_y) > EPS
                  or abs(cap.rot - cap.seed_rot) > EPS)
         if moved:
             placements.append({'reference': ref, 'new_x': cap.x,
                                'new_y': cap.y, 'new_rotation': cap.rot})
-        if (ref in violators0
-                and st.graze_penalty(ref, cap, cap.x, cap.y, cap.rot) <= EPS):
-            resolved.append(ref)
-    unresolved = [r for r in st.caps
-                  if st.graze_penalty(r, st.caps[r], st.caps[r].x,
-                                      st.caps[r].y, st.caps[r].rot) > EPS]
+
+    # #746: ONE grader, so `resolved` and `unresolved` can never be read off
+    # two different boards. They were: `resolved` was built here and never
+    # refreshed, while `unresolved` was rebuilt after the via-nudge below --
+    # so a cap the NUDGE freed was grazing when the credit was computed and
+    # clean when the debit was, and appeared in neither list.
+    #
+    # Disjoint by construction, and the order of `st.caps` is preserved in
+    # both: a ref that grazes NOW is unresolved and cannot also be credited;
+    # only a still-clean ref that was a SEED violator is. Note the asymmetry
+    # is deliberate -- `resolved` is gated on `violators0` (you cannot resolve
+    # what was never broken) and `unresolved` is not (copper this pass drew
+    # can break a cap that started clean, which is #736's whole finding).
+    def _grade():
+        res, unres = [], []
+        for ref, cap in st.caps.items():
+            if st.graze_penalty(ref, cap, cap.x, cap.y, cap.rot) > EPS:
+                unres.append(ref)
+            elif ref in violators0:
+                res.append(ref)
+        return res, unres
+
+    resolved, unresolved = _grade()
+    via_resolved: List[str] = []
+    regrazed: List[str] = []
 
     # Last resort (#313): a cap still grazing at the displacement cap is
     # usually BOXED (no clear cap position exists) -- move the offending
@@ -2415,19 +2453,38 @@ def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
             # to know: from here st.base_seg and st.cap_segs describe different
             # boards, which is what "baseline" means rather than a defect.
             #
-            # KNOWN GAP, deliberately not closed here: `resolved` above is
-            # computed BEFORE the nudge and is not refreshed, so a cap the
-            # sweep cleaned and a connector then grazes can appear in both
-            # lists. That is older than #736 and a different failure mode.
-            unresolved = [r for r in st.caps
-                          if st.graze_penalty(r, st.caps[r], st.caps[r].x,
-                                              st.caps[r].y, st.caps[r].rot) > EPS]
+            # #746: BOTH lists are re-graded here, from the one view the two
+            # refreshes above just established. This is what closes the gap
+            # this comment used to declare open ("`resolved` is computed
+            # BEFORE the nudge and is not refreshed"), in both its directions:
+            # a cap the NUDGE freed is now credited instead of vanishing from
+            # both lists, and a cap the SWEEP cleaned that a connector then
+            # grazes now leaves `resolved` instead of sitting in both.
+            #
+            # The two deltas are taken against `swept` -- the pre-nudge credit
+            # -- and NOT recomputed from a penalty, because "who fixed it" is
+            # a fact about the transition and not about either end state. Set
+            # semantics on lists: `st.caps` has one entry per ref, so `swept`
+            # and `resolved` carry no duplicates and `in` is exact.
+            swept = resolved
+            resolved, unresolved = _grade()
+            via_resolved = [r for r in resolved if r not in swept]
+            regrazed = [r for r in swept if r not in resolved]
 
+    # #746: the credit clause says WHO freed the cap, because `resolved` now
+    # spans both mechanisms and a bare count cannot distinguish them. Both
+    # clauses are suppressed when empty, so a run that never reaches the
+    # via-nudge prints exactly the line it printed before.
+    _credit = (f" ({len(via_resolved)} freed by via-nudge)"
+               if via_resolved else "")
     print(f"Moved {len(placements)} cap(s); resolved {len(resolved)}/"
-          f"{len(violators0)} initial violations; "
+          f"{len(violators0)} initial violations{_credit}; "
           f"{len(unresolved)} unresolved.")
     if unresolved:
         print(f"  Unresolved (need manual attention): {', '.join(sorted(unresolved))}")
+    if regrazed:
+        print(f"  Re-grazed by this pass's own connector copper: "
+              f"{', '.join(sorted(regrazed))}")
     # #725: disclose what was graded ABOVE the flat --clearance, and why.
     # Printed from the ENGINE so the CLI and the GUI plugin both inherit it.
     required = st.required_rows({n.net_id: n.name for n in pcb_data.nets.values()})
@@ -2440,6 +2497,7 @@ def repair_fanout_clearance(pcb_data: PCBData, pcb_file: str,
     return {'placements': placements, 'resolved': resolved,
             'unresolved': unresolved, 'bga_refs': st.bga_refs,
             'via_moves': via_moves, 'new_segments': new_segs,
+            'via_resolved': via_resolved, 'regrazed': regrazed,
             'required': required, 'clearance_notes': list(st.clearance_notes)}
 
 

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -170,6 +170,17 @@ class _Cap:
         # makes the alignment true by construction.
         self.pad_floors = []
         self.max_floor = 0.0
+        # Per-pad COPPER LAYER sets, index-aligned like pad_floors. Needed
+        # because self.segments records only an 'F'/'B' side and files an
+        # In1.Cu track under 'F' (a pre-existing model quirk), so an F-side cap
+        # pad is compared against inner-layer tracks it can never touch. That
+        # phantom is priced at the flat scalar today; without this set the
+        # NETCLASS term -- which is layer-blind -- would raise it too, and the
+        # pass would move caps to clear copper on a layer their pads do not
+        # occupy. Measured on orangecrab at --clearance 0.1 with a Default
+        # class of 0.3: R17/R18/R5's ENTIRE graze is that phantom, 0.082mm
+        # each flat and 0.70/0.70/0.57mm raised. See _seg_effs.
+        self.pad_layers = []
         for p in fp.pads:
             if not any(str(l).endswith('.Cu') for l in p.layers):
                 continue  # paste/mask-only aperture, not copper
@@ -195,6 +206,9 @@ class _Cap:
                 fl = (model.pad_floor(p) if _pad_carries_copper(p)
                       else PadFloor(0.0, 0.0, None))
                 self.pad_floors.append(fl)
+                from check_drc import pad_copper_layers
+                self.pad_layers.append(
+                    frozenset(pad_copper_layers(p, model.board_copper)))
                 mf = model.max_floor(fl)
                 if mf > self.max_floor:
                     self.max_floor = mf
@@ -408,11 +422,18 @@ class _Repair:
         # the model is inert. The 4-tuple shape is pinned: tests assign
         # st.vias wholesale and animate_fanout_clearance.py unpacks it.
         self.vias: List[Tuple[float, float, int, float]] = []
+        # The RADIUS, keyed on the tuple's identity. _via_effs has to strip the
+        # over-reach back off element 3, and deriving the radius arithmetically
+        # would silently mis-price a tuple a test assigned wholesale with a
+        # different keep-out convention. Absent from this map -> graded flat,
+        # which is the same fallback _pad_effs and _seg_effs already take.
+        self._via_radius_by_id: Dict[int, float] = {}
         for v in pcb_data.vias:
             size = v.size if v.size and v.size > 0 else default_via_size
-            self.vias.append((v.x, v.y, v.net_id,
-                              size / 2.0 + self._item_reach(
-                                  self._via_floor_for(v.net_id))))
+            t = (v.x, v.y, v.net_id,
+                 size / 2.0 + self._item_reach(self._via_floor_for(v.net_id)))
+            self.vias.append(t)
+            self._via_radius_by_id[id(t)] = size / 2.0
 
         # --- avoidance: foreign-net tracks on the cap's own side ---
         # Fanout escapes can land on the bottom (cap) side; attraction could
@@ -430,12 +451,17 @@ class _Repair:
         # tuples live for this object's lifetime, so the id is stable; a tuple a
         # test injects is simply absent and grades flat.
         self._seg_floor_by_id: Dict[int, PadFloor] = {}
+        # ...and its REAL layer, for the same reason: the pruned list is built
+        # on the F/B side collapse, so _seg_effs needs the true layer to tell a
+        # pair that shares copper from one that cannot.
+        self._seg_layer_by_id: Dict[int, str] = {}
         for s in pcb_data.segments:
             side = 'B' if (s.layer or '').startswith('B') else 'F'
             fl = self._seg_floor_for(s.net_id, s.layer)
             t = (s.start_x, s.start_y, s.end_x, s.end_y, s.net_id,
                  s.width / 2.0 + self._item_reach(fl), side)
             self.segments.append(t)
+            self._seg_layer_by_id[id(t)] = s.layer
             if fl is not None:
                 self._seg_floor_by_id[id(t)] = fl
 
@@ -492,6 +518,11 @@ class _Repair:
         # #725 is about, and it interacts with the #617 balance below; filed
         # separately. (watchy's 8 NPTH overrides are all 0.100, below the 0.20
         # fab floor, so that board is numerically inert here.)
+        # NB: self.foreign_pads (and self.segments) are read nowhere after
+        # __init__ -- the pruned per-cap lists are what the sweep uses. They
+        # must NOT be deleted as dead: the id-keyed floor maps below depend on
+        # those tuples staying alive, and a recycled id would return ANOTHER
+        # item's floor, silently, with no error.
         self.foreign_pad_floors: List[Optional[PadFloor]] = []
         self.foreign_pad_mf: List[float] = []
         self.caps: Dict[str, _Cap] = {}
@@ -897,8 +928,29 @@ class _Repair:
         floors = [by_id.get(id(t)) for t in src]
         # t[5] is half width + the segment's own over-reach; strip it back.
         halves = [t[5] - self._item_reach(f) for t, f in zip(src, floors)]
-        rows = [[halves[j] + self._pair_or_flat(fa, floors[j])
-                 for j in range(len(src))] for fa in cap.pad_floors]
+        # A pair that shares NO copper layer keeps the FLAT scalar. cap_segs is
+        # pruned on the 'F'/'B' side collapse, which files an In1.Cu track
+        # under 'F', so it contains F-pad/inner-track pairs that cannot touch.
+        # The dru term already scopes itself away from them (empty shared set),
+        # but the netclass term does not -- and raising a phantom is how this
+        # change would move caps for a non-violation. Charging it flat leaves
+        # the pre-existing phantom exactly as it was; removing it altogether is
+        # a separate fix to the side collapse, filed rather than folded in.
+        cap_layers = getattr(cap, 'pad_layers', None)
+        if cap_layers is not None and len(cap_layers) != len(cap.pad_floors):
+            cap_layers = None      # a duck-typed cap; grade flat
+        seg_layers = [self._seg_layer_by_id.get(id(t)) for t in src]
+
+        def eff(fa, mine, j):
+            sl = seg_layers[j]
+            if mine is not None and sl is not None and sl not in mine:
+                return self.clearance
+            return self._pair_or_flat(fa, floors[j])
+
+        rows = [[halves[j] + eff(fa, None if cap_layers is None
+                                 else cap_layers[i], j)
+                 for j in range(len(src))]
+                for i, fa in enumerate(cap.pad_floors)]
         self._cap_seg_eff[ref] = (src, rows)
         return rows
 
@@ -912,10 +964,18 @@ class _Repair:
         rec = self._cap_via_eff.get(ref)
         if rec is not None and rec[0] is vias:
             return rec[1]
-        # v[3] is radius + the via's own over-reach; strip it back to a radius.
-        radii = [v[3] - self._item_reach(self._via_floor_for(v[2])) for v in vias]
-        rows = [[radii[j] + self.via_required(fa, v[2])
-                 for j, v in enumerate(vias)] for fa in cap.pad_floors]
+        # The radius comes from the identity map, never from arithmetic on
+        # v[3]: a tuple a test assigned wholesale carries its own keep-out
+        # convention, and re-deriving would mis-price it silently. Absent ->
+        # graded flat, i.e. v[3] is used as-is.
+        by_id = self._via_radius_by_id
+        rows = []
+        for fa in cap.pad_floors:
+            row = []
+            for v in vias:
+                r = by_id.get(id(v))
+                row.append(v[3] if r is None else r + self.via_required(fa, v[2]))
+            rows.append(row)
         self._cap_via_eff[ref] = (vias, rows)
         return rows
 
@@ -927,6 +987,13 @@ class _Repair:
             return None
         key = (ref, oref)
         rows = self._cap_pair_eff.get(key)
+        # The other three memos guard on their source list's identity; this one
+        # has no list to key on, so it validates its own SHAPE instead. Both
+        # exist for the same reason: st.caps / st.cap_* are assignable from a
+        # test, and a stale memo here is an IndexError or a wrong requirement.
+        if rows is not None and (len(rows) != len(cap.pad_floors)
+                                 or (rows and len(rows[0]) != len(other.pad_floors))):
+            rows = None
         if rows is None:
             rows = [[self._pair_or_flat(fa, fb) for fb in other.pad_floors]
                     for fa in cap.pad_floors]
@@ -978,16 +1045,30 @@ class _Repair:
                 continue
             fls = cap.pad_floors
             x, y, rot = cap.x, cap.y, cap.rot
+            sx, sy, srot = cap.seed_x, cap.seed_y, cap.seed_rot
+
+            def both(fn):
+                """Nets charged at the SEED pose or the final one.
+
+                The seed half is the point: the pass SUCCEEDS by leaving
+                nothing charged, so a final-pose-only report is empty exactly
+                when the raised requirement did its work -- and the operator
+                could not tell a run graded at --clearance from one graded at
+                five times it."""
+                out = set(fn(ref, cap, sx, sy, srot))
+                out |= set(fn(ref, cap, x, y, rot))
+                return out
+
             for kind, items, floor_of, net_of, charged in (
                     ('pad', self.cap_foreign_pads[ref],
                      lambda t: self._fp_floor_by_id.get(id(t)), lambda t: t[4],
-                     self._pad_shortfalls(ref, cap, x, y, rot)),
+                     both(self._pad_shortfalls)),
                     ('via', self.cap_vias[ref],
                      lambda t: self._via_floor_for(t[2]), lambda t: t[2],
-                     self._via_shortfalls(ref, cap, x, y, rot)),
+                     both(self._via_shortfalls)),
                     ('track', self.cap_segs[ref],
                      lambda t: self._seg_floor_by_id.get(id(t)), lambda t: t[4],
-                     self._seg_shortfalls(ref, cap, x, y, rot))):
+                     both(self._seg_shortfalls))):
                 for net, (mm, src) in best(fls, items, floor_of, net_of,
                                            set(charged)).items():
                     rows.append([ref, '{} {}'.format(kind, net_label(net)),
@@ -995,13 +1076,20 @@ class _Repair:
             # mover-vs-mover: the shortfall is a scalar per pair, so charge the
             # pair as a whole and name it by the partner's reference.
             cand = cap.pad_rects(x, y, rot)
+            seed = cap.pad_rects(sx, sy, srot)
             for oref in self.cap_caps[ref]:
                 other = self.caps[oref]
                 if not self._cap_floors_ok(other):
                     continue
                 effs = self._pair_effs(ref, cap, oref, other)
-                if _pad_pair_shortfall(cand, other.pad_rects(),
-                                       self.clearance, effs) <= EPS:
+                # seed pose OR final pose, for the reason `both` gives above
+                now = _pad_pair_shortfall(cand, other.pad_rects(),
+                                          self.clearance, effs)
+                was = _pad_pair_shortfall(
+                    seed, other.pad_rects(other.seed_x, other.seed_y,
+                                          other.seed_rot),
+                    self.clearance, effs)
+                if now <= EPS and was <= EPS:
                     continue
                 mm, src = 0.0, ''
                 for fa in fls:

--- a/py_placer/placement/labels.py
+++ b/py_placer/placement/labels.py
@@ -293,7 +293,15 @@ def beautify_labels(pcb_data, pcb_file: Optional[str],
     if edge_margin is None:
         edge_margin = 0.55
 
-    part_pads = build_part_pads(footprints, config.silk_pad_clearance)
+    # copper_holes=False (#730): these circles keep label INK off a drill,
+    # and an NPTH pad's `(clearance ...)` is a COPPER rule -- KiCad has no
+    # silk-to-hole rule at all. Honouring it here would push a reference
+    # designator further from a mounting hole for a reason that does not
+    # apply to silkscreen (measured on ulx3s: 0.20mm, at the shipped
+    # silk_pad_clearance of 0.15). The copper consumers in legality.py take
+    # the default.
+    part_pads = build_part_pads(footprints, config.silk_pad_clearance,
+                                copper_holes=False)
     pad_rects = {'F': [], 'B': []}   # (x0, y0, x1, y1)
     hole_circles = []                # (cx, cy, r) -- drills go through: both sides
     for ref, pp in part_pads.items():

--- a/py_placer/placement/labels.py
+++ b/py_placer/placement/labels.py
@@ -310,6 +310,11 @@ def beautify_labels(pcb_data, pcb_file: Optional[str],
                                                           fp.rotation):
             for s in (('F', 'B') if pside is None else (pside,)):
                 pad_rects[s].append((x0, y0, x1, y1))
+        # `hole_circles`, deliberately, NOT `hole_keepouts` (#761): silk adds
+        # its own term below (`< config.silk_pad_clearance`), so this consumer
+        # was already complete -- and the keep-out accessor carries a COPPER
+        # requirement, which is the same reason build_part_pads above asks for
+        # copper_holes=False.
         hole_circles.extend(pp.hole_circles(fp.x, fp.y, fp.rotation))
 
     gate = BoardOutlineGate(pcb_data.board_info, edge_margin)

--- a/py_placer/placement/legality.py
+++ b/py_placer/placement/legality.py
@@ -1597,11 +1597,19 @@ class PartPads:
     `pad_rects`' 6-tuple is deliberately NOT widened to carry the floor: it is a
     public shape (render_placement slices `r[:4]`, two test modules unpack it
     positionally) and the rect index already addresses the pad.
+
+    NPTH holes are carried TWICE (#730), index-aligned: `holes_local` at the
+    copper KEEP-OUT radius that `hole_circles()` serves, and `holes_extent` at
+    the radius `extent_local()` needs. They differ only by the hole pad's own
+    `local_clearance`, and only when a caller asks for it -- but the two
+    questions are different in kind ("how close may copper come" versus "where
+    is this part"), and answering the second with the first lets an author's
+    keep-clear declaration push a part off the board outline.
     """
 
     __slots__ = ('ref', 'side', 'has_tht', 'seed_rot', 'pads_local',
-                 'holes_local', 'n_pads', '_pad_cache', '_hole_cache',
-                 '_ext_cache', 'pad_floors', 'max_floor')
+                 'holes_local', 'holes_extent', 'n_pads', '_pad_cache',
+                 '_hole_cache', '_ext_cache', 'pad_floors', 'max_floor')
 
     def __init__(self, fp, clearance: float, model=None,
                  copper_holes: bool = True):
@@ -1617,6 +1625,7 @@ class PartPads:
         self.seed_rot = (fp.rotation or 0.0) % 360
         self.pads_local = []    # (off_x, off_y, half_x, half_y, net_id, pside)
         self.holes_local = []   # (off_x, off_y, radius) -- NPTH keepouts, inflated
+        self.holes_extent = []  # ...the same holes at their EXTENT radius (#730)
         self.pad_floors = []    # PadFloor per copper pad, index-aligned (#697)
         self.max_floor = 0.0    # upper bound on this part's pad requirements
         for p in fp.pads:
@@ -1668,9 +1677,24 @@ class PartPads:
                            if copper_holes else 0.0)
                     npth_grow = max(0.0, max(defaults.NPTH_TO_TRACK_CLEARANCE,
                                              _lc) - clearance)
+                    # ...and the SAME holes without the override, for extents.
+                    # `holes_local` is a copper KEEP-OUT and `extent_local` is
+                    # a question about where the part physically IS -- an
+                    # author's copper keep-clear must not make a part read as
+                    # hanging off the board outline. Measured on
+                    # splitflap_driver at --clearance 0.25, injecting lc on
+                    # H6/H7's NPTH pads only: without this split, lc 0.90 takes
+                    # `oob_pad_count` from 0 to 2 and lc 0.95 puts both refs in
+                    # the seeder's ZERO-margin off-board census, which
+                    # CLAUDE.md calls the top-priority placement defect. This
+                    # keeps every extent byte-identical to pre-#730.
+                    ext_grow = max(0.0, defaults.NPTH_TO_TRACK_CLEARANCE
+                                   - clearance)
                     for hx, hy, hd in pad_drill_circles(p):
                         self.holes_local.append(
                             (hx - fp.x, hy - fp.y, hd / 2.0 + npth_grow))
+                        self.holes_extent.append(
+                            (hx - fp.x, hy - fp.y, hd / 2.0 + ext_grow))
                 continue
             copper = [l for l in p.layers if str(l).endswith('.Cu')]
             through = (p.drill or 0) > 0
@@ -1742,7 +1766,14 @@ class PartPads:
             for ox, oy, HX, HY, _n, _s in self._rotated(rot):
                 xs0.append(ox - HX); ys0.append(oy - HY)
                 xs1.append(ox + HX); ys1.append(oy + HY)
-            for cx, cy, r in self.hole_circles(0.0, 0.0, rot):
+            # #730: the EXTENT radii, not the keep-out ones -- see the note
+            # beside holes_extent. `_rotated`-style rotation done inline
+            # because holes rotate about the part origin exactly as
+            # hole_circles rotates them.
+            rad = math.radians(-key)
+            hc, hs = math.cos(rad), math.sin(rad)
+            for ox, oy, r in self.holes_extent:
+                cx, cy = ox * hc - oy * hs, ox * hs + oy * hc
                 xs0.append(cx - r); ys0.append(cy - r)
                 xs1.append(cx + r); ys1.append(cy + r)
             if not xs0:

--- a/py_placer/placement/legality.py
+++ b/py_placer/placement/legality.py
@@ -1577,7 +1577,8 @@ class PadClearanceModel:
         return eff, src
 
 
-def resolve_npth_floor(pcb_data) -> float:
+def resolve_npth_floor(pcb_data, pcb_file: str = None,
+                       notes: list = None) -> float:
     """The board's copper-to-NPTH-hole FLOOR: the JLC fab floor, raised to the
     board's own declared `min_hole_clearance` when it declares more (#761).
 
@@ -1598,8 +1599,18 @@ def resolve_npth_floor(pcb_data) -> float:
     `local_clearance` 0.0 -- so it is the single witness that this term fires
     at all, and every other board resolves to 0.2000.
 
+    `pcb_file` follows the #498 rule every sibling here follows -- the
+    CALLER's path when it has one, else `PCBData.source_path`. It is not
+    decoration: a board staged into a temp dir and parsed from there carries a
+    `source_path` that is not the board the caller means, and flat_hierarchy
+    staged that way resolves 0.2000 where the real path resolves 0.2500 --
+    which is exactly the 2.3500 -> 2.4000 radius this term exists for.
+
     Returns the plain fab floor when the board cannot be read, which is what a
-    caller with no board gets by default.
+    caller with no board gets by default. `notes` collects WHY, if a list is
+    given: a silent fallback here drops the modelled floor by up to the
+    declared value and reports a byte-identical census, which is the shape of
+    silence this issue was filed about.
     """
     import routing_defaults as defaults
     floor = float(defaults.NPTH_TO_TRACK_CLEARANCE)
@@ -1607,8 +1618,13 @@ def resolve_npth_floor(pcb_data) -> float:
         return floor
     try:
         from obstacle_map import resolve_hole_clearance
-        return max(floor, float(resolve_hole_clearance(pcb_data, None)))
-    except Exception:                                            # noqa: BLE001
+        return max(floor,
+                   float(resolve_hole_clearance(pcb_data, None, pcb_file)))
+    except Exception as e:                                       # noqa: BLE001
+        if notes is not None:
+            notes.append('copper-to-hole floor unresolved (%s: %s); the NPTH '
+                         'keep-out falls back to the %.2fmm fab floor'
+                         % (type(e).__name__, e, floor))
         return floor
 
 
@@ -2043,11 +2059,19 @@ class LegalityContext:
         # by the board-wide maximum -- this test runs per candidate pose
         # (quench.candidate_valid -> pads_ok), so a board-wide bound would slow
         # every pair on the board for the sake of one fiducial.
-        reach = (self.clearance if model is None
-                 else max(self.clearance, model.base,
-                          pa.max_floor, pb.max_floor))
+        pad_reach = (self.clearance if model is None
+                     else max(self.clearance, model.base,
+                              pa.max_floor, pb.max_floor))
         # ...and the hole keep-outs, which no pad floor accounts for (#761).
-        reach = max(reach, pa.hole_reach, pb.hole_reach)
+        # Kept as a SEPARATE name: the cap branch below charges its shortfall
+        # into the PAD channel, and folding the hole requirement into the
+        # number it charges bills one physical violation to two independent
+        # gates (`pads_ok` tests `cur.pad` and `cur.hole` as separate
+        # conjuncts, and quench sums `sf.hole` on its own). Measured on one
+        # hole at lc 1.0 with pads 0.30 off the wall, the only difference
+        # being the pad-pair product: 60x60 -> pad 0.0000, 70x70 -> pad
+        # 0.7000, hole 0.7000 in both.
+        reach = max(pad_reach, pa.hole_reach, pb.hole_reach)
         if rect_gap(ea, eb) >= reach - EPS:
             return ZERO_SHORTFALL
         rects_a = pa.pad_rects(xa, ya, ra)
@@ -2067,7 +2091,7 @@ class LegalityContext:
             # corpus-reachable, not theoretical: J5 is the one part on the 22
             # tracked boards whose product exceeds the cap.
             g = rect_gap(ea, eb)
-            return PairShortfall(max(0.0, reach - g), g < 0.0,
+            return PairShortfall(max(0.0, pad_reach - g), g < 0.0,
                                  _hole_shortfall(pa, xa, ya, ra, rects_b,
                                                  pb, xb, yb, rb, rects_a),
                                  g < 0.0)
@@ -2254,8 +2278,9 @@ def grade_pad_legality(pcb_data, clearance: float, exact: bool = True,
     # extents (legality's pad_intersection channel, routability, seeder's
     # off-board census) deliberately do not: for them the term would resolve a
     # board and change nothing.
-    parts = build_part_pads(fps, clearance, model,
-                            npth_floor=resolve_npth_floor(pcb_data))
+    parts = build_part_pads(
+        fps, clearance, model,
+        npth_floor=resolve_npth_floor(pcb_data, pcb_file, clearance_notes))
     routing_layers = list(getattr(pcb_data.board_info, 'copper_layers', []) or [])
     check_exact = None
     if exact:
@@ -2396,9 +2421,20 @@ def grade_pad_legality(pcb_data, clearance: float, exact: bool = True,
                         hole_req = req
             if hole_pen > EPS:
                 hole_conflicts += 1
-                # Above the board-wide clearance only -- the same bar the pad
-                # channel applies before it files a row, so a plain hole at the
-                # flat scalar stays quiet.
+                # Above the board-wide clearance only, so a plain hole at the
+                # flat scalar stays quiet. NOT literally the pad channel's
+                # bar, which is `pair_source != ''` and therefore sits at
+                # `model.base` -- the two differ when a netclass lifts
+                # `model.base` above `--clearance`, and "the same bar" would
+                # be wrong in exactly that case.
+                #
+                # DISCLOSED, not fixed: the hole channel files into `required`
+                # but not into `worst`, so a hole-ONLY conflict is printed by
+                # `format_required_clause` and is invisible to
+                # `floorplan.suspect_pairs`, which is built from `worst`.
+                # Widening `worst` changes what `place_seed --repair` chooses
+                # to move -- a placement-behaviour change needing its own
+                # before/after, not a rider on an arithmetic fix.
                 if hole_req > clearance + 1e-9:
                     required.append([key[0], key[1], round(hole_req, 4),
                                      'NPTH hole'])

--- a/py_placer/placement/legality.py
+++ b/py_placer/placement/legality.py
@@ -1721,7 +1721,7 @@ class PartPads:
                 # `_pair_or_flat` (an NPTH tuple files floor `None`, so it
                 # hands back the flat scalar, fanout_clearance.py:894/1306),
                 # and labels.py by comparing against `silk_pad_clearance`
-                # (labels.py:394). legality compared this circle against RAW
+                # (labels.py:399). legality compared this circle against RAW
                 # pad rects and added nothing, so its modelled standoff was
                 # `max(0, requirement - clearance)` -- which collapses to ZERO
                 # once `clearance` reaches the requirement, at 0.20 for a plain
@@ -1878,7 +1878,7 @@ class PartPads:
 
         A copper consumer wants `hole_keepouts` instead. This accessor exists
         for the caller that adds its own term at its own gap test: labels.py
-        (silk, `< config.silk_pad_clearance`, labels.py:394).
+        (silk, `< config.silk_pad_clearance`, labels.py:399).
         """
         key = self._delta_key(rot)
         cache = self._hole_cache.get(key)
@@ -2090,14 +2090,17 @@ class LegalityContext:
             # constrains the pair.
             #
             # The HOLE channel is measured anyway (#761). The cap exists for
-            # the pad x pad product; the hole loops are holes x pads, which is
-            # two orders smaller on every part that trips it -- glasgow_revC's
-            # J5 is 44 pads x 4 holes against a 121-pad neighbour, so 5324
-            # pad pairs but 660 hole tests. Returning a hardcoded `hole=0.0`
-            # here made `cur.hole > base.hole` unable to fire for exactly the
-            # dense connectors that carry mounting holes, and that is
-            # corpus-reachable, not theoretical: J5 is the one part on the 22
-            # tracked boards whose product exceeds the cap.
+            # the pad x pad product; the hole loops are holes x pads, an order
+            # smaller on the one part that trips it -- glasgow_revC's J5 is 44
+            # pads and 2 NPTH drill circles against a 121-pad neighbour that
+            # has none, so 5324 pad pairs against 242 hole tests, a factor of
+            # 22. (First written as "4 holes / 660 tests / two orders", which
+            # a fact-check re-measured; the numbers are here rather than in a
+            # commit message so the next reader can check them.) Returning a
+            # hardcoded `hole=0.0` here made `cur.hole > base.hole` unable to
+            # fire for exactly the dense connectors that carry mounting holes,
+            # and that is corpus-reachable, not theoretical: J5 is the one part
+            # on the 22 tracked boards whose product exceeds the cap.
             g = rect_gap(ea, eb)
             return PairShortfall(max(0.0, pad_reach - g), g < 0.0,
                                  _hole_shortfall(pa, xa, ya, ra, rects_b,

--- a/py_placer/placement/legality.py
+++ b/py_placer/placement/legality.py
@@ -1645,7 +1645,7 @@ class PartPads:
     __slots__ = ('ref', 'side', 'has_tht', 'seed_rot', 'pads_local',
                  'holes_local', 'holes_extent', 'n_pads', '_pad_cache',
                  '_hole_cache', '_keepout_cache', '_ext_cache', 'pad_floors',
-                 'max_floor', 'clearance', 'hole_reach')
+                 'max_floor', 'clearance', 'hole_reach', 'holes_req')
 
     def __init__(self, fp, clearance: float, model=None,
                  copper_holes: bool = True, npth_floor: float = None):
@@ -1668,6 +1668,7 @@ class PartPads:
         self.pads_local = []    # (off_x, off_y, half_x, half_y, net_id, pside)
         self.holes_local = []   # (off_x, off_y, radius) -- NPTH keepouts, inflated
         self.holes_extent = []  # ...the same holes at their EXTENT radius (#730)
+        self.holes_req = []     # ...and the REQUIREMENT each one resolved to (#761)
         self.pad_floors = []    # PadFloor per copper pad, index-aligned (#697)
         self.max_floor = 0.0    # upper bound on this part's pad requirements
         _npth_floor = (defaults.NPTH_TO_TRACK_CLEARANCE if npth_floor is None
@@ -1755,11 +1756,18 @@ class PartPads:
                     # stops a declaration from pushing a part off the outline.
                     ext_grow = max(0.0, defaults.NPTH_TO_TRACK_CLEARANCE
                                    - clearance)
+                    # The resolved requirement itself, for DISCLOSURE
+                    # (#761). Derivable from the radius only with `hd/2` in
+                    # hand, which no consumer has -- and a census that counts
+                    # a conflict without naming what it required is the same
+                    # shape of silence #697 fixed for the pad channel.
+                    npth_req = max(clearance, _npth_floor, _lc)
                     for hx, hy, hd in pad_drill_circles(p):
                         self.holes_local.append(
                             (hx - fp.x, hy - fp.y, hd / 2.0 + npth_grow))
                         self.holes_extent.append(
                             (hx - fp.x, hy - fp.y, hd / 2.0 + ext_grow))
+                        self.holes_req.append(npth_req)
                 continue
             copper = [l for l in p.layers if str(l).endswith('.Cu')]
             through = (p.drill or 0) > 0
@@ -2328,17 +2336,36 @@ def grade_pad_legality(pcb_data, clearance: float, exact: bool = True,
                 if pair_source:
                     required.append([key[0], key[1],
                                      round(pair_required, 4), pair_source])
+            # #761: the hole channel discloses its requirement too. It used
+            # to report a bare `hole_conflicts` count with the mm thrown away,
+            # so a user saw that a mounting hole was too close to something
+            # without ever being told how close it was allowed to be -- and
+            # that number is not the board-wide clearance whenever the hole
+            # pad declares an override or the board declares a floor.
             hole_pen = 0.0
-            for cx, cy, r in holes_b:
+            hole_req = 0.0
+            for (cx, cy, r), req in zip(holes_b, parts[other].holes_req):
                 for a0, a1, a2, a3, _na, _sa in rects_a:
-                    hole_pen += _circle_rect_penetration(cx, cy, r,
-                                                         (a0, a1, a2, a3))
-            for cx, cy, r in holes_a:
+                    pen = _circle_rect_penetration(cx, cy, r,
+                                                   (a0, a1, a2, a3))
+                    hole_pen += pen
+                    if pen > EPS and req > hole_req:
+                        hole_req = req
+            for (cx, cy, r), req in zip(holes_a, parts[ref].holes_req):
                 for b0, b1, b2, b3, _nb, _sb in rects_b:
-                    hole_pen += _circle_rect_penetration(cx, cy, r,
-                                                         (b0, b1, b2, b3))
+                    pen = _circle_rect_penetration(cx, cy, r,
+                                                   (b0, b1, b2, b3))
+                    hole_pen += pen
+                    if pen > EPS and req > hole_req:
+                        hole_req = req
             if hole_pen > EPS:
                 hole_conflicts += 1
+                # Above the board-wide clearance only -- the same bar the pad
+                # channel applies before it files a row, so a plain hole at the
+                # flat scalar stays quiet.
+                if hole_req > clearance + 1e-9:
+                    required.append([key[0], key[1], round(hole_req, 4),
+                                     'NPTH hole'])
 
     oob_count = 0
     oob_amount = 0.0

--- a/py_placer/placement/legality.py
+++ b/py_placer/placement/legality.py
@@ -1609,7 +1609,8 @@ class PartPads:
 
     __slots__ = ('ref', 'side', 'has_tht', 'seed_rot', 'pads_local',
                  'holes_local', 'holes_extent', 'n_pads', '_pad_cache',
-                 '_hole_cache', '_ext_cache', 'pad_floors', 'max_floor')
+                 '_hole_cache', '_keepout_cache', '_ext_cache', 'pad_floors',
+                 'max_floor', 'clearance')
 
     def __init__(self, fp, clearance: float, model=None,
                  copper_holes: bool = True):
@@ -1623,6 +1624,12 @@ class PartPads:
         self.side = footprint_side(fp)
         self.has_tht = footprint_has_through_pads(fp)
         self.seed_rot = (fp.rotation or 0.0) % 360
+        # The flat clearance this part was built at. Stored (#761) because the
+        # NPTH keep-out radius is only complete WITH it -- see hole_keepouts --
+        # and a consumer that had to supply it separately is a consumer that
+        # can forget to, which is exactly how the keep-out came to be graded
+        # without one.
+        self.clearance = float(clearance)
         self.pads_local = []    # (off_x, off_y, half_x, half_y, net_id, pside)
         self.holes_local = []   # (off_x, off_y, radius) -- NPTH keepouts, inflated
         self.holes_extent = []  # ...the same holes at their EXTENT radius (#730)
@@ -1631,10 +1638,25 @@ class PartPads:
         for p in fp.pads:
             if not _pad_carries_copper(p):
                 # Copper-less drilled pad (NPTH mounting hole): the DRILL still
-                # removes copper closer than the NPTH-to-track floor. Inflation
-                # matches fanout_clearance's foreign-pad keepouts. A
+                # removes copper closer than the NPTH-to-track floor. A
                 # paste/mask-only aperture has neither copper nor a hole and
                 # simply drops out.
+                #
+                # The inflation matches fanout_clearance's foreign-pad
+                # keepouts -- and the inflation is only HALF of the rule
+                # (#761). What is stored here is the growth ABOVE `clearance`;
+                # the requirement is that radius PLUS `clearance`, which each
+                # sibling adds at its own gap test: fanout_clearance through
+                # `_pair_or_flat` (an NPTH tuple files floor `None`, so it
+                # hands back the flat scalar, fanout_clearance.py:894/1306),
+                # and labels.py by comparing against `silk_pad_clearance`
+                # (labels.py:391). legality compared this circle against RAW
+                # pad rects and added nothing, so its modelled standoff was
+                # `max(0, requirement - clearance)` -- which collapses to ZERO
+                # once `clearance` reaches the requirement, at 0.20 for a plain
+                # hole and 0.40 for ulx3s's AUDIO1. The inflation matched; the
+                # COMPARISON did not, and only the inflation was ever checked.
+                # `hole_keepouts()` is now the one place that composes both.
                 #
                 # #730: ...or closer than the pad's OWN `(clearance ...)`
                 # override, when that is larger. That is what KiCad enforces
@@ -1715,6 +1737,7 @@ class PartPads:
         self.n_pads = len(self.pads_local)
         self._pad_cache: Dict[float, list] = {}
         self._hole_cache: Dict[float, list] = {}
+        self._keepout_cache: Dict[float, list] = {}
         self._ext_cache: Dict[float, Tuple[float, float, float, float]] = {}
 
     def _delta_key(self, rot: float) -> float:
@@ -1745,7 +1768,13 @@ class PartPads:
         return out
 
     def hole_circles(self, x: float, y: float, rot: float):
-        """[(cx, cy, radius)] NPTH keepout circles at the given pose."""
+        """[(cx, cy, radius)] NPTH hole circles at the given pose, at the
+        INFLATION radius -- the growth above `clearance`, not the requirement.
+
+        A copper consumer wants `hole_keepouts` instead. This accessor exists
+        for the caller that adds its own term at its own gap test: labels.py
+        (silk, `< config.silk_pad_clearance`, labels.py:391).
+        """
         key = self._delta_key(rot)
         cache = self._hole_cache.get(key)
         if cache is None:
@@ -1754,6 +1783,33 @@ class PartPads:
             cache = [(ox * c - oy * s, ox * s + oy * c, r)
                      for ox, oy, r in self.holes_local]
             self._hole_cache[key] = cache
+        return [(x + ox, y + oy, r) for ox, oy, r in cache]
+
+    def hole_keepouts(self, x: float, y: float, rot: float):
+        """[(cx, cy, radius)] NPTH COPPER keep-out circles at the given pose.
+
+        The one resolver for "how close may foreign copper come to this hole"
+        (#761). It is `hole_circles`' radius PLUS the flat clearance, because
+        the stored growth is `max(0, requirement - clearance)`; adding the
+        clearance back composes, per hole, to
+
+            hd/2 + max(clearance, NPTH floor, the hole pad's local_clearance)
+
+        -- a MAX rather than a sum, since the growth is already floored at 0.
+        That is `check_drc`'s own requirement (`max(npth_clr, lc)`,
+        check_drc.py:2733) and what fanout_clearance's cap gate charges.
+
+        Tested against RAW pad rects, so the whole requirement lives in this
+        radius: `_circle_rect_penetration` stays a pure geometric predicate
+        with no clearance parameter to forget.
+        """
+        key = self._delta_key(rot)
+        cache = self._keepout_cache.get(key)
+        if cache is None:
+            clr = self.clearance
+            cache = [(ox, oy, r + clr)
+                     for ox, oy, r in self.hole_circles(0.0, 0.0, rot)]
+            self._keepout_cache[key] = cache
         return [(x + ox, y + oy, r) for ox, oy, r in cache]
 
     def extent_local(self, rot: float):
@@ -1928,11 +1984,13 @@ class LegalityContext:
                     pad_short += eff - g
                     if g < 0.0:
                         overlap = True
+        # #761: keep-outs, not inflations -- the requirement is the stored
+        # growth PLUS the flat clearance, and the rects below are raw.
         hole = 0.0
-        for cx, cy, r in pb.hole_circles(xb, yb, rb):
+        for cx, cy, r in pb.hole_keepouts(xb, yb, rb):
             for a0, a1, a2, a3, _na, _sa in rects_a:
                 hole += _circle_rect_penetration(cx, cy, r, (a0, a1, a2, a3))
-        for cx, cy, r in pa.hole_circles(xa, ya, ra):
+        for cx, cy, r in pa.hole_keepouts(xa, ya, ra):
             for b0, b1, b2, b3, _nb, _sb in rects_b:
                 hole += _circle_rect_penetration(cx, cy, r, (b0, b1, b2, b3))
         return PairShortfall(pad_short, overlap, hole, stack)
@@ -2096,7 +2154,7 @@ def grade_pad_legality(pcb_data, clearance: float, exact: bool = True,
     for ref, pp in parts.items():
         fp = fps[ref]
         rects = pp.pad_rects(fp.x, fp.y, fp.rotation or 0.0)
-        holes = pp.hole_circles(fp.x, fp.y, fp.rotation or 0.0)
+        holes = pp.hole_keepouts(fp.x, fp.y, fp.rotation or 0.0)  # #761
         entries[ref] = (rects, holes)
         ext = pp.extent(fp.x, fp.y, fp.rotation or 0.0)
         if ext is None:

--- a/py_placer/placement/legality.py
+++ b/py_placer/placement/legality.py
@@ -1603,7 +1603,8 @@ class PartPads:
                  'holes_local', 'n_pads', '_pad_cache', '_hole_cache',
                  '_ext_cache', 'pad_floors', 'max_floor')
 
-    def __init__(self, fp, clearance: float, model=None):
+    def __init__(self, fp, clearance: float, model=None,
+                 copper_holes: bool = True):
         # Local imports: check_drc pulls the whole DRC stack (see the
         # BoardOutlineGate note); kicad_parser is cheap but keeps the module's
         # import surface unchanged for existing consumers.
@@ -1618,7 +1619,6 @@ class PartPads:
         self.holes_local = []   # (off_x, off_y, radius) -- NPTH keepouts, inflated
         self.pad_floors = []    # PadFloor per copper pad, index-aligned (#697)
         self.max_floor = 0.0    # upper bound on this part's pad requirements
-        npth_grow = max(0.0, defaults.NPTH_TO_TRACK_CLEARANCE - clearance)
         for p in fp.pads:
             if not _pad_carries_copper(p):
                 # Copper-less drilled pad (NPTH mounting hole): the DRILL still
@@ -1626,7 +1626,45 @@ class PartPads:
                 # matches fanout_clearance's foreign-pad keepouts. A
                 # paste/mask-only aperture has neither copper nor a hole and
                 # simply drops out.
+                #
+                # #730: ...or closer than the pad's OWN `(clearance ...)`
+                # override, when that is larger. That is what KiCad enforces
+                # and what check_drc grades (`max(npth_clr, lc)`,
+                # check_drc.py:2733). PER-PAD, so it is computed per pad and no
+                # longer hoisted above the loop -- a footprint may carry
+                # several holes with different overrides, and a hoisted value
+                # would give them all the first one's answer. Raise-only:
+                # 20 of the 22 tracked boards carry no NPTH override at all,
+                # and watchy's 8 are 0.100, under the 0.20 fab floor, so it is
+                # the negative control rather than a second example. The board
+                # that moves is ulx3s -- AUDIO1's two 1.7mm holes at lc 0.400,
+                # radius 0.950 -> 1.150 at --clearance 0.1.
+                #
+                # `copper_holes` is False for a SILK caller and that is not a
+                # tuning knob. `hole_circles()` answers two different
+                # questions: legality's copper consumers want the override,
+                # and labels.py uses the same circles to keep a reference
+                # designator's INK off a drill. `local_clearance` is a copper
+                # rule -- KiCad has no silk-to-hole rule at all -- so applying
+                # it there would push ulx3s's labels 0.20mm further from
+                # AUDIO1 for a reason that does not exist. Naming the question
+                # in the signature rather than inferring it from `model`:
+                # measured, only one of the six `build_part_pads` call sites
+                # passes a model, so a model gate would leave most copper
+                # consumers unfixed while looking principled.
+                #
+                # STILL MISSING, and structurally so: the BOARD's declared
+                # min_hole_clearance, which check_drc's `npth_clr` carries.
+                # This class takes `(fp, clearance)` with no board pointer --
+                # obstacle_map.resolve_hole_clearance's docstring already
+                # records that it cannot reach here. On a board declaring above
+                # 0.20 this still under-blocks by
+                # `declared - max(0.20, clearance, lc)`. Filed, not closed.
                 if _pad_has_no_copper(p) and (p.drill or 0) > 0:
+                    _lc = ((getattr(p, 'local_clearance', 0.0) or 0.0)
+                           if copper_holes else 0.0)
+                    npth_grow = max(0.0, max(defaults.NPTH_TO_TRACK_CLEARANCE,
+                                             _lc) - clearance)
                     for hx, hy, hd in pad_drill_circles(p):
                         self.holes_local.append(
                             (hx - fp.x, hy - fp.y, hd / 2.0 + npth_grow))
@@ -1719,7 +1757,8 @@ class PartPads:
 
 
 def build_part_pads(footprints: Dict[str, object],
-                    clearance: float, model=None) -> Dict[str, 'PartPads']:
+                    clearance: float, model=None,
+                    copper_holes: bool = True) -> Dict[str, 'PartPads']:
     """PartPads for every footprint that has any pad (copper or NPTH).
 
     `model` is an optional `PadClearanceModel` (#697); without it the parts
@@ -1730,7 +1769,7 @@ def build_part_pads(footprints: Dict[str, object],
     for ref, fp in footprints.items():
         if not getattr(fp, 'pads', None):
             continue
-        pp = PartPads(fp, clearance, model)
+        pp = PartPads(fp, clearance, model, copper_holes)
         if pp.n_pads or pp.holes_local:
             out[ref] = pp
     return out

--- a/py_placer/placement/legality.py
+++ b/py_placer/placement/legality.py
@@ -1610,7 +1610,7 @@ class PartPads:
     __slots__ = ('ref', 'side', 'has_tht', 'seed_rot', 'pads_local',
                  'holes_local', 'holes_extent', 'n_pads', '_pad_cache',
                  '_hole_cache', '_keepout_cache', '_ext_cache', 'pad_floors',
-                 'max_floor', 'clearance')
+                 'max_floor', 'clearance', 'hole_reach')
 
     def __init__(self, fp, clearance: float, model=None,
                  copper_holes: bool = True):
@@ -1735,6 +1735,28 @@ class PartPads:
                 if mf > self.max_floor:
                     self.max_floor = mf
         self.n_pads = len(self.pads_local)
+        # How far this part's hole keep-outs reach BEYOND its own extent
+        # (#761) -- the broad-phase bound, 0.0 with no holes.
+        #
+        # Both early-outs drop a pair on the gap between EXTENT boxes, and
+        # `max_floor` is built from copper pads only: an NPTH pad `continue`s
+        # above, before `pad_floors.append`, so a hole's requirement reaches
+        # neither bound. Measured on ulx3s: AUDIO1.max_floor is 0.0 while its
+        # holes require 0.400, so at `model.base` 0.25 every pair at an extent
+        # gap in [0.25, 0.40) returned ZERO_SHORTFALL before the hole loop ran
+        # -- i.e. the keep-out fix above is INERT without this term.
+        #
+        # Soundness: an extent box contains its hole at `extent_r`, so
+        # `rect_gap(ea, eb) >= dist(hole_centre, foreign_rect) - extent_r`,
+        # while a penetration needs `dist < keepout_r`. Dropping at
+        # `gap >= reach` is therefore safe exactly when
+        # `reach >= keepout_r - extent_r`, which is this.
+        self.hole_reach = 0.0
+        for (_hx, _hy, _kr), (_ex, _ey, _er) in zip(self.holes_local,
+                                                    self.holes_extent):
+            over = (_kr + self.clearance) - _er
+            if over > self.hole_reach:
+                self.hole_reach = over
         self._pad_cache: Dict[float, list] = {}
         self._hole_cache: Dict[float, list] = {}
         self._keepout_cache: Dict[float, list] = {}
@@ -1945,6 +1967,8 @@ class LegalityContext:
         reach = (self.clearance if model is None
                  else max(self.clearance, model.base,
                           pa.max_floor, pb.max_floor))
+        # ...and the hole keep-outs, which no pad floor accounts for (#761).
+        reach = max(reach, pa.hole_reach, pb.hole_reach)
         if rect_gap(ea, eb) >= reach - EPS:
             return ZERO_SHORTFALL
         if pa.n_pads * pb.n_pads > PAIR_TEST_CAP:
@@ -2169,7 +2193,11 @@ def grade_pad_legality(pcb_data, clearance: float, exact: bool = True,
     # maximum. Under-reaching here is how the original bug hid: a fiducial
     # keep-clear 1.016mm wide never entered a census bounded at 0.15 + 0.5.
     board_max_floor = max([pp.max_floor for pp in parts.values()] or [0.0])
-    census_reach = max(clearance, board_max_floor,
+    # ...plus the hole keep-outs (#761): same argument, and the same reason
+    # the per-candidate gate needs it -- an NPTH hole contributes to no pad
+    # floor, so a halo bounded by floors alone never reaches one.
+    board_max_hole = max([pp.hole_reach for pp in parts.values()] or [0.0])
+    census_reach = max(clearance, board_max_floor, board_max_hole,
                        model.base if model is not None else 0.0)
 
     def near_refs(ref):

--- a/py_placer/placement/legality.py
+++ b/py_placer/placement/legality.py
@@ -1671,7 +1671,15 @@ class PartPads:
         self.holes_req = []     # ...and the REQUIREMENT each one resolved to (#761)
         self.pad_floors = []    # PadFloor per copper pad, index-aligned (#697)
         self.max_floor = 0.0    # upper bound on this part's pad requirements
-        _npth_floor = (defaults.NPTH_TO_TRACK_CLEARANCE if npth_floor is None
+        # `copper_holes` gates the BOARD floor exactly as it gates the
+        # pad's own override, and for the same reason: a declared
+        # `min_hole_clearance` is a COPPER rule, and KiCad has no silk-to-hole
+        # rule at all. Gating only the override left silk taking the board's
+        # copper declaration -- caught by this change's own silk arm, which is
+        # why that arm asserts against an OFFERED floor rather than merely
+        # against the default.
+        _npth_floor = (defaults.NPTH_TO_TRACK_CLEARANCE
+                       if (npth_floor is None or not copper_holes)
                        else max(defaults.NPTH_TO_TRACK_CLEARANCE,
                                 float(npth_floor)))
         for p in fp.pads:
@@ -1689,7 +1697,7 @@ class PartPads:
                 # `_pair_or_flat` (an NPTH tuple files floor `None`, so it
                 # hands back the flat scalar, fanout_clearance.py:894/1306),
                 # and labels.py by comparing against `silk_pad_clearance`
-                # (labels.py:391). legality compared this circle against RAW
+                # (labels.py:394). legality compared this circle against RAW
                 # pad rects and added nothing, so its modelled standoff was
                 # `max(0, requirement - clearance)` -- which collapses to ZERO
                 # once `clearance` reaches the requirement, at 0.20 for a plain
@@ -1846,7 +1854,7 @@ class PartPads:
 
         A copper consumer wants `hole_keepouts` instead. This accessor exists
         for the caller that adds its own term at its own gap test: labels.py
-        (silk, `< config.silk_pad_clearance`, labels.py:391).
+        (silk, `< config.silk_pad_clearance`, labels.py:394).
         """
         key = self._delta_key(rot)
         cache = self._hole_cache.get(key)

--- a/py_placer/placement/legality.py
+++ b/py_placer/placement/legality.py
@@ -1690,10 +1690,18 @@ class PartPads:
         # `copper_holes` gates the BOARD floor exactly as it gates the
         # pad's own override, and for the same reason: a declared
         # `min_hole_clearance` is a COPPER rule, and KiCad has no silk-to-hole
-        # rule at all. Gating only the override left silk taking the board's
-        # copper declaration -- caught by this change's own silk arm, which is
-        # why that arm asserts against an OFFERED floor rather than merely
-        # against the default.
+        # rule at all.
+        #
+        # It is HARDENING, not a defect fix, and the commit that added it
+        # (#761) claimed otherwise -- corrected here rather than left
+        # standing. `labels.py:303`, the only `copper_holes=False` caller,
+        # passes no `npth_floor` at all, so silk took the flat fab floor with
+        # or without this gate; measured, silk output is byte-identical across
+        # the whole change. What the silk arm caught is a latent hole that any
+        # future silk caller supplying a floor would fall into, which is worth
+        # closing but is not what the commit said it was.  The arm still
+        # asserts against an OFFERED floor rather than the default, because
+        # that is the only way to see this branch at all.
         _npth_floor = (defaults.NPTH_TO_TRACK_CLEARANCE
                        if (npth_floor is None or not copper_holes)
                        else max(defaults.NPTH_TO_TRACK_CLEARANCE,

--- a/py_placer/placement/legality.py
+++ b/py_placer/placement/legality.py
@@ -1944,6 +1944,25 @@ def _sides_interact(a, b) -> bool:
     return a is None or b is None or a == b
 
 
+def _hole_shortfall(pa, xa, ya, ra, rects_b, pb, xb, yb, rb, rects_a):
+    """Total penetration of either part's NPTH keep-outs into the other's
+    copper (#761). ONE resolver, because `pair_shortfall` reaches it from two
+    branches -- the full pad sweep and the PAIR_TEST_CAP extent branch -- and
+    a second copy is how the cap branch came to report a hardcoded zero.
+
+    Keep-outs, not `hole_circles`: the requirement lives in the radius, and
+    the rects are raw.
+    """
+    hole = 0.0
+    for cx, cy, r in pb.hole_keepouts(xb, yb, rb):
+        for a0, a1, a2, a3, _na, _sa in rects_a:
+            hole += _circle_rect_penetration(cx, cy, r, (a0, a1, a2, a3))
+    for cx, cy, r in pa.hole_keepouts(xa, ya, ra):
+        for b0, b1, b2, b3, _nb, _sb in rects_b:
+            hole += _circle_rect_penetration(cx, cy, r, (b0, b1, b2, b3))
+    return hole
+
+
 def _circle_rect_penetration(cx, cy, r, rect) -> float:
     """How deep a circle penetrates a rect's keepout (0 when clear)."""
     dx = max(rect[0] - cx, 0.0, cx - rect[2])
@@ -2023,14 +2042,27 @@ class LegalityContext:
         reach = max(reach, pa.hole_reach, pb.hole_reach)
         if rect_gap(ea, eb) >= reach - EPS:
             return ZERO_SHORTFALL
-        if pa.n_pads * pb.n_pads > PAIR_TEST_CAP:
-            # Extent-level verdict only: charge the extent shortfall as pad
-            # shortfall so the baseline comparison still constrains the pair.
-            g = rect_gap(ea, eb)
-            return PairShortfall(max(0.0, reach - g), g < 0.0, 0.0,
-                                 g < 0.0)
         rects_a = pa.pad_rects(xa, ya, ra)
         rects_b = pb.pad_rects(xb, yb, rb)
+        if pa.n_pads * pb.n_pads > PAIR_TEST_CAP:
+            # Extent-level verdict for the PAD channel only: charge the extent
+            # shortfall as pad shortfall so the baseline comparison still
+            # constrains the pair.
+            #
+            # The HOLE channel is measured anyway (#761). The cap exists for
+            # the pad x pad product; the hole loops are holes x pads, which is
+            # two orders smaller on every part that trips it -- glasgow_revC's
+            # J5 is 44 pads x 4 holes against a 121-pad neighbour, so 5324
+            # pad pairs but 660 hole tests. Returning a hardcoded `hole=0.0`
+            # here made `cur.hole > base.hole` unable to fire for exactly the
+            # dense connectors that carry mounting holes, and that is
+            # corpus-reachable, not theoretical: J5 is the one part on the 22
+            # tracked boards whose product exceeds the cap.
+            g = rect_gap(ea, eb)
+            return PairShortfall(max(0.0, reach - g), g < 0.0,
+                                 _hole_shortfall(pa, xa, ya, ra, rects_b,
+                                                 pb, xb, yb, rb, rects_a),
+                                 g < 0.0)
         floors_a = pa.pad_floors if model is not None else None
         floors_b = pb.pad_floors if model is not None else None
         pad_short = 0.0
@@ -2062,14 +2094,10 @@ class LegalityContext:
                         overlap = True
         # #761: keep-outs, not inflations -- the requirement is the stored
         # growth PLUS the flat clearance, and the rects below are raw.
-        hole = 0.0
-        for cx, cy, r in pb.hole_keepouts(xb, yb, rb):
-            for a0, a1, a2, a3, _na, _sa in rects_a:
-                hole += _circle_rect_penetration(cx, cy, r, (a0, a1, a2, a3))
-        for cx, cy, r in pa.hole_keepouts(xa, ya, ra):
-            for b0, b1, b2, b3, _nb, _sb in rects_b:
-                hole += _circle_rect_penetration(cx, cy, r, (b0, b1, b2, b3))
-        return PairShortfall(pad_short, overlap, hole, stack)
+        return PairShortfall(pad_short, overlap,
+                             _hole_shortfall(pa, xa, ya, ra, rects_b,
+                                             pb, xb, yb, rb, rects_a),
+                             stack)
 
     def seed_baseline(self, a: str, b: str) -> PairShortfall:
         # The single choke point every consumer routes through (pads_ok and

--- a/py_placer/placement/legality.py
+++ b/py_placer/placement/legality.py
@@ -1577,6 +1577,41 @@ class PadClearanceModel:
         return eff, src
 
 
+def resolve_npth_floor(pcb_data) -> float:
+    """The board's copper-to-NPTH-hole FLOOR: the JLC fab floor, raised to the
+    board's own declared `min_hole_clearance` when it declares more (#761).
+
+    The one resolver, and it lives OUTSIDE `PartPads` on purpose. That class
+    takes a footprint and scalars and reads no board -- a contract
+    `tests/test_730_...py` pins, because six call sites build parts and a
+    board read inside would change what each of them means. So the board is
+    read here, once, by the caller that has one, and the resolved float is
+    passed down. That is exactly the shape `fanout_clearance` already uses
+    (`self.npth_floor`, fanout_clearance.py:664-666).
+
+    `check_drc`'s requirement is
+    `max(clearance, NPTH_TO_TRACK_CLEARANCE, hole_clearance, lc)`
+    (check_drc.py:2714, :2733); this supplies the middle two terms.
+
+    Measured over the 22 tracked boards: `flat_hierarchy` is the ONLY one
+    declaring above the fab floor (0.2500), and all 6 of its NPTH pads carry
+    `local_clearance` 0.0 -- so it is the single witness that this term fires
+    at all, and every other board resolves to 0.2000.
+
+    Returns the plain fab floor when the board cannot be read, which is what a
+    caller with no board gets by default.
+    """
+    import routing_defaults as defaults
+    floor = float(defaults.NPTH_TO_TRACK_CLEARANCE)
+    if pcb_data is None:
+        return floor
+    try:
+        from obstacle_map import resolve_hole_clearance
+        return max(floor, float(resolve_hole_clearance(pcb_data, None)))
+    except Exception:                                            # noqa: BLE001
+        return floor
+
+
 class PartPads:
     """Pose-owning pad/hole model for one footprint.
 
@@ -1613,7 +1648,7 @@ class PartPads:
                  'max_floor', 'clearance', 'hole_reach')
 
     def __init__(self, fp, clearance: float, model=None,
-                 copper_holes: bool = True):
+                 copper_holes: bool = True, npth_floor: float = None):
         # Local imports: check_drc pulls the whole DRC stack (see the
         # BoardOutlineGate note); kicad_parser is cheap but keeps the module's
         # import surface unchanged for existing consumers.
@@ -1635,6 +1670,9 @@ class PartPads:
         self.holes_extent = []  # ...the same holes at their EXTENT radius (#730)
         self.pad_floors = []    # PadFloor per copper pad, index-aligned (#697)
         self.max_floor = 0.0    # upper bound on this part's pad requirements
+        _npth_floor = (defaults.NPTH_TO_TRACK_CLEARANCE if npth_floor is None
+                       else max(defaults.NPTH_TO_TRACK_CLEARANCE,
+                                float(npth_floor)))
         for p in fp.pads:
             if not _pad_carries_copper(p):
                 # Copper-less drilled pad (NPTH mounting hole): the DRILL still
@@ -1687,18 +1725,17 @@ class PartPads:
                 # a COPPER-vs-SILK question on an argument that answers a
                 # different one.
                 #
-                # STILL MISSING, and structurally so: the BOARD's declared
-                # min_hole_clearance, which check_drc's `npth_clr` carries.
-                # This class takes `(fp, clearance)` with no board pointer --
-                # obstacle_map.resolve_hole_clearance's docstring already
-                # records that it cannot reach here. On a board declaring above
-                # 0.20 this still under-blocks by
-                # `declared - max(0.20, clearance, lc)`. Filed, not closed.
+                # The BOARD's declared min_hole_clearance, which
+                # check_drc's `npth_clr` carries, arrives as the resolved
+                # scalar `npth_floor` (#761) -- NOT as a board pointer. This
+                # class still reads no board; `resolve_npth_floor` does, once,
+                # in the caller that has one. It defaults to the fab floor, so
+                # a caller that passes nothing keeps exactly its previous
+                # answer.
                 if _pad_has_no_copper(p) and (p.drill or 0) > 0:
                     _lc = ((getattr(p, 'local_clearance', 0.0) or 0.0)
                            if copper_holes else 0.0)
-                    npth_grow = max(0.0, max(defaults.NPTH_TO_TRACK_CLEARANCE,
-                                             _lc) - clearance)
+                    npth_grow = max(0.0, max(_npth_floor, _lc) - clearance)
                     # ...and the SAME holes without the override, for extents.
                     # `holes_local` is a copper KEEP-OUT and `extent_local` is
                     # a question about where the part physically IS -- an
@@ -1710,6 +1747,12 @@ class PartPads:
                     # the seeder's ZERO-margin off-board census, which
                     # CLAUDE.md calls the top-priority placement defect. This
                     # keeps every extent byte-identical to pre-#730.
+                    # The FLAT floor, deliberately (#761): a board's
+                    # declared copper-to-hole rule is a copper rule, exactly
+                    # like `local_clearance` above, and `extent_local` asks
+                    # where the part physically IS. Keeping it out here keeps
+                    # every extent byte-identical on every board, which is what
+                    # stops a declaration from pushing a part off the outline.
                     ext_grow = max(0.0, defaults.NPTH_TO_TRACK_CLEARANCE
                                    - clearance)
                     for hx, hy, hd in pad_drill_circles(p):
@@ -1870,7 +1913,8 @@ class PartPads:
 
 def build_part_pads(footprints: Dict[str, object],
                     clearance: float, model=None,
-                    copper_holes: bool = True) -> Dict[str, 'PartPads']:
+                    copper_holes: bool = True,
+                    npth_floor: float = None) -> Dict[str, 'PartPads']:
     """PartPads for every footprint that has any pad (copper or NPTH).
 
     `model` is an optional `PadClearanceModel` (#697); without it the parts
@@ -1881,7 +1925,7 @@ def build_part_pads(footprints: Dict[str, object],
     for ref, fp in footprints.items():
         if not getattr(fp, 'pads', None):
             continue
-        pp = PartPads(fp, clearance, model, copper_holes)
+        pp = PartPads(fp, clearance, model, copper_holes, npth_floor)
         if pp.n_pads or pp.holes_local:
             out[ref] = pp
     return out
@@ -2161,7 +2205,13 @@ def grade_pad_legality(pcb_data, clearance: float, exact: bool = True,
     clearance_notes = list(model.notes)
     if not model.active:
         model = None
-    parts = build_part_pads(fps, clearance, model)
+    # The census reads hole keep-outs, so it carries the board's own
+    # copper-to-hole floor. The three call sites that read only pad rects and
+    # extents (legality's pad_intersection channel, routability, seeder's
+    # off-board census) deliberately do not: for them the term would resolve a
+    # board and change nothing.
+    parts = build_part_pads(fps, clearance, model,
+                            npth_floor=resolve_npth_floor(pcb_data))
     routing_layers = list(getattr(pcb_data.board_info, 'copper_layers', []) or [])
     check_exact = None
     if exact:

--- a/py_placer/placement/legality.py
+++ b/py_placer/placement/legality.py
@@ -1649,9 +1649,12 @@ class PartPads:
                 # it there would push ulx3s's labels 0.20mm further from
                 # AUDIO1 for a reason that does not exist. Naming the question
                 # in the signature rather than inferring it from `model`:
-                # measured, only one of the six `build_part_pads` call sites
-                # passes a model, so a model gate would leave most copper
-                # consumers unfixed while looking principled.
+                # measured, only two of the six `build_part_pads` call sites
+                # pass one (grade_pad_legality and quench), so a model gate
+                # would leave legality's own pad-overlap path, routability and
+                # seeder unfixed while looking principled -- and it would key
+                # a COPPER-vs-SILK question on an argument that answers a
+                # different one.
                 #
                 # STILL MISSING, and structurally so: the BOARD's declared
                 # min_hole_clearance, which check_drc's `npth_clr` carries.

--- a/py_placer/placement/quench.py
+++ b/py_placer/placement/quench.py
@@ -516,9 +516,13 @@ class QuenchState:
             pad_model = legality.PadClearanceModel.for_board(
                 pcb_data, clearance, pcb_file)
             pad_model = pad_model if pad_model.active else None
+            # #761: the board's own copper-to-NPTH-hole floor, resolved
+            # once. This context serves `pair_shortfall`, which reads hole
+            # keep-outs, so it is one of the two call sites that need it.
             part_pads = legality.build_part_pads(
                 {ref: pcb_data.footprints[ref] for ref in self.parts
-                 if ref in pcb_data.footprints}, clearance, pad_model)
+                 if ref in pcb_data.footprints}, clearance, pad_model,
+                npth_floor=legality.resolve_npth_floor(pcb_data))
             self.legality_ctx = legality.LegalityContext(
                 part_pads, self.edge_gate, clearance,
                 pose_of=lambda r: (self.parts[r].x, self.parts[r].y,

--- a/py_placer/placement/quench.py
+++ b/py_placer/placement/quench.py
@@ -519,10 +519,21 @@ class QuenchState:
             # #761: the board's own copper-to-NPTH-hole floor, resolved
             # once. This context serves `pair_shortfall`, which reads hole
             # keep-outs, so it is one of the two call sites that need it.
+            #
+            # The notes are PRINTED rather than returned: unlike
+            # `grade_pad_legality` this constructor has no report to file them
+            # into, and a silent fallback drops the modelled floor to the flat
+            # fab value while every downstream number looks normal. Empty on
+            # every board that resolves cleanly.
+            _npth_notes = []
+            _npth = legality.resolve_npth_floor(pcb_data, pcb_file,
+                                                _npth_notes)
+            for _n in _npth_notes:
+                print('WARNING: %s' % _n)
             part_pads = legality.build_part_pads(
                 {ref: pcb_data.footprints[ref] for ref in self.parts
                  if ref in pcb_data.footprints}, clearance, pad_model,
-                npth_floor=legality.resolve_npth_floor(pcb_data, pcb_file))
+                npth_floor=_npth)
             self.legality_ctx = legality.LegalityContext(
                 part_pads, self.edge_gate, clearance,
                 pose_of=lambda r: (self.parts[r].x, self.parts[r].y,

--- a/py_placer/placement/quench.py
+++ b/py_placer/placement/quench.py
@@ -522,7 +522,7 @@ class QuenchState:
             part_pads = legality.build_part_pads(
                 {ref: pcb_data.footprints[ref] for ref in self.parts
                  if ref in pcb_data.footprints}, clearance, pad_model,
-                npth_floor=legality.resolve_npth_floor(pcb_data))
+                npth_floor=legality.resolve_npth_floor(pcb_data, pcb_file))
             self.legality_ctx = legality.LegalityContext(
                 part_pads, self.edge_gate, clearance,
                 pose_of=lambda r: (self.parts[r].x, self.parts[r].y,

--- a/py_placer/placement/writer.py
+++ b/py_placer/placement/writer.py
@@ -266,6 +266,27 @@ def write_placed_output(input_file: str, output_file: str,
             for m in via_moves:
                 v = m[2]
                 nm = n2n.get(v['net_id']) if n2n else None
+                if nm is None and n2n:
+                    # A NAME-net board on which this via's id did not resolve.
+                    # Emitting the numeric dialect here is not a cosmetic
+                    # fallback: combined with a protection spec it produces a
+                    # via `kicad_parser.extract_vias` CANNOT read back -- its
+                    # KiCad-9 pattern has strict field ordering and no gap for
+                    # the protection tokens, so the barrel disappears from the
+                    # model entirely. Invisible copper the router then plans
+                    # tracks through, which is the hazard PR #534 was written
+                    # against and strictly worse than the wrong-tenting bug
+                    # #741 set out to fix.
+                    #
+                    # net 0 is the case that actually occurs, and it is a hole
+                    # in the map rather than an unknown net: `extract_nets`
+                    # records `name_to_id[""] = 0` but never creates a Net for
+                    # id 0, so a legitimate no-net `(net "")` via -- which the
+                    # parser models and this writer emits -- misses the lookup
+                    # on every board. Measured: orangecrab_ext_pll resolves 169
+                    # nets and has no key 0. Name it explicitly.
+                    if v['net_id'] == 0:
+                        nm = ''
                 # Every via in via_moves came OFF this board a few lines up,
                 # so its OWN spec is the whole answer. That much is
                 # plane_io.py:862-866's form -- the rip-up restore, which is
@@ -297,11 +318,19 @@ def write_placed_output(input_file: str, output_file: str,
                 # a dict with no 'x'/'net_id' is not a via and SHOULD raise,
                 # while a dict with no spec is a via nobody recorded one for --
                 # a meaning this line has an answer for.
+                spec = v.get('tenting_attrs') or INHERIT_VIA_PROTECTION
+                if nm is None and spec is not INHERIT_VIA_PROTECTION:
+                    # Belt for the residue of the same hazard: a numeric-net
+                    # emission that still carries a spec. Losing the spec is
+                    # the #741 bug; losing the VIA is worse, so this trades
+                    # back deliberately and only where the two conflict. Not
+                    # reachable from any board today -- per-via protection is
+                    # a KiCad-10 feature and those boards are name-net, so a
+                    # numeric-dialect via never has a spec to begin with.
+                    spec = INHERIT_VIA_PROTECTION
                 elements.append(generate_via_sexpr(
                     v['x'], v['y'], v['size'], v['drill'], v['layers'],
-                    v['net_id'], net_name=nm,
-                    tenting_attrs=(v.get('tenting_attrs')
-                                   or INHERIT_VIA_PROTECTION)))
+                    v['net_id'], net_name=nm, tenting_attrs=spec))
         for nsd in (new_segments or []):
             nm = n2n.get(nsd['net_id']) if n2n else None
             elements.append(generate_segment_sexpr(

--- a/py_placer/placement/writer.py
+++ b/py_placer/placement/writer.py
@@ -272,7 +272,7 @@ def write_placed_output(input_file: str, output_file: str,
             so the barrel disappears from the model entirely. Invisible copper
             the router then plans tracks through, which is the hazard PR #534
             was written against and strictly worse than the wrong-tenting bug
-            #741 set out to fix.
+            #741 set out to fix. The parser asymmetry itself is #748.
             """
             if not n2n:
                 return None
@@ -311,8 +311,8 @@ def write_placed_output(input_file: str, output_file: str,
                 # done that: gui_utils.apply_via_protection returns early on an
                 # empty spec, because pcbnew's *_MODE_FROM_BOARD already means
                 # inherit. plane_io's restore carries the spec but not this
-                # flag, so it still has the residue; filed separately rather
-                # than changed from here.
+                # flag, so it still has the residue; #749 rather than changed
+                # from here.
                 #
                 # Stating the rule HERE rather than relying on the engine key
                 # means the two halves of #741 fail independently: a move dict

--- a/py_placer/placement/writer.py
+++ b/py_placer/placement/writer.py
@@ -252,7 +252,9 @@ def write_placed_output(input_file: str, output_file: str,
     # the fanout stub start. Attached segments are untouched by design.
     if via_moves or new_segments:
         from plane_io import _remove_vias_at_positions
-        from kicad_writer import generate_via_sexpr, generate_segment_sexpr
+        from kicad_writer import (generate_via_sexpr,
+                                  generate_segment_sexpr,
+                                  INHERIT_VIA_PROTECTION)
         n2n = getattr(pcb_data, 'net_id_to_name', None) if pcb_data is not None else None
         elements = []
         if via_moves:
@@ -264,9 +266,42 @@ def write_placed_output(input_file: str, output_file: str,
             for m in via_moves:
                 v = m[2]
                 nm = n2n.get(v['net_id']) if n2n else None
-                elements.append(generate_via_sexpr(v['x'], v['y'], v['size'],
-                                                   v['drill'], v['layers'],
-                                                   v['net_id'], net_name=nm))
+                # Every via in via_moves came OFF this board a few lines up,
+                # so its OWN spec is the whole answer. That much is
+                # plane_io.py:862-866's form -- the rip-up restore, which is
+                # structurally the same act -- and deliberately NOT
+                # plane_io.py:557-563's `or
+                # prevailing_via_protection_in_text(...)`, the right default
+                # for vias this tool ADDS but a THIRD answer for one that
+                # already existed: it would stamp the majority spec of OTHER
+                # vias onto this one.
+                #
+                # `or INHERIT_VIA_PROTECTION` is where this call goes BEYOND
+                # plane_io's form, and it is the second half of #741. An absent
+                # or empty spec is not silence from the CALLER, it is the board
+                # saying nothing about this via -- so emit nothing and let it
+                # keep inheriting `(setup (tenting ...))`. Without it, None/{}
+                # reaches kicad_writer's front+back default and the via GAINS a
+                # fab attribute it never had. The GUI twin has never done that:
+                # gui_utils.apply_via_protection returns early on an empty
+                # spec, because pcbnew's *_MODE_FROM_BOARD already means
+                # inherit. plane_io's restore still carries this residue; filed
+                # separately rather than changed from here.
+                #
+                # Stating the rule HERE rather than relying on the engine key
+                # means the two halves of #741 fail independently: a move dict
+                # that lost the key inherits rather than re-tents.
+                #
+                # `.get` for this one key, and the asymmetry with the
+                # hard-indexed geometry below is deliberate rather than sloppy:
+                # a dict with no 'x'/'net_id' is not a via and SHOULD raise,
+                # while a dict with no spec is a via nobody recorded one for --
+                # a meaning this line has an answer for.
+                elements.append(generate_via_sexpr(
+                    v['x'], v['y'], v['size'], v['drill'], v['layers'],
+                    v['net_id'], net_name=nm,
+                    tenting_attrs=(v.get('tenting_attrs')
+                                   or INHERIT_VIA_PROTECTION)))
         for nsd in (new_segments or []):
             nm = n2n.get(nsd['net_id']) if n2n else None
             elements.append(generate_segment_sexpr(

--- a/py_placer/placement/writer.py
+++ b/py_placer/placement/writer.py
@@ -252,41 +252,45 @@ def write_placed_output(input_file: str, output_file: str,
     # the fanout stub start. Attached segments are untouched by design.
     if via_moves or new_segments:
         from plane_io import _remove_vias_at_positions
-        from kicad_writer import (generate_via_sexpr,
-                                  generate_segment_sexpr,
-                                  INHERIT_VIA_PROTECTION)
+        from kicad_writer import generate_via_sexpr, generate_segment_sexpr
         n2n = getattr(pcb_data, 'net_id_to_name', None) if pcb_data is not None else None
+
+        def _net_name(net_id):
+            """This board's name for a net id, or None if it has none.
+
+            net 0 is spelled out because it is a hole in the map rather than an
+            unknown net: `extract_nets` records `name_to_id[""] = 0` but never
+            creates a Net for id 0, so a legitimate no-net `(net "")` via --
+            which the parser models and this writer emits -- misses the lookup
+            on EVERY board. Measured: orangecrab_ext_pll resolves 169 nets and
+            has no key 0.
+
+            Getting this wrong is not cosmetic. Falling back to the numeric
+            dialect while also emitting a protection spec produces a via
+            `kicad_parser.extract_vias` CANNOT read back -- its KiCad-9 pattern
+            has strict field ordering and no gap for the protection tokens --
+            so the barrel disappears from the model entirely. Invisible copper
+            the router then plans tracks through, which is the hazard PR #534
+            was written against and strictly worse than the wrong-tenting bug
+            #741 set out to fix.
+            """
+            if not n2n:
+                return None
+            nm = n2n.get(net_id)
+            return '' if nm is None and net_id == 0 else nm
+
         elements = []
         if via_moves:
             content, _ = _remove_vias_at_positions(
                 content, [(m[0], m[1]) for m in via_moves],
                 net_ids=[m[2]['net_id'] for m in via_moves],
-                net_names=[n2n.get(m[2]['net_id']) if n2n else None
-                           for m in via_moves])
+                # through the same resolver as the emit: passing None here for
+                # net 0 dropped the removal to POSITIONAL matching for exactly
+                # the via this fix is about.
+                net_names=[_net_name(m[2]['net_id']) for m in via_moves])
             for m in via_moves:
                 v = m[2]
-                nm = n2n.get(v['net_id']) if n2n else None
-                if nm is None and n2n:
-                    # A NAME-net board on which this via's id did not resolve.
-                    # Emitting the numeric dialect here is not a cosmetic
-                    # fallback: combined with a protection spec it produces a
-                    # via `kicad_parser.extract_vias` CANNOT read back -- its
-                    # KiCad-9 pattern has strict field ordering and no gap for
-                    # the protection tokens, so the barrel disappears from the
-                    # model entirely. Invisible copper the router then plans
-                    # tracks through, which is the hazard PR #534 was written
-                    # against and strictly worse than the wrong-tenting bug
-                    # #741 set out to fix.
-                    #
-                    # net 0 is the case that actually occurs, and it is a hole
-                    # in the map rather than an unknown net: `extract_nets`
-                    # records `name_to_id[""] = 0` but never creates a Net for
-                    # id 0, so a legitimate no-net `(net "")` via -- which the
-                    # parser models and this writer emits -- misses the lookup
-                    # on every board. Measured: orangecrab_ext_pll resolves 169
-                    # nets and has no key 0. Name it explicitly.
-                    if v['net_id'] == 0:
-                        nm = ''
+                nm = _net_name(v['net_id'])
                 # Every via in via_moves came OFF this board a few lines up,
                 # so its OWN spec is the whole answer. That much is
                 # plane_io.py:862-866's form -- the rip-up restore, which is
@@ -297,17 +301,18 @@ def write_placed_output(input_file: str, output_file: str,
                 # already existed: it would stamp the majority spec of OTHER
                 # vias onto this one.
                 #
-                # `or INHERIT_VIA_PROTECTION` is where this call goes BEYOND
-                # plane_io's form, and it is the second half of #741. An absent
-                # or empty spec is not silence from the CALLER, it is the board
-                # saying nothing about this via -- so emit nothing and let it
-                # keep inheriting `(setup (tenting ...))`. Without it, None/{}
-                # reaches kicad_writer's front+back default and the via GAINS a
-                # fab attribute it never had. The GUI twin has never done that:
-                # gui_utils.apply_via_protection returns early on an empty
-                # spec, because pcbnew's *_MODE_FROM_BOARD already means
-                # inherit. plane_io's restore still carries this residue; filed
-                # separately rather than changed from here.
+                # `inherit_when_unspecified=True` is where this call goes
+                # BEYOND plane_io's form, and it is the second half of #741. An
+                # absent or empty spec is not silence from the CALLER, it is the
+                # board saying nothing about this via -- so emit nothing and let
+                # it keep inheriting `(setup (tenting ...))`. Without the flag,
+                # None/{} reaches kicad_writer's front+back default and the via
+                # GAINS a fab attribute it never had. The GUI twin has never
+                # done that: gui_utils.apply_via_protection returns early on an
+                # empty spec, because pcbnew's *_MODE_FROM_BOARD already means
+                # inherit. plane_io's restore carries the spec but not this
+                # flag, so it still has the residue; filed separately rather
+                # than changed from here.
                 #
                 # Stating the rule HERE rather than relying on the engine key
                 # means the two halves of #741 fail independently: a move dict
@@ -318,19 +323,32 @@ def write_placed_output(input_file: str, output_file: str,
                 # a dict with no 'x'/'net_id' is not a via and SHOULD raise,
                 # while a dict with no spec is a via nobody recorded one for --
                 # a meaning this line has an answer for.
-                spec = v.get('tenting_attrs') or INHERIT_VIA_PROTECTION
-                if nm is None and spec is not INHERIT_VIA_PROTECTION:
+                spec = v.get('tenting_attrs')
+                if nm is None and spec:
                     # Belt for the residue of the same hazard: a numeric-net
-                    # emission that still carries a spec. Losing the spec is
-                    # the #741 bug; losing the VIA is worse, so this trades
-                    # back deliberately and only where the two conflict. Not
-                    # reachable from any board today -- per-via protection is
-                    # a KiCad-10 feature and those boards are name-net, so a
-                    # numeric-dialect via never has a spec to begin with.
-                    spec = INHERIT_VIA_PROTECTION
+                    # emission that still carries a spec is the unreadable
+                    # pairing described in _net_name. Losing the spec is the
+                    # #741 bug; losing the VIA is worse, so this trades back
+                    # deliberately and only where the two conflict.
+                    #
+                    # Reachable, though not from a real board: no KiCad-9 board
+                    # carries per-via protection (that is a KiCad-10 feature and
+                    # those boards are name-net), but `write_placed_output`
+                    # takes an arbitrary pcb_data, and a synth.make_pcb() one
+                    # has an EMPTY net_id_to_name -- which sends every via
+                    # numeric.
+                    spec = None
                 elements.append(generate_via_sexpr(
                     v['x'], v['y'], v['size'], v['drill'], v['layers'],
-                    v['net_id'], net_name=nm, tenting_attrs=spec))
+                    v['net_id'], net_name=nm, tenting_attrs=spec,
+                    # The DECISION, carried separately from the value: `{}` is
+                    # what Via.tenting_attrs holds for a via that inherits, and
+                    # handing it back without this would re-stamp the via with
+                    # front+back tenting it never had (#741). A sentinel VALUE
+                    # cannot do this job -- the repo's own idiom for carrying a
+                    # spec is `dict(...)`, which would turn any dict-shaped
+                    # sentinel back into a plain {}.
+                    inherit_when_unspecified=True))
         for nsd in (new_segments or []):
             nm = n2n.get(nsd['net_id']) if n2n else None
             elements.append(generate_segment_sexpr(

--- a/py_router/kicad_writer.py
+++ b/py_router/kicad_writer.py
@@ -282,58 +282,11 @@ DEFAULT_VIA_TENTING = {'tenting': '(front yes) (back yes)'}
 VIA_PROTECTION_TOKEN_ORDER = ('tenting', 'covering', 'plugging', 'capping', 'filling')
 
 
-class _InheritViaProtection(dict):
-    """See INHERIT_VIA_PROTECTION.
-
-    An EMPTY dict subclass that is deliberately TRUTHY, which is what makes the
-    sentinel fail SAFE rather than fail loudly. `via_protection_sexpr` matches
-    it by identity, so normally the type never matters -- but identity is a
-    fragile thing to rest a fab attribute on: a `copy.copy`, a pickle round
-    trip, or a second import of this module under a different `sys.path` root
-    (this repo imports `kicad_writer` by bare name from py_router, py_placer
-    and py_tools) all produce an object that is `==` but not `is`.
-
-    So the fallback path must also be right. Being a dict, it survives the
-    truthiness branch and the token loop; being EMPTY, that loop emits nothing
-    -- exactly what the identity branch would have done. A plain `object()`
-    would raise there instead, and a FALSY sentinel would be worse still: it
-    would fall through to the front+back default, which is the bug (#741).
-    """
-    __slots__ = ()
-
-    def __bool__(self):
-        return True
-
-    __nonzero__ = __bool__       # py2-style spelling, harmless and explicit
-
-    def __repr__(self):
-        return 'INHERIT_VIA_PROTECTION'
-
-
-# Pass this as `tenting_attrs` for a via that came OFF the board and is going
-# back on carrying NO spec of its own. It is NOT the same as None: None means
-# "the caller did not say", which keeps the #489 front+back default; this means
-# "the board said nothing about this via, and nothing is the answer". KiCad
-# reads a via with no protection tokens as inheriting the board's
-# `(setup (tenting ...))` -- which is exactly what such a via had before it was
-# lifted, so re-stamping it with front+back tenting changes a fab attribute
-# that nobody asked to change.
-#
-# The GUI half has always behaved this way: gui_utils.apply_via_protection
-# returns early on an empty spec, because pcbnew's *_MODE_FROM_BOARD already
-# means inherit. This is the text writer's half of that (#741).
-#
-# Deliberately OPT-IN. Every existing caller keeps passing what it passes, and
-# tests/test_489_via_tenting.py's pin on the spec-less default -- which calls
-# generate_via_sexpr with no `tenting_attrs` at all -- resolves to None and is
-# untouched. Other re-placement sites (plane_io.restore_failed_reroute_nets is
-# the closest sibling) have the same residue and should adopt this, but each
-# needs its own measurement; #741 scopes it to the placement via-nudge.
-INHERIT_VIA_PROTECTION = _InheritViaProtection()
 
 
 def via_protection_sexpr(tenting_attrs: dict = None,
-                         net_name: str = None) -> str:
+                         net_name: str = None,
+                         inherit_when_unspecified: bool = False) -> str:
     """The `(tenting ...)` / `(covering ...)` / ... fragment to emit for a via.
 
     `tenting_attrs` is a Via's parsed spec ({token: raw inner text}); passing it
@@ -341,24 +294,35 @@ def via_protection_sexpr(tenting_attrs: dict = None,
     stands -- front+back tenting on KiCad 10 output -- since there is no
     board-level policy to consult here (#489 §8).
 
-    THREE states, not two, because `None` and `{}` used to mean the same thing
-    here and they are not the same fact (#741):
+    `inherit_when_unspecified` is what an EXISTING via needs, and it exists
+    because `None` and `{}` cannot answer the question on their own (#741):
 
-      a real spec              -> emit it
-      INHERIT_VIA_PROTECTION   -> emit NOTHING; the board said nothing about
-                                  this via and the via keeps inheriting
-                                  `(setup (tenting ...))`. For a via that came
-                                  OFF the board -- see that constant.
-      None / {} (KiCad 10)     -> the #489 default, front+back tenting
-      None / {} (numeric net)  -> nothing, as before
+      a real spec, either way            -> emit it
+      empty + inherit_when_unspecified   -> emit NOTHING. The board said
+                                            nothing about this via, so the via
+                                            keeps inheriting
+                                            `(setup (tenting ...))` -- which is
+                                            what it had before it was lifted.
+      empty, KiCad 10 (net_name given)   -> the #489 default, front+back
+      empty, numeric net                 -> nothing, as before
 
-    Order matters: the sentinel is tested FIRST and by identity, so a caller
-    that has a real spec always wins, and no truthiness test can reach it.
+    Pass `inherit_when_unspecified=True` whenever you are RE-PLACING a via --
+    rip-up, sub-grid nudge, tap relocation. `{}` is exactly what
+    `Via.tenting_attrs` holds for a via that carries no spec, so handing it back
+    verbatim without this flag re-stamps the via with front+back tenting it
+    never had.
+
+    A KEYWORD rather than a sentinel value, deliberately. A sentinel object has
+    to survive being copied, and the copy idiom this repo actually uses for a
+    spec is `dict(via.tenting_attrs or {})` (fanout_clearance.py, plane_io.py)
+    -- which turns any dict-shaped sentinel back into a plain `{}` and silently
+    restores the bug. Carrying the DECISION separately from the VALUE cannot be
+    undone by copying the value.
     """
-    if tenting_attrs is INHERIT_VIA_PROTECTION:
-        spec = {}
-    elif tenting_attrs:
+    if tenting_attrs:
         spec = tenting_attrs
+    elif inherit_when_unspecified:
+        spec = {}
     elif net_name is not None:
         spec = DEFAULT_VIA_TENTING
     else:
@@ -426,7 +390,8 @@ def prevailing_via_protection_in_text(content: str) -> Optional[dict]:
 
 def generate_via_sexpr(x: float, y: float, size: float, drill: float,
                        layers: List[str], net_id: int, free: bool = False,
-                       net_name: str = None, tenting_attrs: dict = None) -> str:
+                       net_name: str = None, tenting_attrs: dict = None,
+                       inherit_when_unspecified: bool = False) -> str:
     """Generate KiCad S-expression for a via.
 
     Args:
@@ -436,12 +401,18 @@ def generate_via_sexpr(x: float, y: float, size: float, drill: float,
             (Via.tenting_attrs). Pass it for any via that already existed so a
             ripped-and-re-placed via keeps its real tenting/plugging/filling
             instead of being re-stamped with front+back tenting (#489 §8).
+        inherit_when_unspecified: Pass True alongside it for a RE-PLACED via.
+            An empty spec then emits nothing, so a via that was inheriting the
+            board's `(setup (tenting ...))` keeps inheriting it rather than
+            gaining an explicit token it never had (#741). See
+            via_protection_sexpr.
     """
     layers_str = '" "'.join(layers)
     free_str = "\n\t\t(free yes)" if free else ""
     net_str = f'(net "{_escape_net_name(net_name)}")' if net_name is not None else f'(net {net_id})'
     # KiCad 10 adds structured tenting/covering/plugging fields after layers
-    tenting_str = via_protection_sexpr(tenting_attrs, net_name)
+    tenting_str = via_protection_sexpr(tenting_attrs, net_name,
+                                      inherit_when_unspecified)
     return f'''	(via
 		(at {x:.6f} {y:.6f})
 		(size {size})

--- a/py_router/kicad_writer.py
+++ b/py_router/kicad_writer.py
@@ -282,16 +282,87 @@ DEFAULT_VIA_TENTING = {'tenting': '(front yes) (back yes)'}
 VIA_PROTECTION_TOKEN_ORDER = ('tenting', 'covering', 'plugging', 'capping', 'filling')
 
 
-def via_protection_sexpr(tenting_attrs: dict = None, net_name: str = None) -> str:
+class _InheritViaProtection(dict):
+    """See INHERIT_VIA_PROTECTION.
+
+    An EMPTY dict subclass that is deliberately TRUTHY, which is what makes the
+    sentinel fail SAFE rather than fail loudly. `via_protection_sexpr` matches
+    it by identity, so normally the type never matters -- but identity is a
+    fragile thing to rest a fab attribute on: a `copy.copy`, a pickle round
+    trip, or a second import of this module under a different `sys.path` root
+    (this repo imports `kicad_writer` by bare name from py_router, py_placer
+    and py_tools) all produce an object that is `==` but not `is`.
+
+    So the fallback path must also be right. Being a dict, it survives the
+    truthiness branch and the token loop; being EMPTY, that loop emits nothing
+    -- exactly what the identity branch would have done. A plain `object()`
+    would raise there instead, and a FALSY sentinel would be worse still: it
+    would fall through to the front+back default, which is the bug (#741).
+    """
+    __slots__ = ()
+
+    def __bool__(self):
+        return True
+
+    __nonzero__ = __bool__       # py2-style spelling, harmless and explicit
+
+    def __repr__(self):
+        return 'INHERIT_VIA_PROTECTION'
+
+
+# Pass this as `tenting_attrs` for a via that came OFF the board and is going
+# back on carrying NO spec of its own. It is NOT the same as None: None means
+# "the caller did not say", which keeps the #489 front+back default; this means
+# "the board said nothing about this via, and nothing is the answer". KiCad
+# reads a via with no protection tokens as inheriting the board's
+# `(setup (tenting ...))` -- which is exactly what such a via had before it was
+# lifted, so re-stamping it with front+back tenting changes a fab attribute
+# that nobody asked to change.
+#
+# The GUI half has always behaved this way: gui_utils.apply_via_protection
+# returns early on an empty spec, because pcbnew's *_MODE_FROM_BOARD already
+# means inherit. This is the text writer's half of that (#741).
+#
+# Deliberately OPT-IN. Every existing caller keeps passing what it passes, and
+# tests/test_489_via_tenting.py's pin on the spec-less default -- which calls
+# generate_via_sexpr with no `tenting_attrs` at all -- resolves to None and is
+# untouched. Other re-placement sites (plane_io.restore_failed_reroute_nets is
+# the closest sibling) have the same residue and should adopt this, but each
+# needs its own measurement; #741 scopes it to the placement via-nudge.
+INHERIT_VIA_PROTECTION = _InheritViaProtection()
+
+
+def via_protection_sexpr(tenting_attrs: dict = None,
+                         net_name: str = None) -> str:
     """The `(tenting ...)` / `(covering ...)` / ... fragment to emit for a via.
 
     `tenting_attrs` is a Via's parsed spec ({token: raw inner text}); passing it
     keeps what the board actually specified. Without it the previous behavior
     stands -- front+back tenting on KiCad 10 output -- since there is no
     board-level policy to consult here (#489 §8).
+
+    THREE states, not two, because `None` and `{}` used to mean the same thing
+    here and they are not the same fact (#741):
+
+      a real spec              -> emit it
+      INHERIT_VIA_PROTECTION   -> emit NOTHING; the board said nothing about
+                                  this via and the via keeps inheriting
+                                  `(setup (tenting ...))`. For a via that came
+                                  OFF the board -- see that constant.
+      None / {} (KiCad 10)     -> the #489 default, front+back tenting
+      None / {} (numeric net)  -> nothing, as before
+
+    Order matters: the sentinel is tested FIRST and by identity, so a caller
+    that has a real spec always wins, and no truthiness test can reach it.
     """
-    spec = tenting_attrs if tenting_attrs else (
-        DEFAULT_VIA_TENTING if net_name is not None else {})
+    if tenting_attrs is INHERIT_VIA_PROTECTION:
+        spec = {}
+    elif tenting_attrs:
+        spec = tenting_attrs
+    elif net_name is not None:
+        spec = DEFAULT_VIA_TENTING
+    else:
+        spec = {}
     if not spec:
         return ""
     def _one(token: str, inner: str) -> str:

--- a/py_router/obstacle_map.py
+++ b/py_router/obstacle_map.py
@@ -1520,12 +1520,22 @@ _HOLE_CLR_ORIGIN = set()      # paths whose floor came from fab_floor_origin,
                               # live rule below what the board declared
 
 
-def resolve_hole_clearance(pcb_data: PCBData, config) -> float:
+def resolve_hole_clearance(pcb_data: PCBData, config,
+                           pcb_file: str = None) -> float:
     """The copper-to-HOLE floor this board declares, in mm (0.0 = none).
 
     Resolved ENGINE-SIDE off ``PCBData.source_path`` (the #498 mechanism built
     for exactly this), so both fronts inherit it with no wiring. An explicit
     ``config.hole_clearance`` wins and stops the read.
+
+    ``pcb_file`` overrides the parsed ``source_path`` when a caller holds the
+    authoritative path -- the #498 rule the rest of the toolchain follows,
+    "the CALLER's path when it has one, else ``PCBData.source_path``". Added
+    for #761: a board staged into a temp dir and parsed from there carries a
+    ``source_path`` that is not the board the caller means, and
+    ``grade_pad_legality``/``QuenchState`` already thread ``pcb_file`` to
+    ``PadClearanceModel.for_board`` for exactly that reason. Default ``None``
+    keeps every existing caller bit-identical.
 
     TWO sources, and the larger wins: ``design_settings.rules`` (what the
     project declares NOW) and ``kicad_routing_tools.fab_floor_origin`` (what it
@@ -1566,8 +1576,15 @@ def resolve_hole_clearance(pcb_data: PCBData, config) -> float:
       place; a #130 pad-via graze left unrelocated) rather than routing around
       the hole.
     * ``placement/legality.PartPads`` builds its NPTH keep-out radii from a bare
-      ``fp``/``clearance`` pair with no board pointer in hand, so it cannot call
-      this helper without a threaded parameter.
+      ``fp``/``clearance`` pair with no board pointer in hand. **#761 threaded
+      the parameter rather than the board**: ``legality.resolve_npth_floor``
+      calls this helper ONCE in the caller and passes the resolved float down,
+      so ``PartPads`` still holds no board pointer while the two call sites
+      that read hole keep-outs (``grade_pad_legality``, ``QuenchState``) do
+      carry the declared floor. The four that read only pad rects, extents or
+      silk deliberately do not. This bullet is kept, corrected rather than
+      deleted, because "it cannot reach here" was true for two issues and a
+      reader who remembers it needs to see that it stopped being true.
 
     The rule the first three encode: raise this floor on passes that CHOOSE
     where new copper goes or that MOVE copper by a measured shortfall, not on
@@ -1588,7 +1605,7 @@ def resolve_hole_clearance(pcb_data: PCBData, config) -> float:
     explicit = getattr(config, 'hole_clearance', 0.0) or 0.0
     if explicit > 0:
         return float(explicit)
-    path = getattr(pcb_data, 'source_path', "") or ""
+    path = pcb_file or getattr(pcb_data, 'source_path', "") or ""
     if not path:
         return 0.0
     if path not in _HOLE_CLR_CACHE:

--- a/py_tools/animate_fanout_clearance.py
+++ b/py_tools/animate_fanout_clearance.py
@@ -230,7 +230,10 @@ def main():
                    "(default: input_capmove.gif)")
     p.add_argument("--clearance", type=float, default=defaults.CLEARANCE)
     p.add_argument("--grid-step", type=float, default=defaults.GRID_STEP)
-    p.add_argument("--board-edge-clearance", type=float, default=0.55)
+    # None, not 0.55 (#733): the engine resolves it, so the GIF frames the
+    # same usable box the run it visualises actually used. A private copy
+    # here would be a third notion of the margin -- the defect #733 closed.
+    p.add_argument("--board-edge-clearance", type=float, default=None)
     p.add_argument("--capture-radius", type=float, default=2.0)
     p.add_argument("--default-via-size", type=float, default=DEFAULT_VIA_SIZE)
     p.add_argument("--near-margin", type=float, default=1.0)

--- a/py_tools/render_placement.py
+++ b/py_tools/render_placement.py
@@ -763,7 +763,11 @@ def draw_legality(d, r, model, *, side=None):
         p = state.parts.get(ref)
         if p is None:
             continue
-        for (cx, cy, rad) in ctx.parts[ref].hole_circles(p.x, p.y, p.rot):
+        # #761: the KEEP-OUT, not the inflation. This panel is captioned
+        # "orange circles at NPTH keepouts"; hole_circles' radius is the growth
+        # above `clearance`, so at --clearance >= the requirement it drew the
+        # bare drill and the picture agreed with the model's own blind spot.
+        for (cx, cy, rad) in ctx.parts[ref].hole_keepouts(p.x, p.y, p.rot):
             x0, y0 = r.tf.pt(cx - rad, cy - rad)
             x1, y1 = r.tf.pt(cx + rad, cy + rad)
             d.ellipse([min(x0, x1), min(y0, y1), max(x0, x1), max(y0, y1)],

--- a/tests/gui_parity/test_733_cap_edge_clearance_gui.py
+++ b/tests/gui_parity/test_733_cap_edge_clearance_gui.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""#733: the cap-placement edge margin, read off the REAL headless dialog.
+
+`tests/test_733_fanout_clearance_edge_margin.py` covers the engine and greps
+`fanout_gui.py` for the kwarg, but the `swig_gui.py` half -- the resolver and
+the shared-params key -- was gated by NOTHING. Measured by the #733 review:
+deleting `'cap_board_edge_clearance': self._effective_placement_edge_clearance()`
+from `get_shared_params`, or making that method `return None` always, left every
+one of those tests green while the operator's override silently stopped
+travelling.
+
+The three states this asserts, and why each is load-bearing:
+
+  * UNCHECKED -> None, so the engine resolves (CLI parity with an omitted
+    --board-edge-clearance). Not `_effective_board_edge_clearance`, which is the
+    SIGNAL keep-out: it answers 0.0 on a board with no rule and is then
+    fab-floored to 0.20, so reusing it would inset caps at 0.20 instead of 0.55
+    -- a 0.35mm relaxation shipped inside the parity fix. The signal key is read
+    here too, as the negative control that proves the two are different numbers.
+  * CHECKED with a real value -> that value, honoured as typed.
+  * CHECKED with ZERO -> None. This is the footgun the review found: the control
+    is CREATED at defaults.BOARD_EDGE_CLEARANCE (0.0) with a range minimum of
+    0.0, so "ticked the box, typed nothing" is a reachable state, and passing it
+    on would inset caps at the bare clearance -- LOOSER than the 0.55 this tab
+    used before #733.
+
+Needs KiCad's python (wx + pcbnew); re-execs into it automatically, like its
+siblings. Constructs the dialog headless and reads dict values. No routing runs;
+seconds, not minutes.
+
+Run: python3 tests/gui_parity/test_733_cap_edge_clearance_gui.py
+"""
+import os
+import subprocess
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+
+KICAD_PYTHONS = [
+    '/Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/'
+    'Versions/Current/bin/python3',
+    '/usr/bin/python3',
+    r'C:\Program Files\KiCad\10.0\bin\python.exe',
+]
+
+
+def _reexec_into_kicad():
+    for cand in KICAD_PYTHONS:
+        if cand == sys.executable or not os.path.exists(cand):
+            continue
+        if subprocess.run([cand, '-c', 'import pcbnew, wx'],
+                          capture_output=True).returncode == 0:
+            argv = [cand, os.path.abspath(__file__)] + sys.argv[1:]
+            if os.name == 'nt':
+                sys.exit(subprocess.run(argv).returncode)
+            os.execv(cand, argv)
+    # Exit 0, like every sibling in this directory -- these gates are run by
+    # hand and by contributors who may not have KiCad installed, and a hard
+    # failure there is noise, not signal. But say plainly that the gate did NOT
+    # run: this file exists because the swig_gui half was covered by nothing,
+    # and a silent skip re-creates exactly that state on a machine without wx.
+    # CLAUDE.md: probe before recording it as not-run --
+    #   <kicad>/bin/python3 -c "import pcbnew, wx; print(wx.version())"
+    print("SKIP: no python with pcbnew+wx found -- THIS GATE DID NOT RUN, and "
+          "nothing else covers swig_gui._effective_placement_edge_clearance")
+    sys.exit(0)
+
+
+def main():
+    try:
+        import wx  # noqa: F401
+        import pcbnew  # noqa: F401
+    except ImportError:
+        _reexec_into_kicad()
+
+    os.environ.setdefault('WXSUPPRESS_SIZER_FLAGS_CHECK', '1')
+    import wx
+    sys.path.insert(0, REPO)
+    sys.path.insert(0, os.path.join(REPO, 'py_router'))
+    sys.path.insert(0, os.path.join(REPO, 'py_placer'))
+    sys.path.insert(0, os.path.join(REPO, 'py_tools'))
+    sys.path.insert(0, os.path.dirname(REPO))
+
+    app = wx.App(False)  # noqa: F841  (before any wx object)
+    board = os.path.join(REPO, 'kicad_files', 'splitflap_driver.kicad_pcb')
+    from kicad_parser import parse_kicad_pcb
+    from kicad_routing_plugin.swig_gui import RoutingDialog
+    from placement.fanout_clearance import (CAP_EDGE_CLEARANCE,
+                                            resolve_cap_edge_clearance)
+
+    dlg = RoutingDialog(None, parse_kicad_pcb(board), board)
+    failures = []
+
+    def check(what, ok, detail=''):
+        # `detail` is the FAILURE explanation, so print it only on failure --
+        # an OK line carrying "the key is absent" reads as a contradiction.
+        print(('  OK   ' if ok else '  FAIL ') + what
+              + ('' if ok or not detail else ' -- ' + detail))
+        if not ok:
+            failures.append(what)
+
+    def shared():
+        return dlg.fanout_tab.get_shared_params()
+
+    # ON THE GATE: the key must EXIST, or every assertion below reads None from
+    # a dict that simply never carried it and the file passes vacuously.
+    dlg.edge_clearance_check.SetValue(True)
+    dlg.board_edge_clearance.SetValue(0.8)
+    s = shared()
+    check('get_shared_params carries cap_board_edge_clearance',
+          'cap_board_edge_clearance' in s,
+          'the key is absent -- the operator override never reaches the engine')
+    check('checked 0.8 -> the typed value travels',
+          s.get('cap_board_edge_clearance') == 0.8,
+          repr(s.get('cap_board_edge_clearance')))
+
+    dlg.edge_clearance_check.SetValue(False)
+    s = shared()
+    cap, sig = s.get('cap_board_edge_clearance'), s.get('board_edge_clearance')
+    check('unchecked -> None, so the ENGINE resolves it', cap is None, repr(cap))
+    check('...and the engine then answers the placement default',
+          resolve_cap_edge_clearance(board, cap)
+          == (CAP_EDGE_CLEARANCE, 'fixed default'))
+    # NEGATIVE CONTROL: the SIGNAL twin on the same control answers something
+    # else entirely, and something SMALLER. Not `sig != cap` -- with cap None
+    # that is true of any float and would pass on a build that had wired the
+    # two together in the other direction.
+    check('the signal keep-out is a real number, not None',
+          isinstance(sig, (int, float)),
+          f'signal={sig!r} -- the control this compares against is gone')
+    check('...and it is BELOW the placement default, so reusing it would have '
+          'inset caps closer to the edge',
+          isinstance(sig, (int, float)) and sig < CAP_EDGE_CLEARANCE,
+          f'signal={sig!r} vs placement default {CAP_EDGE_CLEARANCE}')
+
+    # The footgun: ticked, but never typed in. SetValue(0.0) reproduces the
+    # control's own creation state (defaults.BOARD_EDGE_CLEARANCE, range min 0).
+    dlg.edge_clearance_check.SetValue(True)
+    dlg.board_edge_clearance.SetValue(0.0)
+    cap = shared().get('cap_board_edge_clearance')
+    check('checked but ZERO -> None (an empty override is UNSET)',
+          cap is None, repr(cap))
+    check('...so the margin does not fall below the placement default',
+          resolve_cap_edge_clearance(board, cap)[0] == CAP_EDGE_CLEARANCE)
+
+    dlg.Destroy()
+    print()
+    if failures:
+        print(f"VERDICT: {len(failures)} FAILURE(S): {', '.join(failures)}")
+        return 1
+    print("VERDICT: cap edge margin reaches the engine from the real dialog")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/gui_parity/test_746_cap_summary_gui.py
+++ b/tests/gui_parity/test_746_cap_summary_gui.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""#746: the plugin's cap-optimization summary, driven with real result dicts.
+
+`tests/test_746_fanout_clearance_resolved_credit.py` covers the engine. The
+GUI half was gated by NOTHING, and had been wrong for a long time because of
+it: `fanout_gui.py` rendered `unresolved` as "could not clear a foreign via"
+while `graze_penalty` has always been via (#130) + track (#278) + pad (#275).
+It named one of the three channels. That was wrong before #736 and more
+visibly wrong after it, which made the track channel reachable in that verdict
+for the first time.
+
+The reason nothing tested it is structural, not an oversight: the text was
+built inline inside `_optimize_decoupling_caps`, which needs a live pcbnew
+board, a fanned-out design and a dialog. #746 lifts it to a module-level
+`cap_optimization_summary(result)` taking a plain dict, so this gate drives the
+REAL function with the REAL dicts the engine returns -- no board, no dialog,
+milliseconds.
+
+The dicts below are not invented. They are the shapes measured on the two rigs
+and the one tracked board in the engine test file, plus the six-key shape the
+engine's two early returns carry.
+
+Needs KiCad's python (fanout_gui imports wx at module level); re-execs into it
+automatically, like its siblings.
+
+Run: python3 tests/gui_parity/test_746_cap_summary_gui.py
+"""
+import os
+import subprocess
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))))
+
+KICAD_PYTHONS = [
+    '/Applications/KiCad/KiCad.app/Contents/Frameworks/Python.framework/'
+    'Versions/Current/bin/python3',
+    '/usr/bin/python3',
+    r'C:\Program Files\KiCad\10.0\bin\python.exe',
+]
+
+
+def _reexec_into_kicad():
+    for cand in KICAD_PYTHONS:
+        if cand == sys.executable or not os.path.exists(cand):
+            continue
+        if subprocess.run([cand, '-c', 'import pcbnew, wx'],
+                          capture_output=True).returncode == 0:
+            argv = [cand, os.path.abspath(__file__)] + sys.argv[1:]
+            if os.name == 'nt':
+                sys.exit(subprocess.run(argv).returncode)
+            os.execv(cand, argv)
+    # Exit 0, like every sibling here -- but say plainly that the gate did NOT
+    # run. CLAUDE.md: probe before recording it as not-run --
+    #   <kicad>/bin/python3 -c "import pcbnew, wx; print(wx.version())"
+    print("SKIP: no python with pcbnew+wx found -- THIS GATE DID NOT RUN, and "
+          "nothing else covers fanout_gui.cap_optimization_summary")
+    sys.exit(0)
+
+
+# --- the result dicts, as MEASURED by tests/test_746_... ------------------
+# arm A: a boxed cap only the #313 via-nudge could free.
+ARM_A = {'placements': [], 'resolved': ['C1'], 'unresolved': [],
+         'via_resolved': ['C1'], 'regrazed': [],
+         'via_moves': [(11.175, 10.0, {})], 'new_segments': [{}]}
+# arm B: a cap the sweep cleaned, re-grazed by the connector this pass drew.
+ARM_B = {'placements': [{}, {}], 'resolved': [], 'unresolved': ['C1', 'C2'],
+         'via_resolved': [], 'regrazed': ['C2'],
+         'via_moves': [(10.0, 12.0, {})], 'new_segments': [{}]}
+# the sweep-only path: the nudger is never called.
+SWEEP = {'placements': [{}], 'resolved': ['C1'], 'unresolved': [],
+         'via_resolved': [], 'regrazed': [], 'via_moves': [],
+         'new_segments': []}
+# orangecrab_ext_pll @0.1, fallback off -- the tracked board that reaches it.
+REAL = {'placements': [{}] * 18, 'resolved': ['C19', 'C44', 'C45', 'C67'],
+        'unresolved': ['R19', 'C1', 'C25', 'C7', 'C52', 'C53', 'C68', 'C55',
+                       'C28', 'C59'],
+        'via_resolved': ['C19', 'C44', 'C45'], 'regrazed': [],
+        'via_moves': [(0, 0, {})] * 9, 'new_segments': [{}] * 17}
+# what the engine's TWO early returns carry: six keys, none of the nudge four.
+EARLY = {'placements': [], 'resolved': [], 'unresolved': [], 'bga_refs': [],
+         'required': [], 'clearance_notes': []}
+
+
+def main():
+    try:
+        import wx  # noqa: F401
+        import pcbnew  # noqa: F401
+    except ImportError:
+        _reexec_into_kicad()
+
+    os.environ.setdefault('WXSUPPRESS_SIZER_FLAGS_CHECK', '1')
+    sys.path.insert(0, REPO)
+    sys.path.insert(0, os.path.join(REPO, 'py_router'))
+    sys.path.insert(0, os.path.join(REPO, 'py_placer'))
+    sys.path.insert(0, os.path.join(REPO, 'py_tools'))
+    sys.path.insert(0, os.path.dirname(REPO))
+
+    from kicad_routing_plugin.fanout_gui import cap_optimization_summary as S
+
+    failures = []
+
+    def check(what, ok, detail=''):
+        print(('  OK   ' if ok else '  FAIL ') + what
+              + ('' if ok or not detail else ' -- ' + detail))
+        if not ok:
+            failures.append(what)
+
+    # ON THE GATE: the function must be reachable and must produce text, or
+    # every assertion below is about an empty string and passes vacuously.
+    check('cap_optimization_summary is importable without a board or dialog',
+          callable(S))
+    # In a try, because the most likely defect here is a KeyError on the
+    # early-return shape: unguarded, that aborts the gate with a traceback
+    # and no FAIL line, which is a non-zero exit that does not say WHY
+    # (CLAUDE.md: assert the reason, not the exit code).
+    try:
+        _early = S(EARLY)
+        check('it returns text for the simplest dict',
+              isinstance(_early, str)
+              and _early.startswith('Decoupling caps'), repr(_early))
+    except Exception as e:                                       # noqa: BLE001
+        check('it returns text for the simplest dict', False,
+              'raised %s: %s -- a read is not defensive, and the plugin '
+              'crashes on a board with no vias' % (type(e).__name__, e))
+
+    # 1. The wording defect this issue names "while here".
+    for name, d in (('armA', ARM_A), ('armB', ARM_B), ('real', REAL)):
+        check('%s: the verdict no longer says "a foreign via" for a via +'
+              ' track + pad grade' % name,
+              'could not clear a foreign via' not in S(d), S(d))
+    check('the unresolved clause names all three channels',
+          'still grazing foreign copper (via/track/pad)' in S(ARM_B), S(ARM_B))
+
+    # 2. The credit the operator could not previously see.
+    check('armA: the nudge is credited by name',
+          '1 cap(s) freed by that nudge' in S(ARM_A), S(ARM_A))
+    check('real: three caps credited to the nudge, not to the sweep',
+          '3 cap(s) freed by that nudge' in S(REAL), S(REAL))
+
+    # 3. The cause of a re-graze is named rather than left anonymous.
+    check('armB: the pass says it broke C2 itself',
+          "re-grazed by this pass's own connector copper: C2" in S(ARM_B),
+          S(ARM_B))
+    check('armB: and C2 is still reported unresolved',
+          'manual: C1, C2' in S(ARM_B), S(ARM_B))
+
+    # 4. SUPPRESSION. This is the arm that protects the 22 tracked boards,
+    # where the nudger is never called at the shipped defaults: the line must
+    # be what it always was, not the new one with empty counts in it.
+    check('sweep-only: the summary is exactly the pre-#746 line',
+          S(SWEEP) == 'Decoupling caps optimized: 1 moved', S(SWEEP))
+    for clause in ('freed by that nudge', 're-grazed', 'still grazing'):
+        check('sweep-only: no %r clause is emitted' % clause,
+              clause not in S(SWEEP), S(SWEEP))
+
+    # 5. The EARLY-RETURN shape. The engine's two early returns carry neither
+    # 'via_moves'/'new_segments' nor 'via_resolved'/'regrazed', so every read
+    # must be a .get. A KeyError here is a crash in the plugin, on the most
+    # ordinary board there is: one with no vias.
+    try:
+        early = S(EARLY)
+        check('a board with no vias does not raise', True)
+        check('...and reports a plain no-op',
+              early == 'Decoupling caps optimized: 0 moved', early)
+    except Exception as e:                                       # noqa: BLE001
+        check('a board with no vias does not raise', False,
+              '%s: %s' % (type(e).__name__, e))
+
+    # 6. A None where a list is expected -- the engine never does this, but
+    # `.get(k) or []` is what makes the reads defensive and a bare `.get(k)`
+    # would pass every arm above and crash only here.
+    try:
+        check('None values are tolerated like absent ones',
+              S({'placements': None, 'unresolved': None, 'via_moves': None,
+                 'via_resolved': None, 'regrazed': None})
+              == 'Decoupling caps optimized: 0 moved')
+    except Exception as e:                                       # noqa: BLE001
+        check('None values are tolerated like absent ones', False,
+              '%s: %s' % (type(e).__name__, e))
+
+    # 7. The method still routes through this function rather than carrying a
+    # second copy of the wording -- the CLI/GUI drift shape CLAUDE.md warns
+    # about, one front silently keeping its own text.
+    import inspect
+    from kicad_routing_plugin import fanout_gui as FG
+    body = inspect.getsource(FG.FanoutTab._optimize_decoupling_caps)
+    check('_optimize_decoupling_caps delegates instead of rebuilding the text',
+          'cap_optimization_summary(result)' in body
+          and 'Decoupling caps optimized' not in body)
+
+    print()
+    if failures:
+        print(f"VERDICT: {len(failures)} FAILURE(S): {'; '.join(failures)}")
+        return 1
+    print("VERDICT: the plugin's cap summary names the right channels, "
+          "credits the nudge, and is unchanged where nothing nudged")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/gui_parity/test_cli_postpass_coverage.py
+++ b/tests/gui_parity/test_cli_postpass_coverage.py
@@ -40,10 +40,18 @@ PLUGIN = REPO / "kicad_routing_plugin"
 # post-passes (run_drc graze audit, fix_project_for_output) were a blind spot.
 # Point at the package __init__ where main() actually lives.
 # #522 layout: the CLI mains live under py_router/.
+# #725: place_fanout_clearance.py was absent, so this gate never scanned the
+# decoupling-cap repair CLI even though its main() runs two tracked post-passes
+# (warn_if_missing_project_floor, fix_project_for_output). That matters
+# specifically because the cap-repair engine now reads the sibling .kicad_pro
+# and .kicad_dru for its own arithmetic: dropping the project on the way out
+# does not just cost the next step its DRC floor, it silently changes what the
+# NEXT cap-repair run prices at.
 CLI_MAINS = ["py_router/route.py", "py_router/route_diff.py",
              "py_router/route_planes.py", "py_router/repair_planes.py",
              "py_router/bga_fanout/__init__.py",
-             "py_router/qfn_fanout/__init__.py"]
+             "py_router/qfn_fanout/__init__.py",
+             "py_placer/place_fanout_clearance.py"]
 
 # Known post-engine passes -> GUI counterpart symbol(s). A pass is "covered" if
 # ANY listed symbol appears anywhere under kicad_routing_plugin/. Keep the RHS

--- a/tests/gui_parity/test_manifest_plan_parity.py
+++ b/tests/gui_parity/test_manifest_plan_parity.py
@@ -282,6 +282,13 @@ _MUST_RESOLVE = {
     'impedance', 'ordering', 'direction', 'time_matching',
     'keepout', 'guide_corridor', 'length_match_groups', 'swappable_nets',
     'polarity_swap_nets', 'qfn_track_width', 'qfn_clearance',
+    # #733: place_fanout_clearance's --board-edge-clearance -> the SHARED
+    # Basic-tab edge control (not a cap_* one), which ai_plan's
+    # _GEOMETRY_OVERRIDE_CHECKS ticks by this exact name. This set gates the
+    # NAME (does it reach a control?); check_cap_flags below gates the
+    # converter ROW that produces it. Measured: deleting the CAP_FLAG_PARAMS
+    # row leaves this half green, which is why both exist.
+    'board_edge_clearance',
 }
 
 
@@ -342,6 +349,42 @@ def check_param_resolution():
             bad.append((p, f"alias -> {tgt!r}, but no such GUI control"))
         else:
             bad.append((p, "no control, no alias, not special -> would be ignored"))
+    return bad
+
+
+def check_cap_flags():
+    """#733: the optimize_caps step's flags survive conversion.
+
+    The pairs loop above deliberately `continue`s on place_fanout_clearance.py
+    ("optimize_caps: no routing flags to assert"), so nothing there looks at
+    CAP_FLAG_PARAMS at all. That was harmless while every row named a
+    bga_options control the plan executor ignores anyway; it stopped being
+    harmless when --board-edge-clearance joined the table, because that one
+    names a REAL dialog control and changes where cap copper may sit relative
+    to Edge.Cuts. Measured: deleting its row left the whole gate green.
+
+    Self-contained, like check_group_flags: no corpus needed.
+    """
+    bad = []
+    argv = ['python3', 'py_placer/place_fanout_clearance.py', 'in.kicad_pcb',
+            'out.kicad_pcb', '--board-edge-clearance', '0.85',
+            '--near-margin', '1.5', '--no-rotate']
+    step = m2p.cap_optimization_step(argv)
+    if step.get('action') != 'optimize_caps':
+        return [('(step)', f"action is {step.get('action')!r}")]
+    params = step.get('params') or {}
+    for flag, key, want in (('--board-edge-clearance', 'board_edge_clearance', 0.85),
+                            ('--near-margin', 'cap_near_margin', 1.5),
+                            ('--no-rotate', 'cap_allow_rotation', False)):
+        if params.get(key) != want:
+            bad.append((flag, f"-> {key}={params.get(key)!r}, expected {want!r}"))
+    # NEGATIVE CONTROL: an omitted flag must NOT be invented. An engine-resolved
+    # default that leaked into the plan would pin the margin at plan time and
+    # defeat the point of resolving it per board.
+    bare = m2p.cap_optimization_step(
+        ['python3', 'py_placer/place_fanout_clearance.py', 'in.kicad_pcb'])
+    if 'board_edge_clearance' in (bare.get('params') or {}):
+        bad.append(('(omitted)', 'an unset flag was materialised into the plan'))
     return bad
 
 
@@ -473,6 +516,13 @@ def main():
     for p, why in res_bad:
         print(f"    {p}: {why}")
 
+    # #733 optimize_caps flags (self-contained, no corpus needed).
+    cap_bad = check_cap_flags()
+    print(f"\nCap-optimization flags: {'OK' if not cap_bad else 'FAILED'} "
+          f"(--board-edge-clearance and the cap_* knobs survive).")
+    for f, why in cap_bad:
+        print(f"    {f}: {why}")
+
     # #459 placement-block flags (self-contained, no corpus needed).
     grp_bad = check_group_flags()
     print(f"\nPlacement-block flags: {'OK' if not grp_bad else 'FAILED'} "
@@ -486,7 +536,7 @@ def main():
     for f, why in ref_bad:
         print(f"    {f}: {why}")
 
-    return 1 if (total_bad or res_bad or grp_bad or ref_bad) else 0
+    return 1 if (total_bad or res_bad or cap_bad or grp_bad or ref_bad) else 0
 
 
 if __name__ == "__main__":

--- a/tests/mutate_730.py
+++ b/tests/mutate_730.py
@@ -128,9 +128,9 @@ ROWS = [
     # lc=0.00 CONTROL arms while the headline refusal arms still pass -- which
     # is why those controls are not optional.
     ('via-override-uses-the-BOARD-floor', 'fc',
-     '            d = _seg_seg_dist(x1, y1, x2, y2, hx1, hy1, hx2, hy2) - hr',
-     '            d = _seg_seg_dist(x1, y1, x2, y2, hx1, hy1, hx2, hy2) - hr\n'
-     '            hlc = max(hlc, getattr(st, \'npth_floor\', 0.0))',
+     '                                     hx1, hy1, hx2, hy2) - hr',
+     '                                     hx1, hy1, hx2, hy2) - hr'
+     '\n            hlc = max(hlc, getattr(st, \'npth_floor\', 0.0))',
      (T730,), 'KILLED'),
     # The classic #617 mutation on the BASE gate, and the row the lc=0.00
     # CONTROL arms exist for. `via-override-uses-the-BOARD-floor` does NOT
@@ -181,10 +181,36 @@ ROWS = [
      '    npth_step = max(npth_clr, resolve_hole_clearance(pcb_data, None))',
      "    npth_step = max(npth_clr, getattr(st, 'npth_floor', 0.0))",
      (T730, T737), 'KILLED'),
-    # ---- the distance kernel -------------------------------------------
-    ('seg-seg-crossing-test-relaxed', 'fc',
-     '    if o1 * o2 < 0 and o3 * o4 < 0:',
-     '    if o1 * o2 <= 0 and o3 * o4 <= 0:',
+    # ---- the guard that stopped holding #617's mutation ------------------
+    # A review laundered the board read into the floor -- `npth_clr` reassigned
+    # from `npth_step` on the next line -- and every check in test_737's
+    # rewritten guard still passed, because the read itself was still pinned to
+    # the `npth_step` assignment. The old blanket ban made this unspellable.
+    # Both files now pin the floor's assignment COUNT as well.
+    ('board-read-laundered-into-the-floor', 'fc',
+     '    npth_step = max(npth_clr, resolve_hole_clearance(pcb_data, None))',
+     '    npth_step = max(npth_clr, resolve_hole_clearance(pcb_data, None))\n'
+     '    npth_clr = npth_step',
+     (T730, T737, T617), 'KILLED'),
+    # ---- the SLOT / capsule geometry ------------------------------------
+    # All three of these survived the whole fanout test family until #730's
+    # review built slot fixtures for them. They are identical to the shipped
+    # code for a ROUND hole, which every other rig in the file uses -- so no
+    # amount of adding round-hole arms would ever have caught one.
+    ('override-hole-treated-as-a-POINT', 'fc',
+     '            override_holes.append((_h1[0], _h1[1], _h2[0], _h2[1], _hr,',
+     '            override_holes.append((_h1[0], _h1[1], _h1[0], _h1[1], _hr,',
+     (T730,), 'KILLED'),
+    ('site-A-rect-centred-on-the-PAD-not-the-circle', 'fc',
+     '                                (hx - hr, hy - hr, hx + hr, hy + hr, -1, None))',
+     '                                (p.global_x - hr, p.global_y - hr,'
+     '\n                                 p.global_x + hr, p.global_y + hr,'
+     ' -1, None))',
+     (T730,), 'KILLED'),
+    ('site-E-long-axis-drill', 'leg',
+     '                            (hx - fp.x, hy - fp.y, hd / 2.0 + npth_grow))',
+     '                            (hx - fp.x, hy - fp.y,'
+     '\n                             (p.drill or 0.0) / 2.0 + npth_grow))',
      (T730,), 'KILLED'),
     # ---- site E: PartPads ----------------------------------------------
     ('site-E-reverted-to-the-hoist', 'leg',

--- a/tests/mutate_730.py
+++ b/tests/mutate_730.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""The #730 mutation battery, shipped so its numbers can be re-derived.
+
+`tests/test_730_fanout_clearance_npth_local_clearance.py` records what each arm
+kills. A count is only checkable if the exact source edit is written down --
+two reviewers of the #746 branch reconstructed its rows from their names and
+both got the wrong answer, because a plausible-looking reconstruction of one
+row was semantically inert. So the edits live here, as data, next to the
+numbers they produced.
+
+Every row carries an EXPECTATION. Some mutations are deliberately inert -- the
+override list is already filtered to `lc > npth_step`, so re-spelling the
+CHARGE as `max(npth_clr, lc)` cannot change an answer -- and an inert row
+recorded as an expected survivor is a finding, while an inert row quietly
+deleted is a hole. A row whose verdict does not match its expectation is
+reported as WRONG.
+
+Two structural differences from `tests/mutate_750.py`, both forced by #730's
+shape:
+
+  * rows target TWO engine files (`fanout_clearance.py`, `legality.py`), so
+    each row names its target and BOTH are checked clean before anything runs
+    and restored in the `finally`.
+  * rows are graded by more than one test file -- site D's exclusion is held by
+    `test_617` as well as by `test_730` -- so each row names its tests and is
+    KILLED if ANY of them exits non-zero. `test_617` is a `run()`-style script
+    rather than unittest, so the FAIL/ERROR scraper tolerates its prose.
+
+NOT named `test_*.py`, so `tests/run_all.py` does not collect it: it REWRITES
+the engine in place. One writer per tree -- do not run it while a suite, an A/B
+replay or a review is reading the same checkout. The file refuses to start on a
+dirty engine, because restoring would write the COMMITTED text back over
+uncommitted work.
+
+    python3 tests/mutate_730.py
+    python3 tests/mutate_730.py --row site-A-reverted
+
+A row is KILLED by a FAILURE **or an ERROR**: dropping a `getattr` makes an arm
+raise rather than fail, and a battery that counted only failures would call
+that a survivor.
+
+An anchor that does not match EXACTLY ONCE is reported as BROKEN rather than
+skipped -- a battery that silently applies nothing reports every row as a
+survivor, which reads as a catastrophic test failure and is really a stale
+anchor.
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import subprocess
+import sys
+
+_TESTS = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_TESTS)
+
+FC = os.path.join(_ROOT, 'py_placer', 'placement', 'fanout_clearance.py')
+LEG = os.path.join(_ROOT, 'py_placer', 'placement', 'legality.py')
+TARGETS = {'fc': FC, 'leg': LEG}
+
+T730 = os.path.join(_TESTS, 'test_730_fanout_clearance_npth_local_clearance.py')
+T737 = os.path.join(_TESTS, 'test_737_fanout_clearance_via_hole.py')
+T617 = os.path.join(_TESTS, 'test_617_placement_fanout_hole_clearance.py')
+
+_VIA_GATE = """        if override_holes and override_hole_gap(
+                v.net_id, nx, ny, nx, ny) < vr - 1e-4:
+            return False"""
+_CONN_GATE = """        if override_holes and override_hole_gap(
+                net_id, sx, sy, ex, ey) < hw - 1e-4:
+            return False"""
+_E_BLOCK = """                    _lc = ((getattr(p, 'local_clearance', 0.0) or 0.0)
+                           if copper_holes else 0.0)
+                    npth_grow = max(0.0, max(defaults.NPTH_TO_TRACK_CLEARANCE,
+                                             _lc) - clearance)"""
+
+# (name, target, old, new, tests, expect)
+ROWS = [
+    # ---- site A: the cap keep-out rect ---------------------------------
+    ('site-A-reverted', 'fc',
+     '                        grow = max(0.0, max(self.npth_floor, lc) - clearance)',
+     '                        grow = max(0.0, self.npth_floor - clearance)',
+     (T730,), 'KILLED'),
+    ('site-A-loses-the-fab-floor', 'fc',
+     'max(0.0, max(self.npth_floor, lc) - clearance)',
+     'max(0.0, lc - clearance)',
+     (T730,), 'KILLED'),
+    ('site-A-threshold-at-clearance', 'fc',
+     'max(0.0, max(self.npth_floor, lc) - clearance)',
+     'max(0.0, max(clearance, lc) - clearance)',
+     (T730,), 'KILLED'),
+    ('site-A-getattr-dropped', 'fc',
+     "                        lc = getattr(p, 'local_clearance', 0.0) or 0.0",
+     '                        lc = p.local_clearance',
+     (T730,), 'KILLED'),
+    ('site-A-lc-becomes-a-PadFloor', 'fc',
+     '                            self.foreign_pad_floors.append(None)',
+     '                            self.foreign_pad_floors.append(\n'
+     '                                None if self._floors is None\n'
+     '                                else self._floors.pad_floor(p))',
+     (T730,), 'KILLED'),
+    # the long-axis trap: identical for a round hole, so ONLY the slot arm
+    # can see it. Recorded because "identical on the corpus" is exactly the
+    # reason a slot fixture had to be built by hand.
+    ('site-A-long-axis-drill', 'fc',
+     '                            hr = hd / 2.0 + grow',
+     '                            hr = (p.drill or 0.0) / 2.0 + grow',
+     (T730,), 'KILLED'),
+    # ---- site B: the via gate ------------------------------------------
+    ('via-override-gate-deleted', 'fc', _VIA_GATE, '        pass',
+     (T730, T737), 'KILLED'),
+    # the LOWER direction of the step threshold. Only the lc-0.15-at-gap-0.120
+    # arm can see this: at any gap above the override it is inert.
+    ('via-override-threshold-at-clearance', 'fc',
+     '            if _hlc <= npth_step + 1e-9:',
+     '            if _hlc <= clearance + 1e-9:',
+     (T730,), 'KILLED'),
+    # ...and the UPPER direction.
+    ('via-override-threshold-doubled', 'fc',
+     '            if _hlc <= npth_step + 1e-9:',
+     '            if _hlc <= 2 * npth_step + 1e-9:',
+     (T730,), 'KILLED'),
+    ('via-override-uses-the-DRILL-radius', 'fc',
+     '                v.net_id, nx, ny, nx, ny) < vr - 1e-4:',
+     '                v.net_id, nx, ny, nx, ny) < _via_drill_radius(v) - 1e-4:',
+     (T730,), 'KILLED'),
+    # the mutation _FakeSt.npth_floor = 0.60 exists for. It refuses the two
+    # lc=0.00 CONTROL arms while the headline refusal arms still pass -- which
+    # is why those controls are not optional.
+    ('via-override-uses-the-BOARD-floor', 'fc',
+     '            d = _seg_seg_dist(x1, y1, x2, y2, hx1, hy1, hx2, hy2) - hr',
+     '            d = _seg_seg_dist(x1, y1, x2, y2, hx1, hy1, hx2, hy2) - hr\n'
+     '            hlc = max(hlc, getattr(st, \'npth_floor\', 0.0))',
+     (T730,), 'KILLED'),
+    # The classic #617 mutation on the BASE gate, and the row the lc=0.00
+    # CONTROL arms exist for. `via-override-uses-the-BOARD-floor` does NOT
+    # reach them -- with no override the hole never enters the filtered list,
+    # so the gap helper is never consulted -- which the battery reported and
+    # this row corrects.
+    ('base-via-gate-reads-st-npth_floor', 'fc',
+     '                clearance + vr - 1e-4:',
+     "                max(clearance, getattr(st, 'npth_floor', 0.0)) "
+     '+ vr - 1e-4:',
+     (T730, T737), 'KILLED'),
+    ('via-override-drops-the-own-net-skip', 'fc',
+     '            if hnet == net_id:\n                continue',
+     '            if False:\n                continue',
+     (T730,), 'KILLED'),
+    # ---- site C: the connector gate ------------------------------------
+    ('connector-override-gate-deleted', 'fc', _CONN_GATE, '        pass',
+     (T730,), 'KILLED'),
+    # #617's floor. Measured on the sibling branch: this used to pass
+    # test_617, test_370 and test_fanout_clearance and was caught by a source
+    # guard ALONE. test_730 now holds it behaviourally as well.
+    ('connector-BASE-floor-lowered', 'fc',
+     '                npth_clr + hw - 1e-4:',
+     '                clearance + hw - 1e-4:',
+     (T730, T737, T617), 'KILLED'),
+    # ---- the two INERT re-spellings, recorded rather than omitted -------
+    # The list is already filtered to `lc > npth_step >= npth_clr`, so
+    # `max(npth_clr, hlc) == hlc` for every member. The FILTER carries the
+    # arm, not the charge -- which is the thing a reader is most likely to get
+    # backwards, and the reason both rows ship.
+    ('via-override-charged-as-a-MAX', 'fc',
+     '            if d - hlc < best:',
+     '            if d - max(npth_clr, hlc) < best:',
+     (T730,), 'SURVIVED'),
+    ('override-charge-given-the-VIA-step', 'fc',
+     '            if d - hlc < best:',
+     '            if d - (hlc if hlc > npth_clr else clearance) < best:',
+     (T730,), 'SURVIVED'),
+    # ---- site D: the EXCLUDED unification ------------------------------
+    # Three independent kills, which is what an excluded site deserves.
+    ('nudger-npth_clr-made-BOARD-AWARE', 'fc',
+     '    npth_clr = max(clearance, defaults.NPTH_TO_TRACK_CLEARANCE)',
+     '    from obstacle_map import resolve_hole_clearance as _rhc0\n'
+     '    npth_clr = max(clearance, defaults.NPTH_TO_TRACK_CLEARANCE,\n'
+     '                   _rhc0(pcb_data, None))',
+     (T730, T737, T617), 'KILLED'),
+    ('nudger-threshold-reads-st-instead-of-the-board', 'fc',
+     '    npth_step = max(npth_clr, resolve_hole_clearance(pcb_data, None))',
+     "    npth_step = max(npth_clr, getattr(st, 'npth_floor', 0.0))",
+     (T730, T737), 'KILLED'),
+    # ---- the distance kernel -------------------------------------------
+    ('seg-seg-crossing-test-relaxed', 'fc',
+     '    if o1 * o2 < 0 and o3 * o4 < 0:',
+     '    if o1 * o2 <= 0 and o3 * o4 <= 0:',
+     (T730,), 'KILLED'),
+    # ---- site E: PartPads ----------------------------------------------
+    ('site-E-reverted-to-the-hoist', 'leg',
+     [('        self.max_floor = 0.0    # upper bound on this part'
+       "'s pad requirements\n",
+       '        self.max_floor = 0.0    # upper bound on this part'
+       "'s pad requirements\n"
+       '        npth_grow = max(0.0, defaults.NPTH_TO_TRACK_CLEARANCE'
+       ' - clearance)\n'),
+      (_E_BLOCK, '                    pass')],
+     None, (T730,), 'KILLED'),
+    ('site-E-loses-the-fab-floor', 'leg',
+     '                    npth_grow = max(0.0, max(defaults.NPTH_TO_TRACK_CLEARANCE,\n'
+     '                                             _lc) - clearance)',
+     '                    npth_grow = max(0.0, _lc - clearance)',
+     (T730,), 'KILLED'),
+    ('site-E-threshold-at-clearance', 'leg',
+     '                    npth_grow = max(0.0, max(defaults.NPTH_TO_TRACK_CLEARANCE,\n'
+     '                                             _lc) - clearance)',
+     '                    npth_grow = max(0.0, max(clearance, _lc) - clearance)',
+     (T730,), 'KILLED'),
+    ('site-E-silk-gate-dropped', 'leg',
+     "                    _lc = ((getattr(p, 'local_clearance', 0.0) or 0.0)\n"
+     '                           if copper_holes else 0.0)',
+     "                    _lc = getattr(p, 'local_clearance', 0.0) or 0.0",
+     (T730,), 'KILLED'),
+    # an exact re-spelling of `max`. Recorded so nobody reads its survival as
+    # a coverage hole.
+    ('site-E-max-respelled-as-a-conditional', 'leg',
+     '                    npth_grow = max(0.0, max(defaults.NPTH_TO_TRACK_CLEARANCE,\n'
+     '                                             _lc) - clearance)',
+     '                    _f = defaults.NPTH_TO_TRACK_CLEARANCE\n'
+     '                    npth_grow = max(0.0, (_lc if _lc > _f else _f)\n'
+     '                                    - clearance)',
+     (T730,), 'SURVIVED'),
+]
+
+
+def _dirty(path):
+    p = subprocess.run(['git', 'status', '--porcelain', '--', path],
+                       capture_output=True, text=True, cwd=_ROOT)
+    return bool(p.stdout.strip())
+
+
+def run(only=None):
+    rows = [r for r in ROWS if only is None or r[0] == only]
+    if not rows:
+        print('no row named %r' % only)
+        return 1
+    for path in TARGETS.values():
+        if _dirty(path):
+            print('REFUSING: %s has uncommitted changes. Commit or stash '
+                  'first -- this battery restores by overwriting.'
+                  % os.path.basename(path))
+            return 2
+
+    orig = {k: io.open(v, encoding='utf-8', newline='').read()
+            for k, v in TARGETS.items()}
+    results = []
+    try:
+        for name, tgt, old, new, tests, expect in rows:
+            path = TARGETS[tgt]
+            base = orig[tgt]
+            # A row may carry several edits: some mutations are only
+            # expressible as a coordinated pair (site-E's hoist needs the
+            # hoisted line put back AND the per-pad block removed), and
+            # applying half of one produces a crash rather than the defect.
+            edits = old if isinstance(old, list) else [(old, new)]
+            counts = [base.count(o) for o, _n in edits]
+            if counts != [1] * len(edits):
+                results.append((name, 'BROKEN', expect,
+                                'anchors matched %s times' % counts, []))
+                continue
+            mutated = base
+            for o, nw in edits:
+                mutated = mutated.replace(o, nw, 1)
+            io.open(path, 'w', encoding='utf-8', newline='').write(mutated)
+            killed, failed = False, []
+            for t in tests:
+                p = subprocess.run([sys.executable, '-X', 'utf8', t],
+                                   capture_output=True, text=True,
+                                   encoding='utf-8', errors='replace',
+                                   timeout=1800, cwd=_ROOT)
+                out = (p.stderr or '') + (p.stdout or '')
+                if p.returncode:
+                    killed = True
+                failed += ['%s::%s' % (os.path.basename(t)[5:8],
+                                       l.split('(')[0].replace('FAIL: ', '')
+                                       .replace('ERROR: ', '').strip())
+                           for l in out.splitlines()
+                           if l.startswith(('FAIL:', 'ERROR:'))]
+            io.open(path, 'w', encoding='utf-8', newline='').write(base)
+            results.append((name, 'KILLED' if killed else 'SURVIVED', expect,
+                            '%d' % len(failed), failed))
+    finally:
+        for k, v in TARGETS.items():
+            io.open(v, 'w', encoding='utf-8', newline='').write(orig[k])
+
+    w = max(len(r[0]) for r in results)
+    wrong = 0
+    for name, verdict, expect, cnt, failed in results:
+        mark = ''
+        if verdict != expect:
+            mark = '   <-- WRONG, expected %s' % expect
+            wrong += 1
+        print('%-*s  %-9s  %-3s%s' % (w, name, verdict, cnt, mark))
+        for f in failed:
+            print('%s      %s' % (' ' * w, f))
+    killed = sum(1 for r in results if r[1] == 'KILLED')
+    survived = sum(1 for r in results if r[1] == 'SURVIVED')
+    broken = sum(1 for r in results if r[1] == 'BROKEN')
+    print('\n%d rows: %d killed, %d survived (%d of them expected), %d broken'
+          % (len(results), killed, survived,
+             sum(1 for r in results if r[1] == r[2] == 'SURVIVED'), broken))
+    if wrong or broken:
+        print('%d row(s) did not match their expectation' % (wrong + broken))
+    return 1 if (wrong or broken) else 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument('--row', help='run a single row by name')
+    a = ap.parse_args()
+    return run(a.row)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/mutate_746.py
+++ b/tests/mutate_746.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""The #746 mutation battery, shipped so its numbers can be re-derived.
+
+`tests/test_746_fanout_clearance_resolved_credit.py` records a kill count per
+row in its module docstring.  A count is only checkable if the exact source
+edit is written down, and a review of this branch made that concrete: two
+reviewers reconstructed the rows from their names and got 9 where the
+docstring says 11, because a plausible-looking reconstruction of one row was
+semantically inert.  So the edits live here, as data, next to the numbers they
+produced.
+
+NOT named `test_*.py`, so `tests/run_all.py` does not collect it: it REWRITES
+the engine in place.  One writer per tree -- do not run it while a suite, an
+A/B replay or a review is reading the same checkout.  Every row is restored in
+a `finally`, and the file refuses to start on a dirty engine.
+
+    python3 tests/mutate_746.py             # both batteries
+    python3 tests/mutate_746.py engine      # or one of them
+    python3 tests/mutate_746.py gui
+    python3 tests/mutate_746.py --row regrazed-keyed-on-swept
+
+Each row is (name, exact_old_text, exact_new_text).  An anchor that does not
+match EXACTLY ONCE is reported as BROKEN rather than skipped -- a battery that
+silently applies nothing reports every row as a survivor, which reads as a
+catastrophic test failure and is really a stale anchor.
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import subprocess
+import sys
+
+_TESTS = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_TESTS)
+
+ENGINE = os.path.join(_ROOT, 'py_placer', 'placement', 'fanout_clearance.py')
+GUI = os.path.join(_ROOT, 'kicad_routing_plugin', 'fanout_gui.py')
+ENGINE_TEST = os.path.join(_TESTS, 'test_746_fanout_clearance_resolved_credit.py')
+GUI_TEST = os.path.join(_TESTS, 'gui_parity', 'test_746_cap_summary_gui.py')
+
+# --- the engine battery: 12 rows, 12 killed ------------------------------
+_REFRESH = """            swept = resolved
+            was_grazing = set(unresolved)
+            resolved, unresolved = _grade()
+            via_resolved = [r for r in resolved if r not in swept]
+            regrazed = [r for r in unresolved if r not in was_grazing]"""
+
+ENGINE_ROWS = [
+    # the defect itself: `resolved` computed before the nudge, never refreshed
+    ('resolved-refresh-reverted', _REFRESH,
+     """            _unused, unresolved = _grade()"""),
+    # the spelling a review replaced: can only name a cap that was ALSO a
+    # seed violator, so a cap that arrived clean gets no cause named
+    ('regrazed-keyed-on-swept',
+     "            regrazed = [r for r in unresolved if r not in was_grazing]",
+     "            regrazed = [r for r in swept if r not in resolved]"),
+    # credit the nudge with everything the descent did too
+    ('via_resolved-is-all-of-resolved',
+     "            via_resolved = [r for r in resolved if r not in swept]",
+     "            via_resolved = list(resolved)"),
+    # ... the same error made at the DECLARATION, where it also reaches the
+    # path on which the nudger is never called
+    ('via_resolved-seeded-with-resolved',
+     "    via_resolved: List[str] = []",
+     "    via_resolved: List[str] = list(resolved)"),
+    ('deltas-swapped',
+     """            via_resolved = [r for r in resolved if r not in swept]
+            regrazed = [r for r in unresolved if r not in was_grazing]""",
+     """            via_resolved = [r for r in swept if r not in resolved]
+            regrazed = [r for r in was_grazing if r not in unresolved]"""),
+    ('regrazed-print-deleted',
+     """    if regrazed:
+        print(f"  Re-grazed by this pass's own connector copper: "
+              f"{', '.join(sorted(regrazed))}")""",
+     "    pass"),
+    # "(0 freed by via-nudge)" on every board that never nudges
+    ('credit-clause-unconditional',
+     """    _credit = (f" ({len(via_resolved)} freed by via-nudge)"
+               if via_resolved else "")""",
+     '    _credit = f" ({len(via_resolved)} freed by via-nudge)"'),
+    # the returned order is a contract: test_736 asserts unresolved == ['C1']
+    ('grade-returns-sorted',
+     "        return res, unres",
+     "        return sorted(res), sorted(unres)"),
+    # credit caps that were never broken -> "resolved 55/14"
+    ('violators0-gate-dropped',
+     """            elif ref in violators0:
+                res.append(ref)""",
+     """            else:
+                res.append(ref)"""),
+    # both deltas become empty on every board, silently
+    ('swept-bound-after-the-regrade',
+     """            swept = resolved
+            was_grazing = set(unresolved)
+            resolved, unresolved = _grade()""",
+     """            resolved, unresolved = _grade()
+            swept = resolved
+            was_grazing = set(unresolved)"""),
+    # #736's ordering: the connectors must reach the track view first
+    ('registrar-after-the-regrade',
+     "            st.register_new_segments(new_segs)",
+     "            pass  # registrar moved below"),
+    # NOTE the dedent: the point of this row is that the deltas escape the
+    # `if via_moves:` guard, so a run that never nudged still credits one.
+    # Dedenting only the two comprehensions (leaving them semantically the
+    # same) is the inert reconstruction that produced a false survivor.
+    ('deltas-hoisted-out-of-the-guard', _REFRESH,
+     """            resolved, unresolved = _grade()
+    via_resolved = list(resolved)
+    regrazed = []"""),
+]
+
+# --- the GUI battery: 5 rows, 5 killed ------------------------------------
+GUI_ROWS = [
+    ('old-wording-restored',
+     """        summary += (f"; {len(unresolved)} still grazing foreign copper "
+                    f"(via/track/pad) "
+                    f"(manual: {', '.join(sorted(unresolved))})")""",
+     """        summary += (f"; {len(unresolved)} could not clear a foreign via "
+                    f"(manual: {', '.join(sorted(unresolved))})")"""),
+    ('credit-clause-deleted',
+     """    if via_resolved:
+        summary += f"; {len(via_resolved)} cap(s) freed by that nudge\"""",
+     "    pass"),
+    ('regrazed-clause-deleted',
+     """    if regrazed:
+        summary += (f"; {len(regrazed)} re-grazed by this pass's own "
+                    f"connector copper: {', '.join(sorted(regrazed))}")""",
+     "    pass"),
+    ('credit-clause-unconditional',
+     """    if via_resolved:
+        summary += f"; {len(via_resolved)} cap(s) freed by that nudge\"""",
+     '    summary += f"; {len(via_resolved)} cap(s) freed by that nudge"'),
+    # the engine's two early returns carry neither new key
+    ('bare-get-no-or-default',
+     "    via_resolved = result.get('via_resolved') or []",
+     "    via_resolved = result['via_resolved']"),
+]
+
+BATTERIES = {
+    'engine': (ENGINE, ENGINE_TEST, ENGINE_ROWS),
+    'gui': (GUI, GUI_TEST, GUI_ROWS),
+}
+
+
+def _dirty(path):
+    p = subprocess.run(['git', 'status', '--porcelain', '--', path],
+                       capture_output=True, text=True, cwd=_ROOT)
+    return bool(p.stdout.strip())
+
+
+def run(which, only=None):
+    src_path, test_path, rows = BATTERIES[which]
+    rows = [r for r in rows if only is None or r[0] == only]
+    if not rows:
+        print('no row named %r in the %s battery' % (only, which))
+        return 1
+    if _dirty(src_path):
+        # Restoring would write the COMMITTED text back over uncommitted work.
+        print('REFUSING: %s has uncommitted changes. Commit or stash first -- '
+              'this battery restores by overwriting.' % os.path.basename(src_path))
+        return 2
+
+    orig = io.open(src_path, encoding='utf-8', newline='').read()
+    results = []
+    try:
+        for name, old, new in rows:
+            n = orig.count(old)
+            if n != 1:
+                results.append((name, 'BROKEN', 'anchor matched %d times' % n, []))
+                continue
+            io.open(src_path, 'w', encoding='utf-8', newline='').write(
+                orig.replace(old, new, 1))
+            p = subprocess.run([sys.executable, '-X', 'utf8', test_path],
+                               capture_output=True, text=True, timeout=1800,
+                               cwd=_ROOT)
+            io.open(src_path, 'w', encoding='utf-8', newline='').write(orig)
+            out = (p.stderr or '') + (p.stdout or '')
+            if which == 'engine':
+                failed = [l.split('(')[0].replace('FAIL: ', '')
+                          .replace('ERROR: ', '').strip()
+                          for l in out.splitlines()
+                          if l.startswith(('FAIL:', 'ERROR:'))]
+            else:
+                failed = [l.strip()[5:].strip() for l in out.splitlines()
+                          if l.strip().startswith('FAIL')]
+            results.append((name, 'KILLED' if p.returncode else 'SURVIVED',
+                            '%d' % len(failed), failed))
+    finally:
+        io.open(src_path, 'w', encoding='utf-8', newline='').write(orig)
+
+    w = max(len(r[0]) for r in results)
+    for name, verdict, cnt, failed in results:
+        print('%-*s  %-9s  %s' % (w, name, verdict, cnt))
+        for f in failed:
+            print('%s      %s' % (' ' * w, f))
+    killed = sum(1 for r in results if r[1] == 'KILLED')
+    broken = sum(1 for r in results if r[1] == 'BROKEN')
+    print('\n%s: killed %d / %d%s'
+          % (which, killed, len(results),
+             ', %d BROKEN ANCHOR(S)' % broken if broken else ''))
+    return 0 if killed == len(results) else 1
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument('battery', nargs='?', choices=sorted(BATTERIES),
+                    help='default: both')
+    ap.add_argument('--row', help='run a single row by name')
+    a = ap.parse_args()
+    rc = 0
+    for which in ([a.battery] if a.battery else sorted(BATTERIES)):
+        rc |= run(which, a.row)
+        print()
+    return rc
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/mutate_750.py
+++ b/tests/mutate_750.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""The #750 mutation battery, shipped so its numbers can be re-derived.
+
+`tests/test_750_fanout_clearance_via_drill.py` records what each arm kills. A
+count is only checkable if the exact source edit is written down -- two
+reviewers of the #746 branch reconstructed its rows from their names and both
+got the wrong answer, because a plausible-looking reconstruction of one row
+was semantically inert. So the edits live here, as data, next to the numbers
+they produced.
+
+Every row carries an EXPECTATION. Some of these mutations are deliberately
+inert -- `not d or d < 0` is indistinguishable from `not d or d <= 0`,
+because `not d` already catches 0 and -0.0 -- and an inert row recorded as an
+expected survivor is a finding, while an inert row quietly deleted is a hole.
+A row whose verdict does not match its expectation is reported as WRONG.
+
+NOT named `test_*.py`, so `tests/run_all.py` does not collect it: it REWRITES
+the engine in place. One writer per tree -- do not run it while a suite, an
+A/B replay or a review is reading the same checkout. Every row is restored in
+a `finally`, and the file refuses to start on a dirty engine.
+
+    python3 tests/mutate_750.py
+    python3 tests/mutate_750.py --row guard-reverted-to-or
+
+A row is KILLED by a FAILURE **or an ERROR**: dropping the `getattr` makes
+`test_a_via_like_with_no_drill_is_priced_rather_than_crashing` raise rather
+than fail, and a battery that counted only failures would call that a
+survivor.
+
+An anchor that does not match EXACTLY ONCE is reported as BROKEN rather than
+skipped -- a battery that silently applies nothing reports every row as a
+survivor, which reads as a catastrophic test failure and is really a stale
+anchor.
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import subprocess
+import sys
+
+_TESTS = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_TESTS)
+
+ENGINE = os.path.join(_ROOT, 'py_placer', 'placement', 'fanout_clearance.py')
+ENGINE_TEST = os.path.join(_TESTS, 'test_750_fanout_clearance_via_drill.py')
+
+_GUARD = """    if not d or d <= 0:
+        d = default_drill
+    return d / 2.0"""
+
+# (name, old, new, expect)
+ROWS = [
+    # --- the defect itself: the spelling, not the literal -----------------
+    ('guard-reverted-to-or',
+     "    d = getattr(via, 'drill', None)\n" + _GUARD,
+     "    return (getattr(via, 'drill', None) or default_drill) / 2.0",
+     'KILLED'),
+    # the plausible-looking guard a later "simplification" actually writes:
+    # it still admits every negative.
+    ('guard-is-none-or-equals-zero',
+     _GUARD,
+     """    if d is None or d == 0:
+        d = default_drill
+    return d / 2.0""",
+     'KILLED'),
+    # --- the two INERT re-spellings, recorded rather than omitted ---------
+    # `not d` already catches 0 and -0.0, so `< 0` and `<= 0` cannot differ.
+    ('guard-lt-zero-instead-of-le-zero',
+     _GUARD,
+     """    if not d or d < 0:
+        d = default_drill
+    return d / 2.0""",
+     'SURVIVED'),
+    # `d is None` plus `<= 0` covers exactly what `not d` plus `<= 0` does
+    # for every numeric input; only a non-numeric falsy value differs, and
+    # no parse path produces one.
+    ('guard-is-none-instead-of-not-d',
+     _GUARD,
+     """    if d is None or d <= 0:
+        d = default_drill
+    return d / 2.0""",
+     'SURVIVED'),
+    # --- the constant --------------------------------------------------
+    # Arm C brackets it to (0.24, 0.40], so BOTH directions are caught.
+    ('constant-lowered-to-0.2',
+     '_UNREADABLE_VIA_DRILL = 0.3  # mm',
+     '_UNREADABLE_VIA_DRILL = 0.2  # mm',
+     'KILLED'),
+    ('constant-raised-to-0.5',
+     '_UNREADABLE_VIA_DRILL = 0.3  # mm',
+     '_UNREADABLE_VIA_DRILL = 0.5  # mm',
+     'KILLED'),
+    # --- the resolver body ----------------------------------------------
+    ('returns-the-diameter-not-the-radius',
+     '    return d / 2.0',
+     '    return d',
+     'KILLED'),
+    # kills the only arm that passes a via-like with no `drill` at all --
+    # as an ERROR, not a failure.
+    ('getattr-dropped',
+     "    d = getattr(via, 'drill', None)",
+     '    d = via.drill',
+     'KILLED'),
+    # --- the call sites --------------------------------------------------
+    # the offender's drill resolved with the MOVING via's. Needs a rig where
+    # the two RESOLVE differently, which arm A does NOT: -0.3 and 0.3 both
+    # come back 0.15 there. TestEachViaContributesITSOWNDrill exists because
+    # this row survived every behavioural arm until it was added.
+    ('offender-drill-resolved-with-the-movers',
+     'vdr + ovdr + H2H_VIA',
+     'vdr + vdr + H2H_VIA',
+     'KILLED'),
+    # the typo class. Both floors are in scope, so this is NOT a source-guard
+    # blind spot as first assumed -- the positive-count guard sees it, because
+    # the needle it counts stops matching. Measured: 3 kills, one of them
+    # behavioural (the neighbour that must still be ADMITTED).
+    ('h2h-via-floor-swapped-for-the-pad-one',
+     'vdr + ovdr + H2H_VIA',
+     'vdr + ovdr + H2H_PAD',
+     'KILLED'),
+    # NOTE: this also perturbs test_732's landing (its _rig(DVS_SMALL,
+    # [0.30, 0.02]) arm is decided by this gate), so the kill is not
+    # attributable to test_750 alone.
+    ('h2h-via-gate-deleted',
+     """            # net-INDEPENDENT: two holes collide whatever they carry
+            if d < vdr + ovdr + H2H_VIA:
+                return False""",
+     '            pass',
+     'KILLED'),
+    # the copper radius substituted for the drill radius at the capsule
+    # gate. NOTE: an EXISTING arm kills this first -- test_737:691-716 pins
+    # that landing to four places -- so test_750 is not its sole gate.
+    ('capsule-gate-reads-the-COPPER-radius',
+     'vdr + prad + H2H_PAD',
+     'vr + prad + H2H_PAD',
+     'KILLED'),
+    # the evasion an absence-only source guard would miss: it restores the
+    # old semantics exactly while still mentioning the constant.
+    ('literal-restored-at-the-capsule-gate',
+     'vdr + prad + H2H_PAD',
+     '(v.drill or _UNREADABLE_VIA_DRILL) / 2.0 + prad + H2H_PAD',
+     'KILLED'),
+    # --- the precompute --------------------------------------------------
+    # Semantically identical -- a performance regression only, so NO
+    # behavioural arm can see it. Killed by the two SOURCE guards, which is
+    # exactly why they count the positive form and the ordering rather than
+    # just the absence of the old literal. Recorded here so nobody reads
+    # the kill as evidence that the inlining changes an answer. It does not.
+    ('precompute-inlined-per-candidate',
+     '        for ov, ovdr in board_via_drills:',
+     '        for ov in pcb_data.vias:\n            ovdr = _via_drill_radius(ov)',
+     'KILLED'),
+    # --- the writer ------------------------------------------------------
+    # the gate prices an unreadable drill; the payload must still carry what
+    # the board declared.
+    ('writer-emits-the-RESOLVED-drill',
+     "'drill': v.drill,",
+     "'drill': _via_drill_radius(v) * 2,",
+     'KILLED'),
+]
+
+
+def _dirty(path):
+    p = subprocess.run(['git', 'status', '--porcelain', '--', path],
+                       capture_output=True, text=True, cwd=_ROOT)
+    return bool(p.stdout.strip())
+
+
+def run(only=None):
+    rows = [r for r in ROWS if only is None or r[0] == only]
+    if not rows:
+        print('no row named %r' % only)
+        return 1
+    if _dirty(ENGINE):
+        # Restoring would write the COMMITTED text back over uncommitted work.
+        print('REFUSING: %s has uncommitted changes. Commit or stash first -- '
+              'this battery restores by overwriting.' % os.path.basename(ENGINE))
+        return 2
+
+    orig = io.open(ENGINE, encoding='utf-8', newline='').read()
+    results = []
+    try:
+        for name, old, new, expect in rows:
+            n = orig.count(old)
+            if n != 1:
+                results.append((name, 'BROKEN', expect,
+                                'anchor matched %d times' % n, []))
+                continue
+            io.open(ENGINE, 'w', encoding='utf-8', newline='').write(
+                orig.replace(old, new, 1))
+            p = subprocess.run([sys.executable, '-X', 'utf8', ENGINE_TEST],
+                               capture_output=True, text=True, timeout=1800,
+                               cwd=_ROOT)
+            io.open(ENGINE, 'w', encoding='utf-8', newline='').write(orig)
+            out = (p.stderr or '') + (p.stdout or '')
+            failed = [l.split('(')[0].replace('FAIL: ', '')
+                      .replace('ERROR: ', '').strip()
+                      for l in out.splitlines()
+                      if l.startswith(('FAIL:', 'ERROR:'))]
+            results.append((name, 'KILLED' if p.returncode else 'SURVIVED',
+                            expect, '%d' % len(failed), failed))
+    finally:
+        io.open(ENGINE, 'w', encoding='utf-8', newline='').write(orig)
+
+    w = max(len(r[0]) for r in results)
+    wrong = 0
+    for name, verdict, expect, cnt, failed in results:
+        mark = ''
+        if verdict != expect:
+            mark = '   <-- WRONG, expected %s' % expect
+            wrong += 1
+        print('%-*s  %-9s  %-3s%s' % (w, name, verdict, cnt, mark))
+        for f in failed:
+            print('%s      %s' % (' ' * w, f))
+    killed = sum(1 for r in results if r[1] == 'KILLED')
+    survived = sum(1 for r in results if r[1] == 'SURVIVED')
+    broken = sum(1 for r in results if r[1] == 'BROKEN')
+    print('\n%d rows: %d killed, %d survived (%d of them expected), %d broken'
+          % (len(results), killed, survived,
+             sum(1 for r in results if r[1] == r[2] == 'SURVIVED'), broken))
+    if wrong or broken:
+        print('%d row(s) did not match their expectation' % (wrong + broken))
+    return 1 if (wrong or broken) else 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument('--row', help='run a single row by name')
+    a = ap.parse_args()
+    return run(a.row)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/mutate_750.py
+++ b/tests/mutate_750.py
@@ -152,6 +152,25 @@ ROWS = [
      '        for ov, ovdr in board_via_drills:',
      '        for ov in pcb_data.vias:\n            ovdr = _via_drill_radius(ov)',
      'KILLED'),
+    # THE DANGEROUS version of the tidy-up: fold the coordinates into the
+    # same tuple, since they are right there. Silent, and wrong for every via
+    # relocated on an earlier cap -- measured during review, the second via
+    # lands at (5.1061, 6.1061) instead of (5.0500, 6.0000). A 400-seed
+    # old-vs-new fuzz did NOT catch it (only 8 seeds move two vias), which is
+    # why the guard for it is structural.
+    ('positions-cached-alongside-the-radius',
+     [('    board_via_drills = [(ov, _via_drill_radius(ov)) for ov in pcb_data.vias]',
+       '    board_via_drills = [(ov, _via_drill_radius(ov), ov.x, ov.y) for ov in pcb_data.vias]'),
+      ("""        for ov, ovdr in board_via_drills:
+            if ov is v:
+                continue
+            d = math.hypot(nx - ov.x, ny - ov.y)""",
+       """        for ov, ovdr, oX, oY in board_via_drills:
+            if ov is v:
+                continue
+            d = math.hypot(nx - oX, ny - oY)""")],
+     None,
+     'KILLED'),
     # --- the writer ------------------------------------------------------
     # the gate prices an unreadable drill; the payload must still carry what
     # the board declared.
@@ -183,13 +202,20 @@ def run(only=None):
     results = []
     try:
         for name, old, new, expect in rows:
-            n = orig.count(old)
-            if n != 1:
+            # A row may carry several edits: the dangerous version of a
+            # mutation is sometimes only expressible as a coordinated pair
+            # (see positions-cached-alongside-the-radius), and applying half
+            # of it produces a crash rather than the silent defect.
+            edits = old if isinstance(old, list) else [(old, new)]
+            counts = [orig.count(o) for o, _n in edits]
+            if counts != [1] * len(edits):
                 results.append((name, 'BROKEN', expect,
-                                'anchor matched %d times' % n, []))
+                                'anchors matched %s times' % counts, []))
                 continue
-            io.open(ENGINE, 'w', encoding='utf-8', newline='').write(
-                orig.replace(old, new, 1))
+            mutated = orig
+            for o, nw in edits:
+                mutated = mutated.replace(o, nw, 1)
+            io.open(ENGINE, 'w', encoding='utf-8', newline='').write(mutated)
             p = subprocess.run([sys.executable, '-X', 'utf8', ENGINE_TEST],
                                capture_output=True, text=True, timeout=1800,
                                cwd=_ROOT)

--- a/tests/mutate_761.py
+++ b/tests/mutate_761.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""The #761 mutation battery, shipped so its numbers can be re-derived.
+
+`tests/test_761_legality_npth_keepout.py` records what each arm kills. A count
+is only checkable if the exact source edit is written down -- two reviewers of
+the #746 branch reconstructed its rows from their names and both got the wrong
+answer, because a plausible-looking reconstruction of one row was semantically
+inert. So the edits live here, as data, next to the numbers they produced.
+
+Every row carries an EXPECTATION. Some mutations are deliberately inert -- an
+exact re-spelling of a `max` cannot change an answer -- and an inert row
+recorded as an expected survivor is a finding, while an inert row quietly
+deleted is a hole. A row whose verdict does not match its expectation is
+reported as WRONG.
+
+ONE target (`legality.py`), unlike `mutate_730.py`'s two, and rows are graded
+by more than one test file: the tripwire and corpus arms live in `test_730`,
+the standoff and broad-phase arms in `test_761`, and the renamed inflation
+guard in `test_placement_pad_legality`. A row is KILLED if ANY of its named
+tests exits non-zero.
+
+This is the THIRD copy of this runner (`mutate_730.py`, `mutate_750.py`). It is
+not refactored into a shared one deliberately: that would rewrite two shipped
+batteries whose recorded counts are the evidence for two merged reviews, which
+is a change to make on its own, not inside a fix.
+
+NOT named `test_*.py`, so `tests/run_all.py` does not collect it: it REWRITES
+the engine in place. One writer per tree -- do not run it while a suite, an A/B
+replay or a review is reading the same checkout. The file refuses to start on a
+dirty engine, because restoring would write the COMMITTED text back over
+uncommitted work.
+
+    python3 tests/mutate_761.py
+    python3 tests/mutate_761.py --row keepout-drops-the-clearance
+
+A row is KILLED by a FAILURE **or an ERROR**: dropping a term makes some arms
+raise rather than fail, and a battery that counted only failures would call
+that a survivor.
+
+An anchor that does not match EXACTLY ONCE is reported as BROKEN rather than
+skipped -- a battery that silently applies nothing reports every row as a
+survivor, which reads as a catastrophic test failure and is really a stale
+anchor.
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import subprocess
+import sys
+
+_TESTS = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_TESTS)
+
+LEG = os.path.join(_ROOT, 'py_placer', 'placement', 'legality.py')
+QUENCH = os.path.join(_ROOT, 'py_placer', 'placement', 'quench.py')
+TARGETS = {'leg': LEG, 'quench': QUENCH}
+
+T761 = os.path.join(_TESTS, 'test_761_legality_npth_keepout.py')
+T730 = os.path.join(_TESTS, 'test_730_fanout_clearance_npth_local_clearance.py')
+TPAD = os.path.join(_TESTS, 'test_placement_pad_legality.py')
+
+_KEEPOUT = """            cache = [(ox, oy, r + clr)
+                     for ox, oy, r in self.hole_circles(0.0, 0.0, rot)]"""
+_HOLE_LOOPS = """    hole = 0.0
+    for cx, cy, r in pb.hole_keepouts(xb, yb, rb):
+        for a0, a1, a2, a3, _na, _sa in rects_a:
+            hole += _circle_rect_penetration(cx, cy, r, (a0, a1, a2, a3))
+    for cx, cy, r in pa.hole_keepouts(xa, ya, ra):
+        for b0, b1, b2, b3, _nb, _sb in rects_b:
+            hole += _circle_rect_penetration(cx, cy, r, (b0, b1, b2, b3))
+    return hole"""
+
+# (name, target, old, new, tests, expect)
+ROWS = [
+    # ---- the keep-out radius itself ------------------------------------
+    ('keepout-drops-the-clearance', 'leg',
+     _KEEPOUT,
+     """            cache = [(ox, oy, r)
+                     for ox, oy, r in self.hole_circles(0.0, 0.0, rot)]""",
+     (T761, TPAD), 'KILLED'),
+    ('keepout-adds-clearance-twice', 'leg',
+     _KEEPOUT,
+     """            cache = [(ox, oy, r + clr + clr)
+                     for ox, oy, r in self.hole_circles(0.0, 0.0, rot)]""",
+     (T761, TPAD), 'KILLED'),
+    ('keepout-serves-the-EXTENT-radius', 'leg',
+     _KEEPOUT,
+     """            cache = [(ox, oy, r + clr)
+                     for ox, oy, r in self.holes_extent]""",
+     (T761,), 'KILLED'),
+
+    # ---- the consumers -------------------------------------------------
+    # ONE of the two loops, not both: a battery that reverts both cannot
+    # distinguish "the accessor is wired" from "half of it is".
+    ('pair-shortfall-reverts-ONE-loop', 'leg',
+     '    for cx, cy, r in pb.hole_keepouts(xb, yb, rb):',
+     '    for cx, cy, r in pb.hole_circles(xb, yb, rb):',
+     (T761,), 'KILLED'),
+    ('pair-shortfall-reverts-the-OTHER-loop', 'leg',
+     '    for cx, cy, r in pa.hole_keepouts(xa, ya, ra):',
+     '    for cx, cy, r in pa.hole_circles(xa, ya, ra):',
+     (T761,), 'KILLED'),
+    ('census-reverts-to-hole_circles', 'leg',
+     '        holes = pp.hole_keepouts(fp.x, fp.y, fp.rotation or 0.0)  # #761',
+     '        holes = pp.hole_circles(fp.x, fp.y, fp.rotation or 0.0)',
+     (T761,), 'KILLED'),
+
+    # ---- the broad phase -----------------------------------------------
+    ('reach-drops-hole_reach', 'leg',
+     '        reach = max(reach, pa.hole_reach, pb.hole_reach)',
+     '        reach = max(reach, 0.0)',
+     (T761,), 'KILLED'),
+    ('census-reach-drops-hole_reach', 'leg',
+     '    census_reach = max(clearance, board_max_floor, board_max_hole,',
+     '    census_reach = max(clearance, board_max_floor,',
+     (T761,), 'KILLED'),
+    ('hole_reach-forgets-the-clearance', 'leg',
+     '            over = (_kr + self.clearance) - _er',
+     '            over = _kr - _er',
+     (T761,), 'KILLED'),
+    ('pair-cap-goes-back-to-a-hardcoded-zero', 'leg',
+     """            return PairShortfall(max(0.0, reach - g), g < 0.0,
+                                 _hole_shortfall(pa, xa, ya, ra, rects_b,
+                                                 pb, xb, yb, rb, rects_a),
+                                 g < 0.0)""",
+     """            return PairShortfall(max(0.0, reach - g), g < 0.0, 0.0,
+                                 g < 0.0)""",
+     (T761,), 'KILLED'),
+
+    # ---- the board floor -----------------------------------------------
+    ('npth-floor-ignored', 'leg',
+     """        _npth_floor = (defaults.NPTH_TO_TRACK_CLEARANCE
+                       if (npth_floor is None or not copper_holes)
+                       else max(defaults.NPTH_TO_TRACK_CLEARANCE,
+                                float(npth_floor)))""",
+     '        _npth_floor = defaults.NPTH_TO_TRACK_CLEARANCE',
+     (T761, T730), 'KILLED'),
+    ('silk-takes-the-board-floor', 'leg',
+     """        _npth_floor = (defaults.NPTH_TO_TRACK_CLEARANCE
+                       if (npth_floor is None or not copper_holes)
+                       else max(defaults.NPTH_TO_TRACK_CLEARANCE,
+                                float(npth_floor)))""",
+     """        _npth_floor = (defaults.NPTH_TO_TRACK_CLEARANCE
+                       if npth_floor is None
+                       else max(defaults.NPTH_TO_TRACK_CLEARANCE,
+                                float(npth_floor)))""",
+     (T761,), 'KILLED'),
+    ('npth-floor-can-LOWER-the-fab-floor', 'leg',
+     """                       else max(defaults.NPTH_TO_TRACK_CLEARANCE,
+                                float(npth_floor)))""",
+     '                       else float(npth_floor))',
+     (T761,), 'KILLED'),
+    ('the-board-floor-leaks-into-EXTENTS', 'leg',
+     """                    ext_grow = max(0.0, defaults.NPTH_TO_TRACK_CLEARANCE
+                                   - clearance)""",
+     '                    ext_grow = max(0.0, _npth_floor - clearance)',
+     (T761,), 'KILLED'),
+    ('the-census-passes-no-board-floor', 'leg',
+     """    parts = build_part_pads(fps, clearance, model,
+                            npth_floor=resolve_npth_floor(pcb_data))""",
+     '    parts = build_part_pads(fps, clearance, model)',
+     (T761, T730), 'KILLED'),
+    ('partpads-reads-the-board', 'leg',
+     '        _npth_floor = (defaults.NPTH_TO_TRACK_CLEARANCE',
+     '        resolve_hole_clearance = None\n'
+     '        _npth_floor = (defaults.NPTH_TO_TRACK_CLEARANCE',
+     (T730,), 'KILLED'),
+
+    ('cap-branch-charges-the-hole-reach-as-PAD', 'leg',
+     '            return PairShortfall(max(0.0, pad_reach - g), g < 0.0,',
+     '            return PairShortfall(max(0.0, reach - g), g < 0.0,',
+     (T761,), 'KILLED'),
+    ('resolve-npth-floor-ignores-pcb_file', 'leg',
+     '        return max(floor,
+                   float(resolve_hole_clearance(pcb_data, None, pcb_file)))',
+     '        return max(floor,
+                   float(resolve_hole_clearance(pcb_data, None, None)))',
+     (T761,), 'KILLED'),
+    ('failed-floor-resolution-is-silent', 'leg',
+     """        if notes is not None:
+            notes.append('copper-to-hole floor unresolved (%s: %s); the NPTH '
+                         'keep-out falls back to the %.2fmm fab floor'
+                         % (type(e).__name__, e, floor))""",
+     '        pass',
+     (T761,), 'KILLED'),
+    ('quench-passes-no-board-floor', 'quench',
+&
+     '                npth_floor=None)',
+     (T761,), 'KILLED'),
+
+    # ---- the disclosure ------------------------------------------------
+    ('hole-disclosure-removed', 'leg',
+     """                if hole_req > clearance + 1e-9:
+                    required.append([key[0], key[1], round(hole_req, 4),
+                                     'NPTH hole'])""",
+     '                pass',
+     (T761,), 'KILLED'),
+    ('hole-disclosure-fires-for-EVERY-hole', 'leg',
+     '                if hole_req > clearance + 1e-9:',
+     '                if hole_req > 0.0:',
+     (T761,), 'KILLED'),
+    ('holes_req-loses-the-clearance-term', 'leg',
+     '                    npth_req = max(clearance, _npth_floor, _lc)',
+     '                    npth_req = max(_npth_floor, _lc)',
+     (T761,), 'KILLED'),
+
+    # ---- deliberately inert, recorded so its survival is not read as a
+    # ---- hole ----------------------------------------------------------
+    ('keepout-max-respelled-as-a-sum-of-parts', 'leg',
+     _HOLE_LOOPS,
+     _HOLE_LOOPS.replace('    hole = 0.0', '    hole = 0.0 + 0.0'),
+     (T761,), 'SURVIVED'),
+]
+
+
+def _dirty(path):
+    p = subprocess.run(['git', 'status', '--porcelain', '--', path],
+                       capture_output=True, text=True, cwd=_ROOT)
+    return bool(p.stdout.strip())
+
+
+def run(only=None):
+    rows = [r for r in ROWS if only is None or r[0] == only]
+    if not rows:
+        print('no row named %r' % only)
+        return 1
+    for path in TARGETS.values():
+        if _dirty(path):
+            print('REFUSING: %s has uncommitted changes. Commit or stash '
+                  'first -- this battery restores by overwriting.'
+                  % os.path.basename(path))
+            return 2
+
+    orig = {k: io.open(v, encoding='utf-8', newline='').read()
+            for k, v in TARGETS.items()}
+    results = []
+    try:
+        for name, tgt, old, new, tests, expect in rows:
+            path = TARGETS[tgt]
+            base = orig[tgt]
+            edits = old if isinstance(old, list) else [(old, new)]
+            counts = [base.count(o) for o, _n in edits]
+            if counts != [1] * len(edits):
+                results.append((name, 'BROKEN', expect,
+                                'anchors matched %s times' % counts, []))
+                continue
+            mutated = base
+            for o, nw in edits:
+                mutated = mutated.replace(o, nw, 1)
+            io.open(path, 'w', encoding='utf-8', newline='').write(mutated)
+            killed, failed = False, []
+            for t in tests:
+                p = subprocess.run([sys.executable, '-X', 'utf8', t],
+                                   capture_output=True, text=True,
+                                   encoding='utf-8', errors='replace',
+                                   timeout=1800, cwd=_ROOT)
+                out = (p.stderr or '') + (p.stdout or '')
+                if p.returncode:
+                    killed = True
+                failed += ['%s::%s' % (os.path.basename(t)[5:8],
+                                       l.split('(')[0].replace('FAIL: ', '')
+                                       .replace('ERROR: ', '').strip())
+                           for l in out.splitlines()
+                           if l.startswith(('FAIL:', 'ERROR:'))]
+            io.open(path, 'w', encoding='utf-8', newline='').write(base)
+            results.append((name, 'KILLED' if killed else 'SURVIVED', expect,
+                            '%d' % len(failed), failed))
+    finally:
+        for k, v in TARGETS.items():
+            io.open(v, 'w', encoding='utf-8', newline='').write(orig[k])
+
+    w = max(len(r[0]) for r in results)
+    wrong = 0
+    for name, verdict, expect, cnt, failed in results:
+        mark = ''
+        if verdict != expect:
+            mark = '   <-- WRONG, expected %s' % expect
+            wrong += 1
+        print('%-*s  %-9s  %-3s%s' % (w, name, verdict, cnt, mark))
+        for f in failed:
+            print('%s      %s' % (' ' * w, f))
+    killed = sum(1 for r in results if r[1] == 'KILLED')
+    survived = sum(1 for r in results if r[1] == 'SURVIVED')
+    broken = sum(1 for r in results if r[1] == 'BROKEN')
+    print('\n%d rows: %d killed, %d survived (%d of them expected), %d broken'
+          % (len(results), killed, survived,
+             sum(1 for r in results if r[1] == r[2] == 'SURVIVED'), broken))
+    if wrong or broken:
+        print('%d row(s) did not match their expectation' % (wrong + broken))
+    return 1 if (wrong or broken) else 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument('--row', help='run a single row by name')
+    a = ap.parse_args()
+    return run(a.row)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/mutate_761.py
+++ b/tests/mutate_761.py
@@ -173,10 +173,10 @@ ROWS = [
      '            return PairShortfall(max(0.0, reach - g), g < 0.0,',
      (T761,), 'KILLED'),
     ('resolve-npth-floor-ignores-pcb_file', 'leg',
-     '        return max(floor,
-                   float(resolve_hole_clearance(pcb_data, None, pcb_file)))',
-     '        return max(floor,
-                   float(resolve_hole_clearance(pcb_data, None, None)))',
+     """        return max(floor,
+                   float(resolve_hole_clearance(pcb_data, None, pcb_file)))""",
+     """        return max(floor,
+                   float(resolve_hole_clearance(pcb_data, None, None)))""",
      (T761,), 'KILLED'),
     ('failed-floor-resolution-is-silent', 'leg',
      """        if notes is not None:
@@ -186,7 +186,7 @@ ROWS = [
      '        pass',
      (T761,), 'KILLED'),
     ('quench-passes-no-board-floor', 'quench',
-&
+     '                npth_floor=legality.resolve_npth_floor(pcb_data, pcb_file))',
      '                npth_floor=None)',
      (T761,), 'KILLED'),
 

--- a/tests/mutate_761.py
+++ b/tests/mutate_761.py
@@ -109,8 +109,8 @@ ROWS = [
 
     # ---- the broad phase -----------------------------------------------
     ('reach-drops-hole_reach', 'leg',
-     '        reach = max(reach, pa.hole_reach, pb.hole_reach)',
-     '        reach = max(reach, 0.0)',
+     '        reach = max(pad_reach, pa.hole_reach, pb.hole_reach)',
+     '        reach = max(pad_reach, 0.0)',
      (T761,), 'KILLED'),
     ('census-reach-drops-hole_reach', 'leg',
      '    census_reach = max(clearance, board_max_floor, board_max_hole,',
@@ -121,11 +121,11 @@ ROWS = [
      '            over = _kr - _er',
      (T761,), 'KILLED'),
     ('pair-cap-goes-back-to-a-hardcoded-zero', 'leg',
-     """            return PairShortfall(max(0.0, reach - g), g < 0.0,
+     """            return PairShortfall(max(0.0, pad_reach - g), g < 0.0,
                                  _hole_shortfall(pa, xa, ya, ra, rects_b,
                                                  pb, xb, yb, rb, rects_a),
                                  g < 0.0)""",
-     """            return PairShortfall(max(0.0, reach - g), g < 0.0, 0.0,
+     """            return PairShortfall(max(0.0, pad_reach - g), g < 0.0, 0.0,
                                  g < 0.0)""",
      (T761,), 'KILLED'),
 
@@ -158,8 +158,9 @@ ROWS = [
      '                    ext_grow = max(0.0, _npth_floor - clearance)',
      (T761,), 'KILLED'),
     ('the-census-passes-no-board-floor', 'leg',
-     """    parts = build_part_pads(fps, clearance, model,
-                            npth_floor=resolve_npth_floor(pcb_data))""",
+     """    parts = build_part_pads(
+        fps, clearance, model,
+        npth_floor=resolve_npth_floor(pcb_data, pcb_file, clearance_notes))""",
      '    parts = build_part_pads(fps, clearance, model)',
      (T761, T730), 'KILLED'),
     ('partpads-reads-the-board', 'leg',

--- a/tests/mutate_761.py
+++ b/tests/mutate_761.py
@@ -187,8 +187,9 @@ ROWS = [
      '        pass',
      (T761,), 'KILLED'),
     ('quench-passes-no-board-floor', 'quench',
-     '                npth_floor=legality.resolve_npth_floor(pcb_data, pcb_file))',
-     '                npth_floor=None)',
+     """            _npth = legality.resolve_npth_floor(pcb_data, pcb_file,
+                                                _npth_notes)""",
+     '            _npth = None',
      (T761,), 'KILLED'),
 
     # ---- the disclosure ------------------------------------------------

--- a/tests/stress/RUNBOOK.md
+++ b/tests/stress/RUNBOOK.md
@@ -365,8 +365,11 @@ harmless.
    those caps clear and pulls each pad toward its nearest same-net ball (so a
    later power/GND via shares the via). It reads each via's real size from the
    board, only moves 2-pad caps near a BGA, never overlaps caps, and is a no-op
-   when nothing collides. It prints `resolved R/M ... K unresolved`; unresolved
-   caps need a manual nudge. Feed `<out>` into the next step; verify with
+   when nothing collides. It prints `resolved R/V initial violations; K
+   unresolved`, with `(F freed by via-nudge)` when the #313 last resort had to
+   move a via; `resolved` is graded at the END of the pass and credits both
+   mechanisms (#746). Unresolved caps are still grazing foreign copper (via,
+   track or pad) and need a manual nudge. Feed `<out>` into the next step; verify with
    `check_drc.py <out> -c <floor>` (PAD-VIA drops).
 6. Diff pairs: if `--diff-pairs` reports pairs, route them with route_diff.py
    AFTER fanout and BEFORE signal routing (gap from --design-rules; use

--- a/tests/stress/RUNBOOK.md
+++ b/tests/stress/RUNBOOK.md
@@ -366,10 +366,13 @@ harmless.
    later power/GND via shares the via). It reads each via's real size from the
    board, only moves 2-pad caps near a BGA, never overlaps caps, and is a no-op
    when nothing collides. It prints `resolved R/V initial violations; K
-   unresolved`, with `(F freed by via-nudge)` when the #313 last resort had to
-   move a via; `resolved` is graded at the END of the pass and credits both
-   mechanisms (#746). Unresolved caps are still grazing foreign copper (via,
-   track or pad) and need a manual nudge. Feed `<out>` into the next step; verify with
+   unresolved`, with `(F freed by via-nudge)` when the #313 last resort moved
+   a via to free a boxed cap; `resolved` is graded at the END of the pass and
+   credits both mechanisms (#746). Unresolved caps are still grazing foreign
+   copper (via, track or pad) and need a manual nudge; a `Re-grazed by this
+   pass's own connector copper:` line names the ones that were clean before
+   the nudge, i.e. copper this step drew rather than copper the board arrived
+   with. Feed `<out>` into the next step; verify with
    `check_drc.py <out> -c <floor>` (PAD-VIA drops).
 6. Diff pairs: if `--diff-pairs` reports pairs, route them with route_diff.py
    AFTER fanout and BEFORE signal routing (gap from --design-rules; use

--- a/tests/stress/manifest_to_plan.py
+++ b/tests/stress/manifest_to_plan.py
@@ -440,6 +440,13 @@ CAP_FLAG_PARAMS = {
     '--displacement-growth': 'cap_displacement_growth',
     '--max-passes': 'cap_max_passes',
     '--cap-prefix': 'cap_prefix',
+    # #733. NOT a cap_* name: its GUI home is the SHARED Basic-tab edge control,
+    # which ai_plan._GEOMETRY_OVERRIDE_CHECKS already maps by this exact name
+    # ('board_edge_clearance' -> 'edge_clearance_check'), so a plan carrying it
+    # ticks the override box and the value reaches the engine. Only an EXPLICIT
+    # flag needs carrying: an omitted one now resolves to the same number on
+    # both fronts (placement/fanout_clearance.resolve_cap_edge_clearance).
+    '--board-edge-clearance': 'board_edge_clearance',
 }
 CAP_BOOL_FLAGS = {'--no-rotate': ('cap_allow_rotation', False)}  # inverted sense
 

--- a/tests/test_628_cap_owns_milled_ring.py
+++ b/tests/test_628_cap_owns_milled_ring.py
@@ -155,9 +155,9 @@ def main():
               'C1' in rep.caps)
         check("fixture: the edge gate is ACTIVE (else nothing is tested)",
               rep.edge_gate.active)
-        check(f"fixture: gate margin is non-zero ({rep._edge_margin}) -- the "
+        check(f"fixture: gate margin is non-zero ({rep.edge_margin}) -- the "
               f"'margin-0 is inert' argument does not cover this gate",
-              rep._edge_margin > 0.0)
+              rep.edge_margin > 0.0)
 
         # --- API surface (reported, not fatal -- see _owned/_blocked above)
         check("API: _Repair grows _owned_rings",

--- a/tests/test_725_fanout_clearance_pad_floors.py
+++ b/tests/test_725_fanout_clearance_pad_floors.py
@@ -620,9 +620,11 @@ class TestPruneRadiiStayExact(unittest.TestCase):
 
     def test_the_seed_baseline_is_in_the_SAME_currency(self):
         """A baseline priced flat while candidates price at the requirement
-        makes `_worsens_any_net` fire on every pose and the pass stops moving
-        anything -- a failure whose symptom is FEWER placements, which reads as
-        conservative rather than broken."""
+        makes `_worsens_any_net` compare two different units, so the accept
+        gate reads a pose as worse-than-seed on a pair that did not change.
+        Measured by reverting that line at HEAD, the placement count moves in a
+        CLASS-DEPENDENT direction and not by much -- which is exactly why this
+        asserts the CURRENCY rather than a placement count."""
         raised = [k for k, v in self.st.base_cap_pad.items() if v > 0.0]
         self.assertTrue(raised, 'no mover pair has a non-zero seed baseline')
         for key in raised:

--- a/tests/test_725_fanout_clearance_pad_floors.py
+++ b/tests/test_725_fanout_clearance_pad_floors.py
@@ -461,35 +461,50 @@ class TestChannels(unittest.TestCase):
     # is no longer 0. MUTATION: make `_seg_shares` return False always -> `on`
     # drops to 0 and the vacuity guard fires.
 
-    def test_a_board_with_NO_copper_layers_is_not_scoped_by_layer(self):
+    def test_a_board_with_NO_copper_layers_RESOLVES_one(self):
         """If `board_info.copper_layers` is empty, `pad_copper_layers` resolves
-        NOTHING for a `*.Cu` pad -- so every cap pad would look copper-less,
-        every pair would take the off-layer fallback, and the whole board would
-        be graded at the flat scalar. Before the layer scoping existed such a
-        board only ever OVER-blocked; the fallback flips the direction, and
-        under-blocking ships a violation. So the scoping switches itself off."""
+        NOTHING for a `*.Cu` pad -- so every such pad reads copper-less and the
+        scoping would grade the board at the flat scalar. #725 handled that by
+        switching scoping OFF entirely, on the reasoning that the board only
+        ever over-blocked before.
+
+        #731 corrected the reasoning. Switching off falls back to the 'F'/'B'
+        side collapse, and check_drc does NOT switch off: it resolves the same
+        situation with a three-level fallback (filter to `.Cu`, then the layers
+        segments sit on, then ['F.Cu','B.Cu']) and still expands and grades a
+        `*.Cu` pad over the result. The side collapse drops every B.Cu and
+        inner track a through-hole pad shares copper with -- an UNDER-block,
+        which is what actually ships a violation. Measured on rp2350 with the
+        copper list cleared and cap pads made through-hole: 280 pairs check_drc
+        grades that the old fallback ignored.
+
+        So `_Repair` now resolves a copper list the same way check_drc does,
+        and `_all_cu` is never empty on a board that has any copper at all."""
         with tempfile.TemporaryDirectory() as td:
             p = _stage(td, 'nocu', classes=_default_class(0.4))
             pcb = parse_kicad_pcb(p)
+            real = list(pcb.board_info.copper_layers)
             pcb.board_info.copper_layers = []
             st = _repair(p, pcb=pcb)
             # ON THE BRANCH: the model must still be active, or nothing is
             # scoped anyway and this passes for the wrong reason.
             self.assertIsNotNone(st._floors)
-            self.assertEqual(st._all_cu, frozenset())
+            self.assertEqual(pcb.board_info.copper_layers, [])
+            # ...and the fallback reconstructed a real list from the segments.
+            self.assertTrue(st._all_cu, 'the fallback resolved no copper')
+            self.assertTrue(st._all_cu <= set(real),
+                            'the fallback invented a layer: %r'
+                            % (st._all_cu - set(real),))
             cap = st.caps[ANCHOR_CAP]
-            self.assertIsNone(st._cap_pad_layers(cap),
-                              'layer scoping stayed on with no copper layers')
+            self.assertIsNotNone(st._cap_pad_layers(cap),
+                                 'layer scoping switched itself off')
             rows = st._pad_effs(ANCHOR_CAP, cap)
             self.assertTrue(rows)
             self.assertIn(0.4, {round(v, 6) for r in rows for v in r},
                           'every pair fell back to the flat scalar -- the '
                           'board is now UNDER-blocked')
-    # MUTATION: `return pl if self._all_cu else None` -> `return pl` -> the
-    # `assertIsNone` fails. NB the effs are 0.4 either way on this board: only
-    # a `*.Cu` pad resolves empty against an empty layer list, and orangecrab's
-    # cap pads are all concrete F.Cu/B.Cu, so the under-block this guards
-    # against needs a through-hole cap pad to appear at all.
+    # MUTATION: drop the segment-derived fallback for `_all_cu` -> it is empty,
+    # `_cap_pad_layers` returns None and the assertIsNotNone fires.
 
     def test_a_relaxing_rule_REPLACES_downward(self):
         """A dru rule REPLACES, so it can lower a pair below the netclass.

--- a/tests/test_725_fanout_clearance_pad_floors.py
+++ b/tests/test_725_fanout_clearance_pad_floors.py
@@ -1,0 +1,694 @@
+"""#725: the fanout-clearance repair pass must price each pair at its REAL
+required clearance -- netclass, `.kicad_dru` layer rule, pad `(clearance ...)`
+override -- exactly as check_drc grades it, and stay byte-identical on a board
+that declares none of them.
+
+Conventions this file follows (from #697's test file, and CLAUDE.md):
+
+  * REAL parser dataclasses and REAL boards. `_Repair.__init__` reads courtyards
+    and locked refs from the file on disk, so even a synthetic case needs a file.
+  * Every assertion names the single-line MUTATION that must kill it.
+  * Assert you are ON the branch before asserting about it -- each test spies the
+    value its branch keys on, with a detail string saying why.
+
+It deliberately imports neither `run_utils` nor `subprocess`: `run_all.py`
+classifies a test as integration by grepping its SOURCE for those, and `--fast`
+would then never run this file.
+"""
+from __future__ import annotations
+
+RUN_ALL_TIMEOUT = 900
+
+import json
+import math
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+_TESTS = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_TESTS)
+for _p in ('', 'py_router', 'py_placer', 'py_tools'):
+    _d = os.path.join(_ROOT, _p)
+    if _d not in sys.path:
+        sys.path.insert(0, _d)
+if _TESTS not in sys.path:
+    sys.path.insert(0, _TESTS)
+
+from kicad_parser import parse_kicad_pcb
+from copy_board import copy_board
+import placement.legality as L
+from placement.legality import PadClearanceModel
+from placement.fanout_clearance import (_Repair, _pad_pair_shortfall,
+                                        _point_to_rect_dist, _rect_gap,
+                                        nudge_vias_for_unresolved,
+                                        repair_fanout_clearance)
+
+BOARD = os.path.join(_ROOT, 'kicad_files', 'orangecrab_ext_pll.kicad_pcb')
+INERT = os.path.join(_ROOT, 'kicad_files',
+                     'rp2350_fpga_eensy_prePlane.kicad_pcb')
+CLEAR = 0.1
+
+# Measured anchors on the stock board at CLEAR (see the PR body). TP32.1 is a
+# B.Cu test point on net 69 sitting 0.1346mm from C20's pad -- above the flat
+# 0.1 and below anything a declaration raises it to, which is precisely the
+# band the flat scalar cannot see.
+ANCHOR_CAP = 'C20'
+ANCHOR_NET = 69
+ANCHOR_GAP = 0.1346
+MOVER_A, MOVER_B = 'C49', 'C62'
+
+# The inert board's recorded result, which #725 must not move.
+INERT_UNRESOLVED = ['C16', 'C17', 'C18', 'C19', 'C22', 'C23', 'C24']
+INERT_PLACEMENTS = 2
+
+
+def _repair(path, clearance=CLEAR, prefix='C,R,FB', pcb=None):
+    """The 10-POSITIONAL construction every other test in this family uses.
+    Calling it positionally is itself part of the #725 shape contract."""
+    return _Repair(pcb if pcb is not None else parse_kicad_pcb(path), path,
+                   clearance, 0.1, 0.55, 1.0, 2.0, 0.3, prefix, set())
+
+
+def _stage(tmp, name, classes=None, dru=None):
+    """A COPY of the in-repo board (siblings carried by copy_board), plus an
+    optional netclass project and/or an optional .kicad_dru."""
+    d = os.path.join(tmp, name)
+    os.makedirs(d, exist_ok=True)
+    dst = os.path.join(d, 'b.kicad_pcb')
+    copy_board(BOARD, dst)
+    pro = os.path.splitext(dst)[0] + '.kicad_pro'
+    if classes is not None:
+        with open(pro, 'w', encoding='utf-8') as f:
+            json.dump({'net_settings': {'classes': classes,
+                                        'netclass_assignments': {},
+                                        'netclass_patterns': []}}, f)
+    elif os.path.exists(pro):
+        os.remove(pro)
+    if dru is not None:
+        with open(os.path.splitext(dst)[0] + '.kicad_dru', 'w',
+                  encoding='utf-8') as f:
+            f.write(dru)
+    return dst
+
+
+def _default_class(clearance):
+    return [{'name': 'Default', 'clearance': clearance, 'track_width': 0.2,
+             'via_diameter': 0.6, 'via_drill': 0.4, 'priority': 2147483647}]
+
+
+def _dru(layer, mm):
+    return ('(version 1)\n(rule r (layer "%s") '
+            '(constraint clearance (min %gmm)))\n' % (layer, mm))
+
+
+def _pad_rect(p):
+    """The pad rect exactly as _Repair builds it (rect_rotation folded in)."""
+    t = math.radians(getattr(p, 'rect_rotation', 0.0) or 0.0)
+    c, s = abs(math.cos(t)), abs(math.sin(t))
+    hx, hy = p.size_x / 2.0, p.size_y / 2.0
+    ex, ey = hx * c + hy * s, hx * s + hy * c
+    return (p.global_x - ex, p.global_y - ey, p.global_x + ex, p.global_y + ey)
+
+
+def _anchor_pad(pcb):
+    """The parser Pad behind the ANCHOR_GAP tuple -- located by matching the
+    rect the module itself computes, so this cannot drift from the geometry."""
+    st = _repair(BOARD, pcb=pcb)
+    cap = st.caps[ANCHOR_CAP]
+    r = cap.pad_rects()[0]
+    for t in st.cap_foreign_pads[ANCHOR_CAP]:
+        if t[4] == r[4] or t[4] == -1:
+            continue
+        if t[5] is not None and t[5] != cap.side:
+            continue
+        gap = _rect_gap(r[:4], t[:4])
+        if abs(gap - ANCHOR_GAP) > 5e-3:
+            continue
+        for fref, fp in pcb.footprints.items():
+            for p in fp.pads:
+                if p.net_id != t[4]:
+                    continue
+                if max(abs(a - b) for a, b in zip(_pad_rect(p), t[:4])) < 1e-9:
+                    return fref, p, gap
+    raise AssertionError('the ANCHOR_GAP pair is gone -- the fixture moved')
+
+
+def _short(st, ref):
+    cap = st.caps[ref]
+    return st._pad_shortfalls(ref, cap, cap.x, cap.y, cap.rot)
+
+
+class TestSourcesReachTheEngine(unittest.TestCase):
+    """Each of the three declaration channels must arrive, and a board with
+    none of them must not build a model at all."""
+
+    def test_pad_override_raises_a_pad_pair(self):
+        pcb = parse_kicad_pcb(BOARD)
+        owner, pad, gap = _anchor_pad(pcb)
+        # ON THE BRANCH: the pair must sit in the band the flat scalar misses,
+        # or every assertion below passes for the wrong reason.
+        self.assertTrue(CLEAR < gap < 0.5,
+                        'gap %.4f is not in (%.2f, 0.5) -- this test would '
+                        'pass vacuously' % (gap, CLEAR))
+        self.assertEqual(_short(_repair(BOARD, pcb=pcb), ANCHOR_CAP), {},
+                         'the stock board must not charge this pair')
+        pad.local_clearance = 0.5
+        st = _repair(BOARD, pcb=pcb)
+        self.assertIsNotNone(st._floors, 'the override did not activate a model')
+        got = _short(st, ANCHOR_CAP)
+        self.assertIn(pad.net_id,
+                      got, 'the %s override never reached the shortfall' % owner)
+        self.assertAlmostEqual(got[pad.net_id], 0.5 - gap, places=4)
+    # MUTATION: `_pad_shortfalls` back to `if gap < self.clearance - EPS:`
+    # (with the matching `self.clearance - gap`) -> got == {}.
+
+    def test_netclass_from_a_sibling_project_raises_a_pad_pair(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = _stage(td, 'ncl', classes=_default_class(0.4))
+            pcb = parse_kicad_pcb(p)
+            m = PadClearanceModel.for_board(pcb, CLEAR, p)
+            named = sum(1 for n in pcb.nets.values() if n.name)
+            # ON THE BRANCH: every named net must have arrived, at 0.4.
+            self.assertEqual(len(m.net_floor), named,
+                             'the project reached %d of %d named nets'
+                             % (len(m.net_floor), named))
+            self.assertEqual({round(v, 6) for v in m.net_floor.values()}, {0.4})
+            self.assertIn(ANCHOR_NET, _short(_repair(p, pcb=pcb), ANCHOR_CAP),
+                          'the netclass never reached the shortfall')
+    # MUTATION: drop the `PadClearanceModel.for_board` call in
+    # `_Repair.__init__` -> the shortfall is empty.
+
+    def test_dru_layer_rule_raises_a_pad_pair(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = _stage(td, 'dru', dru=_dru('B.Cu', 0.5))
+            pcb = parse_kicad_pcb(p)
+            m = PadClearanceModel.for_board(pcb, CLEAR, p)
+            # ON THE BRANCH: the rule must have parsed, on the anchor's layer.
+            self.assertEqual({k: round(v, 6) for k, v in m.layer_rules.items()},
+                             {'B.Cu': 0.5}, 'the .kicad_dru did not parse')
+            self.assertIn(ANCHOR_NET, _short(_repair(p, pcb=pcb), ANCHOR_CAP),
+                          'the layer rule never reached the shortfall')
+    # MUTATION: drop `read_board_layer_clearances` from the model -> empty.
+
+    def test_a_board_declaring_nothing_builds_no_model(self):
+        pcb = parse_kicad_pcb(INERT)
+        self.assertFalse(PadClearanceModel.for_board(pcb, CLEAR, INERT).active)
+        self.assertIsNone(_repair(INERT, pcb=pcb)._floors,
+                          'an inert board must take the flat path')
+    # MUTATION: drop the `.active` gate -> `_floors` is a model.
+
+
+class TestChannels(unittest.TestCase):
+    """pad<->pad, via<->pad and track<->pad, each priced at the requirement."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.td = tempfile.mkdtemp()
+        cls.path = _stage(cls.td, 'chan', dru=_dru('B.Cu', 0.5))
+        cls.st = _repair(cls.path)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.td, ignore_errors=True)
+
+    def test_static_foreign_pad_is_charged(self):
+        got = _short(self.st, ANCHOR_CAP)
+        self.assertIn(ANCHOR_NET, got)
+        self.assertAlmostEqual(got[ANCHOR_NET], 0.5 - ANCHOR_GAP, places=3)
+    # MUTATION: `_pad_shortfalls` back to the flat scalar -> {}.
+
+    def test_mover_vs_mover_pad_is_charged(self):
+        a, b = self.st.caps[MOVER_A], self.st.caps[MOVER_B]
+        gap = min(_rect_gap(ra[:4], rb[:4]) for ra in a.pad_rects()
+                  for rb in b.pad_rects() if ra[4] != rb[4])
+        # ON THE BRANCH: the pair must sit in the uncharged band.
+        self.assertTrue(CLEAR < gap < 0.5,
+                        '%s<->%s gap %.4f is outside the band -- this test '
+                        'would pass vacuously' % (MOVER_A, MOVER_B, gap))
+        effs = self.st._pair_effs(MOVER_A, a, MOVER_B, b)
+        self.assertIsNotNone(effs, 'no per-pair requirements were resolved')
+        self.assertEqual(
+            _pad_pair_shortfall(a.pad_rects(), b.pad_rects(), CLEAR), 0.0,
+            'the flat scalar must see nothing here')
+        self.assertGreater(
+            _pad_pair_shortfall(a.pad_rects(), b.pad_rects(), CLEAR, effs), 0.0)
+    # MUTATION: `_pad_pair_shortfall` back to `if gap < clearance - EPS:` -> 0.0.
+
+    def test_via_dru_rule_binds_through_the_span(self):
+        """A via has no pad layers of its own, so its PadFloor must be scoped to
+        ALL copper. Built with `layers=None`, PadClearanceModel.pair does
+        `fb.layers or ()`, the shared set is empty, and EVERY dru rule is
+        silently discarded -- a wrong answer that passes every other test."""
+        fl = self.st.via_floor(0)
+        self.assertIsNotNone(fl)
+        self.assertTrue(fl.layers, 'the via floor carries no layer scope')
+        self.assertIn('B.Cu', fl.layers)
+        pf = self.st.caps[ANCHOR_CAP].pad_floors[0]
+        self.assertAlmostEqual(self.st.via_required(pf, 0), 0.5, places=6)
+    # MUTATION: build the via PadFloor with `layers=None` -> via_required
+    # returns the flat 0.1.
+
+    def test_track_is_scoped_to_the_SEGMENTS_own_layer(self):
+        """check_drc resolves pad-segment as a single-layer REPLACE on
+        `seg.layer`, NOT over the F/B `side` the tuple carries (which files an
+        In1.Cu track under 'F')."""
+        pf = self.st.caps[ANCHOR_CAP].pad_floors[0]      # a B-side cap pad
+        self.assertAlmostEqual(
+            self.st.required(pf, self.st.seg_floor(0, 'B.Cu')), 0.5, places=6)
+        self.assertAlmostEqual(
+            self.st.required(pf, self.st.seg_floor(0, 'F.Cu')), CLEAR, places=6)
+        self.assertAlmostEqual(
+            self.st.required(pf, self.st.seg_floor(0, 'In1.Cu')), CLEAR,
+            places=6)
+    # MUTATION: scope the segment floor to `self._all_cu` -> the F.Cu and
+    # In1.Cu arms return 0.5 too.
+
+    def test_a_relaxing_rule_REPLACES_downward(self):
+        """A dru rule REPLACES, so it can lower a pair below the netclass.
+        Pinning this is what proves the compare uses pair(), not max_floor()."""
+        with tempfile.TemporaryDirectory() as td:
+            p = _stage(td, 'relax', classes=_default_class(0.4),
+                       dru=_dru('B.Cu', 0.15))
+            st = _repair(p)
+            cap = st.caps[ANCHOR_CAP]
+            pf = cap.pad_floors[0]
+            # ON THE BRANCH: the pad's own netclass must be the 0.4 the rule is
+            # about to replace, or "replaced downward" is not what is tested.
+            self.assertAlmostEqual(pf.ncl, 0.4, places=6)
+            self.assertAlmostEqual(st.required(pf, st.seg_floor(0, 'B.Cu')),
+                                   0.15, places=6)
+            # ...while the BROAD-PHASE bound keeps the 0.4: a relaxing rule
+            # REPLACES a pair value but must never shrink a prune, which may
+            # over-reach and must never under-reach.
+            self.assertGreaterEqual(
+                cap.max_floor, 0.4,
+                'the broad-phase bound was lowered by a relaxing rule')
+    # MUTATION: use `max_floor` instead of `pair` in the eff precompute -> the
+    # first assertion reads 0.4.
+
+    def test_the_track_bbox_reject_widens_with_the_requirement(self):
+        """`_seg_shortfalls`' cheap bbox reject is a SKIP keyed on the same
+        half-width the compare uses; left flat it drops raised pairs."""
+        ref = ANCHOR_CAP
+        cap = self.st.caps[ref]
+        segs = self.st.cap_segs[ref]
+        self.assertTrue(segs, 'no tracks in reach of %s' % ref)
+        rows = self.st._seg_effs(ref, cap)
+        self.assertIsNotNone(rows)
+        widened = sum(1 for i in range(len(rows))
+                      for j, t in enumerate(segs)
+                      if rows[i][j] > t[5] - self.st._item_reach(
+                          self.st._seg_floor_by_id.get(id(t))) + CLEAR + 1e-9)
+        self.assertGreater(widened, 0,
+                           'no track keep-out was raised -- this test would '
+                           'pass vacuously')
+    # MUTATION: leave `_seg_shortfalls`' reject at the flat `halfw` -> the
+    # widened band is never scanned.
+
+
+class TestPruneRadiiStayExact(unittest.TestCase):
+    """The pruned neighbour lists are documented as EXACT, not approximate.
+    That claim dies the moment a requirement exceeds the flat scalar."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.td = tempfile.mkdtemp()
+        cls.path = _stage(cls.td, 'prune', classes=_default_class(0.6))
+        cls.st = _repair(cls.path)
+        cls.flat = _repair(BOARD)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.td, ignore_errors=True)
+
+    def test_no_pruned_list_shrinks_at_a_raised_requirement(self):
+        """Every list must grow, or stay equal where nothing sits in the band --
+        never shrink. A shrunk list is a pair the pass can no longer see."""
+        grew = {}
+        for ref in self.st.caps:
+            for name in ('cap_foreign_pads', 'cap_caps', 'cap_segs', 'cap_vias'):
+                a = len(getattr(self.flat, name)[ref])
+                b = len(getattr(self.st, name)[ref])
+                self.assertGreaterEqual(
+                    b, a, '%s[%s] SHRANK %d -> %d at a raised requirement'
+                          % (name, ref, a, b))
+                if b > a:
+                    grew[name] = grew.get(name, 0) + 1
+        # ON THE BRANCH: each reach must actually have been raised, or this
+        # passes on a no-op change.
+        for name in ('cap_foreign_pads', 'cap_caps', 'cap_segs', 'cap_vias'):
+            self.assertIn(name, grew,
+                          '%s never grew -- its reach was not raised' % name)
+    # MUTATION: revert any one of the four prune radii -> that list shrinks and
+    # its name is missing from `grew`.
+
+    def test_a_foreign_pad_beyond_the_OLD_reach_is_still_kept(self):
+        cap = self.st.caps[ANCHOR_CAP]
+        r = cap.rect()
+        cx, cy = (r[0] + r[2]) / 2.0, (r[1] + r[3]) / 2.0
+        span = math.hypot(r[2] - cx, r[3] - cy)
+        old = 3.0 + span + CLEAR          # max_displacement_cap + span + flat
+        beyond = 0
+        for t in self.st.cap_foreign_pads[ANCHOR_CAP]:
+            px, py = (t[0] + t[2]) / 2.0, (t[1] + t[3]) / 2.0
+            ph = math.hypot(t[2] - px, t[3] - py)
+            if math.hypot(px - cx, py - cy) > old + ph:
+                beyond += 1
+        self.assertGreater(beyond, 0,
+                           'no foreign pad sits beyond the old reach %.3f -- '
+                           'this test would pass vacuously' % old)
+    # MUTATION: `:466` back to `max_displacement_cap + span + clearance` ->
+    # nothing beyond the old reach survives.
+
+    def test_the_bbox_prescreen_widens_with_the_requirement(self):
+        """`_blocked_geom`'s pad-bbox prescreen is a SKIP: left at the flat
+        scalar it silently drops exactly the pairs a declaration raises."""
+        pairs = 0
+        for ref, cap in self.st.caps.items():
+            for oref in self.st.cap_caps[ref]:
+                other = self.st.caps[oref]
+                gap = _rect_gap(cap.pad_bbox(cap.x, cap.y, cap.rot),
+                                other.pad_bbox())
+                screen = max(self.st.clearance, cap.max_floor, other.max_floor)
+                if self.st.clearance <= gap < screen:
+                    pairs += 1
+        self.assertGreater(pairs, 0,
+                           'no mover pair sits between the flat scalar and the '
+                           'widened prescreen -- this test would pass vacuously')
+    # MUTATION: `_blocked_geom`'s prescreen back to `>= self.clearance` ->
+    # every one of those pairs is skipped before its shortfall is computed.
+
+    def test_the_seed_baseline_is_in_the_SAME_currency(self):
+        """A baseline priced flat while candidates price at the requirement
+        makes `_worsens_any_net` fire on every pose and the pass stops moving
+        anything -- a failure whose symptom is FEWER placements, which reads as
+        conservative rather than broken."""
+        raised = [k for k, v in self.st.base_cap_pad.items() if v > 0.0]
+        self.assertTrue(raised, 'no mover pair has a non-zero seed baseline')
+        for key in raised:
+            ref, oref = tuple(key) if len(key) == 2 else (tuple(key)[0],) * 2
+            cap, other = self.st.caps[ref], self.st.caps[oref]
+            self.assertAlmostEqual(
+                self.st.base_cap_pad[key],
+                _pad_pair_shortfall(cap.pad_rects(), other.pad_rects(),
+                                    self.st.clearance,
+                                    self.st._pair_effs(ref, cap, oref, other)),
+                places=9,
+                msg='%s<->%s baseline is not in the candidates currency'
+                    % (ref, oref))
+        # and the flat pricing must NOT reproduce them, or the two currencies
+        # are indistinguishable here.
+        flat_zero = sum(
+            1 for key in raised
+            for ref, oref in [tuple(key)]
+            if _pad_pair_shortfall(self.st.caps[ref].pad_rects(),
+                                   self.st.caps[oref].pad_rects(),
+                                   self.st.clearance) == 0.0)
+        self.assertGreater(flat_zero, 0,
+                           'every raised baseline is also non-zero flat -- this '
+                           'test would pass vacuously')
+    # MUTATION: `base_cap_pad` back to the 3-argument `_pad_pair_shortfall` ->
+    # the raised baselines read 0.0.
+
+
+class TestNudgerGraderConsistency(unittest.TestCase):
+    """`nudge_vias_for_unresolved`'s offender test and `via_penalty`'s grazing
+    test must resolve the SAME number for the same (cap pad, via) pair. If they
+    diverge, the nudger returns an empty offender list for a cap the grader
+    flagged and the cap stays unresolved forever with nothing printed."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.td = tempfile.mkdtemp()
+        cls.path = _stage(cls.td, 'nudge', classes=_default_class(0.4))
+        cls.st = _repair(cls.path)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.td, ignore_errors=True)
+
+    def test_the_grader_rows_are_built_from_via_required(self):
+        ref = ANCHOR_CAP
+        cap = self.st.caps[ref]
+        vias = self.st.cap_vias[ref]
+        self.assertTrue(vias, 'no vias in reach of %s' % ref)
+        rows = self.st._via_effs(ref, cap, vias)
+        self.assertIsNotNone(rows)
+        raised = 0
+        for i, fa in enumerate(cap.pad_floors):
+            for j, v in enumerate(vias):
+                radius = v[3] - self.st._item_reach(self.st.via_floor(v[2]))
+                want = self.st.via_required(fa, v[2])
+                self.assertAlmostEqual(rows[i][j], radius + want, places=9)
+                raised += (want > self.st.clearance + 1e-9)
+        # ON THE BRANCH: some pair must actually be raised, or the loop above
+        # compares the flat scalar with itself.
+        self.assertGreater(raised, 0, 'no (pad, via) pair was raised -- this '
+                                      'test would pass vacuously')
+    # MUTATION: build the via eff rows from anything but `via_required` -> the
+    # equality fails.
+
+    def test_the_offender_predicate_sees_what_the_grader_charges(self):
+        """The nudger's offender test, replayed here against the same helper.
+        A via that the grader charges must be an offender, and there must be at
+        least one that the FLAT predicate would have missed."""
+        only_raised = 0
+        for ref, cap in self.st.caps.items():
+            rects = cap.pad_rects(cap.x, cap.y, cap.rot)
+            for vx, vy, vnet, keepout in self.st.cap_vias[ref]:
+                radius = keepout - self.st._item_reach(self.st.via_floor(vnet))
+                for i, (bx0, by0, bx1, by1, net) in enumerate(rects):
+                    if vnet == net:
+                        continue
+                    d = _point_to_rect_dist(vx, vy, (bx0, by0, bx1, by1))
+                    want = self.st.via_required(cap.pad_floors[i], vnet)
+                    hit_now = d < radius + want - 1e-6
+                    hit_flat = d < radius + self.st.clearance - 1e-6
+                    self.assertFalse(hit_flat and not hit_now,
+                                     'the raised predicate LOST an offender '
+                                     'the flat one saw (%s, via %g,%g)'
+                                     % (ref, vx, vy))
+                    only_raised += (hit_now and not hit_flat)
+        self.assertGreater(only_raised, 0,
+                           'no via is an offender only under the raised '
+                           'requirement -- this test would pass vacuously')
+    # MUTATION: the offender test in `nudge_vias_for_unresolved` back to
+    # `vr + clearance` -> those `only_raised` vias become invisible to the
+    # nudger while the grader still reports their caps unresolved.
+
+    def test_a_duck_typed_state_grades_flat_instead_of_crashing(self):
+        """test_617 and test_370 drive the nudger with a _FakeSt/_FakeCap that
+        carries none of this machinery."""
+        class _FakeSt(object):
+            caps = {}
+            locked_refs = set()
+
+            def graze_penalty(self, *a):
+                return 0.0
+
+        self.assertEqual(
+            nudge_vias_for_unresolved(_FakeSt(), parse_kicad_pcb(INERT), CLEAR),
+            ([], []))
+    # MUTATION: read `st._floors` (or `cap.pad_floors`) directly instead of via
+    # getattr -> AttributeError, and two existing test files go red.
+
+
+class TestShapeContract(unittest.TestCase):
+    """Four tuple shapes are unpacked positionally outside this module. #725
+    carries floors in parallel lists and identity maps precisely so that none
+    of them had to widen."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.td = tempfile.mkdtemp()
+        cls.path = _stage(cls.td, 'shape', classes=_default_class(0.4))
+        cls.st = _repair(cls.path)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.td, ignore_errors=True)
+
+    def test_the_four_pinned_tuple_widths(self):
+        # ON THE BRANCH: grading the FLAT path proves nothing about the shapes.
+        self.assertIsNotNone(self.st._floors)
+        self.assertTrue(all(len(v) == 4 for v in self.st.vias))
+        self.assertTrue(all(len(s) == 7 for s in self.st.segments))
+        self.assertTrue(all(len(t) == 6 for t in self.st.foreign_pads))
+        for cap in self.st.caps.values():
+            self.assertTrue(all(len(r) == 5 for r in cap.pad_rects()))
+    # MUTATION: widen any of them -> animate_fanout_clearance.py and three
+    # existing test files stop unpacking.
+
+    def test_pad_floors_stay_index_aligned_through_every_rotation(self):
+        cap = self.st.caps[ANCHOR_CAP]
+        self.assertEqual(len(cap.pad_floors), len(cap.pads))
+        base = [r[4] for r in cap.pad_rects(cap.x, cap.y, 0.0)]
+        for rot in (0.0, 90.0, 180.0, 270.0):
+            rects = cap.pad_rects(cap.x, cap.y, rot)
+            self.assertEqual(len(rects), len(cap.pad_floors))
+            self.assertEqual([r[4] for r in rects], base,
+                             'pad order changed at rot %g -- floors would '
+                             'address the wrong pad' % rot)
+    # MUTATION: sort or filter inside `_pad_cache_for` -> the nets reorder.
+
+    def test_injecting_st_vias_wholesale_still_grades(self):
+        """`st.vias = [...]` is the idiom tests/test_fanout_clearance.py uses.
+        Any POSITIONAL parallel floor list would desync right here."""
+        st = _repair(self.path)
+        cap = st.caps[ANCHOR_CAP]
+        own = {p[4] for p in cap.pads}
+        foreign = next(n for n in range(1, 50) if n not in own)
+        r = cap.pad_rects()[0]
+        st.vias = [((r[0] + r[2]) / 2.0, (r[1] + r[3]) / 2.0, foreign,
+                    0.35 / 2 + CLEAR)]
+        st.cap_vias = {ref: st.vias for ref in st.caps}
+        self.assertGreater(
+            st.via_penalty(cap, cap.x, cap.y, cap.rot,
+                           st.cap_vias[ANCHOR_CAP], ref=ANCHOR_CAP), 0.0)
+    # MUTATION: key the via floors by list position -> IndexError, or a
+    # silently wrong requirement.
+
+    def test_injecting_cap_foreign_pads_grades_without_misindexing(self):
+        st = _repair(self.path)
+        cap = st.caps[ANCHOR_CAP]
+        own = {p[4] for p in cap.pads}
+        foreign = next(n for n in range(1, 50) if n not in own)
+        r = cap.pad_rects()[0]
+        st.cap_foreign_pads[ANCHOR_CAP] = [
+            (r[0] - 0.15, r[1], r[0] - 0.05, r[3], foreign, cap.side)]
+        self.assertIn(foreign, _short(st, ANCHOR_CAP))
+    # MUTATION: drop the source-list identity guard in `_pad_effs` -> stale
+    # rows index a list that no longer exists (IndexError).
+
+    def test_ten_positional_arguments_still_construct(self):
+        _Repair(parse_kicad_pcb(BOARD), BOARD, CLEAR, 0.1, 0.55, 1.0, 2.0, 0.3,
+                'C', set())
+    # MUTATION: insert a parameter before `max_displacement_cap` -> four
+    # existing test files break.
+
+
+class TestInertness(unittest.TestCase):
+    """A board declaring nothing must take the IDENTICAL flat path -- a
+    stronger claim than 'it gives the same answer'."""
+
+    @staticmethod
+    def _counting():
+        hits = [0]
+        orig = PadClearanceModel.pair
+
+        def counting(self, a, b):
+            hits[0] += 1
+            return orig(self, a, b)
+        return hits, orig, counting
+
+    def test_the_model_is_never_consulted_on_an_inert_board(self):
+        """A result comparison alone passes even if the model runs and returns
+        `base` every time, which would be a real (perf) regression hiding
+        behind a correct answer."""
+        hits, orig, counting = self._counting()
+        PadClearanceModel.pair = counting
+        try:
+            r = repair_fanout_clearance(parse_kicad_pcb(INERT), INERT,
+                                        clearance=CLEAR)
+        finally:
+            PadClearanceModel.pair = orig
+        self.assertEqual(hits[0], 0,
+                         'the model was consulted %d times on a board that '
+                         'declares nothing' % hits[0])
+        self.assertEqual(len(r['placements']), INERT_PLACEMENTS)
+        self.assertEqual(sorted(r['unresolved']), INERT_UNRESOLVED)
+        self.assertEqual(r['required'], [])
+        self.assertEqual(r['clearance_notes'], [])
+    # MUTATION: drop the `.active` gate in `_Repair.__init__` -> hits > 0.
+
+    def test_the_counter_itself_fires_on_a_declaring_board(self):
+        """Without this, the test above also passes if `pair` is simply never
+        the method the fix calls."""
+        hits, orig, counting = self._counting()
+        PadClearanceModel.pair = counting
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                _repair(_stage(td, 'ctr', classes=_default_class(0.4)))
+        finally:
+            PadClearanceModel.pair = orig
+        self.assertGreater(hits[0], 0)
+
+
+class TestReport(unittest.TestCase):
+    def test_required_rows_name_the_source_and_render(self):
+        with tempfile.TemporaryDirectory() as td:
+            st = _repair(_stage(td, 'rep', classes=_default_class(0.4)))
+            rows = st.required_rows()
+            self.assertTrue(rows, 'nothing was reported as raised')
+            for ref, who, mm, src in rows:
+                self.assertIn(src, ('netclass', 'layer rule', 'pad override'))
+                self.assertGreater(mm, st.clearance)
+            clause = L.format_required_clause({'required': rows})
+            self.assertIn('requires', clause)
+            self.assertIn('netclass', clause)
+
+    def test_only_CHARGED_pairs_are_reported(self):
+        """An in-reach pair that happens to be clear is not a finding, it is the
+        normal case on a declaring board. Reporting all of them buries the real
+        ones under hundreds of rows."""
+        with tempfile.TemporaryDirectory() as td:
+            st = _repair(_stage(td, 'rep2', classes=_default_class(0.4)))
+            in_reach = sum(len(st.cap_foreign_pads[r]) + len(st.cap_vias[r])
+                           + len(st.cap_segs[r]) for r in st.caps)
+            self.assertGreater(in_reach, 1000, 'the fixture got small')
+            self.assertLess(len(st.required_rows()), 100,
+                            'required_rows is reporting in-reach pairs rather '
+                            'than charged ones')
+    # MUTATION: drop the `charged` filter in `required_rows` -> hundreds of rows.
+
+    def test_an_unreadable_declaration_is_disclosed_not_silent(self):
+        """A FAILED read is exactly what makes a model look inert, so the notes
+        must be captured BEFORE the active-drop."""
+        import list_nets
+        orig = list_nets.net_clearance_map
+
+        def boom(*a, **k):
+            raise IOError('staged failure')
+        list_nets.net_clearance_map = boom
+        try:
+            with tempfile.TemporaryDirectory() as td:
+                st = _repair(_stage(td, 'unread', classes=_default_class(0.4)))
+                self.assertTrue(st.clearance_notes,
+                                'the failed netclass read was silent')
+        finally:
+            list_nets.net_clearance_map = orig
+    # MUTATION: read `model.notes` after `if not model.active: model = None`
+    # -> AttributeError, or the notes are lost.
+
+
+class TestAnimatorRecorderStillUnpacks(unittest.TestCase):
+    """tests/test_431_animator_port.py drives render_gif with a SYNTHETIC
+    recorder and never touches the real `_Recorder`, so it passes even if a
+    shape change breaks the shipped animator. This is the only coverage."""
+
+    def test_the_real_on_move_recorder_survives(self):
+        import animate_fanout_clearance as AFC
+        rec = AFC._Recorder()
+        repair_fanout_clearance(parse_kicad_pcb(INERT), INERT, clearance=CLEAR,
+                                max_displacement=0.0, max_passes=1, on_move=rec)
+        self.assertTrue(rec.static['vias'], 'no vias were recorded')
+        self.assertTrue(all(len(v) == 4 for v in rec.static['vias']))
+    # MUTATION: widen st.vias to 5-tuples -> ValueError inside _Recorder.
+
+
+class TestParityGateRegistration(unittest.TestCase):
+    def test_place_fanout_clearance_is_a_scanned_CLI_main(self):
+        """tests/gui_parity/** is NOT collected by run_all.py's flat glob, so
+        nothing in the default suite runs that lint. Assert it here."""
+        with open(os.path.join(_TESTS, 'gui_parity',
+                               'test_cli_postpass_coverage.py'),
+                  encoding='utf-8') as fh:
+            self.assertIn('py_placer/place_fanout_clearance.py', fh.read())
+    # MUTATION: remove it from CLI_MAINS -> the cap-repair CLI's post-passes go
+    # unscanned again.
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/test_725_fanout_clearance_pad_floors.py
+++ b/tests/test_725_fanout_clearance_pad_floors.py
@@ -24,7 +24,9 @@ from __future__ import annotations
 RUN_ALL_FAST_OK = True
 RUN_ALL_TIMEOUT = 900
 
+import contextlib
 import copy
+import io
 import json
 import math
 import os
@@ -163,7 +165,14 @@ class TestSourcesReachTheEngine(unittest.TestCase):
                          'the stock board must not charge this pair')
         pad.local_clearance = 0.5
         st = _repair(BOARD, pcb=pcb)
-        self.assertIsNotNone(st._floors, 'the override did not activate a model')
+        # NB: NOT `assertIsNotNone(st._floors)` -- this board's 6 fiducials
+        # already carry local_clearance 0.375, so the model is active before
+        # this test writes anything, and that assertion would credit the setup
+        # for a state it did not create.
+        self.assertAlmostEqual(st.caps[ANCHOR_CAP].max_floor, 0.0, places=9,
+                               msg='the CAP carries a floor of its own -- the '
+                                   'shortfall below would not isolate the '
+                                   'foreign override')
         got = _short(st, ANCHOR_CAP)
         self.assertIn(pad.net_id,
                       got, 'the %s override never reached the shortfall' % owner)
@@ -443,8 +452,11 @@ class TestChannels(unittest.TestCase):
             self.assertIn(0.4, {round(v, 6) for r in rows for v in r},
                           'every pair fell back to the flat scalar -- the '
                           'board is now UNDER-blocked')
-    # MUTATION: `return pl if self._all_cu else None` -> `return pl` -> every
-    # pad reads as copper-less and the whole board grades flat.
+    # MUTATION: `return pl if self._all_cu else None` -> `return pl` -> the
+    # `assertIsNone` fails. NB the effs are 0.4 either way on this board: only
+    # a `*.Cu` pad resolves empty against an empty layer list, and orangecrab's
+    # cap pads are all concrete F.Cu/B.Cu, so the under-block this guards
+    # against needs a through-hole cap pad to appear at all.
 
     def test_a_relaxing_rule_REPLACES_downward(self):
         """A dru rule REPLACES, so it can lower a pair below the netclass.
@@ -466,8 +478,10 @@ class TestChannels(unittest.TestCase):
             self.assertGreaterEqual(
                 cap.max_floor, 0.4,
                 'the broad-phase bound was lowered by a relaxing rule')
-    # MUTATION: use `max_floor` instead of `pair` in the eff precompute -> the
-    # first assertion reads 0.4.
+    # MUTATION: `_pair_or_flat` -> `max(self.clearance, model.max_floor(fa),
+    # model.max_floor(fb))` -> the `required(...)` assertion reads 0.4 instead
+    # of the replaced-down 0.15. (A mutation confined to the eff builders does
+    # NOT reach this test -- it reads the resolver directly.)
 
     def test_the_track_bbox_reject_widens_with_the_requirement(self):
         """`_seg_shortfalls`' cheap bbox reject is a SKIP keyed on the same
@@ -485,8 +499,10 @@ class TestChannels(unittest.TestCase):
         self.assertGreater(widened, 0,
                            'no track keep-out was raised -- this test would '
                            'pass vacuously')
-    # MUTATION: leave `_seg_shortfalls`' reject at the flat `halfw` -> the
-    # widened band is never scanned.
+    # MUTATION: `_seg_effs`' `halves[j] + eff(...)` -> `halves[j] +
+    # self.clearance` -> no row exceeds the flat half-width.
+    # NB this reads the eff ROWS; `_seg_shortfalls`' own widened bbox reject is
+    # a separate site and is NOT what this test covers.
 
 
 class TestPruneRadiiStayExact(unittest.TestCase):
@@ -522,8 +538,12 @@ class TestPruneRadiiStayExact(unittest.TestCase):
         for name in ('cap_foreign_pads', 'cap_caps', 'cap_segs', 'cap_vias'):
             self.assertIn(name, grew,
                           '%s never grew -- its reach was not raised' % name)
-    # MUTATION: revert any one of the four prune radii -> that list shrinks and
-    # its name is missing from `grew`.
+    # MUTATION: revert the foreign-pad radius or the cap-cap radius -> that
+    # list shrinks and its name is missing from `grew`.
+    # NB the segment and via radii are NOT covered here: on a uniform-class
+    # fixture the ITEMS' own floors already grow those two lists, so removing
+    # the cap-side slack leaves `grew` intact. They are covered by
+    # test_the_cap_side_slack_raises_the_via_and_track_reaches.
 
     def test_a_foreign_pad_beyond_the_OLD_reach_is_still_kept(self):
         cap = self.st.caps[ANCHOR_CAP]
@@ -772,21 +792,79 @@ class TestNudgerGraderConsistency(unittest.TestCase):
     # MUTATION: drop the `_radii[id(moved)] = ...` carry-over in
     # `nudge_vias_for_unresolved` -> rec is None.
 
+    def test_the_nudger_grades_a_COPPERLESS_cap_pad_flat_too(self):
+        """The copper-less-pad rule must not stop at the eff builders. The
+        nudger resolves through the same helpers, so without the marker it
+        charges a phantom the grader does not -- handing itself a via nothing
+        flagged and printing an operator-facing line naming a non-violation."""
+        with tempfile.TemporaryDirectory() as td:
+            p = _stage(td, 'nudgeflat', classes=_default_class(0.4))
+            pcb = parse_kicad_pcb(p)
+            fp = pcb.footprints[ANCHOR_CAP]
+            real = [q for q in fp.pads if L._pad_carries_copper(q)]
+            hole = copy.deepcopy(real[1])
+            hole.pad_type = 'np_thru_hole'
+            hole.drill = 1.0
+            hole.layers = ['*.Cu', '*.Mask']
+            hole.local_clearance = 1.0
+            fp.pads[fp.pads.index(real[1])] = hole
+            st = _repair(p, pcb=pcb)
+            cap = st.caps[ANCHOR_CAP]
+            flat_i = [k for k in range(len(cap.pad_floors))
+                      if not cap.pad_layers[k]]
+            # ON THE BRANCH: there must be exactly one copper-less pad, and the
+            # board must be declaring, or the phantom cannot arise.
+            self.assertEqual(len(flat_i), 1)
+            self.assertIsNotNone(st._floors)
+            seen = []
+            real_req = st.via_required
+
+            def recording(pad_floor, via_net):
+                seen.append(pad_floor)
+                return real_req(pad_floor, via_net)
+            st.via_required = recording
+            nudge_vias_for_unresolved(st, pcb, CLEAR)
+            self.assertTrue(seen, 'the nudger never consulted via_required')
+            bad = [f for f in seen if f is cap.pad_floors[flat_i[0]]]
+            self.assertEqual(bad, [], 'the nudger priced the copper-less pad '
+                                      'at its own floor instead of flat')
+    # MUTATION: drop the `pad_layers` check in `cap_floors_of` -> the
+    # copper-less pad's floor reaches via_required.
+
     def test_a_duck_typed_state_grades_flat_instead_of_crashing(self):
         """test_617 and test_370 drive the nudger with a _FakeSt/_FakeCap that
-        carries none of this machinery."""
+        carries none of this machinery.
+
+        The cap and the UNRESOLVED verdict are both load-bearing: with no caps
+        the function returns at its pre-existing early return, 58 lines above
+        the first `getattr(st, ...)` this change added, and the test proves
+        nothing at all. It did exactly that until an audit measured the line
+        coverage."""
+        pcb = parse_kicad_pcb(INERT)
+
+        class _FakeCap(object):
+            pads = [(0.0, 0.0, 0.1, 0.1, 1)]
+            x = y = rot = 0.0
+            side = 'F'
+
+            def pad_rects(self, *a):
+                b = pcb.board_info.board_bounds
+                return [(b[0] + 1.0, b[1] + 1.0, b[0] + 1.2, b[1] + 1.2, 1)]
+
         class _FakeSt(object):
-            caps = {}
+            caps = {'C1': _FakeCap()}
             locked_refs = set()
 
             def graze_penalty(self, *a):
-                return 0.0
-
-        self.assertEqual(
-            nudge_vias_for_unresolved(_FakeSt(), parse_kicad_pcb(INERT), CLEAR),
-            ([], []))
-    # MUTATION: read `st._floors` (or `cap.pad_floors`) directly instead of via
-    # getattr -> AttributeError, and two existing test files go red.
+                return 1.0          # unresolved, so the offender loop RUNS
+        st = _FakeSt()
+        moves, segs = nudge_vias_for_unresolved(st, pcb, CLEAR)
+        self.assertEqual((moves, segs), ([], []))
+        # ON THE BRANCH: prove the guarded reads were reached, not skipped.
+        self.assertIsNone(getattr(st, '_floors', None))
+        self.assertFalse(hasattr(_FakeCap, 'pad_floors'))
+    # MUTATION: read `st.required` / `cap.pad_floors` directly instead of via
+    # getattr -> AttributeError here, and in test_617 / test_370.
 
 
 class TestShapeContract(unittest.TestCase):
@@ -807,11 +885,19 @@ class TestShapeContract(unittest.TestCase):
     def test_the_four_pinned_tuple_widths(self):
         # ON THE BRANCH: grading the FLAT path proves nothing about the shapes.
         self.assertIsNotNone(self.st._floors)
-        self.assertTrue(all(len(v) == 4 for v in self.st.vias))
-        self.assertTrue(all(len(s) == 7 for s in self.st.segments))
-        self.assertTrue(all(len(t) == 6 for t in self.st.foreign_pads))
+        # every all() below is vacuous on an empty collection, so gate each
+        for what, coll, width in (('vias', self.st.vias, 4),
+                                  ('segments', self.st.segments, 7),
+                                  ('foreign_pads', self.st.foreign_pads, 6)):
+            self.assertTrue(coll, 'no %s on this fixture -- the width '
+                                  'assertion would be vacuous' % what)
+            self.assertTrue(all(len(t) == width for t in coll),
+                            '%s is not %d wide' % (what, width))
+        self.assertTrue(self.st.caps)
         for cap in self.st.caps.values():
-            self.assertTrue(all(len(r) == 5 for r in cap.pad_rects()))
+            rects = cap.pad_rects()
+            self.assertTrue(rects)
+            self.assertTrue(all(len(r) == 5 for r in rects))
     # MUTATION: widen any of them -> animate_fanout_clearance.py and three
     # existing test files stop unpacking.
 
@@ -825,7 +911,9 @@ class TestShapeContract(unittest.TestCase):
             self.assertEqual([r[4] for r in rects], base,
                              'pad order changed at rot %g -- floors would '
                              'address the wrong pad' % rot)
-    # MUTATION: sort or filter inside `_pad_cache_for` -> the nets reorder.
+    # MUTATION: FILTER inside `_pad_cache_for` (drop a pad) -> the length
+    # assertions fail. NB a deterministic SORT is not covered: `base` comes
+    # from the same function, so both sides reorder together.
 
     def test_injecting_st_vias_wholesale_is_graded_AS_INJECTED(self):
         """`st.vias = [...]` is the idiom tests/test_fanout_clearance.py uses.
@@ -896,11 +984,64 @@ class TestShapeContract(unittest.TestCase):
     # MUTATION: drop the source-list identity guard in `_pad_effs` -> the
     # shortfall reads 0.35.
 
-    def test_ten_positional_arguments_still_construct(self):
-        _Repair(parse_kicad_pcb(BOARD), BOARD, CLEAR, 0.1, 0.55, 1.0, 2.0, 0.3,
-                'C', set())
-    # MUTATION: insert a parameter before `max_displacement_cap` -> four
-    # existing test files break.
+    def test_via_penalty_without_a_ref_grades_FLAT_as_documented(self):
+        """`via_penalty(cap, x, y, rot)` is a public 4-positional path existing
+        tests use. Its docstring says the flat scalar is used there. #725
+        redefined the tuple's keep-out slot as the prune OVER-reach, so grading
+        that slot directly charges more than any pair needs -- and more than
+        upstream's slot, which really was radius + clearance."""
+        with tempfile.TemporaryDirectory() as td:
+            p = _stage(td, 'noref', classes=_default_class(0.4),
+                       dru=_dru('In1.Cu', 0.9))
+            st = _repair(p)
+            ref = 'C7'          # C20's vias clear both ways; C7's do not
+            cap = st.caps[ref]
+            vias = st.cap_vias[ref]
+            self.assertTrue(vias)
+            flat = st.via_penalty(cap, cap.x, cap.y, cap.rot, vias)
+            expect = over = 0.0
+            for (bx0, by0, bx1, by1, net) in cap.pad_rects():
+                for v in vias:
+                    if v[2] == net:
+                        continue
+                    d = _point_to_rect_dist(v[0], v[1], (bx0, by0, bx1, by1))
+                    ko = st._via_radius_by_id[id(v)][1] + CLEAR
+                    if d < ko - 1e-6:
+                        expect += ko - d
+                    if d < v[3] - 1e-6:          # the tuple's over-reach slot
+                        over += v[3] - d
+            # ON THE BRANCH: the two must actually differ on this cap, or the
+            # assertion below holds whichever quantity is graded.
+            self.assertGreater(over, expect + 1.0,
+                               'flat and over-reach coincide here (%.4f vs '
+                               '%.4f) -- this would pass vacuously'
+                               % (expect, over))
+            self.assertAlmostEqual(flat, expect, places=9,
+                                   msg='the no-ref path graded at the prune '
+                                       'over-reach, not the flat scalar')
+    # MUTATION: grade `keepout` directly in via_penalty's flat branch -> the
+    # penalty comes out far above the flat scalar.
+
+    def test_ten_positional_arguments_bind_to_the_documented_params(self):
+        """Four existing test files construct _Repair with 10 positionals. A
+        bare construction asserts nothing -- inserting a DEFAULTED parameter
+        still constructs fine and binds every argument to the wrong name. Check
+        the signature, then check the values landed."""
+        import inspect
+        names = list(inspect.signature(_Repair.__init__).parameters)[1:11]
+        self.assertEqual(names, ['pcb_data', 'pcb_file', 'clearance',
+                                 'grid_step', 'board_edge_clearance',
+                                 'near_margin', 'capture_radius',
+                                 'default_via_size', 'cap_prefix',
+                                 'extra_locked'])
+        st = _Repair(parse_kicad_pcb(BOARD), BOARD, CLEAR, 0.1, 0.55, 1.0, 2.0,
+                     0.3, 'C', set())
+        self.assertEqual(st.clearance, CLEAR)
+        self.assertEqual(st.grid_step, 0.1)
+        self.assertEqual(st.capture_radius, 2.0)
+        self.assertEqual(st._cap_prefixes, ('C',))
+    # MUTATION: insert ANY parameter (defaulted or not) before `extra_locked`
+    # -> the name list differs, and the values land on the wrong attributes.
 
 
 class TestInertness(unittest.TestCase):
@@ -937,6 +1078,49 @@ class TestInertness(unittest.TestCase):
         self.assertEqual(r['clearance_notes'], [])
     # MUTATION: drop the `.active` gate in `_Repair.__init__` -> hits > 0.
 
+    def test_the_locked_warning_still_names_a_COPPERLESS_NPTH_pad(self):
+        """The locked-part warning exists to surface a foreign via inside a
+        locked pad's keep-out. A via inside a 1.7mm mounting hole is exactly
+        that, and upstream reported it. #725's copper predicate must decide how
+        the pair is PRICED, not whether it is seen -- dropping such pads removed
+        real rows on a board that declares nothing at all, which would break
+        the inertness claim in this channel."""
+        pcb = parse_kicad_pcb(INERT)
+        st = _repair(INERT, pcb=pcb)
+        # ON THE BRANCH: an inert board, and a locked part to convert.
+        self.assertIsNone(st._floors)
+        locked = sorted(st.locked_refs)
+        self.assertTrue(locked, 'no locked part on this fixture')
+
+        def warn_rows(board):
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                repair_fanout_clearance(board, INERT, clearance=CLEAR)
+            return [ln.strip() for ln in buf.getvalue().splitlines()
+                    if '<-> via at' in ln]
+
+        # ON THE BRANCH: convert the pad that actually HAS a via in its
+        # keep-out, or the row it should keep does not exist either way.
+        # (Match the ref token exactly -- 'U8.16'.startswith('U8.1') is True,
+        # and a prefix test silently passed on the wrong row while checking
+        # this fix.)
+        before = warn_rows(pcb)
+        self.assertTrue(before, 'no locked-pad warning at all on this fixture')
+        ref, pnum = before[0].split(' ')[0].split('.', 1)
+        fp = pcb.footprints[ref]
+        pad = next(q for q in fp.pads if str(q.pad_number) == pnum)
+        pad.pad_type = 'np_thru_hole'
+        pad.drill = 1.7
+        pad.layers = ['*.Cu', '*.Mask']
+        self.assertFalse(L._pad_carries_copper(pad))
+        after = warn_rows(pcb)
+        named = [r for r in after if r.split(' ')[0] == '%s.%s' % (ref, pnum)]
+        self.assertTrue(named,
+                        'the copper-less locked pad vanished from the warning: '
+                        '%r -> %r' % (before, after))
+    # MUTATION: `continue` on `not _pad_carries_copper(p)` in the locked
+    # warning -> those rows disappear, on an INERT board.
+
     def test_the_counter_itself_fires_on_a_declaring_board(self):
         """Without this, the test above also passes if `pair` is simply never
         the method the fix calls."""
@@ -948,6 +1132,9 @@ class TestInertness(unittest.TestCase):
         finally:
             PadClearanceModel.pair = orig
         self.assertGreater(hits[0], 0)
+    # MUTATION: make the counter patch a method the fix does not call (e.g.
+    # `pair_with_source`) -> this control goes red while the inertness test
+    # above still passes, which is the point of having it.
 
 
 class TestReport(unittest.TestCase):
@@ -959,9 +1146,18 @@ class TestReport(unittest.TestCase):
             for ref, who, mm, src in rows:
                 self.assertIn(src, ('netclass', 'layer rule', 'pad override'))
                 self.assertGreater(mm, st.clearance)
+            # every source this fixture can produce is 'netclass'; assert that
+            # rather than a 3-way `assertIn` that one value satisfies
+            self.assertEqual({r[3] for r in rows}, {'netclass'})
             clause = L.format_required_clause({'required': rows})
             self.assertIn('requires', clause)
             self.assertIn('netclass', clause)
+            # the mover-vs-mover leg must contribute, or deleting it passes
+            self.assertTrue([r for r in rows if r[1].startswith('cap ')],
+                            'no mover-vs-mover row -- deleting that leg would '
+                            'leave this test green')
+    # MUTATION: delete the mover-vs-mover leg of `required_rows` -> the last
+    # assertion fails (it left 59 of 77 rows and passed before this guard).
 
     def test_only_CHARGED_pairs_are_reported(self):
         """An in-reach pair that happens to be clear is not a finding, it is the
@@ -976,6 +1172,45 @@ class TestReport(unittest.TestCase):
                             'required_rows is reporting in-reach pairs rather '
                             'than charged ones')
     # MUTATION: drop the `charged` filter in `required_rows` -> hundreds of rows.
+
+    def test_the_report_never_names_an_OFF_LAYER_track_pair(self):
+        """`required_rows` must MIRROR what was charged, not re-derive it.
+        `_seg_effs` prices a cap-pad/track pair that shares no copper layer at
+        the flat scalar (the F/B side collapse puts such pairs in `cap_segs` at
+        all); a report that resolves the requirement independently names them
+        anyway, at the netclass. check_drc grades no such pair, so every one of
+        those rows sends the reader after a violation that does not exist --
+        measured at up to 43% of the disclosure on rp2350."""
+        with tempfile.TemporaryDirectory() as td:
+            p = _stage(td, 'offrep', classes=_default_class(0.4), src=INERT)
+            pcb = parse_kicad_pcb(p)
+            st = _repair(p, pcb=pcb)
+            names = {n.net_id: n.name for n in pcb.nets.values()}
+            by_name = {v: k for k, v in names.items()}
+            rows = st.required_rows(names)
+            tracks = [r for r in rows if r[1].startswith('track ')]
+            # ON THE BRANCH: there must BE track rows and there must be
+            # off-layer pairs in reach, or this proves nothing.
+            self.assertTrue(tracks, 'no track rows at all on this fixture')
+            off_pairs = sum(
+                1 for ref, cap in st.caps.items()
+                for t in st.cap_segs[ref]
+                if not any(st._seg_layer_by_id.get(id(t)) in pl
+                           for pl in cap.pad_layers))
+            self.assertGreater(off_pairs, 0, 'no off-layer pair in any pruned '
+                                             'list -- this would pass vacuously')
+            for ref, who, mm, src in tracks:
+                nid = by_name.get(who[6:])
+                cap = st.caps[ref]
+                shared = any(
+                    any(st._seg_layer_by_id.get(id(t)) in pl
+                        for pl in cap.pad_layers)
+                    for t in st.cap_segs[ref] if t[4] == nid)
+                self.assertTrue(shared,
+                                '%s <-> %s shares no copper layer, so it is '
+                                'priced flat and must not be reported' % (ref, who))
+    # MUTATION: drop the `layer not in cap_layers[i]` guard in
+    # `required_rows`' `best()` -> phantom rows come back.
 
     def test_an_unreadable_declaration_is_disclosed_not_silent(self):
         """A FAILED read is exactly what makes a model look INERT, so the notes

--- a/tests/test_725_fanout_clearance_pad_floors.py
+++ b/tests/test_725_fanout_clearance_pad_floors.py
@@ -240,8 +240,68 @@ class TestSourcesReachTheEngine(unittest.TestCase):
         self.assertAlmostEqual(cap.max_floor, 0.5, places=6,
                                msg='the NPTH override reached max_floor and '
                                    'would widen every prune and the prescreen')
+        # ...and the pad's LAYER SET is empty, which is the marker every eff
+        # builder keys "grade this pad flat" on.
+        self.assertEqual(cap.pad_layers[-1], frozenset())
+        self.assertTrue(cap.pad_layers[0], 'the copper pad lost its layers')
     # MUTATION: drop the `_pad_carries_copper` guard on `model.pad_floor(p)` in
     # `_Cap.__init__` -> max_floor becomes 3.0.
+
+    def test_a_COPPERLESS_pad_is_graded_flat_in_EVERY_channel(self):
+        """Zeroing the copper-less pad's own override is not enough: the
+        PARTNER's netclass still flows through `pair()`, charging a keep-out
+        against a pad check_drc does not grade at all. Same defect as the
+        off-layer phantom, in the pad / via / cap-cap channels.
+
+        Measured before this guard, with C20's second copper pad replaced by an
+        np_thru_hole at lc=1.0 on a Default-0.4 board: that pad was priced at
+        0.4 against every foreign pad, and C20's foreign-pad shortfall read
+        0.6950mm where the flat scalar sees 0.2450."""
+        with tempfile.TemporaryDirectory() as td:
+            p = _stage(td, 'npthflat', classes=_default_class(0.4))
+            pcb = parse_kicad_pcb(p)
+            fp = pcb.footprints[ANCHOR_CAP]
+            real = [q for q in fp.pads if L._pad_carries_copper(q)]
+            self.assertGreaterEqual(len(real), 2, 'need a 2-copper-pad cap')
+            hole = copy.deepcopy(real[1])
+            hole.pad_type = 'np_thru_hole'
+            hole.drill = 1.0
+            hole.layers = ['*.Cu', '*.Mask']
+            hole.local_clearance = 1.0
+            fp.pads[fp.pads.index(real[1])] = hole
+            st = _repair(p, pcb=pcb)
+            cap = st.caps[ANCHOR_CAP]
+            flat_i = [k for k in range(len(cap.pad_floors))
+                      if not cap.pad_layers[k]]
+            live_i = [k for k in range(len(cap.pad_floors))
+                      if cap.pad_layers[k]]
+            # ON THE BRANCH: one of each, or this proves nothing.
+            self.assertEqual(len(flat_i), 1)
+            self.assertTrue(live_i)
+            fi, li = flat_i[0], live_i[0]
+
+            pad_rows = st._pad_effs(ANCHOR_CAP, cap)
+            self.assertEqual({round(v, 6) for v in pad_rows[fi]}, {CLEAR})
+            self.assertEqual({round(v, 6) for v in pad_rows[li]}, {0.4},
+                             'the COPPER pad must still be charged at 0.4')
+
+            vias = st.cap_vias[ANCHOR_CAP]
+            self.assertTrue(vias)
+            via_rows = st._via_effs(ANCHOR_CAP, cap, vias)
+            for j, v in enumerate(vias):
+                radius = st._via_radius_by_id[id(v)][1]
+                self.assertAlmostEqual(via_rows[fi][j], radius + CLEAR,
+                                       places=9)
+                self.assertAlmostEqual(via_rows[li][j], radius + 0.4, places=9)
+
+            oref = next((o for o in st.cap_caps[ANCHOR_CAP]
+                         if st._cap_floors_ok(st.caps[o])), None)
+            self.assertIsNotNone(oref, 'no mover neighbour to pair with')
+            pair_rows = st._pair_effs(ANCHOR_CAP, cap, oref, st.caps[oref])
+            self.assertEqual({round(v, 6) for v in pair_rows[fi]}, {CLEAR})
+            self.assertEqual({round(v, 6) for v in pair_rows[li]}, {0.4})
+    # MUTATION: drop the `_flat_pad` test in `_pad_effs` / `_via_effs` /
+    # `_pair_effs` -> the copper-less row comes back at 0.4.
 
     def test_a_board_declaring_nothing_builds_no_model(self):
         pcb = parse_kicad_pcb(INERT)
@@ -358,6 +418,33 @@ class TestChannels(unittest.TestCase):
             self.assertGreater(on, 0, 'no on-layer pair was raised')
     # MUTATION: drop the off-layer test in `_seg_effs` -> the off-layer rows
     # come back at the netclass 0.4.
+
+    def test_a_board_with_NO_copper_layers_is_not_scoped_by_layer(self):
+        """If `board_info.copper_layers` is empty, `pad_copper_layers` resolves
+        NOTHING for a `*.Cu` pad -- so every cap pad would look copper-less,
+        every pair would take the off-layer fallback, and the whole board would
+        be graded at the flat scalar. Before the layer scoping existed such a
+        board only ever OVER-blocked; the fallback flips the direction, and
+        under-blocking ships a violation. So the scoping switches itself off."""
+        with tempfile.TemporaryDirectory() as td:
+            p = _stage(td, 'nocu', classes=_default_class(0.4))
+            pcb = parse_kicad_pcb(p)
+            pcb.board_info.copper_layers = []
+            st = _repair(p, pcb=pcb)
+            # ON THE BRANCH: the model must still be active, or nothing is
+            # scoped anyway and this passes for the wrong reason.
+            self.assertIsNotNone(st._floors)
+            self.assertEqual(st._all_cu, frozenset())
+            cap = st.caps[ANCHOR_CAP]
+            self.assertIsNone(st._cap_pad_layers(cap),
+                              'layer scoping stayed on with no copper layers')
+            rows = st._pad_effs(ANCHOR_CAP, cap)
+            self.assertTrue(rows)
+            self.assertIn(0.4, {round(v, 6) for r in rows for v in r},
+                          'every pair fell back to the flat scalar -- the '
+                          'board is now UNDER-blocked')
+    # MUTATION: `return pl if self._all_cu else None` -> `return pl` -> every
+    # pad reads as copper-less and the whole board grades flat.
 
     def test_a_relaxing_rule_REPLACES_downward(self):
         """A dru rule REPLACES, so it can lower a pair below the netclass.

--- a/tests/test_725_fanout_clearance_pad_floors.py
+++ b/tests/test_725_fanout_clearance_pad_floors.py
@@ -11,12 +11,17 @@ Conventions this file follows (from #697's test file, and CLAUDE.md):
   * Assert you are ON the branch before asserting about it -- each test spies the
     value its branch keys on, with a detail string saying why.
 
-It deliberately imports neither `run_utils` nor `subprocess`: `run_all.py`
-classifies a test as integration by grepping its SOURCE for those, and `--fast`
-would then never run this file.
+Nothing here shells out or drives a CLI: it runs entirely in-process in ~22 s.
+`run_all.is_integration` classifies by grepping the SOURCE for `run_utils` and
+the name of the standard sub-process module, and this file NAMES those markers
+in prose (including in this sentence) -- which is exactly how the first version
+of it got bucketed as integration and silently skipped under `--fast`, a test
+file that proves nothing being worse than no test file at all. Hence the
+explicit opt-out below.
 """
 from __future__ import annotations
 
+RUN_ALL_FAST_OK = True
 RUN_ALL_TIMEOUT = 900
 
 import json

--- a/tests/test_725_fanout_clearance_pad_floors.py
+++ b/tests/test_725_fanout_clearance_pad_floors.py
@@ -316,6 +316,49 @@ class TestChannels(unittest.TestCase):
     # MUTATION: scope the segment floor to `self._all_cu` -> the F.Cu and
     # In1.Cu arms return 0.5 too.
 
+    def test_an_OFF_LAYER_track_pair_keeps_the_flat_scalar(self):
+        """`cap_segs` is pruned on the F/B side collapse, which files an
+        In1.Cu track under 'F' -- so it contains cap-pad/inner-track pairs that
+        cannot touch and that check_drc never grades at all. The dru term
+        scopes itself away from them (empty shared set), but the NETCLASS term
+        is layer-blind, so charging it there would raise a PHANTOM and move
+        caps to clear copper on a layer their pads do not occupy.
+
+        Measured before this guard, on this board at a Default class of 0.3:
+        R17/R18/R5's entire graze WAS the phantom -- 0.0821mm each flat,
+        0.6991/0.6991/0.5686 raised."""
+        with tempfile.TemporaryDirectory() as td:
+            p = _stage(td, 'offlayer', classes=_default_class(0.4))
+            st = _repair(p)
+            checked = off = on = 0
+            for ref, cap in st.caps.items():
+                rows = st._seg_effs(ref, cap)
+                if rows is None:
+                    continue
+                for i in range(len(cap.pad_floors)):
+                    mine = cap.pad_layers[i]
+                    for j, t in enumerate(st.cap_segs[ref]):
+                        layer = st._seg_layer_by_id.get(id(t))
+                        if layer is None:
+                            continue
+                        half = t[5] - st._item_reach(
+                            st._seg_floor_by_id.get(id(t)))
+                        checked += 1
+                        if layer in mine:
+                            on += rows[i][j] > half + CLEAR + 1e-9
+                        else:
+                            off += 1
+                            self.assertAlmostEqual(
+                                rows[i][j], half + CLEAR, places=9,
+                                msg='%s pad %d vs an off-layer %s track was '
+                                    'charged above the flat scalar'
+                                    % (ref, i, layer))
+            # ON THE BRANCH: both kinds must be present, or this proves nothing
+            self.assertGreater(off, 0, 'no off-layer pair in any pruned list')
+            self.assertGreater(on, 0, 'no on-layer pair was raised')
+    # MUTATION: drop the off-layer test in `_seg_effs` -> the off-layer rows
+    # come back at the netclass 0.4.
+
     def test_a_relaxing_rule_REPLACES_downward(self):
         """A dru rule REPLACES, so it can lower a pair below the netclass.
         Pinning this is what proves the compare uses pair(), not max_floor()."""
@@ -653,22 +696,45 @@ class TestShapeContract(unittest.TestCase):
                              'address the wrong pad' % rot)
     # MUTATION: sort or filter inside `_pad_cache_for` -> the nets reorder.
 
-    def test_injecting_st_vias_wholesale_still_grades(self):
+    def test_injecting_st_vias_wholesale_is_graded_AS_INJECTED(self):
         """`st.vias = [...]` is the idiom tests/test_fanout_clearance.py uses.
-        Any POSITIONAL parallel floor list would desync right here."""
-        st = _repair(self.path)
-        cap = st.caps[ANCHOR_CAP]
-        own = {p[4] for p in cap.pads}
-        foreign = next(n for n in range(1, 50) if n not in own)
-        r = cap.pad_rects()[0]
-        st.vias = [((r[0] + r[2]) / 2.0, (r[1] + r[3]) / 2.0, foreign,
-                    0.35 / 2 + CLEAR)]
-        st.cap_vias = {ref: st.vias for ref in st.caps}
-        self.assertGreater(
-            st.via_penalty(cap, cap.x, cap.y, cap.rot,
-                           st.cap_vias[ANCHOR_CAP], ref=ANCHOR_CAP), 0.0)
-    # MUTATION: key the via floors by list position -> IndexError, or a
-    # silently wrong requirement.
+        The injected tuple carries its own keep-out convention, so it must be
+        used verbatim -- deriving the radius by subtracting `_item_reach` off
+        element 3 and adding the pair requirement back silently re-prices it.
+
+        Staged with a netclass AND an inner-layer dru rule on purpose: that is
+        what makes `_item_reach` (0.5, raised by the rule on the via's all-copper
+        scope) differ from `pair` (0.4, the netclass, since the cap pad does not
+        share the ruled layer). On a fixture where they coincide, a derived
+        radius round-trips by luck and this test would pass either way."""
+        with tempfile.TemporaryDirectory() as td:
+            p = _stage(td, 'inject', classes=_default_class(0.4),
+                       dru=_dru('In1.Cu', 0.5))
+            st = _repair(p)
+            cap = st.caps[ANCHOR_CAP]
+            own = {q[4] for q in cap.pads}
+            foreign = next(n for n in range(1, 50) if n not in own)
+            r = cap.pad_rects()[0]
+            injected = ((r[0] + r[2]) / 2.0, (r[1] + r[3]) / 2.0, foreign,
+                        0.35 / 2 + CLEAR)
+            st.vias = [injected]
+            st.cap_vias = {ref: st.vias for ref in st.caps}
+            # ON THE BRANCH: the two must actually differ here.
+            reach = st._item_reach(st.via_floor(foreign))
+            pair = st.via_required(cap.pad_floors[0], foreign)
+            self.assertNotAlmostEqual(
+                reach, pair, places=6,
+                msg='_item_reach == pair on this fixture -- a derived radius '
+                    'would round-trip by luck and this test would pass '
+                    'whether or not the identity map is used')
+            rows = st._via_effs(ANCHOR_CAP, cap, st.cap_vias[ANCHOR_CAP])
+            self.assertAlmostEqual(rows[0][0], injected[3], places=9,
+                                   msg='the injected keep-out was re-priced')
+            self.assertGreater(
+                st.via_penalty(cap, cap.x, cap.y, cap.rot,
+                               st.cap_vias[ANCHOR_CAP], ref=ANCHOR_CAP), 0.0)
+    # MUTATION: derive the radius from `v[3] - _item_reach(...)` instead of the
+    # identity map -> rows[0][0] comes out 0.1mm low.
 
     def test_injecting_cap_foreign_pads_grades_without_misindexing(self):
         """A tuple a test injected carries no registered floor, so it must be

--- a/tests/test_725_fanout_clearance_pad_floors.py
+++ b/tests/test_725_fanout_clearance_pad_floors.py
@@ -38,6 +38,7 @@ if _TESTS not in sys.path:
 
 from kicad_parser import parse_kicad_pcb
 from copy_board import copy_board
+from synth import make_via
 import placement.legality as L
 from placement.legality import PadClearanceModel
 from placement.fanout_clearance import (_Repair, _pad_pair_shortfall,
@@ -71,13 +72,13 @@ def _repair(path, clearance=CLEAR, prefix='C,R,FB', pcb=None):
                    clearance, 0.1, 0.55, 1.0, 2.0, 0.3, prefix, set())
 
 
-def _stage(tmp, name, classes=None, dru=None):
-    """A COPY of the in-repo board (siblings carried by copy_board), plus an
+def _stage(tmp, name, classes=None, dru=None, src=None):
+    """A COPY of an in-repo board (siblings carried by copy_board), plus an
     optional netclass project and/or an optional .kicad_dru."""
     d = os.path.join(tmp, name)
     os.makedirs(d, exist_ok=True)
     dst = os.path.join(d, 'b.kicad_pcb')
-    copy_board(BOARD, dst)
+    copy_board(src or BOARD, dst)
     pro = os.path.splitext(dst)[0] + '.kicad_pro'
     if classes is not None:
         with open(pro, 'w', encoding='utf-8') as f:
@@ -364,21 +365,78 @@ class TestPruneRadiiStayExact(unittest.TestCase):
 
     def test_the_bbox_prescreen_widens_with_the_requirement(self):
         """`_blocked_geom`'s pad-bbox prescreen is a SKIP: left at the flat
-        scalar it silently drops exactly the pairs a declaration raises."""
-        pairs = 0
-        for ref, cap in self.st.caps.items():
-            for oref in self.st.cap_caps[ref]:
-                other = self.st.caps[oref]
-                gap = _rect_gap(cap.pad_bbox(cap.x, cap.y, cap.rot),
-                                other.pad_bbox())
-                screen = max(self.st.clearance, cap.max_floor, other.max_floor)
-                if self.st.clearance <= gap < screen:
-                    pairs += 1
-        self.assertGreater(pairs, 0,
-                           'no mover pair sits between the flat scalar and the '
-                           'widened prescreen -- this test would pass vacuously')
-    # MUTATION: `_blocked_geom`'s prescreen back to `>= self.clearance` ->
-    # every one of those pairs is skipped before its shortfall is computed.
+        scalar it silently drops exactly the pairs a declaration raises.
+
+        Behavioural, not arithmetic: it walks a cap toward each neighbour until
+        the pair is charged beyond its seed baseline while the pad BBOXES are
+        still further apart than the flat scalar, then asserts _blocked_geom
+        actually vetoes that pose."""
+        pcb = parse_kicad_pcb(BOARD)
+        for p in pcb.footprints[ANCHOR_CAP].pads:
+            p.local_clearance = 1.2      # raise only this mover's own pads
+        st = _repair(BOARD, pcb=pcb)
+        cap = st.caps[ANCHOR_CAP]
+        found = None
+        for oref in st.cap_caps[ANCHOR_CAP]:
+            other = st.caps[oref]
+            base = st.base_cap_pad.get(frozenset((ANCHOR_CAP, oref)), 0.0)
+            effs = st._pair_effs(ANCHOR_CAP, cap, oref, other)
+            orect = other.rect()
+            ocx, ocy = (orect[0] + orect[2]) / 2.0, (orect[1] + orect[3]) / 2.0
+            d = math.hypot(ocx - cap.x, ocy - cap.y)
+            for k in range(1, 25):
+                step = k * 0.1
+                if step >= d:
+                    break
+                nx = cap.x + (ocx - cap.x) * step / d
+                ny = cap.y + (ocy - cap.y) * step / d
+                pads = cap.pad_rects(nx, ny, cap.rot)
+                bbox_gap = _rect_gap(cap.pad_bbox(nx, ny, cap.rot),
+                                     other.pad_bbox())
+                charged = _pad_pair_shortfall(pads, other.pad_rects(),
+                                              st.clearance, effs)
+                flat = _pad_pair_shortfall(pads, other.pad_rects(), st.clearance)
+                if (bbox_gap >= st.clearance and charged > base + 1e-6
+                        and flat == 0.0):
+                    found = (oref, nx, ny, bbox_gap, charged, base)
+                    break
+            if found:
+                break
+        # ON THE BRANCH: the pose must be one the OLD prescreen would skip, and
+        # one the flat pricing scores at exactly zero.
+        self.assertIsNotNone(found, 'no pose sits beyond the flat prescreen '
+                                    'while being charged -- this test would '
+                                    'pass vacuously')
+        oref, nx, ny, bbox_gap, charged, base = found
+        self.assertGreaterEqual(bbox_gap, st.clearance)
+        self.assertGreater(charged, base)
+        self.assertTrue(
+            st._blocked_geom(ANCHOR_CAP, cap, nx, ny, cap.rot),
+            '_blocked_geom let a charged %s<->%s pose through (bbox gap %.4f '
+            '>= the flat %.2f, so the prescreen skipped it)'
+            % (ANCHOR_CAP, oref, bbox_gap, st.clearance))
+    # MUTATION: `_blocked_geom`'s prescreen back to `>= self.clearance` -> the
+    # pair is skipped before its shortfall is computed and the pose is allowed.
+
+    def test_the_cap_side_slack_raises_the_via_and_track_reaches(self):
+        """`cap_segs`/`cap_vias` add the CAP's own excess over the flat scalar.
+        A uniform netclass hides this -- the item's own floor already grew the
+        list -- so raise one mover's pads and leave every via and track at the
+        flat value."""
+        pcb = parse_kicad_pcb(BOARD)
+        for p in pcb.footprints[ANCHOR_CAP].pads:
+            p.local_clearance = 1.2
+        st = _repair(BOARD, pcb=pcb)
+        # ON THE BRANCH: the cap is raised and the items are NOT.
+        self.assertAlmostEqual(st.caps[ANCHOR_CAP].max_floor, 1.2, places=6)
+        self.assertEqual(st._item_reach(st.via_floor(0)), CLEAR)
+        for name in ('cap_segs', 'cap_vias'):
+            a = len(getattr(self.flat, name)[ANCHOR_CAP])
+            b = len(getattr(st, name)[ANCHOR_CAP])
+            self.assertGreater(b, a, '%s did not grow with the cap-side slack '
+                                     '(%d -> %d)' % (name, a, b))
+    # MUTATION: `via_slack = 0.0`, or drop `max(0.0, cap_mf - clearance)` from
+    # `seg_reach` -> that list stops growing.
 
     def test_the_seed_baseline_is_in_the_SAME_currency(self):
         """A baseline priced flat while candidates price at the requirement
@@ -450,33 +508,45 @@ class TestNudgerGraderConsistency(unittest.TestCase):
     # MUTATION: build the via eff rows from anything but `via_required` -> the
     # equality fails.
 
-    def test_the_offender_predicate_sees_what_the_grader_charges(self):
-        """The nudger's offender test, replayed here against the same helper.
-        A via that the grader charges must be an offender, and there must be at
-        least one that the FLAT predicate would have missed."""
-        only_raised = 0
-        for ref, cap in self.st.caps.items():
-            rects = cap.pad_rects(cap.x, cap.y, cap.rot)
-            for vx, vy, vnet, keepout in self.st.cap_vias[ref]:
-                radius = keepout - self.st._item_reach(self.st.via_floor(vnet))
-                for i, (bx0, by0, bx1, by1, net) in enumerate(rects):
-                    if vnet == net:
-                        continue
-                    d = _point_to_rect_dist(vx, vy, (bx0, by0, bx1, by1))
-                    want = self.st.via_required(cap.pad_floors[i], vnet)
-                    hit_now = d < radius + want - 1e-6
-                    hit_flat = d < radius + self.st.clearance - 1e-6
-                    self.assertFalse(hit_flat and not hit_now,
-                                     'the raised predicate LOST an offender '
-                                     'the flat one saw (%s, via %g,%g)'
-                                     % (ref, vx, vy))
-                    only_raised += (hit_now and not hit_flat)
-        self.assertGreater(only_raised, 0,
-                           'no via is an offender only under the raised '
-                           'requirement -- this test would pass vacuously')
+    def test_the_offender_loop_RESOLVES_rather_than_assuming_the_scalar(self):
+        """Drives the real `nudge_vias_for_unresolved` and counts how often its
+        offender loop consults `via_required`.
+
+        Every via is parked far from every cap, so there are no offenders and
+        the function returns empty either way -- but the loop must still have
+        EVALUATED the predicate through the resolver. Priced at the flat scalar
+        instead, the resolver is never called at all, and a cap unresolved
+        because of a RAISED via requirement yields an empty offender list: the
+        pass then reports it unresolved forever and prints nothing."""
+        pcb = parse_kicad_pcb(self.path)
+        st = _repair(self.path, pcb=pcb)
+        bounds = pcb.board_info.board_bounds
+        far = make_via(bounds[0] + 2.0, bounds[1] + 2.0, net_id=1)
+        pcb.vias[:] = [far]
+        st.vias = [(far.x, far.y, 1, 0.25 + st._item_reach(st.via_floor(1)))]
+        st.cap_vias = {r: st.vias for r in st.caps}
+        unresolved = [r for r in st.caps
+                      if st.graze_penalty(r, st.caps[r], st.caps[r].x,
+                                          st.caps[r].y, st.caps[r].rot) > 1e-6]
+        # ON THE BRANCH: the loop only runs at all if some cap is unresolved,
+        # and only reaches the resolver if a via is in the list.
+        self.assertTrue(unresolved, 'no cap is unresolved -- the offender loop '
+                                    'never runs and this proves nothing')
+        calls = [0]
+        real = st.via_required
+
+        def counting(pad_floor, via_net):
+            calls[0] += 1
+            return real(pad_floor, via_net)
+        st.via_required = counting
+        moves, segs = nudge_vias_for_unresolved(st, pcb, CLEAR)
+        self.assertEqual((moves, segs), ([], []),
+                         'the far-away via should offend nobody')
+        self.assertGreater(calls[0], 0,
+                           'the offender loop never consulted via_required -- '
+                           'it is pricing at the flat scalar')
     # MUTATION: the offender test in `nudge_vias_for_unresolved` back to
-    # `vr + clearance` -> those `only_raised` vias become invisible to the
-    # nudger while the grader still reports their caps unresolved.
+    # `vr + clearance - EPS` -> calls[0] == 0.
 
     def test_a_duck_typed_state_grades_flat_instead_of_crashing(self):
         """test_617 and test_370 drive the nudger with a _FakeSt/_FakeCap that
@@ -551,6 +621,11 @@ class TestShapeContract(unittest.TestCase):
     # silently wrong requirement.
 
     def test_injecting_cap_foreign_pads_grades_without_misindexing(self):
+        """A tuple a test injected carries no registered floor, so it must be
+        graded at the FLAT scalar. Without the source-list identity guard the
+        memo built during __init__ is reused, and row[0] silently supplies the
+        requirement of a completely different pad -- a wrong number that raises
+        no error and looks entirely plausible."""
         st = _repair(self.path)
         cap = st.caps[ANCHOR_CAP]
         own = {p[4] for p in cap.pads}
@@ -558,9 +633,21 @@ class TestShapeContract(unittest.TestCase):
         r = cap.pad_rects()[0]
         st.cap_foreign_pads[ANCHOR_CAP] = [
             (r[0] - 0.15, r[1], r[0] - 0.05, r[3], foreign, cap.side)]
-        self.assertIn(foreign, _short(st, ANCHOR_CAP))
-    # MUTATION: drop the source-list identity guard in `_pad_effs` -> stale
-    # rows index a list that no longer exists (IndexError).
+        rect = st.cap_foreign_pads[ANCHOR_CAP][0][:4]
+        got = _short(st, ANCHOR_CAP)
+        self.assertIn(foreign, got)
+        # Summed over EVERY cap pad, at the FLAT scalar. Graded off a stale row
+        # it would come out at the board's declared 0.4 instead.
+        flat = sum(max(0.0, CLEAR - _rect_gap(p[:4], rect))
+                   for p in cap.pad_rects())
+        declared = sum(max(0.0, 0.4 - _rect_gap(p[:4], rect))
+                       for p in cap.pad_rects())
+        self.assertNotAlmostEqual(flat, declared, places=6)   # not vacuous
+        self.assertAlmostEqual(got[foreign], flat, places=6,
+                               msg='the injected pad was graded at a stale '
+                                   'row rather than the flat scalar')
+    # MUTATION: drop the source-list identity guard in `_pad_effs` -> the
+    # shortfall reads 0.35.
 
     def test_ten_positional_arguments_still_construct(self):
         _Repair(parse_kicad_pcb(BOARD), BOARD, CLEAR, 0.1, 0.55, 1.0, 2.0, 0.3,
@@ -644,8 +731,12 @@ class TestReport(unittest.TestCase):
     # MUTATION: drop the `charged` filter in `required_rows` -> hundreds of rows.
 
     def test_an_unreadable_declaration_is_disclosed_not_silent(self):
-        """A FAILED read is exactly what makes a model look inert, so the notes
-        must be captured BEFORE the active-drop."""
+        """A FAILED read is exactly what makes a model look INERT, so the notes
+        must be captured BEFORE the active-drop.
+
+        Staged on the board with NO pad overrides on purpose: on a board that
+        has some, the failed netclass read still leaves the model active and
+        the notes survive by accident, so the ordering is never tested."""
         import list_nets
         orig = list_nets.net_clearance_map
 
@@ -654,7 +745,13 @@ class TestReport(unittest.TestCase):
         list_nets.net_clearance_map = boom
         try:
             with tempfile.TemporaryDirectory() as td:
-                st = _repair(_stage(td, 'unread', classes=_default_class(0.4)))
+                p = _stage(td, 'unread', classes=_default_class(0.4), src=INERT)
+                st = _repair(p)
+                # ON THE BRANCH: the failure must leave the model INACTIVE, or
+                # the notes survive for the wrong reason.
+                self.assertIsNone(st._floors,
+                                  'the model stayed active -- the ordering is '
+                                  'not under test on this fixture')
                 self.assertTrue(st.clearance_notes,
                                 'the failed netclass read was silent')
         finally:

--- a/tests/test_725_fanout_clearance_pad_floors.py
+++ b/tests/test_725_fanout_clearance_pad_floors.py
@@ -68,9 +68,28 @@ ANCHOR_NET = 69
 ANCHOR_GAP = 0.1346
 MOVER_A, MOVER_B = 'C49', 'C62'
 
-# The inert board's recorded result, which #725 must not move.
-INERT_UNRESOLVED = ['C16', 'C17', 'C18', 'C19', 'C22', 'C23', 'C24']
-INERT_PLACEMENTS = 2
+# The inert board's recorded result. #725 did not move it; #731 did, on
+# purpose and by a lot -- 2 placements and 7 unresolved caps became 1 and 1.
+#
+# rp2350 declares no netclass, no .kicad_dru and no pad override, so the
+# clearance model is INERT and the pre-#731 layer side-channels were both
+# empty here. It is also 6 copper layers, and 2342 of its 4331 pruned
+# pad x track pairs were OFF-LAYER, carrying 4.6685mm of phantom seed graze
+# against 0.0142mm of real. Per-cap seed track graze, on-layer / off-layer:
+#
+#   C16  0.0000 / 0.7046      C20  0.0000 / 0.2900
+#   C17  0.0000 / 0.4913      C22  0.0000 / 0.9160
+#   C18  0.0106 / 0.0000      C23  0.0036 / 0.5836
+#   C19  0.0000 / 0.7851      C24  0.0000 / 0.8979
+#
+# So six of the eight caps were violators purely on phantom, and only C18 and
+# C23 have anything real. C18 is resolved; C23 is not, and is the one cap that
+# legitimately remains unresolved. The old run also SHIPPED a violation for
+# this: it moved C19 to clear a phantom and put its GND pad 0.145mm inside a
+# real F.Cu track, so check_drc flagged a PAD-SEGMENT on the output of a board
+# that is clean as it ships. It is clean again now.
+INERT_UNRESOLVED = ['C23']
+INERT_PLACEMENTS = 1
 
 
 def _repair(path, clearance=CLEAR, prefix='C,R,FB', pcb=None):
@@ -385,31 +404,46 @@ class TestChannels(unittest.TestCase):
     # MUTATION: scope the segment floor to `self._all_cu` -> the F.Cu and
     # In1.Cu arms return 0.5 too.
 
-    def test_an_OFF_LAYER_track_pair_keeps_the_flat_scalar(self):
-        """`cap_segs` is pruned on the F/B side collapse, which files an
-        In1.Cu track under 'F' -- so it contains cap-pad/inner-track pairs that
-        cannot touch and that check_drc never grades at all. The dru term
-        scopes itself away from them (empty shared set), but the NETCLASS term
-        is layer-blind, so charging it there would raise a PHANTOM and move
-        caps to clear copper on a layer their pads do not occupy.
+    def test_an_OFF_LAYER_track_pair_is_not_in_cap_segs_AT_ALL(self):
+        """#725 charged an off-layer pair the FLAT scalar so a netclass could
+        not amplify it; #731 removed the pair instead, which is what check_drc
+        does (check_pad_segment_overlap returns early off-layer).
 
-        Measured before this guard, on this board at a Default class of 0.3:
+        This test used to assert the flat price and to REQUIRE such a pair to
+        exist (`assertGreater(off, 0)`). Under #731 that is structurally
+        impossible, so the spy moved: it recomputes the OLD 'F'/'B' side prune
+        and asserts THAT still admits off-layer pairs, then asserts the real
+        `cap_segs` admits none. Without the recomputed spy this test would pass
+        just as well on a build that had deleted track grading outright, which
+        is why the on-layer arm below is kept unchanged.
+
+        Measured on this board at a Default class of 0.3 before #731:
         R17/R18/R5's entire graze WAS the phantom -- 0.0821mm each flat,
         0.6991/0.6991/0.5686 raised."""
         with tempfile.TemporaryDirectory() as td:
             p = _stage(td, 'offlayer', classes=_default_class(0.4))
             st = _repair(p)
+            # ON THE BRANCH: the OLD side prune really did admit off-layer
+            # pairs on this board, so "0 now" is a change, not a tautology.
+            old_off = 0
+            for ref, cap in st.caps.items():
+                for t in st.segments:
+                    if st._seg_side(t[6]) != cap.side:
+                        continue
+                    if not any(t[6] in pl for pl in cap.pad_layers):
+                        old_off += 1
+            self.assertGreater(old_off, 0,
+                               'the OLD side prune admitted no off-layer pair '
+                               'on this board -- the spy proves nothing')
             checked = off = on = 0
             for ref, cap in st.caps.items():
                 rows = st._seg_effs(ref, cap)
                 if rows is None:
                     continue
-                for i in range(len(cap.pad_floors)):
+                for i in range(len(cap.pad_layers)):
                     mine = cap.pad_layers[i]
                     for j, t in enumerate(st.cap_segs[ref]):
-                        layer = st._seg_layer_by_id.get(id(t))
-                        if layer is None:
-                            continue
+                        layer = t[6]
                         half = t[5] - st._item_reach(
                             st._seg_floor_by_id.get(id(t)))
                         checked += 1
@@ -417,16 +451,15 @@ class TestChannels(unittest.TestCase):
                             on += rows[i][j] > half + CLEAR + 1e-9
                         else:
                             off += 1
-                            self.assertAlmostEqual(
-                                rows[i][j], half + CLEAR, places=9,
-                                msg='%s pad %d vs an off-layer %s track was '
-                                    'charged above the flat scalar'
-                                    % (ref, i, layer))
-            # ON THE BRANCH: both kinds must be present, or this proves nothing
-            self.assertGreater(off, 0, 'no off-layer pair in any pruned list')
+            self.assertEqual(off, 0,
+                             '%d off-layer pair(s) survived the prune' % off)
+            # ON THE BRANCH: on-layer pairs must still be raised, or the whole
+            # track channel is simply gone and `off == 0` is vacuous.
             self.assertGreater(on, 0, 'no on-layer pair was raised')
-    # MUTATION: drop the off-layer test in `_seg_effs` -> the off-layer rows
-    # come back at the netclass 0.4.
+            self.assertGreater(checked, 0, 'no pair was examined at all')
+    # MUTATION: revert the prune to `if seg[6] != cap.side: continue` -> `off`
+    # is no longer 0. MUTATION: make `_seg_shares` return False always -> `on`
+    # drops to 0 and the vacuity guard fires.
 
     def test_a_board_with_NO_copper_layers_is_not_scoped_by_layer(self):
         """If `board_info.copper_layers` is empty, `pad_copper_layers` resolves
@@ -1175,12 +1208,19 @@ class TestReport(unittest.TestCase):
 
     def test_the_report_never_names_an_OFF_LAYER_track_pair(self):
         """`required_rows` must MIRROR what was charged, not re-derive it.
-        `_seg_effs` prices a cap-pad/track pair that shares no copper layer at
-        the flat scalar (the F/B side collapse puts such pairs in `cap_segs` at
-        all); a report that resolves the requirement independently names them
-        anyway, at the netclass. check_drc grades no such pair, so every one of
-        those rows sends the reader after a violation that does not exist --
-        measured at up to 43% of the disclosure on rp2350."""
+        Before #731 the F/B side collapse put pairs sharing no copper layer
+        into `cap_segs` at all, `_seg_effs` priced them at the flat scalar, and
+        a report resolving the requirement independently named them anyway, at
+        the netclass -- up to 43% of the disclosure on rp2350, every row
+        sending the reader after a violation check_drc does not grade.
+
+        #731 removes the pair rather than repricing it, so the guard in
+        `best()` is now belt-and-braces for the real prune and load-bearing
+        only for a MIXED-layer cap (an SMD pad beside a through-hole one),
+        where the union prune keeps a track only some pads share. The spy that
+        used to require an off-layer pair to exist therefore moved to the OLD
+        side prune; the per-row `shared` assertion below is unchanged and is
+        what still discriminates."""
         with tempfile.TemporaryDirectory() as td:
             p = _stage(td, 'offrep', classes=_default_class(0.4), src=INERT)
             pcb = parse_kicad_pcb(p)
@@ -1189,28 +1229,36 @@ class TestReport(unittest.TestCase):
             by_name = {v: k for k, v in names.items()}
             rows = st.required_rows(names)
             tracks = [r for r in rows if r[1].startswith('track ')]
-            # ON THE BRANCH: there must BE track rows and there must be
-            # off-layer pairs in reach, or this proves nothing.
+            # ON THE BRANCH: there must BE track rows, or this proves nothing.
             self.assertTrue(tracks, 'no track rows at all on this fixture')
+            # ...and the OLD prune must have admitted off-layer pairs here, or
+            # the phantom this guard is about never existed on this fixture.
+            old_off = sum(
+                1 for ref, cap in st.caps.items()
+                for t in st.segments
+                if st._seg_side(t[6]) == cap.side
+                and not any(t[6] in pl for pl in cap.pad_layers))
+            self.assertGreater(old_off, 0, 'the OLD side prune admitted no '
+                                           'off-layer pair -- spy proves nothing')
+            # ...and the NEW prune must admit none.
             off_pairs = sum(
                 1 for ref, cap in st.caps.items()
                 for t in st.cap_segs[ref]
-                if not any(st._seg_layer_by_id.get(id(t)) in pl
-                           for pl in cap.pad_layers))
-            self.assertGreater(off_pairs, 0, 'no off-layer pair in any pruned '
-                                             'list -- this would pass vacuously')
+                if not any(t[6] in pl for pl in cap.pad_layers))
+            self.assertEqual(off_pairs, 0,
+                             '%d off-layer pair(s) survived the prune' % off_pairs)
             for ref, who, mm, src in tracks:
                 nid = by_name.get(who[6:])
                 cap = st.caps[ref]
                 shared = any(
-                    any(st._seg_layer_by_id.get(id(t)) in pl
-                        for pl in cap.pad_layers)
+                    any(t[6] in pl for pl in cap.pad_layers)
                     for t in st.cap_segs[ref] if t[4] == nid)
                 self.assertTrue(shared,
                                 '%s <-> %s shares no copper layer, so it is '
-                                'priced flat and must not be reported' % (ref, who))
-    # MUTATION: drop the `layer not in cap_layers[i]` guard in
-    # `required_rows`' `best()` -> phantom rows come back.
+                                'not charged and must not be reported' % (ref, who))
+    # MUTATION: drop the `_seg_shares` guard in `required_rows`' `best()` ->
+    # a mixed-layer cap's phantom rows come back. MUTATION: revert the prune to
+    # the side collapse -> `off_pairs` is no longer 0.
 
     def test_an_unreadable_declaration_is_disclosed_not_silent(self):
         """A FAILED read is exactly what makes a model look INERT, so the notes

--- a/tests/test_725_fanout_clearance_pad_floors.py
+++ b/tests/test_725_fanout_clearance_pad_floors.py
@@ -641,6 +641,48 @@ class TestNudgerGraderConsistency(unittest.TestCase):
     # MUTATION: the offender test in `nudge_vias_for_unresolved` back to
     # `vr + clearance - EPS` -> calls[0] == 0.
 
+    def test_a_RELOCATED_via_keeps_its_radius(self):
+        """`nudge_vias_for_unresolved` rebuilds `st.vias`, so a moved via is a
+        NEW tuple. Without carrying its entry across, it drops out of the radius
+        map and is graded at its keep-out SLOT -- the prune over-reach -- rather
+        than at the pair's requirement. Conservative, but wrong, and it is the
+        one map that gains entries after __init__, so the entry must also hold
+        its tuple or a recycled id hands back another via's radius.
+
+        No tracked board relocates a via at the shipped 0.6mm budget, so this
+        rigs one: a single foreign via just outside a cap pad, a cleared
+        neighbourhood, and a wider `max_shift`."""
+        pcb = parse_kicad_pcb(BOARD)
+        st = _repair(BOARD, pcb=pcb)
+        cap = st.caps['C67']
+        r = cap.pad_rects()[0]
+        own = {q[4] for q in cap.pads}
+        fnet = next(n for n in pcb.nets if n and n not in own)
+        vx, vy = r[2] + 0.20, (r[1] + r[3]) / 2.0
+        pcb.vias[:] = [make_via(vx, vy, net_id=fnet, size=0.5, drill=0.3)]
+        pcb.segments[:] = []
+        t0 = (vx, vy, fnet, 0.25 + st._item_reach(st.via_floor(fnet)))
+        st.vias = [t0]
+        st._via_radius_by_id = {id(t0): (t0, 0.25)}
+        st.cap_vias = {k: st.vias for k in st.caps}
+        st.segments = []
+        st.cap_segs = {k: [] for k in st.caps}
+        moves, _segs = nudge_vias_for_unresolved(st, pcb, CLEAR, max_shift=4.0)
+        # ON THE BRANCH: the via must actually have moved, or the carry-over
+        # branch never ran and this test would pass vacuously.
+        self.assertEqual(len(moves), 1, 'no via was relocated')
+        self.assertEqual(len(st.vias), 1)
+        moved = st.vias[0]
+        self.assertNotEqual((moved[0], moved[1]), (t0[0], t0[1]))
+        rec = st._via_radius_by_id.get(id(moved))
+        self.assertIsNotNone(rec, 'the relocated via lost its radius')
+        self.assertAlmostEqual(rec[1], 0.25, places=9)
+        self.assertIs(rec[0], moved,
+                      'the map does not hold the tuple it keys on -- a '
+                      'recycled id would return another via\'s radius')
+    # MUTATION: drop the `_radii[id(moved)] = ...` carry-over in
+    # `nudge_vias_for_unresolved` -> rec is None.
+
     def test_a_duck_typed_state_grades_flat_instead_of_crashing(self):
         """test_617 and test_370 drive the nudger with a _FakeSt/_FakeCap that
         carries none of this machinery."""

--- a/tests/test_725_fanout_clearance_pad_floors.py
+++ b/tests/test_725_fanout_clearance_pad_floors.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 RUN_ALL_FAST_OK = True
 RUN_ALL_TIMEOUT = 900
 
+import copy
 import json
 import math
 import os
@@ -46,7 +47,7 @@ from copy_board import copy_board
 from synth import make_via
 import placement.legality as L
 from placement.legality import PadClearanceModel
-from placement.fanout_clearance import (_Repair, _pad_pair_shortfall,
+from placement.fanout_clearance import (_Cap, _Repair, _pad_pair_shortfall,
                                         _point_to_rect_dist, _rect_gap,
                                         nudge_vias_for_unresolved,
                                         repair_fanout_clearance)
@@ -197,6 +198,50 @@ class TestSourcesReachTheEngine(unittest.TestCase):
             self.assertIn(ANCHOR_NET, _short(_repair(p, pcb=pcb), ANCHOR_CAP),
                           'the layer rule never reached the shortfall')
     # MUTATION: drop `read_board_layer_clearances` from the model -> empty.
+
+    def test_an_override_on_a_COPPERLESS_pad_is_not_charged(self):
+        """`_Cap`'s pad filter is deliberately loose (`endswith('.Cu')`), which
+        admits an np_thru_hole pad -- it lists *.Cu and carries no copper. A
+        FLOOR must not be that loose: PadClearanceModel.pad_floor reads
+        local_clearance unconditionally, so charging it would move a cap to
+        clear copper that does not exist, and would contradict the model's own
+        inertness rule, which refuses to ACTIVATE for an NPTH-only override."""
+        pcb = parse_kicad_pcb(BOARD)
+        model = PadClearanceModel.for_board(pcb, CLEAR, BOARD)
+        self.assertTrue(model.active)
+        fp = copy.deepcopy(pcb.footprints[ANCHOR_CAP])
+        # the footprint carries paste-only apertures too; take a REAL copper pad
+        real = next(p for p in fp.pads if L._pad_carries_copper(p))
+        real.local_clearance = 0.5                # copper, must be charged
+        hole = copy.deepcopy(real)
+        hole.pad_number = 'H1'
+        hole.pad_type = 'np_thru_hole'
+        hole.drill = 1.0
+        hole.layers = ['*.Cu', '*.Mask']
+        hole.net_id = 0
+        hole.local_clearance = 3.0                # absurd, and must be ignored
+        fp.pads.append(hole)
+        # _Cap directly, not through _Repair: appending a pad would push this
+        # footprint past the `n_copper <= 2` cap test and it would stop being a
+        # mover at all -- the very coupling the loose filter's comment warns
+        # about.
+        cap = _Cap(fp, (-0.5, -0.5, 0.5, 0.5), model)
+        # ON THE BRANCH: the loose GEOMETRY filter must still admit the hole
+        # (it lists *.Cu), or this tests nothing. The footprint also carries
+        # paste-only apertures, which the filter correctly drops.
+        loose = [p for p in fp.pads
+                 if any(str(l).endswith('.Cu') for l in p.layers)]
+        self.assertIn(hole, loose, 'the hole was dropped by the geometry '
+                                   'filter -- this test would pass vacuously')
+        self.assertEqual(len(cap.pads), len(loose))
+        self.assertEqual(len(cap.pad_floors), len(cap.pads))
+        self.assertEqual(cap.pad_floors[-1].lc, 0.0,
+                         'the copper-less pad was given a clearance floor')
+        self.assertAlmostEqual(cap.max_floor, 0.5, places=6,
+                               msg='the NPTH override reached max_floor and '
+                                   'would widen every prune and the prescreen')
+    # MUTATION: drop the `_pad_carries_copper` guard on `model.pad_floor(p)` in
+    # `_Cap.__init__` -> max_floor becomes 3.0.
 
     def test_a_board_declaring_nothing_builds_no_model(self):
         pcb = parse_kicad_pcb(INERT)

--- a/tests/test_730_fanout_clearance_npth_local_clearance.py
+++ b/tests/test_730_fanout_clearance_npth_local_clearance.py
@@ -58,7 +58,7 @@ boards `run_utils.corpus_boards()` returns (37 copper-less drilled pads), only
 ulx3s carries a binding override, and its nearest foreign copper misses the new
 requirement by 0.010mm.
 
-THE BATTERY: `tests/mutate_730.py`, 25 rows -- 22 killed, 3 survived (all three
+THE BATTERY: `tests/mutate_730.py`, 28 rows -- 25 killed, 3 survived (all three
 expected and recorded with their reason), 0 broken. It ships rather than a
 number in this docstring because two reviewers of the #746 branch tried to
 re-derive its kill counts from row NAMES and both got the wrong answer. It
@@ -91,11 +91,13 @@ rule is now complete:
     whose ring does not span its drill (#441), and any plated pad with lc > 0.
     `_Repair` models plated pads as copper rects with no drill keep-out.
 
-Nothing here shells out or drives a CLI; it runs in-process. `run_all`
-classifies by grepping the SOURCE for `run_utils` and the name of the standard
-sub-process module, and this file names both in prose -- which is exactly how
-test_725 was once bucketed as integration and silently skipped under `--fast`.
-Hence the explicit opt-out below.
+This drives no CLI and routes nothing, but it does not run purely in-process
+either: `run_utils.corpus_boards()` shells out ONCE, for `git ls-files`, which
+is milliseconds. That is the whole reason the opt-out below is needed and also
+the whole reason it is legitimate -- `run_all` classifies by grepping the
+SOURCE for `run_utils`, so adopting that helper silently drops a file out of
+`--fast`, which is how test_725 was once bucketed as integration and skipped
+there. Drop the marker if an arm ever drives a real chain.
 """
 from __future__ import annotations
 
@@ -149,12 +151,15 @@ OLD_KEEPOUT = {0.10: AUDIO1_HR + 0.20, 0.25: AUDIO1_HR + 0.25}
 # whole change: 1.260 from the centre against a 1.250 requirement.
 AUDIO1_NEAREST_COPPER = 0.4100                                       # R60.2
 
-# ---- the two hand-mirrored engine constants ------------------------------
-# Function-local literals inside nudge_vias_for_unresolved: they cannot be
-# imported, so every threshold computed here is a hand mirror, and the source
-# guard below fails if the engine's move.
+# ---- the ONE hand-mirrored engine constant -------------------------------
+# `H2H_PAD` is a function-local literal inside nudge_vias_for_unresolved: it
+# cannot be imported, so every threshold computed from it here is a hand
+# mirror, and the source guard below fails if the engine's moves.
+# `NPTH_FLOOR` is NOT mirrored -- it is imported, right here -- and saying so
+# matters, because a reader who believes it is mirrored will look for a guard
+# that should not exist.
 H2H_PAD = 0.45
-NPTH_FLOOR = defaults.NPTH_TO_TRACK_CLEARANCE                        # 0.20
+NPTH_FLOOR = defaults.NPTH_TO_TRACK_CLEARANCE                        # imported
 
 # ---- the synthetic via rigs (site B/C), test_737's geometry ---------------
 CLEAR = 0.10
@@ -186,6 +191,9 @@ C_STUB_W = 1.0
 C_HW = C_STUB_W / 2.0                                                # 0.50
 C_MAX_SHIFT = 0.15
 C_LANDING = (3.05, 3.0)
+# the along-axis candidates C_MAX_SHIFT actually reaches. 3.05 is the one
+# valid_via_pos accepts, so it is the candidate the connector gate decides.
+ALL_CANDIDATES_C = ((3.05, 3.0), (3.10, 3.0), (3.15, 3.0))
 # The cap footprint sits on B.Cu so its rects cannot gate the F.Cu connector
 # (connector_clear skips a rect whose cap layer differs), while the SAME rects
 # still box the via -- valid_via_pos has no layer gate. That separation is what
@@ -259,6 +267,20 @@ def _npth(x, y, lc, drill=H_DRILL, ref='H1', net=0):
                  layers=['F.Mask', 'B.Mask'], drill=drill,
                  pad_type='np_thru_hole')
     p.local_clearance = lc
+    return p
+
+
+def _slot(x, y, lc, *, short=0.5, long_=2.5, net=0, ref='H1'):
+    """A real `(drill oval short long)` NPTH pad -- a MILLED SLOT.
+
+    `pad_drill_capsule` reads `drill_w`/`drill_h`, not size/shape: a pad with
+    only `shape='oval'` set yields a zero-length capsule, and an arm built on
+    one would pass while testing nothing.
+    """
+    p = _npth(x, y, lc, drill=long_, ref=ref, net=net)
+    p.drill_w, p.drill_h = short, long_
+    p.size_x, p.size_y = short, long_
+    p.shape = 'oval'
     return p
 
 
@@ -468,6 +490,14 @@ class TestTheKeepOutRectHonoursTheHolesOwnOverride(unittest.TestCase):
         self.assertEqual(len(halves), len(circles),
                          'the slot did not become one keep-out per circle')
         self.assertEqual(sorted(set(halves)), [want])
+        # ...and the CENTRES, which the radii alone throw away. Without this a
+        # keep-out centred on the PAD rather than on each circle survives the
+        # whole fanout test family -- measured by a review, which is how it got
+        # here.
+        got = sorted((round((x0 + x1) / 2.0, 4), round((y0 + y1) / 2.0, 4))
+                     for x0, y0, x1, y1, net, _s in st.foreign_pads if net == -1)
+        self.assertEqual(got, sorted((round(cx, 4), round(cy, 4))
+                                     for cx, cy, _d in circles))
         self.assertNotAlmostEqual(want, slot.drill / 2.0 + grow, places=4,
                                   msg='the long-axis spelling would give the '
                                       'same answer here, so this arm cannot '
@@ -527,8 +557,13 @@ class TestARelocatedViaHonoursTheHolesOwnOverride(unittest.TestCase):
         gap = XH_REFUSED - LANDING[0] - HR - VR
         self.assertTrue(CLEAR + 0.04 < gap < AUDIO1_LC - 0.04,
                         'gap %.4f is not strictly inside (clearance, lc)' % gap)
-        # (iii) EVERY candidate is inside the override, so `moves == []` means
-        #       "all refused" and not "the budget ran out";
+        # (iii) every candidate THE WALLS ADMIT is inside the override, so
+        #       `moves == []` is not "the budget ran out". Note what this does
+        #       NOT say: the engine's spiral tries 176 candidates here, and
+        #       `(3.05, 3.0)` is one the override gate would ACCEPT -- the
+        #       walls refuse it first. The refusal is `walls AND override`, and
+        #       the thing that makes it attributable to the override is the
+        #       paired lc=0.00 control below, not this loop;
         for cx, _cy in ALL_CANDIDATES:
             self.assertLess(XH_REFUSED - cx - HR - VR, AUDIO1_LC + 1e-9)
         # (iv) and the landing is legal for the DRILL gate, so a refusal here
@@ -577,6 +612,69 @@ class TestARelocatedViaHonoursTheHolesOwnOverride(unittest.TestCase):
     # FOUR are clear-of-the-override controls like this one. A file with only
     # refusal arms would not see it at all.
 
+    def test_a_SLOT_override_hole_is_measured_along_its_whole_axis(self):
+        """A milled slot is a CAPSULE, and the gate must measure to its axis.
+
+        Every other override hole in this file is round, so `pad_drill_capsule`
+        hands back a zero-length capsule and the segment-to-segment measure
+        degenerates to point-to-point -- meaning the capsule half of it is
+        never exercised. A review found three mutations surviving on exactly
+        that (collapse the capsule to one end, measure the connector from an
+        endpoint only, centre site A's rects on the pad instead of the
+        circles), so the slot is built here rather than assumed.
+
+        The via sits off the MIDDLE of the slot, which is the one arrangement
+        an endpoint-only measure gets wrong: 1.2500 to the axis, but 1.6008 to
+        either end.
+        """
+        xh = 4.70
+        v = make_via(VIA0[0], VIA0[1], net_id=3, size=V_SIZE, drill=V_DRILL)
+        stub = make_seg(2.0, 3.0, VIA0[0], VIA0[1], width=0.2, layer='F.Cu',
+                        net_id=3)
+        hole = _slot(xh, 3.0, AUDIO1_LC)
+        from kicad_parser import pad_drill_capsule
+        (a, b, hr) = pad_drill_capsule(hole)
+        # ON THE BRANCH: a real capsule, the via is off its MIDDLE, and the
+        # endpoint measure would clear the requirement while the axis one does
+        # not -- without that separation the arm cannot see the mutation.
+        self.assertGreater(math.hypot(b[0] - a[0], b[1] - a[1]), 1.0,
+                           'not a slot; this arm is vacuous')
+        axis_d = abs(xh - LANDING[0])
+        end_d = min(math.hypot(LANDING[0] - e[0], LANDING[1] - e[1])
+                    for e in (a, b))
+        need = hr + VR + AUDIO1_LC
+        self.assertTrue(axis_d < need < end_d,
+                        'axis %.4f / need %.4f / nearest end %.4f do not '
+                        'separate' % (axis_d, need, end_d))
+        # ...and the two gates that are NOT under test must both pass here.
+        self.assertGreater(axis_d - hr, CLEAR + VR)                  # base
+        self.assertGreater(axis_d, V_DRILL / 2.0 + hr + H2H_PAD)     # drill
+
+        pcb = make_pcb(board_info=_bi(), vias=[v], segments=[stub],
+                       footprints={'C1': SimpleNamespace(layer='F.Cu',
+                                                         pads=[])},
+                       pads_by_net={0: [hole]}, zones=[])
+        moves, segs, out = _nudge(_FakeSt(WALLS), pcb, CLEAR,
+                                  max_shift=MAX_SHIFT)
+        self.assertIn('no clear spot', out)
+        self.assertEqual(moves, [])
+        # the same slot with no override moves, so the refusal is #730's and
+        # not the capsule merely being large.
+        hole2 = _slot(xh, 3.0, 0.0)
+        v2 = make_via(VIA0[0], VIA0[1], net_id=3, size=V_SIZE, drill=V_DRILL)
+        pcb2 = make_pcb(board_info=_bi(), vias=[v2],
+                        segments=[make_seg(2.0, 3.0, VIA0[0], VIA0[1],
+                                           width=0.2, layer='F.Cu', net_id=3)],
+                        footprints={'C1': SimpleNamespace(layer='F.Cu',
+                                                          pads=[])},
+                        pads_by_net={0: [hole2]}, zones=[])
+        moves2, _s2, _o2 = _nudge(_FakeSt(WALLS), pcb2, CLEAR,
+                                  max_shift=MAX_SHIFT)
+        self.assertEqual(len(moves2), 1)
+    # MUTATION: collapse the override capsule to either endpoint, or measure
+    # the gate from a via/connector ENDPOINT rather than along the axis -> this
+    # arm moves. It is the only capsule-shaped override hole in the file.
+
     def test_a_hole_on_the_vias_OWN_net_is_exempt(self):
         """A track legitimately reaches its own mounting-hole pad, and
         check_drc's via arm makes the same exemption."""
@@ -621,6 +719,9 @@ class TestTheOverrideIsASTEPNotAMax(unittest.TestCase):
     def test_an_lc_JUST_ABOVE_npth_clr_charges_it_in_full(self):
         npth_clr = max(CLEAR, NPTH_FLOOR)
         self.assertGreater(LC_HIGH, npth_clr + 1e-9)
+        # ...for every candidate the walls admit; see the note in
+        # TestARelocatedViaHonoursTheHolesOwnOverride about what that does and
+        # does not establish.
         for cx, _cy in ALL_CANDIDATES:
             self.assertLess(XH_STEP - cx - HR - VR, LC_HIGH + 1e-9)
         self.assertEqual(self._moves(LC_HIGH), 0)
@@ -685,8 +786,15 @@ class TestTheConnectorHonoursTheHolesOwnOverride(unittest.TestCase):
         npth_clr = max(CLEAR, NPTH_FLOOR)
         self.assertTrue(HR + C_HW + npth_clr + 0.05 <= seg_dist
                         <= HR + C_HW + AUDIO1_LC - 0.05)
-        # (iv) and every candidate is inside.
-        for cx, _cy in ALL_CANDIDATES[:1] + ((3.10, 3.0), (3.15, 3.0)):
+        # (iv) and every candidate the budget REACHES is inside. C_MAX_SHIFT
+        #      is 0.15, so the along-axis candidates are 3.05 / 3.10 / 3.15 --
+        #      3.05 being the one `valid_via_pos` accepts, which makes it the
+        #      candidate this gate actually decides. (An earlier version of
+        #      this loop listed 3.45, three times the budget away, and omitted
+        #      3.05 entirely; the assertion held either way, which is why a
+        #      review had to find it rather than a failure.)
+        for cx, _cy in ALL_CANDIDATES_C:
+            self.assertLessEqual(cx - C_LANDING[0], C_MAX_SHIFT + 1e-9)
             self.assertLess(XH_C_REFUSED - cx, HR + C_HW + AUDIO1_LC + 1e-9)
         self.assertIn('no clear spot', out)
         self.assertEqual(moves, [])
@@ -709,11 +817,19 @@ class TestTheConnectorHonoursTheHolesOwnOverride(unittest.TestCase):
         self.assertEqual(len(moves), 1)
         self.assertEqual(len(segs), 1)
 
-    def test_the_connector_arm_is_a_MAX_not_a_STEP(self):
-        """An `lc` BELOW the floor this gate already charges must change
-        nothing -- `max(npth_clr, lc)` collapses to `npth_clr`. This is the
-        arm that keeps sites B and C from being written as one expression: B
-        returns `clearance` in this case, C returns `npth_clr`."""
+    def test_a_SUB_FLOOR_override_charges_the_connector_nothing(self):
+        """An `lc` below `npth_step` never enters `override_holes` at all, so
+        the connector's requirement stays exactly what it was.
+
+        NOT a MAX-versus-STEP discriminator, which is what this arm's name and
+        docstring claimed until a review measured it: at this geometry the wall
+        gap clears BOTH candidate charges, so the two spellings agree and the
+        arm cannot separate them. What separates them is
+        `test_the_connector_floor_is_npth_clr_and_not_clearance` below, which
+        sits between the two floors. What THIS arm holds is the filter's lower
+        edge -- that a sub-floor declaration is not quietly promoted -- which is
+        the same property `override-charge-given-the-VIA-step` survives on, and
+        worth a behavioural arm for exactly that reason."""
         npth_clr = max(CLEAR, NPTH_FLOOR)
         self.assertLess(LC_LOW, npth_clr)
         self.assertEqual(len(_run_conn(XH_C_REFUSED, LC_LOW)[1]), 1)
@@ -797,10 +913,13 @@ class TestTheConnectorGateStaysAtTheFlatFabFloor(unittest.TestCase):
         # ...and the far site still DOES read the board, or the two have been
         # unified from the other end -- which loses the cap-side raise #617
         # shipped.
+        # `assertTrue(... in ...)`, not `assertIn`: `_Repair.__init__` is 577
+        # lines, and assertIn prints the haystack. test_732 measured a 393KB
+        # failure message doing exactly this.
         rsrc = inspect.getsource(_Repair.__init__)
-        self.assertIn('resolve_hole_clearance', rsrc,
-                      '_Repair.npth_floor stopped reading the board; #617 '
-                      'changed exactly that site on purpose')
+        self.assertTrue('resolve_hole_clearance' in rsrc,
+                        '_Repair.npth_floor stopped reading the board; #617 '
+                        'changed exactly that site on purpose')
     # MUTATION: nudger-npth_clr-made-BOARD-AWARE -> measured 3 kills across 2
     # files: this arm plus test_617's two checks.
     #
@@ -831,6 +950,38 @@ class TestThePartPadsHoleKeepOutIsPerHole(unittest.TestCase):
     # site-E-loses-the-fab-floor (3), site-E-threshold-at-clearance (3).
     # site-E-max-respelled-as-a-conditional SURVIVES, expected -- an exact
     # re-spelling of `max`, recorded so its survival is not read as a hole.
+
+    def test_a_SLOT_hole_grows_from_the_SHORT_axis(self):
+        """Site A has had this fixture since #730 shipped; site E had not, and
+        a review measured `hd/2` -> `p.drill/2` surviving the whole placement
+        family there. `p.drill` on a slot is the LONG axis -- 2.5 where the
+        keep-out radius is 0.25 -- so the two spellings differ by an order of
+        magnitude on a slot and not at all on a round hole."""
+        from kicad_parser import pad_drill_circles
+        slot = _slot(10.0, 10.0, AUDIO1_LC)
+        fp = SimpleNamespace(reference='H1', x=10.0, y=10.0, rotation=0.0,
+                             layer='F.Cu', pads=[slot])
+        circles = list(pad_drill_circles(slot))
+        # ON THE BRANCH: a real slot, and the two spellings really do differ.
+        self.assertGreater(len(circles), 1, 'not a slot; this arm is vacuous')
+        self.assertNotAlmostEqual(circles[0][2], slot.drill, places=6)
+        pp = PartPads(fp, CLEAR)
+        grow = max(0.0, max(NPTH_FLOOR, AUDIO1_LC) - CLEAR)
+        want = round(circles[0][2] / 2.0 + grow, 4)
+        self.assertEqual(sorted({round(r, 4) for _x, _y, r in pp.holes_local}),
+                         [want])
+        self.assertEqual(len(pp.holes_local), len(circles))
+        self.assertNotAlmostEqual(want, slot.drill / 2.0 + grow, places=4,
+                                  msg='the long-axis spelling would give the '
+                                      'same answer here')
+        # ...and the EXTENT radii track the same circles, minus the override.
+        ext = max(0.0, NPTH_FLOOR - CLEAR)
+        self.assertEqual(
+            sorted({round(r, 4) for _x, _y, r in pp.holes_extent}),
+            [round(circles[0][2] / 2.0 + ext, 4)])
+    # MUTATION: site-E-long-axis-drill -> 1.55 instead of 0.55. Measured: this
+    # arm alone; it survived test_730, test_placement_pad_legality, test_697
+    # and test_beautify_labels before it existed.
 
     def test_the_SILK_consumer_is_opted_out(self):
         """`local_clearance` is a COPPER rule -- KiCad has no silk-to-hole rule
@@ -868,7 +1019,12 @@ class TestThePartPadsHoleKeepOutIsPerHole(unittest.TestCase):
         # scan would read that as the read itself.
         code = ' '.join(l.split('#')[0] for l in
                         inspect.getsource(PartPads.__init__).splitlines())
-        self.assertNotIn('resolve_hole_clearance', code)
+        # assertTrue, not assertNotIn -- see the note in the sibling arm about
+        # printing the haystack.
+        self.assertTrue('resolve_hole_clearance' not in code,
+                        'PartPads reads the board now; that changes what the '
+                        'six build_part_pads call sites mean and needs its '
+                        'own review')
     # MUTATION: none in the battery -- a DISCLOSURE arm, not a fix assertion.
     # It fails if someone threads a board pointer in here without revisiting
     # what that means for the six build_part_pads call sites.
@@ -925,12 +1081,17 @@ class TestOneHoleRule(unittest.TestCase):
                       'mirror is stale' % H2H_PAD)
 
     def test_the_scalar_mirror_matches_the_shared_kernel(self):
-        """`_seg_seg_dist` copies `_seg_capsule_axis_dist` term for term rather
-        than approximating it, because the four hole gates measure the same
-        holes and must agree about touching cases. The kernel's crossing test
-        is a STRICT `o1*o2 < 0`; `_segs_cross` counts an orientation of 0 as a
-        crossing and would answer 0.0 where the kernel does not."""
+        """The override gates measure with the SHARED seg-to-seg helper, and it
+        must agree with `_seg_capsule_axis_dist` -- the kernel the two sibling
+        hole gates measure with -- because all four grade the same holes.
+
+        The kernel's crossing test is a STRICT `o1*o2 < 0`. This module's own
+        `_segs_cross` counts an orientation of 0 as a crossing and would answer
+        0.0 where the kernel does not, which is why the gates do not use it;
+        the `endpoint ON the other line` case below is exactly that
+        disagreement, and it is the reason this arm exists."""
         import numpy as np
+        from check_drc import _seg_seg_dist_coords
         from single_ended_routing import _seg_capsule_axis_dist
         cases = [
             (0.0, 0.0, 1.0, 0.0, 0.5, -1.0, 0.5, 1.0),      # proper crossing
@@ -948,10 +1109,14 @@ class TestOneHoleRule(unittest.TestCase):
                     np.asarray([c[5]], dtype=float),
                     np.asarray([c[6]], dtype=float),
                     np.asarray([c[7]], dtype=float))[0])
-                self.assertAlmostEqual(FC._seg_seg_dist(*c), want, places=9)
-    # MUTATION: seg-seg-crossing-test-relaxed (`< 0` -> `<= 0`) -> measured 6
-    # arms. Two are this test's own subTests; the other four are geometry arms
-    # that would silently start measuring 0.0 for a touching case.
+                self.assertAlmostEqual(_seg_seg_dist_coords(*c), want,
+                                       places=9)
+    # MUTATION: none in the battery any more -- the row that killed this
+    # (`seg-seg-crossing-test-relaxed`) mutated a LOCAL copy of the kernel that
+    # #730 no longer carries, since the gates now call the shared helper. The
+    # arm is kept as a CHANGE DETECTOR on that helper: it is used by
+    # placement/legality.py at three sites besides these gates, so relaxing its
+    # crossing test would be felt well beyond #730.
 
 
 class TestInertOnTheTrackedCorpus(unittest.TestCase):
@@ -966,7 +1131,17 @@ class TestInertOnTheTrackedCorpus(unittest.TestCase):
         cls.boards = run_utils.corpus_boards()
 
     def _scan(self, clearance):
-        """(total NPTH pads, {board: [binding pads]}) at this clearance."""
+        """(total NPTH pads, {board: [binding pads]}) at this clearance.
+
+        The floor is sites A/B/C's -- it carries the board's declared
+        min_hole_clearance. Site E's is STRICTLY LOWER, because `PartPads`
+        cannot see the board at all (asserted two classes up), so a hole with
+        `npth_clr < lc <= declared` binds at site E while this scan calls it
+        non-binding. Inert on the corpus today: the one board declaring above
+        the fab floor is flat_hierarchy, and all 6 of its NPTH pads are at
+        lc 0.0. Stated because "selected the way the ENGINE selects" is true of
+        A/B/C and only approximately true of E.
+        """
         total, binding = 0, {}
         for b in self.boards:
             try:

--- a/tests/test_730_fanout_clearance_npth_local_clearance.py
+++ b/tests/test_730_fanout_clearance_npth_local_clearance.py
@@ -1003,31 +1003,59 @@ class TestThePartPadsHoleKeepOutIsPerHole(unittest.TestCase):
     # one test (one per clearance subTest, plus the factory check).
 
     def test_no_board_read_is_attempted_here_and_that_is_DISCLOSED(self):
-        """A disclosure, not a fix. legality's keep-out is
+        """REWRITTEN by #761, not relaxed.
+
+        #730 shipped this as a disclosure: legality's keep-out was
         `max(clearance, 0.20, lc)` where check_drc's track arm is
-        `max(clearance, 0.20, hole_clearance, lc)`, so on a board declaring
-        above 0.20 this still under-blocks. `PartPads` is structurally unable
-        to see it -- no board pointer -- and that is asserted so the gap
-        cannot be quietly forgotten."""
+        `max(clearance, 0.20, hole_clearance, lc)`, `PartPads` could not see
+        the board, and the arm said so out loud -- ending "that changes what
+        the six build_part_pads call sites mean and needs its own review".
+
+        #761 DID that review (2 of the 6 read hole keep-outs; the other 4 read
+        pad rects and extents only) and supplied the term the way
+        `fanout_clearance` already does: resolved ONCE, outside, and passed in
+        as a float. So the property this arm defends is unchanged -- the class
+        still reads no board -- while the value it lacked now arrives.
+
+        Relaxing it instead would have been the easy move and the wrong one: a
+        board POINTER in here re-opens exactly the six-call-site question, so
+        the ban stays, positionally, and the new parameter is asserted to be a
+        scalar rather than merely present."""
         params = list(inspect.signature(PartPads.__init__).parameters)
-        self.assertEqual(params[:5],
-                         ['self', 'fp', 'clearance', 'model', 'copper_holes'])
+        self.assertEqual(params[:6],
+                         ['self', 'fp', 'clearance', 'model', 'copper_holes',
+                          'npth_floor'])
         for banned in ('pcb_data', 'pcb_file', 'board', 'source_path'):
             self.assertNotIn(banned, params)
-        # CODE only: this very fix's comment NAMES resolve_hole_clearance
-        # when explaining why the read is impossible here, and a raw-source
-        # scan would read that as the read itself.
+        # A SCALAR, not a board wearing a scalar's name: the default must be
+        # usable arithmetic-free (None -> the fab floor) and a float must be
+        # accepted positionally.
+        fp = _e_footprint()
+        self.assertEqual(
+            [round(r, 4) for _x, _y, r in PartPads(fp, 0.10).holes_local],
+            [round(r, 4) for _x, _y, r in
+             PartPads(fp, 0.10, None, True, None).holes_local])
+        raised = [round(r, 4) for _x, _y, r in
+                  PartPads(fp, 0.10, None, True, 0.25).holes_local]
+        self.assertNotEqual(
+            raised,
+            [round(r, 4) for _x, _y, r in PartPads(fp, 0.10).holes_local],
+            'npth_floor is inert -- the parameter exists but reaches nothing')
+        # CODE only: this fix's comments NAME resolve_hole_clearance when
+        # explaining where the read now happens, and a raw-source scan would
+        # read that as the read itself.
         code = ' '.join(l.split('#')[0] for l in
                         inspect.getsource(PartPads.__init__).splitlines())
         # assertTrue, not assertNotIn -- see the note in the sibling arm about
         # printing the haystack.
-        self.assertTrue('resolve_hole_clearance' not in code,
-                        'PartPads reads the board now; that changes what the '
-                        'six build_part_pads call sites mean and needs its '
-                        'own review')
-    # MUTATION: none in the battery -- a DISCLOSURE arm, not a fix assertion.
-    # It fails if someone threads a board pointer in here without revisiting
-    # what that means for the six build_part_pads call sites.
+        for banned in ('resolve_hole_clearance', 'obstacle_map',
+                       'resolve_npth_floor'):
+            self.assertTrue(banned not in code,
+                            'PartPads reads the board now (%s); that changes '
+                            'what the six build_part_pads call sites mean and '
+                            'needs its own review' % banned)
+    # MUTATION: 761-partpads-reads-the-board (KILLED). Still a DISCLOSURE arm
+    # for the board POINTER; the scalar half is a real fix assertion.
 
 
 class TestOneHoleRule(unittest.TestCase):

--- a/tests/test_730_fanout_clearance_npth_local_clearance.py
+++ b/tests/test_730_fanout_clearance_npth_local_clearance.py
@@ -1,0 +1,1061 @@
+#!/usr/bin/env python3
+"""#730: an NPTH hole pad's own `local_clearance` must reach every
+copper-to-hole decision in py_placer, exactly as check_drc grades it.
+
+KiCad holds copper off a mounting hole at the hole pad's own `(clearance ...)`
+when that exceeds the fab floor, and `check_drc` mirrors it -- every
+copper-less drilled pad is filed with a required clearance of
+`max(npth_clr, lc)` (check_drc.py:2733, #505). The router has honoured that
+since #326/#505 (obstacle_map.py:1759-1788). py_placer read
+`pad.local_clearance` for hole geometry NOWHERE.
+
+THE TWO ARMS HAVE DIFFERENT SHAPES, and this file's structure follows from it:
+
+    TRACK arm (check_drc.py:2733)   max(npth_clr, lc)                  a MAX
+    VIA arm   (check_drc.py:2851)   lc if lc > npth_clr else clearance  a STEP
+
+Five sites, all fixed, all covered here:
+
+  A  _Repair.__init__'s foreign-pad loop -- the cap keep-out rect      TRACK
+  B  valid_via_pos's copper-to-hole gate                               VIA
+  C  connector_clear's copper-to-hole gate                             TRACK
+  D  the two NPTH floors this pass carries -- DELIBERATE, not unified
+  E  legality.PartPads.__init__'s hole inflation                       TRACK
+
+MEASURED, on this tree. Every number was produced by running the engine, and
+every bound was crossed by sweeping just inside and just outside each end.
+
+  Site A, ulx3s AUDIO1 (hd/2 0.850, lc 0.400, npth_floor 0.200):
+        --clearance 0.10   1.0500 -> 1.2500   (check_drc wants 1.2500)
+        --clearance 0.25   1.1000 -> 1.2500   (check_drc wants 1.2500)
+
+  Site B, the #737 rig at clearance 0.10 / max_shift 0.55:
+        gap 0.300 lc 0.40   0 moves, "no clear spot"    <- the fix
+        gap 0.300 lc 0.00   1 move -> (3.4500, 3.0000)  <- not a board floor
+        gap 0.500 lc 0.40   1 move                      <- no over-rejection
+
+  Site B, THE STEP, at gap 0.120 (clearance 0.10, npth_step 0.20). The charge
+  jumps from `clearance` to `lc` across ONE TENTH OF A MICRON, which is what a
+  step means and what a max cannot do:
+        lc 0.10 / 0.15 / 0.19 / 0.1999 / 0.2000  -> 1 move (charged clearance)
+        lc 0.2001 / 0.21 / 0.25 / 0.40           -> 0 moves (charged lc)
+  and the charge itself, at lc 0.25: gap 0.230 refuses, gap 0.250 moves.
+
+  Site C, connector gate (via 0.5/0.2, stub width 1.0 -> hw 0.50, hole 1.0):
+        seg_dist 1.300 lc 0.40   0 moves                <- the fix
+        seg_dist 1.500 lc 0.40   1 move                 <- control
+        seg_dist 1.300 lc 0.00   1 move                 <- not a board floor
+        seg_dist 1.300 lc 0.15   1 move                 <- the MAX's low side
+        seg_dist 1.150 lc 0.00   0 moves                <- the npth_clr FLOOR
+        bound: 1.350 refuses, 1.400 moves == hr + hw + lc
+
+  Site E, one footprint carrying three holes at lc 0.00 / 0.40 / 0.15:
+        --clearance 0.10   [0.60, 0.60, 0.60] -> [0.60, 0.80, 0.60]
+        --clearance 0.25   [0.50, 0.50, 0.50] -> [0.50, 0.65, 0.50]
+
+CORPUS-INERT, and this file asserts that rather than narrating it. Over the 22
+boards `run_utils.corpus_boards()` returns (37 copper-less drilled pads), only
+ulx3s carries a binding override, and its nearest foreign copper misses the new
+requirement by 0.010mm.
+
+THE BATTERY: `tests/mutate_730.py`, 25 rows -- 22 killed, 3 survived (all three
+expected and recorded with their reason), 0 broken. It ships rather than a
+number in this docstring because two reviewers of the #746 branch tried to
+re-derive its kill counts from row NAMES and both got the wrong answer. It
+found four things this file was wrong about, and all four are now recorded at
+the arm rather than smoothed over: two arms that did not exist (the `getattr`
+and the slot had no engine-side gate at all), one arm crediting itself with a
+kill it cannot make, and one source guard that reported green against the very
+mutation it was written for.
+
+Conventions, from #697/#725 and CLAUDE.md:
+
+  * REAL parser dataclasses and REAL boards. `_Repair.__init__` reads
+    courtyards and locked refs from the file on disk.
+  * Every assertion names the single-line MUTATION that must kill it, written
+    AFTER `tests/mutate_730.py` ran and carrying the measured kill count.
+  * Assert you are ON the branch before asserting about it. Acute here: an
+    `lc` at or below `max(npth_floor, clearance)` changes NOTHING at any of the
+    five sites, so a rig whose lc is not strictly above the floor is vacuous.
+
+NOT COVERED, deliberately, and named so the next reader does not conclude the
+rule is now complete:
+
+  * `PartPads` still cannot see the BOARD's declared min_hole_clearance -- it
+    takes `(fp, clearance)` with no board pointer. Asserted as a signature
+    property below rather than left to be discovered.
+  * An overridden mounting hole ON A MOVABLE CAP is modelled by neither site A
+    (the foreign-pad loop never runs for a cap footprint) nor site E.
+    Pre-existing, untouched here.
+  * check_drc grades two further hole classes this does not touch: a PLATED pad
+    whose ring does not span its drill (#441), and any plated pad with lc > 0.
+    `_Repair` models plated pads as copper rects with no drill keep-out.
+
+Nothing here shells out or drives a CLI; it runs in-process. `run_all`
+classifies by grepping the SOURCE for `run_utils` and the name of the standard
+sub-process module, and this file names both in prose -- which is exactly how
+test_725 was once bucketed as integration and silently skipped under `--fast`.
+Hence the explicit opt-out below.
+"""
+from __future__ import annotations
+
+RUN_ALL_FAST_OK = True
+RUN_ALL_TIMEOUT = 900
+
+import contextlib
+import inspect
+import io
+import math
+import os
+import re
+import sys
+import unittest
+from types import SimpleNamespace
+
+_TESTS = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_TESTS)
+for _p in ('', 'py_router', 'py_placer', 'py_tools'):
+    _d = os.path.join(_ROOT, _p)
+    if _d not in sys.path:
+        sys.path.insert(0, _d)
+if _TESTS not in sys.path:
+    sys.path.insert(0, _TESTS)
+
+import run_utils
+import routing_defaults as defaults
+from kicad_parser import BoardInfo, parse_kicad_pcb
+from check_drc import _pad_has_no_copper, point_to_pad_distance
+from obstacle_map import resolve_hole_clearance
+from synth import make_pad, make_pcb, make_seg, make_via
+from placement import fanout_clearance as FC
+from placement import legality as LEG
+from placement.fanout_clearance import _Repair, nudge_vias_for_unresolved
+from placement.legality import PartPads, build_part_pads
+
+ULX3S = os.path.join(_ROOT, 'kicad_files', 'ulx3s.kicad_pcb')
+WATCHY = os.path.join(_ROOT, 'kicad_files', 'watchy.kicad_pcb')
+
+# ---- ulx3s's AUDIO1, the board the issue measures on ----------------------
+AUDIO1_DRILL = 1.700          # the two np_thru_hole pads, the ONLY two on it
+AUDIO1_LC = 0.400             # their `(clearance 0.4)`
+AUDIO1_HR = AUDIO1_DRILL / 2.0
+# check_drc's requirement from the hole CENTRE, equal at both clearances
+# because `lc` outranks `max(clearance, NPTH_TO_TRACK_CLEARANCE)` in each.
+CHECKER_WANTS = AUDIO1_HR + AUDIO1_LC                                # 1.2500
+# What the pass modelled BEFORE #730: `hd/2 + max(npth_floor, clearance)`.
+OLD_KEEPOUT = {0.10: AUDIO1_HR + 0.20, 0.25: AUDIO1_HR + 0.25}
+# Tightest foreign copper on the corpus, hole WALL to pad copper. This is the
+# number that makes site A corpus-inert, and it is the tightest margin in the
+# whole change: 1.260 from the centre against a 1.250 requirement.
+AUDIO1_NEAREST_COPPER = 0.4100                                       # R60.2
+
+# ---- the two hand-mirrored engine constants ------------------------------
+# Function-local literals inside nudge_vias_for_unresolved: they cannot be
+# imported, so every threshold computed here is a hand mirror, and the source
+# guard below fails if the engine's move.
+H2H_PAD = 0.45
+NPTH_FLOOR = defaults.NPTH_TO_TRACK_CLEARANCE                        # 0.20
+
+# ---- the synthetic via rigs (site B/C), test_737's geometry ---------------
+CLEAR = 0.10
+MAX_SHIFT = 0.55
+V_SIZE, V_DRILL = 1.4, 0.3
+VR = V_SIZE / 2.0                                                    # 0.70
+H_DRILL = 1.0
+HR = H_DRILL / 2.0                                                   # 0.50
+VIA0 = (3.0, 3.0)
+LANDING = (3.45, 3.0)
+ALL_CANDIDATES = ((3.45, 3.0), (3.50, 3.0), (3.55, 3.0))
+WALLS = [(0.0, 0.0, 2.625, 8.0, 2), (0.0, 3.90, 8.0, 8.0, 2),
+         (0.0, 0.0, 8.0, 2.10, 2)]
+# copper-edge-to-hole-WALL gap at the first candidate:
+#   XH - LANDING.x - HR - VR
+XH_REFUSED = 4.95      # gap 0.300, inside lc 0.40
+XH_MOVES = 5.15        # gap 0.500, clear of lc 0.40
+# THE STEP rig: a gap strictly between `clearance` and an lc at/below npth_clr.
+XH_STEP = 4.77         # gap 0.120  (0.020 over CLEAR, 0.030 under LC_LOW)
+LC_LOW = 0.15          # <= npth_clr -> the checker charges `clearance`
+LC_HIGH = 0.25         # >  npth_clr -> the checker charges `lc`
+STEP_MOVES, STEP_REFUSES = 0.2000, 0.2001     # the measured threshold, 1e-4 mm
+XH_HIGH_REFUSES, XH_HIGH_MOVES = 4.88, 4.90   # the CHARGE bound at LC_HIGH
+
+# ---- the connector rig (site C) ------------------------------------------
+C_V_SIZE, C_V_DRILL = 0.5, 0.2
+C_VR = C_V_SIZE / 2.0                                                # 0.25
+C_STUB_W = 1.0
+C_HW = C_STUB_W / 2.0                                                # 0.50
+C_MAX_SHIFT = 0.15
+C_LANDING = (3.05, 3.0)
+# The cap footprint sits on B.Cu so its rects cannot gate the F.Cu connector
+# (connector_clear skips a rect whose cap layer differs), while the SAME rects
+# still box the via -- valid_via_pos has no layer gate. That separation is what
+# makes the connector gate the binding one, and the arms attributable.
+C_RECTS = [(2.0, 2.9, 2.68, 3.1, 2), (2.0, 3.36, 8.0, 8.0, 2),
+           (2.0, 0.0, 8.0, 2.64, 2)]
+XH_C_REFUSED = 4.35    # seg_dist 1.300, inside HR + C_HW + 0.40 = 1.400
+XH_C_MOVES = 4.55      # seg_dist 1.500
+XH_C_FLOOR = 4.20      # seg_dist 1.150: over a `clearance` floor (1.10),
+                       # under the `npth_clr` one (1.20)
+XH_C_BOUND_REFUSES, XH_C_BOUND_MOVES = 4.40, 4.45     # 1.350 / 1.400
+
+# ---- site E ---------------------------------------------------------------
+E_LCS = (0.00, 0.40, 0.15)          # below / above / below the 0.20 floor
+E_RADII = {0.10: [0.60, 0.80, 0.60], 0.25: [0.50, 0.65, 0.50]}
+E_RADII_SILK = {0.10: [0.60, 0.60, 0.60], 0.25: [0.50, 0.50, 0.50]}
+
+
+class _FakeCap:
+    """Minimal stand-in for _Cap: fixed pad rects, never moves."""
+
+    def __init__(self, rects, side='F'):
+        self._rects = list(rects)
+        self.side = side
+        self.x = self.y = self.rot = 0.0
+
+    def pad_rects(self, x=None, y=None, rot=None):
+        return self._rects
+
+
+class _FakeSt:
+    """The duck-typed `st` the #370/#617 harnesses pass: no resolvers at all,
+    so every requirement in the nudger falls back to the flat scalar.
+
+    #: `npth_floor` is 0.60 here, NOT the 0.40 test_737/test_750 use. Those
+    #: picked 0.40 to catch `max(clearance, getattr(st, 'npth_floor', 0.0))`
+    #: reading 0.0; here 0.40 is ALSO the real ulx3s override this file is
+    #: about, and a reader could not tell the two numbers apart. 0.60 is above
+    #: every gap any rig here uses (largest 0.500), so a gate that wrongly
+    #: reads it still refuses everything and every control arm goes red.
+    """
+
+    npth_floor = 0.60
+
+    def __init__(self, rects, side='F'):
+        self.caps = {'C1': _FakeCap(rects, side)}
+        self.vias = []
+
+    def graze_penalty(self, ref, cap, x, y, rot):
+        return 1.0          # permanently unresolved, so the offender loop RUNS
+
+
+def _nudge(st, pcb, clear=CLEAR, **kw):
+    """Drive the real pass, capturing what it printed. The PRINTED OUTPUT is
+    half the evidence: a refusal that prints nothing is indistinguishable from
+    a pass that never looked (the #732 silent-failure lesson)."""
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        moves, segs = nudge_vias_for_unresolved(st, pcb, clear, **kw)
+    return moves, segs, buf.getvalue()
+
+
+def _bi():
+    return BoardInfo(layers={}, copper_layers=['F.Cu', 'B.Cu'],
+                     board_bounds=(0.0, 0.0, 8.0, 8.0))
+
+
+def _npth(x, y, lc, drill=H_DRILL, ref='H1', net=0):
+    p = make_pad(net_id=net, x=x, y=y, ref=ref, num='H1',
+                 size_x=drill, size_y=drill, shape='circle',
+                 layers=['F.Mask', 'B.Mask'], drill=drill,
+                 pad_type='np_thru_hole')
+    p.local_clearance = lc
+    return p
+
+
+def _via_board(xh, lc, *, hole_net=0, v_size=V_SIZE, v_drill=V_DRILL,
+               stub_w=0.2, cap_layer='F.Cu'):
+    v = make_via(VIA0[0], VIA0[1], net_id=3, size=v_size, drill=v_drill)
+    stub = make_seg(2.0, 3.0, VIA0[0], VIA0[1], width=stub_w, layer='F.Cu',
+                    net_id=3)
+    hole = _npth(xh, 3.0, lc, net=hole_net)
+    pcb = make_pcb(board_info=_bi(), vias=[v], segments=[stub],
+                   footprints={'C1': SimpleNamespace(layer=cap_layer, pads=[])},
+                   pads_by_net={hole_net: [hole]}, zones=[])
+    return v, pcb
+
+
+def _run_via(xh, lc, clear=CLEAR, **kw):
+    v, pcb = _via_board(xh, lc, **kw)
+    moves, segs, out = _nudge(_FakeSt(WALLS), pcb, clear, max_shift=MAX_SHIFT)
+    return v, moves, segs, out
+
+
+def _run_conn(xh, lc, clear=CLEAR):
+    v, pcb = _via_board(xh, lc, v_size=C_V_SIZE, v_drill=C_V_DRILL,
+                        stub_w=C_STUB_W, cap_layer='B.Cu')
+    moves, segs, out = _nudge(_FakeSt(C_RECTS, side='B'), pcb, clear,
+                              max_shift=C_MAX_SHIFT)
+    return v, moves, segs, out
+
+
+def _e_footprint():
+    """One footprint carrying THREE NPTH holes with different overrides.
+    Three, because one hole cannot distinguish per-hole from hoisted."""
+    return SimpleNamespace(
+        reference='H1', x=10.0, y=10.0, rotation=0.0, layer='F.Cu',
+        pads=[_npth(10.0, 10.0 + 3.0 * i, lc) for i, lc in enumerate(E_LCS)])
+
+
+def _npth_pads(pcb):
+    """Every copper-less drilled pad, selected the way the ENGINE selects --
+    check_drc's own predicate, never `pad_type == 'np_thru_hole'` (which misses
+    a pad declaring no copper layer) and never a ref-name filter."""
+    return [(ref, p) for ref, fp in pcb.footprints.items() for p in fp.pads
+            if _pad_has_no_copper(p) and (p.drill or 0) > 0]
+
+
+def _repair(path, clearance, pcb=None):
+    """The 10-POSITIONAL construction every other test in this family uses.
+    Calling it positionally is itself part of the #725 shape contract."""
+    return _Repair(pcb if pcb is not None else parse_kicad_pcb(path), path,
+                   clearance, 0.1, 0.55, 1.0, 2.0, 0.3, 'C', set())
+
+
+def _npth_rect_halves(st):
+    """The half-extent of every NPTH keep-out rect `_Repair` filed. Net -1 is
+    the marker the engine stamps on them and nothing else uses."""
+    return [round((t[2] - t[0]) / 2.0, 4) for t in st.foreign_pads if t[4] == -1]
+
+
+class TestTheKeepOutRectHonoursTheHolesOwnOverride(unittest.TestCase):
+    """Site A, on the board the issue measures: ulx3s's AUDIO1."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.pcb = parse_kicad_pcb(ULX3S)
+
+    def test_the_keep_out_lands_on_check_drcs_own_requirement(self):
+        for clearance in (0.10, 0.25):
+            with self.subTest(clearance=clearance):
+                st = _repair(ULX3S, clearance, pcb=self.pcb)
+                # ON THE BRANCH: the override must be STRICTLY above the floor
+                # this site already charged, or the arm is vacuous -- `max`
+                # with a smaller term changes nothing.
+                floor = max(st.npth_floor, st.clearance)
+                self.assertGreater(
+                    AUDIO1_LC, floor + 1e-9,
+                    'lc %.3f is not above max(npth_floor %.3f, clearance %.3f) '
+                    '-- this arm cannot see the fix' % (AUDIO1_LC,
+                                                        st.npth_floor,
+                                                        st.clearance))
+                # ...and this board declares NO min_hole_clearance, so the
+                # floor is the bare fab floor and the arithmetic below is the
+                # arithmetic in the docstring.
+                self.assertAlmostEqual(st.npth_floor, NPTH_FLOOR, places=6)
+                halves = _npth_rect_halves(st)
+                self.assertEqual(len(halves), 2,
+                                 'AUDIO1 has exactly two np_thru_hole pads and '
+                                 'they are the only ones on this board')
+                for half in halves:
+                    self.assertAlmostEqual(half + st.clearance, CHECKER_WANTS,
+                                           places=4)
+                    self.assertGreater(half + st.clearance,
+                                       OLD_KEEPOUT[clearance] + 1e-9,
+                                       'the keep-out did not move off what this '
+                                       'site modelled before #730')
+    # MUTATION: site-A-reverted -> 1.0500 / 1.1000 instead of 1.2500. Measured:
+    # 3 arms fire (this one twice, once per clearance subTest, plus the SLOT
+    # arm). site-A-threshold-at-clearance does NOT fire here -- it needs a hole
+    # whose lc is BELOW the fab floor, which is watchy's job.
+
+    def test_watchy_is_the_NEGATIVE_control_and_a_real_one(self):
+        """watchy carries eight GENUINE overrides that must change nothing:
+        all 0.100, under the 0.20 fab floor, so `max` keeps the floor. A
+        control with no override at all would prove much less -- it could not
+        tell "the override was ignored" from "there was none"."""
+        pcb = parse_kicad_pcb(WATCHY)
+        pads = _npth_pads(pcb)
+        # ON THE BRANCH: they really are overrides, and really are below.
+        lcs = sorted({getattr(p, 'local_clearance', 0.0) or 0.0
+                      for _r, p in pads})
+        self.assertEqual(len(pads), 8)
+        self.assertEqual(lcs, [0.1])
+        self.assertLess(lcs[0], NPTH_FLOOR,
+                        'watchy s override is no longer under the fab floor; '
+                        'it has stopped being a negative control')
+        for clearance in (0.10, 0.25):
+            with self.subTest(clearance=clearance):
+                st = _repair(WATCHY, clearance, pcb=pcb)
+                halves = _npth_rect_halves(st)
+                expect = round(0.75 / 2.0 + max(0.0, st.npth_floor - clearance),
+                               4)
+                self.assertEqual(sorted(set(halves)), [expect],
+                                 'a sub-floor override moved a keep-out')
+    # MUTATION: site-A-loses-the-fab-floor (`max(0.0, lc - clearance)`) and
+    # site-A-threshold-at-clearance both shrink these sub-floor holes. Measured:
+    # 2 arms each, this one and the attribute-less-pad arm -- and NOT the ulx3s
+    # headline, whose lc is above the floor either way. This arm is the only
+    # place a BELOW-floor override is graded.
+
+    def test_the_NPTH_entry_still_carries_NO_floor(self):
+        """The override must move the RECT, never become a `PadFloor`. The
+        copper-to-hole rule is net-independent, so a floor could be amplified
+        by a neighbouring pad's netclass and double-count the same millimetre
+        -- which is exactly what the #725 note at that site forbids."""
+        st = _repair(ULX3S, 0.10, pcb=self.pcb)
+        idx = [i for i, t in enumerate(st.foreign_pads) if t[4] == -1]
+        self.assertEqual(len(idx), 2)
+        for i in idx:
+            self.assertIsNone(st.foreign_pad_floors[i])
+            self.assertEqual(st.foreign_pad_mf[i], 0.0)
+            self.assertIsNone(
+                st._fp_floor_by_id.get(id(st.foreign_pads[i])),
+                'an NPTH tuple reached the id-keyed floor map, so a '
+                'neighbouring netclass can now raise a net-independent rule')
+        # ON THE BRANCH, and this is the assertion that makes the arm mean
+        # something: ulx3s's model IS active (BAT1's two SMD pads carry
+        # lc 0.700), so "the NPTH hole got no floor" is a real outcome and not
+        # an artefact of an inert board.
+        self.assertIsNotNone(
+            st._floors,
+            'ulx3s no longer activates PadClearanceModel, so this arm no '
+            'longer shows that an ACTIVE model still gives the hole nothing')
+    # MUTATION: site-A-lc-becomes-a-PadFloor -> the assertIsNone fires.
+    # Measured: 1 arm, this one. Nothing else in the tree notices an NPTH
+    # tuple acquiring a floor, which is why the arm is not merely a tidiness
+    # check.
+
+    def test_a_SLOT_drill_grows_EVERY_circle(self):
+        """`pad_drill_circles` walks a slot as several circles. The grow must
+        apply to each, and must come from the CIRCLE's diameter rather than
+        from `pad.drill` -- which for an oval is the long axis."""
+        # A real `(drill oval 3.0 1.0)`. pad_drill_capsule reads drill_w /
+        # drill_h, NOT size/shape -- a pad with only `shape='oval'` set yields
+        # ONE circle and the arm would pass while testing nothing.
+        p = _npth(50.0, 50.0, AUDIO1_LC, drill=3.0)
+        p.drill_w, p.drill_h = 3.0, 1.0
+        p.size_x, p.size_y = 3.0, 1.0
+        p.shape = 'oval'
+        from kicad_parser import pad_drill_circles
+        circles = list(pad_drill_circles(p))
+        # ON THE BRANCH: a real slot, and the circle diameter is NOT p.drill.
+        self.assertGreater(len(circles), 1, 'not a slot; this arm is vacuous')
+        self.assertNotAlmostEqual(circles[0][2], p.drill, places=6)
+        grow = max(0.0, max(NPTH_FLOOR, AUDIO1_LC) - CLEAR)
+        want = round(circles[0][2] / 2.0 + grow, 4)
+        halves = [round(hd / 2.0 + grow, 4) for _x, _y, hd in circles]
+        self.assertEqual(sorted(set(halves)), [want])
+    # MUTATION: none reachable -- this arm computes its expectation the way
+    # the engine does, so it is a SHAPE check on pad_drill_circles and not a
+    # gate on the engine's use of it. The arm below is what gates that.
+
+    def test_a_SLOT_in_the_ENGINE_grows_from_the_CIRCLE_not_pad_drill(self):
+        """The same trap, but through `_Repair` rather than beside it.
+
+        `hr = hd / 2.0 + grow` and `hr = p.drill / 2.0 + grow` are IDENTICAL
+        for every round hole, so no board in the corpus can tell them apart --
+        `p.drill` on a slot is the LONG axis. A slot has to be injected, and
+        the mutation battery reported this row as a survivor until it was.
+        """
+        import copy
+        from kicad_parser import pad_drill_circles
+        pcb = copy.deepcopy(self.pcb)
+        ref, src = _npth_pads(pcb)[0]
+        slot = copy.deepcopy(src)
+        slot.drill = 3.0                 # the LONG axis: KiCad's back-compat
+        slot.drill_w, slot.drill_h = 3.0, 1.0
+        slot.size_x, slot.size_y = 3.0, 1.0
+        slot.shape = 'oval'
+        pcb.footprints[ref].pads = [slot]
+        # ON THE BRANCH: a real slot, and the two spellings really do differ.
+        circles = list(pad_drill_circles(slot))
+        self.assertGreater(len(circles), 1, 'not a slot; this arm is vacuous')
+        self.assertNotAlmostEqual(circles[0][2], slot.drill, places=6)
+        st = _repair(ULX3S, CLEAR, pcb=pcb)
+        grow = max(0.0, max(st.npth_floor, AUDIO1_LC) - CLEAR)
+        want = round(circles[0][2] / 2.0 + grow, 4)
+        halves = _npth_rect_halves(st)
+        self.assertEqual(len(halves), len(circles),
+                         'the slot did not become one keep-out per circle')
+        self.assertEqual(sorted(set(halves)), [want])
+        self.assertNotAlmostEqual(want, slot.drill / 2.0 + grow, places=4,
+                                  msg='the long-axis spelling would give the '
+                                      'same answer here, so this arm cannot '
+                                      'tell them apart')
+    # MUTATION: site-A-long-axis-drill -> 1.8000 instead of 0.8000. 1 arm.
+
+    def test_a_pad_carrying_NO_local_clearance_attribute_is_priced(self):
+        """The `getattr`, and the only thing in this file that reaches it.
+
+        The repo's convention (legality.py:1503-1509) is `getattr` and never a
+        bare read, because the placement tests build duck-typed pad fakes that
+        do not carry the field -- a hard read turns a missing attribute into a
+        crash instead of the "no override" it means. Every pad the PARSER
+        produces has it, so a real board cannot exercise this and the mutation
+        battery reported the row as a survivor until this arm existed.
+        """
+        import copy
+        pcb = copy.deepcopy(self.pcb)
+        ref, src = _npth_pads(pcb)[0]
+        # A genuine duck type, not a real Pad with the field deleted: `Pad`
+        # declares `local_clearance` with a CLASS-level default, so `del` on
+        # an instance falls straight back to it and `hasattr` stays True. The
+        # ON-THE-BRANCH guard below caught exactly that.
+        bare = SimpleNamespace(
+            pad_type='np_thru_hole', layers=list(src.layers),
+            drill=src.drill, drill_w=0.0, drill_h=0.0,
+            hole_x=None, hole_y=None, rotation=0.0,
+            global_x=src.global_x, global_y=src.global_y,
+            size_x=src.size_x, size_y=src.size_y, net_id=0,
+            local_x=src.local_x, local_y=src.local_y,
+            rect_rotation=0.0, pad_number='H1', component_ref=ref)
+        self.assertFalse(hasattr(bare, 'local_clearance'))
+        pcb.footprints[ref].pads = [bare]
+        st = _repair(ULX3S, CLEAR, pcb=pcb)          # must not raise
+        want = round(bare.drill / 2.0
+                     + max(0.0, st.npth_floor - CLEAR), 4)
+        self.assertEqual(_npth_rect_halves(st), [want],
+                         'a pad with no override attribute was not priced at '
+                         'the bare fab floor')
+    # MUTATION: site-A-getattr-dropped -> AttributeError, an ERROR rather than
+    # a failure, which is why the battery counts an ERROR as a kill. Measured:
+    # 1 arm, this one -- and the row reported SURVIVED until this arm existed,
+    # because every pad the parser builds carries the field.
+
+
+class TestARelocatedViaHonoursTheHolesOwnOverride(unittest.TestCase):
+    """Site B, the VIA arm."""
+
+    def test_a_via_inside_an_OVERRIDDEN_holes_keep_out_is_refused(self):
+        v, moves, segs, out = _run_via(XH_REFUSED, AUDIO1_LC)
+        # ON THE BRANCH, four ways:
+        #  (i) the override outranks npth_clr, or the gate never fires;
+        npth_clr = max(CLEAR, NPTH_FLOOR)
+        self.assertGreater(AUDIO1_LC, npth_clr + 1e-9)
+        # (ii) the landing sits between what the base gate charges and what
+        #      the override charges, so ONLY the override can decide;
+        gap = XH_REFUSED - LANDING[0] - HR - VR
+        self.assertTrue(CLEAR + 0.04 < gap < AUDIO1_LC - 0.04,
+                        'gap %.4f is not strictly inside (clearance, lc)' % gap)
+        # (iii) EVERY candidate is inside the override, so `moves == []` means
+        #       "all refused" and not "the budget ran out";
+        for cx, _cy in ALL_CANDIDATES:
+            self.assertLess(XH_REFUSED - cx - HR - VR, AUDIO1_LC + 1e-9)
+        # (iv) and the landing is legal for the DRILL gate, so a refusal here
+        #      cannot be the hole-to-hole test's.
+        self.assertGreater(abs(XH_REFUSED - LANDING[0]),
+                           V_DRILL / 2.0 + HR + H2H_PAD + 0.05)
+        self.assertIn('no clear spot', out)
+        self.assertEqual(moves, [])
+        self.assertEqual(segs, [])
+        self.assertEqual((v.x, v.y), VIA0)
+    # MUTATION: via-override-gate-deleted -> the via parks at (3.4500, 3.0000),
+    # 0.3000 off a hole whose own (clearance 0.40) makes check_drc grade it.
+    # Measured: 6 arms, 5 here and 1 in test_737's source guard (which counts
+    # the gates).
+
+    def test_the_same_geometry_with_NO_override_still_moves(self):
+        """The arm without which the one above is not about #730 at all: a
+        board-aware FLOOR would refuse this too. `_FakeSt.npth_floor` is 0.60,
+        above this gap, so a gate that wrongly read it goes red here."""
+        v, moves, segs, out = _run_via(XH_REFUSED, 0.0)
+        self.assertEqual(len(moves), 1)
+        self.assertAlmostEqual(v.x, LANDING[0], places=4)
+        self.assertAlmostEqual(v.y, LANDING[1], places=4)
+        self.assertIn('moved', out)
+    # MUTATION: base-via-gate-reads-st-npth_floor -- `clearance` replaced by
+    # `max(clearance, getattr(st, 'npth_floor', 0.0))`, the classic #617 shape.
+    # Measured: 15 arms across this file and test_737.
+    #
+    # And a correction the battery forced. This arm does NOT kill
+    # via-override-uses-the-BOARD-floor, which is what the note here first
+    # claimed: with lc 0.00 the hole never enters the filtered override list,
+    # so the gap helper is never consulted and a mutation INSIDE it cannot
+    # run. That row is killed by the four CLEAR-of-the-override controls
+    # instead. The arm still earns its place -- it proves the refusal above is
+    # the override's and not a floor's -- but not by the route stated.
+
+    def test_a_via_clear_of_the_override_still_moves(self):
+        """No over-rejection: 0.10mm more room and the same override moves."""
+        v, moves, segs, out = _run_via(XH_MOVES, AUDIO1_LC)
+        gap = XH_MOVES - LANDING[0] - HR - VR
+        self.assertGreater(gap, AUDIO1_LC + 1e-9)
+        self.assertEqual(len(moves), 1)
+        self.assertAlmostEqual(v.x, LANDING[0], places=4)
+        self.assertEqual(len(segs), 1)
+    # MUTATION: via-override-uses-the-BOARD-floor -> measured 4 arms, and ALL
+    # FOUR are clear-of-the-override controls like this one. A file with only
+    # refusal arms would not see it at all.
+
+    def test_a_hole_on_the_vias_OWN_net_is_exempt(self):
+        """A track legitimately reaches its own mounting-hole pad, and
+        check_drc's via arm makes the same exemption."""
+        v, moves, _s, _o = _run_via(XH_REFUSED, AUDIO1_LC, hole_net=3)
+        self.assertEqual(len(moves), 1, 'an own-net hole blocked its own via')
+        v2, moves2, _s2, _o2 = _run_via(XH_REFUSED, AUDIO1_LC, hole_net=0)
+        self.assertEqual(moves2, [], 'the positive control stopped refusing')
+    # MUTATION: via-override-drops-the-own-net-skip -> measured 1 arm, this
+    # one. It is the only own-net fixture in the file.
+
+
+class TestTheOverrideIsASTEPNotAMax(unittest.TestCase):
+    """Site B's threshold, both directions, in ONE geometry.
+
+    check_drc's via arm charges `lc` only when `lc > npth_clr`, and plain
+    `clearance` otherwise. So `max(clearance, lc)` -- the obvious spelling --
+    over-blocks for every `clearance < lc <= npth_clr`, inventing a refusal
+    kicad-cli never reports. Measured at gap 0.120: the charge jumps from
+    0.10 to 0.2001 across a single 0.1um step in lc.
+    """
+
+    def _moves(self, lc, xh=XH_STEP):
+        return len(_run_via(xh, lc)[1])
+
+    def test_an_lc_AT_OR_BELOW_npth_clr_charges_the_via_NOTHING(self):
+        npth_clr = max(CLEAR, NPTH_FLOOR)
+        gap = XH_STEP - LANDING[0] - HR - VR
+        # ON THE BRANCH: the landing is inside the band a `max(clearance, lc)`
+        # gate would refuse -- above `clearance`, below `lc` -- while `lc` is
+        # itself at or below `npth_clr`. Without all three the arm is vacuous.
+        self.assertLessEqual(LC_LOW, npth_clr + 1e-9)
+        self.assertTrue(CLEAR + 1e-9 < gap < LC_LOW - 1e-9,
+                        'gap %.4f is not strictly inside (clearance, lc_low)'
+                        % gap)
+        self.assertEqual(self._moves(LC_LOW), 1)
+    # MUTATION: via-override-threshold-at-clearance (`_hlc <= npth_step` ->
+    # `_hlc <= clearance`) -> this arm refuses. Measured: 2 arms, this one and
+    # the exact-threshold sweep below -- NOT the single arm the note first
+    # claimed. Every other arm in the file uses an lc above npth_clr, where
+    # the two spellings agree.
+
+    def test_an_lc_JUST_ABOVE_npth_clr_charges_it_in_full(self):
+        npth_clr = max(CLEAR, NPTH_FLOOR)
+        self.assertGreater(LC_HIGH, npth_clr + 1e-9)
+        for cx, _cy in ALL_CANDIDATES:
+            self.assertLess(XH_STEP - cx - HR - VR, LC_HIGH + 1e-9)
+        self.assertEqual(self._moves(LC_HIGH), 0)
+    # MUTATION: via-override-threshold-doubled -> measured 7 arms; the upper
+    # direction is far better covered than the lower one, which is why the arm
+    # above exists.
+
+    def test_the_threshold_sits_exactly_at_npth_clr(self):
+        """The bound, crossed rather than derived. Both values are the same
+        geometry; only `lc` moves, by one ten-thousandth of a millimetre."""
+        npth_clr = max(CLEAR, NPTH_FLOOR)
+        self.assertAlmostEqual(STEP_MOVES, npth_clr, places=6)
+        self.assertEqual(self._moves(STEP_MOVES), 1,
+                         'lc exactly AT npth_clr must charge `clearance` -- '
+                         'check_drc s test is a strict `>`')
+        self.assertEqual(self._moves(STEP_REFUSES), 0,
+                         'lc one 1e-4 above npth_clr must charge `lc`')
+
+    def test_the_charge_itself_is_lc_and_the_bound_is_crossed(self):
+        """Having established WHICH holes are charged, this pins WHAT they are
+        charged: at lc 0.25 the requirement is 0.25, so 0.230 refuses and
+        0.250 moves."""
+        self.assertEqual(len(_run_via(XH_HIGH_REFUSES, LC_HIGH)[1]), 0)
+        self.assertEqual(len(_run_via(XH_HIGH_MOVES, LC_HIGH)[1]), 1)
+        self.assertAlmostEqual(XH_HIGH_MOVES - LANDING[0] - HR - VR, LC_HIGH,
+                               places=4)
+    # MUTATION: via-override-uses-the-DRILL-radius (`vr` -> the barrel's DRILL
+    # radius, 0.15 against 0.70) -> measured 5 arms. The bound rows here are
+    # two of them.
+
+    def test_the_two_step_arms_differ_ONLY_in_the_override(self):
+        """Without this, "0.15 moves / 0.25 refuses" could be a geometry
+        difference rather than the step."""
+        a, _pa = _via_board(XH_STEP, LC_LOW)
+        b, _pb = _via_board(XH_STEP, LC_HIGH)
+        self.assertEqual((a.x, a.y, a.size, a.drill),
+                         (b.x, b.y, b.size, b.drill))
+        ha = _pa.pads_by_net[0][0]
+        hb = _pb.pads_by_net[0][0]
+        self.assertEqual((ha.global_x, ha.global_y, ha.drill),
+                         (hb.global_x, hb.global_y, hb.drill))
+        self.assertNotEqual(ha.local_clearance, hb.local_clearance)
+    # MUTATION: none -- a control.
+
+
+class TestTheConnectorHonoursTheHolesOwnOverride(unittest.TestCase):
+    """Site C, the TRACK arm. Its shape differs from site B's and this class
+    is what keeps the two from being unified."""
+
+    def test_a_connector_inside_an_OVERRIDDEN_holes_keep_out_is_refused(self):
+        v, moves, segs, out = _run_conn(XH_C_REFUSED, AUDIO1_LC)
+        seg_dist = XH_C_REFUSED - C_LANDING[0]
+        # ON THE BRANCH, and the attribution matters most here:
+        #  (i) the connector's half-width EXCEEDS the via radius, or this gate
+        #      can never be the binding one and the arm silently becomes a
+        #      second site-B test;
+        self.assertGreater(C_HW, C_VR)
+        # (ii) the VIA gate accepts this landing, with room to spare;
+        self.assertGreaterEqual(seg_dist, HR + C_VR + AUDIO1_LC + 0.05)
+        # (iii) the landing is between the floor this gate already charged and
+        #       what the override charges;
+        npth_clr = max(CLEAR, NPTH_FLOOR)
+        self.assertTrue(HR + C_HW + npth_clr + 0.05 <= seg_dist
+                        <= HR + C_HW + AUDIO1_LC - 0.05)
+        # (iv) and every candidate is inside.
+        for cx, _cy in ALL_CANDIDATES[:1] + ((3.10, 3.0), (3.15, 3.0)):
+            self.assertLess(XH_C_REFUSED - cx, HR + C_HW + AUDIO1_LC + 1e-9)
+        self.assertIn('no clear spot', out)
+        self.assertEqual(moves, [])
+    # MUTATION: connector-override-gate-deleted -> the connector is drawn
+    # 0.300 off a hole wanting 0.400. Measured: 2 arms, this one and the bound
+    # sweep. The via-side rows do NOT fire -- the two gates are separately
+    # held, which is the point of splitting them.
+
+    def test_a_connector_clear_of_the_override_is_still_drawn(self):
+        v, moves, segs, out = _run_conn(XH_C_MOVES, AUDIO1_LC)
+        self.assertEqual(len(moves), 1)
+        self.assertEqual(len(segs), 1)
+        # ON THE BRANCH: the connector really is 1.0mm wide, so `hw` is 0.50
+        # and the arithmetic above is the arithmetic the gate ran.
+        self.assertAlmostEqual(segs[0]['width'], C_STUB_W, places=6)
+        self.assertAlmostEqual(v.x, C_LANDING[0], places=4)
+
+    def test_the_same_geometry_with_NO_override_still_draws_it(self):
+        v, moves, segs, _o = _run_conn(XH_C_REFUSED, 0.0)
+        self.assertEqual(len(moves), 1)
+        self.assertEqual(len(segs), 1)
+
+    def test_the_connector_arm_is_a_MAX_not_a_STEP(self):
+        """An `lc` BELOW the floor this gate already charges must change
+        nothing -- `max(npth_clr, lc)` collapses to `npth_clr`. This is the
+        arm that keeps sites B and C from being written as one expression: B
+        returns `clearance` in this case, C returns `npth_clr`."""
+        npth_clr = max(CLEAR, NPTH_FLOOR)
+        self.assertLess(LC_LOW, npth_clr)
+        self.assertEqual(len(_run_conn(XH_C_REFUSED, LC_LOW)[1]), 1)
+    # MUTATION: override-charge-given-the-VIA-step -> SURVIVED, expected, and
+    # recorded as such in mutate_730.py. The list is already filtered to
+    # `lc > npth_step >= npth_clr`, so `max(npth_clr, lc)` and the step both
+    # collapse to `lc` for every member: the FILTER carries this arm, not the
+    # charge. Worth stating, because it is the thing a reader is most likely
+    # to get backwards.
+
+    def test_the_requirement_bound_is_crossed(self):
+        """`hr + hw + lc` = 1.400, so 1.350 refuses and 1.400 moves. Derived
+        intervals are how #746 shipped a bound that excluded its own
+        counterexample; this one is swept."""
+        self.assertEqual(len(_run_conn(XH_C_BOUND_REFUSES, AUDIO1_LC)[1]), 0)
+        self.assertEqual(len(_run_conn(XH_C_BOUND_MOVES, AUDIO1_LC)[1]), 1)
+        self.assertAlmostEqual(XH_C_BOUND_MOVES - C_LANDING[0],
+                               HR + C_HW + AUDIO1_LC, places=4)
+
+
+class TestTheConnectorGateStaysAtTheFlatFabFloor(unittest.TestCase):
+    """Site D's exclusion, and #737's orphan.
+
+    #617 chose to leave this gate's floor at the flat fab floor and measured
+    the cost of raising it. test_737's source guard says its own assertion is
+    "the ONLY thing in the tree" holding that floor. It no longer is: this arm
+    holds it behaviourally, so a future reader can delete the source guard and
+    still be caught.
+    """
+
+    def test_the_connector_floor_is_npth_clr_and_not_clearance(self):
+        npth_clr = max(CLEAR, NPTH_FLOOR)
+        seg_dist = XH_C_FLOOR - C_LANDING[0]
+        # ON THE BRANCH: the landing sits BETWEEN the two candidate floors --
+        # 0.05 above what `clearance` would require, 0.05 below what
+        # `npth_clr` requires -- so the two spellings must disagree here.
+        self.assertLess(CLEAR, npth_clr)
+        self.assertTrue(HR + C_HW + CLEAR + 1e-9 < seg_dist
+                        < HR + C_HW + npth_clr - 1e-9,
+                        'seg_dist %.4f does not separate the two floors'
+                        % seg_dist)
+        self.assertEqual(len(_run_conn(XH_C_FLOOR, 0.0)[1]), 0,
+                         'the connector gate stopped charging npth_clr -- '
+                         '#617 set that floor deliberately')
+    # MUTATION: connector-BASE-floor-lowered (`npth_clr + hw` ->
+    # `clearance + hw`) -> 1 move to (3.05, 3.0). Measured: this used to pass
+    # test_617, test_370 and test_fanout_clearance, caught by a source guard
+    # alone.
+
+    def test_the_two_NPTH_floors_differ_ON_PURPOSE(self):
+        """The drift guard for #730's site D. `_Repair.npth_floor` reads the
+        board; `nudge_vias_for_unresolved`'s `npth_clr` does not, and #617
+        measured that unifying them returns 0 moves and 0 connectors where the
+        flat floor returns 1 and 1. A later "consistency" refactor must not
+        collapse them silently."""
+        src = [l.split('#')[0] for l in
+               inspect.getsource(FC.nudge_vias_for_unresolved).splitlines()]
+        # `startswith('npth_clr')` alone also matches the connector gate's
+        # CONTINUATION line (`npth_clr + hw - 1e-4:`), which is a use and not
+        # an assignment. Match the assignment.
+        flat = [i for i, l in enumerate(src)
+                if re.match(r'\s*npth_clr\s*=', l)]
+        self.assertEqual(len(flat), 1,
+                         'expected exactly one npth_clr assignment; found %d'
+                         % len(flat))
+        # A POSITIVE shape check, not an absence one, and the mutation
+        # battery is why. The first version asserted that three tokens were
+        # absent from the assignment's FIRST line; the obvious mutant puts the
+        # board read on a CONTINUATION line, under an aliased import, and
+        # evaded both -- it was killed by test_617 alone, and this guard
+        # reported green. An absence guard has to anticipate the spelling; a
+        # shape guard does not.
+        window = ' '.join(src[flat[0]:flat[0] + 3]).split(')')[0] + ')'
+        self.assertEqual(
+            ' '.join(window.split()),
+            'npth_clr = max(clearance, defaults.NPTH_TO_TRACK_CLEARANCE)',
+            'npth_clr is no longer the FLAT two-term max. #617 measured the '
+            'cost of board-deriving it: 1 move / 1 connector at a 0.2200mm '
+            'gap becomes 0 and 0, and the #130 pad-via graze the pass exists '
+            'to remove persists.')
+        # ...and the far site still DOES read the board, or the two have been
+        # unified from the other end -- which loses the cap-side raise #617
+        # shipped.
+        rsrc = inspect.getsource(_Repair.__init__)
+        self.assertIn('resolve_hole_clearance', rsrc,
+                      '_Repair.npth_floor stopped reading the board; #617 '
+                      'changed exactly that site on purpose')
+    # MUTATION: nudger-npth_clr-made-BOARD-AWARE -> measured 3 kills across 2
+    # files: this arm plus test_617's two checks.
+    #
+    # It took a battery run to make that true. The first version of this guard
+    # asserted that three tokens were ABSENT from the assignment's first line;
+    # the obvious mutant puts the board read on a CONTINUATION line under an
+    # aliased import and evaded both, leaving test_617 as the only killer while
+    # this guard reported green. It is a POSITIVE shape check now -- an absence
+    # guard has to anticipate the spelling, a shape guard does not.
+
+
+class TestThePartPadsHoleKeepOutIsPerHole(unittest.TestCase):
+    """Site E."""
+
+    def test_holes_on_ONE_footprint_get_THEIR_OWN_radii(self):
+        fp = _e_footprint()
+        # ON THE BRANCH: all three reach holes_local, and the three overrides
+        # straddle the fab floor -- else "different" is vacuous.
+        self.assertGreater(E_LCS[1], NPTH_FLOOR)
+        self.assertLess(E_LCS[2], NPTH_FLOOR)
+        for clearance, want in E_RADII.items():
+            with self.subTest(clearance=clearance):
+                pp = PartPads(fp, clearance)
+                self.assertEqual(len(pp.holes_local), 3)
+                self.assertEqual([round(r, 4) for _x, _y, r in pp.holes_local],
+                                 want)
+    # MUTATION: site-E-reverted-to-the-hoist (measured 2 arms),
+    # site-E-loses-the-fab-floor (3), site-E-threshold-at-clearance (3).
+    # site-E-max-respelled-as-a-conditional SURVIVES, expected -- an exact
+    # re-spelling of `max`, recorded so its survival is not read as a hole.
+
+    def test_the_SILK_consumer_is_opted_out(self):
+        """`local_clearance` is a COPPER rule -- KiCad has no silk-to-hole rule
+        at all -- and `hole_circles()` serves both questions. labels.py passes
+        `copper_holes=False`; every copper consumer takes the default."""
+        fp = _e_footprint()
+        for clearance, want in E_RADII_SILK.items():
+            with self.subTest(clearance=clearance):
+                pp = PartPads(fp, clearance, None, False)
+                self.assertEqual([round(r, 4) for _x, _y, r in pp.holes_local],
+                                 want)
+        # ...and the flag reaches the factory, which is how labels.py sets it.
+        parts = build_part_pads({'H1': fp}, 0.10, None, False)
+        self.assertEqual([round(r, 4) for _x, _y, r in parts['H1'].holes_local],
+                         E_RADII_SILK[0.10])
+        src = inspect.getsource(LEG.build_part_pads)
+        self.assertIn('copper_holes', src)
+    # MUTATION: site-E-silk-gate-dropped -> measured 3 arms, all inside this
+    # one test (one per clearance subTest, plus the factory check).
+
+    def test_no_board_read_is_attempted_here_and_that_is_DISCLOSED(self):
+        """A disclosure, not a fix. legality's keep-out is
+        `max(clearance, 0.20, lc)` where check_drc's track arm is
+        `max(clearance, 0.20, hole_clearance, lc)`, so on a board declaring
+        above 0.20 this still under-blocks. `PartPads` is structurally unable
+        to see it -- no board pointer -- and that is asserted so the gap
+        cannot be quietly forgotten."""
+        params = list(inspect.signature(PartPads.__init__).parameters)
+        self.assertEqual(params[:5],
+                         ['self', 'fp', 'clearance', 'model', 'copper_holes'])
+        for banned in ('pcb_data', 'pcb_file', 'board', 'source_path'):
+            self.assertNotIn(banned, params)
+        # CODE only: this very fix's comment NAMES resolve_hole_clearance
+        # when explaining why the read is impossible here, and a raw-source
+        # scan would read that as the read itself.
+        code = ' '.join(l.split('#')[0] for l in
+                        inspect.getsource(PartPads.__init__).splitlines())
+        self.assertNotIn('resolve_hole_clearance', code)
+    # MUTATION: none in the battery -- a DISCLOSURE arm, not a fix assertion.
+    # It fails if someone threads a board pointer in here without revisiting
+    # what that means for the six build_part_pads call sites.
+
+
+class TestOneHoleRule(unittest.TestCase):
+    """Source guards. Reported by LINE NUMBER, never `assertIn` over the module
+    source -- test_732 measured a 393KB failure message doing that."""
+
+    def _nudger_src(self):
+        return [l.split('#')[0] for l in
+                inspect.getsource(FC.nudge_vias_for_unresolved).splitlines()]
+
+    def test_the_override_is_resolved_in_exactly_one_place(self):
+        """One selector, one threshold. A second copy is a second answer to
+        "which holes carry an override", and they can only be trusted to agree
+        if there is one."""
+        src = self._nudger_src()
+        sel = [i + 1 for i, l in enumerate(src) if 'override_holes' in l
+               and '=' in l and 'if' not in l]
+        self.assertEqual(len(sel), 2,
+                         'expected exactly two `override_holes` assignments '
+                         '(the build and the reach filter); found %d at '
+                         'function-relative line(s) %s' % (len(sel), sel))
+        step = [i + 1 for i, l in enumerate(src) if 'npth_step' in l
+                and l.lstrip().startswith('npth_step')]
+        self.assertEqual(len(step), 1,
+                         'expected exactly one npth_step assignment; found %s'
+                         % step)
+
+    def test_the_hole_SET_uses_the_engines_own_predicate(self):
+        """Not a re-spelling. The override gate and its two scalar siblings
+        must agree about which holes EXIST -- they measure the same board --
+        and a locally re-derived predicate is how that agreement is lost,
+        silently and by under-blocking."""
+        src = self._nudger_src()
+        build = [i for i, l in enumerate(src) if 'override_holes.append' in l]
+        self.assertEqual(len(build), 1)
+        window = ' '.join(src[max(0, build[0] - 12):build[0] + 1])
+        self.assertIn('_pad_has_no_copper(', window)
+        self.assertIn('pad_drill_capsule(', window)
+        self.assertIn('pads_by_net', window,
+                      'the override list is not built from pads_by_net -- '
+                      '`board_pads` DROPS the pads of movable caps, which the '
+                      'sibling gates keep')
+
+    def test_this_files_mirrored_constants_are_still_the_engines(self):
+        """`H2H_PAD` is a function-local literal and cannot be imported, so the
+        drill-gate arithmetic in this file's ON-THE-BRANCH guards is a hand
+        mirror that would silently reason about the wrong number."""
+        joined = ' '.join(self._nudger_src())
+        self.assertIn('H2H_PAD = %s' % H2H_PAD, joined,
+                      "the engine's H2H_PAD is no longer %s, so this file's "
+                      'mirror is stale' % H2H_PAD)
+
+    def test_the_scalar_mirror_matches_the_shared_kernel(self):
+        """`_seg_seg_dist` copies `_seg_capsule_axis_dist` term for term rather
+        than approximating it, because the four hole gates measure the same
+        holes and must agree about touching cases. The kernel's crossing test
+        is a STRICT `o1*o2 < 0`; `_segs_cross` counts an orientation of 0 as a
+        crossing and would answer 0.0 where the kernel does not."""
+        import numpy as np
+        from single_ended_routing import _seg_capsule_axis_dist
+        cases = [
+            (0.0, 0.0, 1.0, 0.0, 0.5, -1.0, 0.5, 1.0),      # proper crossing
+            (0.0, 0.0, 1.0, 0.0, 0.5, 0.0, 0.5, 1.0),       # endpoint ON it
+            (0.0, 0.0, 1.0, 0.0, 2.0, 0.0, 3.0, 0.0),       # collinear, apart
+            (0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0),       # two points
+            (0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 1.0),       # X
+            (1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 2.0, 0.0),       # point vs segment
+        ]
+        for c in cases:
+            with self.subTest(case=c):
+                want = float(_seg_capsule_axis_dist(
+                    c[0], c[1], c[2], c[3],
+                    np.asarray([c[4]], dtype=float),
+                    np.asarray([c[5]], dtype=float),
+                    np.asarray([c[6]], dtype=float),
+                    np.asarray([c[7]], dtype=float))[0])
+                self.assertAlmostEqual(FC._seg_seg_dist(*c), want, places=9)
+    # MUTATION: seg-seg-crossing-test-relaxed (`< 0` -> `<= 0`) -> measured 6
+    # arms. Two are this test's own subTests; the other four are geometry arms
+    # that would silently start measuring 0.0 for a touching case.
+
+
+class TestInertOnTheTrackedCorpus(unittest.TestCase):
+    """Self-expiring bounds. Every clause is selected the way the ENGINE
+    selects -- `git ls-files` for the board set, check_drc's own predicate for
+    the holes, `resolve_hole_clearance` for the floor -- never a name grep.
+    #746 shipped a bound whose candidate set excluded its own counterexample
+    because it grepped footprint names where the engine calls a detector."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.boards = run_utils.corpus_boards()
+
+    def _scan(self, clearance):
+        """(total NPTH pads, {board: [binding pads]}) at this clearance."""
+        total, binding = 0, {}
+        for b in self.boards:
+            try:
+                pcb = parse_kicad_pcb(b)
+            except Exception:                                    # noqa: BLE001
+                continue
+            floor = max(NPTH_FLOOR, resolve_hole_clearance(pcb, None),
+                        clearance)
+            hit = []
+            for ref, p in _npth_pads(pcb):
+                total += 1
+                if (getattr(p, 'local_clearance', 0.0) or 0.0) > floor + 1e-9:
+                    hit.append((ref, p))
+            if hit:
+                binding[os.path.basename(b)] = hit
+        return total, binding
+
+    def test_exactly_one_tracked_board_carries_a_binding_override(self):
+        if not self.boards:
+            print('SKIP: git cannot identify the tracked corpus')
+            self.skipTest('no git')
+        self.assertGreaterEqual(len(self.boards), 20,
+                                'the tracked corpus collapsed; this arm '
+                                'proves nothing')
+        for clearance in (0.10, 0.25):
+            with self.subTest(clearance=clearance):
+                total, binding = self._scan(clearance)
+                self.assertGreater(total, 25,
+                                   'only %d copper-less drilled pads found; '
+                                   'the scan is not reading the boards'
+                                   % total)
+                self.assertEqual(sorted(binding), ['ulx3s.kicad_pcb'],
+                                 'the set of boards a #730 override binds on '
+                                 'has CHANGED: %r. The "corpus-inert" claim in '
+                                 'the #730 PR has EXPIRED -- re-run the '
+                                 'before/after sweep and record the numbers'
+                                 % {k: len(v) for k, v in binding.items()})
+                self.assertEqual(len(binding['ulx3s.kicad_pcb']), 2)
+
+    def test_the_one_binding_board_still_misses_by_ten_microns(self):
+        """The tightest number in the whole change, and the reason site A is
+        corpus-inert rather than a behaviour win. Asserted against the bound
+        itself with the margin printed, not against an invented safety
+        subtraction."""
+        if not self.boards:
+            print('SKIP: git cannot identify the tracked corpus')
+            self.skipTest('no git')
+        pcb = parse_kicad_pcb(ULX3S)
+        holes = _npth_pads(pcb)
+        self.assertEqual(len(holes), 2)
+        worst = None
+        for ref, hp in holes:
+            hr = hp.drill / 2.0
+            for r2, fp2 in pcb.footprints.items():
+                if r2 == ref:
+                    continue
+                for q in fp2.pads:
+                    if _pad_has_no_copper(q):
+                        continue
+                    d = point_to_pad_distance(hp.global_x, hp.global_y, q) - hr
+                    if worst is None or d < worst[0]:
+                        worst = (d, '%s.%s' % (r2, q.pad_number))
+        self.assertIsNotNone(worst)
+        margin = worst[0] - AUDIO1_LC
+        print('        ulx3s AUDIO1 hole wall -> %s at %.4fmm; the #730 '
+              'requirement is %.4f, margin %.4fmm'
+              % (worst[1], worst[0], AUDIO1_LC, margin))
+        self.assertGreater(margin, 0.0,
+                           'foreign copper is now INSIDE the #730 keep-out on '
+                           'ulx3s (%s at %.4fmm vs a %.4f requirement). Site A '
+                           'has stopped being corpus-inert -- re-measure the '
+                           'repair pass before/after and update the PR'
+                           % (worst[1], worst[0], AUDIO1_LC))
+        self.assertAlmostEqual(worst[0], AUDIO1_NEAREST_COPPER, places=4)
+    # MUTATION: none -- self-expiring corpus bounds, not fix assertions.
+
+    def test_no_tracked_board_can_reach_the_via_or_connector_gate(self):
+        """Sites B and C are unreachable on the corpus, and this says so with
+        the reason rather than leaving it implied: the only board with a
+        binding override carries no vias at all, so the reach filter empties
+        its override list and both gates cost one truth test."""
+        if not self.boards:
+            print('SKIP: git cannot identify the tracked corpus')
+            self.skipTest('no git')
+        pcb = parse_kicad_pcb(ULX3S)
+        self.assertEqual(len(pcb.vias), 0,
+                         'ulx3s now carries vias, so the #730 via/connector '
+                         'gates may be reachable -- re-measure')
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_730_fanout_clearance_npth_local_clearance.py
+++ b/tests/test_730_fanout_clearance_npth_local_clearance.py
@@ -1162,11 +1162,15 @@ class TestInertOnTheTrackedCorpus(unittest.TestCase):
         """(total NPTH pads, {board: [binding pads]}) at this clearance.
 
         The floor is sites A/B/C's -- it carries the board's declared
-        min_hole_clearance. Site E's is STRICTLY LOWER, because `PartPads`
-        cannot see the board at all (asserted two classes up), so a hole with
-        `npth_clr < lc <= declared` binds at site E while this scan calls it
-        non-binding. Inert on the corpus today: the one board declaring above
-        the fab floor is flat_hierarchy, and all 6 of its NPTH pads are at
+        min_hole_clearance, and since #761 site E carries it too: the caller
+        resolves it once (`legality.resolve_npth_floor`) and passes the
+        scalar, so this scan and site E now select on the SAME floor. It was
+        strictly lower while `PartPads` could not see the board, which made a
+        hole with `npth_clr < lc <= declared` bind at site E while this scan
+        called it non-binding -- unreachable then and gone now, but recorded
+        because the fix, not the argument, is what closed it. Inert on the
+        corpus either way: the one board declaring above the fab floor is
+        flat_hierarchy, and all 6 of its NPTH pads are at
         lc 0.0. Stated because "selected the way the ENGINE selects" is true of
         A/B/C and only approximately true of E.
         """

--- a/tests/test_731_fanout_clearance_track_layer_scope.py
+++ b/tests/test_731_fanout_clearance_track_layer_scope.py
@@ -392,14 +392,37 @@ class TestTheInertPath(unittest.TestCase):
     # MUTATION: source `board_copper` from a `PadClearanceModel.for_board`
     # call instead of `self._all_cu` -> hits > 0.
 
-    def test_an_ON_layer_inert_cell_is_the_tuples_own_half_width_BIT_EXACTLY(self):
-        """`t[5] - clearance + clearance` is not float-identical to `t[5]`, and
-        this file's contract is that an inert board is BYTE-identical. Asserted
-        with assertEqual, not assertAlmostEqual."""
+    def test_an_ON_layer_inert_cell_NEVER_REACHES_THE_RESOLVER(self):
+        """On the inert path the eff cell is the tuple's own over-reach, taken
+        directly rather than rebuilt as `halves[j] + clearance`.
+
+        The point is the CALL, not the rounding. Rebuilding it routes every
+        inert cell through `_pair_or_flat`, which is the funnel the clearance
+        model hangs off -- a board that declares nothing would start consulting
+        the resolver once per pair. Spied directly, because the arithmetic
+        round-trip is float-exact on every cell measured (0 of 1063 on rp2350),
+        so an equality check alone cannot tell the two forms apart: a mutation
+        replacing this arm left the value assertion GREEN."""
         st = self.st
+        calls = []
+        orig = _Repair._pair_or_flat
+
+        def spy(self_, fa, fb):
+            calls.append((fa, fb))
+            return orig(self_, fa, fb)
+        _Repair._pair_or_flat = spy
+        try:
+            st._cap_seg_eff.clear()
+            rows_by_ref = {ref: st._seg_effs(ref, cap)
+                           for ref, cap in st.caps.items()}
+        finally:
+            _Repair._pair_or_flat = orig
+        self.assertEqual(calls, [],
+                         'the resolver was consulted %d time(s) building the '
+                         'TRACK eff matrix on an inert board' % len(calls))
         checked = 0
         for ref, cap in st.caps.items():
-            rows = st._seg_effs(ref, cap)
+            rows = rows_by_ref[ref]
             self.assertIsNotNone(rows, '%s got no eff matrix' % ref)
             for i in range(len(cap.pads)):
                 for j, t in enumerate(st.cap_segs[ref]):
@@ -410,9 +433,11 @@ class TestTheInertPath(unittest.TestCase):
                                      '%s pad %d vs track %d: %r != %r'
                                      % (ref, i, j, rows[i][j], t[5]))
                     checked += 1
+        # ON THE BRANCH: there must BE inert cells, or "0 calls" is vacuous.
         self.assertGreater(checked, 0, 'no inert pair was examined')
-    # MUTATION: replace the `t[5]` arm with `halves[j] + self.clearance` -> the
-    # assertEqual fails on the pairs where the float round-trip is lossy.
+    # MUTATION: replace the `fa is None and floors[j] is None` arm with `False`
+    # -> every inert cell falls through to `_pair_or_flat` and `calls` is no
+    # longer empty.
 
     def test_the_inert_boards_recorded_result_is_the_NEW_one(self):
         """Six of rp2350's eight caps were violators purely on phantom. Only
@@ -521,23 +546,45 @@ class TestTheOffSwitches(unittest.TestCase):
 class TestShapeAndClassification(unittest.TestCase):
 
     def test_the_Cap_constructor_takes_board_copper_POSITIONALLY(self):
-        """`board_copper` must be a real parameter, not a defaulted one that a
-        3-positional caller silently skips: with a default of `()`, every
-        `*.Cu` pad would resolve to the EMPTY set and read as copper-less --
-        the fix would look present and grade nothing."""
+        """`board_copper` must default to None, NOT to `()`.
+
+        With `()` the fallback to the model's own copper list never fires, so a
+        3-positional `_Cap(fp, lb, model)` -- which `test_725` uses -- resolves
+        `pad_copper_layers(p, [])`. That still resolves a CONCRETE `F.Cu` pad,
+        which is why a naive fixture cannot see it: only a `*.Cu` pad collapses
+        to the empty set, and an empty set is the "copper-less, grade flat"
+        marker. So the board would silently stop scoping its through-hole pads
+        while every visible signal looked fine. Measured: with a plain
+        signature check plus a 4-positional construction, that mutation
+        SURVIVED the whole suite."""
         names = list(inspect.signature(_Cap.__init__).parameters)
         self.assertEqual(names[1:5],
                          ['fp', 'courtyard_local', 'model', 'board_copper'])
+        self.assertIsNone(
+            inspect.signature(_Cap.__init__).parameters['board_copper'].default,
+            'board_copper defaults to something other than None, so the '
+            'fallback to model.board_copper cannot fire')
         pcb = parse_kicad_pcb(BOARD)
-        fp = pcb.footprints[CAP]
+        fp = copy.deepcopy(pcb.footprints[CAP])
+        for p in _copper_pads(fp):
+            _as_through(p)                      # now a `*.Cu` pad
         cu = pcb.board_info.copper_layers
+        # (a) 4-positional, no model at all: layers still resolve.
         cap = _Cap(fp, (-0.5, -0.5, 0.5, 0.5), None, cu)
-        # Built with NO model at all, and still resolves real layers.
         self.assertEqual(cap.pad_floors, [])
-        self.assertEqual(sorted(cap.pad_layers[0]), ['F.Cu'])
         self.assertEqual(len(cap.pad_layers), len(cap.pads))
-    # MUTATION: gate the pad_layers build on `model is not None` -> pad_layers
-    # is [] here. MUTATION: rename or reorder the parameter -> the name list
+        self.assertEqual(len(cap.pad_layers[0]), len(cu))
+        # (b) 3-positional with only a model, the shape test_725 uses: the
+        # fallback to model.board_copper must carry the layers.
+        model = PadClearanceModel.for_board(pcb, CLEAR, BOARD)
+        cap3 = _Cap(fp, (-0.5, -0.5, 0.5, 0.5), model)
+        self.assertEqual(len(cap3.pad_layers[0]), len(cu),
+                         'a 3-positional _Cap resolved %r for a *.Cu pad -- '
+                         'board_copper is shadowing the model fallback'
+                         % (cap3.pad_layers[0],))
+    # MUTATION: `board_copper=()` -> arm (b) resolves the empty set.
+    # MUTATION: gate the pad_layers build on `model is not None` -> arm (a) has
+    # no pad_layers. MUTATION: rename or reorder the parameter -> the name list
     # differs.
 
     def test_the_segment_tuple_is_still_SEVEN_wide_and_carries_a_LAYER(self):

--- a/tests/test_731_fanout_clearance_track_layer_scope.py
+++ b/tests/test_731_fanout_clearance_track_layer_scope.py
@@ -23,11 +23,14 @@ Conventions this file follows (from #697/#725 and CLAUDE.md):
     "and this one still is".
 
 Nothing here shells out or drives a CLI: it runs entirely in-process in ~25 s.
-`run_all.is_integration` classifies by grepping the SOURCE for `run_utils` and
-the name of the standard sub-process module, and this file NAMES those markers
-in prose (including in this sentence), which is how the first version of the
-#725 file got bucketed as integration and silently skipped under `--fast`.
-Hence the explicit opt-out below.
+`run_all.is_integration` classifies by grepping the SOURCE for the literal
+strings `import run_utils`, `from run_utils` and the name of the standard
+sub-process module. This file contains NONE of them as written -- the prose
+above is hyphenated and unqualified on purpose -- so the opt-out below is
+belt-and-braces, not load-bearing: it is here so that a later edit which does
+introduce one of those strings cannot silently reclassify the file and skip it
+under `--fast`. That is not hypothetical; it is what happened to the first
+version of the #725 file (6c2096c6).
 """
 from __future__ import annotations
 
@@ -35,6 +38,7 @@ RUN_ALL_FAST_OK = True
 
 import copy
 import inspect
+import io
 import os
 import sys
 import unittest
@@ -151,8 +155,12 @@ class TestTheTruthTable(unittest.TestCase):
             self.assertAlmostEqual(pen, 0.0, places=9,
                                    msg='%s track charged %.6f against an F.Cu '
                                        'pad' % (layer, pen))
-    # MUTATION: revert the prune to `if seg[6] != cap.side: continue` -> every
-    # arm charges BITE (0.05).
+    # MUTATION: `_seg_shares` -> `return True` -> every arm charges BITE
+    # (0.05). NB reverting the PRUNE alone does NOT kill this: the gate is
+    # two-layer (prune + `_seg_effs`), and with the grading half intact the
+    # pair is still priced `_OFF_LAYER` and billed nothing. Only
+    # `test_no_pruned_pair_is_one_check_drc_would_IGNORE` sees a prune-only
+    # revert -- it fires there at exactly 928.
 
     def test_the_SAME_geometry_on_F_Cu_IS_still_charged(self):
         """The negative control. Without it, a build that deleted track grading
@@ -311,7 +319,8 @@ class TestTheSeedPhantomIsGone(unittest.TestCase):
                                    0.0, places=9, msg='%s track graze' % ref)
             self.assertAlmostEqual(st.graze_penalty(ref, cap, x, y, rot),
                                    0.0, places=9, msg='%s total' % ref)
-    # MUTATION: revert the prune -> each reads 0.0821.
+    # MUTATION: `_seg_shares` -> `return True` -> each reads 0.0821. (A
+    # prune-only revert leaves these green; see the note above.)
 
     def test_the_boards_whole_seed_track_graze_is_zero_and_was_not(self):
         """0.246393mm before #731, every micron of it off-layer: this board has
@@ -326,7 +335,8 @@ class TestTheSeedPhantomIsGone(unittest.TestCase):
                                    % (total, PRE_FIX_PHANTOM_MM))
         # ON THE BRANCH: there must be tracks in the pruned lists at all.
         self.assertGreater(sum(len(v) for v in st.cap_segs.values()), 0)
-    # MUTATION: revert the prune -> the total reads 0.246393.
+    # MUTATION: `_seg_shares` -> `return True` -> the total reads 0.246393.
+    # (A prune-only revert leaves this green; see the note above.)
 
 
 class TestTheInertPath(unittest.TestCase):
@@ -449,8 +459,10 @@ class TestTheInertPath(unittest.TestCase):
         self.assertEqual(sorted(r['unresolved']), ['C23'])
         self.assertEqual(sorted(r['resolved']), ['C18'])
         self.assertEqual(r['required'], [], 'an inert board discloses nothing')
-    # MUTATION: any revert of the prune, the unconditional pad_layers, or the
-    # `_cap_pad_layers` anchor -> the 7-ref unresolved list comes back.
+    # MUTATION: `_seg_shares` -> `return True`, or reverting the
+    # unconditional pad_layers, or the `_cap_pad_layers` anchor -> the 7-ref
+    # unresolved list comes back. (A prune-only revert leaves this green: the
+    # grading half still zeroes the phantom.)
 
 
 class TestTheOffSwitches(unittest.TestCase):
@@ -513,34 +525,232 @@ class TestTheOffSwitches(unittest.TestCase):
     # MUTATION: delete the `_seg_shares` branch in `_seg_effs` -> this reads
     # BITE (0.05) while every board-level test stays green.
 
-    def test_a_board_with_NO_copper_layers_falls_back_to_the_SIDE_collapse(self):
-        """`pad_copper_layers(p, [])` resolves nothing for a `*.Cu` pad, so
-        every pad would read copper-less and every pair would take the
-        off-layer path -- an UNDER-block, which ships violations. Scoping
-        switches off wholesale. It must fall back to the OLD side test, NOT to
-        keeping every segment on the board: check_drc still layer-scopes such a
-        board (its routing_layers falls back to the segment-derived set), so
-        the placer must stay on the over-block side."""
+    def test_a_board_with_NO_copper_layers_RESOLVES_one_instead_of_giving_up(self):
+        """A board whose `(layers ...)` stanza yields no copper must NOT fall
+        back to the 'F'/'B' side collapse.
+
+        That looked like the safe direction and is not. check_drc resolves the
+        same situation with a THREE-level fallback -- filter to `.Cu`, then the
+        layers segments actually sit on, then ['F.Cu','B.Cu'] -- and still
+        expands a `*.Cu` pad over the result and grades it. The side collapse
+        DROPS every B.Cu and inner track a through-hole cap pad shares copper
+        with, which is an UNDER-block and the exact mirror bug #731 fixes.
+        Measured on rp2350 with the copper list cleared and cap pads made
+        through-hole: 280 pairs check_drc grades that the side-collapse
+        fallback ignored, byte-identical to the pre-#731 count."""
         pcb = parse_kicad_pcb(BOARD)
+        real = list(pcb.board_info.copper_layers)
         pcb.board_info.copper_layers = []
         st = _repair(BOARD, pcb=pcb)
-        self.assertEqual(st._all_cu, frozenset())
+        # ON THE BRANCH: the board really declares nothing, and the fallback
+        # really had to reconstruct the list from the segments.
+        self.assertEqual(pcb.board_info.copper_layers, [])
+        self.assertTrue(st._all_cu, 'the fallback resolved no copper at all')
+        self.assertTrue(st._all_cu <= set(real),
+                        'the fallback invented a layer the board lacks: %r'
+                        % (st._all_cu - set(real),))
+        # ...and scoping stays ON, so a through-hole pad keeps its inner and
+        # back-side copper.
         cap = st.caps[CAP]
-        self.assertIsNone(st._cap_pad_layers(cap),
-                          'layer scoping stayed on with no copper layers')
-        # ON THE BRANCH: the board must carry tracks on BOTH sides, or "did not
-        # keep everything" cannot be distinguished from "kept everything".
-        sides = {st._seg_side(t[6]) for t in st.segments}
-        self.assertEqual(sides, {'F', 'B'})
-        kept = st.cap_segs[CAP]
-        self.assertTrue(kept, 'the fallback dropped every track')
-        self.assertTrue(all(st._seg_side(t[6]) == cap.side for t in kept),
-                        'a track from the OTHER side survived: the fallback '
-                        'stopped filtering instead of using the side test')
-        self.assertLess(len(kept), len(st.segments),
-                        'the fallback kept every segment on the board')
-    # MUTATION: make the `_union is None` arm keep every segment -> the last
-    # two assertions fail.
+        self.assertIsNotNone(st._cap_pad_layers(cap),
+                             'layer scoping switched itself off')
+        for t in st.cap_segs[CAP]:
+            self.assertIn(t[6], st._all_cu)
+            self.assertTrue(any(t[6] in pl for pl in cap.pad_layers),
+                            'an off-layer track survived the fallback')
+        self.assertEqual(sorted(st._all_cu_ordered), sorted(st._all_cu))
+    # MUTATION: `self._all_cu = frozenset(board_info.copper_layers or ())`
+    # (drop the fallback) -> `_all_cu` is empty, `_cap_pad_layers` returns None
+    # and the assertIsNotNone fires.
+    #
+    # NB the prune's `_union is None` arm is deliberately NOT pinned by a
+    # mutation: with the fallback in place it is reachable only for a cap with
+    # zero copper pads, whose pad_rects is empty, so no assertion anywhere can
+    # observe what it keeps. Claiming a mutation for it would be an unearned
+    # MUTATION line -- the exact defect this file's review found elsewhere.
+
+    def test_EVERY_tracked_board_resolves_a_copper_list_and_stays_scoped(self):
+        """The invariant the prune's off-switch now rests on: `_all_cu` is
+        never empty, so layer scoping never silently degrades to the side
+        collapse on a real board."""
+        import subprocess
+        out = subprocess.run(['git', 'ls-files', '-z', 'kicad_files/*.kicad_pcb'],
+                             cwd=_ROOT, capture_output=True, text=True)
+        boards = [b for b in out.stdout.split(chr(0)) if b]
+        if not boards:
+            self.skipTest('git could not list the corpus')
+        checked = 0
+        for rel in boards:
+            path = os.path.join(_ROOT, rel)
+            pcb = parse_kicad_pcb(path)
+            st = _repair(path, pcb=pcb)
+            self.assertTrue(st._all_cu, '%s resolved no copper layers' % rel)
+            for ref, cap in st.caps.items():
+                self.assertIsNotNone(
+                    st._cap_pad_layers(cap),
+                    '%s %s: layer scoping switched off on a real board'
+                    % (rel, ref))
+                checked += 1
+        self.assertGreater(checked, 0, 'no cap on any tracked board')
+    # MUTATION: drop the segment-derived fallback for `_all_cu` -> a board
+    # whose (layers ...) stanza yields no copper fails the first assertion.
+
+    def test_a_cap_whose_pads_carry_NO_COPPER_is_graded_flat_in_the_TRACK_channel_too(self):
+        """4bbfa4de established that a copper-less pad is graded FLAT in every
+        channel: check_drc does not grade such a pad at all, so letting the
+        partner's netclass through would charge a keep-out that does not exist.
+
+        An empty per-pad union must therefore NOT read as 'scoping off'. It did
+        in the first version of #731, which switched the guard off for the
+        TRACK channel alone -- so `_flat_pad` read False and those pads were
+        charged at the partner's netclass, reinstating in one channel exactly
+        the phantom the previous commit removed from every other."""
+        import tempfile, json
+        with tempfile.TemporaryDirectory() as td:
+            from copy_board import copy_board
+            dst = os.path.join(td, 'b.kicad_pcb')
+            copy_board(BOARD, dst)
+            with open(os.path.splitext(dst)[0] + '.kicad_pro', 'w',
+                      encoding='utf-8') as f:
+                json.dump({'net_settings': {'classes': [
+                    {'name': 'Default', 'clearance': 0.4, 'track_width': 0.2,
+                     'via_diameter': 0.6, 'via_drill': 0.4,
+                     'priority': 2147483647}],
+                    'netclass_assignments': {}, 'netclass_patterns': []}}, f)
+            pcb = parse_kicad_pcb(dst)
+            for p in _copper_pads(pcb.footprints[CAP]):
+                p.layers = ['*.Cu', '*.Mask']
+                p.pad_type = 'np_thru_hole'
+                p.drill = 0.3
+            st = _repair(dst, pcb=pcb)
+            cap = st.caps[CAP]
+            # ON THE BRANCH: the model is active (0.4) and every pad of this
+            # cap really did resolve copper-less, or nothing is being tested.
+            self.assertIsNotNone(st._floors)
+            self.assertEqual(list(st._cap_pad_layers(cap)),
+                             [frozenset()] * len(cap.pads))
+            # The union is EMPTY but scoping stays ON -- that is the whole
+            # point. (None, None) here is what let the netclass through.
+            pl, union = st._cap_seg_scope(cap)
+            self.assertIsNotNone(pl, 'scoping switched off for the track '
+                                     'channel on a copper-less cap')
+            self.assertEqual(union, frozenset())
+            # A pad with no copper shares copper with nothing, so there is no
+            # track pair at all -- which is exactly what check_drc does with
+            # it (_pad_has_no_copper skips the pad outright). Charging such a
+            # pair, at ANY price, is the phantom.
+            self.assertEqual(st.cap_segs[CAP], [],
+                             '%d track pair(s) kept for a cap whose every pad '
+                             'is copper-less' % len(st.cap_segs[CAP]))
+            self.assertAlmostEqual(
+                st.seg_penalty(CAP, cap, cap.x, cap.y, cap.rot), 0.0, places=9)
+            # ON THE BRANCH / cross-channel: the PAD channel still grades these
+            # same pads, and grades them FLAT at 0.1 -- not at the 0.4 class.
+            # If the track channel disagreed with that, the two channels would
+            # be grading one cap two different ways, which is the defect.
+            prows = st._pad_effs(CAP, cap)
+            self.assertTrue(prows and prows[0], 'no foreign pad in reach')
+            self.assertEqual({round(v, 9) for r in prows for v in r}, {CLEAR})
+    # MUTATION: `return (pl, u) if u else (None, None)` in `_cap_seg_scope` ->
+    # `union` reads None, the track pairs come back and are charged at the 0.4
+    # netclass while the pad channel still says 0.1.
+
+
+    def test_the_PRUNE_keeps_a_track_on_a_layer_the_board_does_not_declare(self):
+        """The prune's `layer in self._all_cu` conjunct, tested where it lives.
+
+        `test_an_INJECTED_tuple_with_an_UNRECOGNISED_layer_is_still_graded`
+        pins the same invariant on the GRADING side, but it injects into
+        `cap_segs` AFTER the prune, so it never reaches this arm -- deleting
+        the conjunct survived that test. A track on a layer the board's copper
+        list omits must be KEPT (and charged): check_drc reaches such a segment
+        through its own segment-derived fallback, so dropping it under-blocks.
+        """
+        pcb = parse_kicad_pcb(BOARD)
+        pads = _copper_pads(pcb.footprints[CAP])
+        target = pads[0]
+        x0, x1 = target.global_x - target.size_x / 2, target.global_x + target.size_x / 2
+        keepout = TRACK_W / 2 + CLEAR
+        ty = target.global_y - target.size_y / 2 - keepout + BITE
+        seg = make_seg(x0 - 1.0, ty, x1 + 1.0, ty, layer='In9.Cu',
+                       net_id=FOREIGN_NET, width=TRACK_W)
+        pcb.segments = [seg]
+        pcb.vias = []
+        st = _repair(BOARD, pcb=pcb)
+        cap = st.caps[CAP]
+        # ON THE BRANCH: the layer really is absent from the board's list and
+        # from the pad's set, so only the `_all_cu` conjunct can save it.
+        self.assertNotIn('In9.Cu', st._all_cu)
+        self.assertNotIn('In9.Cu', cap.pad_layers[0])
+        self.assertTrue(st.cap_segs[CAP],
+                        'a track on an UNDECLARED layer was pruned away -- '
+                        'check_drc still reaches it, so this under-blocks')
+        self.assertAlmostEqual(
+            st.seg_penalty(CAP, cap, cap.x, cap.y, cap.rot), BITE, places=9)
+    # MUTATION: drop the `layer in self._all_cu` conjunct from the PRUNE
+    # (`elif layer not in _union: continue`) -> the track is dropped and the
+    # penalty reads 0.0.
+
+    def test_a_COPPERLESS_pad_meeting_an_UNKNOWN_layer_is_charged_FLAT(self):
+        """`_seg_effs`' `elif flat_pad:` arm.
+
+        Reaching it takes a precise combination, which is why a naive fixture
+        cannot pin it. A copper-less pad against a REAL layer is already
+        removed by `_seg_shares`; against an unknown layer whose segment has no
+        registered floor, the flat arm and the fallback both yield the same
+        number. The arm only bites for a copper-less pad meeting a segment that
+        is BOTH on a layer the board does not declare AND carries a resolved
+        netclass floor -- and then the difference is the whole netclass."""
+        import tempfile, json
+        from copy_board import copy_board
+        with tempfile.TemporaryDirectory() as td:
+            dst = os.path.join(td, 'b.kicad_pcb')
+            copy_board(BOARD, dst)
+            with open(os.path.splitext(dst)[0] + '.kicad_pro', 'w',
+                      encoding='utf-8') as f:
+                json.dump({'net_settings': {'classes': [
+                    {'name': 'Default', 'clearance': 0.4, 'track_width': 0.2,
+                     'via_diameter': 0.6, 'via_drill': 0.4,
+                     'priority': 2147483647}],
+                    'netclass_assignments': {}, 'netclass_patterns': []}}, f)
+            pcb = parse_kicad_pcb(dst)
+            pads = _copper_pads(pcb.footprints[CAP])
+            for pad in pads:
+                pad.layers = ['*.Cu', '*.Mask']
+                pad.pad_type = 'np_thru_hole'
+                pad.drill = 0.3
+            target = pads[0]
+            x0 = target.global_x - target.size_x / 2
+            x1 = target.global_x + target.size_x / 2
+            keepout = TRACK_W / 2 + CLEAR
+            ty = target.global_y - target.size_y / 2 - keepout + BITE
+            pcb.segments = [make_seg(x0 - 1.0, ty, x1 + 1.0, ty,
+                                     layer='In9.Cu', net_id=FOREIGN_NET,
+                                     width=TRACK_W)]
+            pcb.vias = []
+            st = _repair(dst, pcb=pcb)
+            cap = st.caps[CAP]
+            # ON THE BRANCH, all four conditions the arm needs:
+            self.assertIsNotNone(st._floors)                 # model active
+            self.assertEqual(cap.pad_layers[0], frozenset())  # copper-less pad
+            self.assertNotIn('In9.Cu', st._all_cu)            # unknown layer
+            t = st.segments[0]
+            floor = st._seg_floor_by_id.get(id(t))
+            self.assertIsNotNone(floor, 'the segment carries no floor, so the '
+                                        'flat arm and the fallback agree and '
+                                        'this test cannot discriminate')
+            self.assertAlmostEqual(floor.ncl, 0.4, places=6)
+            self.assertTrue(st.cap_segs[CAP], 'the unknown-layer track was '
+                                              'pruned away')
+            rows = st._seg_effs(CAP, cap)
+            half = t[5] - st._item_reach(floor)
+            self.assertAlmostEqual(rows[0][0], half + CLEAR, places=9,
+                                   msg='a copper-less pad was charged %r; the '
+                                       'flat price is %r and the netclass '
+                                       'price is %r'
+                                       % (rows[0][0], half + CLEAR, half + 0.4))
+    # MUTATION: delete the `elif flat_pad:` arm in `_seg_effs` -> the cell is
+    # priced at the 0.4 netclass instead of the flat 0.1.
 
 
 class TestShapeAndClassification(unittest.TestCase):
@@ -602,15 +812,29 @@ class TestShapeAndClassification(unittest.TestCase):
     # MUTATION: put `side` back in element 6 -> `assertIn(t[6], _all_cu)` fails.
 
     def test_this_file_is_collected_as_a_FAST_test(self):
-        """This file names the integration markers in its own prose, which is
-        exactly how the #725 file got bucketed as integration and skipped under
-        --fast (commit 6c2096c6)."""
+        """A file bucketed as integration is skipped under --fast, and a test
+        file that proves nothing is worse than none (6c2096c6).
+
+        Note what this does and does not pin. The opt-out marker is currently
+        INERT -- this file contains none of the literal strings the classifier
+        greps for, so deleting `RUN_ALL_FAST_OK = True` changes nothing today.
+        Asserting on the marker would therefore be asserting on a value the
+        branch does not key on. What is worth pinning is the OUTCOME: the file
+        is collected and it is fast. The second half below is the one that
+        would fail if a later edit introduced a marker string while the opt-out
+        had been dropped."""
         import run_all
-        self.assertFalse(run_all.is_integration(os.path.abspath(__file__)))
+        path = os.path.abspath(__file__)
+        self.assertFalse(run_all.is_integration(path))
         found = [os.path.basename(f) for f in run_all.discover(['731'])]
         self.assertIn(os.path.basename(__file__), found)
-    # MUTATION: delete the `RUN_ALL_FAST_OK = True` line -> is_integration
-    # returns True and the file is skipped under --fast.
+        # The opt-out must still be present, because it is the only thing that
+        # keeps the line above true if the source ever gains a marker string.
+        src = io.open(path, encoding='utf-8').read()
+        self.assertIn('RUN_ALL_FAST_OK = True', src)
+    # MUTATION: delete the `RUN_ALL_FAST_OK = True` line AND add `import
+    # subprocess` -> is_integration returns True. Deleting the marker alone is
+    # caught only by the last assertion, which is why it is written out.
 
 
 if __name__ == '__main__':

--- a/tests/test_731_fanout_clearance_track_layer_scope.py
+++ b/tests/test_731_fanout_clearance_track_layer_scope.py
@@ -1,0 +1,570 @@
+"""#731: the fanout-clearance repair pass must grade a cap pad against a track
+only when the two SHARE A REAL COPPER LAYER -- the same predicate check_drc
+gates on -- instead of against an 'F'/'B' board SIDE that files every
+non-B layer under 'F'.
+
+The collapse was wrong in both directions. It ADDED pairs an F-side cap pad can
+never touch (928 of them on orangecrab at --clearance 0.1, 0.2464mm of phantom
+seed graze against 0.0000mm of real; R17/R18/R5's entire bill), and it DROPPED
+the B.Cu and inner-layer tracks a THROUGH-HOLE cap pad really does share copper
+with. Neither is academic: on rp2350 -- a board that is DRC-clean as it ships --
+the old pass moved C19 to clear a phantom and put its GND pad 0.145mm inside a
+real F.Cu track, so the step introduced a PAD-SEGMENT violation.
+
+Conventions this file follows (from #697/#725 and CLAUDE.md):
+
+  * REAL parser dataclasses and REAL boards. `_Repair.__init__` reads courtyards
+    and locked refs from the file on disk, so even a synthetic case needs a file.
+  * Every assertion names the single-line MUTATION that must kill it.
+  * Assert you are ON the branch before asserting about it -- each test spies the
+    value its branch keys on, with a detail string saying why.
+  * A removal test needs a NEGATIVE CONTROL, or it passes just as well on a build
+    that deleted the whole channel. Every "is not charged" here is paired with an
+    "and this one still is".
+
+Nothing here shells out or drives a CLI: it runs entirely in-process in ~25 s.
+`run_all.is_integration` classifies by grepping the SOURCE for `run_utils` and
+the name of the standard sub-process module, and this file NAMES those markers
+in prose (including in this sentence), which is how the first version of the
+#725 file got bucketed as integration and silently skipped under `--fast`.
+Hence the explicit opt-out below.
+"""
+from __future__ import annotations
+
+RUN_ALL_FAST_OK = True
+
+import copy
+import inspect
+import os
+import sys
+import unittest
+
+_TESTS = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_TESTS)
+for _p in ('', 'py_router', 'py_placer', 'py_tools'):
+    _d = os.path.join(_ROOT, _p)
+    if _d not in sys.path:
+        sys.path.insert(0, _d)
+if _TESTS not in sys.path:
+    sys.path.insert(0, _TESTS)
+
+from kicad_parser import parse_kicad_pcb
+from synth import make_seg
+import check_drc
+from check_drc import check_pad_segment_overlap, pad_copper_layers
+from placement.legality import PadClearanceModel
+from placement.fanout_clearance import (_Cap, _OFF_LAYER, _Repair,
+                                        repair_fanout_clearance)
+
+BOARD = os.path.join(_ROOT, 'kicad_files', 'orangecrab_ext_pll.kicad_pcb')
+INERT = os.path.join(_ROOT, 'kicad_files',
+                     'rp2350_fpga_eensy_prePlane.kicad_pcb')
+CLEAR = 0.1
+
+# R17 is an F-side 0402 near a BGA with two copper pads (net 69 / net 70) and
+# two paste-only apertures that _Cap's copper filter drops. Its ENTIRE seed
+# graze before #731 was phantom In1.Cu track pairs.
+CAP = 'R17'
+PHANTOM_CAPS = ('R17', 'R18', 'R5')
+FOREIGN_NET = 2          # neither 69 nor 70
+TRACK_W = 0.1            # half width 0.05, so keep-out = 0.05 + CLEAR
+BITE = 0.05              # how far inside the keep-out band the track sits
+
+# The cap prefix the CLI defaults to. NOT 'C': with 'C' alone the movable set is
+# 51 caps and R17/R18/R5 -- the three this issue is about -- never appear.
+PREFIX = 'C,R,FB'
+
+# Measured on the stock boards at CLEAR, before #731 (see the PR body).
+PRE_FIX_OFF_LAYER_PAIRS = 928       # orangecrab, same-net pairs included
+PRE_FIX_PHANTOM_MM = 0.246393       # orangecrab seed graze, all of it phantom
+PRE_FIX_INERT_OFF_PAIRS = 2342      # rp2350
+BOTH_GRADED = 618                   # orangecrab pairs check_drc DOES grade
+
+
+def _repair(path, pcb=None, clearance=CLEAR, prefix=PREFIX):
+    """The 10-POSITIONAL construction every test in this family uses."""
+    return _Repair(pcb if pcb is not None else parse_kicad_pcb(path), path,
+                   clearance, 0.1, 0.55, 1.0, 2.0, 0.3, prefix, set())
+
+
+def _routing_layers(pcb):
+    """check_drc's own layer list for the overlap checks."""
+    return [l for l in (pcb.board_info.copper_layers or [])
+            if l.endswith('.Cu')]
+
+
+def _as_through(pad, layers=('*.Cu', '*.Mask')):
+    """Convert a copper pad in place into a plated through-hole pad."""
+    pad.layers = list(layers)
+    pad.pad_type = 'thru_hole'
+    pad.drill = 0.3
+    return pad
+
+
+def _copper_pads(fp):
+    """The pads _Cap keeps, in _Cap's own order (its loose endswith filter)."""
+    return [p for p in fp.pads
+            if any(str(l).endswith('.Cu') for l in p.layers)]
+
+
+class TestTheTruthTable(unittest.TestCase):
+    """One real cap, one synthetic track, every (pad kind, track layer) cell --
+    graded by the pass and by check_drc, and required to agree."""
+
+    def _case(self, layer, through=False, pad_index=0, net=FOREIGN_NET):
+        """Build R17 with exactly one foreign track biting `BITE` into the
+        keep-out band of `pad_index`, and return (seg_penalty, drc, st, pcb)."""
+        pcb = parse_kicad_pcb(BOARD)
+        fp = pcb.footprints[CAP]
+        pads = _copper_pads(fp)
+        if through:
+            for p in pads:
+                _as_through(p)
+        target = pads[pad_index]
+        x0, x1 = target.global_x - target.size_x / 2, target.global_x + target.size_x / 2
+        y0 = target.global_y - target.size_y / 2
+        # A horizontal track below the pad rect: distance = keepout - BITE.
+        keepout = TRACK_W / 2 + CLEAR
+        ty = y0 - keepout + BITE
+        seg = make_seg(x0 - 1.0, ty, x1 + 1.0, ty,
+                       layer=layer, net_id=net, width=TRACK_W)
+        pcb.segments = [seg]
+        pcb.vias = []
+        st = _repair(BOARD, pcb=pcb)
+        cap = st.caps[CAP]
+        pen = st.seg_penalty(CAP, cap, cap.x, cap.y, cap.rot)
+        drc = check_pad_segment_overlap(target, seg, CLEAR,
+                                        _routing_layers(pcb),
+                                        clearance_margin=0.0)
+        return pen, drc, st, pcb
+
+    def test_an_INNER_layer_track_is_not_charged_against_an_F_side_SMD_pad(self):
+        """The whole issue, on one cap: an In1.Cu track cannot touch an F.Cu
+        pad, and check_drc grades no such pair."""
+        for layer in ('In1.Cu', 'In2.Cu', 'In3.Cu', 'In4.Cu'):
+            pen, drc, st, _ = self._case(layer)
+            # ON THE BRANCH: the cap really is F-side and really is scoped,
+            # or "not charged" could be true for an unrelated reason.
+            self.assertEqual(st.caps[CAP].side, 'F')
+            self.assertIsNotNone(st._cap_pad_layers(st.caps[CAP]))
+            self.assertFalse(drc[0], '%s: check_drc changed its mind' % layer)
+            self.assertAlmostEqual(pen, 0.0, places=9,
+                                   msg='%s track charged %.6f against an F.Cu '
+                                       'pad' % (layer, pen))
+    # MUTATION: revert the prune to `if seg[6] != cap.side: continue` -> every
+    # arm charges BITE (0.05).
+
+    def test_the_SAME_geometry_on_F_Cu_IS_still_charged(self):
+        """The negative control. Without it, a build that deleted track grading
+        outright would satisfy the test above perfectly."""
+        pen, drc, st, _ = self._case('F.Cu')
+        # ON THE BRANCH: the track must actually be in the pruned list, or
+        # "charged" is being decided somewhere other than the layer gate.
+        self.assertTrue(st.cap_segs[CAP],
+                        'the F.Cu track was pruned away -- the layer gate is '
+                        'dropping copper the cap really does share')
+        self.assertTrue(drc[0])
+        self.assertAlmostEqual(pen, BITE, places=9)
+        self.assertAlmostEqual(pen, drc[1], places=6,
+                               msg='the pass and check_drc disagree on the '
+                                   'overlap of a pair they both grade')
+    # MUTATION: make `_seg_shares` return False always -> this goes red while
+    # the inner-layer test above stays green.
+
+    def test_a_THROUGH_HOLE_cap_pad_KEEPS_the_B_Cu_track(self):
+        """The mirror. A through-hole pad's copper spans every layer, so the
+        side collapse DROPPED the B.Cu track it really does share -- an
+        UNDER-block, which is the direction that ships a violation."""
+        pen, drc, st, _ = self._case('B.Cu', through=True)
+        cap = st.caps[CAP]
+        # ON THE BRANCH: the pad must span all copper and the cap must be
+        # F-side, or this is not the cross-side case at all.
+        self.assertEqual(cap.side, 'F')
+        self.assertEqual(len(cap.pad_layers[0]), 6,
+                         'the through-hole pad did not resolve every copper '
+                         'layer: %r' % (cap.pad_layers[0],))
+        self.assertTrue(drc[0], 'check_drc does not grade this pair either -- '
+                                'the fixture is wrong, not the engine')
+        self.assertAlmostEqual(pen, BITE, places=9,
+                               msg='the B.Cu track was dropped for a pad whose '
+                                   'copper spans it')
+    # MUTATION: keep the side test as an AND alongside the layer test
+    # (`if self._seg_side(layer) != cap.side or ...`) -> the B.Cu track is
+    # dropped again and this reads 0.0, while the two tests above stay green.
+
+    def test_every_cell_agrees_with_check_pad_segment_overlap(self):
+        """Parity with the authority, over the whole 2 x 4 table."""
+        seen_true = seen_false = 0
+        for through in (False, True):
+            for layer in ('F.Cu', 'In1.Cu', 'In2.Cu', 'B.Cu'):
+                pen, drc, _, _ = self._case(layer, through=through)
+                cell = '%s pad vs %s' % ('THT' if through else 'SMD', layer)
+                self.assertEqual(pen > 1e-9, bool(drc[0]),
+                                 '%s: pass says %.6f, check_drc says %r'
+                                 % (cell, pen, drc[0]))
+                if drc[0]:
+                    seen_true += 1
+                    self.assertAlmostEqual(pen, drc[1], places=6, msg=cell)
+                else:
+                    seen_false += 1
+        # ON THE BRANCH: the table must contain both verdicts, or agreement is
+        # trivial (all-clear agrees with all-clear).
+        self.assertGreater(seen_true, 0)
+        self.assertGreater(seen_false, 0)
+    # MUTATION: build `pad_layers` from `frozenset(p.layers)` instead of
+    # `pad_copper_layers(p, board_copper)` -> a `*.Cu` pad resolves to
+    # {'*.Cu'}, matches no seg.layer, and all four THT rows read 0.0.
+
+    def test_a_MIXED_pad_cap_scopes_PER_PAD_not_by_the_UNION(self):
+        """The prune keeps the UNION of a cap's pad layers (a superset, so it
+        can never drop a chargeable pair); the GRADING must then apply the
+        exact per-pad set. A cap with one through-hole pad beside one F.Cu SMD
+        pad is the only shape where the two answers differ."""
+        pcb = parse_kicad_pcb(BOARD)
+        pads = _copper_pads(pcb.footprints[CAP])
+        _as_through(pads[0])                      # pad 0 spans all copper
+        target = pads[1]                          # pad 1 stays F.Cu only
+        x0, x1 = target.global_x - target.size_x / 2, target.global_x + target.size_x / 2
+        keepout = TRACK_W / 2 + CLEAR
+        ty = target.global_y - target.size_y / 2 - keepout + BITE
+        seg = make_seg(x0 - 1.0, ty, x1 + 1.0, ty,
+                       layer='B.Cu', net_id=FOREIGN_NET, width=TRACK_W)
+        pcb.segments = [seg]
+        pcb.vias = []
+        st = _repair(BOARD, pcb=pcb)
+        cap = st.caps[CAP]
+        # ON THE BRANCH: the two pads must really differ, or per-pad and union
+        # are the same answer and this test cannot tell them apart.
+        self.assertEqual(len(cap.pad_layers[0]), 6)
+        self.assertEqual(sorted(cap.pad_layers[1]), ['F.Cu'])
+        rl = _routing_layers(pcb)
+        d_tht = check_pad_segment_overlap(pads[0], seg, CLEAR, rl,
+                                          clearance_margin=0.0)
+        d_smd = check_pad_segment_overlap(target, seg, CLEAR, rl,
+                                          clearance_margin=0.0)
+        # check_drc grades the THT pad and not the SMD one; the pass must bill
+        # exactly the same total.
+        self.assertTrue(d_tht[0])
+        self.assertFalse(d_smd[0])
+        pen = st.seg_penalty(CAP, cap, cap.x, cap.y, cap.rot)
+        self.assertAlmostEqual(pen, d_tht[1], places=6,
+                               msg='billed %.6f; the union would bill the SMD '
+                                   'pad too' % pen)
+        # ...and the off-layer cell really is the sentinel, not a small number.
+        rows = st._seg_effs(CAP, cap)
+        self.assertEqual(rows[1][0], _OFF_LAYER)
+        self.assertNotEqual(rows[0][0], _OFF_LAYER)
+    # MUTATION: grade with `union(cap.pad_layers)` instead of
+    # `cap.pad_layers[i]` -> the SMD pad is billed too and the total rises.
+
+
+class TestTheSeedPhantomIsGone(unittest.TestCase):
+    """The board-level claim, on the board the issue was measured on."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.pcb = parse_kicad_pcb(BOARD)
+        cls.st = _repair(BOARD, pcb=cls.pcb)
+        cls.rl = _routing_layers(cls.pcb)
+
+    def test_no_pruned_pair_is_one_check_drc_would_IGNORE(self):
+        """Every (cap pad, pruned track) pair must be one check_drc grades."""
+        st, pcb = self.st, self.pcb
+        both = ignored = 0
+        for ref, cap in st.caps.items():
+            pads = _copper_pads(pcb.footprints[ref])
+            self.assertEqual(len(pads), len(cap.pads),
+                             '%s: pad list misaligned with _Cap' % ref)
+            for p in pads:
+                expanded = pad_copper_layers(p, pcb.board_info.copper_layers)
+                for t in st.cap_segs[ref]:
+                    if t[6] in expanded:
+                        both += 1
+                    else:
+                        ignored += 1
+        self.assertEqual(ignored, 0,
+                         '%d pruned pair(s) are ones check_drc does not grade '
+                         '(was %d before #731)'
+                         % (ignored, PRE_FIX_OFF_LAYER_PAIRS))
+        # ON THE BRANCH: 0/0 would also satisfy the line above.
+        self.assertEqual(both, BOTH_GRADED,
+                         'the number of REAL pairs moved: %d, expected %d'
+                         % (both, BOTH_GRADED))
+    # MUTATION: revert the prune to the side collapse -> `ignored` returns to
+    # 928. MUTATION: make `_seg_shares` return False -> `both` collapses to 0.
+
+    def test_R17_R18_R5_have_NO_seed_graze_left_in_ANY_channel(self):
+        """Their entire bill was off-layer track graze -- 0.0821mm each -- so
+        they were violators, were moved, and were candidates for the via
+        nudger, which moves real vias and appends real segments."""
+        st = self.st
+        for ref in PHANTOM_CAPS:
+            cap = st.caps[ref]
+            x, y, rot = cap.x, cap.y, cap.rot
+            # Named per channel so the test says WHY, not just that it is 0.
+            self.assertAlmostEqual(
+                st.via_penalty(cap, x, y, rot, st.cap_vias[ref], ref=ref),
+                0.0, places=9, msg='%s via graze' % ref)
+            self.assertAlmostEqual(st.pad_penalty(ref, cap, x, y, rot),
+                                   0.0, places=9, msg='%s pad graze' % ref)
+            self.assertAlmostEqual(st.seg_penalty(ref, cap, x, y, rot),
+                                   0.0, places=9, msg='%s track graze' % ref)
+            self.assertAlmostEqual(st.graze_penalty(ref, cap, x, y, rot),
+                                   0.0, places=9, msg='%s total' % ref)
+    # MUTATION: revert the prune -> each reads 0.0821.
+
+    def test_the_boards_whole_seed_track_graze_is_zero_and_was_not(self):
+        """0.246393mm before #731, every micron of it off-layer: this board has
+        NO on-layer seed track graze at all, which is why check_drc reports
+        zero PAD-SEGMENT violations on it."""
+        st = self.st
+        total = sum(st.seg_penalty(r, c, c.x, c.y, c.rot)
+                    for r, c in st.caps.items())
+        self.assertAlmostEqual(total, 0.0, places=9,
+                               msg='%.6f mm of seed track graze remains (was '
+                                   '%.6f, all phantom)'
+                                   % (total, PRE_FIX_PHANTOM_MM))
+        # ON THE BRANCH: there must be tracks in the pruned lists at all.
+        self.assertGreater(sum(len(v) for v in st.cap_segs.values()), 0)
+    # MUTATION: revert the prune -> the total reads 0.246393.
+
+
+class TestTheInertPath(unittest.TestCase):
+    """The case a fix built on #725's side-channels would have MISSED.
+
+    rp2350 declares no netclass, no .kicad_dru and no pad override, so
+    PadClearanceModel is inert -- and before #731 both layer side-channels were
+    gated on it. It is also 6 copper layers and carried 4.6685mm of phantom
+    seed graze against 0.0142mm of real, the largest phantom measured anywhere.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.pcb = parse_kicad_pcb(INERT)
+        cls.st = _repair(INERT, pcb=cls.pcb)
+
+    def test_layer_scoping_SURVIVES_a_board_that_declares_nothing(self):
+        st = self.st
+        # ON THE BRANCH: the model really must be inert, or this passes for the
+        # wrong reason -- it would just be testing the active path again.
+        self.assertIsNone(st._floors,
+                          'rp2350 built a clearance model; this fixture no '
+                          'longer tests the inert path')
+        self.assertTrue(st._all_cu, 'no copper layers -> scoping switches off')
+        for ref, cap in st.caps.items():
+            self.assertTrue(cap.pad_layers,
+                            '%s has no pad_layers on an inert board' % ref)
+            self.assertIsNotNone(st._cap_pad_layers(cap),
+                                 '%s: layer scoping switched itself off' % ref)
+        off = sum(1 for ref, cap in st.caps.items()
+                  for t in st.cap_segs[ref]
+                  if not any(t[6] in pl for pl in cap.pad_layers))
+        self.assertEqual(off, 0,
+                         '%d off-layer pair(s) survived on the inert board '
+                         '(was %d)' % (off, PRE_FIX_INERT_OFF_PAIRS))
+    # MUTATION: move the `pad_layers` build back inside `if model is not None:`
+    # -> pad_layers is [] here and every assertion above fails.
+    # MUTATION: re-anchor `_cap_pad_layers` on `pad_floors` -> it returns None
+    # on this board and `off` returns to 2342.
+
+    def test_the_model_is_STILL_never_consulted_on_an_inert_board(self):
+        """The layer data must come from `board_info.copper_layers`, never from
+        `model.board_copper` -- sourcing it from the model would ACTIVATE the
+        model on a board that declares nothing."""
+        hits = [0]
+        orig = PadClearanceModel.pair
+
+        def counting(self, a, b):
+            hits[0] += 1
+            return orig(self, a, b)
+        PadClearanceModel.pair = counting
+        try:
+            r = repair_fanout_clearance(parse_kicad_pcb(INERT), INERT,
+                                        clearance=CLEAR)
+        finally:
+            PadClearanceModel.pair = orig
+        self.assertEqual(hits[0], 0,
+                         'the model was consulted %d times on a board that '
+                         'declares nothing' % hits[0])
+        # ON THE BRANCH: the run must have done something, or 0 calls is
+        # trivially true.
+        self.assertTrue(r['bga_refs'])
+    # MUTATION: source `board_copper` from a `PadClearanceModel.for_board`
+    # call instead of `self._all_cu` -> hits > 0.
+
+    def test_an_ON_layer_inert_cell_is_the_tuples_own_half_width_BIT_EXACTLY(self):
+        """`t[5] - clearance + clearance` is not float-identical to `t[5]`, and
+        this file's contract is that an inert board is BYTE-identical. Asserted
+        with assertEqual, not assertAlmostEqual."""
+        st = self.st
+        checked = 0
+        for ref, cap in st.caps.items():
+            rows = st._seg_effs(ref, cap)
+            self.assertIsNotNone(rows, '%s got no eff matrix' % ref)
+            for i in range(len(cap.pads)):
+                for j, t in enumerate(st.cap_segs[ref]):
+                    self.assertNotEqual(
+                        rows[i][j], _OFF_LAYER,
+                        '%s: an off-layer pair survived the prune' % ref)
+                    self.assertEqual(rows[i][j], t[5],
+                                     '%s pad %d vs track %d: %r != %r'
+                                     % (ref, i, j, rows[i][j], t[5]))
+                    checked += 1
+        self.assertGreater(checked, 0, 'no inert pair was examined')
+    # MUTATION: replace the `t[5]` arm with `halves[j] + self.clearance` -> the
+    # assertEqual fails on the pairs where the float round-trip is lossy.
+
+    def test_the_inert_boards_recorded_result_is_the_NEW_one(self):
+        """Six of rp2350's eight caps were violators purely on phantom. Only
+        C18 (0.0106mm on-layer) and C23 (0.0036mm) have anything real; C18 is
+        resolved and C23 is the one cap that legitimately remains unresolved."""
+        r = repair_fanout_clearance(parse_kicad_pcb(INERT), INERT,
+                                    clearance=CLEAR)
+        self.assertEqual(len(r['placements']), 1)
+        self.assertEqual(sorted(r['unresolved']), ['C23'])
+        self.assertEqual(sorted(r['resolved']), ['C18'])
+        self.assertEqual(r['required'], [], 'an inert board discloses nothing')
+    # MUTATION: any revert of the prune, the unconditional pad_layers, or the
+    # `_cap_pad_layers` anchor -> the 7-ref unresolved list comes back.
+
+
+class TestTheOffSwitches(unittest.TestCase):
+    """The three ways layer scoping must decline to act."""
+
+    def _one_track_board(self, layer, net=FOREIGN_NET):
+        pcb = parse_kicad_pcb(BOARD)
+        pads = _copper_pads(pcb.footprints[CAP])
+        target = pads[0]
+        x0, x1 = target.global_x - target.size_x / 2, target.global_x + target.size_x / 2
+        keepout = TRACK_W / 2 + CLEAR
+        ty = target.global_y - target.size_y / 2 - keepout + BITE
+        pcb.segments = [make_seg(x0 - 1.0, ty, x1 + 1.0, ty, layer=layer,
+                                 net_id=net, width=TRACK_W)]
+        pcb.vias = []
+        return pcb
+
+    def test_an_INJECTED_tuple_with_an_UNRECOGNISED_layer_is_still_graded(self):
+        """A tuple a test injects carries whatever it likes in the layer slot --
+        `tests/test_fanout_clearance.py` injects the cap's own 'F'/'B' side.
+        An UNKNOWN layer must be CHARGED: over-blocking is the only direction
+        that can never ship a violation, and this is the arm that replaced
+        #725's `sl is None` fallback."""
+        pcb = self._one_track_board('F.Cu')
+        st = _repair(BOARD, pcb=pcb)
+        cap = st.caps[CAP]
+        real = st.cap_segs[CAP][0]
+        for slot in ('F', 'B', None, 'Nonsense.Cu'):
+            injected = real[:6] + (slot,)
+            st.cap_segs[CAP] = [injected]
+            st._cap_seg_eff.pop(CAP, None)
+            # ON THE BRANCH: the slot really is not a board copper layer.
+            self.assertNotIn(slot, st._all_cu)
+            pen = st.seg_penalty(CAP, cap, cap.x, cap.y, cap.rot)
+            self.assertGreater(pen, 1e-6,
+                               'an injected tuple with layer slot %r was '
+                               'silently dropped' % (slot,))
+    # MUTATION: drop the `layer not in self._all_cu` arm of `_seg_shares` ->
+    # every injected tuple grades 0 and
+    # test_fanout_clearance::test_seed_track_graze_is_resolved goes red too.
+
+    def test_an_INJECTED_OFF_LAYER_tuple_is_NOT_charged(self):
+        """The GRADING skip, tested independently of the prune. With the prune
+        working, no real board can put an off-layer pair in front of
+        `_seg_shortfalls` -- so without this test a mutation that deletes the
+        per-pad gate is caught by nothing."""
+        pcb = self._one_track_board('F.Cu')
+        st = _repair(BOARD, pcb=pcb)
+        cap = st.caps[CAP]
+        real = st.cap_segs[CAP][0]
+        # ON THE BRANCH: the same tuple on its real layer IS charged.
+        self.assertGreater(st.seg_penalty(CAP, cap, cap.x, cap.y, cap.rot), 1e-6)
+        st.cap_segs[CAP] = [real[:6] + ('In1.Cu',)]
+        st._cap_seg_eff.pop(CAP, None)
+        self.assertIn('In1.Cu', st._all_cu)
+        self.assertNotIn('In1.Cu', cap.pad_layers[0])
+        pen = st.seg_penalty(CAP, cap, cap.x, cap.y, cap.rot)
+        self.assertAlmostEqual(pen, 0.0, places=9,
+                               msg='an off-layer tuple was charged %.6f' % pen)
+    # MUTATION: delete the `_seg_shares` branch in `_seg_effs` -> this reads
+    # BITE (0.05) while every board-level test stays green.
+
+    def test_a_board_with_NO_copper_layers_falls_back_to_the_SIDE_collapse(self):
+        """`pad_copper_layers(p, [])` resolves nothing for a `*.Cu` pad, so
+        every pad would read copper-less and every pair would take the
+        off-layer path -- an UNDER-block, which ships violations. Scoping
+        switches off wholesale. It must fall back to the OLD side test, NOT to
+        keeping every segment on the board: check_drc still layer-scopes such a
+        board (its routing_layers falls back to the segment-derived set), so
+        the placer must stay on the over-block side."""
+        pcb = parse_kicad_pcb(BOARD)
+        pcb.board_info.copper_layers = []
+        st = _repair(BOARD, pcb=pcb)
+        self.assertEqual(st._all_cu, frozenset())
+        cap = st.caps[CAP]
+        self.assertIsNone(st._cap_pad_layers(cap),
+                          'layer scoping stayed on with no copper layers')
+        # ON THE BRANCH: the board must carry tracks on BOTH sides, or "did not
+        # keep everything" cannot be distinguished from "kept everything".
+        sides = {st._seg_side(t[6]) for t in st.segments}
+        self.assertEqual(sides, {'F', 'B'})
+        kept = st.cap_segs[CAP]
+        self.assertTrue(kept, 'the fallback dropped every track')
+        self.assertTrue(all(st._seg_side(t[6]) == cap.side for t in kept),
+                        'a track from the OTHER side survived: the fallback '
+                        'stopped filtering instead of using the side test')
+        self.assertLess(len(kept), len(st.segments),
+                        'the fallback kept every segment on the board')
+    # MUTATION: make the `_union is None` arm keep every segment -> the last
+    # two assertions fail.
+
+
+class TestShapeAndClassification(unittest.TestCase):
+
+    def test_the_Cap_constructor_takes_board_copper_POSITIONALLY(self):
+        """`board_copper` must be a real parameter, not a defaulted one that a
+        3-positional caller silently skips: with a default of `()`, every
+        `*.Cu` pad would resolve to the EMPTY set and read as copper-less --
+        the fix would look present and grade nothing."""
+        names = list(inspect.signature(_Cap.__init__).parameters)
+        self.assertEqual(names[1:5],
+                         ['fp', 'courtyard_local', 'model', 'board_copper'])
+        pcb = parse_kicad_pcb(BOARD)
+        fp = pcb.footprints[CAP]
+        cu = pcb.board_info.copper_layers
+        cap = _Cap(fp, (-0.5, -0.5, 0.5, 0.5), None, cu)
+        # Built with NO model at all, and still resolves real layers.
+        self.assertEqual(cap.pad_floors, [])
+        self.assertEqual(sorted(cap.pad_layers[0]), ['F.Cu'])
+        self.assertEqual(len(cap.pad_layers), len(cap.pads))
+    # MUTATION: gate the pad_layers build on `model is not None` -> pad_layers
+    # is [] here. MUTATION: rename or reorder the parameter -> the name list
+    # differs.
+
+    def test_the_segment_tuple_is_still_SEVEN_wide_and_carries_a_LAYER(self):
+        """#731 replaced element 6 rather than widening the tuple, because
+        `_seg_shortfalls` unpacks it positionally in two places and
+        test_725's TestShapeContract pins the width."""
+        st = _repair(BOARD)
+        self.assertTrue(st.segments)
+        for t in st.segments[:50]:
+            self.assertEqual(len(t), 7)
+            self.assertIn(t[6], st._all_cu)
+        self.assertFalse(hasattr(st, '_seg_layer_by_id'),
+                         'the companion layer map is back -- there are two '
+                         'answers to "what layer is this track on" again')
+    # MUTATION: put `side` back in element 6 -> `assertIn(t[6], _all_cu)` fails.
+
+    def test_this_file_is_collected_as_a_FAST_test(self):
+        """This file names the integration markers in its own prose, which is
+        exactly how the #725 file got bucketed as integration and skipped under
+        --fast (commit 6c2096c6)."""
+        import run_all
+        self.assertFalse(run_all.is_integration(os.path.abspath(__file__)))
+        found = [os.path.basename(f) for f in run_all.discover(['731'])]
+        self.assertIn(os.path.basename(__file__), found)
+    # MUTATION: delete the `RUN_ALL_FAST_OK = True` line -> is_integration
+    # returns True and the file is skipped under --fast.
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/test_732_fanout_clearance_via_radius.py
+++ b/tests/test_732_fanout_clearance_via_radius.py
@@ -1,0 +1,613 @@
+"""#732: a via's RADIUS must have ONE resolver in the fanout-clearance pass.
+
+`_Repair.__init__` built its keep-out list from
+`v.size if v.size and v.size > 0 else default_via_size`, while
+`nudge_vias_for_unresolved` priced the SAME barrel at a hard-coded
+`(v.size or 0.5) / 2.0` in four places, and its #313 connectivity tolerance at
+`max(1e-3, v.size / 2.0)` with no fallback at all. For a via the board did not
+size, the grader and the nudger therefore resolved DIFFERENT keep-outs -- the
+divergence the module's own comments forbid for the clearance term (#725).
+
+Three failure modes, all measured at HEAD 0bfc0be0 before the fix:
+
+  * `--default-via-size` ABOVE 0.5: grader keep-out 0.500, nudger threshold
+    0.350. The grader reports the cap unresolved (penetration 0.080000) and the
+    offender list comes back EMPTY, so the `for v in offenders:` body never
+    runs -- not even the "no clear spot" line prints. Captured nudger stdout
+    was literally ''. The cap stays unresolved forever with nothing on screen.
+  * BELOW 0.5 -- which is the SHIPPED CLI DEFAULT of 0.3
+    (bga_fanout.constants.DEFAULT_VIA_SIZE): the nudger over-estimates and
+    relocates vias whose grader penetration is exactly 0.000000, recording them
+    for the writer and laying connector copper for nothing.
+  * The tolerance: a size-0 via collapses `tol` to 1e-3, so a same-net stub end
+    0.100mm off the via centre is not matched, `conn_layers` comes back EMPTY,
+    and `all([])` is True -- the via is relocated with ZERO connectors and the
+    stub is orphaned. That is the pre-#313 behaviour the comment above the line
+    says was fixed.
+
+WHY THE GRADERS ARE NOT TOUCHED, and why that is a finding rather than an
+omission. `--default-via-size` is an OPERATOR's belief about a board being
+placed. It is not licence for a DRC/connectivity grader to disagree with KiCad,
+and KiCad honours a declared size literally.
+
+Measured on KiCad 10 with two boards identical but for one via's size, graded
+through check_connected's KiCad refill cross-check. State the geometry
+precisely, because the naive version of this experiment shows NOTHING: what
+governs is the PERPENDICULAR distance from the same-net copper to the barrel
+centre, not the stub's endpoint offset, and a track wide enough to cover the
+barrel keeps the net connected at either size. With ~0.2mm of effective
+separation, KiCad reports 0 unconnected links at `(size 0.5)` and 1 at
+`(size 0)`; a first attempt at a 0.100mm endpoint offset with a 0.2mm track
+reported 0 in BOTH arms, because the track's own copper already reached the
+barrel.
+
+`(size 0)` is additionally a hard KiCad DRC error in its own right
+(`via_diameter (min 0.5000 mm; actual 0.0000 mm)`, plus `track_dangling`), which
+is the strongest form of the point: KiCad does not quietly assume a diameter
+for such a via, it rejects it. So a grader that invented one would report
+CONNECTED what KiCad reports OPEN -- the direction that hides an open.
+`TestTheGradersStillReadTheBoard` pins that decision behaviourally, on
+`connectivity.endpoint_reaches_via`, so a later reader does not "fix"
+check_drc / check_connected / connectivity into disagreeing with KiCad.
+
+Conventions this file follows (from #697/#725/#731 and CLAUDE.md):
+
+  * REAL parser dataclasses and REAL boards. `_Repair.__init__` reads
+    courtyards and locked refs from the file on disk.
+  * Every assertion names the single-line MUTATION that must kill it.
+  * Assert you are ON the branch before asserting about it -- each test spies
+    the value its branch keys on, with a detail string saying why.
+  * Every "is not charged" is paired with a NEGATIVE CONTROL that still is.
+
+Runs in-process in ~20 s; nothing here shells out.
+"""
+from __future__ import annotations
+
+RUN_ALL_FAST_OK = True
+RUN_ALL_TIMEOUT = 900
+
+import contextlib
+import inspect
+import io
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+
+_TESTS = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_TESTS)
+for _p in ('', 'py_router', 'py_placer', 'py_tools'):
+    _d = os.path.join(_ROOT, _p)
+    if _d not in sys.path:
+        sys.path.insert(0, _d)
+if _TESTS not in sys.path:
+    sys.path.insert(0, _TESTS)
+
+from kicad_parser import BoardInfo, parse_kicad_pcb
+from synth import make_pcb, make_seg, make_via
+from placement import fanout_clearance as FC
+from placement.fanout_clearance import _Repair, nudge_vias_for_unresolved
+
+# Declares no netclass, no .kicad_dru and no pad override, so the clearance
+# model is INERT: via_required == clearance and _item_reach == clearance on
+# BOTH sides. The radius is then the only variable that can differ, which is
+# the isolation this issue needs and which orangecrab (6 fiducials carrying
+# local_clearance 0.375) cannot give.
+BOARD = os.path.join(_ROOT, 'kicad_files', 'rp2350_fpga_eensy_prePlane.kicad_pcb')
+CLEAR = 0.1
+PREFIX = 'C,R,FB'          # the CLI default; with 'C' alone R-refs never appear
+CAP = 'C16'                # a decoupling cap with clear board on both sides
+FOREIGN = 5                # neither of C16's own nets (2 and 4)
+
+# The two working points. 0.5 is deliberately avoided: it is the constant the
+# nudger used to hard-code, so at 0.5 the two conventions AGREE and every test
+# here would pass vacuously.
+DVS_BIG = 0.8              # grader radius 0.40 vs the old nudger's 0.25
+DVS_SMALL = 0.3            # the shipped CLI default; 0.15 vs 0.25, sign flipped
+OLD_NUDGER_RADIUS = 0.5 / 2.0
+
+
+def _repair(pcb, dvs, path=BOARD):
+    """The 10-POSITIONAL construction every test in this family uses. `dvs` is
+    argument 8, `default_via_size` -- the knob this issue is about, and the one
+    #725's shape contract pins in that slot."""
+    return _Repair(pcb, path, CLEAR, 0.1, 0.55, 1.0, 2.0, dvs, PREFIX, set())
+
+
+def _rig(dvs, gaps, sizes=None, stubs=()):
+    """A REAL board whose vias are replaced by ones parked at EXACT distances
+    from a real cap pad's rect, so `_point_to_rect_dist` IS the requested gap
+    and every threshold below is closed-form rather than measured.
+
+    Returns (pcb, st, cap, rect). Vias sit on the pad rect's horizontal centre
+    line, outside its right edge, on a foreign net.
+    """
+    pcb = parse_kicad_pcb(BOARD)
+    probe = _repair(pcb, dvs)
+    rect = probe.caps[CAP].pad_rects()[1]        # the net-2 pad
+    cy = (rect[1] + rect[3]) / 2.0
+    if sizes is None:
+        sizes = [0.0] * len(gaps)
+    pcb.vias[:] = [make_via(rect[2] + g, cy, net_id=FOREIGN, size=sz)
+                   for g, sz in zip(gaps, sizes)]
+    pcb.segments[:] = list(stubs)
+    st = _repair(pcb, dvs)
+    # Isolate the via channel: no foreign tracks, and every cap sees every via.
+    st.cap_segs = {k: [] for k in st.caps}
+    st.cap_vias = {k: st.vias for k in st.caps}
+    return pcb, st, st.caps[CAP], rect
+
+
+def _nudge(st, pcb, **kw):
+    """Drive the real pass, capturing what it printed. The PRINTED OUTPUT is
+    half the evidence for #732: above 0.5 the old build printed nothing at all,
+    which is what made the failure silent."""
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        moves, segs = nudge_vias_for_unresolved(st, pcb, CLEAR, **kw)
+    return moves, segs, buf.getvalue()
+
+
+class TestOneRadiusRule(unittest.TestCase):
+    """There is exactly one implementation of "how wide is this via"."""
+
+    def test_a_size_zero_via_resolves_to_the_operators_default(self):
+        pcb = parse_kicad_pcb(BOARD)
+        pcb.vias[0].size = 0.0
+        st = _repair(pcb, DVS_BIG)
+        v, t = pcb.vias[0], st.vias[0]
+        # ON THE BRANCH, both halves:
+        self.assertFalse(v.size, 'the via carries a size -- the fallback branch '
+                                 'is not taken and this test is vacuous')
+        self.assertNotAlmostEqual(
+            DVS_BIG / 2.0, OLD_NUDGER_RADIUS, places=9,
+            msg='at default_via_size 0.5 the old hard-coded fallback EQUALS the '
+                'resolver, so this test could not fail')
+        self.assertAlmostEqual(st.via_radius(v), DVS_BIG / 2.0, places=12)
+        # the tuple and the identity map are built from that same number
+        self.assertAlmostEqual(t[3], st.via_radius(v) + CLEAR, places=12)
+        self.assertAlmostEqual(st._via_radius_by_id[id(t)][1], st.via_radius(v),
+                               places=12)
+    # MUTATION: `via_radius` back to `(via.size or 0.5) / 2.0` -> reads 0.25,
+    # not 0.40, and all three assertions fail.
+
+    def test_a_via_with_a_REAL_size_ignores_the_default(self):
+        """NEGATIVE CONTROL for the test above: the operator's belief must not
+        override a size the board actually carries."""
+        pcb = parse_kicad_pcb(BOARD)
+        pcb.vias[0].size = 0.4
+        for dvs in (DVS_SMALL, DVS_BIG):
+            st = _repair(pcb, dvs)
+            self.assertAlmostEqual(st.via_radius(pcb.vias[0]), 0.2, places=12,
+                                   msg='default_via_size %s leaked into a via '
+                                       'that declares its own size' % dvs)
+    # MUTATION: make `via_radius` return `default_size / 2` unconditionally.
+
+    def test_the_module_has_exactly_ONE_spelling_of_a_via_radius(self):
+        """A source guard. The bug was not a wrong number, it was N numbers."""
+        src = inspect.getsource(FC)
+        # ON THE BRANCH: the resolver exists at all.
+        self.assertIn('def via_radius', src)
+        lines = src.split(chr(10))
+        for gone, where in ((' (v.size or 0.5)', 'the nudger validation/offender sites'),
+                            ('(ov.size or 0.5)', 'the foreign-via sites'),
+                            ('max(1e-3, v.size / 2.0)', 'the #313 connectivity tolerance'),
+                            ('keepout - st._item_reach', 'the locked-part warning')):
+            # Report the offending LINES, not the whole 130KB module: an
+            # assertNotIn on a source-sized haystack prints the haystack, and
+            # one failure produced 393KB of output.
+            hits = ['%d: %s' % (i + 1, l.strip())
+                    for i, l in enumerate(lines) if gone in l]
+            self.assertEqual(
+                hits, [],
+                '%s still resolves a via radius its own way -- %s'
+                % (where, '; '.join(hits)))
+    # MUTATION: re-introduce any one of those spellings -> its assertNotIn fires.
+
+
+class TestNudgerSeesWhatTheGraderFlags(unittest.TestCase):
+    """The offender test and the grader must agree about WHICH via offends."""
+
+    def test_above_the_old_fallback_the_nudger_can_SEE_the_flagged_via(self):
+        """The silent failure. Grader keep-out 0.500, old nudger 0.350; a via
+        at 0.420 sits in the band only the resolved radius can see."""
+        pcb, st, cap, rect = _rig(DVS_BIG, [0.42, 1.50])
+        near = pcb.vias[0]
+        # ON THE BRANCH, both halves:
+        self.assertGreater(
+            st.graze_penalty(CAP, cap, cap.x, cap.y, cap.rot), FC.EPS,
+            'the grader does not flag this cap, so the offender loop never runs')
+        self.assertTrue(
+            OLD_NUDGER_RADIUS + CLEAR <= 0.42 < st.via_radius(near) + CLEAR,
+            'the via is not in the band that separates the two conventions '
+            '(old %.3f, resolved %.3f)' % (OLD_NUDGER_RADIUS + CLEAR,
+                                           st.via_radius(near) + CLEAR))
+        moves, _segs, out = _nudge(st, pcb, max_shift=4.0)
+        # The SILENCE is the headline symptom, so assert it first: asserting the
+        # move count first shadows this one, and then no mutation can ever make
+        # the printed output the reported failure.
+        self.assertIn('via-nudge:', out,
+                      'the pass printed NOTHING about a cap it reports '
+                      'unresolved -- the silent failure #732 is about')
+        self.assertEqual(len(moves), 1, 'expected exactly the 0.42 via to move')
+        self.assertAlmostEqual(moves[0][0], rect[2] + 0.42, places=6)
+        # Where it LANDED, not just which via moved. moves[0][0..1] is the OLD
+        # position, so without this nothing checks the destination -- and the
+        # destination is what `valid_via_pos` prices with its own `vr`.
+        gap = FC._point_to_rect_dist(near.x, near.y, rect[:4])
+        self.assertGreaterEqual(
+            gap, st.via_radius(near) + CLEAR - 1e-9,
+            'the via landed %.4fmm from the pad, inside its resolved keep-out '
+            '%.4fmm -- valid_via_pos is pricing the barrel at a constant'
+            % (gap, st.via_radius(near) + CLEAR))
+        self.assertLess(
+            gap, st.via_radius(near) + CLEAR + 0.30,
+            'the via was pushed far beyond its keep-out, so this assertion '
+            'would hold for a much smaller radius too and proves little')
+        # NEGATIVE CONTROL: the via at 1.50 is clear under BOTH conventions and
+        # is still left alone.
+        self.assertAlmostEqual(pcb.vias[1].x, rect[2] + 1.50, places=6,
+                               msg='a genuinely clear via was moved')
+    # MUTATION: the offender loop back to `(v.size or 0.5) / 2.0` -> moves == []
+    # and `out` is '' (measured at HEAD: exactly that).
+
+    def test_below_it_a_PHANTOM_via_is_no_longer_chased(self):
+        """The shipped CLI default. Grader keep-out 0.250, old nudger 0.350: a
+        via at 0.300 is a phantom the old build relocated anyway."""
+        pcb, st, cap, rect = _rig(DVS_SMALL, [0.30, 0.02])
+        phantom = pcb.vias[0]
+        # ON THE BRANCH, three guards:
+        self.assertGreater(
+            st.graze_penalty(CAP, cap, cap.x, cap.y, cap.rot), FC.EPS,
+            'no cap is unresolved, so the offender loop never runs')
+        self.assertTrue(
+            st.via_radius(phantom) + CLEAR <= 0.30 < OLD_NUDGER_RADIUS + CLEAR,
+            'the phantom is not in the band only the OLD fallback could see')
+        self.assertLessEqual(
+            st.via_penalty(cap, cap.x, cap.y, cap.rot,
+                           [st.vias[0]], ref=CAP), FC.EPS,
+            'the grader DOES charge the 0.30 via -- it is not a phantom, and '
+            'this test is measuring the wrong thing')
+        moves, _segs, _out = _nudge(st, pcb, max_shift=4.0)
+        # NEGATIVE CONTROL is the assertion itself: the real offender still moves.
+        self.assertEqual(len(moves), 1,
+                         'expected only the 0.02 via (the real offender) to move')
+        self.assertAlmostEqual(moves[0][0], rect[2] + 0.02, places=6,
+                               msg='the phantom moved instead of the real offender')
+    # MUTATION: the offender loop back to `(v.size or 0.5) / 2.0` -> len(moves)
+    # becomes 2 and the phantom is relocated (measured at HEAD).
+
+    def test_the_offender_loop_RESOLVES_the_radius_through_st(self):
+        """Isolate the OFFENDER LOOP specifically.
+
+        A foreign TRACK makes the cap unresolved, so the loop runs -- but the
+        only via is 40mm away, so it offends nobody and neither `valid_via_pos`
+        nor `connector_clear` is ever entered. Any call to the resolver
+        therefore came from the offender test itself. Priced at a constant, the
+        resolver is never called at all, and a cap unresolved because of a
+        RAISED via requirement would yield an empty offender list: the pass
+        reports it unresolved forever and prints nothing.
+        """
+        pcb = parse_kicad_pcb(BOARD)
+        probe = _repair(pcb, DVS_BIG)
+        rect = probe.caps[CAP].pad_rects()[1]
+        cy = (rect[1] + rect[3]) / 2.0
+        # A foreign track biting into the cap pad's keep-out band.
+        bite = make_seg(rect[2] + 0.05, cy - 2.0, rect[2] + 0.05, cy + 2.0,
+                        width=0.1, layer='F.Cu', net_id=FOREIGN)
+        pcb.segments[:] = [bite]
+        pcb.vias[:] = [make_via(rect[2] + 40.0, cy, net_id=FOREIGN, size=0.0)]
+        st = _repair(pcb, DVS_BIG)
+        st.cap_vias = {k: st.vias for k in st.caps}
+        cap = st.caps[CAP]
+        # ON THE BRANCH, three guards: the loop only runs on an unresolved cap,
+        # only reaches the resolver if a via is in the list, and the via must
+        # NOT be an offender or a validator would run and muddy the count.
+        unresolved = [r for r in st.caps
+                      if st.graze_penalty(r, st.caps[r], st.caps[r].x,
+                                          st.caps[r].y, st.caps[r].rot) > FC.EPS]
+        self.assertIn(CAP, unresolved,
+                      'the track does not make %s unresolved, so the offender '
+                      'loop never runs' % CAP)
+        self.assertTrue(pcb.vias, 'no vias -- the inner loop never executes')
+        self.assertLessEqual(
+            st.via_penalty(cap, cap.x, cap.y, cap.rot, st.vias, ref=CAP),
+            FC.EPS, 'the far via grazes the cap, so a validator will run and '
+                    'this test no longer isolates the offender loop')
+        calls, real = [0], st.via_radius
+
+        def counting(v):
+            calls[0] += 1
+            return real(v)
+        st.via_radius = counting
+        moves, segs, _out = _nudge(st, pcb)
+        self.assertEqual((moves, segs), ([], []),
+                         'a via 40mm away should offend nobody')
+        self.assertGreater(calls[0], 0,
+                           'the offender loop never consulted via_radius -- it '
+                           'is pricing the barrel at a constant')
+    # MUTATION: the offender loop back to a hard-coded fallback -> calls == 0.
+
+
+class TestTheConnectivityTolerance(unittest.TestCase):
+    """#313: copper terminating within the VIA BODY is joined through it and
+    needs a connector on its layer when the via moves."""
+
+    def _stub_rig(self, size):
+        pcb, st, cap, rect = _rig(DVS_BIG, [0.42], sizes=[size])
+        v = pcb.vias[0]
+        near = make_seg(v.x, v.y - 0.30, v.x, v.y - 0.10,
+                        width=0.2, layer='F.Cu', net_id=FOREIGN)
+        far = make_seg(v.x, v.y + 0.90, v.x, v.y + 1.40,
+                       width=0.2, layer='B.Cu', net_id=FOREIGN)
+        pcb.segments[:] = [near, far]
+        return pcb, st, v
+
+    def test_a_size_zero_vias_stub_still_gets_its_connector(self):
+        pcb, st, v = self._stub_rig(0.0)
+        # ON THE BRANCH: 0.10mm is inside the resolved body but far outside the
+        # 1e-3 the old expression collapsed to.
+        self.assertTrue(1e-3 < 0.10 < st.via_radius(v),
+                        'the stub end is not in the band that separates the two '
+                        'tolerances (resolved radius %.3f)' % st.via_radius(v))
+        moves, segs, _out = _nudge(st, pcb, max_shift=4.0)
+        self.assertEqual(len(moves), 1, 'the via did not move; nothing to prove')
+        layers = {s['layer'] for s in segs}
+        self.assertIn('F.Cu', layers,
+                      'the via was relocated with NO connector back to its stub '
+                      '-- the #313 open this tolerance exists to prevent')
+        # NEGATIVE CONTROL: a same-net stub 0.90mm away is genuinely out of
+        # reach of the barrel and must still get nothing.
+        self.assertNotIn('B.Cu', layers,
+                         'a stub far outside the via body was given a connector')
+    # MUTATION: `tol` back to `max(1e-3, v.size / 2.0)` -> conn_layers is EMPTY,
+    # `all([])` is True so the move still happens, and segs loses F.Cu.
+
+    # NOT COVERED BEHAVIOURALLY, and here is the full list rather than a silent
+    # gap. A mutation run reverted each converted site individually with a
+    # guard-evading spelling; these are the ones no test noticed:
+    #
+    #   * `connector_clear`'s foreign-via term
+    #   * `valid_via_pos`'s foreign-via term (`via_rad(ov)`)
+    #
+    # `valid_via_pos`'s OWN `vr` was in that list too and is now covered, by
+    # asserting where the via LANDS rather than only which via moved.
+    #
+    # For the two that remain: the foreign-via terms only bind when a FOREIGN
+    # via sits close enough to matter, and every fixture here parks its foreign
+    # vias against the cap pad rather than against each other. I tried to cover
+    # `connector_clear`'s and the rig was VACUOUS -- `segs` came back empty, so
+    # the assertion loop never iterated.
+    #
+    # The reason is structural, not laziness. For a foreign via of the same
+    # radius r, `valid_via_pos` requires centre-to-centre >= r + r + clearance
+    # while `connector_clear` requires point-to-segment >= r + hw + clearance.
+    # With r 0.4 and a 0.2mm connector that is 0.9mm versus 0.6mm, so
+    # valid_via_pos is STRICTLY stricter: any blocker close enough to trip the
+    # connector test has already rejected the candidate position. The term can
+    # only bind against the connector's MIDDLE, and a connector is at most
+    # max_shift long, so its midpoint sits within half a shift of the old via
+    # position -- where the moving via already was, i.e. somewhere that was
+    # legal by construction.
+    #
+    # It is therefore guarded by SPELLING only
+    # (test_the_module_has_exactly_ONE_spelling_of_a_via_radius). Filed rather
+    # than faked. The same holds for the locked-part warning's `_rec is None`
+    # branch, which is unreachable while every tuple comes from __init__.
+
+    def test_a_via_with_a_real_size_is_priced_exactly_as_before(self):
+        """The whole fix is gated on a falsy size. A real one must resolve to
+        exactly `size / 2`, before and after."""
+        pcb, st, v = self._stub_rig(0.5)
+        self.assertAlmostEqual(st.via_radius(v), 0.25, places=12)
+        self.assertAlmostEqual(st.via_radius(v), OLD_NUDGER_RADIUS, places=12,
+                               msg='a real-sized via must be priced identically '
+                                   'to the pre-#732 build')
+    # MUTATION: make via_radius apply the default even when size > 0.
+
+
+class TestTheDuckTypedPathStaysInert(unittest.TestCase):
+    """`nudge_vias_for_unresolved` is public and the #370/#617 harnesses drive
+    it with a stand-in `st` carrying no resolvers at all."""
+
+    class _FakeCap:
+        def __init__(self, rects):
+            self._rects = list(rects)
+            self.side = 'F'
+            self.x = self.y = self.rot = 0.0
+
+        def pad_rects(self, x=None, y=None, rot=None):
+            return self._rects
+
+    class _FakeSt:
+        def __init__(self, rects, cap_cls):
+            self.caps = {'C1': cap_cls(rects)}
+            self.vias = []
+
+        def graze_penalty(self, ref, cap, x, y, rot):
+            return 1.0
+
+    def test_the_fallback_is_the_value_the_nudger_always_used(self):
+        """DRIVES the real function with a duck-typed `st`, so the fallback
+        branch is actually executed. Asserting on `_via_radius` alone
+        would leave `via_rad`'s fallback dead code that a `raise` could replace
+        without any test noticing -- which is exactly what a mutation run found
+        the first version of this test doing."""
+        BAR = (0.2, 0.9, 1.8, 1.1, 2)      # cap pad bar; only +y escapes
+        st = self._FakeSt([BAR], self._FakeCap)
+        v = make_via(1.0, 1.4, net_id=3, size=0.0)
+        pcb = make_pcb(vias=[v], board_info=BoardInfo(
+            layers={}, board_bounds=(-5.0, -5.0, 15.0, 50.0),
+            copper_layers=['F.Cu', 'B.Cu']),
+            footprints={'C1': SimpleNamespace(layer='F.Cu', pads=[])})
+        # ON THE BRANCH, both halves:
+        self.assertIsNone(getattr(st, 'via_radius', None),
+                          'the fake grew a resolver -- the fallback is never '
+                          'exercised and this test is vacuous')
+        self.assertFalse(v.size, 'the via declares a size, so the fallback '
+                                 'branch is not taken')
+        self.assertEqual(FC._UNREADABLE_VIA_SIZE, 0.5,
+                         'the duck-typed fallback silently changed value; the '
+                         'nudger hard-coded 0.5 at four sites before #732 and '
+                         'this rename must not move it')
+        moves, _segs, _out = _nudge(st, pcb, max_shift=4.0)
+        self.assertEqual(len(moves), 1, 'the fake st did not drive a move, so '
+                                        'the fallback was never reached')
+        # The relocated via must clear the bar by the FALLBACK radius: the bar
+        # spans y in [0.9, 1.1], so a via at radius r must sit at least
+        # r + CLEAR above 1.1.
+        self.assertGreaterEqual(
+            v.y, BAR[3] + OLD_NUDGER_RADIUS + CLEAR - 1e-9,
+            'the nudger cleared the bar by %.3f, not by the fallback radius '
+            '%.3f' % (v.y - BAR[3] - CLEAR, OLD_NUDGER_RADIUS))
+        # NEGATIVE CONTROL: a via that DECLARES a size is priced off the via,
+        # not off the fallback -- a wider one must be pushed further.
+        st2 = self._FakeSt([BAR], self._FakeCap)
+        v2 = make_via(1.0, 1.4, net_id=3, size=1.0)
+        pcb2 = make_pcb(vias=[v2], board_info=BoardInfo(
+            layers={}, board_bounds=(-5.0, -5.0, 15.0, 50.0),
+            copper_layers=['F.Cu', 'B.Cu']),
+            footprints={'C1': SimpleNamespace(layer='F.Cu', pads=[])})
+        moves2, _s2, _o2 = _nudge(st2, pcb2, max_shift=4.0)
+        self.assertEqual(len(moves2), 1)
+        self.assertGreater(v2.y, v.y,
+                           'a 1.0mm via was not pushed further than a size-0 '
+                           'one, so the radius is not being read at all')
+    # MUTATION: change UNREADABLE_VIA_SIZE -> the fallback assertion fires.
+    # MUTATION: replace via_rad's fallback body with `raise` -> this test dies
+    # (it is the only one that reaches that branch).
+
+
+class TestTheLockedWarningReadsTheMap(unittest.TestCase):
+    """The last arithmetic re-derivation of a radius in the file. It agrees
+    with the map on every real via -- which is what licenses replacing it."""
+
+    def test_the_arithmetic_and_the_map_agree_on_every_real_via(self):
+        pcb = parse_kicad_pcb(BOARD)
+        st = _repair(pcb, DVS_SMALL)
+        # ON THE BRANCH:
+        self.assertTrue(st.vias, 'the board has no vias to compare')
+        self.assertEqual(len(st._via_radius_by_id), len(st.vias),
+                         'not every tuple is registered, so the map is not the '
+                         'authority this test claims it is')
+        for t in st.vias:
+            self.assertAlmostEqual(
+                t[3] - st._item_reach(st.via_floor(t[2])),
+                st._via_radius_by_id[id(t)][1], places=12,
+                msg='the old subtraction and the map disagree at %r' % (t,))
+    # MUTATION: none kills this one -- it is the MEASUREMENT that licenses the
+    # locked-warning change (the two forms are numerically identical on a real
+    # board, so the swap is inert). The source guard in TestOneRadiusRule is
+    # what stops the arithmetic coming back.
+
+
+class TestTheGradersStillReadTheBoard(unittest.TestCase):
+    """MEASURED DECISION, pinned so nobody "fixes" it later.
+
+    KiCad honours a declared via size literally. On two boards identical but
+    for one via's size, with a same-net stub end 0.100mm off its centre,
+    check_connected's KiCad refill cross-check reported 0 unconnected links at
+    `(size 0.5)` and 1 at `(size 0)`. A zero-diameter barrel joins nothing, so
+    a grader that substituted `--default-via-size` would report CONNECTED what
+    KiCad reports OPEN. The operator's belief governs PLACEMENT, not grading.
+    """
+
+    def test_the_grader_mirror_credits_a_size_zero_barrel_at_ZERO(self):
+        """BEHAVIOURAL, not a string match.
+
+        An earlier version of this test asserted only
+        `'defaults.via_radius' not in source`, which such a mutant defeats with
+        `from routing_defaults import via_radius as _vr`, and which would pass
+        just as well on a build that hard-coded 0.5 in the grader by hand. It
+        pinned a spelling, not the decision.
+
+        `connectivity.endpoint_reaches_via` is the right thing to pin: it is
+        public, its docstring explicitly documents itself as the mirror of
+        check_connected's via credit, and it is the function a well-meaning
+        reader would "fix". Its contract is that the credit is the BARREL
+        radius plus the copper's own radius -- so for a via the board sizes at
+        0, the barrel contributes nothing and only the copper's own reach and
+        the coincidence floor remain.
+        """
+        import connectivity
+        from connectivity import COINCIDENCE_TOL, endpoint_reaches_via
+        LAY = ['F.Cu', 'B.Cu']
+        big = make_via(0.0, 0.0, net_id=7, size=0.8)
+        zero = make_via(0.0, 0.0, net_id=7, size=0.0)
+        # A zero-radius probe: the credit is then the barrel alone.
+        # 0.25: inside the 0.8 barrel (0.40), far outside the 0.02 floor,
+        # and strictly inside a 0.6 invented diameter (0.30) so a mutant
+        # that substitutes one is caught. NOT 0.30 -- that equals such a
+        # mutant's radius exactly and the strict `<` lets it through.
+        d = 0.25
+        # ON THE BRANCH: the same probe IS credited against a real barrel, so a
+        # False below is the barrel's absence and not a broken fixture.
+        self.assertTrue(endpoint_reaches_via(d, 0.0, 0.0, big, LAY, LAY),
+                        'a 0.8mm barrel does not reach 0.25mm; the fixture is '
+                        'not measuring the barrel')
+        self.assertGreater(d, COINCIDENCE_TOL,
+                           'the probe is inside the coincidence floor, so this '
+                           'would pass whatever the radius is')
+        self.assertFalse(
+            endpoint_reaches_via(d, 0.0, 0.0, zero, LAY, LAY),
+            'a via the board sizes at 0 was credited with 0.25mm of barrel '
+            'reach. KiCad honours a declared size literally -- (size 0) is a '
+            'via_diameter DRC error there and that barrel joins nothing -- so '
+            'inventing a diameter here reports CONNECTED what KiCad reports '
+            'OPEN, the direction that hides an open. --default-via-size is an '
+            'operator belief about a board being PLACED; it is not licence for '
+            'a grader to disagree with KiCad.')
+        # And the source of that number is still the board, not a constant.
+        self.assertNotIn('_UNREADABLE_VIA_SIZE', inspect.getsource(connectivity),
+                         'connectivity now imports the placement pass fallback')
+    # MUTATION: give connectivity.endpoint_reaches_via a non-zero fallback for a
+    # size-0 via (e.g. restore `(getattr(via,'size',0.6) or 0.6)`) -> the
+    # assertFalse fires.
+
+
+class TestInertOnTheTrackedCorpus(unittest.TestCase):
+    """Every changed expression is gated on a falsy size, and no tracked board
+    has one -- so the whole change is provably inert on the corpus. Asserted
+    rather than narrated."""
+
+    def test_no_tracked_board_carries_a_via_the_fix_could_touch(self):
+        import re
+        import subprocess
+        # git ls-files, NOT a glob: eleven boards in kicad_files/ are gitignored
+        # build products (interf_u_*, sonde_u_*, fanout_output*, ...). Globbing
+        # made this test pass only on a machine that had run the examples and
+        # FAIL on a fresh clone -- measured, 602 tokens vs the 1520 a populated
+        # tree sees.
+        try:
+            out = subprocess.check_output(
+                ['git', 'ls-files', 'kicad_files/*.kicad_pcb'],
+                cwd=_ROOT, stderr=subprocess.DEVNULL).decode()
+        except Exception as exc:                       # no git, no answer
+            raise unittest.SkipTest('git ls-files unavailable: %s' % exc)
+        boards = [os.path.join(_ROOT, ln) for ln in out.splitlines()
+                  if ln.strip()]
+        pat = re.compile(r'\(size\s+([0-9.]+)\s*\)')
+        total = zero = 0
+        for path in boards:
+            with io.open(path, encoding='utf-8', errors='replace') as fh:
+                for m in pat.finditer(fh.read()):
+                    total += 1
+                    if float(m.group(1)) <= 0:
+                        zero += 1
+        # ON THE BRANCH: the scan actually read the tracked corpus.
+        self.assertGreater(len(boards), 15,
+                           'git listed only %d tracked boards' % len(boards))
+        self.assertGreater(total, 500,
+                           'the scan found only %d size tokens across %d tracked '
+                           'boards -- it is not reading the corpus'
+                           % (total, len(boards)))
+        self.assertEqual(zero, 0,
+                         '%d tracked via(s) now have size <= 0, so the "provably '
+                         'inert on the corpus" claim in the PR is no longer '
+                         'true and must be re-measured' % zero)
+    # MUTATION: add a `(size 0)` via to any tracked board -> this fails, which
+    # is the point: the inertness claim stops being true and must be restated.
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/test_733_fanout_clearance_edge_margin.py
+++ b/tests/test_733_fanout_clearance_edge_margin.py
@@ -1,0 +1,739 @@
+"""#733: the board-edge requirement must have ONE resolver in this pass.
+
+`_Repair.__init__` insets `usable` and builds `edge_gate` at
+`max(clearance, board_edge_clearance)`, and gates every candidate cap rect on
+that. `nudge_vias_for_unresolved` -- which RELOCATES real vias and DRAWS real
+connector segments, the only channel here that emits copper rather than moving
+parts -- gated its own `edge_ok_point` / `edge_ok_seg` at the bare flat
+`clearance`, and took no `board_edge_clearance` parameter at all, so it could
+not agree.
+
+Measured on the rig below at HEAD 0f62d190, at the shipped CLI defaults
+(`--clearance 0.25`, `--board-edge-clearance 0.55`):
+
+    board top 2.15, cap bar at y 0.9..1.1, one foreign 0.5mm via at (1.0, 1.4)
+
+  * before: the via is relocated to (1.0, 1.600) and the writer keeps it
+    (place_fanout_clearance.py:138). Its centre is 0.550mm from Edge.Cuts --
+    0.30mm inside the band the cap mover reserves, on copper this pass created.
+  * after: no candidate validates, the pass prints "no clear spot", and the
+    via stays put.
+
+The same 0.30mm on the GUI path, which passed NO value and silently took the
+signature default whatever the board or the operator said.
+
+TIGHTEN-ONLY, and that is the interesting half. `resolve_cap_edge_clearance`
+raises the 0.55 default to a board's declared `min_copper_edge_clearance` but
+never lowers it, because `fix_project_for_output` PINS that field UP to the fab
+copper-to-edge floor 0.20 on every board it writes
+(fix_kicad_drc_settings.py:608 -> :748-753, the one raise-allowed key) and
+`bga_fanout.py` calls it -- so in the documented pipeline
+`bga_fanout.py -> place_fanout_clearance.py` every board arrives declaring
+>= 0.20 even when its author declared nothing. Read plainly board-first, that
+0.20 comes back tagged "board constraint" -- this pipeline's own default
+wearing the board's name -- and the cap margin would silently drop to
+max(clearance, 0.20).
+
+A FINDING THIS FILE EXISTS FOR. The two harnesses that drive
+`nudge_vias_for_unresolved` with a duck-typed `st` --
+tests/test_370_tierb_fixes.py:377-383 and
+tests/test_617_placement_fanout_hole_clearance.py:243 -- do NOT pin the
+None-fallback at all. Every landing they exercise clears 0.80mm, so a fallback
+of 0.55 passes all five of their arms unchanged. `TestTheDuckTypedPathStaysInert`
+brackets the fallback to (0.20, 0.30] on a rig built for it, because the
+regression a later reader would introduce by "tidying" that line is one nothing
+else would catch.
+
+Conventions this file follows (from #697/#725/#731/#732 and CLAUDE.md):
+
+  * REAL parser dataclasses, and a REAL board wherever the outline matters.
+  * Every assertion names the single-line MUTATION that must kill it.
+  * Assert you are ON the branch before asserting about it.
+  * Every "is refused" is paired with a NEGATIVE CONTROL that still passes.
+  * No fixture sits ON a threshold. Measured: at clearance 0.1 the r=0.05
+    candidate lands 0.34999999999999987 from a 0.35 requirement and is
+    float-rejected, so every rig here keeps >= 0.05mm of headroom.
+
+Runs in-process in a few seconds; nothing here shells out.
+"""
+from __future__ import annotations
+
+RUN_ALL_FAST_OK = True
+RUN_ALL_TIMEOUT = 900
+
+import contextlib
+import inspect
+import io
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+_TESTS = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_TESTS)
+for _p in ('', 'py_router', 'py_placer', 'py_tools'):
+    _d = os.path.join(_ROOT, _p)
+    if _d not in sys.path:
+        sys.path.insert(0, _d)
+if _TESTS not in sys.path:
+    sys.path.insert(0, _TESTS)
+
+from kicad_parser import BoardInfo, PCBData, Segment, Via, parse_kicad_pcb
+from check_drc import (board_edge_geometry, _point_on_board,
+                       _point_to_rings_distance)
+from placement import fanout_clearance as FC
+from placement.fanout_clearance import (CAP_EDGE_CLEARANCE, _Repair,
+                                        nudge_vias_for_unresolved,
+                                        resolve_cap_edge_clearance)
+
+# The inert board (#732's, for the same reason): no netclass, no .kicad_dru, no
+# pad override and NO sibling .kicad_pro, so every pair requirement collapses to
+# `clearance` and the EDGE MARGIN is the only variable this file can move.
+BOARD = os.path.join(_ROOT, 'kicad_files', 'rp2350_fpga_eensy_prePlane.kicad_pcb')
+# The only tracked board with real interior Edge.Cuts rings that also carries no
+# vias of its own, so its outline can be borrowed without foreign copper.
+WATCHY = os.path.join(_ROOT, 'kicad_files', 'watchy.kicad_pcb')
+
+CLEAR = 0.25               # routing_defaults.CLEARANCE, the shipped --clearance
+BEC = 0.55                 # the shipped --board-edge-clearance == CAP_EDGE_CLEARANCE
+VIA_R = 0.25               # a 0.5mm via: needs 0.50 under the old convention and
+                           # 0.80 under the new one -- a 0.30mm band.
+PREFIX = 'C,R,FB'
+FOREIGN = 3
+
+HBAR = (0.2, 0.9, 1.8, 1.1, 2)   # cap pad bar on net 2; the only escape is +y
+
+
+class _FakeCap:
+    """Minimal stand-in for _Cap: fixed pad rects, never moves."""
+
+    def __init__(self, rects):
+        self._rects = rects
+        self.x = self.y = self.rot = 0.0
+
+    def pad_rects(self, x=None, y=None, rot=None):
+        return self._rects
+
+
+class _FakeSt:
+    """The duck-typed `st` the #370/#617 harnesses pass: no resolvers at all.
+
+    `edge_margin` is ABSENT, not None, so `getattr(st, 'edge_margin', None)`
+    takes its default -- the branch TestTheDuckTypedPathStaysInert pins.
+    """
+
+    def __init__(self, rects):
+        self.caps = {'C1': _FakeCap(rects)}
+        self.vias = []
+
+    def graze_penalty(self, ref, cap, x, y, rot):
+        return 1.0          # permanently unresolved, so the offender loop RUNS
+
+
+class _MarginSt(_FakeSt):
+    """...plus the one resolver this issue is about."""
+
+    def __init__(self, rects, margin):
+        super().__init__(rects)
+        self.edge_margin = margin
+
+
+class _SpySt(_FakeSt):
+    """Counts reads of `edge_margin`, so "the nudger READ st" is provable."""
+
+    def __init__(self, rects, margin):
+        super().__init__(rects)
+        self._margin = margin
+        self.reads = 0
+
+    @property
+    def edge_margin(self):
+        self.reads += 1
+        return self._margin
+
+
+def _repair(pcb, bec=BEC, clear=CLEAR, path=BOARD):
+    """The 10-POSITIONAL construction this family uses (#725's shape contract
+    pins the slots); `bec` is argument 5."""
+    return _Repair(pcb, path, clear, 0.1, bec, 1.0, 2.0, 0.8, PREFIX, set())
+
+
+def _bbox_board(top, vias, segments=()):
+    bi = BoardInfo(layers={}, board_bounds=(0.0, 0.0, 2.0, top),
+                   copper_layers=['F.Cu', 'B.Cu'])
+    return PCBData(board_info=bi, nets={},
+                   footprints={'C1': SimpleNamespace(layer='F.Cu', pads=[])},
+                   vias=list(vias), segments=list(segments), pads_by_net={})
+
+
+def _graze_via(x=1.0, y=1.4):
+    return Via(x=x, y=y, size=2 * VIA_R, drill=0.3,
+               layers=['F.Cu', 'B.Cu'], net_id=FOREIGN)
+
+
+def _nudge(st, pcb, clear=CLEAR, **kw):
+    """Drive the real pass, capturing what it printed. The PRINTED OUTPUT is
+    half the evidence: a refusal that prints nothing is indistinguishable from
+    a pass that never looked (the #732 silent-failure lesson)."""
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        moves, segs = nudge_vias_for_unresolved(st, pcb, clear, **kw)
+    return moves, segs, buf.getvalue()
+
+
+def _rig_a(top, st, clear=CLEAR, segments=()):
+    """Bbox rig: one foreign via boxed by a cap bar so its ONLY escape is +y,
+    straight at the top edge. Measured landing is (1.0, 1.600) whenever a move
+    happens at all, so `top - 1.6` IS the edge distance under test. A sideways
+    escape would need r >= 1.3, well past the 0.6mm search budget."""
+    v = _graze_via()
+    pcb = _bbox_board(top, [v], segments)
+    moves, segs, out = _nudge(st, pcb, clear)
+    return v, pcb, moves, segs, out
+
+
+class TestTheBoardEdgeRequirementHasOneResolver(unittest.TestCase):
+    """The invariant #733 is about, on a real board: one number, not two."""
+
+    def test_the_cap_mover_and_the_nudger_read_the_same_margin(self):
+        pcb = parse_kicad_pcb(BOARD)
+        st = _repair(pcb)
+        # ON THE BRANCH: if the two conventions coincided, this whole file
+        # would pass vacuously.
+        self.assertGreater(BEC, CLEAR,
+                           'board_edge_clearance does not exceed clearance, so '
+                           'max() is a no-op and nothing here is under test')
+        self.assertAlmostEqual(st.edge_margin, BEC, places=12,
+                               msg='edge_margin is not max(clearance, bec)')
+        self.assertAlmostEqual(st.edge_margin, st.edge_gate.margin, places=12,
+                               msg='the rect gate and the scalar disagree -- '
+                                   'there are two storages again')
+        b = pcb.board_info.board_bounds
+        self.assertAlmostEqual(st.usable[0] - b[0], st.edge_margin, places=12,
+                               msg='the bbox inset is not the same number')
+        self.assertAlmostEqual(b[2] - st.usable[2], st.edge_margin, places=12)
+    # MUTATION: `return self.edge_gate.margin` -> `return self.clearance`.
+
+    def test_a_clearance_above_the_edge_flag_wins_the_max(self):
+        pcb = parse_kicad_pcb(BOARD)
+        big = _repair(pcb, bec=0.55, clear=0.6)
+        self.assertAlmostEqual(big.edge_margin, 0.6, places=12,
+                               msg='a clearance above the edge flag must win')
+        self.assertAlmostEqual(big.edge_gate.margin, 0.6, places=12)
+        # NEGATIVE CONTROL: below it, the edge flag still governs.
+        small = _repair(pcb, bec=0.55, clear=0.1)
+        self.assertAlmostEqual(small.edge_margin, 0.55, places=12,
+                               msg='the edge flag stopped governing')
+    # MUTATION: `margin = max(clearance, board_edge_clearance)` ->
+    # `margin = board_edge_clearance` -- the first assertion reads 0.55.
+
+    def test_the_nudger_never_gates_below_the_clearance_it_was_called_with(self):
+        """The flat `clearance` argument is this function's own floor: an st
+        must never LOWER the edge test below it.
+
+        Defensive rather than load-bearing, and worth saying so: no LIVE caller
+        can hand the nudger a sub-clearance margin today. `_Repair` is built at
+        one site and its margin is already max(clearance, ...); the margin-ZERO
+        outline gate render_placement builds is a shallow COPY it keeps beside
+        `state.edge_gate` (render_placement.py:275-284), not a `_Repair`. An
+        earlier version of this docstring claimed otherwise and the #733
+        fact-check caught it. A duck-typed st CAN, and this is that."""
+        st = _MarginSt([HBAR], 0.0)
+        # 1.90 - 1.6 = 0.30 of room; max(0.25, 0.0) needs 0.25 + 0.25 = 0.50.
+        _v, _pcb, moves, _segs, out = _rig_a(1.90, st)
+        self.assertIn('no clear spot', out,
+                      'a margin-0 st silently lowered the edge gate below the '
+                      'clearance the caller passed')
+        self.assertEqual(moves, [], 'the via was relocated at a 0.0 margin')
+        # NEGATIVE CONTROL: the same st on a roomier board still moves it, so
+        # the rig is not simply dead.
+        st2 = _MarginSt([HBAR], 0.0)
+        _v2, _pcb2, moves2, _s2, _o2 = _rig_a(2.15, st2)
+        self.assertEqual(len(moves2), 1,
+                         'the margin-0 arm rejects everything; the first '
+                         'assertion proves nothing')
+    # MUTATION: `max(clearance, _edge_m)` -> `_edge_m` -- edge_margin becomes
+    # 0.0, need drops to 0.25 <= 0.30, and the via moves.
+
+
+class TestARelocatedViaHonoursTheBoardEdgeMargin(unittest.TestCase):
+    """edge_ok_point, both signs."""
+
+    def test_a_via_in_the_band_between_the_two_conventions_is_refused(self):
+        """The headline. At top 2.15 the only landing sits 0.550mm from
+        Edge.Cuts: clear under `clearance` (needs 0.500), inside the margin
+        (needs 0.800)."""
+        # ON THE BRANCH: the landing must be IN the band, or this test is a
+        # statement about some other geometry.
+        self.assertTrue(VIA_R + CLEAR <= 0.55 < VIA_R + BEC,
+                        'the landing is not in the band that separates the two '
+                        'conventions (old %.3f, new %.3f)'
+                        % (VIA_R + CLEAR, VIA_R + BEC))
+        v, _pcb, moves, segs, out = _rig_a(2.15, _MarginSt([HBAR], BEC))
+        # The PRINT first: assert the move count first and no mutation can ever
+        # make the silence the reported failure (#732's lesson).
+        self.assertIn('no clear spot', out,
+                      'the pass said nothing about a via it declined to move')
+        self.assertEqual(moves, [], 'the via was relocated into the edge band')
+        self.assertEqual(segs, [], 'connector copper was drawn for no move')
+        self.assertEqual((v.x, v.y), (1.0, 1.4), 'the via was mutated in place')
+        # NEGATIVE CONTROL, same board: without the resolver the old convention
+        # accepts exactly this landing -- which is what #733 reports.
+        v2, _p2, moves2, _s2, out2 = _rig_a(2.15, _FakeSt([HBAR]))
+        self.assertEqual(len(moves2), 1,
+                         'the permissive arm did not move either, so the two '
+                         'conventions are not being separated here')
+        self.assertAlmostEqual(v2.y, 1.6, places=4)
+        self.assertIn('moved', out2)
+    # MUTATION: `need = r + edge_margin` -> `need = r + clearance` -- the via
+    # moves and stdout says "moved" instead of "no clear spot".
+
+    def test_a_via_with_real_room_still_moves_at_the_raised_margin(self):
+        """The over-rejection guard: raising the margin must not simply stop
+        the pass working."""
+        v, _pcb, moves, _segs, out = _rig_a(2.60, _MarginSt([HBAR], BEC))
+        self.assertEqual(len(moves), 1,
+                         'a via with 1.00mm of room was refused at a 0.80mm '
+                         'requirement -- the gate over-rejects')
+        self.assertAlmostEqual(v.y, 1.6, places=4)
+        self.assertIn('moved', out)
+    # MUTATION: `need = r + edge_margin` -> `need = r + 2 * edge_margin`.
+
+
+class TestAConnectorSegmentHonoursTheBoardEdgeMargin(unittest.TestCase):
+    """edge_ok_seg. The connector is copper this pass DRAWS, so it is the half
+    that matters most -- and it is priced on its own half-width."""
+
+    def _rig_b(self, width, st):
+        """Rig A at top 2.60 plus a same-net stub on B.Cu, so the connector is
+        drawn there. B.Cu ON PURPOSE: connector_clear's cap-pad term is
+        layer-gated (cap pads exist only on the cap's own side), so a wide F.Cu
+        connector would be killed by the bar and the edge term never reached.
+        On B.Cu the ONLY live gate is edge_ok_seg -- no board pads, no foreign
+        vias (the moving via is same-net), no foreign segments, no NPTH."""
+        stub = Segment(start_x=1.0, start_y=1.6, end_x=1.0, end_y=1.4,
+                       width=width, layer='B.Cu', net_id=FOREIGN)
+        return _rig_a(2.60, st, segments=[stub])
+
+    def test_a_wide_connector_is_gated_on_its_own_half_width_plus_the_margin(self):
+        # ON THE BRANCH: the POINT test passes at this board size, so a refusal
+        # here is attributable to edge_ok_seg and to nothing else.
+        self.assertGreaterEqual(2.60 - 1.6, VIA_R + BEC,
+                                'the via itself does not clear the margin, so '
+                                'edge_ok_point could be doing the rejecting')
+        self.assertLess(2.60 - 1.6, 1.2 / 2.0 + BEC,
+                        'a 1.2mm connector already clears the margin; this rig '
+                        'separates nothing')
+        _v, _pcb, moves, segs, out = self._rig_b(1.2, _MarginSt([HBAR], BEC))
+        self.assertIn('no clear spot', out,
+                      'the pass said nothing about a connector it declined')
+        self.assertEqual(moves, [], 'the via moved despite an illegal connector')
+        self.assertEqual(segs, [])
+        # NEGATIVE CONTROL: the old convention draws exactly that connector.
+        _v2, _p2, moves2, segs2, _o2 = self._rig_b(1.2, _FakeSt([HBAR]))
+        self.assertEqual(len(moves2), 1)
+        self.assertEqual([(s['layer'], s['width']) for s in segs2],
+                         [('B.Cu', 1.2)],
+                         'the permissive arm did not draw the wide connector, '
+                         'so the two conventions are not being separated')
+    # MUTATION: `need = hw + edge_margin` -> `need = hw + clearance`.
+
+    def test_a_narrow_connector_on_the_same_board_still_moves(self):
+        """Isolates the half-width term: without this, a gate that ignored `hw`
+        entirely would still pass the test above."""
+        _v, _pcb, moves, segs, _out = self._rig_b(0.2, _MarginSt([HBAR], BEC))
+        self.assertEqual(len(moves), 1,
+                         'a 0.2mm connector with 1.00mm of room was refused')
+        self.assertEqual([(s['layer'], s['width']) for s in segs],
+                         [('B.Cu', 0.2)])
+    # MUTATION: `need = hw + edge_margin` -> `need = 2 * hw + edge_margin`
+    # over-rejects and this move disappears.
+
+
+class TestTheRealOutlineBranch(unittest.TestCase):
+    """Both helpers have a rings branch and a bbox branch. The tests above
+    exercise the bbox one; this exercises the rings one on real Edge.Cuts."""
+
+    def _watchy(self):
+        bi = parse_kicad_pcb(WATCHY).board_info
+        rings, outer, cutouts = board_edge_geometry(bi)
+        # Derived, never hard-coded: a watchy re-export must not silently
+        # un-calibrate this fixture.
+        cut_y = max(y for _x, y in cutouts[0])
+        return bi, rings, outer, cutouts, cut_y
+
+    def _run(self, st):
+        bi, rings, outer, cutouts, cut_y = self._watchy()
+        v = Via(x=85.0, y=cut_y + 0.95, size=2 * VIA_R, drill=0.3,
+                layers=['F.Cu', 'B.Cu'], net_id=FOREIGN)
+        bar = (84.2, cut_y + 1.25, 85.8, cut_y + 1.45, 2)
+        pcb = PCBData(board_info=bi, nets={},
+                      footprints={'C1': SimpleNamespace(layer='F.Cu', pads=[])},
+                      vias=[v], segments=[], pads_by_net={})
+        st = st([bar]) if st is _FakeSt else st([bar], BEC)
+        moves, segs, out = _nudge(st, pcb)
+        return v, moves, out, rings, outer, cutouts, bi
+
+    def test_a_via_beside_a_real_milled_slot_is_refused_at_the_board_margin(self):
+        # NEGATIVE CONTROL FIRST, because it establishes the geometry the
+        # positive assertion depends on.
+        v, moves, out, rings, outer, cutouts, bi = self._run(_FakeSt)
+        self.assertTrue(rings, 'watchy yielded no rings -- this is the bbox '
+                               'branch again, not the outline branch')
+        self.assertEqual(len(moves), 1,
+                         'the permissive arm did not move; nothing to compare')
+        d = _point_to_rings_distance(v.x, v.y, rings)
+        self.assertTrue(_point_on_board(v.x, v.y, outer, cutouts),
+                        'the permissive arm parked the via off the board, '
+                        'which is a different bug from the one under test')
+        # ON THE BRANCH, twice over: the landing is in the band, AND the bbox
+        # branch would happily accept it -- so the rings are what reject it.
+        self.assertTrue(VIA_R + CLEAR <= d < VIA_R + BEC,
+                        'the landing is %.4f from Edge.Cuts, not in the band '
+                        '(%.3f, %.3f)' % (d, VIA_R + CLEAR, VIA_R + BEC))
+        b = bi.board_bounds
+        self.assertGreater(min(v.x - b[0], b[2] - v.x, v.y - b[1], b[3] - v.y),
+                           VIA_R + BEC,
+                           'the bounding box alone would also reject this '
+                           'point, so the ring geometry proves nothing')
+        v2, moves2, out2, *_ = self._run(_MarginSt)
+        self.assertIn('no clear spot', out2)
+        self.assertEqual(moves2, [],
+                         'the via was parked %.4fmm from a real milled slot' % d)
+    # MUTATION: `need = r + edge_margin` -> `need = r + clearance` in the RING
+    # branch -- the via is parked 0.719mm from Edge.Cuts.
+
+
+class TestTheDuckTypedPathStaysInert(unittest.TestCase):
+    """#370/#617 pass an st with no resolvers. Their fixtures do NOT pin the
+    fallback -- every landing they exercise clears 0.80mm -- so it is pinned
+    here or nowhere."""
+
+    def test_the_fallback_is_exactly_the_clearance_argument(self):
+        st = _FakeSt([HBAR])
+        # ON THE BRANCH: the fake must not have grown a margin.
+        self.assertIsNone(getattr(st, 'edge_margin', None),
+                          'the fake carries a margin, so the fallback branch '
+                          'is never taken and this test is vacuous')
+        # Bracket it. 2.15 leaves 0.55 of room and needs fallback + 0.25 <= 0.55;
+        # 2.05 leaves 0.45 and must still refuse. Together the fallback is pinned
+        # to the OPEN interval (0.20, 0.30) -- open at BOTH ends, measured: 0.30
+        # itself fails the 2.15 arm, because the bbox branch has no -1e-6
+        # tolerance where the rings branch does. CLEAR is 0.25, comfortably
+        # inside. This BRACKETS the fallback; it does not prove it EQUALS
+        # `clearance`, and an earlier version of this docstring overclaimed
+        # that. What it rules out is the regression that matters: a 0.55
+        # fallback, which neither #370 nor #617 would notice.
+        _v, _p, moves_hi, _s, _o = _rig_a(2.15, _FakeSt([HBAR]))
+        self.assertEqual(len(moves_hi), 1,
+                         'the fallback is above 0.30 -- a 0.55 fallback lands '
+                         'here, and neither #370 nor #617 would notice')
+        _v2, _p2, moves_lo, _s2, _o2 = _rig_a(2.05, _FakeSt([HBAR]))
+        self.assertEqual(moves_lo, [],
+                         'the fallback is at or below 0.20 -- lower than the '
+                         'clearance the caller passed')
+        # ...and an st that declares exactly CLEAR is indistinguishable from an
+        # st with no margin at all, on every arm.
+        for top in (2.05, 2.15, 2.60):
+            a = _rig_a(top, _FakeSt([HBAR]))[2]
+            b = _rig_a(top, _MarginSt([HBAR], CLEAR))[2]
+            self.assertEqual(len(a), len(b),
+                             'the absent-margin path and an explicit %s '
+                             'diverge at top %s' % (CLEAR, top))
+    # MUTATION: `getattr(st, 'edge_margin', None)` -> `..., 0.55)` -- the 2.15
+    # arm gives 0 moves. Verified: NEITHER #370 NOR #617 catches this.
+
+    def test_the_nudger_reads_st_s_margin_rather_than_recomputing_it(self):
+        st = _SpySt([HBAR], BEC)
+        _v, _p, moves, _s, out = _rig_a(2.15, st)
+        self.assertEqual(st.reads, 1,
+                         'edge_margin was read %d times; the #725 shim block '
+                         'reads each resolver exactly once, outside the '
+                         'candidate sweep' % st.reads)
+        # Paired with the behavioural half, so a mutant that reads the value
+        # and then discards it is caught too.
+        self.assertEqual(moves, [], 'the value was read but not used')
+        self.assertIn('no clear spot', out)
+    # MUTATION: `edge_margin = clearance` (ignore st) -> reads == 0 AND the
+    # via moves.
+
+    def test_no_edge_test_in_the_nudger_spells_the_bare_clearance(self):
+        """Guards the two sites by spelling as well as behaviour, because a
+        third edge test could be added tomorrow with the old convention."""
+        src = inspect.getsource(FC.nudge_vias_for_unresolved).splitlines()
+        bad = [f'{i + 1}: {ln.strip()}' for i, ln in enumerate(src)
+               if 'need = ' in ln and 'edge_margin' not in ln]
+        self.assertEqual(bad, [],
+                         'an edge test still gates on something other than '
+                         'edge_margin: %s' % bad)
+        # ON THE BRANCH: the resolver is read at all.
+        self.assertTrue(any('edge_margin' in ln for ln in src),
+                        'the nudger does not mention edge_margin, so the guard '
+                        'above is vacuously satisfied')
+    # MUTATION: re-introduce `need = r + clearance` at either site.
+
+
+class TestTheEdgeMarginResolver(unittest.TestCase):
+    """resolve_cap_edge_clearance: tighten-only, and every branch reachable."""
+
+    def _board_declaring(self, tmp, value, name):
+        pcb = os.path.join(tmp, name + '.kicad_pcb')
+        shutil.copyfile(BOARD, pcb)
+        with open(os.path.splitext(pcb)[0] + '.kicad_pro', 'w',
+                  encoding='utf-8') as f:
+            json.dump({'board': {'design_settings': {
+                'rules': {'min_copper_edge_clearance': value}}}}, f)
+        return pcb
+
+    def test_an_explicit_positive_value_is_honoured_in_both_directions(self):
+        self.assertEqual(resolve_cap_edge_clearance(BOARD, 0.2),
+                         (0.2, 'cli'),
+                         'an operator asking for LESS was overridden')
+        self.assertEqual(resolve_cap_edge_clearance(BOARD, 0.9),
+                         (0.9, 'cli'))
+    # MUTATION: drop the `if explicit is not None and explicit > 0` early return.
+
+    def test_an_explicit_ZERO_is_unset_rather_than_a_margin_of_zero(self):
+        """The footgun the #733 review found in this change: the GUI's Min Edge
+        Clearance spin is CREATED at defaults.BOARD_EDGE_CLEARANCE (0.0) with a
+        range minimum of 0.0, so "ticked the override, typed nothing" hands this
+        a 0. Honoured literally, the cap margin would fall to max(clearance, 0)
+        -- the bare clearance -- which is the 0.30mm under-block #733 closes,
+        re-opened through a different door and LOOSER than the plugin's old
+        0.55. Same rule resolve_cli_floor applies to every routing floor."""
+        for zero in (0, 0.0, -0.1):
+            self.assertEqual(
+                resolve_cap_edge_clearance(BOARD, zero),
+                (CAP_EDGE_CLEARANCE, 'fixed default'),
+                'an explicit %r was taken as a real margin' % (zero,))
+        # NEGATIVE CONTROL: a small POSITIVE value is still honoured, so the
+        # guard has not swallowed the operator's override wholesale.
+        self.assertEqual(resolve_cap_edge_clearance(BOARD, 0.01),
+                         (0.01, 'cli'))
+    # MUTATION: `explicit is not None and explicit > 0` -> `explicit is not
+    # None` -- the 0 arms return (0.0, 'cli').
+
+    def test_a_board_asking_for_more_room_raises_the_margin(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            pcb = self._board_declaring(tmp, 0.9, 'roomy')
+            # ON THE BRANCH: the declaration must exceed the default, or this
+            # is the fixed-default branch wearing a different name.
+            self.assertGreater(0.9, CAP_EDGE_CLEARANCE)
+            self.assertEqual(resolve_cap_edge_clearance(pcb),
+                             (0.9, 'board constraint, raised'))
+    # MUTATION: `declared > CAP_EDGE_CLEARANCE` -> `declared is not None`
+    # still passes here; it is the NEXT test that kills that one.
+
+    def test_a_board_asking_for_less_can_never_lower_the_margin(self):
+        """The reason this is tighten-only. 0.20 is not hypothetical: it is the
+        fab copper-to-edge floor fix_project_for_output PINS into every board
+        this pipeline writes, so a plainly board-first read would take this
+        pipeline's own default back as the board's declaration."""
+        with tempfile.TemporaryDirectory() as tmp:
+            for value in (0.2, 0.5, 0.0):
+                pcb = self._board_declaring(tmp, value, 'tight%s' % value)
+                self.assertEqual(
+                    resolve_cap_edge_clearance(pcb),
+                    (CAP_EDGE_CLEARANCE, 'fixed default'),
+                    'a declared %s LOWERED the cap margin' % value)
+    # MUTATION: `declared > CAP_EDGE_CLEARANCE` -> `declared is not None and
+    # declared > 0` -- the 0.2 and 0.5 arms drop the margin.
+
+    def test_a_board_with_no_project_and_an_unreadable_one_take_the_default(self):
+        self.assertEqual(resolve_cap_edge_clearance(BOARD),
+                         (CAP_EDGE_CLEARANCE, 'fixed default'))
+        # ON THE BRANCH: BOARD really has no sibling project, or the assertion
+        # above is testing the wrong branch.
+        self.assertFalse(
+            os.path.exists(os.path.splitext(BOARD)[0] + '.kicad_pro'),
+            'the inert board grew a .kicad_pro; pick another')
+        # Not a path at all -- an unsaved GUI board reaches this.
+        self.assertEqual(resolve_cap_edge_clearance(None),
+                         (CAP_EDGE_CLEARANCE, 'fixed default'))
+    # MUTATION: remove the try/except -> the None case raises TypeError.
+
+    def test_the_engine_resolves_an_omitted_margin_and_says_so(self):
+        """The default is None, and the ENGINE resolves it -- which is what
+        makes the CLI, the plugin and the animator agree without any of them
+        carrying a copy."""
+        import placement.fanout_clearance as mod
+        sig = inspect.signature(mod.repair_fanout_clearance)
+        self.assertIsNone(sig.parameters['board_edge_clearance'].default,
+                          'the engine still carries a numeric default, so a '
+                          'front end that passes nothing gets it silently')
+        pcb = parse_kicad_pcb(BOARD)
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            mod.repair_fanout_clearance(pcb, BOARD, clearance=CLEAR,
+                                        max_displacement=0.0, max_passes=1)
+        self.assertIn('board-edge margin for caps: 0.55mm (fixed default)',
+                      buf.getvalue(),
+                      'the engine resolved the margin without disclosing it')
+        # ...and it discloses an EXPLICIT one too. Printing only the resolved
+        # case would disclose exactly the branch that needs no explaining, and
+        # an operator reading a transcript would have to know which of three
+        # fronts invoked this to know which margin it used.
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            mod.repair_fanout_clearance(pcb, BOARD, clearance=CLEAR,
+                                        board_edge_clearance=0.2,
+                                        max_displacement=0.0, max_passes=1)
+        self.assertIn('board-edge margin for caps: 0.2mm (cli)', buf.getvalue(),
+                      'a caller-supplied margin is applied silently')
+
+    def test_the_resolved_margin_actually_reaches_the_repair_state(self):
+        """The wire, not the report. Everything else here either constructs
+        _Repair directly with an explicit margin or reads the PRINTED line, so
+        a build that resolved the margin, printed it, and then handed _Repair
+        the UNRESOLVED value would pass the lot -- the "asserts a reported
+        value rather than the one used" hole the #733 fact-check went looking
+        for. Spy on the constructor and read what it was actually given."""
+        import placement.fanout_clearance as mod
+        seen = []
+        real = mod._Repair
+
+        class _Spy(real):
+            def __init__(self, pcb, path, clearance, grid_step, bec, *a, **kw):
+                seen.append(bec)
+                super().__init__(pcb, path, clearance, grid_step, bec, *a, **kw)
+
+        pcb = parse_kicad_pcb(BOARD)
+        mod._Repair = _Spy
+        try:
+            with contextlib.redirect_stdout(io.StringIO()):
+                mod.repair_fanout_clearance(pcb, BOARD, clearance=CLEAR,
+                                            max_displacement=0.0, max_passes=1)
+                mod.repair_fanout_clearance(parse_kicad_pcb(BOARD), BOARD,
+                                            clearance=CLEAR,
+                                            board_edge_clearance=0.9,
+                                            max_displacement=0.0, max_passes=1)
+        finally:
+            mod._Repair = real
+        # ON THE BRANCH: the spy must have run, or `seen` is empty and every
+        # assertion below is vacuously true.
+        self.assertEqual(len(seen), 2, 'the _Repair spy never ran')
+        self.assertEqual(seen[0], CAP_EDGE_CLEARANCE,
+                         'the omitted margin was RESOLVED and PRINTED but '
+                         '%r reached _Repair' % (seen[0],))
+        self.assertEqual(seen[1], 0.9,
+                         'an explicit margin did not reach _Repair')
+    # MUTATION: pass `board_edge_clearance` (the parameter) to _Repair instead
+    # of the resolved value -> seen[0] is None and this is the only test that
+    # notices.
+    # MUTATION: `board_edge_clearance: Optional[float] = None` -> `= 0.55`.
+
+
+class TestTheFrontEndsDoNotCarryTheirOwnCopy(unittest.TestCase):
+    """#733's other two facts: the CLI hardcoded 0.55 and the GUI passed
+    nothing at all. Both must now defer to the engine."""
+
+    def test_the_two_clis_default_to_none_so_the_engine_resolves(self):
+        # assertTrue on a computed boolean, never assertIn against a whole
+        # file: a failing assertIn prints the ENTIRE haystack, and a 100KB
+        # failure message buries the one line that matters (#732's lesson).
+        for script in ('py_placer/place_fanout_clearance.py',
+                       'py_tools/animate_fanout_clearance.py'):
+            with open(os.path.join(_ROOT, script), encoding='utf-8') as f:
+                src = f.read()
+            self.assertTrue(
+                '"--board-edge-clearance", type=float, default=None' in src,
+                '%s still carries its own numeric edge default' % script)
+    # MUTATION: put `default=0.55` back in either script.
+
+    def test_the_plugin_passes_the_margin_to_the_engine(self):
+        with open(os.path.join(_ROOT, 'kicad_routing_plugin', 'fanout_gui.py'),
+                  encoding='utf-8') as f:
+            src = f.read()
+        self.assertTrue(
+            "board_edge_clearance=fanout_config.get('cap_board_edge_clearance')"
+            in src,
+            'the plugin does not pass the cap edge margin, so it takes the '
+            'engine signature default whatever the operator asked for')
+        # ...and the key is actually populated, on BOTH entry points.
+        self.assertEqual(
+            src.count("'cap_board_edge_clearance': shared.get("), 2,
+            'only one of the two GUI entry points populates the key')
+        # NEGATIVE CONTROL, and the trap this design had to avoid: the QFN
+        # SIGNAL keep-out is a DIFFERENT key that answers 0.0 on a board with
+        # no edge rule (fab-floored to 0.20 by _effective_board_edge_clearance)
+        # and also feeds update_live_drc_floors. Reusing it would have inset
+        # caps at 0.20 instead of 0.55 -- a 0.35mm relaxation shipped inside
+        # the parity fix. Measured on the real headless dialog: unchecked, the
+        # signal key reads 0.2 and the cap key reads None.
+        self.assertTrue(
+            "board_edge_clearance=shared.get('board_edge_clearance', 0.0)"
+            in src,
+            'the QFN signal keep-out kwarg changed; the cap margin was meant '
+            'to be a SEPARATE key and this control no longer proves it is')
+    # MUTATION: drop the board_edge_clearance kwarg from the engine call.
+
+    def test_a_recorded_manifest_carries_an_explicit_flag_into_the_plan(self):
+        sys.path.insert(0, os.path.join(_TESTS, 'stress'))
+        import manifest_to_plan as M
+        step = M.cap_optimization_step(
+            ['py_placer/place_fanout_clearance.py', 'b.kicad_pcb',
+             '--board-edge-clearance', '0.3', '--near-margin', '1.5'])
+        self.assertEqual(step['params'].get('board_edge_clearance'), 0.3,
+                         'an explicit --board-edge-clearance is dropped on '
+                         'replay, so the GUI plan routes at a different margin')
+        # ON THE BRANCH: the converter is doing real work, not returning {}.
+        self.assertEqual(step['params'].get('cap_near_margin'), 1.5)
+        # ...and the param name is one the plan executor can apply.
+        with open(os.path.join(_ROOT, 'kicad_routing_plugin', 'ai_plan.py'),
+                  encoding='utf-8') as f:
+            src = f.read()
+        self.assertTrue("'board_edge_clearance': 'edge_clearance_check'" in src,
+                        'the plan executor has no override checkbox for this '
+                        'param, so a plan carrying it would set a disabled '
+                        'control and the value would be ignored')
+    # MUTATION: remove the CAP_FLAG_PARAMS row.
+
+
+class TestTheCorpusBound(unittest.TestCase):
+    """What the change can and cannot reach on boards this repo can measure."""
+
+    def _tracked(self):
+        # EVERY tracked board, not just kicad_files/ -- five more live under
+        # tests/fixtures/, and an earlier version of this scan missed them while
+        # the PR called its result "the tracked corpus".
+        out = subprocess.run(['git', 'ls-files', '*.kicad_pcb'],
+                             cwd=_ROOT, capture_output=True, text=True)
+        return [os.path.join(_ROOT, p) for p in out.stdout.split()
+                if p.endswith('.kicad_pcb')]
+
+    def test_no_tracked_board_carries_a_milled_ring_this_change_could_refuse(self):
+        """The cap mover exempts a milled ring a cap's own pads sit in (#628);
+        the nudger has no analogue, because that exemption exists for a
+        COURTYARD RECT artifact a via does not have. Bound the asymmetry: it is
+        unreachable on every tracked board. When that stops being true this
+        test fails, which is the point."""
+        boards = self._tracked()
+        self.assertGreater(len(boards), 25,
+                           'git ls-files returned %d boards -- never glob the '
+                           'directory, 11 boards in kicad_files/ alone are '
+                           'gitignored build products' % len(boards))
+        milled, ringed = [], []
+        for b in boards:
+            bi = parse_kicad_pcb(b).board_info
+            if [c for c in (getattr(bi, 'board_edge_contours', None) or [])
+                    if len(c) >= 3]:
+                milled.append(os.path.basename(b))
+            rings, _o, _c = board_edge_geometry(bi)
+            if rings:
+                ringed.append(os.path.basename(b))
+        self.assertEqual(milled, [],
+                         'a tracked board now carries a milled contour (%s) -- '
+                         'the "#628 asymmetry is unreachable" claim in the PR '
+                         'must be re-measured' % milled)
+        # ON THE BRANCH: some boards DO yield rings, so the scan is real.
+        self.assertTrue(ringed, 'no tracked board yielded any Edge.Cuts ring, '
+                                'so this scan proves nothing')
+    # MUTATION: add a milled Edge.Cuts contour to any tracked board.
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/test_736_fanout_clearance_regrade_view.py
+++ b/tests/test_736_fanout_clearance_regrade_view.py
@@ -104,13 +104,20 @@ Conventions this file follows (#697/#725/#731/#732/#733/#737 and CLAUDE.md):
         mutations -- dropping `_item_reach`, and omitting the floor map --
         cancel and both survive.
 
-MUTATION BATTERY: 18 single-line mutations of the fix, 18 killed, each named
+MUTATION BATTERY: 22 single-line mutations of the fix, 22 killed, each named
 by the arm that kills it under `TestOneConstructionSiteOnePrunePredicate`. Two
 false-positive probes -- a trailing comment naming a guarded literal, and a
 comment line naming the pricing spelling -- are correctly inert.
 
-Two of the eighteen exist because the FIRST run of that battery let them
-through, and both are recorded rather than quietly fixed:
+Four of the twenty-two (19-22) exist because an adversarial review of this
+branch found a defect the fix INTRODUCED: `required_rows` grades the seed pose
+as well as the final one, and a connector the pass DREW did not exist at the
+seed, so charging it there invented a `track <net>` row describing a pair no
+board ever had -- the same class of phantom #731 removed from that very report.
+`TestTheSeedHalfOfTheDisclosureIgnoresPassCreatedCopper` is that finding.
+
+Two more exist because the FIRST run of the battery let them through, and both
+are recorded rather than quietly fixed:
 
   * `if via_moves:` -> `if True:` changes no NUMBER, because the via prune is
     exact and de-pruning grades identically. The first version of
@@ -218,6 +225,15 @@ DECL_CLASS = [{'name': 'Default', 'clearance': 0.2, 'track_width': 0.2,
 DECL_LC = 0.5               # a pad override, so pair() != _item_reach()
 DECL_T5 = 0.35              # HW + _item_reach(seg floor)  = 0.15 + max(0.1,0.2)
 DECL_EFF = 0.65             # HW + pair(cap floor, seg floor) = 0.15 + 0.5
+
+# A connector hugging C1's SEED pads: 0.100 off pad 2's seed edge against the
+# 0.650 declared keep-out, so it IS charged there -- and 1.900 clear of the
+# pads once the cap has walked SEED_HUG_WALK away, so it is NOT charged at the
+# pose the pass left it in. That asymmetry is the whole of the seed-half
+# disclosure defect an adversarial review found in this branch.
+SEED_HUG = {'start': (10.90, CAP_XY[1]), 'end': (11.05, CAP_XY[1]),
+            'width': TRACK_W, 'layer': 'F.Cu', 'net_id': NET_V}
+SEED_HUG_WALK = 2.5
 
 
 def _bga():
@@ -665,6 +681,58 @@ class TestTheRefreshIsSkippedWhenNothingMoved(unittest.TestCase):
     # asserted only the track half and the mutation SURVIVED the battery.
 
 
+class TestTheSeedHalfOfTheDisclosureIgnoresPassCreatedCopper(unittest.TestCase):
+    """`required_rows` grades `_seg_shortfalls` at the SEED pose as well as the
+    final one -- deliberately, so that a pass which SUCCEEDS still discloses
+    the raised requirement that did the work.
+
+    A connector this pass DREW did not exist at the seed. Charging it there
+    invents a `track <net>` row describing a pair no board ever had, which is
+    exactly the class of phantom #731 removed from this very report. Measured
+    on the rig below before the scope was added: `{3: 0.550}` charged at the
+    seed against `{}` at the final pose -- 0.650 (the declared eff cell) minus
+    the 0.100 the connector sits off pad 2's SEED edge.
+
+    Found by an adversarial review of this branch, not by me.
+    """
+
+    def test_a_connector_hugging_the_SEED_pads_produces_no_track_row(self):
+        with _stub(DECL_CLASS) as path:
+            pcb, v = _board(VIA_CLEAR, 'F.Cu', lc=DECL_LC)
+            st = _Repair(pcb, path, CLEAR, 0.1, 0.55, 1.0, 2.0, 0.3, 'C',
+                         set())
+            self.assertIsNotNone(st._floors, 'an INERT board discloses '
+                                             'nothing, so this arm would pass '
+                                             'on an empty report')
+            cap = st.caps['C1']
+            seed_n = st._seed_seg_n['C1']
+            cap.x = cap.seed_x - SEED_HUG_WALK      # the pose the pass left
+            self.assertEqual(st.register_new_segments([SEED_HUG]), 1)
+            self.assertEqual(len(st.cap_segs['C1']), seed_n + 1)
+
+            # ON THE BRANCH: the fixture really does reach the phantom -- the
+            # connector is charged at the seed pose over ALL copper, and clear
+            # at the pose the cap is actually in.
+            self.assertEqual(
+                st._seg_shortfalls('C1', cap, cap.x, cap.y, cap.rot), {})
+            self.assertIn(
+                NET_V, st._seg_shortfalls('C1', cap, cap.seed_x, cap.seed_y,
+                                          cap.seed_rot))
+            # ...and scoped to the seed-era copper it is not
+            self.assertEqual(
+                st._seg_shortfalls('C1', cap, cap.seed_x, cap.seed_y,
+                                   cap.seed_rot, upto=seed_n), {})
+
+            tracks = [r for r in st.required_rows({})
+                      if str(r[1]).startswith('track ')]
+            self.assertEqual(tracks, [],
+                             'the disclosure names a track pair that exists '
+                             'on neither the seed board nor the final one')
+    # MUTATION: drop the `upto` slice from _seg_shortfalls; record
+    # _seed_seg_n AFTER the append instead of in __init__; pass no seed_kw to
+    # both() for the track kind.
+
+
 class TestThePruneIsAnchoredOnTheSEEDPose(unittest.TestCase):
     """By the time a connector is registered the caps have already moved, so
     `_prune_segs` is handed `self._cap_geom` -- the SEED-pose geometry -- and
@@ -722,7 +790,7 @@ class TestOneConstructionSiteOnePrunePredicate(unittest.TestCase):
     are REPORTED; never `assertIn` over the whole source (#732 measured a
     393KB failure message from that).
 
-    THE BATTERY, as RUN: 18 mutations, 18 killed, plus two inert probes.
+    THE BATTERY, as RUN: 22 mutations, 22 killed, plus two inert probes.
 
       1  delete the refresh call ............ graze_penalty_RISES + 3 others
       2  call it BEFORE the nudge ........... graze_penalty_RISES + 3 others
@@ -742,10 +810,16 @@ class TestOneConstructionSiteOnePrunePredicate(unittest.TestCase):
       16 drop the distance filter ........... prune_predicate_has_ONE_spelling
       17 make the refresh unconditional ..... RefreshIsSkippedWhenNothingMoved
       18 prune from the MOVED pose .......... PruneIsAnchoredOnTheSEEDPose
+      19 ignore the `upto` seed scope ....... SeedHalfIgnoresPassCreatedCopper
+      20 record `_seed_seg_n` after the append  same
+      21 grade the seed half over ALL copper .. same
+      22 registrar reports the wrong count ... same
 
-    10, 11, 15, 16, 17 and 18 have exactly ONE killer each; the module
-    docstring records that 17 and 18 SURVIVED the first run of this battery and
-    what was added to catch them.
+    TEN of them -- 10, 11, 15, 16, 17, 18 and each of 19-22 -- have exactly
+    ONE killer, which is why those arms exist at all; the
+    module docstring records that 17 and 18 SURVIVED the first run of this
+    battery, and that 19-22 exist because a review found a defect the fix
+    itself introduced.
 
     INERT PROBES, which must change nothing: a trailing comment naming
     `self._seg_floor_by_id[`, and a comment line naming the pricing spelling

--- a/tests/test_736_fanout_clearance_regrade_view.py
+++ b/tests/test_736_fanout_clearance_regrade_view.py
@@ -1,0 +1,954 @@
+"""#736: the post-nudge re-grade must see the copper the pass itself drew.
+
+`repair_fanout_clearance` ends by asking `nudge_vias_for_unresolved` to move
+offending vias, then re-grades to produce the final `unresolved` list. The
+nudger does TWO things to the board: it moves vias, and it APPENDS new
+connector `Segment`s to `pcb_data.segments` to restore continuity back to each
+moved via's stub start.
+
+The re-grade refreshed only the via view (`st.cap_vias = {r: st.vias ...}`).
+`st.segments`, `st.cap_segs` and `st._seg_floor_by_id` were snapshotted in
+`_Repair.__init__`, before those connectors existed, and nothing rebuilt them --
+so `_seg_shortfalls`, the PAD-SEGMENT channel of `graze_penalty`, and
+`required_rows`' disclosure both read a stale track view. Both front ends WRITE
+that copper (placement/writer.py on the CLI, the plugin's pcbnew mirror in the
+GUI), so the summary is a statement about a board that already carries it.
+
+THE HEADLINE, measured on the rig below at `--clearance 0.1` and graded by the
+AUTHORITATIVE checker rather than by the repair pass's own grader:
+
+    arm B  through-hole cap pads, connector on B.Cu
+      before   1 via move, 1 connector, `unresolved == []`      <- RESOLVED
+      after    same move, same connector, `unresolved == ['C1']`
+      check_drc.check_pad_segment_overlap(C1.2, the connector)
+               -> violation, overlap 0.1200mm
+
+That overlap IS the requirement: the connector's copper reaches 0.020mm INSIDE
+the pad (0.130 centre-gap minus its 0.150 half-width), and the repair's own
+grader charges the same 0.1200.
+
+WHICH WINDOW THIS RUNS THROUGH, stated precisely because the obvious reading is
+wrong. On the connector's OWN layer the draw gate and the accept gate are the
+same number -- `connector_clear` charges `hw + req(pfl, cfl)` and `_seg_effs`
+charges `halves[j] + _pair_or_flat(fa, floors[j])` with `halves[j] == hw`, the
+same two floors through the same resolver -- and `connector_clear` is the
+STRICTER of the two, by EPS. So an ACCEPTED same-layer connector can never be
+charged here, and `TestTheDrawGateAndTheGraderAgreeOnTheSameLayer` measures
+that rather than asserting it. Two windows remain:
+
+  * arm B, the #738 window: `connector_clear` scopes a cap pad by the
+    FOOTPRINT's side (`cl != layer`), so it never tests a back-side or
+    inner-layer connector against a THROUGH-HOLE cap pad, whose copper spans
+    every layer. This is a REAL violation -- check_drc agrees, above.
+  * arm C, a window #738's own proposed fix does NOT close: a connector on a
+    layer absent from `_all_cu` is charged by `_seg_shares` (which charges an
+    unknown layer on purpose) while `connector_clear` skips it. Measured
+    identical numbers to arm B with no through-hole pad anywhere -- BUT
+    check_drc grades that pair CLEAN. It is the module's documented
+    over-block, not a shipped violation, and its test says so.
+
+An earlier draft of this file had that backwards and called arm C the durable
+demonstration of a shipped violation. It is durable; it is not a violation.
+
+WHY THE RIG IS SYNTHETIC. Measured over the 22 boards `git ls-files
+kicad_files/*.kicad_pcb` returns, at `--clearance` 0.25 and 0.10: 2 run the
+full pass, 1 reaches the via-nudger, and **0 emit a connector**. The one in-repo
+configuration that does is the FALLBACK-OFF leg of the frozen sweep
+`test_fanout_clearance.py` uses -- orangecrab_ext_pll at 0.10, 9 via moves and
+17 connectors on B.Cu / F.Cu / In1.Cu / In2.Cu -- and after the fix all 17
+enter the grader's view and NOTHING changes (`unresolved` 10 -> 10, every
+per-cap shortfall `{}`). Both facts are asserted by
+`TestInertOnTheTrackedCorpus`, the second so the first cannot be a statement
+about unreachable code.
+
+Which leg, precisely, because the obvious answer is wrong: that test runs both,
+and `via_clear_fallback=False` is the load-bearing flag. With the fallback ON
+the same board reports 0 unresolved, so the nudger is never called at all -- 0
+moves, 0 connectors. `allow_rotations` makes no difference either way.
+Measured, all four combinations.
+
+THE ZONE IS THE TRICK. `conn_layers` can be fed by a same-net segment, a
+via-in-pad pad, or a ZONE. A stub `Segment` terminating at the via necessarily
+starts inside the cap's keep-out on its own layer and destroys the isolation; a
+via-in-pad `Pad` enters `foreign_pads` and charges the pad channel.
+`_Repair.__init__` reads `pcb_data.zones` NOWHERE -- the module's only read is
+inside `nudge_vias_for_unresolved`'s pour-tie loop -- so a zone carries the
+connector's LAYER in as a free parameter while leaving every keep-out channel
+empty. The board therefore has ZERO segments until the connector exists, and
+every arm's seed `seg_penalty` is exactly 0.0000.
+
+Conventions this file follows (#697/#725/#731/#732/#733/#737 and CLAUDE.md):
+
+  * REAL parser dataclasses, and a real file on disk -- `_Repair.__init__`
+    reads courtyards, locked refs and the clearance model from `pcb_file`.
+  * Every assertion names the single-line MUTATION that must kill it.
+  * Assert you are ON THE BRANCH before asserting about it.
+  * Every "is refused" is paired with a NEGATIVE CONTROL that still moves, and
+    every "is charged" with one that is drawn and correctly NOT charged.
+  * A refusal is asserted from the PRINTED OUTPUT before the counts -- a
+    refusal that prints nothing is indistinguishable from a pass that never
+    looked (#732's silent-failure lesson).
+  * No fixture sits within 0.05mm of the quantity its assertion measures. The
+    two gaps are 0.130 and 0.375 against a 0.250 keep-out, i.e. 0.120 and 0.125
+    of margin. THREE tighter boundaries exist and are named here rather than
+    left for a reviewer to find:
+      - the landing (11.330) clears the VIA keep-out (11.300) by 0.030. That is
+        the spiral's own 0.05mm radial quantum, and no assertion measures it --
+        the landings are asserted EXACTLY, so they are change detectors for
+        precisely that.
+      - C2's probe pose sits 0.100 past the plateau edge at dy = 1.70 (where
+        its pad's y-range starts covering the connector). Asserted on the
+        plateau, at dy = 1.80.
+      - the declaring arm's `t[5]` (0.350) and its `effs` cell (0.650) differ
+        by 0.300 ON PURPOSE: without that inequality the two likeliest
+        mutations -- dropping `_item_reach`, and omitting the floor map --
+        cancel and both survive.
+
+MUTATION BATTERY: 18 single-line mutations of the fix, 18 killed, each named
+by the arm that kills it under `TestOneConstructionSiteOnePrunePredicate`. Two
+false-positive probes -- a trailing comment naming a guarded literal, and a
+comment line naming the pricing spelling -- are correctly inert.
+
+Two of the eighteen exist because the FIRST run of that battery let them
+through, and both are recorded rather than quietly fixed:
+
+  * `if via_moves:` -> `if True:` changes no NUMBER, because the via prune is
+    exact and de-pruning grades identically. The first version of
+    `TestTheRefreshIsSkippedWhenNothingMoved` asserted only the track half and
+    the mutation survived. It is now caught on list IDENTITY -- `cap_vias[ref]
+    is not st.vias` -- which is the real consequence: an eff-matrix rebuild of
+    n_pads x n_ALL_vias per cap, on every board that reaches the nudger and
+    moves nothing, i.e. every tracked board at the shipped defaults.
+  * anchoring the prune on `cap.rect()` instead of `self._cap_geom` survived
+    because every arm here freezes the caps (`max_displacement=0.0`), so no
+    cap ever moves. `TestThePruneIsAnchoredOnTheSEEDPose` moves one by hand.
+
+ONE mutation is DECLARED unkillable rather than papered over: `if via_moves:`
+-> `if new_segs:`. A via move whose `conn_layers` is empty registers nothing
+either way, so no arm can separate them -- recorded as test_737 records its own
+surviving spelling.
+
+Runtime ~40s, in-process apart from one `git ls-files`.
+"""
+from __future__ import annotations
+
+RUN_ALL_FAST_OK = True
+RUN_ALL_TIMEOUT = 900
+
+import contextlib
+import inspect
+import io
+import json
+import os
+import re
+import sys
+import tempfile
+import unittest
+
+_TESTS = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_TESTS)
+for _p in ('', 'py_router', 'py_placer', 'py_tools'):
+    _d = os.path.join(_ROOT, _p)
+    if _d not in sys.path:
+        sys.path.insert(0, _d)
+if _TESTS not in sys.path:
+    sys.path.insert(0, _TESTS)
+
+import routing_defaults as defaults
+import run_utils
+from check_drc import check_pad_segment_overlap
+from kicad_parser import BoardInfo, Footprint, Zone, parse_kicad_pcb
+from placement import fanout_clearance as FC
+from placement.fanout_clearance import _Repair, repair_fanout_clearance
+from synth import make_net, make_pad, make_pcb, make_via
+
+# --- the rig, and every number it is worth ---------------------------------
+CLEAR = 0.1                 # place_fanout_clearance.py's own --help example
+CU = ['F.Cu', 'In1.Cu', 'In2.Cu', 'B.Cu']
+BOUNDS = (0.0, 0.0, 60.0, 20.0)
+TRACK_W = defaults.TRACK_WIDTH      # 0.3 -- the width the pour-tie path falls
+HW = TRACK_W / 2.0                  # back to; imported, never mirrored
+V_SIZE, V_DRILL = 0.8, 0.3
+VR = V_SIZE / 2.0                   # 0.40
+
+NET_V = 3                   # the foreign net the via and its connector carry
+NET_A, NET_B = 11, 12       # C1's two pads
+CAP_XY = (10.0, 10.0)
+CAP2_XY = (10.0, 8.0)
+BGA_XY = (7.6, 10.0)
+
+PAD_HALF = 0.3              # 0.6mm square pads at local +-0.5 ...
+PAD2_EDGE = CAP_XY[0] + 0.5 + PAD_HALF          # ... so pad 2's right edge
+
+SEG_KEEPOUT = HW + CLEAR                        # 0.25, what the GRADER charges
+VIA_KEEPOUT = VR + CLEAR                        # 0.40, what valid_via_pos needs
+
+VIA_DEEP = 10.930           # gap 0.130 -> charged SEG_KEEPOUT - 0.130
+VIA_CLEAR = 11.175          # gap 0.375 -> clear by 0.125
+GAP_DEEP = VIA_DEEP - PAD2_EDGE                 # 0.130
+CHARGE = SEG_KEEPOUT - GAP_DEEP                 # 0.1200
+
+LAND_DEEP = (11.330, 10.0)
+LAND_CLEAR = (11.325, 10.0)
+# The connector runs from the via's OLD position to its new one, so its
+# start is VIA_CLEAR itself. Spelled that way rather than as
+# `LAND_CLEAR[0] - 0.15` -- the same point in arithmetic, and one ULP
+# below it in float.
+CONN_CLEAR = (VIA_CLEAR, CAP_XY[1], LAND_CLEAR[0], CAP_XY[1])
+
+# The per-cap track prune keeps anything within
+#   max_displacement_cap + 2*span + clearance   (+ the track's own over-reach)
+# of the cap's SEED centre: 5.058801mm here (3.0 + 2*0.854400 + 0.1 + 0.25).
+# FAR_D is inside it and FAR_D - WALK_BACK is outside it, both by more than the
+# 0.05 this file allows itself, so a prune anchored on the MOVED pose drops a
+# track the seed-anchored one keeps.
+FAR_D = 4.90
+FAR_SEG = (CAP_XY[0] + FAR_D, CAP_XY[1],
+           CAP_XY[0] + FAR_D + 0.15, CAP_XY[1])
+WALK_BACK = -0.30
+
+# C1 walked +0.30 in x puts its pad edge 0.075 from the connector.
+PROBE_C1 = (0.30, 0.0)
+PROBE_C2 = (0.30, 1.80)
+PROBE_CHARGE = 0.1750
+
+DECL_CLASS = [{'name': 'Default', 'clearance': 0.2, 'track_width': 0.2,
+               'via_diameter': 0.6, 'via_drill': 0.4,
+               'priority': 2147483647}]
+DECL_LC = 0.5               # a pad override, so pair() != _item_reach()
+DECL_T5 = 0.35              # HW + _item_reach(seg floor)  = 0.15 + max(0.1,0.2)
+DECL_EFF = 0.65             # HW + pair(cap floor, seg floor) = 0.15 + 0.5
+
+
+def _bga():
+    """detect_package_type keys on the footprint NAME, so a 3x3 grid whose
+    name says BGA is enough to give _Repair a ball field to sit caps near."""
+    pads = []
+    for i, dx in enumerate((-0.8, 0.0, 0.8)):
+        for j, dy in enumerate((-0.8, 0.0, 0.8)):
+            pads.append(make_pad(net_id=100 + 3 * i + j,
+                                 x=BGA_XY[0] + dx, y=BGA_XY[1] + dy,
+                                 ref='U1', num='%d%d' % (i, j),
+                                 size_x=0.4, size_y=0.4, shape='circle',
+                                 layers=['F.Cu'], local_x=dx, local_y=dy))
+    return Footprint(reference='U1', footprint_name='lib:BGA-9_3x3_0.8mm',
+                     x=BGA_XY[0], y=BGA_XY[1], rotation=0.0, layer='F.Cu',
+                     pads=pads)
+
+
+def _cap(ref, cx, cy, through=False):
+    """A C-prefixed 2-copper-pad part -- what _Repair's cap detection admits.
+
+    `through` is the ONE variable that separates arm B from its control: the
+    pads become `*.Cu` plated through-hole, so their copper spans every layer
+    while the FOOTPRINT still sits on F.Cu. That is the whole of the #738
+    window, expressed as one keyword.
+    """
+    kw = dict(size_x=2 * PAD_HALF, size_y=2 * PAD_HALF, shape='rect')
+    if through:
+        kw.update(layers=['*.Cu', '*.Mask'], drill=0.3, pad_type='thru_hole')
+    else:
+        kw.update(layers=['F.Cu'])
+    pads = [make_pad(net_id=NET_A, x=cx - 0.5, y=cy, ref=ref, num='1',
+                     local_x=-0.5, local_y=0.0, **kw),
+            make_pad(net_id=NET_B, x=cx + 0.5, y=cy, ref=ref, num='2',
+                     local_x=0.5, local_y=0.0, **kw)]
+    return Footprint(reference=ref, footprint_name='lib:C_0402_1005Metric',
+                     x=cx, y=cy, rotation=0.0, layer='F.Cu', pads=pads)
+
+
+def _board(via_x, zone_layer, through=False, second_cap=False, lc=0.0):
+    bi = BoardInfo(layers={}, copper_layers=list(CU), board_bounds=BOUNDS)
+    v = make_via(via_x, CAP_XY[1], net_id=NET_V, size=V_SIZE, drill=V_DRILL)
+    fps = {'U1': _bga(), 'C1': _cap('C1', *CAP_XY, through=through)}
+    if second_cap:
+        fps['C2'] = _cap('C2', *CAP2_XY, through=through)
+    if lc:
+        for p in fps['C1'].pads:
+            p.local_clearance = lc
+    zone = Zone(net_id=NET_V, net_name='N3', layer=zone_layer,
+                polygon=[(via_x - 1.0, CAP_XY[1] - 1.0),
+                         (via_x + 1.0, CAP_XY[1] - 1.0),
+                         (via_x + 1.0, CAP_XY[1] + 1.0),
+                         (via_x - 1.0, CAP_XY[1] + 1.0)])
+    pads_by_net = {}
+    for fp in fps.values():
+        for p in fp.pads:
+            pads_by_net.setdefault(p.net_id, []).append(p)
+    nets = {0: make_net(0, '')}
+    for k in list(pads_by_net) + [NET_V]:
+        nets.setdefault(k, make_net(k, 'N%d' % k))
+    pcb = make_pcb(board_info=bi, nets=nets, vias=[v], segments=[],
+                   footprints=fps, pads_by_net=pads_by_net, zones=[zone])
+    return pcb, v
+
+
+@contextlib.contextmanager
+def _stub(classes=None):
+    """A bare board FILE so the path-reading collaborators degrade cleanly
+    (courtyards -> {}, locked refs -> set(), PadClearanceModel -> INERT unless
+    `classes` declares one). #617's idiom."""
+    with tempfile.TemporaryDirectory() as td:
+        path = os.path.join(td, 'b.kicad_pcb')
+        with io.open(path, 'w', encoding='utf-8') as f:
+            f.write('(kicad_pcb (version 20240108))\n')
+        if classes is not None:
+            with io.open(os.path.join(td, 'b.kicad_pro'), 'w',
+                         encoding='utf-8') as f:
+                json.dump({'net_settings': {'classes': classes,
+                                            'netclass_assignments': {},
+                                            'netclass_patterns': []}}, f)
+        yield path
+
+
+def _run(pcb, path, **kw):
+    """Drive the WHOLE pass, capturing stdout and the internal `_Repair`.
+
+    `on_move` is the supported hook the animator uses: it is handed the state
+    at the seed frame, and every frame is the SAME object, so it is the only
+    way to see cap_segs / segments / _seg_floor_by_id from outside without
+    monkeypatching.
+
+    max_displacement=0.0 with max_passes=1 is the BOXED cap of #313 expressed
+    as a budget rather than as a wall of obstacle geometry -- the same rig
+    tests/test_fanout_clearance.py's via-clear-fallback check uses.
+    """
+    seen, buf = [], io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        res = repair_fanout_clearance(
+            pcb, path, clearance=CLEAR, cap_prefix='C',
+            max_displacement=0.0, max_passes=1, allow_rotations=False,
+            via_clear_fallback=False, on_move=lambda st: seen.append(st), **kw)
+    return res, (seen[0] if seen else None), buf.getvalue()
+
+
+def _arm(via_x, zone_layer, **kw):
+    with _stub(kw.pop('classes', None)) as path:
+        pcb, v = _board(via_x, zone_layer, **kw)
+        pre = None
+
+        res, st, out = _run(pcb, path)
+        return pcb, v, res, st, out, pre
+
+
+class TestTheDrawGateAndTheGraderAgreeOnTheSameLayer(unittest.TestCase):
+    """The measurement that LICENSES this file's framing: on the connector's
+    own layer the two gates are the same number, so #736 cannot ship a false
+    RESOLVED there. Without this, every other arm reads as a lucky fixture."""
+
+    def test_a_same_layer_connector_in_the_keepout_is_REFUSED_at_draw_time(self):
+        pcb, v, res, st, out, _ = _arm(VIA_DEEP, 'F.Cu')
+        # ON THE BRANCH: the cap really is a violator, so the nudger really ran
+        self.assertIn('Caps initially grazing foreign copper', out)
+        self.assertEqual(sorted(st.caps), ['C1'],
+                         'U1 leaked into the cap set; cap_prefix is wrong')
+        self.assertLess(GAP_DEEP, SEG_KEEPOUT - 0.05,
+                        'the fixture no longer sits inside the keep-out')
+        # the PRINTED refusal first (#732): a refusal that prints nothing is
+        # indistinguishable from a pass that never looked
+        self.assertIn("via-nudge: no clear spot for C1's offending via", out)
+        self.assertEqual(res['via_moves'], [])
+        self.assertEqual(res['new_segments'], [])
+        self.assertEqual((v.x, v.y), (VIA_DEEP, CAP_XY[1]))
+        self.assertEqual(len(pcb.segments), 0)
+    # MUTATION: none -- this arm licenses the claim rather than testing the
+    # fix, and it fails loudly if the draw gate is ever weakened.
+
+    def test_the_NEGATIVE_control_with_room_still_moves(self):
+        pcb, v, res, st, out, _ = _arm(VIA_CLEAR, 'F.Cu')
+        self.assertIn('via-nudge: moved', out)
+        self.assertEqual(len(res['via_moves']), 1)
+        self.assertEqual((round(v.x, 4), round(v.y, 4)), LAND_CLEAR)
+    # MUTATION: none (control).
+
+    def test_the_two_gates_resolve_to_the_SAME_requirement(self):
+        """Arithmetic, not geometry: `connector_clear` charges
+        `hw + req(pfl, cfl)` and `_seg_effs` charges `halves + pair(fa, fb)`
+        from the same two floors. Compared on a DECLARING board, where both
+        are free to be wrong differently."""
+        with _stub(DECL_CLASS) as path:
+            pcb, v = _board(VIA_CLEAR, 'F.Cu', lc=DECL_LC)
+            st = _Repair(pcb, path, CLEAR, 0.1, 0.55, 1.0, 2.0, 0.3, 'C',
+                         set())
+            self.assertIsNotNone(st._floors, 'the model is INERT -- this arm '
+                                             'would compare 0.1 with 0.1')
+            cap = st.caps['C1']
+            st.register_new_segments([{'start': CONN_CLEAR[:2],
+                                       'end': CONN_CLEAR[2:],
+                                       'width': TRACK_W, 'layer': 'F.Cu',
+                                       'net_id': NET_V}])
+            cfl = st.seg_floor(NET_V, 'F.Cu')
+            drawn = HW + st.required(cap.pad_floors[1], cfl)
+            graded = st._seg_effs('C1', cap)[1][-1]
+            self.assertAlmostEqual(drawn, graded, places=12)
+            self.assertAlmostEqual(graded, DECL_EFF, places=9)
+    # MUTATION: price the tuple at `HW + self.clearance` -> graded 0.25 != drawn.
+
+
+class TestTheConnectorEntersTheGradersView(unittest.TestCase):
+    """LOAD-BEARING, and deliberately built on a connector the draw gate
+    genuinely ACCEPTS on the cap's own layer. Nothing here depends on #738 or
+    on any layer-scope divergence, so #738 landing cannot touch it."""
+
+    def setUp(self):
+        self.pcb, self.v, self.res, self.st, self.out, _ = _arm(
+            VIA_CLEAR, 'F.Cu', second_cap=True)
+        # ON THE BRANCH: the pass reached the nudger and really drew copper
+        self.assertEqual(len(self.res['via_moves']), 1, self.out)
+        self.assertEqual([(s['layer'], s['width'])
+                          for s in self.res['new_segments']],
+                         [('F.Cu', TRACK_W)])
+        self.assertIn('via-nudge: moved', self.out)
+        self.seg = self.pcb.segments[-1]
+
+    def test_the_track_view_gained_exactly_the_connector(self):
+        self.assertEqual(len(self.st.segments), len(self.pcb.segments))
+        self.assertEqual(len(self.st.segments), 1)
+    # MUTATION: drop the register_new_segments call -> 0 != 1.
+
+    def test_the_tuple_is_priced_and_layered_as_init_would_have(self):
+        t = self.st.cap_segs['C1'][-1]
+        self.assertEqual(t[:5], (CONN_CLEAR[0], CONN_CLEAR[1], CONN_CLEAR[2],
+                                 CONN_CLEAR[3], NET_V))
+        self.assertEqual(t[6], 'F.Cu',
+                         'element 6 is a board SIDE again -- the pre-#731 '
+                         'collapse')
+        self.assertAlmostEqual(
+            t[5], self.seg.width / 2.0 + self.st._item_reach(
+                self.st.seg_floor(self.seg.net_id, self.seg.layer)), places=12)
+        self.assertAlmostEqual(t[5], SEG_KEEPOUT, places=9)
+    # MUTATION: `t[6] = _seg_side(layer)`; drop `_item_reach`; drop the `/2`.
+
+    def test_the_floor_map_holds_no_orphan_id(self):
+        live = {id(t) for t in self.st.segments}
+        self.assertLessEqual(set(self.st._seg_floor_by_id), live,
+                             'an entry keys a tuple that is not in the live '
+                             'list -- a recycled id would return ANOTHER '
+                             "track's floor, silently")
+    # MUTATION: build the tuple without filing it in self.segments.
+
+    def test_every_cap_in_reach_was_refreshed_with_a_NEW_list(self):
+        for ref in ('C1', 'C2'):
+            self.assertEqual(len(self.st.cap_segs[ref]), 1,
+                             '%s did not keep the connector' % ref)
+        effs = self.st._seg_effs('C1', self.st.caps['C1'])
+        self.assertTrue(all(len(row) == len(self.st.cap_segs['C1'])
+                            for row in effs),
+                        'the _cap_seg_eff memo is one column short -- '
+                        'cap_segs was appended to IN PLACE, so its identity '
+                        'never changed and the memo was never rebuilt')
+    # MUTATION: `cap_segs[ref].append(t)`; refresh only the repaired cap.
+
+    def test_the_pass_did_not_INVENT_a_charge_for_clear_copper(self):
+        for ref in ('C1', 'C2'):
+            cap = self.st.caps[ref]
+            self.assertAlmostEqual(
+                self.st.seg_penalty(ref, cap, cap.x, cap.y, cap.rot), 0.0,
+                places=9, msg='%s is charged for a connector the draw gate '
+                              'accepted -- the fix OVER-blocks' % ref)
+        self.assertEqual(self.res['unresolved'], [])
+    # MUTATION: charge the tuple at the prune over-reach instead of the pair.
+
+    def test_graze_penalty_RISES_for_a_pose_inside_the_connectors_keepout(self):
+        """The behavioural half, with no layer-scope dependence at all: walk
+        each cap toward the connector and the charge must appear."""
+        for ref, (dx, dy) in (('C1', PROBE_C1), ('C2', PROBE_C2)):
+            cap = self.st.caps[ref]
+            self.assertAlmostEqual(
+                sum(self.st._seg_shortfalls(
+                    ref, cap, cap.x + dx, cap.y + dy, cap.rot).values()),
+                PROBE_CHARGE, places=4,
+                msg='%s: the connector is not in the view, or is priced wrong'
+                    % ref)
+    # MUTATION: any of the above; also "build from st.segments instead of the
+    # nudger's dicts" (nothing to build from) and "call it BEFORE the nudge".
+
+
+class TestTheStaleViewShipsAFalseRESOLVED(unittest.TestCase):
+    """THE HEADLINE. A through-hole cap pad and a back-side connector: the
+    draw gate never tests the pair (#738), the grader charges it, and
+    check_drc -- the authority -- agrees the copper really is in violation."""
+
+    def setUp(self):
+        self.pcb, self.v, self.res, self.st, self.out, _ = _arm(
+            VIA_DEEP, 'B.Cu', through=True)
+
+    def test_the_connector_is_DRAWN_and_now_CHARGED(self):
+        # draw side FIRST, and exactly -- see the CHANGE DETECTOR note below
+        self.assertEqual([(s['layer'], s['width'])
+                          for s in self.res['new_segments']],
+                         [('B.Cu', TRACK_W)],
+                         'the off-side connector was NOT drawn. If #738 has '
+                         'landed that is CORRECT: delete this class, keep '
+                         'TestTheConnectorEntersTheGradersView, and record in '
+                         'the #738 PR that #736\'s behavioural window closed.')
+        self.assertEqual((round(self.v.x, 4), round(self.v.y, 4)), LAND_DEEP)
+        cap = self.st.caps['C1']
+        self.assertAlmostEqual(
+            self.st.seg_penalty('C1', cap, cap.x, cap.y, cap.rot), CHARGE,
+            places=4)
+        self.assertEqual(self.res['unresolved'], ['C1'])
+    # MUTATION: delete the refresh -> unresolved == [] and the pass reports a
+    # cap RESOLVED with a connector 0.020mm INSIDE one of its pads.
+
+    def test_check_drc_agrees_it_is_a_real_violation(self):
+        """Not the repair pass's own arithmetic: the authoritative checker, at
+        margin 0 so the number is the requirement and not a tolerance band."""
+        pad2 = self.pcb.footprints['C1'].pads[1]
+        viol, overlap, _pt = check_pad_segment_overlap(
+            pad2, self.pcb.segments[-1], CLEAR, CU, clearance_margin=0.0)
+        self.assertTrue(viol, 'check_drc grades this pair clean -- the fix is '
+                              'reporting a phantom, not a violation')
+        self.assertAlmostEqual(overlap, CHARGE, places=4)
+    # MUTATION: none -- this is the arm that makes the headline a fact rather
+    # than a claim about one grader agreeing with itself.
+
+    def test_the_NEGATIVE_control_SMD_pads_is_drawn_and_NOT_charged(self):
+        """One variable away from the arm above: the same B.Cu connector
+        against SMD F.Cu pads, which share no copper with it."""
+        pcb, v, res, st, out, _ = _arm(VIA_DEEP, 'B.Cu', through=False)
+        self.assertEqual([(s['layer'], s['width'])
+                          for s in res['new_segments']], [('B.Cu', TRACK_W)])
+        cap = st.caps['C1']
+        self.assertAlmostEqual(st.seg_penalty('C1', cap, cap.x, cap.y,
+                                              cap.rot), 0.0, places=9)
+        self.assertEqual(res['unresolved'], [])
+        pad2 = pcb.footprints['C1'].pads[1]
+        viol, _ov, _pt = check_pad_segment_overlap(
+            pad2, pcb.segments[-1], CLEAR, CU, clearance_margin=0.0)
+        self.assertFalse(viol)
+    # MUTATION: drop the layer gate from the rebuilt prune -> charged, and
+    # check_drc says it should not be.
+
+
+class TestTheLayerScopeSurvivesTheRebuild(unittest.TestCase):
+    """#731's regression guard, and the ONLY arm that kills one mutation."""
+
+    def test_a_DECLARED_layer_the_cap_pads_do_not_share_is_excluded(self):
+        pcb, v, res, st, out, _ = _arm(VIA_DEEP, 'In1.Cu')
+        # the connector IS drawn and IS on the board ...
+        self.assertEqual([(s['layer'], s['width'])
+                          for s in res['new_segments']], [('In1.Cu', TRACK_W)])
+        self.assertEqual(len(st.segments), 1)
+        self.assertIn('In1.Cu', st._all_cu, 'the layer is UNKNOWN to the '
+                                            'board, so _seg_shares charges it '
+                                            'and this arm tests nothing')
+        # ... and the F.Cu SMD cap pads share no copper with it
+        self.assertEqual(len(st.cap_segs['C1']), 0)
+        cap = st.caps['C1']
+        self.assertAlmostEqual(st.seg_penalty('C1', cap, cap.x, cap.y,
+                                              cap.rot), 0.0, places=9)
+        self.assertEqual(res['unresolved'], [])
+    # MUTATION: `t[6] = _seg_side(s.layer)` -- the pre-#731 collapse. 'F' is
+    # not in _all_cu, so _seg_shares charges it and a PHANTOM appears. This is
+    # the only arm that catches it: on the F.Cu and B.Cu arms the collapse is
+    # numerically invisible.
+
+
+class TestTheUnknownLayerOverBlockIsDELIBERATE(unittest.TestCase):
+    """Arm C. A connector on a layer the board never declared is charged --
+    by policy, not by accident (`_seg_shares`: "over-blocking is the only
+    direction that can never ship a violation").
+
+    It is pinned HERE, apart from the headline, because check_drc grades the
+    pair CLEAN. Reading it as a violation is the mistake an earlier draft of
+    this file made."""
+
+    def test_it_is_charged_even_though_the_checker_calls_it_clean(self):
+        pcb, v, res, st, out, _ = _arm(VIA_DEEP, 'In3.Cu')
+        self.assertNotIn('In3.Cu', st._all_cu,
+                         'In3.Cu became a declared layer; this arm now tests '
+                         'the same thing as the In1.Cu one')
+        self.assertEqual([(s['layer'], s['width'])
+                          for s in res['new_segments']], [('In3.Cu', TRACK_W)])
+        cap = st.caps['C1']
+        self.assertAlmostEqual(st.seg_penalty('C1', cap, cap.x, cap.y,
+                                              cap.rot), CHARGE, places=4)
+        self.assertEqual(res['unresolved'], ['C1'])
+        # ... and the authority disagrees, which is the point of this class
+        pad2 = pcb.footprints['C1'].pads[1]
+        viol, _ov, _pt = check_pad_segment_overlap(
+            pad2, pcb.segments[-1], CLEAR, CU, clearance_margin=0.0)
+        self.assertFalse(viol, 'check_drc now flags this -- the over-block '
+                               'has become a real rule and this class should '
+                               'be re-read as a violation arm')
+    # MUTATION: drop the `_seg_shares` fallback from the rebuilt prune.
+
+
+class TestTheRebuildPricesTheConnectorCorrectly(unittest.TestCase):
+    """A DECLARING board, where `t[5]` and the eff cell are free to differ --
+    0.350 against 0.650 here. Without that inequality the two likeliest
+    mutations cancel exactly and both survive."""
+
+    def _st(self, path, pcb):
+        st = _Repair(pcb, path, CLEAR, 0.1, 0.55, 1.0, 2.0, 0.3, 'C', set())
+        st.register_new_segments([{'start': CONN_CLEAR[:2],
+                                   'end': CONN_CLEAR[2:], 'width': TRACK_W,
+                                   'layer': 'F.Cu', 'net_id': NET_V}])
+        return st
+
+    def test_the_two_prices_are_separated_and_both_correct(self):
+        with _stub(DECL_CLASS) as path:
+            pcb, v = _board(VIA_CLEAR, 'F.Cu', lc=DECL_LC)
+            st = self._st(path, pcb)
+            self.assertIsNotNone(st._floors, 'the model is INERT')
+            t = st.segments[-1]
+            self.assertAlmostEqual(t[5], DECL_T5, places=9)
+            self.assertAlmostEqual(st._seg_effs('C1', st.caps['C1'])[1][-1],
+                                   DECL_EFF, places=9)
+            self.assertGreater(abs(DECL_EFF - DECL_T5), 0.05,
+                               'the two prices coincide, so a mutation that '
+                               'swaps them survives')
+    # MUTATION: drop `_item_reach` -> t[5] 0.25; omit the floor map -> the eff
+    # cell moves.
+
+    def test_the_floor_filed_is_the_TRACK_floor_object_itself(self):
+        """Identity, not value: `_seg_floor_for` memoises per (net, layer), so
+        the right floor is the same OBJECT. A via floor is scoped to ALL
+        copper and would diverge only under a layer-scoped .kicad_dru rule --
+        which no behavioural arm here has, so this is the only killer."""
+        with _stub(DECL_CLASS) as path:
+            pcb, v = _board(VIA_CLEAR, 'F.Cu', lc=DECL_LC)
+            st = self._st(path, pcb)
+            t = st.segments[-1]
+            fl = st.seg_floor(NET_V, 'F.Cu')
+            self.assertIsNotNone(fl, 'an inert board makes this None is None')
+            self.assertIs(st._seg_floor_by_id.get(id(t)), fl)
+    # MUTATION: file `_via_floor_for(net)` instead of `_seg_floor_for(net,
+    # layer)` -- behaviourally invisible without a dru rule.
+
+    def test_an_INERT_board_files_no_floor_at_all(self):
+        with _stub() as path:
+            pcb, v = _board(VIA_CLEAR, 'F.Cu')
+            st = self._st(path, pcb)
+            self.assertIsNone(st._floors)
+            t = st.segments[-1]
+            self.assertNotIn(id(t), st._seg_floor_by_id)
+            self.assertAlmostEqual(t[5], SEG_KEEPOUT, places=9)
+    # MUTATION: file the floor unconditionally (drop `if fl is not None`).
+
+
+class TestTheRefreshIsSkippedWhenNothingMoved(unittest.TestCase):
+    """The refresh is guarded, and the guard is not decorative: EVERY tracked
+    board that reaches the nudger at the shipped defaults makes zero moves."""
+
+    def test_a_run_that_moved_no_via_leaves_the_track_view_alone(self):
+        with _stub() as path:
+            pcb, v = _board(VIA_DEEP, 'F.Cu')
+            st_probe = _Repair(pcb, path, CLEAR, 0.1, 0.55, 1.0, 2.0, 0.3,
+                               'C', set())
+            before = {r: st_probe.cap_segs[r] for r in st_probe.caps}
+            segs_before = st_probe.segments
+
+            res, st, out = _run(pcb, path)
+        self.assertIn('no clear spot', out)
+        self.assertEqual(res['via_moves'], [])
+        # the run built its OWN _Repair, so compare the live one's identities
+        self.assertEqual(len(st.segments), 0)
+        for ref in st.caps:
+            self.assertEqual(st.cap_segs[ref], [])
+            # ...and the VIA half of the refresh did not run either. This is
+            # the only observable consequence of an unguarded refresh: the
+            # `cap_vias` line DE-prunes every cap onto the whole-board list,
+            # which is numerically identical (the prune is exact) but pays an
+            # eff-matrix rebuild of n_pads x n_ALL_vias per cap on every board
+            # that reaches the nudger and moves nothing -- which is every
+            # tracked board at the shipped defaults.
+            self.assertIsNot(st.cap_vias[ref], st.vias,
+                             'the per-cap via lists were de-pruned on a run '
+                             'that moved NO via -- the refresh is unguarded')
+        self.assertEqual(len(segs_before), 0)
+        self.assertEqual(sorted(before), sorted(st.caps))
+    # MUTATION: `if via_moves:` -> `if True:`. It changes no number -- the
+    # via prune is exact, so de-pruning grades the same -- which is why the
+    # assertion above is on list IDENTITY. The first version of this class
+    # asserted only the track half and the mutation SURVIVED the battery.
+
+
+class TestThePruneIsAnchoredOnTheSEEDPose(unittest.TestCase):
+    """By the time a connector is registered the caps have already moved, so
+    `_prune_segs` is handed `self._cap_geom` -- the SEED-pose geometry -- and
+    not `cap.rect()`.
+
+    That is not a stylistic choice. The reach bound is the reachable-DISK
+    argument (a cap moves at most `max_displacement_cap` from its SEED), which
+    is what makes the prune EXACT rather than approximate; and
+    `required_rows` grades `_seg_shortfalls` at the SEED pose as well as the
+    final one, so a moved-pose radius is a superset for neither.
+    """
+
+    def test_a_track_in_reach_of_the_SEED_survives_a_cap_that_moved_away(self):
+        with _stub() as path:
+            pcb, v = _board(VIA_CLEAR, 'F.Cu')
+            st = _Repair(pcb, path, CLEAR, 0.1, 0.55, 1.0, 2.0, 0.3, 'C',
+                         set())
+            cap = st.caps['C1']
+            _cx, _cy, span, _r = st._cap_geom['C1']
+            thr = (st._max_disp_cap + 2 * span + st.clearance
+                   + max(0.0, cap.max_floor - st.clearance)
+                   + HW + st.clearance)
+            # ON THE BRANCH: the fixture straddles the real threshold, both
+            # ways, by more than the 0.05mm this file allows itself
+            self.assertGreater(thr - FAR_D, 0.05, 'the track is not in reach '
+                                                  'of the seed after all')
+            self.assertGreater((FAR_D - WALK_BACK) - thr, 0.05,
+                               'the moved pose still reaches it, so a '
+                               'moved-pose prune would keep it too')
+            cap.x += WALK_BACK              # the pose the sweep left it in
+            self.assertNotEqual(cap.x, cap.seed_x)
+
+            st.register_new_segments([{'start': FAR_SEG[:2],
+                                       'end': FAR_SEG[2:], 'width': TRACK_W,
+                                       'layer': 'F.Cu', 'net_id': NET_V}])
+            self.assertEqual(
+                len(st.cap_segs['C1']), 1,
+                'the connector was pruned away: the reach was measured from '
+                "the cap's CURRENT pose, not its seed, which silently "
+                'redefines what "exact" means for this prune')
+    # MUTATION: recompute (ccx, ccy, span) from cap.rect() in the registrar
+    # instead of reading self._cap_geom.
+
+
+class TestOneConstructionSiteOnePrunePredicate(unittest.TestCase):
+    """SOURCE GUARD. #736 exists because both halves of "how a track becomes a
+    graded tuple" were inline in `__init__` and existed nowhere else, so
+    nothing could register a track that appeared later. Adding a second
+    spelling is that defect again, and no fixture can catch it.
+
+    CODE only -- `l.split('#')[0]` drops a trailing comment as well as a
+    full-line one, because the engine's comment blocks name every one of these
+    symbols repeatedly. Reading raw lines both invents sites and lets a real
+    one hide behind a trailing comment (#737's lesson). Offending line numbers
+    are REPORTED; never `assertIn` over the whole source (#732 measured a
+    393KB failure message from that).
+
+    THE BATTERY, as RUN: 18 mutations, 18 killed, plus two inert probes.
+
+      1  delete the refresh call ............ graze_penalty_RISES + 3 others
+      2  call it BEFORE the nudge ........... graze_penalty_RISES + 3 others
+      3  hand the registrar an empty list ... graze_penalty_RISES + 3 others
+      4  register but never prune per cap ... every_cap_in_reach, SEEDPose
+      5  prune but never file the tuple ..... CONSTRUCTED_in_exactly_one_place
+      6  refresh AFTER the unresolved recompute  connector_is_DRAWN_and_CHARGED
+      7  drop `_item_reach` ................. two_prices_are_separated
+      8  drop the `/2` ...................... tuple_is_priced_and_layered
+      9  omit the floor map ................. floor_filed_is_the_TRACK_floor
+      10 file `_via_floor_for` instead ...... floor_filed_is_the_TRACK_floor
+      11 `t[6] = _seg_side(layer)` .......... LayerScopeSurvivesTheRebuild
+      12 extend `cap_segs[ref]` IN PLACE .... cap_segs_is_ASSIGNED + 3 others
+      13 file the floor under a stale id .... floor_filed_is_the_TRACK_floor
+      14 refresh only the first cap ......... every_cap_in_reach (C2)
+      15 drop the layer filter .............. LayerScopeSurvivesTheRebuild
+      16 drop the distance filter ........... prune_predicate_has_ONE_spelling
+      17 make the refresh unconditional ..... RefreshIsSkippedWhenNothingMoved
+      18 prune from the MOVED pose .......... PruneIsAnchoredOnTheSEEDPose
+
+    10, 11, 15, 16, 17 and 18 have exactly ONE killer each; the module
+    docstring records that 17 and 18 SURVIVED the first run of this battery and
+    what was added to catch them.
+
+    INERT PROBES, which must change nothing: a trailing comment naming
+    `self._seg_floor_by_id[`, and a comment line naming the pricing spelling
+    and an in-place `cap_segs[r] +=`. Both pass, so the comment stripper is
+    doing its job rather than the guard being loose.
+
+    DECLARED UNKILLABLE, rather than papered over: `if via_moves:` ->
+    `if new_segs:`. A via move whose `conn_layers` is empty registers nothing
+    either way, so no arm can separate them. Recorded as test_737 records its
+    own surviving spelling.
+    """
+
+    @staticmethod
+    def _code(obj):
+        return [l.split('#')[0] for l in inspect.getsource(obj).splitlines()]
+
+    def _sites(self, lines, literal):
+        return [i + 1 for i, l in enumerate(lines) if literal in l]
+
+    def setUp(self):
+        self.mod = self._code(FC)
+        self.rep = self._code(FC._Repair)
+        self.builder = self._code(FC._Repair._register_segment)
+        self.pruner = self._code(FC._Repair._prune_segs)
+        self.nudger = self._code(FC.nudge_vias_for_unresolved)
+
+    def test_a_track_tuple_is_CONSTRUCTED_in_exactly_one_place(self):
+        for lit, where in (('self.segments.append(', self.builder),
+                           ('self._seg_floor_by_id[', self.builder),
+                           ('width / 2.0 + self._item_reach(', self.builder)):
+            sites = self._sites(self.mod, lit)
+            self.assertEqual(
+                len(sites), 1,
+                '%r occurs at %d sites (module-relative line(s) %s). #736 '
+                'exists because the one in __init__ was the only one, so '
+                'nothing could register the connectors the pass draws. A '
+                'second is that defect again.' % (lit, len(sites), sites))
+            self.assertTrue(any(lit in l for l in where),
+                            '%r moved out of _register_segment' % lit)
+    # MUTATION: re-inline the tuple build in __init__ or in the registrar.
+
+    def test_the_prune_predicate_has_exactly_one_spelling(self):
+        sites = self._sites(self.rep, '_point_to_seg_dist(')
+        self.assertEqual(len(sites), 1,
+                         '_Repair measures a point-to-track distance at %d '
+                         'sites (class-relative line(s) %s); the prune must '
+                         'have one' % (len(sites), sites))
+        self.assertTrue(any('_point_to_seg_dist(' in l for l in self.pruner))
+        calls = self._sites(self.mod, 'self._prune_segs(')
+        self.assertEqual(len(calls), 2,
+                         'expected exactly two callers of the prune -- '
+                         '__init__ and the registrar; found %d at %s'
+                         % (len(calls), calls))
+    # MUTATION: re-inline the prune loop in either caller.
+
+    def test_cap_segs_is_ASSIGNED_and_never_mutated_in_place(self):
+        asg = re.compile(r'self\.cap_segs\[[^\]]+\]\s*=[^=]')
+        writes = [i + 1 for i, l in enumerate(self.mod) if asg.search(l)]
+        self.assertEqual(len(writes), 2,
+                         'expected two cap_segs assignments (__init__ and the '
+                         'registrar); found %d at %s' % (len(writes), writes))
+        inplace = re.compile(r'cap_segs\[[^\]]*\]\s*(?:\.append|\.extend|\+=)')
+        bad = [i + 1 for i, l in enumerate(self.mod) if inplace.search(l)]
+        self.assertEqual(bad, [],
+                         'cap_segs is mutated IN PLACE at line(s) %s -- the '
+                         '_cap_seg_eff memo revalidates on the list IDENTITY, '
+                         'so the rows are never rebuilt and _seg_shortfalls '
+                         'indexes past the end of its row' % bad)
+    # MUTATION: `cap_segs[ref].append(t)` / `.extend(kept)` / `+= kept`.
+
+    def test_the_registrar_is_not_reached_from_the_duck_typed_nudger(self):
+        """`nudge_vias_for_unresolved` takes a duck-typed `st` -- five test
+        files pass a stand-in carrying only caps / vias / graze_penalty. A
+        resolver there has an honest flat fallback; a MUTATION does not,
+        because "silently do nothing" IS this defect."""
+        self.assertEqual(self._sites(self.nudger, 'register_new_segments('), [])
+        calls = [i + 1 for i, l in enumerate(self.mod)
+                 if 'register_new_segments(' in l and 'def ' not in l]
+        self.assertEqual(len(calls), 1,
+                         'expected exactly one call site; found %d at %s'
+                         % (len(calls), calls))
+    # MUTATION: move the call inside the nudger -> five test files AttributeError.
+
+    def test_the_zero_count_arms_are_not_searching_for_dead_strings(self):
+        """Every `== 0` arm above passes after a rename. Assert the positive
+        controls exist, so a rename fails HERE rather than disarming them."""
+        for token, floor in (('cap_segs', 6), ('self.segments', 3),
+                             ('_seg_floor_by_id', 4),
+                             ('pcb_data.segments', 5)):
+            n = sum(1 for l in self.mod if token in l)
+            self.assertGreaterEqual(
+                n, floor, '%r appears %d times in CODE (expected >= %d) -- it '
+                          'was renamed, and the zero-count arms of this file '
+                          'are now vacuous' % (token, n, floor))
+    # MUTATION: rename any of those identifiers.
+
+    def test_a_trailing_comment_cannot_arm_or_disarm_the_guard(self):
+        """False-positive probe: the stripper must drop a trailing comment, so
+        a comment MENTIONING a guarded literal invents no site."""
+        probe = ['        x = 1  # self.segments.append( and cap_segs[r] += q',
+                 '        # width / 2.0 + self._item_reach(fl)']
+        stripped = [l.split('#')[0] for l in probe]
+        self.assertEqual(self._sites(stripped, 'self.segments.append('), [])
+        self.assertEqual(
+            self._sites(stripped, 'width / 2.0 + self._item_reach('), [])
+    # MUTATION: read raw lines instead of stripping comments.
+
+
+class TestInertOnTheTrackedCorpus(unittest.TestCase):
+    """Two arms. The first says no tracked board emits a connector at the
+    shipped defaults, so the change is inert there. The second is what stops
+    that from being a statement about unreachable code."""
+
+    @staticmethod
+    def _reaching():
+        """Boards carrying BOTH vias and a movable near-BGA cap -- the only
+        ones that get past repair_fanout_clearance's two early returns."""
+        boards = run_utils.corpus_boards()
+        if not boards:
+            return None
+        out = []
+        for b in boards:
+            try:
+                pcb = parse_kicad_pcb(b)
+            except Exception:                                    # noqa: BLE001
+                continue
+            if not pcb.vias:
+                continue
+            if not any('BGA' in (f.footprint_name or '').upper()
+                       for f in pcb.footprints.values()):
+                continue
+            out.append(b)
+        return out
+
+    def test_no_tracked_board_EMITS_a_connector_at_the_shipped_defaults(self):
+        reaching = self._reaching()
+        if reaching is None:
+            print('SKIP: git cannot identify the tracked corpus')
+            self.skipTest('no git')
+        self.assertGreaterEqual(len(reaching), 3,
+                                'the candidate set collapsed; the filter is '
+                                'wrong and this arm proves nothing')
+        emitters = []
+        for b in reaching:
+            for clr in (0.25, 0.10):
+                buf = io.StringIO()
+                with contextlib.redirect_stdout(buf):
+                    r = repair_fanout_clearance(parse_kicad_pcb(b), b,
+                                                clearance=clr)
+                if r.get('new_segments'):
+                    emitters.append((os.path.basename(b), clr,
+                                     len(r['new_segments'])))
+        self.assertEqual(emitters, [],
+                         'a tracked board now emits connector copper: %r. The '
+                         '"inert on the corpus" claim in the #736 PR has '
+                         'EXPIRED -- re-run the before/after and record the '
+                         'new unresolved lists.' % (emitters,))
+    # MUTATION: none -- a self-expiring corpus bound, not a fix assertion.
+
+    def test_the_one_configuration_that_DOES_emit_connectors_is_still_clean(self):
+        """The FALLBACK-OFF leg of tests/test_fanout_clearance.py's frozen
+        sweep, on the one board that reaches the nudger with it: 9 via moves
+        and 17 connectors on four different layers, all registered, and NOT
+        ONE of them lands in any cap's keep-out. This is the whole in-repo
+        real-board A/B for #736, and it is what makes the synthetic rig
+        necessary rather than lazy.
+
+        `via_clear_fallback=False` is not decoration: with the fallback ON the
+        same board reports 0 unresolved, so the nudger is never called and
+        this arm would assert about nothing."""
+        board = os.path.join(_ROOT, 'kicad_files',
+                             'orangecrab_ext_pll.kicad_pcb')
+        if not os.path.isfile(board):
+            print('SKIP: %s is absent' % board)
+            self.skipTest('fixture absent')
+        pcb = parse_kicad_pcb(board)
+        seen, buf = [], io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            r = repair_fanout_clearance(pcb, board, clearance=0.1,
+                                        max_displacement=0.0, max_passes=1,
+                                        via_clear_fallback=False,
+                                        on_move=lambda st: seen.append(st))
+        st = seen[0]
+        self.assertGreater(len(r['new_segments']), 10,
+                           'this configuration stopped emitting connectors, '
+                           'so the arm below is vacuous')
+        self.assertGreater(len({s['layer'] for s in r['new_segments']}), 2)
+        registered = {(round(s['start'][0], 6), round(s['start'][1], 6),
+                       round(s['end'][0], 6), round(s['end'][1], 6),
+                       s['net_id'], s['layer'])
+                      for s in r['new_segments']}
+        live = {(round(t[0], 6), round(t[1], 6), round(t[2], 6),
+                 round(t[3], 6), t[4], t[6]) for t in st.segments}
+        self.assertLessEqual(registered, live,
+                             'a connector the pass drew never reached the '
+                             'track view')
+        dirty = {ref: st._seg_shortfalls(ref, c, c.x, c.y, c.rot)
+                 for ref, c in st.caps.items()}
+        self.assertEqual({k: v for k, v in dirty.items() if v}, {},
+                         'a connector now grazes a cap on a REAL board -- '
+                         'grade it with check_drc before believing it')
+    # MUTATION: delete the refresh -> `registered <= live` fails.
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/test_737_fanout_clearance_via_hole.py
+++ b/tests/test_737_fanout_clearance_via_hole.py
@@ -87,28 +87,43 @@ Conventions this file follows (#697/#725/#731/#732/#733 and CLAUDE.md):
       - the corpus bound, where the widest tracked ring 0.1500 sits 0.0500
         under the 0.2000 threshold. That IS the finding, not a fixture.
 
-A 14-mutation run over the engine gate kills 13. The survivor is named rather
-than hidden: `<` -> `<=`. Its mechanism is worth stating correctly, because the
-obvious version is wrong: it is NOT that no candidate lands on an exact tie --
-this rig generates two (XH_MOVES at r = 0.50 gives a gap of exactly 0.2000, and
-XH_SEPARATES_THE_FLOORS at r = 0.50 exactly 0.1000), they are simply never
-reached because an earlier radius wins. The real reason is stronger: the gate
-compares against `floor + vr - 1e-4`, so a gap sitting on the FLOOR is 1e-4
-clear of the COMPARISON boundary, and `<` and `<=` are therefore behaviourally
-identical for every input -- not merely for every input this file tries.
+A 17-mutation run over the engine gate kills 17. Getting there took two wrong
+explanations of ONE mutation, `<` -> `<=`, and both are recorded because the
+second is the more seductive:
 
-Dropping the `- 1e-4` was likewise measured to leave the entire suite green (it
-was predicted to break test_732's DVS_BIG rig; it does not). It is therefore
-held by the source guard in `TestTheFloorIsTheVIARuleNotTheTRACKFloor` -- the two sibling
-gates must read as one expression, which is a source property.
+  1. "no candidate lands on an exact tie" -- false. This rig generates two
+     (XH_MOVES at r = 0.50 gives a gap of exactly 0.2000, and
+     XH_SEPARATES_THE_FLOORS at r = 0.50 exactly 0.1000); they are simply never
+     REACHED, because an earlier radius wins.
+  2. "the `- 1e-4` moves the comparison boundary off the floor, so the two
+     spellings are identical for EVERY input" -- also false, and it reasons
+     about the wrong quantity. The tie that matters is at the COMPARISON
+     boundary `floor + vr - 1e-4`, not at the floor, and that boundary is
+     reachable from ordinary 1um-grid KiCad geometry.
 
-Five of those fourteen were added after review found the first version of the
-source guard defeatable, and all five die: the epsilon hidden behind a trailing
-comment, the floor hidden behind one, the CONNECTOR gate unified onto this
-gate's floor, `H2H_PAD` moved, and the staged project's declaring key mistyped.
+`TestTheComparisonIsSTRICT` builds it: an NPTH hole of drill 0.500100 at
+x = 4.499950 makes the helper return exactly 0.7998999999999999, which IS
+`clearance + vr - 1e-4` in float. The shipped `<` accepts that candidate and
+the via relocates; `<=` refuses it and the repair is lost. So the survival was
+a FIXTURE GAP, not a proof of equivalence -- and the fixture now exists.
+
+This is the one place the file's "no fixture within 0.05mm of the quantity
+under test" convention is deliberately inverted: an exact tie IS the quantity
+under test there, and the arm asserts the tie before asserting about it.
+
+Eight of the seventeen were added by successive review rounds, and all eight
+die: the epsilon hidden behind a trailing comment, the floor hidden behind one,
+the CONNECTOR gate unified onto this gate's floor, `H2H_PAD` moved, the staged
+project's declaring key mistyped, the track floor SPELT as `clearance`
+(`max(clearance, 0.20)`, which the source guard alone cannot catch), the same
+via the named constant, and a board-aware `getattr(st, 'npth_floor', 0.0)`.
 Two FALSE-POSITIVE probes -- a comment mentioning `_seg_foreign_hole_dist(`,
 and one mentioning `st.npth_floor` -- correctly change nothing, which the
-earlier raw-line version of the guard did not manage.
+earlier raw-line version of the source guard did not manage.
+
+Dropping the `- 1e-4` is killed by the source guard only; it was measured to
+leave the entire suite green on behaviour alone (it was predicted to break
+test_732's DVS_BIG rig; it does not).
 
 Runs in-process in a couple of seconds; the corpus class shells out once for
 `git ls-files`.
@@ -169,10 +184,11 @@ LANDING = (3.45, 3.0)          # the FIRST landing the walls admit
 # admitted at r = 0.50 and 0.55, both also at k = 0 -- (3.50, 3.00) and
 # (3.55, 3.00). Naming LANDING "the only one" would be false, and the refusal
 # arms do not rest on it being the only one. They rest on something stronger:
-# the hole sits ON that single admissible ray, so the copper-to-hole gap grows
-# monotonically with r, and a hole close enough to refuse (3.45) refuses every
-# candidate BEYOND it too -- which is why a refusal arm ends with an empty
-# `moves` rather than with a different landing. ALL_CANDIDATES pins the set.
+# every admissible candidate lies on the +x ray and the hole is FURTHER along
+# it, so the copper-to-hole gap SHRINKS as r grows -- (3.45) is the roomiest of
+# the three, and refusing it refuses the other two a fortiori. That is why a
+# refusal arm ends with an empty `moves` rather than with a different landing.
+# ALL_CANDIDATES pins the set, and the arms assert every member.
 ALL_CANDIDATES = ((3.45, 3.0), (3.50, 3.0), (3.55, 3.0))
 WALL_L = (0.0, 0.0, 2.625, 8.0, 2)
 WALL_T = (0.0, 3.90, 8.0, 8.0, 2)
@@ -538,6 +554,58 @@ class TestTheFloorIsTheVIARuleNotTheTRACKFloor(unittest.TestCase):
     # any fixture that could catch it would sit on the threshold.
 
 
+class TestTheComparisonIsSTRICT(unittest.TestCase):
+    """`<`, not `<=`. The only mutation this file could not kill for two
+    rounds, because both explanations offered for its survival were wrong (see
+    the module docstring). A gap exactly ON the comparison boundary
+    `clearance + vr - 1e-4` is reachable from ordinary 1um-grid geometry, and
+    the two spellings disagree there."""
+
+    #: Chosen so `_seg_foreign_hole_dist` returns the boundary EXACTLY in
+    #: float. Both are 1um-grid values a real board could carry.
+    TIE_DRILL = 0.500100
+    TIE_X = 4.499950
+
+    def _tie_board(self):
+        bi = BoardInfo(layers={}, copper_layers=['F.Cu', 'B.Cu'],
+                       board_bounds=(0.0, 0.0, 8.0, 8.0))
+        v = make_via(VIA0[0], VIA0[1], net_id=3, size=V_SIZE, drill=V_DRILL)
+        stub = make_seg(2.0, 3.0, VIA0[0], VIA0[1], width=0.2, layer='F.Cu',
+                        net_id=3)
+        hole = make_pad(net_id=0, x=self.TIE_X, y=3.0, ref='H1REF', num='H1',
+                        size_x=self.TIE_DRILL, size_y=self.TIE_DRILL,
+                        shape='circle', layers=['F.Mask', 'B.Mask'],
+                        drill=self.TIE_DRILL, pad_type='np_thru_hole')
+        pcb = make_pcb(board_info=bi, vias=[v], segments=[stub],
+                       footprints={'C1': SimpleNamespace(layer='F.Cu',
+                                                         pads=[])},
+                       pads_by_net={0: [hole]}, zones=[])
+        return v, pcb
+
+    def test_a_candidate_exactly_ON_the_boundary_is_ACCEPTED(self):
+        """Deliberately inverts this file's own no-fixture-on-a-threshold rule:
+        an exact tie IS the quantity under test here."""
+        v, pcb = self._tie_board()
+        # ON THE BRANCH: assert the tie before asserting about it. Float
+        # equality is the point, so `assertEqual`, not assertAlmostEqual.
+        boundary = CLEAR + VR - 1e-4
+        self.assertEqual(
+            _seg_foreign_hole_dist(pcb, 3, LANDING[0], LANDING[1],
+                                   LANDING[0], LANDING[1]), boundary,
+            'the fixture no longer lands on the comparison boundary, so this '
+            'arm cannot tell `<` from `<=` and proves nothing')
+        moves, segs, out = _nudge(_FakeSt(WALLS), pcb, max_shift=MAX_SHIFT)
+        self.assertEqual(len(moves), 1,
+                         'a candidate exactly ON the boundary was refused -- '
+                         'the comparison is `<=`, and a gap equal to the '
+                         'requirement is legal, not a violation')
+        self.assertAlmostEqual(v.x, LANDING[0], places=4)
+        self.assertEqual(len(segs), 1)
+        self.assertIn('moved', out)
+    # MUTATION: `<` -> `<=` -- this candidate is refused, `no clear spot`
+    # prints, and the repair is lost. Nothing else in the file catches it.
+
+
 class TestTheTwoSiblingValidatorsSeeTheSameHoles(unittest.TestCase):
     """Why the gate calls the shared helper instead of reusing `board_pads`."""
 
@@ -550,7 +618,12 @@ class TestTheTwoSiblingValidatorsSeeTheSameHoles(unittest.TestCase):
 
     def test_an_NPTH_hole_on_a_MOVABLE_CAP_is_still_seen(self):
         """`board_pads` drops the pads of movable caps; the helper keeps them.
-        This is the ONE arm that separates the two implementations."""
+        This is the one arm that separates the two implementations on
+        BEHAVIOUR. The source guard co-kills that mutation for a structural
+        reason -- any inline version necessarily removes a
+        `_seg_foreign_hole_dist(` call site -- so "the only thing that catches
+        it" would be false; this is the only thing that catches it by running
+        the pass."""
         v, pcb, moves, segs, out = _rig(XH_REFUSED_BY_BOTH, hole_ref='C1')
         # ON THE BRANCH: the pad really is invisible to a board_pads-based
         # gate, and really is visible to the helper.
@@ -566,7 +639,8 @@ class TestTheTwoSiblingValidatorsSeeTheSameHoles(unittest.TestCase):
         self.assertEqual((moves, segs), ([], []))
         self.assertEqual((v.x, v.y), VIA0)
     # MUTATION: reimplement the gate inline over `board_pads` (reusing its
-    # `cap_` capsule) -- this arm moves while every other arm still passes.
+    # `cap_` capsule) -- this arm moves. The source guard also fires, on the
+    # missing call site; this is the only BEHAVIOURAL arm that does.
 
     def test_a_hole_on_the_VIAS_OWN_NET_is_exempt(self):
         """NEGATIVE CONTROL for the net filter. A via on the hole's own net

--- a/tests/test_737_fanout_clearance_via_hole.py
+++ b/tests/test_737_fanout_clearance_via_hole.py
@@ -339,7 +339,7 @@ class TestARelocatedViaHonoursTheHoleFloor(unittest.TestCase):
     def test_the_gate_prices_the_BARREL_not_the_DRILL(self):
         """What separates #737's gate from the drill test beside it."""
         v, _pcb, moves, _segs, _out = _rig(XH_REFUSED_BY_BOTH)
-        self.assertGreater(VR, (v.drill or 0.3) / 2.0 + 0.05,
+        self.assertGreater(VR, FC._via_drill_radius(v) + 0.05,
                            'barrel and drill radius are too close for this '
                            'rig to tell the two conventions apart')
         # A drill-priced gate would need only 0.15 + 0.50 + 0.20 = 0.85 of

--- a/tests/test_737_fanout_clearance_via_hole.py
+++ b/tests/test_737_fanout_clearance_via_hole.py
@@ -530,17 +530,71 @@ class TestTheFloorIsTheVIARuleNotTheTRACKFloor(unittest.TestCase):
         # candidate the 0.05mm spiral produces lands on one. It is kept because
         # the two sibling gates must read as one expression, which is a source
         # property, so a source guard is the honest place to hold it.
-        eps = [i + 1 for i in calls
+        # #730 added two OVERRIDE gates beside these two, and they carry the
+        # same tolerance for the same reason -- four gates measuring the same
+        # holes must read as one expression. Counted by their own call, so a
+        # third scalar gate is still caught by the `len(calls) == 2` above.
+        ogates = [i for i, l in enumerate(src) if 'override_hole_gap(' in l
+                  and 'def ' not in l]
+        self.assertEqual(len(ogates), 2,
+                         'expected exactly two #730 override-hole gates (via '
+                         'and connector); found %d at function-relative '
+                         'line(s) %s' % (len(ogates), [i + 1 for i in ogates]))
+        eps = [i + 1 for i in calls + ogates
                if '1e-4' not in ' '.join(src[i:i + 3])]
         self.assertEqual(eps, [],
-                         'a hole gate dropped the 1e-4 the other one carries, '
+                         'a hole gate dropped the 1e-4 the others carry, '
                          'at function-relative line(s) %s' % eps)
-        drift = [i + 1 for i, l in enumerate(src)
-                 if 'npth_floor' in l or 'resolve_hole_clearance' in l]
+        # THE BOARD READ. This was a blanket ban until #730, and the ban was
+        # coarser than the decision it encoded. #617 refused board-deriving a
+        # FLOOR, because a raised floor abandons landings check_drc grades
+        # clean -- measured, and still measured: declared 0.25 gives 0 moves
+        # and 0 connectors where the flat floor gives 1 and 1.
+        #
+        # #730's `npth_step` is a THRESHOLD, not a floor. It decides whether a
+        # pad's own `(clearance ...)` outranks the fab floor, so raising it
+        # makes the override gate fire LESS often -- it can only ever charge
+        # less, never more, which is the opposite direction. And the direction
+        # is not the whole argument: what keeps that gate from costing repairs
+        # is that it fires only for an explicit, author-declared per-pad
+        # keep-clear, never for a board-wide floor. That is the distinction
+        # from #617.
+        #
+        # So the guard is now POSITIONAL, because "which direction" is a
+        # property of the EXPRESSION and not of the identifier:
+        # `npth_step = max(npth_clr, resolve_hole_clearance(...))` relaxes and
+        # `npth_clr = max(npth_clr, resolve_hole_clearance(...))` -- literally
+        # the #617 mutation -- raises, and a guard phrased as "board reads are
+        # fine" would pass both.
+        board = [i for i, l in enumerate(src)
+                 if 'resolve_hole_clearance(' in l and 'import' not in l]
+        self.assertEqual(len(board), 1,
+                         'expected exactly one board-derived hole read (#730 s '
+                         'step threshold); found %d at function-relative '
+                         'line(s) %s' % (len(board), [i + 1 for i in board]))
+        self.assertRegex(src[board[0]].lstrip(), r'^npth_step\s*=',
+                         'the board-derived read is not the `npth_step` '
+                         'assignment -- #617 refused it in every other '
+                         'position, at function-relative line %d'
+                         % (board[0] + 1))
+        # ...and no GATE may add it. A threshold that leaks into a gate line is
+        # a floor wearing a threshold's name.
+        for i in calls + ogates:
+            self.assertNotIn('npth_step', ' '.join(src[i:i + 3]),
+                             'a hole gate ADDS the board-derived value at '
+                             'function-relative line %d -- threshold only'
+                             % (i + 1))
+        # `st.npth_floor` stays banned outright, and for its OWN reason rather
+        # than #617's: this function is public and its harnesses pass duck
+        # types, so `getattr(st, 'npth_floor', ...)` silently takes the
+        # default -- and the default is the LOW threshold, the direction that
+        # costs repairs. It is also the wrong number, omitting `clearance`.
+        # `pcb_data` is a real argument on every path, so the read goes there.
+        drift = [i + 1 for i, l in enumerate(src) if 'npth_floor' in l]
         self.assertEqual(drift, [],
-                         'the nudger reads a BOARD-AWARE hole floor at '
-                         'function-relative line(s) %s -- #617 refused that'
-                         % drift)
+                         'the nudger reads st.npth_floor at function-relative '
+                         'line(s) %s -- a duck-typed harness carries none, so '
+                         'the getattr default decides silently' % drift)
         # And the one constant this file HAND-MIRRORS. `H2H_PAD` is a
         # function-local literal, so it cannot be imported; three ON-THE-BRANCH
         # guards above reason about the drill test using the mirror, and would

--- a/tests/test_737_fanout_clearance_via_hole.py
+++ b/tests/test_737_fanout_clearance_via_hole.py
@@ -348,8 +348,10 @@ class TestARelocatedViaHonoursTheHoleFloor(unittest.TestCase):
                            V_DRILL / 2.0 + HR + CLEAR + 0.05,
                            'a drill-priced gate would refuse this landing too')
         self.assertEqual(moves, [])
-    # MUTATION: `clearance + vr` -> `clearance + (v.drill or 0.3) / 2.0` -- the
-    # requirement falls to 0.75 of centre distance and the via moves.
+    # MUTATION: `clearance + vr` -> `clearance + _via_drill_radius(v)` -- the
+    # requirement falls to 0.75 of centre distance and the via moves. (#750
+    # named that resolver; the mutant used to be spelled with the bare
+    # `(v.drill or 0.3) / 2.0` this function no longer contains.)
 
 
 class TestTheFloorIsTheVIARuleNotTheTRACKFloor(unittest.TestCase):

--- a/tests/test_737_fanout_clearance_via_hole.py
+++ b/tests/test_737_fanout_clearance_via_hole.py
@@ -1,0 +1,545 @@
+"""#737: the relocated via's COPPER must be tested against an NPTH hole.
+
+`nudge_vias_for_unresolved` has two sibling validators, written to mirror each
+other. `connector_clear` tests the connector TRACK's copper against copper-less
+drill holes; `valid_via_pos` had NO equivalent for the via it relocates. Its
+only drilled-pad gate is drill-to-drill at the JLC `H2H_PAD` floor, which
+measures the DRILL -- so it covered the annular ring only while
+
+    ring = (size - drill) / 2  <=  H2H_PAD - npth_clr
+
+That bound is NOT the constant 0.25 the issue quotes: `npth_clr` is
+`max(clearance, NPTH_TO_TRACK_CLEARANCE)`, so it is 0.25 only at clearance
+<= 0.20, **0.20 at the shipped `--clearance` 0.25**, and 0 at clearance >= 0.45.
+Past it the pass parks ring copper inside a mounting hole's keep-out -- and it
+WRITES that via (placement/writer.py on the CLI, the plugin's own pcbnew mirror
+in the GUI).
+
+Measured at HEAD before the fix, on the rig below (`--clearance 0.1`, a 1.4/0.3
+via boxed so its only escape is +x): the via relocates to (3.4500, 3.0000),
+0.0500mm of copper-to-hole-WALL gap where 0.2000 is required, and `check_drc`
+grades that board with its own via arm of the same rule:
+
+    VIA-HOLE violations (1):
+      Hole:net_0 (MH1.H1) <-> Via:net_1 (copper-to-hole)
+        Overlap: 0.050mm    Hole: (4.70,3.00)    Via: (3.45,3.00)
+
+After the fix no candidate validates, `via-nudge: no clear spot` prints, and the
+via stays put. A via with real room still relocates.
+
+WHY THE FLOOR IS `npth_clr` AND NOT A BARE `clearance`, decided by measurement
+rather than by argument. Both candidates were run over all 27 tracked boards at
+`--clearance` 0.25 AND 0.1, comparing placements with coordinates, the
+unresolved list, `via_moves`, `new_segments` and stdout: **0 boards differ, on
+either arm, at either clearance.** Both are inert everywhere this repo can
+measure, so the conservative one ships. Two facts make that cheap:
+
+  * At every shipped default they are the SAME NUMBER. `routing_defaults`
+    CLEARANCE is 0.25 and `npth_clr` is `max(clearance, 0.20)`, so on the CLI,
+    GUI and animator path `npth_clr == clearance` exactly and this gate IS
+    check_drc's `via-hole` arm. The choice bites only below clearance 0.20.
+  * `npth_clr >= clearance` always, so the pass can never emit a via its own
+    checker then flags -- a one-way invariant a bare `clearance` gives only as
+    equality.
+
+NOT A REVERSAL OF #617, and `TestTheFloorIsTheFlatFabFloor` pins that
+behaviourally. #617 measured that RAISING this pass's hole floor to a board's
+DECLARED `min_hole_clearance` turns 1 move / 1 connector into 0 / 0; #737 ADDS a
+missing gate at the flat fab floor and leaves the declared value unread.
+
+DELIBERATELY NOT CLOSED HERE: neither hole gate honours the hole pad's own
+`local_clearance`, which check_drc does honour -- that is #730, a wrong VALUE
+where this is a missing GATE.
+
+Conventions this file follows (#697/#725/#731/#732/#733 and CLAUDE.md):
+
+  * Every assertion names the single-line MUTATION that must kill it.
+  * Assert you are ON THE BRANCH before asserting about it.
+  * Every "is refused" is paired with a NEGATIVE CONTROL that still moves.
+  * No fixture sits within 0.05mm of the quantity under test. The ONE
+    sub-0.05 boundary in the rig is the CAP gate (0.025 either side of
+    nx = 3.425); that is the sweep's own 0.05mm radial quantum, it is stated
+    here rather than left for a reviewer to find, and it is not the quantity
+    any assertion below measures.
+
+A 9-mutation run over the engine gate kills 8. The survivor is named rather
+than hidden: `<` -> `<=`. It, and dropping the `- 1e-4`, were both measured to
+leave the ENTIRE suite green on behaviour alone -- they decide an exact tie, and
+the 0.05mm spiral produces no candidate that sits on one. The 1e-4 is therefore
+held by the SOURCE guard in `TestTheFloorIsTheFlatFabFloor` (the two sibling
+gates must read as one expression, which is a source property); `<=` is held by
+nothing, because any fixture that could catch it would have to sit on the
+threshold this file's own convention forbids.
+
+Runs in-process in a couple of seconds; the corpus class shells out once for
+`git ls-files`.
+
+    python3 tests/test_737_fanout_clearance_via_hole.py
+"""
+from __future__ import annotations
+
+RUN_ALL_FAST_OK = True
+RUN_ALL_TIMEOUT = 900
+
+import contextlib
+import inspect
+import io
+import json
+import math
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+_TESTS = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_TESTS)
+for _p in ('', 'py_router', 'py_placer', 'py_tools'):
+    _d = os.path.join(_ROOT, _p)
+    if _d not in sys.path:
+        sys.path.insert(0, _d)
+if _TESTS not in sys.path:
+    sys.path.insert(0, _TESTS)
+
+import routing_defaults as defaults
+from bga_fanout.constants import DEFAULT_VIA_SIZE
+from check_drc import _pad_has_no_copper
+from kicad_parser import BoardInfo, parse_kicad_pcb
+from single_ended_routing import _seg_foreign_hole_dist
+from synth import make_pad, make_pcb, make_seg, make_via
+from placement import fanout_clearance as FC
+from placement.fanout_clearance import nudge_vias_for_unresolved
+
+# --- the rig ---------------------------------------------------------------
+CLEAR = 0.1                    # -> npth_clr 0.20; every other requirement 0.10
+NPTH_FLOOR = defaults.NPTH_TO_TRACK_CLEARANCE       # 0.20
+H2H_PAD = 0.45                 # the function's own literal, mirrored here
+V_SIZE, V_DRILL = 1.4, 0.3     # vr 0.70, ring 0.55 -- past the masking bound
+VR = V_SIZE / 2.0
+H_DRILL = 1.0                  # hr 0.50
+HR = H_DRILL / 2.0
+MAX_SHIFT = 0.55
+VIA0 = (3.0, 3.0)              # the offending via, net 3
+LANDING = (3.45, 3.0)          # the ONLY landing the walls admit
+
+# Foreign-net (2) walls that box the search to +x, so the landing is
+# deterministic and one-dimensional: T/B admit only |dy| <= 0.10, and L needs
+# nx >= 3.425, so the first admissible ring is r = 0.45 -> (3.45, 3.00).
+WALL_L = (0.0, 0.0, 2.625, 8.0, 2)
+WALL_T = (0.0, 3.90, 8.0, 8.0, 2)
+WALL_B = (0.0, 0.0, 8.0, 2.10, 2)
+WALLS = [WALL_L, WALL_T, WALL_B]
+
+# Hole x positions. Distance from the landing is XH - 3.45; the gate measures
+# to the hole WALL, so the requirement is `floor + VR` on `XH - 3.45 - HR`.
+XH_REFUSED_BY_BOTH = 4.70      # wall gap 0.050 -- refused at either floor
+XH_SEPARATES_THE_FLOORS = 4.80  # wall gap 0.150 -- refused at 0.20, not at 0.10
+XH_MOVES = 4.90                # wall gap 0.250 -- moves at 0.20, not at 0.40
+
+
+class _FakeCap:
+    """Minimal stand-in for _Cap: fixed pad rects, never moves."""
+
+    def __init__(self, rects):
+        self._rects = list(rects)
+        self.x = self.y = self.rot = 0.0
+
+    def pad_rects(self, x=None, y=None, rot=None):
+        return self._rects
+
+
+class _FakeSt:
+    """The duck-typed `st` the #370/#617 harnesses pass: no resolvers at all,
+    so every requirement in the nudger falls back to the flat scalar."""
+
+    def __init__(self, rects):
+        self.caps = {'C1': _FakeCap(rects)}
+        self.vias = []
+
+    def graze_penalty(self, ref, cap, x, y, rot):
+        return 1.0          # permanently unresolved, so the offender loop RUNS
+
+
+def _board(xh, *, hole_net=0, hole_ref='H1REF', source_path=None,
+           v_size=V_SIZE, v_drill=V_DRILL, h_drill=H_DRILL):
+    bi = BoardInfo(layers={}, copper_layers=['F.Cu', 'B.Cu'],
+                   board_bounds=(0.0, 0.0, 8.0, 8.0))
+    v = make_via(VIA0[0], VIA0[1], net_id=3, size=v_size, drill=v_drill)
+    stub = make_seg(2.0, 3.0, VIA0[0], VIA0[1], width=0.2, layer='F.Cu',
+                    net_id=3)
+    hole = make_pad(net_id=hole_net, x=xh, y=3.0, ref=hole_ref, num='H1',
+                    size_x=h_drill, size_y=h_drill, shape='circle',
+                    layers=['F.Mask', 'B.Mask'], drill=h_drill,
+                    pad_type='np_thru_hole')
+    kw = {} if source_path is None else {'source_path': source_path}
+    pcb = make_pcb(board_info=bi, vias=[v], segments=[stub],
+                   footprints={'C1': SimpleNamespace(layer='F.Cu', pads=[])},
+                   pads_by_net={hole_net: [hole]}, zones=[], **kw)
+    return v, pcb
+
+
+def _nudge(st, pcb, clear=CLEAR, **kw):
+    """Drive the real pass, capturing what it printed. The PRINTED OUTPUT is
+    half the evidence: a refusal that prints nothing is indistinguishable from
+    a pass that never looked (the #732 silent-failure lesson)."""
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        moves, segs = nudge_vias_for_unresolved(st, pcb, clear, **kw)
+    return moves, segs, buf.getvalue()
+
+
+def _rig(xh, **kw):
+    v, pcb = _board(xh, **kw)
+    moves, segs, out = _nudge(_FakeSt(WALLS), pcb, max_shift=MAX_SHIFT)
+    return v, pcb, moves, segs, out
+
+
+def _wall_gap(xh, at=LANDING, hr=HR):
+    """The copper-edge-to-hole-WALL gap the new gate actually measures."""
+    return math.hypot(at[0] - xh, at[1] - 3.0) - hr - VR
+
+
+class TestARelocatedViaHonoursTheHoleFloor(unittest.TestCase):
+    """The headline, both signs."""
+
+    def test_a_via_whose_RING_reaches_into_a_mounting_hole_is_refused(self):
+        # ON THE BRANCH 1: the ring must be past the bound the DRILL test
+        # masks, or this rig is a statement about some other geometry.
+        self.assertGreater((V_SIZE - V_DRILL) / 2.0, H2H_PAD - NPTH_FLOOR,
+                           'the via ring does not exceed H2H_PAD - npth_clr, '
+                           'so the drill test would reject this landing on '
+                           'its own and the new gate is not what is measured')
+        # ON THE BRANCH 2: the landing is DRILL-test-legal, so the refusal
+        # below is attributable to the new gate and to nothing else.
+        d_axis = abs(LANDING[0] - XH_REFUSED_BY_BOTH)
+        self.assertGreaterEqual(d_axis, V_DRILL / 2.0 + HR + H2H_PAD + 0.05,
+                                'the landing is inside the drill-to-drill '
+                                'keep-out, so the drill test refuses it too')
+        self.assertLess(_wall_gap(XH_REFUSED_BY_BOTH), NPTH_FLOOR - 0.05,
+                        'the landing is not inside the copper-to-hole band')
+        v, _pcb, moves, segs, out = _rig(XH_REFUSED_BY_BOTH)
+        # The PRINT first: assert it before the counts and no mutation can
+        # make the silence be the reported failure.
+        self.assertIn('no clear spot', out,
+                      'the pass said nothing about a via it declined to move')
+        self.assertEqual(moves, [], 'the via was relocated into the hole band')
+        self.assertEqual(segs, [], 'connector copper was drawn for no move')
+        self.assertEqual((v.x, v.y), VIA0, 'the via was mutated in place')
+    # MUTATION: delete the `_seg_foreign_hole_dist` gate in valid_via_pos --
+    # the via is parked at (3.4500, 3.0000) with 0.0500mm of copper-to-hole
+    # gap and stdout says "moved" (check_drc: VIA-HOLE, overlap 0.050mm).
+
+    def test_a_via_with_real_room_still_moves(self):
+        """The over-rejection guard, and the negative control for every
+        refusal in this file: the same rig with the hole 0.20mm further off."""
+        self.assertGreaterEqual(_wall_gap(XH_MOVES), NPTH_FLOOR + 0.04,
+                                'the control landing is not clear of the gate')
+        v, _pcb, moves, segs, out = _rig(XH_MOVES)
+        self.assertEqual(len(moves), 1,
+                         'a via with 0.25mm of copper-to-hole gap was refused '
+                         'at a 0.20mm requirement -- the gate over-rejects')
+        self.assertAlmostEqual(v.x, LANDING[0], places=4)
+        self.assertAlmostEqual(v.y, LANDING[1], places=4)
+        self.assertEqual([(s['layer'], s['width']) for s in segs],
+                         [('F.Cu', 0.2)])
+        self.assertIn('moved', out)
+    # MUTATION: `npth_clr + vr` -> `npth_clr + 2 * vr` -- the gate
+    # over-rejects and this move disappears.
+
+    def test_the_gate_prices_the_BARREL_not_the_DRILL(self):
+        """What separates #737's gate from the drill test beside it."""
+        v, _pcb, moves, _segs, _out = _rig(XH_REFUSED_BY_BOTH)
+        self.assertGreater(VR, (v.drill or 0.3) / 2.0 + 0.05,
+                           'barrel and drill radius are too close for this '
+                           'rig to tell the two conventions apart')
+        # A drill-priced gate would need only 0.15 + 0.50 + 0.20 = 0.85 of
+        # centre distance; the landing has 1.25, so it would accept.
+        self.assertGreater(abs(LANDING[0] - XH_REFUSED_BY_BOTH),
+                           V_DRILL / 2.0 + HR + NPTH_FLOOR + 0.05,
+                           'a drill-priced gate would refuse this landing too')
+        self.assertEqual(moves, [])
+    # MUTATION: `npth_clr + vr` -> `npth_clr + (v.drill or 0.3) / 2.0` -- the
+    # requirement falls to 0.85 of centre distance and the via moves.
+
+
+class TestTheFloorIsTheFlatFabFloor(unittest.TestCase):
+    """Brackets the floor from BOTH sides: above a bare `clearance`, and not
+    raised by a board's declared `min_hole_clearance` (the #617 pin)."""
+
+    def test_the_floor_is_not_the_bare_clearance(self):
+        # ON THE BRANCH: above clearance 0.20 the two candidates coincide and
+        # this arm asserts nothing.
+        self.assertLess(CLEAR, NPTH_FLOOR,
+                        'at this clearance npth_clr == clearance, so this '
+                        'test cannot separate the two conventions')
+        gap = _wall_gap(XH_SEPARATES_THE_FLOORS)
+        self.assertGreater(gap, CLEAR + 0.04,
+                           'the landing is inside the bare-clearance band '
+                           'too, so a `clearance` floor would refuse it as '
+                           'well and this arm proves nothing')
+        self.assertLess(gap, NPTH_FLOOR - 0.04,
+                        'the landing is outside the npth_clr band')
+        _v, _pcb, moves, segs, out = _rig(XH_SEPARATES_THE_FLOORS)
+        self.assertIn('no clear spot', out)
+        self.assertEqual((moves, segs), ([], []))
+    # MUTATION: `npth_clr + vr` -> `clearance + vr` -- the requirement drops
+    # to a 0.10mm wall gap and the via moves to (3.4500, 3.0000).
+
+    def test_a_DECLARED_min_hole_clearance_changes_nothing(self):
+        """#617's balance, pinned behaviourally rather than by comment. A
+        board declaring 0.40 would refuse this landing if the gate read the
+        board; the flat floor accepts it, so the #130 repair is kept."""
+        self.assertGreater(_wall_gap(XH_MOVES), NPTH_FLOOR + 0.04,
+                           'the landing does not clear the flat floor')
+        self.assertLess(_wall_gap(XH_MOVES), 0.40 - 0.04,
+                        'the landing clears 0.40 as well, so a board-aware '
+                        'gate would accept it and this arm is vacuous')
+        with tempfile.TemporaryDirectory() as td:
+            pcb_path = os.path.join(td, 'b.kicad_pcb')
+            with open(pcb_path, 'w', encoding='utf-8') as f:
+                f.write('(kicad_pcb (version 20240108))\n')
+            with open(os.path.join(td, 'b.kicad_pro'), 'w',
+                      encoding='utf-8') as f:
+                json.dump({'board': {'design_settings':
+                                     {'rules': {'min_hole_clearance': 0.40}}}},
+                          f)
+            v, pcb = _board(XH_MOVES, source_path=pcb_path)
+            moves, segs, out = _nudge(_FakeSt(WALLS), pcb, max_shift=MAX_SHIFT)
+        self.assertEqual(len(moves), 1,
+                         'the declared 0.40 reached this gate -- #617 '
+                         'measured that raising it costs the repair entirely')
+        self.assertAlmostEqual(v.x, LANDING[0], places=4)
+        self.assertEqual(len(segs), 1)
+        self.assertIn('moved', out)
+    # MUTATION: `npth_clr` -> `st.npth_floor` (or a resolve_hole_clearance
+    # read) -- this arm refuses while the project-less arm above still moves.
+
+    def test_both_hole_gates_in_the_nudger_spell_the_same_floor(self):
+        """A source guard, because the two sibling validators drifting apart
+        IS this issue. Reports the offending LINES, never assertIn over the
+        whole source (test_732 measured a 393KB failure message)."""
+        src = inspect.getsource(FC.nudge_vias_for_unresolved).splitlines()
+        calls = [i for i, l in enumerate(src)
+                 if '_seg_foreign_hole_dist(' in l
+                 and not l.lstrip().startswith('#')]
+        self.assertEqual(len(calls), 2,
+                         'expected exactly two copper-to-hole gates (the via '
+                         'and the connector); found %d at function-relative '
+                         'line(s) %s' % (len(calls), [i + 1 for i in calls]))
+        bad = [i + 1 for i in calls
+               if 'npth_clr' not in ' '.join(src[i:i + 3])]
+        self.assertEqual(bad, [],
+                         'a hole gate does not spell npth_clr, at '
+                         'function-relative line(s) %s' % bad)
+        # The tolerance too. This one is pinned HERE and nowhere else, and
+        # deliberately so: measured, dropping `- 1e-4` from the via gate leaves
+        # the whole suite green, because it only decides an exact tie and no
+        # candidate the 0.05mm spiral produces lands on one. It is kept because
+        # the two sibling gates must read as one expression, which is a source
+        # property, so a source guard is the honest place to hold it.
+        eps = [i + 1 for i in calls
+               if '1e-4' not in ' '.join(src[i:i + 3])]
+        self.assertEqual(eps, [],
+                         'a hole gate dropped the 1e-4 the other one carries, '
+                         'at function-relative line(s) %s' % eps)
+        drift = [i + 1 for i, l in enumerate(src)
+                 if ('npth_floor' in l or 'resolve_hole_clearance' in l)
+                 and not l.lstrip().startswith('#')]
+        self.assertEqual(drift, [],
+                         'the nudger reads a BOARD-AWARE hole floor at '
+                         'function-relative line(s) %s -- #617 refused that'
+                         % drift)
+    # MUTATION: re-spell either gate's floor, drop either 1e-4, or add a third
+    # gate -- the count, the `bad` list or the `eps` list changes. This arm is
+    # the ONLY thing that kills the 1e-4 mutation; `<` -> `<=` is killed by
+    # nothing at all, and is left declared rather than papered over, because
+    # any fixture that could catch it would sit on the threshold.
+
+
+class TestTheTwoSiblingValidatorsSeeTheSameHoles(unittest.TestCase):
+    """Why the gate calls the shared helper instead of reusing `board_pads`."""
+
+    @staticmethod
+    def _board_pads_would_see(pcb, cap_refs):
+        """`board_pads`' own filter, rebuilt here so the claim below is
+        measured rather than asserted from reading the source."""
+        return [p for ps in pcb.pads_by_net.values() for p in ps
+                if getattr(p, 'component_ref', None) not in cap_refs]
+
+    def test_an_NPTH_hole_on_a_MOVABLE_CAP_is_still_seen(self):
+        """`board_pads` drops the pads of movable caps; the helper keeps them.
+        This is the ONE arm that separates the two implementations."""
+        v, pcb, moves, segs, out = _rig(XH_REFUSED_BY_BOTH, hole_ref='C1')
+        # ON THE BRANCH: the pad really is invisible to a board_pads-based
+        # gate, and really is visible to the helper.
+        self.assertEqual(self._board_pads_would_see(pcb, {'C1'}), [],
+                         'the hole pad is NOT filtered out of board_pads, so '
+                         'this rig does not exercise the scope difference')
+        self.assertAlmostEqual(
+            _seg_foreign_hole_dist(pcb, 3, LANDING[0], LANDING[1],
+                                   LANDING[0], LANDING[1]), 0.75, places=4,
+            msg='the helper does not see this hole either, so the outcome '
+                'below is not about the scope difference')
+        self.assertIn('no clear spot', out)
+        self.assertEqual((moves, segs), ([], []))
+        self.assertEqual((v.x, v.y), VIA0)
+    # MUTATION: reimplement the gate inline over `board_pads` (reusing its
+    # `cap_` capsule) -- this arm moves while every other arm still passes.
+
+    def test_a_hole_on_the_VIAS_OWN_NET_is_exempt(self):
+        """NEGATIVE CONTROL for the net filter. A via on the hole's own net
+        legitimately lands there; check_drc's via arm exempts it the same way
+        (`if via.net_id == hnet: continue`)."""
+        v, pcb, moves, segs, out = _rig(XH_REFUSED_BY_BOTH, hole_net=3)
+        self.assertEqual(
+            _seg_foreign_hole_dist(pcb, 3, LANDING[0], LANDING[1],
+                                   LANDING[0], LANDING[1]), 1e9,
+            'the helper still sees this hole, so the exemption under test is '
+            'not the reason for the outcome below')
+        self.assertEqual(len(moves), 1,
+                         'an OWN-NET mounting hole blocked its own net')
+        self.assertEqual(len(segs), 1)
+        self.assertAlmostEqual(v.x, LANDING[0], places=4)
+        self.assertIn('moved', out)
+        # POSITIVE CONTROL, identical geometry on a foreign net.
+        self.assertEqual(_rig(XH_REFUSED_BY_BOTH)[2], [],
+                         'the foreign-net arm moves too, so this rig does not '
+                         'separate own-net from foreign-net at all')
+    # MUTATION: pass `0` (or drop the net argument) instead of `v.net_id` --
+    # a net-tied mounting hole blocks its own net's via and this arm refuses.
+
+
+class TestTheDrillTestIsUnchanged(unittest.TestCase):
+    """#617's own rig, verbatim. The change detector that says the #130 repair
+    is kept -- and the measurement that licenses the change."""
+
+    NPTH = (1.0, 0.98)
+    ND = 0.2
+    BAR = (0.2, 0.9, 1.8, 1.1, 2)
+
+    def _rig617(self):
+        bi = BoardInfo(layers={}, copper_layers=['F.Cu', 'B.Cu'],
+                       board_bounds=(0.0, 0.0, 3.0, 3.0))
+        v = make_via(1.0, 1.4, net_id=3, size=0.5, drill=0.3)
+        stub = make_seg(1.0, 1.6, 1.0, 1.4, width=0.2, layer='F.Cu', net_id=3)
+        hole = make_pad(net_id=0, x=self.NPTH[0], y=self.NPTH[1], ref='BUS1',
+                        num='H1', size_x=self.ND, size_y=self.ND,
+                        shape='circle', layers=['F.Mask', 'B.Mask'],
+                        drill=self.ND, pad_type='np_thru_hole')
+        pcb = make_pcb(board_info=bi, vias=[v], segments=[stub],
+                       footprints={'C1': SimpleNamespace(layer='F.Cu',
+                                                         pads=[])},
+                       pads_by_net={0: [hole]}, zones=[])
+        return v, pcb
+
+    def test_the_617_rig_relocates_to_exactly_the_same_place(self):
+        v, pcb = self._rig617()
+        moves, segs, out = _nudge(_FakeSt([self.BAR]), pcb)
+        self.assertEqual((len(moves), len(segs)), (1, 1),
+                         'the #130 pad-via repair #617 measured was traded '
+                         'away by this change')
+        self.assertAlmostEqual(v.x, 1.1148, places=4)
+        self.assertAlmostEqual(v.y, 1.6772, places=4)
+        self.assertIn('moved', out)
+        gap = _seg_foreign_hole_dist(
+            pcb, segs[0]['net_id'], segs[0]['start'][0], segs[0]['start'][1],
+            segs[0]['end'][0], segs[0]['end'][1]) - segs[0]['width'] / 2.0
+        self.assertAlmostEqual(gap, 0.22, places=4,
+                               msg='#617 records this connector landing at '
+                                   '0.2200mm; it moved')
+    # MUTATION: any change to the gate that rejects this landing -- the counts
+    # go to (0, 0) and the refusal line appears instead.
+
+    def test_the_new_gate_is_numerically_unreachable_on_a_NORMAL_via(self):
+        """Why #617 stays green, as an inequality rather than a hope: on a
+        0.5/0.3 via the DRILL test is the stricter of the two, so the new gate
+        can never be the binding one there."""
+        drill_need = 0.3 / 2.0 + self.ND / 2.0 + H2H_PAD          # 0.70
+        gate_need = 0.5 / 2.0 + self.ND / 2.0 + NPTH_FLOOR        # 0.55
+        self.assertGreater(drill_need, gate_need + 0.10,
+                           'the two requirements are close enough that the '
+                           'new gate could become the binding one here')
+        v, pcb = self._rig617()
+        _nudge(_FakeSt([self.BAR]), pcb)
+        d = math.hypot(v.x - self.NPTH[0], v.y - self.NPTH[1])
+        self.assertGreater(d, gate_need + 0.10,
+                           'the achieved landing has less than 0.10mm of '
+                           'headroom on the new gate')
+        self.assertAlmostEqual(d, 0.706588, places=5)
+    # MUTATION: none kills these -- they are the measurement that licenses the
+    # change. Their job is to fail loudly if a later edit moves the landing.
+
+
+class TestInertOnTheTrackedCorpus(unittest.TestCase):
+    """A self-expiring bound. The gate is UNREACHABLE on every board this repo
+    tracks, which is why the demonstration above is synthetic on purpose."""
+
+    @staticmethod
+    def _tracked():
+        out = subprocess.run(['git', 'ls-files', '-z', '*.kicad_pcb'],
+                             cwd=_ROOT, capture_output=True, text=True)
+        return [os.path.join(_ROOT, p) for p in out.stdout.split('\0')
+                if p.endswith('.kicad_pcb')]
+
+    def test_no_tracked_via_is_fat_enough_for_the_gate_to_bind(self):
+        boards = self._tracked()
+        self.assertGreater(len(boards), 25,
+                           'git ls-files returned %d boards -- never glob the '
+                           'directory, 11 boards in kicad_files/ alone are '
+                           'gitignored build products' % len(boards))
+        widest, where, total, with_both = 0.0, None, 0, []
+        for b in boards:
+            pcb = parse_kicad_pcb(b)
+            vias = [v for v in pcb.vias if (v.size or 0) > 0]
+            holes = [p for ps in pcb.pads_by_net.values() for p in ps
+                     if (getattr(p, 'drill', 0) or 0) > 0
+                     and _pad_has_no_copper(p)]
+            total += len(vias)
+            if not vias:
+                continue
+            r = max((v.size - (v.drill or 0)) / 2.0 for v in vias)
+            if r > widest:
+                widest, where = r, os.path.basename(b)
+            if holes:
+                with_both.append(os.path.basename(b))
+        self.assertGreater(total, 500,
+                           'only %d sized vias across the corpus -- the bound '
+                           'below would be vacuous' % total)
+        bound = H2H_PAD - max(defaults.CLEARANCE, NPTH_FLOOR)      # 0.20
+        self.assertLess(widest, bound - 0.04,
+                        'a tracked board now carries a via ring of %.4f (%s), '
+                        'at or near the %.4f bound where this gate starts to '
+                        'bind at the shipped --clearance %.2f. The "provably '
+                        'inert on the corpus" claim in this PR must be '
+                        're-measured.' % (widest, where, bound,
+                                          defaults.CLEARANCE))
+        # The boards carrying BOTH vias and copper-less holes are the only
+        # ones where this gate could ever fire; name them, so a change there
+        # is visible rather than silent.
+        self.assertEqual(sorted(with_both),
+                         ['orangecrab_ext_pll.kicad_pcb',
+                          'rp2350_fpga_eensy_prePlane.kicad_pcb'],
+                         'the set of boards carrying both vias and '
+                         'copper-less holes changed; re-run the corpus A/B')
+    # MUTATION: add a via with size - drill > 0.32 to any tracked board -- the
+    # inertness claim stops being true and this fails with the board's name.
+
+    def test_every_via_this_pipeline_CREATES_is_below_the_bound(self):
+        """The corpus is a snapshot; these are the sizes the tool itself
+        emits, and they are what keep the gate inert on boards it produces."""
+        bound = H2H_PAD - max(defaults.CLEARANCE, NPTH_FLOOR)
+        for name, size, drill in (
+                ('BGA_VIA', defaults.BGA_VIA_SIZE, defaults.BGA_VIA_DRILL),
+                ('VIA', defaults.VIA_SIZE, defaults.VIA_DRILL),
+                ('DEFAULT_VIA_SIZE', DEFAULT_VIA_SIZE, defaults.VIA_DRILL)):
+            with self.subTest(name):
+                self.assertLess((size - drill) / 2.0, bound - 0.04,
+                                '%s (%s/%s) now has a ring at the %.4f bound'
+                                % (name, size, drill, bound))
+    # MUTATION: raise BGA_VIA_SIZE past 0.62 -- the fanout vias this pass
+    # moves start binding and the inertness claim must be restated.
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/test_737_fanout_clearance_via_hole.py
+++ b/tests/test_737_fanout_clearance_via_hole.py
@@ -61,9 +61,13 @@ declared value is still unread here, and the floor charged is the LOWER of the
 two candidates, so this pass refuses strictly less than the version review
 rejected.
 
-DELIBERATELY NOT CLOSED HERE: neither hole gate honours the hole pad's own
-`local_clearance`, which check_drc does honour -- that is #730, a wrong VALUE
-where this is a missing GATE.
+CLOSED SINCE, by #730: neither hole gate honoured the hole pad's own
+`local_clearance`, which check_drc does honour -- a wrong VALUE where this was
+a missing GATE. Each gate now has an ADDITIVE override sibling beside it, and
+the two arms keep their different shapes (this one's is a STEP, the
+connector's a MAX). The source guard below counts four hole gates for that
+reason. Behavioural coverage lives in
+tests/test_730_fanout_clearance_npth_local_clearance.py.
 
 Conventions this file follows (#697/#725/#731/#732/#733 and CLAUDE.md):
 
@@ -514,16 +518,22 @@ class TestTheFloorIsTheVIARuleNotTheTRACKFloor(unittest.TestCase):
         self.assertIn('clearance', vtxt,
                       'the VIA gate does not spell `clearance`, which is what '
                       'check_drc s via-hole arm grades at')
-        # This assertion is the ONLY thing in the tree that holds the
-        # connector floor. Measured: rewriting `npth_clr + hw` to
-        # `clearance + hw` passes test_617, test_370 and test_fanout_clearance
-        # (20 tests) -- including test_617's own "UNCHANGED site" arm, which
-        # exists to pin exactly that floor. Same position as the 1e-4 above,
-        # and worth the same disclosure rather than a silent reliance.
+        # This assertion WAS the only thing in the tree holding the connector
+        # floor, and that is no longer true -- amended here rather than left
+        # as a stale claim. Measured when this file shipped: rewriting
+        # `npth_clr + hw` to `clearance + hw` passed test_617, test_370 and
+        # test_fanout_clearance (20 tests), including test_617's own
+        # "UNCHANGED site" arm, which exists to pin exactly that floor.
+        # #730 added a BEHAVIOURAL arm for it --
+        # test_730's TestTheConnectorGateStaysAtTheFlatFabFloor puts a
+        # connector 1.150mm off a hole wall, over what `clearance` would
+        # require and under what `npth_clr` does -- so the mutation is now
+        # killed twice, once here and once there. This guard is kept as
+        # belt-and-braces: a source property is still the honest place to hold
+        # a source property.
         self.assertIn('npth_clr', ctxt,
                       'the CONNECTOR gate no longer spells npth_clr -- #617 '
-                      'set that floor deliberately, and NOTHING else in the '
-                      'tree catches this')
+                      'set that floor deliberately')
         # The tolerance too. This one is pinned HERE and nowhere else, and
         # deliberately so: measured, dropping `- 1e-4` from the via gate leaves
         # the whole suite green, because it only decides an exact tie and no

--- a/tests/test_737_fanout_clearance_via_hole.py
+++ b/tests/test_737_fanout_clearance_via_hole.py
@@ -6,46 +6,60 @@ drill holes; `valid_via_pos` had NO equivalent for the via it relocates. Its
 only drilled-pad gate is drill-to-drill at the JLC `H2H_PAD` floor, which
 measures the DRILL -- so it covered the annular ring only while
 
-    ring = (size - drill) / 2  <=  H2H_PAD - npth_clr
+    ring = (size - drill) / 2  <=  H2H_PAD - clearance
 
-That bound is NOT the constant 0.25 the issue quotes: `npth_clr` is
-`max(clearance, NPTH_TO_TRACK_CLEARANCE)`, so it is 0.25 only at clearance
-<= 0.20, **0.20 at the shipped `--clearance` 0.25**, and 0 at clearance >= 0.45.
-Past it the pass parks ring copper inside a mounting hole's keep-out -- and it
-WRITES that via (placement/writer.py on the CLI, the plugin's own pcbnew mirror
-in the GUI).
+which is **0.20 at the shipped `--clearance` 0.25** and 0 at clearance >= 0.45,
+where every via binds. (The issue quotes a constant 0.25; that is the value for
+the TRACK floor, and this gate is not charged at the track floor -- see below.)
+Past that bound the pass parks ring copper inside a mounting hole's keep-out --
+and it WRITES that via (placement/writer.py on the CLI, the plugin's own pcbnew
+mirror in the GUI).
 
 Measured at HEAD before the fix, on the rig below (`--clearance 0.1`, a 1.4/0.3
 via boxed so its only escape is +x): the via relocates to (3.4500, 3.0000),
-0.0500mm of copper-to-hole-WALL gap where 0.2000 is required, and `check_drc`
-grades that board with its own via arm of the same rule:
+0.0500mm of copper-to-hole-WALL gap where the graded requirement is 0.1000, and
+`check_drc` grades that board with its own via arm of the same rule:
 
     VIA-HOLE violations (1):
       Hole:net_0 (MH1.H1) <-> Via:net_1 (copper-to-hole)
         Overlap: 0.050mm    Hole: (4.70,3.00)    Via: (3.45,3.00)
 
-After the fix no candidate validates, `via-nudge: no clear spot` prints, and the
-via stays put. A via with real room still relocates.
+The overlap IS the proof of the requirement: 0.1000 - 0.0500. After the fix no
+candidate validates, `via-nudge: no clear spot` prints, and the via stays put. A
+via with real room still relocates.
 
-WHY THE FLOOR IS `npth_clr` AND NOT A BARE `clearance`, decided by measurement
-rather than by argument. Both candidates were run over all 27 tracked boards at
-`--clearance` 0.25 AND 0.1, comparing placements with coordinates, the
-unresolved list, `via_moves`, `new_segments` and stdout: **0 boards differ, on
-either arm, at either clearance.** Both are inert everywhere this repo can
-measure, so the conservative one ships. Two facts make that cheap:
+WHY THE FLOOR IS `clearance` AND NOT THE SIBLING'S `npth_clr`. The asymmetry is
+the point, not an oversight, and it was decided by measurement after a first
+version of this file shipped the sibling's floor.
 
-  * At every shipped default they are the SAME NUMBER. `routing_defaults`
-    CLEARANCE is 0.25 and `npth_clr` is `max(clearance, 0.20)`, so on the CLI,
-    GUI and animator path `npth_clr == clearance` exactly and this gate IS
-    check_drc's `via-hole` arm. The choice bites only below clearance 0.20.
-  * `npth_clr >= clearance` always, so the pass can never emit a via its own
-    checker then flags -- a one-way invariant a bare `clearance` gives only as
-    equality.
+`npth_clr` is `max(clearance, NPTH_TO_TRACK_CLEARANCE)` -- a routing policy for
+TRACKS, which is what `connector_clear` gates. `check_drc` grades a VIA against
+a plain NPTH hole at `clearance` instead
+(`kicad_req = req_clr if req_clr > npth_clr else clearance`) and records why:
+charging a via the track floor "invents items kicad-cli never reports" (crkbd,
+7 phantoms at 0.016-0.023mm). `obstacle_map` stamps the same asymmetry -- a
+plain NPTH is a track keep-out, not a via-copper one.
 
-NOT A REVERSAL OF #617, and `TestTheFloorIsTheFlatFabFloor` pins that
-behaviourally. #617 measured that RAISING this pass's hole floor to a board's
-DECLARED `min_hole_clearance` turns 1 move / 1 connector into 0 / 0; #737 ADDS a
-missing gate at the flat fab floor and leaves the declared value unread.
+Charging `npth_clr` here does not merely cost search room, it COSTS THE REPAIR.
+Measured, and pinned by `TestTheTrackFloorWouldAbandonARepair`: at
+`--clearance 0.1` a landing 0.1500mm off the hole wall is graded CLEAN by
+check_drc (`NO DRC VIOLATIONS FOUND`), the track floor refuses it, no other
+candidate validates, and the cap keeps the #130 pad-via graze this pass exists
+to remove. That is the exact failure `obstacle_map.resolve_hole_clearance`
+names for this function BY NAME -- an all-or-nothing repair whose one clearing
+candidate must not be refused -- and it is the same balance #617 struck for the
+connector gate.
+
+The two floors are EQUAL at `--clearance >= 0.20`, so this only ever differs
+below the fab floor. That is not hypothetical: `place_fanout_clearance.py`'s own
+`--help` example is `--clearance 0.1`, and the GUI control's minimum is 0.05.
+
+NOT A REVERSAL OF #617, and `TestTheFloorIsTheVIARuleNotTheTRACKFloor` pins it
+behaviourally: #617 measured that RAISING this pass's hole floor -- to a board's
+DECLARED `min_hole_clearance` -- turns 1 move / 1 connector into 0 / 0. The
+declared value is still unread here, and the floor charged is the LOWER of the
+two candidates, so this pass refuses strictly less than the version review
+rejected.
 
 DELIBERATELY NOT CLOSED HERE: neither hole gate honours the hole pad's own
 `local_clearance`, which check_drc does honour -- that is #730, a wrong VALUE
@@ -73,7 +87,7 @@ Conventions this file follows (#697/#725/#731/#732/#733 and CLAUDE.md):
       - the corpus bound, where the widest tracked ring 0.1500 sits 0.0500
         under the 0.2000 threshold. That IS the finding, not a fixture.
 
-A 9-mutation run over the engine gate kills 8. The survivor is named rather
+A 14-mutation run over the engine gate kills 13. The survivor is named rather
 than hidden: `<` -> `<=`. Its mechanism is worth stating correctly, because the
 obvious version is wrong: it is NOT that no candidate lands on an exact tie --
 this rig generates two (XH_MOVES at r = 0.50 gives a gap of exactly 0.2000, and
@@ -85,15 +99,16 @@ identical for every input -- not merely for every input this file tries.
 
 Dropping the `- 1e-4` was likewise measured to leave the entire suite green (it
 was predicted to break test_732's DVS_BIG rig; it does not). It is therefore
-held by the SOURCE guard in `TestTheFloorIsTheFlatFabFloor` -- the two sibling
+held by the source guard in `TestTheFloorIsTheVIARuleNotTheTRACKFloor` -- the two sibling
 gates must read as one expression, which is a source property.
 
-A second round of four mutations, added after a review found the first version
-of that guard defeatable, kills all four: the epsilon hidden behind a trailing
-comment, the floor hidden behind one, `H2H_PAD` moved, and the staged project's
-declaring key mistyped. Two FALSE-POSITIVE probes -- a comment mentioning
-`_seg_foreign_hole_dist(`, and one mentioning `st.npth_floor` -- correctly
-change nothing, which the earlier raw-line version of the guard did not manage.
+Five of those fourteen were added after review found the first version of the
+source guard defeatable, and all five die: the epsilon hidden behind a trailing
+comment, the floor hidden behind one, the CONNECTOR gate unified onto this
+gate's floor, `H2H_PAD` moved, and the staged project's declaring key mistyped.
+Two FALSE-POSITIVE probes -- a comment mentioning `_seg_foreign_hole_dist(`,
+and one mentioning `st.npth_floor` -- correctly change nothing, which the
+earlier raw-line version of the guard did not manage.
 
 Runs in-process in a couple of seconds; the corpus class shells out once for
 `git ls-files`.
@@ -136,7 +151,8 @@ from placement import fanout_clearance as FC
 from placement.fanout_clearance import nudge_vias_for_unresolved
 
 # --- the rig ---------------------------------------------------------------
-CLEAR = 0.1                    # -> npth_clr 0.20; every other requirement 0.10
+CLEAR = 0.1                    # the VIA gate's floor, and check_drc's
+                               # -> npth_clr 0.20, the SIBLING's floor
 NPTH_FLOOR = defaults.NPTH_TO_TRACK_CLEARANCE       # 0.20
 H2H_PAD = 0.45                 # the function's own literal, mirrored here
 V_SIZE, V_DRILL = 1.4, 0.3     # vr 0.70, ring 0.55 -- past the masking bound
@@ -166,7 +182,8 @@ WALLS = [WALL_L, WALL_T, WALL_B]
 # Hole x positions. Distance from the landing is XH - 3.45; the gate measures
 # to the hole WALL, so the requirement is `floor + VR` on `XH - 3.45 - HR`.
 XH_REFUSED_BY_BOTH = 4.70      # wall gap 0.050 -- refused at either floor
-XH_SEPARATES_THE_FLOORS = 4.80  # wall gap 0.150 -- refused at 0.20, not at 0.10
+XH_SEPARATES_THE_FLOORS = 4.80  # wall gap 0.150 -- MOVES at 0.10, refused at
+                               # 0.20; check_drc grades this landing CLEAN
 XH_MOVES = 4.90                # wall gap 0.250 -- moves at 0.20, not at 0.40
 
 
@@ -238,8 +255,8 @@ class TestARelocatedViaHonoursTheHoleFloor(unittest.TestCase):
     def test_a_via_whose_RING_reaches_into_a_mounting_hole_is_refused(self):
         # ON THE BRANCH 1: the ring must be past the bound the DRILL test
         # masks, or this rig is a statement about some other geometry.
-        self.assertGreater((V_SIZE - V_DRILL) / 2.0, H2H_PAD - NPTH_FLOOR,
-                           'the via ring does not exceed H2H_PAD - npth_clr, '
+        self.assertGreater((V_SIZE - V_DRILL) / 2.0, H2H_PAD - CLEAR,
+                           'the via ring does not exceed H2H_PAD - clearance, '
                            'so the drill test would reject this landing on '
                            'its own and the new gate is not what is measured')
         # ON THE BRANCH 2: the landing is DRILL-test-legal, so the refusal
@@ -248,7 +265,7 @@ class TestARelocatedViaHonoursTheHoleFloor(unittest.TestCase):
         self.assertGreaterEqual(d_axis, V_DRILL / 2.0 + HR + H2H_PAD + 0.05,
                                 'the landing is inside the drill-to-drill '
                                 'keep-out, so the drill test refuses it too')
-        self.assertLess(_wall_gap(XH_REFUSED_BY_BOTH), NPTH_FLOOR - 0.05,
+        self.assertLess(_wall_gap(XH_REFUSED_BY_BOTH), CLEAR - 0.04,
                         'the landing is not inside the copper-to-hole band')
         # ON THE BRANCH 3: an empty `moves` means EVERY admissible candidate was
         # refused, not just the first. The walls admit three, all on the +x ray,
@@ -257,7 +274,7 @@ class TestARelocatedViaHonoursTheHoleFloor(unittest.TestCase):
         # would silently become a statement about the search budget.
         for cand in ALL_CANDIDATES:
             self.assertLess(_wall_gap(XH_REFUSED_BY_BOTH, at=cand),
-                            NPTH_FLOOR - 0.04,
+                            CLEAR - 0.04,
                             'candidate %s clears the gate, so a refusal here '
                             'would be about the 0.55mm budget, not the gate'
                             % (cand,))
@@ -270,24 +287,28 @@ class TestARelocatedViaHonoursTheHoleFloor(unittest.TestCase):
         self.assertEqual(segs, [], 'connector copper was drawn for no move')
         self.assertEqual((v.x, v.y), VIA0, 'the via was mutated in place')
     # MUTATION: delete the `_seg_foreign_hole_dist` gate in valid_via_pos --
-    # the via is parked at (3.4500, 3.0000) with 0.0500mm of copper-to-hole
-    # gap and stdout says "moved" (check_drc: VIA-HOLE, overlap 0.050mm).
+    # the via is parked at (3.4500, 3.0000) with 0.0500mm of copper-to-hole gap
+    # against a 0.1000 requirement, and stdout says "moved" (check_drc:
+    # VIA-HOLE, overlap 0.050mm -- which IS 0.1000 - 0.0500).
 
     def test_a_via_with_real_room_still_moves(self):
         """The over-rejection guard, and the negative control for every
         refusal in this file: the same rig with the hole 0.20mm further off."""
-        self.assertGreaterEqual(_wall_gap(XH_MOVES), NPTH_FLOOR + 0.04,
+        # Clear of BOTH candidate floors, so it is a control whichever one
+        # the gate charges -- it cannot be quietly invalidated by that choice.
+        self.assertGreaterEqual(_wall_gap(XH_MOVES),
+                                max(CLEAR, NPTH_FLOOR) + 0.04,
                                 'the control landing is not clear of the gate')
         v, _pcb, moves, segs, out = _rig(XH_MOVES)
         self.assertEqual(len(moves), 1,
                          'a via with 0.25mm of copper-to-hole gap was refused '
-                         'at a 0.20mm requirement -- the gate over-rejects')
+                         'at a 0.10mm requirement -- the gate over-rejects')
         self.assertAlmostEqual(v.x, LANDING[0], places=4)
         self.assertAlmostEqual(v.y, LANDING[1], places=4)
         self.assertEqual([(s['layer'], s['width']) for s in segs],
                          [('F.Cu', 0.2)])
         self.assertIn('moved', out)
-    # MUTATION: `npth_clr + vr` -> `npth_clr + 2 * vr` -- the gate
+    # MUTATION: `clearance + vr` -> `clearance + 2 * vr` -- the gate
     # over-rejects and this move disappears.
 
     def test_the_gate_prices_the_BARREL_not_the_DRILL(self):
@@ -299,35 +320,78 @@ class TestARelocatedViaHonoursTheHoleFloor(unittest.TestCase):
         # A drill-priced gate would need only 0.15 + 0.50 + 0.20 = 0.85 of
         # centre distance; the landing has 1.25, so it would accept.
         self.assertGreater(abs(LANDING[0] - XH_REFUSED_BY_BOTH),
-                           V_DRILL / 2.0 + HR + NPTH_FLOOR + 0.05,
+                           V_DRILL / 2.0 + HR + CLEAR + 0.05,
                            'a drill-priced gate would refuse this landing too')
         self.assertEqual(moves, [])
-    # MUTATION: `npth_clr + vr` -> `npth_clr + (v.drill or 0.3) / 2.0` -- the
-    # requirement falls to 0.85 of centre distance and the via moves.
+    # MUTATION: `clearance + vr` -> `clearance + (v.drill or 0.3) / 2.0` -- the
+    # requirement falls to 0.75 of centre distance and the via moves.
 
 
-class TestTheFloorIsTheFlatFabFloor(unittest.TestCase):
-    """Brackets the floor from BOTH sides: above a bare `clearance`, and not
-    raised by a board's declared `min_hole_clearance` (the #617 pin)."""
+class TestTheFloorIsTheVIARuleNotTheTRACKFloor(unittest.TestCase):
+    """The via gate charges `clearance`; its sibling charges `npth_clr`. That
+    asymmetry is deliberate -- check_drc grades a track and a via against a
+    plain NPTH hole at different values, and so does obstacle_map -- and these
+    arms are what stop a later reader unifying the two."""
 
-    def test_the_floor_is_not_the_bare_clearance(self):
-        # ON THE BRANCH: above clearance 0.20 the two candidates coincide and
-        # this arm asserts nothing.
+    def test_the_floor_is_NOT_the_siblings_track_floor(self):
+        # ON THE BRANCH: at clearance >= 0.20 the two coincide and this arm
+        # asserts nothing at all.
         self.assertLess(CLEAR, NPTH_FLOOR,
                         'at this clearance npth_clr == clearance, so this '
                         'test cannot separate the two conventions')
         gap = _wall_gap(XH_SEPARATES_THE_FLOORS)
         self.assertGreater(gap, CLEAR + 0.04,
-                           'the landing is inside the bare-clearance band '
-                           'too, so a `clearance` floor would refuse it as '
-                           'well and this arm proves nothing')
+                           'the landing is inside the via floor too, so it '
+                           'would be refused either way and this arm proves '
+                           'nothing')
         self.assertLess(gap, NPTH_FLOOR - 0.04,
-                        'the landing is outside the npth_clr band')
-        _v, _pcb, moves, segs, out = _rig(XH_SEPARATES_THE_FLOORS)
-        self.assertIn('no clear spot', out)
-        self.assertEqual((moves, segs), ([], []))
-    # MUTATION: `npth_clr + vr` -> `clearance + vr` -- the requirement drops
-    # to a 0.10mm wall gap and the via moves to (3.4500, 3.0000).
+                        'the landing clears the track floor as well, so the '
+                        'two conventions are not being separated here')
+        v, _pcb, moves, segs, out = _rig(XH_SEPARATES_THE_FLOORS)
+        self.assertEqual(len(moves), 1,
+                         'the via gate is charging the TRACK floor: it '
+                         'refused a landing check_drc grades clean')
+        self.assertAlmostEqual(v.x, LANDING[0], places=4)
+        self.assertEqual(len(segs), 1)
+        self.assertIn('moved', out)
+    # MUTATION: `clearance + vr` -> `npth_clr + vr` -- the requirement rises to
+    # a 0.20mm wall gap, this landing is refused, and (see the next arm) the
+    # repair is abandoned rather than merely relocated.
+
+    def test_the_track_floor_would_ABANDON_a_repair_check_drc_calls_clean(self):
+        """Why the asymmetry is not pedantry. `nudge_vias_for_unresolved` is an
+        all-or-nothing repair -- obstacle_map.resolve_hole_clearance names this
+        function BY NAME as one whose single clearing candidate must not be
+        refused. On this rig the track floor refuses every candidate, so the
+        cap would keep the #130 pad-via graze the pass exists to remove.
+
+        check_drc's own requirement for a via against a plain NPTH hole is
+        `hr + via.size/2 + clearance`, i.e. a wall gap of `clearance`.
+        Reproduced with the real checker on the equivalent board:
+
+            python3 py_router/check_drc.py rig48.kicad_pcb --clearance 0.1
+            -> NO DRC VIOLATIONS FOUND
+        """
+        self.assertGreaterEqual(
+            _wall_gap(XH_SEPARATES_THE_FLOORS), CLEAR,
+            'this landing is NOT clean at check_drc s via requirement, so '
+            'refusing it costs nothing and this arm is not about what it says')
+        # EVERY candidate the walls admit is inside the TRACK floor, so
+        # charging it loses the repair outright rather than moving it.
+        for cand in ALL_CANDIDATES:
+            self.assertLess(_wall_gap(XH_SEPARATES_THE_FLOORS, at=cand),
+                            NPTH_FLOOR,
+                            'candidate %s clears the track floor, so charging '
+                            'it would relocate rather than abandon, and this '
+                            'arm overstates the cost' % (cand,))
+        moves = _rig(XH_SEPARATES_THE_FLOORS)[2]
+        self.assertEqual(len(moves), 1,
+                         'the repair was abandoned on a landing check_drc '
+                         'grades CLEAN -- the exact failure mode '
+                         'obstacle_map.resolve_hole_clearance warns about for '
+                         'this function by name')
+    # MUTATION: `clearance + vr` -> `npth_clr + vr` -- 0 moves, 0 connectors,
+    # and `no clear spot` printed, on geometry the checker calls clean.
 
     def test_a_DECLARED_min_hole_clearance_changes_nothing(self):
         """#617's balance, pinned behaviourally rather than by comment. A
@@ -369,10 +433,13 @@ class TestTheFloorIsTheFlatFabFloor(unittest.TestCase):
     # MUTATION: `npth_clr` -> `st.npth_floor` (or a resolve_hole_clearance
     # read) -- this arm refuses while the project-less arm above still moves.
 
-    def test_both_hole_gates_in_the_nudger_spell_the_same_floor(self):
-        """A source guard, because the two sibling validators drifting apart
-        IS this issue. Reports the offending LINES, never assertIn over the
-        whole source (test_732 measured a 393KB failure message)."""
+    def test_the_two_hole_gates_keep_their_DIFFERENT_floors(self):
+        """A source guard. The two sibling validators drifting apart IS
+        this issue -- but they must agree about which HOLES exist, not
+        about what one COSTS: a track is charged npth_clr and a via
+        clearance, and unifying them in either direction is a defect.
+        Reports the offending LINES, never assertIn over the whole source
+        (test_732 measured a 393KB failure message)."""
         # CODE only. `l.lstrip().startswith('#')` drops a full-line comment
         # but not a trailing one, and the engine's comment block around this
         # very gate names `_seg_foreign_hole_dist`, `npth_clr`, `st.npth_floor`
@@ -389,11 +456,28 @@ class TestTheFloorIsTheFlatFabFloor(unittest.TestCase):
                          'expected exactly two copper-to-hole gates (the via '
                          'and the connector); found %d at function-relative '
                          'line(s) %s' % (len(calls), [i + 1 for i in calls]))
-        bad = [i + 1 for i in calls
-               if 'npth_clr' not in ' '.join(src[i:i + 3])]
-        self.assertEqual(bad, [],
-                         'a hole gate does not spell npth_clr, at '
-                         'function-relative line(s) %s' % bad)
+        # The two gates must spell DIFFERENT floors, and this is the guard
+        # that stops a later reader "tidying" them into one. The via gate
+        # (`v.net_id`) charges `clearance`; the connector gate (`net_id`, `hw`)
+        # charges `npth_clr`.
+        via_gate = [i for i in calls if 'v.net_id' in src[i]]
+        conn_gate = [i for i in calls if i not in via_gate]
+        self.assertEqual((len(via_gate), len(conn_gate)), (1, 1),
+                         'could not tell the via gate from the connector gate '
+                         'at function-relative line(s) %s'
+                         % [i + 1 for i in calls])
+        vtxt = ' '.join(src[via_gate[0]:via_gate[0] + 3])
+        ctxt = ' '.join(src[conn_gate[0]:conn_gate[0] + 3])
+        self.assertNotIn('npth_clr', vtxt,
+                         'the VIA gate spells npth_clr -- that is the TRACK '
+                         'floor, and charging it abandons repairs check_drc '
+                         'grades clean')
+        self.assertIn('clearance', vtxt,
+                      'the VIA gate does not spell `clearance`, which is what '
+                      'check_drc s via-hole arm grades at')
+        self.assertIn('npth_clr', ctxt,
+                      'the CONNECTOR gate no longer spells npth_clr -- #617 '
+                      'set that floor deliberately')
         # The tolerance too. This one is pinned HERE and nowhere else, and
         # deliberately so: measured, dropping `- 1e-4` from the via gate leaves
         # the whole suite green, because it only decides an exact tie and no
@@ -525,15 +609,15 @@ class TestTheDrillTestIsUnchanged(unittest.TestCase):
         0.5/0.3 via the DRILL test is the stricter of the two, so the new gate
         can never be the binding one there."""
         drill_need = 0.3 / 2.0 + self.ND / 2.0 + H2H_PAD          # 0.70
-        gate_need = 0.5 / 2.0 + self.ND / 2.0 + NPTH_FLOOR        # 0.55
-        self.assertGreater(drill_need, gate_need + 0.10,
+        gate_need = 0.5 / 2.0 + self.ND / 2.0 + CLEAR             # 0.45
+        self.assertGreater(drill_need, gate_need + 0.20,
                            'the two requirements are close enough that the '
                            'new gate could become the binding one here')
         v, pcb = self._rig617()
         _nudge(_FakeSt([self.BAR]), pcb)
         d = math.hypot(v.x - self.NPTH[0], v.y - self.NPTH[1])
-        self.assertGreater(d, gate_need + 0.10,
-                           'the achieved landing has less than 0.10mm of '
+        self.assertGreater(d, gate_need + 0.20,
+                           'the achieved landing has less than 0.20mm of '
                            'headroom on the new gate')
         self.assertAlmostEqual(d, 0.706588, places=5)
     # MUTATION: none kills these -- they are the measurement that licenses the
@@ -588,7 +672,7 @@ class TestInertOnTheTrackedCorpus(unittest.TestCase):
         self.assertGreater(total, 500,
                            'only %d sized vias across the corpus -- the bound '
                            'below would be vacuous' % total)
-        bound = H2H_PAD - max(defaults.CLEARANCE, NPTH_FLOOR)      # 0.20
+        bound = H2H_PAD - defaults.CLEARANCE                       # 0.20
         # Compared against the bound ITSELF, with the margin reported. An
         # arbitrary safety subtraction here would be the tightest number in
         # the file (0.1500 against 0.1600) while LOOKING like the loosest --
@@ -619,7 +703,7 @@ class TestInertOnTheTrackedCorpus(unittest.TestCase):
     def test_every_via_this_pipeline_CREATES_is_below_the_bound(self):
         """The corpus is a snapshot; these are the sizes the tool itself
         emits, and they are what keep the gate inert on boards it produces."""
-        bound = H2H_PAD - max(defaults.CLEARANCE, NPTH_FLOOR)
+        bound = H2H_PAD - defaults.CLEARANCE
         for name, size, drill in (
                 ('BGA_VIA', defaults.BGA_VIA_SIZE, defaults.BGA_VIA_DRILL),
                 ('VIA', defaults.VIA_SIZE, defaults.VIA_DRILL),

--- a/tests/test_737_fanout_clearance_via_hole.py
+++ b/tests/test_737_fanout_clearance_via_hole.py
@@ -56,20 +56,44 @@ Conventions this file follows (#697/#725/#731/#732/#733 and CLAUDE.md):
   * Every assertion names the single-line MUTATION that must kill it.
   * Assert you are ON THE BRANCH before asserting about it.
   * Every "is refused" is paired with a NEGATIVE CONTROL that still moves.
-  * No fixture sits within 0.05mm of the quantity under test. The ONE
-    sub-0.05 boundary in the rig is the CAP gate (0.025 either side of
-    nx = 3.425); that is the sweep's own 0.05mm radial quantum, it is stated
-    here rather than left for a reviewer to find, and it is not the quantity
-    any assertion below measures.
+  * No fixture in the rig below sits within 0.05mm of the quantity its
+    assertion measures -- the three hole positions sit at gaps 0.050 / 0.150 /
+    0.250 against a 0.200 floor, i.e. exactly 0.05 clear on both sides. Four
+    tighter boundaries exist and are named here rather than left for a reviewer
+    to find, because a blanket claim that ignored them would be false:
+      - the CAP gate, 0.025 either side of nx = 3.425. That is the sweep's own
+        0.05mm radial quantum, and no assertion here measures it.
+      - #617's INHERITED rig, whose landing clears the drill gate by 0.006588
+        (0.706588 vs 0.700000) -- that margin is what CHOOSES the landing, and
+        it is #617's geometry, not a fixture this file picked. The arm that
+        reads it asserts the landing exactly, so it is a change detector for
+        precisely that.
+      - the same rig's connector, 0.0200 clear of the connector's own floor
+        (0.3200 vs 0.3000) -- again inherited, and asserted exactly (0.2200).
+      - the corpus bound, where the widest tracked ring 0.1500 sits 0.0500
+        under the 0.2000 threshold. That IS the finding, not a fixture.
 
 A 9-mutation run over the engine gate kills 8. The survivor is named rather
-than hidden: `<` -> `<=`. It, and dropping the `- 1e-4`, were both measured to
-leave the ENTIRE suite green on behaviour alone -- they decide an exact tie, and
-the 0.05mm spiral produces no candidate that sits on one. The 1e-4 is therefore
-held by the SOURCE guard in `TestTheFloorIsTheFlatFabFloor` (the two sibling
-gates must read as one expression, which is a source property); `<=` is held by
-nothing, because any fixture that could catch it would have to sit on the
-threshold this file's own convention forbids.
+than hidden: `<` -> `<=`. Its mechanism is worth stating correctly, because the
+obvious version is wrong: it is NOT that no candidate lands on an exact tie --
+this rig generates two (XH_MOVES at r = 0.50 gives a gap of exactly 0.2000, and
+XH_SEPARATES_THE_FLOORS at r = 0.50 exactly 0.1000), they are simply never
+reached because an earlier radius wins. The real reason is stronger: the gate
+compares against `floor + vr - 1e-4`, so a gap sitting on the FLOOR is 1e-4
+clear of the COMPARISON boundary, and `<` and `<=` are therefore behaviourally
+identical for every input -- not merely for every input this file tries.
+
+Dropping the `- 1e-4` was likewise measured to leave the entire suite green (it
+was predicted to break test_732's DVS_BIG rig; it does not). It is therefore
+held by the SOURCE guard in `TestTheFloorIsTheFlatFabFloor` -- the two sibling
+gates must read as one expression, which is a source property.
+
+A second round of four mutations, added after a review found the first version
+of that guard defeatable, kills all four: the epsilon hidden behind a trailing
+comment, the floor hidden behind one, `H2H_PAD` moved, and the staged project's
+declaring key mistyped. Two FALSE-POSITIVE probes -- a comment mentioning
+`_seg_foreign_hole_dist(`, and one mentioning `st.npth_floor` -- correctly
+change nothing, which the earlier raw-line version of the guard did not manage.
 
 Runs in-process in a couple of seconds; the corpus class shells out once for
 `git ls-files`.
@@ -121,11 +145,19 @@ H_DRILL = 1.0                  # hr 0.50
 HR = H_DRILL / 2.0
 MAX_SHIFT = 0.55
 VIA0 = (3.0, 3.0)              # the offending via, net 3
-LANDING = (3.45, 3.0)          # the ONLY landing the walls admit
+LANDING = (3.45, 3.0)          # the FIRST landing the walls admit
 
-# Foreign-net (2) walls that box the search to +x, so the landing is
-# deterministic and one-dimensional: T/B admit only |dy| <= 0.10, and L needs
-# nx >= 3.425, so the first admissible ring is r = 0.45 -> (3.45, 3.00).
+# Foreign-net (2) walls that box the search to +x, so the search is
+# one-dimensional: T/B admit only |dy| <= 0.10, and L needs nx >= 3.425, so the
+# first admissible ring is r = 0.45 -> (3.45, 3.00). Two further candidates are
+# admitted at r = 0.50 and 0.55, both also at k = 0 -- (3.50, 3.00) and
+# (3.55, 3.00). Naming LANDING "the only one" would be false, and the refusal
+# arms do not rest on it being the only one. They rest on something stronger:
+# the hole sits ON that single admissible ray, so the copper-to-hole gap grows
+# monotonically with r, and a hole close enough to refuse (3.45) refuses every
+# candidate BEYOND it too -- which is why a refusal arm ends with an empty
+# `moves` rather than with a different landing. ALL_CANDIDATES pins the set.
+ALL_CANDIDATES = ((3.45, 3.0), (3.50, 3.0), (3.55, 3.0))
 WALL_L = (0.0, 0.0, 2.625, 8.0, 2)
 WALL_T = (0.0, 3.90, 8.0, 8.0, 2)
 WALL_B = (0.0, 0.0, 8.0, 2.10, 2)
@@ -218,6 +250,17 @@ class TestARelocatedViaHonoursTheHoleFloor(unittest.TestCase):
                                 'keep-out, so the drill test refuses it too')
         self.assertLess(_wall_gap(XH_REFUSED_BY_BOTH), NPTH_FLOOR - 0.05,
                         'the landing is not inside the copper-to-hole band')
+        # ON THE BRANCH 3: an empty `moves` means EVERY admissible candidate was
+        # refused, not just the first. The walls admit three, all on the +x ray,
+        # so the gap grows monotonically with r and the far ones are the ones
+        # that could plausibly escape. Assert they do not -- otherwise this arm
+        # would silently become a statement about the search budget.
+        for cand in ALL_CANDIDATES:
+            self.assertLess(_wall_gap(XH_REFUSED_BY_BOTH, at=cand),
+                            NPTH_FLOOR - 0.04,
+                            'candidate %s clears the gate, so a refusal here '
+                            'would be about the 0.55mm budget, not the gate'
+                            % (cand,))
         v, _pcb, moves, segs, out = _rig(XH_REFUSED_BY_BOTH)
         # The PRINT first: assert it before the counts and no mutation can
         # make the silence be the reported failure.
@@ -305,6 +348,17 @@ class TestTheFloorIsTheFlatFabFloor(unittest.TestCase):
                                      {'rules': {'min_hole_clearance': 0.40}}}},
                           f)
             v, pcb = _board(XH_MOVES, source_path=pcb_path)
+            # VERIFY THE INPUT before trusting the output (CLAUDE.md's
+            # run_utils.evidence rule). The assertion below is an ABSENCE --
+            # "the declared value changed nothing" -- so a fixture that
+            # declares nothing passes it forever, for the wrong reason. Mistype
+            # the key and resolve_hole_clearance returns 0.0; this line is what
+            # makes that a failure instead of a green.
+            from obstacle_map import resolve_hole_clearance
+            self.assertAlmostEqual(
+                resolve_hole_clearance(pcb, None), 0.40, places=6,
+                msg='the staged project does not actually declare 0.40, so '
+                    'this arm would pass even if the gate DID read the board')
             moves, segs, out = _nudge(_FakeSt(WALLS), pcb, max_shift=MAX_SHIFT)
         self.assertEqual(len(moves), 1,
                          'the declared 0.40 reached this gate -- #617 '
@@ -319,10 +373,18 @@ class TestTheFloorIsTheFlatFabFloor(unittest.TestCase):
         """A source guard, because the two sibling validators drifting apart
         IS this issue. Reports the offending LINES, never assertIn over the
         whole source (test_732 measured a 393KB failure message)."""
-        src = inspect.getsource(FC.nudge_vias_for_unresolved).splitlines()
+        # CODE only. `l.lstrip().startswith('#')` drops a full-line comment
+        # but not a trailing one, and the engine's comment block around this
+        # very gate names `_seg_foreign_hole_dist`, `npth_clr`, `st.npth_floor`
+        # and `1e-4` repeatedly -- so reading raw lines both invented gates
+        # (measured: one `# see _seg_foreign_hole_dist(` line took the count to
+        # 3) and let a real one hide behind `npth_clr + vr:  # the 1e-4 was
+        # here`, which passed every arm of this file.
+        src = [l.split('#')[0]
+               for l in inspect.getsource(FC.nudge_vias_for_unresolved)
+               .splitlines()]
         calls = [i for i, l in enumerate(src)
-                 if '_seg_foreign_hole_dist(' in l
-                 and not l.lstrip().startswith('#')]
+                 if '_seg_foreign_hole_dist(' in l]
         self.assertEqual(len(calls), 2,
                          'expected exactly two copper-to-hole gates (the via '
                          'and the connector); found %d at function-relative '
@@ -344,12 +406,19 @@ class TestTheFloorIsTheFlatFabFloor(unittest.TestCase):
                          'a hole gate dropped the 1e-4 the other one carries, '
                          'at function-relative line(s) %s' % eps)
         drift = [i + 1 for i, l in enumerate(src)
-                 if ('npth_floor' in l or 'resolve_hole_clearance' in l)
-                 and not l.lstrip().startswith('#')]
+                 if 'npth_floor' in l or 'resolve_hole_clearance' in l]
         self.assertEqual(drift, [],
                          'the nudger reads a BOARD-AWARE hole floor at '
                          'function-relative line(s) %s -- #617 refused that'
                          % drift)
+        # And the one constant this file HAND-MIRRORS. `H2H_PAD` is a
+        # function-local literal, so it cannot be imported; three ON-THE-BRANCH
+        # guards above reason about the drill test using the mirror, and would
+        # silently reason about the wrong number if the engine's changed.
+        self.assertIn('H2H_PAD = %s' % H2H_PAD, ' '.join(src),
+                      "the engine's H2H_PAD is no longer %s, so this file's "
+                      'mirror -- and the drill-test arithmetic in every '
+                      'ON-THE-BRANCH guard here -- is stale' % H2H_PAD)
     # MUTATION: re-spell either gate's floor, drop either 1e-4, or add a third
     # gate -- the count, the `bad` list or the `eps` list changes. This arm is
     # the ONLY thing that kills the 1e-4 mutation; `<` -> `<=` is killed by
@@ -475,12 +544,25 @@ class TestInertOnTheTrackedCorpus(unittest.TestCase):
     """A self-expiring bound. The gate is UNREACHABLE on every board this repo
     tracks, which is why the demonstration above is synthetic on purpose."""
 
-    @staticmethod
-    def _tracked():
-        out = subprocess.run(['git', 'ls-files', '-z', '*.kicad_pcb'],
-                             cwd=_ROOT, capture_output=True, text=True)
-        return [os.path.join(_ROOT, p) for p in out.stdout.split('\0')
-                if p.endswith('.kicad_pcb')]
+    def _tracked(self):
+        """The boards git TRACKS. A checkout with no git, or a source export
+        outside a repo, cannot identify that set at all -- and must SKIP rather
+        than grade against a set it cannot name. Before this, a `git ls-files`
+        that exited 128 with empty output failed the count assertion below and
+        reported the gitignored-build-products reason, which is the WRONG
+        cause: `out.returncode` was captured and never read."""
+        try:
+            out = subprocess.run(['git', 'ls-files', '-z', '*.kicad_pcb'],
+                                 cwd=_ROOT, capture_output=True, text=True)
+        except OSError as e:
+            self.skipTest('SKIP: cannot run git to identify the tracked '
+                          'corpus: %s' % e)
+        if out.returncode != 0:
+            self.skipTest('SKIP: git ls-files exited %d (%s) -- the tracked '
+                          'corpus cannot be identified here'
+                          % (out.returncode, out.stderr.strip()[:120]))
+        return [os.path.join(_ROOT, q) for q in out.stdout.split(chr(0))
+                if q.endswith('.kicad_pcb')]
 
     def test_no_tracked_via_is_fat_enough_for_the_gate_to_bind(self):
         boards = self._tracked()
@@ -507,13 +589,22 @@ class TestInertOnTheTrackedCorpus(unittest.TestCase):
                            'only %d sized vias across the corpus -- the bound '
                            'below would be vacuous' % total)
         bound = H2H_PAD - max(defaults.CLEARANCE, NPTH_FLOOR)      # 0.20
-        self.assertLess(widest, bound - 0.04,
+        # Compared against the bound ITSELF, with the margin reported. An
+        # arbitrary safety subtraction here would be the tightest number in
+        # the file (0.1500 against 0.1600) while LOOKING like the loosest --
+        # and it is the bound, not a safety band, that the claim is about.
+        self.assertLess(widest, bound,
                         'a tracked board now carries a via ring of %.4f (%s), '
-                        'at or near the %.4f bound where this gate starts to '
+                        'at or over the %.4f bound where this gate starts to '
                         'bind at the shipped --clearance %.2f. The "provably '
                         'inert on the corpus" claim in this PR must be '
                         're-measured.' % (widest, where, bound,
                                           defaults.CLEARANCE))
+        self.assertGreater(bound - widest, 0.04,
+                           'the widest tracked ring %.4f is now within 0.04mm '
+                           'of the %.4f bound -- still inert, but the margin '
+                           'this PR reported as 0.0500 has shrunk'
+                           % (widest, bound))
         # The boards carrying BOTH vias and copper-less holes are the only
         # ones where this gate could ever fire; name them, so a change there
         # is visible rather than silent.

--- a/tests/test_737_fanout_clearance_via_hole.py
+++ b/tests/test_737_fanout_clearance_via_hole.py
@@ -202,6 +202,15 @@ class _FakeSt:
     """The duck-typed `st` the #370/#617 harnesses pass: no resolvers at all,
     so every requirement in the nudger falls back to the flat scalar."""
 
+    #: A REAL `st` is a `_Repair`, which carries `npth_floor` (the board-aware
+    #: hole floor). The duck type must carry one too, or the most likely wrong
+    #: floor -- `max(clearance, getattr(st, 'npth_floor', 0.0))` -- reads 0.0
+    #: here, behaves exactly like the right one, and is caught only by the
+    #: source guard. Measured: without this attribute that mutation survives
+    #: every behavioural arm in this file. 0.40 is above every gap the rig
+    #: uses, so a gate that reads it refuses landings the checker calls clean.
+    npth_floor = 0.40
+
     def __init__(self, rects):
         self.caps = {'C1': _FakeCap(rects)}
         self.vias = []
@@ -394,9 +403,21 @@ class TestTheFloorIsTheVIARuleNotTheTRACKFloor(unittest.TestCase):
     # and `no clear spot` printed, on geometry the checker calls clean.
 
     def test_a_DECLARED_min_hole_clearance_changes_nothing(self):
-        """#617's balance, pinned behaviourally rather than by comment. A
-        board declaring 0.40 would refuse this landing if the gate read the
-        board; the flat floor accepts it, so the #130 repair is kept."""
+        """A board declaring 0.40 would refuse this landing if the gate read
+        the board; it does not, so the #130 repair is kept.
+
+        The reason the declared value must stay unread is stronger than the
+        #617 appeal it used to rest on, and it is checkable: it changes
+        nothing in check_drc's VIA arm either. The declared floor enters that
+        arm only through the `req_clr > npth_clr` THRESHOLD, so with a
+        declared 0.40 and no pad override the graded requirement is still
+        `clearance`. A gate that read the board would therefore refuse copper
+        its own checker calls clean.
+
+        `_FakeSt.npth_floor` exists for this arm: without it the
+        `max(clearance, getattr(st, 'npth_floor', 0.0))` mutation reads 0.0
+        and slips through every behavioural test in this file.
+        """
         self.assertGreater(_wall_gap(XH_MOVES), NPTH_FLOOR + 0.04,
                            'the landing does not clear the flat floor')
         self.assertLess(_wall_gap(XH_MOVES), 0.40 - 0.04,
@@ -475,9 +496,16 @@ class TestTheFloorIsTheVIARuleNotTheTRACKFloor(unittest.TestCase):
         self.assertIn('clearance', vtxt,
                       'the VIA gate does not spell `clearance`, which is what '
                       'check_drc s via-hole arm grades at')
+        # This assertion is the ONLY thing in the tree that holds the
+        # connector floor. Measured: rewriting `npth_clr + hw` to
+        # `clearance + hw` passes test_617, test_370 and test_fanout_clearance
+        # (20 tests) -- including test_617's own "UNCHANGED site" arm, which
+        # exists to pin exactly that floor. Same position as the 1e-4 above,
+        # and worth the same disclosure rather than a silent reliance.
         self.assertIn('npth_clr', ctxt,
                       'the CONNECTOR gate no longer spells npth_clr -- #617 '
-                      'set that floor deliberately')
+                      'set that floor deliberately, and NOTHING else in the '
+                      'tree catches this')
         # The tolerance too. This one is pinned HERE and nowhere else, and
         # deliberately so: measured, dropping `- 1e-4` from the via gate leaves
         # the whole suite green, because it only decides an exact tie and no

--- a/tests/test_737_fanout_clearance_via_hole.py
+++ b/tests/test_737_fanout_clearance_via_hole.py
@@ -587,6 +587,19 @@ class TestTheFloorIsTheVIARuleNotTheTRACKFloor(unittest.TestCase):
                          'assignment -- #617 refused it in every other '
                          'position, at function-relative line %d'
                          % (board[0] + 1))
+        # ...and it must not be LAUNDERED into the floor. Pinning the read to
+        # `npth_step` is not enough on its own: `npth_clr = npth_step` on the
+        # next line reinstates #617's mutation while every check above still
+        # passes, and a review found exactly that. So pin the floor's
+        # assignment count too -- one, and the shape guard in test_730 says
+        # what that one must be.
+        flat = [i + 1 for i, l in enumerate(src)
+                if l.lstrip().startswith('npth_clr =')]
+        self.assertEqual(len(flat), 1,
+                         'npth_clr is assigned %d times (at function-relative '
+                         'line(s) %s) -- a second assignment is how a board-'
+                         'derived value reaches the floor #617 kept flat'
+                         % (len(flat), flat))
         # ...and no GATE may add it. A threshold that leaks into a gate line is
         # a floor wearing a threshold's name.
         for i in calls + ogates:
@@ -613,11 +626,14 @@ class TestTheFloorIsTheVIARuleNotTheTRACKFloor(unittest.TestCase):
                       "the engine's H2H_PAD is no longer %s, so this file's "
                       'mirror -- and the drill-test arithmetic in every '
                       'ON-THE-BRANCH guard here -- is stale' % H2H_PAD)
-    # MUTATION: re-spell either gate's floor, drop either 1e-4, or add a third
-    # gate -- the count, the `bad` list or the `eps` list changes. This arm is
-    # the ONLY thing that kills the 1e-4 mutation; `<` -> `<=` is killed by
-    # nothing at all, and is left declared rather than papered over, because
-    # any fixture that could catch it would sit on the threshold.
+    # MUTATION: re-spell either gate's floor, drop any of the four 1e-4s, add
+    # a fifth hole gate, move the board read out of `npth_step`, or assign
+    # `npth_clr` twice -- one of the counts or lists above changes. (The
+    # trailer used to name a `bad` list; there has never been one in this
+    # method. Corrected while #730 rewrote the guard around it.) This arm is
+    # still the ONLY thing that kills the 1e-4 mutation; `<` -> `<=` is killed
+    # by nothing at all, and is left declared rather than papered over,
+    # because any fixture that could catch it would sit on the threshold.
 
 
 class TestTheComparisonIsSTRICT(unittest.TestCase):

--- a/tests/test_741_via_nudge_tenting.py
+++ b/tests/test_741_via_nudge_tenting.py
@@ -124,8 +124,13 @@ CLOSED by arms added afterwards rather than declared away. Three arms overlap
 tests/test_489_via_tenting.py, which owns those values; they are kept only as
 end-to-end change detectors and are marked as such.
 
-RUNTIME: ~20-30s. One subprocess (the CLI arm), one memoised rig per clearance,
-and the corpus spec arm is a TEXT scan rather than a parse.
+RUNTIME: ~14s warm, and it is almost all one class -- measured 13.8/13.9/13.8
+over three runs, of which TestInertOnTheTrackedCorpus is 13.5. A cold cache is
+much worse: an independent reviewer measured 57s on a fresh checkout, because
+that class parses and drives the engine over 22 boards x 2 clearances. That is
+why this file does NOT declare RUN_ALL_FAST_OK -- run_all.py's rule is that a
+test driving a routing chain belongs in the integration bucket whatever it
+imports. The rest (rig, 34 other arms, one CLI subprocess) is under a second.
 """
 
 # NO RUN_ALL_FAST_OK. Measured six runs: 54-67s, of which

--- a/tests/test_741_via_nudge_tenting.py
+++ b/tests/test_741_via_nudge_tenting.py
@@ -50,10 +50,14 @@ this file lie:
     the correct output are THE SAME STRING. The only Type-VII example in the
     repo is the inline `REAL_VIA` string in tests/test_489_via_tenting.py,
     which is not a board.
-  * A `synth.make_pcb()` board CANNOT reproduce the defect at all. It leaves
-    `net_id_to_name` empty, so `placement/writer.py`'s `n2n` is falsy, `nm` is
-    None, and `via_protection_sexpr` returns "" -- nothing is emitted either
-    way. An arm built that way is green today and proves nothing.
+  * A `synth.make_pcb()` board leaves `net_id_to_name` empty, so
+    `placement/writer.py`'s `n2n` is falsy and every via is emitted with a
+    NUMERIC net token. Note what that does and does not break, because the
+    obvious reading is wrong: a real spec is still emitted (the `net_name`
+    gate guards only the DEFAULT), so half one would appear to work -- but the
+    numeric-net parser defect described below then drops the whole via at
+    re-parse, and the spec-less half collapses to silence. An arm built that
+    way grades a via that is not in the model.
   * The vias MUST carry `(uuid "...")`. `kicad_parser
     ._extract_via_protection_attrs` keys specs by uuid and `continue`s on a
     uuid-less via, so the spec would arrive `{}` and every assertion below
@@ -112,16 +116,24 @@ TWO HAZARDS this file must not fall into, both measured:
     the "nothing else changed" arm diffs `_strip_via_blocks(out)` against
     `_strip_via_blocks(inp)` instead.
 
-THE BATTERY: 20 mutations, with the killer named beside each arm and the full
-table at the bottom of this file. One is DECLARED UNKILLABLE rather than
-papered over; two overlap tests/test_489_via_tenting.py, which owns those
-values, and are kept only as end-to-end change detectors.
+THE BATTERY: 28 mutations, RUN rather than reasoned about, with the killer
+named beside each arm and the full table at the bottom of this file. 25 killed,
+THREE declared survivors -- recorded, not papered over. Two further survivors
+were found by an adversarial review of this file and a mutation run, and were
+CLOSED by arms added afterwards rather than declared away. Three arms overlap
+tests/test_489_via_tenting.py, which owns those values; they are kept only as
+end-to-end change detectors and are marked as such.
 
 RUNTIME: ~20-30s. One subprocess (the CLI arm), one memoised rig per clearance,
 and the corpus spec arm is a TEXT scan rather than a parse.
 """
 
-RUN_ALL_FAST_OK = True
+# NO RUN_ALL_FAST_OK. Measured six runs: 54-67s, of which
+# TestInertOnTheTrackedCorpus is ~50s -- it drives the whole engine over 22
+# boards x 2 clearances. run_all.py's own rule is that a test which drives a
+# routing chain belongs in the integration bucket whatever it imports, and the
+# opt-out is documented for ~4s unit tests. Declaring both the opt-out and a
+# 900s timeout would have been the two declarations disagreeing out loud.
 RUN_ALL_TIMEOUT = 900
 
 import contextlib
@@ -479,7 +491,11 @@ class TestATypeVIIViaSurvivesTheNudge(unittest.TestCase):
         # VACUITY GUARD: the INPUT really carries a spec. Without the uuid,
         # _extract_via_protection_attrs skips the via and every assertion below
         # would pass on {} == {}.
-        src = _via_by_net(self.rig.pcb, 'VF1')
+        # Re-parsed from disk, NOT rig.pcb: the pass mutates that object in
+        # place (v.x, v.y = nx, ny), so calling it "the input" would be reading
+        # post-pass state and asserting a spec is unmutated on the very object
+        # a mutation could have mutated.
+        src = _via_by_net(parse_kicad_pcb(self.rig.src), 'VF1')
         self.assertEqual(src.tenting_attrs, TYPE_VII)
         self.assertNotIn('tenting', src.tenting_attrs)
 
@@ -525,8 +541,15 @@ class TestATypeVIIViaSurvivesTheNudge(unittest.TestCase):
         self.assertEqual(len(self.rig.out_pcb.vias), 3,
                          'the moved via was appended without removing the '
                          'original: a stacked same-net barrel pair')
-        got = re.search(r'\(uuid "([^"]+)"\)',
-                        _via_block(self.rig.out_text, 'VF1')).group(1)
+        blk = _via_block(self.rig.out_text, 'VF1')
+        m = re.search(r'\(uuid "([^"]+)"\)', blk)
+        # presence FIRST: without it, deleting the (uuid ...) line reports an
+        # AttributeError on None instead of this arm's authored reason.
+        self.assertIsNotNone(m, 'the re-emitted via carries NO uuid, so it can '
+                                'never receive a protection spec at the next '
+                                'parse (_extract_via_protection_attrs keys by '
+                                'uuid)')
+        got = m.group(1)
         self.assertTrue(got)
         self.assertNotEqual(got, UUID_VF1,
                             'the re-emitted via reuses the input uuid; two '
@@ -562,9 +585,11 @@ class TestASpecLessViaEmitsNothingAndInherits(unittest.TestCase):
         self.assertIn('via-nudge: moved VF2 via (11.175,10.500) -> '
                       '(11.325,10.500) to free C2', self.rig.out)
         self.assertTrue(self.rig.wrote)
-        self.assertEqual(_via_by_net(self.rig.pcb, 'VF2').tenting_attrs, {},
-                         'the INPUT via gained a spec; this is no longer the '
-                         'spec-less case')
+        # re-parsed from disk; see the note in the headline class's setUp
+        self.assertEqual(
+            _via_by_net(parse_kicad_pcb(self.rig.src), 'VF2').tenting_attrs,
+            {}, 'the INPUT via gained a spec; this is no longer the spec-less '
+                'case')
 
     def test_a_via_that_inherited_still_inherits(self):
         v = _via_by_net(self.rig.out_pcb, 'VF2')
@@ -633,6 +658,51 @@ class TestTheHash489DefaultDidNotMove(unittest.TestCase):
                 'a %s of the sentinel no longer inherits: it either raised or '
                 'fell through to the front+back default' % how)
 
+    def test_a_spec_the_TEXT_parser_never_touched_is_still_collapsed(self):
+        """KILLS the whitespace-collapse survivor. `via_protection_sexpr._one`
+        collapses its inner text onto one line -- and NO fixture in this file
+        or in test_489 could see that, because `_balanced_token_text` already
+        collapses on the way IN, so a spec that came from the text parser is
+        one line before the writer ever sees it.
+
+        The pcbnew path does not go through that parser, and neither does a
+        hand-built spec. Build one with real newlines and tabs, which is what
+        a caller assembling a spec by hand produces.
+
+        Found by a mutation run: dropping the collapse left this file AND
+        test_489_via_tenting.py green."""
+        ragged = {'covering': '(front no)\n\t\t\t(back no)',
+                  'capping': '\n\t\tyes\n\t'}
+        out = generate_via_sexpr(1, 2, 0.6, 0.3, ['F.Cu', 'B.Cu'], 5,
+                                 net_name='GND', tenting_attrs=ragged)
+        self.assertIn('(covering (front no) (back no))', out, out)
+        self.assertIn('(capping yes)', out, out)
+        for line in out.splitlines():
+            self.assertLessEqual(
+                line.count('('), 3,
+                'a protection token spilled across lines: %r' % line)
+    # MUTATION 15: drop `inner = " ".join((inner or '').split())` in _one.
+
+    def test_a_token_KiCad_adds_LATER_is_re_emitted_rather_than_dropped(self):
+        """KILLS the unrecognised-token survivor. `via_protection_sexpr` emits
+        spec keys outside VIA_PROTECTION_TOKEN_ORDER after the known ones,
+        deliberately -- losing a spec is the bug this whole area exists to
+        prevent, and a KiCad that adds a sixth protection token must not have
+        it silently dropped by a re-placement.
+
+        No board in the corpus and no fixture in this file carries such a
+        token, so the line was uncovered. Found by a mutation run."""
+        spec = dict(TYPE_VII)
+        spec['electroplating'] = 'yes'      # a token this repo does not know
+        out = generate_via_sexpr(1, 2, 0.6, 0.3, ['F.Cu', 'B.Cu'], 5,
+                                 net_name='GND', tenting_attrs=spec)
+        self.assertIn('(electroplating yes)', out, out)
+        self.assertEqual(_prot_tokens(out),
+                         ['covering', 'plugging', 'capping', 'filling'],
+                         'the KNOWN tokens must still lead, in canonical '
+                         'order, with the unknown one appended after')
+    # MUTATION B: delete the `parts += [...]` unrecognised-token line.
+
     def test_the_sentinel_emits_nothing_and_a_real_spec_still_wins(self):
         self.assertEqual(
             _prot_tokens(generate_via_sexpr(
@@ -680,16 +750,33 @@ class TestTheHash489DefaultDidNotMove(unittest.TestCase):
                          'DEFAULT_VIA_TENTING changed. test_489_via_tenting.py '
                          'owns this value; re-read #489 s8 and re-measure this '
                          'file before touching it.')
-        self.assertEqual(VIA_PROTECTION_TOKEN_ORDER,
-                         ('tenting', 'covering', 'plugging', 'capping',
-                          'filling'))
+        # Deliberately NOT re-pinning VIA_PROTECTION_TOKEN_ORDER as a literal
+        # tuple. test_489 owns the EMITTED order; moving 'tenting' within that
+        # constant is an in-scope #489 change that would have turned this file
+        # red and left test_489 green -- a value this class says it does not
+        # own, pinned in the one direction its owner cannot cover. Assert only
+        # the property this file depends on: that the four Type-VII tokens
+        # keep a stable relative order.
+        self.assertEqual(
+            [t for t in VIA_PROTECTION_TOKEN_ORDER if t in TYPE_VII],
+            ['covering', 'plugging', 'capping', 'filling'])
 
 
 class TestAViaTheNudgeNeverTouchedIsUnchanged(unittest.TestCase):
     """VF3 sits 18mm away and is nobody's offender."""
 
+    def setUp(self):
+        self.rig = _rig(CLEAR)
+        # ON THE BRANCH. Without this, an engine that never reached the nudger
+        # satisfies every assertion below -- measured: with
+        # nudge_vias_for_unresolved neutered to `return [], []` this class
+        # alone passed in 0.29s. Found by an adversarial review of this file.
+        self.assertIn('via-nudge: moved VF1 via', self.rig.out)
+        self.assertEqual(len(self.rig.res['via_moves']), 2, self.rig.out)
+        self.assertTrue(self.rig.wrote)
+
     def test_the_control_vias_block_is_BYTE_identical(self):
-        rig = _rig(CLEAR)
+        rig = self.rig
         self.assertEqual(_via_block(rig.out_text, 'VF3'),
                          _via_block(rig.in_text, 'VF3'),
                          'a via nobody moved was rewritten -- including its '
@@ -697,8 +784,17 @@ class TestAViaTheNudgeNeverTouchedIsUnchanged(unittest.TestCase):
         v = _via_by_net(rig.out_pcb, 'VF3')
         self.assertEqual(v.tenting_attrs, TYPE_VII)
         self.assertEqual((round(v.x, 4), round(v.y, 4)), CTRL_XY)
-    # MUTATION 11b: net-agnostic removal in _remove_vias_at_positions.
     # MUTATION: a writer that re-emits every via instead of the moved ones.
+    #
+    # NOT this arm: net-agnostic removal (dropping net_ids=/net_names= from
+    # writer.py). MEASURED to leave this file entirely green, because nothing
+    # on the rig sits within _remove_vias_at_positions' 2e-3 tolerance of a
+    # moved via's old position -- and a coincident via cannot be ADDED to the
+    # rig, because at 0.15mm it fails the hole-to-hole gate and the nudge then
+    # refuses (measured: VF1 stops moving). That mutation is owned by
+    # tests/test_via_move_removal_net_name.py, which drives
+    # _remove_vias_at_positions directly with a positive and a negative net
+    # match -- the #344 stacked-via regression.
 
 
 class TestTheMoveDictCarriesTheSpecForTheGUI(unittest.TestCase):
@@ -735,6 +831,9 @@ class TestTheMoveDictCarriesTheSpecForTheGUI(unittest.TestCase):
         shape of code where a shared reference eventually bites."""
         src = _via_by_net(self.rig.pcb, 'VF1')
         d = self.by['VF1']
+        # presence FIRST: without it, mutation 1 (drop the key) reports a bare
+        # KeyError traceback here instead of this arm's authored reason.
+        self.assertIn('tenting_attrs', d)
         self.assertEqual(d['tenting_attrs'], src.tenting_attrs)
         self.assertIsNot(d['tenting_attrs'], src.tenting_attrs)
     # MUTATION 5: `dict(getattr(v,'tenting_attrs',{}) or {})` ->
@@ -753,13 +852,24 @@ class TestTheMoveDictCarriesTheSpecForTheGUI(unittest.TestCase):
                           'the contract docstring no longer names %r' % k)
     # MUTATION: rename the key; add a second, differently-spelled one.
 
-    def test_the_value_matches_a_real_parser_Via_field(self):
-        """Built with tests/synth.py's canonical builder rather than a
-        hand-rolled literal, so a change to Via's field shape fails HERE instead
-        of drifting."""
+    def test_a_synth_Via_round_trips_through_the_writer_and_parser(self):
+        """The previous version of this arm asserted
+        `Via(tenting_attrs=X).tenting_attrs == X` -- a value compared to itself
+        through a constructor, which no change to any of the three files under
+        test could break. Replaced with the round trip it was pretending to
+        be: synth Via -> generate_via_sexpr -> _extract_via_protection_attrs.
+        Found by an adversarial review of this file."""
         probe = make_via(0.0, 0.0, net_id=1, size=V_SIZE, drill=V_DRILL,
                          tenting_attrs=dict(TYPE_VII))
-        self.assertEqual(probe.tenting_attrs, TYPE_VII)
+        probe.uuid = 'deadbeef-0000-0000-0000-00000000ffff'
+        text = generate_via_sexpr(probe.x, probe.y, probe.size, probe.drill,
+                                  probe.layers, probe.net_id, net_name='NB1',
+                                  tenting_attrs=probe.tenting_attrs)
+        back = KP._extract_via_protection_attrs(text)
+        self.assertEqual(len(back), 1, text)
+        self.assertEqual(list(back.values())[0], TYPE_VII, text)
+    # MUTATION A: `_one` emits `({token})` and drops the inner text.
+    # MUTATION A2: `parts = parts[:1]` -- emit only the first token.
 
 
 class TestARefusedNudgeLeavesTheBoardTextAlone(unittest.TestCase):
@@ -777,9 +887,12 @@ class TestARefusedNudgeLeavesTheBoardTextAlone(unittest.TestCase):
         self.assertEqual(rig.res['new_segments'], [])
         for net, spec in (('VF1', TYPE_VII), ('VF2', {}), ('VF3', TYPE_VII)):
             self.assertEqual(_via_by_net(rig.pcb, net).tenting_attrs, spec)
-        if rig.wrote:
-            self.assertEqual(_strip_via_blocks(rig.out_text),
-                             _strip_via_blocks(rig.in_text))
+        self.assertTrue(rig.wrote,
+                        'the writer refused, so the text comparison below '
+                        'would silently vanish while the printed-refusal half '
+                        'still looked satisfied')
+        self.assertEqual(_strip_via_blocks(rig.out_text),
+                         _strip_via_blocks(rig.in_text))
     # MUTATION 19: weaken the draw gate so a boxed via moves anyway.
 
     def test_the_NEGATIVE_control_at_the_shipped_clearance_still_moves(self):
@@ -797,6 +910,14 @@ class TestTheShippedCLIPathKeepsTheSpec(unittest.TestCase):
     other copper is name-style, AND via_protection_sexpr goes silent entirely.
     Every in-process arm passes pcb_data itself and cannot see it.
 
+    MEASURED, because my first statement of the mechanism was backwards: the
+    spec is NOT silenced. `via_protection_sexpr`'s `net_name` gate guards only
+    the DEFAULT, so a real spec is still emitted -- next to a numeric net
+    token, which is the shape `extract_vias`' KiCad-9 pattern cannot match, so
+    the via VANISHES from the re-parse. The arm below therefore asserts the via
+    is still THERE before asserting anything about its spec, or the failure
+    arrives as a bare helper assertion instead of this arm's own reason.
+
     Note the CLI's own guard is `if result['placements'] or
     result.get('via_moves') or ...`, and on this rig `placements == []` -- so
     via_moves alone is what triggers the write, which is exactly the path under
@@ -813,6 +934,13 @@ class TestTheShippedCLIPathKeepsTheSpec(unittest.TestCase):
         self.assertIn('via-nudge: moved VF1 via', (r.stdout or '') + (r.stderr or ''))
         run_utils.evidence(dst, 'the CLI output board')
         out = parse_kicad_pcb(dst)
+        self.assertEqual(
+            sorted(out.nets[v.net_id].name for v in out.vias),
+            ['VF1', 'VF2', 'VF3'],
+            'a via is MISSING from the re-parse. The likeliest cause is a via '
+            'emitted with a numeric net token AND a protection spec, which '
+            "extract_vias' KiCad-9 pattern cannot match -- so the barrel is "
+            'gone from the model, not merely its spec.')
         self.assertEqual(_via_by_net(out, 'VF1').tenting_attrs, TYPE_VII)
         self.assertEqual(_via_by_net(out, 'VF2').tenting_attrs, {})
         self.assertEqual(_via_by_net(out, 'VF3').tenting_attrs, TYPE_VII)
@@ -927,17 +1055,27 @@ class TestOneEmitSiteOneSpecArgument(unittest.TestCase):
         """FALSE-POSITIVE PROBE. placement/writer.py's comment block names
         `generate_via_sexpr` and `_remove_vias_at_positions` in prose; the
         stripper must drop them (#737's lesson)."""
-        probe = ["    x = 1  # generate_via_sexpr(a, b) and via_moves.append(",
-                 "    # 'tenting_attrs': dict(getattr(v, 'tenting_attrs', {}))"]
-        stripped = [l.split('#')[0] for l in probe]
+        def _probe():
+            x = 1  # generate_via_sexpr(a, b) and via_moves.append(
+            # 'tenting_attrs': dict(getattr(v, 'tenting_attrs', {}))
+            return x
+
+        # Through the REAL helper. Re-implementing the stripper inline left a
+        # change to _code invisible to its own probe.
+        stripped = _code(_probe)
         self.assertEqual(_calls(stripped, 'generate_via_sexpr'), [])
         self.assertEqual([l for l in stripped if "'tenting_attrs'" in l], [])
 
     def test_the_sentinel_branch_is_tested_before_the_truthiness_branch(self):
-        """The sentinel is truthy, so branch ORDER is what makes it safe. A
-        source guard rather than a fixture, because reordering the branches
-        raises rather than mis-emits, and a crash is not what this file is
-        for."""
+        """A SOURCE guard, and the reason is the opposite of the obvious one.
+        Reordering the two branches does not raise and does not mis-emit: the
+        sentinel is an empty DICT, so it survives the truthiness branch and the
+        token loop and produces the identical file. MEASURED -- with the
+        branches swapped, this arm is the ONLY thing in the suite that fails.
+
+        That is precisely why it exists. The ordering is load-bearing for the
+        NEXT person, who may make the sentinel something that is not a dict;
+        no fixture can see it today."""
         import kicad_writer as KW
         src = _code(KW.via_protection_sexpr)
         ident = [i for i, l in enumerate(src)
@@ -998,7 +1136,7 @@ class TestInertOnTheTrackedCorpus(unittest.TestCase):
         relocates carries a spec the writer would have produced anyway."""
         boards = self._boards()
         self._skip_without_git(boards)
-        full, moved, specs = set(), 0, set()
+        full, moved, specs, blew = set(), 0, set(), []
         for b in boards:
             for clr in (0.25, 0.10):
                 try:
@@ -1008,7 +1146,13 @@ class TestInertOnTheTrackedCorpus(unittest.TestCase):
                             pcb, b, clearance=clr, max_displacement=0.0,
                             max_displacement_cap=0.0, max_passes=1,
                             allow_rotations=False, via_clear_fallback=False)
-                except Exception:
+                except Exception as e:
+                    # COLLECTED, not swallowed. `continue` alone meant an
+                    # engine regression that started raising on 20 of the 22
+                    # boards left both corpus arms green. Measured today: zero.
+                    blew.append('%s @ %s: %s: %s'
+                                % (os.path.basename(b), clr,
+                                   type(e).__name__, e))
                     continue
                 # The two EARLY-RETURN dicts (no BGA / no movable cap) carry no
                 # 'via_moves' key at all, so only a board that ran the whole
@@ -1025,15 +1169,23 @@ class TestInertOnTheTrackedCorpus(unittest.TestCase):
                                   '%s @ %s: the move dict lost the key on a '
                                   'REAL board' % (b, clr))
                     specs.add(tuple(sorted((d['tenting_attrs'] or {}).items())))
+        self.assertEqual(blew, [], 'the pass RAISED on tracked board(s); '
+                                   'that is a finding, not something to skip')
         self.assertGreaterEqual(len(full), 2,
                                 'only %d tracked BOARD(s) ran the full pass '
                                 '(2 measured, over 4 board-clearance pairs); '
                                 'this arm is no longer measuring anything'
                                 % len(full))
-        self.assertGreaterEqual(moved, 9,
-                                'the corpus moved %d vias, down from the 9 '
-                                'measured: the arm below now grades an empty '
-                                'set' % moved)
+        # A FLOOR OF ONE, not of nine. Nine is what the corpus moves today
+        # (orangecrab_ext_pll @ 0.10) and it is disclosed rather than asserted:
+        # pinning it would turn a *tenting* test red for a *geometry* reason
+        # the day a legitimate nudge change relocates eight vias instead.
+        print('corpus disclosure: %d via(s) moved across %d board(s); '
+              'today that is 9 on orangecrab_ext_pll @ 0.10'
+              % (moved, len(full)))
+        self.assertGreaterEqual(moved, 1,
+                                'the corpus moved NO vias, so the spec '
+                                'assertion below grades an empty set')
         self.assertEqual(
             specs, {tuple(sorted(DEFAULT_VIA_TENTING.items()))},
             'a tracked board now MOVES a via whose spec is not the writer '
@@ -1087,54 +1239,98 @@ class TestInertOnTheTrackedCorpus(unittest.TestCase):
         self.assertIn('rp2350_fpga_eensy_prePlane.kicad_pcb', counts, counts)
 
 
-# THE BATTERY, as RUN. The killer per row is named in the trailing
-# `# MUTATION n:` comment beside the arm that kills it.
+# THE BATTERY, as RUN -- every row below was applied to the tree and the file
+# re-run, not reasoned about. 28 mutations, 25 killed, 3 survivors, 0 BROKEN
+# (no mutation made this file die before it checked anything). The killer per
+# row is also named in the trailing `# MUTATION n:` comment beside the arm.
 #
-#    1  drop the move-dict key .................. headline / move-dict / source
-#    2  drop tenting_attrs= at the emit ......... headline / source guard
-#    3  pass None at the emit ................... headline ONLY (the source
-#                                                  guard sees the kwarg)
-#    4  pass {} at the emit .................... headline / move-dict
-#   4b  set the key only when non-empty ......... the present-and-empty arm
-#    5  share the dict instead of copying ....... TestTheDictHoldsACOPY, ALONE
-#    6  drop the `or {}` ...................... DECLARED UNKILLABLE, below
-#    7  copy the spec onto the wrong via ........ headline + spec-less together
-#    8  emit no uuid ........................... headline (the spec vanishes)
-#    9  re-emit the input uuid .................. the uuid arm
-#   10  skip _remove_vias_at_positions .......... via count 3 / whole-file diff
-#   11  drop net_name=nm ....................... the (net "VF2") arm
-#  11b  net-agnostic removal .................... the untouched-control arm
-#   12  drop `or INHERIT_VIA_PROTECTION` ........ spec-less arm / source guard
-#   13  reorder via_protection_sexpr's branches   489-default arms + the
-#                                                  branch-order source arm
-#   14  reorder VIA_PROTECTION_TOKEN_ORDER ...... canonical-order arm (overlaps
-#                                                  test_489; kept as an
-#                                                  end-to-end detector)
-#   15  drop the whitespace collapse ............ the collapse arm (same
-#                                                  overlap)
-#   16  a second emit site under py_placer/ ..... source guard, ALONE
-#   17  rename any guarded identifier ........... the anti-rot arm, ALONE
-#   18  drop pcb_data= in the CLI main .......... the CLI subprocess arm, ALONE
-#   19  weaken the draw gate ................... the refusal arm
-#   20  any geometry change from the fix ........ the exact landings in every
-#                                                  setUp
-#   22  strip the pattern out of plane_io ....... the house-pattern arm
+#    1  drop the move-dict key ......... headline, collapse, move-dict x4, the
+#                                         source arm, the CLI arm, the corpus arm
+#    2  drop tenting_attrs= at the emit  headline, collapse, spec-less, source,
+#                                         anti-rot, CLI
+#    3  pass None at the emit .......... the same six as 2 -- the source arm DOES
+#                                         fire, because it requires the SENTINEL
+#                                         in the argument text, not just the kwarg
+#    4  pass {} at the emit ............ the same six as 2. NOT the move-dict
+#                                         arms: a writer-side mutation cannot
+#                                         reach the engine dict
+#   4b  key only when spec non-empty ... the present-and-empty arm, ALONE
+#    5  share the dict, don't copy ..... TestTheDictHoldsACOPY, ALONE
+#    6  drop the `or {}` .............. SURVIVES -- declared, see below
+#    7  copy the spec to the wrong via . headline + spec-less together
+#    8  emit no uuid .................. headline + the uuid arm
+#   10  skip _remove_vias_at_positions . the uuid/count arm, the whole-file diff,
+#                                         and five more
+#   11  drop net_name=nm ............... the (net "VF2") arm + 5
+#   12  drop `or INHERIT_VIA_PROTECTION` spec-less, source, anti-rot, CLI
+#  12b  pass the sentinel UNCONDITIONALLY  headline, collapse, CLI
+#  13a  truthiness branch above identity  the branch-order SOURCE arm, ALONE --
+#                                         behaviourally inert, which is the
+#                                         point of that arm
+#  13b  sentinel falls through to default  spec-less, both sentinel arms, CLI
+#  13c  make the sentinel FALSY ........ the identity/truthiness arm + the
+#                                         copy/pickle arm
+#   14  reorder VIA_PROTECTION_TOKEN_ORDER  the canonical-order arm + 2
+#   15  drop the whitespace collapse ... the ragged-spec arm (ADDED after a
+#                                         mutation run showed this file AND
+#                                         test_489 both green without it)
+#   16  a second emit site in py_placer/  the source arm, ALONE
+#   17  rename any guarded identifier .. the anti-rot arm, ALONE
+#   18  drop pcb_data= in the CLI main .. the CLI subprocess arm, ALONE
+#   19  weaken the draw gate ........... the refusal arm, ALONE
+#   20  spiral step 0.05 -> 0.1 ........ SURVIVES -- declared, see below
+#    A  _one drops the inner text ...... headline, collapse, both #489 default
+#                                         arms, CLI
+#   A2  emit only the FIRST token ...... headline, collapse, CLI (the VF1-only
+#                                         mutation: VF2 emits nothing either
+#                                         way and every #489 arm has one token)
+#    B  drop the unrecognised-token line  the later-token arm (ADDED; it
+#                                         survived before)
+#    C  change the emitted indentation .. SURVIVES -- declared, see below
+#   22  strip the pattern out of plane_io  the house-pattern arm
 #
-# DECLARED UNKILLABLE, recorded rather than papered over -- #6. `Via
-# .tenting_attrs` is `field(default_factory=dict)` and the pcbnew builder passes
-# `_pcbnew_via_protection_attrs(track)`, which returns `{}` or a dict. NO parse
-# path in this repo produces None, so `dict(getattr(v, 'tenting_attrs', {}))`
-# and `dict(getattr(v, 'tenting_attrs', {}) or {})` are identical everywhere
-# reachable. A killer could be manufactured with a via-like carrying None, but
-# that would assert about a state no caller produces -- the phantom fixture
-# #731 removed from a different report. The `or {}` stays because plane_io.py
-# spells it that way, and one spelling is worth more than one branch.
+# NOT IN THIS FILE, and named so it does not read as uncovered: net-agnostic
+# removal (dropping net_ids=/net_names= at the writer). It leaves this file
+# green -- nothing on the rig is within _remove_vias_at_positions' 2e-3
+# tolerance of a moved via's old position, and a coincident via CANNOT be added
+# to the rig because at 0.15mm it fails the hole-to-hole gate and the nudge
+# then refuses (measured). It is owned by tests/test_via_move_removal_net_name
+# .py, the #344 stacked-via regression, which drives that function directly
+# with a positive and a negative net match.
 #
-# RECORDED AS UNCOVERED, named rather than silently missing: the GUI mirror
-# (fanout_gui.py's nudge block -> gui_utils.apply_via_protection) needs pcbnew,
-# and tests/gui_parity/** is not collected by run_all.py's flat glob.
-# TestTheMoveDictCarriesTheSpecForTheGUI pins the CONTRACT that block reads;
-# the pcbnew half is not exercised here.
+# THE THREE SURVIVORS, recorded rather than papered over. Two FURTHER
+# survivors -- #15 (the whitespace collapse) and #B (the unrecognised-token
+# emit) -- were found by an adversarial review of this file and a mutation run,
+# and are NOT in this list: arms were added to kill them, and both kills are
+# verified. Rows 15 and B name those arms.
+#
+#   #6, drop the `or {}` in dict(getattr(v, 'tenting_attrs', {}) or {}).
+#   Via.tenting_attrs is field(default_factory=dict) and
+#   _pcbnew_via_protection_attrs returns {} or a dict, so NO parse path in this
+#   repo produces None and the two spellings are identical everywhere
+#   reachable. A killer could be manufactured with a via-like carrying None,
+#   but that asserts about a state no caller produces -- the phantom fixture
+#   #731 removed from a different report. The spelling stays because
+#   plane_io.py spells it that way, and one spelling beats one branch.
+#
+#   #20, the spiral quantum (r += 0.05 -> 0.1). The rig's clear spot is at
+#   radius exactly 0.15, which both step sizes reach, and the 0.7 refusal is
+#   unchanged because 0.65 still exceeds max_shift 0.6. So the landings this
+#   file asserts are genuinely identical. On a REAL board a via whose clear
+#   spot is at 0.10 would be pushed to 0.15 -- a geometry change this rig
+#   cannot see. The claim in row 20 is therefore narrowed: the landings catch a
+#   change that MOVES the landing, not every geometry change.
+#
+#   #C, the indentation of the emitted fragment. Semantically the same s-expr;
+#   uncovered in the "records what is pinned" sense only.
+#
+#   Net-agnostic removal is NOT in this list either: see the note above -- it
+#   is owned by tests/test_via_move_removal_net_name.py rather than uncovered.
+#
+# RECORDED AS UNCOVERED: the GUI mirror (fanout_gui.py's nudge block ->
+# gui_utils.apply_via_protection) needs pcbnew, and tests/gui_parity/** is not
+# collected by run_all.py's flat glob. TestTheMoveDictCarriesTheSpecForTheGUI
+# pins the CONTRACT that block reads; the pcbnew half is not exercised here.
 
 
 if __name__ == '__main__':

--- a/tests/test_741_via_nudge_tenting.py
+++ b/tests/test_741_via_nudge_tenting.py
@@ -116,8 +116,8 @@ TWO HAZARDS this file must not fall into, both measured:
     the "nothing else changed" arm diffs `_strip_via_blocks(out)` against
     `_strip_via_blocks(inp)` instead.
 
-THE BATTERY: 31 mutations, RUN rather than reasoned about, with the killer
-named beside each arm and the full table at the bottom of this file. 28 killed,
+THE BATTERY: 32 mutations, RUN rather than reasoned about, with the killer
+named beside each arm and the full table at the bottom of this file. 29 killed,
 THREE declared survivors -- recorded, not papered over. Two further survivors
 were found by an adversarial review of this file and a mutation run, and were
 CLOSED by arms added afterwards rather than declared away. Three arms overlap
@@ -159,7 +159,6 @@ import run_utils                                                # noqa: E402
 import kicad_parser as KP                                       # noqa: E402
 from kicad_parser import parse_kicad_pcb                        # noqa: E402
 from kicad_writer import (DEFAULT_VIA_TENTING,                  # noqa: E402
-                          INHERIT_VIA_PROTECTION,
                           VIA_PROTECTION_TOKEN_ORDER,
                           generate_via_sexpr)
 from placement import fanout_clearance as FC                    # noqa: E402
@@ -598,8 +597,8 @@ class TestASpecLessViaEmitsNothingAndInherits(unittest.TestCase):
         self.assertEqual(_prot_tokens(_via_block(self.rig.out_text, 'VF2')), [],
                          'the re-placed via was stamped with a protection '
                          'token the board never gave it')
-    # MUTATION 12: drop `or INHERIT_VIA_PROTECTION` at writer.py's emit.
-    # MUTATION 13: make the sentinel branch fall through to DEFAULT_VIA_TENTING.
+    # MUTATION 12: drop `inherit_when_unspecified=True` at writer.py's emit.
+    # MUTATION 13: make the inherit branch fall through to the default.
 
     def test_the_KiCad10_name_net_survives_so_this_arm_cannot_pass_wrongly(self):
         """`via_protection_sexpr` goes SILENT, not default, when net_name is
@@ -641,22 +640,40 @@ class TestTheHash489DefaultDidNotMove(unittest.TestCase):
                       generate_via_sexpr(1, 2, 0.6, 0.3, ['F.Cu', 'B.Cu'], 5,
                                          net_name='GND', tenting_attrs={}))
 
-    def test_a_COPY_of_the_sentinel_still_emits_nothing(self):
-        """Identity is not the only path that must be correct. This is the arm
-        that would have failed when the sentinel was a bare object(): a copy
-        fell into the truthiness branch and then raised in the token loop."""
-        import copy
-        import pickle
-        for made, how in ((copy.copy(INHERIT_VIA_PROTECTION), 'copy'),
-                          (pickle.loads(pickle.dumps(INHERIT_VIA_PROTECTION)),
-                           'pickle')):
-            self.assertIsNot(made, INHERIT_VIA_PROTECTION, how)
+    def test_a_COPIED_spec_still_inherits_which_is_why_this_is_a_KEYWORD(self):
+        """WHY THE DECISION IS A KEYWORD AND NOT A SENTINEL VALUE.
+
+        The first version of this fix used a sentinel object passed as
+        `tenting_attrs`. It survived copy, deepcopy and pickle -- and was
+        destroyed by `dict()`, `.copy()` and `{**s}`, all of which turn a
+        dict-shaped sentinel into a plain `{}` that lands straight back on the
+        front+back default. That matters because `dict(...)` is EXACTLY the
+        idiom this repo uses to carry a spec: fanout_clearance.py's move dict
+        and plane_io.py:783 both spell it that way, and CLAUDE.md sends the
+        next author to those very sites.
+
+        A flag carried beside the value cannot be undone by copying the value.
+        Found by a cold review of this branch."""
+        for make, how in ((lambda d: dict(d), 'dict()'),
+                          (lambda d: d.copy(), '.copy()'),
+                          (lambda d: {**d}, '{**d}'),
+                          (lambda d: d, 'verbatim')):
             self.assertEqual(
                 _prot_tokens(generate_via_sexpr(
                     1, 2, 0.6, 0.3, ['F.Cu', 'B.Cu'], 5, net_name='GND',
-                    tenting_attrs=made)), [],
-                'a %s of the sentinel no longer inherits: it either raised or '
-                'fell through to the front+back default' % how)
+                    tenting_attrs=make({}),
+                    inherit_when_unspecified=True)), [],
+                'a spec carried through %s stopped inheriting and fell back to '
+                'the front+back default -- the #741 bug, restored by a copy'
+                % how)
+            self.assertEqual(
+                _prot_tokens(generate_via_sexpr(
+                    1, 2, 0.6, 0.3, ['F.Cu', 'B.Cu'], 5, net_name='GND',
+                    tenting_attrs=make(dict(TYPE_VII)),
+                    inherit_when_unspecified=True)),
+                ['covering', 'plugging', 'capping', 'filling'],
+                'a REAL spec carried through %s was lost' % how)
+    # MUTATION 26: make the flag a sentinel VALUE again -> the dict() arm fires.
 
     def test_a_spec_the_TEXT_parser_never_touched_is_still_collapsed(self):
         """KILLS the whitespace-collapse survivor. `via_protection_sexpr._one`
@@ -703,15 +720,22 @@ class TestTheHash489DefaultDidNotMove(unittest.TestCase):
                          'order, with the unknown one appended after')
     # MUTATION B: delete the `parts += [...]` unrecognised-token line.
 
-    def test_the_sentinel_emits_nothing_and_a_real_spec_still_wins(self):
+    def test_the_flag_emits_nothing_and_a_real_spec_still_wins(self):
         self.assertEqual(
             _prot_tokens(generate_via_sexpr(
                 1, 2, 0.6, 0.3, ['F.Cu', 'B.Cu'], 5, net_name='GND',
-                tenting_attrs=INHERIT_VIA_PROTECTION)), [])
+                inherit_when_unspecified=True)), [])
         self.assertEqual(
             _prot_tokens(generate_via_sexpr(
                 1, 2, 0.6, 0.3, ['F.Cu', 'B.Cu'], 5, net_name='GND',
                 tenting_attrs=dict(TYPE_VII))),
+            ['covering', 'plugging', 'capping', 'filling'])
+        # ...and the flag never OVERRIDES a real spec
+        self.assertEqual(
+            _prot_tokens(generate_via_sexpr(
+                1, 2, 0.6, 0.3, ['F.Cu', 'B.Cu'], 5, net_name='GND',
+                tenting_attrs=dict(TYPE_VII),
+                inherit_when_unspecified=True)),
             ['covering', 'plugging', 'capping', 'filling'])
 
     def test_the_numeric_net_dialect_is_still_silent_either_way(self):
@@ -723,23 +747,19 @@ class TestTheHash489DefaultDidNotMove(unittest.TestCase):
         self.assertEqual(
             _prot_tokens(generate_via_sexpr(
                 1, 2, 0.6, 0.3, ['F.Cu', 'B.Cu'], 5,
-                tenting_attrs=INHERIT_VIA_PROTECTION)), [])
+                inherit_when_unspecified=True)), [])
 
-    def test_the_sentinel_is_compared_by_identity_not_truthiness(self):
-        """The sentinel is TRUTHY, which is what makes it safe rather than
-        what makes it dangerous. `via_protection_sexpr` matches it by identity
-        first -- but identity is fragile (a copy, a pickle, a second import of
-        kicad_writer under a different sys.path root), so the FALLBACK path
-        must be right too. Being an EMPTY dict, it survives the truthiness
-        branch and the token loop and emits nothing: the same answer. A falsy
-        sentinel would instead reach the front+back default, which is the
-        defect. Pin every property that argument rests on."""
-        self.assertTrue(INHERIT_VIA_PROTECTION,
-                        'the sentinel went FALSY: it now falls through to the '
-                        'front+back default, which is the bug')
-        self.assertIsNot(INHERIT_VIA_PROTECTION, {})
-        self.assertIsInstance(INHERIT_VIA_PROTECTION, dict)
-        self.assertEqual(len(INHERIT_VIA_PROTECTION), 0)
+    def test_a_real_spec_always_wins_over_the_flag(self):
+        """Branch ORDER: the spec is tested first, so a caller that sets the
+        flag defensively on every re-placement -- which is what CLAUDE.md now
+        tells them to do -- never loses a real spec by doing so."""
+        for flag in (True, False):
+            self.assertEqual(
+                _prot_tokens(generate_via_sexpr(
+                    1, 2, 0.6, 0.3, ['F.Cu', 'B.Cu'], 5, net_name='GND',
+                    tenting_attrs={'capping': 'yes'},
+                    inherit_when_unspecified=flag)), ['capping'])
+    # MUTATION 27: test inherit_when_unspecified BEFORE the spec.
 
     def test_the_imported_default_is_still_what_489_documented(self):
         """ANTI-ROT: the arms above follow the symbol, so they would keep
@@ -1083,22 +1103,20 @@ class TestOneEmitSiteOneSpecArgument(unittest.TestCase):
             'tenting_attrs= argument, so via_protection_sexpr falls through to '
             'DEFAULT_VIA_TENTING and every nudged via ships tented (#489 s8, '
             '#741).' % bad)
-        # The sentinel is resolved a few lines ABOVE the call now (the net-0
-        # guard needs it before the emit), so look for it in the enclosing
-        # function rather than in the call's argument text -- and require BOTH
-        # uses: the `or` that answers the spec-less case, and the belt that
-        # refuses to pair a numeric net with a spec.
-        uses = [i + 1 for i, l in enumerate(self.writer)
-                if 'INHERIT_VIA_PROTECTION' in l and 'import' not in l]
-        self.assertGreaterEqual(
-            len(uses), 2,
-            'placement/writer.py references INHERIT_VIA_PROTECTION on %d code '
-            'line(s) (%s); expected at least two -- the `or` that answers the '
-            'spec-less case (the second half of #741) and the belt that will '
-            'not pair a numeric net token with a protection spec (the via-loss '
-            'regression that fix introduced).' % (len(uses), uses))
-        nospec = [ln for ln, args in calls if 'tenting_attrs=' not in args]
-        self.assertEqual(nospec, [], nospec)
+        noflag = [ln for ln, args in calls
+                  if 'inherit_when_unspecified' not in args]
+        self.assertEqual(
+            noflag, [],
+            'the emit at line(s) %s passes a spec but not '
+            'inherit_when_unspecified, so a via that carried NO spec is '
+            'stamped with front+back tenting it never had -- the second half '
+            'of #741.' % noflag)
+        # and the net-0 / numeric-dialect guard, which is what stops the same
+        # call turning a via into copper the parser cannot see.
+        self.assertEqual(
+            len([1 for l in self.writer if 'def _net_name(' in l]), 1,
+            'placement/writer.py no longer resolves the net name through one '
+            'helper; the emit and the REMOVAL can now disagree about net 0')
     # MUTATIONS 2, 12, 16.
 
     def test_no_OTHER_file_under_py_placer_emits_a_via(self):
@@ -1154,7 +1172,8 @@ class TestOneEmitSiteOneSpecArgument(unittest.TestCase):
         for token, lines, floor in (
                 ('generate_via_sexpr', self.writer, 2),
                 ('tenting_attrs', self.writer, 1),
-                ('INHERIT_VIA_PROTECTION', self.writer, 2),
+                ('inherit_when_unspecified', self.writer, 1),
+                ('_net_name', self.writer, 3),
                 ('_remove_vias_at_positions', self.writer, 2),
                 ('via_moves', self.nudger, 3),
                 ('tenting_attrs', self.nudger, 1)):
@@ -1180,29 +1199,17 @@ class TestOneEmitSiteOneSpecArgument(unittest.TestCase):
         self.assertEqual(_calls(stripped, 'generate_via_sexpr'), [])
         self.assertEqual([l for l in stripped if "'tenting_attrs'" in l], [])
 
-    def test_the_sentinel_branch_is_tested_before_the_truthiness_branch(self):
-        """A SOURCE guard, and the reason is the opposite of the obvious one.
-        Reordering the two branches does not raise and does not mis-emit: the
-        sentinel is an empty DICT, so it survives the truthiness branch and the
-        token loop and produces the identical file. MEASURED -- with the
-        branches swapped, this arm is the ONLY thing in the suite that fails.
-
-        That is precisely why it exists. The ordering is load-bearing for the
-        NEXT person, who may make the sentinel something that is not a dict;
-        no fixture can see it today."""
+    def test_no_sentinel_VALUE_came_back(self):
+        """The decision must stay a keyword. A sentinel passed as
+        `tenting_attrs` is destroyed by `dict()`, which is the repo's own idiom
+        for carrying a spec -- see the dict()/copy()/{**} arm above."""
         import kicad_writer as KW
-        src = _code(KW.via_protection_sexpr)
-        ident = [i for i, l in enumerate(src)
-                 if 'is INHERIT_VIA_PROTECTION' in l]
-        truthy = [i for i, l in enumerate(src)
-                  if re.search(r'elif\s+tenting_attrs\s*:', l)]
-        self.assertEqual(len(ident), 1, src)
-        self.assertEqual(len(truthy), 1, src)
-        self.assertLess(ident[0], truthy[0],
-                        'the identity test must come FIRST: the sentinel is '
-                        'truthy, so a truthiness branch above it would swallow '
-                        'it and then index it like a dict')
-    # MUTATION 13: reorder the branches.
+        src = '\n'.join(_code(KW))
+        self.assertNotIn('INHERIT_VIA_PROTECTION', src,
+                         'a sentinel VALUE is back in kicad_writer; it cannot '
+                         'survive dict(), which is how this repo copies a spec')
+        self.assertIn('inherit_when_unspecified', src)
+    # MUTATION 26: reintroduce the sentinel.
 
 
 class TestInertOnTheTrackedCorpus(unittest.TestCase):
@@ -1354,7 +1361,7 @@ class TestInertOnTheTrackedCorpus(unittest.TestCase):
 
 
 # THE BATTERY, as RUN -- every row below was applied to the tree and the file
-# re-run, not reasoned about. 31 mutations, 28 killed, 3 survivors, 0 BROKEN
+# re-run, not reasoned about. 32 mutations, 29 killed, 3 survivors, 0 BROKEN
 # (no mutation made this file die before it checked anything). The killer per
 # row is also named in the trailing `# MUTATION n:` comment beside the arm.
 #
@@ -1376,14 +1383,16 @@ class TestInertOnTheTrackedCorpus(unittest.TestCase):
 #   10  skip _remove_vias_at_positions . the uuid/count arm, the whole-file diff,
 #                                         and five more
 #   11  drop net_name=nm ............... the (net "VF2") arm + 5
-#   12  drop `or INHERIT_VIA_PROTECTION` spec-less, source, anti-rot, CLI
+#   12  drop inherit_when_unspecified=True  spec-less, source, anti-rot, CLI
 #  12b  pass the sentinel UNCONDITIONALLY  headline, collapse, CLI
-#  13a  truthiness branch above identity  the branch-order SOURCE arm, ALONE --
-#                                         behaviourally inert, which is the
-#                                         point of that arm
-#  13b  sentinel falls through to default  spec-less, both sentinel arms, CLI
-#  13c  make the sentinel FALSY ........ the identity/truthiness arm + the
-#                                         copy/pickle arm
+#  13b  inherit branch -> the default ... spec-less arm, both flag arms, CLI
+#   26  make the decision a sentinel VALUE  the dict()/copy()/{**} arm and the
+#                                         no-sentinel source arm. This is the
+#                                         design the first draft shipped; a
+#                                         cold review measured that dict() --
+#                                         the repo's OWN idiom for copying a
+#                                         spec -- destroys it
+#   27  test the flag BEFORE the spec ... the real-spec-wins arm
 #   14  reorder VIA_PROTECTION_TOKEN_ORDER  the canonical-order arm + 2
 #   15  drop the whitespace collapse ... the ragged-spec arm (ADDED after a
 #                                         mutation run showed this file AND

--- a/tests/test_741_via_nudge_tenting.py
+++ b/tests/test_741_via_nudge_tenting.py
@@ -1,0 +1,1141 @@
+# -*- coding: utf-8 -*-
+"""#741: a nudged via must keep EXACTLY the protection the board gave it.
+
+THE DEFECT, in one sentence with two halves. The #313 via-nudge relocates a
+REAL, pre-existing via to free a boxed-in decoupling cap: the writer deletes it
+from the board text (`plane_io._remove_vias_at_positions`) and re-emits it
+0.15mm away. A via that comes off the board and goes back on must return with
+the protection the board gave it -- NO MORE and NO LESS. Both halves were
+wrong.
+
+MEASURED on the rig below, at HEAD~1 (the defect) and HEAD (the fix):
+
+    via   input spec                    BEFORE                      AFTER
+    ----  ----------------------------  --------------------------  -----------
+    VF1   covering (front no)(back no)  {'tenting':                 == input,
+          plugging (front no)(back no)   '(front yes) (back yes)'}   token for
+          capping yes / filling yes     -- the WHOLE spec destroyed  token
+    VF2   {} (inherits the board)       {'tenting':                 {}
+                                         '(front yes) (back yes)'}
+                                        -- GAINED a fab attribute
+    VF3   Type VII, never nudged        unchanged                   unchanged
+
+So a via-in-pad needing IPC-4761 Type VII (filled + capped + plated) shipped
+TENTED, silently, from a pass whose stated job is to tidy clearance (half one);
+and a via that had been inheriting the board's `(setup (tenting ...))` came back
+with an explicit token it never carried (half two).
+
+Half two is also a CLI/GUI DIVERGENCE, which is what makes it part of this
+failure mode rather than a separate taste question: `gui_utils
+.apply_via_protection` returns early on an empty spec, because pcbnew's
+`*_MODE_FROM_BOARD` already means inherit. The GUI has never re-stamped such a
+via. Only the text writer did.
+
+THE AUTHORITY here is a RE-PARSE of the file the writer actually produced --
+never the pass's own `via_moves` dict, which is half of the thing being fixed.
+Deliberately NOT check_drc: DRC grades geometry, and a tented via and an
+untented one are geometrically identical, so DRC is blind to this by
+construction. Geometry is pinned separately, by the exact landings in every
+setUp and by the whole-file-minus-via-blocks diff.
+
+WHY THE FIXTURE IS AN AUTHORED BOARD TEXT, and not a tracked board or a
+`synth.make_pcb()`. Three measured reasons, all of which would otherwise make
+this file lie:
+
+  * NO tracked board carries a non-tenting per-via spec. Exactly two carry a
+    per-via spec at all -- orangecrab_ext_pll (136 vias) and
+    rp2350_fpga_eensy_prePlane (70) -- and BOTH carry only
+    `(tenting (front yes) (back yes))`, which is byte-for-byte
+    `kicad_writer.DEFAULT_VIA_TENTING`. On the corpus the defect's output and
+    the correct output are THE SAME STRING. The only Type-VII example in the
+    repo is the inline `REAL_VIA` string in tests/test_489_via_tenting.py,
+    which is not a board.
+  * A `synth.make_pcb()` board CANNOT reproduce the defect at all. It leaves
+    `net_id_to_name` empty, so `placement/writer.py`'s `n2n` is falsy, `nm` is
+    None, and `via_protection_sexpr` returns "" -- nothing is emitted either
+    way. An arm built that way is green today and proves nothing.
+  * The vias MUST carry `(uuid "...")`. `kicad_parser
+    ._extract_via_protection_attrs` keys specs by uuid and `continue`s on a
+    uuid-less via, so the spec would arrive `{}` and every assertion below
+    would pass on `{} == {}`. Every setUp asserts the INPUT spec first.
+
+And the vias use the KiCad-10 `(net "NAME")` dialect deliberately. Measured
+while building this rig, and filed separately: the KiCad-9 NUMERIC via regex in
+`kicad_parser.extract_vias` has strict field ordering, while its v10 twin was
+given a flexible `.*?` gap for exactly these tokens -- so a numeric-net via
+carrying ANY protection token does not merely lose its spec, it VANISHES from
+the model entirely. Zero tracked boards are affected, so it is latent, but this
+file must not be the place it hides.
+
+THE RIG, and every margin it is worth.
+
+    board            60 x 20, four Edge.Cuts lines
+    U1               BGA-9, 3x3 @ 0.8mm, 0.4mm balls, centred (7.6, 10.0)
+                     -> ball-field copper ends at x = 8.6
+    C1               (10.0,  9.5), 0.6mm square pads at local +-0.5
+    C2               (10.0, 10.5), same
+    VF1              (11.175,  9.5) Type-VII spec, uuid 1111...   -> NUDGED
+    VF2              (11.175, 10.5) NO spec,       uuid 2222...   -> NUDGED
+    VF3              (30.0,  10.0) Type-VII spec,  uuid 3333...   -> untouched
+    via size/drill   0.8 / 0.3  ->  copper radius 0.40
+
+  * the offending gap is 0.375 (C1 pad 2's edge at x=10.8 to the via centre)
+    against a keep-out of 0.40 + 0.10 = 0.500: 0.125 INSIDE, so 0.125 of
+    margin. The refusal arm runs the same board at clearance 0.7; measured, the
+    refusal begins between 0.50 and 0.55, so that arm has ~0.15 of margin. Both
+    are outside the 0.05mm fixture rule.
+  * the landing (11.325) clears the keep-out edge (11.300) by 0.025. That is
+    INSIDE the 0.05 rule and it is disclosed rather than hidden: it is the
+    spiral search's own radial quantum (`r += 0.05`), not a fixture choice, and
+    NO assertion measures that clearance. The landings are asserted EXACTLY, so
+    they are change detectors for precisely that number.
+  * C1's pads start at x=9.2 and the ball field ends at x=8.6 -> 0.4 of slack
+    against `near_margin=1.0`. Nothing asserts the near-BGA test; every setUp
+    asserts `sorted(st.caps) == ['C1','C2']` so a change fails loudly instead.
+  * C1 and C2's pad rows are 0.4mm apart. Nothing measures that.
+
+`max_displacement_cap=0.0` is load-bearing: without it the `via_clear_fallback`
+leg searches `_candidate_positions(cap, max_displacement_cap, ...)` -- the CAP
+budget, not the per-cap one -- relocates the cap, and the nudger is never
+called, so every arm here would assert about nothing. `via_clear_fallback=False`
+belts the same brace in-process; the CLI arm cannot pass it and passes
+`--max-displacement-cap 0` instead.
+
+TWO HAZARDS this file must not fall into, both measured:
+
+  * NET IDS ARE NOT STABLE ACROSS THE WRITE. The writer deletes the moved vias
+    and APPENDS them, so the output via order is VF3, VF1, VF2 and the ids are
+    re-synthesised. Every lookup here is by net NAME through
+    `pcb.nets[v.net_id].name` -- never by index, never by uuid.
+  * THE RE-EMITTED VIA GETS A FRESH UUID (`generate_via_sexpr` mints one),
+    which is why CLAUDE.md forbids whole-file diffing a `.kicad_pcb` and why
+    the "nothing else changed" arm diffs `_strip_via_blocks(out)` against
+    `_strip_via_blocks(inp)` instead.
+
+THE BATTERY: 20 mutations, with the killer named beside each arm and the full
+table at the bottom of this file. One is DECLARED UNKILLABLE rather than
+papered over; two overlap tests/test_489_via_tenting.py, which owns those
+values, and are kept only as end-to-end change detectors.
+
+RUNTIME: ~20-30s. One subprocess (the CLI arm), one memoised rig per clearance,
+and the corpus spec arm is a TEXT scan rather than a parse.
+"""
+
+RUN_ALL_FAST_OK = True
+RUN_ALL_TIMEOUT = 900
+
+import contextlib
+import glob
+import inspect
+import io
+import os
+import re
+import sys
+import tempfile
+import unittest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_HERE)
+for _p in ('', 'py_router', 'py_placer', 'py_tools'):
+    _d = os.path.join(_ROOT, _p) if _p else _ROOT
+    if _d not in sys.path:
+        sys.path.insert(0, _d)
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+import run_utils                                                # noqa: E402
+import kicad_parser as KP                                       # noqa: E402
+from kicad_parser import parse_kicad_pcb                        # noqa: E402
+from kicad_writer import (DEFAULT_VIA_TENTING,                  # noqa: E402
+                          INHERIT_VIA_PROTECTION,
+                          VIA_PROTECTION_TOKEN_ORDER,
+                          generate_via_sexpr)
+from placement import fanout_clearance as FC                    # noqa: E402
+from placement.fanout_clearance import repair_fanout_clearance  # noqa: E402
+from placement.writer import write_placed_output                # noqa: E402
+from synth import make_via                                      # noqa: E402
+
+# --------------------------------------------------------------------- the rig
+
+CLEAR = 0.1          # the value place_fanout_clearance.py's own help example uses
+CLEAR_BOXED = 0.7    # the refusal arm; measured, refusal begins between .50/.55
+V_SIZE, V_DRILL = 0.8, 0.3
+VR = V_SIZE / 2.0                    # 0.40 copper radius
+VIA_KEEPOUT = VR + CLEAR             # 0.50, what valid_via_pos needs
+PAD_HALF = 0.3                       # 0.6mm square cap pads at local +-0.5
+
+BGA_XY = (7.6, 10.0)
+CAP1_XY = (10.0, 9.5)
+CAP2_XY = (10.0, 10.5)
+VIA_X = 11.175                       # gap 0.375 to pad 2's edge (10.8)
+CTRL_XY = (30.0, 10.0)
+LAND_VF1 = (11.325, 9.5)             # MEASURED
+LAND_VF2 = (11.325, 10.5)            # MEASURED
+
+UUID_VF1 = '11111111-1111-1111-1111-111111111111'
+UUID_VF2 = '22222222-2222-2222-2222-222222222222'
+UUID_VF3 = '33333333-3333-3333-3333-333333333333'
+
+# MULTI-LINE on purpose: that is the shape real KiCad writes (see the hackrf
+# block in tests/test_489_via_tenting.py), so it exercises
+# _balanced_token_text's whitespace collapse on the way IN and
+# via_protection_sexpr's on the way OUT.
+TYPE_VII_TEXT = (
+    '\t\t(covering\n\t\t\t(front no)\n\t\t\t(back no)\n\t\t)\n'
+    '\t\t(plugging\n\t\t\t(front no)\n\t\t\t(back no)\n\t\t)\n'
+    '\t\t(capping yes)\n'
+    '\t\t(filling yes)')
+
+# ...and this is what the PARSER yields from it (it normalises whitespace
+# itself), so input and output specs compare with a plain ==.
+TYPE_VII = {'covering': '(front no) (back no)',
+            'plugging': '(front no) (back no)',
+            'capping': 'yes',
+            'filling': 'yes'}
+
+_LAYERS = '\n'.join([
+    '\t(layers',
+    '\t\t(0 "F.Cu" signal)',
+    '\t\t(2 "B.Cu" signal)',
+    '\t\t(9 "F.Adhes" user "F.Adhesive")',
+    '\t\t(11 "F.Paste" user)',
+    '\t\t(13 "F.SilkS" user "F.Silkscreen")',
+    '\t\t(15 "F.Mask" user)',
+    '\t\t(17 "B.Mask" user)',
+    '\t\t(44 "Edge.Cuts" user)',
+    '\t\t(46 "F.CrtYd" user "F.Courtyard")',
+    '\t\t(49 "F.Fab" user)',
+    '\t)'])
+
+
+def _edge(x1, y1, x2, y2, uu):
+    return ('\t(gr_line\n\t\t(start %s %s)\n\t\t(end %s %s)\n'
+            '\t\t(stroke (width 0.05) (type solid))\n'
+            '\t\t(layer "Edge.Cuts")\n\t\t(uuid "%s")\n\t)'
+            % (x1, y1, x2, y2, uu))
+
+
+def _pad(num, lx, ly, w, h, net_id, net_name, shape='rect'):
+    return ('\t\t(pad "%s" smd %s\n\t\t\t(at %s %s)\n\t\t\t(size %s %s)\n'
+            '\t\t\t(layers "F.Cu" "F.Paste" "F.Mask")\n'
+            '\t\t\t(net %d "%s")\n\t\t)'
+            % (num, shape, lx, ly, w, h, net_id, net_name))
+
+
+def _cap(ref, x, y, na, nb, ia, ib, uu):
+    # No F.CrtYd polygon: extract_courtyard_bboxes then returns {} and every cap
+    # falls back to its pad bbox -- the same regime test_736's one-line _stub()
+    # produces, so the two files' rigs are comparable.
+    return '\n'.join([
+        '\t(footprint "Capacitor_SMD:C_0402_1005Metric"',
+        '\t\t(layer "F.Cu")',
+        '\t\t(uuid "%s")' % uu,
+        '\t\t(at %s %s)' % (x, y),
+        '\t\t(property "Reference" "%s" (at 0 -1 0) (layer "F.SilkS")'
+        ' (uuid "%s-r") (effects (font (size 0.5 0.5) (thickness 0.1))))'
+        % (ref, uu),
+        _pad('1', -0.5, 0, 0.6, 0.6, ia, na),
+        _pad('2', 0.5, 0, 0.6, 0.6, ib, nb),
+        '\t)'])
+
+
+def _bga(ref, x, y, uu):
+    # Named BGA-* so detect_package_type returns 'BGA' by NAME, which is what
+    # puts it in st.bga_refs and makes C1/C2 "movable near-BGA caps" at all.
+    rows, n = [], 10
+    for i in range(3):
+        for j in range(3):
+            rows.append(_pad('%s%d' % ('ABC'[i], j + 1),
+                             (j - 1) * 0.8, (i - 1) * 0.8, 0.4, 0.4,
+                             n, 'BALL%d' % n, shape='circle'))
+            n += 1
+    return '\n'.join([
+        '\t(footprint "Package_BGA:BGA-9_1.4x1.4mm_Layout3x3_P0.8mm"',
+        '\t\t(layer "F.Cu")',
+        '\t\t(uuid "%s")' % uu,
+        '\t\t(at %s %s)' % (x, y),
+        '\t\t(property "Reference" "%s" (at 0 -1.5 0) (layer "F.SilkS")'
+        ' (uuid "%s-r") (effects (font (size 0.5 0.5) (thickness 0.1))))'
+        % (ref, uu),
+    ] + rows + ['\t)'])
+
+
+def _via(x, y, net, uu, spec=''):
+    s = ('\n' + spec) if spec else ''
+    return ('\t(via\n\t\t(at %s %s)\n\t\t(size %s)\n\t\t(drill %s)\n'
+            '\t\t(layers "F.Cu" "B.Cu")%s\n\t\t(net "%s")\n\t\t(uuid "%s")\n\t)'
+            % (x, y, V_SIZE, V_DRILL, s, net, uu))
+
+
+def _board_text():
+    return '\n'.join([
+        '(kicad_pcb',
+        '\t(version 20240108)',
+        '\t(generator "pcbnew")',
+        '\t(generator_version "8.0")',
+        '\t(general\n\t\t(thickness 1.6)\n\t)',
+        '\t(paper "A4")',
+        _LAYERS,
+        # NO board-level (tenting ...) default on purpose: the defect is about
+        # the PER-VIA spec, and a board default would hand a reader a second
+        # explanation for the same output.
+        '\t(setup\n\t\t(pad_to_mask_clearance 0)\n\t)',
+        '\t(net 0 "")',
+        '\t(net 1 "NA1")',
+        '\t(net 2 "NB1")',
+        '\t(net 3 "NA2")',
+        '\t(net 4 "NB2")',
+        # VF1/VF2/VF3 are FOREIGN to every cap pad -- graze_penalty only counts
+        # foreign copper, so a via sharing a cap pad's net is not an offender
+        # and the nudger is never reached.
+        '\t(net 5 "VF1")',
+        '\t(net 6 "VF2")',
+        '\t(net 7 "VF3")',
+    ] + ['\t(net %d "BALL%d")' % (n, n) for n in range(10, 19)] + [
+        _edge(0, 0, 60, 0, 'e1'), _edge(60, 0, 60, 20, 'e2'),
+        _edge(60, 20, 0, 20, 'e3'), _edge(0, 20, 0, 0, 'e4'),
+        _bga('U1', BGA_XY[0], BGA_XY[1], 'aaaaaaaa-0000-0000-0000-00000000u001'),
+        _cap('C1', CAP1_XY[0], CAP1_XY[1], 'NA1', 'NB1', 1, 2,
+             'cccccccc-0000-0000-0000-0000000000c1'),
+        _cap('C2', CAP2_XY[0], CAP2_XY[1], 'NA2', 'NB2', 3, 4,
+             'cccccccc-0000-0000-0000-0000000000c2'),
+        _via(VIA_X, 9.5, 'VF1', UUID_VF1, TYPE_VII_TEXT),
+        _via(VIA_X, 10.5, 'VF2', UUID_VF2),
+        _via(CTRL_XY[0], CTRL_XY[1], 'VF3', UUID_VF3, TYPE_VII_TEXT),
+        ')'])
+
+
+RIG_BOARD = _board_text()
+
+# --------------------------------------------------------------------- helpers
+
+_TD = None
+_RIGS = {}
+
+
+def setUpModule():
+    global _TD, _RIGS
+    _TD, _RIGS = tempfile.TemporaryDirectory(), {}
+
+
+def tearDownModule():
+    _TD.cleanup()
+
+
+class _Rig(object):
+    pass
+
+
+def _stage(subdir):
+    d = os.path.join(_TD.name, subdir)
+    os.makedirs(d, exist_ok=True)
+    src = os.path.join(d, 'rig.kicad_pcb')
+    with io.open(src, 'w', encoding='utf-8', newline='') as f:
+        f.write(RIG_BOARD)
+    # A check whose INPUT is missing tests nothing (CLAUDE.md / run_utils).
+    run_utils.evidence(src, 'the authored #741 rig board')
+    return d, src
+
+
+def _rig(clearance=CLEAR):
+    """Stage RIG_BOARD, run the REAL pass, write through the REAL writer,
+    re-parse. Memoised per clearance: it is well under a second, but every
+    class wants it and re-running would make the numbers look run-dependent."""
+    if clearance in _RIGS:
+        return _RIGS[clearance]
+    d, src = _stage('c%g' % clearance)
+    pcb = parse_kicad_pcb(src)
+    seen, buf = [], io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        res = repair_fanout_clearance(
+            pcb, src, clearance=clearance, cap_prefix='C',
+            max_displacement=0.0, max_displacement_cap=0.0, max_passes=1,
+            allow_rotations=False, via_clear_fallback=False,
+            on_move=lambda st: seen.append(st))
+    dst = os.path.join(d, 'out.kicad_pcb')
+    wrote = write_placed_output(src, dst, res['placements'],
+                                via_moves=res.get('via_moves'),
+                                new_segments=res.get('new_segments'),
+                                pcb_data=pcb)
+    r = _Rig()
+    r.src, r.dst, r.pcb, r.res, r.wrote = src, dst, pcb, res, wrote
+    r.st = seen[0] if seen else None
+    r.out = buf.getvalue()
+    r.in_text = RIG_BOARD
+    if wrote:
+        with io.open(dst, encoding='utf-8') as f:
+            r.out_text = f.read()
+    else:
+        r.out_text = None
+    r.out_pcb = (parse_kicad_pcb(dst) if wrote else None)
+    _RIGS[clearance] = r
+    return r
+
+
+def _via_by_net(pcb, name):
+    """Identity is by NET NAME. Never by index (the writer reorders) and never
+    by uuid (the re-emitted via gets a fresh one)."""
+    hits = [v for v in pcb.vias
+            if v.net_id in pcb.nets and pcb.nets[v.net_id].name == name]
+    assert len(hits) == 1, '%d vias on net %r, expected exactly 1' % (
+        len(hits), name)
+    return hits[0]
+
+
+def _via_blocks(text):
+    """[(text, net_name_or_None)] for every balanced `(via ...)` block."""
+    out = []
+    for m in re.finditer(r'\(via(?=[\s(])', text):
+        depth = 0
+        for i, c in enumerate(text[m.start():]):
+            if c == '(':
+                depth += 1
+            elif c == ')':
+                depth -= 1
+                if depth == 0:
+                    blk = text[m.start():m.start() + i + 1]
+                    nm = re.search(r'\(net\s+"([^"]*)"\)', blk)
+                    out.append((blk, nm.group(1) if nm else None))
+                    break
+    return out
+
+
+def _via_block(text, net_name):
+    hits = [b for b, n in _via_blocks(text) if n == net_name]
+    assert len(hits) == 1, '%d via blocks for %r' % (len(hits), net_name)
+    return hits[0]
+
+
+def _strip_via_blocks(text):
+    for blk, _ in _via_blocks(text):
+        text = text.replace(blk, '')
+    return text
+
+
+def _read(path):
+    with io.open(path, encoding='utf-8', errors='replace') as f:
+        return f.read()
+
+
+def _prot_tokens(block):
+    """The protection tokens present in one raw `(via ...)` block, in order."""
+    return [m.group(1) for m in re.finditer(
+        r'\((tenting|covering|plugging|capping|filling)[\s)]', block)]
+
+
+def _code(obj):
+    """Source lines with trailing comments stripped, line numbering preserved.
+    placement/writer.py's comment block names `generate_via_sexpr` in prose;
+    reading raw lines would let a comment arm or disarm every guard below."""
+    return [l.split('#')[0] for l in inspect.getsource(obj).splitlines()]
+
+
+def _calls(lines, name):
+    """[(line, argument text)] per `name(...)` call. writer.py's call is
+    MULTI-LINE, so a line-wise `in` test cannot see its argument list."""
+    text, out = '\n'.join(lines), []
+    for m in re.finditer(re.escape(name) + r'\s*\(', text):
+        i = text.index('(', m.start() + len(name))
+        depth = 0
+        for j in range(i, len(text)):
+            if text[j] == '(':
+                depth += 1
+            elif text[j] == ')':
+                depth -= 1
+                if depth == 0:
+                    out.append((text.count('\n', 0, m.start()) + 1,
+                                text[i + 1:j]))
+                    break
+    return out
+
+
+# -------------------------------------------------------------------- the arms
+
+class TestATypeVIIViaSurvivesTheNudge(unittest.TestCase):
+    """THE HEADLINE. A via carrying IPC-4761 Type VII -- filled + capped +
+    plated, and deliberately NOT tented -- is nudged 0.15mm to tidy C1's
+    clearance, and came back TENTED with its whole spec gone.
+
+    MEASURED at HEAD~1: {'tenting': '(front yes) (back yes)'} in place of the
+    four tokens the board carried."""
+
+    def setUp(self):
+        self.rig = _rig(CLEAR)
+        out = self.rig.out
+        # PRINTED OUTPUT FIRST (#732's lesson): a pass that never looked prints
+        # nothing, and is otherwise indistinguishable from one that looked and
+        # agreed.
+        self.assertIn('via-nudge: moved VF1 via (11.175,9.500) -> '
+                      '(11.325,9.500) to free C1', out)
+        self.assertEqual(sorted(self.rig.st.caps), ['C1', 'C2'],
+                         'the cap set changed: cap_prefix or the near-BGA test '
+                         'moved, and this rig no longer proves what it says')
+        self.assertEqual(len(self.rig.res['via_moves']), 2, out)
+        self.assertEqual(self.rig.res['new_segments'], [],
+                         'a connector appeared: conn_layers is no longer empty, '
+                         'so this rig now also exercises #736 and its margins '
+                         'have to be re-derived')
+        self.assertTrue(self.rig.wrote, 'the writer refused; nothing to grade')
+        # VACUITY GUARD: the INPUT really carries a spec. Without the uuid,
+        # _extract_via_protection_attrs skips the via and every assertion below
+        # would pass on {} == {}.
+        src = _via_by_net(self.rig.pcb, 'VF1')
+        self.assertEqual(src.tenting_attrs, TYPE_VII)
+        self.assertNotIn('tenting', src.tenting_attrs)
+
+    def test_the_reparsed_output_via_keeps_its_spec_token_for_token(self):
+        v = _via_by_net(self.rig.out_pcb, 'VF1')
+        self.assertEqual((round(v.x, 4), round(v.y, 4)), LAND_VF1,
+                         'the via did not land where it lands today -- assert '
+                         'the geometry before asserting about the spec')
+        self.assertEqual(
+            v.tenting_attrs, TYPE_VII,
+            'the nudge re-stamped the via: a via-in-pad needing IPC-4761 Type '
+            'VII shipped with a different fab spec after a move whose stated '
+            'job was to tidy clearance')
+        self.assertNotIn('tenting', v.tenting_attrs)
+    # MUTATION 1: drop the 'tenting_attrs' key from the move dict.
+    # MUTATION 2: drop `tenting_attrs=` at writer.py's emit.
+    # MUTATION 3: pass None there.  MUTATION 4: pass {} there.
+
+    def test_the_emitted_block_collapses_the_spec_and_orders_it_canonically(self):
+        """`via_protection_sexpr` collapses the parsed inner text onto one line
+        and emits VIA_PROTECTION_TOKEN_ORDER. Asserted from RAW TEXT, because
+        the parser normalises whitespace on the way back in and a re-parse can
+        see neither.
+
+        OVERLAP, recorded rather than hidden: tests/test_489_via_tenting.py
+        owns both contracts at the generate_via_sexpr UNIT level and kills both
+        mutations too. This arm is the END-TO-END change detector -- the only
+        one that would catch py_placer growing an emitter of its own."""
+        blk = _via_block(self.rig.out_text, 'VF1')
+        self.assertNotIn('(tenting', blk, blk)
+        self.assertIn('(covering (front no) (back no))', blk, blk)
+        self.assertIn('(plugging (front no) (back no))', blk, blk)
+        self.assertEqual(_prot_tokens(blk),
+                         ['covering', 'plugging', 'capping', 'filling'], blk)
+    # MUTATION 14: reorder VIA_PROTECTION_TOKEN_ORDER.
+    # MUTATION 15: drop the `" ".join(inner.split())` collapse.
+
+    def test_the_output_has_a_fresh_uuid_and_still_only_three_vias(self):
+        """Two failure modes that would make the headline lie in OPPOSITE
+        directions: a re-emitted via with no uuid loses its spec at the next
+        parse, and a removal that missed leaves a STACKED duplicate -- one
+        tented, one not -- which no DRC will ever flag."""
+        self.assertEqual(len(self.rig.out_pcb.vias), 3,
+                         'the moved via was appended without removing the '
+                         'original: a stacked same-net barrel pair')
+        got = re.search(r'\(uuid "([^"]+)"\)',
+                        _via_block(self.rig.out_text, 'VF1')).group(1)
+        self.assertTrue(got)
+        self.assertNotEqual(got, UUID_VF1,
+                            'the re-emitted via reuses the input uuid; two '
+                            'elements now claim one identity')
+    # MUTATION 8: drop the (uuid ...) line from generate_via_sexpr.
+    # MUTATION 9: re-emit the uuid unchanged.
+    # MUTATION 10: skip the _remove_vias_at_positions call.
+
+    def test_NOTHING_outside_the_rewritten_via_blocks_changed(self):
+        """CLAUDE.md forbids whole-file diffing a .kicad_pcb because outputs
+        carry per-run uuids. Scoped so it is legitimate: the via blocks are the
+        only place a fresh uuid appears here, and they are compared field for
+        field by the other arms."""
+        self.assertEqual(_strip_via_blocks(self.rig.out_text),
+                         _strip_via_blocks(self.rig.in_text))
+    # MUTATION: none (control). The whole-file statement that this fix changes
+    # no geometry and nothing else.
+
+
+class TestASpecLessViaEmitsNothingAndInherits(unittest.TestCase):
+    """The OTHER half, and the one that is a CLI/GUI divergence rather than a
+    lost attribute. VF2 is nudged on the same board, the same distance, in the
+    same pass -- and says nothing about protection, because it inherits the
+    board's `(setup (tenting ...))`.
+
+    MEASURED at HEAD~1: it came back carrying an explicit
+    {'tenting': '(front yes) (back yes)'} it never had. The GUI twin has never
+    done that -- gui_utils.apply_via_protection returns early on an empty spec
+    because pcbnew's *_MODE_FROM_BOARD already means inherit."""
+
+    def setUp(self):
+        self.rig = _rig(CLEAR)
+        self.assertIn('via-nudge: moved VF2 via (11.175,10.500) -> '
+                      '(11.325,10.500) to free C2', self.rig.out)
+        self.assertTrue(self.rig.wrote)
+        self.assertEqual(_via_by_net(self.rig.pcb, 'VF2').tenting_attrs, {},
+                         'the INPUT via gained a spec; this is no longer the '
+                         'spec-less case')
+
+    def test_a_via_that_inherited_still_inherits(self):
+        v = _via_by_net(self.rig.out_pcb, 'VF2')
+        self.assertEqual((round(v.x, 4), round(v.y, 4)), LAND_VF2)
+        self.assertEqual(v.tenting_attrs, {})
+        self.assertEqual(_prot_tokens(_via_block(self.rig.out_text, 'VF2')), [],
+                         'the re-placed via was stamped with a protection '
+                         'token the board never gave it')
+    # MUTATION 12: drop `or INHERIT_VIA_PROTECTION` at writer.py's emit.
+    # MUTATION 13: make the sentinel branch fall through to DEFAULT_VIA_TENTING.
+
+    def test_the_KiCad10_name_net_survives_so_this_arm_cannot_pass_wrongly(self):
+        """`via_protection_sexpr` goes SILENT, not default, when net_name is
+        None. Without this line the arm above would pass for entirely the wrong
+        reason on a via that had lost its net."""
+        self.assertIn('(net "VF2")', _via_block(self.rig.out_text, 'VF2'))
+    # MUTATION 11: drop `net_name=nm` at writer.py's emit.
+
+    def test_the_engine_dict_says_present_and_empty_not_absent(self):
+        """Absent and empty are different facts for a caller that distinguishes
+        'inherit' from 'nothing to say' -- which is the whole content of this
+        fix."""
+        by = {self.rig.pcb.nets[d['net_id']].name: d
+              for _x, _y, d in self.rig.res['via_moves']}
+        self.assertIn('tenting_attrs', by['VF2'])
+        self.assertEqual(by['VF2']['tenting_attrs'], {})
+    # MUTATION 4b: set the key only when the source spec is non-empty.
+
+
+class TestTheHash489DefaultDidNotMove(unittest.TestCase):
+    """The sentinel is OPT-IN, and this is what that buys: a caller with no
+    opinion still gets the #489-documented default, so nothing outside the
+    via-nudge changed behaviour.
+
+    tests/test_489_via_tenting.py OWNS these values; this file owns only the
+    fact that the new third state did not leak into them."""
+
+    def test_no_tenting_attrs_still_means_front_plus_back_on_KiCad10(self):
+        v10 = generate_via_sexpr(1, 2, 0.6, 0.3, ['F.Cu', 'B.Cu'], 5,
+                                 net_name='GND')
+        self.assertIn('(tenting (front yes) (back yes))', v10)
+    # MUTATION 13: reorder via_protection_sexpr's branches so the sentinel or
+    # an empty dict reaches the default arm.
+
+    def test_an_empty_dict_is_still_the_default_not_the_sentinel(self):
+        """`{}` from a caller is NOT the sentinel. Only the sentinel means
+        'inherit'; the fix must not have collapsed the two."""
+        self.assertIn('(tenting (front yes) (back yes))',
+                      generate_via_sexpr(1, 2, 0.6, 0.3, ['F.Cu', 'B.Cu'], 5,
+                                         net_name='GND', tenting_attrs={}))
+
+    def test_a_COPY_of_the_sentinel_still_emits_nothing(self):
+        """Identity is not the only path that must be correct. This is the arm
+        that would have failed when the sentinel was a bare object(): a copy
+        fell into the truthiness branch and then raised in the token loop."""
+        import copy
+        import pickle
+        for made, how in ((copy.copy(INHERIT_VIA_PROTECTION), 'copy'),
+                          (pickle.loads(pickle.dumps(INHERIT_VIA_PROTECTION)),
+                           'pickle')):
+            self.assertIsNot(made, INHERIT_VIA_PROTECTION, how)
+            self.assertEqual(
+                _prot_tokens(generate_via_sexpr(
+                    1, 2, 0.6, 0.3, ['F.Cu', 'B.Cu'], 5, net_name='GND',
+                    tenting_attrs=made)), [],
+                'a %s of the sentinel no longer inherits: it either raised or '
+                'fell through to the front+back default' % how)
+
+    def test_the_sentinel_emits_nothing_and_a_real_spec_still_wins(self):
+        self.assertEqual(
+            _prot_tokens(generate_via_sexpr(
+                1, 2, 0.6, 0.3, ['F.Cu', 'B.Cu'], 5, net_name='GND',
+                tenting_attrs=INHERIT_VIA_PROTECTION)), [])
+        self.assertEqual(
+            _prot_tokens(generate_via_sexpr(
+                1, 2, 0.6, 0.3, ['F.Cu', 'B.Cu'], 5, net_name='GND',
+                tenting_attrs=dict(TYPE_VII))),
+            ['covering', 'plugging', 'capping', 'filling'])
+
+    def test_the_numeric_net_dialect_is_still_silent_either_way(self):
+        """#489 pins that a KiCad-9 numeric-net via emits no protection at all.
+        The sentinel must not have turned that into a default."""
+        self.assertEqual(
+            _prot_tokens(generate_via_sexpr(1, 2, 0.6, 0.3,
+                                            ['F.Cu', 'B.Cu'], 5)), [])
+        self.assertEqual(
+            _prot_tokens(generate_via_sexpr(
+                1, 2, 0.6, 0.3, ['F.Cu', 'B.Cu'], 5,
+                tenting_attrs=INHERIT_VIA_PROTECTION)), [])
+
+    def test_the_sentinel_is_compared_by_identity_not_truthiness(self):
+        """The sentinel is TRUTHY, which is what makes it safe rather than
+        what makes it dangerous. `via_protection_sexpr` matches it by identity
+        first -- but identity is fragile (a copy, a pickle, a second import of
+        kicad_writer under a different sys.path root), so the FALLBACK path
+        must be right too. Being an EMPTY dict, it survives the truthiness
+        branch and the token loop and emits nothing: the same answer. A falsy
+        sentinel would instead reach the front+back default, which is the
+        defect. Pin every property that argument rests on."""
+        self.assertTrue(INHERIT_VIA_PROTECTION,
+                        'the sentinel went FALSY: it now falls through to the '
+                        'front+back default, which is the bug')
+        self.assertIsNot(INHERIT_VIA_PROTECTION, {})
+        self.assertIsInstance(INHERIT_VIA_PROTECTION, dict)
+        self.assertEqual(len(INHERIT_VIA_PROTECTION), 0)
+
+    def test_the_imported_default_is_still_what_489_documented(self):
+        """ANTI-ROT: the arms above follow the symbol, so they would keep
+        passing if the value changed. This makes that change VISIBLE here
+        instead of silent."""
+        self.assertEqual(DEFAULT_VIA_TENTING,
+                         {'tenting': '(front yes) (back yes)'},
+                         'DEFAULT_VIA_TENTING changed. test_489_via_tenting.py '
+                         'owns this value; re-read #489 s8 and re-measure this '
+                         'file before touching it.')
+        self.assertEqual(VIA_PROTECTION_TOKEN_ORDER,
+                         ('tenting', 'covering', 'plugging', 'capping',
+                          'filling'))
+
+
+class TestAViaTheNudgeNeverTouchedIsUnchanged(unittest.TestCase):
+    """VF3 sits 18mm away and is nobody's offender."""
+
+    def test_the_control_vias_block_is_BYTE_identical(self):
+        rig = _rig(CLEAR)
+        self.assertEqual(_via_block(rig.out_text, 'VF3'),
+                         _via_block(rig.in_text, 'VF3'),
+                         'a via nobody moved was rewritten -- including its '
+                         'uuid, which no consumer can follow across that')
+        v = _via_by_net(rig.out_pcb, 'VF3')
+        self.assertEqual(v.tenting_attrs, TYPE_VII)
+        self.assertEqual((round(v.x, 4), round(v.y, 4)), CTRL_XY)
+    # MUTATION 11b: net-agnostic removal in _remove_vias_at_positions.
+    # MUTATION: a writer that re-emits every via instead of the moved ones.
+
+
+class TestTheMoveDictCarriesTheSpecForTheGUI(unittest.TestCase):
+    """kicad_routing_plugin/fanout_gui.py already reads `vd.get('tenting_attrs')`
+    off this dict -- written for #489 s8 and DEAD since, because the engine
+    never put the key there.
+
+    Asserted at the ENGINE and not through the GUI on purpose. In the GUI,
+    `pcb_data.vias[i].tenting_attrs` is itself built by
+    `_pcbnew_via_protection_attrs(track)`, which is the SAME call the GUI's own
+    fallback makes -- so the fallback re-derives an identical value and would
+    MASK an engine revert. The GUI cannot be its own regression detector here."""
+
+    def setUp(self):
+        self.rig = _rig(CLEAR)
+        self.assertIn('via-nudge: moved', self.rig.out)
+        self.assertEqual(len(self.rig.res['via_moves']), 2, self.rig.out)
+        self.by = {self.rig.pcb.nets[d['net_id']].name: d
+                   for _x, _y, d in self.rig.res['via_moves']}
+        self.assertEqual(sorted(self.by), ['VF1', 'VF2'])
+
+    def test_the_dict_carries_the_key_with_the_SOURCE_vias_spec(self):
+        self.assertIn('tenting_attrs', self.by['VF1'],
+                      "the GUI's read is still dead: it re-tents every via it "
+                      "nudges, and the CLI half of the fix hides that")
+        self.assertEqual(self.by['VF1']['tenting_attrs'], TYPE_VII)
+    # MUTATION 1: delete the dict key.
+
+    def test_the_dict_holds_a_COPY_not_the_live_Vias_attribute(self):
+        """The ONLY killer for `dict(getattr(...))` -> `getattr(...)`, and it
+        exists for that alone. Nothing in the shipped path mutates the spec, so
+        the mutation is invisible to every other arm -- while the via itself IS
+        mutated a few lines earlier (`v.x, v.y = nx, ny`), which is exactly the
+        shape of code where a shared reference eventually bites."""
+        src = _via_by_net(self.rig.pcb, 'VF1')
+        d = self.by['VF1']
+        self.assertEqual(d['tenting_attrs'], src.tenting_attrs)
+        self.assertIsNot(d['tenting_attrs'], src.tenting_attrs)
+    # MUTATION 5: `dict(getattr(v,'tenting_attrs',{}) or {})` ->
+    #             `getattr(v,'tenting_attrs',{})`.
+
+    def test_the_key_set_is_exactly_what_the_contract_docstring_says(self):
+        """Two consumers index this dict (placement/writer.py and the plugin's
+        pcbnew mirror) and #741 IS a key that went unnamed, so the shape is
+        pinned here and spelled in the docstring."""
+        self.assertEqual(set(self.by['VF1']),
+                         {'x', 'y', 'size', 'drill', 'layers', 'net_id',
+                          'tenting_attrs'})
+        doc = inspect.getdoc(FC.nudge_vias_for_unresolved) or ''
+        for k in ('tenting_attrs', 'net_id', 'layers'):
+            self.assertIn(k, doc,
+                          'the contract docstring no longer names %r' % k)
+    # MUTATION: rename the key; add a second, differently-spelled one.
+
+    def test_the_value_matches_a_real_parser_Via_field(self):
+        """Built with tests/synth.py's canonical builder rather than a
+        hand-rolled literal, so a change to Via's field shape fails HERE instead
+        of drifting."""
+        probe = make_via(0.0, 0.0, net_id=1, size=V_SIZE, drill=V_DRILL,
+                         tenting_attrs=dict(TYPE_VII))
+        self.assertEqual(probe.tenting_attrs, TYPE_VII)
+
+
+class TestARefusedNudgeLeavesTheBoardTextAlone(unittest.TestCase):
+    """The same board at clearance 0.7, where no clear spot exists inside the
+    0.6mm search. This licenses the framing: a via's spec is only ever at risk
+    when the via is actually re-emitted."""
+
+    def test_a_boxed_via_is_REFUSED_and_every_spec_is_untouched(self):
+        rig = _rig(CLEAR_BOXED)
+        # the PRINTED refusal FIRST -- a refusal that prints nothing is
+        # indistinguishable from a pass that never looked.
+        self.assertIn("via-nudge: no clear spot for C1's offending via "
+                      "at (11.18, 9.50) within 0.6mm", rig.out)
+        self.assertEqual(rig.res['via_moves'], [])
+        self.assertEqual(rig.res['new_segments'], [])
+        for net, spec in (('VF1', TYPE_VII), ('VF2', {}), ('VF3', TYPE_VII)):
+            self.assertEqual(_via_by_net(rig.pcb, net).tenting_attrs, spec)
+        if rig.wrote:
+            self.assertEqual(_strip_via_blocks(rig.out_text),
+                             _strip_via_blocks(rig.in_text))
+    # MUTATION 19: weaken the draw gate so a boxed via moves anyway.
+
+    def test_the_NEGATIVE_control_at_the_shipped_clearance_still_moves(self):
+        rig = _rig(CLEAR)
+        self.assertIn('via-nudge: moved', rig.out)
+        self.assertEqual(len(rig.res['via_moves']), 2)
+    # MUTATION: none (control).
+
+
+class TestTheShippedCLIPathKeepsTheSpec(unittest.TestCase):
+    """The one subprocess arm. It earns its cost on a mutation nothing
+    in-process can kill: drop `pcb_data=pcb_data` at
+    place_fanout_clearance.py's write_placed_output call. Then `n2n` is None,
+    `nm` is None, the via emits a NUMERIC `(net 7)` token into a board whose
+    other copper is name-style, AND via_protection_sexpr goes silent entirely.
+    Every in-process arm passes pcb_data itself and cannot see it.
+
+    Note the CLI's own guard is `if result['placements'] or
+    result.get('via_moves') or ...`, and on this rig `placements == []` -- so
+    via_moves alone is what triggers the write, which is exactly the path under
+    test."""
+
+    def test_place_fanout_clearance_py_writes_both_answers_through(self):
+        d, src = _stage('cli')
+        dst = os.path.join(d, 'out.kicad_pcb')
+        r = run_utils.check(
+            [sys.executable, run_utils.tool('place_fanout_clearance.py'),
+             src, dst, '--clearance', str(CLEAR),
+             '--max-displacement', '0', '--max-displacement-cap', '0',
+             '--max-passes', '1', '--no-rotate'], accept=True)
+        self.assertIn('via-nudge: moved VF1 via', (r.stdout or '') + (r.stderr or ''))
+        run_utils.evidence(dst, 'the CLI output board')
+        out = parse_kicad_pcb(dst)
+        self.assertEqual(_via_by_net(out, 'VF1').tenting_attrs, TYPE_VII)
+        self.assertEqual(_via_by_net(out, 'VF2').tenting_attrs, {})
+        self.assertEqual(_via_by_net(out, 'VF3').tenting_attrs, TYPE_VII)
+        with io.open(dst, encoding='utf-8') as f:
+            text = f.read()
+        self.assertIn('(net "VF1")', _via_block(text, 'VF1'))
+        self.assertEqual(_prot_tokens(_via_block(text, 'VF2')), [])
+    # MUTATION 18: drop pcb_data= at place_fanout_clearance.py's writer call.
+
+
+class TestOneEmitSiteOneSpecArgument(unittest.TestCase):
+    """Source-structure guard: the mutations no fixture can reach.
+
+    Reports LINE NUMBERS, never source text -- #732 measured a 393KB failure
+    message from an assertIn over a whole module."""
+
+    def setUp(self):
+        from placement import writer as W
+        self.W = W
+        self.writer = _code(W)
+        self.nudger = _code(FC.nudge_vias_for_unresolved)
+
+    def test_py_placer_emits_a_via_at_ONE_site_that_passes_spec_and_sentinel(self):
+        calls = _calls(self.writer, 'generate_via_sexpr')
+        self.assertEqual(
+            len(calls), 1,
+            'generate_via_sexpr is called at %d sites in placement/writer.py '
+            '(line(s) %s). #741 exists because the single site forgot one '
+            'argument; a second site is that defect with somewhere to hide.'
+            % (len(calls), [ln for ln, _ in calls]))
+        bad = [ln for ln, args in calls if 'tenting_attrs' not in args]
+        self.assertEqual(
+            bad, [],
+            'generate_via_sexpr at line(s) %s emits a via with no '
+            'tenting_attrs= argument, so via_protection_sexpr falls through to '
+            'DEFAULT_VIA_TENTING and every nudged via ships tented (#489 s8, '
+            '#741).' % bad)
+        noinherit = [ln for ln, args in calls
+                     if 'INHERIT_VIA_PROTECTION' not in args]
+        self.assertEqual(
+            noinherit, [],
+            'the emit at line(s) %s passes a spec but no inherit sentinel, so '
+            'a via that carried NO spec is stamped with front+back tenting it '
+            'never had -- the second half of #741.' % noinherit)
+    # MUTATIONS 2, 12, 16.
+
+    def test_no_OTHER_file_under_py_placer_emits_a_via(self):
+        """A directory sweep, not inspect: the point is that a NEW module
+        cannot grow a second emitter without landing here."""
+        hits = sorted(
+            os.path.relpath(p, _ROOT).replace('\\', '/')
+            for p in glob.glob(os.path.join(_ROOT, 'py_placer', '**', '*.py'),
+                               recursive=True)
+            if 'generate_via_sexpr' in _read(p))
+        self.assertEqual(hits, ['py_placer/placement/writer.py'],
+                         'py_placer gained a via emitter at %s' % hits)
+    # MUTATION 16: add an unguarded via emitter anywhere else under py_placer/.
+
+    def test_the_move_dict_is_BUILT_in_exactly_one_place(self):
+        appends = [i + 1 for i, l in enumerate(self.nudger)
+                   if 'via_moves.append(' in l]
+        self.assertEqual(len(appends), 1,
+                         'the via-move dict is constructed at %d sites '
+                         '(function-relative line(s) %s)'
+                         % (len(appends), appends))
+        # The KEY spelling, with its colon: `'tenting_attrs'` alone also
+        # matches the contract docstring (which names it deliberately) and the
+        # `getattr(v, 'tenting_attrs', ...)` continuation line, so counting
+        # that would be counting three different things.
+        keys = [i + 1 for i, l in enumerate(self.nudger)
+                if "'tenting_attrs':" in l]
+        self.assertEqual(len(keys), 1,
+                         "the move dict sets 'tenting_attrs' at %d CODE "
+                         "line(s) of the nudger (function-relative %s); "
+                         "expected exactly one" % (len(keys), keys))
+    # MUTATION: build the dict in two places; drop the key.
+
+    def test_the_pattern_this_fix_COPIES_still_exists(self):
+        """#741's fix is not novel: py_router/plane_io.py already carries the
+        identical pair, for the identical reason (a via that came OFF the board
+        and goes back on). If plane_io drops it, this file's docstring claim
+        that it is a house pattern has rotted, and so has half of #489."""
+        import plane_io
+        pl = _code(plane_io)
+        self.assertEqual(
+            len([1 for l in pl if "'tenting_attrs': dict(getattr(" in l]), 1,
+            'plane_io no longer carries the move-dict half of the pattern')
+        self.assertGreaterEqual(
+            len([ln for ln, a in _calls(pl, 'generate_via_sexpr')
+                 if 'tenting_attrs' in a]), 2,
+            'plane_io no longer carries the emit half of the pattern')
+    # MUTATION 22: strip the pair out of plane_io.
+
+    def test_the_count_arms_are_not_searching_for_dead_strings(self):
+        """ANTI-ROT. Every count arm above passes after a rename. Assert the
+        positive controls so a rename fails HERE instead of disarming them."""
+        for token, lines, floor in (
+                ('generate_via_sexpr', self.writer, 2),
+                ('tenting_attrs', self.writer, 1),
+                ('INHERIT_VIA_PROTECTION', self.writer, 2),
+                ('_remove_vias_at_positions', self.writer, 2),
+                ('via_moves', self.nudger, 3),
+                ('tenting_attrs', self.nudger, 1)):
+            n = sum(1 for l in lines if token in l)
+            self.assertGreaterEqual(
+                n, floor,
+                '%r appears %d times in CODE (expected >= %d): it was renamed, '
+                'and the count arms of this class are now vacuous'
+                % (token, n, floor))
+
+    def test_a_trailing_comment_cannot_arm_or_disarm_the_guard(self):
+        """FALSE-POSITIVE PROBE. placement/writer.py's comment block names
+        `generate_via_sexpr` and `_remove_vias_at_positions` in prose; the
+        stripper must drop them (#737's lesson)."""
+        probe = ["    x = 1  # generate_via_sexpr(a, b) and via_moves.append(",
+                 "    # 'tenting_attrs': dict(getattr(v, 'tenting_attrs', {}))"]
+        stripped = [l.split('#')[0] for l in probe]
+        self.assertEqual(_calls(stripped, 'generate_via_sexpr'), [])
+        self.assertEqual([l for l in stripped if "'tenting_attrs'" in l], [])
+
+    def test_the_sentinel_branch_is_tested_before_the_truthiness_branch(self):
+        """The sentinel is truthy, so branch ORDER is what makes it safe. A
+        source guard rather than a fixture, because reordering the branches
+        raises rather than mis-emits, and a crash is not what this file is
+        for."""
+        import kicad_writer as KW
+        src = _code(KW.via_protection_sexpr)
+        ident = [i for i, l in enumerate(src)
+                 if 'is INHERIT_VIA_PROTECTION' in l]
+        truthy = [i for i, l in enumerate(src)
+                  if re.search(r'elif\s+tenting_attrs\s*:', l)]
+        self.assertEqual(len(ident), 1, src)
+        self.assertEqual(len(truthy), 1, src)
+        self.assertLess(ident[0], truthy[0],
+                        'the identity test must come FIRST: the sentinel is '
+                        'truthy, so a truthiness branch above it would swallow '
+                        'it and then index it like a dict')
+    # MUTATION 13: reorder the branches.
+
+
+class TestInertOnTheTrackedCorpus(unittest.TestCase):
+    """Three arms, and the DISCLOSURE they carry matters more than the passes.
+
+    "INERT" here means the fix changes no GEOMETRY, and on the tracked corpus
+    it changes no BYTES either. Not, note, because the corpus never reaches the
+    nudger -- an earlier draft of this class asserted that and the run
+    falsified it. MEASURED over the 22 boards `git ls-files
+    kicad_files/*.kicad_pcb` returns, at clearance 0.25 and 0.10 with
+    displacement pinned to 0 and the cap fallback OFF (the configuration that
+    maximally FORCES the nudger):
+
+        DISTINCT boards that ran the whole pass ...........  2
+        board-clearance PAIRS that ran it .................  4
+        pairs that moved a via ............................  1
+          orangecrab_ext_pll.kicad_pcb @ 0.10 .............  9 vias
+        distinct source specs among those 9 ...............  exactly
+                                            {'tenting': '(front yes) (back yes)'}
+
+    That last line is the whole inertness argument, and it is what the second
+    arm asserts: every via the corpus moves already carries byte-for-byte
+    `kicad_writer.DEFAULT_VIA_TENTING`, so the string this fix emits and the
+    string the defect emitted are THE SAME STRING. Neither half of #741 can
+    fire on it -- the spec is not lost because it is re-emitted verbatim, and
+    it is not gained because it was already there.
+
+    Which is also exactly why the corpus can never be the DEMONSTRATION, and
+    why the synthetic rig above is necessary rather than lazy. Both arms are
+    self-expiring: they fail the day a board with a real Type-VII via is
+    tracked, which is the day this file should be re-measured against it."""
+
+    @staticmethod
+    def _boards():
+        return run_utils.corpus_boards()
+
+    def _skip_without_git(self, boards):
+        if not boards:
+            print('SKIP: git cannot identify the tracked corpus')
+            self.skipTest('git ls-files returned nothing')
+
+    def test_every_via_the_corpus_MOVES_re_emits_to_the_same_string(self):
+        """THE inertness arm. Run the pass over every tracked board in the
+        configuration that most forces a nudge, and assert that each via it
+        relocates carries a spec the writer would have produced anyway."""
+        boards = self._boards()
+        self._skip_without_git(boards)
+        full, moved, specs = set(), 0, set()
+        for b in boards:
+            for clr in (0.25, 0.10):
+                try:
+                    pcb = parse_kicad_pcb(b)
+                    with contextlib.redirect_stdout(io.StringIO()):
+                        res = repair_fanout_clearance(
+                            pcb, b, clearance=clr, max_displacement=0.0,
+                            max_displacement_cap=0.0, max_passes=1,
+                            allow_rotations=False, via_clear_fallback=False)
+                except Exception:
+                    continue
+                # The two EARLY-RETURN dicts (no BGA / no movable cap) carry no
+                # 'via_moves' key at all, so only a board that ran the whole
+                # pass can answer this. Do NOT spell it
+                # `res.get('via_moves') or []`: that reads "never reached the
+                # nudger" as "reached it and moved nothing", and the floor
+                # below would then be counting the wrong set.
+                if 'via_moves' not in res:
+                    continue
+                full.add(b)
+                for _x, _y, d in res['via_moves']:
+                    moved += 1
+                    self.assertIn('tenting_attrs', d,
+                                  '%s @ %s: the move dict lost the key on a '
+                                  'REAL board' % (b, clr))
+                    specs.add(tuple(sorted((d['tenting_attrs'] or {}).items())))
+        self.assertGreaterEqual(len(full), 2,
+                                'only %d tracked BOARD(s) ran the full pass '
+                                '(2 measured, over 4 board-clearance pairs); '
+                                'this arm is no longer measuring anything'
+                                % len(full))
+        self.assertGreaterEqual(moved, 9,
+                                'the corpus moved %d vias, down from the 9 '
+                                'measured: the arm below now grades an empty '
+                                'set' % moved)
+        self.assertEqual(
+            specs, {tuple(sorted(DEFAULT_VIA_TENTING.items()))},
+            'a tracked board now MOVES a via whose spec is not the writer '
+            'default: %s. The corpus is no longer inert under this fix -- '
+            'which also means it can now demonstrate #741. Re-measure, and '
+            'consider replacing this file\'s synthetic rig with that board.'
+            % sorted(specs))
+    # MUTATION 1 on a REAL board: the assertIn fires.
+    # Otherwise a self-expiring corpus bound.
+
+    def test_every_tracked_per_via_spec_is_one_the_default_would_produce(self):
+        """A TEXT scan, not a repair run. Any tracked via whose spec is not
+        DEFAULT_VIA_TENTING is a via the shipped defect would have CORRUPTED,
+        and the day one appears this file's rig should be replaced by it."""
+        boards = self._boards()
+        self._skip_without_git(boards)
+        specs, carriers = set(), {}
+        for b in boards:
+            with io.open(b, encoding='utf-8', errors='replace') as f:
+                text = f.read()
+            attrs = KP._extract_via_protection_attrs(text)
+            if attrs:
+                carriers[os.path.basename(b)] = len(attrs)
+            for spec in attrs.values():
+                specs.add(tuple(sorted(spec.items())))
+        want = tuple(sorted(DEFAULT_VIA_TENTING.items()))
+        self.assertTrue(specs, 'no tracked board carries a per-via spec at '
+                               'all; the parse path may have regressed')
+        self.assertEqual(
+            specs, {want},
+            'a tracked board now carries a per-via spec the writer default '
+            'would NOT produce: %s. This file says the corpus cannot '
+            'demonstrate #741 -- that is no longer true. Use the real board.'
+            % sorted(specs))
+        self.assertGreaterEqual(len(carriers), 2, carriers)
+    # MUTATION: none -- self-expiring. If it fires, re-measure; do not relax.
+
+    def test_the_two_spec_carrying_boards_are_still_found(self):
+        """Guards the arm above against a parse regression that would empty the
+        set and make it pass vacuously."""
+        boards = self._boards()
+        self._skip_without_git(boards)
+        counts = {}
+        for b in boards:
+            with io.open(b, encoding='utf-8', errors='replace') as f:
+                text = f.read()
+            n = len(KP._extract_via_protection_attrs(text))
+            if n:
+                counts[os.path.basename(b)] = n
+        self.assertIn('orangecrab_ext_pll.kicad_pcb', counts, counts)
+        self.assertIn('rp2350_fpga_eensy_prePlane.kicad_pcb', counts, counts)
+
+
+# THE BATTERY, as RUN. The killer per row is named in the trailing
+# `# MUTATION n:` comment beside the arm that kills it.
+#
+#    1  drop the move-dict key .................. headline / move-dict / source
+#    2  drop tenting_attrs= at the emit ......... headline / source guard
+#    3  pass None at the emit ................... headline ONLY (the source
+#                                                  guard sees the kwarg)
+#    4  pass {} at the emit .................... headline / move-dict
+#   4b  set the key only when non-empty ......... the present-and-empty arm
+#    5  share the dict instead of copying ....... TestTheDictHoldsACOPY, ALONE
+#    6  drop the `or {}` ...................... DECLARED UNKILLABLE, below
+#    7  copy the spec onto the wrong via ........ headline + spec-less together
+#    8  emit no uuid ........................... headline (the spec vanishes)
+#    9  re-emit the input uuid .................. the uuid arm
+#   10  skip _remove_vias_at_positions .......... via count 3 / whole-file diff
+#   11  drop net_name=nm ....................... the (net "VF2") arm
+#  11b  net-agnostic removal .................... the untouched-control arm
+#   12  drop `or INHERIT_VIA_PROTECTION` ........ spec-less arm / source guard
+#   13  reorder via_protection_sexpr's branches   489-default arms + the
+#                                                  branch-order source arm
+#   14  reorder VIA_PROTECTION_TOKEN_ORDER ...... canonical-order arm (overlaps
+#                                                  test_489; kept as an
+#                                                  end-to-end detector)
+#   15  drop the whitespace collapse ............ the collapse arm (same
+#                                                  overlap)
+#   16  a second emit site under py_placer/ ..... source guard, ALONE
+#   17  rename any guarded identifier ........... the anti-rot arm, ALONE
+#   18  drop pcb_data= in the CLI main .......... the CLI subprocess arm, ALONE
+#   19  weaken the draw gate ................... the refusal arm
+#   20  any geometry change from the fix ........ the exact landings in every
+#                                                  setUp
+#   22  strip the pattern out of plane_io ....... the house-pattern arm
+#
+# DECLARED UNKILLABLE, recorded rather than papered over -- #6. `Via
+# .tenting_attrs` is `field(default_factory=dict)` and the pcbnew builder passes
+# `_pcbnew_via_protection_attrs(track)`, which returns `{}` or a dict. NO parse
+# path in this repo produces None, so `dict(getattr(v, 'tenting_attrs', {}))`
+# and `dict(getattr(v, 'tenting_attrs', {}) or {})` are identical everywhere
+# reachable. A killer could be manufactured with a via-like carrying None, but
+# that would assert about a state no caller produces -- the phantom fixture
+# #731 removed from a different report. The `or {}` stays because plane_io.py
+# spells it that way, and one spelling is worth more than one branch.
+#
+# RECORDED AS UNCOVERED, named rather than silently missing: the GUI mirror
+# (fanout_gui.py's nudge block -> gui_utils.apply_via_protection) needs pcbnew,
+# and tests/gui_parity/** is not collected by run_all.py's flat glob.
+# TestTheMoveDictCarriesTheSpecForTheGUI pins the CONTRACT that block reads;
+# the pcbnew half is not exercised here.
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/test_741_via_nudge_tenting.py
+++ b/tests/test_741_via_nudge_tenting.py
@@ -116,8 +116,8 @@ TWO HAZARDS this file must not fall into, both measured:
     the "nothing else changed" arm diffs `_strip_via_blocks(out)` against
     `_strip_via_blocks(inp)` instead.
 
-THE BATTERY: 28 mutations, RUN rather than reasoned about, with the killer
-named beside each arm and the full table at the bottom of this file. 25 killed,
+THE BATTERY: 31 mutations, RUN rather than reasoned about, with the killer
+named beside each arm and the full table at the bottom of this file. 28 killed,
 THREE declared survivors -- recorded, not papered over. Two further survivors
 were found by an adversarial review of this file and a mutation run, and were
 CLOSED by arms added afterwards rather than declared away. Three arms overlap
@@ -872,6 +872,111 @@ class TestTheMoveDictCarriesTheSpecForTheGUI(unittest.TestCase):
     # MUTATION A2: `parts = parts[:1]` -- emit only the first token.
 
 
+class TestANoNetViaIsNotTurnedIntoInvisibleCopper(unittest.TestCase):
+    """THE REGRESSION THIS FIX ITSELF INTRODUCED, caught by an independent
+    reachability review rather than by me.
+
+    `via_protection_sexpr` picks the net dialect from `net_name` and the
+    protection tokens from `tenting_attrs` INDEPENDENTLY. So a via emitted with
+    a numeric `(net N)` token AND a spec is a shape `kicad_parser.extract_vias`
+    cannot match -- its KiCad-9 pattern has strict field ordering and no gap
+    for the protection tokens, while its KiCad-10 twin was given one. Such a
+    via does not merely lose its spec: it VANISHES from the model. Invisible
+    copper the router then plans tracks through, which is the hazard PR #534
+    was written against, and strictly worse than the wrong-tenting bug #741
+    set out to fix.
+
+    Before this fix the placement writer passed no `tenting_attrs`, so it could
+    never produce that pairing. After it, one input does: a via whose net id
+    does not resolve to a name. That is not hypothetical -- `extract_nets`
+    records `name_to_id[""] = 0` but never creates a `Net` for id 0, so a
+    legitimate no-net `(net "")` via misses the lookup on EVERY board.
+    Measured: kicad_files/orangecrab_ext_pll.kicad_pcb resolves 169 nets and
+    has no key 0.
+
+    MEASURED on the call below, one via move with net_id 0 and a Type-VII
+    spec, on a pcb_data whose map has had key 0 removed to match a real board:
+
+        0cdafd7a  (before #741)      (net 0)   no tokens    3 in file, 3 parsed
+        the #741 fix, no guard       (net 0)   4 tokens     3 in file, 2 PARSED
+        with the guard               (net "")  4 tokens     3 in file, 3 parsed
+
+    The middle row is the regression. The third keeps the spec AND the via.
+
+    Driven through `write_placed_output` directly rather than the rig, because
+    the rig declares a numeric net table and therefore HAS a key 0 -- it cannot
+    reach this at all, which is exactly why the defect survived the first
+    review round."""
+
+    def _emit(self, net_id, spec):
+        d, src = _stage('net0-%s' % net_id)
+        pcb = parse_kicad_pcb(src)
+        # Match a real KiCad-10 board: nets resolved by name, no entry for 0.
+        pcb.net_id_to_name.pop(0, None)
+        self.assertNotIn(0, pcb.net_id_to_name,
+                         'the map still has a key 0, so this arm is not '
+                         'reproducing a real board and proves nothing')
+        move = (VIA_X, 9.5, {'x': LAND_VF1[0], 'y': LAND_VF1[1],
+                             'size': V_SIZE, 'drill': V_DRILL,
+                             'layers': ['F.Cu', 'B.Cu'], 'net_id': net_id,
+                             'tenting_attrs': dict(spec)})
+        dst = os.path.join(d, 'out.kicad_pcb')
+        with contextlib.redirect_stdout(io.StringIO()):
+            wrote = write_placed_output(src, dst, [], via_moves=[move],
+                                        new_segments=[], pcb_data=pcb)
+        self.assertTrue(wrote)
+        text = _read(dst)
+        moved = [b for b, _n in _via_blocks(text)
+                 if ('%.6f' % LAND_VF1[0]) in b]
+        self.assertEqual(len(moved), 1, text)
+        return text, moved[0], parse_kicad_pcb(dst)
+
+    def test_a_no_net_via_with_a_spec_survives_the_round_trip(self):
+        text, blk, out = self._emit(0, TYPE_VII)
+        n_in_file = len(_via_blocks(text))
+        self.assertEqual(
+            len(out.vias), n_in_file,
+            'the written board has %d vias and the parser reads back %d. A '
+            'via was emitted in a dialect our own parser cannot match, so it '
+            'is invisible copper -- worse than the spec loss #741 fixes.'
+            % (n_in_file, len(out.vias)))
+    # MUTATION 23: neutralise BOTH guards (the net-0 naming AND the belt)
+    # -> (net 0) plus four protection tokens, and the via is gone: 3 in file,
+    # 2 parsed. Either guard alone still saves it, which is why 24 and 25 are
+    # separate rows.
+
+    def test_it_is_emitted_in_the_NAME_dialect_and_keeps_its_spec(self):
+        """The guard must not buy the via back by throwing the spec away --
+        that would re-open #741 for exactly this via."""
+        text, blk, out = self._emit(0, TYPE_VII)
+        self.assertIn('(net "")', blk, blk)
+        self.assertNotIn('(net 0)', blk, blk)
+        self.assertEqual(_prot_tokens(blk),
+                         ['covering', 'plugging', 'capping', 'filling'], blk)
+        v = [x for x in out.vias if x.net_id == 0]
+        self.assertEqual(len(v), 1)
+        self.assertEqual(v[0].tenting_attrs, TYPE_VII)
+    # MUTATION 24: make the guard suppress the spec instead of naming the net
+    # (nm stays None, spec -> INHERIT) -> the via survives but ships bare.
+
+    def test_the_belt_never_emits_a_numeric_net_ALONGSIDE_a_spec(self):
+        """The residue guard, for an id that is not 0 and does not resolve.
+        No board produces this today -- per-via protection is a KiCad-10
+        feature and those boards are name-net -- so it is asserted at the
+        writer rather than through a fixture. Losing the spec here is the
+        deliberate trade: losing the VIA is worse."""
+        text, blk, out = self._emit(9999, TYPE_VII)
+        numeric = '(net 9999)' in blk
+        if numeric:
+            self.assertEqual(_prot_tokens(blk), [],
+                             'a numeric net token was emitted ALONGSIDE a '
+                             'protection spec -- the exact pairing extract_'
+                             'vias cannot read back')
+        self.assertEqual(len(out.vias), len(_via_blocks(text)),
+                         'a via was lost at re-parse')
+    # MUTATION 25: drop the `if nm is None and spec is not INHERIT...` belt.
+
+
 class TestARefusedNudgeLeavesTheBoardTextAlone(unittest.TestCase):
     """The same board at clearance 0.7, where no clear spot exists inside the
     0.6mm search. This licenses the framing: a via's spec is only ever at risk
@@ -978,13 +1083,22 @@ class TestOneEmitSiteOneSpecArgument(unittest.TestCase):
             'tenting_attrs= argument, so via_protection_sexpr falls through to '
             'DEFAULT_VIA_TENTING and every nudged via ships tented (#489 s8, '
             '#741).' % bad)
-        noinherit = [ln for ln, args in calls
-                     if 'INHERIT_VIA_PROTECTION' not in args]
-        self.assertEqual(
-            noinherit, [],
-            'the emit at line(s) %s passes a spec but no inherit sentinel, so '
-            'a via that carried NO spec is stamped with front+back tenting it '
-            'never had -- the second half of #741.' % noinherit)
+        # The sentinel is resolved a few lines ABOVE the call now (the net-0
+        # guard needs it before the emit), so look for it in the enclosing
+        # function rather than in the call's argument text -- and require BOTH
+        # uses: the `or` that answers the spec-less case, and the belt that
+        # refuses to pair a numeric net with a spec.
+        uses = [i + 1 for i, l in enumerate(self.writer)
+                if 'INHERIT_VIA_PROTECTION' in l and 'import' not in l]
+        self.assertGreaterEqual(
+            len(uses), 2,
+            'placement/writer.py references INHERIT_VIA_PROTECTION on %d code '
+            'line(s) (%s); expected at least two -- the `or` that answers the '
+            'spec-less case (the second half of #741) and the belt that will '
+            'not pair a numeric net token with a protection spec (the via-loss '
+            'regression that fix introduced).' % (len(uses), uses))
+        nospec = [ln for ln, args in calls if 'tenting_attrs=' not in args]
+        self.assertEqual(nospec, [], nospec)
     # MUTATIONS 2, 12, 16.
 
     def test_no_OTHER_file_under_py_placer_emits_a_via(self):
@@ -1240,7 +1354,7 @@ class TestInertOnTheTrackedCorpus(unittest.TestCase):
 
 
 # THE BATTERY, as RUN -- every row below was applied to the tree and the file
-# re-run, not reasoned about. 28 mutations, 25 killed, 3 survivors, 0 BROKEN
+# re-run, not reasoned about. 31 mutations, 28 killed, 3 survivors, 0 BROKEN
 # (no mutation made this file die before it checked anything). The killer per
 # row is also named in the trailing `# MUTATION n:` comment beside the arm.
 #
@@ -1288,6 +1402,17 @@ class TestInertOnTheTrackedCorpus(unittest.TestCase):
 #                                         survived before)
 #    C  change the emitted indentation .. SURVIVES -- declared, see below
 #   22  strip the pattern out of plane_io  the house-pattern arm
+#   23  drop BOTH net-0 guards .......... all three no-net arms -- the via is
+#                                          LOST (3 in file, 2 parsed). This is
+#                                          the REGRESSION the #741 fix itself
+#                                          introduced. Removing only ONE guard
+#                                          does not lose the via, because the
+#                                          other still catches it; that is the
+#                                          point of having two, and it is why
+#                                          rows 24 and 25 exist separately.
+#   24  net-0 guard does nothing ........ the name-dialect arm (the belt then
+#                                          saves the via but it ships BARE)
+#   25  drop the numeric+spec belt ...... the belt arm
 #
 # NOT IN THIS FILE, and named so it does not read as uncovered: net-agnostic
 # removal (dropping net_ids=/net_names= at the writer). It leaves this file

--- a/tests/test_746_fanout_clearance_resolved_credit.py
+++ b/tests/test_746_fanout_clearance_resolved_credit.py
@@ -30,33 +30,58 @@ pre-nudge R with a post-nudge U, and it fails in BOTH directions:
 
 A REAL TRACKED BOARD DEMONSTRATES HALF A, which is what makes this more than a
 synthetic curiosity.  `kicad_files/orangecrab_ext_pll.kicad_pcb` at clearance
-0.1 with the cap fallback off went
+0.1 in the FORCING configuration below -- ALL FOUR knobs, not just the
+fallback: at `via_clear_fallback=False` alone the descent clears all 14 and
+the nudger is never called -- went
 
     before   "Moved 18 cap(s); resolved 1/14 initial violations; 10 unresolved."
     after    "Moved 18 cap(s); resolved 4/14 initial violations
               (3 freed by via-nudge); 10 unresolved."
 
 -- C19, C44 and C45 were freed by the nudge and credited nowhere.  Half B has
-no tracked board (see the window derivation below) and is synthetic here.
+no tracked board -- measured, see below -- and is synthetic here.
 
-THE WINDOW HALF B NEEDS, because it is not obvious and a future reader will
-otherwise assume the rig is arbitrary.  `valid_via_pos` gates a landing against
-every cap rect with NO layer gate, at `vr + via_req`; a connector is charged at
-`hw + pair`.  With `hw <= vr` the connector's charged band is a subset of the
-via's, so no cap can be newly grazed and half B is unreachable.  The window is
-exactly `hw - vr` = (stub width - via size) / 2, independent of the floors,
-which cancel.  Arm B therefore drives a 3.0mm stub into a 0.4mm via (window
-+1.30mm).  It also needs the #738 layer window -- the cap pads are THROUGH-HOLE
-so their copper spans the connector's inner layer while `connector_clear` tests
-only the footprint's own side.  Both conditions are single-variable controls
-here: `TestTheReGrazeIsTheOffLayerWindow` flips the stub to F.Cu and the pass
-declines to draw the connector at all.
+WHY ARM B'S RIG IS SHAPED THE WAY IT IS.  Half B needs the connector to graze
+a cap the relocated via does not, and `valid_via_pos` gates a landing against
+every cap rect with NO layer gate.  The geometry is a capsule against a disc:
+the via is tested as ONE disc of radius `R_v = vr + via_req` at the LANDING
+(`_point_to_rect_dist`), while the connector is charged as a capsule of radius
+`R_c = hw + pair` around the whole path from the old position to the new
+(`_seg_to_rect_dist`).  A point beside the path's INTERIOR is in the capsule
+and in neither endpoint's disc, so the reachable condition is on the nudge
+LENGTH, not on the two radii alone:
+
+    reachable  <=>  R_c >= R_v,  or  L >= 2 * sqrt(R_v^2 - R_c^2)
+
+with `L <= max_shift` (0.6).  A FIRST VERSION OF THIS FILE GOT THAT WRONG: it
+said `hw <= vr` made half B unreachable, which is the answer for one point
+(arm A's 0.8mm via and 0.3mm connector need L >= 0.866 and cannot get it) read
+as a general law.  A review refuted it with a working rig at `hw == vr`, where
+the bound is 0 and any nudge at all suffices.  The floors DO cancel wherever
+they resolve equal, and that half survived the same review: `via_req` spans
+`_all_cu`, which contains the connector's one layer, so `via_req >= pair`
+always.
+
+Arm B sits far inside the reachable region rather than on its boundary --
+`R_c = 1.60` against `R_v = 0.30`, so no length is required at all -- because
+it is a demonstration, not a boundary test.  It also needs #738's layer
+window: the cap pads are THROUGH-HOLE, so their copper spans the connector's
+inner layer while `connector_clear` tests only the footprint's own side.  That
+is the single-variable control
+`test_the_regraze_is_the_off_layer_window_not_a_generic_effect`, which flips
+the stub to F.Cu and watches the pass decline to draw the connector at all.
+
+THAT NO TRACKED BOARD SHOWS HALF B IS MEASURED, NOT DERIVED -- `regrazed` is
+empty on all 88 corpus rows below.  The corrected condition above is wide
+enough that it would be dishonest to claim otherwise.
 
 The corpus is the inertness argument, measured rather than asserted: over the
 22 boards `git ls-files` returns, at clearance 0.25 and 0.10, at the shipped
 defaults AND at the forcing configuration, 88 rows differ in exactly ONE place
--- the orangecrab row above.  At the shipped defaults no tracked board reaches
-the via-nudge at all, so all 44 of those rows are byte-identical.
+-- the orangecrab row above.  At the shipped defaults no tracked board NUDGES
+A VIA (one, rp2350_fpga_eensy_prePlane, does reach the nudger and is refused
+every landing), so all 44 of those rows print an identical summary and
+`regrazed` is empty on all 88.
 
 MUTATION BATTERY, 12 rows against the engine, 12 killed, 0 survivors.  The
 count per row is what makes the `# MUTATION:` notes checkable rather than
@@ -78,13 +103,20 @@ decorative, so it is recorded here:
 Three rows are killed by exactly one arm, and each names why that arm exists
 rather than being redundant with the rest.
 
-TWO OF MY OWN `# MUTATION:` NOTES WERE WRONG and are corrected in place rather
-than quietly deleted, because the shape recurs: both named an arm that CANNOT
-reach the mutation.  `via_resolved = list(resolved)` lives inside the
-`if via_moves:` block, so the sweep-only class -- where that guard is False --
-can never see it; I had written that this class was what caught it.  The
-battery said one arm caught it, and a different one.  A note claiming a gate
-that does not gate is worth less than no note.
+TWO OF MY OWN `# MUTATION:` NOTES WERE WRONG, in two DIFFERENT ways, and are
+corrected in place rather than quietly deleted:
+
+  * one named an arm that CANNOT reach the mutation.  `via_resolved =
+    list(resolved)` lives inside the `if via_moves:` block, so the sweep-only
+    class -- which exists precisely because that guard is False there -- can
+    never execute it.  I had written that this class was what caught it; the
+    battery says one arm does, and a different one.
+  * the other claimed SOLE credit for a mutation ten arms catch.  The
+    partition arm does reach the delta swap and does kill it; it is simply not
+    "silent" anywhere, and the note said it was.
+
+A note claiming a gate that does not gate is worth less than no note, and so
+is one claiming coverage it shares with nine others.
 
 ARM C EXISTS BECAUSE A REVIEW FOUND THE FIRST `regrazed` KEYED ON THE WRONG
 THING.  Spelled `[r for r in swept if r not in resolved]` it can only ever
@@ -122,7 +154,8 @@ if _TESTS not in sys.path:
     sys.path.insert(0, _TESTS)
 
 import run_utils
-from kicad_parser import BoardInfo, Footprint, Zone, parse_kicad_pcb
+from kicad_parser import (BoardInfo, Footprint, Zone, detect_package_type,
+                          parse_kicad_pcb)
 from placement import fanout_clearance as FC
 from placement.fanout_clearance import repair_fanout_clearance
 from synth import make_net, make_pad, make_pcb, make_seg, make_via
@@ -154,7 +187,7 @@ B_STUB_W = 3.0              # hw 1.50 vs vr 0.20 -> a +1.30mm window
 B_STUB_X0 = 4.0
 B_LANDING = (10.230, 12.554)    # MEASURED
 B_C3 = (11.4, 13.9)         # NEVER a seed violator: 1.709mm off the stub
-                            # against its 1.600 keep-out, and 1.109 off the
+                            # against its 1.600 keep-out, and 1.110 off the
                             # connector's far end against the same -- so the
                             # pass breaks a cap that arrived perfectly clean
 B_NEAR = 8.0                # the caps sit further from the BGA than the 1.0
@@ -602,7 +635,7 @@ class TestTheTwoListsAreDisjointAndOrdered(unittest.TestCase):
                     [r for r in order if r in set(res['unresolved'])])
     # MUTATION: `return sorted(res), sorted(unres)` in _grade() -- survives on
     # these rigs (C1 < C2 already) and is killed by the real-board arm, where
-    # st.caps order is R19, C1, C25, C7, ... and sorted() is not.
+    # `unresolved` comes out R19, C1, C25, C7, ... and sorted() does not.
 
     def test_the_two_disclosure_keys_partition_against_the_pre_nudge_credit(self):
         """via_resolved and regrazed are DISJOINT and each is a subset of the
@@ -698,8 +731,12 @@ class TestOnARealTrackedBoard(unittest.TestCase):
     # sit on, which is the failure the window derivation says cannot happen.
 
     def test_the_order_here_is_NOT_sorted(self):
-        """What kills `sorted()` in _grade(): this board's st.caps order puts
-        R19 first, so a sorted list is observably different."""
+        """What kills `sorted()` in _grade(): this board's `unresolved`
+        comes out R19-first, so a sorted list is observably different.  (The
+        head of `st.caps` itself is R17, R13, C22, ... -- also unsorted, but it
+        is the RETURNED list that carries the contract, and `resolved` here
+        happens to be in sorted order, so `unresolved` is the one that
+        discriminates.)"""
         self.assertNotEqual(self.res['unresolved'],
                             sorted(self.res['unresolved']))
         self.assertEqual(self.res['unresolved'][0], 'R19')
@@ -767,20 +804,36 @@ class TestInertOnTheTrackedCorpus(unittest.TestCase):
                 continue
             if not pcb.vias:
                 continue
-            if not any('BGA' in (f.footprint_name or '').upper()
+            # The ENGINE's own selector, not a name grep. `find_components_by_type`
+            # goes through detect_package_type, which also answers 'BGA' for
+            # LGA / CSP / WLCSP / WLP / CGA and for a geometric ball field with
+            # no keyword at all. Measured: a name grep selects 3 of the 22
+            # tracked boards and the engine's detector selects 4 -- and the
+            # missed one, rp2350_fpga_eensy_prePlane (a WLCSP-49), is exactly
+            # the board that REACHES the nudger at the shipped defaults. A
+            # bound that excludes its own counterexample is not a bound.
+            if not any(detect_package_type(f) == 'BGA'
                        for f in pcb.footprints.values()):
                 continue
             out.append(b)
         return out
 
     def test_no_tracked_board_nudges_a_via_at_the_shipped_defaults(self):
+        """NUDGES, not `reaches`: rp2350_fpga_eensy_prePlane does reach the
+        nudger at clearance 0.25 and is refused every landing it tries, so it
+        moves no via and neither new key can be non-empty. That is a weaker
+        and TRUE statement, and it is the one this arm holds."""
         reaching = self._reaching()
         if reaching is None:
             print('SKIP: git cannot identify the tracked corpus')
             self.skipTest('no git')
-        self.assertGreaterEqual(len(reaching), 3,
+        self.assertGreaterEqual(len(reaching), 4,
                                 'the candidate set collapsed; the filter is '
-                                'wrong and this arm proves nothing')
+                                'wrong and this arm proves nothing. It was 3 '
+                                'while it grepped names, which passed this '
+                                'guard at the boundary while silently '
+                                'dropping the one board that reaches the '
+                                'nudger')
         noisy = []
         for b in reaching:
             for clr in (0.25, 0.10):

--- a/tests/test_746_fanout_clearance_resolved_credit.py
+++ b/tests/test_746_fanout_clearance_resolved_credit.py
@@ -58,21 +58,25 @@ defaults AND at the forcing configuration, 88 rows differ in exactly ONE place
 -- the orangecrab row above.  At the shipped defaults no tracked board reaches
 the via-nudge at all, so all 44 of those rows are byte-identical.
 
-MUTATION BATTERY, 11 rows against the engine, 11 killed, 0 survivors.  The
+MUTATION BATTERY, 12 rows against the engine, 12 killed, 0 survivors.  The
 count per row is what makes the `# MUTATION:` notes checkable rather than
 decorative, so it is recorded here:
 
-    resolved-refresh-reverted            10 arms   the defect itself
-    deltas-swapped                       10        via_resolved <-> regrazed
-    deltas-hoisted-out-of-the-guard       7        credit on a run with no nudge
-    swept-bound-after-the-regrade         6        both deltas empty everywhere
+    resolved-refresh-reverted            11 arms   the defect itself
+    deltas-swapped                       11        via_resolved <-> regrazed
+    deltas-hoisted-out-of-the-guard       8        credit on a run with no nudge
+    swept-bound-after-the-regrade         7        both deltas empty everywhere
     credit-clause-unconditional           4        "(0 freed by via-nudge)"
     via_resolved-seeded-with-resolved     4        the descent's credit, restamped
-    registrar-after-the-regrade           3        #736's ordering
+    registrar-after-the-regrade           4        #736's ordering
     violators0-gate-dropped               3        "resolved 55/14"
+    regrazed-print-deleted                2
     grade-returns-sorted                  1        only the real board's order
     via_resolved-is-all-of-resolved       1        only the real board
-    regrazed-print-deleted                1
+    regrazed-keyed-on-swept               1        only arm C
+
+Three rows are killed by exactly one arm, and each names why that arm exists
+rather than being redundant with the rest.
 
 TWO OF MY OWN `# MUTATION:` NOTES WERE WRONG and are corrected in place rather
 than quietly deleted, because the shape recurs: both named an arm that CANNOT
@@ -81,6 +85,15 @@ reach the mutation.  `via_resolved = list(resolved)` lives inside the
 can never see it; I had written that this class was what caught it.  The
 battery said one arm caught it, and a different one.  A note claiming a gate
 that does not gate is worth less than no note.
+
+ARM C EXISTS BECAUSE A REVIEW FOUND THE FIRST `regrazed` KEYED ON THE WRONG
+THING.  Spelled `[r for r in swept if r not in resolved]` it can only ever
+name a cap that was ALSO a seed violator, so a cap that arrived perfectly
+clean and was broken by this pass's own connector was the single kind of
+re-graze with no cause named -- the exact case the engine docstring says
+exists.  Re-keyed on the transition (`unresolved` minus the pre-nudge
+`unresolved`), and arm C is the only arm in this file that tells the two
+spellings apart, because arm B's C2 happens to be a seed violator too.
 
 Runtime ~30s warm, in-process apart from one `git ls-files`.
 
@@ -140,6 +153,10 @@ B_VIA_SIZE, B_VIA_DRILL = 0.4, 0.2
 B_STUB_W = 3.0              # hw 1.50 vs vr 0.20 -> a +1.30mm window
 B_STUB_X0 = 4.0
 B_LANDING = (10.230, 12.554)    # MEASURED
+B_C3 = (11.4, 13.9)         # NEVER a seed violator: 1.709mm off the stub
+                            # against its 1.600 keep-out, and 1.109 off the
+                            # connector's far end against the same -- so the
+                            # pass breaks a cap that arrived perfectly clean
 B_NEAR = 8.0                # the caps sit further from the BGA than the 1.0
                             # default admits; without this `st.caps` is empty
                             # and the pass early-returns having graded nothing
@@ -262,6 +279,30 @@ def arm_b(*, layer='In1.Cu', through=True, stub_w=B_STUB_W, **kw):
                 via_clear_fallback=False)
     opts.update(kw)
     return _drive(bi, [v], [stub], fps, [], **opts)
+
+
+def arm_c():
+    """Arm B's board with C2 replaced by a cap that is CLEAN at the seed.
+
+    C1 is still buried and still calls the nudger; C3 sits outside every
+    keep-out on the board it was handed and is broken purely by the connector
+    this pass then draws.  It is never a violator, so it never enters
+    `violators0`, never enters `resolved`, and is invisible to any disclosure
+    keyed on the seed -- which is what an adversarial review of the first
+    version of this fix found.
+    """
+    bi = BoardInfo(layers={}, copper_layers=list(CU), board_bounds=B_BOUNDS)
+    v = make_via(B_VIA[0], B_VIA[1], net_id=3, size=B_VIA_SIZE,
+                 drill=B_VIA_DRILL)
+    stub = make_seg(B_STUB_X0, B_Y, B_VIA[0], B_Y, width=B_STUB_W,
+                    layer='In1.Cu', net_id=3)
+    fps = {'U1': _bga(*B_BGA),
+           'C1': _cap('C1', B_C1[0], B_C1[1], 11, 12, through=True),
+           'C3': _cap('C3', B_C3[0], B_C3[1], 15, 16, through=True)}
+    return _drive(bi, [v], [stub], fps, [], max_displacement=B_DISP,
+                  max_displacement_cap=B_DISP, max_passes=30,
+                  allow_rotations=False, near_margin=B_NEAR,
+                  via_clear_fallback=False)
 
 
 def sweep_only(disp=0.3):
@@ -426,6 +467,37 @@ class TestACapCleanedThenReGrazedLeavesResolved(unittest.TestCase):
         self.assertEqual(res['unresolved'], ['C1'])
     # MUTATION: none -- a control.
 
+    def test_a_cap_that_was_NEVER_broken_still_gets_its_cause_named(self):
+        """The case a review of the first version of this fix found missing.
+
+        C3 arrives clean -- not in `violators0`, so it can never be in
+        `resolved` -- and this pass's own connector breaks it.  Keyed on the
+        seed (`[r for r in swept if r not in resolved]`) that cap is the ONE
+        kind of re-graze with no cause named, which is the opposite of what
+        the disclosure is for.  Keyed on the TRANSITION it is named."""
+        res, _st, out = arm_c()
+        # ON THE BRANCH, three ways: C3 must not be a seed violator, must not
+        # have moved, and the connector must exist. Miss any and the arm is
+        # about something else.
+        self.assertIn('Caps initially grazing foreign copper (via/track/pad): '
+                      '1 (C1)', out,
+                      'C3 is a SEED violator here, so this rig no longer '
+                      'isolates the never-broken case')
+        self.assertEqual([p['reference'] for p in res['placements']], ['C1'],
+                         'C3 moved; it must be broken where it stands')
+        self.assertEqual(len(res['new_segments']), 1)
+
+        self.assertEqual(_line(out, '  Re-grazed'),
+                         "  Re-grazed by this pass's own connector copper: C3")
+        self.assertEqual(res['regrazed'], ['C3'])
+        self.assertEqual(res['unresolved'], ['C1', 'C3'])
+        self.assertEqual(res['resolved'], [])
+    # MUTATION: `regrazed = [r for r in swept if r not in resolved]` -- the
+    # first spelling. C3 was never in `violators0`, so `swept` cannot contain
+    # it and regrazed goes to []: the pass breaks a cap that arrived clean and
+    # reports it as an anonymous `unresolved`. Arm B alone does NOT catch this,
+    # because its C2 happens to be a seed violator as well.
+
 
 class TestTheSweepOnlyRunIsUnchanged(unittest.TestCase):
     """A run that never reaches the via-nudge must print what it always did."""
@@ -470,13 +542,15 @@ class TestTheSweepOnlyRunIsUnchanged(unittest.TestCase):
 class TestTheTwoListsAreDisjointAndOrdered(unittest.TestCase):
     """The shape contract both front ends read, on every arm at once."""
 
-    ARMS = ('arm_a', 'arm_b', 'arm_b_smd', 'arm_b_onlayer', 'sweep_only')
+    ARMS = ('arm_a', 'arm_b', 'arm_c', 'arm_b_smd', 'arm_b_onlayer',
+            'sweep_only')
 
     @classmethod
     def setUpClass(cls):
         cls.runs = {
             'arm_a': arm_a(),
             'arm_b': arm_b(),
+            'arm_c': arm_c(),
             'arm_b_smd': arm_b(through=False),
             'arm_b_onlayer': arm_b(layer='F.Cu'),
             'sweep_only': sweep_only(),

--- a/tests/test_746_fanout_clearance_resolved_credit.py
+++ b/tests/test_746_fanout_clearance_resolved_credit.py
@@ -1,0 +1,695 @@
+#!/usr/bin/env python3
+"""Issue #746: `resolved` was graded against a board that no longer existed.
+
+`repair_fanout_clearance` built its two summary lists at different times.
+`resolved` was computed right after the cap-move descent; `unresolved` was
+computed there too and then RECOMPUTED after the via-nudge had moved vias and
+drawn connector copper.  `resolved` never was.  So the operator's line mixed a
+pre-nudge R with a post-nudge U, and it fails in BOTH directions:
+
+  A. A cap the NUDGE frees reaches neither list.  It was grazing when the
+     credit was computed and clean when the debit was.
+
+         before   resolved []      unresolved []
+                  "Moved 0 cap(s); resolved 0/1 initial violations; 0 unresolved."
+         after    resolved ['C1']  unresolved []  via_resolved ['C1']
+                  "... resolved 1/1 initial violations (1 freed by via-nudge); 0 unresolved."
+
+  B. A cap the SWEEP cleaned that a connector this same pass drew then grazes
+     appears in BOTH lists.
+
+         before   resolved ['C2']  unresolved ['C1','C2']   <- C2 in both
+                  "Moved 2 cap(s); resolved 1/2 initial violations; 2 unresolved."
+         after    resolved []      unresolved ['C1','C2']   regrazed ['C2']
+                  "Moved 2 cap(s); resolved 0/2 initial violations; 2 unresolved."
+                  "  Re-grazed by this pass's own connector copper: C2"
+
+     1 + 2 = 3 credits on a 2-cap board.  Reachable only after #736 made the
+     post-nudge re-grade see the connectors, which is why the file declared it
+     a KNOWN GAP there instead of closing it.
+
+A REAL TRACKED BOARD DEMONSTRATES HALF A, which is what makes this more than a
+synthetic curiosity.  `kicad_files/orangecrab_ext_pll.kicad_pcb` at clearance
+0.1 with the cap fallback off went
+
+    before   "Moved 18 cap(s); resolved 1/14 initial violations; 10 unresolved."
+    after    "Moved 18 cap(s); resolved 4/14 initial violations
+              (3 freed by via-nudge); 10 unresolved."
+
+-- C19, C44 and C45 were freed by the nudge and credited nowhere.  Half B has
+no tracked board (see the window derivation below) and is synthetic here.
+
+THE WINDOW HALF B NEEDS, because it is not obvious and a future reader will
+otherwise assume the rig is arbitrary.  `valid_via_pos` gates a landing against
+every cap rect with NO layer gate, at `vr + via_req`; a connector is charged at
+`hw + pair`.  With `hw <= vr` the connector's charged band is a subset of the
+via's, so no cap can be newly grazed and half B is unreachable.  The window is
+exactly `hw - vr` = (stub width - via size) / 2, independent of the floors,
+which cancel.  Arm B therefore drives a 3.0mm stub into a 0.4mm via (window
++1.30mm).  It also needs the #738 layer window -- the cap pads are THROUGH-HOLE
+so their copper spans the connector's inner layer while `connector_clear` tests
+only the footprint's own side.  Both conditions are single-variable controls
+here: `TestTheReGrazeIsTheOffLayerWindow` flips the stub to F.Cu and the pass
+declines to draw the connector at all.
+
+The corpus is the inertness argument, measured rather than asserted: over the
+22 boards `git ls-files` returns, at clearance 0.25 and 0.10, at the shipped
+defaults AND at the forcing configuration, 88 rows differ in exactly ONE place
+-- the orangecrab row above.  At the shipped defaults no tracked board reaches
+the via-nudge at all, so all 44 of those rows are byte-identical.
+
+Runtime ~50s warm, in-process apart from one `git ls-files`.
+
+    python3 tests/test_746_fanout_clearance_resolved_credit.py
+"""
+from __future__ import annotations
+
+RUN_ALL_FAST_OK = True
+RUN_ALL_TIMEOUT = 900
+
+import contextlib
+import inspect
+import io
+import os
+import sys
+import tempfile
+import unittest
+
+_TESTS = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_TESTS)
+for _p in ('', 'py_router', 'py_placer', 'py_tools'):
+    _d = os.path.join(_ROOT, _p)
+    if _d not in sys.path:
+        sys.path.insert(0, _d)
+if _TESTS not in sys.path:
+    sys.path.insert(0, _TESTS)
+
+import run_utils
+from kicad_parser import BoardInfo, Footprint, Zone, parse_kicad_pcb
+from placement import fanout_clearance as FC
+from placement.fanout_clearance import repair_fanout_clearance
+from synth import make_net, make_pad, make_pcb, make_seg, make_via
+
+# --- the rig, and every number it is worth --------------------------------
+CLEAR = 0.1                 # place_fanout_clearance.py's own --help example
+CU = ['F.Cu', 'In1.Cu', 'In2.Cu', 'B.Cu']
+PAD_HALF = 0.3              # 0.6mm square pads at local +-0.5
+
+# Arm A: one boxed cap, one foreign via the nudger can move out of its way.
+A_BOUNDS = (0.0, 0.0, 60.0, 20.0)
+A_Y = 10.0
+A_BGA = (7.6, A_Y)
+A_CAP = (10.0, A_Y)
+A_VIA_X = 11.175            # 0.375 off pad 2's edge against a 0.400 keep-out
+A_VIA_SIZE, A_VIA_DRILL = 0.8, 0.3
+A_LANDING = (11.325, A_Y)   # MEASURED: where the nudger parks it
+
+# Arm B: a wide stub into a small via, so the connector's keep-out EXCEEDS the
+# relocated via's -- see the window derivation in the module docstring.
+B_BOUNDS = (0.0, 0.0, 60.0, 24.0)
+B_Y = 12.0
+B_BGA = (6.0, B_Y)
+B_C1 = (9.8, B_Y)           # buried in the stub: the sweep can never free it
+B_C2 = (12.0, B_Y)          # a seed violator the sweep CAN free
+B_VIA = (10.0, B_Y)
+B_VIA_SIZE, B_VIA_DRILL = 0.4, 0.2
+B_STUB_W = 3.0              # hw 1.50 vs vr 0.20 -> a +1.30mm window
+B_STUB_X0 = 4.0
+B_LANDING = (10.230, 12.554)    # MEASURED
+B_NEAR = 8.0                # the caps sit further from the BGA than the 1.0
+                            # default admits; without this `st.caps` is empty
+                            # and the pass early-returns having graded nothing
+B_DISP = 0.4
+
+# The forcing configuration: no cap may move and the fallback is off, so a cap
+# can only be freed by the nudge.  #313's boxed cap as a budget rather than as
+# a wall of obstacle geometry.
+FORCING = dict(max_displacement=0.0, max_displacement_cap=0.0, max_passes=1,
+               via_clear_fallback=False)
+
+REAL_BOARD = os.path.join(_ROOT, 'kicad_files', 'orangecrab_ext_pll.kicad_pcb')
+REAL_RESOLVED = ['C19', 'C44', 'C45', 'C67']
+REAL_VIA_RESOLVED = ['C19', 'C44', 'C45']       # C67 is the SWEEP's one credit
+REAL_LINE = ('Moved 18 cap(s); resolved 4/14 initial violations '
+             '(3 freed by via-nudge); 10 unresolved.')
+REAL_LINE_BEFORE = 'Moved 18 cap(s); resolved 1/14 initial violations; 10 unresolved.'
+
+
+def _bga(bx, by):
+    """detect_package_type keys on the footprint NAME, so a 3x3 grid whose
+    name says BGA is enough to give _Repair a ball field to sit caps near."""
+    pads = []
+    for i, dx in enumerate((-0.8, 0.0, 0.8)):
+        for j, dy in enumerate((-0.8, 0.0, 0.8)):
+            pads.append(make_pad(net_id=100 + 3 * i + j, x=bx + dx, y=by + dy,
+                                 ref='U1', num='%d%d' % (i, j), size_x=0.4,
+                                 size_y=0.4, shape='circle', layers=['F.Cu'],
+                                 local_x=dx, local_y=dy))
+    return Footprint(reference='U1', footprint_name='lib:BGA-9_3x3_0.8mm',
+                     x=bx, y=by, rotation=0.0, layer='F.Cu', pads=pads)
+
+
+def _cap(ref, cx, cy, na, nb, through=False):
+    """A C-prefixed 2-copper-pad part -- what _Repair's cap detection admits.
+
+    `through` is the ONE variable that opens #738's layer window: the pads
+    become `*.Cu` plated through-hole, so their copper spans every layer while
+    the FOOTPRINT still sits on F.Cu and `connector_clear` tests only that
+    side.  Arm B needs it; every other arm here leaves it False.
+    """
+    kw = dict(size_x=2 * PAD_HALF, size_y=2 * PAD_HALF, shape='rect')
+    if through:
+        kw.update(layers=['*.Cu', '*.Mask'], drill=0.3, pad_type='thru_hole')
+    else:
+        kw.update(layers=['F.Cu'])
+    pads = [make_pad(net_id=na, x=cx - 0.5, y=cy, ref=ref, num='1',
+                     local_x=-0.5, local_y=0.0, **kw),
+            make_pad(net_id=nb, x=cx + 0.5, y=cy, ref=ref, num='2',
+                     local_x=0.5, local_y=0.0, **kw)]
+    return Footprint(reference=ref, footprint_name='lib:C_0402_1005Metric',
+                     x=cx, y=cy, rotation=0.0, layer='F.Cu', pads=pads)
+
+
+def _drive(bi, vias, segs, fps, zones, **kw):
+    """Build the PCBData, stage a bare board FILE so the path-reading
+    collaborators degrade cleanly (courtyards -> {}, locked refs -> set(),
+    PadClearanceModel -> INERT), run the WHOLE pass, capture stdout.
+
+    `on_move` is the supported hook the animator uses and the only way to see
+    the internal `_Repair` -- in particular `st.caps`, whose iteration order
+    both returned lists must preserve.
+    """
+    pads_by_net = {}
+    for fp in fps.values():
+        for p in fp.pads:
+            pads_by_net.setdefault(p.net_id, []).append(p)
+    nets = {0: make_net(0, '')}
+    for k in list(pads_by_net) + [v.net_id for v in vias]:
+        nets.setdefault(k, make_net(k, 'N%d' % k))
+    pcb = make_pcb(board_info=bi, nets=nets, vias=list(vias),
+                   segments=list(segs), footprints=fps,
+                   pads_by_net=pads_by_net, zones=list(zones))
+    seen = []
+    with tempfile.TemporaryDirectory() as td:
+        path = os.path.join(td, 'b.kicad_pcb')
+        with io.open(path, 'w', encoding='utf-8') as f:
+            f.write('(kicad_pcb (version 20240108))\n')
+        # A check whose INPUT is missing tests nothing (CLAUDE.md/run_utils).
+        run_utils.evidence(path, 'the staged #746 rig board')
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            res = repair_fanout_clearance(pcb, path, clearance=CLEAR,
+                                          cap_prefix='C',
+                                          on_move=lambda st: seen.append(st),
+                                          **kw)
+    return res, (seen[0] if seen else None), buf.getvalue()
+
+
+def arm_a(**kw):
+    """One cap, one via, nothing may move: only the nudge can free it."""
+    bi = BoardInfo(layers={}, copper_layers=list(CU), board_bounds=A_BOUNDS)
+    v = make_via(A_VIA_X, A_Y, net_id=3, size=A_VIA_SIZE, drill=A_VIA_DRILL)
+    # A same-net zone under the via is what gives the relocated via a
+    # connector to draw -- without a tie of some kind conn_layers is empty and
+    # the via moves with no copper behind it.
+    zone = Zone(net_id=3, net_name='N3', layer='In1.Cu',
+                polygon=[(A_VIA_X - 1.0, A_Y - 1.0), (A_VIA_X + 1.0, A_Y - 1.0),
+                         (A_VIA_X + 1.0, A_Y + 1.0), (A_VIA_X - 1.0, A_Y + 1.0)])
+    fps = {'U1': _bga(*A_BGA), 'C1': _cap('C1', A_CAP[0], A_CAP[1], 11, 12)}
+    opts = dict(FORCING, allow_rotations=False)
+    opts.update(kw)
+    return _drive(bi, [v], [], fps, [zone], **opts)
+
+
+def arm_b(*, layer='In1.Cu', through=True, stub_w=B_STUB_W, **kw):
+    """Two caps on a wide same-net stub.  C1 is buried and can never clear, so
+    it is what calls the nudger; C2 is a seed violator the sweep frees, and
+    the connector drawn for C1's via then grazes it."""
+    bi = BoardInfo(layers={}, copper_layers=list(CU), board_bounds=B_BOUNDS)
+    v = make_via(B_VIA[0], B_VIA[1], net_id=3, size=B_VIA_SIZE,
+                 drill=B_VIA_DRILL)
+    stub = make_seg(B_STUB_X0, B_Y, B_VIA[0], B_Y, width=stub_w, layer=layer,
+                    net_id=3)
+    fps = {'U1': _bga(*B_BGA),
+           'C1': _cap('C1', B_C1[0], B_C1[1], 11, 12, through=through),
+           'C2': _cap('C2', B_C2[0], B_C2[1], 13, 14, through=through)}
+    opts = dict(max_displacement=B_DISP, max_displacement_cap=B_DISP,
+                max_passes=30, allow_rotations=False, near_margin=B_NEAR,
+                via_clear_fallback=False)
+    opts.update(kw)
+    return _drive(bi, [v], [stub], fps, [], **opts)
+
+
+def sweep_only(disp=0.3):
+    """Arm A's board with a displacement budget, so the SWEEP clears the cap
+    and the nudger is never called at all (`if unresolved:` is False)."""
+    return arm_a(max_displacement=disp, max_displacement_cap=disp,
+                 max_passes=30)
+
+
+def _summary(out):
+    return next((l for l in out.splitlines() if l.startswith('Moved ')), None)
+
+
+def _line(out, prefix):
+    return next((l.rstrip() for l in out.splitlines()
+                 if l.startswith(prefix)), None)
+
+
+_REAL_CACHE = {}
+
+
+def _real():
+    """The one tracked board that reaches the nudger, memoised: it costs a few
+    seconds and four arms want it."""
+    if 'r' not in _REAL_CACHE:
+        run_utils.evidence(REAL_BOARD, 'the orangecrab_ext_pll fixture')
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            res = repair_fanout_clearance(parse_kicad_pcb(REAL_BOARD),
+                                          REAL_BOARD, clearance=CLEAR,
+                                          **FORCING)
+        _REAL_CACHE['r'] = (res, buf.getvalue())
+    return _REAL_CACHE['r']
+
+
+class TestTheNudgeIsCreditedInsteadOfLost(unittest.TestCase):
+    """Half A: the cap the last resort exists to free."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.res, cls.st, cls.out = arm_a()
+
+    def test_the_rig_reaches_the_nudger_and_the_nudger_moves_the_via(self):
+        # ON THE BRANCH: without this every assertion below is about a pass
+        # that graded a board nobody touched, and half A cannot arise.
+        self.assertIn('Caps initially grazing foreign copper (via/track/pad): '
+                      '1 (C1)', self.out,
+                      'C1 is not a SEED violator, so there is nothing for the '
+                      'nudge to be credited WITH')
+        self.assertIn('via-nudge: moved N3 via (%.3f,%.3f) -> (%.3f,%.3f) to '
+                      'free C1' % (A_VIA_X, A_Y, A_LANDING[0], A_LANDING[1]),
+                      self.out, 'the nudger did not move the via it names')
+        self.assertEqual(len(self.res['via_moves']), 1)
+        self.assertEqual(len(self.res['new_segments']), 1)
+        self.assertEqual(self.res['placements'], [],
+                         'a cap MOVED, so this arm no longer isolates the '
+                         'nudge from the sweep')
+    # MUTATION: none -- this arm licenses the claim rather than testing the fix.
+
+    def test_the_freed_cap_is_credited_to_resolved(self):
+        # The PRINT first: assert it before the counts and no mutation can
+        # make the silence be the reported failure.
+        self.assertEqual(
+            _summary(self.out),
+            'Moved 0 cap(s); resolved 1/1 initial violations '
+            '(1 freed by via-nudge); 0 unresolved.')
+        self.assertEqual(self.res['resolved'], ['C1'])
+        self.assertEqual(self.res['unresolved'], [])
+    # MUTATION: drop the `resolved, unresolved = _grade()` refresh from the
+    # `if via_moves:` block (leave only the `unresolved` recompute) -- resolved
+    # goes back to [] and the line reads "resolved 0/1 initial violations;
+    # 0 unresolved." about a run that fixed the one violation it found.
+
+    def test_the_credit_names_the_nudge_as_the_mechanism(self):
+        self.assertEqual(self.res['via_resolved'], ['C1'])
+        self.assertEqual(self.res['regrazed'], [])
+    # MUTATION: `via_resolved = list(resolved)` -- passes here (swept is empty)
+    # and FAILS test_the_sweeps_own_credit_is_not_attributed_to_the_nudge.
+
+    def test_a_second_rig_frees_a_cap_the_same_way(self):
+        """Arm B's board with SMD pads: a different stub, a different landing,
+        the same credit.  One rig proving half A would leave the finding
+        resting on one set of coordinates."""
+        res, _st, out = arm_b(through=False)
+        self.assertIn('via-nudge: moved N3 via (10.000,12.000) -> '
+                      '(10.000,12.550) to free C1', out)
+        self.assertEqual(res['via_resolved'], ['C1'])
+        self.assertEqual(res['resolved'], ['C1'])
+        self.assertEqual(res['unresolved'], [])
+        self.assertEqual(
+            _summary(out),
+            'Moved 1 cap(s); resolved 1/1 initial violations '
+            '(1 freed by via-nudge); 0 unresolved.')
+    # MUTATION: same as test_the_freed_cap_is_credited_to_resolved.
+
+
+class TestACapCleanedThenReGrazedLeavesResolved(unittest.TestCase):
+    """Half B: the pass's own connector copper breaking a cap it had fixed."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.res, cls.st, cls.out = arm_b()
+
+    def test_the_rig_reaches_the_nudger_and_the_sweep_frees_C2(self):
+        # ON THE BRANCH, three ways: both caps must be SEED violators, the
+        # sweep must actually move C2, and a connector must be drawn.  Miss
+        # any one and "C2 left resolved" is true for the wrong reason.
+        self.assertIn('Caps initially grazing foreign copper (via/track/pad): '
+                      '2 (C1, C2)', self.out)
+        moved = {p['reference']: (round(p['new_x'], 3), round(p['new_y'], 3))
+                 for p in self.res['placements']}
+        self.assertEqual(moved, {'C1': (10.2, 12.0), 'C2': (12.4, 12.0)},
+                         'the sweep no longer frees C2, so there is no credit '
+                         'for the connector to take away')
+        self.assertEqual(len(self.res['via_moves']), 1)
+        self.assertEqual([(s['layer'], s['width'])
+                          for s in self.res['new_segments']],
+                         [('In1.Cu', B_STUB_W)],
+                         'the connector this arm is about was not drawn')
+    # MUTATION: none -- an on-the-branch guard.
+
+    def test_C2_is_in_unresolved_and_NOT_also_in_resolved(self):
+        self.assertEqual(
+            _summary(self.out),
+            'Moved 2 cap(s); resolved 0/2 initial violations; 2 unresolved.')
+        self.assertEqual(self.res['unresolved'], ['C1', 'C2'])
+        self.assertEqual(self.res['resolved'], [])
+        self.assertEqual(sorted(set(self.res['resolved'])
+                                & set(self.res['unresolved'])), [])
+    # MUTATION: drop the `resolved` half of the refresh -> resolved == ['C2']
+    # while unresolved == ['C1','C2'], i.e. 1 + 2 = 3 credits on a 2-cap board,
+    # and the line reads "resolved 1/2 initial violations; 2 unresolved."
+
+    def test_the_cause_is_named_rather_than_left_anonymous(self):
+        self.assertEqual(
+            _line(self.out, '  Re-grazed'),
+            "  Re-grazed by this pass's own connector copper: C2")
+        self.assertEqual(self.res['regrazed'], ['C2'])
+        self.assertEqual(self.res['via_resolved'], [])
+    # MUTATION: delete the `if regrazed:` print -> the cap is still correctly
+    # reported unresolved, but nothing says the pass did it, which is the
+    # whole difference between a board that arrived broken and one we broke.
+
+    def test_the_regraze_is_the_off_layer_window_not_a_generic_effect(self):
+        """Single-variable control: put the stub -- and so the connector -- on
+        the caps' OWN side.  There `connector_clear` and the grader agree
+        exactly (#736), so the pass declines to draw the connector at all and
+        nothing is re-grazed.  This is what stops half B from reading as 'the
+        nudger routinely wrecks caps'."""
+        res, _st, out = arm_b(layer='F.Cu')
+        self.assertIn("via-nudge: no clear spot for C1's offending via", out)
+        self.assertEqual(res['via_moves'], [])
+        self.assertEqual(res['new_segments'], [])
+        self.assertEqual(res['regrazed'], [])
+        # ... and the pre-nudge credit stands, unrefreshed and correct.
+        self.assertEqual(res['resolved'], ['C2'])
+        self.assertEqual(res['unresolved'], ['C1'])
+    # MUTATION: none -- a control.
+
+
+class TestTheSweepOnlyRunIsUnchanged(unittest.TestCase):
+    """A run that never reaches the via-nudge must print what it always did."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.res, cls.st, cls.out = sweep_only()
+
+    def test_the_nudger_is_never_called(self):
+        # ON THE BRANCH: `if unresolved:` must be False, not merely "the
+        # nudger found nothing" -- a rig that reaches it and declines would
+        # exercise a different path than the one this class claims.
+        self.assertNotIn('via-nudge', self.out,
+                         'the nudger ran; this class is about the path where '
+                         'it is not even called')
+        self.assertEqual(self.res['via_moves'], [])
+        self.assertEqual(self.res['new_segments'], [])
+
+    def test_the_sweeps_own_credit_is_not_attributed_to_the_nudge(self):
+        self.assertEqual(self.res['resolved'], ['C1'])
+        self.assertEqual(self.res['via_resolved'], [])
+        self.assertEqual(self.res['regrazed'], [])
+    # MUTATION: `via_resolved = list(resolved)` -> ['C1'], and the summary
+    # credits the via-nudge for a cap the descent walked clear on its own.
+
+    def test_both_new_clauses_are_suppressed_so_the_line_is_the_old_line(self):
+        self.assertEqual(
+            _summary(self.out),
+            'Moved 1 cap(s); resolved 1/1 initial violations; 0 unresolved.')
+        self.assertIsNone(_line(self.out, '  Re-grazed'))
+        self.assertNotIn('freed by via-nudge', self.out)
+    # MUTATION: emit `_credit` unconditionally -> "(0 freed by via-nudge)" on
+    # every board that never nudges, i.e. on all 22 tracked ones at the
+    # shipped defaults.
+
+
+class TestTheTwoListsAreDisjointAndOrdered(unittest.TestCase):
+    """The shape contract both front ends read, on every arm at once."""
+
+    ARMS = ('arm_a', 'arm_b', 'arm_b_smd', 'arm_b_onlayer', 'sweep_only')
+
+    @classmethod
+    def setUpClass(cls):
+        cls.runs = {
+            'arm_a': arm_a(),
+            'arm_b': arm_b(),
+            'arm_b_smd': arm_b(through=False),
+            'arm_b_onlayer': arm_b(layer='F.Cu'),
+            'sweep_only': sweep_only(),
+        }
+
+    def test_no_ref_is_in_both_lists(self):
+        for name in self.ARMS:
+            res, _st, _out = self.runs[name]
+            with self.subTest(arm=name):
+                self.assertEqual(
+                    sorted(set(res['resolved']) & set(res['unresolved'])), [],
+                    'a cap is credited and debited by the same run')
+    # MUTATION: drop the `resolved` half of the refresh -> arm_b fails.
+
+    def test_resolved_is_a_subset_of_the_seed_violators(self):
+        """`violators0` never leaves the engine, so it is re-derived from the
+        printed disclosure -- which is the operator's only view of it too."""
+        for name in self.ARMS:
+            res, _st, out = self.runs[name]
+            head = _line(out, 'Caps initially grazing foreign copper')
+            self.assertIsNotNone(head, 'the seed disclosure vanished')
+            seeds = set()
+            if '(' in head:
+                seeds = {s.strip() for s in
+                         head.split('(', 2)[-1].rstrip(')').split(',')}
+            with self.subTest(arm=name):
+                self.assertLessEqual(set(res['resolved']), seeds,
+                                     'a cap was credited as resolved that was '
+                                     'never a violator')
+    # MUTATION: drop the `elif ref in violators0` gate in _grade() -> every
+    # clean cap is credited; arm_b_onlayer reports resolved ['C2'] -> ['C2']
+    # unchanged but arm_a's sweep_only sibling gains the BGA-adjacent caps.
+
+    def test_both_lists_follow_st_caps_order(self):
+        """test_736:506 asserts `res['unresolved'] == ['C1']` by LIST equality,
+        so order is a contract, not an accident."""
+        for name in self.ARMS:
+            res, st, _out = self.runs[name]
+            self.assertIsNotNone(st, 'the on_move hook never fired')
+            order = list(st.caps)
+            with self.subTest(arm=name):
+                self.assertEqual(
+                    res['resolved'],
+                    [r for r in order if r in set(res['resolved'])])
+                self.assertEqual(
+                    res['unresolved'],
+                    [r for r in order if r in set(res['unresolved'])])
+    # MUTATION: `return sorted(res), sorted(unres)` in _grade() -- survives on
+    # these rigs (C1 < C2 already) and is killed by the real-board arm, where
+    # st.caps order is R19, C1, C25, C7, ... and sorted() is not.
+
+    def test_the_two_disclosure_keys_partition_against_the_pre_nudge_credit(self):
+        """via_resolved and regrazed are DISJOINT and each is a subset of the
+        list it is a delta into."""
+        for name in self.ARMS:
+            res, _st, _out = self.runs[name]
+            with self.subTest(arm=name):
+                self.assertEqual(
+                    sorted(set(res['via_resolved']) & set(res['regrazed'])), [])
+                self.assertLessEqual(set(res['via_resolved']),
+                                     set(res['resolved']))
+                self.assertLessEqual(set(res['regrazed']),
+                                     set(res['unresolved']))
+    # MUTATION: swap the two comprehensions' direction -> arm_a's via_resolved
+    # becomes [] and arm_b's regrazed becomes [], both silently.
+
+
+class TestTheEarlyReturnsOmitTheNudgeKeys(unittest.TestCase):
+    """The documented contract: the early returns carry neither key, exactly
+    as they carry no via_moves / new_segments, and every caller uses .get."""
+
+    def _early(self, **kw):
+        bi = BoardInfo(layers={}, copper_layers=list(CU), board_bounds=A_BOUNDS)
+        fps = {'U1': _bga(*A_BGA)}
+        fps.update(kw.pop('extra_fps', {}))
+        return _drive(bi, kw.pop('vias', []), [], fps, [], **dict(FORCING, **kw))
+
+    def test_a_board_with_no_vias_returns_the_six_key_shape(self):
+        res, _st, out = self._early()
+        self.assertIn('No vias on the board', out)
+        for k in ('via_moves', 'new_segments', 'via_resolved', 'regrazed'):
+            self.assertNotIn(k, res, 'the early return grew a %r key; if that '
+                                     'is deliberate, say so here' % (k,))
+        self.assertEqual(res['resolved'], [])
+        self.assertEqual(res['unresolved'], [])
+
+    def test_a_board_with_no_movable_caps_returns_the_same_shape(self):
+        v = make_via(A_VIA_X, A_Y, net_id=3, size=A_VIA_SIZE, drill=A_VIA_DRILL)
+        res, _st, out = self._early(vias=[v])
+        self.assertIn('No movable caps near a BGA', out)
+        for k in ('via_moves', 'new_segments', 'via_resolved', 'regrazed'):
+            self.assertNotIn(k, res)
+    # MUTATION: add the two keys to either early return -- harmless, but it
+    # would make the docstring's "exactly as they carry no via_moves" false.
+
+    def test_the_gui_read_survives_the_early_shape(self):
+        """fanout_gui.py reads all four with .get; this is that read, spelled
+        the way the plugin spells it, against the dict that lacks them."""
+        res, _st, _out = self._early()
+        self.assertEqual(len(res.get('via_moves', [])), 0)
+        self.assertEqual(list(res.get('via_resolved') or []), [])
+        self.assertEqual(list(res.get('regrazed') or []), [])
+
+
+class TestOnARealTrackedBoard(unittest.TestCase):
+    """Half A is not synthetic.  This is the arm that says so."""
+
+    @classmethod
+    def setUpClass(cls):
+        if not os.path.isfile(REAL_BOARD):
+            raise unittest.SkipTest('SKIP: %s is absent' % REAL_BOARD)
+        cls.res, cls.out = _real()
+
+    def test_the_board_reaches_the_nudger_in_this_configuration(self):
+        # ON THE BRANCH: `via_clear_fallback=False` is not decoration -- with
+        # the fallback ON this board reports 0 unresolved, the nudger is never
+        # called, and every assertion below would be about nothing.
+        self.assertEqual(len(self.res['via_moves']), 9)
+        self.assertEqual(len(self.res['new_segments']), 17)
+        self.assertEqual(len(self.res['placements']), 18)
+
+    def test_three_real_caps_were_freed_by_the_nudge_and_credited_nowhere(self):
+        self.assertEqual(_summary(self.out), REAL_LINE)
+        self.assertEqual(self.res['resolved'], REAL_RESOLVED)
+        self.assertEqual(self.res['via_resolved'], REAL_VIA_RESOLVED)
+        self.assertEqual(len(self.res['unresolved']), 10)
+    # MUTATION: drop the `resolved` half of the refresh -> the line reverts to
+    # REAL_LINE_BEFORE ("resolved 1/14"), losing C19, C44 and C45.
+
+    def test_the_pass_did_not_break_a_cap_it_had_fixed_on_this_board(self):
+        self.assertEqual(self.res['regrazed'], [],
+                         'a tracked board now re-grazes a cap the sweep '
+                         'cleaned -- grade it with check_drc before believing '
+                         'the summary, and re-record the window derivation in '
+                         'this file, which says no tracked board can')
+        self.assertIsNone(_line(self.out, '  Re-grazed'))
+
+    def test_the_order_here_is_NOT_sorted(self):
+        """What kills `sorted()` in _grade(): this board's st.caps order puts
+        R19 first, so a sorted list is observably different."""
+        self.assertNotEqual(self.res['unresolved'],
+                            sorted(self.res['unresolved']))
+        self.assertEqual(self.res['unresolved'][0], 'R19')
+    # MUTATION: `return sorted(res), sorted(unres)` -> this fails; without
+    # this arm that mutation survives the whole file.
+
+
+class TestTheRefreshStillRunsAfterTheRegistrar(unittest.TestCase):
+    """#736's ordering constraint, which #746 must not disturb: the connector
+    copper is absorbed into the track view BEFORE anything re-grades against
+    it.  Asserted on LINE NUMBERS rather than on source text -- an assertNotIn
+    against a 130KB module prints 393KB on failure (#732)."""
+
+    @staticmethod
+    def _lines(needle):
+        src = inspect.getsource(FC).splitlines()
+        return [i for i, l in enumerate(src, 1) if needle in l]
+
+    def test_register_new_segments_precedes_every_grade_call(self):
+        reg = self._lines('st.register_new_segments(new_segs)')
+        grade = self._lines('resolved, unresolved = _grade()')
+        self.assertEqual(len(reg), 1, 'the registrar moved or was duplicated')
+        self.assertEqual(len(grade), 2, 'expected exactly two _grade() calls: '
+                                        'one before the nudge, one after')
+        self.assertLess(grade[0], reg[0], 'the pre-nudge grade must come first')
+        self.assertLess(reg[0], grade[1],
+                        'the re-grade now runs BEFORE the connectors are '
+                        'registered, so it reads a track view missing exactly '
+                        'the copper this pass drew (#736)')
+
+    def test_the_via_view_refresh_also_precedes_the_re_grade(self):
+        via = self._lines('st.cap_vias = {r: st.vias for r in st.caps}')
+        grade = self._lines('resolved, unresolved = _grade()')
+        self.assertEqual(len(via), 1)
+        self.assertLess(via[0], grade[1])
+
+    def test_swept_is_bound_before_the_re_grade_rebinds_resolved(self):
+        """`swept = resolved` is a NAME binding; if it lands after the
+        rebinding it captures the post-nudge list and both deltas are
+        empty on every board, silently."""
+        swept = self._lines('swept = resolved')
+        grade = self._lines('resolved, unresolved = _grade()')
+        self.assertEqual(len(swept), 1)
+        self.assertLess(swept[0], grade[1])
+    # MUTATION: move `swept = resolved` below the re-grade -> via_resolved and
+    # regrazed are [] everywhere; arm_a and arm_b both fail.
+
+
+class TestInertOnTheTrackedCorpus(unittest.TestCase):
+    """A self-expiring bound: at the SHIPPED defaults no tracked board reaches
+    the via-nudge, so neither new key can be non-empty and neither new clause
+    can print.  If that ever changes, the PR's inertness claim has expired and
+    this says so rather than quietly passing."""
+
+    @staticmethod
+    def _reaching():
+        boards = run_utils.corpus_boards()
+        if not boards:
+            return None
+        out = []
+        for b in boards:
+            try:
+                pcb = parse_kicad_pcb(b)
+            except Exception:                                    # noqa: BLE001
+                continue
+            if not pcb.vias:
+                continue
+            if not any('BGA' in (f.footprint_name or '').upper()
+                       for f in pcb.footprints.values()):
+                continue
+            out.append(b)
+        return out
+
+    def test_no_tracked_board_nudges_a_via_at_the_shipped_defaults(self):
+        reaching = self._reaching()
+        if reaching is None:
+            print('SKIP: git cannot identify the tracked corpus')
+            self.skipTest('no git')
+        self.assertGreaterEqual(len(reaching), 3,
+                                'the candidate set collapsed; the filter is '
+                                'wrong and this arm proves nothing')
+        noisy = []
+        for b in reaching:
+            for clr in (0.25, 0.10):
+                buf = io.StringIO()
+                with contextlib.redirect_stdout(buf):
+                    r = repair_fanout_clearance(parse_kicad_pcb(b), b,
+                                                clearance=clr)
+                out = buf.getvalue()
+                if (r.get('via_resolved') or r.get('regrazed')
+                        or 'freed by via-nudge' in out
+                        or _line(out, '  Re-grazed')):
+                    noisy.append((os.path.basename(b), clr,
+                                  r.get('via_resolved'), r.get('regrazed')))
+                # and the invariant holds on every board, nudge or not
+                self.assertEqual(
+                    sorted(set(r.get('resolved') or [])
+                           & set(r.get('unresolved') or [])), [],
+                    '%s @ %s reports a cap in both lists' % (b, clr))
+        self.assertEqual(noisy, [],
+                         'a tracked board now reaches the via-nudge at the '
+                         'shipped defaults: %r. The "inert at the defaults" '
+                         'claim in the #746 PR has EXPIRED -- re-run the '
+                         'before/after sweep and record the new numbers.'
+                         % (noisy,))
+    # MUTATION: none -- a self-expiring corpus bound, not a fix assertion.
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/test_746_fanout_clearance_resolved_credit.py
+++ b/tests/test_746_fanout_clearance_resolved_credit.py
@@ -58,7 +58,31 @@ defaults AND at the forcing configuration, 88 rows differ in exactly ONE place
 -- the orangecrab row above.  At the shipped defaults no tracked board reaches
 the via-nudge at all, so all 44 of those rows are byte-identical.
 
-Runtime ~50s warm, in-process apart from one `git ls-files`.
+MUTATION BATTERY, 11 rows against the engine, 11 killed, 0 survivors.  The
+count per row is what makes the `# MUTATION:` notes checkable rather than
+decorative, so it is recorded here:
+
+    resolved-refresh-reverted            10 arms   the defect itself
+    deltas-swapped                       10        via_resolved <-> regrazed
+    deltas-hoisted-out-of-the-guard       7        credit on a run with no nudge
+    swept-bound-after-the-regrade         6        both deltas empty everywhere
+    credit-clause-unconditional           4        "(0 freed by via-nudge)"
+    via_resolved-seeded-with-resolved     4        the descent's credit, restamped
+    registrar-after-the-regrade           3        #736's ordering
+    violators0-gate-dropped               3        "resolved 55/14"
+    grade-returns-sorted                  1        only the real board's order
+    via_resolved-is-all-of-resolved       1        only the real board
+    regrazed-print-deleted                1
+
+TWO OF MY OWN `# MUTATION:` NOTES WERE WRONG and are corrected in place rather
+than quietly deleted, because the shape recurs: both named an arm that CANNOT
+reach the mutation.  `via_resolved = list(resolved)` lives inside the
+`if via_moves:` block, so the sweep-only class -- where that guard is False --
+can never see it; I had written that this class was what caught it.  The
+battery said one arm caught it, and a different one.  A note claiming a gate
+that does not gate is worth less than no note.
+
+Runtime ~30s warm, in-process apart from one `git ls-files`.
 
     python3 tests/test_746_fanout_clearance_resolved_credit.py
 """
@@ -314,8 +338,13 @@ class TestTheNudgeIsCreditedInsteadOfLost(unittest.TestCase):
     def test_the_credit_names_the_nudge_as_the_mechanism(self):
         self.assertEqual(self.res['via_resolved'], ['C1'])
         self.assertEqual(self.res['regrazed'], [])
-    # MUTATION: `via_resolved = list(resolved)` -- passes here (swept is empty)
-    # and FAILS test_the_sweeps_own_credit_is_not_attributed_to_the_nudge.
+    # MUTATION: `via_resolved = list(resolved)`. This arm does NOT kill it --
+    # `swept` is empty on a rig where no cap moves, so the two spellings agree
+    # here. Measured: of the 26 arms in this file exactly ONE goes red, the
+    # real-board one, where the descent's own credit (C67) is in `resolved`
+    # and must not be attributed to the nudge. The first draft of this comment
+    # claimed the sweep-only class caught it; the battery said otherwise, and
+    # that mutation is unreachable from there (it lives inside `if via_moves:`).
 
     def test_a_second_rig_frees_a_cap_the_same_way(self):
         """Arm B's board with SMD pads: a different stub, a different landing,
@@ -414,13 +443,18 @@ class TestTheSweepOnlyRunIsUnchanged(unittest.TestCase):
                          'it is not even called')
         self.assertEqual(self.res['via_moves'], [])
         self.assertEqual(self.res['new_segments'], [])
+    # MUTATION: none -- an on-the-branch guard.
 
     def test_the_sweeps_own_credit_is_not_attributed_to_the_nudge(self):
         self.assertEqual(self.res['resolved'], ['C1'])
         self.assertEqual(self.res['via_resolved'], [])
         self.assertEqual(self.res['regrazed'], [])
-    # MUTATION: `via_resolved = list(resolved)` -> ['C1'], and the summary
-    # credits the via-nudge for a cap the descent walked clear on its own.
+    # MUTATION: seed the declaration -- `via_resolved: List[str] = list(resolved)`
+    # instead of `[]` -- so a cap the DESCENT walked clear is credited to the
+    # nudge on every board that never nudges. Also killed by hoisting the two
+    # delta comprehensions out of the `if via_moves:` guard. Note the mutation
+    # INSIDE that guard (`via_resolved = list(resolved)`) cannot be caught
+    # here: the guard is False on this path, so the block never runs.
 
     def test_both_new_clauses_are_suppressed_so_the_line_is_the_old_line(self):
         self.assertEqual(
@@ -472,9 +506,11 @@ class TestTheTwoListsAreDisjointAndOrdered(unittest.TestCase):
                 self.assertLessEqual(set(res['resolved']), seeds,
                                      'a cap was credited as resolved that was '
                                      'never a violator')
-    # MUTATION: drop the `elif ref in violators0` gate in _grade() -> every
-    # clean cap is credited; arm_b_onlayer reports resolved ['C2'] -> ['C2']
-    # unchanged but arm_a's sweep_only sibling gains the BGA-adjacent caps.
+    # MUTATION: drop the `elif ref in violators0` gate in _grade(), so every
+    # clean cap is credited whether or not it was ever broken. Measured: three
+    # arms go red, this one among them, and the real board's line becomes
+    # "resolved 55/14 initial violations" -- a numerator above its own
+    # denominator, from a pass claiming caps it never touched.
 
     def test_both_lists_follow_st_caps_order(self):
         """test_736:506 asserts `res['unresolved'] == ['C1']` by LIST equality,
@@ -506,8 +542,11 @@ class TestTheTwoListsAreDisjointAndOrdered(unittest.TestCase):
                                      set(res['resolved']))
                 self.assertLessEqual(set(res['regrazed']),
                                      set(res['unresolved']))
-    # MUTATION: swap the two comprehensions' direction -> arm_a's via_resolved
-    # becomes [] and arm_b's regrazed becomes [], both silently.
+    # MUTATION: swap the two comprehensions' direction. Measured: this arm
+    # goes red on three of its five subTests -- but so do nine other arms, so
+    # it is corroboration rather than the only guard. The shape it uniquely
+    # holds is the SUBSET half: a delta key that names a ref outside the list
+    # it is a delta into.
 
 
 class TestTheEarlyReturnsOmitTheNudgeKeys(unittest.TestCase):
@@ -545,6 +584,7 @@ class TestTheEarlyReturnsOmitTheNudgeKeys(unittest.TestCase):
         self.assertEqual(len(res.get('via_moves', [])), 0)
         self.assertEqual(list(res.get('via_resolved') or []), [])
         self.assertEqual(list(res.get('regrazed') or []), [])
+    # MUTATION: none -- a control on the plugin's own spelling.
 
 
 class TestOnARealTrackedBoard(unittest.TestCase):
@@ -579,6 +619,9 @@ class TestOnARealTrackedBoard(unittest.TestCase):
                          'the summary, and re-record the window derivation in '
                          'this file, which says no tracked board can')
         self.assertIsNone(_line(self.out, '  Re-grazed'))
+    # MUTATION: none -- a self-expiring bound. It is also what would catch a
+    # future change that made the nudger draw connectors a real board's caps
+    # sit on, which is the failure the window derivation says cannot happen.
 
     def test_the_order_here_is_NOT_sorted(self):
         """What kills `sorted()` in _grade(): this board's st.caps order puts

--- a/tests/test_750_fanout_clearance_via_drill.py
+++ b/tests/test_750_fanout_clearance_via_drill.py
@@ -55,31 +55,59 @@ so nobody restores them:
     parks two vias 0.28mm apart, both FOREIGN -- so the copper term
     short-circuits and H2H_VIA alone decides that arm's landing. What is
     true is weaker: no assertion KEYS on it, so deleting the gate goes green
-    there. The battery records that, and records that deleting the gate
-    perturbs test_732's landing too, so that row is not attributable to this
-    file alone.
-  * "H2H_PAD is covered only as a negative." `tests/test_737_...py:691-716`
+    there -- measured, test_732 runs 12 tests OK against an engine whose
+    H2H_VIA gate is `pass`. It DOES steer that arm's landing (via #2 goes
+    (151.32, 116.1389) -> (151.57, 116.5889) without the gate), but the arm
+    asserts `moves[0][0]`, the START x, which does not move. So THIS file is
+    the sole gate on that row, and trimming
+    `test_a_sane_drill_is_refused_by_BOTH_spellings` as redundant with
+    test_732 would remove the only thing holding it.
+  * "H2H_PAD is covered only as a negative."
+    `test_737:693-711`'s `test_the_617_rig_relocates_to_exactly_the_same_place`
     pins a landing to four places that H2H_PAD binds with 0.006588 mm of
-    headroom, and says so in as many words.
+    headroom -- landing (1.1148, 1.6772) to NPTH (1.0, 0.98) is 0.706588
+    against a drill-gate need of 0.700000. That number is stated in test_737's
+    module docstring at :80-84, not beside the arm.
 
 BRACKETING THE CONSTANT, because pinning `_UNREADABLE_VIA_DRILL == 0.3` on
 its own is a source assertion, not a behavioural one. Arm C places the NPTH
 hole so that the resolved value lands between two decisions:
 
-    hole at x=4.12 (candidate 1.07 from it)  ->  REFUSED   => fallback > 0.24
-    hole at x=4.20 (candidate 1.15 from it)  ->  ACCEPTED  => fallback <= 0.40
+    hole at x=4.12  ->  REFUSED   => fallback > 0.2714
+    hole at x=4.20  ->  ACCEPTED  => fallback <= 0.4000
 
-so the fallback is bracketed to (0.24, 0.40] by behaviour, and `drill=0.0`
-lands identically to `drill=0.3` in both -- which a fallback of 0, or of
-`_UNREADABLE_VIA_SIZE`, would not do.
+so the fallback is bracketed to (0.2714, 0.4000] by behaviour, and
+`drill=0.0` lands identically to `drill=0.3` in both -- which a fallback of
+0, or of `_UNREADABLE_VIA_SIZE`, would not do.
+
+THE LOWER BOUND IS NOT THE AXIAL ARITHMETIC, and a review caught me writing
+that it was. (0.24, 0.40] came from the first candidate alone; the rig admits
+at least FOUR -- (3.05, 3.0), (3.0462, 3.0191), (3.0354, 3.0354) and
+(3.0383, 3.0924) -- and REFUSED means refusing all of them. The farthest is
+1.085671 from the hole, so the real bound is f > 0.271342. Confirmed by
+patching the constant and running this file:
+
+    constant   REFUSED arm   ACCEPTED arm
+      0.25       3 FAIL          ok        <- inside the bracket I first wrote
+      0.27       3 FAIL          ok
+      0.28         ok            ok
+      0.30         ok            ok        <- shipped
+      0.40         ok            ok
+      0.41         ok          3 FAIL
+
+so both ends bind, and 0.25 -- which the first bracket declared safe -- turns
+the REFUSED arm red. Exactly the sort of bound that reads as tight and is
+not.
 
 INPUTS WHERE THE TWO SPELLINGS DIFFER, measured over the whole class rather
 than assumed. `-0.0` does NOT differ (it is falsy, so both substitute) and
 `nan` does NOT differ (both propagate it, and `d < nan + ...` is False either
 way) -- do not "tidy" a -0.3 into a -0.0 here, and do not add a NaN arm.
-`-1e-9` and `-inf` do differ but cannot survive the via regex, whose drill
-class carries no `e`, so a board declaring one loses the via entirely. The
-reachable class is plain decimal negatives, which BOTH parse paths admit:
+`-1e-9` and `-inf` do differ, but only as SPELLINGS a board cannot use: the
+drill class admits no `e`, so the token `1e-9` is unmatchable and the via is
+dropped whole. The VALUE is reachable -- `(drill -0.000000001)` matches and
+floats to exactly -1e-9 -- so the honest statement is that the reachable
+class is plain decimal negatives, which BOTH parse paths admit:
 the class carries a `-` and the `float()` after it checks no sign.
 
 The second delta is the `getattr`: the old expression raised AttributeError
@@ -189,9 +217,12 @@ H2H_PAD = 0.45
 # A foreign-net (2) cap pad rect whose right edge is 0.32 from the via -- just
 # inside the offender threshold VR + CLEAR = 0.35, so the cap is grazed and the
 # offender loop runs -- while the r = 0.05 candidate at (3.05, 3.00) sits 0.37
-# from it and is admitted. Every other candidate on the first two rings is
-# either closer to the rect or off the +x ray, which is what makes LANDING the
-# only one and lets a refusal be asserted as `moves == []`.
+# from it and is admitted. LANDING is the FIRST candidate the sweep reaches,
+# NOT the only admitted one: measured, the rect also admits (3.0462, 3.0191),
+# (3.0354, 3.0354) and (3.0383, 3.0924). So `moves == []` says the gate under
+# test refused EVERY admitted candidate -- the stronger claim, and the reason
+# the bracket's lower bound comes from the farthest of them rather than from
+# LANDING (see the docstring).
 RECT = (2.0, 2.9, 2.68, 3.1, 2)
 
 # The value the three removed sites hard-coded, mirrored the way test_732
@@ -200,9 +231,12 @@ RECT = (2.0, 2.9, 2.68, 3.1, 2)
 OLD_NUDGER_DRILL_RADIUS = 0.3 / 2.0
 
 # Arm C's two hole positions and the bracket they impose on the fallback.
-BRACKET_REFUSE_X = 4.12        # candidate 1.07 away -> refused  => f > 0.24
-BRACKET_ACCEPT_X = 4.20        # candidate 1.15 away -> accepted => f <= 0.40
-BRACKET_LO, BRACKET_HI = 0.24, 0.40
+BRACKET_REFUSE_X = 4.12        # refuses EVERY admitted candidate => f > 0.2714
+BRACKET_ACCEPT_X = 4.20        # admits the first one            => f <= 0.4000
+# Measured by sweeping the resolver's default at 0.001, NOT derived from the
+# axial candidate -- see the docstring for the two wrong brackets that came
+# from doing it the other way round.
+BRACKET_LO, BRACKET_HI = 0.2714, 0.4000
 
 
 class _FakeCap:
@@ -328,7 +362,7 @@ class TestTheGateThatStoppedFiring(unittest.TestCase):
         self.assertEqual(moves, [])
     # MUTATION: the guard back to `or` -> the via moves to (3.05, 3.00) and
     # both the print and the count assertions fail. This arm kills 6 of the
-    # battery's 15 rows -- the two guard re-spellings, both constant moves,
+    # battery's 16 rows -- the two guard re-spellings, both constant moves,
     # the diameter/radius slip, and the deleted gate.
 
     def test_TWO_negative_drills_switched_the_gate_OFF(self):
@@ -368,7 +402,8 @@ class TestTheGateThatStoppedFiring(unittest.TestCase):
         self.assertEqual(moves, [])
     # MUTATION: either constant move -> the substituted radius changes and
     # the ON-THE-BRANCH equality between the two spellings fires. Killed by 4
-    # rows. (An earlier version of this note claimed the arm could NOT see a
+    # rows, of which only 2 are constant moves (the others are the
+    # diameter/radius slip and the deleted gate). (An earlier version of this note claimed the arm could NOT see a
     # constant move; the battery says otherwise, which is why the notes are
     # written after it runs and carry its counts.)
 
@@ -411,6 +446,9 @@ class TestEachViaContributesITSOWNDrill(unittest.TestCase):
                                       'vdr + vdr are indistinguishable here')
         self.assertAlmostEqual(_via_drill_radius(v) + _via_drill_radius(ov)
                                + H2H_VIA, 0.6, places=9)
+    # MUTATION: returns-the-diameter-not-the-radius -- the two radii double
+    # and the 0.6 equality fires. Killed by 1 row; it is the ON-THE-BRANCH
+    # guard for the two arms below, not a claim of its own.
 
     def test_a_neighbour_inside_the_SUMMED_floor_is_refused(self):
         v, ov, pcb = self._board(self.NEAR)
@@ -495,8 +533,14 @@ class TestTheFallbackResolvesToExactlyPointThree(unittest.TestCase):
     def _land(self, v_drill, hole_x):
         v, _hole, pcb = _hole_board(v_drill, hole_x)
         # ON THE BRANCH: for the 0.0/None rows the fallback really is taken.
+        # `assertFalse(v.drill)` would be TAUTOLOGICAL here -- Via is a plain
+        # dataclass with no normalisation, so `v.drill is v_drill` and the
+        # assertion cannot fail under `not v_drill`. Assert the RESOLVED value
+        # instead, which is what the gate below actually consumes.
         if not v_drill:
-            self.assertFalse(v.drill, 'the fallback branch is not taken')
+            self.assertAlmostEqual(_via_drill_radius(v),
+                                   _UNREADABLE_VIA_DRILL / 2.0, places=12,
+                                   msg='the fallback branch is not taken')
         moves, _segs, _out, land = _run(pcb)
         return len(moves), land
 
@@ -635,6 +679,9 @@ class TestOneDrillRule(unittest.TestCase):
             self.assertEqual(hits, [],
                              '%s still resolves a drill inline -- %s'
                              % (where, '; '.join(hits)))
+    # MUTATION: literal-restored-at-the-capsule-gate -- the evasion that
+    # keeps the constant's NAME. Killed by 1 row, and this is the ONLY arm
+    # that sees it structurally.
 
     def test_the_resolver_is_actually_CALLED_twice_and_where(self):
         """Absence alone is evadable: `(ov.drill or _UNREADABLE_VIA_DRILL)`
@@ -648,6 +695,9 @@ class TestOneDrillRule(unittest.TestCase):
                          'the pad drill-capsule gate no longer reads vdr')
         self.assertEqual(len(self._hits('vdr + ovdr + H2H_VIA')), 1,
                          'the via-to-via gate no longer reads the resolver')
+    # MUTATION: 6 rows -- every edit that moves, renames or duplicates a call
+    # site. The widest net in the file, and the reason absence alone is not
+    # enough: it is what catches `(ov.drill or _UNREADABLE_VIA_DRILL)`.
 
     def test_the_offender_radii_are_resolved_BEFORE_the_candidate_sweep(self):
         """Not a style point. The gate runs inside the 16-angle x 12-radius
@@ -660,6 +710,9 @@ class TestOneDrillRule(unittest.TestCase):
         self.assertLess(pre[0], use[0],
                         'the precompute no longer precedes the gate that '
                         'reads it, so it is not a precompute')
+    # MUTATION: 4 rows, of which precompute-inlined-per-candidate is the one
+    # this arm exists for -- semantically inert, so NO behavioural arm can see
+    # it and this is its only gate.
 
     def test_the_gate_reads_the_offenders_position_LIVE(self):
         """NOT COVERED BEHAVIOURALLY, and disclosed rather than skipped.
@@ -671,7 +724,10 @@ class TestOneDrillRule(unittest.TestCase):
         via's coordinates DO change between iterations. Folding them into the
         same tuple is the obvious tidy-up and is a real defect: measured on a
         two-cap rig during review, the second via lands at (5.1061, 6.1061)
-        instead of (5.0500, 6.0000).
+        instead of (5.0500, 6.0000). Those coordinates are a REVIEW
+        measurement and are deliberately not re-derivable from this repo: the
+        rig is not shipped, because a two-cap geometry tuned to expose one
+        mutant is not a general guard and would read as one.
 
         A 400-seed randomized old-vs-new fuzz did NOT catch that mutant --
         only 8 seeds moved two vias at all -- so a behavioural arm here would
@@ -693,6 +749,9 @@ class TestOneDrillRule(unittest.TestCase):
         self.assertEqual(len(dist), 1,
                          'the via-to-via gate no longer measures to ov.x/ov.y '
                          'as they are NOW')
+    # MUTATION: 4 rows, of which positions-cached-alongside-the-radius is the
+    # one this arm exists for -- the silent tidy-up, invisible to a 400-seed
+    # fuzz, and this is its only gate.
 
     def test_this_files_mirrored_floors_are_still_the_engines(self):
         """H2H_VIA/H2H_PAD are function-local literals and cannot be
@@ -720,6 +779,10 @@ class TestThePadSideStillRefusesToInvent(unittest.TestCase):
                       'the pad capsule now has a fallback of its own; #750 '
                       'named the VIA drill precisely because the pad drill '
                       'beside it is measured')
+    # MUTATION: NONE in the battery, and that is a disclosure rather than an
+    # omission. It guards a line #750 did not touch, against a "consistency"
+    # pass that has not been written; mutating it would only be mutating this
+    # arm's own subject to watch it fire.
 
     def test_the_writer_still_emits_the_drill_the_board_declared(self):
         """The gate prices an unreadable drill at 0.3; the writer must still

--- a/tests/test_750_fanout_clearance_via_drill.py
+++ b/tests/test_750_fanout_clearance_via_drill.py
@@ -1,0 +1,744 @@
+#!/usr/bin/env python3
+"""#750: a via's DRILL must have ONE resolver in the fanout-clearance pass.
+
+`valid_via_pos` priced a via's drill as `(x.drill or 0.3) / 2.0` at three
+sites -- the pad drill-capsule gate and both terms of the via-to-via
+hole-to-hole gate -- while the COPPER radius on those same two lines already
+went through #732's `_via_radius`. One expression, two conventions, and the
+drill half had no name at all.
+
+The literal is not the interesting part; the SPELLING is. `or` keeps a
+NEGATIVE value, so the drill term goes negative and WEAKENS the gate it is
+summed into, and with both drills negative the whole threshold turns negative
+and the gate can never fire. Measured at d7658c93 against d04a9c07, on the
+rigs below (clearance 0.1, max_shift 0.15, so the only candidate the cap
+rect admits is (3.05, 3.00)):
+
+  A. the via-to-via gate, one SAME-NET neighbour at (3.30, 3.00), so the
+     copper term at `ov.net_id != v.net_id` is skipped and the hole-to-hole
+     term is the ONLY thing that can decide the landing:
+
+       v.drill   ov.drill   old threshold    d7658c93        d04a9c07
+        0.3       0.3        +0.5000         no clear spot   no clear spot
+       -0.3       0.3        +0.2000         MOVES           no clear spot
+        0.0       0.3        +0.5000         no clear spot   no clear spot
+       -0.3      -0.3        -0.1000         MOVES           no clear spot
+
+     The last row is the point. A threshold of -0.10 mm is one no distance
+     can undercut, so the gate is not weakened, it is OFF -- and the pass
+     parks the via 0.2500 mm from the neighbour's centre where the same two
+     barrels at a sane 0.3 drill require 0.5000 mm. Exactly HALF the fab
+     hole-to-hole floor, from a gate that exists to enforce it.
+
+  B. the pad drill-capsule gate, one NPTH hole (drill 1.0) and no second
+     via, so the via-to-via gate is inert:
+
+       v.drill   capsule floor   d7658c93                   d04a9c07
+        0.3       1.1000         no clear spot              no clear spot
+       -0.3       0.8000         MOVES to 0.9000 of hole    no clear spot
+        0.0       1.1000         no clear spot              no clear spot
+
+THE FALLBACK BRANCH HAD NEVER RUN. `synth.make_via` defaults `drill=0.3`, and
+every via built anywhere that reaches this function -- test_370, 617, 725,
+731, 732, 733, 736, 737, 741, 746 -- carries a positive drill. So no
+assertion in the suite has ever executed `(x.drill or 0.3)`'s fallback on
+either gate, and no driver has ever passed a via-like carrying no `drill` at
+all. That is what `TestTheFallbackResolvesToExactlyPointThree` and the
+`getattr` arm are for, and it is why they are worth having even though they
+are INERT with respect to the fix.
+
+Two claims an earlier draft of this file made are FALSE and are recorded here
+so nobody restores them:
+
+  * "H2H_VIA has no test of any kind." It fires and BINDS today.
+    `tests/test_732_...py:257` drives `_rig(DVS_SMALL, [0.30, 0.02])`, which
+    parks two vias 0.28mm apart, both FOREIGN -- so the copper term
+    short-circuits and H2H_VIA alone decides that arm's landing. What is
+    true is weaker: no assertion KEYS on it, so deleting the gate goes green
+    there. The battery records that, and records that deleting the gate
+    perturbs test_732's landing too, so that row is not attributable to this
+    file alone.
+  * "H2H_PAD is covered only as a negative." `tests/test_737_...py:691-716`
+    pins a landing to four places that H2H_PAD binds with 0.006588 mm of
+    headroom, and says so in as many words.
+
+BRACKETING THE CONSTANT, because pinning `_UNREADABLE_VIA_DRILL == 0.3` on
+its own is a source assertion, not a behavioural one. Arm C places the NPTH
+hole so that the resolved value lands between two decisions:
+
+    hole at x=4.12 (candidate 1.07 from it)  ->  REFUSED   => fallback > 0.24
+    hole at x=4.20 (candidate 1.15 from it)  ->  ACCEPTED  => fallback <= 0.40
+
+so the fallback is bracketed to (0.24, 0.40] by behaviour, and `drill=0.0`
+lands identically to `drill=0.3` in both -- which a fallback of 0, or of
+`_UNREADABLE_VIA_SIZE`, would not do.
+
+INPUTS WHERE THE TWO SPELLINGS DIFFER, measured over the whole class rather
+than assumed. `-0.0` does NOT differ (it is falsy, so both substitute) and
+`nan` does NOT differ (both propagate it, and `d < nan + ...` is False either
+way) -- do not "tidy" a -0.3 into a -0.0 here, and do not add a NaN arm.
+`-1e-9` and `-inf` do differ but cannot survive the via regex, whose drill
+class carries no `e`, so a board declaring one loses the via entirely. The
+reachable class is plain decimal negatives, which BOTH parse paths admit:
+the class carries a `-` and the `float()` after it checks no sign.
+
+The second delta is the `getattr`: the old expression raised AttributeError
+on a via-like with no `drill`, and the resolver prices it at the fallback.
+Deliberate, and reachable only from a test stand-in.
+
+INERT ON THE CORPUS: 0 of the 602 vias across the 22 boards
+`run_utils.corpus_boards()` returns has a falsy or negative drill (the
+minimum on the corpus is 0.15). Stated as 602/22, not the issue's 604/27 --
+that figure is the repo-wide `*.kicad_pcb` set, five of which live under
+tests/fixtures/.
+
+MUTATION BATTERY, 15 rows against the engine: 13 killed, 2 SURVIVED and both
+expected, 0 broken. The counts make the `# MUTATION:` notes checkable rather
+than decorative, so they are recorded here and the battery itself ships as
+`tests/mutate_750.py`:
+
+    returns-the-diameter-not-the-radius     19 assertions  every arithmetic arm
+    constant-raised-to-0.5                   8             bracket, upper half
+    constant-lowered-to-0.2                  7             bracket, lower half
+    h2h-via-gate-deleted                     7             + perturbs test_732
+    guard-reverted-to-or                     6             THE DEFECT
+    guard-is-none-or-equals-zero             6             still admits negatives
+    capsule-gate-reads-the-COPPER-radius     5             vdr -> vr
+    offender-drill-resolved-with-the-movers  3             vdr + vdr
+    h2h-via-floor-swapped-for-the-pad-one    3             the typo class
+    literal-restored-at-the-capsule-gate     3             the source-guard evasion
+    precompute-inlined-per-candidate         2             SOURCE guards only
+    getattr-dropped                          1             as an ERROR
+    writer-emits-the-RESOLVED-drill          1
+    guard-lt-zero-instead-of-le-zero         0  SURVIVED, expected: `not d`
+    guard-is-none-instead-of-not-d           0  SURVIVED, expected: already covers it
+
+FOUR OF THIS FILE'S `# MUTATION:` NOTES WERE WRONG BEFORE THE BATTERY RAN,
+and are corrected in place rather than quietly deleted: two called an arm "a
+control, MUTATION: none" when the battery kills it; one said an arm could not
+see a constant move when it can; and one credited the `vdr -> vr` swap to an
+arm the battery leaves green. A note asserting coverage is a claim like any
+other, so write it AFTER the run and put the measured count in it.
+
+Conventions (from #725/#731/#732/#737 and CLAUDE.md): REAL parser
+dataclasses; every assertion names the single-line MUTATION that must kill
+it, with the count the battery measured; assert you are ON the branch before
+asserting about it; every refusal paired with an acceptance that still
+happens. The battery itself ships, as `tests/mutate_750.py`.
+
+Runs in-process in ~4 s; the only shelling out is one `git ls-files`.
+
+    python3 tests/test_750_fanout_clearance_via_drill.py
+"""
+from __future__ import annotations
+
+RUN_ALL_FAST_OK = True
+RUN_ALL_TIMEOUT = 900
+
+import contextlib
+import inspect
+import io
+import math
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+
+_TESTS = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_TESTS)
+for _p in ('', 'py_router', 'py_placer', 'py_tools'):
+    _d = os.path.join(_ROOT, _p)
+    if _d not in sys.path:
+        sys.path.insert(0, _d)
+if _TESTS not in sys.path:
+    sys.path.insert(0, _TESTS)
+
+import run_utils
+import routing_defaults as defaults
+from kicad_parser import BoardInfo, parse_kicad_pcb
+from synth import make_pad, make_pcb, make_via
+from placement import fanout_clearance as FC
+from placement.fanout_clearance import (_UNREADABLE_VIA_DRILL, _via_drill_radius,
+                                        _via_radius, nudge_vias_for_unresolved)
+
+# --- the rig ---------------------------------------------------------------
+CLEAR = 0.1
+MAX_SHIFT = 0.15               # two rings: r = 0.05 and 0.10 (and 0.15)
+V_SIZE = 0.5
+VR = V_SIZE / 2.0              # 0.25 -- with CLEAR, the cap gate needs 0.35
+VIA0 = (3.0, 3.0)              # the offending via, net 3
+LANDING = (3.05, 3.0)          # the ONLY candidate the cap rect admits
+NEIGH = (3.30, 3.0)            # a SAME-NET neighbour: isolates the drill term
+H_DRILL = 1.0                  # the NPTH hole; prad 0.50
+PRAD = H_DRILL / 2.0
+
+# The function's own literals, mirrored here because they are FUNCTION-LOCAL
+# (fanout_clearance.py, inside nudge_vias_for_unresolved) and cannot be
+# imported. TestOneDrillRule re-reads them out of the source, so a change to
+# either fails loudly instead of silently invalidating the arithmetic below.
+H2H_VIA = 0.2
+H2H_PAD = 0.45
+
+# A foreign-net (2) cap pad rect whose right edge is 0.32 from the via -- just
+# inside the offender threshold VR + CLEAR = 0.35, so the cap is grazed and the
+# offender loop runs -- while the r = 0.05 candidate at (3.05, 3.00) sits 0.37
+# from it and is admitted. Every other candidate on the first two rings is
+# either closer to the rect or off the +x ray, which is what makes LANDING the
+# only one and lets a refusal be asserted as `moves == []`.
+RECT = (2.0, 2.9, 2.68, 3.1, 2)
+
+# The value the three removed sites hard-coded, mirrored the way test_732
+# mirrors OLD_NUDGER_RADIUS. Every "the two spellings differ" arm below is
+# vacuous unless the drill it uses forces a branch where they do.
+OLD_NUDGER_DRILL_RADIUS = 0.3 / 2.0
+
+# Arm C's two hole positions and the bracket they impose on the fallback.
+BRACKET_REFUSE_X = 4.12        # candidate 1.07 away -> refused  => f > 0.24
+BRACKET_ACCEPT_X = 4.20        # candidate 1.15 away -> accepted => f <= 0.40
+BRACKET_LO, BRACKET_HI = 0.24, 0.40
+
+
+class _FakeCap:
+    """Minimal stand-in for _Cap: fixed pad rects, never moves."""
+
+    def __init__(self, rects):
+        self._rects = list(rects)
+        self.x = self.y = self.rot = 0.0
+
+    def pad_rects(self, x=None, y=None, rot=None):
+        return self._rects
+
+
+class _FakeSt:
+    """The duck-typed `st` the #370/#617 harnesses pass: no resolvers at all,
+    so every requirement in the nudger falls back to the flat scalar."""
+
+    #: A REAL `st` is a `_Repair` and carries this. The duck type must too, or
+    #: the most likely wrong hole floor -- `max(clearance, getattr(st,
+    #: 'npth_floor', 0.0))` -- reads 0.0 here, behaves exactly like the right
+    #: one, and is caught by nothing (test_737 measured that). 0.40 is above
+    #: every gap these rigs use, so a gate that reads it refuses landings the
+    #: checker calls clean.
+    npth_floor = 0.40
+
+    def __init__(self, rects):
+        self.caps = {'C1': _FakeCap(rects)}
+        self.vias = []
+
+    def graze_penalty(self, ref, cap, x, y, rot):
+        return 1.0          # permanently unresolved, so the offender loop RUNS
+
+
+def _nudge(st, pcb, clear=CLEAR, **kw):
+    """Drive the real pass, capturing what it printed. The PRINTED OUTPUT is
+    half the evidence: a refusal that prints nothing is indistinguishable from
+    a pass that never looked (the #732 silent-failure lesson)."""
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        moves, segs = nudge_vias_for_unresolved(st, pcb, clear, **kw)
+    return moves, segs, buf.getvalue()
+
+
+def _bi():
+    return BoardInfo(layers={}, copper_layers=['F.Cu', 'B.Cu'],
+                     board_bounds=(0.0, 0.0, 8.0, 8.0))
+
+
+def _neighbour_board(v_drill, ov_drill):
+    """Arm A: the offending via plus ONE same-net neighbour, no pads at all."""
+    v = make_via(VIA0[0], VIA0[1], net_id=3, size=V_SIZE, drill=v_drill)
+    ov = make_via(NEIGH[0], NEIGH[1], net_id=3, size=V_SIZE, drill=ov_drill)
+    pcb = make_pcb(board_info=_bi(), vias=[v, ov], segments=[], footprints={},
+                   pads_by_net={}, zones=[])
+    return v, ov, pcb
+
+
+def _hole_board(v_drill, hole_x):
+    """Arm B/C: the offending via plus ONE NPTH hole, and NO second via, so
+    the via-to-via gate cannot contribute."""
+    v = make_via(VIA0[0], VIA0[1], net_id=3, size=V_SIZE, drill=v_drill)
+    hole = make_pad(net_id=0, x=hole_x, y=VIA0[1], ref='H1REF', num='H1',
+                    size_x=H_DRILL, size_y=H_DRILL, shape='circle',
+                    layers=['F.Mask', 'B.Mask'], drill=H_DRILL,
+                    pad_type='np_thru_hole')
+    pcb = make_pcb(board_info=_bi(), vias=[v], segments=[], footprints={},
+                   pads_by_net={0: [hole]}, zones=[])
+    return v, hole, pcb
+
+
+def _run(pcb):
+    moves, segs, out = _nudge(_FakeSt([RECT]), pcb, max_shift=MAX_SHIFT)
+    land = (moves[0][2]['x'], moves[0][2]['y']) if moves else None
+    return moves, segs, out, land
+
+
+def _old_threshold(a, b, floor):
+    """What the REMOVED spelling computed. Kept as an executable expression
+    rather than a number in a comment, so the numbers in the docstring above
+    can be re-derived by reading this file."""
+    return (a or 0.3) / 2.0 + (b or 0.3) / 2.0 + floor
+
+
+class TestTheGateThatStoppedFiring(unittest.TestCase):
+    """A negative drill made the via-to-via hole-to-hole term NEGATIVE, and
+    two of them switched the gate off entirely."""
+
+    def test_a_sane_drill_is_refused_by_BOTH_spellings(self):
+        """The control. Without it every refusal below could be a rig that
+        refuses everything."""
+        v, ov, pcb = _neighbour_board(0.3, 0.3)
+        # ON THE BRANCH: the fallback is NOT taken, so this arm is about the
+        # declared value and the two spellings must agree.
+        self.assertTrue(v.drill and ov.drill, 'this arm needs declared drills')
+        self.assertAlmostEqual(_old_threshold(0.3, 0.3, H2H_VIA), 0.5, places=9)
+        moves, _segs, out, _land = _run(pcb)
+        self.assertIn('no clear spot', out)
+        self.assertEqual(moves, [])
+    # MUTATION: h2h-via-gate-deleted -- a refusal that is the gate's, so
+    # deleting the gate turns it into a move. Killed by 1 row; it is also the
+    # control that makes the -0.3 rows below mean something.
+
+    def test_a_NEGATIVE_drill_no_longer_buys_a_landing(self):
+        """d7658c93 moved the via here; d04a9c07 refuses it."""
+        v, ov, pcb = _neighbour_board(-0.3, 0.3)
+        # ON THE BRANCH, two guards: the removed spelling really did go
+        # negative on this input, and the resolver really does not.
+        self.assertLess((v.drill or 0.3) / 2.0, 0.0,
+                        'the drill is not negative, so the old spelling and '
+                        'the resolver agree and this arm cannot fail')
+        self.assertAlmostEqual(_via_drill_radius(v), OLD_NUDGER_DRILL_RADIUS,
+                               places=9)
+        # ... and the landing sits in the window the two thresholds straddle.
+        d = math.hypot(LANDING[0] - NEIGH[0], LANDING[1] - NEIGH[1])
+        self.assertAlmostEqual(d, 0.25, places=9)
+        self.assertLess(_old_threshold(-0.3, 0.3, H2H_VIA), d,
+                        'the OLD threshold does not admit this landing, so '
+                        'the arm proves nothing about the change')
+        self.assertGreater(_via_drill_radius(v) + _via_drill_radius(ov)
+                           + H2H_VIA, d)
+        moves, _segs, out, _land = _run(pcb)
+        self.assertIn('no clear spot', out)
+        self.assertEqual(moves, [])
+    # MUTATION: the guard back to `or` -> the via moves to (3.05, 3.00) and
+    # both the print and the count assertions fail. This arm kills 6 of the
+    # battery's 15 rows -- the two guard re-spellings, both constant moves,
+    # the diameter/radius slip, and the deleted gate.
+
+    def test_TWO_negative_drills_switched_the_gate_OFF(self):
+        """The headline. A threshold of -0.10mm is one no distance can
+        undercut -- the gate is not weakened, it is inoperative, and the pass
+        parked the via at HALF the fab hole-to-hole floor."""
+        v, ov, pcb = _neighbour_board(-0.3, -0.3)
+        # ON THE BRANCH: the removed spelling's threshold really is negative.
+        old_t = _old_threshold(-0.3, -0.3, H2H_VIA)
+        self.assertLess(old_t, 0.0, 'the old threshold is not negative here, '
+                                    'so "the gate cannot fire" is not what '
+                                    'this arm is testing')
+        self.assertAlmostEqual(old_t, -0.1, places=9)
+        # What the same two barrels require once the drill is read sanely.
+        sane = _old_threshold(0.3, 0.3, H2H_VIA)
+        d = math.hypot(LANDING[0] - NEIGH[0], LANDING[1] - NEIGH[1])
+        self.assertAlmostEqual(d / sane, 0.5, places=9,
+                               msg='the landing is no longer exactly half the '
+                                   'sane floor; restate the docstring')
+        moves, _segs, out, _land = _run(pcb)
+        self.assertIn('no clear spot', out)
+        self.assertEqual(moves, [])
+    # MUTATION: the guard back to `or` -> 1 move to (3.05, 3.00), 0.2500 from
+    # a neighbour whose sane floor is 0.5000.
+
+    def test_a_falsy_drill_is_inert_across_the_change(self):
+        """0.0 substitutes identically in both spellings -- the fallback is
+        NOT where the behaviour moved, and saying so is half the honesty of
+        this file."""
+        v, _ov, pcb = _neighbour_board(0.0, 0.3)
+        self.assertFalse(v.drill, 'the via declares a drill, so the fallback '
+                                  'branch is not taken and this arm is vacuous')
+        self.assertAlmostEqual(_old_threshold(0.0, 0.3, H2H_VIA),
+                               _via_drill_radius(v) + 0.15 + H2H_VIA, places=9)
+        moves, _segs, out, _land = _run(pcb)
+        self.assertIn('no clear spot', out)
+        self.assertEqual(moves, [])
+    # MUTATION: either constant move -> the substituted radius changes and
+    # the ON-THE-BRANCH equality between the two spellings fires. Killed by 4
+    # rows. (An earlier version of this note claimed the arm could NOT see a
+    # constant move; the battery says otherwise, which is why the notes are
+    # written after it runs and carry its counts.)
+
+
+class TestEachViaContributesITSOWNDrill(unittest.TestCase):
+    """The via-to-via gate sums TWO resolved radii, and arm A cannot tell them
+    apart: -0.3 and 0.3 both resolve to 0.15, so `vdr + ovdr` and `vdr + vdr`
+    are the same number there. The battery said so -- those mutations were
+    killed only by the source guard. These two arms give the neighbour a
+    DIFFERENT drill (0.5 -> 0.25) and place it where each mutation flips a
+    decision, so the gate is pinned behaviourally as well as structurally.
+
+    v.drill 0.3 -> 0.15, ov.drill 0.5 -> 0.25, so the correct floor is
+    0.15 + 0.25 + 0.20 = 0.60. `vdr + vdr` gives 0.50 and the H2H_PAD typo
+    gives 0.85, and one landing distance sits inside each gap."""
+
+    #: 0.55 is between the mutant floor (0.50) and the correct one (0.60):
+    #: correct REFUSES, `vdr + vdr` accepts.
+    NEAR = (LANDING[0] + 0.55, LANDING[1])
+    #: 0.70 is between the correct floor (0.60) and the H2H_PAD typo (0.85):
+    #: correct ACCEPTS, the typo refuses.
+    FAR = (LANDING[0] + 0.70, LANDING[1])
+
+    def _board(self, neigh):
+        v = make_via(VIA0[0], VIA0[1], net_id=3, size=V_SIZE, drill=0.3)
+        ov = make_via(neigh[0], neigh[1], net_id=3, size=V_SIZE, drill=0.5)
+        pcb = make_pcb(board_info=_bi(), vias=[v, ov], segments=[],
+                       footprints={}, pads_by_net={}, zones=[])
+        return v, ov, pcb
+
+    def test_the_two_drills_really_are_different(self):
+        """ON THE BRANCH for both arms below. Without this the pair is arm A
+        again, and every mutation that swaps one term for the other survives
+        -- which is exactly what the first version of this file did."""
+        v, ov, _pcb = self._board(self.NEAR)
+        self.assertNotAlmostEqual(_via_drill_radius(v), _via_drill_radius(ov),
+                                  places=9,
+                                  msg='the neighbour resolves to the same '
+                                      'radius as the mover, so vdr + ovdr and '
+                                      'vdr + vdr are indistinguishable here')
+        self.assertAlmostEqual(_via_drill_radius(v) + _via_drill_radius(ov)
+                               + H2H_VIA, 0.6, places=9)
+
+    def test_a_neighbour_inside_the_SUMMED_floor_is_refused(self):
+        v, ov, pcb = self._board(self.NEAR)
+        d = math.hypot(LANDING[0] - ov.x, LANDING[1] - ov.y)
+        self.assertAlmostEqual(d, 0.55, places=9)
+        self.assertLess(d, _via_drill_radius(v) + _via_drill_radius(ov)
+                        + H2H_VIA)
+        self.assertGreater(d, 2 * _via_drill_radius(v) + H2H_VIA,
+                           'the landing also clears the MOVER-doubled floor, '
+                           'so this arm cannot see that mutation')
+        moves, _segs, out, _land = _run(pcb)
+        self.assertIn('no clear spot', out)
+        self.assertEqual(moves, [])
+    # MUTATION: `vdr + ovdr` -> `vdr + vdr` at the via-to-via gate -> the
+    # floor falls to 0.50, the landing at 0.55 is admitted, and the via moves.
+
+    def test_a_neighbour_outside_it_is_still_ADMITTED(self):
+        """The acceptance half. Without it the arm above is satisfied by any
+        rig that refuses everything, and the H2H_PAD typo -- which only ever
+        makes the gate stricter -- would have nothing to fail."""
+        v, ov, pcb = self._board(self.FAR)
+        d = math.hypot(LANDING[0] - ov.x, LANDING[1] - ov.y)
+        self.assertAlmostEqual(d, 0.7, places=9)
+        self.assertGreater(d, _via_drill_radius(v) + _via_drill_radius(ov)
+                           + H2H_VIA)
+        self.assertLess(d, _via_drill_radius(v) + _via_drill_radius(ov)
+                        + H2H_PAD,
+                        'the landing also clears the PAD floor, so swapping '
+                        'the two floors here would change nothing')
+        moves, _segs, _out, land = _run(pcb)
+        self.assertEqual(len(moves), 1)
+        self.assertEqual(land, LANDING)
+    # MUTATION: H2H_VIA -> H2H_PAD at the via-to-via gate -> the floor rises
+    # to 0.85, every candidate is refused, and this move disappears.
+
+
+class TestTheCapsuleGateReadsTheSameResolver(unittest.TestCase):
+    """The other site: the via's drill against a board pad's drill capsule.
+    A separate arm because a fix applied to one line and not the other is
+    exactly the class of bug #750 exists to remove."""
+
+    def test_a_NEGATIVE_drill_no_longer_buys_a_landing_at_the_CAPSULE(self):
+        v, _hole, pcb = _hole_board(-0.3, 3.95)
+        # ON THE BRANCH: no second via, so the via-to-via gate cannot be what
+        # decides this -- the capsule gate is alone.
+        self.assertEqual(len(pcb.vias), 1)
+        d = abs(LANDING[0] - 3.95)
+        self.assertAlmostEqual(d, 0.9, places=9)
+        self.assertLess((-0.3) / 2.0 + PRAD + H2H_PAD, d,
+                        'the OLD capsule floor does not admit this landing')
+        self.assertGreater(_via_drill_radius(v) + PRAD + H2H_PAD, d,
+                           'the NEW capsule floor does not refuse it either, '
+                           'so the arm separates nothing')
+        moves, _segs, out, _land = _run(pcb)
+        self.assertIn('no clear spot', out)
+        self.assertEqual(moves, [])
+    # MUTATION: the guard back to `or` -> 1 move to (3.05, 3.00), 0.9000
+    # from a hole whose sane floor is 1.1000. Killed by 3 rows, including
+    # `literal-restored-at-the-capsule-gate` -- the evasion that keeps the
+    # constant's NAME while restoring the old semantics. NOT by swapping
+    # `vdr` for `vr` here: measured, that leaves this arm green (the bracket
+    # arms and the writer arm catch it instead).
+
+    def test_the_sane_drill_control_at_the_capsule(self):
+        v, _hole, pcb = _hole_board(0.3, 3.95)
+        self.assertTrue(v.drill)
+        moves, _segs, out, _land = _run(pcb)
+        self.assertIn('no clear spot', out)
+        self.assertEqual(moves, [])
+    # MUTATION: none -- a control.
+
+
+class TestTheFallbackResolvesToExactlyPointThree(unittest.TestCase):
+    """The branch no test in this repo had ever executed, on either gate.
+
+    Pinning `_UNREADABLE_VIA_DRILL == 0.3` is a source assertion. These two
+    arms pin it BEHAVIOURALLY, by placing the hole so the resolved value
+    lands between an acceptance and a refusal, which brackets it to
+    (0.24, 0.40] -- and by showing a declared 0.3 lands identically, which a
+    fallback of 0, or of _UNREADABLE_VIA_SIZE (0.5), would not."""
+
+    def _land(self, v_drill, hole_x):
+        v, _hole, pcb = _hole_board(v_drill, hole_x)
+        # ON THE BRANCH: for the 0.0/None rows the fallback really is taken.
+        if not v_drill:
+            self.assertFalse(v.drill, 'the fallback branch is not taken')
+        moves, _segs, _out, land = _run(pcb)
+        return len(moves), land
+
+    def test_the_fallback_is_REFUSED_where_a_smaller_one_would_pass(self):
+        d = abs(LANDING[0] - BRACKET_REFUSE_X)
+        self.assertAlmostEqual(d, 1.07, places=9)
+        for drill in (0.0, None):
+            with self.subTest(drill=drill):
+                self.assertEqual(self._land(drill, BRACKET_REFUSE_X), (0, None))
+        # ... and the same board with the value DECLARED behaves identically,
+        # which is the whole claim: the fallback resolves to 0.3, not near it.
+        self.assertEqual(self._land(0.3, BRACKET_REFUSE_X), (0, None))
+        self.assertGreater(_UNREADABLE_VIA_DRILL, BRACKET_LO,
+                           'a fallback at or below %.2f would ACCEPT this '
+                           'landing' % BRACKET_LO)
+    # MUTATION: the constant to 0.2 (or 0.1, or 0) -> the floor falls below
+    # 1.07 and all three rows move.
+
+    def test_the_fallback_is_ACCEPTED_where_a_larger_one_would_not(self):
+        d = abs(LANDING[0] - BRACKET_ACCEPT_X)
+        self.assertAlmostEqual(d, 1.15, places=9)
+        for drill in (0.0, None, 0.3):
+            with self.subTest(drill=drill):
+                self.assertEqual(self._land(drill, BRACKET_ACCEPT_X),
+                                 (1, LANDING))
+        self.assertLessEqual(_UNREADABLE_VIA_DRILL, BRACKET_HI,
+                             'a fallback above %.2f would REFUSE this landing'
+                             % BRACKET_HI)
+        # The negative control that keeps the pair honest: a LARGER declared
+        # drill on the same board does refuse, so the gate is live here and
+        # the acceptance above is not "this rig accepts everything".
+        self.assertEqual(self._land(0.5, BRACKET_ACCEPT_X), (0, None))
+    # MUTATION: the constant to 0.5 -> the 0.0 and None rows refuse while the
+    # 0.3 row still moves, so the subTest reports which row diverged.
+
+
+class TestTheTwoResolversAgree(unittest.TestCase):
+    """#750 is #732's rule applied to the drill, and `via_rad`'s docstring
+    already stated that rule for the size. These arms pin that the two
+    functions take the same branch on the same inputs -- the property a later
+    edit to either would break silently."""
+
+    #: (value, takes-the-fallback). Note what is NOT here and why:
+    #: `nan` -- both spellings propagate it and `d < nan + ...` is False
+    #: either way, so a NaN arm would be vacuous rather than reassuring.
+    CASES = ((None, True), (0, True), (0.0, True), (-0.0, True),
+             (False, True), (-1e-9, True), (-0.3, True), (-1.0, True),
+             (0.15, False), (0.2, False), (0.3, False), (0.5, False),
+             (1.0, False))
+
+    #: Detecting "did it substitute?" by comparing the ANSWER to the
+    #: constant does not work, and getting that wrong is the first thing this
+    #: file did: `_via_drill_radius(drill=0.3)` returns 0.15, which is exactly
+    #: what the fallback returns, so the test passed the value through and
+    #: read it as a substitution. Both resolvers take the default as a
+    #: PARAMETER, so pass one nothing else could produce and read the branch
+    #: off the answer.
+    SENTINEL = 9.0
+
+    def test_the_drill_resolver_branches_exactly_as_the_size_one_does(self):
+        for val, is_fallback in self.CASES:
+            with self.subTest(val=val):
+                d = _via_drill_radius(SimpleNamespace(drill=val), self.SENTINEL)
+                s = _via_radius(SimpleNamespace(size=val), self.SENTINEL)
+                took_d = (d == self.SENTINEL / 2.0)
+                took_s = (s == self.SENTINEL / 2.0)
+                self.assertEqual(took_d, is_fallback,
+                                 'the drill resolver %s the default on %r'
+                                 % ('took' if took_d else 'did not take', val))
+                self.assertEqual(took_d, took_s,
+                                 'the two resolvers take DIFFERENT branches '
+                                 'on %r' % (val,))
+    # MUTATION: the guard to `if d is None or d == 0` -> every negative row
+    # stops taking the fallback and the assertEqual fires with the value.
+
+    def test_minus_zero_does_NOT_differ_and_that_is_why_it_is_here(self):
+        """`-0.0` is falsy, so both spellings substitute. Recorded as its own
+        arm so nobody "tidies" a -0.3 elsewhere in this file into a -0.0 and
+        turns a real arm vacuous."""
+        self.assertAlmostEqual((-0.0 or 0.3) / 2.0,
+                               _via_drill_radius(SimpleNamespace(drill=-0.0)),
+                               places=12)
+    # MUTATION: both constant moves and the diameter/radius slip -- killed
+    # by 3 rows. It documents a NON-difference between the two SPELLINGS, not
+    # an absence of coverage.
+
+    def test_a_via_like_with_no_drill_is_priced_rather_than_crashing(self):
+        """The SECOND behavioural delta, and the one an earlier draft of the
+        PR body missed. The removed expression raised AttributeError here."""
+        blank = SimpleNamespace()
+        with self.assertRaises(AttributeError):
+            (blank.drill or 0.3) / 2.0          # what the three sites did
+        self.assertAlmostEqual(_via_drill_radius(blank),
+                               _UNREADABLE_VIA_DRILL / 2.0, places=12)
+    # MUTATION: drop the `getattr` for `via.drill` -> this arm ERRORS (not
+    # fails), which is why the battery counts an error as a kill.
+
+    def test_the_constant_agrees_with_the_toolchains_own_via_drill_TODAY(self):
+        """A self-expiring change detector, NOT a wiring. They are separate
+        questions -- see the constant's comment -- and they happen to agree."""
+        self.assertEqual(_UNREADABLE_VIA_DRILL, 0.3)
+        self.assertEqual(_UNREADABLE_VIA_DRILL, defaults.VIA_DRILL,
+                         'routing_defaults.VIA_DRILL has moved. These are '
+                         'deliberately NOT wired together (a fab default vs a '
+                         'pricing assumption); re-read the constant\'s comment '
+                         'and decide, do not just nudge this number')
+    # MUTATION: the constant to anything else -> both assertions fire.
+
+
+class TestOneDrillRule(unittest.TestCase):
+    """A source guard, because the bug was not a wrong number -- it was N
+    numbers. Scoped to the FUNCTION and comment-stripped: `(v.drill or 0.3)`
+    appears in _via_drill_radius's own docstring describing what it replaced,
+    and a module-wide raw-line scan would flag it (test_737:480-486 records
+    the same false-positive class)."""
+
+    @staticmethod
+    def _src():
+        return [l.split('#')[0] for l in
+                inspect.getsource(FC.nudge_vias_for_unresolved).splitlines()]
+
+    def _hits(self, needle):
+        return [i + 1 for i, l in enumerate(self._src()) if needle in l]
+
+    def test_no_site_resolves_a_via_drill_its_own_way(self):
+        src = self._src()
+        # ON THE BRANCH: the resolver exists at all.
+        self.assertTrue(callable(_via_drill_radius))
+        for gone, where in (('.drill or 0.3', 'the two hole-to-hole gates'),
+                            ('.drill or ', 'any drill fallback at all')):
+            hits = ['%d: %s' % (i + 1, l.strip())
+                    for i, l in enumerate(src) if gone in l]
+            # Report the offending LINES, not the whole function: an
+            # assertNotIn on a source haystack prints the haystack (#732
+            # measured 393KB for one such failure).
+            self.assertEqual(hits, [],
+                             '%s still resolves a drill inline -- %s'
+                             % (where, '; '.join(hits)))
+
+    def test_the_resolver_is_actually_CALLED_twice_and_where(self):
+        """Absence alone is evadable: `(ov.drill or _UNREADABLE_VIA_DRILL)`
+        would pass the arm above and restore the old semantics exactly. So
+        count the positive form too, in the shape test_737:487-495 uses."""
+        self.assertEqual(len(self._hits('vdr = _via_drill_radius(v)')), 1,
+                         'the per-via hoist is gone or duplicated')
+        self.assertEqual(len(self._hits('_via_drill_radius(ov)')), 1,
+                         'the per-offender resolve is gone or duplicated')
+        self.assertEqual(len(self._hits('vdr + prad + H2H_PAD')), 1,
+                         'the pad drill-capsule gate no longer reads vdr')
+        self.assertEqual(len(self._hits('vdr + ovdr + H2H_VIA')), 1,
+                         'the via-to-via gate no longer reads the resolver')
+
+    def test_the_offender_radii_are_resolved_BEFORE_the_candidate_sweep(self):
+        """Not a style point. The gate runs inside the 16-angle x 12-radius
+        sweep, so resolving there costs one call per via per CANDIDATE -- and
+        this file's own neighbours (board_pads) are flattened here for
+        exactly that reason, in a comment that says so."""
+        pre = self._hits('_via_drill_radius(ov)')
+        use = self._hits('vdr + ovdr + H2H_VIA')
+        self.assertEqual((len(pre), len(use)), (1, 1))
+        self.assertLess(pre[0], use[0],
+                        'the precompute no longer precedes the gate that '
+                        'reads it, so it is not a precompute')
+
+    def test_this_files_mirrored_floors_are_still_the_engines(self):
+        """H2H_VIA/H2H_PAD are function-local literals and cannot be
+        imported, so every threshold computed above is a hand mirror."""
+        joined = ' '.join(self._src())
+        for name, val in (('H2H_VIA', H2H_VIA), ('H2H_PAD', H2H_PAD)):
+            self.assertIn('%s = %s' % (name, val), joined,
+                          "the engine's %s is no longer %s, so this file's "
+                          'mirror -- and every ON-THE-BRANCH threshold in it '
+                          '-- is stale' % (name, val))
+    # MUTATION: H2H_VIA -> H2H_PAD at the via-to-via gate is a typo class this
+    # does NOT catch (both names still exist); the behavioural arms do.
+
+
+class TestThePadSideStillRefusesToInvent(unittest.TestCase):
+    """The asymmetry is the point, not an oversight: the pad half of the
+    capsule comparison is always MEASURED, and only the via half was made up.
+    A later "consistency" pass must not level it the other way."""
+
+    def test_a_pad_with_no_drill_gets_no_capsule_rather_than_a_default(self):
+        src = ' '.join(l.split('#')[0] for l in
+                       inspect.getsource(FC.nudge_vias_for_unresolved)
+                       .splitlines())
+        self.assertIn('pad_drill_capsule(p) if (p.drill and p.drill > 0)', src,
+                      'the pad capsule now has a fallback of its own; #750 '
+                      'named the VIA drill precisely because the pad drill '
+                      'beside it is measured')
+
+    def test_the_writer_still_emits_the_drill_the_board_declared(self):
+        """The gate prices an unreadable drill at 0.3; the writer must still
+        re-emit whatever the via actually carried. A resolver that leaked into
+        the payload would silently re-drill the board."""
+        v, _hole, pcb = _hole_board(0.0, BRACKET_ACCEPT_X)
+        moves, _segs, _out, land = _run(pcb)
+        # ON THE BRANCH: this board is one where the via DOES move.
+        self.assertEqual(land, LANDING)
+        self.assertEqual(moves[0][2]['drill'], 0.0,
+                         'the nudge re-emitted the RESOLVED drill instead of '
+                         'the declared one')
+    # MUTATION: `'drill': v.drill` -> `'drill': _via_drill_radius(v) * 2` in
+    # the via_moves payload -> this fires with 0.3.
+
+
+class TestInertOnTheTrackedCorpus(unittest.TestCase):
+    """Every changed expression is gated on a falsy or negative drill, and no
+    tracked board has one -- so the change is provably inert on the corpus.
+    Asserted rather than narrated, and self-expiring."""
+
+    def test_no_tracked_via_has_a_falsy_or_negative_drill(self):
+        boards = run_utils.corpus_boards()
+        if not boards:
+            print('SKIP: git cannot identify the tracked corpus')
+            self.skipTest('no git')
+        # The COUNT guard comes from the production selector, not from what I
+        # happened to observe: corpus_boards() is `git ls-files`, and a plain
+        # glob of kicad_files/ returns 33 in a used working copy (#746 shipped
+        # a bound whose candidate set excluded its own counterexample).
+        self.assertGreaterEqual(len(boards), 20,
+                                'the tracked corpus collapsed; this arm '
+                                'proves nothing')
+        total = 0
+        offenders = []
+        smallest = None
+        for b in boards:
+            try:
+                pcb = parse_kicad_pcb(b)
+            except Exception:                                    # noqa: BLE001
+                continue
+            for v in pcb.vias:
+                total += 1
+                if not v.drill or v.drill <= 0:
+                    offenders.append((os.path.basename(b), v.x, v.y, v.drill))
+                elif smallest is None or v.drill < smallest:
+                    smallest = v.drill
+        self.assertGreater(total, 500,
+                           'only %d vias found; the corpus scan is not '
+                           'reading the boards' % total)
+        self.assertEqual(offenders, [],
+                         'a tracked board now carries a via with a falsy or '
+                         'negative drill: %r. The "inert on the corpus" claim '
+                         'in the #750 PR has EXPIRED -- re-run the '
+                         'before/after sweep and record the new numbers'
+                         % (offenders,))
+        self.assertGreater(smallest, 0.0)
+    # MUTATION: none -- a self-expiring corpus bound, not a fix assertion.
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/test_750_fanout_clearance_via_drill.py
+++ b/tests/test_750_fanout_clearance_via_drill.py
@@ -92,26 +92,33 @@ minimum on the corpus is 0.15). Stated as 602/22, not the issue's 604/27 --
 that figure is the repo-wide `*.kicad_pcb` set, five of which live under
 tests/fixtures/.
 
-MUTATION BATTERY, 15 rows against the engine: 13 killed, 2 SURVIVED and both
+MUTATION BATTERY, 16 rows against the engine: 14 killed, 2 SURVIVED and both
 expected, 0 broken. The counts make the `# MUTATION:` notes checkable rather
 than decorative, so they are recorded here and the battery itself ships as
 `tests/mutate_750.py`:
 
     returns-the-diameter-not-the-radius     19 assertions  every arithmetic arm
     constant-raised-to-0.5                   8             bracket, upper half
+    h2h-via-gate-deleted                     8             + perturbs test_732
     constant-lowered-to-0.2                  7             bracket, lower half
-    h2h-via-gate-deleted                     7             + perturbs test_732
     guard-reverted-to-or                     6             THE DEFECT
     guard-is-none-or-equals-zero             6             still admits negatives
     capsule-gate-reads-the-COPPER-radius     5             vdr -> vr
-    offender-drill-resolved-with-the-movers  3             vdr + vdr
+    offender-drill-resolved-with-the-movers  4             vdr + vdr
     h2h-via-floor-swapped-for-the-pad-one    3             the typo class
     literal-restored-at-the-capsule-gate     3             the source-guard evasion
-    precompute-inlined-per-candidate         2             SOURCE guards only
+    precompute-inlined-per-candidate         3             SOURCE guards only
     getattr-dropped                          1             as an ERROR
+    positions-cached-alongside-the-radius    1             SOURCE guard only
     writer-emits-the-RESOLVED-drill          1
     guard-lt-zero-instead-of-le-zero         0  SURVIVED, expected: `not d`
     guard-is-none-instead-of-not-d           0  SURVIVED, expected: already covers it
+
+Two rows are killed by a SOURCE guard and by nothing else, and that is a
+finding rather than a gap: both are semantically inert (a per-candidate
+re-resolve) or need a two-cap geometry a randomized fuzz does not reach (the
+cached-position one -- 400 seeds, 0 catches, because only 8 of them move two
+vias at all). Where a structural guard is the only guard, the arm says so.
 
 FOUR OF THIS FILE'S `# MUTATION:` NOTES WERE WRONG BEFORE THE BATTERY RAN,
 and are corrected in place rather than quietly deleted: two called an arm "a
@@ -653,6 +660,39 @@ class TestOneDrillRule(unittest.TestCase):
         self.assertLess(pre[0], use[0],
                         'the precompute no longer precedes the gate that '
                         'reads it, so it is not a precompute')
+
+    def test_the_gate_reads_the_offenders_position_LIVE(self):
+        """NOT COVERED BEHAVIOURALLY, and disclosed rather than skipped.
+
+        The precompute caches the drill RADIUS and nothing else, and that is
+        the whole of what makes it safe -- "nothing mutates pcb_data.vias" is
+        true and is NOT the invariant. The nudger relocates vias IN PLACE
+        (`v.x, v.y = nx, ny`) and processes caps one after another, so a
+        via's coordinates DO change between iterations. Folding them into the
+        same tuple is the obvious tidy-up and is a real defect: measured on a
+        two-cap rig during review, the second via lands at (5.1061, 6.1061)
+        instead of (5.0500, 6.0000).
+
+        A 400-seed randomized old-vs-new fuzz did NOT catch that mutant --
+        only 8 seeds moved two vias at all -- so a behavioural arm here would
+        be one geometry pretending to be a general guard. The structural form
+        says exactly what it checks."""
+        src = self._src()
+        gate = [i for i, l in enumerate(src) if 'ovdr' in l]
+        self.assertEqual(len(gate), 2, 'the precomputed radius is read in %d '
+                                       'places, expected 2' % len(gate))
+        self.assertIn('for ov, ovdr in board_via_drills', src[gate[0]])
+        # A 2-tuple, so there is nowhere for a position to be cached.
+        self.assertIn('[(ov, _via_drill_radius(ov)) for ov in pcb_data.vias]',
+                      ' '.join(src),
+                      'the precompute now carries more than (via, radius); if '
+                      'that is a POSITION, the gate below is reading a stale '
+                      'one for every via relocated on an earlier cap')
+        # ... and the distance is still taken from the live attributes.
+        dist = [l for l in src if 'math.hypot(nx - ov.x, ny - ov.y)' in l]
+        self.assertEqual(len(dist), 1,
+                         'the via-to-via gate no longer measures to ov.x/ov.y '
+                         'as they are NOW')
 
     def test_this_files_mirrored_floors_are_still_the_engines(self):
         """H2H_VIA/H2H_PAD are function-local literals and cannot be

--- a/tests/test_761_legality_npth_keepout.py
+++ b/tests/test_761_legality_npth_keepout.py
@@ -317,6 +317,18 @@ class TestTheBoardFloorReachesTheKeepOut(unittest.TestCase):
             self.assertEqual(len(hits), want,
                              '%s passes npth_floor at %d site(s), expected '
                              '%d (%s)' % (rel, len(hits), want, who))
+            # ...and passes the RESOLVER, not just the keyword. A site
+            # spelling `npth_floor=None` satisfies a keyword count while
+            # supplying nothing -- which is exactly what the battery row
+            # `quench-passes-no-board-floor` does, and it SURVIVED until this
+            # clause existed.
+            resolved = [i + 1 for i, l in enumerate(src.splitlines())
+                        if 'resolve_npth_floor(' in l.split('#')[0]
+                        and not l.lstrip().startswith('def ')]
+            self.assertGreaterEqual(
+                len(resolved), want,
+                '%s names npth_floor but never calls resolve_npth_floor '
+                '(%s)' % (rel, who))
         for rel in ('py_placer/placement/labels.py',
                     'py_placer/placement/routability.py',
                     'py_placer/placement/seeder.py'):

--- a/tests/test_761_legality_npth_keepout.py
+++ b/tests/test_761_legality_npth_keepout.py
@@ -1,0 +1,605 @@
+#!/usr/bin/env python3
+"""#761: legality's NPTH copper keep-out is the inflation PLUS the clearance.
+
+`PartPads` stores each NPTH hole at the growth ABOVE `clearance`
+(`max(0, requirement - clearance)`) and the copper consumers compared that
+circle against RAW pad rects, adding nothing back -- so the modelled standoff
+from the hole wall was `max(0, requirement - clearance)`, which COLLAPSES TO
+ZERO once `clearance` reaches the requirement.
+
+Both siblings add the term at their own gap test: `fanout_clearance` through
+`_pair_or_flat` (an NPTH tuple files floor `None`, so it hands back the flat
+scalar) and `labels.py` by comparing against `silk_pad_clearance`. legality
+was the only place in the repo using the constant as a subtrahend with no
+matching addend, and the unit test that guarded it
+(`test_npth_hole_inflation_matches_fanout_convention`) is named for the half
+that was right and runs only at `clearance = 0.09`, below the fab floor,
+where the bug is invisible.
+
+Four things this file pins that are easy to get wrong:
+
+  * The keep-out is measured against `check_drc`'s own REQUIREMENT, not
+    against legality's own inflation -- that comparison is the one the defect
+    survived for want of. It is a hand MIRROR and this file says so: a
+    fact-check of the #761 premise established that `check_drc` has NO
+    pad-vs-NPTH-hole arm at all (its `holes` list feeds a TRACK arm and a VIA
+    arm, and the pad-pad check skips NPTH pads), so "grade the corpus with
+    check_drc" is not available as a check on this fix. See
+    `TestParityWithTheChecker`, which pins both the absence and the
+    expression.
+  * The broad phase must reach the hole or the fix is INERT: both early-outs
+    are bounded by pad floors, and an NPTH pad reaches no pad floor.
+    `TestTheBroadPhaseReachesTheHole` fails if either term is dropped.
+  * SILK and EXTENTS must not move. `local_clearance` and the board's declared
+    `min_hole_clearance` are copper rules; `extent_local` asks where a part
+    physically IS, and #730 shipped and then fixed an off-board regression
+    caused by conflating the two.
+  * The corpus bound is SELF-EXPIRING. It is inert at file poses today with
+    ulx3s clearing by 0.010mm; if a board moves, the PR's claim has expired
+    and the arm says so rather than being nudged.
+
+`RUN_ALL_FAST_OK`: every arm is in-process geometry plus board parses. No
+chain runs here.
+"""
+from __future__ import annotations
+
+RUN_ALL_FAST_OK = True
+RUN_ALL_TIMEOUT = 900
+
+import io
+import math
+import os
+import sys
+import unittest
+from types import SimpleNamespace
+
+_TESTS = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_TESTS)
+for _p in ('', 'py_router', 'py_placer', 'py_tools'):
+    _d = os.path.join(_ROOT, _p)
+    if _d not in sys.path:
+        sys.path.insert(0, _d)
+if _TESTS not in sys.path:
+    sys.path.insert(0, _TESTS)
+
+import run_utils
+import routing_defaults as defaults
+from kicad_parser import parse_kicad_pcb, pad_drill_circles
+from check_drc import _pad_has_no_copper
+from obstacle_map import resolve_hole_clearance
+from synth import make_pad, make_pcb
+from placement.legality import (EPS, LegalityContext, PartPads,
+                                _circle_rect_penetration, build_part_pads,
+                                format_required_clause, grade_pad_legality,
+                                resolve_npth_floor)
+
+ULX3S = os.path.join(_ROOT, 'kicad_files', 'ulx3s.kicad_pcb')
+FLAT_HIER = os.path.join(_ROOT, 'kicad_files', 'flat_hierarchy.kicad_pcb')
+SPLITFLAP = os.path.join(_ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
+
+# The fab floor, IMPORTED rather than mirrored -- saying so because a reader
+# who believes it is mirrored will look for a source guard that should not
+# exist.
+NPTH_FLOOR = defaults.NPTH_TO_TRACK_CLEARANCE                        # 0.20
+
+# ulx3s AUDIO1: the two np_thru_hole pads, the ONLY two on the board.
+AUDIO1_DRILL = 1.700
+AUDIO1_LC = 0.400
+AUDIO1_HR = AUDIO1_DRILL / 2.0
+
+# Three holes on ONE footprint whose overrides STRADDLE the fab floor. One
+# hole cannot distinguish per-hole from hoisted, and one override on the same
+# side of the floor as the others cannot distinguish `max` from a bare read.
+E_LCS = (0.00, 0.40, 0.15)
+
+# The measured collapse, before -> after, as the STANDOFF FROM THE HOLE WALL
+# for ulx3s's AUDIO1. `after` is flat because `lc` outranks every clearance
+# here; `before` is the arithmetic the defect implemented.
+COLLAPSE = {0.10: 0.300, 0.20: 0.200, 0.25: 0.150, 0.40: 0.000}
+
+H_DRILL = 2.0
+
+
+def _npth(x, y, lc, ref='H1', drill=H_DRILL, num='H1'):
+    """A copper-less drilled pad. REAL parser dataclasses via synth, not a
+    duck-typed fake: `grade_pad_legality`'s exact re-verification hands pads
+    to check_drc's perimeter sampler, which reads fields a minimal fake does
+    not carry -- and a fake that silently skipped the exact path would test
+    the AABB fallback while claiming to test the census."""
+    p = make_pad(net_id=0, x=x, y=y, ref=ref, num=num,
+                 size_x=drill, size_y=drill, shape='circle',
+                 layers=['F.Mask', 'B.Mask'], drill=drill,
+                 pad_type='np_thru_hole')
+    p.local_clearance = lc
+    return p
+
+
+def _cu(x, y, ref='C1', net=7, sx=1.0, sy=1.0, num='1'):
+    return make_pad(net_id=net, x=x, y=y, ref=ref, num=num,
+                    size_x=sx, size_y=sy, shape='rect', layers=['F.Cu'],
+                    drill=0.0, pad_type='smd')
+
+
+def _fp(ref, x, y, pads, rot=0.0):
+    return SimpleNamespace(reference=ref, x=x, y=y, rotation=rot,
+                           layer='F.Cu', pads=pads)
+
+
+def _e_footprint():
+    """One footprint carrying THREE NPTH holes with different overrides."""
+    return _fp('H1', 10.0, 10.0,
+               [_npth(10.0, 10.0 + 3.0 * i, lc, num='H%d' % (i + 1))
+                for i, lc in enumerate(E_LCS)])
+
+
+def _hole_pair(wall_gap, lc=AUDIO1_LC, clearance=0.25, drill=H_DRILL):
+    """An NPTH hole at the origin and ONE foreign copper pad whose near edge
+    sits `wall_gap` from the hole WALL. Returns (pcb, ctx, poses)."""
+    hr = drill / 2.0
+    cx = hr + wall_gap + 0.5
+    h = _fp('H1', 0.0, 0.0, [_npth(0.0, 0.0, lc)])
+    c = _fp('C1', cx, 0.0, [_cu(cx, 0.0)])
+    fps = {'H1': h, 'C1': c}
+    parts = build_part_pads(fps, clearance)
+    poses = {r: (f.x, f.y, f.rotation) for r, f in fps.items()}
+    ctx = LegalityContext(parts, None, clearance,
+                          pose_of=lambda r: poses[r],
+                          seed_of=lambda r: poses[r])
+    return make_pcb(footprints=fps), ctx, parts
+
+
+class TestTheKeepOutIsTheRequirement(unittest.TestCase):
+    """The collapse, as a change detector."""
+
+    def test_the_standoff_is_max_clearance_floor_lc_at_every_clearance(self):
+        fp = _e_footprint()
+        # ON THE BRANCH: the three overrides straddle the fab floor, else
+        # "different" is vacuous.
+        self.assertGreater(E_LCS[1], NPTH_FLOOR)
+        self.assertLess(E_LCS[2], NPTH_FLOOR)
+        for clearance in (0.05, 0.10, 0.20, 0.25, 0.40, 0.60):
+            pp = PartPads(fp, clearance)
+            got = [round(r, 9) for _x, _y, r in
+                   pp.hole_keepouts(0.0, 0.0, 0.0)]
+            want = [round(H_DRILL / 2.0 + max(clearance, NPTH_FLOOR, lc), 9)
+                    for lc in E_LCS]
+            with self.subTest(clearance=clearance):
+                self.assertEqual(got, want)
+    # MUTATION: keepout-drops-the-clearance (KILLED),
+    # keepout-adds-clearance-twice (KILLED), site-E-loses-the-fab-floor
+    # (KILLED).
+
+    def test_the_standoff_is_NEVER_zero(self):
+        """The specific thing that was wrong. A radius equal to the bare drill
+        means the placer charges only literal drill overlap."""
+        fp = _e_footprint()
+        for clearance in (0.20, 0.25, 0.40, 0.60, 1.0):
+            pp = PartPads(fp, clearance)
+            for (_x, _y, r), (_ex, _ey, _er) in zip(
+                    pp.hole_keepouts(0.0, 0.0, 0.0), pp.holes_local):
+                with self.subTest(clearance=clearance):
+                    self.assertGreater(r - H_DRILL / 2.0, 0.0)
+                    # places=9, not >=: `hd/2 + x` then `- hd/2` is not
+                    # exactly `x` in binary, and 0.3999999999999999 failing a
+                    # `>= 0.4` is a float artefact, not a finding.
+                    self.assertGreaterEqual(
+                        round(r - H_DRILL / 2.0, 9), round(clearance, 9))
+
+    def test_the_measured_collapse_on_ulx3s(self):
+        """The table in the PR, re-derived from the board rather than typed."""
+        pcb = parse_kicad_pcb(ULX3S)
+        fp = pcb.footprints['AUDIO1']
+        for clearance, before in sorted(COLLAPSE.items()):
+            pp = PartPads(fp, clearance)
+            circles = pp.hole_circles(fp.x, fp.y, fp.rotation or 0.0)
+            keepouts = pp.hole_keepouts(fp.x, fp.y, fp.rotation or 0.0)
+            with self.subTest(clearance=clearance):
+                # what the defect modelled: the INFLATION alone
+                self.assertAlmostEqual(circles[0][2] - AUDIO1_HR, before,
+                                       places=6)
+                # what it is now: check_drc's requirement, flat in clearance
+                self.assertAlmostEqual(keepouts[0][2] - AUDIO1_HR, AUDIO1_LC,
+                                       places=6)
+        print('        ulx3s AUDIO1 standoff, was %s -> now %.4f at every one'
+              % ({k: round(v, 3) for k, v in sorted(COLLAPSE.items())},
+                 AUDIO1_LC))
+
+    def test_a_SLOT_hole_keeps_the_term_on_EVERY_sampled_circle(self):
+        """`pad_drill_circles` samples a slot along its capsule axis. A term
+        applied to the first circle only would leave the rest of the slot at
+        the bare drill, which is exactly the shape of the original defect.
+
+        `pad_drill_capsule` reads `drill_w`/`drill_h`, NOT size/shape: a pad
+        with only `shape='oval'` yields a zero-length capsule, and an arm
+        built on one passes while testing nothing. Measured -- the first draft
+        of this arm did exactly that."""
+        p = _npth(5.0, 5.0, AUDIO1_LC, drill=3.0)
+        p.drill_w, p.drill_h = 1.0, 3.0
+        p.size_x, p.size_y = 1.0, 3.0
+        p.shape = 'oval'
+        fp = _fp('H1', 5.0, 5.0, [p])
+        clearance = 0.25
+        pp = PartPads(fp, clearance)
+        circles = pad_drill_circles(p)
+        self.assertGreater(len(circles), 1, 'not a sampled slot; arm is void')
+        self.assertEqual(len(pp.holes_local), len(circles))
+        want = round(circles[0][2] / 2.0
+                     + max(clearance, NPTH_FLOOR, AUDIO1_LC), 9)
+        self.assertEqual(
+            sorted({round(r, 9) for _x, _y, r in
+                    pp.hole_keepouts(0.0, 0.0, 0.0)}), [want])
+
+
+class TestTheBoardFloorReachesTheKeepOut(unittest.TestCase):
+    """#761's third term: the board's own declared min_hole_clearance."""
+
+    def test_the_floor_moves_a_radius_and_the_default_does_not(self):
+        fp = _e_footprint()
+        clearance = 0.10
+        flat = [round(r, 9) for _x, _y, r in
+                PartPads(fp, clearance).hole_keepouts(0, 0, 0)]
+        raised = [round(r, 9) for _x, _y, r in
+                  PartPads(fp, clearance, None, True,
+                           0.25).hole_keepouts(0, 0, 0)]
+        # Only the two holes whose own lc is BELOW 0.25 move; the 0.40 one is
+        # already above it, which is what makes this a max and not a set.
+        self.assertEqual([a == b for a, b in zip(flat, raised)],
+                         [False, True, False])
+        self.assertEqual(
+            flat, [round(r, 9) for _x, _y, r in
+                   PartPads(fp, clearance, None, True, None
+                            ).hole_keepouts(0, 0, 0)])
+    # MUTATION: npth-floor-ignored (KILLED).
+
+    def test_a_floor_BELOW_the_fab_floor_cannot_lower_anything(self):
+        fp = _e_footprint()
+        base = [round(r, 9) for _x, _y, r in
+                PartPads(fp, 0.05).hole_keepouts(0, 0, 0)]
+        for lowered in (0.0, 0.05, 0.19):
+            with self.subTest(npth_floor=lowered):
+                self.assertEqual(
+                    base, [round(r, 9) for _x, _y, r in
+                           PartPads(fp, 0.05, None, True, lowered
+                                    ).hole_keepouts(0, 0, 0)])
+
+    def test_flat_hierarchy_is_the_ONE_witness_on_the_corpus(self):
+        """Selected the way the engine selects -- `resolve_hole_clearance` per
+        board, never a name grep -- so it expires if another board declares."""
+        boards = run_utils.corpus_boards()
+        if not boards:
+            print('SKIP: git cannot identify the tracked corpus')
+            self.skipTest('no git')
+        declaring = {}
+        for b in boards:
+            pcb = parse_kicad_pcb(b)
+            floor = resolve_npth_floor(pcb)
+            if floor > NPTH_FLOOR + 1e-9:
+                declaring[os.path.basename(b)] = round(floor, 4)
+        self.assertEqual(declaring, {'flat_hierarchy.kicad_pcb': 0.25},
+                         'the set of tracked boards declaring above the fab '
+                         'floor has CHANGED: %r -- the #761 PR says '
+                         'flat_hierarchy is the single witness, and that claim '
+                         'has EXPIRED' % declaring)
+        # ...and it is a witness only because its own holes declare nothing,
+        # so the floor is the term that moves them.
+        pcb = parse_kicad_pcb(FLAT_HIER)
+        lcs = {round(getattr(p, 'local_clearance', 0.0) or 0.0, 4)
+               for f in pcb.footprints.values() for p in f.pads
+               if (getattr(p, 'drill', 0) or 0) > 0 and _pad_has_no_copper(p)}
+        self.assertEqual(lcs, {0.0})
+
+    def test_resolve_npth_floor_survives_a_board_it_cannot_read(self):
+        """A caller with no board gets the fab floor, not a crash and not 0."""
+        self.assertAlmostEqual(resolve_npth_floor(None), NPTH_FLOOR)
+        self.assertAlmostEqual(
+            resolve_npth_floor(SimpleNamespace()), NPTH_FLOOR)
+
+
+class TestParityWithTheChecker(unittest.TestCase):
+    """The comparison the defect survived for want of. legality was only ever
+    checked against its own inflation."""
+
+    def test_the_gate_flips_at_check_drcs_requirement(self):
+        req = max(0.25, NPTH_FLOOR, AUDIO1_LC)
+        for gap, want_flag in ((req - 0.01, True), (req + 0.01, False)):
+            _pcb, ctx, _parts = _hole_pair(gap)
+            sf = ctx.pair_shortfall('H1', 'C1')
+            with self.subTest(gap=round(gap, 4)):
+                self.assertEqual(sf.hole > EPS, want_flag)
+                if want_flag:
+                    self.assertAlmostEqual(sf.hole, req - gap, places=6)
+
+    def test_there_IS_no_pad_vs_hole_arm_in_check_drc_to_compare_against(self):
+        """A disclosure, and the reason this file cannot close the loop by
+        grading the corpus.
+
+        #761 says "check_drc grades the same geometry at max(npth_clr, lc)".
+        It grades the same RULE, not the same geometry: the `holes` list it
+        builds is consumed in exactly two places, a TRACK arm and a VIA arm,
+        and the pad-to-pad check skips NPTH pads outright. Nothing in this
+        repo grades pad copper against an NPTH hole -- which is precisely why
+        the placer could model that pair at zero for as long as it did, and
+        why "run check_drc on the corpus" is not available as a check on this
+        fix.
+
+        Reported by LINE, never `assertIn` over the module source: test_732
+        measured a 393KB failure message doing that."""
+        src = io.open(os.path.join(_ROOT, 'py_router', 'check_drc.py'),
+                      encoding='utf-8').read().splitlines()
+        consumers = [i + 1 for i, l in enumerate(src)
+                     if l.strip().startswith('if holes and ')]
+        self.assertEqual(len(consumers), 2,
+                         'check_drc consumes its NPTH `holes` list at %d '
+                         'places now, not 2. If one of them is a PAD arm, '
+                         'this file should compare against it instead of '
+                         'mirroring the requirement' % len(consumers))
+        kinds = [src[i - 1].strip() for i in consumers]
+        self.assertEqual(kinds, ['if holes and segs:',
+                                 'if holes and pcb_data.vias:'])
+        skips = [i + 1 for i, l in enumerate(src)
+                 if 'NPTH hole: no copper to short/graze' in l]
+        self.assertEqual(len(skips), 2,
+                         'the pad-pad check no longer skips NPTH pads at two '
+                         'sites (found %r) -- re-read what it does now' % skips)
+
+    def test_the_requirement_matches_check_drcs_own_expression(self):
+        """A hand MIRROR, said out loud. `npth_clr` is a function-local inside
+        `run_drc`, so it cannot be imported; this pins the line it lives on so
+        the mirror breaks loudly rather than drifting."""
+        src = io.open(os.path.join(_ROOT, 'py_router', 'check_drc.py'),
+                      encoding='utf-8').read().splitlines()
+        want = ('npth_clr = max(clearance, defaults.NPTH_TO_TRACK_CLEARANCE, '
+                'hole_clearance)')
+        hits = [i + 1 for i, l in enumerate(src) if l.strip() == want]
+        self.assertEqual(len(hits), 1,
+                         'check_drc\'s NPTH requirement is no longer spelled '
+                         '%r (found at %r); the mirror below is stale' %
+                         (want, hits))
+        for board, ref in ((ULX3S, 'AUDIO1'), (FLAT_HIER, 'HOLE4')):
+            pcb = parse_kicad_pcb(board)
+            fp = pcb.footprints[ref]
+            floor = resolve_npth_floor(pcb)
+            for clearance in (0.10, 0.25, 0.40):
+                pp = PartPads(fp, clearance, None, True, floor)
+                for p in fp.pads:
+                    if not (_pad_has_no_copper(p) and (p.drill or 0) > 0):
+                        continue
+                    lc = getattr(p, 'local_clearance', 0.0) or 0.0
+                    # check_drc.py:2714 then :2733, spelled the same way
+                    npth_clr = max(clearance,
+                                   defaults.NPTH_TO_TRACK_CLEARANCE,
+                                   resolve_hole_clearance(pcb, None))
+                    with self.subTest(board=os.path.basename(board),
+                                      clearance=clearance):
+                        self.assertAlmostEqual(max(npth_clr, lc),
+                                               max(pp.holes_req), places=9)
+
+    def test_the_requirement_is_DISCLOSED_not_just_counted(self):
+        pcb, _ctx, _parts = _hole_pair(0.30)
+        rep = grade_pad_legality(pcb, 0.25, worst_n=4, exact=False)
+        self.assertEqual(rep['hole_conflicts'], 1)
+        self.assertEqual(rep['required'],
+                         [['C1', 'H1', round(AUDIO1_LC, 4), 'NPTH hole']])
+        self.assertIn('NPTH hole', format_required_clause(rep))
+    # MUTATION: hole-disclosure-removed (KILLED).
+
+    def test_a_hole_at_the_FLAT_scalar_discloses_nothing(self):
+        """The same bar the pad channel applies: `required` names pairs graded
+        ABOVE the board-wide clearance, so an ordinary hole stays quiet."""
+        pcb, _ctx, _parts = _hole_pair(0.10, lc=0.0, clearance=0.25)
+        rep = grade_pad_legality(pcb, 0.25, worst_n=4, exact=False)
+        self.assertEqual(rep['hole_conflicts'], 1)
+        self.assertEqual(rep['required'], [])
+
+
+class TestTheBroadPhaseReachesTheHole(unittest.TestCase):
+    """Both early-outs are bounded by PAD floors, and an NPTH pad reaches no
+    pad floor -- it `continue`s before `pad_floors.append`. Without the
+    `hole_reach` term the keep-out fix is INERT for exactly the pairs it was
+    written for."""
+
+    def test_a_pair_beyond_the_pad_reach_is_still_measured(self):
+        clearance = 0.25
+        req = max(clearance, NPTH_FLOOR, AUDIO1_LC)                  # 0.400
+        gap = 0.30
+        # ON THE BRANCH: the gap sits in the band the old bound dropped --
+        # beyond `clearance` but inside the requirement. Without this, the arm
+        # would pass for a reason that has nothing to do with the fix.
+        self.assertGreater(gap, clearance)
+        self.assertLess(gap, req)
+        _pcb, ctx, parts = _hole_pair(gap, clearance=clearance)
+        self.assertAlmostEqual(parts['H1'].hole_reach, req, places=6)
+        sf = ctx.pair_shortfall('H1', 'C1')
+        self.assertAlmostEqual(sf.hole, req - gap, places=6)
+    # MUTATION: reach-drops-hole-reach (KILLED).
+
+    def test_the_census_halo_reaches_it_too(self):
+        clearance = 0.25
+        pcb, _ctx, _parts = _hole_pair(0.30, clearance=clearance)
+        rep = grade_pad_legality(pcb, clearance, worst_n=4, exact=False)
+        self.assertEqual(rep['hole_conflicts'], 1)
+    # MUTATION: census-reach-drops-hole-reach (KILLED).
+
+    def test_hole_reach_is_zero_for_a_part_with_no_holes(self):
+        fp = _fp('C1', 0.0, 0.0, [_cu(0.0, 0.0)])
+        self.assertEqual(PartPads(fp, 0.25).hole_reach, 0.0)
+
+    def test_the_three_hole_lists_stay_index_aligned(self):
+        """`hole_reach` zips two of them and the census zips a third. A length
+        or order mismatch would silently mis-pair a radius with a
+        requirement."""
+        for fp in (_e_footprint(),
+                   _fp('H1', 0, 0, [_npth(0, 0, 0.4), _cu(3, 0)])):
+            pp = PartPads(fp, 0.25)
+            self.assertEqual(len(pp.holes_local), len(pp.holes_extent))
+            self.assertEqual(len(pp.holes_local), len(pp.holes_req))
+            for (kx, ky, _kr), (ex, ey, _er) in zip(pp.holes_local,
+                                                    pp.holes_extent):
+                self.assertAlmostEqual(kx, ex, places=12)
+                self.assertAlmostEqual(ky, ey, places=12)
+
+
+class TestSilkAndExtentsDoNotMove(unittest.TestCase):
+    """`local_clearance` and the board's declared floor are COPPER rules.
+    #730 shipped an off-board regression by conflating the two and then fixed
+    it; this change must not reopen it."""
+
+    def test_the_silk_consumer_gets_the_same_circles_as_before(self):
+        fp = _e_footprint()
+        for clearance in (0.10, 0.15, 0.25):
+            silk = PartPads(fp, clearance, None, False)
+            with self.subTest(clearance=clearance):
+                # no override term...
+                self.assertEqual(
+                    sorted({round(r, 9) for _x, _y, r in silk.holes_local}),
+                    [round(H_DRILL / 2.0
+                           + max(0.0, NPTH_FLOOR - clearance), 9)])
+                # ...and no board floor either, even when one is OFFERED.
+                # Offered, not merely defaulted: the first version of the
+                # engine change gated only the pad override on `copper_holes`
+                # and let silk take the board's declared copper rule, and an
+                # arm that passed `None` here would have missed it.
+                self.assertEqual(
+                    [round(r, 9) for _x, _y, r in silk.holes_local],
+                    [round(r, 9) for _x, _y, r in
+                     PartPads(fp, clearance, None, False, 0.90).holes_local])
+    # MUTATION: silk-takes-the-board-floor (KILLED).
+
+    def test_labels_calls_hole_circles_not_hole_keepouts(self):
+        """A source guard by LINE, not `assertIn` over the module text --
+        test_732 measured a 393KB failure message doing that."""
+        src = io.open(os.path.join(_ROOT, 'py_placer', 'placement',
+                                   'labels.py'), encoding='utf-8').read()
+        hits = [i + 1 for i, l in enumerate(src.splitlines())
+                if 'hole_keepouts' in l.split('#')[0]]
+        self.assertEqual(hits, [],
+                         'labels.py reaches the COPPER keep-out accessor at '
+                         'line(s) %r; silk has no such rule' % hits)
+
+    def test_extents_are_untouched_by_either_copper_term(self):
+        fp = _e_footprint()
+        for clearance in (0.10, 0.25):
+            base = [round(r, 9) for _x, _y, r in
+                    PartPads(fp, clearance).holes_extent]
+            want = [round(H_DRILL / 2.0
+                          + max(0.0, NPTH_FLOOR - clearance), 9)] * len(E_LCS)
+            with self.subTest(clearance=clearance):
+                self.assertEqual(base, want)
+                self.assertEqual(
+                    base, [round(r, 9) for _x, _y, r in
+                           PartPads(fp, clearance, None, True,
+                                    0.90).holes_extent])
+
+    def test_a_huge_override_does_not_push_a_part_off_the_outline(self):
+        """The #730 regression, re-measured on the board that produced it."""
+        pcb = parse_kicad_pcb(SPLITFLAP)
+        clearance = 0.25
+        holes = [(ref, p) for ref, f in pcb.footprints.items() for p in f.pads
+                 if (getattr(p, 'drill', 0) or 0) > 0 and _pad_has_no_copper(p)]
+        self.assertGreater(len(holes), 0, 'no NPTH pads; the arm is void')
+        base = grade_pad_legality(pcb, clearance, worst_n=0, exact=False)
+        for lc in (0.90, 0.95, 1.50):
+            for _ref, p in holes:
+                p.local_clearance = lc
+            got = grade_pad_legality(pcb, clearance, worst_n=0, exact=False)
+            with self.subTest(lc=lc):
+                self.assertEqual(got['oob_pad_count'],
+                                 base['oob_pad_count'])
+                self.assertEqual(got['oob_pad_refs'], base['oob_pad_refs'])
+
+
+class TestInertOnTheTrackedCorpusAtFilePoses(unittest.TestCase):
+    """Self-expiring. Corpus-inert AT FILE POSES is the #761 claim; the
+    change is live during pose SEARCH, which no corpus board exercises at
+    rest. Every clause selects the way the engine selects."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.boards = run_utils.corpus_boards()
+
+    def _scan(self, clearance):
+        """(rows, conflicts). One row per board carrying an NPTH hole:
+        (name, requirement, tightest hole-WALL-to-foreign-copper gap)."""
+        rows, conflicts = [], {}
+        for b in self.boards:
+            pcb = parse_kicad_pcb(b)
+            holes = [(ref, p) for ref, f in pcb.footprints.items()
+                     for p in f.pads
+                     if (getattr(p, 'drill', 0) or 0) > 0
+                     and _pad_has_no_copper(p)]
+            if not holes:
+                continue
+            floor = resolve_npth_floor(pcb)
+            parts = build_part_pads(pcb.footprints, clearance, None, True,
+                                    floor)
+            rects = {}
+            for ref, pp in parts.items():
+                f = pcb.footprints[ref]
+                rects[ref] = pp.pad_rects(f.x, f.y, f.rotation or 0.0)
+            worst, worst_req, hits = 1e9, 0.0, 0
+            for href, hp in holes:
+                req = max(clearance, floor,
+                          getattr(hp, 'local_clearance', 0.0) or 0.0)
+                for hx, hy, hd in pad_drill_circles(hp):
+                    hr = hd / 2.0
+                    for ref, rs in rects.items():
+                        if ref == href:
+                            continue
+                        for x0, y0, x1, y1, _n, _s in rs:
+                            dx = max(x0 - hx, 0.0, hx - x1)
+                            dy = max(y0 - hy, 0.0, hy - y1)
+                            g = math.hypot(dx, dy) - hr
+                            if g < req - 1e-9:
+                                hits += 1
+                            if g - req < worst - worst_req:
+                                worst, worst_req = g, req
+            rows.append((os.path.basename(b), worst_req, worst))
+            if hits:
+                conflicts[os.path.basename(b)] = hits
+        return rows, conflicts
+
+    def test_no_tracked_board_gains_a_hole_conflict_at_its_file_poses(self):
+        if not self.boards:
+            print('SKIP: git cannot identify the tracked corpus')
+            self.skipTest('no git')
+        self.assertGreaterEqual(len(self.boards), 20,
+                                'the tracked corpus collapsed; this arm '
+                                'proves nothing')
+        for clearance in (0.10, 0.25):
+            rows, conflicts = self._scan(clearance)
+            with self.subTest(clearance=clearance):
+                self.assertGreaterEqual(
+                    len(rows), 8,
+                    'only %d boards carry an NPTH hole; the scan is not '
+                    'reading them' % len(rows))
+                self.assertEqual(
+                    conflicts, {},
+                    'the #761 "corpus-inert at file poses" claim has EXPIRED: '
+                    '%r. Re-run the before/after sweep and record the numbers '
+                    'rather than relaxing this arm' % conflicts)
+                if clearance == 0.25:
+                    for name, req, gap in sorted(rows, key=lambda r: r[2] - r[1]):
+                        print('        %-30s req %.3f  gap %.4f  margin %+.4f'
+                              % (name, req, gap, gap - req))
+
+    def test_ulx3s_is_the_tightest_and_it_clears_by_ten_microns(self):
+        """The tightest margin in the change, asserted against the bound
+        itself with the margin printed -- not against an invented threshold."""
+        if not self.boards:
+            print('SKIP: git cannot identify the tracked corpus')
+            self.skipTest('no git')
+        rows, _ = self._scan(0.25)
+        tightest = min(rows, key=lambda r: r[2] - r[1])
+        self.assertEqual(tightest[0], 'ulx3s.kicad_pcb',
+                         'the tightest tracked board is now %r, not ulx3s -- '
+                         'the PR names ulx3s and that has EXPIRED' % (tightest,))
+        self.assertAlmostEqual(tightest[1], AUDIO1_LC, places=4)
+        self.assertAlmostEqual(tightest[2], 0.4100, places=4)
+        self.assertGreater(tightest[2] - tightest[1], 0.0)
+        self.assertLess(tightest[2] - tightest[1], 0.02,
+                        'the margin GREW; ulx3s is no longer the near miss '
+                        'the PR describes')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/test_761_legality_npth_keepout.py
+++ b/tests/test_761_legality_npth_keepout.py
@@ -68,7 +68,8 @@ from kicad_parser import parse_kicad_pcb, pad_drill_circles
 from check_drc import _pad_has_no_copper
 from obstacle_map import resolve_hole_clearance
 from synth import make_pad, make_pcb
-from placement.legality import (EPS, LegalityContext, PartPads,
+from placement.legality import (EPS, PAIR_TEST_CAP, LegalityContext,
+                                PartPads,
                                 _circle_rect_penetration, build_part_pads,
                                 format_required_clause, grade_pad_legality,
                                 resolve_npth_floor)
@@ -98,6 +99,11 @@ E_LCS = (0.00, 0.40, 0.15)
 COLLAPSE = {0.10: 0.300, 0.20: 0.200, 0.25: 0.150, 0.40: 0.000}
 
 H_DRILL = 2.0
+
+# `grade_pad_legality`'s neighbour-grid cell, hand-mirrored from the engine's
+# `cell = 4.0` local. Only the halo arm below depends on it, and it depends on
+# it structurally (is the term's reach wider than one cell?), not numerically.
+CENSUS_CELL = 4.0
 
 
 def _npth(x, y, lc, ref='H1', drill=H_DRILL, num='H1'):
@@ -288,6 +294,97 @@ class TestTheBoardFloorReachesTheKeepOut(unittest.TestCase):
                if (getattr(p, 'drill', 0) or 0) > 0 and _pad_has_no_copper(p)}
         self.assertEqual(lcs, {0.0})
 
+    def test_the_two_HOLE_consumers_pass_it_and_the_others_do_not(self):
+        """A source guard, by LINE, and it exists because behaviour cannot
+        reach it: the one tracked board that declares above the fab floor
+        clears its nearest copper by 3.69mm, so dropping the term from the
+        census changes no ANSWER on any board we have. Measured -- the
+        mutation row `the-census-passes-no-board-floor` SURVIVED every
+        behavioural arm in this file.
+
+        The distinction being pinned is the whole point of the #730 tripwire's
+        "needs its own review": of the six `build_part_pads` call sites, the
+        two that read hole KEEP-OUTS carry the board floor, and the four that
+        read only pad rects, extents or silk do not -- for them it would
+        resolve a board and change nothing."""
+        pairs = (('py_placer/placement/legality.py', 1, 'grade_pad_legality'),
+                 ('py_placer/placement/quench.py', 1, 'quench'))
+        for rel, want, who in pairs:
+            src = io.open(os.path.join(_ROOT, *rel.split('/')),
+                          encoding='utf-8').read()
+            hits = [i + 1 for i, l in enumerate(src.splitlines())
+                    if 'npth_floor=' in l.split('#')[0]]
+            self.assertEqual(len(hits), want,
+                             '%s passes npth_floor at %d site(s), expected '
+                             '%d (%s)' % (rel, len(hits), want, who))
+        for rel in ('py_placer/placement/labels.py',
+                    'py_placer/placement/routability.py',
+                    'py_placer/placement/seeder.py'):
+            src = io.open(os.path.join(_ROOT, *rel.split('/')),
+                          encoding='utf-8').read()
+            hits = [i + 1 for i, l in enumerate(src.splitlines())
+                    if 'npth_floor=' in l.split('#')[0]]
+            self.assertEqual(hits, [],
+                             '%s passes npth_floor at line(s) %r -- it reads '
+                             'extents or silk, not hole keep-outs, so the '
+                             'term resolves a board and changes nothing '
+                             'there' % (rel, hits))
+
+    def test_the_CALLERS_path_wins_over_the_parsed_source_path(self):
+        """The #498 rule every sibling here follows. A board staged into a
+        temp dir and parsed from there carries a `source_path` that is not the
+        board the caller means, and `grade_pad_legality` already threads
+        `pcb_file` to `PadClearanceModel.for_board` for exactly that reason.
+
+        flat_hierarchy is the fixture because it is the one tracked board that
+        declares above the fab floor -- on any other board both answers are
+        0.2000 and the arm would be vacuous."""
+        import shutil
+        import tempfile
+        real = resolve_npth_floor(parse_kicad_pcb(FLAT_HIER))
+        self.assertAlmostEqual(real, 0.25, places=6)
+        d = tempfile.mkdtemp(prefix='t761_')
+        try:
+            staged = os.path.join(d, 'staged.kicad_pcb')
+            shutil.copyfile(FLAT_HIER, staged)      # the board ALONE, #441
+            pcb = parse_kicad_pcb(staged)
+            # ...the staged board on its own cannot answer,
+            self.assertAlmostEqual(resolve_npth_floor(pcb), NPTH_FLOOR,
+                                   places=6)
+            # ...and the caller's path restores it.
+            self.assertAlmostEqual(resolve_npth_floor(pcb, FLAT_HIER), 0.25,
+                                   places=6)
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+    # MUTATION: resolve-npth-floor-ignores-pcb_file (KILLED).
+
+    def test_a_failed_resolution_is_NOTED_not_swallowed(self):
+        """`grade_pad_legality` returns `clearance_notes` for exactly this --
+        "anything that went WRONG resolving the requirement". A silent
+        fallback drops the modelled floor by up to the declared value and
+        returns a byte-identical report, which is the shape of silence this
+        issue was filed about."""
+        import obstacle_map
+        pcb = parse_kicad_pcb(FLAT_HIER)
+        notes = []
+        self.assertAlmostEqual(resolve_npth_floor(pcb, None, notes), 0.25)
+        self.assertEqual(notes, [])
+        real = obstacle_map.resolve_hole_clearance
+
+        def boom(*_a, **_k):
+            raise IOError('the .kicad_pro is unreadable')
+
+        obstacle_map.resolve_hole_clearance = boom
+        try:
+            self.assertAlmostEqual(resolve_npth_floor(pcb, None, notes),
+                                   NPTH_FLOOR, places=6)
+        finally:
+            obstacle_map.resolve_hole_clearance = real
+        self.assertEqual(len(notes), 1)
+        self.assertIn('unreadable', notes[0])
+        self.assertIn('fab floor', notes[0])
+    # MUTATION: failed-floor-resolution-is-silent (KILLED).
+
     def test_resolve_npth_floor_survives_a_board_it_cannot_read(self):
         """A caller with no board gets the fab floor, not a crash and not 0."""
         self.assertAlmostEqual(resolve_npth_floor(None), NPTH_FLOOR)
@@ -448,12 +545,20 @@ class TestTheBroadPhaseReachesTheHole(unittest.TestCase):
         WIDER than one cell. Six millimetres around a mounting hole is not a
         stunt value -- it is a screw-head/washer keep-out, which is what a
         `(clearance ...)` on an NPTH pad is usually for -- but the arm is
-        honest that a corpus-scale override cannot reach this branch."""
+        honest that a corpus-scale override cannot reach this branch.
+
+        The SEPARATION is load-bearing too, and getting it wrong is how the
+        second draft of this arm still survived. The halo is symmetric -- the
+        census walks every ref -- so BOTH parts' un-widened halos have to miss
+        the other's cells. At 2.0mm apart they still shared cell 0 and the arm
+        passed for free. 4.0mm puts the pad's own extent in cell 1 with H1
+        registered in {-1, 0}, which no 0.75mm halo can bridge."""
         clearance = 0.25
         big_lc = 6.0
-        self.assertGreater(big_lc, 4.0, 'the census cell size; below it the '
-                                        'halo term cannot change an answer')
-        pcb, _ctx, parts = _hole_pair(2.0, lc=big_lc, clearance=clearance)
+        self.assertGreater(big_lc, CENSUS_CELL,
+                           'the census cell size; below it the halo term '
+                           'cannot change an answer')
+        pcb, _ctx, parts = _hole_pair(4.0, lc=big_lc, clearance=clearance)
         self.assertAlmostEqual(parts['H1'].hole_reach, big_lc, places=6)
         rep = grade_pad_legality(pcb, clearance, worst_n=4, exact=False)
         self.assertEqual(rep['hole_conflicts'], 1)
@@ -461,6 +566,87 @@ class TestTheBroadPhaseReachesTheHole(unittest.TestCase):
                          [['C1', 'H1', round(big_lc, 4), 'NPTH hole']])
     # MUTATION: census-reach-drops-hole_reach (KILLED by this arm, NOT by the
     # one above it -- see its docstring).
+
+    def test_the_PAIR_TEST_CAP_branch_still_measures_the_hole(self):
+        """`pair_shortfall` returns early when `pa.n_pads * pb.n_pads` exceeds
+        the cap, and that branch used to hardcode `hole=0.0` -- so the hole
+        channel could never fire for exactly the dense connectors that carry
+        mounting holes. Corpus-reachable: glasgow_revC's J5 x U30 is 5324.
+
+        Two grids of copper pads whose PRODUCT clears the cap -- 64 x 65,
+        not 64 + 65, which is the arithmetic the first draft of this arm got
+        wrong and failed on."""
+        clearance = 0.25
+        n = 8
+        a_pads = [_npth(0.0, 0.0, AUDIO1_LC)]
+        a_pads += [_cu(-2.0 - 0.1 * i, -2.0 - 0.1 * j, 'H1', net=5,
+                       sx=0.05, sy=0.05, num='p%d_%d' % (i, j))
+                   for i in range(n) for j in range(n)]
+        gap = 0.30
+        cx = H_DRILL / 2.0 + gap + 0.5
+        b_pads = [_cu(cx, 0.0, 'C1', num='b0')]
+        b_pads += [_cu(cx + 2.0 + 0.1 * i, 2.0 + 0.1 * j, 'C1',
+                       sx=0.05, sy=0.05, num='q%d_%d' % (i, j))
+                   for i in range(n) for j in range(n)]
+        fps = {'H1': _fp('H1', 0.0, 0.0, a_pads),
+               'C1': _fp('C1', cx, 0.0, b_pads)}
+        parts = build_part_pads(fps, clearance)
+        self.assertGreater(parts['H1'].n_pads * parts['C1'].n_pads,
+                           PAIR_TEST_CAP,
+                           'the fixture no longer trips the cap; this arm '
+                           'would then test the ordinary path')
+        poses = {r: (f.x, f.y, f.rotation) for r, f in fps.items()}
+        ctx = LegalityContext(parts, None, clearance,
+                              pose_of=lambda r: poses[r],
+                              seed_of=lambda r: poses[r])
+        req = max(clearance, NPTH_FLOOR, AUDIO1_LC)
+        self.assertAlmostEqual(ctx.pair_shortfall('H1', 'C1').hole,
+                               req - gap, places=6)
+    # MUTATION: pair-cap-goes-back-to-a-hardcoded-zero (KILLED).
+
+    def test_the_cap_branch_does_not_bill_the_hole_to_the_PAD_channel(self):
+        """`reach` feeds two things: the early-out, and the PAD shortfall the
+        cap branch charges. Folding `hole_reach` into one number billed a
+        single physical violation to two independent gates -- `pads_ok` tests
+        `cur.pad` and `cur.hole` as separate conjuncts and quench sums
+        `sf.hole` on its own.
+
+        The tell is that the answer depended on the PAD-PAIR PRODUCT, which is
+        a performance switch and must never change a verdict. Found by an
+        adversarial review of this branch, not by me."""
+        clearance = 0.25
+        lc = 1.0
+        gap = 0.30
+        seen = {}
+        for n in (7, 9):              # 49 and 81 copper pads: under, over
+            a_pads = [_npth(0.0, 0.0, lc)]
+            a_pads += [_cu(-3.0 - 0.1 * i, -3.0 - 0.1 * j, 'H1', net=5,
+                           sx=0.05, sy=0.05, num='p%d_%d' % (i, j))
+                       for i in range(n) for j in range(n)]
+            cx = H_DRILL / 2.0 + gap + 0.5
+            b_pads = [_cu(cx, 0.0, 'C1', num='b0')]
+            b_pads += [_cu(cx + 3.0 + 0.1 * i, 3.0 + 0.1 * j, 'C1',
+                           sx=0.05, sy=0.05, num='q%d_%d' % (i, j))
+                       for i in range(n) for j in range(n)]
+            fps = {'H1': _fp('H1', 0.0, 0.0, a_pads),
+                   'C1': _fp('C1', cx, 0.0, b_pads)}
+            parts = build_part_pads(fps, clearance)
+            poses = {r: (f.x, f.y, f.rotation) for r, f in fps.items()}
+            ctx = LegalityContext(parts, None, clearance,
+                                  pose_of=lambda r: poses[r],
+                                  seed_of=lambda r: poses[r])
+            seen[n] = (parts['H1'].n_pads * parts['C1'].n_pads,
+                       ctx.pair_shortfall('H1', 'C1'))
+        # ON THE BRANCH: the two fixtures straddle the cap, else this arm is
+        # comparing a branch with itself.
+        self.assertLess(seen[7][0], PAIR_TEST_CAP)
+        self.assertGreater(seen[9][0], PAIR_TEST_CAP)
+        req = max(clearance, NPTH_FLOOR, lc)
+        for n, (_prod, sf) in sorted(seen.items()):
+            with self.subTest(pads=n):
+                self.assertAlmostEqual(sf.hole, req - gap, places=6)
+                self.assertAlmostEqual(sf.pad, 0.0, places=6)
+    # MUTATION: cap-branch-charges-the-hole-reach-as-PAD (KILLED).
 
     def test_hole_reach_is_zero_for_a_part_with_no_holes(self):
         fp = _fp('C1', 0.0, 0.0, [_cu(0.0, 0.0)])

--- a/tests/test_761_legality_npth_keepout.py
+++ b/tests/test_761_legality_npth_keepout.py
@@ -487,18 +487,22 @@ class TestParityWithTheChecker(unittest.TestCase):
             floor = resolve_npth_floor(pcb)
             for clearance in (0.10, 0.25, 0.40):
                 pp = PartPads(fp, clearance, None, True, floor)
-                for p in fp.pads:
-                    if not (_pad_has_no_copper(p) and (p.drill or 0) > 0):
-                        continue
-                    lc = getattr(p, 'local_clearance', 0.0) or 0.0
-                    # check_drc.py:2714 then :2733, spelled the same way
-                    npth_clr = max(clearance,
-                                   defaults.NPTH_TO_TRACK_CLEARANCE,
-                                   resolve_hole_clearance(pcb, None))
-                    with self.subTest(board=os.path.basename(board),
-                                      clearance=clearance):
-                        self.assertAlmostEqual(max(npth_clr, lc),
-                                               max(pp.holes_req), places=9)
+                # check_drc.py:2714 then :2733, spelled the same way.
+                # Compared as SETS, not per-pad against the footprint max: a
+                # max hides a hole whose own requirement is lower, which is
+                # exactly the per-hole property #730 shipped.
+                npth_clr = max(clearance, defaults.NPTH_TO_TRACK_CLEARANCE,
+                               resolve_hole_clearance(pcb, None))
+                want = sorted({
+                    round(max(npth_clr,
+                              getattr(p, 'local_clearance', 0.0) or 0.0), 9)
+                    for p in fp.pads
+                    if _pad_has_no_copper(p) and (p.drill or 0) > 0})
+                with self.subTest(board=os.path.basename(board),
+                                  clearance=clearance):
+                    self.assertTrue(want, 'no NPTH pad; the arm is void')
+                    self.assertEqual(sorted({round(r, 9)
+                                             for r in pp.holes_req}), want)
 
     def test_the_requirement_is_DISCLOSED_not_just_counted(self):
         pcb, _ctx, _parts = _hole_pair(0.30)
@@ -510,8 +514,13 @@ class TestParityWithTheChecker(unittest.TestCase):
     # MUTATION: hole-disclosure-removed (KILLED).
 
     def test_a_hole_at_the_FLAT_scalar_discloses_nothing(self):
-        """The same bar the pad channel applies: `required` names pairs graded
-        ABOVE the board-wide clearance, so an ordinary hole stays quiet."""
+        """`required` names pairs graded ABOVE the board-wide clearance, so an
+        ordinary hole stays quiet.
+
+        NOT literally the pad channel's bar -- that one is `pair_source != ''`
+        and therefore sits at `model.base`, which a netclass can lift above
+        `--clearance`. This docstring said "the same bar" until a review
+        measured otherwise."""
         pcb, _ctx, _parts = _hole_pair(0.10, lc=0.0, clearance=0.25)
         rep = grade_pad_legality(pcb, 0.25, worst_n=4, exact=False)
         self.assertEqual(rep['hole_conflicts'], 1)
@@ -585,9 +594,12 @@ class TestTheBroadPhaseReachesTheHole(unittest.TestCase):
         channel could never fire for exactly the dense connectors that carry
         mounting holes. Corpus-reachable: glasgow_revC's J5 x U30 is 5324.
 
-        Two grids of copper pads whose PRODUCT clears the cap -- 64 x 65,
-        not 64 + 65, which is the arithmetic the first draft of this arm got
-        wrong and failed on."""
+        Two grids of copper pads whose PRODUCT clears the cap. The first
+        draft asserted `n * n > PAIR_TEST_CAP` on the GRID size and then built
+        parts of `n*n + 1` pads each, so at n=40 it refused on 1600 while the
+        real product was 1601 x 1601. The pre-check now guards the thing the
+        engine actually compares -- `parts[a].n_pads * parts[b].n_pads` -- and
+        n is 8, giving 64 x 65 = 4160."""
         clearance = 0.25
         n = 8
         a_pads = [_npth(0.0, 0.0, AUDIO1_LC)]
@@ -823,6 +835,43 @@ class TestInertOnTheTrackedCorpusAtFilePoses(unittest.TestCase):
                     for name, req, gap in sorted(rows, key=lambda r: r[2] - r[1]):
                         print('        %-30s req %.3f  gap %.4f  margin %+.4f'
                               % (name, req, gap, gap - req))
+
+    def test_the_POSITIVE_control_the_inertness_claim_needs(self):
+        """"Inert on the corpus" and "wired to nothing" print the same PASS.
+
+        This is the arm that tells them apart: raise `--clearance` until the
+        keep-out DOES bind and assert exactly which boards light up. At 0.20 --
+        what `corpus_noop_sweep` and `test_placement_ab` both run at -- the
+        census is silent on all 22 boards; at 0.50 it fires on three, and only
+        in the hole channel.
+
+        Measured independently twice, by me and by a reviewer who had not seen
+        my numbers, and they agree to the count."""
+        if not self.boards:
+            print('SKIP: git cannot identify the tracked corpus')
+            self.skipTest('no git')
+        seen = {}
+        for clr in (0.20, 0.50):
+            hits = {}
+            for b in self.boards:
+                pcb = parse_kicad_pcb(b)
+                rep = grade_pad_legality(pcb, clr, worst_n=0, exact=False,
+                                         pcb_file=b)
+                if rep['hole_conflicts']:
+                    hits[os.path.basename(b)] = rep['hole_conflicts']
+            seen[clr] = hits
+        self.assertEqual(seen[0.20], {},
+                         'the corpus is no longer inert at the clearance the '
+                         'standing gates run at: %r' % seen[0.20])
+        self.assertEqual(
+            seen[0.50],
+            {'orangecrab_ext_pll.kicad_pcb': 2,
+             'rp2350_fpga_eensy_prePlane.kicad_pcb': 4,
+             'ulx3s.kicad_pcb': 1},
+            'the positive control has MOVED: %r. Either the keep-out stopped '
+            'binding -- in which case the corpus arms above are passing '
+            'vacuously -- or a board changed. Re-measure; do not adjust this '
+            'dict to match.' % seen[0.50])
 
     def test_ulx3s_is_the_tightest_and_it_clears_by_ten_microns(self):
         """The tightest margin in the change, asserted against the bound

--- a/tests/test_761_legality_npth_keepout.py
+++ b/tests/test_761_legality_npth_keepout.py
@@ -309,6 +309,23 @@ class TestParityWithTheChecker(unittest.TestCase):
                 if want_flag:
                     self.assertAlmostEqual(sf.hole, req - gap, places=6)
 
+    def test_it_flips_the_same_way_with_the_ARGUMENTS_SWAPPED(self):
+        """`pair_shortfall` runs the hole loop TWICE -- once per direction --
+        and a fixture that only ever puts the hole on one side leaves the
+        other loop untested. Measured: reverting exactly one of the two loops
+        SURVIVED the battery until this arm existed."""
+        req = max(0.25, NPTH_FLOOR, AUDIO1_LC)
+        for gap, want_flag in ((req - 0.01, True), (req + 0.01, False)):
+            _pcb, ctx, _parts = _hole_pair(gap)
+            with self.subTest(gap=round(gap, 4)):
+                # ...and asserted equal to each other, not just to the flag:
+                # a loop that ran but measured the wrong pair would still
+                # produce a True here.
+                self.assertEqual(ctx.pair_shortfall('C1', 'H1').hole,
+                                 ctx.pair_shortfall('H1', 'C1').hole)
+                self.assertEqual(
+                    ctx.pair_shortfall('C1', 'H1').hole > EPS, want_flag)
+
     def test_there_IS_no_pad_vs_hole_arm_in_check_drc_to_compare_against(self):
         """A disclosure, and the reason this file cannot close the loop by
         grading the corpus.
@@ -418,7 +435,32 @@ class TestTheBroadPhaseReachesTheHole(unittest.TestCase):
         pcb, _ctx, _parts = _hole_pair(0.30, clearance=clearance)
         rep = grade_pad_legality(pcb, clearance, worst_n=4, exact=False)
         self.assertEqual(rep['hole_conflicts'], 1)
-    # MUTATION: census-reach-drops-hole-reach (KILLED).
+
+    def test_the_census_HALO_needs_the_term_once_the_reach_clears_a_cell(self):
+        """The census neighbour search is a 4.0mm cell hash expanded by
+        `census_reach + 0.5`, so the term only changes an ANSWER once the
+        reach can carry a conflict across a cell boundary -- below that the
+        quantisation covers it and dropping the term is inert.
+
+        Measured: with a 0.400 requirement the row
+        `census-reach-drops-hole_reach` SURVIVED the battery, because the two
+        parts share a cell whatever the halo is. So this arm uses a keep-clear
+        WIDER than one cell. Six millimetres around a mounting hole is not a
+        stunt value -- it is a screw-head/washer keep-out, which is what a
+        `(clearance ...)` on an NPTH pad is usually for -- but the arm is
+        honest that a corpus-scale override cannot reach this branch."""
+        clearance = 0.25
+        big_lc = 6.0
+        self.assertGreater(big_lc, 4.0, 'the census cell size; below it the '
+                                        'halo term cannot change an answer')
+        pcb, _ctx, parts = _hole_pair(2.0, lc=big_lc, clearance=clearance)
+        self.assertAlmostEqual(parts['H1'].hole_reach, big_lc, places=6)
+        rep = grade_pad_legality(pcb, clearance, worst_n=4, exact=False)
+        self.assertEqual(rep['hole_conflicts'], 1)
+        self.assertEqual(rep['required'],
+                         [['C1', 'H1', round(big_lc, 4), 'NPTH hole']])
+    # MUTATION: census-reach-drops-hole_reach (KILLED by this arm, NOT by the
+    # one above it -- see its docstring).
 
     def test_hole_reach_is_zero_for_a_part_with_no_holes(self):
         fp = _fp('C1', 0.0, 0.0, [_cu(0.0, 0.0)])

--- a/tests/test_761_legality_npth_keepout.py
+++ b/tests/test_761_legality_npth_keepout.py
@@ -683,10 +683,12 @@ class TestSilkAndExtentsDoNotMove(unittest.TestCase):
                     [round(H_DRILL / 2.0
                            + max(0.0, NPTH_FLOOR - clearance), 9)])
                 # ...and no board floor either, even when one is OFFERED.
-                # Offered, not merely defaulted: the first version of the
-                # engine change gated only the pad override on `copper_holes`
-                # and let silk take the board's declared copper rule, and an
-                # arm that passed `None` here would have missed it.
+                # Offered, not merely defaulted, and the distinction is the
+                # whole arm: `labels.py` -- the only `copper_holes=False`
+                # caller in the tree -- passes NO floor, so the default path
+                # is silent about the branch. This is a latent hole for a
+                # future silk caller, not a shipped defect; silk output is
+                # byte-identical across the whole of #761.
                 self.assertEqual(
                     [round(r, 9) for _x, _y, r in silk.holes_local],
                     [round(r, 9) for _x, _y, r in

--- a/tests/test_fanout_clearance.py
+++ b/tests/test_fanout_clearance.py
@@ -297,5 +297,4 @@ if __name__ == '__main__':
     test_seed_track_graze_is_resolved()
     test_seg_to_rect_dist_exact()
     test_mover_pad_short_is_hard_blocked()
-    test_mover_pad_short_is_hard_blocked()
     print("ALL PASS")

--- a/tests/test_placement_pad_legality.py
+++ b/tests/test_placement_pad_legality.py
@@ -84,17 +84,34 @@ class TestPartPads(unittest.TestCase):
         c = abs(math.cos(math.radians(45)))
         self.assertAlmostEqual(w, 2 * (1.0 * c + 0.5 * c), places=6)
 
-    def test_npth_hole_inflation_matches_fanout_convention(self):
-        clearance = 0.09
-        fp = FakeFP('H1', 5, 5, pads=[FakePad(5, 5, 3.2, 3.2, net=0,
-                                              layers=('*.Cu',), drill=2.2,
-                                              pad_type='np_thru_hole')])
-        pp = PartPads(fp, clearance)
-        self.assertEqual(pp.n_pads, 0)          # no copper
-        self.assertEqual(len(pp.holes_local), 1)
-        (_ox, _oy, r) = pp.holes_local[0]
-        grow = max(0.0, defaults.NPTH_TO_TRACK_CLEARANCE - clearance)
-        self.assertAlmostEqual(r, 2.2 / 2.0 + grow, places=9)
+    def test_npth_hole_inflation_and_STANDOFF_match_the_fanout_convention(self):
+        """Renamed by #761, because the old name was for the half that was
+        right.
+
+        It asserted the INFLATION -- which did match fanout_clearance -- and
+        stopped there, at `clearance = 0.09` only, below the 0.20 fab floor.
+        The comparison did not match: legality tested that circle against raw
+        pad rects and added nothing, so the modelled standoff was
+        `max(0, requirement - clearance)` and collapsed to zero at and above
+        the requirement. This arm now pins BOTH halves, and the second
+        clearance is above the floor, where the old assertion is vacuous."""
+        for clearance in (0.09, 0.25):
+            fp = FakeFP('H1', 5, 5, pads=[FakePad(5, 5, 3.2, 3.2, net=0,
+                                                  layers=('*.Cu',), drill=2.2,
+                                                  pad_type='np_thru_hole')])
+            pp = PartPads(fp, clearance)
+            with self.subTest(clearance=clearance):
+                self.assertEqual(pp.n_pads, 0)          # no copper
+                self.assertEqual(len(pp.holes_local), 1)
+                (_ox, _oy, r) = pp.holes_local[0]
+                grow = max(0.0, defaults.NPTH_TO_TRACK_CLEARANCE - clearance)
+                self.assertAlmostEqual(r, 2.2 / 2.0 + grow, places=9)
+                # ...and the standoff the consumers actually charge.
+                (_kx, _ky, kr) = pp.hole_keepouts(5, 5, 0)[0]
+                self.assertAlmostEqual(
+                    kr - 2.2 / 2.0,
+                    max(clearance, defaults.NPTH_TO_TRACK_CLEARANCE),
+                    places=9)
 
     def test_paste_only_aperture_skipped(self):
         fp = FakeFP('C1', 0, 0, pads=[FakePad(0, 0, 1, 1, layers=('F.Paste',))])


### PR DESCRIPTION
Closes #761.

> **This PR shows CONFLICTING and none of the conflict is #761's.** It is
> inherited from #741 (PR #752): upstream's `b6fc8132` — the via-protection work
> for #748/#749/#751 — conflicts in `CLAUDE.md`, `docs/api-kicad-writer.md` and
> `py_router/kicad_writer.py`, and all three hunks come only from #741's commits.
> #761 touches `py_placer/placement/{legality,labels,quench,README}`,
> `py_router/obstacle_map.py`, `py_tools/render_placement.py` and four test
> files, none of which upstream has moved. (`kicad_routing_plugin/fanout_gui.py`
> is touched by both sides and auto-merges.) Based on the open row
> #725→#731→#732→#733→#737→#736→#741→#746→#750→#730.

## The rule, and the half of it that was never checked

`placement/legality.PartPads` stores each NPTH mounting hole at the growth
**above** `clearance` and the copper consumers compared that circle against
**raw, uninflated pad rects with no additive term**. So the modelled standoff
from the hole wall was `max(0, requirement − clearance)`, which collapses to
**zero** once `clearance` reaches the requirement.

Both siblings add the term at their own gap test — `fanout_clearance` through
`_pair_or_flat` (an NPTH tuple files floor `None`, so it hands back the flat
scalar) and `labels.py` by comparing against `silk_pad_clearance`. **legality
was the only place in the repo using the constant as a subtrahend with no
matching addend.**

The comment that got it here said *"Inflation matches fanout_clearance's
foreign-pad keepouts"*. True, and only half the rule: the inflation matched, the
**comparison** did not, and only the inflation was ever checked. The unit test
guarding it is named `test_npth_hole_inflation_matches_fanout_convention` — for
the half that was right — and ran only at `clearance = 0.09`, below the 0.20 fab
floor, where the defect is invisible.

Measured on `kicad_files/ulx3s.kicad_pcb`, AUDIO1's two 1.700 mm NPTH pads at
`(clearance 0.4)` — standoff from the hole wall:

| `--clearance` | 0.10 | 0.20 | 0.25 | 0.40 |
|---|---|---|---|---|
| was | 0.300 | 0.200 | 0.150 | **0.000** |
| is | 0.400 | 0.400 | 0.400 | 0.400 |

`hole_keepouts()` is the one resolver. The storage **convention** is
unchanged — `holes_local` still holds the growth above `clearance` — so the silk
consumer, `holes_extent` and #730's radius change detectors all keep working,
and `_circle_rect_penetration` stays a pure geometric predicate with no
clearance parameter to forget.

*Not* "the stored values are unchanged", which an earlier draft of this
paragraph claimed and a fact-check refuted: commit 3 moves them at the two call
sites that pass a board floor — flat_hierarchy HOLE4 goes 2.2500 → 2.3000. The
consequences above still hold because the silk and extent readers pass no
floor, but the premise as written was wrong.

**#761's own numbers predate #762.** The issue says the radius is 0.8500 from
`--clearance 0.20` up; that is the tree *before* `daa2d272` added the
`local_clearance` term. Re-measured on both trees, `daa2d272^` reproduces the
issue's table exactly at all four clearances. The defect is unchanged — only the
collapse point moved, from 0.20 to 0.40 for this pad, and it is still 0.20 for
any hole with no override.

## Eight code commits, three of them corrections to the earlier ones

13 commits in all; the five not listed are the README, the test files and two
test fix-ups.

| | commit | what |
|---|---|---|
| 1 | `c1085271` | `hole_keepouts` + the four copper consumers + the comment — the arithmetic |
| 2 | `57801689` | `hole_reach` in both broad-phase bounds |
| 3 | `b02761b7` | the board's declared `min_hole_clearance`, as a resolved float — the review #730's tripwire demanded |
| 4 | `31d1a84e` | the hole census names what it required |
| 5 | `d1c952f3` | `PAIR_TEST_CAP` measures holes — a **pre-existing** early-out, found by fact-check |
| 6 | `44e986f9` | `copper_holes` gates the board floor too |
| 7 | `7b40ad27` | five defects an adversarial review found in 1–6, **including one I introduced in 2** |
| 8 | `a7b68581` | commit 6 claimed a defect that did not exist — correction |

**Commit 2 — the band commit 1 alone still cannot see.** Both early-outs are
bounded by pad floors, and an NPTH pad `continue`s before `pad_floors.append`,
so a hole's requirement reaches neither. Measured: `ulx3s` `AUDIO1.max_floor` is
0.0 while its holes require 0.400, so at `model.base` 0.25 a pair at an extent
gap in `[0.25, 0.40)` returned `ZERO_SHORTFALL` before the hole loop ran.

An earlier draft called commit 1 "inert without this", which a fact-check
refuted. Commit 1 alone already produces the whole corpus positive control
below; what commit 2 adds is exactly the blind band `[clearance, requirement)`
— a 2.0 mm NPTH at lc 0.400, `--clearance 0.25`:

```
wall gap   parent    commit 1 only   branch
  0.10     0.0500       0.3000       0.3000
  0.20     0.0000       0.2000       0.2000
  0.30     0.0000       0.0000       0.1000   <- what commit 2 adds
  0.45     0.0000       0.0000       0.0000
```

The hole is a **#730 regression specifically** — `d540c21f` split `holes_extent`
from `holes_local`, and before that split the two were equal and the early-out
was sound for holes.

**And the census half of commit 2 has NO corpus witness.** `census_reach`'s new
`board_max_hole` term never exceeds `max(clearance, board_max_floor,
model.base)` on any of the 9 hole-carrying boards at 0.10, 0.25 or 0.50 —
`board_max_floor` or `model.base` always dominates. It is kept as a correctness
term, proven only synthetically (a keep-clear wider than the 4.0 mm census cell,
`test_the_census_HALO_needs_the_term_once_the_reach_clears_a_cell`), and this PR
does not claim a board where it changes an answer.

The soundness argument is in the comment rather than asserted, and a reviewer
attacked it with ~205 000 randomized and boundary-bisected probes: **0 breaks**,
the bound is exactly tight (equality at `gap == reach` gives penetration
`0.000e+00`), and 45° is the *most* conservative direction, not the least. Cost:
ulx3s `--clearance 0.25` goes from 154 to **156** inner-loop pairs out of 25 425;
census pairs +0 on every board. For an ordinary hole `hole_reach == clearance`
exactly, so it is a no-op unless an override or a board declaration is present.

**Commit 3 — `PartPads` still reads no board.** #730 shipped
`test_no_board_read_is_attempted_here_and_that_is_DISCLOSED`, which pins the
constructor's parameter list and fails with *"that changes what the six
build_part_pads call sites mean and needs its own review"*. This is that review,
and the answer is the distinction, not the count:

| question the caller asks | sites | gets the floor |
|---|---|---|
| hole keep-outs | `grade_pad_legality`, `quench` | **yes** |
| pad rects / extents | legality's `pad_intersection` channel, `routability`, `seeder` | no — it would resolve a board and change nothing |
| silk | `labels.py` | no — it is a copper rule |

Shape copied from `fanout_clearance.py:664-666`: resolve **once, outside**, pass
the float. The tripwire is **rewritten, not relaxed** — the board-pointer ban
stays positional and the new parameter is asserted to be a scalar that actually
moves a radius. `holes_extent` deliberately keeps the flat floor, so every extent
stays byte-identical and no keep-clear can push a part off the outline.

`flat_hierarchy` is the **only** tracked board declaring above the fab floor
(0.2500), and all 6 of its NPTH pads carry `lc 0.0` — so it is the single witness
that the term fires at all: HOLE4 at `--clearance 0.10`, keep-out radius
2.3500 → 2.4000, extents unchanged.

**Commit 5 — the pair cap, which was broken before this branch.**
`pair_shortfall`'s `PAIR_TEST_CAP` branch returned a hardcoded `hole=0.0`, so
the hole channel could never fire for the dense connectors that carry mounting
holes. That is in `d540c21f` too — it is a pre-existing defect this branch
happened to walk into, not one commits 1–4 introduced.

Corpus-reachable: `glasgow_revC` J5 × U30 is the one over-cap pair with a hole
on the 22 tracked boards — 44 × 121 = **5324 pad pairs** against 2 hole circles
× 121 pads = **242 hole tests**, a factor of 22. (The commit message and the
shipped comment first said "4 holes / 660 tests / two orders"; re-measured and
corrected — J5 has 2 NPTH drill circles, not 4.)

**Commit 6 — one of these was mine.** `reach` feeds two things: the early-out,
and the shortfall the cap branch charges as `PairShortfall.pad`. Folding
`hole_reach` into one number billed a single physical violation to two
independent gates. The tell is that the answer depended on the pad-pair
**product**, a performance switch that must never move a verdict:

```
identical geometry, one hole at lc 1.0, pads 0.30mm off the wall
  60x60 = 3600 pairs, uncapped ->  pad 0.0000   hole 0.7000
  70x70 = 4900 pairs, capped   ->  pad 0.7000   hole 0.7000
```

Also in 6: `resolve_npth_floor` dropped the caller's `pcb_file` (the #498 rule;
flat_hierarchy staged into a temp dir resolves 0.2000 where the real path
resolves 0.2500 — exactly the radius this term exists for), fixed **at** the
resolver with an optional `pcb_file` on `obstacle_map.resolve_hole_clearance`
rather than a second path read; a failed resolution was silent while
`clearance_notes` exists for exactly that; and `obstacle_map`'s docstring still
said `PartPads` cannot reach the helper, corrected in place rather than deleted.

## What this does NOT claim

- **`check_drc` has no pad-vs-NPTH-hole arm at all.** Its `holes` list feeds a
  TRACK arm and a VIA arm, and the pad-pad check skips NPTH pads at two sites.
  The *rule* is shared — KiCad's `hole_clearance` is item-type agnostic — but
  this geometry is graded nowhere else in the repo, which is why the placer could
  model it at zero for as long as it did and why "grade the corpus with
  `check_drc`" is not available as a check. `TestParityWithTheChecker` pins the
  absence by line and mirrors `check_drc.py:2714`'s expression, saying out loud
  that it is a mirror.
- **The silk commit (`44e986f9`) claimed a defect that did not exist**, corrected
  in commit 7. `labels.py` is the only `copper_holes=False` caller and passes no
  floor, so silk took the flat fab floor either way — 24 hole circles and 539
  `beautify_labels` results are byte-identical across the whole change. The gate
  is hardening against a future silk caller, not a shipped fix.
- **Disclosed, not fixed:** the hole channel files into `required` but not into
  `worst`, so a hole-ONLY conflict is printed by `format_required_clause` and is
  invisible to `floorplan.suspect_pairs`. Widening `worst` changes what
  `place_seed --repair` moves, which needs its own before/after.
- **`PartPads.clearance` is a public mutable slot** feeding `hole_reach` (at
  `__init__`) and `_keepout_cache` (a LAZY per-rotation memo). Mutating it
  between construction and first use moves the radii but not the reach; after
  first use it leaves the already-cached rotations stale. Nothing mutates it
  today; `seeder` mutates `state.clearance` at four sites next door.
- **The `required` disclosure has no corpus witness either.** It fires only when
  an override or a board floor exceeds `--clearance`, so at 0.50 — the one
  clearance where the hole channel fires on real boards — `required` is empty on
  all three. It is demonstrated synthetically and on the two boards that can
  reach it in principle (ulx3s, flat_hierarchy), not on a corpus run.
- **New line on stdout.** `grade_pad_legality` and `QuenchState` now reach
  `resolve_hole_clearance`, which prints `Copper-to-hole clearance 0.25mm (…)`
  once per process for a board declaring above the fab floor — new output for
  `check_assembly`, `place_optimize`, `place_seed`, `place_reconstruct`,
  `lock_advisor` and `floorplan`. Announce-once per (process, path), so an
  in-process A/B sees it on one arm only.
- **`clearance_notes` is threaded at the census only.** `quench.py`'s call site
  passes `pcb_file` but no `notes`, so a failed resolution there is still
  silent — it has no notes channel to file into.
- **Two `grade_pad_legality` callers still resolve off `source_path`**
  (`floorplan.py:1533`, `lock_advisor.py:261`). They hold no path to pass —
  both take only `pcb_data` — so they get the same answer they got before this
  change; the gap is theirs to close, not this PR's to paper over.
  `fanout_clearance.py:666` / `:2809` DO hold one and still call
  `resolve_hole_clearance(pcb_data, None)`; the new parameter is available to
  them and wiring it is a separate change with its own before/after.

## Corpus: INERT at file poses, live during pose search

Re-measured on the 22 boards `run_utils.corpus_boards()` returns, at
`--clearance` 0.10 and 0.25, at the complete requirement
`max(clearance, max(NPTH_TO_TRACK_CLEARANCE, declared), lc)`. **9 boards carry an
NPTH hole (37 holes); 13 carry none, so they are vacuous rather than clean** —
the claim rests on those 9.

| board | req @0.25 | tightest wall gap | margin | conflicts |
|---|---|---|---|---|
| ulx3s | 0.400 | 0.4100 (AUDIO1↔R60) | **+0.0100** | 0 → 0 |
| rp2350_fpga_eensy_prePlane | 0.250 | 0.3705 (J2↔R11) | +0.1205 | 0 → 0 |
| orangecrab_ext_pll | 0.250 | 0.3910 (H4↔FID6) | +0.1410 | 0 → 0 |
| watchy | 0.250 | 0.6332 (SW1↔J1) | +0.3832 | 0 → 0 |
| glasgow_revC | 0.250 | 0.8150 | +0.5650 | 0 → 0 |
| splitflap_driver | 0.250 | 0.8920 | +0.6420 | 0 → 0 |
| esp_prog | 0.250 | 1.3125 | +1.0625 | 0 → 0 |
| tigard | 0.250 | 1.3136 | +1.0636 | 0 → 0 |
| flat_hierarchy | 0.250 | 3.9449 | +3.6949 | 0 → 0 |

But `pair_shortfall` and `grade_pad_legality` are what the pose search grades
with: `quench` builds the one production `LegalityContext` and `seeder` calls
`pair_shortfall` directly. (`routability` also builds parts, but reads only
`pp.extent` and never reaches the hole channel — an earlier draft listed it here
and a fact-check refuted that.)

A reviewer counted 709 real hole penetrations under jittered poses and reported
the widened census halo catching 2 on splitflap_driver and 3 on tigard that the
old one missed. **That attribution does not survive re-measurement** — with the
model active, `census_reach` is unchanged on every corpus row at 0.10 and 0.25,
so the halo term cannot have been the cause; the keep-out RADIUS (commit 1) is.
The penetrations are real, the halo credit is not, and it is corrected here
rather than quoted.

The corpus arms in `tests/test_761_...py` are **self-expiring**: they assert 0
conflicts on every board at both clearances and pin ulx3s's 0.010 mm margin,
with a message saying the PR's claim has EXPIRED and must be re-measured rather
than the arm relaxed.

## The two standing gates: neither moved

Run on the branch AND on the branch point `d540c21f`, in separate worktrees, by
someone who had not seen my numbers.

**`tests/stress/corpus_noop_sweep.py`** — "HEALTHY BOARDS DO NOT MOVE":

```
42/44 sweeps quiet, 2 moved, 0 could not be swept
VERDICT: PASS (44 row(s) match the recorded baseline)
```

Identical on both sides. The branch-vs-parent JSON diff is empty **at the full
result-dict level**, not merely at the signature level: 0 diffs across
`moved` / `proposed` / `vectors` / `legalize_moves` / `unevidenced` /
`repaired` / `unresolved` on all 44 rows. The two movers are `glasgow_revC`'s
recorded pre-existing `C21`, which the baseline already carries verbatim — and
`glasgow_revC` is precisely the board that would have shown a change, since it
carries 4 NPTH pads and its J5 is the part that exceeds `PAIR_TEST_CAP`.

*Caveat, pre-existing and identical on both sides:* the committed baseline holds
66 rows over 33 boards while only 22 boards exist in `kicad_files/` (11 recorded
boards are generated outputs). So this gate grades **44 of 66** recorded rows.

**`tests/test_placement_ab.py`** — full table, ~5m46s:

```
pinned:   3/3 rows match their measured verdict
baseline: 3 row(s) match placement_ab_baseline.json
PASS
```

Zero `DRIFT` / `INVERTED` / `ORPHAN` / `MALFORMED` on either side, and the two
logs are identical line-for-line — every optimizer trace line included — apart
from temp paths and timings. **`tests/placement_ab_baseline.json` is therefore
NOT re-recorded**, which is the correct outcome: nothing moved.

**Positive control, so PASS is not a dead-code pass.** `grade_pad_legality` at
file poses, branch vs parent, all 22 boards:

| `--clearance` | result |
|---|---|
| 0.10, 0.20, 0.25 | identical on every board, `hole_conflicts` 0 |
| 0.50 | branch diverges on exactly three boards, hole channel ONLY — `orangecrab_ext_pll` 0→2, `rp2350_fpga_eensy_prePlane` 0→4, `ulx3s` 0→1, with `pad_conflicts`, `pad_shortfall` and `oob_pad_count` unchanged |

The new keep-out is live and reachable in this tree; it simply does not bind on
healthy file poses at any clearance the gates use, which is exactly the claim.
All three of 0.10 / 0.20 / 0.25 are listed because **the two gates do not run at
one value**: `test_placement_ab` runs at 0.2, while `corpus_noop_sweep` shells
the CLIs with no `--clearance` at all, so each board resolves its own floor —
measured, 0.25 on 20 of 22 boards, 0.20 on flat_hierarchy, 0.09 on
routed_output. `quench(pad_legality=…)` defaults to True, so the A/B gate's
quench runs do execute the changed call site.

## Verification

- **`tests/run_all.py`: 420 passed, 0 failed, 1 timed out** at its own 1200 s
  budget (`test_obstacle_map_balance.py`, under contention from a second suite
  and two review agents on the same box) — re-run alone below. A first run
  reported 94 failures, ALL of them `ModuleNotFoundError: No module named
  'grid_router'`: the compiled Rust extension is gitignored and absent from a
  fresh worktree. That is an environment artifact, not the change; the numbers
  above are from the re-run with `rust_router/grid_router.pyd` (0.21.1) in
  place. Recorded because a 94-failure log is exactly the shape of a
  catastrophic regression and it is worth knowing it is not one.
- `test_obstacle_map_balance.py` re-run alone: **PASS**, exit 0.
- `tests/test_761_legality_npth_keepout.py` — 31 arms; `test_730`,
  `test_placement_pad_legality`, `test_697`, `test_beautify_labels` and
  `test_617_origin_inheritance` all green.
- `tests/mutate_761.py` — **24 rows, 23 KILLED, 1 expected survivor, 0 broken.**
  Rows went BROKEN four separate times as the engine moved under them, which is
  the battery doing its job: an anchor that does not match EXACTLY ONCE is
  reported BROKEN rather than skipped, because a battery that silently applies
  nothing reports every row as a survivor.
  `quench-passes-no-board-floor` SURVIVED until the call-site guard stopped
  counting the *keyword* — `npth_floor=None` satisfies a keyword count while
  supplying nothing.
- A POSITIVE CONTROL in the corpus class, because "inert on the corpus" and
  "wired to nothing" print the same PASS and nothing told them apart.
- Two independent adversarial reviewers, one on the composition and one on the
  bound. Between them: 26 460 composition cases (0 failures at 1e-12, ULP
  artefacts at 1.11e-16), ~205 000 bound probes (0 breaks), byte-identical
  extents and silk across the whole change, and the five defects in commit 6.
- Four defects I introduced and then found, all recorded rather than tidied
  away: a slot arm that set `shape='oval'` and tested **nothing** (a
  zero-length capsule); a silk arm that would have missed the gate by passing
  `None`; a cap arm whose pre-check asserted `n*n` against the cap while the
  parts it built had `n*n + 1` pads each; and two mutation rows left as a
  `SyntaxError` by unescaped `sed` metacharacters (`bb8f4477`) — a battery that
  cannot start reports nothing at all, which is only safe because someone runs
  it.
- A fact-check of this description refuted **eight** of its claims. Each is
  corrected above with the measurement, in place rather than deleted: the
  "commit 1 is inert without commit 2" overstatement, "storage is unchanged",
  the commit count and the pre-existing-ness of commit 5, the census-halo
  credit, the clearance the gates run at, `routability` in the pose-search
  list, the `PartPads.clearance` cache description, and the shipped comment's
  "4 holes / 660 tests".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
