### PR TITLE
#830: an unreadable route summary is a non-verdict, not a crash

### DIFF
--- a/py_placer/converge.py
+++ b/py_placer/converge.py
@@ -76,17 +76,73 @@ def scoped_route(board, nets, out=None, extra_args=(), timeout=None):
     r = subprocess.run(argv, capture_output=True, text=True, encoding='utf-8',
                        errors='replace', timeout=timeout, cwd=ROOT)
     summary = {}
+    # A summary we cannot READ is a non-verdict, not an exception. This file
+    # can exist and not parse -- a killed router, ENOSPC, a flush that fails at
+    # close, a stale file at a reused path -- and route.py exits 0 on that path
+    # having printed only a WARNING. Raising here does not spoil one candidate;
+    # it empties the CALLER's loop, and none of the four call sites catch it
+    # (cmd_poses has no try at all; place_portfolio._probe and compare_seeds
+    # catch only subprocess.TimeoutExpired). compare_seeds collects its rows
+    # and writes seeds.json only AFTER the loop, so a throw on seed 3 of 8
+    # ships no document at all, at an exit code not in its own vocabulary.
+    #
+    # `summary` stays {} -- the no-verdict channel every caller already handles
+    # -- and `summary_error` says WHICH absence this was, because the return
+    # code is 0 either way and the router's own WARNING has usually fallen out
+    # of the 1500-character stdout_tail by the time we return:
+    #     summary truthy           -> a verdict
+    #     {} + summary_error None  -> the router wrote nothing
+    #     {} + summary_error set   -> the router wrote something unreadable
+    # Same shape, and the same reasoning, as _load_defects below.
+    #
+    # (OSError, ValueError) rather than the narrower JSONDecodeError: json.load
+    # decodes the text handle first, so a tail cut mid-UTF-8-sequence raises
+    # UnicodeDecodeError -- a ValueError that is NOT a JSONDecodeError.
+    summary_error = None
     if os.path.isfile(js):
-        with open(js, encoding='utf-8') as f:
-            summary = json.load(f)
+        try:
+            with open(js, encoding='utf-8') as f:
+                summary = json.load(f)
+        except (OSError, ValueError) as exc:                    # noqa: BLE001
+            summary_error = f'{type(exc).__name__}: {exc}'
+            # stderr, never stdout: `converge poses` pipes a JSON document.
+            print(f"  WARNING: unreadable route summary {js} "
+                  f"({summary_error}); rc={r.returncode} -- treating as "
+                  f"no summary", file=sys.stderr)
     return {'argv': argv, 'returncode': r.returncode, 'board': out,
-            'json': js, 'summary': summary, 'stdout_tail': r.stdout[-1500:]}
+            'json': js, 'summary': summary, 'summary_error': summary_error,
+            'stdout_tail': r.stdout[-1500:]}
 
 
 def route_verdict(summary):
     """(failures, note) from a route summary -- the tier-3 comparison key."""
     if not summary:
         return None, 'no summary'
+    # Every read below is a `.get(..., default)`, so a dict that is truthy but
+    # carries NONE of the verdict's own keys scores 0 failures and 'clean' --
+    # the best possible result, for a document that never mentioned routing.
+    # `{}` was caught above; `{'x': 1}` was not.
+    #
+    # PRESENCE, not truthiness: a genuinely clean route sets `failed_single:
+    # []`, and ANY ONE key is enough to judge -- a summary carrying
+    # failed_single but not open_single must still degrade to the old
+    # arithmetic (tests/test_open_single_verdict.py). `protected_skipped` is
+    # deliberately absent from the tuple: it only decorates the note, so a
+    # document carrying it alone would still fabricate a 0.
+    #
+    # HARDENING, not a live bug: route.py's summary literal sets failed_single,
+    # open_single AND multipoint_pads_total unconditionally (route.py:3606,
+    # 3611, 3624), and there is one append site into _SUMMARY_SINK, so nothing
+    # it writes today lands here. This is the schema-drift tripwire.
+    #
+    # The tuple is INLINE rather than a module constant on purpose: the gap
+    # between scoped_route and route_verdict is where #713's probe helpers land,
+    # and a constant parked there would collide with them for no benefit.
+    if not any(k in summary for k in ('failed_single', 'open_single',
+                                      'failed_multipoint',
+                                      'multipoint_pads_total',
+                                      'multipoint_pads_connected')):
+        return None, 'unreadable summary'
     failed = list(summary.get('failed_single') or [])
     # Routed-but-OPEN nets (kept result, disconnected pads). Before this key a
     # non-multipoint open net weighed ZERO here -- probes read failures=0 on
@@ -409,9 +465,20 @@ def cmd_poses(a):
                                                      'new_rotation': p['rot']}])
                 res = scoped_route(cand, a.affected, extra_args=a.route_args or [])
                 n, note = route_verdict(res['summary'])
+                # `nets`/`returncode`/`summary_error` so a row that carries no
+                # verdict still says what happened. `failures: None` alone
+                # cannot distinguish "the router died", "it wrote nothing" and
+                # "it wrote something unreadable". A `status` vocabulary
+                # belongs with #713's probe helpers, which own it; this row
+                # deliberately does not invent a second one.
+                # .get(), not a subscript: scoped_route is monkeypatched with a
+                # hand-built dict in the #713 probe tests.
                 p['route'] = {'failures': n, 'note': note,
                               'iterations': res['summary'].get('total_iterations'),
-                              'vias': res['summary'].get('total_vias')}
+                              'vias': res['summary'].get('total_vias'),
+                              'nets': len(a.affected),
+                              'returncode': res['returncode'],
+                              'summary_error': res.get('summary_error')}
     # A cut sweep returns a DIFFERENT best pose with a byte-identical document
     # shape -- measured, r=3/s=0.25: a full sweep chose rot 0 where a truncated
     # one chose rot 90, with no key marking it partial. A ranking nobody can

--- a/py_placer/converge.py
+++ b/py_placer/converge.py
@@ -624,8 +624,20 @@ def cmd_record(a):
     if a.score:
         try:
             _score_doc = json.loads(a.score)
-        except Exception:                                       # noqa: BLE001
-            _score_doc = None
+        except (OSError, ValueError) as exc:                    # noqa: BLE001
+            # REFUSE, rather than carrying None forward. This used to swallow
+            # the failure here and at the board_sha check below, then hit a
+            # THIRD, unguarded `json.loads(a.score)` while building the ledger
+            # entry -- so a truncated --score-file crashed with a traceback at
+            # exit 1, AFTER store.put() had already written the board into the
+            # content store. Same defect as the route-summary read this change
+            # is about, in the same file: a document that exists and does not
+            # parse. `--score-file` reads it off disk, so the "valid prefix of
+            # a killed writer" case applies here too.
+            print(f"record: --score is not readable JSON "
+                  f"({type(exc).__name__}: {exc}). Nothing was written.",
+                  file=sys.stderr)
+            return 2
     if a.lens and isinstance(_score_doc, dict) and \
             _grades_another_board(a.board, _score_doc):
         # NEVER SILENT. The skip is correct -- a verdict about this board must
@@ -866,7 +878,10 @@ def cmd_record(a):
              'parent_sha': (prev or {}).get('result_sha'),
              'result_sha': sha, 'lever': a.lever,
              'lever_argv': list(a.argv) if a.argv else None,
-             'score': json.loads(a.score) if a.score else None,
+             # _score_doc, not a THIRD json.loads: the payload was parsed and
+             # validated once at the top of this function, which is the only
+             # place that can still refuse before anything is written.
+             'score': _score_doc,
              'renders': list(a.render_json) if a.render_json else None,
              # The MEASUREMENT the next lap is aimed at, not a paragraph
              # about it. Run 20 recorded "throat 0.409mm vs 0.450 needed,

--- a/py_placer/converge.py
+++ b/py_placer/converge.py
@@ -118,6 +118,16 @@ def route_verdict(summary):
     """(failures, note) from a route summary -- the tier-3 comparison key."""
     if not summary:
         return None, 'no summary'
+    # A summary that is not a MAPPING at all. `json.load` is happy to return a
+    # str, a list or a number, and the whole premise here is documents route.py
+    # did not write -- a stale file at a reused path, another tool's output.
+    # Without this the guard below is worse than useless on a str: `k in
+    # summary` becomes a SUBSTRING test, so a document merely mentioning
+    # "failed_single" passes it and then dies on `.get` two lines down. On an
+    # int it raises TypeError outright. Either way the crash lands back in the
+    # caller's loop -- the exact failure scoped_route's guard just closed.
+    if not isinstance(summary, dict):
+        return None, 'unreadable summary'
     # Every read below is a `.get(..., default)`, so a dict that is truthy but
     # carries NONE of the verdict's own keys scores 0 failures and 'clean' --
     # the best possible result, for a document that never mentioned routing.
@@ -471,13 +481,15 @@ def cmd_poses(a):
                 # "it wrote something unreadable". A `status` vocabulary
                 # belongs with #713's probe helpers, which own it; this row
                 # deliberately does not invent a second one.
-                # .get(), not a subscript: scoped_route is monkeypatched with a
-                # hand-built dict in the #713 probe tests.
+                # .get() for BOTH of the new reads, not a subscript: #713's
+                # probe tests replace scoped_route with a lambda returning a
+                # hand-built dict, and a row that is defensive about one key
+                # while subscripting the next is not defensive at all.
                 p['route'] = {'failures': n, 'note': note,
                               'iterations': res['summary'].get('total_iterations'),
                               'vias': res['summary'].get('total_vias'),
                               'nets': len(a.affected),
-                              'returncode': res['returncode'],
+                              'returncode': res.get('returncode'),
                               'summary_error': res.get('summary_error')}
     # A cut sweep returns a DIFFERENT best pose with a byte-identical document
     # shape -- measured, r=3/s=0.25: a full sweep chose rot 0 where a truncated

--- a/py_router/route.py
+++ b/py_router/route.py
@@ -5486,10 +5486,11 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
             write_summary_file(json_out, _merged)
             print(f"  route summary written to {json_out}")
         except Exception as _e:
+            # write_summary_file's message already says what state the
+            # destination is in -- removed, or a stale file it could not
+            # remove. Do not add a reassurance here that the code cannot keep.
             print(f"  WARNING: could not write --json-out {json_out}: "
                   f"{type(_e).__name__}: {_e}")
-            print(f"           {json_out} was left UNTOUCHED -- a reader gets "
-                  f"the previous file or no file, never half of one.")
 
     from net_story import net_story_enabled, dump_net_story
     if net_story_enabled():

--- a/py_router/route.py
+++ b/py_router/route.py
@@ -5471,13 +5471,25 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
     # rescues, Phase-3 tap order, costs -- assembled from state.
     if json_out:
         try:
-            from route_summary import merge_summaries
+            from route_summary import merge_summaries, write_summary_file
             _merged = merge_summaries(list(_SUMMARY_SINK), _RECONCILE_RAISED[0])
-            with open(json_out, 'w', encoding='utf-8') as _jf:
-                json.dump(_merged if _merged is not None else {}, _jf, indent=1)
+            # ALL-OR-NOTHING (#830). This was `open(json_out,'w')` +
+            # `json.dump`, which truncates the destination before the first
+            # chunk is encoded and then STREAMS into it -- so a failure partway
+            # (ENOSPC, a flush that fails at close, an external kill, or a key
+            # stamped onto the summary after the JSON_SUMMARY gate above)
+            # published a HALF document. The except below then printed a
+            # warning and route.py exited 0, exactly as a run with failed nets
+            # does, while every reader of this file -- including an external
+            # `place_route_loop --accept-cmd` judge -- crashed on it. Failing
+            # CLOSED, with no file, is the case they all already handle.
+            write_summary_file(json_out, _merged)
             print(f"  route summary written to {json_out}")
         except Exception as _e:
-            print(f"  WARNING: could not write --json-out {json_out}: {_e}")
+            print(f"  WARNING: could not write --json-out {json_out}: "
+                  f"{type(_e).__name__}: {_e}")
+            print(f"           {json_out} was left UNTOUCHED -- a reader gets "
+                  f"the previous file or no file, never half of one.")
 
     from net_story import net_story_enabled, dump_net_story
     if net_story_enabled():

--- a/py_router/route_summary.py
+++ b/py_router/route_summary.py
@@ -18,11 +18,13 @@ reconciliation raised, so it needs neither a regex nor a marker string).
 Both were the same 110 lines in two places until they were not.
 """
 import json
+import os
 import re
 from typing import Dict, List, Optional
 
 __all__ = ['merge_summaries', 'merge_route_summaries', 'summary_min',
-           'SUMMARY_RE', 'SUMMARY_MIN_RE', 'RECONCILE_ABORTED', 'EFFORT_KEYS']
+           'write_summary_file', 'SUMMARY_RE', 'SUMMARY_MIN_RE',
+           'RECONCILE_ABORTED', 'EFFORT_KEYS']
 
 SUMMARY_RE = re.compile(r'JSON_SUMMARY: (\{.*\})')
 
@@ -305,3 +307,69 @@ def summary_min(merged: Dict, name_cap: int = 20) -> Dict:
         out['finalize_excluded_nets'] = _names(
             merged['finalize_excluded_nets'])
     return out
+
+
+def write_summary_file(path: str, merged: Optional[Dict]) -> None:
+    """Publish `merged` at `path` ALL-OR-NOTHING. Raises if it cannot.
+
+    `route.py --json-out` is a published contract with readers this repo does
+    not own -- `place_route_loop --accept-cmd` hands the path straight to an
+    arbitrary external judge -- and every reader opens it the same way:
+    ``if os.path.isfile(js): json.load(...)``. So a file that EXISTS and does
+    not parse is the worst artifact this can produce: the existence check
+    passes and the parse raises, out of loops that catch only
+    subprocess.TimeoutExpired.
+
+    The call this replaced could not avoid producing exactly that. It was
+    ``open(path, 'w')`` followed by ``json.dump(...)``: the open TRUNCATES the
+    destination before the first chunk is encoded, and json.dump then streams
+    -- it calls ``iterencode(o)`` with ``_one_shot=False``, so the C encoder is
+    never used, with or without `indent`, and the pure-Python generator writes
+    chunk by chunk straight into the handle. Any failure partway therefore
+    published a valid PREFIX of the document. route.py's `except Exception`
+    around the call cannot undo that: the truncation already happened, and it
+    only prints a WARNING, after which route.py exits 0 like any other run.
+
+    So: serialise FIRST (a payload that will not encode opens nothing at all),
+    write to a sibling temp file, and publish with os.replace, which is atomic
+    on POSIX and Windows alike. A reader sees the whole previous file or the
+    whole new one, never half of either. Same idiom as board_store.put and the
+    .kicad_pro writeback, and the one tests/stress/predictor_study.py adopted
+    after a study run died on a JSONDecodeError that "read like a study failure
+    and was a file-system race" -- this bug, in another file.
+
+    Deliberately NO ``default=str``: route.py prints the same dict through a
+    bare ``json.dumps`` outside any try, before this is ever reached, so an
+    unserialisable summary is already a loud failure of the whole run.
+    Coercing here would let the FILE carry a ``<obj at 0x...>`` repr that the
+    stdout line refused -- non-deterministic, and silently divergent from
+    ``merge_route_summaries(log)``, which a test compares against this file.
+
+    Deliberately NO fallback document either. `converge.route_verdict` scores a
+    truthy dict carrying none of the failure keys as `(0, 'clean')`, so an
+    ``{'complete': false}`` placeholder would rank a broken candidate FIRST.
+    Failing closed -- no file -- lands every caller in the `summary = {}` /
+    "no summary" case they all already handle, where a candidate without a
+    verdict ranks last and never best.
+    """
+    # indent=1, no sort_keys, default ensure_ascii: byte-identical to what the
+    # streaming writer produced, so the on-disk format does not change.
+    text = json.dumps({} if merged is None else merged, indent=1)
+    # pid-suffixed: several routes can share one output directory.
+    tmp = f'{path}.{os.getpid()}.tmp'
+    published = False
+    try:
+        with open(tmp, 'w', encoding='utf-8') as fh:
+            fh.write(text)
+        # Windows refuses os.replace while another process holds the
+        # destination open (PermissionError: [WinError 5]). Letting that
+        # propagate is correct: the caller prints its WARNING and the
+        # destination keeps whatever it already had.
+        os.replace(tmp, path)
+        published = True
+    finally:
+        if not published:
+            try:
+                os.remove(tmp)
+            except OSError:
+                pass

--- a/py_router/route_summary.py
+++ b/py_router/route_summary.py
@@ -358,8 +358,14 @@ def write_summary_file(path: str, merged: Optional[Dict]) -> None:
     truthy dict carrying none of the failure keys as `(0, 'clean')`, so an
     ``{'complete': false}`` placeholder would rank a broken candidate FIRST.
     Failing closed -- no file -- lands every caller in the `summary = {}` /
-    "no summary" case they all already handle, where a candidate without a
-    verdict ranks last and never best.
+    "no summary" case they all already handle. Stated precisely, because the
+    three handle it differently: compare_seeds ranks such a row last and never
+    picks it as `best`; cmd_poses only annotates; place_portfolio DROPS it from
+    the routed ranking and falls through to the static one, so with every probe
+    unreadable it still names a best on crossings/HPWL alone (`probe_kind:
+    null` is the only tell). That last one is pre-existing and is not made
+    worse here -- but it is not "ranks last", and saying so would be the
+    comfortable version.
 
     FAILING CLOSED MEANS DELETING THE DESTINATION, and that is not fussiness.
     An atomic publish that merely declines to overwrite leaves the PREVIOUS
@@ -376,9 +382,10 @@ def write_summary_file(path: str, merged: Optional[Dict]) -> None:
     If the destination cannot be removed either -- the same lock that blocked
     the rename -- the stale file survives and the raised message SAYS SO, so
     the caller's warning is true rather than reassuring. Note the in-repo
-    precedent at predictor_study.py:266 CATCHES this PermissionError instead;
-    it can, because there the surviving file provably carries the same content.
-    Here it does not.
+    precedent at predictor_study.py:270 CATCHES this PermissionError instead.
+    It can, because it then RE-READS the survivor and compares its argv_sha,
+    raising SystemExit on disagreement -- it verifies rather than assumes.
+    Nothing here can verify a route summary that way, so it re-raises.
     """
     tmp = f'{path}.{os.getpid()}.tmp'   # several routes can share a directory
     try:

--- a/py_router/route_summary.py
+++ b/py_router/route_summary.py
@@ -381,7 +381,6 @@ def write_summary_file(path: str, merged: Optional[Dict]) -> None:
     Here it does not.
     """
     tmp = f'{path}.{os.getpid()}.tmp'   # several routes can share a directory
-    published = False
     try:
         # indent=1, no sort_keys, default ensure_ascii: byte-identical to what
         # the streaming writer produced, so the on-disk format does not change.
@@ -391,7 +390,6 @@ def write_summary_file(path: str, merged: Optional[Dict]) -> None:
         # Windows refuses os.replace while another process holds the
         # destination open (PermissionError: [WinError 5]).
         os.replace(tmp, path)
-        published = True
     except Exception as exc:
         _discard(tmp)
         _discard(path)
@@ -401,6 +399,3 @@ def write_summary_file(path: str, merged: Optional[Dict]) -> None:
             + ('; a PREVIOUS run\'s summary is still there and could NOT be '
                'removed -- do not read it as this run\'s' if stale else
                '; no file was left behind')) from exc
-    finally:
-        if not published:
-            _discard(tmp)

--- a/py_router/route_summary.py
+++ b/py_router/route_summary.py
@@ -309,6 +309,15 @@ def summary_min(merged: Dict, name_cap: int = 20) -> Dict:
     return out
 
 
+def _discard(path: str) -> None:
+    """Best-effort unlink. A file we cannot remove is reported by the caller,
+    never silently tolerated."""
+    try:
+        os.remove(path)
+    except OSError:
+        pass
+
+
 def write_summary_file(path: str, merged: Optional[Dict]) -> None:
     """Publish `merged` at `path` ALL-OR-NOTHING. Raises if it cannot.
 
@@ -351,25 +360,47 @@ def write_summary_file(path: str, merged: Optional[Dict]) -> None:
     Failing closed -- no file -- lands every caller in the `summary = {}` /
     "no summary" case they all already handle, where a candidate without a
     verdict ranks last and never best.
+
+    FAILING CLOSED MEANS DELETING THE DESTINATION, and that is not fussiness.
+    An atomic publish that merely declines to overwrite leaves the PREVIOUS
+    run's summary standing at `path` -- a complete, parseable document that
+    every reader accepts as this run's, with no signal anywhere: the reader's
+    guard sees valid JSON, so it reports no error, and the verdict is simply
+    about the wrong run. That is worse than the truncated file this replaced,
+    which at least announces itself. Measured: with os.replace forced to fail,
+    a destination holding {"failed_single": ["OLD_RUN"]} still held it after a
+    write of ["NEW_RUN"] -- and `place_route_loop` reuses
+    `work/loop_round{N}_route.json` across runs and hands it to `--accept-cmd`,
+    so the judge would score this round against the last one's tally.
+
+    If the destination cannot be removed either -- the same lock that blocked
+    the rename -- the stale file survives and the raised message SAYS SO, so
+    the caller's warning is true rather than reassuring. Note the in-repo
+    precedent at predictor_study.py:266 CATCHES this PermissionError instead;
+    it can, because there the surviving file provably carries the same content.
+    Here it does not.
     """
-    # indent=1, no sort_keys, default ensure_ascii: byte-identical to what the
-    # streaming writer produced, so the on-disk format does not change.
-    text = json.dumps({} if merged is None else merged, indent=1)
-    # pid-suffixed: several routes can share one output directory.
-    tmp = f'{path}.{os.getpid()}.tmp'
+    tmp = f'{path}.{os.getpid()}.tmp'   # several routes can share a directory
     published = False
     try:
+        # indent=1, no sort_keys, default ensure_ascii: byte-identical to what
+        # the streaming writer produced, so the on-disk format does not change.
+        text = json.dumps({} if merged is None else merged, indent=1)
         with open(tmp, 'w', encoding='utf-8') as fh:
             fh.write(text)
         # Windows refuses os.replace while another process holds the
-        # destination open (PermissionError: [WinError 5]). Letting that
-        # propagate is correct: the caller prints its WARNING and the
-        # destination keeps whatever it already had.
+        # destination open (PermissionError: [WinError 5]).
         os.replace(tmp, path)
         published = True
+    except Exception as exc:
+        _discard(tmp)
+        _discard(path)
+        stale = os.path.exists(path)
+        raise OSError(
+            f'could not publish {path}: {type(exc).__name__}: {exc}'
+            + ('; a PREVIOUS run\'s summary is still there and could NOT be '
+               'removed -- do not read it as this run\'s' if stale else
+               '; no file was left behind')) from exc
     finally:
         if not published:
-            try:
-                os.remove(tmp)
-            except OSError:
-                pass
+            _discard(tmp)

--- a/tests/mutate_830.py
+++ b/tests/mutate_830.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""The #830 mutation battery, shipped so its numbers can be re-derived.
+
+Same contract as `tests/mutate_799.py`, which this copies: a row is KILLED by a
+failure OR an error; an anchor that does not match EXACTLY ONCE is BROKEN,
+never silently skipped; `str.replace(old, new, 1)`, never `sed`; originals
+restored in a `finally`; and it REFUSES to start on a dirty engine, because
+restoring would write the committed text back over uncommitted work.
+
+Every row here reverts or weakens one specific decision in the fix, and names
+the test that must notice. The two that matter most are the ones that do NOT
+simply undo the change:
+
+  * `the-guard-is-narrowed-to-JSONDecodeError` -- the clause the issue itself
+    suggested. It must be killed, because json.load decodes the handle first
+    and a tail cut mid-UTF-8-sequence raises UnicodeDecodeError.
+  * `the-presence-test-demands-every-key` -- `any` -> `all`, which still
+    refuses `{'x': 1}` and so passes the headline check, but breaks the
+    older-summary degradation that test_open_single_verdict.py pins. It exists
+    to prove the boundary tests are load-bearing rather than decorative.
+
+NOT named `test_*.py`, so `tests/run_all.py` never collects it: it rewrites
+engine files in place. One writer per tree.
+
+    python3 tests/mutate_830.py
+    python3 tests/mutate_830.py --row the-read-is-unguarded-again
+    python3 tests/mutate_830.py --list
+    python3 tests/mutate_830.py --selftest
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import shutil
+import subprocess
+import sys
+
+_TESTS = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_TESTS)
+
+CONVERGE = os.path.join(_ROOT, 'py_placer', 'converge.py')
+ROUTE = os.path.join(_ROOT, 'py_router', 'route.py')
+RSUM = os.path.join(_ROOT, 'py_router', 'route_summary.py')
+TARGETS = {'cv': CONVERGE, 'rt': ROUTE, 'rs': RSUM}
+
+T830 = os.path.join(_TESTS, 'test_830_probe_summary_guard.py')
+TCV = os.path.join(_TESTS, 'test_converge.py')
+TOS = os.path.join(_TESTS, 'test_open_single_verdict.py')
+
+ROWS = [
+    # ---- the reader guard --------------------------------------------------
+    ('the-read-is-unguarded-again', 'cv',
+     "        try:\n"
+     "            with open(js, encoding='utf-8') as f:\n"
+     "                summary = json.load(f)\n",
+     "        if True:\n"
+     "            with open(js, encoding='utf-8') as f:\n"
+     "                summary = json.load(f)\n",
+     (T830,), 'KILLED'),
+
+    # The anchor carries the NEXT line too: the except clause is byte-identical
+    # to _load_defects' further down the file (the idiom was copied from it),
+    # so the one-line form matched twice and reported BROKEN.
+    ('the-guard-is-narrowed-to-JSONDecodeError', 'cv',
+     "        except (OSError, ValueError) as exc:                    # noqa: BLE001\n"
+     "            summary_error = f'{type(exc).__name__}: {exc}'\n",
+     "        except json.JSONDecodeError as exc:                     # noqa: BLE001\n"
+     "            summary_error = f'{type(exc).__name__}: {exc}'\n",
+     (T830,), 'KILLED'),
+
+    ('the-cause-is-swallowed-not-named', 'cv',
+     "            summary_error = f'{type(exc).__name__}: {exc}'\n",
+     "            summary_error = None\n",
+     (T830,), 'KILLED'),
+
+    ('the-key-is-conditional-on-the-outcome', 'cv',
+     "            'json': js, 'summary': summary, 'summary_error': summary_error,\n",
+     "            'json': js, 'summary': summary,\n",
+     (T830,), 'KILLED'),
+
+    ('the-warning-goes-to-stdout', 'cv',
+     "                  f\"no summary\", file=sys.stderr)\n",
+     "                  f\"no summary\")\n",
+     (T830,), 'KILLED'),
+
+    # ---- the route_verdict tripwire ----------------------------------------
+    ('a-keyless-summary-scores-as-clean-again', 'cv',
+     "    if not any(k in summary for k in ('failed_single', 'open_single',\n"
+     "                                      'failed_multipoint',\n"
+     "                                      'multipoint_pads_total',\n"
+     "                                      'multipoint_pads_connected')):\n"
+     "        return None, 'unreadable summary'\n",
+     "    if False:\n"
+     "        return None, 'unreadable summary'\n",
+     (T830,), 'KILLED'),
+
+    # `any` -> `all`. Still refuses {'x': 1}, so the headline check passes;
+    # what it breaks is an older summary that predates open_single. This is
+    # the row that proves the boundary tests are load-bearing.
+    ('the-presence-test-demands-every-key', 'cv',
+     "    if not any(k in summary for k in ('failed_single', 'open_single',\n",
+     "    if not all(k in summary for k in ('failed_single', 'open_single',\n",
+     (T830, TOS, TCV), 'KILLED'),
+
+    # protected_skipped only decorates the note; admitting it would let a
+    # document with no failure terms unlock the arithmetic and score 0.
+    ('protected-skipped-alone-unlocks-the-verdict', 'cv',
+     "                                      'multipoint_pads_connected')):\n",
+     "                                      'multipoint_pads_connected',\n"
+     "                                      'protected_skipped')):\n",
+     (T830,), 'KILLED'),
+
+    # ---- the publisher -----------------------------------------------------
+    ('batch-route-streams-into-json-out-again', 'rt',
+     "            write_summary_file(json_out, _merged)\n",
+     "            with open(json_out, 'w', encoding='utf-8') as _jf:\n"
+     "                json.dump(_merged if _merged is not None else {}, _jf,\n"
+     "                          indent=1)\n",
+     (T830,), 'KILLED'),
+
+    ('the-publish-is-not-atomic', 'rs',
+     "    tmp = f'{path}.{os.getpid()}.tmp'\n",
+     "    tmp = path\n",
+     (T830,), 'KILLED'),
+
+    ('a-failed-write-leaves-its-litter', 'rs',
+     "        if not published:\n"
+     "            try:\n"
+     "                os.remove(tmp)\n"
+     "            except OSError:\n"
+     "                pass\n",
+     "        if False:\n"
+     "            try:\n"
+     "                os.remove(tmp)\n"
+     "            except OSError:\n"
+     "                pass\n",
+     (T830,), 'KILLED'),
+
+    # The on-disk format is a published contract: --json-out is read by
+    # place_route_loop --accept-cmd, i.e. by judges this repo does not own.
+    ('the-on-disk-format-drifts', 'rs',
+     "    text = json.dumps({} if merged is None else merged, indent=1)\n",
+     "    text = json.dumps({} if merged is None else merged, indent=2)\n",
+     (T830,), 'KILLED'),
+
+    ('a-none-merge-writes-nothing', 'rs',
+     "    text = json.dumps({} if merged is None else merged, indent=1)\n",
+     "    text = json.dumps(merged, indent=1)\n",
+     (T830,), 'KILLED'),
+
+    # ---- the poses row -----------------------------------------------------
+    ('the-poses-row-cannot-say-what-happened', 'cv',
+     "                              'nets': len(a.affected),\n"
+     "                              'returncode': res['returncode'],\n"
+     "                              'summary_error': res.get('summary_error')}\n",
+     "                              'nets': len(a.affected)}\n",
+     (T830,), 'KILLED'),
+]
+
+
+def _git_clean(paths):
+    r = subprocess.run(['git', 'diff', '--quiet', '--'] + list(paths),
+                       cwd=_ROOT)
+    return r.returncode == 0
+
+
+def _drop_pyc():
+    """Remove every cached bytecode file under the trees we mutate.
+
+    CPython validates a `.pyc` on the source's mtime with ONE-SECOND
+    granularity and its size. Two size-preserving rows applied inside the same
+    second can therefore leave the second import reading the FIRST mutant --
+    reported as a survivor for a row that was never really applied. Several
+    rows here are size-preserving one-token edits (`any` -> `all`, `indent=1`
+    -> `indent=2`), so this is not hypothetical.
+    """
+    for base in (os.path.join(_ROOT, 'py_placer'),
+                 os.path.join(_ROOT, 'py_router')):
+        for dirpath, dirnames, _files in os.walk(base):
+            if os.path.basename(dirpath) == '__pycache__':
+                shutil.rmtree(dirpath, ignore_errors=True)
+                dirnames[:] = []
+
+
+def _run(tests):
+    env = dict(os.environ, PYTHONDONTWRITEBYTECODE='1')
+    for t in tests:
+        r = subprocess.run([sys.executable, '-B', '-X', 'utf8', t],
+                           cwd=_ROOT, capture_output=True, text=True,
+                           encoding='utf-8', errors='replace', env=env)
+        if r.returncode != 0:
+            return True, f"{os.path.basename(t)} exit {r.returncode}"
+    return False, "all named tests passed"
+
+
+def _selftest():
+    """Prove the .pyc defence instead of asserting it.
+
+    Applies a size-preserving mutation to route_summary.py twice within one
+    second and requires the SECOND probe to observe the SECOND mutant. The
+    probe prints the published bytes, which differ per mutant -- a probe that
+    printed only "it wrote something" would report OK against a stale cache.
+    """
+    if not _git_clean([RSUM]):
+        print("REFUSED: route_summary.py is dirty", file=sys.stderr)
+        return 2
+    src = io.open(RSUM, encoding='utf-8').read()
+    anchor = "    text = json.dumps({} if merged is None else merged, indent=1)\n"
+    if src.count(anchor) != 1:
+        print(f"BROKEN selftest: anchor matched {src.count(anchor)} times",
+              file=sys.stderr)
+        return 2
+    probe = [sys.executable, '-B', '-X', 'utf8', '-c',
+             "import sys, os, tempfile; sys.path.insert(0, 'py_router');"
+             "from route_summary import write_summary_file as w;"
+             "d = tempfile.mkdtemp(); p = os.path.join(d, 'r.json');"
+             "w(p, {'a': [1]});"
+             "print(repr(open(p, encoding='utf-8').read()))"]
+    env = dict(os.environ, PYTHONDONTWRITEBYTECODE='1')
+    seen = []
+    try:
+        for repl in (anchor.replace('indent=1', 'indent=2'),
+                     anchor.replace('indent=1', 'indent=3')):
+            _drop_pyc()
+            io.open(RSUM, 'w', encoding='utf-8', newline='').write(
+                src.replace(anchor, repl, 1))
+            r = subprocess.run(probe, cwd=_ROOT, capture_output=True,
+                               text=True, encoding='utf-8', env=env)
+            seen.append(r.stdout.strip())
+    finally:
+        _drop_pyc()
+        io.open(RSUM, 'w', encoding='utf-8', newline='').write(src)
+    ok = len(seen) == 2 and all(seen) and seen[0] != seen[1]
+    print(f"  selftest: two same-second size-preserving mutations, probe read "
+          f"{seen} -- "
+          + ('OK: the second import saw the SECOND mutant' if ok else
+             'the probe cannot tell the mutants apart, or the second read a '
+             'STALE .pyc'))
+    return 0 if ok else 1
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--row', action='append', default=None)
+    ap.add_argument('--list', action='store_true')
+    ap.add_argument('--selftest', action='store_true')
+    a = ap.parse_args()
+
+    if a.list:
+        for name, tgt, _o, _n, tests, exp in ROWS:
+            print(f"  {exp:9} {name}  [{tgt}] "
+                  f"-> {', '.join(os.path.basename(t) for t in tests)}")
+        return 0
+    if a.selftest:
+        return _selftest()
+
+    rows = ROWS
+    if a.row:
+        unknown = [n for n in a.row if n not in {r[0] for r in ROWS}]
+        if unknown:
+            print(f"no such row: {', '.join(unknown)}; try --list",
+                  file=sys.stderr)
+            return 2
+        rows = [r for r in ROWS if r[0] in set(a.row)]
+
+    if not _git_clean(TARGETS.values()):
+        print("REFUSED: the target files are dirty. Restoring would write the "
+              "COMMITTED text back over uncommitted work.", file=sys.stderr)
+        return 2
+
+    # The battery is only evidence if the gate passes UNMUTATED first.
+    _drop_pyc()
+    baseline_killed, why = _run((T830, TCV, TOS))
+    if baseline_killed:
+        print(f"BROKEN: the gate does not pass on the UNMUTATED tree ({why}).",
+              file=sys.stderr)
+        return 2
+
+    originals = {k: io.open(p, encoding='utf-8').read()
+                 for k, p in TARGETS.items()}
+    verdicts = []
+    try:
+        for name, tgt, old, new, tests, expect in rows:
+            src = originals[tgt]
+            n = src.count(old)
+            if n != 1:
+                verdicts.append((name, 'BROKEN', f"anchor matched {n} times"))
+                print(f"  BROKEN   {name} -- anchor matched {n} times")
+                continue
+            _drop_pyc()
+            io.open(TARGETS[tgt], 'w', encoding='utf-8', newline='').write(
+                src.replace(old, new, 1))
+            killed, why = _run(tests)
+            io.open(TARGETS[tgt], 'w', encoding='utf-8', newline='').write(src)
+            _drop_pyc()
+            got = 'KILLED' if killed else 'SURVIVED'
+            mark = 'ok' if got == expect else 'WRONG'
+            verdicts.append((name, got, why))
+            print(f"  {got:9}{'' if mark == 'ok' else ' WRONG'} "
+                  f"{name} -- {why}")
+    finally:
+        for k, p in TARGETS.items():
+            io.open(p, 'w', encoding='utf-8', newline='').write(originals[k])
+        _drop_pyc()
+
+    killed = sum(1 for _n, g, _w in verdicts if g == 'KILLED')
+    survived = sum(1 for _n, g, _w in verdicts if g == 'SURVIVED')
+    broken = [n for n, g, _w in verdicts if g == 'BROKEN']
+    wrong = [r[0] for r, (_n, g, _w) in zip(rows, verdicts)
+             if g != r[5] and g != 'BROKEN']
+    print(f"\n{len(verdicts)} row(s): {killed} killed, {survived} survived, "
+          f"{len(broken)} broken, {len(wrong)} disagreeing with expectation")
+    if wrong:
+        print("  WRONG: " + ', '.join(wrong))
+    if broken:
+        print("  BROKEN: " + ', '.join(broken))
+    return 1 if (wrong or broken) else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/mutate_830.py
+++ b/tests/mutate_830.py
@@ -111,6 +111,16 @@ ROWS = [
      "                                      'protected_skipped')):\n",
      (T830,), 'KILLED'),
 
+    # A document json.load accepts that is not a MAPPING. On a str the presence
+    # test becomes a SUBSTRING test; on an int it raises TypeError. Either way
+    # the crash lands back in the caller's loop.
+    ('a-non-mapping-document-reaches-the-presence-test', 'cv',
+     "    if not isinstance(summary, dict):\n"
+     "        return None, 'unreadable summary'\n",
+     "    if False:\n"
+     "        return None, 'unreadable summary'\n",
+     (T830,), 'KILLED'),
+
     # ---- the publisher -----------------------------------------------------
     ('batch-route-streams-into-json-out-again', 'rt',
      "            write_summary_file(json_out, _merged)\n",
@@ -139,6 +149,25 @@ ROWS = [
 
     # The on-disk format is a published contract: --json-out is read by
     # place_route_loop --accept-cmd, i.e. by judges this repo does not own.
+    # The defect the first version of write_summary_file actually had: an
+    # atomic publish that merely declines to overwrite leaves the PREVIOUS
+    # run's summary standing at the path, which every reader accepts as this
+    # run's with no signal anywhere.
+    ('a-failed-publish-fails-stale-not-closed', 'rs',
+     "        _discard(tmp)\n"
+     "        _discard(path)\n"
+     "        stale = os.path.exists(path)\n",
+     "        _discard(tmp)\n"
+     "        stale = os.path.exists(path)\n",
+     (T830,), 'KILLED'),
+
+    ('a-failed-publish-does-not-say-what-survived', 'rs',
+     "            + ('; a PREVIOUS run\\'s summary is still there and could NOT be '\n"
+     "               'removed -- do not read it as this run\\'s' if stale else\n"
+     "               '; no file was left behind')) from exc\n",
+     "            ) from exc\n",
+     (T830,), 'KILLED'),
+
     ('the-on-disk-format-drifts', 'rs',
      "    text = json.dumps({} if merged is None else merged, indent=1)\n",
      "    text = json.dumps({} if merged is None else merged, indent=2)\n",

--- a/tests/mutate_830.py
+++ b/tests/mutate_830.py
@@ -130,21 +130,16 @@ ROWS = [
      (T830,), 'KILLED'),
 
     ('the-publish-is-not-atomic', 'rs',
-     "    tmp = f'{path}.{os.getpid()}.tmp'\n",
+     "    tmp = f'{path}.{os.getpid()}.tmp'   # several routes can share a directory\n",
      "    tmp = path\n",
      (T830,), 'KILLED'),
 
     ('a-failed-write-leaves-its-litter', 'rs',
-     "        if not published:\n"
-     "            try:\n"
-     "                os.remove(tmp)\n"
-     "            except OSError:\n"
-     "                pass\n",
-     "        if False:\n"
-     "            try:\n"
-     "                os.remove(tmp)\n"
-     "            except OSError:\n"
-     "                pass\n",
+     "    except Exception as exc:\n"
+     "        _discard(tmp)\n"
+     "        _discard(path)\n",
+     "    except Exception as exc:\n"
+     "        _discard(path)\n",
      (T830,), 'KILLED'),
 
     # The on-disk format is a published contract: --json-out is read by
@@ -158,6 +153,7 @@ ROWS = [
      "        _discard(path)\n"
      "        stale = os.path.exists(path)\n",
      "        _discard(tmp)\n"
+     "        pass\n"
      "        stale = os.path.exists(path)\n",
      (T830,), 'KILLED'),
 
@@ -181,7 +177,7 @@ ROWS = [
     # ---- the poses row -----------------------------------------------------
     ('the-poses-row-cannot-say-what-happened', 'cv',
      "                              'nets': len(a.affected),\n"
-     "                              'returncode': res['returncode'],\n"
+     "                              'returncode': res.get('returncode'),\n"
      "                              'summary_error': res.get('summary_error')}\n",
      "                              'nets': len(a.affected)}\n",
      (T830,), 'KILLED'),

--- a/tests/mutate_830.py
+++ b/tests/mutate_830.py
@@ -121,6 +121,28 @@ ROWS = [
      "        return None, 'unreadable summary'\n",
      (T830,), 'KILLED'),
 
+    # The SECOND unguarded json.loads in converge.py, in cmd_record. Reverting
+    # the refusal puts the crash back: two swallowing parses, then a third
+    # unguarded one while building the ledger entry.
+    ('record-swallows-an-unparseable-score-again', 'cv',
+     "            print(f\"record: --score is not readable JSON \"\n"
+     "                  f\"({type(exc).__name__}: {exc}). Nothing was written.\",\n"
+     "                  file=sys.stderr)\n"
+     "            return 2\n",
+     "            _score_doc = None\n",
+     (T830,), 'KILLED'),
+
+    # SURVIVES, and the reason is the design rather than a hole: once the
+    # refusal above is in place, `a.score` is guaranteed parseable by the time
+    # the ledger entry is built, so re-parsing it succeeds and nothing
+    # observable changes. The row is kept because it stops surviving the day
+    # someone weakens that refusal back into a swallow -- which is exactly the
+    # shape the bug had. Recorded, not deleted.
+    ('the-ledger-entry-reparses-the-score', 'cv',
+     "             'score': _score_doc,\n",
+     "             'score': json.loads(a.score) if a.score else None,\n",
+     (T830,), 'SURVIVED'),
+
     # ---- the publisher -----------------------------------------------------
     ('batch-route-streams-into-json-out-again', 'rt',
      "            write_summary_file(json_out, _merged)\n",

--- a/tests/test_830_probe_summary_guard.py
+++ b/tests/test_830_probe_summary_guard.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""#830: an unreadable route summary is a NON-VERDICT, not a crash.
+
+`converge.scoped_route` json.load'ed route.py's `--json-out` with no guard, so
+a file that EXISTS and does not parse raised JSONDecodeError straight out of
+the function. That did not spoil one candidate -- it emptied the CALLER's loop:
+`cmd_poses` has no try at all, and `place_portfolio._probe` and `compare_seeds`
+catch only `subprocess.TimeoutExpired`. compare_seeds writes seeds.json only
+AFTER its loop, so a throw on seed 3 of 8 shipped no document at all.
+
+Pinned here:
+
+  1. scoped_route RETURNS on an unreadable summary, with `summary` {} -- the
+     no-verdict channel every caller already handles.
+  2. It DISCLOSES which absence it was (`summary_error`, always present, None
+     when the read was fine). The return code is 0 either way, so without this
+     "wrote nothing" and "wrote garbage" are the same row.
+  3. The complaint goes to STDERR: converge's stdout is a JSON data channel.
+  4. route_verdict refuses a truthy-but-KEYLESS summary instead of scoring it
+     0 failures / 'clean'. Hardening, not a live bug -- and the two boundaries
+     it must not move are re-pinned here so the predicate cannot drift into
+     them.
+  5. route.py publishes --json-out all-or-nothing (serialise, temp, replace),
+     so a failed write leaves the destination untouched rather than truncated.
+
+No board is routed: route.py is replaced by a stub that writes a chosen payload
+to whatever --json-out path scoped_route picked. Hence the FAST_OK opt-out from
+run_all's "mentions subprocess => integration" classification.
+"""
+import ast
+import contextlib
+import io
+import json
+import os
+import shutil
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for _p in (ROOT, os.path.join(ROOT, 'py_router'),
+           os.path.join(ROOT, 'py_placer'), os.path.join(ROOT, 'py_tools')):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import converge                                              # noqa: E402
+from route_summary import write_summary_file                 # noqa: E402
+
+RUN_ALL_FAST_OK = True
+
+#: Exactly what a streaming json.dump leaves when it stops partway: a valid
+#: PREFIX of the document, which `os.path.isfile` accepts and `json.load` does
+#: not.
+TRUNCATED = '{\n "failed_single": [\n  "A"\n ],\n "poison": '
+
+#: The stub router. It reads its own argv to find whatever --json-out path
+#: scoped_route chose, writes `PAYLOAD`, and exits 0 -- which is what route.py
+#: does on this path: its `except` only prints a WARNING, and a route.py run
+#: with failed nets exits 0 too.
+_STUB = '''\
+import sys
+p = sys.argv[sys.argv.index('--json-out') + 1]
+with open(p, 'w', encoding='utf-8') as f:
+    f.write(PAYLOAD)
+sys.exit(RC)
+'''
+
+
+@contextlib.contextmanager
+def _router_writes(payload, rc=0):
+    """Point converge at a stub route.py that writes `payload`."""
+    td = tempfile.mkdtemp(prefix='t830_stub_')
+    stub = os.path.join(td, 'route_stub.py')
+    with open(stub, 'w', encoding='utf-8') as f:
+        f.write(_STUB.replace('PAYLOAD', repr(payload)).replace('RC', str(rc)))
+    real = converge._ROUTE_PY
+    converge._ROUTE_PY = stub
+    try:
+        yield
+    finally:
+        converge._ROUTE_PY = real
+        shutil.rmtree(td, ignore_errors=True)
+
+
+def _scoped(payload, rc=0):
+    with _router_writes(payload, rc):
+        res = converge.scoped_route('no-such.kicad_pcb', ['GND'])
+    # Verify the INPUT before trusting the output: a stub that wrote nothing
+    # would exercise the missing-file branch and prove nothing at all.
+    assert os.path.isfile(res['json']), (
+        f"the stub wrote no file; this test would prove nothing: {res}")
+    with open(res['json'], encoding='utf-8') as f:
+        raw = f.read()
+    shutil.rmtree(os.path.dirname(res['json']), ignore_errors=True)
+    return res, raw
+
+
+# ------------------------------------------------------- 1-3: the reader guard
+
+def test_a_truncated_summary_returns_instead_of_raising():
+    res, raw = _scoped(TRUNCATED)
+    try:
+        json.loads(raw)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError('the stub wrote parseable JSON; repro is void')
+    assert res['summary'] == {}, res['summary']
+    assert 'JSONDecodeError' in (res['summary_error'] or ''), res
+    assert converge.route_verdict(res['summary']) == (None, 'no summary')
+    print('  PASS: a truncated route.json degrades to no-summary, not a crash')
+
+
+def test_an_empty_file_lands_in_the_same_channel():
+    """A router killed before its first byte, not one that wrote nothing."""
+    res, _ = _scoped('')
+    assert res['summary'] == {} and res['summary_error'], res
+    print('  PASS: an empty summary file is disclosed, not silently empty')
+
+
+def test_a_readable_summary_carries_the_key_as_None():
+    """The key is UNCONDITIONAL: a row's shape must not depend on its outcome,
+    or a consumer has to guess whether the absence of the key means success."""
+    res, _ = _scoped(json.dumps({'failed_single': [], 'open_single': [],
+                                 'multipoint_pads_total': 0,
+                                 'multipoint_pads_connected': 0}))
+    assert 'summary_error' in res, f'key missing on the happy path: {res}'
+    assert res['summary_error'] is None, res['summary_error']
+    assert converge.route_verdict(res['summary']) == (0, 'clean')
+    print('  PASS: summary_error is present and None on a good read')
+
+
+def test_the_complaint_is_on_stderr_because_stdout_is_a_data_channel():
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        res, _ = _scoped(TRUNCATED)
+    assert out.getvalue() == '', (
+        f'stdout carries the `poses` JSON document: {out.getvalue()!r}')
+    assert 'JSONDecodeError' in err.getvalue(), err.getvalue()
+    assert res['json'] in err.getvalue(), 'the warning must name the file'
+    print('  PASS: the unreadable-summary warning goes to stderr')
+
+
+def test_the_guard_catches_oserror_too_not_just_a_parse_failure():
+    """json.load decodes the handle FIRST, so a tail cut mid-UTF-8-sequence
+    raises UnicodeDecodeError -- a ValueError that is NOT a JSONDecodeError.
+    The narrower `except json.JSONDecodeError` the issue suggested misses it."""
+    src = ast.parse(open(converge.__file__, encoding='utf-8').read())
+    fn = next(n for n in ast.walk(src)
+              if isinstance(n, ast.FunctionDef) and n.name == 'scoped_route')
+    caught = {i.id for h in ast.walk(fn) if isinstance(h, ast.ExceptHandler)
+              for i in ast.walk(h.type) if isinstance(i, ast.Name)}
+    assert {'OSError', 'ValueError'} <= caught, (
+        f'scoped_route must catch (OSError, ValueError); catches {caught}')
+    # and prove the wider clause is not decoration
+    payload = b'{"failed_single": ["\xe2\x82'          # cut mid-UTF-8
+    td = tempfile.mkdtemp(prefix='t830_utf8_')
+    p = os.path.join(td, 'route.json')
+    with open(p, 'wb') as f:
+        f.write(payload)
+    try:
+        with open(p, encoding='utf-8') as f:
+            json.load(f)
+    except ValueError as exc:
+        assert not isinstance(exc, json.JSONDecodeError), (
+            'pick a payload that really decodes badly')
+    else:
+        raise AssertionError('the cut sequence parsed; repro is void')
+    finally:
+        shutil.rmtree(td, ignore_errors=True)
+    print('  PASS: the guard is wide enough for a bad decode, not just bad JSON')
+
+
+# ------------------------------------------------ 4: the route_verdict tripwire
+
+def test_route_verdict_refuses_a_summary_with_none_of_its_keys():
+    assert converge.route_verdict({'x': 1}) == (None, 'unreadable summary')
+    # protected_skipped only decorates the note -- alone it is not a verdict,
+    # so it must NOT be enough to unlock the arithmetic.
+    assert converge.route_verdict(
+        {'protected_skipped': {'--rip-existing-nets': {'GND': 'locked'}}}) == (
+        None, 'unreadable summary')
+    print('  PASS: a truthy but keyless summary no longer scores as clean')
+
+
+def test_the_guard_moves_neither_boundary_it_must_not():
+    """Both are pinned by existing tests; re-pinned here because the predicate
+    that refuses a keyless dict is one edit away from refusing these."""
+    # tests/test_converge.py: an empty summary keeps its own note
+    assert converge.route_verdict({}) == (None, 'no summary')
+    # tests/test_open_single_verdict.py: ONE key present is enough to judge --
+    # a log predating open_single must degrade to the old arithmetic, not
+    # be refused.
+    assert converge.route_verdict({'failed_single': ['A']})[0] == 1
+    # a clean route that happens to carry only the multipoint keys
+    assert converge.route_verdict({'multipoint_pads_total': 4,
+                                   'multipoint_pads_connected': 4}) == (
+        0, 'clean')
+    print('  PASS: the presence test refuses only documents with no verdict')
+
+
+# ------------------------------------------------------------ 5: the publisher
+
+def test_a_failed_write_leaves_the_destination_untouched():
+    with tempfile.TemporaryDirectory() as td:
+        path = os.path.join(td, 'route.json')
+
+        # a payload that cannot serialise must create NOTHING -- not the
+        # destination (a reader checks os.path.isfile) and no temp litter
+        try:
+            write_summary_file(path, {'failed_single': ['A'],
+                                      'poison': {1, 2}, 'tail': 'x'})
+        except TypeError:
+            pass
+        else:
+            raise AssertionError('an unserialisable summary must raise')
+        assert not os.path.exists(path), (
+            'a failed write must not create the destination: the reader '
+            'checks os.path.isfile and would then crash on json.load')
+        assert os.listdir(td) == [], f'temp litter survived: {os.listdir(td)}'
+
+        # a good payload publishes, byte-identical to the streaming writer
+        good = {'failed_single': [], 'open_single': [], 'total_iterations': 3}
+        write_summary_file(path, good)
+        with open(path, encoding='utf-8') as f:
+            published = f.read()
+        buf = io.StringIO()
+        json.dump(good, buf, indent=1)
+        assert published == buf.getvalue(), (
+            'the on-disk format changed; --json-out is a published contract')
+
+        # a LATER failed write must not disturb what is already published
+        try:
+            write_summary_file(path, {'poison': {1, 2}})
+        except TypeError:
+            pass
+        with open(path, encoding='utf-8') as f:
+            assert f.read() == published, (
+                'a failed write disturbed the previously published file')
+        assert os.listdir(td) == ['route.json'], os.listdir(td)
+    print('  PASS: --json-out is whole or absent, never half')
+
+
+def test_none_publishes_an_empty_document_as_the_old_writer_did():
+    with tempfile.TemporaryDirectory() as td:
+        path = os.path.join(td, 'route.json')
+        write_summary_file(path, None)
+        with open(path, encoding='utf-8') as f:
+            assert json.load(f) == {}, 'merge_summaries(None) must write {}'
+    print('  PASS: a None merge still writes an empty document')
+
+
+def test_batch_route_no_longer_streams_into_json_out():
+    """A SOURCE guard: the write block only runs at the end of a real route, so
+    no behavioural test of batch_route is cheap enough to catch a revert. This
+    walks the AST rather than grepping text, because a comment quoting the old
+    call would satisfy a grep."""
+    src = ast.parse(open(os.path.join(ROOT, 'py_router', 'route.py'),
+                         encoding='utf-8').read())
+    fn = next(n for n in ast.walk(src)
+              if isinstance(n, ast.FunctionDef) and n.name == 'batch_route')
+    calls = [n for n in ast.walk(fn) if isinstance(n, ast.Call)]
+    names = {c.func.id for c in calls if isinstance(c.func, ast.Name)}
+    assert 'write_summary_file' in names, (
+        'batch_route must publish --json-out through '
+        'route_summary.write_summary_file (serialise, temp file, os.replace)')
+    # and no json.dump(...) whose second argument is a file handle opened on
+    # json_out -- i.e. no streaming dump left anywhere in the function
+    dumps = [c for c in calls if isinstance(c.func, ast.Attribute)
+             and c.func.attr == 'dump']
+    for c in dumps:
+        seg = ast.unparse(c)
+        assert '_jf' not in seg, (
+            f'batch_route still streams json.dump into the --json-out handle: '
+            f'{seg}')
+    print('  PASS: batch_route publishes --json-out atomically')
+
+
+def test_cmd_poses_route_row_says_what_happened():
+    """The row is hand-built (nothing in the repo reads it, so this is the only
+    thing holding its shape). AST, not grep: prose could satisfy a text match."""
+    src = ast.parse(open(converge.__file__, encoding='utf-8').read())
+    fn = next(n for n in ast.walk(src)
+              if isinstance(n, ast.FunctionDef) and n.name == 'cmd_poses')
+    rows = [n.value for n in ast.walk(fn) if isinstance(n, ast.Assign)
+            and isinstance(n.value, ast.Dict)
+            and any(isinstance(k, ast.Constant) and k.value == 'failures'
+                    for k in n.value.keys)]
+    assert len(rows) == 1, f'expected one route row literal, found {len(rows)}'
+    keys = {k.value for k in rows[0].keys if isinstance(k, ast.Constant)}
+    assert {'failures', 'note', 'iterations', 'vias', 'nets', 'returncode',
+            'summary_error'} <= keys, (
+        f'the poses route row cannot say what happened; keys={sorted(keys)}')
+    print('  PASS: cmd_poses reports nets/returncode/summary_error')
+
+
+def main():
+    bad = []
+    for name, fn in sorted(globals().items()):
+        if not name.startswith('test_'):
+            continue
+        print(f'--- {name}')
+        try:
+            fn()
+        except Exception as exc:                             # noqa: BLE001
+            bad.append(f'{name}: {type(exc).__name__}: {exc}')
+            print(f'  FAIL: {bad[-1]}')
+    if bad:
+        print(f'\n{len(bad)} FAILED')
+        return 1
+    print('ALL PASS')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_830_probe_summary_guard.py
+++ b/tests/test_830_probe_summary_guard.py
@@ -300,6 +300,39 @@ def test_a_write_that_fails_AFTER_the_temp_file_still_leaves_it_untouched():
     print('  PASS: a publish that fails mid-flight leaves NO file, and says so')
 
 
+def test_the_publish_is_a_rename_from_a_different_file():
+    """The atomicity property itself, which neither test above can see.
+
+    Once a failed publish removes the destination, `tmp = path` reaches the
+    same END STATE as the atomic version by every observable this file has --
+    both leave no file. What actually differs is what a CONCURRENT READER can
+    observe mid-write, which no single-process test can catch by racing it.
+    So assert the mechanism instead: the publish must be a rename INTO the
+    destination from somewhere else. A writer that streams into the
+    destination renames it onto itself, and that is exactly the mutant.
+    """
+    real_replace, seen = os.replace, []
+
+    def _record(src, dst):
+        seen.append((src, dst))
+        return real_replace(src, dst)
+
+    with tempfile.TemporaryDirectory() as td:
+        path = os.path.join(td, 'route.json')
+        os.replace = _record
+        try:
+            write_summary_file(path, {'failed_single': []})
+        finally:
+            os.replace = real_replace
+    assert seen, 'the publish never went through os.replace at all'
+    src, dst = seen[-1]
+    assert dst == path, f'published to {dst}, not {path}'
+    assert src != path, (
+        'the summary was renamed onto itself -- it was written straight into '
+        'the destination, so a reader can see it half-written')
+    print('  PASS: the summary is published by renaming a sibling into place')
+
+
 def test_route_verdict_survives_a_document_that_is_not_a_mapping():
     """json.load happily returns a str, a list or a number, and the premise of
     this whole change is documents route.py did not write.

--- a/tests/test_830_probe_summary_guard.py
+++ b/tests/test_830_probe_summary_guard.py
@@ -209,8 +209,10 @@ def test_a_failed_write_leaves_the_destination_untouched():
         try:
             write_summary_file(path, {'failed_single': ['A'],
                                       'poison': {1, 2}, 'tail': 'x'})
-        except TypeError:
-            pass
+        except OSError as exc:
+            assert 'not JSON serializable' in str(exc), exc
+            assert isinstance(exc.__cause__, TypeError), (
+                'the original cause must be chained, not swallowed')
         else:
             raise AssertionError('an unserialisable summary must raise')
         assert not os.path.exists(path), (
@@ -228,15 +230,21 @@ def test_a_failed_write_leaves_the_destination_untouched():
         assert published == buf.getvalue(), (
             'the on-disk format changed; --json-out is a published contract')
 
-        # a LATER failed write must not disturb what is already published
+        # a LATER failed write must REMOVE what is already published, not
+        # preserve it. A previous run's summary standing at this run's path is
+        # a complete, parseable document with no signal that it is stale --
+        # every reader accepts it as this run's. Preserving it was the first
+        # version of this function's real defect, and this assertion is the
+        # inversion of what that version asserted.
         try:
             write_summary_file(path, {'poison': {1, 2}})
-        except TypeError:
+        except OSError:
             pass
-        with open(path, encoding='utf-8') as f:
-            assert f.read() == published, (
-                'a failed write disturbed the previously published file')
-        assert os.listdir(td) == ['route.json'], os.listdir(td)
+        assert not os.path.exists(path), (
+            'a failed write left the previous run\'s summary standing in for '
+            'this one')
+        assert os.listdir(td) == [], os.listdir(td)
+        assert published  # the first write really did publish
     print('  PASS: --json-out is whole or absent, never half')
 
 
@@ -266,24 +274,44 @@ def test_a_write_that_fails_AFTER_the_temp_file_still_leaves_it_untouched():
             raise OSError(5, 'Access is denied')
 
         os.replace = _boom
+        err = None
         try:
             write_summary_file(path, {'failed_single': ['LATER'],
                                       'total_iterations': 999})
-        except OSError:
-            pass
+        except OSError as exc:
+            err = exc
         else:
             raise AssertionError('a failed publish must not report success')
         finally:
             os.replace = real_replace
+        assert before, 'the stale document was never published; repro is void'
 
-        with open(path, encoding='utf-8') as f:
-            after = f.read()
-        assert after == before, (
-            'a failed publish overwrote the destination -- the writer is not '
-            'atomic, so a reader can see a half document')
-        assert os.listdir(td) == ['route.json'], (
+        # FAIL CLOSED, not fail stale. The destination must not still hold the
+        # PREVIOUS run's summary: that is a complete, parseable document every
+        # reader accepts as this run's, with no signal anywhere -- strictly
+        # worse than the truncated file this replaced, which announces itself.
+        assert not os.path.exists(path), (
+            'a failed publish left the previous run\'s summary in place; a '
+            'reader would score this run against the last one\'s tally')
+        assert os.listdir(td) == [], (
             f'the temp file survived a failed publish: {os.listdir(td)}')
-    print('  PASS: a publish that fails mid-flight leaves the old file intact')
+        assert 'no file was left behind' in str(err), (
+            f'the error must say what state the destination is in: {err}')
+    print('  PASS: a publish that fails mid-flight leaves NO file, and says so')
+
+
+def test_route_verdict_survives_a_document_that_is_not_a_mapping():
+    """json.load happily returns a str, a list or a number, and the premise of
+    this whole change is documents route.py did not write.
+
+    On a str the presence test below would be a SUBSTRING test, so a document
+    merely mentioning one of the key names passes it and then dies on `.get`
+    -- back in the caller's loop, which is the failure scoped_route's guard
+    just closed. On an int it raises TypeError outright."""
+    for doc in (1, True, 3.5, [1], 'failed_single was empty', ('a',)):
+        assert converge.route_verdict(doc) == (None, 'unreadable summary'), (
+            f'route_verdict({doc!r}) must refuse, not crash or score')
+    print('  PASS: a non-mapping document is refused, not crashed on')
 
 
 def test_none_publishes_an_empty_document_as_the_old_writer_did():

--- a/tests/test_830_probe_summary_guard.py
+++ b/tests/test_830_probe_summary_guard.py
@@ -240,6 +240,52 @@ def test_a_failed_write_leaves_the_destination_untouched():
     print('  PASS: --json-out is whole or absent, never half')
 
 
+def test_a_write_that_fails_AFTER_the_temp_file_still_leaves_it_untouched():
+    """The ATOMICITY half, which the test above cannot see.
+
+    A payload that will not serialise never opens anything, so
+    serialise-first alone passes that check -- a writer that wrote straight
+    into the destination would too. What separates them is a failure BETWEEN
+    the write and the publish, which is exactly the reachable case here:
+    ENOSPC, a flush that fails at close, or -- measured in this repo, at
+    predictor_study.py:271 -- os.replace raising PermissionError [WinError 5]
+    on Windows because another process holds the destination open.
+
+    So: force os.replace to fail and require the destination to keep the bytes
+    it already had. A non-atomic writer has overwritten them by this point.
+    """
+    real_replace = os.replace
+    with tempfile.TemporaryDirectory() as td:
+        path = os.path.join(td, 'route.json')
+        first = {'failed_single': [], 'open_single': [], 'total_iterations': 1}
+        write_summary_file(path, first)
+        with open(path, encoding='utf-8') as f:
+            before = f.read()
+
+        def _boom(src, dst):
+            raise OSError(5, 'Access is denied')
+
+        os.replace = _boom
+        try:
+            write_summary_file(path, {'failed_single': ['LATER'],
+                                      'total_iterations': 999})
+        except OSError:
+            pass
+        else:
+            raise AssertionError('a failed publish must not report success')
+        finally:
+            os.replace = real_replace
+
+        with open(path, encoding='utf-8') as f:
+            after = f.read()
+        assert after == before, (
+            'a failed publish overwrote the destination -- the writer is not '
+            'atomic, so a reader can see a half document')
+        assert os.listdir(td) == ['route.json'], (
+            f'the temp file survived a failed publish: {os.listdir(td)}')
+    print('  PASS: a publish that fails mid-flight leaves the old file intact')
+
+
 def test_none_publishes_an_empty_document_as_the_old_writer_did():
     with tempfile.TemporaryDirectory() as td:
         path = os.path.join(td, 'route.json')

--- a/tests/test_830_probe_summary_guard.py
+++ b/tests/test_830_probe_summary_guard.py
@@ -400,6 +400,44 @@ def test_cmd_poses_route_row_says_what_happened():
     print('  PASS: cmd_poses reports nets/returncode/summary_error')
 
 
+def test_record_refuses_a_score_payload_it_cannot_parse():
+    """The SECOND unguarded json.loads in this file, and a live one.
+
+    `cmd_record` parsed --score three times: twice inside `except Exception:
+    ... = None` swallowers, then once unguarded while building the ledger
+    entry. Neither swallow proves the string parses, so a truncated
+    --score-file reached the third parse and crashed with a traceback at exit
+    1 -- AFTER store.put() had written the board into the content store. It
+    now refuses at the top, which is the posture the surrounding comment
+    already claims ("Refuse before anything is written").
+    """
+    import shutil
+    import subprocess
+    board_src = os.path.join(ROOT, 'kicad_files', 'splitflap_driver.kicad_pcb')
+    if not os.path.isfile(board_src):
+        print('  SKIP: fixture missing')
+        return
+    with tempfile.TemporaryDirectory() as td:
+        board = os.path.join(td, 'b.kicad_pcb')
+        shutil.copy(board_src, board)
+        score = os.path.join(td, 'score.json')
+        with open(score, 'w', encoding='utf-8') as f:
+            f.write('{\n "blocking": 3,\n "board_sha": ')   # a valid PREFIX
+        r = subprocess.run(
+            [sys.executable, '-X', 'utf8', converge.__file__, 'record',
+             '--ledger', os.path.join(td, 'ledger'), '--board', board,
+             '--kind', 'completion', '--score-file', score,
+             '--argv', os.path.join(ROOT, 'py_router', 'route.py'), 'x'],
+            capture_output=True, text=True, encoding='utf-8',
+            errors='replace', cwd=ROOT)
+        both = (r.stdout or '') + (r.stderr or '')
+        assert 'Traceback' not in both, f'record still crashes:\n{both[-800:]}'
+        assert r.returncode == 2, f'expected a refusal (2), got {r.returncode}'
+        assert 'not readable JSON' in both, both[-400:]
+        assert 'Nothing was written' in both, both[-400:]
+    print('  PASS: record refuses an unparseable score before writing anything')
+
+
 def main():
     bad = []
     for name, fn in sorted(globals().items()):


### PR DESCRIPTION
Closes #830.

*(`converge.py` line numbers below are against `main`; this branch adds ~90
lines to that file. `route.py` numbers are the same on both.)*

`converge.scoped_route` reads back the file `route.py --json-out` wrote, with no
guard:

```python
    summary = {}
    if os.path.isfile(js):
        with open(js, encoding='utf-8') as f:
            summary = json.load(f)
```

A file that **exists and does not parse** therefore raises `JSONDecodeError`
straight out of the function — and none of the four `scoped_route` call sites
catch it. `cmd_poses` has no `try` at all; `place_portfolio._probe` (itself
called from three places: the baseline, the window loop, the full loop) and
`compare_seeds` catch only `subprocess.TimeoutExpired`;
`tests/test_placement_probe` catches only `ImportError`.

So one malformed file did not cost one candidate — it emptied the caller's whole
loop. `compare_seeds` writes `seeds.json` only *after* the loop, so a throw on
seed 3 of 8 produces **no document at all** and exits 1, which is not in its
documented exit vocabulary (0/4/2). `place_portfolio` is Step 0c-bis of the
`plan-pcb-placement` skill.

## Reproduced

The real `scoped_route`, against a stub router that writes a valid prefix and
exits 0 — which is what `route.py` does here: its `except` only prints a
WARNING, and a run with failed nets exits 0 anyway (`route.py:6676`).

```
before:  RAISED: JSONDecodeError: Expecting value: line 5 column 12 (char 43)
         => the exception escapes scoped_route; no caller catches it.

after :  WARNING: unreadable route summary ...\route.json
           (JSONDecodeError: Expecting value: line 5 column 12 (char 43));
           rc=0 -- treating as no summary
         summary       = {}
         summary_error = 'JSONDecodeError: Expecting value: line 5 ...'
         route_verdict = (None, 'no summary')
```

## Four changes

**1. `scoped_route` guards the read and names the cause.** `summary` stays `{}`
— the no-verdict channel every caller already handles — and a new
always-present `summary_error` separates "the router wrote nothing" from "the
router wrote something unreadable". The return code cannot: it is 0 either way,
and the router's own WARNING has usually fallen out of the 1500-character
`stdout_tail` (measured on the *smallest* in-repo fixture it already sits 1595
chars from the end).

`(OSError, ValueError)`, the idiom already used by `_load_defects` in this same
file — deliberately wider than the `json.JSONDecodeError` the issue suggested:
`json.load` decodes the text handle first, so a tail cut mid-UTF-8-sequence
raises `UnicodeDecodeError`, a `ValueError` that is *not* a `JSONDecodeError`.
The complaint goes to **stderr**, because converge's stdout is a JSON data
channel.

How the three callers then behave is worth stating precisely rather than
comfortably: `compare_seeds` ranks a verdictless row last and never picks it as
`best`; `cmd_poses` only annotates; `place_portfolio` **drops** it from the
routed ranking and `select_best` falls through to the static one, so with every
probe unreadable it still names a `best` on crossings/HPWL alone
(`probe_kind: null` is the only tell). That last is pre-existing and not made
worse here, but it is not "ranks last".

**2. `route_verdict` refuses a summary it cannot judge.** Two arms:

- *Not a mapping.* `json.load` happily returns a str, a list or a number. On a
  `str`, `k in summary` is a **substring** test, so a document merely
  *mentioning* `failed_single` passed the guard and died on `.get` two lines
  later; on an int it raised `TypeError`. And `json.load` *succeeds* on such a
  file, so `summary_error` is `None` and the caller gets no signal at all — the
  crash lands right back in the loop arm 1 just protected.
- *Truthy but keyless.* Every field is read with `.get(..., default)`, so
  `route_verdict({'x': 1})` returned `(0, 'clean')` — the best possible score,
  for a document that never mentioned routing.

Presence, not truthiness, and **any one** key is enough: a clean route sets
`failed_single: []`, and a summary predating `open_single` must still degrade to
the old arithmetic.

**The keyless half is hardening, not a live bug**, and the code says so.
`route.py` sets `failed_single`, `open_single` and `multipoint_pads_total`
unconditionally (`route.py:3606/3611/3624`) with a single append site into
`_SUMMARY_SINK` (`:3899`), so nothing it writes today reaches it. It is a
schema-drift tripwire.

**3. `route.py` publishes `--json-out` all-or-nothing.** The old call was
`open(json_out,'w')` + `json.dump`: the open truncates the destination before
the first chunk is encoded, and `json.dump` then *streams* — it calls
`iterencode` with `_one_shot=False`, so the C encoder is never used, with or
without `indent`. A failure partway therefore published a valid **prefix**, and
the `except` only printed a WARNING, after which route.py exited 0. Now:
serialise first, write a sibling temp file, `os.replace`.

**Failing closed means deleting the destination**, which is worth spelling out
because the obvious implementation gets it wrong — mine did, and a review caught
it. An atomic publish that merely *declines* to overwrite leaves the **previous
run's** summary standing at that path: a complete, parseable document every
reader accepts as this run's, with no signal anywhere. That is strictly worse
than the truncated file this replaces, which at least announces itself. Measured
on **the rejected implementation**, with `os.replace` forced to fail:

```
published stale: {"failed_single": ["OLD_RUN"]}
replace RAISED:  [Errno 5] locked
destination now: {"failed_single": ["OLD_RUN"]}     <- the wrong run's verdict
```

and on the shipped one:

```
RAISED: OSError could not publish ...\route.json: PermissionError:
        [Errno 5] locked; no file was left behind
destination exists now: False        dir listing: []
```

Reachable: `place_route_loop:1241` reuses `work/loop_round{N}_route.json` across
runs and `:1256` hands exactly that path to `--accept-cmd`, so an external judge
would score this round against the last one's tally. If the destination cannot
be removed either — the same lock that blocked the rename — the raised message
says the stale file survived, so the warning is true rather than reassuring.

Note what this does **not** claim. A non-serialisable value cannot reach that
block: `route.py:3898` already runs the same dict through an *unguarded*
`json.dumps`, and both it and the write block are direct children of
`batch_route`'s body under no `if` and no `try`, so no path reaches the write
without passing the gate. The reachable causes are ENOSPC, a flush that fails at
`close()`, an external kill, and a key stamped onto the summary *after* that
gate — `route.py:4293` `finalize_excluded_nets` is the only such key in the
whole 3899–5711 range (`list[str]` today, so safe, but ungated).

The precedent is in-repo: `predictor_study.py:260` adopted this same atomic
write after a study run died on a `JSONDecodeError` that *"read like a study
failure and was a file-system race"*. It **catches** the Windows
`PermissionError` at `:270` where this re-raises — it can, because it then
re-reads the survivor and compares its `argv_sha`, raising on disagreement. It
verifies. Nothing here can verify a route summary that way.

**4. `cmd_record` had the same bug, and I had written it off.** The PR
description originally called converge's other unguarded `json.loads`
"dead-risk, already round-tripped twice". A fact-check falsified that: both
earlier parses are `except Exception: ... = None` **swallowers**, so a malformed
payload reaches the third, unguarded one — and `--score-file` reads it off disk,
the same "exists and does not parse" input class. Reproduced:

```
before:  json.decoder.JSONDecodeError: Expecting value: line 3 column 15
         (char 32), traceback, exit 1
after :  record: --score is not readable JSON (JSONDecodeError: ...).
         Nothing was written.   -> exit 2
```

Worse than a plain crash: it happened *after* `store.put()` had already written
the board into the content store. It now refuses at the first parse, which is
the posture the surrounding comment already claims ("Refuse before anything is
written"), and the ledger entry is built from the document already parsed.

`cmd_poses`' hand-built row gains `nets`/`returncode`/`summary_error`.

## Verification

```
tests/run_all.py                         499 passed, 0 failed, 0 timed out,
                                         0 skipped (3454 s)
tests/test_830_probe_summary_guard.py    15 checks, ALL PASS
tests/mutate_830.py                      19 rows: 18 killed, 1 survived
                                         (expected, reason recorded), 0 broken
tests/mutate_830.py --selftest           OK (the .pyc defence, proven not asserted)
tests/test_converge.py                   ALL PASS   (route_verdict boundary)
tests/test_open_single_verdict.py        ALL PASS   (the any-vs-all trap)
tests/test_json_out_summary.py           ALL PASS   (incl. the end-to-end real route)
tests/test_portfolio.py                  14/14
tests/gui_parity/test_manifest_plan_parity.py   OK
tests/gui_parity/test_cli_postpass_coverage.py  0 failures, 0 warnings
```

The suite number is a single clean run on this branch; re-derive the battery
numbers with `python3 tests/mutate_830.py` (`--list` prints the *declared*
expectations, not measurements).

On-disk format unchanged: `json.dumps(o, indent=1)` and what
`json.dump(o, fp, indent=1)` writes are identical bytes — key order,
`ensure_ascii` escapes, and no trailing newline in either. Pinned by a
text-level comparison in the new test; note the end-to-end test in
`test_json_out_summary.py` compares *parsed* documents, so it pins content, not
format.

**GUI-inert.** The plugin never sets `json_out` (zero hits in
`kicad_routing_plugin/`; `tests/gui_parity/test_engine_kwarg_parity.py:90` lists
it in `CLI_ONLY_OK`). The write is inside the shared engine `batch_route`, not a
CLI `main()` post-pass, so `test_cli_postpass_coverage` needs no new
registration. No new flag or engine parameter, so the "Claude-settable end to
end" checklist is not engaged; both no-wx parity gates were run anyway.

One round of blind adversarial review found three real defects in my own work
here (the fail-stale publisher, the non-mapping crash, an inconsistent
subscript); the mutation battery then found a fourth — a `finally` block that
had become unreachable — plus a test asserting an end state where only the
mechanism distinguishes the two writers; and a hostile fact-check of this
description found the `cmd_record` bug above by falsifying my claim about it.
Each is recorded in its own commit with the measurement.

## Behaviour changes worth knowing

- The writer now needs write permission on the **directory** (to create the
  sibling temp and rename it), where it previously needed it only on the file.
- `os.replace` replaces a **symlink or hardlink** at `json_out` with a fresh
  regular file, where the old writer wrote *through* it.

Neither affects this repo's own callers (converge uses `mkdtemp`,
`place_route_loop` creates its own directory), but both are real for an
operator-supplied `--json-out`.

## Deliberately excluded

- **`place_portfolio.py` and `compare_seeds.py` are untouched.** They stop
  crashing via the `scoped_route` guard alone, and PR #827 (issue #713) rewrites
  both — this keeps the two changes textually disjoint. The honest consequence:
  their rows still cannot say *why* a probe has no verdict, so `summary_error`
  currently lands only in `cmd_poses`' row, which nothing reads. Its consumers
  arrive with #827's `probe_route`, which is the one place that should map it to
  a status.
- **No `status` vocabulary.** #830 item 3 asks that `cmd_poses`' row match
  `probe_route`'s shape, but `probe_route` and `PROBE_STATUSES` exist only on
  #827's branch. A second copy here would be exactly the duplicate that PR
  exists to delete, so this adds only the keys that need no new vocabulary.
- **Other `--json-out`-style writers** (`check_reachability`, `net_forensics`,
  `render_placement`, `board_brief`, `check_capacity`, `check_drc`) still stream
  into their destinations — same defect class, different files.
  `write_summary_file` is the **pattern to copy**, not a drop-in: it hardcodes
  `indent=1` with no `sort_keys`/`default=str`, and four of those six use
  `sort_keys=True`, `default=str`, or `indent=2`, so reusing it verbatim would
  change their on-disk formats.

## Known limits

A `kill -9` between the temp write and `os.replace` strands a `.tmp` beside the
destination — a stray file rather than a poisoned artifact, the same trade
`board_store.py:76` documents. There is no `fsync`, so this is atomic against
other *processes*, not against power loss.

## Note on PR #827

#827 also touches `scoped_route` (it removes the `timeout` parameter, two lines
above this change, with the unchanged `summary = {}` between them). **#827 does
not touch `route_verdict` at all**, so only `scoped_route` can conflict, and
narrowly. Happy to rebase whichever you prefer.
