### PR TITLE
#698: an explicit --reseat is judged on what the operator asked about

### DIFF
--- a/.claude/skills/plan-pcb-placement/SKILL.md
+++ b/.claude/skills/plan-pcb-placement/SKILL.md
@@ -83,8 +83,11 @@ grow, no hard gate term got worse, no declared claim got worse, and one
 scope-relevant basis strictly improved; `hpwl` is the one term it is licensed to
 pay, because a seat made for a declared reason is hpwl-worse by construction.
 `--reseat-min-gain MM` raises the bar on the wirelength basis only (the count
-bases threshold at one whole defect); the default 0 already rejects a shuffle,
-which measures as *exactly* zero rather than as a small win.
+bases threshold at one whole defect). The default is 0: measured over 16
+explicit re-seats on four corpus boards, every gain that reached the gate was
+≥1 mm, so a floor would buy nothing there — see `tests/measure_698_min_gain.py`,
+and read its `pre_prune` column rather than the headline, because most of the
+zero rows are seats the prune sweep reverted rather than shuffles.
 
 #### When a part will not seat, read the verdict before reaching for a hammer
 

--- a/.claude/skills/plan-pcb-placement/SKILL.md
+++ b/.claude/skills/plan-pcb-placement/SKILL.md
@@ -84,9 +84,9 @@ scope-relevant basis strictly improved; `hpwl` is the one term it is licensed to
 pay, because a seat made for a declared reason is hpwl-worse by construction.
 `--reseat-min-gain MM` raises the bar on the wirelength basis only (the count
 bases threshold at one whole defect). The default is 0: measured over 16
-explicit re-seats on four corpus boards, every gain that reached the gate was
-≥1 mm, so a floor would buy nothing there — see `tests/measure_698_min_gain.py`,
-and read its `pre_prune` column rather than the headline, because most of the
+explicit re-seats on four corpus boards, every **non-zero** gain was ≥1 mm, so a
+floor would buy nothing there — see `tests/measure_698_min_gain.py`, and read its
+`pre_prune` and `moved` columns rather than the headline, because 9 of the 10
 zero rows are seats the prune sweep reverted rather than shuffles.
 
 #### When a part will not seat, read the verdict before reaching for a hammer

--- a/.claude/skills/plan-pcb-placement/SKILL.md
+++ b/.claude/skills/plan-pcb-placement/SKILL.md
@@ -72,6 +72,20 @@ Expect `recovery` to get no better and `collateral_pad_rms` to grow: this puts
 parts where the netlist wants them, not where they were. That is the intended
 trade.
 
+**On a `[GATE REFUSED]`, read `accept_basis`, not the gate tuple (#698).** A
+named scope and the bare auto scope are judged by different rules, and the
+summary says which: `policy` is `auto:oob-strict` or
+`explicit:one-term-strict`, `fired` is the basis that carried the pass, and
+`terms` lists *every* basis with its before/after — so a refusal tells you what
+would have to change. The auto rule is unchanged (the off-board amount must
+strictly improve). A named scope is accepted when the off-outline count did not
+grow, no hard gate term got worse, no declared claim got worse, and one
+scope-relevant basis strictly improved; `hpwl` is the one term it is licensed to
+pay, because a seat made for a declared reason is hpwl-worse by construction.
+`--reseat-min-gain MM` raises the bar on the wirelength basis only (the count
+bases threshold at one whole defect); the default 0 already rejects a shuffle,
+which measures as *exactly* zero rather than as a small win.
+
 #### When a part will not seat, read the verdict before reaching for a hammer
 
 Every part the rung leaves unseated carries a **`no_pose_verdict`** in the

--- a/docs/floorplan-intent.md
+++ b/docs/floorplan-intent.md
@@ -265,6 +265,18 @@ A constraint the search cannot see can only ever produce a failing grade. This
 is the whole table, and the "no" column is the part worth reading — each of
 them is a decision, not an omission.
 
+There is a **third** consumer beside the two columns below, added by
+[#698](https://github.com/drandyhaas/KiCadRoutingTools/issues/698):
+`place_seed --reseat REF` measures the same three enforced rules *before and
+after* the pass, through the same `zone_escape` / `keepout_hit` /
+`rect_overlap_area` the grade calls, and uses them two ways — the per-term
+**vector** as a licence (no declared claim may get worse, termwise) and the
+breach **count** as one of the terms an explicit re-seat may be accepted *on*.
+It is a measurement, not a per-pose gate: arming the monotone zone gate on that
+path would make the re-seat refuse its own target, which is why
+`pose_score.make_state` hands it keep-outs and withholds zones. `reseat_scope`
+reports the whole picture in `accept_basis`.
+
 | rule | graded | seat search (#701) | quench gate (#702) | if not, why not |
 |---|---|---|---|---|
 | `zone_containment` | yes | via `zone_gate` | **yes** | — |

--- a/py_placer/place_reconstruct.py
+++ b/py_placer/place_reconstruct.py
@@ -557,7 +557,11 @@ Examples:
         return rep
 
     def _reseat_report(rep, preview=False):
-        d = {'scope': rep['scope'], 'scope_source': rep['scope_source'],
+        # #698: the same vocabulary as `place_seed`'s summary. This rung's
+        # scope is always `auto:damage_witnesses`, so the basis is `oob` or
+        # None -- but the two CLIs must not describe one pass differently.
+        d = {'accept_basis': rep.get('accept_basis'),
+             'scope': rep['scope'], 'scope_source': rep['scope_source'],
              'reseated': rep['reseated'], 'unseated': rep['unseated'],
              'refused': rep['refused'], 'pruned': rep['pruned'],
              'edge_bands_dropped': rep['edge_bands_dropped'],

--- a/py_placer/place_seed.py
+++ b/py_placer/place_seed.py
@@ -140,6 +140,21 @@ Examples:
                         "pose being discarded). Composes with --repair and "
                         "runs BEFORE it. Judge it on witnesses_after, not on "
                         "how far anything moved")
+    p.add_argument("--reseat-min-gain", type=float, default=0.0, metavar="MM",
+                   help="With --reseat REF (an EXPLICIT scope): the smallest "
+                        "wirelength win, in mm, that counts as a re-seat. 0 "
+                        "(the default) means any strict win. It gates the "
+                        "MILLIMETRE basis only -- the scope's own HPWL, which "
+                        "is where a sideways shuffle can score. The "
+                        "intent-violation, blocking-pair and stack bases are "
+                        "COUNTS, whose smallest meaningful gain is one whole "
+                        "defect: one number compared against both currencies "
+                        "would be asserting an exchange rate between half a "
+                        "millimetre of wire and half a keep-out violation. "
+                        "Inert on the AUTO scope (bare --reseat), whose rule "
+                        "is unchanged. JSON_SUMMARY accept_basis reports every "
+                        "basis, whether this applied to it, and by how much "
+                        "each one missed")
     p.add_argument("--dry-run", action="store_true",
                    help="With --repair/--reseat: print the move list and "
                         "grades, write nothing")
@@ -161,6 +176,17 @@ Examples:
                 "everything)")
     if args.dry_run and not (args.repair or args.reseat is not None):
         p.error("--dry-run only applies to --repair / --reseat")
+    if args.reseat_min_gain and args.reseat is None:
+        p.error("--reseat-min-gain only applies to --reseat")
+    if args.reseat_min_gain < 0:
+        p.error("--reseat-min-gain is a magnitude in mm; negative is not a "
+                "looser threshold, it is a typo")
+    if args.reseat_min_gain and args.reseat == []:
+        # An inert knob says so, rather than reading as a threshold that
+        # happened to find nothing wrong (cli_gates' own disclosure rule).
+        print("--reseat-min-gain is inert on the AUTO scope: that rule is "
+              "'the off-board amount strictly improved', which this does not "
+              "gate", file=sys.stderr)
 
     try:
         from redo_record import record_invocation
@@ -241,7 +267,8 @@ Examples:
                 grid_step=args.grid_step, seed=args.seed,
                 # The same flag, not a second one: it was parsed and
                 # silently ignored on this path (#699).
-                evict_depth=args.evict_depth)
+                evict_depth=args.evict_depth,
+                min_gain=args.reseat_min_gain)
             for note in reseat['notes']:
                 print(f"  NOTE: {note}")
             # Over the SCOPE only: the line prints it as "{n} re-seated
@@ -267,6 +294,21 @@ Examples:
                   f"{len(reseat['witnesses_after'])}"
                   + ('' if reseat['accepted'] else '  [GATE REFUSED]'))
             print(f"  gate {reseat['gate_before']} -> {reseat['gate_after']}")
+            # #698: WHICH scope-relevant term carried the pass, or -- on a
+            # refusal -- what every basis measured. A verdict with no basis is
+            # how this pass came to refuse on a term the operator never asked
+            # about for a whole release.
+            _ab = reseat.get('accept_basis') or {}
+            if _ab.get('fired'):
+                _t = next((t for t in _ab.get('terms') or []
+                           if t['term'] == _ab['fired']), {})
+                print(f"  accepted on {_ab['fired']}: "
+                      f"{_t.get('before')} -> {_t.get('after')} "
+                      f"({_t.get('units')}); {_ab.get('policy')}")
+            elif _ab.get('policy') == 'explicit:one-term-strict':
+                print("  no basis fired: " + ", ".join(
+                    f"{t['term']} {t['before']}->{t['after']}"
+                    for t in (_ab.get('terms') or [])))
             summary.update({
                 'reseat': True,
                 'scope': reseat['scope'],
@@ -292,6 +334,11 @@ Examples:
                 'gate_before': reseat['gate_before'],
                 'gate_after': reseat['gate_after'],
                 'accepted': reseat['accepted'],
+                # #698: the whole basis record, not just the winner -- a basis
+                # that measured nothing and a basis that measured no change
+                # must not look alike to a reader of the summary either.
+                'accept_basis': reseat.get('accept_basis'),
+                'reseat_min_gain': args.reseat_min_gain,
                 'reseat_max_move_mm': round(_rmax, 3),
             })
             _advance(reseat['moves'], 'reseat')

--- a/py_placer/place_seed.py
+++ b/py_placer/place_seed.py
@@ -306,7 +306,14 @@ Examples:
                       f"{_t.get('before')} -> {_t.get('after')} "
                       f"({_t.get('units')}); {_ab.get('policy')}")
             elif _ab.get('policy') == 'explicit:one-term-strict':
-                print("  no basis fired: " + ", ".join(
+                # "would have fired", never "no basis fired": on a safety or
+                # licence refusal the top-level `fired` is None by design while
+                # a term still carries `first`, and printing "no basis fired"
+                # then contradicts the record right beside it.
+                _first = next((t['term'] for t in (_ab.get('terms') or [])
+                               if t.get('first')), None)
+                print(("  refused despite " + _first + " improving: "
+                       if _first else "  no basis improved: ") + ", ".join(
                     f"{t['term']} {t['before']}->{t['after']}"
                     for t in (_ab.get('terms') or [])))
             summary.update({

--- a/py_placer/placement/README.md
+++ b/py_placer/placement/README.md
@@ -263,6 +263,51 @@ a new stack would sit below it unread. At depth 0 — the default, and what
 `place_reconstruct`'s reseat rung uses — nothing outside the scope is touched
 and the counts are 0.
 
+**An EXPLICIT scope is accepted on a different rule from the auto one (#698),
+and the difference is structural rather than a preference.** On
+`auto:damage_witnesses` the pass's win *is* `oob`, at index 3 of the gate tuple
+— **above** `hpwl` — so the lexicographic compare already sees it, `prune`
+cannot revert a genuine homecoming, and `after[oob] < before[oob]` is a complete
+rule. On an explicit scope the win is a declared claim or the scope's own
+wirelength, which the tuple cannot see **at all**; `after[oob] < before[oob]` is
+then unsatisfiable for any part that is on the board, so an explicitly named
+part could never be re-seated whatever the search found. So:
+
+- **Safety is TERM-WISE, not lexicographic.** Every gate term must not worsen
+  except `hpwl`, the one licensed term — a seat made for a declared reason is
+  hpwl-worse *by construction*, for the same reason `exempt` gives above.
+  Measured on #698's fixture: escaping the declared keep-out costs +11.372 mm of
+  hpwl on 20 of 20 seeds, so a lexicographic `after <= before` refuses exactly
+  the case the change exists for. `oob` stays hard but is no longer required to
+  *improve*, and that one asymmetry is the whole bug.
+- **A separate trigger.** At least one basis in `RESEAT_BASES` must strictly
+  improve: the six hard gate terms, the scope's own HPWL, and the count of
+  breached declared claims. All are reported in `accept_basis` whether they
+  fired or not — a basis that measured nothing and a basis that measured no
+  change must not look alike.
+- **The intent VECTOR is the guard; the intent COUNT is only the trigger.** A
+  bare count carries the trap `quench._IntentTerm` names — a part hopping from
+  keep-out A into keep-out B reads `1 -> 1`, which a monotone rule admits — so
+  `IntentProbe.licence` separately refuses any term that *rose*, termwise and
+  never summed.
+- **`prune_assignment` had to be taught the same thing**, because it reverts
+  *first*. Its tuple has no intent term either, so a seat that cleared a
+  keep-out reads as a pure hpwl loss and was undone before the gate ran. It now
+  takes an `intent_probe` and refuses a revert that would re-break a
+  declaration — a conjunct rather than an `exempt` entry, so the sweep still
+  catches every mis-move it caught before and stays monotone, now on
+  `(tuple, intent vector)` jointly. Kept moves are named in a `prune: KEPT …`
+  note.
+- **`--reseat-min-gain` (mm) gates the HPWL basis only.** Count bases threshold
+  at one whole defect; one number compared against both currencies would assert
+  an exchange rate between half a millimetre of wire and half a keep-out
+  violation. The default is **0.0**, and that is measured rather than assumed:
+  over 16 explicit re-seats on four corpus boards the gains are bimodal with no
+  middle — 10 are *exactly* 0.000 (the search re-seats the part where it already
+  was) and the 6 real relocations run 1.004 to 19.875 mm. A shuffle does not
+  produce a small positive gain here, so a non-zero floor would buy nothing and
+  could reject a genuine small win.
+
 Requires an Edge.Cuts outline (exit 3 without one — the outline is spec-owned
 and will not be invented) and refuses a board that already looks placed
 (use `place_portfolio.py` to explore around an existing placement, or

--- a/py_placer/placement/README.md
+++ b/py_placer/placement/README.md
@@ -276,10 +276,11 @@ part could never be re-seated whatever the search found. So:
 - **Safety is TERM-WISE, not lexicographic.** Every gate term must not worsen
   except `hpwl`, the one licensed term — a seat made for a declared reason is
   hpwl-worse *by construction*, for the same reason `exempt` gives above.
-  Measured on #698's fixture: escaping the declared keep-out costs +11.372 mm of
-  hpwl on 20 of 20 seeds, so a lexicographic `after <= before` refuses exactly
-  the case the change exists for. `oob` stays hard but is no longer required to
-  *improve*, and that one asymmetry is the whole bug.
+  Measured on #698's fixture, swept over 20 seeds: escaping the declared
+  keep-out costs hpwl on **20 of 20** — 6.82 to 12.39 mm, a different value per
+  seed, since the seat search is seeded — so a lexicographic `after <= before`
+  refuses exactly the case the change exists for. `oob` stays hard but is no
+  longer required to *improve*, and that one asymmetry is the whole bug.
 - **A separate trigger.** At least one basis in `RESEAT_BASES` must strictly
   improve: the six hard gate terms, the scope's own HPWL, and the count of
   breached declared claims. All are reported in `accept_basis` whether they
@@ -298,15 +299,26 @@ part could never be re-seated whatever the search found. So:
   catches every mis-move it caught before and stays monotone, now on
   `(tuple, intent vector)` jointly. Kept moves are named in a `prune: KEPT …`
   note.
-- **`--reseat-min-gain` (mm) gates the HPWL basis only.** Count bases threshold
-  at one whole defect; one number compared against both currencies would assert
-  an exchange rate between half a millimetre of wire and half a keep-out
-  violation. The default is **0.0**, and that is measured rather than assumed:
-  over 16 explicit re-seats on four corpus boards the gains are bimodal with no
-  middle — 10 are *exactly* 0.000 (the search re-seats the part where it already
-  was) and the 6 real relocations run 1.004 to 19.875 mm. A shuffle does not
-  produce a small positive gain here, so a non-zero floor would buy nothing and
-  could reject a genuine small win.
+- **`--reseat-min-gain` (mm) gates the `scope_hpwl` basis only.** Count bases
+  threshold at one whole defect; one number compared against both currencies
+  would assert an exchange rate between half a millimetre of wire and half a
+  keep-out violation. The other continuous bases are floored at
+  `MEASURE_QUANTUM` instead, because `reconstruct.measure` rounds them to 4
+  decimals and a "gain" at or below that is rounding — measured before that
+  floor existed, an `overlap` gain of 1e-4 mm² fired and bought a 50 mm hpwl
+  blow-up.
+
+  The default is **0.0**, from `tests/measure_698_min_gain.py` (16 explicit
+  re-seats on four corpus boards, parts chosen by pad count so the sample cannot
+  be fitted to the conclusion). **Read that script's `pre_prune` column before
+  quoting it**: the gains look bimodal — 10 exactly 0.000, and 6 running 1.004
+  to 19.875 mm — but 9 of the 10 zeros are seats `prune_assignment` REVERTED
+  (the search relocated by tens of millimetres to an hpwl-worse pose, so `after`
+  is the restored input pose), and only one is a genuine no-op. The bimodality
+  is therefore partly structural: anything surviving prune has improved hpwl by
+  construction. What the sample does support is narrower and still sufficient —
+  among the re-seats that reach the gate, the smallest gain is ~1 mm, so a
+  non-zero default would buy nothing here while risking a genuine small win.
 
 Requires an Edge.Cuts outline (exit 3 without one — the outline is spec-owned
 and will not be invented) and refuses a board that already looks placed

--- a/py_placer/placement/README.md
+++ b/py_placer/placement/README.md
@@ -302,11 +302,14 @@ part could never be re-seated whatever the search found. So:
 - **`--reseat-min-gain` (mm) gates the `scope_hpwl` basis only.** Count bases
   threshold at one whole defect; one number compared against both currencies
   would assert an exchange rate between half a millimetre of wire and half a
-  keep-out violation. The other continuous bases are floored at
-  `MEASURE_QUANTUM` instead, because `reconstruct.measure` rounds them to 4
-  decimals and a "gain" at or below that is rounding — measured before that
-  floor existed, an `overlap` gain of 1e-4 mm² fired and bought a 50 mm hpwl
-  blow-up.
+  keep-out violation. Every continuous basis is *also* floored at
+  `MEASURE_QUANTUM`, the last digit `reconstruct.measure` keeps for the 4-dp
+  legality terms: without it the old `gain > 1e-9` let an `overlap` improvement
+  of 1e-4 mm² — a change in the last representable digit — accept a pass, and
+  since `hpwl` is the licensed term such a pass may be arbitrarily worse on
+  wirelength. The floor is also what makes the rule **monotone in
+  `--reseat-min-gain`**: a threshold below the quantum falls through to it, so
+  a stricter flag can never produce a looser gate.
 
   The default is **0.0**, from `tests/measure_698_min_gain.py` (16 explicit
   re-seats on four corpus boards, parts chosen by pad count so the sample cannot
@@ -317,8 +320,8 @@ part could never be re-seated whatever the search found. So:
   is the restored input pose), and only one is a genuine no-op. The bimodality
   is therefore partly structural: anything surviving prune has improved hpwl by
   construction. What the sample does support is narrower and still sufficient —
-  among the re-seats that reach the gate, the smallest gain is ~1 mm, so a
-  non-zero default would buy nothing here while risking a genuine small win.
+  every re-seat whose gain was **non-zero** gained at least ~1 mm, so a non-zero
+  default would buy nothing here while risking a genuine small win.
 
 Requires an Edge.Cuts outline (exit 3 without one — the outline is spec-owned
 and will not be invented) and refuses a board that already looks placed

--- a/py_placer/placement/quench.py
+++ b/py_placer/placement/quench.py
@@ -100,6 +100,222 @@ class _IntentTerm(NamedTuple):
     anchor: bool              # zone_containment: grade the courtyard CENTRE
     entry: Optional[Dict]     # keepout: the raw entry `keepout_hit` reads
 
+
+# --------------------------------------------------------------------------
+# The declared-claim measurement, as three free functions (#698)
+#
+# `QuenchState` is not the only consumer any more. `seeder.reseat_scope` has to
+# ask "is this part further outside its declared claims than it was" WITHOUT
+# arming the per-pose seat gate -- `pose_score.make_state` passes that state
+# `keepouts` and deliberately withholds `intent_zones`, because the re-seat's
+# whole job is to move a part that is ALREADY violating and a monotone gate
+# would make it refuse its own target. So the measurement is separable from the
+# state that enforces it, and there is still exactly ONE of it.
+# --------------------------------------------------------------------------
+
+def build_zone_spec(zones, parts, refs=None
+                    ) -> Dict[str, Tuple[_IntentTerm, ...]]:
+    """The pose-INVARIANT zone terms binding each ref: `{ref: (term, ...)}`.
+
+    Everything that does not depend on a pose is settled here so the per-pose
+    cost is the geometry and nothing else: block membership, the
+    exclusive-zone side filter, the tolerance, and the `zone_fits_courtyard`
+    anchor decision (which reads only w/h and tests both orders, so no rotation
+    in this engine's lattice can flip it).
+
+    `refs` limits the walk to a subset -- the re-seat measures its scope, not
+    the board. `None` means every part, which is what a `QuenchState` wants.
+
+    The KEEP-OUT half is deliberately NOT here: it is resolved live, per call,
+    by `intent_spec` -- see that function for why freezing it breaks #701's
+    census.
+    """
+    spec: Dict[str, Tuple[_IntentTerm, ...]] = {}
+    if not zones:
+        return spec
+    from . import floorplan as _fp
+    items = (parts.items() if refs is None
+             else ((r, parts[r]) for r in refs if r in parts))
+    for _ref, _p in items:
+        _terms: List[_IntentTerm] = []
+        for _z in zones:
+            _tol = float(_z['tolerance_mm'])
+            if _ref in _z['refs']:
+                # At the ORIGIN: `zone_fits_courtyard` reads only w/h, so
+                # position is irrelevant and passing 0,0 says so. Both
+                # rotations, matching `seeder.zone_gate`'s own form, so the two
+                # cannot disagree about which branch a part is on.
+                _anchor = not any(
+                    _fp.zone_fits_courtyard(
+                        _z['rect'], _p.rect(0.0, 0.0, _r), _tol)
+                    for _r in (_p.rot % 360, (_p.rot + 90) % 360))
+                _terms.append(_IntentTerm(
+                    'zone_containment', _z['name'], tuple(_z['rect']),
+                    _tol, _anchor, None))
+            elif _z['exclusive'] and (not _z['side']
+                                      or _p.side == _z['side']):
+                # `elif`, not `if`: `rule_zone_exclusive` skips members of the
+                # block that owns the zone. Membership and the side filter are
+                # both pose-invariant, so the set of rects a stranger must
+                # avoid is resolved here.
+                _terms.append(_IntentTerm(
+                    'zone_exclusive', _z['name'], tuple(_z['rect']),
+                    legality.EPS, False, None))
+        if _terms:
+            spec[_ref] = tuple(_terms)
+    return spec
+
+
+def intent_spec(zone_spec, keepouts_for, ref) -> Tuple[_IntentTerm, ...]:
+    """The claims binding `ref` right now: frozen zone terms, plus keep-out
+    terms derived LIVE from `keepouts_for`.
+
+    The keep-out slice is deliberately not frozen. `seeder.count_legal_poses`
+    answers "how many seats would lifting keep-out X free" by temporarily
+    removing X from `state.keepouts_for[ref]` and recounting -- and a frozen
+    copy defeats that lift silently, because `pose_ok` reaches this gate
+    through `candidate_valid`. Measured when it WAS frozen: the #701 census
+    went `lifted=49` to `lifted=0` on arm Q's fixture, and a stranded part's
+    verdict degraded from `keepout_blocks` to `no_movable_neighbour`, whose
+    prose -- "NOTHING seated is near enough to be in the way" -- is verbatim
+    the misleading answer that disclosure exists to replace.
+
+    Still pose-INVARIANT and still resolved once: `keepouts_for` is the cached
+    resolution, and this only reads it.
+    """
+    zones = zone_spec.get(ref, ())
+    kos = keepouts_for.get(ref, ())
+    if not kos:
+        return zones
+    return zones + tuple(
+        _IntentTerm('keepout', str(k.get('name') or '<unnamed>'),
+                    None, 0.0, False, k)
+        for k in kos)
+
+
+def intent_term_values(spec: Tuple[_IntentTerm, ...], rects
+                       ) -> Tuple[float, ...]:
+    """This pose measured against every term in `spec`, in the spec's order.
+
+    A VECTOR, never a scalar -- see `_IntentTerm`.
+    """
+    from . import floorplan as _fp   # lazy: see seeder.pose_ok's reason
+    out = []
+    for t in spec:
+        if t.rule == 'keepout':
+            # BOTH rects, because `rule_keepout` grades both: a THT part's
+            # leads pierce a keep-out from the far side.
+            out.append(_fp.keepout_hit(t.entry, rects))
+        elif t.rule == 'zone_exclusive':
+            # COURTYARD ONLY -- `rule_zone_exclusive` reads `part.rect` and
+            # never `tht_rect`. Matching the grade includes matching what it
+            # declines to measure.
+            out.append(rect_overlap_area(rects[0], t.rect))
+        else:
+            out.append(_fp.zone_escape(t.rect, rects[0], t.anchor)[0])
+    return tuple(out)
+
+
+class IntentProbe:
+    """MEASUREMENT-ONLY declared-claim vectors for a state whose GATE has none.
+
+    `pose_score.make_state` hands the re-seat `keepouts` and deliberately
+    WITHHOLDS `intent_zones` (pose_score.py:84-90): the re-seat's job is to move
+    a part that is ALREADY violating, and a monotone per-pose zone gate would
+    make the repair refuse its own target. That argument is about the SEAT
+    PREDICATE. It says nothing against measuring the same claims once before and
+    once after the pass, which is what this does. It assigns to neither
+    `state._intent_spec` nor `state._intent_active`, so `candidate_valid` sees
+    exactly what it saw before -- and a source guard in
+    `tests/test_698_reseat_acceptance.py` pins that, because the tempting
+    "simplification" is to pass `intent_zones=` to `make_state` and re-open the
+    bug `pose_score.py` describes.
+
+    The spec is FROZEN here, unlike `intent_spec_for` -- which is deliberately
+    live so `seeder.count_legal_poses` can lift a keep-out and recount
+    (see `intent_spec`). Different consumer, opposite requirement: a
+    before/after comparison of two vectors of DIFFERENT LENGTH is not a
+    comparison at all, and a lift landing between the two snapshots would
+    produce one silently.
+    """
+
+    def __init__(self, state, zones: Sequence[Dict] = (), refs=None) -> None:
+        self.state = state
+        rs = (sorted(state.parts) if refs is None
+              else sorted(r for r in refs if r in state.parts))
+        zone_spec = build_zone_spec(zones, state.parts, refs=rs)
+        self.spec: Dict[str, Tuple[_IntentTerm, ...]] = {}
+        for r in rs:
+            s = intent_spec(zone_spec, state.keepouts_for, r)
+            if s:
+                self.spec[r] = s
+        self.refs: Tuple[str, ...] = tuple(rs)
+
+    @property
+    def active(self) -> bool:
+        return bool(self.spec)
+
+    def terms(self, ref) -> Tuple[float, ...]:
+        """`ref`'s claim vector at its CURRENT pose.
+
+        Safe to call in the middle of a sweep that is moving OTHER parts, and
+        `_incumbent_intent`'s docstring is why: the intent terms are
+        part-vs-DECLARED-GEOMETRY, never part-vs-part, so nothing another part
+        does can change them. That is what makes this legal to hand to
+        `reconstruct.prune_assignment` as a per-ref callable.
+        """
+        s = self.spec.get(ref)
+        if not s:
+            return ()
+        return intent_term_values(s, self.state.parts[ref].rects())
+
+    def snapshot(self) -> Dict:
+        """Every bound ref's vector, plus the BREACH COUNT and its by-rule split.
+
+        A term is breached when its value is above its own `threshold` -- the
+        comparison `intent_clear` makes, and the same event `floorplan.grade`
+        raises a `Violation` for, so the count is in the GRADE's currency while
+        every underlying compare stays in the TERM's.
+
+        The count is only ever a TRIGGER, never a guard. On its own it carries
+        the aggregation trap `_IntentTerm` names: a part hopping from keep-out A
+        into keep-out B reads `1 -> 1`, which a monotone rule would admit. The
+        guard is `licence()` below, on the VECTORS.
+        """
+        vecs = {r: self.terms(r) for r in sorted(self.spec)}
+        count = 0
+        by_rule: Dict[str, int] = {}
+        for r, vals in vecs.items():
+            for v, t in zip(vals, self.spec[r]):
+                if v > t.threshold:
+                    count += 1
+                    by_rule[t.rule] = by_rule.get(t.rule, 0) + 1
+        return {'count': count, 'by_rule': by_rule, 'terms': vecs}
+
+    def licence(self, before: Dict, after: Dict) -> Tuple[bool, List[Tuple]]:
+        """(ok, risen) -- no declared term binding a probed ref may RISE.
+
+        TERMWISE and never summed (`_IntentTerm`), which is what makes
+        `snapshot()['count']` safe to use as the acceptance trigger: the A -> B
+        keep-out hop that the count cannot see is a term that ROSE, and this
+        refuses it. `risen` names each one `(ref, rule, name, before, after)` --
+        the #701 doctrine that a claim which refuses is a NAMED verdict.
+        """
+        risen: List[Tuple] = []
+        b_terms, a_terms = before.get('terms', {}), after.get('terms', {})
+        for ref in sorted(self.spec):
+            bv, av = b_terms.get(ref, ()), a_terms.get(ref, ())
+            if len(bv) != len(av):
+                # Cannot happen with a frozen spec; if it ever does, refusing is
+                # the only honest answer -- see the class docstring.
+                risen.append((ref, 'spec', 'length-changed', len(bv), len(av)))
+                continue
+            for t, b, a in zip(self.spec[ref], bv, av):
+                if a > b + legality.EPS:
+                    risen.append((ref, t.rule, t.name, b, a))
+        return (not risen), risen
+
+
 # Both helpers now live in placement/legality.py, the single home shared with
 # fanout_clearance (which carried byte-identical copies). Kept as module-level
 # aliases: they are part of this module's de-facto surface (tests import them).
@@ -561,51 +777,19 @@ class QuenchState:
                     self.keepouts_for[_ref] = _binding
 
         # --- #702 declared claims, resolved ONCE per state ------------------
-        # Everything pose-invariant is settled here so the per-pose cost is the
-        # geometry and nothing else: block membership, the exclusive-zone side
-        # filter, the tolerance, and the `zone_fits_courtyard` anchor decision
-        # (which reads only w/h and tests both orders, so no rotation in this
-        # engine's lattice can flip it).
+        # The zone half is built by the free `build_zone_spec` (#698), which is
+        # the SAME construction `seeder.reseat_scope` uses for its acceptance
+        # measurement -- a second copy here is how the two would come to
+        # disagree about which parts a block binds.
         #
         # `_intent_active` is False on every board that declares nothing --
         # which is every board in the corpus today -- and `candidate_valid`
         # guards on it before any arithmetic, so the whole channel costs one
         # bool load and one branch and the objective is bit-identical.
         self.intent_zones = tuple(intent_zones or ())
-        self._intent_spec: Dict[str, Tuple[_IntentTerm, ...]] = {}
-        self._intent_active = False
-        if self.intent_zones or self.keepouts_for:
-            from . import floorplan as _fp
-            for _ref, _p in self.parts.items():
-                _terms: List[_IntentTerm] = []
-                for _z in self.intent_zones:
-                    _tol = float(_z['tolerance_mm'])
-                    if _ref in _z['refs']:
-                        # At the ORIGIN: `zone_fits_courtyard` reads only w/h,
-                        # so position is irrelevant and passing 0,0 says so.
-                        # Both rotations, matching `seeder.zone_gate`'s own
-                        # form, so the two cannot disagree about which branch
-                        # a part is on.
-                        _anchor = not any(
-                            _fp.zone_fits_courtyard(
-                                _z['rect'], _p.rect(0.0, 0.0, _r), _tol)
-                            for _r in (_p.rot % 360, (_p.rot + 90) % 360))
-                        _terms.append(_IntentTerm(
-                            'zone_containment', _z['name'], tuple(_z['rect']),
-                            _tol, _anchor, None))
-                    elif _z['exclusive'] and (not _z['side']
-                                              or _p.side == _z['side']):
-                        # `elif`, not `if`: `rule_zone_exclusive` skips members
-                        # of the block that owns the zone. Membership and the
-                        # side filter are both pose-invariant, so the set of
-                        # rects a stranger must avoid is resolved here.
-                        _terms.append(_IntentTerm(
-                            'zone_exclusive', _z['name'], tuple(_z['rect']),
-                            legality.EPS, False, None))
-                if _terms:
-                    self._intent_spec[_ref] = tuple(_terms)
-            self._intent_active = bool(self._intent_spec
-                                       or self.keepouts_for)
+        self._intent_spec: Dict[str, Tuple[_IntentTerm, ...]] = build_zone_spec(
+            self.intent_zones, self.parts)
+        self._intent_active = bool(self._intent_spec or self.keepouts_for)
         # ref -> the incumbent pose's term vector. Cleared beside
         # `_inc_violation` on every move, for the same reason. Never computed
         # on a compliant board: `intent_ok` returns on its absolute branch.
@@ -1196,14 +1380,7 @@ class QuenchState:
         Still pose-INVARIANT and still resolved once: `keepouts_for` is the
         cached resolution, and this only reads it.
         """
-        zones = self._intent_spec.get(ref, ())
-        kos = self.keepouts_for.get(ref, ())
-        if not kos:
-            return zones
-        return zones + tuple(
-            _IntentTerm('keepout', str(k.get('name') or '<unnamed>'),
-                        None, 0.0, False, k)
-            for k in kos)
+        return intent_spec(self._intent_spec, self.keepouts_for, ref)
 
     def intent_terms(self, ref, rects) -> Tuple[float, ...]:
         """This pose measured against every declared claim binding `ref`, in
@@ -1211,21 +1388,7 @@ class QuenchState:
 
         A VECTOR, never a scalar -- see `_IntentTerm`.
         """
-        from . import floorplan as _fp   # lazy: see seeder.pose_ok's reason
-        out = []
-        for t in self.intent_spec_for(ref):
-            if t.rule == 'keepout':
-                # BOTH rects, because `rule_keepout` grades both: a THT part's
-                # leads pierce a keep-out from the far side.
-                out.append(_fp.keepout_hit(t.entry, rects))
-            elif t.rule == 'zone_exclusive':
-                # COURTYARD ONLY -- `rule_zone_exclusive` reads `part.rect` and
-                # never `tht_rect`. Matching the grade includes matching what
-                # it declines to measure.
-                out.append(rect_overlap_area(rects[0], t.rect))
-            else:
-                out.append(_fp.zone_escape(t.rect, rects[0], t.anchor)[0])
-        return tuple(out)
+        return intent_term_values(self.intent_spec_for(ref), rects)
 
     def intent_clear(self, ref, rects) -> bool:
         """ABSOLUTE: every term at or below its own threshold.
@@ -1839,10 +2002,18 @@ class QuenchState:
                 'halo': halo, 'edge': edge, 'hpwl': self.hpwl(),
                 'align': align, 'orient': orient, 'corridor_cut': cut}
 
-    def hpwl(self):
+    def hpwl(self, nets=None):
         """Half-perimeter wirelength: sum over nets of the pad bbox's width plus
         height (mm). The classic placement-quality proxy, and one of the columns
         a placement scorecard wants (#411).
+
+        `nets` restricts the sum to a net-id subset -- what
+        `seeder.reseat_scope` needs to price the wirelength of the nets ITS
+        scope touches (#698). `None`, the default, is every net and is the
+        loop this method has always run, so `legality_metrics` and therefore
+        `reconstruct.measure`'s `hpwl` term are bit-identical. One optional
+        argument rather than a second HPWL in `seeder.py`: two implementations
+        of one number is how they come to disagree.
 
         Its value here is that it is airwire-ORDER-INVARIANT by construction: it
         reads only the extremes of each net's pad positions, so unlike the MST
@@ -1854,7 +2025,10 @@ class QuenchState:
         ever reappears.)
         """
         total = 0.0
-        for net_id, refs in self.net_refs.items():
+        items = (self.net_refs.items() if nets is None else
+                 [(n, self.net_refs[n]) for n in sorted(nets)
+                  if n in self.net_refs])
+        for net_id, refs in items:
             xs, ys = [], []
             for ref in refs:
                 for gx, gy, n in self.parts[ref].pad_globals():

--- a/py_placer/placement/reconstruct.py
+++ b/py_placer/placement/reconstruct.py
@@ -1039,15 +1039,21 @@ def prune_assignment(state, old: Dict[str, Tuple[float, float, float]],
         state.apply_move(ref, x, y, rot)
         after = measure(state, edge_bands)
         after_intent = intent_probe(ref) if intent_probe is not None else ()
-        # 1e-9: the same tolerance `seeder.eviction_licence_ok` uses. One pass
-        # must not carry two.
-        undoes_intent = any(a > b + 1e-9
+        # `legality.EPS`, the same tolerance `quench.IntentProbe.licence` uses
+        # for the same question -- "did a declared term RISE". One pass must
+        # not answer it two ways.
+        undoes_intent = any(a > b + legality.EPS
                             for a, b in zip(after_intent, base_intent))
-        if not undoes_intent and (after < base
-                                  or (after == base and ref not in evidenced)):
+        wanted = (after < base or (after == base and ref not in evidenced))
+        if not undoes_intent and wanted:
             pruned.append(ref)
         else:
-            if undoes_intent:
+            # `and wanted`: without it this credits the probe for every revert
+            # the TUPLE refused on its own, so a part the sweep was never going
+            # to touch is reported as "a declared claim justifies it". A note
+            # that overstates what the new conjunct did is how the conjunct
+            # comes to look load-bearing when it is inert.
+            if undoes_intent and wanted:
                 held.append(ref)
             state.apply_move(ref, *cur)
     if notes is not None and pruned:

--- a/py_placer/placement/reconstruct.py
+++ b/py_placer/placement/reconstruct.py
@@ -959,7 +959,8 @@ def prune_assignment(state, old: Dict[str, Tuple[float, float, float]],
                      notes: Optional[List[str]] = None,
                      edge_bands: Optional[Dict[str, float]] = None,
                      exempt: Optional[Set[str]] = None,
-                     evidenced: Optional[Set[str]] = None) -> List[str]:
+                     evidenced: Optional[Set[str]] = None,
+                     intent_probe=None) -> List[str]:
     """Per-part revert sweep after an ACCEPTED assignment (run-4 F3b).
 
     The stage gate is one board-wide lexicographic tuple, so an assignment
@@ -985,9 +986,38 @@ def prune_assignment(state, old: Dict[str, Tuple[float, float, float]],
     displaced hole coming home is gate-neutral by construction for the same
     reason, so requiring strict improvement there would reject the homecoming
     the whole fit exists to produce.
+
+    `intent_probe(ref) -> tuple` (#698) is the DECLARED-CLAIM conjunct on the
+    revert: a callable returning `ref`'s intent term vector at its CURRENT
+    pose, sampled either side of the tentative restore. A revert that would
+    make any term WORSE is refused -- termwise and never summed, matching
+    `quench.QuenchState.intent_ok`.
+
+    It is needed because the tuple this sweep compares has **no intent term at
+    all**, so a part that escaped a declared keep-out looks like a pure
+    hpwl loss and is reverted before the pass gate ever runs. Measured on
+    #698's fixture: `prune: reverted 1 per-part mis-move(s) ... U1`, on 20 of
+    20 seeds, undoing a seat that had cleared the keep-out.
+
+    It is a CONJUNCT rather than an `exempt` entry deliberately. `exempt` skips
+    the part entirely, so a ref that escaped a 0.1mm2 keep-out kiss would also
+    become immune to prune reverting a 30mm mis-move. With the probe the sweep
+    still reverts everything the tuple wants reverted, unless doing so would
+    re-break a declaration -- so it stays monotone by construction, now on
+    `(tuple, intent vector)` jointly, which is the property the paragraph above
+    claims.
+
+    Sampling `ref`'s vector mid-sweep is safe while OTHER parts are moving, and
+    `_incumbent_intent`'s docstring is why: the intent terms are
+    part-vs-DECLARED-GEOMETRY, never part-vs-part.
+
+    With `intent_probe=None` both vectors are `()`, `zip` is empty, `any(())`
+    is False, and the expression is character-for-character the original -- so
+    every existing caller is inert.
     """
     evidenced = evidenced or set()
     pruned: List[str] = []
+    held: List[str] = []
 
     def moved_dist(item):
         ref, (x, y, _r) = item
@@ -1004,16 +1034,29 @@ def prune_assignment(state, old: Dict[str, Tuple[float, float, float]],
         if math.hypot(p.x - x, p.y - y) < 1e-9 and abs(p.rot - rot) < 1e-9:
             continue
         base = measure(state, edge_bands)
+        base_intent = intent_probe(ref) if intent_probe is not None else ()
         cur = (p.x, p.y, p.rot)
         state.apply_move(ref, x, y, rot)
         after = measure(state, edge_bands)
-        if after < base or (after == base and ref not in evidenced):
+        after_intent = intent_probe(ref) if intent_probe is not None else ()
+        # 1e-9: the same tolerance `seeder.eviction_licence_ok` uses. One pass
+        # must not carry two.
+        undoes_intent = any(a > b + 1e-9
+                            for a, b in zip(after_intent, base_intent))
+        if not undoes_intent and (after < base
+                                  or (after == base and ref not in evidenced)):
             pruned.append(ref)
         else:
+            if undoes_intent:
+                held.append(ref)
             state.apply_move(ref, *cur)
     if notes is not None and pruned:
         notes.append(f"prune: reverted {len(pruned)} per-part mis-move(s) "
                      f"the global gate could not see: {', '.join(pruned)}")
+    if notes is not None and held:
+        notes.append(f"prune: KEPT {len(held)} move(s) that a declared claim "
+                     f"justifies and the gate tuple cannot rank: "
+                     f"{', '.join(held)}")
     return pruned
 
 

--- a/py_placer/placement/seeder.py
+++ b/py_placer/placement/seeder.py
@@ -2638,6 +2638,260 @@ def eviction_licence_ok(before: Sequence[float],
             and after[_ovl] <= before[_ovl] + 1e-9)
 
 
+# --------------------------------------------------------------------------
+# #698: what an EXPLICIT re-seat may be accepted on
+#
+# The auto scope and an explicit scope differ in one structural way, and every
+# decision below follows from it. On `auto:damage_witnesses` the pass's win IS
+# `oob`, which sits at index 3 of the gate tuple -- ABOVE `hpwl` -- so the
+# lexicographic compare already sees it, prune cannot revert a genuine
+# homecoming, and `after[oob] < before[oob]` is a complete rule. On an explicit
+# scope the win is a declared claim or the scope's own wirelength, which the
+# tuple cannot see AT ALL. That is why the explicit branch needs a term-wise
+# safety condition plus a SEPARATE trigger, and why the answer is not an eighth
+# tuple term (`measure` has no intent to measure, and
+# tests/test_run8_gate_conjuncts.py pins the arity at 7 with its own reason).
+# --------------------------------------------------------------------------
+
+#: The scope-relevant terms an explicit re-seat may be accepted ON, in the order
+#: they are tried and reported. Exported so a test reads the vocabulary FROM the
+#: engine rather than restating it -- `quench.INTENT_ENFORCED_RULES`'s device.
+#: Severity order, weakest last: `scope_hpwl` is a netlist PROXY, and the whole
+#: point of a declared claim is that it overrules the proxy.
+RESEAT_BASES = ('locked_contacts', 'pad_pairs', 'hole', 'oob', 'intent',
+                'stacks', 'overlap', 'scope_hpwl')
+
+#: Each basis in its OWN currency. There is no exchange rate between them and
+#: `--reseat-min-gain` does not invent one -- see `reseat_accept`.
+RESEAT_BASIS_UNITS = {'locked_contacts': 'count', 'pad_pairs': 'count',
+                      'hole': 'mm', 'oob': 'mm', 'intent': 'count',
+                      'stacks': 'count', 'overlap': 'mm2',
+                      'scope_hpwl': 'mm'}
+
+#: The ONE gate term an explicit re-seat is licensed to worsen, and the reason
+#: it is not also a basis: a seat made for a declared reason is hpwl-worse BY
+#: CONSTRUCTION, because hpwl is the netlist proxy the declaration overrules.
+#: `placement/README.md` says it in the same words for the evicted-part
+#: exemption -- "an edge-class seat is hpwl-worse BY DESIGN". Measured on #698's
+#: own fixture: escaping keep-out `hot` costs +0.812 mm of hpwl, so any rule
+#: that forbids hpwl rising refuses exactly the case this exists for.
+RESEAT_LICENSED_TERM = 'hpwl'
+
+
+def reseat_safety_ok(before: Sequence[float],
+                     after: Sequence[float]) -> Tuple[bool, List[str]]:
+    """(ok, the GATE_TERMS that ROSE). TERM-WISE, deliberately not lexicographic.
+
+    A lexicographic `after <= before` reads `hpwl` at index 5 and so refuses
+    every declared-claim escape -- the trap this whole change exists to avoid.
+    Term-wise with one licensed term says the intended thing instead: the pass
+    may pay wirelength for a claim, and may pay NOTHING else.
+
+    `oob` is hard but is NOT required to improve, and that asymmetry is issue
+    #698 in one line: requiring it to improve is what makes the pass a no-op
+    for any part already on the board, while requiring it not to worsen keeps
+    the defect CLAUDE.md ranks first -- pad copper off the outline -- unbuyable.
+    """
+    from placement import reconstruct as _recon
+    idx = _recon.GATE_TERMS.index
+    rose: List[str] = []
+    for n in ('locked_contacts', 'pad_pairs', 'stacks'):
+        if after[idx(n)] > before[idx(n)]:          # integer counts, exact
+            rose.append(n)
+    for n in ('hole', 'oob', 'overlap'):
+        # 1e-9, the SAME epsilon `eviction_licence_ok` uses. Two licences on
+        # one pass must not carry two tolerances, and `measure` rounds these
+        # to 4 decimals anyway.
+        if after[idx(n)] > before[idx(n)] + 1e-9:
+            rose.append(n)
+    return (not rose), rose
+
+
+def scope_hpwl(state, refs) -> float:
+    """HPWL over the nets a scope ref has a pad on (mm).
+
+    Scope-restricted rather than the tuple's board-wide `hpwl`, for one
+    measured reason: at `--evict-depth >= 1` the pass also moves parts OUTSIDE
+    its scope, so a board-wide delta can be carried by an evicted part while
+    the ref the operator named got worse. The pass is judged on its scope.
+    """
+    nets = set()
+    for r in refs:
+        p = state.parts.get(r)
+        if p is None:
+            continue
+        for _gx, _gy, n in p.pad_globals():
+            if n > 0:
+                nets.add(n)
+    return round(state.hpwl(nets), 3)
+
+
+def reseat_bases(gate: Sequence[float], intent_count: int,
+                 hpwl_scope: float) -> Dict[str, float]:
+    """{basis -> value} for all of `RESEAT_BASES` at one measurement point."""
+    from placement import reconstruct as _recon
+    idx = _recon.GATE_TERMS.index
+    out = {n: gate[idx(n)] for n in RESEAT_BASES
+           if n in _recon.GATE_TERMS}
+    out['intent'] = intent_count
+    out['scope_hpwl'] = hpwl_scope
+    return out
+
+
+def reseat_accept(before: Sequence[float], after: Sequence[float], *,
+                  scope_source: str,
+                  witnesses_before, witnesses_after,
+                  bases_before: Optional[Dict[str, float]] = None,
+                  bases_after: Optional[Dict[str, float]] = None,
+                  intent_risen: Sequence = (),
+                  min_gain: float = 0.0) -> Tuple[bool, Dict]:
+    """THE re-seat acceptance rule. (accepted, accept_basis).
+
+    Plain numbers, no state -- `eviction_licence_ok`'s shape and its reason:
+    the whole policy becomes directly testable without a fixture that has to
+    defeat `prune_assignment` first.
+
+    `--reseat-min-gain` is MILLIMETRES and gates the `scope_hpwl` basis ONLY.
+    A single scalar compared against a count, a millimetre, an mm2 of intrusion
+    and `keepout_hit`'s fabricated circle marker is the summing error wearing a
+    threshold's clothes: it asserts an exchange rate between "half a millimetre
+    of wire" and "half a keep-out violation". `_IntentTerm` refuses that rate
+    inside one ref's vector, and the accept basis refuses it across bases.
+    Count bases threshold at ONE WHOLE defect, which is the only figure their
+    currency has; the remaining continuous bases are legality terms, where any
+    strict improvement is real and a shuffle cannot manufacture one.
+
+    `scope_hpwl` is where the sideways shuffle lives and is therefore both LAST
+    and the only gated basis.
+    """
+    from placement import reconstruct as _recon
+    _oob = _recon.GATE_TERMS.index('oob')
+    _hp = _recon.GATE_TERMS.index(RESEAT_LICENSED_TERM)
+    witness_ok = len(witnesses_after) <= len(witnesses_before)
+
+    basis: Dict = {
+        'scope_source': scope_source,
+        'witness_ok': witness_ok,
+        'witnesses_before': len(witnesses_before),
+        'witnesses_after': len(witnesses_after),
+        'hpwl_before': before[_hp], 'hpwl_after': after[_hp],
+        'hpwl_delta': round(after[_hp] - before[_hp], 3),
+        'min_gain': float(min_gain), 'min_gain_units': 'mm',
+        'min_gain_applies_to': 'scope_hpwl',
+        'fired': None, 'terms': [],
+        # Measured-and-clean must not look like never-measured: the auto path
+        # leaves these None rather than reporting an empty pass.
+        'safety': None, 'intent_licence': None,
+    }
+
+    if scope_source != 'explicit':
+        basis['policy'] = 'auto:oob-strict'
+        accepted = (after[_oob] < before[_oob] and witness_ok)
+        basis['terms'] = [{
+            'term': 'oob', 'units': 'mm', 'before': before[_oob],
+            'after': after[_oob],
+            'gain': round(before[_oob] - after[_oob], 4),
+            'min_gain_applies': False,
+            'would_fire': after[_oob] < before[_oob],
+            'first': after[_oob] < before[_oob]}]
+        if accepted:
+            basis['fired'] = 'oob'
+        return accepted, basis
+
+    basis['policy'] = 'explicit:one-term-strict'
+    safe, rose = reseat_safety_ok(before, after)
+    basis['safety'] = {'ok': safe, 'worsened': rose,
+                       'licensed': RESEAT_LICENSED_TERM}
+    risen = [tuple(r) for r in intent_risen]
+    basis['intent_licence'] = {'ok': not risen, 'risen': risen}
+
+    bb = bases_before or {}
+    ba = bases_after or {}
+    fired = None
+    for name in RESEAT_BASES:
+        b, a = bb.get(name), ba.get(name)
+        if b is None or a is None:
+            continue
+        gain = b - a
+        units = RESEAT_BASIS_UNITS[name]
+        gated = (name == 'scope_hpwl')
+        if units == 'count':
+            ok = gain >= 1
+        elif gated:
+            ok = gain > max(abs(float(min_gain)), 1e-9)
+        else:
+            ok = gain > 1e-9
+        first = ok and fired is None
+        if first:
+            fired = name
+        # `would_fire` is per-term and says only "this basis improved enough".
+        # The DECISION is the top-level `fired`, which is None unless the
+        # safety half also held -- so a refused pass still discloses which
+        # basis would have carried it, rather than reporting a bare no.
+        basis['terms'].append({
+            'term': name, 'units': units,
+            'before': b, 'after': a,
+            'gain': round(gain, 4) if units != 'count' else gain,
+            'min_gain_applies': gated,
+            'would_fire': bool(ok), 'first': bool(first)})
+
+    accepted = bool(witness_ok and safe and not risen and fired is not None)
+    basis['fired'] = fired if accepted else None
+    return accepted, basis
+
+
+def reseat_refusal_note(n_scope: int, basis: Dict) -> str:
+    """Why the pass was refused, in the terms it was actually judged on.
+
+    The old note said "did not strictly improve the off-board amount" on EVERY
+    path, which on an explicit scope names a term the operator never asked
+    about and cannot move -- that sentence, quoted back with `(2.15 -> 2.15)`
+    in it, is what issue #698 was filed with. A refusal that misnames its own
+    reason sends the reader to fix the wrong thing.
+    """
+    head = f"REVERTED: re-seating {n_scope} part(s) was refused"
+    if basis.get('policy') == 'auto:oob-strict':
+        t = (basis.get('terms') or [{}])[0]
+        return (f"{head}: on the AUTO scope the rule is that the off-board "
+                f"amount strictly improves ({t.get('before')} -> "
+                f"{t.get('after')}) and the witness count does not grow "
+                f"({basis.get('witnesses_before')} -> "
+                f"{basis.get('witnesses_after')}). Both conjuncts are "
+                f"required: the gate tuple is lexicographic, so a large oob "
+                f"win would hide a new stack or an hpwl blow-up below it, and "
+                f"a sideways move that changes neither is not a re-seat.")
+    if basis.get('eviction_licence') is False:
+        return (f"{head}: the eviction licence. See the note above.")
+    if not basis.get('witness_ok', True):
+        return (f"{head}: the off-outline part count GREW "
+                f"({basis.get('witnesses_before')} -> "
+                f"{basis.get('witnesses_after')}), which no basis may buy.")
+    safety = basis.get('safety') or {}
+    if not safety.get('ok', True):
+        return (f"{head}: it worsened {', '.join(safety.get('worsened') or [])}"
+                f". An explicit re-seat is licensed to pay "
+                f"{safety.get('licensed')} for a claim -- a seat made for a "
+                f"declared reason is hpwl-worse by construction -- and is "
+                f"licensed to pay nothing else.")
+    lic = basis.get('intent_licence') or {}
+    if not lic.get('ok', True):
+        why = "; ".join(f"{r} {rule} {name!r} {b:g} -> {a:g}"
+                        for r, rule, name, b, a in (lic.get('risen') or []))
+        return (f"{head}: a declared claim got WORSE ({why}). Measured "
+                f"termwise and never summed, so a part cannot leave one "
+                f"keep-out by entering another and report no change.")
+    gains = ", ".join(
+        f"{t['term']} {t['before']}->{t['after']} ({t['units']})"
+        for t in (basis.get('terms') or []))
+    mg = basis.get('min_gain') or 0.0
+    tail = (f" `scope_hpwl` additionally had to beat --reseat-min-gain "
+            f"{mg:g}mm." if mg else "")
+    return (f"{head}: nothing improved. An explicit scope is accepted when no "
+            f"hard term and no declared claim got worse AND at least one "
+            f"scope-relevant term strictly improved; none did. Considered: "
+            f"{gains}.{tail}")
+
+
 def reseat_scope(pcb_data, pcb_file: str, intent, *,
                  lock_globs: Optional[Sequence[str]] = None,
                  refs: Optional[Sequence[str]] = None,
@@ -2647,6 +2901,7 @@ def reseat_scope(pcb_data, pcb_file: str, intent, *,
                  grid_step: float = 0.1,
                  seed: int = 0,
                  evict_depth: int = 0,
+                 min_gain: float = 0.0,
                  edge_bands: Optional[Dict[str, float]] = None) -> Dict:
     """LIFT a subset of parts and re-seat them FROM SCRATCH at their net
     centroids, holding every other part fixed as an obstacle.
@@ -2810,6 +3065,14 @@ def reseat_scope(pcb_data, pcb_file: str, intent, *,
                 'evictions': 0, 'evictions_reverted': 0,
                 'gate_before': list(_recon.measure(state, edge_bands or {})),
                 'gate_after': list(_recon.measure(state, edge_bands or {})),
+                # #698: the SAME keys as the seated path, for the reason the
+                # census keys above are here -- a consumer that reads
+                # `accept_basis` on one path and KeyErrors on the other is the
+                # schema split this early-out already shipped once.
+                'accept_basis': {'scope_source': scope_source,
+                                 'policy': 'empty', 'fired': None,
+                                 'terms': [], 'safety': None,
+                                 'intent_licence': None},
                 'accepted': True, 'pruned': [],
                 'witnesses_before': sorted(witnesses_before),
                 'witnesses_after': sorted(witnesses_before),
@@ -2877,8 +3140,38 @@ def reseat_scope(pcb_data, pcb_file: str, intent, *,
               "part 30km off the board in a measured probe.")
     intent2 = dataclasses.replace(intent, edge_connectors=tuple(keep))
 
+    # ---- the declared-claim probe (#698) ------------------------------------
+    # Explicit scope only. On the auto scope the pass's win is `oob`, which the
+    # gate tuple already ranks above `hpwl`, so nothing here is needed and
+    # nothing here runs -- `place_reconstruct`'s ladder rung is bit-identical.
+    #
+    # MEASUREMENT ONLY. `state` was built by `pose_score.make_state`, which
+    # hands the re-seat `keepouts` and deliberately withholds `intent_zones`
+    # (pose_score.py:84-90) -- arming the monotone zone gate would make this
+    # pass refuse its own target. `IntentProbe` assigns to neither
+    # `state._intent_spec` nor `state._intent_active`.
+    probe = None
+    if scope_source == 'explicit':
+        from placement.groups import parse_sources as _parse_sources
+        from placement import quench as _q
+        # `or auto`: resolving at a bare `()` makes every `group:`-shaped block
+        # resolve to NOTHING, silently -- `cli_gates.resolve_intent_gate_for_cli`
+        # states the same rule and the same reason.
+        _srcs = tuple(group_sources) or _parse_sources('auto')
+        _bundle, _problems = floorplan.resolve_intent_gate(
+            intent, pcb_data, _srcs)
+        for _v in _problems:
+            # Reported, never dropped: a block that resolves to nothing gates
+            # nobody and looks identical to a gate that is working.
+            notes.append(f"intent gate: [{_v.rule}] {_v.message}")
+        probe = _q.IntentProbe(state, zones=_bundle['zones'], refs=scope)
+
     # ---- seat ---------------------------------------------------------------
     before = _recon.measure(state, gate_bands)
+    intent_before = probe.snapshot() if probe is not None else None
+    bases_before = (reseat_bases(before, intent_before['count'],
+                                 scope_hpwl(state, scope))
+                    if probe is not None else None)
     old = {r: (state.parts[r].x, state.parts[r].y, state.parts[r].rot)
            for r in sorted(scope)}
     res = seed_from_intent(
@@ -2944,10 +3237,22 @@ def reseat_scope(pcb_data, pcb_file: str, intent, *,
     after = _recon.measure(state, gate_bands)
     witnesses_after = _recon.damage_witnesses(state)
     _oob = _recon.GATE_TERMS.index('oob')
-    accepted = (after[_oob] < before[_oob]
-                and len(witnesses_after) <= len(witnesses_before))
+    intent_after = probe.snapshot() if probe is not None else None
+    bases_after = (reseat_bases(after, intent_after['count'],
+                                scope_hpwl(state, scope))
+                   if probe is not None else None)
+    _risen = ()
+    if probe is not None:
+        _lic_ok, _risen = probe.licence(intent_before, intent_after)
+    accepted, accept_basis = reseat_accept(
+        before, after, scope_source=scope_source,
+        witnesses_before=witnesses_before, witnesses_after=witnesses_after,
+        bases_before=bases_before, bases_after=bases_after,
+        intent_risen=_risen, min_gain=min_gain)
     if evicted and not eviction_licence_ok(before, after):
         accepted = False
+        accept_basis['fired'] = None
+        accept_basis['eviction_licence'] = False
         _stk = _recon.GATE_TERMS.index('stacks')
         _ovl = _recon.GATE_TERMS.index('overlap')
         notes.append(
@@ -2960,14 +3265,7 @@ def reseat_scope(pcb_data, pcb_file: str, intent, *,
             state.apply_move(ref, x, y, rot)
         witnesses_after = _recon.damage_witnesses(state)
         after = _recon.measure(state, gate_bands)
-        notes.append(
-            f"REVERTED: re-seating {len(scope)} part(s) did not strictly "
-            f"improve the off-board amount ({before[_oob]:g} -> "
-            f"{after[_oob]:g}) or raised the witness count "
-            f"({len(witnesses_before)} -> {len(witnesses_after)}). Both "
-            f"conjuncts are required: the gate tuple is lexicographic, so a "
-            f"large oob win would hide a new stack or an hpwl blow-up below "
-            f"it, and a sideways move that changes neither is not a re-seat.")
+        notes.append(reseat_refusal_note(len(scope), accept_basis))
 
     if evicted:
         notes.append(
@@ -3035,6 +3333,11 @@ def reseat_scope(pcb_data, pcb_file: str, intent, *,
             'scope': sorted(scope), 'scope_source': scope_source,
             'notes': notes,
             'gate_before': list(before), 'gate_after': list(after),
+            # #698: which scope-relevant term carried the pass, what the safety
+            # half saw, and every basis that did NOT fire. All three bases are
+            # always reported: a basis that measured nothing and a basis that
+            # measured no change must not look alike.
+            'accept_basis': accept_basis,
             'accepted': accepted, 'pruned': sorted(pruned),
             'witnesses_before': sorted(witnesses_before),
             'witnesses_after': sorted(witnesses_after),

--- a/py_placer/placement/seeder.py
+++ b/py_placer/placement/seeder.py
@@ -2672,10 +2672,19 @@ RESEAT_BASIS_UNITS = {'locked_contacts': 'count', 'pad_pairs': 'count',
 #: it is not also a basis: a seat made for a declared reason is hpwl-worse BY
 #: CONSTRUCTION, because hpwl is the netlist proxy the declaration overrules.
 #: `placement/README.md` says it in the same words for the evicted-part
-#: exemption -- "an edge-class seat is hpwl-worse BY DESIGN". Measured on #698's
-#: own fixture: escaping keep-out `hot` costs +0.812 mm of hpwl, so any rule
-#: that forbids hpwl rising refuses exactly the case this exists for.
+#: exemption -- "an edge-class seat is hpwl-worse BY DESIGN". Measured on
+#: `tests/test_698_reseat_acceptance.py`'s keep-out fixture, swept over 20
+#: seeds: escaping keep-out `hot` costs hpwl on 20 of 20 (6.82 to 12.39 mm --
+#: a different value per seed, since the seat search is seeded), so any rule
+#: that forbids hpwl rising refuses exactly the case this exists for. `arm_B`
+#: computes that counterfactual rather than asserting it.
 RESEAT_LICENSED_TERM = 'hpwl'
+
+#: The smallest change `reconstruct.measure` can express. It rounds every
+#: continuous term to 4 decimals, so a "gain" at or below this is rounding, not
+#: a measurement -- and the continuous legality bases are not gated by
+#: `--reseat-min-gain`, so nothing else would stop noise from carrying a pass.
+MEASURE_QUANTUM = 1e-4
 
 
 def reseat_safety_ok(before: Sequence[float],
@@ -2708,12 +2717,21 @@ def reseat_safety_ok(before: Sequence[float],
 
 
 def scope_hpwl(state, refs) -> float:
-    """HPWL over the nets a scope ref has a pad on (mm).
+    """HPWL over the NETS a scope ref has a pad on (mm).
 
-    Scope-restricted rather than the tuple's board-wide `hpwl`, for one
-    measured reason: at `--evict-depth >= 1` the pass also moves parts OUTSIDE
-    its scope, so a board-wide delta can be carried by an evicted part while
-    the ref the operator named got worse. The pass is judged on its scope.
+    Narrower than the tuple's board-wide `hpwl`, which is the point: a net that
+    touches no scope ref cannot move in this pass, so including it only adds a
+    constant that hides the signal.
+
+    It is NOT "the scope's own contribution", and the difference matters at
+    `--evict-depth >= 1`. The sum runs over every pad on those nets, so an
+    evicted neighbour sharing a net with the scope can supply part or all of
+    the gain while the ref the operator named got worse. Measured on the
+    `plain_board` fixture with scope `{U1}`, moving only CON2: `scope_hpwl`
+    62.0 -> 8.0. What stops that being a licence is elsewhere -- the intent
+    probe covers the whole board (see `reseat_scope`), and
+    `eviction_licence_ok` refuses any eviction that raised stacks or overlap --
+    not this function, which is only a wirelength number over a net set.
     """
     nets = set()
     for r in refs:
@@ -2736,6 +2754,36 @@ def reseat_bases(gate: Sequence[float], intent_count: int,
     out['intent'] = intent_count
     out['scope_hpwl'] = hpwl_scope
     return out
+
+
+def basis_skeleton(scope_source: str, *, policy: str,
+                   witnesses_before=(), witnesses_after=(),
+                   hpwl_before: float = 0.0, hpwl_after: float = 0.0,
+                   min_gain: float = 0.0) -> Dict:
+    """The `accept_basis` key set, in ONE place.
+
+    Every return path of `reseat_scope` -- the seated one, the early-out, and
+    both policies -- carries the same keys because they all come from here. The
+    early-out used to hand back 6 of the 15 under a comment promising parity,
+    which `reseat_refusal_note` then KeyError'd on: exactly the schema split
+    that early-out's own census keys exist to prevent, one field down.
+    """
+    return {
+        'scope_source': scope_source,
+        'policy': policy,
+        'witness_ok': True,
+        'witnesses_before': len(witnesses_before),
+        'witnesses_after': len(witnesses_after),
+        'hpwl_before': hpwl_before, 'hpwl_after': hpwl_after,
+        'hpwl_delta': round(hpwl_after - hpwl_before, 3),
+        'min_gain': float(min_gain), 'min_gain_units': 'mm',
+        'min_gain_applies_to': 'scope_hpwl',
+        'fired': None, 'terms': [],
+        # Measured-and-clean must not look like never-measured: a path that
+        # does not run these leaves them None rather than reporting a clean
+        # pass over nothing.
+        'safety': None, 'intent_licence': None,
+    }
 
 
 def reseat_accept(before: Sequence[float], after: Sequence[float], *,
@@ -2769,20 +2817,11 @@ def reseat_accept(before: Sequence[float], after: Sequence[float], *,
     _hp = _recon.GATE_TERMS.index(RESEAT_LICENSED_TERM)
     witness_ok = len(witnesses_after) <= len(witnesses_before)
 
-    basis: Dict = {
-        'scope_source': scope_source,
-        'witness_ok': witness_ok,
-        'witnesses_before': len(witnesses_before),
-        'witnesses_after': len(witnesses_after),
-        'hpwl_before': before[_hp], 'hpwl_after': after[_hp],
-        'hpwl_delta': round(after[_hp] - before[_hp], 3),
-        'min_gain': float(min_gain), 'min_gain_units': 'mm',
-        'min_gain_applies_to': 'scope_hpwl',
-        'fired': None, 'terms': [],
-        # Measured-and-clean must not look like never-measured: the auto path
-        # leaves these None rather than reporting an empty pass.
-        'safety': None, 'intent_licence': None,
-    }
+    basis = basis_skeleton(
+        scope_source, policy='', witnesses_before=witnesses_before,
+        witnesses_after=witnesses_after, hpwl_before=before[_hp],
+        hpwl_after=after[_hp], min_gain=min_gain)
+    basis['witness_ok'] = witness_ok
 
     if scope_source != 'explicit':
         basis['policy'] = 'auto:oob-strict'
@@ -2817,10 +2856,24 @@ def reseat_accept(before: Sequence[float], after: Sequence[float], *,
         gated = (name == 'scope_hpwl')
         if units == 'count':
             ok = gain >= 1
-        elif gated:
-            ok = gain > max(abs(float(min_gain)), 1e-9)
+        elif gated and min_gain:
+            # `>=`, not `>`. The flag's help calls it "the smallest win that
+            # COUNTS as a re-seat", and `scope_hpwl` is quantised to 3dp, so
+            # exact equality with a round threshold is the common case rather
+            # than a corner: `--reseat-min-gain 0.5` refusing a gain of 0.5
+            # would be the flag not doing what it says.
+            ok = gain >= float(min_gain) - 1e-9
         else:
-            ok = gain > 1e-9
+            # `MEASURE_QUANTUM`, not an epsilon. `reconstruct.measure` rounds
+            # every continuous term to 4dp, so a gain at or below that is not
+            # a measurement -- and these bases are ungated by `min_gain`, so
+            # nothing else stops noise from carrying a pass. Measured before
+            # this floor existed: `overlap 0.5000 -> 0.4999` (1e-4) fired and
+            # bought an hpwl blow-up of 50mm, which the licence permits
+            # because hpwl is licensed. Run 4 demoted `overlap` below `hpwl`
+            # in GATE_TERMS because 0.73mm2 of kiss had vetoed a 44mm
+            # homecoming; 0.0001mm2 should certainly not buy one.
+            ok = gain > MEASURE_QUANTUM
         first = ok and fired is None
         if first:
             fired = name
@@ -2850,6 +2903,16 @@ def reseat_refusal_note(n_scope: int, basis: Dict) -> str:
     reason sends the reader to fix the wrong thing.
     """
     head = f"REVERTED: re-seating {n_scope} part(s) was refused"
+    # FIRST, on BOTH policies. `reseat_scope` sets this flag on either scope,
+    # and the auto branch below returns -- so an evicted auto pass used to
+    # print "the off-board amount strictly improves (9.65 -> 0.0) and the
+    # witness count does not grow (2 -> 0)" as its REASON for refusing, with
+    # both conjuncts visibly satisfied in the sentence stating them. That is
+    # the defect this function exists to prevent, one branch over.
+    if basis.get('eviction_licence') is False:
+        return (f"{head}: the eviction licence -- moving parts outside the "
+                f"scope raised the stack count or the overlap area. See the "
+                f"note above for the figures.")
     if basis.get('policy') == 'auto:oob-strict':
         t = (basis.get('terms') or [{}])[0]
         return (f"{head}: on the AUTO scope the rule is that the off-board "
@@ -2860,8 +2923,6 @@ def reseat_refusal_note(n_scope: int, basis: Dict) -> str:
                 f"required: the gate tuple is lexicographic, so a large oob "
                 f"win would hide a new stack or an hpwl blow-up below it, and "
                 f"a sideways move that changes neither is not a re-seat.")
-    if basis.get('eviction_licence') is False:
-        return (f"{head}: the eviction licence. See the note above.")
     if not basis.get('witness_ok', True):
         return (f"{head}: the off-outline part count GREW "
                 f"({basis.get('witnesses_before')} -> "
@@ -2968,18 +3029,34 @@ def reseat_scope(pcb_data, pcb_file: str, intent, *,
          `evidenced=scope` (a part coming back onto the board is gate-neutral
          on several terms by construction, exactly like the mounting-hole
          homecoming that rule was written for).
-      3. A pass-specific conjunct the tuple cannot express: `oob` must STRICTLY
-         improve AND the witness count must not rise. The tuple's lexicographic
-         comparison stops at the first differing term, and a re-seat moves
-         `oob` (index 3) hugely in its own favour -- which would HIDE a new
-         stack, an hpwl blow-up or piled-on overlap below it. This conjunct is
-         what stops the pass 'succeeding' by moving a part sideways.
+      3. A pass-specific conjunct the tuple cannot express, and it depends on
+         `scope_source` (#698). See `reseat_accept`, which is the rule; in
+         outline:
+
+         * **AUTO scope** -- unchanged: `oob` must STRICTLY improve AND the
+           witness count must not rise. The tuple's lexicographic comparison
+           stops at the first differing term, and this pass moves `oob`
+           (index 3) hugely in its own favour, which would HIDE a new stack,
+           an hpwl blow-up or piled-on overlap below it.
+         * **EXPLICIT scope** -- the same rule is unsatisfiable here, because a
+           part that is legal and ON the board cannot move `oob` at all, so an
+           explicitly named ref could never be re-seated whatever the search
+           found. Instead: the witness count must not rise, no HARD gate term
+           may worsen (`hpwl` is the one licensed term -- a seat made for a
+           declared reason is hpwl-worse by construction), no declared claim
+           may worsen termwise, and at least one basis in `RESEAT_BASES` must
+           strictly improve. What stops a sideways move 'succeeding' is that
+           `oob` is no longer the only thing measured, not that it is required.
 
     Returns `{'moves', 'reseated', 'refused', 'unseated', 'evicted', 'scope',
     'scope_source', 'notes', 'gate_before', 'gate_after', 'accepted',
-    'witnesses_before', 'witnesses_after', 'edge_bands_dropped', 'pruned'}`.
+    'accept_basis', 'witnesses_before', 'witnesses_after',
+    'edge_bands_dropped', 'pruned'}`.
     `reseated` stays the SCOPE parts that moved; an evicted part is not a
-    re-seat and is counted separately.
+    re-seat and is counted separately. `accept_basis` is the whole verdict --
+    which basis carried the pass, what the safety half saw, and every basis
+    that did not fire -- and it is present on EVERY return path, including the
+    empty-scope early-out.
 
     NOT `placement/reseat.py`, which is a different mechanism for a different
     problem (Hungarian re-assignment of a proximity-tethered decap cluster onto
@@ -3051,6 +3128,7 @@ def reseat_scope(pcb_data, pcb_file: str, intent, *,
 
     def _empty(reason: str) -> Dict:
         notes.append(reason)
+        _empty_gate = _recon.measure(state, edge_bands or {})
         return {'moves': [], 'reseated': [], 'refused': sorted(refused),
                 'intent_used': intent,
                 'unseated': [], 'scope': [], 'scope_source': scope_source,
@@ -3063,16 +3141,20 @@ def reseat_scope(pcb_data, pcb_file: str, intent, *,
                 'no_pose_blockers': {}, 'no_pose_verdict': {},
                 'no_pose_census': {}, 'evicted': [],
                 'evictions': 0, 'evictions_reverted': 0,
-                'gate_before': list(_recon.measure(state, edge_bands or {})),
-                'gate_after': list(_recon.measure(state, edge_bands or {})),
+                'gate_before': list(_empty_gate),
+                'gate_after': list(_empty_gate),
                 # #698: the SAME keys as the seated path, for the reason the
                 # census keys above are here -- a consumer that reads
                 # `accept_basis` on one path and KeyErrors on the other is the
-                # schema split this early-out already shipped once.
-                'accept_basis': {'scope_source': scope_source,
-                                 'policy': 'empty', 'fired': None,
-                                 'terms': [], 'safety': None,
-                                 'intent_licence': None},
+                # schema split this early-out already shipped once. Built from
+                # the shared skeleton so the promise is structural, not a
+                # literal someone has to keep in step.
+                'accept_basis': basis_skeleton(
+                    scope_source, policy='empty',
+                    witnesses_before=witnesses_before,
+                    witnesses_after=witnesses_before,
+                    hpwl_before=_empty_gate[_recon.GATE_TERMS.index('hpwl')],
+                    hpwl_after=_empty_gate[_recon.GATE_TERMS.index('hpwl')]),
                 'accepted': True, 'pruned': [],
                 'witnesses_before': sorted(witnesses_before),
                 'witnesses_after': sorted(witnesses_before),
@@ -3164,7 +3246,16 @@ def reseat_scope(pcb_data, pcb_file: str, intent, *,
             # Reported, never dropped: a block that resolves to nothing gates
             # nobody and looks identical to a gate that is working.
             notes.append(f"intent gate: [{_v.rule}] {_v.message}")
-        probe = _q.IntentProbe(state, zones=_bundle['zones'], refs=scope)
+        # The WHOLE BOARD, not `refs=scope`. The scope is not the set of parts
+        # this pass can move: at `--evict-depth >= 1` it trades out neighbours
+        # nobody named, and those refs are not known until `seed_from_intent`
+        # has run -- after the "before" snapshot has to be taken. Scoped to the
+        # named refs, the licence could not see an evicted stranger pushed INTO
+        # a keep-out: the scope ref's own escape fires the `intent` basis, no
+        # gate term moves, and the pass is accepted having created the
+        # violation it was run to remove. Only claim-bound refs get terms, so
+        # on a board that declares nothing this is still empty.
+        probe = _q.IntentProbe(state, zones=_bundle['zones'])
 
     # ---- seat ---------------------------------------------------------------
     before = _recon.measure(state, gate_bands)

--- a/py_placer/placement/seeder.py
+++ b/py_placer/placement/seeder.py
@@ -2680,10 +2680,11 @@ RESEAT_BASIS_UNITS = {'locked_contacts': 'count', 'pad_pairs': 'count',
 #: computes that counterfactual rather than asserting it.
 RESEAT_LICENSED_TERM = 'hpwl'
 
-#: The smallest change `reconstruct.measure` can express. It rounds every
-#: continuous term to 4 decimals, so a "gain" at or below this is rounding, not
-#: a measurement -- and the continuous legality bases are not gated by
-#: `--reseat-min-gain`, so nothing else would stop noise from carrying a pass.
+#: The last digit `reconstruct.measure` keeps for the continuous LEGALITY terms
+#: -- `hole`, `oob` and `overlap` are rounded to 4 decimals (`hpwl` to 3). A
+#: gain must EXCEED this to count: a change in the last representable digit of
+#: a 4dp aggregate is not evidence of anything, and these bases are otherwise
+#: ungated, so nothing else would stop rounding from carrying a pass.
 MEASURE_QUANTUM = 1e-4
 
 
@@ -2764,13 +2765,20 @@ def basis_skeleton(scope_source: str, *, policy: str,
 
     Every return path of `reseat_scope` -- the seated one, the early-out, and
     both policies -- carries the same keys because they all come from here. The
-    early-out used to hand back 6 of the 15 under a comment promising parity,
-    which `reseat_refusal_note` then KeyError'd on: exactly the schema split
-    that early-out's own census keys exist to prevent, one field down.
+    early-out used to hand back 6 of the 15 under a comment promising parity:
+    exactly the schema split that early-out's own census keys exist to prevent,
+    one field down. (It did NOT crash anything -- `reseat_refusal_note` reads
+    every field with `.get`, and no engine path passes an empty-scope basis to
+    it. The defect is the broken promise, which a consumer outside this repo is
+    entitled to rely on, not a live traceback.)
     """
     return {
         'scope_source': scope_source,
         'policy': policy,
+        # Present on EVERY path, so the seated path cannot carry a key the
+        # early-out lacks. `reseat_scope` overwrites it with False when the
+        # licence refuses; None means the question never arose.
+        'eviction_licence': None,
         'witness_ok': True,
         'witnesses_before': len(witnesses_before),
         'witnesses_after': len(witnesses_after),
@@ -2856,23 +2864,35 @@ def reseat_accept(before: Sequence[float], after: Sequence[float], *,
         gated = (name == 'scope_hpwl')
         if units == 'count':
             ok = gain >= 1
-        elif gated and min_gain:
+        elif gated and float(min_gain) > MEASURE_QUANTUM:
             # `>=`, not `>`. The flag's help calls it "the smallest win that
             # COUNTS as a re-seat", and `scope_hpwl` is quantised to 3dp, so
             # exact equality with a round threshold is the common case rather
             # than a corner: `--reseat-min-gain 0.5` refusing a gain of 0.5
             # would be the flag not doing what it says.
+            #
+            # The guard is `> MEASURE_QUANTUM`, not a bare truthiness test, and
+            # that is the whole reason this branch is written out. A threshold
+            # BELOW the quantum must not reach it: with `elif gated and
+            # min_gain` a `--reseat-min-gain 1e-12` sent a gain of EXACTLY ZERO
+            # down this path and accepted it -- a looser gate from a stricter
+            # flag, admitting the very sideways shuffle the basis exists to
+            # refuse, and reachable (10 of the 16 corpus rows in
+            # `tests/measure_698_min_gain.py` have a gain of exactly 0.000). A
+            # negative `min_gain` did the same through the kwarg, which the CLI
+            # validator cannot see. Falling through to the floor below makes
+            # the rule MONOTONE in `min_gain`: a bigger threshold is never
+            # looser, and no threshold is ever looser than no threshold.
             ok = gain >= float(min_gain) - 1e-9
         else:
-            # `MEASURE_QUANTUM`, not an epsilon. `reconstruct.measure` rounds
-            # every continuous term to 4dp, so a gain at or below that is not
-            # a measurement -- and these bases are ungated by `min_gain`, so
-            # nothing else stops noise from carrying a pass. Measured before
-            # this floor existed: `overlap 0.5000 -> 0.4999` (1e-4) fired and
-            # bought an hpwl blow-up of 50mm, which the licence permits
-            # because hpwl is licensed. Run 4 demoted `overlap` below `hpwl`
-            # in GATE_TERMS because 0.73mm2 of kiss had vetoed a 44mm
-            # homecoming; 0.0001mm2 should certainly not buy one.
+            # `MEASURE_QUANTUM`, not an epsilon. These bases are ungated by
+            # `min_gain`, so without a floor the old `gain > 1e-9` fired on a
+            # change in the LAST DIGIT `measure` keeps -- an `overlap` gain of
+            # 1e-4 mm2 was enough to accept a pass, and since `hpwl` is the
+            # licensed term such a pass may be arbitrarily worse on wirelength.
+            # Run 4 demoted `overlap` below `hpwl` in GATE_TERMS because
+            # 0.73mm2 of kiss had vetoed a 44mm homecoming; 0.0001mm2 must not
+            # buy one in the other direction.
             ok = gain > MEASURE_QUANTUM
         first = ok and fired is None
         if first:
@@ -3144,17 +3164,19 @@ def reseat_scope(pcb_data, pcb_file: str, intent, *,
                 'gate_before': list(_empty_gate),
                 'gate_after': list(_empty_gate),
                 # #698: the SAME keys as the seated path, for the reason the
-                # census keys above are here -- a consumer that reads
-                # `accept_basis` on one path and KeyErrors on the other is the
-                # schema split this early-out already shipped once. Built from
-                # the shared skeleton so the promise is structural, not a
-                # literal someone has to keep in step.
+                # census keys above are here -- one function must not return
+                # two schemas. Built from the shared skeleton so the promise is
+                # structural, not a literal someone has to keep in step.
+                # `min_gain` is the caller's, not a fabricated 0.0: reporting a
+                # threshold that was never the one in force is the same defect
+                # as reporting a census that never ran.
                 'accept_basis': basis_skeleton(
                     scope_source, policy='empty',
                     witnesses_before=witnesses_before,
                     witnesses_after=witnesses_before,
                     hpwl_before=_empty_gate[_recon.GATE_TERMS.index('hpwl')],
-                    hpwl_after=_empty_gate[_recon.GATE_TERMS.index('hpwl')]),
+                    hpwl_after=_empty_gate[_recon.GATE_TERMS.index('hpwl')],
+                    min_gain=min_gain),
                 'accepted': True, 'pruned': [],
                 'witnesses_before': sorted(witnesses_before),
                 'witnesses_after': sorted(witnesses_before),

--- a/py_placer/placement/seeder.py
+++ b/py_placer/placement/seeder.py
@@ -3233,7 +3233,15 @@ def reseat_scope(pcb_data, pcb_file: str, intent, *,
     pruned = _recon.prune_assignment(state, old, notes,
                                      edge_bands=gate_bands,
                                      exempt=set(evicted),
-                                     evidenced=set(scope))
+                                     evidenced=set(scope),
+                                     # #698: the sweep's tuple has no intent
+                                     # term, so a seat that cleared a declared
+                                     # keep-out reads as a pure hpwl loss and
+                                     # is reverted before the gate below ever
+                                     # runs. `None` on the auto scope, where
+                                     # the pass's win IS in the tuple.
+                                     intent_probe=(probe.terms if probe
+                                                   is not None else None))
     after = _recon.measure(state, gate_bands)
     witnesses_after = _recon.damage_witnesses(state)
     _oob = _recon.GATE_TERMS.index('oob')

--- a/tests/measure_698_min_gain.py
+++ b/tests/measure_698_min_gain.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Where `--reseat-min-gain`'s default comes from (#698), shipped so the number
+can be re-derived rather than quoted.
+
+The only basis a sideways shuffle can score on is `scope_hpwl`, so the question
+is: on real boards, what gain does an explicit re-seat actually produce? Parts
+are chosen by pad count -- a property of the BOARD, not of the answer -- so the
+sample cannot be fitted to the conclusion.
+
+NOT named `test_*.py`: `tests/run_all.py` does not collect it, because it runs
+16 full re-seats on corpus boards (minutes, not seconds) and asserts nothing.
+It is a measurement, and its output is quoted in `placement/README.md`.
+
+    python3 -X utf8 tests/measure_698_min_gain.py
+
+**Read the `pre_prune` column before drawing the obvious conclusion.** The first
+write-up of this measurement said the zero rows were the search "re-seating the
+part where it already was". That is false, and this column is what shows it: the
+search relocates by tens of millimetres, to a pose that is hpwl-WORSE, and
+`prune_assignment` reverts it -- so `after` is measured at the restored input
+pose and the gain is trivially 0.000. The zeros are prune artifacts, not
+no-ops, and the bimodality is therefore partly STRUCTURAL: anything that
+survives prune has improved hpwl by construction.
+
+What the sample does support is narrower and still enough: among the re-seats
+that reach the gate at all, the smallest gain is ~1 mm, so a non-zero default
+would buy nothing here while risking a genuine small win.
+"""
+from __future__ import annotations
+
+import os
+import sys
+
+_TESTS = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_TESTS)
+for _p in (_ROOT, os.path.join(_ROOT, 'py_router'),
+           os.path.join(_ROOT, 'py_tools'), os.path.join(_ROOT, 'py_placer')):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from kicad_parser import parse_kicad_pcb                     # noqa: E402
+from placement import floorplan, reconstruct, seeder         # noqa: E402
+
+BOARDS = ['splitflap_driver.kicad_pcb', 'tigard.kicad_pcb',
+          'watchy.kicad_pcb', 'esp_prog.kicad_pcb']
+TOPN = 4
+
+
+def rows_for(name):
+    path = os.path.join(_ROOT, 'kicad_files', name)
+    if not os.path.exists(path):
+        return []
+    pcb = parse_kicad_pcb(path)
+    intent = floorplan.empty_intent(path)
+    ranked = sorted(pcb.footprints.items(),
+                    key=lambda kv: (-len(kv[1].pads), kv[0]))
+    out = []
+    for ref, _fp in ranked[:TOPN]:
+        seen = {}
+        real = reconstruct.prune_assignment
+
+        def spy(state, old, notes=None, _seen=seen, _real=real, _ref=ref, **kw):
+            # The SEARCH's pose, before the sweep can revert it. Without this
+            # the zero rows are unreadable.
+            _seen['moved'] = max(
+                (abs(state.parts[r].x - old[r][0])
+                 + abs(state.parts[r].y - old[r][1])) for r in old)
+            _seen['pre'] = seeder.scope_hpwl(state, {_ref})
+            res = _real(state, old, notes, **kw)
+            _seen['pruned'] = list(res)
+            return res
+
+        reconstruct.prune_assignment = spy
+        try:
+            rep = seeder.reseat_scope(parse_kicad_pcb(path), path, intent,
+                                      refs=[ref], group_sources=(),
+                                      clearance=0.2, board_edge_clearance=0.5,
+                                      grid_step=0.1, seed=0)
+        except Exception as e:                          # noqa: BLE001
+            out.append((name, ref, None, None, None, None,
+                        f'ERR {type(e).__name__}: {e}'))
+            continue
+        finally:
+            reconstruct.prune_assignment = real
+        ab = rep.get('accept_basis') or {}
+        t = next((t for t in ab.get('terms') or []
+                  if t['term'] == 'scope_hpwl'), {})
+        out.append((name, ref, t.get('before'), t.get('after'),
+                    seen.get('pre'), seen.get('pruned'),
+                    ('ACCEPT ' + str(ab.get('fired'))) if rep['accepted']
+                    else 'refuse'))
+    return out
+
+
+def main():
+    allrows = []
+    for b in BOARDS:
+        allrows += rows_for(b)
+    print(f"{'board':<28} {'ref':<8} {'hpwl_b':>10} {'hpwl_a':>10} "
+          f"{'pre_prune':>10} {'gain':>9} {'pruned':>7}  verdict")
+    gains = []
+    for name, ref, b, a, pre, pruned, verdict in allrows:
+        if b is None:
+            print(f"{name:<28} {ref:<8} {'-':>10} {'-':>10} {'-':>10} "
+                  f"{'-':>9} {'-':>7}  {verdict}")
+            continue
+        g = b - a
+        gains.append(g)
+        print(f"{name:<28} {ref:<8} {b:>10.3f} {a:>10.3f} "
+              f"{(f'{pre:.3f}' if pre is not None else '-'):>10} {g:>9.3f} "
+              f"{str(bool(pruned)):>7}  {verdict}")
+    pos = sorted(g for g in gains if g > 1e-9)
+    zero = [g for g in gains if abs(g) <= 1e-9]
+    print(f"\n{len(gains)} explicit re-seats measured on {len(BOARDS)} boards; "
+          f"{len(pos)} produced a positive scope_hpwl gain, "
+          f"{len(zero)} exactly zero")
+    if pos:
+        print(f"smallest positive gain: {pos[0]:.3f} mm; "
+              f"largest: {pos[-1]:.3f} mm")
+    print("The zero rows are reverted seats, not no-ops -- compare `pre_prune` "
+          "against `hpwl_b` and read the module docstring before quoting this.")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/measure_698_min_gain.py
+++ b/tests/measure_698_min_gain.py
@@ -13,18 +13,24 @@ It is a measurement, and its output is quoted in `placement/README.md`.
 
     python3 -X utf8 tests/measure_698_min_gain.py
 
-**Read the `pre_prune` column before drawing the obvious conclusion.** The first
-write-up of this measurement said the zero rows were the search "re-seating the
-part where it already was". That is false, and this column is what shows it: the
-search relocates by tens of millimetres, to a pose that is hpwl-WORSE, and
-`prune_assignment` reverts it -- so `after` is measured at the restored input
-pose and the gain is trivially 0.000. The zeros are prune artifacts, not
+**Read the `pre_prune` and `moved` columns before drawing the obvious
+conclusion.** The first write-up of this measurement said the zero rows were the
+search "re-seating the part where it already was". That is false, and these
+columns are what show it: the search relocates, to a pose that is hpwl-WORSE,
+and `prune_assignment` reverts it -- so `after` is measured at the restored
+input pose and the gain is trivially 0.000. The zeros are prune artifacts, not
 no-ops, and the bimodality is therefore partly STRUCTURAL: anything that
 survives prune has improved hpwl by construction.
 
-What the sample does support is narrower and still enough: among the re-seats
-that reach the gate at all, the smallest gain is ~1 mm, so a non-zero default
-would buy nothing here while risking a genuine small win.
+`moved` is printed rather than described because the description was wrong too.
+The displacements are NOT uniformly large -- on the recorded run they run 0.14
+to 63.79 mm, and two of the nine reverted rows (tigard U5, U6) move well under a
+millimetre, which are exactly the micro-shuffles the paragraph above says the
+zeros are not. Most are large; some are not; the column says which.
+
+What the sample does support is narrower and still enough: every re-seat whose
+gain was NON-ZERO gained at least ~1 mm, so a non-zero default would buy nothing
+here while risking a genuine small win.
 """
 from __future__ import annotations
 
@@ -77,7 +83,7 @@ def rows_for(name):
                                       clearance=0.2, board_edge_clearance=0.5,
                                       grid_step=0.1, seed=0)
         except Exception as e:                          # noqa: BLE001
-            out.append((name, ref, None, None, None, None,
+            out.append((name, ref, None, None, None, None, None,
                         f'ERR {type(e).__name__}: {e}'))
             continue
         finally:
@@ -86,7 +92,7 @@ def rows_for(name):
         t = next((t for t in ab.get('terms') or []
                   if t['term'] == 'scope_hpwl'), {})
         out.append((name, ref, t.get('before'), t.get('after'),
-                    seen.get('pre'), seen.get('pruned'),
+                    seen.get('pre'), seen.get('moved'), seen.get('pruned'),
                     ('ACCEPT ' + str(ab.get('fired'))) if rep['accepted']
                     else 'refuse'))
     return out
@@ -97,18 +103,20 @@ def main():
     for b in BOARDS:
         allrows += rows_for(b)
     print(f"{'board':<28} {'ref':<8} {'hpwl_b':>10} {'hpwl_a':>10} "
-          f"{'pre_prune':>10} {'gain':>9} {'pruned':>7}  verdict")
+          f"{'pre_prune':>10} {'moved':>8} {'gain':>9} {'pruned':>7}"
+          f"  verdict")
     gains = []
-    for name, ref, b, a, pre, pruned, verdict in allrows:
+    for name, ref, b, a, pre, moved, pruned, verdict in allrows:
         if b is None:
             print(f"{name:<28} {ref:<8} {'-':>10} {'-':>10} {'-':>10} "
-                  f"{'-':>9} {'-':>7}  {verdict}")
+                  f"{'-':>8} {'-':>9} {'-':>7}  {verdict}")
             continue
         g = b - a
         gains.append(g)
         print(f"{name:<28} {ref:<8} {b:>10.3f} {a:>10.3f} "
-              f"{(f'{pre:.3f}' if pre is not None else '-'):>10} {g:>9.3f} "
-              f"{str(bool(pruned)):>7}  {verdict}")
+              f"{(f'{pre:.3f}' if pre is not None else '-'):>10} "
+              f"{(f'{moved:.2f}' if moved is not None else '-'):>8} "
+              f"{g:>9.3f} {str(bool(pruned)):>7}  {verdict}")
     pos = sorted(g for g in gains if g > 1e-9)
     zero = [g for g in gains if abs(g) <= 1e-9]
     print(f"\n{len(gains)} explicit re-seats measured on {len(BOARDS)} boards; "
@@ -117,8 +125,9 @@ def main():
     if pos:
         print(f"smallest positive gain: {pos[0]:.3f} mm; "
               f"largest: {pos[-1]:.3f} mm")
-    print("The zero rows are reverted seats, not no-ops -- compare `pre_prune` "
-          "against `hpwl_b` and read the module docstring before quoting this.")
+    print("The zero rows are reverted seats, not no-ops -- compare "
+          "`pre_prune` against `hpwl_b`, read `moved` for how far the search "
+          "actually went, and read the module docstring before quoting this.")
     return 0
 
 

--- a/tests/mutate_698.py
+++ b/tests/mutate_698.py
@@ -165,6 +165,14 @@ ROWS = [
      "            ok = gain > 1e-9\n",
      (T698,), 'KILLED'),
 
+    # The regression the FIX WAVE introduced and the re-verification caught: a
+    # bare truthiness guard sends a sub-quantum threshold down the `>=` branch,
+    # so a stricter flag produces a LOOSER gate.
+    ('the-min_gain-branch-guards-on-truthiness', 's',
+     "        elif gated and float(min_gain) > MEASURE_QUANTUM:\n",
+     "        elif gated and min_gain:\n",
+     (T698,), 'KILLED'),
+
     ('min_gain-gates-the-count-bases-too', 's',
      "        if units == 'count':\n"
      "            ok = gain >= 1\n",
@@ -300,6 +308,17 @@ ROWS = [
      "            ok = gain > MEASURE_QUANTUM\n",
      "            ok = gain > 1e-9\n",
      (T698,), 'KILLED'),
+
+    # EXPECTED SURVIVOR, recorded rather than deleted. `keepout_hit` already
+    # thresholds at `legality.EPS` internally and `grid_step` is 0.1mm, so no
+    # realizable term rises into the gap between 1e-9 and 1e-6 -- the change is
+    # about ONE PASS not answering "did a declared term rise" two ways, not
+    # about a decision that moves. Kept as a change detector, and recorded so
+    # that "no arm covers it" is a stated fact rather than a discovery.
+    ('prune-uses-a-different-epsilon-from-the-licence', 'r',
+     "        undoes_intent = any(a > b + legality.EPS\n",
+     "        undoes_intent = any(a > b + 1e-9\n",
+     (T698,), 'SURVIVED'),
 
     ('the-KEPT-note-credits-the-probe-for-every-held-revert', 'r',
      "            if undoes_intent and wanted:\n",

--- a/tests/mutate_698.py
+++ b/tests/mutate_698.py
@@ -265,6 +265,53 @@ ROWS = [
      "        items = self.net_refs.items()\n",
      (T698,), 'KILLED'),
 
+    # ---- the pre-push review's findings ------------------------------------
+    ('the-auto-branch-outranks-the-eviction-licence', 's',
+     "    if basis.get('eviction_licence') is False:\n"
+     "        return (f\"{head}: the eviction licence -- moving parts outside "
+     "the \"\n"
+     "                f\"scope raised the stack count or the overlap area. See "
+     "the \"\n"
+     "                f\"note above for the figures.\")\n",
+     "",
+     (T698,), 'KILLED'),
+
+    ('the-empty-basis-goes-back-to-a-literal', 's',
+     "                'accept_basis': basis_skeleton(\n"
+     "                    scope_source, policy='empty',\n"
+     "                    witnesses_before=witnesses_before,\n"
+     "                    witnesses_after=witnesses_before,\n"
+     "                    hpwl_before=_empty_gate[_recon.GATE_TERMS.index("
+     "'hpwl')],\n"
+     "                    hpwl_after=_empty_gate[_recon.GATE_TERMS.index("
+     "'hpwl')]),\n",
+     "                'accept_basis': {'scope_source': scope_source,\n"
+     "                                 'policy': 'empty', 'fired': None,\n"
+     "                                 'terms': [], 'safety': None,\n"
+     "                                 'intent_licence': None},\n",
+     (T698,), 'KILLED'),
+
+    ('min_gain-refuses-a-gain-of-exactly-min_gain', 's',
+     "            ok = gain >= float(min_gain) - 1e-9\n",
+     "            ok = gain > float(min_gain)\n",
+     (T698,), 'KILLED'),
+
+    ('a-continuous-basis-fires-on-rounding-noise', 's',
+     "            ok = gain > MEASURE_QUANTUM\n",
+     "            ok = gain > 1e-9\n",
+     (T698,), 'KILLED'),
+
+    ('the-KEPT-note-credits-the-probe-for-every-held-revert', 'r',
+     "            if undoes_intent and wanted:\n",
+     "            if undoes_intent:\n",
+     (T698,), 'KILLED'),
+
+    ('the-probe-goes-back-to-the-named-scope-only', 's',
+     "        probe = _q.IntentProbe(state, zones=_bundle['zones'])\n",
+     "        probe = _q.IntentProbe(state, zones=_bundle['zones'], "
+     "refs=scope)\n",
+     (T698,), 'KILLED'),
+
     # ---- reporting ---------------------------------------------------------
     ('accept_basis-never-names-the-winner', 's',
      "    basis['fired'] = fired if accepted else None\n",

--- a/tests/mutate_698.py
+++ b/tests/mutate_698.py
@@ -284,19 +284,18 @@ ROWS = [
      "",
      (T698,), 'KILLED'),
 
-    ('the-empty-basis-goes-back-to-a-literal', 's',
-     "                'accept_basis': basis_skeleton(\n"
-     "                    scope_source, policy='empty',\n"
-     "                    witnesses_before=witnesses_before,\n"
-     "                    witnesses_after=witnesses_before,\n"
-     "                    hpwl_before=_empty_gate[_recon.GATE_TERMS.index("
-     "'hpwl')],\n"
-     "                    hpwl_after=_empty_gate[_recon.GATE_TERMS.index("
-     "'hpwl')]),\n",
-     "                'accept_basis': {'scope_source': scope_source,\n"
-     "                                 'policy': 'empty', 'fired': None,\n"
-     "                                 'terms': [], 'safety': None,\n"
-     "                                 'intent_licence': None},\n",
+    # Anchored on ONE line each, deliberately: the multi-line anchors these
+    # replace went stale twice in one session as the call grew arguments, and a
+    # BROKEN row is indistinguishable from a catastrophic test failure until
+    # you read it.
+    ('the-empty-basis-reports-a-fabricated-min_gain', 's',
+     "                    min_gain=min_gain),\n",
+     "                    min_gain=0.0),\n",
+     (T698,), 'KILLED'),
+
+    ('the-skeleton-drops-the-eviction_licence-key', 's',
+     "        'eviction_licence': None,\n",
+     "",
      (T698,), 'KILLED'),
 
     ('min_gain-refuses-a-gain-of-exactly-min_gain', 's',
@@ -338,15 +337,8 @@ ROWS = [
      (T698,), 'KILLED'),
 
     ('the-early-out-drops-accept_basis', 's',
-     "                'accept_basis': basis_skeleton(\n"
-     "                    scope_source, policy='empty',\n"
-     "                    witnesses_before=witnesses_before,\n"
-     "                    witnesses_after=witnesses_before,\n"
-     "                    hpwl_before=_empty_gate[_recon.GATE_TERMS.index"
-     "('hpwl')],\n"
-     "                    hpwl_after=_empty_gate[_recon.GATE_TERMS.index"
-     "('hpwl')]),\n",
-     "",
+     "                'accept_basis': basis_skeleton(\n",
+     "                'accept_basis_MISSING': basis_skeleton(\n",
      (T698,), 'KILLED'),
 
     ('the-auto-path-reports-a-safety-half-it-never-measured', 's',

--- a/tests/mutate_698.py
+++ b/tests/mutate_698.py
@@ -161,7 +161,7 @@ ROWS = [
 
     # ---- min_gain ----------------------------------------------------------
     ('min_gain-is-ignored', 's',
-     "            ok = gain > max(abs(float(min_gain)), 1e-9)\n",
+     "            ok = gain >= float(min_gain) - 1e-9\n",
      "            ok = gain > 1e-9\n",
      (T698,), 'KILLED'),
 
@@ -195,13 +195,13 @@ ROWS = [
 
     # ---- the prune probe ---------------------------------------------------
     ('prune-ignores-the-probe', 'r',
-     "        undoes_intent = any(a > b + 1e-9\n"
+     "        undoes_intent = any(a > b + legality.EPS\n"
      "                            for a, b in zip(after_intent, base_intent))\n",
      "        undoes_intent = False\n",
      (T698,), 'KILLED'),
 
     ('prune-refuses-every-revert', 'r',
-     "        undoes_intent = any(a > b + 1e-9\n"
+     "        undoes_intent = any(a > b + legality.EPS\n"
      "                            for a, b in zip(after_intent, base_intent))\n",
      "        undoes_intent = bool(after_intent)\n",
      (T698, T630), 'KILLED'),
@@ -319,10 +319,14 @@ ROWS = [
      (T698,), 'KILLED'),
 
     ('the-early-out-drops-accept_basis', 's',
-     "                'accept_basis': {'scope_source': scope_source,\n"
-     "                                 'policy': 'empty', 'fired': None,\n"
-     "                                 'terms': [], 'safety': None,\n"
-     "                                 'intent_licence': None},\n",
+     "                'accept_basis': basis_skeleton(\n"
+     "                    scope_source, policy='empty',\n"
+     "                    witnesses_before=witnesses_before,\n"
+     "                    witnesses_after=witnesses_before,\n"
+     "                    hpwl_before=_empty_gate[_recon.GATE_TERMS.index"
+     "('hpwl')],\n"
+     "                    hpwl_after=_empty_gate[_recon.GATE_TERMS.index"
+     "('hpwl')]),\n",
      "",
      (T698,), 'KILLED'),
 

--- a/tests/mutate_698.py
+++ b/tests/mutate_698.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""The #698 mutation battery, shipped so its numbers can be re-derived.
+
+`tests/test_698_reseat_acceptance.py` records what each arm kills. A count is
+only checkable if the exact source edit is written down, so the edits live here
+as data, next to the numbers they produced.
+
+Every row carries an EXPECTATION. An inert row recorded as an expected survivor
+is a finding; an inert row quietly deleted is a hole. A row whose verdict does
+not match its expectation is reported as WRONG.
+
+WHY THIS BATTERY EXISTS FOR THIS CHANGE. #698 is a change to an ACCEPTANCE
+rule, and an acceptance rule is the easiest thing in this repo to test
+vacuously: every arm can be satisfied by a board that would have come out right
+under the old rule too. Two of this change's own arms were caught that way
+before the battery existed -- arm G asserted the auto path on a healthy board,
+where the auto census is empty by construction and the gate is never reached at
+all, so every assertion in it passed while testing nothing.
+
+NOT named `test_*.py`, so `tests/run_all.py` does not collect it: it REWRITES
+the engine in place. One writer per tree -- do not run it while a suite, an A/B
+replay or a review is reading the same checkout. It refuses to start on a dirty
+engine, because restoring would write the COMMITTED text back over uncommitted
+work.
+
+    python3 tests/mutate_698.py
+    python3 tests/mutate_698.py --row hpwl-is-hard-too
+    python3 tests/mutate_698.py --list
+
+A row is KILLED by a FAILURE **or an ERROR**: several of these make an arm raise
+rather than fail, and a battery that counted only failures would call that a
+survivor.
+
+An anchor that does not match EXACTLY ONCE is reported as BROKEN rather than
+skipped -- a battery that silently applies nothing reports every row as a
+survivor, which reads as a catastrophic test failure and is really a stale
+anchor.
+
+Python `str.replace`, never `sed`.
+
+THE MEASURED TABLE IS IN THE HEADER OF `test_698_reseat_acceptance.py`, FROM THE
+RUN -- never predicted here and never edited afterwards to match.
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import subprocess
+import sys
+
+_TESTS = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_TESTS)
+
+SEEDER = os.path.join(_ROOT, 'py_placer', 'placement', 'seeder.py')
+RECON = os.path.join(_ROOT, 'py_placer', 'placement', 'reconstruct.py')
+QUENCH = os.path.join(_ROOT, 'py_placer', 'placement', 'quench.py')
+TARGETS = {'s': SEEDER, 'r': RECON, 'q': QUENCH}
+
+T698 = os.path.join(_TESTS, 'test_698_reseat_acceptance.py')
+T630 = os.path.join(_TESTS, 'test_630_seeder_eviction.py')
+T702 = os.path.join(_TESTS, 'test_702_quench_intent_gate.py')
+TPS = os.path.join(_TESTS, 'test_place_seed.py')
+
+ROWS = [
+    # ---- the acceptance rule ----------------------------------------------
+    ('the-explicit-branch-never-fires', 's',
+     "    if scope_source != 'explicit':\n",
+     "    if True:\n",
+     (T698,), 'KILLED'),
+
+    ('the-explicit-branch-always-fires', 's',
+     "    if scope_source != 'explicit':\n",
+     "    if False:\n",
+     (T698, TPS), 'KILLED'),
+
+    ('accept-anything-that-is-safe', 's',
+     "    accepted = bool(witness_ok and safe and not risen "
+     "and fired is not None)\n",
+     "    accepted = bool(witness_ok and safe and not risen)\n",
+     (T698,), 'KILLED'),
+
+    ('drop-the-safety-half', 's',
+     "    accepted = bool(witness_ok and safe and not risen "
+     "and fired is not None)\n",
+     "    accepted = bool(witness_ok and not risen and fired is not None)\n",
+     (T698,), 'KILLED'),
+
+    ('drop-the-intent-licence', 's',
+     "    accepted = bool(witness_ok and safe and not risen "
+     "and fired is not None)\n",
+     "    accepted = bool(witness_ok and safe and fired is not None)\n",
+     (T698,), 'KILLED'),
+
+    ('drop-the-witness-conjunct', 's',
+     "    accepted = bool(witness_ok and safe and not risen "
+     "and fired is not None)\n",
+     "    accepted = bool(safe and not risen and fired is not None)\n",
+     (T698,), 'KILLED'),
+
+    # ---- the term-wise licence --------------------------------------------
+    ('hpwl-is-hard-too', 's',
+     "    for n in ('hole', 'oob', 'overlap'):\n",
+     "    for n in ('hole', 'oob', 'overlap', 'hpwl'):\n",
+     (T698,), 'KILLED'),
+
+    ('oob-must-still-improve', 's',
+     "    for n in ('hole', 'oob', 'overlap'):\n"
+     "        # 1e-9, the SAME epsilon `eviction_licence_ok` uses. Two licences"
+     " on\n"
+     "        # one pass must not carry two tolerances, and `measure` rounds "
+     "these\n"
+     "        # to 4 decimals anyway.\n"
+     "        if after[idx(n)] > before[idx(n)] + 1e-9:\n"
+     "            rose.append(n)\n",
+     "    for n in ('hole', 'oob', 'overlap'):\n"
+     "        if after[idx(n)] >= before[idx(n)] - 1e-9:\n"
+     "            rose.append(n)\n",
+     (T698,), 'KILLED'),
+
+    ('stacks-may-worsen', 's',
+     "    for n in ('locked_contacts', 'pad_pairs', 'stacks'):\n",
+     "    for n in ('locked_contacts', 'pad_pairs'):\n",
+     (T698,), 'KILLED'),
+
+    ('the-safety-half-never-objects', 's',
+     "    return (not rose), rose\n",
+     "    return True, rose\n",
+     (T698,), 'KILLED'),
+
+    # ---- the bases ---------------------------------------------------------
+    ('the-intent-basis-is-dropped', 's',
+     "    out['intent'] = intent_count\n",
+     "    out['intent'] = 0\n",
+     (T698,), 'KILLED'),
+
+    ('scope_hpwl-is-the-whole-board', 's',
+     "    return round(state.hpwl(nets), 3)\n",
+     "    return round(state.hpwl(), 3)\n",
+     (T698,), 'KILLED'),
+
+    ('hpwl-becomes-a-basis', 's',
+     "RESEAT_BASES = ('locked_contacts', 'pad_pairs', 'hole', 'oob', "
+     "'intent',\n"
+     "                'stacks', 'overlap', 'scope_hpwl')\n",
+     "RESEAT_BASES = ('locked_contacts', 'pad_pairs', 'hole', 'oob', "
+     "'intent',\n"
+     "                'stacks', 'overlap', 'scope_hpwl', 'hpwl')\n",
+     (T698,), 'KILLED'),
+
+    # EXPECTED SURVIVOR, recorded rather than deleted. Every count basis is an
+    # integer, so `> 0` and `>= 1` are the same predicate; the row is here
+    # because `>= 1` is the form that stays correct if a basis ever becomes a
+    # float, and it change-detects that. It is NOT evidence of a test hole.
+    ('a-count-basis-fires-on-any-gain', 's',
+     "        if units == 'count':\n"
+     "            ok = gain >= 1\n",
+     "        if units == 'count':\n"
+     "            ok = gain > 0\n",
+     (T698,), 'SURVIVED'),
+
+    # ---- min_gain ----------------------------------------------------------
+    ('min_gain-is-ignored', 's',
+     "            ok = gain > max(abs(float(min_gain)), 1e-9)\n",
+     "            ok = gain > 1e-9\n",
+     (T698,), 'KILLED'),
+
+    ('min_gain-gates-the-count-bases-too', 's',
+     "        if units == 'count':\n"
+     "            ok = gain >= 1\n",
+     "        if units == 'count':\n"
+     "            ok = gain >= max(1, float(min_gain))\n",
+     (T698,), 'KILLED'),
+
+    # ---- the intent licence (the VECTOR, not the count) --------------------
+    ('the-licence-sums-the-vector', 'q',
+     "            for t, b, a in zip(self.spec[ref], bv, av):\n"
+     "                if a > b + legality.EPS:\n"
+     "                    risen.append((ref, t.rule, t.name, b, a))\n",
+     "            if sum(av) > sum(bv) + legality.EPS:\n"
+     "                risen.append((ref, 'sum', 'summed', sum(bv), sum(av)))\n",
+     (T698,), 'KILLED'),
+
+    ('the-licence-never-objects', 'q',
+     "        return (not risen), risen\n",
+     "        return True, risen\n",
+     (T698,), 'KILLED'),
+
+    ('a-breach-is-at-or-above-threshold', 'q',
+     "                if v > t.threshold:\n"
+     "                    count += 1\n",
+     "                if v >= t.threshold:\n"
+     "                    count += 1\n",
+     (T698,), 'KILLED'),
+
+    # ---- the prune probe ---------------------------------------------------
+    ('prune-ignores-the-probe', 'r',
+     "        undoes_intent = any(a > b + 1e-9\n"
+     "                            for a, b in zip(after_intent, base_intent))\n",
+     "        undoes_intent = False\n",
+     (T698,), 'KILLED'),
+
+    ('prune-refuses-every-revert', 'r',
+     "        undoes_intent = any(a > b + 1e-9\n"
+     "                            for a, b in zip(after_intent, base_intent))\n",
+     "        undoes_intent = bool(after_intent)\n",
+     (T698, T630), 'KILLED'),
+
+    ('the-probe-is-never-handed-over', 's',
+     "                                     intent_probe=(probe.terms if probe\n"
+     "                                                   is not None "
+     "else None))\n",
+     "                                     intent_probe=None)\n",
+     (T698,), 'KILLED'),
+
+    ('prune-samples-the-probe-after-twice', 'r',
+     "        base_intent = intent_probe(ref) if intent_probe is not None "
+     "else ()\n",
+     "        base_intent = ()\n",
+     (T698,), 'KILLED'),
+
+    # ---- the probe must not ARM the seat gate ------------------------------
+    ('the-probe-arms-the-state', 'q',
+     "        self.refs: Tuple[str, ...] = tuple(rs)\n",
+     "        self.refs: Tuple[str, ...] = tuple(rs)\n"
+     "        state._intent_spec = dict(self.spec)\n"
+     "        state._intent_active = True\n",
+     (T698,), 'KILLED'),
+
+    # ---- the extraction was supposed to be behaviour-free ------------------
+    # The first version of this row mutated `not any(` to `False or not any(`,
+    # which is the SAME expression -- a row that cannot fail, recorded as an
+    # expected survivor. It looked like a finding and was a tautology.
+    ('the-zone-spec-forgets-the-anchor-branch', 'q',
+     "                _anchor = not any(\n"
+     "                    _fp.zone_fits_courtyard(\n"
+     "                        _z['rect'], _p.rect(0.0, 0.0, _r), _tol)\n"
+     "                    for _r in (_p.rot % 360, (_p.rot + 90) % 360))\n",
+     "                _anchor = False\n",
+     (T702,), 'KILLED'),
+
+    ('the-zone-spec-drops-the-exclusive-branch', 'q',
+     "            elif _z['exclusive'] and (not _z['side']\n",
+     "            elif False and _z['exclusive'] and (not _z['side']\n",
+     (T702,), 'KILLED'),
+
+    # EXPECTED SURVIVOR, recorded rather than deleted, and the reason matters:
+    # `refs` is a work-SAVING pre-filter, not a correctness boundary.
+    # `IntentProbe.__init__` walks the same ref set again when it builds
+    # `self.spec`, so a wider `build_zone_spec` produces terms that are then
+    # discarded. Removing the parameter would be a defensible simplification;
+    # what would NOT be defensible is reading this survivor as a test hole and
+    # writing an arm that asserts the pre-filter through the probe, which
+    # cannot see it.
+    ('build_zone_spec-ignores-its-refs-filter', 'q',
+     "    items = (parts.items() if refs is None\n"
+     "             else ((r, parts[r]) for r in refs if r in parts))\n",
+     "    items = parts.items()\n",
+     (T698, T702), 'SURVIVED'),
+
+    ('hpwl-ignores-its-net-subset', 'q',
+     "        items = (self.net_refs.items() if nets is None else\n"
+     "                 [(n, self.net_refs[n]) for n in sorted(nets)\n"
+     "                  if n in self.net_refs])\n",
+     "        items = self.net_refs.items()\n",
+     (T698,), 'KILLED'),
+
+    # ---- reporting ---------------------------------------------------------
+    ('accept_basis-never-names-the-winner', 's',
+     "    basis['fired'] = fired if accepted else None\n",
+     "    basis['fired'] = None\n",
+     (T698,), 'KILLED'),
+
+    ('the-early-out-drops-accept_basis', 's',
+     "                'accept_basis': {'scope_source': scope_source,\n"
+     "                                 'policy': 'empty', 'fired': None,\n"
+     "                                 'terms': [], 'safety': None,\n"
+     "                                 'intent_licence': None},\n",
+     "",
+     (T698,), 'KILLED'),
+
+    ('the-auto-path-reports-a-safety-half-it-never-measured', 's',
+     "        'safety': None, 'intent_licence': None,\n",
+     "        'safety': {'ok': True, 'worsened': []},\n"
+     "        'intent_licence': {'ok': True, 'risen': []},\n",
+     (T698,), 'KILLED'),
+
+    ('the-refusal-note-goes-back-to-blaming-oob', 's',
+     "        notes.append(reseat_refusal_note(len(scope), accept_basis))\n",
+     "        notes.append(f\"REVERTED: re-seating {len(scope)} part(s) did \"\n"
+     "                     f\"not strictly improve the off-board amount\")\n",
+     (T698,), 'KILLED'),
+]
+
+
+def _git_clean(paths):
+    r = subprocess.run(['git', 'diff', '--quiet', '--'] + list(paths),
+                       cwd=_ROOT)
+    return r.returncode == 0
+
+
+def _run(tests):
+    for t in tests:
+        r = subprocess.run([sys.executable, '-X', 'utf8', t],
+                           cwd=_ROOT, capture_output=True, text=True,
+                           encoding='utf-8', errors='replace')
+        if r.returncode != 0:
+            return True, f"{os.path.basename(t)} exit {r.returncode}"
+    return False, "all named tests passed"
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--row', action='append', default=None)
+    ap.add_argument('--list', action='store_true')
+    a = ap.parse_args()
+
+    if a.list:
+        for name, tgt, _o, _n, tests, exp in ROWS:
+            print(f"  {exp:9} {name}  [{tgt}] "
+                  f"-> {', '.join(os.path.basename(t) for t in tests)}")
+        return 0
+
+    rows = ROWS
+    if a.row:
+        unknown = [n for n in a.row if n not in {r[0] for r in ROWS}]
+        if unknown:
+            print(f"no such row: {', '.join(unknown)}; try --list",
+                  file=sys.stderr)
+            return 2
+        rows = [r for r in ROWS if r[0] in set(a.row)]
+
+    if not _git_clean(TARGETS.values()):
+        print("REFUSED: the engine files are dirty. Restoring would write the "
+              "COMMITTED text back over uncommitted work.", file=sys.stderr)
+        return 2
+
+    originals = {k: io.open(p, encoding='utf-8').read()
+                 for k, p in TARGETS.items()}
+    verdicts = []
+    try:
+        for name, tgt, old, new, tests, expect in rows:
+            src = originals[tgt]
+            n = src.count(old)
+            if n != 1:
+                verdicts.append((name, 'BROKEN', f"anchor matched {n} times"))
+                print(f"  BROKEN   {name} -- anchor matched {n} times")
+                continue
+            io.open(TARGETS[tgt], 'w', encoding='utf-8', newline='').write(
+                src.replace(old, new, 1))
+            killed, why = _run(tests)
+            io.open(TARGETS[tgt], 'w', encoding='utf-8',
+                    newline='').write(src)
+            got = 'KILLED' if killed else 'SURVIVED'
+            mark = 'ok' if got == expect else 'WRONG'
+            verdicts.append((name, got, why))
+            print(f"  {got:9}{'' if mark == 'ok' else ' WRONG'} {name} -- {why}")
+    finally:
+        for k, p in TARGETS.items():
+            io.open(p, 'w', encoding='utf-8', newline='').write(originals[k])
+
+    wrong = [v for v, (name, got, _w) in zip(rows, verdicts)
+             if got != v[5]]
+    broken = [n for n, g, _w in verdicts if g == 'BROKEN']
+    print(f"\n{len(verdicts)} row(s): "
+          f"{sum(1 for _n, g, _w in verdicts if g == 'KILLED')} killed, "
+          f"{sum(1 for _n, g, _w in verdicts if g == 'SURVIVED')} survived, "
+          f"{len(broken)} broken, {len(wrong)} disagreeing with expectation")
+    return 1 if (wrong or broken) else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_698_reseat_acceptance.py
+++ b/tests/test_698_reseat_acceptance.py
@@ -18,10 +18,20 @@ optimizer, which makes the control circular. Here the answer is a theorem.
 **The KEEPOUT fixture's hpwl cost is a theorem, and that was measured the hard
 way.** Every net is a 2-pad net between U1 and a partner; both partners sit
 strictly INSIDE the keep-out rect, so any pose that clears the rect is strictly
-farther from both. The first version of this fixture put the partners outside,
-where their bounding box CONTAINED most escape poses -- hpwl was flat and prune
-reverted on only 9 of 20 seeds, so `pruned == ['U1']` would have been a
-seed-0 accident asserted as a property. `arm_M_seed_independence` pins it.
+farther from both. Swept over 20 seeds on the fixture as it stands: hpwl is
+worse on **20 of 20** (6.82 to 12.39 mm -- a different value per seed, since
+the seat search is seeded; 11.372 at seed 0), prune reverts on 20 of 20 without
+the probe, and the pass is accepted on 20 of 20 with it.
+
+The first version of this fixture put the partners at (3,3) and (17,9), OUTSIDE
+the rect, where their bounding box contained most escape poses. HPWL was flat at
+39.2 and prune reverted on **9 of 20** seeds -- so on the other 11 the seat
+survived prune and only the acceptance gate refused it, and `pruned == ['U1']`
+would have been a seed-0 accident asserted as a property. (That measurement was
+taken at the time and the fixture has since been replaced, so it is not
+re-derivable from this tree; the rebuild moved the partners, halved U1's
+courtyard and added the keep-out's `allow` list.) `arm_M_seed_independence` is
+what stops it recurring.
 
 Mutation battery: `tests/mutate_698.py` -- **32 rows: 30 killed, 2 survived
 (both recorded with their reason), 0 broken, 0 disagreeing with expectation.**
@@ -513,11 +523,34 @@ def arm_H_seat_gate_stays_disarmed(wd):
 
     # A source guard, because the tempting "simplification" is to hand
     # `intent_zones=` to make_state and re-open the bug pose_score describes.
+    #
+    # Asserted on the SHAPE, not on the absence of a token. The first version
+    # was `'intent_zones=' not in src` over the whole file, which is both too
+    # broad (a comment mentioning the token fails it) and too weak (`**kw`, an
+    # alias, or `intent_zones =` with spaces passes it). Walk the AST and look
+    # at what `pose_score.make_state` is actually CALLED with.
+    import ast
     src = open(os.path.join(REPO, 'py_placer', 'placement', 'seeder.py'),
                encoding='utf-8').read()
-    check("seeder.py never passes intent_zones= to a state factory",
-          'intent_zones=' not in src,
-          "0 occurrences -- see pose_score.make_state's own comment")
+    calls, offenders, starstar = 0, [], 0
+    for node in ast.walk(ast.parse(src)):
+        if not isinstance(node, ast.Call):
+            continue
+        fn = node.func
+        if not (isinstance(fn, ast.Attribute) and fn.attr == 'make_state'):
+            continue
+        calls += 1
+        for kw in node.keywords:
+            if kw.arg is None:
+                starstar += 1           # **kw could smuggle it in
+            elif kw.arg == 'intent_zones':
+                offenders.append(node.lineno)
+    check("seeder.py calls pose_score.make_state at all", calls > 0,
+          f"{calls} call site(s) found by AST")
+    check("and no call passes intent_zones=", not offenders,
+          f"offending lines: {offenders or 'none'}")
+    check("and none of them splats **kwargs, which could smuggle it in",
+          starstar == 0, f"{starstar} **kwargs splat(s)")
     qsrc = open(os.path.join(REPO, 'py_placer', 'placement', 'quench.py'),
                 encoding='utf-8').read()
     cls = qsrc[qsrc.index('class IntentProbe'):qsrc.index('def rect_gap')
@@ -887,6 +920,96 @@ def arm_R_prune_still_reverts_a_claim_bound_part(wd):
           abs(st.parts['U1'].x - home[0]) < 1e-9, f"x={st.parts['U1'].x}")
 
 
+def arm_S_review_findings(wd):
+    """Every defect the pre-push review found, pinned so it cannot come back.
+
+    All five were in code this change added, and none was reachable from the
+    behavioural arms above -- which is the argument for the review, not against
+    the arms.
+    """
+    print("--- S: the pre-push review's findings, pinned")
+    idx = reconstruct.GATE_TERMS.index
+    base = [0, 0, 0.0, 0.0, 0, 10.0, 0.0]
+    bb = {n: 0.0 for n in seeder.RESEAT_BASES}
+
+    # SF-1: an evicted AUTO pass used to print both conjuncts as SATISFIED in
+    # the sentence giving them as the reason for refusing.
+    _ok, ab = seeder.reseat_accept(
+        [0, 0, 0.0, 9.65, 0, 10.0, 0.0], [0, 0, 0.0, 0.0, 0, 10.0, 0.0],
+        scope_source='auto:damage_witnesses',
+        witnesses_before=['A', 'B'], witnesses_after=[])
+    ab['eviction_licence'] = False
+    note = seeder.reseat_refusal_note(1, ab)
+    check("SF-1: an evicted auto refusal blames the eviction licence",
+          'eviction licence' in note and 'strictly improves' not in note,
+          note[:100])
+
+    # SF-2: `_empty`'s basis must carry the seated path's key set, or
+    # `reseat_refusal_note` KeyErrors on it.
+    b = keepout_board(wd, 's')
+    _p, it = keepout_intent(wd, 's')
+    seated = reseat(b, it, ['U1'])
+    empty = reseat(b, it, ['NOSUCHREF*'])
+    missing = sorted(set(seated['accept_basis']) - set(empty['accept_basis']))
+    check("SF-2: the early-out's accept_basis has the same keys", not missing,
+          f"missing={missing or 'none'} ({len(empty['accept_basis'])} keys)")
+    try:
+        seeder.reseat_refusal_note(0, empty['accept_basis'])
+        note_ok = True
+    except KeyError as e:                                    # noqa: BLE001
+        note_ok = f"KeyError {e}"
+    check("SF-2: and the refusal note renders against it", note_ok is True,
+          str(note_ok))
+
+    # SF-3: a gain of EXACTLY --reseat-min-gain must count; the help calls it
+    # "the smallest win that counts".
+    ba = dict(bb, scope_hpwl=-0.5)          # gain of exactly 0.5
+    for mg, want in ((0.5, True), (0.5001, False)):
+        ok, _ = seeder.reseat_accept(
+            base, list(base), scope_source='explicit',
+            witnesses_before=[], witnesses_after=[],
+            bases_before=bb, bases_after=ba, min_gain=mg)
+        check(f"SF-3: gain 0.5 against --reseat-min-gain {mg} -> "
+              f"{'accept' if want else 'refuse'}", ok is want, f"accepted={ok}")
+
+    # N-1: a continuous legality basis must not fire on rounding noise.
+    for delta, want in ((1e-4, False), (2e-3, True)):
+        ok, _ = seeder.reseat_accept(
+            base, list(base), scope_source='explicit',
+            witnesses_before=[], witnesses_after=[],
+            bases_before=dict(bb, overlap=0.5),
+            bases_after=dict(bb, overlap=0.5 - delta))
+        check(f"N-1: an overlap gain of {delta:g} mm2 -> "
+              f"{'accept' if want else 'refuse'}", ok is want,
+              f"accepted={ok} (MEASURE_QUANTUM={seeder.MEASURE_QUANTUM})")
+
+    # SF-4: the KEPT note must not credit the probe for a revert the TUPLE
+    # refused on its own.
+    pcb = parse_kicad_pcb(b)
+    bundle, _pr = floorplan.resolve_intent_gate(it, pcb, ())
+    import pose_score
+    st = pose_score.make_state(pcb, b, clearance=0.2,
+                               board_edge_clearance=0.5, grid_step=0.1,
+                               keepouts=it.keepouts)
+    probe = q.IntentProbe(st, zones=bundle['zones'])
+    # `old` = a pose FARTHER from U1's partners than where it stands, so the
+    # tuple does not want the revert; U1 is clear of the keep-out either way.
+    st.apply_move('U1', 13.5, 6.0, 0.0)
+    notes = []
+    pruned = reconstruct.prune_assignment(
+        st, {'U1': (18.0, 11.0, 0.0)}, notes, edge_bands={},
+        intent_probe=probe.terms)
+    check("SF-4: the tuple declines the revert", pruned == [], f"{pruned}")
+    check("SF-4: and no note credits the intent probe for it",
+          not any('KEPT' in n for n in notes), f"notes={notes}")
+
+    # SF-6a: the probe covers the whole board, not just the named scope, so an
+    # EVICTED stranger cannot be pushed into a keep-out unseen.
+    check("SF-6a: the probe binds every claim-bound ref, not only the scope",
+          set(probe.spec) >= {'U1'} and probe.refs == tuple(sorted(st.parts)),
+          f"probe.refs={probe.refs}")
+
+
 def main():
     with tempfile.TemporaryDirectory() as wd:
         arm_A_keepout_accepted(wd)
@@ -907,6 +1030,7 @@ def main():
         arm_P_end_to_end_cli(wd)
         arm_Q_the_conjuncts_compose(wd)
         arm_R_prune_still_reverts_a_claim_bound_part(wd)
+        arm_S_review_findings(wd)
     print(f"\n{passed}/{passed + failed} checks passed")
     return 1 if failed else 0
 

--- a/tests/test_698_reseat_acceptance.py
+++ b/tests/test_698_reseat_acceptance.py
@@ -33,10 +33,10 @@ re-derivable from this tree; the rebuild moved the partners, halved U1's
 courtyard and added the keep-out's `allow` list.) `arm_M_seed_independence` is
 what stops it recurring.
 
-Mutation battery: `tests/mutate_698.py` -- **38 rows: 36 killed, 2 survived
-(both recorded with their reason), 0 broken, 0 disagreeing with expectation.**
+Mutation battery: `tests/mutate_698.py` -- **41 rows: 38 killed, 3 survived
+(all recorded with their reason), 0 broken, 0 disagreeing with expectation.**
 
-What it caught in THIS file, over two rounds, which is why it exists:
+What it caught in THIS file, over three rounds, which is why it exists:
 
 | mutation | why it survived |
 |---|---|
@@ -46,9 +46,13 @@ What it caught in THIS file, over two rounds, which is why it exists:
 | `the-KEPT-note-credits-the-probe-for-every-held-revert` | **round 2** -- the arm-S check written for that very finding put U1 outside the keep-out at BOTH poses, so `undoes_intent` was False and the mutated line was unreachable. |
 | `the-probe-goes-back-to-the-named-scope-only` | **round 2** -- that check asserted on a probe the TEST built, which says nothing about the one `reseat_scope` builds. It now spies the real call site. |
 
-The round-2 pair is the lesson worth keeping: those two checks were written to
-pin findings from a code review, and they were themselves vacuous. A fix is not
-verified by the reviewer that motivated it.
+| `the-min_gain-branch-guards-on-truthiness` | **round 3** -- a REGRESSION the round-2 fix introduced. `elif gated and min_gain` let `--reseat-min-gain 1e-12` accept a gain of exactly zero: a stricter flag, a looser gate. SF-3 tested only 0.0, 0.5, 0.5001 and 1000.0, none of which can see it. `SF-3b` now pins monotonicity. |
+| `the-empty-basis-reports-a-fabricated-min_gain` | **round 3** -- fixed in round 2 and checked nowhere, so the row could only have been BROKEN or vacuous. |
+
+The round-2 and round-3 findings are the lesson worth keeping: those checks
+were written to pin findings from a review, and were themselves vacuous or
+wrong. A fix is not verified by the reviewer that motivated it -- three rounds
+running, the pass over the fixes found something the pass before it had missed.
 
 And one the battery caught in ITSELF: the row
 `the-zone-spec-forgets-the-anchor-branch` originally mutated `not any(` to

--- a/tests/test_698_reseat_acceptance.py
+++ b/tests/test_698_reseat_acceptance.py
@@ -1,0 +1,757 @@
+"""#698: `place_seed --reseat REF` can accept an on-board part.
+
+The bug had TWO reverting mechanisms and fixing either alone leaves the board
+broken, so the arms below are built to tell them apart:
+
+* **M1**, the acceptance gate (`seeder.reseat_scope`): `after[oob] <
+  before[oob]`. A part that is legal and ON the board has `oob` unchanged, so an
+  explicitly named part could never be re-seated whatever the search found.
+* **M2**, `reconstruct.prune_assignment`, which reverts FIRST and compares a
+  tuple with no intent term -- so a seat that cleared a declared keep-out reads
+  as a pure hpwl loss and is undone before the gate ever runs.
+
+Fixtures are synthetic, in the shape of `tests/test_702_quench_intent_gate.py`'s
+(copied, as that file copied `test_701_keepout_seating.py`'s): on a corpus board
+"where should this part have gone" is only answerable by re-running the
+optimizer, which makes the control circular. Here the answer is a theorem.
+
+**The KEEPOUT fixture's hpwl cost is a theorem, and that was measured the hard
+way.** Every net is a 2-pad net between U1 and a partner; both partners sit
+strictly INSIDE the keep-out rect, so any pose that clears the rect is strictly
+farther from both. The first version of this fixture put the partners outside,
+where their bounding box CONTAINED most escape poses -- hpwl was flat and prune
+reverted on only 9 of 20 seeds, so `pruned == ['U1']` would have been a
+seed-0 accident asserted as a property. `arm_M_seed_independence` pins it.
+
+Mutation battery: `tests/mutate_698.py`.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for _p in (REPO,):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+        sys.path.insert(0, os.path.join(_p, 'py_router'))
+        sys.path.insert(0, os.path.join(_p, 'py_tools'))
+        sys.path.insert(0, os.path.join(_p, 'py_placer'))
+
+import run_utils                                             # noqa: E402
+from kicad_parser import parse_kicad_pcb                     # noqa: E402
+from placement import floorplan, reconstruct, seeder         # noqa: E402
+from placement import quench as q                            # noqa: E402
+from placement.writer import write_placed_output              # noqa: E402
+from placement.quench import INTENT_ENFORCED_RULES           # noqa: E402
+
+RUN_ALL_TIMEOUT = 1200
+
+passed = failed = 0
+
+
+def check(name, ok, detail=""):
+    """Prints `detail` on OK and FAIL alike, so every detail must read as a
+    MEASUREMENT rather than as a failure explanation."""
+    global passed, failed
+    passed += bool(ok)
+    failed += not ok
+    print(f"  {'OK  ' if ok else 'FAIL'} {name}" + (f" -- {detail}" if detail
+                                                    else ""))
+
+
+# --------------------------------------------------------------------------
+# fixtures
+# --------------------------------------------------------------------------
+
+def _part(ref, x, y, half_w, half_h, npads=2, layer='F.Cu', thru=False,
+          nets=None, rot=0.0):
+    fp_name = f'test:P{ref}'
+    nets = nets or tuple(1 if i == 0 else 2 for i in range(npads))
+    if thru:
+        pads = ''.join(
+            f'\t\t(pad "{i + 1}" thru_hole circle\n'
+            f'\t\t\t(at {i * 0.6 - 0.3} 0)\n'
+            f'\t\t\t(size 0.6 0.6)\n\t\t\t(drill 0.35)\n'
+            f'\t\t\t(layers "*.Cu" "*.Mask")\n'
+            f'\t\t\t(net {nets[i]} "N{nets[i]}")\n'
+            f'\t\t\t(uuid "p{i}-{ref}")\n\t\t)\n' for i in range(npads))
+    else:
+        pads = ''.join(
+            f'\t\t(pad "{i + 1}" smd rect\n'
+            f'\t\t\t(at {i * 0.2 - 0.2} 0)\n'
+            f'\t\t\t(size 0.3 0.3)\n\t\t\t(layers "{layer}")\n'
+            f'\t\t\t(net {nets[i]} "N{nets[i]}")\n'
+            f'\t\t\t(uuid "p{i}-{ref}")\n\t\t)\n' for i in range(npads))
+    return f'''\t(footprint "{fp_name}"
+\t\t(layer "{layer.split('.')[0]}.Cu")
+\t\t(uuid "fp-{ref}")
+\t\t(at {x} {y} {rot})
+\t\t(property "Reference" "{ref}"
+\t\t\t(at 0 0)
+\t\t)
+\t\t(fp_rect
+\t\t\t(start {-half_w} {-half_h})
+\t\t\t(end {half_w} {half_h})
+\t\t\t(layer "{layer.split('.')[0]}.CrtYd")
+\t\t\t(uuid "cy-{ref}")
+\t\t)
+{pads}\t)
+'''
+
+
+def board(path, parts, size):
+    body = ('(kicad_pcb\n\t(version 20241229)\n\t(net 0 "")\n'
+            + ''.join(f'\t(net {i} "N{i}")\n' for i in range(1, 9))
+            + ('\t(gr_rect\n\t\t(start 0 0)\n\t\t(end {} {})\n'
+               '\t\t(layer "Edge.Cuts")\n\t\t(uuid "e1")\n\t)\n').format(*size)
+            + ''.join(parts) + ')\n')
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(body)
+    return path
+
+
+def load(doc, wd, tag='fp'):
+    p = os.path.join(wd, f'{tag}.json')
+    with open(p, 'w', encoding='utf-8') as f:
+        json.dump(doc, f)
+    return p, floorplan.load_intent(p)
+
+
+KO_SIZE = (20.0, 12.0)
+KO_RECT = [8.0, 4.0, 12.0, 8.0]
+
+
+def keepout_board(wd, tag='ko', ux=10.0, uy=6.0):
+    """U1 (1x1 courtyard) inside keep-out `hot`; its two net partners R1 (9,5)
+    and C1 (11,7) strictly INSIDE the rect and in `allow`.
+
+    The partner placement is the fixture's whole point -- see the module
+    docstring. U1's input pose is fully legal: only the declared claim says it
+    is in the wrong place.
+    """
+    return board(os.path.join(wd, f'{tag}.kicad_pcb'),
+                 [_part('U1', ux, uy, 0.5, 0.5, npads=4, nets=(1, 2, 3, 4)),
+                  _part('R1', 9.0, 5.0, 0.4, 0.3, npads=2, nets=(1, 2)),
+                  _part('C1', 11.0, 7.0, 0.4, 0.3, npads=2, nets=(3, 4))],
+                 size=KO_SIZE)
+
+
+def keepout_intent(wd, tag='ko', keepouts=True):
+    ko = ([{"name": "hot", "rect": list(KO_RECT), "allow": ["R1", "C1"]}]
+          if keepouts else [])
+    d = {"schema": 1, "kind": "floorplan-intent", "units": "mm",
+         "envelope": {"rect": [0.0, 0.0, KO_SIZE[0], KO_SIZE[1]],
+                      "tolerance_mm": 0.5},
+         "blocks": [{"name": "all", "refs": ["U1", "R1", "C1"]}]}
+    if ko:
+        d["keepouts"] = ko
+    return load(d, wd, tag)
+
+
+PL_SIZE = (31.75, 14.5)
+
+
+def plain_board(wd, tag='pl'):
+    """A legal, on-board, MISPLACED part with NO declared claim at all -- the
+    pure form of the defect. Nothing but the scope's own wirelength can carry
+    it, so this arm proves the fix is not intent-dependent."""
+    return board(os.path.join(wd, f'{tag}.kicad_pcb'),
+                 [_part('CON2', 15.0, 7.0, 8.9, 1.3, npads=7, thru=True,
+                        nets=(1, 2, 3, 4, 5, 6, 7)),
+                  _part('U1', 4.0, 3.0, 1.5, 1.5, npads=4, nets=(1, 2, 3, 4)),
+                  _part('U2', 6.0, 11.0, 1.5, 1.5, npads=3, nets=(5, 6, 7))],
+                 size=PL_SIZE)
+
+
+def plain_intent(wd, tag='pl'):
+    return load({"schema": 1, "kind": "floorplan-intent", "units": "mm",
+                 "envelope": {"rect": [0.0, 0.0, PL_SIZE[0], PL_SIZE[1]],
+                              "tolerance_mm": 0.5},
+                 "blocks": [{"name": "all",
+                             "refs": ["CON2", "U1", "U2"]}]}, wd, tag)
+
+
+def reseat(bpath, intent, refs, **kw):
+    kw.setdefault('clearance', 0.2)
+    kw.setdefault('board_edge_clearance', 0.5)
+    kw.setdefault('grid_step', 0.1)
+    kw.setdefault('seed', 0)
+    return seeder.reseat_scope(parse_kicad_pcb(bpath), bpath, intent,
+                               refs=refs, group_sources=(), **kw)
+
+
+def graded_errors(bpath, intent, rule=None, ref=None):
+    r = floorplan.grade(intent, parse_kicad_pcb(bpath), bpath)
+    return [v for v in r.errors
+            if (rule is None or v.rule == rule)
+            and (ref is None or v.ref == ref)]
+
+
+def basis_term(basis, name):
+    return next((t for t in (basis.get('terms') or [])
+                 if t['term'] == name), {})
+
+
+# --------------------------------------------------------------------------
+# arms
+# --------------------------------------------------------------------------
+
+def arm_A_keepout_accepted(wd):
+    """The headline: a legal on-board part a declared keep-out says is
+    misplaced is re-seated, and the basis is the INTENT count."""
+    print("--- A: the keep-out fixture is accepted, on the intent basis")
+    b = keepout_board(wd, 'a')
+    _p, it = keepout_intent(wd, 'a')
+
+    before_err = graded_errors(b, it, rule='keepout', ref='U1')
+    check("control: the input board GRADES as a keep-out violation",
+          len(before_err) == 1, f"{len(before_err)} keepout error(s) on U1")
+
+    rep = reseat(b, it, ['U1'])
+    ab = rep['accept_basis']
+    check("the pass is accepted", rep['accepted'] is True,
+          f"accepted={rep['accepted']} notes={rep['notes']}")
+    check("the basis that fired is `intent`", ab.get('fired') == 'intent',
+          f"fired={ab.get('fired')}")
+    t = basis_term(ab, 'intent')
+    check("the intent basis went 1 -> 0",
+          (t.get('before'), t.get('after')) == (1, 0),
+          f"intent {t.get('before')} -> {t.get('after')}")
+    check("the policy is the explicit one",
+          ab.get('policy') == 'explicit:one-term-strict', str(ab.get('policy')))
+    check("U1 actually moved", rep['reseated'] == ['U1'], str(rep['reseated']))
+
+    # The board the pass would WRITE must grade clean -- the check that makes
+    # the acceptance mean something rather than merely happen.
+    out = os.path.join(wd, 'a_out.kicad_pcb')
+    write_placed_output(b, out, rep['moves'])
+    after_err = graded_errors(out, it, rule='keepout')
+    check("the WRITTEN board grades clean on keepout", not after_err,
+          f"{len(after_err)} keepout error(s) after")
+
+
+def arm_B_hpwl_licence(wd):
+    """The escape is hpwl-WORSE and is accepted anyway. A lexicographic
+    `after <= before` reads hpwl at index 5 and would refuse exactly this."""
+    print("--- B: hpwl is the one LICENSED term")
+    b = keepout_board(wd, 'b')
+    _p, it = keepout_intent(wd, 'b')
+    rep = reseat(b, it, ['U1'])
+    ab = rep['accept_basis']
+    hp = _idx('hpwl')
+    rose = rep['gate_after'][hp] - rep['gate_before'][hp]
+    check("the accepted seat RAISED hpwl", rose > 1e-9,
+          f"hpwl {rep['gate_before'][hp]} -> {rep['gate_after'][hp]} "
+          f"(+{rose:.3f})")
+    check("accept_basis records the licence and the term it names",
+          (ab.get('safety') or {}).get('licensed') == 'hpwl',
+          str((ab.get('safety') or {}).get('licensed')))
+    check("the safety half still passed", (ab.get('safety') or {}).get('ok'),
+          str(ab.get('safety')))
+    check("`hpwl` is NOT among the bases it may be accepted on",
+          'hpwl' not in seeder.RESEAT_BASES, str(seeder.RESEAT_BASES))
+    # The counterfactual, stated as a measurement: a lexicographic rule refuses.
+    lex = tuple(rep['gate_after']) <= tuple(rep['gate_before'])
+    check("a LEXICOGRAPHIC safety rule would have refused this seat", not lex,
+          f"after<=before is {lex} -- which is why the rule is term-wise")
+
+
+def _idx(name):
+    return reconstruct.GATE_TERMS.index(name)
+
+
+def arm_C_prune_is_the_other_mechanism(wd):
+    """M2 alone reverts the seat. Proven by running the sweep BOTH ways on the
+    same seated state -- not by reasoning about it."""
+    print("--- C: prune_assignment is an independent reverting mechanism")
+    b = keepout_board(wd, 'c')
+    _p, it = keepout_intent(wd, 'c')
+
+    seen = {}
+    real = reconstruct.prune_assignment
+
+    def spy(state, old, notes=None, **kw):
+        # Snapshot the seated poses, then run the sweep twice from the same
+        # state: once WITHOUT the probe (what shipped) and once with it.
+        seated = {r: (state.parts[r].x, state.parts[r].y, state.parts[r].rot)
+                  for r in old}
+        probe = kw.get('intent_probe')
+        kw_noprobe = dict(kw, intent_probe=None)
+        seen['without'] = list(real(state, old, None, **kw_noprobe))
+        for r, (x, y, rot) in seated.items():       # restore the seated poses
+            state.apply_move(r, x, y, rot)
+        seen['with'] = list(real(state, old, notes, **kw))
+        seen['had_probe'] = probe is not None
+        return seen['with']
+
+    reconstruct.prune_assignment = spy
+    try:
+        rep = reseat(b, it, ['U1'])
+    finally:
+        reconstruct.prune_assignment = real
+
+    check("the reseat DID hand prune an intent probe", seen.get('had_probe'),
+          str(seen.get('had_probe')))
+    check("WITHOUT the probe, prune reverts the seat",
+          seen.get('without') == ['U1'], f"pruned={seen.get('without')}")
+    check("WITH the probe, prune keeps it", seen.get('with') == [],
+          f"pruned={seen.get('with')}")
+    check("the KEPT move is disclosed in a note",
+          any('KEPT' in n and 'U1' in n for n in rep['notes']),
+          "; ".join(n for n in rep['notes'] if 'prune' in n))
+
+
+def arm_D_prune_probe_inert(wd):
+    """`intent_probe=None` is the original expression, character for
+    character. Asserted behaviourally, since that is what callers rely on."""
+    print("--- D: prune_assignment is inert without a probe")
+    b = plain_board(wd, 'd')
+    _p, it = plain_intent(wd, 'd')
+    pcb = parse_kicad_pcb(b)
+    import pose_score
+    st = pose_score.make_state(pcb, b, clearance=0.2,
+                               board_edge_clearance=0.5, grid_step=0.1)
+    old = {'CON2': (st.parts['CON2'].x, st.parts['CON2'].y,
+                    st.parts['CON2'].rot)}
+    st.apply_move('CON2', 10.0, 6.0, 0.0)          # a move prune should revert
+    a = reconstruct.prune_assignment(st, dict(old), None, edge_bands={})
+    st.apply_move('CON2', 10.0, 6.0, 0.0)
+    bnone = reconstruct.prune_assignment(st, dict(old), None, edge_bands={},
+                                         intent_probe=None)
+    check("omitting the kwarg and passing None agree", a == bnone,
+          f"{a} vs {bnone}")
+    st.apply_move('CON2', 10.0, 6.0, 0.0)
+    empty = reconstruct.prune_assignment(st, dict(old), None, edge_bands={},
+                                         intent_probe=lambda _r: ())
+    check("an EMPTY probe vector is also inert", empty == a,
+          f"{empty} vs {a}")
+
+
+def arm_E_plain_board_hpwl_basis(wd):
+    """The claim-free board: no zone, no keep-out, `oob` immovable. Only the
+    scope's own wirelength can carry it -- so this proves the fix is not
+    intent-dependent."""
+    print("--- E: a board with NO declared claim, accepted on scope_hpwl")
+    b = plain_board(wd, 'e')
+    _p, it = plain_intent(wd, 'e')
+    check("control: the board declares nothing this can gate on",
+          not graded_errors(b, it), "0 grade errors on the input")
+    rep = reseat(b, it, ['CON2'])
+    ab = rep['accept_basis']
+    check("the pass is accepted", rep['accepted'] is True,
+          f"accepted={rep['accepted']}")
+    check("the basis that fired is `scope_hpwl`",
+          ab.get('fired') == 'scope_hpwl', str(ab.get('fired')))
+    t = basis_term(ab, 'scope_hpwl')
+    check("and it is a real relocation, not a shuffle",
+          (t.get('before', 0) - t.get('after', 0)) > 1.0,
+          f"scope_hpwl {t.get('before')} -> {t.get('after')}")
+    check("the intent basis measured, and measured nothing",
+          basis_term(ab, 'intent').get('before') == 0,
+          f"intent={basis_term(ab, 'intent')}")
+    check("`oob` did not move, which is why the OLD rule refused this",
+          basis_term(ab, 'oob').get('before')
+          == basis_term(ab, 'oob').get('after') == 0.0,
+          f"oob={basis_term(ab, 'oob')}")
+
+
+def arm_F_min_gain(wd):
+    """`--reseat-min-gain` gates the mm basis and NOT the count bases."""
+    print("--- F: min_gain gates the millimetre basis only")
+    b = plain_board(wd, 'f')
+    _p, it = plain_intent(wd, 'f')
+    lo = reseat(b, it, ['CON2'], min_gain=0.0)
+    hi = reseat(b, it, ['CON2'], min_gain=1000.0)
+    check("control: at min_gain 0 the scope_hpwl basis carries it",
+          lo['accepted'] and lo['accept_basis']['fired'] == 'scope_hpwl',
+          f"fired={lo['accept_basis']['fired']}")
+    check("above the gain, the same pass is REFUSED",
+          hi['accepted'] is False, f"accepted={hi['accepted']}")
+    check("and the refusal names the min-gain, not the off-board amount",
+          any('reseat-min-gain' in n for n in hi['notes']),
+          "; ".join(n for n in hi['notes'] if 'REVERTED' in n)[:140])
+    check("the gated basis is marked as gated, the count bases are not",
+          (basis_term(hi['accept_basis'], 'scope_hpwl')['min_gain_applies']
+           is True
+           and basis_term(hi['accept_basis'], 'intent')['min_gain_applies']
+           is False),
+          "scope_hpwl gated, intent not")
+
+    # A COUNT basis must be untouched by a millimetre threshold -- the whole
+    # reason there is one flag and not one number per currency.
+    kb = keepout_board(wd, 'f2')
+    _p2, it2 = keepout_intent(wd, 'f2')
+    k = reseat(kb, it2, ['U1'], min_gain=1000.0)
+    check("a huge mm threshold does NOT block the intent COUNT basis",
+          k['accepted'] and k['accept_basis']['fired'] == 'intent',
+          f"accepted={k['accepted']} fired={k['accept_basis'].get('fired')}")
+
+
+def arm_G_auto_scope_unchanged(wd):
+    """The auto scope keeps the verbatim rule, and the new machinery is not
+    merely equal there -- it is UNREACHABLE. A poison probe proves it.
+
+    The fixture needs a genuinely OFF-OUTLINE part, or the auto census is empty
+    and `reseat_scope` returns through `_empty` without ever reaching the gate
+    -- which is correct behaviour on a healthy board (the census is zero on all
+    33 corpus boards) and would make this arm assert nothing.
+    """
+    print("--- G: the auto scope is untouched, and provably so")
+    b = board(os.path.join(wd, 'g.kicad_pcb'),
+              [_part('U9', 20.6, 6.0, 0.5, 0.5, npads=2, nets=(1, 2)),
+               _part('R9', 6.0, 6.0, 0.4, 0.3, npads=2, nets=(1, 2))],
+              size=KO_SIZE)
+    _p, it = load({"schema": 1, "kind": "floorplan-intent", "units": "mm",
+                   "envelope": {"rect": [0.0, 0.0, KO_SIZE[0], KO_SIZE[1]],
+                                "tolerance_mm": 0.5},
+                   "blocks": [{"name": "all", "refs": ["U9", "R9"]}]},
+                  wd, 'g')
+
+    rep = reseat(b, it, None)                      # refs=None -> auto
+    check("control: the fixture HAS an off-outline part, so the auto census "
+          "is non-empty", rep['scope'] == ['U9'],
+          f"scope={rep['scope']} witnesses={rep['witnesses_before']}")
+    check("the scope source is the auto census",
+          rep['scope_source'] == 'auto:damage_witnesses', rep['scope_source'])
+    ab = rep['accept_basis']
+    check("the auto policy is the old one", ab.get('policy') == 'auto:oob-strict',
+          str(ab.get('policy')))
+    check("the auto path measured no safety half and no intent licence",
+          ab.get('safety') is None and ab.get('intent_licence') is None,
+          "both None -- 'not measured' must not look like 'measured clean'")
+    check("only the oob term is reported",
+          [t['term'] for t in ab['terms']] == ['oob'],
+          str([t['term'] for t in ab['terms']]))
+
+    real_init = q.IntentProbe.__init__
+
+    def poison(self, *a, **kw):
+        raise AssertionError("IntentProbe was built on the AUTO path")
+
+    q.IntentProbe.__init__ = poison
+    try:
+        rep2 = reseat(b, it, None)
+        reached = False
+    except AssertionError:
+        reached = True
+    finally:
+        q.IntentProbe.__init__ = real_init
+    check("a POISONED probe is never constructed on the auto path", not reached,
+          "the auto branch cannot reach it, which no output diff can show")
+    check("and the poisoned run agrees with the clean one",
+          not reached and rep2['gate_after'] == rep['gate_after'],
+          "gate tuples identical")
+
+
+def arm_H_seat_gate_stays_disarmed(wd):
+    """The probe must not arm the per-pose zone gate. `pose_score.make_state`
+    withholds `intent_zones` because a monotone gate would make the re-seat
+    refuse its own target; measuring is not gating."""
+    print("--- H: measuring the zones does not ARM them")
+    b = keepout_board(wd, 'h')
+    _p, it = keepout_intent(wd, 'h')
+
+    seen = {}
+    real = q.IntentProbe.__init__
+
+    def spy(self, state, zones=(), refs=None):
+        real(self, state, zones=zones, refs=refs)
+        seen['state_spec'] = dict(state._intent_spec)
+        seen['probe_spec'] = {r: len(v) for r, v in self.spec.items()}
+        seen['state_obj'] = state
+
+    q.IntentProbe.__init__ = spy
+    try:
+        reseat(b, it, ['U1'])
+    finally:
+        q.IntentProbe.__init__ = real
+
+    check("the STATE's own zone spec stayed empty",
+          seen.get('state_spec') == {}, str(seen.get('state_spec')))
+    check("while the PROBE bound U1's keep-out",
+          seen.get('probe_spec', {}).get('U1') == 1,
+          str(seen.get('probe_spec')))
+
+    # A source guard, because the tempting "simplification" is to hand
+    # `intent_zones=` to make_state and re-open the bug pose_score describes.
+    src = open(os.path.join(REPO, 'py_placer', 'placement', 'seeder.py'),
+               encoding='utf-8').read()
+    check("seeder.py never passes intent_zones= to a state factory",
+          'intent_zones=' not in src,
+          "0 occurrences -- see pose_score.make_state's own comment")
+    qsrc = open(os.path.join(REPO, 'py_placer', 'placement', 'quench.py'),
+                encoding='utf-8').read()
+    cls = qsrc[qsrc.index('class IntentProbe'):qsrc.index('def rect_gap')
+               if 'def rect_gap' in qsrc[qsrc.index('class IntentProbe'):]
+               else len(qsrc)]
+    body = qsrc[qsrc.index('class IntentProbe'):]
+    body = body[:body.index('\n\n\n')] if '\n\n\n' in body else body
+    check("IntentProbe assigns to neither _intent_spec nor _intent_active",
+          ('_intent_spec =' not in body and '_intent_active =' not in body),
+          f"{len(body.splitlines())} lines scanned")
+    del cls
+
+
+def arm_I_intent_vector_is_the_guard(wd):
+    """The COUNT cannot see a keep-out A -> B hop; the VECTOR can. This is the
+    trap `_IntentTerm` names, at pass level."""
+    print("--- I: the vector is the guard, the count only the trigger")
+    b = keepout_board(wd, 'i')
+    _p, it = keepout_intent(wd, 'i')
+    pcb = parse_kicad_pcb(b)
+    bundle, _pr = floorplan.resolve_intent_gate(it, pcb, ())
+    import pose_score
+    st = pose_score.make_state(pcb, b, clearance=0.2,
+                               board_edge_clearance=0.5, grid_step=0.1,
+                               keepouts=it.keepouts)
+    probe = q.IntentProbe(st, zones=bundle['zones'], refs={'U1'})
+    check("control: U1 is bound by exactly one keep-out term",
+          len(probe.spec.get('U1', ())) == 1, str(probe.spec.get('U1')))
+
+    inside = probe.snapshot()
+    # Hand-build the A -> B hop the count cannot see: two terms, one leaves,
+    # one enters, count 1 -> 1.
+    hop_b = {'count': 1, 'by_rule': {'keepout': 1},
+             'terms': {'U1': (5.0, 0.0)}}
+    hop_a = {'count': 1, 'by_rule': {'keepout': 1},
+             'terms': {'U1': (0.0, 5.0)}}
+    probe.spec['U1'] = probe.spec['U1'] + probe.spec['U1']   # 2 terms
+    ok, risen = probe.licence(hop_b, hop_a)
+    check("the COUNT is unchanged across the hop",
+          hop_b['count'] == hop_a['count'] == 1, "1 -> 1")
+    check("but the licence REFUSES it, naming the term that rose",
+          ok is False and risen and risen[0][1] == 'keepout',
+          f"risen={risen}")
+    check("and a clean vector passes the same licence",
+          probe.licence(inside, inside)[0] is True, "no term rose")
+
+
+def arm_J_hard_terms(wd):
+    """`reseat_safety_ok` is pure policy, so every licensed/hard term is
+    testable directly -- `eviction_licence_ok`'s own shape and reason."""
+    print("--- J: the term-wise licence, one assertion per term")
+    n = len(reconstruct.GATE_TERMS)
+    base = [0, 0, 0.0, 0.0, 0, 10.0, 0.0]
+    check("control: an unchanged tuple is safe",
+          seeder.reseat_safety_ok(base, list(base)) == (True, []),
+          str(seeder.reseat_safety_ok(base, list(base))))
+    for term in reconstruct.GATE_TERMS:
+        worse = list(base)
+        i = _idx(term)
+        worse[i] = base[i] + (1 if isinstance(base[i], int) else 1.0)
+        ok, rose = seeder.reseat_safety_ok(base, worse)
+        if term == seeder.RESEAT_LICENSED_TERM:
+            check(f"{term} may worsen (it is the licensed term)",
+                  ok is True and rose == [], f"ok={ok} rose={rose}")
+        else:
+            check(f"{term} may NOT worsen", ok is False and rose == [term],
+                  f"ok={ok} rose={rose}")
+    check("every gate term is either hard or the licensed one",
+          n == len([t for t in reconstruct.GATE_TERMS
+                    if t == seeder.RESEAT_LICENSED_TERM
+                    or not seeder.reseat_safety_ok(
+                        base, [b + (1 if isinstance(b, int) else 1.0)
+                               if j == _idx(t) else b
+                               for j, b in enumerate(base)])[0]]),
+          f"{n} terms, none unclassified")
+
+
+def arm_K_schema_parity(wd):
+    """`_empty` and the seated path must return the same keys. This function
+    shipped a schema split once already."""
+    print("--- K: both return paths carry the same keys")
+    b = keepout_board(wd, 'k')
+    _p, it = keepout_intent(wd, 'k')
+    seated = reseat(b, it, ['U1'])
+    empty = reseat(b, it, ['NOSUCHREF*'])
+    check("the no-scope path is a RESULT, not an error",
+          empty['accepted'] is True and empty['scope'] == [],
+          f"accepted={empty['accepted']} scope={empty['scope']}")
+    missing = sorted(set(seated) - set(empty))
+    check("the early-out carries every key the seated path does",
+          missing == ['intent_used'] or not missing,
+          f"missing={missing}")
+    check("including accept_basis", 'accept_basis' in empty,
+          f"policy={empty['accept_basis'].get('policy')}")
+    check("and its policy says which path it was",
+          empty['accept_basis'].get('policy') == 'empty',
+          str(empty['accept_basis'].get('policy')))
+
+
+def arm_L_agreement_with_the_grade(wd):
+    """Over a pose lattice, the probe's breach count and `floorplan.grade`
+    must agree. If they ever disagree, the re-seat is being judged against a
+    rule the grader does not have."""
+    print("--- L: the probe agrees with the grade, pose by pose")
+    _p, it = keepout_intent(wd, 'l')
+    import pose_score
+    disagree = []
+    n = 0
+    for ux in [x * 0.5 for x in range(4, 33)]:
+        for uy in [y * 0.5 for y in range(4, 21)]:
+            bp = keepout_board(wd, 'l_probe', ux=ux, uy=uy)
+            pcb = parse_kicad_pcb(bp)
+            bundle, _pr = floorplan.resolve_intent_gate(it, pcb, ())
+            st = pose_score.make_state(pcb, bp, clearance=0.2,
+                                       board_edge_clearance=0.5,
+                                       grid_step=0.1, keepouts=it.keepouts)
+            pr = q.IntentProbe(st, zones=bundle['zones'], refs={'U1'})
+            mine = pr.snapshot()['count']
+            theirs = len([v for v in graded_errors(bp, it, ref='U1')
+                          if v.rule in INTENT_ENFORCED_RULES])
+            n += 1
+            if mine != theirs:
+                disagree.append((ux, uy, mine, theirs))
+    check(f"probe and grade agree on all {n} poses", not disagree,
+          f"{len(disagree)} disagreement(s)"
+          + (f", first {disagree[0]}" if disagree else ""))
+    check("and the lattice actually straddles the keep-out",
+          n > 100, f"{n} poses swept over a {KO_SIZE[0]}x{KO_SIZE[1]} board")
+
+
+def arm_M_seed_independence(wd):
+    """Is the keep-out fixture's behaviour a property of the BOARD or of one
+    seed? The first version of this fixture failed this arm 9/20."""
+    print("--- M: the fixture is seed-independent")
+    b = keepout_board(wd, 'm')
+    _p, it = keepout_intent(wd, 'm')
+    acc = 0
+    bases = set()
+    for s in range(8):
+        rep = reseat(b, it, ['U1'], seed=s)
+        acc += bool(rep['accepted'])
+        bases.add((rep['accept_basis'] or {}).get('fired'))
+    check("accepted on every seed", acc == 8, f"{acc}/8 seeds accepted")
+    check("and always on the same basis", bases == {'intent'}, str(bases))
+
+
+def arm_N_enforced_rules_covered(wd):
+    """Every rule the engine claims to enforce is exercised here, and the
+    vocabulary is read FROM the engine so a new rule cannot be forgotten."""
+    print("--- N: the enforced-rule vocabulary is pinned both ways")
+    check("INTENT_ENFORCED_RULES is the expected three",
+          set(INTENT_ENFORCED_RULES) == {'zone_containment', 'zone_exclusive',
+                                         'keepout'},
+          str(INTENT_ENFORCED_RULES))
+    check("every enforced rule is a real floorplan rule",
+          all(r in dict(floorplan.RULES) for r in INTENT_ENFORCED_RULES),
+          "all present in floorplan.RULES")
+    check("RESEAT_BASES has a unit for every basis",
+          set(seeder.RESEAT_BASES) == set(seeder.RESEAT_BASIS_UNITS),
+          str(sorted(set(seeder.RESEAT_BASES)
+                     ^ set(seeder.RESEAT_BASIS_UNITS))))
+    check("the licensed term is not also a basis",
+          seeder.RESEAT_LICENSED_TERM not in seeder.RESEAT_BASES,
+          f"{seeder.RESEAT_LICENSED_TERM} absent from RESEAT_BASES")
+    non_gate = [b for b in seeder.RESEAT_BASES
+                if b not in reconstruct.GATE_TERMS]
+    check("the only non-tuple bases are the two this change adds",
+          sorted(non_gate) == ['intent', 'scope_hpwl'], str(non_gate))
+
+
+def arm_O_zone_containment_basis(wd):
+    """A zone, not a keep-out: the other enforced rule that can bind a scope
+    ref, through the same measurement."""
+    print("--- O: a declared ZONE drives the same basis")
+    b = board(os.path.join(wd, 'o.kicad_pcb'),
+              [_part('U1', 30.0, 12.0, 1.0, 1.0, npads=2, nets=(1, 2)),
+               _part('R1', 6.0, 6.0, 0.4, 0.3, npads=2, nets=(1, 2))],
+              size=(40.0, 24.0))
+    _p, it = load({"schema": 1, "kind": "floorplan-intent", "units": "mm",
+                   "envelope": {"rect": [0.0, 0.0, 40.0, 24.0],
+                                "tolerance_mm": 0.5},
+                   "blocks": [{"name": "z", "refs": ["U1"],
+                               "zone": [3.0, 3.0, 11.0, 11.0],
+                               "tolerance_mm": 0.5}]}, wd, 'o')
+    check("control: U1 starts outside its declared zone",
+          len(graded_errors(b, it, rule='zone_containment', ref='U1')) == 1,
+          "1 zone_containment error on the input")
+    rep = reseat(b, it, ['U1'])
+    ab = rep['accept_basis']
+    check("the pass is accepted on the intent basis",
+          rep['accepted'] and ab.get('fired') == 'intent',
+          f"accepted={rep['accepted']} fired={ab.get('fired')}")
+    check("the by-rule split names zone_containment",
+          basis_term(ab, 'intent').get('before') == 1,
+          f"intent {basis_term(ab, 'intent')}")
+    out = os.path.join(wd, 'o_out.kicad_pcb')
+    write_placed_output(b, out, rep['moves'])
+    check("and the written board grades clean",
+          not graded_errors(out, it, rule='zone_containment'),
+          "0 zone_containment errors after")
+
+
+def arm_P_end_to_end_cli(wd):
+    """Through the real CLI, because everything above is in-process. A
+    non-zero exit is not evidence -- assert the REASON."""
+    print("--- P: the CLI, refusing and accepting for stated reasons")
+    seed_py = os.path.join(REPO, 'py_placer', 'place_seed.py')
+    b = keepout_board(wd, 'p')
+    ipath, _it = keepout_intent(wd, 'p')
+    run_utils.evidence(b, 'the reproducer board')
+    run_utils.evidence(ipath, 'the intent')
+
+    out = os.path.join(wd, 'p_out.kicad_pcb')
+    r = run_utils.check([sys.executable, '-X', 'utf8', seed_py, b, out,
+                         '--intent', ipath, '--clearance', '0.2',
+                         '--board-edge-clearance', '0.5', '--reseat', 'U1'],
+                        accept=True)
+    check("the CLI accepts and names the basis on stdout",
+          'accepted on intent' in r.stdout,
+          [ln.strip() for ln in r.stdout.splitlines()
+           if 'accepted on' in ln][:1])
+    summ = json.loads([ln for ln in r.stdout.splitlines()
+                       if ln.startswith('JSON_SUMMARY:')][-1]
+                      .split('JSON_SUMMARY:', 1)[1])
+    check("JSON_SUMMARY carries accept_basis",
+          (summ.get('accept_basis') or {}).get('fired') == 'intent',
+          str((summ.get('accept_basis') or {}).get('fired')))
+    check("and the min-gain it was run at",
+          summ.get('reseat_min_gain') == 0.0, str(summ.get('reseat_min_gain')))
+    check("grade_errors reached 0", summ.get('grade_errors') == 0,
+          str(summ.get('grade_errors')))
+
+    # The refusal, for a STATED reason rather than a bare non-zero exit.
+    pb = plain_board(wd, 'p2')
+    ip2, _it2 = plain_intent(wd, 'p2')
+    run_utils.check([sys.executable, '-X', 'utf8', seed_py, pb,
+                     os.path.join(wd, 'p2_out.kicad_pcb'), '--intent', ip2,
+                     '--clearance', '0.2', '--board-edge-clearance', '0.5',
+                     '--reseat', 'CON2', '--reseat-min-gain', '1000'],
+                    refuse='reseat-min-gain', code=4)
+    check("a sub-threshold win is refused NAMING the min-gain", True,
+          "exit 4 with 'reseat-min-gain' in the output")
+    run_utils.check([sys.executable, '-X', 'utf8', seed_py, pb,
+                     os.path.join(wd, 'p3_out.kicad_pcb'), '--intent', ip2,
+                     '--reseat-min-gain', '-1', '--reseat', 'CON2'],
+                    refuse='magnitude in mm', code=2)
+    check("a negative min-gain is an argparse refusal, not a looser bar", True,
+          "exit 2")
+
+
+def main():
+    with tempfile.TemporaryDirectory() as wd:
+        arm_A_keepout_accepted(wd)
+        arm_B_hpwl_licence(wd)
+        arm_C_prune_is_the_other_mechanism(wd)
+        arm_D_prune_probe_inert(wd)
+        arm_E_plain_board_hpwl_basis(wd)
+        arm_F_min_gain(wd)
+        arm_G_auto_scope_unchanged(wd)
+        arm_H_seat_gate_stays_disarmed(wd)
+        arm_I_intent_vector_is_the_guard(wd)
+        arm_J_hard_terms(wd)
+        arm_K_schema_parity(wd)
+        arm_L_agreement_with_the_grade(wd)
+        arm_M_seed_independence(wd)
+        arm_N_enforced_rules_covered(wd)
+        arm_O_zone_containment_basis(wd)
+        arm_P_end_to_end_cli(wd)
+    print(f"\n{passed}/{passed + failed} checks passed")
+    return 1 if failed else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_698_reseat_acceptance.py
+++ b/tests/test_698_reseat_acceptance.py
@@ -984,30 +984,69 @@ def arm_S_review_findings(wd):
               f"accepted={ok} (MEASURE_QUANTUM={seeder.MEASURE_QUANTUM})")
 
     # SF-4: the KEPT note must not credit the probe for a revert the TUPLE
-    # refused on its own.
-    pcb = parse_kicad_pcb(b)
-    bundle, _pr = floorplan.resolve_intent_gate(it, pcb, ())
+    # refused on its own. The case needs `undoes_intent` TRUE (the old pose is
+    # INSIDE the keep-out, so restoring it re-breaks the claim) while the tuple
+    # declines anyway -- here because a blocker sits on the old pose, so the
+    # revert would create courtyard overlap. Both halves matter: with only the
+    # first, the tuple wants the revert and the mutation is unreachable, which
+    # is how the first version of this check passed while testing nothing.
+    b4 = board(os.path.join(wd, 's4.kicad_pcb'),
+               [_part('U1', 14.0, 2.0, 0.5, 0.5, npads=4, nets=(1, 2, 3, 4)),
+                _part('R1', 9.0, 5.0, 0.4, 0.3, npads=2, nets=(1, 2)),
+                _part('C1', 11.0, 7.0, 0.4, 0.3, npads=2, nets=(3, 4)),
+                _part('BLK', 10.0, 6.0, 1.2, 1.2, npads=2, nets=(7, 8))],
+               size=KO_SIZE)
+    _p4, it4 = keepout_intent(wd, 's4')
+    pcb4 = parse_kicad_pcb(b4)
+    bundle4, _pr4 = floorplan.resolve_intent_gate(it4, pcb4, ())
     import pose_score
-    st = pose_score.make_state(pcb, b, clearance=0.2,
-                               board_edge_clearance=0.5, grid_step=0.1,
-                               keepouts=it.keepouts)
-    probe = q.IntentProbe(st, zones=bundle['zones'])
-    # `old` = a pose FARTHER from U1's partners than where it stands, so the
-    # tuple does not want the revert; U1 is clear of the keep-out either way.
-    st.apply_move('U1', 13.5, 6.0, 0.0)
-    notes = []
-    pruned = reconstruct.prune_assignment(
-        st, {'U1': (18.0, 11.0, 0.0)}, notes, edge_bands={},
-        intent_probe=probe.terms)
-    check("SF-4: the tuple declines the revert", pruned == [], f"{pruned}")
-    check("SF-4: and no note credits the intent probe for it",
-          not any('KEPT' in n for n in notes), f"notes={notes}")
+    st4 = pose_score.make_state(pcb4, b4, clearance=0.2,
+                                board_edge_clearance=0.5, grid_step=0.1,
+                                keepouts=it4.keepouts)
+    probe4 = q.IntentProbe(st4, zones=bundle4['zones'])
+    old4 = (10.0, 6.0, 0.0)                 # inside `hot`, and on top of BLK
+    check("SF-4 control: the CURRENT pose breaches nothing",
+          probe4.terms('U1') == (0.0,), f"terms={probe4.terms('U1')}")
+    st4.apply_move('U1', *old4)
+    breached = probe4.terms('U1')
+    st4.apply_move('U1', 14.0, 2.0, 0.0)
+    check("SF-4 control: the OLD pose breaches the keep-out",
+          breached and breached[0] > 0, f"terms={breached}")
+    notes4 = []
+    pruned4 = reconstruct.prune_assignment(
+        st4, {'U1': old4}, notes4, edge_bands={}, intent_probe=probe4.terms)
+    check("SF-4: the tuple declines the revert on its own", pruned4 == [],
+          f"pruned={pruned4}")
+    check("SF-4: and no KEPT note credits the intent probe for it",
+          not any('KEPT' in n for n in notes4), f"notes={notes4}")
 
-    # SF-6a: the probe covers the whole board, not just the named scope, so an
-    # EVICTED stranger cannot be pushed into a keep-out unseen.
-    check("SF-6a: the probe binds every claim-bound ref, not only the scope",
-          set(probe.spec) >= {'U1'} and probe.refs == tuple(sorted(st.parts)),
-          f"probe.refs={probe.refs}")
+    # SF-6a: the probe `reseat_scope` ACTUALLY BUILDS must cover the whole
+    # board, so an evicted stranger cannot be pushed into a keep-out unseen.
+    # Asserted at the real call site -- a probe this test constructs proves
+    # nothing about the one the engine constructs.
+    seen6 = {}
+    real6 = q.IntentProbe.__init__
+
+    def spy6(self, state, zones=(), refs=None):
+        real6(self, state, zones=zones, refs=refs)
+        seen6['refs_arg'] = refs
+        seen6['covered'] = set(self.refs)
+        seen6['parts'] = set(state.parts)
+
+    q.IntentProbe.__init__ = spy6
+    try:
+        reseat(b, it, ['U1'])
+    finally:
+        q.IntentProbe.__init__ = real6
+    check("SF-6a: reseat_scope builds the probe over the WHOLE board",
+          seen6.get('refs_arg') is None
+          and seen6.get('covered') == seen6.get('parts'),
+          f"refs={seen6.get('refs_arg')}, "
+          f"{len(seen6.get('covered') or ())} of "
+          f"{len(seen6.get('parts') or ())} parts covered")
+    check("SF-6a: and that is strictly more than the named scope",
+          len(seen6.get('covered') or ()) > 1,
+          f"scope was ['U1'], probe covers {sorted(seen6.get('covered') or ())}")
 
 
 def main():

--- a/tests/test_698_reseat_acceptance.py
+++ b/tests/test_698_reseat_acceptance.py
@@ -693,14 +693,26 @@ def arm_M_seed_independence(wd):
     print("--- M: the fixture is seed-independent")
     b = keepout_board(wd, 'm')
     _p, it = keepout_intent(wd, 'm')
-    acc = 0
-    bases = set()
-    for s in range(8):
+    hp = _idx('hpwl')
+    n = 20                      # the number the module docstring quotes
+    acc, worse, bases, deltas = 0, 0, set(), []
+    for s in range(n):
         rep = reseat(b, it, ['U1'], seed=s)
         acc += bool(rep['accepted'])
         bases.add((rep['accept_basis'] or {}).get('fired'))
-    check("accepted on every seed", acc == 8, f"{acc}/8 seeds accepted")
+        d = rep['gate_after'][hp] - rep['gate_before'][hp]
+        deltas.append(round(d, 3))
+        worse += d > 1e-9
+    check(f"accepted on every one of {n} seeds", acc == n,
+          f"{acc}/{n} seeds accepted")
     check("and always on the same basis", bases == {'intent'}, str(bases))
+    # The hpwl claim in the module docstring, re-derived rather than quoted.
+    # It is a RANGE, not a constant: the seat search is seeded, so every seed
+    # escapes to a different pose. An earlier version of this file recorded one
+    # seed's value as if it held for all 20.
+    check(f"the escape costs hpwl on every one of {n} seeds", worse == n,
+          f"{worse}/{n} worse; range {min(deltas)} to {max(deltas)} mm, "
+          f"{len(set(deltas))} distinct values")
 
 
 def arm_N_enforced_rules_covered(wd):
@@ -969,14 +981,37 @@ def arm_S_review_findings(wd):
 
     # SF-3: a gain of EXACTLY --reseat-min-gain must count; the help calls it
     # "the smallest win that counts".
-    ba = dict(bb, scope_hpwl=-0.5)          # gain of exactly 0.5
-    for mg, want in ((0.5, True), (0.5001, False)):
-        ok, _ = seeder.reseat_accept(
+    def _hp(gain, mg):
+        ok, _b = seeder.reseat_accept(
             base, list(base), scope_source='explicit',
             witnesses_before=[], witnesses_after=[],
-            bases_before=bb, bases_after=ba, min_gain=mg)
+            bases_before=bb, bases_after=dict(bb, scope_hpwl=-gain),
+            min_gain=mg)
+        return ok
+
+    for mg, want in ((0.5, True), (0.5001, False)):
         check(f"SF-3: gain 0.5 against --reseat-min-gain {mg} -> "
-              f"{'accept' if want else 'refuse'}", ok is want, f"accepted={ok}")
+              f"{'accept' if want else 'refuse'}", _hp(0.5, mg) is want,
+              f"accepted={_hp(0.5, mg)}")
+
+    # SF-3b: MONOTONE in min_gain. The first fix lost this: `elif gated and
+    # min_gain` sent a sub-quantum threshold down the `>=` branch, so
+    # `--reseat-min-gain 1e-12` accepted a gain of EXACTLY ZERO -- a looser
+    # gate from a stricter flag, admitting the sideways shuffle the basis
+    # exists to refuse. A negative one did the same through the kwarg, which
+    # the CLI validator cannot see.
+    check("SF-3b: a sub-quantum threshold does not accept a ZERO gain",
+          _hp(0.0, 1e-12) is False, f"accepted={_hp(0.0, 1e-12)}")
+    check("SF-3b: nor does it accept a sub-quantum gain",
+          _hp(6e-5, 5e-5) is False, f"accepted={_hp(6e-5, 5e-5)}")
+    check("SF-3b: a NEGATIVE threshold does not accept a WORSENING basis",
+          _hp(-3.0, -5.0) is False, f"accepted={_hp(-3.0, -5.0)}")
+    check("SF-3b: and raising the threshold never loosens the gate",
+          all(not (_hp(g, hi) and not _hp(g, lo))
+              for g in (0.0, 6e-5, 0.5, 2.0)
+              for lo, hi in ((0.0, 1e-12), (1e-12, 5e-5), (5e-5, 0.5),
+                             (0.5, 2.0))),
+          "monotone over 4 gains x 4 threshold pairs")
 
     # N-1: a continuous legality basis must not fire on rounding noise.
     for delta, want in ((1e-4, False), (2e-3, True)):
@@ -1053,6 +1088,65 @@ def arm_S_review_findings(wd):
     check("SF-6a: and that is strictly more than the named scope",
           len(seen6.get('covered') or ()) > 1,
           f"scope was ['U1'], probe covers {sorted(seen6.get('covered') or ())}")
+
+    # SF-6b: the BEHAVIOUR, not just the constructor argument. Nothing else in
+    # the tree passes `evict_depth` together with a keep-out, so without this
+    # the whole-board probe is pinned only by how it is built. A stub eviction
+    # drops a stranger INTO `hot` while the scope ref escapes it: with the
+    # whole-board probe the licence refuses; scoped to the named refs it is
+    # accepted, and the `intent` basis even reads 1 -> 0 while the board is
+    # still in violation.
+    b6 = board(os.path.join(wd, 's6.kicad_pcb'),
+               [_part('U1', 10.0, 6.0, 0.5, 0.5, npads=4, nets=(1, 2, 3, 4)),
+                _part('R1', 9.0, 5.0, 0.4, 0.3, npads=2, nets=(1, 2)),
+                _part('C1', 11.0, 7.0, 0.4, 0.3, npads=2, nets=(3, 4)),
+                _part('S', 3.0, 3.0, 0.5, 0.5, npads=2, nets=(7, 8))],
+               size=KO_SIZE)
+    _p6, it6 = keepout_intent(wd, 's6')
+    real_seed = seeder.seed_from_intent
+
+    def stub_seed(pcb2, path2, intent2, rng, **kw):
+        """Seat U1 clear of `hot` and 'evict' S straight into it."""
+        return {'placements': [
+                    {'reference': 'U1', 'new_x': 15.0, 'new_y': 10.0,
+                     'new_rotation': 0.0},
+                    {'reference': 'S', 'new_x': 10.0, 'new_y': 6.0,
+                     'new_rotation': 0.0}],
+                'unseated': [], 'notes': [],
+                'evictions': [{'accepted': True, 'blockers': ['S']}],
+                'no_pose_blockers': {}, 'no_pose_verdict': {},
+                'no_pose_census': {}}
+
+    seeder.seed_from_intent = stub_seed
+    try:
+        wide = reseat(b6, it6, ['U1'], evict_depth=1)
+        real_probe_init = q.IntentProbe.__init__
+
+        def narrow_init(self, state, zones=(), refs=None):
+            real_probe_init(self, state, zones=zones, refs={'U1'})
+
+        q.IntentProbe.__init__ = narrow_init
+        try:
+            narrow = reseat(b6, it6, ['U1'], evict_depth=1)
+        finally:
+            q.IntentProbe.__init__ = real_probe_init
+    finally:
+        seeder.seed_from_intent = real_seed
+
+    risen = ((wide['accept_basis'].get('intent_licence') or {}).get('risen')
+             or [])
+    check("SF-6b: the whole-board probe REFUSES an evicted stranger pushed "
+          "into a keep-out", wide['accepted'] is False,
+          f"accepted={wide['accepted']}")
+    check("SF-6b: and names the stranger and the claim",
+          any(r[0] == 'S' and r[1] == 'keepout' for r in risen),
+          f"risen={risen}")
+    check("SF-6b: control -- scoped to the named refs it is ACCEPTED",
+          narrow['accepted'] is True, f"accepted={narrow['accepted']}")
+    check("SF-6b: and the scoped basis even reads intent 1 -> 0 on a board "
+          "still in violation",
+          basis_term(narrow['accept_basis'], 'intent').get('after') == 0,
+          f"intent={basis_term(narrow['accept_basis'], 'intent')}")
 
 
 def main():

--- a/tests/test_698_reseat_acceptance.py
+++ b/tests/test_698_reseat_acceptance.py
@@ -23,7 +23,21 @@ where their bounding box CONTAINED most escape poses -- hpwl was flat and prune
 reverted on only 9 of 20 seeds, so `pruned == ['U1']` would have been a
 seed-0 accident asserted as a property. `arm_M_seed_independence` pins it.
 
-Mutation battery: `tests/mutate_698.py`.
+Mutation battery: `tests/mutate_698.py` -- **32 rows: 30 killed, 2 survived
+(both recorded with their reason), 0 broken, 0 disagreeing with expectation.**
+
+What it caught in THIS file, which is why it exists:
+
+| mutation | why it survived the first time |
+|---|---|
+| `drop-the-safety-half` | a legal seat search never worsens a hard term, so no behavioural arm could reach the conjunct. `arm_Q` drives `reseat_accept` directly. |
+| `prune-refuses-every-revert` | no fixture had prune legitimately reverting a claim-bound part, so "the probe is a conjunct, not an exemption" was untested. `arm_R`. |
+| `hpwl-ignores-its-net-subset` | every net on the plain fixture touched the scope ref, so `scope_hpwl` and the board-wide `hpwl` were the same number. R8/R9 fixed that. |
+
+And one it caught in ITSELF: the row `the-zone-spec-forgets-the-anchor-branch`
+originally mutated `not any(` to `False or not any(`, which is the same
+expression -- a row that could not fail, recorded as an expected survivor. It
+read as a finding and was a tautology.
 """
 import json
 import os

--- a/tests/test_698_reseat_acceptance.py
+++ b/tests/test_698_reseat_acceptance.py
@@ -978,6 +978,17 @@ def arm_S_review_findings(wd):
         note_ok = f"KeyError {e}"
     check("SF-2: and the refusal note renders against it", note_ok is True,
           str(note_ok))
+    # The keys must also carry the CALLER's values, not fabricated ones: a
+    # reported threshold that was never in force is the same defect as a
+    # reported census that never ran, one field over.
+    empty_mg = reseat(b, it, ['NOSUCHREF*'], min_gain=0.75)
+    check("SF-2: the early-out reports the min_gain it was given",
+          empty_mg['accept_basis'].get('min_gain') == 0.75,
+          f"min_gain={empty_mg['accept_basis'].get('min_gain')}")
+    check("SF-2: and the skeleton carries eviction_licence on both paths",
+          ('eviction_licence' in seated['accept_basis']
+           and 'eviction_licence' in empty['accept_basis']),
+          "present on both")
 
     # SF-3: a gain of EXACTLY --reseat-min-gain must count; the help calls it
     # "the smallest win that counts".

--- a/tests/test_698_reseat_acceptance.py
+++ b/tests/test_698_reseat_acceptance.py
@@ -157,11 +157,17 @@ def plain_board(wd, tag='pl'):
     """A legal, on-board, MISPLACED part with NO declared claim at all -- the
     pure form of the defect. Nothing but the scope's own wirelength can carry
     it, so this arm proves the fix is not intent-dependent."""
+    # R8/R9 carry net 8, which CON2 has no pad on. They are what makes
+    # `scope_hpwl` differ from the board-wide `hpwl` -- without a net OUTSIDE
+    # the scope the two numbers are equal and `state.hpwl(nets)` could ignore
+    # its subset undetected (a mutation that survived until they were added).
     return board(os.path.join(wd, f'{tag}.kicad_pcb'),
                  [_part('CON2', 15.0, 7.0, 8.9, 1.3, npads=7, thru=True,
                         nets=(1, 2, 3, 4, 5, 6, 7)),
                   _part('U1', 4.0, 3.0, 1.5, 1.5, npads=4, nets=(1, 2, 3, 4)),
-                  _part('U2', 6.0, 11.0, 1.5, 1.5, npads=3, nets=(5, 6, 7))],
+                  _part('U2', 6.0, 11.0, 1.5, 1.5, npads=3, nets=(5, 6, 7)),
+                  _part('R8', 27.0, 2.0, 0.4, 0.3, npads=2, nets=(8, 8)),
+                  _part('R9', 29.0, 12.5, 0.4, 0.3, npads=2, nets=(8, 8))],
                  size=PL_SIZE)
 
 
@@ -355,6 +361,23 @@ def arm_E_plain_board_hpwl_basis(wd):
           basis_term(ab, 'oob').get('before')
           == basis_term(ab, 'oob').get('after') == 0.0,
           f"oob={basis_term(ab, 'oob')}")
+
+    # `scope_hpwl` must be the SCOPE's nets, not the board's. Net 8 (R8<->R9)
+    # touches no scope ref, so the two numbers must differ -- without this the
+    # subset argument to `state.hpwl` could be ignored undetected.
+    import pose_score
+    pcb = parse_kicad_pcb(b)
+    st = pose_score.make_state(pcb, b, clearance=0.2,
+                               board_edge_clearance=0.5, grid_step=0.1)
+    board_wide = round(st.hpwl(), 3)
+    scoped = seeder.scope_hpwl(st, {'CON2'})
+    check("scope_hpwl is strictly less than the board-wide hpwl",
+          scoped < board_wide - 1e-9,
+          f"scope {scoped} vs board {board_wide} -- net 8 is outside the scope")
+    check("and the basis reports the SCOPED number",
+          abs(basis_term(ab, 'scope_hpwl').get('before', 0) - scoped) < 1e-6,
+          f"basis before={basis_term(ab, 'scope_hpwl').get('before')} "
+          f"scope_hpwl={scoped}")
 
 
 def arm_F_min_gain(wd):
@@ -731,6 +754,125 @@ def arm_P_end_to_end_cli(wd):
           "exit 2")
 
 
+def arm_Q_the_conjuncts_compose(wd):
+    """`reseat_accept` is pure policy, so each conjunct is testable directly --
+    which is the only way to reach the ones a legal seat search cannot produce.
+
+    Every row here exists because a mutation survived without it: deleting
+    `safe`, deleting `not risen` and deleting `witness_ok` from the conjunct
+    all passed the behavioural arms, since a legal seat never worsens a hard
+    term and the fixtures' claims never rise.
+    """
+    print("--- Q: each conjunct refuses on its own")
+    idx = reconstruct.GATE_TERMS.index
+    before = [0, 0, 0.0, 0.0, 0, 10.0, 0.0]
+    after = list(before)
+    bb = {n: 0.0 for n in seeder.RESEAT_BASES}
+    bb['intent'] = 1
+    ba = dict(bb, intent=0)                 # one whole defect cleared
+
+    def acc(**kw):
+        kw.setdefault('scope_source', 'explicit')
+        kw.setdefault('witnesses_before', ['A'])
+        kw.setdefault('witnesses_after', ['A'])
+        kw.setdefault('bases_before', bb)
+        kw.setdefault('bases_after', ba)
+        return seeder.reseat_accept(kw.pop('before', before),
+                                    kw.pop('after', after), **kw)
+
+    ok, basis = acc()
+    check("control: safe, no risen claim, one basis fired -> ACCEPTED",
+          ok is True and basis['fired'] == 'intent',
+          f"accepted={ok} fired={basis['fired']}")
+
+    worse = list(after)
+    worse[idx('stacks')] = before[idx('stacks')] + 1
+    ok2, b2 = acc(after=worse)
+    check("a worsened HARD term refuses a pass whose basis fired",
+          ok2 is False and b2['safety']['worsened'] == ['stacks'],
+          f"accepted={ok2} worsened={b2['safety']['worsened']}")
+    check("and the refusal note names the term, not the off-board amount",
+          'stacks' in seeder.reseat_refusal_note(1, b2)
+          and 'off-board amount' not in seeder.reseat_refusal_note(1, b2),
+          seeder.reseat_refusal_note(1, b2)[:110])
+
+    lic = list(after)
+    lic[idx('hpwl')] = before[idx('hpwl')] + 5.0
+    ok3, _b3 = acc(after=lic)
+    check("the LICENSED term worsening does not refuse it", ok3 is True,
+          f"accepted={ok3} with hpwl +5.0")
+
+    ok4, b4 = acc(intent_risen=[('U1', 'keepout', 'hot', 0.0, 5.0)])
+    check("a RISEN declared claim refuses it even though the count improved",
+          ok4 is False and b4['intent_licence']['ok'] is False,
+          f"accepted={ok4} risen={b4['intent_licence']['risen']}")
+    check("and that refusal names the claim",
+          "'hot'" in seeder.reseat_refusal_note(1, b4),
+          seeder.reseat_refusal_note(1, b4)[:110])
+
+    ok5, b5 = acc(witnesses_after=['A', 'B'])
+    check("a GROWN off-outline count refuses it",
+          ok5 is False and b5['witness_ok'] is False,
+          f"accepted={ok5} witness_ok={b5['witness_ok']}")
+    check("and that refusal names the count",
+          'GREW' in seeder.reseat_refusal_note(1, b5),
+          seeder.reseat_refusal_note(1, b5)[:110])
+
+    ok6, b6 = acc(bases_after=dict(bb))     # nothing improved
+    check("no basis firing refuses it", ok6 is False and b6['fired'] is None,
+          f"accepted={ok6} fired={b6['fired']}")
+
+    # The auto branch, on the same numbers, must be the OLD rule.
+    ok7, b7 = acc(scope_source='auto:damage_witnesses')
+    check("the auto branch ignores every basis and reads oob only",
+          ok7 is False and b7['policy'] == 'auto:oob-strict',
+          f"accepted={ok7} policy={b7['policy']} (oob did not move)")
+    moved = list(after)
+    moved[idx('oob')] = before[idx('oob')] - 1.0
+    ok8, _b8 = acc(after=moved, scope_source='auto:damage_witnesses')
+    check("and accepts on a strict oob improvement alone", ok8 is True,
+          "oob 0.0 -> -1.0")
+
+
+def arm_R_prune_still_reverts_a_claim_bound_part(wd):
+    """The probe is a CONJUNCT, not an exemption: a part bound by a claim is
+    still pruned when the revert does not re-break anything.
+
+    Without this, `undoes_intent = bool(after_intent)` -- refuse EVERY revert
+    of any claim-bound part -- passes the whole suite, and the sweep silently
+    stops doing its job for exactly the parts this change touches.
+    """
+    print("--- R: a claim-bound part is still prunable")
+    b = keepout_board(wd, 'r')
+    _p, it = keepout_intent(wd, 'r')
+    pcb = parse_kicad_pcb(b)
+    bundle, _pr = floorplan.resolve_intent_gate(it, pcb, ())
+    import pose_score
+    st = pose_score.make_state(pcb, b, clearance=0.2,
+                               board_edge_clearance=0.5, grid_step=0.1,
+                               keepouts=it.keepouts)
+    probe = q.IntentProbe(st, zones=bundle['zones'], refs={'U1'})
+
+    # Both poses are OUTSIDE the keep-out, so the claim vector is 0 either way
+    # -- the revert cannot re-break anything -- but the `old` pose is nearer
+    # U1's net partners, so the tuple wants it back.
+    home = (13.5, 6.0, 0.0)
+    away = (18.0, 11.0, 0.0)
+    st.apply_move('U1', *home)
+    check("control: the 'home' pose breaches nothing", probe.terms('U1') == (0.0,),
+          f"terms={probe.terms('U1')}")
+    st.apply_move('U1', *away)
+    check("control: the 'away' pose breaches nothing either",
+          probe.terms('U1') == (0.0,), f"terms={probe.terms('U1')}")
+
+    pruned = reconstruct.prune_assignment(
+        st, {'U1': home}, None, edge_bands={}, intent_probe=probe.terms)
+    check("prune reverts it, probe or no probe", pruned == ['U1'],
+          f"pruned={pruned}")
+    check("and the revert actually landed",
+          abs(st.parts['U1'].x - home[0]) < 1e-9, f"x={st.parts['U1'].x}")
+
+
 def main():
     with tempfile.TemporaryDirectory() as wd:
         arm_A_keepout_accepted(wd)
@@ -749,6 +891,8 @@ def main():
         arm_N_enforced_rules_covered(wd)
         arm_O_zone_containment_basis(wd)
         arm_P_end_to_end_cli(wd)
+        arm_Q_the_conjuncts_compose(wd)
+        arm_R_prune_still_reverts_a_claim_bound_part(wd)
     print(f"\n{passed}/{passed + failed} checks passed")
     return 1 if failed else 0
 

--- a/tests/test_698_reseat_acceptance.py
+++ b/tests/test_698_reseat_acceptance.py
@@ -33,21 +33,27 @@ re-derivable from this tree; the rebuild moved the partners, halved U1's
 courtyard and added the keep-out's `allow` list.) `arm_M_seed_independence` is
 what stops it recurring.
 
-Mutation battery: `tests/mutate_698.py` -- **32 rows: 30 killed, 2 survived
+Mutation battery: `tests/mutate_698.py` -- **38 rows: 36 killed, 2 survived
 (both recorded with their reason), 0 broken, 0 disagreeing with expectation.**
 
-What it caught in THIS file, which is why it exists:
+What it caught in THIS file, over two rounds, which is why it exists:
 
-| mutation | why it survived the first time |
+| mutation | why it survived |
 |---|---|
 | `drop-the-safety-half` | a legal seat search never worsens a hard term, so no behavioural arm could reach the conjunct. `arm_Q` drives `reseat_accept` directly. |
 | `prune-refuses-every-revert` | no fixture had prune legitimately reverting a claim-bound part, so "the probe is a conjunct, not an exemption" was untested. `arm_R`. |
 | `hpwl-ignores-its-net-subset` | every net on the plain fixture touched the scope ref, so `scope_hpwl` and the board-wide `hpwl` were the same number. R8/R9 fixed that. |
+| `the-KEPT-note-credits-the-probe-for-every-held-revert` | **round 2** -- the arm-S check written for that very finding put U1 outside the keep-out at BOTH poses, so `undoes_intent` was False and the mutated line was unreachable. |
+| `the-probe-goes-back-to-the-named-scope-only` | **round 2** -- that check asserted on a probe the TEST built, which says nothing about the one `reseat_scope` builds. It now spies the real call site. |
 
-And one it caught in ITSELF: the row `the-zone-spec-forgets-the-anchor-branch`
-originally mutated `not any(` to `False or not any(`, which is the same
-expression -- a row that could not fail, recorded as an expected survivor. It
-read as a finding and was a tautology.
+The round-2 pair is the lesson worth keeping: those two checks were written to
+pin findings from a code review, and they were themselves vacuous. A fix is not
+verified by the reviewer that motivated it.
+
+And one the battery caught in ITSELF: the row
+`the-zone-spec-forgets-the-anchor-branch` originally mutated `not any(` to
+`False or not any(`, which is the same expression -- a row that could not fail,
+recorded as an expected survivor. It read as a finding and was a tautology.
 """
 import json
 import os


### PR DESCRIPTION
Closes #698

Split out of #796 after it merged: #698's central acceptance term is the
declared-claim measurement that landed there, so this is built on top of it
rather than on a second copy of a measurement the grade already owns.
Rebased onto current `main` and re-verified there.

---


`place_seed --reseat` is the only re-seat-from-scratch path in the engine, and
CLAUDE.md recommends it over nudging for a part that has moved far from where it
belongs. Its acceptance gate made it a **no-op for every part that is on the
board**:

```python
accepted = (after[_oob] < before[_oob]
            and len(witnesses_after) <= len(witnesses_before))
```

`oob` is the off-board amount. A part that is legal and on the board has it
unchanged, so the strict inequality is false whatever the search found.

A detail worth naming, because it misleads: the `(2.15 -> 2.15)` the issue
quotes is **not what the gate compared**. The old code re-measures *after*
restoring the poses and prints that, so the pair is tautologically equal on every
refused run. `accept_basis` is computed before the revert, so the numbers it
reports are the ones the gate actually saw.

### Two mechanisms, and fixing either alone leaves the board broken

The issue's own follow-up comment contributes the second, and it is right:
`prune_assignment` reverts **first**, and its tuple has no intent term either, so
a seat that cleared a declared keep-out reads as a pure hpwl loss and is undone
before the gate ever runs.

Measured on two fixtures, both a legal on-board part in the wrong place:

| | keep-out fixture | claim-free fixture |
|---|---|---|
| declared claim binding the scope | keep-out `hot` | **none** |
| prune reverts the seat | **yes, 20/20 seeds** | no |
| hpwl of the search's pose | **worse on 20/20** (6.82–12.392 mm, 20 distinct values) | **better** (scope hpwl 109.1 → 70.281) |
| basis the fix accepts on | `intent` | `scope_hpwl` |
| fixed by the gate change alone | **no** | yes |

The phase order is the proof: with the gate fixed and prune not, the claim-free
board was accepted and the keep-out board was still refused.

### The shape of the fix, and why it is not an eighth gate term

The auto scope and an explicit scope differ in one structural way. On
`auto:damage_witnesses` the pass's win **is** `oob`, at index 3 of the gate tuple
— *above* `hpwl` — so the lexicographic compare already sees it and the old rule
is complete. That branch is unchanged, and `place_reconstruct`'s ladder rung
(which passes no `refs`) takes the same decisions on the same boards; its report
JSON does gain an `accept_basis` key and the auto refusal text is reworded, so
"bit-identical" would be the wrong word. On an explicit scope the win is a
declared claim or the scope's own wirelength, which the tuple cannot see **at
all**. Hence a term-wise safety condition plus a separate trigger.

- **`hpwl` is the one licensed term.** A seat made for a declared reason is
  hpwl-worse by construction, because hpwl is the netlist proxy the declaration
  overrules — `placement/README.md` says exactly that for the evicted-part
  exemption, and the issue reporter's own comment made that citation first. A
  lexicographic `after <= before` reads hpwl at index 5 and would refuse the very
  case this exists for; `arm_B` computes that counterfactual rather than
  asserting it.
- **`oob` stays hard but is no longer required to *improve*.** That single
  asymmetry is the bug: requiring improvement makes the pass a no-op; requiring
  non-worsening keeps off-outline pad copper — the defect CLAUDE.md ranks first —
  unbuyable.
- **The intent VECTOR is the guard; the intent COUNT is only the trigger.** A
  bare count carries the trap `_IntentTerm` names: a part hopping from keep-out A
  into keep-out B reads `1 → 1`, which a monotone rule admits. `licence()`
  separately refuses any term that *rose*, termwise, never summed.
- **The probe covers the whole board, not the named scope.** The scope is not the
  set of parts this pass can move: at `--evict-depth >= 1` it trades out
  neighbours nobody named, and those refs do not exist until after the "before"
  snapshot must be taken. Scoped to the named refs, the licence cannot see an
  evicted stranger pushed *into* a keep-out — demonstrated in `arm_S`/SF-6b,
  where the narrowed control accepts while reporting `intent 1 → 0` on a board
  still in violation.
- **Not an eighth `GATE_TERMS` entry.** `measure(state, edge_bands)` has no
  intent to measure at its 15 call sites across the reconstruct ladder; a tuple
  slot holds a scalar while the measurement is a vector in three currencies; and
  `tests/test_run8_gate_conjuncts.py` pins the arity at 7 with its own recorded
  reason.
- **`prune_assignment` takes an `intent_probe` conjunct, not an `exempt` entry.**
  `exempt` skips the part entirely, so a ref that escaped a 0.1 mm² keep-out kiss
  would also become immune to prune reverting a 30 mm mis-move. As a conjunct the
  sweep goes on reverting everything the tuple wants reverted *unless* that would
  re-break a declaration, and stays monotone — now on `(tuple, intent vector)`
  jointly. With `intent_probe=None` the expression is provably inert
  (`zip((), ())`), so the other call sites are untouched.

### One measurement, shared with the grade

The zone terms reach the re-seat as a **measurement-only** spec that is never
installed on the state. `pose_score.make_state` hands this path `keepouts` and
deliberately withholds `intent_zones`, because the re-seat's job is to move a
part that is *already* violating and a monotone per-pose gate would make it
refuse its own target. `IntentProbe` assigns to neither `state._intent_spec` nor
`state._intent_active`, and an AST guard asserts that no `make_state` call in
`seeder.py` passes `intent_zones=` or splats `**kwargs`.

The three enforced rules are measured through the same `zone_escape` /
`keepout_hit` / `rect_overlap_area` the grade calls — `build_zone_spec`,
`intent_spec` and `intent_term_values` are extractions from `QuenchState`, not
copies of it. An arm sweeps **493 poses** and asserts the probe's breach count
equals `floorplan.grade`'s, filtered to the scope and the enforced rules.

### `--reseat-min-gain`, and an honest account of its default

It gates the **`scope_hpwl`** basis only. Count bases threshold at one whole
defect: one number compared against both currencies would assert an exchange rate
between half a millimetre of wire and half a keep-out violation, which is the
summing error `_IntentTerm` refuses inside one ref's vector. Every continuous
basis is *also* floored at `MEASURE_QUANTUM`, the last digit `measure` keeps for
the 4-dp legality terms — without it the old `gain > 1e-9` let an `overlap`
improvement in the last representable digit accept a pass, and since `hpwl` is
licensed such a pass may be arbitrarily worse on wirelength. That floor is also
what makes the rule **monotone in `--reseat-min-gain`**: a threshold below the
quantum falls through to it, so a stricter flag can never produce a looser gate.

The default is **0.0**, from `tests/measure_698_min_gain.py` (committed, so the
number is re-derivable): 16 explicit re-seats on four corpus boards, parts chosen
by pad count so the sample cannot be fitted to the conclusion. **The first
write-up of this measurement was wrong, and the script now carries the columns
that show it.** The gains look bimodal — 10 exactly 0.000, 6 running 1.004 to
19.875 mm — but 9 of the 10 zeros are seats `prune_assignment` *reverted*: the
search moved the part (0.14 to 63.79 mm; mostly far, two under 0.31 mm) to a pose
that is hpwl-worse, so `after` is the restored input pose. Only one is a genuine
no-op. The bimodality is therefore partly structural — anything surviving prune
has improved hpwl by construction. What the sample supports is narrower and still
sufficient: every **non-zero** gain was ≥ 1 mm, so a non-zero default would buy
nothing here while risking a genuine small win.

### Verification

- `tests/test_698_reseat_acceptance.py` — **119 checks**, 19 arms, every
  accepting arm with a control.
- `tests/mutate_698.py` — **41 rows: 38 killed, 3 survived** (all recorded with
  their reason), 0 broken, 0 disagreeing with expectation.
- `tests/test_placement_ab.py`, run **at this HEAD**: `pinned 7/7`,
  `baseline: 7 row(s) match`, PASS — ~100 recorded numeric leaves over four large
  boards, unchanged.
- **Full suite at this HEAD, on a clean frozen tree: 451 passed, 0 failed, 0
  timed out, 0 skipped.**

### What the review found, since it is most of the value here

Two reviewers run separately, then the battery re-run over their fixes, then a
third pass over *that*. Every round found something the round before it had
passed, and almost all of it was in what I had just written:

- An adversarial verifier caught the first keep-out fixture being a **seed-0
  accident**: its net partners sat outside the keep-out, so hpwl was flat and
  prune reverted on only **9 of 20** seeds. Rebuilt with the partners strictly
  inside the rect, the cost is a theorem — `arm_M` re-derives it, 20/20.
- The battery caught **three arms passing without reaching the branch they
  named**, and one row *in itself* that could not fail (`not any(` → `False or
  not any(`, the same expression).
- The code review found the new refusal note **misnaming its own reason** on an
  evicted auto pass — printing both conjuncts as satisfied in the sentence giving
  them as the cause, which is #698's own defect one branch over; the probe being
  blind to evicted parts; `_empty`'s basis carrying 6 of 15 keys under a comment
  promising parity; `--reseat-min-gain X` refusing a gain of exactly X; and the
  continuous bases firing on rounding noise.
- The fact-checker found **two "measured" numbers that were not**: `+0.812 mm`
  stale from the replaced fixture and shipped in an engine docstring, and
  `+11.372 mm on 20 of 20 seeds` fusing two facts (twenty seeds give twenty
  different deltas). It also found the min-gain *argument* false, and that the
  A/B table had only ever run at the prep commit while a commit message cited it
  as verification of itself. Both are re-run and re-stated here.
- Re-running the battery over those fixes caught **two of the new arms being
  vacuous too** — written to pin the review's findings, and not reaching them.
- The third pass caught a **regression the second had introduced**:
  `elif gated and min_gain` is a truthiness guard, so `--reseat-min-gain 1e-12`
  accepted a gain of *exactly zero* — a stricter flag producing a looser gate,
  admitting the sideways shuffle the basis exists to refuse. Reachable: 10 of the
  16 corpus rows have a gain of exactly 0.000.

Three commit messages in this branch contain claims the later rounds corrected;
the corrections are in the commits that follow them and in this description,
which is the accurate one.

### CLI/GUI threading

None needed, stated as a decision rather than an omission: `place_seed.py` is in
`manifest_to_plan.REFUSED_TOOLS` and the plugin never reaches this path
(`grep -rn reseat kicad_routing_plugin/` is empty). `--corridor-weight` is the
precedent this PR's #702 half already established.
