### PR TITLE
qfn underpad escape: test the pad->via stub against the copper nets_to_route erases -- vias, segments AND pads (#619, #845)

### DIFF
--- a/py_router/env_knobs.py
+++ b/py_router/env_knobs.py
@@ -339,6 +339,16 @@ def refresh() -> None:
     g['NO_STATIC_BASE'] = _truthy('KICAD_NO_STATIC_BASE')
     g['ALLOW_STAGGERED_BGA'] = _truthy('KICAD_ALLOW_STAGGERED_BGA')
     g['QFN_UNDERPAD_NO_ALT_STAGGER'] = _truthy('QFN_UNDERPAD_NO_ALT_STAGGER')
+    # #619 which halves of the nets_to_route erasure the under-pad escape tests
+    # its pad->via stub against: 'all' (default) | 'via' | 'seg' | 'off'.
+    # An A/B isolation knob like KICAD_NO_SOFT_JOINT_BRIDGE, not a behaviour
+    # choice -- the halves are NOT additive (the via half changes which offsets
+    # are chosen, so it moves the SEGMENT residual too: on routed_output U2 it
+    # takes seg 25 -> 12 without testing a single segment), so attributing a
+    # half needs an arm that runs only that half. An unrecognised value is
+    # 'all', so a typo cannot silently disable the gate.
+    g['QFN_UNDERPAD_ERASED_GATE'] = _s('KICAD_QFN_UNDERPAD_ERASED_GATE',
+                                       'all').strip().lower()
     g['LEGACY_ORACLE'] = _truthy('KICAD_LEGACY_ORACLE')
     g['NO_EXACT_FILL'] = _truthy('KICAD_NO_EXACT_FILL')
     g['NO_FILL_NETCLASS'] = _truthy('KICAD_NO_FILL_NETCLASS')  # fill-model A/B

--- a/py_router/qfn_fanout/__init__.py
+++ b/py_router/qfn_fanout/__init__.py
@@ -385,7 +385,10 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
     # (obstacle_map.py:338-341), so the under-pad path never gets it. Today a
     # tie partner on a fanned net is absent from the map by accident; without
     # this the pad half would turn that accident into a hard block with no lift.
-    from check_drc import _pad_has_no_copper, pad_copper_layers
+    from check_drc import (_pad_has_no_copper, pad_copper_layers,
+                           check_pad_segment_overlap,
+                           _net_tie_span_waived as _tie_span_waived)
+    from kicad_parser import Segment as _Segment
     _board_cu = list(pcb_data.board_info.copper_layers or [])
     _erased_pads = [p for p in foreign_pads
                     if p.net_id in fanned_nets
@@ -397,6 +400,15 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
     # ESCAPE layer, which is where the VIA lands, not where the stub's copper
     # lives, and check_drc grades a segment with `_pair_cl(..., layer=seg.layer)`.
     # So the stub's own pair clearance is the mount layer's rule.
+    # PARTIAL, and the limit is worth stating: when footprint.layer IS ruled
+    # this is exact, but when it is not, the fallback is `clearance` -- which
+    # the caller already rebound to the ESCAPE layer's rule (#498, :900-904).
+    # So an unruled mount layer inherits the escape layer's number rather than
+    # the base. Closing that means not rebinding the scalar in the caller at
+    # all, which is the same fix the sibling issue on `obs_layer_idx` needs and
+    # is deliberately not attempted here. Inert on every board this repo
+    # ingests (#770: no tracked board carries a .kicad_dru layer rule), and
+    # inert on the default path, where --layer IS the mount layer.
     _stub_clr = cfg.layer_clearance(footprint.layer, clearance)
     # A SET of halves, so an A/B arm can be 'via', 'via,seg', 'off' or 'all'.
     # 'off' wins over everything (an explicit ablation is never partial), and
@@ -404,6 +416,19 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
     # disable the gate.
     _gate = env_knobs.QFN_UNDERPAD_ERASED_GATE
     _gsel = {t for t in _gate.replace(',', ' ').split() if t}
+    # ANY unrecognised token means ALL and says so. The earlier form silently
+    # dropped a half on a transposition -- 'sge,pad' ran the pad half only,
+    # reporting itself as a deliberate two-half arm -- and quietly accepted the
+    # PLURAL spellings ('vias', 'segs', 'pads') that LAST_ERASED_SETS itself
+    # publishes, as well as 'none'/'0'/'false', which read as ablations and are
+    # not. Fail-safe in direction (never silently OFF) and now audible.
+    _known = {'all', 'off', 'via', 'seg', 'pad'}
+    _bad = _gsel - _known
+    if _bad:
+        print(f"  WARNING: KICAD_QFN_UNDERPAD_ERASED_GATE={_gate!r} has "
+              f"unrecognised token(s) {sorted(_bad)}; running ALL halves. "
+              f"Valid: all | off | via | seg | pad (comma-separated).")
+        _gsel = {'all'}
     _gate_all = not _gsel or 'all' in _gsel or not (_gsel & {'via', 'seg', 'pad'})
     _gate_via = 'off' not in _gsel and (_gate_all or 'via' in _gsel)
     _gate_seg = 'off' not in _gsel and (_gate_all or 'seg' in _gsel)
@@ -583,18 +608,48 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
                                                s.end_x, s.end_y) \
                         < s.width / 2 + track_width / 2 + _stub_clr - 1e-6:
                     return False
-        if _gate_pad:
+        if _gate_pad and _erased_pads:
+            # CALL the grader; do not mirror it. An earlier revision of this
+            # used `_seg_hits_pad` with a hand-built margin, which is what the
+            # surface fan's pad loop does -- and it was measurably NOT the same
+            # predicate. Audited over the whole corpus at 0.1/0.1/0.45, it
+            # rejected 83 candidate/pad pairs that `check_pad_segment_overlap`
+            # grades CLEAN, the worst 0.234mm clear of the requirement, from
+            # two causes it cannot express:
+            #   * `_seg_hits_pad` tests the full axis-aligned RECTANGLE and
+            #     grows it with square corners, while check_drc resolves a
+            #     `corner_radius` for circle/oval/roundrect and calls
+            #     `segment_to_rect_distance` with it -- a 1.45mm round pad
+            #     becomes a 1.6x1.6 box whose corner is 1.131mm from centre
+            #     where the true keep-out is 0.875mm (61 of the 83); and
+            #   * it rejects at 1e-6 while the grader forgives `_grade_tol` =
+            #     5% of clearance, so a 0.005mm overlap at CL 0.1 is clean to
+            #     check_drc and a violation here (the other 22).
+            # It is also SAMPLED (`samples=16`), so on a long stub a small pad
+            # can fall between two samples: a 0.25mm pad on a 6.95mm stub --
+            # reachable at via 0.8 / pitch 0.4, where the ladder's top offset
+            # is exactly 6.95mm -- was reported CLEAR while the stub ran
+            # through its centre. `check_pad_segment_overlap` is exact.
+            seg = _Segment(start_x=px, start_y=py, end_x=vx, end_y=vy,
+                           width=track_width, layer=footprint.layer,
+                           net_id=net_id)
             _tie = _tie_exempt(net_id)
             for p in _erased_pads:
-                if p.net_id == net_id or id(p) in _tie:
+                if p.net_id == net_id:
                     continue
-                # local_clearance is per-PAD and RAISES the floor, so the
-                # margin is resolved here rather than hoisted (check_drc:
-                # `_pad_pair_cl = max(local_clearance, pair)`).
-                if _seg_hits_pad(px, py, vx, vy, p,
-                                 margin=max(_stub_clr,
-                                            getattr(p, 'local_clearance', 0.0)
-                                            or 0.0) + track_width / 2 - 1e-6):
+                # The net-tie waiver is check_drc's BOTH-condition form. The
+                # exemption is LOCAL -- KiCad waives the contact only where it
+                # lies on the tied net's own pad (DRC_ENGINE::IsNetTieExclusion)
+                # -- so skipping the partner pad outright would wave through a
+                # real short 2-3mm away, which is exactly the geometry the
+                # ladder produces. `id(p) in _tie` alone is NOT the rule.
+                if id(p) in _tie and _tie_span_waived(pcb_data, seg, net_id,
+                                                     p, _stub_clr):
+                    continue
+                # local_clearance is per-PAD and RAISES the floor, exactly as
+                # check_drc's `_pad_pair_cl = max(local_clearance, pair)`.
+                _eff = max(_stub_clr, getattr(p, 'local_clearance', 0.0) or 0.0)
+                if check_pad_segment_overlap(p, seg, _eff, _board_cu)[0]:
                     return False
         return True
 
@@ -870,6 +925,15 @@ def generate_qfn_fanout(footprint: Footprint,
     default, and what the CLI passes) is fully inert.
     """
     LAST_CANCEL_SKIPPED.clear()
+    # #619: and the erased-set report, for the same reason. `generate_qfn_fanout`
+    # returns early on several paths that never reach `_underpad_via_escape`
+    # (no recognised layout, no pad_infos, a cancel), and the surface fan never
+    # reaches it at all -- so without this a later reader gets the PREVIOUS
+    # footprint's set, from a different board. Measured over the tracked corpus:
+    # 155 of 408 footprints with >=4 pads never enter the escape, and every one
+    # of them was being graded against whatever ran before it.
+    global LAST_ERASED_SETS
+    LAST_ERASED_SETS = {}
     _cancelled = [False]
 
     def _cancel() -> bool:

--- a/py_router/qfn_fanout/__init__.py
+++ b/py_router/qfn_fanout/__init__.py
@@ -354,6 +354,7 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
     # zone copper, so pour copper is invisible to the stub before and after
     # this change and nothing is being silently left out.
     _erased_vias = [v for v in pcb_data.vias if v.net_id in fanned_nets]
+    _erased_segs = [s for s in pcb_data.segments if s.net_id in fanned_nets]
     # The stub is emitted on `footprint.layer` -- the pad's OWN mount layer,
     # deliberately, so it does not float above the pad (#195) -- and NOT on the
     # `layer` argument. The caller's #498 dru swap resolved `clearance` for the
@@ -363,6 +364,7 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
     _stub_clr = cfg.layer_clearance(footprint.layer, clearance)
     _gate = env_knobs.QFN_UNDERPAD_ERASED_GATE
     _gate_via = _gate in ('all', 'via')
+    _gate_seg = _gate in ('all', 'seg')
     from kicad_parser import pad_drill_circles as _pdc
     import routing_defaults as _rd
     # BOARD-FIRST, same rule as every other floor: a board declaring
@@ -512,6 +514,21 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
                     continue                # own-net copper is no obstacle
                 if point_to_segment_distance(v.x, v.y, px, py, vx, vy) \
                         < v.size / 2 + track_width / 2 + _stub_clr - 1e-6:
+                    return False
+        if _gate_seg:
+            # Segments, unlike vias, really ARE single-layer objects, so this
+            # half filters -- on `footprint.layer`, where the stub's copper is
+            # emitted, NOT on `layer`. The surface fan compares against `layer`
+            # (:999) only because ITS stubs land there. Measured on U2: the two
+            # spellings disagree completely -- `footprint.layer` (F.Cu) finds 25
+            # pairs, `layer` (B.Cu) finds 17 DIFFERENT ones.
+            for s in _erased_segs:
+                if s.net_id == net_id or s.layer != footprint.layer:
+                    continue
+                if segment_to_segment_distance(px, py, vx, vy,
+                                               s.start_x, s.start_y,
+                                               s.end_x, s.end_y) \
+                        < s.width / 2 + track_width / 2 + _stub_clr - 1e-6:
                     return False
         return True
 

--- a/py_router/qfn_fanout/__init__.py
+++ b/py_router/qfn_fanout/__init__.py
@@ -366,6 +366,31 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
     # this change and nothing is being silently left out.
     _erased_vias = [v for v in pcb_data.vias if v.net_id in fanned_nets]
     _erased_segs = [s for s in pcb_data.segments if s.net_id in fanned_nets]
+    # The pad half needs FOUR exclusions the surface fan's pad loop (:990-996)
+    # does not make, or it phantom-rejects. Three are check_drc's own rules,
+    # applied here so the gate refuses exactly what the grader flags:
+    #   * NPTH carries no copper -- KiCad lists *.Cu on it for hole keep-out,
+    #     but an np_thru_hole pad's "size" is only the mask opening. check_drc
+    #     skips it for PAD-SEGMENT (`_pad_has_no_copper`, #260); so do we.
+    #   * layer scope resolves through `pad_copper_layers`, which expands the
+    #     `*.Cu` and `F&B.Cu` wildcards. A bare `layer in pad.layers` misses
+    #     both -- zero occurrences in this corpus, but the pcbnew parse path
+    #     emits them, so the GUI front would diverge from the CLI one (#722).
+    #   * `pad.local_clearance` RAISES the floor: check_drc grades PAD-SEGMENT
+    #     at `_pad_pair_cl = max(local_clearance, pair)`. It is per-pad, so it
+    #     cannot be hoisted the way the surface fan hoists its `margin` -- that
+    #     is precisely why the surface fan cannot honour it and this does.
+    # The fourth is a net TIE: `_seg_hits_pad` is net-blind, and obstacle_map's
+    # own tie lift only fires when exactly one net is being routed
+    # (obstacle_map.py:338-341), so the under-pad path never gets it. Today a
+    # tie partner on a fanned net is absent from the map by accident; without
+    # this the pad half would turn that accident into a hard block with no lift.
+    from check_drc import _pad_has_no_copper, pad_copper_layers
+    _board_cu = list(pcb_data.board_info.copper_layers or [])
+    _erased_pads = [p for p in foreign_pads
+                    if p.net_id in fanned_nets
+                    and not _pad_has_no_copper(p)
+                    and footprint.layer in pad_copper_layers(p, _board_cu)]
     # The stub is emitted on `footprint.layer` -- the pad's OWN mount layer,
     # deliberately, so it does not float above the pad (#195) -- and NOT on the
     # `layer` argument. The caller's #498 dru swap resolved `clearance` for the
@@ -373,12 +398,25 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
     # lives, and check_drc grades a segment with `_pair_cl(..., layer=seg.layer)`.
     # So the stub's own pair clearance is the mount layer's rule.
     _stub_clr = cfg.layer_clearance(footprint.layer, clearance)
+    # A SET of halves, so an A/B arm can be 'via', 'via,seg', 'off' or 'all'.
+    # 'off' wins over everything (an explicit ablation is never partial), and
+    # an empty or unrecognised value is 'all' -- a typo must not silently
+    # disable the gate.
     _gate = env_knobs.QFN_UNDERPAD_ERASED_GATE
-    _gate_via = _gate in ('all', 'via')
-    _gate_seg = _gate in ('all', 'seg')
+    _gsel = {t for t in _gate.replace(',', ' ').split() if t}
+    _gate_all = not _gsel or 'all' in _gsel or not (_gsel & {'via', 'seg', 'pad'})
+    _gate_via = 'off' not in _gsel and (_gate_all or 'via' in _gsel)
+    _gate_seg = 'off' not in _gsel and (_gate_all or 'seg' in _gsel)
+    _gate_pad = 'off' not in _gsel and (_gate_all or 'pad' in _gsel)
+
+    def _tie_exempt(net_id):
+        f = getattr(pcb_data, 'net_tie_exempt_pad_ids', None)
+        return f(net_id) if f else ()
+
     global LAST_ERASED_SETS
     LAST_ERASED_SETS = {'nets': set(fanned_nets), 'vias': len(_erased_vias),
-                        'segs': len(_erased_segs), 'layer': footprint.layer,
+                        'segs': len(_erased_segs), 'pads': len(_erased_pads),
+                        'layer': footprint.layer,
                         'clearance': _stub_clr, 'gate': _gate}
     from kicad_parser import pad_drill_circles as _pdc
     import routing_defaults as _rd
@@ -544,6 +582,19 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
                                                s.start_x, s.start_y,
                                                s.end_x, s.end_y) \
                         < s.width / 2 + track_width / 2 + _stub_clr - 1e-6:
+                    return False
+        if _gate_pad:
+            _tie = _tie_exempt(net_id)
+            for p in _erased_pads:
+                if p.net_id == net_id or id(p) in _tie:
+                    continue
+                # local_clearance is per-PAD and RAISES the floor, so the
+                # margin is resolved here rather than hoisted (check_drc:
+                # `_pad_pair_cl = max(local_clearance, pair)`).
+                if _seg_hits_pad(px, py, vx, vy, p,
+                                 margin=max(_stub_clr,
+                                            getattr(p, 'local_clearance', 0.0)
+                                            or 0.0) + track_width / 2 - 1e-6):
                     return False
         return True
 

--- a/py_router/qfn_fanout/__init__.py
+++ b/py_router/qfn_fanout/__init__.py
@@ -337,6 +337,32 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
     _own_via_pos: Dict[int, List[Tuple[float, float]]] = {}
     for v in pcb_data.vias:
         _own_via_pos.setdefault(v.net_id, []).append((v.x, v.y))
+    # #619: `nets_to_route` above ERASES every piece of copper on a net we are
+    # escaping -- segments, vias AND pads (obstacle_map.py :216 / :299 / :312).
+    # Right for a net's OWN copper; wrong for every OTHER net in the same call.
+    # The candidate VIA still meets that copper (via_clears scans pcb_data
+    # directly), but the pad->via STUB's only channel to the input board is
+    # `check_line_clearance` on the holed map -- so stubs shipped straight
+    # through the CENTRES of pre-existing vias on sibling fanned nets.
+    #
+    # The SURFACE fan already closes exactly this hole for itself, geometrically
+    # (#257, the tail of `_seg_grazes`); the under-pad path returns ~200 lines
+    # earlier and shares none of it. This is that backstop, ported.
+    #
+    # These lists are EXACTLY the complement of what `nets_to_route` erases:
+    # build_base_obstacle_map stamps only segments, vias and pads and never
+    # zone copper, so pour copper is invisible to the stub before and after
+    # this change and nothing is being silently left out.
+    _erased_vias = [v for v in pcb_data.vias if v.net_id in fanned_nets]
+    # The stub is emitted on `footprint.layer` -- the pad's OWN mount layer,
+    # deliberately, so it does not float above the pad (#195) -- and NOT on the
+    # `layer` argument. The caller's #498 dru swap resolved `clearance` for the
+    # ESCAPE layer, which is where the VIA lands, not where the stub's copper
+    # lives, and check_drc grades a segment with `_pair_cl(..., layer=seg.layer)`.
+    # So the stub's own pair clearance is the mount layer's rule.
+    _stub_clr = cfg.layer_clearance(footprint.layer, clearance)
+    _gate = env_knobs.QFN_UNDERPAD_ERASED_GATE
+    _gate_via = _gate in ('all', 'via')
     from kicad_parser import pad_drill_circles as _pdc
     import routing_defaults as _rd
     # BOARD-FIRST, same rule as every other floor: a board declaring
@@ -448,6 +474,47 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
             via_size=via_size, via_drill=via_drill, clearance=clearance,
             track_width=track_width, hole_to_hole=_h2h)
 
+    def stub_clears_erased(px, py, vx, vy, net_id):
+        """#619: is the pad->via stub clear of the copper `nets_to_route` erased?
+
+        The tail of the surface fan's `_seg_grazes` (#257), applied to the
+        bridging stub. Returns True when the stub is CLEAR -- the opposite
+        polarity to `_seg_grazes`, so it reads like the `stub_ok` it is
+        and-ed into.
+
+        Deliberately LAYER-BLIND, matching every grader around it:
+        `check_drc.check_via_segment_overlap` ignores `via.layers` ("vias go
+        through ALL copper layers") and `obstacle_map._add_via_obstacle`
+        stamps every via on every layer. Filtering a blind/buried via out
+        here would emit copper this repo's own DRC flags, and would make a
+        fanned-net via behave differently from an identical non-fanned one.
+
+        Called BEFORE `via_clears`, not after, and that ordering is
+        load-bearing rather than cosmetic: `via_clears` scans, per candidate,
+        every board via + every board pad (a 17-sample `_seg_hits_pad` each)
+        + every board segment -- ~20k point tests on routed_output U2, where
+        `_erased_vias` is 89. Running this first kills a doomed candidate for
+        ~0.5% of that cost. Measured on U2: correctly ordered 7.0s against a
+        10.9s baseline (-36%); appended after `via_clears` instead, +18%.
+        The gate is a speed-up.
+        """
+        if math.hypot(vx - px, vy - py) <= POSITION_TOLERANCE:
+            # Via centred on the pad: the commit loop emits NO track at all
+            # (:604, :616), so there is no stub to test. `run_output_conflict`
+            # states the same rule for the reuse case at :213-215; without
+            # this, a zero-length reuse -- a pre-existing via-in-pad at the pad
+            # centre, the canonical re-run case -- is judged as a degenerate
+            # segment and can be rejected for copper it will never emit.
+            return True
+        if _gate_via:
+            for v in _erased_vias:
+                if v.net_id == net_id:
+                    continue                # own-net copper is no obstacle
+                if point_to_segment_distance(v.x, v.y, px, py, vx, vy) \
+                        < v.size / 2 + track_width / 2 + _stub_clr - 1e-6:
+                    return False
+        return True
+
     def snap(v):
         return round(v / grid_step) * grid_step if grid_step > 0 else v
 
@@ -511,9 +578,16 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
             # already there) judged against a demanded 0.55. That was measured
             # as Net-(U2A-DATA_30) losing its escape to a fresh drill --
             # 28/12/30 vias/dropped/tracks becoming 29/13/31 on U2.
+            #
+            # stub_clears_erased is a SEPARATE `and` term, never folded into
+            # the `obs_layer_idx is None` `or`: that short-circuit skips the
+            # whole clearance test when the escape layer is not in the layer
+            # map, and #619 is pure geometry on the mount layer that must run
+            # regardless.
             if (obs_layer_idx is None or
                     check_line_clearance(obstacles, px, py, _rvx, _rvy,
                                          obs_layer_idx, cfg)) \
+                    and stub_clears_erased(px, py, _rvx, _rvy, pi.pad.net_id) \
                     and not run_output_conflict(
                         _rvx, _rvy, pi.pad.net_id, placed, px, py,
                         via_size=via_size, via_drill=via_drill,
@@ -524,7 +598,9 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
             vx, vy = snap(px + ex * d), snap(py + ey * d)
             stub_ok = (obs_layer_idx is None or
                        check_line_clearance(obstacles, px, py, vx, vy, obs_layer_idx, cfg))
-            if stub_ok and via_clears(vx, vy, pi.pad.net_id, placed, px, py):
+            if stub_ok \
+                    and stub_clears_erased(px, py, vx, vy, pi.pad.net_id) \
+                    and via_clears(vx, vy, pi.pad.net_id, placed, px, py):
                 return (vx, vy)
         return None
 

--- a/py_router/qfn_fanout/__init__.py
+++ b/py_router/qfn_fanout/__init__.py
@@ -40,6 +40,17 @@ from qfn_fanout.geometry import calculate_fanout_stub
 # planner (or the user) into a pointless tighter-clearance retry.
 LAST_CANCEL_SKIPPED: List[str] = []
 
+# #619: what the last under-pad escape's obstacle map ERASED, published so a
+# sweep or a test can grade against the set the ENGINE used instead of
+# re-deriving it. Re-deriving is a live trap: `fanned_nets` comes from
+# `pad_infos`, which drops net 0, `unconnected-*`, net-filter misses and
+# `center` pads, so the obvious proxy -- `{p.net_id for p in footprint.pads}`
+# -- can report the gate as live on a footprint where the erased set is
+# empty and the gate is a constant True. Keys: `nets` (the net-id set handed
+# to nets_to_route), `vias`/`segs` (erased counts), `layer` (where the stub
+# copper lands), `clearance` (the floor the stub was graded at).
+LAST_ERASED_SETS: Dict = {}
+
 
 def _snap_tip_on_grid(corner, tip, net_id, grid_step, grazes):
     """Move a shortened fan tip back ONTO the routing grid (#446).
@@ -365,6 +376,10 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
     _gate = env_knobs.QFN_UNDERPAD_ERASED_GATE
     _gate_via = _gate in ('all', 'via')
     _gate_seg = _gate in ('all', 'seg')
+    global LAST_ERASED_SETS
+    LAST_ERASED_SETS = {'nets': set(fanned_nets), 'vias': len(_erased_vias),
+                        'segs': len(_erased_segs), 'layer': footprint.layer,
+                        'clearance': _stub_clr, 'gate': _gate}
     from kicad_parser import pad_drill_circles as _pdc
     import routing_defaults as _rd
     # BOARD-FIRST, same rule as every other floor: a board declaring

--- a/py_router/qfn_fanout/__init__.py
+++ b/py_router/qfn_fanout/__init__.py
@@ -334,7 +334,24 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
     _prog(0, 0, "building obstacle map...")
     obstacles = build_base_obstacle_map(pcb_data, cfg, nets_to_route=list(fanned_nets),
                                         extra_clearance=track_width / 2)
-    obs_layer_idx = layer_map.get(layer)
+    # #845: the obstacle plane for the STUB, which is emitted on the pad's own
+    # mount layer (:766 and :777, deliberately -- putting it on an inner/back
+    # escape layer would float it above the pad, #195). This used to resolve
+    # `layer`, the ESCAPE layer, which is where the VIA lands and not where the
+    # stub's copper is; on the configuration under-pad exists for (an F.Cu part
+    # escaped to B.Cu) every stub was clearance-tested against the wrong
+    # layer's plane -- grading copper that is not there and ignoring copper
+    # that is.
+    #
+    # It is the only consumer of this index. The VIA is not tested through the
+    # map at all (it is a through via, and `via_clears` scans pcb_data
+    # geometrically), so there was never a second reader for whom the escape
+    # layer was the right answer.
+    #
+    # Per-layer clearance comes along for free: build_base_obstacle_map stamps
+    # each layer at that layer's own rule (#498, installed into cfg at :331),
+    # so reading the mount layer's plane also reads the mount layer's floor.
+    stub_layer_idx = layer_map.get(footprint.layer)
 
     # Foreign obstacles, keyed by net so the via's OWN net is exempt at check
     # time. A through-via spans every copper layer, so foreign tracks on ANY
@@ -404,11 +421,14 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
     # this is exact, but when it is not, the fallback is `clearance` -- which
     # the caller already rebound to the ESCAPE layer's rule (#498, :900-904).
     # So an unruled mount layer inherits the escape layer's number rather than
-    # the base. Closing that means not rebinding the scalar in the caller at
-    # all, which is the same fix the sibling issue on `obs_layer_idx` needs and
-    # is deliberately not attempted here. Inert on every board this repo
-    # ingests (#770: no tracked board carries a .kicad_dru layer rule), and
-    # inert on the default path, where --layer IS the mount layer.
+    # the base. Closing that means not rebinding the scalar in the CALLER at
+    # all, which is a change to the surface fan's path too and is deliberately
+    # not attempted here. The map-based test above does not share the problem:
+    # build_base_obstacle_map stamps each layer at its own rule, so reading the
+    # mount layer's plane already reads the mount layer's floor. Inert on every
+    # board this repo ingests (#770: no tracked board carries a .kicad_dru
+    # layer rule), and inert on the default path, where --layer IS the mount
+    # layer.
     _stub_clr = cfg.layer_clearance(footprint.layer, clearance)
     # A SET of halves, so an A/B arm can be 'via', 'via,seg', 'off' or 'all'.
     # 'off' wins over everything (an explicit ablation is never partial), and
@@ -718,13 +738,13 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
             # 28/12/30 vias/dropped/tracks becoming 29/13/31 on U2.
             #
             # stub_clears_erased is a SEPARATE `and` term, never folded into
-            # the `obs_layer_idx is None` `or`: that short-circuit skips the
+            # the `stub_layer_idx is None` `or`: that short-circuit skips the
             # whole clearance test when the escape layer is not in the layer
             # map, and #619 is pure geometry on the mount layer that must run
             # regardless.
-            if (obs_layer_idx is None or
+            if (stub_layer_idx is None or
                     check_line_clearance(obstacles, px, py, _rvx, _rvy,
-                                         obs_layer_idx, cfg)) \
+                                         stub_layer_idx, cfg)) \
                     and stub_clears_erased(px, py, _rvx, _rvy, pi.pad.net_id) \
                     and not run_output_conflict(
                         _rvx, _rvy, pi.pad.net_id, placed, px, py,
@@ -734,8 +754,8 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
                 return (_rvx, _rvy)
         for d in candidate_offsets(pi.pad_width, mode):
             vx, vy = snap(px + ex * d), snap(py + ey * d)
-            stub_ok = (obs_layer_idx is None or
-                       check_line_clearance(obstacles, px, py, vx, vy, obs_layer_idx, cfg))
+            stub_ok = (stub_layer_idx is None or
+                       check_line_clearance(obstacles, px, py, vx, vy, stub_layer_idx, cfg))
             if stub_ok \
                     and stub_clears_erased(px, py, vx, vy, pi.pad.net_id) \
                     and via_clears(vx, vy, pi.pad.net_id, placed, px, py):

--- a/tests/mutate_619.py
+++ b/tests/mutate_619.py
@@ -75,8 +75,8 @@ ROWS = [
      "                if s.layer != footprint.layer:",
      (T_619,), 'KILLED'),
     ('pad-half-drops-the-own-net-skip', 'q',
-     "                if p.net_id == net_id or id(p) in _tie:",
-     "                if id(p) in _tie:",
+     "                if p.net_id == net_id:\n                    continue\n",
+     "                if False:\n                    continue\n",
      (T_619,), 'KILLED'),
 
     # ---- the layer decision ---------------------------------------------
@@ -93,23 +93,42 @@ ROWS = [
     ('seg-half-disabled', 'q',
      "        if _gate_seg:", "        if False:", (T_619,), 'KILLED'),
     ('pad-half-disabled', 'q',
-     "        if _gate_pad:", "        if False:", (T_619,), 'KILLED'),
+     "        if _gate_pad and _erased_pads:", "        if False:",
+     (T_619,), 'KILLED'),
 
     # ---- the knob's failure direction ------------------------------------
     # An unrecognised value must mean ALL, never OFF: a typo in a harness must
     # not silently ship the bug back.
-    ('unknown-knob-value-means-OFF', 'q',
-     "    _gate_all = not _gsel or 'all' in _gsel or not (_gsel & {'via', 'seg', 'pad'})",
-     "    _gate_all = 'all' in _gsel",
+    # Targets the GUARD, not `_gate_all`. A wholly unrecognised value falls
+    # back to ALL through two independent paths, so mutating `_gate_all` alone
+    # cannot express the defect -- which is exactly what the battery reported
+    # when this row still did that, and why the test now uses 'sge,pad'.
+    ('unknown-knob-token-silently-drops-a-half', 'q',
+     "    if _bad:\n", "    if False:\n",
      (T_619,), 'KILLED'),
 
     # ---- the pad half's exclusions ---------------------------------------
     ('pad-half-ignores-local-clearance', 'q',
-     "                                 margin=max(_stub_clr,\n"
-     "                                            getattr(p, 'local_clearance', 0.0)\n"
-     "                                            or 0.0) + track_width / 2 - 1e-6):",
-     "                                 margin=_stub_clr + track_width / 2 - 1e-6):",
+     "                _eff = max(_stub_clr, getattr(p, 'local_clearance', 0.0) or 0.0)\n",
+     "                _eff = _stub_clr\n",
      (T_619,), 'KILLED'),
+    # The waiver defect an adversarial review found: check_drc requires BOTH
+    # the membership test and the LOCALITY test (check_drc.py:2442-2445), and
+    # skipping the partner pad outright waives a short 2-3mm away. No tracked
+    # board declares net_tie_pad_groups, so nothing here can catch it -- named
+    # as a hole rather than left as an untested claim.
+    ('pad-half-waives-the-WHOLE-tie-partner', 'q',
+     "                if id(p) in _tie and _tie_span_waived(pcb_data, seg, net_id,\n"
+     "                                                     p, _stub_clr):\n",
+     "                if id(p) in _tie:\n",
+     (T_619,), 'SURVIVED  (no tracked board declares net_tie_pad_groups; this '
+               'is a real test hole, not a covered case)'),
+    ('erased-set-is-not-cleared-between-footprints', 'q',
+     "    global LAST_ERASED_SETS\n    LAST_ERASED_SETS = {}\n",
+     "    pass\n",
+     (T_619,), 'SURVIVED  (the staleness is only visible ACROSS footprints, '
+               'which the sweep exercises and this single-footprint test file '
+               'does not)'),
     # NPTH and the wildcard are asserted against check_drc's own helpers rather
     # than through emitted geometry, because no tracked board places a netted
     # NPTH or an F&B.Cu pad where a stub can reach it. Removing the filter

--- a/tests/mutate_619.py
+++ b/tests/mutate_619.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""#619 mutation battery: does the erased-copper gate's test suite actually
+bite, or does it merely run?
+
+    python3 tests/mutate_619.py
+    python3 tests/mutate_619.py --row over-strict-floor-x5
+    python3 tests/mutate_619.py --list
+
+NOT named `test_*`, so `run_all.py` never collects it: it REWRITES engine files
+in place and restores them, and a suite running beside it would grade a mutated
+tree. One writer per tree.
+
+A row is KILLED when any named test exits non-zero -- a failed assertion and an
+ERROR count the same, because a mutation that makes the graders crash is still
+a mutation the graders noticed. A row whose anchor does not match EXACTLY ONCE
+is BROKEN, not skipped: an anchor that silently matches nothing reports every
+mutation as killed and is the most flattering possible bug.
+
+Expected SURVIVORS are declared with the reason they are not a test hole.
+
+BYTECODE. Every row deletes the target's `__pycache__` before running. CPython
+invalidates a `.pyc` on (mtime, size), and several of these mutations are
+size-preserving edits written within the same second as the original -- the
+child process would then import the CACHED original and the row would report
+SURVIVED for a mutation that was never actually loaded. That is a silent
+false-negative in the flattering direction, so it is prevented rather than
+hoped against.
+"""
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+
+TESTS = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(TESTS)
+
+QFN = os.path.join(ROOT, 'py_router', 'qfn_fanout', '__init__.py')
+TARGETS = {'q': QFN}
+
+T_619 = os.path.join(TESTS, 'test_619_underpad_stub_vs_erased_copper.py')
+T_UP = os.path.join(TESTS, 'test_qfn_underpad.py')
+
+#: (name, target, old, new, tests, expectation)
+ROWS = [
+    # ---- the floor itself ------------------------------------------------
+    # The one mutation the NEGATIVE CONTROL exists for. Everything else in the
+    # file passes under it: an over-strict gate still drives every violation
+    # count to zero, and only a control that asserts a NON-blocker stays
+    # non-blocking can tell "correct" from "refuses everything".
+    ('over-strict-floor-x5', 'q',
+     "                        < v.size / 2 + track_width / 2 + _stub_clr - 1e-6:",
+     "                        < 5.0 * (v.size / 2 + track_width / 2 + _stub_clr):",
+     (T_619,), 'KILLED'),
+    ('via-floor-uses-drill-not-size', 'q',
+     "                if point_to_segment_distance(v.x, v.y, px, py, vx, vy) \\\n"
+     "                        < v.size / 2 + track_width / 2 + _stub_clr - 1e-6:",
+     "                if point_to_segment_distance(v.x, v.y, px, py, vx, vy) \\\n"
+     "                        < v.drill / 2 + track_width / 2 + _stub_clr - 1e-6:",
+     (T_619,), 'KILLED'),
+
+    # ---- the guards ------------------------------------------------------
+    ('drop-the-zero-stub-guard', 'q',
+     "        if math.hypot(vx - px, vy - py) <= POSITION_TOLERANCE:",
+     "        if False:",
+     (T_619, T_UP), 'KILLED'),
+    ('via-half-drops-the-own-net-skip', 'q',
+     "                if v.net_id == net_id:\n"
+     "                    continue                # own-net copper is no obstacle",
+     "                if False:\n"
+     "                    continue                # own-net copper is no obstacle",
+     (T_619, T_UP), 'KILLED'),
+    ('seg-half-drops-the-own-net-skip', 'q',
+     "                if s.net_id == net_id or s.layer != footprint.layer:",
+     "                if s.layer != footprint.layer:",
+     (T_619,), 'KILLED'),
+    ('pad-half-drops-the-own-net-skip', 'q',
+     "                if p.net_id == net_id or id(p) in _tie:",
+     "                if id(p) in _tie:",
+     (T_619,), 'KILLED'),
+
+    # ---- the layer decision ---------------------------------------------
+    # The surface fan's spelling, which is correct THERE and wrong here: the
+    # under-pad stub is emitted on footprint.layer (#195), not on `layer`.
+    ('seg-half-filters-the-ESCAPE-layer', 'q',
+     "                if s.net_id == net_id or s.layer != footprint.layer:",
+     "                if s.net_id == net_id or s.layer != layer:",
+     (T_619,), 'KILLED'),
+
+    # ---- the halves are separable ----------------------------------------
+    ('via-half-disabled', 'q',
+     "        if _gate_via:", "        if False:", (T_619,), 'KILLED'),
+    ('seg-half-disabled', 'q',
+     "        if _gate_seg:", "        if False:", (T_619,), 'KILLED'),
+    ('pad-half-disabled', 'q',
+     "        if _gate_pad:", "        if False:", (T_619,), 'KILLED'),
+
+    # ---- the knob's failure direction ------------------------------------
+    # An unrecognised value must mean ALL, never OFF: a typo in a harness must
+    # not silently ship the bug back.
+    ('unknown-knob-value-means-OFF', 'q',
+     "    _gate_all = not _gsel or 'all' in _gsel or not (_gsel & {'via', 'seg', 'pad'})",
+     "    _gate_all = 'all' in _gsel",
+     (T_619,), 'KILLED'),
+
+    # ---- the pad half's exclusions ---------------------------------------
+    ('pad-half-ignores-local-clearance', 'q',
+     "                                 margin=max(_stub_clr,\n"
+     "                                            getattr(p, 'local_clearance', 0.0)\n"
+     "                                            or 0.0) + track_width / 2 - 1e-6):",
+     "                                 margin=_stub_clr + track_width / 2 - 1e-6):",
+     (T_619,), 'KILLED'),
+    # NPTH and the wildcard are asserted against check_drc's own helpers rather
+    # than through emitted geometry, because no tracked board places a netted
+    # NPTH or an F&B.Cu pad where a stub can reach it. Removing the filter
+    # therefore changes no output on this corpus -- a REAL test hole, named
+    # rather than hidden, and the reason those two checks call the helpers
+    # directly instead of pretending a board covers them.
+    ('pad-half-includes-NPTH', 'q',
+     "                    and not _pad_has_no_copper(p)",
+     "                    and True",
+     (T_619,), 'SURVIVED  (no tracked board has a netted NPTH within stub '
+               'reach; check 8 asserts the helper, not emitted geometry)'),
+
+    # ---- the dru clearance ----------------------------------------------
+    # #770: the .kicad_dru layer-rule subset #498 models does not intersect any
+    # board this repo ingests, so _stub_clr == clearance on every fixture. The
+    # distinction is real (the stub lands on footprint.layer while the caller
+    # resolved the rule for the escape layer) but unfalsifiable here.
+    ('stub-clearance-ignores-the-dru-layer-map', 'q',
+     "    _stub_clr = cfg.layer_clearance(footprint.layer, clearance)",
+     "    _stub_clr = clearance",
+     (T_619, T_UP), 'SURVIVED  (#770: no tracked board carries a .kicad_dru '
+                    'layer rule, so the two values are equal on every fixture)'),
+]
+
+
+def run(tests):
+    env = dict(os.environ, PYTHONDONTWRITEBYTECODE='1')
+    for t in tests:
+        r = subprocess.run([sys.executable, '-X', 'utf8', t],
+                           cwd=ROOT, capture_output=True, text=True, env=env)
+        if r.returncode != 0:
+            return True, os.path.basename(t)
+    return False, ''
+
+
+def _drop_pycache(path):
+    d = os.path.join(os.path.dirname(path), '__pycache__')
+    shutil.rmtree(d, ignore_errors=True)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument('--row')
+    ap.add_argument('--list', action='store_true')
+    a = ap.parse_args()
+    if a.list:
+        for n, t, _o, _w, tests, exp in ROWS:
+            print(f'  {n:44s} {os.path.basename(TARGETS[t]):14s} {exp}')
+        return 0
+
+    dirty = subprocess.run(['git', 'diff', '--quiet', '--'] + list(TARGETS.values()),
+                           cwd=ROOT).returncode
+    if dirty:
+        print('REFUSED: the files this battery rewrites have uncommitted '
+              'changes.\nRestoring them would write the COMMITTED text back '
+              'over your work. Commit first.')
+        return 2
+
+    rows = [r for r in ROWS if not a.row or r[0] == a.row]
+    if not rows:
+        print(f'no row named {a.row!r}')
+        return 2
+    originals = {k: open(v, encoding='utf-8').read() for k, v in TARGETS.items()}
+    killed = survived = broken = disagree = 0
+    try:
+        for name, tgt, old, new, tests, exp in rows:
+            src = originals[tgt]
+            if src.count(old) != 1:
+                print(f'  {name:44s} BROKEN (anchor matched {src.count(old)}x)')
+                broken += 1
+                continue
+            with open(TARGETS[tgt], 'w', encoding='utf-8', newline='') as fh:
+                fh.write(src.replace(old, new))
+            _drop_pycache(TARGETS[tgt])
+            try:
+                died, by = run(tests)
+            finally:
+                with open(TARGETS[tgt], 'w', encoding='utf-8', newline='') as fh:
+                    fh.write(src)
+                _drop_pycache(TARGETS[tgt])
+            got = 'KILLED' if died else 'SURVIVED'
+            want = exp.split()[0]
+            mark = '' if got == want else '   *** DISAGREES with ' + exp
+            if got != want:
+                disagree += 1
+            killed += died
+            survived += not died
+            print(f'  {name:44s} {got:9s} {by}{mark}')
+    finally:
+        for k, v in TARGETS.items():
+            with open(v, 'w', encoding='utf-8', newline='') as fh:
+                fh.write(originals[k])
+            _drop_pycache(v)
+    print(f'\n{len(rows)} row(s): {killed} killed, {survived} survived, '
+          f'{broken} broken, {disagree} disagreeing with expectation')
+    return 1 if (broken or disagree) else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/mutate_619.py
+++ b/tests/mutate_619.py
@@ -80,6 +80,14 @@ ROWS = [
      (T_619,), 'KILLED'),
 
     # ---- the layer decision ---------------------------------------------
+    # #845: the PRIMARY clearance test's plane. Reverting it to the escape
+    # layer is the exact defect that shipped, and it is invisible on a
+    # same-layer call -- which is every board in the corpus sweep. Only the
+    # cross-layer pins can catch it.
+    ('primary-clearance-test-reads-the-ESCAPE-layer', 'q',
+     "    stub_layer_idx = layer_map.get(footprint.layer)",
+     "    stub_layer_idx = layer_map.get(layer)",
+     (T_619, T_UP), 'KILLED'),
     # The surface fan's spelling, which is correct THERE and wrong here: the
     # under-pad stub is emitted on footprint.layer (#195), not on `layer`.
     ('seg-half-filters-the-ESCAPE-layer', 'q',

--- a/tests/sweep_619_erased_copper.py
+++ b/tests/sweep_619_erased_copper.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""#619 corpus sweep: what the under-pad escape emits into copper the obstacle
+map erased, and what closing that costs.
+
+    python3 tests/sweep_619_erased_copper.py off > off.txt
+    python3 tests/sweep_619_erased_copper.py all > all.txt
+    python3 tests/sweep_619_erased_copper.py --diff off.txt all.txt
+
+NOT named `test_*`, so `run_all.py` never collects it: it drives the whole
+tracked board corpus through the fanout engine and takes minutes, not seconds.
+It exists in the repo rather than in a scratch directory so the table in the PR
+is re-runnable from a clean clone -- the sibling failing of PR #645, whose own
+"what I could not verify" section says its 408-footprint table was not.
+
+ONE ARM PER PROCESS, deliberately. `env_knobs` reads the environment once at
+import; an in-process arm switch would depend on `refresh()` having reached
+every consumer, and a stale read would silently grade one arm as the other.
+
+SELECTION IS BY PAD COUNT, NOT BY PACKAGE NAME. `qfn_fanout.py -c` accepts any
+reference and the GUI dropdown lists every footprint with enough pads, so a
+QFN/QFP name filter measures a different population than the tool serves --
+that is how PR #645's first revision reported 2 changed footprints where the
+truth was 7. Under-pad via-drop is the fine-pitch/CSP escape method; a WLCSP-20
+is its core case, not an out-of-scope one.
+
+The three residual counters are the point. Each counts EMITTED stubs that sit
+inside the clearance floor of PRE-EXISTING copper on a DIFFERENT fanned net --
+i.e. copper `nets_to_route` erased from the obstacle map. They are computed
+from the engine's returned geometry, graded with `check_drc`'s own predicates
+where one exists, so the sweep and the shipped grader cannot drift apart.
+"""
+import argparse
+import contextlib
+import io
+import json
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # #522
+sys.path.insert(0, os.path.join(ROOT, 'py_tools'))  # #522
+
+TRACK_W, CLEARANCE, VIA_SIZE, VIA_DRILL, GRID = 0.1, 0.1, 0.45, 0.25, 0.05
+MIN_PADS = 4
+
+
+def _counters(footprint, pcb, tracks):
+    """(via, seg, pad) emitted-stub contacts with erased copper.
+
+    `fanned_nets` is rebuilt the way the ENGINE builds it -- from the pads it
+    actually escapes -- rather than from `footprint.pads`. The two differ
+    (pad_infos drops net 0, `unconnected-*`, net-filter misses and `center`
+    pads), and the engine's set is the one handed to `nets_to_route`, so it is
+    the one that defines what got erased.
+    """
+    from check_drc import check_via_segment_overlap, check_pad_segment_overlap
+    from geometry_utils import segment_to_segment_distance
+    from kicad_parser import Segment
+    import qfn_fanout
+
+    # The set the ENGINE erased, published by the run that just happened --
+    # never re-derived from footprint.pads (see LAST_ERASED_SETS' comment).
+    fanned = qfn_fanout.LAST_ERASED_SETS.get('nets') or set()
+    ev = [v for v in pcb.vias if v.net_id in fanned]
+    es = [s for s in pcb.segments if s.net_id in fanned]
+    ep = [p for plist in pcb.pads_by_net.values() for p in plist
+          if p.net_id in fanned]
+    layers = list(pcb.board_info.copper_layers or [])
+
+    n_via = n_seg = n_pad = 0
+    for t in tracks:
+        seg = Segment(start_x=t['start'][0], start_y=t['start'][1],
+                      end_x=t['end'][0], end_y=t['end'][1],
+                      width=t['width'], layer=t['layer'], net_id=t['net_id'])
+        for v in ev:
+            if v.net_id == t['net_id']:
+                continue
+            if check_via_segment_overlap(v, seg, CLEARANCE)[0]:
+                n_via += 1
+        for s in es:
+            if s.net_id == t['net_id'] or s.layer != t['layer']:
+                continue
+            if segment_to_segment_distance(
+                    seg.start_x, seg.start_y, seg.end_x, seg.end_y,
+                    s.start_x, s.start_y, s.end_x, s.end_y) \
+                    < s.width / 2 + seg.width / 2 + CLEARANCE - 1e-6:
+                n_seg += 1
+        for p in ep:
+            if p.net_id == t['net_id']:
+                continue
+            if check_pad_segment_overlap(p, seg, CLEARANCE, layers)[0]:
+                n_pad += 1
+    return n_via, n_seg, n_pad, len(ev), len(es), len(ep)
+
+
+def sweep(arm, allow_vip=False, boards=None):
+    from run_utils import corpus_boards
+    from kicad_parser import parse_kicad_pcb
+    from qfn_fanout import generate_qfn_fanout
+
+    rows = []
+    paths = boards or corpus_boards()
+    if not paths:
+        print("SKIP: git could not list the tracked board corpus")
+        return None
+    for bp in paths:
+        name = os.path.splitext(os.path.basename(bp))[0]
+        try:
+            pcb = parse_kicad_pcb(os.path.join(ROOT, bp))
+        except Exception as e:                       # a board we cannot parse
+            print(f"  !! {name}: parse failed ({type(e).__name__})")
+            continue
+        for ref, fp in sorted(pcb.footprints.items()):
+            if len(fp.pads) < MIN_PADS:
+                continue
+            try:
+                buf = io.StringIO()
+                with contextlib.redirect_stdout(buf):
+                    tracks, vias, dropped = generate_qfn_fanout(
+                        fp, pcb, layer=fp.layer, track_width=TRACK_W,
+                        clearance=CLEARANCE, grid_step=GRID,
+                        escape_method="underpad", via_size=VIA_SIZE,
+                        via_drill=VIA_DRILL, allow_via_in_pad=allow_vip)
+            except Exception as e:
+                print(f"  !! {name} {ref}: {type(e).__name__}: {e}")
+                continue
+            nv, ns, npd, ev, es, ep = _counters(fp, pcb, tracks)
+            rows.append({
+                'board': name, 'ref': ref, 'pads': len(fp.pads),
+                'tracks': len(tracks), 'vias': len(vias),
+                'dropped': sorted(dropped),
+                'erased': [ev, es, ep], 'pairs': [nv, ns, npd],
+                # exact emitted geometry, so two arms can be compared for
+                # byte-identity rather than merely for equal counts
+                'geom': [[list(t['start']), list(t['end']), t['layer'],
+                          t['net_id']] for t in tracks]
+                        + [[v['x'], v['y'], v['net_id']] for v in vias],
+            })
+    return rows
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('arm', nargs='?', default='all',
+                    help="KICAD_QFN_UNDERPAD_ERASED_GATE value for this run")
+    ap.add_argument('--allow-via-in-pad', action='store_true')
+    ap.add_argument('--board', action='append',
+                    help="limit to these board paths (repeatable)")
+    ap.add_argument('--diff', nargs=2, metavar=('A.json', 'B.json'))
+    a = ap.parse_args()
+
+    if a.diff:
+        A = {(r['board'], r['ref']): r for r in json.load(open(a.diff[0]))}
+        B = {(r['board'], r['ref']): r for r in json.load(open(a.diff[1]))}
+        same = [k for k in A if k in B and A[k]['geom'] == B[k]['geom']]
+        chg = sorted(k for k in A if k in B and A[k]['geom'] != B[k]['geom'])
+        live = [k for k in A if any(A[k]['erased'])]
+        print(f"footprints compared          : {len(set(A) & set(B))}")
+        print(f"gate-live (erased set non-0) : {len(live)}")
+        print(f"byte-identical emitted geom  : {len(same)}")
+        print(f"CHANGED                      : {len(chg)}")
+        tot = [0, 0, 0, 0, 0, 0]
+        print(f"\n{'board / part':42} {'erased v/s/p':>16} "
+              f"{'A t/v/d':>12} {'B t/v/d':>12} {'A pairs':>10} {'B pairs':>10}")
+        for k in chg:
+            x, y = A[k], B[k]
+            xa = f"{x['tracks']}/{x['vias']}/{len(x['dropped'])}"
+            ya = f"{y['tracks']}/{y['vias']}/{len(y['dropped'])}"
+            print(f"{k[0] + ' ' + k[1]:42} "
+                  f"{'/'.join(map(str, x['erased'])):>16} "
+                  f"{xa:>12} {ya:>12} "
+                  f"{'/'.join(map(str, x['pairs'])):>10} "
+                  f"{'/'.join(map(str, y['pairs'])):>10}")
+        for k in set(A) & set(B):
+            for i in range(3):
+                tot[i] += A[k]['pairs'][i]
+                tot[3 + i] += B[k]['pairs'][i]
+        print(f"\nresidual pairs via/seg/pad   A: {tot[0]}/{tot[1]}/{tot[2]}"
+              f"   B: {tot[3]}/{tot[4]}/{tot[5]}")
+        wa = sum(len(A[k]['dropped']) for k in set(A) & set(B))
+        wb = sum(len(B[k]['dropped']) for k in set(A) & set(B))
+        print(f"escapes dropped              A: {wa}   B: {wb}"
+              f"   (withdrawn by B: {wb - wa})")
+        return 0
+
+    os.environ['KICAD_QFN_UNDERPAD_ERASED_GATE'] = a.arm
+    import env_knobs
+    env_knobs.refresh()
+    rows = sweep(a.arm, a.allow_via_in_pad, a.board)
+    if rows is None:
+        return 77
+    out = f"sweep619_{a.arm}{'_vip' if a.allow_via_in_pad else ''}.json"
+    with open(out, 'w') as f:
+        json.dump(rows, f)
+    tv = sum(r['pairs'][0] for r in rows)
+    ts = sum(r['pairs'][1] for r in rows)
+    tp = sum(r['pairs'][2] for r in rows)
+    live = sum(1 for r in rows if any(r['erased']))
+    print(f"\narm={a.arm} vip={a.allow_via_in_pad}: {len(rows)} footprints, "
+          f"{live} gate-live")
+    print(f"residual stub-vs-erased pairs  via={tv}  seg={ts}  pad={tp}")
+    print(f"escapes dropped: {sum(len(r['dropped']) for r in rows)}")
+    print(f"wrote {out}")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_619_underpad_stub_vs_erased_copper.py
+++ b/tests/test_619_underpad_stub_vs_erased_copper.py
@@ -1,0 +1,495 @@
+#!/usr/bin/env python3
+"""Issue #619 -- the QFN under-pad (via-drop) escape emitted its pad->via
+bridging stub without ever testing it against PRE-EXISTING copper belonging to
+another net in the SAME fanout call.
+
+MECHANISM. `_underpad_via_escape` builds its obstacle map with
+`build_base_obstacle_map(..., nets_to_route=list(fanned_nets))`, and
+`nets_to_route` ERASES every piece of copper on those nets -- segments
+(`obstacle_map.py:216`), vias (`:299`) and pads (`:312`). Right for a net's OWN
+copper; wrong for every OTHER net being escaped beside it. The candidate VIA
+still meets that copper, because `via_clears` scans `pcb_data` directly -- but
+it tests only the via CENTRE. The STUB's one channel to the input board is
+`check_line_clearance` on the holed map, so stubs shipped straight through the
+CENTRES of foreign vias. The SURFACE fan has a geometric backstop for exactly
+this (`_fanned_existing_segs` / `_fanned_existing_vias`, issue #257); the
+under-pad path returns ~200 lines earlier and shares none of it.
+
+THE ISSUE UNDERCOUNTS ITSELF. It names the via half only. Measured over every
+footprint with >=4 pads on all 22 tracked boards (408 of them, no package-name
+filter -- `tests/sweep_619_erased_copper.py`), the emitted-stub contacts with
+erased copper are via=20, seg=75, pad=49. The segment half is the largest.
+
+WHAT IS PINNED HERE, and what each check is FOR:
+
+1. THE ERASURE ITSELF, asserted directly rather than through an outcome. The
+   same obstacle map built with `nets_to_route=[A, B]` reports the stub line
+   CLEAR while `nets_to_route=[A]` reports the same line BLOCKED. If that ever
+   stops being true the bug is gone for a reason this file does not model, and
+   every other check here is testing nothing.
+
+2. INJECTION + COUNTER-GUARD. `kicad_files/tigard.kicad_pcb` is the only
+   fixture with ZERO board vias AND ZERO board segments, so an injected
+   obstacle is the only one and the baseline cannot be contaminated. Inject a
+   via on net B onto net A's stub, re-run with BOTH nets in the filter (both
+   must be fanned or the map would not erase it), and assert the exact emitted
+   tuple -- not merely "no stub inside the floor", which any change that
+   dropped every pad would satisfy vacuously.
+
+3. NEGATIVE CONTROL. The same via injected OFF the escape ray, just outside the
+   floor, must NOT block anything. This is the only check with teeth against an
+   over-strict gate: multiply the floor by 5 and every other check in this file
+   still passes.
+
+4. THE GATE IS LIVE WHERE IT CLAIMS TO BE. A no-op guard on a footprint whose
+   erased set is EMPTY proves nothing -- the predicate is a constant True
+   there. Liveness is read from `qfn_fanout.LAST_ERASED_SETS`, published by the
+   engine, NEVER re-derived: `fanned_nets` comes from `pad_infos`, which drops
+   net 0, `unconnected-*`, net-filter misses and `center` pads, so the obvious
+   proxy `{p.net_id for p in footprint.pads}` disagrees with it and can report
+   a dead loop as live.
+
+5. THE THREE HALVES ARE INDEPENDENT AND NOT ADDITIVE. Each is pinned alone via
+   KICAD_QFN_UNDERPAD_ERASED_GATE. Neither the via half nor the segment half
+   alone reaches zero on U2, and each moves the OTHER category without testing
+   it -- withdrawing an escape changes which offsets the remaining pads take.
+   A single tally per half would credit the wrong mechanism.
+
+6. THE MEASURED BOARDS, with the cost pinned as well as the fix. The tallies
+   are deliberately brittle change-detectors, in this repo's house style (see
+   `test_qfn_underpad.py`'s own 18/22/20 pin): any future change to the escape
+   ladder fails them and forces a re-measurement rather than silent drift.
+
+7. LAYER SCOPE, as a decision pin. The via half is layer-BLIND because
+   `check_drc.check_via_segment_overlap` grades a via against segments on every
+   copper layer regardless of `via.layers`; the segment half is layer-FILTERED
+   because segments really are single-layer. It filters on `footprint.layer`
+   (where the stub lands, #195) and NOT on `layer`, and the two are not
+   interchangeable: on U2 they find 25 and 17 pairs and the sets are disjoint.
+
+8. THE PAD HALF'S FOUR EXCLUSIONS. NPTH (no copper), the `*.Cu` / `F&B.Cu`
+   wildcards, per-pad `local_clearance`, and net ties. Each is check_drc's own
+   rule or KiCad's; without them the pad half phantom-rejects. The surface
+   fan's pad loop makes none of them, so these are not inherited -- they are
+   the reason this half is safe to ship.
+
+    python3 tests/test_619_underpad_stub_vs_erased_copper.py
+"""
+import contextlib
+import io
+import math
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))  # #522
+sys.path.insert(0, os.path.join(ROOT, 'py_tools'))  # #522
+
+from kicad_parser import parse_kicad_pcb, Via, Segment
+import qfn_fanout
+from qfn_fanout import generate_qfn_fanout
+import env_knobs
+
+TIGARD = os.path.join(ROOT, "kicad_files", "tigard.kicad_pcb")
+U2BOARD = os.path.join(ROOT, "kicad_files", "routed_output.kicad_pcb")
+ORANGE = os.path.join(ROOT, "kicad_files", "orangecrab_ext_pll.kicad_pcb")
+RP2350 = os.path.join(ROOT, "kicad_files", "rp2350_fpga_eensy_prePlane.kicad_pcb")
+WATCHY = os.path.join(ROOT, "kicad_files", "watchy.kicad_pcb")
+LVDS = os.path.join(ROOT, "kicad_files", "lvds_converter_dualclk_gnd.kicad_pcb")
+
+TW, CL, VS, VD, GRID = 0.1, 0.1, 0.45, 0.25, 0.05
+FLOOR = VS / 2 + TW / 2 + CL           # 0.3750 mm, the injected via's floor
+
+CHECKS = []
+
+
+def check(name, ok, detail=""):
+    CHECKS.append((name, bool(ok)))
+    print(("  ok   " if ok else "  FAIL ") + name + (f"  [{detail}]" if detail else ""))
+
+
+def _gate(value):
+    """Run the next fanout with only these halves of the gate live."""
+    os.environ['KICAD_QFN_UNDERPAD_ERASED_GATE'] = value
+    env_knobs.refresh()
+
+
+def _fanout(pcb, ref, net_filter=None, layer=None, vip=False):
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        return generate_qfn_fanout(
+            pcb.footprints[ref], pcb, net_filter=net_filter,
+            layer=layer or pcb.footprints[ref].layer,
+            track_width=TW, clearance=CL, grid_step=GRID,
+            escape_method="underpad", via_size=VS, via_drill=VD,
+            allow_via_in_pad=vip)
+
+
+def _erased(pcb, ref):
+    """The sets the ENGINE erased on the run that just happened."""
+    return qfn_fanout.LAST_ERASED_SETS
+
+
+def _pairs(pcb, tracks):
+    """Emitted stubs inside the floor of erased copper on a DIFFERENT net.
+
+    Graded with check_drc's own predicates, so this cannot drift away from what
+    the shipped grader flags.
+    """
+    from check_drc import check_via_segment_overlap, check_pad_segment_overlap
+    from geometry_utils import segment_to_segment_distance
+    fanned = qfn_fanout.LAST_ERASED_SETS.get('nets') or set()
+    cu = list(pcb.board_info.copper_layers or [])
+    nv = ns = npd = 0
+    for t in tracks:
+        seg = Segment(start_x=t['start'][0], start_y=t['start'][1],
+                      end_x=t['end'][0], end_y=t['end'][1],
+                      width=t['width'], layer=t['layer'], net_id=t['net_id'])
+        for v in pcb.vias:
+            if v.net_id in fanned and v.net_id != t['net_id'] \
+                    and check_via_segment_overlap(v, seg, CL)[0]:
+                nv += 1
+        for s in pcb.segments:
+            if s.net_id in fanned and s.net_id != t['net_id'] \
+                    and s.layer == t['layer'] \
+                    and segment_to_segment_distance(
+                        seg.start_x, seg.start_y, seg.end_x, seg.end_y,
+                        s.start_x, s.start_y, s.end_x, s.end_y) \
+                    < s.width / 2 + seg.width / 2 + CL - 1e-6:
+                ns += 1
+        for plist in pcb.pads_by_net.values():
+            for p in plist:
+                if p.net_id in fanned and p.net_id != t['net_id'] \
+                        and check_pad_segment_overlap(p, seg, CL, cu)[0]:
+                    npd += 1
+    return nv, ns, npd
+
+
+# ---------------------------------------------------------------- 1, 2, 3 ---
+def test_erasure_injection_and_control():
+    print("\n1-3. the erasure itself, an injected blocker, and the control "
+          "(tigard U3, QFN-64)")
+    _gate('all')
+    pcb = parse_kicad_pcb(TIGARD)
+    check("tigard carries ZERO vias and ZERO segments -- an injected obstacle "
+          "is the only one, so the baseline cannot be contaminated",
+          len(pcb.vias) == 0 and len(pcb.segments) == 0,
+          f"{len(pcb.vias)} vias, {len(pcb.segments)} segments")
+
+    a, b = "/BD0", "/BD1"
+    nid_a = next(n for n, net in pcb.nets.items() if net.name == a)
+    nid_b = next(n for n, net in pcb.nets.items() if net.name == b)
+
+    tracks, vias, dropped = _fanout(pcb, "U3", [a, b])
+    check("baseline: both nets escape, nothing dropped",
+          (len(tracks), len(vias), sorted(dropped)) == (2, 2, []),
+          f"{len(tracks)}/{len(vias)}/{sorted(dropped)}")
+    a_stub = [t for t in tracks if t['net_id'] == nid_a]
+    if not a_stub:
+        check("net A emitted a stub to inject onto", False)
+        return
+    (ax0, ay0), (ax1, ay1) = a_stub[0]['start'], a_stub[0]['end']
+    ix, iy = (ax0 + ax1) / 2.0, (ay0 + ay1) / 2.0
+
+    # -- 1. THE MECHANISM. Same map, same line, opposite answers.
+    from obstacle_map import (build_base_obstacle_map, build_layer_map,
+                              check_line_clearance)
+    from routing_config import GridRouteConfig
+    p2 = parse_kicad_pcb(TIGARD)
+    p2.vias.append(Via(x=ix, y=iy, size=VS, drill=0.2,
+                       layers=["F.Cu", "B.Cu"], net_id=nid_b))
+    cfg = GridRouteConfig(layers=list(p2.board_info.copper_layers),
+                          track_width=TW, clearance=CL)
+    li = build_layer_map(cfg.layers)["F.Cu"]
+    m_ab = build_base_obstacle_map(p2, cfg, nets_to_route=[nid_a, nid_b],
+                                   extra_clearance=TW / 2)
+    m_a = build_base_obstacle_map(p2, cfg, nets_to_route=[nid_a],
+                                  extra_clearance=TW / 2)
+    check("MECHANISM: the map the escape builds (nets_to_route=[A,B]) reports "
+          "net A's stub line CLEAR -- the injected via was erased from it",
+          check_line_clearance(m_ab, ax0, ay0, ax1, ay1, li, cfg) is True)
+    check("MECHANISM: the SAME line on a map that keeps net B "
+          "(nets_to_route=[A]) is BLOCKED -- so the erasure, not the geometry, "
+          "is what hid it",
+          check_line_clearance(m_a, ax0, ay0, ax1, ay1, li, cfg) is False)
+
+    # -- 2. OUTCOME + counter-guard.
+    t2, v2, d2 = _fanout(p2, "U3", [a, b])
+    nv, ns, npd = _pairs(p2, t2)
+    check("no emitted stub is inside the injected via's clearance floor",
+          (nv, ns, npd) == (0, 0, 0), f"via/seg/pad = {nv}/{ns}/{npd}")
+    check(f"counter-guard: net A ({a}) is DROPPED, not silently re-routed -- "
+          f"the offset ladder only walks FURTHER OUT along the same escape "
+          f"ray, so a blocker on that ray blocks every remaining candidate",
+          a in d2, f"dropped={sorted(d2)}")
+    check("counter-guard: exact tuple (1 track, 1 via, dropped=['/BD0']) -- a "
+          "change that dropped EVERY pad would pass the violation check above",
+          (len(t2), len(v2), sorted(d2)) == (1, 1, [a]),
+          f"{len(t2)}/{len(v2)}/{sorted(d2)}")
+    check("counter-guard: the surviving track belongs to net B",
+          len(t2) == 1 and t2[0]['net_id'] == nid_b)
+
+    # -- 3. NEGATIVE CONTROL: outside the floor must not block.
+    dx, dy = ax1 - ax0, ay1 - ay0
+    L = math.hypot(dx, dy)
+    nx, ny = ix + (-dy / L) * 0.40, iy + (dx / L) * 0.40
+    p3 = parse_kicad_pcb(TIGARD)
+    p3.vias.append(Via(x=nx, y=ny, size=VS, drill=0.2,
+                       layers=["F.Cu", "B.Cu"], net_id=nid_b))
+    from geometry_utils import point_to_segment_distance as _p2s
+    d_ctrl = _p2s(nx, ny, ax0, ay0, ax1, ay1)
+    check(f"negative control sits in the band an over-strict floor would catch "
+          f"({FLOOR:.4f} <= d < {5 * FLOOR:.4f})",
+          FLOOR <= d_ctrl < 5 * FLOOR, f"d={d_ctrl:.4f}")
+    t3, v3, d3 = _fanout(p3, "U3", [a, b])
+    check("NEGATIVE CONTROL: a via OUTSIDE the floor blocks nothing -- the "
+          "(2, 2, []) baseline survives. Multiplying the floor by 5 fails "
+          "HERE and nowhere else in this file",
+          (len(t3), len(v3), sorted(d3)) == (2, 2, []),
+          f"{len(t3)}/{len(v3)}/{sorted(d3)}")
+
+
+# -------------------------------------------------------------------- 4 -----
+def test_gate_live_but_rejects_nothing():
+    print("\n4. the gate is LIVE and still rejects nothing (byte-identical)")
+    _gate('all')
+    for board, ref, expect in NOOP_ROWS:
+        pcb = parse_kicad_pcb(board)
+        tracks, vias, dropped = _fanout(pcb, ref)
+        e = _erased(pcb, ref)
+        live = (e.get('vias', 0), e.get('segs', 0), e.get('pads', 0))
+        name = os.path.basename(board).replace('.kicad_pcb', '')
+        check(f"{name} {ref}: the erased set is NON-EMPTY, so the predicate "
+              f"really runs here (a board with none makes it a constant True "
+              f"and guards nothing)",
+              any(live), f"erased v/s/p = {live[0]}/{live[1]}/{live[2]}")
+        got = (len(tracks), len(vias), len(dropped))
+        check(f"{name} {ref}: escape tally unchanged at {expect} -- the gate "
+              f"does not over-reject",
+              got == expect, f"got {got}")
+
+
+# -------------------------------------------------------------------- 5 -----
+def test_halves_are_independent_and_not_additive():
+    print("\n5. each half alone, on routed_output U2 -- NOT additive")
+    for arm, expect, pairs in ARM_ROWS:
+        _gate(arm)
+        pcb = parse_kicad_pcb(U2BOARD)
+        tracks, vias, dropped = _fanout(pcb, "U2")
+        got = (len(tracks), len(vias), len(dropped))
+        gp = _pairs(pcb, tracks)
+        check(f"arm={arm:8}: tally {expect}", got == expect, f"got {got}")
+        check(f"arm={arm:8}: residual via/seg/pad = "
+              f"{pairs[0]}/{pairs[1]}/{pairs[2]}",
+              gp == pairs, f"got {gp[0]}/{gp[1]}/{gp[2]}")
+    check("NOT ADDITIVE: the via half alone leaves segment contacts and the "
+          "segment half alone leaves via contacts -- neither is the whole fix, "
+          "and each moves the other's count without testing it",
+          ARM_ROWS[1][2][1] > 0 and ARM_ROWS[2][2][0] > 0,
+          f"via-arm seg={ARM_ROWS[1][2][1]}, seg-arm via={ARM_ROWS[2][2][0]}")
+
+
+# -------------------------------------------------------------------- 6 -----
+def test_measured_boards():
+    print("\n6. the measured boards: the fix AND its cost")
+    _gate('all')
+    for board, ref, expect, pre in BOARD_ROWS:
+        pcb = parse_kicad_pcb(board)
+        tracks, vias, dropped = _fanout(pcb, ref)
+        got = (len(tracks), len(vias), len(dropped))
+        gp = _pairs(pcb, tracks)
+        name = os.path.basename(board).replace('.kicad_pcb', '')
+        check(f"{name} {ref}: no emitted stub sits inside erased copper's "
+              f"floor (was via/seg/pad {pre[0]}/{pre[1]}/{pre[2]} pre-fix)",
+              gp == (0, 0, 0), f"got {gp[0]}/{gp[1]}/{gp[2]}")
+        check(f"{name} {ref}: escape tally pinned at {expect} -- this is the "
+              f"COST, pinned so it cannot drift silently",
+              got == expect, f"got {got}")
+
+
+# -------------------------------------------------------------------- 7 -----
+def test_layer_scope_decision():
+    print("\n7. layer scope: blind for vias, filtered for segments")
+    from check_drc import check_via_segment_overlap
+    buried = Via(x=10.0, y=10.0, size=VS, drill=VD,
+                 layers=["In1.Cu", "In2.Cu"], net_id=1)
+    seg = Segment(start_x=9.0, start_y=10.0, end_x=11.0, end_y=10.0,
+                  width=TW, layer="F.Cu", net_id=2)
+    hit, _ = check_via_segment_overlap(buried, seg, CL)
+    check("check_drc grades a via against segments on EVERY copper layer "
+          "regardless of via.layers, so a layer-FILTERED via backstop would "
+          "ship copper this repo's own grader flags -- the via half is "
+          "deliberately layer-blind, and this fails the day that changes",
+          hit is True)
+    # And the segment half's filter is on the STUB's layer, not the escape
+    # layer. On U2 the two spellings disagree completely.
+    _gate('all')
+    pcb = parse_kicad_pcb(U2BOARD)
+    fp = pcb.footprints["U2"]
+    check("the fixture actually exercises the distinction: the escape layer "
+          "argument and footprint.layer are different layers here",
+          fp.layer == "F.Cu")
+
+
+# -------------------------------------------------------------------- 8 -----
+def test_pad_half_exclusions():
+    print("\n8. the pad half's four exclusions")
+    from check_drc import _pad_has_no_copper, pad_copper_layers
+    from kicad_parser import Pad
+
+    def _pad(num, layers, drill, ptype, size=1.0):
+        return Pad(component_ref="X1", pad_number=num,
+                   global_x=0.0, global_y=0.0, local_x=0.0, local_y=0.0,
+                   size_x=size, size_y=size, shape="circle", layers=layers,
+                   net_id=7, net_name="GND", drill=drill, pad_type=ptype)
+
+    npth = _pad("H1", ["*.Cu"], 2.0, "np_thru_hole", size=2.0)
+    check("NPTH is excluded: KiCad lists *.Cu on it for hole keep-out but an "
+          "np_thru_hole pad carries no ring, and check_drc skips it for "
+          "PAD-SEGMENT (#260) -- including it would phantom-reject",
+          _pad_has_no_copper(npth) is True)
+
+    th = _pad("1", ["*.Cu"], 0.6, "thru_hole")
+    cu = ["F.Cu", "In1.Cu", "In2.Cu", "B.Cu"]
+    check("the *.Cu wildcard expands: a bare `layer in pad.layers` would miss "
+          "a through-hole barrel entirely, and the pcbnew parse path emits "
+          "that spelling even where the text parser does not (#722)",
+          "F.Cu" in pad_copper_layers(th, cu) and
+          "In1.Cu" in pad_copper_layers(th, cu),
+          str(sorted(pad_copper_layers(th, cu))))
+
+    fb = _pad("2", ["F&B.Cu"], 0.0, "smd")
+    got = pad_copper_layers(fb, cu)
+    check("...and so does F&B.Cu, to exactly front and back",
+          got == {"F.Cu", "B.Cu"}, str(sorted(got)))
+
+    # local_clearance, tested BEHAVIOURALLY and PAIRED. An arithmetic assertion
+    # that max(cl, lc) > cl would pass without the engine reading the field at
+    # all. Inject a pad on net B beside net A's stub, far enough out that the
+    # default floor does NOT reach it, and flip only `local_clearance`:
+    #   lc = 0.0  -> stub survives, baseline (2, 2, []) intact
+    #   lc = 0.5  -> stub withdrawn, net A dropped
+    # Distances are chosen so `via_clears`' own pad loop cannot be what moved:
+    # the pad sits at the stub's MIDPOINT, 0.673 mm from the via centre against
+    # that loop's 0.425 mm reach.
+    _gate('all')
+    a, b = "/BD0", "/BD1"
+    base = parse_kicad_pcb(TIGARD)
+    nid_a = next(n for n, net in base.nets.items() if net.name == a)
+    nid_b = next(n for n, net in base.nets.items() if net.name == b)
+    t0, _, _ = _fanout(base, "U3", [a, b])
+    astub = [t for t in t0 if t['net_id'] == nid_a][0]
+    mx = (astub['start'][0] + astub['end'][0]) / 2.0
+    my = (astub['start'][1] + astub['end'][1]) / 2.0
+
+    res = {}
+    for lc in (0.0, 0.5):
+        p = parse_kicad_pcb(TIGARD)
+        inj = _pad("LC", ["F.Cu"], 0.0, "smd", size=0.2)
+        inj.component_ref, inj.net_id, inj.net_name = "INJ", nid_b, b
+        inj.global_x, inj.global_y = mx, my + 0.45
+        inj.local_clearance = lc
+        p.pads_by_net.setdefault(nid_b, []).append(inj)
+        res[lc] = _fanout(p, "U3", [a, b])
+    t_lo, v_lo, d_lo = res[0.0]
+    t_hi, v_hi, d_hi = res[0.5]
+    check("local_clearance control: at lc=0.0 the injected pad is OUTSIDE the "
+          "floor and blocks nothing -- the (2, 2, []) baseline survives",
+          (len(t_lo), len(v_lo), sorted(d_lo)) == (2, 2, []),
+          f"{len(t_lo)}/{len(v_lo)}/{sorted(d_lo)}")
+    check("local_clearance is READ, per pad: the SAME pad at lc=0.5 raises the "
+          "floor past the stub and net A is dropped. The surface fan's hoisted "
+          "`margin` structurally cannot do this",
+          a in d_hi and (len(t_hi), len(v_hi)) != (2, 2),
+          f"{len(t_hi)}/{len(v_hi)}/{sorted(d_hi)}")
+
+    pcb = parse_kicad_pcb(TIGARD)
+    check("PCBData exposes the net-tie exemption the pad half honours "
+          "(_seg_hits_pad is net-blind, and obstacle_map's own tie lift only "
+          "fires when exactly ONE net is being routed, so the under-pad path "
+          "never receives it)",
+          callable(getattr(pcb, 'net_tie_exempt_pad_ids', None)))
+
+
+# --------------------------------------------------------------------------
+# Measured rows. Every number here was produced on this branch by
+# `tests/sweep_619_erased_copper.py` over all 408 footprints with >=4 pads on
+# the 22 tracked boards; none is carried over from PR #645, whose numbers were
+# taken on an engine `98bd0fae` has since rewritten in exactly these two gates.
+#
+# Corpus totals, gate off -> all three halves:
+#     residual stub-vs-erased pairs   via/seg/pad   20/75/49  ->  0/0/0
+#     byte-identical emitted geometry               391 of 408
+#     footprints changed                            17
+#     escapes withdrawn                             49  (973 -> 1022 dropped)
+# --------------------------------------------------------------------------
+
+# Gate LIVE (non-empty erased sets) and output byte-identical. These are the
+# guard with teeth: a footprint whose erased set is EMPTY runs a predicate that
+# is a constant True and proves nothing.
+NOOP_ROWS = [
+    (U2BOARD, "U3", (19, 19, 59)),      # erased 209 vias / 938 segs / 486 pads
+    (U2BOARD, "IC1", (33, 33, 24)),     # erased  72 / 382 / 329
+    (LVDS, "IC2", (12, 11, 0)),         # erased   9 /  97 /  47, nothing dropped
+]
+
+# Each half alone on routed_output U2, and the pairs it leaves behind.
+# (arm, tally t/v/d, residual pairs via/seg/pad)
+ARM_ROWS = [
+    ('off',     (27, 26, 15), (7, 32, 0)),
+    ('via',     (20, 19, 22), (0, 13, 0)),   # via contacts gone, 13 seg remain
+    ('seg',     (16, 15, 26), (2, 0, 0)),    # seg contacts gone,  2 via remain
+    ('all',     (14, 13, 28), (0, 0, 0)),
+]
+
+# (board, ref, post-fix tally t/v/d, pre-fix pairs via/seg/pad)
+# The last two changed ONLY because of the pad half -- their erased via and
+# segment sets are both empty, so they are the evidence that half earns its
+# place. It was pre-registered as a withdrawal candidate on a 5-board sample
+# that showed zero yield; the full 408-footprint sweep found 49 pairs on 9
+# footprints across 6 boards, so it ships.
+BOARD_ROWS = [
+    (U2BOARD, "U2", (14, 13, 28), (7, 32, 0)),
+    (ORANGE, "U7", (2, 0, 4), (3, 0, 4)),
+    (ORANGE, "U3", (33, 33, 62), (1, 14, 11)),
+    (RP2350, "U6", (6, 3, 41), (2, 11, 1)),
+    (TIGARD, "U3", (43, 43, 5), (0, 0, 4)),     # pad half only
+    (WATCHY, "J3", (12, 12, 7), (0, 0, 9)),     # pad half only
+]
+
+
+def run():
+    for b in (TIGARD, U2BOARD, ORANGE, RP2350, WATCHY, LVDS):
+        if not os.path.exists(b):
+            print(f"SKIP: missing fixture {b}")
+            return 77
+    prev = os.environ.get('KICAD_QFN_UNDERPAD_ERASED_GATE')
+    try:
+        test_erasure_injection_and_control()
+        if NOOP_ROWS:
+            test_gate_live_but_rejects_nothing()
+        if ARM_ROWS:
+            test_halves_are_independent_and_not_additive()
+        if BOARD_ROWS:
+            test_measured_boards()
+        test_layer_scope_decision()
+        test_pad_half_exclusions()
+    finally:
+        if prev is None:
+            os.environ.pop('KICAD_QFN_UNDERPAD_ERASED_GATE', None)
+        else:
+            os.environ['KICAD_QFN_UNDERPAD_ERASED_GATE'] = prev
+        env_knobs.refresh()
+    bad = [n for n, ok in CHECKS if not ok]
+    print("-" * 68)
+    print(f"{len(CHECKS) - len(bad)}/{len(CHECKS)} checks passed")
+    if bad:
+        print("FAILED: " + "; ".join(bad))
+        return 1
+    print("ALL PASS")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(run())

--- a/tests/test_619_underpad_stub_vs_erased_copper.py
+++ b/tests/test_619_underpad_stub_vs_erased_copper.py
@@ -128,10 +128,29 @@ def _fanout(pcb, ref, net_filter=None, layer=None, vip=False):
 
 def _erased(pcb, ref):
     """The sets the ENGINE erased on the run that just happened."""
-    return qfn_fanout.LAST_ERASED_SETS
+    return getattr(qfn_fanout, 'LAST_ERASED_SETS', {})
 
 
-def _pairs(pcb, tracks):
+def _fanned(pcb, ref):
+    """The net-id set `nets_to_route` erased, from the engine where it can be.
+
+    On a build that does NOT publish `LAST_ERASED_SETS` -- i.e. the RED arm,
+    with this fix reverted -- fall back to the footprint's own nets. That
+    fallback is a SUPERSET of `fanned_nets` (it keeps net 0, `unconnected-*`
+    and `center` pads that `pad_infos` drops), so it can only over-count. That
+    is the right direction for a RED arm, where the expectation is zero, and it
+    is never used on the GREEN arm. Without this the whole file dies on an
+    AttributeError, which reports a BROKEN TEST as though it were a satisfied
+    guard -- the exact failure mode CLAUDE.md's `run_utils.check` exists to
+    prevent.
+    """
+    got = getattr(qfn_fanout, 'LAST_ERASED_SETS', {}).get('nets')
+    if got is not None:
+        return got
+    return {p.net_id for p in pcb.footprints[ref].pads if p.net_id}
+
+
+def _pairs(pcb, tracks, ref=None):
     """Emitted stubs inside the floor of erased copper on a DIFFERENT net.
 
     Graded with check_drc's own predicates, so this cannot drift away from what
@@ -139,7 +158,8 @@ def _pairs(pcb, tracks):
     """
     from check_drc import check_via_segment_overlap, check_pad_segment_overlap
     from geometry_utils import segment_to_segment_distance
-    fanned = qfn_fanout.LAST_ERASED_SETS.get('nets') or set()
+    fanned = _fanned(pcb, ref) if ref else (
+        getattr(qfn_fanout, 'LAST_ERASED_SETS', {}).get('nets') or set())
     cu = list(pcb.board_info.copper_layers or [])
     nv = ns = npd = 0
     for t in tracks:
@@ -182,6 +202,12 @@ def test_erasure_injection_and_control():
     nid_b = next(n for n, net in pcb.nets.items() if net.name == b)
 
     tracks, vias, dropped = _fanout(pcb, "U3", [a, b])
+    check("the engine publishes LAST_ERASED_SETS, so every check below grades "
+          "against the set `nets_to_route` actually erased rather than a proxy "
+          "for it (absent = this file falls back to a superset and says so, "
+          "instead of dying on an AttributeError and reporting a broken test "
+          "as a satisfied guard)",
+          getattr(qfn_fanout, 'LAST_ERASED_SETS', {}).get('nets') is not None)
     check("baseline: both nets escape, nothing dropped",
           (len(tracks), len(vias), sorted(dropped)) == (2, 2, []),
           f"{len(tracks)}/{len(vias)}/{sorted(dropped)}")
@@ -216,7 +242,7 @@ def test_erasure_injection_and_control():
 
     # -- 2. OUTCOME + counter-guard.
     t2, v2, d2 = _fanout(p2, "U3", [a, b])
-    nv, ns, npd = _pairs(p2, t2)
+    nv, ns, npd = _pairs(p2, t2, "U3")
     check("no emitted stub is inside the injected via's clearance floor",
           (nv, ns, npd) == (0, 0, 0), f"via/seg/pad = {nv}/{ns}/{npd}")
     check(f"counter-guard: net A ({a}) is DROPPED, not silently re-routed -- "
@@ -278,7 +304,7 @@ def test_halves_are_independent_and_not_additive():
         pcb = parse_kicad_pcb(U2BOARD)
         tracks, vias, dropped = _fanout(pcb, "U2")
         got = (len(tracks), len(vias), len(dropped))
-        gp = _pairs(pcb, tracks)
+        gp = _pairs(pcb, tracks, "U2")
         check(f"arm={arm:8}: tally {expect}", got == expect, f"got {got}")
         check(f"arm={arm:8}: residual via/seg/pad = "
               f"{pairs[0]}/{pairs[1]}/{pairs[2]}",
@@ -298,7 +324,7 @@ def test_measured_boards():
         pcb = parse_kicad_pcb(board)
         tracks, vias, dropped = _fanout(pcb, ref)
         got = (len(tracks), len(vias), len(dropped))
-        gp = _pairs(pcb, tracks)
+        gp = _pairs(pcb, tracks, ref)
         name = os.path.basename(board).replace('.kicad_pcb', '')
         check(f"{name} {ref}: no emitted stub sits inside erased copper's "
               f"floor (was via/seg/pad {pre[0]}/{pre[1]}/{pre[2]} pre-fix)",

--- a/tests/test_619_underpad_stub_vs_erased_copper.py
+++ b/tests/test_619_underpad_stub_vs_erased_copper.py
@@ -74,7 +74,7 @@ WHAT IS PINNED HERE, and what each check is FOR:
    the reason this half is safe to ship.
 
 MUTATION EVIDENCE (`python3 tests/mutate_619.py`, from the run -- never edited
-to match a prediction). 14 rows, 12 KILLED, 2 SURVIVED, 0 broken:
+to match a prediction). 16 rows, 12 KILLED, 4 SURVIVED, 0 broken:
 
     over-strict-floor-x5                      KILLED    (the negative control)
     via-floor-uses-drill-not-size             KILLED
@@ -86,12 +86,14 @@ to match a prediction). 14 rows, 12 KILLED, 2 SURVIVED, 0 broken:
     via-half-disabled                         KILLED
     seg-half-disabled                         KILLED
     pad-half-disabled                         KILLED
-    unknown-knob-value-means-OFF              KILLED
+    unknown-knob-token-silently-drops-a-half  KILLED
     pad-half-ignores-local-clearance          KILLED
+    pad-half-waives-the-WHOLE-tie-partner     SURVIVED (declared)
+    erased-set-is-not-cleared-between-fps     SURVIVED (declared)
     pad-half-includes-NPTH                    SURVIVED (declared)
     stub-clearance-ignores-the-dru-layer-map  SURVIVED (declared)
 
-FOUR of those kills exist only because the battery found them SURVIVING first,
+FIVE of those kills exist only because the battery found them SURVIVING first,
 and every one was a check that read as though it covered the thing it named:
 
   * the zero-stub guard was argued for in a commit message and tested nowhere;
@@ -101,14 +103,23 @@ and every one was a check that read as though it covered the thing it named:
     swapping `footprint.layer` for `layer` changed nothing. It needed a
     CROSS-LAYER run (U2 mounted F.Cu, escaped to B.Cu) to become a check;
   * no pinned geometry sat between the drill-derived and copper-derived floors;
-  * the knob's fail-safe direction (an unknown value means ALL, never OFF) was
-    asserted only by reading the code.
+  * the knob's fail-safe direction was asserted only by reading the code; and
+  * once that WAS tested, the battery caught the test using a NON-discriminating
+    spelling. A wholly unrecognised value ('bogus') falls back to ALL through
+    two independent paths, so it cannot tell a hardened parser from a naive
+    one. The input that can is a TRANSPOSED token beside a valid one --
+    'sge,pad', which the naive set form reads as a deliberate pad-only arm
+    while silently dropping two halves.
 
-The two declared survivors are real test holes, named rather than hidden: no
-tracked board places a netted NPTH within stub reach, and #770 records that no
-board this repo ingests carries a `.kicad_dru` layer rule, so `_stub_clr` and
-`clearance` are equal on every fixture. Both are asserted against check_drc's
-helpers directly (check 8) instead of pretending a board covers them.
+The four declared survivors are real test holes, named rather than hidden:
+no tracked board declares `net_tie_pad_groups`, so the locality half of the
+net-tie waiver is unfalsifiable here; the stale-set defect is only visible
+ACROSS footprints, which the sweep exercises and this single-footprint file
+does not; no tracked board places a netted NPTH within stub reach; and #770
+records that no board this repo ingests carries a `.kicad_dru` layer rule, so
+`_stub_clr` and `clearance` are equal on every fixture. The first is the one
+that matters -- it could pass a real short -- and it is named here precisely
+because nothing in the repo can catch it.
 
     python3 tests/test_619_underpad_stub_vs_erased_copper.py
 """
@@ -334,12 +345,20 @@ def test_erasure_injection_and_control():
     # -- 3c. AN UNRECOGNISED KNOB VALUE MEANS ALL, NEVER OFF. A typo in a
     #    harness must not silently ship the bug back. Same injected board as
     #    check 2, so the expected outcome is exactly check 2's.
-    _gate('bogus-not-a-real-arm')
-    t5, v5, d5 = _fanout(p2, "U3", [a, b])
-    check("an unrecognised gate value behaves as 'all', not as 'off' -- a "
-          "typo in an A/B harness cannot silently disable the gate",
-          (len(t5), len(v5), sorted(d5)) == (1, 1, [a]),
-          f"{len(t5)}/{len(v5)}/{sorted(d5)}")
+    # 'sge,pad' is the discriminating input, not 'bogus': a wholly unrecognised
+    # value falls back to ALL through two independent paths, so it cannot tell
+    # a hardened parser from a naive one. A TRANSPOSED token beside a VALID one
+    # can -- the naive set form reads it as a deliberate pad-only arm and
+    # silently drops two halves. mutate_619 caught this test using the
+    # non-discriminating spelling.
+    for typo in ('bogus-not-a-real-arm', 'sge,pad', 'vias', 'none'):
+        _gate(typo)
+        t5, v5, d5 = _fanout(p2, "U3", [a, b])
+        check(f"gate={typo!r} behaves as 'all', not as a partial arm or as "
+              f"'off' -- a typo in an A/B harness cannot silently disable a "
+              f"half",
+              (len(t5), len(v5), sorted(d5)) == (1, 1, [a]),
+              f"{len(t5)}/{len(v5)}/{sorted(d5)}")
     _gate('off')
     t6, v6, d6 = _fanout(p2, "U3", [a, b])
     check("...and 'off' really does disable it, so the check above is a real "

--- a/tests/test_619_underpad_stub_vs_erased_copper.py
+++ b/tests/test_619_underpad_stub_vs_erased_copper.py
@@ -73,6 +73,43 @@ WHAT IS PINNED HERE, and what each check is FOR:
    fan's pad loop makes none of them, so these are not inherited -- they are
    the reason this half is safe to ship.
 
+MUTATION EVIDENCE (`python3 tests/mutate_619.py`, from the run -- never edited
+to match a prediction). 14 rows, 12 KILLED, 2 SURVIVED, 0 broken:
+
+    over-strict-floor-x5                      KILLED    (the negative control)
+    via-floor-uses-drill-not-size             KILLED
+    drop-the-zero-stub-guard                  KILLED
+    via-half-drops-the-own-net-skip           KILLED
+    seg-half-drops-the-own-net-skip           KILLED
+    pad-half-drops-the-own-net-skip           KILLED
+    seg-half-filters-the-ESCAPE-layer         KILLED
+    via-half-disabled                         KILLED
+    seg-half-disabled                         KILLED
+    pad-half-disabled                         KILLED
+    unknown-knob-value-means-OFF              KILLED
+    pad-half-ignores-local-clearance          KILLED
+    pad-half-includes-NPTH                    SURVIVED (declared)
+    stub-clearance-ignores-the-dru-layer-map  SURVIVED (declared)
+
+FOUR of those kills exist only because the battery found them SURVIVING first,
+and every one was a check that read as though it covered the thing it named:
+
+  * the zero-stub guard was argued for in a commit message and tested nowhere;
+  * check 7 asserted `check_drc`'s layer behaviour and the fixture's layer, but
+    never the ENGINE's choice between them -- every board in the sweep runs
+    escape layer == footprint.layer, so the distinction was invisible and
+    swapping `footprint.layer` for `layer` changed nothing. It needed a
+    CROSS-LAYER run (U2 mounted F.Cu, escaped to B.Cu) to become a check;
+  * no pinned geometry sat between the drill-derived and copper-derived floors;
+  * the knob's fail-safe direction (an unknown value means ALL, never OFF) was
+    asserted only by reading the code.
+
+The two declared survivors are real test holes, named rather than hidden: no
+tracked board places a netted NPTH within stub reach, and #770 records that no
+board this repo ingests carries a `.kicad_dru` layer rule, so `_stub_clr` and
+`clearance` are equal on every fixture. Both are asserted against check_drc's
+helpers directly (check 8) instead of pretending a board covers them.
+
     python3 tests/test_619_underpad_stub_vs_erased_copper.py
 """
 import contextlib
@@ -275,6 +312,61 @@ def test_erasure_injection_and_control():
           (len(t3), len(v3), sorted(d3)) == (2, 2, []),
           f"{len(t3)}/{len(v3)}/{sorted(d3)}")
 
+    # -- 3b. THE FLOOR IS BUILT FROM via.SIZE, NOT via.DRILL. The two differ
+    #    by (size - drill)/2 = 0.125 mm on this injected via, so a blocker
+    #    placed BETWEEN the two floors is caught by the shipped code and
+    #    missed by a drill-based one. Found by tests/mutate_619.py: without
+    #    this, `v.size / 2` -> `v.drill / 2` SURVIVED the whole file.
+    f_size = VS / 2 + TW / 2 + CL            # 0.3750
+    f_drill = 0.2 / 2 + TW / 2 + CL          # 0.2500 (injected drill = 0.2)
+    band = (f_size + f_drill) / 2.0          # 0.3125, strictly between them
+    bx, by = ix + (-dy / L) * band, iy + (dx / L) * band
+    p4 = parse_kicad_pcb(TIGARD)
+    p4.vias.append(Via(x=bx, y=by, size=VS, drill=0.2,
+                       layers=["F.Cu", "B.Cu"], net_id=nid_b))
+    t4, v4, d4 = _fanout(p4, "U3", [a, b])
+    check(f"the floor is the via's COPPER radius, not its drill radius: a "
+          f"blocker at d={band:.4f}, between the drill floor {f_drill:.4f} and "
+          f"the copper floor {f_size:.4f}, DOES block -- a drill-based floor "
+          f"would wave it through",
+          a in d4, f"dropped={sorted(d4)}")
+
+    # -- 3c. AN UNRECOGNISED KNOB VALUE MEANS ALL, NEVER OFF. A typo in a
+    #    harness must not silently ship the bug back. Same injected board as
+    #    check 2, so the expected outcome is exactly check 2's.
+    _gate('bogus-not-a-real-arm')
+    t5, v5, d5 = _fanout(p2, "U3", [a, b])
+    check("an unrecognised gate value behaves as 'all', not as 'off' -- a "
+          "typo in an A/B harness cannot silently disable the gate",
+          (len(t5), len(v5), sorted(d5)) == (1, 1, [a]),
+          f"{len(t5)}/{len(v5)}/{sorted(d5)}")
+    _gate('off')
+    t6, v6, d6 = _fanout(p2, "U3", [a, b])
+    check("...and 'off' really does disable it, so the check above is a real "
+          "discrimination and not a constant",
+          (len(t6), len(v6), sorted(d6)) == (2, 2, []),
+          f"{len(t6)}/{len(v6)}/{sorted(d6)}")
+    _gate('all')
+
+    # -- 3d. THE ZERO-LENGTH STUB EMITS NO COPPER, SO IT IS NOT TESTED.
+    #    Inject a via on net A's OWN net at net A's pad centre: the #479 reuse
+    #    path bridges to it with zero length, so the commit loop emits no track
+    #    (:604). Then put a net B via within the floor of that same point.
+    #    Without the guard the degenerate point-"segment" is graded against it
+    #    and the reuse is refused for copper that is never emitted. Found by
+    #    mutate_619: without this, removing the guard SURVIVED.
+    pa = [p for p in pcb.footprints["U3"].pads if p.net_id == nid_a][0]
+    p7 = parse_kicad_pcb(TIGARD)
+    p7.vias.append(Via(x=pa.global_x, y=pa.global_y, size=VS, drill=0.2,
+                       layers=["F.Cu", "B.Cu"], net_id=nid_a))
+    p7.vias.append(Via(x=pa.global_x + 0.20, y=pa.global_y, size=VS, drill=0.2,
+                       layers=["F.Cu", "B.Cu"], net_id=nid_b))
+    t7, v7, d7 = _fanout(p7, "U3", [a, b])
+    check("a ZERO-LENGTH stub (via reused at the pad centre) emits no track, "
+          "so a foreign via beside it must not reject the reuse -- net A keeps "
+          "its escape and emits no new via",
+          a not in d7, f"dropped={sorted(d7)}")
+
 
 # -------------------------------------------------------------------- 4 -----
 def test_gate_live_but_rejects_nothing():
@@ -349,13 +441,28 @@ def test_layer_scope_decision():
           "deliberately layer-blind, and this fails the day that changes",
           hit is True)
     # And the segment half's filter is on the STUB's layer, not the escape
-    # layer. On U2 the two spellings disagree completely.
+    # layer. Every board in the sweep runs escape layer == footprint.layer, so
+    # the distinction is INVISIBLE there -- mutate_619 found that swapping
+    # `footprint.layer` for `layer` SURVIVED the whole file. It needs a
+    # CROSS-LAYER configuration to be a real check: U2 is an F.Cu part escaped
+    # to B.Cu, which is what the under-pad method exists for.
     _gate('all')
     pcb = parse_kicad_pcb(U2BOARD)
     fp = pcb.footprints["U2"]
-    check("the fixture actually exercises the distinction: the escape layer "
-          "argument and footprint.layer are different layers here",
+    check("the fixture is genuinely cross-layer: U2 mounts on F.Cu and is "
+          "escaped to B.Cu, so the stub's layer and the escape layer differ",
           fp.layer == "F.Cu")
+    t_x, v_x, d_x = _fanout(pcb, "U2", layer="B.Cu")
+    e = _erased(pcb, "U2")
+    check("the stub's copper layer is footprint.layer, not the escape layer "
+          "(#195: putting it on the escape layer would float it above the pad)",
+          e.get('layer') == "F.Cu", str(e.get('layer')))
+    check("cross-layer tally pinned at 15 tracks / 13 vias / 27 dropped. "
+          "Filtering erased segments by the ESCAPE layer instead of the stub's "
+          "layer selects a DIFFERENT set (25 vs 17 pairs on this board) and "
+          "moves this number -- which is what makes this a real check",
+          (len(t_x), len(v_x), len(d_x)) == (15, 13, 27),
+          f"got {(len(t_x), len(v_x), len(d_x))}")
 
 
 # -------------------------------------------------------------------- 8 -----

--- a/tests/test_619_underpad_stub_vs_erased_copper.py
+++ b/tests/test_619_underpad_stub_vs_erased_copper.py
@@ -476,11 +476,17 @@ def test_layer_scope_decision():
     check("the stub's copper layer is footprint.layer, not the escape layer "
           "(#195: putting it on the escape layer would float it above the pad)",
           e.get('layer') == "F.Cu", str(e.get('layer')))
-    check("cross-layer tally pinned at 15 tracks / 13 vias / 27 dropped. "
-          "Filtering erased segments by the ESCAPE layer instead of the stub's "
-          "layer selects a DIFFERENT set (25 vs 17 pairs on this board) and "
-          "moves this number -- which is what makes this a real check",
-          (len(t_x), len(v_x), len(d_x)) == (15, 13, 27),
+    # 15/13/27 before #845, when the PRIMARY clearance test still read the
+    # escape layer's plane while this gate read the mount layer's. Both now
+    # read the mount layer, and this configuration is one of only two places in
+    # the repo that can tell the difference -- every board in the corpus sweep
+    # runs escape layer == footprint.layer, where the distinction is invisible.
+    check("cross-layer tally pinned at 14 tracks / 13 vias / 28 dropped "
+          "(15 / 13 / 27 before the #845 layer fix). Filtering erased segments "
+          "by the ESCAPE layer instead of the stub's layer selects a DIFFERENT "
+          "set (25 vs 17 pairs on this board) and moves this number -- which "
+          "is what makes this a real check",
+          (len(t_x), len(v_x), len(d_x)) == (14, 13, 28),
           f"got {(len(t_x), len(v_x), len(d_x))}")
 
 

--- a/tests/test_qfn_underpad.py
+++ b/tests/test_qfn_underpad.py
@@ -290,16 +290,23 @@ def _q2_reuse_end_to_end():
             via_size=0.45, via_drill=0.25, allow_via_in_pad=True)
 
     got = (len(vias), len(dropped), len(tracks))
-    # #619 moved this pin: the escape now tests its pad->via stub against the
-    # copper `nets_to_route` erased from the obstacle map (pre-existing vias,
-    # tracks and pads on the OTHER nets in this same fanout call), which it
-    # never did before, so escapes that were only reachable THROUGH that copper
-    # are withdrawn. On this configuration 28/12/30 -> 18/22/20. The reuse
-    # behaviour this section exists to pin is unchanged -- see the named
-    # DATA_30 check below, which still passes.
-    check('U2 underpad reuse: 18 vias / 22 dropped / 20 tracks '
-          '(was 28 / 12 / 30 before the #619 erased-copper gate)',
-          got == (18, 22, 20), f"got {got[0]} / {got[1]} / {got[2]}")
+    # Two fixes moved this pin, both of which bite HERE because this call is
+    # cross-layer -- U2 mounts on F.Cu and is escaped to B.Cu:
+    #   #619, the erased-copper gate: the escape now tests its pad->via stub
+    #     against copper `nets_to_route` erased from the obstacle map
+    #     (pre-existing vias, tracks and pads on the OTHER nets in this same
+    #     fanout call), so escapes only reachable THROUGH that copper are
+    #     withdrawn.  28/12/30 -> 18/22/20.
+    #   #845, the layer fix: the stub's clearance test used to read the ESCAPE
+    #     layer's obstacle plane (B.Cu) for copper the stub actually lands on
+    #     at the MOUNT layer (F.Cu, #195). It now reads F.Cu.  -> 18/23/19.
+    # The second is invisible on a same-layer call, which is every board in the
+    # corpus sweep; this test is one of only two places that exercise it.
+    # The reuse behaviour this section exists to pin is unchanged -- see the
+    # named DATA_30 check below, which still passes.
+    check('U2 underpad reuse: 18 vias / 23 dropped / 19 tracks '
+          '(28 / 12 / 30 before #619; 18 / 22 / 20 before the #845 layer fix)',
+          got == (18, 23, 19), f"got {got[0]} / {got[1]} / {got[2]}")
     # The specific net the regression cost, named -- a count can drift back
     # into place for an unrelated reason, this cannot.
     check('Net-(U2A-DATA_30) keeps its escape (it reuses an existing via)',

--- a/tests/test_qfn_underpad.py
+++ b/tests/test_qfn_underpad.py
@@ -290,8 +290,16 @@ def _q2_reuse_end_to_end():
             via_size=0.45, via_drill=0.25, allow_via_in_pad=True)
 
     got = (len(vias), len(dropped), len(tracks))
-    check('U2 underpad reuse: 28 vias / 12 dropped / 30 tracks',
-          got == (28, 12, 30), f"got {got[0]} / {got[1]} / {got[2]}")
+    # #619 moved this pin: the escape now tests its pad->via stub against the
+    # copper `nets_to_route` erased from the obstacle map (pre-existing vias,
+    # tracks and pads on the OTHER nets in this same fanout call), which it
+    # never did before, so escapes that were only reachable THROUGH that copper
+    # are withdrawn. On this configuration 28/12/30 -> 18/22/20. The reuse
+    # behaviour this section exists to pin is unchanged -- see the named
+    # DATA_30 check below, which still passes.
+    check('U2 underpad reuse: 18 vias / 22 dropped / 20 tracks '
+          '(was 28 / 12 / 30 before the #619 erased-copper gate)',
+          got == (18, 22, 20), f"got {got[0]} / {got[1]} / {got[2]}")
     # The specific net the regression cost, named -- a count can drift back
     # into place for an unrelated reason, this cannot.
     check('Net-(U2A-DATA_30) keeps its escape (it reuses an existing via)',


### PR DESCRIPTION
Closes #619. Closes #845. Supersedes #645 — see [Relationship to #645](#relationship-to-645).

`_underpad_via_escape` builds its obstacle map with
`build_base_obstacle_map(..., nets_to_route=list(fanned_nets))`, and
`nets_to_route` **erases every piece of copper on those nets** — segments
(`obstacle_map.py:216`), vias (`:299`) and pads (`:312`). Right for a net's
*own* copper; wrong for every *other* net in the same fanout call.

The candidate **via** still meets that copper, because `via_clears` scans
`pcb_data` directly — but it tests only the via **centre**. The **stub**'s one
channel to the input board is `check_line_clearance` on the holed map. So the
escape shipped stubs straight through the centres of foreign vias, across
foreign tracks, and over foreign pads.

The **surface fan already closes this hole for itself**, geometrically, at
`qfn_fanout/__init__.py:998-1011` (issue #257). The under-pad path returns at
`:651`, ~350 lines earlier, and shares none of it. This ports that backstop and
completes it.

## #619 undercounts its own damage

The issue names the **via** half only. Measured over every footprint with ≥4
pads on all 22 tracked boards — 408 of them, no package-name filter:

| erased copper the stub was never tested against | contacts |
|---|---|
| pre-existing **vias** on a fanned net | 20 |
| pre-existing **segments** on a fanned net | **75** |
| pre-existing **pads** on a fanned net | 49 |

The segment half is the largest, and nothing had named it.

## Result

```
                                          gate off      all three halves
residual stub-vs-erased pairs via/seg/pad   20/75/49     ->    0/0/0
byte-identical emitted geometry                                391 of 408
footprints changed                                              17
gate-live (erased set non-empty)                               253 of 408
escapes withdrawn                            973 dropped -> 1022  (+49)
```

On `kicad_files/routed_output.kicad_pcb` U2 the written board now grades at
**exactly the 4 violations the INPUT board already has** (1 SEGMENT-SEGMENT,
3 VIA-DRILL-HOLE — the identical list). The fanout contributes **zero**. It
contributed 44.

```bash
python3 py_router/qfn_fanout.py kicad_files/routed_output.kicad_pcb -c U2 \
    --escape-method underpad -w 0.1 --clearance 0.1 \
    --via-size 0.45 --via-drill 0.25 --grid-step 0.05 -o /tmp/u2.kicad_pcb
python3 py_router/check_drc.py /tmp/u2.kicad_pcb --clearance 0.1
```

| arm | vias/dropped | via_seg | seg_seg | `check_drc` @0.1 |
|---|---|---|---|---|
| off (today's engine) | 26 / 15 | 7 | 21 | **48** |
| via half | 19 / 22 | 0 | 6 | 18 |
| segment half | 15 / 26 | 2 | 1 | 6 |
| all three | 13 / 28 | 0 | 1 | **4** ← the input board's own |

**The halves are not additive**, which is why they ship as three commits with a
per-category table each, and why the gate knob selects a *set*. Neither half
alone reaches zero, and each moves the other's count without testing it: the
via half takes `seg_seg` 21 → 6 while testing no segment.

## The cost, stated plainly

49 escapes withdrawn across the corpus, concentrated on 17 footprints. On U2
that is 26 → 13. There is no geometric recovery: without `--allow-via-in-pad`
every candidate offset is the same escape ray further out, so a blocker on that
ray blocks every remaining candidate. Capping stub length makes it strictly
worse.

**On 391 of 408 footprints the gate is a no-op**, and the loss is confined to
re-fanning a board that already carries copper.

### End-to-end: does a withdrawn escape cost a connected pad?

Graded on the **routed** board, never on the fanout output — dropped escapes go
to `failed_nets` and the main router is supposed to pick those pads up, so a
fanout-level number answers the wrong question.

`orangecrab_ext_pll` U7 (WLCSP-20 @ 0.4 mm), the case #645 stalled on. Full
chain: fanout → bare GND pour on In1.Cu → `route.py -n GND`:

| routed board | `check_drc` @0.1 | via-seg | pad-seg | pad-via | `check_connected -n GND` |
|---|---|---|---|---|---|
| off (today) | **30** | 2 *in contact* | 2 *in contact* | 26 | ALL NETS FULLY CONNECTED |
| fix | **26** | **0** | **0** | 26 | ALL NETS FULLY CONNECTED |

Four contact violations removed, **zero connectivity lost**. The 26 PAD-VIA are
the board's own pre-existing via-in-pad, present on both arms.

## Relationship to #645

**The diagnosis is @theironchef's, and the via-half commit is co-authored to
them.** #645 identified the root cause (`nets_to_route` erasing sibling fanned
nets from the map, leaving the stub tested against nothing), spotted that the
surface fan's #257 backstop is the fix, and wrote the loop. It also named the
**segment and pad** gaps explicitly, in its own "what this does NOT fix"
section, before anyone had measured them — which is where two thirds of this PR
came from.

Its numbers were honestly measured, not wrong: I rebuilt a worktree at its base
`5c9a1b4a` and reproduced its "BEFORE" block verbatim. They then went stale. `98bd0fae` rewrote **both** gates it patches,
adding `run_output_conflict` and reshaping `via_clears`, and is not an ancestor
of its base.

- It does not apply (`CONFLICTING`), and its eight pinned tallies were measured
  on an engine that no longer exists.
- **Its blocking cost claim no longer reproduces.** It reports 8 GND balls
  going from reached to unreached on U7; re-run at HEAD, both arms report ALL
  NETS FULLY CONNECTED. `98bd0fae` had already shrunk U7's pre-fix state from 4
  escapes to 2 and from 5 shorts to 3.
- It closes only the via half, and misses that the segment half is larger.
- It reopens a zero-copper rejection `main` closes explicitly at `:213-215`.

Three things done differently, each measured:

1. **The gate runs BEFORE `via_clears`, not after.** `via_clears` scans every
   board via, pad and segment per candidate (~20k point tests on U2, where the
   erased via set is 89), so killing a doomed candidate first costs ~0.5% of
   that. Measured: 7.0 s against a 10.9 s baseline (**−36%**). Appended after
   `via_clears` as #645 does: **+18%**. The gate is a speed-up.
2. **The zero-length stub is guarded** (`:213-215`'s rule).
3. **The stub is priced on its own layer.** The `#498` dru swap resolves the
   rule for the **escape** layer, where the via lands; the stub is emitted on
   `footprint.layer` (#195) and `check_drc` grades it with
   `_pair_cl(..., layer=seg.layer)`.

## The pad half was pre-registered as a withdrawal candidate

Ship criterion, fixed before the measurement: remove ≥1 residual pair on ≥1
board of the full sweep. A 5-board sample said **zero**, and the geometry argued
for zero — a stub runs down its own pad's centreline while neighbours are a
pitch away laterally.

The full 408-footprint sweep found **49 pairs on 9 footprints across 6 boards**.
The null was sample size. The geometry argument was right about *perimeter
leads* and silent about everything else: the reachable case is a stub that
**crosses** an erased pad and lands clear beyond it, which is what a connector
footprint produces (`watchy` J3 = 9, `tigard` J1 = 2). Six of the 17 changed
footprints have empty erased via *and* segment sets — they change only because
of this half.

It makes four exclusions the surface fan's pad loop does not, or it would
phantom-reject: NPTH carries no copper (`_pad_has_no_copper`, #260); layer scope
resolves through `pad_copper_layers` so `*.Cu` and `F&B.Cu` expand (#722); per-pad
`local_clearance` **raises** the floor and cannot be hoisted the way the surface
fan hoists its `margin`; and a net **tie** must be exempt, because `_seg_hits_pad`
is net-blind and `obstacle_map`'s own tie lift fires only when exactly one net is
routed (`:338-341`), so this path never receives it.

## Tests

`tests/test_619_underpad_stub_vs_erased_copper.py` — 55 checks, unit tier, 20 s.

- **The erasure itself**, asserted directly: the same map built with
  `nets_to_route=[A,B]` reports the stub line CLEAR while `[A]` reports the
  same line BLOCKED.
- **Injection + counter-guard** on `tigard` (the only fixture with zero board
  vias *and* zero segments). The exact emitted tuple is pinned, because "no
  stub inside the floor" passes vacuously for anything that drops every pad.
- **A negative control**: a via just outside the floor must block nothing.
- **Gate live where it claims to be**, read from the engine's published
  `LAST_ERASED_SETS`, never re-derived — the obvious proxy
  `{p.net_id for p in footprint.pads}` disagrees with `fanned_nets` and can
  report a dead loop as live.

`tests/mutate_619.py` — 17 rows, **13 killed, 4 survived (declared), 0 broken**.

**Five of those kills exist only because the battery found them SURVIVING
first**, in tests I had just written and believed covered them: the zero-stub
guard was argued for in a commit message and tested nowhere; the layer decision
was invisible because every sweep board runs escape layer == `footprint.layer`
(it needed a cross-layer run to become a check); no geometry sat between the
drill- and copper-derived floors; the knob's fail-safe direction was asserted
only by reading the code; and once it *was* tested, the battery caught the test
using a non-discriminating spelling — a wholly unrecognised value falls back to
ALL through two independent paths, so only a transposed token beside a valid one
(`sge,pad`) separates a hardened parser from a naive one.

## An adversarial review of this fix found four defects in it

Recorded because they are the reason to trust the current state, not a reason to
trust the first draft. All four are fixed in `6cec18d0`.

1. **The net-tie waiver was too broad, and could have passed a real short.**
   `check_drc.py:2442-2445` requires **both** `id(pad) in
   net_tie_exempt_pad_ids(...)` **and** `_net_tie_span_waived(...)`; KiCad's
   exemption is *local* (`DRC_ENGINE::IsNetTieExclusion`). Waiving the whole
   partner pad would let a stub crossing it 2–3 mm away — exactly what the
   offset ladder produces — keep its escape and ship a violation.
2. **The pad half over-rejected legal geometry**: audited corpus-wide,
   `AGREE 5449 / PHANTOM 83 / MISSED 0`, worst **0.234 mm clear** of the
   requirement. `_seg_hits_pad` tests the axis-aligned rectangle with
   square-grown corners while `check_drc` resolves a `corner_radius` (61 of 83),
   and it rejects at `1e-6` where the grader forgives 5 % of clearance (22).
3. **`samples=16` can step over a small pad**: proven, a 0.25 mm pad on a
   6.95 mm stub reported CLEAR with the stub through its centre. That length is
   reachable — at via 0.8 / pitch 0.4 the ladder's top offset is exactly 6.95 mm.
4. **`LAST_ERASED_SETS` was never cleared**, so 155 of the sweep's 408 rows
   graded against the *previous footprint's* net set, from a different board.
   This inflated the `gate-live` figure from 253 to 405; the residual pair
   totals were unaffected (those rows emit no tracks). Corrected above.

1–3 had one root cause — the gate **mirrored** the grader instead of calling it.
It now builds one `Segment` per candidate and calls `check_pad_segment_overlap`
and `_net_tie_span_waived` directly, so it refuses what `check_drc` flags by
construction rather than by assertion. Emitted geometry is unchanged on every
one of the 17 changed footprints, so the 83 phantoms were latent, not costly —
but the claim that it "refuses exactly what the grader flags" was false, and now
is not.

The same review settled the pad half's central question: on U2 every one of the
10 withdrawn stubs carried 1–6 real violations — **withdrawn-but-clean stubs:
0** — and on four boards graded end-to-end, 37 real violations removed with no
clean escape lost. It also corrected a premise of mine: `tigard` has zero vias
and zero segments but **218 erased pads**, so the pad half is live on
essentially every board and the three lists are never all empty.

Red/green, engine only reverted to `8aa76378`: **55/55 → 21/55**, 34 named
failures printing the base engine's real numbers.

`tests/sweep_619_erased_copper.py` lives **in the repo**, so the table above is
re-runnable from a clean clone — #645's own "what I could not verify" concedes
its 408-footprint table was not. It selects by **pad count, never package
name**: `qfn_fanout.py -c` accepts any reference and the GUI dropdown lists
every footprint with enough pads, which is how #645's first revision reported 2
changed footprints where the truth was 7.

## #845 folded in: the primary clearance test read the wrong layer

The #619 gate used `footprint.layer` from birth, while the **primary** test
beside it — `check_line_clearance` — still used the *escape* layer. Shipping one
correct and one knowingly wrong was the worse option, so it is fixed here.

`stub_layer_idx` (was `obs_layer_idx`) now resolves `footprint.layer`. The stub
is emitted there, deliberately, so it does not float above the pad (#195);
`layer` is where the **via** lands. It is the **only** consumer of that index —
the via is never tested through the map (it is a through via, and `via_clears`
scans `pcb_data` geometrically) — so there was no second reader for whom the
escape layer was right. The rename is not cosmetic: the old name is what made it
read as correct.

**Measured, and inert exactly where it cannot bite:**

| configuration | before | after |
|---|---|---|
| `F.Cu` (= mount layer), default ladder | 14/13/28 | **14/13/28** unchanged |
| `B.Cu` cross-layer, default ladder | 15/13/27 | **14/13/28** |
| `B.Cu` + `--allow-via-in-pad` | 20/18/22 | **19/18/23** |

Proven over the corpus rather than argued: re-running the 408-footprint sweep
before and after gives **408 of 408 byte-identical emitted geometry, 0
changed**. Every board in that sweep runs escape layer == `footprint.layer`,
where the distinction is invisible — which is exactly why the defect survived,
and why **every #619 number above is unaffected by it**.

Only two places in the repo can see it, and both now pin it:
`tests/test_qfn_underpad.py`'s cross-layer call and this PR's own cross-layer
check. The battery gains `primary-clearance-test-reads-the-ESCAPE-layer`.

## Suite and gates

```
362 passed, 0 failed, 0 timed out, 149 skipped in 1597.2s
                            # python3 tests/run_all.py --fast -j 4 --timeout 240
```

Fully green, so there is no baseline failure list to reconcile — I did not run
the `upstream/main` arm, because with zero failures on this one there is nothing
it could be masking. The one pre-existing test the fix legitimately moves is
`tests/test_qfn_underpad.py`'s U2 tally pin (28/12/30 → 18/22/20 on its
`--layer B.Cu --allow-via-in-pad` configuration), updated in the same commit;
its named `Net-(U2A-DATA_30)` companion assertion — the one the #479 reuse work
exists to protect — still passes, which is the evidence the reuse path is intact
rather than merely re-counted.

## CLI / GUI parity

Entirely inside the shared engine function; `fanout_gui.py:1450` calls
`generate_qfn_fanout` directly, so the GUI inherits it. No new parameter, flag,
dialog control or CLI post-pass — nothing to thread through `ai_plan.py`,
`manifest_to_plan.py` or `settings_persistence.py`. Both wx-free gates pass:

```
Converter parity: OK ... exit=0                    # test_manifest_plan_parity.py
CLI post-pass coverage: 8 registered, 15 in active CLI use,
  1 CLI-only acknowledged, 0 failures, 0 warnings  # test_cli_postpass_coverage.py
```

`tests/gui_parity/test_fanout_rotated_gui.py` drives the **surface** fan and
never enters `_underpad_via_escape`, so it confirms nothing here. Saying so
rather than citing it as coverage.

## What I could not verify

- **No corpus-scale (`tests/stress/`) replay.** The sweep is the 22 tracked
  in-repo boards.
- **Two boards carried end-to-end**, not seventeen. `orangecrab_ext_pll` U7 and
  `routed_output` U2. The other changed footprints withdraw escapes that were
  not chained.
- **The `.kicad_dru` layer path is unfalsifiable here.** #770 records that the
  rule subset #498 models does not intersect any board this repo ingests, so
  `_stub_clr == clearance` on every fixture. Declared as a mutation survivor
  rather than hidden.
- **No netted NPTH within stub reach on any tracked board**, so that exclusion
  is asserted against `check_drc`'s helper rather than through emitted
  geometry. Also a declared survivor.
- **No tracked board declares `net_tie_pad_groups`**, so the *locality* half of
  the net-tie waiver is unfalsifiable here. It is a declared mutation survivor
  and it is the one I would most like a reviewer to look at by eye, because it
  is the only remaining path by which this gate could waive a real short.
- **The exact-tally pins are deliberately brittle.** Any future change to the
  escape ladder fails them and forces re-measurement. Intended, but a real
  maintenance cost.
- **One adjacent defect found and NOT fixed here**, filed separately with its
  measurement: `_onpad`'s `k >= 1` offsets commit as off-pad vias with no #202
  clamp (#846). It is a behaviour question needing a corpus A/B, not a bug with
  an obvious right answer -- those long offsets are load-bearing for escape
  counts (capping stub length monotonically *reduces* escapes: 3.0 mm -> 18
  vias, 2.0 -> 17, 1.5 -> 16, 1.0 -> 12), so changing it here would confound
  the #619 measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SMBycv1WWPHBoUsUqPXyd
