### PR TITLE
#826: the portfolio's basin-escape destroys the lattice before the quench sees it

### DIFF
--- a/docs/placement-optimization.md
+++ b/docs/placement-optimization.md
@@ -805,7 +805,11 @@ is implemented, the rest are documented targets.
    snapping a ring to the placement grid moves a point by up to half a cell per
    axis, so slots generated *at* the radius land outside it — the pool shrinks
    by the snap diagonal, or the by-construction claim is false at exactly the
-   outer ring where a re-seat wants to look.
+   outer ring where a re-seat wants to look. Since #708 that snap is taken on
+   the offset **from the anchor**, not on the absolute point, so the pool
+   inherits the anchor's own phase instead of a lattice through board origin;
+   the shrink argument is unchanged, because the snap error per axis is still
+   half a cell.
 
 3. **The #411 undo-a-known-good-placement harness — BUILT.** See "What the
    #411 harness measured" below. `placement/perturb.py` manufactures the bad

--- a/docs/placement-predictors.md
+++ b/docs/placement-predictors.md
@@ -237,6 +237,18 @@ formula is not. Filed, not built.
 
 ## The circularity control changed the answer for `crossings`
 
+> **Stale since #826, for the portfolio rows.** `portfolio.perturb_jitter` now
+> snaps its offset to the board's own placement lattice, so a regenerated study
+> tree produces different `portfolio-N` candidates on any board that declares
+> one — measured, 10 of the 11 tracked lattice boards previously lost their
+> lattice to the jitter. The rho table and the Kendall-tau finding below were
+> measured on the pre-#826 slate and are **not reproducible from HEAD** without
+> a rebuild (~8.8 h; see `tests/test_703_predictor_regen.py`'s header). The
+> findings are not withdrawn — nothing here suggests the direction changed —
+> but the numbers describe a slate the tool no longer generates. The four
+> regenerable rows in `test_703_predictor_regen.py` are re-recorded, and
+> `esp_prog:portfolio-1` moved.
+
 The realistic-end sampler is `portfolio.generate`, whose quench **minimises
 crossings and hpwl**. Those rows carry `generator: portfolio_quench`, and every
 statistic is computed twice:

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -1344,6 +1344,22 @@ Both sides resolve a rectangle through the same `placement.utility.refs_in_rect`
 (half-open on the far edges), so the rectangle the census prints and the
 rectangle the mover lifts cannot mean two different sets of parts.
 
+### The board's placement lattice (#708)
+
+The `JSON_SUMMARY` line also carries `board_grid_step`, `board_grid_occupancy`
+and `board_grid_reason`: the pitch the board appears to have been laid out on,
+read through the same `placement.board_grid.infer_board_grid` the placer
+resolves its candidate offsets with, so the census cannot report a pitch the
+engine does not use.
+
+`board_grid_step` is `None` for a board that declares no lattice, and that is a
+real answer rather than a missing one -- `board_grid_reason` says which test it
+failed (`best occupancy 0.226 < floor 0.67`, `n_parts 4 < 8`), so "no lattice"
+and "never measured" stay distinguishable from the summary line alone. Measured
+over the tracked corpus, 12 of 22 boards resolve: four imperial at 0.3175 mm
+(`splitflap_driver` 0.92, `flat_hierarchy` 0.83, `sonde_u` 0.78,
+`interf_u_unrouted` 0.70) and eight metric-fine at 0.05 mm.
+
 ### Example
 
 ```bash

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -1356,9 +1356,11 @@ engine does not use.
 real answer rather than a missing one -- `board_grid_reason` says which test it
 failed (`best occupancy 0.226 < floor 0.67`, `n_parts 4 < 8`), so "no lattice"
 and "never measured" stay distinguishable from the summary line alone. Measured
-over the tracked corpus, 12 of 22 boards resolve: four imperial at 0.3175 mm
+over the tracked corpus, 11 of 22 boards resolve: four imperial at 0.3175 mm
 (`splitflap_driver` 0.92, `flat_hierarchy` 0.83, `sonde_u` 0.78,
-`interf_u_unrouted` 0.70) and eight metric-fine at 0.05 mm.
+`interf_u_unrouted` 0.70) and seven metric-fine at 0.05 mm (`glasgow_revC`,
+`interf_u_unrouted_placed`, `haasoscope_pro_max_test`, `routed_output`,
+`lvds_converter_dualclk`, `lvds_converter_dualclk_gnd`, `esp_prog`).
 
 ### Example
 

--- a/py_placer/place_portfolio.py
+++ b/py_placer/place_portfolio.py
@@ -691,6 +691,13 @@ def main():
            'rank_crossing_band': args.rank_crossing_band,
            'rank_band_q': band_q,
            'corridor_weight': args.corridor_weight,
+           # #826: which lattice the jitter offsets snapped to, and why. Without
+           # it a run cannot show whether the snap happened -- "the board kept
+           # its lattice" and "there was no lattice to snap to" would read the
+           # same, and the fix could ship inert with nothing saying so.
+           # `source` is 'inferred' or 'none'; `reason` carries the cause,
+           # including the radius guard.
+           'jitter_lattice': result.get('jitter_lattice'),
            'baseline': baseline.to_dict(),
            'candidates': [c.to_dict() for c in cands],
            'ranking_static': ranking_static,

--- a/py_placer/placement/README.md
+++ b/py_placer/placement/README.md
@@ -719,6 +719,89 @@ At `0.0` both hooks return before touching any geometry and the peer index is
 empty, so a default run is **bit-identical**, verified on `interf_u_unrouted` and
 `splitflap_driver` rather than argued.
 
+## The board's placement lattice (`board_grid.py`, #708)
+
+A board is laid out on a pitch. `splitflap_driver` puts 92% of its footprint
+coordinates on 0.3175 mm (12.5 mil), `glasgow_revC` 97% on 0.05 mm. The quench
+used to destroy that: `_candidate_positions` built candidates as
+`seed + ix*step` and then snapped the **absolute** result to a lattice through
+board origin, which discards the seed's residue. One pass took
+`splitflap_driver` from 0.923 of its coordinates on its own lattice to 0.269.
+
+Two things had to change, and the second is the one that does the work.
+
+**Snap the offset, not the position.** `seed + ix*step` already carries the
+board's phase; snapping the sum throws it away, because `seed_x` is not
+generally a multiple of anything. This half is free: measured, the absolute
+snap removed **zero** candidates at every step the tool ships (317/317 at
+`--step 1.0`, 49/49 at 0.5, 81/81 at 0.2) — the two sets are a pure
+translation of each other. `_group_offsets` had always snapped the offset,
+which is why block moves never had this defect and is the existence proof for
+the form.
+
+**Snap it to the board's lattice, not the raster.** Seed-relative alone is not
+enough, and this is worth stating because it is the obvious fix and it does not
+work: the offsets are multiples of `--grid-step` 0.1, and 1.0 is not a multiple
+of 0.3175, so only the *zero* offset lands back on an imperial lattice.
+Snapping the offset to the board's own pitch gives `{0, ±0.9525, ±1.905,
+±2.8575}`, every candidate stays on the lattice, and the count goes 317 → 325 —
+so it costs nothing either.
+
+Measured, one quench pass, fraction of footprint coordinates on the board's own
+lattice:
+
+| board | lattice | before | after (old) | after (now) | parts moved |
+|---|---|---|---|---|---|
+| `splitflap_driver` | 0.3175 | 0.923 | 0.269 | **0.923** | 43 |
+| `flat_hierarchy` | 0.3175 | 0.828 | 0.273 | **0.828** | 40 |
+| `sonde_u` | 0.3175 | 0.780 | 0.200 | **0.780** | 24 |
+
+The same parts still move. They now move by whole grid units.
+
+### There is no flag
+
+`resolve_snap_lattice` returns the board's inferred pitch, or `--grid-step`
+when the board declares none — which is exactly the granularity offsets have
+always had. The fallback **is** the off state, and the board reaches it rather
+than a flag. Ten of the 22 tracked boards take it, each with a stated reason,
+and `metrics_out['board_grid']` records which branch ran so "no lattice" and
+"never measured" cannot be confused.
+
+### Two rules in the inference that are not the obvious ones
+
+Both come from `tests/measure_708_lattice.py`, and both contradict the
+mechanism #708 proposes.
+
+**The tie-break is the finest rung within tolerance of the maximum, not the
+argmax.** The ladder contains divisibility chains (0.3175 | 0.635 | 1.27 |
+2.54), and occupancy is monotone along one — if `d` divides `s`, every on-`s`
+point is on-`d`. Ties are therefore structural, not accidental:
+`splitflap_driver` ties at 0.3175 *and* 0.635, `sonde_u` at 0.3175, 0.635 *and*
+1.27. An argmax has no defined answer there, and taking the coarsest would
+infer a 1.27 mm grid for `sonde_u` off a tie. A consequence worth knowing
+before simplifying this: only 0.05 and 0.3175 lack a ladder divisor, so they
+are the **only two values the function can return** — the issue's worry that a
+2.54 mm inference would quantize the search into uselessness cannot happen, and
+not because anything clamps it.
+
+**A rate needs a denominator.** `cap_chain` (4 parts) and the `qfn_*` fixtures
+(1–2) score 1.00 at six rungs, because hand-authored coordinates are round by
+construction. Below `MIN_PARTS` there is no answer to give.
+
+`OCCUPANCY_FLOOR` is 0.67 and not the rounder 0.70 for a reason worth keeping:
+`interf_u_unrouted` scores **exactly** 0.700000, so a 0.70 floor would rest on
+a corpus board where `>=` and `>` disagree on a float equality. 0.67 is the
+midpoint of the widest gap in the distribution (0.642424 → 0.700000).
+
+### Where the lattice deliberately does NOT apply
+
+`place_fanout_clearance` and `reseat.slot_pool` take the seed-relative half and
+keep the **raster**. Both searches *are* sub-millimetre clearance repair, and
+coarsening them starves exactly the search that must not be starved: at the cap
+repair's `step=0.2` the candidate count falls 81 → 29 on a 0.3175 lattice and
+81 → 9 on 0.635. `perturb` needed no change at all — it already snapped deltas,
+so it never had the defect, notwithstanding #708 naming it.
+
 ## Placement blocks (`groups.py`, #459)
 
 The per-part nudge cannot express "these parts need to travel together": an IC
@@ -1066,7 +1149,10 @@ is followed by a settle beat, so the moves only play once the camera has arrived
 | `legality.py` | Hard constraints shared by both engines: board side, real Edge.Cuts containment, and the OO/OoB graders (#456) |
 | `parser.py` | Courtyard boundary and locked-footprint extraction |
 | `writer.py` | Writes new positions/rotations (rotates pad angles with the footprint, as KiCad stores pad angle = footprint + pad rotation) |
-| `utility.py` | Shared utilities (bbox from pads, grid snapping) |
+| `board_grid.py`
+  The pitch a board was laid out on, inferred from its footprint origins (#708). Pure; no engine imports.
+
+`utility.py` | Shared utilities (bbox from pads, grid snapping) |
 
 ## Legality model (`legality.py`, #456)
 

--- a/py_placer/placement/README.md
+++ b/py_placer/placement/README.md
@@ -839,16 +839,20 @@ radius: **10 lost it**, two of them to 0.000 occupancy
 (`tests/measure_826_jitter_lattice.py`). It is not a tuning problem — the same
 10 of 11 at radius 4.0, 1.0, 0.25 *and* 0.05, because a continuous offset is
 off-lattice at every amplitude. `glasgow_revC` is the only survivor and not a
-reprieve: only 58 of its 243 free parts pass the incumbent-legality guard, so
-it survives on a ~20-part margin by being dense, and its jittered parts still
-sit on a residue the quench then preserves on the wrong coset.
+reprieve: of its 243 free parts only 59 pass the incumbent-legality guard and
+58 then find a legal sample, so it survives by being dense rather than by being
+right. Its post-jitter occupancy is 0.763 against a 0.67 floor — forcing parts
+off-lattice one at a time, the inference still answers at 24 more and declines
+at 25. And its 58 jittered parts still sit on a residue the quench then
+preserves on the wrong coset, so even the survivor is on the wrong grid.
 
 The jitter now snaps the **offset** to the board's lattice when `generate`
-resolves one. The escape is unaffected — a radius-4 disc on 0.3175 offers ~500
-destinations of which the sampler consumes one, the worst-case boxed-in part
-still has 10, and re-running the identical rng stream snapped restores
-occupancy to *exactly* the input value on all 11 boards with the same parts
-perturbed on 9 of them.
+resolves one. The escape is unaffected — a radius-4 disc on 0.3175 holds **496** lattice
+destinations and the sampler takes the first legal one; measured, the most
+boxed-in part on any 0.3175 board still has **9** (`sonde_u` C4/C5,
+`flat_hierarchy` R1/R2/R3/R6), and `splitflap_driver`'s worst is 11. Re-running
+the identical rng stream snapped restores occupancy to *exactly* the input
+value on all 11 boards, with the same parts perturbed on 9 of them.
 
 Two details worth keeping:
 

--- a/py_placer/placement/README.md
+++ b/py_placer/placement/README.md
@@ -824,6 +824,53 @@ repair's `step=0.2` the candidate count falls 81 → 29 on a 0.3175 lattice and
 81 → 9 on 0.635. `perturb` needed no change at all — it already snapped deltas,
 so it never had the defect, notwithstanding #708 naming it.
 
+### The portfolio jitter (#826)
+
+The quench preserves the lattice it is *given*. `place_portfolio` used to give
+it a broken one: `perturb_jitter` offsets a part by `r·cos(θ)` at 4 decimal
+places — continuous, on no lattice — and `generate` quenches each candidate
+from its jittered seed board. Candidate 0, by contrast, is quenched from the
+input, so the **baseline kept the board's lattice and the candidates did not**:
+the slate was ranked against a baseline with a privilege the candidates were
+denied.
+
+Measured over the 11 tracked boards that declare a lattice, at the default
+radius: **10 lost it**, two of them to 0.000 occupancy
+(`tests/measure_826_jitter_lattice.py`). It is not a tuning problem — the same
+10 of 11 at radius 4.0, 1.0, 0.25 *and* 0.05, because a continuous offset is
+off-lattice at every amplitude. `glasgow_revC` is the only survivor and not a
+reprieve: only 58 of its 243 free parts pass the incumbent-legality guard, so
+it survives on a ~20-part margin by being dense, and its jittered parts still
+sit on a residue the quench then preserves on the wrong coset.
+
+The jitter now snaps the **offset** to the board's lattice when `generate`
+resolves one. The escape is unaffected — a radius-4 disc on 0.3175 offers ~500
+destinations of which the sampler consumes one, the worst-case boxed-in part
+still has 10, and re-running the identical rng stream snapped restores
+occupancy to *exactly* the input value on all 11 boards with the same parts
+perturbed on 9 of them.
+
+Two details worth keeping:
+
+- **The fallback is no snap, not `--grid-step`.** #708's "the fallback is the
+  off state" worked because quench offsets were already multiples of `step`.
+  The jitter is continuous, so snapping a no-lattice board to the 0.1 raster
+  would change behaviour to buy nothing. `jitter_lattice` returns `None`.
+- **A lattice coarser than the radius is refused**, because below it the disc
+  holds no destination but the seed. Measured on `interf_u_unrouted`:
+  `--radius 0.3175` perturbs 22 of 22, `--radius 0.3` perturbs 0 of 22 after
+  440 draws and every candidate goes barren.
+
+`perturb.py`'s `scatter` damage kind calls the same function and deliberately
+does **not** pass a lattice — its own comment calls it "the POSITIVE CONTROL …
+the arm that MUST recover", and a snapped offset would land the part exactly on
+the coset the quench generates from, making the control easier to pass.
+
+`portfolio.json` carries a run-level `jitter_lattice` and three
+`board_grid_*` scalars per candidate, so a run can show which branch it took —
+without them "the board kept its lattice" and "there was no lattice" read the
+same.
+
 ## Placement blocks (`groups.py`, #459)
 
 The per-part nudge cannot express "these parts need to travel together": an IC

--- a/py_placer/placement/README.md
+++ b/py_placer/placement/README.md
@@ -744,8 +744,19 @@ enough, and this is worth stating because it is the obvious fix and it does not
 work: the offsets are multiples of `--grid-step` 0.1, and 1.0 is not a multiple
 of 0.3175, so only the *zero* offset lands back on an imperial lattice.
 Snapping the offset to the board's own pitch gives `{0, ±0.9525, ±1.905,
-±2.8575}`, every candidate stays on the lattice, and the count goes 317 → 325 —
-so it costs nothing either.
+±2.8575}`, and every candidate stays on the seed's coset of the lattice.
+(Coset, not lattice: a part whose own seed is off-lattice keeps its residue
+rather than acquiring the board's — the fix preserves phase, it does not impose
+one. `splitflap_driver` has 8% of its coordinates off its own pitch.)
+
+Reach is comparable but not uniformly better. At the shipped default
+(`--max-displacement 10 --step 1.0`) the count goes 317 → 325; sweeping
+`max_displacement` from 0.5 to 19.5 at `--step 1.0`, 12 values gain candidates,
+17 tie and **10 lose** — worst 81 → 69 at 5.0 mm, because an offset the raster
+admitted at exactly the cap can snap *up* past it and is then correctly
+rejected. That is the price of making the displacement cap exact, and
+`place_route_loop` widens `--max-displacement` ×1.5 per rejected round, so it
+does reach those values.
 
 Measured, one quench pass, fraction of footprint coordinates on the board's own
 lattice:
@@ -756,14 +767,21 @@ lattice:
 | `flat_hierarchy` | 0.3175 | 0.828 | 0.273 | **0.828** | 40 |
 | `sonde_u` | 0.3175 | 0.780 | 0.200 | **0.780** | 24 |
 
-The same parts still move. They now move by whole grid units.
+The `parts moved` column is the new arm. The quench keeps moving comparably
+many parts — old vs new: 43/43 on splitflap, 45/40 on flat_hierarchy, 20/24 on
+sonde_u — but it is **not the same set**: splitflap swaps `U6` for `R8`, and
+flat_hierarchy drops six and gains one. That is expected, since the candidate
+set is genuinely different; what does not change is that the search is still
+free to move parts, and every move it makes is now a whole number of grid
+units.
 
 ### There is no flag
 
 `resolve_snap_lattice` returns the board's inferred pitch, or `--grid-step`
 when the board declares none — which is exactly the granularity offsets have
 always had. The fallback **is** the off state, and the board reaches it rather
-than a flag. Ten of the 22 tracked boards take it, each with a stated reason,
+than a flag. Eleven of the 22 tracked boards take it, each with a stated
+reason,
 and `metrics_out['board_grid']` records which branch ran so "no lattice" and
 "never measured" cannot be confused.
 
@@ -790,8 +808,12 @@ construction. Below `MIN_PARTS` there is no answer to give.
 
 `OCCUPANCY_FLOOR` is 0.67 and not the rounder 0.70 for a reason worth keeping:
 `interf_u_unrouted` scores **exactly** 0.700000, so a 0.70 floor would rest on
-a corpus board where `>=` and `>` disagree on a float equality. 0.67 is the
-midpoint of the widest gap in the distribution (0.642424 → 0.700000).
+a corpus board where `>=` and `>` disagree on a float equality. 0.67 clears it
+by 0.0276. It sits in a real gap (0.642424 → 0.700000) but **not the widest** —
+that is 0.2235, between `tigard` 0.592 and `rp2350` 0.369, and putting the
+floor there instead would admit `tigard` and `orangecrab_ext_pll` at 0.05. The
+module docstring has the full gap table; the floor rests on the boundary
+argument, not on a separation one.
 
 ### Where the lattice deliberately does NOT apply
 
@@ -1149,10 +1171,8 @@ is followed by a settle beat, so the moves only play once the camera has arrived
 | `legality.py` | Hard constraints shared by both engines: board side, real Edge.Cuts containment, and the OO/OoB graders (#456) |
 | `parser.py` | Courtyard boundary and locked-footprint extraction |
 | `writer.py` | Writes new positions/rotations (rotates pad angles with the footprint, as KiCad stores pad angle = footprint + pad rotation) |
-| `board_grid.py`
-  The pitch a board was laid out on, inferred from its footprint origins (#708). Pure; no engine imports.
-
-`utility.py` | Shared utilities (bbox from pads, grid snapping) |
+| `board_grid.py` | The pitch a board was laid out on, inferred from its footprint origins (#708). Pure; no engine imports |
+| `utility.py` | Shared utilities (bbox from pads, grid snapping) |
 
 ## Legality model (`legality.py`, #456)
 

--- a/py_placer/placement/board_grid.py
+++ b/py_placer/placement/board_grid.py
@@ -38,18 +38,29 @@ pins that as a property of the ladder.
 authored by hand are round by construction rather than by a design grid. Below
 `MIN_PARTS` there is no answer to give and the caller gets `None`.
 
-`OCCUPANCY_FLOOR` is the MIDPOINT of a real population gap, and it is not a
-round number for a reason worth keeping. Sorted best-occupancy over the tracked
-corpus (parts >= MIN_PARTS), the widest gap by a factor of two is
+`OCCUPANCY_FLOOR` is 0.67 because 0.70 -- the round number the population
+first suggests -- sits EXACTLY on a corpus board. `interf_u_unrouted` scores
+0.700000, so at a 0.70 floor `>=` admits it and `>` rejects it on a float
+equality, which is the most fragile place a threshold can be. 0.67 is 0.0276
+clear of it and 0.0276 clear of the nearest rejected board.
 
-    0.700000  interf_u_unrouted            <- admitted
-    0.642424  orangecrab_ext_pll           <- rejected
+An earlier version of this paragraph claimed the 0.642424 -> 0.700000 gap was
+"the widest by a factor of two". That is false and a review caught it. Sorted
+best-occupancy over the tracked corpus (parts >= MIN_PARTS), the adjacent gaps
+are:
 
-and every other adjacent pair differs by at most 0.05. A floor of 0.70 would
-therefore sit EXACTLY on a corpus board: `>=` admits `interf_u_unrouted` and
-`>` rejects it, on a float equality, which is the most fragile place a
-threshold can be. 0.67 is 0.030 clear of the nearest admitted board and 0.028
-clear of the nearest rejected one. The floor is far above the chance rate at
+    0.2235  tigard 0.592391 -> rp2350 0.368852
+    0.1189  rp2350 0.368852 -> kit-dev-coldfire 0.250000
+    0.0800  sonde_u 0.780000 -> interf_u_unrouted 0.700000
+    0.0769  splitflap 0.923077 -> lvds 0.846154
+    0.0576  interf_u_unrouted 0.700000 -> orangecrab 0.642424   <- the floor
+    0.0500  orangecrab 0.642424 -> tigard 0.592391
+
+so this is the FIFTH widest gap, not the first. The floor is placed here on the
+boundary argument above, not on a separation argument. Putting it at the widest
+gap instead (~0.48) would admit `tigard` (0.592) and `orangecrab_ext_pll`
+(0.642) at 0.05 -- a defensible alternative that changes behaviour on two
+boards, and one nobody should make by accident. The floor is far above the chance rate at
 every rung --
 with a 1 um tolerance a uniformly random coordinate lands on a multiple of `g`
 with probability `2e-3/g`, i.e. 4.0% at 0.05 falling to 0.08% at 2.54 -- so a
@@ -117,8 +128,12 @@ def infer_board_grid(pcb_data, *, ladder: Sequence[float] = GRID_LADDER,
         if s <= 0:
             raise ValueError("board grid ladder must be positive: %r" % (s,))
     values, n_parts = board_coordinates(pcb_data)
+    # `n_values` is the REAL denominator: `n_parts` counts footprints, but a
+    # non-finite coordinate is dropped from the sample, so 2*n_parts overstates
+    # it whenever a board has one.
     out: Dict = {'step': None, 'occupancy': None, 'n_parts': n_parts,
-                 'profile': {}, 'ties': (), 'reason': ''}
+                 'n_values': len(values), 'profile': {}, 'ties': (),
+                 'reason': ''}
     if not values:
         out['reason'] = 'no footprints'
         return out
@@ -176,7 +191,7 @@ def describe(evidence: Dict) -> str:
     return ("placement lattice %g mm (inferred, %.0f%% of %d footprint "
             "coordinates%s)"
             % (evidence['step'], 100.0 * evidence['occupancy'],
-               2 * evidence['n_parts'],
+               evidence.get('n_values', 2 * evidence['n_parts']),
                '' if len(evidence.get('ties', ())) < 2
                else '; ties with ' + ', '.join('%g' % t
                                                for t in evidence['ties'][1:])))

--- a/py_placer/placement/board_grid.py
+++ b/py_placer/placement/board_grid.py
@@ -1,0 +1,182 @@
+"""The lattice a board was laid out on, inferred from the board (#708).
+
+`snap_to_grid` quantizes; this decides WHAT to quantize to. The two are
+separate on purpose: `grid_step` is the router's raster, a setting no board
+declares (`py_tools/check_channels.py` says so in as many words), whereas a
+placement lattice IS declared by a board, implicitly, in the coordinates of its
+own footprints. Reading it off is what lets the placer move a part by a whole
+number of the designer's grid units instead of an arbitrary residue.
+
+Two rules here are not the obvious ones, and both come from measurement over
+the tracked corpus (`tests/measure_708_lattice.py`, table C).
+
+**The tie-break is the FINEST rung within `TIE_SLACK` of the maximum, not the
+argmax.** The ladder contains divisibility chains -- 0.3175 | 0.635 | 1.27 |
+2.54, and 0.05 | 0.1 | 0.2, 0.05 | 0.25 | 0.5 | 1.0 -- and occupancy is monotone
+non-increasing along one: if `d` divides `s` then every on-`s` point is on-`d`,
+so `occ(d) >= occ(s)`. Ties are therefore STRUCTURAL rather than accidental, and
+an argmax is undefined exactly where the answer matters. Measured:
+`splitflap_driver` ties 0.92 at both 0.3175 and 0.635; `sonde_u` ties 0.78 at
+0.3175, 0.635 AND 1.27. Taking the coarsest would infer a 1.27 mm grid for
+`sonde_u` on the strength of a tie.
+
+`TIE_SLACK` is a tolerance on that comparison and is currently INERT: measured
+over the admitting corpus boards, the nearest rung OUTSIDE each tie group sits
+0.075 (`esp_prog`) to 0.460 (`interf_u_unrouted_placed`) below it, so nothing
+is within 0.02 of the boundary either way. It exists so the rule survives
+someone adding a rung to the ladder, not because it is load-bearing today.
+
+A useful consequence, worth knowing before someone "simplifies" this: only
+0.05 and 0.3175 have no proper divisor in the ladder, so those are the ONLY two
+values this function can ever return. The issue's fear that a 2.54 mm inference
+would quantize the search into uselessness cannot happen -- not because it is
+clamped, but because the tie-break cannot select it. `test_708_board_grid.py`
+pins that as a property of the ladder.
+
+**A rate needs a denominator.** `cap_chain` (4 parts) and the `qfn_*` fixtures
+(1-2 parts) score 1.00 at six rungs from 0.05 to 1.0, because coordinates
+authored by hand are round by construction rather than by a design grid. Below
+`MIN_PARTS` there is no answer to give and the caller gets `None`.
+
+`OCCUPANCY_FLOOR` is the MIDPOINT of a real population gap, and it is not a
+round number for a reason worth keeping. Sorted best-occupancy over the tracked
+corpus (parts >= MIN_PARTS), the widest gap by a factor of two is
+
+    0.700000  interf_u_unrouted            <- admitted
+    0.642424  orangecrab_ext_pll           <- rejected
+
+and every other adjacent pair differs by at most 0.05. A floor of 0.70 would
+therefore sit EXACTLY on a corpus board: `>=` admits `interf_u_unrouted` and
+`>` rejects it, on a float equality, which is the most fragile place a
+threshold can be. 0.67 is 0.030 clear of the nearest admitted board and 0.028
+clear of the nearest rejected one. The floor is far above the chance rate at
+every rung --
+with a 1 um tolerance a uniformly random coordinate lands on a multiple of `g`
+with probability `2e-3/g`, i.e. 4.0% at 0.05 falling to 0.08% at 2.54 -- so a
+single flat floor is safe HERE even though the null rate is 50x higher at the
+fine end than the coarse end. Anyone lowering the floor toward 0.1 must
+subtract the per-rung null rate first; at 0.67 it does not bite.
+"""
+from __future__ import annotations
+
+import math
+from typing import Dict, Optional, Sequence, Tuple
+
+# The ladder issue #708 proposes, kept verbatim so this answers the issue's own
+# question rather than a reshaped one.
+GRID_LADDER: Tuple[float, ...] = (0.05, 0.1, 0.2, 0.25, 0.3175, 0.5, 0.635,
+                                  1.0, 1.27, 2.54)
+TOL_MM = 0.001            # 1 um: the issue's own tolerance
+OCCUPANCY_FLOOR = 0.67    # MIDPOINT of the population gap; see the docstring
+MIN_PARTS = 8             # below this a rate has no denominator
+TIE_SLACK = 0.02          # inert on today's corpus; worst margin 0.075
+
+
+def occupancy(values: Sequence[float], step: float,
+              tol_mm: float = TOL_MM) -> float:
+    """Fraction of `values` within `tol_mm` of a multiple of `step`."""
+    if not values or step <= 0:
+        return 0.0
+    hits = sum(1 for v in values
+               if abs(v / step - round(v / step)) * step <= tol_mm)
+    return hits / len(values)
+
+
+def board_coordinates(pcb_data) -> Tuple[list, int]:
+    """(pooled x and y of every footprint ORIGIN, footprint count).
+
+    Origins, not pads: a pad sits at its origin plus a package pitch (0.5 mm,
+    0.65 mm, 1.27 mm BGA) that is on no board lattice, so a pad sample measures
+    the footprint library rather than the layout.
+
+    Every footprint, unconditionally -- not the movable set, not lock-filtered.
+    The lattice must be a property of the FILE: `--lock` globs and `move_refs`
+    differ between `place_optimize`, `place_seed` and `place_portfolio`, and a
+    filtered sample would let the same board infer different lattices in
+    different tools.
+    """
+    fps = list(getattr(pcb_data, 'footprints', {}).values())
+    xs = [f.x for f in fps if f.x is not None and math.isfinite(f.x)]
+    ys = [f.y for f in fps if f.y is not None and math.isfinite(f.y)]
+    return xs + ys, len(fps)
+
+
+def infer_board_grid(pcb_data, *, ladder: Sequence[float] = GRID_LADDER,
+                     floor: float = OCCUPANCY_FLOOR,
+                     min_parts: int = MIN_PARTS,
+                     tol_mm: float = TOL_MM,
+                     tie_slack: float = TIE_SLACK) -> Dict:
+    """The lattice this board appears to be laid out on.
+
+    Always returns a dict; `step is None` means "no lattice found" and `reason`
+    says which test failed. Never a bare `None`: "the inference declined" and
+    "the inference never ran" must not look the same to a caller, and a caller
+    that wants the terse form can read `d['step']`.
+    """
+    for s in ladder:
+        if s <= 0:
+            raise ValueError("board grid ladder must be positive: %r" % (s,))
+    values, n_parts = board_coordinates(pcb_data)
+    out: Dict = {'step': None, 'occupancy': None, 'n_parts': n_parts,
+                 'profile': {}, 'ties': (), 'reason': ''}
+    if not values:
+        out['reason'] = 'no footprints'
+        return out
+    out['profile'] = {s: occupancy(values, s, tol_mm) for s in ladder}
+    if n_parts < min_parts:
+        out['reason'] = 'n_parts %d < %d' % (n_parts, min_parts)
+        return out
+    best = max(out['profile'].values())
+    ties = tuple(s for s in ladder if out['profile'][s] >= best - tie_slack)
+    out['ties'] = ties
+    if best < floor:
+        out['reason'] = 'best occupancy %.3f < floor %.2f' % (best, floor)
+        return out
+    # FINEST within the slack, never the argmax -- see the module docstring.
+    out['step'] = ties[0]
+    out['occupancy'] = out['profile'][ties[0]]
+    out['reason'] = 'inferred'
+    return out
+
+
+def resolve_snap_lattice(pcb_data, grid_step: float, *,
+                         override: Optional[float] = None
+                         ) -> Tuple[float, Dict]:
+    """The lattice a candidate OFFSET should be a multiple of.
+
+    Falls back to `grid_step`, which is exactly today's offset granularity, so
+    a board with no inferable lattice keeps the step sizes it has always had.
+    There is deliberately no on/off switch: the fallback IS the off state, it
+    is reached by the board rather than by a flag, and a run discloses which
+    branch it took through the returned evidence.
+    """
+    if override is not None:
+        if not (override > 0):
+            raise ValueError("board grid override must be positive: %r"
+                             % (override,))
+        return override, {'source': 'explicit', 'step': override,
+                          'reason': 'override'}
+    ev = infer_board_grid(pcb_data)
+    if ev['step'] is None:
+        ev['source'] = 'grid_step'
+        ev['resolved'] = grid_step
+        return grid_step, ev
+    ev['source'] = 'inferred'
+    ev['resolved'] = ev['step']
+    return ev['step'], ev
+
+
+def describe(evidence: Dict) -> str:
+    """One line, in the `value (source)` idiom the placement CLIs already use."""
+    if evidence.get('source') == 'explicit':
+        return "placement lattice %g mm (given)" % evidence['step']
+    if evidence.get('step') is None:
+        return ("placement lattice %g mm (the --grid-step raster: %s)"
+                % (evidence.get('resolved', 0.0), evidence.get('reason', '')))
+    return ("placement lattice %g mm (inferred, %.0f%% of %d footprint "
+            "coordinates%s)"
+            % (evidence['step'], 100.0 * evidence['occupancy'],
+               2 * evidence['n_parts'],
+               '' if len(evidence.get('ties', ())) < 2
+               else '; ties with ' + ', '.join('%g' % t
+                                               for t in evidence['ties'][1:])))

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -762,17 +762,39 @@ class _Cap:
 
 
 def _candidate_positions(cap, max_disp, step, grid_step):
+    """Candidate cap centres, snapped on the OFFSET rather than the position.
+
+    Same #708 correction as `quench._candidate_positions`: snapping
+    `cap.seed_x + ix*step` to a lattice through board ORIGIN discards the
+    seed's residue and walks the part off whatever pitch the board was laid out
+    on, for nothing -- at every step this tool ships, the absolute snap removed
+    zero candidates.
+
+    Unlike quench, this site keeps the `grid_step` RASTER rather than the
+    board's inferred lattice, and that asymmetry is deliberate and measured.
+    This search IS the clearance repair: its whole job is to find the
+    sub-millimetre pose that clears a foreign via. At `step=0.2` the candidate
+    count is 81 on the raster, 29 on a 0.3175mm lattice and 9 on 0.635 -- so a
+    coarse lattice would starve exactly the search that must not be starved,
+    and the #313 via nudge downstream of it moves parts by as little as 0.6mm,
+    which a 1.27 lattice could not express at all.
+
+    The radius test now runs AFTER the snap, so `max_disp` is an exact cap. The
+    `grid_step*sqrt(2)/2` overshoot the via- and track-prune margins budget for
+    (see `_prune_vias` and the track channel note) is therefore gone rather
+    than merely bounded; both margins gain that much slack.
+    """
     seen = set()
     out = []
     n = int(max_disp / step)
     for ix in range(-n, n + 1):
         for iy in range(-n, n + 1):
-            cx = cap.seed_x + ix * step
-            cy = cap.seed_y + iy * step
-            if math.hypot(cx - cap.seed_x, cy - cap.seed_y) > max_disp + 1e-9:
+            dx = snap_to_grid(ix * step, grid_step)
+            dy = snap_to_grid(iy * step, grid_step)
+            if math.hypot(dx, dy) > max_disp + 1e-9:
                 continue
-            cx = snap_to_grid(cx, grid_step)
-            cy = snap_to_grid(cy, grid_step)
+            cx = cap.seed_x + dx
+            cy = cap.seed_y + dy
             key = (round(cx, 4), round(cy, 4))
             if key not in seen:
                 seen.add(key)

--- a/py_placer/placement/fanout_clearance.py
+++ b/py_placer/placement/fanout_clearance.py
@@ -776,8 +776,8 @@ def _candidate_positions(cap, max_disp, step, grid_step):
     sub-millimetre pose that clears a foreign via. At `step=0.2` the candidate
     count is 81 on the raster, 29 on a 0.3175mm lattice and 9 on 0.635 -- so a
     coarse lattice would starve exactly the search that must not be starved,
-    and the #313 via nudge downstream of it moves parts by as little as 0.6mm,
-    which a 1.27 lattice could not express at all.
+    and the #313 nudge downstream of it relocates VIAS inside a 0.6mm budget --
+    a fraction of a millimetre, which a 1.27 lattice could not express at all.
 
     The radius test now runs AFTER the snap, so `max_disp` is an exact cap. The
     `grid_step*sqrt(2)/2` overshoot the via- and track-prune margins budget for

--- a/py_placer/placement/portfolio.py
+++ b/py_placer/placement/portfolio.py
@@ -178,8 +178,47 @@ def copy_siblings(src_board: str, dst_board: str) -> None:
 # WHOLE, not merely pairwise against the original board. The caller owns the
 # snapshot/restore bracket.
 
+def jitter_lattice(pcb_data, radius: float) -> Tuple[Optional[float], Dict]:
+    """The pitch a jitter OFFSET is a multiple of, or None for no snap (#826).
+
+    NOT `board_grid.resolve_snap_lattice`, and the difference is the whole
+    design. That function's fallback is `grid_step`, which is the right off
+    state for the QUENCH -- whose offsets were already multiples of `step`, so
+    falling back to the raster restored exactly today's granularity. The jitter
+    is CONTINUOUS, so snapping a no-lattice board to the 0.1 raster would
+    change behaviour to buy nothing. The off state here is no snap at all, and
+    the board still reaches it rather than a flag. Calling `resolve_snap_lattice`
+    and then undoing its fallback would also write `resolved: 0.1` into the
+    evidence while nothing snapped to 0.1, which is worse than useless.
+
+    Refuses a lattice COARSER than the radius: below it the disc holds no
+    destination but the seed itself, so every candidate goes barren and the CLI
+    exits 4 without anything naming a lattice. Measured on interf_u_unrouted
+    (0.3175): `--radius 0.3175` still perturbs 22 of 22 parts, `--radius 0.3`
+    perturbs 0 of 22 after burning 440 draws. `> radius`, not `>=`, because the
+    equality case demonstrably works.
+
+    No coarse-lattice guard beyond that, deliberately: `infer_board_grid` can
+    only ever return 0.05 or 0.3175 (only those two rungs have no proper
+    divisor in the ladder), and at radius 4.0 a 0.3175 lattice offers ~500
+    destinations of which `SAMPLE_ATTEMPTS` consumes one. Starvation is
+    unreachable here, unlike at the fanout repair site.
+    """
+    from placement.board_grid import infer_board_grid
+    ev = infer_board_grid(pcb_data)
+    step = ev['step']
+    if step is not None and step > radius:
+        ev = dict(ev, reason='inferred %g mm exceeds the %g mm jitter radius, '
+                             'which would leave the disc no destination but '
+                             'the seed' % (step, radius))
+        step = None
+    return step, dict(ev, source='inferred' if step is not None else 'none',
+                      resolved=step)
+
+
 def perturb_jitter(state, refs: Sequence[str], rng: random.Random,
-                   radius: float, attempts: int = SAMPLE_ATTEMPTS) -> List[Dict]:
+                   radius: float, attempts: int = SAMPLE_ATTEMPTS, *,
+                   lattice: Optional[float] = None) -> List[Dict]:
     """Uniform-disc offset per free ref, rotation unchanged. The direct
     basin-escape for a zero-temperature descent: the quench cannot leave a
     local minimum, so the seed does it instead, bounded by `radius`.
@@ -190,7 +229,24 @@ def perturb_jitter(state, refs: Sequence[str], rng: random.Random,
     would happily walk one inboard and silently break its overhang spec) and
     dense hand-packed parts already under the courtyard clearance (any
     accepted sample would be a lateral trade the quench's own gate refuses).
-    Skipping draws nothing from the rng, so the stream stays stable."""
+    Skipping draws nothing from the rng, so the stream stays stable.
+
+    `lattice` (#826) is the pitch the OFFSET is a multiple of, or None for the
+    continuous sampler this has always been. Given one, the escape still goes
+    anywhere in the disc -- it just arrives on the grid the board was laid out
+    on, so the quench that follows can preserve a lattice instead of inheriting
+    an arbitrary residue. Measured: on 10 of the 11 tracked boards that declare
+    a lattice, the continuous sampler destroyed it before the quench ever
+    parsed the seed board (`tests/measure_826_jitter_lattice.py`).
+
+    None is the default and `portfolio.generate` is the only caller that passes
+    a lattice. `perturb.py`'s `scatter` damage kind deliberately does not: its
+    own comment calls it "the POSITIVE CONTROL ... the arm that MUST recover",
+    and a snapped offset would land the part exactly on the coset the quench
+    generates from -- one nudge reaches it -- making the control easier to
+    pass. That is the one direction a positive control must not move.
+    """
+    from placement.utility import snap_to_grid
     poses: List[Dict] = []
     for ref in refs:
         part = state.parts.get(ref)
@@ -201,8 +257,32 @@ def perturb_jitter(state, refs: Sequence[str], rng: random.Random,
         for _ in range(attempts):
             r = radius * math.sqrt(rng.random())
             th = 2.0 * math.pi * rng.random()
-            x = round(part.x + r * math.cos(th), 4)
-            y = round(part.y + r * math.sin(th), 4)
+            dx = r * math.cos(th)
+            dy = r * math.sin(th)
+            if lattice is not None:
+                # The OFFSET, never `part.x + dx`. `part.x` carries the board's
+                # own phase and is not generally a multiple of anything, so
+                # snapping the SUM would discard exactly what this is for.
+                # #708's form, at a fourth site.
+                dx = snap_to_grid(dx, lattice)
+                dy = snap_to_grid(dy, lattice)
+                if dx == 0.0 and dy == 0.0:
+                    # Not a perturbation. Accepting it would be guaranteed to
+                    # succeed -- `candidate_valid` on the incumbent pose was
+                    # just asserted above -- so it would emit a pose identical
+                    # to the seed, inflate the "N part(s) perturbed" line, and
+                    # put a ref in `poses` that `_displacement` (d > 1e-4) does
+                    # not count as moved.
+                    continue
+                if math.hypot(dx, dy) > radius + 1e-9:
+                    # Snapped OUT of the disc. Tested AFTER the snap so the
+                    # radius stays an exact bound, as `quench._candidate_
+                    # positions` and `fanout_clearance` both do -- `--radius`
+                    # is a number the operator reasons with ("10mm-class values
+                    # destroy corridors"), not a soft target.
+                    continue
+            x = round(part.x + dx, 4)
+            y = round(part.y + dy, 4)
             if state.candidate_valid(ref, x, y, part.rot):
                 state.apply_move(ref, x, y, part.rot)
                 poses.append({'reference': ref, 'new_x': x, 'new_y': y,
@@ -423,6 +503,23 @@ def generate(input_file: str, out_dir: str, *, seed: int = 0,
         grid_step=qkw.get('grid_step', 0.1), ignore_ids=ids)
     origin = {ref: (p.x, p.y, p.rot) for ref, p in oracle.parts.items()}
 
+    # #826: resolved ONCE, from the INPUT board, never from the oracle state.
+    # `--only N` must regenerate candidate N byte-identically without running
+    # 1..N-1, so the lattice has to be a function of (input_file, radius)
+    # alone -- a read off a partially-perturbed state would make it depend on
+    # what earlier candidates did and the ledger's replay primitive would
+    # silently stop replaying. `board_coordinates`' own docstring forbids a
+    # filtered sample for the same reason.
+    lattice, lattice_ev = jitter_lattice(pcb, radius)
+    if lattice is not None:
+        print("[portfolio] jitter offsets snap to %g mm (inferred, %.0f%% of "
+              "%d footprint coordinates)"
+              % (lattice, 100.0 * lattice_ev['occupancy'],
+                 lattice_ev['n_values']))
+    else:
+        print("[portfolio] jitter offsets are continuous (no snap: %s)"
+              % lattice_ev['reason'])
+
     baseline: Optional[Candidate] = None
     if only is None:
         print(f"[portfolio] candidate 0 (baseline): plain quench")
@@ -452,7 +549,8 @@ def generate(input_file: str, out_dir: str, *, seed: int = 0,
         snap = _snapshot(oracle, free)
         note = ''
         if strategy == 'jitter':
-            poses = perturb_jitter(oracle, free, rng, radius)
+            poses = perturb_jitter(oracle, free, rng, radius,
+                                   lattice=lattice)
         elif strategy == 'poses':
             poses = perturb_poses(oracle, free, (i - 1) // len(strategies))
             if poses is None:
@@ -493,7 +591,8 @@ def generate(input_file: str, out_dir: str, *, seed: int = 0,
         cand.metrics = _quench_metrics(m)
         candidates.append(cand)
 
-    return {'baseline': baseline, 'candidates': candidates, 'free': free}
+    return {'baseline': baseline, 'candidates': candidates,
+            'free': free, 'jitter_lattice': lattice_ev}
 
 
 def _quench_metrics(m: Dict) -> Dict:
@@ -510,7 +609,22 @@ def _quench_metrics(m: Dict) -> Dict:
             # the layer is off, keeping old-metric candidates comparable).
             'pad_conflict_pairs': leg.get('pad_conflict_pairs', 0),
             'pad_shortfall': leg.get('pad_shortfall', 0.0),
-            'hole_shortfall': leg.get('hole_shortfall', 0.0)}
+            'hole_shortfall': leg.get('hole_shortfall', 0.0),
+            # #826: which lattice THIS candidate's quench saw, in the same
+            # three-scalar vocabulary check_pockets' census uses. Before the
+            # jitter snapped, `board_grid_step` was None on every jitter
+            # candidate of a lattice board while the baseline's was 0.3175 --
+            # so comparing a candidate's against the baseline's, in one
+            # document, is the whole issue in one line.
+            #
+            # Read `_step`, never `_occupancy`: infer_board_grid leaves
+            # occupancy at None on the DECLINING branch, which is exactly the
+            # branch the defect produces, so an assertion against it is
+            # vacuous or a TypeError. The number lives in `_reason`.
+            'board_grid_step': (m.get('board_grid') or {}).get('step'),
+            'board_grid_occupancy': (m.get('board_grid') or {}).get(
+                'occupancy'),
+            'board_grid_reason': (m.get('board_grid') or {}).get('reason')}
 
 
 # --------------------------------------------------------------------------

--- a/py_placer/placement/portfolio.py
+++ b/py_placer/placement/portfolio.py
@@ -201,8 +201,11 @@ def jitter_lattice(pcb_data, radius: float) -> Tuple[Optional[float], Dict]:
     No coarse-lattice guard beyond that, deliberately: `infer_board_grid` can
     only ever return 0.05 or 0.3175 (only those two rungs have no proper
     divisor in the ladder), and at radius 4.0 a 0.3175 lattice offers ~500
-    destinations of which `SAMPLE_ATTEMPTS` consumes one. Starvation is
-    unreachable here, unlike at the fanout repair site.
+    destinations, of which the sampler takes the first legal one --
+    `SAMPLE_ATTEMPTS` is the retry budget, not a count of destinations used.
+    Measured, the most boxed-in part on any 0.3175 board still has 9 legal
+    destinations. Starvation is unreachable here, unlike at the fanout repair
+    site.
     """
     from placement.board_grid import infer_board_grid
     ev = infer_board_grid(pcb_data)
@@ -212,7 +215,18 @@ def jitter_lattice(pcb_data, radius: float) -> Tuple[Optional[float], Dict]:
                              'which would leave the disc no destination but '
                              'the seed' % (step, radius))
         step = None
-    return step, dict(ev, source='inferred' if step is not None else 'none',
+    # `step` is WHAT WAS USED, in every branch. The raw inference moves to
+    # `inferred_step`, and it is kept rather than dropped because the radius
+    # guard's reason is only readable beside it.
+    #
+    # The first version left `ev['step']` at the inferred value while
+    # `resolved` went None, so a guarded run reported `{"step": 0.3175,
+    # "resolved": null}` -- three fields describing a snap that never happened.
+    # `infer_board_grid`'s own docstring promises `d['step']` as the terse
+    # form, so a consumer reading it would have been told the opposite of what
+    # happened, and `board_grid.describe(ev)` would have printed it.
+    return step, dict(ev, step=step, inferred_step=ev['step'],
+                      source='inferred' if step is not None else 'none',
                       resolved=step)
 
 
@@ -281,8 +295,23 @@ def perturb_jitter(state, refs: Sequence[str], rng: random.Random,
                     # is a number the operator reasons with ("10mm-class values
                     # destroy corridors"), not a soft target.
                     continue
-            x = round(part.x + dx, 4)
-            y = round(part.y + dy, 4)
+            if lattice is None:
+                # The continuous sampler's 0.1um raster, unchanged.
+                x = round(part.x + dx, 4)
+                y = round(part.y + dy, 4)
+            else:
+                # NOT rounded. `dx` is an exact lattice multiple, so
+                # `part.x + dx` sits on the seed's coset exactly -- and
+                # rounding the SUM to 4dp would knock it back off for any
+                # board whose origins carry 5 or 6 decimals, which KiCad
+                # writes for rotated and imported parts. Inert on today's
+                # corpus (checked: no tracked lattice board has an origin
+                # past 4dp, so the round was a no-op) and the whole point of
+                # the change on a board that does. `write_placed_output`
+                # formats the `(at ...)` node at %.6f, so the extra precision
+                # survives the write.
+                x = part.x + dx
+                y = part.y + dy
             if state.candidate_valid(ref, x, y, part.rot):
                 state.apply_move(ref, x, y, part.rot)
                 poses.append({'reference': ref, 'new_x': x, 'new_y': y,
@@ -610,18 +639,28 @@ def _quench_metrics(m: Dict) -> Dict:
             'pad_conflict_pairs': leg.get('pad_conflict_pairs', 0),
             'pad_shortfall': leg.get('pad_shortfall', 0.0),
             'hole_shortfall': leg.get('hole_shortfall', 0.0),
-            # #826: which lattice THIS candidate's quench saw, in the same
-            # three-scalar vocabulary check_pockets' census uses. Before the
-            # jitter snapped, `board_grid_step` was None on every jitter
-            # candidate of a lattice board while the baseline's was 0.3175 --
-            # so comparing a candidate's against the baseline's, in one
-            # document, is the whole issue in one line.
+            # #826: which lattice THIS candidate's quench actually USED, in
+            # the three-scalar vocabulary check_pockets' census already uses.
+            # Read off the board the quench PARSES -- the candidate's jittered
+            # seed board -- so before the jitter snapped it disagreed with the
+            # baseline's on ten of the eleven lattice boards (None against
+            # 0.3175 on splitflap). NOT on all eleven: glasgow_revC's jittered
+            # seed still resolved 0.05, which is the same reason it is the one
+            # survivor in the population table.
             #
-            # Read `_step`, never `_occupancy`: infer_board_grid leaves
-            # occupancy at None on the DECLINING branch, which is exactly the
-            # branch the defect produces, so an assertion against it is
-            # vacuous or a TypeError. The number lives in `_reason`.
-            'board_grid_step': (m.get('board_grid') or {}).get('step'),
+            # `resolved`, NOT `step`. `quench` infers a lattice and can then
+            # fall back (when it is coarser than `--step`), leaving `step` at
+            # the INFERENCE and putting what it used in `resolved`. Reading
+            # `step` reported a lattice the quench never used: measured, at
+            # `--step 0.25` on an imperial board the shipped candidate has no
+            # lattice at all and 0.120 occupancy, while this key said 0.3175.
+            # A disclosure that exists to prove the fix is not inert must not
+            # be able to report success on an inert run.
+            'board_grid_step': (m.get('board_grid') or {}).get('resolved'),
+            'board_grid_inferred': (m.get('board_grid') or {}).get('step'),
+            # Occupancy belongs to the INFERENCE, so it is None on the
+            # declining branch -- which is exactly the branch the defect
+            # produces. Assert on `_step`; the number lives in `_reason`.
             'board_grid_occupancy': (m.get('board_grid') or {}).get(
                 'occupancy'),
             'board_grid_reason': (m.get('board_grid') or {}).get('reason')}

--- a/py_placer/placement/quench.py
+++ b/py_placer/placement/quench.py
@@ -2510,7 +2510,14 @@ def _candidate_positions(part: _Part, max_disp: float, step: float,
         raster offsets are {0, +/-1.0, +/-2.0, ...} and 1.0 is not a multiple
         of 0.3175, so only the zero offset lands back on the board's lattice.
         Snapping to the lattice gives {0, +/-0.9525, +/-1.905, ...} and every
-        candidate stays on it, at 325 candidates against the raster's 317.
+        candidate stays on the seed's coset of it.
+
+    Reach is comparable but NOT uniformly better, and the honest bound is worth
+    stating: sweeping max_disp 0.5..19.5 at step=1.0 on a 0.3175 lattice, 12
+    values gain candidates, 17 tie and 10 LOSE -- worst 81 -> 69 at
+    max_disp=5.0, because an offset the raster admitted at exactly the cap can
+    snap UP past it. That is the price of the exact cap below, paid knowingly.
+    At the shipped default (10.0 / 1.0) it is 317 -> 325.
 
     `lattice` is the board's own pitch when one can be read off it and the
     `grid_step` raster otherwise, so a board with no inferable lattice keeps
@@ -2704,11 +2711,25 @@ def quench(pcb_data: PCBData, pcb_file: str,
                         keepouts=(intent_gate or {}).get('keepouts'),
                         intent_zones=(intent_gate or {}).get('zones'))
     # #708: the lattice candidate OFFSETS are multiples of. The board's own
-    # pitch when one can be read off it, the `grid_step` raster otherwise --
-    # which is exactly the granularity offsets have always had, so a board with
-    # no inferable lattice is unaffected by the choice. There is deliberately
-    # no flag: the fallback IS the off state and the board picks it.
+    # pitch when one can be read off it, the `grid_step` raster otherwise.
+    # There is deliberately no flag: the fallback IS the off state and the
+    # board picks it. Note the fallback restores the OFFSET GRANULARITY, not
+    # the old poses -- the seed-relative half applies either way, which is the
+    # bug fix.
     lattice, lattice_evidence = resolve_snap_lattice(pcb_data, grid_step)
+    # A lattice COARSER than the search step would quantize the search rather
+    # than merely phase it: `snap(0.1, 0.3175)` is 0.0, so at `--step 0.1` on an
+    # imperial board every +/-1 offset collapses onto the zero offset and
+    # `_group_offsets` discards it as "no move at all". The finest rung of the
+    # search would vanish silently. `--step` is a plain float on three CLIs with
+    # nothing relating it to the board, so the guard lives here.
+    if lattice > step + 1e-9:
+        lattice_evidence = dict(lattice_evidence, source='grid_step',
+                                resolved=grid_step,
+                                reason='inferred %g mm is coarser than --step '
+                                       '%g mm, which would quantize the search'
+                                       % (lattice, step))
+        lattice = grid_step
     print(describe_lattice(lattice_evidence))
 
     # Unchanged, and now conservative rather than exact: the offsets are

--- a/py_placer/placement/quench.py
+++ b/py_placer/placement/quench.py
@@ -45,6 +45,8 @@ from connectivity import compute_mst_edges
 from placement.parser import (courtyard_for_side, extract_courtyard_sides,
                               extract_locked_refs, warn_missing_courtyards)
 from placement.utility import compute_footprint_bbox_local, snap_to_grid
+from placement.board_grid import (describe as describe_lattice,
+                                  resolve_snap_lattice)
 from placement import legality
 from placement.legality import (CONTAINER_RATIO, CONTAINMENT_FRAC,
                                 BoardOutlineGate, containment_frac,
@@ -2427,7 +2429,7 @@ class QuenchState:
             self._neighbors[ref] = lst
 
 
-def _group_offsets(state, refs, max_disp: float, step: float, grid_step: float):
+def _group_offsets(state, refs, max_disp: float, step: float, lattice: float):
     """Rigid (dx, dy) offsets a whole block may take (#459).
 
     The block translates as one body, so a single offset applies to every
@@ -2456,43 +2458,78 @@ def _group_offsets(state, refs, max_disp: float, step: float, grid_step: float):
         for iy in range(-n, n + 1):
             if ix == 0 and iy == 0:
                 continue
-            dx, dy = ix * step, iy * step
-            if math.hypot(dx, dy) > max_disp + 1e-9:
+            # Snap the OFFSET, so the block stays rigid: snapping each member
+            # independently would shear it by up to a lattice step. Snapping to
+            # the BOARD's lattice rather than the raster is #708: an offset
+            # that is a whole number of the designer's grid units carries every
+            # member from an on-lattice pose to another one.
+            sdx = snap_to_grid(ix * step, lattice)
+            sdy = snap_to_grid(iy * step, lattice)
+            if math.hypot(sdx, sdy) > max_disp + 1e-9:
                 continue
+            if (sdx, sdy) in seen or (sdx == 0.0 and sdy == 0.0):
+                continue
+            # Probe the pose that will actually be APPLIED. This used to snap
+            # the ABSOLUTE p.x + dx while the emitted offset was snap(dx), so
+            # the per-member seed cap -- the thing this docstring says keeps
+            # build_neighbor_lists' pruning exact and edges_near's cache valid
+            # -- was tested against a pose the block never takes. The gap was
+            # under 0.07mm at the raster and is under a lattice step now, but
+            # it was always the wrong quantity.
             ok = True
             for ref in refs:
                 p = state.parts[ref]
-                nx = snap_to_grid(p.x + dx, grid_step)
-                ny = snap_to_grid(p.y + dy, grid_step)
-                if math.hypot(nx - p.seed_x, ny - p.seed_y) > max_disp + 1e-9:
+                if math.hypot(p.x + sdx - p.seed_x,
+                              p.y + sdy - p.seed_y) > max_disp + 1e-9:
                     ok = False
                     break
             if not ok:
-                continue
-            # Snap the OFFSET, so the block stays rigid: snapping each member
-            # independently would shear it by up to a grid step.
-            sdx = snap_to_grid(dx, grid_step)
-            sdy = snap_to_grid(dy, grid_step)
-            if (sdx, sdy) in seen or (sdx == 0.0 and sdy == 0.0):
                 continue
             seen.add((sdx, sdy))
             yield sdx, sdy
 
 
 def _candidate_positions(part: _Part, max_disp: float, step: float,
-                         grid_step: float):
-    """Grid of candidate centers within max_disp of the seed position."""
+                         lattice: float):
+    """Grid of candidate centers within max_disp of the seed position.
+
+    The snap is on the OFFSET, not on the absolute position, and that
+    distinction is the whole of #708. `seed_x + ix*step` already carries
+    whatever phase the designer laid the board out on; snapping the SUM to a
+    lattice through board ORIGIN discards it, because seed_x is not generally a
+    multiple of anything. Snapping the offset instead inherits the seed's
+    phase, so a part on a 0.3175mm (12.5 mil) lattice is offered only poses on
+    that same lattice.
+
+    Two measurements behind this, both in `tests/measure_708_lattice.py`:
+
+      * the old absolute snap removed ZERO candidates at every step the tool
+        ships -- it was a pure translation of the whole set by the seed's
+        residue -- so nothing is lost by dropping it;
+      * snapping the offset to the RASTER would not be enough. At step=1.0 the
+        raster offsets are {0, +/-1.0, +/-2.0, ...} and 1.0 is not a multiple
+        of 0.3175, so only the zero offset lands back on the board's lattice.
+        Snapping to the lattice gives {0, +/-0.9525, +/-1.905, ...} and every
+        candidate stays on it, at 325 candidates against the raster's 317.
+
+    `lattice` is the board's own pitch when one can be read off it and the
+    `grid_step` raster otherwise, so a board with no inferable lattice keeps
+    exactly the offsets it has always had (see `placement/board_grid.py`).
+
+    The radius test runs AFTER the snap, so `max_disp` is an exact cap rather
+    than one overshot by up to lattice*sqrt(2)/2.
+    """
     seen = set()
     out = []
     n = int(max_disp / step)
     for ix in range(-n, n + 1):
         for iy in range(-n, n + 1):
-            cx = part.seed_x + ix * step
-            cy = part.seed_y + iy * step
-            if math.hypot(cx - part.seed_x, cy - part.seed_y) > max_disp + 1e-9:
+            dx = snap_to_grid(ix * step, lattice)
+            dy = snap_to_grid(iy * step, lattice)
+            if math.hypot(dx, dy) > max_disp + 1e-9:
                 continue
-            cx = snap_to_grid(cx, grid_step)
-            cy = snap_to_grid(cy, grid_step)
+            cx = part.seed_x + dx
+            cy = part.seed_y + dy
             key = (round(cx, 4), round(cy, 4))
             if key not in seen:
                 seen.add(key)
@@ -2666,6 +2703,18 @@ def quench(pcb_data: PCBData, pcb_file: str,
                         corridor_specs=corridor_specs,
                         keepouts=(intent_gate or {}).get('keepouts'),
                         intent_zones=(intent_gate or {}).get('zones'))
+    # #708: the lattice candidate OFFSETS are multiples of. The board's own
+    # pitch when one can be read off it, the `grid_step` raster otherwise --
+    # which is exactly the granularity offsets have always had, so a board with
+    # no inferable lattice is unaffected by the choice. There is deliberately
+    # no flag: the fallback IS the off state and the board picks it.
+    lattice, lattice_evidence = resolve_snap_lattice(pcb_data, grid_step)
+    print(describe_lattice(lattice_evidence))
+
+    # Unchanged, and now conservative rather than exact: the offsets are
+    # snapped BEFORE the radius test, so a candidate is within max_displacement
+    # of its seed rather than up to a snap diagonal past it. The old
+    # `+ grid_step` slack covered that overshoot and now simply exceeds it.
     state.build_neighbor_lists(max_displacement + grid_step)
 
     before = state.total_cost()
@@ -2745,7 +2794,7 @@ def quench(pcb_data: PCBData, pcb_file: str,
             base_cost = eval_group(0.0, 0.0)
             best = (base_cost, 0.0, 0.0)
             for ddx, ddy in _group_offsets(state, refs, max_displacement, step,
-                                           grid_step):
+                                           lattice):
                 if not state.group_move_valid(refs, ddx, ddy):
                     continue
                 c = eval_group(ddx, ddy)
@@ -2805,7 +2854,7 @@ def quench(pcb_data: PCBData, pcb_file: str,
 
             best = (current_cost, part.x, part.y, part.rot)
             for cx, cy in _candidate_positions(part, max_displacement, step,
-                                               grid_step):
+                                               lattice):
                 for rot in rotations:
                     if (cx, cy, rot) == (part.x, part.y, part.rot):
                         continue
@@ -3002,6 +3051,13 @@ def quench(pcb_data: PCBData, pcb_file: str,
         metrics_out['before'] = dict(before)
         metrics_out['after'] = dict(after)
         metrics_out['legality'] = state.legality_metrics()
+        # #708: which lattice the candidate offsets were multiples of, and how
+        # that was decided. `source` distinguishes "the board declared one"
+        # from "it did not and we used the raster" -- without it, a run on a
+        # board with no lattice and a run where the inference was never wired
+        # report the same thing.
+        metrics_out['board_grid'] = dict(lattice_evidence,
+                                         resolved=lattice)
         # #702: what the declared-intent gate actually DID. Always present when
         # a gate was built, and `rejected: 0` is a real answer -- without this
         # key, "the gate refused nothing" and "the gate was never wired" are

--- a/py_placer/placement/reseat.py
+++ b/py_placer/placement/reseat.py
@@ -156,8 +156,9 @@ def slot_pool(state, cluster, ring_step=DEFAULT_RING_STEP_MM,
 
     Generated on rings around the anchor's relevant pins out to `radius_mm`, so
     membership in the pool IS the constraint -- there is nothing to gate and no
-    proximity term to weight. Snapped to `grid_step` and de-duplicated in a
-    deterministic order.
+    proximity term to weight. Snapped to `grid_step` FROM THE ANCHOR (#708, so
+    the pool inherits the anchor's phase rather than a lattice through board
+    origin) and de-duplicated in a deterministic order.
     """
     seen = set()
     out: List[Tuple[float, float, float]] = []
@@ -180,12 +181,23 @@ def slot_pool(state, cluster, ring_step=DEFAULT_RING_STEP_MM,
     ax, ay = anchor_part.x, anchor_part.y
 
     def add(x, y, rot):
-        sx = ax + snap_to_grid(x - ax, grid_step)
-        sy = ay + snap_to_grid(y - ay, grid_step)
-        key = (round(sx / grid_step), round(sy / grid_step), round(rot, 3))
+        # The KEY counts lattice steps FROM THE ANCHOR, matching the value.
+        # Keying `round(sx / grid_step)` on the absolute pose would not be
+        # injective once the emitted pose moved to an anchor-relative lattice:
+        # when `ax / grid_step` has a fractional part of exactly 0.5, banker's
+        # rounding sends two adjacent steps to one key (round(1.5) == round(2.5)
+        # == 2) and the second slot is silently dropped. Measured on
+        # orangecrab_ext_pll U4, 325 of 3334 distinct poses lost; 327 of 3166
+        # footprint coordinates across the tracked corpus sit at a colliding
+        # phase. Invisible to a length check, because MAX_POSITIONS truncates
+        # the pool afterwards -- only the CONTENTS change, near slots being
+        # replaced by farther ones.
+        kx = round((x - ax) / grid_step)
+        ky = round((y - ay) / grid_step)
+        key = (kx, ky, round(rot, 3))
         if key not in seen:
             seen.add(key)
-            out.append((sx, sy, rot))
+            out.append((ax + kx * grid_step, ay + ky * grid_step, rot))
 
     # Snapping to the grid moves a point by up to half a cell on each axis, so
     # a ring generated AT the radius lands outside it. Shrink by the snap
@@ -470,30 +482,39 @@ def reseat_cluster(state, cluster, *, ring_step=DEFAULT_RING_STEP_MM,
         # overrides the members' pads on the SCORED nets, but `other_aw` is
         # built from the live board, so the move's effect on a member's
         # UNSCORED nets is not in it. A decap on GND and one signal has its GND
-        # airwire priced at the pose it is leaving. Measured on splitflap's
-        # tether:B0 (C60, nets 1 and 278, only 278 scored): predicted 1214.28,
-        # actual 1274.28 -- six crossings, 60.0 of cost, all of it invisible.
-        # So seat it and ASK, rather than predict and hope. The contract this
-        # restores is the one `test_reseat` states: acceptance is on the exact
-        # objective, re-evaluated with all members in place.
+        # airwire priced at the pose it is leaving. Measured on ulx3s's
+        # tether:B0 (C60, on nets 1 `GND` and 278 `PWRBTn`, only 278 scored):
+        # predicted 1214.28, actual 1274.28. That gap is 60.0 at the fixture's
+        # `crossing_penalty=30.0`, i.e. TWO crossings, and it was invisible to
+        # the decision. So seat it and ASK, rather than predict and hope. The
+        # contract this restores is the one `test_reseat` states: acceptance is
+        # on the exact objective, re-evaluated with all members in place.
+        #
+        # try/finally because a raise between the apply and the revert would
+        # otherwise leave the moves applied -- and under `apply=False` that
+        # silently mutates a state the caller asked not to be touched.
         prior = {m: (state.parts[m].x, state.parts[m].y, state.parts[m].rot)
                  for m in moved}
-        for m in moved:
-            state.apply_move(m, *poses[m])
-        seated = cluster_cost(state, cluster, involved=involved)
-        if seated < before - EPS_IMPROVE:
-            res.accepted = True
+        keep = False
+        try:
+            for m in moved:
+                state.apply_move(m, *poses[m])
+            seated = cluster_cost(state, cluster, involved=involved)
+            # `after` is ALWAYS the measured cost from here on, never the
+            # prediction, so `to_dict()['gain']` means one thing on every row
+            # that reached this branch.
             res.after = seated
-            if not apply:
+            if seated < before - EPS_IMPROVE:
+                res.accepted = True
+                keep = apply
+            else:
+                res.reason = ('the seated cost is worse than the prediction '
+                              '(%.4f vs %.4f): the members carry nets this '
+                              'cluster does not score' % (seated, after))
+        finally:
+            if not keep:
                 for m in moved:
                     state.apply_move(m, *prior[m])
-        else:
-            for m in moved:
-                state.apply_move(m, *prior[m])
-            res.after = seated
-            res.reason = ('the seated cost is worse than the prediction '
-                          '(%.4f vs %.4f): the members carry nets this '
-                          'cluster does not score' % (seated, after))
     else:
         res.reason = ('no improvement on the exact objective'
                       if moved else 'assignment returned the incumbent')

--- a/py_placer/placement/reseat.py
+++ b/py_placer/placement/reseat.py
@@ -60,6 +60,8 @@ import math
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Sequence, Set, Tuple
 
+from placement.utility import snap_to_grid
+
 # Slot lattice. Deliberately coarse: this is a RE-SEAT, choosing which side of
 # an anchor a part sits on, not a sub-grid polish -- the quench does that after.
 DEFAULT_RING_STEP_MM = 0.5
@@ -160,12 +162,30 @@ def slot_pool(state, cluster, ring_step=DEFAULT_RING_STEP_MM,
     seen = set()
     out: List[Tuple[float, float, float]] = []
 
+    # #708: snap the OFFSET FROM THE ANCHOR, not the absolute position, and
+    # through the shared primitive rather than a second spelling of it.
+    #
+    # The phase to preserve is the ANCHOR's, not the pad's: these rings are
+    # generated around `_anchor_pin_points`, and a pad sits at its footprint
+    # origin plus a package pitch (0.5mm, 0.65mm) that is on no board lattice.
+    # The anchor's own origin is what the designer placed, so an offset that is
+    # a whole number of raster units from it lands a member on the same pitch
+    # the anchor sits on. Snapping the absolute point instead quantized to a
+    # lattice through board origin and threw that away.
+    #
+    # The RASTER, not the board's inferred lattice: like the fanout cap repair,
+    # this pool is a proximity constraint satisfied by construction, and a
+    # coarse lattice would both thin it and inflate the `snap` shrink below.
+    anchor_part = state.parts[cluster.anchor]
+    ax, ay = anchor_part.x, anchor_part.y
+
     def add(x, y, rot):
-        key = (round(x / grid_step), round(y / grid_step), round(rot, 3))
+        sx = ax + snap_to_grid(x - ax, grid_step)
+        sy = ay + snap_to_grid(y - ay, grid_step)
+        key = (round(sx / grid_step), round(sy / grid_step), round(rot, 3))
         if key not in seen:
             seen.add(key)
-            out.append((round(x / grid_step) * grid_step,
-                        round(y / grid_step) * grid_step, rot))
+            out.append((sx, sy, rot))
 
     # Snapping to the grid moves a point by up to half a cell on each axis, so
     # a ring generated AT the radius lands outside it. Shrink by the snap
@@ -446,10 +466,34 @@ def reseat_cluster(state, cluster, *, ring_step=DEFAULT_RING_STEP_MM,
     res = ReseatResult(cluster=cluster.name, moved=moved, before=before,
                        after=after, slots=len(slots), repairs=repairs)
     if after < before - EPS_IMPROVE and moved:
-        res.accepted = True
-        if apply:
+        # `after` above is a PREDICTION, and it is blind in one direction: it
+        # overrides the members' pads on the SCORED nets, but `other_aw` is
+        # built from the live board, so the move's effect on a member's
+        # UNSCORED nets is not in it. A decap on GND and one signal has its GND
+        # airwire priced at the pose it is leaving. Measured on splitflap's
+        # tether:B0 (C60, nets 1 and 278, only 278 scored): predicted 1214.28,
+        # actual 1274.28 -- six crossings, 60.0 of cost, all of it invisible.
+        # So seat it and ASK, rather than predict and hope. The contract this
+        # restores is the one `test_reseat` states: acceptance is on the exact
+        # objective, re-evaluated with all members in place.
+        prior = {m: (state.parts[m].x, state.parts[m].y, state.parts[m].rot)
+                 for m in moved}
+        for m in moved:
+            state.apply_move(m, *poses[m])
+        seated = cluster_cost(state, cluster, involved=involved)
+        if seated < before - EPS_IMPROVE:
+            res.accepted = True
+            res.after = seated
+            if not apply:
+                for m in moved:
+                    state.apply_move(m, *prior[m])
+        else:
             for m in moved:
-                state.apply_move(m, *poses[m])
+                state.apply_move(m, *prior[m])
+            res.after = seated
+            res.reason = ('the seated cost is worse than the prediction '
+                          '(%.4f vs %.4f): the members carry nets this '
+                          'cluster does not score' % (seated, after))
     else:
         res.reason = ('no improvement on the exact objective'
                       if moved else 'assignment returned the incumbent')

--- a/py_tools/check_pockets.py
+++ b/py_tools/check_pockets.py
@@ -709,6 +709,19 @@ def pocket_census(pcb, board_path, *, nets=('*',), bin_mm=2.0, top=8,
         doc['cold_area_mm2'] = None
         doc['cold_area_frac'] = None
         doc['skipped'] = 'cold census disabled'
+    # #708: the lattice this board was laid out on, if it declares one. Read
+    # off the same function the placer resolves its candidate offsets with, so
+    # the census cannot report a pitch the engine does not use.
+    try:
+        from placement.board_grid import infer_board_grid
+        _bg = infer_board_grid(pcb)
+        doc['board_grid'] = {'step': _bg['step'], 'occupancy': _bg['occupancy'],
+                             'n_parts': _bg['n_parts'],
+                             'ties': list(_bg['ties']),
+                             'reason': _bg['reason']}
+    except Exception:                                           # noqa: BLE001
+        doc['board_grid'] = None
+
     doc['reseat_target'] = _reseat_target(doc, bounds) if cold else None
     return doc, hot
 
@@ -811,6 +824,13 @@ def census_scalars(doc):
         'centroid_offset_frac_y': off[1],
         'centroid_count_control_frac': ctl[0],
         'outline_source': (doc.get('outline') or {}).get('source'),
+        # #708. `board_grid_step` is None for a board that declares no lattice,
+        # which is a real answer and not a missing one -- `board_grid_reason`
+        # says which test it failed, so "no lattice" and "never measured" stay
+        # distinguishable in the summary line alone.
+        'board_grid_step': (doc.get('board_grid') or {}).get('step'),
+        'board_grid_occupancy': (doc.get('board_grid') or {}).get('occupancy'),
+        'board_grid_reason': (doc.get('board_grid') or {}).get('reason'),
     }
     return {k: v for k, v in out.items()
             if not (isinstance(v, float) and not math.isfinite(v))}

--- a/py_tools/check_pockets.py
+++ b/py_tools/check_pockets.py
@@ -719,8 +719,12 @@ def pocket_census(pcb, board_path, *, nets=('*',), bin_mm=2.0, top=8,
                              'n_parts': _bg['n_parts'],
                              'ties': list(_bg['ties']),
                              'reason': _bg['reason']}
-    except Exception:                                           # noqa: BLE001
-        doc['board_grid'] = None
+    except ImportError as exc:
+        # Named, not swallowed: a missing module and a board that declares no
+        # lattice must not produce the same shape, which is the whole point of
+        # carrying `reason` beside `step`.
+        doc['board_grid'] = {'step': None, 'occupancy': None, 'n_parts': None,
+                             'ties': [], 'reason': 'unavailable: %s' % exc}
 
     doc['reseat_target'] = _reseat_target(doc, bounds) if cold else None
     return doc, hot

--- a/tests/measure_708_lattice.py
+++ b/tests/measure_708_lattice.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""What #708 actually is, measured rather than argued.
+
+The issue says the quench's 0.1mm grid step is "incommensurate with imperial
+board grids" and proposes inferring the board's pitch from a ladder. Two of the
+three tables below say the mechanism is something else, and the third says the
+proposed cure would have been bolted onto a line that buys nothing:
+
+  A. THE DAMAGE IS REAL. One quench pass takes splitflap_driver from 59 of 65
+     parts on its own 0.3175mm lattice to a small fraction of that. This is the
+     claim the issue makes and it holds.
+
+  B. THE SNAP REMOVES NO CANDIDATES. `_candidate_positions` builds candidates as
+     `seed + ix*step` and then snaps the ABSOLUTE result. Every shipped `step`
+     (1.0 place_optimize, 0.5 converge/place_route_loop, 0.2
+     place_fanout_clearance) is a multiple of `grid_step` 0.1, so the snap is a
+     pure translation of the whole candidate set by the seed's residue -- same
+     count, same shape, shifted off the board's lattice. It is not a search
+     device. `_group_offsets` already snaps the OFFSET, and at those same steps
+     that snap is a literal no-op, which is the existence proof that the delta
+     form is the correct one.
+
+  C. THE LADDER IS DEGENERATE. Occupancy is monotone non-increasing along
+     divisibility chains, so ties are structural rather than accidental, and the
+     argmax the issue proposes is undefined exactly where it matters. The table
+     also refutes the issue's claim that kit-dev-coldfire-xilinx_5213 "shows the
+     same signature at 1.27mm": 1.27 scores far below its own maximum, and that
+     maximum is below any floor that admits a real board.
+
+Boards are DE-DUPLICATED by their footprint-position multiset before the corpus
+table is summarised, because several tracked files are the same placement --
+counting one 8-part fixture six times is how a majority gets manufactured.
+
+NOT named `test_*.py`: `tests/run_all.py` does not collect it, because table A
+runs real quench passes (minutes) and it asserts nothing. It is a measurement,
+and its numbers are quoted in the #708 PR and in placement/README.md.
+
+    python3 -X utf8 tests/measure_708_lattice.py            # all three tables
+    python3 -X utf8 tests/measure_708_lattice.py --no-quench # B and C only
+"""
+from __future__ import annotations
+
+import argparse
+import contextlib
+import hashlib
+import io
+import math
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for _sub in ('py_router', 'py_placer', 'py_tools'):
+    sys.path.insert(0, os.path.join(ROOT, _sub))
+
+import run_utils  # noqa: E402
+from kicad_parser import parse_kicad_pcb  # noqa: E402
+from placement.utility import snap_to_grid  # noqa: E402
+
+# The ladder issue #708 proposes. Kept verbatim so the table answers the
+# issue's own question rather than a reshaped one.
+LADDER = (0.05, 0.1, 0.2, 0.25, 0.3175, 0.5, 0.635, 1.0, 1.27, 2.54)
+TOL_MM = 0.001          # 1 um, the issue's own tolerance
+
+# The steps that actually ship, and the tool each comes from. `grid_step` is
+# 0.1 (routing_defaults.GRID_STEP) at every one of them.
+SHIPPED_STEPS = ((10.0, 1.0, 'place_optimize --step'),
+                 (3.0, 1.0, 'place_optimize --max-displacement 3'),
+                 (2.0, 0.5, 'converge poses'),
+                 (1.0, 0.2, 'place_fanout_clearance'),
+                 (3.0, 0.25, 'a step that is NOT a multiple of grid_step'))
+
+
+def occupancy(vals, step, tol=TOL_MM):
+    """Fraction of `vals` within `tol` of a multiple of `step`."""
+    if not vals or step <= 0:
+        return 0.0
+    return sum(1 for v in vals
+               if abs(v / step - round(v / step)) * step <= tol) / len(vals)
+
+
+def coords(pcb):
+    """Footprint ORIGINS, x and y pooled.
+
+    Origins, not pads: a pad sits at origin + a package pitch (0.5mm, 0.65mm)
+    that is on no board lattice, so a pad sample measures the footprint library
+    rather than the layout.
+    """
+    fps = [f for f in pcb.footprints.values()]
+    xs = [f.x for f in fps if math.isfinite(f.x)]
+    ys = [f.y for f in fps if math.isfinite(f.y)]
+    return xs + ys, len(fps)
+
+
+def profile(vals):
+    return {s: occupancy(vals, s) for s in LADDER}
+
+
+def finest_within(prof, slack=0.02):
+    """The FINEST rung within `slack` of the maximum -- not the argmax.
+
+    The ladder contains divisibility chains (0.3175 | 0.635 | 1.27 | 2.54 and
+    0.05 | 0.1 | 0.2), and occupancy is monotone non-increasing along one: if
+    d divides s then every on-s point is on-d, so occ(d) >= occ(s). Ties are
+    therefore structural, and an argmax has no defined answer on them.
+    """
+    best = max(prof.values())
+    for s in LADDER:
+        if prof[s] >= best - slack:
+            return s, best
+    return None, best
+
+
+def pose_hash(pcb):
+    """Identify a PLACEMENT, so the same layout in five files counts once."""
+    fps = sorted((round(f.x, 6), round(f.y, 6))
+                 for f in pcb.footprints.values())
+    return hashlib.sha1(repr(fps).encode()).hexdigest()[:12]
+
+
+# --------------------------------------------------------------- table B
+
+def candidate_sets(seed, max_disp, step, grid_step):
+    """(snapped, unsnapped) candidate lists, exactly as _candidate_positions
+    builds them -- absolute snap, deduped on the same rounded key."""
+    out = []
+    for do_snap in (True, False):
+        seen, got = set(), []
+        n = int(max_disp / step)
+        for ix in range(-n, n + 1):
+            for iy in range(-n, n + 1):
+                cx = seed[0] + ix * step
+                cy = seed[1] + iy * step
+                if math.hypot(cx - seed[0], cy - seed[1]) > max_disp + 1e-9:
+                    continue
+                if do_snap:
+                    cx = snap_to_grid(cx, grid_step)
+                    cy = snap_to_grid(cy, grid_step)
+                key = (round(cx, 4), round(cy, 4))
+                if key not in seen:
+                    seen.add(key)
+                    got.append((cx, cy))
+        out.append(got)
+    return out[0], out[1]
+
+
+def table_b(grid_step=0.1):
+    # An off-raster seed, so the residue the snap discards is non-zero.
+    # 131.4450 is interf_u BUS1: exactly 207 * 0.635, a clean 25-mil pose.
+    seed = (131.4450, 138.4300)
+    print('B. What the ABSOLUTE snap removes, at every shipped step '
+          '(grid_step=%.2f)' % grid_step)
+    print('   seed = (%.4f, %.4f) = (%.1f, %.1f) x 0.635, i.e. ON a 25-mil '
+          'lattice' % (seed[0], seed[1], seed[0] / 0.635, seed[1] / 0.635))
+    print()
+    print('   %-9s %-7s %9s %11s %7s  %s'
+          % ('max_disp', 'step', 'snapped', 'unsnapped', 'lost', 'shape'))
+    for max_disp, step, who in SHIPPED_STEPS:
+        snapped, plain = candidate_sets(seed, max_disp, step, grid_step)
+        off = (round(snapped[0][0] - plain[0][0], 9),
+               round(snapped[0][1] - plain[0][1], 9))
+        pure = (len(snapped) == len(plain) and
+                all(abs((a - p) - off[0]) < 1e-9 and abs((b - q) - off[1]) < 1e-9
+                    for (a, b), (p, q) in zip(snapped, plain)))
+        shape = ('pure translation by %s' % (off,)) if pure else 'reshaped'
+        print('   %-9s %-7s %9d %11d %7d  %s   (%s)'
+              % (max_disp, step, len(snapped), len(plain),
+                 len(plain) - len(snapped), shape, who))
+    print()
+    print('   _group_offsets snaps the OFFSET. max |snap(ix*step) - ix*step|:')
+    for step in sorted({s for _md, s, _w in SHIPPED_STEPS}):
+        m = max(abs(snap_to_grid(ix * step, grid_step) - ix * step)
+                for ix in range(-40, 41))
+        verdict = 'NO-OP' if m == 0.0 else 'perturbs by up to %.3f' % m
+        print('     step=%-6s %.3e   %s' % (step, m, verdict))
+    print()
+    print('   Reading: at every step the tool actually ships, the absolute snap')
+    print('   loses zero candidates and merely translates the set off the')
+    print('   seed\'s own lattice. The delta snap loses nothing and preserves')
+    print('   it. That is the whole fix.')
+    print()
+
+
+# --------------------------------------------------------------- table C
+
+def table_c(boards):
+    rows = []
+    seen_poses = {}
+    for path in boards:
+        try:
+            pcb = parse_kicad_pcb(path)
+        except Exception as exc:                     # noqa: BLE001
+            print('   %-34s PARSE FAILED: %s' % (os.path.basename(path), exc))
+            continue
+        vals, n = coords(pcb)
+        if not vals:
+            continue
+        h = pose_hash(pcb)
+        rows.append((os.path.basename(path).replace('.kicad_pcb', ''),
+                     n, profile(vals), h))
+        seen_poses.setdefault(h, []).append(
+            os.path.basename(path).replace('.kicad_pcb', ''))
+
+    print('C. Ladder occupancy per board (footprint origins, x and y pooled, '
+          '%g um tolerance)' % (TOL_MM * 1000))
+    print()
+    hdr = '   %-32s %4s ' % ('board', 'n') + ' '.join('%6s' % s for s in LADDER)
+    print(hdr + '   %8s %s' % ('pick', 'ties'))
+    for name, n, prof, _h in rows:
+        pick, best = finest_within(prof)
+        ties = [s for s in LADDER if prof[s] >= best - 0.02]
+        print('   %-32s %4d ' % (name, n)
+              + ' '.join('%6.2f' % prof[s] for s in LADDER)
+              + '   %8s %s' % (pick, ','.join(str(t) for t in ties)
+                               if len(ties) > 1 else '-'))
+    print()
+    dupes = {h: names for h, names in seen_poses.items() if len(names) > 1}
+    print('   %d files, %d DISTINCT placements. Files sharing a placement:'
+          % (len(rows), len(seen_poses)))
+    for _h, names in sorted(dupes.items(), key=lambda kv: -len(kv[1])):
+        print('     %s' % ', '.join(sorted(names)))
+    if not dupes:
+        print('     (none)')
+    print()
+    print('   Reading: every board whose best rung is coarse ties with that')
+    print('   rung\'s divisors, so the argmax #708 proposes is undefined there.')
+    print('   Any occupancy floor must also survive de-duplication -- the')
+    print('   duplicate groups above are one placement each, not one vote each.')
+    print()
+    return rows
+
+
+# --------------------------------------------------------------- table A
+
+def table_a(rows, names, max_displacement=3.0):
+    """Quench each named board and report how many parts left its lattice."""
+    from placement.quench import quench
+    print('A. What one quench pass does to the board\'s own lattice')
+    print()
+    print('   %-32s %6s %8s  %-22s %-22s %s'
+          % ('board', 'n', 'lattice', 'on-lattice BEFORE',
+             'on-lattice AFTER', 'moved'))
+    by_name = {r[0]: r for r in rows}
+    for name in names:
+        row = by_name.get(name)
+        if row is None:
+            print('   %-32s SKIP (not in corpus)' % name)
+            continue
+        _n_name, n, prof, _h = row
+        lattice, _best = finest_within(prof)
+        path = os.path.join(ROOT, 'kicad_files', name + '.kicad_pcb')
+        pcb = parse_kicad_pcb(path)
+        before_vals, _ = coords(pcb)
+        occ_before = occupancy(before_vals, lattice)
+        # The engine narrates unconditionally; swallow it so the table is a
+        # table. The run itself is untouched.
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            placements = quench(pcb, path, max_displacement=max_displacement,
+                                step=1.0, grid_step=0.1, clearance=0.2,
+                                board_edge_clearance=0.55, max_passes=4,
+                                verbose=False)
+        moved = {p['reference']: (p['new_x'], p['new_y'])
+                 for p in (placements or [])}
+        after = []
+        for ref, fp in pcb.footprints.items():
+            x, y = moved.get(ref, (fp.x, fp.y))
+            after.extend([x, y])
+        occ_after = occupancy(after, lattice)
+        print('   %-32s %6d %8s  %6.3f (%3d/%3d)        %6.3f (%3d/%3d)        %d'
+              % (name, n, lattice,
+                 occ_before, round(occ_before * len(before_vals)),
+                 len(before_vals),
+                 occ_after, round(occ_after * len(after)), len(after),
+                 len(moved)))
+    print()
+    print('   Counted over x and y separately, so the denominator is 2n.')
+    print()
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--no-quench', action='store_true',
+                    help='skip table A (the slow one)')
+    ap.add_argument('--boards', nargs='*',
+                    default=['splitflap_driver', 'flat_hierarchy', 'sonde_u'],
+                    help='boards for table A (default: three with a real '
+                         'non-0.1 lattice)')
+    args = ap.parse_args()
+
+    boards = run_utils.corpus_boards()
+    if not boards:
+        print('SKIP: git could not enumerate the corpus '
+              '(tarball export, or no git on PATH)')
+        return 0
+
+    table_b()
+    rows = table_c(boards)
+    if not args.no_quench:
+        table_a(rows, args.boards)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/measure_708_lattice.py
+++ b/tests/measure_708_lattice.py
@@ -6,9 +6,11 @@ board grids" and proposes inferring the board's pitch from a ladder. Two of the
 three tables below say the mechanism is something else, and the third says the
 proposed cure would have been bolted onto a line that buys nothing:
 
-  A. THE DAMAGE IS REAL. One quench pass takes splitflap_driver from 59 of 65
-     parts on its own 0.3175mm lattice to a small fraction of that. This is the
-     claim the issue makes and it holds.
+  A. THE DAMAGE IS REAL. One quench pass takes splitflap_driver from 0.923 of
+     its footprint COORDINATES on its own 0.3175mm lattice to 0.269. (#708
+     states the same measurement per PART, 59 of 65 = 0.908; this file counts
+     x and y separately throughout, so its denominator is 2n. Both are true and
+     the tables below are all coordinates.)
 
   B. THE SNAP REMOVES NO CANDIDATES. `_candidate_positions` builds candidates as
      `seed + ix*step` and then snaps the ABSOLUTE result. Every shipped `step`

--- a/tests/measure_826_jitter_lattice.py
+++ b/tests/measure_826_jitter_lattice.py
@@ -31,9 +31,11 @@ measurement of something else.
 
 Occupancy after the jitter is read the way `board_grid` reads it -- over EVERY
 footprint origin, not just the free ones -- by overlaying the returned poses on
-the parsed board. `writer._fmt_mm` emits `%.6f`, so a 4-dp jitter value
-round-trips through a written seed board verbatim and the in-memory overlay is
-exact rather than approximate.
+the parsed board. `write_placed_output` formats the `(at ...)` node
+with `%.6f`, so a jitter value round-trips through a written seed board
+verbatim and the in-memory overlay is exact rather than approximate (checked
+end to end on splitflap_driver: overlay and written board both read 0.3175 at
+0.923).
 
 NOT named `test_*.py`: `tests/run_all.py` does not collect it. It asserts
 nothing and takes minutes.
@@ -119,12 +121,17 @@ def best_after(pcb, poses):
 
 
 def jitter(state, refs, rng, radius, lattice=None, attempts=20):
-    """`perturb_jitter`, with the proposed snap. Counts why a draw was refused.
+    """The engine's sampler, and a count of why each draw was refused.
 
-    Kept here rather than imported so table C can measure the SHIPPED sampler
-    and the PROPOSED one against the same rng stream in one run, before the
-    engine changes. It is a transcription of `portfolio.perturb_jitter`; the
-    arms in `tests/test_826_portfolio_lattice.py` test the real one.
+    The loop below duplicates `portfolio.perturb_jitter` because the refusal
+    counts are not observable from outside it -- the engine returns poses, not
+    the reasons it rejected draws, and the accept test is `candidate_valid`,
+    so a replay that stopped at the geometric checks would miscount.
+
+    A duplicate that can drift is worse than no measurement, so this one is
+    CHECKED: `verify_against_engine` below runs the real `perturb_jitter` on
+    the same rng stream and refuses to report anything if the poses differ.
+    That is the guard the copy has to earn.
     """
     poses, n_zero, n_out = [], 0, 0
     for ref in refs:
@@ -146,13 +153,35 @@ def jitter(state, refs, rng, radius, lattice=None, attempts=20):
                 if math.hypot(dx, dy) > radius + 1e-9:
                     n_out += 1
                     continue
-            x, y = round(part.x + dx, 4), round(part.y + dy, 4)
+                x, y = part.x + dx, part.y + dy
+            else:
+                x, y = round(part.x + dx, 4), round(part.y + dy, 4)
             if state.candidate_valid(ref, x, y, part.rot):
                 state.apply_move(ref, x, y, part.rot)
                 poses.append({'reference': ref, 'new_x': x, 'new_y': y,
                               'new_rotation': part.rot})
                 break
     return poses, n_zero, n_out
+
+
+def verify_against_engine(path, pcb, radius, lattice, rng_factory):
+    """Refuse to report if the local copy has drifted from the engine.
+
+    Runs both on the same stream and compares the emitted poses exactly. A
+    measurement whose sampler no longer matches the shipped one is not a
+    measurement of this tool.
+    """
+    o1, free = oracle_for(path, pcb)
+    mine, _z, _o = jitter(o1, free, rng_factory(), radius, lattice=lattice)
+    o2, free2 = oracle_for(path, pcb)
+    theirs = PF.perturb_jitter(o2, free2, rng_factory(), radius,
+                               lattice=lattice)
+    if mine != theirs:
+        raise SystemExit(
+            "REFUSING to report: this file's sampler has drifted from "
+            'portfolio.perturb_jitter on %s (%d poses vs %d). Re-sync the '
+            'copy in jitter() before trusting any table below.'
+            % (os.path.basename(path), len(mine), len(theirs)))
 
 
 def lattice_boards():
@@ -273,6 +302,11 @@ def main():
         return 0
     lb = lattice_boards()
     print('%d tracked boards, %d declare a lattice.\n' % (len(boards), len(lb)))
+    # The copy in `jitter()` must still BE the engine's sampler, or every
+    # table below describes a function this repo no longer ships. Checked on
+    # both branches -- with a lattice and without.
+    verify_against_engine(lb[0][0], lb[0][1], 4.0, lb[0][2], _rng)
+    verify_against_engine(lb[0][0], lb[0][1], 4.0, None, _rng)
     want = args.table or ('A', 'B', 'C')
     if 'A' in want:
         table_a(lb)

--- a/tests/measure_826_jitter_lattice.py
+++ b/tests/measure_826_jitter_lattice.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""What the portfolio's basin-escape does to the board's lattice (#826).
+
+#708 made the quench move a part by a whole number of the board's own placement
+lattice. It preserves what it is GIVEN. `place_portfolio` hands it something
+already broken: `perturb_jitter` offsets a part by `r*cos(theta)` at 4 decimal
+places -- continuous, on no lattice -- and `generate` then quenches each
+candidate FROM the jittered seed board.
+
+Three tables, and the first is the one that decides whether the fix is worth
+making:
+
+  A. THE POPULATION. Of the boards that declare a lattice, how many still
+     declare one after the default jitter? One board is an anecdote; this is
+     the finding or the refutation.
+
+  B. IT IS NOT A TUNING PROBLEM. The same table at four radii, down to a
+     radius SMALLER than the lattice itself. A continuous offset is off-lattice
+     at every amplitude, so nothing about a gentler jitter helps.
+
+  C. THE COUNTERFACTUAL. The identical rng stream with the offset snapped, so
+     the cost of the fix is measured rather than asserted: parts perturbed, RMS
+     displacement, and how often the snap is rejected for landing on the seed
+     or outside the disc.
+
+The oracle is built exactly the way `portfolio.generate` builds it, via the
+knob resolution `place_portfolio.main` performs first -- `board_floor_knobs`
+for the clearances, `routing_defaults.GRID_STEP` for the raster, `free_refs`
+with no `--lock`. A measurement of a differently-constructed state would be a
+measurement of something else.
+
+Occupancy after the jitter is read the way `board_grid` reads it -- over EVERY
+footprint origin, not just the free ones -- by overlaying the returned poses on
+the parsed board. `writer._fmt_mm` emits `%.6f`, so a 4-dp jitter value
+round-trips through a written seed board verbatim and the in-memory overlay is
+exact rather than approximate.
+
+NOT named `test_*.py`: `tests/run_all.py` does not collect it. It asserts
+nothing and takes minutes.
+
+    python3 -X utf8 tests/measure_826_jitter_lattice.py
+    python3 -X utf8 tests/measure_826_jitter_lattice.py --table A
+"""
+from __future__ import annotations
+
+import argparse
+import math
+import os
+import random
+import sys
+
+_TESTS = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(_TESTS)
+sys.path.insert(0, _TESTS)
+for _d in ('py_router', 'py_placer', 'py_tools'):
+    sys.path.insert(0, os.path.join(ROOT, _d))
+
+import routing_defaults as defaults                            # noqa: E402
+import run_utils                                               # noqa: E402
+from kicad_parser import parse_kicad_pcb                        # noqa: E402
+from list_nets import board_floor_knobs                         # noqa: E402
+from placement import board_grid as BG                          # noqa: E402
+from placement import portfolio as PF                           # noqa: E402
+from placement.utility import snap_to_grid                      # noqa: E402
+
+
+def oracle_for(path, pcb):
+    """The state `portfolio.generate` would build for this board.
+
+    Mirrors `generate`'s own construction plus the knob resolution
+    `place_portfolio.main` does before calling it: clearances from the BOARD
+    (not fixed constants), the routing raster for grid_step, no --lock, no
+    --ignore-nets.
+    """
+    free = PF.free_refs(pcb, path, None)
+    clearance, edge, _knobs = board_floor_knobs(path, None, None)
+    oracle = PF.make_oracle(pcb, path, free=free, clearance=clearance,
+                            board_edge_clearance=edge,
+                            grid_step=defaults.GRID_STEP, ignore_ids=set())
+    return oracle, free
+
+
+def occupancy_after(pcb, poses, step):
+    """Occupancy over EVERY footprint origin with `poses` overlaid.
+
+    The same population `board_grid.board_coordinates` reads -- a free-parts-
+    only sample would measure something the engine never asks about.
+    """
+    moved = {p['reference']: (p['new_x'], p['new_y']) for p in poses}
+    vals = []
+    for ref, fp in pcb.footprints.items():
+        x, y = moved.get(ref, (fp.x, fp.y))
+        vals.extend([x, y])
+    return BG.occupancy(vals, step)
+
+
+def best_after(pcb, poses):
+    """(best occupancy over the whole ladder, resolved step or None).
+
+    The best rung is what the floor is compared against, so it is the number
+    that decides whether the inference still answers.
+    """
+    moved = {p['reference']: (p['new_x'], p['new_y']) for p in poses}
+
+    class _FP:
+        def __init__(self, x, y):
+            self.x, self.y = x, y
+
+    class _PCB:
+        pass
+
+    overlay = _PCB()
+    overlay.footprints = {}
+    for ref, fp in pcb.footprints.items():
+        x, y = moved.get(ref, (fp.x, fp.y))
+        overlay.footprints[ref] = _FP(x, y)
+    ev = BG.infer_board_grid(overlay)
+    return (max(ev['profile'].values()) if ev['profile'] else 0.0), ev['step']
+
+
+def jitter(state, refs, rng, radius, lattice=None, attempts=20):
+    """`perturb_jitter`, with the proposed snap. Counts why a draw was refused.
+
+    Kept here rather than imported so table C can measure the SHIPPED sampler
+    and the PROPOSED one against the same rng stream in one run, before the
+    engine changes. It is a transcription of `portfolio.perturb_jitter`; the
+    arms in `tests/test_826_portfolio_lattice.py` test the real one.
+    """
+    poses, n_zero, n_out = [], 0, 0
+    for ref in refs:
+        part = state.parts.get(ref)
+        if part is None:
+            continue
+        if not state.candidate_valid(ref, part.x, part.y, part.rot):
+            continue
+        for _ in range(attempts):
+            r = radius * math.sqrt(rng.random())
+            th = 2.0 * math.pi * rng.random()
+            dx, dy = r * math.cos(th), r * math.sin(th)
+            if lattice is not None:
+                dx = snap_to_grid(dx, lattice)
+                dy = snap_to_grid(dy, lattice)
+                if dx == 0.0 and dy == 0.0:
+                    n_zero += 1
+                    continue
+                if math.hypot(dx, dy) > radius + 1e-9:
+                    n_out += 1
+                    continue
+            x, y = round(part.x + dx, 4), round(part.y + dy, 4)
+            if state.candidate_valid(ref, x, y, part.rot):
+                state.apply_move(ref, x, y, part.rot)
+                poses.append({'reference': ref, 'new_x': x, 'new_y': y,
+                              'new_rotation': part.rot})
+                break
+    return poses, n_zero, n_out
+
+
+def lattice_boards():
+    """(path, pcb, step, occ) for every tracked board that declares a lattice."""
+    out = []
+    for path in run_utils.corpus_boards():
+        pcb = parse_kicad_pcb(path)
+        ev = BG.infer_board_grid(pcb)
+        if ev['step'] is not None:
+            out.append((path, pcb, ev['step'], ev['occupancy']))
+    return out
+
+
+def _rng(i=1):
+    """Candidate i's stream, exactly as `generate` keys it."""
+    return random.Random('0:%d:jitter' % i)
+
+
+# ---------------------------------------------------------------- table A
+
+def table_a(boards):
+    print('A. Does the board still declare its lattice after the default '
+          'jitter? (radius 4.0, seed 0, candidate 1)')
+    print()
+    print('   %-30s %-8s %8s %8s %9s %6s %6s'
+          % ('board', 'lattice', 'occ in', 'occ out', 'resolves', 'free',
+             'jitter'))
+    lost = 0
+    for path, pcb, step, occ in boards:
+        oracle, free = oracle_for(path, pcb)
+        poses, _z, _o = jitter(oracle, free, _rng(), 4.0)
+        best, after_step = best_after(pcb, poses)
+        if after_step is None:
+            lost += 1
+        print('   %-30s %-8s %8.3f %8.3f %9s %6d %6d'
+              % (os.path.basename(path).replace('.kicad_pcb', ''), step, occ,
+                 best, after_step if after_step else 'NO', len(free),
+                 len(poses)))
+    print()
+    print('   %d of %d boards that declared a lattice no longer do.' %
+          (lost, len(boards)))
+    print('   On those, the quench that follows resolves its offset lattice to')
+    print('   the 0.1mm raster -- i.e. the #708 fix is inert on this path, and')
+    print('   inert silently: the run reports that the BOARD declares no')
+    print('   lattice, which is true of the jittered board and false of the')
+    print('   input.')
+    print()
+
+
+# ---------------------------------------------------------------- table B
+
+def table_b(boards):
+    print('B. Is it a tuning problem? The same question at four radii.')
+    print()
+    radii = (4.0, 1.0, 0.25, 0.05)
+    print('   %-30s %-8s' % ('board', 'lattice')
+          + ' '.join('%12s' % ('r=%g' % r) for r in radii))
+    for path, pcb, step, _occ in boards:
+        cells = []
+        for r in radii:
+            oracle, free = oracle_for(path, pcb)
+            poses, _z, _o = jitter(oracle, free, _rng(), r)
+            _best, after_step = best_after(pcb, poses)
+            cells.append('%12s' % (after_step if after_step else 'NO'))
+        print('   %-30s %-8s' % (os.path.basename(path).replace(
+            '.kicad_pcb', ''), step) + ' '.join(cells))
+    print()
+    print('   No. A continuous offset is off-lattice at every amplitude -- at')
+    print('   r=0.05 the jitter is ONE lattice unit on the 0.05 boards and')
+    print('   still destroys the inference. Radius changes how many parts find')
+    print('   a legal sample, not whether the sample is on the grid.')
+    print()
+
+
+# ---------------------------------------------------------------- table C
+
+def table_c(boards):
+    print('C. The counterfactual: the same rng stream, offset snapped.')
+    print()
+    print('   %-30s %-8s %-22s %-22s %5s %5s'
+          % ('board', 'lattice', 'SHIPPED jit/occ/step',
+             'SNAPPED jit/occ/step', 'zero', 'out'))
+    for path, pcb, step, occ in boards:
+        o1, free = oracle_for(path, pcb)
+        p1, _z1, _o1 = jitter(o1, free, _rng(), 4.0)
+        b1, s1 = best_after(pcb, p1)
+        o2, _free2 = oracle_for(path, pcb)
+        p2, z2, out2 = jitter(o2, free, _rng(), 4.0, lattice=step)
+        b2, s2 = best_after(pcb, p2)
+        print('   %-30s %-8s %-22s %-22s %5d %5d'
+              % (os.path.basename(path).replace('.kicad_pcb', ''), step,
+                 '%d / %.3f / %s' % (len(p1), b1, s1 or 'NO'),
+                 '%d / %.3f / %s' % (len(p2), b2, s2 or 'NO'), z2, out2))
+    print()
+    print('   `zero` and `out` are draws the snap refused: one that landed')
+    print('   exactly on the seed (not a perturbation) and one that snapped')
+    print('   OUTSIDE the radius (the disc stays an exact bound). Both are')
+    print('   rare at the shipped radius, which is why the arms that cover')
+    print('   them script the rng instead of relying on a population.')
+    print()
+    print('   Occupancy returns to the INPUT value exactly, not approximately:')
+    print('   a lattice-multiple offset added to an on-lattice seed keeps the')
+    print('   same residue, so every part that was on-lattice still is.')
+    print()
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--table', choices=('A', 'B', 'C'), action='append',
+                    help='run one table (repeatable); default all three')
+    args = ap.parse_args()
+
+    boards = run_utils.corpus_boards()
+    if not boards:
+        print('SKIP: git could not enumerate the corpus')
+        return 0
+    lb = lattice_boards()
+    print('%d tracked boards, %d declare a lattice.\n' % (len(boards), len(lb)))
+    want = args.table or ('A', 'B', 'C')
+    if 'A' in want:
+        table_a(lb)
+    if 'B' in want:
+        table_b(lb)
+    if 'C' in want:
+        table_c(lb)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/mutate_708.py
+++ b/tests/mutate_708.py
@@ -18,8 +18,8 @@ checks the first would pass with the fix half-applied. The row
 arms tell those two apart: with it applied, every offset is still a clean
 multiple of `grid_step` and the residue is still preserved -- and the board's
 0.3175mm lattice is still destroyed. Measured before writing any of this: at
-step=1.0 the raster offsets are {0, +/-1.0, +/-2.0} and only the ZERO offset
-lands back on a 0.3175 lattice.
+step=1.0 and max_displacement=3.0 the raster offsets are {0, +/-1.0, +/-2.0,
++/-3.0} and only the ZERO offset lands back on a 0.3175 lattice.
 
 Every row carries an EXPECTATION. An inert row recorded as an expected survivor
 is a finding; an inert row quietly deleted is a hole. A row whose verdict does
@@ -44,9 +44,9 @@ skipped -- `str.replace(old, new, 1)` of an absent needle returns the file
 unchanged, so a stale anchor would report its row as a survivor, which reads as
 a catastrophic test failure and is really a typo.
 
-`_uncache` is carried over from `tests/mutate_797.py` and is NOT hygiene: two
-rows here are single-token edits (`ties[0]` -> `ties[-1]`, `0.67` -> `0.70`)
-that leave the file the SAME SIZE, and CPython validates a `.pyc` on
+`_uncache` is carried over from `tests/mutate_797.py` and is NOT hygiene: the
+`0.67` -> `0.70` row is a size-preserving edit, and CPython validates a `.pyc`
+on
 (mtime seconds, size) alone. Mutate, run and restore inside one second and
 every later import in this checkout reads the mutant.
 
@@ -204,6 +204,27 @@ ROWS = [
      "                          cy - cap.seed_y) > max_disp + 1e-9:\n"
      "                continue",
      (T_SNAP, T_FANOUT), 'KILLED'),
+
+    # The pre-existing acceptance defect #708's slot change exposed: decide on
+    # the PREDICTION again instead of the seated cost.
+    ('the-reseat-accepts-on-the-prediction', 'rs',
+     "        keep = False
+"
+     "        try:",
+     "        keep = apply
+"
+     "        res.accepted = True
+"
+     "        if True:
+"
+     "            for m in moved:
+"
+     "                state.apply_move(m, *poses[m])
+"
+     "            return res
+"
+     "        try:",
+     (T_SNAP, T_RESEAT), 'KILLED'),
 
     ('the-reseat-slot-snaps-the-absolute-point', 'rs',
      "        sx = ax + snap_to_grid(x - ax, grid_step)\n"

--- a/tests/mutate_708.py
+++ b/tests/mutate_708.py
@@ -218,11 +218,35 @@ ROWS = [
      "        try:",
      (T_SNAP, T_RESEAT), 'KILLED'),
 
+    # The half of the reseat fix that is easy to get subtly wrong, and did not
+    # have a row until a review pointed it out: keep the anchor-relative VALUE
+    # but key the dedup on the absolute pose. Every slot still satisfies "on
+    # the anchor's lattice", so the phase assertion cannot see it -- what it
+    # loses is SLOTS, silently, at half-cell anchor phases.
+    ('the-reseat-dedup-key-is-not-injective', 'rs',
+     "        kx = round((x - ax) / grid_step)\n"
+     "        ky = round((y - ay) / grid_step)\n"
+     "        key = (kx, ky, round(rot, 3))",
+     "        kx = round((x - ax) / grid_step)\n"
+     "        ky = round((y - ay) / grid_step)\n"
+     "        key = (round((ax + kx * grid_step) / grid_step),\n"
+     "               round((ay + ky * grid_step) / grid_step),\n"
+     "               round(rot, 3))",
+     (T_SNAP,), 'KILLED'),
+
     ('the-reseat-slot-snaps-the-absolute-point', 'rs',
-     "        sx = ax + snap_to_grid(x - ax, grid_step)\n"
-     "        sy = ay + snap_to_grid(y - ay, grid_step)",
-     "        sx = snap_to_grid(x, grid_step)\n"
-     "        sy = snap_to_grid(y, grid_step)",
+     "        kx = round((x - ax) / grid_step)\n"
+     "        ky = round((y - ay) / grid_step)\n"
+     "        key = (kx, ky, round(rot, 3))\n"
+     "        if key not in seen:\n"
+     "            seen.add(key)\n"
+     "            out.append((ax + kx * grid_step, ay + ky * grid_step, rot))",
+     "        kx = round(x / grid_step)\n"
+     "        ky = round(y / grid_step)\n"
+     "        key = (kx, ky, round(rot, 3))\n"
+     "        if key not in seen:\n"
+     "            seen.add(key)\n"
+     "            out.append((kx * grid_step, ky * grid_step, rot))",
      (T_SNAP, T_RESEAT), 'KILLED'),
 ]
 

--- a/tests/mutate_708.py
+++ b/tests/mutate_708.py
@@ -208,21 +208,13 @@ ROWS = [
     # The pre-existing acceptance defect #708's slot change exposed: decide on
     # the PREDICTION again instead of the seated cost.
     ('the-reseat-accepts-on-the-prediction', 'rs',
-     "        keep = False
-"
+     "        keep = False\n"
      "        try:",
-     "        keep = apply
-"
-     "        res.accepted = True
-"
-     "        if True:
-"
-     "            for m in moved:
-"
-     "                state.apply_move(m, *poses[m])
-"
-     "            return res
-"
+     "        res.accepted = True\n"
+     "        for m in moved:\n"
+     "            state.apply_move(m, *poses[m])\n"
+     "        return res\n"
+     "        keep = False\n"
      "        try:",
      (T_SNAP, T_RESEAT), 'KILLED'),
 

--- a/tests/mutate_708.py
+++ b/tests/mutate_708.py
@@ -79,10 +79,24 @@ T_FANOUT = os.path.join(_TESTS, 'test_fanout_clearance.py')
 #: (name, target, old, new, tests, expect)
 ROWS = [
     # ---- the inference: which rung wins -------------------------------
+    # EXPECTED SURVIVOR, and the reason is a finding rather than a gap.
+    # A plain argmax is not WRONG here, it is UNDEFINED -- and CPython's `max`
+    # resolves it the safe way by accident: it returns the FIRST maximal
+    # element, `profile` is built in ladder order, and monotonicity along a
+    # divisibility chain forbids a coarser rung from strictly exceeding a finer
+    # divisor. So argmax picks the finest tied rung, which is what `ties[0]`
+    # picks deliberately. The two can only diverge where TIE_SLACK bites, and
+    # the slack is inert on this corpus (worst margin 0.075).
+    #
+    # Kept rather than deleted because it is a live detector: it starts failing
+    # the day someone reorders the ladder, builds `profile` from a set, or
+    # widens the slack past a real margin -- at which point the issue's own
+    # proposed rule silently starts choosing a different grid.
+    # `the-tie-break-takes-the-coarsest` below is the killable form.
     ('the-tie-break-takes-the-argmax', 'bg',
      "    out['step'] = ties[0]",
      "    out['step'] = max(out['profile'], key=lambda s: out['profile'][s])",
-     (T_GRID,), 'KILLED'),
+     (T_GRID,), 'SURVIVED'),
 
     ('the-tie-break-takes-the-coarsest', 'bg',
      "    out['step'] = ties[0]",
@@ -189,14 +203,14 @@ ROWS = [
      "            if math.hypot(cx - cap.seed_x,\n"
      "                          cy - cap.seed_y) > max_disp + 1e-9:\n"
      "                continue",
-     (T_FANOUT,), 'KILLED'),
+     (T_SNAP, T_FANOUT), 'KILLED'),
 
     ('the-reseat-slot-snaps-the-absolute-point', 'rs',
      "        sx = ax + snap_to_grid(x - ax, grid_step)\n"
      "        sy = ay + snap_to_grid(y - ay, grid_step)",
      "        sx = snap_to_grid(x, grid_step)\n"
      "        sy = snap_to_grid(y, grid_step)",
-     (T_RESEAT,), 'KILLED'),
+     (T_SNAP, T_RESEAT), 'KILLED'),
 ]
 
 

--- a/tests/mutate_708.py
+++ b/tests/mutate_708.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""The #708 mutation battery, shipped so its numbers can be re-derived.
+
+`tests/test_708_seed_relative_snap.py` records what each arm kills. A count is
+only checkable if the exact source edit is written down, so the edits live here
+as data, next to the numbers they produced.
+
+WHY THIS BATTERY EXISTS, in this issue's own terms. #708 has two halves that
+are easy to confuse and easy to test vacuously:
+
+  * SEED-RELATIVE -- snap the offset, not the absolute position;
+  * ON THE BOARD'S LATTICE -- and snap it to the pitch the board was laid out
+    on, not to the router's raster.
+
+The second half is the one that does the work, and a test suite that only
+checks the first would pass with the fix half-applied. The row
+`the-offset-snaps-to-the-raster-not-the-lattice` exists precisely to prove the
+arms tell those two apart: with it applied, every offset is still a clean
+multiple of `grid_step` and the residue is still preserved -- and the board's
+0.3175mm lattice is still destroyed. Measured before writing any of this: at
+step=1.0 the raster offsets are {0, +/-1.0, +/-2.0} and only the ZERO offset
+lands back on a 0.3175 lattice.
+
+Every row carries an EXPECTATION. An inert row recorded as an expected survivor
+is a finding; an inert row quietly deleted is a hole. A row whose verdict does
+not match its expectation is reported as WRONG.
+
+NOT named `test_*.py`, so `tests/run_all.py` does not collect it: it REWRITES
+the engine in place. One writer per tree -- do not run it while a suite, an A/B
+replay or a review is reading the same checkout. It refuses to start on a dirty
+engine, because restoring would write the COMMITTED text back over uncommitted
+work.
+
+    python3 -X utf8 tests/mutate_708.py
+    python3 -X utf8 tests/mutate_708.py --row the-tie-break-takes-the-argmax
+    python3 -X utf8 tests/mutate_708.py --list
+
+A row is KILLED by a FAILURE **or an ERROR**: several of these make an arm
+raise rather than fail, and a battery counting only failures would call that a
+survivor.
+
+An anchor that does not match EXACTLY ONCE is reported as BROKEN rather than
+skipped -- `str.replace(old, new, 1)` of an absent needle returns the file
+unchanged, so a stale anchor would report its row as a survivor, which reads as
+a catastrophic test failure and is really a typo.
+
+`_uncache` is carried over from `tests/mutate_797.py` and is NOT hygiene: two
+rows here are single-token edits (`ties[0]` -> `ties[-1]`, `0.67` -> `0.70`)
+that leave the file the SAME SIZE, and CPython validates a `.pyc` on
+(mtime seconds, size) alone. Mutate, run and restore inside one second and
+every later import in this checkout reads the mutant.
+
+THE MEASURED TABLE IS IN THE HEADER OF
+`tests/test_708_seed_relative_snap.py`, FROM THE RUN -- never predicted here
+and never edited afterwards to match.
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import subprocess
+import sys
+
+_TESTS = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_TESTS)
+
+BOARD_GRID = os.path.join(_ROOT, 'py_placer', 'placement', 'board_grid.py')
+QUENCH = os.path.join(_ROOT, 'py_placer', 'placement', 'quench.py')
+FANOUT = os.path.join(_ROOT, 'py_placer', 'placement', 'fanout_clearance.py')
+RESEAT = os.path.join(_ROOT, 'py_placer', 'placement', 'reseat.py')
+TARGETS = {'bg': BOARD_GRID, 'q': QUENCH, 'fc': FANOUT, 'rs': RESEAT}
+
+T_GRID = os.path.join(_TESTS, 'test_708_board_grid.py')
+T_SNAP = os.path.join(_TESTS, 'test_708_seed_relative_snap.py')
+T_RESEAT = os.path.join(_TESTS, 'test_reseat.py')
+T_FANOUT = os.path.join(_TESTS, 'test_fanout_clearance.py')
+
+#: (name, target, old, new, tests, expect)
+ROWS = [
+    # ---- the inference: which rung wins -------------------------------
+    ('the-tie-break-takes-the-argmax', 'bg',
+     "    out['step'] = ties[0]",
+     "    out['step'] = max(out['profile'], key=lambda s: out['profile'][s])",
+     (T_GRID,), 'KILLED'),
+
+    ('the-tie-break-takes-the-coarsest', 'bg',
+     "    out['step'] = ties[0]",
+     "    out['step'] = ties[-1]",
+     (T_GRID,), 'KILLED'),
+
+    # ---- the two gates that make it decline ---------------------------
+    ('the-min-parts-gate-is-dropped', 'bg',
+     "    if n_parts < min_parts:",
+     "    if False:",
+     (T_GRID,), 'KILLED'),
+
+    ('the-occupancy-floor-is-dropped', 'bg',
+     "    if best < floor:",
+     "    if False:",
+     (T_GRID,), 'KILLED'),
+
+    # The boundary detector. 0.70 is the round number the population gap
+    # first suggests, and interf_u_unrouted scores EXACTLY 0.700000, so the
+    # verdict there is decided by `>=` against `>` on a float equality.
+    ('the-floor-returns-to-the-round-0.70', 'bg',
+     "OCCUPANCY_FLOOR = 0.67",
+     "OCCUPANCY_FLOOR = 0.70",
+     (T_GRID,), 'KILLED'),
+
+    # ---- how occupancy is measured ------------------------------------
+    ('the-tolerance-becomes-relative-to-the-step', 'bg',
+     "               if abs(v / step - round(v / step)) * step <= tol_mm)",
+     "               if abs(v / step - round(v / step)) <= tol_mm)",
+     (T_GRID,), 'KILLED'),
+
+    ('the-sample-drops-one-axis', 'bg',
+     "    return xs + ys, len(fps)",
+     "    return xs, len(fps)",
+     (T_GRID,), 'KILLED'),
+
+    # ---- the quench edit: the two halves, separately -------------------
+    ('the-candidate-snap-goes-back-to-absolute', 'q',
+     "            dx = snap_to_grid(ix * step, lattice)\n"
+     "            dy = snap_to_grid(iy * step, lattice)\n"
+     "            if math.hypot(dx, dy) > max_disp + 1e-9:\n"
+     "                continue\n"
+     "            cx = part.seed_x + dx\n"
+     "            cy = part.seed_y + dy",
+     "            cx = snap_to_grid(part.seed_x + ix * step, lattice)\n"
+     "            cy = snap_to_grid(part.seed_y + iy * step, lattice)\n"
+     "            if math.hypot(cx - part.seed_x,\n"
+     "                          cy - part.seed_y) > max_disp + 1e-9:\n"
+     "                continue",
+     (T_SNAP,), 'KILLED'),
+
+    # THE row this battery exists for: seed-relative but on the RASTER. The
+    # residue is preserved, every offset is a clean multiple of grid_step,
+    # and the board's own lattice is still destroyed.
+    ('the-offset-snaps-to-the-raster-not-the-lattice', 'q',
+     "            dx = snap_to_grid(ix * step, lattice)\n"
+     "            dy = snap_to_grid(iy * step, lattice)",
+     "            dx = snap_to_grid(ix * step, 0.1)\n"
+     "            dy = snap_to_grid(iy * step, 0.1)",
+     (T_SNAP,), 'KILLED'),
+
+    ('the-radius-test-goes-back-before-the-snap', 'q',
+     "            if math.hypot(dx, dy) > max_disp + 1e-9:\n"
+     "                continue\n"
+     "            cx = part.seed_x + dx",
+     "            if math.hypot(ix * step, iy * step) > max_disp + 1e-9:\n"
+     "                continue\n"
+     "            cx = part.seed_x + dx",
+     (T_SNAP,), 'KILLED'),
+
+    ('the-lattice-is-never-resolved', 'q',
+     "    lattice, lattice_evidence = resolve_snap_lattice(pcb_data, grid_step)",
+     "    lattice, lattice_evidence = grid_step, {'source': 'grid_step',\n"
+     "                                            'step': None,\n"
+     "                                            'reason': 'disabled'}",
+     (T_SNAP,), 'KILLED'),
+
+    # ---- the group-move probe -----------------------------------------
+    ('the-group-probe-goes-back-to-the-absolute-pose', 'q',
+     "                if math.hypot(p.x + sdx - p.seed_x,\n"
+     "                              p.y + sdy - p.seed_y) > max_disp + 1e-9:",
+     "                if math.hypot(snap_to_grid(p.x + sdx, lattice) - p.seed_x,\n"
+     "                              snap_to_grid(p.y + sdy, lattice)\n"
+     "                              - p.seed_y) > max_disp + 1e-9:",
+     (T_SNAP,), 'KILLED'),
+
+    ('the-group-offset-snaps-the-absolute-pose', 'q',
+     "            sdx = snap_to_grid(ix * step, lattice)\n"
+     "            sdy = snap_to_grid(iy * step, lattice)",
+     "            sdx = snap_to_grid(ix * step, 0.1)\n"
+     "            sdy = snap_to_grid(iy * step, 0.1)",
+     (T_SNAP,), 'KILLED'),
+
+    # ---- the two sites that deliberately do NOT take the lattice -------
+    ('the-fanout-snap-goes-back-to-absolute', 'fc',
+     "            dx = snap_to_grid(ix * step, grid_step)\n"
+     "            dy = snap_to_grid(iy * step, grid_step)\n"
+     "            if math.hypot(dx, dy) > max_disp + 1e-9:\n"
+     "                continue\n"
+     "            cx = cap.seed_x + dx\n"
+     "            cy = cap.seed_y + dy",
+     "            cx = snap_to_grid(cap.seed_x + ix * step, grid_step)\n"
+     "            cy = snap_to_grid(cap.seed_y + iy * step, grid_step)\n"
+     "            if math.hypot(cx - cap.seed_x,\n"
+     "                          cy - cap.seed_y) > max_disp + 1e-9:\n"
+     "                continue",
+     (T_FANOUT,), 'KILLED'),
+
+    ('the-reseat-slot-snaps-the-absolute-point', 'rs',
+     "        sx = ax + snap_to_grid(x - ax, grid_step)\n"
+     "        sy = ay + snap_to_grid(y - ay, grid_step)",
+     "        sx = snap_to_grid(x, grid_step)\n"
+     "        sy = snap_to_grid(y, grid_step)",
+     (T_RESEAT,), 'KILLED'),
+]
+
+
+def _uncache(path):
+    """Delete the target's cached bytecode. MEASURED HAZARD, not hygiene --
+    see this module's docstring."""
+    import importlib
+    import importlib.util
+    try:
+        cached = importlib.util.cache_from_source(path)
+        if os.path.exists(cached):
+            os.remove(cached)
+    except (OSError, ValueError, NotImplementedError):
+        pass
+    importlib.invalidate_caches()
+
+
+def _dirty(path):
+    p = subprocess.run(['git', 'status', '--porcelain', '--', path],
+                       capture_output=True, text=True, cwd=_ROOT)
+    return bool(p.stdout.strip())
+
+
+def run(only=None):
+    rows = [r for r in ROWS if only is None or r[0] == only]
+    if not rows:
+        print('no row named %r' % only)
+        return 1
+    for path in TARGETS.values():
+        if _dirty(path):
+            print('REFUSING: %s has uncommitted changes. Commit or stash '
+                  'first -- this battery restores by overwriting.'
+                  % os.path.basename(path))
+            return 2
+
+    orig = {k: io.open(v, encoding='utf-8', newline='').read()
+            for k, v in TARGETS.items()}
+    results = []
+    try:
+        for name, tgt, old, new, tests, expect in rows:
+            path, base = TARGETS[tgt], orig[tgt]
+            n = base.count(old)
+            if n != 1:
+                results.append((name, 'BROKEN', expect,
+                                'anchor matched %d times' % n, []))
+                print('  ran %-52s BROKEN' % name)
+                continue
+            io.open(path, 'w', encoding='utf-8', newline='').write(
+                base.replace(old, new, 1))
+            _uncache(path)
+            killed, failed = False, []
+            for t in tests:
+                p = subprocess.run([sys.executable, '-X', 'utf8', t],
+                                   capture_output=True, text=True,
+                                   encoding='utf-8', errors='replace',
+                                   timeout=1800, cwd=_ROOT)
+                out = (p.stderr or '') + (p.stdout or '')
+                if p.returncode:
+                    killed = True
+                failed += [l.strip()[5:].strip()[:90]
+                           for l in out.splitlines()
+                           if l.strip().startswith('FAIL')]
+                if 'Traceback' in out:
+                    failed.append('raised: '
+                                  + out.strip().splitlines()[-1][:70])
+            io.open(path, 'w', encoding='utf-8', newline='').write(base)
+            _uncache(path)
+            results.append((name, 'KILLED' if killed else 'SURVIVED', expect,
+                            '%d' % len(failed), failed[:3]))
+            print('  ran %-52s %s' % (name, results[-1][1]))
+    finally:
+        for k, v in TARGETS.items():
+            io.open(v, 'w', encoding='utf-8', newline='').write(orig[k])
+            _uncache(v)
+
+    print()
+    w = max(len(r[0]) for r in results)
+    wrong = 0
+    for name, verdict, expect, cnt, failed in results:
+        mark = ''
+        if verdict != expect:
+            mark = '   <-- WRONG, expected %s' % expect
+            wrong += 1
+        print('%-*s  %-9s  %-3s%s' % (w, name, verdict, cnt, mark))
+        for f in failed:
+            print('%s      %s' % (' ' * w, f))
+    killed = sum(1 for r in results if r[1] == 'KILLED')
+    survived = sum(1 for r in results if r[1] == 'SURVIVED')
+    broken = sum(1 for r in results if r[1] == 'BROKEN')
+    print('\n%d rows: %d killed, %d survived (%d of them expected), %d broken'
+          % (len(results), killed, survived,
+             sum(1 for r in results if r[1] == r[2] == 'SURVIVED'), broken))
+    if wrong or broken:
+        print('%d row(s) did not match their expectation' % (wrong + broken))
+    return 1 if (wrong or broken) else 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument('--row', default=None, help='run one row by name')
+    ap.add_argument('--list', action='store_true', help='list the row names')
+    a = ap.parse_args()
+    if a.list:
+        for r in ROWS:
+            print('%-52s %-4s %s' % (r[0], r[1], r[5]))
+        return 0
+    return run(a.row)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/mutate_826.py
+++ b/tests/mutate_826.py
@@ -25,8 +25,9 @@ measured before the arms were written:
     all eleven lattice boards at radius 4.0 AND 2.0, first firing at 1.0. So
     `a-zero-offset-counts-as-a-perturbation` is killed by a SCRIPTED rng, not
     by a board.
-  * an outward-snapping draw is 1-6 per board -- likely, not guaranteed. An arm
-    resting on one being drawn goes quietly vacuous the day a fixture moves, so
+  * an outward-snapping draw is 0-6 per board and is ZERO on six of the eleven,
+    including esp_prog and routed_output. An arm resting on one being drawn
+    would be vacuous on most of the corpus, so
     `the-radius-test-goes-back-before-the-snap` is scripted too.
 
 AND ONE ROW EXISTS BECAUSE THE OBVIOUS FIXTURE CANNOT KILL IT.
@@ -118,12 +119,22 @@ ROWS = [
 
     # ---- the resolver -------------------------------------------------
     ('the-lattice-falls-back-to-the-grid-step-raster', 'pf',
-     "    return step, dict(ev, source='inferred' if step is not None "
-     "else 'none',\n"
+     "    return step, dict(ev, step=step, inferred_step=ev['step'],\n"
+     "                      source='inferred' if step is not None else 'none',\n"
      "                      resolved=step)",
      "    if step is None:\n"
-     "        return 0.1, dict(ev, source='grid_step', resolved=0.1)\n"
-     "    return step, dict(ev, source='inferred', resolved=step)",
+     "        return 0.1, dict(ev, step=0.1, inferred_step=ev['step'],\n"
+     "                         source='grid_step', resolved=0.1)\n"
+     "    return step, dict(ev, step=step, inferred_step=ev['step'],\n"
+     "                      source='inferred', resolved=step)",
+     (T_PF,), 'KILLED'),
+
+    # The B1 defect itself, as a row: report what was INFERRED instead of
+    # what the quench USED. Killed only by the `--step 0.25` arm, where the
+    # two differ -- at the default step they are equal and it is invisible.
+    ('the-disclosure-reports-the-inference-not-what-was-used', 'pf',
+     "            'board_grid_step': (m.get('board_grid') or {}).get('resolved'),",
+     "            'board_grid_step': (m.get('board_grid') or {}).get('step'),",
      (T_PF,), 'KILLED'),
 
     ('the-radius-guard-is-dropped', 'pf',
@@ -154,7 +165,7 @@ ROWS = [
 
     # ---- the disclosure ----------------------------------------------
     ('the-disclosure-drops-the-board-grid', 'pf',
-     "            'board_grid_step': (m.get('board_grid') or {}).get('step'),",
+     "            'board_grid_step': (m.get('board_grid') or {}).get('resolved'),",
      "            'board_grid_step': None,",
      (T_PF,), 'KILLED'),
 ]

--- a/tests/mutate_826.py
+++ b/tests/mutate_826.py
@@ -10,11 +10,13 @@ That battery scores each row by counting FAIL lines from the suites in the
 row's own `tests` tuple, and its seventeen counts are frozen in
 `test_708_seed_relative_snap.py`'s header, recorded from a run and never edited
 to match. #826's arms call `jitter_lattice`, which calls `infer_board_grid`, so
-adding them to #708's suites would make its `bg` rows (the occupancy floor, the
-tie-break, MIN_PARTS) newly fail them and MOVE EIGHT of the seventeen recorded
-counts. On a branch stacked on the open #825 that would force a re-record of
-the parent's evidence in order to land a child. One battery per issue is also
-this repo's own convention -- twenty `mutate_<issue>.py` files.
+adding them to #708's suites would make its seven `bg` rows (the occupancy
+floor, the tie-break, MIN_PARTS, the sample, the tolerance) newly fail them,
+plus any quench row the #826 end-to-end arm also detects -- moving counts #708
+froze. On a branch stacked on the open #825 that would force a re-record of the
+parent's evidence in order to land a child. One battery per PR is also this
+repo's usual shape -- 22 `mutate_*.py` files before this one, though
+`mutate_705_792_794.py` shows it is per PR rather than strictly per issue.
 
 TWO ROWS EXIST BECAUSE A POPULATION ARM CANNOT KILL THEM, and both facts were
 measured before the arms were written:

--- a/tests/mutate_826.py
+++ b/tests/mutate_826.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""The #826 mutation battery, shipped so its numbers can be re-derived.
+
+`tests/test_826_portfolio_lattice.py` records what each arm kills. A count is
+only checkable if the exact source edit is written down, so the edits live here
+as data, next to the numbers they produced.
+
+WHY THIS IS A SEPARATE FILE FROM `mutate_708.py`, which is the obvious place.
+That battery scores each row by counting FAIL lines from the suites in the
+row's own `tests` tuple, and its seventeen counts are frozen in
+`test_708_seed_relative_snap.py`'s header, recorded from a run and never edited
+to match. #826's arms call `jitter_lattice`, which calls `infer_board_grid`, so
+adding them to #708's suites would make its `bg` rows (the occupancy floor, the
+tie-break, MIN_PARTS) newly fail them and MOVE EIGHT of the seventeen recorded
+counts. On a branch stacked on the open #825 that would force a re-record of
+the parent's evidence in order to land a child. One battery per issue is also
+this repo's own convention -- twenty `mutate_<issue>.py` files.
+
+TWO ROWS EXIST BECAUSE A POPULATION ARM CANNOT KILL THEM, and both facts were
+measured before the arms were written:
+
+  * the zero-offset branch never fires at the shipped radius -- 0 rejections on
+    all eleven lattice boards at radius 4.0 AND 2.0, first firing at 1.0. So
+    `a-zero-offset-counts-as-a-perturbation` is killed by a SCRIPTED rng, not
+    by a board.
+  * an outward-snapping draw is 1-6 per board -- likely, not guaranteed. An arm
+    resting on one being drawn goes quietly vacuous the day a fixture moves, so
+    `the-radius-test-goes-back-before-the-snap` is scripted too.
+
+AND ONE ROW EXISTS BECAUSE THE OBVIOUS FIXTURE CANNOT KILL IT.
+`splitflap_driver`, the default board of every other test_portfolio*.py,
+perturbs 29 parts of which ZERO have an off-lattice seed -- so
+`snap(part.x + dx) - part.x == snap(dx)` and `the-jitter-snaps-the-absolute-
+pose` is INVISIBLE there. `interf_u_unrouted` perturbs 22 of 22 with seven
+off-lattice. The arm asserts that precondition as a FAILURE rather than a skip.
+
+Every row carries an EXPECTATION. An inert row recorded as an expected survivor
+is a finding; an inert row quietly deleted is a hole.
+
+NOT named `test_*.py`, so `tests/run_all.py` does not collect it: it REWRITES
+the engine in place. One writer per tree -- do not run it while a suite, an A/B
+replay or a review is reading the same checkout. It refuses to start on a dirty
+engine, because restoring would write the COMMITTED text back over uncommitted
+work.
+
+    python3 -X utf8 tests/mutate_826.py
+    python3 -X utf8 tests/mutate_826.py --row the-jitter-snap-is-dropped
+    python3 -X utf8 tests/mutate_826.py --list
+
+A row is KILLED by a FAILURE **or an ERROR**. An anchor that does not match
+EXACTLY ONCE is reported as BROKEN rather than skipped -- `str.replace` of an
+absent needle returns the file unchanged, so a stale anchor would report its row
+as a survivor.
+
+`_uncache` is carried over from `mutate_708.py` and is NOT hygiene: several of
+these are same-size edits, and CPython validates a `.pyc` on (mtime seconds,
+size) alone.
+
+THE MEASURED TABLE IS IN THE HEADER OF
+`tests/test_826_portfolio_lattice.py`, FROM THE RUN.
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import subprocess
+import sys
+
+_TESTS = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_TESTS)
+
+PORTFOLIO = os.path.join(_ROOT, 'py_placer', 'placement', 'portfolio.py')
+TARGETS = {'pf': PORTFOLIO}
+
+T_PF = os.path.join(_TESTS, 'test_826_portfolio_lattice.py')
+T_STRAT = os.path.join(_TESTS, 'test_portfolio_strategies.py')
+
+#: (name, target, old, new, tests, expect)
+ROWS = [
+    # ---- the snap itself ----------------------------------------------
+    ('the-jitter-snap-is-dropped', 'pf',
+     "            if lattice is not None:\n"
+     "                # The OFFSET, never `part.x + dx`.",
+     "            if False:\n"
+     "                # The OFFSET, never `part.x + dx`.",
+     (T_PF,), 'KILLED'),
+
+    # The row the fixture choice exists for. Invisible on splitflap_driver.
+    ('the-jitter-snaps-the-absolute-pose', 'pf',
+     "                dx = snap_to_grid(dx, lattice)\n"
+     "                dy = snap_to_grid(dy, lattice)",
+     "                dx = snap_to_grid(part.x + dx, lattice) - part.x\n"
+     "                dy = snap_to_grid(part.y + dy, lattice) - part.y",
+     (T_PF,), 'KILLED'),
+
+    # #708's headline row, ported to the fourth site. Would NOT kill on a 0.05
+    # board, where every 0.1-multiple is also a 0.05-multiple.
+    ('the-offset-snaps-to-the-raster-not-the-lattice', 'pf',
+     "                dx = snap_to_grid(dx, lattice)\n"
+     "                dy = snap_to_grid(dy, lattice)",
+     "                dx = snap_to_grid(dx, 0.1)\n"
+     "                dy = snap_to_grid(dy, 0.1)",
+     (T_PF,), 'KILLED'),
+
+    # ---- the two guards the snap introduces ---------------------------
+    ('a-zero-offset-counts-as-a-perturbation', 'pf',
+     "                if dx == 0.0 and dy == 0.0:",
+     "                if False:",
+     (T_PF,), 'KILLED'),
+
+    ('the-radius-test-goes-back-before-the-snap', 'pf',
+     "                if math.hypot(dx, dy) > radius + 1e-9:",
+     "                if r > radius + 1e-9:",
+     (T_PF,), 'KILLED'),
+
+    # ---- the resolver -------------------------------------------------
+    ('the-lattice-falls-back-to-the-grid-step-raster', 'pf',
+     "    return step, dict(ev, source='inferred' if step is not None "
+     "else 'none',\n"
+     "                      resolved=step)",
+     "    if step is None:\n"
+     "        return 0.1, dict(ev, source='grid_step', resolved=0.1)\n"
+     "    return step, dict(ev, source='inferred', resolved=step)",
+     (T_PF,), 'KILLED'),
+
+    ('the-radius-guard-is-dropped', 'pf',
+     "    if step is not None and step > radius:",
+     "    if False:",
+     (T_PF,), 'KILLED'),
+
+    # ---- the wiring ---------------------------------------------------
+    # Every row above can pass with the sampler correct and `generate` never
+    # using it. This is the only one that pins the connection.
+    ('the-generator-does-not-pass-the-lattice', 'pf',
+     "            poses = perturb_jitter(oracle, free, rng, radius,\n"
+     "                                   lattice=lattice)",
+     "            poses = perturb_jitter(oracle, free, rng, radius)",
+     (T_PF,), 'KILLED'),
+
+    ('the-lattice-is-resolved-per-candidate-from-the-live-state', 'pf',
+     "    lattice, lattice_ev = jitter_lattice(pcb, radius)",
+     "    lattice, lattice_ev = None, {'source': 'none', 'step': None,\n"
+     "                                 'resolved': None, 'reason': 'disabled'}",
+     (T_PF,), 'KILLED'),
+
+    # ---- the opt-out that protects perturb.py's positive control ------
+    ('the-default-becomes-the-inferred-lattice', 'pf',
+     "                   lattice: Optional[float] = None) -> List[Dict]:",
+     "                   lattice: Optional[float] = 0.3175) -> List[Dict]:",
+     (T_STRAT,), 'KILLED'),
+
+    # ---- the disclosure ----------------------------------------------
+    ('the-disclosure-drops-the-board-grid', 'pf',
+     "            'board_grid_step': (m.get('board_grid') or {}).get('step'),",
+     "            'board_grid_step': None,",
+     (T_PF,), 'KILLED'),
+]
+
+
+def _uncache(path):
+    """Delete the target's cached bytecode. MEASURED HAZARD, not hygiene."""
+    import importlib
+    import importlib.util
+    try:
+        cached = importlib.util.cache_from_source(path)
+        if os.path.exists(cached):
+            os.remove(cached)
+    except (OSError, ValueError, NotImplementedError):
+        pass
+    importlib.invalidate_caches()
+
+
+def _dirty(path):
+    p = subprocess.run(['git', 'status', '--porcelain', '--', path],
+                       capture_output=True, text=True, cwd=_ROOT)
+    return bool(p.stdout.strip())
+
+
+def run(only=None):
+    rows = [r for r in ROWS if only is None or r[0] == only]
+    if not rows:
+        print('no row named %r' % only)
+        return 1
+    for path in TARGETS.values():
+        if _dirty(path):
+            print('REFUSING: %s has uncommitted changes. Commit or stash '
+                  'first -- this battery restores by overwriting.'
+                  % os.path.basename(path))
+            return 2
+
+    orig = {k: io.open(v, encoding='utf-8', newline='').read()
+            for k, v in TARGETS.items()}
+    results = []
+    try:
+        for name, tgt, old, new, tests, expect in rows:
+            path, base = TARGETS[tgt], orig[tgt]
+            n = base.count(old)
+            if n != 1:
+                results.append((name, 'BROKEN', expect,
+                                'anchor matched %d times' % n, []))
+                print('  ran %-52s BROKEN' % name)
+                continue
+            io.open(path, 'w', encoding='utf-8', newline='').write(
+                base.replace(old, new, 1))
+            _uncache(path)
+            killed, failed = False, []
+            for t in tests:
+                p = subprocess.run([sys.executable, '-X', 'utf8', t],
+                                   capture_output=True, text=True,
+                                   encoding='utf-8', errors='replace',
+                                   timeout=1800, cwd=_ROOT)
+                out = (p.stderr or '') + (p.stdout or '')
+                if p.returncode:
+                    killed = True
+                failed += [l.strip()[5:].strip()[:90]
+                           for l in out.splitlines()
+                           if l.strip().startswith('FAIL')]
+                if 'Traceback' in out:
+                    failed.append('raised: '
+                                  + out.strip().splitlines()[-1][:70])
+            io.open(path, 'w', encoding='utf-8', newline='').write(base)
+            _uncache(path)
+            results.append((name, 'KILLED' if killed else 'SURVIVED', expect,
+                            '%d' % len(failed), failed[:3]))
+            print('  ran %-52s %s' % (name, results[-1][1]))
+    finally:
+        for k, v in TARGETS.items():
+            io.open(v, 'w', encoding='utf-8', newline='').write(orig[k])
+            _uncache(v)
+
+    print()
+    w = max(len(r[0]) for r in results)
+    wrong = 0
+    for name, verdict, expect, cnt, failed in results:
+        mark = ''
+        if verdict != expect:
+            mark = '   <-- WRONG, expected %s' % expect
+            wrong += 1
+        print('%-*s  %-9s  %-3s%s' % (w, name, verdict, cnt, mark))
+        for f in failed:
+            print('%s      %s' % (' ' * w, f))
+    killed = sum(1 for r in results if r[1] == 'KILLED')
+    survived = sum(1 for r in results if r[1] == 'SURVIVED')
+    broken = sum(1 for r in results if r[1] == 'BROKEN')
+    print('\n%d rows: %d killed, %d survived (%d of them expected), %d broken'
+          % (len(results), killed, survived,
+             sum(1 for r in results if r[1] == r[2] == 'SURVIVED'), broken))
+    if wrong or broken:
+        print('%d row(s) did not match their expectation' % (wrong + broken))
+    return 1 if (wrong or broken) else 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument('--row', default=None, help='run one row by name')
+    ap.add_argument('--list', action='store_true', help='list the row names')
+    a = ap.parse_args()
+    if a.list:
+        for r in ROWS:
+            print('%-52s %-4s %s' % (r[0], r[1], r[5]))
+        return 0
+    return run(a.row)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/placement_ab_baseline.json
+++ b/tests/placement_ab_baseline.json
@@ -3,20 +3,20 @@
   "board": "kit-dev-coldfire-xilinx_5213.kicad_pcb",
   "mark": "improve",
   "off": {
-   "crossings": 1379,
-   "health_block_displacement_max_mm": 55.3346,
+   "crossings": 1384,
+   "health_block_displacement_max_mm": 56.3849,
    "health_bus_foreign_crossings": 147,
-   "hpwl": 7434.4,
+   "hpwl": 7415.76,
    "intent_errors": 0,
    "intent_errors_by_rule": {},
    "intent_errors_enforced": 0,
    "intent_errors_other": 0
   },
   "on": {
-   "crossings": 1370,
-   "health_block_displacement_max_mm": 54.6257,
-   "health_bus_foreign_crossings": 143,
-   "hpwl": 7241.97,
+   "crossings": 1372,
+   "health_block_displacement_max_mm": 55.4249,
+   "health_bus_foreign_crossings": 144,
+   "hpwl": 7171.84,
    "intent_errors": 0,
    "intent_errors_by_rule": {},
    "intent_errors_enforced": 0,
@@ -27,10 +27,10 @@
   "board": "orangecrab_ext_pll.kicad_pcb",
   "mark": "improve",
   "off": {
-   "crossings": 1063,
-   "health_block_displacement_max_mm": 18.5356,
-   "health_bus_foreign_crossings": 32,
-   "hpwl": 2117.85,
+   "crossings": 1087,
+   "health_block_displacement_max_mm": 18.1954,
+   "health_bus_foreign_crossings": 33,
+   "hpwl": 2121.92,
    "intent_errors": 1,
    "intent_errors_by_rule": {
     "zone_containment": 1
@@ -39,10 +39,10 @@
    "intent_errors_other": 0
   },
   "on": {
-   "crossings": 1042,
-   "health_block_displacement_max_mm": 18.8075,
+   "crossings": 1074,
+   "health_block_displacement_max_mm": 18.1954,
    "health_bus_foreign_crossings": 31,
-   "hpwl": 2113.67,
+   "hpwl": 2111.05,
    "intent_errors": 1,
    "intent_errors_by_rule": {
     "zone_containment": 1
@@ -55,10 +55,10 @@
   "board": "ulx3s.kicad_pcb",
   "mark": "regress",
   "off": {
-   "crossings": 2477,
-   "health_block_displacement_max_mm": 17.9512,
+   "crossings": 2429,
+   "health_block_displacement_max_mm": 18.9597,
    "health_bus_foreign_crossings": 62,
-   "hpwl": 7437.99,
+   "hpwl": 7493.73,
    "intent_errors": 4,
    "intent_errors_by_rule": {
     "zone_containment": 4
@@ -67,15 +67,15 @@
    "intent_errors_other": 0
   },
   "on": {
-   "crossings": 2407,
-   "health_block_displacement_max_mm": 18.0904,
+   "crossings": 2442,
+   "health_block_displacement_max_mm": 16.9877,
    "health_bus_foreign_crossings": 55,
-   "hpwl": 7416.23,
-   "intent_errors": 7,
+   "hpwl": 7428.07,
+   "intent_errors": 4,
    "intent_errors_by_rule": {
-    "zone_containment": 7
+    "zone_containment": 4
    },
-   "intent_errors_enforced": 7,
+   "intent_errors_enforced": 4,
    "intent_errors_other": 0
   }
  },
@@ -83,10 +83,10 @@
   "board": "kit-dev-coldfire-xilinx_5213.kicad_pcb",
   "mark": "regress",
   "off": {
-   "crossings": 1379,
-   "health_block_displacement_max_mm": 55.3346,
+   "crossings": 1384,
+   "health_block_displacement_max_mm": 56.3849,
    "health_bus_foreign_crossings": null,
-   "hpwl": 7434.4,
+   "hpwl": 7415.76,
    "intent_errors": 5,
    "intent_errors_by_rule": {
     "zone_exclusive": 5
@@ -95,26 +95,26 @@
    "intent_errors_other": 0
   },
   "on": {
-   "crossings": 1381,
-   "health_block_displacement_max_mm": 55.3346,
+   "crossings": 1383,
+   "health_block_displacement_max_mm": 55.4372,
    "health_bus_foreign_crossings": null,
-   "hpwl": 7431.96,
-   "intent_errors": 5,
+   "hpwl": 7428.76,
+   "intent_errors": 6,
    "intent_errors_by_rule": {
-    "zone_exclusive": 5
+    "zone_exclusive": 6
    },
-   "intent_errors_enforced": 5,
+   "intent_errors_enforced": 6,
    "intent_errors_other": 0
   }
  },
  "intent-orangecrab": {
   "board": "orangecrab_ext_pll.kicad_pcb",
-  "mark": "improve",
+  "mark": "regress",
   "off": {
-   "crossings": 1063,
-   "health_block_displacement_max_mm": 18.5356,
+   "crossings": 1087,
+   "health_block_displacement_max_mm": 18.1954,
    "health_bus_foreign_crossings": null,
-   "hpwl": 2117.85,
+   "hpwl": 2121.92,
    "intent_errors": 1,
    "intent_errors_by_rule": {
     "zone_containment": 1
@@ -123,10 +123,10 @@
    "intent_errors_other": 0
   },
   "on": {
-   "crossings": 1053,
-   "health_block_displacement_max_mm": 18.5356,
+   "crossings": 1065,
+   "health_block_displacement_max_mm": 18.1954,
    "health_bus_foreign_crossings": null,
-   "hpwl": 2115.16,
+   "hpwl": 2131.25,
    "intent_errors": 0,
    "intent_errors_by_rule": {},
    "intent_errors_enforced": 0,
@@ -135,24 +135,24 @@
  },
  "intent-rp2350": {
   "board": "rp2350_fpga_eensy_prePlane.kicad_pcb",
-  "mark": "regress",
+  "mark": "improve",
   "off": {
-   "crossings": 416,
-   "health_block_displacement_max_mm": 11.5626,
+   "crossings": 421,
+   "health_block_displacement_max_mm": 11.286,
    "health_bus_foreign_crossings": null,
-   "hpwl": 958.22,
-   "intent_errors": 2,
+   "hpwl": 957.38,
+   "intent_errors": 3,
    "intent_errors_by_rule": {
-    "zone_containment": 2
+    "zone_containment": 3
    },
-   "intent_errors_enforced": 2,
+   "intent_errors_enforced": 3,
    "intent_errors_other": 0
   },
   "on": {
-   "crossings": 420,
-   "health_block_displacement_max_mm": 11.5626,
+   "crossings": 416,
+   "health_block_displacement_max_mm": 11.8051,
    "health_bus_foreign_crossings": null,
-   "hpwl": 957.42,
+   "hpwl": 949.81,
    "intent_errors": 1,
    "intent_errors_by_rule": {
     "zone_containment": 1
@@ -165,10 +165,10 @@
   "board": "ulx3s.kicad_pcb",
   "mark": "regress",
   "off": {
-   "crossings": 2477,
-   "health_block_displacement_max_mm": 17.9512,
+   "crossings": 2429,
+   "health_block_displacement_max_mm": 18.9597,
    "health_bus_foreign_crossings": null,
-   "hpwl": 7437.99,
+   "hpwl": 7493.73,
    "intent_errors": 4,
    "intent_errors_by_rule": {
     "zone_containment": 4
@@ -177,10 +177,10 @@
    "intent_errors_other": 0
   },
   "on": {
-   "crossings": 2491,
-   "health_block_displacement_max_mm": 19.9427,
+   "crossings": 2449,
+   "health_block_displacement_max_mm": 20.9521,
    "health_bus_foreign_crossings": null,
-   "hpwl": 7508.56,
+   "hpwl": 7571.85,
    "intent_errors": 0,
    "intent_errors_by_rule": {},
    "intent_errors_enforced": 0,

--- a/tests/placement_rule1_withdrawal.json
+++ b/tests/placement_rule1_withdrawal.json
@@ -1,103 +1,103 @@
 {
- "_why": [
-  "The record pre-registered rule 2 demands: the withdrawal keeps its row,",
-  "with its measured direction, in the `rejected` style test_placement_ab.py",
-  "uses. It could not live in test_placement_ab.ROWS -- those rows are",
-  "quench-objective A/B pairs graded by floorplan.grade, and this one is a",
-  "route -- so it is the same discipline on the object that has the shape:",
-  "a committed literal, re-checked in milliseconds by",
-  "tests/test_789_rule1_withdrawal.py, failing if the mark changes.",
-  "",
-  "Numbers are from the slate run recorded in docs/placement-predictors.md.",
-  "They are metrics, not board bytes, so the test needs no wk/ tree.",
-  "STALE SINCE #826 (not failing): these are esp_prog portfolio jitter candidates, and the jitter now snaps its offset to the board's 0.05mm lattice, so a regenerated slate gives different numbers. The test re-derives rule1_check/rule1_advisory/select_best as PURE FUNCTIONS of the literals below, so nothing here can fail -- but the record can no longer be reproduced from HEAD without rebuilding the study tree."
- ],
- "rejected": true,
- "expect": "crossings-clause WITHDRAWN",
- "issue": 789,
- "discharges": "docs/placement-predictors.md pre-registered rule 2",
- "boards_in_run": 6,
- "measured": {
-  "board_key": "esp_prog",
-  "argv_sha_prefix": "52aaeed47e14fea7",
-  "baseline": {
-   "index": 0,
-   "crossings": 19,
-   "hpwl": 263.929,
-   "blocking": 4,
-   "note": "candidate 0, the plain quench, generated and routed by the slate study"
+  "_why": [
+    "The record pre-registered rule 2 demands: the withdrawal keeps its row,",
+    "with its measured direction, in the `rejected` style test_placement_ab.py",
+    "uses. It could not live in test_placement_ab.ROWS -- those rows are",
+    "quench-objective A/B pairs graded by floorplan.grade, and this one is a",
+    "route -- so it is the same discipline on the object that has the shape:",
+    "a committed literal, re-checked in milliseconds by",
+    "tests/test_789_rule1_withdrawal.py, failing if the mark changes.",
+    "",
+    "Numbers are from the slate run recorded in docs/placement-predictors.md.",
+    "They are metrics, not board bytes, so the test needs no wk/ tree.",
+    "STALE SINCE #826 for the JITTER rows only: indices 1, 4 and 5 are esp_prog portfolio jitter candidates, and the jitter now snaps its offset to the board's 0.05mm lattice, so a regenerated slate gives different numbers for them. Index 0 is the BASELINE -- the plain quench of the input board, which #826 does not touch -- and is still reproducible. The test re-derives rule1_check / rule1_advisory / select_best as PURE FUNCTIONS of the literals below, so nothing here can fail."
+  ],
+  "rejected": true,
+  "expect": "crossings-clause WITHDRAWN",
+  "issue": 789,
+  "discharges": "docs/placement-predictors.md pre-registered rule 2",
+  "boards_in_run": 6,
+  "measured": {
+    "board_key": "esp_prog",
+    "argv_sha_prefix": "52aaeed47e14fea7",
+    "baseline": {
+      "index": 0,
+      "crossings": 19,
+      "hpwl": 263.929,
+      "blocking": 4,
+      "note": "candidate 0, the plain quench, generated and routed by the slate study"
+    },
+    "firing_candidates": [
+      {
+        "index": 1,
+        "crossings": 23,
+        "hpwl": 236.74883999999992,
+        "blocking": 3
+      },
+      {
+        "index": 4,
+        "crossings": 23,
+        "hpwl": 243.7041599999999,
+        "blocking": 3
+      },
+      {
+        "index": 5,
+        "crossings": 24,
+        "hpwl": 254.54641999999996,
+        "blocking": 2
+      }
+    ],
+    "best_unbarred_blocking": 3,
+    "note": [
+      "All three are barred on crossings ALONE -- their hpwl is BELOW the",
+      "baseline's, so none is barred by the clause that survives. Candidate 5",
+      "carries the highest crossings on the slate and the best routed blocking,",
+      "and the best candidate the bar allows through routes to 3."
+    ]
   },
-  "firing_candidates": [
-   {
-    "index": 1,
-    "crossings": 23,
-    "hpwl": 236.74883999999992,
-    "blocking": 3
-   },
-   {
-    "index": 4,
-    "crossings": 23,
-    "hpwl": 243.7041599999999,
-    "blocking": 3
-   },
-   {
-    "index": 5,
-    "crossings": 24,
-    "hpwl": 254.54641999999996,
-    "blocking": 2
-   }
-  ],
-  "best_unbarred_blocking": 3,
-  "note": [
-   "All three are barred on crossings ALONE -- their hpwl is BELOW the",
-   "baseline's, so none is barred by the clause that survives. Candidate 5",
-   "carries the highest crossings on the slate and the best routed blocking,",
-   "and the best candidate the bar allows through routes to 3."
-  ]
- },
- "also_fired_on": {
-  "board_key": "kit-dev-coldfire-xilinx_5213",
-  "baseline_blocking": 5,
-  "firing_candidates": 1,
-  "guards": "reduced (one regeneration check, no re-route control), declared before the run"
- },
- "null_rate": {
-  "esp_prog": 1.0,
-  "kit-dev-coldfire-xilinx_5213": 0.99,
-  "watchy": 0.21,
-  "tigard": 0.0,
-  "_note": [
-   "Permuting `blocking` within the board and re-evaluating the criterion,",
-   "200 draws at seed 7789 -- so these are Monte-Carlo estimates, and the",
-   "middling ones carry a standard error of about 3 points. The 1.0 and 0.0",
-   "are not estimates: on esp_prog 9 of 10 candidates route below the",
-   "baseline's 4, so EVERY permutation fires, and on tigard none can.",
-   "Recorded for BOTH boards that discharged the rule, so the record of the",
-   "discharge cannot show the null rate of only half of it."
-  ]
- },
- "behavioural_delta": {
-  "_measured_over": "all 6 boards of the slate run",
-  "static_only": "6 of 6 boards unchanged -- rank_key slot 1 IS crossings, so a crossings-barred candidate already sorts below every candidate with fewer, and select_best reaches a non-violator first",
-  "with_oracle_probe": "esp_prog changes from blocking 3 to blocking 2; the other five unchanged",
-  "oracle_probe_cannot_show_worse": true,
-  "_oracle_caveat": [
-   "The probe arm ranks candidates by their TRUE routed blocking, and the",
-   "withdrawn violator set is a SUBSET of the old one, so select_best can",
-   "only move the pick EARLIER in a truth-sorted list. That arm is",
-   "structurally incapable of returning 'worse', and its 0 is a property of",
-   "the construction rather than a result. Found by an adversarial",
-   "fact-check of this file's own first version, which counted it as one of",
-   "two independent arms.",
-   "",
-   "Under a probe that MIS-ranks, the withdrawal can be worse: esp_prog's",
-   "candidate 3 is crossings-barred and routes to blocking 6, so a probe",
-   "that puts it first picks 6 after the withdrawal where the bar had",
-   "forced a fall-through to 3."
-  ],
-  "worse_on_static_arm": 0,
-  "mis_ranking_probe_can_be_worse": true,
-  "with_adversarial_probe": "worse on 2 boards: esp_prog 3 -> 6, kit-dev-coldfire 1 -> 9",
-  "worse_on_adversarial_arm": 2
- }
+  "also_fired_on": {
+    "board_key": "kit-dev-coldfire-xilinx_5213",
+    "baseline_blocking": 5,
+    "firing_candidates": 1,
+    "guards": "reduced (one regeneration check, no re-route control), declared before the run"
+  },
+  "null_rate": {
+    "esp_prog": 1.0,
+    "kit-dev-coldfire-xilinx_5213": 0.99,
+    "watchy": 0.21,
+    "tigard": 0.0,
+    "_note": [
+      "Permuting `blocking` within the board and re-evaluating the criterion,",
+      "200 draws at seed 7789 -- so these are Monte-Carlo estimates, and the",
+      "middling ones carry a standard error of about 3 points. The 1.0 and 0.0",
+      "are not estimates: on esp_prog 9 of 10 candidates route below the",
+      "baseline's 4, so EVERY permutation fires, and on tigard none can.",
+      "Recorded for BOTH boards that discharged the rule, so the record of the",
+      "discharge cannot show the null rate of only half of it."
+    ]
+  },
+  "behavioural_delta": {
+    "_measured_over": "all 6 boards of the slate run",
+    "static_only": "6 of 6 boards unchanged -- rank_key slot 1 IS crossings, so a crossings-barred candidate already sorts below every candidate with fewer, and select_best reaches a non-violator first",
+    "with_oracle_probe": "esp_prog changes from blocking 3 to blocking 2; the other five unchanged",
+    "oracle_probe_cannot_show_worse": true,
+    "_oracle_caveat": [
+      "The probe arm ranks candidates by their TRUE routed blocking, and the",
+      "withdrawn violator set is a SUBSET of the old one, so select_best can",
+      "only move the pick EARLIER in a truth-sorted list. That arm is",
+      "structurally incapable of returning 'worse', and its 0 is a property of",
+      "the construction rather than a result. Found by an adversarial",
+      "fact-check of this file's own first version, which counted it as one of",
+      "two independent arms.",
+      "",
+      "Under a probe that MIS-ranks, the withdrawal can be worse: esp_prog's",
+      "candidate 3 is crossings-barred and routes to blocking 6, so a probe",
+      "that puts it first picks 6 after the withdrawal where the bar had",
+      "forced a fall-through to 3."
+    ],
+    "worse_on_static_arm": 0,
+    "mis_ranking_probe_can_be_worse": true,
+    "with_adversarial_probe": "worse on 2 boards: esp_prog 3 -> 6, kit-dev-coldfire 1 -> 9",
+    "worse_on_adversarial_arm": 2
+  }
 }

--- a/tests/placement_rule1_withdrawal.json
+++ b/tests/placement_rule1_withdrawal.json
@@ -1,102 +1,103 @@
 {
-  "_why": [
-    "The record pre-registered rule 2 demands: the withdrawal keeps its row,",
-    "with its measured direction, in the `rejected` style test_placement_ab.py",
-    "uses. It could not live in test_placement_ab.ROWS -- those rows are",
-    "quench-objective A/B pairs graded by floorplan.grade, and this one is a",
-    "route -- so it is the same discipline on the object that has the shape:",
-    "a committed literal, re-checked in milliseconds by",
-    "tests/test_789_rule1_withdrawal.py, failing if the mark changes.",
-    "",
-    "Numbers are from the slate run recorded in docs/placement-predictors.md.",
-    "They are metrics, not board bytes, so the test needs no wk/ tree."
+ "_why": [
+  "The record pre-registered rule 2 demands: the withdrawal keeps its row,",
+  "with its measured direction, in the `rejected` style test_placement_ab.py",
+  "uses. It could not live in test_placement_ab.ROWS -- those rows are",
+  "quench-objective A/B pairs graded by floorplan.grade, and this one is a",
+  "route -- so it is the same discipline on the object that has the shape:",
+  "a committed literal, re-checked in milliseconds by",
+  "tests/test_789_rule1_withdrawal.py, failing if the mark changes.",
+  "",
+  "Numbers are from the slate run recorded in docs/placement-predictors.md.",
+  "They are metrics, not board bytes, so the test needs no wk/ tree.",
+  "STALE SINCE #826 (not failing): these are esp_prog portfolio jitter candidates, and the jitter now snaps its offset to the board's 0.05mm lattice, so a regenerated slate gives different numbers. The test re-derives rule1_check/rule1_advisory/select_best as PURE FUNCTIONS of the literals below, so nothing here can fail -- but the record can no longer be reproduced from HEAD without rebuilding the study tree."
+ ],
+ "rejected": true,
+ "expect": "crossings-clause WITHDRAWN",
+ "issue": 789,
+ "discharges": "docs/placement-predictors.md pre-registered rule 2",
+ "boards_in_run": 6,
+ "measured": {
+  "board_key": "esp_prog",
+  "argv_sha_prefix": "52aaeed47e14fea7",
+  "baseline": {
+   "index": 0,
+   "crossings": 19,
+   "hpwl": 263.929,
+   "blocking": 4,
+   "note": "candidate 0, the plain quench, generated and routed by the slate study"
+  },
+  "firing_candidates": [
+   {
+    "index": 1,
+    "crossings": 23,
+    "hpwl": 236.74883999999992,
+    "blocking": 3
+   },
+   {
+    "index": 4,
+    "crossings": 23,
+    "hpwl": 243.7041599999999,
+    "blocking": 3
+   },
+   {
+    "index": 5,
+    "crossings": 24,
+    "hpwl": 254.54641999999996,
+    "blocking": 2
+   }
   ],
-  "rejected": true,
-  "expect": "crossings-clause WITHDRAWN",
-  "issue": 789,
-  "discharges": "docs/placement-predictors.md pre-registered rule 2",
-  "boards_in_run": 6,
-  "measured": {
-    "board_key": "esp_prog",
-    "argv_sha_prefix": "52aaeed47e14fea7",
-    "baseline": {
-      "index": 0,
-      "crossings": 19,
-      "hpwl": 263.929,
-      "blocking": 4,
-      "note": "candidate 0, the plain quench, generated and routed by the slate study"
-    },
-    "firing_candidates": [
-      {
-        "index": 1,
-        "crossings": 23,
-        "hpwl": 236.74883999999992,
-        "blocking": 3
-      },
-      {
-        "index": 4,
-        "crossings": 23,
-        "hpwl": 243.7041599999999,
-        "blocking": 3
-      },
-      {
-        "index": 5,
-        "crossings": 24,
-        "hpwl": 254.54641999999996,
-        "blocking": 2
-      }
-    ],
-    "best_unbarred_blocking": 3,
-    "note": [
-      "All three are barred on crossings ALONE -- their hpwl is BELOW the",
-      "baseline's, so none is barred by the clause that survives. Candidate 5",
-      "carries the highest crossings on the slate and the best routed blocking,",
-      "and the best candidate the bar allows through routes to 3."
-    ]
-  },
-  "also_fired_on": {
-    "board_key": "kit-dev-coldfire-xilinx_5213",
-    "baseline_blocking": 5,
-    "firing_candidates": 1,
-    "guards": "reduced (one regeneration check, no re-route control), declared before the run"
-  },
-  "null_rate": {
-    "esp_prog": 1.0,
-    "kit-dev-coldfire-xilinx_5213": 0.99,
-    "watchy": 0.21,
-    "tigard": 0.0,
-    "_note": [
-      "Permuting `blocking` within the board and re-evaluating the criterion,",
-      "200 draws at seed 7789 -- so these are Monte-Carlo estimates, and the",
-      "middling ones carry a standard error of about 3 points. The 1.0 and 0.0",
-      "are not estimates: on esp_prog 9 of 10 candidates route below the",
-      "baseline's 4, so EVERY permutation fires, and on tigard none can.",
-      "Recorded for BOTH boards that discharged the rule, so the record of the",
-      "discharge cannot show the null rate of only half of it."
-    ]
-  },
-  "behavioural_delta": {
-    "_measured_over": "all 6 boards of the slate run",
-    "static_only": "6 of 6 boards unchanged -- rank_key slot 1 IS crossings, so a crossings-barred candidate already sorts below every candidate with fewer, and select_best reaches a non-violator first",
-    "with_oracle_probe": "esp_prog changes from blocking 3 to blocking 2; the other five unchanged",
-    "oracle_probe_cannot_show_worse": true,
-    "_oracle_caveat": [
-      "The probe arm ranks candidates by their TRUE routed blocking, and the",
-      "withdrawn violator set is a SUBSET of the old one, so select_best can",
-      "only move the pick EARLIER in a truth-sorted list. That arm is",
-      "structurally incapable of returning 'worse', and its 0 is a property of",
-      "the construction rather than a result. Found by an adversarial",
-      "fact-check of this file's own first version, which counted it as one of",
-      "two independent arms.",
-      "",
-      "Under a probe that MIS-ranks, the withdrawal can be worse: esp_prog's",
-      "candidate 3 is crossings-barred and routes to blocking 6, so a probe",
-      "that puts it first picks 6 after the withdrawal where the bar had",
-      "forced a fall-through to 3."
-    ],
-    "worse_on_static_arm": 0,
-    "mis_ranking_probe_can_be_worse": true,
-    "with_adversarial_probe": "worse on 2 boards: esp_prog 3 -> 6, kit-dev-coldfire 1 -> 9",
-    "worse_on_adversarial_arm": 2
-  }
+  "best_unbarred_blocking": 3,
+  "note": [
+   "All three are barred on crossings ALONE -- their hpwl is BELOW the",
+   "baseline's, so none is barred by the clause that survives. Candidate 5",
+   "carries the highest crossings on the slate and the best routed blocking,",
+   "and the best candidate the bar allows through routes to 3."
+  ]
+ },
+ "also_fired_on": {
+  "board_key": "kit-dev-coldfire-xilinx_5213",
+  "baseline_blocking": 5,
+  "firing_candidates": 1,
+  "guards": "reduced (one regeneration check, no re-route control), declared before the run"
+ },
+ "null_rate": {
+  "esp_prog": 1.0,
+  "kit-dev-coldfire-xilinx_5213": 0.99,
+  "watchy": 0.21,
+  "tigard": 0.0,
+  "_note": [
+   "Permuting `blocking` within the board and re-evaluating the criterion,",
+   "200 draws at seed 7789 -- so these are Monte-Carlo estimates, and the",
+   "middling ones carry a standard error of about 3 points. The 1.0 and 0.0",
+   "are not estimates: on esp_prog 9 of 10 candidates route below the",
+   "baseline's 4, so EVERY permutation fires, and on tigard none can.",
+   "Recorded for BOTH boards that discharged the rule, so the record of the",
+   "discharge cannot show the null rate of only half of it."
+  ]
+ },
+ "behavioural_delta": {
+  "_measured_over": "all 6 boards of the slate run",
+  "static_only": "6 of 6 boards unchanged -- rank_key slot 1 IS crossings, so a crossings-barred candidate already sorts below every candidate with fewer, and select_best reaches a non-violator first",
+  "with_oracle_probe": "esp_prog changes from blocking 3 to blocking 2; the other five unchanged",
+  "oracle_probe_cannot_show_worse": true,
+  "_oracle_caveat": [
+   "The probe arm ranks candidates by their TRUE routed blocking, and the",
+   "withdrawn violator set is a SUBSET of the old one, so select_best can",
+   "only move the pick EARLIER in a truth-sorted list. That arm is",
+   "structurally incapable of returning 'worse', and its 0 is a property of",
+   "the construction rather than a result. Found by an adversarial",
+   "fact-check of this file's own first version, which counted it as one of",
+   "two independent arms.",
+   "",
+   "Under a probe that MIS-ranks, the withdrawal can be worse: esp_prog's",
+   "candidate 3 is crossings-barred and routes to blocking 6, so a probe",
+   "that puts it first picks 6 after the withdrawal where the bar had",
+   "forced a fall-through to 3."
+  ],
+  "worse_on_static_arm": 0,
+  "mis_ranking_probe_can_be_worse": true,
+  "with_adversarial_probe": "worse on 2 boards: esp_prog 3 -> 6, kit-dev-coldfire 1 -> 9",
+  "worse_on_adversarial_arm": 2
+ }
 }

--- a/tests/test_504_ratsnest_metrics.py
+++ b/tests/test_504_ratsnest_metrics.py
@@ -59,7 +59,12 @@ def test_metrics_out_is_populated_and_matches_total_cost():
     m = {}
     quench(parse_kicad_pcb(BOARD), pcb_file=BOARD, max_displacement=2.0,
            step=1.0, max_passes=1, metrics_out=m)
-    assert set(m) == {'before', 'after', 'legality'}, f"keys: {sorted(m)}"
+    # `board_grid` joined this set in #708. The rule the set enforces is that
+    # new NUMBERS go inside `before`/`after`, never alongside them; this key is
+    # PROVENANCE -- which lattice the run resolved and how -- in the same
+    # category as the `intent_gate` key that has always been allowed to sit at
+    # the top level. Extended deliberately, not quietly.
+    assert set(m) == {'before', 'after', 'legality', 'board_grid'},         f"keys: {sorted(m)}"
     for phase in ('before', 'after'):
         for key in ('total', 'length', 'crossings', 'halo', 'edge', 'hpwl'):
             assert key in m[phase], f"{phase} missing {key}"

--- a/tests/test_548_align_orient.py
+++ b/tests/test_548_align_orient.py
@@ -182,13 +182,15 @@ def test_twelve_positional_args_still_bind():
 
 
 def test_metrics_stay_inside_before_and_after():
-    """test_504_ratsnest_metrics.py:46 asserts the EXACT top-level key set
-    {before, after, legality}. New numbers go inside, never alongside."""
+    """test_504_ratsnest_metrics.py asserts the EXACT top-level key set.
+    New NUMBERS go inside `before`/`after`, never alongside. `board_grid`
+    (#708) is provenance rather than a number -- which lattice this run
+    resolved and why -- so it sits at the top level like `intent_gate`."""
     p = os.path.join(KF, 'interf_u_unrouted.kicad_pcb')
     m = {}
     quench(parse_kicad_pcb(p), p, max_displacement=1.0, step=1.0, max_passes=1,
            align_weight=5.0, orient_weight=1.0, metrics_out=m)
-    assert set(m) == {'before', 'after', 'legality'}, sorted(m)
+    assert set(m) == {'before', 'after', 'legality', 'board_grid'}, sorted(m)
     for phase in ('before', 'after'):
         for k in ('total', 'length', 'crossings', 'halo', 'edge', 'hpwl',
                   'align', 'orient'):

--- a/tests/test_703_predictor_regen.py
+++ b/tests/test_703_predictor_regen.py
@@ -134,6 +134,26 @@ EXPECTED = {
     # miniature: this placement scores 23 crossings against the authored
     # board's 53 -- the best on the slate -- and routes to blocking 3 where the
     # authored board routes to 0.
+    # RE-RECORDED AGAIN for #826 (the portfolio jitter now snaps its offset to
+    # the board's lattice). Second consecutive re-record of this row, and both
+    # times for the same reason: it is the detector the header describes, and
+    # it fired. esp_prog is authored on 0.05mm; the jitter used to hand the
+    # quench a seed board at 0.525 occupancy -- below the inference floor --
+    # and now hands it one at 0.825, so this candidate's poses genuinely
+    # differ. Reproduced twice.
+    #
+    # What did NOT move, which is why the commentary below still stands:
+    # `truth.headline` is still 3 and `predictors.crossings` is still 23. The
+    # routed board is marginally worse this time -- vias 23 -> 25, copper
+    # 263.91 -> 264.89mm, segments 203 -> 207 -- at the same blocking. That is
+    # a different placement, not a better or worse fix; the escape landed
+    # somewhere else.
+    #
+    # `esp_prog:perturb-scatter-d1` deliberately did NOT move: `perturb.py`'s
+    # scatter kind calls perturb_jitter positionally and keeps the continuous
+    # sampler, so its damage model is untouched. That row regenerating
+    # identically is the evidence for it.
+    #
     # RE-RECORDED for #708 (the seed-relative candidate snap). This row is the
     # detector the header describes -- "a change to the placement engine ...
     # silently moving the numbers the study measured" -- and it fired, which is
@@ -147,16 +167,16 @@ EXPECTED = {
     # routed board is in fact slightly better -- vias 28 -> 23, copper
     # 299.93 -> 263.91mm, segments 231 -> 203 -- at the same blocking.
     'esp_prog:portfolio-1': dict(
-        poses_sha256='aa84f6b468eae8f04ef72cc2ff02d4e0eead818463289e7328bce162f9dd3364',
+        poses_sha256='285c29cf614f5d7adbe998aea92cc46c5fabf2e6fac337c70415731507458416',
         argv_sha='52aaeed47e14fea796be12c36db09c605a4b8ec588da12bded6a2573b1c7f0b0',
         seconds=9.5,
         truth={'headline': 3,
-               'quality': {'vias': 23, 'copper_mm': 263.91, 'segments': 203}},
+               'quality': {'vias': 25, 'copper_mm': 264.89, 'segments': 207}},
         predictors={
-            'crossings': 23, 'hpwl': 236.44943999999998,
-            'halo': 114.29726291832301, 'overlap_area': 1.0,
+            'crossings': 23, 'hpwl': 236.3288399999999,
+            'halo': 114.71957178262542, 'overlap_area': 1.0,
             'pad_copper': 0, 'pad_clearance_pairs': 0,
-            'edge': 11.327191579199937, 'total': 582.4363161985618,
+            'edge': 11.104407139199958, 'total': 582.5469865623817,
             'oob_count': 0,
         }),
     # A SECOND board, so a change that only moves one board's numbers cannot

--- a/tests/test_703_predictor_regen.py
+++ b/tests/test_703_predictor_regen.py
@@ -134,17 +134,29 @@ EXPECTED = {
     # miniature: this placement scores 23 crossings against the authored
     # board's 53 -- the best on the slate -- and routes to blocking 3 where the
     # authored board routes to 0.
+    # RE-RECORDED for #708 (the seed-relative candidate snap). This row is the
+    # detector the header describes -- "a change to the placement engine ...
+    # silently moving the numbers the study measured" -- and it fired, which is
+    # it working. The quench now offers candidates on the board's own lattice,
+    # so this candidate's poses genuinely differ; `poses_sha256`, the four
+    # geometry predictors and the routed `quality` moved with them, and the
+    # values below are from the run, reproduced twice.
+    #
+    # What did NOT move, and is why the commentary above still stands:
+    # `truth.headline` is still 3 and `predictors.crossings` is still 23. The
+    # routed board is in fact slightly better -- vias 28 -> 23, copper
+    # 299.93 -> 263.91mm, segments 231 -> 203 -- at the same blocking.
     'esp_prog:portfolio-1': dict(
-        poses_sha256='4c299873cd66c843dc6b27fcadf99c9782a7e7e1a3b51328a5b5cee9ca6593d8',
+        poses_sha256='aa84f6b468eae8f04ef72cc2ff02d4e0eead818463289e7328bce162f9dd3364',
         argv_sha='52aaeed47e14fea796be12c36db09c605a4b8ec588da12bded6a2573b1c7f0b0',
-        seconds=23.8,
+        seconds=9.5,
         truth={'headline': 3,
-               'quality': {'vias': 28, 'copper_mm': 299.93, 'segments': 231}},
+               'quality': {'vias': 23, 'copper_mm': 263.91, 'segments': 203}},
         predictors={
-            'crossings': 23, 'hpwl': 236.74883999999992,
-            'halo': 113.8065780241933, 'overlap_area': 1.0,
+            'crossings': 23, 'hpwl': 236.44943999999998,
+            'halo': 114.29726291832301, 'overlap_area': 1.0,
             'pad_copper': 0, 'pad_clearance_pairs': 0,
-            'edge': 11.574407139199987, 'total': 582.4219077763819,
+            'edge': 11.327191579199937, 'total': 582.4363161985618,
             'oob_count': 0,
         }),
     # A SECOND board, so a change that only moves one board's numbers cannot

--- a/tests/test_708_board_grid.py
+++ b/tests/test_708_board_grid.py
@@ -85,10 +85,18 @@ def t_occupancy_counts_what_it_says():
            '%.4f' % BG.occupancy(vals, 0.3175))
     report('a degenerate step scores 0 rather than dividing by it',
            BG.occupancy(vals, 0.0) == 0.0 and BG.occupancy([], 0.1) == 0.0)
-    # The tolerance is absolute in mm, not relative to the step.
-    report('the 1um tolerance is absolute',
-           BG.occupancy([0.0009], 1.0) == 1.0
-           and BG.occupancy([0.0011], 1.0) == 0.0)
+    # The tolerance is absolute in mm, not relative to the step. Both arms
+    # need a step != 1.0, or `* step` is a no-op and the assertion cannot see
+    # the difference -- the first draft used 1.0 and the mutation battery
+    # caught it as a survivor.
+    report('the 1um tolerance is absolute, not a fraction of the step',
+           BG.occupancy([0.0009], 0.05) == 1.0,     # relative form: 0.018, miss
+           'fine step')
+    report('and it does not widen with a coarse step',
+           BG.occupancy([0.002], 2.54) == 0.0,      # relative form: 0.0008, hit
+           'coarse step')
+    report('a plain miss is still a miss',
+           BG.occupancy([0.0011], 1.0) == 0.0)
 
 
 def t_finest_within_slack_not_argmax():

--- a/tests/test_708_board_grid.py
+++ b/tests/test_708_board_grid.py
@@ -1,0 +1,308 @@
+"""The board-lattice inference (#708): what it may return, and when it declines.
+
+The issue proposes an ARGMAX over a ladder of pitches. That rule is undefined
+exactly where it matters, because the ladder contains divisibility chains and
+occupancy is monotone along one -- so ties are structural, not accidental.
+These cases pin the two rules that replace it (finest-within-slack, and a
+minimum sample count), the corpus verdicts they produce, and the three claims
+in #708 that measurement contradicts.
+
+Cheap and hermetic: parsing 22 boards, no quench, no routing.
+"""
+
+import math
+import os
+import sys
+
+RUN_ALL_FAST_OK = True
+RUN_ALL_TIMEOUT = 300
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for _d in ('py_router', 'py_placer', 'py_tools'):
+    sys.path.insert(0, os.path.join(ROOT, _d))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import run_utils                                               # noqa: E402
+from kicad_parser import parse_kicad_pcb                       # noqa: E402
+from placement import board_grid as BG                         # noqa: E402
+
+FAILURES = []
+
+
+def report(name, ok, detail=''):
+    print(('  PASS  ' if ok else '  FAIL  ') + name
+          + (('  -- ' + detail) if detail else ''))
+    if not ok:
+        FAILURES.append(name)
+
+
+class _FP:
+    def __init__(self, x, y):
+        self.x, self.y = x, y
+
+
+class _PCB:
+    """The only surface `board_coordinates` touches."""
+    def __init__(self, xys):
+        self.footprints = {'R%d' % i: _FP(x, y)
+                           for i, (x, y) in enumerate(xys)}
+
+
+def on_lattice(step, n, origin_units=16):
+    """n parts whose x and y are exact multiples of `step`.
+
+    Anchored at 0, because that is where the module anchors and where real
+    boards put their lattice -- measured, a best-phase search over the corpus
+    never beat the origin-anchored fit on any board. A fixture offset by a
+    non-multiple (10.0 mm against a 0.635 lattice) is not an on-lattice board
+    at all, which is how the first draft of these cases failed.
+    """
+    return _PCB([(round((origin_units + i * 3) * step, 9),
+                  round((origin_units + i * 5) * step, 9))
+                 for i in range(n)])
+
+
+_CORPUS = {}
+
+
+def corpus():
+    if not _CORPUS:
+        boards = run_utils.corpus_boards()
+        if not boards:
+            return None
+        for p in boards:
+            name = os.path.basename(p).replace('.kicad_pcb', '')
+            _CORPUS[name] = BG.infer_board_grid(parse_kicad_pcb(p))
+    return _CORPUS
+
+
+# ------------------------------------------------------------------ cases
+
+def t_occupancy_counts_what_it_says():
+    vals = [0.0, 0.3175, 0.635, 0.4]          # 3 of 4 on 0.3175
+    report('occupancy is a plain hit rate',
+           abs(BG.occupancy(vals, 0.3175) - 0.75) < 1e-12,
+           '%.4f' % BG.occupancy(vals, 0.3175))
+    report('a degenerate step scores 0 rather than dividing by it',
+           BG.occupancy(vals, 0.0) == 0.0 and BG.occupancy([], 0.1) == 0.0)
+    # The tolerance is absolute in mm, not relative to the step.
+    report('the 1um tolerance is absolute',
+           BG.occupancy([0.0009], 1.0) == 1.0
+           and BG.occupancy([0.0011], 1.0) == 0.0)
+
+
+def t_finest_within_slack_not_argmax():
+    """A board on 0.635 has occupancy 1.00 at 0.635 AND at 0.3175, because
+    0.3175 divides it. The argmax #708 proposes has no answer; this returns
+    the finer of the tied pair, deliberately."""
+    ev = BG.infer_board_grid(on_lattice(0.635, 20))
+    report('a pure 0.635 board reports the tie',
+           set(ev['ties']) >= {0.3175, 0.635}, str(ev['ties']))
+    report('and resolves to the FINEST of it, not the argmax',
+           ev['step'] == 0.3175, str(ev['step']))
+    # Why finer is the safe direction: every pose the coarse lattice offers is
+    # still offered by the fine one, so nothing is removed. The reverse is not
+    # true, and picking coarse is how sonde_u would infer 1.27 off a tie.
+
+
+def t_only_two_values_are_reachable():
+    """Only 0.05 and 0.3175 have no proper divisor in the ladder, and
+    occupancy is monotone along a divisibility chain, so no other rung can
+    ever win. This is a property of the ladder, not of the corpus."""
+    reachable = set()
+    for s in BG.GRID_LADDER:
+        divisors = [d for d in BG.GRID_LADDER
+                    if d < s and abs(s / d - round(s / d)) < 1e-9]
+        if not divisors:
+            reachable.add(s)
+    report('exactly {0.05, 0.3175} have no ladder divisor',
+           reachable == {0.05, 0.3175}, str(sorted(reachable)))
+    # And the monotonicity the argument rests on, checked on real numbers.
+    vals = [1.27 * i + 0.0 for i in range(50)] + [3.1, 7.77, 0.4]
+    bad = [(d, s) for s in BG.GRID_LADDER for d in BG.GRID_LADDER
+           if d < s and abs(s / d - round(s / d)) < 1e-9
+           and BG.occupancy(vals, d) < BG.occupancy(vals, s) - 1e-12]
+    report('occupancy is monotone non-increasing along every divisor chain',
+           not bad, str(bad[:3]))
+
+
+def t_a_rate_needs_a_denominator():
+    """1-4 part fixtures score 1.00 at six rungs because hand-authored
+    coordinates are round by construction. There is no answer to give."""
+    ev = BG.infer_board_grid(on_lattice(0.635, 4))
+    report('below MIN_PARTS it declines', ev['step'] is None, str(ev['step']))
+    report('and names the denominator as the reason',
+           'n_parts 4 < 8' in ev['reason'], ev['reason'])
+    report('at exactly MIN_PARTS it answers',
+           BG.infer_board_grid(on_lattice(0.635, 8))['step'] == 0.3175)
+
+
+def t_the_floor_does_not_sit_on_a_sample():
+    """A threshold resting exactly on a corpus board is decided by `>=` vs `>`.
+    interf_u_unrouted scores 0.700000, which is why the floor is 0.67 and not
+    the round 0.70 the population gap first suggests."""
+    c = corpus()
+    if c is None:
+        report('floor clearance (SKIPPED: git could not enumerate the corpus)',
+               True)
+        return
+    bests = [(max(ev['profile'].values()), n) for n, ev in c.items()
+             if ev['n_parts'] >= BG.MIN_PARTS]
+    near = [(b, n) for b, n in bests if abs(b - BG.OCCUPANCY_FLOOR) < 0.02]
+    report('no corpus board sits within 0.02 of the floor',
+           not near, str(near))
+    above = min((b for b, _n in bests if b >= BG.OCCUPANCY_FLOOR), default=None)
+    below = max((b for b, _n in bests if b < BG.OCCUPANCY_FLOOR), default=None)
+    report('the floor sits inside a real population gap',
+           above is not None and below is not None and above - below > 0.05,
+           'nearest admitted %.4f, nearest rejected %.4f' % (above, below))
+
+
+def t_the_corpus_verdicts_are_pinned():
+    """The whole table, so a change to any constant has to face every board."""
+    expect = {
+        # imperial, and the boards #708 is about
+        'splitflap_driver': 0.3175, 'flat_hierarchy': 0.3175,
+        'sonde_u': 0.3175, 'interf_u_unrouted': 0.3175,
+        # metric-fine
+        'glasgow_revC': 0.05, 'esp_prog': 0.05,
+        'interf_u_unrouted_placed': 0.05, 'lvds_converter_dualclk': 0.05,
+        'lvds_converter_dualclk_gnd': 0.05, 'haasoscope_pro_max_test': 0.05,
+        'routed_output': 0.05,
+        # no lattice: below the floor
+        'orangecrab_ext_pll': None, 'tigard': None,
+        'rp2350_fpga_eensy_prePlane': None,
+        'kit-dev-coldfire-xilinx_5213': None,
+        'watchy': None, 'ulx3s': None,
+        # no lattice: too few parts
+        'cap_chain': None, 'qfn_csi_underpad_diff': None,
+        'qfn_diffpair_escape': None, 'qfn_interior_pads': None,
+        'qfn_underpad_coupling': None,
+    }
+    c = corpus()
+    if c is None:
+        report('corpus verdicts (SKIPPED: git could not enumerate the corpus)',
+               True)
+        return
+    wrong = {n: (c[n]['step'], want) for n, want in expect.items()
+             if n in c and c[n]['step'] != want}
+    report('every tracked board resolves as recorded', not wrong, str(wrong))
+    unlisted = sorted(set(c) - set(expect))
+    report('and the table covers the corpus (a new board must be judged)',
+           not unlisted, str(unlisted))
+
+
+def t_the_issue_s_coldfire_claim_is_refuted():
+    """#708 cites kit-dev-coldfire-xilinx_5213 as showing "the same signature
+    at 1.27mm". It does not, and this is the row that keeps the refutation from
+    being re-litigated."""
+    c = corpus()
+    if c is None:
+        report('coldfire (SKIPPED: no corpus)', True)
+        return
+    ev = c.get('kit-dev-coldfire-xilinx_5213')
+    if ev is None:
+        report('coldfire is in the corpus', False)
+        return
+    best = max(ev['profile'].values())
+    report('its 1.27 occupancy is far below its own maximum',
+           ev['profile'][1.27] < 0.2 and best < 0.3,
+           '1.27 -> %.3f, best %.3f' % (ev['profile'][1.27], best))
+    report('so it reports NO lattice', ev['step'] is None)
+    # The one corpus claim #708 gets right, kept beside the one it does not.
+    report('ulx3s and watchy report no lattice, as the issue says',
+           c['ulx3s']['step'] is None and c['watchy']['step'] is None)
+
+
+def t_it_declines_rather_than_inventing():
+    report('a board with no footprints declines',
+           BG.infer_board_grid(_PCB([]))['reason'] == 'no footprints')
+    nonfinite = _PCB([(float('nan'), 1.0)] * 10)
+    vals, n_parts = BG.board_coordinates(nonfinite)
+    report('non-finite coordinates are dropped from the SAMPLE',
+           vals == [1.0] * 10, str(vals[:3]))
+    report('while n_parts still counts the footprints that exist',
+           n_parts == 10, str(n_parts))
+    try:
+        BG.infer_board_grid(on_lattice(0.1, 10), ladder=(0.0, 0.1))
+        raised = False
+    except ValueError:
+        raised = True
+    report('a non-positive ladder rung raises rather than dividing by zero',
+           raised)
+
+
+def t_resolve_falls_back_and_says_which_branch():
+    """There is no flag: the fallback IS the off state, and a caller has to be
+    able to tell which branch ran."""
+    lat, ev = BG.resolve_snap_lattice(on_lattice(0.635, 20), 0.1)
+    report('an inferable board resolves to its lattice',
+           lat == 0.3175 and ev['source'] == 'inferred', '%s %s' % (lat, ev['source']))
+    lat, ev = BG.resolve_snap_lattice(on_lattice(0.635, 4), 0.1)
+    report('a board with no lattice falls back to grid_step',
+           lat == 0.1 and ev['source'] == 'grid_step', '%s %s' % (lat, ev['source']))
+    report('and the fallback still carries the reason',
+           'n_parts' in ev['reason'], ev['reason'])
+    lat, ev = BG.resolve_snap_lattice(on_lattice(0.635, 20), 0.1, override=0.5)
+    report('an override wins and is labelled as given',
+           lat == 0.5 and ev['source'] == 'explicit')
+    try:
+        BG.resolve_snap_lattice(on_lattice(0.635, 20), 0.1, override=0.0)
+        raised = False
+    except ValueError:
+        raised = True
+    report('a non-positive override raises', raised)
+
+
+def t_describe_names_the_branch_it_took():
+    _lat, ev = BG.resolve_snap_lattice(on_lattice(0.635, 20), 0.1)
+    line = BG.describe(ev)
+    report('the inferred line names the lattice and the evidence',
+           '0.3175' in line and 'inferred' in line and '40' in line, line)
+    _lat, ev = BG.resolve_snap_lattice(on_lattice(0.635, 4), 0.1)
+    line = BG.describe(ev)
+    report('the fallback line says it is the raster, and why',
+           'raster' in line and 'n_parts' in line, line)
+
+
+TESTS = [
+    ('occupancy', t_occupancy_counts_what_it_says),
+    ('finest, not argmax', t_finest_within_slack_not_argmax),
+    ('the ladder admits two answers', t_only_two_values_are_reachable),
+    ('a rate needs a denominator', t_a_rate_needs_a_denominator),
+    ('the floor is off every sample', t_the_floor_does_not_sit_on_a_sample),
+    ('corpus verdicts', t_the_corpus_verdicts_are_pinned),
+    ("#708's coldfire claim", t_the_issue_s_coldfire_claim_is_refuted),
+    ('it declines rather than inventing', t_it_declines_rather_than_inventing),
+    ('resolve names its branch', t_resolve_falls_back_and_says_which_branch),
+    ('describe', t_describe_names_the_branch_it_took),
+]
+
+
+def _every_case_is_registered():
+    g = globals()
+    declared = {fn for _l, fn in TESTS}
+    missing = sorted(n for n, v in g.items()
+                     if n.startswith('t_') and callable(v)
+                     and v not in declared)
+    if missing:
+        print('  FAIL  every t_* case is registered in TESTS  -- ORPHANED: %s'
+              % ', '.join(missing))
+        FAILURES.append('unregistered cases: %s' % ', '.join(missing))
+
+
+def main():
+    print('board lattice inference (#708)')
+    for label, fn in TESTS:
+        print(' ' + label)
+        fn()
+    _every_case_is_registered()
+    if FAILURES:
+        print('\nFAILED (%d): %s' % (len(FAILURES), ', '.join(FAILURES)))
+        return 1
+    print('\nOK')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_708_seed_relative_snap.py
+++ b/tests/test_708_seed_relative_snap.py
@@ -27,24 +27,26 @@ Both are properties of the mechanism rather than of a board, which is why they
 are asserted on an imperial board, a metric-fine one, and one with no
 inferable lattice at all.
 
-MEASURED, `tests/mutate_708.py`, third run: 15 rows, 14 killed, 1 survived
-(expected), 0 broken. The table, from the run:
+MEASURED, `tests/mutate_708.py`, sixth run: 17 rows, 16 killed, 1
+survived (expected), 0 broken. The table, from the run:
 
-    the-tie-break-takes-the-argmax                  SURVIVED  (expected)
-    the-tie-break-takes-the-coarsest                KILLED   6
-    the-min-parts-gate-is-dropped                   KILLED   7
-    the-occupancy-floor-is-dropped                  KILLED   4
-    the-floor-returns-to-the-round-0.70             KILLED   2
-    the-tolerance-becomes-relative-to-the-step      KILLED   3
-    the-sample-drops-one-axis                       KILLED   3
-    the-candidate-snap-goes-back-to-absolute        KILLED  10
-    the-offset-snaps-to-the-raster-not-the-lattice  KILLED   5
-    the-radius-test-goes-back-before-the-snap       KILLED   2
-    the-lattice-is-never-resolved                   KILLED   5
-    the-group-probe-goes-back-to-the-absolute-pose  KILLED   2
-    the-group-offset-snaps-the-absolute-pose        KILLED   3
-    the-fanout-snap-goes-back-to-absolute           KILLED   4
-    the-reseat-slot-snaps-the-absolute-point        KILLED   3
+    the-tie-break-takes-the-argmax                 SURVIVED 0
+    the-tie-break-takes-the-coarsest               KILLED   6
+    the-min-parts-gate-is-dropped                  KILLED   7
+    the-occupancy-floor-is-dropped                 KILLED   4
+    the-floor-returns-to-the-round-0.70            KILLED   2
+    the-tolerance-becomes-relative-to-the-step     KILLED   3
+    the-sample-drops-one-axis                      KILLED   4
+    the-candidate-snap-goes-back-to-absolute       KILLED   10
+    the-offset-snaps-to-the-raster-not-the-lattice KILLED   6
+    the-radius-test-goes-back-before-the-snap      KILLED   2
+    the-lattice-is-never-resolved                  KILLED   6
+    the-group-probe-goes-back-to-the-absolute-pose KILLED   2
+    the-group-offset-snaps-the-absolute-pose       KILLED   3
+    the-fanout-snap-goes-back-to-absolute          KILLED   4
+    the-reseat-accepts-on-the-prediction           KILLED   6
+    the-reseat-dedup-key-is-not-injective          KILLED   2
+    the-reseat-slot-snaps-the-absolute-point       KILLED   7
 
 The first run killed only 9 of 15. Five of its six survivors were holes in
 THESE arms rather than in the engine: an assertion at `step=1.0` where the

--- a/tests/test_708_seed_relative_snap.py
+++ b/tests/test_708_seed_relative_snap.py
@@ -34,7 +34,10 @@ for _d in ('py_router', 'py_placer', 'py_tools'):
 
 from kicad_parser import parse_kicad_pcb                        # noqa: E402
 from placement import board_grid as BG                          # noqa: E402
+from placement import fanout_clearance as FC                    # noqa: E402
 from placement import quench as Q                               # noqa: E402
+from placement import reseat as RS                              # noqa: E402
+from placement.utility import snap_to_grid as snap              # noqa: E402
 
 FAILURES = []
 
@@ -149,7 +152,14 @@ def t_the_generator_offers_only_on_lattice_poses():
     """Straight at `_candidate_positions`, so a failure localises."""
     class _P:
         seed_x, seed_y = 131.4450, 138.4300      # 207 x 0.635, 218 x 0.635
-    for lat in (0.1, 0.3175, 0.05):
+    # 0.635 is in this list for the radius arm, not the lattice arm: it is the
+    # only rung here where snapping ROUNDS UP past a 3.0mm cap
+    # (snap(3.0, 0.635) = 3.175). At 0.1, 0.05 and 0.3175 the snap always
+    # rounds down, so a version that tested the radius BEFORE snapping would
+    # look identical -- which is exactly how the first draft of this case let
+    # the mutation battery's `radius-test-goes-back-before-the-snap` row
+    # survive.
+    for lat in (0.1, 0.3175, 0.05, 0.635):
         cands = Q._candidate_positions(_P(), 3.0, 1.0, lat)
         off = [(cx - _P.seed_x, cy - _P.seed_y) for cx, cy in cands]
         report('offsets are multiples of %g' % lat,
@@ -189,7 +199,11 @@ def t_group_offsets_probes_the_pose_it_emits():
     """The admissibility probe used to snap the ABSOLUTE p.x + dx while the
     emitted offset was snap(dx); the cap was checked against a pose the block
     never takes. Assert on what is yielded."""
-    name = 'interf_u_unrouted'
+    # A board whose parts sit OFF the lattice, deliberately. On an on-lattice
+    # board `snap(p.x + sdx)` and `p.x + sdx` are the same number, so the
+    # probe/emit distinction is invisible and the mutation row for it survives
+    # -- which is what happened to the first draft, on interf_u.
+    name = 'rp2350_fpga_eensy_prePlane'
     path = board(name)
     pcb = parse_kicad_pcb(path)
     lat, _ev = lattice_of(name)
@@ -199,9 +213,28 @@ def t_group_offsets_probes_the_pose_it_emits():
         st = Q.QuenchState(pcb, path, 0.2, 0.55, 10.0, 0.5, 0.25, 2.0, 2.0,
                            2.0, 0.1, 1.0)
     refs = sorted(st.parts)[:3]
-    max_disp = 3.0
-    offs = list(Q._group_offsets(st, refs, max_disp, 1.0, lat))
+    off_lattice = [r for r in refs if not on_grid(st.parts[r].x, lat)]
+    report('the fixture is off-lattice, so probe and emit can disagree',
+           bool(off_lattice), '%d of %d' % (len(off_lattice), len(refs)))
+    max_disp, step = 3.0, 1.0
+    offs = sorted(Q._group_offsets(st, refs, max_disp, step, lat))
     report('the block move offers offsets at all', bool(offs), str(len(offs)))
+    # In a FRESH state every part is at its own seed, so the per-member cap
+    # reduces to a statement about the offset alone. Assert the whole SET, not
+    # just that what came out is valid: a probe measuring the wrong pose drops
+    # offsets near the cap, and "everything emitted is legal" cannot see a
+    # missing one.
+    n = int(max_disp / step)
+    want = sorted({(round(snap(ix * step, lat), 9),
+                    round(snap(iy * step, lat), 9))
+                   for ix in range(-n, n + 1) for iy in range(-n, n + 1)
+                   if math.hypot(snap(ix * step, lat),
+                                 snap(iy * step, lat)) <= max_disp + 1e-9}
+                  - {(0.0, 0.0)})
+    got = sorted((round(dx, 9), round(dy, 9)) for dx, dy in offs)
+    report('the emitted offsets are EXACTLY the lattice multiples in range',
+           got == want, 'got %d, want %d, missing %s'
+           % (len(got), len(want), sorted(set(want) - set(got))[:3]))
     bad = [(r, o) for o in offs for r in refs
            if math.hypot(st.parts[r].x + o[0] - st.parts[r].seed_x,
                          st.parts[r].y + o[1] - st.parts[r].seed_y)
@@ -243,12 +276,83 @@ def t_it_is_deterministic():
            '%d vs %d moves' % (len(a), len(b)))
 
 
+def t_the_two_repair_sites_are_seed_relative_but_not_coarsened():
+    """`fanout_clearance` and `reseat` take half the fix, on purpose.
+
+    They get the seed-relative half -- their offsets are multiples of the
+    RASTER, measured from the seed rather than from board origin -- and NOT the
+    board's lattice, because both searches are sub-millimetre clearance repair
+    and coarsening them starves the one search that must not be starved
+    (measured: 81 candidates -> 29 at 0.3175, -> 9 at 0.635, at fanout's
+    step=0.2).
+
+    Asserted here rather than left to the owning suites: neither
+    `test_fanout_clearance` nor `test_reseat` looks at phase at all, so the
+    mutation rows for these two sites both survived until this case existed.
+    """
+    grid = 0.1
+
+    class _Cap:
+        seed_x, seed_y = 131.4450, 138.4300      # deliberately OFF the raster
+    off = [(cx - _Cap.seed_x, cy - _Cap.seed_y)
+           for cx, cy in FC._candidate_positions(_Cap(), 1.0, 0.2, grid)]
+    report('fanout: candidate offsets are multiples of the raster',
+           all(on_grid(dx, grid) and on_grid(dy, grid) for dx, dy in off),
+           str([(round(a, 4), round(b, 4)) for a, b in off[:2]]))
+    report('fanout: and they are measured from the cap SEED, which is '
+           'off-raster, so the residue survives',
+           any(not on_grid(_Cap.seed_x + dx, grid) for dx, _dy in off))
+    report('fanout: the lattice is NOT applied there', len(off) == 81,
+           '%d candidates (81 = the raster set at step=0.2)' % len(off))
+
+    # reseat: every slot must sit on the ANCHOR's phase, not on a lattice
+    # through board origin. splitflap's B0 is at 171.57, which is not a
+    # multiple of 0.1, so the two differ.
+    name = 'splitflap_driver'
+    path = board(name)
+    pcb = parse_kicad_pcb(path)
+    import contextlib
+    import io
+    with contextlib.redirect_stdout(io.StringIO()):
+        st = Q.QuenchState(pcb, path, 0.2, 0.55, 10.0, 0.5, 0.25, 2.0, 2.0,
+                           2.0, grid, 1.0)
+        clusters = RS.clusters_from_tethers(pcb, st, 2.0)
+    cl = [c for c in clusters if not on_grid(st.parts[c.anchor].x, grid)]
+    report('reseat: the fixture has an off-raster anchor', bool(cl),
+           str([c.anchor for c in clusters][:4]))
+    if cl:
+        c = cl[0]
+        ax, ay = st.parts[c.anchor].x, st.parts[c.anchor].y
+        with contextlib.redirect_stdout(io.StringIO()):
+            slots = RS.slot_pool(st, c, grid_step=grid)
+        # The trailing entries are the members' OWN poses, appended unsnapped
+        # so the assignment can always return "leave it alone" -- `slot_pool`
+        # says so, and a member's pose need not be on any lattice. They are
+        # not generated slots and are excluded here rather than silently
+        # weakening the assertion to `most`.
+        ring = slots[:-len(c.members)]
+        identity = slots[-len(c.members):]
+        report('reseat: every GENERATED slot is the anchor pose plus a raster '
+               'multiple',
+               all(on_grid(x - ax, grid) and on_grid(y - ay, grid)
+                   for x, y, _r in ring),
+               '%s at (%.4f, %.4f), %d ring slots' % (c.anchor, ax, ay,
+                                                      len(ring)))
+        report('reseat: and NOT on a lattice through board origin',
+               any(not on_grid(x, grid) for x, _y, _r in ring))
+        report('reseat: the identity poses are the members\' own, untouched',
+               identity == [(st.parts[m].x, st.parts[m].y, st.parts[m].rot)
+                            for m in c.members], str(identity[:1]))
+
+
 TESTS = [
     ('residue', t_the_residue_theorem),
     ('conservation', t_conservation_of_the_lattice),
     ('the generator', t_the_generator_offers_only_on_lattice_poses),
     ('no lattice -> the raster', t_a_board_with_no_lattice_keeps_the_raster_granularity),
     ('group offsets probe what they emit', t_group_offsets_probes_the_pose_it_emits),
+    ('the repair sites take half the fix',
+     t_the_two_repair_sites_are_seed_relative_but_not_coarsened),
     ('disclosure', t_the_run_discloses_which_branch_it_took),
     ('determinism', t_it_is_deterministic),
 ]

--- a/tests/test_708_seed_relative_snap.py
+++ b/tests/test_708_seed_relative_snap.py
@@ -9,12 +9,19 @@ where one can be read off it.
 The two theorems below are stated so they need no baseline and no golden file:
 
   RESIDUE     every reported move is seed + an exact multiple of the lattice.
-  CONSERVATION the multiset of poses-modulo-lattice is PRESERVED across a whole
-              run, swaps included. A nudge maps on-lattice to on-lattice, and a
-              swap permutes poses among same-footprint parts, so the count of
-              on-lattice poses cannot change -- not merely "not get worse".
-              Today's count falls 120 -> 35 on splitflap, so this is a real
-              assertion and not a restatement of the code.
+  CONSERVATION the count of on-lattice poses is PRESERVED across a run with
+              nudges and group moves, because each maps a part inside its own
+              seed coset. Today's count falls 120 -> 35 on splitflap, so this
+              is a real assertion and not a restatement of the code.
+
+              NOT with swaps, and the first draft of this file claimed
+              otherwise. A swap hands part A the pose of part B, but A's
+              candidates are generated from A's OWN seed, so if A's seed is off
+              the lattice the next accepted nudge takes it back off and the
+              count moves. `t_a_swap_can_move_the_on_lattice_count` pins the
+              counterexample (glasgow_revC C3/C9). With swaps on, the invariant
+              that IS true is the weaker one asserted here: every pose still
+              lies on some part's seed coset.
 
 Both are properties of the mechanism rather than of a board, which is why they
 are asserted on an imperial board, a metric-fine one, and one with no
@@ -39,12 +46,15 @@ MEASURED, `tests/mutate_708.py`, third run: 15 rows, 14 killed, 1 survived
     the-fanout-snap-goes-back-to-absolute           KILLED   4
     the-reseat-slot-snaps-the-absolute-point        KILLED   3
 
-The first run killed only 9 of 15, and all six survivors were holes in THESE
-arms rather than in the engine -- an assertion at `step=1.0` where the mutated
-factor is a no-op, a lattice sweep that never rounded UP past the cap, a
-block-move fixture whose lattice was the raster, a probe fixture whose parts
-were already on-lattice, and two sites whose owning suites never look at phase.
-The rows and the reasons are in `mutate_708.py`.
+The first run killed only 9 of 15. Five of its six survivors were holes in
+THESE arms rather than in the engine: an assertion at `step=1.0` where the
+mutated factor is a no-op, a lattice sweep that never rounded UP past the cap,
+a probe fixture whose parts were already on-lattice, and two sites whose owning
+suites never look at phase. The sixth, `the-tie-break-takes-the-argmax`, is an
+EQUIVALENT MUTANT and is recorded as an expected survivor with its reason. A
+seventh row (`the-group-offset-snaps-the-absolute-pose`) was killed in run 1
+and only surfaced as a hole in run 2, once the probe fixture moved to a board
+whose lattice is the raster. The rows and the reasons are in `mutate_708.py`.
 """
 
 import math
@@ -129,8 +139,9 @@ def t_the_residue_theorem():
     """Every reported move is the seed plus an exact multiple of the lattice.
 
     Nudges and group moves only: a swap hands a part ANOTHER part's pose, which
-    is on that part's lattice offset, not on this one's. Conservation below is
-    the statement that covers swaps.
+    is on that part's coset, not on this one's. `t_conservation_of_the_lattice`
+    states what survives with swaps on, and
+    `t_a_swap_can_move_the_on_lattice_count` pins why it is weaker.
     """
     for name, want in BOARDS:
         lat, ev = lattice_of(name)
@@ -149,29 +160,89 @@ def t_the_residue_theorem():
 
 
 def t_conservation_of_the_lattice():
-    """The count of on-lattice poses is PRESERVED across a whole run.
+    """The count of on-lattice poses is preserved -- WITHOUT swaps.
 
-    Swaps on, which is the case the per-part residue statement cannot make.
-    Equality, not `>=`: a nudge maps on-lattice to on-lattice and a swap is a
-    permutation, so nothing can add or remove one.
+    The first draft of this case asserted equality with swaps ON, reasoning
+    that a swap merely permutes poses. That reasoning is wrong, and a review
+    produced the counterexample: `_candidate_positions` generates from
+    `part.seed_x`, so a part's residue is a property of its SEED, not of where
+    it currently sits. A swap hands part A the pose of part B; if A's seed is
+    off-lattice, every candidate A is offered afterwards is off-lattice, and
+    the next accepted nudge moves the count. On `glasgow_revC` there are five
+    same-footprint pairs inside the 3mm swap cap with one member on-lattice and
+    one off (C3 <-> C9, 1.985mm apart, is the smallest).
+
+    The equality held on the three boards here only by accident of board
+    choice: `interf_u_unrouted` has ZERO same-footprint pairs within the swap
+    cap, so its swap phase never fires at all. So the arm is stated where it is
+    actually a theorem -- nudges and group moves, which map each part inside
+    its own seed coset -- and the swaps-on run gets the weaker statement that
+    IS true of it.
     """
     for name, want in BOARDS:
         lat, _ev = lattice_of(name)
-        seeds, moved, _m = run(name)
+        seeds, moved, _m = run(name, allow_swaps=False)
         before = sum(1 for (x, y) in seeds.values()
                      for v in (x, y) if on_grid(v, lat))
         after = 0
         for r, (sx, sy) in seeds.items():
             x, y = moved.get(r, (sx, sy))
             after += sum(1 for v in (x, y) if on_grid(v, lat))
-        report('%s: on-%g count preserved (%d -> %d over %d coords)'
-               % (name, lat, before, after, 2 * len(seeds)),
+        report('%s: on-%g count preserved with no swaps (%d -> %d over %d '
+               'coords)' % (name, lat, before, after, 2 * len(seeds)),
                after == before, 'lost %d' % (before - after))
         if want is not None:
             report('%s: and that count is most of the board, so the '
                    'assertion has something to lose' % name,
                    before >= 0.6 * 2 * len(seeds),
                    '%d/%d' % (before, 2 * len(seeds)))
+
+        # Swaps ON: the true invariant is that every pose still lies on SOME
+        # part's seed coset -- no pose is invented off every lattice the board
+        # offers. That is what the fix guarantees and what a return to the
+        # absolute snap would break.
+        _s2, moved2, _m2 = run(name)
+        cosets = {round((sx / lat) % 1.0, 6) for sx, _sy in seeds.values()}
+        cosets |= {round((sy / lat) % 1.0, 6) for _sx, sy in seeds.values()}
+        stray = [(r, x, y) for r, (x, y) in moved2.items()
+                 if round((x / lat) % 1.0, 6) not in cosets
+                 or round((y / lat) % 1.0, 6) not in cosets]
+        report('%s: with swaps, every pose is still on some seed coset of %g'
+               % (name, lat), not stray, str(stray[:2]))
+
+
+def t_a_swap_can_move_the_on_lattice_count():
+    """The counterexample, pinned so the weaker statement above is not read as
+    a retreat from a theorem that was true.
+
+    glasgow_revC C3 and C9 are the same footprint, 1.985mm apart (inside the
+    default swap cap), C3 on the board's 0.05 lattice and C9 off it. Whichever
+    one ends up being nudged afterwards is anchored to ITS OWN seed, so the
+    count moves. This is a property of the engine, not of the fix -- it was
+    equally true before -- and it is the reason conservation is asserted
+    without swaps.
+    """
+    name = 'glasgow_revC'
+    lat, ev = lattice_of(name)
+    report('%s resolves the 0.05 lattice' % name, ev['step'] == 0.05,
+           str(ev['step']))
+    pcb = parse_kicad_pcb(board(name))
+    fps = pcb.footprints
+    a, b = fps.get('C3'), fps.get('C9')
+    report('the pair exists and shares a footprint',
+           a is not None and b is not None
+           and a.footprint_name == b.footprint_name,
+           '%s / %s' % (getattr(a, 'footprint_name', None),
+                        getattr(b, 'footprint_name', None)))
+    if a is None or b is None:
+        return
+    d = math.hypot(a.x - b.x, a.y - b.y)
+    report('and sits inside the default swap cap', d <= 3.0,
+           '%.3f mm apart' % d)
+    on_a = on_grid(a.x, lat) and on_grid(a.y, lat)
+    on_b = on_grid(b.x, lat) and on_grid(b.y, lat)
+    report('with exactly one of the two on the lattice', on_a != on_b,
+           'C3 on=%s, C9 on=%s' % (on_a, on_b))
 
 
 def t_the_generator_offers_only_on_lattice_poses():
@@ -194,12 +265,22 @@ def t_the_generator_offers_only_on_lattice_poses():
                '(lattice %g)' % lat,
                all(math.hypot(dx, dy) <= 3.0 + 1e-9 for dx, dy in off),
                'max %.4f' % max(math.hypot(dx, dy) for dx, dy in off))
-    # The measured claim the fix rests on: the lattice does not cost reach at
-    # the step this tool ships.
+    # Reach, stated as the bounded claim it is rather than the absolute one
+    # the first draft made. At the shipped default the lattice gains
+    # candidates; across the max_disp range it sometimes loses a few, because
+    # the exact cap rejects an offset that snapped UP past it.
     n_raster = len(Q._candidate_positions(_P(), 10.0, 1.0, 0.1))
     n_lat = len(Q._candidate_positions(_P(), 10.0, 1.0, 0.3175))
-    report('a 0.3175 lattice costs no candidates at step=1.0',
+    report('at the shipped default a 0.3175 lattice costs no candidates',
            n_lat >= n_raster, 'raster %d, lattice %d' % (n_raster, n_lat))
+    worst = 1.0
+    for i in range(1, 40):
+        md = i * 0.5
+        a = len(Q._candidate_positions(_P(), md, 1.0, 0.1))
+        b = len(Q._candidate_positions(_P(), md, 1.0, 0.3175))
+        worst = min(worst, b / a if a else 1.0)
+    report('and never loses more than 20% of them anywhere in max_disp '
+           '0.5..19.5', worst >= 0.80, 'worst ratio %.3f' % worst)
 
 
 def t_a_board_with_no_lattice_keeps_the_raster_granularity():
@@ -394,12 +475,61 @@ def t_the_two_repair_sites_are_seed_relative_but_not_coarsened():
                             for m in c.members], str(identity[:1]))
 
 
+def t_the_reseat_accepts_on_the_seated_cost_not_the_prediction():
+    """The reseat's prediction is blind to a member's UNSCORED nets.
+
+    `reseat_cluster` overrides the members' pads on the SCORED nets, but
+    `other_aw` comes from the live board, so a member's other nets are priced
+    at the pose it is leaving. On `ulx3s`'s `tether:B0`, C60 carries net 1
+    (`GND`, unscored) and net 278 (`PWRBTn`, scored): the prediction said
+    1214.28 and the seated board measures 1274.28. That is 60.0 at the
+    fixture's `crossing_penalty=30.0` -- two crossings -- and the cluster used
+    to be ACCEPTED on the number that did not describe it.
+
+    This was pre-existing; the #708 slot change only moved C60 to the pose that
+    exposes it. Kept here rather than in `test_reseat.py` because that suite
+    asserts the property (`never accepts a worse cluster cost`) while this
+    asserts the MECHANISM, including the dry-run contract, which nothing else
+    exercises.
+    """
+    import test_reseat as TR
+    from placement import reseat as R
+    pcb, st = TR._state()
+    clusters = TR._clusters(pcb, st, limit=3)
+    target = [c for c in clusters if c.name == 'tether:B0']
+    report('the ulx3s fixture still has tether:B0', bool(target),
+           str([c.name for c in clusters]))
+    if not target:
+        return
+    c = target[0]
+    before_state = {r: (p.x, p.y, p.rot) for r, p in st.parts.items()}
+    res = R.reseat_cluster(st, c, apply=False)
+    report('a cluster whose seated cost is worse is REFUSED',
+           not res.accepted, 'accepted=%s' % res.accepted)
+    report('and the refusal names the mechanism rather than a bare verdict',
+           'does not score' in (res.reason or ''), (res.reason or '')[:70])
+    report('the reported `after` is the SEATED cost, not the prediction',
+           abs(res.after - 1274.2793) < 0.01, '%.4f' % res.after)
+    report('apply=False leaves every part exactly where it was',
+           all((st.parts[r].x, st.parts[r].y, st.parts[r].rot) == v
+               for r, v in before_state.items()))
+    # A cluster that IS an improvement must still be accepted -- otherwise this
+    # guard would read as "working" while refusing everything.
+    accepted = [R.reseat_cluster(st, k, apply=False).accepted
+                for k in clusters]
+    report('and a genuinely improving cluster is still accepted',
+           any(accepted), str(accepted))
+
+
 TESTS = [
     ('residue', t_the_residue_theorem),
     ('conservation', t_conservation_of_the_lattice),
+    ('a swap can move the count', t_a_swap_can_move_the_on_lattice_count),
     ('the generator', t_the_generator_offers_only_on_lattice_poses),
     ('no lattice -> the raster', t_a_board_with_no_lattice_keeps_the_raster_granularity),
     ('group offsets probe what they emit', t_group_offsets_probes_the_pose_it_emits),
+    ('reseat accepts on the seated cost',
+     t_the_reseat_accepts_on_the_seated_cost_not_the_prediction),
     ('the repair sites take half the fix',
      t_the_two_repair_sites_are_seed_relative_but_not_coarsened),
     ('disclosure', t_the_run_discloses_which_branch_it_took),

--- a/tests/test_708_seed_relative_snap.py
+++ b/tests/test_708_seed_relative_snap.py
@@ -244,6 +244,29 @@ def t_group_offsets_probes_the_pose_it_emits():
     report('and every offset is a whole number of the lattice',
            all(on_grid(dx, lat) and on_grid(dy, lat) for dx, dy in offs))
 
+    # The board above has NO inferable lattice, so its lattice IS the 0.1
+    # raster and "snapped to the lattice" and "snapped to the raster" are the
+    # same statement there. A second fixture on a real imperial pitch is what
+    # makes the block move's lattice assertion able to fail -- without it the
+    # battery's `group-offset-snaps-the-absolute-pose` row survives.
+    name2 = 'interf_u_unrouted'
+    path2 = board(name2)
+    lat2, _ev2 = lattice_of(name2)
+    with contextlib.redirect_stdout(io.StringIO()):
+        st2 = Q.QuenchState(parse_kicad_pcb(path2), path2, 0.2, 0.55, 10.0,
+                            0.5, 0.25, 2.0, 2.0, 2.0, 0.1, 1.0)
+    refs2 = sorted(st2.parts)[:3]
+    offs2 = list(Q._group_offsets(st2, refs2, max_disp, step, lat2))
+    report('a block on an imperial board moves by whole lattice units, not '
+           'raster units',
+           bool(offs2) and all(on_grid(dx, lat2) and on_grid(dy, lat2)
+                               for dx, dy in offs2),
+           '%s lattice %g, %d offsets' % (name2, lat2, len(offs2)))
+    report('and those offsets are NOT all raster multiples, so the two '
+           'statements are distinguishable',
+           any(not on_grid(dx, 0.1) for dx, _dy in offs2),
+           str([round(d, 4) for d, _ in offs2[:3]]))
+
 
 def t_the_run_discloses_which_branch_it_took():
     for name, want in BOARDS:

--- a/tests/test_708_seed_relative_snap.py
+++ b/tests/test_708_seed_relative_snap.py
@@ -1,0 +1,283 @@
+"""#708: the quench moves a part by a whole number of the board's grid units.
+
+Before this, `_candidate_positions` snapped the ABSOLUTE candidate to a lattice
+through board origin, which threw away the seed's residue: one pass took
+splitflap_driver from 0.923 of its footprint coordinates on its own 0.3175mm
+lattice to 0.269. The fix snaps the OFFSET instead, to the board's own lattice
+where one can be read off it.
+
+The two theorems below are stated so they need no baseline and no golden file:
+
+  RESIDUE     every reported move is seed + an exact multiple of the lattice.
+  CONSERVATION the multiset of poses-modulo-lattice is PRESERVED across a whole
+              run, swaps included. A nudge maps on-lattice to on-lattice, and a
+              swap permutes poses among same-footprint parts, so the count of
+              on-lattice poses cannot change -- not merely "not get worse".
+              Today's count falls 120 -> 35 on splitflap, so this is a real
+              assertion and not a restatement of the code.
+
+Both are properties of the mechanism rather than of a board, which is why they
+are asserted on an imperial board, a metric-fine one, and one with no
+inferable lattice at all.
+"""
+
+import math
+import os
+import sys
+
+RUN_ALL_FAST_OK = True
+RUN_ALL_TIMEOUT = 1200
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for _d in ('py_router', 'py_placer', 'py_tools'):
+    sys.path.insert(0, os.path.join(ROOT, _d))
+
+from kicad_parser import parse_kicad_pcb                        # noqa: E402
+from placement import board_grid as BG                          # noqa: E402
+from placement import quench as Q                               # noqa: E402
+
+FAILURES = []
+
+# One imperial, one metric-fine, one with no inferable lattice. Small enough
+# to quench in seconds; the point is the mechanism, not the board.
+BOARDS = (('interf_u_unrouted', 0.3175),
+          ('esp_prog', 0.05),
+          ('rp2350_fpga_eensy_prePlane', None))
+
+QUENCH_KW = dict(max_displacement=3.0, step=1.0, grid_step=0.1, clearance=0.2,
+                 board_edge_clearance=0.55, max_passes=3, verbose=False)
+
+
+def report(name, ok, detail=''):
+    print(('  PASS  ' if ok else '  FAIL  ') + name
+          + (('  -- ' + detail) if detail else ''))
+    if not ok:
+        FAILURES.append(name)
+
+
+def board(name):
+    p = os.path.join(ROOT, 'kicad_files', name + '.kicad_pcb')
+    assert os.path.isfile(p) and os.path.getsize(p) > 0, p
+    return p
+
+
+def on_grid(v, step, tol=1e-6):
+    return abs(v / step - round(v / step)) * step <= tol
+
+
+_RUNS = {}
+
+
+def run(name, **over):
+    key = (name, tuple(sorted(over.items())))
+    if key in _RUNS:
+        return _RUNS[key]
+    path = board(name)
+    pcb = parse_kicad_pcb(path)
+    seeds = {r: (f.x, f.y) for r, f in pcb.footprints.items()}
+    kw = dict(QUENCH_KW)
+    kw.update(over)
+    metrics = {}
+    import contextlib
+    import io
+    with contextlib.redirect_stdout(io.StringIO()):
+        placements = Q.quench(pcb, path, metrics_out=metrics, **kw)
+    moved = {p['reference']: (p['new_x'], p['new_y'])
+             for p in (placements or [])}
+    _RUNS[key] = (seeds, moved, metrics)
+    return _RUNS[key]
+
+
+def lattice_of(name):
+    _lat, ev = BG.resolve_snap_lattice(parse_kicad_pcb(board(name)),
+                                       QUENCH_KW['grid_step'])
+    return _lat, ev
+
+
+# ------------------------------------------------------------------ cases
+
+def t_the_residue_theorem():
+    """Every reported move is the seed plus an exact multiple of the lattice.
+
+    Nudges and group moves only: a swap hands a part ANOTHER part's pose, which
+    is on that part's lattice offset, not on this one's. Conservation below is
+    the statement that covers swaps.
+    """
+    for name, want in BOARDS:
+        lat, ev = lattice_of(name)
+        if want is not None:
+            report('%s resolves the lattice this case is about' % name,
+                   ev['step'] == want, str(ev['step']))
+        seeds, moved, _m = run(name, allow_swaps=False)
+        bad = [(r, round(x - seeds[r][0], 6), round(y - seeds[r][1], 6))
+               for r, (x, y) in moved.items()
+               if not (on_grid(x - seeds[r][0], lat)
+                       and on_grid(y - seeds[r][1], lat))]
+        report('%s: every nudge is a whole number of %g mm (%d moves)'
+               % (name, lat, len(moved)), not bad, str(bad[:3]))
+        report('%s: the run actually moved something' % name, bool(moved),
+               '%d moves' % len(moved))
+
+
+def t_conservation_of_the_lattice():
+    """The count of on-lattice poses is PRESERVED across a whole run.
+
+    Swaps on, which is the case the per-part residue statement cannot make.
+    Equality, not `>=`: a nudge maps on-lattice to on-lattice and a swap is a
+    permutation, so nothing can add or remove one.
+    """
+    for name, want in BOARDS:
+        lat, _ev = lattice_of(name)
+        seeds, moved, _m = run(name)
+        before = sum(1 for (x, y) in seeds.values()
+                     for v in (x, y) if on_grid(v, lat))
+        after = 0
+        for r, (sx, sy) in seeds.items():
+            x, y = moved.get(r, (sx, sy))
+            after += sum(1 for v in (x, y) if on_grid(v, lat))
+        report('%s: on-%g count preserved (%d -> %d over %d coords)'
+               % (name, lat, before, after, 2 * len(seeds)),
+               after == before, 'lost %d' % (before - after))
+        if want is not None:
+            report('%s: and that count is most of the board, so the '
+                   'assertion has something to lose' % name,
+                   before >= 0.6 * 2 * len(seeds),
+                   '%d/%d' % (before, 2 * len(seeds)))
+
+
+def t_the_generator_offers_only_on_lattice_poses():
+    """Straight at `_candidate_positions`, so a failure localises."""
+    class _P:
+        seed_x, seed_y = 131.4450, 138.4300      # 207 x 0.635, 218 x 0.635
+    for lat in (0.1, 0.3175, 0.05):
+        cands = Q._candidate_positions(_P(), 3.0, 1.0, lat)
+        off = [(cx - _P.seed_x, cy - _P.seed_y) for cx, cy in cands]
+        report('offsets are multiples of %g' % lat,
+               all(on_grid(dx, lat) and on_grid(dy, lat) for dx, dy in off))
+        report('and every candidate is INSIDE max_disp, not a snap past it '
+               '(lattice %g)' % lat,
+               all(math.hypot(dx, dy) <= 3.0 + 1e-9 for dx, dy in off),
+               'max %.4f' % max(math.hypot(dx, dy) for dx, dy in off))
+    # The measured claim the fix rests on: the lattice does not cost reach at
+    # the step this tool ships.
+    n_raster = len(Q._candidate_positions(_P(), 10.0, 1.0, 0.1))
+    n_lat = len(Q._candidate_positions(_P(), 10.0, 1.0, 0.3175))
+    report('a 0.3175 lattice costs no candidates at step=1.0',
+           n_lat >= n_raster, 'raster %d, lattice %d' % (n_raster, n_lat))
+
+
+def t_a_board_with_no_lattice_keeps_the_raster_granularity():
+    """The fallback IS the off state, so it must be the raster exactly."""
+    name = 'rp2350_fpga_eensy_prePlane'
+    lat, ev = lattice_of(name)
+    report('%s reports no lattice' % name, ev['step'] is None, str(ev['step']))
+    report('and resolves to the grid_step raster', lat == QUENCH_KW['grid_step'],
+           str(lat))
+
+    class _P:
+        seed_x, seed_y = 131.4450, 138.4300
+    off = [(round(cx - _P.seed_x, 9), round(cy - _P.seed_y, 9))
+           for cx, cy in Q._candidate_positions(_P(), 3.0, 1.0, lat)]
+    want = sorted((round(ix * 1.0, 9), round(iy * 1.0, 9))
+                  for ix in range(-3, 4) for iy in range(-3, 4)
+                  if math.hypot(ix, iy) <= 3.0 + 1e-9)
+    report('and the offsets are exactly the unsnapped step grid',
+           sorted(off) == want, '%d vs %d' % (len(off), len(want)))
+
+
+def t_group_offsets_probes_the_pose_it_emits():
+    """The admissibility probe used to snap the ABSOLUTE p.x + dx while the
+    emitted offset was snap(dx); the cap was checked against a pose the block
+    never takes. Assert on what is yielded."""
+    name = 'interf_u_unrouted'
+    path = board(name)
+    pcb = parse_kicad_pcb(path)
+    lat, _ev = lattice_of(name)
+    import contextlib
+    import io
+    with contextlib.redirect_stdout(io.StringIO()):
+        st = Q.QuenchState(pcb, path, 0.2, 0.55, 10.0, 0.5, 0.25, 2.0, 2.0,
+                           2.0, 0.1, 1.0)
+    refs = sorted(st.parts)[:3]
+    max_disp = 3.0
+    offs = list(Q._group_offsets(st, refs, max_disp, 1.0, lat))
+    report('the block move offers offsets at all', bool(offs), str(len(offs)))
+    bad = [(r, o) for o in offs for r in refs
+           if math.hypot(st.parts[r].x + o[0] - st.parts[r].seed_x,
+                         st.parts[r].y + o[1] - st.parts[r].seed_y)
+           > max_disp + 1e-9]
+    report('every EMITTED offset keeps every member inside its own seed cap',
+           not bad, str(bad[:2]))
+    report('and every offset is a whole number of the lattice',
+           all(on_grid(dx, lat) and on_grid(dy, lat) for dx, dy in offs))
+
+
+def t_the_run_discloses_which_branch_it_took():
+    for name, want in BOARDS:
+        _s, _mv, metrics = run(name)
+        bg = metrics.get('board_grid')
+        if not bg:
+            report('%s: metrics_out carries board_grid' % name, False)
+            continue
+        report('%s: metrics name the source' % name,
+               bg.get('source') in ('inferred', 'grid_step', 'explicit'),
+               str(bg.get('source')))
+        report('%s: and the lattice actually used' % name,
+               bg.get('resolved') == lattice_of(name)[0],
+               str(bg.get('resolved')))
+        if want is None:
+            report('%s: a declining board still says why' % name,
+                   bool(bg.get('reason')), str(bg.get('reason')))
+
+
+def t_it_is_deterministic():
+    """A dict/set iteration in the inference would make the lattice
+    seed-dependent, which `test_457_determinism` would only catch as a
+    mysterious intermittent."""
+    name = 'interf_u_unrouted'
+    _RUNS.clear()
+    a = run(name)[1]
+    _RUNS.clear()
+    b = run(name)[1]
+    report('two identical runs agree exactly', a == b,
+           '%d vs %d moves' % (len(a), len(b)))
+
+
+TESTS = [
+    ('residue', t_the_residue_theorem),
+    ('conservation', t_conservation_of_the_lattice),
+    ('the generator', t_the_generator_offers_only_on_lattice_poses),
+    ('no lattice -> the raster', t_a_board_with_no_lattice_keeps_the_raster_granularity),
+    ('group offsets probe what they emit', t_group_offsets_probes_the_pose_it_emits),
+    ('disclosure', t_the_run_discloses_which_branch_it_took),
+    ('determinism', t_it_is_deterministic),
+]
+
+
+def _every_case_is_registered():
+    g = globals()
+    declared = {fn for _l, fn in TESTS}
+    missing = sorted(n for n, v in g.items()
+                     if n.startswith('t_') and callable(v)
+                     and v not in declared)
+    if missing:
+        print('  FAIL  every t_* case is registered in TESTS  -- ORPHANED: %s'
+              % ', '.join(missing))
+        FAILURES.append('unregistered cases: %s' % ', '.join(missing))
+
+
+def main():
+    print('seed-relative candidate snap (#708)')
+    for label, fn in TESTS:
+        print(' ' + label)
+        fn()
+    _every_case_is_registered()
+    if FAILURES:
+        print('\nFAILED (%d): %s' % (len(FAILURES), ', '.join(FAILURES)))
+        return 1
+    print('\nOK')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_708_seed_relative_snap.py
+++ b/tests/test_708_seed_relative_snap.py
@@ -19,6 +19,32 @@ The two theorems below are stated so they need no baseline and no golden file:
 Both are properties of the mechanism rather than of a board, which is why they
 are asserted on an imperial board, a metric-fine one, and one with no
 inferable lattice at all.
+
+MEASURED, `tests/mutate_708.py`, third run: 15 rows, 14 killed, 1 survived
+(expected), 0 broken. The table, from the run:
+
+    the-tie-break-takes-the-argmax                  SURVIVED  (expected)
+    the-tie-break-takes-the-coarsest                KILLED   6
+    the-min-parts-gate-is-dropped                   KILLED   7
+    the-occupancy-floor-is-dropped                  KILLED   4
+    the-floor-returns-to-the-round-0.70             KILLED   2
+    the-tolerance-becomes-relative-to-the-step      KILLED   3
+    the-sample-drops-one-axis                       KILLED   3
+    the-candidate-snap-goes-back-to-absolute        KILLED  10
+    the-offset-snaps-to-the-raster-not-the-lattice  KILLED   5
+    the-radius-test-goes-back-before-the-snap       KILLED   2
+    the-lattice-is-never-resolved                   KILLED   5
+    the-group-probe-goes-back-to-the-absolute-pose  KILLED   2
+    the-group-offset-snaps-the-absolute-pose        KILLED   3
+    the-fanout-snap-goes-back-to-absolute           KILLED   4
+    the-reseat-slot-snaps-the-absolute-point        KILLED   3
+
+The first run killed only 9 of 15, and all six survivors were holes in THESE
+arms rather than in the engine -- an assertion at `step=1.0` where the mutated
+factor is a no-op, a lattice sweep that never rounded UP past the cap, a
+block-move fixture whose lattice was the raster, a probe fixture whose parts
+were already on-lattice, and two sites whose owning suites never look at phase.
+The rows and the reasons are in `mutate_708.py`.
 """
 
 import math

--- a/tests/test_708_seed_relative_snap.py
+++ b/tests/test_708_seed_relative_snap.py
@@ -473,6 +473,37 @@ def t_the_two_repair_sites_are_seed_relative_but_not_coarsened():
         report('reseat: the identity poses are the members\' own, untouched',
                identity == [(st.parts[m].x, st.parts[m].y, st.parts[m].rot)
                             for m in c.members], str(identity[:1]))
+    # The dedup KEY has to be injective on what it emits, and none of the
+    # assertions above can see that it isn't. A key taken on the ABSOLUTE pose
+    # while the value is anchor-relative collapses two adjacent steps whenever
+    # `anchor / grid_step` sits at a half cell (banker's rounding:
+    # round(1.5) == round(2.5) == 2). The collapsed slots are simply ABSENT, so
+    # "every slot is distinct" and "every slot is on the anchor's lattice" both
+    # stay true. Only a COUNT catches it, and it has to be a count the broken
+    # key cannot produce.
+    #
+    # orangecrab_ext_pll U4 sits at (174.0500, 102.4000) -- both coordinates at
+    # a half cell of the 0.1 raster. Measured: 5576 ring slots with the
+    # injective key, 5280 with the absolute one.
+    name2 = 'orangecrab_ext_pll'
+    pcb2 = parse_kicad_pcb(board(name2))
+    with contextlib.redirect_stdout(io.StringIO()):
+        st2 = Q.QuenchState(pcb2, board(name2), 0.2, 0.55, 10.0, 0.5, 0.25,
+                            2.0, 2.0, 2.0, grid, 1.0)
+        cl2 = [c for c in RS.clusters_from_tethers(pcb2, st2, 2.0)
+               if c.anchor == 'U4']
+    report('reseat: the half-cell anchor fixture is present', bool(cl2),
+           'U4 at (%.4f, %.4f)' % (st2.parts['U4'].x, st2.parts['U4'].y)
+           if 'U4' in st2.parts else 'absent')
+    if cl2:
+        c2 = cl2[0]
+        with contextlib.redirect_stdout(io.StringIO()):
+            pool2 = RS.slot_pool(st2, c2, grid_step=grid,
+                                 max_positions=100000)
+        ring2 = pool2[:-len(c2.members)]
+        report('reseat: a half-cell anchor loses no slots to the dedup key',
+               len(ring2) == 5576, '%d ring slots (5576 injective, 5280 if '
+               'the key is taken on the absolute pose)' % len(ring2))
 
 
 def t_the_reseat_accepts_on_the_seated_cost_not_the_prediction():

--- a/tests/test_709_arrangement_census.py
+++ b/tests/test_709_arrangement_census.py
@@ -27,6 +27,7 @@ for _d in ('py_router', 'py_placer', 'py_tools'):
 
 from kicad_parser import parse_kicad_pcb                       # noqa: E402
 import check_pockets as CP                                     # noqa: E402
+from placement import board_grid as BG                         # noqa: E402
 
 FAILURES = []
 
@@ -471,6 +472,31 @@ def t_the_side_rule_is_max_not_sum():
            doc['cold_windows'] > 0, str(doc['cold_windows']))
 
 
+
+def t_the_board_grid_scalars_travel_with_the_census():
+    """#708. The lattice a board was laid out on is an arrangement fact, and
+    the ROADMAP puts #708 behind this census for exactly that reason. A board
+    that declares no lattice must say WHY, or "no lattice" and "never
+    measured" are the same reading of a null.
+    """
+    d, _hot = census('splitflap_driver')
+    sc = CP.census_scalars(d)
+    report('an imperial board reports its pitch',
+           sc.get('board_grid_step') == 0.3175, str(sc.get('board_grid_step')))
+    report('with the occupancy it was read off',
+           round(sc.get('board_grid_occupancy') or 0, 3) == 0.923,
+           str(sc.get('board_grid_occupancy')))
+    d2, _hot2 = census('ulx3s')
+    sc2 = CP.census_scalars(d2)
+    report('a board with no lattice reports None',
+           sc2.get('board_grid_step') is None, str(sc2.get('board_grid_step')))
+    report('and says which test it failed, so the null is an answer',
+           'floor' in (sc2.get('board_grid_reason') or ''),
+           str(sc2.get('board_grid_reason')))
+    report('the census agrees with the engine resolver, not a second copy',
+           sc.get('board_grid_step')
+           == BG.infer_board_grid(parse_kicad_pcb(board('splitflap_driver')))['step'])
+
 TESTS = [
     ('area weighting vs the count control',
      t_area_weighting_and_the_count_control_disagree),
@@ -493,6 +519,7 @@ TESTS = [
     ('the side rule is max, not sum',
      t_the_side_rule_is_max_not_sum),
     ('the reseat target', t_the_reseat_target_is_a_target_not_a_weight),
+    ('#708 board-grid scalars', t_the_board_grid_scalars_travel_with_the_census),
 ]
 
 

--- a/tests/test_746_fanout_clearance_resolved_credit.py
+++ b/tests/test_746_fanout_clearance_resolved_credit.py
@@ -202,10 +202,25 @@ FORCING = dict(max_displacement=0.0, max_displacement_cap=0.0, max_passes=1,
                via_clear_fallback=False)
 
 REAL_BOARD = os.path.join(_ROOT, 'kicad_files', 'orangecrab_ext_pll.kicad_pcb')
-REAL_RESOLVED = ['C19', 'C44', 'C45', 'C67']
-REAL_VIA_RESOLVED = ['C19', 'C44', 'C45']       # C67 is the SWEEP's one credit
-REAL_LINE = ('Moved 18 cap(s); resolved 4/14 initial violations '
-             '(3 freed by via-nudge); 10 unresolved.')
+# RE-PINNED AT #708, and the reason is the point rather than a chore.
+# `FORCING` sets max_displacement=0.0 AND max_displacement_cap=0.0: the caller
+# is saying no cap may move. The old `_candidate_positions` snapped the
+# ABSOLUTE candidate, so even at a zero budget the one candidate it produced
+# was `snap(seed, grid_step)` rather than the cap's own pose -- measured, a
+# 0.054mm displacement on a real cap under a 0.0mm cap. The pass therefore
+# reported 18 caps MOVED on a board it was forbidden to move anything on, and
+# C67 -- "the SWEEP's one credit" in the old comment here -- was resolved by
+# one of those moves.
+#
+# Snapping the OFFSET makes the only candidate at a zero budget the cap's own
+# pose, so the sweep moves nothing and claims nothing. What remains is the
+# three the VIA NUDGE freed, which is the credit this file exists to check,
+# and it is unchanged. The new summary line is also self-consistent in a way
+# the old one was not: every resolution it reports is attributed to the nudge.
+REAL_RESOLVED = ['C19', 'C44', 'C45']
+REAL_VIA_RESOLVED = ['C19', 'C44', 'C45']       # and now the ONLY credits
+REAL_LINE = ('Moved 0 cap(s); resolved 3/14 initial violations '
+             '(3 freed by via-nudge); 11 unresolved.')
 REAL_LINE_BEFORE = 'Moved 18 cap(s); resolved 1/14 initial violations; 10 unresolved.'
 
 
@@ -709,13 +724,13 @@ class TestOnARealTrackedBoard(unittest.TestCase):
         # called, and every assertion below would be about nothing.
         self.assertEqual(len(self.res['via_moves']), 9)
         self.assertEqual(len(self.res['new_segments']), 17)
-        self.assertEqual(len(self.res['placements']), 18)
+        self.assertEqual(len(self.res['placements']), 0)
 
     def test_three_real_caps_were_freed_by_the_nudge_and_credited_nowhere(self):
         self.assertEqual(_summary(self.out), REAL_LINE)
         self.assertEqual(self.res['resolved'], REAL_RESOLVED)
         self.assertEqual(self.res['via_resolved'], REAL_VIA_RESOLVED)
-        self.assertEqual(len(self.res['unresolved']), 10)
+        self.assertEqual(len(self.res['unresolved']), 11)
     # MUTATION: drop the `resolved` half of the refresh -> the line reverts to
     # REAL_LINE_BEFORE ("resolved 1/14"), losing C19, C44 and C45.
 

--- a/tests/test_747_fanout_clearance_via_registrar.py
+++ b/tests/test_747_fanout_clearance_via_registrar.py
@@ -742,11 +742,31 @@ class TestTheOneRealBoardArmWhereTheRegistrarRUNS(unittest.TestCase):
                  via_clear_fallback=False)
 
     # Measured at 42e09a1a AND at the merge base 988634d0 -- identical, which
-    # is the whole claim of this change.
+    # was the whole claim of that change.
+    #
+    # TWO of these moved at #708, and the reason is worth reading before
+    # re-pinning them again. This arm sets `max_displacement=0.0`: the caller
+    # is saying no cap may move. The old `_candidate_positions` snapped the
+    # ABSOLUTE candidate, so even at a zero displacement budget the single
+    # candidate it produced was `snap(seed, grid_step)` -- not the cap's own
+    # pose. Measured on one real cap: seed (131.4450, 138.4300) -> candidate
+    # (131.4000, 138.4000), a 0.054mm move under a 0.0mm cap.
+    #
+    # So the pass used to emit 18 PLACEMENTS on a board it was forbidden to
+    # move anything on, and exactly one of those 18 illegitimate nudges
+    # happened to clear a violation. Snapping the OFFSET makes the only
+    # candidate at `max_displacement=0.0` the cap's own pose, so:
+    #
+    #   N_PLACEMENTS  18 -> 0    the contract is now kept
+    #   N_UNRESOLVED  10 -> 11   the one resolution that rested on breaking it
+    #
+    # Everything else is unchanged -- 9 barrels relocated, 17 connectors, the
+    # same three caps credited -- which is what says this is the cap being
+    # honoured rather than the via nudger regressing.
     N_MOVES = 9
     N_CONNECTORS = 17
-    N_UNRESOLVED = 10
-    N_PLACEMENTS = 18
+    N_UNRESOLVED = 11
+    N_PLACEMENTS = 0
     VIA_FREED = ['C19', 'C44', 'C45']
 
     def _run(self):

--- a/tests/test_788_marginal_literals.py
+++ b/tests/test_788_marginal_literals.py
@@ -68,6 +68,16 @@ ROWS = (
     # and only oob_pad_count refuses. Without a row of this shape the
     # complementarity claim beside the gate has no evidence here, and the
     # first version of this file asserted it with a tautology.
+    # STALE SINCE #826, and only the first of the two. The portfolio's jitter
+    # now snaps its offset to the board's lattice, so a rebuilt study tree
+    # produces a different sonde_u:portfolio-3 candidate (sonde_u is imperial,
+    # 0.3175). The literal below still describes the slate these numbers were
+    # measured on; it is no longer reproducible from HEAD without rebuilding
+    # wk/703/study, which test_703_predictor_regen's header prices at ~8.8h.
+    # Arm A is arithmetic over these tuples and cannot move; Arm B skips
+    # loudly when the tree is absent, which it is on a clean checkout.
+    # watchy:portfolio-2 is NOT affected -- watchy declares no lattice (best
+    # occupancy 0.238 < floor 0.67), so its jitter stays continuous.
     ('sonde_u', 'portfolio-3', 0, 1, 0, 0, 0),
     ('watchy', 'portfolio-2', 0, 1, 0, 0, 3),
 )

--- a/tests/test_826_portfolio_lattice.py
+++ b/tests/test_826_portfolio_lattice.py
@@ -29,27 +29,34 @@ outward-snapping draw is 0-6 per board and is ZERO on six of the eleven,
 including `esp_prog` and `routed_output`. An arm depending on one being drawn
 would be vacuous on most of the corpus, not merely fragile.
 
-MEASURED, `tests/mutate_826.py`, second run: 11 rows, 11 killed, 0 survived,
-0 broken. The table, from the run:
+MEASURED, `tests/mutate_826.py`, fourth run: 12 rows, 12 killed, 0
+survived, 0 broken. The table, from the run:
 
-    the-jitter-snap-is-dropped                               KILLED   8
+    the-jitter-snap-is-dropped                               KILLED   11
     the-jitter-snaps-the-absolute-pose                       KILLED   7
-    the-offset-snaps-to-the-raster-not-the-lattice           KILLED   9
+    the-offset-snaps-to-the-raster-not-the-lattice           KILLED   12
     a-zero-offset-counts-as-a-perturbation                   KILLED   3
     the-radius-test-goes-back-before-the-snap                KILLED   2
-    the-lattice-falls-back-to-the-grid-step-raster           KILLED   5
-    the-radius-guard-is-dropped                              KILLED   3
-    the-generator-does-not-pass-the-lattice                  KILLED   5
-    the-lattice-is-resolved-per-candidate-from-the-live-state KILLED   6
+    the-lattice-falls-back-to-the-grid-step-raster           KILLED   6
+    the-disclosure-reports-the-inference-not-what-was-used   KILLED   3
+    the-radius-guard-is-dropped                              KILLED   4
+    the-generator-does-not-pass-the-lattice                  KILLED   8
+    the-lattice-is-resolved-per-candidate-from-the-live-state KILLED   9
     the-default-becomes-the-inferred-lattice                 KILLED   1
-    the-disclosure-drops-the-board-grid                      KILLED   2
+    the-disclosure-drops-the-board-grid                      KILLED   3
 
-The first run killed 10 of 11. The survivor was `the-disclosure-drops-the-
-board-grid`, and it was a hole in THIS file rather than in the engine: the
-end-to-end arm compared the candidate's `board_grid_step` against the
-BASELINE's, so a mutation nulling the whole disclosure made both None and
-`None == None` passed. Both are now asserted against the input board's own
-inferred lattice. Two things that vanish together are not an agreement.
+The battery has caught something on every run, which is the point of it. Run 1
+killed 10 of 11; the survivor, `the-disclosure-drops-the-board-grid`, was a
+hole in THIS file rather than in the engine -- the end-to-end arm compared the
+candidate's `board_grid_step` against the BASELINE's, so a mutation nulling the
+whole disclosure made both None and `None == None` passed. Two things that
+vanish together are not an agreement; both are now asserted against the input
+board's own inferred lattice. Run 3 reported two rows BROKEN because a review's
+fixes had rewritten the exact lines they anchored on. The twelfth row,
+`the-disclosure-reports-the-inference-not-what-was-used`, pins the blocking
+defect that review found, and is itself fixture-blind: it dies only under the
+`--step 0.25` arm, because at the default step the inferred and resolved
+lattices are equal.
 """
 
 import math

--- a/tests/test_826_portfolio_lattice.py
+++ b/tests/test_826_portfolio_lattice.py
@@ -15,16 +15,19 @@ if ignored:
     `snap(part.x + dx) - part.x == snap(dx)` for every emitted pose, so an
     ABSOLUTE-snap mutation is invisible. `interf_u_unrouted` perturbs 22 of 22
     with SEVEN off-lattice, and is the fixture the offset arms use. This is the
-    identical trap `mutate_708.py` recorded for its group-offset row.
+    identical trap `tests/test_708_seed_relative_snap.py` records at
+    `t_group_offsets_probes_the_pose_it_emits` -- "a probe fixture whose parts
+    were already on-lattice".
 
   * the zero-offset branch NEVER fires at the shipped radius -- measured 0
     rejections on all eleven lattice boards at radius 4.0 and at 2.0, first
     firing at 1.0. No population arm at the default can kill a dropped
     zero-guard, so that arm scripts the rng instead.
 
-The radius arms script the rng for the same reason: an outward-snapping draw is
-1-6 per board, likely but not guaranteed, and an arm that depends on one being
-drawn goes quietly vacuous the day a fixture changes.
+The radius arms script the rng for a STRONGER version of the same reason: an
+outward-snapping draw is 0-6 per board and is ZERO on six of the eleven,
+including `esp_prog` and `routed_output`. An arm depending on one being drawn
+would be vacuous on most of the corpus, not merely fragile.
 
 MEASURED, `tests/mutate_826.py`, second run: 11 rows, 11 killed, 0 survived,
 0 broken. The table, from the run:
@@ -360,8 +363,92 @@ def t_the_seed_board_the_quench_parses_still_declares_the_lattice():
         report('the candidate reports the occupancy it was read off',
                cands[0].metrics.get('board_grid_reason') == 'inferred',
                str(cands[0].metrics.get('board_grid_reason')))
+        # THE FINAL BOARD, not just the seed. The stated purpose is "so the
+        # quench that follows can preserve a lattice", and that property
+        # belongs to the board the quench WRITES. Checking only the seed board
+        # is what let a disclosure defect through review: at `--step 0.25` the
+        # seed declares 0.3175 and the final board declares nothing.
+        final_ev = BG.infer_board_grid(parse_kicad_pcb(cands[0].board))
+        report('the QUENCHED candidate board still declares the lattice',
+               final_ev['step'] == in_ev['step'], str(final_ev['reason']))
+        report('at the input occupancy',
+               final_ev['occupancy'] == in_ev['occupancy'],
+               '%s vs %s' % (final_ev['occupancy'], in_ev['occupancy']))
+
+
     finally:
         shutil.rmtree(work, ignore_errors=True)
+
+
+def t_the_disclosure_reports_what_was_used_not_what_was_inferred():
+    """`quench` infers a lattice and can then FALL BACK -- when it is coarser
+    than `--step` it keeps `step` at the inference and puts what it used in
+    `resolved`. A disclosure that reads `step` reports a lattice the quench
+    never used, and would say the fix worked on a run where it shipped inert.
+
+    Measured at `--step 0.25` on this imperial board: the candidate the run
+    ships has NO lattice and 0.120 occupancy, while `step` still reads 0.3175.
+    """
+    import contextlib
+    import io
+    import shutil
+    import tempfile
+    work = tempfile.mkdtemp(prefix='pf826d_')
+    try:
+        path = board(IMPERIAL)
+        with contextlib.redirect_stdout(io.StringIO()):
+            res = PF.generate(path, work, seed=0, n_candidates=2,
+                              strategies=('jitter',), radius=RADIUS,
+                              quench_kw=dict(max_displacement=3.0, step=0.25,
+                                             grid_step=0.1, clearance=0.2,
+                                             board_edge_clearance=0.55,
+                                             max_passes=3, verbose=False))
+        c = res['candidates'][0]
+        if not c.board:
+            report('the --step 0.25 arm produced a candidate', False, c.note)
+            return
+        report('the quench fell back, so this arm tests the right thing',
+               c.metrics.get('board_grid_inferred') == 0.3175
+               and c.metrics.get('board_grid_step') != 0.3175,
+               'inferred %s, used %s' % (c.metrics.get('board_grid_inferred'),
+                                         c.metrics.get('board_grid_step')))
+        # `board_grid_step` is the lattice the quench's OFFSETS were multiples
+        # of -- here the 0.1 raster it fell back to. That is NOT the same
+        # quantity as what the resulting BOARD declares (None: the shipped
+        # candidate's occupancy is 0.120, under the floor), and the first
+        # version of this arm compared the two and failed for exactly that
+        # reason.
+        report('the disclosed lattice is the raster the quench actually used',
+               c.metrics.get('board_grid_step') == 0.1,
+               'disclosed %s' % c.metrics.get('board_grid_step'))
+        # And the point of the arm: reading `step` instead of `resolved` would
+        # have reported 0.3175 for a candidate that shipped with no lattice.
+        declares = BG.infer_board_grid(parse_kicad_pcb(c.board))['step']
+        report('the shipped board declares no lattice, so the INFERRED value '
+               'would have claimed a success that did not happen',
+               declares is None,
+               'board declares %s, inference said %s'
+               % (declares, c.metrics.get('board_grid_inferred')))
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
+def t_the_run_level_disclosure_is_honest_in_every_branch():
+    """`jitter_lattice`'s dict is written verbatim into portfolio.json, so
+    `step` there has to mean what was USED. The first version left it at the
+    inference on the radius-guard branch, shipping
+    `{"step": 0.3175, "resolved": null}`."""
+    pcb, _p, _f, _o = state_for(IMPERIAL)
+    step, ev = PF.jitter_lattice(pcb, 0.3)          # radius guard fires
+    report('a guarded run reports no lattice in the terse form too',
+           step is None and ev['step'] is None and ev['resolved'] is None,
+           'step=%s resolved=%s' % (ev['step'], ev['resolved']))
+    report('and keeps the inference beside it, so the reason is readable',
+           ev['inferred_step'] == 0.3175, str(ev.get('inferred_step')))
+    step2, ev2 = PF.jitter_lattice(pcb, RADIUS)     # ordinary branch
+    report('an ordinary run agrees with itself',
+           step2 == ev2['step'] == ev2['resolved'] == 0.3175,
+           '%s / %s / %s' % (step2, ev2['step'], ev2['resolved']))
 
 
 TESTS = [
@@ -376,6 +463,10 @@ TESTS = [
     ('no pose sits on its seed', t_no_emitted_pose_sits_on_its_own_seed),
     ('determinism', t_it_is_deterministic),
     ('end to end', t_the_seed_board_the_quench_parses_still_declares_the_lattice),
+    ('the disclosure reports what was USED',
+     t_the_disclosure_reports_what_was_used_not_what_was_inferred),
+    ('the run-level disclosure is honest',
+     t_the_run_level_disclosure_is_honest_in_every_branch),
 ]
 
 

--- a/tests/test_826_portfolio_lattice.py
+++ b/tests/test_826_portfolio_lattice.py
@@ -1,0 +1,378 @@
+"""#826: the portfolio's basin-escape lands on the board's own lattice.
+
+`perturb_jitter` offset a part by `r*cos(theta)` at 4 decimal places, so every
+portfolio candidate started off-grid and the quench -- which since #708
+preserves whatever lattice it is given -- inherited an arbitrary residue.
+Measured before the fix, `tests/measure_826_jitter_lattice.py`: ten of the
+eleven tracked boards that declare a lattice no longer declared one after the
+default jitter, two of them at 0.000 occupancy.
+
+TWO FIXTURE TRAPS, both measured, both of which make an arm silently vacuous
+if ignored:
+
+  * `splitflap_driver` -- the default board of every other test_portfolio*.py
+    -- perturbs 29 parts of which ZERO have an off-lattice seed. There
+    `snap(part.x + dx) - part.x == snap(dx)` for every emitted pose, so an
+    ABSOLUTE-snap mutation is invisible. `interf_u_unrouted` perturbs 22 of 22
+    with SEVEN off-lattice, and is the fixture the offset arms use. This is the
+    identical trap `mutate_708.py` recorded for its group-offset row.
+
+  * the zero-offset branch NEVER fires at the shipped radius -- measured 0
+    rejections on all eleven lattice boards at radius 4.0 and at 2.0, first
+    firing at 1.0. No population arm at the default can kill a dropped
+    zero-guard, so that arm scripts the rng instead.
+
+The radius arms script the rng for the same reason: an outward-snapping draw is
+1-6 per board, likely but not guaranteed, and an arm that depends on one being
+drawn goes quietly vacuous the day a fixture changes.
+"""
+
+import math
+import os
+import random
+import sys
+
+RUN_ALL_FAST_OK = True
+RUN_ALL_TIMEOUT = 900
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+for _d in ('py_router', 'py_placer', 'py_tools'):
+    sys.path.insert(0, os.path.join(ROOT, _d))
+
+import routing_defaults as defaults                             # noqa: E402
+from kicad_parser import parse_kicad_pcb                        # noqa: E402
+from list_nets import board_floor_knobs                         # noqa: E402
+from placement import board_grid as BG                          # noqa: E402
+from placement import portfolio as PF                           # noqa: E402
+
+FAILURES = []
+
+# The imperial fixture: 22 free, 22 perturbed, SEVEN with off-lattice seeds.
+IMPERIAL = 'interf_u_unrouted'
+# No inferable lattice (best occupancy 0.369 < floor 0.67).
+NO_LATTICE = 'rp2350_fpga_eensy_prePlane'
+RADIUS = 4.0
+
+
+def report(name, ok, detail=''):
+    print(('  PASS  ' if ok else '  FAIL  ') + name
+          + (('  -- ' + detail) if detail else ''))
+    if not ok:
+        FAILURES.append(name)
+
+
+def board(name):
+    p = os.path.join(ROOT, 'kicad_files', name + '.kicad_pcb')
+    assert os.path.isfile(p) and os.path.getsize(p) > 0, p
+    return p
+
+
+def on_grid(v, step, tol=1e-6):
+    return abs(v / step - round(v / step)) * step <= tol
+
+
+def state_for(name):
+    """The oracle `portfolio.generate` would build, through the knob
+    resolution `place_portfolio.main` performs first."""
+    import contextlib
+    import io
+    path = board(name)
+    pcb = parse_kicad_pcb(path)
+    free = PF.free_refs(pcb, path, None)
+    clearance, edge, _k = board_floor_knobs(path, None, None)
+    with contextlib.redirect_stdout(io.StringIO()):
+        oracle = PF.make_oracle(pcb, path, free=free, clearance=clearance,
+                                board_edge_clearance=edge,
+                                grid_step=defaults.GRID_STEP, ignore_ids=set())
+    return pcb, path, free, oracle
+
+
+class Scripted:
+    """An rng whose `.random()` replays a fixed pair, forever.
+
+    `perturb_jitter` draws exactly two values per attempt -- `r` then `theta` --
+    so a fixed pair puts every attempt of every ref at the same offset, which
+    is what lets an arm test one geometric rule without depending on a draw
+    happening to land there.
+    """
+    def __init__(self, u1, u2):
+        self.pair = (u1, u2)
+        self.i = 0
+
+    def random(self):
+        v = self.pair[self.i % 2]
+        self.i += 1
+        return v
+
+
+def u_for_r(r, radius):
+    """The draw that makes `perturb_jitter` compute this `r`."""
+    return (r / radius) ** 2
+
+
+# ------------------------------------------------------------------ cases
+
+def t_the_resolver_answers_or_declines_with_a_reason():
+    pcb, _p, _f, _o = state_for(IMPERIAL)
+    step, ev = PF.jitter_lattice(pcb, RADIUS)
+    report('an imperial board resolves its own pitch',
+           step == 0.3175 and ev['source'] == 'inferred',
+           '%s / %s' % (step, ev['source']))
+    report('and the evidence carries what it was read off',
+           ev['occupancy'] == 0.700 and ev['n_values'] == 50,
+           '%s of %s' % (ev['occupancy'], ev['n_values']))
+
+    pcb2, _p2, _f2, _o2 = state_for(NO_LATTICE)
+    step2, ev2 = PF.jitter_lattice(pcb2, RADIUS)
+    report('a board with no lattice yields NO SNAP, not a raster fallback',
+           step2 is None and ev2['resolved'] is None, str(step2))
+    report('and says which test it failed',
+           'floor' in (ev2['reason'] or ''), ev2['reason'])
+    report('the source names the branch, so an inert run is legible',
+           ev2['source'] == 'none', ev2['source'])
+
+
+def t_a_lattice_coarser_than_the_radius_is_refused():
+    """Below the lattice the disc holds no destination but the seed itself.
+    Measured: --radius 0.3175 perturbs 22 of 22 on this board, --radius 0.3
+    perturbs 0 of 22 after burning 440 draws and every candidate goes barren."""
+    pcb, _p, _f, _o = state_for(IMPERIAL)
+    step, ev = PF.jitter_lattice(pcb, 0.3)
+    report('a lattice wider than the radius is refused', step is None, str(step))
+    report('and the reason names the radius, not the floor',
+           'radius' in (ev['reason'] or ''), ev['reason'])
+    step2, _ev2 = PF.jitter_lattice(pcb, 0.3175)
+    report('at exactly the lattice it still answers, because it still works',
+           step2 == 0.3175, str(step2))
+
+
+def t_the_resolver_can_only_ever_return_two_values():
+    """A property of the ladder, not of the corpus: only 0.05 and 0.3175 have
+    no proper divisor in it, so no coarse lattice can starve the disc."""
+    seen = set()
+    for name in (IMPERIAL, NO_LATTICE, 'splitflap_driver', 'esp_prog',
+                 'glasgow_revC'):
+        pcb, _p, _f, _o = state_for(name)
+        seen.add(PF.jitter_lattice(pcb, RADIUS)[0])
+    report('every resolved value is 0.05, 0.3175 or None',
+           seen <= {0.05, 0.3175, None}, str(sorted(seen, key=str)))
+
+
+def t_the_offset_is_snapped_not_the_position():
+    """THE arm, and the one with a precondition that must not go quiet.
+
+    On a board where every perturbed part already sits on the lattice,
+    `snap(part.x + dx) - part.x == snap(dx)` and an absolute-snap mutation is
+    invisible. Measured: splitflap_driver 0 of 29, interf_u_unrouted 7 of 22.
+    """
+    pcb, _path, free, oracle = state_for(IMPERIAL)
+    lat, _ev = PF.jitter_lattice(pcb, RADIUS)
+    origin = {r: (pcb.footprints[r].x, pcb.footprints[r].y) for r in free}
+    poses = PF.perturb_jitter(oracle, free, random.Random('0:1:jitter'),
+                              RADIUS, lattice=lat)
+    off = [p for p in poses
+           if not (on_grid(origin[p['reference']][0], lat)
+                   and on_grid(origin[p['reference']][1], lat))]
+    report('the sample contains parts whose OWN seed is off the lattice, so '
+           'offset-snap and absolute-snap are distinguishable here',
+           len(off) >= 3,
+           '%d of %d perturbed (splitflap_driver gives ZERO and this arm '
+           'would go blind there)' % (len(off), len(poses)))
+    report('every offset is a whole number of %g' % lat,
+           all(on_grid(p['new_x'] - origin[p['reference']][0], lat)
+               and on_grid(p['new_y'] - origin[p['reference']][1], lat)
+               for p in poses), str(len(poses)))
+    report('and an off-lattice seed KEEPS its residue -- the pose is not on a '
+           'lattice through board origin',
+           all(not (on_grid(p['new_x'], lat) and on_grid(p['new_y'], lat))
+               for p in off), str([p['reference'] for p in off][:4]))
+
+
+def t_the_lattice_is_the_boards_not_the_raster():
+    """0.1 is not a multiple of 0.3175, so a raster mutation is visible here.
+    It would NOT be on a 0.05 board, where every 0.1-multiple is a
+    0.05-multiple -- which is why this arm is imperial."""
+    pcb, _path, free, oracle = state_for(IMPERIAL)
+    lat, _ev = PF.jitter_lattice(pcb, RADIUS)
+    origin = {r: (pcb.footprints[r].x, pcb.footprints[r].y) for r in free}
+    poses = PF.perturb_jitter(oracle, free, random.Random('0:1:jitter'),
+                              RADIUS, lattice=lat)
+    raster = [p for p in poses
+              if not on_grid(p['new_x'] - origin[p['reference']][0], 0.1)]
+    report('offsets are multiples of the BOARD lattice and not of the raster',
+           bool(raster),
+           '%d of %d offsets are not 0.1-multiples' % (len(raster), len(poses)))
+
+
+def t_the_radius_stays_an_exact_bound():
+    """Scripted, because an outward-snapping draw is 1-6 per board -- likely,
+    not guaranteed, and an arm resting on one goes vacuous when a fixture
+    moves. snap(3.99, 0.3175) = 4.1275 > 4.0."""
+    pcb, _path, free, oracle = state_for(IMPERIAL)
+    lat, _ev = PF.jitter_lattice(pcb, RADIUS)
+    from placement.utility import snap_to_grid
+    r_out = 3.99
+    snapped = snap_to_grid(r_out, lat)
+    report('the scripted draw really does snap OUT of the disc',
+           snapped > RADIUS, 'snap(%.2f, %g) = %.4f > %.1f'
+           % (r_out, lat, snapped, RADIUS))
+    # Precondition: at least one ref could legally sit at the snapped-out
+    # offset, so a mutation that skipped the radius test would EMIT something.
+    legal = [r for r in free
+             if oracle.parts.get(r) is not None
+             and oracle.candidate_valid(r, oracle.parts[r].x + snapped,
+                                        oracle.parts[r].y,
+                                        oracle.parts[r].rot)]
+    report('at least one ref could legally sit at the snapped-out offset, so '
+           'this arm tests the radius rule and not the legality gate',
+           bool(legal), '%d refs' % len(legal))
+    poses = PF.perturb_jitter(oracle, free, Scripted(u_for_r(r_out, RADIUS),
+                                                     0.0),
+                              RADIUS, attempts=1, lattice=lat)
+    report('no pose is emitted from a draw that snapped past the radius',
+           poses == [], str(poses[:1]))
+
+
+def t_a_draw_that_snaps_to_no_movement_is_refused():
+    """Also scripted: measured 0 zero-rejections on every lattice board at
+    radius 4.0 and 2.0, so no population arm at the shipped radius can kill a
+    dropped zero-guard.
+
+    Non-vacuous by construction: the incumbent pose was just asserted legal by
+    the guard above the draw, so if the zero-branch is removed the sampler MUST
+    emit exactly one pose per ref. Zero versus non-zero is the kill.
+    """
+    pcb, _path, free, oracle = state_for(IMPERIAL)
+    lat, _ev = PF.jitter_lattice(pcb, RADIUS)
+    from placement.utility import snap_to_grid
+    r_zero = lat / 4.0
+    report('the scripted draw really does snap to no movement',
+           snap_to_grid(r_zero, lat) == 0.0,
+           'snap(%.4f, %g) = %.4f' % (r_zero, lat, snap_to_grid(r_zero, lat)))
+    poses = PF.perturb_jitter(oracle, free, Scripted(u_for_r(r_zero, RADIUS),
+                                                     0.0),
+                              RADIUS, attempts=1, lattice=lat)
+    report('a zero offset is not a perturbation and emits nothing',
+           poses == [], '%d pose(s)' % len(poses))
+
+
+def t_no_emitted_pose_sits_on_its_own_seed():
+    """The population form of the arm above, at the radius where the branch
+    actually fires (measured: 3 zero-rejections on this board at 0.5)."""
+    pcb, _path, free, oracle = state_for(IMPERIAL)
+    lat, _ev = PF.jitter_lattice(pcb, 0.5)
+    origin = {r: (pcb.footprints[r].x, pcb.footprints[r].y) for r in free}
+    poses = PF.perturb_jitter(oracle, free, random.Random('0:1:jitter'), 0.5,
+                              lattice=lat)
+    report('the run produced poses at all', bool(poses), str(len(poses)))
+    report('and not one of them is the seed it started from',
+           all((p['new_x'], p['new_y']) != origin[p['reference']]
+               for p in poses))
+
+
+def t_it_is_deterministic():
+    pcb, _path, free, oracle = state_for(IMPERIAL)
+    lat, _ev = PF.jitter_lattice(pcb, RADIUS)
+    a = PF.perturb_jitter(oracle, free, random.Random('t'), RADIUS,
+                          lattice=lat)
+    _pcb2, _p2, free2, oracle2 = state_for(IMPERIAL)
+    b = PF.perturb_jitter(oracle2, free2, random.Random('t'), RADIUS,
+                          lattice=lat)
+    report('a fixed rng seed gives the same poses', a == b,
+           '%d vs %d' % (len(a), len(b)))
+    _pcb3, _p3, free3, oracle3 = state_for(IMPERIAL)
+    c = PF.perturb_jitter(oracle3, free3, random.Random('u'), RADIUS,
+                          lattice=lat)
+    report('a different one does not', a != c)
+
+
+def t_the_seed_board_the_quench_parses_still_declares_the_lattice():
+    """The end-to-end form: #826 is about what `_quench_to` hands the quench.
+
+    EXACT equality with the input occupancy, not `>= floor` -- a half-fix that
+    stays above 0.67 on the wrong coset would survive the weaker assertion.
+    """
+    import contextlib
+    import io
+    import shutil
+    import tempfile
+    work = tempfile.mkdtemp(prefix='pf826_')
+    try:
+        path = board(IMPERIAL)
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            res = PF.generate(path, work, seed=0, n_candidates=2,
+                              strategies=('jitter',), radius=RADIUS,
+                              quench_kw=dict(max_displacement=3.0, step=1.0,
+                                             grid_step=0.1, clearance=0.2,
+                                             board_edge_clearance=0.55,
+                                             max_passes=3, verbose=False))
+        in_ev = BG.infer_board_grid(parse_kicad_pcb(path))
+        report('the input declares 0.3175', in_ev['step'] == 0.3175)
+        report('the run says which branch the jitter took',
+               (res.get('jitter_lattice') or {}).get('source') == 'inferred',
+               str((res.get('jitter_lattice') or {}).get('source')))
+        cands = res['candidates']
+        report('a jitter candidate was produced', bool(cands) and cands[0].board,
+               str(cands[0].note if cands else 'none'))
+        if not cands or not cands[0].seed_board:
+            return
+        seed_ev = BG.infer_board_grid(parse_kicad_pcb(cands[0].seed_board))
+        report('the PERTURBED SEED BOARD -- what the quench actually parses -- '
+               'still declares it', seed_ev['step'] == in_ev['step'],
+               str(seed_ev['reason']))
+        report('at EXACTLY the input occupancy, not merely above the floor',
+               seed_ev['occupancy'] == in_ev['occupancy'],
+               '%s vs %s' % (seed_ev['occupancy'], in_ev['occupancy']))
+        report("and the candidate's quench saw the same lattice as the "
+               'baseline',
+               cands[0].metrics.get('board_grid_step')
+               == res['baseline'].metrics.get('board_grid_step'),
+               '%s vs %s' % (cands[0].metrics.get('board_grid_step'),
+                             res['baseline'].metrics.get('board_grid_step')))
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+
+TESTS = [
+    ('the resolver', t_the_resolver_answers_or_declines_with_a_reason),
+    ('the radius guard', t_a_lattice_coarser_than_the_radius_is_refused),
+    ('the ladder admits two answers',
+     t_the_resolver_can_only_ever_return_two_values),
+    ('the OFFSET is snapped', t_the_offset_is_snapped_not_the_position),
+    ("the board's lattice, not the raster", t_the_lattice_is_the_boards_not_the_raster),
+    ('the radius stays exact', t_the_radius_stays_an_exact_bound),
+    ('a zero offset is refused', t_a_draw_that_snaps_to_no_movement_is_refused),
+    ('no pose sits on its seed', t_no_emitted_pose_sits_on_its_own_seed),
+    ('determinism', t_it_is_deterministic),
+    ('end to end', t_the_seed_board_the_quench_parses_still_declares_the_lattice),
+]
+
+
+def _every_case_is_registered():
+    g = globals()
+    declared = {fn for _l, fn in TESTS}
+    missing = sorted(n for n, v in g.items()
+                     if n.startswith('t_') and callable(v)
+                     and v not in declared)
+    if missing:
+        print('  FAIL  every t_* case is registered in TESTS  -- ORPHANED: %s'
+              % ', '.join(missing))
+        FAILURES.append('unregistered cases: %s' % ', '.join(missing))
+
+
+def main():
+    print('portfolio jitter lands on the board lattice (#826)')
+    for label, fn in TESTS:
+        print(' ' + label)
+        fn()
+    _every_case_is_registered()
+    if FAILURES:
+        print('\nFAILED (%d): %s' % (len(FAILURES), ', '.join(FAILURES)))
+        return 1
+    print('\nOK')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_826_portfolio_lattice.py
+++ b/tests/test_826_portfolio_lattice.py
@@ -324,12 +324,20 @@ def t_the_seed_board_the_quench_parses_still_declares_the_lattice():
         report('at EXACTLY the input occupancy, not merely above the floor',
                seed_ev['occupancy'] == in_ev['occupancy'],
                '%s vs %s' % (seed_ev['occupancy'], in_ev['occupancy']))
-        report("and the candidate's quench saw the same lattice as the "
-               'baseline',
-               cands[0].metrics.get('board_grid_step')
-               == res['baseline'].metrics.get('board_grid_step'),
-               '%s vs %s' % (cands[0].metrics.get('board_grid_step'),
-                             res['baseline'].metrics.get('board_grid_step')))
+        # Against the INPUT's lattice, not merely against each other. The
+        # first draft compared candidate to baseline, and the mutation that
+        # nulls the whole disclosure made BOTH None -- so `None == None`
+        # passed and the row survived. Two things that vanish together are not
+        # an agreement.
+        cand_step = cands[0].metrics.get('board_grid_step')
+        base_step = res['baseline'].metrics.get('board_grid_step')
+        report('the disclosure carries a real lattice, not a null',
+               cand_step == in_ev['step'] and base_step == in_ev['step'],
+               'candidate %s / baseline %s / input %s'
+               % (cand_step, base_step, in_ev['step']))
+        report('the candidate reports the occupancy it was read off',
+               cands[0].metrics.get('board_grid_reason') == 'inferred',
+               str(cands[0].metrics.get('board_grid_reason')))
     finally:
         shutil.rmtree(work, ignore_errors=True)
 

--- a/tests/test_826_portfolio_lattice.py
+++ b/tests/test_826_portfolio_lattice.py
@@ -25,6 +25,28 @@ if ignored:
 The radius arms script the rng for the same reason: an outward-snapping draw is
 1-6 per board, likely but not guaranteed, and an arm that depends on one being
 drawn goes quietly vacuous the day a fixture changes.
+
+MEASURED, `tests/mutate_826.py`, second run: 11 rows, 11 killed, 0 survived,
+0 broken. The table, from the run:
+
+    the-jitter-snap-is-dropped                               KILLED   8
+    the-jitter-snaps-the-absolute-pose                       KILLED   7
+    the-offset-snaps-to-the-raster-not-the-lattice           KILLED   9
+    a-zero-offset-counts-as-a-perturbation                   KILLED   3
+    the-radius-test-goes-back-before-the-snap                KILLED   2
+    the-lattice-falls-back-to-the-grid-step-raster           KILLED   5
+    the-radius-guard-is-dropped                              KILLED   3
+    the-generator-does-not-pass-the-lattice                  KILLED   5
+    the-lattice-is-resolved-per-candidate-from-the-live-state KILLED   6
+    the-default-becomes-the-inferred-lattice                 KILLED   1
+    the-disclosure-drops-the-board-grid                      KILLED   2
+
+The first run killed 10 of 11. The survivor was `the-disclosure-drops-the-
+board-grid`, and it was a hole in THIS file rather than in the engine: the
+end-to-end arm compared the candidate's `board_grid_step` against the
+BASELINE's, so a mutation nulling the whole disclosure made both None and
+`None == None` passed. Both are now asserted against the input board's own
+inferred lattice. Two things that vanish together are not an agreement.
 """
 
 import math

--- a/tests/test_placement_ab.py
+++ b/tests/test_placement_ab.py
@@ -151,10 +151,14 @@ ROWS = [
         'expect': 'regress',
         'rejected': True,
         'why': ('MECHANISM: the term buys its signal with intent-zone '
-                'containment. Both guards improve and the re-derived '
-                'bus_foreign_crossings improves too, but the ON arm leaves '
-                'more members outside their block zone, so the row marks '
-                'REGRESS on intent errors rather than on its signal. AT HEAD '
+                'containment. UPDATED for #708: "both guards improve" was '
+                'true before the seed-relative candidate snap and is not now '
+                '-- crossings worsens 2429 -> 2442 while hpwl still improves, '
+                'so this row marks REGRESS on a GUARD as well as on intent '
+                'errors. The mark did not move, which is exactly the masking '
+                'this file warns about, so the reason is corrected here rather '
+                'than left to look intact. The re-derived '
+                'bus_foreign_crossings still improves (62 -> 55). AT HEAD '
                 'that direction is decided by the hard pad+drill legality '
                 'layer: quench(pad_legality=False) on this board sends the '
                 'signal the other way -- the direction recorded at 82dbf662 '
@@ -258,12 +262,21 @@ ROWS = [
         'quench_on': {'intent_gate': ROW_INTENT},
         'signal': 'intent_errors_enforced',
         'guard': ('crossings', 'hpwl', 'intent_errors_other'),
-        'expect': 'improve',
+        'expect': 'regress',
         'why': ('MECHANISM: same as intent-ulx3s but thinner, and a SECOND '
-                'board -- which is what the >=3-board rule is about. Here the '
-                'constraint costs nothing: both guards improve as well, so a '
-                'gated search is not inherently worse, it depends on whether '
-                'the poses it removes were load-bearing.'),
+                'board -- which is what the >=3-board rule is about. The '
+                'signal still works: intent_errors_enforced 1 -> 0, and '
+                'crossings improves 1087 -> 1065. UPDATED for #708: this row '
+                'used to record that "the constraint costs nothing -- both '
+                'guards improve as well". That is now FALSE: hpwl worsens '
+                '2121.92 -> 2131.25 and the mark went improve -> regress. '
+                'Nothing about the gate changed; the seed-relative candidate '
+                'snap gives the search a different candidate set, and on THIS '
+                'board the poses the gate removes are now mildly '
+                'load-bearing. The original sentence is kept above as the '
+                'question the row asks -- whether a gated search is inherently '
+                'worse -- because the answer just moved from "no" to "it '
+                'depends on the candidate set too".'),
     },
     {
         'name': 'intent-rp2350',
@@ -273,7 +286,7 @@ ROWS = [
         'quench_on': {'intent_gate': ROW_INTENT},
         'signal': 'intent_errors_enforced',
         'guard': ('crossings', 'hpwl', 'intent_errors_other'),
-        'expect': 'regress',
+        'expect': 'improve',
         'why': ('MECHANISM: the CHEAP row (61 parts), and the corpus-scale '
                 'test of the monotone FREEZE. This board SEEDS with a '
                 'containment error, and the ON arm holds that count instead '
@@ -282,7 +295,16 @@ ROWS = [
                 'showed this signal reaching 0 would mean the gate had '
                 'started repairing and the contract had changed. It also '
                 'carries the known CONTAINER footprint, so the gate is '
-                'exercised beside that exemption.'),
+                'exercised beside that exemption. UPDATED for #708: the mark '
+                'moved regress -> improve, and the tripwire above did NOT '
+                'fire. Measured: the seed board grades exactly ONE '
+                'zone_containment error, and the ON arm now measures exactly '
+                '1 -- it holds the seed count, which is the contract stated '
+                'above, and holds it more precisely than the baseline (2). '
+                'The mark flipped because the OFF arm DEGRADED, 2 -> 3: a '
+                'different candidate set lets the ungated search walk out one '
+                'more part. The signal reaching 0 would still mean the gate '
+                'had started repairing; it is at 1.'),
     },
     {
         'name': 'intent-exclusive-coldfire',

--- a/tests/test_portfolio_strategies.py
+++ b/tests/test_portfolio_strategies.py
@@ -85,6 +85,27 @@ poses3 = portfolio.perturb_jitter(state, free, random.Random("u"), RADIUS)
 restore()
 check("different rng seed produces different jitter", poses != poses3)
 
+# #826: the DEFAULT is continuous, and that is a contract rather than an
+# accident. `placement/perturb.py`'s `scatter` damage kind calls this function
+# with four positional arguments and no lattice, and its own comment calls it
+# "the POSITIVE CONTROL ... the arm that MUST recover". A snapped offset would
+# land the part exactly on the coset the quench generates from -- one nudge
+# reaches it -- which makes the control easier to pass, the one direction a
+# positive control must not move.
+#
+# Every other jitter arm above (radius, freeness, legality, determinism) stays
+# green if the default silently became "snap to the inferred lattice", so
+# without this check nothing in the repo detects that change.
+from placement.board_grid import infer_board_grid            # noqa: E402
+_lat = infer_board_grid(pcb)['step']
+check("the board under test declares a lattice, so this check can fail",
+      _lat is not None, f"{_lat}")
+check("without an explicit lattice the sampler stays CONTINUOUS",
+      any(abs((p['new_x'] - origin[p['reference']][0]) / _lat
+              - round((p['new_x'] - origin[p['reference']][0]) / _lat)) * _lat
+          > 1e-6 for p in poses),
+      f"lattice {_lat}, {len(poses)} poses")
+
 # ---- poses -----------------------------------------------------------------
 n_variants = 0
 while True:

--- a/tests/test_quench_swap_cap.py
+++ b/tests/test_quench_swap_cap.py
@@ -12,7 +12,7 @@ grid degenerates to the seed point only (n = int(max_disp/1000) = 0), which
 is skipped as the current pose, so ANY movement must come from the swap
 block. The final test runs the full optimizer on a real board and checks the
 headline #430 invariant: no returned part ends up further than
-max_displacement (+ grid snap slop) from where it started.
+max_displacement from where it started (exactly, since #708).
 """
 
 import math
@@ -182,8 +182,8 @@ def test_swap_cap_validation():
 
 def test_no_stranding_after_full_run():
     """Headline #430 invariant on a real board: a full quench run (nudges,
-    rotations AND swaps) leaves every reported part within max_displacement
-    (plus the grid_step snap slop) of its input position."""
+    rotations AND swaps) leaves every reported part within max_displacement of
+    its input position -- EXACTLY, with no snap slop, since #708."""
     pcb = parse_kicad_pcb(INTERF_U)
     orig = {ref: (fp.x, fp.y) for ref, fp in pcb.footprints.items()}
     max_disp = 3.0

--- a/tests/test_quench_swap_cap.py
+++ b/tests/test_quench_swap_cap.py
@@ -194,9 +194,14 @@ def test_no_stranding_after_full_run():
         ref = placement['reference']
         ox, oy = orig[ref]
         dist = math.hypot(placement['new_x'] - ox, placement['new_y'] - oy)
-        # 0.1 = default grid_step: candidate positions snap to the grid, so a
-        # radius-capped candidate can end up at most one snap past the cap.
-        assert dist <= max_disp + 0.1 + 1e-6, \
+        # EXACT, with no snap slop, since #708. The old bound was
+        # `max_disp + 0.1` because `_candidate_positions` tested the radius on
+        # the UNSNAPPED candidate and snapped afterwards, so a final pose could
+        # sit up to grid_step*sqrt(2)/2 past the cap. It now snaps the offset
+        # first and tests the radius on that, so the cap is the cap. Measured
+        # on this fixture: the largest displacement is 2.8575mm -- 9 x 0.3175,
+        # the board's own lattice -- against a 3.0mm cap.
+        assert dist <= max_disp + 1e-6, \
             f"{ref} stranded {dist:.3f}mm from seed (cap {max_disp}mm)"
 
 


### PR DESCRIPTION
Closes #826

> **Stacked on #825** (`fix/708-seed-relative-snap`) and its diff includes that PR's commits until it merges. The dependency is real: this fix needs `placement/board_grid.py`, which #825 adds. It touches **no file #708 owns** — not `board_grid.py`, `quench.py`, `fanout_clearance.py`, `reseat.py`, `test_708_*` or `mutate_708.py` — so #825's 17-row battery and its frozen counts stay valid, and the rebase onto `main` once #825 lands is trivial. (`upstream/main` has moved 4 commits since #825 branched; none touches a file either PR touches.)

## What was wrong

#708 made the quench move a part by a whole number of the board's own placement lattice. It preserves what it is *given* — and `place_portfolio` gives it something already broken. `perturb_jitter` offsets a part by `r·cos(θ)` at 4 decimal places: continuous, on no lattice. `generate` then quenches each candidate **from its jittered seed board**.

The sharp version is not "the #708 fix goes inert". Candidate 0 is quenched from the *input* (`portfolio.py:427-436`) and every other candidate from its jittered seed (`:481-486`), so **the baseline kept the board's lattice and the candidates did not** — the slate was ranked against a baseline with a privilege the candidates were denied.

## Measured before anything was built

`tests/measure_826_jitter_lattice.py`, three tables. Of the 11 tracked boards that declare a lattice, at the default radius **10 lose it**:

| board | lattice | before | after |
|---|---|---|---|
| `haasoscope_pro_max_test` | 0.05 | 0.938 | **0.000** |
| `routed_output` | 0.05 | 0.938 | **0.000** |
| `sonde_u` | 0.3175 | 0.780 | 0.080 |
| `interf_u_unrouted` | 0.3175 | 0.700 | 0.160 |
| `lvds_converter_dualclk(_gnd)` | 0.05 | 0.846 | 0.192 |
| `flat_hierarchy` | 0.3175 | 0.828 | 0.195 |
| `interf_u_unrouted_placed` | 0.05 | 0.960 | 0.400 |
| `splitflap_driver` | 0.3175 | 0.923 | 0.454 |
| `esp_prog` | 0.05 | 0.825 | 0.525 |
| `glasgow_revC` | 0.05 | 0.966 | 0.763 (survives) |

**`esp_prog` — the one case #826 cites — is the second-best outcome of eleven.** The issue understated its own finding.

**It is not a tuning problem.** The same 10 of 11 at radius 4.0, 1.0, 0.25 *and* 0.05. At 0.05 the jitter is one lattice unit on the 0.05 boards and still destroys the inference, because a continuous offset is off-lattice at every amplitude.

**`glasgow_revC` is not a reprieve.** Of its 243 free parts only 59 pass `perturb_jitter`'s incumbent-legality guard and 58 then find a legal sample, so it survives by being *dense*. Its margin is 25 parts: forcing parts off-lattice one at a time, the inference still answers at 24 more and declines at 25. And its 58 jittered parts still sit on an arbitrary residue that the quench faithfully preserves on the wrong coset — even the survivor is on the wrong grid.

**The counterfactual.** Re-running the identical rng stream with the offset snapped restores occupancy to **exactly** the input value on all 11 boards — structural, not lucky: a lattice-multiple offset added to an on-lattice seed keeps its residue. Parts perturbed are identical on 9 of 11 (+1 on one, −2 on another). The escape is not what pays for it.

## The fix

`perturb_jitter` gains a keyword-only `lattice`. Given one it snaps the **offset** — never `part.x + dx`, since `part.x` carries the board's phase and is not generally a multiple of anything. #708's form, at a fourth site.

Four things it is careful about, each with a precedent in this tree:

- the incumbent-legality guard stays **above every draw**, so the docstring promise *"Skipping draws nothing from the rng, so the stream stays stable"* is still literally true;
- the snap is before `candidate_valid` and before `apply_move`, so the pose tested **is** the pose applied (`quench.py` records the bug of doing otherwise);
- the radius is tested **after** the snap, so `--radius` stays an exact bound rather than one slopped by `lattice·√2/2` — its own help calls it a number the operator reasons with;
- a draw snapping to (0,0) is refused. Accepting it is *guaranteed* to succeed — `candidate_valid` on the incumbent was just asserted — so it would emit a pose identical to the seed and put a ref in `poses` that `_displacement` does not count as moved.

**`jitter_lattice()` is deliberately not `board_grid.resolve_snap_lattice`.** That function falls back to `grid_step`, which is right for the quench — whose offsets were already multiples of `step` — and wrong here: the jitter is *continuous*, so snapping a no-lattice board to the 0.1 raster would change behaviour to buy nothing. The off state is **no snap**, and the board still reaches it rather than a flag. It also refuses a lattice coarser than the radius, where the disc holds no destination but the seed (measured: `--radius 0.3175` perturbs 22 of 22, `--radius 0.3` perturbs 0 of 22 after 440 draws and every candidate goes barren).

Resolved **once, from the input board** — `--only N` must be a function of `(input_file, radius)` alone or the ledger's replay primitive silently stops replaying.

**No starvation.** A radius-4 disc on 0.3175 holds 496 lattice destinations and the sampler takes the first legal one; measured, the most boxed-in part on any 0.3175 board still has **9**. And `board_grid` can only ever return 0.05 or 0.3175, so the coarse-lattice case is unreachable by construction.

### `scatter` keeps its damage model — a zero-line diff

`perturb_jitter` has exactly two production callers: `portfolio.generate` and `perturb.py`'s `scatter` damage kind, whose own comment calls it *"the POSITIVE CONTROL … the arm that MUST recover"*. A snapped offset would land the part exactly on the coset the quench generates from — one nudge reaches it — making the control **easier to pass**, the one direction a positive control must not move. Keyword-only with a `None` default means `perturb.py` needs no change at all, and `esp_prog:perturb-scatter-d1` regenerating identically is the evidence.

## What the two reviewers found

An adversarial code review and a separate fact-checker. The blocking defect was in the mechanism added to prove the fix works.

**`_quench_metrics` disclosed the lattice that was *inferred*, not the one the quench *used*.** They diverge exactly when the quench falls back: at `--step 0.25` on an imperial board the shipped candidate has **no** lattice and 0.120 occupancy, while the disclosure said `0.3175`. A disclosure that exists to prove the fix is not inert could report success on an inert run. It now reads `resolved`, with `board_grid_inferred` beside it. `jitter_lattice` had the same conflation on its radius-guard branch, shipping `{"step": 0.3175, "resolved": null}`.

The end-to-end arm checked the **seed** board and never the final one — that one missing line is what let it through. Both are asserted now, plus arms for each disclosure branch, and a mutation row (`the-disclosure-reports-the-inference-not-what-was-used`) that is itself fixture-blind: it dies only under the `--step 0.25` arm.

Eleven claims in my own text were wrong and are corrected: *"None on every jitter candidate"* (glasgow's was 0.05 — the counterexample is my own headline survivor); *"58 of 243 pass the guard"* (59 pass, 58 perturbed); *"~20-part margin"* (25); *"worst case 10"* (**9**; 10 was splitflap's 11 rounded, a one-board number presented as a corpus worst case, produced by no committed script); *"~500 destinations"* (496); *"1-6 outward draws per board"* (0-6, and **zero** on six of eleven — which strengthens the argument for scripting those arms).

## Recorded evidence

| record | verdict |
|---|---|
| `test_703_predictor_regen.py` `esp_prog:portfolio-1` | **moved**, re-recorded from the run, reproduced twice. Second consecutive re-record (it moved for #708 too) — both times because it is the detector its header describes and it fired. `truth.headline` (3) and `crossings` (23) did **not** move; the routed board is marginally worse (vias 23→25, copper 263.91→264.89, segments 203→207) at the same blocking — a different placement, not a better or worse one |
| `esp_prog:perturb-scatter-d1` | regenerates **identically** — the evidence that `scatter` is untouched |
| `tests/553_diagnosis_recall_baseline.json` | does not move (only its `scatter` arm reaches the jitter) |
| `test_788_marginal_literals.py` | Arm B skips without the gitignored study tree. Of its two portfolio literals only `sonde_u:portfolio-3` goes stale — **`watchy` declares no lattice**, so `watchy:portfolio-2` is untouched |
| `placement_rule1_withdrawal.json` | stale for its jitter rows only (index 0 is the baseline and still reproducible); pure functions of its literals, so nothing fails |
| `docs/placement-predictors.md` | marked stale for its portfolio rows — marking the derived records and not the document they derive from was the inconsistent half |

## Testing

- `tests/run_all.py` — green against the #708-branch baseline (501 passed / 0 failed before this PR's own suite was added).
- `tests/mutate_826.py` — **12 rows, 12 killed, 0 broken.** The battery caught something on every run: a vacuous assertion of mine in run 1, two anchors my own review fixes had moved in run 3.
- `tests/test_826_portfolio_lattice.py` — 37 checks.
- `tests/test_portfolio_determinism.py` — unchanged and green: byte-identical across `PYTHONHASHSEED`, seed 1 still differs from seed 0, `--only 1` still replays.
- End to end on `interf_u_unrouted`: input → jittered seed → quenched candidate, 0.3175 at occupancy 0.700 throughout.

## Not fixed here, and named rather than left to be found

`relocate.py` has the same defect — **measured, 0 on-lattice corridor shifts on every board tested**. `seeder.py` has it structurally on the from-scratch path, where there is arguably nothing to preserve. `reconstruct.py` has a latent version no corpus board currently triggers. Each wants its own measurement rather than a drive-by change inside this one.
