### PR TITLE
#620/#618: manage_vias stops being blind to the vias it is placing right now

### DIFF
--- a/py_router/bga_fanout/__init__.py
+++ b/py_router/bga_fanout/__init__.py
@@ -51,6 +51,8 @@ from bga_fanout.geometry import (
     clamp_via_to_pad,
     immovable_foreign_pads,
     via_clears_pad_rects,
+    PendingVias,
+    thin_drill_to_clear,
 )
 from bga_fanout.escape import (
     find_escape_channel,
@@ -619,7 +621,7 @@ def manage_vias(
     via_size: float,
     via_drill: float,
     clearance: float,
-) -> Tuple[List[Dict], List[Dict]]:
+) -> Tuple[List[Dict], List[Dict], List['FanoutRoute']]:
     """
     Manage vias for fanout routes.
 
@@ -635,23 +637,40 @@ def manage_vias(
         clearance: Minimum clearance between vias
 
     Returns:
-        Tuple of (vias_to_add, vias_to_remove)
+        Tuple of (vias_to_add, vias_to_remove, via_blocked_routes)
 
-    KNOWN GAP, NOT FIXED HERE -- D10's self-blindness, in this function.
-    `vias_to_add` is appended to below and never read back, and BOTH guards
-    that gate an append iterate `pcb_data.vias` only: `would_overlap_existing_via`
-    and `via_in_pad_conflict`'s drill loop. So two vias added in ONE call are
-    never tested against each other -- the same shape as the qfn underpad
-    escape's, where the fix was to test each candidate against this run's own
-    output as well as the input board (`qfn_fanout.run_output_conflict`, which
-    is reusable and would be this code's second caller).
+    D10's SELF-BLINDNESS, CLOSED HERE (#620). `vias_to_add` was appended to
+    below and never read back, and BOTH guards that gate an append iterate
+    `pcb_data.vias` only: `would_overlap_existing_via` and
+    `via_in_pad_conflict`'s drill loop. So two vias added in ONE call were
+    never tested against each other. `PendingVias` (bga_fanout/geometry.py) is
+    the missing half, and its docstring argues what it tests -- the drill
+    always, the ring only for a via the clamp could not fit inside its pad --
+    from a sweep rather than from first principles.
 
-    Structurally verified by reading; the IMPACT is UNMEASURED, deliberately
-    stated as such. A 0.5mm-pitch BGA taking via 0.45 + clearance 0.1 needs
-    0.55mm between adjacent ball centres and has 0.50 -- but `clamp_via_to_pad`
-    shrinks a via to fit its pad first, and on that pitch it may clamp far
-    enough to make the pair legal anyway. Whether this bites needs measuring
-    on a real fine-pitch BGA before anyone claims it does.
+    The impact, which the issue deliberately left UNMEASURED, is measured now:
+    on an empty board two 0.30mm-pitch balls with 0.25mm pads ship holes
+    0.15mm apart against a 0.20mm fab floor, `added=2 blocked=0`, and two
+    coincident same-net balls ship TWO `(via ...)` s-exprs at one point. The
+    issue's own worked example -- 0.5mm pitch, via 0.45, clearance 0.1 -- was
+    right to hedge: `clamp_via_to_pad` shrinks that via to the ball pad first
+    and the pair is legal. **No board in this repo reaches the refusal branch
+    at CLI defaults**, which is why the evidence is a constructed fixture and
+    the corpus arms are a safety check, not a headline.
+
+    The cost is stated where it is paid: a refusal drops the escape (see the
+    #756 block below), so the conflict branch descends the fab drill ladder
+    before giving one up, and `--fab-overrides` -- which collapses that ladder
+    to one hard rung -- cannot descend at all. That is the configuration the
+    #620 contributor measured as pure loss, and their measurement is why this
+    has a ladder and a same-site rule at all.
+
+    RESIDUAL, named rather than hidden: a conflict is resolved against the vias
+    committed SO FAR, while the two whole-net drops that run after this
+    function returns (`esc_dropped`, and the via-vs-foreign-track pass) can
+    later delete a via a refusal was measured against. Twins are immune -- same
+    net, dropped together -- but a distinct-pair loser is not recoverable once
+    its tracks are gone.
 
     `via_in_pad_conflict`'s drill floor was the OTHER gap here -- priced at
     the flat `routing_defaults.HOLE_TO_HOLE_CLEARANCE` rather than the
@@ -665,10 +684,10 @@ def manage_vias(
     **The cost, which the via-nudge half does not pay:** a refusal here
     DROPS the escape rather than searching again, so a tighter floor can
     turn an escaped ball into a failed net. The via-nudge answers that with
-    a two-rung ladder; this pass has no second rung to descend to. Stated
-    at the resolution site with the numbers.
-
-    The self-blindness above is untouched and still open.
+    a two-rung ladder; this pass had no second rung to descend to. Stated
+    at the resolution site with the numbers. #620 gives the SAME-CALL arm one
+    (`thin_drill_to_clear`); the board-facing arm above still has none, so a
+    board declaration can still refuse an escape outright.
     """
     def find_nearby_via(x: float, y: float, net_id: int, max_dist: float):
         """Find an existing via on the same net within max_dist of position."""
@@ -856,6 +875,16 @@ def manage_vias(
     floor_pads = 0
     escalated_count = 0
 
+    # #620: this run's OWN output, queryable as it grows. Every guard above
+    # scans `pcb_data`, and `vias_to_add` was appended to and never read back,
+    # so two vias placed in one call were spaced against the input board and
+    # against nothing else. `PendingVias` is the missing half; what it tests
+    # and what it deliberately does not is argued at its definition.
+    _pending = PendingVias(_h2h, clearance)
+    _twin_shared = 0       # coincident same-net sites served by ONE hole
+    _thinned = []          # (from, to) drills a deeper fab rung rescued
+    _pending_refused = []  # (net name, reason) escapes no rung could place
+
     # Check distance threshold: via is "at pad" if within via radius + small tolerance
     via_proximity_threshold = via_size / 2 + 0.1
 
@@ -906,6 +935,39 @@ def manage_vias(
                                        route.net_id) is not None:
                     via_blocked_routes.append(route)
                     continue
+                # #620: the pair test the input-board guards above cannot do.
+                # Placed AFTER them so the board keeps its present precedence
+                # -- this only decides among sites THIS call is creating.
+                _bulges = status == 'floor'
+                _v, _detail = _pending.verdict(pad_x, pad_y, v_size, v_drill,
+                                               route.net_id, _bulges)
+                if _v == 'twin':
+                    # Two routes, one physical hole. Both keep their tracks and
+                    # both anchor to the via already committed here: the ball-
+                    # anchor test downstream (`_has_copper`) looks for a via
+                    # inside the pad, and this is that via. Today's code
+                    # appends a second identical dict and the writer, which
+                    # does not dedupe, emits both as stacked copper.
+                    _twin_shared += 1
+                    continue
+                if _v == 'conflict':
+                    # A refusal here drops the escape -- there is no re-sweep
+                    # -- so descend the fab ladder's drill floors first. The
+                    # twin branch above cannot re-fire for a thinner drill, so
+                    # 'clear' is the right predicate.
+                    _thin = thin_drill_to_clear(
+                        v_drill, floors, rung,
+                        lambda cand: _pending.verdict(
+                            pad_x, pad_y, v_size, cand, route.net_id,
+                            _bulges)[0] == 'clear')
+                    if _thin is None:
+                        via_blocked_routes.append(route)
+                        _pending_refused.append(
+                            (route.pad.net_name or f"net{route.net_id}",
+                             _detail[0]))
+                        continue
+                    _thinned.append((v_drill, _thin))
+                    v_drill = _thin
                 if not would_overlap_existing_via(pad_x, pad_y, v_size):
                     vias_to_add.append({
                         'x': pad_x,
@@ -915,6 +977,8 @@ def manage_vias(
                         'layers': ['F.Cu', 'B.Cu'],
                         'net_id': route.net_id
                     })
+                    _pending.add(pad_x, pad_y, v_size, v_drill, route.net_id,
+                                 _bulges)
 
     if vias_to_add:
         print(f"  Adding {len(vias_to_add)} vias at pads on non-top layers")
@@ -926,6 +990,26 @@ def manage_vias(
         print(f"  WARNING: {floor_pads} pad(s) smaller than the fab via floor "
               f"({fab_floor_min(copper)['via_diameter']:.2f}mm dia); via held at the "
               f"floor and still bulges past the pad edge")
+    # #620 disclosure. Separate from the #253/#370 line below because these are
+    # this run's own vias meeting each other, which the reader cannot act on in
+    # the same way: the levers are the pitch, the drill and the fab tier.
+    if _twin_shared:
+        print(f"  #620: {_twin_shared} coincident same-net site(s) share one "
+              f"via instead of stacking two")
+    if _thinned:
+        warn_fab_escalation(
+            f"{len(_thinned)} via-in-pad drill(s) thinned to "
+            f"{min(t[1] for t in _thinned):g}mm to hold the {_h2h:g}mm "
+            f"hole-to-hole floor ({_h2h_src}) against this run's own vias")
+    if _pending_refused:
+        _names = sorted({n for n, _r in _pending_refused})
+        _reasons = sorted({r for _n, r in _pending_refused})
+        print(f"  WARNING: {len(_pending_refused)} escape(s) dropped: this "
+              f"run's own via-in-pads cannot be spaced at the {_h2h:g}mm "
+              f"hole-to-hole floor ({_h2h_src}) on this pitch, and no fab rung "
+              f"is thin enough ({'; '.join(_reasons)}); retry with "
+              f"--escape-method underpad, a smaller --via-drill, or a fab tier "
+              f"whose floor this pitch can meet: {', '.join(_names)}")
     if vias_to_remove:
         print(f"  Removing {len(vias_to_remove)} unnecessary vias at pads on top layer")
     if via_blocked_routes:

--- a/py_router/bga_fanout/__init__.py
+++ b/py_router/bga_fanout/__init__.py
@@ -968,17 +968,44 @@ def manage_vias(
                         continue
                     _thinned.append((v_drill, _thin))
                     v_drill = _thin
-                if not would_overlap_existing_via(pad_x, pad_y, v_size):
-                    vias_to_add.append({
-                        'x': pad_x,
-                        'y': pad_y,
-                        'size': v_size,
-                        'drill': v_drill,
-                        'layers': ['F.Cu', 'B.Cu'],
-                        'net_id': route.net_id
-                    })
-                    _pending.add(pad_x, pad_y, v_size, v_drill, route.net_id,
-                                 _bulges)
+                if would_overlap_existing_via(pad_x, pad_y, v_size):
+                    # #620, second half: this used to be `if not ...: append`,
+                    # so a refusal here dropped the VIA and kept the route --
+                    # its inner-layer track shipped anyway, connected to
+                    # nothing, while the ball still counted as escaped. The
+                    # sibling guard two lines up does the opposite, and the
+                    # #508 comment at this function's call site says why: the
+                    # old code "left the sibling routes in `routes` -- still
+                    # counted escaped, shipping via-in-pad balls with no
+                    # track". This is the same defect with the halves swapped.
+                    #
+                    # THE REFUSAL SET IS UNCHANGED -- only the bookkeeping is.
+                    # `would_overlap_existing_via` stays net-BLIND (a same-net
+                    # via inside the pad is already handled by the
+                    # `existing_via` branch above); making it foreign-only
+                    # would change WHICH sites get a via, which is not this
+                    # issue.
+                    #
+                    # Measured on orangecrab_ext_pll U3 at defaults, the one
+                    # in-repo board that reaches this branch: it fires 11
+                    # times over the retry passes (4 distinct nets, every
+                    # blocker foreign), and the output board is UNCHANGED --
+                    # each stranded route was removed by a later filter
+                    # anyway, and its net already reported unescaped. So this
+                    # ships as a coherence fix with no measured board effect,
+                    # said plainly rather than dressed up.
+                    via_blocked_routes.append(route)
+                    continue
+                vias_to_add.append({
+                    'x': pad_x,
+                    'y': pad_y,
+                    'size': v_size,
+                    'drill': v_drill,
+                    'layers': ['F.Cu', 'B.Cu'],
+                    'net_id': route.net_id
+                })
+                _pending.add(pad_x, pad_y, v_size, v_drill, route.net_id,
+                             _bulges)
 
     if vias_to_add:
         print(f"  Adding {len(vias_to_add)} vias at pads on non-top layers")
@@ -1016,8 +1043,9 @@ def manage_vias(
         names = sorted(r.pad.net_name or f"net{r.net_id}" for r in via_blocked_routes)
         print(f"  WARNING: {len(via_blocked_routes)} escape(s) dropped: via-in-pad "
               f"would hit an immovable foreign pad (locked part/connector/test "
-              f"point, #253), a drill within hole-to-hole of another hole, or a "
-              f"foreign track (#370): {', '.join(names)}")
+              f"point, #253), a drill within hole-to-hole of another hole, a "
+              f"foreign track (#370), or an existing via's ring (#620): "
+              f"{', '.join(names)}")
 
     return vias_to_add, vias_to_remove, via_blocked_routes
 

--- a/py_router/bga_fanout/__init__.py
+++ b/py_router/bga_fanout/__init__.py
@@ -665,12 +665,23 @@ def manage_vias(
     #620 contributor measured as pure loss, and their measurement is why this
     has a ladder and a same-site rule at all.
 
-    RESIDUAL, named rather than hidden: a conflict is resolved against the vias
-    committed SO FAR, while the two whole-net drops that run after this
-    function returns (`esc_dropped`, and the via-vs-foreign-track pass) can
-    later delete a via a refusal was measured against. Twins are immune -- same
-    net, dropped together -- but a distinct-pair loser is not recoverable once
-    its tracks are gone.
+    THREE RESIDUALS, named rather than hidden. An adversarial review found the
+    second and third; all are deterministic, none is a correctness bug, and
+    each costs escapes in a case no in-repo board reaches.
+
+    1. A conflict is resolved against the vias committed SO FAR, while the two
+       whole-net drops that run after this function returns (`esc_dropped`, and
+       the via-vs-foreign-track pass) can later delete a via a refusal was
+       measured against. Twins are immune -- same net, dropped together -- but
+       a distinct-pair loser is not recoverable once its tracks are gone.
+    2. The loser of a conflict is whichever route arrives LATER, with no
+       tiebreak. Route order is a deterministic list order, so the output is
+       reproducible, but it is not escape-maximising: three balls in a row at
+       0.30mm pitch keep 2 escapes in four of six route permutations and 1 in
+       the two that place the middle ball first.
+    3. A refusal costs the net's WHOLE fanout, not the one ball, because the
+       caller drops every route of a blocked net (the #508 coherence rule at
+       this function's call site). The disclosure below says so.
 
     `via_in_pad_conflict`'s drill floor was the OTHER gap here -- priced at
     the flat `routing_defaults.HOLE_TO_HOLE_CLEARANCE` rather than the
@@ -939,8 +950,13 @@ def manage_vias(
                 # Placed AFTER them so the board keeps its present precedence
                 # -- this only decides among sites THIS call is creating.
                 _bulges = status == 'floor'
+                # The candidate ball's anchor radius, spelled the way the
+                # downstream ball-anchor test spells it (`_has_copper`): a via
+                # this far in is a via that connects this ball.
+                _atol = max(route.pad.size_x, route.pad.size_y) / 2 + 0.01
                 _v, _detail = _pending.verdict(pad_x, pad_y, v_size, v_drill,
-                                               route.net_id, _bulges)
+                                               route.net_id, _bulges,
+                                               anchor_tol=_atol)
                 if _v == 'twin':
                     # Two routes, one physical hole. Both keep their tracks and
                     # both anchor to the via already committed here: the ball-
@@ -948,6 +964,22 @@ def manage_vias(
                     # inside the pad, and this is that via. Today's code
                     # appends a second identical dict and the writer, which
                     # does not dedupe, emits both as stacked copper.
+                    #
+                    # The SURVIVOR must be the tighter pad's clamp. Which via
+                    # survived used to be whichever route arrived first, so two
+                    # coincident same-net pads of 0.25 and 0.60 kept a 0.45 via
+                    # bulging past the 0.25 pad -- the #202 violation
+                    # `clamp_via_to_pad` exists to prevent, re-created by the
+                    # merge. Tighten instead.
+                    _tx, _ty, _ts, _td = _detail
+                    if _pending.tighten(_tx, _ty, v_size, v_drill):
+                        for _v_dict in vias_to_add:
+                            if (_v_dict['x'] == _tx and _v_dict['y'] == _ty
+                                    and _v_dict['net_id'] == route.net_id):
+                                _v_dict['size'] = min(_v_dict['size'], v_size)
+                                _v_dict['drill'] = min(_v_dict['drill'],
+                                                       v_drill)
+                                break
                     _twin_shared += 1
                     continue
                 if _v == 'conflict':
@@ -959,7 +991,7 @@ def manage_vias(
                         v_drill, floors, rung,
                         lambda cand: _pending.verdict(
                             pad_x, pad_y, v_size, cand, route.net_id,
-                            _bulges)[0] == 'clear')
+                            _bulges, anchor_tol=_atol)[0] == 'clear')
                     if _thin is None:
                         via_blocked_routes.append(route)
                         _pending_refused.append(
@@ -1024,10 +1056,13 @@ def manage_vias(
         print(f"  #620: {_twin_shared} coincident same-net site(s) share one "
               f"via instead of stacking two")
     if _thinned:
+        # The SET of drills, not min(): several rungs can be used in one run
+        # and "thinned to 0.15mm" would misdescribe a via thinned to 0.17.
+        _to = ', '.join(f"{d:g}" for d in sorted({t[1] for t in _thinned}))
         warn_fab_escalation(
-            f"{len(_thinned)} via-in-pad drill(s) thinned to "
-            f"{min(t[1] for t in _thinned):g}mm to hold the {_h2h:g}mm "
-            f"hole-to-hole floor ({_h2h_src}) against this run's own vias")
+            f"{len(_thinned)} via-in-pad drill(s) thinned to {_to}mm to hold "
+            f"the {_h2h:g}mm hole-to-hole floor ({_h2h_src}) against this "
+            f"run's own vias")
     if _pending_refused:
         _names = sorted({n for n, _r in _pending_refused})
         _reasons = sorted({r for _n, r in _pending_refused})
@@ -1037,6 +1072,12 @@ def manage_vias(
               f"is thin enough ({'; '.join(_reasons)}); retry with "
               f"--escape-method underpad, a smaller --via-drill, or a fab tier "
               f"whose floor this pitch can meet: {', '.join(_names)}")
+        # The caller drops the whole NET of a blocked route (#508 coherence:
+        # `blocked_net_ids` removes every route of that net plus its tracks),
+        # so one refused ball costs its net's entire fanout. Named here
+        # because the count above reads like a per-ball cost and is not.
+        print(f"           each of those nets loses its WHOLE fanout, not "
+              f"just the refused ball ({len(_names)} net(s))")
     if vias_to_remove:
         print(f"  Removing {len(vias_to_remove)} unnecessary vias at pads on top layer")
     if via_blocked_routes:

--- a/py_router/bga_fanout/__init__.py
+++ b/py_router/bga_fanout/__init__.py
@@ -950,13 +950,15 @@ def manage_vias(
                 # Placed AFTER them so the board keeps its present precedence
                 # -- this only decides among sites THIS call is creating.
                 _bulges = status == 'floor'
-                # The candidate ball's anchor radius, spelled the way the
-                # downstream ball-anchor test spells it (`_has_copper`): a via
-                # this far in is a via that connects this ball.
-                _atol = max(route.pad.size_x, route.pad.size_y) / 2 + 0.01
+                # The candidate ball's pad, as a RECTANGLE: a via inside it
+                # is a via that connects this ball. A scalar radius here
+                # merged two DISTINCT oblong pads into one via and stranded
+                # the loser's route -- see `PendingVias.verdict`.
+                _abox = (route.pad.size_x / 2 + 0.01,
+                         route.pad.size_y / 2 + 0.01)
                 _v, _detail = _pending.verdict(pad_x, pad_y, v_size, v_drill,
                                                route.net_id, _bulges,
-                                               anchor_tol=_atol)
+                                               anchor_box=_abox)
                 if _v == 'twin':
                     # Two routes, one physical hole. Both keep their tracks and
                     # both anchor to the via already committed here: the ball-
@@ -991,7 +993,7 @@ def manage_vias(
                         v_drill, floors, rung,
                         lambda cand: _pending.verdict(
                             pad_x, pad_y, v_size, cand, route.net_id,
-                            _bulges, anchor_tol=_atol)[0] == 'clear')
+                            _bulges, anchor_box=_abox)[0] == 'clear')
                     if _thin is None:
                         via_blocked_routes.append(route)
                         _pending_refused.append(

--- a/py_router/bga_fanout/geometry.py
+++ b/py_router/bga_fanout/geometry.py
@@ -417,13 +417,23 @@ class PendingVias:
             self._max_size = s
 
     def verdict(self, x, y, size, drill, net_id, bulges=False, tol=1e-6,
-                anchor_tol=None):
+                anchor_box=None):
         """How a candidate at (x, y) relates to what this call already placed.
 
-        ``anchor_tol`` is the candidate BALL's own anchor radius -- the same
-        ``max(size_x, size_y) / 2 + 0.01`` the downstream ball-anchor test
-        (``_has_copper``) uses to decide whether a via connects a ball. Default
-        ``site_tol`` (1 um) if not given.
+        ``anchor_box`` is the candidate BALL's own pad half-extents,
+        ``(size_x / 2 + t, size_y / 2 + t)`` -- a RECTANGLE, because a pad is
+        one. Default: the 1 um site tolerance in both axes.
+
+        A SCALAR RADIUS HERE WAS A BUG, and an expensive one, so it is spelled
+        out. The first version took ``max(size_x, size_y) / 2 + 0.01`` and
+        compared it against a straight-line distance, which on an OBLONG pad
+        reaches far outside the copper along the short axis: two same-net
+        0.30 x 1.50 fingers 0.50mm apart -- an ordinary fine-pitch QFP pair
+        whose pads are 0.20mm apart and NOT touching -- were merged into one
+        via, and the second route shipped with no via at all while still
+        counting as escaped. That is precisely the defect the sibling commit
+        fixes, re-created by the merge. An adversarial review found it, with
+        17 footprints on 11 in-repo boards matching the geometry.
 
         Returns ``(verdict, detail)``:
 
@@ -441,12 +451,13 @@ class PendingVias:
             today's, which appends a second identical dict that the writer
             emits as a second ``(via ...)`` at the same point.
 
-            KEYED ON THE ANCHOR RADIUS, NOT ON AN EXACT MATCH. An exact-match
-            rule has a 1 um cliff: an adversarial review found same-net sites
-            0.0010mm apart merging into one via while 0.0011mm apart DROPPED an
-            escape outright, because no fab rung can space two holes 1.1 um
-            apart. Anything inside the ball's own pad is a via that anchors it,
-            which is the question actually being asked.
+            KEYED ON THE PAD, NOT ON AN EXACT MATCH. An exact-match rule has a
+            1 um cliff: an adversarial review found same-net sites 0.0010mm
+            apart merging into one via while 0.0011mm apart DROPPED an escape
+            outright, because no fab rung can space two holes 1.1 um apart. A
+            via inside the ball's own pad is a via that anchors it, which is
+            the question actually being asked -- and "inside the pad" is a
+            rectangle test, per ``anchor_box`` above.
         ``('conflict', (reason, x, y))``
             that via is closer than a floor allows. A DIFFERENT net at the same
             site lands here, not in ``'twin'``: two nets sharing one hole is a
@@ -454,19 +465,22 @@ class PendingVias:
         """
         d = drill or 0.0
         s = size or 0.0
-        atol = self._tol if anchor_tol is None else max(anchor_tol, self._tol)
+        ahx, ahy = ((self._tol, self._tol) if anchor_box is None else
+                    (max(anchor_box[0], self._tol),
+                     max(anchor_box[1], self._tol)))
         # Broad phase: nothing outside this x-window can be within either floor
-        # of the candidate, whatever its y. `atol` is in it because a twin can
+        # of the candidate, whatever its y. `ahx` is in it because a twin can
         # sit further out than either floor when the pad is large.
         window = max(d / 2.0 + self._max_drill / 2.0 + self._h2h,
                      s / 2.0 + self._max_size / 2.0 + self._clearance,
-                     atol)
+                     ahx)
         lo = bisect.bisect_left(self._xs, x - window)
         hi = bisect.bisect_right(self._xs, x + window)
         best = None
         for (ox, oy, os_, od, onet, obulges) in self._rows[lo:hi]:
             dist = math.hypot(ox - x, oy - y)
-            if onet == net_id and dist <= atol:
+            if (onet == net_id
+                    and abs(ox - x) <= ahx and abs(oy - y) <= ahy):
                 return 'twin', (ox, oy, os_, od)
             if dist <= self._tol:
                 return 'conflict', ("two nets would share one hole", ox, oy)

--- a/py_router/bga_fanout/geometry.py
+++ b/py_router/bga_fanout/geometry.py
@@ -5,10 +5,12 @@ Functions for calculating 45-degree stubs, exit points, and jog endpoints.
 """
 from __future__ import annotations
 
+import bisect
 import math
 from typing import List, Tuple, Optional, Dict
 
 from bga_fanout.types import BGAGrid, Channel
+from bga_fanout.constants import POSITION_TOLERANCE
 
 # Reference prefixes place_fanout_clearance treats as movable passives (keep in
 # sync with its --cap-prefix default): an unlocked <=2-copper-pad part with one
@@ -291,3 +293,163 @@ def calculate_jog_end(exit_pos: Tuple[float, float],
                    round(jog_end[1] / grid_step) * grid_step)
 
     return jog_end, extension_point
+
+
+# --- #620: the run's own output, testable against itself ---------------------
+
+class PendingVias:
+    """The via-in-pads ONE ``manage_vias`` call has already committed.
+
+    Everything else in that function tests a candidate against the INPUT board:
+    ``would_overlap_existing_via`` and ``via_in_pad_conflict`` both iterate
+    ``pcb_data.vias``, and ``vias_to_add`` was appended to and never read back.
+    So two vias placed in one call were spaced against the board and against
+    nothing else. This is the missing half.
+
+    WHAT IS TESTED, AND WHY IT IS NOT SYMMETRIC (measured, not assumed):
+
+    * **The drill, always.** The balls are SMD and carry no hole, so every hole
+      in the neighbourhood is one this pass is creating. A drill pair too close
+      is never a condition the board shipped.
+    * **The ring, only when a via BULGES past its pad.** ``clamp_via_to_pad``
+      shrinks a via-in-pad into its ball pad first, and a via that fits inside
+      its pad occupies no copper the pad did not already occupy -- so a ring
+      test on such a pair only restates the board's own ball-to-ball spacing,
+      and rejects escapes over a condition neither the fab nor ``check_drc``
+      would attribute to the fanout. When the pad is smaller than the deepest
+      fab rung's via, the clamp gives up and holds the floor via (status
+      ``'floor'``, which the pass already warns about because it "still bulges
+      past the pad edge"). That one really does add copper, and is tested.
+
+      Swept over all 6565 physical (pitch, pad) combinations at clearances
+      0.10 / 0.15 / 0.20 / 0.25 / 0.30: of the pairs a ring test would reject
+      and the drill test would not, the ones whose own pads are NOT already
+      sub-clearance number 0 / 90 / 155 / 195 / 210 -- and **every one of them
+      is a bulging via** (clamp status ``'floor'``, 100% at every clearance).
+      That measurement is what the split above is for; an earlier draft of this
+      class tested the drill only and justified it with a claim -- "a clamped
+      via never adds copper" -- that is true of the clamp and false of the
+      floor case it silently included.
+
+    The ring arm is foreign-net only: same-net copper in contact is not a
+    clearance violation. (``would_overlap_existing_via``'s board-facing test is
+    net-BLIND; that is pre-existing and deliberately not changed here.)
+
+    Scalar ``math.hypot`` with a sorted-by-x broad phase, deliberately NOT
+    numpy: numpy's hypot is not CPython's Neumaier-compensated one and the two
+    disagree by 1 ULP on ~17% of off-grid inputs, each disagreement feeding a
+    ``dist < floor`` comparison -- the finding that closed #786/#787. The broad
+    phase is also simply faster at this size (2.0 ms vs 12.8 ms vectorised on
+    the largest in-repo BGA, 529 balls).
+    """
+
+    __slots__ = ('_h2h', '_clearance', '_tol', '_xs', '_rows', '_max_drill',
+                 '_max_size')
+
+    def __init__(self, hole_to_hole: float, clearance: float,
+                 site_tol: float = None):
+        self._h2h = hole_to_hole
+        self._clearance = clearance
+        self._tol = POSITION_TOLERANCE if site_tol is None else site_tol
+        self._xs: List[float] = []      # sorted, parallel to _rows
+        self._rows: List[Tuple] = []    # (x, y, size, drill, net_id, bulges)
+        self._max_drill = 0.0
+        self._max_size = 0.0
+
+    def __len__(self):
+        return len(self._xs)
+
+    def add(self, x, y, size, drill, net_id, bulges=False):
+        """Record a via this call has committed."""
+        d = drill or 0.0
+        s = size or 0.0
+        i = bisect.bisect_left(self._xs, x)
+        self._xs.insert(i, x)
+        self._rows.insert(i, (x, y, s, d, net_id, bool(bulges)))
+        if d > self._max_drill:
+            self._max_drill = d
+        if s > self._max_size:
+            self._max_size = s
+
+    def verdict(self, x, y, size, drill, net_id, bulges=False, tol=1e-6):
+        """How a candidate at (x, y) relates to what this call already placed.
+
+        Returns ``(verdict, detail)``:
+
+        ``('clear', None)``
+            nothing committed so far is in the way.
+        ``('twin', (x, y))``
+            the SAME net already has a via at this exact site. The two routes
+            want ONE physical hole, not two -- an exposed pad modelled as an
+            F.Cu + B.Cu pair puts two routes at one coordinate (5 of this
+            repo's 22 boards do it; ``interf_u`` BUS1 has 31 such sites on one
+            component). Distance 0 is below every threshold, so a plain spacing
+            test makes twins refuse each other and takes their net with them,
+            while the honest answer -- one via serving both routes -- is
+            strictly better than today's, which appends a second identical dict
+            that the writer emits as a second ``(via ...)`` at the same point.
+        ``('conflict', (reason, x, y))``
+            that via is closer than a floor allows. A DIFFERENT net at the same
+            site lands here, not in ``'twin'``: two nets sharing one hole is a
+            short, and no rung can ever clear distance 0.
+        """
+        d = drill or 0.0
+        s = size or 0.0
+        # Broad phase: nothing outside this x-window can be within either floor
+        # of the candidate, whatever its y.
+        window = max(d / 2.0 + self._max_drill / 2.0 + self._h2h,
+                     s / 2.0 + self._max_size / 2.0 + self._clearance)
+        lo = bisect.bisect_left(self._xs, x - window)
+        hi = bisect.bisect_right(self._xs, x + window)
+        best = None
+        for (ox, oy, os_, od, onet, obulges) in self._rows[lo:hi]:
+            dist = math.hypot(ox - x, oy - y)
+            if dist <= self._tol:
+                if onet == net_id:
+                    return 'twin', (ox, oy)
+                return 'conflict', ("two nets would share one hole", ox, oy)
+            need = d / 2.0 + od / 2.0 + self._h2h
+            if dist < need - tol:
+                if best is None or dist < best[0]:
+                    best = (dist, "drill hole-to-hole vs this run's own via",
+                            ox, oy)
+                continue
+            if (bulges or obulges) and onet != net_id:
+                ring = s / 2.0 + os_ / 2.0 + self._clearance
+                if dist < ring - tol and (best is None or dist < best[0]):
+                    best = (dist, "via ring vs this run's own via (one held "
+                            "at the fab floor bulges past its pad)", ox, oy)
+        if best is not None:
+            return 'conflict', (best[1], best[2], best[3])
+        return 'clear', None
+
+
+def thin_drill_to_clear(drill, floors, rung, clears):
+    """The second rung ``manage_vias`` never had (#620).
+
+    A refusal there DROPS the escape -- there is no re-sweep -- so a spacing
+    rule that can only refuse turns escaped balls into failed nets. Before
+    refusing, descend the fab ladder's drill floors: a thinner drill inside an
+    unchanged ring is more manufacturable in every dimension but the drill, so
+    what is being spent is fab tier, which is what ``warn_fab_escalation``
+    exists to disclose.
+
+    ``clears(candidate_drill)`` is the caller's predicate. Returns the largest
+    drill that clears, or ``None`` if no rung does.
+
+    **A ``--fab-overrides`` run has no ladder to descend.** ``fab_floor_ladder``
+    collapses to ONE hard rung when an override file is supplied, by design:
+    the file states the user's exact fab limits, so there is no deeper tier to
+    escalate into. Such a run refuses instead -- the honest answer to a declared
+    fab that cannot drill these holes at this pitch. It is also why the
+    contributor who first built this fix measured it as pure loss: their arm
+    raised ``via_drill`` to 0.35 through an override file, which both makes the
+    floor unmeetable at 0.5 mm pitch AND removes every rung that could rescue
+    it.
+    """
+    cands = sorted({f['via_drill'] for f in floors[rung:]
+                    if f['via_drill'] < drill - 1e-9}, reverse=True)
+    for cand in cands:
+        if clears(cand):
+            return cand
+    return None

--- a/py_router/bga_fanout/geometry.py
+++ b/py_router/bga_fanout/geometry.py
@@ -306,30 +306,50 @@ class PendingVias:
     So two vias placed in one call were spaced against the board and against
     nothing else. This is the missing half.
 
-    WHAT IS TESTED, AND WHY IT IS NOT SYMMETRIC (measured, not assumed):
+    WHAT IS TESTED, AND WHY IT IS NOT SYMMETRIC:
 
     * **The drill, always.** The balls are SMD and carry no hole, so every hole
-      in the neighbourhood is one this pass is creating. A drill pair too close
-      is never a condition the board shipped.
-    * **The ring, only when a via BULGES past its pad.** ``clamp_via_to_pad``
-      shrinks a via-in-pad into its ball pad first, and a via that fits inside
-      its pad occupies no copper the pad did not already occupy -- so a ring
-      test on such a pair only restates the board's own ball-to-ball spacing,
-      and rejects escapes over a condition neither the fab nor ``check_drc``
-      would attribute to the fanout. When the pad is smaller than the deepest
-      fab rung's via, the clamp gives up and holds the floor via (status
-      ``'floor'``, which the pass already warns about because it "still bulges
-      past the pad edge"). That one really does add copper, and is tested.
+      in the neighbourhood is one this pass is creating: a drill pair too close
+      is never a condition the board shipped. It is also the arm with a LEVER --
+      a thinner drill can cure it (``thin_drill_to_clear``), and a hole pair
+      below the fab floor is not a DRC opinion but an unbuildable board.
+    * **The ring, only when a via BULGES past its pad** (clamp status
+      ``'floor'``: the ball pad is smaller than the deepest fab rung's via, so
+      ``clamp_via_to_pad`` gives up and holds the floor, which the pass already
+      warns "still bulges past the pad edge").
 
-      Swept over all 6565 physical (pitch, pad) combinations at clearances
-      0.10 / 0.15 / 0.20 / 0.25 / 0.30: of the pairs a ring test would reject
-      and the drill test would not, the ones whose own pads are NOT already
-      sub-clearance number 0 / 90 / 155 / 195 / 210 -- and **every one of them
-      is a bulging via** (clamp status ``'floor'``, 100% at every clearance).
-      That measurement is what the split above is for; an earlier draft of this
-      class tested the drill only and justified it with a claim -- "a clamped
-      via never adds copper" -- that is true of the clamp and false of the
-      floor case it silently included.
+      The reason is NOT that a fitting via's ring is free. Two things are true
+      at once and only the second is a justification:
+
+        - Ring-to-ring spacing for a via clamped into its pad EQUALS the
+          footprint's own pad-to-pad spacing, because both features sit at ball
+          centres and the via is no wider than the pad. So the fanout is asking
+          the fab for an etch pitch the footprint already demands. A bulging via
+          asks for a TIGHTER one, which the board's own geometry does not
+          demonstrate is achievable. That is the line the split is drawn on.
+        - It is NOT true that a fitting via adds no copper. A ball pad is
+          ``['F.Cu']``; the via spans F.Cu to B.Cu. On the inner layers and
+          B.Cu there is no pad under the ring at all, so at the same spacing
+          the copper IS new, and ``check_drc``'s VIA-VIA arm can legitimately
+          flag it. An earlier draft of this docstring called such a pair
+          "phantom" on the strength of the F.Cu picture, and an adversarial
+          review was right to refuse that.
+
+      There is also no lever on this arm: a via-in-pad site is the ball centre
+      by definition, and a bulging via is already at the deepest fab rung, so
+      neither moving nor shrinking is available. Refusing removes an escape and
+      nothing else. That is why the arm is narrow and why it is disclosed.
+
+      AN EARLIER DRAFT CITED A SWEEP HERE -- "of the ring-only rejections whose
+      pads are not already sub-clearance, 100% are bulging vias, at every
+      clearance" -- and presented it as the measurement the scope rested on.
+      **It is a tautology**, and is recorded here so nobody re-derives it and
+      believes it: a ring-only rejection needs ``pitch < via + clearance``, and
+      "pads not already sub-clearance" is ``pitch >= pad + clearance``; together
+      those give ``pad < via``, which IS the bulge condition. It holds for any
+      clamp function whatsoever. ``tests/test_620_pending_via_pairs.py`` now
+      pins it AS an identity, and measures the thing that is actually
+      contingent: what a bulge-blind ring arm would additionally reject.
 
     The ring arm is foreign-net only: same-net copper in contact is not a
     clearance violation. (``would_overlap_existing_via``'s board-facing test is
@@ -359,6 +379,31 @@ class PendingVias:
     def __len__(self):
         return len(self._xs)
 
+    def tighten(self, x, y, size, drill):
+        """Shrink the via recorded at (x, y) to `size`/`drill`.
+
+        The twin merge keeps ONE via for two routes, and which one it keeps was
+        whichever arrived first -- so two coincident same-net pads of 0.25 and
+        0.60 gave a 0.45 via when the big pad went first, bulging past the
+        small pad and re-creating exactly the #202 violation
+        ``clamp_via_to_pad`` exists to prevent. An adversarial review found it.
+        The surviving via must be the TIGHTER pad's clamp, so the caller
+        tightens on a twin hit. Returns True if anything changed.
+
+        `_max_drill`/`_max_size` are deliberately NOT lowered here: they only
+        size the broad-phase window, and leaving them high makes the window
+        wider than needed, which cannot miss a conflict. Recomputing them would
+        be the only way to make them wrong.
+        """
+        for i, (ox, oy, os_, od, onet, ob) in enumerate(self._rows):
+            if ox == x and oy == y:
+                if size < os_ - 1e-12 or drill < od - 1e-12:
+                    self._rows[i] = (ox, oy, min(size, os_), min(drill, od),
+                                     onet, ob)
+                    return True
+                return False
+        return False
+
     def add(self, x, y, size, drill, net_id, bulges=False):
         """Record a via this call has committed."""
         d = drill or 0.0
@@ -371,23 +416,37 @@ class PendingVias:
         if s > self._max_size:
             self._max_size = s
 
-    def verdict(self, x, y, size, drill, net_id, bulges=False, tol=1e-6):
+    def verdict(self, x, y, size, drill, net_id, bulges=False, tol=1e-6,
+                anchor_tol=None):
         """How a candidate at (x, y) relates to what this call already placed.
+
+        ``anchor_tol`` is the candidate BALL's own anchor radius -- the same
+        ``max(size_x, size_y) / 2 + 0.01`` the downstream ball-anchor test
+        (``_has_copper``) uses to decide whether a via connects a ball. Default
+        ``site_tol`` (1 um) if not given.
 
         Returns ``(verdict, detail)``:
 
         ``('clear', None)``
             nothing committed so far is in the way.
-        ``('twin', (x, y))``
-            the SAME net already has a via at this exact site. The two routes
-            want ONE physical hole, not two -- an exposed pad modelled as an
-            F.Cu + B.Cu pair puts two routes at one coordinate (5 of this
-            repo's 22 boards do it; ``interf_u`` BUS1 has 31 such sites on one
-            component). Distance 0 is below every threshold, so a plain spacing
-            test makes twins refuse each other and takes their net with them,
-            while the honest answer -- one via serving both routes -- is
-            strictly better than today's, which appends a second identical dict
-            that the writer emits as a second ``(via ...)`` at the same point.
+        ``('twin', (x, y, size, drill))``
+            the SAME net already has a via INSIDE this ball's pad, so that via
+            already connects this ball and a second hole would buy nothing. Two
+            routes, one physical hole. An exposed pad modelled as an F.Cu +
+            B.Cu pair puts two routes at one coordinate (5 of this repo's 22
+            boards do it; ``interf_u`` BUS1 has 31 such sites on one
+            component), and distance 0 is below every threshold, so a plain
+            spacing test makes twins refuse each other and takes their net with
+            them -- while one via serving both routes is strictly better than
+            today's, which appends a second identical dict that the writer
+            emits as a second ``(via ...)`` at the same point.
+
+            KEYED ON THE ANCHOR RADIUS, NOT ON AN EXACT MATCH. An exact-match
+            rule has a 1 um cliff: an adversarial review found same-net sites
+            0.0010mm apart merging into one via while 0.0011mm apart DROPPED an
+            escape outright, because no fab rung can space two holes 1.1 um
+            apart. Anything inside the ball's own pad is a via that anchors it,
+            which is the question actually being asked.
         ``('conflict', (reason, x, y))``
             that via is closer than a floor allows. A DIFFERENT net at the same
             site lands here, not in ``'twin'``: two nets sharing one hole is a
@@ -395,18 +454,21 @@ class PendingVias:
         """
         d = drill or 0.0
         s = size or 0.0
+        atol = self._tol if anchor_tol is None else max(anchor_tol, self._tol)
         # Broad phase: nothing outside this x-window can be within either floor
-        # of the candidate, whatever its y.
+        # of the candidate, whatever its y. `atol` is in it because a twin can
+        # sit further out than either floor when the pad is large.
         window = max(d / 2.0 + self._max_drill / 2.0 + self._h2h,
-                     s / 2.0 + self._max_size / 2.0 + self._clearance)
+                     s / 2.0 + self._max_size / 2.0 + self._clearance,
+                     atol)
         lo = bisect.bisect_left(self._xs, x - window)
         hi = bisect.bisect_right(self._xs, x + window)
         best = None
         for (ox, oy, os_, od, onet, obulges) in self._rows[lo:hi]:
             dist = math.hypot(ox - x, oy - y)
+            if onet == net_id and dist <= atol:
+                return 'twin', (ox, oy, os_, od)
             if dist <= self._tol:
-                if onet == net_id:
-                    return 'twin', (ox, oy)
                 return 'conflict', ("two nets would share one hole", ox, oy)
             need = d / 2.0 + od / 2.0 + self._h2h
             if dist < need - tol:

--- a/py_router/bga_fanout/underpad.py
+++ b/py_router/bga_fanout/underpad.py
@@ -754,6 +754,13 @@ def generate_underpad_escape(footprint: Footprint,
     _copper = len(getattr(pcb_data.board_info, 'copper_layers', None) or []) or 4
     floors = fab_floor_ladder(_copper)
     clamp_stats = {'clamped': 0, 'floor': 0, 'escalated': 0}
+    # #618's policy answer: DISCLOSE. Sites this engine declines to put a
+    # via-in-pad on because their hole is inside the hole-to-hole floor --
+    # 'sites' for the single-ended centre fallback, 'coupled' for a diff pair.
+    # Refuse-to-build was measured and rejected: on ulx3s U1, honouring a
+    # declared 0.9mm floor costs 15 of 199 escapes, so refusing the RUN would
+    # throw away 184 good ones to prevent 62 bad holes.
+    h2h_stats = {'sites': 0, 'coupled': 0}
 
     # DRILL FLOOR, board-first and raise-only. `_via_site_conflict` below spaced
     # every drill it places at the flat routing_defaults.HOLE_TO_HOLE_CLEARANCE
@@ -1566,6 +1573,74 @@ def generate_underpad_escape(footprint: Footprint,
             half = via_size / 2.0
         return via_site_ok(vx, vy, half)
 
+    def _via_site_geom(pad):
+        """(x, y, size, drill) for the escape via this ball would get.
+
+        Pure: uses `clamp_via_to_pad` directly rather than `via_for_pad`, whose
+        `clamp_stats` side effect would count vias that are only being
+        CONSIDERED.
+        """
+        vx, vy = _via_spot(pad, True)
+        if (vx, vy) == (pad.global_x, pad.global_y):
+            cs, cd, _st, _r = clamp_via_to_pad(via_size, via_drill, pad, floors)
+        else:
+            cs, cd = via_size, via_drill
+        return vx, vy, cs, cd
+
+    def _coupled_via_sites_ok(pp, nn):
+        """#618: gate the COUPLED escape's two via-in-pads the way every other
+        via site in this engine is gated.
+
+        `_drop_escape_via` emits a via-in-pad at each ball centre, and its two
+        callers gated that on `_via_gate_ok` alone -- the locked-SMD copper
+        check -- and only when the board HAS locked SMD pads. So on an ordinary
+        board the coupled pair's vias went in with no `_via_site_conflict` at
+        all: not against the board's drills, not against this run's committed
+        vias, and not against each other. Every other via site in this file
+        goes through `_via_site_conflict` (`_site_ok`, and the centre-site
+        fallback #567 closed at the plane-drop path); this one did not, which
+        is the structurally live remainder of #618 -- the issue's other three
+        clauses were closed by #567 and #756.
+
+        `skip_resv=True` for the same reason #567 gives at its own call site:
+        these sites ARE the mutual centre reservation, so including `resv`
+        would make each ball veto itself.
+
+        THE PAIR IS ALSO TESTED AGAINST ITSELF, which `_via_site_conflict`
+        cannot do: neither via is in `vias_to_add` when the decision is made,
+        so `_via_ctx` cannot see the sibling. DRILL ONLY, on the reasoning
+        `PendingVias` sets out for the channel engine: both balls are SMD and
+        carry no hole, so both holes are ones this pass creates, and a drill
+        pair inside the floor is an unbuildable board rather than a DRC
+        opinion. The RING between the pair is left alone because a via clamped
+        into its pad asks the fab for the etch pitch the footprint already
+        demands, and because there is no lever -- a via-in-pad site IS the ball
+        centre, so refusing buys a lost escape and nothing else. It is NOT
+        because the copper is already there: a ball pad is one layer and the
+        via spans all of them.
+
+        Drill hole-to-hole is net-independent (#282), which is what makes it
+        the right test for a P/N pair.
+        """
+        if locked_smd_pads and not all(_via_gate_ok(q) for q in (pp, nn)):
+            return False           # a through via would hit locked copper
+        sites = [_via_site_geom(q) for q in (pp, nn)]
+        for pad, (vx, vy, cs, cd) in zip((pp, nn), sites):
+            ctx = _via_ctx(pad.net_id, vx, vy)
+            why = _via_site_conflict(vx, vy, pad.net_id, ctx, vr=cs / 2.0,
+                                     vdr=(cd or 0.0) / 2.0, skip_resv=True)
+            if why is not None:
+                if why.startswith('drill hole'):
+                    h2h_stats['coupled'] += 1
+                return False
+        (ax, ay, _as, ad), (bx, by, _bs, bd) = sites
+        if math.hypot(ax - bx, ay - by) < ((ad or 0.0) / 2.0
+                                           + (bd or 0.0) / 2.0
+                                           + _h2h - 1e-6):
+            h2h_stats['coupled'] += 1
+            return False           # the pair's own two holes, #620's shape
+        return True
+
     def _drop_escape_via(pad):
         """Emit this ball's escape via -- at its dog-bone site (plus the
         pad->via stub, whose corridor was stamped at reservation) when
@@ -1648,9 +1723,11 @@ def generate_underpad_escape(footprint: Footprint,
             if De <= Lc + 0.01:
                 continue
             for L, use_via in candidates:
-                if use_via and locked_smd_pads and not all(
-                        _via_gate_ok(q) for q in (pp, nn)):
-                    continue  # a through via would hit locked copper
+                # #618: locked copper, or a via site conflicting with the
+                # board, with this run's own committed copper, or with the
+                # pair's own sibling hole.
+                if use_via and not _coupled_via_sites_ok(pp, nn):
+                    continue
                 segs = []
                 ok = True
                 for pad, side in ((pp, 1.0), (nn, -1.0)):
@@ -1742,9 +1819,11 @@ def generate_underpad_escape(footprint: Footprint,
                 return (mx + along * ex + off * px, my + along * ey + off * py)
 
             for L, use_via in candidates:
-                if use_via and locked_smd_pads and not all(
-                        _via_gate_ok(q) for q in (pp, nn)):
-                    continue  # a through via would hit locked copper
+                # #618: locked copper, or a via site conflicting with the
+                # board, with this run's own committed copper, or with the
+                # pair's own sibling hole.
+                if use_via and not _coupled_via_sites_ok(pp, nn):
+                    continue
                 for tside in (1.0, -1.0):         # which gap the trail bulges through
                     lside = -tside
                     lead_segs = [(_via_spot(lead, use_via), pt(De - run, lside * half_sp)),
@@ -2184,9 +2263,17 @@ def generate_underpad_escape(footprint: Footprint,
                 key = ('c', round(x, 6), round(y, 6))
                 ok = _m.get(key)
                 if ok is None:
-                    ok = _via_site_conflict(x, y, _nid, _c, vr=_cs / 2.0,
-                                            vdr=(_cd or 0.0) / 2.0,
-                                            skip_resv=True) is None
+                    _why = _via_site_conflict(x, y, _nid, _c, vr=_cs / 2.0,
+                                              vdr=(_cd or 0.0) / 2.0,
+                                              skip_resv=True)
+                    ok = _why is None
+                    # #618 asks for a policy on via-in-pad sites the
+                    # hole-to-hole floor refuses -- skip, warn, or fail. This
+                    # is the WARN answer. Counted on the cache MISS so each
+                    # distinct site counts once. It changes no decision; it
+                    # makes one visible that the operator could not see.
+                    if _why is not None and _why.startswith('drill hole'):
+                        h2h_stats['sites'] += 1
                     _m[key] = ok
                 return ok
             key = (round(x, 6), round(y, 6))
@@ -2515,6 +2602,17 @@ def generate_underpad_escape(footprint: Footprint,
             print(f"  Under-pad: WARNING {clamp_stats['floor']} pad(s) smaller than "
                   f"the fab via floor ({fab_floor_min(_copper)['via_diameter']:.2f}mm "
                   f"dia); via held at the floor and still bulges past the pad edge")
+        # #618: the hole-to-hole floor's cost, disclosed. Refusing these sites
+        # is not new (the floor has been enforced since #756); being able to
+        # SEE that the floor is what refused them is. Balls that lose their
+        # via-in-pad here fall to the checked off-centre search, and only fail
+        # to the main router if that finds nothing either.
+        if h2h_stats['sites'] or h2h_stats['coupled']:
+            print(f"  Under-pad: {h2h_stats['sites']} via-in-pad centre site(s)"
+                  f" and {h2h_stats['coupled']} coupled pair(s) declined by the"
+                  f" {_h2h:g}mm hole-to-hole floor ({_h2h_src}); the levers are"
+                  f" a smaller --via-drill, a fab tier whose floor this pitch"
+                  f" can meet, or the board's own min_hole_to_hole")
     # The FAB requirement under-pad escape creates (#489 §8): via-in-pad needs
     # IPC-4761 Type VII. Emitted from the shared engine so both fronts report it.
     from fab_notes import print_via_in_pad_note

--- a/py_router/bga_fanout/underpad.py
+++ b/py_router/bga_fanout/underpad.py
@@ -760,7 +760,7 @@ def generate_underpad_escape(footprint: Footprint,
     # Refuse-to-build was measured and rejected: on ulx3s U1, honouring a
     # declared 0.9mm floor costs 15 of 199 escapes, so refusing the RUN would
     # throw away 184 good ones to prevent 62 bad holes.
-    h2h_stats = {'sites': 0, 'coupled': 0}
+    h2h_stats = {'sites': 0, 'coupled_pairs': set()}
 
     # DRILL FLOOR, board-first and raise-only. `_via_site_conflict` below spaced
     # every drill it places at the flat routing_defaults.HOLE_TO_HOLE_CLEARANCE
@@ -1624,6 +1624,14 @@ def generate_underpad_escape(footprint: Footprint,
         """
         if locked_smd_pads and not all(_via_gate_ok(q) for q in (pp, nn)):
             return False           # a through via would hit locked copper
+
+        # COUNT PAIRS, NOT CALLS. This gate runs inside `strict x direction x
+        # candidate` loops from two templates and is not memoised, so a bare
+        # `+= 1` reported "8 coupled pair(s) declined" on a board with ONE
+        # coupled pair (16 calls for it). An adversarial review measured that.
+        # The `sites` counter is fine -- its caller memoises per ball centre.
+        _pair_key = tuple(sorted((id(pp), id(nn))))
+
         sites = [_via_site_geom(q) for q in (pp, nn)]
         for pad, (vx, vy, cs, cd) in zip((pp, nn), sites):
             ctx = _via_ctx(pad.net_id, vx, vy)
@@ -1631,13 +1639,13 @@ def generate_underpad_escape(footprint: Footprint,
                                      vdr=(cd or 0.0) / 2.0, skip_resv=True)
             if why is not None:
                 if why.startswith('drill hole'):
-                    h2h_stats['coupled'] += 1
+                    h2h_stats['coupled_pairs'].add(_pair_key)
                 return False
         (ax, ay, _as, ad), (bx, by, _bs, bd) = sites
         if math.hypot(ax - bx, ay - by) < ((ad or 0.0) / 2.0
                                            + (bd or 0.0) / 2.0
                                            + _h2h - 1e-6):
-            h2h_stats['coupled'] += 1
+            h2h_stats['coupled_pairs'].add(_pair_key)
             return False           # the pair's own two holes, #620's shape
         return True
 
@@ -2607,9 +2615,10 @@ def generate_underpad_escape(footprint: Footprint,
         # SEE that the floor is what refused them is. Balls that lose their
         # via-in-pad here fall to the checked off-centre search, and only fail
         # to the main router if that finds nothing either.
-        if h2h_stats['sites'] or h2h_stats['coupled']:
+        _n_coupled_declined = len(h2h_stats['coupled_pairs'])
+        if h2h_stats['sites'] or _n_coupled_declined:
             print(f"  Under-pad: {h2h_stats['sites']} via-in-pad centre site(s)"
-                  f" and {h2h_stats['coupled']} coupled pair(s) declined by the"
+                  f" and {_n_coupled_declined} coupled pair(s) declined by the"
                   f" {_h2h:g}mm hole-to-hole floor ({_h2h_src}); the levers are"
                   f" a smaller --via-drill, a fab tier whose floor this pitch"
                   f" can meet, or the board's own min_hole_to_hole")

--- a/tests/mutate_620.py
+++ b/tests/mutate_620.py
@@ -279,13 +279,24 @@ ROWS = [
      '        sites = [_via_site_geom(q) for q in (pp, nn)]',
      (T618,), 'KILLED'),
 
+    # EXPECTED SURVIVOR, and the reason is worth more than the row.
+    # `_via_site_conflict` has two domains: the board's own copper, and the
+    # vias THIS RUN has already committed (`_via_ctx` folds `vias_to_add` in).
+    # The first is already covered by the occupancy grid, which is built from
+    # the board before any escape runs -- measured: planting a foreign via on
+    # the exact coordinate a coupled escape chooses still keeps every emitted
+    # via clear of it with this check disabled, so the mutation changes
+    # nothing observable. The second domain is the one only this check covers,
+    # and no in-repo board reaches it: the only rigs that couple are 0.8mm
+    # pitch, where a committed via is 0.4mm clear of the floor. So the row is
+    # a measured no-op HERE and load-bearing in general. Recorded, not deleted.
     ('coupled-gate-skips-the-site-conflict', 'up',
      '            if why is not None:\n'
      "                if why.startswith('drill hole'):\n"
      "                    h2h_stats['coupled'] += 1\n"
      '                return False',
      '            if False:\n                return False',
-     (T618,), 'KILLED'),
+     (T618,), 'SURVIVED'),
 
     # I recorded this as an expected SURVIVOR, reasoning that the only in-repo
     # rigs are 0.8mm-pitch parts whose pair clears by 0.4mm. The battery

--- a/tests/mutate_620.py
+++ b/tests/mutate_620.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""The #620/#618 mutation battery, shipped so its numbers can be re-derived.
+
+`tests/test_620_pending_via_pairs.py` and `tests/test_618_coupled_via_site_gate.py`
+record what each arm kills. A count is only checkable if the exact source edit
+is written down -- two reviewers of an earlier branch reconstructed rows from
+their names and both got the wrong answer, because a plausible-looking
+reconstruction of one row was semantically inert. So the edits live here, as
+data, next to the numbers they produced.
+
+Every row carries an EXPECTATION. An inert row recorded as an expected survivor
+is a finding; an inert row quietly deleted is a hole.
+
+THREE targets: the pair test and ladder in `bga_fanout/geometry.py`, their
+wiring in `bga_fanout/__init__.py`, and #618's coupled-escape gate in
+`bga_fanout/underpad.py`.
+
+THE ROWS TO LOOK AT FIRST if this file ever goes red are the four broad-phase
+ones. An adversarial review found that the differential test named
+`window = max(d + self._h2h,` in its own docstring and could not kill it: the
+parameter grid never made the drill term binding, so half the window could be
+corrupted freely. `broad-phase-window-drops-the-halving` is that exact
+mutation, and it is why the grid now sweeps floors of zero and drills that
+exceed every ring.
+
+THIS RUNNER IS A COPY of `mutate_756.py`'s (itself the fourth). Deliberately
+not refactored into a shared one: that would rewrite shipped batteries whose
+recorded counts are the evidence for merged reviews, which is a change to make
+on its own and not inside a fix.
+
+NOT named `test_*.py`, so `tests/run_all.py` does not collect it: it REWRITES
+the engine in place. One writer per tree -- do not run it while a suite, an A/B
+replay or a review is reading the same checkout. It refuses to start on a dirty
+engine, because restoring would write the COMMITTED text back over uncommitted
+work.
+
+    python3 tests/mutate_620.py
+    python3 tests/mutate_620.py --row twin-branch-refuses-instead
+
+A row is KILLED by a FAILURE **or an ERROR**: dropping a term makes some arms
+raise rather than fail, and a battery counting only failures would call that a
+survivor.
+
+An anchor that does not match EXACTLY ONCE is reported as BROKEN rather than
+skipped -- a battery that silently applies nothing reports every row as a
+survivor, which reads as a catastrophic test failure and is really a stale
+anchor.
+
+ANCHORS ARE WRITTEN WITH LF AND TRANSLATED TO THE TARGET'S OWN ENDING. All
+three targets are LF in git (`.gitattributes` has `*.py text eol=lf`), so from
+a clean checkout the translation is a no-op. It is here because a WORKING TREE
+can still be CRLF -- any edit written through Python's text mode on Windows
+converts the whole file, which happened twice while building this branch.
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import subprocess
+import sys
+
+_TESTS = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_TESTS)
+
+GEO = os.path.join(_ROOT, 'py_router', 'bga_fanout', 'geometry.py')
+BGA = os.path.join(_ROOT, 'py_router', 'bga_fanout', '__init__.py')
+UP = os.path.join(_ROOT, 'py_router', 'bga_fanout', 'underpad.py')
+TARGETS = {'geo': GEO, 'bga': BGA, 'up': UP}
+
+T620 = os.path.join(_TESTS, 'test_620_pending_via_pairs.py')
+T618 = os.path.join(_TESTS, 'test_618_coupled_via_site_gate.py')
+T370 = os.path.join(_TESTS, 'test_370_tierb_fixes.py')
+T756 = os.path.join(_TESTS, 'test_756_fanout_clearance_drill_floors.py')
+
+_WINDOW = ("        window = max(d / 2.0 + self._max_drill / 2.0 + self._h2h,\n"
+           "                     s / 2.0 + self._max_size / 2.0 + "
+           "self._clearance,\n"
+           "                     atol)")
+
+# (name, target, old, new, tests, expect)
+ROWS = [
+    # --- the defect itself: the pair test ----------------------------------
+    ('pair-test-never-consulted', 'bga',
+     '                _v, _detail = _pending.verdict(pad_x, pad_y, v_size, '
+     'v_drill,\n'
+     '                                               route.net_id, _bulges,\n'
+     '                                               anchor_tol=_atol)',
+     "                _v, _detail = 'clear', None",
+     (T620,), 'KILLED'),
+
+    ('verdict-always-clear', 'geo',
+     '        d = drill or 0.0\n        s = size or 0.0\n'
+     '        atol = self._tol if anchor_tol is None else max(anchor_tol, '
+     'self._tol)',
+     "        return 'clear', None\n"
+     '        d = drill or 0.0\n        s = size or 0.0\n'
+     '        atol = self._tol if anchor_tol is None else max(anchor_tol, '
+     'self._tol)',
+     (T620,), 'KILLED'),
+
+    ('pending-never-records-the-committed-via', 'bga',
+     '                _pending.add(pad_x, pad_y, v_size, v_drill, '
+     'route.net_id,\n                             _bulges)',
+     '                pass',
+     (T620,), 'KILLED'),
+
+    # --- the DRILL arm ------------------------------------------------------
+    ('drill-arm-deleted', 'geo',
+     '            need = d / 2.0 + od / 2.0 + self._h2h',
+     '            need = 0.0',
+     (T620,), 'KILLED'),
+
+    ('drill-arm-drops-the-floor', 'geo',
+     '            need = d / 2.0 + od / 2.0 + self._h2h',
+     '            need = d / 2.0 + od / 2.0',
+     (T620,), 'KILLED'),
+
+    ('drill-arm-reads-the-FAB-floor-not-the-boards', 'bga',
+     '    _pending = PendingVias(_h2h, clearance)',
+     '    _pending = PendingVias(_h2h_fab, clearance)',
+     (T620,), 'KILLED'),
+
+    # --- the RING arm and its bulge condition -------------------------------
+    ('ring-arm-deleted', 'geo',
+     '            if (bulges or obulges) and onet != net_id:',
+     '            if False:',
+     (T620,), 'KILLED'),
+
+    ('ring-arm-ignores-the-bulge', 'geo',
+     '            if (bulges or obulges) and onet != net_id:',
+     '            if onet != net_id:',
+     (T620,), 'KILLED'),
+
+    ('ring-arm-ignores-the-net', 'geo',
+     '            if (bulges or obulges) and onet != net_id:',
+     '            if (bulges or obulges):',
+     (T620,), 'KILLED'),
+
+    ('bulge-flag-hardwired-false', 'bga',
+     "                _bulges = status == 'floor'",
+     '                _bulges = False',
+     (T620,), 'KILLED'),
+
+    ('bulge-flag-hardwired-true', 'bga',
+     "                _bulges = status == 'floor'",
+     '                _bulges = True',
+     (T620,), 'KILLED'),
+
+    # --- THE BROAD PHASE. The rows an earlier test could not kill. ----------
+    ('broad-phase-window-drops-the-halving', 'geo',
+     _WINDOW,
+     '        window = max(d + self._h2h,\n'
+     '                     s / 2.0 + self._max_size / 2.0 + self._clearance,\n'
+     '                     atol)',
+     (T620,), 'KILLED'),
+
+    ('broad-phase-window-drops-the-ring-term', 'geo',
+     _WINDOW,
+     '        window = max(d / 2.0 + self._max_drill / 2.0 + self._h2h,\n'
+     '                     atol)',
+     (T620,), 'KILLED'),
+
+    ('broad-phase-window-drops-the-drill-term', 'geo',
+     _WINDOW,
+     '        window = max(s / 2.0 + self._max_size / 2.0 + self._clearance,\n'
+     '                     atol)',
+     (T620,), 'KILLED'),
+
+    ('broad-phase-window-drops-the-anchor-term', 'geo',
+     _WINDOW,
+     '        window = max(d / 2.0 + self._max_drill / 2.0 + self._h2h,\n'
+     '                     s / 2.0 + self._max_size / 2.0 + self._clearance)',
+     (T620,), 'KILLED'),
+
+    ('broad-phase-max-drill-never-updated', 'geo',
+     '        if d > self._max_drill:\n            self._max_drill = d',
+     '        pass',
+     (T620,), 'KILLED'),
+
+    # --- TWINS --------------------------------------------------------------
+    ('twin-branch-refuses-instead', 'geo',
+     '            if onet == net_id and dist <= atol:\n'
+     "                return 'twin', (ox, oy, os_, od)",
+     '            if onet == net_id and dist <= atol:\n'
+     "                return 'conflict', ('same site', ox, oy)",
+     (T620,), 'KILLED'),
+
+    ('twin-branch-ignores-the-net', 'geo',
+     '            if onet == net_id and dist <= atol:',
+     '            if dist <= atol:',
+     (T620,), 'KILLED'),
+
+    ('twin-keyed-on-the-exact-site-again', 'geo',
+     '            if onet == net_id and dist <= atol:',
+     '            if onet == net_id and dist <= self._tol:',
+     (T620,), 'KILLED'),
+
+    ('twin-appends-a-second-via-anyway', 'bga',
+     "                    _twin_shared += 1\n                    continue",
+     '                    _twin_shared += 1',
+     (T620,), 'KILLED'),
+
+    ('twin-keeps-the-FIRST-via-not-the-tighter', 'bga',
+     '                    if _pending.tighten(_tx, _ty, v_size, v_drill):',
+     '                    if False:',
+     (T620,), 'KILLED'),
+
+    # --- THE LADDER ---------------------------------------------------------
+    ('ladder-never-tried', 'bga',
+     '                    _thin = thin_drill_to_clear(',
+     '                    _thin = None or thin_drill_to_clear(',
+     (T620,), 'SURVIVED'),      # deliberately inert: a no-op control row
+
+    ('ladder-refuses-immediately', 'bga',
+     '                    if _thin is None:',
+     '                    if True:',
+     (T620,), 'KILLED'),
+
+    ('ladder-returns-the-thinnest-rung', 'geo',
+     "    cands = sorted({f['via_drill'] for f in floors[rung:]\n"
+     "                    if f['via_drill'] < drill - 1e-9}, reverse=True)",
+     "    cands = sorted({f['via_drill'] for f in floors[rung:]\n"
+     "                    if f['via_drill'] < drill - 1e-9})",
+     (T620,), 'KILLED'),
+
+    ('ladder-returns-a-rung-that-does-not-clear', 'geo',
+     '    for cand in cands:\n        if clears(cand):\n            return cand',
+     '    for cand in cands:\n        return cand',
+     (T620,), 'KILLED'),
+
+    ('ladder-climbs-above-its-own-rung', 'geo',
+     "    cands = sorted({f['via_drill'] for f in floors[rung:]",
+     "    cands = sorted({f['via_drill'] for f in floors[0:]",
+     (T620,), 'SURVIVED'),      # rung 0 is the top: floors[0:] == floors[rung:]
+                                # whenever the clamp did not escalate, and the
+                                # filter drops anything >= drill. Recorded as a
+                                # measured no-op, not deleted.
+
+    ('thinned-drill-not-applied', 'bga',
+     '                    _thinned.append((v_drill, _thin))\n'
+     '                    v_drill = _thin',
+     '                    _thinned.append((v_drill, _thin))',
+     (T620,), 'KILLED'),
+
+    # --- the second guard's bookkeeping (#620's other half) -----------------
+    ('silent-skip-restored', 'bga',
+     '                if would_overlap_existing_via(pad_x, pad_y, v_size):',
+     '                if False and would_overlap_existing_via(pad_x, pad_y, '
+     'v_size):',
+     (T620,), 'KILLED'),
+
+    # --- the disclosures ----------------------------------------------------
+    ('refusal-disclosure-deleted', 'bga',
+     '        print(f"  WARNING: {len(_pending_refused)} escape(s) dropped: '
+     'this "',
+     '        _unused = (f"  WARNING: {len(_pending_refused)} escape(s) '
+     'dropped: this "',
+     (T620,), 'KILLED'),
+
+    ('thinning-escalation-not-disclosed', 'bga',
+     '        warn_fab_escalation(\n'
+     '            f"{len(_thinned)} via-in-pad drill(s) thinned to {_to}mm to '
+     'hold "',
+     '        _unused = (\n'
+     '            f"{len(_thinned)} via-in-pad drill(s) thinned to {_to}mm to '
+     'hold "',
+     (T620,), 'KILLED'),
+
+    # --- #618: the coupled escape's via sites -------------------------------
+    ('coupled-gate-reverted-to-locked-smd-only', 'up',
+     '                if use_via and not _coupled_via_sites_ok(pp, nn):',
+     '                if use_via and locked_smd_pads and not all(\n'
+     '                        _via_gate_ok(q) for q in (pp, nn)):',
+     (T618,), 'KILLED'),
+
+    ('coupled-gate-skips-the-site-conflict', 'up',
+     '            if why is not None:\n'
+     "                if why.startswith('drill hole'):\n"
+     "                    h2h_stats['coupled'] += 1\n"
+     '                return False',
+     '            if False:\n                return False',
+     (T618,), 'KILLED'),
+
+    ('coupled-pair-not-tested-against-itself', 'up',
+     '        if math.hypot(ax - bx, ay - by) < ((ad or 0.0) / 2.0\n'
+     '                                           + (bd or 0.0) / 2.0\n'
+     '                                           + _h2h - 1e-6):',
+     '        if False:',
+     (T618,), 'SURVIVED'),      # 0.8mm-pitch parts are the only in-repo rigs
+                                # and their pair clears by 0.4mm; recorded as
+                                # measured-uncovered rather than deleted.
+
+    ('h2h-decline-not-disclosed', 'up',
+     '            print(f"  Under-pad: {h2h_stats[\'sites\']} via-in-pad centre '
+     'site(s)"',
+     '            _unused = (f"  Under-pad: {h2h_stats[\'sites\']} via-in-pad '
+     'centre site(s)"',
+     (T618,), 'KILLED'),
+
+    # --- #756's arms must still hold (this branch touches the same file) ----
+    ('bga-via-arm-reverted-to-the-flat-constant', 'bga',
+     '                    + _h2h - 1e-6:',
+     '                    + HOLE_TO_HOLE_CLEARANCE - 1e-6:',
+     (T756, T620), 'KILLED'),
+
+    ('bga-drops-the-fab-wrap', 'bga',
+     '    _h2h = max(_h2h_decl, _h2h_fab)',
+     '    _h2h = _h2h_decl',
+     (T756, T370), 'KILLED'),
+]
+
+
+def _dirty(path):
+    p = subprocess.run(['git', 'status', '--porcelain', '--', path],
+                       capture_output=True, text=True, cwd=_ROOT)
+    return bool(p.stdout.strip())
+
+
+def run(only=None):
+    rows = [r for r in ROWS if only is None or r[0] == only]
+    if not rows:
+        print('no row named %r' % only)
+        return 1
+    for path in TARGETS.values():
+        if _dirty(path):
+            print('REFUSING: %s has uncommitted changes. Commit or stash '
+                  'first -- this battery restores by overwriting.'
+                  % os.path.basename(path))
+            return 2
+
+    orig = {k: io.open(v, encoding='utf-8', newline='').read()
+            for k, v in TARGETS.items()}
+    results = []
+    try:
+        for name, tgt, old, new, tests, expect in rows:
+            path = TARGETS[tgt]
+            base = orig[tgt]
+            edits = old if isinstance(old, list) else [(old, new)]
+            if '\r\n' in base:
+                edits = [(o.replace('\n', '\r\n'), n.replace('\n', '\r\n'))
+                         for o, n in edits]
+            counts = [base.count(o) for o, _n in edits]
+            if counts != [1] * len(edits):
+                results.append((name, 'BROKEN', expect,
+                                'anchors matched %s times' % counts, []))
+                continue
+            mutated = base
+            for o, nw in edits:
+                mutated = mutated.replace(o, nw, 1)
+            io.open(path, 'w', encoding='utf-8', newline='').write(mutated)
+            killed, failed = False, []
+            for t in tests:
+                p = subprocess.run([sys.executable, '-X', 'utf8', t],
+                                   capture_output=True, text=True,
+                                   encoding='utf-8', errors='replace',
+                                   timeout=1800, cwd=_ROOT)
+                out = (p.stderr or '') + (p.stdout or '')
+                if p.returncode:
+                    killed = True
+                failed += ['%s::%s' % (os.path.basename(t)[5:8],
+                                       l.split('(')[0].replace('FAIL: ', '')
+                                       .replace('ERROR: ', '').strip())
+                           for l in out.splitlines()
+                           if l.startswith(('FAIL:', 'ERROR:'))]
+            io.open(path, 'w', encoding='utf-8', newline='').write(base)
+            results.append((name, 'KILLED' if killed else 'SURVIVED', expect,
+                            '%d' % len(failed), failed))
+    finally:
+        for k, v in TARGETS.items():
+            io.open(v, 'w', encoding='utf-8', newline='').write(orig[k])
+
+    w = max(len(r[0]) for r in results)
+    wrong = 0
+    for name, verdict, expect, cnt, failed in results:
+        mark = ''
+        if verdict != expect:
+            mark = '   <-- WRONG, expected %s' % expect
+            wrong += 1
+        print('%-*s  %-9s  %-3s%s' % (w, name, verdict, cnt, mark))
+        for f in failed:
+            print('%s      %s' % (' ' * w, f))
+    killed = sum(1 for r in results if r[1] == 'KILLED')
+    survived = sum(1 for r in results if r[1] == 'SURVIVED')
+    broken = sum(1 for r in results if r[1] == 'BROKEN')
+    print('\n%d rows: %d killed, %d survived (%d of them expected), %d broken'
+          % (len(results), killed, survived,
+             sum(1 for r in results if r[1] == r[2] == 'SURVIVED'), broken))
+    if wrong or broken:
+        print('%d row(s) did not match their expectation' % (wrong + broken))
+    return 1 if (wrong or broken) else 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument('--row', help='run a single row by name')
+    a = ap.parse_args()
+    return run(a.row)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/mutate_620.py
+++ b/tests/mutate_620.py
@@ -207,10 +207,16 @@ ROWS = [
      (T620,), 'KILLED'),
 
     # --- THE LADDER ---------------------------------------------------------
-    ('ladder-never-tried', 'bga',
+    # NAMED FOR WHAT IT IS, after an audit pointed out the old name asserted a
+    # behaviour the edit does not produce: `None or X` is exactly `X`, so this
+    # never stops the ladder being tried. It is the battery's OWN control --
+    # the row that proves a SURVIVED verdict is reachable and that the runner
+    # is not silently killing everything. `ladder-refuses-immediately` is the
+    # row that actually removes the ladder.
+    ('control-semantically-inert-edit', 'bga',
      '                    _thin = thin_drill_to_clear(',
      '                    _thin = None or thin_drill_to_clear(',
-     (T620,), 'SURVIVED'),      # deliberately inert: a no-op control row
+     (T620,), 'SURVIVED'),
 
     ('ladder-refuses-immediately', 'bga',
      '                    if _thin is None:',
@@ -229,13 +235,16 @@ ROWS = [
      '    for cand in cands:\n        return cand',
      (T620,), 'KILLED'),
 
+    # EXPECTED SURVIVOR, with the rationale CORRECTED by an audit. It is not
+    # "rung 0 is the top" -- the real reason is the `via_drill < drill - 1e-9`
+    # filter: the standard ladder's drills are [0.20, 0.15, 0.15], so widening
+    # the slice can only re-admit drills the filter then throws away. The row
+    # stays because the slice IS load-bearing for a ladder whose shallow rungs
+    # are thinner than a deep one, which no packaged tier is today.
     ('ladder-climbs-above-its-own-rung', 'geo',
      "    cands = sorted({f['via_drill'] for f in floors[rung:]",
      "    cands = sorted({f['via_drill'] for f in floors[0:]",
-     (T620,), 'SURVIVED'),      # rung 0 is the top: floors[0:] == floors[rung:]
-                                # whenever the clamp did not escalate, and the
-                                # filter drops anything >= drill. Recorded as a
-                                # measured no-op, not deleted.
+     (T620,), 'SURVIVED'),
 
     ('thinned-drill-not-applied', 'bga',
      '                    _thinned.append((v_drill, _thin))\n'
@@ -244,10 +253,21 @@ ROWS = [
      (T620,), 'KILLED'),
 
     # --- the second guard's bookkeeping (#620's other half) -----------------
-    ('silent-skip-restored', 'bga',
+    # RENAMED after an audit: `if False and ...` DELETES the refusal, it does
+    # not restore the old drop-via/keep-route shape. Both are live mutations
+    # worth having, so the second one is now its own row below.
+    ('ring-guard-refusal-deleted', 'bga',
      '                if would_overlap_existing_via(pad_x, pad_y, v_size):',
      '                if False and would_overlap_existing_via(pad_x, pad_y, '
      'v_size):',
+     (T620,), 'KILLED'),
+
+    # The actual pre-#620 shape: the via is dropped and the ROUTE is kept, so
+    # an inner-layer track ships with nothing connecting it to the ball.
+    ('silent-skip-restored', 'bga',
+     '                if would_overlap_existing_via(pad_x, pad_y, v_size):\n',
+     '                if would_overlap_existing_via(pad_x, pad_y, v_size):\n'
+     '                    continue\n',
      (T620,), 'KILLED'),
 
     # --- the disclosures ----------------------------------------------------

--- a/tests/mutate_620.py
+++ b/tests/mutate_620.py
@@ -76,7 +76,7 @@ T756 = os.path.join(_TESTS, 'test_756_fanout_clearance_drill_floors.py')
 _WINDOW = ("        window = max(d / 2.0 + self._max_drill / 2.0 + self._h2h,\n"
            "                     s / 2.0 + self._max_size / 2.0 + "
            "self._clearance,\n"
-           "                     atol)")
+           "                     ahx)")
 
 # (name, target, old, new, tests, expect)
 ROWS = [
@@ -85,18 +85,16 @@ ROWS = [
      '                _v, _detail = _pending.verdict(pad_x, pad_y, v_size, '
      'v_drill,\n'
      '                                               route.net_id, _bulges,\n'
-     '                                               anchor_tol=_atol)',
+     '                                               anchor_box=_abox)',
      "                _v, _detail = 'clear', None",
      (T620,), 'KILLED'),
 
     ('verdict-always-clear', 'geo',
      '        d = drill or 0.0\n        s = size or 0.0\n'
-     '        atol = self._tol if anchor_tol is None else max(anchor_tol, '
-     'self._tol)',
+     '        ahx, ahy = ((self._tol, self._tol) if anchor_box is None else',
      "        return 'clear', None\n"
      '        d = drill or 0.0\n        s = size or 0.0\n'
-     '        atol = self._tol if anchor_tol is None else max(anchor_tol, '
-     'self._tol)',
+     '        ahx, ahy = ((self._tol, self._tol) if anchor_box is None else',
      (T620,), 'KILLED'),
 
     ('pending-never-records-the-committed-via', 'bga',
@@ -152,19 +150,19 @@ ROWS = [
      _WINDOW,
      '        window = max(d + self._h2h,\n'
      '                     s / 2.0 + self._max_size / 2.0 + self._clearance,\n'
-     '                     atol)',
+     '                     ahx)',
      (T620,), 'KILLED'),
 
     ('broad-phase-window-drops-the-ring-term', 'geo',
      _WINDOW,
      '        window = max(d / 2.0 + self._max_drill / 2.0 + self._h2h,\n'
-     '                     atol)',
+     '                     ahx)',
      (T620,), 'KILLED'),
 
     ('broad-phase-window-drops-the-drill-term', 'geo',
      _WINDOW,
      '        window = max(s / 2.0 + self._max_size / 2.0 + self._clearance,\n'
-     '                     atol)',
+     '                     ahx)',
      (T620,), 'KILLED'),
 
     ('broad-phase-window-drops-the-anchor-term', 'geo',
@@ -180,20 +178,26 @@ ROWS = [
 
     # --- TWINS --------------------------------------------------------------
     ('twin-branch-refuses-instead', 'geo',
-     '            if onet == net_id and dist <= atol:\n'
+     '            if (onet == net_id\n'
+     '                    and abs(ox - x) <= ahx and abs(oy - y) <= ahy):\n'
      "                return 'twin', (ox, oy, os_, od)",
-     '            if onet == net_id and dist <= atol:\n'
+     '            if (onet == net_id\n'
+     '                    and abs(ox - x) <= ahx and abs(oy - y) <= ahy):\n'
      "                return 'conflict', ('same site', ox, oy)",
      (T620,), 'KILLED'),
 
     ('twin-branch-ignores-the-net', 'geo',
-     '            if onet == net_id and dist <= atol:',
-     '            if dist <= atol:',
+     '            if (onet == net_id\n'
+     '                    and abs(ox - x) <= ahx and abs(oy - y) <= ahy):',
+     '            if (True\n'
+     '                    and abs(ox - x) <= ahx and abs(oy - y) <= ahy):',
      (T620,), 'KILLED'),
 
     ('twin-keyed-on-the-exact-site-again', 'geo',
-     '            if onet == net_id and dist <= atol:',
-     '            if onet == net_id and dist <= self._tol:',
+     '            if (onet == net_id\n'
+     '                    and abs(ox - x) <= ahx and abs(oy - y) <= ahy):',
+     '            if (onet == net_id\n'
+     '                    and dist <= self._tol and abs(oy - y) <= ahy):',
      (T620,), 'KILLED'),
 
     ('twin-appends-a-second-via-anyway', 'bga',
@@ -313,7 +317,7 @@ ROWS = [
     ('coupled-gate-skips-the-site-conflict', 'up',
      '            if why is not None:\n'
      "                if why.startswith('drill hole'):\n"
-     "                    h2h_stats['coupled'] += 1\n"
+     "                    h2h_stats['coupled_pairs'].add(_pair_key)\n"
      '                return False',
      '            if False:\n                return False',
      (T618,), 'SURVIVED'),

--- a/tests/mutate_620.py
+++ b/tests/mutate_620.py
@@ -268,10 +268,15 @@ ROWS = [
      (T620,), 'KILLED'),
 
     # --- #618: the coupled escape's via sites -------------------------------
+    # Anchored INSIDE the gate, not at a call site: the call site text is
+    # identical at both of them, and a two-match anchor is reported BROKEN
+    # (which is right -- a battery that silently applies one of two edits
+    # measures half a mutation). Returning True after the locked-SMD check
+    # reproduces the pre-#618 behaviour exactly, at both callers at once.
     ('coupled-gate-reverted-to-locked-smd-only', 'up',
-     '                if use_via and not _coupled_via_sites_ok(pp, nn):',
-     '                if use_via and locked_smd_pads and not all(\n'
-     '                        _via_gate_ok(q) for q in (pp, nn)):',
+     '        sites = [_via_site_geom(q) for q in (pp, nn)]',
+     '        return True\n'
+     '        sites = [_via_site_geom(q) for q in (pp, nn)]',
      (T618,), 'KILLED'),
 
     ('coupled-gate-skips-the-site-conflict', 'up',
@@ -282,14 +287,17 @@ ROWS = [
      '            if False:\n                return False',
      (T618,), 'KILLED'),
 
+    # I recorded this as an expected SURVIVOR, reasoning that the only in-repo
+    # rigs are 0.8mm-pitch parts whose pair clears by 0.4mm. The battery
+    # refuted it: the declared-0.7 arm makes the pair need 0.9mm at 0.8mm
+    # pitch, so the pair-vs-itself test is what declines it and the row is
+    # KILLED. Kept as the record of a wrong expectation corrected by measuring.
     ('coupled-pair-not-tested-against-itself', 'up',
      '        if math.hypot(ax - bx, ay - by) < ((ad or 0.0) / 2.0\n'
      '                                           + (bd or 0.0) / 2.0\n'
      '                                           + _h2h - 1e-6):',
      '        if False:',
-     (T618,), 'SURVIVED'),      # 0.8mm-pitch parts are the only in-repo rigs
-                                # and their pair clears by 0.4mm; recorded as
-                                # measured-uncovered rather than deleted.
+     (T618,), 'KILLED'),
 
     ('h2h-decline-not-disclosed', 'up',
      '            print(f"  Under-pad: {h2h_stats[\'sites\']} via-in-pad centre '

--- a/tests/test_618_coupled_via_site_gate.py
+++ b/tests/test_618_coupled_via_site_gate.py
@@ -46,6 +46,7 @@ geometry against a declaration a fab could really make.
 """
 import json
 import os
+import re
 import shutil
 import sys
 import tempfile
@@ -248,6 +249,32 @@ class TestTheDeclaredFloorIsHonoured(unittest.TestCase):
                 round(gap, 6), 0.70,
                 f'a run announcing a 0.7mm floor still emits a {gap:.4f}mm '
                 f'drill gap')
+
+    def test_the_disclosure_counts_PAIRS_not_CALLS(self):
+        """`_coupled_via_sites_ok` runs inside `strict x direction x candidate`
+        loops from two templates and is not memoised, so a bare counter counts
+        invocations. An adversarial review measured a run printing "8 coupled
+        pair(s) declined" on a board with ONE coupled pair -- the gate was
+        called 16 times for it.
+
+        A disclosure that overstates by an order of magnitude is worse than
+        none: it invites the operator to go looking for pairs that do not
+        exist. The declined count can never exceed the pairs the run found.
+
+        MUTATION: `h2h_stats['coupled_pairs'].add(...)` -> a bare `+= 1`
+        counter -- this arm dies."""
+        with tempfile.TemporaryDirectory() as tmp:
+            _v, log = _fanout(_board_with_floor(tmp, 0.70))
+        m = re.search(r'and (\d+) coupled pair\(s\) declined', log)
+        found = re.search(r'Found (\d+) differential pair\(s\)', log)
+        self.assertIsNotNone(found, 'the rig found no diff pairs at all')
+        if m is None:
+            self.skipTest('no coupled pair declined on this rig')
+        self.assertLessEqual(
+            int(m.group(1)), int(found.group(1)),
+            f'the run reports {m.group(1)} coupled pair(s) declined but only '
+            f'found {found.group(1)} differential pair(s) -- the counter is '
+            f'counting gate CALLS')
 
     def test_the_decline_is_DISCLOSED(self):
         """#618's policy question, answered as WARN. MUTATION: delete the

--- a/tests/test_618_coupled_via_site_gate.py
+++ b/tests/test_618_coupled_via_site_gate.py
@@ -154,21 +154,29 @@ class TestTheGateIsInertOnTheBoardAsShipped(unittest.TestCase):
                                 f'gap against its own 0.25mm declaration')
 
 
-class TestTheSiteConflictHalfIsLive(unittest.TestCase):
-    """The half the gate exists for, and the one the mutation battery caught
-    having NO coverage: `_via_site_conflict` against the board's own copper.
+class TestNoViaLandsOnBoardCopper(unittest.TestCase):
+    """An END-TO-END property, and NOT a test of the coupled gate's
+    site-conflict half -- which is the finding, so it is written down here
+    rather than claimed away.
 
-    The arms below plant a foreign-net via at a coordinate the unplanted run
-    puts a coupled escape via on, then re-run. With the gate, that ball's site
-    is declined and no via lands on the planted hole; without it, the coupled
-    pair goes in regardless and two drills share a point.
+    The arms plant a foreign-net via on the exact coordinate the unplanted run
+    puts a COUPLED escape via on (verified: `vias[0]` is a Z-pair via and the
+    rig couples 13 of 13 pairs), then re-run and assert no emitted via lands
+    within the hole-to-hole floor of it.
 
-    Two engine runs, because the plant site has to be a coordinate this engine
-    actually chooses -- a hand-picked ball centre would prove nothing if the
-    pair never couples there.
+    THE MUTATION BATTERY SHOWS THIS PASSES EVEN WITH
+    `_coupled_via_sites_ok`'s `_via_site_conflict` LOOP DISABLED. That is not a
+    hole in the arms; it is what the code does. `_via_site_conflict` has two
+    domains -- the board's own copper, and the vias this run has already
+    committed -- and the first is already covered by the occupancy grid, which
+    is built from the board before any escape runs. The check is redundant for
+    a board via and load-bearing only against this run's own output, which no
+    in-repo board reaches (the only rigs that couple are 0.8mm pitch, where a
+    committed via clears the floor by 0.4mm). `mutate_620.py` records that as
+    an expected survivor with the same reasoning.
 
-    MUTATION: `return True` before the `_via_site_conflict` loop in
-    `_coupled_via_sites_ok` -- these arms die.
+    So what these arms pin is the OUTCOME -- a coupled escape never drills into
+    copper the board already has -- by whichever mechanism holds it.
     """
 
     def test_a_foreign_hole_at_a_coupled_ball_centre_declines_that_site(self):

--- a/tests/test_618_coupled_via_site_gate.py
+++ b/tests/test_618_coupled_via_site_gate.py
@@ -154,6 +154,70 @@ class TestTheGateIsInertOnTheBoardAsShipped(unittest.TestCase):
                                 f'gap against its own 0.25mm declaration')
 
 
+class TestTheSiteConflictHalfIsLive(unittest.TestCase):
+    """The half the gate exists for, and the one the mutation battery caught
+    having NO coverage: `_via_site_conflict` against the board's own copper.
+
+    The arms below plant a foreign-net via at a coordinate the unplanted run
+    puts a coupled escape via on, then re-run. With the gate, that ball's site
+    is declined and no via lands on the planted hole; without it, the coupled
+    pair goes in regardless and two drills share a point.
+
+    Two engine runs, because the plant site has to be a coordinate this engine
+    actually chooses -- a hand-picked ball centre would prove nothing if the
+    pair never couples there.
+
+    MUTATION: `return True` before the `_via_site_conflict` loop in
+    `_coupled_via_sites_ok` -- these arms die.
+    """
+
+    def test_a_foreign_hole_at_a_coupled_ball_centre_declines_that_site(self):
+        from kicad_writer import add_tracks_and_vias_to_pcb
+        with tempfile.TemporaryDirectory() as tmp:
+            plain = _board_with_floor(tmp, 0.25)
+            vias, _log = _fanout(plain)
+            self.assertTrue(vias, 'the rig emits no vias at all')
+            target = vias[0]
+            # Plant a foreign-net via ON that site, in the INPUT board.
+            planted = os.path.join(tmp, 'planted.kicad_pcb')
+            shutil.copy(os.path.splitext(plain)[0] + '.kicad_pro',
+                        os.path.join(tmp, 'planted.kicad_pro'))
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                add_tracks_and_vias_to_pcb(
+                    plain, planted, [],
+                    [{'x': target['x'], 'y': target['y'], 'size': 0.3,
+                      'drill': 0.2, 'layers': ['F.Cu', 'B.Cu'],
+                      'net_id': 0}])
+            evidence(planted, 'the planted board')
+            after, log2 = _fanout(planted)
+
+        floor = 0.25
+        clashes = [v for v in after
+                   if math.hypot(v['x'] - target['x'], v['y'] - target['y'])
+                   < (v['drill'] or 0) / 2 + 0.1 + floor - 1e-6]
+        self.assertEqual(
+            clashes, [],
+            f'{len(clashes)} emitted via(s) land within the {floor}mm '
+            f'hole-to-hole floor of a via that was already on the board at '
+            f'({target["x"]:.4f}, {target["y"]:.4f}) -- the site-conflict half '
+            f'of the coupled gate is not running')
+
+    def test_the_plant_is_what_moved_it(self):
+        """Without this, the arm above passes on a rig where the engine simply
+        never chooses that coordinate again for its own reasons."""
+        with tempfile.TemporaryDirectory() as tmp:
+            plain = _board_with_floor(tmp, 0.25)
+            vias, _log = _fanout(plain)
+        self.assertTrue(vias)
+        hit = [v for v in vias
+               if math.hypot(v['x'] - vias[0]['x'], v['y'] - vias[0]['y'])
+               < 1e-9]
+        self.assertTrue(hit, 'the unplanted run does not put a via on the '
+                             'coordinate the planted arm tests, so that arm '
+                             'proves nothing')
+
+
 class TestTheDeclaredFloorIsHonoured(unittest.TestCase):
     """#618 clause 2, re-derived. A declaration the geometry cannot meet must
     change the outcome -- otherwise the floor is decorative, which is exactly

--- a/tests/test_618_coupled_via_site_gate.py
+++ b/tests/test_618_coupled_via_site_gate.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""#618: the coupled diff-pair escape emitted its two via-in-pads ungated.
+
+    python3 tests/test_618_coupled_via_site_gate.py [-v]
+
+`_drop_escape_via` (bga_fanout/underpad.py) puts a via in each ball of a
+coupled pair, and its two callers gated that on `_via_gate_ok` alone -- the
+locked-SMD copper check -- AND only when the board has locked SMD pads. So on
+an ordinary board those two vias went in with no `_via_site_conflict` at all:
+not against the board's own drills, not against this run's committed vias, and
+not against each other. Every other via site in that file goes through
+`_via_site_conflict`.
+
+WHAT #618 ACTUALLY CLAIMS, CLAUSE BY CLAUSE, because three of its four claims
+are false at HEAD and repeating them would be worse than useless:
+
+  1. "Via-in-pad sites sit at ball centres under the mutual centre-reservation
+     contract, not through `_via_site_conflict`" -- TRUE, but only for the
+     COUPLED emit above. The single-ended centre site was closed by #567
+     (`bbd65f31`), which calls `_via_site_conflict(..., skip_resv=True)`.
+     This file's gate closes the remaining half.
+  2. "a board declaring min_hole_to_hole 0.9 still gets 0.6mm gaps (measured on
+     ulx3s U1)" -- FALSE at HEAD, closed by #756 (`7303cd82`, committed one
+     hour after #618 was filed). Measured: ulx3s U1 has no `.kicad_pro` at all,
+     so the 0.9 declaration is CONSTRUCTED; with one planted, the run announces
+     the 0.9 floor and the sub-0.9 pairs go 62 -> 0. `TestTheDeclaredFloorIsHonoured`
+     re-derives that here so the closure stays a change detector rather than a
+     claim in a commit message.
+  3. "arguably a refuse-to-build condition ... flagging it needs a policy
+     decision (skip via-in-pad? warn? fail?)" -- OPEN, and answered: WARN.
+     Refuse-to-build was measured and rejected -- honouring a declared 0.9 on
+     ulx3s costs 15 of 199 escapes, so refusing the RUN would throw away 184
+     good escapes to prevent 62 bad holes. The house style is clamp-and-warn
+     (`fab_tiers.warn_fab_escalation`, `fab_notes`), with a hard `return 1`
+     reserved for "no useful board is possible".
+  4. "The escape-path fix (#616) already handles every non-via-in-pad site" --
+     a statement about #616, not a request.
+
+THE GATE'S OWN COST, which is why the arms below are paired: it can only ever
+DECLINE a via site, and a declined coupled pair falls back to single-ended (or
+to the router). On the two real boards measured it declines nothing -- glasgow
+U30 and ulx3s U1 are 0.8mm-pitch parts whose clamped 0.2mm drills need 0.4mm
+and have 0.8. The refusal arm therefore RAISES THE FLOOR on a copy of a real
+board rather than inventing a footprint, so what it exercises is the shipped
+geometry against a declaration a fab could really make.
+"""
+import json
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))
+sys.path.insert(0, os.path.join(ROOT, 'py_tools'))
+
+import contextlib                                              # noqa: E402
+import io                                                      # noqa: E402
+import math                                                    # noqa: E402
+from kicad_parser import parse_kicad_pcb                       # noqa: E402
+from bga_fanout import generate_bga_fanout                     # noqa: E402
+# `evidence` refuses a fixture that is missing or empty BEFORE it is used as
+# input, because a check whose input is missing tests nothing (CLAUDE.md). It
+# also, deliberately, makes `run_all` classify this file as INTEGRATION: it
+# runs four whole under-pad fanouts of a 121-ball BGA and belongs nowhere near
+# the fast set. The classifier keys on markers like `from run_utils`, and
+# without one a several-minute board test is collected as a unit test.
+from run_utils import evidence                                 # noqa: E402
+
+RUN_ALL_TIMEOUT = 900
+
+BOARD = os.path.join(ROOT, 'kicad_files', 'glasgow_revC.kicad_pcb')
+COMPONENT = 'U30'
+LAYERS = ['F.Cu', 'In1.Cu', 'In2.Cu', 'B.Cu']
+PARAMS = dict(track_width=0.12, clearance=0.1, via_size=0.35, via_drill=0.2,
+              diff_pair_gap=0.101)
+PAIRS = ['Z*']
+
+
+def _board_with_floor(tmp, h2h):
+    """glasgow_revC copied with its project, `min_hole_to_hole` overwritten.
+
+    The project MUST come along: a bare `.kicad_pcb` copy strands the DRC floor
+    and the run resolves a different one, which is #441 and would make these
+    arms measure the copy rather than the declaration.
+    """
+    dst = os.path.join(tmp, 'g.kicad_pcb')
+    shutil.copy(BOARD, dst)
+    with open(os.path.splitext(BOARD)[0] + '.kicad_pro', encoding='utf-8') as f:
+        pro = json.load(f)
+    if h2h is None:
+        pro['board']['design_settings']['rules'].pop('min_hole_to_hole', None)
+    else:
+        pro['board']['design_settings']['rules']['min_hole_to_hole'] = h2h
+    with open(os.path.join(tmp, 'g.kicad_pro'), 'w', encoding='utf-8') as f:
+        json.dump(pro, f)
+    evidence(dst, 'the copied board')
+    evidence(os.path.join(tmp, 'g.kicad_pro'), 'the copied project')
+    return dst
+
+
+def _fanout(path):
+    """Returns (vias, transcript). Engine call, no file written."""
+    pcb = parse_kicad_pcb(path)
+    fp = pcb.footprints[COMPONENT]
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        _tracks, vias, _vrem, _failed = generate_bga_fanout(
+            fp, pcb, layers=LAYERS, escape_method='underpad',
+            diff_pair_patterns=PAIRS, **PARAMS)
+    return vias, buf.getvalue()
+
+
+def _min_drill_gap(vias):
+    best = None
+    for i, a in enumerate(vias):
+        for b in vias[i + 1:]:
+            ax, ay = a['x'], a['y']
+            bx, by = b['x'], b['y']
+            d = (math.hypot(ax - bx, ay - by)
+                 - (a['drill'] or 0) / 2 - (b['drill'] or 0) / 2)
+            if best is None or d < best:
+                best = d
+    return best
+
+
+class TestTheGateIsInertOnTheBoardAsShipped(unittest.TestCase):
+    """The paired half. A gate that can only decline must be shown NOT to
+    decline the geometry people actually run, or its cost is unbounded."""
+
+    def test_the_shipped_board_still_escapes_and_still_couples(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            vias, log = _fanout(_board_with_floor(tmp, 0.25))
+        self.assertGreater(len(vias), 0, 'the rig escapes nothing, so it '
+                                         'cannot show the gate is inert')
+        self.assertIn('diff pairs coupled', log,
+                      'no pair coupled at all -- this rig no longer reaches '
+                      'the code #618 is about')
+        self.assertNotIn('coupled pair(s) declined', log.replace(
+            '0 coupled pair(s) declined', ''),
+            'the gate declines a coupled pair on the board as shipped')
+
+    def test_the_shipped_geometry_clears_its_own_declared_floor(self):
+        """0.8mm pitch, drills clamped to 0.2: needs 0.4, has 0.8. Asserted so
+        the inertness above has a REASON on the record, not just a count."""
+        with tempfile.TemporaryDirectory() as tmp:
+            vias, _log = _fanout(_board_with_floor(tmp, 0.25))
+        gap = _min_drill_gap(vias)
+        self.assertIsNotNone(gap)
+        self.assertGreaterEqual(round(gap, 6), 0.25,
+                                f'the shipped board emits a {gap:.4f}mm drill '
+                                f'gap against its own 0.25mm declaration')
+
+
+class TestTheDeclaredFloorIsHonoured(unittest.TestCase):
+    """#618 clause 2, re-derived. A declaration the geometry cannot meet must
+    change the outcome -- otherwise the floor is decorative, which is exactly
+    what #618 accused this engine of and what #756 fixed."""
+
+    def test_a_floor_the_pitch_cannot_meet_declines_sites(self):
+        """0.8mm pitch with 0.2mm drills clears 0.25 and cannot clear 0.7
+        (0.2 + 0.7 = 0.9 > 0.8). MUTATION: revert `_h2h` to the flat
+        HOLE_TO_HOLE_CLEARANCE -- this arm dies while the inert arms pass."""
+        with tempfile.TemporaryDirectory() as tmp:
+            _v_lo, log_lo = _fanout(_board_with_floor(tmp, 0.25))
+        with tempfile.TemporaryDirectory() as tmp:
+            v_hi, log_hi = _fanout(_board_with_floor(tmp, 0.70))
+        self.assertIn('Hole-to-hole 0.7mm', log_hi,
+                      'the 0.7 declaration was not read at all')
+        self.assertNotIn('Hole-to-hole 0.7mm', log_lo)
+        gap = _min_drill_gap(v_hi)
+        if gap is not None:
+            self.assertGreaterEqual(
+                round(gap, 6), 0.70,
+                f'a run announcing a 0.7mm floor still emits a {gap:.4f}mm '
+                f'drill gap')
+
+    def test_the_decline_is_DISCLOSED(self):
+        """#618's policy question, answered as WARN. MUTATION: delete the
+        `h2h_stats` print -- the operator gets a worse board with no reason
+        given, which is the state #618 objected to."""
+        with tempfile.TemporaryDirectory() as tmp:
+            _v, log = _fanout(_board_with_floor(tmp, 0.70))
+        self.assertIn('hole-to-hole floor', log,
+                      'sites declined by the floor are not disclosed')
+        self.assertIn('declined by the', log)
+        self.assertIn('--via-drill', log,
+                      'the disclosure names no lever, so it is a complaint '
+                      'rather than an instruction')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/test_620_pending_via_pairs.py
+++ b/tests/test_620_pending_via_pairs.py
@@ -28,18 +28,28 @@ mistakes a synthetic number for a board measurement.
 THE SCOPE IS ASYMMETRIC AND THAT IS THE DESIGN (`PendingVias`):
 
   * the DRILL is always tested -- the balls are SMD and carry no hole, so every
-    hole in the neighbourhood is one this pass creates;
+    hole in the neighbourhood is one this pass creates, and a thinner drill is
+    a lever that can actually cure a conflict;
   * the RING is tested only when a via BULGES past its pad (clamp status
-    `'floor'`), because a via that fits inside its pad occupies no copper the
-    pad did not already occupy, so a ring test on such a pair restates the
-    board's own ball-to-ball spacing.
+    `'floor'`), because a via clamped INTO its pad asks the fab for the etch
+    pitch the footprint already demands, while a bulging one asks for a tighter
+    one -- and because a via-in-pad site has no lever at all: it is the ball
+    centre by definition and a bulging via is already at the deepest fab rung.
 
-That split is a MEASUREMENT, not a principle: swept over all 6565 physical
-(pitch, pad) combinations at clearances 0.10/0.15/0.20/0.25/0.30, the ring-only
-rejections whose own pads are NOT already sub-clearance number
-0/90/155/195/210, and 100% of them are bulging vias at every clearance.
-`TestTheRingArmIsOnlyForBulgingVias` re-derives both halves so the claim stays
-a change detector.
+AN EARLIER VERSION OF THIS FILE JUSTIFIED THAT SPLIT WITH A SWEEP -- "of the
+ring-only rejections whose pads are not already sub-clearance, 100% are bulging
+vias, at every clearance" -- and an adversarial review showed the claim is a
+TAUTOLOGY: `pitch >= pad + clearance` and `pitch < via + clearance` give
+`pad < via`, which IS the bulge, for any clamp function whatsoever. It is kept
+below AS an identity (`test_the_bulge_EQUIVALENCE_is_an_identity...`) so nobody
+re-derives it and reads it as evidence, and the contingent quantity is measured
+separately: what a bulge-blind ring arm would additionally reject.
+
+It is ALSO NOT TRUE that a fitting via adds no copper, which is what that sweep
+was standing in for. A ball pad is `['F.Cu']` and the via spans F.Cu to B.Cu,
+so on the inner layers there is no pad under the ring at all. The honest
+argument is the etch-pitch one above, not a claim that the copper is already
+there.
 
 A REFUSAL DROPS THE ESCAPE -- this pass has no re-sweep -- so the conflict
 branch descends the fab drill ladder first (`thin_drill_to_clear`). That is not
@@ -253,6 +263,27 @@ class TestTwinsShareOneHole(_TmpCase):
         self.assertAlmostEqual(add[0]['y'], 10.0, places=6)
         self.assertEqual(add[0]['net_id'], 7)
 
+    def test_there_is_no_ONE_MICRON_CLIFF(self):
+        """An exact-match twin rule had one, and an adversarial review found
+        it: two same-net sites 0.0010mm apart merged into one via and both
+        balls kept their escapes, while 0.0011mm apart DROPPED one outright --
+        because no fab rung can space two holes 1.1 um apart, so the conflict
+        branch had nothing to descend to. A 100-nanometre difference in a
+        footprint's modelling decided whether a ball escaped.
+
+        The twin rule keys on the ball's own ANCHOR radius instead (the
+        `_has_copper` spelling), so anything inside the pad is a via that
+        already connects this ball.
+
+        MUTATION: replace `anchor_tol` with `self._tol` in `verdict` -- the
+        0.0011 row dies."""
+        for sep in (0.0, 0.0005, 0.0010, 0.0011, 0.05, 0.2):
+            add, blocked, _t = _two_balls(sep, 0.5, same_net=True)
+            self.assertEqual(
+                (len(add), len(blocked)), (1, 0),
+                f'same-net balls {sep}mm apart (well inside a 0.5mm pad) '
+                f'gave {len(add)} via(s) and {len(blocked)} dropped escape(s)')
+
     def test_two_NETS_at_one_site_are_a_conflict_not_a_twin(self):
         """One hole cannot carry two nets. MUTATION: key the twin test on
         position alone and drop the net comparison."""
@@ -261,17 +292,83 @@ class TestTwinsShareOneHole(_TmpCase):
                          'two different nets are sharing one hole, which is a '
                          'short, or the second was silently skipped')
 
-    def test_the_pre_620_pass_STACKED_them(self):
-        """The behaviour being replaced, asserted from the writer's side so the
-        improvement is not just a claim: two identical dicts at one point are
-        two `(via ...)` s-exprs, because `kicad_writer` does not dedupe.
+    def test_no_two_vias_share_a_point(self):
+        """MUTATION: append without consulting `_pending` -- duplicates return.
 
-        This arm pins that the FIX does not produce them. MUTATION: append
-        without consulting `_pending` -- duplicates return."""
+        An earlier docstring here claimed this arm asserted "from the writer's
+        side", which it never did -- it only checks the dicts. A reviewer
+        checked the underlying claim instead and it holds:
+        `add_tracks_and_vias_to_pcb` on `splitflap_driver` with two identical
+        via dicts emits TWO `(via ...)` at one point. The claim is true and is
+        pinned by `test_the_writer_really_does_not_dedupe` below, which calls
+        the writer rather than describing it."""
         add, _b, _t = _two_balls(0.0, 0.5, same_net=True)
         keys = [(round(v['x'], 6), round(v['y'], 6), v['net_id']) for v in add]
         self.assertEqual(len(keys), len(set(keys)),
                          'stacked same-net vias at one point are back')
+
+    def test_the_writer_really_does_not_dedupe(self):
+        """The premise the twin rule rests on, CALLED rather than asserted
+        about. If the writer ever grows a dedupe, sharing one via stops being
+        an improvement over stacking two and this file's argument changes.
+
+        MUTATION: none -- this pins a fact about a different module."""
+        from kicad_writer import add_tracks_and_vias_to_pcb
+        board = os.path.join(os.path.dirname(os.path.dirname(
+            os.path.abspath(__file__))), 'kicad_files',
+            'splitflap_driver.kicad_pcb')
+        if not os.path.isfile(board):
+            self.skipTest('fixture board missing')
+        with open(board, encoding='utf-8') as f:
+            before = f.read().count('(via')
+        via = {'x': 100.0, 'y': 100.0, 'size': 0.4, 'drill': 0.2,
+               'layers': ['F.Cu', 'B.Cu'], 'net_id': 0}
+        with tempfile.TemporaryDirectory() as tmp:
+            out = os.path.join(tmp, 'w.kicad_pcb')
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                add_tracks_and_vias_to_pcb(board, out, [],
+                                           [dict(via), dict(via)])
+            with open(out, encoding='utf-8') as f:
+                after = f.read().count('(via')
+        self.assertEqual(after - before, 2,
+                         'the writer now dedupes identical vias, so stacking '
+                         'is no longer the thing the twin rule avoids')
+
+    def test_the_surviving_twin_via_is_the_TIGHTER_pad_s_clamp(self):
+        """Which via survives a merge used to be whichever route arrived first,
+        so two coincident same-net pads of 0.25 and 0.60 kept a 0.45 via that
+        bulges past the 0.25 pad -- the #202 violation `clamp_via_to_pad`
+        exists to prevent, re-created by the merge. Found by an adversarial
+        review. Asserted in BOTH orders, because the defect was order-only and
+        one order passed the whole time.
+
+        MUTATION: delete the `_pending.tighten` block -- the big-pad-first
+        order ships a 0.45 via."""
+        for order in ((0.25, 0.60), (0.60, 0.25)):
+            a = _ball(10.0, 10.0, 7, order[0], 'A1')
+            b = _ball(10.0, 10.0, 7, order[1], 'A2')
+            ra = FanoutRoute(pad=a, pad_pos=(10.0, 10.0),
+                             stub_end=(10.5, 10.5), exit_pos=(11.0, 10.5),
+                             layer='B.Cu')
+            rb = FanoutRoute(pad=b, pad_pos=(10.0, 10.0),
+                             stub_end=(10.5, 9.5), exit_pos=(11.0, 9.5),
+                             layer='B.Cu')
+            pcb = make_pcb(board_info=BoardInfo(
+                layers={}, copper_layers=list(CU),
+                board_bounds=(0.0, 0.0, 20.0, 20.0)),
+                vias=[], segments=[], pads_by_net={7: [a, b]},
+                source_path='', zones=[])
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                add, _rm, blocked = manage_vias([ra, rb], pcb, 'F.Cu', 0.45,
+                                                0.2, 0.1)
+            self.assertEqual((len(add), len(blocked)), (1, 0),
+                             f'order {order}: the twins did not merge')
+            self.assertLessEqual(
+                add[0]['size'], min(order) + 1e-9,
+                f'order {order}: the surviving via is {add[0]["size"]}mm, '
+                f'which bulges past the {min(order)}mm pad (#202)')
 
 
 class TestTheLadderKeepsTheEscape(_TmpCase):
@@ -299,6 +396,28 @@ class TestTheLadderKeepsTheEscape(_TmpCase):
         self.assertGreaterEqual(round(gap, 6), H2H,
                                 f'the thinned pair still ships {gap:.4f}mm of '
                                 f'hole-to-hole against a {H2H}mm floor')
+
+    def test_the_THINNED_drill_is_what_gets_recorded(self):
+        """The pending record must carry the drill that actually ships, or the
+        NEXT candidate is spaced against a hole that does not exist. Passing
+        the pre-thin drill is over-strict rather than unsafe, which is why no
+        arm caught it until a reviewer mutated exactly that line.
+
+        Asserted through behaviour: a third ball placed just outside the
+        THINNED floor and just inside the ORIGINAL one must be accepted.
+
+        MUTATION: `_pending.add(..., v_drill_before_thinning, ...)`."""
+        p = PendingVias(H2H, 0.1)
+        p.add(10.0, 10.0, 0.32, 0.15, 7)         # as if thinned 0.17 -> 0.15
+        # 0.36 clears 0.15/2 + 0.17/2 + 0.20 = 0.36 exactly, and clears the
+        # all-thinned floor 0.35; it would NOT clear 0.17/0.17 (0.37).
+        self.assertEqual(p.verdict(10.36, 10.0, 0.32, 0.17, 8)[0], 'clear')
+        stale = PendingVias(H2H, 0.1)
+        stale.add(10.0, 10.0, 0.32, 0.17, 7)     # the un-thinned record
+        self.assertEqual(stale.verdict(10.36, 10.0, 0.32, 0.17, 8)[0],
+                         'conflict',
+                         'the two records are indistinguishable here, so this '
+                         'arm cannot detect a stale drill')
 
     def test_the_escalation_is_DISCLOSED(self):
         """A silent tier escalation is a fab cost the operator did not choose.
@@ -410,58 +529,81 @@ class TestTheRingArmIsOnlyForBulgingVias(_TmpCase):
                          'a FITTING via pair is refused on ring clearance -- '
                          'the phantom rejection the scope exists to avoid')
 
-    def test_the_sweep_THIS_SCOPE_RESTS_ON_still_says_so(self):
-        """The scope decision is a measurement, so re-derive it here rather
-        than quoting it in prose. A number that lives only in a terminal is
-        exactly the kind that goes stale inside a confident comment.
+    def test_the_bulge_EQUIVALENCE_is_an_identity_not_a_measurement(self):
+        """An earlier version of this file swept 6565 (pitch, pad) pairs and
+        reported "of the ring-only rejections whose pads are not already
+        sub-clearance, 100% are bulging vias, at every clearance" as the
+        measurement the scope rested on. An adversarial review showed it is a
+        TAUTOLOGY, and the honest thing is to keep it -- as an identity, so
+        nobody re-derives it and mistakes it for evidence:
 
-        For every physically possible (pitch, pad) -- pad < pitch, so the balls
-        do not overlap -- classify the pair the way the two candidate rules
-        would. The claim: of the pairs a RING rule would reject and the DRILL
-        rule would not, every one whose own pads are NOT already sub-clearance
-        is a BULGING via. If that ever stops holding, the ring arm's `bulges`
-        condition is refusing (or admitting) something new and this file's
-        argument for it no longer applies.
+            ring-only rejection   =>  pitch <  via + clearance
+            pads not sub-clearance =>  pitch >= pad + clearance
+            therefore                  pad  <  via, which IS the bulge
 
-        MUTATION: none in the engine -- this arm guards the DESIGN. It fails if
-        `clamp_via_to_pad` or the fab ladder changes shape, which is precisely
-        when the scope wants re-deciding."""
-        recorded = {0.10: 0, 0.15: 90, 0.20: 155, 0.25: 195, 0.30: 210}
-        pitches = [round(0.20 + i * 0.01, 4) for i in range(101)]
-        pads = [round(0.05 + i * 0.01, 4) for i in range(116)]
+        It holds for ANY clamp function, so this arm proves it with clamps that
+        have nothing to do with the real one. If it ever fails, the two
+        definitions have drifted apart and the whole framing needs redoing.
+
+        MUTATION: none. This arm guards a claim, not a branch."""
+        clamps = {'huge': lambda p: 5.0, 'tiny': lambda p: 0.01,
+                  'triple': lambda p: 3 * p, 'exact': lambda p: p,
+                  'real': lambda p: _clamped(p)[0]}
+        for name, via_of in clamps.items():
+            for clearance in (0.05, 0.10, 0.20, 0.35, 0.50):
+                bad = []
+                for i in range(20, 121):
+                    pitch = round(i * 0.01, 4)
+                    for j in range(5, 121):
+                        psize = round(j * 0.01, 4)
+                        if psize >= pitch:
+                            continue
+                        vs = via_of(psize)
+                        if pitch >= vs + clearance - 1e-9:
+                            continue                   # not a ring rejection
+                        if pitch - psize < clearance - 1e-9:
+                            continue                   # pads already that close
+                        if vs <= psize + 1e-9:
+                            bad.append((pitch, psize, vs))
+                self.assertEqual(
+                    bad, [], f'clamp {name!r} at clearance {clearance}: '
+                             f'{len(bad)} ring-only non-phantom pair(s) that '
+                             f'do NOT bulge, e.g. {bad[:2]} -- the identity '
+                             f'this file documents has broken')
+
+    def test_what_a_BULGE_BLIND_ring_arm_would_additionally_reject(self):
+        """The contingent quantity the tautology above is not. How many real
+        (pitch, pad) combinations does the shipped arm KEEP that a ring arm
+        without the `bulges` condition would refuse? That number is the cost of
+        the alternative design, and unlike the identity it can move.
+
+        Counted over the same grid at the CLI-default clearance and at three
+        wider ones. Recorded, so a change in `clamp_via_to_pad` or the fab
+        ladder shows up here as a moved number rather than silently."""
+        recorded = {0.10: 150, 0.15: 310, 0.20: 495, 0.25: 705}
         for clearance, expect in sorted(recorded.items()):
-            ring_only_real = 0
-            not_bulging = []
+            extra = 0
             combos = 0
-            for pitch in pitches:
-                for psize in pads:
+            for i in range(20, 121):
+                pitch = round(i * 0.01, 4)
+                for j in range(5, 121):
+                    psize = round(j * 0.01, 4)
                     if psize >= pitch:
                         continue
                     combos += 1
                     vs, vd, _st, _r = _clamped(psize)
-                    d_bad = pitch < vd + H2H - 1e-9
-                    r_bad = pitch < vs + clearance - 1e-9
-                    if d_bad or not r_bad:
-                        continue
-                    if pitch - psize < clearance - 1e-9:
-                        continue                       # phantom: pads already
-                    ring_only_real += 1
-                    if vs <= psize + 1e-9:
-                        not_bulging.append((pitch, psize, vs, vd))
+                    if pitch < vd + H2H - 1e-9:
+                        continue          # the drill arm refuses it anyway
+                    if pitch < vs + clearance - 1e-9 and vs <= psize + 1e-9:
+                        extra += 1        # ring-blind would refuse; we keep
             self.assertEqual(combos, 6565,
-                             'the sweep grid moved; the recorded counts below '
-                             'are about a different population')
+                             'the grid moved; the counts here are about a '
+                             'different population')
             self.assertEqual(
-                not_bulging, [],
-                f'at clearance {clearance}: {len(not_bulging)} ring-only '
-                f'rejection(s) are NOT bulging vias, e.g. {not_bulging[:3]} -- '
-                f'the `bulges` condition now excludes a real catch, so the '
-                f'drill-only-unless-bulging scope needs re-deciding')
-            self.assertEqual(
-                ring_only_real, expect,
-                f'at clearance {clearance} the sweep now finds '
-                f'{ring_only_real} ring-only real rejections, not the '
-                f'{expect} this scope was chosen against')
+                extra, expect,
+                f'at clearance {clearance} a bulge-blind ring arm would '
+                f'additionally refuse {extra} combination(s), not the {expect} '
+                f'recorded when this scope was chosen')
 
     def test_the_ring_arm_is_foreign_net_only(self):
         """Same-net copper in contact is not a clearance violation. Distance
@@ -556,30 +698,49 @@ class TestPendingViasItself(unittest.TestCase):
         failure is reproducible.
 
         MUTATION: shrink the window (drop the `self._clearance` term, or use
-        `d` instead of `d/2 + max/2`) -- this arm dies."""
-        rng = random.Random(620)
-        for trial in range(200):
-            h2h = rng.choice((0.15, 0.20, 0.30))
-            clearance = rng.choice((0.10, 0.20))
-            p = PendingVias(h2h, clearance)
-            rows = []
-            for _ in range(rng.randint(1, 25)):
-                x = round(rng.uniform(0.0, 3.0), 4)
-                y = round(rng.uniform(0.0, 3.0), 4)
-                s = rng.choice((0.25, 0.30, 0.45))
-                d = rng.choice((0.15, 0.20, 0.30))
-                n = rng.randint(1, 3)
-                b = rng.random() < 0.5
-                cand = (x, y, s, d, n, b)
-                got = p.verdict(*cand)[0]
-                want = _brute(rows, cand, h2h, clearance)
-                self.assertEqual(got, want,
-                                 f'trial {trial}: broad phase disagrees with '
-                                 f'brute force at {cand} over {len(rows)} '
-                                 f'placed')
-                if got == 'clear':
-                    p.add(*cand)
-                    rows.append(cand)
+        `d` instead of `d/2 + max/2`) -- this arm dies.
+
+        THE PARAMETER GRID IS THE TEST. An earlier version of this arm swept
+        drills 0.15/0.20/0.30 against clearances 0.10/0.20 and named that
+        second mutation in its own docstring while being UNABLE TO KILL IT:
+        with those numbers the ring term always dominated the max(), so the
+        drill half of the window was never load-bearing and could be corrupted
+        freely. An adversarial review found it, and the fix is not a new
+        assertion but a grid where each term binds in turn -- drills that
+        exceed every ring, rings that exceed every drill, and floors of zero.
+        Several seeds, because one seed is a sample of one."""
+        for seed in (620, 1, 7, 12345, 99991):
+            rng = random.Random(seed)
+            for trial in range(120):
+                # Ranges chosen so the drill term and the ring term each
+                # dominate the window in some trials, and neither always.
+                h2h = rng.choice((0.0, 0.05, 0.20, 0.30, 1.10))
+                clearance = rng.choice((0.0, 0.02, 0.10, 0.20, 0.90))
+                p = PendingVias(h2h, clearance)
+                rows = []
+                for _ in range(rng.randint(1, 25)):
+                    x = round(rng.uniform(-2.0, 3.0), 4)
+                    y = round(rng.uniform(-2.0, 3.0), 4)
+                    s = round(rng.choice((0.05, 0.25, 0.45, 1.20, 2.40)), 4)
+                    d = round(rng.choice((0.0, 0.05, 0.20, 1.10, 2.40)), 4)
+                    n = rng.randint(1, 3)
+                    b = rng.random() < 0.5
+                    cand = (x, y, s, d, n, b)
+                    got = p.verdict(*cand)[0]
+                    # Feed the brute force the SAME rows in the SAME order the
+                    # scan sees them (x-sorted). The window is what is under
+                    # test; iteration order is not, and at a zero floor two
+                    # rows can both sit inside the site tolerance, where first-
+                    # hit-wins would make an order difference look like a
+                    # window bug.
+                    want = _brute(list(p._rows), cand, h2h, clearance)
+                    self.assertEqual(got, want,
+                                     f'seed {seed} trial {trial}: broad phase '
+                                     f'disagrees with brute force at {cand} '
+                                     f'over {len(rows)} placed')
+                    if got == 'clear':
+                        p.add(*cand)
+                        rows.append(cand)
 
     def test_it_uses_math_hypot_not_numpy(self):
         """#786/#787 closed on the finding that numpy's hypot is not CPython's
@@ -611,8 +772,10 @@ def _brute(rows, cand, h2h, clearance, tol=1e-6, site_tol=0.001):
     best = None
     for (ox, oy, os_, od, onet, obulges) in rows:
         dist = math.hypot(ox - x, oy - y)
+        if onet == net and dist <= site_tol:
+            return 'twin'
         if dist <= site_tol:
-            return 'twin' if onet == net else 'conflict'
+            return 'conflict'
         if dist < d / 2 + od / 2 + h2h - tol:
             if best is None or dist < best:
                 best = dist

--- a/tests/test_620_pending_via_pairs.py
+++ b/tests/test_620_pending_via_pairs.py
@@ -263,6 +263,35 @@ class TestTwinsShareOneHole(_TmpCase):
         self.assertAlmostEqual(add[0]['y'], 10.0, places=6)
         self.assertEqual(add[0]['net_id'], 7)
 
+    def test_a_twin_FURTHER_OUT_than_either_floor_is_still_a_twin(self):
+        """The anchor term in the broad-phase window, which nothing else makes
+        binding.
+
+        `verdict`'s window is `max(drill term, ring term, anchor_tol)`. On a
+        BGA-sized pad the drill term (0.40mm at the standard floor) exceeds the
+        anchor radius, so dropping `atol` from the max changes nothing and the
+        mutation survives -- the battery caught exactly that. A BIG pad inverts
+        it: a 2.0mm pad has an anchor radius of 1.01mm against a 0.40mm drill
+        window, so a twin 0.9mm away is inside the pad and OUTSIDE the window.
+        Without the anchor term it is never even scanned, so the second route
+        gets its own via 0.9mm from the first -- two holes in one pad.
+
+        MUTATION: drop `atol` from the `window = max(...)` -- this arm dies."""
+        p = PendingVias(H2H, 0.1)
+        p.add(10.0, 10.0, 0.45, 0.2, 7)
+        self.assertGreater(1.01, 0.2 / 2 + 0.2 / 2 + H2H,
+                           'the rig no longer makes the ANCHOR term the '
+                           'binding one, so it cannot detect its loss')
+        self.assertEqual(p.verdict(10.9, 10.0, 0.45, 0.2, 7,
+                                   anchor_tol=1.01)[0], 'twin',
+                         'a same-net via well inside this ball pad is no '
+                         'longer recognised as its anchor')
+        # ... and end to end, where it becomes a second hole in one pad.
+        add, blocked, _t = _two_balls(0.9, 2.0, same_net=True)
+        self.assertEqual((len(add), len(blocked)), (1, 0),
+                         'two routes 0.9mm apart inside one 2.0mm pad got '
+                         'two vias')
+
     def test_there_is_no_ONE_MICRON_CLIFF(self):
         """An exact-match twin rule had one, and an adversarial review found
         it: two same-net sites 0.0010mm apart merged into one via and both

--- a/tests/test_620_pending_via_pairs.py
+++ b/tests/test_620_pending_via_pairs.py
@@ -1,0 +1,589 @@
+#!/usr/bin/env python3
+"""#620: `manage_vias` never tested the vias of ONE call against each other.
+
+`vias_to_add` was appended to and never read back, and both guards that gate an
+append iterate `pcb_data.vias` only (`would_overlap_existing_via`,
+`via_in_pad_conflict`'s drill loop). So every via a call placed was spaced
+against the INPUT board and against nothing else, and two placed in one call
+could ship holes closer than the fab floor -- or, for two routes at one
+coordinate, two `(via ...)` s-exprs stacked at the same point, since
+`kicad_writer` does not dedupe.
+
+MEASURED, because the issue deliberately left the impact unmeasured and its own
+worked example was wrong to worry: on an empty board at CLI-ish defaults (via
+0.45 / drill 0.2 / clearance 0.1) the pre-fix pass shipped
+
+    pitch 0.30, pad 0.25  ->  holes 0.15mm apart, floor 0.20, added=2 blocked=0
+    pitch 0.25, pad 0.20  ->  holes 0.10mm apart, floor 0.20, added=2 blocked=0
+    pitch 0.30, pad 0.20  ->  holes 0.15mm apart, floor 0.20, added=2 blocked=0
+
+while the issue's own 0.50mm-pitch example is LEGAL, exactly as it hedged --
+`clamp_via_to_pad` shrinks the via into the ball pad first. **No board in this
+repo reaches the refusal branch at CLI defaults** (seven fanout runs, zero
+illegal emitted pairs; the tightest emitted pair anywhere is orangecrab U4 at
+0.2907mm against a 0.20 floor), so the fixture here is CONSTRUCTED and the
+corpus arms are a safety check, not the headline. Said plainly so no reader
+mistakes a synthetic number for a board measurement.
+
+THE SCOPE IS ASYMMETRIC AND THAT IS THE DESIGN (`PendingVias`):
+
+  * the DRILL is always tested -- the balls are SMD and carry no hole, so every
+    hole in the neighbourhood is one this pass creates;
+  * the RING is tested only when a via BULGES past its pad (clamp status
+    `'floor'`), because a via that fits inside its pad occupies no copper the
+    pad did not already occupy, so a ring test on such a pair restates the
+    board's own ball-to-ball spacing.
+
+That split is a MEASUREMENT, not a principle: swept over all 6565 physical
+(pitch, pad) combinations at clearances 0.10/0.15/0.20/0.25/0.30, the ring-only
+rejections whose own pads are NOT already sub-clearance number
+0/90/155/195/210, and 100% of them are bulging vias at every clearance.
+`TestTheRingArmIsOnlyForBulgingVias` re-derives both halves so the claim stays
+a change detector.
+
+A REFUSAL DROPS THE ESCAPE -- this pass has no re-sweep -- so the conflict
+branch descends the fab drill ladder first (`thin_drill_to_clear`). That is not
+decoration: at pitch 0.36 / pad 0.32 both escapes survive with the second
+drill thinned 0.17 -> 0.15, where a refuse-only design drops one. And it is not
+a cure-all: `--fab-overrides` collapses the ladder to a single hard rung by
+design, which is precisely the configuration the #620 contributor measured as
+pure loss (`via_drill = 0.35` at 0.5mm pitch: unmeetable floor AND no rung).
+
+Conventions (from #725/#731/#732/#733/#737/#750/#756 and CLAUDE.md): REAL
+parser dataclasses; every refusal paired with an acceptance that still happens,
+so no arm can pass on a rig that refuses everything; assert you are ON the
+branch before asserting about it; every assertion names the mutation that must
+kill it.
+"""
+import contextlib
+import io
+import json
+import math
+import os
+import random
+import shutil
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))), 'py_router'))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from kicad_parser import Pad, BoardInfo                          # noqa: E402
+from synth import make_pcb                                       # noqa: E402
+import fab_tiers                                                 # noqa: E402
+from fab_tiers import fab_floor_ladder, fab_floor_min            # noqa: E402
+from bga_fanout import manage_vias                               # noqa: E402
+from bga_fanout.types import FanoutRoute                         # noqa: E402
+from bga_fanout.geometry import (PendingVias, thin_drill_to_clear,  # noqa: E402
+                                 clamp_via_to_pad)
+
+CU = ('F.Cu', 'In1.Cu', 'In2.Cu', 'B.Cu')
+H2H = fab_floor_min(len(CU))['hole_to_hole']          # 0.20, standard tier
+LADDER = fab_floor_ladder(len(CU))
+
+
+def _ball(x, y, net_id, size, num='A1'):
+    return Pad(pad_number=num, net_id=net_id, net_name=f'/N{net_id}',
+               global_x=x, global_y=y, local_x=0.0, local_y=0.0,
+               size_x=size, size_y=size, shape='circle', layers=['F.Cu'],
+               drill=0.0, pad_type='smd', component_ref='U1')
+
+
+def _stub_board(tmp, name, rules=None):
+    """A bare board file, plus a sibling project when `rules` is not None.
+
+    Only the PROJECT has to exist on disk (`board_floor` reads it); the PCBData
+    is synthetic. `rules={}` is a project that EXISTS and declares nothing,
+    which is a different case from no project at all.
+    """
+    d = os.path.join(tmp, name)
+    os.makedirs(d, exist_ok=True)
+    pcb = os.path.join(d, 'b.kicad_pcb')
+    with open(pcb, 'w', encoding='utf-8') as f:
+        f.write('(kicad_pcb (version 20240108))\n')
+    if rules is not None:
+        with open(os.path.join(d, 'b.kicad_pro'), 'w', encoding='utf-8') as f:
+            json.dump({'board': {'design_settings': {'rules': rules}}}, f)
+    return pcb
+
+
+def _two_balls(pitch, pad_size, *, same_net=False, source_path='',
+               via_size=0.45, via_drill=0.2, clearance=0.1):
+    """Two balls `pitch` apart on a board carrying NO copper at all.
+
+    The empty board is the point: every guard that predates #620 scans
+    `pcb_data`, so on an empty board they are all vacuously satisfied and the
+    ONLY thing that can refuse the pair is a test of the two candidates against
+    each other. Returns (vias_to_add, via_blocked_routes, transcript).
+    """
+    a = _ball(10.0, 10.0, 7, pad_size, 'A1')
+    b = _ball(10.0 + pitch, 10.0, 7 if same_net else 8, pad_size, 'A2')
+    ra = FanoutRoute(pad=a, pad_pos=(a.global_x, a.global_y),
+                     stub_end=(a.global_x, a.global_y + 0.5),
+                     exit_pos=(a.global_x, a.global_y + 1.0), layer='B.Cu')
+    rb = FanoutRoute(pad=b, pad_pos=(b.global_x, b.global_y),
+                     stub_end=(b.global_x, b.global_y - 0.5),
+                     exit_pos=(b.global_x, b.global_y - 1.0), layer='B.Cu')
+    pcb = make_pcb(board_info=BoardInfo(layers={}, copper_layers=list(CU),
+                                        board_bounds=(0.0, 0.0, 20.0, 20.0)),
+                   vias=[], segments=[],
+                   pads_by_net=({7: [a, b]} if same_net else {7: [a], 8: [b]}),
+                   source_path=source_path, zones=[])
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        add, _rm, blocked = manage_vias([ra, rb], pcb, 'F.Cu', via_size,
+                                        via_drill, clearance)
+    return add, blocked, buf.getvalue()
+
+
+def _clamped(pad_size, via_size=0.45, via_drill=0.2):
+    return clamp_via_to_pad(via_size, via_drill, _ball(0, 0, 7, pad_size),
+                            LADDER)
+
+
+class _TmpCase(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self._tmp, ignore_errors=True)
+        # `warn_fab_escalation` dedupes per context string for the whole
+        # PROCESS, so an arm that runs second sees no warning even when it
+        # escalated. Clearing here is what makes the transcript arms
+        # independent of test ORDER.
+        fab_tiers._escalation_warned.clear()
+
+    def board(self, name, **rules):
+        return _stub_board(self._tmp, name, rules)
+
+
+class TestOnTheBranch(_TmpCase):
+    """Every geometry below is derived from what `clamp_via_to_pad` does to
+    these pads. If the clamp moves, the arms measure a different geometry and
+    say nothing about #620 -- so pin the derivation before using it."""
+
+    def test_the_clamp_puts_these_pads_where_this_file_says(self):
+        self.assertEqual(_clamped(0.25)[:2], (0.25, 0.15),
+                         'the 0.25 pad no longer clamps to the advanced rung; '
+                         'every 0.25-pad arm below is about other geometry')
+        self.assertEqual(_clamped(0.20)[2], 'floor',
+                         'the 0.20 pad no longer BULGES; the ring arms below '
+                         'lose the only case they exist for')
+        self.assertEqual(_clamped(0.32)[:2], (0.32, 0.17),
+                         'the ladder rig no longer starts above the deepest '
+                         'drill rung, so nothing can be thinned')
+        self.assertEqual(H2H, 0.20,
+                         'the standard-tier hole-to-hole floor moved; the '
+                         'pitches below were chosen against 0.20')
+
+
+class TestThePairTest(_TmpCase):
+    """The gap #620 names, with a refusal and an acceptance at every rig."""
+
+    def test_a_sub_floor_pair_is_no_longer_shipped(self):
+        """MUTATION: drop the `_pending.verdict` call, or make its 'conflict'
+        branch `pass`. Killed by the blocked count, not by the via count --
+        a via count alone cannot tell a refusal from a twin."""
+        add, blocked, _t = _two_balls(0.30, 0.25)
+        self.assertEqual((len(add), len(blocked)), (1, 1),
+                         'two holes 0.15mm apart against a 0.20mm floor are '
+                         'still both shipped')
+
+    def test_a_clearing_pair_is_still_shipped(self):
+        """The acceptance half. MUTATION: widen the floor (`_h2h` -> a larger
+        constant) and this arm dies while the refusal above still passes."""
+        add, blocked, _t = _two_balls(0.35, 0.25)
+        self.assertEqual((len(add), len(blocked)), (2, 0),
+                         'a LEGAL pair (0.20mm hole gap at a 0.20mm floor) is '
+                         'being refused -- the gate is over-tight')
+
+    def test_the_issue_s_own_worked_example_is_legal(self):
+        """#620 worried about 0.5mm pitch with via 0.45 + clearance 0.1, and
+        hedged that the clamp might legalize it. It does. Pinned so nobody
+        'fixes' the hedge by tightening the gate onto ordinary BGAs.
+
+        MUTATION: extend the ring arm to non-bulging vias -- this arm dies
+        (0.5 < 0.45 + 0.1) while every drill arm above still passes."""
+        add, blocked, _t = _two_balls(0.50, 0.25)
+        self.assertEqual((len(add), len(blocked)), (2, 0),
+                         'an ordinary 0.5mm-pitch BGA is now losing escapes; '
+                         'that is the phantom rejection this scope avoids')
+
+    def test_the_floor_is_the_BOARD_s_when_the_board_declares_one(self):
+        """#620's fix inherits #756's board-first floor rather than a second
+        constant. A 0.30 declaration refuses a pair the 0.20 fab floor allows.
+
+        MUTATION: read `_h2h_fab` instead of `_h2h` in the verdict."""
+        legal_at_fab = _two_balls(0.35, 0.25,
+                                  source_path=_stub_board(self._tmp, 'none'))
+        self.assertEqual((len(legal_at_fab[0]), len(legal_at_fab[1])), (2, 0),
+                         'the undeclared board must be unchanged')
+        declared = _two_balls(0.35, 0.25,
+                              source_path=self.board('h30',
+                                                     min_hole_to_hole=0.30))
+        self.assertEqual((len(declared[0]), len(declared[1])), (1, 1),
+                         'a board declaring 0.30 still gets 0.20 spacing '
+                         'between the vias of one call')
+
+
+class TestTwinsShareOneHole(_TmpCase):
+    """Coincident same-net sites are ONE physical hole, not a mutual refusal.
+
+    This is the half that makes the fix safe: an exposed pad modelled as an
+    F.Cu + B.Cu pair puts two routes at one coordinate on 5 of this repo's 22
+    boards (`interf_u` BUS1 has 31 such sites on one component), and distance 0
+    is below every threshold, so a plain spacing test drops the net whole. That
+    is the mechanism behind the #620 contributor's measured GND strap-pool
+    collapse (53 -> 0): `_has_copper` treats a `vias_to_add` entry as a ball's
+    anchor, so refusing the anchors leaves the extras nothing to strap to.
+    """
+
+    def test_two_routes_at_one_site_get_one_via(self):
+        """MUTATION: return 'conflict' instead of 'twin' for a same-net
+        coincident hit -- this arm dies with (0, 1) or (1, 1)."""
+        add, blocked, _t = _two_balls(0.0, 0.5, same_net=True)
+        self.assertEqual((len(add), len(blocked)), (1, 0),
+                         'coincident same-net sites are not sharing one via')
+
+    def test_the_shared_via_sits_where_both_balls_are(self):
+        """A via merged to the WRONG place disconnects both balls while
+        keeping the count right, so the count alone is not evidence."""
+        add, _b, _t = _two_balls(0.0, 0.5, same_net=True)
+        self.assertAlmostEqual(add[0]['x'], 10.0, places=6)
+        self.assertAlmostEqual(add[0]['y'], 10.0, places=6)
+        self.assertEqual(add[0]['net_id'], 7)
+
+    def test_two_NETS_at_one_site_are_a_conflict_not_a_twin(self):
+        """One hole cannot carry two nets. MUTATION: key the twin test on
+        position alone and drop the net comparison."""
+        add, blocked, _t = _two_balls(0.0, 0.5, same_net=False)
+        self.assertEqual((len(add), len(blocked)), (1, 1),
+                         'two different nets are sharing one hole, which is a '
+                         'short, or the second was silently skipped')
+
+    def test_the_pre_620_pass_STACKED_them(self):
+        """The behaviour being replaced, asserted from the writer's side so the
+        improvement is not just a claim: two identical dicts at one point are
+        two `(via ...)` s-exprs, because `kicad_writer` does not dedupe.
+
+        This arm pins that the FIX does not produce them. MUTATION: append
+        without consulting `_pending` -- duplicates return."""
+        add, _b, _t = _two_balls(0.0, 0.5, same_net=True)
+        keys = [(round(v['x'], 6), round(v['y'], 6), v['net_id']) for v in add]
+        self.assertEqual(len(keys), len(set(keys)),
+                         'stacked same-net vias at one point are back')
+
+
+class TestTheLadderKeepsTheEscape(_TmpCase):
+    """A refusal here drops the escape, so the ladder is what keeps this fix
+    from being the net negative the contributor measured."""
+
+    def test_a_conflict_a_deeper_rung_rescues_keeps_BOTH_escapes(self):
+        """MUTATION: delete the `thin_drill_to_clear` call and refuse
+        immediately -- this arm dies (1, 1)."""
+        add, blocked, _t = _two_balls(0.36, 0.32)
+        self.assertEqual((len(add), len(blocked)), (2, 0),
+                         'the ladder no longer rescues a pair a deeper drill '
+                         'rung can space')
+        self.assertEqual(sorted(v['drill'] for v in add), [0.15, 0.17],
+                         'both vias kept their original drill, so the pair '
+                         'that ships is still sub-floor')
+
+    def test_the_thinned_pair_actually_clears_the_floor(self):
+        """Asserting the drill VALUE is not the same as asserting the pair is
+        legal; a wrong rung would satisfy the arm above. Re-derive it."""
+        add, _b, _t = _two_balls(0.36, 0.32)
+        a, b = add[0], add[1]
+        gap = (math.hypot(a['x'] - b['x'], a['y'] - b['y'])
+               - a['drill'] / 2 - b['drill'] / 2)
+        self.assertGreaterEqual(round(gap, 6), H2H,
+                                f'the thinned pair still ships {gap:.4f}mm of '
+                                f'hole-to-hole against a {H2H}mm floor')
+
+    def test_the_escalation_is_DISCLOSED(self):
+        """A silent tier escalation is a fab cost the operator did not choose.
+        MUTATION: drop the `warn_fab_escalation` call."""
+        _a, _b, transcript = _two_balls(0.36, 0.32)
+        self.assertIn('thinned', transcript,
+                      'the drill thinning is now silent')
+        self.assertIn('escalated standard->advanced fab floor', transcript,
+                      'the thinning no longer routes through '
+                      'warn_fab_escalation, so --fab-tier advice is lost')
+
+    def test_no_rung_means_an_honest_drop_not_a_shipped_violation(self):
+        """The deepest-rung case. MUTATION: return the deepest drill from
+        `thin_drill_to_clear` regardless of `clears` -- this arm dies."""
+        add, blocked, transcript = _two_balls(0.30, 0.25)
+        self.assertEqual((len(add), len(blocked)), (1, 1))
+        self.assertIn('escape(s) dropped', transcript,
+                      'a dropped escape is not disclosed at all')
+        self.assertIn('hole-to-hole floor', transcript)
+
+
+class TestTheRingArmIsOnlyForBulgingVias(_TmpCase):
+    """The measured scope decision, re-derived rather than restated.
+
+    A via clamped INTO its pad adds no copper the pad did not already have, so
+    testing its ring against a sibling only restates the board's own ball
+    spacing. A via the clamp could not fit (status 'floor') really does bulge,
+    and is tested. The sweep says every ring-only rejection with a
+    non-sub-clearance pad gap is of the second kind, at every clearance.
+    """
+
+    def test_a_FITTING_pair_inside_ring_distance_is_kept(self):
+        """pitch 0.45, pad 0.40: via 0.40, so ring needs 0.40 + 0.10 = 0.50 and
+        the pair has 0.45 -- a ring test would refuse it. The pads themselves
+        are 0.05mm apart, so that refusal fixes nothing the board did not ship.
+
+        MUTATION: drop the `bulges` condition from the ring arm."""
+        self.assertEqual(_clamped(0.40)[2], 'clamped', 'rig no longer fits')
+        add, blocked, _t = _two_balls(0.45, 0.40)
+        self.assertEqual((len(add), len(blocked)), (2, 0),
+                         'a fitting via pair is being refused on ring '
+                         'clearance -- the phantom rejection')
+
+    def test_the_ring_arm_CANNOT_fire_alone_at_the_default_clearance(self):
+        """Measured while writing this file, and worth pinning because it makes
+        two of the arms here look wrong until you see it.
+
+        A bulging via is the deepest rung's, 0.25/0.15. Its ring needs
+        `0.25 + clearance`; its drill needs `0.15 + 0.20`. So the ring can only
+        refuse a pair the drill accepts when
+
+            via + clearance > drill + h2h   <=>   clearance > h2h - (via - drill)
+
+        which at the standard tier is `clearance > 0.10`. At the CLI default of
+        exactly 0.10 the two floors COINCIDE and the ring arm can never be the
+        deciding one -- which is why the (pitch, pad) sweep found 0 ring-only
+        real rejections at clearance 0.10 and 90/155/195/210 at 0.15/0.20/
+        0.25/0.30. The arms below therefore run at 0.20.
+
+        MUTATION: change the ring arm's `+ self._clearance` to a constant --
+        this arm's arithmetic no longer describes the code."""
+        vs, vd, st, _r = _clamped(0.10)
+        self.assertEqual((vs, vd, st), (0.25, 0.15, 'floor'))
+        self.assertAlmostEqual(vs + 0.10, vd + H2H, places=9,
+                               msg='the ring and drill floors no longer '
+                                   'coincide at clearance 0.10; the sweep '
+                                   'numbers quoted here are about other '
+                                   'geometry')
+
+    def test_a_BULGING_pair_inside_ring_distance_is_refused(self):
+        """The other half, so the arm above cannot pass by the ring arm being
+        dead. pad 0.10 cannot take even the deepest rung's 0.25 via, so the via
+        is held at the floor and bulges 0.075mm past the pad on every side.
+
+        Run at clearance 0.20 for the reason the previous arm measures, and at
+        a pitch where the DRILL clears -- otherwise the refusal cannot be
+        attributed to the ring at all.
+
+        MUTATION: delete the ring arm entirely -- this arm dies while every
+        drill arm still passes."""
+        vs, vd, st, _r = _clamped(0.10)
+        self.assertEqual(st, 'floor', 'rig no longer bulges')
+        self.assertGreaterEqual(0.40, vd + H2H,
+                                'the rig pitch must CLEAR the drill floor, or '
+                                'this arm cannot attribute the refusal to the '
+                                'ring')
+        self.assertLess(0.40, vs + 0.20,
+                        'the rig pitch must be inside ring distance')
+        add, blocked, _t = _two_balls(0.40, 0.10, clearance=0.20)
+        self.assertEqual((len(add), len(blocked)), (1, 1),
+                         'a bulging via pair inside ring clearance ships '
+                         'anyway; the ring arm is dead')
+
+    def test_a_FITTING_pair_at_the_same_distance_is_kept(self):
+        """The pair to the arm above, holding pitch and clearance fixed and
+        moving ONLY the bulge. Without this, 'refused at 0.40' could be any
+        rule at all.
+
+        pad 0.30 takes the 0.30 rung exactly, so the via fits and does not
+        bulge; its drill is thinned to 0.15 by the annular ring, so the drill
+        floor (0.35) still clears at 0.40."""
+        vs, vd, st, _r = _clamped(0.30)
+        self.assertEqual(st, 'clamped', 'rig no longer fits its pad')
+        self.assertGreaterEqual(0.40, vd + H2H)
+        self.assertLess(0.40, vs + 0.20, 'rig is not inside ring distance, so '
+                                         'it proves nothing about the ring')
+        add, blocked, _t = _two_balls(0.40, 0.30, clearance=0.20)
+        self.assertEqual((len(add), len(blocked)), (2, 0),
+                         'a FITTING via pair is refused on ring clearance -- '
+                         'the phantom rejection the scope exists to avoid')
+
+    def test_the_sweep_THIS_SCOPE_RESTS_ON_still_says_so(self):
+        """The scope decision is a measurement, so re-derive it here rather
+        than quoting it in prose. A number that lives only in a terminal is
+        exactly the kind that goes stale inside a confident comment.
+
+        For every physically possible (pitch, pad) -- pad < pitch, so the balls
+        do not overlap -- classify the pair the way the two candidate rules
+        would. The claim: of the pairs a RING rule would reject and the DRILL
+        rule would not, every one whose own pads are NOT already sub-clearance
+        is a BULGING via. If that ever stops holding, the ring arm's `bulges`
+        condition is refusing (or admitting) something new and this file's
+        argument for it no longer applies.
+
+        MUTATION: none in the engine -- this arm guards the DESIGN. It fails if
+        `clamp_via_to_pad` or the fab ladder changes shape, which is precisely
+        when the scope wants re-deciding."""
+        recorded = {0.10: 0, 0.15: 90, 0.20: 155, 0.25: 195, 0.30: 210}
+        pitches = [round(0.20 + i * 0.01, 4) for i in range(101)]
+        pads = [round(0.05 + i * 0.01, 4) for i in range(116)]
+        for clearance, expect in sorted(recorded.items()):
+            ring_only_real = 0
+            not_bulging = []
+            combos = 0
+            for pitch in pitches:
+                for psize in pads:
+                    if psize >= pitch:
+                        continue
+                    combos += 1
+                    vs, vd, _st, _r = _clamped(psize)
+                    d_bad = pitch < vd + H2H - 1e-9
+                    r_bad = pitch < vs + clearance - 1e-9
+                    if d_bad or not r_bad:
+                        continue
+                    if pitch - psize < clearance - 1e-9:
+                        continue                       # phantom: pads already
+                    ring_only_real += 1
+                    if vs <= psize + 1e-9:
+                        not_bulging.append((pitch, psize, vs, vd))
+            self.assertEqual(combos, 6565,
+                             'the sweep grid moved; the recorded counts below '
+                             'are about a different population')
+            self.assertEqual(
+                not_bulging, [],
+                f'at clearance {clearance}: {len(not_bulging)} ring-only '
+                f'rejection(s) are NOT bulging vias, e.g. {not_bulging[:3]} -- '
+                f'the `bulges` condition now excludes a real catch, so the '
+                f'drill-only-unless-bulging scope needs re-deciding')
+            self.assertEqual(
+                ring_only_real, expect,
+                f'at clearance {clearance} the sweep now finds '
+                f'{ring_only_real} ring-only real rejections, not the '
+                f'{expect} this scope was chosen against')
+
+    def test_the_ring_arm_is_foreign_net_only(self):
+        """Same-net copper in contact is not a clearance violation. Distance
+        0.40 clears the drill floor (0.35) so only the ring can decide.
+
+        MUTATION: drop the `onet != net_id` condition -- this arm dies."""
+        p = PendingVias(H2H, 0.20)
+        p.add(10.0, 10.0, 0.25, 0.15, 7, bulges=True)
+        same = p.verdict(10.40, 10.0, 0.25, 0.15, 7, bulges=True)
+        self.assertEqual(same[0], 'clear',
+                         'a same-net bulging pair is refused on ring '
+                         'clearance it does not owe')
+        foreign = p.verdict(10.40, 10.0, 0.25, 0.15, 8, bulges=True)
+        self.assertEqual(foreign[0], 'conflict',
+                         'the ring arm is dead: a foreign bulging pair 0.40 '
+                         'apart needs 0.45')
+
+
+class TestPendingViasItself(unittest.TestCase):
+    """The helper, directly. Module-level and pure precisely so it can be."""
+
+    def test_the_broad_phase_agrees_with_brute_force(self):
+        """The window is an optimisation, and a wrong window is INVISIBLE in
+        every aggregate count -- it just silently stops refusing. Compared
+        against an exhaustive scan over pseudo-random sites, fixed seed so a
+        failure is reproducible.
+
+        MUTATION: shrink the window (drop the `self._clearance` term, or use
+        `d` instead of `d/2 + max/2`) -- this arm dies."""
+        rng = random.Random(620)
+        for trial in range(200):
+            h2h = rng.choice((0.15, 0.20, 0.30))
+            clearance = rng.choice((0.10, 0.20))
+            p = PendingVias(h2h, clearance)
+            rows = []
+            for _ in range(rng.randint(1, 25)):
+                x = round(rng.uniform(0.0, 3.0), 4)
+                y = round(rng.uniform(0.0, 3.0), 4)
+                s = rng.choice((0.25, 0.30, 0.45))
+                d = rng.choice((0.15, 0.20, 0.30))
+                n = rng.randint(1, 3)
+                b = rng.random() < 0.5
+                cand = (x, y, s, d, n, b)
+                got = p.verdict(*cand)[0]
+                want = _brute(rows, cand, h2h, clearance)
+                self.assertEqual(got, want,
+                                 f'trial {trial}: broad phase disagrees with '
+                                 f'brute force at {cand} over {len(rows)} '
+                                 f'placed')
+                if got == 'clear':
+                    p.add(*cand)
+                    rows.append(cand)
+
+    def test_it_uses_math_hypot_not_numpy(self):
+        """#786/#787 closed on the finding that numpy's hypot is not CPython's
+        Neumaier-compensated one -- they disagree by 1 ULP on ~17% of off-grid
+        inputs, and each disagreement feeds a `dist < floor` comparison. A
+        vectorised port here would be a behaviour change needing a corpus A/B,
+        not a free win; it is also slower at this size (2.0ms vs 12.8ms on the
+        largest in-repo BGA). Asserted on the SOURCE because there is no other
+        way to catch a well-meaning port.
+
+        Stripped of comments first: this file's own prose mentions numpy, and
+        so does the class docstring, so a naive grep passes on the explanation
+        of why not to.
+        """
+        import inspect
+        import bga_fanout.geometry as g
+        src = inspect.getsource(g.PendingVias)
+        code = '\n'.join(ln for ln in src.splitlines()
+                         if not ln.lstrip().startswith('#'))
+        code = code.split('"""')[0] + '"""'.join(code.split('"""')[2:])
+        self.assertIn('math.hypot(', code)
+        self.assertNotIn('numpy', code)
+        self.assertNotIn('np.', code)
+
+
+def _brute(rows, cand, h2h, clearance, tol=1e-6, site_tol=0.001):
+    """The window-free spec `PendingVias.verdict` must match."""
+    x, y, s, d, net, bulges = cand
+    best = None
+    for (ox, oy, os_, od, onet, obulges) in rows:
+        dist = math.hypot(ox - x, oy - y)
+        if dist <= site_tol:
+            return 'twin' if onet == net else 'conflict'
+        if dist < d / 2 + od / 2 + h2h - tol:
+            if best is None or dist < best:
+                best = dist
+            continue
+        if (bulges or obulges) and onet != net:
+            if dist < s / 2 + os_ / 2 + clearance - tol:
+                if best is None or dist < best:
+                    best = dist
+    return 'conflict' if best is not None else 'clear'
+
+
+class TestTheLadderHelper(unittest.TestCase):
+    def test_it_returns_the_LARGEST_rung_that_clears(self):
+        """A ladder that jumps straight to the deepest rung escalates the fab
+        tier further than the geometry needs. MUTATION: iterate ascending."""
+        self.assertEqual(thin_drill_to_clear(0.30, LADDER, 0,
+                                             lambda d: d <= 0.20), 0.20)
+
+    def test_it_returns_None_when_no_rung_clears(self):
+        """MUTATION: return the last candidate instead of None -- the caller
+        then ships a violation instead of dropping honestly."""
+        self.assertIsNone(thin_drill_to_clear(0.30, LADDER, 0,
+                                              lambda d: False))
+
+    def test_an_override_file_leaves_NO_rung_to_descend(self):
+        """`fab_floor_ladder` collapses to one hard rung under an override
+        file, by design. That is the contributor's `via_drill = 0.35` arm, and
+        why this fix cannot rescue it. MUTATION: make the ladder fall back to
+        the packaged tiers when overrides are set."""
+        one = fab_floor_ladder(4, overrides={'via_drill': 0.35})
+        self.assertEqual(len(one), 1,
+                         'an override file no longer collapses the ladder; '
+                         'a run that pinned its fab limits can now escalate '
+                         'past them')
+        self.assertIsNone(thin_drill_to_clear(0.35, one, 0, lambda d: True),
+                          'a single-rung ladder must offer nothing thinner')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/test_620_pending_via_pairs.py
+++ b/tests/test_620_pending_via_pairs.py
@@ -480,6 +480,72 @@ class TestTheRingArmIsOnlyForBulgingVias(_TmpCase):
                          'apart needs 0.45')
 
 
+class TestTheSilentSkipIsNowAnHonestDrop(_TmpCase):
+    """#620's other half, in the SAME two guards.
+
+    `would_overlap_existing_via` used to gate the append as `if not ...:
+    append`, so when it fired the via was dropped and the ROUTE was kept: its
+    inner-layer track shipped anyway, connected to nothing, while the ball
+    still counted as escaped. The guard two lines above does the opposite --
+    `via_blocked_routes`, whose tracks the caller strips -- and the #508
+    comment at this function's call site says exactly why that shape was
+    adopted: the old code "left the sibling routes in `routes` -- still counted
+    escaped, shipping via-in-pad balls with no track."
+
+    THE REFUSAL SET IS UNCHANGED; only the bookkeeping is. Measured on
+    orangecrab_ext_pll U3 at defaults -- the one in-repo board that reaches
+    this branch -- it fires 11 times over the retry passes (4 distinct nets,
+    every blocker foreign) and the written board does not change, because each
+    stranded route was removed by a later filter anyway.
+
+    The rig needs a blocker that trips the RING guard while CLEARING the drill
+    guard that runs first, or the arm attributes the drop to the wrong rule: a
+    via of size 0.6 and drill 0.1 at 0.5mm needs 0.625 of ring (fires) and
+    0.35 of drill (clears).
+    """
+
+    def _run(self, sep, ov_size=0.6, ov_drill=0.1):
+        from synth import make_via
+        ball = _ball(10.0, 10.0, 7, 0.5)
+        r = FanoutRoute(pad=ball, pad_pos=(10.0, 10.0), stub_end=(10.5, 10.5),
+                        exit_pos=(11.0, 10.5), layer='B.Cu')
+        ov = make_via(10.0 + sep, 10.0, net_id=9, size=ov_size, drill=ov_drill)
+        pcb = make_pcb(board_info=BoardInfo(layers={},
+                                            copper_layers=list(CU),
+                                            board_bounds=(0.0, 0.0, 20.0, 20.0)),
+                       vias=[ov], segments=[], pads_by_net={7: [ball]},
+                       source_path='', zones=[])
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            add, _rm, blocked = manage_vias([r], pcb, 'F.Cu', 0.45, 0.2, 0.1)
+        return len(add), len(blocked)
+
+    def test_ON_THE_BRANCH_the_blocker_trips_the_ring_and_clears_the_drill(self):
+        """Without this, a drop at 0.5mm could be the drill guard and the arm
+        below would be about a different rule entirely."""
+        v_drill, ov_drill, h2h = 0.2, 0.1, H2H
+        self.assertGreaterEqual(0.5, v_drill / 2 + ov_drill / 2 + h2h,
+                                'the rig blocker no longer clears the DRILL '
+                                'guard, which runs first')
+        self.assertLess(0.5, 0.45 / 2 + 0.6 / 2 + 0.1,
+                        'the rig blocker no longer trips the RING guard, so '
+                        'nothing refuses and the arm is inert')
+
+    def test_the_refused_escape_is_REPORTED_not_silently_stranded(self):
+        """MUTATION: restore `if not would_overlap_existing_via(...): append`
+        -- the via count stays 0 and only the BLOCKED count catches it, which
+        is exactly why this arm asserts the pair."""
+        self.assertEqual(self._run(0.5), (0, 1),
+                         'a via refused on ring clearance leaves its route in '
+                         'place again: an inner-layer track with no via')
+
+    def test_a_clearing_blocker_still_gets_its_via(self):
+        """The acceptance half, so the arm above cannot pass on a rig that
+        refuses everything. 0.7 > 0.625."""
+        self.assertEqual(self._run(0.7), (1, 0),
+                         'the ring guard is now refusing a via that clears it')
+
+
 class TestPendingViasItself(unittest.TestCase):
     """The helper, directly. Module-level and pure precisely so it can be."""
 

--- a/tests/test_620_pending_via_pairs.py
+++ b/tests/test_620_pending_via_pairs.py
@@ -267,23 +267,24 @@ class TestTwinsShareOneHole(_TmpCase):
         """The anchor term in the broad-phase window, which nothing else makes
         binding.
 
-        `verdict`'s window is `max(drill term, ring term, anchor_tol)`. On a
-        BGA-sized pad the drill term (0.40mm at the standard floor) exceeds the
-        anchor radius, so dropping `atol` from the max changes nothing and the
-        mutation survives -- the battery caught exactly that. A BIG pad inverts
-        it: a 2.0mm pad has an anchor radius of 1.01mm against a 0.40mm drill
-        window, so a twin 0.9mm away is inside the pad and OUTSIDE the window.
-        Without the anchor term it is never even scanned, so the second route
-        gets its own via 0.9mm from the first -- two holes in one pad.
+        `verdict`'s window is `max(drill term, ring term, anchor half-width)`.
+        On a BGA-sized pad the drill term (0.40mm at the standard floor)
+        exceeds the anchor half-width, so dropping it from the max changes
+        nothing and the mutation survives -- the battery caught exactly that.
+        A BIG pad inverts it: a 2.0mm pad has a 1.01mm half-width against a
+        0.40mm drill window, so a twin 0.9mm away is inside the pad and
+        OUTSIDE the window. Without the anchor term it is never even scanned,
+        so the second route gets its own via 0.9mm from the first -- two holes
+        in one pad.
 
-        MUTATION: drop `atol` from the `window = max(...)` -- this arm dies."""
+        MUTATION: drop `ahx` from the `window = max(...)` -- this arm dies."""
         p = PendingVias(H2H, 0.1)
         p.add(10.0, 10.0, 0.45, 0.2, 7)
         self.assertGreater(1.01, 0.2 / 2 + 0.2 / 2 + H2H,
                            'the rig no longer makes the ANCHOR term the '
                            'binding one, so it cannot detect its loss')
         self.assertEqual(p.verdict(10.9, 10.0, 0.45, 0.2, 7,
-                                   anchor_tol=1.01)[0], 'twin',
+                                   anchor_box=(1.01, 1.01))[0], 'twin',
                          'a same-net via well inside this ball pad is no '
                          'longer recognised as its anchor')
         # ... and end to end, where it becomes a second hole in one pad.
@@ -291,6 +292,47 @@ class TestTwinsShareOneHole(_TmpCase):
         self.assertEqual((len(add), len(blocked)), (1, 0),
                          'two routes 0.9mm apart inside one 2.0mm pad got '
                          'two vias')
+
+    def test_an_OBLONG_pad_does_not_swallow_its_NEIGHBOUR(self):
+        """The regression an adversarial review found in the twin rule's first
+        version, which took `max(size_x, size_y) / 2 + 0.01` as a RADIUS and
+        compared it against a straight-line distance. On a 0.30 x 1.50 finger
+        that radius is 0.76mm -- more than twice the pad's own half-width --
+        so two same-net fingers 0.50mm apart, whose copper is 0.20mm apart and
+        NOT touching, merged into ONE via and the second route shipped with no
+        via while still counting as escaped. Exactly the defect the sibling
+        commit fixes, re-created by the merge. 17 footprints on 11 in-repo
+        boards match this geometry (glasgow U1/J5/U21, kit-dev U102/U301,
+        watchy U4/J3, rp2350 U6, tigard U5/U6, lvds IC2/IC3, orangecrab J6).
+
+        MUTATION: make `anchor_box` a scalar radius again, or compare `dist`
+        instead of the per-axis deltas -- this arm dies."""
+        a = _ball(10.0, 10.0, 7, 0.3, 'A1')
+        a.size_y = 1.5
+        b = _ball(10.5, 10.0, 7, 0.3, 'A2')
+        b.size_y = 1.5
+        ra = FanoutRoute(pad=a, pad_pos=(10.0, 10.0), stub_end=(10.0, 10.9),
+                         exit_pos=(10.0, 11.4), layer='B.Cu')
+        rb = FanoutRoute(pad=b, pad_pos=(10.5, 10.0), stub_end=(10.5, 9.1),
+                         exit_pos=(10.5, 8.6), layer='B.Cu')
+        pcb = make_pcb(board_info=BoardInfo(layers={}, copper_layers=list(CU),
+                                            board_bounds=(0.0, 0.0, 20.0, 20.0)),
+                       vias=[], segments=[], pads_by_net={7: [a, b]},
+                       source_path='', zones=[])
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            add, _rm, blocked = manage_vias([ra, rb], pcb, 'F.Cu', 0.45, 0.2,
+                                            0.1)
+        self.assertEqual(
+            (len(add), len(blocked)), (2, 0),
+            'two DISTINCT same-net pads 0.50mm apart were merged into one '
+            'via, so one route ships with no via and still counts escaped')
+        for pad in (a, b):
+            self.assertTrue(
+                any(abs(v['x'] - pad.global_x) <= pad.size_x / 2 + 0.01
+                    and abs(v['y'] - pad.global_y) <= pad.size_y / 2 + 0.01
+                    for v in add),
+                f'pad at ({pad.global_x}, {pad.global_y}) has no via inside it')
 
     def test_there_is_no_ONE_MICRON_CLIFF(self):
         """An exact-match twin rule had one, and an adversarial review found
@@ -304,7 +346,7 @@ class TestTwinsShareOneHole(_TmpCase):
         `_has_copper` spelling), so anything inside the pad is a via that
         already connects this ball.
 
-        MUTATION: replace `anchor_tol` with `self._tol` in `verdict` -- the
+        MUTATION: replace `anchor_box` with `self._tol` in `verdict` -- the
         0.0011 row dies."""
         for sep in (0.0, 0.0005, 0.0010, 0.0011, 0.05, 0.2):
             add, blocked, _t = _two_balls(sep, 0.5, same_net=True)
@@ -429,24 +471,45 @@ class TestTheLadderKeepsTheEscape(_TmpCase):
     def test_the_THINNED_drill_is_what_gets_recorded(self):
         """The pending record must carry the drill that actually ships, or the
         NEXT candidate is spaced against a hole that does not exist. Passing
-        the pre-thin drill is over-strict rather than unsafe, which is why no
-        arm caught it until a reviewer mutated exactly that line.
+        the pre-thin drill is over-strict rather than unsafe.
 
-        Asserted through behaviour: a third ball placed just outside the
-        THINNED floor and just inside the ORIGINAL one must be accepted.
+        THIS ARM RUNS `manage_vias`, and that is the whole point. An earlier
+        version asserted on `PendingVias` directly -- it built one record with
+        0.15 and one with 0.17 and checked they differ -- which is true of the
+        class and says NOTHING about which one the call site passes. A reviewer
+        applied the exact mutation the docstring named (capture the drill
+        before the ladder, hand THAT to `_pending.add`) and all 32 tests stayed
+        green while a real escape was lost.
 
-        MUTATION: `_pending.add(..., v_drill_before_thinning, ...)`."""
-        p = PendingVias(H2H, 0.1)
-        p.add(10.0, 10.0, 0.32, 0.15, 7)         # as if thinned 0.17 -> 0.15
-        # 0.36 clears 0.15/2 + 0.17/2 + 0.20 = 0.36 exactly, and clears the
-        # all-thinned floor 0.35; it would NOT clear 0.17/0.17 (0.37).
-        self.assertEqual(p.verdict(10.36, 10.0, 0.32, 0.17, 8)[0], 'clear')
-        stale = PendingVias(H2H, 0.1)
-        stale.add(10.0, 10.0, 0.32, 0.17, 7)     # the un-thinned record
-        self.assertEqual(stale.verdict(10.36, 10.0, 0.32, 0.17, 8)[0],
-                         'conflict',
-                         'the two records are indistinguishable here, so this '
-                         'arm cannot detect a stale drill')
+        Three balls in a row: the first pair conflicts and is rescued by the
+        ladder, and the third is spaced against the SECOND via's recorded
+        drill. With the thinned value recorded it clears; with the pre-thin
+        value it is refused.
+
+        MUTATION: `_pending.add(..., <the pre-thin drill>, ...)` -- this arm
+        dies (2 added, 1 blocked)."""
+        pads, routes = [], []
+        for i, x in enumerate((10.0, 10.36, 10.71)):
+            p = _ball(x, 10.0, 7 + i, 0.32, f'A{i}')
+            pads.append(p)
+            routes.append(FanoutRoute(
+                pad=p, pad_pos=(x, 10.0), stub_end=(x, 10.5),
+                exit_pos=(x, 11.0), layer='B.Cu'))
+        pcb = make_pcb(board_info=BoardInfo(layers={},
+                                            copper_layers=list(CU),
+                                            board_bounds=(0.0, 0.0, 20.0, 20.0)),
+                       vias=[], segments=[],
+                       pads_by_net={7 + i: [p] for i, p in enumerate(pads)},
+                       source_path='', zones=[])
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            add, _rm, blocked = manage_vias(routes, pcb, 'F.Cu', 0.45, 0.2, 0.1)
+        self.assertEqual(
+            (len(add), len(blocked)), (3, 0),
+            'the third ball was refused, which means it was spaced against a '
+            'drill wider than the one actually recorded')
+        self.assertEqual(sorted(v['drill'] for v in add), [0.15, 0.15, 0.17],
+                         'the drills that shipped are not the ladder result')
 
     def test_the_escalation_is_DISCLOSED(self):
         """A silent tier escalation is a fab cost the operator did not choose.


### PR DESCRIPTION
Closes #620. Closes #618.

`manage_vias` (`py_router/bga_fanout/__init__.py`) appended to `vias_to_add` and
never read it back, and both guards that gate an append iterate `pcb_data.vias`
only — so every via a call placed was spaced against the **input board and
against nothing else**. Two vias placed in one call were never compared.

The function's own docstring has named this gap since #756 and marked it
unfixed, with the impact "deliberately stated as UNMEASURED". It is measured
now, and the measurement corrects the issue on two points.

## The bug, measured

Two balls on a board carrying **no copper at all** — the point of the empty
board is that every pre-#620 guard scans `pcb_data`, so nothing but a pair test
can refuse. CLI-ish defaults (via 0.45 / drill 0.2 / clearance 0.1):

| pitch | pad | clamped via | holes apart | fab floor | before | after |
|---|---|---|---|---|---|---|
| 0.30 | 0.25 | 0.25/0.15 | **0.1500** | 0.20 | 2 added, 0 dropped | 1 added, 1 dropped |
| 0.25 | 0.20 | 0.25/0.15 | **0.1000** | 0.20 | 2 added, 0 dropped | 1 added, 1 dropped |
| 0.30 | 0.20 | 0.25/0.15 | **0.1500** | 0.20 | 2 added, 0 dropped | 1 added, 1 dropped |
| 0.35 | 0.25 | 0.25/0.15 | 0.2000 | 0.20 | 2 added | 2 added *(legal)* |
| 0.50 | 0.25 | 0.25/0.15 | 0.3500 | 0.20 | 2 added | 2 added *(legal)* |

Two **coincident same-net** balls shipped **two `(via …)` s-exprs at one point**
(`kicad_writer` does not dedupe — asserted by calling the writer, not by
describing it). They now share one hole.

**The issue's own worked example is the 0.50 row, and it was right to hedge:**
`clamp_via_to_pad` shrinks the via into the ball pad first and the pair is
legal. **No board in this repo reaches the refusal branch at CLI defaults** —
seven fanout runs, zero illegal emitted pairs, the tightest emitted pair
anywhere being orangecrab U4 at 0.2907 mm against a 0.20 floor. So the fixture
is **constructed**, and is labelled that way everywhere rather than dressed up
as a board result.

## Answering the negative result on this issue

@theironchef built this fix, measured it as a **net negative**, and posted the
numbers rather than opening a PR — which is why it is fixable at all. All five
of their figures reproduce exactly on today's main. Two of their findings are
load-bearing here:

* **A same-site exemption is mandatory.** Coincident F.Cu/B.Cu exposed-pad
  twins put two routes at one coordinate on 5 of this repo's 22 boards
  (`interf_u` BUS1 has 31 on one component). Distance 0 is below every
  threshold, so a plain spacing test makes twins refuse each other and takes
  the net with them. That is the mechanism behind their GND strap-pool collapse
  (53 → 0): `_has_copper` treats a `vias_to_add` entry as a ball's anchor, so
  refusing the anchors leaves the extras nothing to strap to.
* **A refusal has no second rung.** So a conflict now descends the fab drill
  ladder before giving up: at pitch 0.36 / pad 0.32 both escapes survive with
  the second drill thinned 0.17 → 0.15, disclosed through
  `warn_fab_escalation`. Their own arm cannot be rescued and is not claimed to
  be — `--fab-overrides` collapses the ladder to one hard rung *by design*, so
  `via_drill = 0.35` at 0.5 mm pitch has an unmeetable floor **and** no rung.

One correction: `run_output_conflict` **does** exist
(`qfn_fanout/__init__.py:133`). It is not reused — its `adds_via=True` floor
has no same-site exemption, so reusing it would change QFN behaviour.

## Two claims of mine that an adversarial review destroyed

Both were in the first commit, and both flattered the change.

**The scope justification was a tautology.** I swept 6565 (pitch, pad)
combinations and reported "of the ring-only rejections whose pads are not
already sub-clearance, 100% are bulging vias, at every clearance". That is a
restatement of two definitions — `pitch ≥ pad + clearance` and
`pitch < via + clearance` give `pad < via`, which *is* the bulge — and it holds
for any clamp function whatsoever (proved with via ≡ 5.0, via ≡ 0.01,
via = 3·pad, via = random: 0 exceptions in 25 cells). It measured nothing. It
is kept as an explicit **identity** test so nobody re-derives it as evidence,
and the contingent quantity is measured instead: a bulge-blind ring arm would
additionally reject 150 / 310 / 495 / 705 of 6565 combinations at clearance
0.10 / 0.15 / 0.20 / 0.25.

**The premise it stood in for was false.** "A via that fits inside its pad
occupies no copper the pad did not already occupy" holds on F.Cu only — a ball
pad is `['F.Cu']` and the via spans F.Cu–B.Cu, so on the inner layers there is
no pad under the ring at all. The honest argument, and the one that ships, is
different: a via clamped *into* its pad asks the fab for the etch pitch the
footprint already demands, while a bulging one asks for a tighter one — and a
via-in-pad site has no lever at all, since it *is* the ball centre and a
bulging via is already at the deepest fab rung.

## What ships

* **The drill, always** — the balls are SMD and carry no hole, so every hole is
  one this pass creates, and a thinner drill is a lever that can cure a
  conflict.
* **The ring, only when the via bulges past its pad**, foreign nets only.
* **Coincident same-net sites share one hole**, and the survivor is the
  **tighter** pad's clamp (keeping the first via re-created the #202 violation
  `clamp_via_to_pad` exists to prevent).
* **The twin rule keys on the ball's pad, as a rectangle** — an exact-match rule
  had a 1 µm cliff (0.0010 mm apart merged, 0.0011 mm apart dropped an escape),
  and a scalar *radius* was worse: see below.
* Scalar `math.hypot` with a sorted-by-x broad phase, **not numpy**: #786/#787
  closed on the finding that numpy's hypot is not CPython's Neumaier-compensated
  one (~17 % 1-ULP disagreement on off-grid inputs, each feeding a
  `dist < floor` comparison), and the broad phase is also faster here
  (2.0 ms vs 12.8 ms on the largest in-repo BGA, 529 balls).
* **The second guard's bookkeeping.** `would_overlap_existing_via` returning
  True dropped the via and *kept* the route — an inner-layer track with no via,
  still counted escaped. It now goes to `via_blocked_routes` like its sibling.
  The refusal set is unchanged; the census (same probe, both trees, command in
  the commit message) says the branch fires **11 times at base and 6 after**, on
  4 nets, every blocker foreign, and 0 times on four other arms — the drop is
  the point, since a refused route no longer survives into the retry passes.
  The board does not change.

## A second review round, and a regression it caught in my fix for the first

A second adversarial pass over the review fixes found seven more, one of them a
**regression I had just introduced**:

* **The twin rule's first version merged DISTINCT pads.** It took
  `max(size_x, size_y) / 2 + 0.01` as a radius against a straight-line
  distance. On a 0.30 × 1.50 finger that is 0.76 mm — more than twice the pad's
  own half-width — so two same-net fingers 0.50 mm apart, copper 0.20 mm apart
  and *not touching*, merged into one via and the second route shipped with no
  via while still counting as escaped. **Exactly the defect this PR fixes
  elsewhere.** 17 footprints on 11 in-repo boards match the geometry, and every
  real firing was this wrong case; it was latent (final copper unchanged on
  those boards) rather than shipping, which is not a defence. `anchor_box` is
  now the pad's half-extents, tested per axis.
* **`test_the_THINNED_drill_is_what_gets_recorded` named a mutation it could
  not kill** — it asserted on `PendingVias` directly and never ran
  `manage_vias`, so it could not see which drill the call site passes. Rewritten
  to run the engine over three balls; verified to die under the mutation.
* **The #618 decline counter counted gate CALLS, not pairs** — it printed "8
  coupled pair(s) declined" on a board with one coupled pair. Counts a set of
  pair identities now, pinned by an arm asserting the declined count can never
  exceed the pairs the run found.
* **My census figure was the BASE arm and carried no command.** Re-measured with
  one probe in both trees: 11 → 6, four nets. A reviewer's 16 → 9 with six nets
  is the same board *without* `--plane-drop off`; the two extra nets are plane
  nets that flag excludes. Both are right, and neither was reproducible without
  its flags.
* Three battery rows were misnamed or mis-explained (`ladder-never-tried` is
  semantically inert and is now `control-semantically-inert-edit`;
  `ladder-climbs-above-its-own-rung` kept its verdict and lost a wrong reason;
  `silent-skip-restored` deleted the refusal rather than restoring the old
  shape, and is now split into two rows).
* And my own `anchor_tol` → `anchor_box` rename **staled 10 of 37 battery
  anchors**, which the runner reported as BROKEN rather than as survivors —
  the distinction that makes it a battery.

## #618, clause by clause

Three of its four claims are false at HEAD, so the PR records what is actually
true rather than repeating them.

| clause | verdict |
|---|---|
| "sites sit at ball centres, not through `_via_site_conflict`" | **TRUE for the coupled diff-pair emit only** — the single-ended centre site was closed by #567 (`bbd65f31`). **Closed here.** |
| "a board declaring `min_hole_to_hole` 0.9 still gets 0.6 mm gaps (ulx3s U1)" | **FALSE at HEAD** — closed by #756 (`7303cd82`, committed *one hour after* the issue was filed). Also not reproducible as written: `kicad_files/ulx3s.kicad_pro` does not exist, so the 0.9 is constructed. With one planted, sub-0.9 pairs go **62 → 0**. |
| "arguably refuse-to-build … needs a policy decision" | **OPEN, and answered: WARN.** Refuse-to-build was measured and rejected — honouring 0.9 on ulx3s costs 15 of 199 escapes, so refusing the *run* throws away 184 good escapes to prevent 62 bad holes. |
| "#616 already handles every non-via-in-pad site" | a statement, not a request |

`_coupled_via_sites_ok` gates both coupled sites through `_via_site_conflict`
(`skip_resv=True`, for #567's own reason) and adds the test that function cannot
do — the pair against **itself**, since neither via is in `vias_to_add` when the
decision is made. The policy answer is a disclosure line; on
`ulx3s U1 --escape-method underpad` it now says:

```
Under-pad: 5 via-in-pad centre site(s) and 0 coupled pair(s) declined by the
0.2mm hole-to-hole floor (fixed default); the levers are a smaller --via-drill,
a fab tier whose floor this pitch can meet, or the board's own min_hole_to_hole
```

Those five declines were previously invisible.

## Gates

Base = upstream/main `8aa76378`, re-run, not an archived wave. Copper compared
**parsed at full precision**, never file bytes (outputs carry per-run UUIDs).

| arm | escaped/failed | vias | DRC | min emitted h2h | copper | check_connected |
|---|---|---|---|---|---|---|
| orangecrab U3 `--fab-overrides via_drill=0.35` | 19/95 | 4 | 740 | 0.6500 | IDENTICAL | IDENTICAL |
| orangecrab U3 default | 19/95 | 5 | 732 | 0.8500 | IDENTICAL | IDENTICAL |
| orangecrab U4 default | 0/0 | 12 | 545 | 0.2907 | IDENTICAL | IDENTICAL |
| glasgow_revC U30 (declares 0.25) | 99/0 | 37 | 785 | 0.6000 | IDENTICAL | IDENTICAL |
| ulx3s U1 under-pad | 199/5 | 81 | 2136 | 0.5500 | IDENTICAL | IDENTICAL |
| ulx3s U1 under-pad, diff pairs | 199/5 | 85 | — | 0.5000 | IDENTICAL | IDENTICAL |
| orangecrab U3 under-pad, diff pairs | 0/13 | 113 | — | 0.2000 | IDENTICAL | IDENTICAL |

The first row is the contributor's own command. **The strap pool stays at 53.**

Independently reproduced by a reviewer with their own comparator on three of
these boards, and on 60 dense random ball grids: the fix ships **0** sub-floor
drill pairs where base ships **977**. A second reviewer re-ran two arms with
their own copper hash and got the same identity.

**Mutation battery** (`tests/mutate_620.py`, three targets):
**37 rows, 34 killed, 3 survived — all 3 expected, 0 broken.** The three
survivors are recorded no-ops with their measured reasons, not deleted:
a semantically-inert control, a ladder-slice widening the `< drill` filter
discards, and the coupled gate's board-copper check, which the occupancy grid
already covers (planting a foreign via on the exact coordinate a coupled escape
chooses still keeps every emitted via clear of it with that check disabled).

**Also run:** `test_620` 34, `test_618` 6 (~9 min), `test_370`, `test_756` 35,
and the wx-free parity gates `test_cli_postpass_coverage` (no new CLI-only
post-pass) and `test_manifest_plan_parity`. **Not run:** `ab_replay_grade.py`
(needs a recorded run set absent from this checkout) and the KiCad-python GUI
gates — this change is Class 1 (shared engine, reached by `fanout_gui.py`
through `generate_bga_fanout`), so it adds no parameter for the GUI to thread.

## Not done here, measured and named

`bga_fanout.py` passes `hole_to_hole_clearance` to `enforce_fab_floors`
(`getattr(args, …, None)`) but **never declares the flag**, so it is always
`None` — while `route.py`, `route_diff.py`, `route_planes.py` and
`repair_planes.py` all declare it. Closing that means a new engine parameter
and the full GUI parity thread for a knob #618 does not ask for; it wants its
own issue.

Three residuals are named in the `manage_vias` docstring rather than hidden: a
conflict is resolved against vias committed *so far* (a later whole-net drop can
delete a blocker a refusal was measured against); the loser of a conflict is
whoever arrives later, with no tiebreak (deterministic, not escape-maximising);
and a refusal costs the net's whole fanout, which the disclosure now says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9ujvWvgTRjQYyzibuy5yT
