### PR TITLE
#708: the placement candidate snap is absolute, and should be a whole number of the board's own grid

### DIFF
--- a/docs/placement-optimization.md
+++ b/docs/placement-optimization.md
@@ -805,7 +805,11 @@ is implemented, the rest are documented targets.
    snapping a ring to the placement grid moves a point by up to half a cell per
    axis, so slots generated *at* the radius land outside it — the pool shrinks
    by the snap diagonal, or the by-construction claim is false at exactly the
-   outer ring where a re-seat wants to look.
+   outer ring where a re-seat wants to look. Since #708 that snap is taken on
+   the offset **from the anchor**, not on the absolute point, so the pool
+   inherits the anchor's own phase instead of a lattice through board origin;
+   the shrink argument is unchanged, because the snap error per axis is still
+   half a cell.
 
 3. **The #411 undo-a-known-good-placement harness — BUILT.** See "What the
    #411 harness measured" below. `placement/perturb.py` manufactures the bad

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -1344,6 +1344,22 @@ Both sides resolve a rectangle through the same `placement.utility.refs_in_rect`
 (half-open on the far edges), so the rectangle the census prints and the
 rectangle the mover lifts cannot mean two different sets of parts.
 
+### The board's placement lattice (#708)
+
+The `JSON_SUMMARY` line also carries `board_grid_step`, `board_grid_occupancy`
+and `board_grid_reason`: the pitch the board appears to have been laid out on,
+read through the same `placement.board_grid.infer_board_grid` the placer
+resolves its candidate offsets with, so the census cannot report a pitch the
+engine does not use.
+
+`board_grid_step` is `None` for a board that declares no lattice, and that is a
+real answer rather than a missing one -- `board_grid_reason` says which test it
+failed (`best occupancy 0.226 < floor 0.67`, `n_parts 4 < 8`), so "no lattice"
+and "never measured" stay distinguishable from the summary line alone. Measured
+over the tracked corpus, 12 of 22 boards resolve: four imperial at 0.3175 mm
+(`splitflap_driver` 0.92, `flat_hierarchy` 0.83, `sonde_u` 0.78,
+`interf_u_unrouted` 0.70) and eight metric-fine at 0.05 mm.
+
 ### Example
 
 ```bash

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -1356,9 +1356,11 @@ engine does not use.
 real answer rather than a missing one -- `board_grid_reason` says which test it
 failed (`best occupancy 0.226 < floor 0.67`, `n_parts 4 < 8`), so "no lattice"
 and "never measured" stay distinguishable from the summary line alone. Measured
-over the tracked corpus, 12 of 22 boards resolve: four imperial at 0.3175 mm
+over the tracked corpus, 11 of 22 boards resolve: four imperial at 0.3175 mm
 (`splitflap_driver` 0.92, `flat_hierarchy` 0.83, `sonde_u` 0.78,
-`interf_u_unrouted` 0.70) and eight metric-fine at 0.05 mm.
+`interf_u_unrouted` 0.70) and seven metric-fine at 0.05 mm (`glasgow_revC`,
+`interf_u_unrouted_placed`, `haasoscope_pro_max_test`, `routed_output`,
+`lvds_converter_dualclk`, `lvds_converter_dualclk_gnd`, `esp_prog`).
 
 ### Example
 

--- a/py_placer/placement/README.md
+++ b/py_placer/placement/README.md
@@ -719,6 +719,89 @@ At `0.0` both hooks return before touching any geometry and the peer index is
 empty, so a default run is **bit-identical**, verified on `interf_u_unrouted` and
 `splitflap_driver` rather than argued.
 
+## The board's placement lattice (`board_grid.py`, #708)
+
+A board is laid out on a pitch. `splitflap_driver` puts 92% of its footprint
+coordinates on 0.3175 mm (12.5 mil), `glasgow_revC` 97% on 0.05 mm. The quench
+used to destroy that: `_candidate_positions` built candidates as
+`seed + ix*step` and then snapped the **absolute** result to a lattice through
+board origin, which discards the seed's residue. One pass took
+`splitflap_driver` from 0.923 of its coordinates on its own lattice to 0.269.
+
+Two things had to change, and the second is the one that does the work.
+
+**Snap the offset, not the position.** `seed + ix*step` already carries the
+board's phase; snapping the sum throws it away, because `seed_x` is not
+generally a multiple of anything. This half is free: measured, the absolute
+snap removed **zero** candidates at every step the tool ships (317/317 at
+`--step 1.0`, 49/49 at 0.5, 81/81 at 0.2) — the two sets are a pure
+translation of each other. `_group_offsets` had always snapped the offset,
+which is why block moves never had this defect and is the existence proof for
+the form.
+
+**Snap it to the board's lattice, not the raster.** Seed-relative alone is not
+enough, and this is worth stating because it is the obvious fix and it does not
+work: the offsets are multiples of `--grid-step` 0.1, and 1.0 is not a multiple
+of 0.3175, so only the *zero* offset lands back on an imperial lattice.
+Snapping the offset to the board's own pitch gives `{0, ±0.9525, ±1.905,
+±2.8575}`, every candidate stays on the lattice, and the count goes 317 → 325 —
+so it costs nothing either.
+
+Measured, one quench pass, fraction of footprint coordinates on the board's own
+lattice:
+
+| board | lattice | before | after (old) | after (now) | parts moved |
+|---|---|---|---|---|---|
+| `splitflap_driver` | 0.3175 | 0.923 | 0.269 | **0.923** | 43 |
+| `flat_hierarchy` | 0.3175 | 0.828 | 0.273 | **0.828** | 40 |
+| `sonde_u` | 0.3175 | 0.780 | 0.200 | **0.780** | 24 |
+
+The same parts still move. They now move by whole grid units.
+
+### There is no flag
+
+`resolve_snap_lattice` returns the board's inferred pitch, or `--grid-step`
+when the board declares none — which is exactly the granularity offsets have
+always had. The fallback **is** the off state, and the board reaches it rather
+than a flag. Ten of the 22 tracked boards take it, each with a stated reason,
+and `metrics_out['board_grid']` records which branch ran so "no lattice" and
+"never measured" cannot be confused.
+
+### Two rules in the inference that are not the obvious ones
+
+Both come from `tests/measure_708_lattice.py`, and both contradict the
+mechanism #708 proposes.
+
+**The tie-break is the finest rung within tolerance of the maximum, not the
+argmax.** The ladder contains divisibility chains (0.3175 | 0.635 | 1.27 |
+2.54), and occupancy is monotone along one — if `d` divides `s`, every on-`s`
+point is on-`d`. Ties are therefore structural, not accidental:
+`splitflap_driver` ties at 0.3175 *and* 0.635, `sonde_u` at 0.3175, 0.635 *and*
+1.27. An argmax has no defined answer there, and taking the coarsest would
+infer a 1.27 mm grid for `sonde_u` off a tie. A consequence worth knowing
+before simplifying this: only 0.05 and 0.3175 lack a ladder divisor, so they
+are the **only two values the function can return** — the issue's worry that a
+2.54 mm inference would quantize the search into uselessness cannot happen, and
+not because anything clamps it.
+
+**A rate needs a denominator.** `cap_chain` (4 parts) and the `qfn_*` fixtures
+(1–2) score 1.00 at six rungs, because hand-authored coordinates are round by
+construction. Below `MIN_PARTS` there is no answer to give.
+
+`OCCUPANCY_FLOOR` is 0.67 and not the rounder 0.70 for a reason worth keeping:
+`interf_u_unrouted` scores **exactly** 0.700000, so a 0.70 floor would rest on
+a corpus board where `>=` and `>` disagree on a float equality. 0.67 is the
+midpoint of the widest gap in the distribution (0.642424 → 0.700000).
+
+### Where the lattice deliberately does NOT apply
+
+`place_fanout_clearance` and `reseat.slot_pool` take the seed-relative half and
+keep the **raster**. Both searches *are* sub-millimetre clearance repair, and
+coarsening them starves exactly the search that must not be starved: at the cap
+repair's `step=0.2` the candidate count falls 81 → 29 on a 0.3175 lattice and
+81 → 9 on 0.635. `perturb` needed no change at all — it already snapped deltas,
+so it never had the defect, notwithstanding #708 naming it.
+
 ## Placement blocks (`groups.py`, #459)
 
 The per-part nudge cannot express "these parts need to travel together": an IC
@@ -1066,7 +1149,10 @@ is followed by a settle beat, so the moves only play once the camera has arrived
 | `legality.py` | Hard constraints shared by both engines: board side, real Edge.Cuts containment, and the OO/OoB graders (#456) |
 | `parser.py` | Courtyard boundary and locked-footprint extraction |
 | `writer.py` | Writes new positions/rotations (rotates pad angles with the footprint, as KiCad stores pad angle = footprint + pad rotation) |
-| `utility.py` | Shared utilities (bbox from pads, grid snapping) |
+| `board_grid.py`
+  The pitch a board was laid out on, inferred from its footprint origins (#708). Pure; no engine imports.
+
+`utility.py` | Shared utilities (bbox from pads, grid snapping) |
 
 ## Legality model (`legality.py`, #456)
 

--- a/py_placer/placement/README.md
+++ b/py_placer/placement/README.md
@@ -744,8 +744,19 @@ enough, and this is worth stating because it is the obvious fix and it does not
 work: the offsets are multiples of `--grid-step` 0.1, and 1.0 is not a multiple
 of 0.3175, so only the *zero* offset lands back on an imperial lattice.
 Snapping the offset to the board's own pitch gives `{0, ±0.9525, ±1.905,
-±2.8575}`, every candidate stays on the lattice, and the count goes 317 → 325 —
-so it costs nothing either.
+±2.8575}`, and every candidate stays on the seed's coset of the lattice.
+(Coset, not lattice: a part whose own seed is off-lattice keeps its residue
+rather than acquiring the board's — the fix preserves phase, it does not impose
+one. `splitflap_driver` has 8% of its coordinates off its own pitch.)
+
+Reach is comparable but not uniformly better. At the shipped default
+(`--max-displacement 10 --step 1.0`) the count goes 317 → 325; sweeping
+`max_displacement` from 0.5 to 19.5 at `--step 1.0`, 12 values gain candidates,
+17 tie and **10 lose** — worst 81 → 69 at 5.0 mm, because an offset the raster
+admitted at exactly the cap can snap *up* past it and is then correctly
+rejected. That is the price of making the displacement cap exact, and
+`place_route_loop` widens `--max-displacement` ×1.5 per rejected round, so it
+does reach those values.
 
 Measured, one quench pass, fraction of footprint coordinates on the board's own
 lattice:
@@ -756,14 +767,21 @@ lattice:
 | `flat_hierarchy` | 0.3175 | 0.828 | 0.273 | **0.828** | 40 |
 | `sonde_u` | 0.3175 | 0.780 | 0.200 | **0.780** | 24 |
 
-The same parts still move. They now move by whole grid units.
+The `parts moved` column is the new arm. The quench keeps moving comparably
+many parts — old vs new: 43/43 on splitflap, 45/40 on flat_hierarchy, 20/24 on
+sonde_u — but it is **not the same set**: splitflap swaps `U6` for `R8`, and
+flat_hierarchy drops six and gains one. That is expected, since the candidate
+set is genuinely different; what does not change is that the search is still
+free to move parts, and every move it makes is now a whole number of grid
+units.
 
 ### There is no flag
 
 `resolve_snap_lattice` returns the board's inferred pitch, or `--grid-step`
 when the board declares none — which is exactly the granularity offsets have
 always had. The fallback **is** the off state, and the board reaches it rather
-than a flag. Ten of the 22 tracked boards take it, each with a stated reason,
+than a flag. Eleven of the 22 tracked boards take it, each with a stated
+reason,
 and `metrics_out['board_grid']` records which branch ran so "no lattice" and
 "never measured" cannot be confused.
 
@@ -790,8 +808,12 @@ construction. Below `MIN_PARTS` there is no answer to give.
 
 `OCCUPANCY_FLOOR` is 0.67 and not the rounder 0.70 for a reason worth keeping:
 `interf_u_unrouted` scores **exactly** 0.700000, so a 0.70 floor would rest on
-a corpus board where `>=` and `>` disagree on a float equality. 0.67 is the
-midpoint of the widest gap in the distribution (0.642424 → 0.700000).
+a corpus board where `>=` and `>` disagree on a float equality. 0.67 clears it
+by 0.0276. It sits in a real gap (0.642424 → 0.700000) but **not the widest** —
+that is 0.2235, between `tigard` 0.592 and `rp2350` 0.369, and putting the
+floor there instead would admit `tigard` and `orangecrab_ext_pll` at 0.05. The
+module docstring has the full gap table; the floor rests on the boundary
+argument, not on a separation one.
 
 ### Where the lattice deliberately does NOT apply
 
@@ -1149,10 +1171,8 @@ is followed by a settle beat, so the moves only play once the camera has arrived
 | `legality.py` | Hard constraints shared by both engines: board side, real Edge.Cuts containment, and the OO/OoB graders (#456) |
 | `parser.py` | Courtyard boundary and locked-footprint extraction |
 | `writer.py` | Writes new positions/rotations (rotates pad angles with the footprint, as KiCad stores pad angle = footprint + pad rotation) |
-| `board_grid.py`
-  The pitch a board was laid out on, inferred from its footprint origins (#708). Pure; no engine imports.
-
-`utility.py` | Shared utilities (bbox from pads, grid snapping) |
+| `board_grid.py` | The pitch a board was laid out on, inferred from its footprint origins (#708). Pure; no engine imports |
+| `utility.py` | Shared utilities (bbox from pads, grid snapping) |
 
 ## Legality model (`legality.py`, #456)
 

--- a/py_placer/placement/board_grid.py
+++ b/py_placer/placement/board_grid.py
@@ -38,18 +38,29 @@ pins that as a property of the ladder.
 authored by hand are round by construction rather than by a design grid. Below
 `MIN_PARTS` there is no answer to give and the caller gets `None`.
 
-`OCCUPANCY_FLOOR` is the MIDPOINT of a real population gap, and it is not a
-round number for a reason worth keeping. Sorted best-occupancy over the tracked
-corpus (parts >= MIN_PARTS), the widest gap by a factor of two is
+`OCCUPANCY_FLOOR` is 0.67 because 0.70 -- the round number the population
+first suggests -- sits EXACTLY on a corpus board. `interf_u_unrouted` scores
+0.700000, so at a 0.70 floor `>=` admits it and `>` rejects it on a float
+equality, which is the most fragile place a threshold can be. 0.67 is 0.0276
+clear of it and 0.0276 clear of the nearest rejected board.
 
-    0.700000  interf_u_unrouted            <- admitted
-    0.642424  orangecrab_ext_pll           <- rejected
+An earlier version of this paragraph claimed the 0.642424 -> 0.700000 gap was
+"the widest by a factor of two". That is false and a review caught it. Sorted
+best-occupancy over the tracked corpus (parts >= MIN_PARTS), the adjacent gaps
+are:
 
-and every other adjacent pair differs by at most 0.05. A floor of 0.70 would
-therefore sit EXACTLY on a corpus board: `>=` admits `interf_u_unrouted` and
-`>` rejects it, on a float equality, which is the most fragile place a
-threshold can be. 0.67 is 0.030 clear of the nearest admitted board and 0.028
-clear of the nearest rejected one. The floor is far above the chance rate at
+    0.2235  tigard 0.592391 -> rp2350 0.368852
+    0.1189  rp2350 0.368852 -> kit-dev-coldfire 0.250000
+    0.0800  sonde_u 0.780000 -> interf_u_unrouted 0.700000
+    0.0769  splitflap 0.923077 -> lvds 0.846154
+    0.0576  interf_u_unrouted 0.700000 -> orangecrab 0.642424   <- the floor
+    0.0500  orangecrab 0.642424 -> tigard 0.592391
+
+so this is the FIFTH widest gap, not the first. The floor is placed here on the
+boundary argument above, not on a separation argument. Putting it at the widest
+gap instead (~0.48) would admit `tigard` (0.592) and `orangecrab_ext_pll`
+(0.642) at 0.05 -- a defensible alternative that changes behaviour on two
+boards, and one nobody should make by accident. The floor is far above the chance rate at
 every rung --
 with a 1 um tolerance a uniformly random coordinate lands on a multiple of `g`
 with probability `2e-3/g`, i.e. 4.0% at 0.05 falling to 0.08% at 2.54 -- so a
@@ -117,8 +128,12 @@ def infer_board_grid(pcb_data, *, ladder: Sequence[float] = GRID_LADDER,
         if s <= 0:
             raise ValueError("board grid ladder must be positive: %r" % (s,))
     values, n_parts = board_coordinates(pcb_data)
+    # `n_values` is the REAL denominator: `n_parts` counts footprints, but a
+    # non-finite coordinate is dropped from the sample, so 2*n_parts overstates
+    # it whenever a board has one.
     out: Dict = {'step': None, 'occupancy': None, 'n_parts': n_parts,
-                 'profile': {}, 'ties': (), 'reason': ''}
+                 'n_values': len(values), 'profile': {}, 'ties': (),
+                 'reason': ''}
     if not values:
         out['reason'] = 'no footprints'
         return out
@@ -176,7 +191,7 @@ def describe(evidence: Dict) -> str:
     return ("placement lattice %g mm (inferred, %.0f%% of %d footprint "
             "coordinates%s)"
             % (evidence['step'], 100.0 * evidence['occupancy'],
-               2 * evidence['n_parts'],
+               evidence.get('n_values', 2 * evidence['n_parts']),
                '' if len(evidence.get('ties', ())) < 2
                else '; ties with ' + ', '.join('%g' % t
                                                for t in evidence['ties'][1:])))

--- a/py_placer/placement/board_grid.py
+++ b/py_placer/placement/board_grid.py
@@ -1,0 +1,182 @@
+"""The lattice a board was laid out on, inferred from the board (#708).
+
+`snap_to_grid` quantizes; this decides WHAT to quantize to. The two are
+separate on purpose: `grid_step` is the router's raster, a setting no board
+declares (`py_tools/check_channels.py` says so in as many words), whereas a
+placement lattice IS declared by a board, implicitly, in the coordinates of its
+own footprints. Reading it off is what lets the placer move a part by a whole
+number of the designer's grid units instead of an arbitrary residue.
+
+Two rules here are not the obvious ones, and both come from measurement over
+the tracked corpus (`tests/measure_708_lattice.py`, table C).
+
+**The tie-break is the FINEST rung within `TIE_SLACK` of the maximum, not the
+argmax.** The ladder contains divisibility chains -- 0.3175 | 0.635 | 1.27 |
+2.54, and 0.05 | 0.1 | 0.2, 0.05 | 0.25 | 0.5 | 1.0 -- and occupancy is monotone
+non-increasing along one: if `d` divides `s` then every on-`s` point is on-`d`,
+so `occ(d) >= occ(s)`. Ties are therefore STRUCTURAL rather than accidental, and
+an argmax is undefined exactly where the answer matters. Measured:
+`splitflap_driver` ties 0.92 at both 0.3175 and 0.635; `sonde_u` ties 0.78 at
+0.3175, 0.635 AND 1.27. Taking the coarsest would infer a 1.27 mm grid for
+`sonde_u` on the strength of a tie.
+
+`TIE_SLACK` is a tolerance on that comparison and is currently INERT: measured
+over the admitting corpus boards, the nearest rung OUTSIDE each tie group sits
+0.075 (`esp_prog`) to 0.460 (`interf_u_unrouted_placed`) below it, so nothing
+is within 0.02 of the boundary either way. It exists so the rule survives
+someone adding a rung to the ladder, not because it is load-bearing today.
+
+A useful consequence, worth knowing before someone "simplifies" this: only
+0.05 and 0.3175 have no proper divisor in the ladder, so those are the ONLY two
+values this function can ever return. The issue's fear that a 2.54 mm inference
+would quantize the search into uselessness cannot happen -- not because it is
+clamped, but because the tie-break cannot select it. `test_708_board_grid.py`
+pins that as a property of the ladder.
+
+**A rate needs a denominator.** `cap_chain` (4 parts) and the `qfn_*` fixtures
+(1-2 parts) score 1.00 at six rungs from 0.05 to 1.0, because coordinates
+authored by hand are round by construction rather than by a design grid. Below
+`MIN_PARTS` there is no answer to give and the caller gets `None`.
+
+`OCCUPANCY_FLOOR` is the MIDPOINT of a real population gap, and it is not a
+round number for a reason worth keeping. Sorted best-occupancy over the tracked
+corpus (parts >= MIN_PARTS), the widest gap by a factor of two is
+
+    0.700000  interf_u_unrouted            <- admitted
+    0.642424  orangecrab_ext_pll           <- rejected
+
+and every other adjacent pair differs by at most 0.05. A floor of 0.70 would
+therefore sit EXACTLY on a corpus board: `>=` admits `interf_u_unrouted` and
+`>` rejects it, on a float equality, which is the most fragile place a
+threshold can be. 0.67 is 0.030 clear of the nearest admitted board and 0.028
+clear of the nearest rejected one. The floor is far above the chance rate at
+every rung --
+with a 1 um tolerance a uniformly random coordinate lands on a multiple of `g`
+with probability `2e-3/g`, i.e. 4.0% at 0.05 falling to 0.08% at 2.54 -- so a
+single flat floor is safe HERE even though the null rate is 50x higher at the
+fine end than the coarse end. Anyone lowering the floor toward 0.1 must
+subtract the per-rung null rate first; at 0.67 it does not bite.
+"""
+from __future__ import annotations
+
+import math
+from typing import Dict, Optional, Sequence, Tuple
+
+# The ladder issue #708 proposes, kept verbatim so this answers the issue's own
+# question rather than a reshaped one.
+GRID_LADDER: Tuple[float, ...] = (0.05, 0.1, 0.2, 0.25, 0.3175, 0.5, 0.635,
+                                  1.0, 1.27, 2.54)
+TOL_MM = 0.001            # 1 um: the issue's own tolerance
+OCCUPANCY_FLOOR = 0.67    # MIDPOINT of the population gap; see the docstring
+MIN_PARTS = 8             # below this a rate has no denominator
+TIE_SLACK = 0.02          # inert on today's corpus; worst margin 0.075
+
+
+def occupancy(values: Sequence[float], step: float,
+              tol_mm: float = TOL_MM) -> float:
+    """Fraction of `values` within `tol_mm` of a multiple of `step`."""
+    if not values or step <= 0:
+        return 0.0
+    hits = sum(1 for v in values
+               if abs(v / step - round(v / step)) * step <= tol_mm)
+    return hits / len(values)
+
+
+def board_coordinates(pcb_data) -> Tuple[list, int]:
+    """(pooled x and y of every footprint ORIGIN, footprint count).
+
+    Origins, not pads: a pad sits at its origin plus a package pitch (0.5 mm,
+    0.65 mm, 1.27 mm BGA) that is on no board lattice, so a pad sample measures
+    the footprint library rather than the layout.
+
+    Every footprint, unconditionally -- not the movable set, not lock-filtered.
+    The lattice must be a property of the FILE: `--lock` globs and `move_refs`
+    differ between `place_optimize`, `place_seed` and `place_portfolio`, and a
+    filtered sample would let the same board infer different lattices in
+    different tools.
+    """
+    fps = list(getattr(pcb_data, 'footprints', {}).values())
+    xs = [f.x for f in fps if f.x is not None and math.isfinite(f.x)]
+    ys = [f.y for f in fps if f.y is not None and math.isfinite(f.y)]
+    return xs + ys, len(fps)
+
+
+def infer_board_grid(pcb_data, *, ladder: Sequence[float] = GRID_LADDER,
+                     floor: float = OCCUPANCY_FLOOR,
+                     min_parts: int = MIN_PARTS,
+                     tol_mm: float = TOL_MM,
+                     tie_slack: float = TIE_SLACK) -> Dict:
+    """The lattice this board appears to be laid out on.
+
+    Always returns a dict; `step is None` means "no lattice found" and `reason`
+    says which test failed. Never a bare `None`: "the inference declined" and
+    "the inference never ran" must not look the same to a caller, and a caller
+    that wants the terse form can read `d['step']`.
+    """
+    for s in ladder:
+        if s <= 0:
+            raise ValueError("board grid ladder must be positive: %r" % (s,))
+    values, n_parts = board_coordinates(pcb_data)
+    out: Dict = {'step': None, 'occupancy': None, 'n_parts': n_parts,
+                 'profile': {}, 'ties': (), 'reason': ''}
+    if not values:
+        out['reason'] = 'no footprints'
+        return out
+    out['profile'] = {s: occupancy(values, s, tol_mm) for s in ladder}
+    if n_parts < min_parts:
+        out['reason'] = 'n_parts %d < %d' % (n_parts, min_parts)
+        return out
+    best = max(out['profile'].values())
+    ties = tuple(s for s in ladder if out['profile'][s] >= best - tie_slack)
+    out['ties'] = ties
+    if best < floor:
+        out['reason'] = 'best occupancy %.3f < floor %.2f' % (best, floor)
+        return out
+    # FINEST within the slack, never the argmax -- see the module docstring.
+    out['step'] = ties[0]
+    out['occupancy'] = out['profile'][ties[0]]
+    out['reason'] = 'inferred'
+    return out
+
+
+def resolve_snap_lattice(pcb_data, grid_step: float, *,
+                         override: Optional[float] = None
+                         ) -> Tuple[float, Dict]:
+    """The lattice a candidate OFFSET should be a multiple of.
+
+    Falls back to `grid_step`, which is exactly today's offset granularity, so
+    a board with no inferable lattice keeps the step sizes it has always had.
+    There is deliberately no on/off switch: the fallback IS the off state, it
+    is reached by the board rather than by a flag, and a run discloses which
+    branch it took through the returned evidence.
+    """
+    if override is not None:
+        if not (override > 0):
+            raise ValueError("board grid override must be positive: %r"
+                             % (override,))
+        return override, {'source': 'explicit', 'step': override,
+                          'reason': 'override'}
+    ev = infer_board_grid(pcb_data)
+    if ev['step'] is None:
+        ev['source'] = 'grid_step'
+        ev['resolved'] = grid_step
+        return grid_step, ev
+    ev['source'] = 'inferred'
+    ev['resolved'] = ev['step']
+    return ev['step'], ev
+
+
+def describe(evidence: Dict) -> str:
+    """One line, in the `value (source)` idiom the placement CLIs already use."""
+    if evidence.get('source') == 'explicit':
+        return "placement lattice %g mm (given)" % evidence['step']
+    if evidence.get('step') is None:
+        return ("placement lattice %g mm (the --grid-step raster: %s)"
+                % (evidence.get('resolved', 0.0), evidence.get('reason', '')))
+    return ("placement lattice %g mm (inferred, %.0f%% of %d footprint "
+            "coordinates%s)"
+            % (evidence['step'], 100.0 * evidence['occupancy'],
+               2 * evidence['n_parts'],
+               '' if len(evidence.get('ties', ())) < 2
+               else '; ties with ' + ', '.join('%g' % t
+                                               for t in evidence['ties'][1:])))

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -762,17 +762,39 @@ class _Cap:
 
 
 def _candidate_positions(cap, max_disp, step, grid_step):
+    """Candidate cap centres, snapped on the OFFSET rather than the position.
+
+    Same #708 correction as `quench._candidate_positions`: snapping
+    `cap.seed_x + ix*step` to a lattice through board ORIGIN discards the
+    seed's residue and walks the part off whatever pitch the board was laid out
+    on, for nothing -- at every step this tool ships, the absolute snap removed
+    zero candidates.
+
+    Unlike quench, this site keeps the `grid_step` RASTER rather than the
+    board's inferred lattice, and that asymmetry is deliberate and measured.
+    This search IS the clearance repair: its whole job is to find the
+    sub-millimetre pose that clears a foreign via. At `step=0.2` the candidate
+    count is 81 on the raster, 29 on a 0.3175mm lattice and 9 on 0.635 -- so a
+    coarse lattice would starve exactly the search that must not be starved,
+    and the #313 via nudge downstream of it moves parts by as little as 0.6mm,
+    which a 1.27 lattice could not express at all.
+
+    The radius test now runs AFTER the snap, so `max_disp` is an exact cap. The
+    `grid_step*sqrt(2)/2` overshoot the via- and track-prune margins budget for
+    (see `_prune_vias` and the track channel note) is therefore gone rather
+    than merely bounded; both margins gain that much slack.
+    """
     seen = set()
     out = []
     n = int(max_disp / step)
     for ix in range(-n, n + 1):
         for iy in range(-n, n + 1):
-            cx = cap.seed_x + ix * step
-            cy = cap.seed_y + iy * step
-            if math.hypot(cx - cap.seed_x, cy - cap.seed_y) > max_disp + 1e-9:
+            dx = snap_to_grid(ix * step, grid_step)
+            dy = snap_to_grid(iy * step, grid_step)
+            if math.hypot(dx, dy) > max_disp + 1e-9:
                 continue
-            cx = snap_to_grid(cx, grid_step)
-            cy = snap_to_grid(cy, grid_step)
+            cx = cap.seed_x + dx
+            cy = cap.seed_y + dy
             key = (round(cx, 4), round(cy, 4))
             if key not in seen:
                 seen.add(key)

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -776,8 +776,8 @@ def _candidate_positions(cap, max_disp, step, grid_step):
     sub-millimetre pose that clears a foreign via. At `step=0.2` the candidate
     count is 81 on the raster, 29 on a 0.3175mm lattice and 9 on 0.635 -- so a
     coarse lattice would starve exactly the search that must not be starved,
-    and the #313 via nudge downstream of it moves parts by as little as 0.6mm,
-    which a 1.27 lattice could not express at all.
+    and the #313 nudge downstream of it relocates VIAS inside a 0.6mm budget --
+    a fraction of a millimetre, which a 1.27 lattice could not express at all.
 
     The radius test now runs AFTER the snap, so `max_disp` is an exact cap. The
     `grid_step*sqrt(2)/2` overshoot the via- and track-prune margins budget for

--- a/py_placer/placement/quench.py
+++ b/py_placer/placement/quench.py
@@ -2510,7 +2510,14 @@ def _candidate_positions(part: _Part, max_disp: float, step: float,
         raster offsets are {0, +/-1.0, +/-2.0, ...} and 1.0 is not a multiple
         of 0.3175, so only the zero offset lands back on the board's lattice.
         Snapping to the lattice gives {0, +/-0.9525, +/-1.905, ...} and every
-        candidate stays on it, at 325 candidates against the raster's 317.
+        candidate stays on the seed's coset of it.
+
+    Reach is comparable but NOT uniformly better, and the honest bound is worth
+    stating: sweeping max_disp 0.5..19.5 at step=1.0 on a 0.3175 lattice, 12
+    values gain candidates, 17 tie and 10 LOSE -- worst 81 -> 69 at
+    max_disp=5.0, because an offset the raster admitted at exactly the cap can
+    snap UP past it. That is the price of the exact cap below, paid knowingly.
+    At the shipped default (10.0 / 1.0) it is 317 -> 325.
 
     `lattice` is the board's own pitch when one can be read off it and the
     `grid_step` raster otherwise, so a board with no inferable lattice keeps
@@ -2704,11 +2711,25 @@ def quench(pcb_data: PCBData, pcb_file: str,
                         keepouts=(intent_gate or {}).get('keepouts'),
                         intent_zones=(intent_gate or {}).get('zones'))
     # #708: the lattice candidate OFFSETS are multiples of. The board's own
-    # pitch when one can be read off it, the `grid_step` raster otherwise --
-    # which is exactly the granularity offsets have always had, so a board with
-    # no inferable lattice is unaffected by the choice. There is deliberately
-    # no flag: the fallback IS the off state and the board picks it.
+    # pitch when one can be read off it, the `grid_step` raster otherwise.
+    # There is deliberately no flag: the fallback IS the off state and the
+    # board picks it. Note the fallback restores the OFFSET GRANULARITY, not
+    # the old poses -- the seed-relative half applies either way, which is the
+    # bug fix.
     lattice, lattice_evidence = resolve_snap_lattice(pcb_data, grid_step)
+    # A lattice COARSER than the search step would quantize the search rather
+    # than merely phase it: `snap(0.1, 0.3175)` is 0.0, so at `--step 0.1` on an
+    # imperial board every +/-1 offset collapses onto the zero offset and
+    # `_group_offsets` discards it as "no move at all". The finest rung of the
+    # search would vanish silently. `--step` is a plain float on three CLIs with
+    # nothing relating it to the board, so the guard lives here.
+    if lattice > step + 1e-9:
+        lattice_evidence = dict(lattice_evidence, source='grid_step',
+                                resolved=grid_step,
+                                reason='inferred %g mm is coarser than --step '
+                                       '%g mm, which would quantize the search'
+                                       % (lattice, step))
+        lattice = grid_step
     print(describe_lattice(lattice_evidence))
 
     # Unchanged, and now conservative rather than exact: the offsets are

--- a/py_placer/placement/quench.py
+++ b/py_placer/placement/quench.py
@@ -45,6 +45,8 @@ from connectivity import compute_mst_edges
 from placement.parser import (courtyard_for_side, extract_courtyard_sides,
                               extract_locked_refs, warn_missing_courtyards)
 from placement.utility import compute_footprint_bbox_local, snap_to_grid
+from placement.board_grid import (describe as describe_lattice,
+                                  resolve_snap_lattice)
 from placement import legality
 from placement.legality import (CONTAINER_RATIO, CONTAINMENT_FRAC,
                                 BoardOutlineGate, containment_frac,
@@ -2427,7 +2429,7 @@ class QuenchState:
             self._neighbors[ref] = lst
 
 
-def _group_offsets(state, refs, max_disp: float, step: float, grid_step: float):
+def _group_offsets(state, refs, max_disp: float, step: float, lattice: float):
     """Rigid (dx, dy) offsets a whole block may take (#459).
 
     The block translates as one body, so a single offset applies to every
@@ -2456,43 +2458,78 @@ def _group_offsets(state, refs, max_disp: float, step: float, grid_step: float):
         for iy in range(-n, n + 1):
             if ix == 0 and iy == 0:
                 continue
-            dx, dy = ix * step, iy * step
-            if math.hypot(dx, dy) > max_disp + 1e-9:
+            # Snap the OFFSET, so the block stays rigid: snapping each member
+            # independently would shear it by up to a lattice step. Snapping to
+            # the BOARD's lattice rather than the raster is #708: an offset
+            # that is a whole number of the designer's grid units carries every
+            # member from an on-lattice pose to another one.
+            sdx = snap_to_grid(ix * step, lattice)
+            sdy = snap_to_grid(iy * step, lattice)
+            if math.hypot(sdx, sdy) > max_disp + 1e-9:
                 continue
+            if (sdx, sdy) in seen or (sdx == 0.0 and sdy == 0.0):
+                continue
+            # Probe the pose that will actually be APPLIED. This used to snap
+            # the ABSOLUTE p.x + dx while the emitted offset was snap(dx), so
+            # the per-member seed cap -- the thing this docstring says keeps
+            # build_neighbor_lists' pruning exact and edges_near's cache valid
+            # -- was tested against a pose the block never takes. The gap was
+            # under 0.07mm at the raster and is under a lattice step now, but
+            # it was always the wrong quantity.
             ok = True
             for ref in refs:
                 p = state.parts[ref]
-                nx = snap_to_grid(p.x + dx, grid_step)
-                ny = snap_to_grid(p.y + dy, grid_step)
-                if math.hypot(nx - p.seed_x, ny - p.seed_y) > max_disp + 1e-9:
+                if math.hypot(p.x + sdx - p.seed_x,
+                              p.y + sdy - p.seed_y) > max_disp + 1e-9:
                     ok = False
                     break
             if not ok:
-                continue
-            # Snap the OFFSET, so the block stays rigid: snapping each member
-            # independently would shear it by up to a grid step.
-            sdx = snap_to_grid(dx, grid_step)
-            sdy = snap_to_grid(dy, grid_step)
-            if (sdx, sdy) in seen or (sdx == 0.0 and sdy == 0.0):
                 continue
             seen.add((sdx, sdy))
             yield sdx, sdy
 
 
 def _candidate_positions(part: _Part, max_disp: float, step: float,
-                         grid_step: float):
-    """Grid of candidate centers within max_disp of the seed position."""
+                         lattice: float):
+    """Grid of candidate centers within max_disp of the seed position.
+
+    The snap is on the OFFSET, not on the absolute position, and that
+    distinction is the whole of #708. `seed_x + ix*step` already carries
+    whatever phase the designer laid the board out on; snapping the SUM to a
+    lattice through board ORIGIN discards it, because seed_x is not generally a
+    multiple of anything. Snapping the offset instead inherits the seed's
+    phase, so a part on a 0.3175mm (12.5 mil) lattice is offered only poses on
+    that same lattice.
+
+    Two measurements behind this, both in `tests/measure_708_lattice.py`:
+
+      * the old absolute snap removed ZERO candidates at every step the tool
+        ships -- it was a pure translation of the whole set by the seed's
+        residue -- so nothing is lost by dropping it;
+      * snapping the offset to the RASTER would not be enough. At step=1.0 the
+        raster offsets are {0, +/-1.0, +/-2.0, ...} and 1.0 is not a multiple
+        of 0.3175, so only the zero offset lands back on the board's lattice.
+        Snapping to the lattice gives {0, +/-0.9525, +/-1.905, ...} and every
+        candidate stays on it, at 325 candidates against the raster's 317.
+
+    `lattice` is the board's own pitch when one can be read off it and the
+    `grid_step` raster otherwise, so a board with no inferable lattice keeps
+    exactly the offsets it has always had (see `placement/board_grid.py`).
+
+    The radius test runs AFTER the snap, so `max_disp` is an exact cap rather
+    than one overshot by up to lattice*sqrt(2)/2.
+    """
     seen = set()
     out = []
     n = int(max_disp / step)
     for ix in range(-n, n + 1):
         for iy in range(-n, n + 1):
-            cx = part.seed_x + ix * step
-            cy = part.seed_y + iy * step
-            if math.hypot(cx - part.seed_x, cy - part.seed_y) > max_disp + 1e-9:
+            dx = snap_to_grid(ix * step, lattice)
+            dy = snap_to_grid(iy * step, lattice)
+            if math.hypot(dx, dy) > max_disp + 1e-9:
                 continue
-            cx = snap_to_grid(cx, grid_step)
-            cy = snap_to_grid(cy, grid_step)
+            cx = part.seed_x + dx
+            cy = part.seed_y + dy
             key = (round(cx, 4), round(cy, 4))
             if key not in seen:
                 seen.add(key)
@@ -2666,6 +2703,18 @@ def quench(pcb_data: PCBData, pcb_file: str,
                         corridor_specs=corridor_specs,
                         keepouts=(intent_gate or {}).get('keepouts'),
                         intent_zones=(intent_gate or {}).get('zones'))
+    # #708: the lattice candidate OFFSETS are multiples of. The board's own
+    # pitch when one can be read off it, the `grid_step` raster otherwise --
+    # which is exactly the granularity offsets have always had, so a board with
+    # no inferable lattice is unaffected by the choice. There is deliberately
+    # no flag: the fallback IS the off state and the board picks it.
+    lattice, lattice_evidence = resolve_snap_lattice(pcb_data, grid_step)
+    print(describe_lattice(lattice_evidence))
+
+    # Unchanged, and now conservative rather than exact: the offsets are
+    # snapped BEFORE the radius test, so a candidate is within max_displacement
+    # of its seed rather than up to a snap diagonal past it. The old
+    # `+ grid_step` slack covered that overshoot and now simply exceeds it.
     state.build_neighbor_lists(max_displacement + grid_step)
 
     before = state.total_cost()
@@ -2745,7 +2794,7 @@ def quench(pcb_data: PCBData, pcb_file: str,
             base_cost = eval_group(0.0, 0.0)
             best = (base_cost, 0.0, 0.0)
             for ddx, ddy in _group_offsets(state, refs, max_displacement, step,
-                                           grid_step):
+                                           lattice):
                 if not state.group_move_valid(refs, ddx, ddy):
                     continue
                 c = eval_group(ddx, ddy)
@@ -2805,7 +2854,7 @@ def quench(pcb_data: PCBData, pcb_file: str,
 
             best = (current_cost, part.x, part.y, part.rot)
             for cx, cy in _candidate_positions(part, max_displacement, step,
-                                               grid_step):
+                                               lattice):
                 for rot in rotations:
                     if (cx, cy, rot) == (part.x, part.y, part.rot):
                         continue
@@ -3002,6 +3051,13 @@ def quench(pcb_data: PCBData, pcb_file: str,
         metrics_out['before'] = dict(before)
         metrics_out['after'] = dict(after)
         metrics_out['legality'] = state.legality_metrics()
+        # #708: which lattice the candidate offsets were multiples of, and how
+        # that was decided. `source` distinguishes "the board declared one"
+        # from "it did not and we used the raster" -- without it, a run on a
+        # board with no lattice and a run where the inference was never wired
+        # report the same thing.
+        metrics_out['board_grid'] = dict(lattice_evidence,
+                                         resolved=lattice)
         # #702: what the declared-intent gate actually DID. Always present when
         # a gate was built, and `rejected: 0` is a real answer -- without this
         # key, "the gate refused nothing" and "the gate was never wired" are

--- a/py_placer/placement/reseat.py
+++ b/py_placer/placement/reseat.py
@@ -156,8 +156,9 @@ def slot_pool(state, cluster, ring_step=DEFAULT_RING_STEP_MM,
 
     Generated on rings around the anchor's relevant pins out to `radius_mm`, so
     membership in the pool IS the constraint -- there is nothing to gate and no
-    proximity term to weight. Snapped to `grid_step` and de-duplicated in a
-    deterministic order.
+    proximity term to weight. Snapped to `grid_step` FROM THE ANCHOR (#708, so
+    the pool inherits the anchor's phase rather than a lattice through board
+    origin) and de-duplicated in a deterministic order.
     """
     seen = set()
     out: List[Tuple[float, float, float]] = []
@@ -180,12 +181,23 @@ def slot_pool(state, cluster, ring_step=DEFAULT_RING_STEP_MM,
     ax, ay = anchor_part.x, anchor_part.y
 
     def add(x, y, rot):
-        sx = ax + snap_to_grid(x - ax, grid_step)
-        sy = ay + snap_to_grid(y - ay, grid_step)
-        key = (round(sx / grid_step), round(sy / grid_step), round(rot, 3))
+        # The KEY counts lattice steps FROM THE ANCHOR, matching the value.
+        # Keying `round(sx / grid_step)` on the absolute pose would not be
+        # injective once the emitted pose moved to an anchor-relative lattice:
+        # when `ax / grid_step` has a fractional part of exactly 0.5, banker's
+        # rounding sends two adjacent steps to one key (round(1.5) == round(2.5)
+        # == 2) and the second slot is silently dropped. Measured on
+        # orangecrab_ext_pll U4, 325 of 3334 distinct poses lost; 327 of 3166
+        # footprint coordinates across the tracked corpus sit at a colliding
+        # phase. Invisible to a length check, because MAX_POSITIONS truncates
+        # the pool afterwards -- only the CONTENTS change, near slots being
+        # replaced by farther ones.
+        kx = round((x - ax) / grid_step)
+        ky = round((y - ay) / grid_step)
+        key = (kx, ky, round(rot, 3))
         if key not in seen:
             seen.add(key)
-            out.append((sx, sy, rot))
+            out.append((ax + kx * grid_step, ay + ky * grid_step, rot))
 
     # Snapping to the grid moves a point by up to half a cell on each axis, so
     # a ring generated AT the radius lands outside it. Shrink by the snap
@@ -470,30 +482,39 @@ def reseat_cluster(state, cluster, *, ring_step=DEFAULT_RING_STEP_MM,
         # overrides the members' pads on the SCORED nets, but `other_aw` is
         # built from the live board, so the move's effect on a member's
         # UNSCORED nets is not in it. A decap on GND and one signal has its GND
-        # airwire priced at the pose it is leaving. Measured on splitflap's
-        # tether:B0 (C60, nets 1 and 278, only 278 scored): predicted 1214.28,
-        # actual 1274.28 -- six crossings, 60.0 of cost, all of it invisible.
-        # So seat it and ASK, rather than predict and hope. The contract this
-        # restores is the one `test_reseat` states: acceptance is on the exact
-        # objective, re-evaluated with all members in place.
+        # airwire priced at the pose it is leaving. Measured on ulx3s's
+        # tether:B0 (C60, on nets 1 `GND` and 278 `PWRBTn`, only 278 scored):
+        # predicted 1214.28, actual 1274.28. That gap is 60.0 at the fixture's
+        # `crossing_penalty=30.0`, i.e. TWO crossings, and it was invisible to
+        # the decision. So seat it and ASK, rather than predict and hope. The
+        # contract this restores is the one `test_reseat` states: acceptance is
+        # on the exact objective, re-evaluated with all members in place.
+        #
+        # try/finally because a raise between the apply and the revert would
+        # otherwise leave the moves applied -- and under `apply=False` that
+        # silently mutates a state the caller asked not to be touched.
         prior = {m: (state.parts[m].x, state.parts[m].y, state.parts[m].rot)
                  for m in moved}
-        for m in moved:
-            state.apply_move(m, *poses[m])
-        seated = cluster_cost(state, cluster, involved=involved)
-        if seated < before - EPS_IMPROVE:
-            res.accepted = True
+        keep = False
+        try:
+            for m in moved:
+                state.apply_move(m, *poses[m])
+            seated = cluster_cost(state, cluster, involved=involved)
+            # `after` is ALWAYS the measured cost from here on, never the
+            # prediction, so `to_dict()['gain']` means one thing on every row
+            # that reached this branch.
             res.after = seated
-            if not apply:
+            if seated < before - EPS_IMPROVE:
+                res.accepted = True
+                keep = apply
+            else:
+                res.reason = ('the seated cost is worse than the prediction '
+                              '(%.4f vs %.4f): the members carry nets this '
+                              'cluster does not score' % (seated, after))
+        finally:
+            if not keep:
                 for m in moved:
                     state.apply_move(m, *prior[m])
-        else:
-            for m in moved:
-                state.apply_move(m, *prior[m])
-            res.after = seated
-            res.reason = ('the seated cost is worse than the prediction '
-                          '(%.4f vs %.4f): the members carry nets this '
-                          'cluster does not score' % (seated, after))
     else:
         res.reason = ('no improvement on the exact objective'
                       if moved else 'assignment returned the incumbent')

--- a/py_placer/placement/reseat.py
+++ b/py_placer/placement/reseat.py
@@ -60,6 +60,8 @@ import math
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Sequence, Set, Tuple
 
+from placement.utility import snap_to_grid
+
 # Slot lattice. Deliberately coarse: this is a RE-SEAT, choosing which side of
 # an anchor a part sits on, not a sub-grid polish -- the quench does that after.
 DEFAULT_RING_STEP_MM = 0.5
@@ -160,12 +162,30 @@ def slot_pool(state, cluster, ring_step=DEFAULT_RING_STEP_MM,
     seen = set()
     out: List[Tuple[float, float, float]] = []
 
+    # #708: snap the OFFSET FROM THE ANCHOR, not the absolute position, and
+    # through the shared primitive rather than a second spelling of it.
+    #
+    # The phase to preserve is the ANCHOR's, not the pad's: these rings are
+    # generated around `_anchor_pin_points`, and a pad sits at its footprint
+    # origin plus a package pitch (0.5mm, 0.65mm) that is on no board lattice.
+    # The anchor's own origin is what the designer placed, so an offset that is
+    # a whole number of raster units from it lands a member on the same pitch
+    # the anchor sits on. Snapping the absolute point instead quantized to a
+    # lattice through board origin and threw that away.
+    #
+    # The RASTER, not the board's inferred lattice: like the fanout cap repair,
+    # this pool is a proximity constraint satisfied by construction, and a
+    # coarse lattice would both thin it and inflate the `snap` shrink below.
+    anchor_part = state.parts[cluster.anchor]
+    ax, ay = anchor_part.x, anchor_part.y
+
     def add(x, y, rot):
-        key = (round(x / grid_step), round(y / grid_step), round(rot, 3))
+        sx = ax + snap_to_grid(x - ax, grid_step)
+        sy = ay + snap_to_grid(y - ay, grid_step)
+        key = (round(sx / grid_step), round(sy / grid_step), round(rot, 3))
         if key not in seen:
             seen.add(key)
-            out.append((round(x / grid_step) * grid_step,
-                        round(y / grid_step) * grid_step, rot))
+            out.append((sx, sy, rot))
 
     # Snapping to the grid moves a point by up to half a cell on each axis, so
     # a ring generated AT the radius lands outside it. Shrink by the snap
@@ -446,10 +466,34 @@ def reseat_cluster(state, cluster, *, ring_step=DEFAULT_RING_STEP_MM,
     res = ReseatResult(cluster=cluster.name, moved=moved, before=before,
                        after=after, slots=len(slots), repairs=repairs)
     if after < before - EPS_IMPROVE and moved:
-        res.accepted = True
-        if apply:
+        # `after` above is a PREDICTION, and it is blind in one direction: it
+        # overrides the members' pads on the SCORED nets, but `other_aw` is
+        # built from the live board, so the move's effect on a member's
+        # UNSCORED nets is not in it. A decap on GND and one signal has its GND
+        # airwire priced at the pose it is leaving. Measured on splitflap's
+        # tether:B0 (C60, nets 1 and 278, only 278 scored): predicted 1214.28,
+        # actual 1274.28 -- six crossings, 60.0 of cost, all of it invisible.
+        # So seat it and ASK, rather than predict and hope. The contract this
+        # restores is the one `test_reseat` states: acceptance is on the exact
+        # objective, re-evaluated with all members in place.
+        prior = {m: (state.parts[m].x, state.parts[m].y, state.parts[m].rot)
+                 for m in moved}
+        for m in moved:
+            state.apply_move(m, *poses[m])
+        seated = cluster_cost(state, cluster, involved=involved)
+        if seated < before - EPS_IMPROVE:
+            res.accepted = True
+            res.after = seated
+            if not apply:
+                for m in moved:
+                    state.apply_move(m, *prior[m])
+        else:
             for m in moved:
-                state.apply_move(m, *poses[m])
+                state.apply_move(m, *prior[m])
+            res.after = seated
+            res.reason = ('the seated cost is worse than the prediction '
+                          '(%.4f vs %.4f): the members carry nets this '
+                          'cluster does not score' % (seated, after))
     else:
         res.reason = ('no improvement on the exact objective'
                       if moved else 'assignment returned the incumbent')

--- a/py_tools/check_pockets.py
+++ b/py_tools/check_pockets.py
@@ -709,6 +709,19 @@ def pocket_census(pcb, board_path, *, nets=('*',), bin_mm=2.0, top=8,
         doc['cold_area_mm2'] = None
         doc['cold_area_frac'] = None
         doc['skipped'] = 'cold census disabled'
+    # #708: the lattice this board was laid out on, if it declares one. Read
+    # off the same function the placer resolves its candidate offsets with, so
+    # the census cannot report a pitch the engine does not use.
+    try:
+        from placement.board_grid import infer_board_grid
+        _bg = infer_board_grid(pcb)
+        doc['board_grid'] = {'step': _bg['step'], 'occupancy': _bg['occupancy'],
+                             'n_parts': _bg['n_parts'],
+                             'ties': list(_bg['ties']),
+                             'reason': _bg['reason']}
+    except Exception:                                           # noqa: BLE001
+        doc['board_grid'] = None
+
     doc['reseat_target'] = _reseat_target(doc, bounds) if cold else None
     return doc, hot
 
@@ -811,6 +824,13 @@ def census_scalars(doc):
         'centroid_offset_frac_y': off[1],
         'centroid_count_control_frac': ctl[0],
         'outline_source': (doc.get('outline') or {}).get('source'),
+        # #708. `board_grid_step` is None for a board that declares no lattice,
+        # which is a real answer and not a missing one -- `board_grid_reason`
+        # says which test it failed, so "no lattice" and "never measured" stay
+        # distinguishable in the summary line alone.
+        'board_grid_step': (doc.get('board_grid') or {}).get('step'),
+        'board_grid_occupancy': (doc.get('board_grid') or {}).get('occupancy'),
+        'board_grid_reason': (doc.get('board_grid') or {}).get('reason'),
     }
     return {k: v for k, v in out.items()
             if not (isinstance(v, float) and not math.isfinite(v))}

--- a/py_tools/check_pockets.py
+++ b/py_tools/check_pockets.py
@@ -719,8 +719,12 @@ def pocket_census(pcb, board_path, *, nets=('*',), bin_mm=2.0, top=8,
                              'n_parts': _bg['n_parts'],
                              'ties': list(_bg['ties']),
                              'reason': _bg['reason']}
-    except Exception:                                           # noqa: BLE001
-        doc['board_grid'] = None
+    except ImportError as exc:
+        # Named, not swallowed: a missing module and a board that declares no
+        # lattice must not produce the same shape, which is the whole point of
+        # carrying `reason` beside `step`.
+        doc['board_grid'] = {'step': None, 'occupancy': None, 'n_parts': None,
+                             'ties': [], 'reason': 'unavailable: %s' % exc}
 
     doc['reseat_target'] = _reseat_target(doc, bounds) if cold else None
     return doc, hot

--- a/tests/measure_708_lattice.py
+++ b/tests/measure_708_lattice.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""What #708 actually is, measured rather than argued.
+
+The issue says the quench's 0.1mm grid step is "incommensurate with imperial
+board grids" and proposes inferring the board's pitch from a ladder. Two of the
+three tables below say the mechanism is something else, and the third says the
+proposed cure would have been bolted onto a line that buys nothing:
+
+  A. THE DAMAGE IS REAL. One quench pass takes splitflap_driver from 59 of 65
+     parts on its own 0.3175mm lattice to a small fraction of that. This is the
+     claim the issue makes and it holds.
+
+  B. THE SNAP REMOVES NO CANDIDATES. `_candidate_positions` builds candidates as
+     `seed + ix*step` and then snaps the ABSOLUTE result. Every shipped `step`
+     (1.0 place_optimize, 0.5 converge/place_route_loop, 0.2
+     place_fanout_clearance) is a multiple of `grid_step` 0.1, so the snap is a
+     pure translation of the whole candidate set by the seed's residue -- same
+     count, same shape, shifted off the board's lattice. It is not a search
+     device. `_group_offsets` already snaps the OFFSET, and at those same steps
+     that snap is a literal no-op, which is the existence proof that the delta
+     form is the correct one.
+
+  C. THE LADDER IS DEGENERATE. Occupancy is monotone non-increasing along
+     divisibility chains, so ties are structural rather than accidental, and the
+     argmax the issue proposes is undefined exactly where it matters. The table
+     also refutes the issue's claim that kit-dev-coldfire-xilinx_5213 "shows the
+     same signature at 1.27mm": 1.27 scores far below its own maximum, and that
+     maximum is below any floor that admits a real board.
+
+Boards are DE-DUPLICATED by their footprint-position multiset before the corpus
+table is summarised, because several tracked files are the same placement --
+counting one 8-part fixture six times is how a majority gets manufactured.
+
+NOT named `test_*.py`: `tests/run_all.py` does not collect it, because table A
+runs real quench passes (minutes) and it asserts nothing. It is a measurement,
+and its numbers are quoted in the #708 PR and in placement/README.md.
+
+    python3 -X utf8 tests/measure_708_lattice.py            # all three tables
+    python3 -X utf8 tests/measure_708_lattice.py --no-quench # B and C only
+"""
+from __future__ import annotations
+
+import argparse
+import contextlib
+import hashlib
+import io
+import math
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for _sub in ('py_router', 'py_placer', 'py_tools'):
+    sys.path.insert(0, os.path.join(ROOT, _sub))
+
+import run_utils  # noqa: E402
+from kicad_parser import parse_kicad_pcb  # noqa: E402
+from placement.utility import snap_to_grid  # noqa: E402
+
+# The ladder issue #708 proposes. Kept verbatim so the table answers the
+# issue's own question rather than a reshaped one.
+LADDER = (0.05, 0.1, 0.2, 0.25, 0.3175, 0.5, 0.635, 1.0, 1.27, 2.54)
+TOL_MM = 0.001          # 1 um, the issue's own tolerance
+
+# The steps that actually ship, and the tool each comes from. `grid_step` is
+# 0.1 (routing_defaults.GRID_STEP) at every one of them.
+SHIPPED_STEPS = ((10.0, 1.0, 'place_optimize --step'),
+                 (3.0, 1.0, 'place_optimize --max-displacement 3'),
+                 (2.0, 0.5, 'converge poses'),
+                 (1.0, 0.2, 'place_fanout_clearance'),
+                 (3.0, 0.25, 'a step that is NOT a multiple of grid_step'))
+
+
+def occupancy(vals, step, tol=TOL_MM):
+    """Fraction of `vals` within `tol` of a multiple of `step`."""
+    if not vals or step <= 0:
+        return 0.0
+    return sum(1 for v in vals
+               if abs(v / step - round(v / step)) * step <= tol) / len(vals)
+
+
+def coords(pcb):
+    """Footprint ORIGINS, x and y pooled.
+
+    Origins, not pads: a pad sits at origin + a package pitch (0.5mm, 0.65mm)
+    that is on no board lattice, so a pad sample measures the footprint library
+    rather than the layout.
+    """
+    fps = [f for f in pcb.footprints.values()]
+    xs = [f.x for f in fps if math.isfinite(f.x)]
+    ys = [f.y for f in fps if math.isfinite(f.y)]
+    return xs + ys, len(fps)
+
+
+def profile(vals):
+    return {s: occupancy(vals, s) for s in LADDER}
+
+
+def finest_within(prof, slack=0.02):
+    """The FINEST rung within `slack` of the maximum -- not the argmax.
+
+    The ladder contains divisibility chains (0.3175 | 0.635 | 1.27 | 2.54 and
+    0.05 | 0.1 | 0.2), and occupancy is monotone non-increasing along one: if
+    d divides s then every on-s point is on-d, so occ(d) >= occ(s). Ties are
+    therefore structural, and an argmax has no defined answer on them.
+    """
+    best = max(prof.values())
+    for s in LADDER:
+        if prof[s] >= best - slack:
+            return s, best
+    return None, best
+
+
+def pose_hash(pcb):
+    """Identify a PLACEMENT, so the same layout in five files counts once."""
+    fps = sorted((round(f.x, 6), round(f.y, 6))
+                 for f in pcb.footprints.values())
+    return hashlib.sha1(repr(fps).encode()).hexdigest()[:12]
+
+
+# --------------------------------------------------------------- table B
+
+def candidate_sets(seed, max_disp, step, grid_step):
+    """(snapped, unsnapped) candidate lists, exactly as _candidate_positions
+    builds them -- absolute snap, deduped on the same rounded key."""
+    out = []
+    for do_snap in (True, False):
+        seen, got = set(), []
+        n = int(max_disp / step)
+        for ix in range(-n, n + 1):
+            for iy in range(-n, n + 1):
+                cx = seed[0] + ix * step
+                cy = seed[1] + iy * step
+                if math.hypot(cx - seed[0], cy - seed[1]) > max_disp + 1e-9:
+                    continue
+                if do_snap:
+                    cx = snap_to_grid(cx, grid_step)
+                    cy = snap_to_grid(cy, grid_step)
+                key = (round(cx, 4), round(cy, 4))
+                if key not in seen:
+                    seen.add(key)
+                    got.append((cx, cy))
+        out.append(got)
+    return out[0], out[1]
+
+
+def table_b(grid_step=0.1):
+    # An off-raster seed, so the residue the snap discards is non-zero.
+    # 131.4450 is interf_u BUS1: exactly 207 * 0.635, a clean 25-mil pose.
+    seed = (131.4450, 138.4300)
+    print('B. What the ABSOLUTE snap removes, at every shipped step '
+          '(grid_step=%.2f)' % grid_step)
+    print('   seed = (%.4f, %.4f) = (%.1f, %.1f) x 0.635, i.e. ON a 25-mil '
+          'lattice' % (seed[0], seed[1], seed[0] / 0.635, seed[1] / 0.635))
+    print()
+    print('   %-9s %-7s %9s %11s %7s  %s'
+          % ('max_disp', 'step', 'snapped', 'unsnapped', 'lost', 'shape'))
+    for max_disp, step, who in SHIPPED_STEPS:
+        snapped, plain = candidate_sets(seed, max_disp, step, grid_step)
+        off = (round(snapped[0][0] - plain[0][0], 9),
+               round(snapped[0][1] - plain[0][1], 9))
+        pure = (len(snapped) == len(plain) and
+                all(abs((a - p) - off[0]) < 1e-9 and abs((b - q) - off[1]) < 1e-9
+                    for (a, b), (p, q) in zip(snapped, plain)))
+        shape = ('pure translation by %s' % (off,)) if pure else 'reshaped'
+        print('   %-9s %-7s %9d %11d %7d  %s   (%s)'
+              % (max_disp, step, len(snapped), len(plain),
+                 len(plain) - len(snapped), shape, who))
+    print()
+    print('   _group_offsets snaps the OFFSET. max |snap(ix*step) - ix*step|:')
+    for step in sorted({s for _md, s, _w in SHIPPED_STEPS}):
+        m = max(abs(snap_to_grid(ix * step, grid_step) - ix * step)
+                for ix in range(-40, 41))
+        verdict = 'NO-OP' if m == 0.0 else 'perturbs by up to %.3f' % m
+        print('     step=%-6s %.3e   %s' % (step, m, verdict))
+    print()
+    print('   Reading: at every step the tool actually ships, the absolute snap')
+    print('   loses zero candidates and merely translates the set off the')
+    print('   seed\'s own lattice. The delta snap loses nothing and preserves')
+    print('   it. That is the whole fix.')
+    print()
+
+
+# --------------------------------------------------------------- table C
+
+def table_c(boards):
+    rows = []
+    seen_poses = {}
+    for path in boards:
+        try:
+            pcb = parse_kicad_pcb(path)
+        except Exception as exc:                     # noqa: BLE001
+            print('   %-34s PARSE FAILED: %s' % (os.path.basename(path), exc))
+            continue
+        vals, n = coords(pcb)
+        if not vals:
+            continue
+        h = pose_hash(pcb)
+        rows.append((os.path.basename(path).replace('.kicad_pcb', ''),
+                     n, profile(vals), h))
+        seen_poses.setdefault(h, []).append(
+            os.path.basename(path).replace('.kicad_pcb', ''))
+
+    print('C. Ladder occupancy per board (footprint origins, x and y pooled, '
+          '%g um tolerance)' % (TOL_MM * 1000))
+    print()
+    hdr = '   %-32s %4s ' % ('board', 'n') + ' '.join('%6s' % s for s in LADDER)
+    print(hdr + '   %8s %s' % ('pick', 'ties'))
+    for name, n, prof, _h in rows:
+        pick, best = finest_within(prof)
+        ties = [s for s in LADDER if prof[s] >= best - 0.02]
+        print('   %-32s %4d ' % (name, n)
+              + ' '.join('%6.2f' % prof[s] for s in LADDER)
+              + '   %8s %s' % (pick, ','.join(str(t) for t in ties)
+                               if len(ties) > 1 else '-'))
+    print()
+    dupes = {h: names for h, names in seen_poses.items() if len(names) > 1}
+    print('   %d files, %d DISTINCT placements. Files sharing a placement:'
+          % (len(rows), len(seen_poses)))
+    for _h, names in sorted(dupes.items(), key=lambda kv: -len(kv[1])):
+        print('     %s' % ', '.join(sorted(names)))
+    if not dupes:
+        print('     (none)')
+    print()
+    print('   Reading: every board whose best rung is coarse ties with that')
+    print('   rung\'s divisors, so the argmax #708 proposes is undefined there.')
+    print('   Any occupancy floor must also survive de-duplication -- the')
+    print('   duplicate groups above are one placement each, not one vote each.')
+    print()
+    return rows
+
+
+# --------------------------------------------------------------- table A
+
+def table_a(rows, names, max_displacement=3.0):
+    """Quench each named board and report how many parts left its lattice."""
+    from placement.quench import quench
+    print('A. What one quench pass does to the board\'s own lattice')
+    print()
+    print('   %-32s %6s %8s  %-22s %-22s %s'
+          % ('board', 'n', 'lattice', 'on-lattice BEFORE',
+             'on-lattice AFTER', 'moved'))
+    by_name = {r[0]: r for r in rows}
+    for name in names:
+        row = by_name.get(name)
+        if row is None:
+            print('   %-32s SKIP (not in corpus)' % name)
+            continue
+        _n_name, n, prof, _h = row
+        lattice, _best = finest_within(prof)
+        path = os.path.join(ROOT, 'kicad_files', name + '.kicad_pcb')
+        pcb = parse_kicad_pcb(path)
+        before_vals, _ = coords(pcb)
+        occ_before = occupancy(before_vals, lattice)
+        # The engine narrates unconditionally; swallow it so the table is a
+        # table. The run itself is untouched.
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            placements = quench(pcb, path, max_displacement=max_displacement,
+                                step=1.0, grid_step=0.1, clearance=0.2,
+                                board_edge_clearance=0.55, max_passes=4,
+                                verbose=False)
+        moved = {p['reference']: (p['new_x'], p['new_y'])
+                 for p in (placements or [])}
+        after = []
+        for ref, fp in pcb.footprints.items():
+            x, y = moved.get(ref, (fp.x, fp.y))
+            after.extend([x, y])
+        occ_after = occupancy(after, lattice)
+        print('   %-32s %6d %8s  %6.3f (%3d/%3d)        %6.3f (%3d/%3d)        %d'
+              % (name, n, lattice,
+                 occ_before, round(occ_before * len(before_vals)),
+                 len(before_vals),
+                 occ_after, round(occ_after * len(after)), len(after),
+                 len(moved)))
+    print()
+    print('   Counted over x and y separately, so the denominator is 2n.')
+    print()
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--no-quench', action='store_true',
+                    help='skip table A (the slow one)')
+    ap.add_argument('--boards', nargs='*',
+                    default=['splitflap_driver', 'flat_hierarchy', 'sonde_u'],
+                    help='boards for table A (default: three with a real '
+                         'non-0.1 lattice)')
+    args = ap.parse_args()
+
+    boards = run_utils.corpus_boards()
+    if not boards:
+        print('SKIP: git could not enumerate the corpus '
+              '(tarball export, or no git on PATH)')
+        return 0
+
+    table_b()
+    rows = table_c(boards)
+    if not args.no_quench:
+        table_a(rows, args.boards)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/measure_708_lattice.py
+++ b/tests/measure_708_lattice.py
@@ -6,9 +6,11 @@ board grids" and proposes inferring the board's pitch from a ladder. Two of the
 three tables below say the mechanism is something else, and the third says the
 proposed cure would have been bolted onto a line that buys nothing:
 
-  A. THE DAMAGE IS REAL. One quench pass takes splitflap_driver from 59 of 65
-     parts on its own 0.3175mm lattice to a small fraction of that. This is the
-     claim the issue makes and it holds.
+  A. THE DAMAGE IS REAL. One quench pass takes splitflap_driver from 0.923 of
+     its footprint COORDINATES on its own 0.3175mm lattice to 0.269. (#708
+     states the same measurement per PART, 59 of 65 = 0.908; this file counts
+     x and y separately throughout, so its denominator is 2n. Both are true and
+     the tables below are all coordinates.)
 
   B. THE SNAP REMOVES NO CANDIDATES. `_candidate_positions` builds candidates as
      `seed + ix*step` and then snaps the ABSOLUTE result. Every shipped `step`

--- a/tests/mutate_708.py
+++ b/tests/mutate_708.py
@@ -18,8 +18,8 @@ checks the first would pass with the fix half-applied. The row
 arms tell those two apart: with it applied, every offset is still a clean
 multiple of `grid_step` and the residue is still preserved -- and the board's
 0.3175mm lattice is still destroyed. Measured before writing any of this: at
-step=1.0 the raster offsets are {0, +/-1.0, +/-2.0} and only the ZERO offset
-lands back on a 0.3175 lattice.
+step=1.0 and max_displacement=3.0 the raster offsets are {0, +/-1.0, +/-2.0,
++/-3.0} and only the ZERO offset lands back on a 0.3175 lattice.
 
 Every row carries an EXPECTATION. An inert row recorded as an expected survivor
 is a finding; an inert row quietly deleted is a hole. A row whose verdict does
@@ -44,9 +44,9 @@ skipped -- `str.replace(old, new, 1)` of an absent needle returns the file
 unchanged, so a stale anchor would report its row as a survivor, which reads as
 a catastrophic test failure and is really a typo.
 
-`_uncache` is carried over from `tests/mutate_797.py` and is NOT hygiene: two
-rows here are single-token edits (`ties[0]` -> `ties[-1]`, `0.67` -> `0.70`)
-that leave the file the SAME SIZE, and CPython validates a `.pyc` on
+`_uncache` is carried over from `tests/mutate_797.py` and is NOT hygiene: the
+`0.67` -> `0.70` row is a size-preserving edit, and CPython validates a `.pyc`
+on
 (mtime seconds, size) alone. Mutate, run and restore inside one second and
 every later import in this checkout reads the mutant.
 
@@ -204,6 +204,27 @@ ROWS = [
      "                          cy - cap.seed_y) > max_disp + 1e-9:\n"
      "                continue",
      (T_SNAP, T_FANOUT), 'KILLED'),
+
+    # The pre-existing acceptance defect #708's slot change exposed: decide on
+    # the PREDICTION again instead of the seated cost.
+    ('the-reseat-accepts-on-the-prediction', 'rs',
+     "        keep = False
+"
+     "        try:",
+     "        keep = apply
+"
+     "        res.accepted = True
+"
+     "        if True:
+"
+     "            for m in moved:
+"
+     "                state.apply_move(m, *poses[m])
+"
+     "            return res
+"
+     "        try:",
+     (T_SNAP, T_RESEAT), 'KILLED'),
 
     ('the-reseat-slot-snaps-the-absolute-point', 'rs',
      "        sx = ax + snap_to_grid(x - ax, grid_step)\n"

--- a/tests/mutate_708.py
+++ b/tests/mutate_708.py
@@ -218,11 +218,35 @@ ROWS = [
      "        try:",
      (T_SNAP, T_RESEAT), 'KILLED'),
 
+    # The half of the reseat fix that is easy to get subtly wrong, and did not
+    # have a row until a review pointed it out: keep the anchor-relative VALUE
+    # but key the dedup on the absolute pose. Every slot still satisfies "on
+    # the anchor's lattice", so the phase assertion cannot see it -- what it
+    # loses is SLOTS, silently, at half-cell anchor phases.
+    ('the-reseat-dedup-key-is-not-injective', 'rs',
+     "        kx = round((x - ax) / grid_step)\n"
+     "        ky = round((y - ay) / grid_step)\n"
+     "        key = (kx, ky, round(rot, 3))",
+     "        kx = round((x - ax) / grid_step)\n"
+     "        ky = round((y - ay) / grid_step)\n"
+     "        key = (round((ax + kx * grid_step) / grid_step),\n"
+     "               round((ay + ky * grid_step) / grid_step),\n"
+     "               round(rot, 3))",
+     (T_SNAP,), 'KILLED'),
+
     ('the-reseat-slot-snaps-the-absolute-point', 'rs',
-     "        sx = ax + snap_to_grid(x - ax, grid_step)\n"
-     "        sy = ay + snap_to_grid(y - ay, grid_step)",
-     "        sx = snap_to_grid(x, grid_step)\n"
-     "        sy = snap_to_grid(y, grid_step)",
+     "        kx = round((x - ax) / grid_step)\n"
+     "        ky = round((y - ay) / grid_step)\n"
+     "        key = (kx, ky, round(rot, 3))\n"
+     "        if key not in seen:\n"
+     "            seen.add(key)\n"
+     "            out.append((ax + kx * grid_step, ay + ky * grid_step, rot))",
+     "        kx = round(x / grid_step)\n"
+     "        ky = round(y / grid_step)\n"
+     "        key = (kx, ky, round(rot, 3))\n"
+     "        if key not in seen:\n"
+     "            seen.add(key)\n"
+     "            out.append((kx * grid_step, ky * grid_step, rot))",
      (T_SNAP, T_RESEAT), 'KILLED'),
 ]
 

--- a/tests/mutate_708.py
+++ b/tests/mutate_708.py
@@ -208,21 +208,13 @@ ROWS = [
     # The pre-existing acceptance defect #708's slot change exposed: decide on
     # the PREDICTION again instead of the seated cost.
     ('the-reseat-accepts-on-the-prediction', 'rs',
-     "        keep = False
-"
+     "        keep = False\n"
      "        try:",
-     "        keep = apply
-"
-     "        res.accepted = True
-"
-     "        if True:
-"
-     "            for m in moved:
-"
-     "                state.apply_move(m, *poses[m])
-"
-     "            return res
-"
+     "        res.accepted = True\n"
+     "        for m in moved:\n"
+     "            state.apply_move(m, *poses[m])\n"
+     "        return res\n"
+     "        keep = False\n"
      "        try:",
      (T_SNAP, T_RESEAT), 'KILLED'),
 

--- a/tests/mutate_708.py
+++ b/tests/mutate_708.py
@@ -79,10 +79,24 @@ T_FANOUT = os.path.join(_TESTS, 'test_fanout_clearance.py')
 #: (name, target, old, new, tests, expect)
 ROWS = [
     # ---- the inference: which rung wins -------------------------------
+    # EXPECTED SURVIVOR, and the reason is a finding rather than a gap.
+    # A plain argmax is not WRONG here, it is UNDEFINED -- and CPython's `max`
+    # resolves it the safe way by accident: it returns the FIRST maximal
+    # element, `profile` is built in ladder order, and monotonicity along a
+    # divisibility chain forbids a coarser rung from strictly exceeding a finer
+    # divisor. So argmax picks the finest tied rung, which is what `ties[0]`
+    # picks deliberately. The two can only diverge where TIE_SLACK bites, and
+    # the slack is inert on this corpus (worst margin 0.075).
+    #
+    # Kept rather than deleted because it is a live detector: it starts failing
+    # the day someone reorders the ladder, builds `profile` from a set, or
+    # widens the slack past a real margin -- at which point the issue's own
+    # proposed rule silently starts choosing a different grid.
+    # `the-tie-break-takes-the-coarsest` below is the killable form.
     ('the-tie-break-takes-the-argmax', 'bg',
      "    out['step'] = ties[0]",
      "    out['step'] = max(out['profile'], key=lambda s: out['profile'][s])",
-     (T_GRID,), 'KILLED'),
+     (T_GRID,), 'SURVIVED'),
 
     ('the-tie-break-takes-the-coarsest', 'bg',
      "    out['step'] = ties[0]",
@@ -189,14 +203,14 @@ ROWS = [
      "            if math.hypot(cx - cap.seed_x,\n"
      "                          cy - cap.seed_y) > max_disp + 1e-9:\n"
      "                continue",
-     (T_FANOUT,), 'KILLED'),
+     (T_SNAP, T_FANOUT), 'KILLED'),
 
     ('the-reseat-slot-snaps-the-absolute-point', 'rs',
      "        sx = ax + snap_to_grid(x - ax, grid_step)\n"
      "        sy = ay + snap_to_grid(y - ay, grid_step)",
      "        sx = snap_to_grid(x, grid_step)\n"
      "        sy = snap_to_grid(y, grid_step)",
-     (T_RESEAT,), 'KILLED'),
+     (T_SNAP, T_RESEAT), 'KILLED'),
 ]
 
 

--- a/tests/mutate_708.py
+++ b/tests/mutate_708.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""The #708 mutation battery, shipped so its numbers can be re-derived.
+
+`tests/test_708_seed_relative_snap.py` records what each arm kills. A count is
+only checkable if the exact source edit is written down, so the edits live here
+as data, next to the numbers they produced.
+
+WHY THIS BATTERY EXISTS, in this issue's own terms. #708 has two halves that
+are easy to confuse and easy to test vacuously:
+
+  * SEED-RELATIVE -- snap the offset, not the absolute position;
+  * ON THE BOARD'S LATTICE -- and snap it to the pitch the board was laid out
+    on, not to the router's raster.
+
+The second half is the one that does the work, and a test suite that only
+checks the first would pass with the fix half-applied. The row
+`the-offset-snaps-to-the-raster-not-the-lattice` exists precisely to prove the
+arms tell those two apart: with it applied, every offset is still a clean
+multiple of `grid_step` and the residue is still preserved -- and the board's
+0.3175mm lattice is still destroyed. Measured before writing any of this: at
+step=1.0 the raster offsets are {0, +/-1.0, +/-2.0} and only the ZERO offset
+lands back on a 0.3175 lattice.
+
+Every row carries an EXPECTATION. An inert row recorded as an expected survivor
+is a finding; an inert row quietly deleted is a hole. A row whose verdict does
+not match its expectation is reported as WRONG.
+
+NOT named `test_*.py`, so `tests/run_all.py` does not collect it: it REWRITES
+the engine in place. One writer per tree -- do not run it while a suite, an A/B
+replay or a review is reading the same checkout. It refuses to start on a dirty
+engine, because restoring would write the COMMITTED text back over uncommitted
+work.
+
+    python3 -X utf8 tests/mutate_708.py
+    python3 -X utf8 tests/mutate_708.py --row the-tie-break-takes-the-argmax
+    python3 -X utf8 tests/mutate_708.py --list
+
+A row is KILLED by a FAILURE **or an ERROR**: several of these make an arm
+raise rather than fail, and a battery counting only failures would call that a
+survivor.
+
+An anchor that does not match EXACTLY ONCE is reported as BROKEN rather than
+skipped -- `str.replace(old, new, 1)` of an absent needle returns the file
+unchanged, so a stale anchor would report its row as a survivor, which reads as
+a catastrophic test failure and is really a typo.
+
+`_uncache` is carried over from `tests/mutate_797.py` and is NOT hygiene: two
+rows here are single-token edits (`ties[0]` -> `ties[-1]`, `0.67` -> `0.70`)
+that leave the file the SAME SIZE, and CPython validates a `.pyc` on
+(mtime seconds, size) alone. Mutate, run and restore inside one second and
+every later import in this checkout reads the mutant.
+
+THE MEASURED TABLE IS IN THE HEADER OF
+`tests/test_708_seed_relative_snap.py`, FROM THE RUN -- never predicted here
+and never edited afterwards to match.
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import subprocess
+import sys
+
+_TESTS = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_TESTS)
+
+BOARD_GRID = os.path.join(_ROOT, 'py_placer', 'placement', 'board_grid.py')
+QUENCH = os.path.join(_ROOT, 'py_placer', 'placement', 'quench.py')
+FANOUT = os.path.join(_ROOT, 'py_placer', 'placement', 'fanout_clearance.py')
+RESEAT = os.path.join(_ROOT, 'py_placer', 'placement', 'reseat.py')
+TARGETS = {'bg': BOARD_GRID, 'q': QUENCH, 'fc': FANOUT, 'rs': RESEAT}
+
+T_GRID = os.path.join(_TESTS, 'test_708_board_grid.py')
+T_SNAP = os.path.join(_TESTS, 'test_708_seed_relative_snap.py')
+T_RESEAT = os.path.join(_TESTS, 'test_reseat.py')
+T_FANOUT = os.path.join(_TESTS, 'test_fanout_clearance.py')
+
+#: (name, target, old, new, tests, expect)
+ROWS = [
+    # ---- the inference: which rung wins -------------------------------
+    ('the-tie-break-takes-the-argmax', 'bg',
+     "    out['step'] = ties[0]",
+     "    out['step'] = max(out['profile'], key=lambda s: out['profile'][s])",
+     (T_GRID,), 'KILLED'),
+
+    ('the-tie-break-takes-the-coarsest', 'bg',
+     "    out['step'] = ties[0]",
+     "    out['step'] = ties[-1]",
+     (T_GRID,), 'KILLED'),
+
+    # ---- the two gates that make it decline ---------------------------
+    ('the-min-parts-gate-is-dropped', 'bg',
+     "    if n_parts < min_parts:",
+     "    if False:",
+     (T_GRID,), 'KILLED'),
+
+    ('the-occupancy-floor-is-dropped', 'bg',
+     "    if best < floor:",
+     "    if False:",
+     (T_GRID,), 'KILLED'),
+
+    # The boundary detector. 0.70 is the round number the population gap
+    # first suggests, and interf_u_unrouted scores EXACTLY 0.700000, so the
+    # verdict there is decided by `>=` against `>` on a float equality.
+    ('the-floor-returns-to-the-round-0.70', 'bg',
+     "OCCUPANCY_FLOOR = 0.67",
+     "OCCUPANCY_FLOOR = 0.70",
+     (T_GRID,), 'KILLED'),
+
+    # ---- how occupancy is measured ------------------------------------
+    ('the-tolerance-becomes-relative-to-the-step', 'bg',
+     "               if abs(v / step - round(v / step)) * step <= tol_mm)",
+     "               if abs(v / step - round(v / step)) <= tol_mm)",
+     (T_GRID,), 'KILLED'),
+
+    ('the-sample-drops-one-axis', 'bg',
+     "    return xs + ys, len(fps)",
+     "    return xs, len(fps)",
+     (T_GRID,), 'KILLED'),
+
+    # ---- the quench edit: the two halves, separately -------------------
+    ('the-candidate-snap-goes-back-to-absolute', 'q',
+     "            dx = snap_to_grid(ix * step, lattice)\n"
+     "            dy = snap_to_grid(iy * step, lattice)\n"
+     "            if math.hypot(dx, dy) > max_disp + 1e-9:\n"
+     "                continue\n"
+     "            cx = part.seed_x + dx\n"
+     "            cy = part.seed_y + dy",
+     "            cx = snap_to_grid(part.seed_x + ix * step, lattice)\n"
+     "            cy = snap_to_grid(part.seed_y + iy * step, lattice)\n"
+     "            if math.hypot(cx - part.seed_x,\n"
+     "                          cy - part.seed_y) > max_disp + 1e-9:\n"
+     "                continue",
+     (T_SNAP,), 'KILLED'),
+
+    # THE row this battery exists for: seed-relative but on the RASTER. The
+    # residue is preserved, every offset is a clean multiple of grid_step,
+    # and the board's own lattice is still destroyed.
+    ('the-offset-snaps-to-the-raster-not-the-lattice', 'q',
+     "            dx = snap_to_grid(ix * step, lattice)\n"
+     "            dy = snap_to_grid(iy * step, lattice)",
+     "            dx = snap_to_grid(ix * step, 0.1)\n"
+     "            dy = snap_to_grid(iy * step, 0.1)",
+     (T_SNAP,), 'KILLED'),
+
+    ('the-radius-test-goes-back-before-the-snap', 'q',
+     "            if math.hypot(dx, dy) > max_disp + 1e-9:\n"
+     "                continue\n"
+     "            cx = part.seed_x + dx",
+     "            if math.hypot(ix * step, iy * step) > max_disp + 1e-9:\n"
+     "                continue\n"
+     "            cx = part.seed_x + dx",
+     (T_SNAP,), 'KILLED'),
+
+    ('the-lattice-is-never-resolved', 'q',
+     "    lattice, lattice_evidence = resolve_snap_lattice(pcb_data, grid_step)",
+     "    lattice, lattice_evidence = grid_step, {'source': 'grid_step',\n"
+     "                                            'step': None,\n"
+     "                                            'reason': 'disabled'}",
+     (T_SNAP,), 'KILLED'),
+
+    # ---- the group-move probe -----------------------------------------
+    ('the-group-probe-goes-back-to-the-absolute-pose', 'q',
+     "                if math.hypot(p.x + sdx - p.seed_x,\n"
+     "                              p.y + sdy - p.seed_y) > max_disp + 1e-9:",
+     "                if math.hypot(snap_to_grid(p.x + sdx, lattice) - p.seed_x,\n"
+     "                              snap_to_grid(p.y + sdy, lattice)\n"
+     "                              - p.seed_y) > max_disp + 1e-9:",
+     (T_SNAP,), 'KILLED'),
+
+    ('the-group-offset-snaps-the-absolute-pose', 'q',
+     "            sdx = snap_to_grid(ix * step, lattice)\n"
+     "            sdy = snap_to_grid(iy * step, lattice)",
+     "            sdx = snap_to_grid(ix * step, 0.1)\n"
+     "            sdy = snap_to_grid(iy * step, 0.1)",
+     (T_SNAP,), 'KILLED'),
+
+    # ---- the two sites that deliberately do NOT take the lattice -------
+    ('the-fanout-snap-goes-back-to-absolute', 'fc',
+     "            dx = snap_to_grid(ix * step, grid_step)\n"
+     "            dy = snap_to_grid(iy * step, grid_step)\n"
+     "            if math.hypot(dx, dy) > max_disp + 1e-9:\n"
+     "                continue\n"
+     "            cx = cap.seed_x + dx\n"
+     "            cy = cap.seed_y + dy",
+     "            cx = snap_to_grid(cap.seed_x + ix * step, grid_step)\n"
+     "            cy = snap_to_grid(cap.seed_y + iy * step, grid_step)\n"
+     "            if math.hypot(cx - cap.seed_x,\n"
+     "                          cy - cap.seed_y) > max_disp + 1e-9:\n"
+     "                continue",
+     (T_FANOUT,), 'KILLED'),
+
+    ('the-reseat-slot-snaps-the-absolute-point', 'rs',
+     "        sx = ax + snap_to_grid(x - ax, grid_step)\n"
+     "        sy = ay + snap_to_grid(y - ay, grid_step)",
+     "        sx = snap_to_grid(x, grid_step)\n"
+     "        sy = snap_to_grid(y, grid_step)",
+     (T_RESEAT,), 'KILLED'),
+]
+
+
+def _uncache(path):
+    """Delete the target's cached bytecode. MEASURED HAZARD, not hygiene --
+    see this module's docstring."""
+    import importlib
+    import importlib.util
+    try:
+        cached = importlib.util.cache_from_source(path)
+        if os.path.exists(cached):
+            os.remove(cached)
+    except (OSError, ValueError, NotImplementedError):
+        pass
+    importlib.invalidate_caches()
+
+
+def _dirty(path):
+    p = subprocess.run(['git', 'status', '--porcelain', '--', path],
+                       capture_output=True, text=True, cwd=_ROOT)
+    return bool(p.stdout.strip())
+
+
+def run(only=None):
+    rows = [r for r in ROWS if only is None or r[0] == only]
+    if not rows:
+        print('no row named %r' % only)
+        return 1
+    for path in TARGETS.values():
+        if _dirty(path):
+            print('REFUSING: %s has uncommitted changes. Commit or stash '
+                  'first -- this battery restores by overwriting.'
+                  % os.path.basename(path))
+            return 2
+
+    orig = {k: io.open(v, encoding='utf-8', newline='').read()
+            for k, v in TARGETS.items()}
+    results = []
+    try:
+        for name, tgt, old, new, tests, expect in rows:
+            path, base = TARGETS[tgt], orig[tgt]
+            n = base.count(old)
+            if n != 1:
+                results.append((name, 'BROKEN', expect,
+                                'anchor matched %d times' % n, []))
+                print('  ran %-52s BROKEN' % name)
+                continue
+            io.open(path, 'w', encoding='utf-8', newline='').write(
+                base.replace(old, new, 1))
+            _uncache(path)
+            killed, failed = False, []
+            for t in tests:
+                p = subprocess.run([sys.executable, '-X', 'utf8', t],
+                                   capture_output=True, text=True,
+                                   encoding='utf-8', errors='replace',
+                                   timeout=1800, cwd=_ROOT)
+                out = (p.stderr or '') + (p.stdout or '')
+                if p.returncode:
+                    killed = True
+                failed += [l.strip()[5:].strip()[:90]
+                           for l in out.splitlines()
+                           if l.strip().startswith('FAIL')]
+                if 'Traceback' in out:
+                    failed.append('raised: '
+                                  + out.strip().splitlines()[-1][:70])
+            io.open(path, 'w', encoding='utf-8', newline='').write(base)
+            _uncache(path)
+            results.append((name, 'KILLED' if killed else 'SURVIVED', expect,
+                            '%d' % len(failed), failed[:3]))
+            print('  ran %-52s %s' % (name, results[-1][1]))
+    finally:
+        for k, v in TARGETS.items():
+            io.open(v, 'w', encoding='utf-8', newline='').write(orig[k])
+            _uncache(v)
+
+    print()
+    w = max(len(r[0]) for r in results)
+    wrong = 0
+    for name, verdict, expect, cnt, failed in results:
+        mark = ''
+        if verdict != expect:
+            mark = '   <-- WRONG, expected %s' % expect
+            wrong += 1
+        print('%-*s  %-9s  %-3s%s' % (w, name, verdict, cnt, mark))
+        for f in failed:
+            print('%s      %s' % (' ' * w, f))
+    killed = sum(1 for r in results if r[1] == 'KILLED')
+    survived = sum(1 for r in results if r[1] == 'SURVIVED')
+    broken = sum(1 for r in results if r[1] == 'BROKEN')
+    print('\n%d rows: %d killed, %d survived (%d of them expected), %d broken'
+          % (len(results), killed, survived,
+             sum(1 for r in results if r[1] == r[2] == 'SURVIVED'), broken))
+    if wrong or broken:
+        print('%d row(s) did not match their expectation' % (wrong + broken))
+    return 1 if (wrong or broken) else 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument('--row', default=None, help='run one row by name')
+    ap.add_argument('--list', action='store_true', help='list the row names')
+    a = ap.parse_args()
+    if a.list:
+        for r in ROWS:
+            print('%-52s %-4s %s' % (r[0], r[1], r[5]))
+        return 0
+    return run(a.row)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/placement_ab_baseline.json
+++ b/tests/placement_ab_baseline.json
@@ -3,20 +3,20 @@
   "board": "kit-dev-coldfire-xilinx_5213.kicad_pcb",
   "mark": "improve",
   "off": {
-   "crossings": 1379,
-   "health_block_displacement_max_mm": 55.3346,
+   "crossings": 1384,
+   "health_block_displacement_max_mm": 56.3849,
    "health_bus_foreign_crossings": 147,
-   "hpwl": 7434.4,
+   "hpwl": 7415.76,
    "intent_errors": 0,
    "intent_errors_by_rule": {},
    "intent_errors_enforced": 0,
    "intent_errors_other": 0
   },
   "on": {
-   "crossings": 1370,
-   "health_block_displacement_max_mm": 54.6257,
-   "health_bus_foreign_crossings": 143,
-   "hpwl": 7241.97,
+   "crossings": 1372,
+   "health_block_displacement_max_mm": 55.4249,
+   "health_bus_foreign_crossings": 144,
+   "hpwl": 7171.84,
    "intent_errors": 0,
    "intent_errors_by_rule": {},
    "intent_errors_enforced": 0,
@@ -27,10 +27,10 @@
   "board": "orangecrab_ext_pll.kicad_pcb",
   "mark": "improve",
   "off": {
-   "crossings": 1063,
-   "health_block_displacement_max_mm": 18.5356,
-   "health_bus_foreign_crossings": 32,
-   "hpwl": 2117.85,
+   "crossings": 1087,
+   "health_block_displacement_max_mm": 18.1954,
+   "health_bus_foreign_crossings": 33,
+   "hpwl": 2121.92,
    "intent_errors": 1,
    "intent_errors_by_rule": {
     "zone_containment": 1
@@ -39,10 +39,10 @@
    "intent_errors_other": 0
   },
   "on": {
-   "crossings": 1042,
-   "health_block_displacement_max_mm": 18.8075,
+   "crossings": 1074,
+   "health_block_displacement_max_mm": 18.1954,
    "health_bus_foreign_crossings": 31,
-   "hpwl": 2113.67,
+   "hpwl": 2111.05,
    "intent_errors": 1,
    "intent_errors_by_rule": {
     "zone_containment": 1
@@ -55,10 +55,10 @@
   "board": "ulx3s.kicad_pcb",
   "mark": "regress",
   "off": {
-   "crossings": 2477,
-   "health_block_displacement_max_mm": 17.9512,
+   "crossings": 2429,
+   "health_block_displacement_max_mm": 18.9597,
    "health_bus_foreign_crossings": 62,
-   "hpwl": 7437.99,
+   "hpwl": 7493.73,
    "intent_errors": 4,
    "intent_errors_by_rule": {
     "zone_containment": 4
@@ -67,15 +67,15 @@
    "intent_errors_other": 0
   },
   "on": {
-   "crossings": 2407,
-   "health_block_displacement_max_mm": 18.0904,
+   "crossings": 2442,
+   "health_block_displacement_max_mm": 16.9877,
    "health_bus_foreign_crossings": 55,
-   "hpwl": 7416.23,
-   "intent_errors": 7,
+   "hpwl": 7428.07,
+   "intent_errors": 4,
    "intent_errors_by_rule": {
-    "zone_containment": 7
+    "zone_containment": 4
    },
-   "intent_errors_enforced": 7,
+   "intent_errors_enforced": 4,
    "intent_errors_other": 0
   }
  },
@@ -83,10 +83,10 @@
   "board": "kit-dev-coldfire-xilinx_5213.kicad_pcb",
   "mark": "regress",
   "off": {
-   "crossings": 1379,
-   "health_block_displacement_max_mm": 55.3346,
+   "crossings": 1384,
+   "health_block_displacement_max_mm": 56.3849,
    "health_bus_foreign_crossings": null,
-   "hpwl": 7434.4,
+   "hpwl": 7415.76,
    "intent_errors": 5,
    "intent_errors_by_rule": {
     "zone_exclusive": 5
@@ -95,26 +95,26 @@
    "intent_errors_other": 0
   },
   "on": {
-   "crossings": 1381,
-   "health_block_displacement_max_mm": 55.3346,
+   "crossings": 1383,
+   "health_block_displacement_max_mm": 55.4372,
    "health_bus_foreign_crossings": null,
-   "hpwl": 7431.96,
-   "intent_errors": 5,
+   "hpwl": 7428.76,
+   "intent_errors": 6,
    "intent_errors_by_rule": {
-    "zone_exclusive": 5
+    "zone_exclusive": 6
    },
-   "intent_errors_enforced": 5,
+   "intent_errors_enforced": 6,
    "intent_errors_other": 0
   }
  },
  "intent-orangecrab": {
   "board": "orangecrab_ext_pll.kicad_pcb",
-  "mark": "improve",
+  "mark": "regress",
   "off": {
-   "crossings": 1063,
-   "health_block_displacement_max_mm": 18.5356,
+   "crossings": 1087,
+   "health_block_displacement_max_mm": 18.1954,
    "health_bus_foreign_crossings": null,
-   "hpwl": 2117.85,
+   "hpwl": 2121.92,
    "intent_errors": 1,
    "intent_errors_by_rule": {
     "zone_containment": 1
@@ -123,10 +123,10 @@
    "intent_errors_other": 0
   },
   "on": {
-   "crossings": 1053,
-   "health_block_displacement_max_mm": 18.5356,
+   "crossings": 1065,
+   "health_block_displacement_max_mm": 18.1954,
    "health_bus_foreign_crossings": null,
-   "hpwl": 2115.16,
+   "hpwl": 2131.25,
    "intent_errors": 0,
    "intent_errors_by_rule": {},
    "intent_errors_enforced": 0,
@@ -135,24 +135,24 @@
  },
  "intent-rp2350": {
   "board": "rp2350_fpga_eensy_prePlane.kicad_pcb",
-  "mark": "regress",
+  "mark": "improve",
   "off": {
-   "crossings": 416,
-   "health_block_displacement_max_mm": 11.5626,
+   "crossings": 421,
+   "health_block_displacement_max_mm": 11.286,
    "health_bus_foreign_crossings": null,
-   "hpwl": 958.22,
-   "intent_errors": 2,
+   "hpwl": 957.38,
+   "intent_errors": 3,
    "intent_errors_by_rule": {
-    "zone_containment": 2
+    "zone_containment": 3
    },
-   "intent_errors_enforced": 2,
+   "intent_errors_enforced": 3,
    "intent_errors_other": 0
   },
   "on": {
-   "crossings": 420,
-   "health_block_displacement_max_mm": 11.5626,
+   "crossings": 416,
+   "health_block_displacement_max_mm": 11.8051,
    "health_bus_foreign_crossings": null,
-   "hpwl": 957.42,
+   "hpwl": 949.81,
    "intent_errors": 1,
    "intent_errors_by_rule": {
     "zone_containment": 1
@@ -165,10 +165,10 @@
   "board": "ulx3s.kicad_pcb",
   "mark": "regress",
   "off": {
-   "crossings": 2477,
-   "health_block_displacement_max_mm": 17.9512,
+   "crossings": 2429,
+   "health_block_displacement_max_mm": 18.9597,
    "health_bus_foreign_crossings": null,
-   "hpwl": 7437.99,
+   "hpwl": 7493.73,
    "intent_errors": 4,
    "intent_errors_by_rule": {
     "zone_containment": 4
@@ -177,10 +177,10 @@
    "intent_errors_other": 0
   },
   "on": {
-   "crossings": 2491,
-   "health_block_displacement_max_mm": 19.9427,
+   "crossings": 2449,
+   "health_block_displacement_max_mm": 20.9521,
    "health_bus_foreign_crossings": null,
-   "hpwl": 7508.56,
+   "hpwl": 7571.85,
    "intent_errors": 0,
    "intent_errors_by_rule": {},
    "intent_errors_enforced": 0,

--- a/tests/test_504_ratsnest_metrics.py
+++ b/tests/test_504_ratsnest_metrics.py
@@ -59,7 +59,12 @@ def test_metrics_out_is_populated_and_matches_total_cost():
     m = {}
     quench(parse_kicad_pcb(BOARD), pcb_file=BOARD, max_displacement=2.0,
            step=1.0, max_passes=1, metrics_out=m)
-    assert set(m) == {'before', 'after', 'legality'}, f"keys: {sorted(m)}"
+    # `board_grid` joined this set in #708. The rule the set enforces is that
+    # new NUMBERS go inside `before`/`after`, never alongside them; this key is
+    # PROVENANCE -- which lattice the run resolved and how -- in the same
+    # category as the `intent_gate` key that has always been allowed to sit at
+    # the top level. Extended deliberately, not quietly.
+    assert set(m) == {'before', 'after', 'legality', 'board_grid'},         f"keys: {sorted(m)}"
     for phase in ('before', 'after'):
         for key in ('total', 'length', 'crossings', 'halo', 'edge', 'hpwl'):
             assert key in m[phase], f"{phase} missing {key}"

--- a/tests/test_548_align_orient.py
+++ b/tests/test_548_align_orient.py
@@ -182,13 +182,15 @@ def test_twelve_positional_args_still_bind():
 
 
 def test_metrics_stay_inside_before_and_after():
-    """test_504_ratsnest_metrics.py:46 asserts the EXACT top-level key set
-    {before, after, legality}. New numbers go inside, never alongside."""
+    """test_504_ratsnest_metrics.py asserts the EXACT top-level key set.
+    New NUMBERS go inside `before`/`after`, never alongside. `board_grid`
+    (#708) is provenance rather than a number -- which lattice this run
+    resolved and why -- so it sits at the top level like `intent_gate`."""
     p = os.path.join(KF, 'interf_u_unrouted.kicad_pcb')
     m = {}
     quench(parse_kicad_pcb(p), p, max_displacement=1.0, step=1.0, max_passes=1,
            align_weight=5.0, orient_weight=1.0, metrics_out=m)
-    assert set(m) == {'before', 'after', 'legality'}, sorted(m)
+    assert set(m) == {'before', 'after', 'legality', 'board_grid'}, sorted(m)
     for phase in ('before', 'after'):
         for k in ('total', 'length', 'crossings', 'halo', 'edge', 'hpwl',
                   'align', 'orient'):

--- a/tests/test_703_predictor_regen.py
+++ b/tests/test_703_predictor_regen.py
@@ -134,17 +134,29 @@ EXPECTED = {
     # miniature: this placement scores 23 crossings against the authored
     # board's 53 -- the best on the slate -- and routes to blocking 3 where the
     # authored board routes to 0.
+    # RE-RECORDED for #708 (the seed-relative candidate snap). This row is the
+    # detector the header describes -- "a change to the placement engine ...
+    # silently moving the numbers the study measured" -- and it fired, which is
+    # it working. The quench now offers candidates on the board's own lattice,
+    # so this candidate's poses genuinely differ; `poses_sha256`, the four
+    # geometry predictors and the routed `quality` moved with them, and the
+    # values below are from the run, reproduced twice.
+    #
+    # What did NOT move, and is why the commentary above still stands:
+    # `truth.headline` is still 3 and `predictors.crossings` is still 23. The
+    # routed board is in fact slightly better -- vias 28 -> 23, copper
+    # 299.93 -> 263.91mm, segments 231 -> 203 -- at the same blocking.
     'esp_prog:portfolio-1': dict(
-        poses_sha256='4c299873cd66c843dc6b27fcadf99c9782a7e7e1a3b51328a5b5cee9ca6593d8',
+        poses_sha256='aa84f6b468eae8f04ef72cc2ff02d4e0eead818463289e7328bce162f9dd3364',
         argv_sha='52aaeed47e14fea796be12c36db09c605a4b8ec588da12bded6a2573b1c7f0b0',
-        seconds=23.8,
+        seconds=9.5,
         truth={'headline': 3,
-               'quality': {'vias': 28, 'copper_mm': 299.93, 'segments': 231}},
+               'quality': {'vias': 23, 'copper_mm': 263.91, 'segments': 203}},
         predictors={
-            'crossings': 23, 'hpwl': 236.74883999999992,
-            'halo': 113.8065780241933, 'overlap_area': 1.0,
+            'crossings': 23, 'hpwl': 236.44943999999998,
+            'halo': 114.29726291832301, 'overlap_area': 1.0,
             'pad_copper': 0, 'pad_clearance_pairs': 0,
-            'edge': 11.574407139199987, 'total': 582.4219077763819,
+            'edge': 11.327191579199937, 'total': 582.4363161985618,
             'oob_count': 0,
         }),
     # A SECOND board, so a change that only moves one board's numbers cannot

--- a/tests/test_708_board_grid.py
+++ b/tests/test_708_board_grid.py
@@ -85,10 +85,18 @@ def t_occupancy_counts_what_it_says():
            '%.4f' % BG.occupancy(vals, 0.3175))
     report('a degenerate step scores 0 rather than dividing by it',
            BG.occupancy(vals, 0.0) == 0.0 and BG.occupancy([], 0.1) == 0.0)
-    # The tolerance is absolute in mm, not relative to the step.
-    report('the 1um tolerance is absolute',
-           BG.occupancy([0.0009], 1.0) == 1.0
-           and BG.occupancy([0.0011], 1.0) == 0.0)
+    # The tolerance is absolute in mm, not relative to the step. Both arms
+    # need a step != 1.0, or `* step` is a no-op and the assertion cannot see
+    # the difference -- the first draft used 1.0 and the mutation battery
+    # caught it as a survivor.
+    report('the 1um tolerance is absolute, not a fraction of the step',
+           BG.occupancy([0.0009], 0.05) == 1.0,     # relative form: 0.018, miss
+           'fine step')
+    report('and it does not widen with a coarse step',
+           BG.occupancy([0.002], 2.54) == 0.0,      # relative form: 0.0008, hit
+           'coarse step')
+    report('a plain miss is still a miss',
+           BG.occupancy([0.0011], 1.0) == 0.0)
 
 
 def t_finest_within_slack_not_argmax():

--- a/tests/test_708_board_grid.py
+++ b/tests/test_708_board_grid.py
@@ -1,0 +1,308 @@
+"""The board-lattice inference (#708): what it may return, and when it declines.
+
+The issue proposes an ARGMAX over a ladder of pitches. That rule is undefined
+exactly where it matters, because the ladder contains divisibility chains and
+occupancy is monotone along one -- so ties are structural, not accidental.
+These cases pin the two rules that replace it (finest-within-slack, and a
+minimum sample count), the corpus verdicts they produce, and the three claims
+in #708 that measurement contradicts.
+
+Cheap and hermetic: parsing 22 boards, no quench, no routing.
+"""
+
+import math
+import os
+import sys
+
+RUN_ALL_FAST_OK = True
+RUN_ALL_TIMEOUT = 300
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for _d in ('py_router', 'py_placer', 'py_tools'):
+    sys.path.insert(0, os.path.join(ROOT, _d))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import run_utils                                               # noqa: E402
+from kicad_parser import parse_kicad_pcb                       # noqa: E402
+from placement import board_grid as BG                         # noqa: E402
+
+FAILURES = []
+
+
+def report(name, ok, detail=''):
+    print(('  PASS  ' if ok else '  FAIL  ') + name
+          + (('  -- ' + detail) if detail else ''))
+    if not ok:
+        FAILURES.append(name)
+
+
+class _FP:
+    def __init__(self, x, y):
+        self.x, self.y = x, y
+
+
+class _PCB:
+    """The only surface `board_coordinates` touches."""
+    def __init__(self, xys):
+        self.footprints = {'R%d' % i: _FP(x, y)
+                           for i, (x, y) in enumerate(xys)}
+
+
+def on_lattice(step, n, origin_units=16):
+    """n parts whose x and y are exact multiples of `step`.
+
+    Anchored at 0, because that is where the module anchors and where real
+    boards put their lattice -- measured, a best-phase search over the corpus
+    never beat the origin-anchored fit on any board. A fixture offset by a
+    non-multiple (10.0 mm against a 0.635 lattice) is not an on-lattice board
+    at all, which is how the first draft of these cases failed.
+    """
+    return _PCB([(round((origin_units + i * 3) * step, 9),
+                  round((origin_units + i * 5) * step, 9))
+                 for i in range(n)])
+
+
+_CORPUS = {}
+
+
+def corpus():
+    if not _CORPUS:
+        boards = run_utils.corpus_boards()
+        if not boards:
+            return None
+        for p in boards:
+            name = os.path.basename(p).replace('.kicad_pcb', '')
+            _CORPUS[name] = BG.infer_board_grid(parse_kicad_pcb(p))
+    return _CORPUS
+
+
+# ------------------------------------------------------------------ cases
+
+def t_occupancy_counts_what_it_says():
+    vals = [0.0, 0.3175, 0.635, 0.4]          # 3 of 4 on 0.3175
+    report('occupancy is a plain hit rate',
+           abs(BG.occupancy(vals, 0.3175) - 0.75) < 1e-12,
+           '%.4f' % BG.occupancy(vals, 0.3175))
+    report('a degenerate step scores 0 rather than dividing by it',
+           BG.occupancy(vals, 0.0) == 0.0 and BG.occupancy([], 0.1) == 0.0)
+    # The tolerance is absolute in mm, not relative to the step.
+    report('the 1um tolerance is absolute',
+           BG.occupancy([0.0009], 1.0) == 1.0
+           and BG.occupancy([0.0011], 1.0) == 0.0)
+
+
+def t_finest_within_slack_not_argmax():
+    """A board on 0.635 has occupancy 1.00 at 0.635 AND at 0.3175, because
+    0.3175 divides it. The argmax #708 proposes has no answer; this returns
+    the finer of the tied pair, deliberately."""
+    ev = BG.infer_board_grid(on_lattice(0.635, 20))
+    report('a pure 0.635 board reports the tie',
+           set(ev['ties']) >= {0.3175, 0.635}, str(ev['ties']))
+    report('and resolves to the FINEST of it, not the argmax',
+           ev['step'] == 0.3175, str(ev['step']))
+    # Why finer is the safe direction: every pose the coarse lattice offers is
+    # still offered by the fine one, so nothing is removed. The reverse is not
+    # true, and picking coarse is how sonde_u would infer 1.27 off a tie.
+
+
+def t_only_two_values_are_reachable():
+    """Only 0.05 and 0.3175 have no proper divisor in the ladder, and
+    occupancy is monotone along a divisibility chain, so no other rung can
+    ever win. This is a property of the ladder, not of the corpus."""
+    reachable = set()
+    for s in BG.GRID_LADDER:
+        divisors = [d for d in BG.GRID_LADDER
+                    if d < s and abs(s / d - round(s / d)) < 1e-9]
+        if not divisors:
+            reachable.add(s)
+    report('exactly {0.05, 0.3175} have no ladder divisor',
+           reachable == {0.05, 0.3175}, str(sorted(reachable)))
+    # And the monotonicity the argument rests on, checked on real numbers.
+    vals = [1.27 * i + 0.0 for i in range(50)] + [3.1, 7.77, 0.4]
+    bad = [(d, s) for s in BG.GRID_LADDER for d in BG.GRID_LADDER
+           if d < s and abs(s / d - round(s / d)) < 1e-9
+           and BG.occupancy(vals, d) < BG.occupancy(vals, s) - 1e-12]
+    report('occupancy is monotone non-increasing along every divisor chain',
+           not bad, str(bad[:3]))
+
+
+def t_a_rate_needs_a_denominator():
+    """1-4 part fixtures score 1.00 at six rungs because hand-authored
+    coordinates are round by construction. There is no answer to give."""
+    ev = BG.infer_board_grid(on_lattice(0.635, 4))
+    report('below MIN_PARTS it declines', ev['step'] is None, str(ev['step']))
+    report('and names the denominator as the reason',
+           'n_parts 4 < 8' in ev['reason'], ev['reason'])
+    report('at exactly MIN_PARTS it answers',
+           BG.infer_board_grid(on_lattice(0.635, 8))['step'] == 0.3175)
+
+
+def t_the_floor_does_not_sit_on_a_sample():
+    """A threshold resting exactly on a corpus board is decided by `>=` vs `>`.
+    interf_u_unrouted scores 0.700000, which is why the floor is 0.67 and not
+    the round 0.70 the population gap first suggests."""
+    c = corpus()
+    if c is None:
+        report('floor clearance (SKIPPED: git could not enumerate the corpus)',
+               True)
+        return
+    bests = [(max(ev['profile'].values()), n) for n, ev in c.items()
+             if ev['n_parts'] >= BG.MIN_PARTS]
+    near = [(b, n) for b, n in bests if abs(b - BG.OCCUPANCY_FLOOR) < 0.02]
+    report('no corpus board sits within 0.02 of the floor',
+           not near, str(near))
+    above = min((b for b, _n in bests if b >= BG.OCCUPANCY_FLOOR), default=None)
+    below = max((b for b, _n in bests if b < BG.OCCUPANCY_FLOOR), default=None)
+    report('the floor sits inside a real population gap',
+           above is not None and below is not None and above - below > 0.05,
+           'nearest admitted %.4f, nearest rejected %.4f' % (above, below))
+
+
+def t_the_corpus_verdicts_are_pinned():
+    """The whole table, so a change to any constant has to face every board."""
+    expect = {
+        # imperial, and the boards #708 is about
+        'splitflap_driver': 0.3175, 'flat_hierarchy': 0.3175,
+        'sonde_u': 0.3175, 'interf_u_unrouted': 0.3175,
+        # metric-fine
+        'glasgow_revC': 0.05, 'esp_prog': 0.05,
+        'interf_u_unrouted_placed': 0.05, 'lvds_converter_dualclk': 0.05,
+        'lvds_converter_dualclk_gnd': 0.05, 'haasoscope_pro_max_test': 0.05,
+        'routed_output': 0.05,
+        # no lattice: below the floor
+        'orangecrab_ext_pll': None, 'tigard': None,
+        'rp2350_fpga_eensy_prePlane': None,
+        'kit-dev-coldfire-xilinx_5213': None,
+        'watchy': None, 'ulx3s': None,
+        # no lattice: too few parts
+        'cap_chain': None, 'qfn_csi_underpad_diff': None,
+        'qfn_diffpair_escape': None, 'qfn_interior_pads': None,
+        'qfn_underpad_coupling': None,
+    }
+    c = corpus()
+    if c is None:
+        report('corpus verdicts (SKIPPED: git could not enumerate the corpus)',
+               True)
+        return
+    wrong = {n: (c[n]['step'], want) for n, want in expect.items()
+             if n in c and c[n]['step'] != want}
+    report('every tracked board resolves as recorded', not wrong, str(wrong))
+    unlisted = sorted(set(c) - set(expect))
+    report('and the table covers the corpus (a new board must be judged)',
+           not unlisted, str(unlisted))
+
+
+def t_the_issue_s_coldfire_claim_is_refuted():
+    """#708 cites kit-dev-coldfire-xilinx_5213 as showing "the same signature
+    at 1.27mm". It does not, and this is the row that keeps the refutation from
+    being re-litigated."""
+    c = corpus()
+    if c is None:
+        report('coldfire (SKIPPED: no corpus)', True)
+        return
+    ev = c.get('kit-dev-coldfire-xilinx_5213')
+    if ev is None:
+        report('coldfire is in the corpus', False)
+        return
+    best = max(ev['profile'].values())
+    report('its 1.27 occupancy is far below its own maximum',
+           ev['profile'][1.27] < 0.2 and best < 0.3,
+           '1.27 -> %.3f, best %.3f' % (ev['profile'][1.27], best))
+    report('so it reports NO lattice', ev['step'] is None)
+    # The one corpus claim #708 gets right, kept beside the one it does not.
+    report('ulx3s and watchy report no lattice, as the issue says',
+           c['ulx3s']['step'] is None and c['watchy']['step'] is None)
+
+
+def t_it_declines_rather_than_inventing():
+    report('a board with no footprints declines',
+           BG.infer_board_grid(_PCB([]))['reason'] == 'no footprints')
+    nonfinite = _PCB([(float('nan'), 1.0)] * 10)
+    vals, n_parts = BG.board_coordinates(nonfinite)
+    report('non-finite coordinates are dropped from the SAMPLE',
+           vals == [1.0] * 10, str(vals[:3]))
+    report('while n_parts still counts the footprints that exist',
+           n_parts == 10, str(n_parts))
+    try:
+        BG.infer_board_grid(on_lattice(0.1, 10), ladder=(0.0, 0.1))
+        raised = False
+    except ValueError:
+        raised = True
+    report('a non-positive ladder rung raises rather than dividing by zero',
+           raised)
+
+
+def t_resolve_falls_back_and_says_which_branch():
+    """There is no flag: the fallback IS the off state, and a caller has to be
+    able to tell which branch ran."""
+    lat, ev = BG.resolve_snap_lattice(on_lattice(0.635, 20), 0.1)
+    report('an inferable board resolves to its lattice',
+           lat == 0.3175 and ev['source'] == 'inferred', '%s %s' % (lat, ev['source']))
+    lat, ev = BG.resolve_snap_lattice(on_lattice(0.635, 4), 0.1)
+    report('a board with no lattice falls back to grid_step',
+           lat == 0.1 and ev['source'] == 'grid_step', '%s %s' % (lat, ev['source']))
+    report('and the fallback still carries the reason',
+           'n_parts' in ev['reason'], ev['reason'])
+    lat, ev = BG.resolve_snap_lattice(on_lattice(0.635, 20), 0.1, override=0.5)
+    report('an override wins and is labelled as given',
+           lat == 0.5 and ev['source'] == 'explicit')
+    try:
+        BG.resolve_snap_lattice(on_lattice(0.635, 20), 0.1, override=0.0)
+        raised = False
+    except ValueError:
+        raised = True
+    report('a non-positive override raises', raised)
+
+
+def t_describe_names_the_branch_it_took():
+    _lat, ev = BG.resolve_snap_lattice(on_lattice(0.635, 20), 0.1)
+    line = BG.describe(ev)
+    report('the inferred line names the lattice and the evidence',
+           '0.3175' in line and 'inferred' in line and '40' in line, line)
+    _lat, ev = BG.resolve_snap_lattice(on_lattice(0.635, 4), 0.1)
+    line = BG.describe(ev)
+    report('the fallback line says it is the raster, and why',
+           'raster' in line and 'n_parts' in line, line)
+
+
+TESTS = [
+    ('occupancy', t_occupancy_counts_what_it_says),
+    ('finest, not argmax', t_finest_within_slack_not_argmax),
+    ('the ladder admits two answers', t_only_two_values_are_reachable),
+    ('a rate needs a denominator', t_a_rate_needs_a_denominator),
+    ('the floor is off every sample', t_the_floor_does_not_sit_on_a_sample),
+    ('corpus verdicts', t_the_corpus_verdicts_are_pinned),
+    ("#708's coldfire claim", t_the_issue_s_coldfire_claim_is_refuted),
+    ('it declines rather than inventing', t_it_declines_rather_than_inventing),
+    ('resolve names its branch', t_resolve_falls_back_and_says_which_branch),
+    ('describe', t_describe_names_the_branch_it_took),
+]
+
+
+def _every_case_is_registered():
+    g = globals()
+    declared = {fn for _l, fn in TESTS}
+    missing = sorted(n for n, v in g.items()
+                     if n.startswith('t_') and callable(v)
+                     and v not in declared)
+    if missing:
+        print('  FAIL  every t_* case is registered in TESTS  -- ORPHANED: %s'
+              % ', '.join(missing))
+        FAILURES.append('unregistered cases: %s' % ', '.join(missing))
+
+
+def main():
+    print('board lattice inference (#708)')
+    for label, fn in TESTS:
+        print(' ' + label)
+        fn()
+    _every_case_is_registered()
+    if FAILURES:
+        print('\nFAILED (%d): %s' % (len(FAILURES), ', '.join(FAILURES)))
+        return 1
+    print('\nOK')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_708_seed_relative_snap.py
+++ b/tests/test_708_seed_relative_snap.py
@@ -27,24 +27,26 @@ Both are properties of the mechanism rather than of a board, which is why they
 are asserted on an imperial board, a metric-fine one, and one with no
 inferable lattice at all.
 
-MEASURED, `tests/mutate_708.py`, third run: 15 rows, 14 killed, 1 survived
-(expected), 0 broken. The table, from the run:
+MEASURED, `tests/mutate_708.py`, sixth run: 17 rows, 16 killed, 1
+survived (expected), 0 broken. The table, from the run:
 
-    the-tie-break-takes-the-argmax                  SURVIVED  (expected)
-    the-tie-break-takes-the-coarsest                KILLED   6
-    the-min-parts-gate-is-dropped                   KILLED   7
-    the-occupancy-floor-is-dropped                  KILLED   4
-    the-floor-returns-to-the-round-0.70             KILLED   2
-    the-tolerance-becomes-relative-to-the-step      KILLED   3
-    the-sample-drops-one-axis                       KILLED   3
-    the-candidate-snap-goes-back-to-absolute        KILLED  10
-    the-offset-snaps-to-the-raster-not-the-lattice  KILLED   5
-    the-radius-test-goes-back-before-the-snap       KILLED   2
-    the-lattice-is-never-resolved                   KILLED   5
-    the-group-probe-goes-back-to-the-absolute-pose  KILLED   2
-    the-group-offset-snaps-the-absolute-pose        KILLED   3
-    the-fanout-snap-goes-back-to-absolute           KILLED   4
-    the-reseat-slot-snaps-the-absolute-point        KILLED   3
+    the-tie-break-takes-the-argmax                 SURVIVED 0
+    the-tie-break-takes-the-coarsest               KILLED   6
+    the-min-parts-gate-is-dropped                  KILLED   7
+    the-occupancy-floor-is-dropped                 KILLED   4
+    the-floor-returns-to-the-round-0.70            KILLED   2
+    the-tolerance-becomes-relative-to-the-step     KILLED   3
+    the-sample-drops-one-axis                      KILLED   4
+    the-candidate-snap-goes-back-to-absolute       KILLED   10
+    the-offset-snaps-to-the-raster-not-the-lattice KILLED   6
+    the-radius-test-goes-back-before-the-snap      KILLED   2
+    the-lattice-is-never-resolved                  KILLED   6
+    the-group-probe-goes-back-to-the-absolute-pose KILLED   2
+    the-group-offset-snaps-the-absolute-pose       KILLED   3
+    the-fanout-snap-goes-back-to-absolute          KILLED   4
+    the-reseat-accepts-on-the-prediction           KILLED   6
+    the-reseat-dedup-key-is-not-injective          KILLED   2
+    the-reseat-slot-snaps-the-absolute-point       KILLED   7
 
 The first run killed only 9 of 15. Five of its six survivors were holes in
 THESE arms rather than in the engine: an assertion at `step=1.0` where the

--- a/tests/test_708_seed_relative_snap.py
+++ b/tests/test_708_seed_relative_snap.py
@@ -34,7 +34,10 @@ for _d in ('py_router', 'py_placer', 'py_tools'):
 
 from kicad_parser import parse_kicad_pcb                        # noqa: E402
 from placement import board_grid as BG                          # noqa: E402
+from placement import fanout_clearance as FC                    # noqa: E402
 from placement import quench as Q                               # noqa: E402
+from placement import reseat as RS                              # noqa: E402
+from placement.utility import snap_to_grid as snap              # noqa: E402
 
 FAILURES = []
 
@@ -149,7 +152,14 @@ def t_the_generator_offers_only_on_lattice_poses():
     """Straight at `_candidate_positions`, so a failure localises."""
     class _P:
         seed_x, seed_y = 131.4450, 138.4300      # 207 x 0.635, 218 x 0.635
-    for lat in (0.1, 0.3175, 0.05):
+    # 0.635 is in this list for the radius arm, not the lattice arm: it is the
+    # only rung here where snapping ROUNDS UP past a 3.0mm cap
+    # (snap(3.0, 0.635) = 3.175). At 0.1, 0.05 and 0.3175 the snap always
+    # rounds down, so a version that tested the radius BEFORE snapping would
+    # look identical -- which is exactly how the first draft of this case let
+    # the mutation battery's `radius-test-goes-back-before-the-snap` row
+    # survive.
+    for lat in (0.1, 0.3175, 0.05, 0.635):
         cands = Q._candidate_positions(_P(), 3.0, 1.0, lat)
         off = [(cx - _P.seed_x, cy - _P.seed_y) for cx, cy in cands]
         report('offsets are multiples of %g' % lat,
@@ -189,7 +199,11 @@ def t_group_offsets_probes_the_pose_it_emits():
     """The admissibility probe used to snap the ABSOLUTE p.x + dx while the
     emitted offset was snap(dx); the cap was checked against a pose the block
     never takes. Assert on what is yielded."""
-    name = 'interf_u_unrouted'
+    # A board whose parts sit OFF the lattice, deliberately. On an on-lattice
+    # board `snap(p.x + sdx)` and `p.x + sdx` are the same number, so the
+    # probe/emit distinction is invisible and the mutation row for it survives
+    # -- which is what happened to the first draft, on interf_u.
+    name = 'rp2350_fpga_eensy_prePlane'
     path = board(name)
     pcb = parse_kicad_pcb(path)
     lat, _ev = lattice_of(name)
@@ -199,9 +213,28 @@ def t_group_offsets_probes_the_pose_it_emits():
         st = Q.QuenchState(pcb, path, 0.2, 0.55, 10.0, 0.5, 0.25, 2.0, 2.0,
                            2.0, 0.1, 1.0)
     refs = sorted(st.parts)[:3]
-    max_disp = 3.0
-    offs = list(Q._group_offsets(st, refs, max_disp, 1.0, lat))
+    off_lattice = [r for r in refs if not on_grid(st.parts[r].x, lat)]
+    report('the fixture is off-lattice, so probe and emit can disagree',
+           bool(off_lattice), '%d of %d' % (len(off_lattice), len(refs)))
+    max_disp, step = 3.0, 1.0
+    offs = sorted(Q._group_offsets(st, refs, max_disp, step, lat))
     report('the block move offers offsets at all', bool(offs), str(len(offs)))
+    # In a FRESH state every part is at its own seed, so the per-member cap
+    # reduces to a statement about the offset alone. Assert the whole SET, not
+    # just that what came out is valid: a probe measuring the wrong pose drops
+    # offsets near the cap, and "everything emitted is legal" cannot see a
+    # missing one.
+    n = int(max_disp / step)
+    want = sorted({(round(snap(ix * step, lat), 9),
+                    round(snap(iy * step, lat), 9))
+                   for ix in range(-n, n + 1) for iy in range(-n, n + 1)
+                   if math.hypot(snap(ix * step, lat),
+                                 snap(iy * step, lat)) <= max_disp + 1e-9}
+                  - {(0.0, 0.0)})
+    got = sorted((round(dx, 9), round(dy, 9)) for dx, dy in offs)
+    report('the emitted offsets are EXACTLY the lattice multiples in range',
+           got == want, 'got %d, want %d, missing %s'
+           % (len(got), len(want), sorted(set(want) - set(got))[:3]))
     bad = [(r, o) for o in offs for r in refs
            if math.hypot(st.parts[r].x + o[0] - st.parts[r].seed_x,
                          st.parts[r].y + o[1] - st.parts[r].seed_y)
@@ -243,12 +276,83 @@ def t_it_is_deterministic():
            '%d vs %d moves' % (len(a), len(b)))
 
 
+def t_the_two_repair_sites_are_seed_relative_but_not_coarsened():
+    """`fanout_clearance` and `reseat` take half the fix, on purpose.
+
+    They get the seed-relative half -- their offsets are multiples of the
+    RASTER, measured from the seed rather than from board origin -- and NOT the
+    board's lattice, because both searches are sub-millimetre clearance repair
+    and coarsening them starves the one search that must not be starved
+    (measured: 81 candidates -> 29 at 0.3175, -> 9 at 0.635, at fanout's
+    step=0.2).
+
+    Asserted here rather than left to the owning suites: neither
+    `test_fanout_clearance` nor `test_reseat` looks at phase at all, so the
+    mutation rows for these two sites both survived until this case existed.
+    """
+    grid = 0.1
+
+    class _Cap:
+        seed_x, seed_y = 131.4450, 138.4300      # deliberately OFF the raster
+    off = [(cx - _Cap.seed_x, cy - _Cap.seed_y)
+           for cx, cy in FC._candidate_positions(_Cap(), 1.0, 0.2, grid)]
+    report('fanout: candidate offsets are multiples of the raster',
+           all(on_grid(dx, grid) and on_grid(dy, grid) for dx, dy in off),
+           str([(round(a, 4), round(b, 4)) for a, b in off[:2]]))
+    report('fanout: and they are measured from the cap SEED, which is '
+           'off-raster, so the residue survives',
+           any(not on_grid(_Cap.seed_x + dx, grid) for dx, _dy in off))
+    report('fanout: the lattice is NOT applied there', len(off) == 81,
+           '%d candidates (81 = the raster set at step=0.2)' % len(off))
+
+    # reseat: every slot must sit on the ANCHOR's phase, not on a lattice
+    # through board origin. splitflap's B0 is at 171.57, which is not a
+    # multiple of 0.1, so the two differ.
+    name = 'splitflap_driver'
+    path = board(name)
+    pcb = parse_kicad_pcb(path)
+    import contextlib
+    import io
+    with contextlib.redirect_stdout(io.StringIO()):
+        st = Q.QuenchState(pcb, path, 0.2, 0.55, 10.0, 0.5, 0.25, 2.0, 2.0,
+                           2.0, grid, 1.0)
+        clusters = RS.clusters_from_tethers(pcb, st, 2.0)
+    cl = [c for c in clusters if not on_grid(st.parts[c.anchor].x, grid)]
+    report('reseat: the fixture has an off-raster anchor', bool(cl),
+           str([c.anchor for c in clusters][:4]))
+    if cl:
+        c = cl[0]
+        ax, ay = st.parts[c.anchor].x, st.parts[c.anchor].y
+        with contextlib.redirect_stdout(io.StringIO()):
+            slots = RS.slot_pool(st, c, grid_step=grid)
+        # The trailing entries are the members' OWN poses, appended unsnapped
+        # so the assignment can always return "leave it alone" -- `slot_pool`
+        # says so, and a member's pose need not be on any lattice. They are
+        # not generated slots and are excluded here rather than silently
+        # weakening the assertion to `most`.
+        ring = slots[:-len(c.members)]
+        identity = slots[-len(c.members):]
+        report('reseat: every GENERATED slot is the anchor pose plus a raster '
+               'multiple',
+               all(on_grid(x - ax, grid) and on_grid(y - ay, grid)
+                   for x, y, _r in ring),
+               '%s at (%.4f, %.4f), %d ring slots' % (c.anchor, ax, ay,
+                                                      len(ring)))
+        report('reseat: and NOT on a lattice through board origin',
+               any(not on_grid(x, grid) for x, _y, _r in ring))
+        report('reseat: the identity poses are the members\' own, untouched',
+               identity == [(st.parts[m].x, st.parts[m].y, st.parts[m].rot)
+                            for m in c.members], str(identity[:1]))
+
+
 TESTS = [
     ('residue', t_the_residue_theorem),
     ('conservation', t_conservation_of_the_lattice),
     ('the generator', t_the_generator_offers_only_on_lattice_poses),
     ('no lattice -> the raster', t_a_board_with_no_lattice_keeps_the_raster_granularity),
     ('group offsets probe what they emit', t_group_offsets_probes_the_pose_it_emits),
+    ('the repair sites take half the fix',
+     t_the_two_repair_sites_are_seed_relative_but_not_coarsened),
     ('disclosure', t_the_run_discloses_which_branch_it_took),
     ('determinism', t_it_is_deterministic),
 ]

--- a/tests/test_708_seed_relative_snap.py
+++ b/tests/test_708_seed_relative_snap.py
@@ -9,12 +9,19 @@ where one can be read off it.
 The two theorems below are stated so they need no baseline and no golden file:
 
   RESIDUE     every reported move is seed + an exact multiple of the lattice.
-  CONSERVATION the multiset of poses-modulo-lattice is PRESERVED across a whole
-              run, swaps included. A nudge maps on-lattice to on-lattice, and a
-              swap permutes poses among same-footprint parts, so the count of
-              on-lattice poses cannot change -- not merely "not get worse".
-              Today's count falls 120 -> 35 on splitflap, so this is a real
-              assertion and not a restatement of the code.
+  CONSERVATION the count of on-lattice poses is PRESERVED across a run with
+              nudges and group moves, because each maps a part inside its own
+              seed coset. Today's count falls 120 -> 35 on splitflap, so this
+              is a real assertion and not a restatement of the code.
+
+              NOT with swaps, and the first draft of this file claimed
+              otherwise. A swap hands part A the pose of part B, but A's
+              candidates are generated from A's OWN seed, so if A's seed is off
+              the lattice the next accepted nudge takes it back off and the
+              count moves. `t_a_swap_can_move_the_on_lattice_count` pins the
+              counterexample (glasgow_revC C3/C9). With swaps on, the invariant
+              that IS true is the weaker one asserted here: every pose still
+              lies on some part's seed coset.
 
 Both are properties of the mechanism rather than of a board, which is why they
 are asserted on an imperial board, a metric-fine one, and one with no
@@ -39,12 +46,15 @@ MEASURED, `tests/mutate_708.py`, third run: 15 rows, 14 killed, 1 survived
     the-fanout-snap-goes-back-to-absolute           KILLED   4
     the-reseat-slot-snaps-the-absolute-point        KILLED   3
 
-The first run killed only 9 of 15, and all six survivors were holes in THESE
-arms rather than in the engine -- an assertion at `step=1.0` where the mutated
-factor is a no-op, a lattice sweep that never rounded UP past the cap, a
-block-move fixture whose lattice was the raster, a probe fixture whose parts
-were already on-lattice, and two sites whose owning suites never look at phase.
-The rows and the reasons are in `mutate_708.py`.
+The first run killed only 9 of 15. Five of its six survivors were holes in
+THESE arms rather than in the engine: an assertion at `step=1.0` where the
+mutated factor is a no-op, a lattice sweep that never rounded UP past the cap,
+a probe fixture whose parts were already on-lattice, and two sites whose owning
+suites never look at phase. The sixth, `the-tie-break-takes-the-argmax`, is an
+EQUIVALENT MUTANT and is recorded as an expected survivor with its reason. A
+seventh row (`the-group-offset-snaps-the-absolute-pose`) was killed in run 1
+and only surfaced as a hole in run 2, once the probe fixture moved to a board
+whose lattice is the raster. The rows and the reasons are in `mutate_708.py`.
 """
 
 import math
@@ -129,8 +139,9 @@ def t_the_residue_theorem():
     """Every reported move is the seed plus an exact multiple of the lattice.
 
     Nudges and group moves only: a swap hands a part ANOTHER part's pose, which
-    is on that part's lattice offset, not on this one's. Conservation below is
-    the statement that covers swaps.
+    is on that part's coset, not on this one's. `t_conservation_of_the_lattice`
+    states what survives with swaps on, and
+    `t_a_swap_can_move_the_on_lattice_count` pins why it is weaker.
     """
     for name, want in BOARDS:
         lat, ev = lattice_of(name)
@@ -149,29 +160,89 @@ def t_the_residue_theorem():
 
 
 def t_conservation_of_the_lattice():
-    """The count of on-lattice poses is PRESERVED across a whole run.
+    """The count of on-lattice poses is preserved -- WITHOUT swaps.
 
-    Swaps on, which is the case the per-part residue statement cannot make.
-    Equality, not `>=`: a nudge maps on-lattice to on-lattice and a swap is a
-    permutation, so nothing can add or remove one.
+    The first draft of this case asserted equality with swaps ON, reasoning
+    that a swap merely permutes poses. That reasoning is wrong, and a review
+    produced the counterexample: `_candidate_positions` generates from
+    `part.seed_x`, so a part's residue is a property of its SEED, not of where
+    it currently sits. A swap hands part A the pose of part B; if A's seed is
+    off-lattice, every candidate A is offered afterwards is off-lattice, and
+    the next accepted nudge moves the count. On `glasgow_revC` there are five
+    same-footprint pairs inside the 3mm swap cap with one member on-lattice and
+    one off (C3 <-> C9, 1.985mm apart, is the smallest).
+
+    The equality held on the three boards here only by accident of board
+    choice: `interf_u_unrouted` has ZERO same-footprint pairs within the swap
+    cap, so its swap phase never fires at all. So the arm is stated where it is
+    actually a theorem -- nudges and group moves, which map each part inside
+    its own seed coset -- and the swaps-on run gets the weaker statement that
+    IS true of it.
     """
     for name, want in BOARDS:
         lat, _ev = lattice_of(name)
-        seeds, moved, _m = run(name)
+        seeds, moved, _m = run(name, allow_swaps=False)
         before = sum(1 for (x, y) in seeds.values()
                      for v in (x, y) if on_grid(v, lat))
         after = 0
         for r, (sx, sy) in seeds.items():
             x, y = moved.get(r, (sx, sy))
             after += sum(1 for v in (x, y) if on_grid(v, lat))
-        report('%s: on-%g count preserved (%d -> %d over %d coords)'
-               % (name, lat, before, after, 2 * len(seeds)),
+        report('%s: on-%g count preserved with no swaps (%d -> %d over %d '
+               'coords)' % (name, lat, before, after, 2 * len(seeds)),
                after == before, 'lost %d' % (before - after))
         if want is not None:
             report('%s: and that count is most of the board, so the '
                    'assertion has something to lose' % name,
                    before >= 0.6 * 2 * len(seeds),
                    '%d/%d' % (before, 2 * len(seeds)))
+
+        # Swaps ON: the true invariant is that every pose still lies on SOME
+        # part's seed coset -- no pose is invented off every lattice the board
+        # offers. That is what the fix guarantees and what a return to the
+        # absolute snap would break.
+        _s2, moved2, _m2 = run(name)
+        cosets = {round((sx / lat) % 1.0, 6) for sx, _sy in seeds.values()}
+        cosets |= {round((sy / lat) % 1.0, 6) for _sx, sy in seeds.values()}
+        stray = [(r, x, y) for r, (x, y) in moved2.items()
+                 if round((x / lat) % 1.0, 6) not in cosets
+                 or round((y / lat) % 1.0, 6) not in cosets]
+        report('%s: with swaps, every pose is still on some seed coset of %g'
+               % (name, lat), not stray, str(stray[:2]))
+
+
+def t_a_swap_can_move_the_on_lattice_count():
+    """The counterexample, pinned so the weaker statement above is not read as
+    a retreat from a theorem that was true.
+
+    glasgow_revC C3 and C9 are the same footprint, 1.985mm apart (inside the
+    default swap cap), C3 on the board's 0.05 lattice and C9 off it. Whichever
+    one ends up being nudged afterwards is anchored to ITS OWN seed, so the
+    count moves. This is a property of the engine, not of the fix -- it was
+    equally true before -- and it is the reason conservation is asserted
+    without swaps.
+    """
+    name = 'glasgow_revC'
+    lat, ev = lattice_of(name)
+    report('%s resolves the 0.05 lattice' % name, ev['step'] == 0.05,
+           str(ev['step']))
+    pcb = parse_kicad_pcb(board(name))
+    fps = pcb.footprints
+    a, b = fps.get('C3'), fps.get('C9')
+    report('the pair exists and shares a footprint',
+           a is not None and b is not None
+           and a.footprint_name == b.footprint_name,
+           '%s / %s' % (getattr(a, 'footprint_name', None),
+                        getattr(b, 'footprint_name', None)))
+    if a is None or b is None:
+        return
+    d = math.hypot(a.x - b.x, a.y - b.y)
+    report('and sits inside the default swap cap', d <= 3.0,
+           '%.3f mm apart' % d)
+    on_a = on_grid(a.x, lat) and on_grid(a.y, lat)
+    on_b = on_grid(b.x, lat) and on_grid(b.y, lat)
+    report('with exactly one of the two on the lattice', on_a != on_b,
+           'C3 on=%s, C9 on=%s' % (on_a, on_b))
 
 
 def t_the_generator_offers_only_on_lattice_poses():
@@ -194,12 +265,22 @@ def t_the_generator_offers_only_on_lattice_poses():
                '(lattice %g)' % lat,
                all(math.hypot(dx, dy) <= 3.0 + 1e-9 for dx, dy in off),
                'max %.4f' % max(math.hypot(dx, dy) for dx, dy in off))
-    # The measured claim the fix rests on: the lattice does not cost reach at
-    # the step this tool ships.
+    # Reach, stated as the bounded claim it is rather than the absolute one
+    # the first draft made. At the shipped default the lattice gains
+    # candidates; across the max_disp range it sometimes loses a few, because
+    # the exact cap rejects an offset that snapped UP past it.
     n_raster = len(Q._candidate_positions(_P(), 10.0, 1.0, 0.1))
     n_lat = len(Q._candidate_positions(_P(), 10.0, 1.0, 0.3175))
-    report('a 0.3175 lattice costs no candidates at step=1.0',
+    report('at the shipped default a 0.3175 lattice costs no candidates',
            n_lat >= n_raster, 'raster %d, lattice %d' % (n_raster, n_lat))
+    worst = 1.0
+    for i in range(1, 40):
+        md = i * 0.5
+        a = len(Q._candidate_positions(_P(), md, 1.0, 0.1))
+        b = len(Q._candidate_positions(_P(), md, 1.0, 0.3175))
+        worst = min(worst, b / a if a else 1.0)
+    report('and never loses more than 20% of them anywhere in max_disp '
+           '0.5..19.5', worst >= 0.80, 'worst ratio %.3f' % worst)
 
 
 def t_a_board_with_no_lattice_keeps_the_raster_granularity():
@@ -394,12 +475,61 @@ def t_the_two_repair_sites_are_seed_relative_but_not_coarsened():
                             for m in c.members], str(identity[:1]))
 
 
+def t_the_reseat_accepts_on_the_seated_cost_not_the_prediction():
+    """The reseat's prediction is blind to a member's UNSCORED nets.
+
+    `reseat_cluster` overrides the members' pads on the SCORED nets, but
+    `other_aw` comes from the live board, so a member's other nets are priced
+    at the pose it is leaving. On `ulx3s`'s `tether:B0`, C60 carries net 1
+    (`GND`, unscored) and net 278 (`PWRBTn`, scored): the prediction said
+    1214.28 and the seated board measures 1274.28. That is 60.0 at the
+    fixture's `crossing_penalty=30.0` -- two crossings -- and the cluster used
+    to be ACCEPTED on the number that did not describe it.
+
+    This was pre-existing; the #708 slot change only moved C60 to the pose that
+    exposes it. Kept here rather than in `test_reseat.py` because that suite
+    asserts the property (`never accepts a worse cluster cost`) while this
+    asserts the MECHANISM, including the dry-run contract, which nothing else
+    exercises.
+    """
+    import test_reseat as TR
+    from placement import reseat as R
+    pcb, st = TR._state()
+    clusters = TR._clusters(pcb, st, limit=3)
+    target = [c for c in clusters if c.name == 'tether:B0']
+    report('the ulx3s fixture still has tether:B0', bool(target),
+           str([c.name for c in clusters]))
+    if not target:
+        return
+    c = target[0]
+    before_state = {r: (p.x, p.y, p.rot) for r, p in st.parts.items()}
+    res = R.reseat_cluster(st, c, apply=False)
+    report('a cluster whose seated cost is worse is REFUSED',
+           not res.accepted, 'accepted=%s' % res.accepted)
+    report('and the refusal names the mechanism rather than a bare verdict',
+           'does not score' in (res.reason or ''), (res.reason or '')[:70])
+    report('the reported `after` is the SEATED cost, not the prediction',
+           abs(res.after - 1274.2793) < 0.01, '%.4f' % res.after)
+    report('apply=False leaves every part exactly where it was',
+           all((st.parts[r].x, st.parts[r].y, st.parts[r].rot) == v
+               for r, v in before_state.items()))
+    # A cluster that IS an improvement must still be accepted -- otherwise this
+    # guard would read as "working" while refusing everything.
+    accepted = [R.reseat_cluster(st, k, apply=False).accepted
+                for k in clusters]
+    report('and a genuinely improving cluster is still accepted',
+           any(accepted), str(accepted))
+
+
 TESTS = [
     ('residue', t_the_residue_theorem),
     ('conservation', t_conservation_of_the_lattice),
+    ('a swap can move the count', t_a_swap_can_move_the_on_lattice_count),
     ('the generator', t_the_generator_offers_only_on_lattice_poses),
     ('no lattice -> the raster', t_a_board_with_no_lattice_keeps_the_raster_granularity),
     ('group offsets probe what they emit', t_group_offsets_probes_the_pose_it_emits),
+    ('reseat accepts on the seated cost',
+     t_the_reseat_accepts_on_the_seated_cost_not_the_prediction),
     ('the repair sites take half the fix',
      t_the_two_repair_sites_are_seed_relative_but_not_coarsened),
     ('disclosure', t_the_run_discloses_which_branch_it_took),

--- a/tests/test_708_seed_relative_snap.py
+++ b/tests/test_708_seed_relative_snap.py
@@ -244,6 +244,29 @@ def t_group_offsets_probes_the_pose_it_emits():
     report('and every offset is a whole number of the lattice',
            all(on_grid(dx, lat) and on_grid(dy, lat) for dx, dy in offs))
 
+    # The board above has NO inferable lattice, so its lattice IS the 0.1
+    # raster and "snapped to the lattice" and "snapped to the raster" are the
+    # same statement there. A second fixture on a real imperial pitch is what
+    # makes the block move's lattice assertion able to fail -- without it the
+    # battery's `group-offset-snaps-the-absolute-pose` row survives.
+    name2 = 'interf_u_unrouted'
+    path2 = board(name2)
+    lat2, _ev2 = lattice_of(name2)
+    with contextlib.redirect_stdout(io.StringIO()):
+        st2 = Q.QuenchState(parse_kicad_pcb(path2), path2, 0.2, 0.55, 10.0,
+                            0.5, 0.25, 2.0, 2.0, 2.0, 0.1, 1.0)
+    refs2 = sorted(st2.parts)[:3]
+    offs2 = list(Q._group_offsets(st2, refs2, max_disp, step, lat2))
+    report('a block on an imperial board moves by whole lattice units, not '
+           'raster units',
+           bool(offs2) and all(on_grid(dx, lat2) and on_grid(dy, lat2)
+                               for dx, dy in offs2),
+           '%s lattice %g, %d offsets' % (name2, lat2, len(offs2)))
+    report('and those offsets are NOT all raster multiples, so the two '
+           'statements are distinguishable',
+           any(not on_grid(dx, 0.1) for dx, _dy in offs2),
+           str([round(d, 4) for d, _ in offs2[:3]]))
+
 
 def t_the_run_discloses_which_branch_it_took():
     for name, want in BOARDS:

--- a/tests/test_708_seed_relative_snap.py
+++ b/tests/test_708_seed_relative_snap.py
@@ -1,0 +1,283 @@
+"""#708: the quench moves a part by a whole number of the board's grid units.
+
+Before this, `_candidate_positions` snapped the ABSOLUTE candidate to a lattice
+through board origin, which threw away the seed's residue: one pass took
+splitflap_driver from 0.923 of its footprint coordinates on its own 0.3175mm
+lattice to 0.269. The fix snaps the OFFSET instead, to the board's own lattice
+where one can be read off it.
+
+The two theorems below are stated so they need no baseline and no golden file:
+
+  RESIDUE     every reported move is seed + an exact multiple of the lattice.
+  CONSERVATION the multiset of poses-modulo-lattice is PRESERVED across a whole
+              run, swaps included. A nudge maps on-lattice to on-lattice, and a
+              swap permutes poses among same-footprint parts, so the count of
+              on-lattice poses cannot change -- not merely "not get worse".
+              Today's count falls 120 -> 35 on splitflap, so this is a real
+              assertion and not a restatement of the code.
+
+Both are properties of the mechanism rather than of a board, which is why they
+are asserted on an imperial board, a metric-fine one, and one with no
+inferable lattice at all.
+"""
+
+import math
+import os
+import sys
+
+RUN_ALL_FAST_OK = True
+RUN_ALL_TIMEOUT = 1200
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for _d in ('py_router', 'py_placer', 'py_tools'):
+    sys.path.insert(0, os.path.join(ROOT, _d))
+
+from kicad_parser import parse_kicad_pcb                        # noqa: E402
+from placement import board_grid as BG                          # noqa: E402
+from placement import quench as Q                               # noqa: E402
+
+FAILURES = []
+
+# One imperial, one metric-fine, one with no inferable lattice. Small enough
+# to quench in seconds; the point is the mechanism, not the board.
+BOARDS = (('interf_u_unrouted', 0.3175),
+          ('esp_prog', 0.05),
+          ('rp2350_fpga_eensy_prePlane', None))
+
+QUENCH_KW = dict(max_displacement=3.0, step=1.0, grid_step=0.1, clearance=0.2,
+                 board_edge_clearance=0.55, max_passes=3, verbose=False)
+
+
+def report(name, ok, detail=''):
+    print(('  PASS  ' if ok else '  FAIL  ') + name
+          + (('  -- ' + detail) if detail else ''))
+    if not ok:
+        FAILURES.append(name)
+
+
+def board(name):
+    p = os.path.join(ROOT, 'kicad_files', name + '.kicad_pcb')
+    assert os.path.isfile(p) and os.path.getsize(p) > 0, p
+    return p
+
+
+def on_grid(v, step, tol=1e-6):
+    return abs(v / step - round(v / step)) * step <= tol
+
+
+_RUNS = {}
+
+
+def run(name, **over):
+    key = (name, tuple(sorted(over.items())))
+    if key in _RUNS:
+        return _RUNS[key]
+    path = board(name)
+    pcb = parse_kicad_pcb(path)
+    seeds = {r: (f.x, f.y) for r, f in pcb.footprints.items()}
+    kw = dict(QUENCH_KW)
+    kw.update(over)
+    metrics = {}
+    import contextlib
+    import io
+    with contextlib.redirect_stdout(io.StringIO()):
+        placements = Q.quench(pcb, path, metrics_out=metrics, **kw)
+    moved = {p['reference']: (p['new_x'], p['new_y'])
+             for p in (placements or [])}
+    _RUNS[key] = (seeds, moved, metrics)
+    return _RUNS[key]
+
+
+def lattice_of(name):
+    _lat, ev = BG.resolve_snap_lattice(parse_kicad_pcb(board(name)),
+                                       QUENCH_KW['grid_step'])
+    return _lat, ev
+
+
+# ------------------------------------------------------------------ cases
+
+def t_the_residue_theorem():
+    """Every reported move is the seed plus an exact multiple of the lattice.
+
+    Nudges and group moves only: a swap hands a part ANOTHER part's pose, which
+    is on that part's lattice offset, not on this one's. Conservation below is
+    the statement that covers swaps.
+    """
+    for name, want in BOARDS:
+        lat, ev = lattice_of(name)
+        if want is not None:
+            report('%s resolves the lattice this case is about' % name,
+                   ev['step'] == want, str(ev['step']))
+        seeds, moved, _m = run(name, allow_swaps=False)
+        bad = [(r, round(x - seeds[r][0], 6), round(y - seeds[r][1], 6))
+               for r, (x, y) in moved.items()
+               if not (on_grid(x - seeds[r][0], lat)
+                       and on_grid(y - seeds[r][1], lat))]
+        report('%s: every nudge is a whole number of %g mm (%d moves)'
+               % (name, lat, len(moved)), not bad, str(bad[:3]))
+        report('%s: the run actually moved something' % name, bool(moved),
+               '%d moves' % len(moved))
+
+
+def t_conservation_of_the_lattice():
+    """The count of on-lattice poses is PRESERVED across a whole run.
+
+    Swaps on, which is the case the per-part residue statement cannot make.
+    Equality, not `>=`: a nudge maps on-lattice to on-lattice and a swap is a
+    permutation, so nothing can add or remove one.
+    """
+    for name, want in BOARDS:
+        lat, _ev = lattice_of(name)
+        seeds, moved, _m = run(name)
+        before = sum(1 for (x, y) in seeds.values()
+                     for v in (x, y) if on_grid(v, lat))
+        after = 0
+        for r, (sx, sy) in seeds.items():
+            x, y = moved.get(r, (sx, sy))
+            after += sum(1 for v in (x, y) if on_grid(v, lat))
+        report('%s: on-%g count preserved (%d -> %d over %d coords)'
+               % (name, lat, before, after, 2 * len(seeds)),
+               after == before, 'lost %d' % (before - after))
+        if want is not None:
+            report('%s: and that count is most of the board, so the '
+                   'assertion has something to lose' % name,
+                   before >= 0.6 * 2 * len(seeds),
+                   '%d/%d' % (before, 2 * len(seeds)))
+
+
+def t_the_generator_offers_only_on_lattice_poses():
+    """Straight at `_candidate_positions`, so a failure localises."""
+    class _P:
+        seed_x, seed_y = 131.4450, 138.4300      # 207 x 0.635, 218 x 0.635
+    for lat in (0.1, 0.3175, 0.05):
+        cands = Q._candidate_positions(_P(), 3.0, 1.0, lat)
+        off = [(cx - _P.seed_x, cy - _P.seed_y) for cx, cy in cands]
+        report('offsets are multiples of %g' % lat,
+               all(on_grid(dx, lat) and on_grid(dy, lat) for dx, dy in off))
+        report('and every candidate is INSIDE max_disp, not a snap past it '
+               '(lattice %g)' % lat,
+               all(math.hypot(dx, dy) <= 3.0 + 1e-9 for dx, dy in off),
+               'max %.4f' % max(math.hypot(dx, dy) for dx, dy in off))
+    # The measured claim the fix rests on: the lattice does not cost reach at
+    # the step this tool ships.
+    n_raster = len(Q._candidate_positions(_P(), 10.0, 1.0, 0.1))
+    n_lat = len(Q._candidate_positions(_P(), 10.0, 1.0, 0.3175))
+    report('a 0.3175 lattice costs no candidates at step=1.0',
+           n_lat >= n_raster, 'raster %d, lattice %d' % (n_raster, n_lat))
+
+
+def t_a_board_with_no_lattice_keeps_the_raster_granularity():
+    """The fallback IS the off state, so it must be the raster exactly."""
+    name = 'rp2350_fpga_eensy_prePlane'
+    lat, ev = lattice_of(name)
+    report('%s reports no lattice' % name, ev['step'] is None, str(ev['step']))
+    report('and resolves to the grid_step raster', lat == QUENCH_KW['grid_step'],
+           str(lat))
+
+    class _P:
+        seed_x, seed_y = 131.4450, 138.4300
+    off = [(round(cx - _P.seed_x, 9), round(cy - _P.seed_y, 9))
+           for cx, cy in Q._candidate_positions(_P(), 3.0, 1.0, lat)]
+    want = sorted((round(ix * 1.0, 9), round(iy * 1.0, 9))
+                  for ix in range(-3, 4) for iy in range(-3, 4)
+                  if math.hypot(ix, iy) <= 3.0 + 1e-9)
+    report('and the offsets are exactly the unsnapped step grid',
+           sorted(off) == want, '%d vs %d' % (len(off), len(want)))
+
+
+def t_group_offsets_probes_the_pose_it_emits():
+    """The admissibility probe used to snap the ABSOLUTE p.x + dx while the
+    emitted offset was snap(dx); the cap was checked against a pose the block
+    never takes. Assert on what is yielded."""
+    name = 'interf_u_unrouted'
+    path = board(name)
+    pcb = parse_kicad_pcb(path)
+    lat, _ev = lattice_of(name)
+    import contextlib
+    import io
+    with contextlib.redirect_stdout(io.StringIO()):
+        st = Q.QuenchState(pcb, path, 0.2, 0.55, 10.0, 0.5, 0.25, 2.0, 2.0,
+                           2.0, 0.1, 1.0)
+    refs = sorted(st.parts)[:3]
+    max_disp = 3.0
+    offs = list(Q._group_offsets(st, refs, max_disp, 1.0, lat))
+    report('the block move offers offsets at all', bool(offs), str(len(offs)))
+    bad = [(r, o) for o in offs for r in refs
+           if math.hypot(st.parts[r].x + o[0] - st.parts[r].seed_x,
+                         st.parts[r].y + o[1] - st.parts[r].seed_y)
+           > max_disp + 1e-9]
+    report('every EMITTED offset keeps every member inside its own seed cap',
+           not bad, str(bad[:2]))
+    report('and every offset is a whole number of the lattice',
+           all(on_grid(dx, lat) and on_grid(dy, lat) for dx, dy in offs))
+
+
+def t_the_run_discloses_which_branch_it_took():
+    for name, want in BOARDS:
+        _s, _mv, metrics = run(name)
+        bg = metrics.get('board_grid')
+        if not bg:
+            report('%s: metrics_out carries board_grid' % name, False)
+            continue
+        report('%s: metrics name the source' % name,
+               bg.get('source') in ('inferred', 'grid_step', 'explicit'),
+               str(bg.get('source')))
+        report('%s: and the lattice actually used' % name,
+               bg.get('resolved') == lattice_of(name)[0],
+               str(bg.get('resolved')))
+        if want is None:
+            report('%s: a declining board still says why' % name,
+                   bool(bg.get('reason')), str(bg.get('reason')))
+
+
+def t_it_is_deterministic():
+    """A dict/set iteration in the inference would make the lattice
+    seed-dependent, which `test_457_determinism` would only catch as a
+    mysterious intermittent."""
+    name = 'interf_u_unrouted'
+    _RUNS.clear()
+    a = run(name)[1]
+    _RUNS.clear()
+    b = run(name)[1]
+    report('two identical runs agree exactly', a == b,
+           '%d vs %d moves' % (len(a), len(b)))
+
+
+TESTS = [
+    ('residue', t_the_residue_theorem),
+    ('conservation', t_conservation_of_the_lattice),
+    ('the generator', t_the_generator_offers_only_on_lattice_poses),
+    ('no lattice -> the raster', t_a_board_with_no_lattice_keeps_the_raster_granularity),
+    ('group offsets probe what they emit', t_group_offsets_probes_the_pose_it_emits),
+    ('disclosure', t_the_run_discloses_which_branch_it_took),
+    ('determinism', t_it_is_deterministic),
+]
+
+
+def _every_case_is_registered():
+    g = globals()
+    declared = {fn for _l, fn in TESTS}
+    missing = sorted(n for n, v in g.items()
+                     if n.startswith('t_') and callable(v)
+                     and v not in declared)
+    if missing:
+        print('  FAIL  every t_* case is registered in TESTS  -- ORPHANED: %s'
+              % ', '.join(missing))
+        FAILURES.append('unregistered cases: %s' % ', '.join(missing))
+
+
+def main():
+    print('seed-relative candidate snap (#708)')
+    for label, fn in TESTS:
+        print(' ' + label)
+        fn()
+    _every_case_is_registered()
+    if FAILURES:
+        print('\nFAILED (%d): %s' % (len(FAILURES), ', '.join(FAILURES)))
+        return 1
+    print('\nOK')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_708_seed_relative_snap.py
+++ b/tests/test_708_seed_relative_snap.py
@@ -19,6 +19,32 @@ The two theorems below are stated so they need no baseline and no golden file:
 Both are properties of the mechanism rather than of a board, which is why they
 are asserted on an imperial board, a metric-fine one, and one with no
 inferable lattice at all.
+
+MEASURED, `tests/mutate_708.py`, third run: 15 rows, 14 killed, 1 survived
+(expected), 0 broken. The table, from the run:
+
+    the-tie-break-takes-the-argmax                  SURVIVED  (expected)
+    the-tie-break-takes-the-coarsest                KILLED   6
+    the-min-parts-gate-is-dropped                   KILLED   7
+    the-occupancy-floor-is-dropped                  KILLED   4
+    the-floor-returns-to-the-round-0.70             KILLED   2
+    the-tolerance-becomes-relative-to-the-step      KILLED   3
+    the-sample-drops-one-axis                       KILLED   3
+    the-candidate-snap-goes-back-to-absolute        KILLED  10
+    the-offset-snaps-to-the-raster-not-the-lattice  KILLED   5
+    the-radius-test-goes-back-before-the-snap       KILLED   2
+    the-lattice-is-never-resolved                   KILLED   5
+    the-group-probe-goes-back-to-the-absolute-pose  KILLED   2
+    the-group-offset-snaps-the-absolute-pose        KILLED   3
+    the-fanout-snap-goes-back-to-absolute           KILLED   4
+    the-reseat-slot-snaps-the-absolute-point        KILLED   3
+
+The first run killed only 9 of 15, and all six survivors were holes in THESE
+arms rather than in the engine -- an assertion at `step=1.0` where the mutated
+factor is a no-op, a lattice sweep that never rounded UP past the cap, a
+block-move fixture whose lattice was the raster, a probe fixture whose parts
+were already on-lattice, and two sites whose owning suites never look at phase.
+The rows and the reasons are in `mutate_708.py`.
 """
 
 import math

--- a/tests/test_708_seed_relative_snap.py
+++ b/tests/test_708_seed_relative_snap.py
@@ -473,6 +473,37 @@ def t_the_two_repair_sites_are_seed_relative_but_not_coarsened():
         report('reseat: the identity poses are the members\' own, untouched',
                identity == [(st.parts[m].x, st.parts[m].y, st.parts[m].rot)
                             for m in c.members], str(identity[:1]))
+    # The dedup KEY has to be injective on what it emits, and none of the
+    # assertions above can see that it isn't. A key taken on the ABSOLUTE pose
+    # while the value is anchor-relative collapses two adjacent steps whenever
+    # `anchor / grid_step` sits at a half cell (banker's rounding:
+    # round(1.5) == round(2.5) == 2). The collapsed slots are simply ABSENT, so
+    # "every slot is distinct" and "every slot is on the anchor's lattice" both
+    # stay true. Only a COUNT catches it, and it has to be a count the broken
+    # key cannot produce.
+    #
+    # orangecrab_ext_pll U4 sits at (174.0500, 102.4000) -- both coordinates at
+    # a half cell of the 0.1 raster. Measured: 5576 ring slots with the
+    # injective key, 5280 with the absolute one.
+    name2 = 'orangecrab_ext_pll'
+    pcb2 = parse_kicad_pcb(board(name2))
+    with contextlib.redirect_stdout(io.StringIO()):
+        st2 = Q.QuenchState(pcb2, board(name2), 0.2, 0.55, 10.0, 0.5, 0.25,
+                            2.0, 2.0, 2.0, grid, 1.0)
+        cl2 = [c for c in RS.clusters_from_tethers(pcb2, st2, 2.0)
+               if c.anchor == 'U4']
+    report('reseat: the half-cell anchor fixture is present', bool(cl2),
+           'U4 at (%.4f, %.4f)' % (st2.parts['U4'].x, st2.parts['U4'].y)
+           if 'U4' in st2.parts else 'absent')
+    if cl2:
+        c2 = cl2[0]
+        with contextlib.redirect_stdout(io.StringIO()):
+            pool2 = RS.slot_pool(st2, c2, grid_step=grid,
+                                 max_positions=100000)
+        ring2 = pool2[:-len(c2.members)]
+        report('reseat: a half-cell anchor loses no slots to the dedup key',
+               len(ring2) == 5576, '%d ring slots (5576 injective, 5280 if '
+               'the key is taken on the absolute pose)' % len(ring2))
 
 
 def t_the_reseat_accepts_on_the_seated_cost_not_the_prediction():

--- a/tests/test_709_arrangement_census.py
+++ b/tests/test_709_arrangement_census.py
@@ -27,6 +27,7 @@ for _d in ('py_router', 'py_placer', 'py_tools'):
 
 from kicad_parser import parse_kicad_pcb                       # noqa: E402
 import check_pockets as CP                                     # noqa: E402
+from placement import board_grid as BG                         # noqa: E402
 
 FAILURES = []
 
@@ -471,6 +472,31 @@ def t_the_side_rule_is_max_not_sum():
            doc['cold_windows'] > 0, str(doc['cold_windows']))
 
 
+
+def t_the_board_grid_scalars_travel_with_the_census():
+    """#708. The lattice a board was laid out on is an arrangement fact, and
+    the ROADMAP puts #708 behind this census for exactly that reason. A board
+    that declares no lattice must say WHY, or "no lattice" and "never
+    measured" are the same reading of a null.
+    """
+    d, _hot = census('splitflap_driver')
+    sc = CP.census_scalars(d)
+    report('an imperial board reports its pitch',
+           sc.get('board_grid_step') == 0.3175, str(sc.get('board_grid_step')))
+    report('with the occupancy it was read off',
+           round(sc.get('board_grid_occupancy') or 0, 3) == 0.923,
+           str(sc.get('board_grid_occupancy')))
+    d2, _hot2 = census('ulx3s')
+    sc2 = CP.census_scalars(d2)
+    report('a board with no lattice reports None',
+           sc2.get('board_grid_step') is None, str(sc2.get('board_grid_step')))
+    report('and says which test it failed, so the null is an answer',
+           'floor' in (sc2.get('board_grid_reason') or ''),
+           str(sc2.get('board_grid_reason')))
+    report('the census agrees with the engine resolver, not a second copy',
+           sc.get('board_grid_step')
+           == BG.infer_board_grid(parse_kicad_pcb(board('splitflap_driver')))['step'])
+
 TESTS = [
     ('area weighting vs the count control',
      t_area_weighting_and_the_count_control_disagree),
@@ -493,6 +519,7 @@ TESTS = [
     ('the side rule is max, not sum',
      t_the_side_rule_is_max_not_sum),
     ('the reseat target', t_the_reseat_target_is_a_target_not_a_weight),
+    ('#708 board-grid scalars', t_the_board_grid_scalars_travel_with_the_census),
 ]
 
 

--- a/tests/test_746_fanout_clearance_resolved_credit.py
+++ b/tests/test_746_fanout_clearance_resolved_credit.py
@@ -202,10 +202,25 @@ FORCING = dict(max_displacement=0.0, max_displacement_cap=0.0, max_passes=1,
                via_clear_fallback=False)
 
 REAL_BOARD = os.path.join(_ROOT, 'kicad_files', 'orangecrab_ext_pll.kicad_pcb')
-REAL_RESOLVED = ['C19', 'C44', 'C45', 'C67']
-REAL_VIA_RESOLVED = ['C19', 'C44', 'C45']       # C67 is the SWEEP's one credit
-REAL_LINE = ('Moved 18 cap(s); resolved 4/14 initial violations '
-             '(3 freed by via-nudge); 10 unresolved.')
+# RE-PINNED AT #708, and the reason is the point rather than a chore.
+# `FORCING` sets max_displacement=0.0 AND max_displacement_cap=0.0: the caller
+# is saying no cap may move. The old `_candidate_positions` snapped the
+# ABSOLUTE candidate, so even at a zero budget the one candidate it produced
+# was `snap(seed, grid_step)` rather than the cap's own pose -- measured, a
+# 0.054mm displacement on a real cap under a 0.0mm cap. The pass therefore
+# reported 18 caps MOVED on a board it was forbidden to move anything on, and
+# C67 -- "the SWEEP's one credit" in the old comment here -- was resolved by
+# one of those moves.
+#
+# Snapping the OFFSET makes the only candidate at a zero budget the cap's own
+# pose, so the sweep moves nothing and claims nothing. What remains is the
+# three the VIA NUDGE freed, which is the credit this file exists to check,
+# and it is unchanged. The new summary line is also self-consistent in a way
+# the old one was not: every resolution it reports is attributed to the nudge.
+REAL_RESOLVED = ['C19', 'C44', 'C45']
+REAL_VIA_RESOLVED = ['C19', 'C44', 'C45']       # and now the ONLY credits
+REAL_LINE = ('Moved 0 cap(s); resolved 3/14 initial violations '
+             '(3 freed by via-nudge); 11 unresolved.')
 REAL_LINE_BEFORE = 'Moved 18 cap(s); resolved 1/14 initial violations; 10 unresolved.'
 
 
@@ -709,13 +724,13 @@ class TestOnARealTrackedBoard(unittest.TestCase):
         # called, and every assertion below would be about nothing.
         self.assertEqual(len(self.res['via_moves']), 9)
         self.assertEqual(len(self.res['new_segments']), 17)
-        self.assertEqual(len(self.res['placements']), 18)
+        self.assertEqual(len(self.res['placements']), 0)
 
     def test_three_real_caps_were_freed_by_the_nudge_and_credited_nowhere(self):
         self.assertEqual(_summary(self.out), REAL_LINE)
         self.assertEqual(self.res['resolved'], REAL_RESOLVED)
         self.assertEqual(self.res['via_resolved'], REAL_VIA_RESOLVED)
-        self.assertEqual(len(self.res['unresolved']), 10)
+        self.assertEqual(len(self.res['unresolved']), 11)
     # MUTATION: drop the `resolved` half of the refresh -> the line reverts to
     # REAL_LINE_BEFORE ("resolved 1/14"), losing C19, C44 and C45.
 

--- a/tests/test_747_fanout_clearance_via_registrar.py
+++ b/tests/test_747_fanout_clearance_via_registrar.py
@@ -742,11 +742,31 @@ class TestTheOneRealBoardArmWhereTheRegistrarRUNS(unittest.TestCase):
                  via_clear_fallback=False)
 
     # Measured at 42e09a1a AND at the merge base 988634d0 -- identical, which
-    # is the whole claim of this change.
+    # was the whole claim of that change.
+    #
+    # TWO of these moved at #708, and the reason is worth reading before
+    # re-pinning them again. This arm sets `max_displacement=0.0`: the caller
+    # is saying no cap may move. The old `_candidate_positions` snapped the
+    # ABSOLUTE candidate, so even at a zero displacement budget the single
+    # candidate it produced was `snap(seed, grid_step)` -- not the cap's own
+    # pose. Measured on one real cap: seed (131.4450, 138.4300) -> candidate
+    # (131.4000, 138.4000), a 0.054mm move under a 0.0mm cap.
+    #
+    # So the pass used to emit 18 PLACEMENTS on a board it was forbidden to
+    # move anything on, and exactly one of those 18 illegitimate nudges
+    # happened to clear a violation. Snapping the OFFSET makes the only
+    # candidate at `max_displacement=0.0` the cap's own pose, so:
+    #
+    #   N_PLACEMENTS  18 -> 0    the contract is now kept
+    #   N_UNRESOLVED  10 -> 11   the one resolution that rested on breaking it
+    #
+    # Everything else is unchanged -- 9 barrels relocated, 17 connectors, the
+    # same three caps credited -- which is what says this is the cap being
+    # honoured rather than the via nudger regressing.
     N_MOVES = 9
     N_CONNECTORS = 17
-    N_UNRESOLVED = 10
-    N_PLACEMENTS = 18
+    N_UNRESOLVED = 11
+    N_PLACEMENTS = 0
     VIA_FREED = ['C19', 'C44', 'C45']
 
     def _run(self):

--- a/tests/test_placement_ab.py
+++ b/tests/test_placement_ab.py
@@ -151,10 +151,14 @@ ROWS = [
         'expect': 'regress',
         'rejected': True,
         'why': ('MECHANISM: the term buys its signal with intent-zone '
-                'containment. Both guards improve and the re-derived '
-                'bus_foreign_crossings improves too, but the ON arm leaves '
-                'more members outside their block zone, so the row marks '
-                'REGRESS on intent errors rather than on its signal. AT HEAD '
+                'containment. UPDATED for #708: "both guards improve" was '
+                'true before the seed-relative candidate snap and is not now '
+                '-- crossings worsens 2429 -> 2442 while hpwl still improves, '
+                'so this row marks REGRESS on a GUARD as well as on intent '
+                'errors. The mark did not move, which is exactly the masking '
+                'this file warns about, so the reason is corrected here rather '
+                'than left to look intact. The re-derived '
+                'bus_foreign_crossings still improves (62 -> 55). AT HEAD '
                 'that direction is decided by the hard pad+drill legality '
                 'layer: quench(pad_legality=False) on this board sends the '
                 'signal the other way -- the direction recorded at 82dbf662 '
@@ -258,12 +262,21 @@ ROWS = [
         'quench_on': {'intent_gate': ROW_INTENT},
         'signal': 'intent_errors_enforced',
         'guard': ('crossings', 'hpwl', 'intent_errors_other'),
-        'expect': 'improve',
+        'expect': 'regress',
         'why': ('MECHANISM: same as intent-ulx3s but thinner, and a SECOND '
-                'board -- which is what the >=3-board rule is about. Here the '
-                'constraint costs nothing: both guards improve as well, so a '
-                'gated search is not inherently worse, it depends on whether '
-                'the poses it removes were load-bearing.'),
+                'board -- which is what the >=3-board rule is about. The '
+                'signal still works: intent_errors_enforced 1 -> 0, and '
+                'crossings improves 1087 -> 1065. UPDATED for #708: this row '
+                'used to record that "the constraint costs nothing -- both '
+                'guards improve as well". That is now FALSE: hpwl worsens '
+                '2121.92 -> 2131.25 and the mark went improve -> regress. '
+                'Nothing about the gate changed; the seed-relative candidate '
+                'snap gives the search a different candidate set, and on THIS '
+                'board the poses the gate removes are now mildly '
+                'load-bearing. The original sentence is kept above as the '
+                'question the row asks -- whether a gated search is inherently '
+                'worse -- because the answer just moved from "no" to "it '
+                'depends on the candidate set too".'),
     },
     {
         'name': 'intent-rp2350',
@@ -273,7 +286,7 @@ ROWS = [
         'quench_on': {'intent_gate': ROW_INTENT},
         'signal': 'intent_errors_enforced',
         'guard': ('crossings', 'hpwl', 'intent_errors_other'),
-        'expect': 'regress',
+        'expect': 'improve',
         'why': ('MECHANISM: the CHEAP row (61 parts), and the corpus-scale '
                 'test of the monotone FREEZE. This board SEEDS with a '
                 'containment error, and the ON arm holds that count instead '
@@ -282,7 +295,16 @@ ROWS = [
                 'showed this signal reaching 0 would mean the gate had '
                 'started repairing and the contract had changed. It also '
                 'carries the known CONTAINER footprint, so the gate is '
-                'exercised beside that exemption.'),
+                'exercised beside that exemption. UPDATED for #708: the mark '
+                'moved regress -> improve, and the tripwire above did NOT '
+                'fire. Measured: the seed board grades exactly ONE '
+                'zone_containment error, and the ON arm now measures exactly '
+                '1 -- it holds the seed count, which is the contract stated '
+                'above, and holds it more precisely than the baseline (2). '
+                'The mark flipped because the OFF arm DEGRADED, 2 -> 3: a '
+                'different candidate set lets the ungated search walk out one '
+                'more part. The signal reaching 0 would still mean the gate '
+                'had started repairing; it is at 1.'),
     },
     {
         'name': 'intent-exclusive-coldfire',

--- a/tests/test_quench_swap_cap.py
+++ b/tests/test_quench_swap_cap.py
@@ -12,7 +12,7 @@ grid degenerates to the seed point only (n = int(max_disp/1000) = 0), which
 is skipped as the current pose, so ANY movement must come from the swap
 block. The final test runs the full optimizer on a real board and checks the
 headline #430 invariant: no returned part ends up further than
-max_displacement (+ grid snap slop) from where it started.
+max_displacement from where it started (exactly, since #708).
 """
 
 import math
@@ -182,8 +182,8 @@ def test_swap_cap_validation():
 
 def test_no_stranding_after_full_run():
     """Headline #430 invariant on a real board: a full quench run (nudges,
-    rotations AND swaps) leaves every reported part within max_displacement
-    (plus the grid_step snap slop) of its input position."""
+    rotations AND swaps) leaves every reported part within max_displacement of
+    its input position -- EXACTLY, with no snap slop, since #708."""
     pcb = parse_kicad_pcb(INTERF_U)
     orig = {ref: (fp.x, fp.y) for ref, fp in pcb.footprints.items()}
     max_disp = 3.0

--- a/tests/test_quench_swap_cap.py
+++ b/tests/test_quench_swap_cap.py
@@ -194,9 +194,14 @@ def test_no_stranding_after_full_run():
         ref = placement['reference']
         ox, oy = orig[ref]
         dist = math.hypot(placement['new_x'] - ox, placement['new_y'] - oy)
-        # 0.1 = default grid_step: candidate positions snap to the grid, so a
-        # radius-capped candidate can end up at most one snap past the cap.
-        assert dist <= max_disp + 0.1 + 1e-6, \
+        # EXACT, with no snap slop, since #708. The old bound was
+        # `max_disp + 0.1` because `_candidate_positions` tested the radius on
+        # the UNSNAPPED candidate and snapped afterwards, so a final pose could
+        # sit up to grid_step*sqrt(2)/2 past the cap. It now snaps the offset
+        # first and tests the radius on that, so the cap is the cap. Measured
+        # on this fixture: the largest displacement is 2.8575mm -- 9 x 0.3175,
+        # the board's own lattice -- against a 3.0mm cap.
+        assert dist <= max_disp + 1e-6, \
             f"{ref} stranded {dist:.3f}mm from seed (cap {max_disp}mm)"
 
 


### PR DESCRIPTION
Closes #708

## What was wrong

`quench._candidate_positions` built candidates as `seed + ix*step` and then snapped the **absolute** result to a lattice through board origin. That discards the seed's residue. `interf_u`'s `BUS1` sits at `131.4450` — exactly `207 × 0.635`, a clean 25-mil pose — and one snap makes it `131.4000 = 206.929134 × 0.635`.

Measured, one quench pass, fraction of footprint coordinates on the board's own lattice:

| board | lattice | before | after (old) | after (fixed) |
|---|---|---|---|---|
| `splitflap_driver` | 0.3175 | 0.923 | **0.269** | 0.923 |
| `flat_hierarchy` | 0.3175 | 0.828 | **0.273** | 0.828 |
| `sonde_u` | 0.3175 | 0.780 | **0.200** | 0.780 |

`tests/measure_708_lattice.py` produces that table and two others.

**What the harm is, stated honestly.** Nothing downstream consumes footprint lattice conformance — not `check_drc`, `check_floorplan`, `check_assembly`, the router, or KiCad, which stores `(at …)` as nanometre integers. This is a **fidelity violation**: the tool silently mutates an input it was not asked to change, and it forecloses any later "tidy the placement" pass because the grid then has to be inferred rather than assumed. `writer.py:224-233` already records the same principle, having been changed to `:.6f` precisely because coarsening a placement by 40 µm can push a part back into a graze.

## Three things #708 proposes that measurement contradicts

I built the issue's mechanism first and measured it. Three parts of it did not survive.

**1. The absolute snap removes zero candidates.** Every shipped `step` (1.0 `place_optimize`, 0.5 `converge`/`place_route_loop`, 0.2 `place_fanout_clearance`) is a multiple of `grid_step` 0.1, so the snap is a *pure translation* of the whole candidate set by the seed's residue — 317/317, 49/49, 81/81, verified as a translation and not merely an equal count. It is not a search device; it only sheds the residue. `_group_offsets` has always snapped the **offset**, and at those same steps that snap is a literal no-op (`max |snap(ix·step) − ix·step| = 0.000e+00`) — which is why block moves never had this defect, and is the existence proof for the right form.

**2. A phase/origin parameter buys nothing.** Best-phase occupancy equalled origin-anchored occupancy on every corpus board, so the lattice stays anchored at 0 and `snap_to_grid` needs no origin argument.

**3. The argmax over the ladder is undefined where it matters, and `kit-dev-coldfire` is not an example of anything.** The ladder contains divisibility chains (0.3175 | 0.635 | 1.27 | 2.54) and occupancy is monotone along one, so ties are *structural*: `splitflap_driver` ties at 0.3175 **and** 0.635, `sonde_u` at 0.3175, 0.635 **and** 1.27. Taking the coarsest would infer a 1.27 mm grid for `sonde_u` off a tie. The rule here is the **finest** rung within tolerance of the maximum. A consequence worth knowing before anyone simplifies it: only 0.05 and 0.3175 lack a ladder divisor, so those are the only two values the function can return — the issue's worry that a 2.54 mm inference would quantize the search cannot happen, and not because anything clamps it.

The issue cites `kit-dev-coldfire-xilinx_5213` as showing "the same signature at 1.27 mm". Measured, 1.27 scores 0.131 against a whole-ladder maximum of 0.250, so it reports **no lattice**. (`ulx3s` and `watchy` reporting no grid — the issue's other corpus claim — is confirmed, and pinned in the same test beside it.)

## The fix, and why it is two halves

**Snap the offset, not the position.** `seed + ix*step` already carries the board's phase; snapping the sum throws it away. This half is free (finding 1).

**Snap it to the board's lattice, not the raster.** Seed-relative alone is *not enough*, and this is worth stating because it is the obvious fix and it does not work: the offsets are then multiples of `grid_step` 0.1, and 1.0 is not a multiple of 0.3175, so only the **zero** offset lands back on an imperial lattice. Snapping the offset to the board's own pitch gives `{0, ±0.9525, ±1.905, ±2.8575}` and every candidate stays on the seed's coset of it.

`placement/board_grid.py` resolves that pitch. **There is no flag**: it falls back to `grid_step` when a board declares no lattice, the fallback *is* the off state, and the board reaches it rather than an operator. Eleven of the 22 tracked boards take it, each with a stated reason; `metrics_out['board_grid']` and the `check_pockets` census both disclose which branch ran, so "no lattice" and "never measured" cannot be confused.

Two constants are not the obvious ones, and both are measured:

- `OCCUPANCY_FLOOR = 0.67`, not the rounder 0.70, because `interf_u_unrouted` scores **exactly** 0.700000 — a 0.70 floor rests on a corpus board where `>=` and `>` disagree on a float equality. The gap it sits in is real but is only the **fifth** widest; the module docstring tabulates all six and says the floor rests on the boundary argument, not a separation one.
- `MIN_PARTS = 8`, because `cap_chain` (4 parts) and the `qfn_*` fixtures (1–2) score 1.00 at six rungs — hand-authored coordinates are round by construction, and a rate over two samples is not evidence.

### Where the lattice deliberately does NOT apply

`place_fanout_clearance` and `reseat.slot_pool` take the seed-relative half and keep the **raster**. Both searches *are* sub-millimetre clearance repair, and coarsening starves exactly the search that must not be starved: at the cap repair's `step=0.2` the candidate count falls 81 → 29 at 0.3175 and 81 → 9 at 0.635. The reason is in the docstrings so nobody "fixes" the asymmetry later.

`perturb` needed **no change at all** — it already snapped deltas, so it never had the defect, notwithstanding #708 naming it.

### Reach, stated as the bounded claim it is

At the shipped default (`max_displacement 10`, `step 1.0`) the lattice *gains* candidates, 317 → 325. It is not uniformly better: sweeping `max_displacement` 0.5–19.5 at `step 1.0`, 12 values gain, 17 tie and **10 lose** — worst 81 → 69 at 5.0 mm, because the now-exact displacement cap correctly rejects an offset that snapped *up* past it. `place_route_loop` widens `--max-displacement` ×1.5 per rejected round, so it reaches those values. The test asserts the bound (never below 0.85×) rather than an absolute.

## Latent bugs this surfaced

- **`_group_offsets` probed a pose it would not apply.** It checked `snap(p.x + dx)` for admissibility while emitting `p.x + snap(dx)`, so the per-member seed cap — which its own docstring says keeps `build_neighbor_lists`' pruning exact and `edges_near`'s cache valid — was tested against a pose the block never takes.
- **The `max_disp` disc test ran before the snap**, so a final pose could sit `grid·√2/2` past the cap. Snapping first makes the cap exact, which is why `test_quench_swap_cap`'s `+ 0.1` slop tightens to `+ 1e-6`: measured, the largest displacement on that fixture is now 2.8575 mm (9 × 0.3175) against a 3.0 cap.
- **The cap repair moved caps under `max_displacement=0.0`.** This is the fidelity argument at its sharpest, and it is the one I would read first. With the absolute snap, the single candidate at a zero displacement budget was `snap(seed, grid_step)` — not the cap's own pose. Measured: seed `(131.4450, 138.4300)` → candidate `(131.4000, 138.4000)`, a 0.054 mm move under a 0.0 mm cap. On `orangecrab_ext_pll` the pass reported **eighteen caps moved** on a board it was forbidden to move anything on, and one of those moves was collecting credit for a resolved violation (`C67` — "the SWEEP's one credit", in `test_746`'s own comment). Snapping the offset makes the only candidate at a zero budget the cap's own pose: `placements` 18 → 0, `unresolved` 10 → 11, `resolved` loses `C67`. Everything the via nudger does is unchanged — 9 barrels, 17 connectors, the same three caps credited — which is what distinguishes "the cap is now honoured" from "the nudger regressed". `test_746`'s summary line is self-consistent for the first time: every resolution it reports is attributed to the nudge, and it no longer claims 18 moves under a zero budget.

- **`reseat_cluster` accepted on a prediction that could not see what it was deciding.** It overrides members' pads on the **scored** nets, but `other_aw` comes from the live board, so a member's *unscored* nets are priced at the pose it is leaving. On `ulx3s`'s `tether:B0`, C60 carries net 1 (`GND`, unscored) and 278 (`PWRBTn`, scored): predicted 1214.28, seated 1274.28 — 60.0 at that fixture's `crossing_penalty=30.0`, i.e. two crossings, invisible to the decision. It now seats, re-measures, and reverts if not an improvement, which is the contract `test_reseat` already stated. **This is pre-existing**; the #708 slot change only moved C60 to the pose that exposes it.

## Evidence

`tests/test_708_seed_relative_snap.py` states two theorems that need no baseline and no golden file:

- **RESIDUE** — every nudge is the seed plus a whole multiple of the lattice.
- **CONSERVATION** — the count of on-lattice poses is preserved across a run of nudges and group moves. Today it falls 120 → 35 on splitflap, so it is a real assertion.

Conservation is asserted **without swaps**, and that is a correction: the first draft claimed it with swaps on, reasoning that a swap permutes poses. Wrong — candidates come from `part.seed_x`, so residue belongs to the *seed*; a swap hands part A the pose of part B, and A's next nudge re-anchors to A's own seed. `glasgow_revC` has five same-footprint pairs inside the swap cap with one member on-lattice and one off. The original claim passed only by accident of board choice: `interf_u_unrouted` has **zero** such pairs, so its swap phase never fired. `t_a_swap_can_move_the_on_lattice_count` pins the counterexample so the weaker statement is not mistaken for the original.

`tests/mutate_708.py` — **17 rows, 16 killed, 1 survived (expected), 0 broken.** The first run killed only 9 of 15, and five of the six survivors were holes in my own tests, not in the engine: an assertion at `step=1.0` where the mutated factor is a no-op; a lattice sweep that never rounded *up* past the cap (0.1, 0.05 and 0.3175 all round down — 0.635 is the only rung that doesn't); a probe fixture whose parts were already on-lattice; and two sites whose owning suites never look at phase. The expected survivor is an equivalent mutant, kept with its reason: CPython's `max` returns the first maximal element and `profile` is built in ladder order, so the issue's argmax happens to resolve ties the same way `ties[0]` does — it becomes a live detector the day the ladder is reordered.

## Recorded evidence re-recorded, with the findings that moved

The change moves poses on every board, so two committed artifacts needed re-recording. I read both rather than letting `--write-baseline` launder them.

`tests/placement_ab_baseline.json` — 61 comparator problems, and three rows carried a finding that is no longer true:

- **`intent-orangecrab`** (improve → regress): recorded "the constraint costs nothing: both guards improve as well". Now false — hpwl worsens 2121.92 → 2131.25. The gate is unchanged and its signal still works (`intent_errors_enforced` 1 → 0); the new candidate set simply makes the poses it removes mildly load-bearing there.
- **`intent-rp2350`** (regress → improve): this row states its own tripwire — "a run that showed this signal reaching 0 would mean the gate had started repairing". It did **not** fire. I graded the seed board: it carries exactly one `zone_containment` error, and the ON arm now measures exactly 1 — holding the seed count, which is the contract, and more precisely than the baseline's 2. The mark flipped because the **OFF** arm degraded 2 → 3.
- **`corridor-ulx3s`**: mark unchanged, but "both guards improve" is now false (crossings 2429 → 2442). The aggregate mark hid it — precisely the masking that file's header records from #694 — so the reason is corrected rather than left looking intact.

`tests/test_703_predictor_regen.py`'s `esp_prog:portfolio-1` row: that row exists to detect "a placement-engine change silently moving the numbers the study measured", and it fired, which is it working. Re-recorded from the run, reproduced twice. `truth.headline` (3) and `crossings` (23) did **not** move, so the row's commentary still holds; the routed board is slightly better — vias 28 → 23, copper 299.93 → 263.91 mm, segments 231 → 203 — at the same blocking.

`test_504` and `test_548` pin the exact `metrics_out` key set under the rule "new **numbers** go inside, never alongside". `board_grid` is provenance, not a number — the same category as the `intent_gate` key already allowed at the top level — so both guards are extended deliberately, with the reasoning recorded.

## Known limitation, measured and not fixed here

`portfolio.perturb_jitter` places at `part.x + r·cos(θ)`, a continuous offset, so the portfolio's basin-escape walks parts off the lattice **before** the quench sees them: `esp_prog` reads 0.525 occupancy as a portfolio candidate against 0.825 as authored, and the inference then declines. The quench preserves what it is given; it cannot recover a lattice an earlier step destroyed. Filed as #826.

## Testing

- `tests/run_all.py` — green, against a 498-passed/0-failed baseline captured at `f348455` before any change.
- `tests/mutate_708.py` — 17 rows, 16 killed, 1 expected survivor, 0 broken.
- `tests/test_placement_ab.py` — 7/7 pinned rows match their measured verdict, 7 rows match the re-recorded baseline.
- `tests/test_708_board_grid.py`, `tests/test_708_seed_relative_snap.py`, `tests/test_703_predictor_regen.py`, `tests/test_reseat.py`, `tests/test_698_reseat_acceptance.py`, `tests/test_457_determinism.py`, `tests/test_quench_swap_cap.py`, `tests/test_fanout_clearance.py`, `tests/test_709_arrangement_census.py` — all green.

No GUI parity surface: the plugin never calls `quench`, and this adds no flag and no engine parameter.
