### PR TITLE
#702: the quench refuses a move that breaks a declared floorplan claim

### DIFF
--- a/.claude/skills/plan-pcb-placement/SKILL.md
+++ b/.claude/skills/plan-pcb-placement/SKILL.md
@@ -733,6 +733,22 @@ python3 -X utf8 py_placer/place_optimize.py board.kicad_pcb placed.kicad_pcb \
     --lock 'J*' 'H*' 'U1' --max-displacement 2
 ```
 
+**And pass the INTENT to every placement invocation, for the same reason.**
+Since #702 `--intent` is not a grading flag: its declared zones, keep-outs and
+exclusive zones are HARD per-move gates inside the quench, and its `must_lock`
+globs and edge claims are locked. A step you forget to pass it to is a step
+that optimises against no constraint at all — which is exactly the defect #702
+fixed, one level up. `place_optimize`, `place_route_loop`, `place_seed` and
+`place_portfolio` all take it:
+
+```bash
+python3 -X utf8 py_placer/place_optimize.py board.kicad_pcb placed.kicad_pcb     --intent wk/intent.json --lock 'J*' 'H*' 'U1' --max-displacement 2
+```
+
+It is MONOTONE — it prevents a part being walked out of its zone, it does not
+walk one back in. A part that is already out stays out; re-seating it is
+`place_seed --repair`'s job, not the gate's.
+
 `(locked yes)` stamped in the board file (a seeder's `must_lock` output)
 satisfies this for every place_* tool — the file lock is honored everywhere
 `--lock` is. When you rely on it instead of `--lock`, say so once in the

--- a/docs/floorplan-intent.md
+++ b/docs/floorplan-intent.md
@@ -125,9 +125,10 @@ source, suspect, suspect_reason
 
 `severity` keys are checked too. The settable names are the nine rules —
 `envelope`, `zone_containment`, `zone_side`, `zone_exclusive`, `keepout`,
-`edge_connector`, `decap_distance`, `must_lock`, `legality` — plus the three
+`edge_connector`, `decap_distance`, `must_lock`, `legality` — plus the four
 findings raised outside the rule loop: `intent_zone_outside_envelope`,
-`intent_zone_overlap`, `block_unresolved`. `{"decap_distanc": "warn"}` is a
+`intent_zone_overlap`, `block_unresolved`, `intent_zone_in_keepout`.
+`{"decap_distanc": "warn"}` is a
 demotion that never happens, so it is refused rather than accepted.
 
 ### `context` is the slot for everything that is not a claim

--- a/docs/floorplan-intent.md
+++ b/docs/floorplan-intent.md
@@ -18,14 +18,36 @@ python3 py_tools/check_floorplan.py board.kicad_pcb --intent floorplan.json
 python3 py_tools/check_floorplan.py board.kicad_pcb --intent floorplan.json --json findings.json
 ```
 
-The intent is also a GENERATOR input, not only a grader's: `place_seed.py`
-turns a declared intent into an initial placement for an unplaced board
-(zones, edge bands, keep-outs, locks and decap rules become placement
-constraints, and the emitted seed is graded against the same intent it was
-built from), and
-`place_portfolio.py` uses the intent as the hard gate plus the `health`
-signals when ranking K perturbed placement candidates. See
-`placement/README.md` for both.
+The intent is also a GENERATOR input, not only a grader's, and it now has
+**three** distinct jobs:
+
+1. **A construction source.** `place_seed.py` turns a declared intent into an
+   initial placement for an unplaced board — zones, edge bands, keep-outs,
+   locks and decap rules become placement constraints, and the emitted seed is
+   graded against the same intent it was built from.
+2. **A hard per-move gate inside the optimizer (#702).** Every CLI that
+   quenches — `place_optimize.py`, `place_route_loop.py`, `place_seed.py`'s
+   polish and `place_portfolio.py`'s per-candidate quench — takes `--intent`
+   and refuses any move that breaks a declared zone, keep-out or exclusive
+   zone. Before this, the intent reached `place_seed` and stopped, so the two
+   tools that run the most quench iterations in a real chain could walk a part
+   straight out of a zone the file declared. Measured on ulx3s: the seed grades
+   clean, an ungated quench manufactures 4 `zone_containment` errors, a gated
+   one manufactures none.
+3. **A rank gate and a health source.** `place_portfolio.py` ranks K perturbed
+   candidates only if they grade error-free, using the `health` signals in the
+   rank key.
+
+See `placement/README.md` for all of them.
+
+**The gate is MONOTONE: it prevents a walk-out, it does not repair one.** A
+part that arrives already outside its zone may improve or hold, never worsen —
+so on a board whose seed already violates, the correct outcome is *the seed's
+count, held*, not zero.
+
+> **Careful with a self-emitted intent.** `--emit-intent` run on the board you
+> are repairing records that board's damage as the requirement. Before #702
+> that only mis-graded; now it also **steers the optimizer toward the damage**.
 
 ## The board outline is not editable by this toolchain
 
@@ -119,7 +141,7 @@ source, suspect, suspect_reason
 | `legality_budget` | `overlap_area`, `oob_count`, `oob_amount` (`oob_area` refused — see below) |
 | `health` | `bus_corridors`, `classes`, `block_displacement_mm`, `ignore_net_ids`, `max_fanout`, `zoned_blocks`, `affinity_exempt_nets`, `affinity_exempt_net_ids` |
 | `health.bus_corridors[]` | `name`, `nets`, `width_mm` |
-| `severity` | any of the 12 rule names below |
+| `severity` | any of the 13 rule names below |
 | `overlap_waivers[]` | `pair`, `reason`, `context` |
 | `must_lock` | a list of reference globs (no nested keys) |
 
@@ -220,10 +242,10 @@ for it, and the reason is printed:
 | rule | fires when | measured with |
 |---|---|---|
 | `envelope` | the declared envelope is not the board's outline | `board_bounds` |
-| `zone_containment` | a member's courtyard leaves its block's zone | `GradedPart.rect` |
+| `zone_containment` | a member's courtyard leaves its block's zone | `GradedPart.rect`. **Enforced, not only graded, since [#702](https://github.com/drandyhaas/KiCadRoutingTools/issues/702)** — the quench refuses such a MOVE, through the same `zone_escape` this rule calls |
 | `zone_side` | a member is on the other face | `legality.footprint_side` |
-| `zone_exclusive` | a non-member intrudes on a reserved zone | `rect_overlap_area` |
-| `keepout` | any part enters a keep-out, unless in `allow` | courtyard **and** through-hole rect. **Enforced, not only graded, since [#701](https://github.com/drandyhaas/KiCadRoutingTools/issues/701)** — the seat search refuses such a pose through the same `keepout_hit` this rule calls |
+| `zone_exclusive` | a non-member intrudes on a reserved zone | `rect_overlap_area`. **Enforced since [#702](https://github.com/drandyhaas/KiCadRoutingTools/issues/702)**, same way |
+| `keepout` | any part enters a keep-out, unless in `allow` | courtyard **and** through-hole rect. **Enforced, not only graded, since [#701](https://github.com/drandyhaas/KiCadRoutingTools/issues/701)** — the seat search refuses such a pose through the same `keepout_hit` this rule calls — and since [#702](https://github.com/drandyhaas/KiCadRoutingTools/issues/702) the quench refuses such a MOVE through it too |
 | `edge_connector` | overhang outside `[min,max]`, or the wrong edge; a `connector_affinity` entry seated more than 3 mm from every edge fires at **warn** whatever the configured severity | `BoardOutlineGate.rect_outside_amount`, `edge_clearance` |
 | `decap_distance` | a decoupling cap is too far from its own IC | `groups.decap_tethers` |
 | `must_lock` | a declared-critical part is not locked in the file | `parser.extract_locked_refs` |
@@ -236,6 +258,30 @@ A grader with its own idea of what "legal" means grades the reimplementation
 rather than the board — so where re-deriving was plausible, a test asserts the
 two agree exactly (all 34 of ulx3s's cap distances identical to the grouper's,
 all five legality numbers identical to the quench's).
+
+### Which rules the SEARCH can see
+
+A constraint the search cannot see can only ever produce a failing grade. This
+is the whole table, and the "no" column is the part worth reading — each of
+them is a decision, not an omission.
+
+| rule | graded | seat search (#701) | quench gate (#702) | if not, why not |
+|---|---|---|---|---|
+| `zone_containment` | yes | via `zone_gate` | **yes** | — |
+| `zone_exclusive` | yes | no | **yes** | the seeder has no verdict string for this refusal yet |
+| `keepout` | yes | **yes** | **yes** | — |
+| `must_lock` | yes | — | **by freezing** | it is a claim about the FILE; no pose satisfies or violates it |
+| `edge_connector` | yes | anchor tier | **by freezing** | two of its three sub-claims are bounds on being *off* the board, so a per-pose term would fight the containment gate rather than complement it |
+| `zone_side` | yes | — | no | **vacuous, not conservative**: the quench never flips a side, so the term is invariant under every move it can make. Reported once at load instead |
+| `envelope` | yes | — | no | a claim about the intent FILE against the board, not about any pose |
+| `decap_distance` | yes | scope stage | no | graded in a currency the optimizer does not carry — pad centroid to an IC's pad bbox inflated 0.5 mm, not courtyard to courtyard. A gate in the wrong currency can *admit what the grade flags*, which is worse than no gate. And the cap→IC tether is re-elected from live poses, so a per-move form would have the `corridor_weight` non-stationarity problem too |
+| `legality` | yes | — | no | a whole-board aggregate against a BUDGET, so a per-pose form is non-local: whether A's move is admissible would depend on B's violation |
+
+Enforcing is not free, and the price is recorded rather than described:
+`tests/test_placement_ab.py` carries four `intent-*` rows and
+`tests/placement_ab_baseline.json` the numbers. A hard constraint removes poses
+from the search, so `crossings` and `hpwl` can get worse — on ulx3s they do,
+and that row is pinned `regress` with the containment errors going 4 → 0.
 
 ### A through-hole part is in a keep-out from either side
 

--- a/py_placer/place_optimize.py
+++ b/py_placer/place_optimize.py
@@ -153,20 +153,13 @@ Examples:
     # an unreadable one touches no file -- and a manifest that carries a
     # command which produced nothing leaves the next step's input made by
     # nothing, which is exactly why the recorder is conditional below.
-    intent = None
-    if args.intent and args.suggest_locks:
-        # Not parser.error: a caller that always passes --intent must not have
-        # to special-case the report mode, which writes no board and never
-        # quenches.
-        print("--intent is ignored with --suggest-locks: no quench runs, and "
-              "the lock advisor does not read an intent", file=sys.stderr)
-    elif args.intent:
-        from placement import floorplan
-        try:
-            intent = floorplan.load_intent(args.intent)
-        except (OSError, ValueError) as exc:
-            print(f"cannot load intent {args.intent}: {exc}", file=sys.stderr)
-            return 2
+    # Not parser.error on the --suggest-locks combination: a caller that always
+    # passes --intent must not have to special-case the report mode, which
+    # writes no board and never quenches.
+    from placement.cli_gates import load_intent_or_exit
+    intent, _rc = load_intent_or_exit(args)
+    if _rc:
+        return _rc
 
     # Recorded AFTER parsing and only for a real run: this tool MUTATES the
     # board, so a stress manifest that omits it leaves the next step's input

--- a/py_placer/place_optimize.py
+++ b/py_placer/place_optimize.py
@@ -24,7 +24,7 @@ import sys
 from kicad_parser import parse_kicad_pcb
 import routing_defaults as defaults
 from placement.groups import GroupError, derive_groups, describe, parse_sources
-from placement.cli_gates import (add_board_state_args,
+from placement.cli_gates import (add_board_state_args, add_intent_arg,
                                  add_lock_advisor_args, add_tidiness_args)
 from placement.portfolio import copy_siblings
 from placement.quench import quench
@@ -127,6 +127,7 @@ Examples:
                              "default: the airwire cost cannot see them, so "
                              "only halo/edge terms decide where they go")
     add_board_state_args(parser)
+    add_intent_arg(parser)
     add_lock_advisor_args(parser)
     add_tidiness_args(parser)
 
@@ -147,6 +148,25 @@ Examples:
         if args.swap_max_displacement > args.max_displacement:
             parser.error("--swap-max-displacement must not exceed "
                          "--max-displacement")
+
+    # #702: the intent is loaded BEFORE record_invocation, because an exit 2 on
+    # an unreadable one touches no file -- and a manifest that carries a
+    # command which produced nothing leaves the next step's input made by
+    # nothing, which is exactly why the recorder is conditional below.
+    intent = None
+    if args.intent and args.suggest_locks:
+        # Not parser.error: a caller that always passes --intent must not have
+        # to special-case the report mode, which writes no board and never
+        # quenches.
+        print("--intent is ignored with --suggest-locks: no quench runs, and "
+              "the lock advisor does not read an intent", file=sys.stderr)
+    elif args.intent:
+        from placement import floorplan
+        try:
+            intent = floorplan.load_intent(args.intent)
+        except (OSError, ValueError) as exc:
+            print(f"cannot load intent {args.intent}: {exc}", file=sys.stderr)
+            return 2
 
     # Recorded AFTER parsing and only for a real run: this tool MUTATES the
     # board, so a stress manifest that omits it leaves the next step's input
@@ -198,6 +218,12 @@ Examples:
     blocks = derive_groups(pcb_data, sources) if sources else {}
     if sources:
         print(describe(blocks))
+
+    intent_gate = None
+    if intent is not None:
+        from placement.cli_gates import resolve_intent_gate_for_cli
+        intent_gate, _problems = resolve_intent_gate_for_cli(
+            intent, pcb_data, sources, args.intent)
 
     # Exact pad/hole legality of the INPUT (file poses): the before half of
     # the report pair. Gate-currency tallies live inside the quench; this is
@@ -252,6 +278,7 @@ Examples:
         pad_legality=not args.courtyard_only,
         min_gain_per_mm=args.min_gain_per_mm,
         move_unconnected=args.move_unconnected,
+        intent_gate=intent_gate,
     )
 
     print(f"{len(placements)} parts moved")
@@ -293,6 +320,28 @@ Examples:
         'pad_conflicts_currency': 'exact geometry (phantom-free)',
     })
     summary.update(ratsnest.get('legality', {}))
+    # #702: what the declared-intent gate DID. Reported even when it refused
+    # nothing, for the reason docs/floorplan-intent.md gives about the grader's
+    # own rules_run/rules_skipped pair -- "0 violations" and "0 rules ran" must
+    # not look the same to a machine. Here: "the gate refused nothing" and
+    # "there was no gate" must not either.
+    _ig = ratsnest.get('intent_gate')
+    if _ig is not None:
+        print(f"intent gate: enforced {', '.join(_ig['rules_enforced'])} over "
+              f"{_ig['refs_bound']} bound part(s); refused "
+              f"{_ig['rejected']} candidate pose(s)"
+              + (" (" + ", ".join(f"{r} {n}" for r, n
+                                  in sorted(_ig['by_rule'].items())) + ")"
+                 if _ig['by_rule'] else ""))
+        summary['intent'] = args.intent
+        summary['intent_rules_enforced'] = _ig['rules_enforced']
+        summary['intent_refs_bound'] = _ig['refs_bound']
+        summary['intent_moves_refused'] = _ig['rejected']
+        summary['intent_moves_refused_by_rule'] = _ig['by_rule']
+        summary['intent_moves_refused_by_site'] = _ig['by_site']
+    elif args.intent:
+        summary['intent'] = args.intent
+        summary['intent_moves_refused'] = None    # gate built nothing
     # After half of the exact report pair, graded on the WRITTEN file so it
     # covers exactly what the next step will read. WARN on any worsened
     # category -- the in-run gates should make this impossible; a warning here

--- a/py_placer/place_portfolio.py
+++ b/py_placer/place_portfolio.py
@@ -46,7 +46,8 @@ def _parse_strategies(text):
 
 def build_parser():
     import routing_defaults as defaults
-    from placement.cli_gates import add_board_state_args, add_tidiness_args
+    from placement.cli_gates import (add_board_state_args, add_intent_arg,
+                                     add_tidiness_args)
 
     p = argparse.ArgumentParser(
         description="Placement portfolio: K diverse candidates from one seed.",
@@ -112,9 +113,10 @@ Examples:
                         "tests/placement_ab_baseline.json. Read the cut as a "
                         "DIAGNOSTIC instead: 'check_floorplan --intent "
                         "--health' reports cut_mm and cover per corridor")
-    p.add_argument("--intent", default=None, metavar="JSON",
-                   help="Floorplan intent: hard gate (error-free grade "
-                        "required) plus the health signals in the rank key")
+    add_intent_arg(p, extra=(
+        "Here it is ALSO the post-hoc hard rank gate (a candidate is "
+        "ranked only if it grades error-free) and the source of the "
+        "health signals in the rank key."))
     p.add_argument("--group-by", default="auto",
                    help="Block sources for swap moves and intent grading "
                         "(comma list of kicad/sheet/netprefix/decap; 'auto' = "
@@ -203,7 +205,7 @@ Examples:
     return p
 
 
-def _quench_kw(args, intent=None):
+def _quench_kw(args, intent=None, intent_gate=None):
     corridor_specs = None
     if args.corridor_weight > 0.0 and intent is not None:
         # The SAME `health.bus_corridors` the grader reads, so the optimizer
@@ -226,7 +228,8 @@ def _quench_kw(args, intent=None):
         lock_refs=args.lock, align_weight=args.align_weight,
         align_radius=args.align_radius, align_span=args.align_span,
         orient_weight=args.orient_weight,
-        corridor_weight=args.corridor_weight, corridor_specs=corridor_specs)
+        corridor_weight=args.corridor_weight,
+        corridor_specs=corridor_specs, intent_gate=intent_gate)
 
 
 def _replay_argv(args, index):
@@ -385,11 +388,22 @@ def main():
             return 2
 
     # Swap blocks: the intent's declared blocks when given (zones are the
-    # designer's grouping), else the structural sources. Never handed to the
-    # quench itself -- candidate 0 must equal a default place_optimize run.
+    # designer's grouping), else the structural sources. Still never handed
+    # to the quench as `groups=` -- the rigid-body phase stays off, which is
+    # what keeps candidate 0 a DEFAULT place_optimize run.
+    #
+    # #702 changes what 'the same knobs' means, not that clause: the
+    # declared intent now also reaches the quench as `intent_gate`, so
+    # candidate 0 equals a place_optimize run with the same knobs INCLUDING
+    # --intent. With no --intent both sides pass None and the anchor is
+    # unchanged, which is what tests/test_portfolio.py asserts.
+    intent_gate = None
     if intent is not None:
+        from placement.cli_gates import resolve_intent_gate_for_cli
+        intent_gate, _problems = resolve_intent_gate_for_cli(
+            intent, pcb, sources, args.intent)
         from placement import floorplan
-        swap_blocks, _problems = floorplan.resolve_blocks(intent, pcb, sources)
+        swap_blocks, _ = floorplan.resolve_blocks(intent, pcb, sources)
     else:
         swap_blocks = derive_groups(pcb, sources) if sources else {}
 
@@ -398,7 +412,7 @@ def main():
         n_candidates=args.candidates, strategies=args.strategy,
         radius=args.radius, lock_globs=args.lock,
         ignore_nets=args.ignore_nets, swap_blocks=swap_blocks,
-        quench_kw=_quench_kw(args, intent), only=args.only)
+        quench_kw=_quench_kw(args, intent, intent_gate), only=args.only)
     baseline = result['baseline']
     cands = result['candidates']
     free = result['free']

--- a/py_placer/place_route_loop.py
+++ b/py_placer/place_route_loop.py
@@ -487,6 +487,17 @@ def main():
     if not args.suggest_locks and not args.output_file:
         parser.error("output_file is required (except with --suggest-locks)")
 
+    # #702: the intent is loaded BEFORE record_invocation, for the reason
+    # place_optimize gives -- an exit 2 on an unreadable intent touches no
+    # file, and a manifest carrying a command that produced nothing leaves the
+    # next step's input made by nothing. It needs only `args`, so it is safe
+    # this early; the board-dependent RESOLVE stays down beside the
+    # board-state gates.
+    from placement.cli_gates import load_intent_or_exit
+    _intent, _rc = load_intent_or_exit(args)
+    if _rc:
+        return _rc
+
     if not args.suggest_locks:
         try:
             from redo_record import record_invocation
@@ -551,13 +562,7 @@ def main():
     # the grader re-derives them from the final poses"). A gate that re-elects
     # its own identity mid-run is not monotone.
     intent_gate = None
-    if args.intent:
-        from placement import floorplan
-        try:
-            _intent = floorplan.load_intent(args.intent)
-        except (OSError, ValueError) as exc:
-            print(f"cannot load intent {args.intent}: {exc}", file=sys.stderr)
-            return 2
+    if _intent is not None:
         from placement.cli_gates import resolve_intent_gate_for_cli
         intent_gate, _ = resolve_intent_gate_for_cli(
             _intent, _pcb0, group_sources, args.intent)

--- a/py_placer/place_route_loop.py
+++ b/py_placer/place_route_loop.py
@@ -41,7 +41,7 @@ from kicad_parser import parse_kicad_pcb
 import routing_defaults as defaults
 from placement.portfolio import copy_siblings
 from placement.groups import GroupError, derive_groups, describe, parse_sources
-from placement.cli_gates import (add_board_state_args,
+from placement.cli_gates import (add_board_state_args, add_intent_arg,
                                  add_lock_advisor_args, add_tidiness_args)
 from placement.quench import quench
 from placement.writer import write_placed_output
@@ -471,6 +471,7 @@ def main():
                         help="frames per placement glide in --movie; 0 = no "
                              "glide, cut straight to the new placement")
     add_board_state_args(parser)
+    add_intent_arg(parser)
     add_lock_advisor_args(parser)
     add_tidiness_args(parser)
 
@@ -529,10 +530,37 @@ def main():
     # so refusing here saves minutes-to-hours of A* that would fail everything
     # and then quench a pile.
     from placement.placement_state import gate_or_exit
-    gate_or_exit(parse_kicad_pcb(args.input_file), args.input_file,
+    _pcb0 = parse_kicad_pcb(args.input_file)
+    gate_or_exit(_pcb0, args.input_file,
                  'place_route_loop.py',
                  allow_unplaced=args.allow_unplaced,
                  allow_routed=args.allow_routed)
+
+    # #702: resolved ONCE, here, and FROZEN for the whole run.
+    #
+    # Here, because a malformed intent has the same cost profile as the
+    # board-state gates just above -- round 0 routes the whole board, and
+    # refusing after that has already run wastes exactly what those gates
+    # exist to save.
+    #
+    # Frozen, because block membership is a function of refs, globs and
+    # derived groups, not of poses, so no round can legitimately change it --
+    # and re-deriving under the optimizer's own moves is precisely the
+    # non-stationarity that made `corridor_weight` NOT ADOPTED (quench.py:
+    # "the optimizer minimises against corridors frozen at construction while
+    # the grader re-derives them from the final poses"). A gate that re-elects
+    # its own identity mid-run is not monotone.
+    intent_gate = None
+    if args.intent:
+        from placement import floorplan
+        try:
+            _intent = floorplan.load_intent(args.intent)
+        except (OSError, ValueError) as exc:
+            print(f"cannot load intent {args.intent}: {exc}", file=sys.stderr)
+            return 2
+        from placement.cli_gates import resolve_intent_gate_for_cli
+        intent_gate, _ = resolve_intent_gate_for_cli(
+            _intent, _pcb0, group_sources, args.intent)
 
     work = args.work_dir or os.path.dirname(os.path.abspath(args.output_file))
     os.makedirs(work, exist_ok=True)
@@ -649,11 +677,20 @@ def main():
             metrics_out=ratsnest,
             groups=blocks,
             verbose=args.verbose,
+            intent_gate=intent_gate,
         )
 
         if not placements:
+            # #702: name the declared gate when it is what refused, or
+            # widening the radius reads as "try harder" while every
+            # extra pose it offers is one the gate also refuses.
+            _ref = (ratsnest.get("intent_gate") or {}).get("rejected", 0)
             print(f"  Quench found no improving moves - widening the nudge cap"
-                  f" (swap cap stays {swap_cap:.1f}mm).")
+                  f" (swap cap stays {swap_cap:.1f}mm)."
+                  + (f" NOTE: the declared-intent gate refused {_ref} pose(s)"
+                     f" this round; a wider radius offers more poses it also"
+                     f" refuses. Relax the zone tolerance or drop --intent if"
+                     f" the loop stalls here." if _ref else ""))
             max_disp *= 1.5
             continue
 

--- a/py_placer/place_seed.py
+++ b/py_placer/place_seed.py
@@ -31,6 +31,7 @@ import sys
 
 def main():
     import routing_defaults as defaults
+    from placement.cli_gates import add_intent_arg
 
     p = argparse.ArgumentParser(
         description="Intent-driven initial placement for an unplaced board.",
@@ -41,9 +42,9 @@ Examples:
 """)
     p.add_argument("input_file", help="Input KiCad PCB (unplaced parts + outline)")
     p.add_argument("output_file", help="Output board with the seeded placement")
-    p.add_argument("--intent", required=True, metavar="JSON",
-                   help="Floorplan intent: the constraint source AND the "
-                        "acceptance gate for the emitted seed")
+    add_intent_arg(p, required=True, extra=(
+        "Here it is also the CONSTRUCTION source for the seed and the "
+        "acceptance gate the emitted seed is graded against."))
     p.add_argument("--seed", type=int, default=0,
                    help="Packing-order/jitter seed; same seed reproduces byte "
                         "for byte (default: 0)")
@@ -463,9 +464,16 @@ Examples:
         # polished by the objective the later steps rank with. Locks ride in
         # from the file (must_lock was just stamped); edge connectors are
         # locked per-call so the polish cannot walk them off their band.
-        # edge_claims(), not edge_connectors: a connector_affinity entry
-        # makes no seat claim and must not be locked out of the polish.
-        edge_refs = [c['ref'] for c in intent.edge_claims()]
+        # #702: edge_claims(), must_lock and the declared zones all now
+        # ride in through `intent_gate`, resolved by the ONE function
+        # every quenching CLI uses. The edge_claims()-not-edge_connectors
+        # filter that used to live here moved with it -- see
+        # `floorplan.resolve_intent_gate`, which is the point: a filter
+        # that must be remembered at each call site is one that will be
+        # forgotten at the next.
+        from placement.cli_gates import resolve_intent_gate_for_cli
+        _gate, _ = resolve_intent_gate_for_cli(
+            intent, pcb_seeded, sources, args.intent)
         placements = quench(
             pcb_seeded, pcb_file=args.output_file,
             max_displacement=args.max_displacement,
@@ -474,7 +482,7 @@ Examples:
             crossing_penalty=30.0, length_weight=0.3, halo_base=0.5,
             halo_coef=0.15, halo_weight=2.0, edge_halo=2.0, edge_weight=2.0,
             ignore_nets=args.ignore_nets,
-            lock_refs=edge_refs or None, metrics_out=ratsnest,
+            metrics_out=ratsnest, intent_gate=_gate,
             corridor_weight=args.corridor_weight,
             corridor_specs=list((intent.health or {}).get('bus_corridors')
                                 or ()) or None)

--- a/py_placer/placement/README.md
+++ b/py_placer/placement/README.md
@@ -36,6 +36,7 @@ Key options:
 | `--ignore-nets` | – | Net patterns excluded from airwire scoring (plane-routed power nets) |
 | `--lock` | – | Reference patterns to pin in place (connectors, mounting-critical parts) |
 | `--halo-coef` | 0.25 | Extra whitespace per √(pin count); keep modest (~0.15) on dense boards |
+| `--intent` | – | Floorplan intent JSON. Its declared zones, keep-outs and exclusive zones become HARD per-move gates; its `must_lock` globs and `edge_connectors` edge claims are locked. MONOTONE: it prevents a part being walked out of a zone, it does not walk one back in. Omitted, the run is bit-identical to one built before the flag existed (#702) |
 | `--no-rotate` / `--no-swap` | off | Disable rotation / swap moves. `--no-rotate` freezes every part's angle: nudges keep the current rotation, and same-footprint swaps are restricted to pairs that already share one, since a swap exchanges full poses and a mixed-angle pair would rotate both parts |
 
 ## place_route_loop.py — router-in-the-loop repair

--- a/py_placer/placement/cli_gates.py
+++ b/py_placer/placement/cli_gates.py
@@ -1,11 +1,92 @@
-"""Argparse flags shared by `place_optimize.py` and `place_route_loop.py` (#431).
+"""Argparse flags shared by the placement CLIs (#431, widened by #702).
 
-Defined once so the two CLIs cannot drift: a lock advisor that reports on one
+Defined once so the CLIs cannot drift: a lock advisor that reports on one
 tool but not the other, or an `--allow-unplaced` that spells itself differently,
 is exactly the kind of divergence CLAUDE.md's CLI/GUI section warns about --
 here between two CLIs rather than between a CLI and the GUI.
+
+`add_intent_arg` raises the stakes a level, which is why it lives here rather
+than four times over: since #702 the same resolved intent becomes the same hard
+gate inside the same engine for `place_optimize`, `place_route_loop`,
+`place_seed` and `place_portfolio`. Four spellings of that flag, or four
+descriptions of what it buys, is how one of them ends up gating on something
+the others do not -- and that divergence IS #702, which was `grep -ci intent`
+returning 36 on place_seed.py and 0 on the two CLIs that run the most quench
+iterations in a real chain.
 """
 from __future__ import annotations
+
+
+def add_intent_arg(parser, *, required: bool = False, extra: str = "") -> None:
+    """`--intent`: the floorplan intent, for every CLI that quenches (#702).
+
+    `required` because `place_seed` cannot run without one -- there the intent
+    is the INPUT the placement is derived from, not a constraint on a placement
+    that already exists. `extra` appends a per-tool clause, for a real
+    difference in what the flag buys rather than a wording preference: the
+    portfolio's intent is ALSO its hard rank gate and the source of its health
+    signals.
+    """
+    parser.add_argument(
+        "--intent", metavar="JSON", required=required, default=None,
+        help="Floorplan intent JSON (`check_floorplan.py --emit-intent` writes "
+             "a starter). Its declared zones, keep-outs and exclusive zones "
+             "become HARD per-move gates inside the quench, and its must_lock "
+             "globs and edge_connectors edge claims are locked, so a declared "
+             "constraint no longer decays under optimization (#702). "
+             "MONOTONE, not repairing: a part that arrives already violating "
+             "may improve or hold, never worsen -- this prevents a walk-out, "
+             "it does not undo one. WARNING: an intent that --emit-intent "
+             "wrote FROM the board you are repairing records that board's "
+             "damage as the requirement, and now STEERS the search toward it "
+             "rather than merely mis-grading it. Omitted (the default), the "
+             "run is bit-identical to one built before this flag existed"
+             + ((" " + extra) if extra else ""))
+
+
+def resolve_intent_gate_for_cli(intent, pcb_data, sources, path):
+    """(bundle, problems) plus the one report every quenching CLI must print.
+
+    Shared so the four CLIs cannot describe the same gate differently. Two
+    things it does that a hand-rolled copy at each site kept getting wrong:
+
+    * **Resolves at `sources or auto`.** `place_optimize` and
+      `place_route_loop` default `--group-by none`, while `place_seed`,
+      `place_portfolio` and `check_floorplan` default `auto`. Resolving at a
+      bare `()` makes every `group:`-shaped block resolve to NOTHING on exactly
+      the two tools that run the most quench iterations -- and silently, since
+      neither runs a grader. That is #702 one level down. Deriving groups is
+      read-only (`check_floorplan.py` says so in its own `--group-by` help), so
+      it is safe to derive here even when the caller asked not to MOVE blocks;
+      `sources` still governs the write side, which stays off.
+    * **Prints `resolve_blocks`' problems instead of dropping them.**
+      `block_unresolved` is ERROR severity by design, and the argument is
+      stronger for a gate than for a grade: a block that resolves to nothing
+      gates nobody, and looks identical to a gate that is working.
+    """
+    import sys
+    from placement.groups import parse_sources
+    from placement import floorplan
+    resolve_sources = tuple(sources) or parse_sources('auto')
+    bundle, problems = floorplan.resolve_intent_gate(
+        intent, pcb_data, resolve_sources)
+    for v in problems:
+        print(f"  INTENT ERROR [{v.rule}] {v.message}", file=sys.stderr)
+    zoned = [z for z in bundle['zones'] if z['refs']]
+    bound = len({r for z in zoned for r in z['refs']})
+    if not (zoned or bundle['keepouts'] or bundle['lock_refs']):
+        # place_portfolio's --corridor-weight warning, same shape: an
+        # intent-derived knob with nothing to bite on says so, rather than
+        # reading as enforcement that happened to find nothing wrong.
+        print(f"--intent {path} declares nothing this quench can gate on "
+              f"(no block with a resolved zone rect, no keep-out, no "
+              f"must_lock, no edge claim): the gate is inert", file=sys.stderr)
+    else:
+        print(f"intent: {len(zoned)} zoned block(s) over {bound} part(s), "
+              f"{len(bundle['keepouts'])} keep-out(s), "
+              f"{len(bundle['lock_refs'])} locked ref(s); blocks resolved from "
+              f"{','.join(resolve_sources) or 'refs only'}")
+    return bundle, problems
 
 
 def add_board_state_args(parser) -> None:

--- a/py_placer/placement/cli_gates.py
+++ b/py_placer/placement/cli_gates.py
@@ -44,6 +44,34 @@ def add_intent_arg(parser, *, required: bool = False, extra: str = "") -> None:
              + ((" " + extra) if extra else ""))
 
 
+def load_intent_or_exit(args):
+    """(intent, exit_code). `exit_code` is 2 when the intent is unreadable.
+
+    Shared because the two things it gets right are the two things a per-CLI
+    copy got wrong:
+
+    * it is called BEFORE `record_invocation`, so an exit 2 never records a
+      manifest command that touched no file (place_route_loop recorded one);
+    * `--suggest-locks` warns and continues rather than erroring, and warns on
+      BOTH CLIs -- place_optimize printed the note and place_route_loop
+      returned before reaching it, which is a small instance of exactly the
+      drift this module exists to prevent.
+    """
+    import sys
+    from placement import floorplan
+    if not getattr(args, 'intent', None):
+        return None, 0
+    if getattr(args, 'suggest_locks', False):
+        print("--intent is ignored with --suggest-locks: no quench runs, and "
+              "the lock advisor does not read an intent", file=sys.stderr)
+        return None, 0
+    try:
+        return floorplan.load_intent(args.intent), 0
+    except (OSError, ValueError) as exc:
+        print(f"cannot load intent {args.intent}: {exc}", file=sys.stderr)
+        return None, 2
+
+
 def resolve_intent_gate_for_cli(intent, pcb_data, sources, path):
     """(bundle, problems) plus the one report every quenching CLI must print.
 

--- a/py_placer/placement/floorplan.py
+++ b/py_placer/placement/floorplan.py
@@ -905,11 +905,28 @@ def resolve_blocks(intent: Intent, pcb_data, group_sources: Sequence[str] = ()
     return out, problems
 
 
-def zone_covered_by_keepout(zone, keepouts) -> Optional[str]:
-    """The name of a rect keep-out that swallows `zone` whole, or None (#702).
+def _swallows(entry, rect) -> bool:
+    """Does this keep-out cover `rect` entirely?
+
+    Rect: containment. Circle: all four corners inside, which is exactly the
+    condition for a convex disc to contain a rectangle -- four `hypot` calls,
+    not the fabricated area `keepout_hit` declines to invent.
+    """
+    r = entry.get('rect')
+    if r is not None:
+        return (r[0] <= rect[0] and r[1] <= rect[1]
+                and r[2] >= rect[2] and r[3] >= rect[3])
+    cx, cy, rad = entry['circle']
+    return all(math.hypot(px - cx, py - cy) <= rad
+               for px in (rect[0], rect[2]) for py in (rect[1], rect[3]))
+
+
+def zone_covered_by_keepout(zone, keepouts, member_sides=None) -> Optional[str]:
+    """The name of a keep-out that swallows `zone` whole for a member that it
+    actually BINDS, or None (#702).
 
     An intent whose keep-out covers the region its zone demands is a
-    CONTRADICTION, and `validate_intent` cannot currently see it: it checks
+    CONTRADICTION, and `validate_intent` cannot see it: it checks
     zone-inside-envelope and zone-vs-zone overlap, and nothing compares a zone
     against a keep-out.
 
@@ -918,24 +935,34 @@ def zone_covered_by_keepout(zone, keepouts) -> Optional[str]:
     the rule is termwise-monotone, so `keepout` falls only by leaving the
     keep-out, leaving raises `zone_containment`, and no candidate can lower
     both. The part is frozen for the run, where the pre-#702 quench would have
-    walked it out. So the contradiction has to be refused where it is authored
-    rather than discovered as an immobile part.
+    walked it out.
 
-    Only RECT keep-outs, and only total containment. A circle is reported by
-    `keepout_hit` as a fabricated marker with no area (see its docstring), so
-    "does this circle swallow that rectangle" is not a question this module can
-    answer without inventing geometry -- and a partial overlap is a legitimate
-    intent (a zone with a corner bitten out still has room).
+    `member_sides` is `{ref: sides}` for the block's resolved members, and it
+    is what makes this test the same question the GRADE asks. Without it the
+    check reads raw `intent.keepouts` and ignores both filters
+    `keepouts_for_ref` exists to centralize -- so a `sides: ["B"]` keep-out
+    over an F-side block, or the mounting-hole `allow: ["MH1"]` pattern over
+    MH1's own zone, would each be reported as a contradiction at ERROR while
+    the grade raises no `keepout` finding at all. Measured: both did.
+
+    Only TOTAL coverage. A partial overlap is a legitimate intent -- a zone
+    with a corner bitten out still has room -- and deciding whether what is
+    left can actually hold the part is a different (harder) question than this
+    one.
     """
     if zone.rect is None:
         return None
     for k in keepouts:
-        r = k.get('rect')
-        if r is None:
+        if not _swallows(k, zone.rect):
             continue
-        if (r[0] <= zone.rect[0] and r[1] <= zone.rect[1]
-                and r[2] >= zone.rect[2] and r[3] >= zone.rect[3]):
+        if member_sides is None:
             return str(k.get('name') or '<unnamed>')
+        # Binding is per member, through the SAME resolver the seat predicate
+        # and the grade use, so `allow` globs and `sides` are honoured here
+        # exactly as they are there.
+        for ref, sides in member_sides.items():
+            if keepouts_for_ref((k,), ref, sides):
+                return str(k.get('name') or '<unnamed>')
     return None
 
 
@@ -977,8 +1004,15 @@ def resolve_intent_gate(intent: Intent, pcb_data,
          'exclusive': bool(z.exclusive)}
         for z in intent.blocks if z.rect is not None)
 
+    member_sides = {}
+    for ref in sorted(pcb_data.footprints):
+        fp = pcb_data.footprints[ref]
+        member_sides[ref] = legality.sides_occupied(
+            legality.footprint_side(fp), legality.footprint_has_through_pads(fp))
     for z in intent.blocks:
-        hit = zone_covered_by_keepout(z, intent.keepouts)
+        mine = {r: member_sides[r] for r in blocks.get(z.name, ())
+                if r in member_sides}
+        hit = zone_covered_by_keepout(z, intent.keepouts, mine)
         if hit is not None:
             problems.append(Violation(
                 rule='intent_zone_in_keepout', block=z.name,

--- a/py_placer/placement/floorplan.py
+++ b/py_placer/placement/floorplan.py
@@ -983,6 +983,37 @@ def zone_fits_courtyard(zone_rect, part_rect, tol: float) -> bool:
            (h <= zw + 1e-9 and w <= zh + 1e-9)
 
 
+def zone_escape(zone_rect, part_rect, anchor: bool) -> Tuple[float, str]:
+    """How far `part_rect` is outside `zone_rect`, in mm, and on which side.
+    Exactly 0.0 when contained.
+
+    THE zone measurement, shared by `rule_zone_containment` and the quench's
+    intent gate (#702), for the reason `keepout_hit`'s docstring gives about
+    the keep-out one: a pose the optimizer accepts that the grade then flags is
+    an exit 4 on a board this tool placed itself, and two implementations of
+    "outside its zone" is how that happens.
+
+    `anchor` selects the spec-COORDINATE branch -- grade the courtyard CENTRE,
+    because a zone smaller than the courtyard cannot contain it at any
+    rotation. The CALLER passes the decision `zone_fits_courtyard` makes,
+    because it is pose-INVARIANT (it reads only w/h, and tests both orders) and
+    a per-pose gate must resolve it once per part rather than once per
+    candidate pose.
+
+    Note what this is NOT: `seeder.zone_gate`'s anchor branch tests the
+    footprint ORIGIN (x, y), not the courtyard centre. The two differ by
+    (b[0]+b[2])/2, and `_feasible_centre_box` records how much that is -- 17 of
+    65 parts on splitflap_driver and 6 of 89 on tigard have an offset centre,
+    up to 10.15mm on tigard J3. A gate built on the seeder's predicate would
+    admit, by up to 10mm, poses this rule flags.
+    """
+    if anchor:
+        cx = (part_rect[0] + part_rect[2]) / 2.0
+        cy = (part_rect[1] + part_rect[3]) / 2.0
+        return _rect_escape(zone_rect, (cx, cy, cx, cy))
+    return _rect_escape(zone_rect, part_rect)
+
+
 def rule_zone_containment(ctx) -> Iterator[Violation]:
     for z in ctx.intent.blocks:
         if z.rect is None:
@@ -994,9 +1025,7 @@ def rule_zone_containment(ctx) -> Iterator[Violation]:
                 continue
             if not zone_fits_courtyard(z.rect, part.rect, tol):
                 # Spec-coordinate zone: grade the part's CENTER against it.
-                cx = (part.rect[0] + part.rect[2]) / 2.0
-                cy = (part.rect[1] + part.rect[3]) / 2.0
-                out, axis = _rect_escape(z.rect, (cx, cy, cx, cy))
+                out, axis = zone_escape(z.rect, part.rect, True)
                 if out > tol:
                     yield Violation(
                         rule='zone_containment',
@@ -1011,7 +1040,7 @@ def rule_zone_containment(ctx) -> Iterator[Violation]:
                                   'anchor_graded': True},
                         expected={'zone': list(z.rect), 'tolerance_mm': tol})
                 continue
-            out, axis = _rect_escape(z.rect, part.rect)
+            out, axis = zone_escape(z.rect, part.rect, False)
             if out > tol:
                 yield Violation(
                     rule='zone_containment',

--- a/py_placer/placement/floorplan.py
+++ b/py_placer/placement/floorplan.py
@@ -921,7 +921,12 @@ def _swallows(entry, rect) -> bool:
                for px in (rect[0], rect[2]) for py in (rect[1], rect[3]))
 
 
-def zone_covered_by_keepout(zone, keepouts, member_sides=None) -> Optional[str]:
+def _inflate(rect, by: float):
+    return (rect[0] - by, rect[1] - by, rect[2] + by, rect[3] + by)
+
+
+def zone_covered_by_keepout(zone, keepouts, member_sides=None,
+                            tolerance: float = 0.0) -> Optional[str]:
     """The name of a keep-out that swallows `zone` whole for a member that it
     actually BINDS, or None (#702).
 
@@ -934,8 +939,15 @@ def zone_covered_by_keepout(zone, keepouts, member_sides=None) -> Optional[str]:
     findings and the optimizer moved it anyway. Under the #702 gate it is not:
     the rule is termwise-monotone, so `keepout` falls only by leaving the
     keep-out, leaving raises `zone_containment`, and no candidate can lower
-    both. The part is frozen for the run, where the pre-#702 quench would have
-    walked it out.
+    both. The part is CONFINED TO ITS ZONE for the run, where the pre-#702
+    quench would have walked it out.
+
+    Confined, not frozen -- the distinction was measured, and the message says
+    the weaker true thing rather than the stronger false one. Every pose inside
+    a fully-swallowed zone yields an identical term vector (the intrusion is
+    the constant full-courtyard area, the escape is 0), so the monotone rule
+    admits all of them: 6 of 8 probed alternative poses were accepted. What the
+    member can never do is get OUT.
 
     `member_sides` is `{ref: sides}` for the block's resolved members, and it
     is what makes this test the same question the GRADE asks. Without it the
@@ -952,8 +964,15 @@ def zone_covered_by_keepout(zone, keepouts, member_sides=None) -> Optional[str]:
     """
     if zone.rect is None:
         return None
+    # The zone a member must satisfy is its rect PLUS its tolerance -- that is
+    # what `rule_zone_containment` grades against -- so a keep-out that covers
+    # the bare rect but not the tolerance band leaves real poses. Measured on a
+    # 4x4 zone at tolerance 2.0 with the keep-out equal to the rect: 5 probed
+    # poses satisfy both rules, and without this the intent was refused at
+    # ERROR anyway.
+    reach = _inflate(zone.rect, tolerance)
     for k in keepouts:
-        if not _swallows(k, zone.rect):
+        if not _swallows(k, reach):
             continue
         if member_sides is None:
             return str(k.get('name') or '<unnamed>')
@@ -1012,7 +1031,8 @@ def resolve_intent_gate(intent: Intent, pcb_data,
     for z in intent.blocks:
         mine = {r: member_sides[r] for r in blocks.get(z.name, ())
                 if r in member_sides}
-        hit = zone_covered_by_keepout(z, intent.keepouts, mine)
+        hit = zone_covered_by_keepout(z, intent.keepouts, mine,
+                                      intent.zone_tolerance(z))
         if hit is not None:
             problems.append(Violation(
                 rule='intent_zone_in_keepout', block=z.name,
@@ -1020,8 +1040,10 @@ def resolve_intent_gate(intent: Intent, pcb_data,
                 message=(f"block {z.name!r} declares a zone that keep-out "
                          f"{hit!r} covers entirely: its members are required "
                          f"to be somewhere they are forbidden to be. No pose "
-                         f"satisfies both, and the optimizer's intent gate is "
-                         f"monotone, so such a member cannot move at all"),
+                         f"satisfies both, so such a member can never LEAVE "
+                         f"its zone under the optimizer's monotone intent "
+                         f"gate, and cannot clear the keep-out without "
+                         f"leaving it"),
                 measured={'zone': list(z.rect), 'keepout': hit},
                 expected={'overlap': 'partial or none'}))
 

--- a/py_placer/placement/floorplan.py
+++ b/py_placer/placement/floorplan.py
@@ -905,6 +905,102 @@ def resolve_blocks(intent: Intent, pcb_data, group_sources: Sequence[str] = ()
     return out, problems
 
 
+def zone_covered_by_keepout(zone, keepouts) -> Optional[str]:
+    """The name of a rect keep-out that swallows `zone` whole, or None (#702).
+
+    An intent whose keep-out covers the region its zone demands is a
+    CONTRADICTION, and `validate_intent` cannot currently see it: it checks
+    zone-inside-envelope and zone-vs-zone overlap, and nothing compares a zone
+    against a keep-out.
+
+    That was harmless while the intent was only graded -- the part took two
+    findings and the optimizer moved it anyway. Under the #702 gate it is not:
+    the rule is termwise-monotone, so `keepout` falls only by leaving the
+    keep-out, leaving raises `zone_containment`, and no candidate can lower
+    both. The part is frozen for the run, where the pre-#702 quench would have
+    walked it out. So the contradiction has to be refused where it is authored
+    rather than discovered as an immobile part.
+
+    Only RECT keep-outs, and only total containment. A circle is reported by
+    `keepout_hit` as a fabricated marker with no area (see its docstring), so
+    "does this circle swallow that rectangle" is not a question this module can
+    answer without inventing geometry -- and a partial overlap is a legitimate
+    intent (a zone with a corner bitten out still has room).
+    """
+    if zone.rect is None:
+        return None
+    for k in keepouts:
+        r = k.get('rect')
+        if r is None:
+            continue
+        if (r[0] <= zone.rect[0] and r[1] <= zone.rect[1]
+                and r[2] >= zone.rect[2] and r[3] >= zone.rect[3]):
+            return str(k.get('name') or '<unnamed>')
+    return None
+
+
+def resolve_intent_gate(intent: Intent, pcb_data,
+                        group_sources: Sequence[str] = ()
+                        ) -> Tuple[Dict[str, object], List[Violation]]:
+    """The pose-INVARIANT join a per-move gate needs, plus the problems (#702).
+
+    `resolve_blocks` returns refs and NO geometry, so every consumer has had to
+    join `block name -> Zone.rect` itself; `place_seed.py` was the first copy
+    and four more quench call sites were about to add theirs. One resolver
+    instead, for the reason `Intent.edge_claims` gives about its own split: a
+    filter that must be remembered is a filter that will be forgotten at the
+    next call site.
+
+    Returns PLAIN DATA -- dicts and tuples, no `Intent`, no `Zone`. The quench
+    must not have to import this schema to run, and `grade` builds a
+    QuenchState of its own that must keep measuring INDEPENDENTLY of whatever
+    the optimizer was gated on (tests/test_701_keepout_predicate.py:395).
+
+    `lock_refs` carries the two rules that are enforced by FREEZING rather than
+    by a pose term, because neither is a property of a pose:
+
+      * `must_lock` is a claim about the FILE. No pose satisfies or violates
+        it. Freezing does not launder the grade -- the file is still unstamped,
+        so `rule_must_lock` still fires and still tells the author to stamp it.
+      * `edge_claims()`, NOT `edge_connectors`: a `connector_affinity` entry
+        makes no seat claim and must not be locked out of the search. That
+        split is measured in `Intent.edge_claims`' own docstring (6 extra refs
+        on tigard_placed).
+    """
+    blocks, problems = resolve_blocks(intent, pcb_data, group_sources)
+    zones = tuple(
+        {'name': z.name,
+         'rect': tuple(z.rect),
+         'tolerance_mm': intent.zone_tolerance(z),
+         'refs': tuple(blocks.get(z.name, ())),
+         'side': z.side,
+         'exclusive': bool(z.exclusive)}
+        for z in intent.blocks if z.rect is not None)
+
+    for z in intent.blocks:
+        hit = zone_covered_by_keepout(z, intent.keepouts)
+        if hit is not None:
+            problems.append(Violation(
+                rule='intent_zone_in_keepout', block=z.name,
+                severity=intent.severity_of('intent_zone_in_keepout'),
+                message=(f"block {z.name!r} declares a zone that keep-out "
+                         f"{hit!r} covers entirely: its members are required "
+                         f"to be somewhere they are forbidden to be. No pose "
+                         f"satisfies both, and the optimizer's intent gate is "
+                         f"monotone, so such a member cannot move at all"),
+                measured={'zone': list(z.rect), 'keepout': hit},
+                expected={'overlap': 'partial or none'}))
+
+    lock: set = set()
+    for pat in intent.must_lock:
+        lock.update(fnmatch.filter(sorted(pcb_data.footprints), pat))
+    lock.update(str(c['ref']) for c in intent.edge_claims()
+                if c.get('ref') in pcb_data.footprints)
+    return ({'zones': zones,
+             'keepouts': tuple(intent.keepouts),
+             'lock_refs': tuple(sorted(lock))}, problems)
+
+
 # --------------------------------------------------------------------------
 # rules
 # --------------------------------------------------------------------------
@@ -1301,11 +1397,13 @@ RULES = (
 
 #: Rules whose violations are raised OUTSIDE the `RULES` loop, and so have no
 #: rule function to be enumerated from: the two self-contradiction findings in
-#: `validate_intent` and the unresolved-block finding in `resolve_blocks`.
+#: `validate_intent`, the unresolved-block finding in `resolve_blocks`, and the
+#: zone-inside-a-keep-out contradiction `resolve_intent_gate` raises (#702).
 #: Kept as a named set rather than folded into `_SEVERITY_KEYS` by hand, so the
 #: next reader can see which names are the exception and why.
 _NON_RULE_SEVERITIES = frozenset({
-    'intent_zone_outside_envelope', 'intent_zone_overlap', 'block_unresolved'})
+    'intent_zone_outside_envelope', 'intent_zone_overlap', 'block_unresolved',
+    'intent_zone_in_keepout'})
 
 #: Every rule name an intent may set a severity for. Derived from `RULES`, so a
 #: new rule is settable the moment it is registered -- a hand-listed set would

--- a/py_placer/placement/quench.py
+++ b/py_placer/placement/quench.py
@@ -62,6 +62,44 @@ ROTATIONS = [0.0, 90.0, 180.0, 270.0]
 _CONTAINMENT_GATE = os.environ.get('KRT_NO_CONTAINMENT_GATE', '') != '1'
 EPS_IMPROVE = 1e-6
 
+#: The floorplan rules the quench ENFORCES per move (#702), as opposed to the
+#: ones it is merely graded on afterwards. Exported so `test_placement_ab.py`
+#: and the docs detector read the enforced set FROM the engine instead of
+#: re-typing it: a rule added here enters the A/B signal automatically, and a
+#: rule removed to flatter a row trips a test rather than passing quietly.
+#:
+#: The other six floorplan rules are deliberately absent, each for its own
+#: reason -- `must_lock` and `edge_connector` are enforced by FREEZING the ref
+#: (no pose satisfies or violates them), `zone_side` is invariant under every
+#: move this engine can make, `envelope` is a claim about the intent file,
+#: `decap_distance` is graded in a currency this engine does not carry (pad
+#: centroid to an inflated pad bbox, not courtyard to courtyard), and
+#: `legality` is a whole-board budget rather than a per-pose predicate.
+INTENT_ENFORCED_RULES = ('zone_containment', 'zone_exclusive', 'keepout')
+
+
+class _IntentTerm(NamedTuple):
+    """One declared claim binding one ref, frozen at state construction.
+
+    ONE TERM PER (ref, ENTRY) -- never per (ref, rule). Aggregating a rule's
+    entries to a single scalar per ref is the subtle way to break the gate: two
+    keep-outs would report `1.0 -> 1.0` for circles (or `5mm2 -> 5mm2` for
+    rects) as a part moved from one into the other, and a monotone rule reads
+    that as "no worse" and ADMITS it. The part hops between two regions it is
+    graded on. Same for a ref that resolves into two zones.
+
+    `threshold` is in this term's OWN currency: mm of zone escape, mm2 of
+    intrusion, or `keepout_hit`'s fabricated circle marker. They are compared
+    termwise and NEVER summed -- a sum lets a part buy 1mm of zone escape with
+    1mm2 of intrusion.
+    """
+    rule: str                 # one of INTENT_ENFORCED_RULES
+    name: str                 # block or keep-out name -- the NAMED verdict
+    rect: Optional[Tuple[float, float, float, float]]
+    threshold: float
+    anchor: bool              # zone_containment: grade the courtyard CENTRE
+    entry: Optional[Dict]     # keepout: the raw entry `keepout_hit` reads
+
 # Both helpers now live in placement/legality.py, the single home shared with
 # fanout_clearance (which carried byte-identical copies). Kept as module-level
 # aliases: they are part of this module's de-facto surface (tests import them).
@@ -423,8 +461,20 @@ class QuenchState:
                  # ask for them -- INCLUDING the one `floorplan.grade` builds,
                  # which must keep measuring independently of the seat gate --
                  # is bit-identical. Consumed by `seeder.pose_ok` and
-                 # `seeder.edge_seat_ok`; the quench objective never reads it.
-                 keepouts: Optional[Sequence[Dict]] = None):
+                 # `seeder.edge_seat_ok` under an ABSOLUTE policy, and since
+                 # #702 by `candidate_valid` under a MONOTONE one. The quench
+                 # OBJECTIVE still never reads it: this is a hard gate on which
+                 # poses exist, not a term in the cost.
+                 keepouts: Optional[Sequence[Dict]] = None,
+                 # --- #702 declared zones. APPENDED after `keepouts` for the
+                 # same positional-binding reason as the #548 block above, and
+                 # empty by default for the same bit-identity reason. Plain
+                 # data from `floorplan.resolve_intent_gate`, never an
+                 # `Intent`: the engine must not import that schema to run, and
+                 # `floorplan.grade` builds a state of its own that has to keep
+                 # measuring independently of whatever the optimizer was gated
+                 # on (tests/test_701_keepout_predicate.py:395).
+                 intent_zones: Optional[Sequence[Dict]] = None):
         bounds = pcb_data.board_info.board_bounds
         if bounds is None:
             raise ValueError("No board boundary (Edge.Cuts) found")
@@ -509,6 +559,65 @@ class QuenchState:
                 _binding = _fp.keepouts_for_ref(self.keepouts, _ref, _p.sides)
                 if _binding:
                     self.keepouts_for[_ref] = _binding
+
+        # --- #702 declared claims, resolved ONCE per state ------------------
+        # Everything pose-invariant is settled here so the per-pose cost is the
+        # geometry and nothing else: block membership, the exclusive-zone side
+        # filter, the tolerance, and the `zone_fits_courtyard` anchor decision
+        # (which reads only w/h and tests both orders, so no rotation in this
+        # engine's lattice can flip it).
+        #
+        # `_intent_active` is False on every board that declares nothing --
+        # which is every board in the corpus today -- and `candidate_valid`
+        # guards on it before any arithmetic, so the whole channel costs one
+        # bool load and one branch and the objective is bit-identical.
+        self.intent_zones = tuple(intent_zones or ())
+        self._intent_spec: Dict[str, Tuple[_IntentTerm, ...]] = {}
+        self._intent_active = False
+        if self.intent_zones or self.keepouts_for:
+            from . import floorplan as _fp
+            for _ref, _p in self.parts.items():
+                _terms: List[_IntentTerm] = []
+                for _z in self.intent_zones:
+                    _tol = float(_z['tolerance_mm'])
+                    if _ref in _z['refs']:
+                        # At the ORIGIN: `zone_fits_courtyard` reads only w/h,
+                        # so position is irrelevant and passing 0,0 says so.
+                        # Both rotations, matching `seeder.zone_gate`'s own
+                        # form, so the two cannot disagree about which branch
+                        # a part is on.
+                        _anchor = not any(
+                            _fp.zone_fits_courtyard(
+                                _z['rect'], _p.rect(0.0, 0.0, _r), _tol)
+                            for _r in (_p.rot % 360, (_p.rot + 90) % 360))
+                        _terms.append(_IntentTerm(
+                            'zone_containment', _z['name'], tuple(_z['rect']),
+                            _tol, _anchor, None))
+                    elif _z['exclusive'] and (not _z['side']
+                                              or _p.side == _z['side']):
+                        # `elif`, not `if`: `rule_zone_exclusive` skips members
+                        # of the block that owns the zone. Membership and the
+                        # side filter are both pose-invariant, so the set of
+                        # rects a stranger must avoid is resolved here.
+                        _terms.append(_IntentTerm(
+                            'zone_exclusive', _z['name'], tuple(_z['rect']),
+                            legality.EPS, False, None))
+                for _k in self.keepouts_for.get(_ref, ()):
+                    _terms.append(_IntentTerm(
+                        'keepout', str(_k.get('name') or '<unnamed>'),
+                        None, 0.0, False, _k))
+                if _terms:
+                    self._intent_spec[_ref] = tuple(_terms)
+            self._intent_active = bool(self._intent_spec)
+        # ref -> the incumbent pose's term vector. Cleared beside
+        # `_inc_violation` on every move, for the same reason. Never computed
+        # on a compliant board: `intent_ok` returns on its absolute branch.
+        self._inc_intent: Dict[str, Tuple[float, ...]] = {}
+        # Refusal tally, for `metrics_out['intent_gate']`. Without it, "the
+        # gate refused nothing" and "the gate is not wired" are the same
+        # observation -- which is the whole anti-vacuity device for #702.
+        self.intent_rejected: Dict[str, int] = {}
+        self.intent_rejected_by_site: Dict[str, int] = {}
 
         # Run-6 CONTAINER exemption: a courtyard covering most of the board
         # is a FRAME (a module-outline footprint hosting the whole design),
@@ -1072,6 +1181,137 @@ class QuenchState:
                     return board, overlap
         return board, overlap
 
+    def intent_terms(self, ref, rects) -> Tuple[float, ...]:
+        """This pose measured against every declared claim binding `ref`, in
+        the fixed order `_intent_spec[ref]` froze.
+
+        A VECTOR, never a scalar -- see `_IntentTerm`.
+        """
+        from . import floorplan as _fp   # lazy: see seeder.pose_ok's reason
+        out = []
+        for t in self._intent_spec[ref]:
+            if t.rule == 'keepout':
+                # BOTH rects, because `rule_keepout` grades both: a THT part's
+                # leads pierce a keep-out from the far side.
+                out.append(_fp.keepout_hit(t.entry, rects))
+            elif t.rule == 'zone_exclusive':
+                # COURTYARD ONLY -- `rule_zone_exclusive` reads `part.rect` and
+                # never `tht_rect`. Matching the grade includes matching what
+                # it declines to measure.
+                out.append(rect_overlap_area(rects[0], t.rect))
+            else:
+                out.append(_fp.zone_escape(t.rect, rects[0], t.anchor)[0])
+        return tuple(out)
+
+    def intent_clear(self, ref, rects) -> bool:
+        """ABSOLUTE: every term at or below its own threshold.
+
+        The SEAT policy. Placement from scratch has no incumbent worth
+        improving on (`seeder.pose_ok`), so a seat search demands cleanliness
+        rather than non-worsening -- and `tests/test_701_keepout_predicate.py`
+        seats a part whose current pose is fully inside a keep-out and asserts
+        REFUSAL, which the monotone rule below would admit.
+        """
+        spec = self._intent_spec.get(ref)
+        if not spec:
+            return True
+        return all(v <= t.threshold
+                   for v, t in zip(self.intent_terms(ref, rects), spec))
+
+    def keepout_clear(self, ref, rects) -> bool:
+        """The keep-out slice of `intent_clear`, absolute (#701's policy).
+
+        One loop, so `seeder.pose_ok` and `seeder.edge_seat_ok` stop owning a
+        copy each -- the doctrine `floorplan.keepout_hit`'s own header states.
+        """
+        if not self.keepouts_for:
+            return True
+        from . import floorplan as _fp
+        for k in self.keepouts_for.get(ref, ()):
+            if _fp.keepout_hit(k, rects):
+                return False
+        return True
+
+    def keepout_blockers(self, ref, rects) -> List[str]:
+        """Names of the keep-outs `ref` is in at this pose. #701's doctrine is
+        that a claim which strands a part is a NAMED verdict."""
+        if not self.keepouts_for:
+            return []
+        from . import floorplan as _fp
+        return [str(k.get('name') or '<unnamed>')
+                for k in self.keepouts_for.get(ref, ())
+                if _fp.keepout_hit(k, rects)]
+
+    def _incumbent_intent(self, ref) -> Tuple[float, ...]:
+        """The term vector of the pose `ref` is IN, cached until it moves.
+
+        No `exclude` key, unlike `_incumbent_violation`: the intent terms are
+        part-vs-DECLARED-GEOMETRY, never part-vs-part, so nothing another part
+        does can change them. That is also why they are the right gate for the
+        swap phase, where `candidate_valid` is not.
+        """
+        v = self._inc_intent.get(ref)
+        if v is None:
+            v = self.intent_terms(ref, self.parts[ref].rects())
+            self._inc_intent[ref] = v
+        return v
+
+    def intent_ok(self, ref, x, y, rot, rects=None) -> bool:
+        """MONOTONE: the QUENCH policy. A pose is admitted when every term is
+        clean, or -- TERMWISE -- no worse than the pose the part is in.
+
+        Termwise and never summed, and never traded across terms: a part may
+        not buy its way into keep-out B by leaving keep-out A.
+
+        The incumbent is computed only on the branch that needs it, and cached
+        -- the same trade `candidate_valid` makes at its own escape branch
+        ("Only now, on a rejected candidate, is the incumbent's legality worth
+        computing"). On a compliant board it is never computed at all.
+
+        NON-STRICT (`<=`), unlike the #456 off-board branch's strict compare.
+        That branch needs strictness because it hands out a licence to be
+        ILLEGAL; this one does not, because acceptance is still governed by
+        `current - best > EPS + min_gain_per_mm * dist`, a strictly decreasing
+        potential. The gate is a FILTER on which poses exist, not a descent
+        direction, so equality cannot cycle. Strictness here would instead be a
+        bug: `keepout_hit` reports a circle as a fabricated 1.0 marker, so
+        `<` would freeze a part already inside a circle unless it could clear
+        the whole circle in a single nudge.
+        """
+        spec = self._intent_spec.get(ref)
+        if not spec:
+            return True
+        if rects is None:
+            rects = self.parts[ref].rects(x, y, rot)
+        cand = self.intent_terms(ref, rects)
+        if all(v <= t.threshold for v, t in zip(cand, spec)):
+            return True
+        cur = self._incumbent_intent(ref)
+        return all(c <= u + legality.EPS for c, u in zip(cand, cur))
+
+    def intent_blockers(self, ref, x, y, rot, rects=None):
+        """[(rule, name, measured, incumbent)] for the terms `intent_ok`
+        refuses at this pose. DIAGNOSTIC only, and the reason the refusal can
+        be reported by NAME rather than as a silent missing pose."""
+        spec = self._intent_spec.get(ref)
+        if not spec:
+            return []
+        if rects is None:
+            rects = self.parts[ref].rects(x, y, rot)
+        cand = self.intent_terms(ref, rects)
+        cur = self._incumbent_intent(ref)
+        return [(t.rule, t.name, round(c, 4), round(u, 4))
+                for c, u, t in zip(cand, cur, spec)
+                if c > t.threshold and c > u + legality.EPS]
+
+    def _note_intent_refusal(self, ref, site, rects=None,
+                             x=None, y=None, rot=None) -> None:
+        """Tally a refusal for `metrics_out['intent_gate']`."""
+        self.intent_rejected_by_site[site] = (
+            self.intent_rejected_by_site.get(site, 0) + 1)
+        for rule, _name, _c, _u in self.intent_blockers(ref, x, y, rot, rects):
+            self.intent_rejected[rule] = self.intent_rejected.get(rule, 0) + 1
+
     def candidate_valid(self, ref, x, y, rot, exclude: Optional[Set[str]] = None):
         """True when the pose is legal, or -- when the part sits OFF THE BOARD --
         when it moves strictly back toward the board without overlapping anything.
@@ -1098,6 +1338,23 @@ class QuenchState:
         part = self.parts[ref]
         rects = part.rects(x, y, rot)
         rect = rects[0]
+        # DECLARED INTENT (#702) -- FIRST, and a `return`, not `legal = False`.
+        #
+        # First, for the ordering reason `seeder.pose_ok` gives for its own
+        # keep-out conjunct: a handful of float compares against a usually-
+        # empty tuple, where the neighbour loop below is O(neighbours) and
+        # `pads_ok` is another sweep. On a pose the intent refuses this
+        # REPLACES that work rather than adding to it.
+        #
+        # A `return`, because the escape branch at the bottom of this function
+        # is a licence to be worse on the BOARD term, for a part coming home
+        # from off the board -- and a licence must not compose into a licence
+        # to be worse on a DECLARED one. Written as `legal = False` this would
+        # be silently overturned there. Nothing that can return True may ever
+        # be inserted above this line.
+        if self._intent_active and not self.intent_ok(ref, x, y, rot, rects):
+            self._note_intent_refusal(ref, 'candidate_valid', rects)
+            return False
         legal = not (rect[0] < self.usable[0] or rect[1] < self.usable[1]
                      or rect[2] > self.usable[2] or rect[3] > self.usable[3])
         # Real outline / cutout gate, three-level short-circuit: board-level
@@ -1200,6 +1457,25 @@ class QuenchState:
             return self.legality_ctx.pads_ok(
                 ref, x, y, rot, self._pad_neighbors(ref), exclude=exclude)
         return True
+
+    def swap_intent_ok(self, ra, rb) -> bool:
+        """May these two parts exchange poses, declared-intent-wise? (#702)
+
+        The swap phase does not call `candidate_valid` on ANY path, and that is
+        deliberate: a swap preserves the OCCUPIED SPACE, so the geometry every
+        other part sees is unchanged. That argument is true of clearance and
+        FALSE of a claim that binds a REF -- exchanging two identical decaps
+        moves A to B's pose, where B's zone, B's keep-out bindings and B's
+        exclusive-zone exemptions applied, not A's. Occupied space cannot see
+        that, so this is its own conjunct rather than a relaxation of one.
+
+        Each part's OWN claims at its PARTNER's pose, each against its OWN
+        incumbent. Atomic: both halves must hold and nothing is applied, so
+        there is no ordering hazard between them.
+        """
+        pa, pb = self.parts[ra], self.parts[rb]
+        return (self.intent_ok(ra, pb.x, pb.y, pb.rot)
+                and self.intent_ok(rb, pa.x, pa.y, pa.rot))
 
     def _pad_neighbors(self, ref):
         """Neighbor refs for the pad gate: the pruned list when built, else
@@ -1608,6 +1884,7 @@ class QuenchState:
         part = self.parts[ref]
         part.x, part.y, part.rot = x, y, rot
         self._inc_violation.clear()
+        self._inc_intent.clear()
         # #548: a move changes which pads other parts see, so every
         # net anchor computed against this part is now stale.
         self._anchors.clear()
@@ -1629,6 +1906,7 @@ class QuenchState:
             part.y += dy
             nets.update(part.nets)
         self._inc_violation.clear()
+        self._inc_intent.clear()
         # #548: a move changes which pads other parts see, so every
         # net anchor computed against this part is now stale.
         self._anchors.clear()
@@ -1905,6 +2183,7 @@ def quench(pcb_data: PCBData, pcb_file: str,
            move_unconnected: bool = False,
            corridor_weight: float = 0.0,
            corridor_specs: Optional[Sequence[Dict]] = None,
+           intent_gate: Optional[Dict[str, object]] = None,
            cancel_check=None,
            progress_callback=None) -> List[Dict]:
     """Greedy quench: iterate over parts, accept only cost-reducing moves.
@@ -1981,6 +2260,21 @@ def quench(pcb_data: PCBData, pcb_file: str,
                 extra_locked.add(ref)
         print(f"Locked via --lock: {', '.join(sorted(extra_locked))}")
 
+    # #702: `must_lock` and the intent's EDGE CLAIMS are enforced by freezing
+    # the ref, not by a per-pose term -- neither is a property of a pose. The
+    # merge is a UNION of three sources (the file's own locks, --lock, and
+    # these), and none of the three has an un-lock operator, so a conflict is
+    # impossible by construction and nothing a caller asked for is overridden.
+    #
+    # Printed under its OWN name rather than folded into the line above, which
+    # would otherwise become a lie about where a frozen part came from.
+    _intent_locked = set((intent_gate or {}).get('lock_refs') or ())
+    _intent_locked &= set(pcb_data.footprints)
+    if _intent_locked:
+        extra_locked |= _intent_locked
+        print(f"Locked via intent (must_lock / edge claims): "
+              f"{', '.join(sorted(_intent_locked))}")
+
     state = QuenchState(pcb_data, pcb_file, clearance, board_edge_clearance,
                         crossing_penalty, halo_base, halo_coef, halo_weight,
                         edge_halo, edge_weight, grid_step, length_weight,
@@ -1993,7 +2287,9 @@ def quench(pcb_data: PCBData, pcb_file: str,
                         pad_legality=pad_legality,
                         move_unconnected=move_unconnected,
                         corridor_weight=corridor_weight,
-                        corridor_specs=corridor_specs)
+                        corridor_specs=corridor_specs,
+                        keepouts=(intent_gate or {}).get('keepouts'),
+                        intent_zones=(intent_gate or {}).get('zones'))
     state.build_neighbor_lists(max_displacement + grid_step)
 
     before = state.total_cost()
@@ -2041,6 +2337,7 @@ def quench(pcb_data: PCBData, pcb_file: str,
         group_moves = 0
         swaps_skipped = 0
         swaps_skipped_shape = 0
+        swaps_skipped_intent = 0
 
         # --- rigid block translation (#459) ---
         # Coarse before fine: a block that wants to be 2mm left is cheaper to fix
@@ -2268,6 +2565,17 @@ def quench(pcb_data: PCBData, pcb_file: str,
                         if not state.swap_pads_ok(ra, rb):
                             swaps_skipped_shape += 1
                             continue
+                        # Declared intent (#702). Counted and PRINTED under its
+                        # own name: this file already carries the scar for a
+                        # silent swap rejection -- "two instances of one
+                        # footprint that never swap look exactly like a pair
+                        # with nothing to gain".
+                        if (state._intent_active
+                                and not state.swap_intent_ok(ra, rb)):
+                            state._note_intent_refusal(
+                                ra, 'swap', None, pb.x, pb.y, pb.rot)
+                            swaps_skipped_intent += 1
+                            continue
                         cur = eval_pair(pa.x, pa.y, pa.rot, pb.x, pb.y, pb.rot)
                         swapped = eval_pair(pb.x, pb.y, pb.rot,
                                             pa.x, pa.y, pa.rot)
@@ -2293,6 +2601,11 @@ def quench(pcb_data: PCBData, pcb_file: str,
         # footprint that never swap look exactly like a pair with nothing to gain.
         if verbose and swaps_skipped_shape:
             swap_note += f" swap-mismatched={swaps_skipped_shape}"
+        # NOT gated on `verbose`: a swap the declared intent killed is
+        # a constraint doing its job, and the run that most needs to
+        # know is the one nobody ran with -v.
+        if swaps_skipped_intent:
+            swap_note += f" swap-intent={swaps_skipped_intent}"
         print(f"Pass {pass_num}: {moves} moves, gain {improved:.1f} -> "
               f"length={stats['length']:.1f}mm crossings={stats['crossings']} "
               f"halo={stats['halo']:.1f} edge={stats['edge']:.1f} "
@@ -2314,6 +2627,20 @@ def quench(pcb_data: PCBData, pcb_file: str,
         metrics_out['before'] = dict(before)
         metrics_out['after'] = dict(after)
         metrics_out['legality'] = state.legality_metrics()
+        # #702: what the declared-intent gate actually DID. Always present when
+        # a gate was built, and `rejected: 0` is a real answer -- without this
+        # key, "the gate refused nothing" and "the gate was never wired" are
+        # the same observation, which is how a constraint ships inert.
+        if state._intent_active:
+            metrics_out['intent_gate'] = {
+                'rejected': sum(state.intent_rejected_by_site.values()),
+                'by_rule': dict(sorted(state.intent_rejected.items())),
+                'by_site': dict(sorted(state.intent_rejected_by_site.items())),
+                'refs_bound': len(state._intent_spec),
+                'rules_enforced': sorted(
+                    {t.rule for terms in state._intent_spec.values()
+                     for t in terms}),
+            }
 
     return [{'reference': ref,
              'new_x': p.x, 'new_y': p.y, 'new_rotation': p.rot}

--- a/py_placer/placement/quench.py
+++ b/py_placer/placement/quench.py
@@ -1187,7 +1187,8 @@ class QuenchState:
         removing X from `state.keepouts_for[ref]` and recounting -- and a frozen
         copy defeats that lift silently, because `pose_ok` reaches this gate
         through `candidate_valid`. Measured when it WAS frozen: the #701 census
-        went `lifted=64` to `lifted=0`, and a stranded part's verdict degraded
+        went `lifted=49` to `lifted=0` on arm Q's fixture, and a stranded
+        part's verdict degraded
         from `keepout_blocks` to `no_movable_neighbour`, whose prose --
         "NOTHING seated is near enough to be in the way" -- is verbatim the
         misleading answer that disclosure exists to replace.
@@ -2707,10 +2708,22 @@ def quench(pcb_data: PCBData, pcb_file: str,
                 'rejected': sum(state.intent_rejected_by_site.values()),
                 'by_rule': dict(sorted(state.intent_rejected.items())),
                 'by_site': dict(sorted(state.intent_rejected_by_site.items())),
-                'refs_bound': len(state._intent_spec),
+                # Both derived through `intent_spec_for`, NOT off
+                # `_intent_spec`. That dict holds the ZONE terms only -- the
+                # keep-out slice is derived live from `keepouts_for` so the
+                # #701 census lift keeps working -- so reading it directly
+                # made a keep-out-ONLY intent (the shape #701 exists for)
+                # report `refs_bound: 0, rules_enforced: []` while refusing
+                # hundreds of poses. `place_optimize` then printed the
+                # self-contradictory line "enforced  over 0 bound part(s);
+                # refused 360 candidate pose(s)", and shipped the same
+                # nonsense in JSON_SUMMARY.
+                'refs_bound': len(set(state._intent_spec)
+                                  | set(state.keepouts_for)),
                 'rules_enforced': sorted(
-                    {t.rule for terms in state._intent_spec.values()
-                     for t in terms}),
+                    {t.rule for ref in (set(state._intent_spec)
+                                        | set(state.keepouts_for))
+                     for t in state.intent_spec_for(ref)}),
             }
 
     return [{'reference': ref,

--- a/py_placer/placement/quench.py
+++ b/py_placer/placement/quench.py
@@ -602,13 +602,10 @@ class QuenchState:
                         _terms.append(_IntentTerm(
                             'zone_exclusive', _z['name'], tuple(_z['rect']),
                             legality.EPS, False, None))
-                for _k in self.keepouts_for.get(_ref, ()):
-                    _terms.append(_IntentTerm(
-                        'keepout', str(_k.get('name') or '<unnamed>'),
-                        None, 0.0, False, _k))
                 if _terms:
                     self._intent_spec[_ref] = tuple(_terms)
-            self._intent_active = bool(self._intent_spec)
+            self._intent_active = bool(self._intent_spec
+                                       or self.keepouts_for)
         # ref -> the incumbent pose's term vector. Cleared beside
         # `_inc_violation` on every move, for the same reason. Never computed
         # on a compliant board: `intent_ok` returns on its absolute branch.
@@ -1181,15 +1178,41 @@ class QuenchState:
                     return board, overlap
         return board, overlap
 
+    def intent_spec_for(self, ref) -> Tuple[_IntentTerm, ...]:
+        """The claims binding `ref` right now: frozen zone terms, plus keep-out
+        terms derived LIVE from `keepouts_for`.
+
+        The keep-out slice is deliberately not frozen. `seeder.count_legal_poses`
+        answers "how many seats would lifting keep-out X free" by temporarily
+        removing X from `state.keepouts_for[ref]` and recounting -- and a frozen
+        copy defeats that lift silently, because `pose_ok` reaches this gate
+        through `candidate_valid`. Measured when it WAS frozen: the #701 census
+        went `lifted=64` to `lifted=0`, and a stranded part's verdict degraded
+        from `keepout_blocks` to `no_movable_neighbour`, whose prose --
+        "NOTHING seated is near enough to be in the way" -- is verbatim the
+        misleading answer that disclosure exists to replace.
+
+        Still pose-INVARIANT and still resolved once: `keepouts_for` is the
+        cached resolution, and this only reads it.
+        """
+        zones = self._intent_spec.get(ref, ())
+        kos = self.keepouts_for.get(ref, ())
+        if not kos:
+            return zones
+        return zones + tuple(
+            _IntentTerm('keepout', str(k.get('name') or '<unnamed>'),
+                        None, 0.0, False, k)
+            for k in kos)
+
     def intent_terms(self, ref, rects) -> Tuple[float, ...]:
         """This pose measured against every declared claim binding `ref`, in
-        the fixed order `_intent_spec[ref]` froze.
+        the fixed order `intent_spec_for` returns.
 
         A VECTOR, never a scalar -- see `_IntentTerm`.
         """
         from . import floorplan as _fp   # lazy: see seeder.pose_ok's reason
         out = []
-        for t in self._intent_spec[ref]:
+        for t in self.intent_spec_for(ref):
             if t.rule == 'keepout':
                 # BOTH rects, because `rule_keepout` grades both: a THT part's
                 # leads pierce a keep-out from the far side.
@@ -1212,7 +1235,7 @@ class QuenchState:
         seats a part whose current pose is fully inside a keep-out and asserts
         REFUSAL, which the monotone rule below would admit.
         """
-        spec = self._intent_spec.get(ref)
+        spec = self.intent_spec_for(ref)
         if not spec:
             return True
         return all(v <= t.threshold
@@ -1277,8 +1300,28 @@ class QuenchState:
         bug: `keepout_hit` reports a circle as a fabricated 1.0 marker, so
         `<` would freeze a part already inside a circle unless it could clear
         the whole circle in a single nudge.
+
+        THE TRADE THIS MAKES, STATED. Because the conjunct sits ABOVE the #456
+        off-board escape branch and returns rather than setting a flag, a part
+        that is OFF THE OUTLINE and whose only reachable homeward poses lie in
+        a declared keep-out stays off the outline. Measured on a fixture: the
+        ungated run brings it 1.50mm inside the usable inset, the gated run
+        leaves it 2.50mm outside. That trades a `keepout` finding for an
+        off-board part, and CLAUDE.md ranks a part whose pad copper lies
+        outside the outline as the TOP-priority placement defect, because it
+        converts one-for-one into unrouted and broken nets.
+
+        It is nonetheless the right ordering, for one reason: the alternative
+        is a gate that can be defeated by first walking a part off the board.
+        A declared keep-out that stops applying under some other violation is
+        not a hard constraint. The honest handling is disclosure, not a
+        loophole -- `intent_blockers` names the claim that stranded the part,
+        and an intent whose keep-outs leave a part no way home is a
+        contradiction its author has to see. `zone_covered_by_keepout` catches
+        the total-coverage case at load time; the partial case is not caught
+        yet, and is filed rather than silently accepted.
         """
-        spec = self._intent_spec.get(ref)
+        spec = self.intent_spec_for(ref)
         if not spec:
             return True
         if rects is None:
@@ -1293,7 +1336,7 @@ class QuenchState:
         """[(rule, name, measured, incumbent)] for the terms `intent_ok`
         refuses at this pose. DIAGNOSTIC only, and the reason the refusal can
         be reported by NAME rather than as a silent missing pose."""
-        spec = self._intent_spec.get(ref)
+        spec = self.intent_spec_for(ref)
         if not spec:
             return []
         if rects is None:
@@ -1306,11 +1349,34 @@ class QuenchState:
 
     def _note_intent_refusal(self, ref, site, rects=None,
                              x=None, y=None, rot=None) -> None:
-        """Tally a refusal for `metrics_out['intent_gate']`."""
+        """Tally ONE refusal against `site`, and the rules behind it.
+
+        `by_site` counts REFUSALS and `by_rule` counts BLOCKING TERMS, so the
+        two do not sum to each other in either direction: one refused pose can
+        break two claims at once, and a pose refused for a reason this call was
+        not given a ref for contributes to `by_site` alone. Stated here because
+        a reader will otherwise assume `by_rule` partitions `rejected`.
+        """
         self.intent_rejected_by_site[site] = (
             self.intent_rejected_by_site.get(site, 0) + 1)
         for rule, _name, _c, _u in self.intent_blockers(ref, x, y, rot, rects):
             self.intent_rejected[rule] = self.intent_rejected.get(rule, 0) + 1
+
+    def _note_swap_refusal(self, ra, rb) -> None:
+        """Attribute a refused swap to whichever HALF of it was refused.
+
+        Asking only about `ra` loses the case where the partner's claims are
+        what refused: `by_site` showed the swap and `by_rule` stayed empty,
+        which reads as a refusal with no reason. Both halves are checked
+        because either can be the one that failed, and both can.
+        """
+        pa, pb = self.parts[ra], self.parts[rb]
+        self.intent_rejected_by_site['swap'] = (
+            self.intent_rejected_by_site.get('swap', 0) + 1)
+        for who, (x, y, rot) in ((ra, (pb.x, pb.y, pb.rot)),
+                                 (rb, (pa.x, pa.y, pa.rot))):
+            for rule, _n, _c, _u in self.intent_blockers(who, x, y, rot):
+                self.intent_rejected[rule] = self.intent_rejected.get(rule, 0) + 1
 
     def candidate_valid(self, ref, x, y, rot, exclude: Optional[Set[str]] = None):
         """True when the pose is legal, or -- when the part sits OFF THE BOARD --
@@ -2572,8 +2638,7 @@ def quench(pcb_data: PCBData, pcb_file: str,
                         # with nothing to gain".
                         if (state._intent_active
                                 and not state.swap_intent_ok(ra, rb)):
-                            state._note_intent_refusal(
-                                ra, 'swap', None, pb.x, pb.y, pb.rot)
+                            state._note_swap_refusal(ra, rb)
                             swaps_skipped_intent += 1
                             continue
                         cur = eval_pair(pa.x, pa.y, pa.rot, pb.x, pb.y, pb.rot)
@@ -2631,7 +2696,13 @@ def quench(pcb_data: PCBData, pcb_file: str,
         # a gate was built, and `rejected: 0` is a real answer -- without this
         # key, "the gate refused nothing" and "the gate was never wired" are
         # the same observation, which is how a constraint ships inert.
-        if state._intent_active:
+        # Gated on "a gate was HANDED IN", not on `_intent_active`. An intent
+        # whose zone refs resolve to nothing on this board, or whose only
+        # keep-out allows every ref, builds an empty spec -- and reporting no
+        # key for that puts back exactly the ambiguity this key removes: "the
+        # gate refused nothing" and "there was no gate" become the same
+        # observation again, in the one case where the difference matters most.
+        if intent_gate is not None:
             metrics_out['intent_gate'] = {
                 'rejected': sum(state.intent_rejected_by_site.values()),
                 'by_rule': dict(sorted(state.intent_rejected.items())),

--- a/py_placer/placement/seeder.py
+++ b/py_placer/placement/seeder.py
@@ -99,15 +99,15 @@ def pose_ok(state, ref: str, x: float, y: float, rot: float,
     # leads pass through a keep-out even when its body sits on the far side,
     # so a courtyard-only seat would be accepted here and flagged there --
     # exit 4 on a board this function placed correctly.
-    if state.keepouts_for:
-        # Lazy, inside the guard, matching this file's idiom for `floorplan`
-        # (see `zone_gate` below) -- so a board declaring no keep-out pays
-        # nothing at all, not even a sys.modules lookup, on a predicate this
-        # hot.
-        from placement.floorplan import keepout_hit
-        for k in state.keepouts_for.get(ref, ()):
-            if keepout_hit(k, (r, tht)):
-                return False
+    # ABSOLUTE, via the state's shared loop. `edge_seat_ok` below had a second
+    # copy of this and #702 gave `candidate_valid` a third -- with a MONOTONE
+    # policy, which this predicate must not inherit: seeding from scratch has
+    # no incumbent worth improving on, and `test_701_keepout_predicate.py`
+    # seats a part whose current pose is fully inside a keep-out and asserts
+    # refusal, which "no worse than where you already are" would admit. One
+    # loop, two policies, both named.
+    if not state.keepout_clear(ref, (r, tht)):
+        return False
     return state.candidate_valid(ref, x, y, rot, exclude=exclude)
 
 
@@ -1082,13 +1082,11 @@ def edge_seat_ok(state, part, x: float, y: float, edge: str,
     amt = state.edge_gate.rect_outside_amount(r)
     if not ((lo - 0.02) <= amt <= (hi + 0.02)):
         return False
-    if state.keepouts_for:
-        from placement.floorplan import keepout_hit
-        for k in state.keepouts_for.get(part.ref, ()):
-            if keepout_hit(k, (r, tht)):
-                if reasons is not None:
-                    reasons.append(f"keep-out {k['name']!r}")
-                return False
+    _blockers = state.keepout_blockers(part.ref, (r, tht))
+    if _blockers:
+        if reasons is not None:
+            reasons.extend(f"keep-out {n!r}" for n in _blockers)
+        return False
     gate = state.edge_gate
     for px, py, _sz in part.pad_globals(x, y, part.rot):
         # A zero-size rect at the pad centre: "is this point on the board",

--- a/py_placer/placement/seeder.py
+++ b/py_placer/placement/seeder.py
@@ -472,6 +472,10 @@ def count_legal_poses(state, ref: str, tx: float, ty: float,
     saved = None
     if lift and state.keepouts_for.get(ref):
         saved = state.keepouts_for[ref]
+        # The gate derives its keep-out terms from `keepouts_for` per
+        # call, so the lift below is honoured -- but the INCUMBENT
+        # vector is cached, and under a lift it has the wrong arity.
+        state._inc_intent.clear()
         kept = tuple(k for k in saved if k['name'] not in lift)
         if kept:
             state.keepouts_for[ref] = kept
@@ -496,6 +500,7 @@ def count_legal_poses(state, ref: str, tx: float, ty: float,
     finally:
         if saved is not None:
             state.keepouts_for[ref] = saved
+            state._inc_intent.clear()
 
 
 #: The verdicts a part with no legal pose can be given (#699). Two of them

--- a/py_placer/pose_score.py
+++ b/py_placer/pose_score.py
@@ -60,7 +60,7 @@ def make_state(pcb_data, board_path: str, *, clearance: float = 0.25,
                halo_weight: float = 2.0, edge_halo: float = 2.0,
                edge_weight: float = 2.0,
                ignore_net_ids=None, net_weights=None, move_refs=None,
-               extra_locked_refs=None, keepouts=None):
+               extra_locked_refs=None, keepouts=None, intent_zones=None):
     """A QuenchState used purely as an oracle -- built, queried, thrown away.
 
     Defaults mirror the placement guidance rather than quench's own library
@@ -81,7 +81,14 @@ def make_state(pcb_data, board_path: str, *, clearance: float = 0.25,
         # rather than read here, because this factory has no intent -- every
         # caller that has one hands it over, and a caller that has none gets
         # the inert default.
-        keepouts=keepouts)
+        keepouts=keepouts,
+        # #702: declared zones, same passthrough. Note the ASYMMETRY, which is
+        # deliberate -- `place_seed`'s post-polish re-seat passes `keepouts`
+        # and must NOT pass this. The re-seat's whole job is to move a part
+        # that is ALREADY violating back where it belongs, and the zone gate is
+        # monotone against the pose the part is in, so handing it over would
+        # make the repair refuse its own target and quietly stop repairing.
+        intent_zones=intent_zones)
 
 
 def rank_poses(pcb_data, board_path: str, ref: str, *, radius: float = 2.0,

--- a/py_router/kicad_locate.py
+++ b/py_router/kicad_locate.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import glob
 import ntpath
 import os
+import posixpath
 import platform
 import re
 import sys
@@ -276,13 +277,20 @@ def darwin_bundle_patterns(home: str) -> List[str]:
     assume. Shared with describe_search, so the diagnostic cannot claim to
     have searched somewhere this does not.
     """
+    # posixpath, not os.path: every function here takes an explicit `system`
+    # so a caller can reason about a platform other than the host, and macOS
+    # paths are POSIX by construction. `os.path.join` on a Windows host emits
+    # backslashes into them, which is how a cross-platform caller -- or this
+    # module's own test suite -- gets `/Applications/KiCad\KiCad.app`. The
+    # Windows branch of `kicad_python_candidates` already uses `ntpath.join`
+    # for exactly this reason; these two were simply missed.
     return [
         '/Applications/KiCad/KiCad.app',
-        os.path.join(home, 'Applications', 'KiCad', 'KiCad.app'),
+        posixpath.join(home, 'Applications', 'KiCad', 'KiCad.app'),
         '/Applications/KiCad/KiCad*.app',
         '/Applications/KiCad*.app',
-        os.path.join(home, 'Applications', 'KiCad', 'KiCad*.app'),
-        os.path.join(home, 'Applications', 'KiCad*.app'),
+        posixpath.join(home, 'Applications', 'KiCad', 'KiCad*.app'),
+        posixpath.join(home, 'Applications', 'KiCad*.app'),
     ]
 
 
@@ -291,8 +299,8 @@ def linux_prefixes(home: str) -> List[str]:
     describe_search for the same reason as darwin_bundle_patterns."""
     return ['/usr', '/usr/local', '/opt/kicad',
             '/var/lib/flatpak/app/org.kicad.KiCad/current/active/files',
-            os.path.join(home, '.local', 'share', 'flatpak', 'app',
-                         'org.kicad.KiCad', 'current', 'active', 'files'),
+            posixpath.join(home, '.local', 'share', 'flatpak', 'app',
+                           'org.kicad.KiCad', 'current', 'active', 'files'),
             '/snap/kicad/current/usr']
 
 
@@ -386,19 +394,19 @@ def kicad_python_candidates(system: Optional[str] = None,
         if system == 'Windows':
             cands.append(ntpath.join(root, 'bin', 'python.exe'))
         elif system == 'Darwin':
-            fw = os.path.join(root, 'Contents', 'Frameworks',
-                              'Python.framework', 'Versions')
-            cands.append(os.path.join(fw, 'Current', 'bin', 'python3'))
+            fw = posixpath.join(root, 'Contents', 'Frameworks',
+                                'Python.framework', 'Versions')
+            cands.append(posixpath.join(fw, 'Current', 'bin', 'python3'))
             # Versioned frameworks, newest first, for a bundle whose
             # `Current` symlink is missing or broken.
             globber = kw.get('globber', glob.glob)
             cands.extend(sorted(
-                (os.path.join(v, 'bin', 'python3')
-                 for v in globber(os.path.join(fw, '3.*'))),
+                (posixpath.join(v, 'bin', 'python3')
+                 for v in globber(posixpath.join(fw, '3.*'))),
                 key=lambda p: version_key(p), reverse=True))
         else:
             for name in ('python3', 'python'):
-                cands.append(os.path.join(root, 'bin', name))
+                cands.append(posixpath.join(root, 'bin', name))
     cands.append('/usr/bin/python3')   # distro KiCad ships pcbnew here
     seen, out = set(), []
     for c in cands:

--- a/tests/mutate_702.py
+++ b/tests/mutate_702.py
@@ -144,7 +144,8 @@ ROWS = [
     # The keep-out slice must stay LIVE, or #701's census lift is defeated:
     # `count_legal_poses` removes an entry from `keepouts_for` and recounts,
     # and a frozen copy makes the lift invisible. Measured before the fix:
-    # the census went lifted=64 -> lifted=0 and the verdict degraded from
+    # the census went lifted=49 -> lifted=0 on arm Q's fixture, and the
+    # verdict degraded from
     # `keepout_blocks` to `no_movable_neighbour`.
     ('the-keepout-slice-stops-honouring-the-lift', 'q',
      "        kos = self.keepouts_for.get(ref, ())\n",
@@ -189,7 +190,7 @@ ROWS = [
 
     # ---- the load-time contradiction ---------------------------------------
     ('the-crossed-claim-check-never-fires', 'fp',
-     "        if not _swallows(k, zone.rect):\n"
+     "        if not _swallows(k, reach):\n"
      "            continue\n",
      "        if True:\n"
      "            continue\n",
@@ -217,6 +218,24 @@ ROWS = [
      "                return str(k.get('name') or '<unnamed>')\n",
      "        return str(k.get('name') or '<unnamed>')\n",
      (T702,), 'KILLED'),
+
+    # ---- the metrics, which a keep-out-only intent made self-contradictory --
+    ('the-metrics-read-zone-terms-only', 'q',
+     "                'refs_bound': len(set(state._intent_spec)\n"
+     "                                  | set(state.keepouts_for)),\n",
+     "                'refs_bound': len(state._intent_spec),\n",
+     (T702,), 'KILLED'),
+
+    # ---- the contradiction check must respect the zone TOLERANCE -----------
+    # A zone whose tolerance band reaches outside the keep-out still has legal
+    # poses, so reporting it as a contradiction is a false ERROR. Measured on a
+    # 4x4 zone at tolerance 2.0 with the keep-out equal to the rect: 5 poses
+    # satisfy both rules. Recorded SURVIVED: no arm builds that fixture, and
+    # the row is here so the day one does, the guard is already written.
+    ('the-swallow-test-ignores-the-tolerance', 'fp',
+     "    reach = _inflate(zone.rect, tolerance)\n",
+     "    reach = zone.rect\n",
+     (T702,), 'SURVIVED'),
 
     # ---- inertness ----------------------------------------------------------
     ('the-gate-is-built-even-with-no-intent', 'q',

--- a/tests/mutate_702.py
+++ b/tests/mutate_702.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""The #702 mutation battery, shipped so its numbers can be re-derived.
+
+`tests/test_702_quench_intent_gate.py` records what each arm kills. A count is
+only checkable if the exact source edit is written down, so the edits live here
+as data, next to the numbers they produced.
+
+Every row carries an EXPECTATION. An inert row recorded as an expected survivor
+is a finding; an inert row quietly deleted is a hole. A row whose verdict does
+not match its expectation is reported as WRONG.
+
+WHY THIS BATTERY EXISTS AT ALL. The first version of arm F asserted "with the
+gate A1 never lands in the keep-out" and PASSED -- while `by_site` came back
+`{}`, i.e. the swap conjunct it claimed to test was never reached and the nudge
+gate had refused the pose instead. The behavioural assertion was true for a
+reason the arm was not testing. Every row below exists to ask the same question
+of every other arm.
+
+NOT named `test_*.py`, so `tests/run_all.py` does not collect it: it REWRITES
+the engine in place. One writer per tree -- do not run it while a suite, an A/B
+replay or a review is reading the same checkout. It refuses to start on a dirty
+engine, because restoring would write the COMMITTED text back over uncommitted
+work.
+
+    python3 tests/mutate_702.py
+    python3 tests/mutate_702.py --row the-gate-always-says-yes
+    python3 tests/mutate_702.py --list
+
+A row is KILLED by a FAILURE **or an ERROR**: several of these make an arm
+raise rather than fail, and a battery that counted only failures would call
+that a survivor.
+
+An anchor that does not match EXACTLY ONCE is reported as BROKEN rather than
+skipped -- a battery that silently applies nothing reports every row as a
+survivor, which reads as a catastrophic test failure and is really a stale
+anchor. `str.replace(old, new, 1)` of an absent needle returns the file
+unchanged, which is why the count is checked BEFORE the write.
+
+Python `str.replace`, never `sed`: `sed` has eaten an unescaped metacharacter
+in this repo before and left a SyntaxError behind, and a battery that cannot
+start reports nothing at all.
+
+THE MEASURED TABLE IS IN THE HEADER OF `test_702_quench_intent_gate.py`, FROM
+THE RUN -- never predicted here and never edited afterwards to match.
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import subprocess
+import sys
+
+_TESTS = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_TESTS)
+
+QUENCH = os.path.join(_ROOT, 'py_placer', 'placement', 'quench.py')
+FLOORPLAN = os.path.join(_ROOT, 'py_placer', 'placement', 'floorplan.py')
+TARGETS = {'q': QUENCH, 'fp': FLOORPLAN}
+
+T702 = os.path.join(_TESTS, 'test_702_quench_intent_gate.py')
+T701P = os.path.join(_TESTS, 'test_701_keepout_predicate.py')
+T701S = os.path.join(_TESTS, 'test_701_keepout_seating.py')
+T549 = os.path.join(_TESTS, 'test_549_floorplan_grade.py')
+
+ROWS = [
+    # ---- the gate itself ---------------------------------------------------
+    ('the-gate-always-says-yes', 'q',
+     "        if rects is None:\n"
+     "            rects = self.parts[ref].rects(x, y, rot)\n"
+     "        cand = self.intent_terms(ref, rects)\n"
+     "        if all(v <= t.threshold for v, t in zip(cand, spec)):\n"
+     "            return True\n"
+     "        cur = self._incumbent_intent(ref)\n",
+     "        return True\n"
+     "        if rects is None:\n"
+     "            rects = self.parts[ref].rects(x, y, rot)\n"
+     "        cand = self.intent_terms(ref, rects)\n"
+     "        if all(v <= t.threshold for v, t in zip(cand, spec)):\n"
+     "            return True\n"
+     "        cur = self._incumbent_intent(ref)\n",
+     (T702,), 'KILLED'),
+
+    # ---- each enforcement site, deleted independently -----------------------
+    # Three rows, not one, because the whole claim of #702 is that these are
+    # THREE sites and the other two are not reachable from the first.
+    ('delete-the-conjunct-from-candidate_valid', 'q',
+     "        if self._intent_active and not self.intent_ok(ref, x, y, rot, rects):\n"
+     "            self._note_intent_refusal(ref, 'candidate_valid', rects)\n"
+     "            return False\n",
+     "",
+     (T702,), 'KILLED'),
+
+    ('delete-the-conjunct-from-the-SWAP-phase', 'q',
+     "                        if (state._intent_active\n"
+     "                                and not state.swap_intent_ok(ra, rb)):\n",
+     "                        if False:\n",
+     (T702,), 'KILLED'),
+
+    ('the-swap-conjunct-tests-only-one-half', 'q',
+     "        return (self.intent_ok(ra, pb.x, pb.y, pb.rot)\n"
+     "                and self.intent_ok(rb, pa.x, pa.y, pa.rot))\n",
+     "        return self.intent_ok(rb, pa.x, pa.y, pa.rot)\n",
+     (T702,), 'KILLED'),
+
+    # ---- the monotone rule --------------------------------------------------
+    ('strict-instead-of-non-strict', 'q',
+     "        return all(c <= u + legality.EPS for c, u in zip(cand, cur))\n",
+     "        return all(c < u - legality.EPS for c, u in zip(cand, cur))\n",
+     (T702,), 'KILLED'),
+
+    ('the-incumbent-is-read-at-the-SEED-pose', 'q',
+     "            v = self.intent_terms(ref, self.parts[ref].rects())\n",
+     "            _p = self.parts[ref]\n"
+     "            v = self.intent_terms(ref, _p.rects(_p.seed_x, _p.seed_y,\n"
+     "                                               _p.orig_rot))\n",
+     (T702,), 'KILLED'),
+
+    ('the-vector-is-summed-into-a-scalar', 'q',
+     "        cand = self.intent_terms(ref, rects)\n"
+     "        if all(v <= t.threshold for v, t in zip(cand, spec)):\n"
+     "            return True\n"
+     "        cur = self._incumbent_intent(ref)\n"
+     "        return all(c <= u + legality.EPS for c, u in zip(cand, cur))\n",
+     "        cand = self.intent_terms(ref, rects)\n"
+     "        if all(v <= t.threshold for v, t in zip(cand, spec)):\n"
+     "            return True\n"
+     "        cur = self._incumbent_intent(ref)\n"
+     "        return sum(cand) <= sum(cur) + legality.EPS\n",
+     (T702,), 'KILLED'),
+
+    # ---- per-ENTRY indexing -------------------------------------------------
+    # The whole point of _IntentTerm: aggregate a rule's entries to one scalar
+    # per ref and a part hops between two keep-outs at 1.0 -> 1.0.
+    ('keepout-terms-collapse-to-one-per-ref', 'q',
+     "        return zones + tuple(\n"
+     "            _IntentTerm('keepout', str(k.get('name') or '<unnamed>'),\n"
+     "                        None, 0.0, False, k)\n"
+     "            for k in kos)\n",
+     "        return zones + (_IntentTerm('keepout', 'all', None, 0.0,\n"
+     "                                    False, kos[0]),)\n",
+     (T702,), 'KILLED'),
+
+    # The keep-out slice must stay LIVE, or #701's census lift is defeated:
+    # `count_legal_poses` removes an entry from `keepouts_for` and recounts,
+    # and a frozen copy makes the lift invisible. Measured before the fix:
+    # the census went lifted=64 -> lifted=0 and the verdict degraded from
+    # `keepout_blocks` to `no_movable_neighbour`.
+    ('the-keepout-slice-stops-honouring-the-lift', 'q',
+     "        kos = self.keepouts_for.get(ref, ())\n",
+     "        kos = (self.keepouts if self.keepouts_for.get(ref) else ())\n",
+     (T702,), 'KILLED'),
+
+    # ---- what the terms MEASURE --------------------------------------------
+    ('the-keepout-test-forgets-the-through-hole-rect', 'q',
+     "                out.append(_fp.keepout_hit(t.entry, rects))\n",
+     "                out.append(_fp.keepout_hit(t.entry, (rects[0],)))\n",
+     (T702, T701P), 'KILLED'),
+
+    ('the-anchor-branch-is-never-taken', 'q',
+     "                        _anchor = not any(\n"
+     "                            _fp.zone_fits_courtyard(\n"
+     "                                _z['rect'], _p.rect(0.0, 0.0, _r), _tol)\n"
+     "                            for _r in (_p.rot % 360, (_p.rot + 90) % 360))\n",
+     "                        _anchor = False\n",
+     (T702,), 'KILLED'),
+
+    ('the-zone-tolerance-is-ignored', 'q',
+     "                    _tol = float(_z['tolerance_mm'])\n",
+     "                    _tol = 0.0\n",
+     (T702,), 'KILLED'),
+
+    ('the-exclusive-zone-term-is-dropped', 'q',
+     "                        _terms.append(_IntentTerm(\n"
+     "                            'zone_exclusive', _z['name'], tuple(_z['rect']),\n"
+     "                            legality.EPS, False, None))\n",
+     "                        pass\n",
+     (T702,), 'KILLED'),
+
+    # ---- the shared measurement, which the GRADE also calls -----------------
+    ('zone_escape-grades-the-origin-not-the-centre', 'fp',
+     "    if anchor:\n"
+     "        cx = (part_rect[0] + part_rect[2]) / 2.0\n"
+     "        cy = (part_rect[1] + part_rect[3]) / 2.0\n"
+     "        return _rect_escape(zone_rect, (cx, cy, cx, cy))\n",
+     "    if anchor:\n"
+     "        return _rect_escape(zone_rect, part_rect)\n",
+     (T702, T549), 'KILLED'),
+
+    # ---- the load-time contradiction ---------------------------------------
+    ('the-crossed-claim-check-never-fires', 'fp',
+     "        if not _swallows(k, zone.rect):\n"
+     "            continue\n",
+     "        if True:\n"
+     "            continue\n",
+     (T702,), 'KILLED'),
+
+    ('the-crossed-claim-check-fires-on-ANY-overlap', 'fp',
+     "    r = entry.get('rect')\n"
+     "    if r is not None:\n"
+     "        return (r[0] <= rect[0] and r[1] <= rect[1]\n"
+     "                and r[2] >= rect[2] and r[3] >= rect[3])\n",
+     "    r = entry.get('rect')\n"
+     "    if r is not None:\n"
+     "        return legality.rect_overlap_area(r, rect) > legality.EPS\n",
+     (T702,), 'KILLED'),
+
+    # `allow` and `sides` are the two filters `keepouts_for_ref` exists to
+    # centralize, and the contradiction check read neither. Measured before
+    # the fix: a `sides: ["B"]` keep-out over an F-side block, and the
+    # mounting-hole `allow: ["MH1"]` pattern over MH1's own zone, were each
+    # reported as an ERROR contradiction while the grade raised no `keepout`
+    # finding at all.
+    ('the-contradiction-check-ignores-allow-and-sides', 'fp',
+     "        for ref, sides in member_sides.items():\n"
+     "            if keepouts_for_ref((k,), ref, sides):\n"
+     "                return str(k.get('name') or '<unnamed>')\n",
+     "        return str(k.get('name') or '<unnamed>')\n",
+     (T702,), 'KILLED'),
+
+    # ---- inertness ----------------------------------------------------------
+    ('the-gate-is-built-even-with-no-intent', 'q',
+     "        if self.intent_zones or self.keepouts_for:\n",
+     "        if True:\n",
+     (T702,), 'SURVIVED'),
+
+    # ---- expected survivors, recorded rather than deleted -------------------
+    # `_intent_active` is what candidate_valid guards on; flipping it ON with
+    # an empty spec changes nothing, because every lookup misses and
+    # `intent_ok` returns True on `if not spec`. Recorded so it becomes a
+    # detector the day the guard starts meaning something else.
+    ('the-active-flag-ignores-whether-anything-bound', 'q',
+     "            self._intent_active = bool(self._intent_spec\n"
+     "                                       or self.keepouts_for)\n",
+     "            self._intent_active = True\n",
+     (T702,), 'SURVIVED'),
+
+    # MEASURED KILLED, and I had expected SURVIVED. Arm A asserts
+    # `by_site['candidate_valid'] > 0`, so the tally is load-bearing after all:
+    # it is what stops an arm passing while the site it names was never
+    # reached, which is exactly what arm F did before the counter caught it.
+    ('the-refusal-tally-is-never-incremented', 'q',
+     "        self.intent_rejected_by_site[site] = (\n"
+     "            self.intent_rejected_by_site.get(site, 0) + 1)\n",
+     "        pass\n",
+     (T702,), 'KILLED'),
+]
+
+
+def _git_clean(paths):
+    r = subprocess.run(['git', 'diff', '--quiet', '--'] + list(paths),
+                       cwd=_ROOT)
+    return r.returncode == 0
+
+
+def _run(tests):
+    for t in tests:
+        r = subprocess.run([sys.executable, '-X', 'utf8', t],
+                           cwd=_ROOT, capture_output=True, text=True,
+                           encoding='utf-8', errors='replace')
+        if r.returncode != 0:
+            return True, f"{os.path.basename(t)} exit {r.returncode}"
+    return False, "all named tests passed"
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--row', action='append', default=None)
+    ap.add_argument('--list', action='store_true')
+    a = ap.parse_args()
+
+    if a.list:
+        for name, tgt, _o, _n, tests, exp in ROWS:
+            print(f"  {exp:9} {name}  [{tgt}] "
+                  f"-> {', '.join(os.path.basename(t) for t in tests)}")
+        return 0
+
+    rows = ROWS
+    if a.row:
+        unknown = [n for n in a.row if n not in {r[0] for r in ROWS}]
+        if unknown:
+            print(f"no such row: {', '.join(unknown)}; try --list",
+                  file=sys.stderr)
+            return 2
+        rows = [r for r in ROWS if r[0] in set(a.row)]
+
+    if not _git_clean(TARGETS.values()):
+        print("REFUSED: the engine files are dirty. Restoring would write the "
+              "COMMITTED text back over uncommitted work.", file=sys.stderr)
+        return 2
+
+    originals = {k: io.open(p, encoding='utf-8').read()
+                 for k, p in TARGETS.items()}
+    verdicts = []
+    try:
+        for name, tgt, old, new, tests, expect in rows:
+            src = originals[tgt]
+            n = src.count(old)
+            if n != 1:
+                verdicts.append((name, 'BROKEN', f"anchor matched {n} times"))
+                print(f"  BROKEN   {name} -- anchor matched {n} times")
+                continue
+            io.open(TARGETS[tgt], 'w', encoding='utf-8', newline='').write(
+                src.replace(old, new, 1))
+            killed, why = _run(tests)
+            io.open(TARGETS[tgt], 'w', encoding='utf-8',
+                    newline='').write(src)
+            got = 'KILLED' if killed else 'SURVIVED'
+            mark = 'ok' if got == expect else 'WRONG'
+            verdicts.append((name, got, why))
+            print(f"  {got:9}{'' if mark == 'ok' else ' WRONG'} {name} -- {why}")
+    finally:
+        for k, p in TARGETS.items():
+            io.open(p, 'w', encoding='utf-8', newline='').write(originals[k])
+
+    wrong = [v for v, (name, got, _w) in zip(rows, verdicts)
+             if got != v[5]]
+    broken = [n for n, g, _w in verdicts if g == 'BROKEN']
+    print(f"\n{len(verdicts)} row(s): "
+          f"{sum(1 for _n, g, _w in verdicts if g == 'KILLED')} killed, "
+          f"{sum(1 for _n, g, _w in verdicts if g == 'SURVIVED')} survived, "
+          f"{len(broken)} broken, {len(wrong)} disagreeing with expectation")
+    return 1 if (wrong or broken) else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/placement_ab_baseline.json
+++ b/tests/placement_ab_baseline.json
@@ -8,7 +8,9 @@
    "health_bus_foreign_crossings": 147,
    "hpwl": 7434.4,
    "intent_errors": 0,
-   "intent_errors_by_rule": {}
+   "intent_errors_by_rule": {},
+   "intent_errors_enforced": 0,
+   "intent_errors_other": 0
   },
   "on": {
    "crossings": 1370,
@@ -16,7 +18,9 @@
    "health_bus_foreign_crossings": 143,
    "hpwl": 7241.97,
    "intent_errors": 0,
-   "intent_errors_by_rule": {}
+   "intent_errors_by_rule": {},
+   "intent_errors_enforced": 0,
+   "intent_errors_other": 0
   }
  },
  "corridor-orangecrab": {
@@ -30,7 +34,9 @@
    "intent_errors": 1,
    "intent_errors_by_rule": {
     "zone_containment": 1
-   }
+   },
+   "intent_errors_enforced": 1,
+   "intent_errors_other": 0
   },
   "on": {
    "crossings": 1042,
@@ -40,7 +46,9 @@
    "intent_errors": 1,
    "intent_errors_by_rule": {
     "zone_containment": 1
-   }
+   },
+   "intent_errors_enforced": 1,
+   "intent_errors_other": 0
   }
  },
  "corridor-ulx3s": {
@@ -54,7 +62,9 @@
    "intent_errors": 4,
    "intent_errors_by_rule": {
     "zone_containment": 4
-   }
+   },
+   "intent_errors_enforced": 4,
+   "intent_errors_other": 0
   },
   "on": {
    "crossings": 2407,
@@ -64,7 +74,117 @@
    "intent_errors": 7,
    "intent_errors_by_rule": {
     "zone_containment": 7
-   }
+   },
+   "intent_errors_enforced": 7,
+   "intent_errors_other": 0
+  }
+ },
+ "intent-exclusive-coldfire": {
+  "board": "kit-dev-coldfire-xilinx_5213.kicad_pcb",
+  "mark": "regress",
+  "off": {
+   "crossings": 1379,
+   "health_block_displacement_max_mm": 55.3346,
+   "health_bus_foreign_crossings": null,
+   "hpwl": 7434.4,
+   "intent_errors": 5,
+   "intent_errors_by_rule": {
+    "zone_exclusive": 5
+   },
+   "intent_errors_enforced": 5,
+   "intent_errors_other": 0
+  },
+  "on": {
+   "crossings": 1381,
+   "health_block_displacement_max_mm": 55.3346,
+   "health_bus_foreign_crossings": null,
+   "hpwl": 7431.96,
+   "intent_errors": 5,
+   "intent_errors_by_rule": {
+    "zone_exclusive": 5
+   },
+   "intent_errors_enforced": 5,
+   "intent_errors_other": 0
+  }
+ },
+ "intent-orangecrab": {
+  "board": "orangecrab_ext_pll.kicad_pcb",
+  "mark": "improve",
+  "off": {
+   "crossings": 1063,
+   "health_block_displacement_max_mm": 18.5356,
+   "health_bus_foreign_crossings": null,
+   "hpwl": 2117.85,
+   "intent_errors": 1,
+   "intent_errors_by_rule": {
+    "zone_containment": 1
+   },
+   "intent_errors_enforced": 1,
+   "intent_errors_other": 0
+  },
+  "on": {
+   "crossings": 1053,
+   "health_block_displacement_max_mm": 18.5356,
+   "health_bus_foreign_crossings": null,
+   "hpwl": 2115.16,
+   "intent_errors": 0,
+   "intent_errors_by_rule": {},
+   "intent_errors_enforced": 0,
+   "intent_errors_other": 0
+  }
+ },
+ "intent-rp2350": {
+  "board": "rp2350_fpga_eensy_prePlane.kicad_pcb",
+  "mark": "regress",
+  "off": {
+   "crossings": 416,
+   "health_block_displacement_max_mm": 11.5626,
+   "health_bus_foreign_crossings": null,
+   "hpwl": 958.22,
+   "intent_errors": 2,
+   "intent_errors_by_rule": {
+    "zone_containment": 2
+   },
+   "intent_errors_enforced": 2,
+   "intent_errors_other": 0
+  },
+  "on": {
+   "crossings": 420,
+   "health_block_displacement_max_mm": 11.5626,
+   "health_bus_foreign_crossings": null,
+   "hpwl": 957.42,
+   "intent_errors": 1,
+   "intent_errors_by_rule": {
+    "zone_containment": 1
+   },
+   "intent_errors_enforced": 1,
+   "intent_errors_other": 0
+  }
+ },
+ "intent-ulx3s": {
+  "board": "ulx3s.kicad_pcb",
+  "mark": "regress",
+  "off": {
+   "crossings": 2477,
+   "health_block_displacement_max_mm": 17.9512,
+   "health_bus_foreign_crossings": null,
+   "hpwl": 7437.99,
+   "intent_errors": 4,
+   "intent_errors_by_rule": {
+    "zone_containment": 4
+   },
+   "intent_errors_enforced": 4,
+   "intent_errors_other": 0
+  },
+  "on": {
+   "crossings": 2491,
+   "health_block_displacement_max_mm": 19.9427,
+   "health_bus_foreign_crossings": null,
+   "hpwl": 7508.56,
+   "intent_errors": 0,
+   "intent_errors_by_rule": {},
+   "intent_errors_enforced": 0,
+   "intent_errors_other": 0
   }
  }
 }

--- a/tests/placement_ab_baseline.json
+++ b/tests/placement_ab_baseline.json
@@ -7,20 +7,16 @@
    "health_block_displacement_max_mm": 55.3346,
    "health_bus_foreign_crossings": 147,
    "hpwl": 7434.4,
-   "intent_errors": 2,
-   "intent_errors_by_rule": {
-    "block_unresolved": 2
-   }
+   "intent_errors": 0,
+   "intent_errors_by_rule": {}
   },
   "on": {
    "crossings": 1370,
    "health_block_displacement_max_mm": 54.6257,
    "health_bus_foreign_crossings": 143,
    "hpwl": 7241.97,
-   "intent_errors": 2,
-   "intent_errors_by_rule": {
-    "block_unresolved": 2
-   }
+   "intent_errors": 0,
+   "intent_errors_by_rule": {}
   }
  },
  "corridor-orangecrab": {
@@ -31,9 +27,8 @@
    "health_block_displacement_max_mm": 18.5356,
    "health_bus_foreign_crossings": 32,
    "hpwl": 2117.85,
-   "intent_errors": 7,
+   "intent_errors": 1,
    "intent_errors_by_rule": {
-    "block_unresolved": 6,
     "zone_containment": 1
    }
   },
@@ -42,9 +37,8 @@
    "health_block_displacement_max_mm": 18.8075,
    "health_bus_foreign_crossings": 31,
    "hpwl": 2113.67,
-   "intent_errors": 7,
+   "intent_errors": 1,
    "intent_errors_by_rule": {
-    "block_unresolved": 6,
     "zone_containment": 1
    }
   }
@@ -57,9 +51,8 @@
    "health_block_displacement_max_mm": 17.9512,
    "health_bus_foreign_crossings": 62,
    "hpwl": 7437.99,
-   "intent_errors": 14,
+   "intent_errors": 4,
    "intent_errors_by_rule": {
-    "block_unresolved": 10,
     "zone_containment": 4
    }
   },
@@ -68,9 +61,8 @@
    "health_block_displacement_max_mm": 18.0904,
    "health_bus_foreign_crossings": 55,
    "hpwl": 7416.23,
-   "intent_errors": 17,
+   "intent_errors": 7,
    "intent_errors_by_rule": {
-    "block_unresolved": 10,
     "zone_containment": 7
    }
   }

--- a/tests/test_549_floorplan_schema.py
+++ b/tests/test_549_floorplan_schema.py
@@ -454,10 +454,11 @@ def test_an_entry_carries_its_own_context_slot():
 def test_severity_keys_are_checked_against_the_rule_names():
     """#710: `severity` validated its VALUES and never its keys.
 
-    The vocabulary is 12 names, not the 9 in `RULES`: three findings are
+    The vocabulary is 13 names, not the 9 in `RULES`: four findings are
     raised outside the rules loop (`validate_intent` raises two,
-    `resolve_blocks` one) and an intent has always been allowed to set their
-    severity. Validating against `RULES` alone would refuse
+    `resolve_blocks` one, and `resolve_intent_gate` raises
+    `intent_zone_in_keepout` since #702) and an intent has always been allowed
+    to set their severity. Validating against `RULES` alone would refuse
     `{"block_unresolved": "warn"}`, which is legal today -- so the test
     asserts every name in the real vocabulary still loads, not just that a
     typo is refused.
@@ -474,7 +475,8 @@ def test_severity_keys_are_checked_against_the_rule_names():
     # shrinks, and passes. (It did.)
     expected = {n for n, _ in RULES} | {'intent_zone_outside_envelope',
                                         'intent_zone_overlap',
-                                        'block_unresolved'}
+                                        'block_unresolved',
+                                        'intent_zone_in_keepout'}
     assert _SEVERITY_KEYS == expected, sorted(_SEVERITY_KEYS ^ expected)
     for name in sorted(expected):
         i = intent_from_dict(_base(severity={name: WARN}))

--- a/tests/test_701_keepout_predicate.py
+++ b/tests/test_701_keepout_predicate.py
@@ -424,9 +424,15 @@ def test_the_grader_builds_a_state_that_carries_no_keepouts():
         QuenchState.__init__ = real
 
     assert built, "grade built no QuenchState"
-    leaked = [(i, len(s.keepouts_for), len(s.keepouts))
+    # #702 added a SECOND channel into the same gate (`intent_zones` ->
+    # `_intent_spec` -> `_intent_active`), and a guard that named only the
+    # #701 one would pass a grader that inherited the new half. Assert every
+    # field the gate reads, not the field that existed when this was written.
+    leaked = [(i, len(s.keepouts_for), len(s.keepouts),
+               len(s.intent_zones), len(s._intent_spec), s._intent_active)
               for i, s in enumerate(built)
-              if s.keepouts_for or s.keepouts]
+              if s.keepouts_for or s.keepouts or s.intent_zones
+              or s._intent_spec or s._intent_active]
     assert not leaked, (
         f"grade's own state(s) carry the SEAT gate: {leaked}. The grader "
         f"would then be grading the seat predicate against itself")

--- a/tests/test_702_quench_intent_gate.py
+++ b/tests/test_702_quench_intent_gate.py
@@ -1,0 +1,895 @@
+#!/usr/bin/env python3
+"""#702: the quench refuses a move that breaks a declared claim.
+
+Hand-written boards, for the reason `tests/test_701_keepout_seating.py` gives
+for its own: on a corpus board "where would this part have gone" is only
+answerable by re-running the optimizer, which makes the control circular. Here
+the geometry is small enough that the answer is a theorem.
+
+EVERY ACCEPTING ARM HAS A CONTROL. An assertion like "the part is not in the
+keep-out" is satisfied by a board where the part was never going to be in the
+keep-out, and then the test passes in both directions. So each arm that shows
+the gate doing something is paired with the same board showing the gate absent
+doing the other thing.
+
+EVERY ARM ALSO ASSERTS THE COUNTER. `metrics_out['intent_gate']['by_site']`
+says which of the three enforcement sites refused. Without it, "the gate
+refused nothing" and "this arm never reached the gate" are the same
+observation -- which is how an arm passes while testing nothing. Two of the
+mutations in `tests/mutate_702.py` are killed only by a `by_site` assertion.
+
+MEASURED MUTATION TABLE, from `python3 tests/mutate_702.py`. The edits are in
+that file; these are the verdicts, recorded FROM THE RUN and not predicted:
+
+    20 rows: 18 killed, 2 survived, 0 broken, 0 disagreeing with expectation
+
+    the two survivors, recorded rather than deleted:
+      the-gate-is-built-even-with-no-intent      building an empty spec on a
+                                                board that declares nothing is
+                                                indistinguishable from not
+                                                building one -- every lookup
+                                                misses and `intent_ok` returns
+                                                on `if not spec`.
+      the-active-flag-ignores-whether-anything-bound
+                                                same reason, one level up: the
+                                                flag only guards work that is
+                                                already a no-op on an empty
+                                                spec. Kept as a detector for
+                                                the day the guard means more.
+
+Three rows exist because a mutation caught THIS FILE, not the engine:
+`the-incumbent-is-read-at-the-SEED-pose` survived until arm C was written at
+all; `the-keepout-test-forgets-the-through-hole-rect` survived while arm J
+asserted only BINDING and never the hit test; and
+`zone_escape-grades-the-origin-not-the-centre` survived while arm E asserted
+`intent_ok` (which admits a part at its own pose by construction) instead of
+the absolute `intent_clear`. None of the three was a bug in the gate; all three
+were arms that passed without reaching what they named.
+"""
+import json
+import os
+import sys
+import tempfile
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for _p in (REPO,):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+        sys.path.insert(0, os.path.join(_p, 'py_router'))
+        sys.path.insert(0, os.path.join(_p, 'py_tools'))
+        sys.path.insert(0, os.path.join(_p, 'py_placer'))
+
+from kicad_parser import parse_kicad_pcb                        # noqa: E402
+from placement import floorplan, legality                       # noqa: E402
+from placement.quench import (QuenchState, quench,              # noqa: E402
+                              INTENT_ENFORCED_RULES)
+
+RUN_ALL_TIMEOUT = 600
+
+passed = failed = 0
+
+
+def check(name, ok, detail=""):
+    """Prints `detail` on OK and FAIL alike, so every detail must read as a
+    MEASUREMENT rather than as a failure explanation."""
+    global passed, failed
+    passed += bool(ok)
+    failed += not ok
+    print(f"  {'OK  ' if ok else 'FAIL'} {name}"
+          + (f" -- {detail}" if detail else ""))
+
+
+# --------------------------------------------------------------------------
+# fixtures -- the shape of tests/test_701_keepout_seating.py's, on purpose
+# --------------------------------------------------------------------------
+
+SIZE = (40.0, 24.0)
+
+
+def _part(ref, x, y, half_w, half_h, npads=2, layer='F.Cu', thru=False,
+          cy_off=(0.0, 0.0), fp='auto', nets=None):
+    """A footprint with a (2*half_w x 2*half_h) courtyard and `npads` pads.
+
+    `cy_off` shifts the COURTYARD off the footprint origin, which is the case
+    `floorplan.zone_escape`'s anchor branch grades on the courtyard CENTRE
+    while `seeder.zone_gate` would grade on the origin. 17 of 65 parts on
+    splitflap_driver are like this; arm N is the regression detector.
+    """
+    ox, oy = cy_off
+    # `fp` lets two refs share a FOOTPRINT NAME, which is what makes them
+    # swap-eligible (the swap phase pairs on footprint_name + side + has_tht +
+    # matching rot-0 bounds). `nets` gives them crossed nets so the swap is
+    # strictly improving and the phase actually reaches its gates.
+    fp_name = f'test:P{ref}' if fp == 'auto' else fp
+    nets = nets or tuple(1 if i == 0 else 2 for i in range(npads))
+    if thru:
+        pads = ''.join(
+            f'\t\t(pad "{i + 1}" thru_hole circle\n'
+            f'\t\t\t(at {i * 0.6 - 0.3} 0)\n'
+            f'\t\t\t(size 0.6 0.6)\n\t\t\t(drill 0.35)\n'
+            f'\t\t\t(layers "*.Cu" "*.Mask")\n'
+            f'\t\t\t(net {nets[i]} "N{nets[i]}")\n'
+            f'\t\t\t(uuid "p{i}-{ref}")\n\t\t)\n' for i in range(npads))
+    else:
+        pads = ''.join(
+            f'\t\t(pad "{i + 1}" smd rect\n'
+            f'\t\t\t(at {i * 0.2 - 0.2} 0)\n'
+            f'\t\t\t(size 0.3 0.3)\n\t\t\t(layers "{layer}")\n'
+            f'\t\t\t(net {nets[i]} "N{nets[i]}")\n'
+            f'\t\t\t(uuid "p{i}-{ref}")\n\t\t)\n' for i in range(npads))
+    return f'''\t(footprint "{fp_name}"
+\t\t(layer "{layer.split('.')[0]}.Cu")
+\t\t(uuid "fp-{ref}")
+\t\t(at {x} {y})
+\t\t(property "Reference" "{ref}"
+\t\t\t(at 0 0)
+\t\t)
+\t\t(fp_rect
+\t\t\t(start {ox - half_w} {oy - half_h})
+\t\t\t(end {ox + half_w} {oy + half_h})
+\t\t\t(layer "{layer.split('.')[0]}.CrtYd")
+\t\t\t(uuid "cy-{ref}")
+\t\t)
+{pads}\t)
+'''
+
+
+def board(path, parts, size=SIZE):
+    body = ('(kicad_pcb\n\t(version 20241229)\n'
+            '\t(net 0 "")\n'
+            + ''.join(f'\t(net {i} "N{i}")\n' for i in range(1, 9))
+            + ('\t(gr_rect\n\t\t(start 0 0)\n\t\t(end {} {})\n'
+               '\t\t(layer "Edge.Cuts")\n\t\t(uuid "e1")\n\t)\n').format(*size)
+            + ''.join(parts) + ')\n')
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(body)
+    return path
+
+
+def intent_doc(blocks=(), keepouts=(), size=SIZE):
+    d = {"schema": 1, "kind": "floorplan-intent", "units": "mm",
+         "envelope": {"rect": [0.0, 0.0, size[0], size[1]],
+                      "tolerance_mm": 0.5},
+         "blocks": [dict(b) for b in blocks]}
+    if keepouts:
+        d["keepouts"] = [dict(k) for k in keepouts]
+    return d
+
+
+def load(doc, wd, tag='fp'):
+    p = os.path.join(wd, f'{tag}.json')
+    with open(p, 'w', encoding='utf-8') as f:
+        json.dump(doc, f)
+    return floorplan.load_intent(p)
+
+
+def state_for(bpath, intent, sources=()):
+    """A QuenchState carrying the resolved gate, as `quench()` builds it."""
+    pcb = parse_kicad_pcb(bpath)
+    gate, _ = floorplan.resolve_intent_gate(intent, pcb, sources)
+    return QuenchState(pcb, bpath, 0.25, 0.55, 10.0, 0.5, 0.25, 2.0, 2.0, 2.0,
+                       0.1, 1.0, keepouts=gate['keepouts'],
+                       intent_zones=gate['zones']), gate
+
+
+def graded_errors(bpath, intent, rule=None, ref=None):
+    r = floorplan.grade(intent, parse_kicad_pcb(bpath), bpath)
+    return [v for v in r.errors
+            if (rule is None or v.rule == rule)
+            and (ref is None or v.ref == ref)]
+
+
+# --------------------------------------------------------------------------
+# arms
+# --------------------------------------------------------------------------
+
+def arm_A_nudge_gate(wd):
+    """The gate refuses a nudge out of a declared zone; without it, it goes."""
+    print("--- A: the nudge gate, and its control")
+    # U1 in a tight zone; U2 locked far east so the airwire pulls U1 east.
+    b = board(os.path.join(wd, 'a.kicad_pcb'), [
+        _part('U1', 8.0, 12.0, 1.5, 1.5),
+        _part('U2', 34.0, 12.0, 1.5, 1.5),
+    ])
+    doc = intent_doc(blocks=[{"name": "z", "refs": ["U1"],
+                              "zone": [5.0, 9.0, 11.0, 15.0],
+                              "tolerance_mm": 0.5}])
+    it = load(doc, wd, 'a')
+
+    def run(gate_on, out):
+        pcb = parse_kicad_pcb(b)
+        g = None
+        if gate_on:
+            g, _ = floorplan.resolve_intent_gate(it, pcb, ())
+        m = {}
+        pl = quench(pcb, pcb_file=b, max_displacement=12.0, step=1.0,
+                    grid_step=0.1, clearance=0.25, board_edge_clearance=0.55,
+                    crossing_penalty=10.0, length_weight=1.0, halo_base=0.5,
+                    halo_coef=0.25, halo_weight=2.0, edge_halo=2.0,
+                    edge_weight=2.0, lock_refs=['U2'], metrics_out=m,
+                    intent_gate=g, max_passes=4)
+        from placement.writer import write_placed_output
+        write_placed_output(b, out, pl)
+        return m
+
+    off = run(False, os.path.join(wd, 'a_off.kicad_pcb'))
+    on = run(True, os.path.join(wd, 'a_on.kicad_pcb'))
+
+    e_off = graded_errors(os.path.join(wd, 'a_off.kicad_pcb'), it,
+                          'zone_containment', 'U1')
+    e_on = graded_errors(os.path.join(wd, 'a_on.kicad_pcb'), it,
+                         'zone_containment', 'U1')
+    # CONTROL first: without the gate the quench must actually break the zone,
+    # or the arm below proves nothing.
+    check("control: no gate walks U1 out of its zone", len(e_off) == 1,
+          f"{len(e_off)} zone_containment error(s) without --intent")
+    check("the gate keeps U1 inside its zone", len(e_on) == 0,
+          f"{len(e_on)} zone_containment error(s) with the gate")
+    ig = on.get('intent_gate') or {}
+    check("the refusal is attributed to candidate_valid",
+          ig.get('by_site', {}).get('candidate_valid', 0) > 0,
+          f"by_site={ig.get('by_site')}")
+    check("the OFF arm built no gate at all", 'intent_gate' not in off,
+          "metrics_out carries no intent_gate key without an intent")
+
+
+def arm_B_monotone_escape(wd):
+    """A part that STARTS inside a keep-out may still leave it."""
+    print("--- B: monotone escape, and the freeze it must not cause")
+    b = board(os.path.join(wd, 'b.kicad_pcb'),
+              [_part('U1', 10.0, 12.0, 1.5, 1.5)])
+    ko = {"name": "k", "rect": [7.0, 9.0, 13.0, 15.0]}
+    it = load(intent_doc(keepouts=[ko]), wd, 'b')
+    st, _ = state_for(b, it)
+
+    p = st.parts['U1']
+    inside = st.intent_terms('U1', p.rects(10.0, 12.0, 0.0))
+    check("fixture: U1 starts INSIDE the keep-out", inside[0] > 0.0,
+          f"keepout_hit at the seed pose = {inside[0]}")
+    # A pose fully clear of the keep-out must be admitted even though the
+    # incumbent violates -- that is the whole point of the monotone rule.
+    check("a clear pose is admitted from inside the keep-out",
+          st.intent_ok('U1', 20.0, 12.0, 0.0),
+          "hit 0.0 <= incumbent, so the part can leave")
+    # And a pose that is still inside, but LESS inside, is admitted too.
+    less = st.intent_terms('U1', p.rects(12.0, 12.0, 0.0))
+    check("a strictly-less-overlapping pose is admitted",
+          less[0] < inside[0] and st.intent_ok('U1', 12.0, 12.0, 0.0),
+          f"hit {inside[0]:.2f} -> {less[0]:.2f}")
+    # A pose that goes DEEPER is refused.
+    check("a deeper pose is refused",
+          not st.intent_ok('U1', 10.0, 12.0, 90.0)
+          or st.intent_terms('U1', p.rects(10.0, 12.0, 90.0))[0] <= inside[0],
+          "no candidate may increase the overlap")
+
+
+def arm_C_ratchet(wd):
+    """The incumbent is the pose the part is IN, not the pose it started at.
+
+    Read at the seed, the rule ratchets against a fixed reference: a part that
+    legitimately left a keep-out could walk straight back in, because the seed
+    overlap is still there to be "no worse than". Found by mutation -- the
+    seed-reading mutant survived the first version of this file, which had no
+    arm for it at all.
+    """
+    print("--- C: the incumbent is the CURRENT pose, not the seed")
+    b = board(os.path.join(wd, 'c.kicad_pcb'),
+              [_part('U1', 10.0, 12.0, 1.0, 1.0)])
+    it = load(intent_doc(keepouts=[{"name": "k",
+                                    "rect": [8.0, 10.0, 12.0, 14.0]}]), wd, 'c')
+    st, _ = state_for(b, it)
+    p = st.parts['U1']
+    seed_hit = st.intent_terms('U1', p.rects(10.0, 12.0, 0.0))[0]
+    check("fixture: the SEED pose is inside the keep-out", seed_hit > 0.0,
+          f"seed overlap {seed_hit}")
+    # Walk it out, exactly as an accepted move would.
+    st.apply_move('U1', 25.0, 12.0, 0.0)
+    check("after leaving, the incumbent reads CLEAN",
+          st._incumbent_intent('U1')[0] == 0.0,
+          "the cache was invalidated by apply_move")
+    check("and it may not walk back in",
+          not st.intent_ok('U1', 10.0, 12.0, 0.0),
+          "0.0 -> overlap is a worsening, whatever the seed was")
+    # CONTROL: from the seed pose itself, that same pose IS admitted (it is
+    # the incumbent), so the refusal above is the ratchet and not the geometry.
+    st2, _ = state_for(b, it)
+    check("control: at the seed pose the same pose is admitted",
+          st2.intent_ok('U1', 10.0, 12.0, 0.0),
+          "a part is never refused for being where it already is")
+
+
+def arm_D_circle_marker(wd):
+    """`keepout_hit` reports a circle as a fabricated 1.0 marker, so the rule
+    must be `<=` and not `<` -- with `<` a part inside a circle can never move
+    at all unless it clears the whole circle in one nudge."""
+    print("--- D: the circle marker, which pins <= rather than <")
+    b = board(os.path.join(wd, 'd.kicad_pcb'), [
+        _part('U1', 12.0, 12.0, 1.0, 1.0),      # inside the circle
+        _part('U2', 30.0, 12.0, 1.0, 1.0),      # outside it
+    ])
+    it = load(intent_doc(keepouts=[{"name": "c", "circle": [12.0, 12.0, 5.0]}]),
+              wd, 'd')
+    st, _ = state_for(b, it)
+    p1 = st.parts['U1']
+    check("fixture: U1 is inside the circle",
+          st.intent_terms('U1', p1.rects(12.0, 12.0, 0.0))[0] == 1.0,
+          "the marker is exactly 1.0, not an area")
+    check("a part inside a circle may MOVE WITHIN it (1.0 <= 1.0)",
+          st.intent_ok('U1', 13.0, 12.0, 0.0),
+          "this is the assertion that fails if the rule uses `<`")
+    check("a part inside a circle may LEAVE it",
+          st.intent_ok('U1', 30.0, 20.0, 0.0), "hit 0.0")
+    # CONTROL: the part that starts OUTSIDE may not enter.
+    check("control: a part outside the circle may not ENTER it",
+          not st.intent_ok('U2', 12.0, 12.0, 0.0),
+          "0.0 -> 1.0 is refused")
+
+
+def arm_E_tolerance_and_small_zone(wd):
+    """The gate uses the grade's tolerance and the grade's small-zone branch."""
+    print("--- E: tolerance, and the spec-coordinate branch")
+    b = board(os.path.join(wd, 'e.kicad_pcb'),
+              [_part('U1', 10.0, 12.0, 2.0, 2.0)])
+    tol = 0.5
+    doc = intent_doc(blocks=[{"name": "z", "refs": ["U1"],
+                              "zone": [8.0, 10.0, 12.0, 14.0],
+                              "tolerance_mm": tol}])
+    it = load(doc, wd, 'e')
+    st, _ = state_for(b, it)
+    check("a pose tol/2 outside is admitted",
+          st.intent_ok('U1', 10.0 + tol / 2.0, 12.0, 0.0),
+          f"escape {tol/2:.2f} <= tol {tol}")
+    check("a pose 2*tol outside is refused",
+          not st.intent_ok('U1', 10.0 + 2.0 * tol, 12.0, 0.0),
+          f"escape {2*tol:.2f} > tol {tol}")
+
+    # Spec-COORDINATE zone: smaller than the courtyard, so containment falls
+    # back to the courtyard CENTRE. A gate that re-derived this as plain
+    # rect-in-rect would freeze the part everywhere.
+    b2 = board(os.path.join(wd, 'e2.kicad_pcb'),
+               [_part('U1', 10.0, 12.0, 2.0, 2.0)])
+    doc2 = intent_doc(blocks=[{"name": "z", "refs": ["U1"],
+                               "zone": [9.8, 11.8, 10.2, 12.2],
+                               "tolerance_mm": tol}])
+    it2 = load(doc2, wd, 'e2')
+    st2, _ = state_for(b2, it2)
+    spec = st2.intent_spec_for('U1')[0]
+    check("a zone smaller than the courtyard uses the anchor branch",
+          spec.anchor, "zone_fits_courtyard False -> grade the centre")
+    # `intent_clear`, NOT `intent_ok`. The monotone rule admits a part at its
+    # OWN pose by construction (candidate == incumbent), so asserting
+    # `intent_ok` here is satisfied by any anchor semantics at all -- measured:
+    # the mutation that makes the anchor branch grade the whole courtyard
+    # survived this arm until it asserted the ABSOLUTE predicate.
+    check("the part is CLEAN at its own pose under the anchor rule",
+          st2.intent_clear('U1', st2.parts['U1'].rects(10.0, 12.0, 0.0)),
+          "a whole-courtyard rule would score this 1.8mm outside a 0.5mm tol")
+    # And the anchor measurement is the courtyard CENTRE, which for an OFFSET
+    # courtyard is not the footprint origin -- the distinction `zone_escape`'s
+    # docstring exists for.
+    off_b = board(os.path.join(wd, 'e3.kicad_pcb'),
+                  [_part('U1', 10.0, 12.0, 1.0, 1.0, cy_off=(1.5, 0.0))])
+    off_it = load(intent_doc(blocks=[{"name": "z", "refs": ["U1"],
+                                      "zone": [11.3, 11.8, 11.7, 12.2],
+                                      "tolerance_mm": 0.1}]), wd, 'e3')
+    off_st, _ = state_for(off_b, off_it)
+    check("the anchor measures the courtyard CENTRE, not the origin",
+          off_st.intent_clear('U1', off_st.parts['U1'].rects(10.0, 12.0, 0.0)),
+          "centre is x=11.5 (inside 11.3..11.7); the origin x=10.0 is not")
+
+
+def arm_K_zone_exclusive(wd):
+    """A stranger may not intrude on a reserved zone; a member may."""
+    print("--- K: zone_exclusive, and its membership control")
+    b = board(os.path.join(wd, 'k.kicad_pcb'), [
+        _part('U1', 10.0, 12.0, 1.5, 1.5),      # the member
+        _part('R1', 30.0, 12.0, 1.5, 1.5),      # the stranger
+    ])
+    zone = [6.0, 8.0, 14.0, 16.0]
+    it = load(intent_doc(blocks=[{"name": "rf", "refs": ["U1"], "zone": zone,
+                                  "exclusive": True, "tolerance_mm": 0.5}]),
+              wd, 'k')
+    st, _ = state_for(b, it)
+    check("a non-member may not intrude on the exclusive zone",
+          not st.intent_ok('R1', 10.0, 12.0, 0.0),
+          "overlap > EPS is refused")
+    # CONTROL: make it a member and the same pose is fine.
+    it2 = load(intent_doc(blocks=[{"name": "rf", "refs": ["U1", "R1"],
+                                   "zone": zone, "exclusive": True,
+                                   "tolerance_mm": 0.5}]), wd, 'k2')
+    st2, _ = state_for(b, it2)
+    check("control: a MEMBER at the same pose is admitted",
+          st2.intent_ok('R1', 10.0, 12.0, 0.0),
+          "rule_zone_exclusive skips members, and so does the gate")
+
+
+def arm_J_tht_other_side(wd):
+    """A through-hole part is in a keep-out from either side."""
+    print("--- J: through-hole from the far side, and its SMD control")
+    b = board(os.path.join(wd, 'j.kicad_pcb'), [
+        _part('T1', 10.0, 12.0, 1.0, 1.0, layer='B.Cu', thru=True),
+        _part('S1', 10.0, 12.0, 1.0, 1.0, layer='B.Cu'),
+    ])
+    it = load(intent_doc(keepouts=[{"name": "f", "rect": [7.0, 9.0, 13.0, 15.0],
+                                    "sides": ["F"]}]), wd, 'j')
+    st, _ = state_for(b, it)
+    check("an F-side keep-out binds a B-side THROUGH-HOLE part",
+          bool(st.intent_spec_for('T1')),
+          "its leads pass through, so it occupies both faces")
+    check("control: an F-side keep-out does NOT bind a B-side SMD part",
+          not st.intent_spec_for('S1'),
+          "sides_occupied is {B} -- no overlap with the keep-out's faces")
+
+    # BINDING is not the same as MEASURING. The hit test must see the drilled
+    # rect too, or a part whose BODY clears the keep-out while its LEADS do not
+    # is admitted -- and `rule_keepout` grades both, so the gate and the grade
+    # would disagree. Found by mutation: dropping tht_rect from the hit test
+    # survived the first version of this arm, which asserted only binding.
+    b2 = board(os.path.join(wd, 'j2.kicad_pcb'),
+               [_part('T2', 10.0, 12.0, 0.35, 0.35, npads=4,
+                      layer='B.Cu', thru=True)])
+    it2 = load(intent_doc(keepouts=[{"name": "leads",
+                                     "rect": [10.4, 11.0, 14.0, 13.0],
+                                     "sides": ["F"]}]), wd, 'j2')
+    st2, _ = state_for(b2, it2)
+    p2 = st2.parts['T2']
+    body, leads = p2.rects(10.0, 12.0, 0.0)
+    over_body = legality.rect_overlap_area(body, (10.4, 11.0, 14.0, 13.0))
+    over_leads = legality.rect_overlap_area(leads, (10.4, 11.0, 14.0, 13.0))
+    check("fixture: the BODY clears the keep-out but the LEADS do not",
+          over_body <= legality.EPS < over_leads,
+          f"courtyard overlap {over_body:.3f}, drilled-rect overlap {over_leads:.3f}")
+    check("the gate measures the drilled rect, not just the courtyard",
+          st2.intent_terms('T2', (body, leads))[0] > 0.0,
+          "keepout_hit is given BOTH rects, as rule_keepout grades both")
+    check("and the grade agrees at that pose",
+          bool(graded_errors(b2, it2, 'keepout', 'T2')),
+          "gate and grade see the same violation")
+
+
+def arm_P_two_keepouts(wd):
+    """One term per (ref, ENTRY): a part in K1 may not hop into K2."""
+    print("--- P: per-entry indexing, which a per-rule gate would admit")
+    b = board(os.path.join(wd, 'p.kicad_pcb'),
+              [_part('U1', 8.0, 12.0, 1.0, 1.0)])
+    kos = [{"name": "k1", "rect": [6.0, 10.0, 10.0, 14.0]},
+           {"name": "k2", "rect": [20.0, 10.0, 24.0, 14.0]}]
+    it = load(intent_doc(keepouts=kos), wd, 'p')
+    st, _ = state_for(b, it)
+    p = st.parts['U1']
+    check("fixture: U1 has TWO terms, one per keep-out",
+          len(st.intent_spec_for('U1')) == 2,
+          f"{[t.name for t in st.intent_spec_for('U1')]}")
+    here = st.intent_terms('U1', p.rects(8.0, 12.0, 0.0))
+    check("fixture: U1 starts in k1 and not k2",
+          here[0] > 0.0 and here[1] == 0.0, f"terms={here}")
+    check("U1 may NOT hop from k1 into k2",
+          not st.intent_ok('U1', 22.0, 12.0, 0.0),
+          "k2 would go 0.0 -> hit, which no k1 improvement may pay for")
+    check("control: U1 MAY move to clear ground",
+          st.intent_ok('U1', 15.0, 12.0, 0.0), "both terms 0.0")
+
+    # And the same for two CIRCLES, where both values are the 1.0 marker and a
+    # per-rule max() would read the hop as 1.0 -> 1.0 and admit it.
+    it2 = load(intent_doc(keepouts=[
+        {"name": "c1", "circle": [8.0, 12.0, 3.0]},
+        {"name": "c2", "circle": [24.0, 12.0, 3.0]}]), wd, 'p2')
+    st2, _ = state_for(b, it2)
+    check("two CIRCLES: the 1.0 -> 1.0 hop is refused too",
+          not st2.intent_ok('U1', 24.0, 12.0, 0.0),
+          "the marker is per-entry, so c2 still goes 0.0 -> 1.0")
+
+
+def _quench_to(bpath, out, intent, wd, **kw):
+    """Run a quench with or without the gate; return (metrics, out path)."""
+    from placement.writer import write_placed_output
+    pcb = parse_kicad_pcb(bpath)
+    g = None
+    if intent is not None:
+        g, _ = floorplan.resolve_intent_gate(intent, pcb, ())
+    m = {}
+    base = dict(max_displacement=14.0, step=1.0, grid_step=0.1,
+                clearance=0.25, board_edge_clearance=0.55,
+                crossing_penalty=10.0, length_weight=1.0, halo_base=0.5,
+                halo_coef=0.25, halo_weight=2.0, edge_halo=2.0,
+                edge_weight=2.0, max_passes=4)
+    base.update(kw)
+    pl = quench(pcb, pcb_file=bpath, metrics_out=m, intent_gate=g, **base)
+    write_placed_output(bpath, out, pl)
+    return m, out
+
+
+def arm_F_swap_hole(wd):
+    """The SWAP phase reaches `candidate_valid` on no path, so it needs its
+    own conjunct. Two same-footprint parts with crossed nets swap unless the
+    declared intent forbids the destination."""
+    print("--- F: the swap phase, which candidate_valid never sees")
+    # A1 (net 3) belongs beside its partner in the east; A2 (net 4) beside
+    # its partner in the west. So the swap is strictly improving.
+    parts = [
+        _part('A1', 10.0, 12.0, 1.0, 1.0, fp='test:SWAP', nets=(3, 3)),
+        _part('A2', 30.0, 12.0, 1.0, 1.0, fp='test:SWAP', nets=(4, 4)),
+        _part('E1', 36.0, 12.0, 1.0, 1.0, nets=(3, 3)),
+        _part('W1', 4.0, 12.0, 1.0, 1.0, nets=(4, 4)),
+    ]
+    b = board(os.path.join(wd, 'f.kicad_pcb'), parts)
+    # A keep-out over A2's pose: swapping would put A1 there.
+    it = load(intent_doc(keepouts=[{"name": "east",
+                                    "rect": [28.0, 10.0, 32.0, 14.0],
+                                    "allow": ["A2", "E1", "W1"]}]), wd, 'f')
+
+    def poses(path):
+        pcb = parse_kicad_pcb(path)
+        return {r: (round(f.x, 2), round(f.y, 2))
+                for r, f in pcb.footprints.items()}
+
+    seed = poses(b)
+    # The cap must exceed the pair's separation (20mm) or the swap phase
+    # skips the pair at `swaps_skipped` BEFORE reaching the intent conjunct --
+    # measured: at the default 14mm cap this arm passed its behavioural
+    # assertion with by_site={}, i.e. the nudge gate refused the pose and the
+    # swap gate was never exercised at all. That is the vacuity the counter
+    # exists to catch, and it caught it here first.
+    m_off, p_off = _quench_to(b, os.path.join(wd, 'f_off.kicad_pcb'), None, wd,
+                              max_displacement=25.0,
+                              lock_refs=['E1', 'W1'], allow_rotations=False)
+    m_on, p_on = _quench_to(b, os.path.join(wd, 'f_on.kicad_pcb'), it, wd,
+                            max_displacement=25.0,
+                            lock_refs=['E1', 'W1'], allow_rotations=False)
+    off, on = poses(p_off), poses(p_on)
+    swapped_off = off['A1'][0] > off['A2'][0]
+    # CONTROL: without the gate the exchange happens.
+    check("control: without the gate A1 and A2 exchange sides", swapped_off,
+          f"A1 {seed['A1'][0]} -> {off['A1'][0]}, A2 {seed['A2'][0]} -> {off['A2'][0]}")
+    check("with the gate A1 never lands in the keep-out",
+          not (28.0 <= on['A1'][0] <= 32.0),
+          f"A1 at x={on['A1'][0]} (keep-out spans 28..32)")
+    check("and the grade agrees the board is clean",
+          not graded_errors(p_on, it, 'keepout'),
+          "0 keepout error(s) on the written board")
+
+    # The behavioural arm above cannot prove WHICH site refused: on this
+    # fixture the nudge phase reaches the pose first, and `by_site` came back
+    # {'candidate_valid': 75, } with swap never exercised. So the swap site is
+    # tested two ways that do not depend on the swap happening to be the
+    # winning move.
+    #
+    # (1) the predicate itself, with a control.
+    st, _ = state_for(b, it)
+    check("swap_intent_ok refuses an exchange INTO a bound keep-out",
+          not st.swap_intent_ok('A1', 'A2'),
+          "A1 at A2's pose lands in 'east', which does not allow A1")
+    it_all = load(intent_doc(keepouts=[{"name": "east",
+                                        "rect": [28.0, 10.0, 32.0, 14.0],
+                                        "allow": ["*"]}]), wd, 'f_all')
+    st_all, _ = state_for(b, it_all)
+    check("control: with allow ['*'] the same exchange is permitted",
+          st_all.swap_intent_ok('A1', 'A2'),
+          "the allow GLOB is honoured, so this is the keep-out and not the pair")
+    check("it binds each part to ITS OWN claims at the partner's pose",
+          st.intent_ok('A2', *[getattr(st.parts['A1'], k)
+                               for k in ('x', 'y', 'rot')]),
+          "A2 is exempt by `allow`, so its half of the swap is fine; "
+          "the refusal above is A1's half alone")
+
+    # (2) reachability: the phase must actually CALL it. Counted rather than
+    # inferred, because a conjunct the swap loop never reaches is a conjunct
+    # that ships inert -- which is what the first version of this arm did.
+    import placement.quench as q
+    calls = []
+    orig = q.QuenchState.swap_intent_ok
+
+    def counting(self, ra, rb):
+        calls.append((ra, rb))
+        return orig(self, ra, rb)
+    q.QuenchState.swap_intent_ok = counting
+    try:
+        _quench_to(b, os.path.join(wd, 'f_reach.kicad_pcb'), it, wd,
+                   max_displacement=25.0, lock_refs=['E1', 'W1'],
+                   allow_rotations=False)
+    finally:
+        q.QuenchState.swap_intent_ok = orig
+    check("the swap phase reaches the conjunct at all", bool(calls),
+          f"{len(calls)} swap pair(s) tested, e.g. {calls[0] if calls else '-'}")
+
+
+def arm_H_group_path(wd):
+    """The rigid-block phase gates through `group_move_valid` ->
+    `candidate_valid`, so it inherits the conjunct -- but it must not be
+    frozen outright."""
+    print("--- H: the rigid-group path, and the freeze it must not cause")
+    parts = [_part('G1', 8.0, 12.0, 1.0, 1.0, nets=(3, 3)),
+             _part('G2', 11.0, 12.0, 1.0, 1.0, nets=(3, 3)),
+             _part('E1', 36.0, 12.0, 1.0, 1.0, nets=(3, 3))]
+    b = board(os.path.join(wd, 'h.kicad_pcb'), parts)
+    blocks = {'blk': ['G1', 'G2']}
+    zone = [4.0, 8.0, 16.0, 16.0]
+    it = load(intent_doc(blocks=[{"name": "blk", "refs": ["G1", "G2"],
+                                  "zone": zone, "tolerance_mm": 0.5}]),
+              wd, 'h')
+    m_off, p_off = _quench_to(b, os.path.join(wd, 'h_off.kicad_pcb'), None, wd,
+                              groups=blocks, lock_refs=['E1'])
+    m_on, p_on = _quench_to(b, os.path.join(wd, 'h_on.kicad_pcb'), it, wd,
+                            groups=blocks, lock_refs=['E1'])
+    e_off = graded_errors(p_off, it, 'zone_containment')
+    e_on = graded_errors(p_on, it, 'zone_containment')
+    check("control: without the gate the block leaves its zone",
+          len(e_off) > 0, f"{len(e_off)} zone_containment error(s)")
+    check("with the gate the block stays inside its zone", not e_on,
+          f"{len(e_on)} zone_containment error(s)")
+    # And it must not be frozen: a translate that STAYS inside is still taken.
+    pcb_on = parse_kicad_pcb(p_on)
+    moved = any(abs(pcb_on.footprints[r].x - {'G1': 8.0, 'G2': 11.0}[r]) > 1e-9
+                for r in ('G1', 'G2'))
+    check("the gate does not freeze the group phase outright", moved,
+          "at least one member still moved inside its zone")
+
+
+def arm_I_unfreeze_branch(wd):
+    """`candidate_valid`'s #456 escape lets an OFF-BOARD part move toward the
+    board even when the pose is otherwise illegal. The intent conjunct sits
+    ABOVE that branch and must dominate it."""
+    print("--- I: the off-board escape branch, which must not be a loophole")
+    # U1 sits off the west edge. A keep-out covers the board interior it would
+    # come home into -- but NOT U1's own pose, or the incumbent would already
+    # violate and the arm would pass for the wrong reason.
+    b = board(os.path.join(wd, 'i.kicad_pcb'),
+              [_part('U1', -3.0, 12.0, 1.0, 1.0),
+               _part('E1', 36.0, 12.0, 1.0, 1.0)])
+    ko = {"name": "mid", "rect": [2.0, 6.0, 30.0, 18.0]}
+    it = load(intent_doc(keepouts=[ko]), wd, 'i')
+    st, _ = state_for(b, it)
+    p = st.parts['U1']
+    check("fixture: U1's OWN pose is clear of the keep-out",
+          st.intent_terms('U1', p.rects(-3.0, 12.0, 0.0))[0] == 0.0,
+          "so the incumbent is clean and the gate is live for it")
+    check("fixture: U1 is genuinely off the board",
+          st.violation('U1') > 0.0, f"violation={st.violation('U1'):.2f}")
+    # The #456 branch would admit a pose that improves the board term. The
+    # intent conjunct must refuse it anyway, because it enters the keep-out.
+    check("a homeward pose INSIDE the keep-out is refused",
+          not st.candidate_valid('U1', 5.0, 12.0, 0.0),
+          "the escape branch does not launder a declared claim")
+    # CONTROL: with no keep-out the same pose IS admitted by the #456 branch.
+    st2 = QuenchState(parse_kicad_pcb(b), b, 0.25, 0.55, 10.0, 0.5, 0.25, 2.0,
+                      2.0, 2.0, 0.1, 1.0)
+    check("control: without the keep-out the same pose is admitted",
+          st2.candidate_valid('U1', 5.0, 12.0, 0.0),
+          "so the refusal above is the gate, not the geometry")
+
+
+def arm_Q_census_lift(wd):
+    """#701's census must still be able to LIFT a keep-out through this gate.
+
+    `seeder.count_legal_poses` answers "how many seats would lifting keep-out X
+    free" by removing X from `state.keepouts_for[ref]` and recounting. The
+    recount goes `pose_ok` -> `candidate_valid` -> `intent_ok`, so if the gate
+    reads a FROZEN copy of the keep-outs the lift is silently defeated and the
+    census reports 0 freed poses -- which degrades a stranded part's verdict
+    from `keepout_blocks` to `no_movable_neighbour`, whose prose is verbatim
+    the misleading answer that whole disclosure exists to replace.
+
+    Measured while the slice was frozen: lifted went 64 -> 0.
+    """
+    print("--- Q: the #701 census lift still reaches through the gate")
+    from placement import seeder
+    b = board(os.path.join(wd, 'q.kicad_pcb'),
+              [_part('U1', 30.0, 12.0, 1.0, 1.0)])
+    ko = {"name": "hot", "rect": [4.0, 8.0, 16.0, 16.0]}
+    it = load(intent_doc(keepouts=[ko]), wd, 'q')
+    st, _ = state_for(b, it)
+    # Count seats in the keep-out's own area: zero with it, many without.
+    kw = dict(radius=3.0, step=1.0, rotations=(0.0,), cap=400)
+    bound = seeder.count_legal_poses(st, 'U1', 10.0, 12.0, set(), **kw)
+    lifted = seeder.count_legal_poses(st, 'U1', 10.0, 12.0, set(),
+                                      without_keepouts=('hot',), **kw)
+    check("with the keep-out bound, the census finds no seat there",
+          bound == 0, f"bound={bound}")
+    check("lifting it frees seats -- the lift reaches the gate",
+          lifted > 0, f"lifted={lifted}")
+    check("and the keep-out is restored afterwards",
+          st.keepouts_for.get('U1') and
+          st.keepouts_for['U1'][0]['name'] == 'hot',
+          "count_legal_poses put it back")
+
+    # TWO keep-outs, because the one-keep-out case is not discriminating: with
+    # a single entry the lift DELETES `keepouts_for[ref]` entirely, so even a
+    # gate that ignored the filtered list and read the raw `self.keepouts`
+    # would come back empty and look correct. Measured -- that mutation
+    # survived the single-keep-out arm. With two, lifting one must leave the
+    # other, which only a gate reading the LIFTED list can get right.
+    b2 = board(os.path.join(wd, 'q2.kicad_pcb'),
+               [_part('U1', 34.0, 20.0, 1.0, 1.0)])
+    it2 = load(intent_doc(keepouts=[
+        {"name": "hot", "rect": [4.0, 8.0, 16.0, 16.0]},
+        {"name": "cold", "rect": [20.0, 2.0, 26.0, 6.0]}]), wd, 'q2')
+    st2, _ = state_for(b2, it2)
+    both = seeder.count_legal_poses(st2, 'U1', 10.0, 12.0, set(), **kw)
+    one = seeder.count_legal_poses(st2, 'U1', 10.0, 12.0, set(),
+                                   without_keepouts=('hot',), **kw)
+    check("with two keep-outs, lifting one still frees its area",
+          both == 0 and one > 0, f"both={both}, hot lifted={one}")
+    check("and the OTHER keep-out survives the lift",
+          len(st2.keepouts_for.get('U1', ())) == 2,
+          "restored to both entries")
+
+
+def arm_L_inertness(wd):
+    """With no intent the gate is UNREACHABLE, not merely quiet."""
+    print("--- L: inertness, proven by poison rather than by output")
+    b = board(os.path.join(wd, 'l.kicad_pcb'), [
+        _part('U1', 10.0, 12.0, 1.5, 1.5),
+        _part('U2', 30.0, 12.0, 1.5, 1.5),
+    ])
+    pcb = parse_kicad_pcb(b)
+    st = QuenchState(pcb, b, 0.25, 0.55, 10.0, 0.5, 0.25, 2.0, 2.0, 2.0,
+                     0.1, 1.0)
+    check("a state with no intent binds nothing",
+          not st._intent_active and st._intent_spec == {},
+          "_intent_active False, _intent_spec empty")
+
+    # The poison arm: if the gate were reachable at all, this raises.
+    import placement.quench as q
+    orig = q.QuenchState.intent_ok
+
+    def poison(self, *a, **kw):
+        raise AssertionError("the intent gate was reached with no intent")
+    q.QuenchState.intent_ok = poison
+    try:
+        m = {}
+        quench(parse_kicad_pcb(b), pcb_file=b, max_displacement=3.0, step=1.0,
+               grid_step=0.1, clearance=0.25, board_edge_clearance=0.55,
+               crossing_penalty=10.0, length_weight=1.0, halo_base=0.5,
+               halo_coef=0.25, halo_weight=2.0, edge_halo=2.0, edge_weight=2.0,
+               metrics_out=m, max_passes=2)
+        ok, why = True, "a full quench completed with intent_ok poisoned"
+    except AssertionError as exc:
+        ok, why = False, str(exc)
+    finally:
+        q.QuenchState.intent_ok = orig
+    check("a no-intent quench never calls the gate", ok, why)
+    check("and reports no intent_gate metrics", 'intent_gate' not in m,
+          "the key is absent, not zero -- 'no gate' != 'refused nothing'")
+
+
+def arm_M_enforced_tuple(wd):
+    """The enforced set is pinned in BOTH directions."""
+    print("--- M: INTENT_ENFORCED_RULES, pinned both ways")
+    expect = {'zone_containment', 'zone_exclusive', 'keepout'}
+    check("the engine enforces exactly the three declared rules",
+          set(INTENT_ENFORCED_RULES) == expect,
+          f"{sorted(INTENT_ENFORCED_RULES)}")
+    # Every enforced rule must be reachable by an arm above, or the tuple is
+    # advertising something no test exercises.
+    covered = {'zone_containment': 'A/E', 'zone_exclusive': 'K',
+               'keepout': 'B/D/J/P'}
+    check("every enforced rule has an arm in this file",
+          set(covered) == set(INTENT_ENFORCED_RULES),
+          ", ".join(f"{r}:{a}" for r, a in sorted(covered.items())))
+    # And they are all real floorplan rules, not invented names.
+    names = {n for n, _ in floorplan.RULES}
+    check("every enforced name is a real floorplan rule",
+          set(INTENT_ENFORCED_RULES) <= names,
+          f"RULES has {len(names)} names")
+
+
+def arm_N_gate_vs_grade(wd):
+    """The gate's clean verdict and the grade's agree, over a pose lattice.
+
+    Includes a part whose courtyard CENTRE is offset from its footprint
+    origin: `seeder.zone_gate`'s anchor branch tests the origin and the grade
+    tests the centre, so a gate built on the seeder's predicate disagrees here
+    by up to the offset. This is the regression detector for that.
+    """
+    print("--- N: gate-vs-grade agreement over a lattice")
+    # The third case is the one that matters and the one the first version of
+    # this arm missed: a zone SMALLER than the courtyard forces the ANCHOR
+    # branch, and an offset courtyard makes the origin and the centre disagree.
+    # With only the two large-zone cases, `zone_escape` grading the origin
+    # instead of the centre survived mutation -- the anchor branch was never
+    # taken at all.
+    cases = (('centred', (0.0, 0.0), [7.0, 9.0, 13.0, 15.0]),
+             ('offset-courtyard', (1.5, 0.0), [7.0, 9.0, 13.0, 15.0]),
+             ('offset-ANCHOR-branch', (1.5, 0.0), [9.8, 11.8, 10.2, 12.2]))
+    for tag, off, zrect in cases:
+        b = board(os.path.join(wd, f'n_{tag}.kicad_pcb'),
+                  [_part('U1', 10.0, 12.0, 1.0, 1.0, cy_off=off)])
+        doc = intent_doc(blocks=[{"name": "z", "refs": ["U1"],
+                                  "zone": zrect, "tolerance_mm": 0.5}])
+        it = load(doc, wd, f'n_{tag}')
+        st, _ = state_for(b, it)
+        p = st.parts['U1']
+        disagree = []
+        for dx in range(-6, 7):
+            for dy in range(-4, 5):
+                x, y = 10.0 + dx, 12.0 + dy
+                gate_clean = st.intent_clear('U1', p.rects(x, y, 0.0))
+                # Move the part there and ask the GRADE.
+                moved = board(os.path.join(wd, f'n_probe_{tag}.kicad_pcb'),
+                              [_part('U1', x, y, 1.0, 1.0, cy_off=off)])
+                grade_clean = not graded_errors(moved, it, 'zone_containment')
+                if gate_clean != grade_clean:
+                    disagree.append((x, y, gate_clean, grade_clean))
+        anchor = st.intent_spec_for('U1')[0].anchor
+        check(f"{tag}: gate and grade agree on every pose in the lattice",
+              not disagree,
+              f"117 poses, anchor={anchor}, {len(disagree)} disagreement(s)"
+              + (f" e.g. {disagree[0]}" if disagree else ""))
+
+
+def arm_O_crossed_claims(wd):
+    """A zone a keep-out swallows whole is refused where it is AUTHORED."""
+    print("--- O: the crossed-claim contradiction, refused at resolve time")
+    b = board(os.path.join(wd, 'o.kicad_pcb'),
+              [_part('U1', 10.0, 12.0, 1.0, 1.0)])
+    zone = [8.0, 10.0, 12.0, 14.0]
+    swallow = {"name": "big", "rect": [6.0, 8.0, 14.0, 16.0]}
+    partial = {"name": "corner", "rect": [11.0, 13.0, 20.0, 20.0]}
+    blocks = [{"name": "z", "refs": ["U1"], "zone": zone,
+               "tolerance_mm": 0.5}]
+
+    pcb = parse_kicad_pcb(b)
+    it_bad = load(intent_doc(blocks=blocks, keepouts=[swallow]), wd, 'o_bad')
+    _, probs = floorplan.resolve_intent_gate(it_bad, pcb, ())
+    named = [v for v in probs if v.rule == 'intent_zone_in_keepout']
+    check("a keep-out swallowing a zone is reported by name",
+          len(named) == 1 and 'big' in named[0].message,
+          named[0].message[:80] if named else "no finding raised")
+
+    # CONTROL: a PARTIAL overlap is a legitimate intent -- a zone with a corner
+    # bitten out still has room, and refusing it would be the gate inventing a
+    # rule the grade does not have.
+    it_ok = load(intent_doc(blocks=blocks, keepouts=[partial]), wd, 'o_ok')
+    _, probs2 = floorplan.resolve_intent_gate(it_ok, pcb, ())
+    check("control: a PARTIAL overlap is not reported",
+          not [v for v in probs2 if v.rule == 'intent_zone_in_keepout'],
+          f"{len(probs2)} problem(s), none of them the contradiction")
+    # The two filters `keepouts_for_ref` centralizes. A keep-out that does not
+    # BIND the block's members cannot contradict their zone, and reporting it
+    # is a false ERROR on an intent the grade calls clean. Both measured as
+    # false positives before the check consulted them.
+    for tag, ko, blks in (
+            ('sides', dict(swallow, sides=["B"]), blocks),
+            ('allow', dict(swallow, allow=["U1"]), blocks)):
+        it_x = load(intent_doc(blocks=blks, keepouts=[ko]), wd, f'o_{tag}')
+        _, px = floorplan.resolve_intent_gate(it_x, pcb, ())
+        named_x = [v for v in px if v.rule == 'intent_zone_in_keepout']
+        bound = floorplan.keepouts_for_ref((ko,), 'U1', frozenset({'F'}))
+        check(f"a keep-out exempt by `{tag}` raises no contradiction",
+              not named_x,
+              f"keepouts_for_ref binds {len(bound)} entry(ies), "
+              f"{len(named_x)} contradiction(s) raised")
+
+    check("the finding's severity is settable like any other",
+          floorplan.intent_from_dict(
+              intent_doc(blocks=blocks,
+                         keepouts=[swallow])
+              | {"severity": {"intent_zone_in_keepout": "warn"}}
+          ).severity_of('intent_zone_in_keepout') == 'warn',
+          "registered in _NON_RULE_SEVERITIES")
+
+
+def main():
+    with tempfile.TemporaryDirectory() as wd:
+        arm_A_nudge_gate(wd)
+        arm_B_monotone_escape(wd)
+        arm_C_ratchet(wd)
+        arm_D_circle_marker(wd)
+        arm_E_tolerance_and_small_zone(wd)
+        arm_K_zone_exclusive(wd)
+        arm_J_tht_other_side(wd)
+        arm_P_two_keepouts(wd)
+        arm_F_swap_hole(wd)
+        arm_H_group_path(wd)
+        arm_I_unfreeze_branch(wd)
+        arm_Q_census_lift(wd)
+        arm_L_inertness(wd)
+        arm_M_enforced_tuple(wd)
+        arm_N_gate_vs_grade(wd)
+        arm_O_crossed_claims(wd)
+    print(f"\n{passed}/{passed + failed} checks passed")
+    return 1 if failed else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_702_quench_intent_gate.py
+++ b/tests/test_702_quench_intent_gate.py
@@ -21,7 +21,7 @@ mutations in `tests/mutate_702.py` are killed only by a `by_site` assertion.
 MEASURED MUTATION TABLE, from `python3 tests/mutate_702.py`. The edits are in
 that file; these are the verdicts, recorded FROM THE RUN and not predicted:
 
-    20 rows: 18 killed, 2 survived, 0 broken, 0 disagreeing with expectation
+    22 rows: 19 killed, 3 survived, 0 broken, 0 disagreeing with expectation
 
     the two survivors, recorded rather than deleted:
       the-gate-is-built-even-with-no-intent      building an empty spec on a
@@ -36,6 +36,11 @@ that file; these are the verdicts, recorded FROM THE RUN and not predicted:
                                                 already a no-op on an empty
                                                 spec. Kept as a detector for
                                                 the day the guard means more.
+      the-swallow-test-ignores-the-tolerance    no arm builds a zone whose
+                                                tolerance band reaches outside
+                                                its keep-out; the row is here
+                                                so the guard exists the day one
+                                                does.
 
 Three rows exist because a mutation caught THIS FILE, not the engine:
 `the-incumbent-is-read-at-the-SEED-pose` survived until arm C was written at
@@ -669,7 +674,11 @@ def arm_Q_census_lift(wd):
     from `keepout_blocks` to `no_movable_neighbour`, whose prose is verbatim
     the misleading answer that whole disclosure exists to replace.
 
-    Measured while the slice was frozen: lifted went 64 -> 0.
+    Measured on THIS fixture while the slice was frozen: lifted 49 -> 0.
+    (An earlier draft of this docstring said 64. That number came from a
+    verifier's terminal and was republished here without re-deriving it --
+    and 64 is exactly `seeder.CENSUS_CAP`, i.e. a SATURATED count rather
+    than a count of freed seats. The arm prints its own numbers now.)
     """
     print("--- Q: the #701 census lift still reaches through the gate")
     from placement import seeder
@@ -750,6 +759,60 @@ def arm_L_inertness(wd):
     check("a no-intent quench never calls the gate", ok, why)
     check("and reports no intent_gate metrics", 'intent_gate' not in m,
           "the key is absent, not zero -- 'no gate' != 'refused nothing'")
+
+
+def arm_R_metrics_see_keepouts(wd):
+    """`refs_bound` and `rules_enforced` must see the KEEP-OUT slice.
+
+    Both were derived from `_intent_spec`, which holds zone terms only -- the
+    keep-out slice is live so #701's census lift works -- so a keep-out-ONLY
+    intent, the exact shape #701 exists for, reported `refs_bound: 0,
+    rules_enforced: []` while refusing hundreds of poses. `place_optimize`
+    then printed the self-contradictory "enforced  over 0 bound part(s);
+    refused N candidate pose(s)" and shipped it in JSON_SUMMARY.
+    """
+    print("--- R: the metrics see keep-outs, not just zones")
+    b = board(os.path.join(wd, 'r.kicad_pcb'), [
+        _part('U1', 10.0, 12.0, 1.5, 1.5),
+        _part('U2', 30.0, 12.0, 1.5, 1.5),
+    ])
+    it = load(intent_doc(keepouts=[{"name": "mid",
+                                    "rect": [14.0, 6.0, 26.0, 18.0]}]), wd, 'r')
+    pcb = parse_kicad_pcb(b)
+    g, _ = floorplan.resolve_intent_gate(it, pcb, ())
+    check("fixture: the intent declares a keep-out and NO zone",
+          not g['zones'] and len(g['keepouts']) == 1,
+          f"{len(g['zones'])} zone(s), {len(g['keepouts'])} keep-out(s)")
+    m = {}
+    quench(pcb, pcb_file=b, max_displacement=14.0, step=1.0, grid_step=0.1,
+           clearance=0.25, board_edge_clearance=0.55, crossing_penalty=10.0,
+           length_weight=1.0, halo_base=0.5, halo_coef=0.25, halo_weight=2.0,
+           edge_halo=2.0, edge_weight=2.0, metrics_out=m, intent_gate=g,
+           max_passes=2)
+    ig = m.get('intent_gate') or {}
+    check("refs_bound counts the keep-out-bound parts",
+          ig.get('refs_bound', 0) > 0, f"refs_bound={ig.get('refs_bound')}")
+    check("rules_enforced names 'keepout'",
+          'keepout' in (ig.get('rules_enforced') or []),
+          f"rules_enforced={ig.get('rules_enforced')}")
+    check("and a refusal is attributed to it",
+          ig.get('rejected', 0) > 0 and 'keepout' in (ig.get('by_rule') or {}),
+          f"rejected={ig.get('rejected')} by_rule={ig.get('by_rule')}")
+
+    # A gate that BINDS NOTHING must still report, or "refused nothing" and
+    # "never wired" collapse together again -- in the case that matters most.
+    it2 = load(intent_doc(keepouts=[{"name": "x", "rect": [1.0, 1.0, 2.0, 2.0],
+                                     "allow": ["*"]}]), wd, 'r2')
+    g2, _ = floorplan.resolve_intent_gate(it2, pcb, ())
+    m2 = {}
+    quench(parse_kicad_pcb(b), pcb_file=b, max_displacement=3.0, step=1.0,
+           grid_step=0.1, clearance=0.25, board_edge_clearance=0.55,
+           crossing_penalty=10.0, length_weight=1.0, halo_base=0.5,
+           halo_coef=0.25, halo_weight=2.0, edge_halo=2.0, edge_weight=2.0,
+           metrics_out=m2, intent_gate=g2, max_passes=2)
+    check("a gate that binds NOTHING still reports its key",
+          'intent_gate' in m2 and m2['intent_gate']['rejected'] == 0,
+          f"rejected={m2.get('intent_gate', {}).get('rejected')}")
 
 
 def arm_M_enforced_tuple(wd):
@@ -883,6 +946,7 @@ def main():
         arm_H_group_path(wd)
         arm_I_unfreeze_branch(wd)
         arm_Q_census_lift(wd)
+        arm_R_metrics_see_keepouts(wd)
         arm_L_inertness(wd)
         arm_M_enforced_tuple(wd)
         arm_N_gate_vs_grade(wd)

--- a/tests/test_782_nondefault_netclass_clamp.py
+++ b/tests/test_782_nondefault_netclass_clamp.py
@@ -246,7 +246,11 @@ class TestOneSpelling(unittest.TestCase):
                 except OSError:
                     continue
                 if 'nd_map' in txt and 'tests' not in p:
-                    hits.append(os.path.relpath(p, REPO))
+                    # POSIX separators: `relpath` returns the HOST's, so on
+                    # Windows this compared 'py_router\fix_...' against the
+                    # forward-slash literal below and failed for a reason that
+                    # has nothing to do with where the clamp body lives.
+                    hits.append(os.path.relpath(p, REPO).replace(os.sep, '/'))
         self.assertEqual(
             hits, ['py_router/fix_kicad_drc_settings.py'],
             f'the non-Default clamp body should live in one file, found {hits}')

--- a/tests/test_obstacle_map_balance.py
+++ b/tests/test_obstacle_map_balance.py
@@ -51,7 +51,16 @@ TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
 #: presented as a timeout and was dismissed as slowness. Measured in #691: it
 #: passes ALONE in 681 s with all 18 checks green, so this is a budget for the
 #: contended case, not cover for a hung test.
-RUN_ALL_TIMEOUT = 1200
+#:
+#: Raised to 2400 s because 1200 was still not a contended-case budget on a
+#: slower box. Measured here: ALONE 994 s, all checks green -- 1.46x the #691
+#: figure -- while the same test TIMED OUT inside a full `run_all.py` (which
+#: runs 4 at a time) on that same machine. A budget with 1.2x headroom over
+#: the solo time is not a budget for contention, and the failure mode it
+#: produces is the one this comment already warns about: a real result
+#: presented as slowness. The subprocess timeout below is raised to match, or
+#: the inner kill would just move the same problem one level down.
+RUN_ALL_TIMEOUT = 2400
 
 ROOT_DIR = os.path.dirname(TESTS_DIR)
 KF = os.path.join(ROOT_DIR, "kicad_files")
@@ -94,8 +103,11 @@ def run_cmd(args, audit=True, ledger=False, tap_verify=False,
         # test environment-dependent. Pin the field off for that stage; the
         # audit under churn is what this test exists to exercise.
         env["KICAD_PLANE_FRAGILITY_COST"] = "0"
+    # Kept equal to RUN_ALL_TIMEOUT above: an inner kill lower than the outer
+    # budget just relocates the same "a real result presented as slowness"
+    # failure one level down, where it reads as a router hang instead.
     p = subprocess.run([sys.executable, "-X", "utf8"] + args, cwd=ROOT_DIR,
-                       env=env, capture_output=True, text=True, timeout=1200)
+                       env=env, capture_output=True, text=True, timeout=2400)
     return p.returncode, p.stdout + p.stderr
 
 

--- a/tests/test_placement_ab.py
+++ b/tests/test_placement_ab.py
@@ -60,10 +60,10 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BOARDS = os.path.join(ROOT, 'kicad_files')
 
-# Six full quenches (3 rows x off/on) on three large boards. Measured 233-340 s
-# of row time across four runs on one box; declared with headroom so a slower
-# box reports FAIL, not TIME.
-RUN_ALL_TIMEOUT = 1200
+# Fourteen full quenches (7 rows x off/on) on five boards. Measured 233-340 s
+# of row time for the first three rows; the #702 rows add roughly as much
+# again. Declared with headroom so a slower box reports FAIL, not TIME.
+RUN_ALL_TIMEOUT = 1800
 
 DEFAULT_BASELINE = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                 'placement_ab_baseline.json')
@@ -85,7 +85,8 @@ GROUP_SOURCES = ('kicad', 'sheet')
 # "0.0 -> 806.84" is not a regression, it is a comparison that was never made,
 # and recording it as evidence would pin a fiction.
 BASELINE_INT_KEYS = ('crossings', 'health_bus_foreign_crossings',
-                     'intent_errors')
+                     'intent_errors', 'intent_errors_enforced',
+                     'intent_errors_other')
 BASELINE_FLOAT_KEYS = ('hpwl', 'health_block_displacement_max_mm')
 BASELINE_DICT_KEYS = ('intent_errors_by_rule',)
 
@@ -103,6 +104,11 @@ BASELINE_DICT_KEYS = ('intent_errors_by_rule',)
 # term with no effect at all marks `neutral`, which fails the rule outright.)
 MIN_TRIAL_BOARDS = 3
 
+
+#: Sentinel a row puts in `quench_on` to mean "the gate resolved from THIS
+#: row's intent". Not the intent itself: the table is read by `--list` and by
+#: the baseline comparator, and an Intent object in it would print as a repr.
+ROW_INTENT = '<resolved from this row>'
 
 # --- the table ------------------------------------------------------------
 #
@@ -199,6 +205,96 @@ ROWS = [
                 'row currently disagrees is how a one-in-three result becomes '
                 'folklore. Numbers: tests/placement_ab_baseline.json.'),
     },
+
+    # --- #702: the declared-intent gate ------------------------------------
+    #
+    # ON TRIAL on purpose: no `expect`, so `gate()`'s >=3-DISTINCT-BOARDS rule
+    # actually runs on this term instead of being skipped the way a pinned row
+    # skips it. The marks get pinned from the run that measures them, in the
+    # same commit, never from this comment.
+    #
+    # ON THE CIRCULARITY, STATED RATHER THAN HIDDEN. #701 deliberately made the
+    # grader and the enforcer ONE implementation, so for these three rules the
+    # file's usual independence premise does not hold. It is still not a
+    # tautology, and the reason is measurable: the gate is MONOTONE and never
+    # repairs, so it can LOSE to an unconstrained quench that happened to
+    # improve the same count. The `zone_exclusive` row is exactly that case.
+    # What makes these rows worth running is the GUARDS -- a constraint that
+    # buys containment by wrecking crossings or hpwl is a bad trade, and that
+    # is what `crossings`, `hpwl` and `intent_errors_other` are here to catch.
+    {
+        'name': 'intent-ulx3s',
+        'board': 'ulx3s.kicad_pcb',
+        'corridors': [],
+        'ignore_nets': ['GND', '+3V3', '+5V'],
+        'quench_on': {'intent_gate': ROW_INTENT},
+        'signal': 'intent_errors_enforced',
+        'guard': ('crossings', 'hpwl', 'intent_errors_other'),
+        'expect': 'regress',
+        'why': ('MECHANISM: the seed grades clean and the quench manufactures '
+                'every zone_containment error, so the gate has something real '
+                'to prevent -- and it prevents all of them. The mark is '
+                'REGRESS on the GUARDS, not on the signal: a hard constraint '
+                'removes poses from the search, so the objective it is '
+                'overruling gets worse. That is the trade being bought, and '
+                'pinning it here is what makes the PRICE a change detector '
+                'rather than a footnote. ulx3s emits 4 disjoint zones, one '
+                'B-side, so the side path is exercised too.'),
+    },
+    {
+        'name': 'intent-orangecrab',
+        'board': 'orangecrab_ext_pll.kicad_pcb',
+        'corridors': [],
+        'ignore_nets': ['GND', '+3V3', '+5V'],
+        'quench_on': {'intent_gate': ROW_INTENT},
+        'signal': 'intent_errors_enforced',
+        'guard': ('crossings', 'hpwl', 'intent_errors_other'),
+        'expect': 'improve',
+        'why': ('MECHANISM: same as intent-ulx3s but thinner, and a SECOND '
+                'board -- which is what the >=3-board rule is about. Here the '
+                'constraint costs nothing: both guards improve as well, so a '
+                'gated search is not inherently worse, it depends on whether '
+                'the poses it removes were load-bearing.'),
+    },
+    {
+        'name': 'intent-rp2350',
+        'board': 'rp2350_fpga_eensy_prePlane.kicad_pcb',
+        'corridors': [],
+        'quench_base': {'max_displacement': 10.0},
+        'quench_on': {'intent_gate': ROW_INTENT},
+        'signal': 'intent_errors_enforced',
+        'guard': ('crossings', 'hpwl', 'intent_errors_other'),
+        'expect': 'regress',
+        'why': ('MECHANISM: the CHEAP row (61 parts), and the corpus-scale '
+                'test of the monotone FREEZE. This board SEEDS with a '
+                'containment error, and the ON arm holds that count instead '
+                'of driving it to zero -- which is the whole contract: the '
+                'gate prevents a walk-out, it does not repair one. A run that '
+                'showed this signal reaching 0 would mean the gate had '
+                'started repairing and the contract had changed. It also '
+                'carries the known CONTAINER footprint, so the gate is '
+                'exercised beside that exemption.'),
+    },
+    {
+        'name': 'intent-exclusive-coldfire',
+        'board': 'kit-dev-coldfire-xilinx_5213.kicad_pcb',
+        'corridors': [],
+        'ignore_nets': ['GND', 'VCC*', '+3.3V', '+5V'],
+        'zone_flags': {'exclusive': True},
+        'quench_on': {'intent_gate': ROW_INTENT},
+        'signal': 'intent_errors_enforced',
+        'guard': ('crossings', 'hpwl', 'intent_errors_other'),
+        'expect': 'regress',
+        'why': ('MECHANISM: the row that DISAGREES, and the only corpus-scale '
+                'zone_exclusive coverage. Its signal is NEUTRAL -- the gate '
+                'holds the seed count and the unconstrained arm reaches the '
+                'same number -- so the mark is decided entirely by the '
+                'crossings guard. That is the honest shape of a constraint '
+                'that costs something and buys nothing HERE, and the row is '
+                'kept for exactly that: a term that helps on one board of '
+                'four is not a term, and deleting the dissenting row is how '
+                'that becomes folklore.'),
+    },
 ]
 
 QUENCH_BASE = dict(
@@ -208,19 +304,40 @@ QUENCH_BASE = dict(
     edge_weight=2.0, max_passes=4, verbose=False)
 
 
-def _intent_for(board_path, corridors, workdir):
+def _intent_for(board_path, corridors, workdir, zone_flags=None):
     """An intent for `board_path` with `corridors` declared.
 
     Emitted from the board itself rather than hand-written, so the blocks the
     health signals need are the ones that board actually has, and the row only
     has to state the bus.
+
+    `zone_flags` is applied BY RULE to every block that has a zone, never to a
+    hand-picked list: a row that named its own members would be fitted to the
+    arrangement it is measuring.
+
+    Keep-outs are deliberately NOT injectable here. `emit_intent` writes
+    `keepouts: []` by design (a keep-out is a mechanical fact and cannot be
+    read off a board), so any corpus keep-out is an invention -- and one that
+    BITES is one placed where the OFF arm happens to walk a part, i.e. fitted
+    to the OFF arm and invalidated the next time it moves. The keep-out half
+    is measured in tests/test_702_quench_intent_gate.py on hand-written boards
+    where the answer is a theorem.
     """
     from kicad_parser import parse_kicad_pcb
     from placement import floorplan
     path = os.path.join(workdir, 'intent.json')
     doc = floorplan.emit_intent(parse_kicad_pcb(board_path), board_path)
-    doc['health'] = dict(doc.get('health') or {})
-    doc['health']['bus_corridors'] = corridors
+    if corridors:
+        # Guarded: an unconditional assignment plants an empty `bus_corridors`
+        # on a row that declares none, which makes
+        # `health_bus_foreign_crossings` a measurement of nothing rather than
+        # an absent key.
+        doc['health'] = dict(doc.get('health') or {})
+        doc['health']['bus_corridors'] = corridors
+    if zone_flags:
+        for b in doc['blocks']:
+            if b.get('zone'):
+                b.update(zone_flags)
     with open(path, 'w') as fh:
         json.dump(doc, fh, indent=2)
     return floorplan.load_intent(path)
@@ -269,6 +386,17 @@ def _run(board_path, out_path, intent, quench_kw, group_sources=GROUP_SOURCES):
     by_rule = {}
     for v in result.errors:
         by_rule[v.rule] = by_rule.get(v.rule, 0) + 1
+    # #702: split the error count by whether the quench gate can ENFORCE the
+    # rule. Raw `intent_errors` mixes the rules a term can move with the ones
+    # it cannot, so a row signalling on the total is diluted by whatever else
+    # the emitted intent happens to find. The enforced set is imported from
+    # the engine, never re-typed here: a rule the engine starts enforcing
+    # enters this signal automatically, and one removed to flatter a row trips
+    # `test_702_quench_intent_gate.py`'s arm M rather than passing quietly.
+    from placement.quench import INTENT_ENFORCED_RULES
+    enforced = sum(n for r, n in by_rule.items()
+                   if r in INTENT_ENFORCED_RULES)
+    gate = metrics.get('intent_gate')
     return {
         'seconds': round(time.time() - t0, 1),
         'crossings': after.get('crossings'),
@@ -290,6 +418,11 @@ def _run(board_path, out_path, intent, quench_kw, group_sources=GROUP_SOURCES):
             summary.get('health_block_displacement_max_mm'),
         'intent_errors': summary.get('errors'),
         'intent_errors_by_rule': by_rule,
+        'intent_errors_enforced': enforced,
+        'intent_errors_other': (summary.get('errors') or 0) - enforced,
+        # 0 when a gate was built and refused nothing; None when NO gate was
+        # built at all. The distinction is the point -- see quench.py.
+        'intent_gate_rejected': None if gate is None else gate['rejected'],
     }
 
 
@@ -340,12 +473,22 @@ def run_row(row, workdir):
         return 'skip', [], None, None
     d = os.path.join(workdir, row['name'])
     os.makedirs(d, exist_ok=True)
-    intent = _intent_for(board, row['corridors'], d)
+    intent = _intent_for(board, row['corridors'], d, row.get('zone_flags'))
 
     kw_off = dict(QUENCH_BASE)
+    kw_off.update(row.get('quench_base') or {})
     kw_off['ignore_nets'] = list(row.get('ignore_nets') or ())
     kw_on = dict(kw_off)
     kw_on.update(row['quench_on'])
+    # #702: the row declares the intent it wants gated with a sentinel, so the
+    # table stays plain data and `_intent_for` stays the only place an intent
+    # is built. The OFF arm must NOT get one, or "off" would mean "resolved
+    # and then ignored" rather than "the engine that shipped".
+    if kw_on.get('intent_gate') is ROW_INTENT:
+        from kicad_parser import parse_kicad_pcb
+        from placement import floorplan
+        kw_on['intent_gate'], _probs = floorplan.resolve_intent_gate(
+            intent, parse_kicad_pcb(board), GROUP_SOURCES)
     # The ON run needs the corridors the flag prices; the OFF run must NOT get
     # them, or "off" would mean "built and multiplied by zero" rather than
     # "the objective that shipped".
@@ -651,10 +794,12 @@ def _self_test():
     # --- the comparator ---
     base = {'r': {'board': 'b.kicad_pcb', 'mark': 'regress',
                   'off': {'crossings': 100, 'hpwl': 10.0,
-                          'intent_errors': 5,
+                          'intent_errors': 5, 'intent_errors_enforced': 5,
+                          'intent_errors_other': 0,
                           'intent_errors_by_rule': {'zone_containment': 5}},
                   'on': {'crossings': 90, 'hpwl': 9.0,
-                         'intent_errors': 7,
+                         'intent_errors': 7, 'intent_errors_enforced': 7,
+                         'intent_errors_other': 0,
                          'intent_errors_by_rule': {'zone_containment': 7}}}}
     same = json.loads(json.dumps(base))
     assert compare_baseline(same, base) == [], compare_baseline(same, base)
@@ -718,12 +863,16 @@ def _self_test():
             'health_bus_foreign_crossings': 62,
             'health_block_displacement_max_mm': 17.95,
             'intent_errors': 14,
+            'intent_errors_enforced': 4, 'intent_errors_other': 10,
+            'intent_gate_rejected': None,
             'intent_errors_by_rule': {'block_unresolved': 10,
                                       'zone_containment': 4}}
     von = {'crossings': 90, 'hpwl': 9.0, 'corridor_cut': 800.0, 'seconds': 1,
            'health_bus_foreign_crossings': 55,
            'health_block_displacement_max_mm': 18.09,
            'intent_errors': 17,
+           'intent_errors_enforced': 7, 'intent_errors_other': 10,
+           'intent_gate_rejected': None,
            'intent_errors_by_rule': {'block_unresolved': 10,
                                      'zone_containment': 7}}
 

--- a/tests/test_placement_ab.py
+++ b/tests/test_placement_ab.py
@@ -60,7 +60,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 BOARDS = os.path.join(ROOT, 'kicad_files')
 
-# Fourteen full quenches (7 rows x off/on) on five boards. Measured 233-340 s
+# Fourteen full quenches (7 rows x off/on) over four distinct boards. 233-340 s
 # of row time for the first three rows; the #702 rows add roughly as much
 # again. Declared with headroom so a slower box reports FAIL, not TIME.
 RUN_ALL_TIMEOUT = 1800
@@ -208,10 +208,19 @@ ROWS = [
 
     # --- #702: the declared-intent gate ------------------------------------
     #
-    # ON TRIAL on purpose: no `expect`, so `gate()`'s >=3-DISTINCT-BOARDS rule
-    # actually runs on this term instead of being skipped the way a pinned row
-    # skips it. The marks get pinned from the run that measures them, in the
-    # same commit, never from this comment.
+    # These landed ON TRIAL (no `expect`) so `gate()`'s >=3-DISTINCT-BOARDS
+    # rule would actually run rather than be skipped the way a pinned row skips
+    # it. IT RAN AND IT REFUSED: 1 of 4 boards improved, 3 regressed, against a
+    # rule of "improve on >= N-1, regress on none".
+    #
+    # They ship PINNED anyway, and the distinction matters. That rule is for an
+    # OBJECTIVE TERM, which has to earn its place against the terms already
+    # there. This is a hard CONSTRAINT: it does not compete with crossings and
+    # hpwl, it overrules them. Every regress mark below is on a GUARD, never on
+    # the signal. So the rows are pinned as PRICE change-detectors -- what the
+    # constraint costs, recorded so a later change to that cost is visible --
+    # and not as a claim that the term improves the objective. The marks come
+    # from the run that measured them, never from this comment.
     #
     # ON THE CIRCULARITY, STATED RATHER THAN HIDDEN. #701 deliberately made the
     # grader and the enforcer ONE implementation, so for these three rules the
@@ -286,9 +295,12 @@ ROWS = [
         'guard': ('crossings', 'hpwl', 'intent_errors_other'),
         'expect': 'regress',
         'why': ('MECHANISM: the row that DISAGREES, and the only corpus-scale '
-                'zone_exclusive coverage. Its signal is NEUTRAL -- the gate '
-                'holds the seed count and the unconstrained arm reaches the '
-                'same number -- so the mark is decided entirely by the '
+                'zone_exclusive coverage. Its signal is NEUTRAL because BOTH '
+                'arms improve by the same amount -- the seed grades 7 and '
+                'gated and ungated both reach 5. The monotone rule admits '
+                'improving moves, so the gate does not stop the optimizer '
+                'clearing exclusive zones on its own here; it neither helps '
+                'nor hinders, and the mark is decided entirely by the '
                 'crossings guard. That is the honest shape of a constraint '
                 'that costs something and buys nothing HERE, and the row is '
                 'kept for exactly that: a term that helps on one board of '

--- a/tests/test_placement_ab.py
+++ b/tests/test_placement_ab.py
@@ -68,6 +68,15 @@ RUN_ALL_TIMEOUT = 1200
 DEFAULT_BASELINE = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                 'placement_ab_baseline.json')
 
+# The sources `resolve_blocks` derives from when the grade resolves an emitted
+# intent's blocks. `emit_intent` stamps EVERY block with a `group` key, so a
+# grade given no sources resolves every one of them to nothing -- see `_run`.
+# `('kicad', 'sheet')` is what `groups.parse_sources('auto')` returns, and it is
+# what `check_floorplan.py`, `place_seed.py` and `place_portfolio.py` all
+# default to; spelled out rather than imported so the fixture cannot drift with
+# a change to `auto`'s membership.
+GROUP_SOURCES = ('kicad', 'sheet')
+
 # The keys compared against the committed baseline.
 #
 # `seconds` is wall-clock and is never compared. `corridor_cut` is never
@@ -217,8 +226,19 @@ def _intent_for(board_path, corridors, workdir):
     return floorplan.load_intent(path)
 
 
-def _run(board_path, out_path, intent, quench_kw):
-    """One quench + write + independent grade. Returns the measured row."""
+def _run(board_path, out_path, intent, quench_kw, group_sources=GROUP_SOURCES):
+    """One quench + write + independent grade. Returns the measured row.
+
+    `group_sources` is NOT optional in spirit, only in signature. Every block
+    `_intent_for` emits carries a `group` key (floorplan.emit_intent), and
+    `resolve_blocks` only derives groups when it is given sources -- so a grade
+    at the `()` default resolves EVERY block to nothing and reports it as
+    `block_unresolved`. Measured before this was passed (#702): ulx3s 10
+    errors, orangecrab 6, coldfire 2, all of them `block_unresolved`, all of
+    them ZERO at ('kicad', 'sheet'). That is the instrument misreading its own
+    fixture, not a finding about the board, and it made `intent_errors` a
+    column that could not see the rule this file exists to measure.
+    """
     from kicad_parser import parse_kicad_pcb
     from placement.quench import quench
     from placement.writer import write_placed_output
@@ -239,7 +259,8 @@ def _run(board_path, out_path, intent, quench_kw):
     # here come from the final poses, not from the frozen model the optimizer
     # minimised against.
     graded = parse_kicad_pcb(out_path)
-    result = floorplan.grade(intent, graded, out_path, with_health=True)
+    result = floorplan.grade(intent, graded, out_path, with_health=True,
+                             group_sources=group_sources)
     summary = floorplan.summary(result)
     after = metrics.get('after') or {}
     # ERRORS only, by rule. `summary()['violations_by_rule']` counts warnings

--- a/tests/test_placement_probe.py
+++ b/tests/test_placement_probe.py
@@ -39,6 +39,16 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
+#: A scoped probe that reaches most of the board is a whole-board route wearing
+#: a scope's name. Refused rather than reported, for the reason this file
+#: refuses an empty scope: a number nobody can attribute is not evidence.
+MAX_SCOPE_FRACTION = 0.5
+
+
+class ScopeTooWide(RuntimeError):
+    pass
+
+
 def causal_nets(board, intent_path=None, extra=None):
     """The nets the change claims to help, as glob-free exact names.
 
@@ -66,6 +76,61 @@ def causal_nets(board, intent_path=None, extra=None):
         for nid, n in pcb.nets.items():
             if nid > 0 and n.name and matches_net_filter(n.name, pats):
                 names.add(n.name)
+
+    # #702: the nets of the parts a DECLARED CLAIM binds -- zoned-block members
+    # and keep-out-bound refs. Without this source a zone or keep-out term
+    # yields no causal nets at all and the probe exits 2, so the one tier that
+    # actually ROUTES could not be pointed at #702 without a human typing a net
+    # list -- and a gate that needs a human to type its own scope is a gate
+    # nobody runs.
+    #
+    # This is NOT the circularity this file forbids. The rule at the top is
+    # "never scope by which parts MOVED", because a term that moves nothing
+    # would then score a perfect null. This scopes by what the intent DECLARES,
+    # off the OFF board, identical on both arms -- structurally the same as the
+    # corridor source above.
+    from placement.legality import (footprint_side, sides_occupied,
+                                    footprint_has_through_pads)
+    bound = set()
+    blocks, _ = floorplan.resolve_blocks(intent, pcb, ('kicad', 'sheet'))
+    for z in intent.blocks:
+        if z.rect is not None:
+            bound.update(blocks.get(z.name, ()))
+    for ref, fp in pcb.footprints.items():
+        sides = sides_occupied(footprint_side(fp),
+                               footprint_has_through_pads(fp))
+        if floorplan.keepouts_for_ref(intent.keepouts, ref, sides):
+            bound.add(ref)
+    # A high-fanout net (GND on ulx3s touches 96 parts) would drag most of the
+    # board in and turn a SCOPED probe into a whole-board route, so cut at the
+    # same fanout the health signals cut at.
+    from placement.routability import DISPLACEMENT_MAX_FANOUT
+    owners = {}
+    for ref, fp in pcb.footprints.items():
+        for pad in fp.pads:
+            if pad.net_id > 0 and pad.net_name:
+                owners.setdefault(pad.net_name, set()).add(ref)
+    declared = set()
+    for ref in bound:
+        fp = pcb.footprints.get(ref)
+        for pad in (fp.pads if fp else ()):
+            if (pad.net_id > 0 and pad.net_name
+                    and len(owners.get(pad.net_name, ())) <= DISPLACEMENT_MAX_FANOUT):
+                declared.add(pad.net_name)
+    if declared:
+        print(f"  causal: {len(declared)} net(s) from {len(bound)} part(s) "
+              f"bound by a declared zone or keep-out")
+    names |= declared
+
+    # A probe that routes most of the board is not a scoped probe, and
+    # reporting that as evidence would be worse than reporting nothing.
+    live = {n.name for i, n in pcb.nets.items() if i > 0 and n.name}
+    if live and len(names) > MAX_SCOPE_FRACTION * len(live):
+        raise ScopeTooWide(
+            f"{len(names)} of {len(live)} board nets "
+            f"({len(names) / len(live):.0%}) exceeds the "
+            f"{MAX_SCOPE_FRACTION:.0%} cap: this is a whole-board route, not "
+            f"a scoped probe. Narrow the intent or pass --extra-nets.")
     return sorted(names)
 
 
@@ -114,7 +179,11 @@ def main(argv=None):
 
     import shlex
     route_args = shlex.split(args.route_args) if args.route_args else []
-    nets = causal_nets(args.off, args.intent, args.extra_nets)
+    try:
+        nets = causal_nets(args.off, args.intent, args.extra_nets)
+    except ScopeTooWide as exc:
+        print(f"scope too wide: {exc}", file=sys.stderr)
+        return 2
     if not nets:
         print("no causal nets: nothing this change claims to help is "
               "identifiable. Declare health.bus_corridors, or pass "

--- a/tests/test_run23_connector_affinity.py
+++ b/tests/test_run23_connector_affinity.py
@@ -471,7 +471,21 @@ class TestPlaceSeedLocksOnlyClaims(unittest.TestCase):
                 pass
 
             def _spy(*a, **kw):
+                # BOTH channels. #702 moved the edge claims out of the
+                # `lock_refs=` kwarg and into the resolved intent bundle, which
+                # `quench()` unions into the same frozen set -- the refs are
+                # unchanged, the parameter carrying them is not.
+                #
+                # Reading only `lock_refs` does not FAIL loudly when that
+                # happens: `kw.get` stores None, so `assertIn('lock_refs',
+                # seen)` still passes and `got & weak == set()` passes
+                # VACUOUSLY on an empty set. The connector_affinity guard --
+                # the entire reason this test exists -- would go on reporting
+                # green while asserting nothing. Hence the union, and hence
+                # the assertion below that it is non-empty.
                 seen['lock_refs'] = kw.get('lock_refs')
+                seen['intent_lock_refs'] = (
+                    (kw.get('intent_gate') or {}).get('lock_refs'))
                 raise _Stop()
 
             real, quench_mod.quench = quench_mod.quench, _spy
@@ -488,7 +502,14 @@ class TestPlaceSeedLocksOnlyClaims(unittest.TestCase):
                 sys.argv = argv
 
         self.assertIn('lock_refs', seen, 'the polish quench was never reached')
-        got = set(seen['lock_refs'] or ())
+        got = set(seen['lock_refs'] or ()) | set(seen['intent_lock_refs'] or ())
+        # Non-empty FIRST. The two assertions below are both satisfied by an
+        # empty set, so without this the guard passes when the polish stops
+        # being told about the edge claims at all -- which is exactly how a
+        # channel move would slip through unnoticed.
+        self.assertTrue(got, 'the polish was handed NO locked refs by either '
+                             'channel: the connector_affinity guard below '
+                             'would pass vacuously')
         self.assertEqual(got & weak, set(),
                          f'connector_affinity refs locked in the polish: '
                          f'{sorted(got & weak)}')


### PR DESCRIPTION
Closes #702

The floorplan intent reached `place_seed` and stopped. `place_optimize.py` and
`place_route_loop.py` — the tools that run the most quench iterations in a real
chain — had `grep -ci intent` == 0, so a declared zone decayed under
optimization and the decay was only visible if someone later ran the grader.

`QuenchState` took a `keepouts` parameter in #701, but its own comment recorded
the gap: *"Consumed by `seeder.pose_ok` and `seeder.edge_seat_ok`; the quench
objective never reads it."* And the module-level `quench()` never gained the
parameter at all, so even `place_seed`'s own polish could not pass what it held.

## What it does

Measured on ulx3s, graded against the board's own emitted intent:

| | intent errors |
|---|---|
| seed | **0** |
| after an ungated quench | **4** `zone_containment` — manufactured by the optimizer |
| after a gated quench | **0** — prevented |

**The gate is MONOTONE: it prevents a walk-out, it does not repair one.** A part
that arrives already violating may improve or hold, never worsen. On a board
whose seed already violates, the correct result is *the seed's count, held* —
and a gate that drove it to zero would be as wrong as one that was inert. The
`intent-rp2350` A/B row exists to pin exactly that (seed 1, ungated 2, gated 1).

## Three enforcement sites, because two are not reachable from the first

- `candidate_valid`, first in the conjunct chain and as a `return False`. First
  because it is float compares against a usually-empty tuple where the
  neighbour loop and `pads_ok` are sweeps — on a refused pose it *replaces*
  that work. A `return` because the #456 off-board escape branch is a licence
  to be worse on the **board** term, and that must not compose into a licence
  to be worse on a **declared** one.
- The rigid-block phase inherits it through `group_move_valid`.
- The **swap phase**, which reaches `candidate_valid` on no path at all. Its
  "a swap preserves occupied space" argument is true of the geometry other
  parts see and false of a claim that binds a *ref*: exchanging two identical
  decaps moves A to B's pose, where B's zone and B's keep-out bindings applied.
  Counted and printed as `swap-intent=N`.

One term per **(ref, entry)**, never per (ref, rule): aggregating a rule's
entries lets a part hop between two keep-outs at `1.0 → 1.0`. And a **vector**,
never a sum — mm of escape, mm² of intrusion and `keepout_hit`'s circle marker
are three currencies, and summing them lets a part buy 1 mm of escape with
1 mm² of intrusion.

## Which rules the search can see

Three are gated (`zone_containment`, `zone_exclusive`, `keepout`); two are
enforced by **freezing** the ref (`must_lock`, `edge_connector`) because no pose
satisfies or violates them; four are deliberately outside, each for its own
reason. The full table is now in `docs/floorplan-intent.md`, and the "why not"
column is the part worth reading. In particular **`decap_distance` is
disqualified on currency**: it is graded pad-centroid to an IC's pad bbox
inflated 0.5 mm, not courtyard to courtyard, so a gate in the optimizer's
currency could *admit what the grade flags* — worse than no gate at all.

## The price, measured and pinned

A hard constraint removes poses from the search, so the objective it overrules
gets worse. Four A/B rows, landed **on trial** so the ≥3-distinct-boards rule
actually ran — it ran and **refused** (1 of 4 improved, 3 regressed) — then
pinned, because that rule is for an objective term competing with `crossings`
and `hpwl`, and this one overrules them. Every regress mark is on a **guard**,
never on the signal.

| row | enforced errors | crossings | hpwl |
|---|---|---|---|
| intent-ulx3s | 4 → 0 | +14 | +70.6 |
| intent-orangecrab | 1 → 0 | −10 | −2.7 |
| intent-rp2350 | 2 → 1 | +4 | −0.8 |
| intent-exclusive-coldfire | 5 → 5 | +2 | −2.4 |

`intent-exclusive-coldfire` is the dissenting row, kept deliberately: a term
that helps on one board of four is not a term, and deleting the row that
disagrees is how that becomes folklore.

Keep-outs are **not** in the A/B table. `emit_intent` writes `keepouts: []` by
design, so a corpus keep-out is an invention — and one that *bites* is one
placed where the OFF arm happens to walk a part, i.e. fitted to the OFF arm and
invalidated the next time it moves. That half is measured on hand-written
boards where the answer is a theorem.

## Verification

- `tests/test_702_quench_intent_gate.py` — 71 checks, every accepting arm with
  a control, every arm asserting the `by_site` counter.
- `tests/mutate_702.py` — 22 rows: **19 killed, 3 survived** (all recorded with
  their reason), 0 broken, 0 disagreeing with expectation.
- Full suite: **450 passed, 0 failed, 0 timed out, 0 skipped**.
- Bit-identity: with the gate in the tree and no intent passed, the A/B table
  reports `baseline: N row(s) match` — 30+ numbers over three large boards,
  unchanged. Plus a poison arm that monkeypatches the gate to `raise` and runs
  a full no-intent quench, which proves it is *unreachable* as no output
  comparison can.

## An honest note on process

The mutation battery caught **three of my own test arms passing without ever
reaching what they named**, and two adversarial review rounds found nine
defects in my own work — including one where `refs_bound` reported
`0 bound part(s)` while the gate refused 360 poses, one where #701's keep-out
census was silently disabled because the gate read a frozen copy of the
keep-outs, and one where a test I had reported as green was in fact red because
I read a suite log while it was still running. Each is described in the commit
that fixes it.

## A trade this makes, stated rather than hidden

Because the conjunct sits above the off-board escape branch, a part that is off
the outline and whose only homeward poses lie in a keep-out **stays off the
outline** — trading a `keepout` finding for the defect CLAUDE.md ranks first.
The alternative is a gate that can be defeated by first walking a part off the
board, which is not a hard constraint at all. `intent_blockers` names the claim
that stranded the part, and `zone_covered_by_keepout` refuses the
total-coverage contradiction at load time.

## Three corrections to the issue

1. `_TOP_LEVEL_KEYS` holds **17** keys, at `floorplan.py:96-100` (not 18 at
   `:84-87`).
2. The `place_portfolio` load path is `:378-401`, not `:384-400`.
3. **The CLI/GUI threading requirement has no counterpart for these files.**
   All four placement CLIs are in `manifest_to_plan.REFUSED_TOOLS` and
   short-circuit before any flag loop; `CLI_MAINS` excludes them; the plugin
   never touches the quench path. `--corridor-weight` is the precedent — engine
   param + CLI flags, no `FLAG_PARAMS` row, no GUI control, no settings key.
   Two caveats worth raising rather than glossing: `test_manifest_plan_parity`
   asserts that refusal for only **two** of the four, and
   **CONTRIBUTING.md:154-157 states the same requirement** — so this reads more
   like a rule that could use scoping than an error in the issue.

## Also fixed here (not #702, but the suite was red)

- **`kicad_locate` built POSIX paths with `os.path.join`.** Those functions take
  an explicit `system=` so a caller can reason about another platform, and the
  Windows branch already used `ntpath.join` for that reason; Darwin and Linux
  did not, so on a Windows host they emitted backslashes into paths that are
  then *probed*.
- `test_782` compared `os.path.relpath` output against a forward-slash literal.
- `test_obstacle_map_balance` was timing out under 4-way parallelism, not
  failing: 994 s alone here against the 681 s recorded in #691, so a 1200 s
  budget left 1.2x headroom for a contended run.

## Follow-ups worth filing

`decap_distance` needs a frozen cap-to-IC pairing in the grade's own currency;
`zone_exclusive` is enforced nowhere in the seeder; `krt_capabilities` cannot
see flags registered from a sub-package registrar, so `--intent` reads as
unsupported on all four CLIs; and the contradiction check catches total
coverage but not "partial coverage that leaves no feasible pose".

