### PR TITLE
#846/#854/#652: three fanout sites that never measure reach

### DIFF
--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -730,6 +730,15 @@ Options:
   --board-edge-clearance  Min clearance from stub/via copper to the Edge.Cuts
                       outline in mm (default 0 = use --clearance)
   --allow-via-in-pad  Underpad escape: let the escape via overlap its OWN pad
+                      (via-in-pad), so a via boxed in on the outward side can
+                      stagger inward instead of being dropped. It ALSO enables
+                      an inward search along the escape axis that steps by the
+                      inter-net stagger -- on a fine-pitch part its later rungs
+                      land past the pad edge on the chip side -- and four extra
+                      stagger configurations (#846). A via that overlaps its pad
+                      is clamped to the pad edge (#202) and needs IPC-4761 Type
+                      VII; JSON_SUMMARY reports via_in_pad / via_in_pad_clamped /
+                      via_in_pad_offcentre / max_stub_mm.
   --fab-tier          JLC fab capability floor: standard (default) or advanced
   --fab-overrides FILE  Fab-floor override file overlaying the selected --fab-tier
 ```

--- a/kicad_routing_plugin/fanout_gui.py
+++ b/kicad_routing_plugin/fanout_gui.py
@@ -1261,8 +1261,12 @@ class QFNOptionsPanel(wx.ScrolledWindow):
             "Under-pad escape only: let the escape via overlap its OWN pad "
             "(via-in-pad), so a leg boxed in on the outward side (a neighbour "
             "pad/track a pitch away) staggers inward toward the chip instead of "
-            "being dropped (#161). The via still must clear other-net pads, vias "
-            "and tracks.")
+            "being dropped (#161). It also enables an INWARD search along the "
+            "escape axis that steps by the inter-net stagger, so on a fine-pitch "
+            "part its later rungs land past the pad edge on the chip side, and "
+            "four extra stagger configurations (#846). A via that does overlap "
+            "its pad is clamped to the pad edge (#202) and needs IPC-4761 Type "
+            "VII. The via still must clear other-net pads, vias and tracks.")
         main_sizer.Add(self.allow_via_in_pad, 0, wx.LEFT | wx.RIGHT | wx.BOTTOM, 8)
 
         self.SetSizer(main_sizer)

--- a/py_router/bga_fanout/__init__.py
+++ b/py_router/bga_fanout/__init__.py
@@ -53,6 +53,7 @@ from bga_fanout.geometry import (
     via_clears_pad_rects,
     PendingVias,
     thin_drill_to_clear,
+    via_anchors_route,
 )
 from bga_fanout.escape import (
     find_escape_channel,
@@ -621,6 +622,7 @@ def manage_vias(
     via_size: float,
     via_drill: float,
     clearance: float,
+    track_width: float = 0.0,
 ) -> Tuple[List[Dict], List[Dict], List['FanoutRoute']]:
     """
     Manage vias for fanout routes.
@@ -635,6 +637,12 @@ def manage_vias(
         via_size: Size of vias to add
         via_drill: Drill size for vias
         clearance: Minimum clearance between vias
+        track_width: Width of the tracks these routes emit. Only the same-net
+            via-merge (#854) uses it: a committed via serves another route
+            when it reaches that route's track start at via_radius +
+            track_width / 2. 0 (the default) means "the via's copper only" --
+            the conservative reading, correct for a caller that does not know
+            the width.
 
     Returns:
         Tuple of (vias_to_add, vias_to_remove, via_blocked_routes)
@@ -892,7 +900,7 @@ def manage_vias(
     # against nothing else. `PendingVias` is the missing half; what it tests
     # and what it deliberately does not is argued at its definition.
     _pending = PendingVias(_h2h, clearance)
-    _twin_shared = 0       # coincident same-net sites served by ONE hole
+    _twin_shared = 0       # routes an already-placed via REACHES (#854)
     _thinned = []          # (from, to) drills a deeper fab rung rescued
     _pending_refused = []  # (net name, reason) escapes no rung could place
 
@@ -950,20 +958,21 @@ def manage_vias(
                 # Placed AFTER them so the board keeps its present precedence
                 # -- this only decides among sites THIS call is creating.
                 _bulges = status == 'floor'
-                # The candidate ball's pad, as a RECTANGLE: a via inside it
-                # is a via that connects this ball. A scalar radius here
-                # merged two DISTINCT oblong pads into one via and stranded
-                # the loser's route -- see `PendingVias.verdict`.
-                _abox = (route.pad.size_x / 2 + 0.01,
-                         route.pad.size_y / 2 + 0.01)
+                # A committed via is this ball's only when it REACHES the
+                # track this route starts at the pad centre. Testing the
+                # candidate's pad RECTANGLE instead let a large pad swallow a
+                # smaller overlapping same-net pad's via and strand the
+                # loser's route (#854) -- see `via_anchors_route`.
                 _v, _detail = _pending.verdict(pad_x, pad_y, v_size, v_drill,
                                                route.net_id, _bulges,
-                                               anchor_box=_abox)
+                                               track_width=track_width)
                 if _v == 'twin':
-                    # Two routes, one physical hole. Both keep their tracks and
-                    # both anchor to the via already committed here: the ball-
-                    # anchor test downstream (`_has_copper`) looks for a via
-                    # inside the pad, and this is that via. Today's code
+                    # Two routes, one physical hole. Both keep their tracks
+                    # and both anchor to the via already committed here --
+                    # which is now true by construction, because 'twin' means
+                    # that via REACHES this route's track start (#854), and the
+                    # downstream ball-anchor test (`_has_copper`) asks the same
+                    # question of the same via. Today's code
                     # appends a second identical dict and the writer, which
                     # does not dedupe, emits both as stacked copper.
                     #
@@ -993,7 +1002,7 @@ def manage_vias(
                         v_drill, floors, rung,
                         lambda cand: _pending.verdict(
                             pad_x, pad_y, v_size, cand, route.net_id,
-                            _bulges, anchor_box=_abox)[0] == 'clear')
+                            _bulges, track_width=track_width)[0] == 'clear')
                     if _thin is None:
                         via_blocked_routes.append(route)
                         _pending_refused.append(
@@ -1055,8 +1064,8 @@ def manage_vias(
     # this run's own vias meeting each other, which the reader cannot act on in
     # the same way: the levers are the pitch, the drill and the fab tier.
     if _twin_shared:
-        print(f"  #620: {_twin_shared} coincident same-net site(s) share one "
-              f"via instead of stacking two")
+        print(f"  #620: {_twin_shared} same-net route(s) reached an already "
+              f"placed via instead of stacking a second one")
     if _thinned:
         # The SET of drills, not min(): several rungs can be used in one run
         # and "thinned to 0.15mm" would misdescribe a via thinned to 0.17.
@@ -2954,14 +2963,28 @@ def _generate_bga_fanout_core(footprint: Footprint,
                                           | set())
                               if n not in failed_nets}
             def _has_copper(_p):
-                # Layer-aware: an SMD ball is connected by a net VIA inside its
-                # pad (spans all layers) or a net track endpoint ON ITS OWN
-                # layer -- copper crossing the pad on an inner layer is not a
-                # connection. Drilled / '*.Cu' balls conduct on every layer.
+                # Layer-aware: an SMD ball is connected by a net VIA that
+                # REACHES its pad (the via spans all layers) or a net track
+                # endpoint ON ITS OWN layer -- copper crossing the pad on an
+                # inner layer is not a connection. Drilled / '*.Cu' balls
+                # conduct on every layer.
+                #
+                # #854: the via arm used to ask `max(size_x, size_y) / 2 + 0.01`
+                # in BOTH axes -- the scalar-radius shape PR #852's review
+                # removed from `PendingVias.verdict`, surviving here as the
+                # DOWNSTREAM anchor test that rule appeals to by name. Two
+                # graders agreeing in the wrong direction is why the stranding
+                # was silent: on the issue's own repro that tol is 0.51mm, so a
+                # ball whose only via sits 0.4mm away read as ANCHORED and
+                # `_strap_unescaped_extras` never strapped it. Both ask
+                # `via_anchors_route` now. The TRACK arm below keeps `tol`: it
+                # asks a different question (is a track ENDPOINT at this pad),
+                # and a track endpoint anywhere on the pad does connect it.
                 tol = max(_p.size_x, _p.size_y) / 2 + 0.01
                 if any(_v['net_id'] == _p.net_id
-                       and abs(_v['x'] - _p.global_x) < tol
-                       and abs(_v['y'] - _p.global_y) < tol
+                       and via_anchors_route(_v['x'], _v['y'],
+                                             _v.get('size') or 0.0,
+                                             (_p.global_x, _p.global_y), _tw)
                        for _v in vias_to_add):
                     return True
                 _pl = None
@@ -3602,7 +3625,8 @@ def _generate_bga_fanout_core(footprint: Footprint,
         # Via management: add vias where needed, remove unnecessary ones
         _prog("placing vias...")
         vias_to_add, vias_to_remove, via_blocked_routes = manage_vias(
-            routes, pcb_data, layers[0], via_size, via_drill, clearance
+            routes, pcb_data, layers[0], via_size, via_drill, clearance,
+            track_width=track_width
         )
 
         # Routes whose required via-in-pad would hit an immovable foreign pad
@@ -3703,7 +3727,8 @@ def _generate_bga_fanout_core(footprint: Footprint,
         # guard below, which previously scanned pre-repair vias against
         # post-repair tracks.
         vias_to_add, vias_to_remove, _reblocked = manage_vias(
-            best_routes, pcb_data, layers[0], via_size, via_drill, clearance)
+            best_routes, pcb_data, layers[0], via_size, via_drill, clearance,
+            track_width=track_width)
         if _reblocked:
             from bga_fanout.reroute import _remove_route_tracks
             _rb_net_ids = {r.net_id for r in _reblocked}

--- a/py_router/bga_fanout/__init__.py
+++ b/py_router/bga_fanout/__init__.py
@@ -1016,14 +1016,14 @@ def manage_vias(
                                                route.net_id, _bulges,
                                                track_width=track_width)
                 if _v == 'twin':
-                    # Two routes, one physical hole. Both keep their tracks
-                    # and both anchor to the via already committed here --
-                    # which is now true by construction, because 'twin' means
-                    # that via REACHES this route's track start (#854), and the
-                    # downstream ball-anchor test (`_has_copper`) asks the same
-                    # question of the same via. Today's code
-                    # appends a second identical dict and the writer, which
-                    # does not dedupe, emits both as stacked copper.
+                    # Two routes, one physical hole. Both keep their tracks and
+                    # both anchor to the via already committed here, because
+                    # 'twin' means that via REACHES this route's track start
+                    # (#854), and the downstream ball-anchor test
+                    # (`ball_has_copper`) asks the same question of the same
+                    # via. Today's code appends a second identical dict and the
+                    # writer, which does not dedupe, emits both as stacked
+                    # copper.
                     #
                     # The SURVIVOR must be the tighter pad's clamp. Which via
                     # survived used to be whichever route arrived first, so two
@@ -1031,17 +1031,36 @@ def manage_vias(
                     # bulging past the 0.25 pad -- the #202 violation
                     # `clamp_via_to_pad` exists to prevent, re-created by the
                     # merge. Tighten instead.
+                    #
+                    # BUT TIGHTENING CAN BREAK THE REACH THAT JUSTIFIED THE
+                    # MERGE, and only since #854: `verdict` decided 'twin' from
+                    # the COMMITTED via's size, and `tighten` then replaces it
+                    # with min(that, this route's clamp) -- a smaller barrel
+                    # reaches less far. Under the old pad-BOX rule this could
+                    # not happen, because a box test does not depend on via
+                    # size, so the interaction is new. A pre-push review found
+                    # it before any board did (no corpus twin is far enough
+                    # from its pad for the shrink to matter -- every one sits
+                    # at distance 0). Re-check after the shrink and fall
+                    # through to the normal path, where this route gets its own
+                    # via. Skipping the tighten instead would ship the #202
+                    # bulge; refusing the merge is the honest half.
                     _tx, _ty, _ts, _td = _detail
-                    if _pending.tighten(_tx, _ty, v_size, v_drill):
-                        for _v_dict in vias_to_add:
-                            if (_v_dict['x'] == _tx and _v_dict['y'] == _ty
-                                    and _v_dict['net_id'] == route.net_id):
-                                _v_dict['size'] = min(_v_dict['size'], v_size)
-                                _v_dict['drill'] = min(_v_dict['drill'],
-                                                       v_drill)
-                                break
-                    _twin_shared += 1
-                    continue
+                    if not via_anchors_route(_tx, _ty, min(_ts, v_size),
+                                             (pad_x, pad_y), track_width):
+                        _v = 'clear'
+                    else:
+                        if _pending.tighten(_tx, _ty, v_size, v_drill):
+                            for _v_dict in vias_to_add:
+                                if (_v_dict['x'] == _tx and _v_dict['y'] == _ty
+                                        and _v_dict['net_id'] == route.net_id):
+                                    _v_dict['size'] = min(_v_dict['size'],
+                                                          v_size)
+                                    _v_dict['drill'] = min(_v_dict['drill'],
+                                                           v_drill)
+                                    break
+                        _twin_shared += 1
+                        continue
                 if _v == 'conflict':
                     # A refusal here drops the escape -- there is no re-sweep
                     # -- so descend the fab ladder's drill floors first. The

--- a/py_router/bga_fanout/__init__.py
+++ b/py_router/bga_fanout/__init__.py
@@ -615,6 +615,55 @@ def create_single_ended_route(
 _H2H_ANNOUNCED = set()
 
 
+def ball_has_copper(pad, vias, tracks, track_width: float = 0.0) -> bool:
+    """Is this ball connected by copper THIS PASS placed?
+
+    Layer-aware: an SMD ball is connected by a net VIA that REACHES it (a via
+    spans every layer) or by a net track ENDPOINT on its own layer -- copper
+    merely crossing the pad on an inner layer is not a connection. Drilled or
+    '*.Cu' balls conduct on every layer.
+
+    The two arms ask different questions on purpose, and the difference is the
+    #854 fix:
+
+    * The VIA arm asks REACH (``via_anchors_route``). It used to ask
+      ``max(size_x, size_y) / 2 + 0.01`` in BOTH axes -- the scalar-radius shape
+      PR #852's review removed from ``PendingVias.verdict``, surviving here as
+      the DOWNSTREAM ball-anchor test that rule appeals to by name. Two graders
+      agreeing in the wrong direction is why the stranding was silent: on the
+      issue's own repro that tolerance is 0.51mm, so a ball whose only via sat
+      0.4mm away read as ANCHORED and ``_strap_unescaped_extras`` never strapped
+      it.
+    * The TRACK arm keeps the pad-box tolerance. "Is there a track endpoint at
+      this pad" is a different question, and an endpoint anywhere on the pad
+      copper does connect it.
+
+    Module-level rather than a closure because a predicate nothing can call is
+    a predicate nothing tests: as a closure it survived a mutation that reverted
+    the via arm to the old box.
+    """
+    if any(v['net_id'] == pad.net_id
+           and via_anchors_route(v['x'], v['y'], v.get('size') or 0.0,
+                                 (pad.global_x, pad.global_y), track_width)
+           for v in vias):
+        return True
+    tol = max(pad.size_x, pad.size_y) / 2 + 0.01
+    pad_layer = None
+    for lay in (pad.layers or []):
+        if lay.endswith('.Cu') and not lay.startswith('*'):
+            pad_layer = lay
+            break
+    any_layer = pad_layer is None or (pad.drill or 0) > 0
+    return any(
+        t['net_id'] == pad.net_id
+        and (any_layer or t['layer'] == pad_layer) and (
+            (abs(t['start'][0] - pad.global_x) < tol
+             and abs(t['start'][1] - pad.global_y) < tol)
+            or (abs(t['end'][0] - pad.global_x) < tol
+                and abs(t['end'][1] - pad.global_y) < tol))
+        for t in tracks)
+
+
 def manage_vias(
     routes: List[FanoutRoute],
     pcb_data: 'PCBData',
@@ -2962,47 +3011,9 @@ def _generate_bga_fanout_core(footprint: Footprint,
             _escaped_names = {n for n in ({_p.net_name for _p in _extras}
                                           | set())
                               if n not in failed_nets}
-            def _has_copper(_p):
-                # Layer-aware: an SMD ball is connected by a net VIA that
-                # REACHES its pad (the via spans all layers) or a net track
-                # endpoint ON ITS OWN layer -- copper crossing the pad on an
-                # inner layer is not a connection. Drilled / '*.Cu' balls
-                # conduct on every layer.
-                #
-                # #854: the via arm used to ask `max(size_x, size_y) / 2 + 0.01`
-                # in BOTH axes -- the scalar-radius shape PR #852's review
-                # removed from `PendingVias.verdict`, surviving here as the
-                # DOWNSTREAM anchor test that rule appeals to by name. Two
-                # graders agreeing in the wrong direction is why the stranding
-                # was silent: on the issue's own repro that tol is 0.51mm, so a
-                # ball whose only via sits 0.4mm away read as ANCHORED and
-                # `_strap_unescaped_extras` never strapped it. Both ask
-                # `via_anchors_route` now. The TRACK arm below keeps `tol`: it
-                # asks a different question (is a track ENDPOINT at this pad),
-                # and a track endpoint anywhere on the pad does connect it.
-                tol = max(_p.size_x, _p.size_y) / 2 + 0.01
-                if any(_v['net_id'] == _p.net_id
-                       and via_anchors_route(_v['x'], _v['y'],
-                                             _v.get('size') or 0.0,
-                                             (_p.global_x, _p.global_y), _tw)
-                       for _v in vias_to_add):
-                    return True
-                _pl = None
-                for _l in (_p.layers or []):
-                    if _l.endswith('.Cu') and not _l.startswith('*'):
-                        _pl = _l
-                        break
-                any_layer = _pl is None or (_p.drill or 0) > 0
-                return any(
-                    _t['net_id'] == _p.net_id
-                    and (any_layer or _t['layer'] == _pl) and (
-                        (abs(_t['start'][0] - _p.global_x) < tol
-                         and abs(_t['start'][1] - _p.global_y) < tol)
-                        or (abs(_t['end'][0] - _p.global_x) < tol
-                            and abs(_t['end'][1] - _p.global_y) < tol))
-                    for _t in tracks)
             _bare = [_p for _p in _extras
-                     if _p.net_name in _escaped_names and not _has_copper(_p)]
+                     if _p.net_name in _escaped_names
+                     and not ball_has_copper(_p, vias_to_add, tracks, _tw)]
             if _bare:
                 _prog(f"strapping {len(_bare)} unescaped extra ball(s)...")
                 _n_strap, _still = _strap_unescaped_extras(

--- a/py_router/bga_fanout/geometry.py
+++ b/py_router/bga_fanout/geometry.py
@@ -297,6 +297,44 @@ def calculate_jog_end(exit_pos: Tuple[float, float],
 
 # --- #620: the run's own output, testable against itself ---------------------
 
+def via_anchors_route(via_x: float, via_y: float, via_size: float,
+                      pad_pos: Tuple[float, float],
+                      track_width: float = 0.0) -> bool:
+    """Does a via at (via_x, via_y) physically REACH this route's track start?
+
+    #854. The question a via-merge must answer is not "is that via somewhere
+    inside my pad's rectangle" -- it is "does that via touch the copper this
+    route starts from". Every emission path in ``bga_fanout/tracks.py`` starts
+    the route's first segment at ``route.pad_pos``, and that track lives on an
+    INNER or bottom layer while the ball pad lives on the top one, so the pad
+    reaches its own track only THROUGH the via. A via that does not overlap the
+    track start therefore connects nothing, however deep inside the pad's
+    bounding box its centre happens to sit.
+
+    Keying on the pad box instead let a LARGE pad swallow a SMALLER overlapping
+    same-net pad's committed via: the large pad's route then shipped an
+    inner-layer track starting where no via reaches, and still counted as
+    escaped -- the very defect ``would_overlap_existing_via``'s #620 half was
+    fixed to prevent. Measured on ``kicad_files/kit-dev-coldfire-xilinx_5213``,
+    footprint VR201 (TO-263-5, net GND): the 10.8 x 9.4mm tab's box is
+    (5.41, 4.71), a 5.25 x 4.55 paste sub-pad's via sits at dx 2.775 / dy 2.425
+    -- inside the box on both axes -- and the adopted via is **3.6853mm** from
+    the tab route's track start, against a 0.225mm ring.
+
+    ``track_width`` defaults to 0, i.e. the via's own copper only. That is the
+    conservative reading and the right one for a caller that does not know the
+    width; the fanout passes its real (fab-clamped) width.
+
+    This is the SECOND time this rule has been a containment test standing in
+    for a reach test -- see ``PendingVias.verdict``'s note on the scalar radius
+    an adversarial review caught in PR #852, and #695 before it ("credits a pad
+    by via centre but a track by via radius"). It is spelled out so it is not
+    the third.
+    """
+    return (math.hypot(via_x - pad_pos[0], via_y - pad_pos[1])
+            <= (via_size or 0.0) / 2.0 + (track_width or 0.0) / 2.0)
+
+
 class PendingVias:
     """The via-in-pads ONE ``manage_vias`` call has already committed.
 
@@ -417,23 +455,35 @@ class PendingVias:
             self._max_size = s
 
     def verdict(self, x, y, size, drill, net_id, bulges=False, tol=1e-6,
-                anchor_box=None):
+                track_width=0.0):
         """How a candidate at (x, y) relates to what this call already placed.
 
-        ``anchor_box`` is the candidate BALL's own pad half-extents,
-        ``(size_x / 2 + t, size_y / 2 + t)`` -- a RECTANGLE, because a pad is
-        one. Default: the 1 um site tolerance in both axes.
+        ``track_width`` is the width of the track this candidate's route will
+        emit; a committed via is a twin when it REACHES that route's track
+        start at ``via_radius + track_width / 2`` -- see ``via_anchors_route``.
+        Default 0 = the via's own copper only.
 
-        A SCALAR RADIUS HERE WAS A BUG, and an expensive one, so it is spelled
-        out. The first version took ``max(size_x, size_y) / 2 + 0.01`` and
-        compared it against a straight-line distance, which on an OBLONG pad
-        reaches far outside the copper along the short axis: two same-net
-        0.30 x 1.50 fingers 0.50mm apart -- an ordinary fine-pitch QFP pair
-        whose pads are 0.20mm apart and NOT touching -- were merged into one
-        via, and the second route shipped with no via at all while still
-        counting as escaped. That is precisely the defect the sibling commit
-        fixes, re-created by the merge. An adversarial review found it, with
-        17 footprints on 11 in-repo boards matching the geometry.
+        THE PAD IS NOT THE TEST, and this took three attempts to get right, so
+        it is spelled out.
+
+        * A SCALAR RADIUS was the first bug: ``max(size_x, size_y) / 2 + 0.01``
+          against a straight-line distance reaches far outside the copper along
+          an OBLONG pad's short axis, and two same-net 0.30 x 1.50 fingers
+          0.50mm apart -- an ordinary fine-pitch QFP pair whose pads are 0.20mm
+          apart and NOT touching -- were merged into one via, the second route
+          shipping with no via at all while still counting as escaped. An
+          adversarial review of PR #852 found it, with 17 footprints on 11
+          in-repo boards matching the geometry.
+        * A PER-AXIS RECTANGLE (``anchor_box``) fixed that and was still the
+          wrong question (#854): it closes the equal-size case, because two
+          same-net pads of the same size can only be twins if they overlap by
+          more than half, but a LARGE pad's box still reaches a small pad whose
+          overlap is slight -- and swallows its via. Measured on VR201 of
+          ``kit-dev-coldfire-xilinx_5213``: a via **3.6853mm** from the route it
+          was supposed to anchor, against a 0.225mm ring.
+        * REACH is the question. A pad connects to its own inner-layer track
+          only through the via, so a via that does not touch the track start
+          connects nothing, wherever its centre sits.
 
         Returns ``(verdict, detail)``:
 
@@ -451,13 +501,14 @@ class PendingVias:
             today's, which appends a second identical dict that the writer
             emits as a second ``(via ...)`` at the same point.
 
-            KEYED ON THE PAD, NOT ON AN EXACT MATCH. An exact-match rule has a
+            KEYED ON REACH, NOT ON AN EXACT MATCH. An exact-match rule has a
             1 um cliff: an adversarial review found same-net sites 0.0010mm
             apart merging into one via while 0.0011mm apart DROPPED an escape
             outright, because no fab rung can space two holes 1.1 um apart. A
-            via inside the ball's own pad is a via that anchors it, which is
-            the question actually being asked -- and "inside the pad" is a
-            rectangle test, per ``anchor_box`` above.
+            via that ANCHORS this ball is a via it needs no second hole for,
+            which is the question actually being asked -- and every distance-0
+            case (an exposed pad modelled as an F.Cu + B.Cu pair) is inside any
+            reach, so the cliff stays closed.
         ``('conflict', (reason, x, y))``
             that via is closer than a floor allows. A DIFFERENT net at the same
             site lands here, not in ``'twin'``: two nets sharing one hole is a
@@ -465,22 +516,20 @@ class PendingVias:
         """
         d = drill or 0.0
         s = size or 0.0
-        ahx, ahy = ((self._tol, self._tol) if anchor_box is None else
-                    (max(anchor_box[0], self._tol),
-                     max(anchor_box[1], self._tol)))
+        tw = track_width or 0.0
         # Broad phase: nothing outside this x-window can be within either floor
-        # of the candidate, whatever its y. `ahx` is in it because a twin can
-        # sit further out than either floor when the pad is large.
+        # of the candidate, whatever its y. The third term is the ANCHOR reach
+        # -- the widest committed via plus half a track -- because a twin is
+        # decided by whether that via touches this route's track start.
         window = max(d / 2.0 + self._max_drill / 2.0 + self._h2h,
                      s / 2.0 + self._max_size / 2.0 + self._clearance,
-                     ahx)
+                     self._max_size / 2.0 + tw / 2.0)
         lo = bisect.bisect_left(self._xs, x - window)
         hi = bisect.bisect_right(self._xs, x + window)
         best = None
         for (ox, oy, os_, od, onet, obulges) in self._rows[lo:hi]:
             dist = math.hypot(ox - x, oy - y)
-            if (onet == net_id
-                    and abs(ox - x) <= ahx and abs(oy - y) <= ahy):
+            if onet == net_id and via_anchors_route(ox, oy, os_, (x, y), tw):
                 return 'twin', (ox, oy, os_, od)
             if dist <= self._tol:
                 return 'conflict', ("two nets would share one hole", ox, oy)

--- a/py_router/bga_fanout/underpad.py
+++ b/py_router/bga_fanout/underpad.py
@@ -2617,7 +2617,7 @@ def generate_underpad_escape(footprint: Footprint,
         # to the main router if that finds nothing either.
         _n_coupled_declined = len(h2h_stats['coupled_pairs'])
         if h2h_stats['sites'] or _n_coupled_declined:
-            _unused = (f"  Under-pad: {h2h_stats['sites']} via-in-pad centre site(s)"
+            print(f"  Under-pad: {h2h_stats['sites']} via-in-pad centre site(s)"
                   f" and {_n_coupled_declined} coupled pair(s) declined by the"
                   f" {_h2h:g}mm hole-to-hole floor ({_h2h_src}); the levers are"
                   f" a smaller --via-drill, a fab tier whose floor this pitch"

--- a/py_router/bga_fanout/underpad.py
+++ b/py_router/bga_fanout/underpad.py
@@ -1637,7 +1637,9 @@ def generate_underpad_escape(footprint: Footprint,
             ctx = _via_ctx(pad.net_id, vx, vy)
             why = _via_site_conflict(vx, vy, pad.net_id, ctx, vr=cs / 2.0,
                                      vdr=(cd or 0.0) / 2.0, skip_resv=True)
-            if False:
+            if why is not None:
+                if why.startswith('drill hole'):
+                    h2h_stats['coupled_pairs'].add(_pair_key)
                 return False
         (ax, ay, _as, ad), (bx, by, _bs, bd) = sites
         if math.hypot(ax - bx, ay - by) < ((ad or 0.0) / 2.0
@@ -2615,7 +2617,7 @@ def generate_underpad_escape(footprint: Footprint,
         # to the main router if that finds nothing either.
         _n_coupled_declined = len(h2h_stats['coupled_pairs'])
         if h2h_stats['sites'] or _n_coupled_declined:
-            print(f"  Under-pad: {h2h_stats['sites']} via-in-pad centre site(s)"
+            _unused = (f"  Under-pad: {h2h_stats['sites']} via-in-pad centre site(s)"
                   f" and {_n_coupled_declined} coupled pair(s) declined by the"
                   f" {_h2h:g}mm hole-to-hole floor ({_h2h_src}); the levers are"
                   f" a smaller --via-drill, a fab tier whose floor this pitch"

--- a/py_router/bga_fanout/underpad.py
+++ b/py_router/bga_fanout/underpad.py
@@ -1637,9 +1637,7 @@ def generate_underpad_escape(footprint: Footprint,
             ctx = _via_ctx(pad.net_id, vx, vy)
             why = _via_site_conflict(vx, vy, pad.net_id, ctx, vr=cs / 2.0,
                                      vdr=(cd or 0.0) / 2.0, skip_resv=True)
-            if why is not None:
-                if why.startswith('drill hole'):
-                    h2h_stats['coupled_pairs'].add(_pair_key)
+            if False:
                 return False
         (ax, ay, _as, ad), (bx, by, _bs, bd) = sites
         if math.hypot(ax - bx, ay - by) < ((ad or 0.0) / 2.0

--- a/py_router/diff_pair_loop.py
+++ b/py_router/diff_pair_loop.py
@@ -1112,6 +1112,29 @@ def route_diff_pairs(
                         continue
                 if not polarity_skip:
                     print(f"  {RED}ROUTE FAILED - no rippable blockers found{RESET}")
+                    # #652: the FOURTH site that prints this line, and the one
+                    # a first pass over the code misses. It differs from the
+                    # other three in that the pair is not abandoned here --
+                    # #289 defers it to the single-ended follow-up, where the
+                    # hint would fire again -- but the misleading line is
+                    # printed HERE, and a reader acting on it retries the pair.
+                    try:
+                        from routing_diagnostics import (
+                            fanout_dropped_ball_hint, condense_hint as _ch652)
+                        from routing_state import (
+                            record_net_event as _rne652)
+                        for _nid, _nm in ((pair.p_net_id, pair.p_net_name),
+                                          (pair.n_net_id, pair.n_net_name)):
+                            _h652, _v652 = fanout_dropped_ball_hint(
+                                pcb_data, config, _nid, _nm,
+                                return_verdict=True)
+                            if _h652:
+                                _c652 = _ch652(_h652)
+                                if _c652:
+                                    print(f"  {_c652}")
+                                _rne652(state, _nid, "fanout_dropped", _v652)
+                    except Exception:
+                        pass
                 # #289: a 2-terminal pair that exhausted every coupled path
                 # (rip-up, fallback layer swap, hybrid escape) gets the same
                 # single-ended defer the electrically-short gate uses, instead

--- a/py_router/env_knobs.py
+++ b/py_router/env_knobs.py
@@ -339,6 +339,19 @@ def refresh() -> None:
     g['NO_STATIC_BASE'] = _truthy('KICAD_NO_STATIC_BASE')
     g['ALLOW_STAGGERED_BGA'] = _truthy('KICAD_ALLOW_STAGGERED_BGA')
     g['QFN_UNDERPAD_NO_ALT_STAGGER'] = _truthy('QFN_UNDERPAD_NO_ALT_STAGGER')
+    # #846 how far --allow-via-in-pad's escape-axis ladder may reach:
+    # 'full' (default) | 'pad' | 'barrel'. An A/B isolation knob like
+    # KICAD_QFN_UNDERPAD_ERASED_GATE, not a behaviour choice -- the ladder was
+    # named `_onpad` and documented as on-pad offsets, but its increment is the
+    # INTER-NET stagger, which on a fine-pitch part exceeds the pad, so only
+    # k = 0 is guaranteed on it. The three arms answer "what if it meant what
+    # it said": 'pad' keeps offsets whose via CENTRE stays on the pad
+    # (|k*step| <= pad_width/2), 'barrel' keeps only those whose whole BARREL
+    # does (|k*step| <= pad_width/2 - via_size/2), which on every board
+    # measured collapses the ladder to [0.0]. The two are very different
+    # restrictions and are named separately for that reason. An unrecognised
+    # value is 'full', so a typo cannot silently shorten the ladder.
+    g['QFN_ONPAD_REACH'] = _s('KICAD_QFN_ONPAD_REACH', 'full').strip().lower()
     # #619 which halves of the nets_to_route erasure the under-pad escape tests
     # its pad->via stub against: 'all' (default) | 'via' | 'seg' | 'off'.
     # An A/B isolation knob like KICAD_NO_SOFT_JOINT_BRIDGE, not a behaviour

--- a/py_router/fab_notes.py
+++ b/py_router/fab_notes.py
@@ -74,6 +74,26 @@ def _pad_holds(pad, x: float, y: float, margin: float = 0.0) -> bool:
     return point_to_pad_distance(x, y, pad) <= margin
 
 
+def via_overlaps_pad(pad, via_x: float, via_y: float, via_size: float,
+                     margin: float = 0.0) -> bool:
+    """Does a via's BARREL overlap this pad's copper? (#846)
+
+    The public form of ``_pad_holds``, with the barrel radius applied for the
+    caller. This is the question "is this via in that pad" actually means, and
+    it is asked in two places that used to disagree: here, for the IPC-4761 fab
+    note, and in ``qfn_fanout``'s commit loop, which decides whether to clamp
+    the via to its pad edge (#202). The commit loop used to ask a 0.001mm
+    CENTRE-coincidence question instead, so a via staggered onto its own pad
+    was reported by this module as needing Type VII while shipping unclamped.
+
+    ``via_size`` of 0 or None claims the 0.6 default's radius, as every other
+    consumer of a size-less via in this repo does. ``margin`` is a FLOOR on the
+    credit, not a replacement for it -- see ``via_in_pad_sites``.
+    """
+    vr = (via_size if via_size else 0.6) / 2.0
+    return _pad_holds(pad, via_x, via_y, max(vr - 1e-6, margin))
+
+
 def via_in_pad_sites(vias, pads_by_net: Dict[int, list],
                      margin: float = 0.0) -> List[Tuple[object, object]]:
     """[(via, pad)] for every via whose BARREL overlaps a SAME-NET pad.
@@ -111,11 +131,11 @@ def via_in_pad_sites(vias, pads_by_net: Dict[int, list],
             continue
         # A via with no declared size claims the 0.6 default's radius, as
         # every other consumer of a size-less via in this repo does.
-        vr = (_get(via, 'size', 0.6) or 0.6) / 2.0
+        vsz = _get(via, 'size', 0.6)
         for pad in pads_by_net.get(net_id, ()) or ():
             if _get(pad, 'drill', 0.0) or 0.0:
                 continue  # a plated TH pad's own barrel is not via-in-pad
-            if _pad_holds(pad, vx, vy, max(vr - 1e-6, margin)):
+            if via_overlaps_pad(pad, vx, vy, vsz, margin):
                 sites.append((via, pad))
                 break
     return sites

--- a/py_router/phase3_routing.py
+++ b/py_router/phase3_routing.py
@@ -1424,6 +1424,19 @@ def _retry_victim_main_with_ripup(
         pcb_data=pcb_data, context="phase3 victim reroute")
     if not rippable_blockers:
         print(f"    {victim_name}: main re-route blocked, no rippable blockers")
+        try:   # #652
+            from routing_diagnostics import (fanout_dropped_ball_hint,
+                                             condense_hint as _ch652)
+            _h652, _v652 = fanout_dropped_ball_hint(
+                pcb_data, config, victim_id, victim_name,
+                return_verdict=True)
+            if _h652:
+                _c652 = _ch652(_h652)
+                if _c652:
+                    print(f"    {_c652}")
+                record_net_event(state, victim_id, "fanout_dropped", _v652)
+        except Exception:
+            pass
         return None, []
 
     nested_ripped = []

--- a/py_router/qfn_fanout/README.md
+++ b/py_router/qfn_fanout/README.md
@@ -92,14 +92,32 @@ the alternatives only kick in to rescue an otherwise-dropped leg.
 On a genuinely boxed-in pair (the outer leg has a neighbour pad one pitch away
 *and* the neighbour's diagonal escape sweeping through the only outward room) the
 via has nowhere to go outward, so the plain escape **drops** it. With
-`--allow-via-in-pad` the escape via may sit on its **own** pad (via-in-pad). Its
-candidate offsets then become a **mix**: on-pad positions (centre, then inward
-toward the chip) *and* off-pad positions (outward past the pad), so each leg
-independently takes whichever escapes — a boxed-in leg staggers *inward*, away
-from the neighbour, instead of being dropped, while a leg with outward room still
-goes out. The via still must clear every other-net pad, via and track — it only
-gains permission to overlap its own pad. Name and behaviour match the
-"Allow via-in-pad" option elsewhere in the tools. Example:
+`--allow-via-in-pad` the escape via may sit on its **own** pad (via-in-pad), and
+the search gains an extra ladder of **signed offsets along the escape axis**,
+tried *before* the outward one, plus four extra stagger configurations. So each
+leg independently takes whichever escapes — a boxed-in leg staggers *inward*,
+away from the neighbour, instead of being dropped, while a leg with outward room
+still goes out. The via still must clear every other-net pad, via and track — it
+only gains permission to overlap its own pad.
+
+**That inward ladder is not confined to the pad (#846).** Its increment is the
+*inter-net* stagger — the centre-to-centre a via needs from a **different** net's
+via at this pitch — which on a fine-pitch part is larger than the pad. On
+`routed_output`'s QFN-76 (pitch 0.40, via 0.45, clearance 0.1) the step is
+0.4275 mm against a pad whose escape-axis extent is 0.875 mm, so rung 1 is
+already half a pad-length off centre and rung 8 reaches ±3.42 mm. Measured, the
+flag's rungs are load-bearing: with it on, this ladder won 66 of 84 accepted
+offsets on `routed_output` U2 and every one on `tigard`, `qfn_underpad_coupling`
+and `qfn_diffpair_escape`, and it owns the longest emitted stub there (2.9924 mm).
+So the offsets stay and the name was the wrong half. Set
+`KICAD_QFN_ONPAD_REACH` to confine them (see below).
+
+A via that **does** overlap its pad is clamped to the pad edge so it cannot bulge
+past it (#202), and needs IPC-4761 Type VII (filled + capped + plated) — the run
+prints a FAB NOTE naming the pads. `JSON_SUMMARY` carries `allow_via_in_pad`,
+`via_in_pad`, `via_in_pad_clamped`, `via_in_pad_offcentre` and `max_stub_mm`.
+Name and behaviour match the "Allow via-in-pad" option elsewhere in the tools.
+Example:
 
 ```bash
 python3 py_router/qfn_fanout.py board.kicad_pcb --component U1 --nets 'DP1*' \

--- a/py_router/qfn_fanout/__init__.py
+++ b/py_router/qfn_fanout/__init__.py
@@ -952,6 +952,9 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
         print(f"    dropped (no clear via offset): {dropped}")
     if clamp_n:
         print(f"    clamped {clamp_n} via-in-pad(s) to fit their pad edge (#202)")
+    # Cleared HERE and repopulated in the same breath, but the engine
+    # entry point clears it too: a caller that runs two components in one
+    # process must not read the first one's numbers for the second.
     LAST_UNDERPAD_REPORT.clear()
     LAST_UNDERPAD_REPORT.update({
         'via_in_pad': vip_n,

--- a/py_router/qfn_fanout/__init__.py
+++ b/py_router/qfn_fanout/__init__.py
@@ -62,6 +62,54 @@ LAST_ERASED_SETS: Dict = {}
 LAST_UNDERPAD_REPORT: Dict = {}
 
 
+def axis_offset_ladder(pad_width, via_size, step, mode='near'):
+    """Signed offsets along the escape axis, under KICAD_QFN_ONPAD_REACH (#846).
+
+    `mode` orders them: 'in' sweeps inward (toward the chip) first, 'near'
+    alternates nearest first.
+
+    NOT an "on-pad ladder", though it was called `_onpad` and documented as one.
+    Only k = 0 is guaranteed on the pad. The increment is the INTER-NET stagger
+    -- the centre-to-centre a via needs from a DIFFERENT net's via at this pitch
+    -- and on a fine-pitch part that exceeds the pad: on routed_output's QFN-76
+    (pitch 0.40, via 0.45, clearance 0.1) step is 0.4275 against a pad whose
+    escape-axis extent is 0.875, so rung 1 lands 0.0100 mm inside the pad EDGE,
+    rung 2 is 0.8550 mm out and rung 8 reaches +-3.4199 mm.
+
+    Those rungs ARE load-bearing, measured: with --allow-via-in-pad this ladder
+    is tried first and won 66 of 84 accepted offsets on routed_output U2 and
+    every one on tigard, qfn_underpad_coupling and qfn_diffpair_escape, and it
+    owns the longest emitted stub there (2.9924 mm, pad 65, k = 7). Confining it
+    to the pad regressed 1 of 5 boards ('pad') and 3 of 5 ('barrel') in
+    tests/sweep_846_onpad_ladder.py, so the default is 'full': the ladder is
+    right and the NAME was wrong.
+
+    KICAD_QFN_ONPAD_REACH picks the arm -- 'full' (default), 'pad' (the via
+    CENTRE stays on the pad), 'barrel' (the whole barrel does). An unrecognised
+    value is 'full', so a typo cannot silently shorten the ladder.
+
+    Module-level, and the engine's only source for these offsets, because a
+    test that restates the arithmetic cannot detect the arithmetic changing:
+    the first draft of tests/test_846_onpad_ladder_reach.py rebuilt the ladder
+    from the same formula and every knob row of tests/mutate_846.py SURVIVED.
+
+    Whether a via that lands here is IN a pad is not decided here -- the commit
+    loop asks `via_overlaps_pad`, the fab question.
+    """
+    seq = [0.0]
+    if mode == 'in':
+        seq += [-k * step for k in range(1, 9)] + [k * step for k in range(1, 9)]
+    else:                                   # 'near'
+        for k in range(1, 9):
+            seq += [k * step, -k * step]
+    reach = {'pad': pad_width / 2.0,
+             'barrel': pad_width / 2.0 - via_size / 2.0,
+             }.get(env_knobs.QFN_ONPAD_REACH)
+    if reach is not None:
+        seq = [d for d in seq if abs(d) <= reach + 1e-9]
+    return seq
+
+
 def _snap_tip_on_grid(corner, tip, net_id, grid_step, grazes):
     """Move a shortened fan tip back ONTO the routing grid (#446).
 
@@ -687,36 +735,6 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
     def snap(v):
         return round(v / grid_step) * grid_step if grid_step > 0 else v
 
-    def _axis_offsets(mode):
-        # Signed offsets along the escape axis, ordered by `mode`: 'in' sweeps
-        # inward (toward the chip) first, 'near' alternates nearest first.
-        #
-        # NOT an "on-pad ladder", though it was called `_onpad` and documented
-        # as one (#846). Only k = 0 is guaranteed on the pad. The increment is
-        # `step`, which is the INTER-NET stagger -- the centre-to-centre a via
-        # needs from a DIFFERENT net's via at this pitch -- and on a fine-pitch
-        # part that exceeds the pad: on routed_output's QFN-76 (pitch 0.40, via
-        # 0.45, clearance 0.1) step is 0.4275 against a pad whose escape-axis
-        # extent is 0.875, so k = 1 is already off the pad's centre by half its
-        # length and k = 8 reaches +-3.42 mm.
-        #
-        # These ARE load-bearing, measured: with --allow-via-in-pad this ladder
-        # is tried first and won 66 of 84 accepted offsets on routed_output U2
-        # and every one on tigard, qfn_underpad_coupling and
-        # qfn_diffpair_escape. It also owns the longest emitted stub there
-        # (2.9924 mm, pad 65, k = 7). So the name was the wrong half: the
-        # offsets stay, and what they are is now stated.
-        #
-        # Whether a via that lands here is IN a pad is not decided here -- the
-        # commit loop asks `via_overlaps_pad`, the fab question (#846).
-        seq = [0.0]
-        if mode == 'in':
-            seq += [-k * step for k in range(1, 9)] + [k * step for k in range(1, 9)]
-        else:                                   # 'near'
-            for k in range(1, 9):
-                seq += [k * step, -k * step]
-        return seq
-
     def candidate_offsets(pad_width, mode):
         # `outward` starts past the pad body and always clears it. With
         # --allow-via-in-pad we ALSO offer the axis ladder, which starts ON the
@@ -728,15 +746,8 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
         outward = [base + k * step for k in range(0, 9)]
         if not allow_via_in_pad:
             return outward
-        # #846 A/B arm (KICAD_QFN_ONPAD_REACH): confine the axis ladder to what
-        # its old name claimed. 'full' -- the default and today's behaviour --
-        # applies no limit; an unrecognised value is 'full'.
-        axis = _axis_offsets('near' if mode == 'out' else mode)
-        _reach = {'pad': pad_width / 2.0,
-                  'barrel': pad_width / 2.0 - via_size / 2.0,
-                  }.get(env_knobs.QFN_ONPAD_REACH)
-        if _reach is not None:
-            axis = [d for d in axis if abs(d) <= _reach + 1e-9]
+        axis = axis_offset_ladder(pad_width, via_size, step,
+                                  'near' if mode == 'out' else mode)
         if mode == 'out':
             return outward + axis
         return axis + outward

--- a/py_router/qfn_fanout/__init__.py
+++ b/py_router/qfn_fanout/__init__.py
@@ -51,6 +51,16 @@ LAST_CANCEL_SKIPPED: List[str] = []
 # copper lands), `clearance` (the floor the stub was graded at).
 LAST_ERASED_SETS: Dict = {}
 
+# #846: what the last under-pad escape's COMMIT LOOP decided, published for the
+# same reason as LAST_ERASED_SETS -- a sweep or a test grades against what the
+# engine did rather than re-deriving it. `via_in_pad` is the FAB question (the
+# barrel overlaps same-net pad copper, `fab_notes.via_overlaps_pad`), which is
+# what the IPC-4761 note counts and what #202's clamp is for; it is NOT the
+# 0.001mm centre coincidence this loop used to decide it by. Keys: `via_in_pad`,
+# `via_in_pad_offcentre` (the subset #846 was about, which used to ship
+# unclamped), `clamped`, `max_stub_mm`, `allow_via_in_pad`.
+LAST_UNDERPAD_REPORT: Dict = {}
+
 
 def _snap_tip_on_grid(corner, tip, net_id, grid_step, grazes):
     """Move a shortened fan tip back ONTO the routing grid (#446).
@@ -315,7 +325,7 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
     # the active fab-tier ladder so the clamp escalates standard->advanced (#237).
     _copper = len(getattr(pcb_data.board_info, 'copper_layers', None) or []) or 4
     floors = fab_floor_ladder(_copper)
-    clamp_n = floor_n = escalated_n = offcentre_n = 0
+    clamp_n = floor_n = escalated_n = offcentre_n = vip_n = 0
 
     # Only the nets we're escaping right now are exempt from the obstacle map --
     # the chip's OTHER nets (a routed neighbour pair, a crossing track) must
@@ -677,10 +687,28 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
     def snap(v):
         return round(v / grid_step) * grid_step if grid_step > 0 else v
 
-    def _onpad(mode):
-        # On-pad (via-in-pad) offsets along the escape axis, ordered by `mode`:
-        # 'in' sweeps inward (toward the chip) first; 'near' alternates nearest
-        # first. 0 == via centred on the pad.
+    def _axis_offsets(mode):
+        # Signed offsets along the escape axis, ordered by `mode`: 'in' sweeps
+        # inward (toward the chip) first, 'near' alternates nearest first.
+        #
+        # NOT an "on-pad ladder", though it was called `_onpad` and documented
+        # as one (#846). Only k = 0 is guaranteed on the pad. The increment is
+        # `step`, which is the INTER-NET stagger -- the centre-to-centre a via
+        # needs from a DIFFERENT net's via at this pitch -- and on a fine-pitch
+        # part that exceeds the pad: on routed_output's QFN-76 (pitch 0.40, via
+        # 0.45, clearance 0.1) step is 0.4275 against a pad whose escape-axis
+        # extent is 0.875, so k = 1 is already off the pad's centre by half its
+        # length and k = 8 reaches +-3.42 mm.
+        #
+        # These ARE load-bearing, measured: with --allow-via-in-pad this ladder
+        # is tried first and won 66 of 84 accepted offsets on routed_output U2
+        # and every one on tigard, qfn_underpad_coupling and
+        # qfn_diffpair_escape. It also owns the longest emitted stub there
+        # (2.9924 mm, pad 65, k = 7). So the name was the wrong half: the
+        # offsets stay, and what they are is now stated.
+        #
+        # Whether a via that lands here is IN a pad is not decided here -- the
+        # commit loop asks `via_overlaps_pad`, the fab question (#846).
         seq = [0.0]
         if mode == 'in':
             seq += [-k * step for k in range(1, 9)] + [k * step for k in range(1, 9)]
@@ -690,17 +718,28 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
         return seq
 
     def candidate_offsets(pad_width, mode):
-        # Off-pad outward offsets always clear the pad body. With via-in-pad we
-        # ALSO offer on-pad offsets and mix the two: 'out' prefers off-pad
-        # outward then falls back to on-pad; 'near'/'in' prefer on-pad then fall
-        # back to off-pad outward.
+        # `outward` starts past the pad body and always clears it. With
+        # --allow-via-in-pad we ALSO offer the axis ladder, which starts ON the
+        # pad centre and steps by the inter-net stagger -- so it reaches on-pad
+        # positions AND off-pad ones on the inward side (#846). 'out' prefers
+        # the outward ladder and falls back to the axis one; 'near'/'in' prefer
+        # the axis ladder and fall back to outward.
         base = pad_width / 2 + via_size / 2 + clearance
         outward = [base + k * step for k in range(0, 9)]
         if not allow_via_in_pad:
             return outward
+        # #846 A/B arm (KICAD_QFN_ONPAD_REACH): confine the axis ladder to what
+        # its old name claimed. 'full' -- the default and today's behaviour --
+        # applies no limit; an unrecognised value is 'full'.
+        axis = _axis_offsets('near' if mode == 'out' else mode)
+        _reach = {'pad': pad_width / 2.0,
+                  'barrel': pad_width / 2.0 - via_size / 2.0,
+                  }.get(env_knobs.QFN_ONPAD_REACH)
+        if _reach is not None:
+            axis = [d for d in axis if abs(d) <= _reach + 1e-9]
         if mode == 'out':
-            return outward + _onpad('near')
-        return _onpad(mode) + outward
+            return outward + axis
+        return axis + outward
 
     def place_pin(pi, mode, placed):
         ex, ey = pi.escape_direction
@@ -873,6 +912,7 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
             # escaping (`via_in_pad_sites` scans every same-net pad and would
             # classify against a NEIGHBOUR's, then clamp to this one's).
             if via_overlaps_pad(pi.pad, vx, vy, via_size):
+                vip_n += 1
                 # via-in-pad: clamp to the pad edge so it never bulges past it (#202)
                 v_size, v_drill, status, rung = clamp_via_to_pad(via_size, via_drill, pi.pad, floors)
                 if status == 'clamped':
@@ -896,6 +936,16 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
         print(f"    dropped (no clear via offset): {dropped}")
     if clamp_n:
         print(f"    clamped {clamp_n} via-in-pad(s) to fit their pad edge (#202)")
+    LAST_UNDERPAD_REPORT.clear()
+    LAST_UNDERPAD_REPORT.update({
+        'via_in_pad': vip_n,
+        'via_in_pad_offcentre': offcentre_n,
+        'clamped': clamp_n,
+        'max_stub_mm': round(max((math.hypot(t['end'][0] - t['start'][0],
+                                             t['end'][1] - t['start'][1])
+                                  for t in tracks), default=0.0), 4),
+        'allow_via_in_pad': bool(allow_via_in_pad),
+    })
     if offcentre_n:
         # Disclosed separately, not folded into the line above: these are the
         # vias #846 was about -- overlapping their pad while OFF its centre,
@@ -1499,7 +1549,13 @@ def main():
                         help='Underpad escape: let the escape via overlap its OWN pad '
                              '(via-in-pad), so a via boxed in on the outward side can '
                              'stagger inward toward the chip instead of being dropped. '
-                             'The via still must clear other-net pads, vias and tracks.')
+                             'It also enables an INWARD search along the escape axis '
+                             'that steps by the inter-net stagger, so on a fine-pitch '
+                             'part its later rungs land past the pad edge on the chip '
+                             'side, and four extra stagger configurations (#846). A via '
+                             'that does overlap its pad is clamped to the pad edge '
+                             '(#202) and needs IPC-4761 Type VII. The via still must '
+                             'clear other-net pads, vias and tracks.')
     # #489 section 9: fanout is where a teardrop matters most (a 0.1mm trace
     # meeting a 0.25mm via pad), and this step had no way to ask for one.
     parser.add_argument('--add-teardrops', action='store_true',
@@ -1742,6 +1798,18 @@ def main():
         # and check_drc grade the board at this floor.
         'min_clearance_used': eff_clearance,
     }
+    # #846: what --allow-via-in-pad actually did. Before this, the only
+    # machine-readable numbers a fanout run published were escape counts, so
+    # neither the flag's effect nor a stub-length claim could be checked
+    # without re-parsing the board. `via_in_pad` is the fab question, so it
+    # agrees with the IPC-4761 note printed above it.
+    summary['allow_via_in_pad'] = bool(getattr(args, 'allow_via_in_pad', False))
+    if LAST_UNDERPAD_REPORT:
+        summary['via_in_pad'] = LAST_UNDERPAD_REPORT.get('via_in_pad', 0)
+        summary['via_in_pad_clamped'] = LAST_UNDERPAD_REPORT.get('clamped', 0)
+        summary['via_in_pad_offcentre'] = LAST_UNDERPAD_REPORT.get(
+            'via_in_pad_offcentre', 0)
+        summary['max_stub_mm'] = LAST_UNDERPAD_REPORT.get('max_stub_mm', 0.0)
     try:                       # #653: env knobs into the machine-readable
         import env_knobs as _ek653   # summary, so a harness can detect a
         summary['env_knobs'] = _ek653.active_env_knobs()   # dirty baseline

--- a/py_router/qfn_fanout/__init__.py
+++ b/py_router/qfn_fanout/__init__.py
@@ -76,13 +76,18 @@ def axis_offset_ladder(pad_width, via_size, step, mode='near'):
     escape-axis extent is 0.875, so rung 1 lands 0.0100 mm inside the pad EDGE,
     rung 2 is 0.8550 mm out and rung 8 reaches +-3.4199 mm.
 
-    Those rungs ARE load-bearing, measured: with --allow-via-in-pad this ladder
-    is tried first and won 66 of 84 accepted offsets on routed_output U2 and
-    every one on tigard, qfn_underpad_coupling and qfn_diffpair_escape, and it
-    owns the longest emitted stub there (2.9924 mm, pad 65, k = 7). Confining it
-    to the pad regressed 1 of 5 boards ('pad') and 3 of 5 ('barrel') in
-    tests/sweep_846_onpad_ladder.py, so the default is 'full': the ladder is
-    right and the NAME was wrong.
+    Those rungs ARE load-bearing, measured by
+    `tests/sweep_846_onpad_ladder.py` -- committed, so this stays checkable
+    rather than remembered: confining the ladder regressed escapes on 1 of 5
+    boards ('pad': routed_output U2, 15 -> 10) and 3 of 5 ('barrel'), improved
+    none, and left drc_grazes identical arm-to-arm. So the default is 'full' --
+    the ladder is right and the NAME was wrong.
+
+    It is also where the long stubs come from, which is what #846 reports: on
+    routed_output U2 the longest EMITTED stub is 3.0125 mm against a 0.875 mm
+    pad. (An earlier draft of this docstring said 2.9924 mm -- that is the
+    ladder's requested OFFSET at k = 7, before `snap()` puts the via on the
+    routing grid, not the copper that shipped.)
 
     KICAD_QFN_ONPAD_REACH picks the arm -- 'full' (default), 'pad' (the via
     CENTRE stays on the pad), 'barrel' (the whole barrel does). An unrecognised

--- a/py_router/qfn_fanout/__init__.py
+++ b/py_router/qfn_fanout/__init__.py
@@ -306,6 +306,7 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
     from geometry_utils import segment_to_segment_distance
     from bga_fanout.reroute import _seg_hits_pad
     from bga_fanout.geometry import clamp_via_to_pad
+    from fab_notes import via_overlaps_pad
     from list_nets import fab_floor_ladder, fab_floor_min, warn_fab_escalation
     from routing_config import GridRouteConfig
 
@@ -314,7 +315,7 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
     # the active fab-tier ladder so the clamp escalates standard->advanced (#237).
     _copper = len(getattr(pcb_data.board_info, 'copper_layers', None) or []) or 4
     floors = fab_floor_ladder(_copper)
-    clamp_n = floor_n = escalated_n = 0
+    clamp_n = floor_n = escalated_n = offcentre_n = 0
 
     # Only the nets we're escaping right now are exempt from the obstacle map --
     # the chip's OTHER nets (a routed neighbour pair, a crossing track) must
@@ -851,8 +852,27 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
                 tracks.append({'start': (px, py), 'end': (vx, vy),
                                'width': track_width, 'layer': footprint.layer,
                                'net_id': pi.pad.net_id})
-                v_size, v_drill = via_size, via_drill   # off-pad via: not in a pad
-            else:
+            # Whether a STUB is needed and whether the via is IN THE PAD are
+            # two questions, and this loop used to answer both with one 0.001mm
+            # centre-coincidence test (#846). They come apart in two ways:
+            #
+            #  * `snap()` quantises the via COORDINATE to the routing grid
+            #    (0.05 by default) while pad centres are off-lattice on real
+            #    parts -- 76 of 77 pads on routed_output's QFN-76, 6 of 6 on
+            #    qfn_diffpair_escape -- so the genuinely centred rung lands
+            #    0.0125mm out, 12.5x POSITION_TOLERANCE. The via-in-pad branch
+            #    was unreachable by construction on those boards.
+            #  * an offset rung can put the barrel well inside the pad without
+            #    the centre being on it at all.
+            #
+            # Either way the via shipped at NOMINAL size with no #202 clamp,
+            # free to bulge past the pad -- while `print_via_in_pad_note` below
+            # counted the very same via as needing IPC-4761 Type VII, because
+            # it asks the fab question: does the BARREL overlap the copper. The
+            # commit loop now calls that same predicate, on the pad this leg is
+            # escaping (`via_in_pad_sites` scans every same-net pad and would
+            # classify against a NEIGHBOUR's, then clamp to this one's).
+            if via_overlaps_pad(pi.pad, vx, vy, via_size):
                 # via-in-pad: clamp to the pad edge so it never bulges past it (#202)
                 v_size, v_drill, status, rung = clamp_via_to_pad(via_size, via_drill, pi.pad, floors)
                 if status == 'clamped':
@@ -861,6 +881,10 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
                     floor_n += 1
                 if rung > 0:
                     escalated_n += 1
+                if math.hypot(vx - px, vy - py) > POSITION_TOLERANCE:
+                    offcentre_n += 1
+            else:
+                v_size, v_drill = via_size, via_drill   # off-pad via: not in a pad
             vias.append({'x': vx, 'y': vy, 'size': v_size, 'drill': v_drill,
                          'layers': ['F.Cu', 'B.Cu'], 'net_id': pi.pad.net_id})
 
@@ -872,6 +896,13 @@ def _underpad_via_escape(footprint, pcb_data, pad_infos, layout, layer,
         print(f"    dropped (no clear via offset): {dropped}")
     if clamp_n:
         print(f"    clamped {clamp_n} via-in-pad(s) to fit their pad edge (#202)")
+    if offcentre_n:
+        # Disclosed separately, not folded into the line above: these are the
+        # vias #846 was about -- overlapping their pad while OFF its centre,
+        # which the old test could not see. A reader has to be able to watch
+        # this number move.
+        print(f"    {offcentre_n} of them sit OFF the pad centre (#846); "
+              f"before, those shipped unclamped")
     # The FAB requirement this escape may have just created (#489 §8). Emitted
     # from the shared engine path so the GUI fanout tab reports it too.
     from fab_notes import print_via_in_pad_note

--- a/py_router/reroute_loop.py
+++ b/py_router/reroute_loop.py
@@ -760,6 +760,20 @@ def run_reroute_loop(
                         if _boxin:
                             record_net_event(state, ripped_net_id,
                                              "boxed_in_static", _boxin)
+                        try:   # #652
+                            from routing_diagnostics import (
+                                fanout_dropped_ball_hint)
+                            _h652, _v652 = fanout_dropped_ball_hint(
+                                pcb_data, config, ripped_net_id,
+                                ripped_net_name, return_verdict=True)
+                            if _h652:
+                                _c652 = condense_hint(_h652)
+                                if _c652:
+                                    print(f"  {_c652}")
+                                record_net_event(state, ripped_net_id,
+                                                 "fanout_dropped", _v652)
+                        except Exception:
+                            pass
                     # Remove from pending_multipoint_nets to prevent Phase 3 from
                     # trying to route taps for a net with no main route.
                     if ripped_net_id in state.pending_multipoint_nets:

--- a/py_router/route.py
+++ b/py_router/route.py
@@ -267,6 +267,7 @@ def _empty_results_data() -> dict:
         'vias_to_remove': [],
         'blockers': [],
         'boxed_in': [],
+        'fanout_dropped': [],
         'pad_pairs_open': [],
     }
 
@@ -3733,6 +3734,7 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
     # here because the final failed sets are authoritative.
     blockers_report = []
     boxed_in_report = []
+    fanout_dropped_report = []
     try:
         _final_failed_ids = list(dict.fromkeys(
             failed_single_ids + [m['net_id'] for m in failed_multipoint]))
@@ -3774,10 +3776,26 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
                     _bx = _ev.get('details') or _bx
             if _bx:
                 boxed_in_report.append(dict(_bx, net=_name))
+            # #652: and WHY nothing was rippable, when the answer is that this
+            # net has a ball the fanout never escaped. A third key rather than
+            # a note inside `boxed_in`, for the same reason `boxed_in` is not
+            # inside `blockers`: it answers a different question (the BOARD is
+            # wrong, not the search), and it is the only one of the three whose
+            # fix is upstream of this step. The hint PROSE does not survive --
+            # this loop keeps `details` and drops `hint` -- so a structured
+            # verdict is the only durable form.
+            _fd = None
+            for _ev in (state.net_history.get(_nid) or []):
+                if _ev.get('event') == 'fanout_dropped':
+                    _fd = _ev.get('details') or _fd
+            if _fd:
+                fanout_dropped_report.append(dict(_fd, net=_name))
         if blockers_report:
             summary['blockers'] = blockers_report
         if boxed_in_report:
             summary['boxed_in'] = boxed_in_report
+        if fanout_dropped_report:
+            summary['fanout_dropped'] = fanout_dropped_report
     except Exception:
         blockers_report = []
     # #409 follow-up: pad-pair routability tallies (PRR ingredients: connected
@@ -3923,6 +3941,7 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
             # printed summary, so a key that only reaches stdout does not
             # reach the plugin (CLAUDE.md's Class-1 CLI/GUI gap).
             'boxed_in': boxed_in_report,
+            'fanout_dropped': fanout_dropped_report,
             # #409 follow-up: same data as JSON_SUMMARY['pad_pairs_open']
             # (may be empty).
             'pad_pairs_open': pad_pairs_open_report,
@@ -5671,7 +5690,7 @@ def batch_route(input_file: str, output_file: str, net_names: List[str],
                 # why the caller asked -- and the gate report itself.
                 _keep6 = {k: results_data.get(k) or []
                           for k in ('blockers', 'pad_pairs_open',
-                                    'boxed_in')}
+                                    'boxed_in', 'fanout_dropped')}
                 results_data = _empty_results_data()
                 results_data.update(_keep6)
                 _action = ("DISCARDED this run's changes (nothing is applied "

--- a/py_router/routing_common.py
+++ b/py_router/routing_common.py
@@ -279,6 +279,16 @@ def entombed_bare_pads(pcb_data, net_ids, *, reach: float = 0.05,
 
     Returns ``[(pad, footprint_ref), ...]``.
 
+    NOTE ON WHAT THIS POPULATION LOOKS LIKE, measured before trusting it: on a
+    pre-plane board it is dominated by power and ground. orangecrab_ext_pll
+    gives 120 hits of which 118 are GND / P1.1V / P1.35V / P3.3V; ulx3s gives
+    305, 141 of them GND / +1V1 / +3V3. Those balls are not wrong -- they
+    really do own no copper -- but their FIX is a plane drop, not a re-run of
+    the fanout, and `pcb_data.zones` is empty at that point in the chain so the
+    pour exemption above cannot tell them apart. Callers that turn this into
+    advice must say so: `routing_diagnostics.fanout_dropped_ball_hint` names
+    the plane route for a net with `plane_like_pads` or more pads.
+
     Arguments that are deliberately explicit rather than shared constants:
 
     * ``reach`` -- how close copper must be to count as attached. This repo
@@ -329,15 +339,33 @@ def entombed_bare_pads(pcb_data, net_ids, *, reach: float = 0.05,
         pads = [p for p in fp.pads if p.net_id is not None]
         if len(pads) < min_package_pads:
             continue
+        # Nothing below can report a pad of a net this footprint does not
+        # carry, and the pitch sweep is the expensive part -- so ask first.
+        # Without this the cost is O(failing nets x whole board): measured
+        # 3-5 ms per call on corpus boards, and it scales with FOOTPRINT
+        # count, not with the net being asked about.
+        if not any(p.net_id in want for p in pads):
+            continue
         xs = [p.global_x for p in pads]
         ys = [p.global_y for p in pads]
         x0, x1, y0, y1 = min(xs), max(xs), min(ys), max(ys)
         # The band an outer ring occupies, as a pitch: the smallest non-zero
         # centre-to-centre between pads of this footprint.
+        #
+        # Swept over ALL pads, in x order, with early exit -- not over the
+        # first 60 in FILE order, which an earlier draft did. That was
+        # measurably wrong: on glasgow_revC U1 (87 pads) the truncated prefix
+        # gives 0.5000 where the true minimum is 0.4031, a 24% overestimate
+        # that widens `band` and silences the hint on pads it should reach.
+        # And it was order-dependent, which a geometric predicate must not be.
         pitch = 0.0
-        for i, a in enumerate(pads[:60]):
-            for b in pads[i + 1:60]:
-                d = math.hypot(a.global_x - b.global_x, a.global_y - b.global_y)
+        order = sorted(pads, key=lambda p: (p.global_x, p.global_y))
+        for i, a in enumerate(order):
+            for b in order[i + 1:]:
+                dx = b.global_x - a.global_x
+                if pitch and dx >= pitch:
+                    break          # x-sorted: no later pad can be closer
+                d = math.hypot(dx, a.global_y - b.global_y)
                 if d > 1e-6 and (pitch == 0.0 or d < pitch):
                     pitch = d
         band = pitch * 1.1 + inset

--- a/py_router/routing_common.py
+++ b/py_router/routing_common.py
@@ -254,6 +254,109 @@ def _dist_point_to_polygon(x: float, y: float, polygon: List[Tuple[float, float]
     return best
 
 
+def entombed_bare_pads(pcb_data, net_ids, *, reach: float = 0.05,
+                       min_net_pads: int = 2, min_package_pads: int = 8,
+                       inset: float = 0.65):
+    """Pads a package's own pad field encloses that own NO escape copper (#652).
+
+    This is the geometry behind "the fanout dropped this ball": a pad deep
+    inside a fine-pitch package, with nothing of its net attached to it, cannot
+    be reached by any later routing step -- and the step that reports the
+    failure says `no rippable blockers found`, which is true and useless.
+
+    Re-derived from the board on purpose. A fanout's ``unescaped_nets`` is
+    printed and then lost -- nothing persists it, and #472 already settled that
+    this machinery is board-state-driven so no sidecar file is load-bearing --
+    so a later ``route.py`` process can only see the geometry.
+
+    NOT keyed on ``auto_detect_bga_exclusion_zones``. That helper walks
+    ``find_components_by_type(pcb_data, 'BGA')`` only, and measured on this
+    repo's own boards it returns 3 zones for routed_output (IC1, U3, U1) and
+    none for its QFN-76 U2, and ZERO zones for tigard -- so a zone-keyed
+    diagnosis would stay silent on exactly the fine-pitch parts that drop
+    balls. Entombment is computed from the footprint's own pad bounding box
+    instead, which works for any package.
+
+    Returns ``[(pad, footprint_ref), ...]``.
+
+    Arguments that are deliberately explicit rather than shared constants:
+
+    * ``reach`` -- how close copper must be to count as attached. This repo
+      asks that question at two different tolerances for two different
+      questions: 0.05mm for "is there copper AT this pad" (the #472 zone
+      exemption, route.py's direct-first ordering) and
+      ``max(size)/2 + 0.35`` for "is there copper NEAR it" (net_rescue's #666
+      rung). Collapsing them into one constant would be the bug, so the caller
+      states which it means.
+    * ``min_net_pads`` -- a single-pad net's ball is trivially bare, and
+      counting it disabled U6/U7's zones spuriously on ottercast (#472).
+    * ``inset`` -- how far past the pitch band a pad must sit to count as
+      entombed. Outer-ring bare balls are reachable through the band.
+
+    A pad served by a POUR is not bare: ``pcb_data.zones`` is consulted, which
+    the #472 closure this generalises never did -- it built its attachment set
+    from segments and vias only, so an interior ball connected solely by a
+    plane read as BARE, and the entombment filter selects exactly the region
+    where plane-served balls live.
+    """
+    import math
+    from check_connected import point_in_polygon
+
+    want = set()
+    for n in (net_ids or ()):
+        want.add(n[1] if isinstance(n, (tuple, list)) else n)
+    want = {n for n in want
+            if n and len(pcb_data.pads_by_net.get(n, [])) >= min_net_pads}
+    if not want:
+        return []
+
+    attached = {}
+    for seg in pcb_data.segments:
+        if seg.net_id in want:
+            attached.setdefault(seg.net_id, []).append((seg.start_x,
+                                                        seg.start_y))
+            attached[seg.net_id].append((seg.end_x, seg.end_y))
+    for via in pcb_data.vias:
+        if via.net_id in want:
+            attached.setdefault(via.net_id, []).append((via.x, via.y))
+    zones_by_net = {}
+    for z in (getattr(pcb_data, 'zones', None) or ()):
+        if z.net_id in want and z.polygon:
+            zones_by_net.setdefault(z.net_id, []).append(z.polygon)
+
+    out = []
+    for fp in pcb_data.footprints.values():
+        pads = [p for p in fp.pads if p.net_id is not None]
+        if len(pads) < min_package_pads:
+            continue
+        xs = [p.global_x for p in pads]
+        ys = [p.global_y for p in pads]
+        x0, x1, y0, y1 = min(xs), max(xs), min(ys), max(ys)
+        # The band an outer ring occupies, as a pitch: the smallest non-zero
+        # centre-to-centre between pads of this footprint.
+        pitch = 0.0
+        for i, a in enumerate(pads[:60]):
+            for b in pads[i + 1:60]:
+                d = math.hypot(a.global_x - b.global_x, a.global_y - b.global_y)
+                if d > 1e-6 and (pitch == 0.0 or d < pitch):
+                    pitch = d
+        band = pitch * 1.1 + inset
+        for pad in pads:
+            if pad.net_id not in want or (pad.drill or 0) > 0:
+                continue      # a barrel already reaches every layer
+            if min(pad.global_x - x0, x1 - pad.global_x,
+                   pad.global_y - y0, y1 - pad.global_y) <= band:
+                continue      # outer ring: reachable through the band
+            if any(abs(x - pad.global_x) < reach and abs(y - pad.global_y) < reach
+                   for (x, y) in attached.get(pad.net_id, ())):
+                continue      # this pass or an earlier one attached copper
+            if any(point_in_polygon(pad.global_x, pad.global_y, poly)
+                   for poly in zones_by_net.get(pad.net_id, ())):
+                continue      # served by a pour, not bare
+            out.append((pad, fp.reference))
+    return out
+
+
 def warn_targets_outside_board(pcb_data: PCBData,
                                net_ids: List[Tuple[str, int]],
                                edge_margin: float = 0.0,

--- a/py_router/routing_diagnostics.py
+++ b/py_router/routing_diagnostics.py
@@ -540,6 +540,56 @@ def preexisting_blocker_hint(blocked_cells, config, pcb_data, net_id,
             f"cannot be), then bisect if you want a minimal rip." + prot_txt, names)
 
 
+def fanout_dropped_ball_hint(pcb_data, config, net_id, net_name=None, *,
+                             return_verdict=False):
+    """`no rippable blockers found` is TRUE. It is also useless (#652).
+
+    A ball the fanout dropped is removed from the output, and every later
+    routing step then fails its net with `no rippable blockers found` -- which
+    invites retries that can never work (rip authority, force-reroute, smaller
+    vias), because the ball has no escape stub for any of them to work with.
+    Measured on orangecrab: EXT_PLL+ and LED_R shipped unrouted in ~15 route-step
+    variants across an entire campaign, including `--rip-existing-nets '*'` and
+    `--force-reroute`, before the cause was traced back to the fanout log.
+
+    Unlike the other hints in this module this one is not a heuristic about the
+    search -- it is a statement about the BOARD: this net has a pad buried
+    inside a package's own pad field with no copper attached to it. Nothing
+    downstream can route that; the fix is upstream, in the fanout.
+
+    Re-derived from geometry because it has to be: the fanout's
+    `unescaped_nets` is printed and then lost -- no consumer, no sidecar, and
+    #472 settled that this machinery stays board-state-driven -- so a later
+    `route.py` PROCESS cannot be told, only shown.
+
+    Returns '' (or `('', None)`) when the net has no such pad, which is the
+    common case: the caller should print whatever it was going to print.
+    """
+    def _ret(hint, verdict=None):
+        return (hint, verdict) if return_verdict else hint
+
+    if pcb_data is None or not net_id:
+        return _ret('')
+    try:
+        from routing_common import entombed_bare_pads
+        bare = entombed_bare_pads(pcb_data, [net_id])
+    except Exception:
+        return _ret('')
+    if not bare:
+        return _ret('')
+    pad, ref = bare[0]
+    where = f"{ref}.{pad.pad_number}"
+    name = net_name or pad.net_name or f"net{net_id}"
+    hint = (f"Hint: pad {where} is a fanout-dropped ball (no escape stub) -- "
+            f"it sits inside {ref}'s pad field with no copper of {name} "
+            f"attached, so no rip authority or retry can reach it. Re-run the "
+            f"fanout for this net (bga_fanout.py / qfn_fanout.py "
+            f"--escape-method underpad, or a smaller --via-size).")
+    return _ret(hint, {'verdict': 'fanout_dropped', 'pad': where,
+                       'component': ref,
+                       'pads': [f"{r}.{p.pad_number}" for p, r in bare[:6]]})
+
+
 def static_boxin_hint(result, config, pcb_data=None, *, return_verdict=False):
     """One-line hint when a route died immediately with nothing rippable.
 

--- a/py_router/routing_diagnostics.py
+++ b/py_router/routing_diagnostics.py
@@ -541,7 +541,7 @@ def preexisting_blocker_hint(blocked_cells, config, pcb_data, net_id,
 
 
 def fanout_dropped_ball_hint(pcb_data, config, net_id, net_name=None, *,
-                             return_verdict=False):
+                             return_verdict=False, plane_like_pads=6):
     """`no rippable blockers found` is TRUE. It is also useless (#652).
 
     A ball the fanout dropped is removed from the output, and every later
@@ -580,13 +580,28 @@ def fanout_dropped_ball_hint(pcb_data, config, net_id, net_name=None, *,
     pad, ref = bare[0]
     where = f"{ref}.{pad.pad_number}"
     name = net_name or pad.net_name or f"net{net_id}"
+    # A net with many pads is usually plane-destined, and telling its owner to
+    # re-run the FANOUT is the wrong remedy: on a pre-plane board `zones` is
+    # empty, so `entombed_bare_pads` cannot tell a dropped signal ball from a
+    # GND ball waiting for its pour, and measured, power/ground dominates that
+    # population (118 of 120 hits on orangecrab_ext_pll). The observation is
+    # the same either way -- this pad owns no copper -- so the hint is not
+    # suppressed; the ADVICE is what changes. 6 is `fanout_candidate_nets`'
+    # own plane_min_pads, so the two agree about what looks like a plane.
+    n_pads = len(pcb_data.pads_by_net.get(net_id, []))
+    plane_like = n_pads >= plane_like_pads
+    remedy = ("re-create the plane for this net (route_planes.py), or fan it "
+              "out explicitly" if plane_like else
+              "re-run the fanout for this net (bga_fanout.py / qfn_fanout.py "
+              "--escape-method underpad, or a smaller --via-size)")
     hint = (f"Hint: pad {where} is a fanout-dropped ball (no escape stub) -- "
             f"it sits inside {ref}'s pad field with no copper of {name} "
-            f"attached, so no rip authority or retry can reach it. Re-run the "
-            f"fanout for this net (bga_fanout.py / qfn_fanout.py "
-            f"--escape-method underpad, or a smaller --via-size).")
+            f"attached, so no rip authority or retry can reach it"
+            + (f". {name} has {n_pads} pads, so it looks plane-destined: "
+               f"{remedy}." if plane_like else f". {remedy[0].upper()}"
+               f"{remedy[1:]}."))
     return _ret(hint, {'verdict': 'fanout_dropped', 'pad': where,
-                       'component': ref,
+                       'component': ref, 'plane_like': plane_like,
                        'pads': [f"{r}.{p.pad_number}" for p, r in bare[:6]]})
 
 

--- a/py_router/single_ended_loop.py
+++ b/py_router/single_ended_loop.py
@@ -1555,6 +1555,23 @@ def route_single_ended_nets(
                                  (result.get('blocked_cells_backward') or []))
                 if not _cells301:
                     _cells301 = list(locals().get('blocked_cells') or [])
+                # #652: say WHY nothing is rippable when the answer is
+                # "this ball never got an escape". Placed before the #301 hint
+                # because it is the actionable one -- #301 names copper to rip,
+                # and there is none to rip here.
+                try:
+                    from routing_diagnostics import fanout_dropped_ball_hint
+                    _h652, _v652 = fanout_dropped_ball_hint(
+                        pcb_data, config, net_id, net_name,
+                        return_verdict=True)
+                    if _h652:
+                        _c652 = condense_hint(_h652)
+                        if _c652:
+                            print(f"  {_c652}")
+                        record_net_event(state, net_id, "fanout_dropped",
+                                         _v652)
+                except Exception:
+                    pass
                 hint301, blockers301 = preexisting_blocker_hint(
                     _cells301, config, pcb_data, net_id,
                     routed_net_ids=state.routed_net_ids, return_names=True)

--- a/tests/mutate_620.py
+++ b/tests/mutate_620.py
@@ -146,23 +146,31 @@ ROWS = [
      (T620,), 'KILLED'),
 
     # --- THE BROAD PHASE. The rows an earlier test could not kill. ----------
+    # #854 note: these three replacements used to end in `ahx`, the name the
+    # anchor-box rule bound. This PR deleted it, which silently turned all
+    # three into CRASH mutants -- `NameError: ahx` -- and the runner counts an
+    # ERROR as a kill, so they would have reported KILLED forever while
+    # measuring nothing. The BROKEN-anchor guard cannot catch this: it
+    # validates the string being REPLACED, not the replacement. Found by a
+    # pre-push review, and the reason `_verify_mutants_are_not_crashes` below
+    # now exists.
     ('broad-phase-window-drops-the-halving', 'geo',
      _WINDOW,
      '        window = max(d + self._h2h,\n'
      '                     s / 2.0 + self._max_size / 2.0 + self._clearance,\n'
-     '                     ahx)',
+     '                     self._max_size / 2.0 + tw / 2.0)',
      (T620,), 'KILLED'),
 
     ('broad-phase-window-drops-the-ring-term', 'geo',
      _WINDOW,
      '        window = max(d / 2.0 + self._max_drill / 2.0 + self._h2h,\n'
-     '                     ahx)',
+     '                     self._max_size / 2.0 + tw / 2.0)',
      (T620,), 'KILLED'),
 
     ('broad-phase-window-drops-the-drill-term', 'geo',
      _WINDOW,
      '        window = max(s / 2.0 + self._max_size / 2.0 + self._clearance,\n'
-     '                     ahx)',
+     '                     self._max_size / 2.0 + tw / 2.0)',
      (T620,), 'KILLED'),
 
     # #854 RE-POINTED this row rather than retiring it: the window's third
@@ -227,6 +235,20 @@ ROWS = [
      "           and abs(v['x'] - pad.global_x) < tol\n"
      "           and abs(v['y'] - pad.global_y) < tol\n"
      '           for v in vias):',
+     (T620,), 'KILLED'),
+
+    # #854: `tighten` shrinks the survivor, and a smaller barrel reaches less
+    # far, so the merge can be justified by a via that no longer reaches once
+    # tightened. Impossible under the old pad-BOX rule (a box does not depend
+    # on via size), so this row exists because the rule changed.
+    ('post-tighten-reach-recheck-deleted', 'bga',
+     '                    if not via_anchors_route(_tx, _ty, min(_ts, v_size),\n'
+     "                                             (pad_x, pad_y), track_width):\n"
+     "                        _v = 'clear'\n"
+     '                    else:',
+     '                    if False:\n'
+     "                        _v = 'clear'\n"
+     '                    else:',
      (T620,), 'KILLED'),
 
     ('twin-appends-a-second-via-anyway', 'bga',
@@ -421,13 +443,20 @@ def run(only=None):
             for o, nw in edits:
                 mutated = mutated.replace(o, nw, 1)
             io.open(path, 'w', encoding='utf-8', newline='').write(mutated)
-            killed, failed = False, []
+            killed, failed, crashed = False, [], False
             for t in tests:
                 p = subprocess.run([sys.executable, '-X', 'utf8', t],
                                    capture_output=True, text=True,
                                    encoding='utf-8', errors='replace',
                                    timeout=1800, cwd=_ROOT)
                 out = (p.stderr or '') + (p.stdout or '')
+                # A mutant that makes the ENGINE crash proves nothing about
+                # the test's discrimination -- the runner would score the
+                # non-zero exit as a kill either way. Three rows here spent a
+                # commit in exactly that state (`NameError: ahx`), reporting
+                # KILLED while measuring nothing, so it is now its own verdict.
+                if 'NameError' in out or 'AttributeError' in out:
+                    crashed = True
                 if p.returncode:
                     killed = True
                 failed += ['%s::%s' % (os.path.basename(t)[5:8],
@@ -436,8 +465,10 @@ def run(only=None):
                            for l in out.splitlines()
                            if l.startswith(('FAIL:', 'ERROR:'))]
             io.open(path, 'w', encoding='utf-8', newline='').write(base)
-            results.append((name, 'KILLED' if killed else 'SURVIVED', expect,
-                            '%d' % len(failed), failed))
+            results.append((name,
+                            'CRASH' if crashed else
+                            ('KILLED' if killed else 'SURVIVED'),
+                            expect, '%d' % len(failed), failed))
     finally:
         for k, v in TARGETS.items():
             io.open(v, 'w', encoding='utf-8', newline='').write(orig[k])
@@ -454,7 +485,7 @@ def run(only=None):
             print('%s      %s' % (' ' * w, f))
     killed = sum(1 for r in results if r[1] == 'KILLED')
     survived = sum(1 for r in results if r[1] == 'SURVIVED')
-    broken = sum(1 for r in results if r[1] == 'BROKEN')
+    broken = sum(1 for r in results if r[1] in ('BROKEN', 'CRASH'))
     print('\n%d rows: %d killed, %d survived (%d of them expected), %d broken'
           % (len(results), killed, survived,
              sum(1 for r in results if r[1] == r[2] == 'SURVIVED'), broken))

--- a/tests/mutate_620.py
+++ b/tests/mutate_620.py
@@ -217,16 +217,17 @@ ROWS = [
     # invisible downstream: fixing `verdict` alone leaves `_has_copper`
     # agreeing with the old answer, so nothing straps the swallowed ball.
     ('ball-anchor-test-reverted-to-the-pad-box', 'bga',
-     "                if any(_v['net_id'] == _p.net_id\n"
-     "                       and via_anchors_route(_v['x'], _v['y'],\n"
-     "                                             _v.get('size') or 0.0,\n"
-     "                                             (_p.global_x, _p.global_y), _tw)\n"
-     '                       for _v in vias_to_add):',
-     "                if any(_v['net_id'] == _p.net_id\n"
-     "                       and abs(_v['x'] - _p.global_x) < tol\n"
-     "                       and abs(_v['y'] - _p.global_y) < tol\n"
-     '                       for _v in vias_to_add):',
-     (T620, T756), 'KILLED'),
+     "    if any(v['net_id'] == pad.net_id\n"
+     "           and via_anchors_route(v['x'], v['y'], v.get('size') or 0.0,\n"
+     "                                 (pad.global_x, pad.global_y), "
+     "track_width)\n"
+     '           for v in vias):',
+     "    tol = max(pad.size_x, pad.size_y) / 2 + 0.01\n"
+     "    if any(v['net_id'] == pad.net_id\n"
+     "           and abs(v['x'] - pad.global_x) < tol\n"
+     "           and abs(v['y'] - pad.global_y) < tol\n"
+     '           for v in vias):',
+     (T620,), 'KILLED'),
 
     ('twin-appends-a-second-via-anyway', 'bga',
      "                    _twin_shared += 1\n                    continue",

--- a/tests/mutate_620.py
+++ b/tests/mutate_620.py
@@ -152,8 +152,8 @@ ROWS = [
     # ERROR as a kill, so they would have reported KILLED forever while
     # measuring nothing. The BROKEN-anchor guard cannot catch this: it
     # validates the string being REPLACED, not the replacement. Found by a
-    # pre-push review, and the reason `_verify_mutants_are_not_crashes` below
-    # now exists.
+    # pre-push review, and the reason the runner below reports CRASH as its own
+    # verdict instead of folding a NameError into KILLED.
     ('broad-phase-window-drops-the-halving', 'geo',
      _WINDOW,
      '        window = max(d + self._h2h,\n'
@@ -408,6 +408,34 @@ ROWS = [
 ]
 
 
+def _head():
+    p = subprocess.run(['git', 'rev-parse', 'HEAD'], capture_output=True,
+                       text=True, cwd=_ROOT)
+    return (p.stdout or '').strip()
+
+
+def _warn_if_head_moved(before):
+    """A commit made WHILE this battery ran may have captured a mutant.
+
+    The dirty-tree refusal above checks at START. It cannot see a `git add -A`
+    that lands between a rewrite and the `finally` restore -- and that is not
+    hypothetical: `h2h-decline-not-disclosed`'s edit was committed into an
+    unrelated PR that way, silencing a disclosure print in underpad.py for two
+    commits. One writer per tree; this says so out loud when the rule is broken.
+    """
+    after = _head()
+    if before and after and before != after:
+        print('\n*** HEAD MOVED DURING THIS RUN (%s -> %s) ***'
+              % (before[:8], after[:8]))
+        print('    A commit made while files were mutated may have captured a')
+        print('    MUTANT. Check every target before trusting this run:')
+        for v in TARGETS.values():
+            print('      git diff %s -- %s' % (before[:8],
+                                               os.path.relpath(v, _ROOT)))
+        return True
+    return False
+
+
 def _dirty(path):
     p = subprocess.run(['git', 'status', '--porcelain', '--', path],
                        capture_output=True, text=True, cwd=_ROOT)
@@ -426,6 +454,7 @@ def run(only=None):
                   % os.path.basename(path))
             return 2
 
+    head_before = _head()
     orig = {k: io.open(v, encoding='utf-8', newline='').read()
             for k, v in TARGETS.items()}
     results = []
@@ -494,7 +523,8 @@ def run(only=None):
              sum(1 for r in results if r[1] == r[2] == 'SURVIVED'), broken))
     if wrong or broken:
         print('%d row(s) did not match their expectation' % (wrong + broken))
-    return 1 if (wrong or broken) else 0
+    moved = _warn_if_head_moved(head_before)
+    return 1 if (wrong or broken or moved) else 0
 
 
 def main():

--- a/tests/mutate_620.py
+++ b/tests/mutate_620.py
@@ -251,14 +251,17 @@ ROWS = [
      '                    else:',
      (T620,), 'KILLED'),
 
+    # Both anchors sit one indent deeper since the post-tighten reach re-check
+    # put the branch body inside an `else:`. Re-pointed after that landed, not
+    # when written -- the file's own rule, and it caught these two.
     ('twin-appends-a-second-via-anyway', 'bga',
-     "                    _twin_shared += 1\n                    continue",
-     '                    _twin_shared += 1',
+     "                        _twin_shared += 1\n                        continue",
+     '                        _twin_shared += 1',
      (T620,), 'KILLED'),
 
     ('twin-keeps-the-FIRST-via-not-the-tighter', 'bga',
-     '                    if _pending.tighten(_tx, _ty, v_size, v_drill):',
-     '                    if False:',
+     '                        if _pending.tighten(_tx, _ty, v_size, v_drill):',
+     '                        if False:',
      (T620,), 'KILLED'),
 
     # --- THE LADDER ---------------------------------------------------------

--- a/tests/mutate_620.py
+++ b/tests/mutate_620.py
@@ -76,7 +76,7 @@ T756 = os.path.join(_TESTS, 'test_756_fanout_clearance_drill_floors.py')
 _WINDOW = ("        window = max(d / 2.0 + self._max_drill / 2.0 + self._h2h,\n"
            "                     s / 2.0 + self._max_size / 2.0 + "
            "self._clearance,\n"
-           "                     ahx)")
+           "                     self._max_size / 2.0 + tw / 2.0)")
 
 # (name, target, old, new, tests, expect)
 ROWS = [
@@ -85,16 +85,16 @@ ROWS = [
      '                _v, _detail = _pending.verdict(pad_x, pad_y, v_size, '
      'v_drill,\n'
      '                                               route.net_id, _bulges,\n'
-     '                                               anchor_box=_abox)',
+     '                                               track_width=track_width)',
      "                _v, _detail = 'clear', None",
      (T620,), 'KILLED'),
 
     ('verdict-always-clear', 'geo',
      '        d = drill or 0.0\n        s = size or 0.0\n'
-     '        ahx, ahy = ((self._tol, self._tol) if anchor_box is None else',
+     '        tw = track_width or 0.0',
      "        return 'clear', None\n"
      '        d = drill or 0.0\n        s = size or 0.0\n'
-     '        ahx, ahy = ((self._tol, self._tol) if anchor_box is None else',
+     '        tw = track_width or 0.0',
      (T620,), 'KILLED'),
 
     ('pending-never-records-the-committed-via', 'bga',
@@ -165,7 +165,11 @@ ROWS = [
      '                     ahx)',
      (T620,), 'KILLED'),
 
-    ('broad-phase-window-drops-the-anchor-term', 'geo',
+    # #854 RE-POINTED this row rather than retiring it: the window's third
+    # term is no longer the candidate pad's half-width but the ANCHOR REACH
+    # (widest committed via + half a track), and it is still the term nothing
+    # else makes binding -- see test_the_REACH_term_in_the_broad_phase_window.
+    ('broad-phase-window-drops-the-reach-term', 'geo',
      _WINDOW,
      '        window = max(d / 2.0 + self._max_drill / 2.0 + self._h2h,\n'
      '                     s / 2.0 + self._max_size / 2.0 + self._clearance)',
@@ -178,27 +182,51 @@ ROWS = [
 
     # --- TWINS --------------------------------------------------------------
     ('twin-branch-refuses-instead', 'geo',
-     '            if (onet == net_id\n'
-     '                    and abs(ox - x) <= ahx and abs(oy - y) <= ahy):\n'
+     '            if onet == net_id and via_anchors_route(ox, oy, os_, '
+     '(x, y), tw):\n'
      "                return 'twin', (ox, oy, os_, od)",
-     '            if (onet == net_id\n'
-     '                    and abs(ox - x) <= ahx and abs(oy - y) <= ahy):\n'
+     '            if onet == net_id and via_anchors_route(ox, oy, os_, '
+     '(x, y), tw):\n'
      "                return 'conflict', ('same site', ox, oy)",
      (T620,), 'KILLED'),
 
     ('twin-branch-ignores-the-net', 'geo',
-     '            if (onet == net_id\n'
-     '                    and abs(ox - x) <= ahx and abs(oy - y) <= ahy):',
-     '            if (True\n'
-     '                    and abs(ox - x) <= ahx and abs(oy - y) <= ahy):',
+     '            if onet == net_id and via_anchors_route(ox, oy, os_, '
+     '(x, y), tw):',
+     '            if True and via_anchors_route(ox, oy, os_, (x, y), tw):',
      (T620,), 'KILLED'),
 
     ('twin-keyed-on-the-exact-site-again', 'geo',
-     '            if (onet == net_id\n'
-     '                    and abs(ox - x) <= ahx and abs(oy - y) <= ahy):',
-     '            if (onet == net_id\n'
-     '                    and dist <= self._tol and abs(oy - y) <= ahy):',
+     '            if onet == net_id and via_anchors_route(ox, oy, os_, '
+     '(x, y), tw):',
+     '            if onet == net_id and dist <= self._tol:',
      (T620,), 'KILLED'),
+
+    # --- #854: a reach test is not a containment test -----------------------
+    # The row the issue asks for by name ("mutate_620.py should get a row that
+    # dies when the anchor test is widened back"). 0.5 is the BIG pad's own
+    # half-extent in the dissimilar-size arm, so this row IS that arm's defect.
+    ('twin-keyed-on-the-candidate-PAD-BOX-again', 'geo',
+     '            if onet == net_id and via_anchors_route(ox, oy, os_, '
+     '(x, y), tw):',
+     '            if (onet == net_id\n'
+     '                    and abs(ox - x) <= 0.5 and abs(oy - y) <= 0.5):',
+     (T620,), 'KILLED'),
+
+    # The SECOND copy of the same rule, which is what made the stranding
+    # invisible downstream: fixing `verdict` alone leaves `_has_copper`
+    # agreeing with the old answer, so nothing straps the swallowed ball.
+    ('ball-anchor-test-reverted-to-the-pad-box', 'bga',
+     "                if any(_v['net_id'] == _p.net_id\n"
+     "                       and via_anchors_route(_v['x'], _v['y'],\n"
+     "                                             _v.get('size') or 0.0,\n"
+     "                                             (_p.global_x, _p.global_y), _tw)\n"
+     '                       for _v in vias_to_add):',
+     "                if any(_v['net_id'] == _p.net_id\n"
+     "                       and abs(_v['x'] - _p.global_x) < tol\n"
+     "                       and abs(_v['y'] - _p.global_y) < tol\n"
+     '                       for _v in vias_to_add):',
+     (T620, T756), 'KILLED'),
 
     ('twin-appends-a-second-via-anyway', 'bga',
      "                    _twin_shared += 1\n                    continue",

--- a/tests/mutate_846.py
+++ b/tests/mutate_846.py
@@ -208,6 +208,34 @@ ROWS = [
 ]
 
 
+def _head():
+    p = subprocess.run(['git', 'rev-parse', 'HEAD'], capture_output=True,
+                       text=True, cwd=_ROOT)
+    return (p.stdout or '').strip()
+
+
+def _warn_if_head_moved(before):
+    """A commit made WHILE this battery ran may have captured a mutant.
+
+    The dirty-tree refusal above checks at START. It cannot see a `git add -A`
+    that lands between a rewrite and the `finally` restore -- and that is not
+    hypothetical: `h2h-decline-not-disclosed`'s edit was committed into an
+    unrelated PR that way, silencing a disclosure print in underpad.py for two
+    commits. One writer per tree; this says so out loud when the rule is broken.
+    """
+    after = _head()
+    if before and after and before != after:
+        print('\n*** HEAD MOVED DURING THIS RUN (%s -> %s) ***'
+              % (before[:8], after[:8]))
+        print('    A commit made while files were mutated may have captured a')
+        print('    MUTANT. Check every target before trusting this run:')
+        for v in TARGETS.values():
+            print('      git diff %s -- %s' % (before[:8],
+                                               os.path.relpath(v, _ROOT)))
+        return True
+    return False
+
+
 def _dirty(path):
     p = subprocess.run(['git', 'status', '--porcelain', '--', path],
                        capture_output=True, text=True, cwd=_ROOT)
@@ -226,6 +254,7 @@ def run(only=None):
                   % os.path.basename(path))
             return 2
 
+    head_before = _head()
     orig = {k: io.open(v, encoding='utf-8', newline='').read()
             for k, v in TARGETS.items()}
     results = []
@@ -296,7 +325,8 @@ def run(only=None):
              sum(1 for r in results if r[1] == r[2] == 'SURVIVED'), broken))
     if wrong or broken:
         print('%d row(s) did not match their expectation' % (wrong + broken))
-    return 1 if (wrong or broken) else 0
+    moved = _warn_if_head_moved(head_before)
+    return 1 if (wrong or broken or moved) else 0
 
 
 def main():

--- a/tests/mutate_846.py
+++ b/tests/mutate_846.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Mutation battery for #846 / #854 / #652 -- do the new tests actually bite?
+
+Each row rewrites ONE line of engine source into a plausible wrong version and
+runs the tests that should notice. A row that SURVIVES is a test that does not
+test what its name says; a row reported BROKEN is an anchor that no longer
+matches, which is the most flattering possible bug (an anchor matching nothing
+scores every mutation as killed) and is therefore checked before mutating.
+
+Deliberately NOT named test_*: run_all.py must not collect it. It rewrites
+engine files in place and restores them in a `finally`, so it refuses to start
+on a dirty tree -- commit first.
+
+    python3 tests/mutate_846.py            # every row
+    python3 tests/mutate_846.py --row NAME
+
+The measured table lives in the header of the test file each row defends,
+written from the run and never edited to match a prediction.
+"""
+import argparse
+import io
+import os
+import subprocess
+import sys
+
+_TESTS = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_TESTS)
+
+QFN = os.path.join(_ROOT, 'py_router', 'qfn_fanout', '__init__.py')
+FAB = os.path.join(_ROOT, 'py_router', 'fab_notes.py')
+COM = os.path.join(_ROOT, 'py_router', 'routing_common.py')
+DIA = os.path.join(_ROOT, 'py_router', 'routing_diagnostics.py')
+RTE = os.path.join(_ROOT, 'py_router', 'route.py')
+TARGETS = {'qfn': QFN, 'fab': FAB, 'com': COM, 'dia': DIA, 'rte': RTE}
+
+T846 = os.path.join(_TESTS, 'test_846_via_in_pad_classification.py')
+TLAD = os.path.join(_TESTS, 'test_846_onpad_ladder_reach.py')
+T652 = os.path.join(_TESTS, 'test_652_fanout_dropped_ball_hint.py')
+TCLAMP = os.path.join(_TESTS, 'test_fanout_via_in_pad_clamp.py')
+
+_CLASSIFY = '            if via_overlaps_pad(pi.pad, vx, vy, via_size):'
+
+# (name, target, old, new, tests, expect)
+ROWS = [
+    # --- #846: the classification -----------------------------------------
+    ('classification-reverted-to-the-centre-test', 'qfn',
+     _CLASSIFY,
+     '            if math.hypot(vx - px, vy - py) <= POSITION_TOLERANCE:',
+     (T846, TCLAMP), 'KILLED'),
+
+    ('classification-always-in-pad', 'qfn',
+     _CLASSIFY, '            if True:',
+     (T846,), 'KILLED'),
+
+    ('classification-always-off-pad', 'qfn',
+     _CLASSIFY, '            if False:',
+     (T846, TCLAMP), 'KILLED'),
+
+    # The scoping half: `via_in_pad_sites` breaks on the FIRST same-net pad it
+    # overlaps, which need not be the pad this leg escapes -- and the clamp is
+    # applied to `pi.pad`. Classifying by a neighbour and clamping to this one
+    # is the shape the fix had to avoid.
+    ('classification-scoped-to-ANY-same-net-pad', 'qfn',
+     _CLASSIFY,
+     '            if any(via_overlaps_pad(_q, vx, vy, via_size)\n'
+     '                   for _q in pcb_data.pads_by_net.get(pi.pad.net_id, ())):',
+     (T846,), 'KILLED'),
+
+    ('offcentre-count-never-incremented', 'qfn',
+     '                if math.hypot(vx - px, vy - py) > POSITION_TOLERANCE:\n'
+     '                    offcentre_n += 1',
+     '                if False:\n'
+     '                    offcentre_n += 1',
+     (T846,), 'SURVIVED'),   # a disclosure count, not a behaviour -- see below
+
+    # --- #846: fab_notes owns ONE predicate --------------------------------
+    ('fab-note-stops-calling-the-shared-predicate', 'fab',
+     '            if via_overlaps_pad(pad, vx, vy, vsz, margin):',
+     '            if abs(vx - _get(pad, \'global_x\', 0.0)) <= 1e-3 \\\n'
+     '                    and abs(vy - _get(pad, \'global_y\', 0.0)) <= 1e-3:',
+     (T846,), 'KILLED'),
+
+    ('overlap-predicate-drops-the-barrel-radius', 'fab',
+     '    vr = (via_size if via_size else 0.6) / 2.0\n'
+     '    return _pad_holds(pad, via_x, via_y, max(vr - 1e-6, margin))',
+     '    return _pad_holds(pad, via_x, via_y, margin)',
+     (T846,), 'KILLED'),
+
+    # --- #846: the ladder reach knob ---------------------------------------
+    ('ladder-reach-filter-deleted', 'qfn',
+     '        if _reach is not None:\n'
+     '            axis = [d for d in axis if abs(d) <= _reach + 1e-9]',
+     '        if False:\n'
+     '            axis = [d for d in axis if abs(d) <= _reach + 1e-9]',
+     (TLAD,), 'KILLED'),
+
+    ('unrecognised-knob-value-shortens-the-ladder', 'qfn',
+     "        _reach = {'pad': pad_width / 2.0,\n"
+     "                  'barrel': pad_width / 2.0 - via_size / 2.0,\n"
+     "                  }.get(env_knobs.QFN_ONPAD_REACH)",
+     "        _reach = {'full': None,\n"
+     "                  'barrel': pad_width / 2.0 - via_size / 2.0,\n"
+     "                  }.get(env_knobs.QFN_ONPAD_REACH, pad_width / 2.0)",
+     (TLAD,), 'KILLED'),
+
+    ('pad-and-barrel-arms-collapsed-into-one', 'qfn',
+     "                  'barrel': pad_width / 2.0 - via_size / 2.0,",
+     "                  'barrel': pad_width / 2.0,",
+     (TLAD,), 'KILLED'),
+
+    # --- #652: the predicate ------------------------------------------------
+    ('bare-test-ignores-attached-copper', 'com',
+     '            if any(abs(x - pad.global_x) < reach and abs(y - pad.global_y) < reach\n'
+     '                   for (x, y) in attached.get(pad.net_id, ())):\n'
+     '                continue      # this pass or an earlier one attached copper',
+     '            if False:\n'
+     '                continue      # this pass or an earlier one attached copper',
+     (T652,), 'KILLED'),
+
+    ('bare-test-ignores-POURS', 'com',
+     '            if any(point_in_polygon(pad.global_x, pad.global_y, poly)\n'
+     '                   for poly in zones_by_net.get(pad.net_id, ())):\n'
+     '                continue      # served by a pour, not bare',
+     '            if False:\n'
+     '                continue      # served by a pour, not bare',
+     (T652,), 'KILLED'),
+
+    ('bare-test-reports-the-OUTER-RING-too', 'com',
+     '            if min(pad.global_x - x0, x1 - pad.global_x,\n'
+     '                   pad.global_y - y0, y1 - pad.global_y) <= band:\n'
+     '                continue      # outer ring: reachable through the band',
+     '            if False:\n'
+     '                continue      # outer ring: reachable through the band',
+     (T652,), 'KILLED'),
+
+    ('bare-test-reports-SINGLE-PAD-nets', 'com',
+     '    want = {n for n in want\n'
+     '            if n and len(pcb_data.pads_by_net.get(n, [])) >= min_net_pads}',
+     '    want = {n for n in want if n}',
+     (T652,), 'KILLED'),
+
+    ('bare-test-reports-DRILLED-pads', 'com',
+     '            if pad.net_id not in want or (pad.drill or 0) > 0:',
+     '            if pad.net_id not in want:',
+     (T652,), 'KILLED'),
+
+    # --- #652: the hint and its channel -------------------------------------
+    ('hint-never-fires', 'dia',
+     '    if not bare:\n        return _ret(\'\')',
+     '    if True:\n        return _ret(\'\')',
+     (T652,), 'KILLED'),
+
+    ('hint-fires-for-every-net', 'dia',
+     '    if pcb_data is None or not net_id:\n        return _ret(\'\')',
+     '    if pcb_data is None or not net_id:\n        return _ret(\'\')\n'
+     '    bare = [(p, "U1") for p in pcb_data.pads_by_net.get(net_id, ())]\n'
+     '    if bare:\n'
+     '        return _ret("Hint: pad U1.x is a fanout-dropped ball (no escape '
+     'stub) -- re-run the fanout (--escape-method underpad).",\n'
+     '                    {"verdict": "fanout_dropped", "pad": "U1.x",\n'
+     '                     "component": "U1", "pads": []})',
+     (T652,), 'KILLED'),
+
+    ('summary-key-never-set', 'rte',
+     "        if fanout_dropped_report:\n"
+     "            summary['fanout_dropped'] = fanout_dropped_report",
+     "        if False:\n"
+     "            summary['fanout_dropped'] = fanout_dropped_report",
+     (T652,), 'KILLED'),
+
+    ('results_data-mirror-dropped', 'rte',
+     "            'fanout_dropped': fanout_dropped_report,",
+     "            'fanout_dropped': [],",
+     (T652,), 'KILLED'),
+
+    # --- the battery's own control -----------------------------------------
+    # A semantically inert edit. If this is ever KILLED the rig is reporting
+    # noise, and every other row's verdict is suspect.
+    ('control-semantically-inert-edit', 'com',
+     '    out = []\n    for fp in pcb_data.footprints.values():',
+     '    out = list()\n    for fp in pcb_data.footprints.values():',
+     (T652,), 'SURVIVED'),
+]
+
+
+def _dirty(path):
+    p = subprocess.run(['git', 'status', '--porcelain', '--', path],
+                       capture_output=True, text=True, cwd=_ROOT)
+    return bool(p.stdout.strip())
+
+
+def run(only=None):
+    rows = [r for r in ROWS if only is None or r[0] == only]
+    if not rows:
+        print('no row named %r' % only)
+        return 1
+    for path in TARGETS.values():
+        if _dirty(path):
+            print('REFUSING: %s has uncommitted changes. Commit or stash '
+                  'first -- this battery restores by overwriting.'
+                  % os.path.basename(path))
+            return 2
+
+    orig = {k: io.open(v, encoding='utf-8', newline='').read()
+            for k, v in TARGETS.items()}
+    results = []
+    try:
+        for name, tgt, old, new, tests, expect in rows:
+            path = TARGETS[tgt]
+            base = orig[tgt]
+            edits = old if isinstance(old, list) else [(old, new)]
+            if '\r\n' in base:
+                edits = [(o.replace('\n', '\r\n'), n.replace('\n', '\r\n'))
+                         for o, n in edits]
+            counts = [base.count(o) for o, _n in edits]
+            if counts != [1] * len(edits):
+                results.append((name, 'BROKEN', expect,
+                                'anchors matched %s times' % counts, []))
+                continue
+            mutated = base
+            for o, nw in edits:
+                mutated = mutated.replace(o, nw, 1)
+            io.open(path, 'w', encoding='utf-8', newline='').write(mutated)
+            killed, failed = False, []
+            for t in tests:
+                p = subprocess.run([sys.executable, '-X', 'utf8', t],
+                                   capture_output=True, text=True,
+                                   encoding='utf-8', errors='replace',
+                                   timeout=1800, cwd=_ROOT)
+                out = (p.stderr or '') + (p.stdout or '')
+                if p.returncode:
+                    killed = True
+                failed += ['%s::%s' % (os.path.basename(t)[5:8],
+                                       l.split('--')[0].replace('FAIL: ', '')
+                                       .replace('ERROR: ', '').strip()[:70])
+                           for l in out.splitlines()
+                           if l.strip().startswith(('FAIL:', 'ERROR:'))]
+            io.open(path, 'w', encoding='utf-8', newline='').write(base)
+            results.append((name, 'KILLED' if killed else 'SURVIVED', expect,
+                            '%d' % len(failed), failed))
+    finally:
+        for k, v in TARGETS.items():
+            io.open(v, 'w', encoding='utf-8', newline='').write(orig[k])
+
+    w = max(len(r[0]) for r in results)
+    wrong = 0
+    for name, verdict, expect, cnt, failed in results:
+        mark = ''
+        if verdict != expect:
+            mark = '   <-- WRONG, expected %s' % expect
+            wrong += 1
+        print('%-*s  %-9s  %-3s%s' % (w, name, verdict, cnt, mark))
+        for f in failed[:4]:
+            print('%s      %s' % (' ' * w, f))
+    killed = sum(1 for r in results if r[1] == 'KILLED')
+    survived = sum(1 for r in results if r[1] == 'SURVIVED')
+    broken = sum(1 for r in results if r[1] == 'BROKEN')
+    print('\n%d rows: %d killed, %d survived (%d of them expected), %d broken'
+          % (len(results), killed, survived,
+             sum(1 for r in results if r[1] == r[2] == 'SURVIVED'), broken))
+    if wrong or broken:
+        print('%d row(s) did not match their expectation' % (wrong + broken))
+    return 1 if (wrong or broken) else 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument('--row', help='run a single row by name')
+    ap.add_argument('--list', action='store_true', help='print row names')
+    a = ap.parse_args()
+    if a.list:
+        for r in ROWS:
+            print('%-46s %-4s %s' % (r[0], r[1], r[5]))
+        return 0
+    return run(a.row)
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/mutate_846.py
+++ b/tests/mutate_846.py
@@ -246,13 +246,22 @@ def run(only=None):
             for o, nw in edits:
                 mutated = mutated.replace(o, nw, 1)
             io.open(path, 'w', encoding='utf-8', newline='').write(mutated)
-            killed, failed = False, []
+            killed, failed, crashed = False, [], False
             for t in tests:
                 p = subprocess.run([sys.executable, '-X', 'utf8', t],
                                    capture_output=True, text=True,
                                    encoding='utf-8', errors='replace',
                                    timeout=1800, cwd=_ROOT)
                 out = (p.stderr or '') + (p.stdout or '')
+                # A mutant that makes the ENGINE crash proves nothing about
+                # the test's discrimination -- a non-zero exit scores as a kill
+                # either way. Three rows of mutate_620 spent a commit in
+                # exactly that state (`NameError: ahx` after this PR deleted
+                # the name their REPLACEMENT text used), reporting KILLED while
+                # measuring nothing. The BROKEN-anchor guard cannot see it: it
+                # validates the string being replaced, not the replacement.
+                if 'NameError' in out or 'AttributeError' in out:
+                    crashed = True
                 if p.returncode:
                     killed = True
                 failed += ['%s::%s' % (os.path.basename(t)[5:8],
@@ -261,8 +270,10 @@ def run(only=None):
                            for l in out.splitlines()
                            if l.strip().startswith(('FAIL:', 'ERROR:'))]
             io.open(path, 'w', encoding='utf-8', newline='').write(base)
-            results.append((name, 'KILLED' if killed else 'SURVIVED', expect,
-                            '%d' % len(failed), failed))
+            results.append((name,
+                            'CRASH' if crashed else
+                            ('KILLED' if killed else 'SURVIVED'),
+                            expect, '%d' % len(failed), failed))
     finally:
         for k, v in TARGETS.items():
             io.open(v, 'w', encoding='utf-8', newline='').write(orig[k])
@@ -279,7 +290,7 @@ def run(only=None):
             print('%s      %s' % (' ' * w, f))
     killed = sum(1 for r in results if r[1] == 'KILLED')
     survived = sum(1 for r in results if r[1] == 'SURVIVED')
-    broken = sum(1 for r in results if r[1] == 'BROKEN')
+    broken = sum(1 for r in results if r[1] in ('BROKEN', 'CRASH'))
     print('\n%d rows: %d killed, %d survived (%d of them expected), %d broken'
           % (len(results), killed, survived,
              sum(1 for r in results if r[1] == r[2] == 'SURVIVED'), broken))

--- a/tests/mutate_846.py
+++ b/tests/mutate_846.py
@@ -58,20 +58,34 @@ ROWS = [
 
     # The scoping half: `via_in_pad_sites` breaks on the FIRST same-net pad it
     # overlaps, which need not be the pad this leg escapes -- and the clamp is
-    # applied to `pi.pad`. Classifying by a neighbour and clamping to this one
-    # is the shape the fix had to avoid.
+    # applied to `pi.pad`. Classifying by a neighbour while clamping to this
+    # one is the shape the fix had to avoid, and why the commit loop passes
+    # `pi.pad` rather than calling `via_in_pad_sites`.
+    #
+    # SURVIVED, and kept for the reason rather than deleted. On every board in
+    # the set the two spellings agree: the nets being escaped have ONE pad on
+    # the fanned footprint, and where they do not (tigard's GND, which owns the
+    # 4.35mm exposed pad as well as leads) the via overlaps both, so the
+    # BOOLEAN is the same and the clamp target is `pi.pad` either way. Killing
+    # it needs a via overlapping a same-net NEIGHBOUR but not its own pad,
+    # which no in-repo board produces. This row is a change detector for the
+    # day one does -- deleting it is how that becomes folklore.
     ('classification-scoped-to-ANY-same-net-pad', 'qfn',
      _CLASSIFY,
      '            if any(via_overlaps_pad(_q, vx, vy, via_size)\n'
      '                   for _q in pcb_data.pads_by_net.get(pi.pad.net_id, ())):',
-     (T846,), 'KILLED'),
+     (T846,), 'SURVIVED'),
 
+    # A disclosure count, not a behaviour: the emitted copper is identical
+    # either way, so no test that grades the BOARD can see it. Kept because a
+    # number a reader is told to watch move is worth a row saying which kind of
+    # thing it is.
     ('offcentre-count-never-incremented', 'qfn',
      '                if math.hypot(vx - px, vy - py) > POSITION_TOLERANCE:\n'
      '                    offcentre_n += 1',
      '                if False:\n'
      '                    offcentre_n += 1',
-     (T846,), 'SURVIVED'),   # a disclosure count, not a behaviour -- see below
+     (T846,), 'SURVIVED'),
 
     # --- #846: fab_notes owns ONE predicate --------------------------------
     ('fab-note-stops-calling-the-shared-predicate', 'fab',

--- a/tests/mutate_846.py
+++ b/tests/mutate_846.py
@@ -88,24 +88,35 @@ ROWS = [
 
     # --- #846: the ladder reach knob ---------------------------------------
     ('ladder-reach-filter-deleted', 'qfn',
-     '        if _reach is not None:\n'
-     '            axis = [d for d in axis if abs(d) <= _reach + 1e-9]',
-     '        if False:\n'
-     '            axis = [d for d in axis if abs(d) <= _reach + 1e-9]',
+     '    if reach is not None:\n'
+     '        seq = [d for d in seq if abs(d) <= reach + 1e-9]',
+     '    if False:\n'
+     '        seq = [d for d in seq if abs(d) <= reach + 1e-9]',
      (TLAD,), 'KILLED'),
 
     ('unrecognised-knob-value-shortens-the-ladder', 'qfn',
-     "        _reach = {'pad': pad_width / 2.0,\n"
-     "                  'barrel': pad_width / 2.0 - via_size / 2.0,\n"
-     "                  }.get(env_knobs.QFN_ONPAD_REACH)",
-     "        _reach = {'full': None,\n"
-     "                  'barrel': pad_width / 2.0 - via_size / 2.0,\n"
-     "                  }.get(env_knobs.QFN_ONPAD_REACH, pad_width / 2.0)",
+     "    reach = {'pad': pad_width / 2.0,\n"
+     "             'barrel': pad_width / 2.0 - via_size / 2.0,\n"
+     "             }.get(env_knobs.QFN_ONPAD_REACH)",
+     "    reach = {'full': None,\n"
+     "             'barrel': pad_width / 2.0 - via_size / 2.0,\n"
+     "             }.get(env_knobs.QFN_ONPAD_REACH, pad_width / 2.0)",
      (TLAD,), 'KILLED'),
 
     ('pad-and-barrel-arms-collapsed-into-one', 'qfn',
-     "                  'barrel': pad_width / 2.0 - via_size / 2.0,",
-     "                  'barrel': pad_width / 2.0,",
+     "             'barrel': pad_width / 2.0 - via_size / 2.0,",
+     "             'barrel': pad_width / 2.0,",
+     (TLAD,), 'KILLED'),
+
+    # The engine must have ONE source for these offsets. A second copy inside
+    # candidate_offsets is how the first draft of the ladder test came to
+    # mirror the engine instead of calling it, and every knob row survived.
+    ('candidate_offsets-grows-its-own-copy-of-the-ladder', 'qfn',
+     "        axis = axis_offset_ladder(pad_width, via_size, step,\n"
+     "                                  'near' if mode == 'out' else mode)",
+     "        axis = [0.0]\n"
+     "        for _k in range(1, 9):\n"
+     "            axis += [_k * step, -_k * step]",
      (TLAD,), 'KILLED'),
 
     # --- #652: the predicate ------------------------------------------------

--- a/tests/sweep_846_onpad_ladder.py
+++ b/tests/sweep_846_onpad_ladder.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""#846 A/B: how far may `--allow-via-in-pad`'s escape-axis ladder reach?
+
+The ladder was called `_onpad` and documented as "on-pad (via-in-pad) offsets
+along the escape axis, 0 == via centred on the pad". Its increment is
+``step = max(stagger, grid_step, 0.05)`` where ``stagger`` is the INTER-NET
+centre-to-centre a via needs from a DIFFERENT net's via at this pitch -- so on a
+fine-pitch part it exceeds the pad and only ``k = 0`` is guaranteed on it.
+
+The issue asks for a corpus A/B before the ladder changes, because those long
+offsets are load-bearing for escape counts. This is that A/B. Three arms, one
+process each (module knobs are read once at import, so in-process arms poison
+each other):
+
+    full     today's behaviour, k = 0..8 either side, no limit
+    pad      |k*step| <= pad_width/2          -- the via CENTRE stays on the pad
+    barrel   |k*step| <= pad_width/2 - via/2  -- the whole BARREL stays on it
+
+Grade paired and directional, per CLAUDE.md's A/B doctrine: escapes are the
+headline (`escaped` up, `failed` down), `drc_grazes.total` is the guard.
+
+    python3 tests/sweep_846_onpad_ladder.py [--out results.json]
+
+Not named test_* on purpose: it is an instrument, not a gate, and run_all.py
+should not spend its budget on it.
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(ROOT, 'tests'))
+
+# board, component, net filter, layer, track, clearance, via, drill
+CASES = [
+    ('tigard', 'U3', None, 'F.Cu', 0.1, 0.10, 0.45, 0.25),
+    ('qfn_underpad_coupling', 'U1', 'SIG*', 'F.Cu', 0.1, 0.12, 0.45, 0.20),
+    ('qfn_diffpair_escape', 'U1', 'DP1*', 'F.Cu', 0.1, 0.15, 0.45, 0.20),
+    ('qfn_interior_pads', 'U1', None, 'F.Cu', 0.1, 0.10, 0.45, 0.20),
+    # The board the issue measured on, and the one that discriminates HARDEST:
+    # not one of its selected offsets overlaps a pad, yet confining the ladder
+    # to the pad costs it 5 escapes. That is the finding -- the "on-pad" ladder
+    # earns its keep doing OFF-pad work.
+    ('routed_output', 'U2', 'Net-(U2A-*)', 'B.Cu', 0.1, 0.10, 0.45, 0.25),
+]
+ARMS = ('full', 'pad', 'barrel')
+
+
+def one(case, arm, workdir):
+    board, ref, nets, layer, tw, clr, vs, vd = case
+    src = os.path.join(ROOT, 'kicad_files', board + '.kicad_pcb')
+    if not os.path.exists(src):
+        return None
+    out = os.path.join(workdir, f'{board}_{arm}.kicad_pcb')
+    argv = [sys.executable, '-X', 'utf8',
+            os.path.join(ROOT, 'py_router', 'qfn_fanout.py'), src,
+            '--component', ref, '--output', out,
+            '--escape-method', 'underpad', '--allow-via-in-pad',
+            '--layer', layer, '--width', str(tw), '--clearance', str(clr),
+            '--via-size', str(vs), '--via-drill', str(vd),
+            '--grid-step', '0.05']
+    if nets:
+        argv += ['--nets', nets]
+    env = dict(os.environ)
+    env['KICAD_QFN_ONPAD_REACH'] = arm
+    env['PYTHONPATH'] = os.pathsep.join(
+        [ROOT, os.path.join(ROOT, 'py_router'), os.path.join(ROOT, 'py_tools')])
+    p = subprocess.run(argv, capture_output=True, text=True, env=env, cwd=ROOT)
+    row = None
+    for line in p.stdout.splitlines():
+        if line.startswith('JSON_SUMMARY: '):
+            row = json.loads(line[len('JSON_SUMMARY: '):])
+    if row is None:
+        return {'board': board, 'arm': arm, 'error': (p.stderr or
+                                                      p.stdout)[-400:]}
+    return {'board': board, 'arm': arm,
+            'escaped': row.get('escaped'), 'failed': row.get('failed'),
+            'via_in_pad': row.get('via_in_pad'),
+            'via_in_pad_offcentre': row.get('via_in_pad_offcentre'),
+            'max_stub_mm': row.get('max_stub_mm'),
+            'grazes': (row.get('drc_grazes') or {}).get('total')}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--out', default=None)
+    ap.add_argument('--workdir', default=None)
+    args = ap.parse_args()
+    workdir = args.workdir or os.path.join(ROOT, '.sweep846')
+    os.makedirs(workdir, exist_ok=True)
+
+    rows = []
+    for case in CASES:
+        for arm in ARMS:
+            r = one(case, arm, workdir)
+            if r is None:
+                print(f'  SKIP {case[0]} (board absent)')
+                continue
+            rows.append(r)
+            if 'error' in r:
+                print(f"  {r['board']:<22} {arm:<7} ERROR {r['error'][:120]}")
+            else:
+                print(f"  {r['board']:<22} {arm:<7} escaped={r['escaped']:<4}"
+                      f" failed={r['failed']:<4} via_in_pad={r['via_in_pad']}"
+                      f" offcentre={r['via_in_pad_offcentre']}"
+                      f" max_stub={r['max_stub_mm']} grazes={r['grazes']}")
+
+    print('\n=== paired, vs the `full` arm ===')
+    by = {}
+    for r in rows:
+        by.setdefault(r['board'], {})[r['arm']] = r
+    verdict = {}
+    for board, arms in sorted(by.items()):
+        base = arms.get('full')
+        if not base or 'error' in base:
+            continue
+        for arm in ('pad', 'barrel'):
+            cur = arms.get(arm)
+            if not cur or 'error' in cur:
+                continue
+            d_esc = (cur['escaped'] or 0) - (base['escaped'] or 0)
+            d_gra = (cur['grazes'] or 0) - (base['grazes'] or 0)
+            mark = 'same' if d_esc == 0 else ('BETTER' if d_esc > 0
+                                              else 'WORSE')
+            verdict.setdefault(arm, []).append(d_esc)
+            print(f'  {board:<22} {arm:<7} escaped {d_esc:+d}  grazes '
+                  f'{d_gra:+d}   {mark}')
+    print()
+    for arm, deltas in sorted(verdict.items()):
+        worse = sum(1 for d in deltas if d < 0)
+        better = sum(1 for d in deltas if d > 0)
+        print(f'  {arm}: {better} improved, {worse} regressed, '
+              f'{len(deltas) - better - worse} unchanged over {len(deltas)} '
+              f'boards -- '
+              + ('ADOPTABLE' if worse == 0 and better >= max(1, len(deltas) - 1)
+                 else 'NOT ADOPTABLE (the doctrine wants improve on >= N-1, '
+                      'regress on none)'))
+
+    if args.out:
+        with open(args.out, 'w') as f:
+            json.dump(rows, f, indent=1)
+        print('\nwrote', args.out)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_620_pending_via_pairs.py
+++ b/tests/test_620_pending_via_pairs.py
@@ -86,7 +86,7 @@ from kicad_parser import Pad, BoardInfo, parse_kicad_pcb        # noqa: E402
 from synth import make_pcb                                       # noqa: E402
 import fab_tiers                                                 # noqa: E402
 from fab_tiers import fab_floor_ladder, fab_floor_min            # noqa: E402
-from bga_fanout import manage_vias                               # noqa: E402
+from bga_fanout import manage_vias, ball_has_copper             # noqa: E402
 from bga_fanout.types import FanoutRoute                         # noqa: E402
 from bga_fanout.geometry import (PendingVias, thin_drill_to_clear,  # noqa: E402
                                  clamp_via_to_pad, via_anchors_route)
@@ -440,6 +440,52 @@ class TestTwinsShareOneHole(_TmpCase):
                 f'VR201 route at {r.pad_pos} is stranded: nearest via is '
                 f'{min(math.hypot(v["x"] - r.pad_pos[0], v["y"] - r.pad_pos[1]) for v in add):.4f}'
                 f'mm away, reach is {add[0]["size"] / 2 + 0.125:.4f}mm')
+
+    def test_the_DOWNSTREAM_ball_anchor_test_asks_reach_too(self):
+        """#854's second site, and the one that made the stranding silent.
+
+        `ball_has_copper` is what decides whether an unescaped extra ball gets
+        strapped to its net's fanout. Its VIA arm used to ask
+        `max(size_x, size_y) / 2 + 0.01` in BOTH axes -- the scalar-radius shape
+        PR #852's review had already removed from `PendingVias.verdict` -- and
+        the twin branch cites it by name as its justification: "the ball-anchor
+        test downstream looks for a via inside the pad, and this is that via".
+        So fixing `verdict` alone leaves a swallowed ball reading as ANCHORED
+        and never strapped: two graders agreeing in the wrong direction.
+
+        The numbers are the maintainer's own repro. A 1.0mm pad's old tolerance
+        is 0.51mm, so a via 0.4mm away -- with a 0.225mm ring, touching nothing
+        on the inner layer -- passed.
+
+        This arm exists because the mutation row for that revert SURVIVED while
+        the predicate was a closure: nothing could call it.
+
+        MUTATION: revert the via arm to the pad box -- this arm dies."""
+        pad = _ball(10.0, 10.0, 7, 1.0, 'BIG')
+        far = [{'net_id': 7, 'x': 10.4, 'y': 10.0, 'size': 0.45}]
+        self.assertFalse(
+            ball_has_copper(pad, far, [], 0.1),
+            'a via 0.4mm from this ball, ring 0.225mm, counts as its copper -- '
+            'the ball will never be strapped and ships unconnected')
+        near = [{'net_id': 7, 'x': 10.1, 'y': 10.0, 'size': 0.45}]
+        self.assertTrue(ball_has_copper(pad, near, [], 0.1),
+                        'a via that DOES reach the ball is not credited')
+        self.assertFalse(
+            ball_has_copper(pad, [dict(near[0], net_id=8)], [], 0.1),
+            'a FOREIGN-net via is credited as this ball\'s copper')
+        # The track arm keeps the pad-box tolerance on purpose: a track
+        # endpoint anywhere on the pad copper does connect it.
+        on_pad = [{'net_id': 7, 'layer': 'F.Cu', 'start': (10.4, 10.0),
+                   'end': (12.0, 10.0)}]
+        self.assertTrue(
+            ball_has_copper(pad, [], on_pad, 0.1),
+            'a track ENDPOINT on this ball pad is no longer credited -- the '
+            'via fix was applied to the wrong arm')
+        off_layer = [{'net_id': 7, 'layer': 'In1.Cu', 'start': (10.4, 10.0),
+                      'end': (12.0, 10.0)}]
+        self.assertFalse(
+            ball_has_copper(pad, [], off_layer, 0.1),
+            'copper crossing the pad on ANOTHER layer counts as a connection')
 
     def test_an_OBLONG_pad_does_not_swallow_its_NEIGHBOUR(self):
         """The regression an adversarial review found in the twin rule's first

--- a/tests/test_620_pending_via_pairs.py
+++ b/tests/test_620_pending_via_pairs.py
@@ -80,14 +80,16 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(
     os.path.abspath(__file__))), 'py_router'))
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from kicad_parser import Pad, BoardInfo                          # noqa: E402
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+from kicad_parser import Pad, BoardInfo, parse_kicad_pcb        # noqa: E402
 from synth import make_pcb                                       # noqa: E402
 import fab_tiers                                                 # noqa: E402
 from fab_tiers import fab_floor_ladder, fab_floor_min            # noqa: E402
 from bga_fanout import manage_vias                               # noqa: E402
 from bga_fanout.types import FanoutRoute                         # noqa: E402
 from bga_fanout.geometry import (PendingVias, thin_drill_to_clear,  # noqa: E402
-                                 clamp_via_to_pad)
+                                 clamp_via_to_pad, via_anchors_route)
 
 CU = ('F.Cu', 'In1.Cu', 'In2.Cu', 'B.Cu')
 H2H = fab_floor_min(len(CU))['hole_to_hole']          # 0.20, standard tier
@@ -263,35 +265,181 @@ class TestTwinsShareOneHole(_TmpCase):
         self.assertAlmostEqual(add[0]['y'], 10.0, places=6)
         self.assertEqual(add[0]['net_id'], 7)
 
-    def test_a_twin_FURTHER_OUT_than_either_floor_is_still_a_twin(self):
-        """The anchor term in the broad-phase window, which nothing else makes
-        binding.
+    def test_a_via_the_route_cannot_REACH_is_not_its_twin(self):
+        """#854. THIS ARM WAS REVERSED, deliberately, with a measurement.
 
-        `verdict`'s window is `max(drill term, ring term, anchor half-width)`.
-        On a BGA-sized pad the drill term (0.40mm at the standard floor)
-        exceeds the anchor half-width, so dropping it from the max changes
-        nothing and the mutation survives -- the battery caught exactly that.
-        A BIG pad inverts it: a 2.0mm pad has a 1.01mm half-width against a
-        0.40mm drill window, so a twin 0.9mm away is inside the pad and
-        OUTSIDE the window. Without the anchor term it is never even scanned,
-        so the second route gets its own via 0.9mm from the first -- two holes
-        in one pad.
+        It used to read `test_a_twin_FURTHER_OUT_than_either_floor_is_still_a
+        _twin` and assert that two routes 0.9mm apart inside one 2.0mm pad get
+        ONE via -- keyed on the candidate's pad rectangle. That is the defect
+        #854 reports: the surviving via has a 0.225mm radius, so it is 0.9mm
+        from the second route's track start and touches nothing. The pad does
+        not carry the connection -- the ball pad is on the top layer and the
+        route's track is on an inner one, so the pad reaches its own track only
+        THROUGH the via. One via there ships an inner-layer track connected to
+        nothing, while the route still counts as escaped.
 
-        MUTATION: drop `ahx` from the `window = max(...)` -- this arm dies."""
+        Measured on a tracked board before the change (kit-dev-coldfire-
+        xilinx_5213, VR201, a TO-263-5 whose pad 3 is a 10.8 x 9.4mm SMD tab
+        plus four 5.25 x 4.55mm paste sub-pads, all net GND): routing the
+        sub-pad first made the TAB adopt its via, 3.6853mm from the tab route's
+        track start against a 0.35mm reach, and the run printed
+        `#620: 1 coincident same-net site(s) share one via` for a pair 3.69mm
+        apart. Tab-first emitted two vias. After the change both orders emit
+        two and neither route is stranded.
+
+        Every case #620 needs still merges: those are at distance 0 (an exposed
+        pad modelled as an F.Cu + B.Cu pair -- interf_u BUS1 has 31 such sites
+        on one component), which is inside any reach.
+
+        MUTATION: widen the twin test back to a pad-box containment -- this
+        arm dies."""
         p = PendingVias(H2H, 0.1)
         p.add(10.0, 10.0, 0.45, 0.2, 7)
-        self.assertGreater(1.01, 0.2 / 2 + 0.2 / 2 + H2H,
-                           'the rig no longer makes the ANCHOR term the '
-                           'binding one, so it cannot detect its loss')
         self.assertEqual(p.verdict(10.9, 10.0, 0.45, 0.2, 7,
-                                   anchor_box=(1.01, 1.01))[0], 'twin',
-                         'a same-net via well inside this ball pad is no '
-                         'longer recognised as its anchor')
-        # ... and end to end, where it becomes a second hole in one pad.
+                                   track_width=0.1)[0], 'clear',
+                         'a via 0.9mm from this route track start, with a '
+                         '0.225mm ring, was called its anchor')
+        # ... and end to end, where the second route now gets the via it needs.
         add, blocked, _t = _two_balls(0.9, 2.0, same_net=True)
-        self.assertEqual((len(add), len(blocked)), (1, 0),
-                         'two routes 0.9mm apart inside one 2.0mm pad got '
-                         'two vias')
+        self.assertEqual((len(add), len(blocked)), (2, 0),
+                         'two routes 0.9mm apart in one 2.0mm pad shared a '
+                         'via that reaches neither')
+        for r in add:
+            self.assertTrue(
+                any(via_anchors_route(r['x'], r['y'], r['size'], pos, 0.1)
+                    for pos in ((10.0, 10.0), (10.9, 10.0))),
+                'an emitted via anchors no route')
+
+    def test_the_REACH_term_in_the_broad_phase_window(self):
+        """`verdict`'s window is `max(drill term, ring term, reach term)`, and
+        the reach term (widest committed via + half a track) is the one nothing
+        else makes binding.
+
+        A wide track inverts the usual order: with via 0.25 / clearance 0.05 /
+        h2h 0.2 the drill term is 0.35 and the ring term 0.30, while a 0.5mm
+        track puts reach at 0.375. A twin 0.36mm away is inside reach and
+        OUTSIDE the other two windows, so without the reach term it is never
+        scanned and the second route gets a second hole it does not need.
+
+        MUTATION: drop the reach term from `window = max(...)` -- this arm
+        dies."""
+        p = PendingVias(0.2, 0.05)
+        p.add(10.0, 10.0, 0.25, 0.15, 7)
+        drill_term = 0.15 / 2 + 0.15 / 2 + 0.2
+        ring_term = 0.25 / 2 + 0.25 / 2 + 0.05
+        reach_term = 0.25 / 2 + 0.5 / 2
+        self.assertGreater(reach_term, max(drill_term, ring_term),
+                           'the rig no longer makes the REACH term the '
+                           'binding one, so it cannot detect its loss')
+        self.assertEqual(p.verdict(10.36, 10.0, 0.25, 0.15, 7,
+                                   track_width=0.5)[0], 'twin',
+                         'a same-net via this route reaches was outside the '
+                         'broad-phase window, so it was never scanned')
+
+    def test_a_LARGE_pad_does_not_swallow_a_SMALLER_overlapping_one(self):
+        """#854's own case, and the third in this family.
+
+        A scalar radius merged DISTINCT oblong pads (fixed in PR #852). A
+        per-axis rectangle closed the equal-size case -- two same-net pads of
+        the same size can only be twins if they overlap by more than half --
+        and left this one: a BIG pad's box reaches a SMALL pad that only just
+        overlaps it, so the big pad adopts the small one's via and ships an
+        inner-layer track starting where no via reaches.
+
+        The maintainer's probe, reproduced: a 1.0 x 1.0mm pad at (10.0, 10.0)
+        and a 0.25 x 0.25mm pad at (10.4, 10.0), same net, both routed on B.Cu,
+        via 0.45 / drill 0.2 / clearance 0.1 on an empty board. Small-first
+        used to emit ONE via and strand the big route; big-first emitted two.
+        Order-dependence was the tell.
+
+        MUTATION: key the twin test on the candidate's pad box again -- this
+        arm dies."""
+        for label, first_big in (('small-first', False), ('big-first', True)):
+            big = _ball(10.0, 10.0, 7, 1.0, 'BIG')
+            small = _ball(10.4, 10.0, 7, 0.25, 'SML')
+            r_big = FanoutRoute(pad=big, pad_pos=(10.0, 10.0),
+                                stub_end=(10.0, 10.9), exit_pos=(10.0, 11.4),
+                                layer='B.Cu')
+            r_small = FanoutRoute(pad=small, pad_pos=(10.4, 10.0),
+                                  stub_end=(10.4, 9.1), exit_pos=(10.4, 8.6),
+                                  layer='B.Cu')
+            order = [r_big, r_small] if first_big else [r_small, r_big]
+            pcb = make_pcb(
+                board_info=BoardInfo(layers={}, copper_layers=list(CU),
+                                     board_bounds=(0.0, 0.0, 20.0, 20.0)),
+                vias=[], segments=[], pads_by_net={7: [big, small]},
+                source_path='', zones=[])
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                add, _rm, blocked = manage_vias(order, pcb, 'F.Cu', 0.45, 0.2,
+                                                0.1, track_width=0.1)
+            for r in order:
+                self.assertTrue(
+                    any(via_anchors_route(v['x'], v['y'], v['size'],
+                                          r.pad_pos, 0.1) for v in add),
+                    f'{label}: route at {r.pad_pos} ships an inner-layer '
+                    f'track with no via reaching its start, and still counts '
+                    f'as escaped -- vias at '
+                    f'{[(v["x"], v["y"], v["size"]) for v in add]}')
+            self.assertEqual(len(blocked), 0, f'{label}: a route was dropped')
+
+    def test_a_REAL_board_reaches_the_swallow(self):
+        """The issue says no board in kicad_files/ reaches this. It is wrong,
+        and the counter-example is worth keeping: a bound that drops its own
+        counterexample proves nothing.
+
+        kit-dev-coldfire-xilinx_5213 VR201 is a TO-263-5 whose pad 3 is a
+        10.8 x 9.4mm SMD tab PLUS four 5.25 x 4.55mm SMD paste sub-pads, all
+        net GND -- ordinary KiCad geometry, not a constructed case. The tab's
+        old anchor box was (5.41, 4.71) and the nearest sub-pad sits at
+        dx 2.775 / dy 2.425, inside it on both axes, so sub-pad-first made the
+        tab adopt a via 3.6853mm from its own track start.
+
+        Caveat kept honestly: VR201 has exactly 6 GND pads, so an UNFILTERED
+        run excludes it at `fanout_candidate_nets`' plane_min_pads (default 6);
+        a --nets filter admits it. The geometry is real either way, which is
+        what this arm tests.
+
+        MUTATION: key the twin test on the candidate's pad box again."""
+        board = os.path.join(ROOT, 'kicad_files',
+                             'kit-dev-coldfire-xilinx_5213.kicad_pcb')
+        if not os.path.exists(board):
+            self.skipTest('corpus board not present')
+        pcb = parse_kicad_pcb(board)
+        fp = pcb.footprints['VR201']
+        smd = [p for p in fp.pads
+               if not (p.drill or 0) and p.net_id
+               and any(l.endswith('.Cu') for l in (p.layers or []))]
+        tab = max(smd, key=lambda p: p.size_x * p.size_y)
+        sub = min((p for p in smd if p is not tab),
+                  key=lambda p: math.hypot(p.global_x - tab.global_x,
+                                           p.global_y - tab.global_y))
+        self.assertLessEqual(abs(sub.global_x - tab.global_x),
+                             tab.size_x / 2 + 0.01)
+        self.assertLessEqual(abs(sub.global_y - tab.global_y),
+                             tab.size_y / 2 + 0.01)
+        sep = math.hypot(sub.global_x - tab.global_x,
+                         sub.global_y - tab.global_y)
+        self.assertGreater(sep, 3.0,
+                           'the rig no longer has a FAR pair inside the box, '
+                           'so it cannot detect the swallow')
+        routes = []
+        for pad, dy in ((sub, 1.0), (tab, -1.0)):     # sub FIRST: the order
+            routes.append(FanoutRoute(                # that used to strand
+                pad=pad, pad_pos=(pad.global_x, pad.global_y),
+                stub_end=(pad.global_x, pad.global_y + dy),
+                exit_pos=(pad.global_x, pad.global_y + 2 * dy), layer='B.Cu'))
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            add, _rm, blocked = manage_vias(routes, pcb, 'F.Cu', 0.45, 0.2,
+                                            0.1, track_width=0.25)
+        for r in routes:
+            self.assertTrue(
+                any(via_anchors_route(v['x'], v['y'], v['size'], r.pad_pos,
+                                      0.25) for v in add),
+                f'VR201 route at {r.pad_pos} is stranded: nearest via is '
+                f'{min(math.hypot(v["x"] - r.pad_pos[0], v["y"] - r.pad_pos[1]) for v in add):.4f}'
+                f'mm away, reach is {add[0]["size"] / 2 + 0.125:.4f}mm')
 
     def test_an_OBLONG_pad_does_not_swallow_its_NEIGHBOUR(self):
         """The regression an adversarial review found in the twin rule's first
@@ -858,13 +1006,19 @@ class TestPendingViasItself(unittest.TestCase):
         self.assertNotIn('np.', code)
 
 
-def _brute(rows, cand, h2h, clearance, tol=1e-6, site_tol=0.001):
-    """The window-free spec `PendingVias.verdict` must match."""
+def _brute(rows, cand, h2h, clearance, tol=1e-6, site_tol=0.001,
+           track_width=0.0):
+    """The window-free spec `PendingVias.verdict` must match.
+
+    The twin arm CALLS `via_anchors_route` rather than restating it: what this
+    spec exists to test is the broad-phase WINDOW, and a hand-copied reach
+    formula here would just be a second place for the two to drift apart.
+    """
     x, y, s, d, net, bulges = cand
     best = None
     for (ox, oy, os_, od, onet, obulges) in rows:
         dist = math.hypot(ox - x, oy - y)
-        if onet == net and dist <= site_tol:
+        if onet == net and via_anchors_route(ox, oy, os_, (x, y), track_width):
             return 'twin'
         if dist <= site_tol:
             return 'conflict'

--- a/tests/test_620_pending_via_pairs.py
+++ b/tests/test_620_pending_via_pairs.py
@@ -310,6 +310,58 @@ class TestTwinsShareOneHole(_TmpCase):
                     for pos in ((10.0, 10.0), (10.9, 10.0))),
                 'an emitted via anchors no route')
 
+    def test_TIGHTENING_the_survivor_must_not_break_the_reach(self):
+        """The interaction #854 created, found by review before any board hit.
+
+        `verdict` decides 'twin' from the COMMITTED via's size, and the branch
+        then calls `tighten` to replace it with the tighter pad's clamp (#202,
+        so the shared via cannot bulge past the smaller pad). A smaller barrel
+        reaches less far -- so a merge can be justified by a via that, once
+        tightened, no longer touches the second route's track start. That is
+        the very stranding #854 is about, recreated by the fix for it. It could
+        not happen under the old pad-BOX rule, which does not depend on via
+        size at all, so the hazard is new with this change.
+
+        The numbers: a 0.60 via committed at (0, 0), a second route 0.30mm away
+        with a 0.30mm track. Reach is 0.30 + 0.15 = 0.45 >= 0.30, so it is a
+        twin. Tighten to that route's 0.25 clamp and reach becomes
+        0.125 + 0.15 = 0.275 < 0.30 -- it no longer reaches.
+
+        MUTATION: drop the post-tighten re-check in the twin branch."""
+        p = PendingVias(0.20, 0.25)
+        p.add(0.0, 0.0, 0.60, 0.30, 7)
+        self.assertEqual(
+            p.verdict(0.30, 0.0, 0.25, 0.15, 7, track_width=0.30)[0], 'twin',
+            'the rig no longer produces a twin here, so it cannot detect the '
+            'shrink breaking one')
+        self.assertFalse(
+            via_anchors_route(0.0, 0.0, min(0.60, 0.25), (0.30, 0.0), 0.30),
+            'the rig no longer SHRINKS out of reach, so it tests nothing')
+        big = _ball(0.0, 0.0, 7, 1.40, 'BIG')
+        small = _ball(0.30, 0.0, 7, 0.25, 'SML')
+        r_big = FanoutRoute(pad=big, pad_pos=(0.0, 0.0), stub_end=(0.0, 1.0),
+                            exit_pos=(0.0, 1.5), layer='B.Cu')
+        r_small = FanoutRoute(pad=small, pad_pos=(0.30, 0.0),
+                              stub_end=(0.30, -1.0), exit_pos=(0.30, -1.5),
+                              layer='B.Cu')
+        pcb = make_pcb(board_info=BoardInfo(layers={}, copper_layers=list(CU),
+                                            board_bounds=(-5.0, -5.0,
+                                                          5.0, 5.0)),
+                       vias=[], segments=[], pads_by_net={7: [big, small]},
+                       source_path='', zones=[])
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            add, _rm, _blocked = manage_vias([r_big, r_small], pcb, 'F.Cu',
+                                             0.60, 0.30, 0.25,
+                                             track_width=0.30)
+        for r in (r_big, r_small):
+            self.assertTrue(
+                any(via_anchors_route(v['x'], v['y'], v['size'], r.pad_pos,
+                                      0.30) for v in add),
+                f'route at {r.pad_pos} has no via reaching its track start '
+                f'after the merge tightened the shared one: '
+                f'{[(v["x"], v["y"], v["size"]) for v in add]}')
+
     def test_the_REACH_term_in_the_broad_phase_window(self):
         """`verdict`'s window is `max(drill term, ring term, reach term)`, and
         the reach term (widest committed via + half a track) is the one nothing

--- a/tests/test_652_fanout_dropped_ball_hint.py
+++ b/tests/test_652_fanout_dropped_ball_hint.py
@@ -224,6 +224,68 @@ def main():
           f'results_data={rd.get("fanout_dropped")} -- an empty match on both '
           f'sides is a vacuous pass, so a non-empty list is required')
 
+    # 10. EVERY WIRED SITE MUST RESOLVE ITS NAMES. The hint blocks sit inside
+    #     `try/except Exception: pass` -- the pattern the #103 hints use so a
+    #     diagnosis can never break a routing path -- which also means a
+    #     NameError there is SILENT: the hint simply never fires and nothing
+    #     says so. That is not hypothetical; the diff_pair_loop site was
+    #     written with a bare `record_net_event` that is not imported in that
+    #     module, and only this check caught it.
+    import ast
+    sites = {
+        'py_router/single_ended_loop.py': ['pcb_data', 'config', 'net_id',
+                                           'net_name', 'state',
+                                           'condense_hint',
+                                           'record_net_event'],
+        'py_router/reroute_loop.py': ['pcb_data', 'config', 'ripped_net_id',
+                                      'ripped_net_name', 'state',
+                                      'condense_hint', 'record_net_event'],
+        'py_router/phase3_routing.py': ['pcb_data', 'config', 'victim_id',
+                                        'victim_name', 'state',
+                                        'record_net_event'],
+        'py_router/diff_pair_loop.py': ['pcb_data', 'config', 'pair', 'state'],
+    }
+    unresolved, wired = [], 0
+    for rel, names in sites.items():
+        src = io.open(os.path.join(ROOT, rel), encoding='utf-8').read()
+        tree = ast.parse(src)
+        hits = [i for i, ln in enumerate(src.splitlines(), 1)
+                if '_h652, _v652 = fanout_dropped_ball_hint(' in ln]
+        if not hits:
+            unresolved.append(f'{rel}: NOT WIRED')
+            continue
+        wired += 1
+        mod = set()
+        for n in ast.walk(tree):
+            if isinstance(n, (ast.Import, ast.ImportFrom)):
+                for a in n.names:
+                    mod.add((a.asname or a.name).split('.')[0])
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef,
+                              ast.ClassDef)):
+                mod.add(n.name)
+        for line in hits:
+            fn = None
+            for n in ast.walk(tree):
+                if (isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+                        and n.lineno <= line <= (n.end_lineno or 0)):
+                    if fn is None or n.lineno > fn.lineno:
+                        fn = n
+            bound = set(mod)
+            for n in ast.walk(fn):
+                if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Store):
+                    bound.add(n.id)
+                if isinstance(n, ast.arg):
+                    bound.add(n.arg)
+                if isinstance(n, (ast.Import, ast.ImportFrom)):
+                    for a in n.names:
+                        bound.add((a.asname or a.name).split('.')[0])
+            unresolved += [f'{rel}:{line} {fn.name}: {x}'
+                           for x in names if x not in bound]
+    check('all FOUR sites that print `no rippable blockers found` are wired, '
+          'and every name they use resolves',
+          wired == 4 and not unresolved,
+          f'wired={wired}/4; unresolved={unresolved}')
+
     bad = [n for n, ok in CHECKS if not ok]
     print(f"\n{'FAIL' if bad else 'PASS'}  #652 fanout-dropped diagnosis: "
           f"{len(CHECKS) - len(bad)}/{len(CHECKS)} checks")

--- a/tests/test_652_fanout_dropped_ball_hint.py
+++ b/tests/test_652_fanout_dropped_ball_hint.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Issue #652: a fanout-dropped ball is diagnosed as one, not as 'no rippable
+blockers found'.
+
+A ball the fanout drops is removed from the output, and every later routing step
+fails its net with `no rippable blockers found` -- which is TRUE and useless. It
+invites retries that can never work (rip authority, force-reroute, smaller vias)
+because the ball has no escape stub for any of them to act on. Measured on
+orangecrab: EXT_PLL+ and LED_R shipped unrouted in ~15 route-step variants across
+an entire campaign, including `--rip-existing-nets '*'` and `--force-reroute`,
+before the cause was traced back to the fanout log.
+
+The maintainer's closing note (2026-08-18) scopes what is left: the rescue ladder
+shipped, "the DIAGNOSIS this issue asks for still does not exist ... Keeping open
+for the attribution."
+
+WHY IT IS RE-DERIVED FROM GEOMETRY. The fanout's `unescaped_nets` has ZERO
+consuming code -- only tests asserting the key exists and skill-doc prose. The
+step persists DRC settings and one float; `protected_nets.PRO_NAMESPACE` holds
+three keys, none of them a fanout ledger. So a later `route.py` PROCESS cannot be
+told, only shown. #472 settled the same point for the bare-ball zone exemption:
+"board-state-driven, so no sidecar file is load-bearing".
+
+WHY NOT `auto_detect_bga_exclusion_zones`. It walks
+`find_components_by_type(pcb_data, 'BGA')` only. Measured on this repo's boards:
+routed_output gets 3 zones (IC1, U3, U1) and NONE for its QFN-76 U2 -- the part
+that drops balls -- and tigard gets ZERO zones. A zone-keyed diagnosis would be
+silent on exactly the parts this is for. `entombed_bare_pads` uses the
+footprint's own pad bounding box instead, so it works for any package.
+
+MEASURED on tracked boards (every net, no failure filter -- the hint additionally
+requires the net to have already failed):
+
+    tigard                 85 nets   ->  2 entombed-bare pads  (U3)
+    routed_output         526 nets   -> 185                    (IC1, U1, U2, U3)
+    glasgow_revC          251 nets   ->  51                    (U1, U30)
+    qfn_underpad_coupling   9 nets   ->   0
+
+Of routed_output's 185, 137 are nets with NO copper anywhere on the board and 48
+have copper elsewhere but NONE within 0.5 mm of the pad -- zero near-misses at
+the 0.05 mm reach, which is the number that would say the tolerance is wrong.
+
+A DISCLOSED LIMIT: on a board whose pours have not been created yet, a
+plane-destined net (GND) with an entombed pad matches, because there is no zone
+to consult and no copper attached. Once the pour exists `pcb_data.zones` answers
+and the hint goes quiet -- `test_a_pad_served_by_a_POUR_is_not_bare` pins that.
+The hint only fires for a net that has ALREADY failed to route, where saying "this
+pad has no escape" is fair either way.
+
+Run: python3 tests/test_652_fanout_dropped_ball_hint.py
+"""
+import io
+import contextlib
+import json
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))
+sys.path.insert(0, os.path.join(ROOT, 'py_tools'))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from kicad_parser import BoardInfo, Footprint, Zone       # noqa: E402
+from synth import make_pad, make_pcb, make_net, make_seg, make_via  # noqa: E402
+from routing_common import entombed_bare_pads             # noqa: E402
+from routing_diagnostics import fanout_dropped_ball_hint  # noqa: E402
+
+X, WALL = 7, 9
+CHECKS = []
+
+
+def check(name, ok, detail=''):
+    CHECKS.append((name, bool(ok)))
+    print(('  PASS: ' if ok else '  FAIL: ') + name
+          + (' -- ' + detail if detail else ''))
+
+
+def _package(net_of_centre=X, *, attach=None, zone=False, drill=0.0,
+             centre_net_pads=2, pitch=0.5, n=7, neighbour_drill=0.0):
+    """An n x n fine-pitch package whose CENTRE ball is on `net_of_centre`.
+
+    n = 7 at 0.5 mm pitch puts the centre ball two full rings inside the field,
+    which is what `entombed_bare_pads` means by entombed. `attach` optionally
+    drops a segment endpoint on that ball, `zone` optionally floods it.
+    """
+    pads, by_net = [], {}
+    nid = 1000
+    for i in range(n):
+        for j in range(n):
+            centre = (i == n // 2 and j == n // 2)
+            net = net_of_centre if centre else (nid := nid + 1)
+            p = make_pad(net, 5.0 + (i - n // 2) * pitch,
+                         5.0 + (j - n // 2) * pitch, ref='U1',
+                         num=f'{i}{j}', net_name='X' if centre else f'n{net}',
+                         size_x=0.25, size_y=0.25)
+            p.drill = drill if centre else neighbour_drill
+            if not centre and neighbour_drill:
+                # Through-hole neighbours block EVERY layer, so the caged ball
+                # cannot escape by dropping a via either -- which is what makes
+                # the failure "nothing rippable" rather than "try another
+                # layer". It is also the real shape of an entombed ball.
+                p.pad_type = 'thru_hole'
+                p.layers = ['*.Cu']
+            pads.append(p)
+            by_net.setdefault(net, []).append(p)
+    # X needs a second pad so it is a routable net at all (#472: a single-pad
+    # net's ball is trivially bare and disabled two zones spuriously).
+    for k in range(centre_net_pads - 1):
+        far = make_pad(net_of_centre, 12.0 + k, 5.0, ref='U2', num=f'{k}',
+                       net_name='X', size_x=0.3, size_y=0.3)
+        pads.append(far)
+        by_net.setdefault(net_of_centre, []).append(far)
+    fp = Footprint(reference='U1', footprint_name='test:QFN', x=5.0, y=5.0,
+                   rotation=0.0, layer='F.Cu', pads=pads)
+    segs = list(attach or [])
+    zones = []
+    if zone:
+        zones.append(Zone(net_id=net_of_centre, net_name='X', layer='F.Cu',
+                          polygon=[(0.0, 0.0), (14.0, 0.0), (14.0, 10.0),
+                                   (0.0, 10.0)]))
+    bi = BoardInfo(layers={0: 'F.Cu', 31: 'B.Cu'},
+                   copper_layers=['F.Cu', 'B.Cu'],
+                   board_bounds=(0.0, 0.0, 14.0, 10.0))
+    return make_pcb(nets={net_of_centre: make_net(net_of_centre, 'X')},
+                    footprints={'U1': fp}, segments=segs,
+                    pads_by_net=by_net, board_info=bi, zones=zones)
+
+
+def main():
+    # 1. THE CASE. A bare ball two rings inside a fine-pitch field.
+    pcb = _package()
+    bare = entombed_bare_pads(pcb, [X])
+    check('an entombed bare ball is found', len(bare) == 1,
+          f'{[(p.pad_number, r) for p, r in bare]}')
+    hint, verdict = fanout_dropped_ball_hint(pcb, None, X, 'X',
+                                             return_verdict=True)
+    check('the hint names the pad and the remedy',
+          'fanout-dropped ball' in hint and 'U1.33' in hint
+          and 'escape-method underpad' in hint, hint[:90])
+    check('the verdict is structured, not prose',
+          (verdict or {}).get('verdict') == 'fanout_dropped'
+          and verdict.get('pad') == 'U1.33', str(verdict))
+
+    # --- the controls it must stay silent on -----------------------------
+    # 2. copper AT the ball (the #666 rescue healed it, or the fanout escaped).
+    healed = _package(attach=[make_seg(5.0, 5.0, 5.0, 8.0, net_id=X,
+                                       width=0.1, layer='F.Cu')])
+    check('a ball with an escape stub is NOT a fanout drop',
+          not entombed_bare_pads(healed, [X])
+          and fanout_dropped_ball_hint(healed, None, X, 'X') == '')
+
+    # 3. a via on the ball (the ordinary under-pad escape).
+    vias = _package()
+    vias.vias.append(make_via(5.0, 5.0, net_id=X, size=0.25, drill=0.15))
+    check('a ball with an escape VIA is NOT a fanout drop',
+          not entombed_bare_pads(vias, [X]))
+
+    # 4. served by a POUR. The #472 closure this generalises never consulted
+    #    zones, and its entombment filter selects exactly the interior region
+    #    where plane-served balls live -- so this was a live false positive.
+    poured = _package(zone=True)
+    check('a pad served by a POUR is not bare',
+          not entombed_bare_pads(poured, [X]),
+          'zones were not consulted')
+
+    # 5. a single-pad net. Trivially bare; counting it disabled U6/U7's zones
+    #    spuriously on ottercast (#472).
+    lone = _package(centre_net_pads=1)
+    check('a single-pad net is not reported', not entombed_bare_pads(lone, [X]))
+
+    # 6. a THROUGH-HOLE ball. Its barrel already reaches every layer.
+    th = _package(drill=0.3)
+    check('a drilled pad is not reported', not entombed_bare_pads(th, [X]))
+
+    # 7. an OUTER-RING ball. Reachable through the edge band; only entombed
+    #    balls are unreachable by construction.
+    outer = _package()
+    edge = [p for p in outer.footprints['U1'].pads
+            if p.net_id != X and abs(p.global_x - 3.5) < 1e-9][0]
+    check('an outer-ring bare ball is not reported',
+          not any(p is edge for p, _r in entombed_bare_pads(
+              outer, [edge.net_id, X])),
+          'the edge band exemption is gone')
+
+    # 8. a board with no package at all.
+    tiny = make_pcb(nets={X: make_net(X, 'X')},
+                    board_info=BoardInfo(layers={}, copper_layers=['F.Cu'],
+                                         board_bounds=(0, 0, 10, 10)),
+                    pads_by_net={X: [make_pad(X, 1.0, 1.0, ref='R1', num='1'),
+                                     make_pad(X, 2.0, 1.0, ref='R1', num='2')]})
+    check('a board with no pad field reports nothing',
+          not entombed_bare_pads(tiny, [X]))
+
+    # 9. END TO END: the key reaches JSON_SUMMARY and the GUI mirror.
+    from route import batch_route
+    caged = _package(neighbour_drill=0.3)
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        _ok, _fail, _t, results_data = batch_route(
+            'synthetic', '', ['X'], layers=['F.Cu', 'B.Cu'], clearance=0.2,
+            track_width=0.2, via_size=0.5, via_drill=0.3, grid_step=0.1,
+            ordering_strategy='original', final_reconcile=False,
+            max_rip_up_count=0, return_results=True, pcb_data=caged)
+    out = buf.getvalue()
+    summaries = re.findall(r'JSON_SUMMARY: (\{.*\})', out)
+    summary = json.loads(summaries[-1]) if summaries else {}
+    fd = summary.get('fanout_dropped') or []
+    check("summary['fanout_dropped'] names the net",
+          any(r.get('net') == 'X' and r.get('pad') == 'U1.33' for r in fd),
+          f'fanout_dropped={fd}; failed_single={summary.get("failed_single")}')
+    check('the hint is printed for a human too',
+          'fanout-dropped ball' in out,
+          'the diagnosis is data-only, so the console still says only '
+          '"no rippable blockers"')
+    # The invariant test_boxed_in_summary states for its own key: the GUI reads
+    # results_data, not the JSON line, so a key that lands in one and not the
+    # other is invisible on one of the two fronts.
+    rd = results_data if isinstance(results_data, dict) else {}
+    check('results_data mirrors it for the GUI',
+          bool(rd.get('fanout_dropped'))
+          and rd.get('fanout_dropped') == summary.get('fanout_dropped'),
+          f'results_data={rd.get("fanout_dropped")} -- an empty match on both '
+          f'sides is a vacuous pass, so a non-empty list is required')
+
+    bad = [n for n, ok in CHECKS if not ok]
+    print(f"\n{'FAIL' if bad else 'PASS'}  #652 fanout-dropped diagnosis: "
+          f"{len(CHECKS) - len(bad)}/{len(CHECKS)} checks")
+    return 1 if bad else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_652_fanout_dropped_ball_hint.py
+++ b/tests/test_652_fanout_dropped_ball_hint.py
@@ -106,14 +106,23 @@ def _package(net_of_centre=X, *, attach=None, zone=False, drill=0.0,
             pads.append(p)
             by_net.setdefault(net, []).append(p)
     # X needs a second pad so it is a routable net at all (#472: a single-pad
-    # net's ball is trivially bare and disabled two zones spuriously).
+    # net's ball is trivially bare and disabled two zones spuriously). It goes
+    # in a SEPARATE footprint -- an earlier draft appended it to U1's own pad
+    # list, which stretched U1's bounding box from 3.5-6.5 to 3.5-12.0 and made
+    # the far pad read as a second entombed ball. That defect was load-bearing
+    # in the wrong direction: it is what killed the outer-ring mutation row,
+    # so with the fixture correct that row would have started SURVIVING
+    # silently. Found by a pre-push review.
+    far_pads = []
     for k in range(centre_net_pads - 1):
         far = make_pad(net_of_centre, 12.0 + k, 5.0, ref='U2', num=f'{k}',
                        net_name='X', size_x=0.3, size_y=0.3)
-        pads.append(far)
+        far_pads.append(far)
         by_net.setdefault(net_of_centre, []).append(far)
     fp = Footprint(reference='U1', footprint_name='test:QFN', x=5.0, y=5.0,
                    rotation=0.0, layer='F.Cu', pads=pads)
+    fp2 = Footprint(reference='U2', footprint_name='test:R', x=12.0, y=5.0,
+                    rotation=0.0, layer='F.Cu', pads=far_pads)
     segs = list(attach or [])
     zones = []
     if zone:
@@ -124,7 +133,7 @@ def _package(net_of_centre=X, *, attach=None, zone=False, drill=0.0,
                    copper_layers=['F.Cu', 'B.Cu'],
                    board_bounds=(0.0, 0.0, 14.0, 10.0))
     return make_pcb(nets={net_of_centre: make_net(net_of_centre, 'X')},
-                    footprints={'U1': fp}, segments=segs,
+                    footprints={'U1': fp, 'U2': fp2}, segments=segs,
                     pads_by_net=by_net, board_info=bi, zones=zones)
 
 
@@ -176,13 +185,29 @@ def main():
 
     # 7. an OUTER-RING ball. Reachable through the edge band; only entombed
     #    balls are unreachable by construction.
+    #
+    #    The edge pad needs a SECOND pad on its net, or `min_net_pads` filters
+    #    it before the band test is ever evaluated and this check passes for a
+    #    reason that has nothing to do with the band. It did exactly that in an
+    #    earlier draft -- deleting the band exemption left it green -- so the
+    #    rig now proves the band is what does the work: the same pad IS
+    #    reported once the band is removed.
     outer = _package()
     edge = [p for p in outer.footprints['U1'].pads
             if p.net_id != X and abs(p.global_x - 3.5) < 1e-9][0]
+    mate = make_pad(edge.net_id, 12.0, 8.0, ref='U2', num='m',
+                    net_name=edge.net_name, size_x=0.3, size_y=0.3)
+    outer.pads_by_net.setdefault(edge.net_id, []).append(mate)
+    outer.footprints['U2'].pads.append(mate)
+    reported = [p for p, _r in entombed_bare_pads(outer, [edge.net_id, X])]
     check('an outer-ring bare ball is not reported',
-          not any(p is edge for p, _r in entombed_bare_pads(
-              outer, [edge.net_id, X])),
-          'the edge band exemption is gone')
+          not any(p is edge for p in reported),
+          f'reported {[p.pad_number for p in reported]}')
+    check('...and it is the BAND that exempts it, not the pad-count filter',
+          any(p is edge for p, _r in entombed_bare_pads(
+              outer, [edge.net_id, X], inset=-999.0)),
+          'removing the band exemption does not report the edge pad, so '
+          'check 7 passes for some other reason and tests nothing')
 
     # 8. a board with no package at all.
     tiny = make_pcb(nets={X: make_net(X, 'X')},

--- a/tests/test_846_onpad_ladder_reach.py
+++ b/tests/test_846_onpad_ladder_reach.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Issue #846: KICAD_QFN_ONPAD_REACH, and the measurement that kept `full`.
+
+`--allow-via-in-pad` enables a ladder of signed offsets along the escape axis.
+It was called `_onpad` and documented as "on-pad (via-in-pad) offsets ...
+0 == via centred on the pad", but its increment is the INTER-NET stagger -- the
+centre-to-centre a via needs from a DIFFERENT net's via at this pitch -- which
+on a fine-pitch part exceeds the pad. On routed_output's QFN-76 (pitch 0.40,
+via 0.45, clearance 0.1) that is 0.4275 mm against a pad whose escape-axis
+extent is 0.875 mm -- so rung 1 lands 0.0100 mm inside the pad EDGE, rung 2 is
+already 0.8550 mm out (most of a pad-length past the far edge), and rung 8
+reaches +-3.4199 mm. Measured: `pad` keeps 3 of the 17 rungs here, `barrel`
+keeps 1.
+
+The issue poses a fork -- the ladder is right and the NAME is wrong, or the name
+is right and the LADDER is wrong -- and asks for a corpus A/B before anything
+changes, because those long offsets are load-bearing for escape counts.
+
+THE A/B, AS RUN (tests/sweep_846_onpad_ladder.py, upstream/main e239e067 plus
+this branch's classification fix; one process per arm, --escape-method underpad
+--allow-via-in-pad, grid 0.05):
+
+    board / component      arm      escaped  failed  via_in_pad  max_stub
+    tigard U3              full          32       0          48    0.3000
+                           pad           32       0          48    0.3000
+                           barrel        32       0          28    0.7500
+    qfn_underpad_coupling  full           8       0           8    0.3375
+                           pad            8       0           8    0.3375
+                           barrel         6       2           4    0.7625
+    qfn_diffpair_escape    full           2       0           2    0.3875
+                           pad            2       0           2    0.3875
+                           barrel         2       0           1    3.4625
+    qfn_interior_pads      full           5       0           6    0.2625
+                           pad            5       0           6    0.2625
+                           barrel         4       1           4    0.7625
+    routed_output U2       full          15      22           0    3.0125
+                           pad           10      27           0    2.9125
+                           barrel        10      27           0    2.9125
+
+    pad:    0 improved, 1 regressed, 4 unchanged  -- NOT ADOPTABLE
+    barrel: 0 improved, 3 regressed, 2 unchanged  -- NOT ADOPTABLE
+
+    (Doctrine: improve on >= N-1 boards, regress on none. `drc_grazes.total`
+    was unchanged in all 15 runs.)
+
+SO THE FORK RESOLVES TO "THE LADDER IS RIGHT AND THE NAME WAS WRONG", and the
+default stays `full`. The sharpest single row is routed_output U2: **not one of
+its selected offsets overlaps a pad**, and confining the ladder to the pad still
+costs it 5 escapes. The "on-pad" ladder earns its keep doing OFF-pad work --
+which is precisely why the name had to change and the behaviour did not.
+
+The knob stays so the measurement is re-runnable, and so a later board that
+disagrees can be found rather than argued about.
+
+Run: python3 tests/test_846_onpad_ladder_reach.py
+"""
+import math
+import os
+import subprocess
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))
+sys.path.insert(0, os.path.join(ROOT, 'py_tools'))
+
+CHECKS = []
+
+
+def check(name, ok, detail=''):
+    CHECKS.append((name, bool(ok)))
+    print(('  PASS: ' if ok else '  FAIL: ') + name
+          + (' -- ' + detail if detail else ''))
+
+
+def offsets_for(arm, pad_width=0.875, via=0.45, clearance=0.1, pitch=0.40):
+    """Ask the engine's own ladder, in a CHILD process.
+
+    A child, because env_knobs reads every knob ONCE at import: two arms in one
+    process would both see whichever value was set first.
+    """
+    src = (
+        'import os, sys, json, math\n'
+        'R = %r\n'
+        'sys.path[:0] = [R, os.path.join(R, "py_router"), '
+        'os.path.join(R, "py_tools")]\n'
+        'import env_knobs\n'
+        'step = max(math.sqrt(max(0.0, (%f + %f) ** 2 - %f ** 2)) + 0.05\n'
+        '           if (%f + %f) > %f else 0.0, 0.05, 0.05)\n'
+        'axis = [0.0]\n'
+        'for k in range(1, 9):\n'
+        '    axis += [k * step, -k * step]\n'
+        'reach = {"pad": %f / 2.0, "barrel": %f / 2.0 - %f / 2.0}.get(\n'
+        '    env_knobs.QFN_ONPAD_REACH)\n'
+        'if reach is not None:\n'
+        '    axis = [d for d in axis if abs(d) <= reach + 1e-9]\n'
+        'print(json.dumps({"knob": env_knobs.QFN_ONPAD_REACH, '
+        '"n": len(axis), "max": max(abs(d) for d in axis), "step": step}))\n'
+    ) % (ROOT, via, clearance, pitch, via, clearance, pitch,
+         pad_width, pad_width, via)
+    env = dict(os.environ)
+    env['KICAD_QFN_ONPAD_REACH'] = arm
+    p = subprocess.run([sys.executable, '-X', 'utf8', '-c', src],
+                       capture_output=True, text=True, env=env, cwd=ROOT)
+    if p.returncode != 0:
+        raise AssertionError('probe failed: ' + (p.stderr or p.stdout)[-300:])
+    import json as _j
+    return _j.loads(p.stdout.strip().splitlines()[-1])
+
+
+def main():
+    # The rig's own premise: on this geometry the step EXCEEDS half the pad, so
+    # confining the ladder to the pad must actually remove rungs. Without this,
+    # every check below could pass on a part where the knob does nothing.
+    full = offsets_for('full')
+    pad = offsets_for('pad')
+    barrel = offsets_for('barrel')
+    # The rig's own premise, stated as what the arms must DO rather than as an
+    # inequality about the step: an earlier draft asserted `step > pad_width/2`,
+    # which is FALSE on this geometry (0.4275 vs 0.4375 -- rung 1 sits 0.01 mm
+    # INSIDE the pad edge) and would have failed a rig that works perfectly.
+    check('the arms actually shorten the ladder, so these checks are not '
+          'vacuous',
+          full['n'] > pad['n'] > barrel['n'],
+          f"full={full['n']} pad={pad['n']} barrel={barrel['n']} "
+          f"step={full['step']:.4f}")
+
+    check("'full' is 17 rungs reaching 8*step", full['n'] == 17
+          and abs(full['max'] - 8 * full['step']) < 1e-9,
+          f"n={full['n']} max={full['max']:.4f}")
+
+    check("'pad' keeps only offsets whose via CENTRE stays on the pad",
+          pad['max'] <= 0.875 / 2.0 + 1e-9 and pad['n'] < full['n'],
+          f"n={pad['n']} max={pad['max']:.4f}")
+
+    check("'barrel' keeps only offsets whose whole BARREL stays on the pad",
+          barrel['max'] <= 0.875 / 2.0 - 0.45 / 2.0 + 1e-9,
+          f"n={barrel['n']} max={barrel['max']:.4f}")
+    check("'barrel' collapses this geometry to the centred rung alone",
+          barrel['n'] == 1 and barrel['max'] == 0.0,
+          'the two arms are not interchangeable, which is why both are named')
+
+    # A typo must not silently shorten the ladder. This is the property
+    # KICAD_QFN_UNDERPAD_ERASED_GATE states for itself, and the reason the knob
+    # is a string rather than a bool.
+    typo = offsets_for('PADD')
+    check('an unrecognised value behaves as `full`',
+          typo['n'] == full['n'] and abs(typo['max'] - full['max']) < 1e-9,
+          f"n={typo['n']}")
+
+    # Case-insensitive and whitespace-tolerant, per env_knobs' own parse.
+    loud = offsets_for('  PAD ')
+    check('the knob is case- and whitespace-insensitive',
+          loud['n'] == pad['n'], f"n={loud['n']} vs pad {pad['n']}")
+
+    bad = [n for n, ok in CHECKS if not ok]
+    print(f"\n{'FAIL' if bad else 'PASS'}  #846 ladder reach: "
+          f"{len(CHECKS) - len(bad)}/{len(CHECKS)} checks")
+    return 1 if bad else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_846_onpad_ladder_reach.py
+++ b/tests/test_846_onpad_ladder_reach.py
@@ -73,37 +73,91 @@ def check(name, ok, detail=''):
           + (' -- ' + detail if detail else ''))
 
 
-def offsets_for(arm, pad_width=0.875, via=0.45, clearance=0.1, pitch=0.40):
-    """Ask the engine's own ladder, in a CHILD process.
+PROBE = (
+    'import os, sys, json, math\n'
+    'R = sys.argv[1]\n'
+    'sys.path[:0] = [R, os.path.join(R, "py_router"), '
+    'os.path.join(R, "py_tools")]\n'
+    'import env_knobs\n'
+    'from qfn_fanout import axis_offset_ladder\n'
+    'pad_width, via, clearance, pitch = (float(a) for a in sys.argv[2:6])\n'
+    'need = via + clearance\n'
+    'stagger = (math.sqrt(max(0.0, need * need - pitch * pitch)) + 0.05\n'
+    '           if need > pitch else 0.0)\n'
+    'step = max(stagger, 0.05, 0.05)\n'
+    'axis = axis_offset_ladder(pad_width, via, step)\n'
+    'print(json.dumps({"knob": env_knobs.QFN_ONPAD_REACH, "n": len(axis),\n'
+    '                  "max": max(abs(d) for d in axis), "step": step}))\n'
+)
 
-    A child, because env_knobs reads every knob ONCE at import: two arms in one
-    process would both see whichever value was set first.
+
+def offsets_for(arm, pad_width=0.875, via=0.45, clearance=0.1, pitch=0.40):
+    """The ladder the ENGINE builds, under `arm`, in a CHILD process.
+
+    It CALLS `qfn_fanout.axis_offset_ladder` -- the engine's only source for
+    these offsets -- rather than restating its arithmetic. The first draft of
+    this file rebuilt the ladder from the same formula, and every knob row of
+    tests/mutate_846.py SURVIVED: a test that mirrors the code it grades cannot
+    detect that code changing. Only `step` is computed here, and it is a
+    property of the fixture geometry, not of the thing under test.
+
+    A child process because env_knobs reads every knob ONCE at import, so two
+    arms in one process would both see whichever value was set first.
     """
-    src = (
-        'import os, sys, json, math\n'
-        'R = %r\n'
-        'sys.path[:0] = [R, os.path.join(R, "py_router"), '
-        'os.path.join(R, "py_tools")]\n'
-        'import env_knobs\n'
-        'step = max(math.sqrt(max(0.0, (%f + %f) ** 2 - %f ** 2)) + 0.05\n'
-        '           if (%f + %f) > %f else 0.0, 0.05, 0.05)\n'
-        'axis = [0.0]\n'
-        'for k in range(1, 9):\n'
-        '    axis += [k * step, -k * step]\n'
-        'reach = {"pad": %f / 2.0, "barrel": %f / 2.0 - %f / 2.0}.get(\n'
-        '    env_knobs.QFN_ONPAD_REACH)\n'
-        'if reach is not None:\n'
-        '    axis = [d for d in axis if abs(d) <= reach + 1e-9]\n'
-        'print(json.dumps({"knob": env_knobs.QFN_ONPAD_REACH, '
-        '"n": len(axis), "max": max(abs(d) for d in axis), "step": step}))\n'
-    ) % (ROOT, via, clearance, pitch, via, clearance, pitch,
-         pad_width, pad_width, via)
     env = dict(os.environ)
     env['KICAD_QFN_ONPAD_REACH'] = arm
-    p = subprocess.run([sys.executable, '-X', 'utf8', '-c', src],
+    p = subprocess.run([sys.executable, '-X', 'utf8', '-c', PROBE, ROOT,
+                        str(pad_width), str(via), str(clearance), str(pitch)],
                        capture_output=True, text=True, env=env, cwd=ROOT)
     if p.returncode != 0:
         raise AssertionError('probe failed: ' + (p.stderr or p.stdout)[-300:])
+    import json as _j
+    return _j.loads(p.stdout.strip().splitlines()[-1])
+
+
+ENGINE_PROBE = (
+    'import os, sys, json, math, io, contextlib\n'
+    'R = sys.argv[1]\n'
+    'sys.path[:0] = [R, os.path.join(R, "py_router"), '
+    'os.path.join(R, "py_tools")]\n'
+    'from kicad_parser import parse_kicad_pcb\n'
+    'from qfn_fanout import generate_qfn_fanout\n'
+    'pcb = parse_kicad_pcb(os.path.join(R, "kicad_files", sys.argv[2]))\n'
+    'fp = pcb.footprints[sys.argv[3]]\n'
+    'buf = io.StringIO()\n'
+    'with contextlib.redirect_stdout(buf):\n'
+    '    tracks, vias, dropped = generate_qfn_fanout(\n'
+    '        fp, pcb, net_filter=None, layer="F.Cu", track_width=0.1,\n'
+    '        clearance=0.1, grid_step=0.05, escape_method="underpad",\n'
+    '        via_size=0.45, via_drill=0.25, allow_via_in_pad=True)\n'
+    'own = {}\n'
+    'for p in fp.pads:\n'
+    '    if p.net_id:\n'
+    '        own.setdefault(p.net_id, []).append(p)\n'
+    'worst = 0.0\n'
+    'for v in vias:\n'
+    '    c = own.get(v["net_id"])\n'
+    '    if not c:\n'
+    '        continue\n'
+    '    pad = min(c, key=lambda q: math.hypot(q.global_x - v["x"],\n'
+    '                                          q.global_y - v["y"]))\n'
+    '    worst = max(worst, math.hypot(v["x"] - pad.global_x,\n'
+    '                                  v["y"] - pad.global_y))\n'
+    'print(json.dumps({"vias": len(vias), "dropped": len(dropped),\n'
+    '                  "max_offset": round(worst, 4)}))\n'
+)
+
+
+def engine_for(arm, board='tigard', ref='U3'):
+    """A REAL escape under `arm`: what the knob does to EMITTED copper."""
+    env = dict(os.environ)
+    env['KICAD_QFN_ONPAD_REACH'] = arm
+    p = subprocess.run([sys.executable, '-X', 'utf8', '-c', ENGINE_PROBE, ROOT,
+                        board + '.kicad_pcb', ref],
+                       capture_output=True, text=True, env=env, cwd=ROOT)
+    if p.returncode != 0:
+        raise AssertionError('engine probe failed: '
+                             + (p.stderr or p.stdout)[-400:])
     import json as _j
     return _j.loads(p.stdout.strip().splitlines()[-1])
 
@@ -152,6 +206,30 @@ def main():
     loud = offsets_for('  PAD ')
     check('the knob is case- and whitespace-insensitive',
           loud['n'] == pad['n'], f"n={loud['n']} vs pad {pad['n']}")
+
+    # And end to end, on real copper: the ladder is what the escape actually
+    # uses, so the knob must move the EMITTED vias, not just a list. tigard U3
+    # is 0.5mm-pitch with 0.80 x 0.25 leads.
+    e_full = engine_for('full')
+    e_barrel = engine_for('barrel')
+    check('the knob reaches emitted copper, not just the offset list',
+          e_barrel['max_offset'] != e_full['max_offset'],
+          f"full max_offset={e_full['max_offset']} vias={e_full['vias']} "
+          f"vs barrel max_offset={e_barrel['max_offset']} "
+          f"vias={e_barrel['vias']}")
+    # MEASURED, and the opposite of the intuition that shortening a ladder
+    # shortens stubs: on tigard U3 confining the axis ladder pushes the worst
+    # offset from 0.3000 to 0.7500, because the escape then falls through to
+    # the OUTWARD ladder, whose first rung is already past the pad edge
+    # (base = pad_width/2 + via/2 + clearance = 0.725). Confining the "on-pad"
+    # ladder does not produce more on-pad vias -- it produces further-out ones.
+    check('confining the axis ladder LENGTHENS stubs (the fallback is the '
+          'outward ladder)',
+          e_barrel['max_offset'] > e_full['max_offset'],
+          f"full={e_full['max_offset']} barrel={e_barrel['max_offset']}")
+    check('`full` is the shipped default, and it is the arm the A/B kept',
+          engine_for('full') == engine_for('nonsense-value'),
+          'an unrecognised value no longer behaves as `full` END TO END')
 
     bad = [n for n, ok in CHECKS if not ok]
     print(f"\n{'FAIL' if bad else 'PASS'}  #846 ladder reach: "

--- a/tests/test_846_via_in_pad_classification.py
+++ b/tests/test_846_via_in_pad_classification.py
@@ -16,20 +16,31 @@ THE MEASUREMENT, AS RUN (upstream/main e239e067, --escape-method underpad
     tigard U3                    48       28                  20         0
     qfn_diffpair_escape U1        2        0                   2         0
     qfn_underpad_coupling U1      8        0                   8         0
-    qfn_interior_pads U1 (INT*)   2        2                   0         0
 
-The "OVERLAP-off-centre" column is what this fix moves: 30 vias across three
-tracked boards that overlap the copper of the pad they escape while sitting off
-its centre. Before, every one of them shipped unclamped.
+Every row is a board this file RUNS, so the table is re-derived on each
+invocation rather than remembered. (An earlier draft carried a fifth row,
+qfn_interior_pads under a ``--nets INT*`` filter, which no arm here reproduced
+-- with the whole net set that board reads 6 vias / 0 centred / 6 overlapping.
+A measured row nothing re-measures is how a table starts drifting.)
+
+The "OVERLAP-off-centre" column is what this fix moves: 30 vias across three of
+the four boards, overlapping the copper of the pad they escape while sitting off
+its centre. Before, every one of them shipped unclamped. routed_output is here
+for the OPPOSITE population -- 14 vias, none overlapping -- because without it a
+mutation that clamps everything is invisible.
 
 WHY THE CENTRED COLUMN IS MOSTLY ZERO -- the part the issue did not name.
 ``snap()`` quantises the via COORDINATE to the routing grid (0.05 default),
 while real pad centres are not on that lattice: measured, 76 of 77 pads on
-routed_output's QFN-76, 6 of 6 on qfn_diffpair_escape, 8 of 8 on
-qfn_underpad_coupling, 16 of 66 on tigard. On those boards the genuinely
-centred rung lands **0.0125 mm** from the pad centre -- 12.5x
-POSITION_TOLERANCE -- so the via-in-pad branch was unreachable by construction,
-even for the offset the ladder calls 0.
+routed_output's QFN-76, 6 of 6 on qfn_diffpair_escape and 8 of 8 on
+qfn_underpad_coupling all sit **0.0125 mm** off it -- 12.5x POSITION_TOLERANCE
+-- so on those three the via-in-pad branch was unreachable by construction, even
+for the offset the ladder calls 0.
+
+tigard is the control that keeps this honest: 50 of its 66 pads ARE on the
+lattice (the 16 that are not sit 0.01178-0.03536 mm off), and it duly produced
+28 centred vias. The defect is board-dependent, not universal, and the boards it
+bites are the ones whose pad centres are off-grid.
 
 Run: python3 tests/test_846_via_in_pad_classification.py
 """

--- a/tests/test_846_via_in_pad_classification.py
+++ b/tests/test_846_via_in_pad_classification.py
@@ -56,6 +56,12 @@ CASES = [
     ('qfn_underpad_coupling', 'U1', ['SIG*'], 'F.Cu', 0.1, 0.12),
     ('qfn_diffpair_escape', 'U1', ['DP1*'], 'F.Cu', 0.1, 0.15),
     ('tigard', 'U3', None, 'F.Cu', 0.1, 0.10),
+    # Carries the OPPOSITE population -- 14 vias, none of which overlaps its
+    # pad -- and it is here for that. Without it a mutation that clamps
+    # EVERYTHING (`if True:`) is invisible, because every via on the three
+    # boards above does overlap: measured, that row SURVIVED until this
+    # board was added.
+    ('routed_output', 'U2', ['Net-(U2A-*)'], 'B.Cu', 0.1, 0.10),
 ]
 
 CHECKS = []
@@ -93,6 +99,7 @@ def run(board, ref, nets, layer, tw, clr):
 
 def main():
     ran = 0
+    seen = {'offcentre': 0, 'disjoint': 0}
     for board, ref, nets, layer, tw, clr in CASES:
         got = run(board, ref, nets, layer, tw, clr)
         if got is None:
@@ -129,13 +136,8 @@ def main():
               f'them off centre)', not bad,
               f'unclamped: {bad[:6]}' if bad else '')
 
-        # 2. The rig must actually contain the case, or check 1 is vacuous --
-        #    the trap the BGA half of test_fanout_via_in_pad_clamp guards and
-        #    its QFN half did not.
-        check(f'{board} {ref}: the run contains at least one OFF-CENTRE '
-              f'overlapping via', offcentre,
-              'nothing here exercises #846' if not offcentre else
-              f'max offset {max(d for _v, _p, d in offcentre):.4f} mm')
+        seen['offcentre'] += len(offcentre)
+        seen['disjoint'] += len(disjoint)
 
         # 3. The engine and the FAB NOTE agree, via for via. They are the two
         #    consumers that used to disagree; the note is derived from the
@@ -160,6 +162,15 @@ def main():
         check(f'{board} {ref}: escapes are unchanged by the clamp '
               f'({len(vias)} vias, {len(dropped)} dropped)',
               len(vias) + len(dropped) > 0)
+
+    # The rig must contain BOTH populations, or the per-board checks above are
+    # half vacuous -- the trap the BGA half of test_fanout_via_in_pad_clamp
+    # guards and its QFN half did not. Asserted across the set rather than per
+    # board, because no single board carries both.
+    check('the run exercises OFF-CENTRE overlapping vias (the #846 case)',
+          seen['offcentre'], f"{seen['offcentre']} of them")
+    check('...and DISJOINT vias, so "clamp everything" is detectable',
+          seen['disjoint'], f"{seen['disjoint']} of them")
 
     # 6. THE 12.5 MICRON CASE, stated as geometry rather than as an outcome:
     #    pad centres are off the routing lattice, so snap() cannot place a via

--- a/tests/test_846_via_in_pad_classification.py
+++ b/tests/test_846_via_in_pad_classification.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Issue #846: a via that overlaps its own pad is CLASSIFIED and CLAMPED as one.
+
+The QFN under-pad commit loop decided "via-in-pad" with
+``hypot(via - pad) <= POSITION_TOLERANCE`` -- 0.001 mm. That is not the
+question #202's clamp exists to answer, and it is not the question
+``fab_notes.print_via_in_pad_note`` answers three lines later in the same run.
+So the same via could be reported as needing IPC-4761 Type VII **and** shipped
+at nominal size with no clamp, free to bulge past the pad edge.
+
+THE MEASUREMENT, AS RUN (upstream/main e239e067, --escape-method underpad
+--allow-via-in-pad, via 0.45, grid 0.05):
+
+    board / component          vias  centred  OVERLAP-off-centre  disjoint
+    routed_output U2             14        0                   0        14
+    tigard U3                    48       28                  20         0
+    qfn_diffpair_escape U1        2        0                   2         0
+    qfn_underpad_coupling U1      8        0                   8         0
+    qfn_interior_pads U1 (INT*)   2        2                   0         0
+
+The "OVERLAP-off-centre" column is what this fix moves: 30 vias across three
+tracked boards that overlap the copper of the pad they escape while sitting off
+its centre. Before, every one of them shipped unclamped.
+
+WHY THE CENTRED COLUMN IS MOSTLY ZERO -- the part the issue did not name.
+``snap()`` quantises the via COORDINATE to the routing grid (0.05 default),
+while real pad centres are not on that lattice: measured, 76 of 77 pads on
+routed_output's QFN-76, 6 of 6 on qfn_diffpair_escape, 8 of 8 on
+qfn_underpad_coupling, 16 of 66 on tigard. On those boards the genuinely
+centred rung lands **0.0125 mm** from the pad centre -- 12.5x
+POSITION_TOLERANCE -- so the via-in-pad branch was unreachable by construction,
+even for the offset the ladder calls 0.
+
+Run: python3 tests/test_846_via_in_pad_classification.py
+"""
+import math
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+sys.path.insert(0, os.path.join(ROOT, 'py_router'))
+sys.path.insert(0, os.path.join(ROOT, 'py_tools'))
+
+from kicad_parser import parse_kicad_pcb                       # noqa: E402
+from qfn_fanout import generate_qfn_fanout                     # noqa: E402
+from fab_notes import via_overlaps_pad, via_in_pad_sites       # noqa: E402
+from bga_fanout.constants import POSITION_TOLERANCE            # noqa: E402
+from list_nets import fab_floor_min                            # noqa: E402
+
+GRID = 0.05
+VIA_SIZE, VIA_DRILL = 0.45, 0.20
+
+# board, ref, net filter, layer, track, clearance
+CASES = [
+    ('qfn_underpad_coupling', 'U1', ['SIG*'], 'F.Cu', 0.1, 0.12),
+    ('qfn_diffpair_escape', 'U1', ['DP1*'], 'F.Cu', 0.1, 0.15),
+    ('tigard', 'U3', None, 'F.Cu', 0.1, 0.10),
+]
+
+CHECKS = []
+
+
+def check(name, ok, detail=''):
+    CHECKS.append((name, bool(ok), detail))
+    print(('  PASS: ' if ok else '  FAIL: ') + name + (' -- ' + detail
+                                                       if detail else ''))
+
+
+def escaping_pad(fp, via):
+    """The pad this via escapes: the nearest same-net pad on the footprint."""
+    cands = [p for p in fp.pads if p.net_id == via['net_id']]
+    if not cands:
+        return None
+    return min(cands, key=lambda p: math.hypot(p.global_x - via['x'],
+                                               p.global_y - via['y']))
+
+
+def run(board, ref, nets, layer, tw, clr):
+    path = os.path.join(ROOT, 'kicad_files', board + '.kicad_pcb')
+    if not os.path.exists(path):
+        return None
+    pcb = parse_kicad_pcb(path)
+    fp = pcb.footprints.get(ref)
+    if fp is None:
+        return None
+    tracks, vias, dropped = generate_qfn_fanout(
+        fp, pcb, net_filter=nets, layer=layer, track_width=tw, clearance=clr,
+        grid_step=GRID, escape_method='underpad', via_size=VIA_SIZE,
+        via_drill=VIA_DRILL, allow_via_in_pad=True)
+    return pcb, fp, tracks, vias, dropped
+
+
+def main():
+    ran = 0
+    for board, ref, nets, layer, tw, clr in CASES:
+        got = run(board, ref, nets, layer, tw, clr)
+        if got is None:
+            print(f"  (skipping {board}: not present)")
+            continue
+        ran += 1
+        pcb, fp, tracks, vias, dropped = got
+        ncu = len(pcb.board_info.copper_layers or []) or 4
+        floor_dia = fab_floor_min(ncu)['via_diameter']
+
+        overlapping, offcentre, disjoint = [], [], []
+        for v in vias:
+            pad = escaping_pad(fp, v)
+            if pad is None:
+                continue
+            d = math.hypot(v['x'] - pad.global_x, v['y'] - pad.global_y)
+            if via_overlaps_pad(pad, v['x'], v['y'], VIA_SIZE):
+                overlapping.append((v, pad, d))
+                if d > POSITION_TOLERANCE:
+                    offcentre.append((v, pad, d))
+            else:
+                disjoint.append((v, pad, d))
+
+        # 1. THE DEFECT. Every via that overlaps the pad it escapes is sized to
+        #    that pad (#202), or held at the fab floor because the pad is
+        #    smaller than any buildable via. Before the fix an off-centre
+        #    overlapping via kept the nominal 0.45.
+        bad = [(p.pad_number, v['size'], min(p.size_x, p.size_y), round(d, 4))
+               for v, p, d in overlapping
+               if v['size'] > min(p.size_x, p.size_y) + 1e-9
+               and v['size'] > floor_dia + 1e-9]
+        check(f'{board} {ref}: every via overlapping its own pad is clamped '
+              f'to it ({len(overlapping)} overlapping, {len(offcentre)} of '
+              f'them off centre)', not bad,
+              f'unclamped: {bad[:6]}' if bad else '')
+
+        # 2. The rig must actually contain the case, or check 1 is vacuous --
+        #    the trap the BGA half of test_fanout_via_in_pad_clamp guards and
+        #    its QFN half did not.
+        check(f'{board} {ref}: the run contains at least one OFF-CENTRE '
+              f'overlapping via', offcentre,
+              'nothing here exercises #846' if not offcentre else
+              f'max offset {max(d for _v, _p, d in offcentre):.4f} mm')
+
+        # 3. The engine and the FAB NOTE agree, via for via. They are the two
+        #    consumers that used to disagree; the note is derived from the
+        #    board's own pad table, not from the loop's bookkeeping.
+        noted = {(round(v['x'], 6), round(v['y'], 6))
+                 for v, _pad in via_in_pad_sites(vias, pcb.pads_by_net)}
+        engine = {(round(v['x'], 6), round(v['y'], 6))
+                  for v, _p, _d in overlapping}
+        check(f'{board} {ref}: the commit loop and the IPC-4761 fab note '
+              f'classify the same vias', engine <= noted,
+              f'engine-only: {sorted(engine - noted)[:4]}')
+
+        # 4. A via that misses its pad entirely keeps the nominal size: the fix
+        #    must not clamp everything.
+        wrong = [(p.pad_number, v['size']) for v, p, _d in disjoint
+                 if abs(v['size'] - VIA_SIZE) > 1e-9]
+        check(f'{board} {ref}: a via disjoint from its pad keeps nominal size '
+              f'({len(disjoint)} disjoint)', not wrong, str(wrong[:6]))
+
+        # 5. Nothing was lost. Shrinking a via only relaxes clearance and
+        #    hole-to-hole, so the escape count cannot move.
+        check(f'{board} {ref}: escapes are unchanged by the clamp '
+              f'({len(vias)} vias, {len(dropped)} dropped)',
+              len(vias) + len(dropped) > 0)
+
+    # 6. THE 12.5 MICRON CASE, stated as geometry rather than as an outcome:
+    #    pad centres are off the routing lattice, so snap() cannot place a via
+    #    within POSITION_TOLERANCE of one, and the old centre test could never
+    #    fire there however centred the chosen offset was.
+    off_lattice = {}
+    for board, ref, _n, _l, _t, _c in CASES:
+        path = os.path.join(ROOT, 'kicad_files', board + '.kicad_pcb')
+        if not os.path.exists(path):
+            continue
+        fp = parse_kicad_pcb(path).footprints[ref]
+        offs = []
+        for p in fp.pads:
+            if not p.net_id:
+                continue
+            offs.append(math.hypot(
+                abs(p.global_x - round(p.global_x / GRID) * GRID),
+                abs(p.global_y - round(p.global_y / GRID) * GRID)))
+        off_lattice[board] = (sum(1 for o in offs if o > POSITION_TOLERANCE),
+                              len(offs), max(offs) if offs else 0.0)
+    worst = [b for b, (n, _t, _m) in off_lattice.items() if n]
+    check('pad centres are OFF the routing lattice, so the old centre test '
+          'could not fire for the centred rung either',
+          worst, '; '.join(f'{b}: {n}/{t} off-lattice, up to {m:.4f} mm'
+                           for b, (n, t, m) in off_lattice.items()))
+
+    if not ran:
+        print('SKIP: no corpus board present')
+        return 77
+    bad = [n for n, ok, _d in CHECKS if not ok]
+    print(f"\n{'FAIL' if bad else 'PASS'}  #846 via-in-pad classification: "
+          f"{len(CHECKS) - len(bad)}/{len(CHECKS)} checks")
+    return 1 if bad else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_846_via_in_pad_classification.py
+++ b/tests/test_846_via_in_pad_classification.py
@@ -186,6 +186,35 @@ def main():
           worst, '; '.join(f'{b}: {n}/{t} off-lattice, up to {m:.4f} mm'
                            for b, (n, t, m) in off_lattice.items()))
 
+    # 7. THE PREDICATE ITSELF: overlap is a BARREL question, not a centre one.
+    #    A via whose centre sits outside the pad can still land copper in it,
+    #    and that joint needs Type VII exactly as much -- #695's finding, and
+    #    why fab_notes credits the barrel radius. No board in the table above
+    #    happens to contain the case (every selected offset there keeps its
+    #    CENTRE on the pad), so a mutation dropping the radius survived the
+    #    board arms. It is asserted directly instead.
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    from synth import make_pad as _make_pad
+    lead = _make_pad(1, 0.0, 0.0, ref='U1', num='1', net_name='X',
+                     size_x=0.25, size_y=0.80)
+    outside = 0.20         # pad half-width is 0.125, so the CENTRE is off it
+    check('a via whose CENTRE is off the pad but whose BARREL overlaps it '
+          'counts as via-in-pad',
+          via_overlaps_pad(lead, outside, 0.0, VIA_SIZE),
+          f'centre {outside} mm out on a {lead.size_x} mm-wide lead; the '
+          f'{VIA_SIZE} barrel reaches {outside - VIA_SIZE / 2:+.4f} mm')
+    from check_drc import point_to_pad_distance as _p2p
+    check('...and it is the BARREL that credits it: the via CENTRE is '
+          'outside that pad',
+          _p2p(outside, 0.0, lead) > 0.0,
+          f'centre-to-pad distance {_p2p(outside, 0.0, lead):.4f} mm -- if '
+          f'this were 0 the arm above would pass without the barrel radius, '
+          f'and the mutation dropping it would survive')
+    far = 0.60             # beyond pad half-width + barrel radius
+    check('a via genuinely clear of the pad is NOT via-in-pad',
+          not via_overlaps_pad(lead, far, 0.0, VIA_SIZE),
+          f'{far} mm out; the barrel reaches {far - VIA_SIZE / 2:.4f} mm')
+
     if not ran:
         print('SKIP: no corpus board present')
         return 77

--- a/tests/test_846_via_in_pad_classification.py
+++ b/tests/test_846_via_in_pad_classification.py
@@ -62,17 +62,24 @@ from list_nets import fab_floor_min                            # noqa: E402
 GRID = 0.05
 VIA_SIZE, VIA_DRILL = 0.45, 0.20
 
-# board, ref, net filter, layer, track, clearance
+# board, ref, nets, layer, track, clearance, EXPECTED (vias, dropped)
+#
+# The expected pair is the whole point of #846's neutrality claim: the clamp
+# only ever SHRINKS a via, which relaxes every clearance and hole-to-hole term,
+# so no escape can be lost. An earlier draft asserted `len(vias) + len(dropped)
+# > 0` under the label "escapes are unchanged", which would have passed on
+# (0 vias, 36 dropped). These numbers are the pre-change measurement on
+# upstream/main e239e067.
 CASES = [
-    ('qfn_underpad_coupling', 'U1', ['SIG*'], 'F.Cu', 0.1, 0.12),
-    ('qfn_diffpair_escape', 'U1', ['DP1*'], 'F.Cu', 0.1, 0.15),
-    ('tigard', 'U3', None, 'F.Cu', 0.1, 0.10),
+    ('qfn_underpad_coupling', 'U1', ['SIG*'], 'F.Cu', 0.1, 0.12, (8, 0)),
+    ('qfn_diffpair_escape', 'U1', ['DP1*'], 'F.Cu', 0.1, 0.15, (2, 0)),
+    ('tigard', 'U3', None, 'F.Cu', 0.1, 0.10, (48, 0)),
     # Carries the OPPOSITE population -- 14 vias, none of which overlaps its
     # pad -- and it is here for that. Without it a mutation that clamps
     # EVERYTHING (`if True:`) is invisible, because every via on the three
     # boards above does overlap: measured, that row SURVIVED until this
     # board was added.
-    ('routed_output', 'U2', ['Net-(U2A-*)'], 'B.Cu', 0.1, 0.10),
+    ('routed_output', 'U2', ['Net-(U2A-*)'], 'B.Cu', 0.1, 0.10, (14, 22)),
 ]
 
 CHECKS = []
@@ -111,7 +118,7 @@ def run(board, ref, nets, layer, tw, clr):
 def main():
     ran = 0
     seen = {'offcentre': 0, 'disjoint': 0}
-    for board, ref, nets, layer, tw, clr in CASES:
+    for board, ref, nets, layer, tw, clr, expect in CASES:
         got = run(board, ref, nets, layer, tw, clr)
         if got is None:
             print(f"  (skipping {board}: not present)")
@@ -170,9 +177,12 @@ def main():
 
         # 5. Nothing was lost. Shrinking a via only relaxes clearance and
         #    hole-to-hole, so the escape count cannot move.
-        check(f'{board} {ref}: escapes are unchanged by the clamp '
+        check(f'{board} {ref}: escapes match the PRE-change measurement '
               f'({len(vias)} vias, {len(dropped)} dropped)',
-              len(vias) + len(dropped) > 0)
+              (len(vias), len(dropped)) == expect,
+              f'expected {expect} on upstream/main e239e067 -- the clamp only '
+              f'shrinks vias, which relaxes every clearance term, so no '
+              f'escape may be lost'),
 
     # The rig must contain BOTH populations, or the per-board checks above are
     # half vacuous -- the trap the BGA half of test_fanout_via_in_pad_clamp
@@ -188,7 +198,7 @@ def main():
     #    within POSITION_TOLERANCE of one, and the old centre test could never
     #    fire there however centred the chosen offset was.
     off_lattice = {}
-    for board, ref, _n, _l, _t, _c in CASES:
+    for board, ref, _n, _l, _t, _c, _e in CASES:
         path = os.path.join(ROOT, 'kicad_files', board + '.kicad_pcb')
         if not os.path.exists(path):
             continue

--- a/tests/test_fanout_via_in_pad_clamp.py
+++ b/tests/test_fanout_via_in_pad_clamp.py
@@ -101,19 +101,24 @@ def _via_in_pad_violations(pcb, fp, vias, configured_via, fab):
     Returns (n_in_pad, n_clamped_below_cfg, violations)."""
     floor_dia = fab['via_diameter']   # deepest reachable fab via (fab_floor_min)
     pads = [p for p in fp.pads if getattr(p, 'drill', 0) == 0 and p.net_id]
-    # Only TRUE via-in-pad vias (centred on the pad) are governed by the clamp; an
-    # off-pad staggered via with a connecting stub legitimately extends past a tiny
-    # pad. Match by the code's OWN via-in-pad test (hypot <= POSITION_TOLERANCE),
-    # not merely landing in the pad bbox -- a 0.45 via parked a hair off a 0.25 pad
-    # is an off-pad escape, not a clamp candidate.
-    from bga_fanout.constants import POSITION_TOLERANCE
+    # A via-in-pad is a via whose BARREL OVERLAPS same-net pad copper -- the fab
+    # question, and the one `fab_notes` has always asked.
+    #
+    # This scoping used to be `hypot <= POSITION_TOLERANCE` (0.001mm), copied
+    # from the engine, with a comment claiming "an off-pad staggered via with a
+    # connecting stub legitimately extends past a tiny pad". That was the very
+    # defect #846 reports, restated as a test: a 0.45 via staggered 0.30mm along
+    # a 0.80 x 0.25 lead is INSIDE that pad's copper and bulges 0.1mm past each
+    # long edge. Worse, it made this gate's QFN half vacuous -- measured
+    # n_in_pad = 0 on its own fixture, with no guard to say so (the BGA half has
+    # had one since it was written).
     viols, n_in_pad, n_clamped = [], 0, 0
+    from fab_notes import via_overlaps_pad
     for v in vias:
         pad = None
         for p in pads:
-            if (p.net_id == v['net_id'] and
-                    abs(p.global_x - v['x']) <= POSITION_TOLERANCE and
-                    abs(p.global_y - v['y']) <= POSITION_TOLERANCE):
+            if (p.net_id == v['net_id']
+                    and via_overlaps_pad(p, v['x'], v['y'], v['size'])):
                 if pad is None or min(p.size_x, p.size_y) < min(pad.size_x, pad.size_y):
                     pad = p
         if pad is None:
@@ -181,7 +186,15 @@ def test_methods(verbose):
                 clearance=0.15, grid_step=0.05, **kw))
             n, _nc, viols = _via_in_pad_violations(pcb, fp, vias, kw['via_size'], fab2)
             fails += [f"{label}: {x}" for x in viols]
-            if verbose and not viols:
+            # The guard the BGA half has and this half did not (#846). The
+            # under-pad case MUST place via-in-pads on this board: its pads are
+            # 0.25 wide and every escape lands on one. `stub` may legitimately
+            # place none, so only the under-pad arm is required to exercise
+            # something.
+            if n == 0 and 'underpad' in label:
+                fails.append(f"{label}: placed no via-in-pad "
+                             f"(test exercises nothing)")
+            elif verbose and not viols:
                 print(f"  {label}: {n} via-in-pad, none bulge past max(pad,floor)  OK")
     return fails
 


### PR DESCRIPTION
Three places in the fanout answer **"does copper actually reach this pad?"** — the QFN
commit loop, the BGA via ledger, and the downstream failure report — and none of them
measures reach. One asks whether the via is *centred*, one whether it is *inside a box*,
and one never asks at all.

The class has form here. **#695** — a *placement* issue, `check_weird` crediting "a pad by
via centre but a track by via radius, so via-in-pad reads as dangling and blocks DONE" — was
the same substitution. And PR #852's own review caught a scalar-radius version of #854 and
replaced it with a per-axis box, which closed the equal-size case and left the
dissimilar-size one. This PR makes each site ask its real question and names the predicates
so they cannot drift apart again.

One distinction worth keeping: #846 and #854 are **wrong answers**. #652 is a **missing
question** — `no rippable blockers found` is *true*; the right predicate is simply never
asked at the site that reports the failure, though the repo computes it three times
elsewhere.

Closes #846
Closes #854
Closes #652

---

## #854 — the twin rule asks whether a via REACHES the route

`PendingVias.verdict`'s same-net merge keyed on `anchor_box`, the **candidate's** pad
half-extents, so a large pad swallowed a smaller overlapping same-net pad's committed via,
dropped its own, and shipped an inner-layer track starting where no via reaches — still
counted as escaped.

A ball pad is on the top layer and its route's track on an inner one, so the pad reaches its
own track only **through** the via. `via_anchors_route` asks that; both sites call it.

**Both**, because `_has_copper` — the downstream ball-anchor test the twin branch appeals to
by name — carried the same bug in its looser, pre-#852 form (`max(size_x, size_y)/2 + 0.01`
in *both* axes). Two graders agreeing in the wrong direction is why the stranding was
silent: on the issue's own repro that tolerance is 0.51 mm, so a ball whose only via sat
0.4 mm away read as anchored and `_strap_unescaped_extras` never strapped it. It is now
`ball_has_copper`, module-level — as a closure nothing could call it, and its mutation row
duly survived.

### The issue says no board in `kicad_files/` reaches this. One does

`kit-dev-coldfire-xilinx_5213`, footprint `VR201` (TO-263-5). Its pad 3 is modelled as six
SMD pads on net GND: a 1.10 × 4.60 lead, a 10.8 × 9.4 tab, and four 5.25 × 4.55 paste
sub-pads — ordinary KiCad geometry, not a constructed case. Driving `manage_vias` with the
sub-pad routed first, at via 0.45 / drill 0.2 / clearance 0.1 and a 0.25 mm track:

| | before | after |
|---|---|---|
| sub-pad first | **1 via — the tab route stranded**, nearest via 3.6853 mm away against a 0.3500 mm reach | 2 vias, both anchored |
| tab first | 2 vias | 2 vias |

The before arm also prints `#620: 1 coincident same-net site(s) share one via` for a pair
3.69 mm apart. The order dependence is gone after.

*Two caveats stated rather than buried:* the 0.3500 mm reach is `via/2 + track/2`, and the
0.25 mm track is a parameter of that probe, not a property of the board. And VR201 has
exactly 6 GND pads, so an **unfiltered** run excludes it at `plane_min_pads` (default 6); a
`--nets` filter admits it. The geometry is real either way, which is what the new test
asserts.

The issue's **secondary** suggestion (test the intersection of both pads' boxes) does not
fix its own repro — the via at (10.4, 10.0) lies inside that intersection. The primary
(reach) one does.

**Does the reach rule ever refuse a merge and DROP an escape that used to survive?**
Structurally yes — `verdict` can now return `conflict` where it returned `twin`, and
`thin_drill_to_clear` provably cannot rescue that band, so the caller drops the whole net's
fanout. Measured across all 27 tracked boards, every same-net intra-footprint SMD pad pair,
at five parameter sets (CLI defaults plus four others):

| | old-twin ∧ new-twin | old-twin → **conflict** | old-twin → clear (the fix) |
|---|---|---|---|
| all 5 arms | 36 | **0** | 4 |

Identical at every parameter set, because the corpus's same-net intra-footprint distances
are 0.0 or ≥ 0.4 mm and no ≥ 0.4 pair has a candidate pad ≥ 2·d. So the risk is real and the
corpus does not reach it — stated as a measured null rather than left unsaid.

### A test merged the day before the issue was filed disagreed, and was revised — with the measurement

`test_a_twin_FURTHER_OUT_than_either_floor_is_still_a_twin` asserted that two routes 0.9 mm
apart inside one 2.0 mm pad get **one** via. The surviving via has a 0.225 mm radius, so it
is 0.9 mm from the second route's track start and touches nothing: that test pinned the
stranding this issue reports. It is now `test_a_via_the_route_cannot_REACH_is_not_its_twin`,
asserts two vias, and checks that every emitted via anchors a route. Its docstring records
what it used to say and why the direction changed.

The distance-0 case #620 needs still merges — that follows from `0 <= any radius`, and
`test_two_routes_at_one_site_get_one_via` covers it. (The "`interf_u` BUS1, 31 sites" figure
in `PendingVias.verdict`'s docstring is PR #852's; I could not reproduce it and have not
relied on it.)

The broad-phase window's third term is **re-pointed, not dropped** — it is now the anchor
reach, still the term nothing else makes binding — so `mutate_620`'s row for it survives
with a new meaning rather than being retired.

---

## #846 — a via that overlaps its own pad is classified and clamped as one

The commit loop decided "via-in-pad" with `hypot(via − pad) <= POSITION_TOLERANCE`
(0.001 mm) — neither the question #202's clamp answers nor the one
`fab_notes.print_via_in_pad_note` answers three lines later **in the same run**. So one via
could be reported as needing IPC-4761 Type VII *and* shipped at nominal size, free to bulge
past the pad. `fab_notes` already owned the right predicate; it is now public as
`via_overlaps_pad` and both sites call it.

| board / component | vias | centred | **overlap, off-centre** | disjoint |
|---|---|---|---|---|
| `routed_output` U2 | 14 | 0 | **0** | 14 |
| `tigard` U3 | 48 | 28 | **20** | 0 |
| `qfn_diffpair_escape` U1 | 2 | 0 | **2** | 0 |
| `qfn_underpad_coupling` U1 | 8 | 0 | **8** | 0 |

Every row is a board `tests/test_846_via_in_pad_classification.py` runs, so the table is
re-derived on each invocation. 30 vias across three of the four boards overlapped the copper
of the pad they escape while sitting off its centre; every one shipped unclamped.
`qfn_underpad_coupling` is the clearest: its pads are 0.875 × **0.25** and all 8 escape vias
shipped at **0.45** — bulging 0.1 mm past each long edge, on an in-repo fixture.
`routed_output` is in the set for the opposite population, and earns its place: without it a
mutation that clamps *everything* is invisible.

**Escape counts are unchanged** — 14/22, 48/0, 2/0, 8/0. The search completes before any
clamping and every clearance term is priced at the nominal via, so shrinking one only
relaxes clearance and hole-to-hole. Paired before/after artefacts exist for
`routed_output`, `tigard` and `qfn_underpad_coupling`; `qfn_diffpair_escape`'s after-side
comes from the committed test run.

### The part the issue did not name

`snap()` quantises the via **coordinate** to the routing grid (0.05) while pad centres often
are not on it: **76 of 77** pads on `routed_output`'s QFN-76, 6/6 on `qfn_diffpair_escape`
and 8/8 on `qfn_underpad_coupling` sit **0.0125 mm** off — 12.5× `POSITION_TOLERANCE` — so
on those three the via-in-pad branch was unreachable by construction *even at offset 0*.

`tigard` is the control that keeps this honest: 50 of its 66 pads **are** on the lattice, and
it duly produced 28 centred vias. The defect is board-dependent, and the boards it bites are
the ones whose pad centres are off-grid.

### The ladder: measured, then left alone

`_onpad` → module-level `axis_offset_ladder`, with a docstring that says what it is.
`--allow-via-in-pad`'s help, the GUI tooltip, `py_router/qfn_fanout/README.md` and
`docs/utilities.md` (whose entry stopped mid-sentence) now all say the flag *also* enables an
inward off-pad search and four extra stagger configurations.

`KICAD_QFN_ONPAD_REACH` (`full` | `pad` | `barrel`; unrecognised → `full`) drives
`tests/sweep_846_onpad_ladder.py`, one process per arm. **15 runs, 5 boards:**

- `pad`: 0 improved, 1 regressed, 4 unchanged — **not adoptable**
- `barrel`: 0 improved, 3 regressed, 2 unchanged — **not adoptable**

`drc_grazes` was identical arm-to-arm on every board (0 everywhere except `routed_output`,
which is 1 in all three arms). So the fork resolves to **"the ladder is right and the NAME
was wrong"**: behaviour unchanged, `full` stays the default.

Two things the measurement corrected in my own reasoning:

1. I had believed the long stubs came from the *outward* ladder. They do not. Attributing
   each committed via to its nearest rung puts **all 14** on `routed_output` U2 on the axis
   ladder and none on the outward one, and it owns the longest emitted stub there —
   **3.0125 mm** against a 0.875 mm pad. **The issue's mechanism claim is correct.** Only its
   number is stale: 4.16 mm is not reproducible on `main`, because #844's
   `stub_clears_erased` gate withdraws those escapes.
2. Confining the ladder **lengthens** stubs. On `tigard` U3 the worst pad-to-via offset goes
   0.3000 → 0.7500 under `barrel`, because the escape then falls through to the *outward*
   ladder, whose first rung is already past the pad edge.

`JSON_SUMMARY` gains `allow_via_in_pad`, `via_in_pad`, `via_in_pad_clamped`,
`via_in_pad_offcentre` and `max_stub_mm`. Until now the only machine-readable numbers a
fanout run produced were escape counts — which is how the issue's own figure went stale
unnoticed.

### The #202 gate was scoped by the defect

`tests/test_fanout_via_in_pad_clamp.py` matched via-in-pads with the engine's own
`hypot <= POSITION_TOLERANCE`, under a comment asserting the opposite of this issue. Measured
`n_in_pad = 0` — its QFN half **exercised nothing** while reporting PASS. The BGA half has
had an `if n == 0: "test exercises nothing"` guard since it was written; the QFN half now has
one too, and reports 2 sites where it reported 0.

---

## #652 — a fanout-dropped ball is diagnosed as one

Per the maintainer's closing comment, only the attribution was left. `no rippable blockers
found` is true and useless: it invites retries that can never work, because the ball has no
escape stub for them to act on.

Re-derived from geometry, because it has to be: `unescaped_nets` has **zero consuming
code**, the fanout persists only DRC settings and one float, and #472 already settled that
this machinery stays board-state-driven. A later `route.py` **process** cannot be told, only
shown.

`routing_common.entombed_bare_pads` does **not** key on
`auto_detect_bga_exclusion_zones`, which walks BGA components only — measured,
`routed_output` gets 3 zones (IC1, U3, U1) and **none for its QFN-76 U2**, and `tigard` gets
**zero**. A zone-keyed diagnosis would be silent on exactly the parts this is for.
Entombment comes from the footprint's own pad bounding box, and `pcb_data.zones` is
consulted so a pour-served interior ball is not called bare — which the #472 closure this
generalises never did.

| board | nets | entombed-bare pads |
|---|---|---|
| `tigard` | 85 | 2 (U3) |
| `routed_output` | 526 | 185 (IC1, U1, U2, U3) |
| `glasgow_revC` | 251 | 51 (U1, U30) |
| `qfn_underpad_coupling` | 9 | 0 |

Of `routed_output`'s 185: 137 are nets with no copper anywhere, and the other 48 have copper
elsewhere but none within 0.5 mm of the pad — in fact the nearest is 3.25 mm, so there are no
near-misses at the 0.05 mm reach.

Wired at **all four** sites that print the misleading line — `single_ended_loop`,
`reroute_loop`, `phase3_routing` and `diff_pair_loop` — each inside the `try/except` the #103
hints already use. I originally claimed there were three; the fourth was found by the
pre-push fact-check, and with it a `NameError` that the `try/except` would have swallowed
forever, leaving the hint silently dead at that site. The test now checks statically that all
four are wired **and** that every name each block uses is bound where it stands.

`summary['fanout_dropped']` carries the structured verdict and is mirrored into
`results_data`, because the hint prose does not survive — `route.py`'s report loop keeps
`details['blockers']` and drops `details['hint']`.

**A limit, disclosed in the test rather than discovered later:** before its pours exist, a
plane-destined net with an entombed pad matches. Once the pour is there, `zones` answers and
it goes quiet.

---

## Verification

- `tests/run_all.py`: **521 passed, 0 failed, +1 self-skipped** (baseline at `upstream/main`:
  518 passed, 0 failed, +1 self-skipped -- the +3 are this PR's new test files).
- `tests/mutate_846.py`: **21 rows, 18 killed, 3 survived (all 3 expected), 0 broken**.
- `tests/mutate_620.py`: **40 rows, 37 killed, 3 survived (all 3 expected), 0 broken**.
- GUI-parity gates: `test_manifest_plan_parity` OK, `test_cli_postpass_coverage` OK
  (8 registered, 0 unreachable, 0 failures), `test_engine_kwarg_parity` OK under real
  KiCad python (pcbnew 10.0.0 / wx 4.2.2 -- both classes, not the wx-skip),
  `test_fanout_rotated_gui` **8/10, byte-identical to `upstream/main` on this machine** --
  its GUI leg emits 0 tracks against the CLI's 104 here, on both the branch AND the
  baseline, so the two failures are pre-existing and environmental rather than introduced.
  Reported rather than waved past: it is the only gate that runs a fanout through the real
  dialog, and it is therefore the one I most wanted an answer from. The failing path is the
  STUB fan (104 tracks, 0 vias), which none of these changes touch -- they are all in the
  under-pad commit loop.

The battery earned its keep three times: `ball-anchor-test-reverted-to-the-pad-box` survived
while `_has_copper` was a closure nothing could call; four knob rows survived because the
first draft of the ladder test **restated** the engine's arithmetic instead of calling it;
and `classification-always-in-pad` survived until a board with the opposite population joined
the set. Three rows survive by design, each with its measured reason recorded rather than
deleted.

## Follow-ups, filed rather than fixed here

- `--allow-via-in-pad` and `--escape-method` are unregistered in `manifest_to_plan.py`'s
  tables and in `test_manifest_plan_parity.py`'s `BOOL_FLAGS`; they survive on the
  unknown-flag fallthrough, and the parity fixture has no `qfn_fanout.py` line.
- `ai_plan.py` cannot set a QFN step's `escape_method` (`_PARAM_SPECIAL` resolves it only to
  the BGA panel's control), so a plan carrying `--escape-method underpad
  --allow-via-in-pad` leaves the under-pad escape off and the flag inert.
- `clamp_via_to_pad` measures `min(size_x, size_y)` — the along-edge axis for a QFN lead —
  while the ladder's `base` uses the escape-axis extent.
- `routing_state.get_net_history_summary` prints newer events (`preexisting_blockers`,
  `boxed_in_static`, `fanout_dropped`) as bare names with no detail.
- #652's optional startup WARN over `--nets`-matched nets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A4yGaUMwXoP7xzedneLMW3
