### PR TITLE
#862: an occupancy test beside the bounding box, so a BGA's balls are not all 'interior'

### DIFF
--- a/docs/placement-predictors.md
+++ b/docs/placement-predictors.md
@@ -175,23 +175,23 @@ is not implemented, and this is the measurement rather than a preference:
 
 *It reaches few blockers the shipped halo does not already charge.* The escape
 ledger NAMES the parts eating a face in deficit. Across seven boards there are
-288 such (face, blocker) pairs, and **208 of them (72.2%) already sit inside
+291 such (face, blocker) pairs, and **209 of them (71.8%) already sit inside
 `halo_a + halo_b`** at the A/B harness's own coefficients -- the OFF arm
-already repels them. Of the 80 it does not charge, the demand term fires on
-**14 of the 93 parts involved**. Its whole mechanism is a larger quadratic on
+already repels them. Of the 82 it does not charge, the demand term fires on
+**16 of the 96 parts involved**. Its whole mechanism is a larger quadratic on
 repulsions that already exist, which is the mode
 `docs/placement-optimization.md` records as scattering the layout.
 
 | board | named blockers | already charged |
 |---|---|---|
 | rp2350_fpga_eensy_prePlane | 77 | 55 (71.4%) |
-| orangecrab_ext_pll | 88 | 53 (60.2%) |
+| orangecrab_ext_pll | 89 | 54 (60.7%) |
 | tigard | 39 | 37 (94.9%) |
 | watchy | 48 | 40 (83.3%) |
 | glasgow_revC | 27 | 18 (66.7%) |
 | kit-dev-coldfire | 8 | 5 (62.5%) |
-| ulx3s | 1 | 0 (0.0%) |
-| **total** | **288** | **208 (72.2%)** |
+| ulx3s | 3 | 0 (0.0%) |
+| **total** | **291** | **209 (71.8%)** |
 
 *And it fires where the grader is nearly blind.* The only independent escape
 instrument the placement A/B has is `health_escape_deficit_parts` /
@@ -206,7 +206,7 @@ identical:
 | esp_prog | 0 / 0 | 3 of 16 (19%) | 2.48 mm (U1) |
 | rp2350_fpga_eensy_prePlane | 10 / **13** | **0 of 61** | -- |
 | orangecrab_ext_pll | 20 / 10 | 2 of 154 (1%) | 1.38 mm (J2) |
-| ulx3s | 1 / 5 | 6 of 226 (3%) | 3.03 mm (U2) |
+| ulx3s | 2 / 5 | 6 of 226 (3%) | 3.03 mm (U2) |
 | glasgow_revC | 16 / 4 | 1 of 257 (0%) | 1.50 mm (J5) |
 | tigard | 9 / 8 | 4 of 85 (5%) | 1.51 mm (U5) |
 | watchy | 6 / 9 | 2 of 84 (2%) | 3.03 mm (J3) |
@@ -236,20 +236,42 @@ at in both ledgers -- corpus-wide, face demand fell from 2034 nets to 1203 --
 and it moved neither column of either table above. Both were re-derived at
 that tip with the two commands named above: every deficit / worst pair is
 identical, the 72.2% share is identical, and so is 14 of the 80 uncharged
-pairs.
+pairs. (Both of those numbers move at #862 -- see below. They are left here
+because this paragraph is a record of what was true at THAT tip, not a live
+figure.)
 
 The reason is that this page reports the ESCAPE ledger, and #850 changed only
 `routability.face_lane_ledger` -- it moved that instrument onto the rule this
-one already used, rather than changing this one. Every number here is
-re-derived at the tip and identical.
+one already used, rather than changing this one. Every number was re-derived
+at that tip and identical.
 
-Worth knowing while reading the ulx3s rows in particular: `escape` reports
-ulx3s U1 with demand 0 on all four faces and 379 of its 379 netted balls
-interior, because the box each pad is measured against is set by eight
+*After #862* (2026-09-04) **that stops being true, and both tables move.** The
+sentence above held because #850 changed only the other instrument. #862
+changes the rule BOTH share: a pad the copper box calls enclosed is now asked
+a second question -- is there a track's width of clear copper from its own
+edge to outside the part -- so the escape ledger this page reports moves too.
+Re-derived at the tip with the same two commands:
+
+* the deficit table: **ulx3s 1 / 5 -> 2 / 5**, and nothing else on any of the
+  eight boards. The freed pads are on U1, U9, SD1 and GPDI1, and one more of
+  that board's parts crosses into deficit; the worst deficit is unchanged.
+* the halo share: **72.2% -> 71.8%** already charged, and **14 of 80 -> 16 of
+  82** uncharged pairs the demand term reaches. Both denominators move because
+  a part with no face demand named no blockers, and four parts now do.
+
+**The direction is worth stating rather than leaving to the reader**: the
+share fell, so this re-measurement WEAKENS the "already charged" argument by
+0.4 points, the same way the #841 re-measurement did. It is recorded here for
+the same reason -- a page that only ever reports its numbers holding is not
+reporting.
+
+Worth knowing while reading the ulx3s rows in particular: `escape` USED to
+report ulx3s U1 with demand 0 on all four faces and 379 of its 379 netted
+balls interior, because the box each pad is measured against is set by eight
 UNNETTED 0.127 x 0.508mm alignment marks sitting 0.954mm outside the ball
-field. A bounding box cannot tell eight corner marks from an enclosing ring.
-That is older than either ledger and is filed as **#862** rather than fixed
-here; the board's `1 / 5` row above comes from its other parts.
+field, and a bounding box cannot tell eight corner marks from an enclosing
+ring. **#862** fixed that -- see the *After #862* paragraph below -- and U1
+now reads 308 interior with demand on all four faces.
 
 **What that does to the argument, stated rather than absorbed.** The
 "already charged" share falls 93.6% -> 72.2%, and the pairs the halo misses

--- a/docs/placement-predictors.md
+++ b/docs/placement-predictors.md
@@ -232,7 +232,8 @@ kit-dev-coldfire 0 / 0 -> 1 / 7, glasgow 14 / 2 -> 16 / 4, rp2350 8 / 11 ->
 
 *After #850* (2026-09-03) **nothing on this page moved, and that is a
 measurement rather than an omission.** #850 changed which face a pad points
-at in both ledgers -- corpus-wide, face demand fell from 2034 nets to 1203 --
+at in both ledgers -- corpus-wide, face demand fell from 2034 nets to 1142
+at that tip (1215 at this one, since #862 gave some of it back) --
 and it moved neither column of either table above. Both were re-derived at
 that tip with the two commands named above: every deficit / worst pair is
 identical, the 72.2% share is identical, and so is 14 of the 80 uncharged
@@ -257,7 +258,11 @@ Re-derived at the tip with the same two commands:
   that board's parts crosses into deficit; the worst deficit is unchanged.
 * the halo share: **72.2% -> 71.8%** already charged, and **14 of 80 -> 16 of
   82** uncharged pairs the demand term reaches. Both denominators move because
-  a part with no face demand named no blockers, and four parts now do.
+  a part with no face demand named no blockers, and ulx3s **GPDI1** now
+  does -- that board's named-blocker count goes 1 to 3 (`GPDI1/D51` and
+  `GPDI1/SW1`, both uncharged) and one more pair is charged on orangecrab,
+  taking the corpus total 288 to 291 and the uncharged-pair part population
+  93 to 96.
 
 **The direction is worth stating rather than leaving to the reader**: the
 share fell, so this re-measurement WEAKENS the "already charged" argument by
@@ -273,8 +278,10 @@ field, and a bounding box cannot tell eight corner marks from an enclosing
 ring. **#862** fixed that -- see the *After #862* paragraph below -- and U1
 now reads 308 interior with demand on all four faces.
 
-**What that does to the argument, stated rather than absorbed.** The
-"already charged" share falls 93.6% -> 72.2%, and the pairs the halo misses
+**What that does to the argument, stated rather than absorbed.** (This
+paragraph and the two above it describe the #841 re-measurement; the #862 one
+is in the *After #862* paragraph further up.) The
+"already charged" share falls 93.6% -> 71.8%, and the pairs the halo misses
 that the demand term WOULD reach go from 0 of 26 to 14 of 93. So the first
 claim is weaker than it was: the term is no longer measurably redundant, it is
 mostly redundant. The conclusion does not turn over -- 72% is still most of

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -1304,14 +1304,47 @@ Demand is *"nets with a pad **on** this face"*, and "on" is
 the part's pad copper (`CopperGeometry.copper`), within
 `max(pad_pitch / 2, 0.001 mm)`.
 
-**A known limit of that box, since it is a box and not an occupancy test:** a
-few small pads lying outside the main pad field set it for everything inside.
-On `ulx3s` U1 — an LFE5U BGA — eight *unnetted* 0.127 × 0.508 mm alignment
-marks sit 0.954 mm beyond the ball field on all four sides, and all 379 netted
-balls therefore read as interior, so the part reports demand 0 on every face.
-That predates both ledgers and this section does not fix it -- **#862** --
-and it is recorded here because the number is published and a reader should
-know what it means.
+**A pad the box calls enclosed gets a second question (#862).** A box cannot
+tell a few small pads lying outside the main field from a ring that encloses
+it: on `ulx3s` U1 — an LFE5U BGA — eight *unnetted* 0.127 × 0.508 mm alignment
+marks sit 0.954 mm beyond the ball field on all four sides, so the box rule
+called all 379 netted balls interior and the part reported demand 0 on every
+face. So the rule is a **union of two sufficient conditions**: a pad escapes a
+direction when the band it must cross is shallower than the tolerance **or**
+when a track's width of clear copper crosses that band, with every other pad
+of the part — *including the unnetted ones, which still block a track* —
+inflated by the clearance. A pad that escapes in no direction is interior.
+
+The box half is kept rather than replaced, and that is deliberate. Its error is
+**one-way**: widening the box only ever increases a pad's distance to it, so it
+can manufacture a false interior and never a false escape, which is exactly the
+defect above. Keeping it also keeps the tolerance doing a job the corridor
+cannot — it is the depth below which a straight-shadow model does not apply,
+because a track turns before it has travelled that far. Measured, replacing the
+box test instead *gains* interior pads on two corpus parts whose central pad
+sits 0.07 mm from the box edge.
+
+Measured over the 22 tracked boards, 97 fine-pitch refs at clearance 0.2 /
+track 0.2: interior pads **2054 → 1953**, nine refs move and every one moves
+down. `ulx3s` U1 goes **379 → 308** — 71 balls recover, more than the 67-ball
+outer ring of its 20 × 20 lattice, because some second-row balls escape through
+sites where the outer row has no ball — and its four faces then read demand
+17/11/18/16 against supply 21/31/29/31 at the finest grid, so the board gains
+real demand and is still not short. `qfn_interior_pads` U1 stays at **5**, the
+same five pads: they sit behind that QFN's unnetted south pin row and are
+genuinely enclosed.
+
+> **`interior_pads` now depends on the clearance and the track width.**
+> Before #862 it was a function of the part's geometry alone. It is not any
+> more, because "can a track leave" is a question about track width and
+> clearance — so **a number without its basis is not a number**, and every row
+> publishes the basis it ran at. The dependence is monotone (a coarser basis
+> can only add interior pads) and bounded above by `interior_pads_box`, so *an
+> interior pad that survives the box rule is a fanout fact, not a parameter
+> fact* — the same distinction `supply_routed_grid` / `supply_finest_grid`
+> draws for supply. There is no clamp: at clearance 0.05 a 0.2 mm gap between
+> QFN pins really does pass a 0.1 mm track, and `qfn_interior_pads` U1 reading
+> 0 there is the right answer for a board etched at that floor.
 
 **A pad that is not on any edge of that box is INTERIOR**, and counts toward
 no face's demand. It cannot leave sideways at any pitch — it needs a via — and
@@ -1323,9 +1356,13 @@ way `escape_band_mm` is), and the tool prints them once per ref:
 
 | key | |
 |---|---|
-| `interior_pads` | netted pads on no face — **equal to `escape_ledger`'s `interior_pads` for the same ref at the same clearance** |
+| `interior_pads` | netted pads on no face — **equal to `escape_ledger`'s `interior_pads` for the same ref at the same clearance AND the same track width** (#862 added the second term; measured, price one ledger at track 0.2 and let the other resolve orangecrab's own 0.3 and `U3` reads 227 against 223) |
 | `interior_nets` | distinct nets among them |
 | `interior_demand_nets` | the subset that had **no** pad on any face, i.e. what the four faces actually lost |
+| `interior_pads_box` | the same count under the **box rule alone** — basis-free, and the number to read when you want the fanout fact without the parameter fact |
+| `face_corridor_escapes` | how many pads the corridor freed. `interior_pads + face_corridor_escapes == interior_pads_box` is a conservation law, not a second copy: a count that falls with nothing naming where it went is how a ledger stops looking |
+| `face_corridor_clearance_mm` / `face_corridor_track_mm` | the basis the enclosure test ran at |
+| `face_corridor_source` | `caller` when the corridor ran; `unmodelled`, `no_pad_boxes` or `not_measured` naming which degradation happened instead — three different facts, not one `unknown` |
 
 The third is the one to read when a demand looks low. A net with one pad
 interior and another on a face still has to leave through that face, so it is

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -1329,7 +1329,10 @@ track 0.2: interior pads **2054 → 1953**, nine refs move and every one moves
 down. `ulx3s` U1 goes **379 → 308** — 71 balls recover, more than the 67-ball
 outer ring of its 20 × 20 lattice, because some second-row balls escape through
 sites where the outer row has no ball — and its four faces then read demand
-17/11/18/16 against supply 21/31/29/31 at the finest grid, so the board gains
+17/11/18/16 against supply 21/31/29/31 at the finest grid **as
+`check_channels` resolves that board (track 0.3 / clearance 0.25)** — demand
+is basis-invariant here but supply is not, and at 0.2/0.2 the same faces read
+43/43/40/43 — so the board gains
 real demand and is still not short. `qfn_interior_pads` U1 stays at **5**, the
 same five pads: they sit behind that QFN's unnetted south pin row and are
 genuinely enclosed.
@@ -1342,21 +1345,26 @@ genuinely enclosed.
 > can only add interior pads) and bounded above by `interior_pads_box`, so *an
 > interior pad that survives the box rule is a fanout fact, not a parameter
 > fact* — the same distinction `supply_routed_grid` / `supply_finest_grid`
-> draws for supply. There is no clamp: at clearance 0.05 a 0.2 mm gap between
-> QFN pins really does pass a 0.1 mm track, and `qfn_interior_pads` U1 reading
-> 0 there is the right answer for a board etched at that floor.
+> draws for supply. There is no clamp: `qfn_interior_pads` U1's pin rows are
+> 0.25 mm pads on a 0.5 mm pitch, so the gap between pins is 0.25 mm, and at
+> clearance 0.05 that leaves 0.25 − 2×0.05 = 0.15 mm — which really does pass
+> a 0.1 mm track. U1 reading 0 interior there is the right answer for a board
+> etched at that floor.
 
-**A pad that is not on any edge of that box is INTERIOR**, and counts toward
-no face's demand. It cannot leave sideways at any pitch — it needs a via — and
-charging a face for it blames the face for a fanout problem. On a BGA-529 that
-is 441 of 529 balls; the ledger assigns the 88 that form the perimeter.
+**A pad that escapes in no direction is INTERIOR**, and counts toward no
+face's demand. It cannot leave sideways — it needs a via — and charging a face
+for it blames the face for a fanout problem. On a BGA-529 whose balls are too
+close to pass a track between, that is 441 of 529; the ledger assigns the 88
+that form the perimeter. *(A pad not on any edge of the copper box is
+interior under the BOX HALF alone, which is what `interior_pads_box` reports
+— since #862 that is a bound on `interior_pads`, not a synonym for it.)*
 
-Three keys report it, on every row (they are part-level facts, repeated the
-way `escape_band_mm` is), and the tool prints them once per ref:
+Seven keys report it, on every row (they are part-level facts, repeated the
+way `escape_band_mm` is):
 
 | key | |
 |---|---|
-| `interior_pads` | netted pads on no face — **equal to `escape_ledger`'s `interior_pads` for the same ref at the same clearance AND the same track width** (#862 added the second term; measured, price one ledger at track 0.2 and let the other resolve orangecrab's own 0.3 and `U3` reads 227 against 223) |
+| `interior_pads` | netted pads on no face — **equal to `escape_ledger`'s `interior_pads` for the same ref at the same clearance, the same track width, and the same net population** (#862 added the track-width term; measured, price one ledger at track 0.2 and let the other resolve orangecrab's own 0.3 and `U3` reads 227 against 223). The population term is `ignore_net_ids`: this ledger has none, so a caller that drops plane rails from the escape side is comparing two different sets — on ulx3s U1 with its two plane nets ignored, 190 against 308 |
 | `interior_nets` | distinct nets among them |
 | `interior_demand_nets` | the subset that had **no** pad on any face, i.e. what the four faces actually lost |
 | `interior_pads_box` | the same count under the **box rule alone** — basis-free, and the number to read when you want the fanout fact without the parameter fact |
@@ -1383,11 +1391,21 @@ It is additive: the three in-repo readers of `ledgers`
 a key set, and the skill drivers use the tool through its exit code and its
 printed text, not its JSON.
 
+**#862 adds six more**, and it is a published-schema change for the same
+reason: `interior_pads_box`, `face_corridor_escapes`, `face_corridor_source`,
+`face_corridor_clearance_mm`, `face_corridor_track_mm`, and
+`face_pitch_mm`/`face_pitch_source` on the ESCAPE row, which #850 had put on
+the routability row only. The tool PRINTS the interior count, what the
+corridor freed, the basis and the box-rule count once per ref; the rest are
+JSON-only, which is why this table says "report" rather than "print".
+
 *Before #850* this ledger took `min` over the distance from each pad's
 **centre** to the whole-part extent edge, with no tolerance and no interior
 case, so every netted pad was demand on some face. Corpus-wide that was 2034
-face-demand nets against 1142, and 478 deficit lanes at the finest grid
-against 199; the boards where the two instruments most disagreed (ulx3s,
+face-demand nets against **1215**, and 478 deficit lanes at the finest grid
+against 199; (that first pair read 1142 at the #850 tip and #862 moved it,
+which is why it is regenerated rather than quoted — the deficit pair beside
+it did NOT move, so a reader can see which half this change touched); the boards where the two instruments most disagreed (ulx3s,
 haasoscope_pro_max, routed_output — 68 / 44 / 44 lanes short here against 0 on
 the escape ledger) now agree. Regenerate with
 `tests/measure_850_848_faces.py --table demand`, which prints the two

--- a/py_placer/placement/escape.py
+++ b/py_placer/placement/escape.py
@@ -39,6 +39,7 @@ numpy only; no networkx in the placement stack.
 """
 from __future__ import annotations
 
+import bisect
 import math
 from dataclasses import dataclass
 from typing import Dict, List, NamedTuple, Optional, Sequence, Tuple
@@ -251,6 +252,14 @@ class PartEscape:
     corridor_source: str = 'not_measured'
     corridor_clearance_mm: float = 0.0
     corridor_track_mm: float = 0.0
+    #: The TOLERANCE pitch `assign_faces` ran at, and where it came from --
+    #: NOT `pitch_mm`. They differ on a part whose pad lattice yields no
+    #: pitch: `pad_pitch` answers `inf` there and `assign_faces` substitutes
+    #: the lane. Publishing the raw one would report a basis the rule did not
+    #: use, and `float('inf')` is not JSON either -- measured, `esp_prog`'s
+    #: one-pad `Ref*` made `json.dumps(..., allow_nan=False)` raise.
+    face_pitch_mm: float = 0.0
+    face_pitch_source: str = 'unknown'
 
     @property
     def worst(self) -> Optional[FaceLedger]:
@@ -287,8 +296,11 @@ class PartEscape:
                 'face_corridor_track_mm': round(self.corridor_track_mm, 4),
                 # #850 published these on the routability row only, so until
                 # now the two instruments could not be compared on the basis
-                # they are asserted EQUAL at.
-                'face_pitch_mm': round(self.pitch_mm, 4),
+                # they are asserted EQUAL at. It is `face_pitch_mm`, the pitch
+                # the rule RAN at, not `pitch_mm`, the part's raw lattice
+                # pitch -- they differ wherever the lattice yields none.
+                'face_pitch_mm': round(self.face_pitch_mm, 4),
+                'face_pitch_source': self.face_pitch_source,
                 # Board-wide, so reported once rather than on all four faces.
                 'via_pitch_mm': round(f0.via_pitch_mm, 4) if f0 else 0.0,
                 'signal_layers': f0.signal_layers if f0 else 1,
@@ -717,10 +729,11 @@ def face_of(pad, rect, pitch, pad_box=None,
     does not apply, because a track leaving a pad turns before it has
     travelled that far. Drop it and orangecrab_ext_pll U10 and
     rp2350_fpga_eensy_prePlane U4 each GAIN an interior pad -- both a 0.325mm
-    5-pad part whose central 0.82mm GND pad sits 0.0699mm from the copper box
-    on west and east, plainly on the boundary, whose axis-aligned corridor is
-    nevertheless closed by its flanking pads once they are inflated by
-    clearance. (That divergence is basis-dependent and invisible at clearance
+    part with 5 copper pads, whose central GND pad (0.58 x 0.58 at 45 degrees,
+    so an 0.8202mm axis-aligned extent, which is what this test measures) sits
+    0.0699mm from the copper box on west and east, plainly on the boundary,
+    and whose axis-aligned corridor is nevertheless closed by its flanking
+    pads once they are inflated by clearance. (That divergence is basis-dependent and invisible at clearance
     0.09, where the two rules agree exactly; it appears at 0.20.)
 
     Because the union only ADDS escapes, the corridor is consulted only for
@@ -765,6 +778,25 @@ def face_of(pad, rect, pitch, pad_box=None,
     return None
 
 
+class KeyList(object):
+    """A read-only view of `seq` projected onto element `key`, for `bisect`.
+
+    `bisect` has no `key=` before Python 3.10 and this module supports
+    older interpreters; a projected view costs nothing and needs no copy.
+    """
+    __slots__ = ('seq', 'key')
+
+    def __init__(self, seq, key):
+        self.seq = seq
+        self.key = key
+
+    def __len__(self):
+        return len(self.seq)
+
+    def __getitem__(self, i):
+        return self.seq[i][self.key]
+
+
 class PadCorridors(object):
     """One part's own pad copper, as the field each of its pads must leave.
 
@@ -781,7 +813,7 @@ class PadCorridors(object):
     Built ONCE per part: `obstacles` is every copper pad rect the part has,
     including the UNNETTED ones. That is deliberate and it is the distinction
     a previous attempt at #862 got wrong (`_assignment_rect`, reverted in
-    e1f233b4): an unnetted pad may not DEMAND a lane, which is a fact about
+    39ca0b98): an unnetted pad may not DEMAND a lane, which is a fact about
     demand, and it still BLOCKS a track, which is a fact about escape. Two
     populations for two questions. Measured on `qfn_interior_pads` U1 -- the
     fixture that exists for this case -- pads 34-37 sit 1.075mm inside the
@@ -795,20 +827,54 @@ class PadCorridors(object):
     Its row-mates are beside it rather than in front of it and are skipped for
     the same reason.
     """
-    __slots__ = ('rect', 'obstacles', 'clearance', 'track_width')
+    __slots__ = ('rect', 'obstacles', 'clearance', 'track_width',
+                 '_by_x', '_by_y', '_wx', '_wy')
 
     def __init__(self, rect, obstacles, clearance, track_width):
         self.rect = rect
         self.obstacles = obstacles
         self.clearance = float(clearance)
         self.track_width = float(track_width)
+        # A CANDIDATE INDEX, and it is exact rather than a heuristic. Only
+        # obstacles whose ALONG span overlaps the pad's strip can contribute
+        # an interval at all -- `free_run` clips every one of them to
+        # `[lo, hi]` and drops the empties -- so pre-selecting them changes
+        # no answer and is asserted to change none.
+        #
+        # It is worth having because the naive form is O(pads^2 * 4) per
+        # part and lands hardest where it buys least: haasoscope's U3 is a
+        # BGA-529 with 441 interior balls and NOTHING to rescue, and it paid
+        # 441 * 4 * 529 ~ 0.9M inner iterations for that answer -- measured,
+        # `assign_faces` on it went 0.006s -> 0.700s, and `escape_ledger` on
+        # the board 12x, on a page where `options.escape_layer_gain` calls
+        # the ledger six times per invocation.
+        #
+        # Sorted by along-min, with the widest obstacle recorded so BOTH ends
+        # of the candidate window can be bisected: an obstacle overlaps
+        # `[lo2, hi2]` only if its along-min is in `[lo2 - widest, hi2]`.
+        # On a ball grid that is one column rather than the whole part.
+        self._by_x = sorted(obstacles, key=lambda r: r[0])
+        self._by_y = sorted(obstacles, key=lambda r: r[1])
+        self._wx = max((r[2] - r[0] for r in obstacles), default=0.0)
+        self._wy = max((r[3] - r[1] for r in obstacles), default=0.0)
+
+    def _candidates(self, lo, hi, horizontal):
+        """The obstacles that can possibly clip into `[lo, hi]`."""
+        idx, widest, key = ((self._by_x, self._wx, 0) if horizontal
+                            else (self._by_y, self._wy, 1))
+        lo2 = lo - self.clearance
+        hi2 = hi + self.clearance
+        a = bisect.bisect_left(KeyList(idx, key), lo2 - widest)
+        b = bisect.bisect_right(KeyList(idx, key), hi2)
+        return idx[a:b]
 
     def clear(self, face, pad_box):
         """Can a track of `track_width` leave `pad_box` straight out `face`?"""
         lo, hi, band, horizontal = pad_band(self.rect, face, pad_box)
         if band[1] - band[0] <= 0.0:
             return True          # already on that edge: nothing to cross
-        run = free_run(lo, hi, band, horizontal, self.obstacles,
+        run = free_run(lo, hi, band, horizontal,
+                       self._candidates(lo, hi, horizontal),
                        grow=self.clearance)
         # The epsilon is the caller's half of the trap `FREE_RUN_EPS`
         # documents: a nominally 0.4mm pad's span subtracts to
@@ -1515,7 +1581,9 @@ def part_escape(pcb_data, ref, *, pitch_mm: Optional[float] = None,
                       interior_pads_box=interior_box,
                       corridor_source=asg.corridor_source,
                       corridor_clearance_mm=asg.corridor_clearance_mm,
-                      corridor_track_mm=asg.corridor_track_mm)
+                      corridor_track_mm=asg.corridor_track_mm,
+                      face_pitch_mm=asg.pitch_mm,
+                      face_pitch_source=asg.pitch_source)
 
 
 def escape_ledger(pcb_data, *, refs: Optional[Sequence[str]] = None,

--- a/py_placer/placement/escape.py
+++ b/py_placer/placement/escape.py
@@ -1262,6 +1262,18 @@ def pad_band(rect, face, pad_box):
     from it is fragile by construction.
 
     A band of zero depth means the pad is already on that edge of the box.
+
+    A STATED LIMIT, because it is a cliff rather than a gradient: since the
+    strip IS the pad's own span, a pad NARROWER than `track_width` can never
+    be rescued, however empty the field in front of it. Physically a track
+    wider than its pad is routine (it necks down at the joint); this model
+    says no. Measured on ulx3s U1, whose balls are 0.4mm wide, at clearance
+    0.2: the corridor frees 71 balls at every track width up to and including
+    0.400, and 0 at 0.401. `check_channels` floors the track UP to the fab
+    floor, which can only move toward that edge. Widening the strip to admit
+    a necked track is a real change and would need its own evidence -- the
+    measured alternatives (a pitch-wide window, a zero threshold) both break
+    `qfn_interior_pads`, so it is not a one-line relaxation.
     """
     minx, miny, maxx, maxy = rect
     px0, py0, px1, py1 = pad_box

--- a/py_placer/placement/escape.py
+++ b/py_placer/placement/escape.py
@@ -657,7 +657,8 @@ def _part_rect(fp) -> Tuple[float, float, float, float]:
     return min(xs), min(ys), max(xs), max(ys)
 
 
-def face_of(pad, rect, pitch, pad_box=None) -> Optional[str]:
+def face_of(pad, rect, pitch, pad_box=None,
+            corridor=None) -> Optional[str]:
     """Which face a pad escapes through, or None when it is interior.
 
     A pad on the bounding box escapes through the side it sits on; a corner pad
@@ -681,6 +682,40 @@ def face_of(pad, rect, pitch, pad_box=None) -> Optional[str]:
     pad, or a part whose model could not be built. It degrades to the pad's
     centre, which is what this function always did.
 
+    `corridor` is #862's second, independent escape witness, and it makes
+    this function a UNION of two SUFFICIENT conditions rather than one test:
+    a pad escapes direction `f` when the band it must cross is shallower than
+    `tol`, OR when `PadCorridors.clear` finds a track's width of clear copper
+    across that band. `corridor=None` is byte-identical to the rule as it
+    stood before #862.
+
+    WHY A UNION, and why the box half is kept rather than replaced. The box
+    test's error is ONE-WAY: widening `rect` -- which is all an outlying
+    unnetted pad can do -- only ever INCREASES every distance in `d`, so the
+    box rule can manufacture a false INTERIOR and never a false ESCAPE. #862
+    is exactly that one direction (eight unnetted alignment marks 0.954mm
+    outside ulx3s U1's ball field, tolerance 0.400, all 379 netted balls
+    interior), so a second sufficient condition corrects it without taking on
+    a new error, and `interior_pads` is provably NON-INCREASING against the
+    rule before it.
+
+    Replacing the box test instead was measured and is worse. `tol` is not
+    noise: it is the depth below which the corridor's straight-shadow model
+    does not apply, because a track leaving a pad turns before it has
+    travelled that far. Drop it and orangecrab_ext_pll U10 and
+    rp2350_fpga_eensy_prePlane U4 each GAIN an interior pad -- both a 0.325mm
+    5-pad part whose central 0.82mm GND pad sits 0.0699mm from the copper box
+    on west and east, plainly on the boundary, whose axis-aligned corridor is
+    nevertheless closed by its flanking pads once they are inflated by
+    clearance. (That divergence is basis-dependent and invisible at clearance
+    0.09, where the two rules agree exactly; it appears at 0.20.)
+
+    Because the union only ADDS escapes, the corridor is consulted only for
+    the pads the box half rejects. That is a PROOF, not an optimisation: when
+    `near <= tol` the argmin direction is itself in the escaping set, so the
+    filtered argmin is the unfiltered one and the answer is unchanged
+    whatever the corridor would say about the other three directions.
+
     PUBLIC since #850, because `routability.face_lane_ledger` bucketed pads to
     faces with its own rule -- pad CENTRES against the hole-inclusive `rect`,
     no tolerance, no interior bucket -- and neither file recorded that the
@@ -696,14 +731,76 @@ def face_of(pad, rect, pitch, pad_box=None) -> Optional[str]:
     d = {'west': px0 - minx, 'east': maxx - px1,
          'north': py0 - miny, 'south': maxy - py1}
     near = min(d.values())
+    esc = FACES
     if near > tol:
-        return None
+        if corridor is None or pad_box is None:
+            return None
+        # #862: the box said enclosed. Ask the copper instead -- for each
+        # direction, is there a clear corridor from this pad's edge to
+        # outside the part. A pad the corridor rescues is assigned to the
+        # nearest REACHABLE edge, which is the same argmin this function has
+        # always taken, over a filtered set.
+        esc = tuple(f for f in FACES if corridor.clear(f, pad_box))
+        if not esc:
+            return None
+        near = min(d[f] for f in esc)
     # Ties resolve by FACES order, not by dict order, so the answer does not
     # depend on how the pads were enumerated.
-    for f in FACES:
+    for f in esc:
         if abs(d[f] - near) < 1e-9:
             return f
     return None
+
+
+class PadCorridors(object):
+    """One part's own pad copper, as the field each of its pads must leave.
+
+    #862. `face_of`'s box test asks whether a pad is on the part's copper
+    bounding box; a box cannot tell a few small pads lying outside the main
+    field from a ring that encloses it. This asks the question the box cannot:
+    for one direction, is there a clear corridor at least `track_width` wide
+    from this pad's own copper edge to outside the part.
+
+    It is `span_eaten`'s arithmetic turned on the part's OWN pads instead of
+    its neighbours -- via `free_run`, which answers the largest CONTIGUOUS
+    run rather than the total, because two half-gaps do not make a lane.
+
+    Built ONCE per part: `obstacles` is every copper pad rect the part has,
+    including the UNNETTED ones. That is deliberate and it is the distinction
+    a previous attempt at #862 got wrong (`_assignment_rect`, reverted in
+    e1f233b4): an unnetted pad may not DEMAND a lane, which is a fact about
+    demand, and it still BLOCKS a track, which is a fact about escape. Two
+    populations for two questions. Measured on `qfn_interior_pads` U1 -- the
+    fixture that exists for this case -- pads 34-37 sit 1.075mm inside the
+    part's south copper edge behind the QFN's unnetted south pin row, and
+    dropping unnetted copper reclassifies four of its five interior pads as
+    escaping south.
+
+    The pad under test is not filtered out of `obstacles`, and does not need
+    to be: `free_run`'s band overlap is STRICT, and the band starts at that
+    pad's own edge, so its rect touches the band at one point and is skipped.
+    Its row-mates are beside it rather than in front of it and are skipped for
+    the same reason.
+    """
+    __slots__ = ('rect', 'obstacles', 'clearance', 'track_width')
+
+    def __init__(self, rect, obstacles, clearance, track_width):
+        self.rect = rect
+        self.obstacles = obstacles
+        self.clearance = float(clearance)
+        self.track_width = float(track_width)
+
+    def clear(self, face, pad_box):
+        """Can a track of `track_width` leave `pad_box` straight out `face`?"""
+        lo, hi, band, horizontal = pad_band(self.rect, face, pad_box)
+        if band[1] - band[0] <= 0.0:
+            return True          # already on that edge: nothing to cross
+        run = free_run(lo, hi, band, horizontal, self.obstacles,
+                       grow=self.clearance)
+        # The epsilon is the caller's half of the trap `FREE_RUN_EPS`
+        # documents: a nominally 0.4mm pad's span subtracts to
+        # 0.39999999999997726, so a bare `>=` refuses a track that fits.
+        return run >= self.track_width - FREE_RUN_EPS
 
 
 class FaceAssignment(NamedTuple):
@@ -716,9 +813,25 @@ class FaceAssignment(NamedTuple):
     #: The tolerance pitch `face_of` ran at, and where it came from.
     pitch_mm: float
     pitch_source: str            # 'pad_lattice' | 'lane_fallback'
+    #: The answer the BOX half alone gave, index-aligned with `faces` because
+    #: both are built in one pass over `fp.pads` (#862). NOT a count: the two
+    #: ledgers count over different populations -- `part_escape` drops
+    #: `ignore_net_ids`, `face_lane_ledger` applies an owner filter -- so a
+    #: count taken here would close the identity
+    #: `interior + rescued == interior_box` on neither of them.
+    box_faces: Tuple[Optional[str], ...] = ()
+    #: Where the corridor basis came from, so a reader can tell "nobody
+    #: asked" from "this part has no pad model" (#862). One of 'caller',
+    #: 'not_measured', 'unmodelled', 'no_pad_boxes'.
+    corridor_source: str = 'not_measured'
+    #: The basis the corridor ran at. `interior_pads` is a function of these
+    #: two since #862, where before it was a function of geometry alone.
+    corridor_clearance_mm: float = 0.0
+    corridor_track_mm: float = 0.0
 
 
-def assign_faces(fp, geom, *, lane_mm, fallback_rect=None) -> FaceAssignment:
+def assign_faces(fp, geom, *, lane_mm, fallback_rect=None,
+                 clearance=None, track_width=None) -> FaceAssignment:
     """THE face rule: which face each of `fp`'s pads escapes through.
 
     One function because the disagreement #850 names is not in `face_of`'s
@@ -758,12 +871,55 @@ def assign_faces(fp, geom, *, lane_mm, fallback_rect=None) -> FaceAssignment:
     if pitch == float('inf'):
         pitch, source = lane_mm, 'lane_fallback'
     rect = fallback_rect if geom is None else geom.copper
+
+    # #862's basis. It is a PAIR and it is refused rather than half-filled:
+    # a clearance with no threshold and a threshold with no inflation are
+    # both silently plausible wrong numbers, and this is the one function
+    # both lane ledgers share, so a check here cannot be present in one
+    # instrument and missing from the other.
+    corridor = None
+    csource = 'not_measured'
+    if clearance is None and track_width is None:
+        pass                                  # the pre-#862 answer, by request
+    elif clearance is None or track_width is None:
+        raise ValueError(
+            'assign_faces: the corridor basis is a PAIR (clearance={}, '
+            'track_width={}); one without the other would inflate obstacles '
+            'at a clearance nobody chose, or threshold a run at a width '
+            'nobody chose'.format(clearance, track_width))
+    elif track_width <= 0 or clearance < 0:
+        raise ValueError(
+            'assign_faces: track_width must be positive and clearance '
+            'non-negative (got {}, {}); a zero-width track asks a different '
+            'question -- measured, thresholding at zero takes tigard U3 from '
+            '18 interior pads to 12, glasgow_revC U1 from 27 to 26 and '
+            'qfn_interior_pads U1 from 5 to 0'.format(track_width, clearance))
+    elif geom is None:
+        csource = 'unmodelled'
+    elif not geom.pads:
+        # A part whose pad model could not be built has no obstacles to
+        # measure and no per-pad rects to measure them against. Synthesising
+        # either would be a fiction; the box half keeps today's answer.
+        csource = 'no_pad_boxes'
+    else:
+        corridor = PadCorridors(rect, tuple(geom.pads.values()),
+                                clearance, track_width)
+        csource = 'caller'
+
     out = []
+    boxes = []
     for pad in (fp.pads or []):
         box = None if geom is None else _pad_box(geom, pad)
-        out.append((pad, face_of(pad, rect, pitch, pad_box=box)))
+        bf = face_of(pad, rect, pitch, pad_box=box)
+        boxes.append(bf)
+        if bf is None and corridor is not None and box is not None:
+            bf = face_of(pad, rect, pitch, pad_box=box, corridor=corridor)
+        out.append((pad, bf))
     return FaceAssignment(faces=tuple(out), pitch_mm=pitch,
-                          pitch_source=source)
+                          pitch_source=source, box_faces=tuple(boxes),
+                          corridor_source=csource,
+                          corridor_clearance_mm=float(clearance or 0.0),
+                          corridor_track_mm=float(track_width or 0.0))
 
 
 def _face_geometry(rect, face) -> Tuple[float, float, float, float]:

--- a/py_placer/placement/escape.py
+++ b/py_placer/placement/escape.py
@@ -241,6 +241,16 @@ class PartEscape:
     interior_pads: int        # need a via, not a lane -- a FANOUT signal
     interior_nets: Tuple[int, ...]
     plane_layers_found: Tuple[str, ...] = ()   # #700, disclosure only
+    #: #862. `interior_pads` under the BOX rule alone -- the fanout fact
+    #: without the parameter fact, since `interior_pads` now moves with the
+    #: clearance and the track width and this cannot.
+    interior_pads_box: int = 0
+    #: The basis the enclosure corridor ran at, published for the same reason
+    #: the escape band's is: two instruments that price it differently must
+    #: be able to be told apart from two boards that differ.
+    corridor_source: str = 'not_measured'
+    corridor_clearance_mm: float = 0.0
+    corridor_track_mm: float = 0.0
 
     @property
     def worst(self) -> Optional[FaceLedger]:
@@ -266,6 +276,19 @@ class PartEscape:
                 'faces': [f.to_dict() for f in self.faces],
                 'interior_pads': self.interior_pads,
                 'interior_nets': len(self.interior_nets),
+                # #862, and named identically to `face_lane_ledger`'s rows so
+                # the two instruments' JSON can be diffed key for key.
+                'interior_pads_box': self.interior_pads_box,
+                'face_corridor_escapes': (self.interior_pads_box
+                                          - self.interior_pads),
+                'face_corridor_source': self.corridor_source,
+                'face_corridor_clearance_mm': round(
+                    self.corridor_clearance_mm, 4),
+                'face_corridor_track_mm': round(self.corridor_track_mm, 4),
+                # #850 published these on the routability row only, so until
+                # now the two instruments could not be compared on the basis
+                # they are asserted EQUAL at.
+                'face_pitch_mm': round(self.pitch_mm, 4),
                 # Board-wide, so reported once rather than on all four faces.
                 'via_pitch_mm': round(f0.via_pitch_mm, 4) if f0 else 0.0,
                 'signal_layers': f0.signal_layers if f0 else 1,
@@ -1459,10 +1482,16 @@ def part_escape(pcb_data, ref, *, pitch_mm: Optional[float] = None,
                        clearance=clr, track_width=tw)
     demand: Dict[str, List[int]] = {f: [] for f in FACES}
     interior: List[int] = []
-    for pad, face in asg.faces:
+    interior_box = 0
+    for i, (pad, face) in enumerate(asg.faces):
         nid = getattr(pad, 'net_id', 0)
         if not nid or nid in ignored:
             continue
+        # #862: the box-rule count over the SAME population this one uses --
+        # `ignore_net_ids` dropped, which is why it cannot be taken inside
+        # `assign_faces` where neither caller's filter is known.
+        if asg.box_faces and asg.box_faces[i] is None:
+            interior_box += 1
         if face is None:
             interior.append(nid)
         else:
@@ -1492,7 +1521,11 @@ def part_escape(pcb_data, ref, *, pitch_mm: Optional[float] = None,
     return PartEscape(ref=ref, pitch_mm=pitch, faces=tuple(faces),
                       interior_pads=len(interior),
                       interior_nets=tuple(sorted(set(interior))),
-                      plane_layers_found=tuple(plane_layers_found or ()))
+                      plane_layers_found=tuple(plane_layers_found or ()),
+                      interior_pads_box=interior_box,
+                      corridor_source=asg.corridor_source,
+                      corridor_clearance_mm=asg.corridor_clearance_mm,
+                      corridor_track_mm=asg.corridor_track_mm)
 
 
 def escape_ledger(pcb_data, *, refs: Optional[Sequence[str]] = None,

--- a/py_placer/placement/escape.py
+++ b/py_placer/placement/escape.py
@@ -336,16 +336,6 @@ def pad_pitch(fp) -> float:
     return min(_min_step(xs), _min_step(ys))
 
 
-def has_interior_pads(fp) -> bool:
-    xs = sorted({round(p.local_x, 3) for p in fp.pads})
-    ys = sorted({round(p.local_y, 3) for p in fp.pads})
-    if len(xs) < 3 or len(ys) < 3:
-        return False
-    minx, maxx, miny, maxy = xs[0], xs[-1], ys[0], ys[-1]
-    return any(minx < round(p.local_x, 3) < maxx
-               and miny < round(p.local_y, 3) < maxy for p in fp.pads)
-
-
 def fine_pitch_parts(pcb_data, min_pads: int = MIN_PADS) -> List[str]:
     """Refs worth a lane ledger, by PITCH and geometry -- not by pin count.
 

--- a/py_placer/placement/escape.py
+++ b/py_placer/placement/escape.py
@@ -1376,6 +1376,7 @@ def part_escape(pcb_data, ref, *, pitch_mm: Optional[float] = None,
                 containers: Optional[set] = None,
                 obstruction_rects: Optional[Dict[str, Tuple]] = None,
                 clearance: Optional[float] = None,
+                track_width: Optional[float] = None,
                 pcb_file: Optional[str] = None) -> PartEscape:
     """The full per-face ledger for one part.
 
@@ -1422,10 +1423,17 @@ def part_escape(pcb_data, ref, *, pitch_mm: Optional[float] = None,
     # lane by hand while this reads the board. `escape_ledger` is where they
     # ARE tied -- it resolves `clr` once and passes both -- which is the path
     # every production caller takes.
+    # #862: the enclosure basis is a PAIR, and it is resolved ONCE here
+    # rather than inside the `obstruction_rects is None` branch, where the
+    # track width used to be read and thrown away. `interior_pads` is a
+    # function of these two now -- "can a track leave this pad" is a question
+    # about track width and clearance -- so a caller that reached this entry
+    # point without them would silently grade the enclosure at
+    # `routing_defaults`, which is the #847 failure exactly.
+    tw, clr = track_width, clearance
+    if tw is None or clr is None:
+        tw, clr = lane_pitch_parts(pcb_data, pcb_file, tw, clr)
     if obstruction_rects is None:
-        clr = clearance
-        if clr is None:
-            _tw, clr = lane_pitch_parts(pcb_data, pcb_file)
         obstruction_rects = board_copper_geometry(pcb_data, clr)
 
     # #841: the part's OWN faces are measured on the same copper box it
@@ -1441,7 +1449,14 @@ def part_escape(pcb_data, ref, *, pitch_mm: Optional[float] = None,
     # pairing this loop did inline -- `copper` for assignment, `rect` for the
     # face geometry below -- and the arm that says so is a bit-identical sweep
     # of every published escape number over the tracked corpus.
-    asg = assign_faces(fp, own, lane_mm=lane, fallback_rect=rect)
+    # #862: the enclosure half of that rule needs the basis a track is
+    # actually priced at. It is `tw`/`clr` and NOT `lane`, deliberately:
+    # `lane` is `track + clearance` here and a grid-QUANTIZED pitch in
+    # `routability`, so pricing the corridor off it would make the two
+    # ledgers disagree on `interior_pads` for every board -- the one number
+    # #850 exists to have them agree on.
+    asg = assign_faces(fp, own, lane_mm=lane, fallback_rect=rect,
+                       clearance=clr, track_width=tw)
     demand: Dict[str, List[int]] = {f: [] for f in FACES}
     interior: List[int] = []
     for pad, face in asg.faces:
@@ -1525,7 +1540,8 @@ def escape_ledger(pcb_data, *, refs: Optional[Sequence[str]] = None,
                        via_pitch_mm=vpitch, signal_layers=nsig,
                        signal_layers_source=source, plane_layers_found=planes,
                        sides=sides, containers=containers,
-                       obstruction_rects=orects)
+                       obstruction_rects=orects,
+                       clearance=clr, track_width=tw)
            for r in targets if r in pcb_data.footprints]
     # Sorted by the OWN-LAYER deficit, unchanged. It selects `escape_lanes[:10]`
     # and board_brief's `worst[:WORST_N]`, and feeds

--- a/py_placer/placement/escape.py
+++ b/py_placer/placement/escape.py
@@ -936,6 +936,112 @@ def span_eaten(lo, hi, band, horizontal, obstacles):
     return min(blocked, hi - lo), order
 
 
+#: The threshold epsilon. A pad's own copper span is the strip a track has to
+#: fit in, and that span is a SUBTRACTION of two parsed millimetre
+#: coordinates: ulx3s U1's 0.4mm balls give `139.08 - 138.68 ==
+#: 0.39999999999997726`, which is `< 0.4` and NOT `>= 0.4`. Measured, a bare
+#: `>=` puts the whole outer ring of that BGA back in the interior bucket at
+#: track 0.4 while answering correctly at track 0.2 -- a rule that works at
+#: one basis and silently fails at another, which is the exact failure mode
+#: this module keeps recording. Same 1e-9 `face_of`'s tie block already uses.
+FREE_RUN_EPS = 1e-9
+
+
+def free_run(lo, hi, band, horizontal, obstacles, grow=0.0):
+    """The largest CONTIGUOUS stretch of [lo, hi] that no obstacle covers.
+
+    `span_eaten`'s other question on the same interval arithmetic. That one
+    asks how much of a span is gone; this asks whether any ONE piece of it is
+    still wide enough for a track. A sum cannot answer that -- three 0.1mm
+    gaps and one 0.3mm gap eat the same total and only one of them passes a
+    0.3mm track. Measured over the tracked corpus at clearance 0.09, taking
+    the total instead of the largest run moves nine refs and breaks both of
+    #862's oracles (`qfn_interior_pads` U1 5 -> 2, `tigard` U3 18 -> 16,
+    `glasgow_revC` U1 27 -> 26) -- and it is a value NO-OP at clearance 0.20
+    and 0.25, so a test written at the census basis alone cannot see the
+    difference.
+
+    A SIBLING of `span_eaten` rather than a flag on it. Three differences, and
+    each is a reason not to share a loop:
+
+    * **The band overlap is STRICT** (`>` / `<`, not `>=` / `<=`).
+      `span_eaten`'s obstacles are OTHER parts, which may legitimately touch
+      the band edge; these are the escaping part's OWN pads, and the band
+      starts at the escaping pad's own edge. An inclusive test therefore
+      charges the pad against ITSELF -- its rect touches the band at exactly
+      one point and covers its own strip end to end, so nothing would ever
+      escape -- and against its own ROW-MATES, which are beside it, not in
+      front of it. Strictness removes both exactly, with no self-exclusion
+      bookkeeping.
+    * **`grow` inflates each obstacle on the ALONG axis** before clipping,
+      because a track may not touch foreign copper: the run that has to hold
+      `track_width` is the gap minus one clearance on each side. It is
+      deliberately NOT applied across the band -- the band's far edge is the
+      part's copper box, which is the union of these same rects, so there is
+      nothing beyond it to grow into.
+    * **It returns a length, not `(blocked, by_ref)`.** Nothing here needs to
+      name a blocker; the blocker is the part itself.
+
+    Coordinates are `span_eaten`'s: mm, board frame, `horizontal=True` when
+    the run is measured along x. Returns `hi - lo` when nothing intersects.
+    """
+    intervals = []
+    for rect in obstacles:
+        oxmin, oymin, oxmax, oymax = rect
+        across = (oymin, oymax) if horizontal else (oxmin, oxmax)
+        if across[1] <= band[0] or across[0] >= band[1]:
+            continue                              # not in this pad's way
+        along = (oxmin, oxmax) if horizontal else (oymin, oymax)
+        a, b = max(lo, along[0] - grow), min(hi, along[1] + grow)
+        if b > a:
+            intervals.append((a, b))
+
+    intervals.sort()
+    best = 0.0
+    cur = lo
+    for a, b in intervals:
+        if a > cur:
+            best = max(best, a - cur)
+        cur = max(cur, b)
+    return max(best, hi - cur)
+
+
+def pad_band(rect, face, pad_box):
+    """`(lo, hi, band, horizontal)` for ONE pad's straight way out of `rect`.
+
+    The inward twin of `face_band`. That one looks OUTSIDE the part, for a
+    neighbour's body in the escape band; this looks INSIDE it, from the pad's
+    own copper edge to the part's own copper edge, for the part's own copper
+    -- the other half of "can a track leave this pad", and the half a bounding
+    box cannot answer. #862: eight unnetted alignment marks 0.954mm outside a
+    BGA's ball field set that box for all 379 balls, and a box cannot tell
+    eight corner dots from an enclosing ring.
+
+    `lo, hi` is the pad's OWN span on the perpendicular axis, NOT a
+    pitch-wide window centred on it. Measured, the window form is unstable:
+    at clearance 0.09 it takes ulx3s U1 to 0 interior pads, because a window
+    wider than the pad lets a pad claim a corridor its own copper does not sit
+    in front of. It is also why `pad_pitch` appears nowhere in this
+    arithmetic -- it is a MIN-consecutive-gap over projected local
+    coordinates and reads 0.100 on `qfn_interior_pads`, so anything derived
+    from it is fragile by construction.
+
+    A band of zero depth means the pad is already on that edge of the box.
+    """
+    minx, miny, maxx, maxy = rect
+    px0, py0, px1, py1 = pad_box
+    horizontal = face in ('north', 'south')
+    lo, hi = (px0, px1) if horizontal else (py0, py1)
+    if face == 'north':
+        band = (miny, py0)
+    elif face == 'south':
+        band = (py1, maxy)
+    elif face == 'west':
+        band = (minx, px0)
+    else:
+        band = (px1, maxx)
+    return lo, hi, band, horizontal
+
 #: The escape band's two terms, named so a reader can tell which one decided.
 #: `4 x lane` is the model ("a track has room to turn past four lanes of
 #: depth"); the 1.0mm FLOOR is the term nobody has re-derived (#847) and it was

--- a/py_placer/placement/legality.py
+++ b/py_placer/placement/legality.py
@@ -2407,7 +2407,7 @@ class CopperGeometry(NamedTuple):
     #: HOLES ARE IN BOTH BOXES (see `extent_local_side`): a drill removes
     #: copper on every layer, so it is not a side's to exclude. That is also
     #: why this is very nearly inert -- measured over the tracked corpus at
-    #: clearance 0.2, 18 (ref, side) boxes differ from `rect` at all, 3 are
+    #: clearance 0.2, 20 (ref, side) boxes differ from `rect` at all, 3 are
     #: ever charged against a face in deficit, and no board's reported deficit
     #: moves. It is correct and it is cheap; it is here to be right before a
     #: board exercises it, not because a board does today.

--- a/py_placer/placement/routability.py
+++ b/py_placer/placement/routability.py
@@ -1199,12 +1199,18 @@ def face_lane_ledger(pcb_data, ref: str, *, clearance: float,
 
     demand: Dict[str, set] = {f: set() for f in faces}
     interior_pads = 0
+    interior_box = 0
     interior_nets: set = set()
     interior_demand: set = set()
-    for pad, face in asg.faces:
+    for i, (pad, face) in enumerate(asg.faces):
         nid = pad.net_id
         if not nid:
             continue
+        # #862: the same count under the BOX rule alone, over the same
+        # population, so the row can publish both. `interior_pads` is now a
+        # function of clearance and track width; this one is not.
+        if asg.box_faces and asg.box_faces[i] is None:
+            interior_box += 1
         # GEOMETRY FIRST, THE NET FILTER SECOND. The other way round, the
         # published interior count would be over the owner-filtered subset and
         # would not be comparable with `escape.PartEscape.interior_pads`,
@@ -1356,6 +1362,32 @@ def face_lane_ledger(pcb_data, ref: str, *, clearance: float,
                     'interior_pads': interior_pads,
                     'interior_nets': len(interior_nets),
                     'interior_demand_nets': len(interior_demand),
+                    # #862: the same count under the BOX rule alone. Read it
+                    # when you want the fanout fact without the parameter
+                    # fact -- `interior_pads` moves with the clearance and
+                    # the track width now, and this one cannot, because
+                    # `CopperGeometry.copper` carries neither.
+                    #
+                    # `interior_pads + face_corridor_escapes ==
+                    # interior_pads_box` over this ledger's own population,
+                    # which is a conservation law rather than a second copy:
+                    # a pad that leaves the interior bucket has to be
+                    # accounted for somewhere, and a demand that fell with
+                    # nothing naming where it went is how a ledger stops
+                    # looking and reads as a fix.
+                    'interior_pads_box': interior_box,
+                    'face_corridor_escapes': interior_box - interior_pads,
+                    # ...and the basis the enclosure test ran at, so a reader
+                    # diffing two runs can tell a placement that moved from a
+                    # basis that moved. `source` says 'caller' when the
+                    # corridor actually ran, and names the degradation
+                    # otherwise ('unmodelled', 'no_pad_boxes',
+                    # 'not_measured') rather than reporting one `unknown`
+                    # for three different facts.
+                    'face_corridor_source': asg.corridor_source,
+                    'face_corridor_clearance_mm': round(
+                        asg.corridor_clearance_mm, 4),
+                    'face_corridor_track_mm': round(asg.corridor_track_mm, 4),
                     # ...and the tolerance the face rule ran at. The two
                     # ledgers resolve different LANES (#847) and this is a
                     # second, separate basis: the part's own pad pitch, or
@@ -1403,7 +1435,15 @@ def face_lane_ledger(pcb_data, ref: str, *, clearance: float,
     #
     # ...and since #850 the FACE RULE is shared too -- `escape.assign_faces`,
     # so a pad points at the same face in both instruments and an interior pad
-    # is interior in both. `interior_pads` on the rows above equals
+    # is interior in both. #862 ADDED A TERM TO THAT PRECONDITION: since the
+    # enclosure test asks whether a TRACK can leave, `interior_pads` is a
+    # function of the track width as well as the clearance, so the claim below
+    # holds for the same ref at the same clearance AND THE SAME TRACK WIDTH.
+    # Measured, that is not a formality -- price this ledger at track 0.2 and
+    # let `part_escape` resolve orangecrab_ext_pll's own 0.3, and U3 reads 227
+    # against this ledger's 223, one ref out of 97.
+    #
+    # `interior_pads` on the rows above equals
     # `escape.PartEscape.interior_pads` for the same ref at the same
     # clearance, which is the assertion that says so.
     #

--- a/py_placer/placement/routability.py
+++ b/py_placer/placement/routability.py
@@ -1232,7 +1232,10 @@ def face_lane_ledger(pcb_data, ref: str, *, clearance: float,
     # A net with one pad interior and another on a face is NOT lost demand --
     # it still has to leave through that face. Only the nets with no pad on
     # any face are.
-    interior_demand -= set().union(*demand.values()) if demand else set()
+    # `demand` is a four-key dict literal, so it is always truthy and the
+    # guard this line used to carry never bound. Dropped rather than left
+    # to read as a considered edge case.
+    interior_demand -= set().union(*demand.values())
 
     pitch_fine = _quantized_pitch(track_width, clearance,
                                   FINEST_LEGAL_GRID_MM)

--- a/py_placer/placement/routability.py
+++ b/py_placer/placement/routability.py
@@ -1188,7 +1188,14 @@ def face_lane_ledger(pcb_data, ref: str, *, clearance: float,
     # only assignment moved. That separation is what makes it checkable that
     # this commit changed the demand model and nothing else.
     own = ctx.geom.get(ref)
-    asg = _assign_faces(fp, own, lane_mm=pitch_routed, fallback_rect=ext)
+    # #862: `lane_mm` stays the PITCH fallback only. The enclosure basis is
+    # the raw `track_width` / `clearance` this ledger was called with, never
+    # `pitch_routed` -- that one is grid-quantized (#847), and a structural
+    # verdict that moves with `--grid-step` is exactly the confound the two
+    # supply columns exist to keep out. `escape.part_escape` resolves the
+    # same pair, so the two ledgers price one corridor.
+    asg = _assign_faces(fp, own, lane_mm=pitch_routed, fallback_rect=ext,
+                        clearance=clearance, track_width=track_width)
 
     demand: Dict[str, set] = {f: set() for f in faces}
     interior_pads = 0

--- a/py_tools/check_channels.py
+++ b/py_tools/check_channels.py
@@ -456,13 +456,28 @@ def main():
         # demand is lower than the part's netted pad count. A demand that
         # fell with nothing in the output saying where it went is how a ledger
         # stops looking and reads as a fix.
-        if rows[0]['interior_pads']:
+        if rows[0]['interior_pads'] or rows[0].get('face_corridor_escapes'):
             lost = rows[0]['interior_demand_nets']
+            # #862: how many the enclosure corridor FREED, and the basis it
+            # ran at. Without them a reader diffing two runs cannot tell a
+            # placement that moved from a basis that moved -- `interior_pads`
+            # is a function of the clearance and the track width now, where
+            # before it was a function of geometry alone.
+            freed = rows[0].get('face_corridor_escapes') or 0
+            extra = ''
+            if freed:
+                extra = (f"; {freed} more reach a face through a clear "
+                         f"corridor at track "
+                         f"{rows[0]['face_corridor_track_mm']:g}"
+                         f" / clearance "
+                         f"{rows[0]['face_corridor_clearance_mm']:g}"
+                         f" (box rule alone: {rows[0]['interior_pads_box']})")
             print(f"  {ref}   interior: {rows[0]['interior_pads']} pad(s) on "
                   f"no face -- they need a via, not a lane"
                   + (f"; {lost} net(s) left the faces because of it"
                      if lost else "; every one of their nets still has a pad "
-                                  "on a face, so no face lost demand"))
+                                  "on a face, so no face lost demand")
+                  + extra)
 
     # The absolute deficit, summarised (run-12 Tier 3.6). Printed whether or
     # not --baseline was given, and never gated -- see _deficit_faces.

--- a/tests/measure_850_848_faces.py
+++ b/tests/measure_850_848_faces.py
@@ -65,12 +65,17 @@ DIFF_KEYS = ('refs', 'demand_before', 'demand_after', 'deficit_before',
              'deficit_848_after', 'escape_deficit')
 
 
-def _old_face_rule(fp, geom, *, lane_mm, fallback_rect=None):
+def _old_face_rule(fp, geom, *, lane_mm, fallback_rect=None,
+                   clearance=None, track_width=None):
     """`face_lane_ledger`'s face rule as it stood at e239e067.
 
     `min` over |pad CENTRE - extent edge|: no tolerance, no interior bucket, so
     every pad lands on some face. `geom` is ignored on purpose -- the old rule
     never looked at the copper box, which is the whole point.
+
+    It takes #862's `clearance` / `track_width` and ignores those too: the
+    rule it reproduces predates the enclosure corridor as well, so the BEFORE
+    column of every table below is the pre-#850 AND pre-#862 answer.
     """
     ext = fallback_rect
     out = []
@@ -81,7 +86,9 @@ def _old_face_rule(fp, geom, *, lane_mm, fallback_rect=None):
              'east': abs(pad.global_x - ext[2])}
         out.append((pad, min(d, key=d.get)))
     return E.FaceAssignment(faces=tuple(out), pitch_mm=0.0,
-                            pitch_source='measure_old_rule')
+                            pitch_source='measure_old_rule',
+                            box_faces=tuple(f for _p, f in out),
+                            corridor_source='measure_old_rule')
 
 
 def _whole_part_rect(geom, sides=None):
@@ -149,10 +156,15 @@ def measure(path):
     for ref in refs:
         if not now.get(ref):
             continue
+        # #862: `track_width` is part of the basis now, not decoration. Leave
+        # it out and `part_escape` resolves the BOARD's own -- orangecrab
+        # resolves 0.3 against this page's 0.2 -- and this control reports a
+        # disagreement the two ledgers do not have. Measured: with it, 97 of
+        # 97 refs agree; without it, orangecrab U3 reads 227 against 223.
         int_e += E.part_escape(pcb, ref, ignore_net_ids=(),
                                obstruction_rects=ctx.geom, sides=sides,
-                               containers=cont,
-                               clearance=CLEARANCE).interior_pads
+                               containers=cont, clearance=CLEARANCE,
+                               track_width=TRACK).interior_pads
     esc = E.escape_ledger(pcb, pcb_file=path, track_width=TRACK,
                           clearance=CLEARANCE)
     esc_deficit = sum(f.deficit for p in esc for f in p.faces)

--- a/tests/measure_862_enclosure.py
+++ b/tests/measure_862_enclosure.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Regenerate every number the #862 PR states, from the engine as it is.
+
+Asserts nothing, and is deliberately not named `test_*`: `tests/run_all.py`
+globs `test_*.py` and this is a report. The gate is
+`tests/test_862_enclosure.py`.
+
+BOTH ARMS ARE MEASURED IN ONE PROCESS. The "before" column is the BOX RULE
+ALONE, reached by calling `escape.assign_faces` without a corridor basis --
+which is the documented pre-#862 answer, not a re-implementation of it. So no
+table here depends on checking out a parent commit, and the before column
+re-measures on every run instead of going stale.
+
+    python3 -X utf8 tests/measure_862_enclosure.py                # all tables
+    python3 -X utf8 tests/measure_862_enclosure.py --table interior
+    python3 -X utf8 tests/measure_862_enclosure.py --out after.json
+    python3 -X utf8 tests/measure_862_enclosure.py --diff a.json b.json
+
+THE BASIS IS NOT ONE NUMBER, and that is the point of the `interior` table.
+Before #862 `interior_pads` was a function of the part's geometry alone; since
+#862 it is a function of the clearance and the track width too, because the
+enclosure test asks whether a TRACK can leave. Three bases are in use --
+`check_channels` runs the corpus at 0.09/0.10, `test_850`'s census is taken at
+0.20/0.20, and the CLI's own defaults are 0.25/0.30 -- and two more are swept
+that nothing routes at, because they are where two of the rule's parameters
+are visible at all.
+
+COUNTS ARE NOT SETS. The `interior` table prints the set differences in both
+directions, not just the totals. `qfn_interior_pads` U1 reads 5 before and 5
+after, and that is only a negative control if they are the SAME five pads: the
+reverted `_assignment_rect` experiment printed "5 -> 1" in an "interior pads
+recovered" column and nobody asked which four had moved.
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(_HERE)
+for _p in (_HERE, ROOT, os.path.join(ROOT, 'py_placer'),
+           os.path.join(ROOT, 'py_router'), os.path.join(ROOT, 'py_tools')):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import run_utils                                             # noqa: E402
+from kicad_parser import parse_kicad_pcb                     # noqa: E402
+from placement import escape as E                            # noqa: E402
+from placement import legality as L                          # noqa: E402
+from placement import routability as R                       # noqa: E402
+import check_channels as CC                                  # noqa: E402
+
+SKIP_EXIT = 77
+
+#: The three bases anything actually resolves, then two that nothing does.
+#: 0.05/0.10 and 0.40/0.40 are swept because they are the ONLY places on this
+#: corpus where the threshold epsilon and (at 0.05) the band-overlap
+#: strictness change an answer at all -- so a table without them cannot show
+#: that those two decisions do anything.
+BASES = ((0.09, 0.10), (0.20, 0.20), (0.25, 0.30), (0.05, 0.10), (0.40, 0.40))
+IN_USE = BASES[:3]
+
+DIFF_KEYS = ('refs', 'interior_box', 'interior_union', 'refs_moved',
+             'ulx3s_U1', 'qfn_interior_pads_U1', 'starved_box',
+             'starved_union', 'deficit_box', 'deficit_union')
+
+
+def _interior(fp, geom, clr, trk):
+    """(box set, union set) of the netted pads this part calls interior.
+
+    Keyed on the pad's INDEX in `fp.pads`, paired with its number for
+    display. Not on the number alone: a pad number is not unique within a
+    footprint -- a thermal pad drawn as sub-rects and a row of NC pads both
+    repeat one -- and keying a set on it silently merges them. Measured, that
+    mistake undercounts this corpus by 60 interior pads (1994 against 2054)
+    and drops two of the moved refs off the table entirely, which is the same
+    "a count is not a set" error this script exists to catch in the rule.
+    """
+    asg = E.assign_faces(fp, geom, lane_mm=trk + clr,
+                         clearance=clr, track_width=trk)
+    box, union = set(), set()
+    for i, (pad, face) in enumerate(asg.faces):
+        if not getattr(pad, 'net_id', 0):
+            continue
+        key = (i, pad.pad_number)
+        if asg.box_faces[i] is None:
+            box.add(key)
+        if face is None:
+            union.add(key)
+    return box, union
+
+
+def _sweep(clr, trk):
+    """{ref_key: (box set, union set)} over every tracked board."""
+    out = {}
+    for path in run_utils.corpus_boards():
+        name = os.path.basename(path)[:-len('.kicad_pcb')]
+        pcb = parse_kicad_pcb(path)
+        refs = E.fine_pitch_parts(pcb)
+        if not refs:
+            continue
+        geoms = L.part_copper_geometry(pcb.footprints, clr)
+        for ref in refs:
+            g = geoms.get(ref)
+            if g is None:
+                continue
+            out['%s:%s' % (name, ref)] = _interior(
+                pcb.footprints[ref], g, clr, trk)
+    return out
+
+
+def _gate_census(clr, trk):
+    """(starved, deficit faces) under the box rule and under the union.
+
+    The box arm is reached by stripping the basis at `assign_faces`, which is
+    its own documented "the caller has no opinion" path -- so this is the
+    shipped pre-#862 behaviour rather than a copy of it.
+    """
+    real = E.assign_faces
+
+    def box_only(fp, geom, *, lane_mm, fallback_rect=None,
+                 clearance=None, track_width=None):
+        return real(fp, geom, lane_mm=lane_mm, fallback_rect=fallback_rect)
+
+    res = {}
+    for label, fn in (('box', box_only), ('union', real)):
+        E.assign_faces = fn
+        R.assign_faces = fn
+        starved = deficit = 0
+        for path in run_utils.corpus_boards():
+            pcb = parse_kicad_pcb(path)
+            refs = E.fine_pitch_parts(pcb)
+            if not refs:
+                continue
+            ctx = R.board_lane_context(pcb, clr, pcb_file=path)
+            led = {}
+            for ref in refs:
+                rows = R.face_lane_ledger(pcb, ref, clearance=clr,
+                                          track_width=trk, grid_step=0.05,
+                                          pcb_file=path, context=ctx)
+                if rows:
+                    led[ref] = rows
+            starved += len(CC._starved_faces(led, CC.GATE_MIN_DEMAND))
+            deficit += len(CC._deficit_faces(led))
+        res[label] = (starved, deficit)
+    E.assign_faces = real
+    R.assign_faces = real
+    return res
+
+
+def measure(bases=BASES, with_gate=True):
+    data = {}
+    for clr, trk in bases:
+        sw = _sweep(clr, trk)
+        moved = {k: (len(b), len(u)) for k, (b, u) in sw.items()
+                 if len(b) != len(u)}
+        grew = {k: (len(b), len(u)) for k, (b, u) in sw.items()
+                if len(u) > len(b)}
+        not_subset = {k for k, (b, u) in sw.items() if not (u <= b)}
+        row = {
+            'refs': len(sw),
+            'interior_box': sum(len(b) for b, _u in sw.values()),
+            'interior_union': sum(len(u) for _b, u in sw.values()),
+            'refs_moved': len(moved),
+            'refs_grew': len(grew),
+            'not_subset': sorted(not_subset),
+            'moved': {k: v for k, v in sorted(moved.items())},
+            'ulx3s_U1': list(map(len, sw.get('ulx3s:U1', (set(), set())))),
+            'qfn_interior_pads_U1': list(
+                map(len, sw.get('qfn_interior_pads:U1', (set(), set())))),
+            'qfn_same_pads': (sw['qfn_interior_pads:U1'][0]
+                              == sw['qfn_interior_pads:U1'][1]
+                              if 'qfn_interior_pads:U1' in sw else None),
+        }
+        if with_gate and (clr, trk) in IN_USE:
+            g = _gate_census(clr, trk)
+            row['starved_box'], row['deficit_box'] = g['box']
+            row['starved_union'], row['deficit_union'] = g['union']
+        data['%.2f/%.2f' % (clr, trk)] = row
+    return data
+
+
+def table_interior(data):
+    print('\n#862 -- THE ENCLOSURE RULE, box alone vs box OR corridor')
+    print('%-14s %5s %8s %8s %6s %6s  %-11s %-11s'
+          % ('clr/track', 'refs', 'box', 'union', 'moved', 'grew',
+             'ulx3s:U1', 'qfn:U1'))
+    for basis, d in data.items():
+        used = '' if basis in ['%.2f/%.2f' % b for b in IN_USE] else '  (swept)'
+        print('%-14s %5d %8d %8d %6d %6d  %-11s %-11s%s'
+              % (basis, d['refs'], d['interior_box'], d['interior_union'],
+                 d['refs_moved'], d['refs_grew'],
+                 '%d -> %d' % tuple(d['ulx3s_U1']),
+                 '%d -> %d' % tuple(d['qfn_interior_pads_U1']), used))
+    print('\n  `grew` is the DIRECTION CONTROL and must be 0 everywhere: the')
+    print('  rule is a UNION, so the escape set can only grow and the')
+    print('  interior set can only shrink. A non-zero column means someone')
+    print('  turned it into a replacement -- which is a real mutation, and')
+    print('  measured, it gains interior pads on orangecrab U10 and rp2350 U4.')
+    print('\n  `not_subset` is the same claim as a SET rather than a count:')
+    for basis, d in data.items():
+        if d['not_subset']:
+            print('    %s  NOT A SUBSET: %s' % (basis, d['not_subset']))
+    print('    (empty on every basis above)')
+    print('\n  qfn_interior_pads U1 keeps the SAME pads, not merely the same')
+    print('  count -- the reverted netted-box experiment printed 5 -> 1 as a')
+    print('  win without asking which four pads had moved:')
+    for basis, d in data.items():
+        print('    %-14s same pads: %s' % (basis, d['qfn_same_pads']))
+
+
+def table_moved(data):
+    print('\n#862 -- WHICH REFS MOVE, at the bases in use')
+    for basis, d in data.items():
+        if basis not in ['%.2f/%.2f' % b for b in IN_USE]:
+            continue
+        print('  %s  (%d refs)' % (basis, d['refs_moved']))
+        for k, (b, u) in d['moved'].items():
+            print('      %-38s %4d -> %4d' % (k, b, u))
+
+
+def table_gate(data):
+    print('\n#862 -- THE RANKED RISK: does --gate newly fire?')
+    print('  All three gate predicates are demand-gated (GATE_MIN_DEMAND = '
+          '%d), so demand' % CC.GATE_MIN_DEMAND)
+    print('  RISING is the direction that could make --gate exit 4 where it '
+          'exits 0.')
+    print('  %-14s %-22s %s' % ('clr/track', 'starved box -> union',
+                                'deficit faces box -> union'))
+    for basis, d in data.items():
+        if 'starved_box' not in d:
+            continue
+        print('  %-14s %-22s %s'
+              % (basis, '%d -> %d' % (d['starved_box'], d['starved_union']),
+                 '%d -> %d' % (d['deficit_box'], d['deficit_union'])))
+
+
+def _diff(before, after):
+    b = json.load(open(run_utils.evidence(before, 'the BEFORE json'),
+                       encoding='utf-8'))
+    a = json.load(open(run_utils.evidence(after, 'the AFTER json'),
+                       encoding='utf-8'))
+    moved = 0
+    for basis in sorted(set(b) | set(a)):
+        if basis not in b:
+            print('  %-14s ONLY IN AFTER -- not counted as movement' % basis)
+            continue
+        if basis not in a:
+            print('  %-14s ONLY IN BEFORE -- not counted as movement' % basis)
+            continue
+        for k in DIFF_KEYS:
+            if k in b[basis] and k in a[basis] and b[basis][k] != a[basis][k]:
+                print('  %-14s %-24s %r -> %r'
+                      % (basis, k, b[basis][k], a[basis][k]))
+                moved += 1
+    print('\n%d value(s) moved' % moved)
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--table', choices=('interior', 'moved', 'gate'))
+    ap.add_argument('--out')
+    ap.add_argument('--diff', nargs=2, metavar=('BEFORE', 'AFTER'))
+    args = ap.parse_args()
+    if args.diff:
+        return _diff(*args.diff)
+    if not run_utils.corpus_boards():
+        print('SKIP: git could not name the tracked corpus')
+        return SKIP_EXIT
+
+    data = measure(with_gate=args.table in (None, 'gate'))
+    if args.table in (None, 'interior'):
+        table_interior(data)
+    if args.table in (None, 'moved'):
+        table_moved(data)
+    if args.table in (None, 'gate'):
+        table_gate(data)
+    if args.out:
+        try:
+            sha = subprocess.run(['git', 'rev-parse', 'HEAD'], cwd=ROOT,
+                                 capture_output=True, text=True,
+                                 timeout=30).stdout.strip()
+        except Exception:                                    # noqa: BLE001
+            sha = 'unknown'
+        payload = dict(data)
+        payload['engine_sha'] = sha
+        with open(args.out, 'w', encoding='utf-8') as fh:
+            json.dump(payload, fh, indent=1, sort_keys=True)
+        print('\nwrote %s' % args.out)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/mutate_850_848.py
+++ b/tests/mutate_850_848.py
@@ -22,7 +22,11 @@ gate to pass UNMUTATED first; drop `__pycache__` before and after every row and
 run children with `-B`; treat exit 77 from every witness as UNDECIDED rather
 than a kill; restore in a `finally`.
 
-RECORDED at 093f5f36 -- **17 rows, 17 killed, 0 survived, 0 undecided, 0
+RECORDED at f30f5bdb (the #862 rows land there) -- **26 rows, 26 killed, 0
+survived, 0 undecided, 0 broken, 0 disagreeing.** The 17-row #850/#848
+verdict it carried before was recorded at 093f5f36, a pre-rebase commit that
+is no longer reachable from this branch, so the basis could not be checked out
+and the number could not be reproduced at the tip it named. 0
 broken, 0 disagreeing with expectation.**
 
 Six rows that guarded a `_assignment_rect` experiment were REMOVED with it:
@@ -145,8 +149,9 @@ ROWS = [
      (T850,), 'KILLED'),
 
     ('interior-demand-does-not-subtract-the-faces', 'rou',
-     "    interior_demand -= set().union(*demand.values())"
-     " if demand else set()",
+     # RE-ANCHORED: the `if demand else set()` tail was dead (a four-key
+     # dict literal is always truthy) and was dropped. Same mutation.
+     "    interior_demand -= set().union(*demand.values())",
      "    interior_demand -= set()",
      (T850,), 'KILLED'),
 

--- a/tests/mutate_850_848.py
+++ b/tests/mutate_850_848.py
@@ -71,6 +71,7 @@ LEG = os.path.join(ROOT, 'py_placer', 'placement', 'legality.py')
 CHK = os.path.join(ROOT, 'py_tools', 'check_channels.py')
 TARGETS = {'esc': ESC, 'rou': ROU, 'leg': LEG, 'chk': CHK}
 
+T862 = os.path.join(ROOT, 'tests', 'test_862_enclosure.py')
 T850 = os.path.join(ROOT, 'tests', 'test_850_demand_face_of.py')
 T848 = os.path.join(ROOT, 'tests', 'test_848_side_obstruction.py')
 T849 = os.path.join(ROOT, 'tests', 'test_849_lane_context.py')
@@ -81,17 +82,27 @@ T841 = os.path.join(ROOT, 'tests', 'test_841_obstruction_rect.py')
 ROWS = [
     # ---- #850: the shared face rule ---------------------------------------
     ('the-ledger-goes-back-to-pad-centres', 'rou',
-     "    own = ctx.geom.get(ref)\n"
-     "    asg = _assign_faces(fp, own, lane_mm=pitch_routed, fallback_rect=ext)",
-     "    own = ctx.geom.get(ref)\n"
-     "    asg = _assign_faces(fp, None, lane_mm=pitch_routed,"
-     " fallback_rect=ext)",
+     # RE-ANCHORED for #862, which added the corridor basis to this call.
+     # The MUTATION is unchanged: hand the ledger no geometry, so it falls
+     # back to pad CENTRES measured against the extent.
+     "    asg = _assign_faces(fp, own, lane_mm=pitch_routed, fallback_rect=ext,\n"
+     "                        clearance=clearance, track_width=track_width)",
+     "    asg = _assign_faces(fp, None, lane_mm=pitch_routed, fallback_rect=ext,\n"
+     "                        clearance=clearance, track_width=track_width)",
      (T850,), 'KILLED'),
 
     ('pad_box-is-dropped-so-it-degrades-to-centres', 'esc',
+     # RE-ANCHORED for #862, which split this loop body into a box call and
+     # a corridor rescue. The MUTATION is unchanged: drop the per-pad copper
+     # box so every distance is measured from the pad CENTRE. It disables
+     # the rescue too, and that is the honest shape rather than a widened
+     # mutation -- with no per-pad rect there is nothing to run a corridor
+     # on, which is exactly what `assign_faces` already does for a part
+     # whose pad model could not be built.
      "        box = None if geom is None else _pad_box(geom, pad)\n"
-     "        out.append((pad, face_of(pad, rect, pitch, pad_box=box)))",
-     "        out.append((pad, face_of(pad, rect, pitch)))",
+     "        bf = face_of(pad, rect, pitch, pad_box=box)",
+     "        box = None\n"
+     "        bf = face_of(pad, rect, pitch, pad_box=box)",
      (T850, T841), 'KILLED'),
 
     ('face_of-gets-the-rect-not-the-copper', 'esc',
@@ -165,6 +176,115 @@ ROWS = [
      "    ext = (ctx.geom[ref].copper if ref in ctx.geom else ext)\n"
      "    faces = {'N': (ext[0], ext[1], ext[2], ext[1]),",
      (T850, T849), 'KILLED'),
+
+    # ---- #862: the enclosure corridor -------------------------------------
+    #
+    # WITNESS BASES ARE CHOSEN PER ROW, NOT DEFAULTED. The corpus does not
+    # discriminate every one of these at every basis, and a row killed at a
+    # basis where it is a value no-op is killed by luck. `test_862` runs at
+    # 0.09/0.10, 0.20/0.20, 0.25/0.30 AND 0.40/0.40 for exactly this reason;
+    # the comment on each row says what only it can see.
+
+    # Kills at every basis: ulx3s U1 goes straight back to 379 interior.
+    ('the-corridor-half-is-never-consulted', 'esc',
+     "        if bf is None and corridor is not None and box is not None:",
+     "        if False:",
+     (T862, T850), 'KILLED'),
+
+    # THE ROW A NAIVE WITNESS SURVIVES. Making the corridor a REPLACEMENT for
+    # the box test instead of a second sufficient condition leaves ulx3s U1 at
+    # 308 and qfn_interior_pads U1 at 5 -- both named witnesses agree -- and
+    # is caught only by the direction arm, and only at a basis where the two
+    # rules differ at all. Measured: identical at 0.09/0.10 (both 1953), and
+    # at 0.20/0.20 the replacement GAINS interior pads on orangecrab U10 and
+    # rp2350 U4, a 0.325mm part whose central 0.82mm GND pad sits 0.0699mm
+    # from the copper box and whose axis-aligned corridor is closed by its
+    # flanking pads once inflated.
+    ('the-corridor-replaces-the-box-instead-of-uniting', 'esc',
+     "    esc = FACES\n"
+     "    if near > tol:",
+     "    esc = FACES\n"
+     "    if True:",
+     (T862,), 'KILLED'),
+
+    # The clearance inflation. Kills on qfn_interior_pads (5 -> 0) and tigard
+    # (18 -> 4): without it the gaps between a QFN's pins read as passable.
+    ('the-corridor-forgets-the-clearance', 'esc',
+     "                       grow=self.clearance)",
+     "                       grow=0.0)",
+     (T862,), 'KILLED'),
+
+    # THE SECOND NAIVE-WITNESS SURVIVOR. The epsilon only bites where a free
+    # run lands EXACTLY on the threshold, which over this corpus is clearance
+    # 0.05 and 0.40 and nowhere else. Every basis anything actually routes at
+    # is blind to it. Killed only by test_862's 0.40/0.40 row, where a bare
+    # comparison puts 33 of ulx3s U1's recovered balls back (308 -> 341)
+    # because a nominally 0.4mm pad's span subtracts to 0.39999999999997726.
+    ('the-threshold-epsilon-is-dropped', 'esc',
+     "        return run >= self.track_width - FREE_RUN_EPS",
+     "        return run >= self.track_width",
+     (T862,), 'KILLED'),
+
+    # The band overlap turned CLOSED. Its real stake is not a few pads: the
+    # obstacle list includes the pad's OWN rect, so a closed test blocks every
+    # pad against itself and the union collapses to the box rule exactly --
+    # 2054 interior at every basis, both named witnesses still reading 308 and
+    # 5, every corpus golden still green. Only the unit arms and the
+    # rescue-count arms see it.
+    ('the-band-overlap-becomes-closed', 'esc',
+     "        if across[1] <= band[0] or across[0] >= band[1]:",
+     "        if across[1] < band[0] or across[0] > band[1]:",
+     (T862,), 'KILLED'),
+
+    # The strip. A pitch-wide window is not a refinement, it is a different
+    # rule: measured, it takes ulx3s U1 from 308 to 0 at clearance 0.09, i.e.
+    # it erases the very finding #862 is about while looking generous.
+    ('the-strip-becomes-a-pitch-wide-window', 'esc',
+     "    lo, hi = (px0, px1) if horizontal else (py0, py1)",
+     "    cx, cy = (px0 + px1) / 2.0, (py0 + py1) / 2.0\n"
+     "    lo, hi = ((cx - 0.4, cx + 0.4) if horizontal else (cy - 0.4, cy + 0.4))",
+     (T862,), 'KILLED'),
+
+    # `free_run` must answer the largest CONTIGUOUS run, not the total. This
+    # is a value NO-OP at 0.20/0.20 and 0.25/0.30 -- two half-gaps only fail
+    # to make a lane where the gaps are tight -- so its witness is the
+    # 0.09/0.10 row, where it breaks qfn_interior_pads (5 -> 2), tigard
+    # (18 -> 16) and glasgow_revC U1 (27 -> 26).
+    ('the-free-run-becomes-the-total-free-span', 'esc',
+     "    intervals.sort()\n"
+     "    best = 0.0\n"
+     "    cur = lo\n"
+     "    for a, b in intervals:\n"
+     "        if a > cur:\n"
+     "            best = max(best, a - cur)\n"
+     "        cur = max(cur, b)\n"
+     "    return max(best, hi - cur)",
+     "    intervals.sort()\n"
+     "    best = 0.0\n"
+     "    cur = lo\n"
+     "    for a, b in intervals:\n"
+     "        if a > cur:\n"
+     "            best += a - cur\n"
+     "        cur = max(cur, b)\n"
+     "    return best + max(0.0, hi - cur)",
+     (T862,), 'KILLED'),
+
+    # The two ledgers must price ONE corridor. Feeding the routability side
+    # its grid-quantized pitch instead of the raw track width leaves every
+    # named witness intact and breaks only the reconciliation -- which is the
+    # whole point of #850, and the reason that arm now passes `track_width`.
+    ('the-ledgers-price-different-corridors', 'rou',
+     "                        clearance=clearance, track_width=track_width)",
+     "                        clearance=clearance, track_width=pitch_routed)",
+     (T850, T862), 'KILLED'),
+
+    # The basis must be PUBLISHED. Without it a reader diffing two runs cannot
+    # tell a placement that moved from a basis that moved.
+    ('the-published-basis-is-dropped', 'rou',
+     "                    'face_corridor_track_mm': round(asg.corridor_track_mm, 4),",
+     "                    'face_corridor_track_mm': 0.0,",
+     (T862,), 'KILLED'),
+
 
     # ---- #848: the per-side neighbour rect --------------------------------
     ('the-per-side-union-collapses-to-the-whole-part', 'leg',

--- a/tests/stress/demand_halo_study.py
+++ b/tests/stress/demand_halo_study.py
@@ -87,7 +87,7 @@ def _geom(pcb, path):
     return part_copper_geometry(pcb.footprints or {}, clr)
 
 
-def _face_demand(fp, lane, geom=None):
+def _face_demand(fp, lane, geom=None, clearance=None, track_width=None):
     """Largest per-face distinct-net count, by the ledger's own face rule.
 
     #841: the ledger measures each pad by its own COPPER EDGE against the
@@ -102,11 +102,20 @@ def _face_demand(fp, lane, geom=None):
     face rule, and this file, `part_escape` and `routability.face_lane_ledger`
     all call it. The paragraph above is kept because it is the finding.
 
+    #862: AND IT MUST BE HANDED THE SAME BASIS. `assign_faces` answers the box
+    rule alone when it is given no `clearance`/`track_width` pair, so calling
+    it without one puts this file back on a DIFFERENT rule from the two
+    ledgers -- the third-copy defect above, arriving through the argument list
+    instead of through a reimplementation. Measured on ulx3s at the board's
+    own basis, without the pair: U1 reads demand 0 here against the ledger's
+    18, and SD1 2 against 8.
+
     `geom=None` keeps the old pairing, for a caller with no `PCBData`.
     """
     g = None if geom is None else geom.get(fp.reference)
     asg = escape.assign_faces(fp, g, lane_mm=lane,
-                              fallback_rect=escape._part_rect(fp))
+                              fallback_rect=escape._part_rect(fp),
+                              clearance=clearance, track_width=track_width)
     per = {f: set() for f in escape.FACES}
     for pad, face in asg.faces:
         if not getattr(pad, 'net_id', 0):
@@ -169,24 +178,34 @@ def question_a():
           ' demand term would:' % len(uncharged))
     fired = 0
     seen = set()
+    # A COUNT IS NOT A SET. `fired` counts PAIR hits, and it was being
+    # printed against `len(seen)`, a count of distinct PARTS -- so a
+    # part appearing in several uncharged pairs was counted once per
+    # pair on one side of the sentence and once in total on the other.
+    # Measured, that read '16 of 96 parts' for 5 distinct parts.
+    fires = set()
     for name, a, b, gap, need in uncharged:
         pcb, path = _load(name)
         ncu = len(pcb.board_info.copper_layers or ['F.Cu', 'B.Cu'])
         lane = escape.lane_pitch(pcb, path)
+        tw, clr = escape.lane_pitch_parts(pcb, path)
         geom = _geom(pcb, path)
         hits = []
         for ref in (a, b):
             fp = pcb.footprints[ref]
             pin = len([p for p in fp.pads if p.net_id > 0])
-            want = _face_demand(fp, lane, geom) * lane / ncu
+            want = _face_demand(fp, lane, geom, clearance=clr,
+                                track_width=tw) * lane / ncu
             if want > _shape_halo(pin) + 1e-9:
                 hits.append(ref)
+                fires.add((name, ref))
             seen.add((name, ref))
         fired += len(hits)
         print('     %-28s %-6s/%-6s gap %.3f vs %.3f  demand term fires on: %s'
               % (name, a, b, gap, need, ', '.join(hits) or 'NEITHER'))
-    print('\n   the demand term fires on %d of the %d parts in those pairs.'
-          % (fired, len(seen)))
+    print('\n   the demand term fires on %d of the %d parts in those pairs'
+          '  (%d of the %d pair-hits).'
+          % (len(fires), len(seen), fired, len(uncharged)))
     return total, charged, len(uncharged), fired
 
 
@@ -207,6 +226,7 @@ def question_b():
         # disagree about the board they are both reading.
         nsig, _source, planes = escape.signal_layer_count(pcb)
         lane = escape.lane_pitch(pcb, path)
+        tw, clr = escape.lane_pitch_parts(pcb, path)
         geom = _geom(pcb, path)
         fires = parts = 0
         worst_ask = (0.0, '')
@@ -215,7 +235,8 @@ def question_b():
             if not pin:
                 continue
             parts += 1
-            want = _face_demand(fp, lane, geom) * lane / nsig
+            want = _face_demand(fp, lane, geom, clearance=clr,
+                                track_width=tw) * lane / nsig
             if want > _shape_halo(pin) + 1e-9:
                 fires += 1
                 if want > worst_ask[0]:

--- a/tests/test_835_escape_side_aware.py
+++ b/tests/test_835_escape_side_aware.py
@@ -53,8 +53,8 @@ from placement.options import deficit_totals                  # noqa: E402
 #: `python3 -X utf8 tests/measure_834_835_side_awareness.py --table B`.
 #: Boards absent from a checkout are skipped, not failed.
 EXPECTED = {
-    'ulx3s': (5, 1, 1),
-    'orangecrab_ext_pll': (115, 20, 50),
+    'ulx3s': (6, 2, 2),        # #862: 5, 1, 1 before the corridor
+    'orangecrab_ext_pll': (116, 20, 51),   # #862: 115, 20, 50 before
     'glasgow_revC': (55, 16, 25),
     'rp2350_fpga_eensy_prePlane': (79, 10, 27),
     # #835's controls were "does not move under the SIDE or CONTAINER arm",
@@ -76,11 +76,32 @@ EXPECTED = {
 #: from `EXPECTED` because a deficit that falls can mean the instrument got
 #: honest OR that it stopped counting nets, and only this pair tells them
 #: apart.
+#: RE-RECORDED FOR #862 on three of eight rows, and the five that did not
+#: move are the negative control inside the same table -- so this is a
+#: measurement of which boards have a pad the corridor can free, not a
+#: blanket refresh. Each board is graded at its OWN resolved basis (ulx3s and
+#: orangecrab resolve track 0.3 / clearance 0.25), which is why these numbers
+#: are not the census figures `tests/test_850_demand_face_of.py` records at
+#: 0.20/0.20.
+#:
+#:   ulx3s        (149, 402) -> (233, 314). 88 interior pads freed across the
+#:                board, 71 of them U1's -- the BGA whose eight UNNETTED
+#:                alignment marks set a copper box 0.954mm outside its ball
+#:                field, so the box rule called all 379 balls interior.
+#:   orangecrab   (234, 306) -> (236, 303). Three pads, two nets.
+#:   rp2350       (130, 37) -> (130, 36). One pad, and NO net lost or gained
+#:                a face: every net that pad carries has another pad already
+#:                on one.
+#:
+#: `DEMAND_AT_PAD_CENTRES` below does NOT move, and that is checkable rather
+#: than lucky: its arm passes `obstruction_rects={}`, so `geom` is None, so
+#: the corridor is never built (`corridor_source == 'unmodelled'`) and the
+#: box rule alone answers -- exactly as it did before #862.
 DEMAND = {
-    'ulx3s': (149, 402),
-    'orangecrab_ext_pll': (234, 306),
+    'ulx3s': (233, 314),
+    'orangecrab_ext_pll': (236, 303),
     'glasgow_revC': (307, 108),
-    'rp2350_fpga_eensy_prePlane': (130, 37),
+    'rp2350_fpga_eensy_prePlane': (130, 36),
     'tigard': (103, 18),
     'splitflap_driver': (0, 0),
     'watchy': (113, 1),
@@ -198,6 +219,14 @@ def test_the_demand_model_did_not_collapse_when_the_subject_rect_grew():
     The DIRECTION is the assertion: a bigger box with the same tolerance can
     only pull pads ONTO faces, never off them, so demand never falls and
     interior pads never grow.
+
+    #862 STRENGTHENS both directions rather than threatening them, and they
+    are re-checked here rather than assumed. The enclosure rule became a
+    UNION -- the old box test OR a clear corridor -- so it can only take pads
+    OUT of the interior bucket, which is the same sign as the rect change
+    this arm was written for. If either assert ever has to be weakened, that
+    is a finding about the union having become a replacement, not a number to
+    re-record.
 
     Both sides are MEASURED. The pad-centre arm is reached through the
     documented empty-map fallback -- `obstruction_rects={}` puts the subject
@@ -340,6 +369,10 @@ def test_the_ulx3s_witness_stops_charging_across_the_board():
         'ulx3s at the pad-CENTRE rect is no longer 0, so this witness no '
         'longer isolates the #841 change: {}'.format(centres))
     copper = deficit_totals(E.escape_ledger(pcb, pcb_file=path))['lanes']
+    # #862 moves this from 5 to 6: freeing interior pads on U1, U9, SD1 and
+    # GPDI1 adds demand, and one more face crosses into deficit. The
+    # `centres == 0` assert above is what keeps the witness isolated, and it
+    # is untouched -- the pad-centre arm never builds a corridor.
     assert copper == EXPECTED['ulx3s'][0], (copper, EXPECTED['ulx3s'][0])
     print('  PASS: U9<->SD1 charge each other nowhere; ulx3s is 0 at pad '
           'centres and {} at pad copper'.format(copper))

--- a/tests/test_850_demand_face_of.py
+++ b/tests/test_850_demand_face_of.py
@@ -128,6 +128,33 @@ LANE = dict(clearance=CLR, track_width=TRK, grid_step=GRID)
 #:               interior bucket cannot. The part total falls by 1 while one
 #:               face RISES, which is why nothing here asserts a per-face
 #:               ceiling.
+#: The ONE row #862 moves, asserted as a TRANSITION against `GOLDEN` rather
+#: than written over it. `GOLDEN`'s columns stay the e239e067 oracle and the
+#: #850 recording, so both remain checkable; editing four numbers inside that
+#: table would have retired it for the four rows that did NOT move and left
+#: no record that this change happened. Same shape as #849's
+#: `GOLDEN_PRE_HOIST` / `DEMAND_AFTER_850`.
+#:
+#: `ulx3s:U1` is the row the #850 PR recorded specifically so that the day
+#: #862 was fixed it would fail and say so. This is that day.
+#:
+#: What fixed it: `escape.face_of` is now a UNION -- a pad escapes when its
+#: band to the copper box is shallower than the tolerance (the old test), OR
+#: when a track's width of clear copper crosses that band. The box was set by
+#: eight UNNETTED alignment marks 0.954mm outside the ball field, and a box
+#: cannot tell eight corner dots from an enclosing ring; an occupancy test
+#: can. 71 of the 379 balls recover -- MORE than the 67-ball outer ring of the
+#: 20x20 lattice, because some second-row balls escape through sites where the
+#: outer row has no ball. 308 remain interior because they really are: their
+#: corridors are blocked by their own neighbours, and those balls need vias.
+#:
+#: The basis is part of the row now. Before #862 `interior_pads` was a
+#: function of geometry alone; since #862 it is a function of clearance and
+#: track width too, and this file's are `CLR, TRK` above.
+GOLDEN_AFTER_862 = {
+    'ulx3s:U1': ({'N': 17, 'S': 11, 'W': 18, 'E': 16}, 308, 144),
+}
+
 GOLDEN = {
     'rp2350_fpga_eensy_prePlane:U2': ({'N': 7, 'S': 13, 'W': 5, 'E': 6},
                                       {'N': 5, 'S': 6, 'W': 2, 'E': 4}, 25, 13),
@@ -178,9 +205,10 @@ def the_spy_and_conservation(boards):
         seen = []
         real = E.face_of
 
-        def spy(pad, rect, pitch, pad_box=None):
-            seen.append((pad, rect, pitch, pad_box))
-            return real(pad, rect, pitch, pad_box=pad_box)
+        def spy(pad, rect, pitch, pad_box=None, corridor=None):
+            seen.append((pad, rect, pitch, pad_box, corridor))
+            return real(pad, rect, pitch, pad_box=pad_box,
+                        corridor=corridor)
 
         E.face_of = spy
         try:
@@ -190,9 +218,20 @@ def the_spy_and_conservation(boards):
         if not rows:
             check('spy: %s %s has a ledger' % (name, ref), False)
             continue
+        # #862 made the rule a UNION, so a pad the BOX half rejects is asked
+        # a second time with a corridor. Every pad is still asked exactly
+        # once WITHOUT one, which is the property this arm was written for;
+        # the second call happens only for a pad whose first answer was None.
+        box_calls = [c for c in seen if c[4] is None]
         check('spy: %s %s -- the kernel was called once per pad' % (name, ref),
-              len(seen) == len(fp.pads),
-              '%d calls for %d pads' % (len(seen), len(fp.pads)))
+              len(box_calls) == len(fp.pads),
+              '%d box calls for %d pads' % (len(box_calls), len(fp.pads)))
+        rescue = [c for c in seen if c[4] is not None]
+        check('spy: %s %s -- only a box-interior pad is asked twice'
+              % (name, ref),
+              all(real(p, r, pi, pad_box=b) is None
+                  for p, r, pi, b, _c in rescue),
+              '%d rescue calls' % len(rescue))
         # THE PAIRING: the box is `CopperGeometry.copper` BY OBJECT IDENTITY,
         # not by equality. On a part with no NPTH the `rect` and `copper`
         # boxes coincide, so `==` would pass against either and this arm would
@@ -201,13 +240,13 @@ def the_spy_and_conservation(boards):
         want = ctx.geom[ref].copper
         check('spy: %s %s -- measured against the part COPPER box, by identity'
               % (name, ref),
-              all(r is want for _p, r, _pi, _b in seen),
-              'want %r, saw %r' % (want, {r for _p, r, _pi, _b in seen}))
+              all(r is want for _p, r, _pi, _b, _c in seen),
+              'want %r, saw %r' % (want, {r for _p, r, _pi, _b, _c in seen}))
         # ...and the INVARIANT that `face_of`'s docstring rests on, derived
         # from the pads rather than from the function: every edge of the box
         # it measures against is attained by some pad, which is what puts an
         # edge pad at distance exactly 0.
-        rects = [r for _p, r, _pi, _b in seen]
+        rects = [r for _p, r, _pi, _b, _c in seen]
         nb = [L.pad_box(ctx.geom[ref], p) for p in fp.pads]
         nb = [b for b in nb if b is not None]
         if rects and nb:
@@ -222,21 +261,23 @@ def the_spy_and_conservation(boards):
                   attained and inside,
                   'rect %r attained=%s inside=%s' % (r, attained, inside))
         check('spy: %s %s -- at the part\'s own pad pitch' % (name, ref),
-              all(abs(pi - E.pad_pitch(fp)) < 1e-12 for _p, _r, pi, _b in seen)
+              all(abs(pi - E.pad_pitch(fp)) < 1e-12 for _p, _r, pi, _b, _c in seen)
               and abs(rows[0]['face_pitch_mm'] - round(E.pad_pitch(fp), 4)) < 1e-9,
               'pad_pitch %r, row %r' % (E.pad_pitch(fp), rows[0]['face_pitch_mm']))
         check('spy: %s %s -- every netted pad got its own copper box'
               % (name, ref),
-              all(b is not None for p, _r, _pi, b in seen if p.net_id),
+              all(b is not None for p, _r, _pi, b, _c in seen if p.net_id),
               '%d netted pads with no box'
-              % sum(1 for p, _r, _pi, b in seen if p.net_id and b is None))
+              % sum(1 for p, _r, _pi, b, _c in seen if p.net_id and b is None))
         # 2. CONSERVATION.
-        faced = sum(1 for (_p, _r, _pi, _b), (pad, f)
-                    in zip(seen, E.assign_faces(fp, ctx.geom[ref],
-                                                lane_mm=1.0).faces)
-                    if pad.net_id and f is not None)
-        interior = sum(1 for pad, f in E.assign_faces(
-            fp, ctx.geom[ref], lane_mm=1.0).faces if pad.net_id and f is None)
+        # #862: at the SAME basis the ledger ran at. `assign_faces` without
+        # one answers the box rule alone, and comparing that against a row
+        # produced with a corridor would be comparing two different rules --
+        # the row would look like it had lost pads it never had.
+        asg = E.assign_faces(fp, ctx.geom[ref], lane_mm=1.0,
+                             clearance=CLR, track_width=TRK)
+        faced = sum(1 for pad, f in asg.faces if pad.net_id and f is not None)
+        interior = sum(1 for pad, f in asg.faces if pad.net_id and f is None)
         netted = sum(1 for p in fp.pads if p.net_id)
         check('conservation: %s %s -- faced + interior == netted pads'
               % (name, ref), faced + interior == netted,
@@ -264,9 +305,20 @@ def interior_equals_escape(boards):
             # caller may drop plane rails, and then the two count different
             # pads. The same `geom` at the same clearance is the second
             # control: below 0.20mm the NPTH hole extents differ.
+            #
+            # #862 ADDS A THIRD, and it is not a formality. Since the
+            # enclosure test asks whether a TRACK can leave, `interior_pads`
+            # is a function of clearance AND track width, so this claim is
+            # now "the same ref at the same clearance and the same track
+            # width". Measured: pass `track_width=TRK` and the two ledgers
+            # agree on 97 of 97 refs; leave it out and `part_escape` resolves
+            # the BOARD's own 0.3 while this ledger runs at 0.2, and
+            # orangecrab_ext_pll U3 reads 227 against the row's 223. One ref
+            # is all it takes, and nothing but this arm would have said so.
             pe = E.part_escape(pcb, ref, ignore_net_ids=(),
                                obstruction_rects=ctx.geom, sides=sides,
-                               containers=cont, clearance=CLR)
+                               containers=cont, clearance=CLR,
+                               track_width=TRK)
             if rows[0]['interior_pads'] == pe.interior_pads:
                 agree += 1
             else:
@@ -289,20 +341,40 @@ def the_golden(boards):
             continue
         rows = _rows(parse_kicad_pcb(path), ref, path)
         got = {r['face']: r['demand_nets'] for r in rows}
-        check('golden: %s demand is the recorded transition' % key, got == post,
-              '%r != %r  (was %r at e239e067)' % (got, post, pre))
+        # #862 moves exactly one of these rows. Where it does, the row's
+        # #850 columns stay asserted as history and the CURRENT expectation
+        # comes from the sibling table, together with the DIRECTION -- which
+        # is the part a plain re-record cannot state, and the part that fails
+        # if a later change moves ulx3s the wrong way.
+        after = GOLDEN_AFTER_862.get(key)
+        want_demand, want_ipads, want_ilost = (
+            after if after is not None else (post, ipads, ilost))
+        check('golden: %s demand is the recorded transition' % key,
+              got == want_demand,
+              '%r != %r  (was %r at e239e067, %r after #850)'
+              % (got, want_demand, pre, post))
+        if after is not None:
+            check('golden: %s -- #862 only ADDED demand' % key,
+                  all(got[f] >= post[f] for f in post),
+                  '%r fell against the #850 row %r' % (got, post))
+            check('golden: %s -- #862 only REMOVED interior pads' % key,
+                  want_ipads < ipads, '%d !< %d' % (want_ipads, ipads))
         check('golden: %s interior_pads / interior_demand_nets' % key,
               (rows[0]['interior_pads'], rows[0]['interior_demand_nets'])
-              == (ipads, ilost),
+              == (want_ipads, want_ilost),
               '%r != %r' % ((rows[0]['interior_pads'],
-                             rows[0]['interior_demand_nets']), (ipads, ilost)))
+                             rows[0]['interior_demand_nets']),
+                            (want_ipads, want_ilost)))
         check('golden: %s the part total did not grow' % key,
               sum(got.values()) <= sum(pre.values()),
               '%d > %d' % (sum(got.values()), sum(pre.values())))
         if sum(got.values()) < sum(pre.values()):
             fell += 1
     # ...and the file is not measuring nothing: some ref must actually move,
-    # or every assertion above is satisfied by an inert change.
+    # or every assertion above is satisfied by an inert change. Re-checked
+    # after #862 rather than assumed: ulx3s U1's demand total is 62 against
+    # e239e067's 214, so it still counts as a fall, and rp2350 U2 is the
+    # second. The arm is unchanged and still bites.
     check('golden: the change moved at least two of the pinned refs', fell >= 2,
           '%d fell' % fell)
 
@@ -322,7 +394,8 @@ def only_demand_moved(boards):
     """
     real = E.assign_faces
 
-    def old_rule(fp, geom, *, lane_mm, fallback_rect=None):
+    def old_rule(fp, geom, *, lane_mm, fallback_rect=None,
+                 clearance=None, track_width=None):
         # `min` over |pad CENTRE - extent edge|, no tolerance, no interior --
         # `face_lane_ledger` as it stood at e239e067.
         ext = fallback_rect
@@ -334,7 +407,9 @@ def only_demand_moved(boards):
                  'east': abs(pad.global_x - ext[2])}
             out.append((pad, min(d, key=d.get)))
         return E.FaceAssignment(faces=tuple(out), pitch_mm=0.0,
-                                pitch_source='test_old_rule')
+                                pitch_source='test_old_rule',
+                                box_faces=tuple(f for _p, f in out),
+                                corridor_source='test_old_rule')
 
     drift, moved = [], 0
     for name, path in sorted(boards.items()):

--- a/tests/test_850_demand_face_of.py
+++ b/tests/test_850_demand_face_of.py
@@ -357,8 +357,16 @@ def the_golden(boards):
             check('golden: %s -- #862 only ADDED demand' % key,
                   all(got[f] >= post[f] for f in post),
                   '%r fell against the #850 row %r' % (got, post))
+            # MEASURED against the #850 column, not `want_ipads` against
+            # `ipads`: those are two literals in this file and the check
+            # reduced to `308 < 379`, which no code change can fail. A blind
+            # review caught it. `rows[0]` is the live ledger.
             check('golden: %s -- #862 only REMOVED interior pads' % key,
-                  want_ipads < ipads, '%d !< %d' % (want_ipads, ipads))
+                  rows[0]['interior_pads'] < ipads,
+                  '%r !< %d' % (rows[0]['interior_pads'], ipads))
+            check('golden: %s -- and the box count is the #850 number' % key,
+                  rows[0]['interior_pads_box'] == ipads,
+                  '%r != %d' % (rows[0]['interior_pads_box'], ipads))
         check('golden: %s interior_pads / interior_demand_nets' % key,
               (rows[0]['interior_pads'], rows[0]['interior_demand_nets'])
               == (want_ipads, want_ilost),

--- a/tests/test_862_enclosure.py
+++ b/tests/test_862_enclosure.py
@@ -36,7 +36,7 @@ RUN_ALL_TIMEOUT = 300
 
 FAILURES = []
 PASSED = []
-SECTIONS = 5
+SECTIONS = 7
 
 
 def check(name, cond, detail=''):
@@ -364,11 +364,167 @@ def the_corridor_is_only_asked_about_box_interior_pads():
           '{} pad(s) went the wrong way'.format(len(grew)))
 
 
+
+#: `{(board, ref): {basis: (box interior, union interior)}}` -- the two-sided
+#: gate, on the two boards that fail in OPPOSITE directions plus the four
+#: refs whose numbers must NOT move.
+#:
+#: Read the rows, they are the finding:
+#:   ulx3s U1   379 -> 308. An LFE5U BGA whose eight UNNETTED alignment marks
+#:              set the copper box 0.954mm outside the ball field, so the box
+#:              rule calls all 379 netted balls interior and the part reports
+#:              demand 0 on every face. 71 recover -- more than the 67-ball
+#:              outer ring of the 20x20 lattice, because some second-row balls
+#:              escape through sites where the outer row has no ball, which is
+#:              the thing a ring-vs-interior rule could not do.
+#:   qfn_interior_pads U1   5 -> 5, AND IT IS THE SAME FIVE PADS. The negative
+#:              control: pads 34-37 plus one sit behind the QFN's UNNETTED
+#:              south pin row and are genuinely enclosed. A previous attempt at
+#:              #862 (`_assignment_rect`, reverted in e1f233b4) measured
+#:              against the NETTED pads only and took this to 1. Measured, a
+#:              netted-only obstacle set still takes it to 0 today.
+#:   tigard U3 / glasgow_revC U1 / rp2350 U2 / watchy U1   unchanged, at every
+#:              basis in the envelope. Four refs that the rule must not touch.
+#:
+#: THE BASIS IS PART OF EVERY ROW, because since #862 `interior_pads` is a
+#: function of clearance and track width where before it was a function of
+#: geometry alone. 0.09/0.10 is where `check_channels` runs the corpus,
+#: 0.20/0.20 is `test_850`'s census basis, 0.25/0.30 is the CLI's own default.
+BASES = ((0.09, 0.10), (0.20, 0.20), (0.25, 0.30))
+GOLDEN_862 = {
+    ('ulx3s', 'U1'):              {b: (379, 308) for b in BASES},
+    ('qfn_interior_pads', 'U1'):  {b: (5, 5) for b in BASES},
+    ('tigard', 'U3'):             {b: (18, 18) for b in BASES},
+    ('glasgow_revC', 'U1'):       {b: (27, 27) for b in BASES},
+    ('rp2350_fpga_eensy_prePlane', 'U2'): {b: (25, 25) for b in BASES},
+    ('watchy', 'U1'):             {b: (0, 0) for b in BASES},
+}
+
+
+def _interior(board, ref, clr, trk):
+    """(box interior, union interior, the union's interior pad numbers)."""
+    from kicad_parser import parse_kicad_pcb
+    from placement import legality as L
+    key = (board, round(clr, 6))
+    if key not in _CACHE:
+        root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        pcb = parse_kicad_pcb(os.path.join(root, 'kicad_files',
+                                           board + '.kicad_pcb'))
+        _CACHE[key] = (pcb, L.part_copper_geometry(pcb.footprints, clr))
+    pcb, geoms = _CACHE[key]
+    fp = pcb.footprints[ref]
+    a = E.assign_faces(fp, geoms[ref], lane_mm=trk + clr,
+                       clearance=clr, track_width=trk)
+    box = un = 0
+    names = []
+    for i, (pad, face) in enumerate(a.faces):
+        if not getattr(pad, 'net_id', 0):
+            continue
+        if a.box_faces[i] is None:
+            box += 1
+        if face is None:
+            un += 1
+            names.append(pad.pad_number)
+    return box, un, tuple(sorted(names))
+
+
+# ---------------------------------------------------------------- section 6
+def the_two_sided_gate():
+    """ulx3s must fall a long way; qfn_interior_pads must not move at all.
+
+    They fail in OPPOSITE directions, which is why the issue insists on both:
+    a rule generous enough to free the BGA's outer ring is generous enough to
+    free four pads that are genuinely walled in behind an unnetted pin row.
+    """
+    for (board, ref), rows in sorted(GOLDEN_862.items()):
+        for (clr, trk), (want_box, want_un) in sorted(rows.items()):
+            box, un, _n = _interior(board, ref, clr, trk)
+            check('{}:{} at {}/{} interior {} -> {}'
+                  .format(board, ref, clr, trk, want_box, want_un),
+                  (box, un) == (want_box, want_un),
+                  'measured {} -> {}'.format(box, un))
+
+    # A COUNT IS NOT A SET. `qfn_interior_pads` reads 5 before and 5 after,
+    # and that is only a negative control if they are the SAME five pads --
+    # the reverted experiment's census printed "5 -> 1" as a win without ever
+    # asking which four had moved.
+    from placement import legality as L
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    for clr, trk in BASES:
+        pcb, geoms = _CACHE[('qfn_interior_pads', round(clr, 6))]
+        fp = pcb.footprints['U1']
+        a = E.assign_faces(fp, geoms['U1'], lane_mm=trk + clr,
+                           clearance=clr, track_width=trk)
+        before = tuple(sorted(p.pad_number for i, (p, _f)
+                              in enumerate(a.faces)
+                              if getattr(p, 'net_id', 0)
+                              and a.box_faces[i] is None))
+        after = tuple(sorted(p.pad_number for p, f in a.faces
+                             if getattr(p, 'net_id', 0) and f is None))
+        check('qfn_interior_pads:U1 keeps the SAME pads at {}/{}'
+              .format(clr, trk), before == after,
+              '{} -> {}'.format(before, after))
+
+    # And the recovery on ulx3s is a real rescue, not a re-labelling: the 71
+    # pads the corridor frees must all have been box-interior.
+    box, un, _n = _interior('ulx3s', 'U1', 0.20, 0.20)
+    check('ulx3s:U1 recovers 71 balls', box - un == 71,
+          'recovered {}'.format(box - un))
+
+
+# ---------------------------------------------------------------- section 7
+def the_band_test_is_open_not_closed():
+    """The parameter the prose never named, and it decides everything.
+
+    "An obstacle counts when its band-axis span INTERSECTS the band" can be
+    read open (positive overlap) or closed (touching counts). Open is right,
+    and the witness is real geometry: `tigard` U3's exposed pad is drawn as
+    sub-rects sitting inside a full-size EP rect, and a sub-pad shares the
+    edge y=58.225 with that rect. The EP lies entirely SOUTH of the sub-pad,
+    so it cannot block a NORTHWARD escape -- but a closed test counts it as
+    blocking a band it overlaps by exactly zero.
+
+    The stake is not a few pads. Under the closed reading, an obstacle list
+    that includes the pad's own rect -- which this one deliberately does,
+    because strictness makes self-exclusion free -- blocks every pad against
+    itself, and the union collapses to the box rule EXACTLY: 2054 interior at
+    every basis, every witness ref still reading 308 and 5, and the rule
+    doing nothing at all while every corpus golden still passes.
+    """
+    # An obstacle whose span touches the band's near edge, and one that
+    # touches its far edge, are both entirely outside it.
+    check('touching the near band edge does not block',
+          near(E.free_run(0.0, 1.0, (0.0, 1.0), True,
+                          [(0.0, 1.0, 1.0, 2.0)]), 1.0))
+    check('touching the far band edge does not block',
+          near(E.free_run(0.0, 1.0, (0.0, 1.0), True,
+                          [(0.0, -1.0, 1.0, 0.0)]), 1.0))
+    # ... while any positive overlap does.
+    check('a hair of overlap does block',
+          near(E.free_run(0.0, 1.0, (0.0, 1.0), True,
+                          [(0.0, 0.999999, 1.0, 2.0)]), 0.0))
+
+    # THE SELF-CHARGE. A pad's own rect is in the obstacle list. Its band
+    # starts at its own edge, so under the open test it contributes nothing
+    # -- and if it ever did, it would cover its own strip end to end and
+    # NOTHING would escape anywhere.
+    pad = (4.0, 4.0, 5.0, 5.0)
+    lo, hi, band, horiz = E.pad_band((0.0, 0.0, 10.0, 10.0), 'north', pad)
+    check('a pad does not block its own corridor',
+          near(E.free_run(lo, hi, band, horiz, [pad]), 1.0))
+    check('... in every direction',
+          all(near(E.free_run(*E.pad_band((0.0, 0.0, 10.0, 10.0), f, pad),
+                              obstacles=[pad]), 1.0)
+              for f in E.FACES))
+
+
 def main():
     for fn in (the_free_run_kernel, the_pad_band_geometry,
                the_basis_is_a_pair_or_it_refuses,
                the_degradation_paths_are_declared,
-               the_corridor_is_only_asked_about_box_interior_pads):
+               the_corridor_is_only_asked_about_box_interior_pads,
+               the_two_sided_gate,
+               the_band_test_is_open_not_closed):
         fn()
     for f in FAILURES:
         print('FAIL: {}'.format(f))

--- a/tests/test_862_enclosure.py
+++ b/tests/test_862_enclosure.py
@@ -16,8 +16,16 @@ under them was specified before it was measured. EVERY expected value here is
 derived in the comment above it, from the fixture's own numbers; none was read
 off an implementation.
 
-Deliberately unit-only and fixture-only: it runs no board and takes well under
-a second, so it stays a FAST test that `run_all.py --fast` collects.
+Sections 1-2 are unit-only. EVERYTHING FROM SECTION 3 ON PARSES REAL BOARDS
+-- six of them, with `part_copper_geometry` over every footprint, and section
+8 runs the whole `board_lane_context` + `face_lane_ledger` + `escape_ledger`
+pipeline on ulx3s. Measured wall time is ~20s, not the "well under a second"
+an earlier version of this line claimed. `run_all.py` classifies fast vs
+integration on the strings `import run_utils` / `from run_utils` /
+`subprocess`, none of which appear here, so this file rides in `--fast` on
+that heuristic rather than on a measurement -- said out loud because a 20s
+test in the fast set is a thing a reader should be able to find out from the
+file.
 
     python3 -X utf8 tests/test_862_enclosure.py
 """
@@ -36,7 +44,7 @@ RUN_ALL_TIMEOUT = 300
 
 FAILURES = []
 PASSED = []
-SECTIONS = 8
+SECTIONS = 9
 
 
 def check(name, cond, detail=''):
@@ -380,7 +388,7 @@ def the_corridor_is_only_asked_about_box_interior_pads():
 #:   qfn_interior_pads U1   5 -> 5, AND IT IS THE SAME FIVE PADS. The negative
 #:              control: pads 34-37 plus one sit behind the QFN's UNNETTED
 #:              south pin row and are genuinely enclosed. A previous attempt at
-#:              #862 (`_assignment_rect`, reverted in e1f233b4) measured
+#:              #862 (`_assignment_rect`, reverted in 39ca0b98) measured
 #:              against the NETTED pads only and took this to 1. Measured, a
 #:              netted-only obstacle set still takes it to 0 today.
 #:   tigard U3 / glasgow_revC U1 / rp2350 U2 / watchy U1   unchanged, at every
@@ -405,6 +413,21 @@ GOLDEN_862 = {
     ('glasgow_revC', 'U1'):       {b: (27, 27) for b in BASES},
     ('rp2350_fpga_eensy_prePlane', 'U2'): {b: (25, 25) for b in BASES},
     ('watchy', 'U1'):             {b: (0, 0) for b in BASES},
+    # THE TWO REFS THAT TELL THE UNION FROM A REPLACEMENT, and the reason
+    # they are here: a blind review pointed out that none of the six rows
+    # above distinguishes them -- ulx3s reads 308 and qfn reads 5 under BOTH
+    # rules, at every basis -- so the whole "union, not replacement"
+    # argument had no golden behind it. These two do. Each is a 0.325mm
+    # 5-pad part whose central 0.82mm GND pad sits 0.0699mm from the copper
+    # box on west and east, plainly on the boundary; the corridor alone
+    # calls it interior because an axis-aligned shadow through a 0.07mm band
+    # is closed by the flanking pads once inflated, and the box half is what
+    # keeps it escaping. Under a replacement each reads 1. (The central pad is
+    # 0.58 x 0.58 at 45 degrees; 0.82mm is its axis-aligned extent, which is
+    # the number this rule works in.)
+    ('orangecrab_ext_pll', 'U10'): {b: (0, 0) for b in BASES},
+    ('rp2350_fpga_eensy_prePlane', 'U4'): {b: (0, 0) for b in BASES},
+    # (5 copper pads of 13 pad entries -- the footprint is Texas_X2SON-4.)
 }
 
 
@@ -478,8 +501,72 @@ def the_two_sided_gate():
     check('ulx3s:U1 recovers 71 balls', box - un == 71,
           'recovered {}'.format(box - un))
 
+    # THE UNION IS NOT A REPLACEMENT, asserted by RUNNING the replacement
+    # rather than by an invariant that cannot fail. `assign_faces` can only
+    # add escapes -- it recomputes a face solely when the box half returned
+    # None -- so "no pad the box placed became interior" is true by
+    # construction and sees nothing. This arm patches the box half out and
+    # requires the answer to MOVE, on the two refs that discriminate.
+    from placement import legality as L2
+    moved = {}
+    for board, ref in (('orangecrab_ext_pll', 'U10'),
+                       ('rp2350_fpga_eensy_prePlane', 'U4')):
+        pcb, geoms = _CACHE[(board, 0.2)]
+        fp = pcb.footprints[ref]
+        geom = geoms[ref]
+        corr = E.PadCorridors(geom.copper, tuple(geom.pads.values()), 0.2, 0.2)
+        n = 0
+        for pad in fp.pads:
+            if not getattr(pad, 'net_id', 0):
+                continue
+            box = L2.pad_box(geom, pad)
+            if box is None:
+                continue
+            # The CORRIDOR ALONE, with no box-tolerance accept in front of
+            # it -- which is what "replace" means and what `face_of` cannot
+            # be made to do from outside, because its tolerance short-circuits
+            # before the corridor is ever consulted.
+            if not any(corr.clear(f, box) for f in E.FACES):
+                n += 1
+        moved['%s:%s' % (board, ref)] = n
+    check('a REPLACING rule gains interior pads where the union does not',
+          all(v == 1 for v in moved.values()), repr(moved))
+
 
 # ---------------------------------------------------------------- section 7
+def the_zero_depth_band_is_an_escape():
+    """`PadCorridors.clear`'s base case, which `assign_faces` cannot reach.
+
+    A pad ON the box edge has a band of zero depth and escapes trivially.
+    `assign_faces` never asks: it consults the corridor only when the box
+    half said `min(d) > tol`, and `band[1] - band[0]` IS `d[face]`, so the
+    arm is unreachable through that path -- measured, 0 of 70464 `clear`
+    calls over the corpus at four bases take it.
+
+    It is kept because it is the definition's base case and the guard that
+    binds the moment the box half is removed, and it is tested HERE because
+    nothing else calls `clear` directly -- `free_run` and `pad_band` each
+    have their own arms and the function that actually decides had none.
+    """
+    rect = (0.0, 0.0, 10.0, 10.0)
+    edge = (4.0, 0.0, 5.0, 1.0)          # flush against the box's north edge
+    blocked = [(0.0, 0.0, 10.0, 10.0)]   # a slab covering everything
+    c = E.PadCorridors(rect, tuple(blocked), 0.2, 0.2)
+    check('a pad on the box edge escapes that way even through a slab',
+          c.clear('north', edge))
+    check('...and is still blocked the other way',
+          not c.clear('south', edge))
+
+    # The candidate index must change no answer -- it is a pre-filter on
+    # `free_run`'s own clip, not a heuristic. Asserted on a case where the
+    # index actually excludes something.
+    far = [(100.0, 0.0, 101.0, 10.0)]
+    c2 = E.PadCorridors(rect, tuple(far), 0.2, 0.2)
+    want = E.free_run(4.0, 5.0, (5.0, 10.0), True, far, grow=0.2) >= 0.2
+    check('an obstacle outside the strip is excluded and changes nothing',
+          c2.clear('south', (4.0, 4.0, 5.0, 5.0)) == want)
+
+
 def the_band_test_is_open_not_closed():
     """The parameter the prose never named, and it decides everything.
 
@@ -609,6 +696,7 @@ def main():
                the_corridor_is_only_asked_about_box_interior_pads,
                the_two_sided_gate,
                the_band_test_is_open_not_closed,
+               the_zero_depth_band_is_an_escape,
                the_basis_is_published_by_both):
         fn()
     for f in FAILURES:

--- a/tests/test_862_enclosure.py
+++ b/tests/test_862_enclosure.py
@@ -495,6 +495,19 @@ def the_two_sided_gate():
               .format(clr, trk), before == after,
               '{} -> {}'.format(before, after))
 
+    # THE CLIFF, pinned rather than described. The strip a corridor measures
+    # IS the pad's own span, so a pad narrower than `track_width` can never be
+    # rescued however empty the field in front of it -- and that is a step,
+    # not a slope. ulx3s U1's balls are 0.4mm wide: 71 recover at every track
+    # up to and including 0.400 and 0 at 0.401. `check_channels` floors the
+    # track UP to the fab floor, which can only move toward that edge, so a
+    # reader is entitled to find this out from a test rather than from a
+    # board.
+    for trk, want in ((0.30, 71), (0.40, 71), (0.401, 0), (0.50, 0)):
+        b2, u2, _n2 = _interior('ulx3s', 'U1', 0.20, trk)
+        check('ulx3s:U1 rescues {} at track {}'.format(want, trk),
+              b2 - u2 == want, 'rescued {}'.format(b2 - u2))
+
     # And the recovery on ulx3s is a real rescue, not a re-labelling: the 71
     # pads the corridor frees must all have been box-interior.
     box, un, _n = _interior('ulx3s', 'U1', 0.20, 0.20)

--- a/tests/test_862_enclosure.py
+++ b/tests/test_862_enclosure.py
@@ -390,7 +390,14 @@ def the_corridor_is_only_asked_about_box_interior_pads():
 #: function of clearance and track width where before it was a function of
 #: geometry alone. 0.09/0.10 is where `check_channels` runs the corpus,
 #: 0.20/0.20 is `test_850`'s census basis, 0.25/0.30 is the CLI's own default.
-BASES = ((0.09, 0.10), (0.20, 0.20), (0.25, 0.30))
+#: 0.40/0.40 is not a basis any caller uses, and it is here for a reason a
+#: mutation run supplied: WITHOUT it, dropping FREE_RUN_EPS survives this
+#: whole gate. The epsilon only bites where a free run lands exactly on the
+#: threshold, which on this corpus is clearance 0.05 and 0.40 and nowhere
+#: else -- so a gate pinned only at the bases in use cannot see the trap that
+#: motivated the constant. At 0.40/0.40 a bare comparison puts 33 of ulx3s
+#: U1'''s recovered balls back in the interior bucket (308 -> 341).
+BASES = ((0.09, 0.10), (0.20, 0.20), (0.25, 0.30), (0.40, 0.40))
 GOLDEN_862 = {
     ('ulx3s', 'U1'):              {b: (379, 308) for b in BASES},
     ('qfn_interior_pads', 'U1'):  {b: (5, 5) for b in BASES},

--- a/tests/test_862_enclosure.py
+++ b/tests/test_862_enclosure.py
@@ -540,8 +540,11 @@ def the_zero_depth_band_is_an_escape():
     A pad ON the box edge has a band of zero depth and escapes trivially.
     `assign_faces` never asks: it consults the corridor only when the box
     half said `min(d) > tol`, and `band[1] - band[0]` IS `d[face]`, so the
-    arm is unreachable through that path -- measured, 0 of 70464 `clear`
-    calls over the corpus at four bases take it.
+    arm is unreachable through that path -- measured, 0 of 32960 `clear` calls
+    take it, over `run_utils.corpus_boards()`'s 22 TRACKED boards at four
+    bases. (The basis is named because `kicad_files/` accumulates generated
+    boards, so a directory glob answers a different and larger number on a
+    machine that has run the suite.)
 
     It is kept because it is the definition's base case and the guard that
     binds the moment the box half is removed, and it is tested HERE because

--- a/tests/test_862_enclosure.py
+++ b/tests/test_862_enclosure.py
@@ -36,7 +36,7 @@ RUN_ALL_TIMEOUT = 300
 
 FAILURES = []
 PASSED = []
-SECTIONS = 7
+SECTIONS = 8
 
 
 def check(name, cond, detail=''):
@@ -525,13 +525,91 @@ def the_band_test_is_open_not_closed():
               for f in E.FACES))
 
 
+
+#: The six keys #862 publishes, on BOTH instruments, spelled identically so
+#: the two JSON outputs can be diffed key for key.
+PUBLISHED = ('interior_pads_box', 'face_corridor_escapes',
+             'face_corridor_source', 'face_corridor_clearance_mm',
+             'face_corridor_track_mm', 'face_pitch_mm')
+
+
+# ---------------------------------------------------------------- section 8
+def the_basis_is_published_by_both():
+    """A basis nobody can read is the defect #847 was about, one level down.
+
+    `interior_pads` changed KIND in this change, not just value: it was a
+    function of the part's geometry and is now a function of the clearance and
+    the track width too. A reader diffing two runs must be able to tell a
+    placement that moved from a basis that moved, and to recover the
+    basis-free number when they want the fanout fact alone.
+    """
+    from kicad_parser import parse_kicad_pcb
+    from placement import routability as R
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    path = os.path.join(root, 'kicad_files', 'ulx3s.kicad_pcb')
+    pcb = parse_kicad_pcb(path)
+    ctx = R.board_lane_context(pcb, 0.2, pcb_file=path)
+    rows = R.face_lane_ledger(pcb, 'U1', clearance=0.2, track_width=0.2,
+                              grid_step=0.05, pcb_file=path, context=ctx)
+    led = E.escape_ledger(pcb, refs=['U1'], pcb_file=path,
+                          track_width=0.2, clearance=0.2)
+    esc = led[0].to_dict()
+
+    for k in PUBLISHED:
+        check('the routability row publishes {}'.format(k), k in rows[0])
+        check('the escape row publishes {}'.format(k), k in esc)
+        check('...and the two agree on {}'.format(k),
+              rows[0].get(k) == esc.get(k),
+              '{!r} != {!r}'.format(rows[0].get(k), esc.get(k)))
+        check('...and it is never None on {}'.format(k),
+              rows[0].get(k) is not None and esc.get(k) is not None)
+
+    # The row repeats the part-level facts on all four faces, the way
+    # `escape_band_mm` does, so a machine holding ONE row has the basis.
+    check('every face row carries the basis',
+          all(r['face_corridor_track_mm'] == 0.2
+              and r['face_corridor_clearance_mm'] == 0.2 for r in rows))
+
+    # THE CONSERVATION LAW. A pad that leaves the interior bucket has to be
+    # accounted for somewhere; a count that fell with nothing naming where it
+    # went is how a ledger stops looking and reads as a fix.
+    check('interior + freed == the box-rule count (routability)',
+          (rows[0]['interior_pads'] + rows[0]['face_corridor_escapes']
+           == rows[0]['interior_pads_box']),
+          '{} + {} != {}'.format(rows[0]['interior_pads'],
+                                 rows[0]['face_corridor_escapes'],
+                                 rows[0]['interior_pads_box']))
+    check('interior + freed == the box-rule count (escape)',
+          esc['interior_pads'] + esc['face_corridor_escapes']
+          == esc['interior_pads_box'])
+    check('and ulx3s U1 is the 379 -> 308 witness',
+          (esc['interior_pads_box'], esc['interior_pads'],
+           esc['face_corridor_escapes']) == (379, 308, 71),
+          repr((esc['interior_pads_box'], esc['interior_pads'],
+                esc['face_corridor_escapes'])))
+
+    # `interior_pads_box` is the BASIS-FREE number, and that is checkable
+    # rather than asserted in prose: `CopperGeometry.copper` carries neither
+    # clearance nor track width, so the box count cannot move with them.
+    for clr, trk in ((0.09, 0.10), (0.25, 0.30)):
+        r2 = R.face_lane_ledger(pcb, 'U1', clearance=clr, track_width=trk,
+                                grid_step=0.05, pcb_file=path,
+                                context=R.board_lane_context(
+                                    pcb, clr, pcb_file=path))
+        check('interior_pads_box does not move with the basis {}/{}'
+              .format(clr, trk),
+              r2[0]['interior_pads_box'] == 379,
+              str(r2[0]['interior_pads_box']))
+
+
 def main():
     for fn in (the_free_run_kernel, the_pad_band_geometry,
                the_basis_is_a_pair_or_it_refuses,
                the_degradation_paths_are_declared,
                the_corridor_is_only_asked_about_box_interior_pads,
                the_two_sided_gate,
-               the_band_test_is_open_not_closed):
+               the_band_test_is_open_not_closed,
+               the_basis_is_published_by_both):
         fn()
     for f in FAILURES:
         print('FAIL: {}'.format(f))

--- a/tests/test_862_enclosure.py
+++ b/tests/test_862_enclosure.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""#862: the enclosure test -- the kernel, on arithmetic derived by hand.
+
+`escape.face_of` calls a pad INTERIOR when its copper box is further than
+`max(pad_pitch/2, INTERIOR_EPS)` from all four edges of the part's copper box.
+That box is the union of EVERY pad's copper, and a box cannot tell a few small
+marks outside the pad field from a ring that encloses it: on ulx3s U1, eight
+UNNETTED 0.127 x 0.508mm alignment marks sit 0.954mm beyond the ball field on
+all four sides, so all 379 netted balls read interior and the part reports
+demand 0 on every face.
+
+This file is the gate for the OCCUPANCY half that answers it. Sections 1-2
+cover the kernel alone -- `free_run` and `pad_band` -- because the corpus
+numbers that follow in later sections are only meaningful if the arithmetic
+under them was specified before it was measured. EVERY expected value here is
+derived in the comment above it, from the fixture's own numbers; none was read
+off an implementation.
+
+Deliberately unit-only and fixture-only: it runs no board and takes well under
+a second, so it stays a FAST test that `run_all.py --fast` collects.
+
+    python3 -X utf8 tests/test_862_enclosure.py
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))), 'py_placer'))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(
+    os.path.abspath(__file__))), 'py_router'))
+
+from placement import escape as E                              # noqa: E402
+
+RUN_ALL_TIMEOUT = 120
+RUN_ALL_FAST_OK = True
+
+FAILURES = []
+PASSED = []
+SECTIONS = 2
+
+
+def check(name, cond, detail=''):
+    if cond:
+        PASSED.append(name)
+    else:
+        FAILURES.append('{}{}'.format(name, ': ' + detail if detail else ''))
+
+
+def near(a, b, eps=1e-9):
+    return abs(a - b) < eps
+
+
+# ---------------------------------------------------------------- section 1
+def the_free_run_kernel():
+    """`free_run` returns the largest CONTIGUOUS gap, not the total.
+
+    The distinction is the whole reason this is not `span_eaten`: measured on
+    the tracked corpus at clearance 0.09, thresholding on the total instead
+    moves nine refs and takes `qfn_interior_pads` U1 from 5 interior pads to
+    2 -- while being a value no-op at clearance 0.20 and 0.25, so a test
+    written at the census basis alone cannot tell the two apart.
+    """
+    # Nothing in the way: the whole strip is free.
+    check('empty obstacle list gives the whole strip',
+          near(E.free_run(0.0, 1.0, (0.0, 1.0), True, []), 1.0))
+
+    # One obstacle spanning x 0.0..1.0 inside the band covers everything.
+    full = [(0.0, 0.0, 1.0, 1.0)]
+    check('an obstacle covering the strip leaves nothing',
+          near(E.free_run(0.0, 1.0, (0.0, 1.0), True, full), 0.0))
+
+    # THE DISCRIMINATING FIXTURE. Strip [0, 1]. Three obstacles at
+    # x 0.2..0.3, 0.5..0.6 and 0.8..0.9 leave gaps 0.2 / 0.2 / 0.2 / 0.1,
+    # total free 0.7 but the largest single run 0.2. A 0.3mm track fits in
+    # NONE of them, and a rule that thresholds on the total would pass it.
+    three = [(0.2, 0.0, 0.3, 1.0), (0.5, 0.0, 0.6, 1.0), (0.8, 0.0, 0.9, 1.0)]
+    got = E.free_run(0.0, 1.0, (0.0, 1.0), True, three)
+    check('three small gaps do not add up to one lane', near(got, 0.2),
+          'largest run {} (total free is 0.7)'.format(got))
+
+    # The leading and trailing gaps count too: one obstacle at x 0.4..0.6
+    # leaves 0.4 before it and 0.4 after it.
+    mid = [(0.4, 0.0, 0.6, 1.0)]
+    check('the leading and trailing gaps are runs too',
+          near(E.free_run(0.0, 1.0, (0.0, 1.0), True, mid), 0.4))
+
+    # OVERLAPPING obstacles are unioned, not summed: 0.2..0.5 and 0.4..0.7
+    # cover 0.2..0.7, leaving 0.3 before and 0.3 after.
+    lap = [(0.2, 0.0, 0.5, 1.0), (0.4, 0.0, 0.7, 1.0)]
+    check('overlapping obstacles are unioned',
+          near(E.free_run(0.0, 1.0, (0.0, 1.0), True, lap), 0.3))
+
+    # `grow` inflates ALONG the strip. The three obstacles at 0.2..0.3,
+    # 0.5..0.6 and 0.8..0.9, grown by 0.1 on each side, become 0.1..0.4,
+    # 0.4..0.7 and 0.7..1.0 -- which between them cover 0.1..1.0, so the only
+    # free run left is the leading 0.0..0.1. Every 0.2 gap a bare measurement
+    # saw is eaten by the clearance a track may not touch.
+    grown = [(0.2, 0.0, 0.3, 1.0), (0.5, 0.0, 0.6, 1.0), (0.8, 0.0, 0.9, 1.0)]
+    check('grow closes the gaps a clearance eats',
+          near(E.free_run(0.0, 1.0, (0.0, 1.0), True, grown, grow=0.1), 0.1))
+
+    # Grow is NOT applied across the band, so an obstacle that does not reach
+    # the band is not pulled into it by the clearance. This one spans
+    # y 2.0..3.0 against a band of (0.0, 1.0).
+    off = [(0.0, 2.0, 1.0, 3.0)]
+    check('grow does not drag a far obstacle into the band',
+          near(E.free_run(0.0, 1.0, (0.0, 1.0), True, off, grow=0.5), 1.0))
+
+    # STRICTNESS. An obstacle whose band-axis span merely TOUCHES the band is
+    # not in the way. This is what excludes the escaping pad itself (its rect
+    # starts exactly where the band ends) and its own row-mates, with no
+    # self-exclusion bookkeeping -- the property the whole design rests on.
+    touch = [(0.0, 1.0, 1.0, 2.0)]      # y 1.0..2.0 against band (0.0, 1.0)
+    check('an obstacle touching the band edge is not in the way',
+          near(E.free_run(0.0, 1.0, (0.0, 1.0), True, touch), 1.0))
+    touch_lo = [(0.0, -1.0, 1.0, 0.0)]  # y -1.0..0.0, touching the far edge
+    check('an obstacle touching the far band edge is not in the way',
+          near(E.free_run(0.0, 1.0, (0.0, 1.0), True, touch_lo), 1.0))
+    # ... but one that genuinely enters the band is.
+    inside = [(0.0, 0.5, 1.0, 2.0)]
+    check('an obstacle that enters the band is in the way',
+          near(E.free_run(0.0, 1.0, (0.0, 1.0), True, inside), 0.0))
+
+    # The vertical orientation is the same arithmetic with the axes swapped:
+    # the run is measured along y and the band is on x.
+    vert = [(0.0, 0.4, 1.0, 0.6)]
+    check('the vertical orientation measures along y',
+          near(E.free_run(0.0, 1.0, (0.0, 1.0), False, vert), 0.4))
+
+    # THE EPSILON, on real coordinates rather than invented ones. ulx3s U1's
+    # ball A2 parses to a copper box whose x runs 131.48000000000002 ..
+    # 131.88, so its span is 0.39999999999997726 and a bare `>= 0.4` is
+    # FALSE for a nominally 0.4mm pad. Measured, 385 of that part's 389 pads
+    # are sub-nominal this way, so it is the rule and not a corner case: a
+    # bare comparison puts the BGA's whole outer ring back in the interior
+    # bucket at track 0.4 while answering correctly at track 0.2.
+    #
+    # Invented coordinates do NOT reproduce it -- 139.08 - 138.68 is
+    # 0.4000000000000057, on the other side of the nominal width -- which is
+    # exactly why this fixture carries the parser's numbers.
+    lo, hi = 131.48000000000002, 131.88
+    span = E.free_run(lo, hi, (0.0, 1.0), True, [])
+    check('the kernel reports the true subtracted span', near(span, hi - lo))
+    check('a real ball span is BELOW its nominal width', span < 0.4,
+          'A2 span {!r} -- if this ever stops being true the epsilon is '
+          'untested, not unnecessary'.format(span))
+    check('and clears the nominal width once the epsilon is applied',
+          span >= 0.4 - E.FREE_RUN_EPS)
+
+
+# ---------------------------------------------------------------- section 2
+def the_pad_band_geometry():
+    """`pad_band` is `face_band` turned inward: pad edge to box edge."""
+    # A 10x10 copper box with a 1x1 pad at (4,4)..(5,5).
+    rect = (0.0, 0.0, 10.0, 10.0)
+    box = (4.0, 4.0, 5.0, 5.0)
+
+    # North is toward miny (KiCad y grows downward, as `_face_geometry` has
+    # it), so the band runs from the box's miny up to the pad's own py0, and
+    # the strip is the pad's x span.
+    lo, hi, band, horiz = E.pad_band(rect, 'north', box)
+    check('north: strip is the pad x span, band is miny..py0',
+          (lo, hi, band, horiz) == (4.0, 5.0, (0.0, 4.0), True))
+
+    lo, hi, band, horiz = E.pad_band(rect, 'south', box)
+    check('south: band is py1..maxy',
+          (lo, hi, band, horiz) == (4.0, 5.0, (5.0, 10.0), True))
+
+    lo, hi, band, horiz = E.pad_band(rect, 'west', box)
+    check('west: strip is the pad y span, band is minx..px0',
+          (lo, hi, band, horiz) == (4.0, 5.0, (0.0, 4.0), False))
+
+    lo, hi, band, horiz = E.pad_band(rect, 'east', box)
+    check('east: band is px1..maxx',
+          (lo, hi, band, horiz) == (4.0, 5.0, (5.0, 10.0), False))
+
+    # A pad ON an edge of the box gets a zero-depth band there -- which is
+    # what "already on the box edge" means, and the case the caller reads as
+    # an unconditional escape.
+    edge = (4.0, 0.0, 5.0, 1.0)
+    _lo, _hi, band, _h = E.pad_band(rect, 'north', edge)
+    check('a pad on the box edge has a zero-depth band',
+          near(band[1] - band[0], 0.0))
+
+    # The strip is the PAD's span and nothing else -- not a pitch-wide window.
+    # Measured, a window collapses ulx3s U1 to 0 interior pads at clearance
+    # 0.09, and `pad_pitch` reads 0.100 on qfn_interior_pads, so a
+    # pitch-derived strip is fragile by construction.
+    narrow = (4.4, 4.0, 4.6, 5.0)
+    lo, hi, _b, _h = E.pad_band(rect, 'north', narrow)
+    check('the strip is the pad span, not a pitch-wide window',
+          near(hi - lo, 0.2))
+
+
+def main():
+    for fn in (the_free_run_kernel, the_pad_band_geometry):
+        fn()
+    for f in FAILURES:
+        print('FAIL: {}'.format(f))
+    if FAILURES:
+        print('\n{} FAILED of {} checks in {} sections'
+              .format(len(FAILURES), len(FAILURES) + len(PASSED), SECTIONS))
+        return 1
+    print('OK -- {} checks in {} sections'.format(len(PASSED), SECTIONS))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_862_enclosure.py
+++ b/tests/test_862_enclosure.py
@@ -32,12 +32,11 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(
 
 from placement import escape as E                              # noqa: E402
 
-RUN_ALL_TIMEOUT = 120
-RUN_ALL_FAST_OK = True
+RUN_ALL_TIMEOUT = 300
 
 FAILURES = []
 PASSED = []
-SECTIONS = 2
+SECTIONS = 5
 
 
 def check(name, cond, detail=''):
@@ -193,8 +192,183 @@ def the_pad_band_geometry():
           near(hi - lo, 0.2))
 
 
+
+#: The modelled fixture. `qfn_interior_pads` exists in the corpus for exactly
+#: this question -- an HVQFN-32 whose pads 34-37 (INT1, INT2 and two GND
+#: guards) sit 1.075mm inside the part's south copper edge, boxed in by the
+#: QFN's UNNETTED south pin row. It is the board a previous attempt at #862
+#: broke, so it is the right fixture to build the gate on. Real geometry
+#: rather than stubs, because `part_copper_geometry` refuses to model a pad
+#: that carries no size and the whole point here is the MODELLED path.
+_FIXTURE = 'qfn_interior_pads'
+_FIXTURE_REF = 'U1'
+_CACHE = {}
+
+
+def _fixture(clearance=0.2):
+    key = round(clearance, 6)
+    if key not in _CACHE:
+        from kicad_parser import parse_kicad_pcb
+        from placement import legality as L
+        root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        pcb = parse_kicad_pcb(os.path.join(root, 'kicad_files',
+                                           _FIXTURE + '.kicad_pcb'))
+        geom = L.part_copper_geometry(pcb.footprints, clearance)[_FIXTURE_REF]
+        _CACHE[key] = (pcb.footprints[_FIXTURE_REF], geom)
+    return _CACHE[key]
+
+
+# ---------------------------------------------------------------- section 3
+def the_basis_is_a_pair_or_it_refuses():
+    """A half-named basis is a plausible wrong number, so it raises.
+
+    This lives in `assign_faces` rather than in each ledger because that is
+    the one function both lane ledgers share: a check placed in either caller
+    could be present in one instrument and missing from the other, which is
+    the shape of every defect #835, #841, #847, #849 and #850 closed.
+    """
+    fp, geom = _fixture()
+
+    def raises(**kw):
+        try:
+            E.assign_faces(fp, geom, lane_mm=0.4, **kw)
+        except ValueError as exc:
+            return str(exc)
+        return None
+
+    msg = raises(clearance=0.2)
+    check('a clearance without a track width refuses', msg is not None)
+    check('and the refusal says it is a pair', bool(msg) and 'PAIR' in msg,
+          str(msg))
+
+    check('a track width without a clearance refuses',
+          raises(track_width=0.2) is not None)
+
+    msg = raises(clearance=0.2, track_width=0.0)
+    check('a zero-width track refuses', msg is not None)
+    check('and the refusal cites what a zero threshold measures',
+          bool(msg) and 'qfn_interior_pads' in msg, str(msg))
+
+    check('a negative clearance refuses',
+          raises(clearance=-0.1, track_width=0.2) is not None)
+
+    # Naming NEITHER is the documented way to ask for the pre-#862 answer.
+    a = E.assign_faces(fp, geom, lane_mm=0.4)
+    check('naming neither is not an error',
+          a.corridor_source == 'not_measured', a.corridor_source)
+    check('and then the union answer IS the box answer',
+          list(a.box_faces) == [f for _p, f in a.faces])
+
+
+# ---------------------------------------------------------------- section 4
+def the_degradation_paths_are_declared():
+    """Every path that cannot run the corridor SAYS which one it was.
+
+    Four distinct strings rather than one `unknown`, because "nobody asked"
+    and "this part has no pad model" are different facts and a reader has to
+    be able to tell them apart.
+    """
+    fp, geom = _fixture()
+
+    a = E.assign_faces(fp, None, lane_mm=0.4, fallback_rect=(0.0, 0.0, 4.0,
+                                                             4.0),
+                       clearance=0.2, track_width=0.2)
+    check('an unmodelled part says so', a.corridor_source == 'unmodelled',
+          a.corridor_source)
+
+    a = E.assign_faces(fp, geom._replace(pads={}), lane_mm=0.4,
+                       clearance=0.2, track_width=0.2)
+    check('a part with no pad boxes says so',
+          a.corridor_source == 'no_pad_boxes', a.corridor_source)
+
+    a = E.assign_faces(fp, geom, lane_mm=0.4, clearance=0.2, track_width=0.2)
+    check('a modelled part reports the caller as the source',
+          a.corridor_source == 'caller', a.corridor_source)
+    check('and records the basis it ran at',
+          (a.corridor_clearance_mm, a.corridor_track_mm) == (0.2, 0.2))
+
+    # THE COVERAGE DECLARATION, asserted rather than assumed.
+    # `tests/test_escape_ledger.py`'s synthetic parts carry no pad sizes, so
+    # `part_copper_geometry` returns `modelled=False` with an EMPTY `pads`
+    # table and `legality.pad_box` answers None for every pad. Its
+    # `interior_pads == 9` oracle is preserved by the degradation path above
+    # -- and it witnesses NOTHING about the corridor. Pinned here so that the
+    # day those fixtures gain a pad model, a test says so instead of that
+    # oracle quietly changing meaning.
+    import importlib.util
+    from placement import legality as L
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    spec = importlib.util.spec_from_file_location(
+        '_tel', os.path.join(root, 'tests', 'test_escape_ledger.py'))
+    tel = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(tel)
+    bare = tel._grid_part(n=5, pitch=0.5, interior=True)
+    g = L.part_copper_geometry({'U1': bare}, 0.25).get('U1')
+    check('the escape_ledger fixture is unmodelled',
+          g is not None and not g.modelled)
+    check('... with an empty pad table', g is not None and not g.pads)
+    check('... so every pad_box is None',
+          g is not None and all(L.pad_box(g, p) is None for p in bare.pads))
+    a = E.assign_faces(bare, g, lane_mm=0.45, clearance=0.25, track_width=0.2)
+    check('... the corridor never runs there',
+          a.corridor_source == 'no_pad_boxes', a.corridor_source)
+    check('... and its interior verdict is the box rule, unchanged',
+          list(a.box_faces) == [f for _p, f in a.faces])
+    check('... which is still 9 interior pads',
+          sum(1 for _p, f in a.faces if f is None) == 9,
+          str(sum(1 for _p, f in a.faces if f is None)))
+
+
+# ---------------------------------------------------------------- section 5
+def the_corridor_is_only_asked_about_box_interior_pads():
+    """Not an optimisation -- a proof, and it is asserted as one.
+
+    When `min(d) <= tol` the argmin direction is itself in the escaping set,
+    so filtering the tie block by the corridor cannot move the answer. The
+    union therefore only ADDS escapes, and asking the corridor about a pad the
+    box half already placed would be dead work that could only change an
+    answer by being wrong.
+    """
+    from placement import legality as L
+    fp, geom = _fixture()
+    seen = []
+    real = E.PadCorridors.clear
+
+    def spy(self, face, pad_box):
+        seen.append(pad_box)
+        return real(self, face, pad_box)
+
+    E.PadCorridors.clear = spy
+    try:
+        a = E.assign_faces(fp, geom, lane_mm=0.4,
+                           clearance=0.2, track_width=0.2)
+    finally:
+        E.PadCorridors.clear = real
+
+    asked = set(seen)
+    accepted = {L.pad_box(geom, p)
+                for p, f in zip(fp.pads, a.box_faces)
+                if f is not None and L.pad_box(geom, p) is not None}
+    check('the corridor ran at all', len(seen) > 0, str(len(seen)))
+    check('and was never asked about a pad the box half accepted',
+          not (asked & accepted),
+          '{} of {} accepted pads were asked'.format(
+              len(asked & accepted), len(accepted)))
+
+    # The union can only ADD escapes, never remove one. Provable, and this is
+    # the arm that fails the moment someone makes the corridor a REPLACEMENT
+    # for the box test rather than a second sufficient condition.
+    grew = [i for i, (_p, f) in enumerate(a.faces)
+            if f is None and a.box_faces[i] is not None]
+    check('no pad the box half placed became interior', not grew,
+          '{} pad(s) went the wrong way'.format(len(grew)))
+
+
 def main():
-    for fn in (the_free_run_kernel, the_pad_band_geometry):
+    for fn in (the_free_run_kernel, the_pad_band_geometry,
+               the_basis_is_a_pair_or_it_refuses,
+               the_degradation_paths_are_declared,
+               the_corridor_is_only_asked_about_box_interior_pads):
         fn()
     for f in FAILURES:
         print('FAIL: {}'.format(f))


### PR DESCRIPTION
## A bounding box cannot tell eight corner dots from an enclosing ring

`escape.face_of` decides whether a pad can escape sideways by measuring its
copper edge against `CopperGeometry.copper` — the bounding box over **every**
pad's copper — and calls a pad further than `max(pad_pitch/2, INTERIOR_EPS)`
from all four edges INTERIOR: it needs a via, not a lane.

Closes #862

Rebased onto `main` at `9dda4114` at the maintainer's request, so this is now
purely the #862 delta — 13 commits, 13 files. The #850/#848 half it used to
carry is on `main` already, via the #863 merge (`fd1db046`); I compared each
file's delta over its own base before and after the rebase and all six are
byte-identical.

#850 made this worse by publishing it through a second instrument.

`ulx3s` U1 is an LFE5U BGA: 389 pads, **379 netted balls**, pitch 0.8 so the
face tolerance is 0.4. Eight **unnetted** alignment marks sit at its corners —
four 0.127 × 0.508 mm and four the same oval rotated, stacked in pairs to form
four crosses — **0.954 mm outside the ball field on all four sides**, and they
set `CopperGeometry.copper` — the box every pad's distance is measured against.
0.954 > 0.4, so every one of the 379 balls read INTERIOR and the part reported
**demand 0 on all four faces**: a 379-ball BGA that asks nothing of any of its
channels, and a `check_channels` deficit of 0 for the best possible reason and
the worst possible cause.

**The rule is now a union of two sufficient conditions.** A pad escapes a
direction when the band it must cross is shallower than
`max(pad_pitch/2, INTERIOR_EPS)` — the old test, kept verbatim — **or** when
the largest **contiguous** free run across that band, in the pad's own strip,
is at least one `track_width` wide with every other pad of the part inflated by
`clearance`. A pad that escapes in no direction is interior.

**Why the box half is kept rather than replaced**, which is the load-bearing
design decision:

* its error is **one-way**. Widening the box is all an outlying unnetted pad
  can do, and that only ever *increases* a pad's distance to it, so the box
  rule can manufacture a false INTERIOR and never a false ESCAPE. #862 is
  exactly that one direction, so a second sufficient condition corrects it
  without taking on a new error.
* the tolerance turns out to have a job the corridor cannot do: it is the depth
  below which a straight-shadow model does not apply, because a track leaving
  a pad turns before it has travelled that far. **Measured**, replacing the box
  test instead *gains* interior pads on orangecrab_ext_pll U10 and
  rp2350_fpga_eensy_prePlane U4 — both a 0.325 mm part with 5 copper pads
  (`Texas_X2SON-4`), whose central GND pad is 0.58 × 0.58 at 45°, so an
  **0.8202 mm** axis-aligned extent, sitting **0.0699 mm** from the copper box
  on west and east: plainly on the boundary, yet its axis-aligned corridor is
  closed by the flanking pads once they are inflated.
* it makes `interior_pads` provably non-increasing, and makes "consult the
  corridor only for box-interior pads" a **proof rather than an optimisation**:
  when `min(d) <= tol` the argmin direction is itself in the escaping set, so
  the filtered argmin is the unfiltered one.

### Measured

`tests/measure_862_enclosure.py`, both arms in one process, 97 fine-pitch refs
over the 22 tracked boards:

| clearance / track | box | union | refs moved | grew | `ulx3s:U1` | `qfn_interior_pads:U1` |
|---|---|---|---|---|---|---|
| 0.09 / 0.10 *(the corpus runs here)* | 2054 | 1953 | 9 | 0 | 379 → **308** | 5 → 5 |
| 0.20 / 0.20 *(the census basis)* | 2054 | 1953 | 9 | 0 | 379 → **308** | 5 → 5 |
| 0.25 / 0.30 *(the CLI's defaults)* | 2054 | 1957 | 8 | 0 | 379 → **308** | 5 → 5 |
| 0.05 / 0.10 *(swept)* | 2054 | 1914 | 19 | 0 | 379 → **308** | 5 → **0** |
| 0.40 / 0.40 *(swept)* | 2054 | 1960 | 8 | 0 | 379 → **308** | 5 → 5 |

The nine at 0.20/0.20: `esp_prog:USB1` 5→0, `orangecrab:U3` 227→223,
`orangecrab:U8` 4→2, `orangecrab:U9` 1→0, `rp2350:U7` 1→0, `ulx3s:GPDI1` 2→0,
`ulx3s:SD1` 12→1, `ulx3s:U1` 379→308, `ulx3s:U9` 4→0.

**ulx3s U1 is the point.** 71 balls recover and its faces go from
`N0 E0 S0 W0` to **`N17 S11 W18 E16`**. A full 20 × 20 ring would be 76 balls;
nine sites are empty, so the ring holds **67** — and all 67 recover, plus **4**
second-row balls that escape through those empty sites. That last four is the
thing a ring-vs-interior rule could not do. 308 remain interior because they really are, and those balls need vias. Its
four faces carry supply 21/31/29/31 at the finest grid, so the board gains real
demand and is still not short.

**`qfn_interior_pads` U1 is the other side of the gate**, and it is checked as
the SAME five pads rather than the same count. They sit behind that QFN's
unnetted south pin row and are genuinely enclosed. The two boards fail in
opposite directions, which is why the issue insists on both.

### Two figures in the issue that do not survive measurement

Both were in the fix's favour, which is the direction to distrust:

* the issue says **eight** unnetted marks; U1 carries **ten** pads with copper
  and no net — the eight corner marks that do set the box, plus `W10` and
  `W11`, two 0.4 × 0.4 mm circles *inside* the ball field, which do not touch
  the box but are obstacles to the corridor.
* the issue predicts the outer ring recovers **~88 balls**. The ring holds
  **67** (a full 20 × 20 ring would be 76; nine sites are empty), and the
  measured recovery is **71**.

### One limit of the model, which is a cliff rather than a slope

The strip a corridor measures is the pad's **own** span, so a pad narrower
than `track_width` can never be rescued however empty the field in front of
it. Physically a track wider than its pad is routine — it necks down at the
joint — and this model says no. Measured on ulx3s U1, whose balls are 0.4 mm
wide, at clearance 0.2:

| track | balls recovered |
|---|---|
| 0.20 … 0.400 | **71** |
| 0.401 | **0** |

That is this PR's headline falling off an edge one thousandth of a millimetre
wide, and `check_channels` floors the track *up* to the fab floor, which can
only move toward it. It is stated in `pad_band`'s docstring and pinned by four
rows in the gate, so it is found from a test rather than from a board.

Not fixed here, deliberately: widening the strip to admit a necked track needs
its own evidence, and the two measured alternatives — a pitch-wide window and
a zero threshold — both break `qfn_interior_pads`.

### The semantics change, disclosed rather than discovered

**`interior_pads` is now a function of `clearance` and `track_width`**, where
before it was a function of the part's geometry alone — because the enclosure
test asks whether a *track* can leave. That is a published-semantics change on
a key `check_channels --json`, `board_brief` and `routability.health` all
carry, so six keys are published on **both** instruments, spelled identically
so the two JSON outputs diff key for key:

| key | |
|---|---|
| `interior_pads_box` | the box rule alone — **basis-free**, the fanout fact without the parameter fact |
| `face_corridor_escapes` | how many the corridor freed |
| `face_corridor_source` | `caller` / `not_measured` / `unmodelled` / `no_pad_boxes` — four facts, not one `unknown` |
| `face_corridor_clearance_mm`, `face_corridor_track_mm` | the basis it ran at |
| `face_pitch_mm` on `PartEscape` | #850 added this to the routability row only, so until now the two instruments could not be compared on the basis they are asserted EQUAL at |

The precedent is `supply_routed_grid` / `supply_finest_grid`, not
`face_pitch_*`: the corridor half is monotone in both arguments, so **an
interior pad that survives the box rule is a fanout fact, not a parameter
fact**. All three counts are published though one is derivable, because
`interior_pads + face_corridor_escapes == interior_pads_box` is then a
conservation law over each ledger's own population — a count that falls with
nothing naming where it went is how a ledger stops looking and reads as a fix.

**There is no clamp**, and that is deliberate: `qfn_interior_pads` U1's pin
rows are 0.25 mm pads on a 0.5 mm pitch, so the gap between pins is 0.25 mm,
and at clearance 0.05 that leaves 0.15 mm — which really does pass a 0.1 mm
track. U1 reading 0 there is the right answer for a board etched at that
floor. The repo
has refused this move twice before (`signal_layer_count`, `via_pitch`) for the
same reason.

### The reconciliation held, and its precondition grew

`interior_pads` is equal on **97 of 97** fine-pitch refs — but "the same ref at
the same clearance" is now "at the same clearance **and the same track
width**". That is not a formality: leave `track_width` out of `test_850`'s
reconciliation arm and `part_escape` resolves orangecrab's own 0.3 against the
ledger's 0.2, and U3 reads 227 against the row's 223. One ref out of 97, and
only that arm would have said so. The measure script's `int_R`/`int_E` negative
control caught the same defect independently, printing a WARN.

### The ranked risk, answered

All three `check_channels` gate predicates are demand-gated
(`GATE_MIN_DEMAND = 7`), so demand *rising* is the direction that could make
`--gate` newly exit 4. Measured, box rule vs union, at all three bases in use:

| | starved faces | deficit faces |
|---|---|---|
| 0.09 / 0.10 | 0 → 0 | 57 → 57 |
| 0.20 / 0.20 | 2 → 2 | 102 → 102 |
| 0.25 / 0.30 | 2 → 2 | 134 → 134 |

Not one face moves in either census. The tracked `--gate` pair
(`tests/fixtures/run23/tigard_{damaged,placed}`) is byte-identical: exit 4, the
same two NEW faces, `U3 W` demand 10 supply 24→19 at 21% and `U3 E` demand 9
supply 27→13 at 52%. *(I had predicted `ulx3s GPDI1 E` would gain a reported
deficit line. It does not. The measurement is the claim.)*

### Goldens: split, not overwritten

`test_850`'s `GOLDEN` is **byte-identical**. Its four columns are the
`e239e067` oracle and the #850 recording, and editing numbers inside it would
have retired that oracle for the four rows that did *not* move and left no
record that #862 happened. The single moved row goes to a sibling
`GOLDEN_AFTER_862` asserted as a **transition**, with the direction (#862 may
only ADD demand and only REMOVE interior pads) as its own check — the part a
plain re-record cannot state. Same shape as #849's `GOLDEN_PRE_HOIST` /
`DEMAND_AFTER_850`.

`test_835`'s `DEMAND` moves on three of eight rows and `EXPECTED` on two; the
unchanged rows are the negative control inside the same table. Its two
DIRECTION asserts are untouched and get *stronger*, and `DEMAND_AT_PAD_CENTRES`
does not move at all — checkably, because that arm passes
`obstruction_rects={}`, so `geom` is None and no corridor is ever built.
`test_849` needs no change **for #862** — both its pinned refs are measured
unchanged, which makes it the strongest negative control in the tree. (It does
change in this PR, in #850's commit, where `GOLDEN_PRE_HOIST`'s demand column
moved to a sibling `DEMAND_AFTER_850`.)

`docs/placement-predictors.md` said *"After #850 nothing on this page moved …
every number here is re-derived at the tip and identical"*. **That claim is now
false**, and the fix is not to delete it: it held because #850 changed only the
other instrument, and #862 changes the rule both share. It is scoped to the tip
it was measured at, and an *After #862* paragraph carries the re-derivation by
the two commands the page already names — deficit table `ulx3s 1 / 5 → 2 / 5`,
halo share **72.2% → 71.8%**, uncharged pairs **14 of 80 → 16 of 82**. The
share *fell*, so this re-measurement weakens the page's own argument by 0.4
points, exactly as the #841 re-measurement did.

### `has_interior_pads` is deleted

Zero callers anywhere — one grep hit, the definition. It answered this same
question from rounded pad-CENTRE local coordinates with no copper, no clearance
and no obstacles. Shipping #862 while leaving an uncalled fourth copy in the
module whose last commits were about there being *one* is an invitation for the
next author to pick the cheap-looking one.

---

## Verification, and what it found in my own work

**A mutation battery: 26 rows, 26 killed, 0 survived, 0 undecided, 0 broken.**
Two of the 17 existing anchors went stale the moment the corridor landed, and
are re-anchored in the same commit rather than found 50 minutes into a run.
Nine rows are new, and **witness bases are chosen per row, not defaulted**,
because two of them would survive a gate pinned only at the bases in use:

* `the-corridor-replaces-the-box-instead-of-uniting` leaves *both* named
  witnesses intact (ulx3s 308, qfn 5) and is identical to the union at
  0.09/0.10; only the 0.20/0.20 direction column sees it.
* `the-threshold-epsilon-is-dropped` only bites where a free run lands exactly
  on the threshold, which on this corpus is clearance 0.05 and 0.40 and nowhere
  else — so **every basis anything actually routes at is blind to it**.

**A mutation run found a hole in my own gate.** The epsilon row *survived* all
68 checks at first, because every basis I was testing is one a caller uses. It
is closed by testing 0.40/0.40 explicitly *for the mutation*, where a bare
comparison puts 33 of ulx3s U1's recovered balls back (308 → 341).

**A blind code review and a fact-check ran against the finished branch, and
between them falsified fifteen things.** Every one is fixed in `8aba0cff`;
the ones worth naming here, because they were defects in the *verification*
rather than in the rule:

* **No golden could see the central design decision.** The whole argument is
  "a union, not a replacement" — and all six `GOLDEN_862` refs read the same
  under *both* rules at *every* basis. The arm claiming to catch it was true by
  construction: `assign_faces` recomputes a face only `if bf is None`, so a
  box-accepted pad can never become interior. Fixed by adding the two refs that
  do discriminate (orangecrab U10, rp2350 U4) and an arm that RUNS the
  replacement and requires the answer to move.
* **A direction arm compared two literals.** `test_850`'s "#862 only REMOVED
  interior pads" was `308 < 379`, both from tables in the same file; no code
  change could fail it. It reads the live ledger now.
* **A 12× performance regression, worst where it bought nothing.** haasoscope
  U3 is a BGA-529 with 441 interior balls and nothing to rescue, and paid
  ~0.9M inner iterations for that answer. `PadCorridors` now carries an exact
  candidate index — **asserted equivalent on 388 ref-bases, 0 differing** —
  and the board goes 0.824 s → 0.177 s.
* **`demand_halo_study` was on the box rule** while both ledgers were on the
  union, which is the third-copy defect its own docstring exists to record,
  arriving through the argument list instead of a reimplementation.
* **`PartEscape` published the wrong pitch** under `face_pitch_mm` — the raw
  lattice pitch rather than the one the rule ran at — which also emitted
  `inf` and made the row invalid strict JSON.
* and the numbers: `legality.rect_sides`'s docstring carried #848's
  nine-board figure (18) labelled as the corpus — it is **20**, the extra pair
  being `sonde_u`, which that issue's table did not cover; the maintainer's
  own census agrees. `docs/utilities.md` carried a value this very change
  moves (2034 → 1142, now **1215**) with its own regeneration command three
  lines below it. And two commit citations named pre-rebase SHAs unreachable
  from this branch, so the battery's recorded verdict could not be reproduced
  at the tip it named.

**An earlier verifier re-derived the whole census from the prose alone and
found a fifth free parameter nobody had named**: whether an obstacle
"intersecting" the band counts when it merely *touches*. My read-only prototype
read it closed; the shipped `free_run` reads it open, and open is right —
`tigard` U3's exposed pad is sub-rects inside a full-size EP rect sharing the
edge `y = 58.225`, and that EP lies entirely *south* of the sub-pad, so it
cannot block a *northward* escape. My published 0.05/0.10 figure was wrong as a
result (1926; it is **1914**), and the shipped code agreed with the verifier
all along. The stake is not a few pads: the obstacle list deliberately includes
the pad's own rect, because open-ness makes self-exclusion free — so the closed
reading blocks every pad against itself and **collapses the union back to the
box rule exactly, 2054 at every basis, both witnesses still reading 308 and 5,
every corpus golden still green, and the rule doing nothing at all**. It is now
pinned directly.

The verifier also corrected two claims I had overstated: "the box total is 2054
at every basis" is *structural*, not a measurement (`CopperGeometry.copper`
carries neither clearance nor track width, so it cannot move), and monotonicity
is a *tautology* of the union's shape rather than a geometric finding — still
worth asserting, but only as a check that nobody turned the union into a
replacement.

**And the measurement script made the exact error it exists to catch.** It
keyed its pad sets on `pad_number`, which is not unique inside a footprint — a
thermal pad drawn as sub-rects, a row of NC pads — so the sets silently merged
them. It printed box 1994 against the true 2054, undercounting by 60 pads and
dropping `orangecrab_ext_pll:U8` off the moved list entirely. Caught by
cross-checking against an independent sweep, not by the script. (My commit
message for that fix says "two of the nine"; a fact-check reconstructed the
buggy form and it is one.)

Two guards earned their keep while I broke them: the measure script REFUSED to
print a table when 14 boards raised on a stale stand-in signature, and
`run_utils.evidence` refused a `--diff` against a json that run had not written.

### Gates

`tests/test_862_enclosure.py` — **121 checks in 9 sections**, printing its own
total. Every expected value in the unit sections is derived in the comment above
it from the fixture's own numbers. Three arms exist because they are not true by
construction: a spy asserting the corridor ran *at all* and was never asked
about a pad the box half accepted; the assertion that
`tests/test_escape_ledger.py`'s synthetic parts are `modelled=False` with an
empty pad table, so its `interior_pads == 9` oracle is preserved by the
degradation path **and witnesses nothing about this change**; and the
`interior_pads_box` invariance across three bases.

`tests/measure_862_enclosure.py` — the committed tables, both arms in one
process, `--out` / `--diff`.

### Suite

`tests/run_all.py -j 4` at the tip: **532 passed, 0 failed**, 6164 s, plus one
self-skip (`test_run8_starved_face_gate.py`, whose fixtures live in the
gitignored `wk/` — it self-skipped before this branch too) and four timeouts
under 4-way contention: `test_431_board_gates` (its own 1200 s budget),
`test_826_portfolio_lattice` (its own 900 s), `test_713_plane_score_ranking`
and `test_interf_u` (the 600 s default). Named rather than folded into a
total. **None of the four references `escape_ledger`, `face_lane_ledger`,
`assign_faces`, `part_escape` or `check_channels`** — they are not in this
change's blast radius — and **all four PASS when re-run alone**, which is what the
harness's own "a timeout is not evidence of a broken test" line asks for.

Mutation battery: **26 rows, 26 killed, 0 survived, 0 undecided, 0 broken, 0
disagreeing with expectation.**

### Not affected

No `kicad_routing_plugin/` code references either ledger, and this PR adds no
CLI flag, no GUI-facing engine parameter and no post-engine pass.
`.gui-parity-checked` is deliberately not advanced: no parity audit was
performed.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01A4yGaUMwXoP7xzedneLMW3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A4yGaUMwXoP7xzedneLMW3
