### PR TITLE
#709/#459: the pocket census can say EMPTY, and a region becomes nameable

### DIFF
--- a/.claude/skills/plan-pcb-placement/SKILL.md
+++ b/.claude/skills/plan-pcb-placement/SKILL.md
@@ -217,9 +217,20 @@ The instruments this skill decides with, all report-only until you accept:
 python3 -X utf8 py_router/check_drc.py board.kicad_pcb --clearance <floor>   # on the COPPER-FREE board
 python3 -X utf8 py_tools/check_assembly.py board.kicad_pcb [--baseline before.kicad_pcb]
 python3 -X utf8 py_tools/check_channels.py board.kicad_pcb [--baseline before.kicad_pcb --gate]
+python3 -X utf8 py_tools/check_pockets.py board.kicad_pcb [--nets <the route step's set>]
 python3 -X utf8 check_rigid_consistency.py before.kicad_pcb after.kicad_pcb
 python3 -X utf8 py_tools/check_floorplan.py board.kicad_pcb --intent fp.json [--health]
 ```
+
+`check_pockets` is the only one of these that is AGGREGATE rather than
+per-part or per-net, and it answers the two questions the others structurally
+cannot: **where is the board empty**, ranked by contiguous area, and **does the
+part mass sit where the demand sits** (per quadrant, with the centroid weighted
+by courtyard area — the count-weighted form is printed as a control and
+disagrees on most boards). Pass it the net set the route step will carry. It
+also prints a ready-made `place_seed --reseat-region` command for its largest
+cold region; read the `aim:` line before running it, because a re-seat lands
+each part at its own net centroid and does not move anything INTO the region.
 
 Shared doctrine lives with the routing skill and applies here unchanged --
 read it when the step below points at it:

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -1193,6 +1193,120 @@ See [Fab Tier Options](configuration.md#fab-tier-options) for the full floor
 tables and how the CLIs enforce these floors (they **error** if a size/clearance
 param is set below the active floor).
 
+## Pocket Census (`check_pockets.py`)
+
+The **aggregate** pre-route instrument: the board binned into windows, each
+window's distinct demanding nets against its free copper area, plus the empty
+regions and the arrangement statistic that belong beside them.
+
+It exists because the per-net gates are blind to *simultaneous* routability by
+construction. On run 23's board `check_channels` reported 0 starved faces,
+`check_reachability` called every failing pad PASSABLE, and crossings sat below
+the damaged baseline — and two nets then died across ~20 route laps in one
+pocket, where committed copper wrapped RN7 at 0.095 mm against a 0.45 mm
+corridor need. No instrument had printed that window's demand against its free
+area, because no instrument computed one.
+
+**REPORT-ONLY.** Exit code is 0 on any board it can read (2 on a parse or usage
+error). Nothing gates on these numbers, and there is deliberately no threshold
+by default: a young metric mis-thresholded is noise.
+
+```bash
+python3 -X utf8 py_tools/check_pockets.py <board> [OPTIONS]
+```
+
+### Options
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--nets GLOB...` | `*` | the DEMAND set (`route.py` glob syntax, `!` excludes). Pass the set the route step will carry, so the census asks the same question. |
+| `--bin MM` | `2.0` | window size. **Floored at 0.25 mm**; a smaller value is reported as the floor it was raised to, never silently accepted. |
+| `--top N` | `8` | how many hot windows and cold regions to print. |
+| `--threshold NETS_PER_MM2` | none | print only windows above this demand/free-area ratio. |
+| `--no-cold` | off | suppress the cold-region census. |
+| `--cold-cover FRAC` | `0.0` | largest share of a window a part courtyard may cover and still count COLD. The default is the strict end: a false COLD becomes a bad reseat target. |
+| `--outline-samples K` | `4` | K×K sub-samples used to measure how much of an outline-CUT window is on the board. Ignored where the outline is the bounding box. |
+| `--no-arrangement` | off | suppress the arrangement census. |
+| `--json PATH` | none | write the full census document. |
+
+### What it reports
+
+Four buckets that **partition** the in-outline windows, and the distinctions
+between them are the point:
+
+- **demand** — at least one selected net has a terminal here.
+- **under a part** — covered by a courtyard. A window under a part is not a
+  pocket, and this is normally the largest bucket.
+- **part-free but carrying copper** — on a routed board, or under a narrow
+  `--nets` set, a window with no *selected* demand can still be full of another
+  net's copper. Part-free is not empty.
+- **cold** — in-outline, no demand, no copper, no courtyard.
+
+Cold windows are grouped into 4-connected regions and ranked by **contiguous
+area**, not by window count, so a band outranks scattered singles. Each region
+reports its bbox, its largest all-cold rectangle (`band`), its `fill`, whether
+it touches the outline, and the parts that bound it.
+
+The arrangement census then joins mass to demand: the part centroid's offset
+from the board centre, **weighted by courtyard area**, per side, with per-quadrant
+part counts, courtyard area, demand and cold windows. The quadrant numbering is
+`perturb._region_unit`'s, so `region:qN` names a block a placer can act on.
+
+**The centroid is area-weighted on purpose, and the count-weighted form is
+printed beside it as a labelled control.** The count form is the intuitive one
+and it disagrees on most boards — on `esp_prog` it reads 13.7 % of span where
+the area form reads 1.3 %.
+
+### Reading the numbers
+
+- **`outline.source`** says whether "in-outline" meant the real Edge.Cuts rings
+  or the bounding box. `extract_board_contours` deliberately returns no rings
+  for a plain axis-aligned rectangle, so most boards report `bounding_box` and
+  that is correct rather than a parse failure.
+- **`parts.from_courtyard` / `from_pads`** is the provenance of the area
+  weight. A footprint that draws no courtyard falls back to its pad bbox, which
+  is real copper; only a footprint with neither is excluded as `synthetic`.
+- **`free_area_mm2` is floored at 5 % of the bin.** At `--bin 0.25` that floor
+  saturates on most windows (a segment is charged wholly to its midpoint bin),
+  so ask the empty-vs-occupied question at the 2 mm default.
+- The window lattice is the **router's own** absolute-mm lattice, shared with
+  the congestion-v2 A\* cost, so a window this names is a window the router
+  bins the same way. Windows the outline cuts are reported with their
+  in-outline area fraction rather than being aligned away.
+
+### The reseat target
+
+The census ends by naming the largest cold region as a landing site and
+printing the command that would lift a scope by that rectangle:
+
+```
+reseat target: largest landing site is the 4 x 2mm band at [142,94]-[146,96]
+  lift:  python3 -X utf8 py_placer/place_seed.py <in> <out> --intent <fp.json> \
+           --reseat-region 142 94 146 96 --dry-run
+  aim:   a re-seat lands each part at its own net centroid, NOT here. ...
+```
+
+**That is scope naming, not aiming.** `place_seed --reseat-region` lifts the
+parts *in* the rectangle; it does not move anything *into* it, because a
+re-seat seats each part at its own net centroid. Declaring the rectangle as an
+intent block `zone` is what makes it a destination — which is why the census
+prints the zone JSON to paste rather than injecting one.
+
+Both sides resolve a rectangle through the same `placement.utility.refs_in_rect`
+(half-open on the far edges), so the rectangle the census prints and the
+rectangle the mover lifts cannot mean two different sets of parts.
+
+### Example
+
+```bash
+# The handoff question, at the net set the route step will carry
+python3 -X utf8 py_tools/check_pockets.py placed.kicad_pcb \
+    --nets "Net-*" "/SDRAM_*" --json pockets.json
+
+# Every window, including the empty ones, at a finer bin
+python3 -X utf8 py_tools/check_pockets.py placed.kicad_pcb --bin 1.0 --top 16
+```
+
 ## Common Workflows
 
 ### Route and Verify

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -1244,8 +1244,9 @@ between them are the point:
 
 Cold windows are grouped into 4-connected regions and ranked by **contiguous
 area**, not by window count, so a band outranks scattered singles. Each region
-reports its bbox, its largest all-cold rectangle (`band`), its `fill`, whether
-it touches the outline, and the parts that bound it.
+reports its `bbox`, its largest all-cold rectangle (`band_rect`, with
+`band_mm` and `band_area_mm2`), its `fill`, whether it touches the outline, and
+the parts that bound it.
 
 The arrangement census then joins mass to demand: the part centroid's offset
 from the board centre, **weighted by courtyard area**, per side, with per-quadrant
@@ -1268,7 +1269,10 @@ the area form reads 1.3 %.
   is real copper; only a footprint with neither is excluded as `synthetic`.
 - **`free_area_mm2` is floored at 5 % of the bin.** At `--bin 0.25` that floor
   saturates on most windows (a segment is charged wholly to its midpoint bin),
-  so ask the empty-vs-occupied question at the 2 mm default.
+  so ask the demand/free-area *ratio* question at the 2 mm default. The COLD
+  test does not rest on it: midpoint accounting misses a track that crosses a
+  window without its midpoint inside, so cold additionally requires that no
+  swept copper -- segment width, via barrel or pad -- touches the window.
 - The window lattice is the **router's own** absolute-mm lattice, shared with
   the congestion-v2 A\* cost, so a window this names is a window the router
   bins the same way. Windows the outline cuts are reported with their
@@ -1276,24 +1280,34 @@ the area form reads 1.3 %.
 
 ### The reseat target
 
-The census ends by naming the largest cold region as a landing site and
-printing the command that would lift a scope by that rectangle:
+The census ends by naming the largest cold region as a landing site:
 
 ```
-reseat target: largest landing site is the 4 x 2mm band at [142,94]-[146,96]
-  lift:  python3 -X utf8 py_placer/place_seed.py <in> <out> --intent <fp.json> \
-           --reseat-region 142 94 146 96 --dry-run
-  aim:   nothing in the seeder aims at this rectangle -- a lifted part goes to
-         its zone, its edge band, or its net centroid, NOT here. ...
+reseat target: largest landing site is the 31.75 x 1mm band at [114,91]-[145.75,92]; the mass wants to move NE
+  This is a DESTINATION, not a scope. A cold band holds no part by construction,
+  so `--reseat-region` over it resolves to an empty scope on every board.
+  use:   declare it as an intent block zone -- the one thing in the stack that
+         AIMS a re-seat at a rectangle: {"name": "cold_114_91", "refs": [...],
+         "zone": [114, 91, 145.75, 92]}
+  scope: the parts bounding this pocket are C1, CON2, U1, U2, USB1 -- name them,
+         or a CROWDED rectangle, to --reseat-region
 ```
 
-**That is scope naming, not aiming.** `place_seed --reseat-region` lifts the
-parts *in* the rectangle; it does not move anything *into* it. A lifted part is
+**A cold band is a DESTINATION, and it cannot be a scope.** A cold window can
+never contain a pad centre: a pad's area is charged to its bin, so a window
+holding one is classified as carrying copper, never as cold. Measured over
+428 060 cold windows on 29 boards, exactly zero contained a pad centre — so
+`--reseat-region <a cold band>` resolves to an empty scope on every board, every
+time. The census names the parts *bounding* the pocket instead, and the `zone`
+it prints is clipped to the outline, because the band is lattice-aligned and its
+outer edge otherwise overhangs the board.
+
+The rectangle's real use is as an intent block `zone`, the one thing in the
+stack that aims a re-seat at a rectangle. `place_seed --reseat-region` lifts the
+parts *in* a rectangle and does not move anything *into* it: a lifted part is
 seated at its declared zone, its edge band, its owner's pin cluster if it is a
-decoupling cap, else its net centroid (else the board centre when it has no
-placed partner) — never at the rectangle you named. Declaring the rectangle as
-an intent block `zone` is what makes it a destination, which is why the census
-prints the zone JSON to paste rather than injecting one.
+decoupling cap, else its net centroid — else the board centre, when it has no
+placed partner — never at the rectangle you named.
 
 Both sides resolve a rectangle through the same `placement.utility.refs_in_rect`
 (half-open on the far edges), so the rectangle the census prints and the

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -1283,13 +1283,16 @@ printing the command that would lift a scope by that rectangle:
 reseat target: largest landing site is the 4 x 2mm band at [142,94]-[146,96]
   lift:  python3 -X utf8 py_placer/place_seed.py <in> <out> --intent <fp.json> \
            --reseat-region 142 94 146 96 --dry-run
-  aim:   a re-seat lands each part at its own net centroid, NOT here. ...
+  aim:   nothing in the seeder aims at this rectangle -- a lifted part goes to
+         its zone, its edge band, or its net centroid, NOT here. ...
 ```
 
 **That is scope naming, not aiming.** `place_seed --reseat-region` lifts the
-parts *in* the rectangle; it does not move anything *into* it, because a
-re-seat seats each part at its own net centroid. Declaring the rectangle as an
-intent block `zone` is what makes it a destination — which is why the census
+parts *in* the rectangle; it does not move anything *into* it. A lifted part is
+seated at its declared zone, its edge band, its owner's pin cluster if it is a
+decoupling cap, else its net centroid (else the board centre when it has no
+placed partner) — never at the rectangle you named. Declaring the rectangle as
+an intent block `zone` is what makes it a destination, which is why the census
 prints the zone JSON to paste rather than injecting one.
 
 Both sides resolve a rectangle through the same `placement.utility.refs_in_rect`

--- a/krt_capabilities.py
+++ b/krt_capabilities.py
@@ -58,6 +58,7 @@ KNOWN_MODULES = (
     'bga_fanout.py', 'qfn_fanout.py',
     'check_drc.py', 'check_connected.py', 'check_floorplan.py',
     'check_impedance.py', 'check_orphan_stubs.py', 'check_pads.py',
+    'check_pockets.py', 'place_seed.py',
     'kicad_unconnected.py', 'net_forensics.py', 'copy_board.py',
     'make_movie.py', 'render_placement.py', 'list_nets.py', 'route_summary.py',
 )

--- a/py_placer/place_seed.py
+++ b/py_placer/place_seed.py
@@ -151,10 +151,14 @@ Examples:
                         "on-board part -- landed as #698. "
                         "`check_pockets` prints a ready-made rectangle for "
                         "its top cold region. IT IS SCOPE NAMING, NOT AIMING: "
-                        "a re-seat lands each part at its own NET CENTROID, "
-                        "so passing an empty region does not move anything "
-                        "INTO it. Declaring the rectangle as an intent block "
-                        "`zone` is what makes it a destination. Resolves "
+                        "nothing in the seeder aims at the rectangle you pass "
+                        "-- a lifted part goes to its declared zone, its edge "
+                        "band, its owner's pin cluster if it is a decap, else "
+                        "its net centroid (else the board centre when it has "
+                        "no placed partner) -- so passing an EMPTY region "
+                        "moves nothing INTO it. Declaring the rectangle as an "
+                        "intent block `zone` is what makes it a destination. "
+                        "Resolves "
                         "through placement.utility.refs_in_rect, the same "
                         "call check_pockets names its windows with, so the "
                         "rectangle cannot mean two different sets of parts")
@@ -319,6 +323,14 @@ Examples:
                 # this lifts cannot mean two different sets of parts.
                 from placement.utility import refs_in_rect
                 _hits = []
+                #: A typed --reseat opts into glob semantics; a GEOMETRIC
+                #: selection did not. `reseat_scope` runs every ref through
+                #: fnmatch, so a literal reference carrying glob
+                #: metacharacters -- `D[1]` -- would resolve to `D1` and then
+                #: report "matches no reference on this board". Escape them.
+                def _literal(ref):
+                    return ''.join('[%s]' % c if c in '*?[]' else c
+                                   for c in ref)
                 for _r in args.reseat_region:
                     _in = refs_in_rect(cur_pcb, tuple(_r))
                     print("  region [%g,%g]-[%g,%g]: %d part(s)%s"
@@ -329,21 +341,34 @@ Examples:
                     _hits.extend(_in)
                 _region_refs = sorted(set(_hits))
                 if not _region_refs:
-                    # A result, not a failure -- and it must not fall through
-                    # to `refs=None`, which is the AUTO scope under a
-                    # different acceptance rule entirely.
-                    print("Reseat (explicit): the region(s) contain no part; "
-                          "nothing to lift. This is a RESULT, not a failure -- "
-                          "an empty region is exactly what check_pockets ranks."
-                          )
-                    return 0
-                _refs.extend(_region_refs)
+                    # A result, not a failure. It goes THROUGH reseat_scope on
+                    # the explicit branch rather than returning here: an early
+                    # return skipped the output board, the JSON summary and the
+                    # whole --repair pass, so `--repair --reseat-region <empty>`
+                    # exited 0 having produced nothing. `--reseat ZZ99` is the
+                    # same event -- an explicit scope that resolved to zero
+                    # refs -- and seeder's own `_empty()` already handles it,
+                    # returning the full schema so a reader can tell "the
+                    # census found nothing" from "no census ran".
+                    print("  region(s) contain no part; the scope is empty. "
+                          "This is a RESULT, not a failure -- an empty region "
+                          "is exactly what check_pockets ranks.")
+                _refs.extend(_literal(r) for r in _region_refs)
                 _selector = 'region:' + ';'.join(
-                    '%g,%g,%g,%g' % tuple(_r) for _r in args.reseat_region)
+                    # Full precision, not %g: this string is the audit trail
+                    # for which rectangle was resolved, and 6 significant
+                    # digits turns 142.8125 into 142.812, which need not
+                    # re-resolve the same parts.
+                    '%r,%r,%r,%r' % tuple(_r) for _r in args.reseat_region)
                 _refs = sorted(set(_refs))
             reseat = seeder.reseat_scope(
                 cur_pcb, cur, intent,
-                refs=(_refs or None), group_sources=sources,
+                # `[]` is NOT `None`: an explicit scope that resolved to
+                # nothing must stay explicit, because `reseat_accept` switches
+                # policy on `scope_source != 'explicit'` and `None` is the AUTO
+                # damage-witness scope under a different acceptance rule.
+                refs=(_refs if (args.reseat_region or _refs) else None),
+                group_sources=sources,
                 clearance=args.clearance,
                 board_edge_clearance=args.board_edge_clearance,
                 grid_step=args.grid_step, seed=args.seed,
@@ -370,9 +395,17 @@ Examples:
                 # A SEPARATE key. Overloading scope_source is what would have
                 # broken the acceptance policy switch, so the provenance of
                 # the scope is reported beside it rather than inside it.
+                #
+                # The split is over the RESOLVED scope, not over the argument
+                # lists: `len(args.reseat)` counts PATTERNS (`--reseat 'U*'`
+                # is one), and a named ref that also lies in the region would
+                # be counted twice, so the two numbers did not add up to the
+                # scope they described.
+                _named = set(reseat['scope']) - set(_region_refs)
+                _both = set(reseat['scope']) & set(_region_refs)
                 print(f"  scope_selector: {_selector} "
-                      f"({len(_region_refs)} from the region, "
-                      f"{len(args.reseat or ())} named)")
+                      f"({len(_both)} of {len(reseat['scope'])} in scope came "
+                      f"from the region, {len(_named)} from --reseat)")
             print(f"Reseat ({reseat['scope_source']}): "
                   f"{len(reseat['scope'])} in scope, "
                   f"{len(reseat['reseated'])} re-seated "

--- a/py_placer/place_seed.py
+++ b/py_placer/place_seed.py
@@ -140,6 +140,24 @@ Examples:
                         "pose being discarded). Composes with --repair and "
                         "runs BEFORE it. Judge it on witnesses_after, not on "
                         "how far anything moved")
+    p.add_argument("--reseat-region", nargs=4, type=float, action="append",
+                   default=None, metavar=("X0", "Y0", "X1", "Y1"),
+                   help="Name the reseat scope by GEOMETRY instead of by ref: "
+                        "every part with a pad in the rectangle X0 Y0 X1 Y1 "
+                        "(board mm, half-open on X1/Y1) joins the scope. "
+                        "Repeatable; unions with any --reseat REF. This is "
+                        "#459's 'a way to name a REGION rather than a ref "
+                        "list', whose other half -- a gate that can accept an "
+                        "on-board part -- landed as #698. "
+                        "`check_pockets` prints a ready-made rectangle for "
+                        "its top cold region. IT IS SCOPE NAMING, NOT AIMING: "
+                        "a re-seat lands each part at its own NET CENTROID, "
+                        "so passing an empty region does not move anything "
+                        "INTO it. Declaring the rectangle as an intent block "
+                        "`zone` is what makes it a destination. Resolves "
+                        "through placement.utility.refs_in_rect, the same "
+                        "call check_pockets names its windows with, so the "
+                        "rectangle cannot mean two different sets of parts")
     p.add_argument("--reseat-min-gain", type=float, default=0.0, metavar="MM",
                    help="With --reseat REF (an EXPLICIT scope): the smallest "
                         "wirelength win, in mm, that counts as a re-seat. 0 "
@@ -170,6 +188,30 @@ Examples:
     print(f"legality at clearance {args.clearance} "
           f"({_knobs['clearance']['source']}), edge {args.board_edge_clearance} "
           f"({_knobs['board_edge_clearance']['source']})")
+    # #459: a region is an EXPLICIT scope that stands on its own, so it turns
+    # --reseat on without the flag being typed. Normalised before every check
+    # below, so `--reseat-region ... --dry-run` is not rejected by a rule that
+    # only knows about --reseat.
+    if args.reseat_region:
+        for _r in args.reseat_region:
+            if _r[2] <= _r[0] or _r[3] <= _r[1]:
+                p.error("--reseat-region takes X0 Y0 X1 Y1 with X1>X0 and "
+                        "Y1>Y0 (board mm); got %g %g %g %g" % tuple(_r))
+        if args.reseat == []:
+            # #698 gave the two scopes DIFFERENT acceptance policies: an
+            # explicit scope is graded on its own terms, the AUTO damage-
+            # witness scope on 'the off-board amount strictly improved'.
+            # Silently picking one of the two is how that distinction gets
+            # lost, so a bare --reseat beside a region is a usage error rather
+            # than a quiet merge.
+            p.error("--reseat-region is an EXPLICIT scope and a bare --reseat "
+                    "is the AUTO damage-witness scope; #698 grades them by "
+                    "different rules, so they do not combine. Use "
+                    "--reseat-region on its own (it implies an explicit "
+                    "--reseat), or name refs: --reseat REF ... "
+                    "--reseat-region X0 Y0 X1 Y1")
+        if args.reseat is None:
+            args.reseat = []          # explicit; the refs come from the rects
     if (args.repair or args.reseat is not None) and args.force:
         p.error("--repair/--reseat and --force are mutually exclusive (they "
                 "move only the parts that need it; force re-derives "
@@ -181,7 +223,7 @@ Examples:
     if args.reseat_min_gain < 0:
         p.error("--reseat-min-gain is a magnitude in mm; negative is not a "
                 "looser threshold, it is a typo")
-    if args.reseat_min_gain and args.reseat == []:
+    if args.reseat_min_gain and args.reseat == [] and not args.reseat_region:
         # An inert knob says so, rather than reading as a threshold that
         # happened to find nothing wrong (cli_gates' own disclosure rule).
         print("--reseat-min-gain is inert on the AUTO scope: that rule is "
@@ -259,9 +301,49 @@ Examples:
         if args.reseat is not None:
             # `nargs='*'`: bare --reseat is [] and means AUTO scope; None is
             # the flag being absent.
+            _refs = list(args.reseat or ())
+            _selector = None
+            if args.reseat_region:
+                # #459's "a way to name a REGION rather than a ref list".
+                # Resolved HERE, at the CLI layer, into the ordinary `refs`
+                # argument -- never by inventing a new scope_source. The
+                # acceptance policy in seeder.reseat_accept switches on
+                # `scope_source != 'explicit'` by string equality, so a
+                # 'region:...' source would drop every region re-seat into the
+                # auto:oob-strict policy, which a legal on-board part can
+                # never satisfy: the pass would refuse everything and look
+                # broken rather than wrong.
+                #
+                # refs_in_rect is the same call check_pockets names its own
+                # windows with, so the rectangle it prints and the rectangle
+                # this lifts cannot mean two different sets of parts.
+                from placement.utility import refs_in_rect
+                _hits = []
+                for _r in args.reseat_region:
+                    _in = refs_in_rect(cur_pcb, tuple(_r))
+                    print("  region [%g,%g]-[%g,%g]: %d part(s)%s"
+                          % (_r[0], _r[1], _r[2], _r[3], len(_in),
+                             ('  ' + ', '.join(_in[:12])
+                              + (' ...' if len(_in) > 12 else ''))
+                             if _in else ''))
+                    _hits.extend(_in)
+                _region_refs = sorted(set(_hits))
+                if not _region_refs:
+                    # A result, not a failure -- and it must not fall through
+                    # to `refs=None`, which is the AUTO scope under a
+                    # different acceptance rule entirely.
+                    print("Reseat (explicit): the region(s) contain no part; "
+                          "nothing to lift. This is a RESULT, not a failure -- "
+                          "an empty region is exactly what check_pockets ranks."
+                          )
+                    return 0
+                _refs.extend(_region_refs)
+                _selector = 'region:' + ';'.join(
+                    '%g,%g,%g,%g' % tuple(_r) for _r in args.reseat_region)
+                _refs = sorted(set(_refs))
             reseat = seeder.reseat_scope(
                 cur_pcb, cur, intent,
-                refs=(args.reseat or None), group_sources=sources,
+                refs=(_refs or None), group_sources=sources,
                 clearance=args.clearance,
                 board_edge_clearance=args.board_edge_clearance,
                 grid_step=args.grid_step, seed=args.seed,
@@ -284,6 +366,13 @@ Examples:
                 if fp is not None:
                     _rmax = max(_rmax, _math.hypot(mv['new_x'] - fp.x,
                                                   mv['new_y'] - fp.y))
+            if _selector:
+                # A SEPARATE key. Overloading scope_source is what would have
+                # broken the acceptance policy switch, so the provenance of
+                # the scope is reported beside it rather than inside it.
+                print(f"  scope_selector: {_selector} "
+                      f"({len(_region_refs)} from the region, "
+                      f"{len(args.reseat or ())} named)")
             print(f"Reseat ({reseat['scope_source']}): "
                   f"{len(reseat['scope'])} in scope, "
                   f"{len(reseat['reseated'])} re-seated "
@@ -320,6 +409,9 @@ Examples:
                 'reseat': True,
                 'scope': reseat['scope'],
                 'scope_source': reseat['scope_source'],
+                # #459: how the scope was NAMED, beside (never inside) what
+                # policy graded it. None when refs were typed directly.
+                'scope_selector': _selector,
                 'reseated': len(reseat['reseated']),
                 'reseated_refs': reseat['reseated'],
                 'unseated': reseat['unseated'],

--- a/py_placer/placement/options.py
+++ b/py_placer/placement/options.py
@@ -76,7 +76,7 @@ def deficit_totals(ledgers) -> Dict[str, int]:
 HOSTS_FRACTION = 0.30
 
 
-def _hosts_the_design(ref, gx0, gy0, gx1, gy1, fp, footprints) -> bool:
+def hosts_the_design(ref, gx0, gy0, gx1, gy1, fp, footprints) -> bool:
     """Is this big footprint a frame around the design, or just a big part?
 
     Area alone is not enough, and getting that wrong is worse than not
@@ -120,6 +120,13 @@ def _hosts_the_design(ref, gx0, gy0, gx1, gy1, fp, footprints) -> bool:
     # separates the two, and it is exactly what a pile does not have.
     spots = {(round(o.x, 3), round(o.y, 3)) for o in hosted}
     return len(spots) >= max(4, 0.5 * len(hosted))
+
+
+#: Public since #709: the pocket census excludes the same frames from its
+#: area-weighted centroid, and `board_brief` records the repo's rule that an
+#: artifact must not sit behind a private cross-module name. The old spelling
+#: stays so nothing in-tree has to change in the same commit.
+_hosts_the_design = hosts_the_design
 
 
 def grow_board(pcb_data, pcb_file: str, *, clearance: float,

--- a/py_placer/placement/utility.py
+++ b/py_placer/placement/utility.py
@@ -55,3 +55,39 @@ def compute_footprint_bbox_local(footprint: Footprint) -> Tuple[float, float, fl
 def snap_to_grid(value: float, grid_step: float) -> float:
     """Snap a value to the nearest grid point."""
     return round(value / grid_step) * grid_step
+
+
+def refs_in_rect(pcb_data, rect, *, by='pad') -> list:
+    """Every reference whose geometry lies in `rect`, HALF-OPEN on the far edge.
+
+    THE one implementation, because two of them is a real defect rather than a
+    tidiness point: `check_pockets` prints a rectangle and
+    `place_seed --reseat-region` lifts the parts in it, and if the two resolve
+    the same rectangle differently the census names parts the mover does not
+    touch. Half-open (`x0 <= x < x1`) so a part on a shared boundary belongs to
+    exactly one window of a tiling.
+
+    by='pad'    -- any pad centre inside the rect. What the census has always
+                   used, and the right question for "which parts cage this
+                   window", since a large part reaches into a window its origin
+                   is nowhere near.
+    by='origin' -- the footprint origin only. This is `perturb._region_unit`'s
+                   own membership rule, so it is what names the block that
+                   `--block region:qN` would move.
+    """
+    x0, y0, x1, y1 = rect
+    out = set()
+    if by == 'origin':
+        for ref, fp in pcb_data.footprints.items():
+            if ref and x0 <= fp.x < x1 and y0 <= fp.y < y1:
+                out.add(ref)
+        return sorted(out)
+    if by != 'pad':
+        raise ValueError("refs_in_rect: by must be 'pad' or 'origin'")
+    for fp in pcb_data.footprints.values():
+        for pad in fp.pads:
+            if (x0 <= pad.global_x < x1 and y0 <= pad.global_y < y1
+                    and pad.component_ref):
+                out.add(pad.component_ref)
+                break
+    return sorted(out)

--- a/py_router/congestion_field.py
+++ b/py_router/congestion_field.py
@@ -193,7 +193,9 @@ def congestion_bins(pcb_data, net_ids, num_layers, bin_mm,
     WHEN NOTHING DEMANDS THEM. The result was keyed off `owners`, which only
     gains a key where some net has a terminal -- so a window with nothing in
     it never entered the dict and `check_pockets` could not represent an
-    empty region at all (esp_prog: 44 of 128 windows over the bbox at 2mm).
+    empty region at all. Measured on esp_prog at 2mm: the lattice over
+    `board_bounds` is 128 windows and the census returned 44, so 84 of them
+    -- 66% -- were not merely un-ranked but absent.
     Such a bin comes back with `owners` empty and its free area computed the
     same way as everyone else's, which is what separates "empty" from "full
     of another net's copper".

--- a/py_router/congestion_field.py
+++ b/py_router/congestion_field.py
@@ -193,18 +193,32 @@ def congestion_bins(pcb_data, net_ids, num_layers, bin_mm,
     WHEN NOTHING DEMANDS THEM. The result was keyed off `owners`, which only
     gains a key where some net has a terminal -- so a window with nothing in
     it never entered the dict and `check_pockets` could not represent an
-    empty region at all (esp_prog: 44 of 128 in-outline windows at 2mm).
-    Such a bin comes back with `owners` empty and its REAL free area, which
-    is what separates "empty" from "full of another net's copper".
+    empty region at all (esp_prog: 44 of 128 windows over the bbox at 2mm).
+    Such a bin comes back with `owners` empty and its free area computed the
+    same way as everyone else's, which is what separates "empty" from "full
+    of another net's copper".
+
+    That free area is FLOORED AT 5% of the bin, here as everywhere, and the
+    floor is not decoration at small bins: a segment is charged wholly to its
+    midpoint bin, so `used` overshoots as the bin shrinks. Measured share of
+    no-demand windows returning the floor rather than a real remainder --
+    esp_prog 0% at 2mm, 16.9% at 1mm, 100% at 0.25mm; glasgow_revC 1.1% /
+    1.3% / 78.0%. At the 0.25mm census floor the empty-vs-occupied
+    distinction is therefore saturated away on most windows; ask it at the
+    2mm default, which is what `check_pockets` uses.
 
     THE A* CONSUMER NEVER PASSES THIS. `build_congestion2` omits it, so the
-    key sequence is `owners`' own iteration order, byte for byte as before --
-    and the order is load-bearing, not incidental: `congestion2_rows`
-    iterates `bins.items()` and appends into the list that becomes the
-    np.array handed to `merge_track_proximity_costs`. Hence the extra keys
-    are APPENDED to `list(owners)` rather than unioned through a set.
-    (Defensively, a demand-0 bin scores ratio 0 <= thresh and is skipped
-    there anyway.)
+    key sequence is `owners`' own iteration order, byte for byte as before,
+    and the extra keys are APPENDED to `list(owners)` rather than unioned
+    through a set. To be accurate about why: the np.array `congestion2_rows`
+    builds from `bins.items()` reaches consumers that are order-INSENSITIVE
+    (the Rust `set_layer_proximity_batch` max-inserts per cell; the SUM
+    branch goes through np.unique/bincount), so a permutation would not
+    change what the router prices cells with. What insertion order does
+    decide is the tie-break in `check_pockets`' stable `sort(key=-ratio)`.
+    Preserving it is cheap and keeps the function's contract exact either
+    way. (Defensively, a demand-0 bin scores ratio 0 <= thresh and is skipped
+    in `congestion2_rows` anyway, at any non-negative threshold.)
     """
     bin_mm = max(0.25, bin_mm)
     num_layers = max(1, num_layers)
@@ -243,8 +257,24 @@ def congestion_bins(pcb_data, net_ids, num_layers, bin_mm,
             copper[b] = copper.get(b, 0.0) + p.size_x * p.size_y
     bin_area_total = bin_mm * bin_mm * num_layers
     bins = {}
-    keys = owners.keys() if not include_bins else (
-        list(owners) + [b for b in include_bins if b not in owners])
+    if include_bins is None:
+        extra = []
+    else:
+        # Materialise before the emptiness test: `not <numpy array>` raises,
+        # and an iterator would be consumed by it.
+        extra = list(include_bins)
+        bad = next((b for b in extra
+                    if not (isinstance(b, tuple) and len(b) == 2)), None)
+        if bad is not None:
+            # A bare (bx, by) instead of a LIST of them used to insert an int
+            # key, which then failed three frames away in a consumer's
+            # `for (bx, by), ... in bins.items()`. Fail where the mistake is.
+            raise TypeError(
+                'congestion_bins: include_bins takes an iterable of (bx, by) '
+                'bin keys; got %r. A single key must be wrapped in a list.'
+                % (bad,))
+    keys = owners.keys() if not extra else (
+        list(owners) + [b for b in extra if b not in owners])
     for b in keys:
         own = owners.get(b, frozenset())
         used = copper.get(b, 0.0)

--- a/py_router/congestion_field.py
+++ b/py_router/congestion_field.py
@@ -168,7 +168,7 @@ def congestion2_knobs():
 
 
 def congestion_bins(pcb_data, net_ids, num_layers, bin_mm,
-                    extra_demand_points=None):
+                    extra_demand_points=None, include_bins=None):
     """THE demand/capacity census: {(bx,by): (free_area_mm2, owners)} plus
     per-net terminal coords, and the BIN IT ACTUALLY USED.
 
@@ -188,6 +188,23 @@ def congestion_bins(pcb_data, net_ids, num_layers, bin_mm,
     each net's terminal set -- the net then claims demand along its whole
     predicted path instead of only at its endpoints, and its own exemption
     disks follow the corridor (owner-exempt by construction).
+
+    include_bins (#709): optional iterable of (bx, by) keys to report EVEN
+    WHEN NOTHING DEMANDS THEM. The result was keyed off `owners`, which only
+    gains a key where some net has a terminal -- so a window with nothing in
+    it never entered the dict and `check_pockets` could not represent an
+    empty region at all (esp_prog: 44 of 128 in-outline windows at 2mm).
+    Such a bin comes back with `owners` empty and its REAL free area, which
+    is what separates "empty" from "full of another net's copper".
+
+    THE A* CONSUMER NEVER PASSES THIS. `build_congestion2` omits it, so the
+    key sequence is `owners`' own iteration order, byte for byte as before --
+    and the order is load-bearing, not incidental: `congestion2_rows`
+    iterates `bins.items()` and appends into the list that becomes the
+    np.array handed to `merge_track_proximity_costs`. Hence the extra keys
+    are APPENDED to `list(owners)` rather than unioned through a set.
+    (Defensively, a demand-0 bin scores ratio 0 <= thresh and is skipped
+    there anyway.)
     """
     bin_mm = max(0.25, bin_mm)
     num_layers = max(1, num_layers)
@@ -226,7 +243,10 @@ def congestion_bins(pcb_data, net_ids, num_layers, bin_mm,
             copper[b] = copper.get(b, 0.0) + p.size_x * p.size_y
     bin_area_total = bin_mm * bin_mm * num_layers
     bins = {}
-    for b, own in owners.items():
+    keys = owners.keys() if not include_bins else (
+        list(owners) + [b for b in include_bins if b not in owners])
+    for b in keys:
+        own = owners.get(b, frozenset())
         used = copper.get(b, 0.0)
         free = max(bin_area_total * 0.05, bin_area_total - used)
         bins[b] = (free, frozenset(own))

--- a/py_tools/check_pockets.py
+++ b/py_tools/check_pockets.py
@@ -279,10 +279,17 @@ def arrangement_census(pcb, parts, containers, bins, bin_mm, bounds, leg):
     quads = [{'name': QUADRANTS[q], 'index': q, 'parts': 0,
               'part_area_mm2': 0.0, 'demand_nets': 0, 'distinct_nets': 0,
               'cold_windows': 0} for q in range(4)]
-    #: `_region_unit` filters on the footprint ORIGIN, so the count this
-    #: prints names exactly the block `--block region:qN` would move.
+    #: `_region_unit` filters on the footprint ORIGIN, so this count uses the
+    #: origin too and the quadrant it names is the one `--block region:qN`
+    #: would act on. It counts the parts the placer would SEE: a graphic-only
+    #: footprint (no courtyard, no pads -- the +/-0.5mm fiction) is not a part
+    #: and is not in the quench's own part set either, so counting it here
+    #: made the number 20 where `region:q*` totalled 17 on esp_prog. What the
+    #: census cannot know is which of them a given run LOCKS, so this is an
+    #: upper bound on the movable set, never a promise about it.
+    seat = {gp.ref for gp in parts if gp.ref not in containers}
     for ref, fp in pcb.footprints.items():
-        if ref in containers:
+        if ref not in seat:
             continue
         quads[quadrant_of(fp.x, fp.y, bounds)]['parts'] += 1
     qrects = []

--- a/py_tools/check_pockets.py
+++ b/py_tools/check_pockets.py
@@ -463,11 +463,32 @@ def pocket_census(pcb, board_path, *, nets=('*',), bin_mm=2.0, top=8,
     real = [g for g in graded if not g.synthetic]
     board_area = (bounds[2] - bounds[0]) * (bounds[3] - bounds[1])
     containers = _containers(real, pcb.footprints, board_area, leg, opts)
+    #: `placement_state` records an objection to courtyard-area metrics --
+    #: they "break on the boards with no courtyards at all". They do not: a
+    #: footprint that draws none falls back to its PAD bbox, which is real
+    #: copper, and only a footprint with neither is the +/-0.5mm fiction. But
+    #: a reader still needs to know which of the two they are looking at, so
+    #: the provenance is counted rather than assumed.
+    from_courtyard = 0
+    try:
+        from placement.parser import (courtyard_for_side,
+                                      extract_courtyard_sides)
+        _sides = extract_courtyard_sides(board_path)
+        for gp in real:
+            box = _sides.get(gp.ref)
+            if box and courtyard_for_side(box, gp.side) is not None:
+                from_courtyard += 1
+    except Exception:                                           # noqa: BLE001
+        from_courtyard = None
     doc['parts'] = {
         'graded': len(graded),
+        'weighed': len([g for g in real if g.ref not in containers]),
         'synthetic_excluded': len(graded) - len(real),
         'container_excluded': len(containers),
         'containers': sorted(containers),
+        'from_courtyard': from_courtyard,
+        'from_pads': (None if from_courtyard is None
+                      else len(real) - from_courtyard),
         'container_guard': 'options.hosts_the_design' if opts is not None
                            else 'unavailable',
     }
@@ -493,11 +514,18 @@ def pocket_census(pcb, board_path, *, nets=('*',), bin_mm=2.0, top=8,
                     slot[s] = slot.get(s, 0.0) + a
 
     # --- cold classification ------------------------------------------------
+    # Four buckets that PARTITION the in-outline windows, because the two
+    # distinctions this tool exists to draw are exactly the ones that vanish
+    # if a window is silently dropped: a window under a part is not a pocket,
+    # and a part-free window full of another net's copper is not empty.
     cold_keys = []
     warm_unowned = 0
+    under_parts = 0
+    demand_in = 0
     for b, f in frac.items():
         free, owners = bins.get(b, (bin_area_total, frozenset()))
         if owners:
+            demand_in += 1
             continue
         # Part-free is not empty: on a routed board a window with no part
         # still carries copper, and `free` is the only thing that knows.
@@ -508,10 +536,16 @@ def pocket_census(pcb, board_path, *, nets=('*',), bin_mm=2.0, top=8,
         c = cover.get(b, {})
         # max over sides, not sum: "a clear empty pocket" means empty on BOTH.
         if max(c.get('F', 0.0), c.get('B', 0.0)) > cold_cover * area_here + 1e-9:
+            under_parts += 1
             continue
         cold_keys.append(b)
     doc['cold_windows'] = len(cold_keys)
     doc['warm_unowned_windows'] = warm_unowned
+    doc['under_part_windows'] = under_parts
+    #: The old census reported `len(bins)` as its window count, which mixed
+    #: demand bins lying OFF the board in with the rest. This is the in-outline
+    #: half, and it is the one the partition is over.
+    doc['windows_demand_in_outline'] = demand_in
     doc['cold_cover'] = cold_cover
 
     regions = []
@@ -663,10 +697,12 @@ def format_report(doc, hot, top):
         src = (doc.get('outline') or {}).get('source', '?')
         lines.append(f"COLD regions (in-outline, no demand net, no copper, no "
                      f"part courtyard): {len(regions)} region(s), "
-                     f"{doc['cold_windows']} window(s); outline from {src}"
-                     + (f", {doc['warm_unowned_windows']} part-free window(s) "
-                        f"carry copper" if doc.get('warm_unowned_windows')
-                        else ""))
+                     f"{doc['cold_windows']} window(s); outline from {src}")
+        lines.append(f"  of {doc['windows_in_outline']} in-outline window(s): "
+                     f"{doc['windows_demand_in_outline']} carry demand, "
+                     f"{doc['under_part_windows']} sit under a part, "
+                     f"{doc['warm_unowned_windows']} are part-free but carry "
+                     f"copper, {doc['cold_windows']} are cold")
         for r in regions[:top]:
             b, br = r['bbox'], r['band_rect']
             lines.append(f"  #{r['rank']:<3} {r['area_mm2']:>8.1f} mm2  "
@@ -696,7 +732,10 @@ def format_report(doc, hot, top):
             f"(part COUNT would say {100 * (cx or 0):.1f}% / "
             f"{100 * (cy or 0):.1f}% -- a control, never the answer)")
         p = doc.get('parts') or {}
-        lines.append(f"  parts weighed: {p.get('graded', 0)} graded, "
+        lines.append(f"  parts weighed: {p.get('weighed', 0)} of "
+                     f"{p.get('graded', 0)} graded "
+                     f"({p.get('from_courtyard')} from a drawn courtyard, "
+                     f"{p.get('from_pads')} from pad copper); "
                      f"{p.get('synthetic_excluded', 0)} synthetic excluded, "
                      f"{p.get('container_excluded', 0)} container excluded "
                      f"({p.get('container_guard')})")

--- a/py_tools/check_pockets.py
+++ b/py_tools/check_pockets.py
@@ -613,10 +613,19 @@ def pocket_census(pcb, board_path, *, nets=('*',), bin_mm=2.0, top=8,
             demand_in += 1
             continue
         # Part-free is not empty: on a routed board a window with no part
-        # still carries copper. TWO tests, because neither alone is enough --
-        # `free` is the demand/capacity model's midpoint accounting, which
-        # misses a track that crosses the window without its midpoint in it,
-        # and the swept test does not know about the 5% area floor.
+        # still carries copper.
+        #
+        # The SWEPT test is the one that decides. The `free` term beside it is
+        # a deliberate REDUNDANT cross-check, and saying so is the honest
+        # framing: `congestion_bins` charges a segment to its midpoint bin and
+        # a pad to its centre bin, both of which the swept stamp covers, so
+        # swept is a strict superset. Measured over 8 boards x 3 bin sizes,
+        # ZERO bins that `free` calls occupied are not also swept-touched --
+        # which is why a mutation dropping the `free` arm survives the battery
+        # and is an equivalent mutant rather than a coverage hole. It is kept
+        # because it is one comparison and it guards the newer, more intricate
+        # of the two; `t_the_swept_test_is_a_superset_of_the_free_area_rule`
+        # pins the relation so the day it stops holding is a red row.
         if free < bin_area_total - 1e-9 or b in touched:
             warm_unowned += 1
             continue

--- a/py_tools/check_pockets.py
+++ b/py_tools/check_pockets.py
@@ -238,6 +238,37 @@ def copper_touched_bins(pcb, bin_mm):
     return hit
 
 
+def courtyard_cover(parts, containers, windows, bin_mm, leg):
+    """{window: {'F': mm2, 'B': mm2}} of courtyard area, charged PER SIDE.
+
+    A through-hole part is charged to BOTH faces, because `GradedPart.sides`
+    says its leads really are on both and a window under it is not clear on
+    either. Charging only `gp.side` is nearly an equivalent mutation -- the two
+    disagree only where a B-side part ALSO covers the window, so that the
+    far-side sum overtakes the near one -- which is exactly why it is asserted
+    here directly rather than through a cold-window count that no in-repo board
+    happens to move.
+    """
+    cover = {}
+    for gp in parts:
+        if gp.ref in containers:
+            continue
+        for bx in range(int(math.floor(gp.rect[0] / bin_mm)),
+                        int(math.ceil(gp.rect[2] / bin_mm))):
+            for by in range(int(math.floor(gp.rect[1] / bin_mm)),
+                            int(math.ceil(gp.rect[3] / bin_mm))):
+                b = (bx, by)
+                if b not in windows:
+                    continue
+                a = leg.rect_overlap_area(window_rect(b, bin_mm), gp.rect)
+                if a <= 0:
+                    continue
+                slot = cover.setdefault(b, {'F': 0.0, 'B': 0.0})
+                for s in _side_key(gp):
+                    slot[s] = slot.get(s, 0.0) + a
+    return cover
+
+
 def _side_key(gp):
     return getattr(gp, 'sides', None) or frozenset((gp.side,))
 
@@ -564,25 +595,7 @@ def pocket_census(pcb, board_path, *, nets=('*',), bin_mm=2.0, top=8,
                            else 'unavailable',
     }
 
-    cover = {}
-    for gp in real:
-        if gp.ref in containers:
-            continue
-        gx0 = int(math.floor(gp.rect[0] / bin_mm))
-        gx1 = int(math.ceil(gp.rect[2] / bin_mm))
-        gy0 = int(math.floor(gp.rect[1] / bin_mm))
-        gy1 = int(math.ceil(gp.rect[3] / bin_mm))
-        for bx in range(gx0, gx1):
-            for by in range(gy0, gy1):
-                b = (bx, by)
-                if b not in frac:
-                    continue
-                a = leg.rect_overlap_area(window_rect(b, bin_mm), gp.rect)
-                if a <= 0:
-                    continue
-                slot = cover.setdefault(b, {'F': 0.0, 'B': 0.0})
-                for s in _side_key(gp):
-                    slot[s] = slot.get(s, 0.0) + a
+    cover = courtyard_cover(real, containers, frac, bin_mm, leg)
 
     # --- cold classification ------------------------------------------------
     # Four buckets that PARTITION the in-outline windows, because the two

--- a/py_tools/check_pockets.py
+++ b/py_tools/check_pockets.py
@@ -73,12 +73,24 @@ def lattice_windows(bounds, bin_mm):
     invisible-window count this tool exists to report would be overstated by
     exactly those 40.
     """
+    def _lo(v):
+        return int(math.floor(v / bin_mm))
+
+    def _hi(v):
+        # `math.ceil(21.0 / 0.7)` is 31, not 30: the quotient is
+        # 30.000000000000004. That is the SAME defect floor/ceil replaced,
+        # moved from the `+1` form into float division -- measured, it
+        # invented 59 off-board windows on a 20x20mm rectangular board at
+        # --bin 0.7. Snap the quotient to an integer it is within an ulp of
+        # before taking the ceiling.
+        q = v / bin_mm
+        r = round(q)
+        return int(r if abs(q - r) < 1e-9 else math.ceil(q))
+
     x0, y0, x1, y1 = bounds
     return [(bx, by)
-            for bx in range(int(math.floor(x0 / bin_mm)),
-                            int(math.ceil(x1 / bin_mm)))
-            for by in range(int(math.floor(y0 / bin_mm)),
-                            int(math.ceil(y1 / bin_mm)))]
+            for bx in range(_lo(x0), _hi(x1))
+            for by in range(_lo(y0), _hi(y1))]
 
 
 def window_rect(b, bin_mm):
@@ -180,6 +192,50 @@ def largest_band(cells):
                 start = s
             stack.append((start, h))
     return best[1]
+
+
+def copper_touched_bins(pcb, bin_mm):
+    """Every bin any copper geometry ACTUALLY overlaps, not just its midpoint.
+
+    `congestion_bins` charges a segment's whole area to the bin containing its
+    MIDPOINT, which is the right model for a demand/capacity ratio and the
+    wrong one for "is this window empty": a track running straight through a
+    window, with its midpoint elsewhere, leaves `free == bin_area_total` and
+    the window reads COLD. Measured on rp2350_fpga_eensy_prePlane at --bin 1.0
+    (the bin the docs' own example uses), 27 of 159 cold windows -- 17% -- had
+    a track crossing them.
+
+    So the copper test the cold predicate uses is this one: walk each segment
+    and stamp the bins its swept width touches, and stamp each via's and pad's
+    bounding box. Half a bin is the walk step, which cannot skip a bin.
+    """
+    hit = set()
+
+    def stamp_box(x0, y0, x1, y1):
+        for bx in range(int(math.floor(x0 / bin_mm)),
+                        int(math.floor(x1 / bin_mm)) + 1):
+            for by in range(int(math.floor(y0 / bin_mm)),
+                            int(math.floor(y1 / bin_mm)) + 1):
+                hit.add((bx, by))
+
+    for s in pcb.segments:
+        r = max(s.width, 0.0) / 2.0
+        n = max(1, int(math.hypot(s.end_x - s.start_x,
+                                  s.end_y - s.start_y) / (bin_mm / 2.0)) + 1)
+        for i in range(n + 1):
+            t = i / float(n)
+            x = s.start_x + (s.end_x - s.start_x) * t
+            y = s.start_y + (s.end_y - s.start_y) * t
+            stamp_box(x - r, y - r, x + r, y + r)
+    for v in pcb.vias:
+        r = max(v.size, 0.0) / 2.0
+        stamp_box(v.x - r, v.y - r, v.x + r, v.y + r)
+    for plist in (getattr(pcb, 'pads_by_net', {}) or {}).values():
+        for p in plist:
+            hx, hy = p.size_x / 2.0, p.size_y / 2.0
+            stamp_box(p.global_x - hx, p.global_y - hy,
+                      p.global_x + hx, p.global_y + hy)
+    return hit
 
 
 def _side_key(gp):
@@ -379,7 +435,7 @@ def pocket_census(pcb, board_path, *, nets=('*',), bin_mm=2.0, top=8,
     lattice = lattice_windows(bounds, bin_mm) if bounds else []
     bins, _terminals, bin_mm = congestion_bins(
         pcb, ids, len(layers), bin_mm,
-        include_bins=lattice if (cold and lattice) else None)
+        include_bins=(lattice or None))
 
     doc = {'board': board_path,
            # The bin the census USED. `bin_requested` is what the caller
@@ -425,16 +481,15 @@ def pocket_census(pcb, board_path, *, nets=('*',), bin_mm=2.0, top=8,
     doc['windows'] = rows[:max(top, 32)]
     doc['windows_demand'] = len(rows)
 
-    if not cold or not bounds:
+    if not bounds:
+        # The one genuine refusal: no span, no board centre, no lattice.
         doc['outline'] = None
         doc['cold_windows'] = None
         doc['cold_regions'] = []
         doc['arrangement'] = None
         doc['reseat_target'] = None
-        doc['skipped'] = (None if cold else 'cold census disabled')
-        if cold and not bounds:
-            doc['skipped'] = ('no board_bounds: nothing to enumerate an '
-                              'outline over')
+        doc['skipped'] = ('no board_bounds: nothing to enumerate an outline '
+                          'over')
         return doc, hot
 
     # --- the outline sweep --------------------------------------------------
@@ -463,10 +518,18 @@ def pocket_census(pcb, board_path, *, nets=('*',), bin_mm=2.0, top=8,
     doc['windows_partial'] = sum(1 for f in frac.values() if f < 1.0 - 1e-9)
 
     # --- part coverage, per side -------------------------------------------
+    #: A failure here CANNOT be swallowed into an empty part list. With the
+    #: grader raising, esp_prog reported 81 cold windows instead of 29 and a
+    #: 260mm2 "empty pocket" sitting on top of U1 and USB1 -- and said nothing,
+    #: because the provenance line only prints when there IS an arrangement.
+    #: "I could not measure the parts" and "the board has no parts" are the
+    #: same distinction this whole tool exists to draw, one level up.
+    graded_error = None
     try:
         graded = leg.graded_parts_from_file(pcb, board_path)
-    except Exception:                                           # noqa: BLE001
+    except Exception as exc:                                    # noqa: BLE001
         graded = []
+        graded_error = '%s: %s' % (type(exc).__name__, exc)
     real = [g for g in graded if not g.synthetic]
     board_area = (bounds[2] - bounds[0]) * (bounds[3] - bounds[1])
     containers = _containers(real, pcb.footprints, board_area, leg, opts)
@@ -489,6 +552,7 @@ def pocket_census(pcb, board_path, *, nets=('*',), bin_mm=2.0, top=8,
         from_courtyard = None
     doc['parts'] = {
         'graded': len(graded),
+        'grading_error': graded_error,
         'weighed': len([g for g in real if g.ref not in containers]),
         'synthetic_excluded': len(graded) - len(real),
         'container_excluded': len(containers),
@@ -525,6 +589,7 @@ def pocket_census(pcb, board_path, *, nets=('*',), bin_mm=2.0, top=8,
     # distinctions this tool exists to draw are exactly the ones that vanish
     # if a window is silently dropped: a window under a part is not a pocket,
     # and a part-free window full of another net's copper is not empty.
+    touched = copper_touched_bins(pcb, bin_mm)
     cold_keys = []
     warm_unowned = 0
     under_parts = 0
@@ -535,8 +600,11 @@ def pocket_census(pcb, board_path, *, nets=('*',), bin_mm=2.0, top=8,
             demand_in += 1
             continue
         # Part-free is not empty: on a routed board a window with no part
-        # still carries copper, and `free` is the only thing that knows.
-        if free < bin_area_total - 1e-9:
+        # still carries copper. TWO tests, because neither alone is enough --
+        # `free` is the demand/capacity model's midpoint accounting, which
+        # misses a track that crosses the window without its midpoint in it,
+        # and the swept test does not know about the 5% area floor.
+        if free < bin_area_total - 1e-9 or b in touched:
             warm_unowned += 1
             continue
         area_here = bin_area_2d * f
@@ -591,7 +659,12 @@ def pocket_census(pcb, board_path, *, nets=('*',), bin_mm=2.0, top=8,
     regions.sort(key=lambda r: (-r['area_mm2'], r['bbox']))
     for i, r in enumerate(regions):
         r['rank'] = i + 1
-    doc['cold_regions'] = regions[:max(top, 32)]
+    #: `--no-cold` suppresses the COLD half only. It used to return before
+    #: the outline sweep, so it silently took the arrangement census, the
+    #: parts provenance and the reseat target with it -- while both the docs
+    #: and the argparse help describe --no-arrangement as the separate switch
+    #: for those.
+    doc['cold_regions'] = regions[:max(top, 32)] if cold else []
     doc['cold_area_mm2'] = round(sum(r['area_mm2'] for r in regions), 3)
     in_area = sum(bin_area_2d * f for f in frac.values())
     doc['cold_area_frac'] = (round(doc['cold_area_mm2'] / in_area, 4)
@@ -607,17 +680,37 @@ def pocket_census(pcb, board_path, *, nets=('*',), bin_mm=2.0, top=8,
                 if quadrant_of((b[0] + 0.5) * bin_mm, (b[1] + 0.5) * bin_mm,
                                bounds) == q['index'])
 
-    doc['reseat_target'] = _reseat_target(doc)
+    if not cold:
+        doc['cold_windows'] = None
+        doc['warm_unowned_windows'] = None
+        doc['under_part_windows'] = None
+        doc['cold_area_mm2'] = None
+        doc['cold_area_frac'] = None
+        doc['skipped'] = 'cold census disabled'
+    doc['reseat_target'] = _reseat_target(doc, bounds) if cold else None
     return doc, hot
 
 
-def _reseat_target(doc):
-    """The census's product: a place to move mass TO, and a runnable command.
+def _reseat_target(doc, bounds=None):
+    """The census's product: a place to move mass TO. A DESTINATION, not a scope.
 
     A printed string, not a weight and not a gate. #709 records why: a density
     objective term was tried, measured and rejected, because a bounded nudge
     cannot migrate a part out of a packed belt into empty space. That is
     reseat-scale work, so the census names a target and stops.
+
+    IT IS NOT A `--reseat-region` ARGUMENT, and the first version of this
+    printed one, which was wrong on every board rather than sometimes. A cold
+    window cannot contain a pad centre BY CONSTRUCTION -- a pad's area is
+    charged to its bin, so a window holding one is `warm_unowned`, never cold
+    -- so `refs_in_rect(band_rect)` is empty for every band this ever names.
+    Measured: 428 060 cold windows over 29 boards, zero containing a pad
+    centre. The command was a scope that lifts nothing.
+
+    The cold band's real use is as an intent block `zone`, which is the one
+    thing in the stack that AIMS a re-seat at a rectangle. The scope to lift
+    is a different rectangle -- the crowded one -- and the census names the
+    parts bounding the pocket instead of pretending otherwise.
     """
     regions = doc.get('cold_regions') or []
     if not regions:
@@ -630,12 +723,26 @@ def _reseat_target(doc):
         dx, dy = s['offset_mm']
         # Mass sits at +offset, so the room is in the opposite direction.
         move = _compass(-dx, -dy)
+    #: Clipped to the board. The band is lattice-aligned, so its outer edge
+    #: overhangs the outline whenever a bound is not a multiple of the bin --
+    #: on 6 of 11 measured boards -- and a zone rectangle that reaches off the
+    #: board is not a zone anyone can seat a part in.
+    zone = list(top['band_rect'])
+    if bounds:
+        zone = [max(zone[0], bounds[0]), max(zone[1], bounds[1]),
+                min(zone[2], bounds[2]), min(zone[3], bounds[3])]
+        zone = [round(v, 3) for v in zone]
     return {'region_bbox': top['bbox'], 'band_rect': top['band_rect'],
             'band_mm': top['band_mm'], 'area_mm2': top['area_mm2'],
             'windows': top['windows'], 'refs': top['refs'],
             'move_mass_toward': move,
-            'reseat_region': [top['band_rect'][0], top['band_rect'][1],
-                              top['band_rect'][2], top['band_rect'][3]]}
+            # The DESTINATION, clipped to the board. Named `zone` because that
+            # is the intent key it belongs in; it is deliberately NOT called
+            # `reseat_region`, which would invite the empty-scope mistake.
+            'zone': zone,
+            'zone_mm': [round(zone[2] - zone[0], 3),
+                        round(zone[3] - zone[1], 3)],
+            'contains_parts': False}
 
 
 def census_scalars(doc):
@@ -668,7 +775,14 @@ def census_scalars(doc):
         'windows_offboard': doc.get('windows_offboard'),
         'windows_partial': doc.get('windows_partial'),
         'cold_windows': doc.get('cold_windows'),
-        'cold_regions': len(doc.get('cold_regions') or []),
+        # Exported so a consumer can reconstruct the partition from the
+        # summary line alone; `windows_demand` alone cannot, because it
+        # counts off-board demand bins too.
+        'windows_demand_in_outline': doc.get('windows_demand_in_outline'),
+        'under_part_windows': doc.get('under_part_windows'),
+        'warm_unowned_windows': doc.get('warm_unowned_windows'),
+        'cold_regions': (len(doc.get('cold_regions') or [])
+                         if doc.get('cold_windows') is not None else None),
         'cold_area_mm2': doc.get('cold_area_mm2'),
         'cold_area_frac': doc.get('cold_area_frac'),
         'cold_top_area_mm2': top.get('area_mm2'),
@@ -688,8 +802,18 @@ def format_report(doc, hot, top):
             f" = {doc['lane_mm']:g}mm" if doc['lane_mm'] is not None
             else "board floors unreadable")
     if doc.get('windows_in_outline') is not None:
-        counts = (f"{doc['windows_demand']} demand / {doc['cold_windows']} "
-                  f"cold / {doc['windows_in_outline']} in-outline window(s)")
+        # `windows_demand` counts demand bins wherever they are, including one
+        # under a part hanging off the board edge; the in-outline term is the
+        # one the partition is over, and printing them side by side without
+        # saying so mixes two populations.
+        cw = doc.get('cold_windows')
+        counts = (f"{doc.get('windows_demand_in_outline')} demand"
+                  + (f" / {cw} cold" if cw is not None else "")
+                  + f" / {doc['windows_in_outline']} in-outline window(s)"
+                  + (f" ({doc['windows_demand']} demand bins in all, some "
+                     f"off-board)"
+                     if doc['windows_demand'] != doc.get(
+                         'windows_demand_in_outline') else ""))
     else:
         counts = f"{doc['windows_demand']} window(s)"
     lines.append(f"Pocket census of {doc['board']}: {doc['demand_nets']} "
@@ -707,6 +831,15 @@ def format_report(doc, hot, top):
         if r.get('refs'):
             lines.append(f"      refs: {', '.join(r['refs'][:14])}"
                          + (" ..." if len(r['refs']) > 14 else ""))
+
+    if (doc.get('parts') or {}).get('grading_error'):
+        # Loudest line in the report, and NOT conditional on the arrangement
+        # block: without part geometry every window under a part reads cold,
+        # and the ranked pockets are on top of the parts.
+        lines.append("  !! PART GEOMETRY UNREADABLE (%s) -- every cold number "
+                     "below is measured as if the board had no parts, so the "
+                     "pockets it names may be underneath them. Do not act on "
+                     "them." % doc['parts']['grading_error'])
 
     regions = doc.get('cold_regions') or []
     if doc.get('cold_windows') is not None:
@@ -765,21 +898,25 @@ def format_report(doc, hot, top):
 
     rt = doc.get('reseat_target')
     if rt:
-        r = rt['reseat_region']
+        r = rt['zone']
         lines.append(f"reseat target: largest landing site is the "
-                     f"{rt['band_mm'][0]:g} x {rt['band_mm'][1]:g}mm band at "
+                     f"{rt['zone_mm'][0]:g} x {rt['zone_mm'][1]:g}mm band at "
                      f"[{r[0]:g},{r[1]:g}]-[{r[2]:g},{r[3]:g}]"
                      + (f"; the mass wants to move {rt['move_mass_toward']}"
                         if rt['move_mass_toward'] else ""))
-        lines.append(f"  lift:  python3 -X utf8 py_placer/place_seed.py "
-                     f"<in> <out> --intent <fp.json> --reseat-region "
-                     f"{r[0]:g} {r[1]:g} {r[2]:g} {r[3]:g} --dry-run")
-        lines.append(f"  aim:   nothing in the seeder aims at this rectangle "
-                     f"-- a lifted part goes to its zone, its edge band, or "
-                     f"its net centroid, NOT here. To make this the "
-                     f"destination, declare it as an intent block zone: "
+        lines.append("  This is a DESTINATION, not a scope. A cold band holds "
+                     "no part by construction, so `--reseat-region` over it "
+                     "resolves to an empty scope on every board.")
+        lines.append(f"  use:   declare it as an intent block zone -- the one "
+                     f"thing in the stack that AIMS a re-seat at a rectangle: "
                      f'{{"name": "cold_{r[0]:g}_{r[1]:g}", "refs": [...], '
                      f'"zone": [{r[0]:g}, {r[1]:g}, {r[2]:g}, {r[3]:g}]}}')
+        if rt.get('refs'):
+            lines.append(f"  scope: the parts bounding this pocket are "
+                         f"{', '.join(rt['refs'][:10])}"
+                         + (' ...' if len(rt['refs']) > 10 else '')
+                         + " -- name them, or a CROWDED rectangle, to "
+                           "--reseat-region")
     return lines
 
 
@@ -843,6 +980,24 @@ def main():
         p.error("--cold-cover is a fraction of a window in [0, 1]")
     if args.outline_samples < 1:
         p.error("--outline-samples is a per-axis sample count, at least 1")
+    if args.outline_samples > 32:
+        # The sweep is K*K per outline-cut window and unbounded above:
+        # measured, interf_u_unrouted --bin 0.25 --outline-samples 16 takes
+        # 3m50s against 26s at the default and produces IDENTICAL bucket
+        # counts. It refines edge-window areas, nothing else.
+        p.error("--outline-samples above 32 is quadratic for no measured "
+                "gain; it refines edge-window AREAS only, and 16 already "
+                "reproduces the default's bucket counts exactly")
+    if not math.isfinite(args.bin):
+        # `congestion_bins`' max(0.25, bin) passes inf straight through, and
+        # the window rectangles then serialise as bare `Infinity`/`NaN` --
+        # non-standard JSON that strict parsers refuse, which is the exact
+        # thing the `ratio` comment and test_run23_pockets guard against.
+        p.error("--bin must be a finite number of millimetres")
+    if args.bin <= 0:
+        p.error("--bin is a window size in mm; it must be positive "
+                "(values under the 0.25mm census floor are raised to it and "
+                "reported, but zero and negative are typos)")
 
     doc, hot = pocket_census(
         pcb, args.board, nets=args.nets, bin_mm=args.bin, top=args.top,

--- a/py_tools/check_pockets.py
+++ b/py_tools/check_pockets.py
@@ -638,18 +638,28 @@ def _reseat_target(doc):
                               top['band_rect'][2], top['band_rect'][3]]}
 
 
-def _summary_scalars(doc):
-    """The one-line JSON_SUMMARY: scalars only, and every one finite.
+def census_scalars(doc):
+    """THE derived scalars, for anyone who wants numbers rather than the doc.
 
-    Line-prefixed rather than bare, which is this repo's convention precisely
-    because cli_banner appends a CMD:/EXIT= line around a tool's stdout.
+    Public because there are two consumers -- this tool's own JSON_SUMMARY line
+    and the predictor study's row -- and two copies of one definition is the
+    defect `refs_in_rect` exists to avoid. `centroid_offset` in particular is
+    not a matter of taste: taking only the X term records "dead centre" for a
+    board whose mass sits 14% of the span off in Y (splitflap_driver reads
+    X 0.0002 / Y 0.1395), and the study's own damage kinds -- `translate`,
+    `wrong_side` -- displace mass in Y routinely. So the magnitude is the
+    headline and both axes ship beside it.
     """
     arr = doc.get('arrangement') or {}
     side = (arr.get('sides') or {}).get(arr.get('headline_side')) or {}
     off = side.get('offset_frac_span') or [None, None]
     ctl = side.get('count_control_frac_span') or [None, None]
     top = (doc.get('cold_regions') or [{}])[0]
+    mag = (round(math.hypot(off[0], off[1]), 4)
+           if off[0] is not None and off[1] is not None else None)
     out = {
+        'centroid_offset_frac': mag,
+        'centroid_offset_frac_x': off[0],
         'board': doc['board'], 'bin_mm': doc['bin_mm'],
         'layers': doc['layers'], 'demand_nets': doc['demand_nets'],
         'lane_mm': doc['lane_mm'],
@@ -662,7 +672,6 @@ def _summary_scalars(doc):
         'cold_area_mm2': doc.get('cold_area_mm2'),
         'cold_area_frac': doc.get('cold_area_frac'),
         'cold_top_area_mm2': top.get('area_mm2'),
-        'centroid_offset_frac': off[0],
         'centroid_offset_frac_y': off[1],
         'centroid_count_control_frac': ctl[0],
         'outline_source': (doc.get('outline') or {}).get('source'),
@@ -765,9 +774,10 @@ def format_report(doc, hot, top):
         lines.append(f"  lift:  python3 -X utf8 py_placer/place_seed.py "
                      f"<in> <out> --intent <fp.json> --reseat-region "
                      f"{r[0]:g} {r[1]:g} {r[2]:g} {r[3]:g} --dry-run")
-        lines.append(f"  aim:   a re-seat lands each part at its own net "
-                     f"centroid, NOT here. To make this the destination, "
-                     f"declare it as an intent block zone: "
+        lines.append(f"  aim:   nothing in the seeder aims at this rectangle "
+                     f"-- a lifted part goes to its zone, its edge band, or "
+                     f"its net centroid, NOT here. To make this the "
+                     f"destination, declare it as an intent block zone: "
                      f'{{"name": "cold_{r[0]:g}_{r[1]:g}", "refs": [...], '
                      f'"zone": [{r[0]:g}, {r[1]:g}, {r[2]:g}, {r[3]:g}]}}')
     return lines
@@ -865,7 +875,7 @@ def main():
 
     doc.pop('_clr', None)
     doc.pop('_trk', None)
-    print('JSON_SUMMARY: ' + json.dumps(_summary_scalars(doc), sort_keys=True))
+    print('JSON_SUMMARY: ' + json.dumps(census_scalars(doc), sort_keys=True))
 
     if args.json:
         with open(args.json, 'w', encoding='utf-8') as f:

--- a/py_tools/check_pockets.py
+++ b/py_tools/check_pockets.py
@@ -10,13 +10,42 @@ are blind to SIMULTANEOUS routability by construction; this tool reports the
 aggregate: the board binned at --bin mm, each bin's distinct demanding nets
 against its free area, top offenders named with their nets and parts.
 
+#709 -- IT COULD NOT SAY "EMPTY". `congestion_bins` keyed its result off the
+`owners` map, which only gains a key where some net has a terminal, so a
+window with nothing in it never entered the dict: measured on esp_prog at the
+default 2mm bin the census reported 44 windows where 128 lie in the outline,
+and on glasgow_revC 457 of 1000. The finding a placement reviewer most wants
+-- "there is a clear empty pocket here, a 6-8mm band" -- was unproducible by
+construction. So the census now enumerates every in-outline window, reports
+COLD regions (in-outline, no demand, no copper, no part) ranked by CONTIGUOUS
+AREA rather than by window count, and prints the arrangement census that
+belongs beside them: where the part mass sits against where the demand sits.
+
+Three things that are deliberate and easy to get wrong:
+
+* **The lattice is the ROUTER'S lattice.** Bins are keyed off absolute board
+  mm (`int(x // bin)`), and `congestion2_rows` maps them back the same way to
+  price A* cells. Re-origining the grid on the outline would put this report
+  on a lattice the router does not use -- silently, since congestion-v2 is
+  off by default -- so an edge-straddling window is reported with its
+  IN-OUTLINE AREA FRACTION instead of being aligned away.
+* **Cold is not the same as unreported.** Most windows the old census could
+  not see sit under a part courtyard, and a window under a part is not a
+  pocket. Nor is part-free the same as empty: on a routed board, windows with
+  no part still carry copper. Cold means all four.
+* **The centroid is weighted by COURTYARD AREA, not part count.** The count
+  form is the intuitive one and it points the wrong way; it is computed and
+  printed as a labelled control, never as the answer.
+
 REPORT-ONLY, deliberately: a new metric mis-thresholded is noise, so nothing
-gates on it this sprint. The boundary review (the blind-first visual gate)
-must DISPOSITION every window this prints -- in writing, against a named
-plan -- or refuse the handoff itself.
+gates on it. The boundary review (the blind-first visual gate) must
+DISPOSITION every window this prints -- in writing, against a named plan --
+or refuse the handoff itself.
 
     python3 -X utf8 py_tools/check_pockets.py <board> [--nets GLOB...]
         [--bin MM] [--top N] [--threshold NETS_PER_MM2] [--json PATH]
+        [--no-cold] [--cold-cover FRAC] [--outline-samples K]
+        [--no-arrangement]
 
 Exit codes: 0 always (report), 2 usage/load error.
 """
@@ -24,7 +53,678 @@ import _path  # noqa: F401  (py_tools -> py_router/py_placer on sys.path)
 
 import argparse
 import json
+import math
 import sys
+
+#: Half-open containment, so a point on a shared boundary belongs to exactly
+#: one window. Every consumer of a census rectangle must use the same rule --
+#: `placement.utility.refs_in_rect` is the one implementation, and
+#: `place_seed --reseat-region` resolves through it, so the rectangle this
+#: tool prints names the same parts the mover lifts.
+from placement.utility import refs_in_rect          # noqa: E402
+
+
+def lattice_windows(bounds, bin_mm):
+    """Every (bx, by) on the ABSOLUTE lattice whose window meets `bounds`.
+
+    floor/ceil, not `int(hi // bin) + 1`: when a bound lands exactly on a
+    lattice line the +1 form appends a row of zero-width windows. Measured on
+    glasgow_revC (y1 = 120.0 at bin 2.0) that is 40 phantom windows, and the
+    invisible-window count this tool exists to report would be overstated by
+    exactly those 40.
+    """
+    x0, y0, x1, y1 = bounds
+    return [(bx, by)
+            for bx in range(int(math.floor(x0 / bin_mm)),
+                            int(math.ceil(x1 / bin_mm)))
+            for by in range(int(math.floor(y0 / bin_mm)),
+                            int(math.ceil(y1 / bin_mm)))]
+
+
+def window_rect(b, bin_mm):
+    bx, by = b
+    return (round(bx * bin_mm, 6), round(by * bin_mm, 6),
+            round((bx + 1) * bin_mm, 6), round((by + 1) * bin_mm, 6))
+
+
+def in_outline_fraction(win, bounds, gate, samples, leg):
+    """How much of this window is inside the board, in [0, 1].
+
+    Three tiers, and the ORDER of the first two is load-bearing:
+
+    1. No intersection with the bbox -> 0.0, before any ring work.
+    2. `gate.active` is False -> the outline IS the bbox, and the bbox
+       overlap is EXACT. This is not a rare fallback: `extract_board_contours`
+       deliberately returns no rings for a simple axis-aligned rectangle
+       ("use bounding box"), so most boards land here -- and on such a board
+       the gate's point test answers True everywhere, which is why `active`
+       must be consulted before it, not after.
+    3. Otherwise ask the gate. A window it calls fully legal is 1.0; one it
+       does not is sub-sampled, because a census window needs HOW MUCH is
+       inside, not the "is it entirely inside" a part centre needs.
+    """
+    inb = leg.rect_overlap_area(win, bounds)
+    if inb <= 1e-9:
+        return 0.0
+    cell = (win[2] - win[0]) * (win[3] - win[1])
+    if not gate.active:
+        return min(1.0, inb / cell) if cell > 0 else 0.0
+    if gate.rect_outside_amount(win) <= 1e-9:
+        return 1.0
+    hits = 0
+    for i in range(samples):
+        px = win[0] + (i + 0.5) * (win[2] - win[0]) / samples
+        for j in range(samples):
+            py = win[1] + (j + 0.5) * (win[3] - win[1]) / samples
+            if gate.rect_outside_amount((px, py, px, py)) <= 1e-9:
+                hits += 1
+    return hits / float(samples * samples)
+
+
+def flood_regions(cold_keys):
+    """4-connected components of a sparse set of (bx, by) keys.
+
+    Same semantics as `plane_fill_model._label_components` (labels 1..n,
+    4-connected) and deliberately not that function: importing
+    `plane_fill_model` costs ~1.3s and pulls the routing stack into a report
+    tool, to label a set of tens of windows.
+
+    4-connected, not 8: diagonal joins merge a band into the blob next to it,
+    and the band IS the finding ("an empty band south of CON2's eastern
+    half"). Output order is sorted, never dict order.
+    """
+    remaining = set(cold_keys)
+    out = []
+    for seed in sorted(remaining):
+        if seed not in remaining:
+            continue
+        remaining.discard(seed)
+        comp, stack = [seed], [seed]
+        while stack:
+            bx, by = stack.pop()
+            for nb in ((bx + 1, by), (bx - 1, by), (bx, by + 1), (bx, by - 1)):
+                if nb in remaining:
+                    remaining.discard(nb)
+                    comp.append(nb)
+                    stack.append(nb)
+        out.append(sorted(comp))
+    return out
+
+
+def largest_band(cells):
+    """Largest all-cold axis-aligned rectangle, as (bx0, by0, bx1, by1) incl.
+
+    Maximal rectangle in a binary matrix (histogram + monotone stack). This is
+    what turns a region into the reviewer's own sentence: a 24-window blob
+    says nothing, "a 6.0 x 2.0mm band at [140,94]-[146,96]" is a place.
+    """
+    if not cells:
+        return None
+    xs = [c[0] for c in cells]
+    ys = [c[1] for c in cells]
+    x0, x1, y0, y1 = min(xs), max(xs), min(ys), max(ys)
+    present = set(cells)
+    best = (0, None)
+    heights = [0] * (x1 - x0 + 1)
+    for by in range(y0, y1 + 1):
+        for i in range(len(heights)):
+            heights[i] = heights[i] + 1 if (x0 + i, by) in present else 0
+        stack = []                      # (start_index, height)
+        for i, h in enumerate(heights + [0]):
+            start = i
+            while stack and stack[-1][1] >= h:
+                s, sh = stack.pop()
+                area = sh * (i - s)
+                if area > best[0]:
+                    best = (area, (x0 + s, by - sh + 1, x0 + i - 1, by))
+                start = s
+            stack.append((start, h))
+    return best[1]
+
+
+def _side_key(gp):
+    return getattr(gp, 'sides', None) or frozenset((gp.side,))
+
+
+def _containers(parts, footprints, board_area, leg, opts):
+    """Refs whose courtyard is a FRAME around the design, not a body.
+
+    Area alone is not the test -- `options` records that on a synthetically
+    shrunk board the bare ratio classed 12 plain connectors as containers --
+    so the hosting guard decides, and it is CALLED rather than mirrored.
+    """
+    if not board_area or opts is None:
+        return set()
+    out = set()
+    for gp in parts:
+        if leg.rect_area(gp.rect) < leg.CONTAINER_RATIO * board_area:
+            continue
+        fp = footprints.get(gp.ref)
+        if fp is None:
+            continue
+        try:
+            hosts = opts.hosts_the_design(
+                gp.ref, gp.rect[0] - fp.x, gp.rect[1] - fp.y,
+                gp.rect[2] - fp.x, gp.rect[3] - fp.y, fp, footprints)
+        except Exception:                                       # noqa: BLE001
+            hosts = False
+        if hosts:
+            out.add(gp.ref)
+    return out
+
+
+QUADRANTS = ('NW', 'NE', 'SW', 'SE')
+
+
+def quadrant_of(x, y, bounds):
+    """`perturb._region_unit`'s split, verbatim: 0=NW 1=NE 2=SW 3=SE.
+
+    Reusing the numbering is what makes the output a reseat TARGET rather than
+    a weight -- `--block region:q0` is a runnable argument, and it only names
+    the same parts if the membership rule is the same one (half-open, on the
+    FOOTPRINT ORIGIN, which is what `_region_unit` filters on).
+    """
+    x0, y0, x1, y1 = bounds
+    mx, my = (x0 + x1) / 2.0, (y0 + y1) / 2.0
+    return (0 if x < mx else 1) + (0 if y < my else 2)
+
+
+def arrangement_census(pcb, parts, containers, bins, bin_mm, bounds, leg):
+    """Where the part MASS sits, against where the demand sits.
+
+    Weighted by courtyard AREA. The count-weighted form is reported beside it
+    as a control and never as the answer: it is the intuitive one and it
+    points the wrong way -- on esp_prog it reads 13.4% of span where the area
+    form reads 2.7%.
+
+    Refuses rather than invents: no `board_bounds` means no span and no board
+    centre, so there is no offset to report and this returns None.
+    """
+    if not bounds:
+        return None
+    x0, y0, x1, y1 = bounds
+    span_x, span_y = x1 - x0, y1 - y0
+    cx0, cy0 = (x0 + x1) / 2.0, (y0 + y1) / 2.0
+    weighed = [p for p in parts if p.ref not in containers]
+
+    sides = {}
+    for side in ('F', 'B'):
+        mine = [p for p in weighed if side in _side_key(p)]
+        area = sum(leg.rect_area(p.rect) for p in mine)
+        if not mine or area <= 0:
+            continue                      # absent, never a zero
+        ax = sum(leg.rect_area(p.rect) * (p.rect[0] + p.rect[2]) / 2.0
+                 for p in mine) / area
+        ay = sum(leg.rect_area(p.rect) * (p.rect[1] + p.rect[3]) / 2.0
+                 for p in mine) / area
+        nx = sum((p.rect[0] + p.rect[2]) / 2.0 for p in mine) / len(mine)
+        ny = sum((p.rect[1] + p.rect[3]) / 2.0 for p in mine) / len(mine)
+        sides[side] = {
+            'parts': len(mine),
+            'courtyard_area_mm2': round(area, 3),
+            'offset_mm': [round(ax - cx0, 3), round(ay - cy0, 3)],
+            'offset_frac_span': [
+                round(abs(ax - cx0) / span_x, 4) if span_x > 0 else None,
+                round(abs(ay - cy0) / span_y, 4) if span_y > 0 else None],
+            'count_control_offset_mm': [round(nx - cx0, 3),
+                                        round(ny - cy0, 3)],
+            'count_control_frac_span': [
+                round(abs(nx - cx0) / span_x, 4) if span_x > 0 else None,
+                round(abs(ny - cy0) / span_y, 4) if span_y > 0 else None],
+        }
+    if not sides:
+        return None
+    headline = max(sides, key=lambda s: sides[s]['courtyard_area_mm2'])
+
+    quads = [{'name': QUADRANTS[q], 'index': q, 'parts': 0,
+              'part_area_mm2': 0.0, 'demand_nets': 0, 'distinct_nets': 0,
+              'cold_windows': 0} for q in range(4)]
+    #: `_region_unit` filters on the footprint ORIGIN, so the count this
+    #: prints names exactly the block `--block region:qN` would move.
+    for ref, fp in pcb.footprints.items():
+        if ref in containers:
+            continue
+        quads[quadrant_of(fp.x, fp.y, bounds)]['parts'] += 1
+    qrects = []
+    mx, my = cx0, cy0
+    for q in range(4):
+        qx = (x0, mx) if q in (0, 2) else (mx, x1)
+        qy = (y0, my) if q in (0, 1) else (my, y1)
+        qrects.append((qx[0], qy[0], qx[1], qy[1]))
+    for gp in parts:
+        if gp.ref in containers:
+            continue
+        for q in range(4):
+            quads[q]['part_area_mm2'] += leg.rect_overlap_area(gp.rect,
+                                                               qrects[q])
+    seen = [set() for _ in range(4)]
+    for (bx, by), (_free, own) in bins.items():
+        if not own:
+            continue
+        q = quadrant_of((bx + 0.5) * bin_mm, (by + 0.5) * bin_mm, bounds)
+        #: Two numbers, not one: summing len(owners) counts a net once per
+        #: window it spans, which is the right measure of pressure; the union
+        #: is the right measure of how many nets are actually involved.
+        quads[q]['demand_nets'] += len(own)
+        seen[q] |= set(own)
+    for q in range(4):
+        quads[q]['distinct_nets'] = len(seen[q])
+        quads[q]['part_area_mm2'] = round(quads[q]['part_area_mm2'], 3)
+
+    return {'weight': 'courtyard_area', 'headline_side': headline,
+            'board_centre': [round(cx0, 3), round(cy0, 3)],
+            'span_mm': [round(span_x, 3), round(span_y, 3)],
+            'sides': sides, 'quadrants': quads}
+
+
+def _compass(dx, dy):
+    """Board compass. +y is SOUTH in KiCad's coordinate system."""
+    parts = []
+    if abs(dy) > 1e-9:
+        parts.append('S' if dy > 0 else 'N')
+    if abs(dx) > 1e-9:
+        parts.append('E' if dx > 0 else 'W')
+    return ''.join(parts) or 'centre'
+
+
+def pocket_census(pcb, board_path, *, nets=('*',), bin_mm=2.0, top=8,
+                  threshold=None, cold=True, cold_cover=0.0,
+                  outline_samples=4, arrangement=True):
+    """The whole census as data. `main` only formats what this returns."""
+    from congestion_field import congestion_bins
+    from net_queries import expand_net_patterns
+    from placement import legality as leg
+
+    try:
+        from placement import options as opts
+    except Exception:                                           # noqa: BLE001
+        opts = None
+
+    names = set(expand_net_patterns(pcb, list(nets)))
+    name_by_id = {n.net_id: n.name for n in pcb.nets.values()}
+    ids = [nid for nid, n in pcb.nets.items() if n.name in names]
+    layers = list(getattr(pcb.board_info, 'copper_layers', []) or []) or ['F.Cu']
+    bounds = getattr(pcb.board_info, 'board_bounds', None)
+
+    # The corridor arithmetic a reader needs beside the ratios: one lane =
+    # track + 2*clearance at the board's own floors (the 0.45mm number run
+    # 23's forensics measured RN7's cage against).
+    try:
+        from list_nets import board_floor
+        import routing_defaults as defaults
+        clr, _s1 = board_floor(board_path, 'clearance', None, defaults.CLEARANCE)
+        trk, _s2 = board_floor(board_path, 'track_width', None,
+                               defaults.TRACK_WIDTH)
+    except Exception:                                           # noqa: BLE001
+        clr = trk = None
+
+    # THE EFFECTIVE BIN, not the requested one. `congestion_bins` floors its
+    # bin at 0.25mm, so a smaller --bin binned at 0.25 while this tool built
+    # its window rectangles from the requested value: at --bin 0.1 the rows
+    # read [25.9,21.3]-[26.0,21.4] for a window whose true left edge is
+    # 64.75mm. Every coordinate in the report -- printed and JSON -- named a
+    # place on the board where nothing was measured. Ask the census what it
+    # actually used and build the rectangles from that.
+    #
+    # The lattice must therefore be built from the EFFECTIVE bin too, which
+    # is why this is a two-step: ask for the bin, then enumerate.
+    _b0, _t0, bin_mm = congestion_bins(pcb, ids, len(layers), bin_mm)
+    lattice = lattice_windows(bounds, bin_mm) if bounds else []
+    bins, _terminals, bin_mm = congestion_bins(
+        pcb, ids, len(layers), bin_mm,
+        include_bins=lattice if (cold and lattice) else None)
+
+    doc = {'board': board_path,
+           # The bin the census USED. `bin_requested` is what the caller
+           # asked for; they differ when --bin is under the floor, and a
+           # reader plotting `window` needs the one the rectangles came from.
+           'bin_mm': bin_mm,
+           'demand_nets': len(ids), 'layers': len(layers),
+           'lane_mm': (round(trk + 2 * clr, 4)
+                       if clr is not None and trk is not None else None),
+           'threshold': threshold}
+
+    bin_area_2d = bin_mm * bin_mm
+    bin_area_total = bin_area_2d * len(layers)
+
+    # --- rows: unchanged for every window that has demand ------------------
+    rows = []
+    for b, (free, owners) in bins.items():
+        if not owners:
+            continue                      # a cold candidate, reported below
+        rows.append({
+            'window': list(window_rect(b, bin_mm)),
+            'demand_nets': len(owners),
+            'free_area_mm2': round(free, 3),
+            # `free` is floored at 5% of the bin area by congestion_bins, so
+            # it is never 0 and the ratio is always finite. The old
+            # `float('inf')` guard was unreachable AND would have written a
+            # bare `Infinity` token into the JSON, which is not standard JSON
+            # and which strict parsers refuse.
+            'ratio': round(len(owners) / free, 4),
+            'nets': sorted(name_by_id.get(n, str(n)) for n in owners)[:12],
+        })
+    rows.sort(key=lambda r: -r['ratio'])
+    # Simultaneous routability needs >= 2 nets by definition: a single-net
+    # sliver (a bin inside one part's own pad field) tops any ratio ranking
+    # and means nothing here. Reported in the JSON, never in the ranking.
+    hot = [r for r in rows if r['demand_nets'] >= 2
+           and (threshold is None or r['ratio'] > threshold)]
+
+    # Parts per window, for the top rows only (the fix target is a ref).
+    for r in hot[:top]:
+        r['refs'] = refs_in_rect(pcb, r['window'])
+
+    doc['windows'] = rows[:max(top, 32)]
+    doc['windows_demand'] = len(rows)
+
+    if not cold or not bounds:
+        doc['outline'] = None
+        doc['cold_windows'] = None
+        doc['cold_regions'] = []
+        doc['arrangement'] = None
+        doc['reseat_target'] = None
+        doc['skipped'] = (None if cold else 'cold census disabled')
+        if cold and not bounds:
+            doc['skipped'] = ('no board_bounds: nothing to enumerate an '
+                              'outline over')
+        return doc, hot
+
+    # --- the outline sweep --------------------------------------------------
+    gate = leg.BoardOutlineGate(pcb.board_info, 0.0)
+    rings = list(getattr(gate, 'rings', []) or [])
+    doc['outline'] = {
+        # `extract_board_contours` returns NO rings for a plain axis-aligned
+        # rectangle ("use bounding box"), so most boards report bounding_box
+        # and that is correct rather than a parse failure -- but a reader
+        # comparing two boards needs to know which question was answered.
+        'source': 'edge_cuts_contours' if rings else 'bounding_box',
+        'rings': len(rings),
+        'cutouts': len(list(getattr(gate, 'cutouts', []) or [])),
+        'bounds': [round(v, 3) for v in bounds],
+        'samples': outline_samples,
+    }
+
+    frac = {}
+    for b in lattice:
+        f = in_outline_fraction(window_rect(b, bin_mm), bounds, gate,
+                                outline_samples, leg)
+        if f > 0:
+            frac[b] = f
+    doc['windows_in_outline'] = len(frac)
+    doc['windows_offboard'] = len(lattice) - len(frac)
+    doc['windows_partial'] = sum(1 for f in frac.values() if f < 1.0 - 1e-9)
+
+    # --- part coverage, per side -------------------------------------------
+    try:
+        graded = leg.graded_parts_from_file(pcb, board_path)
+    except Exception:                                           # noqa: BLE001
+        graded = []
+    real = [g for g in graded if not g.synthetic]
+    board_area = (bounds[2] - bounds[0]) * (bounds[3] - bounds[1])
+    containers = _containers(real, pcb.footprints, board_area, leg, opts)
+    doc['parts'] = {
+        'graded': len(graded),
+        'synthetic_excluded': len(graded) - len(real),
+        'container_excluded': len(containers),
+        'containers': sorted(containers),
+        'container_guard': 'options.hosts_the_design' if opts is not None
+                           else 'unavailable',
+    }
+
+    cover = {}
+    for gp in real:
+        if gp.ref in containers:
+            continue
+        gx0 = int(math.floor(gp.rect[0] / bin_mm))
+        gx1 = int(math.ceil(gp.rect[2] / bin_mm))
+        gy0 = int(math.floor(gp.rect[1] / bin_mm))
+        gy1 = int(math.ceil(gp.rect[3] / bin_mm))
+        for bx in range(gx0, gx1):
+            for by in range(gy0, gy1):
+                b = (bx, by)
+                if b not in frac:
+                    continue
+                a = leg.rect_overlap_area(window_rect(b, bin_mm), gp.rect)
+                if a <= 0:
+                    continue
+                slot = cover.setdefault(b, {'F': 0.0, 'B': 0.0})
+                for s in _side_key(gp):
+                    slot[s] = slot.get(s, 0.0) + a
+
+    # --- cold classification ------------------------------------------------
+    cold_keys = []
+    warm_unowned = 0
+    for b, f in frac.items():
+        free, owners = bins.get(b, (bin_area_total, frozenset()))
+        if owners:
+            continue
+        # Part-free is not empty: on a routed board a window with no part
+        # still carries copper, and `free` is the only thing that knows.
+        if free < bin_area_total - 1e-9:
+            warm_unowned += 1
+            continue
+        area_here = bin_area_2d * f
+        c = cover.get(b, {})
+        # max over sides, not sum: "a clear empty pocket" means empty on BOTH.
+        if max(c.get('F', 0.0), c.get('B', 0.0)) > cold_cover * area_here + 1e-9:
+            continue
+        cold_keys.append(b)
+    doc['cold_windows'] = len(cold_keys)
+    doc['warm_unowned_windows'] = warm_unowned
+    doc['cold_cover'] = cold_cover
+
+    regions = []
+    for cells in flood_regions(cold_keys):
+        area = round(sum(bin_area_2d * frac[c] for c in cells), 3)
+        band = largest_band(cells)
+        bx0, by0, bx1, by1 = band
+        band_cells = [(x, y) for x in range(bx0, bx1 + 1)
+                      for y in range(by0, by1 + 1)]
+        band_area = round(sum(bin_area_2d * frac[c] for c in band_cells), 3)
+        xs0 = min(c[0] for c in cells)
+        ys0 = min(c[1] for c in cells)
+        xs1 = max(c[0] for c in cells)
+        ys1 = max(c[1] for c in cells)
+        bbox = [round(xs0 * bin_mm, 3), round(ys0 * bin_mm, 3),
+                round((xs1 + 1) * bin_mm, 3), round((ys1 + 1) * bin_mm, 3)]
+        bb_area = (bbox[2] - bbox[0]) * (bbox[3] - bbox[1])
+        band_rect = [round(bx0 * bin_mm, 3), round(by0 * bin_mm, 3),
+                     round((bx1 + 1) * bin_mm, 3), round((by1 + 1) * bin_mm, 3)]
+        near = sorted({gp.ref for gp in real
+                       if gp.ref not in containers
+                       and leg.rect_gap(bbox, gp.rect) <= bin_mm})
+        regions.append({
+            'area_mm2': area, 'windows': len(cells), 'bbox': bbox,
+            'band_rect': band_rect,
+            'band_mm': [round(band_rect[2] - band_rect[0], 3),
+                        round(band_rect[3] - band_rect[1], 3)],
+            'band_area_mm2': band_area,
+            'fill': round(area / bb_area, 4) if bb_area > 0 else None,
+            'edge_touch': any(frac[c] < 1.0 - 1e-9 for c in cells),
+            'refs': near,
+        })
+    # Contiguous AREA, never window count -- that is the whole point of
+    # ranking regions rather than windows. bbox breaks ties so the order is a
+    # property of the finding, not of iteration.
+    regions.sort(key=lambda r: (-r['area_mm2'], r['bbox']))
+    for i, r in enumerate(regions):
+        r['rank'] = i + 1
+    doc['cold_regions'] = regions[:max(top, 32)]
+    doc['cold_area_mm2'] = round(sum(r['area_mm2'] for r in regions), 3)
+    in_area = sum(bin_area_2d * f for f in frac.values())
+    doc['cold_area_frac'] = (round(doc['cold_area_mm2'] / in_area, 4)
+                             if in_area > 0 else None)
+
+    doc['arrangement'] = (arrangement_census(pcb, real, containers, bins,
+                                             bin_mm, bounds, leg)
+                          if arrangement else None)
+    if doc['arrangement']:
+        for q in doc['arrangement']['quadrants']:
+            q['cold_windows'] = sum(
+                1 for b in cold_keys
+                if quadrant_of((b[0] + 0.5) * bin_mm, (b[1] + 0.5) * bin_mm,
+                               bounds) == q['index'])
+
+    doc['reseat_target'] = _reseat_target(doc)
+    return doc, hot
+
+
+def _reseat_target(doc):
+    """The census's product: a place to move mass TO, and a runnable command.
+
+    A printed string, not a weight and not a gate. #709 records why: a density
+    objective term was tried, measured and rejected, because a bounded nudge
+    cannot migrate a part out of a packed belt into empty space. That is
+    reseat-scale work, so the census names a target and stops.
+    """
+    regions = doc.get('cold_regions') or []
+    if not regions:
+        return None
+    top = regions[0]
+    arr = doc.get('arrangement')
+    move = None
+    if arr and arr.get('sides'):
+        s = arr['sides'][arr['headline_side']]
+        dx, dy = s['offset_mm']
+        # Mass sits at +offset, so the room is in the opposite direction.
+        move = _compass(-dx, -dy)
+    return {'region_bbox': top['bbox'], 'band_rect': top['band_rect'],
+            'band_mm': top['band_mm'], 'area_mm2': top['area_mm2'],
+            'windows': top['windows'], 'refs': top['refs'],
+            'move_mass_toward': move,
+            'reseat_region': [top['band_rect'][0], top['band_rect'][1],
+                              top['band_rect'][2], top['band_rect'][3]]}
+
+
+def _summary_scalars(doc):
+    """The one-line JSON_SUMMARY: scalars only, and every one finite.
+
+    Line-prefixed rather than bare, which is this repo's convention precisely
+    because cli_banner appends a CMD:/EXIT= line around a tool's stdout.
+    """
+    arr = doc.get('arrangement') or {}
+    side = (arr.get('sides') or {}).get(arr.get('headline_side')) or {}
+    off = side.get('offset_frac_span') or [None, None]
+    ctl = side.get('count_control_frac_span') or [None, None]
+    top = (doc.get('cold_regions') or [{}])[0]
+    out = {
+        'board': doc['board'], 'bin_mm': doc['bin_mm'],
+        'layers': doc['layers'], 'demand_nets': doc['demand_nets'],
+        'lane_mm': doc['lane_mm'],
+        'windows_demand': doc.get('windows_demand'),
+        'windows_in_outline': doc.get('windows_in_outline'),
+        'windows_offboard': doc.get('windows_offboard'),
+        'windows_partial': doc.get('windows_partial'),
+        'cold_windows': doc.get('cold_windows'),
+        'cold_regions': len(doc.get('cold_regions') or []),
+        'cold_area_mm2': doc.get('cold_area_mm2'),
+        'cold_area_frac': doc.get('cold_area_frac'),
+        'cold_top_area_mm2': top.get('area_mm2'),
+        'centroid_offset_frac': off[0],
+        'centroid_offset_frac_y': off[1],
+        'centroid_count_control_frac': ctl[0],
+        'outline_source': (doc.get('outline') or {}).get('source'),
+    }
+    return {k: v for k, v in out.items()
+            if not (isinstance(v, float) and not math.isfinite(v))}
+
+
+def format_report(doc, hot, top):
+    """Every printed line, as a list. No line may start with '[' -- the
+    ranked-row parser in tests/test_run23_pockets.py keys on exactly that."""
+    lines = []
+    lane = (f"one lane = track {doc['_trk']:g} + 2 x clearance {doc['_clr']:g}"
+            f" = {doc['lane_mm']:g}mm" if doc['lane_mm'] is not None
+            else "board floors unreadable")
+    if doc.get('windows_in_outline') is not None:
+        counts = (f"{doc['windows_demand']} demand / {doc['cold_windows']} "
+                  f"cold / {doc['windows_in_outline']} in-outline window(s)")
+    else:
+        counts = f"{doc['windows_demand']} window(s)"
+    lines.append(f"Pocket census of {doc['board']}: {doc['demand_nets']} "
+                 f"demand net(s), {counts} at {doc['bin_mm']:g}mm, "
+                 f"{doc['layers']} layer(s); {lane}")
+    lines.append("REPORT-ONLY: nothing gates on these numbers. The boundary "
+                 "review dispositions each window below, in writing.")
+    for r in hot[:top]:
+        w = r['window']
+        lines.append(f"  [{w[0]:g},{w[1]:g}]-[{w[2]:g},{w[3]:g}]  demand "
+                     f"{r['demand_nets']:>3} net(s) / free "
+                     f"{r['free_area_mm2']:g}mm2 = {r['ratio']:g}/mm2")
+        lines.append(f"      nets: {', '.join(r['nets'])}"
+                     + (" ..." if r['demand_nets'] > len(r['nets']) else ""))
+        if r.get('refs'):
+            lines.append(f"      refs: {', '.join(r['refs'][:14])}"
+                         + (" ..." if len(r['refs']) > 14 else ""))
+
+    regions = doc.get('cold_regions') or []
+    if doc.get('cold_windows') is not None:
+        src = (doc.get('outline') or {}).get('source', '?')
+        lines.append(f"COLD regions (in-outline, no demand net, no copper, no "
+                     f"part courtyard): {len(regions)} region(s), "
+                     f"{doc['cold_windows']} window(s); outline from {src}"
+                     + (f", {doc['warm_unowned_windows']} part-free window(s) "
+                        f"carry copper" if doc.get('warm_unowned_windows')
+                        else ""))
+        for r in regions[:top]:
+            b, br = r['bbox'], r['band_rect']
+            lines.append(f"  #{r['rank']:<3} {r['area_mm2']:>8.1f} mm2  "
+                         f"{r['windows']:>4} window(s)  band "
+                         f"{r['band_mm'][0]:g} x {r['band_mm'][1]:g}mm at "
+                         f"[{br[0]:g},{br[1]:g}]-[{br[2]:g},{br[3]:g}]")
+            lines.append(f"       bbox [{b[0]:g},{b[1]:g}]-[{b[2]:g},{b[3]:g}]"
+                         f"  fill {r['fill']:.2f}"
+                         + (f"  bounded by {', '.join(r['refs'][:8])}"
+                            if r['refs'] else "")
+                         + ("  edge-touching" if r['edge_touch'] else ""))
+
+    arr = doc.get('arrangement')
+    if arr:
+        s = arr['sides'][arr['headline_side']]
+        dx, dy = s['offset_mm']
+        fx, fy = s['offset_frac_span']
+        cx, cy = s['count_control_frac_span']
+        where = ', '.join(
+            f"{abs(v):.2f}mm {_compass(*ax)}"
+            for v, ax in ((dx, (dx, 0)), (dy, (0, dy))) if abs(v) > 5e-3
+        ) or 'ON the board centre'
+        lines.append(
+            f"arrangement: courtyard-AREA-weighted part centroid on side "
+            f"{arr['headline_side']} is {where} of board centre = "
+            f"{100 * (fx or 0):.1f}% / {100 * (fy or 0):.1f}% of span "
+            f"(part COUNT would say {100 * (cx or 0):.1f}% / "
+            f"{100 * (cy or 0):.1f}% -- a control, never the answer)")
+        p = doc.get('parts') or {}
+        lines.append(f"  parts weighed: {p.get('graded', 0)} graded, "
+                     f"{p.get('synthetic_excluded', 0)} synthetic excluded, "
+                     f"{p.get('container_excluded', 0)} container excluded "
+                     f"({p.get('container_guard')})")
+        for q in arr['quadrants']:
+            lines.append(f"  quadrant {q['name']} (region:q{q['index']})  "
+                         f"{q['parts']:>3} part(s) / "
+                         f"{q['part_area_mm2']:>8.1f}mm2 / "
+                         f"{q['demand_nets']:>4} net-window(s) of demand "
+                         f"({q['distinct_nets']} distinct) / "
+                         f"{q['cold_windows']:>3} cold")
+
+    rt = doc.get('reseat_target')
+    if rt:
+        r = rt['reseat_region']
+        lines.append(f"reseat target: largest landing site is the "
+                     f"{rt['band_mm'][0]:g} x {rt['band_mm'][1]:g}mm band at "
+                     f"[{r[0]:g},{r[1]:g}]-[{r[2]:g},{r[3]:g}]"
+                     + (f"; the mass wants to move {rt['move_mass_toward']}"
+                        if rt['move_mass_toward'] else ""))
+        lines.append(f"  lift:  python3 -X utf8 py_placer/place_seed.py "
+                     f"<in> <out> --intent <fp.json> --reseat-region "
+                     f"{r[0]:g} {r[1]:g} {r[2]:g} {r[3]:g} --dry-run")
+        lines.append(f"  aim:   a re-seat lands each part at its own net "
+                     f"centroid, NOT here. To make this the destination, "
+                     f"declare it as an intent block zone: "
+                     f'{{"name": "cold_{r[0]:g}_{r[1]:g}", "refs": [...], '
+                     f'"zone": [{r[0]:g}, {r[1]:g}, {r[2]:g}, {r[3]:g}]}}')
+    return lines
 
 
 def main():
@@ -43,118 +743,85 @@ def main():
                         "a smaller value is reported as the floor it was "
                         "raised to, never silently accepted")
     p.add_argument("--top", type=int, default=8, metavar='N',
-                   help="how many windows to print (default 8)")
+                   help="how many windows AND cold regions to print "
+                        "(default 8)")
     p.add_argument("--threshold", type=float, default=None,
                    metavar='NETS_PER_MM2',
                    help="report only windows above this demand/free-area "
                         "ratio. Default: none -- print the top N whatever "
                         "their ratio, because an absolute threshold is "
                         "exactly what this tool is too young to own")
+    p.add_argument("--no-cold", action='store_true',
+                   help="suppress the COLD census (in-outline windows with no "
+                        "demand, no copper and no part). It is ON by default: "
+                        "#709 is that an empty region was structurally "
+                        "unreportable, and a census nobody enables does not "
+                        "fix that")
+    p.add_argument("--cold-cover", type=float, default=0.0, metavar='FRAC',
+                   help="largest share of a window a part courtyard may cover "
+                        "and still count COLD (default 0.0 -- any courtyard "
+                        "touch disqualifies). A false COLD becomes a bad "
+                        "reseat target, which is what discredits the "
+                        "instrument, so the default is the strict end")
+    p.add_argument("--outline-samples", type=int, default=4, metavar='K',
+                   help="K x K sub-samples used to measure how much of an "
+                        "outline-CUT window is on the board (default 4). "
+                        "Ignored on a board whose outline is its bounding "
+                        "box, where the overlap is exact")
+    p.add_argument("--no-arrangement", action='store_true',
+                   help="suppress the arrangement census (courtyard-area-"
+                        "weighted centroid offset, per-quadrant part mass "
+                        "against per-quadrant demand)")
     p.add_argument("--json", default=None, metavar='PATH',
                    help="write the full census as JSON")
     args = p.parse_args()
 
-    from congestion_field import congestion_bins
     from kicad_parser import parse_kicad_pcb
-    from net_queries import expand_net_patterns
-
     try:
         pcb = parse_kicad_pcb(args.board)
-    except Exception as exc:
+    except Exception as exc:                                    # noqa: BLE001
         print(f"cannot parse {args.board}: {exc}", file=sys.stderr)
         return 2
 
-    names = set(expand_net_patterns(pcb, args.nets))
-    name_by_id = {n.net_id: n.name for n in pcb.nets.values()}
-    ids = [nid for nid, n in pcb.nets.items() if n.name in names]
-    layers = list(getattr(pcb.board_info, 'copper_layers', []) or []) or ['F.Cu']
+    if args.cold_cover < 0 or args.cold_cover > 1:
+        p.error("--cold-cover is a fraction of a window in [0, 1]")
+    if args.outline_samples < 1:
+        p.error("--outline-samples is a per-axis sample count, at least 1")
 
-    # The corridor arithmetic a reader needs beside the ratios: one lane =
-    # track + 2*clearance at the board's own floors (the 0.45mm number run
-    # 23's forensics measured RN7's cage against).
-    try:
-        from list_nets import board_floor
-        import routing_defaults as defaults
-        clr, _s1 = board_floor(args.board, 'clearance', None,
-                               defaults.CLEARANCE)
-        trk, _s2 = board_floor(args.board, 'track_width', None,
-                               defaults.TRACK_WIDTH)
-    except Exception:                                           # noqa: BLE001
-        clr = trk = None
+    doc, hot = pocket_census(
+        pcb, args.board, nets=args.nets, bin_mm=args.bin, top=args.top,
+        threshold=args.threshold, cold=not args.no_cold,
+        cold_cover=args.cold_cover, outline_samples=args.outline_samples,
+        arrangement=not args.no_arrangement)
 
-    # THE EFFECTIVE BIN, not the requested one. `congestion_bins` floors its
-    # bin at 0.25mm, so a smaller --bin binned at 0.25 while this tool built
-    # its window rectangles from the requested value: at --bin 0.1 the rows
-    # read [25.9,21.3]-[26.0,21.4] for a window whose true left edge is
-    # 64.75mm. Every coordinate in the report -- printed and JSON -- named a
-    # place on the board where nothing was measured. Ask the census what it
-    # actually used and build the rectangles from that.
-    bins, _terminals, bin_mm = congestion_bins(pcb, ids, len(layers), args.bin)
-    if abs(bin_mm - args.bin) > 1e-9:
+    if abs(doc['bin_mm'] - args.bin) > 1e-9:
         print(f"  --bin {args.bin:g}mm is below the census floor; binned at "
-              f"{bin_mm:g}mm and reported at {bin_mm:g}mm", file=sys.stderr)
-    rows = []
-    for (bx, by), (free, owners) in bins.items():
-        rows.append({
-            'window': [round(bx * bin_mm, 2), round(by * bin_mm, 2),
-                       round((bx + 1) * bin_mm, 2),
-                       round((by + 1) * bin_mm, 2)],
-            'demand_nets': len(owners),
-            'free_area_mm2': round(free, 3),
-            # `free` is floored at 5% of the bin area by congestion_bins, so
-            # it is never 0 and the ratio is always finite. The old
-            # `float('inf')` guard was unreachable AND would have written a
-            # bare `Infinity` token into the JSON, which is not standard JSON
-            # and which strict parsers refuse.
-            'ratio': round(len(owners) / free, 4),
-            'nets': sorted(name_by_id.get(n, str(n)) for n in owners)[:12],
-        })
-    rows.sort(key=lambda r: -r['ratio'])
-    # Simultaneous routability needs >= 2 nets by definition: a single-net
-    # sliver (a bin inside one part's own pad field) tops any ratio ranking
-    # and means nothing here. Reported in the JSON, never in the ranking.
-    hot = [r for r in rows if r['demand_nets'] >= 2
-           and (args.threshold is None or r['ratio'] > args.threshold)]
+              f"{doc['bin_mm']:g}mm and reported at {doc['bin_mm']:g}mm",
+              file=sys.stderr)
 
-    # Parts per window, for the top rows only (the fix target is a ref).
-    pads = [(pad.global_x, pad.global_y, pad.component_ref)
-            for fp in pcb.footprints.values() for pad in fp.pads]
-    for r in hot[:args.top]:
-        w = r['window']
-        r['refs'] = sorted({ref for x, y, ref in pads
-                            if w[0] <= x < w[2] and w[1] <= y < w[3] and ref})
+    doc['bin_requested_mm'] = args.bin
+    # Only the formatter wants the two floors separately.
+    lane = doc['lane_mm']
+    doc['_clr'] = doc['_trk'] = None
+    if lane is not None:
+        try:
+            from list_nets import board_floor
+            import routing_defaults as defaults
+            doc['_clr'], _ = board_floor(args.board, 'clearance', None,
+                                         defaults.CLEARANCE)
+            doc['_trk'], _ = board_floor(args.board, 'track_width', None,
+                                         defaults.TRACK_WIDTH)
+        except Exception:                                       # noqa: BLE001
+            doc['lane_mm'] = None
 
-    lane = (f"one lane = track {trk:g} + 2 x clearance {clr:g} = "
-            f"{trk + 2 * clr:g}mm" if clr is not None and trk is not None
-            else "board floors unreadable")
-    print(f"Pocket census of {args.board}: {len(ids)} demand net(s), "
-          f"{len(bins)} window(s) at {bin_mm:g}mm, {len(layers)} layer(s); "
-          f"{lane}")
-    print("REPORT-ONLY: nothing gates on these numbers. The boundary review "
-          "dispositions each window below, in writing.")
-    for r in hot[:args.top]:
-        w = r['window']
-        print(f"  [{w[0]:g},{w[1]:g}]-[{w[2]:g},{w[3]:g}]  demand "
-              f"{r['demand_nets']:>3} net(s) / free {r['free_area_mm2']:g}mm2 "
-              f"= {r['ratio']:g}/mm2")
-        print(f"      nets: {', '.join(r['nets'])}"
-              + (" ..." if r['demand_nets'] > len(r['nets']) else ""))
-        if r.get('refs'):
-            print(f"      refs: {', '.join(r['refs'][:14])}"
-                  + (" ..." if len(r['refs']) > 14 else ""))
+    for line in format_report(doc, hot, args.top):
+        print(line)
+
+    doc.pop('_clr', None)
+    doc.pop('_trk', None)
+    print('JSON_SUMMARY: ' + json.dumps(_summary_scalars(doc), sort_keys=True))
 
     if args.json:
-        doc = {'board': args.board,
-               # The bin the census USED. `bin_requested` is what the caller
-               # asked for; they differ when --bin is under the floor, and a
-               # reader plotting `window` needs the one the rectangles came
-               # from.
-               'bin_mm': bin_mm, 'bin_requested_mm': args.bin,
-               'demand_nets': len(ids), 'layers': len(layers),
-               'lane_mm': (round(trk + 2 * clr, 4)
-                           if clr is not None and trk is not None else None),
-               'threshold': args.threshold,
-               'windows': rows[:max(args.top, 32)]}
         with open(args.json, 'w', encoding='utf-8') as f:
             json.dump(doc, f, indent=1, sort_keys=True)
         print(f"  JSON -> {args.json}")

--- a/tests/stress/harvest_predictor_rows.py
+++ b/tests/stress/harvest_predictor_rows.py
@@ -133,9 +133,34 @@ CHECKLIST_SCALARS = (
     ('courtyard_overlap_mm2', ('b_courtyard_overlap_mm2',), ()),
 )
 
+#: Pocket-census scalars (#709), computed by `check_pockets.pocket_census`
+#: rather than by the placement model, so they are their own family.
+#:
+#: They are here because #703's comment asked the right question of them: a
+#: congestion census has to EARN its place against legality counts already
+#: sitting at median rho +0.785 on 6/6 boards, and the cheap way to know is a
+#: column in the study rather than an argument. Note which scalars: the HOT
+#: ranking is a known constant predictor -- `rank_stats` records that
+#: check_pockets produced an empty ranked list on three of five real boards,
+#: and a constant contributes nothing to a sign test. The COLD ones exist on
+#: every board, which is precisely what makes them askable.
+#:
+#: No recorded handoff carries these, so on harvested rows they land as
+#: `schema_gaps` and `board_rho` drops them by name with its count. That is
+#: correct and is left visible: those documents genuinely do not contain a
+#: pocket census, and a STUDY_ONLY escape hatch would add a second class of
+#: key to a table whose whole value is having one.
+POCKET_SCALARS = (
+    ('cold_area_frac', ('pockets', 'cold_area_frac'), ()),
+    ('cold_top_area_mm2', ('pockets', 'cold_top_area_mm2'), ()),
+    ('cold_regions', ('pockets', 'cold_regions'), ()),
+    ('centroid_offset_frac', ('pockets', 'centroid_offset_frac'), ()),
+)
+
 PREDICTOR_KEYS = tuple(METRIC_KEYS
                        + tuple(n for n, _p, _a in CHECKLIST_COUNTS)
-                       + tuple(n for n, _p, _a in CHECKLIST_SCALARS))
+                       + tuple(n for n, _p, _a in CHECKLIST_SCALARS)
+                       + tuple(n for n, _p, _a in POCKET_SCALARS))
 
 TRUTH_BY_KEYS = ('unrouted', 'broken', 'drc', 'undersized', 'floorplan',
                  'assembly', 'impedance', 'length', 'net_widths')
@@ -441,6 +466,24 @@ def predictors_from_handoff(handoff):
         if not found:
             pred[name] = None
             gaps.append('checklist.' + '.'.join(path))
+        else:
+            pred[name] = val
+    #: #709. A recorded handoff has no `pockets` block -- render_placement does
+    #: not compute one -- so these land as gaps and `board_rho` drops the row
+    #: for them BY NAME with the resulting n. That is the honest reading: the
+    #: document does not contain the measurement. The dig is written anyway so
+    #: a future handoff that DOES carry one is read rather than ignored.
+    for name, path, legacy in POCKET_SCALARS:
+        val, found = _dig(handoff, path)
+        if not found:
+            for alt in legacy:
+                val, found = _dig(handoff, (alt,) + tuple(path[1:]))
+                if found:
+                    aliases[name] = alt
+                    break
+        if not found:
+            pred[name] = None
+            gaps.append('.'.join(path))
         else:
             pred[name] = val
     return pred, gaps, aliases, unknown

--- a/tests/stress/harvest_predictor_rows.py
+++ b/tests/stress/harvest_predictor_rows.py
@@ -139,11 +139,15 @@ CHECKLIST_SCALARS = (
 #: They are here because #703's comment asked the right question of them: a
 #: congestion census has to EARN its place against legality counts already
 #: sitting at median rho +0.785 on 6/6 boards, and the cheap way to know is a
-#: column in the study rather than an argument. Note which scalars: the HOT
-#: ranking is a known constant predictor -- `rank_stats` records that
-#: check_pockets produced an empty ranked list on three of five real boards,
-#: and a constant contributes nothing to a sign test. The COLD ones exist on
-#: every board, which is precisely what makes them askable.
+#: column in the study rather than an argument.
+#:
+#: On which scalars: the HOT ranking is bounded below by the >= 2-net rule and
+#: can empty out, where the COLD ones are defined on every board. Stated that
+#: way deliberately -- `rank_stats` asserts an empty ranked list on three of
+#: five real boards but names none of them and cites no committed measurement,
+#: and re-measured at HEAD the ranked list is NON-empty on all 8
+#: study/calibration boards (esp_prog 15 rows, glasgow_revC 242), so the
+#: causal clause is not one to repeat.
 #:
 #: No recorded handoff carries these, so on harvested rows they land as
 #: `schema_gaps` and `board_rho` drops them by name with its count. That is

--- a/tests/stress/predictor_study.py
+++ b/tests/stress/predictor_study.py
@@ -465,6 +465,36 @@ def predictors_for(board_path):
         if fnd.get('courtyard_census_error'):
             gaps.append(f'legality.courtyard_census_error='
                         f'{fnd["courtyard_census_error"]}')
+
+    # The pocket census (#709). SEPARATE from the placement model on purpose:
+    # it is the aggregate question -- how much of the board is EMPTY, and does
+    # the part mass sit where the demand does -- which the per-part legality
+    # checklist structurally does not ask.
+    #
+    # #703's comment set the bar and it is the right one: this family has to
+    # earn its place against legality counts already at median rho +0.785 on
+    # 6/6 boards. Adding the columns is what makes that answerable by the
+    # per-board sign test instead of by argument. Note the CHOICE of scalars:
+    # the hot ranking is a known constant predictor (rank_stats records an
+    # empty ranked list on three of five real boards), and a constant
+    # contributes nothing to a sign test; the cold ones exist on every board.
+    #
+    # A failure here is recorded as a gap with its exception and every key
+    # stays None -- never 0, which would be a measurement.
+    try:
+        import check_pockets as _cp
+        _doc, _hot = _cp.pocket_census(pcb, board_path)
+        _arr = _doc.get('arrangement') or {}
+        _side = (_arr.get('sides') or {}).get(_arr.get('headline_side')) or {}
+        _off = (_side.get('offset_frac_span') or [None, None])[0]
+        pred['cold_area_frac'] = _doc.get('cold_area_frac')
+        pred['cold_regions'] = len(_doc.get('cold_regions') or [])
+        _top = (_doc.get('cold_regions') or [{}])[0]
+        pred['cold_top_area_mm2'] = _top.get('area_mm2')
+        pred['centroid_offset_frac'] = _off
+    except Exception as e:                                      # noqa: BLE001
+        gaps.append(f'pockets:{type(e).__name__}: {e}')
+
     for k, v in list(pred.items()):
         if v is None and f'metrics.{k}' not in gaps:
             gaps.append(f'predictor.{k}')

--- a/tests/stress/predictor_study.py
+++ b/tests/stress/predictor_study.py
@@ -474,26 +474,40 @@ def predictors_for(board_path):
     # #703's comment set the bar and it is the right one: this family has to
     # earn its place against legality counts already at median rho +0.785 on
     # 6/6 boards. Adding the columns is what makes that answerable by the
-    # per-board sign test instead of by argument. Note the CHOICE of scalars:
-    # the hot ranking is a known constant predictor (rank_stats records an
-    # empty ranked list on three of five real boards), and a constant
-    # contributes nothing to a sign test; the cold ones exist on every board.
+    # per-board sign test instead of by argument.
     #
-    # A failure here is recorded as a gap with its exception and every key
-    # stays None -- never 0, which would be a measurement.
+    # On the CHOICE of scalars: the hot ranking is the weaker candidate, not
+    # because of any measurement I can point at -- `rank_stats` asserts an
+    # empty ranked list on three of five boards but names none of them, and at
+    # HEAD the ranked list is NON-empty on all 8 study/calibration boards
+    # (esp_prog 15 rows, glasgow_revC 242) -- but because it is bounded below
+    # by the >= 2-net rule and can empty out, where the cold scalars are
+    # defined on every board. That is the honest form of the argument.
+    #
+    # A failure is recorded as a gap with its exception and every key stays
+    # None -- never a number. Computed into a LOCAL and assigned only once the
+    # whole block has succeeded, because a partial failure that had already
+    # written two of four keys shipped real-looking values from a census that
+    # did not finish, and `board_rho` drops only None/NaN.
     try:
         import check_pockets as _cp
         _doc, _hot = _cp.pocket_census(pcb, board_path)
-        _arr = _doc.get('arrangement') or {}
-        _side = (_arr.get('sides') or {}).get(_arr.get('headline_side')) or {}
-        _off = (_side.get('offset_frac_span') or [None, None])[0]
-        pred['cold_area_frac'] = _doc.get('cold_area_frac')
-        pred['cold_regions'] = len(_doc.get('cold_regions') or [])
-        _top = (_doc.get('cold_regions') or [{}])[0]
-        pred['cold_top_area_mm2'] = _top.get('area_mm2')
-        pred['centroid_offset_frac'] = _off
+        _sc = _cp.census_scalars(_doc)
+        _pock = {
+            'cold_area_frac': _sc.get('cold_area_frac'),
+            'cold_regions': _sc.get('cold_regions'),
+            'cold_top_area_mm2': _sc.get('cold_top_area_mm2'),
+            # The MAGNITUDE, not the X term: the study's own `translate` and
+            # `wrong_side` damage kinds move mass in Y, and an X-only column
+            # is blind to them. Measured on esp_prog, translating every
+            # footprint +10mm in Y leaves the X term at 0.0127 while the Y
+            # term goes 0.0581 -> 0.7478.
+            'centroid_offset_frac': _sc.get('centroid_offset_frac'),
+        }
     except Exception as e:                                      # noqa: BLE001
         gaps.append(f'pockets:{type(e).__name__}: {e}')
+    else:
+        pred.update(_pock)
 
     for k, v in list(pred.items()):
         if v is None and f'metrics.{k}' not in gaps:

--- a/tests/test_709_arrangement_census.py
+++ b/tests/test_709_arrangement_census.py
@@ -161,15 +161,70 @@ def t_quadrants_join_mass_to_demand():
     report('distinct nets never exceed net-windows of demand',
            all(q['distinct_nets'] <= q['demand_nets'] for q in quads.values()),
            str([(q['distinct_nets'], q['demand_nets']) for q in quads.values()]))
-    report('quadrant part counts total the footprints on the board',
-           sum(q['parts'] for q in quads.values())
-           == len(parse_kicad_pcb(board('esp_prog')).footprints),
-           str(sum(q['parts'] for q in quads.values())))
+    # The footprints a PLACER would see, which is not every footprint: a
+    # graphic-only one (no courtyard, no pads) is the +/-0.5mm fiction and is
+    # absent from the quench's own part set too.
+    report('quadrant part counts total the WEIGHED parts, not every footprint',
+           sum(q['parts'] for q in quads.values()) == doc['parts']['weighed']
+           < len(parse_kicad_pcb(board('esp_prog')).footprints),
+           '%d quadrant / %d weighed / %d footprints'
+           % (sum(q['parts'] for q in quads.values()),
+              doc['parts']['weighed'],
+              len(parse_kicad_pcb(board('esp_prog')).footprints)))
     report('cold windows are attributed to quadrants too',
            sum(q['cold_windows'] for q in quads.values())
            == doc['cold_windows'],
            '%d vs %d' % (sum(q['cold_windows'] for q in quads.values()),
                          doc['cold_windows']))
+
+
+def t_the_quadrant_counts_are_the_block_region_qN_would_move():
+    """The printed count must be `_region_unit`'s OWN membership, not a
+    lookalike -- otherwise `--block region:q0` moves a different set than the
+    census named, which makes the whole "reseat target" claim false.
+
+    So this CALLS `_region_unit` rather than mirroring its rule.
+    """
+    from placement.perturb import _region_unit
+    from placement import quench as Q
+    p = board('esp_prog')
+    pcb = parse_kicad_pcb(p)
+    doc, _hot = census('esp_prog')
+    quads = {q['index']: q for q in doc['arrangement']['quadrants']}
+    try:
+        state = Q.build_state(pcb, p) if hasattr(Q, 'build_state') else None
+    except Exception:                                           # noqa: BLE001
+        state = None
+    if state is None:
+        from pose_score import make_state
+        state = make_state(pcb, p)
+    free = set(state.parts)
+    bounds = pcb.board_info.board_bounds
+    total_picked = 0
+    for q in range(4):
+        pick = _region_unit(state, free, pcb, q)
+        members = list(pick.members) if pick else []
+        total_picked += len(members)
+        # The geometric rule must AGREE: every ref region:qN picks has to land
+        # in the census's quadrant N. Bucketing by courtyard centre instead of
+        # footprint origin breaks this on any part whose courtyard is not
+        # centred on its origin.
+        stray = [r for r in members
+                 if CP.quadrant_of(pcb.footprints[r].x, pcb.footprints[r].y,
+                                   bounds) != q]
+        report('region:q%d picks nothing the census puts elsewhere' % q,
+               not stray, str(stray))
+        # ...and the census count is an upper bound: it cannot know which
+        # parts a given run locks, but it must never UNDER-count.
+        report('  census %s (%d) >= region:q%d membership (%d)'
+               % (CP.QUADRANTS[q], quads[q]['parts'], q, len(members)),
+               quads[q]['parts'] >= len(members))
+    # On esp_prog nothing is locked, so the two totals meet exactly -- which
+    # is what caught the census counting three graphic-only footprints as
+    # parts (20 against 17).
+    report('esp_prog: nothing locked, so the totals meet exactly',
+           sum(q['parts'] for q in quads.values()) == total_picked,
+           '%d vs %d' % (sum(q['parts'] for q in quads.values()), total_picked))
 
 
 def t_the_quadrant_split_is_perturb_s_own():
@@ -233,6 +288,16 @@ def t_it_refuses_rather_than_inventing_when_there_is_no_span():
            'board_bounds' in (doc.get('skipped') or ''), str(doc.get('skipped')))
     report('  ...and the hot rows still come out',
            doc['windows_demand'] > 0, str(doc['windows_demand']))
+    # ...and the refusal lives in arrangement_census itself, not only in the
+    # caller that happens to short-circuit first. Reached directly, because a
+    # guard only the caller protects is a guard that disappears the moment
+    # someone adds a second caller.
+    from placement import legality as leg
+    report('arrangement_census refuses bounds=None on its own',
+           CP.arrangement_census(pcb, [], set(), {}, 2.0, None, leg) is None)
+    report('  ...and refuses an EMPTY part set rather than dividing by zero',
+           CP.arrangement_census(pcb, [], set(), {}, 2.0,
+                                 (0.0, 0.0, 10.0, 10.0), leg) is None)
 
 
 def t_no_arrangement_switch():
@@ -270,6 +335,8 @@ TESTS = [
     ('synthetic parts excluded', t_synthetic_parts_are_excluded_and_counted),
     ('sides stay separate', t_sides_are_separate_never_summed),
     ('quadrants join mass to demand', t_quadrants_join_mass_to_demand),
+    ('quadrant counts == region:qN membership',
+     t_the_quadrant_counts_are_the_block_region_qN_would_move),
     ("the split is perturb's own", t_the_quadrant_split_is_perturb_s_own),
     ('degrades on a courtyard-free board',
      t_it_degrades_on_a_board_with_no_courtyards_and_says_so),
@@ -280,11 +347,30 @@ TESTS = [
 ]
 
 
+def _every_case_is_registered():
+    """A `t_*` defined and left out of TESTS is a test that never runs.
+
+    That happened here once, to the row that pins the quadrant counts against
+    `_region_unit`. The mutation battery is what noticed, which is a long way
+    round for something the module can check on itself in three lines.
+    """
+    g = globals()
+    declared = {fn for _l, fn in TESTS}
+    missing = sorted(n for n, v in g.items()
+                     if n.startswith('t_') and callable(v)
+                     and v not in declared)
+    if missing:
+        print('  FAIL  every t_* case is registered in TESTS  -- ORPHANED: %s'
+              % ', '.join(missing))
+        FAILURES.append('unregistered cases: %s' % ', '.join(missing))
+
+
 def main():
     print('arrangement census (#709)')
     for label, fn in TESTS:
         print(' ' + label)
         fn()
+    _every_case_is_registered()
     if FAILURES:
         print('\nFAILED (%d): %s' % (len(FAILURES), ', '.join(FAILURES)))
         return 1

--- a/tests/test_709_arrangement_census.py
+++ b/tests/test_709_arrangement_census.py
@@ -404,10 +404,37 @@ def t_a_through_hole_part_covers_BOTH_sides():
     tht = [g for g in graded if len(g.sides) == 2]
     report('the fixture really has through-hole parts', len(tht) > 3,
            '%d of %d' % (len(tht), len(graded)))
-    # Assert the PROPERTY, not a board-dependent count: a behavioural probe
-    # only bites where some window happens to sit in the difference, and on
-    # sonde_u at --cold-cover 0.5 none does (483 either way), so a count
-    # comparison would be a green row that proves nothing.
+    # Assert it on the COVER MAP, which is where the loop lives. A
+    # cold-window count cannot see it: charging `gp.side` only differs from
+    # charging both faces where a B-side part ALSO covers the window and the
+    # far-side sum overtakes the near one, and no in-repo board has such a
+    # window at any --cold-cover (measured on 7 boards x 4 thresholds). A
+    # count comparison would be a green row that proves nothing, which is
+    # exactly what the first version of this case was.
+    from placement import legality as leg2
+    win = {}
+    for g in tht[:1] + [x for x in graded if len(x.sides) == 1][:1]:
+        import math as _m
+        for bx in range(int(_m.floor(g.rect[0] / 2.0)),
+                        int(_m.ceil(g.rect[2] / 2.0))):
+            for by in range(int(_m.floor(g.rect[1] / 2.0)),
+                            int(_m.ceil(g.rect[3] / 2.0))):
+                win[(bx, by)] = 1.0
+    cov = CP.courtyard_cover(tht[:1], set(), win, 2.0, leg2)
+    charged = [v for v in cov.values() if v['F'] > 0 or v['B'] > 0]
+    report('a THT part charges cover to BOTH faces', bool(charged)
+           and all(v['F'] > 0 and v['B'] > 0 for v in charged),
+           str(charged[:1]))
+    smd1 = [x for x in graded if len(x.sides) == 1]
+    if smd1:
+        cov2 = CP.courtyard_cover(smd1[:1], set(), win, 2.0, leg2)
+        touched2 = [v for v in cov2.values() if v['F'] > 0 or v['B'] > 0]
+        report('  ...and a single-sided part charges exactly one',
+               all((v['F'] > 0) != (v['B'] > 0) for v in touched2),
+               str(touched2[:1]))
+    report('  ...and a container is charged nothing at all',
+           CP.courtyard_cover(tht[:1], {tht[0].ref}, win, 2.0, leg2) == {})
+
     one = [g for g in tht][0]
     report('_side_key gives a through-hole part BOTH faces',
            CP._side_key(one) == frozenset(('F', 'B')),

--- a/tests/test_709_arrangement_census.py
+++ b/tests/test_709_arrangement_census.py
@@ -325,8 +325,15 @@ def t_the_reseat_target_is_a_target_not_a_weight():
         return
     report('it names the top cold region',
            rt['region_bbox'] == doc['cold_regions'][0]['bbox'])
-    report('its --reseat-region argument IS the band rect',
-           rt['reseat_region'] == rt['band_rect'], str(rt['reseat_region']))
+    # NOT a --reseat-region argument: a cold band holds no part by
+    # construction, so that command resolved to an empty scope on every board.
+    # It is a `zone` -- a DESTINATION -- clipped to the board.
+    report('it advertises no --reseat-region argument',
+           'reseat_region' not in rt, str(sorted(rt)))
+    report('it names a zone, clipped inside the band rect',
+           rt['zone'][0] >= rt['band_rect'][0] - 1e-6
+           and rt['zone'][2] <= rt['band_rect'][2] + 1e-6,
+           '%s vs %s' % (rt['zone'], rt['band_rect']))
     report('it points AWAY from where the mass already is',
            rt['move_mass_toward'] in ('N', 'S', 'E', 'W', 'NE', 'NW', 'SE',
                                       'SW', 'centre', None),
@@ -337,6 +344,104 @@ def t_the_reseat_target_is_a_target_not_a_weight():
     report('  ...and that direction is the negated mass offset',
            rt['move_mass_toward'] == want,
            '%s vs %s' % (rt['move_mass_toward'], want))
+
+
+def t_the_container_guard_is_pinned_on_the_board_it_fires_on():
+    """`rp2350_fpga_eensy_prePlane`'s U8 is the only container in the corpus.
+
+    Three mutations survived the whole battery here -- "never exclude",
+    "exclude on area alone", and "put containers back into the centroid" --
+    because no test censused the ONE board where the guard fires. It is a live
+    guard, not a dead one, and the suite could not tell the difference.
+    """
+    p = os.path.join(ROOT, 'kicad_files', 'rp2350_fpga_eensy_prePlane.kicad_pcb')
+    if not os.path.isfile(p):
+        report('rp2350 fixture present', False, 'missing')
+        return
+    doc, _hot = CP.pocket_census(parse_kicad_pcb(p), p)
+    parts = doc['parts']
+    report('the guard FIRES on this board -- exactly one container',
+           parts['container_excluded'] == 1, str(parts))
+    report('  ...and names it', parts['containers'] == ['U8'],
+           str(parts['containers']))
+    report('  ...and the guard is the hosting one, not bare area',
+           parts['container_guard'] == 'options.hosts_the_design',
+           str(parts['container_guard']))
+    report('  ...and the excluded part is out of the weighed set',
+           parts['weighed'] == len([1]) * 0 + parts['graded']
+           - parts['synthetic_excluded'] - 1,
+           str(parts))
+
+    # The centroid must MOVE when the container is put back, or "exclude
+    # containers" is a claim no number depends on.
+    from placement import options as opts
+    real = opts.hosts_the_design
+    try:
+        opts.hosts_the_design = lambda *a, **k: False
+        loose, _h = CP.pocket_census(parse_kicad_pcb(p), p)
+    finally:
+        opts.hosts_the_design = real
+    report('  ...and putting it back changes the answer',
+           loose['parts']['container_excluded'] == 0
+           and (loose['arrangement']['sides'][loose['arrangement']
+                                              ['headline_side']]
+                ['courtyard_area_mm2']
+                != doc['arrangement']['sides'][doc['arrangement']
+                                               ['headline_side']]
+                ['courtyard_area_mm2']),
+           'excluded=%s' % loose['parts']['container_excluded'])
+
+
+def t_a_through_hole_part_covers_BOTH_sides():
+    """`GradedPart.sides` gives a THT part both faces, and the cover map has
+    to charge both -- otherwise a window under a through-hole part's courtyard
+    reads uncovered on the far side. A mutation replacing the `for s in
+    _side_key(gp)` loop with `slot[gp.side]` survived the whole battery."""
+    p = board('sonde_u')
+    pcb = parse_kicad_pcb(p)
+    from placement import legality as leg
+    graded = [g for g in leg.graded_parts_from_file(pcb, p) if not g.synthetic]
+    tht = [g for g in graded if len(g.sides) == 2]
+    report('the fixture really has through-hole parts', len(tht) > 3,
+           '%d of %d' % (len(tht), len(graded)))
+    # Assert the PROPERTY, not a board-dependent count: a behavioural probe
+    # only bites where some window happens to sit in the difference, and on
+    # sonde_u at --cold-cover 0.5 none does (483 either way), so a count
+    # comparison would be a green row that proves nothing.
+    one = [g for g in tht][0]
+    report('_side_key gives a through-hole part BOTH faces',
+           CP._side_key(one) == frozenset(('F', 'B')),
+           '%s -> %s' % (one.ref, sorted(CP._side_key(one))))
+    smd = [g for g in graded if len(g.sides) == 1]
+    report('  ...and an SMD part exactly one', bool(smd)
+           and len(CP._side_key(smd[0])) == 1,
+           '%s -> %s' % (smd[0].ref, sorted(CP._side_key(smd[0]))) if smd
+           else 'no SMD part')
+    report('  ...which is legality.sides_occupied, not a local rule',
+           all(CP._side_key(g) == g.sides for g in graded[:20]))
+
+
+def t_the_side_rule_is_max_not_sum():
+    """"A clear empty pocket" means empty on BOTH sides, so the disqualifier
+    is `max(cover_F, cover_B)`. Summing them double-counts a through-hole part
+    and disqualifies windows a single side never covered. A mutation swapping
+    max for + survived the battery."""
+    p = board('sonde_u')
+    doc, _h = CP.pocket_census(parse_kicad_pcb(p), p, cold_cover=0.5)
+    import check_pockets as _cp
+    src = open(os.path.join(ROOT, 'py_tools', 'check_pockets.py'),
+               encoding='utf-8').read()
+    report('the source really uses max over the two sides',
+           "max(c.get('F', 0.0), c.get('B', 0.0))" in src)
+    # Behavioural: a window covered 0.3 on each side is cold under max at
+    # --cold-cover 0.4 and warm under sum. Build that case directly.
+    cover = {'F': 0.3, 'B': 0.3}
+    report('  max keeps a both-sides-lightly-covered window cold',
+           max(cover['F'], cover['B']) <= 0.4)
+    report('  ...where a sum would disqualify it',
+           cover['F'] + cover['B'] > 0.4)
+    report('  and the census is non-trivial on this board',
+           doc['cold_windows'] > 0, str(doc['cold_windows']))
 
 
 TESTS = [
@@ -354,6 +459,12 @@ TESTS = [
     ('refuses without a span',
      t_it_refuses_rather_than_inventing_when_there_is_no_span),
     ('--no-arrangement', t_no_arrangement_switch),
+    ('the container guard, pinned',
+     t_the_container_guard_is_pinned_on_the_board_it_fires_on),
+    ('a THT part covers both sides',
+     t_a_through_hole_part_covers_BOTH_sides),
+    ('the side rule is max, not sum',
+     t_the_side_rule_is_max_not_sum),
     ('the reseat target', t_the_reseat_target_is_a_target_not_a_weight),
 ]
 

--- a/tests/test_709_arrangement_census.py
+++ b/tests/test_709_arrangement_census.py
@@ -1,0 +1,296 @@
+"""The arrangement census: where the mass sits against where the demand sits.
+
+The pockets census put every demand-3 window at one end of run 23's board
+while the part mass sat at the other, and no instrument said so. This is the
+join, plus the caution #709 measured and that is easy to get backwards: the
+centroid must be weighted by COURTYARD AREA, not by part count. The count form
+is the intuitive one and it points the wrong way -- on esp_prog it reads 13.7%
+of span where the area form reads 1.3%.
+
+`placement_state` records the standing objection to courtyard-area metrics --
+"needs polygon area and breaks on the boards with no courtyards at all". B6
+below discharges it as a test rather than as an argument: with the courtyard
+parser returning nothing, the census keeps working off pad copper and SAYS
+that is what it did.
+"""
+
+import math
+import os
+import sys
+
+RUN_ALL_FAST_OK = True
+RUN_ALL_TIMEOUT = 300
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for _d in ('py_router', 'py_placer', 'py_tools'):
+    sys.path.insert(0, os.path.join(ROOT, _d))
+
+from kicad_parser import parse_kicad_pcb                       # noqa: E402
+import check_pockets as CP                                     # noqa: E402
+
+FAILURES = []
+
+
+def report(name, ok, detail=''):
+    print(('  PASS  ' if ok else '  FAIL  ') + name
+          + (('  -- ' + detail) if detail else ''))
+    if not ok:
+        FAILURES.append(name)
+
+
+def board(name):
+    p = os.path.join(ROOT, 'kicad_files', name + '.kicad_pcb')
+    assert os.path.isfile(p) and os.path.getsize(p) > 0, p
+    return p
+
+
+_CACHE = {}
+
+
+def census(name, **kw):
+    key = (name, tuple(sorted(kw.items())))
+    if key not in _CACHE:
+        p = board(name)
+        _CACHE[key] = CP.pocket_census(parse_kicad_pcb(p), p, **kw)
+    return _CACHE[key]
+
+
+def t_area_weighting_and_the_count_control_disagree():
+    """B1: the whole reason the issue warns about this.
+
+    Setting the weight to 1.0 collapses the two forms onto each other and the
+    separation assertion goes red. esp_prog is the board the issue measured.
+    """
+    doc, _hot = census('esp_prog')
+    arr = doc['arrangement']
+    s = arr['sides'][arr['headline_side']]
+    area_x = s['offset_frac_span'][0]
+    count_x = s['count_control_frac_span'][0]
+    report('esp_prog: the area form is ~1.3% of span',
+           abs(area_x - 0.013) < 0.004, 'got %.4f' % area_x)
+    report('esp_prog: the count control is ~13.7% of span',
+           abs(count_x - 0.137) < 0.008, 'got %.4f' % count_x)
+    report('the two forms differ by more than 4x -- they are NOT the same '
+           'statistic', count_x > 4 * area_x, '%.4f vs %.4f' % (count_x, area_x))
+    report('the weight is declared, not implied',
+           arr['weight'] == 'courtyard_area', arr['weight'])
+
+
+def t_the_two_forms_differ_across_the_corpus():
+    """Not a one-board coincidence, and not always in the same direction.
+
+    Recording the direction matters: on splitflap_driver and sonde_u the AREA
+    form is the larger one, so "area weighting always flatters the board" is
+    not what this is.
+    """
+    seen = []
+    for name in ('esp_prog', 'tigard', 'splitflap_driver', 'watchy',
+                 'sonde_u', 'glasgow_revC'):
+        arr = census(name)[0]['arrangement']
+        s = arr['sides'][arr['headline_side']]
+        seen.append((name, s['offset_frac_span'][0],
+                     s['count_control_frac_span'][0]))
+    differ = [n for n, a, c in seen if abs(a - c) > 0.005]
+    report('the two forms disagree on most boards, not just one',
+           len(differ) >= 4, '%d of %d: %s' % (len(differ), len(seen), differ))
+    both_ways = ({n for n, a, c in seen if a > c + 0.005}
+                 and {n for n, a, c in seen if c > a + 0.005})
+    report('and they disagree in BOTH directions', bool(both_ways),
+           str([(n, round(a, 3), round(c, 3)) for n, a, c in seen]))
+
+
+def t_synthetic_parts_are_excluded_and_counted():
+    """B2: the +/-0.5mm fiction is not geometry anyone drew."""
+    doc, _hot = census('esp_prog')
+    p = doc['parts']
+    report('esp_prog: 3 synthetic parts excluded',
+           p['synthetic_excluded'] == 3, str(p['synthetic_excluded']))
+    report('the weighed count is graded minus synthetic minus containers',
+           p['weighed'] == p['graded'] - p['synthetic_excluded']
+           - p['container_excluded'],
+           str(p))
+    for name in ('splitflap_driver', 'sonde_u'):
+        report('%s: no synthetic parts at all' % name,
+               census(name)[0]['parts']['synthetic_excluded'] == 0)
+
+
+def t_sides_are_separate_never_summed():
+    """B3: utilisation is per-side; summing two sides is a recorded error."""
+    doc, _hot = census('esp_prog')
+    arr = doc['arrangement']
+    # A through-hole part occupies BOTH sides -- its leads really are on B --
+    # so a board with no B-side SMD still reports a B side, with less area.
+    # Summing the two would double-count exactly those parts.
+    report('esp_prog reports both sides, F carrying the mass',
+           set(arr['sides']) == {'F', 'B'}
+           and arr['sides']['F']['courtyard_area_mm2']
+           > arr['sides']['B']['courtyard_area_mm2'],
+           str({s: v['courtyard_area_mm2'] for s, v in arr['sides'].items()}))
+    total = sum(v['courtyard_area_mm2'] for v in arr['sides'].values())
+    biggest = max(v['courtyard_area_mm2'] for v in arr['sides'].values())
+    report('  ...and the headline is a SIDE total, never the sum of both',
+           total > biggest, '%.1f summed vs %.1f headline' % (total, biggest))
+    report('the headline side is the one with the most courtyard area',
+           arr['headline_side'] == max(
+               arr['sides'], key=lambda s: arr['sides'][s]['courtyard_area_mm2']))
+    two = [n for n in ('watchy', 'tigard', 'glasgow_revC')
+           if len(census(n)[0]['arrangement']['sides']) == 2]
+    report('at least one corpus board really is two-sided', bool(two), str(two))
+    for n in two:
+        arr = census(n)[0]['arrangement']
+        report('  %s: each side has its own centroid, not a shared one' % n,
+               arr['sides']['F']['offset_mm'] != arr['sides']['B']['offset_mm'])
+
+
+def t_quadrants_join_mass_to_demand():
+    """B4: the join nobody made -- and the count/area discrepancy is DELIBERATE.
+
+    NW on esp_prog holds 12 net-windows of demand and one part origin, while
+    carrying real courtyard area from parts whose ORIGIN is elsewhere. Both
+    numbers are reported because they answer different questions: the count
+    names the block `--block region:qN` would move, the area is the mass.
+    """
+    doc, _hot = census('esp_prog')
+    quads = {q['name']: q for q in doc['arrangement']['quadrants']}
+    report('all four quadrants are present and named',
+           list(quads) == ['NW', 'NE', 'SW', 'SE'], str(list(quads)))
+    nw = quads['NW']
+    report('NW carries demand', nw['demand_nets'] >= 10, str(nw['demand_nets']))
+    report('NW carries courtyard area from parts seated elsewhere',
+           nw['part_area_mm2'] > 0 and nw['parts'] <= 1, str(nw))
+    report('distinct nets never exceed net-windows of demand',
+           all(q['distinct_nets'] <= q['demand_nets'] for q in quads.values()),
+           str([(q['distinct_nets'], q['demand_nets']) for q in quads.values()]))
+    report('quadrant part counts total the footprints on the board',
+           sum(q['parts'] for q in quads.values())
+           == len(parse_kicad_pcb(board('esp_prog')).footprints),
+           str(sum(q['parts'] for q in quads.values())))
+    report('cold windows are attributed to quadrants too',
+           sum(q['cold_windows'] for q in quads.values())
+           == doc['cold_windows'],
+           '%d vs %d' % (sum(q['cold_windows'] for q in quads.values()),
+                         doc['cold_windows']))
+
+
+def t_the_quadrant_split_is_perturb_s_own():
+    """The numbering is `region:qN`'s, or the printed name is a lie."""
+    from placement.perturb import _region_unit                  # noqa: F401
+    b = (0.0, 0.0, 10.0, 10.0)
+    got = [CP.quadrant_of(x, y, b) for x, y in
+           ((1, 1), (9, 1), (1, 9), (9, 9))]
+    report('0=NW 1=NE 2=SW 3=SE', got == [0, 1, 2, 3], str(got))
+    report('the midline is half-open toward the high side',
+           CP.quadrant_of(5.0, 5.0, b) == 3
+           and CP.quadrant_of(4.999, 4.999, b) == 0)
+    report('the names line up with the indices',
+           CP.QUADRANTS == ('NW', 'NE', 'SW', 'SE'))
+
+
+def t_it_degrades_on_a_board_with_no_courtyards_and_says_so():
+    """B6: `placement_state`'s recorded objection, discharged.
+
+    With the courtyard parser returning nothing, every part falls back to its
+    PAD bbox -- real copper, not a fiction -- and the census reports which of
+    the two it used. Raising, or silently reporting the fiction, both fail.
+    """
+    import placement.parser as PP
+    real = PP.extract_courtyard_sides
+    try:
+        PP.extract_courtyard_sides = lambda *_a, **_k: {}
+        p = board('cap_chain')
+        doc, _hot = CP.pocket_census(parse_kicad_pcb(p), p)
+    finally:
+        PP.extract_courtyard_sides = real
+    arr = doc['arrangement']
+    report('a courtyard-free board still produces an arrangement',
+           arr is not None)
+    if arr is None:
+        return
+    s = arr['sides'][arr['headline_side']]
+    report('  its offset is a real finite number',
+           all(isinstance(v, float) and math.isfinite(v)
+               for v in s['offset_mm']), str(s['offset_mm']))
+    p_ = doc['parts']
+    report('  and the census SAYS it measured pad copper, not courtyards',
+           p_['from_courtyard'] == 0 and p_['from_pads'] == p_['graded'],
+           str(p_))
+    report('  a pad bbox is not counted synthetic (it is real copper)',
+           p_['synthetic_excluded'] == 0, str(p_['synthetic_excluded']))
+    live = census('cap_chain')[0]['parts']
+    report('  ...while the unpatched run does read the drawn courtyards',
+           live['from_courtyard'] == live['graded'], str(live))
+
+
+def t_it_refuses_rather_than_inventing_when_there_is_no_span():
+    """The one genuine refusal: no board_bounds means no centre to measure."""
+    p = board('cap_chain')
+    pcb = parse_kicad_pcb(p)
+    pcb.board_info.board_bounds = None
+    doc, _hot = CP.pocket_census(pcb, p)
+    report('no bounds -> arrangement is None, never 0.0',
+           doc['arrangement'] is None)
+    report('  ...and the refusal names its reason',
+           'board_bounds' in (doc.get('skipped') or ''), str(doc.get('skipped')))
+    report('  ...and the hot rows still come out',
+           doc['windows_demand'] > 0, str(doc['windows_demand']))
+
+
+def t_no_arrangement_switch():
+    doc, _hot = census('esp_prog', arrangement=False)
+    report('--no-arrangement suppresses it without touching the cold census',
+           doc['arrangement'] is None and doc['cold_windows'] is not None)
+
+
+def t_the_reseat_target_is_a_target_not_a_weight():
+    doc, _hot = census('esp_prog')
+    rt = doc['reseat_target']
+    report('a reseat target is produced', rt is not None)
+    if rt is None:
+        return
+    report('it names the top cold region',
+           rt['region_bbox'] == doc['cold_regions'][0]['bbox'])
+    report('its --reseat-region argument IS the band rect',
+           rt['reseat_region'] == rt['band_rect'], str(rt['reseat_region']))
+    report('it points AWAY from where the mass already is',
+           rt['move_mass_toward'] in ('N', 'S', 'E', 'W', 'NE', 'NW', 'SE',
+                                      'SW', 'centre', None),
+           str(rt['move_mass_toward']))
+    arr = doc['arrangement']
+    dx, dy = arr['sides'][arr['headline_side']]['offset_mm']
+    want = CP._compass(-dx, -dy)
+    report('  ...and that direction is the negated mass offset',
+           rt['move_mass_toward'] == want,
+           '%s vs %s' % (rt['move_mass_toward'], want))
+
+
+TESTS = [
+    ('area weighting vs the count control',
+     t_area_weighting_and_the_count_control_disagree),
+    ('the two forms across the corpus', t_the_two_forms_differ_across_the_corpus),
+    ('synthetic parts excluded', t_synthetic_parts_are_excluded_and_counted),
+    ('sides stay separate', t_sides_are_separate_never_summed),
+    ('quadrants join mass to demand', t_quadrants_join_mass_to_demand),
+    ("the split is perturb's own", t_the_quadrant_split_is_perturb_s_own),
+    ('degrades on a courtyard-free board',
+     t_it_degrades_on_a_board_with_no_courtyards_and_says_so),
+    ('refuses without a span',
+     t_it_refuses_rather_than_inventing_when_there_is_no_span),
+    ('--no-arrangement', t_no_arrangement_switch),
+    ('the reseat target', t_the_reseat_target_is_a_target_not_a_weight),
+]
+
+
+def main():
+    print('arrangement census (#709)')
+    for label, fn in TESTS:
+        print(' ' + label)
+        fn()
+    if FAILURES:
+        print('\nFAILED (%d): %s' % (len(FAILURES), ', '.join(FAILURES)))
+        return 1
+    print('\nOK')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_709_arrangement_census.py
+++ b/tests/test_709_arrangement_census.py
@@ -293,10 +293,21 @@ def t_it_refuses_rather_than_inventing_when_there_is_no_span():
     # guard only the caller protects is a guard that disappears the moment
     # someone adds a second caller.
     from placement import legality as leg
-    report('arrangement_census refuses bounds=None on its own',
-           CP.arrangement_census(pcb, [], set(), {}, 2.0, None, leg) is None)
+    # With REAL parts, so the refusal cannot be masked by the empty-sides
+    # path: a version that invents (0,0,1,1) instead of refusing returns a
+    # populated document here, and this row goes red.
+    live = parse_kicad_pcb(p)
+    parts = [g for g in leg.graded_parts_from_file(live, p) if not g.synthetic]
+    report('the fixture has parts, so the refusal is not vacuous',
+           len(parts) >= 3, str(len(parts)))
+    report('arrangement_census refuses bounds=None on its own, WITH parts',
+           CP.arrangement_census(live, parts, set(), {}, 2.0, None, leg)
+           is None)
+    report('  ...and still answers when bounds ARE given (the control)',
+           CP.arrangement_census(live, parts, set(), {}, 2.0,
+                                 live.board_info.board_bounds, leg) is not None)
     report('  ...and refuses an EMPTY part set rather than dividing by zero',
-           CP.arrangement_census(pcb, [], set(), {}, 2.0,
+           CP.arrangement_census(live, [], set(), {}, 2.0,
                                  (0.0, 0.0, 10.0, 10.0), leg) is None)
 
 

--- a/tests/test_709_cold_windows.py
+++ b/tests/test_709_cold_windows.py
@@ -537,6 +537,49 @@ def t_the_lattice_survives_inexact_float_division():
                    str(doc['windows_offboard']))
 
 
+def t_the_swept_test_is_a_superset_of_the_free_area_rule():
+    """Why the cold predicate keeps two copper terms, and why one is redundant.
+
+    `congestion_bins` charges a segment to its MIDPOINT bin and a pad to its
+    CENTRE bin; the swept stamp covers a segment's whole path and a pad's whole
+    bbox, so swept should be a strict superset of "free-area says occupied".
+    Measured here across boards and bin sizes: zero counterexamples.
+
+    That is worth pinning rather than assuming, for two reasons. It is what
+    makes a mutation dropping the `free` arm an EQUIVALENT MUTANT rather than a
+    hole in the battery -- and it is the assumption under which keeping that
+    arm is a cheap cross-check on the newer, more intricate swept code instead
+    of dead weight. The day the relation stops holding, one of the two terms is
+    wrong, and this row says which direction.
+    """
+    from congestion_field import congestion_bins
+    from net_queries import expand_net_patterns
+    total = 0
+    for name in ('esp_prog', 'routed_output', 'rp2350_fpga_eensy_prePlane',
+                 'tigard', 'watchy'):
+        p = os.path.join(ROOT, 'kicad_files', name + '.kicad_pcb')
+        if not os.path.isfile(p):
+            continue
+        for bm in (2.0, 1.0):
+            pcb = parse_kicad_pcb(p)
+            layers = len(pcb.board_info.copper_layers or ['F.Cu'])
+            names = set(expand_net_patterns(pcb, ['*']))
+            ids = [n for n, v in pcb.nets.items() if v.name in names]
+            bins, _t, bm2 = congestion_bins(pcb, ids, layers, bm)
+            cap = bm2 * bm2 * layers
+            touched = CP.copper_touched_bins(pcb, bm2)
+            occupied = [k for k, (free, _o) in bins.items()
+                        if free < cap - 1e-9]
+            stray = [k for k in occupied if k not in touched]
+            total += len(occupied)
+            report('%s bin %g: every free-area-occupied bin is swept-touched'
+                   % (name, bm2), not stray,
+                   '%d of %d stray, e.g. %s' % (len(stray), len(occupied),
+                                                stray[:2]))
+    report('and the check was not vacuous -- there were bins to check',
+           total > 500, '%d occupied bins examined' % total)
+
+
 TESTS = [
     ('the defect, by the numbers', t_the_defect_itself),
     ('lattice bounds are floor/ceil', t_the_lattice_bounds_are_floor_ceil),
@@ -551,6 +594,8 @@ TESTS = [
     ('--cold-cover ladder', t_cold_cover_is_a_ladder_not_a_cliff),
     ('every number finite', t_every_number_is_finite_and_json_safe),
     ('--no-cold', t_no_cold_is_a_clean_off_switch),
+    ('swept copper subsumes the free-area rule',
+     t_the_swept_test_is_a_superset_of_the_free_area_rule),
     ('a crossing track is not cold',
      t_a_track_crossing_a_window_is_not_cold),
     ('a cold band holds no part',

--- a/tests/test_709_cold_windows.py
+++ b/tests/test_709_cold_windows.py
@@ -26,6 +26,8 @@ ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 for _d in ('py_router', 'py_placer', 'py_tools'):
     sys.path.insert(0, os.path.join(ROOT, _d))
 
+sys.path.insert(0, os.path.join(ROOT, 'tests'))
+from run_utils import check                                     # noqa: E402
 from kicad_parser import parse_kicad_pcb                       # noqa: E402
 import check_pockets as CP                                     # noqa: E402
 
@@ -103,8 +105,17 @@ def t_the_partition_holds():
         report('%s: demand + under-part + warm-unowned + cold == in-outline'
                % name, total == doc['windows_in_outline'],
                '%d vs %d' % (total, doc['windows_in_outline']))
-        report('  %s: the under-part bucket is the big one, not cold' % name,
-               doc['under_part_windows'] >= 0 and doc['cold_windows'] >= 0)
+        # Not "under-part is the biggest" -- measured, that is FALSE on
+        # watchy (86 under-part vs 150 cold) and cap_chain (12 vs 134). What
+        # IS true is that they are disjoint counts of one universe.
+        report('  %s: every bucket is a non-negative count' % name,
+               all(isinstance(doc[k], int) and doc[k] >= 0
+                   for k in ('windows_demand_in_outline', 'under_part_windows',
+                             'warm_unowned_windows', 'cold_windows')),
+               str({k: doc[k] for k in ('windows_demand_in_outline',
+                                        'under_part_windows',
+                                        'warm_unowned_windows',
+                                        'cold_windows')}))
 
 
 def t_cold_means_no_copper_not_just_no_demand():
@@ -172,8 +183,12 @@ def t_area_accounting_never_exceeds_the_region():
                if r['band_area_mm2'] > r['area_mm2'] + 1e-6]
         report('%s: no band claims more area than its region' % name,
                not bad, str(bad[:1]))
+        # 5e-4, not 1e-6: `area_mm2` is rounded to 3 decimals, so the
+        # comparison has to allow the rounding grain or it is red on
+        # glasgow_revC / orangecrab / ulx3s at --bin 0.25 for a reason that
+        # is not the claim.
         worse = [r for r in doc['cold_regions']
-                 if r['area_mm2'] > r['windows'] * doc['bin_mm'] ** 2 + 1e-6]
+                 if r['area_mm2'] > r['windows'] * doc['bin_mm'] ** 2 + 5e-4]
         report('%s: no region claims more than its windows can hold' % name,
                not worse, str(worse[:1]))
 
@@ -225,16 +240,31 @@ def t_four_connected_not_eight():
     report('a diagonal pair is two components', len(got) == 2, str(got))
     got = CP.flood_regions([(0, 0), (1, 0), (1, 1)])
     report('an L is one component', len(got) == 1, str(got))
-    report('component output is sorted, not dict-ordered',
+    # Two singletons cannot see `sorted(comp)`; an L can. Discovery order
+    # from the seed (0,0) is (0,0),(1,0),(0,1); sorted is (0,0),(0,1),(1,0).
+    report('component MEMBERS are sorted, not discovery-ordered',
+           CP.flood_regions([(0, 0), (1, 0), (0, 1)])
+           == [[(0, 0), (0, 1), (1, 0)]],
+           str(CP.flood_regions([(0, 0), (1, 0), (0, 1)])))
+    report('  ...and the components themselves are ordered too',
            CP.flood_regions([(5, 5), (0, 0)]) == [[(0, 0)], [(5, 5)]])
 
 
 def t_largest_band_is_the_maximal_rectangle():
     #  X X X
     #  X X .      the maximal all-cold rectangle is the 3x1 top row
+    #  X X X
+    #  X X .    -- the solid 2x2 (area 4) beats the 3x1 row (area 3), and
+    #              accepting EITHER answer, as the first version did, made the
+    #              flagship maximality row assert nothing.
     got = CP.largest_band([(0, 0), (1, 0), (2, 0), (0, 1), (1, 1)])
-    report('picks the 3x1 row over the 2x2 that is not solid',
-           got in ((0, 0, 2, 0), (0, 0, 1, 1)), str(got))
+    report('picks the maximal-AREA rectangle, not the longest run',
+           got == (0, 0, 1, 1), str(got))
+    #  X X X
+    #  . . .    -- now the row IS maximal.
+    report('  ...and the row when the row is maximal',
+           CP.largest_band([(0, 0), (1, 0), (2, 0)]) == (0, 0, 2, 0),
+           str(CP.largest_band([(0, 0), (1, 0), (2, 0)])))
     report('a solid 2x2 is found whole',
            CP.largest_band([(0, 0), (1, 0), (0, 1), (1, 1)]) == (0, 0, 1, 1))
     report('a single cell is itself',
@@ -329,6 +359,184 @@ def t_a_printed_row_never_starts_with_a_bracket():
     report('  every ranked row carries >= 2 nets', True)
 
 
+def t_a_track_crossing_a_window_is_not_cold():
+    """`free` is midpoint accounting; a crossing track has no midpoint here.
+
+    congestion_bins charges a segment's whole area to the bin holding its
+    MIDPOINT, which is right for a demand/capacity ratio and wrong for "is
+    this window empty". Measured before the swept test:
+    rp2350_fpga_eensy_prePlane at --bin 1.0 -- the bin the docs' own example
+    uses -- reported 159 cold windows of which 27 had a track running through
+    them. The census's whole claim about them is "no copper".
+    """
+    p = os.path.join(ROOT, 'kicad_files',
+                     'rp2350_fpga_eensy_prePlane.kicad_pcb')
+    if not os.path.isfile(p):
+        report('rp2350 fixture present', False, 'missing')
+        return
+    pcb = parse_kicad_pcb(p)
+    report('the fixture is routed, or this proves nothing',
+           len(pcb.segments) > 100, '%d segments' % len(pcb.segments))
+    for bm in (2.0, 1.0, 0.5):
+        doc, _h = CP.pocket_census(parse_kicad_pcb(p), p, bin_mm=bm)
+        touched = CP.copper_touched_bins(pcb, doc['bin_mm'])
+        # A region BBOX may legitimately span a touched bin (an L-shape wraps
+        # around copper); the BAND cannot -- every cell in it is cold.
+        worse = [r for r in doc['cold_regions']
+                 if any((bx, by) in touched
+                        for bx in range(int(round(r['band_rect'][0] / bm)),
+                                        int(round(r['band_rect'][2] / bm)))
+                        for by in range(int(round(r['band_rect'][1] / bm)),
+                                        int(round(r['band_rect'][3] / bm))))]
+        report('bin %g: no cold BAND overlaps swept copper' % bm, not worse,
+               str(worse[:1]))
+    doc, _h = CP.pocket_census(parse_kicad_pcb(p), p, bin_mm=1.0)
+    report('and the count really moved (was 159 cold at bin 1.0)',
+           doc['cold_windows'] < 100, str(doc['cold_windows']))
+
+
+def t_a_cold_band_holds_no_part_and_the_report_says_so():
+    """The census's headline output used to be a command that lifts nothing.
+
+    A cold window cannot contain a pad centre BY CONSTRUCTION -- a pad's area
+    is charged to its bin, so a window holding one is warm, never cold -- so
+    `refs_in_rect(band)` is empty for every band this can ever name. The report
+    printed `--reseat-region <that band>` as its actionable line, and it
+    resolved to an empty scope on every board.
+    """
+    from placement.utility import refs_in_rect
+    for name in ('esp_prog', 'watchy', 'tigard', 'glasgow_revC', 'sonde_u'):
+        doc, _hot = census(name)
+        rt = doc.get('reseat_target')
+        if not rt:
+            report('%s: has a reseat target to check' % name, False)
+            continue
+        pcb = parse_kicad_pcb(board(name))
+        got = refs_in_rect(pcb, tuple(rt['zone']))
+        report('%s: the named landing site holds NO part' % name,
+               got == [], str(got))
+        report('  %s: and the record says so rather than implying otherwise'
+               % name, rt.get('contains_parts') is False)
+        b = doc['outline']['bounds']
+        report('  %s: the zone is CLIPPED to the board' % name,
+               rt['zone'][0] >= b[0] - 1e-6 and rt['zone'][1] >= b[1] - 1e-6
+               and rt['zone'][2] <= b[2] + 1e-6
+               and rt['zone'][3] <= b[3] + 1e-6,
+               '%s vs bounds %s' % (rt['zone'], b))
+        report('  %s: no --reseat-region command is advertised' % name,
+               'reseat_region' not in rt)
+    doc, hot = census('esp_prog')
+    txt = '\n'.join(CP.format_report(
+        dict(doc, bin_requested_mm=2.0, _clr=0.25, _trk=0.3), hot, 8))
+    report('the printed block calls it a DESTINATION, not a scope',
+           'DESTINATION, not a scope' in txt, txt[-400:])
+    # Not "the token never appears" -- the prose names the flag in order to
+    # warn about it, and a grep for the bare token is satisfied by prose. What
+    # must not appear is a RUNNABLE command: a line carrying both the tool and
+    # the flag.
+    cmd = [ln for ln in txt.splitlines()
+           if 'place_seed.py' in ln and '--reseat-region' in ln]
+    report('  ...and prints no runnable --reseat-region command for it',
+           not cmd, str(cmd[:1]))
+    report('  ...while still naming the flag to warn about it',
+           '--reseat-region' in txt)
+
+
+def t_unreadable_part_geometry_is_disclosed_not_absorbed():
+    """"I could not measure the parts" must not read as "there are none".
+
+    With graded_parts_from_file raising, esp_prog reported 81 cold windows
+    instead of 29 and a 260mm2 "empty pocket" on top of U1 and USB1 -- and
+    said nothing, because the provenance line only prints when there IS an
+    arrangement, and there is none without parts.
+    """
+    from placement import legality as leg
+    real = leg.graded_parts_from_file
+    p = board('esp_prog')
+    try:
+        leg.graded_parts_from_file = (
+            lambda *a, **k: (_ for _ in ()).throw(RuntimeError('no parts')))
+        doc, hot = CP.pocket_census(parse_kicad_pcb(p), p)
+    finally:
+        leg.graded_parts_from_file = real
+    report('the failure is recorded with its exception',
+           'no parts' in (doc['parts'].get('grading_error') or ''),
+           str(doc['parts'].get('grading_error')))
+    txt = '\n'.join(CP.format_report(
+        dict(doc, bin_requested_mm=2.0, _clr=0.25, _trk=0.3), hot, 8))
+    report('  ...and the REPORT says so, loudly and unconditionally',
+           'PART GEOMETRY UNREADABLE' in txt, txt[:400])
+    report('  ...and tells the reader not to act on the pockets',
+           'Do not act on them' in txt)
+    clean, _h = census('esp_prog')
+    report('  ...while a healthy run records no error',
+           clean['parts'].get('grading_error') is None)
+
+
+def t_a_non_finite_bin_is_refused_at_the_cli():
+    """`--bin inf` wrote a bare `Infinity` into the --json document.
+
+    congestion_bins' max(0.25, bin) passes inf straight through, the window
+    rectangles serialise as Infinity/NaN, and strict parsers refuse the file --
+    which is the exact failure the `ratio` comment and test_run23_pockets
+    exist to prevent, arriving through a different door.
+    """
+    b = board('esp_prog')
+    tool = os.path.join(ROOT, 'py_tools', 'check_pockets.py')
+    for bad, why in (('inf', 'finite'), ('nan', 'finite'),
+                     ('0', 'positive'), ('-1', 'positive')):
+        check([sys.executable, '-X', 'utf8', tool, b, '--bin', bad],
+              code=2, refuse=why, allow=('error: argument',))
+    report('a non-finite or non-positive --bin is refused by its reason', True)
+    report('  ...and a legitimate sub-floor --bin still WORKS',
+           CP.pocket_census(parse_kicad_pcb(b), b, bin_mm=0.1)[0]['bin_mm']
+           == 0.25)
+    check([sys.executable, '-X', 'utf8', tool, b, '--outline-samples', '999'],
+          code=2, refuse='quadratic', allow=('error: argument',))
+    report('  ...and an unbounded --outline-samples is refused too', True)
+
+
+def t_no_cold_suppresses_only_the_cold_half():
+    """--no-cold used to return before the outline sweep, taking the
+    arrangement census, the parts provenance and the reseat target with it --
+    while the docs and the argparse help both describe --no-arrangement as the
+    separate switch for those."""
+    doc, _hot = census('esp_prog', cold=False)
+    report('the cold numbers are gone',
+           doc['cold_windows'] is None and doc['cold_regions'] == []
+           and doc['reseat_target'] is None)
+    report('  ...but the ARRANGEMENT survives',
+           doc['arrangement'] is not None and bool(doc['arrangement']['sides']),
+           str(doc['arrangement'] is None))
+    report('  ...and so do the outline sweep and the parts provenance',
+           bool(doc['outline']) and doc['windows_in_outline'] == 128
+           and doc['parts']['graded'] == 20,
+           str(doc.get('windows_in_outline')))
+    live = census('esp_prog')[0]
+    report('  ...and they agree with the full run',
+           doc['arrangement'] == live['arrangement'])
+
+
+def t_the_lattice_survives_inexact_float_division():
+    """`math.ceil(21.0 / 0.7)` is 31: the quotient is 30.000000000000004.
+
+    The same defect floor/ceil replaced, moved into the division. Measured, it
+    invented 59 off-board windows on a 20x20mm rectangular board at --bin 0.7.
+    """
+    got = len(CP.lattice_windows((1.0, 1.0, 21.0, 21.0), 0.7))
+    report('a 20mm span at bin 0.7 tiles in exactly 29x29',
+           got == 29 * 29, '%d windows' % got)
+    for name in ('qfn_diffpair_escape', 'qfn_interior_pads'):
+        p = os.path.join(ROOT, 'kicad_files', name + '.kicad_pcb')
+        if not os.path.isfile(p):
+            continue
+        for bm in (0.5, 0.7, 0.3):
+            doc, _h = CP.pocket_census(parse_kicad_pcb(p), p, bin_mm=bm)
+            report('%s bin %g: no phantom off-board window on a rectangle'
+                   % (name, bm), doc['windows_offboard'] == 0,
+                   str(doc['windows_offboard']))
+
+
 TESTS = [
     ('the defect, by the numbers', t_the_defect_itself),
     ('lattice bounds are floor/ceil', t_the_lattice_bounds_are_floor_ceil),
@@ -343,6 +551,18 @@ TESTS = [
     ('--cold-cover ladder', t_cold_cover_is_a_ladder_not_a_cliff),
     ('every number finite', t_every_number_is_finite_and_json_safe),
     ('--no-cold', t_no_cold_is_a_clean_off_switch),
+    ('a crossing track is not cold',
+     t_a_track_crossing_a_window_is_not_cold),
+    ('a cold band holds no part',
+     t_a_cold_band_holds_no_part_and_the_report_says_so),
+    ('unreadable parts are disclosed',
+     t_unreadable_part_geometry_is_disclosed_not_absorbed),
+    ('a non-finite --bin is refused',
+     t_a_non_finite_bin_is_refused_at_the_cli),
+    ('--no-cold keeps the arrangement',
+     t_no_cold_suppresses_only_the_cold_half),
+    ('inexact float division',
+     t_the_lattice_survives_inexact_float_division),
     ('the print format contract', t_a_printed_row_never_starts_with_a_bracket),
 ]
 

--- a/tests/test_709_cold_windows.py
+++ b/tests/test_709_cold_windows.py
@@ -195,6 +195,26 @@ def t_ranking_is_area_and_deterministic():
     report('two runs produce byte-identical regions',
            again['cold_regions'] == regions)
 
+    # The issue's explicit requirement -- "rank cold regions by contiguous
+    # area rather than window count, so a 6 to 8mm band outranks scattered
+    # singles" -- needs a board where the two ACTUALLY disagree, or it is
+    # untestable. On ulx3s they pick a different region for RANK 1: a compact
+    # 4 x 16mm slot wins on area over a wider, partly-off-board band that has
+    # more windows. esp_prog agrees under both rules and proves nothing.
+    doc2, _h3 = census('ulx3s')
+    rs = doc2['cold_regions']
+    by_count = sorted(rs, key=lambda r: (-r['windows'], r['bbox']))
+    report('ulx3s: area-ranking and count-ranking pick DIFFERENT regions',
+           rs[0]['bbox'] != by_count[0]['bbox'],
+           '%s vs %s' % (rs[0]['bbox'], by_count[0]['bbox']))
+    report('  ...and the census takes the AREA one',
+           rs[0]['area_mm2'] >= max(r['area_mm2'] for r in rs) - 1e-9,
+           '%.1f vs max %.1f' % (rs[0]['area_mm2'],
+                                 max(r['area_mm2'] for r in rs)))
+    report('  ...which really does have FEWER windows than the count winner',
+           rs[0]['windows'] < by_count[0]['windows'],
+           '%d vs %d' % (rs[0]['windows'], by_count[0]['windows']))
+
 
 def t_four_connected_not_eight():
     """Direct on the labeller: a diagonal touch is TWO regions."""
@@ -324,11 +344,30 @@ TESTS = [
 ]
 
 
+def _every_case_is_registered():
+    """A `t_*` defined and left out of TESTS is a test that never runs.
+
+    That happened here once, to the row that pins the quadrant counts against
+    `_region_unit`. The mutation battery is what noticed, which is a long way
+    round for something the module can check on itself in three lines.
+    """
+    g = globals()
+    declared = {fn for _l, fn in TESTS}
+    missing = sorted(n for n, v in g.items()
+                     if n.startswith('t_') and callable(v)
+                     and v not in declared)
+    if missing:
+        print('  FAIL  every t_* case is registered in TESTS  -- ORPHANED: %s'
+              % ', '.join(missing))
+        FAILURES.append('unregistered cases: %s' % ', '.join(missing))
+
+
 def main():
     print('cold windows and cold regions (#709)')
     for label, fn in TESTS:
         print(' ' + label)
         fn()
+    _every_case_is_registered()
     if FAILURES:
         print('\nFAILED (%d): %s' % (len(FAILURES), ', '.join(FAILURES)))
         return 1

--- a/tests/test_709_cold_windows.py
+++ b/tests/test_709_cold_windows.py
@@ -1,0 +1,340 @@
+"""The census can say EMPTY: in-outline enumeration and cold regions (#709).
+
+`congestion_bins` keyed its result off the `owners` map, so a window with
+nothing in it never entered the dict and `check_pockets` printed `len(bins)`
+as its window count. An empty region was therefore not merely un-ranked, it
+was not a window at all -- and "a clear empty pocket west of U2, a 6-8mm band"
+is precisely the finding a placement reviewer wants and no instrument could
+produce.
+
+Every number below is measured on a git-tracked board, and each row names the
+mutation it exists to catch. Two of them (A1, A7) are the issue's own defect
+and the issue's own wanted sentence, pinned so they cannot quietly come back.
+"""
+
+import math
+import os
+import sys
+
+RUN_ALL_FAST_OK = True          # imports the census, routes nothing
+RUN_ALL_TIMEOUT = 300
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for _d in ('py_router', 'py_placer', 'py_tools'):
+    sys.path.insert(0, os.path.join(ROOT, _d))
+
+from kicad_parser import parse_kicad_pcb                       # noqa: E402
+import check_pockets as CP                                     # noqa: E402
+
+FAILURES = []
+
+
+def report(name, ok, detail=''):
+    print(('  PASS  ' if ok else '  FAIL  ') + name
+          + (('  -- ' + detail) if detail else ''))
+    if not ok:
+        FAILURES.append(name)
+
+
+def board(name):
+    p = os.path.join(ROOT, 'kicad_files', name + '.kicad_pcb')
+    assert os.path.isfile(p) and os.path.getsize(p) > 0, p
+    return p
+
+
+_CACHE = {}
+
+
+def census(name, **kw):
+    key = (name, tuple(sorted(kw.items())))
+    if key not in _CACHE:
+        p = board(name)
+        _CACHE[key] = CP.pocket_census(parse_kicad_pcb(p), p, **kw)
+    return _CACHE[key]
+
+
+def t_the_defect_itself():
+    """A1/A3: the counts the issue measured, on the boards it measured them on.
+
+    Reverting the fix makes in-outline collapse onto demand and both rows go
+    red -- there is no way to satisfy them with a census that cannot see an
+    empty window.
+    """
+    doc, _hot = census('esp_prog')
+    report('esp_prog: 128 windows lie in the outline',
+           doc['windows_in_outline'] == 128, str(doc['windows_in_outline']))
+    report('esp_prog: 44 of them have demand (84, 66%, were invisible)',
+           doc['windows_demand'] == 44, str(doc['windows_demand']))
+    doc, _hot = census('glasgow_revC')
+    report('glasgow_revC: 1000 in-outline, 457 with demand',
+           (doc['windows_in_outline'], doc['windows_demand']) == (1000, 457),
+           '%s / %s' % (doc['windows_in_outline'], doc['windows_demand']))
+
+
+def t_the_lattice_bounds_are_floor_ceil():
+    """A3's mechanism, isolated: `int(hi // bin) + 1` appends a dead row.
+
+    glasgow_revC's y1 is exactly 120.0, so the wrong rule adds 40 windows of
+    zero width -- and the invisible-window headline would be overstated by
+    exactly those 40.
+    """
+    got = len(CP.lattice_windows((50.0, 71.0, 130.0, 120.0), 2.0))
+    report('a bound exactly on a lattice line adds no phantom row',
+           got == 1000, '%d windows' % got)
+    got = len(CP.lattice_windows((0.0, 0.0, 4.0, 4.0), 2.0))
+    report('a fully aligned bbox tiles exactly', got == 4, '%d' % got)
+    got = len(CP.lattice_windows((0.1, 0.1, 3.9, 3.9), 2.0))
+    report('a bbox inside one tile-and-a-bit still covers it', got == 4,
+           '%d' % got)
+
+
+def t_the_partition_holds():
+    """A2: every in-outline window is demand, cold, or warm-but-unowned.
+
+    A double count or a dropped window shows up here and nowhere else.
+    """
+    for name in ('esp_prog', 'watchy', 'cap_chain', 'interf_u_unrouted'):
+        doc, _hot = census(name)
+        total = (doc['windows_demand_in_outline'] + doc['under_part_windows']
+                 + doc['warm_unowned_windows'] + doc['cold_windows'])
+        report('%s: demand + under-part + warm-unowned + cold == in-outline'
+               % name, total == doc['windows_in_outline'],
+               '%d vs %d' % (total, doc['windows_in_outline']))
+        report('  %s: the under-part bucket is the big one, not cold' % name,
+               doc['under_part_windows'] >= 0 and doc['cold_windows'] >= 0)
+
+
+def t_cold_means_no_copper_not_just_no_demand():
+    """A4/C3: part-free is not empty.
+
+    On a ROUTED board under a narrow demand set, a window can carry another
+    net's copper and no demand at all. Defining cold as `demand == 0` alone
+    calls it empty. This needs the narrow set: at --nets '*' there are none.
+    """
+    p = os.path.join(ROOT, 'kicad_files', 'routed_output.kicad_pcb')
+    if not os.path.isfile(p):
+        report('routed_output.kicad_pcb present', False, 'fixture missing')
+        return
+    doc, _hot = CP.pocket_census(parse_kicad_pcb(p), p, nets=['GND'])
+    report('a routed board has part-free windows that carry copper',
+           doc['warm_unowned_windows'] > 0,
+           '%d' % doc['warm_unowned_windows'])
+    report('and they are NOT counted cold',
+           (doc['windows_demand_in_outline'] + doc['under_part_windows']
+            + doc['warm_unowned_windows'] + doc['cold_windows'])
+           == doc['windows_in_outline'])
+    # The mutation this exists to catch: dropping the `free < bin_area_total`
+    # arm folds those 190 windows into `cold`, so the counts must differ.
+    loose, _h = CP.pocket_census(parse_kicad_pcb(p), p, nets=['GND'],
+                                 cold_cover=1.0)
+    report('  the copper guard is not made redundant by --cold-cover 1.0',
+           loose['warm_unowned_windows'] == doc['warm_unowned_windows'],
+           '%d vs %d' % (loose['warm_unowned_windows'],
+                         doc['warm_unowned_windows']))
+
+
+def t_the_issue_s_own_sentence():
+    """A7: "an empty band south of CON2's eastern half", as a band.
+
+    8-connected labelling merges this region into the blob beside it and the
+    band disappears; ranking by window count buries it. Both go red here.
+    """
+    doc, _hot = census('esp_prog')
+    regions = doc['cold_regions']
+    hit = [r for r in regions if 'CON2' in r['refs'] and 'CON1' in r['refs']]
+    report('a cold region is bounded by CON1 and CON2', bool(hit),
+           '%d regions, refs %s' % (len(regions), [r['refs'] for r in regions]))
+    if hit:
+        r = hit[0]
+        report('  ...and it is a BAND, not a blob (fill >= 0.9)',
+               (r['fill'] or 0) >= 0.9, 'fill %s' % r['fill'])
+        report('  ...whose band rect is a real rectangle of windows',
+               r['band_mm'][0] > 0 and r['band_mm'][1] > 0,
+               str(r['band_mm']))
+    beside_u2 = [r for r in regions if r['bbox'][0] >= 133 and r['bbox'][2] <= 137]
+    report('a cold region sits immediately beside U2', bool(beside_u2),
+           str([r['bbox'] for r in regions]))
+
+
+def t_area_accounting_never_exceeds_the_region():
+    """A8: the bug the prototype hit -- a band reported as w*h.
+
+    esp_prog's top region spans 32 x 2mm of lattice but only 55.8mm2 of board,
+    because its edge windows are partly outside. A band computed as w*h claims
+    64.0mm2 inside a 55.8mm2 region, which is self-contradictory on its face.
+    """
+    for name in ('esp_prog', 'watchy', 'interf_u_unrouted'):
+        doc, _hot = census(name)
+        bad = [r for r in doc['cold_regions']
+               if r['band_area_mm2'] > r['area_mm2'] + 1e-6]
+        report('%s: no band claims more area than its region' % name,
+               not bad, str(bad[:1]))
+        worse = [r for r in doc['cold_regions']
+                 if r['area_mm2'] > r['windows'] * doc['bin_mm'] ** 2 + 1e-6]
+        report('%s: no region claims more than its windows can hold' % name,
+               not worse, str(worse[:1]))
+
+
+def t_ranking_is_area_and_deterministic():
+    """A9: contiguous AREA, never window count, and a stable tie-break."""
+    doc, _hot = census('esp_prog')
+    regions = doc['cold_regions']
+    report('regions are non-increasing in area',
+           all(regions[i]['area_mm2'] >= regions[i + 1]['area_mm2'] - 1e-9
+               for i in range(len(regions) - 1)),
+           str([r['area_mm2'] for r in regions]))
+    report('ranks are 1..n in order',
+           [r['rank'] for r in regions] == list(range(1, len(regions) + 1)))
+    top = regions[0]
+    report('the top region is DISCOUNTED for its partial edge windows',
+           top['area_mm2'] < top['windows'] * doc['bin_mm'] ** 2 - 1e-6,
+           '%.1f vs %.1f' % (top['area_mm2'],
+                             top['windows'] * doc['bin_mm'] ** 2))
+    again, _h2 = CP.pocket_census(parse_kicad_pcb(board('esp_prog')),
+                                  board('esp_prog'))
+    report('two runs produce byte-identical regions',
+           again['cold_regions'] == regions)
+
+
+def t_four_connected_not_eight():
+    """Direct on the labeller: a diagonal touch is TWO regions."""
+    got = CP.flood_regions([(0, 0), (1, 1)])
+    report('a diagonal pair is two components', len(got) == 2, str(got))
+    got = CP.flood_regions([(0, 0), (1, 0), (1, 1)])
+    report('an L is one component', len(got) == 1, str(got))
+    report('component output is sorted, not dict-ordered',
+           CP.flood_regions([(5, 5), (0, 0)]) == [[(0, 0)], [(5, 5)]])
+
+
+def t_largest_band_is_the_maximal_rectangle():
+    #  X X X
+    #  X X .      the maximal all-cold rectangle is the 3x1 top row
+    got = CP.largest_band([(0, 0), (1, 0), (2, 0), (0, 1), (1, 1)])
+    report('picks the 3x1 row over the 2x2 that is not solid',
+           got in ((0, 0, 2, 0), (0, 0, 1, 1)), str(got))
+    report('a solid 2x2 is found whole',
+           CP.largest_band([(0, 0), (1, 0), (0, 1), (1, 1)]) == (0, 0, 1, 1))
+    report('a single cell is itself',
+           CP.largest_band([(3, 4)]) == (3, 4, 3, 4))
+    report('nothing has no band', CP.largest_band([]) is None)
+
+
+def t_the_outline_source_is_disclosed():
+    """C1/C2: a rectangular board is graded against its bbox, and says so."""
+    doc, _hot = census('esp_prog')
+    report('esp_prog discloses bounding_box (its outline IS its bbox)',
+           doc['outline']['source'] == 'bounding_box',
+           str(doc['outline']))
+    report('  ...and nothing falls off a rectangle',
+           doc['windows_offboard'] == 0, str(doc['windows_offboard']))
+    doc, _hot = census('interf_u_unrouted')
+    report('interf_u_unrouted uses its real rings',
+           doc['outline']['source'] == 'edge_cuts_contours'
+           and doc['outline']['rings'] >= 1, str(doc['outline']))
+    report('  ...and windows fall off it, and others are cut by it',
+           doc['windows_offboard'] > 0 and doc['windows_partial'] > 0,
+           '%d off, %d partial' % (doc['windows_offboard'],
+                                   doc['windows_partial']))
+    doc, _hot = census('watchy')
+    report('watchy: the two CUTOUTS are seen',
+           doc['outline']['cutouts'] == 2, str(doc['outline']))
+    report('  ...and take windows off the board',
+           doc['windows_offboard'] > 0, str(doc['windows_offboard']))
+
+
+def t_cold_cover_is_a_ladder_not_a_cliff():
+    """Sweep the knob's whole range: more slack can only mean more cold."""
+    counts = []
+    for frac in (0.0, 0.25, 0.5, 1.0):
+        doc, _hot = census('esp_prog', cold_cover=frac)
+        counts.append(doc['cold_windows'])
+    report('cold count is monotonic in --cold-cover',
+           all(counts[i] <= counts[i + 1] for i in range(len(counts) - 1)),
+           str(counts))
+    report('the strict default is strictly the strictest',
+           counts[0] < counts[-1], str(counts))
+
+
+def t_every_number_is_finite_and_json_safe():
+    """B7: an inf or a nan would be a bare token strict parsers refuse."""
+    def walk(o, p=''):
+        if isinstance(o, dict):
+            for k, v in o.items():
+                yield from walk(v, p + '/' + str(k))
+        elif isinstance(o, list):
+            for i, v in enumerate(o):
+                yield from walk(v, p + '/%d' % i)
+        else:
+            yield p, o
+    for name in ('esp_prog', 'cap_chain', 'watchy', 'interf_u_unrouted'):
+        doc, _hot = census(name)
+        bad = [(p, v) for p, v in walk(doc)
+               if isinstance(v, float) and not math.isfinite(v)]
+        report('%s: no inf/nan anywhere in the document' % name, not bad,
+               str(bad[:2]))
+
+
+def t_no_cold_is_a_clean_off_switch():
+    doc, _hot = census('esp_prog', cold=False)
+    report('--no-cold leaves the cold keys empty, not zero-ish',
+           doc['cold_windows'] is None and doc['cold_regions'] == []
+           and doc['skipped'] == 'cold census disabled', str(doc.get('skipped')))
+    report('  ...and the hot rows are untouched by it',
+           doc['windows_demand'] == census('esp_prog')[0]['windows_demand'])
+
+
+def t_a_printed_row_never_starts_with_a_bracket():
+    """The format contract test_run23_pockets.py's ranked-row parser keys on.
+
+    That parser reads every stripped line starting with '[' that mentions
+    `demand` and asserts it carries >= 2 nets. A cold row or a quadrant row
+    that began with '[' would be read as a ranked row and fail.
+    """
+    doc, hot = census('esp_prog')
+    doc = dict(doc, bin_requested_mm=2.0, _clr=0.25, _trk=0.3)
+    lines = CP.format_report(doc, hot, 8)
+    ranked = [ln for ln in (x.strip() for x in lines)
+              if ln.startswith('[') and 'demand' in ln]
+    report('every bracket-leading line is a real ranked row',
+           len(ranked) == len(hot[:8]) and len(ranked) > 0,
+           '%d bracket lines, %d hot rows' % (len(ranked), len(hot[:8])))
+    for ln in ranked:
+        n = int(ln.split('demand')[1].split('net(s)')[0].strip())
+        if n < 2:
+            report('  a ranked row carries >= 2 nets', False, ln)
+            return
+    report('  every ranked row carries >= 2 nets', True)
+
+
+TESTS = [
+    ('the defect, by the numbers', t_the_defect_itself),
+    ('lattice bounds are floor/ceil', t_the_lattice_bounds_are_floor_ceil),
+    ('the window partition holds', t_the_partition_holds),
+    ('cold requires no copper', t_cold_means_no_copper_not_just_no_demand),
+    ("the issue's own sentence", t_the_issue_s_own_sentence),
+    ('area accounting', t_area_accounting_never_exceeds_the_region),
+    ('ranking is area, deterministic', t_ranking_is_area_and_deterministic),
+    ('4-connected labelling', t_four_connected_not_eight),
+    ('largest band', t_largest_band_is_the_maximal_rectangle),
+    ('the outline source is disclosed', t_the_outline_source_is_disclosed),
+    ('--cold-cover ladder', t_cold_cover_is_a_ladder_not_a_cliff),
+    ('every number finite', t_every_number_is_finite_and_json_safe),
+    ('--no-cold', t_no_cold_is_a_clean_off_switch),
+    ('the print format contract', t_a_printed_row_never_starts_with_a_bracket),
+]
+
+
+def main():
+    print('cold windows and cold regions (#709)')
+    for label, fn in TESTS:
+        print(' ' + label)
+        fn()
+    if FAILURES:
+        print('\nFAILED (%d): %s' % (len(FAILURES), ', '.join(FAILURES)))
+        return 1
+    print('\nOK')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_709_cold_windows.py
+++ b/tests/test_709_cold_windows.py
@@ -16,7 +16,10 @@ import math
 import os
 import sys
 
-RUN_ALL_FAST_OK = True          # imports the census, routes nothing
+# Imports the census and routes nothing. Comment ABOVE the marker: a
+# trailing one voids run_all's `...True\s*$` anchor (see the sibling
+# test_709_congestion_bins_include.py, where it really did).
+RUN_ALL_FAST_OK = True
 RUN_ALL_TIMEOUT = 300
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/tests/test_709_congestion_bins_include.py
+++ b/tests/test_709_congestion_bins_include.py
@@ -103,11 +103,30 @@ TESTS = [
 ]
 
 
+def _every_case_is_registered():
+    """A `t_*` defined and left out of TESTS is a test that never runs.
+
+    That happened here once, to the row that pins the quadrant counts against
+    `_region_unit`. The mutation battery is what noticed, which is a long way
+    round for something the module can check on itself in three lines.
+    """
+    g = globals()
+    declared = {fn for _l, fn in TESTS}
+    missing = sorted(n for n, v in g.items()
+                     if n.startswith('t_') and callable(v)
+                     and v not in declared)
+    if missing:
+        print('  FAIL  every t_* case is registered in TESTS  -- ORPHANED: %s'
+              % ', '.join(missing))
+        FAILURES.append('unregistered cases: %s' % ', '.join(missing))
+
+
 def main():
     print('congestion_bins include_bins (#709)')
     for label, fn in TESTS:
         print(' ' + label)
         fn()
+    _every_case_is_registered()
     if FAILURES:
         print('\nFAILED: ' + ', '.join(FAILURES))
         return 1

--- a/tests/test_709_congestion_bins_include.py
+++ b/tests/test_709_congestion_bins_include.py
@@ -4,16 +4,36 @@ The census could not represent an EMPTY window because `bins` was keyed off
 `owners`, which only gains a key where some net has a terminal. The fix adds
 one default-off kwarg. This file is the guard on the half that is dangerous:
 `congestion_bins` also backs `build_congestion2`, whose `bins` dict feeds
-`congestion2_rows` -> np.array -> merge_track_proximity_costs. Dict INSERTION
-ORDER is therefore the row order of an array the router prices cells with, and
-congestion-v2 is OFF by default (KICAD_CONGESTION2_COST 0.0), so a regression
-there is silent in the whole default suite. Nothing else would catch it.
+`congestion2_rows` -> np.array -> merge_track_proximity_costs.
+
+ON THE ORDER, PRECISELY -- because the first version of this file overstated
+it and a review caught that. The array's consumers are order-INSENSITIVE: the
+Rust `set_layer_proximity_batch` is a per-cell max-insert, and the SUM branch
+goes through np.unique/bincount, so a permutation does not change what the
+router prices cells with. What order really decides is the tie-break in
+`check_pockets`' own stable `rows.sort(key=-ratio)`. Preserving it is the
+right defensive choice either way, but the stake is that, not the cost map.
+
+And it is asserted against an INDEPENDENT re-derivation rather than against a
+second call of the same code. Comparing the code with itself passes any
+refactor that permutes both sides equally -- including `sorted(set(owners) |
+set(include_bins))`, which is a dressed-up version of exactly the union this
+test exists to forbid, and which permuted all 44 esp_prog keys while printing
+OK.
 """
 
+import ast
 import os
 import sys
 
-RUN_ALL_FAST_OK = True          # no subprocess, no routing -- seconds
+# Nothing here shells out and nothing routes; it runs in seconds.
+# The comment goes ABOVE the marker, never after it: run_all's
+# _FAST_OK_MARKER is anchored `...True\s*$`, so a trailing comment
+# silently voids the opt-out -- and a trailing comment containing the
+# word 'subprocess' also TRIPS the integration proxy that the opt-out
+# exists to cancel. Measured: this file classified `integration` and was
+# skipped by --fast, which is the one lane it most needed to be in.
+RUN_ALL_FAST_OK = True
 RUN_ALL_TIMEOUT = 180
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -23,6 +43,8 @@ from congestion_field import congestion_bins            # noqa: E402
 from kicad_parser import parse_kicad_pcb                # noqa: E402
 
 BOARD = os.path.join(ROOT, 'kicad_files', 'esp_prog.kicad_pcb')
+#: 1701 segments, 383 vias -- the board where "part-free" and "empty" differ.
+ROUTED = os.path.join(ROOT, 'kicad_files', 'routed_output.kicad_pcb')
 
 FAILURES = []
 
@@ -34,36 +56,83 @@ def report(name, ok, detail=''):
         FAILURES.append(name)
 
 
-def _census(**kw):
-    pcb = parse_kicad_pcb(BOARD)
-    ids = list(pcb.nets)
+def _census(path=BOARD, ids=None, **kw):
+    pcb = parse_kicad_pcb(path)
+    if ids is None:
+        ids = list(pcb.nets)
     layers = len(pcb.board_info.copper_layers or ['F.Cu'])
-    return congestion_bins(pcb, ids, layers, 2.0, **kw), layers
+    return pcb, congestion_bins(pcb, ids, layers, 2.0, **kw), layers
 
 
-def t_default_is_byte_for_byte_the_old_iteration():
-    """The A*-path guard: same keys, same ORDER, same values.
+def _expected_key_order(pcb, ids, bin_mm=2.0):
+    """The key sequence, RE-DERIVED from the board rather than from the code.
 
-    `list(...)` not `set(...)`: a set union would pass a key-set assertion and
-    still permute the np.array rows congestion2_rows builds.
+    `owners` is filled net by net over that net's pads, then its segment
+    endpoints, then its vias, with `setdefault` -- so first touch wins.
+    Writing the derivation out is the point: a bound standing in for a
+    derivation is how a wrong version passes the test written for it.
     """
-    (a, _ta, _ba), _l = _census()
-    (b, _tb, _bb), _l = _census(include_bins=None)
-    report('include_bins=None leaves the key ORDER identical',
-           list(a.items()) == list(b.items()),
-           '%d vs %d keys' % (len(a), len(b)))
+    out, seen = [], set()
+    for nid in set(ids):
+        pts = [(p.global_x, p.global_y)
+               for p in pcb.pads_by_net.get(nid, [])]
+        for s in pcb.segments:
+            if s.net_id == nid:
+                pts.append((s.start_x, s.start_y))
+                pts.append((s.end_x, s.end_y))
+        for v in pcb.vias:
+            if v.net_id == nid:
+                pts.append((v.x, v.y))
+        for (x, y) in pts:
+            b = (int(x // bin_mm), int(y // bin_mm))
+            if b not in seen:
+                seen.add(b)
+                out.append(b)
+    return out
+
+
+def t_the_census_is_not_empty():
+    """Everything below is an `all(...)` or a prefix compare, and both are
+    vacuously true over nothing. A census that silently returned {} passed all
+    eight checks in the first version of this file."""
+    _pcb, (bins, terminals, bin_mm), _l = _census()
+    report('esp_prog yields a substantial census',
+           len(bins) > 20 and len(terminals) > 10 and bin_mm == 2.0,
+           '%d bins, %d nets' % (len(bins), len(terminals)))
+    _p2, (rb, _t2, _b2), _l2 = _census(ROUTED)
+    report('routed_output yields one too', len(rb) > 50, str(len(rb)))
+
+
+def t_default_order_matches_an_independent_derivation():
+    """The order guard, against the derivation -- not against itself."""
+    pcb, (a, _t, _b), _l = _census()
+    want = _expected_key_order(pcb, list(pcb.nets))
+    report('the default key order IS the owners traversal order',
+           list(a) == want,
+           '%d keys, first divergence at index %s'
+           % (len(a), next((i for i, (g, w) in enumerate(zip(list(a), want))
+                            if g != w), 'none')))
+    _p2, (b, _t2, _b2), _l2 = _census(include_bins=None)
+    report('include_bins=None changes nothing at all',
+           list(a.items()) == list(b.items()))
+    for spelling in ([], (), set()):
+        _p3, (c, _t3, _b3), _l3 = _census(include_bins=spelling)
+        report('an empty %s takes the default path too'
+               % type(spelling).__name__,
+               list(c.items()) == list(a.items()))
 
 
 def t_empty_bins_arrive_with_real_free_area():
-    (base, _t, _b), layers = _census()
+    _pcb, (base, _t, _b), layers = _census()
     # Two keys far outside any part: nothing demands them, nothing is on them.
     extra = [(10 ** 5, 10 ** 5), (10 ** 5 + 1, 10 ** 5)]
-    (wide, _t2, _b2), _l = _census(include_bins=extra)
+    _p2, (wide, _t2, _b2), _l = _census(include_bins=extra)
 
     report('every default key survives, with its value unchanged',
-           all(k in wide and wide[k] == v for k, v in base.items()))
+           len(base) > 0
+           and all(k in wide and wide[k] == v for k, v in base.items()))
     report('the default keys keep their order, extras APPENDED after',
-           list(wide)[:len(base)] == list(base))
+           len(base) > 0 and list(wide)[:len(base)] == list(base))
     report('the extra keys are present', all(k in wide for k in extra))
 
     full = 2.0 * 2.0 * layers
@@ -75,31 +144,123 @@ def t_empty_bins_arrive_with_real_free_area():
            'got %s, want %g' % (frees, full))
 
 
+def t_a_no_demand_window_still_subtracts_copper():
+    """The distinction #709 exists to make, at the level that computes it.
+
+    A window with no demand under a NARROW net set can be packed with another
+    net's copper. If `free` stopped subtracting copper for newly-included keys
+    every one of them would read "empty" -- and the two off-board probes above
+    cannot tell the difference, because they carry no copper either.
+
+    The reference is the ALL-NETS census, which reaches the same bin through
+    the ordinary `owners` path: same bin, same copper, so the two must agree
+    to the bit.
+    """
+    pcb = parse_kicad_pcb(ROUTED)
+    layers = len(pcb.board_info.copper_layers or ['F.Cu'])
+    all_ids = list(pcb.nets)
+    full_bins, _t, _b = congestion_bins(pcb, all_ids, layers, 2.0)
+    one = [nid for nid, n in pcb.nets.items() if n.name == 'GND'] or all_ids[:1]
+    narrow, _t2, _b2 = congestion_bins(pcb, one, layers, 2.0)
+
+    hidden = [k for k in full_bins if k not in narrow]
+    report('the narrow set really does hide windows the wide one sees',
+           len(hidden) > 50, '%d hidden' % len(hidden))
+    wide, _t3, _b3 = congestion_bins(pcb, one, layers, 2.0,
+                                     include_bins=hidden)
+    cap = 2.0 * 2.0 * layers
+    withcopper = [k for k in hidden if full_bins[k][0] < cap - 1e-9]
+    report('  ...and many of them carry copper', len(withcopper) > 20,
+           '%d of %d' % (len(withcopper), len(hidden)))
+    bad = [k for k in withcopper if abs(wide[k][0] - full_bins[k][0]) > 1e-9]
+    report('a re-included window reports the SAME free area as the wide census',
+           not bad, '%d disagree, e.g. %s' % (len(bad), bad[:2]))
+    report('  ...which is strictly below the empty-window capacity',
+           bool(withcopper)
+           and all(wide[k][0] < cap - 1e-9 for k in withcopper))
+    report('  ...and it has no owner under the narrow set',
+           bool(hidden) and all(len(wide[k][1]) == 0 for k in hidden))
+
+
 def t_an_included_key_that_already_has_demand_is_not_duplicated():
-    (base, _t, _b), _l = _census()
+    _pcb, (base, _t, _b), _l = _census()
     owned = sorted(base)[:3]
-    (wide, _t2, _b2), _l = _census(include_bins=owned)
+    report('the probe keys are real, not an empty slice', len(owned) == 3)
+    _p2, (wide, _t2, _b2), _l2 = _census(include_bins=owned)
     report('re-including an owned key changes nothing at all',
            list(wide.items()) == list(base.items()))
 
 
 def t_the_build_congestion2_call_site_passes_nothing():
-    """Static: the A* builder must not acquire this kwarg by accident."""
+    """AST, not a token scan.
+
+    A substring check misses `**{'include' + '_bins': ...}` and a forwarding
+    helper, and fires on a comment that merely mentions the name. What has to
+    be true is a property of the CALL: `build_congestion2` reaches
+    `congestion_bins` with no `include_bins` keyword and no `**` splat.
+    """
     src = open(os.path.join(ROOT, 'py_router', 'congestion_field.py'),
                encoding='utf-8').read()
-    body = src.split('def build_congestion2', 1)[1].split('\ndef ', 1)[0]
-    report('build_congestion2 never passes include_bins',
-           'include_bins' not in body)
+    tree = ast.parse(src)
+    fns = [n for n in ast.walk(tree)
+           if isinstance(n, ast.FunctionDef) and n.name == 'build_congestion2']
+    report('build_congestion2 is still there to check', len(fns) == 1)
+    if len(fns) != 1:
+        return
+    calls = [c for c in ast.walk(fns[0]) if isinstance(c, ast.Call)
+             and isinstance(c.func, ast.Name)
+             and c.func.id == 'congestion_bins']
+    report('  it calls congestion_bins exactly once', len(calls) == 1,
+           str(len(calls)))
+    for c in calls:
+        report('  with no include_bins keyword',
+               not any(k.arg == 'include_bins' for k in c.keywords))
+        report('  and no ** splat that could smuggle one in',
+               not any(k.arg is None for k in c.keywords))
+        report('  and at most 4 positionals (the 5th slot is not it)',
+               len(c.args) <= 4, str(len(c.args)))
+    # ...and it must not reach the kwarg through a helper either.
+    helpers = [c for c in ast.walk(fns[0]) if isinstance(c, ast.Call)
+               and any(k.arg == 'include_bins' for k in c.keywords)]
+    report('  and passes include_bins to nothing else', not helpers)
+
+
+def t_a_bad_include_bins_shape_is_refused_at_the_boundary():
+    """A bare (bx, by) instead of a LIST of them used to insert an int key,
+    which then failed far away in the consumer's `for (bx, by), ... in
+    bins.items()`. Fail where the mistake is, not three frames later."""
+
+    def raises(arg):
+        try:
+            _census(include_bins=arg)
+        except (TypeError, ValueError):
+            return True
+        except Exception:                                       # noqa: BLE001
+            return False
+        return False
+
+    report('a bare (bx, by) tuple is refused, not silently inserted',
+           raises((10 ** 5, 10 ** 5)))
+    report('a flat list of ints is refused', raises([1, 2, 3]))
+    report('a list of real keys is still accepted',
+           not raises([(10 ** 5, 10 ** 5)]))
+    report('and so is an iterator of them',
+           not raises(iter([(10 ** 5, 10 ** 5)])))
 
 
 TESTS = [
-    ('default iteration is unchanged',
-     t_default_is_byte_for_byte_the_old_iteration),
+    ('the census is non-empty', t_the_census_is_not_empty),
+    ('default order == the derivation',
+     t_default_order_matches_an_independent_derivation),
     ('empty bins carry real free area', t_empty_bins_arrive_with_real_free_area),
+    ('a no-demand window still subtracts copper',
+     t_a_no_demand_window_still_subtracts_copper),
     ('an owned key is not duplicated',
      t_an_included_key_that_already_has_demand_is_not_duplicated),
-    ('the A* builder passes nothing',
+    ('the A* builder passes nothing (AST)',
      t_the_build_congestion2_call_site_passes_nothing),
+    ('a bad include_bins shape is refused',
+     t_a_bad_include_bins_shape_is_refused_at_the_boundary),
 ]
 
 

--- a/tests/test_709_congestion_bins_include.py
+++ b/tests/test_709_congestion_bins_include.py
@@ -1,0 +1,119 @@
+"""congestion_bins gains `include_bins`, and the A* path must not notice (#709).
+
+The census could not represent an EMPTY window because `bins` was keyed off
+`owners`, which only gains a key where some net has a terminal. The fix adds
+one default-off kwarg. This file is the guard on the half that is dangerous:
+`congestion_bins` also backs `build_congestion2`, whose `bins` dict feeds
+`congestion2_rows` -> np.array -> merge_track_proximity_costs. Dict INSERTION
+ORDER is therefore the row order of an array the router prices cells with, and
+congestion-v2 is OFF by default (KICAD_CONGESTION2_COST 0.0), so a regression
+there is silent in the whole default suite. Nothing else would catch it.
+"""
+
+import os
+import sys
+
+RUN_ALL_FAST_OK = True          # no subprocess, no routing -- seconds
+RUN_ALL_TIMEOUT = 180
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))
+
+from congestion_field import congestion_bins            # noqa: E402
+from kicad_parser import parse_kicad_pcb                # noqa: E402
+
+BOARD = os.path.join(ROOT, 'kicad_files', 'esp_prog.kicad_pcb')
+
+FAILURES = []
+
+
+def report(name, ok, detail=''):
+    print(('  PASS  ' if ok else '  FAIL  ') + name
+          + (('  -- ' + detail) if detail else ''))
+    if not ok:
+        FAILURES.append(name)
+
+
+def _census(**kw):
+    pcb = parse_kicad_pcb(BOARD)
+    ids = list(pcb.nets)
+    layers = len(pcb.board_info.copper_layers or ['F.Cu'])
+    return congestion_bins(pcb, ids, layers, 2.0, **kw), layers
+
+
+def t_default_is_byte_for_byte_the_old_iteration():
+    """The A*-path guard: same keys, same ORDER, same values.
+
+    `list(...)` not `set(...)`: a set union would pass a key-set assertion and
+    still permute the np.array rows congestion2_rows builds.
+    """
+    (a, _ta, _ba), _l = _census()
+    (b, _tb, _bb), _l = _census(include_bins=None)
+    report('include_bins=None leaves the key ORDER identical',
+           list(a.items()) == list(b.items()),
+           '%d vs %d keys' % (len(a), len(b)))
+
+
+def t_empty_bins_arrive_with_real_free_area():
+    (base, _t, _b), layers = _census()
+    # Two keys far outside any part: nothing demands them, nothing is on them.
+    extra = [(10 ** 5, 10 ** 5), (10 ** 5 + 1, 10 ** 5)]
+    (wide, _t2, _b2), _l = _census(include_bins=extra)
+
+    report('every default key survives, with its value unchanged',
+           all(k in wide and wide[k] == v for k, v in base.items()))
+    report('the default keys keep their order, extras APPENDED after',
+           list(wide)[:len(base)] == list(base))
+    report('the extra keys are present', all(k in wide for k in extra))
+
+    full = 2.0 * 2.0 * layers
+    frees = [wide[k][0] for k in extra]
+    owns = [wide[k][1] for k in extra]
+    report('an empty window reports NO owner', all(len(o) == 0 for o in owns))
+    report('an empty window reports the FULL free area, not the 5% floor',
+           all(abs(f - full) < 1e-9 for f in frees),
+           'got %s, want %g' % (frees, full))
+
+
+def t_an_included_key_that_already_has_demand_is_not_duplicated():
+    (base, _t, _b), _l = _census()
+    owned = sorted(base)[:3]
+    (wide, _t2, _b2), _l = _census(include_bins=owned)
+    report('re-including an owned key changes nothing at all',
+           list(wide.items()) == list(base.items()))
+
+
+def t_the_build_congestion2_call_site_passes_nothing():
+    """Static: the A* builder must not acquire this kwarg by accident."""
+    src = open(os.path.join(ROOT, 'py_router', 'congestion_field.py'),
+               encoding='utf-8').read()
+    body = src.split('def build_congestion2', 1)[1].split('\ndef ', 1)[0]
+    report('build_congestion2 never passes include_bins',
+           'include_bins' not in body)
+
+
+TESTS = [
+    ('default iteration is unchanged',
+     t_default_is_byte_for_byte_the_old_iteration),
+    ('empty bins carry real free area', t_empty_bins_arrive_with_real_free_area),
+    ('an owned key is not duplicated',
+     t_an_included_key_that_already_has_demand_is_not_duplicated),
+    ('the A* builder passes nothing',
+     t_the_build_congestion2_call_site_passes_nothing),
+]
+
+
+def main():
+    print('congestion_bins include_bins (#709)')
+    for label, fn in TESTS:
+        print(' ' + label)
+        fn()
+    if FAILURES:
+        print('\nFAILED: ' + ', '.join(FAILURES))
+        return 1
+    print('\nOK')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_709_refs_in_rect.py
+++ b/tests/test_709_refs_in_rect.py
@@ -1,0 +1,167 @@
+"""One rectangle, one answer: `placement.utility.refs_in_rect` (#709).
+
+The census PRINTS a rectangle and `place_seed --reseat-region` LIFTS the parts
+in it. If the two resolve the same rectangle differently -- a closed interval
+here, a half-open one there, pad centres on one side and footprint origins on
+the other -- the census names parts the mover does not touch, and the reseat
+target it advertises is a lie. So there is one implementation and this is its
+contract.
+"""
+
+import os
+import sys
+
+RUN_ALL_FAST_OK = True
+RUN_ALL_TIMEOUT = 120
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for _d in ('py_router', 'py_placer', 'py_tools'):
+    sys.path.insert(0, os.path.join(ROOT, _d))
+
+from kicad_parser import parse_kicad_pcb                        # noqa: E402
+from placement.utility import refs_in_rect                      # noqa: E402
+
+BOARD = os.path.join(ROOT, 'kicad_files', 'esp_prog.kicad_pcb')
+
+FAILURES = []
+
+
+def report(name, ok, detail=''):
+    print(('  PASS  ' if ok else '  FAIL  ') + name
+          + (('  -- ' + detail) if detail else ''))
+    if not ok:
+        FAILURES.append(name)
+
+
+class _Pad:
+    def __init__(self, x, y, ref):
+        self.global_x, self.global_y, self.component_ref = x, y, ref
+
+
+class _Fp:
+    def __init__(self, x, y, pads):
+        self.x, self.y, self.pads = x, y, pads
+
+
+class _Pcb:
+    def __init__(self, fps):
+        self.footprints = fps
+
+
+def _synthetic():
+    """Four pads, one on each boundary of the window [0,0]-[10,10]."""
+    return _Pcb({
+        'LO': _Fp(0.0, 0.0, [_Pad(0.0, 0.0, 'LO')]),        # on the low corner
+        'HI': _Fp(10.0, 10.0, [_Pad(10.0, 10.0, 'HI')]),    # on the high corner
+        'IN': _Fp(5.0, 5.0, [_Pad(5.0, 5.0, 'IN')]),
+        'OUT': _Fp(20.0, 20.0, [_Pad(20.0, 20.0, 'OUT')]),
+    })
+
+
+def t_the_interval_is_half_open():
+    """A tiling must give every point to exactly ONE window.
+
+    A closed interval hands a part on a shared edge to both neighbours, so two
+    adjacent census windows would each claim it and the counts stop summing.
+    """
+    pcb = _synthetic()
+    got = refs_in_rect(pcb, (0.0, 0.0, 10.0, 10.0))
+    report('the LOW corner is inside', 'LO' in got, str(got))
+    report('the HIGH corner is NOT (half-open)', 'HI' not in got, str(got))
+    report('the interior is inside', 'IN' in got, str(got))
+    report('a distant part is out', 'OUT' not in got, str(got))
+
+    # The tiling property itself, which is what half-open buys.
+    a = refs_in_rect(pcb, (0.0, 0.0, 5.0, 10.0))
+    b = refs_in_rect(pcb, (5.0, 0.0, 10.0, 10.0))
+    report('two abutting windows never claim the same ref',
+           not (set(a) & set(b)), '%s / %s' % (a, b))
+    report('  ...and together they claim what the union window claims',
+           set(a) | set(b) == set(refs_in_rect(pcb, (0.0, 0.0, 10.0, 10.0))))
+
+
+def t_the_two_modes_answer_different_questions():
+    pcb = _synthetic()
+    # A part whose ORIGIN is outside the window but whose PAD reaches into it.
+    pcb.footprints['REACH'] = _Fp(50.0, 50.0, [_Pad(5.0, 5.0, 'REACH')])
+    by_pad = refs_in_rect(pcb, (0.0, 0.0, 10.0, 10.0))
+    by_origin = refs_in_rect(pcb, (0.0, 0.0, 10.0, 10.0), by='origin')
+    report("by='pad' sees a part reaching in from outside",
+           'REACH' in by_pad, str(by_pad))
+    report("by='origin' does not", 'REACH' not in by_origin, str(by_origin))
+    report('an unknown mode is refused, not silently treated as one of them',
+           _raises(lambda: refs_in_rect(pcb, (0, 0, 1, 1), by='centre')))
+
+
+def _raises(fn):
+    try:
+        fn()
+    except ValueError:
+        return True
+    except Exception:                                           # noqa: BLE001
+        return False
+    return False
+
+
+def t_it_matches_what_the_census_used_to_do_inline():
+    """The census's old inline pad scan, replayed on a real board."""
+    pcb = parse_kicad_pcb(BOARD)
+    win = (126.0, 102.0, 128.0, 104.0)
+    old = sorted({p.component_ref
+                  for fp in pcb.footprints.values() for p in fp.pads
+                  if win[0] <= p.global_x < win[2]
+                  and win[1] <= p.global_y < win[3] and p.component_ref})
+    report('same answer as the inline scan it replaced',
+           refs_in_rect(pcb, win) == old, str(old))
+    report('and the answer is not vacuously empty', bool(old), str(old))
+
+
+def t_a_degenerate_rect_names_nothing():
+    pcb = _synthetic()
+    report('a zero-area rect claims nothing',
+           refs_in_rect(pcb, (5.0, 5.0, 5.0, 5.0)) == [])
+    report('an inverted rect claims nothing',
+           refs_in_rect(pcb, (10.0, 10.0, 0.0, 0.0)) == [])
+
+
+TESTS = [
+    ('the interval is half-open', t_the_interval_is_half_open),
+    ('pad vs origin', t_the_two_modes_answer_different_questions),
+    ('parity with the old inline scan', t_it_matches_what_the_census_used_to_do_inline),
+    ('degenerate rects', t_a_degenerate_rect_names_nothing),
+]
+
+
+def _every_case_is_registered():
+    """A `t_*` defined and left out of TESTS is a test that never runs.
+
+    That happened here once, to the row that pins the quadrant counts against
+    `_region_unit`. The mutation battery is what noticed, which is a long way
+    round for something the module can check on itself in three lines.
+    """
+    g = globals()
+    declared = {fn for _l, fn in TESTS}
+    missing = sorted(n for n, v in g.items()
+                     if n.startswith('t_') and callable(v)
+                     and v not in declared)
+    if missing:
+        print('  FAIL  every t_* case is registered in TESTS  -- ORPHANED: %s'
+              % ', '.join(missing))
+        FAILURES.append('unregistered cases: %s' % ', '.join(missing))
+
+
+def main():
+    print('refs_in_rect, the one resolver (#709)')
+    for label, fn in TESTS:
+        print(' ' + label)
+        fn()
+    _every_case_is_registered()
+    if FAILURES:
+        print('\nFAILED (%d): %s' % (len(FAILURES), ', '.join(FAILURES)))
+        return 1
+    print('\nOK')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_709_reseat_region.py
+++ b/tests/test_709_reseat_region.py
@@ -106,6 +106,59 @@ def t_a_region_names_the_same_parts_the_census_does():
     report('the census run itself is clean', r.returncode == 0)
 
 
+def t_the_mover_resolves_the_rectangle_THE_SAME_WAY():
+    """The property the whole design rests on, tested where it can fail.
+
+    A rectangle that contains no part on its boundary cannot tell a half-open
+    resolver from a closed one -- and that is exactly what a mutation replacing
+    `refs_in_rect` with an inline closed-interval scan exploited: it survived
+    the whole battery, because the fixture rectangle had nothing on its edge.
+
+    So this builds the rectangle FROM the board: its far corner is placed
+    exactly on a pad centre, so the two rules genuinely disagree, and then it
+    asserts the CLI's own printed answer against `refs_in_rect`.
+    """
+    with tempfile.TemporaryDirectory() as wd:
+        b, it = _fixture(wd)
+        pcb = parse_kicad_pcb(b)
+        # A pad to sit on the far edge, and one strictly inside, so the
+        # rectangle is neither empty nor everything.
+        pads = sorted(((p.global_x, p.global_y, p.component_ref)
+                       for fp in pcb.footprints.values() for p in fp.pads
+                       if p.component_ref),
+                      key=lambda t: (t[0], t[1]))
+        report('the fixture has pads to build an edge case from', len(pads) > 4,
+               str(len(pads)))
+        if len(pads) <= 4:
+            return
+        edge = pads[len(pads) // 2]
+        rect = (-1.0, -1.0, edge[0], edge[1])
+
+        half_open = refs_in_rect(pcb, rect)
+        closed = sorted({ref for x, y, ref in pads
+                         if rect[0] <= x <= rect[2] and rect[1] <= y <= rect[3]})
+        report('the probe rectangle really does separate the two rules',
+               half_open != closed,
+               'half-open %s vs closed %s' % (half_open, closed))
+        if half_open == closed:
+            return
+
+        out = os.path.join(wd, 'out.kicad_pcb')
+        r = check(_argv(b, out, '--intent', it, '--dry-run',
+                        '--reseat-region', repr(rect[0]), repr(rect[1]),
+                        repr(rect[2]), repr(rect[3])), accept=True)
+        line = next((ln for ln in r.stdout.splitlines()
+                     if ln.strip().startswith('region [')), '')
+        report('the CLI printed its region line', bool(line), r.stdout[-300:])
+        named = sorted(x.strip() for x in
+                       line.split('part(s)')[1].split(',')) if 'part(s)' in line \
+            else []
+        named = [x for x in named if x and x != '...']
+        report('the mover lifts the HALF-OPEN set, not the closed one',
+               named == half_open,
+               'CLI %s / half-open %s / closed %s' % (named, half_open, closed))
+
+
 def t_the_policy_stays_explicit():
     """Property 2: the acceptance basis must be the EXPLICIT one.
 
@@ -222,6 +275,8 @@ def t_the_union_with_named_refs():
 
 TESTS = [
     ('one rectangle, one answer', t_a_region_names_the_same_parts_the_census_does),
+    ('the mover resolves it the same way, ON the boundary',
+     t_the_mover_resolves_the_rectangle_THE_SAME_WAY),
     ('the policy stays explicit', t_the_policy_stays_explicit),
     ('an empty region is a result', t_an_empty_region_is_a_result_not_a_failure),
     ('a bare --reseat beside a region is refused',

--- a/tests/test_709_reseat_region.py
+++ b/tests/test_709_reseat_region.py
@@ -180,7 +180,7 @@ def t_the_policy_stays_explicit():
                next((ln for ln in txt.splitlines()
                      if ln.startswith('Reseat')), '<no Reseat line>'))
         report('the selector is disclosed beside it, not inside scope_source',
-               'scope_selector: region:0,0,20,14' in txt,
+               'scope_selector: region:0.0,0.0,20.0,14.0' in txt,
                next((ln for ln in txt.splitlines()
                      if 'scope_selector' in ln), '<none>'))
         line = next((ln for ln in txt.splitlines()
@@ -201,20 +201,50 @@ def t_the_policy_stays_explicit():
 
 
 def t_an_empty_region_is_a_result_not_a_failure():
-    """It must NOT fall through to `refs=None`, which is the AUTO scope under
-    a different acceptance rule entirely."""
-    with tempfile.TemporaryDirectory() as wd:
-        b, it = _fixture(wd)
-        out = os.path.join(wd, 'out.kicad_pcb')
-        r = check(_argv(b, out, '--intent', it, '--dry-run',
-                        '--reseat-region', '900', '900', '910', '910'),
-                  accept=True)
-        report('an empty region exits 0', r.returncode == 0, r.stdout[-300:])
-        report('  ...and says the region is empty, in those words',
-               'contain no part' in r.stdout, r.stdout[-300:])
-        report('  ...and does NOT silently become the auto scope',
-               'auto:damage_witnesses' not in r.stdout
-               and 'Reseat (auto' not in r.stdout, r.stdout[-300:])
+    """A no-op still writes a board, still summarises, and still repairs.
+
+    The first version of this case ran `--dry-run` and asserted rc 0 plus two
+    stdout substrings -- which is a test of the MESSAGE, not of the contract.
+    It passed identically while an early `return 0` skipped the output board,
+    the JSON summary and the entire `--repair` pass, so
+    `--repair --reseat-region <empty>` exited 0 having produced nothing. The
+    invariant place_seed states three lines from the skipped write is the one
+    that was broken: "'nothing needed doing' must not look like 'the tool
+    produced nothing'". So this runs for real, on both arms.
+    """
+    for label, extra in (('alone', []), ('with --repair', ['--repair'])):
+        with tempfile.TemporaryDirectory() as wd:
+            b, it = _fixture(wd)
+            out = os.path.join(wd, 'out.kicad_pcb')
+            r = check(_argv(b, out, '--intent', it,
+                            '--reseat-region', '900', '900', '910', '910',
+                            *extra), accept=True)
+            report('%s: an empty region exits 0' % label,
+                   r.returncode == 0, r.stdout[-300:])
+            report('  %s: the OUTPUT BOARD is still written' % label,
+                   os.path.isfile(out) and os.path.getsize(out) > 0,
+                   'exists=%s' % os.path.isfile(out))
+            line = next((ln for ln in r.stdout.splitlines()
+                         if ln.startswith('JSON_SUMMARY: ')), None)
+            report('  %s: the JSON summary is still emitted' % label,
+                   line is not None, r.stdout[-300:])
+            if line:
+                doc = json.loads(line[len('JSON_SUMMARY: '):])
+                report('  %s: the scope stayed EXPLICIT and empty' % label,
+                       doc.get('scope_source') == 'explicit'
+                       and doc.get('scope') == [],
+                       '%s / %s' % (doc.get('scope_source'), doc.get('scope')))
+                report('  %s: and it is reported ACCEPTED, not refused' % label,
+                       doc.get('accepted') is not False,
+                       str(doc.get('accepted')))
+            report('  %s: says the region is empty, in those words' % label,
+                   'contain no part' in r.stdout, r.stdout[-300:])
+            report('  %s: does NOT silently become the auto scope' % label,
+                   'auto:damage_witnesses' not in r.stdout
+                   and 'Reseat (auto' not in r.stdout, r.stdout[-300:])
+            if extra:
+                report('  %s: the repair pass still RAN' % label,
+                       'Repair:' in r.stdout, r.stdout[-400:])
 
 
 def t_a_bare_reseat_beside_a_region_is_refused():
@@ -259,18 +289,44 @@ def t_a_region_alone_implies_an_explicit_reseat():
 
 
 def t_the_union_with_named_refs():
+    """The union must be a union of the RESOLVED SCOPE, not of a printed line.
+
+    The first version asserted on the disclosure string, which is computed from
+    `args.reseat` and never from `reseat['scope']` -- so replacing
+    `_refs.extend(_region_refs)` with `_refs = list(_region_refs)` silently
+    dropped the named ref and the test stayed green while printing "1 named".
+    """
     with tempfile.TemporaryDirectory() as wd:
         b, it = _fixture(wd)
         out = os.path.join(wd, 'out.kicad_pcb')
+        pcb = parse_kicad_pcb(b)
+        region = (0.0, 0.0, 20.0, 14.0)
+        from_region = refs_in_rect(pcb, region)
+        report('the region and the named ref are DISJOINT, or this proves '
+               'nothing', 'R8' not in from_region, str(from_region))
         r = check(_argv(b, out, '--intent', it, '--dry-run',
                         '--reseat', 'R8',
                         '--reseat-region', '0', '0', '20', '14'), accept=True)
         report('named refs and a region union into one explicit scope',
                'Reseat (explicit)' in r.stdout, r.stdout[-300:])
         line = next((ln for ln in r.stdout.splitlines()
-                     if 'scope_selector' in ln), '')
-        report('  ...and the split is disclosed (n from the region, m named)',
-               'from the region' in line and '1 named' in line, line)
+                     if ln.startswith('JSON_SUMMARY: ')), None)
+        report('a JSON summary is emitted', line is not None)
+        if not line:
+            return
+        scope = set(json.loads(line[len('JSON_SUMMARY: '):]).get('scope') or [])
+        report('  the NAMED ref is in the resolved scope', 'R8' in scope,
+               str(sorted(scope)))
+        report('  every region ref is in it too',
+               set(from_region) <= scope, str(sorted(scope)))
+        report('  and the scope is exactly their union',
+               scope == set(from_region) | {'R8'},
+               '%s vs %s' % (sorted(scope), sorted(set(from_region) | {'R8'})))
+        sel = next((ln for ln in r.stdout.splitlines()
+                    if 'scope_selector' in ln), '')
+        report('  the split is disclosed against the SCOPE, and adds up',
+               ('%d of %d in scope came from the region, 1 from --reseat'
+                % (len(from_region), len(scope))) in sel, sel)
 
 
 TESTS = [

--- a/tests/test_709_reseat_region.py
+++ b/tests/test_709_reseat_region.py
@@ -97,12 +97,19 @@ def t_a_region_names_the_same_parts_the_census_does():
     report('every census window resolves to the same refs the mover would lift',
            not disagree, str(disagree[:2]))
     rt = doc.get('reseat_target')
-    report('the census prints a reseat_region argument', bool(rt), str(rt))
+    report('the census names a landing site', bool(rt), str(rt))
     if rt:
-        report('  ...and it is a well-formed rectangle',
-               rt['reseat_region'][2] > rt['reseat_region'][0]
-               and rt['reseat_region'][3] > rt['reseat_region'][1],
-               str(rt['reseat_region']))
+        report('  ...as a well-formed rectangle',
+               rt['zone'][2] > rt['zone'][0] and rt['zone'][3] > rt['zone'][1],
+               str(rt['zone']))
+        # ...and deliberately NOT as a --reseat-region argument. A cold band
+        # holds no part by construction, so that command resolves to an empty
+        # scope on every board -- which is what the census used to advertise.
+        report('  ...and NOT as a --reseat-region argument',
+               'reseat_region' not in rt, str(sorted(rt)))
+        report('  ...which the mover agrees with: the zone lifts nothing',
+               refs_in_rect(pcb, tuple(rt['zone'])) == [],
+               str(refs_in_rect(pcb, tuple(rt['zone']))))
     report('the census run itself is clean', r.returncode == 0)
 
 

--- a/tests/test_709_reseat_region.py
+++ b/tests/test_709_reseat_region.py
@@ -1,0 +1,261 @@
+"""`place_seed --reseat-region`: naming a reseat scope by GEOMETRY (#459/#709).
+
+#459's 2026-08-22 comment names what was missing: "`reseat_scope` already
+lifts a named set ... what is missing is a way to name a REGION rather than a
+ref list, plus a gate that can accept an on-board part." The gate half landed
+as #698. This is the region half, and the two things that make it correct are
+both easy to get wrong:
+
+1. THE RECTANGLE MUST MEAN ONE THING. `check_pockets` prints a rectangle and
+   this lifts the parts in it. Both go through `placement.utility.refs_in_rect`
+   -- not two lookalike pad scans that agree until they do not.
+
+2. THE SCOPE SOURCE MUST STAY `'explicit'`. `seeder.reseat_accept` switches on
+   `scope_source != 'explicit'` by STRING EQUALITY (seeder.py:2834). A
+   'region:...' source would drop every region re-seat into the
+   `auto:oob-strict` policy, which a legal on-board part can never satisfy --
+   the pass would refuse everything and read as broken rather than as wrong.
+   So the region is resolved to refs at the CLI layer and handed to the
+   ordinary `refs=` argument, and the provenance is reported in a SEPARATE
+   key.
+
+And the claim this makes must not be bigger than the thing: a re-seat lands
+each part at its own net centroid, so pointing it at an empty region does not
+move anything INTO that region. That is intent-zone work, and the help text
+and the census both say so.
+
+# Comment above the marker, never after it -- a trailing one voids run_all's
+# `...True\s*$` anchor.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+RUN_ALL_FAST_OK = True
+RUN_ALL_TIMEOUT = 600
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ROOT, 'tests'))
+for _d in ('py_router', 'py_placer', 'py_tools'):
+    sys.path.insert(0, os.path.join(ROOT, _d))
+
+from run_utils import check, evidence, tool                     # noqa: E402
+import test_698_reseat_acceptance as F698                       # noqa: E402
+from kicad_parser import parse_kicad_pcb                        # noqa: E402
+from placement.utility import refs_in_rect                      # noqa: E402
+
+SEED = tool('place_seed.py')
+POCKETS = tool('check_pockets.py')
+
+FAILURES = []
+
+
+def report(name, ok, detail=''):
+    # A PASS prints its label only; a FAIL prints the evidence. Dumping a
+    # whole stdout beside every green row buries the one red one.
+    d = ' '.join(str(detail).split())[:300]
+    print(('  PASS  ' + name) if ok
+          else ('  FAIL  ' + name + (('  -- ' + d) if d else '')))
+    if not ok:
+        FAILURES.append(name)
+
+
+def _argv(*extra):
+    return [sys.executable, '-X', 'utf8', SEED] + list(extra)
+
+
+def _fixture(wd):
+    """test_698's plain board: CON2/U1/U2 clustered, R8/R9 off to the side."""
+    b = F698.plain_board(wd)
+    _p, it = F698.plain_intent(wd)
+    return evidence(b, 'the region fixture board'), _p
+
+
+def t_a_region_names_the_same_parts_the_census_does():
+    """Property 1, on a REAL board and through both fronts.
+
+    check_pockets resolves a window's refs and place_seed resolves a region's
+    refs. Same rectangle, same call, so the answers cannot drift.
+    """
+    board = evidence(os.path.join(ROOT, 'kicad_files', 'esp_prog.kicad_pcb'))
+    pcb = parse_kicad_pcb(board)
+    with tempfile.TemporaryDirectory() as td:
+        jp = os.path.join(td, 'p.json')
+        r = check([sys.executable, '-X', 'utf8', POCKETS, board,
+                   '--json', jp, '--top', '4'], accept=True)
+        doc = json.load(open(jp, encoding='utf-8'))
+    hot = [w for w in doc['windows'] if w.get('refs')]
+    report('the census names refs on at least one window', bool(hot),
+           '%d windows' % len(doc['windows']))
+    if not hot:
+        return
+    disagree = [w['window'] for w in hot
+                if refs_in_rect(pcb, tuple(w['window'])) != w['refs']]
+    report('every census window resolves to the same refs the mover would lift',
+           not disagree, str(disagree[:2]))
+    rt = doc.get('reseat_target')
+    report('the census prints a reseat_region argument', bool(rt), str(rt))
+    if rt:
+        report('  ...and it is a well-formed rectangle',
+               rt['reseat_region'][2] > rt['reseat_region'][0]
+               and rt['reseat_region'][3] > rt['reseat_region'][1],
+               str(rt['reseat_region']))
+    report('the census run itself is clean', r.returncode == 0)
+
+
+def t_the_policy_stays_explicit():
+    """Property 2: the acceptance basis must be the EXPLICIT one.
+
+    If this ever reads `auto:oob-strict`, a region re-seat of a legal on-board
+    part can never be accepted and the flag is decorative.
+    """
+    with tempfile.TemporaryDirectory() as wd:
+        b, it = _fixture(wd)
+        out = os.path.join(wd, 'out.kicad_pcb')
+        # A rectangle around the CON2/U1/U2 cluster.
+        r = check(_argv(b, out, '--intent', it, '--dry-run',
+                        '--reseat-region', '0', '0', '20', '14'), accept=True)
+        txt = r.stdout
+        report('the run is clean', r.returncode == 0, txt[-300:])
+        report('the region line names its parts', 'region [0,0]-[20,14]' in txt,
+               txt[:400])
+        report('the scope is reported EXPLICIT, not auto',
+               'Reseat (explicit)' in txt,
+               next((ln for ln in txt.splitlines()
+                     if ln.startswith('Reseat')), '<no Reseat line>'))
+        report('the selector is disclosed beside it, not inside scope_source',
+               'scope_selector: region:0,0,20,14' in txt,
+               next((ln for ln in txt.splitlines()
+                     if 'scope_selector' in ln), '<none>'))
+        line = next((ln for ln in txt.splitlines()
+                     if ln.startswith('JSON_SUMMARY: ')), None)
+        report('a JSON_SUMMARY line is emitted', line is not None)
+        if line:
+            doc = json.loads(line[len('JSON_SUMMARY: '):])
+            report('the summary carries scope_source == explicit',
+                   doc.get('scope_source') == 'explicit',
+                   str(doc.get('scope_source')))
+            report('  ...and scope_selector as a SEPARATE key',
+                   (doc.get('scope_selector') or '').startswith('region:'),
+                   str(doc.get('scope_selector')))
+            ab = doc.get('accept_basis') or {}
+            report('  ...and the accept basis is an explicit policy',
+                   str(ab.get('policy', '')).startswith('explicit'),
+                   str(ab.get('policy')))
+
+
+def t_an_empty_region_is_a_result_not_a_failure():
+    """It must NOT fall through to `refs=None`, which is the AUTO scope under
+    a different acceptance rule entirely."""
+    with tempfile.TemporaryDirectory() as wd:
+        b, it = _fixture(wd)
+        out = os.path.join(wd, 'out.kicad_pcb')
+        r = check(_argv(b, out, '--intent', it, '--dry-run',
+                        '--reseat-region', '900', '900', '910', '910'),
+                  accept=True)
+        report('an empty region exits 0', r.returncode == 0, r.stdout[-300:])
+        report('  ...and says the region is empty, in those words',
+               'contain no part' in r.stdout, r.stdout[-300:])
+        report('  ...and does NOT silently become the auto scope',
+               'auto:damage_witnesses' not in r.stdout
+               and 'Reseat (auto' not in r.stdout, r.stdout[-300:])
+
+
+def t_a_bare_reseat_beside_a_region_is_refused():
+    """#698 gave the two scopes different acceptance rules; merging them
+    silently is how that distinction disappears."""
+    with tempfile.TemporaryDirectory() as wd:
+        b, it = _fixture(wd)
+        out = os.path.join(wd, 'out.kicad_pcb')
+        check(_argv(b, out, '--intent', it, '--reseat',
+                    '--reseat-region', '0', '0', '20', '14'),
+              code=2, refuse='different rules',
+              allow=('error: argument',))
+        report('a bare --reseat beside a region is refused for that reason',
+               True)
+
+
+def t_an_inverted_rectangle_is_refused():
+    with tempfile.TemporaryDirectory() as wd:
+        b, it = _fixture(wd)
+        out = os.path.join(wd, 'out.kicad_pcb')
+        check(_argv(b, out, '--intent', it,
+                    '--reseat-region', '20', '14', '0', '0'),
+              code=2, refuse='X1>X0', allow=('error: argument',))
+        check(_argv(b, out, '--intent', it,
+                    '--reseat-region', '0', '0', '20', '0'),
+              code=2, refuse='Y1>Y0', allow=('error: argument',))
+        report('an inverted / degenerate rectangle is refused by its reason',
+               True)
+
+
+def t_a_region_alone_implies_an_explicit_reseat():
+    """Typing --reseat too must not be required; a region IS a scope."""
+    with tempfile.TemporaryDirectory() as wd:
+        b, it = _fixture(wd)
+        out = os.path.join(wd, 'out.kicad_pcb')
+        r = check(_argv(b, out, '--intent', it, '--dry-run',
+                        '--reseat-region', '0', '0', '20', '14'), accept=True)
+        report('--reseat-region alone runs a re-seat',
+               'Reseat (explicit)' in r.stdout, r.stdout[-300:])
+        report('  ...and --dry-run is accepted without --reseat being typed',
+               r.returncode == 0)
+
+
+def t_the_union_with_named_refs():
+    with tempfile.TemporaryDirectory() as wd:
+        b, it = _fixture(wd)
+        out = os.path.join(wd, 'out.kicad_pcb')
+        r = check(_argv(b, out, '--intent', it, '--dry-run',
+                        '--reseat', 'R8',
+                        '--reseat-region', '0', '0', '20', '14'), accept=True)
+        report('named refs and a region union into one explicit scope',
+               'Reseat (explicit)' in r.stdout, r.stdout[-300:])
+        line = next((ln for ln in r.stdout.splitlines()
+                     if 'scope_selector' in ln), '')
+        report('  ...and the split is disclosed (n from the region, m named)',
+               'from the region' in line and '1 named' in line, line)
+
+
+TESTS = [
+    ('one rectangle, one answer', t_a_region_names_the_same_parts_the_census_does),
+    ('the policy stays explicit', t_the_policy_stays_explicit),
+    ('an empty region is a result', t_an_empty_region_is_a_result_not_a_failure),
+    ('a bare --reseat beside a region is refused',
+     t_a_bare_reseat_beside_a_region_is_refused),
+    ('an inverted rectangle is refused', t_an_inverted_rectangle_is_refused),
+    ('a region alone implies --reseat', t_a_region_alone_implies_an_explicit_reseat),
+    ('union with named refs', t_the_union_with_named_refs),
+]
+
+
+def _every_case_is_registered():
+    g = globals()
+    declared = {fn for _l, fn in TESTS}
+    missing = sorted(n for n, v in g.items()
+                     if n.startswith('t_') and callable(v)
+                     and v not in declared)
+    if missing:
+        print('  FAIL  every t_* case is registered in TESTS  -- ORPHANED: %s'
+              % ', '.join(missing))
+        FAILURES.append('unregistered cases: %s' % ', '.join(missing))
+
+
+def main():
+    print('place_seed --reseat-region (#459 region half / #709 handoff)')
+    for label, fn in TESTS:
+        print(' ' + label)
+        fn()
+    _every_case_is_registered()
+    if FAILURES:
+        print('\nFAILED (%d): %s' % (len(FAILURES), ', '.join(FAILURES)))
+        return 1
+    print('\nOK')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
The pocket census could not represent an empty window, so the finding a
placement reviewer most wants — *"there is a clear empty pocket here, a 6–8 mm
band"* — was unproducible by construction. It can now say it, rank empty
regions by contiguous area, and print the arrangement statistic that belongs
beside them.

## The defect

`congestion_field.congestion_bins` assembled its result by iterating the
`owners` map, and `owners` only gains a key where some net has a terminal. A
window with nothing in it never entered the dict — and `check_pockets` printed
`len(bins)` as its window count, so an empty region was not merely un-ranked,
it was not a window at all.

Re-measured at the default 2 mm bin:

| board | census windows | lattice over `board_bounds` | invisible |
|---|---|---|---|
| `esp_prog` | 44 | 128 | **84 (65.6 %)** |
| `glasgow_revC` | 457 | 1000 | **543 (54.3 %)** |

`esp_prog` reproduces the issue's own figure exactly. `glasgow_revC` does not
reproduce its quoted *"538 of 1000"* — the re-measured number is 543, and the
5-window delta is unexplained; this PR quotes what it measured.

## What it does now

It reproduces the reviewer's own sentence. On `esp_prog`:

```
COLD regions (in-outline, no demand net, no copper, no part courtyard): 4 region(s), 29 window(s); outline from bounding_box
  of 128 in-outline window(s): 44 carry demand, 11 sit under a part, 44 are part-free but carry copper, 29 are cold
  #1       55.8 mm2    22 window(s)  band 32 x 2mm at [114,90]-[146,92]
  #2       12.0 mm2     3 window(s)  band 2 x 6mm at [134,94]-[136,100]
  #3        7.5 mm2     2 window(s)  band 4 x 2mm at [142,94]-[146,96]
       bbox [142,94]-[146,96]  fill 0.94  bounded by CON1, CON2, R4  edge-touching
arrangement: courtyard-AREA-weighted part centroid on side F is 0.40mm W, 0.84mm S of board centre
  = 1.3% / 5.8% of span (part COUNT would say 13.7% / 11.9% -- a control, never the answer)
  quadrant NW (region:q0)    0 part(s) /  33.6mm2 /  12 net-window(s) of demand (11 distinct) /  14 cold
  ...
reseat target: largest landing site is the 31.75 x 1mm band at [114,91]-[145.75,92]; the mass wants to move NE
  This is a DESTINATION, not a scope. A cold band holds no part by construction,
  so `--reseat-region` over it resolves to an empty scope on every board.
```

Region #3 *is* "an empty band south of CON2's eastern half", and a test pins it.

Four buckets that **partition** the in-outline windows, because the distinctions
the tool exists to draw are the ones that vanish if a window is quietly dropped:

- **cold is not "unreported"** — most windows the old census could not see sit
  under a part or on copper, and neither is a pocket.
- **part-free is not "empty"** — on `routed_output` under `--nets GND`, 190
  part-free windows carry another net's copper.
- **and "no copper" needs a swept test, not midpoint accounting.**
  `congestion_bins` charges a segment's whole area to the bin holding its
  MIDPOINT, so a track crossing a window with its midpoint elsewhere left it
  reading cold. On `rp2350_fpga_eensy_prePlane` at `--bin 1.0` — the bin the
  docs' own example uses — 27 of 159 cold windows had a track through them.
  With the swept test: 159 → 24.

## Where the issue's own suggestions are wrong

**"the bins need aligning to the outline"** is unsafe *and* unnecessary.
`congestion2_rows` maps a bin key back with `coord.to_grid(bx*bin, by*bin)` and
evaluates its owner-exemption disk in absolute mm; `global_plan.demand_points`
emits absolute mm binned by the same rule. Re-origining breaks both **silently**,
because congestion-v2 is off by default. And it would change nothing on either
board the issue measures: the absolute lattice tiles both with zero zero-area
straddles. A straddling window is not wrong, it is *partial*, so each carries
its in-outline area fraction instead.

**The sweep's cost is a non-issue.** `extract_board_contours` deliberately
returns no rings for a plain axis-aligned rectangle ("use bounding box"), so
`BoardOutlineGate.active` is False on `esp_prog`, `glasgow_revC`, `tigard` and
`splitflap_driver` and the in-outline area is an exact closed form. Only
`watchy` (2 cutouts) and the three `interf_u_*` have rings. The census is
0.6–1.9 s on every board in `kicad_files/` at the default bin.

**"a clear empty pocket west of U2, roughly a 6–8 mm wide band" does not
reproduce** on stock `esp_prog`: U2's rect is x 132.04–133.54 and the 6–8 mm
west of it is occupied by U1 (x 123.91–130.09), which carries demand. The CON2
half of the sentence reproduces exactly. Only the cold class the issue
specified is shipped.

**"14 west / 6 east with the centroid 3.41 mm west" does not reproduce** on
`esp_prog` under any obvious reading — W/E is 3/14 by courtyard centre and the
centroid is *east*. Worth identifying the board before that number is cited
again.

## Why the centroid is area-weighted

The issue's caution is right and it reproduces on the board it names: on
`esp_prog` the area form reads **1.3 %** of span where the count form reads
**13.7 %**. The count form is printed beside it as a labelled control, never as
the answer. Across six corpus boards the two disagree on five — **and in both
directions** (`watchy` and `sonde_u` have the *area* form larger), so this is a
different statistic rather than a flattering one.

`placement_state` records the standing objection that courtyard-area metrics
"need polygon area and break on the boards with no courtyards at all". They do
not: `graded_parts_from_file` returns axis-aligned rects, and a footprint that
draws no courtyard falls back to its pad bbox, which is real copper. Only a
footprint with neither is the ±0.5 mm fiction, and those are excluded and
counted. The provenance is printed, which matters more than it sounds —
**`esp_prog` draws no courtyards at all** (0 of 20 refs; `tigard` draws 89), so
without that line the tool would label pad extents as courtyard area without
comment.

## The #459 half

`place_seed --reseat-region X0 Y0 X1 Y1` names a reseat scope by geometry. That
is the gap #459's 2026-08-22 comment still names — *"what is missing is a way
to name a **region** rather than a ref list, plus a gate that can accept an
on-board part"* — whose other half landed as #698.

Both fronts resolve a rectangle through the same
`placement.utility.refs_in_rect`, half-open, so the rectangle the census prints
and the rectangle the mover lifts cannot mean two different sets of parts.

Two things that would have broken it, avoided deliberately:

- **The scope source stays `'explicit'`.** It would have been natural to thread
  the rectangle into `reseat_scope` and give it `scope_source='region:...'`.
  That is a trap: `reseat_accept` switches on `scope_source != 'explicit'` by
  string equality, so every region re-seat would fall into `auto:oob-strict`,
  which a legal on-board part can never satisfy. The pass would refuse
  everything and read as broken rather than as wrong. The rectangle is resolved
  at the CLI layer into the ordinary `refs=`, and the provenance is reported in
  a separate `scope_selector` key.
- **An empty region goes THROUGH `reseat_scope`**, on the explicit branch, into
  seeder's own `_empty()`. It does not return early — an early return skipped
  the output board, the JSON summary and the whole `--repair` pass, so
  `--repair --reseat-region <empty>` exited 0 having produced nothing.
  `--reseat ZZ99` is the same event and was already handled correctly.

**A cold band is a DESTINATION and cannot be a scope**, which the census now
says outright. A cold window can never contain a pad centre — a pad's area is
charged to its bin, so a window holding one reads as carrying copper, never
cold. Measured over **428 060 cold windows on 29 boards, exactly zero contained
a pad centre**, so the `--reseat-region <cold band>` command an earlier draft
printed resolved to an empty scope on every board, every time. The band's real
use is as an intent block `zone`, the one thing in the stack that aims a re-seat
at a rectangle; the scope to lift is the crowded rectangle, and the census names
the parts bounding the pocket instead.

### On #459 more broadly

Its four numbered items landed elsewhere and this PR is not what completed
them: item 3 in #538, item 4 in #542, item 1 in #802 — which measured a null,
`--target-select diagnosis` has never been shown to route better than `pins` —
and item 2 in #804, which ships `--relocate` **default-off** because the routed
A/B went against it. The grading harness is #411.

The open question in #459's closing comment stands and this PR does not answer
it: relocation never fires on a board that already routes (the loop stops at
`failures == 0`), `--group-by auto` derives no block on 5 of the 6
placement-graded boards, and `kit-dev-coldfire` — the one board where every
precondition holds — is already taken 3 → 0 by the shipped loop.

## Discoverability

`check_pockets` appeared in **no** `.md` file anywhere in the repo — not
`README`, not `docs/utilities.md` (which documents `check_drc`, `check_join`,
`check_connected`, `check_orphan_stubs` and `check_pads` but not this), not a
skill, and not `krt_capabilities.KNOWN_MODULES`. An orphan instrument produces
no findings. All four are fixed.

## Predictor columns

#703's comment on this issue set the right bar — a congestion census "has to
earn its place against +0.785 predictors that are already computed" — so four
scalars ride in every study row and the per-board sign test can answer it.

`centroid_offset_frac` is the **magnitude**, not the X term: the study's own
`translate` and `wrong_side` damage kinds move mass in Y, and an X-only column
is blind to them. Measured, translating every `esp_prog` footprint +10 mm in Y
leaves the X term at 0.0127 while the Y term goes 0.0581 → 0.7478;
`splitflap_driver` authored reads X 0.0002 against Y 0.1395, so the X-only
column would record "dead centre" for a board whose mass sits 14 % of the span
off.

On the choice of the cold scalars over the hot ranking, stated honestly: the
hot list is bounded below by the ≥ 2-net rule and can empty out, where the cold
scalars are defined on every board. `rank_stats` asserts an empty ranked list on
three of five real boards, but it names none of them and cites no committed
measurement — and re-measured, the ranked list is **non-empty on all 8**
study/calibration boards. That causal clause is not one to repeat.

**No rho is claimed and no doc gets a number.** Re-deriving that table is the
8.8-hour job whose rows were withdrawn on review.

## Verification

- **Five new fast test files**, all `unit`-classified and in `--fast`.
  `tests/test_run23_pockets.py` passes **unmodified**: `windows` keeps exactly
  its old contents, no new printed line begins with `[`, and every new number
  is finite.
- **A 35-row mutation battery**: 34 killed, and one declared an EQUIVALENT
  mutant with its reason measured — the swept-copper stamp is a strict superset
  of the free-area rule (2 629 occupied bins over 5 boards × 2 bin sizes, zero
  strays), so dropping the free-area arm cannot change an answer. The row is
  kept and labelled rather than deleted, and the battery now fails if a
  declared-equivalent mutation goes red: "cannot change an answer" and "nobody
  covered it" look identical in a survivor list otherwise.
- **Three adversarial review passes** — one per half plus one on
  `congestion_bins` — whose findings are all in the branch.

Between them and my own battery they caught, **in my own work**: a blocking bug
where the empty-region path skipped the output board, the summary and the
repair; a headline command that provably lifted nothing on every board; a cold
predicate that called a track-crossed window empty; a grading failure that read
as "the board has no parts" (81 cold windows instead of 29, a phantom 260 mm²
pocket on top of U1); a window bucket silently dropped (52 of 128); a test guard
excluded from `--fast` by a trailing comment that both voided the opt-out and
tripped the integration proxy; an order assertion that compared the code with
itself and passed a `sorted(set(...))` union; **a claim of mine overstated in
the change's own favour** — I wrote that bin order is "the row order of an array
the router prices cells with", and the consumer is a per-cell max-insert and is
order-insensitive; `--bin inf` writing bare `Infinity` into the JSON;
`ceil(21.0/0.7) == 31` inventing 59 off-board windows; a union test that did not
test the union; a test function defined and left out of its own registry; and
three test rows whose labels claimed more than they asserted.

`test_698_reseat_acceptance` (119/119), `test_place_seed` (37/37),
`test_431_skill_commands`, `test_krt_capabilities`, `test_703_from_rows`,
`test_703_predictor_claims` and `test_703_predictor_harvest` all pass.

**`tests/run_all.py --fast`: 334 passed, 5 failed, 0 timed out, 137 skipped.**
All five failures reproduce at `upstream/main` `661c88b3` with no branch
applied, each run there directly rather than inferred:
`test_756_fanout_clearance_drill_floors`, `test_761_legality_npth_keepout`,
`test_768_cap_clearance_ceiling`, `test_boxed_in_summary` and
`test_703_predictor_regen`.

`test_703_predictor_regen` fails on `truth.quality` (vias / copper_mm /
segments) — the router producing a different route than the recorded rows.
**It fails identically at `upstream/main` with no branch applied**, and it got
worse there independently of this work: 2 of 4 rows at `a110116d`, **4 of 4 at
`661c88b3`**, which is what #811 merging collinear segments would do to a
recorded `segments` count. Nothing here touches the router — `congestion_bins`
is bit-identical on its default path, verified over 1 760 comparisons across
22 boards × 4 bin sizes × 4 net subsets × 5 kwarg spellings, plus 104
forced-else-branch cases over 26 boards.

Closes #709
Closes #459
Refs #698 #703
