### PR TITLE
test(#797): re-anchor the mutation row that #706 and #797 landing together moved

### DIFF
--- a/tests/mutate_797.py
+++ b/tests/mutate_797.py
@@ -278,10 +278,24 @@ ROWS = [
      "",
      (T797S,), 'KILLED'),
 
+    # RE-ANCHORED after #797 and #706 landed together. Both PRs extended this
+    # one condition, for independent reasons -- #701 arms the ladder on a
+    # declared KEEP-OUT, #706 on a DECLARED POSITION, #797 on a declared
+    # EXCLUSIVE ZONE -- and the merge resolved to the disjunction of all
+    # three. The anchor here still described the two-clause form, so it
+    # matched 0 times and the battery reported BROKEN rather than applying the
+    # edit somewhere it did not belong. That is the count-before-write check
+    # doing its job across a merge, and it is why this row is worth having.
+    #
+    # The mutation still removes ONLY the exclusive clause: a row that also
+    # dropped #706's would be testing that PR's feature rather than this one,
+    # and would go red for a reason #797 has nothing to do with.
     ('the-edge-slide-is-armed-for-keepouts-only', 's',
      "            _slide = ((0.0,) if not (state.keepouts_for.get(ref)\n"
+     "                                     or _dec is not None\n"
      "                                     or state.exclusive_for.get(ref)) else",
-     "            _slide = ((0.0,) if not state.keepouts_for.get(ref) else",
+     "            _slide = ((0.0,) if not (state.keepouts_for.get(ref)\n"
+     "                                     or _dec is not None) else",
      (T797S,), 'KILLED'),
 
     # ---- rows kept as EXPECTED SURVIVORS, with the reason ---------------


### PR DESCRIPTION
`tests/mutate_797.py` reports **BROKEN** on `main` as of `f3484551`:

```
the-edge-slide-is-armed-for-keepouts-only   BROKEN   anchor matched 0 times
31 rows: 28 killed, 2 survived (2 of them expected), 1 broken
```

**The engine is correct — this is only the battery pointing at text that moved.**

## What happened

#706 (PR #822) and #797 (PR #823) each extended the *same* condition — the stage-1 along-edge slide ladder's arming test — for independent reasons:

| | arms the ladder when |
|---|---|
| #701 | a declared **keep-out** refuses the even-distribution fraction |
| #706 | the connector has a **declared position**, so two connectors declared at overlapping positions slide off each other |
| #797 | a declared **exclusive zone** refuses it |

The merge resolved to the disjunction of all three, which is right: any one of them can make that fraction unseatable, and the ladder is still skipped entirely when none holds. What it left behind is this battery row, whose anchor still described the two-clause form.

It matched **nothing** rather than something else, and the row was reported **BROKEN** rather than SURVIVED — which is the count-before-write check earning its place across a merge. A battery that silently applied nothing would have reported the row as a survivor, i.e. as a hole in the tests, when the tests are fine.

## The fix

Re-anchor to the three-clause form. The mutation still removes **only** the exclusive clause — a row that also dropped #706's would be testing that PR's feature rather than this one, and would go red for a reason #797 has nothing to do with.

Verified it still bites the right arm: with the clause gone, `E2-exclusive` fails on J1 leaving its declared south edge, and `E2` fails on the two declarations no longer costing the same seat — the asymmetry that row exists to catch.

## Measured

```
31 rows: 29 killed, 2 survived (2 of them expected), 0 broken
```

and **35/35** across every placement file the recently merged PRs added or touched: 549 ×5, 698, 700 ×3, 701 ×2, 702, 705, 706, 709 ×5, 711 ×2, 712, 792 ×3, 793, 794, 797 ×2, 798, 799 ×2.

One file, +15/−1, no engine change.

Refs #797
