### PR TITLE
#701/#704: a declared keep-out is enforced, and a decap limit can be authored

### DIFF
--- a/.claude/skills/plan-pcb-placement/SKILL.md
+++ b/.claude/skills/plan-pcb-placement/SKILL.md
@@ -81,6 +81,7 @@ this part* and *everything near it is locked*.
 
 | verdict | what it means | what to do |
 | --- | --- | --- |
+| `keepout_blocks` | a **declared keep-out** refuses it — measured, by recounting the poses with that keep-out lifted (#701) | move the keep-out, or add the part to its `allow` list if it owns it |
 | `no_movable_neighbour` | nothing seated is near it | eviction cannot help — the pocket does not exist; re-check the outline or the intent |
 | `immovable_given_frozen` | everything near it is frozen (it names each neighbour **and the decision that froze it**) | unlock one of them, or accept it |
 | `blocker_available` | a useful blocker exists, the rung is disarmed | raise `--evict-depth` |

--- a/docs/floorplan-intent.md
+++ b/docs/floorplan-intent.md
@@ -20,8 +20,9 @@ python3 py_tools/check_floorplan.py board.kicad_pcb --intent floorplan.json --js
 
 The intent is also a GENERATOR input, not only a grader's: `place_seed.py`
 turns a declared intent into an initial placement for an unplaced board
-(zones, edge bands, locks and decap rules become placement constraints, and
-the emitted seed is graded against the same intent it was built from), and
+(zones, edge bands, keep-outs, locks and decap rules become placement
+constraints, and the emitted seed is graded against the same intent it was
+built from), and
 `place_portfolio.py` uses the intent as the hard gate plus the `health`
 signals when ranking K perturbed placement candidates. See
 `placement/README.md` for both.
@@ -221,7 +222,7 @@ for it, and the reason is printed:
 | `zone_containment` | a member's courtyard leaves its block's zone | `GradedPart.rect` |
 | `zone_side` | a member is on the other face | `legality.footprint_side` |
 | `zone_exclusive` | a non-member intrudes on a reserved zone | `rect_overlap_area` |
-| `keepout` | any part enters a keep-out, unless in `allow` | courtyard **and** through-hole rect |
+| `keepout` | any part enters a keep-out, unless in `allow` | courtyard **and** through-hole rect. **Enforced, not only graded, since [#701](https://github.com/drandyhaas/KiCadRoutingTools/issues/701)** — the seat search refuses such a pose through the same `keepout_hit` this rule calls |
 | `edge_connector` | overhang outside `[min,max]`, or the wrong edge; a `connector_affinity` entry seated more than 3 mm from every edge fires at **warn** whatever the configured severity | `BoardOutlineGate.rect_outside_amount`, `edge_clearance` |
 | `decap_distance` | a decoupling cap is too far from its own IC | `groups.decap_tethers` |
 | `must_lock` | a declared-critical part is not locked in the file | `parser.extract_locked_refs` |
@@ -446,10 +447,118 @@ design.
 
 A withheld key is **abstained at grade time, not passed**. `check_floorplan
 --intent` reads `context.budget_withheld`, reports every withheld key that the
-intent does not also declare under `N legality budget key(s) NOT DERIVABLE --
+intent does not also declare under `N declared value(s) NOT DERIVABLE --
 not graded, not passed`, and carries them as `budget_abstained` in `--json` and
 as `budget_abstained` / `budget_abstained_keys` in `JSON_SUMMARY`. When the
 whole budget is empty the `legality` rule does not run at all, and its skip
 reason names the withholding rather than saying only "the intent declares no
 legality_budget". Declaring the key by hand overrides the note: a declared
 budget is graded.
+
+The withholding channel is **not legality-only**. `_WITHHELD_RULE` maps each
+withholdable key to the rule it disarms and to the test for "declared by hand
+anyway", so a withheld `decaps.max_distance_mm` reaches `decap_distance`'s skip
+reason exactly as `overlap_area` reaches `legality`'s. A key that is in
+`budget_withheld` but in no such mapping still abstains — reported as not
+derivable, blamed on no rule — rather than being dropped, so a typo'd
+withholding note is visible instead of silent.
+
+## `--declare-decaps`: a decap limit read off the board (#704)
+
+`emit_intent` wrote `decaps: {}` as a constant, so `rule_decap_distance` could
+never fire on an auto-emitted intent. With `--declare-decaps` it derives
+`max_distance_mm` from the board's own tethers.
+
+**The statistic is `ceil(max)`, and the argument is a fixed point, not a
+statistic.** An emitted intent is a baseline to tighten: emit, grade clean,
+re-emit, get the same limit. Only the max has that property. The median is
+refuted by measurement — `glasgow_revC`'s tether median is **0.0000**, because
+58 of its 87 caps sit inside their IC's bounding box and clamp to zero, so a
+median limit flags 29 caps on a healthy human-routed board at the first
+emission. A high percentile has no fixed point at all: it flags ~5% by
+construction, forever, and every violation is then manufactured by the emitter
+rather than found on the board.
+
+`_ceil4`, not `round`, and derived from the **unrounded** max: `round(v, 4)`
+can land below the measured value, so the document would fail against the very
+board it was written from. That bites on 3 of the 9 tracked boards
+(splitflap_driver 3.4617228369700497 → 3.4617, ulx3s 4.714904558949195 →
+4.7149, glasgow_revC 4.786912496589008 → 4.7869). `context.decap_census`
+therefore carries `max_mm` unrounded and `max_mm_display` for the reader.
+
+### When it is withheld, and why the issue's own guard could not be used
+
+The obvious guard — withhold when the emitting board already violates the
+number — is **unreachable**: `ceil(max(observed))` is ≥ every observed value by
+construction, so it would be a branch that never executes, which is worse than
+absent because it reads like a guard.
+
+The reachable analogue is **censoring**. `groups.decap_tethers` drops any cap
+further than `DECAP_RADIUS_MM` (5 mm) from a chip carrying its rail, so the
+observed distribution is censored and a limit read off the survivors can bless
+a board whose caps have left decoupling range. Measured over the tracked
+boards:
+
+| board | tethers ≤5 mm | beyond | censored | max (≤5 mm) | worst beyond |
+|---|---|---|---|---|---|
+| tigard | 25 | 1 | 0.04 | 3.0650 | 6.17 |
+| glasgow_revC | 87 | 5 | 0.05 | 4.7869 | 10.34 |
+| splitflap_driver | 11 | 1 | 0.08 | 3.4617 | **19.30** |
+| watchy | 24 | 2 | 0.08 | 3.7525 | 11.16 |
+| ulx3s | 53 | 7 | 0.12 | 4.7149 | 12.24 |
+| kit-dev-coldfire | 41 | 12 | 0.23 | 4.8990 | — |
+| interf_u_unrouted | 1 | 4 | **0.80** | 4.5800 | 19.82 |
+| sonde_u | **0** | 5 | **1.00** | — | 15.58 |
+
+Healthy 0.04–0.23, degenerate 0.80–1.00. So the limit is withheld when there
+are **no** tethers, **fewer than `DECAP_MIN_SAMPLE` (3)** — a max over one
+sample is a coordinate, not a limit — or **more than `DECAP_MAX_CENSORED`
+(0.25)** of the rail-sharing caps lie beyond the radius.
+
+A rejected alternative, recorded so it is not re-proposed: withhold when
+`max > K × p75` (the max is a tail outlier over its own body). Built and
+measured, and it does **not** separate — healthy splitflap_driver scores 2.46
+and mid-repair `tigard_placed` 2.22.
+
+### What the census discloses that the rule cannot see
+
+`context.decap_census` is written on **every** emission, with or without the
+flag, so a reader of the document can tell "no cap is far from its IC" from
+"nobody measured". It carries the metric, the search radius, the tether and IC
+counts, the max and median, and — the point of it — `beyond_radius`,
+`beyond_radius_refs` and `worst_beyond_mm`.
+
+That last group is a **known, unfixed hole**, disclosed rather than closed: the
+emitter and the rule both call `decap_tethers` at the same 5 mm truncation, so
+`splitflap_driver` emits a limit of 3.4618 while a rail-sharing cap sits
+**19.30 mm** from its IC, invisible to both. `rules_run` goes up; that cap is
+still ungraded.
+
+### Declaring this key CHANGES PLACEMENT
+
+It is not a grading-only knob, which is why it is opt-in, default off, and on
+its own flag rather than folded into `--declare-classes`. `place_seed` reads
+`decaps.max_distance_mm` and, when it is set, pulls every two-net-bearing-pad
+`C*` out of radial zone packing into its per-supply-pin stage. Measured:
+
+| board | seeder scope | graded tethers | in scope, never graded |
+|---|---|---|---|
+| ulx3s | 70 | 53 | 17 |
+| glasgow_revC | 92 | 87 | 5 |
+| watchy | 28 | 24 | 4 |
+| splitflap_driver | 12 | 11 | 1 |
+
+The two populations differ because the two "is this a decap" predicates
+differ — the grouper tests *exactly two distinct net ids*, the seeder *exactly
+two net-bearing pads* — and the metrics differ too. `context.decap_census`
+carries `seeder_scope` and `seeder_scope_ungraded`, and `--emit-intent` prints
+the same warning. Reconciling the predicates is a separate change.
+
+### `keepouts` stays empty, and says so
+
+A keep-out is a mechanical fact — an enclosure rib, a standoff, a battery, a
+display window, an antenna clearance — and none of those can be read off a
+board, so the emitter keeps writing `[]`. What it should not do is leave the
+reader unable to tell *"none declared"* from *"not considered"*, so
+`context.keepouts_note` states which one it is. At grade time the same
+distinction is already carried by `rules_skipped` and by `--require-rules`.

--- a/py_placer/place_seed.py
+++ b/py_placer/place_seed.py
@@ -509,7 +509,12 @@ Examples:
                 st = pose_score.make_state(
                     pcb_cur, args.output_file, clearance=args.clearance,
                     board_edge_clearance=args.board_edge_clearance,
-                    grid_step=args.grid_step)
+                    grid_step=args.grid_step,
+                    # #701: the ONLY seat-predicate call site outside
+                    # seeder.py. Without this the re-seat below would be free
+                    # to put the part back into a declared keep-out while
+                    # fixing its zone.
+                    keepouts=intent.keepouts)
                 blocks2, _p = floorplan.resolve_blocks(intent, pcb_cur,
                                                        sources)
                 zone_of = {}

--- a/py_placer/place_seed.py
+++ b/py_placer/place_seed.py
@@ -500,9 +500,16 @@ Examples:
         # space too (measured: 0.784mm2 of new overlap) -- so the part is
         # RE-SEATED: the seeder's own search, targeted at its seeded pose,
         # constrained to its zone, against the post-polish board.
+        # #701: and it has no keep-out term either, so the same nudge can walk
+        # a part into a declared keep-out -- on a board this tool's own seeder
+        # placed correctly, which then exits 4 against its own intent. Same
+        # repair, same reason, one more rule name.
         if not args.no_polish:
+            _repairable = ('zone_containment', 'keepout')
             broke = sorted({v.ref for v in graded.errors
-                            if v.rule == 'zone_containment' and v.ref})
+                            if v.rule in _repairable and v.ref})
+            _rules = sorted({v.rule for v in graded.errors
+                             if v.rule in _repairable and v.ref})
             if broke:
                 import pose_score
                 pcb_cur = parse_kicad_pcb(args.output_file)
@@ -528,20 +535,25 @@ Examples:
                 for ref in broke:
                     z = zone_of.get(ref)
                     sp = seeded_pose.get(ref)
-                    if z is None or sp is None or ref not in st.parts:
+                    # #701: a keep-out violation does NOT imply a zone. The
+                    # zone-only version required one and skipped a zone-less
+                    # part entirely, which would have left the keep-out half
+                    # of this repair silently inert on most boards.
+                    if sp is None or ref not in st.parts:
                         continue
                     clr = seeder._try_place(
                         st, ref, sp['new_x'], sp['new_y'], set(),
-                        constraint=z.rect, tol=intent.zone_tolerance(z))
+                        constraint=z.rect if z is not None else None,
+                        tol=intent.zone_tolerance(z) if z is not None else 0.5)
                     if clr is not None:
                         p2 = st.parts[ref]
                         fixes.append({'reference': ref, 'new_x': p2.x,
                                       'new_y': p2.y, 'new_rotation': p2.rot})
                 if fixes:
                     print(f"  polish walked "
-                          f"{', '.join(f['reference'] for f in fixes)} out "
-                          f"of a declared zone; re-seated in-zone against "
-                          f"the polished board")
+                          f"{', '.join(f['reference'] for f in fixes)} out of "
+                          f"a declared {' / '.join(_rules)}; re-seated "
+                          f"against the polished board")
                     tmp = args.output_file + '.reseat'
                     write_placed_output(args.output_file, tmp, fixes)
                     os.replace(tmp, args.output_file)

--- a/py_placer/placement/README.md
+++ b/py_placer/placement/README.md
@@ -218,12 +218,16 @@ in the JSON_SUMMARY and as a NOTE:
 
 `no_pose_census[ref]` carries the counts those verdicts came from — `boxed`,
 `movable`, `censused`, `frozen`, `truncated`, `baseline`, `pairs_total`,
-`pairs_censused`, `pairs_truncated`, `best_pair`, `keepouts_freeing` — so a
-capped sweep can never
+`pairs_censused`, `pairs_truncated`, `best_pair`, `keepouts_freeing`,
+`keepouts_joint` — so a capped sweep can never
 read as a complete one. `keepouts_freeing` is `{keep-out name: poses freed by
 lifting it}`, filled only for a part with no pose at all and only over the
 keep-outs that bind it; it is the count `keepout_blocks` is derived from, so
 the verdict cannot drift from a differently-computed claim.
+`keepouts_joint` is the poses freed by lifting **every** bound keep-out at
+once, and it exists because two that overlap over the part's feasible region
+each free *nothing alone* — so `keepouts_freeing` is `{}` and, without this,
+the verdict would fall back to `no_movable_neighbour` and blame the outline.
 `movable` and `censused` are deliberately separate:
 the first is how many neighbours *could* have been censused, the second how
 many were, and quoting the first as the second is the inversion the whole

--- a/py_placer/placement/README.md
+++ b/py_placer/placement/README.md
@@ -206,6 +206,7 @@ in the JSON_SUMMARY and as a NOTE:
 
 | verdict | what it means | what to do about it |
 | --- | --- | --- |
+| `keepout_blocks` | a **declared keep-out** is what refuses it — measured, not inferred: the poses are recounted with that keep-out lifted (#701) | move the keep-out, or add the part to its `allow` list if it owns it |
 | `no_movable_neighbour` | nothing seated is near enough to be in the way | the outline, the zone or the part's own size refuses it |
 | `immovable_given_frozen` | the only neighbours in the way are locked or declared edge connectors, **named with the decision that froze each** | relax that lock, or accept the pose |
 | `no_single_lift_frees` | movable neighbours censused; no single lift frees a pose | try `--evict-depth 2` |
@@ -217,8 +218,13 @@ in the JSON_SUMMARY and as a NOTE:
 
 `no_pose_census[ref]` carries the counts those verdicts came from — `boxed`,
 `movable`, `censused`, `frozen`, `truncated`, `baseline`, `pairs_total`,
-`pairs_censused`, `pairs_truncated`, `best_pair` — so a capped sweep can never
-read as a complete one. `movable` and `censused` are deliberately separate:
+`pairs_censused`, `pairs_truncated`, `best_pair`, `keepouts_freeing` — so a
+capped sweep can never
+read as a complete one. `keepouts_freeing` is `{keep-out name: poses freed by
+lifting it}`, filled only for a part with no pose at all and only over the
+keep-outs that bind it; it is the count `keepout_blocks` is derived from, so
+the verdict cannot drift from a differently-computed claim.
+`movable` and `censused` are deliberately separate:
 the first is how many neighbours *could* have been censused, the second how
 many were, and quoting the first as the second is the inversion the whole
 disclosure exists to prevent.

--- a/py_placer/placement/floorplan.py
+++ b/py_placer/placement/floorplan.py
@@ -683,6 +683,74 @@ def _circle_hits_rect(cx, cy, radius, rect) -> bool:
 
 
 # --------------------------------------------------------------------------
+# keep-outs: ONE resolver and ONE hit test, shared by the grader (rule_keepout,
+# below) and the seat predicate (seeder.pose_ok / seeder.edge_seat_ok).
+#
+# They live here, together, because the alternative measured badly elsewhere in
+# this module: docs/floorplan-intent.md says of the rules that "every one of
+# them measures with the geometry the OPTIMIZER ITSELF gates on", and until
+# #701 the keepout row was the one place that was false -- the optimizer gated
+# on nothing at all. A seat the search accepts that the grade then flags is an
+# exit 4 on a board the seeder produced correctly, so the two must not be two
+# implementations.
+# --------------------------------------------------------------------------
+
+def keepouts_for_ref(keepouts, ref: str, sides) -> Tuple[Dict, ...]:
+    """The keep-out entries that BIND `ref`: not exempted by `allow`, and
+    sharing at least one face with it.
+
+    Pose-INVARIANT by construction -- an fnmatch against a reference and the
+    set of faces a part occupies are both unchanged by moving it -- which is
+    what lets a seat search resolve this ONCE per part instead of once per
+    candidate pose. `_try_place` evaluates thousands of poses per part.
+
+    Both filters live here rather than at each caller, for the reason
+    `Intent.edge_claims` gives about its own split: a filter that must be
+    remembered is a filter that will be forgotten at the next call site. If
+    the seat honoured an `allow` glob the grade ignored, a mounting-hole
+    keep-out would strand its own mounting hole.
+    """
+    out = []
+    for k in keepouts:
+        if any(fnmatch.fnmatch(ref, pat) for pat in (k.get('allow') or ())):
+            continue
+        if not (set(sides) & set(k.get('sides') or ('F', 'B'))):
+            continue
+        out.append(k)
+    return tuple(out)
+
+
+def keepout_hit(entry, rects) -> float:
+    """How far into keep-out `entry` any of `rects` reaches; 0.0 when clear.
+
+    THE hit test. The `legality.EPS` thresholding is INSIDE this function, not
+    at the callers: two `> EPS` comparisons at two call sites are two chances
+    to drift, and a pose the seeder accepts at the boundary that the grade
+    then flags is exactly the round trip this exists to keep closed.
+
+    `rects` may contain None -- `quench._Part.rects()` returns
+    `(courtyard, None)` for a part with no drilled pads -- so both callers can
+    pass their own natural shape without a branch.
+
+    A rect entry returns the overlap AREA in mm2. A circle entry returns 1.0:
+    a MARKER, not a measurement. Nothing in this tree computes circle/rect
+    intersection area, and returning a fabricated one would be a figure a
+    reader could quote.
+    """
+    hit = 0.0
+    for r in rects:
+        if r is None:
+            continue
+        if entry.get('rect') is not None:
+            hit = max(hit, legality.rect_overlap_area(r, entry['rect']))
+        else:
+            cx, cy, radius = entry['circle']
+            if _circle_hits_rect(cx, cy, radius, r):
+                hit = max(hit, 1.0)
+    return hit if hit > legality.EPS else 0.0
+
+
+# --------------------------------------------------------------------------
 # the board's own outline, checked before anything is graded against it
 # --------------------------------------------------------------------------
 
@@ -999,26 +1067,17 @@ def rule_keepout(ctx) -> Iterator[Violation]:
     for k in ctx.intent.keepouts:
         name = k['name']
         allow = k.get('allow') or ()
-        sides = set(k.get('sides') or ('F', 'B'))
         for ref, part in sorted(ctx.parts.items()):
-            if any(fnmatch.fnmatch(ref, pat) for pat in allow):
+            # `allow` and the side filter, from the SHARED resolver: the grader
+            # and the seat predicate must agree on WHICH keep-outs bind a ref,
+            # not merely on the geometry once they do. A through-hole part
+            # occupies BOTH faces -- its leads pass through the keep-out even
+            # when its body sits on the other side -- which is why `sides` is
+            # `part.sides` and the hit test below is given both rects.
+            if not keepouts_for_ref((k,), ref, part.sides):
                 continue
-            # A through-hole part occupies BOTH faces: its leads pass through
-            # the keep-out even when its body sits on the other side.
-            if not (set(part.sides) & sides):
-                continue
-            rects = [part.rect]
-            if part.tht_rect is not None:
-                rects.append(part.tht_rect)
-            hit = 0.0
-            for r in rects:
-                if k.get('rect') is not None:
-                    hit = max(hit, legality.rect_overlap_area(r, k['rect']))
-                else:
-                    cx, cy, radius = k['circle']
-                    if _circle_hits_rect(cx, cy, radius, r):
-                        hit = max(hit, 1.0)
-            if hit > legality.EPS:
+            hit = keepout_hit(k, (part.rect, part.tht_rect))
+            if hit:
                 shape = (_fmt_rect(k['rect']) if k.get('rect') is not None
                          else f"circle {k['circle']}")
                 yield Violation(

--- a/py_placer/placement/floorplan.py
+++ b/py_placer/placement/floorplan.py
@@ -1064,20 +1064,21 @@ def rule_zone_exclusive(ctx) -> Iterator[Violation]:
 
 
 def rule_keepout(ctx) -> Iterator[Violation]:
-    for k in ctx.intent.keepouts:
-        name = k['name']
-        allow = k.get('allow') or ()
-        for ref, part in sorted(ctx.parts.items()):
-            # `allow` and the side filter, from the SHARED resolver: the grader
-            # and the seat predicate must agree on WHICH keep-outs bind a ref,
-            # not merely on the geometry once they do. A through-hole part
-            # occupies BOTH faces -- its leads pass through the keep-out even
-            # when its body sits on the other side -- which is why `sides` is
-            # `part.sides` and the hit test below is given both rects.
-            if not keepouts_for_ref((k,), ref, part.sides):
-                continue
-            hit = keepout_hit(k, (part.rect, part.tht_rect))
-            if hit:
+    # PART-outer, so `keepouts_for_ref` is called once per part over the whole
+    # list -- which is the resolution its own docstring describes, and the
+    # same shape `QuenchState` uses to build `keepouts_for`. Keep-out-outer
+    # with a 1-tuple worked, but rebuilt two sets per (keep-out, part) pair.
+    # Violation order is not affected: `grade` sorts on `Violation.sort_key`.
+    for ref, part in sorted(ctx.parts.items()):
+        # `allow` and the side filter, from the SHARED resolver: the grader
+        # and the seat predicate must agree on WHICH keep-outs bind a ref, not
+        # merely on the geometry once they do. A through-hole part occupies
+        # BOTH faces -- its leads pass through the keep-out even when its body
+        # sits on the other side -- which is why `sides` is `part.sides` and
+        # the hit test is given both rects.
+        for k in keepouts_for_ref(ctx.intent.keepouts, ref, part.sides):
+            if keepout_hit(k, (part.rect, part.tht_rect)):
+                name = k['name']
                 shape = (_fmt_rect(k['rect']) if k.get('rect') is not None
                          else f"circle {k['circle']}")
                 yield Violation(
@@ -1086,7 +1087,7 @@ def rule_keepout(ctx) -> Iterator[Violation]:
                              f"{name!r} {shape}"),
                     measured={'keepout': name, 'side': part.side,
                               'sides_occupied': sorted(part.sides)},
-                    expected={'allow': list(allow)})
+                    expected={'allow': list(k.get('allow') or ())})
 
 
 def rule_edge_connector(ctx) -> Iterator[Violation]:

--- a/py_placer/placement/floorplan.py
+++ b/py_placer/placement/floorplan.py
@@ -1298,6 +1298,37 @@ _SKIP_REASON = {
 }
 
 
+#: A key `emit_intent` may WITHHOLD -> (the rule that key disarms, a predicate
+#: for "the author declared it by hand anyway"). One table, because the old
+#: code hard-wired both halves to `legality`: it computed the abstention as
+#: "in budget_withheld and not in legality_budget", and attached the note only
+#: when `name == 'legality'`. Neither generalises, and #704 adds a withheld key
+#: that is not a budget at all.
+#:
+#: A key that is NOT in this table still abstains -- it is reported as not
+#: derivable and blamed on no rule -- rather than being silently dropped. A
+#: typo'd withholding note is then visible, which is the whole point of the
+#: channel.
+_WITHHELD_RULE = {
+    'overlap_area': ('legality',
+                     lambda i: 'overlap_area' in (i.legality_budget or {})),
+    'oob_count': ('legality',
+                  lambda i: 'oob_count' in (i.legality_budget or {})),
+    'oob_amount': ('legality',
+                   lambda i: 'oob_amount' in (i.legality_budget or {})),
+    'decaps.max_distance_mm': (
+        'decap_distance',
+        lambda i: (i.decaps or {}).get('max_distance_mm') is not None),
+}
+
+
+def _declared_by_hand(intent: Intent, key: str) -> bool:
+    """Did the author declare a withheld key anyway? Then it is graded, and
+    the withholding note is only history."""
+    entry = _WITHHELD_RULE.get(key)
+    return bool(entry and entry[1](intent))
+
+
 def _wants(intent: Intent, rule: str) -> bool:
     if rule == 'envelope':
         return intent.envelope.get('rect') is not None
@@ -1410,15 +1441,18 @@ def grade(intent: Intent, pcb_data, pcb_file: str, *,
     # overrides its withholding note.
     abstained = {str(k): str(v)
                  for k, v in (intent.budget_withheld or {}).items()
-                 if k not in (intent.legality_budget or {})}
+                 if not _declared_by_hand(intent, str(k))}
     for name, fn in RULES:
         if not _wants(intent, name):
             reason = _SKIP_REASON.get(name, 'not requested')
-            if name == 'legality' and abstained:
-                # "declares no legality_budget" is true but reads as "nobody
-                # wanted one". Say that the emitter refused to derive it.
+            # "declares no X" is true but reads as "nobody wanted one". Say
+            # that the emitter refused to DERIVE it, on whichever rule the
+            # withheld key disarms -- not only on `legality` (#704).
+            mine = {k: v for k, v in abstained.items()
+                    if (_WITHHELD_RULE.get(k) or (None,))[0] == name}
+            if mine:
                 reason += ('; the emitter WITHHELD ' + ', '.join(
-                    f'{k} ({v})' for k, v in sorted(abstained.items())))
+                    f'{k} ({v})' for k, v in sorted(mine.items())))
             skipped[name] = reason
             continue
         ran.append(name)
@@ -1477,10 +1511,146 @@ def grade(intent: Intent, pcb_data, pcb_file: str, *,
 # emit: a starter intent, derived from the board
 # --------------------------------------------------------------------------
 
+#: Below this many tethers a `max` is a coordinate, not a limit. Chosen, not
+#: tuned: with one or two samples there is no body-versus-tail to speak of, so
+#: a derived limit describes one cap's position rather than a design rule.
+#: Corpus effect, measured: withholds on interf_u_unrouted (1 tether) alone.
+DECAP_MIN_SAMPLE = 3
+
+#: The share of rail-sharing caps that may lie BEYOND the tether search radius
+#: before a derived limit stops meaning anything. `groups.decap_tethers` drops
+#: any cap further than `DECAP_RADIUS_MM` from a chip carrying its rail, so the
+#: observed distribution is CENSORED by construction and a limit read off the
+#: survivors can bless a board whose caps have left decoupling range entirely.
+#: Measured over the tracked boards: healthy 0.04-0.12 (tigard 0.04,
+#: splitflap_driver 0.08, watchy 0.08, ulx3s 0.12, glasgow_revC 0.05),
+#: degenerate or mid-repair 0.42-1.00 (both run-23 tigard fixtures 0.42,
+#: interf_u_unrouted 0.80, sonde_u 1.00). 0.25 sits in that gap with ~2x
+#: margin on the healthy side and ~1.7x on the other.
+DECAP_MAX_CENSORED = 0.25
+
+
+def decap_census(pcb_data, radius: float = None) -> Dict:
+    """What the board's decoupling tethers look like, and what they HIDE.
+
+    Two passes over `groups.decap_tethers`: one at the ordinary radius, which
+    is the population `rule_decap_distance` will grade, and one unbounded,
+    which is the population that actually exists. The difference is the point
+    of this function -- the rule cannot see a cap that has left the search
+    radius, so a limit derived from the survivors is a limit that says nothing
+    about the board's worst decap. Measured on splitflap_driver: max 3.4617mm
+    within the radius, and a rail-sharing cap 19.30mm away that neither the
+    census nor the rule counts.
+
+    Emitted as `context.decap_census` on EVERY intent, flag or no flag, so a
+    reader of the document can tell "no cap is far from its IC" from "nobody
+    measured". That distinction is this module's own stated principle one
+    level down from `rules_run` / `rules_skipped`.
+    """
+    r = float(groups_mod.DECAP_RADIUS_MM if radius is None else radius)
+    near = groups_mod.decap_tethers(pcb_data, radius=r)
+    dists = sorted(d for caps in near.values() for _c, d in caps)
+    # The same query with the radius prune removed. NOT equivalent to
+    # filtering the near result: without the prune, "nearest chip carrying the
+    # rail" can pick a DIFFERENT chip, so this is a second measurement rather
+    # than a superset.
+    far = groups_mod.decap_tethers(pcb_data, radius=float('inf'))
+    beyond = sorted((c, d) for caps in far.values() for c, d in caps
+                    if d > r)
+    n = len(dists)
+    out = {
+        'source': 'auto-tethers',
+        'metric': ('cap footprint centroid to IC bounding box, clamped to 0 '
+                   'inside (placement.groups.decap_tethers)'),
+        'search_radius_mm': round(r, 4),
+        'tethers': n,
+        'ics': len(near),
+        'beyond_radius': len(beyond),
+        'beyond_radius_refs': [c for c, _d in beyond],   # already sorted
+        'worst_beyond_mm': round(beyond[-1][1], 4) if beyond else None,
+    }
+    if n:
+        # NOT rounded, unlike every other number here. This one is
+        # LOAD-BEARING: `_decap_derivation` ceils it, and `round(v, 4)` can
+        # land BELOW the true max -- measured on 3 of the 9 tracked boards
+        # (splitflap_driver 3.4617228369700497 -> 3.4617, ulx3s
+        # 4.714904558949195 -> 4.7149, glasgow_revC 4.786912496589008 ->
+        # 4.7869). Ceiling a display value that is already low reproduces the
+        # exact defect `_ceil4` exists to prevent -- a budget that fails
+        # against the board it was written from -- and it does so INVISIBLY,
+        # because the rounded number looks right. Rounded for the reader in
+        # `max_mm_display`.
+        out['max_mm'] = dists[-1]
+        out['max_mm_display'] = round(dists[-1], 4)
+        out['median_mm'] = round(dists[n // 2], 4)
+    return out
+
+
+def _decap_derivation(census: Dict) -> Tuple[Optional[float], Optional[str]]:
+    """`(max_distance_mm, withheld_reason)` -- exactly one of them is None.
+
+    The limit is `_ceil4(max)`, and the argument for `max` is a FIXED-POINT
+    argument rather than a statistical one. An emitted intent is a baseline to
+    tighten: emit, grade clean, re-emit, same limit. Only the max has that
+    property.
+
+      * the median is refuted by measurement -- glasgow_revC's tether median
+        is 0.0000, because 58 of its 87 caps sit INSIDE their IC's bounding
+        box and clamp to zero. A median limit flags 29 caps on a healthy
+        human-routed board at the first emission.
+      * a high percentile has no fixed point at all: it flags ~5% by
+        construction, forever. Fix those, re-emit, and it flags another 5%.
+        Every violation would be manufactured by the emitter rather than found
+        on the board, which is what `check_floorplan`'s own --clearance help
+        text warns about one channel over.
+
+    `_ceil4` and not `round`: `round` can land BELOW the measured max, so the
+    document would fail against the very board it was written from. Measured,
+    that bites on 3 of the 7 tracked boards (splitflap_driver 3.46172 ->
+    3.4617, ulx3s 4.71490 -> 4.7149, glasgow_revC 4.78691 -> 4.7869).
+
+    WITHHOLDING. The issue proposing this asked for the `overlap_area` guard:
+    withhold when the emitting board already violates the number. That guard
+    is UNREACHABLE here -- `_ceil4(max(observed)) >= every observed` by
+    construction, so it is a branch that can never execute, which is worse
+    than absent because it reads like a guard. The reachable analogue is the
+    CENSORING above: a board whose caps have left the search radius has a
+    survivors' max that blesses it.
+
+    An alternative was built and measured and does NOT work, recorded here so
+    it is not re-proposed: withhold when `max > K * p75` (the max is a tail
+    outlier over its own body). Healthy splitflap_driver scores 2.46 and
+    mid-repair tigard_placed 2.22 -- the two populations overlap, so no
+    threshold separates them.
+    """
+    n = int(census.get('tethers', 0))
+    if not n:
+        return None, (f"no cap is within {census['search_radius_mm']}mm of a "
+                      f"chip carrying its rail, so nothing was measured"
+                      + (f" ({census['beyond_radius']} rail-sharing cap(s) lie "
+                         f"beyond it, worst {census['worst_beyond_mm']}mm)"
+                         if census.get('beyond_radius') else ""))
+    if n < DECAP_MIN_SAMPLE:
+        return None, (f"only {n} tether(s) on the emitting board -- a max "
+                      f"over {n} sample(s) is a coordinate, not a limit "
+                      f"(DECAP_MIN_SAMPLE={DECAP_MIN_SAMPLE})")
+    beyond = int(census.get('beyond_radius', 0))
+    total = n + beyond
+    if total and beyond / total > DECAP_MAX_CENSORED:
+        return None, (
+            f"{beyond} of {total} rail-sharing cap(s) lie beyond the "
+            f"{census['search_radius_mm']}mm search radius (worst "
+            f"{census['worst_beyond_mm']}mm): a limit derived from the "
+            f"survivors would bless a board whose caps have left decoupling "
+            f"range")
+    return _ceil4(float(census['max_mm'])), None
+
+
 def emit_intent(pcb_data, pcb_file: str, *,
                 group_sources: Sequence[str] = ('kicad', 'sheet'),
                 zone_pad_mm: float = 1.0,
-                declare_classes: bool = False) -> Dict:
+                declare_classes: bool = False,
+                derive_decaps: bool = False) -> Dict:
     """A starter intent READ OFF the board, for a human or a model to edit.
 
     Everything here describes what the board already is. The envelope is
@@ -1814,6 +1984,39 @@ def emit_intent(pcb_data, pcb_file: str, *,
         _budget['overlap_area'] = _ceil4(float(leg['overlap_area']))
     if not _suspects:
         _budget['oob_count'] = int(leg['oob_count'])
+
+    # #704. The census runs on EVERY emission: a reader of the document must
+    # be able to tell "no cap is far from its IC" from "nobody measured", and
+    # `decaps: {}` alone says only the second. The LIMIT is opt-in, because
+    # declaring it is not a grading-only change -- see the seeder note below.
+    _census = decap_census(pcb_data)
+    _decaps: Dict[str, object] = {}
+    if derive_decaps:
+        _limit, _why = _decap_derivation(_census)
+        if _limit is None:
+            _withheld['decaps.max_distance_mm'] = _why
+        else:
+            _decaps['max_distance_mm'] = _limit
+            # Repeated inside the census DELIBERATELY: a hand edit of
+            # `decaps.max_distance_mm` that leaves the census behind is then
+            # detectable rather than a silent lie about where the number came
+            # from.
+            _census['emitted_max_distance_mm'] = _limit
+    # What declaring this key COSTS, measured, next to the number itself.
+    # `seeder.seed_from_intent` uses its presence to pull every 2-net-bearing
+    # -pad `C*` out of radial zone packing into stage 2.5, which seats one cap
+    # per supply pin -- a different population from the one graded here (the
+    # grouper tests "exactly two distinct net ids", the seeder "exactly two
+    # net-bearing pads") and a different metric. On ulx3s that is 70 caps
+    # moved to stage 2.5 against 53 graded, 17 of them never graded at all.
+    _scope = {r for r, fp in (pcb_data.footprints or {}).items()
+              if r[:1].upper() == 'C'
+              and len([p for p in fp.pads if p.net_id > 0]) == 2}
+    _census['seeder_scope'] = len(_scope)
+    _census['seeder_scope_ungraded'] = len(
+        _scope - {c for caps in
+                  groups_mod.decap_tethers(pcb_data).values()
+                  for c, _d in caps})
     return {
         'schema': SCHEMA_VERSION,
         'kind': KIND,
@@ -1823,9 +2026,15 @@ def emit_intent(pcb_data, pcb_file: str, *,
                      'tolerance_mm': DEFAULT_ENVELOPE_TOLERANCE_MM},
         'defaults': {'zone_tolerance_mm': DEFAULT_ZONE_TOLERANCE_MM},
         'blocks': blocks,
+        # A keep-out is a MECHANICAL fact -- an enclosure rib, a standoff, a
+        # battery, a display window, an antenna clearance -- and none of those
+        # can be read off a board, so this stays empty and the emitter says so
+        # in `context.keepouts_note` rather than leaving the reader unable to
+        # tell "none declared" from "not considered" (#704). Since #701 a
+        # declared keep-out is ENFORCED by the seat search, not merely graded.
         'keepouts': [],
         'edge_connectors': conns,
-        'decaps': {},
+        'decaps': _decaps,
         # must_lock is a REQUIREMENT ("these refs must end up locked"), and an
         # emitted intent describes a board rather than making demands of it.
         # Filling it with the board's own locked set (as this did) closed a
@@ -1852,6 +2061,16 @@ def emit_intent(pcb_data, pcb_file: str, *,
             # the intent can tell "withheld" from "forgot" (empty when
             # nothing was withheld).
             'budget_withheld': _withheld,
+            # #704: what the tethers look like, and what the RULE cannot see.
+            # Written on every emission, with or without the limit.
+            'decap_census': _census,
+            'keepouts_note': (
+                'empty because a keep-out is a mechanical fact -- an '
+                'enclosure rib, a standoff, a battery, a display window, an '
+                'antenna clearance -- and none of those can be read off a '
+                'board. "[]" here means NONE DECLARED, never "not '
+                'considered". Declare them by hand; since #701 the seat '
+                'search honours them, not only the grade.'),
             'cutouts': [[[round(x, 3), round(y, 3)] for x, y in ring]
                         for ring in (pcb_data.board_info.board_cutouts or [])],
             'edge_contours': len(
@@ -1896,7 +2115,11 @@ def format_text(r: GradeResult) -> str:
             tag = 'ERROR' if v.severity == ERROR else 'warn '
             lines.append(f"    [{tag}] {v.rule}: {v.message}")
     if r.budget_abstained:
-        lines.append(f"  {len(r.budget_abstained)} legality budget key(s) NOT "
+        # "legality budget key(s)" since #704 would be a lie for a withheld
+        # `decaps.max_distance_mm`, which is not a budget. The WIRE key keeps
+        # its name (`budget_abstained` in to_json and summary) because
+        # consumers and tests pin it and renaming it buys nothing measurable.
+        lines.append(f"  {len(r.budget_abstained)} declared value(s) NOT "
                      f"DERIVABLE -- not graded, not passed:")
         for key in sorted(r.budget_abstained):
             lines.append(f"    - {key}: {r.budget_abstained[key]}")

--- a/py_placer/placement/quench.py
+++ b/py_placer/placement/quench.py
@@ -416,7 +416,15 @@ class QuenchState:
                  # built and the objective is bit-identical.
                  corridor_weight: float = 0.0,
                  corridor_specs: Optional[Sequence[Dict]] = None,
-                 corridor_max_fanout: int = 20):
+                 corridor_max_fanout: int = 20,
+                 # --- #701 intent keep-outs. Appended for the same
+                 # positional-binding reason as the #548 block above, and
+                 # empty by default so every state in the tree that does not
+                 # ask for them -- INCLUDING the one `floorplan.grade` builds,
+                 # which must keep measuring independently of the seat gate --
+                 # is bit-identical. Consumed by `seeder.pose_ok` and
+                 # `seeder.edge_seat_ok`; the quench objective never reads it.
+                 keepouts: Optional[Sequence[Dict]] = None):
         bounds = pcb_data.board_info.board_bounds
         if bounds is None:
             raise ValueError("No board boundary (Edge.Cuts) found")
@@ -482,6 +490,25 @@ class QuenchState:
             self.parts[ref].nets = [n for n in self.parts[ref].nets
                                     if n not in ignore]
         warn_missing_courtyards(no_courtyard, 'quench')
+
+        # #701 intent keep-outs, resolved ONCE per state rather than once per
+        # candidate pose. Neither an `allow` fnmatch against a reference nor
+        # the set of faces a part occupies changes when the part moves, so the
+        # only pose-dependent work left for the seat predicate is the geometry
+        # itself. `_try_place` evaluates thousands of poses per part, so this
+        # is the difference between a conjunct and a regression.
+        #
+        # `keepouts_for` is EMPTY on every board that declares no keep-out --
+        # which is every board in the corpus today -- and `pose_ok` guards on
+        # that emptiness, so the whole channel is inert unless asked for.
+        self.keepouts = tuple(keepouts or ())
+        self.keepouts_for: Dict[str, Tuple[Dict, ...]] = {}
+        if self.keepouts:
+            from . import floorplan as _fp
+            for _ref, _p in self.parts.items():
+                _binding = _fp.keepouts_for_ref(self.keepouts, _ref, _p.sides)
+                if _binding:
+                    self.keepouts_for[_ref] = _binding
 
         # Run-6 CONTAINER exemption: a courtyard covering most of the board
         # is a FRAME (a module-outline footprint hosting the whole design),

--- a/py_placer/placement/seeder.py
+++ b/py_placer/placement/seeder.py
@@ -533,6 +533,10 @@ def _empty_census() -> Dict:
     return {'boxed': 0, 'movable': 0, 'censused': 0, 'frozen': {},
             'truncated': 0, 'baseline': 0, 'pairs_total': 0,
             'pairs_censused': 0, 'pairs_truncated': 0, 'best_pair': None,
+            # #701: poses freed by lifting EVERY bound keep-out at once, for
+            # a part no single one explains. 0 means the keep-outs are not
+            # jointly what refuses it.
+            'keepouts_joint': 0,
             # #701: {keep-out name: poses freed by lifting it}. Present and
             # empty on every part, per this function's whole rationale --
             # a consumer must never need a defaulting `.get` to tell "no
@@ -542,7 +546,7 @@ def _empty_census() -> Dict:
 
 def _verdict_for(cands: Sequence[str], census: Dict) -> str:
     """The verdict for a part still unseated after the census."""
-    if census.get('keepouts_freeing'):
+    if census.get('keepouts_freeing') or census.get('keepouts_joint'):
         # #701, and FIRST: a declared keep-out that frees poses when lifted
         # is the answer, whatever the neighbours look like. It outranks
         # `no_movable_neighbour`, whose prose would actively mislead here,
@@ -585,12 +589,23 @@ def _no_pose_note(ref: str, verdict: str, census: Dict,
         tail += ("; also in the way, and not this rung's to move: "
                  + ', '.join(f"{r} ({why})" for r, why in sorted(frozen.items())))
     if verdict == 'keepout_blocks':
-        who = ', '.join(f"{n!r} (frees {c})" for n, c
-                        in sorted((census.get('keepouts_freeing') or {}).items()))
-        return (f"{ref}: no legal pose, and the DECLARED KEEP-OUT(S) {who} "
-                f"are what refuse it -- not a neighbour, and not this rung's "
-                f"to lift. Move the keep-out, or add {ref} to its `allow` "
-                f"list if it is the part that owns it")
+        freeing = census.get('keepouts_freeing') or {}
+        if freeing:
+            who = ', '.join(f"{n!r} (frees {c})"
+                            for n, c in sorted(freeing.items()))
+            what = (f"the DECLARED KEEP-OUT(S) {who} are what refuse it -- "
+                    f"not a neighbour")
+        else:
+            # The JOINT case: no single keep-out frees a pose, all of them
+            # together do. Naming one here would be false of every individual
+            # one, which is why the sentence does not.
+            what = (f"the declared keep-outs are JOINTLY what refuse it -- "
+                    f"no single one frees a pose, lifting all of them frees "
+                    f"{census.get('keepouts_joint', 0)}, and no neighbour is "
+                    f"involved")
+        return (f"{ref}: no legal pose, and {what}, and not this rung's to "
+                f"lift. Move a keep-out, or add {ref} to an `allow` list if "
+                f"it is the part that owns one")
     if verdict == 'no_movable_neighbour':
         return (f"{ref}: no legal pose, and NOTHING seated is near enough to "
                 f"be in the way -- the outline, the zone or its own size "
@@ -1381,6 +1396,31 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
                              f"edge, so stage 1 leaves it to the later stages")
                 continue
             frac = min(f_hi, max(f_lo, frac))
+            # #701: SLIDE along the edge when a declared keep-out refuses the
+            # even-distribution position, using the same ladder `_seat_edge`
+            # already uses. Without it, one keep-out over the middle of an
+            # edge sent the connector to the ordinary stages, which park it in
+            # the board INTERIOR -- measured: J1 written at (11.22, 6.589) on
+            # a board whose south edge is y=14, trading a `keepout` grade
+            # error for an `edge_connector` one, while 26 clear south-edge
+            # seats existed. The ladder is skipped entirely when nothing is
+            # declared, so a board with no keep-out is unchanged.
+            _slide = ((0.0,) if not state.keepouts_for.get(ref) else
+                      (0.0, 0.05, -0.05, 0.1, -0.1, 0.15, -0.15,
+                       0.2, -0.2, 0.3, -0.3, 0.4, -0.4))
+            _base_frac = frac
+            _why: List[str] = []
+            for _df in _slide:
+                frac = min(f_hi, max(f_lo, _base_frac + _df))
+                _x, _y = _edge_pose(part, bounds, edge, frac, overhang)
+                _x, _y, _conv = _edge_correct(state, ref, edge, _x, _y,
+                                              overhang)
+                _why = []
+                if _conv and edge_seat_ok(state, part, _x, _y, edge, lo,
+                                          float(hi) if hi is not None
+                                          else max(2.0 * overhang, lo + 1.0),
+                                          reasons=_why):
+                    break
             x, y = _edge_pose(part, bounds, edge, frac, overhang)
             x, y, converged = _edge_correct(state, ref, edge, x, y, overhang)
             if not converged:
@@ -1764,13 +1804,30 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
             # none pays nothing and each extra census is already capped by
             # CENSUS_CAP.
             keepouts_freeing: Dict[str, int] = {}
+            keepouts_joint = 0
             if not baseline:
-                for _k in state.keepouts_for.get(ref, ()):
+                _bound = state.keepouts_for.get(ref, ())
+                for _k in _bound:
                     _n = count_legal_poses(state, ref, tx, ty, base_excl,
                                            without_keepouts=(_k['name'],),
                                            **zkw)
                     if _n > baseline:
                         keepouts_freeing[_k['name']] = _n
+                # JOINTLY blocked: two keep-outs that overlap over the part's
+                # feasible region each free nothing ALONE, so the per-keep-out
+                # sweep above reports {} and the verdict would fall back to
+                # `no_movable_neighbour` -- whose prose ("nothing seated is
+                # near enough to be in the way -- the outline, the zone or its
+                # own size refuses it") is exactly the misleading answer this
+                # whole disclosure exists to replace. Measured on a nested
+                # enclosure+boss pair. One extra census, only for a part no
+                # single lift explained, mirroring the blocker side's own
+                # single-then-pair escalation.
+                if not keepouts_freeing and len(_bound) > 1:
+                    keepouts_joint = count_legal_poses(
+                        state, ref, tx, ty, base_excl,
+                        without_keepouts=tuple(k['name'] for k in _bound),
+                        **zkw)
             cinfo: Dict = {}
             cands = _evict_candidates(state, ref, tx, ty, placed, immovable,
                                       constraint=constraint, tol=tol,
@@ -1788,7 +1845,8 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
                            'frozen': cinfo.get('frozen') or {},
                            'truncated': cinfo.get('truncated', 0),
                            'baseline': baseline,
-                           'keepouts_freeing': keepouts_freeing})
+                           'keepouts_freeing': keepouts_freeing,
+                           'keepouts_joint': keepouts_joint})
             no_pose_census[ref] = census
             useful = sorted((n, b) for b, n in freed.items() if n > baseline)
             if not evict_depth:

--- a/py_placer/placement/seeder.py
+++ b/py_placer/placement/seeder.py
@@ -418,7 +418,8 @@ def count_legal_poses(state, ref: str, tx: float, ty: float,
                       cap: int = CENSUS_CAP,
                       max_disp: Optional[float] = None,
                       rotations: Optional[Sequence[float]] = None,
-                      constraint=None, tol: float = 0.5) -> int:
+                      constraint=None, tol: float = 0.5,
+                      without_keepouts: Sequence[str] = ()) -> int:
     """How many legal poses `ref` has near (tx, ty), counting at most `cap`.
 
     This is issue #629's measurement. Three consecutive sweeps in run 19
@@ -443,6 +444,14 @@ def count_legal_poses(state, ref: str, tx: float, ty: float,
     excludes, and the disc alone leaves it counting poses that are outside
     the zone the seat had to satisfy. `radius`/`step` are ignored when a
     constraint is given -- the zone supersedes them.
+
+    `without_keepouts` names declared keep-outs to LIFT for the sweep (#701).
+    A keep-out is measured the way a blocker is measured -- count the poses
+    with it out of the way -- so that "this keep-out is what refuses the
+    part" is a NUMBER from the same predicate the seat search uses, not a
+    static "does the zone intersect a keep-out" test computed some other way.
+    A verdict derived from a different question is the reported-field trap
+    one level up.
     """
     from pose_score import _offsets
     part = state.parts[ref]
@@ -455,21 +464,38 @@ def count_legal_poses(state, ref: str, tx: float, ty: float,
         _step, offsets, _reach = zone_census_offsets(
             part, constraint, tol, tx, ty,
             getattr(state, 'grid_step', 0.1), max_disp)
-    n = 0
-    for dx, dy in offsets:
-        if max_disp is not None and math.hypot(dx, dy) > max_disp + 1e-9:
-            continue
-        x, y = round(tx + dx, 3), round(ty + dy, 3)
-        for rot in rots:
-            # Zone first: it is four float compares, where `pose_ok` ends in
-            # `candidate_valid`. Measured 19x faster on a small zone.
-            if not in_zone(x, y, rot):
+    # Lift the named keep-outs for the duration of the sweep, the same way
+    # `_try_place` swaps `state.clearance` and `_evict_trade` swaps a pose:
+    # a try/finally around the state, so the count comes from `pose_ok`
+    # itself rather than from a second, keep-out-blind predicate.
+    lift = set(without_keepouts or ())
+    saved = None
+    if lift and state.keepouts_for.get(ref):
+        saved = state.keepouts_for[ref]
+        kept = tuple(k for k in saved if k['name'] not in lift)
+        if kept:
+            state.keepouts_for[ref] = kept
+        else:
+            del state.keepouts_for[ref]
+    try:
+        n = 0
+        for dx, dy in offsets:
+            if max_disp is not None and math.hypot(dx, dy) > max_disp + 1e-9:
                 continue
-            if pose_ok(state, ref, x, y, rot, exclude):
-                n += 1
-                if n >= cap:
-                    return n
-    return n
+            x, y = round(tx + dx, 3), round(ty + dy, 3)
+            for rot in rots:
+                # Zone first: it is four float compares, where `pose_ok` ends
+                # in `candidate_valid`. Measured 19x faster on a small zone.
+                if not in_zone(x, y, rot):
+                    continue
+                if pose_ok(state, ref, x, y, rot, exclude):
+                    n += 1
+                    if n >= cap:
+                        return n
+        return n
+    finally:
+        if saved is not None:
+            state.keepouts_for[ref] = saved
 
 
 #: The verdicts a part with no legal pose can be given (#699). Two of them
@@ -487,6 +513,11 @@ NO_POSE_VERDICTS = (
     'no_pair_lift_frees',       # ... and no PAIR of them frees one either
     'blocker_available',        # a lift WOULD free a pose; the depth said no
     'trade_reverted',           # a trade was tried and put back
+    # #701. Before it, a part a declared KEEP-OUT refuses reported
+    # `no_movable_neighbour`, whose prose says "the outline, the zone or its
+    # own size refuses it, not a neighbour" -- false, and the reader's next
+    # move is different: move the keep-out, or add the part to its `allow`.
+    'keepout_blocks',
 )
 
 
@@ -501,12 +532,24 @@ def _empty_census() -> Dict:
     """
     return {'boxed': 0, 'movable': 0, 'censused': 0, 'frozen': {},
             'truncated': 0, 'baseline': 0, 'pairs_total': 0,
-            'pairs_censused': 0, 'pairs_truncated': 0, 'best_pair': None}
+            'pairs_censused': 0, 'pairs_truncated': 0, 'best_pair': None,
+            # #701: {keep-out name: poses freed by lifting it}. Present and
+            # empty on every part, per this function's whole rationale --
+            # a consumer must never need a defaulting `.get` to tell "no
+            # keep-out is in the way" from "keep-outs were not considered".
+            'keepouts_freeing': {}}
 
 
 def _verdict_for(cands: Sequence[str], census: Dict) -> str:
     """The verdict for a part still unseated after the census."""
-    if not cands:
+    if census.get('keepouts_freeing'):
+        # #701, and FIRST: a declared keep-out that frees poses when lifted
+        # is the answer, whatever the neighbours look like. It outranks
+        # `no_movable_neighbour`, whose prose would actively mislead here,
+        # and it sits below `blocker_available` for free -- this function is
+        # only reached when no trade was chosen.
+        v = 'keepout_blocks'
+    elif not cands:
         v = ('immovable_given_frozen' if census.get('frozen')
              else 'no_movable_neighbour')
     else:
@@ -541,6 +584,13 @@ def _no_pose_note(ref: str, verdict: str, census: Dict,
     if frozen and verdict in ('no_single_lift_frees', 'no_pair_lift_frees'):
         tail += ("; also in the way, and not this rung's to move: "
                  + ', '.join(f"{r} ({why})" for r, why in sorted(frozen.items())))
+    if verdict == 'keepout_blocks':
+        who = ', '.join(f"{n!r} (frees {c})" for n, c
+                        in sorted((census.get('keepouts_freeing') or {}).items()))
+        return (f"{ref}: no legal pose, and the DECLARED KEEP-OUT(S) {who} "
+                f"are what refuse it -- not a neighbour, and not this rung's "
+                f"to lift. Move the keep-out, or add {ref} to its `allow` "
+                f"list if it is the part that owns it")
     if verdict == 'no_movable_neighbour':
         return (f"{ref}: no legal pose, and NOTHING seated is near enough to "
                 f"be in the way -- the outline, the zone or its own size "
@@ -1707,6 +1757,20 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
             # and this one reaches `place_seed`'s JSON_SUMMARY.
             zkw = dict(constraint=constraint, tol=tol)
             baseline = count_legal_poses(state, ref, tx, ty, base_excl, **zkw)
+            # #701: which DECLARED KEEP-OUT is refusing this part, measured
+            # the way a blocker is -- count the poses with it lifted. Only
+            # when the part has no pose at all (nothing to explain otherwise)
+            # and only over the keep-outs that BIND it, so a board declaring
+            # none pays nothing and each extra census is already capped by
+            # CENSUS_CAP.
+            keepouts_freeing: Dict[str, int] = {}
+            if not baseline:
+                for _k in state.keepouts_for.get(ref, ()):
+                    _n = count_legal_poses(state, ref, tx, ty, base_excl,
+                                           without_keepouts=(_k['name'],),
+                                           **zkw)
+                    if _n > baseline:
+                        keepouts_freeing[_k['name']] = _n
             cinfo: Dict = {}
             cands = _evict_candidates(state, ref, tx, ty, placed, immovable,
                                       constraint=constraint, tol=tol,
@@ -1723,7 +1787,8 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
                            'censused': cinfo.get('censused', len(cands)),
                            'frozen': cinfo.get('frozen') or {},
                            'truncated': cinfo.get('truncated', 0),
-                           'baseline': baseline})
+                           'baseline': baseline,
+                           'keepouts_freeing': keepouts_freeing})
             no_pose_census[ref] = census
             useful = sorted((n, b) for b, n in freed.items() if n > baseline)
             if not evict_depth:

--- a/py_placer/placement/seeder.py
+++ b/py_placer/placement/seeder.py
@@ -83,11 +83,31 @@ def pose_ok(state, ref: str, x: float, y: float, rot: float,
     pose is off the board, its #456 branch accepts poses that move strictly
     TOWARD the board while still outside it. Placement from scratch has no
     incumbent worth improving on, so full containment is demanded explicitly.
+
+    The third conjunct is the intent's declared KEEP-OUTS (#701). Before it,
+    `rule_keepout` graded a region the seat search walked parts into, forever:
+    a declared keep-out was enforced by nothing at all. It sits BEFORE
+    `candidate_valid` for the same reason `count_legal_poses` puts the zone
+    gate first -- a handful of float compares against a usually-empty tuple,
+    where `candidate_valid` ends in the neighbour loop.
     """
     part = state.parts[ref]
-    r = part.rect(x, y, rot)
+    r, tht = part.rects(x, y, rot)
     if state.edge_gate.rect_outside_amount(r) > 1e-9:
         return False
+    # BOTH rects, because `rule_keepout` grades both: a through-hole part's
+    # leads pass through a keep-out even when its body sits on the far side,
+    # so a courtyard-only seat would be accepted here and flagged there --
+    # exit 4 on a board this function placed correctly.
+    if state.keepouts_for:
+        # Lazy, inside the guard, matching this file's idiom for `floorplan`
+        # (see `zone_gate` below) -- so a board declaring no keep-out pays
+        # nothing at all, not even a sys.modules lookup, on a predicate this
+        # hot.
+        from placement.floorplan import keepout_hit
+        for k in state.keepouts_for.get(ref, ()):
+            if keepout_hit(k, (r, tht)):
+                return False
     return state.candidate_valid(ref, x, y, rot, exclude=exclude)
 
 
@@ -1180,7 +1200,11 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
 
     state = pose_score.make_state(
         pcb_data, pcb_file, clearance=clearance,
-        board_edge_clearance=board_edge_clearance, grid_step=grid_step)
+        board_edge_clearance=board_edge_clearance, grid_step=grid_step,
+        # #701: the declared keep-outs reach the SEAT PREDICATE here, and
+        # every `_try_place` / `count_legal_poses` / `_evict_trade` site in
+        # this module inherits them through `pose_ok`.
+        keepouts=intent.keepouts if intent else ())
     bounds = state.board
     refs_all = sorted(pcb_data.footprints)
     notes: List[str] = []
@@ -1931,7 +1955,11 @@ def repair_placement(pcb_data, pcb_file: str, intent, *,
     state = pose_score.make_state(
         pcb_data, pcb_file, clearance=clearance,
         board_edge_clearance=board_edge_clearance, grid_step=grid_step,
-        extra_locked_refs=_extra_locked or None)
+        extra_locked_refs=_extra_locked or None,
+        # #701: the declared keep-outs reach the SEAT PREDICATE (see
+        # `seed_from_intent`). `intent` is optional on this path, so the
+        # inert default is what a caller without one gets.
+        keepouts=intent.keepouts if intent else ())
     refs_all = sorted(pcb_data.footprints)
     notes: List[str] = []
     must_lock = {r for pat in intent.must_lock
@@ -2554,7 +2582,11 @@ def reseat_scope(pcb_data, pcb_file: str, intent, *,
     state = pose_score.make_state(
         pcb_data, pcb_file, clearance=clearance,
         board_edge_clearance=board_edge_clearance, grid_step=grid_step,
-        extra_locked_refs=_extra_locked or None)
+        extra_locked_refs=_extra_locked or None,
+        # #701: the declared keep-outs reach the SEAT PREDICATE (see
+        # `seed_from_intent`). `intent` is optional on this path, so the
+        # inert default is what a caller without one gets.
+        keepouts=intent.keepouts if intent else ())
     refs_all = sorted(pcb_data.footprints)
     notes: List[str] = []
     must_lock = {r for pat in intent.must_lock

--- a/py_placer/placement/seeder.py
+++ b/py_placer/placement/seeder.py
@@ -972,7 +972,8 @@ def _edge_correct(state, ref: str, edge: str, x: float, y: float,
 
 
 def edge_seat_ok(state, part, x: float, y: float, edge: str,
-                 lo: float, hi: float) -> bool:
+                 lo: float, hi: float,
+                 reasons: Optional[List[str]] = None) -> bool:
     """Is this edge pose a seat, or is the part off the board?
 
     An edge seat is the one seat in the system that cannot use `pose_ok` --
@@ -999,11 +1000,30 @@ def edge_seat_ok(state, part, x: float, y: float, edge: str,
 
     An edge connector's BODY overhangs by design; its PADS do not. That
     asymmetry is what makes this checkable at all.
+
+    A THIRD conjunct, since #701: a declared KEEP-OUT. An edge connector's
+    body may leave the outline; it may not enter a region the intent
+    reserved, and neither of the other two conjuncts can see that -- a
+    mounting-hole keep-out on the north edge leaves the band satisfied and
+    every pad on the board. This is the only place it can go: `pose_ok`
+    demands full containment and an edge seat overhangs by design, so this
+    predicate deliberately bypasses it, and BOTH edge paths come through
+    here -- `_seat_edge`'s `on_board`, and stage 1 of `seed_from_intent`,
+    which runs no legality gate at all by design. `reasons`, when given,
+    collects WHY, so a refusal can name the keep-out instead of sending the
+    reader to look at an outline that is not the problem.
     """
-    r = part.rect(x, y, part.rot)
+    r, tht = part.rects(x, y, part.rot)
     amt = state.edge_gate.rect_outside_amount(r)
     if not ((lo - 0.02) <= amt <= (hi + 0.02)):
         return False
+    if state.keepouts_for:
+        from placement.floorplan import keepout_hit
+        for k in state.keepouts_for.get(part.ref, ()):
+            if keepout_hit(k, (r, tht)):
+                if reasons is not None:
+                    reasons.append(f"keep-out {k['name']!r}")
+                return False
     gate = state.edge_gate
     for px, py, _sz in part.pad_globals(x, y, part.rot):
         # A zero-size rect at the pad centre: "is this point on the board",
@@ -1099,8 +1119,16 @@ def _seat_edge(state, ref: str, entry: Dict, must_lock: Set[str],
                 return False
         return True
 
+    # #701: WHY the band refused, when it was a declared keep-out rather than
+    # the outline. "no conflict-free seat found on the declared north edge"
+    # sends the reader to look at the outline and the neighbours, neither of
+    # which is the problem, and the next move is different: move the keep-out
+    # or add an `allow`.
+    refused: List[str] = []
+
     def on_board(px, py):
-        return edge_seat_ok(state, part, px, py, edge, lo, hi_eff)
+        return edge_seat_ok(state, part, px, py, edge, lo, hi_eff,
+                            reasons=refused)
 
     for df in (0.0, 0.05, -0.05, 0.1, -0.1, 0.15, -0.15,
                0.2, -0.2, 0.3, -0.3, 0.4, -0.4):
@@ -1112,6 +1140,12 @@ def _seat_edge(state, ref: str, entry: Dict, must_lock: Set[str],
         if conflict_free(x, y):
             state.apply_move(ref, round(x, 3), round(y, 3), part.rot)
             return True
+    if refused:
+        # Sorted+deduped: the ladder tries up to 13 fractions and would
+        # otherwise name the same keep-out 13 times.
+        notes.append(f"{ref}: every position on the declared {edge} edge band "
+                     f"is refused by " + ', '.join(sorted(set(refused)))
+                     + " -- move the keep-out, or add this ref to its `allow`")
     return False
 
 
@@ -1316,10 +1350,17 @@ def seed_from_intent(pcb_data, pcb_file: str, intent, rng: random.Random, *,
             # all by design, so nothing downstream catches it.
             hi_eff = float(hi) if hi is not None else max(2.0 * overhang,
                                                           lo + 1.0)
-            if not edge_seat_ok(state, part, x, y, edge, lo, hi_eff):
-                notes.append(f"edge connector {ref}: the {edge} band would "
-                             f"put it off the board, so stage 1 left it for "
-                             f"the later stages")
+            _why: List[str] = []
+            if not edge_seat_ok(state, part, x, y, edge, lo, hi_eff,
+                                reasons=_why):
+                # #701: a keep-out refusal has a DIFFERENT next move from an
+                # off-board one -- move the keep-out, not the band -- so it is
+                # named rather than folded into "would put it off the board".
+                notes.append(f"edge connector {ref}: "
+                             + (f"the {edge} band is refused by "
+                                + ', '.join(sorted(set(_why))) if _why else
+                                f"the {edge} band would put it off the board")
+                             + ", so stage 1 left it for the later stages")
                 continue
             state.apply_move(ref, round(x, 3), round(y, 3), part.rot)
             placed.add(ref)

--- a/py_placer/pose_score.py
+++ b/py_placer/pose_score.py
@@ -60,7 +60,7 @@ def make_state(pcb_data, board_path: str, *, clearance: float = 0.25,
                halo_weight: float = 2.0, edge_halo: float = 2.0,
                edge_weight: float = 2.0,
                ignore_net_ids=None, net_weights=None, move_refs=None,
-               extra_locked_refs=None):
+               extra_locked_refs=None, keepouts=None):
     """A QuenchState used purely as an oracle -- built, queried, thrown away.
 
     Defaults mirror the placement guidance rather than quench's own library
@@ -76,7 +76,12 @@ def make_state(pcb_data, board_path: str, *, clearance: float = 0.25,
         edge_weight=edge_weight, grid_step=grid_step,
         length_weight=length_weight, ignore_net_ids=ignore_net_ids,
         net_weights=net_weights, move_refs=move_refs,
-        extra_locked_refs=extra_locked_refs)
+        extra_locked_refs=extra_locked_refs,
+        # #701: the intent's keep-outs, for the SEAT predicate. Passed through
+        # rather than read here, because this factory has no intent -- every
+        # caller that has one hands it over, and a caller that has none gets
+        # the inert default.
+        keepouts=keepouts)
 
 
 def rank_poses(pcb_data, board_path: str, ref: str, *, radius: float = 2.0,

--- a/py_tools/check_floorplan.py
+++ b/py_tools/check_floorplan.py
@@ -79,6 +79,23 @@ def build_parser():
                         'the proximity rule, which is the detection working. '
                         'Default off to preserve the observation-only round '
                         'trip')
+    p.add_argument('--declare-decaps', action='store_true',
+                   help='with --emit-intent: ALSO derive decaps.'
+                        'max_distance_mm from the board\'s own measured '
+                        'tethers (#704), so rule_decap_distance can fire on '
+                        'an auto intent at all. The limit is ceil(max) over '
+                        'placement.groups.decap_tethers, so it grades CLEAN '
+                        'by construction, and it is WITHHELD into '
+                        'context.budget_withheld when the number would be '
+                        'dishonest: no tethers, fewer than 3, or more than '
+                        'a quarter of the rail-sharing caps already beyond '
+                        'the search radius. SEPARATE from --declare-classes '
+                        'on purpose -- this key is not a part CLASS, and '
+                        'declaring it CHANGES PLACEMENT: place_seed reads it '
+                        'and moves every 2-pin C* out of zone packing into '
+                        'its per-supply-pin stage (ulx3s: 70 caps, of which '
+                        '53 are graded). The tether census is written to '
+                        'context.decap_census either way')
     p.add_argument('--json', metavar='PATH',
                    help='write the full findings (every measurement) as JSON')
     p.add_argument('--group-by', default='auto', metavar='SOURCES',
@@ -143,7 +160,8 @@ def main(argv=None):
     if args.emit_intent:
         try:
             doc = emit_intent(pcb, args.board, group_sources=sources or (),
-                              declare_classes=args.declare_classes)
+                              declare_classes=args.declare_classes,
+                              derive_decaps=args.declare_decaps)
         except UntrustworthyOutline as exc:
             print(f"ERROR: {args.board}: {exc}", file=sys.stderr)
             return UNPLACED_EXIT
@@ -158,6 +176,26 @@ def main(argv=None):
                   f"{len(doc['must_lock'])} locked part(s)")
             print(f"  envelope {doc['envelope']['rect']} -- read from the "
                   f"board. The outline is not editable by this toolchain")
+            # #704: the decap number and what it COSTS, next to each other.
+            cen = (doc.get('context') or {}).get('decap_census') or {}
+            lim = (doc.get('decaps') or {}).get('max_distance_mm')
+            held = ((doc.get('context') or {}).get('budget_withheld')
+                    or {}).get('decaps.max_distance_mm')
+            if lim is not None:
+                print(f"  decaps: max_distance_mm {lim} from "
+                      f"{cen.get('tethers')} tether(s) -- NOTE: place_seed "
+                      f"READS this key and will seat {cen.get('seeder_scope')}"
+                      f" cap(s) per supply pin instead of zone-packing them, "
+                      f"{cen.get('seeder_scope_ungraded')} of which this rule "
+                      f"never grades")
+            elif held:
+                print(f"  decaps: max_distance_mm WITHHELD -- {held}")
+            if cen.get('beyond_radius'):
+                print(f"  decap census: {cen['beyond_radius']} rail-sharing "
+                      f"cap(s) lie beyond the {cen['search_radius_mm']}mm "
+                      f"search radius (worst {cen['worst_beyond_mm']}mm) and "
+                      f"are invisible to the rule -- see "
+                      f"context.decap_census")
         return 0
 
     try:

--- a/tests/test_549_floorplan_schema.py
+++ b/tests/test_549_floorplan_schema.py
@@ -113,8 +113,13 @@ RULE_LITERAL = "rule=[" + chr(39) + chr(34) + "](" + chr(92) + "w+)[" \
 #: that GROWING a key set is as loud as shrinking one. Both directions are
 #: defects: a shrunk set refuses a key real intent files carry, and a grown one
 #: re-admits a key nothing reads -- which is #710 itself. The emitter-driven
-#: detector in test_549_floorplan_grade.py cannot see either, because
-#: `emit_intent` never writes a `health`, `decaps` or `keepouts` object at all.
+#: detector in test_549_floorplan_grade.py cannot see either: it only harvests
+#: `edge_connectors[]` / `blocks[]` entries, and of the remaining objects
+#: `emit_intent` writes only `decaps` (a bare `max_distance_mm`, under
+#: --declare-decaps since #704) and never a `health` or `keepouts` one.
+#: #704's provenance deliberately went to `context`, which has NO key set --
+#: growing `_DECAP_KEYS` would make an older build REFUSE the whole file,
+#: since `_reject_unknown` raises.
 KEY_SETS = {
     '_TOP_LEVEL_KEYS': {
         'schema', 'kind', 'board', 'units', 'min_reader', 'envelope',
@@ -148,8 +153,8 @@ def test_the_key_sets_are_exactly_what_is_documented():
     Shrinking a set is the regression this whole change risks -- it refuses a
     key that real intent files carry. Growing one silently re-admits a key
     nothing reads, which is #710 over again. Neither is visible to the
-    emitter-driven detector in the grade test, which only sees keys
-    `emit_intent` writes.
+    emitter-driven detector in the grade test, which only sees the
+    `edge_connectors[]` / `blocks[]` entry keys `emit_intent` writes.
     """
     for name, expected in sorted(KEY_SETS.items()):
         actual = set(getattr(fp, name))
@@ -170,8 +175,10 @@ def test_an_intent_using_every_known_key_loads():
 
     Pinning the sets catches a set that changed; this catches a set that was
     right while the code around it refused the key anyway -- and it is the
-    only test that exercises `health`, `decaps` and `keepouts` keys through
-    the loader at all, since `emit_intent` never writes those objects.
+    only test that exercises the `health` and `keepouts` keys through the
+    loader at all, since `emit_intent` never writes those objects. `decaps`
+    it does write since #704, but only `max_distance_mm`, so `exempt` and
+    `search_radius_mm` are still covered here alone.
     """
     raw = {
         'schema': SCHEMA_VERSION, 'kind': KIND, 'units': 'mm',

--- a/tests/test_701_keepout_predicate.py
+++ b/tests/test_701_keepout_predicate.py
@@ -441,21 +441,34 @@ def test_the_grader_builds_a_state_that_carries_no_keepouts():
 # 5. the vocabulary is documented -- a static change detector
 # --------------------------------------------------------------------------
 
-def test_every_no_pose_verdict_has_a_README_row():
-    """The README table is the only place a reader learns this vocabulary,
-    and nothing guarded it before. A verdict shipped without its row is a
-    string consumers switch on and humans cannot look up."""
-    readme = io.open(os.path.join(REPO, 'py_placer', 'placement', 'README.md'),
-                     encoding='utf-8').read()
-    missing = [v for v in seeder.NO_POSE_VERDICTS
-               if f"`{v}`" not in readme]
-    assert not missing, f"verdict(s) with no README row: {missing}"
-    # And the census keys, for the same reason.
+#: Every reader-facing table of the verdict vocabulary. BOTH of them: the
+#: skill's table was written independently and had fallen a verdict behind
+#: while the README was current, because only the README was guarded.
+_VERDICT_DOCS = (
+    os.path.join(REPO, 'py_placer', 'placement', 'README.md'),
+    os.path.join(REPO, '.claude', 'skills', 'plan-pcb-placement', 'SKILL.md'),
+)
+
+
+def test_every_no_pose_verdict_has_a_row_in_EVERY_table():
+    """These tables are the only place a reader learns this vocabulary. A
+    verdict shipped without its row is a string consumers switch on and
+    humans cannot look up."""
+    for doc in _VERDICT_DOCS:
+        rel = os.path.relpath(doc, REPO).replace('\\', '/')
+        assert os.path.exists(doc), rel
+        text = io.open(doc, encoding='utf-8').read()
+        missing = [v for v in seeder.NO_POSE_VERDICTS if f"`{v}`" not in text]
+        assert not missing, f"{rel}: verdict(s) with no row: {missing}"
+    # The census keys, for the same reason -- README only, since the skill
+    # table documents verdicts rather than the census.
     keys = sorted(seeder._empty_census())
+    readme = io.open(_VERDICT_DOCS[0], encoding='utf-8').read()
     missing_k = [k for k in keys if f"`{k}`" not in readme]
     assert not missing_k, f"census key(s) with no README mention: {missing_k}"
-    print(f"  PASS: {len(seeder.NO_POSE_VERDICTS)} verdict(s) and "
-          f"{len(keys)} census key(s) all documented")
+    print(f"  PASS: {len(seeder.NO_POSE_VERDICTS)} verdict(s) documented in "
+          f"{len(_VERDICT_DOCS)} table(s); {len(keys)} census key(s) in the "
+          f"README")
 
 
 # --------------------------------------------------------------------------
@@ -479,33 +492,61 @@ def test_every_seat_predicate_caller_outside_the_seeder_attaches_keepouts():
     function to build its state with `keepouts=`."""
     offenders = []
     checked = []
-    for root, _dirs, files in os.walk(os.path.join(REPO, 'py_placer')):
-        for fn in files:
-            if not fn.endswith('.py'):
-                continue
-            path = os.path.join(root, fn)
-            if os.path.basename(path) == 'seeder.py':
-                continue          # the definitions live here
-            tree = ast.parse(io.open(path, encoding='utf-8').read())
-            for node in ast.walk(tree):
-                if not isinstance(node, (ast.FunctionDef,
-                                         ast.AsyncFunctionDef)):
+    #: EVERY python tree that could import the seeder, not just py_placer.
+    #: A module under py_tools/ that builds its own state and calls
+    #: `seeder._try_place` enforces nothing, and a scan rooted at py_placer
+    #: cannot see it.
+    roots = [os.path.join(REPO, d) for d in
+             ('py_placer', 'py_router', 'py_tools')]
+    for root0 in roots:
+        for root, _dirs, files in os.walk(root0):
+            for fn in files:
+                if not fn.endswith('.py'):
                     continue
-                body = ast.dump(node)
-                if not any(f"attr='{f}'" in body or f"id='{f}'" in body
-                           for f in _SEAT_FUNCS):
-                    continue
-                rel = os.path.relpath(path, REPO).replace('\\', '/')
-                checked.append(f"{rel}:{node.lineno} {node.name}")
-                if "keepouts" not in body:
-                    offenders.append(f"{rel}:{node.lineno} {node.name}")
+                path = os.path.join(root, fn)
+                if os.path.basename(path) == 'seeder.py':
+                    continue      # the definitions live here
+                tree = ast.parse(io.open(path, encoding='utf-8').read())
+                for node in ast.walk(tree):
+                    if not isinstance(node, (ast.FunctionDef,
+                                             ast.AsyncFunctionDef)):
+                        continue
+                    if not any(f"attr='{f}'" in ast.dump(node)
+                               or f"id='{f}'" in ast.dump(node)
+                               for f in _SEAT_FUNCS):
+                        continue
+                    rel = os.path.relpath(path, REPO).replace('\\', '/')
+                    checked.append(f"{rel}:{node.lineno} {node.name}")
+                    # The VALUE, not the spelling. `keepouts=None` contains
+                    # the string "keepouts" and satisfies a substring check
+                    # while disabling enforcement completely -- measured, a
+                    # four-character edit that survived both batteries. A
+                    # keyword whose value is a literal None/()/[] is the same
+                    # defect written three ways.
+                    ok = False
+                    for call in ast.walk(node):
+                        if not isinstance(call, ast.Call):
+                            continue
+                        for kw in call.keywords:
+                            if kw.arg != 'keepouts':
+                                continue
+                            v = kw.value
+                            if isinstance(v, ast.Constant) and v.value is None:
+                                continue
+                            if isinstance(v, (ast.Tuple, ast.List)) \
+                                    and not v.elts:
+                                continue
+                            ok = True
+                    if not ok:
+                        offenders.append(f"{rel}:{node.lineno} {node.name}")
     assert checked, ("the scan found NO seat-predicate caller outside "
                      "seeder.py -- the gate is vacuous, fix the scan")
     assert not offenders, (
-        "seat-predicate caller(s) whose state carries no keep-outs, so the "
-        f"rule is unenforced there: {offenders}")
+        "seat-predicate caller(s) whose state carries no keep-outs (absent, "
+        f"or a literal None/empty), so the rule is unenforced there: "
+        f"{offenders}")
     print(f"  PASS: {len(checked)} external seat-predicate caller(s), all "
-          f"attaching keep-outs -- {', '.join(checked)}")
+          f"attaching a NON-EMPTY keepouts value -- {', '.join(checked)}")
 
 
 TESTS = [
@@ -517,7 +558,7 @@ TESTS = [
     test_the_resolver_boundaries,
     test_the_seat_predicate_sees_the_through_hole_rect_not_just_the_body,
     test_the_grader_builds_a_state_that_carries_no_keepouts,
-    test_every_no_pose_verdict_has_a_README_row,
+    test_every_no_pose_verdict_has_a_row_in_EVERY_table,
     test_every_seat_predicate_caller_outside_the_seeder_attaches_keepouts,
 ]
 

--- a/tests/test_701_keepout_predicate.py
+++ b/tests/test_701_keepout_predicate.py
@@ -1,0 +1,529 @@
+#!/usr/bin/env python3
+"""#701: the seat predicate and the grader share ONE keep-out implementation.
+
+`rule_keepout` graded a declared keep-out and the seat search had no keep-out
+concept at all (`grep -c "forbid\\|keepout" py_placer/placement/seeder.py`
+returned 0), so a keep-out was a region `place_seed` walked parts into and
+`check_floorplan` complained about forever. The fix makes both fronts call
+`floorplan.keepouts_for_ref` and `floorplan.keepout_hit`.
+
+That claim -- ONE implementation, not two agreeing ones -- is what this file
+tests, and it is not testable by reading. Four ways, weakest to strongest:
+
+  * IDENTITY, behaviourally: monkeypatch `floorplan.keepout_hit` and show the
+    seat predicate observes the patch. A copy-pasted geometry in `seeder.py`
+    would not, and would still pass every agreement check written against
+    equivalent-but-separate code.
+  * AGREEMENT: sweep keep-outs x parts and require the seat verdict and the
+    GRADE's verdict to be identical on every combination, with the hit/miss
+    split printed -- a sweep that only ever asked about clear poses proves
+    nothing.
+  * BOUNDARIES: the cases where two independent implementations drift first
+    (an exact corner touch, an overlap at +/-EPS, a tangent circle).
+  * A STATIC GATE on the seat-function call sites, because "enforced on one
+    path" is invisible to any behavioural test that does not happen to
+    exercise the missed path.
+
+No subprocess and no `run_utils`, so this stays in `run_all.py --fast`.
+"""
+import ast
+import io
+import os
+import sys
+
+RUN_ALL_FAST_OK = True
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for _p in (REPO,):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+        sys.path.insert(0, os.path.join(_p, 'py_router'))   # placement split
+        sys.path.insert(0, os.path.join(_p, 'py_tools'))    # placement split
+        sys.path.insert(0, os.path.join(_p, 'py_placer'))   # placement split
+
+from kicad_parser import parse_kicad_pcb                        # noqa: E402
+from placement import floorplan, legality, seeder               # noqa: E402
+from placement.quench import QuenchState                        # noqa: E402
+import routing_defaults as defaults                             # noqa: E402
+
+BOARD = os.path.join(REPO, 'kicad_files', 'splitflap_driver.kicad_pcb')
+
+_QKW = dict(clearance=defaults.CLEARANCE, board_edge_clearance=0.55,
+            crossing_penalty=10.0, halo_base=0.5, halo_coef=0.25,
+            halo_weight=2.0, edge_halo=2.0, edge_weight=2.0,
+            grid_step=defaults.GRID_STEP, length_weight=1.0)
+
+
+def _state(pcb, keepouts=None):
+    return QuenchState(pcb, BOARD, keepouts=keepouts, **_QKW)
+
+
+def _entry(**over):
+    """A keep-out entry in the NORMALIZED form `intent_from_dict` produces."""
+    e = {'name': 'k', 'sides': ('F', 'B'), 'allow': ()}
+    e.update(over)
+    return e
+
+
+# --------------------------------------------------------------------------
+# 1. identity -- the seat predicate calls THE function, not a copy of it
+# --------------------------------------------------------------------------
+
+def test_the_seat_predicate_calls_the_graders_own_hit_test():
+    """Behavioural, not structural: a `grep` for the name would be satisfied
+    by a shadowing local, and an agreement sweep would be satisfied by a
+    second implementation that happens to agree today. Patching the object
+    and watching the seat predicate change its answer is the only check that
+    distinguishes ONE implementation from TWO."""
+    pcb = parse_kicad_pcb(BOARD)
+    st = _state(pcb)
+    ref = sorted(st.parts)[0]
+    p = st.parts[ref]
+    r = p.rect()
+    # A keep-out squarely over the part: refused while the real test runs.
+    st_ko = _state(pcb, [_entry(rect=(r[0] - 1, r[1] - 1, r[2] + 1, r[3] + 1))])
+    assert not seeder.pose_ok(st_ko, ref, p.x, p.y, p.rot, set()), \
+        f"{ref} was seated inside a keep-out covering its whole courtyard"
+
+    real = floorplan.keepout_hit
+    seen = []
+    try:
+        floorplan.keepout_hit = lambda e, rects: (seen.append(e), 0.0)[1]
+        assert seeder.pose_ok(st_ko, ref, p.x, p.y, p.rot, set()), \
+            ("pose_ok did not observe the patched floorplan.keepout_hit -- "
+             "it is calling a SECOND implementation, which is the drift this "
+             "whole change exists to prevent")
+    finally:
+        floorplan.keepout_hit = real
+    assert seen, "the patched hit test was never called"
+    print(f"  PASS: pose_ok observes floorplan.keepout_hit "
+          f"({len(seen)} call(s)); it is the same object the grader uses")
+
+
+def test_the_edge_seat_calls_it_too():
+    """`edge_seat_ok` deliberately bypasses `pose_ok` (an edge connector
+    overhangs by design, so full containment is the wrong predicate), so it
+    is a SECOND place the shared test has to be reached from. Both edge
+    paths -- `_seat_edge`'s `on_board` and stage 1 of `seed_from_intent`,
+    which runs no legality gate at all by design -- come through here."""
+    pcb = parse_kicad_pcb(BOARD)
+    st = _state(pcb)
+    ref = sorted(st.parts)[0]
+    p = st.parts[ref]
+    r = p.rect()
+    st_ko = _state(pcb, [_entry(rect=(r[0] - 1, r[1] - 1, r[2] + 1, r[3] + 1))])
+    # A band wide enough that the overhang conjunct cannot be what refuses.
+    seen = []
+    real = floorplan.keepout_hit
+    try:
+        floorplan.keepout_hit = lambda e, rects: (seen.append(e), 0.0)[1]
+        seeder.edge_seat_ok(st_ko, p, p.x, p.y, 'north', 0.0, 1000.0)
+    finally:
+        floorplan.keepout_hit = real
+    assert seen, ("edge_seat_ok never called floorplan.keepout_hit -- the "
+                  "edge path is unguarded, and no pose_ok test can see it")
+    print(f"  PASS: edge_seat_ok observes floorplan.keepout_hit "
+          f"({len(seen)} call(s))")
+
+
+def test_the_edge_seat_names_the_keepout_that_refused_it():
+    """A refusal that says only 'no conflict-free seat on the north edge'
+    sends the reader to look at the outline and the neighbours, which are not
+    the problem. The `reasons` out-param is what lets `_seat_edge` and stage 1
+    say which keep-out it was."""
+    pcb = parse_kicad_pcb(BOARD)
+    st = _state(pcb)
+    ref = sorted(st.parts)[0]
+    p = st.parts[ref]
+    r = p.rect()
+    st_ko = _state(pcb, [_entry(name='enclosure-rib',
+                                rect=(r[0] - 1, r[1] - 1, r[2] + 1, r[3] + 1))])
+    why = []
+    ok = seeder.edge_seat_ok(st_ko, p, p.x, p.y, 'north', 0.0, 1000.0,
+                             reasons=why)
+    assert not ok, "the keep-out did not refuse the edge seat"
+    assert any('enclosure-rib' in w for w in why), \
+        f"the refusal did not name the keep-out: {why}"
+    print(f"  PASS: the edge refusal names the keep-out -- {why}")
+
+
+# --------------------------------------------------------------------------
+# 2. agreement -- the seat verdict and the GRADE verdict, over a sweep
+# --------------------------------------------------------------------------
+
+def _sweep_entries(st):
+    """Keep-outs chosen to produce BOTH hits and misses, over rect/circle,
+    every `sides` spelling, and `allow` absent/exact/glob/universal."""
+    refs = sorted(st.parts)
+    a, b, c = refs[0], refs[len(refs) // 2], refs[-1]
+    ra, rb, rc = st.parts[a].rect(), st.parts[b].rect(), st.parts[c].rect()
+    board = st.board
+    out = [
+        _entry(name='over-a', rect=(ra[0] - .5, ra[1] - .5, ra[2] + .5, ra[3] + .5)),
+        _entry(name='over-b-F', sides=('F',),
+               rect=(rb[0] - .5, rb[1] - .5, rb[2] + .5, rb[3] + .5)),
+        _entry(name='over-b-B', sides=('B',),
+               rect=(rb[0] - .5, rb[1] - .5, rb[2] + .5, rb[3] + .5)),
+        # `sides` absent entirely: the loader defaults it, and a consumer that
+        # re-derives the default differently is what this catches.
+        {'name': 'over-c-nosides', 'allow': (),
+         'rect': (rc[0] - .5, rc[1] - .5, rc[2] + .5, rc[3] + .5)},
+        _entry(name='over-a-allow-exact',
+               rect=(ra[0] - .5, ra[1] - .5, ra[2] + .5, ra[3] + .5),
+               allow=(a,)),
+        _entry(name='over-all-allow-glob',
+               rect=(board[0] - 1, board[1] - 1, board[2] + 1, board[3] + 1),
+               allow=('C*',)),
+        _entry(name='over-all-allow-none',
+               rect=(board[0] - 1, board[1] - 1, board[2] + 1, board[3] + 1),
+               allow=('ZZZ_NO_SUCH_REF*',)),
+        _entry(name='over-all-allow-star',
+               rect=(board[0] - 1, board[1] - 1, board[2] + 1, board[3] + 1),
+               allow=('*',)),
+        _entry(name='circle-on-a',
+               circle=[(ra[0] + ra[2]) / 2.0, (ra[1] + ra[3]) / 2.0, 2.0]),
+        _entry(name='circle-far', circle=[board[0] - 50.0, board[1] - 50.0, 1.0]),
+        # A whole-board circle: every part hit, so `allow`/`sides` are the
+        # only thing that can differ between the two fronts.
+        _entry(name='circle-all',
+               circle=[(board[0] + board[2]) / 2.0, (board[1] + board[3]) / 2.0,
+                       1e4], sides=('F',)),
+    ]
+    return out
+
+
+def _graded_keepout_refs(pcb, entries):
+    """The refs `rule_keepout` flags, via the real `grade`."""
+    raw = floorplan.emit_intent(pcb, BOARD)
+    raw['keepouts'] = [
+        {k: (list(v) if isinstance(v, tuple) else v) for k, v in e.items()}
+        for e in entries]
+    intent = floorplan.intent_from_dict(raw, BOARD)
+    res = floorplan.grade(intent, pcb, BOARD)
+    return {(v.ref, v.measured['keepout']) for v in res.violations
+            if v.rule == 'keepout'}
+
+
+def test_the_seat_verdict_and_the_grade_verdict_agree_on_every_combination():
+    pcb = parse_kicad_pcb(BOARD)
+    st = _state(pcb)
+    entries = _sweep_entries(st)
+    graded = _graded_keepout_refs(pcb, entries)
+
+    st_ko = _state(pcb, entries)
+    hits = misses = 0
+    disagree = []
+    for ref in sorted(st_ko.parts):
+        p = st_ko.parts[ref]
+        rects = p.rects()
+        for e in st_ko.keepouts_for.get(ref, ()):
+            seat_hit = bool(floorplan.keepout_hit(e, rects))
+            grade_hit = (ref, e['name']) in graded
+            if seat_hit:
+                hits += 1
+            else:
+                misses += 1
+            if seat_hit != grade_hit:
+                disagree.append((ref, e['name'], seat_hit, grade_hit))
+        # A keep-out the RESOLVER excluded must also be absent from the grade:
+        # an `allow` the seat honours and the grade ignores would strand a
+        # part that the grade calls clean.
+        bound = {e['name'] for e in st_ko.keepouts_for.get(ref, ())}
+        for e in entries:
+            if e['name'] in bound:
+                continue
+            misses += 1
+            if (ref, e['name']) in graded:
+                disagree.append((ref, e['name'], False, True))
+
+    assert not disagree, ("seat/grade disagreement on "
+                          f"{len(disagree)}: {disagree[:8]}")
+    # A sweep that produced no hits proves nothing; so does one with no
+    # misses. Both bounds, not just a total.
+    assert hits >= 20, f"only {hits} hit(s) -- the sweep is vacuous"
+    assert misses >= 20, f"only {misses} miss(es) -- the sweep is vacuous"
+    print(f"  PASS: {hits + misses} (part, keep-out) combination(s) agree "
+          f"exactly -- {hits} hit, {misses} miss, 0 disagreement")
+
+
+# --------------------------------------------------------------------------
+# 3. boundaries -- where two implementations drift first
+# --------------------------------------------------------------------------
+
+def test_the_hit_test_boundaries():
+    r = (0.0, 0.0, 10.0, 10.0)
+    eps = legality.EPS
+
+    # Corner touch: overlap area exactly 0. Clear, and NOT a hit -- the
+    # threshold lives inside keepout_hit precisely so both fronts agree here.
+    assert floorplan.keepout_hit(
+        _entry(rect=(10.0, 10.0, 20.0, 20.0)), (r,)) == 0.0
+    # Edge touch, zero-area: same answer.
+    assert floorplan.keepout_hit(
+        _entry(rect=(10.0, 0.0, 20.0, 10.0)), (r,)) == 0.0
+    # An overlap a hair under EPS is clear; a hair over is a hit. 10mm wide
+    # strip x d deep => area 10*d, so d = eps/100 is well under and
+    # d = eps is well over.
+    under = floorplan.keepout_hit(
+        _entry(rect=(10.0 - eps / 100.0, 0.0, 20.0, 10.0)), (r,))
+    over = floorplan.keepout_hit(
+        _entry(rect=(10.0 - eps, 0.0, 20.0, 10.0)), (r,))
+    assert under == 0.0, f"sub-EPS overlap reported as a hit: {under}"
+    assert over > 0.0, f"supra-EPS overlap reported as clear: {over}"
+
+    # EXACTLY EPS, which is the only input on which `> EPS` and `>= EPS`
+    # differ -- and therefore the only assertion that pins which side of the
+    # boundary the SHARED threshold falls on. Without it a mutation from `>`
+    # to `>=` survives the whole file, which is the "passes in both
+    # directions" failure this repo names by hand. The construction is exact
+    # in binary: the overlap is [0, EPS] x [0, 1], so the width subtraction
+    # is `EPS - 0.0` and the area is `EPS * 1.0`.
+    unit = (0.0, 0.0, 1.0, 1.0)
+    assert legality.rect_overlap_area(unit, (-5.0, 0.0, eps, 1.0)) == eps, \
+        "the exactly-EPS fixture is not exact on this platform"
+    assert floorplan.keepout_hit(
+        _entry(rect=(-5.0, 0.0, eps, 1.0)), (unit,)) == 0.0, \
+        ("an overlap of exactly EPS must be CLEAR (the threshold is a strict "
+         "`> EPS`); if this fires, the seat predicate and rule_keepout have "
+         "moved apart at the boundary")
+
+    # Circle exactly tangent to the rect: `_circle_hits_rect` uses a strict
+    # `<`, so tangency is clear. Just inside is a hit.
+    assert floorplan.keepout_hit(_entry(circle=[15.0, 5.0, 5.0]), (r,)) == 0.0
+    assert floorplan.keepout_hit(
+        _entry(circle=[15.0, 5.0, 5.0001]), (r,)) == 1.0
+
+    # A None rect is skipped, not crashed on -- quench._Part.rects() returns
+    # (courtyard, None) for the majority of parts.
+    assert floorplan.keepout_hit(_entry(rect=(0, 0, 1, 1)), (None,)) == 0.0
+    assert floorplan.keepout_hit(_entry(rect=(0, 0, 1, 1)), (None, r)) > 0.0
+
+    # The circle branch returns a MARKER, never a fabricated area.
+    assert floorplan.keepout_hit(_entry(circle=[5.0, 5.0, 1.0]), (r,)) == 1.0
+    print("  PASS: corner touch, +/-EPS, tangent circle, None rect, "
+          "circle marker")
+
+
+def test_the_resolver_boundaries():
+    # `allow` is an fnmatch, not an equality test.
+    assert not floorplan.keepouts_for_ref(
+        (_entry(allow=('MH*',)),), 'MH1', ('F',))
+    assert floorplan.keepouts_for_ref(
+        (_entry(allow=('MH*',)),), 'MH', ('F',)) == ()
+    assert floorplan.keepouts_for_ref(
+        (_entry(allow=('MH1',)),), 'MH12', ('F',))
+    # A part shares no face with the keep-out => not bound.
+    assert not floorplan.keepouts_for_ref(
+        (_entry(sides=('B',)),), 'U1', ('F',))
+    # A through-hole part occupies both faces, so a one-sided keep-out binds.
+    assert floorplan.keepouts_for_ref(
+        (_entry(sides=('B',)),), 'U1', ('F', 'B'))
+    # `sides` absent or empty means BOTH -- the loader's default, re-derived
+    # in exactly one place.
+    assert floorplan.keepouts_for_ref(({'name': 'k'},), 'U1', ('B',))
+    assert floorplan.keepouts_for_ref(({'name': 'k', 'sides': None},),
+                                      'U1', ('B',))
+    print("  PASS: allow globs, side intersection, the sides default")
+
+
+# --------------------------------------------------------------------------
+# 4. the grader must NOT inherit the seat gate
+# --------------------------------------------------------------------------
+
+#: A tracked board carrying a part whose THROUGH-HOLE rect sticks out of its
+#: own courtyard, which is what makes the tht term independently observable.
+#: On most footprints tht_rect is a subset of the courtyard, so a keep-out
+#: that hits the leads hits the body too and a seat test cannot tell whether
+#: the second rect was passed at all. Measured over the tracked corpus, only
+#: ulx3s (LCD1, 1.6436mm proud) and glasgow_revC (SW1, 0.35mm) have one.
+_THT_BOARD = os.path.join(REPO, 'kicad_files', 'ulx3s.kicad_pcb')
+_THT_REF = 'LCD1'
+
+
+def test_the_seat_predicate_sees_the_through_hole_rect_not_just_the_body():
+    """`rule_keepout` grades the courtyard AND the drilled-pad rect, because
+    a through-hole part's leads pass through a keep-out even when its body
+    sits on the far side. If the seat predicate looked at the courtyard only,
+    it would SEAT a part the grade then flags -- exit 4 on a board the seeder
+    placed correctly, which is the round-trip break this change exists to
+    close, one level down."""
+    if not os.path.exists(_THT_BOARD):
+        print(f"  SKIP: {_THT_BOARD} not present")
+        return
+    pcb = parse_kicad_pcb(_THT_BOARD)
+    st = QuenchState(pcb, _THT_BOARD, **_QKW)
+    p = st.parts[_THT_REF]
+    body, tht = p.rects()
+    # The sliver of the lead rect that lies OUTSIDE the courtyard, on
+    # whichever side is proudest. A keep-out here hits `tht` and misses
+    # `body`, so it is refused only by a predicate that passes both.
+    gaps = {'w': body[0] - tht[0], 'e': tht[2] - body[2],
+            'n': body[1] - tht[1], 's': tht[3] - body[3]}
+    side = max(gaps, key=gaps.get)
+    assert gaps[side] > 1e-6, \
+        f"{_THT_REF}'s lead rect no longer exceeds its courtyard: {gaps}"
+    m = gaps[side] / 3.0
+    ko = {'w': (tht[0] + m, tht[1], body[0] - m, tht[3]),
+          'e': (body[2] + m, tht[1], tht[2] - m, tht[3]),
+          'n': (tht[0], tht[1] + m, tht[2], body[1] - m),
+          's': (tht[0], body[3] + m, tht[2], tht[3] - m)}[side]
+    e = _entry(name='lead-sliver', rect=ko)
+    assert floorplan.keepout_hit(e, (body,)) == 0.0, \
+        "the fixture rect touches the courtyard; it must hit the leads only"
+    assert floorplan.keepout_hit(e, (body, tht)) > 0.0, \
+        "the fixture rect does not hit the lead rect either"
+
+    st_ko = QuenchState(pcb, _THT_BOARD, keepouts=[e], **_QKW)
+    assert not seeder.pose_ok(st_ko, _THT_REF, p.x, p.y, p.rot, set()), \
+        (f"{_THT_REF} was seated with its LEADS in a keep-out -- pose_ok is "
+         f"passing only the courtyard, so the grade will flag a seat it "
+         f"accepted")
+    # BOTH seat predicates, separately. `edge_seat_ok` bypasses `pose_ok` by
+    # design, so it carries its own copy of the two-rect call and its own way
+    # to lose it. A band of [0, 1e4] makes the overhang conjunct unable to be
+    # what refuses.
+    p2 = st_ko.parts[_THT_REF]
+    assert not seeder.edge_seat_ok(st_ko, p2, p2.x, p2.y, 'north',
+                                   0.0, 1e4), \
+        (f"edge_seat_ok seated {_THT_REF} with its LEADS in a keep-out -- it "
+         f"is passing only the courtyard")
+    print(f"  PASS: {_THT_REF}'s lead rect is {gaps[side]:.4f}mm proud of its "
+          f"courtyard on the {side} side; a keep-out in that sliver refuses "
+          f"BOTH pose_ok and edge_seat_ok")
+
+
+def test_the_grader_builds_a_state_that_carries_no_keepouts():
+    """A grader that inherited the seat gate would be a tautology grading the
+    seat predicate against itself, and every agreement test above would pass
+    for the wrong reason. `grade` builds its own QuenchState and must not
+    pass `keepouts`; `rule_keepout` reads `ctx.intent.keepouts`.
+
+    Asserted on the EFFECTIVE state, not on the constructor argument. A check
+    that read only the kwarg would be satisfied by any code that attaches
+    keep-outs after construction -- which is a check that reads a reported
+    field rather than the value actually used."""
+    pcb = parse_kicad_pcb(BOARD)
+    raw = floorplan.emit_intent(pcb, BOARD)
+    st = sorted(_state(pcb).parts)[0]
+    r = _state(pcb).parts[st].rect()
+    raw['keepouts'] = [{'name': 'k', 'rect': [r[0] - 1, r[1] - 1,
+                                              r[2] + 1, r[3] + 1]}]
+    intent = floorplan.intent_from_dict(raw, BOARD)
+
+    built = []
+    real = QuenchState.__init__
+
+    def spy(self, *a, **kw):
+        built.append(self)
+        return real(self, *a, **kw)
+
+    try:
+        QuenchState.__init__ = spy
+        res = floorplan.grade(intent, pcb, BOARD)
+    finally:
+        QuenchState.__init__ = real
+
+    assert built, "grade built no QuenchState"
+    leaked = [(i, len(s.keepouts_for), len(s.keepouts))
+              for i, s in enumerate(built)
+              if s.keepouts_for or s.keepouts]
+    assert not leaked, (
+        f"grade's own state(s) carry the SEAT gate: {leaked}. The grader "
+        f"would then be grading the seat predicate against itself")
+    # ... and it still finds the violation, from the INTENT.
+    assert any(v.rule == 'keepout' and v.ref == st for v in res.violations), \
+        "the grader stopped grading keep-outs"
+    print(f"  PASS: grade built {len(built)} state(s), none carrying a seat "
+          f"gate, and still flagged {st}")
+
+
+# --------------------------------------------------------------------------
+# 5. the vocabulary is documented -- a static change detector
+# --------------------------------------------------------------------------
+
+def test_every_no_pose_verdict_has_a_README_row():
+    """The README table is the only place a reader learns this vocabulary,
+    and nothing guarded it before. A verdict shipped without its row is a
+    string consumers switch on and humans cannot look up."""
+    readme = io.open(os.path.join(REPO, 'py_placer', 'placement', 'README.md'),
+                     encoding='utf-8').read()
+    missing = [v for v in seeder.NO_POSE_VERDICTS
+               if f"`{v}`" not in readme]
+    assert not missing, f"verdict(s) with no README row: {missing}"
+    # And the census keys, for the same reason.
+    keys = sorted(seeder._empty_census())
+    missing_k = [k for k in keys if f"`{k}`" not in readme]
+    assert not missing_k, f"census key(s) with no README mention: {missing_k}"
+    print(f"  PASS: {len(seeder.NO_POSE_VERDICTS)} verdict(s) and "
+          f"{len(keys)} census key(s) all documented")
+
+
+# --------------------------------------------------------------------------
+# 6. the static gate -- "enforced on one path" is invisible behaviourally
+# --------------------------------------------------------------------------
+
+#: Modules allowed to call a seat predicate. Every entry is a module that
+#: builds its state with `keepouts=`; a NEW caller must be added here AND
+#: attach, which is the whole point of listing them.
+_SEAT_FUNCS = ('_try_place', 'pose_ok', 'count_legal_poses', 'edge_seat_ok')
+
+
+def test_every_seat_predicate_caller_outside_the_seeder_attaches_keepouts():
+    """`pose_ok` is the chokepoint, but only for code that goes through the
+    seeder's own state. A module that builds its own state and calls
+    `seeder._try_place` on it enforces nothing, and no behavioural test can
+    see that unless it happens to exercise that path -- which is exactly how
+    a rule ends up enforced on some paths and silently absent on others.
+
+    So: enumerate the callers mechanically, and require each one's enclosing
+    function to build its state with `keepouts=`."""
+    offenders = []
+    checked = []
+    for root, _dirs, files in os.walk(os.path.join(REPO, 'py_placer')):
+        for fn in files:
+            if not fn.endswith('.py'):
+                continue
+            path = os.path.join(root, fn)
+            if os.path.basename(path) == 'seeder.py':
+                continue          # the definitions live here
+            tree = ast.parse(io.open(path, encoding='utf-8').read())
+            for node in ast.walk(tree):
+                if not isinstance(node, (ast.FunctionDef,
+                                         ast.AsyncFunctionDef)):
+                    continue
+                body = ast.dump(node)
+                if not any(f"attr='{f}'" in body or f"id='{f}'" in body
+                           for f in _SEAT_FUNCS):
+                    continue
+                rel = os.path.relpath(path, REPO).replace('\\', '/')
+                checked.append(f"{rel}:{node.lineno} {node.name}")
+                if "keepouts" not in body:
+                    offenders.append(f"{rel}:{node.lineno} {node.name}")
+    assert checked, ("the scan found NO seat-predicate caller outside "
+                     "seeder.py -- the gate is vacuous, fix the scan")
+    assert not offenders, (
+        "seat-predicate caller(s) whose state carries no keep-outs, so the "
+        f"rule is unenforced there: {offenders}")
+    print(f"  PASS: {len(checked)} external seat-predicate caller(s), all "
+          f"attaching keep-outs -- {', '.join(checked)}")
+
+
+TESTS = [
+    test_the_seat_predicate_calls_the_graders_own_hit_test,
+    test_the_edge_seat_calls_it_too,
+    test_the_edge_seat_names_the_keepout_that_refused_it,
+    test_the_seat_verdict_and_the_grade_verdict_agree_on_every_combination,
+    test_the_hit_test_boundaries,
+    test_the_resolver_boundaries,
+    test_the_seat_predicate_sees_the_through_hole_rect_not_just_the_body,
+    test_the_grader_builds_a_state_that_carries_no_keepouts,
+    test_every_no_pose_verdict_has_a_README_row,
+    test_every_seat_predicate_caller_outside_the_seeder_attaches_keepouts,
+]
+
+
+if __name__ == '__main__':
+    for t in TESTS:
+        print(f"--- {t.__name__}")
+        t()
+    print("ALL PASS")

--- a/tests/test_701_keepout_seating.py
+++ b/tests/test_701_keepout_seating.py
@@ -545,6 +545,37 @@ def arm_polish_repair(wd):
         check("H-a: place_seed exits 0 after repairing itself",
               r.returncode == 0, f"rc={r.returncode}")
 
+    # ---- H-c: the same fault on a part with NO ZONE ---------------------
+    # A keep-out violation does not imply a zone, and most parts on most
+    # boards have none. The repair loop originally required one, which would
+    # have made the keep-out half inert exactly there while reading as
+    # implemented -- so this arm declares a block with members and no `zone`.
+    ipath_c = os.path.join(wd, 'Hc-fp.json')
+    out_c = os.path.join(wd, 'Hc-out.kicad_pcb')
+    bpath_c = os.path.join(wd, 'Hc-in.kicad_pcb')
+    one_part_board(bpath_c)
+    with open(ipath_c, 'w', encoding='utf-8') as f:
+        json.dump({"schema": 1, "kind": "floorplan-intent", "units": "mm",
+                   "envelope": {"rect": [0.0, 0.0, SIZE[0], SIZE[1]],
+                                "tolerance_mm": 0.5},
+                   "blocks": [{"name": "b", "refs": ["U1"]}],
+                   "keepouts": [dict(k) for k in ko]}, f)
+    rc_ = subprocess.run(
+        [sys.executable, '-X', 'utf8',
+         os.path.join('py_placer', 'place_seed.py'), bpath_c, out_c,
+         '--intent', ipath_c, '--clearance', '0.2',
+         '--board-edge-clearance', '0.5', '--force'],
+        capture_output=True, text=True, encoding='utf-8', errors='replace',
+        cwd=REPO, timeout=900, env=env)
+    fired = 'polish walked' in rc_.stdout
+    check("H-c: the repair fires for a part with NO declared zone -- a "
+          "keep-out violation does not imply a zone", fired,
+          "the repair skipped it; the zone-less branch is inert")
+    if fired:
+        ovc = overlap(out_c, 'U1', KO)
+        check("H-c: and U1 is out of the keep-out on the WRITTEN board",
+              ovc == 0.0, f"overlap {ovc}mm2, pose {poses(out_c)['U1']}")
+
     # ---- H-b: the ordinary run ------------------------------------------
     r2, s2, out2 = run(wd, one_part_board, wide_zone_intent(keepouts=ko),
                        tag='Hb', polish=True)

--- a/tests/test_701_keepout_seating.py
+++ b/tests/test_701_keepout_seating.py
@@ -43,6 +43,12 @@ passed = failed = 0
 
 
 def check(name, ok, detail=""):
+    """Prints `detail` on OK and FAIL alike, as test_630_seeder_eviction does.
+
+    Which means every `detail` here must read as a MEASUREMENT, not as a
+    failure explanation: a detail phrased "the repair never fired" next to an
+    `OK` is a log that actively misleads its reader.
+    """
     global passed, failed
     passed += bool(ok)
     failed += not ok
@@ -302,7 +308,7 @@ def arm_stranded_and_its_control(wd):
     check("C: and the stdout NOTE names it too -- the JSON verdict and the "
           "prose come from one function, so they cannot drift",
           bool(named),
-          named[0].strip() if named else "no line names U1 and 'hot'")
+          named[0].strip() if named else "lines naming U1+hot: 0")
 
     # ---- the control: the same impossible-looking zone, no keep-out ------
     r2, s2, out2 = run(wd, one_part_board,
@@ -315,6 +321,43 @@ def arm_stranded_and_its_control(wd):
         ov = overlap(out2, 'U1', KO)
         check("C-control: and it sits in the rect", ov > 0.0,
               f"overlap {ov}mm2")
+
+
+def arm_jointly_blocked(wd):
+    """Two keep-outs that OVERLAP over the part's feasible region each free
+    NOTHING when lifted alone, so the per-keep-out census reports `{}` and --
+    before this arm existed -- the verdict fell back to
+    `no_movable_neighbour`, whose prose blames the outline, the zone or the
+    part's own size. That is exactly the misleading answer the whole
+    disclosure exists to replace, reappearing in the two-keep-out case.
+
+    The fixture is a nested enclosure + boss, which is what a real mechanical
+    intent looks like: a board-wide envelope plus a local obstruction."""
+    ko = [{"name": "enclosure", "rect": list(WHOLE_BOARD), "sides": ["F"]},
+          {"name": "boss", "rect": [5.0, 2.0, 15.0, 10.0], "sides": ["F"]}]
+    tight = (7.5, 3.5, 12.5, 8.5)
+    r, s, out = run(wd, one_part_board,
+                    wide_zone_intent(keepouts=ko, zone=tight), tag='J')
+    check("J: U1 is unseated", s and s.get('unseated_refs') == ['U1'],
+          f"unseated_refs={s and s.get('unseated_refs')}")
+    if not s:
+        return
+    v = (s.get('no_pose_verdict') or {}).get('U1')
+    check("J: the verdict is still keepout_blocks when NO SINGLE keep-out "
+          "frees a pose", v == 'keepout_blocks', f"verdict={v!r}")
+    cen = (s.get('no_pose_census') or {}).get('U1') or {}
+    check("J: keepouts_freeing is empty -- that is the whole point, and it "
+          "is why a per-keep-out sweep alone is not enough",
+          cen.get('keepouts_freeing') == {},
+          f"keepouts_freeing={cen.get('keepouts_freeing')!r}")
+    check("J: and keepouts_joint is the count that carries the verdict",
+          (cen.get('keepouts_joint') or 0) > 0,
+          f"keepouts_joint={cen.get('keepouts_joint')!r}")
+    named = [ln for ln in r.stdout.splitlines()
+             if 'U1' in ln and 'JOINTLY' in ln]
+    check("J: the NOTE says JOINTLY rather than naming one keep-out falsely",
+          bool(named),
+          named[0].strip() if named else "lines saying JOINTLY: 0")
 
 
 # --------------------------------------------------------------------------
@@ -463,14 +506,19 @@ def arm_edge_connector(wd):
           "turns red", ov1 == 0.0,
           f"overlap {ov1}mm2, pose {poses(out1)['J1']}")
     check("G: and the grade agrees", not graded_keepout_errors(out1, it(True)))
-    # The band was given up, which is the honest outcome -- but it must be
-    # DISCLOSED, and disclosed with the keep-out's name. A silent fallback to
-    # the ordinary stages is how a connector quietly stops reaching its edge.
-    named = [ln for ln in r1.stdout.splitlines()
-             if 'J1' in ln and 'shell' in ln]
-    check("G: the refusal is disclosed and NAMES the keep-out, not the "
-          "outline", bool(named),
-          named[0].strip() if named else "no line names both J1 and 'shell'")
+    # ... AND it keeps its declared edge. Stage 1 originally tried a single
+    # along-edge position, so the keep-out sent J1 to the ordinary stages,
+    # which parked it at (11.22, 6.589) -- the board INTERIOR on a board whose
+    # south edge is y=14 -- trading a `keepout` grade error for an
+    # `edge_connector` one while 26 clear south-edge seats existed. The slide
+    # is what makes this assertion pass, and it is the assertion that fails if
+    # the slide is removed.
+    gy = poses(out1)['J1'][1]
+    check("G: and J1 KEEPS its declared south edge rather than being parked "
+          "inland", gy > size[1] - 3.0,
+          f"y={gy} on a {size[1]}mm-tall board (south edge y={size[1]})")
+    check("G: the run has no grade error at all", r1.returncode == 0,
+          f"rc={r1.returncode}")
 
 
 # --------------------------------------------------------------------------
@@ -535,10 +583,11 @@ def arm_polish_repair(wd):
     injected = 'polish walked' in r.stdout
     check("H-a: the injected polish really did break the board, so this arm "
           "is not vacuous", injected,
-          "the repair never fired -- the injection did not take effect")
+          f"repair line present: {injected}")
     if injected:
         check("H-a: the repair names `keepout` as what it repaired",
-              'keepout' in r.stdout, "repair line does not mention keepout")
+              'keepout' in r.stdout,
+              f"names keepout: {'keepout' in r.stdout}")
         ov = overlap(out_a, 'U1', KO)
         check("H-a: and U1 is back out of the keep-out on the WRITTEN board",
               ov == 0.0, f"overlap {ov}mm2, pose {poses(out_a)['U1']}")
@@ -570,7 +619,7 @@ def arm_polish_repair(wd):
     fired = 'polish walked' in rc_.stdout
     check("H-c: the repair fires for a part with NO declared zone -- a "
           "keep-out violation does not imply a zone", fired,
-          "the repair skipped it; the zone-less branch is inert")
+          f"repair line present: {fired}")
     if fired:
         ovc = overlap(out_c, 'U1', KO)
         check("H-c: and U1 is out of the keep-out on the WRITTEN board",
@@ -593,6 +642,7 @@ def main():
     with tempfile.TemporaryDirectory() as wd:
         for fn in (arm_displaced_and_its_control,
                    arm_stranded_and_its_control,
+                   arm_jointly_blocked,
                    arm_allow_owner_exemption,
                    arm_through_hole_from_the_other_side,
                    arm_edge_connector,

--- a/tests/test_701_keepout_seating.py
+++ b/tests/test_701_keepout_seating.py
@@ -1,0 +1,515 @@
+#!/usr/bin/env python3
+"""#701: `place_seed` honours a declared keep-out, end to end.
+
+The board is HAND-WRITTEN rather than taken from the corpus, for one reason:
+a control arm needs a board where the seat location is a THEOREM. On a corpus
+board "where would this part land without the keep-out" is only answerable by
+re-running the seeder, which makes the control circular. Here a single-ref
+zone gets `jx, jy = (0.0, 0.0)` (seeder.py, stage 2), so the target is the
+zone centre exactly and the nearest clear pose can be written down.
+
+Every accepting arm asserts on the RE-PARSED WRITTEN BOARD, never on the JSON
+summary alone -- test_630_seeder_eviction.py records that its own first
+version passed while one part sat 100% inside another's courtyard, because it
+believed a count. The JSON is checked too, for what it claims.
+
+Every arm that shows a keep-out doing something has a CONTROL arm showing the
+same board WITHOUT the keep-out doing the other thing. Without the control,
+an assertion like "the part is not in the rect" is satisfied by a board where
+the part was never going to be in the rect, and the test passes in both
+directions.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for _p in (REPO,):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+        sys.path.insert(0, os.path.join(_p, 'py_router'))   # placement split
+        sys.path.insert(0, os.path.join(_p, 'py_tools'))    # placement split
+        sys.path.insert(0, os.path.join(_p, 'py_placer'))   # placement split
+
+from kicad_parser import parse_kicad_pcb                        # noqa: E402
+from placement import floorplan, legality                       # noqa: E402
+import pose_score                                               # noqa: E402
+
+RUN_ALL_TIMEOUT = 1200
+
+passed = failed = 0
+
+
+def check(name, ok, detail=""):
+    global passed, failed
+    passed += bool(ok)
+    failed += not ok
+    print(f"  {'OK  ' if ok else 'FAIL'} {name}"
+          + (f" -- {detail}" if detail else ""))
+
+
+# --------------------------------------------------------------------------
+# fixtures -- the shape of tests/test_630_seeder_eviction.py's, on purpose
+# --------------------------------------------------------------------------
+
+def _part(ref, x, y, half_w, half_h, npads, pad_y=0.0, layer='F.Cu',
+          thru=False):
+    """A footprint with a (2*half_w x 2*half_h) courtyard and `npads` pads.
+
+    `thru=True` emits drilled pads on every copper layer, which is what makes
+    `footprint_has_through_pads` true and therefore what puts the part on BOTH
+    faces -- the case `rule_keepout` grades from the opposite side.
+    """
+    if thru:
+        pads = ''.join(
+            f'\t\t(pad "{i + 1}" thru_hole circle\n'
+            f'\t\t\t(at {i * 0.6 - 0.3} {pad_y})\n'
+            f'\t\t\t(size 0.6 0.6)\n\t\t\t(drill 0.35)\n'
+            f'\t\t\t(layers "*.Cu" "*.Mask")\n'
+            f'\t\t\t(net {1 if i == 0 else 2} "N{1 if i == 0 else 2}")\n'
+            f'\t\t\t(uuid "p{i}-{ref}")\n\t\t)\n' for i in range(npads))
+    else:
+        pads = ''.join(
+            f'\t\t(pad "{i + 1}" smd rect\n'
+            f'\t\t\t(at {i * 0.2 - 0.2} {pad_y})\n'
+            f'\t\t\t(size 0.3 0.3)\n\t\t\t(layers "{layer}")\n'
+            f'\t\t\t(net {1 if i == 0 else 2} "N{1 if i == 0 else 2}")\n'
+            f'\t\t\t(uuid "p{i}-{ref}")\n\t\t)\n' for i in range(npads))
+    return f'''\t(footprint "test:P{ref}"
+\t\t(layer "{layer.split('.')[0]}.Cu")
+\t\t(uuid "fp-{ref}")
+\t\t(at {x} {y})
+\t\t(property "Reference" "{ref}"
+\t\t\t(at 0 0)
+\t\t)
+\t\t(fp_rect
+\t\t\t(start {-half_w} {-half_h})
+\t\t\t(end {half_w} {half_h})
+\t\t\t(layer "{layer.split('.')[0]}.CrtYd")
+\t\t\t(uuid "cy-{ref}")
+\t\t)
+{pads}\t)
+'''
+
+
+def board(path, parts, size=(20, 12)):
+    body = ('(kicad_pcb\n\t(version 20241229)\n'
+            '\t(net 0 "")\n\t(net 1 "N1")\n\t(net 2 "N2")\n'
+            '\t(gr_rect\n\t\t(start 0 0)\n\t\t(end {} {})\n'
+            '\t\t(layer "Edge.Cuts")\n\t\t(uuid "e1")\n\t)\n'.format(*size)
+            + ''.join(parts) + ')\n')
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(body)
+
+
+SIZE = (20.0, 12.0)
+#: The keep-out every arm below uses. On a 20x12 board it is well inside the
+#: usable inset, so the OUTLINE can never be what refuses a pose.
+KO = (8.0, 4.0, 12.0, 8.0)
+
+
+def one_part_board(path, **kw):
+    """U1 alone: a 4x4 square courtyard at the board centre. Square so that
+    the four rotations the search tries are indistinguishable and the pose
+    arithmetic below cannot be disturbed by one of them."""
+    board(path, [_part('U1', 10, 6, 2.0, 2.0, 4, **kw)], size=SIZE)
+
+
+def wide_zone_intent(keepouts=(), zone=(2.0, 2.0, 18.0, 10.0), refs=('U1',)):
+    """A single-ref zone, so the seat target is the zone CENTRE exactly."""
+    it = {"schema": 1, "kind": "floorplan-intent", "units": "mm",
+          "envelope": {"rect": [0.0, 0.0, SIZE[0], SIZE[1]],
+                       "tolerance_mm": 0.5},
+          "blocks": [{"name": "b", "refs": list(refs), "zone": list(zone),
+                      "tolerance_mm": 0.5}]}
+    if keepouts:
+        it["keepouts"] = [dict(k) for k in keepouts]
+    return it
+
+
+def run(workdir, make_board, intent, *extra, tag='seed', polish=False):
+    bpath = os.path.join(workdir, f'{tag}-in.kicad_pcb')
+    ipath = os.path.join(workdir, f'{tag}-fp.json')
+    out = os.path.join(workdir, f'{tag}-out.kicad_pcb')
+    make_board(bpath)
+    with open(ipath, 'w', encoding='utf-8') as f:
+        json.dump(intent, f)
+    # `--force`: these fixtures carry a handful of parts at honest
+    # coordinates, so the board-state gate reads them as already PLACED and
+    # exits 3. Re-seeding is exactly what the arms want, and the seat target
+    # is the zone centre either way -- a single-ref zone draws no jitter.
+    argv = [sys.executable, '-X', 'utf8',
+            os.path.join('py_placer', 'place_seed.py'), bpath, out,
+            '--intent', ipath, '--clearance', '0.2',
+            '--board-edge-clearance', '0.5', '--force']
+    if not polish:
+        argv.append('--no-polish')
+    argv.extend(extra)
+    r = subprocess.run(argv, capture_output=True, text=True, encoding='utf-8',
+                       errors='replace', cwd=REPO, timeout=900,
+                       env=dict(os.environ, PYTHONHASHSEED='0',
+                                PYTHONIOENCODING='utf-8'))
+    summary = None
+    for line in r.stdout.splitlines():
+        if line.startswith('JSON_SUMMARY:'):
+            summary = json.loads(line.split(':', 1)[1])
+    return r, summary, out
+
+
+def poses(path):
+    pcb = parse_kicad_pcb(path)
+    return {ref: (round(fp.x, 3), round(fp.y, 3), round(fp.rotation, 1))
+            for ref, fp in sorted(pcb.footprints.items())}
+
+
+def courtyard(path, ref):
+    """The written board's courtyard rect for `ref`, re-derived from the file
+    by the same code the grader uses -- never read off the JSON."""
+    pcb = parse_kicad_pcb(path)
+    st = pose_score.make_state(pcb, path, clearance=0.2,
+                               board_edge_clearance=0.5, grid_step=0.1)
+    return st.parts[ref].rect()
+
+
+def overlap(path, ref, rect):
+    return legality.rect_overlap_area(courtyard(path, ref), rect)
+
+
+def pairwise_legal(path):
+    pcb = parse_kicad_pcb(path)
+    pairs = legality.body_overlap_pairs(
+        legality.graded_parts_from_file(pcb, path))
+    st = pose_score.make_state(pcb, path, clearance=0.2,
+                               board_edge_clearance=0.5, grid_step=0.1)
+    bad = [r for r in sorted(st.parts)
+           if not st.candidate_valid(r, st.parts[r].x, st.parts[r].y,
+                                     st.parts[r].rot, exclude=set())]
+    return (not pairs and not bad,
+            f"courtyard overlaps {[(q.a, q.b) for q in pairs]}, "
+            f"candidate_valid rejects {bad}")
+
+
+def graded_keepout_errors(board_path, intent):
+    pcb = parse_kicad_pcb(board_path)
+    res = floorplan.grade(floorplan.intent_from_dict(dict(intent), board_path),
+                          pcb, board_path, clearance=0.2,
+                          board_edge_clearance=0.5)
+    return [v for v in res.errors if v.rule == 'keepout']
+
+
+# --------------------------------------------------------------------------
+# A/B -- the part is displaced OUT of the keep-out, and minimally
+# --------------------------------------------------------------------------
+
+def arm_displaced_and_its_control(wd):
+    """THE THEOREM. U1's courtyard is 4x4 (half 2.0). The zone
+    [2, 2, 18, 10] at tol 0.5 confines the centre to x in [3.5, 16.5],
+    y in [3.5, 8.5]; the target is the zone centre (10, 6).
+
+    Clearing KO = [8, 4, 12, 8] needs cx <= 6 or cx >= 14 or cy <= 2 or
+    cy >= 10. The two cy branches are outside the feasible box, so the
+    minimum displacement from (10, 6) is EXACTLY 4.0mm, at (6, 6) or (14, 6).
+
+    That exact number is the assertion a wrong implementation cannot produce:
+    checking keep-outs only in `_try_place`'s whole-board fallback sweep
+    would seat at a FALLBACK_STEP_MM = 2.0 lattice point, and refusing rather
+    than searching would leave the part unseated.
+    """
+    r, s, out = run(wd, one_part_board,
+                    wide_zone_intent(keepouts=[
+                        {"name": "hot", "rect": list(KO), "sides": ["F"]}]),
+                    tag='A')
+    check("A: the run succeeds and seats U1",
+          r.returncode == 0 and s and s.get('unseated') == 0,
+          f"rc={r.returncode} unseated={s and s.get('unseated')}")
+    if not (s and s.get('unseated') == 0):
+        return
+    ov = overlap(out, 'U1', KO)
+    check("A: U1's courtyard on the WRITTEN board is clear of the keep-out",
+          ov == 0.0, f"overlap {ov}mm2")
+    px, py, _rot = poses(out)['U1']
+    d = round(((px - 10.0) ** 2 + (py - 6.0) ** 2) ** 0.5, 3)
+    check("A: and it moved the MINIMUM 4.0mm to get there", d == 4.0,
+          f"seated at ({px}, {py}), {d}mm from the zone centre")
+    check("A: no keepout violation when the written board is re-graded",
+          not graded_keepout_errors(out, wide_zone_intent(keepouts=[
+              {"name": "hot", "rect": list(KO), "sides": ["F"]}])))
+    ok, det = pairwise_legal(out)
+    check("A: the written board is pairwise legal", ok, det)
+
+    # ---- the control: same board, same zone, NO keep-out declared --------
+    r2, s2, out2 = run(wd, one_part_board, wide_zone_intent(), tag='Actrl')
+    check("A-control: the run succeeds", r2.returncode == 0 and s2)
+    if not s2:
+        return
+    p2 = poses(out2)['U1']
+    check("A-control: U1 lands on the zone centre", (p2[0], p2[1]) == (10.0, 6.0),
+          f"at {p2}")
+    ov2 = overlap(out2, 'U1', KO)
+    check("A-control: and it DOES sit in the rect, so the keep-out is what "
+          "moved it in arm A", ov2 > 0.0, f"overlap {ov2}mm2")
+
+
+# --------------------------------------------------------------------------
+# C/D -- a keep-out that STRANDS a part is NAMED
+# --------------------------------------------------------------------------
+
+#: A keep-out covering the whole board. Stranding a part takes this much:
+#: a keep-out that merely covers its ZONE does not strand it, because stage 3
+#: legitimately re-tries the part at its connectivity centroid with no zone
+#: constraint and finds a legal pose outside. That is correct behaviour (the
+#: grade then reports zone_containment, which is a different finding), so the
+#: stranding arms have to remove every pose on the board, not merely the
+#: zoned ones.
+WHOLE_BOARD = (-1.0, -1.0, SIZE[0] + 1.0, SIZE[1] + 1.0)
+
+
+def arm_stranded_and_its_control(wd):
+    """A keep-out over the entire board leaves U1 no legal pose ANYWHERE, so
+    it is genuinely stranded rather than merely pushed out of its zone.
+
+    A SECOND keep-out is declared in a corner, so "name them all" and "name
+    the first one" are both wrong answers and the assertion can be on the
+    exact set. `cold` binds U1 too, but lifting it frees nothing -- which is
+    precisely what makes the naming a MEASUREMENT rather than a declaration
+    lookup."""
+    ko = [{"name": "hot", "rect": list(WHOLE_BOARD), "sides": ["F"]},
+          {"name": "cold", "rect": [0.6, 0.6, 2.0, 2.0], "sides": ["F"]}]
+    tight = (7.5, 3.5, 12.5, 8.5)
+    r, s, out = run(wd, one_part_board,
+                    wide_zone_intent(keepouts=ko, zone=tight), tag='C')
+    check("C: U1 is reported unseated, not seated in the keep-out",
+          s and s.get('unseated_refs') == ['U1'],
+          f"unseated_refs={s and s.get('unseated_refs')}")
+    if not s:
+        return
+    v = (s.get('no_pose_verdict') or {}).get('U1')
+    check("C: the verdict is keepout_blocks, not no_movable_neighbour",
+          v == 'keepout_blocks', f"verdict={v!r}")
+    cen = (s.get('no_pose_census') or {}).get('U1') or {}
+    freeing = cen.get('keepouts_freeing')
+    check("C: exactly the RESPONSIBLE keep-out is named",
+          sorted(freeing or {}) == ['hot'],
+          f"keepouts_freeing={freeing!r}")
+    check("C: the census says 0 poses with it, and MORE without it -- a "
+          "count from the seat predicate, not a static zone-vs-rect test",
+          cen.get('baseline') == 0 and (freeing or {}).get('hot', 0) > 0,
+          f"baseline={cen.get('baseline')} freeing={freeing!r}")
+    named = [ln for ln in r.stdout.splitlines()
+             if 'U1' in ln and 'hot' in ln and 'keep-out' in ln.lower()]
+    check("C: and the stdout NOTE names it too -- the JSON verdict and the "
+          "prose come from one function, so they cannot drift",
+          bool(named),
+          named[0].strip() if named else "no line names U1 and 'hot'")
+
+    # ---- the control: the same impossible-looking zone, no keep-out ------
+    r2, s2, out2 = run(wd, one_part_board,
+                       wide_zone_intent(zone=tight), tag='Cctrl')
+    check("C-control: with no keep-out declared U1 IS seated -- so arm C is "
+          "not just an impossible board",
+          s2 and s2.get('unseated') == 0,
+          f"unseated={s2 and s2.get('unseated')}")
+    if s2 and s2.get('unseated') == 0:
+        ov = overlap(out2, 'U1', KO)
+        check("C-control: and it sits in the rect", ov > 0.0,
+              f"overlap {ov}mm2")
+
+
+# --------------------------------------------------------------------------
+# E -- the `allow` glob owner exemption, self-controlled
+# --------------------------------------------------------------------------
+
+def arm_allow_owner_exemption(wd):
+    """A mounting-hole keep-out must not strand its own mounting hole -- the
+    mirror of the bug being fixed, and strictly worse, since the part then
+    has no legal pose anywhere.
+
+    Two 2x2 parts with single-ref zones, and one keep-out over the WHOLE
+    board (see WHOLE_BOARD: a keep-out that covers only the zones does not
+    strand anything, because stage 3 re-tries unzoned). MH1 is exempted by
+    the GLOB `MH*` -- a glob, not the exact ref, so an `==` implementation
+    dies here too; R1 is not. Neither arm passes under a wrong
+    implementation: `allow` ignored strands MH1, `allow` matching everything
+    seats R1."""
+    hot = [-1.0, -1.0, 31.0, 13.0]
+
+    def two_part_board(path):
+        board(path, [_part('MH1', 10, 6, 1.0, 1.0, 2),
+                     _part('R1', 20, 6, 1.0, 1.0, 2)], size=(30.0, 12.0))
+
+    it = {"schema": 1, "kind": "floorplan-intent", "units": "mm",
+          "envelope": {"rect": [0.0, 0.0, 30.0, 12.0], "tolerance_mm": 0.5},
+          "blocks": [{"name": "m", "refs": ["MH1"],
+                      "zone": [8.0, 4.5, 12.0, 7.5], "tolerance_mm": 0.5},
+                     {"name": "r", "refs": ["R1"],
+                      "zone": [18.0, 4.5, 22.0, 7.5], "tolerance_mm": 0.5}],
+          "keepouts": [{"name": "rib", "rect": hot, "sides": ["F"],
+                        "allow": ["MH*"]}]}
+    r, s, out = run(wd, two_part_board, it, tag='E')
+    check("E: the exempt part IS seated inside the keep-out",
+          s and 'MH1' not in (s.get('unseated_refs') or []),
+          f"unseated_refs={s and s.get('unseated_refs')}")
+    if s and 'MH1' not in (s.get('unseated_refs') or []):
+        ov = overlap(out, 'MH1', tuple(hot))
+        check("E: ... and its courtyard really is in the rect", ov > 0.0,
+              f"overlap {ov}mm2")
+    check("E: the NON-exempt part in the same keep-out is not",
+          s and s.get('unseated_refs') == ['R1'],
+          f"unseated_refs={s and s.get('unseated_refs')}")
+    check("E: the grade agrees -- no keepout error for the exempt part",
+          not [v for v in graded_keepout_errors(out, it) if v.ref == 'MH1'])
+
+
+# --------------------------------------------------------------------------
+# F -- a through-hole part is in a keep-out from EITHER side
+# --------------------------------------------------------------------------
+
+def arm_through_hole_from_the_other_side(wd):
+    """`rule_keepout` grades a THT part against a keep-out on the face its
+    BODY is not on, because its leads pass through. The seat predicate must
+    agree, or the seeder places a part the grade then flags.
+
+    Three arms, because the side logic has to be shown non-vacuous: a THT
+    part on B is refused by an F-side keep-out; the same board with no
+    keep-out seats it; and an SMD-only part on B is SEATED inside the same
+    F-side keep-out, because it genuinely does not occupy F."""
+    tight = (7.5, 3.5, 12.5, 8.5)
+    ko = [{"name": "hot", "rect": list(WHOLE_BOARD), "sides": ["F"]}]
+
+    def tht_board(path):
+        board(path, [_part('D1', 10, 6, 2.0, 2.0, 4, layer='B.Cu',
+                           thru=True)], size=SIZE)
+
+    def smd_b_board(path):
+        board(path, [_part('D1', 10, 6, 2.0, 2.0, 4, layer='B.Cu')],
+              size=SIZE)
+
+    it = wide_zone_intent(keepouts=ko, zone=tight, refs=('D1',))
+    r, s, out = run(wd, tht_board, it, tag='Fa')
+    check("F-a: a THT part on B is refused by an F-side keep-out",
+          s and s.get('unseated_refs') == ['D1'],
+          f"unseated_refs={s and s.get('unseated_refs')}")
+    if s:
+        check("F-a: ... named as a keep-out refusal",
+              (s.get('no_pose_verdict') or {}).get('D1') == 'keepout_blocks',
+              f"verdict={(s.get('no_pose_verdict') or {}).get('D1')!r}")
+
+    r2, s2, out2 = run(wd, tht_board,
+                       wide_zone_intent(zone=tight, refs=('D1',)), tag='Fb')
+    check("F-b (control): with no keep-out the same THT part IS seated",
+          s2 and s2.get('unseated') == 0,
+          f"unseated={s2 and s2.get('unseated')}")
+
+    r3, s3, out3 = run(wd, smd_b_board, it, tag='Fc')
+    seated = s3 and s3.get('unseated') == 0
+    check("F-c: an SMD-only part on B is SEATED inside the same F-side "
+          "keep-out -- the side test is not vacuous", seated,
+          f"unseated={s3 and s3.get('unseated')}")
+    if seated:
+        ov = overlap(out3, 'D1', tuple(WHOLE_BOARD))
+        check("F-c: ... and its courtyard really is inside the rect",
+              ov > 0.0, f"overlap {ov}mm2")
+
+
+# --------------------------------------------------------------------------
+# G -- the edge-connector seat, which bypasses pose_ok by design
+# --------------------------------------------------------------------------
+
+def arm_edge_connector(wd):
+    """`_seat_edge` and stage 1 use `edge_seat_ok`, not `pose_ok`. A PR that
+    guarded only `pose_ok` leaves this red, and nothing else in the suite
+    catches it -- which is the whole reason this arm exists.
+
+    J1 is a declared south-edge connector on a 20x14 board. The keep-out
+    covers the south band around x = 10, so the along-edge slide has to move
+    it; the control shows where it lands without one."""
+    size = (20.0, 14.0)
+    edgeko = [7.0, 10.0, 13.0, 14.0]
+
+    def edge_board(path):
+        board(path, [_part('J1', 10, 7, 2.0, 1.5, 2, pad_y=-1.0)], size=size)
+
+    def it(with_ko):
+        d = {"schema": 1, "kind": "floorplan-intent", "units": "mm",
+             "envelope": {"rect": [0.0, 0.0, size[0], size[1]],
+                          "tolerance_mm": 0.5},
+             "blocks": [{"name": "b", "refs": ["J1"]}],
+             "edge_connectors": [{"ref": "J1", "edge": "south",
+                                  "overhang_mm": {"min": 0.0, "max": 1.0}}]}
+        if with_ko:
+            d["keepouts"] = [{"name": "shell", "rect": edgeko,
+                              "sides": ["F"]}]
+        return d
+
+    r0, s0, out0 = run(wd, edge_board, it(False), tag='Gctrl')
+    check("G-control: the edge connector is seated with no keep-out",
+          s0 and s0.get('unseated') == 0,
+          f"unseated={s0 and s0.get('unseated')}")
+    if not (s0 and s0.get('unseated') == 0):
+        return
+    ov0 = overlap(out0, 'J1', tuple(edgeko))
+    check("G-control: and it lands INSIDE the rect the keep-out will cover, "
+          "so arm G's assertion is not vacuous", ov0 > 0.0,
+          f"overlap {ov0}mm2, pose {poses(out0)['J1']}")
+
+    r1, s1, out1 = run(wd, edge_board, it(True), tag='G')
+    check("G: the run completes with the keep-out declared",
+          r1.returncode in (0, 4), f"rc={r1.returncode}")
+    ov1 = overlap(out1, 'J1', tuple(edgeko))
+    check("G: the edge seat is clear of the keep-out on the WRITTEN board "
+          "-- this is the arm that reverting the edge_seat_ok conjunct "
+          "turns red", ov1 == 0.0,
+          f"overlap {ov1}mm2, pose {poses(out1)['J1']}")
+    check("G: and the grade agrees", not graded_keepout_errors(out1, it(True)))
+    # The band was given up, which is the honest outcome -- but it must be
+    # DISCLOSED, and disclosed with the keep-out's name. A silent fallback to
+    # the ordinary stages is how a connector quietly stops reaching its edge.
+    named = [ln for ln in r1.stdout.splitlines()
+             if 'J1' in ln and 'shell' in ln]
+    check("G: the refusal is disclosed and NAMES the keep-out, not the "
+          "outline", bool(named),
+          named[0].strip() if named else "no line names both J1 and 'shell'")
+
+
+# --------------------------------------------------------------------------
+# H -- the polish quench has no keep-out term; the self-check repairs it
+# --------------------------------------------------------------------------
+
+def arm_polish_repair(wd):
+    """`place_seed` runs a polish quench after seeding, and the quench has no
+    keep-out concept at all. Without a repair the polish can walk a part back
+    into a keep-out and `place_seed` then fails its own grade, exit 4, on a
+    board its own seeder produced correctly.
+
+    Run arm A's fixture WITH the polish enabled and require a clean grade."""
+    ko = [{"name": "hot", "rect": list(KO), "sides": ["F"]}]
+    r, s, out = run(wd, one_part_board, wide_zone_intent(keepouts=ko),
+                    tag='H', polish=True)
+    check("H: place_seed exits 0 with the polish enabled",
+          r.returncode == 0, f"rc={r.returncode}")
+    check("H: no keepout error in its own self-check",
+          s and s.get('grade_errors') == 0,
+          f"grade_errors={s and s.get('grade_errors')}")
+    ov = overlap(out, 'U1', KO)
+    check("H: the polished board is still clear of the keep-out", ov == 0.0,
+          f"overlap {ov}mm2")
+
+
+def main():
+    with tempfile.TemporaryDirectory() as wd:
+        for fn in (arm_displaced_and_its_control,
+                   arm_stranded_and_its_control,
+                   arm_allow_owner_exemption,
+                   arm_through_hole_from_the_other_side,
+                   arm_edge_connector,
+                   arm_polish_repair):
+            print(f"--- {fn.__name__}")
+            fn(wd)
+    print(f"\n{passed} passed, {failed} failed")
+    return 1 if failed else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_701_keepout_seating.py
+++ b/tests/test_701_keepout_seating.py
@@ -477,24 +477,85 @@ def arm_edge_connector(wd):
 # H -- the polish quench has no keep-out term; the self-check repairs it
 # --------------------------------------------------------------------------
 
-def arm_polish_repair(wd):
-    """`place_seed` runs a polish quench after seeding, and the quench has no
-    keep-out concept at all. Without a repair the polish can walk a part back
-    into a keep-out and `place_seed` then fails its own grade, exit 4, on a
-    board its own seeder produced correctly.
+#: Fault injection for arm H-a. The quench on these tiny fixtures happens to
+#: leave the part alone, so a plain end-to-end run never reaches the repair
+#: and would pass with the repair deleted -- a test that passes in both
+#: directions. This sitecustomize forces the polish to return the one move
+#: that puts U1 back in the keep-out, which is precisely what a real quench
+#: with no keep-out term is free to do.
+_INJECT = '''
+import placement.quench as _q
+_real = _q.quench
 
-    Run arm A's fixture WITH the polish enabled and require a clean grade."""
+
+def _walk_it_in(*a, **kw):
+    _real(*a, **kw)
+    return [{'reference': 'U1', 'new_x': 10.0, 'new_y': 6.0,
+             'new_rotation': 0.0}]
+
+
+_q.quench = _walk_it_in
+'''
+
+
+def arm_polish_repair(wd):
+    """`place_seed` runs a polish quench after seeding, and the quench has NO
+    keep-out term -- `grep keepout py_placer/placement/quench.py` finds
+    nothing relevant. So the polish is free to walk a part back into a
+    declared keep-out, and `place_seed` then exits 4 against its own intent on
+    a board its own seeder placed correctly.
+
+    H-a injects exactly that fault and requires the repair to undo it. H-b is
+    the ordinary end-to-end run."""
     ko = [{"name": "hot", "rect": list(KO), "sides": ["F"]}]
-    r, s, out = run(wd, one_part_board, wide_zone_intent(keepouts=ko),
-                    tag='H', polish=True)
-    check("H: place_seed exits 0 with the polish enabled",
-          r.returncode == 0, f"rc={r.returncode}")
-    check("H: no keepout error in its own self-check",
-          s and s.get('grade_errors') == 0,
-          f"grade_errors={s and s.get('grade_errors')}")
-    ov = overlap(out, 'U1', KO)
-    check("H: the polished board is still clear of the keep-out", ov == 0.0,
-          f"overlap {ov}mm2")
+
+    # ---- H-a: the polish IS forced to break it -------------------------
+    inj = os.path.join(wd, 'inj')
+    os.makedirs(inj, exist_ok=True)
+    with open(os.path.join(inj, 'sitecustomize.py'), 'w',
+              encoding='utf-8') as f:
+        f.write(_INJECT)
+    bpath = os.path.join(wd, 'Ha-in.kicad_pcb')
+    ipath = os.path.join(wd, 'Ha-fp.json')
+    out_a = os.path.join(wd, 'Ha-out.kicad_pcb')
+    one_part_board(bpath)
+    with open(ipath, 'w', encoding='utf-8') as f:
+        json.dump(wide_zone_intent(keepouts=ko), f)
+    env = dict(os.environ, PYTHONHASHSEED='0', PYTHONIOENCODING='utf-8',
+               PYTHONPATH=inj + os.pathsep
+               + os.pathsep.join(os.path.join(REPO, d) for d in
+                                 ('py_placer', 'py_router', 'py_tools')))
+    r = subprocess.run(
+        [sys.executable, '-X', 'utf8',
+         os.path.join('py_placer', 'place_seed.py'), bpath, out_a,
+         '--intent', ipath, '--clearance', '0.2',
+         '--board-edge-clearance', '0.5', '--force'],
+        capture_output=True, text=True, encoding='utf-8', errors='replace',
+        cwd=REPO, timeout=900, env=env)
+    injected = 'polish walked' in r.stdout
+    check("H-a: the injected polish really did break the board, so this arm "
+          "is not vacuous", injected,
+          "the repair never fired -- the injection did not take effect")
+    if injected:
+        check("H-a: the repair names `keepout` as what it repaired",
+              'keepout' in r.stdout, "repair line does not mention keepout")
+        ov = overlap(out_a, 'U1', KO)
+        check("H-a: and U1 is back out of the keep-out on the WRITTEN board",
+              ov == 0.0, f"overlap {ov}mm2, pose {poses(out_a)['U1']}")
+        check("H-a: place_seed exits 0 after repairing itself",
+              r.returncode == 0, f"rc={r.returncode}")
+
+    # ---- H-b: the ordinary run ------------------------------------------
+    r2, s2, out2 = run(wd, one_part_board, wide_zone_intent(keepouts=ko),
+                       tag='Hb', polish=True)
+    check("H-b: place_seed exits 0 with the polish enabled",
+          r2.returncode == 0, f"rc={r2.returncode}")
+    check("H-b: no grade error in its own self-check",
+          s2 and s2.get('grade_errors') == 0,
+          f"grade_errors={s2 and s2.get('grade_errors')}")
+    ov2 = overlap(out2, 'U1', KO)
+    check("H-b: the polished board is clear of the keep-out", ov2 == 0.0,
+          f"overlap {ov2}mm2")
 
 
 def main():

--- a/tests/test_704_decap_emission.py
+++ b/tests/test_704_decap_emission.py
@@ -254,6 +254,38 @@ def test_a_zero_tether_board_does_not_emit_a_vacuous_zero():
     print(f"  PASS: sonde_u (0 tethers) withholds -- {why[:60]}...")
 
 
+#: The board that isolates the CENSORING guard. Every tracked board in
+#: `WITHHELD` is caught by an earlier guard -- sonde_u has no tethers at all
+#: and interf_u_unrouted has one -- so deleting the censoring rule outright
+#: changed no verdict anywhere and the mutation SURVIVED the first version of
+#: this file: a guard with a measured rationale, a named constant and a
+#: documented table, asserted by nothing. `tigard_placed` clears both earlier
+#: guards with 15 tethers and is withheld by censoring alone.
+_CENSORED = os.path.join(REPO, 'tests', 'fixtures', 'run23',
+                         'tigard_placed.kicad_pcb')
+
+
+def test_the_censoring_guard_is_the_ONLY_thing_withholding_on_a_mid_repair_board():
+    if not os.path.exists(_CENSORED):
+        print(f"  SKIP: {_CENSORED} not present")
+        return
+    doc = fp.emit_intent(parse_kicad_pcb(_CENSORED), _CENSORED,
+                         derive_decaps=True)
+    c = doc['context']['decap_census']
+    # It must CLEAR the two earlier guards, or this arm is testing one of
+    # those instead and the censoring rule is still unasserted.
+    assert c['tethers'] >= fp.DECAP_MIN_SAMPLE, c['tethers']
+    total = c['tethers'] + c['beyond_radius']
+    frac = c['beyond_radius'] / total
+    assert frac > fp.DECAP_MAX_CENSORED, (frac, c)
+    assert 'max_distance_mm' not in doc['decaps'], doc['decaps']
+    why = doc['context']['budget_withheld']['decaps.max_distance_mm']
+    assert 'search radius' in why and 'bless' in why, why
+    print(f"  PASS: tigard_placed has {c['tethers']} tethers (clears "
+          f"MIN_SAMPLE) and censors {frac:.2f} > {fp.DECAP_MAX_CENSORED}, so "
+          f"the censoring guard alone withholds it")
+
+
 def test_the_censoring_guard_separates_healthy_from_degenerate():
     """The withholding rule is a threshold on a measured quantity, so the
     measurement is asserted rather than the threshold restated: every emitting
@@ -511,6 +543,7 @@ TESTS = [
     test_no_search_radius_is_written_into_decaps,
     test_a_board_that_cannot_support_a_limit_withholds_and_says_why,
     test_a_zero_tether_board_does_not_emit_a_vacuous_zero,
+    test_the_censoring_guard_is_the_ONLY_thing_withholding_on_a_mid_repair_board,
     test_the_censoring_guard_separates_healthy_from_degenerate,
     test_the_census_discloses_what_the_limit_cannot_see,
     test_the_census_is_deterministic,

--- a/tests/test_704_decap_emission.py
+++ b/tests/test_704_decap_emission.py
@@ -1,0 +1,532 @@
+#!/usr/bin/env python3
+"""#704: `emit_intent` can derive a decap limit, and its absence is legible.
+
+`emit_intent` wrote `'decaps': {}` as a constant, so `rule_decap_distance`
+could never fire on an auto-emitted intent -- a document reporting `pass: true`
+with three of nine rules run.
+
+The traps this file is written against, all of which the repo has been bitten
+by before, and two of which bit THIS change:
+
+  * "zero violations" is satisfied by the bug itself. If the limit is not
+    emitted the rule is SKIPPED, so it reports zero violations. Every
+    grades-clean assertion therefore carries `'decap_distance' in rules_run`
+    as a conjunct.
+  * a loose limit also grades clean. `5.0`, `DECAP_RADIUS_MM`, `999` all pass
+    a clean-round-trip check, so there is a TIGHTNESS assertion: the limit
+    minus a hair must produce a violation.
+  * a check against an ABSENT object passes with the bug present. The
+    withholding arms therefore assert the REASON STRING, never merely that
+    `max_distance_mm` is missing -- which is equally true on `main`.
+  * a fixture set can make a mutation harmless. The `_ceil4` -> `round`
+    mutation is only killable on boards where `round(max, 4) < max`; measured,
+    that is 3 of the 9 tracked boards, so this file asserts its own fixture
+    set still contains at least 3 of them.
+
+`run_utils` is imported for the CLI arms, so `run_all.py` classifies this as
+an integration test. That is correct: the withholding DISCLOSURE only exists
+on stdout.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for _p in (REPO,):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+        sys.path.insert(0, os.path.join(_p, 'py_router'))   # placement split
+        sys.path.insert(0, os.path.join(_p, 'py_tools'))    # placement split
+        sys.path.insert(0, os.path.join(_p, 'py_placer'))   # placement split
+
+import run_utils                                            # noqa: E402
+from kicad_parser import parse_kicad_pcb                    # noqa: E402
+from placement import floorplan as fp                       # noqa: E402
+from placement import groups as groups_mod                  # noqa: E402
+from placement import legality                              # noqa: E402
+
+RUN_ALL_TIMEOUT = 900
+
+#: Boards with tethers, on which the limit is derived and the round trip must
+#: be clean. Deliberately the wide set rather than a convenient subset -- see
+#: `test_the_fixture_set_can_still_kill_the_round_mutation`.
+EMITTING = ('splitflap_driver', 'tigard', 'watchy', 'ulx3s', 'glasgow_revC',
+            'orangecrab_ext_pll', 'kit-dev-coldfire-xilinx_5213')
+#: Boards where the derivation is WITHHELD, and why.
+WITHHELD = {'interf_u_unrouted': 'tether',      # 1 tether: below MIN_SAMPLE
+            'sonde_u': 'nothing was measured'}  # 0 tethers
+
+
+def _board(name):
+    return os.path.join(REPO, 'kicad_files', f'{name}.kicad_pcb')
+
+
+def _present(names):
+    return [n for n in names if os.path.exists(_board(n))]
+
+
+def _emit(name, **kw):
+    p = _board(name)
+    return fp.emit_intent(parse_kicad_pcb(p), p, **kw), p
+
+
+def _true_max(name):
+    t = groups_mod.decap_tethers(parse_kicad_pcb(_board(name)))
+    return max((d for caps in t.values() for _c, d in caps), default=None)
+
+
+# --------------------------------------------------------------------------
+# the default path is untouched
+# --------------------------------------------------------------------------
+
+def test_the_default_emission_declares_no_limit():
+    """`--declare-decaps` is opt-in. Everything that emits without it -- and
+    that is every caller in the tree except the new flag, including
+    `tests/test_placement_ab.py` -- must be byte-unaffected in this key."""
+    n = 0
+    for name in _present(EMITTING + tuple(WITHHELD)):
+        doc, _p = _emit(name)
+        assert doc['decaps'] == {}, (name, doc['decaps'])
+        assert 'decaps.max_distance_mm' not in doc['context']['budget_withheld']
+        n += 1
+    print(f"  PASS: {n} board(s) emit decaps {{}} without the flag")
+
+
+def test_the_census_is_written_either_way():
+    """`decaps: {}` alone cannot tell a reader "no cap is far from its IC"
+    from "nobody measured" -- the same distinction `rules_run` /
+    `rules_skipped` exists for, one level up. So the census runs on EVERY
+    emission, flag or no flag."""
+    for name in _present(EMITTING + tuple(WITHHELD))[:3]:
+        for kw in ({}, {'derive_decaps': True}):
+            doc, _p = _emit(name, **kw)
+            c = doc['context']['decap_census']
+            for k in ('source', 'metric', 'search_radius_mm', 'tethers',
+                      'ics', 'beyond_radius', 'beyond_radius_refs',
+                      'worst_beyond_mm', 'seeder_scope',
+                      'seeder_scope_ungraded'):
+                assert k in c, (name, kw, k)
+            assert c['source'] == 'auto-tethers'
+    print("  PASS: context.decap_census present with and without the flag")
+
+
+def test_the_keepouts_note_says_which_kind_of_empty_it_is():
+    doc, _p = _emit(_present(EMITTING)[0])
+    assert doc['keepouts'] == []
+    note = doc['context']['keepouts_note']
+    assert 'NONE DECLARED' in note and 'not' in note, note
+    print("  PASS: context.keepouts_note distinguishes declared-none from "
+          "not-considered")
+
+
+# --------------------------------------------------------------------------
+# the derived limit
+# --------------------------------------------------------------------------
+
+def test_the_limit_is_the_ceiling_of_the_UNROUNDED_max():
+    """The limit must be derived from the raw max, not from a display value.
+    `round(v, 4)` can land BELOW the measured max, and ceiling an
+    already-low number reproduces the exact defect `_ceil4` exists to
+    prevent: a document that fails against the board it was written from.
+    That is not hypothetical -- it is the bug the first version of this
+    change shipped, on 3 of the 9 tracked boards."""
+    n = 0
+    for name in _present(EMITTING):
+        doc, _p = _emit(name, derive_decaps=True)
+        got = doc['decaps']['max_distance_mm']
+        raw = _true_max(name)
+        assert got == fp._ceil4(raw), (name, got, fp._ceil4(raw), raw)
+        # `>= raw + EPS`, not `>= raw`, and the difference is the point.
+        # `_ceil4` carries a `- 1e-9` guard in its SCALED domain, i.e. ~1e-13
+        # mm, so on a board whose max is 4.899000000000001 it returns 4.899 --
+        # 1e-15 mm low. The grader fires on `dist > limit + legality.EPS`
+        # (1e-6), so this is the predicate that decides whether the document
+        # passes against its own board, and asserting a stricter one I made up
+        # would fail a board the tool grades clean. Measured: kit-dev is that
+        # board, and it grades clean.
+        assert raw <= got + legality.EPS, (
+            f"{name}: emitted {got} is below its own board's worst tether "
+            f"{raw} by more than EPS, so the document fails against the board "
+            f"it was written from")
+        # the census carries the unrounded number the derivation used
+        assert doc['context']['decap_census']['max_mm'] == raw, name
+        n += 1
+    print(f"  PASS: {n} board(s) emit ceil4(unrounded max), all >= their own "
+          f"worst tether")
+
+
+def test_the_fixture_set_can_still_kill_the_round_mutation():
+    """ANTI-VACUITY for the test above. `_ceil4` and `round` differ only where
+    `round(max, 4) < max`; measured, 3 of the 9 tracked boards. A fixture set
+    quietly narrowed to the others would leave that test passing in both
+    directions, so the set is asserted rather than assumed."""
+    live = [n for n in _present(EMITTING)
+            if round(_true_max(n), 4) < _true_max(n)]
+    assert len(live) >= 3, (
+        f"only {len(live)} board(s) in EMITTING can distinguish _ceil4 from "
+        f"round ({live}) -- the round-trip test would pass in both "
+        f"directions")
+    print(f"  PASS: {len(live)} board(s) make the _ceil4/round mutation live "
+          f"-- {', '.join(live)}")
+
+
+def test_the_round_trip_grades_clean_AND_runs_the_rule():
+    """The `rules_run` conjunct is load-bearing. Without it "zero violations"
+    is satisfied by the bug: no limit means the rule is SKIPPED, which reports
+    zero violations on every board."""
+    for name in _present(EMITTING):
+        doc, p = _emit(name, derive_decaps=True)
+        pcb = parse_kicad_pcb(p)
+        r = fp.grade(fp.intent_from_dict(doc, p), pcb, p)
+        assert 'decap_distance' in r.rules_run, (name, sorted(r.rules_run))
+        bad = [v for v in r.violations if v.rule == 'decap_distance']
+        assert not bad, (name, [v.message for v in bad[:3]])
+    print(f"  PASS: {len(_present(EMITTING))} board(s) run decap_distance "
+          f"with zero violations")
+
+
+def test_the_limit_is_TIGHT_not_merely_satisfiable():
+    """A loose constant -- 5.0, DECAP_RADIUS_MM, 999 -- also grades clean and
+    also runs the rule, so the test above cannot tell it from a real
+    measurement. This is the bound only the correct behaviour produces:
+    shaving the limit must produce a violation on EVERY emitting board."""
+    for name in _present(EMITTING):
+        doc, p = _emit(name, derive_decaps=True)
+        doc['decaps']['max_distance_mm'] -= 1e-3
+        pcb = parse_kicad_pcb(p)
+        r = fp.grade(fp.intent_from_dict(doc, p), pcb, p)
+        bad = [v for v in r.violations if v.rule == 'decap_distance']
+        assert bad, (f"{name}: shaving the limit by 1um produced NO "
+                     f"violation, so the limit is not the board's own max")
+    print(f"  PASS: {len(_present(EMITTING))} board(s) violate at "
+          f"limit - 1um -- the limit is the measurement, not slack")
+
+
+def test_no_search_radius_is_written_into_decaps():
+    """The grader reads `search_radius_mm` with `groups.DECAP_RADIUS_MM` as
+    its default. Writing a radius here that differs would have the emitter and
+    the rule measuring different tether populations, and the clean round trip
+    would then be an accident."""
+    for name in _present(EMITTING)[:3]:
+        doc, _p = _emit(name, derive_decaps=True)
+        assert set(doc['decaps']) == {'max_distance_mm'}, doc['decaps']
+    print("  PASS: decaps carries max_distance_mm and nothing else")
+
+
+# --------------------------------------------------------------------------
+# withholding -- asserted on the REASON, never on the absence
+# --------------------------------------------------------------------------
+
+def test_a_board_that_cannot_support_a_limit_withholds_and_says_why():
+    """Asserting `'max_distance_mm' not in decaps` would pass on `main`, with
+    the bug fully present. So each arm asserts the reason string."""
+    n = 0
+    for name, phrase in WITHHELD.items():
+        if not os.path.exists(_board(name)):
+            continue
+        doc, p = _emit(name, derive_decaps=True)
+        assert 'max_distance_mm' not in doc['decaps'], name
+        why = doc['context']['budget_withheld'].get('decaps.max_distance_mm')
+        assert why, f"{name}: withheld with NO reason recorded"
+        assert phrase in why, (name, why)
+        # ... and the census still ran, so "withheld" is distinguishable from
+        # "not considered" here too.
+        assert 'tethers' in doc['context']['decap_census'], name
+        n += 1
+    print(f"  PASS: {n} board(s) withhold with a stated reason")
+
+
+def test_a_zero_tether_board_does_not_emit_a_vacuous_zero():
+    """`max(..., default=0)` would write `max_distance_mm: 0.0`, which grades
+    clean vacuously (there is nothing to grade) and would silently gate every
+    future cap at zero. The purest form of "a check against an absent object
+    passes with the bug present": only the reason string separates the two."""
+    if not os.path.exists(_board('sonde_u')):
+        print("  SKIP: sonde_u not present")
+        return
+    doc, _p = _emit('sonde_u', derive_decaps=True)
+    assert doc['context']['decap_census']['tethers'] == 0
+    assert doc['decaps'].get('max_distance_mm') is None
+    why = doc['context']['budget_withheld']['decaps.max_distance_mm']
+    assert 'nothing was measured' in why, why
+    print(f"  PASS: sonde_u (0 tethers) withholds -- {why[:60]}...")
+
+
+def test_the_censoring_guard_separates_healthy_from_degenerate():
+    """The withholding rule is a threshold on a measured quantity, so the
+    measurement is asserted rather than the threshold restated: every emitting
+    board must sit BELOW the cut and every withheld-for-censoring board ABOVE
+    it. A guard that withheld on everything, or on nothing, fails here."""
+    rows = []
+    for name in _present(EMITTING + tuple(WITHHELD)):
+        c = _emit(name)[0]['context']['decap_census']
+        total = c['tethers'] + c['beyond_radius']
+        rows.append((name, c['tethers'],
+                     (c['beyond_radius'] / total) if total else 1.0))
+    healthy = [r for r in rows if r[0] in EMITTING]
+    assert healthy, "no emitting board present"
+    for name, _n, frac in healthy:
+        assert frac <= fp.DECAP_MAX_CENSORED, (
+            f"{name} censors {frac:.2f} yet a limit is emitted for it")
+    worst = max(f for _n, _t, f in healthy)
+    print(f"  PASS: every emitting board censors <= "
+          f"{fp.DECAP_MAX_CENSORED} (worst {worst:.2f}); "
+          f"{len([r for r in rows if r[2] > fp.DECAP_MAX_CENSORED])} board(s) "
+          f"above it")
+
+
+def test_the_census_discloses_what_the_limit_cannot_see():
+    """The known, unfixed hole: emitter and rule truncate at the same radius,
+    so a rail-sharing cap beyond it is invisible to both. Shipping the limit
+    WITHOUT that disclosure would be the bug #704 complains about relocated --
+    a number that goes up while coverage does not."""
+    if not os.path.exists(_board('splitflap_driver')):
+        print("  SKIP: splitflap_driver not present")
+        return
+    doc, _p = _emit('splitflap_driver', derive_decaps=True)
+    c = doc['context']['decap_census']
+    assert doc['decaps']['max_distance_mm'] < 5.0
+    assert c['beyond_radius'] >= 1, c
+    assert c['worst_beyond_mm'] > 4 * doc['decaps']['max_distance_mm'], c
+    assert c['beyond_radius_refs'], c
+    print(f"  PASS: splitflap_driver emits "
+          f"{doc['decaps']['max_distance_mm']} while disclosing a cap "
+          f"{c['worst_beyond_mm']}mm out, ref(s) {c['beyond_radius_refs']}")
+
+
+def test_the_census_is_deterministic():
+    """`beyond_radius_refs` is built from a dict of lists; an unsorted set
+    would make the emitted document depend on PYTHONHASHSEED, which
+    test_run5_emit_guard pins for the rest of the emitter."""
+    name = _present(EMITTING)[0]
+    outs = []
+    for seed in ('0', '12345'):
+        r = subprocess.run(
+            [sys.executable, '-X', 'utf8', '-c',
+             'import sys,os,json\n'
+             'R=os.getcwd()\n'
+             "for d in ('','py_placer','py_router','py_tools'):"
+             ' sys.path.insert(0,os.path.join(R,d))\n'
+             'from kicad_parser import parse_kicad_pcb\n'
+             'from placement import floorplan as fp\n'
+             'p=sys.argv[1]\n'
+             'print(json.dumps(fp.emit_intent(parse_kicad_pcb(p),p,'
+             'derive_decaps=True)["context"]["decap_census"],sort_keys=True))',
+             _board(name)],
+            capture_output=True, text=True, encoding='utf-8', cwd=REPO,
+            timeout=600, env=dict(os.environ, PYTHONHASHSEED=seed))
+        outs.append(r.stdout.strip().splitlines()[-1])
+    assert outs[0] == outs[1], (outs[0][:200], outs[1][:200])
+    print(f"  PASS: {name}'s census is identical across PYTHONHASHSEED")
+
+
+# --------------------------------------------------------------------------
+# the abstention channel, generalised off `legality`
+# --------------------------------------------------------------------------
+
+def test_a_withheld_decap_key_ABSTAINS_rather_than_skipping_silently():
+    """Before this, the "the emitter WITHHELD" note was hard-wired to
+    `name == 'legality'`, so a withheld decaps key inflated
+    `budget_abstained` while `decap_distance`'s skip reason still read "the
+    intent declares no decaps.max_distance_mm" -- exactly the defect run-23
+    fixed for `legality`."""
+    name = next((n for n in WITHHELD if os.path.exists(_board(n))), None)
+    if name is None:
+        print("  SKIP: no withholding board present")
+        return
+    doc, p = _emit(name, derive_decaps=True)
+    r = fp.grade(fp.intent_from_dict(doc, p), parse_kicad_pcb(p), p)
+    assert 'decap_distance' in r.rules_skipped
+    reason = r.rules_skipped['decap_distance']
+    assert 'WITHHELD' in reason, reason
+    assert 'decaps.max_distance_mm' in reason, reason
+    assert 'decaps.max_distance_mm' in fp.to_json(r)['budget_abstained']
+    s = fp.summary(r)
+    assert 'decaps.max_distance_mm' in s['budget_abstained_keys'], s
+    print(f"  PASS: {name} -- decap_distance skip reason names the "
+          f"withholding, and the key reaches JSON_SUMMARY")
+
+
+def test_a_hand_declared_limit_overrides_the_withholding():
+    """The declared-by-hand test used to be "is it in legality_budget", which
+    a namespaced key never is -- so a hand-declared limit would have abstained
+    anyway while ALSO being graded."""
+    name = next((n for n in WITHHELD if os.path.exists(_board(n))), None)
+    if name is None:
+        print("  SKIP: no withholding board present")
+        return
+    doc, p = _emit(name, derive_decaps=True)
+    doc['decaps']['max_distance_mm'] = 3.0
+    r = fp.grade(fp.intent_from_dict(doc, p), parse_kicad_pcb(p), p)
+    assert 'decap_distance' in r.rules_run, sorted(r.rules_run)
+    assert 'decaps.max_distance_mm' not in r.budget_abstained, \
+        r.budget_abstained
+    print("  PASS: a hand-declared limit is graded, and its withholding note "
+          "is history rather than an abstention")
+
+
+def test_an_unmapped_withheld_key_still_abstains_and_blames_no_rule():
+    """`budget_withheld` is inside the deliberately-open `context`, so its
+    keys are unvalidated. A typo must be REPORTED, not dropped -- otherwise
+    the author believes they recorded a withholding and nothing did."""
+    name = _present(EMITTING)[0]
+    doc, p = _emit(name)
+    # A typo that cannot COLLIDE with any real text. `decaps.max_distance`
+    # would have been a bad choice: `decap_distance`'s own base skip reason
+    # legitimately reads "the intent declares no decaps.max_distance_mm", so a
+    # substring check on it passes for the wrong reason.
+    typo = 'decaps.maxximum_distance_mm'
+    doc['context']['budget_withheld'] = {typo: 'a typo'}
+    r = fp.grade(fp.intent_from_dict(doc, p), parse_kicad_pcb(p), p)
+    assert typo in r.budget_abstained, r.budget_abstained
+    for name_, reason in r.rules_skipped.items():
+        assert typo not in reason, (name_, reason)
+    text = fp.format_text(r)
+    assert 'NOT DERIVABLE' in text and typo in text
+    print("  PASS: an unmapped withheld key abstains, is printed, and is "
+          "attached to no rule")
+
+
+def test_the_printed_heading_is_not_a_legality_claim():
+    """"N legality budget key(s) NOT DERIVABLE" is a lie for a decaps key."""
+    name = next((n for n in WITHHELD if os.path.exists(_board(n))), None)
+    if name is None:
+        print("  SKIP: no withholding board present")
+        return
+    doc, p = _emit(name, derive_decaps=True)
+    r = fp.grade(fp.intent_from_dict(doc, p), parse_kicad_pcb(p), p)
+    text = fp.format_text(r)
+    assert 'declared value(s) NOT DERIVABLE' in text, \
+        [ln for ln in text.splitlines() if 'DERIVABLE' in ln]
+    assert 'legality budget key(s) NOT DERIVABLE' not in text
+    print("  PASS: the heading reads 'declared value(s)', not 'legality "
+          "budget key(s)'")
+
+
+# --------------------------------------------------------------------------
+# the placement coupling, pinned with its numbers
+# --------------------------------------------------------------------------
+
+def test_the_emitted_limit_changes_what_place_seed_seeds():
+    """Declaring this key is NOT a grading-only change: `place_seed` reads it
+    and pulls every 2-net-bearing-pad C* out of radial zone packing into its
+    per-supply-pin stage. The two populations differ because the two "is this
+    a decap" predicates differ.
+
+    Pinned with the numbers so a silent reconciliation of the predicates --
+    which would be a placement change landing unannounced -- fails LOUDLY and
+    with the figure, forcing it to be argued."""
+    if not os.path.exists(_board('ulx3s')):
+        print("  SKIP: ulx3s not present")
+        return
+    pcb = parse_kicad_pcb(_board('ulx3s'))
+    scope = {r for r, f in pcb.footprints.items()
+             if r[:1].upper() == 'C'
+             and len([p for p in f.pads if p.net_id > 0]) == 2}
+    tethered = {c for caps in groups_mod.decap_tethers(pcb).values()
+                for c, _d in caps}
+    assert len(scope) == 70, len(scope)
+    assert len(tethered) == 53, len(tethered)
+    assert len(scope - tethered) == 17, len(scope - tethered)
+    c = _emit('ulx3s', derive_decaps=True)[0]['context']['decap_census']
+    assert c['seeder_scope'] == 70 and c['seeder_scope_ungraded'] == 17, c
+    print("  PASS: ulx3s -- 70 caps enter the seeder's decap stage, 53 are "
+          "graded, 17 are neither; the census reports the same numbers")
+
+
+# --------------------------------------------------------------------------
+# the CLI: the disclosure only exists on stdout
+# --------------------------------------------------------------------------
+
+def test_the_cli_emits_and_warns_about_the_coupling():
+    name = _present(EMITTING)[0]
+    with tempfile.TemporaryDirectory() as wd:
+        out = os.path.join(wd, 'fp.json')
+        r = run_utils.check(
+            [sys.executable, '-X', 'utf8',
+             os.path.join('py_tools', 'check_floorplan.py'), _board(name),
+             '--emit-intent', out, '--declare-decaps'], accept=True)
+        run_utils.evidence(out, 'the emitted intent')
+        doc = json.load(open(out, encoding='utf-8'))
+        assert doc['decaps'].get('max_distance_mm'), doc['decaps']
+        assert 'place_seed' in r.stdout and 'READS this key' in r.stdout, \
+            "the --emit-intent block does not warn about the coupling"
+    print("  PASS: --declare-decaps emits the limit and warns that "
+          "place_seed reads it")
+
+
+def test_the_cli_refuses_a_shaved_limit_with_the_right_REASON():
+    """A non-zero exit is not evidence -- `run_utils.check(refuse=...)`
+    asserts WHY, and reports an ImportError or argparse accident as a BROKEN
+    TEST rather than crediting the guard."""
+    name = _present(EMITTING)[0]
+    with tempfile.TemporaryDirectory() as wd:
+        path = os.path.join(wd, 'fp.json')
+        doc, _p = _emit(name, derive_decaps=True)
+        doc['decaps']['max_distance_mm'] -= 1e-3
+        with open(path, 'w', encoding='utf-8') as fh:
+            json.dump(doc, fh)
+        run_utils.evidence(path, 'the shaved intent')
+        run_utils.check(
+            [sys.executable, '-X', 'utf8',
+             os.path.join('py_tools', 'check_floorplan.py'), _board(name),
+             '--intent', path],
+            refuse='decap_distance', code=4)
+    print("  PASS: a shaved limit exits 4 naming decap_distance")
+
+
+def test_the_cli_reports_a_withholding_on_stdout():
+    name = next((n for n in WITHHELD if os.path.exists(_board(n))), None)
+    if name is None:
+        print("  SKIP: no withholding board present")
+        return
+    with tempfile.TemporaryDirectory() as wd:
+        out = os.path.join(wd, 'fp.json')
+        r = run_utils.check(
+            [sys.executable, '-X', 'utf8',
+             os.path.join('py_tools', 'check_floorplan.py'), _board(name),
+             '--emit-intent', out, '--declare-decaps'], accept=True)
+        assert 'WITHHELD' in r.stdout, r.stdout[-400:]
+        run_utils.evidence(out, 'the emitted intent')
+        r2 = run_utils.check(
+            [sys.executable, '-X', 'utf8',
+             os.path.join('py_tools', 'check_floorplan.py'), _board(name),
+             '--intent', out], accept=True)
+        assert 'NOT DERIVABLE' in r2.stdout, r2.stdout[-400:]
+        assert 'decap_distance' in r2.stdout, r2.stdout[-400:]
+    print(f"  PASS: {name} -- the CLI says WITHHELD on emit and NOT DERIVABLE "
+          f"on grade")
+
+
+TESTS = [
+    test_the_default_emission_declares_no_limit,
+    test_the_census_is_written_either_way,
+    test_the_keepouts_note_says_which_kind_of_empty_it_is,
+    test_the_limit_is_the_ceiling_of_the_UNROUNDED_max,
+    test_the_fixture_set_can_still_kill_the_round_mutation,
+    test_the_round_trip_grades_clean_AND_runs_the_rule,
+    test_the_limit_is_TIGHT_not_merely_satisfiable,
+    test_no_search_radius_is_written_into_decaps,
+    test_a_board_that_cannot_support_a_limit_withholds_and_says_why,
+    test_a_zero_tether_board_does_not_emit_a_vacuous_zero,
+    test_the_censoring_guard_separates_healthy_from_degenerate,
+    test_the_census_discloses_what_the_limit_cannot_see,
+    test_the_census_is_deterministic,
+    test_a_withheld_decap_key_ABSTAINS_rather_than_skipping_silently,
+    test_a_hand_declared_limit_overrides_the_withholding,
+    test_an_unmapped_withheld_key_still_abstains_and_blames_no_rule,
+    test_the_printed_heading_is_not_a_legality_claim,
+    test_the_emitted_limit_changes_what_place_seed_seeds,
+    test_the_cli_emits_and_warns_about_the_coupling,
+    test_the_cli_refuses_a_shaved_limit_with_the_right_REASON,
+    test_the_cli_reports_a_withholding_on_stdout,
+]
+
+
+if __name__ == '__main__':
+    for t in TESTS:
+        print(f"--- {t.__name__}")
+        t()
+    print("ALL PASS")

--- a/tests/test_704_decap_emission.py
+++ b/tests/test_704_decap_emission.py
@@ -351,7 +351,14 @@ def test_the_census_is_deterministic():
             timeout=600, env=dict(os.environ, PYTHONHASHSEED=seed))
         outs.append(r.stdout.strip().splitlines()[-1])
     assert outs[0] == outs[1], (outs[0][:200], outs[1][:200])
-    print(f"  PASS: {name}'s census is identical across PYTHONHASHSEED")
+    # Stable is not the same as SORTED, and only the first is what two runs of
+    # identical code can show. Reversing the order is deterministic too, so it
+    # survives the comparison above -- pin the property the code claims.
+    for nm in _present(EMITTING + tuple(WITHHELD)):
+        refs = _emit(nm)[0]['context']['decap_census']['beyond_radius_refs']
+        assert refs == sorted(refs), (nm, refs)
+    print(f"  PASS: {name}'s census is identical across PYTHONHASHSEED, and "
+          f"beyond_radius_refs is sorted on every board")
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Closes #701. Closes #704.

**On #701 I asked first and got no answer.** I offered on the issue to open this
rather than "push a change to the seat predicate unannounced", and the offer went
unanswered for a week. Here it is as a PR instead, because a diff is easier to
judge than a question — and it is **strictly inert** on every board that declares
no keep-out, which is every board in the corpus. Measured two ways: 0 invocations
of either new primitive across seed / `--repair` / `--reseat` on three boards
(including runs that did real work), and **7/7 byte-identical** `place_seed`
outputs base-vs-branch. Close it if you don't want it.

## Why one PR for two issues

#704's own body says it: *"This is the authoring half of the same gap as the
enforcement half filed separately."* They share `floorplan.py`, the
`budget_withheld` → abstention channel, and the same emit/seed/grade round trip.

---

## THE RULE WAS ENFORCED BY NOTHING

`rule_keepout` grades a declared keep-out. `grep -c "forbid\|keepout"
py_placer/placement/seeder.py` returned **0**. A keep-out was a region
`place_seed` walked parts into and `check_floorplan` complained about, forever.

The issue's suggested fix — thread an existing `forbid` parameter through 13 call
sites — does not apply; the author corrected that on the issue. The real count is
**12** `_try_place(` call sites (the 13th grep hit is the `def`) plus one outside
the module, and threading would touch ~19 places **and still miss the pose
census** — the exact drift `pose_ok`'s own docstring exists to prevent.

So the keep-outs ride on the state and `pose_ok` gains one conjunct. That covers
all 12 sites, the census, and `_evict_trade`'s acceptance test. Two more paths
needed their own work:

- **`edge_seat_ok`** bypasses `pose_ok` deliberately (an edge connector overhangs
  by design), and is used by `_seat_edge` *and* by stage 1, which "runs no
  legality gate at all by design". Editing only `_seat_edge` leaves stage 1 open.
- **The polish quench has no keep-out term**, so it can walk a part back in and
  make `place_seed` fail its own grade. The self-check already had this exact
  repair for `zone_containment`; it now covers `keepout` too.

**Grader and seat share one implementation**, and that is tested behaviourally
rather than by grep: patch `floorplan.keepout_hit` and require the seat predicate
to observe the patch. A copy-pasted geometry would not, and would still pass any
agreement check written against equivalent-but-separate code. The agreement sweep
is 715 (part, keep-out) combinations — 198 hit, 517 miss, **0 disagreement** —
with both bounds asserted, because a sweep with no hits proves nothing.

A keep-out that strands a part now reports `keepout_blocks` with the keep-out
**named and the poses it frees counted**, instead of `no_movable_neighbour`, whose
prose ("the outline, the zone or its own size refuses it, not a neighbour") is
false in that case and sends the reader to three things that are not the problem.

---

## THE SELF-BLESS GUARD #704 ASKS FOR IS UNREACHABLE

The issue asks for the `overlap_area` guard: withhold when the emitting board
already violates the number. `ceil(max(observed))` is ≥ every observed value **by
construction**, so that branch can never execute — worse than absent, because it
reads like a guard.

The reachable analogue is **censoring**: `decap_tethers` drops any cap past 5 mm,
so a survivors' max can bless a board whose caps have left decoupling range.

| board | tethers ≤5 mm | beyond | censored | worst beyond |
|---|---|---|---|---|
| tigard | 25 | 1 | 0.04 | 6.17 |
| glasgow_revC | 87 | 5 | 0.05 | 10.34 |
| splitflap_driver | 11 | 1 | 0.08 | **19.30** |
| watchy | 24 | 2 | 0.08 | 11.16 |
| ulx3s | 53 | 7 | 0.12 | 12.24 |
| kit-dev-coldfire | 41 | 12 | 0.23 | — |
| interf_u_unrouted | 1 | 4 | **0.80** | 19.82 |
| sonde_u | **0** | 5 | **1.00** | 15.58 |

Withheld when there are no tethers, fewer than 3, or >25% censored. **A rejected
alternative, recorded so it is not re-proposed:** withhold when `max > K * p75`.
Built and measured; it does **not** separate — healthy splitflap scores 2.46 and
mid-repair `tigard_placed` 2.22.

The statistic is `ceil(max)` because an emitted intent needs a **fixed point**.
The median is refuted by measurement: glasgow_revC's is **0.0000** (58 of 87 caps
sit inside their IC's bbox and clamp to zero), so a median limit flags 29 caps on
a healthy human-routed board at the first emission.

---

## THIS KEY CHANGES PLACEMENT, NOT ONLY GRADING

`place_seed` reads `decaps.max_distance_mm` and pulls every 2-net-bearing-pad
`C*` out of zone packing into its per-supply-pin stage:

| board | seeder scope | graded tethers | in scope, never graded |
|---|---|---|---|
| ulx3s | 70 | 53 | **17** |
| glasgow_revC | 92 | 87 | 5 |

The two "is this a decap" predicates genuinely differ (grouper: *exactly two
distinct net ids*; seeder: *exactly two net-bearing pads*), as do the metrics.
So the derivation is **opt-in, default off, on its own `--declare-decaps`** rather
than folded into `--declare-classes` — three measured reasons for the separate
flag, including that `tests/test_run23_courtyard_channel.py` asserts
`budget_abstained == ['overlap_area']` *exactly* and would have broken. It is
green here. The coupling is disclosed in the census, the stdout block, the help
text and the docs, and pinned by a test that fails **with the numbers** if the
predicates are silently reconciled.

---

## What this PR does NOT claim

- **The run reported in #704 is not fixed.** On a board of that shape the
  withholding fires, so it still reports 3 rules run, still `pass: true`, still
  exit 0 — plus one line in `budget_abstained`.
- **`rules_run` does not go up on a withheld board.** This converts a silent skip
  into a loud abstention; it does not convert it into coverage.
- **`ceil(max)` is maximal self-bless**, and the censoring guard is only a proxy.
  A cap dragged from 1.2 to 4.9 mm stays inside the radius and sets the limit.
  Known, unfixed.
- **The 5 mm horizon is disclosed, not closed.** splitflap_driver emits 3.4618
  while a rail-sharing cap sits 19.30 mm out, invisible to emitter and rule alike.
- **#701's suggestion 3** (`compile_intent` emitting keep-outs per `place_keepout`
  op) is not implementable on `main` — `plan_resolve.py` lives only in an unmerged
  tree, as the issue author's own correction notes.

## Tests

Three new files, 105 assertions. Every headline is backed by a mutation applied to
the shipped code and reverted — **20 mutations, all killed.** Highlights:

- `pose_ok` conjunct removed → 14 seating failures
- `edge_seat_ok` conjunct removed → the edge arm alone goes red
- `_ceil4` → `round` → the decap round trip fails on 3 boards
- derive without the flag → the default arm **and** the A/B run
- `keepouts=intent.keepouts` → `keepouts=None` → the static AST gate

**Six defects this work caught in itself**, all recorded in the commits — including
deriving the limit from a *display-rounded* max (reintroducing the exact bug
`_ceil4` exists to prevent, on 3 of 9 boards), and **four of my own tests that
passed in both directions**: the `>`/`>=` boundary, the through-hole rect, a
grader-independence check reading a constructor kwarg instead of the effective
state, and a censoring guard asserted by *nothing* until I found the board that
isolates it.

An adversarial verifier then re-derived the whole mutation table, found **three
BLOCKING defects** (all fixed here), and **invented a 14th mutation that survived**
— the four-character `keepouts=None`. Its other two: two overlapping keep-outs
reported `{}` and fell back to the misleading verdict; and stage 1 traded a
`keepout` grade error for an `edge_connector` one by parking a connector inland
when 26 clear edge seats existed. Both fixed, both pinned.

## Verification

- **Full suite: 442 passed, 2 failed, 3 timed out.** Both failures
  (`test_763_kicad_locate`, `test_782_nondefault_netclass_clamp`) reproduce
  identically on `upstream/main` — verified by running each in a worktree at
  `2c84c012`. All three timeouts **pass when run alone**, which is what the
  runner's own note asks for.
- **`test_placement_ab.py` PASS**, 3/3 rows match the committed baseline — no
  re-record owed. The emitted-intent hashes are byte-identical to main on all
  three A/B boards, and a grep for `keepout` over the whole log finds nothing.
- **No `tests/gui_parity/` gate is owed** — the placement seeder is unreachable
  from the plugin (the Placement tab drives Claude Code headless; the only direct
  `placement.*` imports are `placement.labels` and `groups.parse_sources`). Both
  gates CONTRIBUTING.md names were run anyway and are green.
  `.gui-parity-checked` is **not** updated; that is a separate audit.
- One caveat on portability: `test_run5_emit_guard.py` and `test_part_class.py`
  self-skip without the gitignored `wk/` corpus, so they are not portable evidence.

Follow-ups worth filing separately, all measured here: `place_seed --reseat`
seats correctly and then `prune_assignment` reverts it (a gate with no keep-out
term); `place_portfolio` generates violating candidates and gates them after;
`allow` globs are not validated against the board; and the two decap predicates
disagree.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
